### PR TITLE
Fix release workflow secret names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Build stable release (signed + notarized)
         env:
           ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
-          ELECTROBUN_TEAMID: ${{ secrets.APPLE_TEAM_ID }}
-          ELECTROBUN_APPLEID: ${{ secrets.APPLE_ID }}
-          ELECTROBUN_APPLEIDPASS: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          ELECTROBUN_TEAMID: ${{ secrets.ELECTROBUN_TEAMID }}
+          ELECTROBUN_APPLEID: ${{ secrets.ELECTROBUN_APPLEID }}
+          ELECTROBUN_APPLEIDPASS: ${{ secrets.ELECTROBUN_APPLEIDPASS }}
         run: bunx vite build && bunx electrobun build --env=stable
 
       - name: Upload to S3

--- a/change-logs/2026/02/28/fix-release-secrets-mapping.md
+++ b/change-logs/2026/02/28/fix-release-secrets-mapping.md
@@ -1,0 +1,1 @@
+Fixed release workflow secret names to match actual GitHub repo secrets (ELECTROBUN_TEAMID, ELECTROBUN_APPLEID, ELECTROBUN_APPLEIDPASS instead of APPLE_TEAM_ID, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD).


### PR DESCRIPTION
## Summary
- Fixed env var mapping in release workflow: secrets were added as `ELECTROBUN_TEAMID`, `ELECTROBUN_APPLEID`, `ELECTROBUN_APPLEIDPASS` but workflow referenced old names (`APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)