### PR TITLE
Fix 'app is damaged': suppress AppleDouble files in build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,13 @@ jobs:
           ELECTROBUN_TEAMID: ${{ secrets.ELECTROBUN_TEAMID }}
           ELECTROBUN_APPLEID: ${{ secrets.ELECTROBUN_APPLEID }}
           ELECTROBUN_APPLEIDPASS: ${{ secrets.ELECTROBUN_APPLEIDPASS }}
-        run: bunx vite build && bunx electrobun build --env=stable
+          COPYFILE_DISABLE: "1"
+          COPY_EXTENDED_ATTRIBUTES_DISABLE: "1"
+        run: |
+          bunx vite build && bunx electrobun build --env=stable
+          # Clean AppleDouble ._ files that break code signatures
+          find ./build -name '._*' -delete 2>/dev/null || true
+          dot_clean ./build 2>/dev/null || true
 
       - name: Upload to S3
         env:

--- a/change-logs/2026/02/28/fix-appledouble-codesign.md
+++ b/change-logs/2026/02/28/fix-appledouble-codesign.md
@@ -1,0 +1,1 @@
+Fixed "app is damaged" error on signed builds by setting COPYFILE_DISABLE=1 to prevent macOS from creating AppleDouble ._ files inside the app bundle, which invalidate code signatures.


### PR DESCRIPTION
## Summary
- macOS creates `._` (AppleDouble) resource fork files during file operations inside `electrobun build`
- These files end up inside the `.app` bundle and invalidate the code signature → Gatekeeper reports "is damaged and can't be opened"
- Fix: set `COPYFILE_DISABLE=1` and `COPY_EXTENDED_ATTRIBUTES_DISABLE=1` env vars during build, plus post-build cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)