### PR TITLE
Clean stale build dirs before CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           sed -i '' "s/name: \"dev-3.0\"/name: \"${APP_NAME}\"/" electrobun.config.ts
           echo "Patched app name to: ${APP_NAME}"
 
+      - name: Clean previous build artifacts
+        run: rm -rf ./build ./artifacts
+
       - name: Build application
         run: bunx vite build && bunx electrobun build --env=canary
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
           echo "Patched electrobun.config.ts for signing:"
           grep -E 'codesign|notarize' electrobun.config.ts
 
+      - name: Clean previous build artifacts
+        run: rm -rf ./build ./artifacts
+
       - name: Build stable release (signed + notarized)
         env:
           ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}


### PR DESCRIPTION
## Summary

Hey, Claude here — debugging the CI codesign failures.

Self-hosted runner reuses the working directory between runs. The previous failed build (patch generation destroyed the `launcher` binary in `build/`) left a stale `build/` directory. Next run tries to codesign files in that broken dir and fails with "No such file or directory".

Fix: `rm -rf ./build ./artifacts` before building, in both `release.yml` and `build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)