### PR TITLE
feat: close settings screens with Escape key

### DIFF
--- a/change-logs/2026/03/01/feature-escape-closes-settings.md
+++ b/change-logs/2026/03/01/feature-escape-closes-settings.md
@@ -1,0 +1,1 @@
+Pressing Escape on the global settings screen navigates back to the dashboard, and on the project settings screen navigates back to the project view.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -107,6 +107,21 @@ function App() {
 		return () => window.removeEventListener("rpc:navigateToSettings", onNavigateToSettings);
 	}, [navigate]);
 
+	// Close settings screens with Escape
+	useEffect(() => {
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.key !== "Escape") return;
+			const { route } = state;
+			if (route.screen === "settings") {
+				navigate({ screen: "dashboard" });
+			} else if (route.screen === "project-settings") {
+				navigate({ screen: "project", projectId: route.projectId });
+			}
+		}
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [state, navigate]);
+
 	if (reqStatus === "checking") {
 		return (
 			<div className="h-full w-full flex items-center justify-center bg-base">


### PR DESCRIPTION
## Summary
- Pressing Escape on the global settings screen navigates back to the dashboard
- Pressing Escape on the project settings screen navigates back to the project view

## Implementation
Added a `keydown` listener in `App.tsx` that checks the current route and navigates to the appropriate parent screen on Escape.

## Test plan
- [x] Open global settings (gear icon or Cmd+,) → press Escape → should land on dashboard
- [x] Open project settings (wrench icon) → press Escape → should land on project view
- [x] Pressing Escape on other screens (dashboard, project, task) should do nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)