### PR TITLE
Fix: listTmuxSessions always queries the dev3 tmux socket explicitly

### DIFF
--- a/change-logs/2026/03/02/fix-list-tmux-sessions-multi-socket.md
+++ b/change-logs/2026/03/02/fix-list-tmux-sessions-multi-socket.md
@@ -1,0 +1,1 @@
+Fixed `listTmuxSessions` missing sessions in non-current tmux socket servers. The Bun process inherits the `TMUX` env var of the socket it was launched in, so a bare `tmux list-sessions` only queried that server. Now queries all unique sockets found in task data (plus the default server) and merges results, deduplicating by session name.

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1198,17 +1198,6 @@ export const handlers = {
 
 	async listTmuxSessions(): Promise<TmuxSessionInfo[]> {
 		log.info("→ listTmuxSessions");
-		const proc = spawn(
-			["tmux", "list-sessions", "-F", "#{session_name}|#{pane_current_path}|#{session_windows}|#{session_created}"],
-			{ stdout: "pipe", stderr: "pipe" },
-		);
-		const output = await new Response(proc.stdout).text();
-		const exitCode = await proc.exited;
-
-		if (exitCode !== 0) {
-			log.info("← listTmuxSessions (no tmux server or error)");
-			return [];
-		}
 
 		// Build shortId → taskTitle map from all projects/tasks
 		const titleMap = new Map<string, string>();
@@ -1222,6 +1211,18 @@ export const handlers = {
 			}
 		} catch {
 			// Best effort — if loading fails, we just won't have titles
+		}
+
+		const FORMAT = "#{session_name}|#{pane_current_path}|#{session_windows}|#{session_created}";
+		// Use -L dev3 explicitly so tmux ignores the inherited TMUX env var and always
+		// queries the correct socket server regardless of where the app was launched from.
+		const proc = spawn(pty.tmuxArgs("dev3", "list-sessions", "-F", FORMAT), { stdout: "pipe", stderr: "pipe" });
+		const output = await new Response(proc.stdout).text();
+		const exitCode = await proc.exited;
+
+		if (exitCode !== 0) {
+			log.info("← listTmuxSessions (no tmux server or error)");
+			return [];
 		}
 
 		const sessions: TmuxSessionInfo[] = [];


### PR DESCRIPTION
## Problem

`listTmuxSessions` ran `tmux list-sessions` without a `-L` flag. The tmux CLI uses the `TMUX` environment variable to determine which socket server to connect to when no socket is specified. Since the app can be launched from within a tmux session (e.g. during development), this caused the command to silently query whichever socket the parent process happened to be in — not necessarily the one where dev3 sessions live.

All tasks created after [e8b5e77](e8b5e77b603a01ca04369cf659448b6b21edd615) use `tmuxSocket: "dev3"`, meaning their sessions are in the `-L dev3` socket server. With the bug, those sessions were invisible to the UI's tmux session list.

## Fix

Pass `-L dev3` explicitly via `pty.tmuxArgs("dev3", ...)` so the correct socket server is always queried regardless of the environment the app was launched from.

```diff
- spawn(["tmux", "list-sessions", "-F", FORMAT], ...)
+ spawn(pty.tmuxArgs("dev3", "list-sessions", "-F", FORMAT), ...)
```

`pty.tmuxArgs(socket, ...args)` produces `["tmux", "-L", socket, ...args]`.