### PR TITLE
feat: add System theme option (follows OS preference)

### DIFF
--- a/change-logs/2026/03/01/feature-system-theme.md
+++ b/change-logs/2026/03/01/feature-system-theme.md
@@ -1,0 +1,1 @@
+Added a "System" theme option that automatically follows the OS dark/light mode preference. When selected, the app listens for OS theme changes and switches in real time. Localized for English, Russian, and Spanish.

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -4,7 +4,7 @@ import type { Locale } from "../i18n";
 import type { CodingAgent, AgentConfiguration, GlobalSettings as GlobalSettingsType, PermissionMode, EffortLevel } from "../../shared/types";
 import { api } from "../rpc";
 
-type Theme = "dark" | "light";
+type Theme = "dark" | "light" | "system";
 
 function GlobalSettings() {
 	const t = useT();
@@ -33,9 +33,18 @@ function GlobalSettings() {
 	const selectedDefaultAgent = agents.find((a) => a.id === globalSettings.defaultAgentId);
 	const defaultAgentConfigs: AgentConfiguration[] = selectedDefaultAgent?.configurations || [];
 
+	function resolveTheme(th: Theme): "dark" | "light" {
+		if (th === "system") {
+			return window.matchMedia("(prefers-color-scheme: dark)").matches
+				? "dark"
+				: "light";
+		}
+		return th;
+	}
+
 	function applyTheme(th: Theme) {
 		setTheme(th);
-		document.documentElement.dataset.theme = th;
+		document.documentElement.dataset.theme = resolveTheme(th);
 		localStorage.setItem("dev3-theme", th);
 	}
 
@@ -177,6 +186,18 @@ function GlobalSettings() {
 									bg: "#f5f6fa",
 									raised: "#ffffff",
 									text: "#1a1d2e",
+									accent: "#5e9eff",
+								}}
+							/>
+							<ThemeCard
+								name={t("settings.themeSystem")}
+								description={t("settings.themeSystemDesc")}
+								active={theme === "system"}
+								onClick={() => applyTheme("system")}
+								preview={{
+									bg: "linear-gradient(135deg, #171924 50%, #f5f6fa 50%)",
+									raised: "#1e2133",
+									text: "#eceef8",
 									accent: "#5e9eff",
 								}}
 							/>

--- a/src/mainview/i18n/translations/en.ts
+++ b/src/mainview/i18n/translations/en.ts
@@ -29,6 +29,8 @@ const en = {
 	"settings.themeDarkDesc": "Midnight indigo",
 	"settings.themeLight": "Light",
 	"settings.themeLightDesc": "Clean & bright",
+	"settings.themeSystem": "System",
+	"settings.themeSystemDesc": "Follows your OS",
 	"settings.language": "Language",
 	"settings.agents": "Coding Agents",
 	"settings.addAgent": "Add Agent",

--- a/src/mainview/i18n/translations/es.ts
+++ b/src/mainview/i18n/translations/es.ts
@@ -31,6 +31,8 @@ const es: TranslationRecord & Record<string, string> = {
 	"settings.themeDarkDesc": "Índigo nocturno",
 	"settings.themeLight": "Claro",
 	"settings.themeLightDesc": "Limpio y brillante",
+	"settings.themeSystem": "Sistema",
+	"settings.themeSystemDesc": "Según tu SO",
 	"settings.language": "Idioma",
 	"settings.agents": "Agentes de código",
 	"settings.addAgent": "Agregar agente",

--- a/src/mainview/i18n/translations/ru.ts
+++ b/src/mainview/i18n/translations/ru.ts
@@ -33,6 +33,8 @@ const ru: TranslationRecord & Record<string, string> = {
 	"settings.themeDarkDesc": "Полуночный индиго",
 	"settings.themeLight": "Светлая",
 	"settings.themeLightDesc": "Чистая и яркая",
+	"settings.themeSystem": "Системная",
+	"settings.themeSystemDesc": "Как в ОС",
 	"settings.language": "Язык",
 	"settings.agents": "Кодинг-агенты",
 	"settings.addAgent": "Добавить агента",

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -26,9 +26,17 @@ window.addEventListener("unhandledrejection", (event) => {
 	});
 });
 
-// Apply saved theme before React mounts
-const savedTheme = localStorage.getItem("dev3-theme") || "dark";
-document.documentElement.dataset.theme = savedTheme;
+// Apply saved theme before React mounts & keep in sync with OS
+const systemThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
+
+function applySavedTheme() {
+	const saved = localStorage.getItem("dev3-theme") || "dark";
+	document.documentElement.dataset.theme =
+		saved === "system" ? (systemThemeMq.matches ? "dark" : "light") : saved;
+}
+
+applySavedTheme();
+systemThemeMq.addEventListener("change", applySavedTheme);
 
 // Apply saved locale before React mounts
 const savedLocale = localStorage.getItem("dev3-locale") || "en";


### PR DESCRIPTION
## Summary
- Adds a third "System" theme option alongside Dark and Light
- Automatically follows the OS dark/light mode preference and reacts to changes in real time
- Global `matchMedia` listener in `main.tsx` ensures it works even when the settings page is not open
- Localized for English, Russian, and Spanish

## Test plan
- [x] Select "System" theme in Global Settings — app should match OS theme
- [x] Change OS appearance (System Settings → Appearance) — app should switch in real time without reopening settings
- [x] Select Dark or Light explicitly — OS changes should no longer affect the app
- [ ] Reload the app with "system" saved — correct theme applied before React mounts (no flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)