### PR TITLE
Remove .dev3-marker file — CLI now detects context purely from worktr…

### DIFF
--- a/.dev3-marker
+++ b/.dev3-marker
@@ -1,5 +1,0 @@
-{
-  "projectId": "a1c9fe4e-8389-4214-9018-4a2580c261f0",
-  "taskId": "a730d3dc-cfce-4738-9c04-8d4e25c7436d",
-  "socketPath": "/Users/arsenyp/.dev3.0/sockets/79073.sock"
-}

--- a/change-logs/2026/03/02/chore-remove-dev3-marker.md
+++ b/change-logs/2026/03/02/chore-remove-dev3-marker.md
@@ -1,0 +1,1 @@
+Removed `.dev3-marker` file creation from worktree setup and all marker-based context detection from the CLI. The CLI now relies solely on the worktree directory path (`~/.dev3.0/worktrees/{slug}/{id}/worktree`) to resolve project and task context. Updated the `dev3` Claude Code skill to trigger based on the working directory path instead of the marker file presence.

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1,8 +1,7 @@
-import type { Dev3Marker, Project, Task } from "../shared/types";
+import type { Project, Task } from "../shared/types";
 import { createLogger } from "./logger";
 import { spawn } from "./spawn";
 import { DEV3_HOME } from "./paths";
-import { getSocketPath } from "./cli-socket-server";
 
 const log = createLogger("git");
 
@@ -110,19 +109,6 @@ export async function createWorktree(
 	}
 
 	log.info("Worktree created", { wtPath, branch });
-
-	// Write .dev3-marker for CLI auto-detection
-	try {
-		const marker: Dev3Marker = {
-			projectId: project.id,
-			taskId: task.id,
-			socketPath: getSocketPath(),
-		};
-		await Bun.write(`${wtPath}/.dev3-marker`, JSON.stringify(marker, null, 2));
-		log.info("Wrote .dev3-marker", { wtPath });
-	} catch (err) {
-		log.warn("Failed to write .dev3-marker (non-fatal)", { error: String(err) });
-	}
 
 	return { worktreePath: wtPath, branchName: branch };
 }

--- a/src/cli/__tests__/context.test.ts
+++ b/src/cli/__tests__/context.test.ts
@@ -1,60 +1,95 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { detectContext } from "../context";
 
-const TEST_DIR = "/tmp/dev3-cli-test-context";
+const HOME = process.env.HOME || "/tmp";
+const WORKTREES_DIR = `${HOME}/.dev3.0/worktrees`;
+const DATA_DIR = `${HOME}/.dev3.0/data`;
+const PROJECTS_FILE = `${HOME}/.dev3.0/projects.json`;
+
+// We need a unique slug to avoid interfering with real data
+const TEST_SLUG = "test-cli-context-project";
+const TEST_SHORT_ID = "aabbccdd";
+const TEST_PROJECT_ID = "proj-test-123";
+const TEST_TASK_ID = "aabbccdd-1111-2222-3333-444444444444";
+
+const TEST_WORKTREE = `${WORKTREES_DIR}/${TEST_SLUG}/${TEST_SHORT_ID}/worktree`;
+const TEST_TASK_DATA_DIR = `${DATA_DIR}/${TEST_SLUG}`;
+
+let originalProjectsContent: string | null = null;
 
 beforeEach(() => {
-	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-	mkdirSync(TEST_DIR, { recursive: true });
+	// Save original projects.json if it exists
+	if (existsSync(PROJECTS_FILE)) {
+		const { readFileSync } = require("node:fs");
+		originalProjectsContent = readFileSync(PROJECTS_FILE, "utf-8");
+	}
+
+	// Create test worktree directory
+	mkdirSync(TEST_WORKTREE, { recursive: true });
+
+	// Create test task data
+	mkdirSync(TEST_TASK_DATA_DIR, { recursive: true });
+	writeFileSync(
+		`${TEST_TASK_DATA_DIR}/tasks.json`,
+		JSON.stringify([{ id: TEST_TASK_ID }]),
+	);
+
+	// Write projects.json with our test project appended
+	const existingProjects = originalProjectsContent ? JSON.parse(originalProjectsContent) : [];
+	const testProject = {
+		id: TEST_PROJECT_ID,
+		name: "Test Project",
+		path: `/${TEST_SLUG.replaceAll("-", "/")}`,
+	};
+	// Only add if not already present
+	if (!existingProjects.find((p: { id: string }) => p.id === TEST_PROJECT_ID)) {
+		existingProjects.push(testProject);
+	}
+	writeFileSync(PROJECTS_FILE, JSON.stringify(existingProjects));
 });
 
 afterEach(() => {
-	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+	// Clean up test worktree dir
+	const testWorktreeParent = `${WORKTREES_DIR}/${TEST_SLUG}`;
+	if (existsSync(testWorktreeParent)) {
+		rmSync(testWorktreeParent, { recursive: true });
+	}
+
+	// Clean up test task data
+	if (existsSync(TEST_TASK_DATA_DIR)) {
+		rmSync(TEST_TASK_DATA_DIR, { recursive: true });
+	}
+
+	// Restore original projects.json
+	if (originalProjectsContent !== null) {
+		writeFileSync(PROJECTS_FILE, originalProjectsContent);
+	} else if (existsSync(PROJECTS_FILE)) {
+		rmSync(PROJECTS_FILE);
+	}
 });
 
 describe("detectContext", () => {
-	it("returns null when no marker found", () => {
-		expect(detectContext(TEST_DIR)).toBeNull();
+	it("returns null when not in a worktree path", async () => {
+		const { detectContext } = await import("../context");
+		expect(detectContext("/tmp/random-dir")).toBeNull();
 	});
 
-	it("detects marker in cwd", () => {
-		const marker = {
-			projectId: "proj-123",
-			taskId: "task-456",
-			socketPath: "/tmp/test.sock",
-		};
-		writeFileSync(`${TEST_DIR}/.dev3-marker`, JSON.stringify(marker));
-
-		const ctx = detectContext(TEST_DIR);
-		expect(ctx).toEqual({
-			projectId: "proj-123",
-			taskId: "task-456",
-			socketPath: "/tmp/test.sock",
-		});
+	it("detects context from worktree path", async () => {
+		const { detectContext } = await import("../context");
+		const ctx = detectContext(TEST_WORKTREE);
+		expect(ctx).not.toBeNull();
+		expect(ctx!.projectId).toBe(TEST_PROJECT_ID);
+		expect(ctx!.taskId).toBe(TEST_TASK_ID);
 	});
 
-	it("detects marker in parent directory", () => {
-		const marker = {
-			projectId: "proj-abc",
-			taskId: "task-def",
-			socketPath: "/tmp/parent.sock",
-		};
-		writeFileSync(`${TEST_DIR}/.dev3-marker`, JSON.stringify(marker));
-
-		const nestedDir = `${TEST_DIR}/src/components`;
+	it("detects context from nested directory inside worktree", async () => {
+		const { detectContext } = await import("../context");
+		const nestedDir = `${TEST_WORKTREE}/src/components`;
 		mkdirSync(nestedDir, { recursive: true });
 
 		const ctx = detectContext(nestedDir);
-		expect(ctx).toEqual({
-			projectId: "proj-abc",
-			taskId: "task-def",
-			socketPath: "/tmp/parent.sock",
-		});
-	});
-
-	it("returns null for malformed marker JSON", () => {
-		writeFileSync(`${TEST_DIR}/.dev3-marker`, "not json");
-		expect(detectContext(TEST_DIR)).toBeNull();
+		expect(ctx).not.toBeNull();
+		expect(ctx!.projectId).toBe(TEST_PROJECT_ID);
+		expect(ctx!.taskId).toBe(TEST_TASK_ID);
 	});
 });

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname } from "node:path";
-import type { Dev3Marker } from "../shared/types";
 
 const HOME = process.env.HOME || "/tmp";
 const DEV3_HOME = `${HOME}/.dev3.0`;
@@ -12,32 +11,6 @@ export interface CliContext {
 	projectId: string;
 	taskId: string;
 	socketPath: string;
-}
-
-/**
- * Walk up from cwd to find .dev3-marker and resolve project/task context.
- */
-function detectFromMarker(cwd: string): CliContext | null {
-	let dir = cwd;
-	for (let i = 0; i < 30; i++) {
-		const markerPath = `${dir}/.dev3-marker`;
-		if (existsSync(markerPath)) {
-			try {
-				const marker: Dev3Marker = JSON.parse(readFileSync(markerPath, "utf-8"));
-				return {
-					projectId: marker.projectId,
-					taskId: marker.taskId,
-					socketPath: marker.socketPath,
-				};
-			} catch {
-				return null;
-			}
-		}
-		const parent = dirname(dir);
-		if (parent === dir) break;
-		dir = parent;
-	}
-	return null;
 }
 
 /**
@@ -103,10 +76,10 @@ function resolveFromWorktreePath(cwd: string): CliContext | null {
 }
 
 /**
- * Detect context: marker file first, then worktree path fallback.
+ * Detect context from worktree path structure.
  */
 export function detectContext(cwd: string = process.cwd()): CliContext | null {
-	return detectFromMarker(cwd) || resolveFromWorktreePath(cwd);
+	return resolveFromWorktreePath(cwd);
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -270,11 +270,6 @@ export interface CliResponse {
 	error?: string;
 }
 
-export interface Dev3Marker {
-	projectId: string;
-	taskId: string;
-	socketPath: string;
-}
 
 // ---- RPC schema ----
 


### PR DESCRIPTION
…ee path

The marker file was redundant since the worktree path fallback (~/.dev3.0/worktrees/{slug}/{id}/worktree) already provides full project/task context. Removed marker creation from git.ts, marker detection from CLI context.ts, and the Dev3Marker type. Updated the dev3 skill trigger to match on working directory path instead.