### PR TITLE
Fix Homebrew cask SHA-256 mismatch on full-v* releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,8 +273,10 @@ jobs:
             gh release upload "$TAG" "$dmg" --repo "${{ github.repository }}" --clobber
           done
 
+      # Always update Homebrew when ARM64 DMG is available — even for full-v* tags.
+      # full-v* rebuilds the ARM64 DMG and overwrites the GitHub Release asset (--clobber),
+      # so the SHA must be refreshed to match the actually-published binary.
       - name: Update Homebrew Cask
-        if: contains(github.ref_name, 'full-v') == false
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
@@ -300,5 +302,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/dev3.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew Cask already up to date (no changes)"
+            exit 0
+          fi
           git commit -m "Update dev3 to ${VERSION}"
           git push origin main

--- a/change-logs/2026/03/03/fix-homebrew-sha-mismatch.md
+++ b/change-logs/2026/03/03/fix-homebrew-sha-mismatch.md
@@ -1,0 +1,1 @@
+Fixed Homebrew cask SHA-256 mismatch caused by full-v* tags overwriting the ARM64 DMG on GitHub Release without updating the Homebrew formula. The "Update Homebrew Cask" step in the release workflow now runs unconditionally for any build that produces an ARM64 DMG, not just v* tags.


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this fix.

- **Root cause**: `full-v*` tags rebuild the ARM64 DMG and overwrite the GitHub Release asset (`--clobber`), but the "Update Homebrew Cask" step was conditionally skipped for `full-v*` tags (`if: contains(github.ref_name, 'full-v') == false`). This left the Homebrew formula with a stale SHA from the earlier `v*` build.
- **Fix**: Remove the `full-v*` skip condition so the Homebrew formula is always updated when an ARM64 DMG is produced. Also added a no-op guard so the step exits cleanly if the formula already has the correct SHA.

Closes h0x91b/homebrew-dev3#1