### PR TITLE
Allow todo → completed transition (fixes #33)

### DIFF
--- a/change-logs/2026/03/04/fix-todo-to-completed-transition.md
+++ b/change-logs/2026/03/04/fix-todo-to-completed-transition.md
@@ -1,0 +1,1 @@
+Allow tasks in "todo" status to transition directly to "completed". Previously, todo tasks could only move to "in-progress" or "cancelled", which blocked users who accidentally moved a task back to todo from completing it. Also fixed worktree cleanup when completing a task that was moved back to todo but still had a worktree attached.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -701,7 +701,7 @@ describe("task.move", () => {
 		expect(data.updateTask).not.toHaveBeenCalled();
 	});
 
-	it("errors on disallowed transition (todo can only go to in-progress or cancelled)", async () => {
+	it("errors on disallowed transition (todo cannot go to review-by-user)", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "todo" });
 		vi.mocked(data.getProject).mockResolvedValue(project);
@@ -711,7 +711,7 @@ describe("task.move", () => {
 			makeRequest("task.move", {
 				taskId: task.id,
 				projectId: "proj-1",
-				newStatus: "completed",
+				newStatus: "review-by-user",
 			}),
 		);
 		expect(resp.ok).toBe(false);

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -967,6 +967,42 @@ describe("handlers.moveTask", () => {
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
 		expect(result.status).toBe("completed");
 	});
+
+	it("todo → completed (with worktree): cleans up PTY and worktree", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: "/tmp/wt" });
+		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
+		expect(result.status).toBe("completed");
+		expect(pty.destroySession).toHaveBeenCalledWith("task-1");
+		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			status: "completed",
+			worktreePath: null,
+			branchName: null,
+		});
+	});
+
+	it("todo → completed (without worktree): just updates status", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null });
+		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+
+		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
+		expect(result.status).toBe("completed");
+		expect(pty.destroySession).not.toHaveBeenCalled();
+		expect(git.removeWorktree).not.toHaveBeenCalled();
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -569,17 +569,18 @@ export const handlers = {
 			return updated;
 		}
 
-		// active → completed/cancelled: destroy PTY, run cleanup if configured, then remove worktree
-		if (
-			isActive(oldStatus) &&
-			(newStatus === "completed" || newStatus === "cancelled")
-		) {
+		// → completed/cancelled: destroy PTY, run cleanup if configured, then remove worktree
+		if (newStatus === "completed" || newStatus === "cancelled") {
 			if (params.force) {
 				// Force mode: skip PTY destruction, cleanup script, and worktree removal.
 				// The environment is already broken — just update the status.
 				log.info("Force mode: skipping PTY/cleanup/worktree", { taskId: task.id });
-			} else {
-				log.info("Transition: active → terminal, destroying PTY");
+			} else if (isActive(oldStatus) || task.worktreePath) {
+				// Active task or task that still has a worktree (e.g. moved back to todo)
+				log.info("Transition → terminal, cleaning up PTY + worktree", {
+					oldStatus,
+					hasWorktree: !!task.worktreePath,
+				});
 				try {
 					pty.destroySession(task.id);
 				} catch (err) {

--- a/src/mainview/__tests__/transitions.test.ts
+++ b/src/mainview/__tests__/transitions.test.ts
@@ -2,17 +2,16 @@ import { getAllowedTransitions } from "../../shared/types";
 import type { TaskStatus } from "../../shared/types";
 
 describe("getAllowedTransitions", () => {
-	it("todo → only in-progress and cancelled", () => {
+	it("todo → in-progress, completed, and cancelled", () => {
 		const allowed = getAllowedTransitions("todo");
-		expect(allowed).toEqual(["in-progress", "cancelled"]);
+		expect(allowed).toEqual(["in-progress", "completed", "cancelled"]);
 	});
 
-	it("todo → does NOT include user-questions, review-by-ai, review-by-user, completed", () => {
+	it("todo → does NOT include user-questions, review-by-ai, review-by-user", () => {
 		const allowed = getAllowedTransitions("todo");
 		expect(allowed).not.toContain("user-questions");
 		expect(allowed).not.toContain("review-by-ai");
 		expect(allowed).not.toContain("review-by-user");
-		expect(allowed).not.toContain("completed");
 	});
 
 	it("in-progress → all except in-progress", () => {

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -74,7 +74,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 
 		// Warn before completing/cancelling with unpushed changes
 		if (
-			ACTIVE_STATUSES.includes(task.status) &&
+			task.worktreePath &&
 			(targetStatus === "completed" || targetStatus === "cancelled")
 		) {
 			const proceed = await confirmTaskCompletion(task, project, targetStatus, t);

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -120,7 +120,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 		// Warn before completing/cancelling with unpushed changes
 		if (
-			ACTIVE_STATUSES.includes(task.status) &&
+			task.worktreePath &&
 			(newStatus === "completed" || newStatus === "cancelled")
 		) {
 			setMenuOpen(false);

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -118,7 +118,7 @@ function TaskInfoPanel({ task, project, dispatch, navigate }: TaskInfoPanelProps
 	async function handleStatusMove(newStatus: TaskStatus) {
 		// Warn before completing/cancelling with unpushed changes
 		if (
-			ACTIVE_STATUSES.includes(task.status) &&
+			task.worktreePath &&
 			(newStatus === "completed" || newStatus === "cancelled")
 		) {
 			setStatusMenuOpen(false);

--- a/src/mainview/utils/confirmTaskCompletion.ts
+++ b/src/mainview/utils/confirmTaskCompletion.ts
@@ -1,6 +1,5 @@
 import { api } from "../rpc";
 import type { Task, Project, TaskStatus } from "../../shared/types";
-import { ACTIVE_STATUSES } from "../../shared/types";
 import type { TFunction } from "../i18n";
 
 /**
@@ -13,7 +12,6 @@ export async function confirmTaskCompletion(
 	newStatus: TaskStatus,
 	t: TFunction,
 ): Promise<boolean> {
-	if (!ACTIVE_STATUSES.includes(task.status)) return true;
 	if (newStatus !== "completed" && newStatus !== "cancelled") return true;
 	if (!task.worktreePath) return true;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,7 +68,7 @@ export function hexToRgb(hex: string): string {
 /** Returns the list of statuses a task can transition to from `current`. */
 export function getAllowedTransitions(current: TaskStatus): TaskStatus[] {
 	if (current === "todo") {
-		return ["in-progress", "cancelled"];
+		return ["in-progress", "completed", "cancelled"];
 	}
 	return ALL_STATUSES.filter((s) => s !== current);
 }


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI agent working on this fix.

- Tasks in "todo" status can now transition directly to "completed", fixing the case where a user accidentally moves a task back to todo and gets stuck
- Backend `moveTask` handler now cleans up PTY/worktree when completing a task from any status (not just active ones), preventing orphaned worktrees
- UI completion warnings now check for worktree presence instead of active status, so the unpushed-changes dialog shows even for a "todo" task with a leftover worktree

Closes #33