### PR TITLE
Fix terminal link clicks not opening browser

### DIFF
--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -306,10 +306,6 @@ mainWindow.webview.on("dom-ready", async () => {
 	if (typeof url === "string" && /^https?:\/\//.test(url)) {
 		log.info("Opening external URL", { url });
 		Utils.openExternal(url);
-	} else if (typeof url === "string" && url.startsWith("file:///")) {
-		const filePath = decodeURIComponent(url.slice("file://".length));
-		log.info("Opening file path", { url, filePath });
-		Utils.openPath(filePath);
 	} else {
 		log.warn("Blocked new-window-open with unexpected URL", { data: e.data });
 	}

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1536,8 +1536,4 @@ export const handlers = {
 		log.info("← tmuxAction done", { taskId: params.taskId.slice(0, 8), action: params.action });
 	},
 
-	openPath(params: { path: string }): boolean {
-		log.info("→ openPath", { path: params.path });
-		return Utils.openPath(params.path);
-	},
 };

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -199,7 +199,6 @@ function TerminalView({ ptyUrl, taskId }: TerminalViewProps) {
 							fitAddon!.observeResize();
 							term.focus();
 							mouseCleanup = setupMouseTracking(term);
-							registerFilePathLinkProvider(term);
 							console.log("[TerminalView] Terminal fitted, connecting PTY...");
 							connectPty(term, fitAddon!);
 						} catch (err) {
@@ -213,41 +212,6 @@ function TerminalView({ ptyUrl, taskId }: TerminalViewProps) {
 				}
 			});
 			layoutObserver.observe(containerRef.current);
-		}
-
-		// Detect absolute file paths (e.g. /Users/foo/bar.ts) and make them
-		// Cmd+Clickable, opening via Utils.openPath() in the main process.
-		const FILE_PATH_RE = /(?:^|\s)(\/[\w.+-]+(?:\/[\w.@+-]+)+(?::[\d]+)?)/g;
-
-		function registerFilePathLinkProvider(term: Terminal) {
-			term.registerLinkProvider({
-				provideLinks(y: number, callback: (links: any[] | undefined) => void) {
-					const line = term.buffer.active.getLine(y);
-					if (!line) { callback(undefined); return; }
-
-					const text = line.translateToString();
-					const links: any[] = [];
-					let match: RegExpExecArray | null;
-
-					FILE_PATH_RE.lastIndex = 0;
-					while ((match = FILE_PATH_RE.exec(text)) !== null) {
-						const fullMatch = match[1];
-						const startX = match.index + (match[0].length - fullMatch.length);
-						links.push({
-							text: fullMatch,
-							range: {
-								start: { x: startX, y },
-								end: { x: startX + fullMatch.length - 1, y },
-							},
-							activate: () => {
-								api.request.openPath({ path: fullMatch.replace(/:[\d]+$/, "") });
-							},
-						});
-					}
-
-					callback(links.length > 0 ? links : undefined);
-				},
-			});
 		}
 
 		function setupMouseTracking(term: Terminal): () => void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -479,10 +479,6 @@ export type AppRPCSchema = {
 				params: { taskId: string; action: "splitH" | "splitV" | "zoom" };
 				response: void;
 			};
-			openPath: {
-				params: { path: string };
-				response: boolean;
-			};
 		};
 		messages: {
 			taskUpdated: { projectId: string; task: Task };


### PR DESCRIPTION
## Summary

- Handle `new-window-open` event on the Electrobun webview so that Cmd+Click on HTTP/HTTPS URLs in the terminal opens them in the default browser via `Utils.openExternal()`
- Previously, ghostty-web's built-in link providers called `window.open()` which silently failed in the WKWebView context

Closes #30