### PR TITLE
Add reusable Gauge component with demo page

### DIFF
--- a/change-logs/2026/03/04/feature-gauge-components.md
+++ b/change-logs/2026/03/04/feature-gauge-components.md
@@ -1,0 +1,1 @@
+Add reusable skeuomorphic gauge (dial) component extracted from the mastodont-app financial dashboard. The `<Gauge>` component supports configurable min/max, red zone, scalable size, custom tick labels, and sweep angle. Includes an interactive demo page with presets and live controls accessible from the dashboard.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -214,6 +214,8 @@ ApplicationMenu.setApplicationMenu([
 			{ label: "Soft Reset Terminal", action: "terminal-soft-reset" },
 			{ label: "Hard Reset Terminal", action: "terminal-hard-reset" },
 			{ type: "separator" },
+			{ label: "Gauge Demo", action: "gauge-demo" },
+			{ type: "separator" },
 			{ role: "toggleFullScreen" },
 		],
 	},
@@ -348,6 +350,8 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 		});
 	} else if (e.data.action === "open-settings") {
 		(mainWindow.webview.rpc as any).send.navigateToSettings?.({});
+	} else if (e.data.action === "gauge-demo") {
+		(mainWindow.webview.rpc as any).send.navigateToGaugeDemo?.({});
 	} else if (e.data.action === "check-for-updates") {
 		try {
 			const settings = await loadSettings();

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -13,6 +13,7 @@ import TaskTerminal from "./components/TaskTerminal";
 import ProjectSettings from "./components/ProjectSettings";
 import RequirementsCheck from "./components/RequirementsCheck";
 import Changelog from "./components/Changelog";
+import GaugeDemo from "./components/gauges/GaugeDemo";
 
 const SKIP_QUIT_DIALOG_KEY = "dev3-skip-quit-dialog";
 
@@ -134,6 +135,15 @@ function App() {
 		}
 		window.addEventListener("rpc:navigateToSettings", onNavigateToSettings);
 		return () => window.removeEventListener("rpc:navigateToSettings", onNavigateToSettings);
+	}, [navigate]);
+
+	// Listen for View > Gauge Demo menu item
+	useEffect(() => {
+		function onNavigateToGaugeDemo() {
+			navigate({ screen: "gauge-demo" });
+		}
+		window.addEventListener("rpc:navigateToGaugeDemo", onNavigateToGaugeDemo);
+		return () => window.removeEventListener("rpc:navigateToGaugeDemo", onNavigateToGaugeDemo);
 	}, [navigate]);
 
 	// Track page views on route changes
@@ -293,6 +303,8 @@ function App() {
 				return <GlobalSettings />;
 			case "changelog":
 				return <Changelog navigate={navigate} previousRoute={state.previousRoute} />;
+			case "gauge-demo":
+				return <GaugeDemo navigate={navigate} />;
 			default:
 				return null;
 		}

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -72,6 +72,8 @@ function GlobalHeader({ route, projects, tasks, navigate }: GlobalHeaderProps) {
 		segments.push({ label: t("header.settings") });
 	} else if (route.screen === "changelog") {
 		segments.push({ label: t("header.changelog") });
+	} else if (route.screen === "gauge-demo") {
+		segments.push({ label: t("gaugeDemo.title") });
 	}
 
 	return (

--- a/src/mainview/components/gauges/Gauge.tsx
+++ b/src/mainview/components/gauges/Gauge.tsx
@@ -1,0 +1,401 @@
+import { useMemo, useSyncExternalStore, type CSSProperties } from "react";
+
+export type GaugeTheme = "dark" | "light" | "auto";
+
+export interface GaugeProps {
+	/** Current value */
+	value: number;
+	/** Minimum value (default: 0) */
+	min?: number;
+	/** Maximum value */
+	max: number;
+	/** Step between major tick marks (auto-calculated if omitted) */
+	step?: number;
+	/** Value at which red zone starts (optional) */
+	redZone?: number;
+	/** Gauge diameter in px (default: 240) */
+	size?: number;
+	/** Label text (e.g. "Income") */
+	label?: string;
+	/** Unit text (e.g. "p/m") */
+	unit?: string;
+	/** Format function for tick labels */
+	formatLabel?: (value: number) => string;
+	/** Sweep angle range [start, end] in degrees (default: [30, 330]) */
+	angleRange?: [number, number];
+	/** Color theme: "dark", "light", or "auto" (follows app theme). Default: "auto" */
+	theme?: GaugeTheme;
+}
+
+const DEG = Math.PI / 180;
+
+// --- Color palettes ---
+
+interface GaugePalette {
+	bezelGradient: string;
+	bezelShadow: string;
+	bezelInnerBg: string;
+	bezelInnerShadow: string;
+	faceGradient: string;
+	faceBorder: string;
+	faceShadow: string;
+	faceGlare: string;
+	needleColor: string;
+	needleShadow: string;
+	needleShine: string;
+	pivotGradient: string;
+	pivotBorder: string;
+	pivotShadow: string;
+	tickColor: string;
+	tickRedColor: string;
+	labelColor: string;
+	labelRedColor: string;
+	unitColor: string;
+}
+
+const DARK_PALETTE: GaugePalette = {
+	bezelGradient: "linear-gradient(145deg, #CFD6DA 0%, #7F8A93 45%, #5F6A73 55%, #A7B0B7 100%)",
+	bezelShadow: "0 15px 35px rgba(0,0,0,1), inset 0 2px 3px rgba(255,255,255,0.8), inset 0 -2px 3px rgba(0,0,0,0.5)",
+	bezelInnerBg: "radial-gradient(circle at 50% 50%, #08090b 0%, #121518 60%, #1e2228 100%)",
+	bezelInnerShadow: "inset 0 10px 20px rgba(0,0,0,0.9)",
+	faceGradient: "radial-gradient(circle at 50% 50%, #151a24, #0a0e14)",
+	faceBorder: "#141820",
+	faceShadow: "inset 0 10px 30px rgba(0,0,0,1), 0 5px 15px rgba(255,255,255,0.05)",
+	faceGlare: "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.1) 0%, transparent 70%)",
+	needleColor: "#e11d48",
+	needleShadow: "0 4px 8px rgba(0,0,0,0.5)",
+	needleShine: "linear-gradient(to right, rgba(0,0,0,0.2), transparent, rgba(0,0,0,0.2))",
+	pivotGradient: "radial-gradient(circle at 30% 30%, #444, #111)",
+	pivotBorder: "#222",
+	pivotShadow: "0 4px 10px rgba(0,0,0,0.8), inset 0 2px 4px rgba(255,255,255,0.1)",
+	tickColor: "#334155",
+	tickRedColor: "#ef4444",
+	labelColor: "#475569",
+	labelRedColor: "#ef4444",
+	unitColor: "#64748b",
+};
+
+const LIGHT_PALETTE: GaugePalette = {
+	// Gunmetal chrome bezel — neutral silver, Porsche-strict
+	bezelGradient: "linear-gradient(160deg, #ededee 0%, #d4d6da 15%, #a0a4ac 40%, #8e9098 55%, #a0a4ac 70%, #d4d6da 85%, #ededee 100%)",
+	bezelShadow: "0 14px 40px rgba(0,0,0,0.5), 0 4px 12px rgba(0,0,0,0.3), inset 0 3px 4px rgba(255,255,255,0.85), inset 0 -3px 4px rgba(0,0,0,0.4)",
+	// Inner ring — gunmetal tunnel, dark center, lighter edge
+	bezelInnerBg: "radial-gradient(circle, #3e4048 0%, #5c5f68 55%, #a8aab2 100%)",
+	bezelInnerShadow: "inset 0 8px 20px rgba(0,0,0,0.6), inset 0 -3px 6px rgba(0,0,0,0.3)",
+	// Face gradient — user-tuned values
+	faceGradient: "radial-gradient(circle at 46% 42%, rgb(247,247,247) 0%, rgb(237,238,240) 25%, rgb(216,218,222) 55%, rgb(192,196,202) 80%, rgb(176,181,188) 100%)",
+	faceBorder: "#383c42",
+	faceShadow: "inset 0 6px 20px rgba(0,0,0,0.1), inset 0 -2px 6px rgba(0,0,0,0.04), 0 2px 8px rgba(255,255,255,0.2)",
+	// Very subtle glass highlight
+	faceGlare: "radial-gradient(circle at 35% 25%, rgba(255,255,255,0.3) 0%, transparent 50%)",
+	// Classic Porsche red/orange needle
+	needleColor: "#e03e2d",
+	needleShadow: "0 3px 6px rgba(224,62,45,0.35), 0 1px 3px rgba(0,0,0,0.25)",
+	needleShine: "linear-gradient(to right, rgba(0,0,0,0.15), transparent, rgba(0,0,0,0.15))",
+	// Dark chrome pivot cap
+	pivotGradient: "radial-gradient(circle at 30% 30%, #555, #1a1a1a)",
+	pivotBorder: "#2a2a2a",
+	pivotShadow: "0 3px 8px rgba(0,0,0,0.6), inset 0 1px 2px rgba(255,255,255,0.2)",
+	// Dark crisp tick marks on light face — Porsche uses near-black
+	tickColor: "#2c2c2c",
+	tickRedColor: "#d42020",
+	labelColor: "#1a1a1a",
+	labelRedColor: "#d42020",
+	unitColor: "#3a3a3a",
+};
+
+// --- Detect app theme from DOM ---
+
+function getAppTheme(): "dark" | "light" {
+	if (typeof document === "undefined") return "dark";
+	return (document.documentElement.dataset.theme as "dark" | "light") || "dark";
+}
+
+function subscribeToTheme(cb: () => void): () => void {
+	const observer = new MutationObserver(cb);
+	observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+	return () => observer.disconnect();
+}
+
+/** Format large numbers compactly: 1500 → "1.5K", 2000000 → "2M", etc. */
+function compactNumber(v: number): string {
+	const abs = Math.abs(v);
+	if (abs >= 1_000_000_000) {
+		const n = v / 1_000_000_000;
+		return (Number.isInteger(n) ? n : +n.toFixed(1)) + "B";
+	}
+	if (abs >= 1_000_000) {
+		const n = v / 1_000_000;
+		return (Number.isInteger(n) ? n : +n.toFixed(1)) + "M";
+	}
+	if (abs >= 1_000) {
+		const n = v / 1_000;
+		return (Number.isInteger(n) ? n : +n.toFixed(1)) + "K";
+	}
+	return String(v);
+}
+
+function defaultStep(min: number, max: number): number {
+	const range = max - min;
+	const magnitude = Math.pow(10, Math.floor(Math.log10(range)));
+	const normalized = range / magnitude;
+	if (normalized <= 2) return magnitude / 4;
+	if (normalized <= 5) return magnitude / 2;
+	return magnitude;
+}
+
+export function Gauge({
+	value,
+	min = 0,
+	max,
+	step: stepProp,
+	redZone,
+	size = 240,
+	label,
+	unit,
+	formatLabel = compactNumber,
+	angleRange = [30, 330],
+	theme = "auto",
+}: GaugeProps) {
+	const appTheme = useSyncExternalStore(subscribeToTheme, getAppTheme, () => "dark" as const);
+	const resolvedTheme = theme === "auto" ? appTheme : theme;
+	const p = resolvedTheme === "light" ? LIGHT_PALETTE : DARK_PALETTE;
+
+	const step = stepProp ?? defaultStep(min, max);
+	const [angleMin, angleMax] = angleRange;
+	const scale = size / 240;
+
+	const bezelSize = Math.round(size * 1.17);
+	const needleLength = Math.round(size * 0.42);
+	const pivotSize = Math.round(size * 0.13);
+	const tickMargin = 12;
+
+	const clampedValue = Math.min(Math.max(value, min), max);
+	const pct = (clampedValue - min) / (max - min);
+	const needleAngle = pct * (angleMax - angleMin) + angleMin;
+
+	const ticks = useMemo(() => {
+		const MAX_TICKS = 20;
+		let steps = Math.round((max - min) / step);
+		const effectiveStep = steps > MAX_TICKS
+			? (max - min) / MAX_TICKS
+			: step;
+		if (steps > MAX_TICKS) steps = MAX_TICKS;
+		const angleStep = (angleMax - angleMin) / steps;
+		const items: Array<{
+			value: number;
+			angle: number;
+			isRed: boolean;
+			halfAngle?: number;
+		}> = [];
+
+		for (let n = 0; n <= steps; n++) {
+			const v = min + n * effectiveStep;
+			const angle = angleMin + n * angleStep;
+			const isRed = redZone != null && v >= redZone;
+			items.push({
+				value: v,
+				angle,
+				isRed,
+				halfAngle: n < steps ? angle + angleStep / 2 : undefined,
+			});
+		}
+		return items;
+	}, [min, max, step, angleMin, angleMax, redZone]);
+
+	// --- Styles ---
+	const bezelStyle: CSSProperties = {
+		width: bezelSize,
+		height: bezelSize,
+		borderRadius: "50%",
+		background: p.bezelGradient,
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		boxShadow: p.bezelShadow,
+		position: "relative",
+	};
+
+	const bezelInnerStyle: CSSProperties = {
+		position: "absolute",
+		inset: 5 * scale,
+		borderRadius: "50%",
+		background: p.bezelInnerBg,
+		boxShadow: p.bezelInnerShadow,
+	};
+
+	const faceStyle: CSSProperties = {
+		width: size,
+		height: size,
+		borderRadius: "50%",
+		background: p.faceGradient,
+		position: "relative",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		overflow: "hidden",
+		border: `${Math.round(2 * scale)}px solid ${p.faceBorder}`,
+		boxShadow: p.faceShadow,
+		zIndex: 10,
+	};
+
+	const faceGlareStyle: CSSProperties = {
+		position: "absolute",
+		inset: 0,
+		background: p.faceGlare,
+		pointerEvents: "none",
+		borderRadius: "inherit",
+	};
+
+	const needleStyle: CSSProperties = {
+		position: "absolute",
+		top: "50%",
+		left: "50%",
+		display: "block",
+		width: Math.round(4 * scale),
+		height: needleLength,
+		transformOrigin: "50% 0",
+		transform: `translate3d(-50%, 0, 0) rotate(${Math.round(needleAngle)}deg)`,
+		backgroundColor: p.needleColor,
+		boxShadow: p.needleShadow,
+		zIndex: 10,
+		transition: "transform 1.5s cubic-bezier(0.19, 1, 0.22, 1)",
+		borderRadius: `${Math.round(4 * scale)}px ${Math.round(4 * scale)}px 0 0`,
+	};
+
+	const needleShineStyle: CSSProperties = {
+		position: "absolute",
+		top: 0,
+		left: -2 * scale,
+		width: 8 * scale,
+		height: "100%",
+		background: p.needleShine,
+	};
+
+	const pivotStyle: CSSProperties = {
+		position: "absolute",
+		top: "50%",
+		left: "50%",
+		width: pivotSize,
+		height: pivotSize,
+		transform: "translate(-50%, -50%)",
+		background: p.pivotGradient,
+		border: `2px solid ${p.pivotBorder}`,
+		borderRadius: "50%",
+		boxShadow: p.pivotShadow,
+		zIndex: 20,
+	};
+
+	const unitLabelStyle: CSSProperties = {
+		position: "absolute",
+		left: "50%",
+		top: "75%",
+		transform: "translate(-50%, -50%)",
+		textAlign: "center",
+		color: p.unitColor,
+		fontSize: Math.round(10 * scale),
+		fontWeight: 800,
+		textTransform: "uppercase",
+		letterSpacing: 2 * scale,
+		pointerEvents: "none",
+		lineHeight: 1.4,
+	};
+
+	return (
+		<div style={bezelStyle}>
+			<div style={bezelInnerStyle} />
+			<div style={faceStyle}>
+				<div style={faceGlareStyle} />
+
+				{ticks.map((tick, i) => (
+					<GaugeTick
+						key={i}
+						tick={tick}
+						scale={scale}
+						tickMargin={tickMargin}
+						formatLabel={formatLabel}
+						palette={p}
+					/>
+				))}
+
+				{(label || unit) && (
+					<div style={unitLabelStyle}>
+						{label && <div>{label}</div>}
+						{unit && <span style={{ fontSize: Math.round(9 * scale), opacity: 0.7 }}>{unit}</span>}
+					</div>
+				)}
+
+				<div style={needleStyle}>
+					<div style={needleShineStyle} />
+				</div>
+
+				<div style={pivotStyle} />
+			</div>
+		</div>
+	);
+}
+
+interface GaugeTickProps {
+	tick: { value: number; angle: number; isRed: boolean; halfAngle?: number };
+	scale: number;
+	tickMargin: number;
+	formatLabel: (v: number) => string;
+	palette: GaugePalette;
+}
+
+function GaugeTick({ tick, scale, tickMargin, formatLabel, palette }: GaugeTickProps) {
+	const { angle, isRed, halfAngle } = tick;
+	const labelColor = isRed ? palette.labelRedColor : palette.labelColor;
+	const tickColor = isRed ? palette.tickRedColor : palette.tickColor;
+
+	const labelStyle: CSSProperties = {
+		position: "absolute",
+		display: "inline-block",
+		fontSize: Math.round(14 * scale),
+		color: labelColor,
+		transform: "translate(-50%, -50%)",
+		fontWeight: 900,
+		fontFamily: "'Inter', sans-serif",
+		zIndex: 5,
+		pointerEvents: "none",
+		left: `${50 - (50 - tickMargin) * Math.sin(angle * DEG)}%`,
+		top: `${50 + (50 - tickMargin) * Math.cos(angle * DEG)}%`,
+	};
+
+	const mainTickStyle: CSSProperties = {
+		position: "absolute",
+		display: "block",
+		width: Math.round(3 * scale),
+		height: Math.round(10 * scale),
+		transformOrigin: "50% 0",
+		backgroundColor: tickColor,
+		zIndex: 4,
+		left: `${50 - 50 * Math.sin(angle * DEG)}%`,
+		top: `${50 + 50 * Math.cos(angle * DEG)}%`,
+		transform: `translate(-50%, 0) rotate(${angle + 180}deg)`,
+	};
+
+	const halfTickStyle: CSSProperties | undefined = halfAngle != null ? {
+		position: "absolute",
+		display: "block",
+		width: Math.round(2 * scale),
+		height: Math.round(7 * scale),
+		transformOrigin: "50% 0",
+		backgroundColor: tickColor,
+		zIndex: 4,
+		opacity: 0.6,
+		left: `${50 - 50 * Math.sin(halfAngle * DEG)}%`,
+		top: `${50 + 50 * Math.cos(halfAngle * DEG)}%`,
+		transform: `translate(-50%, 0) rotate(${halfAngle + 180}deg)`,
+	} : undefined;
+
+	return (
+		<>
+			<div style={labelStyle}>{formatLabel(tick.value)}</div>
+			<div style={mainTickStyle} />
+			{halfTickStyle && <div style={halfTickStyle} />}
+		</>
+	);
+}
+
+export default Gauge;

--- a/src/mainview/components/gauges/GaugeDemo.tsx
+++ b/src/mainview/components/gauges/GaugeDemo.tsx
@@ -1,0 +1,415 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { Gauge, type GaugeTheme } from "./Gauge";
+import { useT } from "../../i18n";
+
+interface PresetConfig {
+	nameKey: string;
+	min: number;
+	max: number;
+	step: number;
+	value: number;
+	redZone?: number;
+	angleRange: [number, number];
+	label: string;
+	unit: string;
+	formatLabel?: (v: number) => string;
+}
+
+const PRESETS: PresetConfig[] = [
+	{
+		nameKey: "gaugeDemo.presetInvestment",
+		min: 0,
+		max: 100000,
+		step: 20000,
+		value: 45000,
+		angleRange: [45, 315],
+		label: "Invest",
+		unit: "Goal",
+	},
+	{
+		nameKey: "gaugeDemo.presetIncome",
+		min: 0,
+		max: 200000,
+		step: 40000,
+		value: 120000,
+		angleRange: [30, 330],
+		label: "Income",
+		unit: "p/m",
+	},
+	{
+		nameKey: "gaugeDemo.presetExpense",
+		min: 0,
+		max: 200000,
+		step: 40000,
+		value: 150000,
+		redZone: 160000,
+		angleRange: [30, 330],
+		label: "Outflow",
+		unit: "p/m",
+	},
+	{
+		nameKey: "gaugeDemo.presetLimit",
+		min: 0,
+		max: 1,
+		step: 0.25,
+		value: 0.65,
+		angleRange: [60, 300],
+		label: "Limit",
+		unit: "Usage",
+		formatLabel: (v) => `${Math.round(v * 100)}%`,
+	},
+];
+
+interface PlaygroundState {
+	value: number;
+	min: number;
+	max: number;
+	step: number;
+	size: number;
+	redZoneEnabled: boolean;
+	redZone: number;
+	angleStart: number;
+	angleEnd: number;
+	label: string;
+	unit: string;
+}
+
+const DEFAULT_PLAYGROUND: PlaygroundState = {
+	value: 65,
+	min: 0,
+	max: 100,
+	step: 20,
+	size: 280,
+	redZoneEnabled: false,
+	redZone: 80,
+	angleStart: 30,
+	angleEnd: 330,
+	label: "Speed",
+	unit: "km/h",
+};
+
+interface GaugeDemoProps {
+	navigate: (route: { screen: "dashboard" }) => void;
+}
+
+const THEME_OPTIONS: Array<"auto" | "dark" | "light"> = ["auto", "dark", "light"];
+
+export function GaugeDemo({ navigate }: GaugeDemoProps) {
+	const t = useT();
+	const [pg, setPg] = useState<PlaygroundState>(DEFAULT_PLAYGROUND);
+	const [gaugeTheme, setGaugeTheme] = useState<GaugeTheme>("auto");
+	const originalThemeRef = useRef<string | null>(null);
+
+	// On mount, save original app theme. On unmount, restore it.
+	useEffect(() => {
+		originalThemeRef.current = document.documentElement.dataset.theme || null;
+		return () => {
+			// Restore original theme when leaving the page
+			if (originalThemeRef.current) {
+				document.documentElement.dataset.theme = originalThemeRef.current;
+			} else {
+				delete document.documentElement.dataset.theme;
+			}
+		};
+	}, []);
+
+	// When gaugeTheme changes, apply it to <html> for full app simulation
+	useEffect(() => {
+		if (gaugeTheme === "auto") {
+			// Restore original theme
+			if (originalThemeRef.current) {
+				document.documentElement.dataset.theme = originalThemeRef.current;
+			}
+		} else {
+			document.documentElement.dataset.theme = gaugeTheme;
+		}
+	}, [gaugeTheme]);
+
+	const update = useCallback(
+		<K extends keyof PlaygroundState>(key: K, val: PlaygroundState[K]) => {
+			setPg((prev) => ({ ...prev, [key]: val }));
+		},
+		[],
+	);
+
+	const loadPreset = useCallback((preset: PresetConfig) => {
+		setPg({
+			value: preset.value,
+			min: preset.min,
+			max: preset.max,
+			step: preset.step,
+			size: 280,
+			redZoneEnabled: preset.redZone != null,
+			redZone: preset.redZone ?? preset.max * 0.8,
+			angleStart: preset.angleRange[0],
+			angleEnd: preset.angleRange[1],
+			label: preset.label,
+			unit: preset.unit,
+		});
+	}, []);
+
+	return (
+		<div className="flex-1 overflow-y-auto p-6 space-y-8">
+			{/* Header */}
+			<div className="flex items-center gap-4">
+				<button
+					onClick={() => navigate({ screen: "dashboard" })}
+					className="text-fg-3 hover:text-fg transition-colors text-sm"
+				>
+					&larr; {t("gaugeDemo.back")}
+				</button>
+				<h1 className="text-fg text-2xl font-bold flex-1">{t("gaugeDemo.title")}</h1>
+
+				{/* Theme switcher */}
+				<div className="flex items-center gap-1 bg-elevated rounded-lg p-0.5 border border-edge">
+					{THEME_OPTIONS.map((opt) => (
+						<button
+							key={opt}
+							onClick={() => setGaugeTheme(opt)}
+							className={`px-3 py-1 text-xs font-semibold rounded-md transition-colors ${
+								gaugeTheme === opt
+									? "bg-accent text-white"
+									: "text-fg-3 hover:text-fg"
+							}`}
+						>
+							{t(`gaugeDemo.theme${opt[0].toUpperCase()}${opt.slice(1)}` as Parameters<typeof t>[0])}
+						</button>
+					))}
+				</div>
+			</div>
+
+			{/* Presets row */}
+			<section>
+				<h2 className="text-fg-2 text-sm font-semibold mb-4 uppercase tracking-wider">
+					{t("gaugeDemo.presets")}
+				</h2>
+				<div className="flex flex-wrap gap-8 items-end justify-center p-8 bg-raised rounded-2xl border border-edge">
+					{PRESETS.map((preset, i) => (
+						<div key={i} className="flex flex-col items-center gap-3">
+							<Gauge
+								value={preset.value}
+								min={preset.min}
+								max={preset.max}
+								step={preset.step}
+								redZone={preset.redZone}
+								size={i === 1 || i === 2 ? 200 : 160}
+								label={preset.label}
+								unit={preset.unit}
+								formatLabel={preset.formatLabel}
+								angleRange={preset.angleRange}
+								theme={gaugeTheme}
+							/>
+							<button
+								onClick={() => loadPreset(preset)}
+								className="text-xs text-accent hover:text-accent/80 font-semibold uppercase tracking-wider transition-colors"
+							>
+								{t(preset.nameKey as Parameters<typeof t>[0])}
+							</button>
+						</div>
+					))}
+				</div>
+			</section>
+
+			{/* Playground */}
+			<section>
+				<h2 className="text-fg-2 text-sm font-semibold mb-4 uppercase tracking-wider">
+					{t("gaugeDemo.playground")}
+				</h2>
+				<div className="flex flex-col lg:flex-row gap-8">
+					{/* Live gauge */}
+					<div className="flex-1 flex items-center justify-center p-8 bg-raised rounded-2xl border border-edge min-h-[400px]">
+						<Gauge
+							value={pg.value}
+							min={pg.min}
+							max={pg.max}
+							step={pg.step}
+							redZone={pg.redZoneEnabled ? pg.redZone : undefined}
+							size={pg.size}
+							label={pg.label}
+							unit={pg.unit}
+							angleRange={[pg.angleStart, pg.angleEnd]}
+							theme={gaugeTheme}
+						/>
+					</div>
+
+					{/* Controls */}
+					<div className="w-full lg:w-80 space-y-4 p-6 bg-raised rounded-2xl border border-edge">
+						<SliderControl
+							label={t("gaugeDemo.value")}
+							value={pg.value}
+							min={pg.min}
+							max={pg.max}
+							step={pg.step / 10 || 1}
+							onChange={(v) => update("value", v)}
+						/>
+						<div className="grid grid-cols-2 gap-3">
+							<NumberInput
+								label={t("gaugeDemo.min")}
+								value={pg.min}
+								onChange={(v) => update("min", v)}
+							/>
+							<NumberInput
+								label={t("gaugeDemo.max")}
+								value={pg.max}
+								onChange={(v) => update("max", v)}
+							/>
+						</div>
+						<NumberInput
+							label={t("gaugeDemo.step")}
+							value={pg.step}
+							onChange={(v) => update("step", v)}
+						/>
+						<SliderControl
+							label={t("gaugeDemo.size")}
+							value={pg.size}
+							min={100}
+							max={500}
+							step={10}
+							onChange={(v) => update("size", v)}
+						/>
+
+						{/* Red zone toggle + slider */}
+						<div className="space-y-2">
+							<label className="flex items-center gap-2 cursor-pointer select-none">
+								<input
+									type="checkbox"
+									checked={pg.redZoneEnabled}
+									onChange={(e) => update("redZoneEnabled", e.target.checked)}
+									className="w-4 h-4 rounded accent-accent"
+								/>
+								<span className="text-fg-2 text-sm">
+									{t("gaugeDemo.redZoneEnabled")}
+								</span>
+							</label>
+							{pg.redZoneEnabled && (
+								<SliderControl
+									label={t("gaugeDemo.redZone")}
+									value={pg.redZone}
+									min={pg.min}
+									max={pg.max}
+									step={pg.step / 10 || 1}
+									onChange={(v) => update("redZone", v)}
+								/>
+							)}
+						</div>
+
+						{/* Angle range */}
+						<div className="space-y-2">
+							<span className="text-fg-3 text-xs font-medium">
+								{t("gaugeDemo.angleRange")}
+							</span>
+							<div className="grid grid-cols-2 gap-3">
+								<NumberInput
+									label="Start°"
+									value={pg.angleStart}
+									onChange={(v) => update("angleStart", v)}
+								/>
+								<NumberInput
+									label="End°"
+									value={pg.angleEnd}
+									onChange={(v) => update("angleEnd", v)}
+								/>
+							</div>
+						</div>
+
+						{/* Label / Unit */}
+						<div className="grid grid-cols-2 gap-3">
+							<TextInput
+								label={t("gaugeDemo.label")}
+								value={pg.label}
+								onChange={(v) => update("label", v)}
+							/>
+							<TextInput
+								label={t("gaugeDemo.unit")}
+								value={pg.unit}
+								onChange={(v) => update("unit", v)}
+							/>
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
+	);
+}
+
+// --- Small control components ---
+
+function SliderControl({
+	label,
+	value,
+	min,
+	max,
+	step,
+	onChange,
+}: {
+	label: string;
+	value: number;
+	min: number;
+	max: number;
+	step: number;
+	onChange: (v: number) => void;
+}) {
+	return (
+		<div className="space-y-1">
+			<div className="flex justify-between">
+				<span className="text-fg-3 text-xs font-medium">{label}</span>
+				<span className="text-fg-2 text-xs font-mono">{value}</span>
+			</div>
+			<input
+				type="range"
+				min={min}
+				max={max}
+				step={step}
+				value={value}
+				onChange={(e) => onChange(Number(e.target.value))}
+				className="w-full h-1.5 rounded-full appearance-none bg-elevated cursor-pointer accent-accent"
+			/>
+		</div>
+	);
+}
+
+function NumberInput({
+	label,
+	value,
+	onChange,
+}: {
+	label: string;
+	value: number;
+	onChange: (v: number) => void;
+}) {
+	return (
+		<div className="space-y-1">
+			<span className="text-fg-3 text-xs font-medium">{label}</span>
+			<input
+				type="number"
+				value={value}
+				onChange={(e) => onChange(Number(e.target.value))}
+				className="w-full px-2 py-1.5 text-sm rounded-lg bg-elevated border border-edge text-fg focus:outline-none focus:border-accent transition-colors"
+			/>
+		</div>
+	);
+}
+
+function TextInput({
+	label,
+	value,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	onChange: (v: string) => void;
+}) {
+	return (
+		<div className="space-y-1">
+			<span className="text-fg-3 text-xs font-medium">{label}</span>
+			<input
+				type="text"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				className="w-full px-2 py-1.5 text-sm rounded-lg bg-elevated border border-edge text-fg focus:outline-none focus:border-accent transition-colors"
+			/>
+		</div>
+	);
+}
+
+export default GaugeDemo;

--- a/src/mainview/components/gauges/index.ts
+++ b/src/mainview/components/gauges/index.ts
@@ -1,0 +1,1 @@
+export { Gauge, type GaugeProps, type GaugeTheme } from "./Gauge";

--- a/src/mainview/i18n/translations/en.ts
+++ b/src/mainview/i18n/translations/en.ts
@@ -351,6 +351,29 @@ const en = {
 	"status.reviewByUser": "Review by User",
 	"status.completed": "Completed",
 	"status.cancelled": "Cancelled",
+
+	// Gauge Demo
+	"gaugeDemo.title": "Gauge Components",
+	"gaugeDemo.playground": "Playground",
+	"gaugeDemo.presets": "Presets",
+	"gaugeDemo.value": "Value",
+	"gaugeDemo.min": "Min",
+	"gaugeDemo.max": "Max",
+	"gaugeDemo.step": "Step",
+	"gaugeDemo.size": "Size",
+	"gaugeDemo.redZone": "Red Zone",
+	"gaugeDemo.redZoneEnabled": "Enable Red Zone",
+	"gaugeDemo.angleRange": "Sweep Angle",
+	"gaugeDemo.label": "Label",
+	"gaugeDemo.unit": "Unit",
+	"gaugeDemo.presetInvestment": "Investment",
+	"gaugeDemo.presetIncome": "Income",
+	"gaugeDemo.presetExpense": "Expense",
+	"gaugeDemo.presetLimit": "Limit",
+	"gaugeDemo.back": "Back",
+	"gaugeDemo.themeAuto": "Auto",
+	"gaugeDemo.themeDark": "Dark",
+	"gaugeDemo.themeLight": "Light",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/mainview/i18n/translations/es.ts
+++ b/src/mainview/i18n/translations/es.ts
@@ -354,6 +354,29 @@ const es: TranslationRecord & Record<string, string> = {
 	"status.reviewByUser": "Revisión por usuario",
 	"status.completed": "Completado",
 	"status.cancelled": "Cancelado",
+
+	// Gauge Demo
+	"gaugeDemo.title": "Componentes de indicadores",
+	"gaugeDemo.playground": "Zona de pruebas",
+	"gaugeDemo.presets": "Preajustes",
+	"gaugeDemo.value": "Valor",
+	"gaugeDemo.min": "Mín",
+	"gaugeDemo.max": "Máx",
+	"gaugeDemo.step": "Paso",
+	"gaugeDemo.size": "Tamaño",
+	"gaugeDemo.redZone": "Zona roja",
+	"gaugeDemo.redZoneEnabled": "Activar zona roja",
+	"gaugeDemo.angleRange": "Ángulo de barrido",
+	"gaugeDemo.label": "Etiqueta",
+	"gaugeDemo.unit": "Unidad",
+	"gaugeDemo.presetInvestment": "Inversión",
+	"gaugeDemo.presetIncome": "Ingresos",
+	"gaugeDemo.presetExpense": "Gastos",
+	"gaugeDemo.presetLimit": "Límite",
+	"gaugeDemo.back": "Volver",
+	"gaugeDemo.themeAuto": "Auto",
+	"gaugeDemo.themeDark": "Oscuro",
+	"gaugeDemo.themeLight": "Claro",
 };
 
 export default es;

--- a/src/mainview/i18n/translations/ru.ts
+++ b/src/mainview/i18n/translations/ru.ts
@@ -357,6 +357,29 @@ const ru: TranslationRecord & Record<string, string> = {
 	"status.reviewByUser": "Ревью пользователя",
 	"status.completed": "Завершено",
 	"status.cancelled": "Отменено",
+
+	// Gauge Demo
+	"gaugeDemo.title": "Компоненты-циферблаты",
+	"gaugeDemo.playground": "Песочница",
+	"gaugeDemo.presets": "Пресеты",
+	"gaugeDemo.value": "Значение",
+	"gaugeDemo.min": "Мин",
+	"gaugeDemo.max": "Макс",
+	"gaugeDemo.step": "Шаг",
+	"gaugeDemo.size": "Размер",
+	"gaugeDemo.redZone": "Красная зона",
+	"gaugeDemo.redZoneEnabled": "Включить красную зону",
+	"gaugeDemo.angleRange": "Угол развёртки",
+	"gaugeDemo.label": "Метка",
+	"gaugeDemo.unit": "Единица",
+	"gaugeDemo.presetInvestment": "Инвестиции",
+	"gaugeDemo.presetIncome": "Доходы",
+	"gaugeDemo.presetExpense": "Расходы",
+	"gaugeDemo.presetLimit": "Лимит",
+	"gaugeDemo.back": "Назад",
+	"gaugeDemo.themeAuto": "Авто",
+	"gaugeDemo.themeDark": "Тёмная",
+	"gaugeDemo.themeLight": "Светлая",
 };
 
 export default ru;

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -31,6 +31,11 @@ const rpc = Electroview.defineRPC<AppRPCSchema>({
 					new CustomEvent("rpc:navigateToSettings"),
 				);
 			},
+			navigateToGaugeDemo: () => {
+				window.dispatchEvent(
+					new CustomEvent("rpc:navigateToGaugeDemo"),
+				);
+			},
 			terminalSoftReset: () => {
 				window.dispatchEvent(
 					new CustomEvent("rpc:terminalSoftReset"),

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -9,7 +9,8 @@ export type Route =
 	| { screen: "task"; projectId: string; taskId: string }
 	| { screen: "project-settings"; projectId: string }
 	| { screen: "settings" }
-	| { screen: "changelog" };
+	| { screen: "changelog" }
+	| { screen: "gauge-demo" };
 
 // ---- State ----
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -506,6 +506,7 @@ export type AppRPCSchema = {
 		requests: Record<string, never>;
 		messages: {
 			navigateToSettings: {};
+			navigateToGaugeDemo: {};
 			terminalSoftReset: {};
 			terminalHardReset: {};
 		};


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI that built this branch.

- Extracted skeuomorphic car-dashboard gauge from mastodont-app into a universal `<Gauge>` React component with configurable min/max/value/step, optional red zone, scalable size, compact number formatting (K/M/B), and tick count cap
- Two themes: dark (red needle, dark face) and light (gunmetal chrome bezel, silvery face, red needle) with auto-detection from app theme
- Demo page with 4 presets (Investment, Income, Expense, Limit) and interactive playground — accessible via **View > Gauge Demo** menu
- i18n support for en/ru/es