### PR TITLE
Disable autocapitalize on technical input fields

### DIFF
--- a/change-logs/2026/03/04/fix-autocapitalize-agent-inputs.md
+++ b/change-logs/2026/03/04/fix-autocapitalize-agent-inputs.md
@@ -1,0 +1,1 @@
+Disable autocapitalize, autocorrect, and spellcheck on all technical input fields (base command, model, base command override, additional args, env vars, scripts, branch name) in GlobalSettings and ProjectSettings. WKWebView was auto-capitalizing commands like "claude" which broke case-sensitive CLI commands. Fixes #51.

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -397,6 +397,9 @@ function GlobalSettings() {
 															})
 														}
 														placeholder="claude"
+														autoCapitalize="off"
+														autoCorrect="off"
+														spellCheck={false}
 														className="w-full px-3 py-2 bg-elevated border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 													/>
 												</div>
@@ -658,6 +661,9 @@ function ConfigEditor({
 								onChange({ model: e.target.value || undefined })
 							}
 							placeholder="opus, sonnet, etc."
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck={false}
 							className="w-full px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 						/>
 					</div>
@@ -799,6 +805,9 @@ function ConfigEditor({
 								})
 							}
 							placeholder=""
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck={false}
 							className="w-full px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 						/>
 					</div>
@@ -844,6 +853,9 @@ function ListEditor({
 							onChange(next);
 						}}
 						placeholder={placeholder}
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck={false}
 						className="flex-1 px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 					/>
 					<button
@@ -908,6 +920,9 @@ function KeyValueEditor({
 						value={key}
 						onChange={(e) => updateKey(key, e.target.value)}
 						placeholder="KEY"
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck={false}
 						className="w-1/3 px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 					/>
 					<input
@@ -915,6 +930,9 @@ function KeyValueEditor({
 						value={value}
 						onChange={(e) => updateValue(key, e.target.value)}
 						placeholder="value"
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck={false}
 						className="flex-1 px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 					/>
 					<button

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -195,6 +195,9 @@ function ProjectSettings({
 							onChange={(e) => setSetupScript(e.target.value)}
 							rows={4}
 							placeholder="bun install"
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck={false}
 							className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors resize-y"
 						/>
 					</div>
@@ -212,6 +215,9 @@ function ProjectSettings({
 						onChange={(e) => setDevScript(e.target.value)}
 						rows={4}
 						placeholder="bun run dev"
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck={false}
 						className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors resize-y"
 					/>
 				</div>
@@ -229,6 +235,9 @@ function ProjectSettings({
 						onChange={(e) => setCleanupScript(e.target.value)}
 						rows={4}
 						placeholder="git worktree remove ."
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck={false}
 						className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors resize-y"
 					/>
 				</div>
@@ -246,6 +255,9 @@ function ProjectSettings({
 							value={defaultBaseBranch}
 							onChange={(e) => setDefaultBaseBranch(e.target.value)}
 							placeholder="main"
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck={false}
 							className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 						/>
 					</div>

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -663,6 +663,81 @@ describe("GlobalSettings", () => {
 		});
 	});
 
+	describe("autocapitalize disabled on technical inputs", () => {
+		it("base command input has autocapitalize off", async () => {
+			setupMocks();
+			const user = userEvent.setup();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			// Expand Codex
+			const agentHeaders = screen.getAllByRole("button");
+			const codexHeader = agentHeaders.find((b) =>
+				b.textContent?.includes("Codex") && b.textContent?.includes("codex"),
+			)!;
+			await user.click(codexHeader);
+
+			const cmdInput = screen.getByDisplayValue("codex");
+			expect(cmdInput).toHaveAttribute("autocapitalize", "off");
+			expect(cmdInput).toHaveAttribute("autocorrect", "off");
+			expect(cmdInput.getAttribute("spellcheck")).toBe("false");
+		});
+
+		it("model input has autocapitalize off", async () => {
+			setupMocks();
+			const user = userEvent.setup();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			// Expand Claude agent
+			const agentHeaders = screen.getAllByRole("button");
+			const claudeHeader = agentHeaders.find((b) =>
+				b.textContent?.includes("Claude") && b.textContent?.includes("claude"),
+			)!;
+			await user.click(claudeHeader);
+
+			// Expand Default config
+			const configButtons = screen.getAllByRole("button");
+			const defaultConfig = configButtons.find(
+				(b) => b.textContent?.includes("Default") && b.textContent?.includes("sonnet"),
+			)!;
+			await user.click(defaultConfig);
+
+			const modelInput = screen.getByDisplayValue("sonnet");
+			expect(modelInput).toHaveAttribute("autocapitalize", "off");
+			expect(modelInput).toHaveAttribute("autocorrect", "off");
+			expect(modelInput.getAttribute("spellcheck")).toBe("false");
+		});
+
+		it("base command override input has autocapitalize off", async () => {
+			setupMocks();
+			const user = userEvent.setup();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			// Expand Claude agent
+			const agentHeaders = screen.getAllByRole("button");
+			const claudeHeader = agentHeaders.find((b) =>
+				b.textContent?.includes("Claude") && b.textContent?.includes("claude"),
+			)!;
+			await user.click(claudeHeader);
+
+			// Expand Default config
+			const configButtons = screen.getAllByRole("button");
+			const defaultConfig = configButtons.find(
+				(b) => b.textContent?.includes("Default") && b.textContent?.includes("sonnet"),
+			)!;
+			await user.click(defaultConfig);
+
+			// Find the base command override input (empty by default)
+			const overrideLabel = screen.getByText("Base Command Override");
+			const overrideInput = overrideLabel.closest("div")!.querySelector("input")!;
+			expect(overrideInput).toHaveAttribute("autocapitalize", "off");
+			expect(overrideInput).toHaveAttribute("autocorrect", "off");
+			expect(overrideInput.getAttribute("spellcheck")).toBe("false");
+		});
+	});
+
 	describe("config count display", () => {
 		it("shows correct config count per agent", async () => {
 			setupMocks();

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import ProjectSettings from "../ProjectSettings";
+import { I18nProvider } from "../../i18n";
+import type { Project } from "../../../shared/types";
+import type { AppAction, Route } from "../../state";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			updateProjectSettings: vi.fn(),
+			createLabel: vi.fn(),
+			updateLabel: vi.fn(),
+			deleteLabel: vi.fn(),
+		},
+	},
+}));
+
+const mockProject: Project = {
+	id: "proj-1",
+	name: "Test Project",
+	path: "/tmp/test",
+	defaultBaseBranch: "main",
+	setupScript: "bun install",
+	devScript: "bun dev",
+	cleanupScript: "rm -rf dist",
+	labels: [],
+	createdAt: new Date().toISOString(),
+};
+
+function renderProjectSettings(project: Project = mockProject) {
+	const dispatch = vi.fn() as unknown as React.Dispatch<AppAction>;
+	const navigate = vi.fn() as (route: Route) => void;
+	return render(
+		<I18nProvider>
+			<ProjectSettings
+				projectId={project.id}
+				projects={[project]}
+				dispatch={dispatch}
+				navigate={navigate}
+			/>
+		</I18nProvider>,
+	);
+}
+
+describe("ProjectSettings", () => {
+	describe("autocapitalize disabled on technical inputs", () => {
+		it("setup script textarea has autocapitalize off", () => {
+			renderProjectSettings();
+			const textarea = screen.getByDisplayValue("bun install");
+			expect(textarea).toHaveAttribute("autocapitalize", "off");
+			expect(textarea).toHaveAttribute("autocorrect", "off");
+			expect(textarea.getAttribute("spellcheck")).toBe("false");
+		});
+
+		it("dev script textarea has autocapitalize off", () => {
+			renderProjectSettings();
+			const textarea = screen.getByDisplayValue("bun dev");
+			expect(textarea).toHaveAttribute("autocapitalize", "off");
+			expect(textarea).toHaveAttribute("autocorrect", "off");
+			expect(textarea.getAttribute("spellcheck")).toBe("false");
+		});
+
+		it("cleanup script textarea has autocapitalize off", () => {
+			renderProjectSettings();
+			const textarea = screen.getByDisplayValue("rm -rf dist");
+			expect(textarea).toHaveAttribute("autocapitalize", "off");
+			expect(textarea).toHaveAttribute("autocorrect", "off");
+			expect(textarea.getAttribute("spellcheck")).toBe("false");
+		});
+
+		it("base branch input has autocapitalize off", () => {
+			renderProjectSettings();
+			const input = screen.getByDisplayValue("main");
+			expect(input).toHaveAttribute("autocapitalize", "off");
+			expect(input).toHaveAttribute("autocorrect", "off");
+			expect(input.getAttribute("spellcheck")).toBe("false");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI that fixed this one.

WKWebView (used by Electrobun) enables `autocapitalize` on text inputs by default, which corrupts case-sensitive CLI commands (e.g. `claude` becomes `Claude` or `CLAUDE`). This adds `autoCapitalize="off"`, `autoCorrect="off"`, and `spellCheck={false}` to all technical input fields in GlobalSettings and ProjectSettings.

Fixes #51

- **GlobalSettings**: base command, model, base command override, additional args, env vars
- **ProjectSettings**: setup/dev/cleanup script textareas, base branch input
- Added unit tests covering the new attributes