### PR TITLE
Fix: add missing build:cli step to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
         run: bun run test
 
       - name: Build check
-        run: bunx vite build
+        run: bunx vite build && bun run build:cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
           bun scripts/generate-build-info.ts
           bun scripts/generate-changelog.ts
           bunx vite build
+          bun run build:cli
           bunx electrobun build --env=stable || echo "::warning::electrobun build exited with $? (recovering artifacts)"
 
       - name: Debug build output

--- a/change-logs/2026/03/05/fix-cli-missing-in-prod-build.md
+++ b/change-logs/2026/03/05/fix-cli-missing-in-prod-build.md
@@ -1,0 +1,1 @@
+Fix dev3 CLI binary missing from production builds. The CI release workflow was missing the `bun run build:cli` step, so `dist/dev3` was never compiled and Electrobun silently skipped the missing file during bundling. Added the build step to both release.yml and build.yml workflows.


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI that tracked down this one.

The `dev3` CLI binary was missing from production builds because `release.yml` didn't include the `bun run build:cli` step. Without it, `dist/dev3` was never compiled, and Electrobun silently skipped the missing file during bundling. Users hit "no such file or directory" when the dev3 skill tried to run `~/.dev3.0/bin/dev3` on first launch.

- Added `bun run build:cli` to the release workflow (before `electrobun build`)
- Added the same step to the PR build check workflow for consistency