### PR TITLE
Fix zoom review leftovers from PR #54

### DIFF
--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -4,16 +4,16 @@ import GlobalSettings from "../GlobalSettings";
 import { I18nProvider } from "../../i18n";
 import type { CodingAgent, GlobalSettings as GlobalSettingsType } from "../../../shared/types";
 
-// Mock zoom API that main.tsx normally sets up
-(window as any).__dev3Zoom = {
-	applyZoom: vi.fn(),
+vi.mock("../../zoom", () => ({
 	getZoom: vi.fn(() => 1.0),
 	adjustZoom: vi.fn(),
+	applyZoom: vi.fn(),
 	ZOOM_STEP: 0.1,
 	DEFAULT_ZOOM: 1.0,
 	MIN_ZOOM: 0.5,
 	MAX_ZOOM: 2.0,
-};
+	ZOOM_CHANGED_EVENT: "zoom-changed",
+}));
 
 vi.mock("../../rpc", () => ({
 	api: {

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -1,6 +1,6 @@
 import { Electroview } from "electrobun/view";
 import type { AppRPCSchema } from "../shared/types";
-import { adjustZoom, applyZoom, ZOOM_STEP } from "./zoom";
+import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 
 const rpc = Electroview.defineRPC<AppRPCSchema>({
 	maxRequestTime: 120_000, // 2 min — covers native dialogs and git operations
@@ -59,7 +59,7 @@ const rpc = Electroview.defineRPC<AppRPCSchema>({
 				adjustZoom(-ZOOM_STEP);
 			},
 			zoomReset: () => {
-				applyZoom(1.0);
+				applyZoom(DEFAULT_ZOOM);
 			},
 		} as any,
 	},


### PR DESCRIPTION
## Summary

Follow-up to #54 (Zoom Support) — fixes two minor leftovers flagged in review:

- **Hardcoded `1.0` in `rpc.ts`** — `zoomReset` handler used `applyZoom(1.0)` instead of `applyZoom(DEFAULT_ZOOM)`. Now uses the constant for consistency.
- **Stale `window.__dev3Zoom` mock in `GlobalSettings.test.tsx`** — The test still set up a `window.__dev3Zoom` global that was removed in PR #54. Replaced with a proper `vi.mock("../../zoom")`.

## Test plan

- [x] `bun run lint` — no TypeScript errors
- [x] `bun run test` — all 518 + 356 tests pass