### PR TITLE
Start folder picker from home dir and remember last folder

### DIFF
--- a/change-logs/2026/03/05/feature-pick-folder-start-dir.md
+++ b/change-logs/2026/03/05/feature-pick-folder-start-dir.md
@@ -1,0 +1,1 @@
+The folder picker dialog now starts from the user's home directory by default and remembers the parent of the last picked folder for subsequent uses. The preference is persisted in `preferences.json` so it survives app restarts.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -22,6 +22,8 @@ vi.mock("../data", () => ({
 	deleteTask: vi.fn(),
 	removeProject: vi.fn(),
 	updateProject: vi.fn(),
+	getLastPickedFolder: vi.fn(),
+	setLastPickedFolder: vi.fn(),
 }));
 
 vi.mock("../git", () => ({
@@ -1431,22 +1433,46 @@ describe("handlers.showConfirm", () => {
 describe("handlers.pickFolder", () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it("returns the selected path", async () => {
+	it("returns the selected path and saves parent folder", async () => {
+		vi.mocked(data.getLastPickedFolder).mockResolvedValue(undefined);
 		vi.mocked(Utils.openFileDialog).mockResolvedValue(["/Users/test/project"] as any);
 		const result = await handlers.pickFolder();
 		expect(result).toBe("/Users/test/project");
+		expect(data.setLastPickedFolder).toHaveBeenCalledWith("/Users/test");
+	});
+
+	it("uses last picked folder as starting directory", async () => {
+		vi.mocked(data.getLastPickedFolder).mockResolvedValue("/Users/saved/dir");
+		vi.mocked(Utils.openFileDialog).mockResolvedValue(["/Users/saved/dir/app"] as any);
+		await handlers.pickFolder();
+		expect(Utils.openFileDialog).toHaveBeenCalledWith(
+			expect.objectContaining({ startingFolder: "/Users/saved/dir" }),
+		);
+	});
+
+	it("defaults to home directory when no last folder saved", async () => {
+		vi.mocked(data.getLastPickedFolder).mockResolvedValue(undefined);
+		vi.mocked(Utils.openFileDialog).mockResolvedValue(["/some/path"] as any);
+		await handlers.pickFolder();
+		const call = vi.mocked(Utils.openFileDialog).mock.calls[0][0] as any;
+		expect(call.startingFolder).toBeTruthy();
+		expect(typeof call.startingFolder).toBe("string");
 	});
 
 	it("returns null when dialog is cancelled (empty array)", async () => {
+		vi.mocked(data.getLastPickedFolder).mockResolvedValue(undefined);
 		vi.mocked(Utils.openFileDialog).mockResolvedValue([] as any);
 		const result = await handlers.pickFolder();
 		expect(result).toBeNull();
+		expect(data.setLastPickedFolder).not.toHaveBeenCalled();
 	});
 
 	it("returns null when dialog returns null", async () => {
+		vi.mocked(data.getLastPickedFolder).mockResolvedValue(undefined);
 		vi.mocked(Utils.openFileDialog).mockResolvedValue(null as any);
 		const result = await handlers.pickFolder();
 		expect(result).toBeNull();
+		expect(data.setLastPickedFolder).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -272,3 +272,37 @@ export async function getTask(
 	if (!task) throw new Error(`Task not found: ${taskId}`);
 	return task;
 }
+
+// ---- Preferences ----
+
+const PREFERENCES_FILE = `${DEV3_HOME}/preferences.json`;
+
+interface Preferences {
+	lastPickedFolder?: string;
+}
+
+async function loadPreferences(): Promise<Preferences> {
+	try {
+		const file = Bun.file(PREFERENCES_FILE);
+		if (!(await file.exists())) return {};
+		return await file.json();
+	} catch {
+		return {};
+	}
+}
+
+async function savePreferences(prefs: Preferences): Promise<void> {
+	await ensureDir(PREFERENCES_FILE);
+	await Bun.write(PREFERENCES_FILE, JSON.stringify(prefs, null, 2));
+}
+
+export async function getLastPickedFolder(): Promise<string | undefined> {
+	const prefs = await loadPreferences();
+	return prefs.lastPickedFolder;
+}
+
+export async function setLastPickedFolder(folder: string): Promise<void> {
+	const prefs = await loadPreferences();
+	prefs.lastPickedFolder = folder;
+	await savePreferences(prefs);
+}

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
 import { PATHS, Utils } from "electrobun/bun";
 import type { ChangelogEntry, CodingAgent, GlobalSettings, Label, NoteSource, Project, RequirementCheckResult, Task, TaskNote, TaskStatus, TmuxSessionInfo } from "../shared/types";
 import { ACTIVE_STATUSES, LABEL_COLORS, titleFromDescription, extractRepoName } from "../shared/types";
@@ -430,14 +432,22 @@ export const handlers = {
 	async pickFolder(): Promise<string | null> {
 		log.info("→ pickFolder (opening native dialog)");
 		try {
+			const lastFolder = await data.getLastPickedFolder();
+			const startingFolder = lastFolder ?? homedir();
+			log.info("pickFolder starting from", { startingFolder });
+
 			const paths = await Utils.openFileDialog({
+				startingFolder,
 				canChooseFiles: false,
 				canChooseDirectory: true,
 				allowsMultipleSelection: false,
 			});
 			log.info("← pickFolder", { paths });
 			if (!paths || paths.length === 0) return null;
-			return paths[0];
+
+			const picked = paths[0];
+			await data.setLastPickedFolder(dirname(picked));
+			return picked;
 		} catch (err) {
 			log.error("pickFolder failed", { error: String(err) });
 			throw err;


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI agent on this task.

- Folder picker dialog now starts from `$HOME` by default instead of OS-chosen directory
- After picking a folder, the **parent directory** is saved to `preferences.json` and used as starting point next time
- Preference persists across app restarts via `~/.dev3.0/preferences.json`