### PR TITLE
Add vertical drag-and-drop reordering within Kanban columns

### DIFF
--- a/change-logs/2026/03/05/feature-vertical-dnd-reorder.md
+++ b/change-logs/2026/03/05/feature-vertical-dnd-reorder.md
@@ -1,0 +1,1 @@
+Add vertical drag-and-drop reordering within Kanban columns. Tasks can now be dragged up and down within the same status column, and the new order persists across page reloads via a new `columnOrder` field on the Task type. A visual drop indicator (accent-colored line) shows the insertion point during drag. Variant groups move as a unit when reordered.

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -306,3 +306,67 @@ export async function setLastPickedFolder(folder: string): Promise<void> {
 	prefs.lastPickedFolder = folder;
 	await savePreferences(prefs);
 }
+
+/**
+ * Reorder a task (or its variant group) within its current status column.
+ * Assigns sequential columnOrder (0, 1, 2, ...) to all tasks in the column.
+ * Returns the updated column tasks.
+ */
+export async function reorderTasksInColumn(
+	project: Project,
+	taskId: string,
+	targetIndex: number,
+): Promise<Task[]> {
+	log.info("Reordering task in column", { taskId, targetIndex, projectId: project.id });
+	const tasks = await loadTasks(project);
+	const task = tasks.find((t) => t.id === taskId);
+	if (!task) throw new Error(`Task not found: ${taskId}`);
+
+	const columnStatus = task.status;
+
+	// Get all tasks in this column, sorted by existing columnOrder (or createdAt fallback)
+	const columnTasks = tasks
+		.filter((t) => t.status === columnStatus)
+		.sort((a, b) => {
+			if (a.columnOrder !== undefined && b.columnOrder !== undefined) {
+				return a.columnOrder - b.columnOrder;
+			}
+			if (a.columnOrder !== undefined) return -1;
+			if (b.columnOrder !== undefined) return 1;
+			return a.createdAt < b.createdAt ? -1 : 1;
+		});
+
+	// Determine which task IDs to move (variant group moves as a unit)
+	const movingIds = new Set<string>();
+	if (task.groupId) {
+		for (const t of columnTasks) {
+			if (t.groupId === task.groupId) movingIds.add(t.id);
+		}
+	} else {
+		movingIds.add(taskId);
+	}
+
+	// Split into moving items and remaining items
+	const movingItems = columnTasks.filter((t) => movingIds.has(t.id));
+	const remaining = columnTasks.filter((t) => !movingIds.has(t.id));
+
+	// Clamp targetIndex
+	const clampedIndex = Math.max(0, Math.min(targetIndex, remaining.length));
+
+	// Insert at target position
+	remaining.splice(clampedIndex, 0, ...movingItems);
+
+	// Assign sequential columnOrder
+	const now = new Date().toISOString();
+	const updatedColumnTasks: Task[] = [];
+	for (let i = 0; i < remaining.length; i++) {
+		const t = remaining[i];
+		t.columnOrder = i;
+		t.updatedAt = now;
+		updatedColumnTasks.push(t);
+	}
+
+	await saveTasks(project, tasks);
+	log.info("Task reordered", { taskId, targetIndex: clampedIndex, columnTaskCount: updatedColumnTasks.length });
+	return updatedColumnTasks;
+}

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -711,6 +711,17 @@ export const handlers = {
 		return updated;
 	},
 
+	async reorderTask(params: { taskId: string; projectId: string; targetIndex: number }): Promise<Task[]> {
+		log.info("→ reorderTask", params);
+		const project = await data.getProject(params.projectId);
+		const updatedColumnTasks = await data.reorderTasksInColumn(project, params.taskId, params.targetIndex);
+		for (const task of updatedColumnTasks) {
+			pushMessage?.("taskUpdated", { projectId: project.id, task });
+		}
+		log.info("← reorderTask done", { count: updatedColumnTasks.length });
+		return updatedColumnTasks;
+	},
+
 	async deleteTask(params: { taskId: string; projectId: string }): Promise<void> {
 		log.info("→ deleteTask", params);
 		const project = await data.getProject(params.projectId);

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -53,14 +53,20 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 	useEffect(() => {
 		function handleDragEnd() {
 			setDragFromStatus(null);
+			setDraggedTaskId(null);
 		}
 		window.addEventListener("dragend", handleDragEnd);
 		return () => window.removeEventListener("dragend", handleDragEnd);
 	}, []);
 
+	const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
+
 	function handleDragStart(taskId: string) {
 		const task = tasks.find((t) => t.id === taskId);
-		if (task) setDragFromStatus(task.status);
+		if (task) {
+			setDragFromStatus(task.status);
+			setDraggedTaskId(taskId);
+		}
 	}
 
 	async function handleTaskDrop(taskId: string, targetStatus: TaskStatus) {
@@ -96,6 +102,27 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 			trackEvent("task_moved", { from_status: fromStatus, to_status: targetStatus });
 		} catch (err) {
 			alert(t("task.failedMove", { error: String(err) }));
+		}
+	}
+
+	async function handleReorderTask(taskId: string, targetIndex: number) {
+		try {
+			const updatedTasks = await api.request.reorderTask({
+				taskId,
+				projectId: project.id,
+				targetIndex,
+			});
+			for (const task of updatedTasks) {
+				dispatch({ type: "updateTask", task });
+			}
+			// Clear in-session move order so persisted columnOrder takes effect
+			setMoveOrderMap((prev) => {
+				const next = new Map(prev);
+				next.delete(taskId);
+				return next;
+			});
+		} catch (err) {
+			console.error("Failed to reorder task:", err);
 		}
 	}
 
@@ -156,11 +183,13 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 							setLaunchModal({ task, targetStatus })
 						}
 						onTaskDrop={handleTaskDrop}
+						onReorderTask={handleReorderTask}
 						dragFromStatus={dragFromStatus}
 						onDragStart={handleDragStart}
-					onTaskMoved={recordMove}
+						onTaskMoved={recordMove}
 						bellCounts={bellCounts}
-					activeTaskId={activeTaskId}
+						activeTaskId={activeTaskId}
+						draggedTaskId={draggedTaskId}
 					/>
 				))}
 			</div>

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch } from "react";
+import { useState, useRef, useEffect, type Dispatch } from "react";
 import type { CodingAgent, Project, Task, TaskStatus } from "../../shared/types";
 import { STATUS_COLORS, hexToRgb, getAllowedTransitions } from "../../shared/types";
 import type { AppAction, Route } from "../state";
@@ -16,11 +16,13 @@ interface KanbanColumnProps {
 	agents: CodingAgent[];
 	onLaunchVariants: (task: Task, targetStatus: TaskStatus) => void;
 	onTaskDrop: (taskId: string, targetStatus: TaskStatus) => void;
+	onReorderTask: (taskId: string, targetIndex: number) => void;
 	dragFromStatus: TaskStatus | null;
 	onDragStart: (taskId: string) => void;
 	onTaskMoved: (taskId: string) => void;
 	bellCounts: Map<string, number>;
 	activeTaskId?: string;
+	draggedTaskId: string | null;
 }
 
 function KanbanColumn({
@@ -34,58 +36,103 @@ function KanbanColumn({
 	agents,
 	onLaunchVariants,
 	onTaskDrop,
+	onReorderTask,
 	dragFromStatus,
 	onDragStart,
 	onTaskMoved,
 	bellCounts,
 	activeTaskId,
+	draggedTaskId,
 }: KanbanColumnProps) {
 	const t = useT();
 	const color = STATUS_COLORS[status];
 	const [dragOver, setDragOver] = useState(false);
+	const [dropIndex, setDropIndex] = useState<number | null>(null);
+	const taskListRef = useRef<HTMLDivElement>(null);
 
-	// Can this column accept a drop from the dragged task's current status?
-	const isValidTarget =
+	// Is this a same-column reorder drag?
+	const isSameColumnDrag = dragFromStatus === status;
+
+	// Can this column accept a cross-column drop?
+	const isCrossColumnTarget =
 		dragFromStatus !== null &&
 		dragFromStatus !== status &&
 		getAllowedTransitions(dragFromStatus).includes(status);
 
+	// Clear dropIndex when drag ends globally
+	useEffect(() => {
+		function handleDragEnd() {
+			setDropIndex(null);
+		}
+		window.addEventListener("dragend", handleDragEnd);
+		return () => window.removeEventListener("dragend", handleDragEnd);
+	}, []);
+
 	function handleDragOver(e: React.DragEvent) {
-		if (!isValidTarget) return;
+		if (!isCrossColumnTarget && !isSameColumnDrag) return;
 		e.preventDefault();
 		e.dataTransfer.dropEffect = "move";
+
+		// Calculate drop index for same-column reorder
+		if (isSameColumnDrag && taskListRef.current) {
+			const taskElements = taskListRef.current.querySelectorAll("[data-task-id]");
+			let newDropIndex = tasks.length;
+			for (let i = 0; i < taskElements.length; i++) {
+				const rect = taskElements[i].getBoundingClientRect();
+				const midY = rect.top + rect.height / 2;
+				if (e.clientY < midY) {
+					newDropIndex = i;
+					break;
+				}
+			}
+			setDropIndex(newDropIndex);
+		}
 	}
 
 	function handleDragEnter(e: React.DragEvent) {
-		if (!isValidTarget) return;
+		if (!isCrossColumnTarget && !isSameColumnDrag) return;
 		e.preventDefault();
-		setDragOver(true);
+		if (isCrossColumnTarget) setDragOver(true);
 	}
 
 	function handleDragLeave(e: React.DragEvent) {
-		// Only react when leaving the column itself, not its children
 		if (e.currentTarget.contains(e.relatedTarget as Node)) return;
 		setDragOver(false);
+		setDropIndex(null);
 	}
 
 	function handleDrop(e: React.DragEvent) {
 		e.preventDefault();
 		setDragOver(false);
-		if (!isValidTarget) return;
 		const taskId = e.dataTransfer.getData("text/plain");
-		if (taskId) {
+		if (!taskId) {
+			setDropIndex(null);
+			return;
+		}
+
+		if (isSameColumnDrag && dropIndex !== null) {
+			// Same-column reorder — adjust index if dragging down
+			const currentIndex = tasks.findIndex((t) => t.id === taskId);
+			const adjustedIndex = currentIndex !== -1 && currentIndex < dropIndex
+				? dropIndex - 1
+				: dropIndex;
+			if (currentIndex !== adjustedIndex) {
+				onReorderTask(taskId, adjustedIndex);
+			}
+		} else if (isCrossColumnTarget) {
 			onTaskDrop(taskId, status);
 		}
+		setDropIndex(null);
 	}
 
-	const showDropHighlight = dragOver && isValidTarget;
+	const showDropHighlight = dragOver && isCrossColumnTarget;
 
 	return (
 		<div
 			className={`flex flex-col flex-shrink-0 w-[17.5rem] glass-column column-glow rounded-2xl border transition-colors ${
 				showDropHighlight
 					? "border-accent bg-accent/5 shadow-lg shadow-accent/10"
-					: isValidTarget && dragFromStatus
+					: isCrossColumnTarget && dragFromStatus
 						? "border-edge-active"
 						: "border-transparent"
 			}`}
@@ -125,22 +172,29 @@ function KanbanColumn({
 			</div>
 
 			{/* Tasks */}
-			<div className="flex-1 overflow-y-auto px-3 py-3 space-y-2">
-				{tasks.map((task) => (
-					<TaskCard
-						key={task.id}
-						task={task}
-						project={project}
-						dispatch={dispatch}
-						navigate={navigate}
-						agents={agents}
-						onLaunchVariants={onLaunchVariants}
-						onDragStart={onDragStart}
-					onTaskMoved={onTaskMoved}
-						bellCount={bellCounts.get(task.id) ?? 0}
-						isActiveInSplit={task.id === activeTaskId}
-					/>
+			<div ref={taskListRef} className="flex-1 overflow-y-auto px-3 py-3 space-y-2">
+				{tasks.map((task, index) => (
+					<div key={task.id} data-task-id={task.id}>
+						{isSameColumnDrag && dropIndex === index && task.id !== draggedTaskId && (
+							<div className="h-0.5 bg-accent rounded-full mx-1 mb-2 transition-all" />
+						)}
+						<TaskCard
+							task={task}
+							project={project}
+							dispatch={dispatch}
+							navigate={navigate}
+							agents={agents}
+							onLaunchVariants={onLaunchVariants}
+							onDragStart={onDragStart}
+							onTaskMoved={onTaskMoved}
+							bellCount={bellCounts.get(task.id) ?? 0}
+							isActiveInSplit={task.id === activeTaskId}
+						/>
+					</div>
 				))}
+				{isSameColumnDrag && dropIndex === tasks.length && (
+					<div className="h-0.5 bg-accent rounded-full mx-1 mt-0 transition-all" />
+				)}
 
 				{tasks.length === 0 && (
 					<div className="text-fg-muted text-sm text-center py-8">

--- a/src/mainview/components/__tests__/sortTasksForColumn.test.ts
+++ b/src/mainview/components/__tests__/sortTasksForColumn.test.ts
@@ -342,3 +342,71 @@ describe("sortTasksForColumn — user scenario: insert at bottom", () => {
 		expect(ids(result)).toEqual(["V1", "V2", "V3", "V4"]);
 	});
 });
+
+// ============================================================
+// columnOrder — persisted within-column reordering
+// ============================================================
+
+describe("sortTasksForColumn — columnOrder (persisted reorder)", () => {
+	it("columnOrder sorts tasks in ascending order", () => {
+		const tasks = [
+			makeTask({ id: "A", columnOrder: 2, createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "B", columnOrder: 0, createdAt: "2025-01-02T00:00:00Z" }),
+			makeTask({ id: "C", columnOrder: 1, createdAt: "2025-01-03T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap);
+		expect(ids(result)).toEqual(["B", "C", "A"]);
+	});
+
+	it("columnOrder takes priority over movedAt and createdAt", () => {
+		const tasks = [
+			makeTask({ id: "A", columnOrder: 1, movedAt: "2026-01-01T00:00:00Z", createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "B", columnOrder: 0, movedAt: "2025-01-01T00:00:00Z", createdAt: "2025-06-01T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap);
+		// B has lower columnOrder → goes first despite older movedAt
+		expect(ids(result)).toEqual(["B", "A"]);
+	});
+
+	it("tasks with columnOrder come before tasks without", () => {
+		const tasks = [
+			makeTask({ id: "A", createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "B", columnOrder: 0, createdAt: "2025-06-01T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap);
+		expect(ids(result)).toEqual(["B", "A"]);
+	});
+
+	it("moveOrderMap overrides columnOrder", () => {
+		const tasks = [
+			makeTask({ id: "A", columnOrder: 0, createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "B", columnOrder: 1, createdAt: "2025-01-02T00:00:00Z" }),
+		];
+		const moveOrder = new Map([["B", 1]]);
+		const result = sortTasksForColumn(tasks, "top", moveOrder);
+		// B has moveOrderMap entry → goes to top despite columnOrder=1
+		expect(ids(result)).toEqual(["B", "A"]);
+	});
+
+	it("mixed: some with columnOrder, some without — columnOrder group first", () => {
+		const tasks = [
+			makeTask({ id: "A", createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "B", columnOrder: 1, createdAt: "2025-01-02T00:00:00Z" }),
+			makeTask({ id: "C", columnOrder: 0, createdAt: "2025-01-03T00:00:00Z" }),
+			makeTask({ id: "D", createdAt: "2025-01-04T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap);
+		// C(0), B(1) first (by columnOrder), then A, D (by createdAt)
+		expect(ids(result)).toEqual(["C", "B", "A", "D"]);
+	});
+
+	it("columnOrder works the same in bottom mode", () => {
+		const tasks = [
+			makeTask({ id: "A", columnOrder: 2 }),
+			makeTask({ id: "B", columnOrder: 0 }),
+			makeTask({ id: "C", columnOrder: 1 }),
+		];
+		const result = sortTasksForColumn(tasks, "bottom", emptyMap);
+		expect(ids(result)).toEqual(["B", "C", "A"]);
+	});
+});

--- a/src/mainview/components/sortTasks.ts
+++ b/src/mainview/components/sortTasks.ts
@@ -6,7 +6,7 @@ export function sortTasksForColumn(
 	moveOrderMap: Map<string, number>,
 ): Task[] {
 	return [...tasks].sort((a, b) => {
-		// Move order takes top priority (both modes)
+		// Move order takes top priority (in-session cross-column moves)
 		const aOrder = moveOrderMap.get(a.id) ?? 0;
 		const bOrder = moveOrderMap.get(b.id) ?? 0;
 		if (aOrder !== bOrder) {
@@ -14,6 +14,15 @@ export function sortTasksForColumn(
 			// "bottom": lowest counter first (most recent at bottom)
 			return dropPosition === "top" ? bOrder - aOrder : aOrder - bOrder;
 		}
+		// Persisted column order (set by within-column reordering)
+		const aCol = a.columnOrder;
+		const bCol = b.columnOrder;
+		if (aCol !== undefined && bCol !== undefined) {
+			return aCol - bCol;
+		}
+		// Tasks with explicit columnOrder come before those without
+		if (aCol !== undefined) return -1;
+		if (bCol !== undefined) return 1;
 		// Group by groupId: tasks with same groupId stay together
 		const aGroup = a.groupId ?? "";
 		const bGroup = b.groupId ?? "";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -223,6 +223,7 @@ export interface Task {
 	createdAt: string;
 	updatedAt: string;
 	movedAt?: string;
+	columnOrder?: number;
 	tmuxSocket?: string | null;
 	labelIds?: string[];
 	notes?: TaskNote[];
@@ -367,6 +368,10 @@ export type AppRPCSchema = {
 			moveTask: {
 				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean };
 				response: Task;
+			};
+			reorderTask: {
+				params: { taskId: string; projectId: string; targetIndex: number };
+				response: Task[];
 			};
 			deleteTask: {
 				params: { taskId: string; projectId: string };


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this branch.

- Tasks can now be dragged up/down within the same Kanban column to reorder them
- New order persists across page reloads via a `columnOrder` field on the `Task` type
- Visual drop indicator (accent-colored line) shows the insertion point during drag
- Variant groups move as a unit when reordered
- New `reorderTask` RPC endpoint handles persistence with sequential renumbering