### PR TITLE
Make gh auth switch graceful for collaborators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,13 @@ Multiple AI agents may work on this project in parallel. Each agent MUST:
 
 ## GitHub CLI (`gh`)
 
-The repo is owned by the **`h0x91b`** personal account. The developer machine has two `gh` accounts configured (`h0x91b` and `h0x91b-wix`). Before running any `gh` commands that access this repo, **switch to the correct account**:
+The repo is owned by the **`h0x91b`** personal account. The developer machine has two `gh` accounts configured (`h0x91b` and `h0x91b-wix`). Before running any `gh` commands that access this repo, **switch to the correct account** if it is configured:
 
 ```bash
-unset GH_TOKEN && gh auth switch --user h0x91b
+unset GH_TOKEN && gh auth switch --user h0x91b 2>/dev/null || true
 ```
 
-Always prefix `gh` calls with `unset GH_TOKEN &&` to avoid token conflicts (see global CLAUDE.md).
+This is a no-op for collaborators who don't have the `h0x91b` account — `gh` will fall back to whatever account they have configured. Always prefix `gh` calls with `unset GH_TOKEN &&` to avoid token conflicts (see global CLAUDE.md).
 
 ## Git worktree
 

--- a/change-logs/2026/03/06/docs-gh-auth-switch-graceful.md
+++ b/change-logs/2026/03/06/docs-gh-auth-switch-graceful.md
@@ -1,0 +1,1 @@
+Make `gh auth switch --user h0x91b` graceful for collaborators by appending `2>/dev/null || true`. The command now silently no-ops when the `h0x91b` account is not configured, allowing collaborators to use their own `gh` account without errors.


### PR DESCRIPTION
## Summary

- Added `2>/dev/null || true` to the `gh auth switch --user h0x91b` command in `AGENTS.md`
- The command now silently no-ops when the `h0x91b` account is not configured, so collaborators can use their own `gh` account without errors

## Test plan

- [ ] Verify `gh` commands work normally on the owner's machine (account switch still happens)
- [ ] Verify no error is produced when running the command on a machine without the `h0x91b` account

🤖 Generated with [Claude Code](https://claude.com/claude-code)