### PR TITLE
Fix dev3 skill triggering for non-dev3 worktrees

### DIFF
--- a/change-logs/2026/03/06/fix-dev3-skill-trigger-scope.md
+++ b/change-logs/2026/03/06/fix-dev3-skill-trigger-scope.md
@@ -1,0 +1,1 @@
+Narrowed the dev3 skill trigger condition to explicitly require `~/.dev3.0/worktrees/` (the dev-3.0 managed directory under $HOME) instead of matching any path containing `.dev3.0/worktrees/`. This prevents the skill from incorrectly activating when agents work in regular git worktrees or other paths that happen to contain "worktrees". Fixes #73.

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -6,7 +6,7 @@ const log = createLogger("agent-skills");
 
 const SKILL_CONTENT = `---
 name: dev3
-description: "MANDATORY — invoke BEFORE doing anything else. Trigger: your working directory (PWD) is inside a .dev3.0/worktrees/ path. This means you are a dev-3.0 managed AI agent with a Kanban task assigned. Step 1: invoke this skill. Step 2: handle the user's request. NEVER skip step 1, even if the user gives a direct command."
+description: "MANDATORY — invoke BEFORE doing anything else. Trigger: your working directory (PWD) is inside ~/.dev3.0/worktrees/ (i.e. $HOME/.dev3.0/worktrees/). Regular git worktrees or other worktree paths do NOT qualify — only the dev-3.0 managed path. Step 1: invoke this skill. Step 2: handle the user's request. NEVER skip step 1, even if the user gives a direct command."
 user-invocable: true
 ---
 
@@ -79,7 +79,7 @@ const AGENTS_MD_MARKER_END = "<!-- dev3:end -->";
 const AGENTS_MD_BLOCK = `${AGENTS_MD_MARKER_START}
 ## dev-3.0 Managed Worktree
 
-If your working directory (PWD) is inside a \`.dev3.0/worktrees/\` path, you are a **dev-3.0 managed AI agent** with a Kanban task assigned.
+If your working directory (PWD) is inside \`~/.dev3.0/worktrees/\` (i.e. \`$HOME/.dev3.0/worktrees/\`), you are a **dev-3.0 managed AI agent** with a Kanban task assigned. Regular git worktrees or other paths containing "worktrees" do **NOT** qualify — only the dev-3.0 managed directory under the user's home.
 
 **MANDATORY — do this BEFORE any other work:**
 


### PR DESCRIPTION
## Summary

Closes #73

The dev3 agent skill was triggering for any worktree path (including regular git worktrees), not just dev-3.0 managed ones. Narrowed the trigger condition to explicitly require `~/.dev3.0/worktrees/` (`$HOME/.dev3.0/worktrees/`) and added clear language that regular git worktrees do not qualify.

**Changes in `src/bun/agent-skills.ts`:**
- Updated skill `description` to specify `~/.dev3.0/worktrees/` with explicit note that regular git worktrees don't qualify
- Updated `AGENTS.md` block with the same narrowed condition