### PR TITLE
Add config preview card to Default Configuration selector

### DIFF
--- a/change-logs/2026/03/06/feature-config-preview-card.md
+++ b/change-logs/2026/03/06/feature-config-preview-card.md
@@ -1,0 +1,1 @@
+Added a configuration preview card below the Default Configuration dropdown in Global Settings. When a user selects a configuration, the card shows key properties (model, permission mode, effort level, max budget) as tag pills plus a full command preview. This addresses issue #62 by making it clear what each configuration actually does at runtime.

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -370,6 +370,19 @@ function GlobalSettings() {
 										</option>
 									))}
 								</select>
+								{(() => {
+									const selectedConfig = defaultAgentConfigs.find(
+										(c) => c.id === globalSettings.defaultConfigId,
+									) ?? defaultAgentConfigs[0];
+									if (!selectedConfig) return null;
+									return (
+										<ConfigPreviewCard
+											config={selectedConfig}
+											agentBaseCommand={selectedDefaultAgent?.baseCommand ?? ""}
+											t={t}
+										/>
+									);
+								})()}
 							</div>
 						)}
 					</div>
@@ -541,6 +554,74 @@ function GlobalSettings() {
 					</div>
 				</div>
 			</div>
+		</div>
+	);
+}
+
+// ---- Config Preview Card (shown below Default Configuration dropdown) ----
+
+function ConfigPreviewCard({
+	config,
+	agentBaseCommand,
+	t,
+}: {
+	config: AgentConfiguration;
+	agentBaseCommand: string;
+	t: ReturnType<typeof useT>;
+}) {
+	const tags: { label: string; value: string }[] = [];
+
+	if (config.model) {
+		tags.push({ label: t("settings.configModel"), value: config.model });
+	}
+	if (config.permissionMode && config.permissionMode !== "default") {
+		const modeLabels: Record<string, string> = {
+			plan: t("settings.permPlan"),
+			acceptEdits: t("settings.permAcceptEdits"),
+			dontAsk: t("settings.permDontAsk"),
+			bypassPermissions: t("settings.permBypass"),
+		};
+		tags.push({
+			label: t("settings.configPermissionMode"),
+			value: modeLabels[config.permissionMode] ?? config.permissionMode,
+		});
+	}
+	if (config.effort) {
+		const effortLabels: Record<string, string> = {
+			low: t("settings.effortLow"),
+			medium: t("settings.effortMedium"),
+			high: t("settings.effortHigh"),
+		};
+		tags.push({
+			label: t("settings.configEffort"),
+			value: effortLabels[config.effort] ?? config.effort,
+		});
+	}
+	if (config.maxBudgetUsd != null && config.maxBudgetUsd > 0) {
+		tags.push({
+			label: t("settings.configMaxBudget"),
+			value: `$${config.maxBudgetUsd}`,
+		});
+	}
+
+	const { command, envLine } = buildCommandPreview(agentBaseCommand, config);
+
+	return (
+		<div className="mt-3 bg-base border border-edge rounded-xl p-3 space-y-2">
+			{tags.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{tags.map((tag) => (
+						<span
+							key={tag.label}
+							className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-raised rounded-lg text-xs"
+						>
+							<span className="text-fg-3">{tag.label}:</span>
+							<span className="text-fg font-medium">{tag.value}</span>
+						</span>
+					))}
+				</div>
+			)}
+			<CommandPreview command={command} envLine={envLine} />
 		</div>
 	);
 }

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -252,6 +252,29 @@ describe("GlobalSettings", () => {
 			expect(screen.getByText("Default Configuration")).toBeInTheDocument();
 		});
 
+		it("shows config preview card with model info", async () => {
+			setupMocks();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			// Default config is "Default" with model "sonnet"
+			expect(screen.getByText("Model:")).toBeInTheDocument();
+			expect(screen.getByText("sonnet")).toBeInTheDocument();
+		});
+
+		it("shows permission mode in preview when selecting non-default config", async () => {
+			setupMocks(mockAgents, {
+				...mockGlobalSettings,
+				defaultConfigId: "cfg-2",
+			});
+			renderGlobalSettings();
+			await waitForLoad();
+
+			expect(screen.getByText("opus")).toBeInTheDocument();
+			expect(screen.getByText("Permission Mode:")).toBeInTheDocument();
+			expect(screen.getByText("Plan Mode")).toBeInTheDocument();
+		});
+
 		it("changes default config and saves", async () => {
 			setupMocks();
 			const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Hey there, Claude here — the AI that worked on this branch.

- **Config preview card** below the Default Configuration dropdown in Global Settings: shows model, permission mode, effort level, and max budget as tag pills, plus a full command preview. Makes it immediately clear what each configuration does at runtime. Closes #62.
- **Clipboard image paste** in terminal via Ctrl+V / Cmd+V — detects image data on clipboard and writes it as base64 OSC 52 sequence. Closes #83.