### PR TITLE
Auto-generate build-info.generated.ts during lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,6 @@ bun run build
 bun run build:prod
 ```
 
-**Build-info workaround:** In a fresh worktree, `bun run lint` may fail with `Cannot find module '../shared/build-info.generated'`. This file is generated during the build step. Run `bun run build` once to create it, then `bun run lint` will pass.
-
 No linter is configured.
 
 ## Architecture

--- a/change-logs/2026/03/06/fix-lint-build-info.md
+++ b/change-logs/2026/03/06/fix-lint-build-info.md
@@ -1,0 +1,1 @@
+The lint script now auto-generates `build-info.generated.ts` if it's missing, so `bun run lint` works in fresh worktrees without running a full build first. Removed the build-info workaround note from AGENTS.md.

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -7,6 +7,20 @@
  * their errors. We own only `src/` — errors there must be zero.
  */
 
+// Ensure build-info.generated.ts exists (it's created during build,
+// but in a fresh worktree it won't be there yet).
+const buildInfoPath = `${import.meta.dir}/../src/shared/build-info.generated.ts`;
+if (!(await Bun.file(buildInfoPath).exists())) {
+	const gen = Bun.spawnSync(
+		["bun", `${import.meta.dir}/generate-build-info.ts`],
+		{ stdout: "inherit", stderr: "inherit", env: process.env },
+	);
+	if (gen.exitCode !== 0) {
+		console.error("Failed to generate build-info.generated.ts");
+		process.exit(1);
+	}
+}
+
 const result = Bun.spawnSync(["bun", "x", "tsc", "--noEmit"], {
 	stdout: "pipe",
 	stderr: "pipe",


### PR DESCRIPTION
The lint script now checks if build-info.generated.ts exists and
generates it on the fly if missing. This eliminates the need to run
a full build before linting in fresh worktrees. Removed the manual
workaround note from AGENTS.md.
