### PR TITLE
Reduce drag-to-completed latency and disable card during move (#78)

### DIFF
--- a/change-logs/2026/03/06/fix-drag-to-completed-latency.md
+++ b/change-logs/2026/03/06/fix-drag-to-completed-latency.md
@@ -1,0 +1,1 @@
+Reduced drag-to-completed latency by applying optimistic UI updates: the card now moves to the target column immediately upon drop, showing a spinner overlay and disabled state while the backend processes worktree cleanup. On failure, the card reverts to its original position.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -37,6 +37,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 	const [moveOrderMap, setMoveOrderMap] = useState<Map<string, number>>(new Map());
 	const [activeFilters, setActiveFilters] = useState<string[]>([]);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [movingTaskIds, setMovingTaskIds] = useState<Set<string>>(new Set());
 	const moveCounterRef = useRef(0);
 
 	function recordMove(taskId: string) {
@@ -90,7 +91,13 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 		}
 
 		const fromStatus = task.status;
-		// Direct move for all other transitions
+
+		// Optimistic update: move card to target column immediately and mark as moving
+		const optimisticTask = { ...task, status: targetStatus };
+		dispatch({ type: "updateTask", task: optimisticTask });
+		recordMove(task.id);
+		setMovingTaskIds((prev) => new Set(prev).add(task.id));
+
 		try {
 			const updated = await api.request.moveTask({
 				taskId: task.id,
@@ -98,10 +105,17 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 				newStatus: targetStatus,
 			});
 			dispatch({ type: "updateTask", task: updated });
-			recordMove(task.id);
 			trackEvent("task_moved", { from_status: fromStatus, to_status: targetStatus });
 		} catch (err) {
+			// Revert optimistic update on failure
+			dispatch({ type: "updateTask", task });
 			alert(t("task.failedMove", { error: String(err) }));
+		} finally {
+			setMovingTaskIds((prev) => {
+				const next = new Set(prev);
+				next.delete(task.id);
+				return next;
+			});
 		}
 	}
 
@@ -190,6 +204,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 						bellCounts={bellCounts}
 						activeTaskId={activeTaskId}
 						draggedTaskId={draggedTaskId}
+						movingTaskIds={movingTaskIds}
 					/>
 				))}
 			</div>

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -23,6 +23,7 @@ interface KanbanColumnProps {
 	bellCounts: Map<string, number>;
 	activeTaskId?: string;
 	draggedTaskId: string | null;
+	movingTaskIds: Set<string>;
 }
 
 function KanbanColumn({
@@ -43,6 +44,7 @@ function KanbanColumn({
 	bellCounts,
 	activeTaskId,
 	draggedTaskId,
+	movingTaskIds,
 }: KanbanColumnProps) {
 	const t = useT();
 	const color = STATUS_COLORS[status];
@@ -189,6 +191,7 @@ function KanbanColumn({
 							onTaskMoved={onTaskMoved}
 							bellCount={bellCounts.get(task.id) ?? 0}
 							isActiveInSplit={task.id === activeTaskId}
+							isMoving={movingTaskIds.has(task.id)}
 						/>
 					</div>
 				))}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -23,9 +23,10 @@ interface TaskCardProps {
 	onTaskMoved: (taskId: string) => void;
 	bellCount?: number;
 	isActiveInSplit?: boolean;
+	isMoving?: boolean;
 }
 
-function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false }: TaskCardProps) {
+function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false, isMoving: isMovingProp = false }: TaskCardProps) {
 	const t = useT();
 	const [moving, setMoving] = useState(false);
 	const [menuOpen, setMenuOpen] = useState(false);
@@ -48,6 +49,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const previewIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const cardRef = useRef<HTMLDivElement>(null);
 
+	const isDisabled = moving || isMovingProp;
 	const isTodo = task.status === "todo";
 	const isCancelled = task.status === "cancelled";
 	const isActive = ACTIVE_STATUSES.includes(task.status);
@@ -352,7 +354,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	return (
 		<div
 			ref={cardRef}
-			draggable={!moving && !detailOpen}
+			draggable={!isDisabled && !detailOpen}
 			onDragStart={handleDragStart}
 			onMouseEnter={handleCardMouseEnter}
 			onMouseLeave={handleCardMouseLeave}
@@ -360,17 +362,24 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
-			} ${moving ? "opacity-50 pointer-events-none" : ""}`}
+			} ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
 			style={{ borderLeftColor: color }}
 			onClick={handleClick}
 		>
+			{/* Moving spinner overlay */}
+			{isMovingProp && (
+				<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-base/40">
+					<div className="w-4 h-4 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
+				</div>
+			)}
+
 			{/* Dismiss button — top-right, visible on hover */}
 			{showDismissButton && (
 				<button
 					onClick={handleDismiss}
 					className="absolute top-2.5 right-2.5 opacity-0 group-hover:opacity-100 w-5 h-5 flex items-center justify-center rounded-md bg-fg/5 text-fg-3 hover:bg-danger/15 hover:text-danger transition-all"
 					title={isCancelled ? t("task.delete") : t("task.cancel")}
-					disabled={moving}
+					disabled={isDisabled}
 				>
 					<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
 						<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -519,7 +528,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					ref={triggerRef}
 					onClick={toggleMenu}
 					className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-fg/5 transition-colors flex-shrink-0"
-					disabled={moving}
+					disabled={isDisabled}
 				>
 					<div
 						className="w-2 h-2 rounded-full flex-shrink-0"
@@ -540,7 +549,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 						}}
 						className="flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-500 text-white shadow-sm shadow-green-900/30 transition-colors"
 						title={t("task.run")}
-						disabled={moving}
+						disabled={isDisabled}
 					>
 						<svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
 							<path d="M8 5v14l11-7z" />


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI agent behind this PR.

- Drag-drop to `completed`/`cancelled` now applies an **optimistic UI update**: the card moves to the target column instantly instead of waiting 10-20s for worktree cleanup RPC
- The card shows a **spinner overlay** and is fully disabled (`opacity-50`, `pointer-events-none`) while the backend processes
- On RPC failure, the card **reverts** to its original column with an error alert

Closes #78