### PR TITLE
Add loading spinner overlay for drag-drop task moves (#71)

### DIFF
--- a/change-logs/2026/03/06/feature-drag-loading-indicator.md
+++ b/change-logs/2026/03/06/feature-drag-loading-indicator.md
@@ -1,0 +1,1 @@
+Added a loading spinner overlay on task cards when moving via drag-and-drop to Completed or other columns. Previously only context-menu moves showed visual feedback; now drag-drop transitions also display a spinner with a semi-transparent backdrop while the backend processes the move (PTY teardown, cleanup script, worktree removal).

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -34,6 +34,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 	});
 	const [launchModal, setLaunchModal] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
 	const [dragFromStatus, setDragFromStatus] = useState<TaskStatus | null>(null);
+	const [movingTaskIds, setMovingTaskIds] = useState<Set<string>>(new Set());
 	const [moveOrderMap, setMoveOrderMap] = useState<Map<string, number>>(new Map());
 	const [activeFilters, setActiveFilters] = useState<string[]>([]);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -91,6 +92,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 
 		const fromStatus = task.status;
 		// Direct move for all other transitions
+		setMovingTaskIds((prev) => new Set(prev).add(task.id));
 		try {
 			const updated = await api.request.moveTask({
 				taskId: task.id,
@@ -103,6 +105,11 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 		} catch (err) {
 			alert(t("task.failedMove", { error: String(err) }));
 		}
+		setMovingTaskIds((prev) => {
+			const next = new Set(prev);
+			next.delete(task.id);
+			return next;
+		});
 	}
 
 	async function handleReorderTask(taskId: string, targetIndex: number) {
@@ -190,6 +197,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 						bellCounts={bellCounts}
 						activeTaskId={activeTaskId}
 						draggedTaskId={draggedTaskId}
+						movingTaskIds={movingTaskIds}
 					/>
 				))}
 			</div>

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -23,6 +23,7 @@ interface KanbanColumnProps {
 	bellCounts: Map<string, number>;
 	activeTaskId?: string;
 	draggedTaskId: string | null;
+	movingTaskIds: Set<string>;
 }
 
 function KanbanColumn({
@@ -43,6 +44,7 @@ function KanbanColumn({
 	bellCounts,
 	activeTaskId,
 	draggedTaskId,
+	movingTaskIds,
 }: KanbanColumnProps) {
 	const t = useT();
 	const color = STATUS_COLORS[status];
@@ -189,7 +191,8 @@ function KanbanColumn({
 							onTaskMoved={onTaskMoved}
 							bellCount={bellCounts.get(task.id) ?? 0}
 							isActiveInSplit={task.id === activeTaskId}
-						/>
+						externalMoving={movingTaskIds.has(task.id)}
+					/>
 					</div>
 				))}
 				{isSameColumnDrag && dropIndex === tasks.length && (

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -23,11 +23,13 @@ interface TaskCardProps {
 	onTaskMoved: (taskId: string) => void;
 	bellCount?: number;
 	isActiveInSplit?: boolean;
+	externalMoving?: boolean;
 }
 
-function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false }: TaskCardProps) {
+function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false, externalMoving = false }: TaskCardProps) {
 	const t = useT();
-	const [moving, setMoving] = useState(false);
+	const [internalMoving, setMoving] = useState(false);
+	const moving = internalMoving || externalMoving;
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
 	const [menuVisible, setMenuVisible] = useState(false);
@@ -360,10 +362,17 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
-			} ${moving ? "opacity-50 pointer-events-none" : ""}`}
+			} ${moving ? "pointer-events-none" : ""}`}
 			style={{ borderLeftColor: color }}
 			onClick={handleClick}
 		>
+			{/* Loading overlay */}
+			{moving && (
+				<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-base/60 backdrop-blur-[1px]">
+					<div className="w-5 h-5 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
+				</div>
+			)}
+
 			{/* Dismiss button — top-right, visible on hover */}
 			{showDismissButton && (
 				<button


### PR DESCRIPTION
When a card is dragged to Completed (or any column), a spinner overlay
now appears on the card during the RPC call. Previously only context-menu
moves showed the opacity-50 feedback; drag-drop had no visual indicator
while the backend destroyed PTY/worktree. The spinner uses the same
accent color as the rest of the UI and a semi-transparent backdrop.
