### PR TITLE
Auto-rename opaque branches to meaningful names (#27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,14 @@ If you are in a worktree, your working directory will be different (e.g., a temp
 
 ### Branch naming
 
-Worktree branches are auto-generated with opaque names like `dev3/task-8711d3e1`. Once you understand what the user is actually working on, **ask them** if they'd like to rename the branch to something descriptive (e.g., `dev3/fix-login-race-condition`). Do not rename silently — always confirm first. Example prompt: "Хочешь, переименую ветку в `dev3/<suggested-name>`? Сейчас она называется `dev3/task-...`, не очень информативно." If the user agrees, run `git branch -m <old> <new>` (and update the remote if already pushed).
+Worktree branches are auto-generated with opaque names like `dev3/task-8711d3e1`. Once you understand what the task is about, **rename the branch automatically** to something descriptive using `git branch -m <old> dev3/<slug>`. Do not ask for permission — just do it on session start.
+
+**Rules:**
+- Always keep the `dev3/` prefix.
+- Use lowercase kebab-case: `dev3/fix-auth-race-condition`, `dev3/add-drag-reorder`, `dev3/refactor-rpc-handlers`.
+- Derive the slug from the task description/title — 3-5 words max.
+- If the branch already has a meaningful name (doesn't match `dev3/task-*`), skip renaming.
+- If the branch was already pushed to the remote, also update the remote: `git push origin :<old-branch> && git push -u origin <new-branch>`.
 
 ## Changelog policy
 

--- a/change-logs/2026/03/07/feature-auto-branch-naming.md
+++ b/change-logs/2026/03/07/feature-auto-branch-naming.md
@@ -1,0 +1,1 @@
+Updated agent prompts (AGENTS.md and dev3 skill) to auto-rename opaque `dev3/task-<hash>` branches to meaningful names derived from the task description. Agents no longer ask for permission — they rename automatically on session start.

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -25,6 +25,24 @@ Run these two commands **in parallel** (two Bash tool calls in one message) to s
 
 Then set \`in-progress\` and begin working.
 
+## Branch naming
+
+After running \`dev3 current\`, check if the branch matches \`dev3/task-*\` (opaque auto-generated name).
+If it does, **rename it immediately** to something meaningful based on the task description:
+
+\`\`\`bash
+git branch -m dev3/task-XXXXXXXX dev3/<slug>
+\`\`\`
+
+**Rules:**
+- Always keep the \`dev3/\` prefix.
+- Use lowercase kebab-case, 3-5 words: \`dev3/fix-auth-race-condition\`, \`dev3/add-drag-reorder\`.
+- Derive the slug from the task description/title — be concise but descriptive.
+- If the branch already has a meaningful name (does NOT match \`dev3/task-*\`), skip renaming.
+- If the branch was already pushed, also update the remote: \`git push origin :<old> && git push -u origin <new>\`.
+
+Run this ONCE at session start, right after setting \`in-progress\`.
+
 ## Title generation
 
 The task title is auto-generated from the first 80 characters of the description.


### PR DESCRIPTION
## Summary

Closes #27

Updated agent prompts (AGENTS.md and dev3 skill in `agent-skills.ts`) so AI agents automatically rename opaque `dev3/task-<hash>` branches to descriptive kebab-case names derived from the task description on session start. No user confirmation required — agents just do it.

**Changes:**
- **AGENTS.md** — rewrote "Branch naming" section: agents now auto-rename instead of asking
- **src/bun/agent-skills.ts** — added "Branch naming" section to the dev3 skill prompt with clear rules (keep `dev3/` prefix, kebab-case, 3-5 words, handle remote if pushed)