### PR TITLE
Prevent opening a card while it is being moved to completed/cancelled

### DIFF
--- a/change-logs/2026/03/07/fix-card-click-while-moving.md
+++ b/change-logs/2026/03/07/fix-card-click-while-moving.md
@@ -1,0 +1,1 @@
+Prevent opening a task card (navigation or detail modal) while it is being moved to completed/cancelled. Added an `isDisabled` guard at the top of `handleClick()` in TaskCard to block interactions during async status transitions.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -209,6 +209,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const isCompleted = task.status === "completed";
 
 	function handleClick() {
+		if (isDisabled) return;
 		if (isActive && !menuOpen) {
 			closePreview();
 			if (isActiveInSplit) {

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -127,6 +127,7 @@ function renderCard(
 		onTaskMoved?: (taskId: string) => void;
 		bellCount?: number;
 		isActiveInSplit?: boolean;
+		isMoving?: boolean;
 		projectOverride?: Project;
 	},
 ) {
@@ -143,6 +144,7 @@ function renderCard(
 				onTaskMoved={opts?.onTaskMoved ?? vi.fn()}
 				bellCount={opts?.bellCount}
 				isActiveInSplit={opts?.isActiveInSplit}
+				isMoving={opts?.isMoving}
 			/>
 		</I18nProvider>,
 	);
@@ -471,6 +473,31 @@ describe("TaskCard", () => {
 
 			expect(navigate).not.toHaveBeenCalled();
 			expect(screen.getByTestId("task-detail-modal")).toBeInTheDocument();
+		});
+
+		it("clicking active task while moving does not navigate", async () => {
+			const user = userEvent.setup();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" });
+			renderCard(task, { navigate, isMoving: true });
+
+			const card = screen.getByText("My task").closest("[draggable]")!;
+			await user.click(card);
+
+			expect(navigate).not.toHaveBeenCalled();
+		});
+
+		it("clicking completed task while moving does not open detail", async () => {
+			const user = userEvent.setup();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "completed" });
+			renderCard(task, { navigate, isMoving: true });
+
+			const card = screen.getByText("My task").closest("[draggable]")!;
+			await user.click(card);
+
+			expect(navigate).not.toHaveBeenCalled();
+			expect(screen.queryByTestId("task-detail-modal")).not.toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI agent working on this one.

- Added an `isDisabled` guard at the top of `handleClick()` in TaskCard to block navigation and detail modal opens during async status transitions
- Previously only CSS `pointer-events-none` protected against this, which could be bypassed due to React render timing races
- Added two tests confirming clicks are ignored while a card is moving

Closes #50