### PR TITLE
Rename changelog header label from 'Log' to 'Change Log'

### DIFF
--- a/change-logs/2026/03/07/chore-rename-log-to-change-log.md
+++ b/change-logs/2026/03/07/chore-rename-log-to-change-log.md
@@ -1,0 +1,1 @@
+Rename the changelog icon label from "Log" to "Change Log" across all three locales (en, es, ru) for clarity.

--- a/src/mainview/i18n/translations/en.ts
+++ b/src/mainview/i18n/translations/en.ts
@@ -305,7 +305,7 @@ const en = {
 
 	// Changelog
 	"header.changelog": "Changelog",
-	"header.changelogLabel": "Log",
+	"header.changelogLabel": "Change Log",
 	"header.changelogTooltip": "View changelog",
 	"header.githubTooltip": "Website",
 	"header.reportBugTooltip": "Report a bug",

--- a/src/mainview/i18n/translations/es.ts
+++ b/src/mainview/i18n/translations/es.ts
@@ -308,7 +308,7 @@ const es: TranslationRecord & Record<string, string> = {
 
 	// Changelog
 	"header.changelog": "Registro de cambios",
-	"header.changelogLabel": "Log",
+	"header.changelogLabel": "Change Log",
 	"header.changelogTooltip": "Ver registro de cambios",
 	"header.githubTooltip": "Sitio web",
 	"header.reportBugTooltip": "Reportar un error",

--- a/src/mainview/i18n/translations/ru.ts
+++ b/src/mainview/i18n/translations/ru.ts
@@ -313,7 +313,7 @@ const ru: TranslationRecord & Record<string, string> = {
 
 	// Changelog
 	"header.changelog": "Журнал изменений",
-	"header.changelogLabel": "Лог",
+	"header.changelogLabel": "Change Log",
 	"header.changelogTooltip": "Журнал изменений",
 	"header.githubTooltip": "Сайт проекта",
 	"header.reportBugTooltip": "Сообщить об ошибке",


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

Renames the changelog icon label in the global header from `"Log"` to `"Change Log"` across all three locales (en, es, ru). The previous label was too generic and didn't clearly describe what the button opens.