### PR TITLE
Replace disabled Create PR with Push & Create PR combo button

### DIFF
--- a/change-logs/2026/03/07/feature-push-and-create-pr.md
+++ b/change-logs/2026/03/07/feature-push-and-create-pr.md
@@ -1,0 +1,1 @@
+Replace disabled "Create PR" button with an active "Push & Create PR" button when the branch has unpushed commits. Clicking it pushes first, then automatically creates a PR on success — combining two steps into one click.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -283,6 +283,7 @@ function TaskInfoPanel({ task, project, dispatch, navigate }: TaskInfoPanelProps
 	const [pushing, setPushing] = useState(false);
 	const [creatingPR, setCreatingPR] = useState(false);
 	const [refreshingStatus, setRefreshingStatus] = useState(false);
+	const pushThenCreatePRRef = useRef(false);
 	const [compareRef, setCompareRef] = useState<string>(""); // "" = origin/<baseBranch> (default)
 	const [refMenuOpen, setRefMenuOpen] = useState(false);
 	const [refMenuPos, setRefMenuPos] = useState({ top: 0, left: 0 });
@@ -423,6 +424,13 @@ function TaskInfoPanel({ task, project, dispatch, navigate }: TaskInfoPanelProps
 				});
 				setBranchStatus(status);
 			} catch { /* silently ignore */ }
+
+			// Post-push: auto-create PR if triggered by "Push & Create PR"
+			if (detail.operation === "push" && detail.ok && pushThenCreatePRRef.current) {
+				pushThenCreatePRRef.current = false;
+				setPushing(false);
+				handleCreatePR();
+			}
 
 			// Post-merge: show "complete task?" dialog
 			if (detail.operation === "merge" && detail.ok) {
@@ -735,13 +743,14 @@ function TaskInfoPanel({ task, project, dispatch, navigate }: TaskInfoPanelProps
 			? t("infoPanel.pushDisabled")
 			: t("infoPanel.push");
 
-	const createPRDisabled = !branchStatus || branchStatus.ahead === 0 || branchStatus.unpushed !== 0 || creatingPR;
+	const needsPushBeforePR = branchStatus && branchStatus.ahead > 0 && branchStatus.unpushed !== 0;
+	const createPRDisabled = !branchStatus || branchStatus.ahead === 0 || creatingPR || pushing;
 	const createPRTooltip = !branchStatus
 		? t("infoPanel.statusLoading")
 		: branchStatus.ahead === 0
 			? t("infoPanel.createPRDisabledNoCommits")
-			: branchStatus.unpushed !== 0
-				? t("infoPanel.createPRDisabledNotPushed")
+			: needsPushBeforePR
+				? t("infoPanel.pushAndCreatePR")
 				: t("infoPanel.createPR");
 
 	const mergeDisabled = !branchStatus || branchStatus.ahead === 0 || branchStatus.behind > 0 || merging;
@@ -814,14 +823,21 @@ function TaskInfoPanel({ task, project, dispatch, navigate }: TaskInfoPanelProps
 				{pushing ? t("infoPanel.pushing") : t("infoPanel.push")}
 			</button>
 			<button
-				onClick={handleCreatePR}
+				onClick={() => {
+					if (needsPushBeforePR) {
+						pushThenCreatePRRef.current = true;
+						handlePush();
+					} else {
+						handleCreatePR();
+					}
+				}}
 				disabled={createPRDisabled}
 				className={`px-1.5 py-0.5 rounded text-[0.625rem] font-medium transition-colors ${
 					createPRDisabled ? disabledBtnClass : enabledBtnClass
 				}`}
 				title={createPRTooltip}
 			>
-				{creatingPR ? t("infoPanel.creatingPR") : t("infoPanel.createPR")}
+				{creatingPR ? t("infoPanel.creatingPR") : pushing && pushThenCreatePRRef.current ? t("infoPanel.pushingAndCreatingPR") : needsPushBeforePR ? t("infoPanel.pushAndCreatePR") : t("infoPanel.createPR")}
 			</button>
 			<button
 				onClick={handleMerge}

--- a/src/mainview/i18n/translations/en.ts
+++ b/src/mainview/i18n/translations/en.ts
@@ -253,6 +253,8 @@ const en = {
 	"infoPanel.createPRFailed": "Create PR failed: {error}",
 	"infoPanel.createPRDisabledNoCommits": "No commits to create PR for",
 	"infoPanel.createPRDisabledNotPushed": "Push first before creating a PR",
+	"infoPanel.pushAndCreatePR": "Push & Create PR",
+	"infoPanel.pushingAndCreatingPR": "Pushing...",
 	"infoPanel.showDiff": "Show Diff",
 	"infoPanel.showDiffFailed": "Show diff failed: {error}",
 	"infoPanel.showDiffTooltip": "Show diff vs {branch}",

--- a/src/mainview/i18n/translations/es.ts
+++ b/src/mainview/i18n/translations/es.ts
@@ -256,6 +256,8 @@ const es: TranslationRecord & Record<string, string> = {
 	"infoPanel.createPRFailed": "Error al crear PR: {error}",
 	"infoPanel.createPRDisabledNoCommits": "No hay commits para crear PR",
 	"infoPanel.createPRDisabledNotPushed": "Primero haga Push antes de crear PR",
+	"infoPanel.pushAndCreatePR": "Push & Create PR",
+	"infoPanel.pushingAndCreatingPR": "Pusheando...",
 	"infoPanel.showDiff": "Show Diff",
 	"infoPanel.showDiffFailed": "Error al mostrar diff: {error}",
 	"infoPanel.showDiffTooltip": "Mostrar diff vs {branch}",

--- a/src/mainview/i18n/translations/ru.ts
+++ b/src/mainview/i18n/translations/ru.ts
@@ -261,6 +261,8 @@ const ru: TranslationRecord & Record<string, string> = {
 	"infoPanel.createPRFailed": "Не удалось создать PR: {error}",
 	"infoPanel.createPRDisabledNoCommits": "Нет коммитов для создания PR",
 	"infoPanel.createPRDisabledNotPushed": "Сначала сделайте Push",
+	"infoPanel.pushAndCreatePR": "Push & Create PR",
+	"infoPanel.pushingAndCreatingPR": "Пушим...",
 	"infoPanel.showDiff": "Show Diff",
 	"infoPanel.showDiffFailed": "Ошибка показа diff: {error}",
 	"infoPanel.showDiffTooltip": "Показать diff vs {branch}",


### PR DESCRIPTION
When the branch has unpushed commits, the Create PR button now shows
"Push & Create PR" instead of being disabled. Clicking it pushes first,
then automatically triggers PR creation on successful push completion.
