### PR TITLE
Instant grey-out on task complete/cancel

### DIFF
--- a/change-logs/2026/03/08/feature-instant-grey-on-complete.md
+++ b/change-logs/2026/03/08/feature-instant-grey-on-complete.md
@@ -1,0 +1,1 @@
+Task cards now grey out instantly when moved to completed/cancelled status. The menu-based move path now uses optimistic UI updates (like drag-and-drop already did), so the card immediately relocates to the target column with a grayscale + dimmed appearance while the heavy backend cleanup runs in the background.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -41,6 +41,15 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 	const [movingTaskIds, setMovingTaskIds] = useState<Set<string>>(new Set());
 	const moveCounterRef = useRef(0);
 
+	const handleSetMoving = useCallback((taskId: string, isMoving: boolean) => {
+		setMovingTaskIds((prev) => {
+			const next = new Set(prev);
+			if (isMoving) next.add(taskId);
+			else next.delete(taskId);
+			return next;
+		});
+	}, []);
+
 	// Cmd+N — open create task modal (capture phase to intercept before terminal)
 	const handleCmdN = useCallback((e: KeyboardEvent) => {
 		if (!((e.metaKey || e.ctrlKey) && e.key === "n")) return;
@@ -252,6 +261,7 @@ function KanbanBoard({ project, tasks, dispatch, navigate, bellCounts, activeTas
 						activeTaskId={activeTaskId}
 						draggedTaskId={draggedTaskId}
 						movingTaskIds={movingTaskIds}
+						onSetMoving={handleSetMoving}
 						siblingMap={siblingMap}
 					/>
 				))}

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -25,6 +25,7 @@ interface KanbanColumnProps {
 	activeTaskId?: string;
 	draggedTaskId: string | null;
 	movingTaskIds: Set<string>;
+	onSetMoving: (taskId: string, isMoving: boolean) => void;
 	siblingMap: Map<string, Task[]>;
 }
 
@@ -47,6 +48,7 @@ function KanbanColumn({
 	activeTaskId,
 	draggedTaskId,
 	movingTaskIds,
+	onSetMoving,
 	siblingMap,
 }: KanbanColumnProps) {
 	const t = useT();
@@ -196,6 +198,7 @@ function KanbanColumn({
 							bellCount={bellCounts.get(task.id) ?? 0}
 							isActiveInSplit={task.id === activeTaskId}
 							isMoving={movingTaskIds.has(task.id)}
+							onSetMoving={onSetMoving}
 							siblingMap={siblingMap}
 						/>
 					</div>

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -26,10 +26,11 @@ interface TaskCardProps {
 	bellCount?: number;
 	isActiveInSplit?: boolean;
 	isMoving?: boolean;
+	onSetMoving?: (taskId: string, isMoving: boolean) => void;
 	siblingMap?: Map<string, Task[]>;
 }
 
-function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false, isMoving: isMovingProp = false, siblingMap }: TaskCardProps) {
+function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onDragStart: onDragStartProp, onTaskMoved, bellCount = 0, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap }: TaskCardProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const [moving, setMoving] = useState(false);
@@ -66,6 +67,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const isTodo = task.status === "todo";
 	const isCancelled = task.status === "cancelled";
 	const isActive = ACTIVE_STATUSES.includes(task.status);
+	const isCompleting = isDisabled && (task.status === "completed" || task.status === "cancelled");
 	const color = statusColors[task.status];
 
 	// Close menu on click outside
@@ -144,8 +146,19 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		}
 
 		const fromStatus = task.status;
-		setMoving(true);
+		const isTerminal = newStatus === "completed" || newStatus === "cancelled";
 		setMenuOpen(false);
+
+		// Optimistic update for terminal statuses — grey out and move immediately
+		if (isTerminal) {
+			dispatch({ type: "updateTask", task: { ...task, status: newStatus } });
+			dispatch({ type: "clearBell", taskId: task.id });
+			onTaskMoved(task.id);
+			onSetMoving?.(task.id, true);
+		} else {
+			setMoving(true);
+		}
+
 		try {
 			const updated = await api.request.moveTask({
 				taskId: task.id,
@@ -153,10 +166,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				newStatus,
 			});
 			dispatch({ type: "updateTask", task: updated });
-			if (newStatus === "completed" || newStatus === "cancelled") {
-				dispatch({ type: "clearBell", taskId: task.id });
-			}
-			onTaskMoved(task.id);
+			if (!isTerminal) onTaskMoved(task.id);
 			trackEvent("task_moved", { from_status: fromStatus, to_status: newStatus });
 		} catch (err) {
 			// Auto-retry with force — environment is likely broken
@@ -168,16 +178,21 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					force: true,
 				});
 				dispatch({ type: "updateTask", task: updated });
-				if (newStatus === "completed" || newStatus === "cancelled") {
-					dispatch({ type: "clearBell", taskId: task.id });
-				}
-				onTaskMoved(task.id);
+				if (!isTerminal) onTaskMoved(task.id);
 				trackEvent("task_moved", { from_status: fromStatus, to_status: newStatus });
 			} catch (retryErr) {
+				// Revert optimistic update on total failure
+				if (isTerminal) {
+					dispatch({ type: "updateTask", task });
+				}
 				alert(t("task.failedMove", { error: String(retryErr) }));
 			}
 		}
-		setMoving(false);
+		if (isTerminal) {
+			onSetMoving?.(task.id, false);
+		} else {
+			setMoving(false);
+		}
 	}
 
 	async function handleDelete() {
@@ -382,8 +397,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
-			} ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
-			style={{ borderLeftColor: color }}
+			} ${isCompleting ? "grayscale opacity-40 pointer-events-none" : isDisabled ? "opacity-50 pointer-events-none" : ""}`}
+			style={{ borderLeftColor: isCompleting ? "#888" : color }}
 			onClick={handleClick}
 		>
 			{/* Moving spinner overlay */}


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI behind this branch.

- Task cards now grey out instantly (grayscale + dimmed) when moved to completed/cancelled, providing immediate visual feedback before the heavy backend cleanup finishes
- Menu-based moves to terminal statuses now use optimistic UI updates, matching the existing drag-and-drop behavior
- Added `onSetMoving` callback propagated through KanbanBoard → KanbanColumn → TaskCard so the moving state survives card remount when it relocates to a new column