### PR TITLE
Fix double context menu in terminal area

### DIFF
--- a/change-logs/2026/03/08/fix-terminal-double-context-menu.md
+++ b/change-logs/2026/03/08/fix-terminal-double-context-menu.md
@@ -1,0 +1,1 @@
+Suppress native macOS context menu in the terminal area by adding `preventDefault()` on the `contextmenu` event. Previously, right-clicking opened both the native WKWebView menu and the app's custom context menu simultaneously.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -630,6 +630,7 @@ function TerminalView({ ptyUrl, taskId, projectId }: TerminalViewProps) {
 			data-terminal="true"
 			style={{ backgroundColor: termBg }}
 			onClick={() => termRef.current?.focus()}
+			onContextMenu={(e) => e.preventDefault()}
 			onDragOver={handleDragOver}
 			onDrop={handleDrop}
 		/>


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this fix.

- Suppress the native macOS/WKWebView context menu in the terminal area by adding `preventDefault()` on the `contextmenu` event
- Previously, right-clicking opened both the native context menu AND the app's custom menu simultaneously

Closes #144