### PR TITLE
Fix unreliable diffs against main branch

### DIFF
--- a/change-logs/2026/03/08/fix-diff-fetch-dedup.md
+++ b/change-logs/2026/03/08/fix-diff-fetch-dedup.md
@@ -1,0 +1,1 @@
+Fix unreliable diffs against main branch (#141). Added per-project fetch deduplication with 5-second cooldown to prevent git lock contention when multiple callers (polling, git operation completion, merge detection) trigger concurrent fetches. Also added missing `fetchOrigin` call to `showDiff` handler so the tmux diff pane always uses fresh remote refs.

--- a/src/bun/__tests__/git.test.ts
+++ b/src/bun/__tests__/git.test.ts
@@ -95,6 +95,8 @@ import {
 	removeWorktree,
 	getUncommittedChanges,
 	listBranches,
+	fetchOrigin,
+	_resetFetchState,
 } from "../git";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -953,5 +955,80 @@ describe("listBranches", () => {
 
 		expect(localNames).not.toContain("temp-branch");
 		expect(remoteNames).toContain("origin/temp-branch");
+	});
+});
+
+// ─── fetchOrigin ─────────────────────────────────────────────────────────────
+
+describe("fetchOrigin", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		_resetFetchState();
+		repo = createTestRepo();
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("returns true on successful fetch", async () => {
+		const ok = await fetchOrigin(repo.local);
+		expect(ok).toBe(true);
+	});
+
+	it("returns false when project has no remote", async () => {
+		// Create a repo with no origin remote
+		const dir = mkdtempSync(join(tmpdir(), "dev3-no-remote-"));
+		const local = join(dir, "repo");
+		g(`git init "${local}"`, dir);
+		g("git config user.email test@test.com", local);
+		g("git config user.name Test", local);
+		writeFileSync(join(local, "file.txt"), "test");
+		g("git add file.txt", local);
+		g('git commit -m "init"', local);
+
+		try {
+			const ok = await fetchOrigin(local);
+			expect(ok).toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("deduplicates concurrent fetches for the same project", async () => {
+		// Launch three concurrent fetches — only one git process should run
+		const results = await Promise.all([
+			fetchOrigin(repo.local),
+			fetchOrigin(repo.local),
+			fetchOrigin(repo.local),
+		]);
+		// All should succeed (shared the same in-flight promise)
+		expect(results).toEqual([true, true, true]);
+	});
+
+	it("skips fetch within cooldown period", async () => {
+		// First fetch succeeds and records a timestamp
+		const ok1 = await fetchOrigin(repo.local);
+		expect(ok1).toBe(true);
+
+		// Second fetch within cooldown returns true without running git
+		const ok2 = await fetchOrigin(repo.local);
+		expect(ok2).toBe(true);
+	});
+
+	it("allows fetch for different projects concurrently", async () => {
+		// Create a second test repo
+		const repo2 = createTestRepo();
+		try {
+			const [ok1, ok2] = await Promise.all([
+				fetchOrigin(repo.local),
+				fetchOrigin(repo2.local),
+			]);
+			expect(ok1).toBe(true);
+			expect(ok2).toBe(true);
+		} finally {
+			cleanup(repo2);
+		}
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -965,7 +965,7 @@ describe("handlers.fetchBranches", () => {
 		];
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(git.listBranches).mockResolvedValue(branches);
-		vi.mocked(git.fetchOrigin).mockResolvedValue(undefined);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 
 		const result = await handlers.fetchBranches({ projectId: "proj-1" });
 		expect(git.fetchOrigin).toHaveBeenCalledWith(project.path);
@@ -1409,7 +1409,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
-		vi.mocked(git.fetchOrigin).mockResolvedValue(undefined);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 3, behind: 2 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 10, deletions: 5 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(1);
@@ -1432,7 +1432,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
-		vi.mocked(git.fetchOrigin).mockResolvedValue(undefined);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
@@ -1449,7 +1449,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(data.updateTask).mockResolvedValue({ ...task, branchName: "dev3/fix-login" });
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/fix-login");
-		vi.mocked(git.fetchOrigin).mockResolvedValue(undefined);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
@@ -1468,7 +1468,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-aaaa");
-		vi.mocked(git.fetchOrigin).mockResolvedValue(undefined);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -264,9 +264,53 @@ export async function getCurrentBranch(worktreePath: string): Promise<string | n
 	return result.stdout;
 }
 
-export async function fetchOrigin(projectPath: string): Promise<void> {
-	log.debug("Fetching origin", { projectPath });
-	await run(["git", "fetch", "origin", "--quiet"], projectPath);
+// Per-project fetch deduplication: reuse in-flight fetch promises and enforce
+// a cooldown to prevent lock contention when multiple callers (polling, git
+// operation completion, merge detection) trigger concurrent fetches.
+const fetchInFlight = new Map<string, Promise<boolean>>();
+const fetchLastSuccess = new Map<string, number>();
+const FETCH_COOLDOWN_MS = 5_000;
+
+export async function fetchOrigin(projectPath: string): Promise<boolean> {
+	const now = Date.now();
+	const lastSuccess = fetchLastSuccess.get(projectPath) ?? 0;
+
+	// Skip if a successful fetch completed recently
+	if (now - lastSuccess < FETCH_COOLDOWN_MS) {
+		log.debug("fetchOrigin: skipping (cooldown)", { projectPath, msSinceLast: now - lastSuccess });
+		return true;
+	}
+
+	// Reuse in-flight fetch for the same project
+	const existing = fetchInFlight.get(projectPath);
+	if (existing) {
+		log.debug("fetchOrigin: reusing in-flight fetch", { projectPath });
+		return existing;
+	}
+
+	const promise = (async () => {
+		log.debug("Fetching origin", { projectPath });
+		const result = await run(["git", "fetch", "origin", "--quiet"], projectPath);
+		if (result.ok) {
+			fetchLastSuccess.set(projectPath, Date.now());
+		} else {
+			log.warn("fetchOrigin failed", { projectPath, stderr: result.stderr });
+		}
+		return result.ok;
+	})();
+
+	fetchInFlight.set(projectPath, promise);
+	try {
+		return await promise;
+	} finally {
+		fetchInFlight.delete(projectPath);
+	}
+}
+
+/** Reset fetch dedup state — for tests only. */
+export function _resetFetchState(): void {
+	fetchInFlight.clear();
+	fetchLastSuccess.clear();
 }
 
 export async function getBranchStatus(

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1382,6 +1382,10 @@ export const handlers = {
 
 		const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
 		const ref = params.compareRef || `origin/${baseBranch}`;
+
+		// Fetch fresh refs before showing diff (deduped, won't re-fetch within cooldown)
+		await git.fetchOrigin(project.path);
+
 		const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
 		const scriptPath = `/tmp/dev3-${task.id}-git-diff.sh`;
 


### PR DESCRIPTION
## Summary

Closes #141

- Add per-project fetch deduplication to `git.fetchOrigin()` with 5s cooldown — prevents git lock contention when multiple callers (polling, git op completion, merge detection) trigger concurrent fetches
- Add missing `fetchOrigin` call to `showDiff` handler so the tmux diff pane always uses fresh remote refs
- `fetchOrigin` now returns `boolean` (success/failure) and logs errors instead of silently swallowing them

Hey, this is Claude — the AI working on this branch.