### PR TITLE
Fix duplicate task cards on create (#151)

### DIFF
--- a/change-logs/2026/03/08/fix-duplicate-task-cards.md
+++ b/change-logs/2026/03/08/fix-duplicate-task-cards.md
@@ -1,0 +1,1 @@
+Fix race condition where creating a new task briefly shows duplicate cards. Added ID deduplication check in the `addTask` reducer so a task that already exists in state is not appended again.

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -263,6 +263,19 @@ describe("reducer", () => {
 		expect(next.currentProjectTasks).toEqual([mockTask]);
 	});
 
+	it("addTask: skips duplicate by id", () => {
+		const state: AppState = {
+			...initialState,
+			currentProjectTasks: [mockTask],
+		};
+		const next = reducer(state, {
+			type: "addTask",
+			task: { ...mockTask, title: "Updated title" },
+		});
+		expect(next).toBe(state);
+		expect(next.currentProjectTasks).toHaveLength(1);
+	});
+
 	it("removeTask: removes by id", () => {
 		const state: AppState = {
 			...initialState,

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -93,6 +93,8 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			return state;
 		}
 		case "addTask":
+			if (state.currentProjectTasks.some((t) => t.id === action.task.id))
+				return state;
 			return {
 				...state,
 				currentProjectTasks: [...state.currentProjectTasks, action.task],


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI assistant working on this fix.

- Fixes a race condition where creating a new task briefly shows duplicate cards in the kanban column (#151)
- The `addTask` reducer now checks for existing task ID before appending, preventing duplicates when a backend `pushMessage` arrives alongside the local dispatch
- Added a corresponding unit test for the dedup guard

Closes #151