### PR TITLE
Guard setupErrorTracking() against duplicate listener registration on HMR

### DIFF
--- a/change-logs/2026/03/08/fix-duplicate-error-tracking.md
+++ b/change-logs/2026/03/08/fix-duplicate-error-tracking.md
@@ -1,0 +1,1 @@
+Add a guard flag to `setupErrorTracking()` in analytics to prevent duplicate window error/unhandledrejection listeners from accumulating when `initAnalytics()` is called multiple times (e.g. during HMR).

--- a/src/mainview/analytics.ts
+++ b/src/mainview/analytics.ts
@@ -13,6 +13,7 @@ let sessionId = "";
 let userProperties: Record<string, { value: string }> = {};
 let currentScreen = "dashboard";
 let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+let errorTrackingSetup = false;
 let sessionStartTime = 0;
 let previousAppVersion = "";
 
@@ -171,6 +172,9 @@ export function trackEvent(
 // ── Error tracking ──
 
 function setupErrorTracking(): void {
+	if (errorTrackingSetup) return;
+	errorTrackingSetup = true;
+
 	window.addEventListener("error", (event) => {
 		trackEvent("app_exception", {
 			description: `${event.message} at ${event.filename}:${event.lineno}:${event.colno}`,


### PR DESCRIPTION
Add a module-level flag to prevent window error/unhandledrejection
listeners from accumulating when initAnalytics() is called repeatedly.
