### PR TITLE
Fix tmux sessions leaking on task completion

### DIFF
--- a/change-logs/2026/03/08/fix-tmux-session-leak.md
+++ b/change-logs/2026/03/08/fix-tmux-session-leak.md
@@ -1,0 +1,1 @@
+Fix tmux sessions leaking after task completion/cancellation. The destroySession function now always attempts to kill the tmux session on the server even when the in-memory PTY session is missing (e.g. after app restart). Switched from async fire-and-forget spawn to synchronous spawnSync for the kill-session command to ensure it completes reliably.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -925,7 +925,7 @@ describe("task.move", () => {
 		);
 
 		expect(resp.ok).toBe(true);
-		expect(pty.destroySession).toHaveBeenCalledWith(task.id);
+		expect(pty.destroySession).toHaveBeenCalledWith(task.id, undefined);
 		expect(runCleanupScript).toHaveBeenCalledWith(task, project);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, {

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -263,15 +263,15 @@ describe("pty-server", () => {
 			expect(hasSession(id)).toBe(false);
 		});
 
-		it("kills tmux session via spawn", () => {
+		it("kills tmux session via spawnSync", () => {
 			const id = track("task-dstr-02");
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
-			mockSpawn.mockClear();
+			mockSpawnSync.mockClear();
 
 			destroySession(id);
 			activeSessions.splice(activeSessions.indexOf(id), 1);
 
-			const killCall = mockSpawn.mock.calls.find(
+			const killCall = mockSpawnSync.mock.calls.find(
 				(c) => Array.isArray(c[0]) && c[0].includes("kill-session"),
 			);
 			expect(killCall).toBeDefined();
@@ -301,15 +301,44 @@ describe("pty-server", () => {
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
 
 			// Make kill-session throw
-			mockSpawn.mockImplementation((cmd: any) => {
+			mockSpawnSync.mockImplementation((cmd: any) => {
 				if (Array.isArray(cmd) && cmd.includes("kill-session")) {
 					throw new Error("tmux kill failed");
 				}
-				return defaultSpawnReturn() as any;
+				return { exitCode: 0, stdout: new Uint8Array(0) } as any;
 			});
 
 			expect(() => destroySession(id)).not.toThrow();
 			activeSessions.splice(activeSessions.indexOf(id), 1);
+		});
+
+		it("kills tmux session even when not in memory map (fallback socket)", () => {
+			mockSpawnSync.mockClear();
+
+			// Destroy a session that was never created in the Map
+			destroySession("unknown-task-id-1234", "dev3");
+
+			const killCall = mockSpawnSync.mock.calls.find(
+				(c) => Array.isArray(c[0]) && c[0].includes("kill-session"),
+			);
+			expect(killCall).toBeDefined();
+			expect(killCall![0]).toContain("dev3-unknown-");
+			expect(killCall![0]).toContain("-L");
+			expect(killCall![0]).toContain("dev3");
+		});
+
+		it("uses fallback socket 'dev3' when no session and no fallback provided", () => {
+			mockSpawnSync.mockClear();
+
+			destroySession("orphan-task-id-5678");
+
+			const killCall = mockSpawnSync.mock.calls.find(
+				(c) => Array.isArray(c[0]) && c[0].includes("kill-session"),
+			);
+			expect(killCall).toBeDefined();
+			// Should use default "dev3" socket
+			expect(killCall![0]).toContain("-L");
+			expect(killCall![0][2]).toBe("dev3");
 		});
 	});
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1040,7 +1040,7 @@ describe("handlers.moveTask", () => {
 
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
 		expect(result.status).toBe("completed");
-		expect(pty.destroySession).toHaveBeenCalledWith("task-1");
+		expect(pty.destroySession).toHaveBeenCalledWith("task-1", undefined);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 	});
 
@@ -1154,7 +1154,7 @@ describe("handlers.moveTask", () => {
 
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
 		expect(result.status).toBe("completed");
-		expect(pty.destroySession).toHaveBeenCalledWith("task-1");
+		expect(pty.destroySession).toHaveBeenCalledWith("task-1", undefined);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
 			status: "completed",
@@ -1208,7 +1208,7 @@ describe("handlers.deleteTask", () => {
 		vi.mocked(git.removeWorktree).mockResolvedValue(undefined);
 
 		await handlers.deleteTask({ taskId: "task-1", projectId: "proj-1" });
-		expect(pty.destroySession).toHaveBeenCalledWith("task-1");
+		expect(pty.destroySession).toHaveBeenCalledWith("task-1", undefined);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 		expect(data.deleteTask).toHaveBeenCalledWith(project, "task-1");
 	});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -411,7 +411,7 @@ const handlers: Record<string, Handler> = {
 
 		// active → completed/cancelled: destroy PTY, cleanup, remove worktree
 		if (isActive(oldStatus) && (builtinStatus === "completed" || builtinStatus === "cancelled")) {
-			try { pty.destroySession(task.id); } catch {}
+			try { pty.destroySession(task.id, task.tmuxSocket); } catch {}
 			try { await runCleanupScript(task, project); } catch {}
 			playTaskCompleteSound();
 			try { await git.removeWorktree(project, task); } catch {}

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -153,20 +153,33 @@ export function createSession(
 	spawnPty(session, 220, 50);
 }
 
-export function destroySession(taskId: string): void {
+export function destroySession(taskId: string, fallbackSocket?: string | null): void {
 	const session = sessions.get(taskId);
-	if (!session) {
-		log.warn("destroySession: session not found", { taskId: taskId.slice(0, 8) });
-		return;
-	}
+	const socket = session?.tmuxSocket ?? fallbackSocket ?? "dev3";
 
-	log.info("Destroying PTY session", { taskId: taskId.slice(0, 8), hasPid: !!session.proc });
+	log.info("Destroying PTY session", {
+		taskId: taskId.slice(0, 8),
+		hasPid: !!session?.proc,
+		inMap: !!session,
+		socket,
+	});
 
 	// Kill the tmux session explicitly — proc.kill() only disconnects the
 	// attached client, the session itself keeps running on the tmux server.
+	// Use spawnSync to ensure the kill completes before we proceed.
 	const tmuxSessionName = `dev3-${shortId(taskId)}`;
 	try {
-		spawn(tmuxArgs(session.tmuxSocket, "kill-session", "-t", tmuxSessionName));
+		const result = spawnSync(tmuxArgs(socket, "kill-session", "-t", tmuxSessionName));
+		if (result.exitCode !== 0) {
+			const stderr = new TextDecoder().decode(result.stderr).trim();
+			log.warn("tmux kill-session exited non-zero", {
+				taskId: taskId.slice(0, 8),
+				exitCode: result.exitCode,
+				stderr,
+			});
+		} else {
+			log.info("tmux kill-session succeeded", { taskId: taskId.slice(0, 8), tmuxSessionName });
+		}
 	} catch (err) {
 		log.warn("tmux kill-session failed (best-effort)", {
 			taskId: taskId.slice(0, 8),
@@ -174,18 +187,20 @@ export function destroySession(taskId: string): void {
 		});
 	}
 
-	if (session.proc) {
-		session.proc.terminal?.close();
-		session.proc.kill();
-	}
-	if (session.ws) {
-		try {
-			session.ws.close();
-		} catch {
-			// already closed
+	if (session) {
+		if (session.proc) {
+			session.proc.terminal?.close();
+			session.proc.kill();
 		}
+		if (session.ws) {
+			try {
+				session.ws.close();
+			} catch {
+				// already closed
+			}
+		}
+		sessions.delete(taskId);
 	}
-	sessions.delete(taskId);
 }
 
 export function hasSession(taskId: string): boolean {

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -832,7 +832,7 @@ export const handlers = {
 					hasWorktree: !!task.worktreePath,
 				});
 				try {
-					pty.destroySession(task.id);
+					pty.destroySession(task.id, task.tmuxSocket);
 				} catch (err) {
 					log.error("destroySession failed, continuing with task move", {
 						taskId: task.id,
@@ -902,7 +902,7 @@ export const handlers = {
 		// Cleanup if active
 		if (isActive(task.status)) {
 			log.info("Task is active, cleaning up PTY + worktree");
-			pty.destroySession(task.id);
+			pty.destroySession(task.id, task.tmuxSocket);
 			await git.removeWorktree(project, task);
 		}
 


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI that tracked down this tmux ghost session bug.

- **Root cause:** `destroySession()` silently returned early when the PTY session wasn't in the in-memory Map (e.g. after app restart), leaving orphaned tmux sessions on the `dev3` socket server
- **Fix:** `destroySession()` now accepts a fallback socket parameter and always attempts `kill-session` even without an in-memory session. Switched from async fire-and-forget `spawn()` to synchronous `spawnSync()` for reliable completion
- **Callers updated:** `moveTask` and `deleteTask` in both `rpc-handlers.ts` and `cli-socket-server.ts` now pass `task.tmuxSocket` as the fallback