### PR TITLE
Remove redundant variable aliases found by /simplify

### DIFF
--- a/change-logs/2026/03/08/chore-simplify-redundant-aliases.md
+++ b/change-logs/2026/03/08/chore-simplify-redundant-aliases.md
@@ -1,0 +1,1 @@
+Remove redundant variable aliases: collapse `effectiveOldStatus` into `oldStatus` in cli-socket-server.ts, and convert module-level `previousAppVersion` to a local const in analytics.ts.

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -378,17 +378,15 @@ const handlers: Record<string, Handler> = {
 		}
 
 		// If moving from a custom column to a built-in status, allow any transition from the task's current status
-		const effectiveOldStatus = task.status;
+		const oldStatus = task.status;
 		if (!task.customColumnId) {
-			const allowed = getAllowedTransitions(effectiveOldStatus);
+			const allowed = getAllowedTransitions(oldStatus);
 			if (!allowed.includes(builtinStatus)) {
 				throw new Error(
-					`Cannot move task from "${effectiveOldStatus}" to "${builtinStatus}". Allowed: ${allowed.join(", ")}`,
+					`Cannot move task from "${oldStatus}" to "${builtinStatus}". Allowed: ${allowed.join(", ")}`,
 				);
 			}
 		}
-
-		const oldStatus = effectiveOldStatus;
 		const settings = await loadSettings();
 		const dropOpts = { dropPosition: settings.taskDropPosition } as const;
 

--- a/src/mainview/analytics.ts
+++ b/src/mainview/analytics.ts
@@ -14,7 +14,6 @@ let userProperties: Record<string, { value: string }> = {};
 let currentScreen = "dashboard";
 let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 let sessionStartTime = 0;
-let previousAppVersion = "";
 
 function getOrCreateClientId(): string {
 	const key = "dev3-ga-client-id";
@@ -117,7 +116,7 @@ export function initAnalytics(appVersion: string): void {
 	}
 
 	// app_update — fires when the app version changes (not on first open)
-	previousAppVersion = localStorage.getItem("dev3-ga-last-version") || "";
+	const previousAppVersion = localStorage.getItem("dev3-ga-last-version") || "";
 	if (previousAppVersion && previousAppVersion !== appVersion) {
 		initEvents.push({
 			name: "app_update",


### PR DESCRIPTION
- Collapse effectiveOldStatus → oldStatus in cli-socket-server.ts
- Convert module-level previousAppVersion to local const in analytics.ts
