### PR TITLE
Fix Review by AI column position regression from #161

### DIFF
--- a/change-logs/2026/03/08/fix-review-ai-column-position.md
+++ b/change-logs/2026/03/08/fix-review-ai-column-position.md
@@ -1,0 +1,1 @@
+Fix "Review by AI" column appearing at position 4 instead of the far right. The DEFAULT_BEFORE_CUSTOM array in KanbanBoard.tsx still had the old order — moved "review-by-ai" to DEFAULT_AFTER_CUSTOM (after "cancelled") to match the intended ALL_STATUSES order.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -3,8 +3,8 @@ import type { CodingAgent, CustomColumn, GlobalSettings, Project, Task, TaskStat
 import { ALL_STATUSES, ACTIVE_STATUSES } from "../../shared/types";
 
 // Default built-in column order (custom columns can be freely interspersed)
-const DEFAULT_BEFORE_CUSTOM: TaskStatus[] = ["todo", "in-progress", "user-questions", "review-by-ai", "review-by-user"];
-const DEFAULT_AFTER_CUSTOM: TaskStatus[] = ["completed", "cancelled"];
+const DEFAULT_BEFORE_CUSTOM: TaskStatus[] = ["todo", "in-progress", "user-questions", "review-by-user"];
+const DEFAULT_AFTER_CUSTOM: TaskStatus[] = ["completed", "cancelled", "review-by-ai"];
 const ALL_BUILTIN: TaskStatus[] = [...DEFAULT_BEFORE_CUSTOM, ...DEFAULT_AFTER_CUSTOM];
 
 type ColumnSlot =


### PR DESCRIPTION
## Summary

- PR #161 (custom columns) introduced `DEFAULT_BEFORE_CUSTOM` / `DEFAULT_AFTER_CUSTOM` arrays to split built-in columns around custom ones. The "Review by AI" status was placed in `DEFAULT_BEFORE_CUSTOM` at position 4, overriding the intended `ALL_STATUSES` order where it should be last (after Cancelled).
- Moved `review-by-ai` from `DEFAULT_BEFORE_CUSTOM` to `DEFAULT_AFTER_CUSTOM` (after `cancelled`) to restore the correct column order.

Hey, Claude here (the AI fixing this one). This was a side effect of the custom columns PR — the agent that wrote it split the statuses into before/after groups but used the `TaskStatus` union order instead of `ALL_STATUSES` order. One-line fix.