### PR TITLE
Fix terminal preview not hiding on drag start

### DIFF
--- a/change-logs/2026/03/08/fix-hide-preview-on-drag.md
+++ b/change-logs/2026/03/08/fix-hide-preview-on-drag.md
@@ -1,0 +1,1 @@
+Fixed terminal preview popover not closing when drag-and-drop starts on a task card in Kanban view. The preview now hides immediately on dragStart.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -251,6 +251,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	}
 
 	function handleDragStart(e: React.DragEvent) {
+		closePreview();
 		e.dataTransfer.setData("text/plain", task.id);
 		e.dataTransfer.effectAllowed = "move";
 		onDragStartProp(task.id);

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -517,6 +517,33 @@ describe("TaskCard", () => {
 			expect(onDragStart).toHaveBeenCalledWith("t1");
 			expect(mockDataTransfer.setData).toHaveBeenCalledWith("text/plain", "t1");
 		});
+
+		it("closes terminal preview when drag starts", async () => {
+			vi.useFakeTimers();
+			const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" });
+			mockedApi.request.getTerminalPreview.mockResolvedValue("$ hello");
+
+			renderCard(task);
+
+			const card = screen.getByText("My task").closest("[draggable]")!;
+
+			// Trigger hover to open preview
+			fireEvent.mouseEnter(card);
+			// Advance past the 400ms hover delay
+			await vi.advanceTimersByTimeAsync(500);
+
+			// Preview should be open
+			expect(mockedApi.request.getTerminalPreview).toHaveBeenCalled();
+
+			// Start dragging — preview should close
+			const mockDataTransfer = { setData: vi.fn(), effectAllowed: "" };
+			fireEvent.dragStart(card, { dataTransfer: mockDataTransfer });
+
+			// Preview portal should be gone
+			expect(screen.queryByText("$ hello")).not.toBeInTheDocument();
+
+			vi.useRealTimers();
+		});
 	});
 
 	describe("title click and detail modal", () => {


### PR DESCRIPTION
## Summary

- Fixed the terminal preview popover staying visible when initiating drag-and-drop on a task card in Kanban view, obstructing the drag operation
- Added `closePreview()` call in `handleDragStart` to dismiss the preview immediately
- Added a regression test covering the hover → preview → drag → preview-closed flow