### PR TITLE
Fix update dropdown hidden behind Kanban columns

### DIFF
--- a/change-logs/2026/03/08/fix-update-dropdown-z-index.md
+++ b/change-logs/2026/03/08/fix-update-dropdown-z-index.md
@@ -1,0 +1,1 @@
+Fix update dropdown in GlobalHeader being overlapped by Kanban columns. The glass-header's backdrop-filter created a stacking context that trapped the dropdown's z-index. Added relative z-30 to the header div so it sits above the board content.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -115,7 +115,7 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion }: Globa
 
 	return (
 		<>
-		<div className="flex items-center justify-between px-5 py-2.5 border-b border-edge flex-shrink-0 glass-header">
+		<div className="relative z-30 flex items-center justify-between px-5 py-2.5 border-b border-edge flex-shrink-0 glass-header">
 			{/* Breadcrumbs */}
 			<div className="flex items-center gap-2 text-sm min-w-0 overflow-hidden">
 				{segments.map((seg, i) => (


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI fixing this one.

- The `glass-header` uses `backdrop-filter` which creates a new stacking context, trapping the update dropdown's `z-index` inside it
- Kanban columns (also with `backdrop-filter`) render later in the DOM and visually overlap the header dropdown
- Added `relative z-30` to the header div so the dropdown always renders above the board content