### PR TITLE
Fix Escape on project view to navigate to main dashboard

### DIFF
--- a/change-logs/2026/03/09/fix-escape-project-to-dashboard.md
+++ b/change-logs/2026/03/09/fix-escape-project-to-dashboard.md
@@ -1,0 +1,1 @@
+Pressing Escape on a project's Kanban board now navigates back to the main app dashboard, consistent with other screens. Previously, Escape had no effect when viewing a project without an active task.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -274,6 +274,8 @@ function App() {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project" && route.activeTaskId) {
 				navigate({ screen: "project", projectId: route.projectId });
+			} else if (route.screen === "project") {
+				navigate({ screen: "dashboard" });
 			}
 		},
 		[state, navigate, showQuitDialog],

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -149,6 +149,19 @@ describe("App keyboard shortcuts", () => {
 		});
 	});
 
+	describe("Escape from project view", () => {
+		it("Escape from project screen goes back to dashboard", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			await renderApp();
+			await userEvent.keyboard("{Meta>}1{/Meta}");
+			expect(screen.getByTestId("project-screen")).toBeInTheDocument();
+			await userEvent.keyboard("{Escape}");
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+		});
+	});
+
 	describe("project switching (Cmd+1..9)", () => {
 		it("Cmd+1 navigates to the first project", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([


### PR DESCRIPTION
## Summary
- Pressing Escape on a project's Kanban board now navigates back to the main app dashboard
- Previously, Escape had no effect when viewing a project without an active task open
- Added a test covering this behavior in `App.test.tsx`

## Test plan
- [x] Open any project (Kanban board view, no task selected)
- [x] Press Escape — should return to the main dashboard
- [x] Verify Escape still works for other screens (settings → dashboard, project-settings → project, split view with active task → project without active task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)