### PR TITLE
Fix missing dropPosition in custom column resume paths

### DIFF
--- a/change-logs/2026/03/09/fix-custom-column-drop-opts.md
+++ b/change-logs/2026/03/09/fix-custom-column-drop-opts.md
@@ -1,0 +1,1 @@
+Fix missing dropPosition option when resuming completed/cancelled tasks into custom columns. The two custom-column resume paths (CLI socket and moveTaskToCustomColumn RPC) now pass the user's taskDropPosition setting to updateTask, matching the behavior of built-in status moves.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2537,6 +2537,7 @@ describe("moveTaskToCustomColumn — resume logic", () => {
 		vi.clearAllMocks();
 		mockSpawn.mockReturnValue({ stderr: new Response(""), stdout: new Response(""), exited: Promise.resolve(0) });
 		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/new-wt", branchName: "dev3/resumed" } as any);
+		vi.mocked(loadSettings).mockResolvedValue({ updateChannel: "stable", taskDropPosition: "top" } as any);
 	});
 
 	it("moves active task to custom column without worktree changes", async () => {
@@ -2572,7 +2573,7 @@ describe("moveTaskToCustomColumn — resume logic", () => {
 			worktreePath: "/tmp/new-wt",
 			branchName: "dev3/resumed",
 			customColumnId: "col-aaa",
-		});
+		}, { dropPosition: "top" });
 		expect(result.status).toBe("in-progress");
 		expect(result.customColumnId).toBe("col-aaa");
 	});
@@ -2592,7 +2593,7 @@ describe("moveTaskToCustomColumn — resume logic", () => {
 		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", expect.objectContaining({
 			status: "in-progress",
 			customColumnId: "col-aaa",
-		}));
+		}), { dropPosition: "top" });
 	});
 
 	it("throws when custom column not found", async () => {

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -364,13 +364,14 @@ const handlers: Record<string, Handler> = {
 		if (customColumn) {
 			// Moving from completed/cancelled into a custom column resumes the task
 			if (task.status === "completed" || task.status === "cancelled") {
+				const settings = await loadSettings();
 				const wt = await activateTask(project, task, { isReopen: true });
 				const updated = await data.updateTask(project, task.id, {
 					status: "in-progress",
 					worktreePath: wt.worktreePath,
 					branchName: wt.branchName,
 					customColumnId: customColumn.id,
-				});
+				}, { dropPosition: settings.taskDropPosition });
 				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 				return updated;
 			}

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -2128,13 +2128,14 @@ export const handlers = {
 		// Moving from completed/cancelled into a custom column resumes the task (same as reopening to an active status)
 		if (params.customColumnId !== null && (task.status === "completed" || task.status === "cancelled")) {
 			log.info("Reopening task into custom column, creating worktree + PTY", { taskId: task.id });
+			const settings = await loadSettings();
 			const wt = await activateTask(project, task, { isReopen: true });
 			const updated = await data.updateTask(project, task.id, {
 				status: "in-progress",
 				worktreePath: wt.worktreePath,
 				branchName: wt.branchName,
 				customColumnId: params.customColumnId,
-			});
+			}, { dropPosition: settings.taskDropPosition });
 			pushMessage?.("taskUpdated", { projectId: project.id, task: updated });
 			log.info("← moveTaskToCustomColumn done (reopened)", { taskId: params.taskId });
 			return updated;


### PR DESCRIPTION
## Summary
- Custom column resume paths (CLI socket + `moveTaskToCustomColumn` RPC) were missing the `dropPosition` option when calling `updateTask` with a status change
- Resumed tasks now respect the user's `taskDropPosition` setting, matching built-in status move behavior
- Updated tests to verify the new parameter is passed

## Test plan
- [x] All 727 existing tests pass
- [x] `bun run lint` passes
- [ ] Manual: complete a task, drag it into a custom column, restart app — verify task position in column is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)