### PR TITLE
Fix misleading comment: branch guard uses dev3/ prefix not dev3/task-

### DIFF
--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -567,7 +567,7 @@ export async function removeWorktree(
 	);
 
 	if (branchToDelete) {
-		// Only delete branches that dev3 created (dev3/task-* or variant suffixes like feature/login-v1).
+		// Only delete branches that dev3 created (dev3/* prefix).
 		// User-owned branches (e.g. feature/login chosen via branch selector) should be preserved.
 		const isDevBranch = branchToDelete.startsWith("dev3/");
 		const isVariantBranch = task.existingBranch && branchToDelete !== task.existingBranch.replace(/^origin\//, "")


### PR DESCRIPTION
The actual code already used startsWith("dev3/") correctly; the comment
incorrectly described it as dev3/task-* only.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
