### PR TITLE
Fix: can't create task from existing branch

### DIFF
--- a/change-logs/2026/03/09/fix-create-task-from-existing-branch.md
+++ b/change-logs/2026/03/09/fix-create-task-from-existing-branch.md
@@ -1,0 +1,3 @@
+Fix creating a task from an existing branch that is already checked out in another worktree. Previously `git worktree add` would fail with "already used by worktree" error. Now falls back to creating a new task branch (`dev3/task-<id>`) based on the existing branch's HEAD when direct checkout is not possible.
+
+Suggested by @yoavf (h0x91b/dev-3.0#189)

--- a/src/bun/__tests__/git.test.ts
+++ b/src/bun/__tests__/git.test.ts
@@ -93,6 +93,7 @@ import {
 	getBranchStatus,
 	canRebaseCleanly,
 	removeWorktree,
+	createWorktree,
 	getUncommittedChanges,
 	listBranches,
 	fetchOrigin,
@@ -794,6 +795,147 @@ describe("removeWorktree", () => {
 		expect(branches).not.toContain("feature/login-v1");
 		// Original branch should be preserved
 		expect(branches).toContain("feature/login");
+	});
+});
+
+// ─── createWorktree ──────────────────────────────────────────────────────────
+
+describe("createWorktree", () => {
+	let repo: TestRepo;
+
+	function makeProject(path: string): Project {
+		return {
+			id: "proj-1",
+			name: "Test",
+			path,
+			setupScript: "",
+			devScript: "",
+			cleanupScript: "",
+			defaultBaseBranch: "main",
+			createdAt: new Date().toISOString(),
+		};
+	}
+
+	function makeTask(overrides: Partial<Task> = {}): Task {
+		return {
+			id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			seq: 1,
+			projectId: "proj-1",
+			title: "Test task",
+			description: "",
+			status: "in-progress",
+			baseBranch: "main",
+			worktreePath: null,
+			branchName: null,
+			groupId: null,
+			variantIndex: null,
+			agentId: null,
+			configId: null,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+			...overrides,
+		};
+	}
+
+	beforeEach(() => {
+		repo = createTestRepo();
+	});
+
+	afterEach(() => cleanup(repo));
+
+	it("creates worktree from existing branch that is not checked out", async () => {
+		// Create a branch but switch back to main
+		g("git checkout -b feature/available", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "feature/available");
+
+		expect(existsSync(result.worktreePath)).toBe(true);
+		expect(result.branchName).toBe("feature/available");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+	});
+
+	it("falls back to task branch when existing branch is already checked out", async () => {
+		// main is checked out in repo.local — selecting it as existing branch should trigger fallback
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "main");
+
+		expect(existsSync(result.worktreePath)).toBe(true);
+		// Should have created a task branch based on main, not checked out main directly
+		expect(result.branchName).toBe("dev3/task-aaaaaaaa");
+
+		// Verify the worktree has the same content as main
+		const mainContent = readFileSync(join(repo.local, "app.ts"), "utf-8");
+		const wtContent = readFileSync(join(result.worktreePath, "app.ts"), "utf-8");
+		expect(wtContent).toBe(mainContent);
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+		g("git branch -D dev3/task-aaaaaaaa", repo.local);
+	});
+
+	it("falls back to task branch when existing branch is checked out in another worktree", async () => {
+		// Create a branch and check it out in a separate worktree
+		g("git checkout -b feature/busy", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+		const otherWt = join(repo.dir, "other-wt");
+		g(`git worktree add "${otherWt}" feature/busy`, repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "feature/busy");
+
+		expect(existsSync(result.worktreePath)).toBe(true);
+		expect(result.branchName).toBe("dev3/task-aaaaaaaa");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+		g(`git worktree remove --force "${otherWt}"`, repo.local);
+		g("git branch -D dev3/task-aaaaaaaa", repo.local);
+	});
+
+	it("creates worktree from remote branch", async () => {
+		// Create a branch, push it, then delete the local copy
+		g("git checkout -b feature/remote-only", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push origin feature/remote-only", repo.local);
+		g("git checkout main", repo.local);
+		g("git branch -D feature/remote-only", repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "origin/feature/remote-only");
+
+		expect(existsSync(result.worktreePath)).toBe(true);
+		expect(result.branchName).toBe("feature/remote-only");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+	});
+
+	it("creates default task branch when no existing branch specified", async () => {
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task);
+
+		expect(existsSync(result.worktreePath)).toBe(true);
+		expect(result.branchName).toBe("dev3/task-aaaaaaaa");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+		g("git branch -D dev3/task-aaaaaaaa", repo.local);
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -175,9 +175,10 @@ export async function createWorktree(
 		);
 
 		if (!result.ok) {
-			// If it's a remote branch that doesn't have a local tracking branch yet,
-			// try creating a local tracking branch
-			if (existingBranch.startsWith("origin/")) {
+			const isAlreadyCheckedOut = result.stderr.includes("already checked out") || result.stderr.includes("already used by worktree");
+
+			if (existingBranch.startsWith("origin/") && !isAlreadyCheckedOut) {
+				// Remote branch without a local tracking branch yet — create one
 				log.info("Retrying with tracking branch creation", { existingBranch });
 				const trackResult = await run(
 					["git", "worktree", "add", "--track", "-b", resolvedBranch, wtPath, existingBranch],
@@ -187,10 +188,30 @@ export async function createWorktree(
 					log.error("Failed to create worktree from existing branch", { stderr: trackResult.stderr, taskId: task.id });
 					throw new Error(`Failed to create worktree: ${trackResult.stderr}`);
 				}
-			} else {
-				log.error("Failed to create worktree from existing branch", { stderr: result.stderr, taskId: task.id });
-				throw new Error(`Failed to create worktree: ${result.stderr}`);
+				log.info("Worktree created from existing branch (tracking)", { wtPath, branch: resolvedBranch });
+				return { worktreePath: wtPath, branchName: resolvedBranch };
 			}
+
+			if (isAlreadyCheckedOut) {
+				// Branch is checked out in another worktree — create a new task branch based on it
+				const taskBranch = branchName(task);
+				log.info("Branch already checked out, creating task branch based on it", {
+					existingBranch: resolvedBranch, taskBranch, taskId: task.id,
+				});
+				const fallbackResult = await run(
+					["git", "worktree", "add", "-b", taskBranch, wtPath, resolvedBranch],
+					project.path,
+				);
+				if (!fallbackResult.ok) {
+					log.error("Failed to create worktree from existing branch (fallback)", { stderr: fallbackResult.stderr, taskId: task.id });
+					throw new Error(`Failed to create worktree: ${fallbackResult.stderr}`);
+				}
+				log.info("Worktree created with task branch based on existing", { wtPath, branch: taskBranch, base: resolvedBranch });
+				return { worktreePath: wtPath, branchName: taskBranch };
+			}
+
+			log.error("Failed to create worktree from existing branch", { stderr: result.stderr, taskId: task.id });
+			throw new Error(`Failed to create worktree: ${result.stderr}`);
 		}
 
 		log.info("Worktree created from existing branch", { wtPath, branch: resolvedBranch });


### PR DESCRIPTION
## Summary

Hey there! Claude here, the AI assistant working on this fix.

- When creating a task from an existing branch that's already checked out in another worktree (e.g. `main`, or any branch active in another task), `git worktree add` would fail with "already used by worktree"
- Now gracefully falls back to creating a new task branch (`dev3/task-<id>`) based on the existing branch's HEAD — the user gets the same code, just on a fresh branch
- Added 5 integration tests for `createWorktree` covering: direct checkout, fallback for occupied branches, remote branches, and default creation

Closes #189

Thanks to @yoavf for reporting this!