### PR TITLE
Add IntelliJ, Zed, and Sublime Text to Open in... menu

### DIFF
--- a/change-logs/2026/03/09/feature-intellij-open-in.md
+++ b/change-logs/2026/03/09/feature-intellij-open-in.md
@@ -1,1 +1,3 @@
-Added IntelliJ IDEA and IntelliJ IDEA CE to the default list of external apps in the "Open in..." context menu, with a diamond icon matching the IntelliJ brand.
+Added IntelliJ IDEA, IntelliJ IDEA CE, Zed, and Sublime Text to the default list of external apps in the "Open in..." context menu, each with a distinctive Nerd Font icon.
+
+Suggested by @AboMokh-Wix (h0x91b/dev-3.0#158)

--- a/src/mainview/components/OpenInMenu.tsx
+++ b/src/mainview/components/OpenInMenu.tsx
@@ -15,6 +15,8 @@ const APP_ICONS: Record<string, string> = {
 	terminal: "\uF489",
 	intellij: "\u{F0184}",    // nf-md-diamond_stone (IntelliJ)
 	"intellij-ce": "\u{F0184}",
+	zed: "\u{F0599}",            // nf-md-lightning_bolt (Zed)
+	sublime: "\u{F0CC5}",        // nf-md-text_box (Sublime Text)
 };
 
 interface OpenInMenuProps {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -188,6 +188,8 @@ export const DEFAULT_EXTERNAL_APPS: ExternalApp[] = [
 	{ id: "terminal", name: "Terminal", macAppName: "Terminal" },
 	{ id: "intellij", name: "IntelliJ IDEA", macAppName: "IntelliJ IDEA" },
 	{ id: "intellij-ce", name: "IntelliJ IDEA CE", macAppName: "IntelliJ IDEA CE" },
+	{ id: "zed", name: "Zed", macAppName: "Zed" },
+	{ id: "sublime", name: "Sublime Text", macAppName: "Sublime Text" },
 ];
 
 export interface GlobalSettings {


### PR DESCRIPTION
## Summary

- Add **IntelliJ IDEA** and **IntelliJ IDEA CE** to the default external apps list in the "Open in..." context menu
- Add **Zed** and **Sublime Text** as well
- Each app gets a distinctive Nerd Font icon (diamond for IntelliJ, lightning bolt for Zed, text box for Sublime)
- Only installed apps are shown — the existing `open -Ra` check filters automatically

Closes #158

Yo, Claude here (the AI agent on this task). This was prompted by @AboMokh-Wix's request in #158 — great suggestion, adding more editors to the menu is a no-brainer.