### PR TITLE
Fix task create ignoring positional content from @file syntax

### DIFF
--- a/change-logs/2026/03/09/fix-task-create-positional.md
+++ b/change-logs/2026/03/09/fix-task-create-positional.md
@@ -1,0 +1,1 @@
+Fixed `task create` CLI command ignoring positional content from `@file` syntax. When using `dev3 task create @file.md --title "..."`, the file content was silently dropped instead of being used as the task description. Now positional content is used as description (when `--description` is absent) and as title source (first line, when `--title` is absent).

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -725,6 +725,87 @@ describe("task update whitespace validation", () => {
 	});
 });
 
+// ─── task create: positional content as description ──────────────────────────
+// When using @file syntax, the file content lands in positional[0] after
+// resolveFileArgs. If --title is provided but --description is not, the
+// positional content should become the description.
+// Bug: createTask ignores positional args entirely — file content is lost.
+
+describe("task create with positional content (e.g. @file)", () => {
+	const createdTask: Task = {
+		...FAKE_TASK,
+		status: "todo",
+		seq: 55,
+		title: "Port exposure",
+		description: "Show which ports a task uses.\n\n**GitHub:** #190",
+	};
+
+	it("uses positional[0] as description when --title given but no --description", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+
+		const fileContent = "Show which ports a task uses.\n\n**GitHub:** #190";
+		await handleTask(
+			"create",
+			args([fileContent], { project: "proj-001", title: "Port exposure" }),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.title).toBe("Port exposure");
+		expect(params.description).toBe(fileContent);
+	});
+
+	it("--description flag takes priority over positional content", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+
+		await handleTask(
+			"create",
+			args(["file content here"], {
+				project: "proj-001",
+				title: "Task",
+				description: "Explicit desc",
+			}),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.description).toBe("Explicit desc");
+	});
+
+	it("uses first line of positional as title when --title is not provided", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+
+		const fileContent = "Port exposure\n\nShow which ports a task uses.\n\n**GitHub:** #190";
+		await handleTask(
+			"create",
+			args([fileContent], { project: "proj-001" }),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.title).toBe("Port exposure");
+		expect(params.description).toBe(fileContent);
+	});
+
+	it("uses single-line positional as both title and description when no --title", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+
+		const fileContent = "Fix the login bug";
+		await handleTask(
+			"create",
+			args([fileContent], { project: "proj-001" }),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.title).toBe("Fix the login bug");
+	});
+});
+
 // ─── unknown subcommand ──────────────────────────────────────────────────────
 
 describe("task (unknown subcommand)", () => {

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -84,13 +84,22 @@ async function createTask(args: ParsedArgs, socketPath: string, context: CliCont
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
 
-	const title = args.flags.title?.trim();
+	const positionalContent = args.positional[0]?.trim();
+
+	let title = args.flags.title?.trim();
+	if (!title && positionalContent) {
+		// Extract first line as title from positional content (e.g. @file)
+		const firstNewline = positionalContent.indexOf("\n");
+		title = firstNewline === -1 ? positionalContent : positionalContent.slice(0, firstNewline).trim();
+	}
 	if (!title) {
 		exitUsage("--title is required");
 	}
 
+	const description = args.flags.description || positionalContent;
+
 	const params: Record<string, unknown> = { projectId, title };
-	if (args.flags.description) params.description = args.flags.description;
+	if (description) params.description = description;
 
 	const resp = await sendRequest(socketPath, "task.create", params);
 	if (!resp.ok) exitError(resp.error || "Failed to create task");


### PR DESCRIPTION
## Summary

- `createTask` in the CLI only read `--title` and `--description` flags, completely ignoring positional args
- When agents used `dev3 task create @file.md --title "..."`, the file content resolved into `positional[0]` by `resolveFileArgs` but was silently dropped — tasks ended up with title-only and no description
- Now `positional[0]` is used as description when `--description` is absent, and as title source (first line) when `--title` is absent
- Added 4 tests covering all scenarios (positional + title, positional + description override, positional-only single/multi-line)