### PR TITLE
Fix task creation failing silently for new projects

### DIFF
--- a/change-logs/2026/03/09/fix-new-project-task-creation.md
+++ b/change-logs/2026/03/09/fix-new-project-task-creation.md
@@ -1,0 +1,1 @@
+Fix task creation failing silently for new projects. The mkdir-based file lock assumed the parent directory already existed, but for projects with no tasks yet the data directory was never created. Now `acquireLock` handles ENOENT by creating parent directories with `recursive: true`.

--- a/src/bun/__tests__/file-lock.test.ts
+++ b/src/bun/__tests__/file-lock.test.ts
@@ -203,6 +203,41 @@ describe("withFileLock — stale lock recovery", () => {
 	});
 });
 
+describe("withFileLock — non-existent parent directory", () => {
+	it("creates parent directories and acquires lock when parent dir does not exist", async () => {
+		const deepPath = path.join(tmpDir, "deep", "nested", "dir", "tasks.json");
+		const lockDir = deepPath + ".lock";
+
+		// Parent directory does NOT exist — this simulates a brand-new project
+		expect(fs.existsSync(path.dirname(deepPath))).toBe(false);
+
+		const result = await withFileLock(deepPath, async () => {
+			return "success";
+		});
+
+		expect(result).toBe("success");
+		// Lock should be released after execution
+		expect(fs.existsSync(lockDir)).toBe(false);
+		// Parent directory should have been created
+		expect(fs.existsSync(path.dirname(deepPath))).toBe(true);
+	});
+
+	it("serializes concurrent operations even when parent dir did not exist initially", async () => {
+		const deepPath = path.join(tmpDir, "new-project", "tasks.json");
+		let counter = 0;
+
+		const increment = () =>
+			withFileLock(deepPath, async () => {
+				const current = counter;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				counter = current + 1;
+			});
+
+		await Promise.all(Array.from({ length: 5 }, () => increment()));
+		expect(counter).toBe(5);
+	});
+});
+
 describe("withFileLock — re-entrancy (same file, nested calls)", () => {
 	it("does not deadlock on nested lock for the same file", async () => {
 		const filePath = path.join(tmpDir, "test.json");

--- a/src/bun/file-lock.ts
+++ b/src/bun/file-lock.ts
@@ -63,6 +63,11 @@ async function acquireLock(
 			fs.mkdirSync(lockDir);
 			return; // Lock acquired
 		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				// Parent directory doesn't exist (e.g. new project with no tasks yet)
+				fs.mkdirSync(lockDir, { recursive: true });
+				return; // Lock acquired
+			}
 			if (err.code !== "EEXIST") {
 				throw err; // Unexpected error (e.g. permissions)
 			}


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI that tracked this one down.

- The mkdir-based file lock (`acquireLock`) assumed the parent directory already existed when creating the `.lock` directory
- For brand-new projects with zero tasks, `${DEV3_HOME}/data/${slug}/` was never created, so `mkdirSync` failed with ENOENT
- This caused task creation to fail silently — no error shown to the user, just nothing happening
- Fixed by handling ENOENT in `acquireLock` with a `recursive: true` retry, creating missing parent dirs automatically
- Added 2 regression tests covering the scenario