### PR TITLE
Fix info tooltip: proper z-index and sizing

### DIFF
--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -84,20 +84,33 @@ function KanbanColumn({
 	const [dropIndex, setDropIndex] = useState<number | null>(null);
 	const [columnDragSide, setColumnDragSide] = useState<"before" | "after" | null>(null);
 	const [showInfo, setShowInfo] = useState(false);
-	const infoRef = useRef<HTMLDivElement>(null);
+	const [infoPos, setInfoPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+	const infoBtnRef = useRef<HTMLButtonElement>(null);
+	const infoPopupRef = useRef<HTMLDivElement>(null);
 	const taskListRef = useRef<HTMLDivElement>(null);
 
 	// Close info popup on outside click
 	useEffect(() => {
 		if (!showInfo) return;
 		function handleClick(e: MouseEvent) {
-			if (infoRef.current && !infoRef.current.contains(e.target as Node)) {
-				setShowInfo(false);
-			}
+			if (
+				infoBtnRef.current?.contains(e.target as Node) ||
+				infoPopupRef.current?.contains(e.target as Node)
+			) return;
+			setShowInfo(false);
 		}
 		document.addEventListener("mousedown", handleClick);
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [showInfo]);
+
+	function toggleInfo() {
+		if (showInfo) { setShowInfo(false); return; }
+		if (infoBtnRef.current) {
+			const r = infoBtnRef.current.getBoundingClientRect();
+			setInfoPos({ top: r.bottom + 6, left: r.left });
+		}
+		setShowInfo(true);
+	}
 
 	// Is this a same-column reorder drag?
 	const isSameColumnDrag = isCustomColumn
@@ -216,6 +229,7 @@ function KanbanColumn({
 	const showDropHighlight = dragOver && isCrossColumnTarget;
 
 	return (
+		<>
 		<div
 			className={`group/col relative flex flex-col flex-shrink-0 w-[17.5rem] glass-column column-glow rounded-2xl border transition-colors ${
 				showDropHighlight
@@ -279,21 +293,15 @@ function KanbanColumn({
 							{label}
 						</span>
 						{description && (
-							<div ref={infoRef} className="relative flex-shrink-0">
-								<button
-									onClick={() => setShowInfo((v) => !v)}
-									className="text-fg-muted hover:text-fg-3 transition-colors w-4 h-4 flex items-center justify-center rounded-full text-[0.6rem] leading-none opacity-0 group-hover/col:opacity-100 focus:opacity-100"
-									style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-									aria-label="Column info"
-								>
-									{"\uF449"}
-								</button>
-								{showInfo && (
-									<div className="absolute top-6 left-1/2 -translate-x-1/2 z-50 w-52 px-3 py-2 rounded-lg bg-overlay border border-edge shadow-lg text-xs text-fg-2 leading-relaxed">
-										{description}
-									</div>
-								)}
-							</div>
+							<button
+								ref={infoBtnRef}
+								onClick={toggleInfo}
+								className="text-fg-muted hover:text-fg-3 transition-colors w-5 h-5 flex items-center justify-center rounded-full text-base leading-none opacity-0 group-hover/col:opacity-100 focus:opacity-100 flex-shrink-0"
+								style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+								aria-label="Column info"
+							>
+								{"\uF449"}
+							</button>
 						)}
 					</div>
 					{tasks.length > 0 && (
@@ -365,6 +373,17 @@ function KanbanColumn({
 				</div>
 			)}
 		</div>
+		{/* Info tooltip — rendered outside column div to escape stacking context */}
+		{showInfo && description && (
+			<div
+				ref={infoPopupRef}
+				className="fixed z-[9999] w-56 px-3.5 py-2.5 rounded-xl border border-edge shadow-xl text-xs text-fg leading-relaxed"
+				style={{ top: infoPos.top, left: infoPos.left, background: "rgb(var(--surface-overlay))" }}
+			>
+				{description}
+			</div>
+		)}
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary

Hey there, Claude here — the AI working on this branch.

Follow-up to #201. Fixes the column info tooltip that was trapped behind task cards due to stacking context issues:

- Render tooltip as a `fixed` div outside the column's DOM tree (via React fragment), so it escapes `glass-column`'s stacking context
- Compute position from button's `getBoundingClientRect()` on click
- Opaque background using `rgb(var(--surface-overlay))` — no more transparency bleed-through
- Larger info icon (`text-base` instead of `text-[0.6rem]`)