### PR TITLE
Fix: set remote tracking for fallback task branch

### DIFF
--- a/change-logs/2026/03/09/fix-fallback-branch-remote-tracking.md
+++ b/change-logs/2026/03/09/fix-fallback-branch-remote-tracking.md
@@ -1,0 +1,1 @@
+When creating a task from a branch that is already checked out in another worktree, the fallback task branch now automatically sets up remote tracking to the original branch's remote counterpart (if it exists). This ensures `git push` goes to the right remote branch without requiring manual `--set-upstream` configuration.

--- a/src/bun/__tests__/git.test.ts
+++ b/src/bun/__tests__/git.test.ts
@@ -904,6 +904,55 @@ describe("createWorktree", () => {
 		g("git branch -D dev3/task-aaaaaaaa", repo.local);
 	});
 
+	it("sets up remote tracking when fallback branch has a remote counterpart", async () => {
+		// Create feature/tracked, push it to origin, then check it out in another worktree
+		g("git checkout -b feature/tracked", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push origin feature/tracked", repo.local);
+		g("git checkout main", repo.local);
+		const otherWt = join(repo.dir, "other-wt-tracked");
+		g(`git worktree add "${otherWt}" feature/tracked`, repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "feature/tracked");
+
+		expect(result.branchName).toBe("dev3/task-aaaaaaaa");
+		// The fallback task branch should track origin/feature/tracked
+		const upstream = g(`git -C "${result.worktreePath}" rev-parse --abbrev-ref --symbolic-full-name @{u}`, repo.local);
+		expect(upstream.trim()).toBe("origin/feature/tracked");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+		g(`git worktree remove --force "${otherWt}"`, repo.local);
+		g("git branch -D dev3/task-aaaaaaaa", repo.local);
+	});
+
+	it("does not set remote tracking when fallback branch has no remote counterpart", async () => {
+		// Create feature/local-only but do NOT push it; check it out in another worktree
+		g("git checkout -b feature/local-only", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+		const otherWt = join(repo.dir, "other-wt-local");
+		g(`git worktree add "${otherWt}" feature/local-only`, repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const result = await createWorktree(project, task, "feature/local-only");
+
+		expect(result.branchName).toBe("dev3/task-aaaaaaaa");
+		// No upstream should be configured
+		const upstreamResult = g(`git -C "${result.worktreePath}" rev-parse --abbrev-ref --symbolic-full-name @{u} 2>&1 || true`, repo.local);
+		expect(upstreamResult).not.toContain("origin/feature/local-only");
+
+		// Cleanup
+		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+		g(`git worktree remove --force "${otherWt}"`, repo.local);
+		g("git branch -D dev3/task-aaaaaaaa", repo.local);
+	});
+
 	it("creates worktree from remote branch", async () => {
 		// Create a branch, push it, then delete the local copy
 		g("git checkout -b feature/remote-only", repo.local);

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -206,6 +206,19 @@ export async function createWorktree(
 					log.error("Failed to create worktree from existing branch (fallback)", { stderr: fallbackResult.stderr, taskId: task.id });
 					throw new Error(`Failed to create worktree: ${fallbackResult.stderr}`);
 				}
+				// Set up remote tracking so `git push` targets the original remote branch
+				const remoteRef = `origin/${resolvedBranch}`;
+				const remoteCheckResult = await run(
+					["git", "rev-parse", "--verify", remoteRef],
+					project.path,
+				);
+				if (remoteCheckResult.ok) {
+					await run(
+						["git", "branch", "--set-upstream-to", remoteRef],
+						wtPath,
+					);
+					log.info("Set remote tracking branch for fallback task branch", { taskBranch, remoteRef });
+				}
 				log.info("Worktree created with task branch based on existing", { wtPath, branch: taskBranch, base: resolvedBranch });
 				return { worktreePath: wtPath, branchName: taskBranch };
 			}


### PR DESCRIPTION
## Summary

- When a branch is already checked out in another worktree and we fall back to creating a `dev3/task-<id>` branch, now also set its upstream to `origin/<selectedBranch>` if that remote ref exists
- This means `git push` works out of the box without needing `--set-upstream`
- If the selected branch has no remote counterpart, no tracking is set (no-op, safe)

## Test plan

- [x] New test: `sets up remote tracking when fallback branch has a remote counterpart` — verifies `@{u}` is `origin/feature/tracked` after fallback
- [x] New test: `does not set remote tracking when fallback branch has no remote counterpart` — verifies no upstream configured
- [x] All 548 existing tests still pass

Suggested by @ittaiz (h0x91b/dev-3.0#189)

🤖 Generated with [Claude Code](https://claude.com/claude-code)