### PR TITLE
Fix port scanner: single lsof, resilient poller, port validation

### DIFF
--- a/src/bun/__tests__/port-scanner.test.ts
+++ b/src/bun/__tests__/port-scanner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock spawn/spawnSync before importing port-scanner
 vi.mock("../spawn", () => ({
@@ -22,7 +22,17 @@ vi.mock("../logger", () => ({
 	}),
 }));
 
-import { parseLsofOutput, getDescendantPids, getSessionPanePids, scanTaskPorts } from "../port-scanner";
+import {
+	parseLsofOutput,
+	getDescendantPids,
+	getSessionPanePids,
+	scanTaskPorts,
+	getLsofOutput,
+	collectTaskPids,
+	startPortScanPoller,
+	stopPortScanPoller,
+	getPortsForTask,
+} from "../port-scanner";
 import { spawnSync } from "../spawn";
 
 const mockSpawnSync = spawnSync as unknown as ReturnType<typeof vi.fn>;
@@ -114,6 +124,25 @@ describe("parseLsofOutput", () => {
 		const result = parseLsofOutput(output, new Set([123]));
 		expect(result.map((p) => p.port)).toEqual([3000, 5173, 8080]);
 	});
+
+	it("rejects port 0", () => {
+		const output = "p123\ncnode\nn*:0\n";
+		const result = parseLsofOutput(output, new Set([123]));
+		expect(result).toEqual([]);
+	});
+
+	it("rejects port above 65535", () => {
+		const output = "p123\ncnode\nn*:70000\n";
+		const result = parseLsofOutput(output, new Set([123]));
+		expect(result).toEqual([]);
+	});
+
+	it("accepts port 65535", () => {
+		const output = "p123\ncnode\nn*:65535\n";
+		const result = parseLsofOutput(output, new Set([123]));
+		expect(result).toHaveLength(1);
+		expect(result[0].port).toBe(65535);
+	});
 });
 
 describe("getDescendantPids", () => {
@@ -169,6 +198,55 @@ describe("getSessionPanePids", () => {
 	});
 });
 
+describe("getLsofOutput", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns lsof stdout on success", () => {
+		mockSpawnSync.mockReturnValue(makeResult("p123\ncnode\nn*:3000\n"));
+		const result = getLsofOutput();
+		expect(result).toBe("p123\ncnode\nn*:3000\n");
+	});
+
+	it("returns empty string on failure", () => {
+		mockSpawnSync.mockReturnValue(makeResult("", 1));
+		const result = getLsofOutput();
+		expect(result).toBe("");
+	});
+
+	it("returns empty string on exception", () => {
+		mockSpawnSync.mockImplementation(() => { throw new Error("boom"); });
+		const result = getLsofOutput();
+		expect(result).toBe("");
+	});
+});
+
+describe("collectTaskPids", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns pane PIDs plus descendants", () => {
+		mockSpawnSync
+			// tmux list-panes
+			.mockReturnValueOnce(makeResult("100\n"))
+			// pgrep -P 100
+			.mockReturnValueOnce(makeResult("200\n"))
+			// pgrep -P 200
+			.mockReturnValueOnce(makeResult("", 1));
+
+		const pids = collectTaskPids("dev3", "dev3-abc12345");
+		expect(pids).toEqual(new Set([100, 200]));
+	});
+
+	it("returns empty set when no pane PIDs", () => {
+		mockSpawnSync.mockReturnValue(makeResult("", 1));
+		const pids = collectTaskPids("dev3", "dev3-abc12345");
+		expect(pids.size).toBe(0);
+	});
+});
+
 describe("scanTaskPorts", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -196,5 +274,155 @@ describe("scanTaskPorts", () => {
 		expect(result).toEqual([
 			{ port: 3000, pid: 200, processName: "node" },
 		]);
+	});
+
+	it("uses pre-fetched lsof output when provided", () => {
+		mockSpawnSync
+			// tmux list-panes
+			.mockReturnValueOnce(makeResult("100\n"))
+			// pgrep -P 100
+			.mockReturnValueOnce(makeResult("", 1));
+
+		const lsofOutput = "p100\ncbun\nn*:8080\n";
+		const result = scanTaskPorts("dev3", "dev3-abc12345", lsofOutput);
+		expect(result).toEqual([
+			{ port: 8080, pid: 100, processName: "bun" },
+		]);
+		// Should NOT have called lsof (only tmux + pgrep = 2 calls)
+		expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("poller", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		stopPortScanPoller();
+	});
+
+	afterEach(() => {
+		stopPortScanPoller();
+		vi.useRealTimers();
+	});
+
+	it("pushes portsUpdated when ports change", () => {
+		const push = vi.fn();
+		const getActiveSessions = vi.fn().mockReturnValue([
+			{ taskId: "task-1234-5678-abcd", tmuxSocket: "dev3" },
+		]);
+
+		mockSpawnSync
+			// lsof (shared, called first)
+			.mockReturnValueOnce(makeResult("p100\ncnode\nn*:3000\n"))
+			// tmux list-panes for task
+			.mockReturnValueOnce(makeResult("100\n"))
+			// pgrep -P 100
+			.mockReturnValueOnce(makeResult("", 1));
+
+		startPortScanPoller(push, getActiveSessions);
+
+		// Advance past first poll interval
+		vi.advanceTimersByTime(10_000);
+
+		expect(push).toHaveBeenCalledWith("portsUpdated", {
+			taskId: "task-1234-5678-abcd",
+			ports: [{ port: 3000, pid: 100, processName: "node" }],
+		});
+	});
+
+	it("does not push when ports are unchanged", () => {
+		const push = vi.fn();
+		const getActiveSessions = vi.fn().mockReturnValue([
+			{ taskId: "task-unchanged-test", tmuxSocket: "dev3" },
+		]);
+
+		// First poll cycle (lsof first, then tmux + pgrep)
+		mockSpawnSync
+			.mockReturnValueOnce(makeResult("p500\ncnode\nn*:4000\n"))
+			.mockReturnValueOnce(makeResult("500\n"))
+			.mockReturnValueOnce(makeResult("", 1));
+
+		startPortScanPoller(push, getActiveSessions);
+		vi.advanceTimersByTime(10_000);
+		expect(push).toHaveBeenCalledTimes(1);
+
+		// Second poll cycle — same ports
+		mockSpawnSync
+			.mockReturnValueOnce(makeResult("p500\ncnode\nn*:4000\n"))
+			.mockReturnValueOnce(makeResult("500\n"))
+			.mockReturnValueOnce(makeResult("", 1));
+
+		vi.advanceTimersByTime(10_000);
+		// Should still be 1 (no second push)
+		expect(push).toHaveBeenCalledTimes(1);
+	});
+
+	it("cleans up stale cache entries when sessions disappear", () => {
+		const push = vi.fn();
+		let sessions = [
+			{ taskId: "task-aaaa", tmuxSocket: "dev3" as string | null },
+			{ taskId: "task-bbbb", tmuxSocket: "dev3" as string | null },
+		];
+		const getActiveSessions = vi.fn().mockImplementation(() => sessions);
+
+		// First poll: lsof (shared), then tmux+pgrep for each task
+		mockSpawnSync
+			// lsof (shared)
+			.mockReturnValueOnce(makeResult("p100\ncnode\nn*:3000\np200\ncbun\nn*:8080\n"))
+			// tmux pane for task-aaaa
+			.mockReturnValueOnce(makeResult("100\n"))
+			// pgrep for 100
+			.mockReturnValueOnce(makeResult("", 1))
+			// tmux pane for task-bbbb
+			.mockReturnValueOnce(makeResult("200\n"))
+			// pgrep for 200
+			.mockReturnValueOnce(makeResult("", 1));
+
+		startPortScanPoller(push, getActiveSessions);
+		vi.advanceTimersByTime(10_000);
+		expect(push).toHaveBeenCalledTimes(2);
+		expect(getPortsForTask("task-aaaa")).toHaveLength(1);
+		expect(getPortsForTask("task-bbbb")).toHaveLength(1);
+
+		// Second poll: task-bbbb is gone
+		sessions = [{ taskId: "task-aaaa", tmuxSocket: "dev3" }];
+		mockSpawnSync
+			// lsof (shared)
+			.mockReturnValueOnce(makeResult("p100\ncnode\nn*:3000\n"))
+			// tmux pane for task-aaaa
+			.mockReturnValueOnce(makeResult("100\n"))
+			// pgrep for 100
+			.mockReturnValueOnce(makeResult("", 1));
+
+		vi.advanceTimersByTime(10_000);
+		expect(getPortsForTask("task-bbbb")).toEqual([]);
+	});
+
+	it("continues polling even if getActiveSessions throws", () => {
+		const push = vi.fn();
+		const getActiveSessions = vi.fn()
+			.mockImplementationOnce(() => { throw new Error("boom"); })
+			.mockReturnValue([]);
+
+		startPortScanPoller(push, getActiveSessions);
+
+		// First poll — throws
+		vi.advanceTimersByTime(10_000);
+		expect(push).not.toHaveBeenCalled();
+
+		// Second poll — should still fire (poller survived)
+		vi.advanceTimersByTime(10_000);
+		expect(getActiveSessions).toHaveBeenCalledTimes(2);
+	});
+
+	it("stopPortScanPoller prevents further polls", () => {
+		const push = vi.fn();
+		const getActiveSessions = vi.fn().mockReturnValue([]);
+
+		startPortScanPoller(push, getActiveSessions);
+		stopPortScanPoller();
+
+		vi.advanceTimersByTime(20_000);
+		expect(getActiveSessions).not.toHaveBeenCalled();
 	});
 });

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -143,7 +143,7 @@ log.info("CLI socket server ready", { path: cliSocketPath });
 
 // Side-effect: starts the PTY WebSocket server (dynamic import so PATH is patched first)
 const { setOnPtyDied, setOnBell, setOnIdle, getActiveSessionIds } = await import("./pty-server");
-const { startPortScanPoller } = await import("./port-scanner");
+const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");
 
 const DEV_SERVER_PORT = 5173;
 const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
@@ -362,6 +362,7 @@ setOnIdle((taskId) => {
 
 mainWindow.on("close", () => {
 	log.info("Main window closing, cleaning up");
+	stopPortScanPoller();
 	stopSocketServer();
 	Utils.quit();
 });

--- a/src/bun/port-scanner.ts
+++ b/src/bun/port-scanner.ts
@@ -79,7 +79,7 @@ export function parseLsofOutput(output: string, pidSet: Set<number>): PortInfo[]
 			const colonIdx = value.lastIndexOf(":");
 			if (colonIdx < 0) continue;
 			const port = parseInt(value.slice(colonIdx + 1), 10);
-			if (isNaN(port) || seenPorts.has(port)) continue;
+			if (isNaN(port) || port < 1 || port > 65535 || seenPorts.has(port)) continue;
 			seenPorts.add(port);
 			ports.push({ port, pid: currentPid, processName: currentName });
 		}
@@ -90,29 +90,43 @@ export function parseLsofOutput(output: string, pidSet: Set<number>): PortInfo[]
 }
 
 /**
- * Scan listening TCP ports for a tmux session.
+ * Run lsof once and return raw stdout. Shared across all tasks in a poll cycle.
  */
-export function scanTaskPorts(socket: string | null, sessionName: string): PortInfo[] {
-	const panePids = getSessionPanePids(socket, sessionName);
-	if (panePids.length === 0) return [];
+export function getLsofOutput(): string {
+	try {
+		const result = spawnSync(["lsof", "-i", "-P", "-n", "-sTCP:LISTEN", "-F", "pcn"]);
+		if (result.exitCode !== 0) return "";
+		return new TextDecoder().decode(result.stdout);
+	} catch {
+		return "";
+	}
+}
 
-	// Build full PID tree
+/**
+ * Build the full PID set (pane PIDs + all descendants) for a tmux session.
+ */
+export function collectTaskPids(socket: string | null, sessionName: string): Set<number> {
+	const panePids = getSessionPanePids(socket, sessionName);
 	const allPids = new Set<number>(panePids);
 	for (const pid of panePids) {
 		for (const descendant of getDescendantPids(pid)) {
 			allPids.add(descendant);
 		}
 	}
+	return allPids;
+}
 
-	// Run lsof once for all listening TCP sockets
-	try {
-		const result = spawnSync(["lsof", "-i", "-P", "-n", "-sTCP:LISTEN", "-F", "pcn"]);
-		if (result.exitCode !== 0) return [];
-		const output = new TextDecoder().decode(result.stdout);
-		return parseLsofOutput(output, allPids);
-	} catch {
-		return [];
-	}
+/**
+ * Scan listening TCP ports for a tmux session.
+ * Optionally accepts pre-fetched lsof output to avoid redundant calls.
+ */
+export function scanTaskPorts(socket: string | null, sessionName: string, lsofOutput?: string): PortInfo[] {
+	const allPids = collectTaskPids(socket, sessionName);
+	if (allPids.size === 0) return [];
+
+	const output = lsofOutput ?? getLsofOutput();
+	if (!output) return [];
+	return parseLsofOutput(output, allPids);
 }
 
 // ── Background poller ──────────────────────────────────────────────
@@ -131,40 +145,43 @@ const portCache = new Map<string, string>();
 // Cache: taskId → PortInfo[] (actual objects)
 const portData = new Map<string, PortInfo[]>();
 
-function portsEqual(a: string | undefined, b: string): boolean {
-	return a === b;
-}
-
 function poll() {
-	if (!getActiveSessionsFn || !pushMessageFn) return;
+	try {
+		if (!getActiveSessionsFn || !pushMessageFn) return;
 
-	const sessions = getActiveSessionsFn();
-	const activeTaskIds = new Set(sessions.map((s) => s.taskId));
+		const sessions = getActiveSessionsFn();
+		const activeTaskIds = new Set(sessions.map((s) => s.taskId));
 
-	// Clean up stale cache entries
-	for (const taskId of portCache.keys()) {
-		if (!activeTaskIds.has(taskId)) {
-			portCache.delete(taskId);
-			portData.delete(taskId);
-		}
-	}
-
-	for (const { taskId, tmuxSocket } of sessions) {
-		const sessionName = `dev3-${taskId.slice(0, 8)}`;
-		try {
-			const ports = scanTaskPorts(tmuxSocket, sessionName);
-			const serialized = JSON.stringify(ports);
-			if (!portsEqual(portCache.get(taskId), serialized)) {
-				portCache.set(taskId, serialized);
-				portData.set(taskId, ports);
-				pushMessageFn("portsUpdated", { taskId, ports });
+		// Clean up stale cache entries
+		for (const taskId of portCache.keys()) {
+			if (!activeTaskIds.has(taskId)) {
+				portCache.delete(taskId);
+				portData.delete(taskId);
 			}
-		} catch (err) {
-			log.warn("Port scan failed for task", { taskId: taskId.slice(0, 8), error: String(err) });
 		}
-	}
 
-	pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+		// Run lsof once for all tasks (instead of per-task)
+		const lsofOutput = sessions.length > 0 ? getLsofOutput() : "";
+
+		for (const { taskId, tmuxSocket } of sessions) {
+			const sessionName = `dev3-${taskId.slice(0, 8)}`;
+			try {
+				const ports = scanTaskPorts(tmuxSocket, sessionName, lsofOutput);
+				const serialized = JSON.stringify(ports);
+				if (portCache.get(taskId) !== serialized) {
+					portCache.set(taskId, serialized);
+					portData.set(taskId, ports);
+					pushMessageFn!("portsUpdated", { taskId, ports });
+				}
+			} catch (err) {
+				log.warn("Port scan failed for task", { taskId: taskId.slice(0, 8), error: String(err) });
+			}
+		}
+	} catch (err) {
+		log.error("Port scan poll cycle failed", { error: String(err) });
+	} finally {
+		pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+	}
 }
 
 export function startPortScanPoller(

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -140,7 +140,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [portsPopoverOpen]);
 
-	// Ports popover: viewport clamping
+	// Ports popover: viewport clamping (only reposition on open, not on port data updates)
 	useLayoutEffect(() => {
 		if (!portsPopoverOpen || !portsPopoverRef.current || !portsAnchorRef.current) return;
 		const menu = portsPopoverRef.current.getBoundingClientRect();
@@ -156,7 +156,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		if (top < pad) top = pad;
 		setPortsPopoverPos({ top, left });
 		setPortsPopoverVisible(true);
-	}, [portsPopoverOpen, ports]);
+	}, [portsPopoverOpen]);
 
 	function toggleMenu(e: React.MouseEvent) {
 		e.stopPropagation();


### PR DESCRIPTION
## Summary

Follow-up fixes for the port scanner feature (#190):

- **Single `lsof` call per poll cycle** — previously called once per active task, now shared across all tasks in one cycle
- **Resilient poller** — wrapped `poll()` in try/catch/finally so it survives crashes in `getActiveSessionsFn()` instead of silently dying
- **Port range validation** — reject ports outside 1–65535 in `parseLsofOutput`
- **Clean shutdown** — call `stopPortScanPoller()` on window close
- **Popover flicker fix** — remove `ports` from `useLayoutEffect` deps so repositioning only fires on open
- **+14 new tests** — poller lifecycle (push on change, cache dedup, stale cleanup, crash resilience, stop), `getLsofOutput`, `collectTaskPids`, `scanTaskPorts` with pre-fetched lsof, port range edge cases