### PR TITLE
Fix Full Page toggle missing back button

### DIFF
--- a/change-logs/2026/03/10/fix-fullpage-toggle-back.md
+++ b/change-logs/2026/03/10/fix-fullpage-toggle-back.md
@@ -1,0 +1,3 @@
+Fixed the Full Page toggle button in TaskInfoPanel so it acts as a proper toggle — when already in full-page mode, clicking the button now navigates back to the split project view instead of being a dead end.
+
+Suggested by @h0x91b (h0x91b/dev-3.0#214)

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -19,6 +19,7 @@ interface TaskInfoPanelProps {
 	dispatch: Dispatch<AppAction>;
 	navigate: (route: Route) => void;
 	taskPorts?: Map<string, PortInfo[]>;
+	isFullPage?: boolean;
 }
 
 const COLLAPSED_HEIGHT_REM = 3.875; // 62px at 1× zoom – scales with root font-size
@@ -50,7 +51,7 @@ function readNumber(key: string, fallback: number): number {
 }
 
 
-function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts }: TaskInfoPanelProps) {
+function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPage }: TaskInfoPanelProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const [collapsed, setCollapsed] = useState(() => readBool(LS_COLLAPSED, true));
@@ -1239,12 +1240,18 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts }: TaskInf
 						{tmuxHintsPopover}
 						{devServerButton}
 						<button
-							onClick={() => navigate({ screen: "task", projectId: project.id, taskId: task.id })}
+							onClick={() => isFullPage
+								? navigate({ screen: "project", projectId: project.id, activeTaskId: task.id })
+								: navigate({ screen: "task", projectId: project.id, taskId: task.id })
+							}
 							className="flex-shrink-0 p-1 rounded hover:bg-elevated transition-colors text-fg-3 hover:text-fg"
-							title={t("infoPanel.fullScreen")}
+							title={isFullPage ? t("infoPanel.exitFullScreen") : t("infoPanel.fullScreen")}
 						>
 							<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" />
+								{isFullPage
+									? <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 4v4H4M16 4v4h4M8 20v-4H4M16 20v-4h4" />
+									: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" />
+								}
 							</svg>
 						</button>
 						<button
@@ -1308,12 +1315,18 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts }: TaskInf
 							{tmuxHintsPopover}
 							{devServerButton}
 							<button
-								onClick={() => navigate({ screen: "task", projectId: project.id, taskId: task.id })}
+								onClick={() => isFullPage
+									? navigate({ screen: "project", projectId: project.id, activeTaskId: task.id })
+									: navigate({ screen: "task", projectId: project.id, taskId: task.id })
+								}
 								className="flex-shrink-0 p-1 rounded hover:bg-elevated transition-colors text-fg-3 hover:text-fg"
-								title={t("infoPanel.fullScreen")}
+								title={isFullPage ? t("infoPanel.exitFullScreen") : t("infoPanel.fullScreen")}
 							>
 								<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" />
+									{isFullPage
+										? <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 4v4H4M16 4v4h4M8 20v-4H4M16 20v-4h4" />
+										: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" />
+									}
 								</svg>
 							</button>
 							<button

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -171,7 +171,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 
 	return (
 		<div className="h-full w-full flex flex-col overflow-hidden">
-			{!hideInfoPanel && task && project && <TaskInfoPanel task={task} project={project} dispatch={dispatch} navigate={navigate} />}
+			{!hideInfoPanel && task && project && <TaskInfoPanel task={task} project={project} dispatch={dispatch} navigate={navigate} isFullPage />}
 			<div className="flex-1 min-h-0 overflow-hidden">
 				{ptyUrl ? (
 					<TerminalView ptyUrl={ptyUrl} taskId={taskId} projectId={projectId} />

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -98,6 +98,7 @@ function renderPanel(
 		dispatch?: React.Dispatch<AppAction>;
 		navigate?: (route: Route) => void;
 		project?: Project;
+		isFullPage?: boolean;
 	},
 ) {
 	const dispatch = opts?.dispatch ?? vi.fn();
@@ -109,6 +110,7 @@ function renderPanel(
 				project={opts?.project ?? project}
 				dispatch={dispatch}
 				navigate={navigate}
+				isFullPage={opts?.isFullPage}
 			/>
 		</I18nProvider>,
 	);
@@ -1075,6 +1077,22 @@ describe("TaskInfoPanel", () => {
 				screen: "task",
 				projectId: "p1",
 				taskId: "t1",
+			});
+		});
+
+		it("navigates back to project when in full page mode", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const navigate = vi.fn();
+			await act(async () => {
+				renderPanel(makeTask(), { navigate, isFullPage: true });
+			});
+
+			await user.click(screen.getByTitle("Exit full screen"));
+
+			expect(navigate).toHaveBeenCalledWith({
+				screen: "project",
+				projectId: "p1",
+				activeTaskId: "t1",
 			});
 		});
 	});

--- a/src/mainview/i18n/translations/en.ts
+++ b/src/mainview/i18n/translations/en.ts
@@ -251,6 +251,7 @@ const en = {
 	"infoPanel.collapse": "Collapse panel",
 	"infoPanel.expand": "Expand panel",
 	"infoPanel.fullScreen": "Full screen",
+	"infoPanel.exitFullScreen": "Exit full screen",
 	"infoPanel.commitsBehind": "{count} commits behind",
 	"infoPanel.commitsAhead": "{count} commits ahead",
 	"infoPanel.commitsAheadBehind": "{ahead} ahead · {behind} behind",

--- a/src/mainview/i18n/translations/es.ts
+++ b/src/mainview/i18n/translations/es.ts
@@ -254,6 +254,7 @@ const es: TranslationRecord & Record<string, string> = {
 	"infoPanel.collapse": "Contraer panel",
 	"infoPanel.expand": "Expandir panel",
 	"infoPanel.fullScreen": "Pantalla completa",
+	"infoPanel.exitFullScreen": "Salir de pantalla completa",
 	"infoPanel.commitsBehind": "{count} commits atrás",
 	"infoPanel.commitsAhead": "{count} commits adelante",
 	"infoPanel.commitsAheadBehind": "{ahead} adelante · {behind} atrás",

--- a/src/mainview/i18n/translations/ru.ts
+++ b/src/mainview/i18n/translations/ru.ts
@@ -259,6 +259,7 @@ const ru: TranslationRecord & Record<string, string> = {
 	"infoPanel.collapse": "Свернуть панель",
 	"infoPanel.expand": "Развернуть панель",
 	"infoPanel.fullScreen": "На весь экран",
+	"infoPanel.exitFullScreen": "Выйти из полного экрана",
 	"infoPanel.commitsBehind": "{count} коммитов позади",
 	"infoPanel.commitsAhead": "{count} коммитов впереди",
 	"infoPanel.commitsAheadBehind": "{ahead} впереди · {behind} позади",


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI fixing this one.

- The Full Screen button in the task info panel now works as a proper toggle: clicking it in full-page mode navigates back to the split project view with the task still active
- Added `isFullPage` prop to `TaskInfoPanel`, a minimize icon for the exit state, and `exitFullScreen` i18n keys for EN/RU/ES
- Includes a regression test for the new back-navigation behavior

Closes #214