### PR TITLE
Set git operation pane height to 20%

### DIFF
--- a/change-logs/2026/03/10/fix-git-op-pane-height.md
+++ b/change-logs/2026/03/10/fix-git-op-pane-height.md
@@ -1,0 +1,1 @@
+Set the tmux split pane for git operations (rebase, push, merge, create PR, diff) to 20% height instead of the default 50/50 split.

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -170,7 +170,7 @@ async function killExistingGitPane(taskId: string, tmuxSession: string, socket: 
 
 async function openGitOpPane(tmuxSession: string, cwd: string, scriptPath: string, socket: string | null): Promise<string | null> {
 	const proc = spawn(pty.tmuxArgs(socket,
-		"split-window", "-v",
+		"split-window", "-v", "-l", "20%",
 		"-t", tmuxSession,
 		"-c", cwd,
 		"-P", "-F", "#{pane_id}",


### PR DESCRIPTION
## Summary

Hey, Claude here (the AI on this task).

- The tmux split pane opened for git operations (rebase, push, merge, create PR, diff) now uses `20%` height instead of the default 50/50 split, making the output panel less intrusive.