### PR TITLE
Improve custom column UX: add labels and visible input styling

### DIFF
--- a/change-logs/2026/03/10/fix-custom-column-ux.md
+++ b/change-logs/2026/03/10/fix-custom-column-ux.md
@@ -1,0 +1,3 @@
+Improved custom column UX in project settings: the column name field now has a visible border and background so it looks like an actual input, and both fields ("Column name" and "LLM instruction") now have clear labels above them. This prevents users from confusing the name input with the LLM instruction textarea.
+
+Suggested by @h0x91b (h0x91b/dev-3.0#230)

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -111,50 +111,56 @@ function CustomColumnRow({ column, saving, onUpdate, onDelete }: CustomColumnRow
 	return (
 		<div className="p-3 bg-raised rounded-xl border border-edge space-y-2.5">
 			{/* Name + color + delete */}
-			<div className="flex items-center gap-2">
-				<div
-					className="w-4 h-4 rounded-full flex-shrink-0 border border-edge-active"
-					style={{ background: color }}
-				/>
-				<input
-					type="text"
-					value={name}
-					onChange={(e) => setName(e.target.value)}
-					onBlur={() => commitUpdate()}
-					onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
-					aria-label={t("customColumns.columnName")}
-					placeholder={t("customColumns.columnName")}
-					disabled={saving}
-					className="flex-1 bg-transparent text-fg text-sm outline-none placeholder-fg-muted min-w-0"
-				/>
-				{/* Color palette */}
-				<div className="flex items-center gap-1 flex-shrink-0">
-					{LABEL_COLORS.map((c) => (
-						<button
-							key={c}
-							type="button"
-							onClick={() => { setColor(c); commitUpdate(name, c, llmInstruction); }}
-							disabled={saving}
-							className={`w-3.5 h-3.5 rounded-full transition-transform hover:scale-125 ${c === color ? "ring-2 ring-offset-1 ring-fg/30" : ""}`}
-							style={{ background: c }}
-							title={c}
-						/>
-					))}
+			<div>
+				<div className="flex items-center justify-between mb-1">
+					<label className="text-fg-3 text-xs">{t("customColumns.columnName")}</label>
+					<button
+						type="button"
+						onClick={onDelete}
+						disabled={saving}
+						className="w-5 h-5 flex items-center justify-center rounded text-fg-3 hover:text-danger hover:bg-danger/10 transition-colors"
+						title={t("customColumns.deleteColumn")}
+					>
+						<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+							<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
 				</div>
-				<button
-					type="button"
-					onClick={onDelete}
-					disabled={saving}
-					className="ml-1 w-6 h-6 flex items-center justify-center rounded-lg text-fg-3 hover:text-danger hover:bg-danger/10 transition-colors flex-shrink-0"
-					title={t("customColumns.deleteColumn")}
-				>
-					<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
-						<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-					</svg>
-				</button>
+				<div className="flex items-center gap-2">
+					<div
+						className="w-3.5 h-3.5 rounded-full flex-shrink-0"
+						style={{ background: color }}
+					/>
+					<input
+						type="text"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						onBlur={() => commitUpdate()}
+						onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
+						aria-label={t("customColumns.columnName")}
+						placeholder={t("customColumns.columnName")}
+						disabled={saving}
+						className="flex-1 px-3 py-1.5 bg-elevated border border-edge rounded-lg text-fg text-sm placeholder-fg-muted outline-none focus:border-accent/40 transition-colors min-w-0"
+					/>
+					{/* Color palette */}
+					<div className="flex items-center gap-1 flex-shrink-0">
+						{LABEL_COLORS.map((c) => (
+							<button
+								key={c}
+								type="button"
+								onClick={() => { setColor(c); commitUpdate(name, c, llmInstruction); }}
+								disabled={saving}
+								className={`w-3.5 h-3.5 rounded-full transition-transform hover:scale-125 ${c === color ? "ring-2 ring-offset-1 ring-fg/30" : ""}`}
+								style={{ background: c }}
+								title={c}
+							/>
+						))}
+					</div>
+				</div>
 			</div>
 			{/* LLM instruction */}
 			<div>
+				<label className="block text-fg-3 text-xs mb-1">{t("customColumns.llmInstruction")}</label>
 				<textarea
 					value={llmInstruction}
 					onChange={(e) => setLlmInstruction(e.target.value)}


### PR DESCRIPTION
## Summary

- Add **"Column name"** label above the name input so users know what to type there
- Make the name input look like an actual input field (border + background), instead of plain transparent text
- Add **"LLM instruction (when to move here)"** label above the textarea
- Move delete button to the top-right of the card for a cleaner layout

## Before / After

**Before:** The column name field had no border or background — it looked like plain text. The only field that visually looked like an input was the LLM instruction textarea, causing users to type the column name there.

**After:**

![Custom column UX improved](<img width="1336" height="802" alt="image" src="https://github.com/user-attachments/assets/b2421ced-ab63-4e95-b501-fd8ae7606925" />)

Fixes #230

## Test plan
- [x] Open Project Settings → Custom Columns
- [x] Verify "Column name" label appears above the name input
- [x] Verify name input has a visible border/background
- [x] Verify "LLM instruction (when to move here)" label appears above the textarea
- [x] Verify editing column name and LLM instruction still saves correctly on blur/Enter

🤖 Generated with [Claude Code](https://claude.com/claude-code)