### PR TITLE
Use conventional branch prefixes instead of dev3/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,12 +34,16 @@ Agents in this project typically run inside a **git worktree**, not the main wor
 
 ### Branch naming
 
-Worktree branches are auto-generated with opaque names like `dev3/task-8711d3e1`. Once you understand what the task is about, **rename the branch automatically** to something descriptive using `git branch -m <old> dev3/<slug>`. Do not ask for permission — just do it on session start.
+Worktree branches are auto-generated with opaque names like `dev3/task-8711d3e1`. Once you understand what the task is about, **rename the branch automatically** to something descriptive using `git branch -m <old> <type>/<slug>`. Do not ask for permission — just do it on session start.
 
-**Rules:**
-- Always keep the `dev3/` prefix.
-- Use lowercase kebab-case: `dev3/fix-auth-race-condition`, `dev3/add-drag-reorder`, `dev3/refactor-rpc-handlers`.
+> **User preferences override these defaults.** If the user's CLAUDE.md, AGENTS.md, or auto-memory specifies a different branch naming convention (e.g., JIRA ticket prefix, custom format), follow the user's convention instead of the defaults below.
+
+**Default rules** (apply only when the user has no custom branch naming preference):
+- Use a conventional type prefix: `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`.
+- Use lowercase kebab-case: `fix/auth-race-condition`, `feat/drag-reorder`, `refactor/rpc-handlers`.
 - Derive the slug from the task description/title — 3-5 words max.
+
+**Always applies:**
 - If the branch already has a meaningful name (doesn't match `dev3/task-*`), skip renaming.
 - If the branch was already pushed to the remote, also update the remote: `git push origin :<old-branch> && git push -u origin <new-branch>`.
 

--- a/change-logs/2026/03/10/fix-branch-naming-override.md
+++ b/change-logs/2026/03/10/fix-branch-naming-override.md
@@ -1,0 +1,3 @@
+Branch naming convention changed from hardcoded `dev3/` prefix to standard type prefixes (`feat/`, `fix/`, `chore/`, `refactor/`, `docs/`). User preferences from CLAUDE.md, AGENTS.md, or auto-memory now explicitly override these defaults. Worktree cleanup logic updated to track branches by original task name rather than live prefix, so renamed branches are still cleaned up correctly.
+
+Suggested by @AboMokh-Wix (h0x91b/dev-3.0#232)

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -19,13 +19,19 @@ After learning your current task, check if the branch matches \`dev3/task-*\` (o
 If it does, **rename it immediately** to something meaningful based on the task description:
 
 \`\`\`bash
-git branch -m dev3/task-XXXXXXXX dev3/<slug>
+git branch -m dev3/task-XXXXXXXX <type>/<slug>
 \`\`\`
 
-**Rules:**
-- Always keep the \`dev3/\` prefix.
-- Use lowercase kebab-case, 3-5 words: \`dev3/fix-auth-race-condition\`, \`dev3/add-drag-reorder\`.
+> **User preferences override these defaults.** If the user's CLAUDE.md, AGENTS.md, or auto-memory
+> specifies a different branch naming convention (e.g., JIRA ticket prefix, custom format),
+> follow the user's convention instead of the defaults below.
+
+**Default rules** (apply only when the user has no custom branch naming preference):
+- Use a conventional type prefix: \`feat/\`, \`fix/\`, \`chore/\`, \`refactor/\`, \`docs/\`.
+- Use lowercase kebab-case, 3-5 words: \`fix/auth-race-condition\`, \`feat/drag-reorder\`, \`refactor/rpc-handlers\`.
 - Derive the slug from the task description/title — be concise but descriptive.
+
+**Always applies:**
 - If the branch already has a meaningful name (does NOT match \`dev3/task-*\`), skip renaming.
 - If the branch was already pushed, also update the remote: \`git push origin :<old> && git push -u origin <new>\`.
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -669,9 +669,11 @@ export async function removeWorktree(
 	);
 
 	if (branchToDelete) {
-		// Only delete branches that dev3 created (dev3/* prefix).
-		// User-owned branches (e.g. feature/login chosen via branch selector) should be preserved.
-		const isDevBranch = branchToDelete.startsWith("dev3/");
+		// Delete branches that dev3 created. We check task.branchName (the original name
+		// assigned at worktree creation) rather than the live branch name, because agents
+		// may rename branches to conventional prefixes (feat/, fix/, etc.).
+		// A task.branchName starting with "dev3/task-" means dev3 created it.
+		const isDevBranch = task.branchName?.startsWith("dev3/task-") || branchToDelete.startsWith("dev3/");
 		const isVariantBranch = task.existingBranch && branchToDelete !== task.existingBranch.replace(/^origin\//, "")
 			&& branchToDelete.startsWith(task.existingBranch.replace(/^origin\//, ""));
 		if (isDevBranch || isVariantBranch) {


### PR DESCRIPTION
## Summary

- Replace hardcoded `dev3/` branch prefix with standard conventional type prefixes (`feat/`, `fix/`, `chore/`, `refactor/`, `docs/`) as the default naming convention
- User preferences from CLAUDE.md, AGENTS.md, or auto-memory now explicitly override these defaults
- Update worktree cleanup logic to track branches by original task name (`dev3/task-*`) rather than live branch prefix, so renamed branches still get cleaned up correctly

Closes #232

Hey, Claude here — the AI behind this PR.