### PR TITLE
Fix: show custom columns in status move-to dropdowns

### DIFF
--- a/change-logs/2026/03/11/fix-custom-columns-in-dropdowns.md
+++ b/change-logs/2026/03/11/fix-custom-columns-in-dropdowns.md
@@ -1,0 +1,1 @@
+Custom columns defined in Project Settings now appear in all "Move to" status dropdowns (task card, task info panel, and task detail modal). Previously they were only reachable via drag-and-drop on the Kanban board.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -236,6 +236,24 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		}
 	}
 
+	async function handleMoveToCustomColumn(customColumnId: string) {
+		setMenuOpen(false);
+		setMoving(true);
+		try {
+			const updated = await api.request.moveTaskToCustomColumn({
+				taskId: task.id,
+				projectId: project.id,
+				customColumnId,
+			});
+			dispatch({ type: "updateTask", task: updated });
+			onTaskMoved(task.id);
+			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}` });
+		} catch (err) {
+			alert(t("task.failedMove", { error: String(err) }));
+		}
+		setMoving(false);
+	}
+
 	async function handleDelete() {
 		setMenuOpen(false);
 		const confirmed = await api.request.showConfirm({
@@ -637,6 +655,26 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 							{t(statusKey(s))}
 						</button>
 					))}
+					{project.customColumns && project.customColumns.length > 0 && (
+						<>
+							<div className="border-t border-edge-active mt-1.5 pt-1.5" />
+							{project.customColumns
+								.filter((col) => col.id !== task.customColumnId)
+								.map((col) => (
+									<button
+										key={col.id}
+										onClick={() => handleMoveToCustomColumn(col.id)}
+										className="w-full text-left px-3 py-2 text-sm text-fg-2 hover:bg-elevated-hover hover:text-fg flex items-center gap-2.5 transition-colors"
+									>
+										<div
+											className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+											style={{ background: col.color }}
+										/>
+										{col.name}
+									</button>
+								))}
+						</>
+					)}
 					{isCancelled && (
 						<div className="border-t border-edge-active mt-1.5 pt-1.5">
 							<button

--- a/src/mainview/components/TaskDetailModal.tsx
+++ b/src/mainview/components/TaskDetailModal.tsx
@@ -147,6 +147,24 @@ function TaskDetailModal({ task, project, dispatch, onClose }: TaskDetailModalPr
 		}
 	}
 
+	async function handleMoveToCustomColumn(customColumnId: string) {
+		setMovingStatus(true);
+		setStatusMenuOpen(false);
+		try {
+			const updated = await api.request.moveTaskToCustomColumn({
+				taskId: task.id,
+				projectId: project.id,
+				customColumnId,
+			});
+			dispatch({ type: "updateTask", task: updated });
+			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}` });
+			onClose();
+		} catch (err) {
+			alert(t("task.failedMove", { error: String(err) }));
+		}
+		setMovingStatus(false);
+	}
+
 	async function handleStatusMove(newStatus: TaskStatus) {
 		setMovingStatus(true);
 		setStatusMenuOpen(false);
@@ -233,6 +251,7 @@ function TaskDetailModal({ task, project, dispatch, onClose }: TaskDetailModalPr
 			setStatusMenuOpen={setStatusMenuOpen}
 			movingStatus={movingStatus}
 			onStatusMove={handleStatusMove}
+			onMoveToCustomColumn={handleMoveToCustomColumn}
 			onAddNote={handleAddNote}
 			onUpdateNote={handleUpdateNote}
 			onDeleteNote={handleDeleteNote}
@@ -411,6 +430,7 @@ interface ArchivedViewProps {
 	setStatusMenuOpen: (open: boolean) => void;
 	movingStatus: boolean;
 	onStatusMove: (status: TaskStatus) => void;
+	onMoveToCustomColumn: (customColumnId: string) => void;
 	onAddNote: () => void;
 	onUpdateNote: (noteId: string, content: string) => void;
 	onDeleteNote: (noteId: string) => void;
@@ -420,7 +440,7 @@ interface ArchivedViewProps {
 function ArchivedView({
 	task, project, color,
 	statusMenuOpen, setStatusMenuOpen,
-	movingStatus, onStatusMove,
+	movingStatus, onStatusMove, onMoveToCustomColumn,
 	onAddNote, onUpdateNote, onDeleteNote,
 	onClose,
 }: ArchivedViewProps) {
@@ -496,6 +516,26 @@ function ArchivedView({
 											{t(statusKey(s))}
 										</button>
 									))}
+									{project.customColumns && project.customColumns.length > 0 && (
+										<>
+											<div className="border-t border-edge-active mt-1.5 pt-1.5" />
+											{project.customColumns
+												.filter((col) => col.id !== task.customColumnId)
+												.map((col) => (
+													<button
+														key={col.id}
+														onClick={() => onMoveToCustomColumn(col.id)}
+														className="w-full text-left px-3 py-2 text-sm text-fg-2 hover:bg-elevated-hover hover:text-fg flex items-center gap-2.5 transition-colors"
+													>
+														<div
+															className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+															style={{ background: col.color }}
+														/>
+														{col.name}
+													</button>
+												))}
+										</>
+									)}
 								</div>
 							)}
 						</div>

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -189,6 +189,23 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 		setMovingStatus(false);
 	}
 
+	async function handleMoveToCustomColumn(customColumnId: string) {
+		setMovingStatus(true);
+		setStatusMenuOpen(false);
+		try {
+			const updated = await api.request.moveTaskToCustomColumn({
+				taskId: task.id,
+				projectId: project.id,
+				customColumnId,
+			});
+			dispatch({ type: "updateTask", task: updated });
+			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}` });
+		} catch (err) {
+			alert(t("task.failedMove", { error: String(err) }));
+		}
+		setMovingStatus(false);
+	}
+
 	// ---- Tmux hints popover state ----
 	const [hintsOpen, setHintsOpen] = useState(false);
 	const [hintsPos, setHintsPos] = useState({ top: 0, left: 0 });
@@ -671,6 +688,26 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 					{t(statusKey(s))}
 				</button>
 			))}
+			{project.customColumns && project.customColumns.length > 0 && (
+				<>
+					<div className="border-t border-edge-active mt-1.5 pt-1.5" />
+					{project.customColumns
+						.filter((col) => col.id !== task.customColumnId)
+						.map((col) => (
+							<button
+								key={col.id}
+								onClick={() => handleMoveToCustomColumn(col.id)}
+								className="w-full text-left px-3 py-2 text-sm text-fg-2 hover:bg-elevated-hover hover:text-fg flex items-center gap-2.5 transition-colors"
+							>
+								<div
+									className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+									style={{ background: col.color }}
+								/>
+								{col.name}
+							</button>
+						))}
+				</>
+			)}
 		</div>,
 		document.body,
 	);

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -9,6 +9,7 @@ vi.mock("../../rpc", () => ({
 	api: {
 		request: {
 			moveTask: vi.fn(),
+			moveTaskToCustomColumn: vi.fn(),
 			deleteTask: vi.fn(),
 			showConfirm: vi.fn(),
 			setTaskLabels: vi.fn(),
@@ -1026,6 +1027,74 @@ describe("TaskCard", () => {
 					path: "/tmp/worktree",
 				});
 			});
+		});
+	});
+
+	describe("custom columns in status dropdown", () => {
+		const projectWithCustomColumns: Project = {
+			...project,
+			customColumns: [
+				{ id: "col-1", name: "On Hold", color: "#f59e0b", llmInstruction: "When waiting" },
+				{ id: "col-2", name: "Blocked", color: "#ef4444", llmInstruction: "When blocked" },
+			],
+		};
+
+		it("shows custom columns in the move-to dropdown", async () => {
+			const user = userEvent.setup();
+			renderCard(
+				makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }),
+				{ projectOverride: projectWithCustomColumns },
+			);
+
+			await user.click(screen.getByText("Agent is Working"));
+
+			await waitFor(() => {
+				expect(screen.getByText("On Hold")).toBeInTheDocument();
+				expect(screen.getByText("Blocked")).toBeInTheDocument();
+			});
+		});
+
+		it("calls moveTaskToCustomColumn when clicking a custom column", async () => {
+			const user = userEvent.setup();
+			const updatedTask = makeTask({ status: "in-progress", customColumnId: "col-1" });
+			mockedApi.request.moveTaskToCustomColumn.mockResolvedValueOnce(updatedTask);
+			const dispatch = vi.fn();
+
+			renderCard(
+				makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }),
+				{ projectOverride: projectWithCustomColumns, dispatch },
+			);
+
+			await user.click(screen.getByText("Agent is Working"));
+
+			await waitFor(() => {
+				expect(screen.getByText("On Hold")).toBeInTheDocument();
+			});
+
+			await user.click(screen.getByText("On Hold"));
+
+			await waitFor(() => {
+				expect(mockedApi.request.moveTaskToCustomColumn).toHaveBeenCalledWith({
+					taskId: "t1",
+					projectId: "p1",
+					customColumnId: "col-1",
+				});
+			});
+		});
+
+		it("excludes the current custom column from the dropdown", async () => {
+			const user = userEvent.setup();
+			renderCard(
+				makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test", customColumnId: "col-1" }),
+				{ projectOverride: projectWithCustomColumns },
+			);
+
+			await user.click(screen.getByText("Agent is Working"));
+
+			await waitFor(() => {
+				expect(screen.getByText("Blocked")).toBeInTheDocument();
+			});
+			expect(screen.queryByText("On Hold")).not.toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Custom columns from Project Settings now appear in all "Move to" status dropdowns (TaskCard, TaskInfoPanel, TaskDetailModal)
- Previously custom columns were only reachable via drag-and-drop on the Kanban board
- The current custom column is excluded from the list to prevent no-op moves
- Added tests covering custom column rendering, click handling, and filtering

Closes #253

Hey, Claude here — the AI assistant working on this branch.