### PR TITLE
Add missing test: dev3 branch renamed to conventional prefix is deleted on cleanup

### DIFF
--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -122,6 +122,28 @@ describe("removeWorktree", () => {
 		expect(branches).not.toContain("dev3/task-aaaaaaaa");
 	});
 
+	it("removes worktree and deletes branch renamed to conventional prefix (feat/, fix/, etc.)", async () => {
+		const wtPath = join(repo.dir, "worktree");
+		g(`git worktree add -b dev3/task-aaaaaaaa "${wtPath}" main`, repo.local);
+
+		// Agent renames to conventional prefix — no longer starts with dev3/
+		g("git branch -m dev3/task-aaaaaaaa feat/fix-login", wtPath);
+
+		const project = makeProject(repo.local);
+		const task = makeTask({
+			worktreePath: wtPath,
+			branchName: "dev3/task-aaaaaaaa", // original name stored at worktree creation
+		});
+
+		await removeWorktree(project, task);
+
+		expect(existsSync(wtPath)).toBe(false);
+		// The conventionally-prefixed branch should be deleted (dev3 created it)
+		const branches = g("git branch", repo.local);
+		expect(branches).not.toContain("feat/fix-login");
+		expect(branches).not.toContain("dev3/task-aaaaaaaa");
+	});
+
 	it("preserves user-owned branch (non-dev3) on removal", async () => {
 		const wtPath = join(repo.dir, "worktree");
 		g(`git worktree add -b feature/login "${wtPath}" main`, repo.local);


### PR DESCRIPTION
## Summary

- Adds a test case that was missing from PR #244: when an agent renames a `dev3/task-xxx` branch to a conventional prefix (`feat/fix-login`, `fix/auth-bug`, etc.), the renamed branch should still be deleted when the worktree is removed.
- The existing rename test only covered renaming within `dev3/` (e.g. `dev3/task-xxx` → `dev3/fix-critical-bug`), not to non-`dev3/` prefixes — which is the exact scenario PR #244 was meant to fix.

## Test plan

- [x] `bun run test:bun` — new test passes (`git.test.ts` 73 tests)
- [x] No regressions in existing `removeWorktree` test suite (all 5 cases covered and green)