### PR TITLE
Add cross-project Activity tab to dashboard

### DIFF
--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -992,6 +992,21 @@ export const handlers = {
 		return tasks;
 	},
 
+	async getAllProjectTasks(): Promise<{ projectId: string; tasks: Task[] }[]> {
+		log.info("→ getAllProjectTasks");
+		const projects = await data.loadProjects();
+		const results = await Promise.all(
+			projects.map(async (project) => {
+				const tasks = await data.loadTasks(project);
+				const active = tasks.filter((t) => ACTIVE_STATUSES.includes(t.status));
+				return { projectId: project.id, tasks: active };
+			}),
+		);
+		const totalActive = results.reduce((sum, r) => sum + r.tasks.length, 0);
+		log.info(`← getAllProjectTasks: ${totalActive} active task(s) across ${projects.length} project(s)`);
+		return results;
+	},
+
 	async createTask(params: {
 		projectId: string;
 		description: string;

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -457,6 +457,7 @@ function App() {
 						projects={state.projects}
 						dispatch={dispatch}
 						navigate={navigate}
+						bellCounts={state.bellCounts}
 					/>
 				);
 			case "project":

--- a/src/mainview/components/ActivityOverview.tsx
+++ b/src/mainview/components/ActivityOverview.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Project, Task, TaskStatus } from "../../shared/types";
+import { getTaskTitle } from "../../shared/types";
+import type { Route } from "../state";
+import { api } from "../rpc";
+import { useT, statusKey } from "../i18n";
+import { useStatusColors } from "../hooks/useStatusColors";
+
+interface ActivityOverviewProps {
+	projects: Project[];
+	navigate: (route: Route) => void;
+	bellCounts: Map<string, number>;
+}
+
+/** Statuses that require the user's attention — shown as individual task rows. */
+const ATTENTION_STATUSES: TaskStatus[] = ["user-questions", "review-by-user"];
+
+/** Statuses that are "background work" — collapsed into a summary line. */
+const BACKGROUND_STATUSES: TaskStatus[] = ["in-progress", "review-by-ai", "review-by-colleague"];
+
+function timeAgo(isoDate: string | undefined, t: (key: any, vars?: any) => string): string {
+	if (!isoDate) return "";
+	const diff = Date.now() - new Date(isoDate).getTime();
+	const mins = Math.floor(diff / 60_000);
+	if (mins < 1) return t("activity.justNow");
+	if (mins < 60) return t("activity.minutesAgo", { count: String(mins) });
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return t("activity.hoursAgo", { count: String(hours) });
+	const days = Math.floor(hours / 24);
+	return t("activity.daysAgo", { count: String(days) });
+}
+
+function ActivityOverview({ projects, navigate, bellCounts }: ActivityOverviewProps) {
+	const t = useT();
+	const statusColors = useStatusColors();
+	const [tasksByProject, setTasksByProject] = useState<Map<string, Task[]>>(new Map());
+	const [loading, setLoading] = useState(true);
+
+	const fetchAllTasks = useCallback(async () => {
+		try {
+			const results = await api.request.getAllProjectTasks();
+			const map = new Map<string, Task[]>();
+			for (const { projectId, tasks } of results) {
+				map.set(projectId, tasks);
+			}
+			setTasksByProject(map);
+		} catch (err) {
+			console.error("Failed to load all project tasks:", err);
+		}
+		setLoading(false);
+	}, []);
+
+	useEffect(() => {
+		fetchAllTasks();
+	}, [fetchAllTasks]);
+
+	// Stay live: update when tasks change across any project
+	useEffect(() => {
+		function onTaskUpdated(e: Event) {
+			const { task } = (e as CustomEvent).detail as { task: Task };
+			setTasksByProject((prev) => {
+				const next = new Map(prev);
+				const projectTasks = [...(next.get(task.projectId) ?? [])];
+				const idx = projectTasks.findIndex((t) => t.id === task.id);
+				const isActive = ["in-progress", "user-questions", "review-by-ai", "review-by-user", "review-by-colleague"].includes(task.status);
+				if (isActive) {
+					if (idx >= 0) {
+						projectTasks[idx] = task;
+					} else {
+						projectTasks.push(task);
+					}
+				} else if (idx >= 0) {
+					projectTasks.splice(idx, 1);
+				}
+				next.set(task.projectId, projectTasks);
+				return next;
+			});
+		}
+		window.addEventListener("rpc:taskUpdated", onTaskUpdated);
+		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
+	}, []);
+
+	if (loading) {
+		return (
+			<div className="h-full flex items-center justify-center">
+				<div className="w-2 h-2 rounded-full bg-accent animate-pulse" />
+			</div>
+		);
+	}
+
+	const sortedProjects = projects
+		.filter((p) => !p.deleted)
+		.sort((a, b) => {
+			const aCount = tasksByProject.get(a.id)?.length ?? 0;
+			const bCount = tasksByProject.get(b.id)?.length ?? 0;
+			// Projects with active tasks first, then by count descending
+			if (aCount === 0 && bCount > 0) return 1;
+			if (aCount > 0 && bCount === 0) return -1;
+			return bCount - aCount;
+		});
+	const totalActive = Array.from(tasksByProject.values()).reduce((sum, tasks) => sum + tasks.length, 0);
+
+	if (totalActive === 0) {
+		return (
+			<div className="h-full flex flex-col items-center justify-center">
+				<p className="text-fg-3 text-sm">{t("activity.noActiveTasks")}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="h-full overflow-y-auto p-7">
+			<div className="max-w-3xl mx-auto space-y-4">
+				{sortedProjects.map((project) => {
+					const tasks = tasksByProject.get(project.id) ?? [];
+					const hasActiveTasks = tasks.length > 0;
+
+					// Split into attention tasks (shown individually) and background tasks (summarized)
+					const attentionTasks = tasks.filter((t) => ATTENTION_STATUSES.includes(t.status));
+					const backgroundTasks = tasks.filter((t) => BACKGROUND_STATUSES.includes(t.status));
+
+					// Build summary segments: "3 in-progress · 2 AI review"
+					const summarySegments: { status: TaskStatus; count: number }[] = [];
+					for (const status of BACKGROUND_STATUSES) {
+						const count = backgroundTasks.filter((t) => t.status === status).length;
+						if (count > 0) {
+							summarySegments.push({ status, count });
+						}
+					}
+
+					return (
+						<div key={project.id} className="bg-raised rounded-2xl border border-edge overflow-hidden">
+							{/* Project header */}
+							<button
+								onClick={() => navigate({ screen: "project", projectId: project.id })}
+								className={`w-full flex items-center gap-3 px-5 ${hasActiveTasks ? "py-3" : "py-2.5"} hover:bg-raised-hover transition-colors text-left`}
+							>
+								<div className={`${hasActiveTasks ? "w-8 h-8" : "w-6 h-6"} rounded-lg bg-accent/15 flex items-center justify-center flex-shrink-0`}>
+									<svg className={`${hasActiveTasks ? "w-4 h-4" : "w-3 h-3"} text-accent`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+									</svg>
+								</div>
+								<span className={`${hasActiveTasks ? "text-fg font-semibold" : "text-fg-3"} text-sm truncate flex-1`}>{project.name}</span>
+								{hasActiveTasks ? (
+									<span className="text-fg-3 text-xs">{t.plural("activity.taskCount", tasks.length)}</span>
+								) : (
+									<span className="text-fg-muted text-xs">{t("activity.noActiveInProject")}</span>
+								)}
+								<svg className="w-4 h-4 text-fg-muted flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+								</svg>
+							</button>
+
+							{hasActiveTasks && (
+								<div className="border-t border-edge">
+									{/* Attention tasks — shown individually */}
+									{attentionTasks.map((task) => (
+										<button
+											key={task.id}
+											onClick={() => navigate({ screen: "project", projectId: project.id, activeTaskId: task.id })}
+											className="w-full flex items-center gap-3 px-5 py-2.5 hover:bg-raised-hover transition-colors text-left border-b border-edge last:border-b-0"
+										>
+											<span
+												className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+												style={{ backgroundColor: statusColors[task.status] }}
+												title={t(statusKey(task.status))}
+											/>
+											<span className="text-fg-2 text-sm truncate flex-1">
+												{getTaskTitle(task)}
+											</span>
+											{bellCounts.has(task.id) && (
+												<span className="w-2 h-2 rounded-full bg-accent animate-pulse flex-shrink-0" />
+											)}
+											<span
+												className="text-xs flex-shrink-0"
+												style={{ color: statusColors[task.status] }}
+											>
+												{t(statusKey(task.status))}
+											</span>
+											{task.movedAt && (
+												<span className="text-fg-muted text-xs flex-shrink-0 w-16 text-right">
+													{timeAgo(task.movedAt, t)}
+												</span>
+											)}
+										</button>
+									))}
+
+									{/* Background tasks — collapsed summary line */}
+									{summarySegments.length > 0 && (
+										<div className="flex items-center gap-2 px-5 py-2 border-b border-edge last:border-b-0">
+											<div className="flex-1 flex items-center gap-3">
+												{summarySegments.map(({ status, count }) => (
+													<span key={status} className="flex items-center gap-1.5 text-xs text-fg-3">
+														<span
+															className="w-2 h-2 rounded-full"
+															style={{ backgroundColor: statusColors[status] }}
+														/>
+														{count} {t(statusKey(status)).toLowerCase()}
+													</span>
+												))}
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+export default ActivityOverview;

--- a/src/mainview/components/Dashboard.tsx
+++ b/src/mainview/components/Dashboard.tsx
@@ -5,16 +5,21 @@ import { api } from "../rpc";
 import { useT } from "../i18n";
 import { trackEvent } from "../analytics";
 import AddProjectModal from "./AddProjectModal";
+import ActivityOverview from "./ActivityOverview";
+
+type DashboardTab = "activity" | "projects";
 
 interface DashboardProps {
 	projects: Project[];
 	dispatch: Dispatch<AppAction>;
 	navigate: (route: Route) => void;
+	bellCounts: Map<string, number>;
 }
 
-function Dashboard({ projects, dispatch, navigate }: DashboardProps) {
+function Dashboard({ projects, dispatch, navigate, bellCounts }: DashboardProps) {
 	const t = useT();
 	const [showAddModal, setShowAddModal] = useState(false);
+	const [tab, setTab] = useState<DashboardTab>(projects.length > 0 ? "activity" : "projects");
 
 	async function handleRemoveProject(projectId: string) {
 		const confirmed = await api.request.showConfirm({
@@ -33,118 +38,45 @@ function Dashboard({ projects, dispatch, navigate }: DashboardProps) {
 
 	return (
 		<div className="h-full w-full flex flex-col">
-			<div className="flex-1 overflow-y-auto p-7">
-				{projects.length === 0 ? (
-					<div className="flex flex-col items-center justify-center h-full">
-						<div className="w-20 h-20 rounded-2xl bg-raised flex items-center justify-center mb-5">
-							<svg
-								className="w-10 h-10 text-fg-muted"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									strokeWidth={1.5}
-									d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-								/>
-							</svg>
-						</div>
-						<p className="text-fg-2 text-lg font-medium mb-1">
-							{t("dashboard.noProjects")}
-						</p>
-						<p className="text-fg-3 text-sm mb-5">
-							{t("dashboard.noProjectsHint")}
-						</p>
-						<button
-							onClick={() => setShowAddModal(true)}
-							className="px-5 py-2 bg-accent text-white text-sm font-semibold rounded-xl hover:bg-accent-hover shadow-lg shadow-accent/20 transition-all active:scale-95"
-						>
-							{t("dashboard.addProject")}
-						</button>
-					</div>
+			{/* Tab bar */}
+			{projects.length > 0 && (
+				<div className="flex items-center gap-1 px-7 pt-4 pb-1">
+					<button
+						onClick={() => setTab("activity")}
+						className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+							tab === "activity"
+								? "bg-elevated text-fg"
+								: "text-fg-3 hover:text-fg-2 hover:bg-raised-hover"
+						}`}
+					>
+						{t("dashboard.tabActivity")}
+					</button>
+					<button
+						onClick={() => setTab("projects")}
+						className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+							tab === "projects"
+								? "bg-elevated text-fg"
+								: "text-fg-3 hover:text-fg-2 hover:bg-raised-hover"
+						}`}
+					>
+						{t("dashboard.tabProjects")}
+					</button>
+				</div>
+			)}
+			<div className="flex-1 overflow-hidden">
+				{tab === "activity" && projects.length > 0 ? (
+					<ActivityOverview
+						projects={projects}
+						navigate={navigate}
+						bellCounts={bellCounts}
+					/>
 				) : (
-					<div className="max-w-3xl mx-auto">
-						<div className="flex items-center justify-between mb-5">
-							<span className="text-fg-2 text-sm font-medium">
-								{t.plural("dashboard.projectCount", projects.length)}
-							</span>
-							<button
-								onClick={() => setShowAddModal(true)}
-								className="px-4 py-1.5 bg-accent text-white text-sm font-semibold rounded-xl hover:bg-accent-hover shadow-lg shadow-accent/20 transition-all active:scale-95"
-							>
-								{t("dashboard.addProject")}
-							</button>
-						</div>
-						<div className="space-y-3">
-							{projects.map((project) => (
-								<div
-									key={project.id}
-									className="group flex items-center gap-5 p-5 bg-raised rounded-2xl hover:bg-raised-hover border border-edge hover:border-edge-active transition-all cursor-pointer"
-									onClick={() =>
-										navigate({
-											screen: "project",
-											projectId: project.id,
-										})
-									}
-								>
-									<div className="w-12 h-12 rounded-xl bg-accent/15 flex items-center justify-center flex-shrink-0">
-										<svg
-											className="w-6 h-6 text-accent"
-											fill="none"
-											stroke="currentColor"
-											viewBox="0 0 24 24"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												strokeWidth={1.5}
-												d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-											/>
-										</svg>
-									</div>
-									<div className="min-w-0 flex-1">
-										<div className="text-fg font-semibold text-base truncate">
-											{project.name}
-										</div>
-										<div className="text-fg-3 text-sm mt-1 truncate font-mono">
-											{project.path}
-										</div>
-									</div>
-									<button
-										onClick={(e) => {
-											e.stopPropagation();
-											navigate({ screen: "project-settings", projectId: project.id });
-										}}
-										className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-fg transition-all p-1.5 rounded-lg hover:bg-elevated"
-										title={t("header.projectSettings")}
-									>
-										<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-											<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-										</svg>
-									</button>
-									<button
-										onClick={(e) => {
-											e.stopPropagation();
-											api.request.openFolder({ path: project.path }).catch(() => {});
-										}}
-										className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-fg text-sm font-medium transition-all px-3 py-1.5 rounded-lg hover:bg-elevated"
-									>
-										{t("dashboard.openInFinder")}
-									</button>
-									<button
-										onClick={(e) => {
-											e.stopPropagation();
-											handleRemoveProject(project.id);
-										}}
-										className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-danger text-sm font-medium transition-all px-3 py-1.5 rounded-lg hover:bg-danger/10"
-									>
-										{t("dashboard.remove")}
-									</button>
+					<div className="h-full overflow-y-auto p-7">
+						{projects.length === 0 ? (
+							<div className="flex flex-col items-center justify-center h-full">
+								<div className="w-20 h-20 rounded-2xl bg-raised flex items-center justify-center mb-5">
 									<svg
-										className="w-5 h-5 text-fg-muted group-hover:text-fg-3 transition-colors flex-shrink-0"
+										className="w-10 h-10 text-fg-muted"
 										fill="none"
 										stroke="currentColor"
 										viewBox="0 0 24 24"
@@ -152,13 +84,121 @@ function Dashboard({ projects, dispatch, navigate }: DashboardProps) {
 										<path
 											strokeLinecap="round"
 											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M9 5l7 7-7 7"
+											strokeWidth={1.5}
+											d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
 										/>
 									</svg>
 								</div>
-							))}
-						</div>
+								<p className="text-fg-2 text-lg font-medium mb-1">
+									{t("dashboard.noProjects")}
+								</p>
+								<p className="text-fg-3 text-sm mb-5">
+									{t("dashboard.noProjectsHint")}
+								</p>
+								<button
+									onClick={() => setShowAddModal(true)}
+									className="px-5 py-2 bg-accent text-white text-sm font-semibold rounded-xl hover:bg-accent-hover shadow-lg shadow-accent/20 transition-all active:scale-95"
+								>
+									{t("dashboard.addProject")}
+								</button>
+							</div>
+						) : (
+							<div className="max-w-3xl mx-auto">
+								<div className="flex items-center justify-between mb-5">
+									<span className="text-fg-2 text-sm font-medium">
+										{t.plural("dashboard.projectCount", projects.length)}
+									</span>
+									<button
+										onClick={() => setShowAddModal(true)}
+										className="px-4 py-1.5 bg-accent text-white text-sm font-semibold rounded-xl hover:bg-accent-hover shadow-lg shadow-accent/20 transition-all active:scale-95"
+									>
+										{t("dashboard.addProject")}
+									</button>
+								</div>
+								<div className="space-y-3">
+									{projects.map((project) => (
+										<div
+											key={project.id}
+											className="group flex items-center gap-5 p-5 bg-raised rounded-2xl hover:bg-raised-hover border border-edge hover:border-edge-active transition-all cursor-pointer"
+											onClick={() =>
+												navigate({
+													screen: "project",
+													projectId: project.id,
+												})
+											}
+										>
+											<div className="w-12 h-12 rounded-xl bg-accent/15 flex items-center justify-center flex-shrink-0">
+												<svg
+													className="w-6 h-6 text-accent"
+													fill="none"
+													stroke="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path
+														strokeLinecap="round"
+														strokeLinejoin="round"
+														strokeWidth={1.5}
+														d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+													/>
+												</svg>
+											</div>
+											<div className="min-w-0 flex-1">
+												<div className="text-fg font-semibold text-base truncate">
+													{project.name}
+												</div>
+												<div className="text-fg-3 text-sm mt-1 truncate font-mono">
+													{project.path}
+												</div>
+											</div>
+											<button
+												onClick={(e) => {
+													e.stopPropagation();
+													navigate({ screen: "project-settings", projectId: project.id });
+												}}
+												className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-fg transition-all p-1.5 rounded-lg hover:bg-elevated"
+												title={t("header.projectSettings")}
+											>
+												<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+													<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+													<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+												</svg>
+											</button>
+											<button
+												onClick={(e) => {
+													e.stopPropagation();
+													api.request.openFolder({ path: project.path }).catch(() => {});
+												}}
+												className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-fg text-sm font-medium transition-all px-3 py-1.5 rounded-lg hover:bg-elevated"
+											>
+												{t("dashboard.openInFinder")}
+											</button>
+											<button
+												onClick={(e) => {
+													e.stopPropagation();
+													handleRemoveProject(project.id);
+												}}
+												className="opacity-0 group-hover:opacity-100 text-fg-3 hover:text-danger text-sm font-medium transition-all px-3 py-1.5 rounded-lg hover:bg-danger/10"
+											>
+												{t("dashboard.remove")}
+											</button>
+											<svg
+												className="w-5 h-5 text-fg-muted group-hover:text-fg-3 transition-colors flex-shrink-0"
+												fill="none"
+												stroke="currentColor"
+												viewBox="0 0 24 24"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													strokeWidth={2}
+													d="M9 5l7 7-7 7"
+												/>
+											</svg>
+										</div>
+									))}
+								</div>
+							</div>
+						)}
 					</div>
 				)}
 			</div>

--- a/src/mainview/components/__tests__/Dashboard.test.tsx
+++ b/src/mainview/components/__tests__/Dashboard.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../rpc", () => ({
 			cloneAndAddProject: vi.fn(),
 			removeProject: vi.fn(),
 			showConfirm: vi.fn(),
+			getAllProjectTasks: vi.fn(() => Promise.resolve([])),
 			getGlobalSettings: vi.fn(() => Promise.resolve({
 				defaultAgentId: "builtin-claude",
 				defaultConfigId: "claude-default",
@@ -39,6 +40,7 @@ function renderDashboard(
 				projects={projects}
 				dispatch={dispatch ?? vi.fn()}
 				navigate={navigate ?? vi.fn()}
+				bellCounts={new Map()}
 			/>
 		</I18nProvider>,
 	);
@@ -78,25 +80,31 @@ describe("Dashboard", () => {
 	});
 
 	describe("project list", () => {
-		it("renders project name and path", () => {
+		it("renders project name and path", async () => {
+			const user = userEvent.setup();
 			renderDashboard([mockProject]);
+			await user.click(screen.getByText("Projects"));
 			expect(screen.getByText("My Project")).toBeInTheDocument();
 			expect(
 				screen.getByText("/home/user/my-project"),
 			).toBeInTheDocument();
 		});
 
-		it("shows project count", () => {
+		it("shows project count", async () => {
+			const user = userEvent.setup();
 			renderDashboard([mockProject]);
+			await user.click(screen.getByText("Projects"));
 			expect(screen.getByText("1 project")).toBeInTheDocument();
 		});
 
-		it("shows plural count for multiple projects", () => {
+		it("shows plural count for multiple projects", async () => {
+			const user = userEvent.setup();
 			const projects = [
 				mockProject,
 				{ ...mockProject, id: "p2", name: "Second" },
 			];
 			renderDashboard(projects);
+			await user.click(screen.getByText("Projects"));
 			expect(screen.getByText("2 projects")).toBeInTheDocument();
 		});
 	});
@@ -153,6 +161,7 @@ describe("Dashboard", () => {
 			mockedApi.request.removeProject.mockResolvedValue(undefined);
 
 			renderDashboard([mockProject], dispatch);
+			await user.click(screen.getByText("Projects"));
 
 			const removeBtn = screen.getByText("Remove");
 			await user.click(removeBtn);
@@ -174,6 +183,7 @@ describe("Dashboard", () => {
 			mockedApi.request.showConfirm.mockResolvedValue(false);
 
 			renderDashboard([mockProject], dispatch);
+			await user.click(screen.getByText("Projects"));
 			await user.click(screen.getByText("Remove"));
 
 			expect(mockedApi.request.removeProject).not.toHaveBeenCalled();
@@ -187,6 +197,7 @@ describe("Dashboard", () => {
 			const navigate = vi.fn();
 
 			renderDashboard([mockProject], vi.fn(), navigate);
+			await user.click(screen.getByText("Projects"));
 
 			await user.click(screen.getByText("My Project"));
 

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -10,6 +10,18 @@ const dashboard = {
 	"dashboard.failedRemove": "Failed to remove project: {error}",
 	"dashboard.projectCount_one": "{count} project",
 	"dashboard.projectCount_other": "{count} projects",
+	"dashboard.tabActivity": "Activity",
+	"dashboard.tabProjects": "Projects",
+
+	// Activity overview
+	"activity.noActiveTasks": "No active tasks across any project",
+	"activity.taskCount_one": "{count} active",
+	"activity.taskCount_other": "{count} active",
+	"activity.noActiveInProject": "no active tasks",
+	"activity.justNow": "just now",
+	"activity.minutesAgo": "{count}m ago",
+	"activity.hoursAgo": "{count}h ago",
+	"activity.daysAgo": "{count}d ago",
 
 	// GlobalHeader
 	"header.task": "Task",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -10,6 +10,18 @@ const dashboard = {
 	"dashboard.failedRemove": "Error al eliminar proyecto: {error}",
 	"dashboard.projectCount_one": "{count} proyecto",
 	"dashboard.projectCount_other": "{count} proyectos",
+	"dashboard.tabActivity": "Actividad",
+	"dashboard.tabProjects": "Proyectos",
+
+	// Activity overview
+	"activity.noActiveTasks": "Sin tareas activas en ningún proyecto",
+	"activity.taskCount_one": "{count} activa",
+	"activity.taskCount_other": "{count} activas",
+	"activity.noActiveInProject": "sin tareas activas",
+	"activity.justNow": "ahora",
+	"activity.minutesAgo": "hace {count}m",
+	"activity.hoursAgo": "hace {count}h",
+	"activity.daysAgo": "hace {count}d",
 
 	// GlobalHeader
 	"header.task": "Tarea",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -12,6 +12,20 @@ const dashboard = {
 	"dashboard.projectCount_few": "{count} проекта",
 	"dashboard.projectCount_many": "{count} проектов",
 	"dashboard.projectCount_other": "{count} проектов",
+	"dashboard.tabActivity": "Активность",
+	"dashboard.tabProjects": "Проекты",
+
+	// Activity overview
+	"activity.noActiveTasks": "Нет активных задач ни в одном проекте",
+	"activity.taskCount_one": "{count} активная",
+	"activity.taskCount_few": "{count} активных",
+	"activity.taskCount_many": "{count} активных",
+	"activity.taskCount_other": "{count} активных",
+	"activity.noActiveInProject": "нет активных задач",
+	"activity.justNow": "только что",
+	"activity.minutesAgo": "{count}м назад",
+	"activity.hoursAgo": "{count}ч назад",
+	"activity.daysAgo": "{count}д назад",
 
 	// GlobalHeader
 	"header.task": "Задача",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -519,6 +519,10 @@ export type AppRPCSchema = {
 				params: { projectId: string };
 				response: Task[];
 			};
+			getAllProjectTasks: {
+				params: void;
+				response: { projectId: string; tasks: Task[] }[];
+			};
 			createTask: {
 				params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string };
 				response: Task;


### PR DESCRIPTION
## Summary
- Adds an **Activity / Projects** tab toggle to the dashboard for cross-project visibility
- **Attention tasks** (user-questions, review-by-user) are shown as individual clickable rows
- **Background tasks** (in-progress, review-by-ai, review-by-colleague) are collapsed into a summary line with status dots and counts
- Projects with no active tasks are sorted to the bottom with a compact row
- New `getAllProjectTasks` RPC endpoint fetches active tasks across all projects in one call
- Live updates via existing `rpc:taskUpdated` push events
- i18n support for EN, RU, ES

## Test plan
- [ ] Open the app with multiple projects — Activity tab shows as default
- [ ] Verify attention tasks (user-questions, review-by-user) appear as individual rows
- [ ] Verify background tasks are collapsed into a summary line
- [ ] Click a task row — navigates to project kanban with task selected in split view
- [ ] Click a project header — navigates to project kanban
- [ ] Switch to Projects tab — original project list view works as before
- [ ] With no projects — empty state shows correctly (no tabs)
- [ ] `bun run lint` passes with zero errors
- [ ] `bun run test` — backend tests pass (608/608)

🤖 Generated with [Claude Code](https://claude.com/claude-code)