### PR TITLE
Support fork branch references in task creation

### DIFF
--- a/change-logs/2026/03/11/feature-fork-branch-support.md
+++ b/change-logs/2026/03/11/feature-fork-branch-support.md
@@ -1,0 +1,1 @@
+Support fetching branches from GitHub forks in the branch selector. Type `user:branch` (e.g. `yanive:feat/cross-project-activity-tab`) in the branch field and click Fetch — the app automatically adds the fork remote, fetches the branch, and auto-selects it. The worktree creation logic now handles branches from any remote, not just origin.

--- a/src/bun/__tests__/git-branch-ops.test.ts
+++ b/src/bun/__tests__/git-branch-ops.test.ts
@@ -57,10 +57,15 @@ import {
 	canRebaseCleanly,
 	getUncommittedChanges,
 	listBranches,
+	getOriginUrl,
+	deriveForkUrl,
+	fetchFork,
+	_resetFetchState,
 } from "../git";
 
 beforeEach(() => {
 	spawnResponses = [];
+	_resetFetchState();
 });
 
 // ─── getCurrentBranch ────────────────────────────────────────────────────────
@@ -229,5 +234,81 @@ describe("listBranches", () => {
 		queueResponse(0, "");
 		const branches = await listBranches("/repo");
 		expect(branches).toEqual([]);
+	});
+});
+
+// ─── getOriginUrl ────────────────────────────────────────────────────────────
+
+describe("getOriginUrl", () => {
+	it("returns origin URL on success", async () => {
+		queueResponse(0, "https://github.com/h0x91b/dev-3.0.git\n");
+		const url = await getOriginUrl("/repo");
+		expect(url).toBe("https://github.com/h0x91b/dev-3.0.git");
+	});
+
+	it("returns null when command fails", async () => {
+		queueResponse(1, "", "fatal: not a git repository");
+		const url = await getOriginUrl("/not-a-repo");
+		expect(url).toBeNull();
+	});
+});
+
+// ─── deriveForkUrl ───────────────────────────────────────────────────────────
+
+describe("deriveForkUrl", () => {
+	it("replaces owner in HTTPS URL", () => {
+		const result = deriveForkUrl("https://github.com/h0x91b/dev-3.0.git", "yanive");
+		expect(result).toBe("https://github.com/yanive/dev-3.0.git");
+	});
+
+	it("replaces owner in SSH URL", () => {
+		const result = deriveForkUrl("git@github.com:h0x91b/dev-3.0.git", "yanive");
+		expect(result).toBe("git@github.com:yanive/dev-3.0.git");
+	});
+
+	it("handles HTTPS URL without .git suffix", () => {
+		const result = deriveForkUrl("https://github.com/h0x91b/dev-3.0", "yanive");
+		expect(result).toBe("https://github.com/yanive/dev-3.0");
+	});
+
+	it("returns null for unrecognized URL format", () => {
+		const result = deriveForkUrl("not-a-url", "yanive");
+		expect(result).toBeNull();
+	});
+});
+
+// ─── fetchFork ───────────────────────────────────────────────────────────────
+
+describe("fetchFork", () => {
+	it("adds remote and fetches branch successfully", async () => {
+		queueResponse(0, "https://github.com/h0x91b/dev-3.0.git\n"); // get-url origin
+		queueResponse(1, "", "fatal: No such remote");                  // get-url forkOwner (not found)
+		queueResponse(0, "");                                            // remote add
+		queueResponse(0, "");                                            // fetch
+		const result = await fetchFork("/repo", "yanive", "feat/cool-stuff");
+		expect(result).toBe(true);
+	});
+
+	it("reuses existing remote", async () => {
+		queueResponse(0, "https://github.com/h0x91b/dev-3.0.git\n"); // get-url origin
+		queueResponse(0, "https://github.com/yanive/dev-3.0.git\n"); // get-url forkOwner (exists)
+		queueResponse(0, "");                                            // fetch
+		const result = await fetchFork("/repo", "yanive", "feat/cool-stuff");
+		expect(result).toBe(true);
+	});
+
+	it("returns false when origin URL cannot be determined", async () => {
+		queueResponse(1, "", "fatal: not a git repository");
+		const result = await fetchFork("/not-a-repo", "yanive", "feat/cool-stuff");
+		expect(result).toBe(false);
+	});
+
+	it("returns false when fetch fails", async () => {
+		queueResponse(0, "https://github.com/h0x91b/dev-3.0.git\n");
+		queueResponse(1, "", "fatal: No such remote");
+		queueResponse(0, "");                                            // remote add
+		queueResponse(1, "", "fatal: couldn't find remote ref");         // fetch fails
+		const result = await fetchFork("/repo", "yanive", "nonexistent");
+		expect(result).toBe(false);
 	});
 });

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -192,9 +192,20 @@ export async function createWorktree(
 	}
 
 	if (existingBranch) {
-		// Use an existing branch — no -b flag
-		const resolvedBranch = existingBranch.replace(/^origin\//, "");
-		log.info("Creating worktree from existing branch", { wtPath, existingBranch: resolvedBranch, taskId: task.id });
+		// Check if this is a remote tracking ref (origin/xxx, yanive/xxx, etc.)
+		const isRemoteRef = (await run(
+			["git", "rev-parse", "--verify", `refs/remotes/${existingBranch}`],
+			project.path,
+		)).ok;
+
+		// For remote refs, extract local branch name by stripping the remote prefix
+		const resolvedBranch = isRemoteRef
+			? existingBranch.slice(existingBranch.indexOf("/") + 1)
+			: existingBranch;
+
+		log.info("Creating worktree from existing branch", {
+			wtPath, existingBranch, resolvedBranch, isRemoteRef, taskId: task.id,
+		});
 
 		const result = await run(
 			["git", "worktree", "add", wtPath, resolvedBranch],
@@ -204,7 +215,7 @@ export async function createWorktree(
 		if (!result.ok) {
 			const isAlreadyCheckedOut = result.stderr.includes("already checked out") || result.stderr.includes("already used by worktree");
 
-			if (existingBranch.startsWith("origin/") && !isAlreadyCheckedOut) {
+			if (isRemoteRef && !isAlreadyCheckedOut) {
 				// Remote branch without a local tracking branch yet — create one
 				log.info("Retrying with tracking branch creation", { existingBranch });
 				const trackResult = await run(
@@ -234,7 +245,7 @@ export async function createWorktree(
 					throw new Error(`Failed to create worktree: ${fallbackResult.stderr}`);
 				}
 				// Set up remote tracking so `git push` targets the original remote branch
-				const remoteRef = `origin/${resolvedBranch}`;
+				const remoteRef = isRemoteRef ? existingBranch : `origin/${resolvedBranch}`;
 				const remoteCheckResult = await run(
 					["git", "rev-parse", "--verify", remoteRef],
 					project.path,
@@ -377,6 +388,78 @@ export async function fetchOrigin(projectPath: string): Promise<boolean> {
 	} finally {
 		fetchInFlight.delete(projectPath);
 	}
+}
+
+export async function getOriginUrl(projectPath: string): Promise<string | null> {
+	const result = await run(["git", "remote", "get-url", "origin"], projectPath);
+	return result.ok ? result.stdout : null;
+}
+
+/**
+ * Derive a fork URL from the origin URL by replacing the owner.
+ * Supports both HTTPS and SSH formats:
+ *   https://github.com/h0x91b/dev-3.0.git → https://github.com/yanive/dev-3.0.git
+ *   git@github.com:h0x91b/dev-3.0.git → git@github.com:yanive/dev-3.0.git
+ */
+export function deriveForkUrl(originUrl: string, forkOwner: string): string | null {
+	// HTTPS: https://github.com/OWNER/REPO.git
+	const httpsMatch = originUrl.match(/^(https?:\/\/[^/]+\/)([^/]+)(\/[^/]+)$/);
+	if (httpsMatch) {
+		return `${httpsMatch[1]}${forkOwner}${httpsMatch[3]}`;
+	}
+	// SSH: git@github.com:OWNER/REPO.git
+	const sshMatch = originUrl.match(/^([^@]+@[^:]+:)([^/]+)(\/[^/]+)$/);
+	if (sshMatch) {
+		return `${sshMatch[1]}${forkOwner}${sshMatch[3]}`;
+	}
+	return null;
+}
+
+/**
+ * Add a fork remote and fetch a specific branch from it.
+ * Returns true if the branch was successfully fetched.
+ */
+export async function fetchFork(
+	projectPath: string,
+	forkOwner: string,
+	branchName: string,
+): Promise<boolean> {
+	const originUrl = await getOriginUrl(projectPath);
+	if (!originUrl) {
+		log.warn("fetchFork: could not determine origin URL", { projectPath });
+		return false;
+	}
+
+	const forkUrl = deriveForkUrl(originUrl, forkOwner);
+	if (!forkUrl) {
+		log.warn("fetchFork: could not derive fork URL", { originUrl, forkOwner });
+		return false;
+	}
+
+	// Check if remote already exists
+	const remoteCheck = await run(["git", "remote", "get-url", forkOwner], projectPath);
+	if (!remoteCheck.ok) {
+		// Add the remote
+		log.info("Adding fork remote", { forkOwner, forkUrl });
+		const addResult = await run(["git", "remote", "add", forkOwner, forkUrl], projectPath);
+		if (!addResult.ok) {
+			log.error("Failed to add fork remote", { stderr: addResult.stderr });
+			return false;
+		}
+	}
+
+	// Fetch the specific branch
+	log.info("Fetching fork branch", { forkOwner, branchName });
+	const fetchResult = await run(
+		["git", "fetch", forkOwner, branchName, "--quiet"],
+		projectPath,
+	);
+	if (!fetchResult.ok) {
+		log.warn("fetchFork: failed to fetch branch", { forkOwner, branchName, stderr: fetchResult.stderr });
+		return false;
+	}
+
+	return true;
 }
 
 /** Reset fetch dedup state — for tests only. */

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -2661,9 +2661,21 @@ export const handlers = {
 		return git.listBranches(project.path);
 	},
 
-	async fetchBranches(params: { projectId: string }): Promise<Array<{ name: string; isRemote: boolean }>> {
+	async fetchBranches(params: { projectId: string; forkRef?: string }): Promise<Array<{ name: string; isRemote: boolean }>> {
 		const project = await data.getProject(params.projectId);
-		await git.fetchOrigin(project.path);
+		if (params.forkRef) {
+			// Parse "user:branch" format
+			const colonIdx = params.forkRef.indexOf(":");
+			if (colonIdx > 0) {
+				const forkOwner = params.forkRef.slice(0, colonIdx);
+				const branchName = params.forkRef.slice(colonIdx + 1);
+				if (forkOwner && branchName) {
+					await git.fetchFork(project.path, forkOwner, branchName);
+				}
+			}
+		} else {
+			await git.fetchOrigin(project.path);
+		}
 		return git.listBranches(project.path);
 	},
 

--- a/src/mainview/components/BranchSelector.tsx
+++ b/src/mainview/components/BranchSelector.tsx
@@ -7,6 +7,15 @@ interface BranchInfo {
 	isRemote: boolean;
 }
 
+/** Detect GitHub fork reference format: "user:branch" */
+const FORK_REF_RE = /^([a-zA-Z0-9_-]+):(.+)$/;
+
+export function parseForkRef(query: string): { forkOwner: string; branchName: string } | null {
+	const match = query.match(FORK_REF_RE);
+	if (!match) return null;
+	return { forkOwner: match[1], branchName: match[2] };
+}
+
 /** Split a branch name into words on /, -, _, ., and camelCase boundaries. */
 export function splitBranchWords(name: string): string[] {
 	return name
@@ -65,15 +74,29 @@ function BranchSelector({ projectId, selectedBranch, onSelectBranch, reviewMode,
 	const handleFetchBranches = useCallback(async () => {
 		setFetchingBranches(true);
 		try {
-			const result = await api.request.fetchBranches({ projectId });
+			const forkRef = parseForkRef(branchQuery) ? branchQuery : undefined;
+			const result = await api.request.fetchBranches({ projectId, forkRef });
 			setBranches(result);
 			setBranchesLoaded(true);
+			// After fetching a fork branch, auto-select it
+			if (forkRef) {
+				const parsed = parseForkRef(branchQuery);
+				if (parsed) {
+					const expectedRemote = `${parsed.forkOwner}/${parsed.branchName}`;
+					const found = result.find((b) => b.name === expectedRemote);
+					if (found) {
+						onSelectBranch(found.name);
+						setBranchQuery("");
+						setBranchDropdownOpen(false);
+					}
+				}
+			}
 		} catch {
 			// silently fail
 		} finally {
 			setFetchingBranches(false);
 		}
-	}, [projectId]);
+	}, [projectId, branchQuery, onSelectBranch]);
 
 	const filteredBranches = branches.filter((b) =>
 		matchesBranchQuery(b.name, branchQuery),
@@ -231,7 +254,10 @@ function BranchSelector({ projectId, selectedBranch, onSelectBranch, reviewMode,
 
 						{filteredBranches.length === 0 && branchesLoaded && (
 							<div className="px-3 py-2 text-sm text-fg-muted">
-								No branches found
+								{parseForkRef(branchQuery)
+									? t("createTask.branchForkHint")
+									: t("createTask.branchNoneFound")
+								}
 							</div>
 						)}
 					</div>

--- a/src/mainview/components/__tests__/BranchSelector.test.ts
+++ b/src/mainview/components/__tests__/BranchSelector.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			listBranches: vi.fn(),
+			fetchBranches: vi.fn(),
+		},
+	},
+}));
+
+vi.mock("../../analytics", () => ({
+	trackEvent: vi.fn(),
+}));
+
+import { parseForkRef, matchesBranchQuery, splitBranchWords } from "../BranchSelector";
+
+// ─── parseForkRef ────────────────────────────────────────────────────────────
+
+describe("parseForkRef", () => {
+	it("parses valid fork reference", () => {
+		const result = parseForkRef("yanive:feat/cross-project-activity-tab");
+		expect(result).toEqual({
+			forkOwner: "yanive",
+			branchName: "feat/cross-project-activity-tab",
+		});
+	});
+
+	it("parses fork reference with simple branch", () => {
+		const result = parseForkRef("user123:main");
+		expect(result).toEqual({
+			forkOwner: "user123",
+			branchName: "main",
+		});
+	});
+
+	it("parses fork reference with hyphens and underscores in owner", () => {
+		const result = parseForkRef("my-user_name:fix/something");
+		expect(result).toEqual({
+			forkOwner: "my-user_name",
+			branchName: "fix/something",
+		});
+	});
+
+	it("returns null for plain branch name", () => {
+		expect(parseForkRef("feat/some-feature")).toBeNull();
+	});
+
+	it("returns null for empty string", () => {
+		expect(parseForkRef("")).toBeNull();
+	});
+
+	it("returns null for colon at start", () => {
+		expect(parseForkRef(":branch-name")).toBeNull();
+	});
+
+	it("returns null for plain text without colon", () => {
+		expect(parseForkRef("just-a-branch")).toBeNull();
+	});
+});
+
+// ─── splitBranchWords ────────────────────────────────────────────────────────
+
+describe("splitBranchWords", () => {
+	it("splits on slashes", () => {
+		expect(splitBranchWords("feat/login-page")).toEqual(["feat", "login", "page"]);
+	});
+
+	it("splits camelCase", () => {
+		expect(splitBranchWords("myFeatureBranch")).toEqual(["my", "feature", "branch"]);
+	});
+});
+
+// ─── matchesBranchQuery ─────────────────────────────────────────────────────
+
+describe("matchesBranchQuery", () => {
+	it("matches empty query to any branch", () => {
+		expect(matchesBranchQuery("feat/login", "")).toBe(true);
+	});
+
+	it("matches word prefix", () => {
+		expect(matchesBranchQuery("feat/login-page", "log")).toBe(true);
+	});
+
+	it("does not match mid-word", () => {
+		expect(matchesBranchQuery("feat/login-page", "ogin")).toBe(false);
+	});
+
+	it("matches slash-containing query via substring fallback", () => {
+		expect(matchesBranchQuery("origin/feat/login", "origin/feat")).toBe(true);
+	});
+});

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -27,6 +27,8 @@ const kanban = {
 	"createTask.branchFetching": "Fetching...",
 	"createTask.branchLocal": "Local",
 	"createTask.branchRemote": "Remote",
+	"createTask.branchNoneFound": "No branches found",
+	"createTask.branchForkHint": "Click Fetch to pull this branch from the fork",
 	"createTask.useExistingBranch": "Use existing branch",
 	"createTask.reviewMode": "This is a PR review",
 	"createTask.reviewModeHint": "Pre-fills description with a code review prompt",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -116,6 +116,8 @@ const tips = {
 	"tip.autoFillBranch.body": "Switch to a feature branch before creating a task — the branch selector auto-fills so you don't have to search for it.",
 	"tip.taskOpenMode.title": "Full-screen terminal mode",
 	"tip.taskOpenMode.body": "Switch Task Open Mode to \"Full screen\" in Global Settings to open tasks in a distraction-free terminal instead of split view.",
+	"tip.forkBranchSupport.title": "Review fork PRs",
+	"tip.forkBranchSupport.body": "Type user:branch in the branch field (e.g. yanive:feat/new-tab) and click Fetch to pull a branch from a GitHub fork.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -27,6 +27,8 @@ const kanban = {
 	"createTask.branchFetching": "Actualizando...",
 	"createTask.branchLocal": "Locales",
 	"createTask.branchRemote": "Remotas",
+	"createTask.branchNoneFound": "No se encontraron ramas",
+	"createTask.branchForkHint": "Haz clic en Actualizar para obtener la rama del fork",
 	"createTask.useExistingBranch": "Usar rama existente",
 	"createTask.reviewMode": "Esto es una revisión de PR",
 	"createTask.reviewModeHint": "Rellena la descripción con un prompt de revisión de código",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -116,6 +116,8 @@ const tips = {
 	"tip.autoFillBranch.body": "Cambia a una rama de feature antes de crear la tarea — el selector de rama se auto-completará para que no tengas que buscarla.",
 	"tip.taskOpenMode.title": "Modo terminal de pantalla completa",
 	"tip.taskOpenMode.body": "Activa «Pantalla completa» en Modo de apertura de tarea (Ajustes globales) para abrir tareas sin vista dividida.",
+	"tip.forkBranchSupport.title": "Revisa PRs de forks",
+	"tip.forkBranchSupport.body": "Escribe user:branch en el campo de rama (ej. yanive:feat/new-tab) y haz clic en Actualizar para descargar la rama de un fork de GitHub.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -27,6 +27,8 @@ const kanban = {
 	"createTask.branchFetching": "Обновление...",
 	"createTask.branchLocal": "Локальные",
 	"createTask.branchRemote": "Удалённые",
+	"createTask.branchNoneFound": "Ветки не найдены",
+	"createTask.branchForkHint": "Нажмите Обновить, чтобы загрузить ветку из форка",
 	"createTask.useExistingBranch": "Использовать существующую ветку",
 	"createTask.reviewMode": "Это PR ревью",
 	"createTask.reviewModeHint": "Предзаполняет описание промптом для код-ревью",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -116,6 +116,8 @@ const tips = {
 	"tip.autoFillBranch.body": "Переключитесь на фича-ветку перед созданием задачи — селектор ветки заполнится автоматически, искать не придётся.",
 	"tip.taskOpenMode.title": "Режим полноэкранного терминала",
 	"tip.taskOpenMode.body": "Включите «Полный экран» в режиме открытия задач (Глобальные настройки), чтобы открывать задачи без разделённого вида.",
+	"tip.forkBranchSupport.title": "Ревью PR из форков",
+	"tip.forkBranchSupport.body": "Введите user:branch в поле ветки (напр. yanive:feat/new-tab) и нажмите Обновить, чтобы загрузить ветку из форка на GitHub.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -358,6 +358,12 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.taskOpenMode.body",
 		icon: "\u{F0124}", // nf-md-fullscreen
 	},
+	{
+		id: "fork-branch-support",
+		titleKey: "tip.forkBranchSupport.title",
+		bodyKey: "tip.forkBranchSupport.body",
+		icon: "\u{F062C}", // nf-md-source_branch
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -737,7 +737,7 @@ export type AppRPCSchema = {
 				response: Array<{ name: string; isRemote: boolean }>;
 			};
 			fetchBranches: {
-				params: { projectId: string };
+				params: { projectId: string; forkRef?: string };
 				response: Array<{ name: string; isRemote: boolean }>;
 			};
 			getProjectCurrentBranch: {


### PR DESCRIPTION
## Summary

- Adds `user:branch` fork reference support in the Branch selector when creating tasks
- Typing e.g. `yanive:feat/cross-project-activity-tab` and clicking Fetch auto-adds the fork remote, fetches the branch, and selects it
- Generalizes worktree creation to handle branches from any git remote (not just `origin`), using `refs/remotes/` verification instead of hardcoded `origin/` prefix checks
- Includes i18n strings (en/ru/es), a "Did you know?" tip, and 20 new unit tests