### PR TITLE
Fix overcrowded tmux status bar

### DIFF
--- a/change-logs/2026/03/11/fix-tmux-status-bar-clutter.md
+++ b/change-logs/2026/03/11/fix-tmux-status-bar-clutter.md
@@ -1,0 +1,1 @@
+Remove the full worktree path from the tmux status bar to reduce clutter. The bar now shows only the process info, git branch name, and keyboard shortcuts — dropping the redundant and lengthy worktree filesystem path.

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -43,7 +43,7 @@ bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 
 # Status bar
-set -g status-right "#(ps -t #{pane_tty} -o pid=,comm= --sort=-start_time | head -1) | #{pane_current_path} | #(cd #{pane_current_path}; git branch --show-current 2>/dev/null || echo '-') | ^b+| split ^b+- hsplit ^b+z zoom"
+set -g status-right "#(ps -t #{pane_tty} -o pid=,comm= --sort=-start_time | head -1) | #(cd #{pane_current_path}; git branch --show-current 2>/dev/null || echo '-') | ^b+| split ^b+- hsplit ^b+z zoom"
 set -g status-right-length 150
 
 # Clipboard support

--- a/src/mainview/__tests__/shift-keys-e2e.test.ts
+++ b/src/mainview/__tests__/shift-keys-e2e.test.ts
@@ -70,7 +70,7 @@ bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 
 # Status bar
-set -g status-right "#(ps -t #{pane_tty} -o pid=,comm= --sort=-start_time | head -1) | #{pane_current_path} | #(cd #{pane_current_path}; git branch --show-current 2>/dev/null || echo '-') | ^b+| split ^b+- hsplit ^b+z zoom"
+set -g status-right "#(ps -t #{pane_tty} -o pid=,comm= --sort=-start_time | head -1) | #(cd #{pane_current_path}; git branch --show-current 2>/dev/null || echo '-') | ^b+| split ^b+- hsplit ^b+z zoom"
 set -g status-right-length 150
 
 # Clipboard support


### PR DESCRIPTION
Closes #269

## Summary
- Remove the full worktree filesystem path (`#{pane_current_path}`) from the tmux `status-right` config
- The path was very long and redundant — the git branch name already identifies the task context
- Status bar now shows: `process | branch | keyboard shortcuts` instead of `process | /long/worktree/path | branch | shortcuts`

## Test plan
- [x] `bun run lint` passes
- [x] `bun run test` — shift-keys-e2e test (23 tests) passes with updated snapshot
- [ ] Visual: launch a task terminal and verify the bottom bar is less cluttered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
