### PR TITLE
Add ~/.local/bin and ~/bin as PATH fallbacks

### DIFF
--- a/change-logs/2026/03/12/fix-local-bin-path-fallback.md
+++ b/change-logs/2026/03/12/fix-local-bin-path-fallback.md
@@ -1,0 +1,3 @@
+Add ~/.local/bin and ~/bin as fallback PATH directories. Tools installed via pip, pipx, or Claude CLI installer live in ~/.local/bin, which some shell configurations don't include in PATH. The app now appends these directories (if they exist on disk) after resolving the user's shell environment, ensuring commands like `claude` are found regardless of shell config. Also renamed HOMEBREW_FALLBACK_PATHS to FALLBACK_BIN_PATHS and included user-local dirs in system requirements checks.
+
+Suggested by @shmulikf (h0x91b/dev-3.0#279)

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -19,6 +19,7 @@ import { installAgentSkills } from "./agent-skills";
 import { makeTitle } from "./app-utils";
 import electrobunConfig from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
+import { existsSync } from "node:fs";
 
 const log = createLogger("main");
 
@@ -124,6 +125,26 @@ if (shellEnv.path) {
 } else {
 	log.warn("Could not resolve shell PATH, using original", { path: originalPath });
 }
+
+// Ensure well-known user binary directories are in PATH.
+// Some shells/configs don't add these, but tools like pip, pipx, and
+// Claude CLI install binaries there. Append missing dirs that exist on disk.
+{
+	const home = process.env.HOME;
+	if (home) {
+		const userBinDirs = [
+			`${home}/.local/bin`,
+			`${home}/bin`,
+		];
+		for (const dir of userBinDirs) {
+			if (!process.env.PATH?.includes(dir) && existsSync(dir)) {
+				process.env.PATH = `${process.env.PATH}:${dir}`;
+				log.info("Appended user bin dir to PATH", { dir });
+			}
+		}
+	}
+}
+
 if (shellEnv.lang) {
 	process.env.LANG = shellEnv.lang;
 	log.info("Shell LANG resolved", {

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -113,12 +113,14 @@ const SYSTEM_REQUIREMENTS = [
 	{ id: "tmux", name: "tmux", checkCommand: "tmux", installHint: "requirements.installTmux", installCommand: "brew install tmux", brewInstallable: true },
 ];
 
-// Common paths where Homebrew installs binaries (Apple Silicon + Intel)
-const HOMEBREW_FALLBACK_PATHS = [
+// Common paths where package managers install binaries
+const FALLBACK_BIN_PATHS = [
 	"/opt/homebrew/bin",
 	"/usr/local/bin",
 	"/opt/homebrew/sbin",
 	"/usr/local/sbin",
+	// User-local dirs (pip, pipx, Claude CLI, etc.)
+	...(process.env.HOME ? [`${process.env.HOME}/.local/bin`, `${process.env.HOME}/bin`] : []),
 ];
 
 // Will be set by index.ts after window creation
@@ -2298,7 +2300,7 @@ export const handlers = {
 
 			// 3. Fallback: check common Homebrew paths
 			if (!resolvedPath) {
-				for (const dir of HOMEBREW_FALLBACK_PATHS) {
+				for (const dir of FALLBACK_BIN_PATHS) {
 					const candidate = `${dir}/${req.checkCommand}`;
 					if (existsSync(candidate)) {
 						resolvedPath = candidate;

--- a/src/bun/shell-env.ts
+++ b/src/bun/shell-env.ts
@@ -59,11 +59,3 @@ export async function resolveShellEnv(): Promise<{ path?: string; lang?: string 
 		return {};
 	}
 }
-
-/**
- * @deprecated Use resolveShellEnv() instead, which also resolves LANG.
- */
-export async function resolveShellPath(): Promise<string | undefined> {
-	const env = await resolveShellEnv();
-	return env.path;
-}


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this fix.

- Appends `~/.local/bin` and `~/bin` to PATH at startup (if they exist on disk but aren't already present), ensuring tools installed via pip/pipx/Claude CLI installer are found
- Renamed `HOMEBREW_FALLBACK_PATHS` → `FALLBACK_BIN_PATHS` and included user-local dirs in the system requirements fallback check
- Removed unused deprecated `resolveShellPath()`

Fixes #279