### PR TITLE
Limit visible tasks per column with Load More

### DIFF
--- a/change-logs/2026/03/12/feature-column-load-more.md
+++ b/change-logs/2026/03/12/feature-column-load-more.md
@@ -1,0 +1,1 @@
+Kanban columns now show only the 15 most recent tasks by default. A "Show more" button at the bottom reveals the rest, and a "Show less" button collapses them back, improving rendering performance for columns with hundreds of tasks.

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -8,6 +8,8 @@ import TaskCard from "./TaskCard";
 import TipCard from "./TipCard";
 import type { Tip } from "../tips";
 
+const COLUMN_TASK_LIMIT = 15;
+
 // Module-level variable: set synchronously on dragstart, cleared on dragend.
 // Avoids relying on dataTransfer.types which may not include custom MIME types in WKWebView.
 let _activeDragColumnId: string | null = null;
@@ -96,9 +98,16 @@ function KanbanColumn({
 	const [columnDragSide, setColumnDragSide] = useState<"before" | "after" | null>(null);
 	const [showInfo, setShowInfo] = useState(false);
 	const [infoPos, setInfoPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+	const [expanded, setExpanded] = useState(false);
 	const infoBtnRef = useRef<HTMLButtonElement>(null);
 	const infoPopupRef = useRef<HTMLDivElement>(null);
 	const taskListRef = useRef<HTMLDivElement>(null);
+
+	// Auto-collapse when column identity changes (e.g. project switch)
+	const columnKey = `${status}:${customColumnId ?? ""}`;
+	useEffect(() => {
+		setExpanded(false);
+	}, [columnKey]);
 
 	// Close info popup on outside click
 	useEffect(() => {
@@ -239,6 +248,9 @@ function KanbanColumn({
 
 	const showDropHighlight = dragOver && isCrossColumnTarget;
 
+	const visibleTasks = expanded ? tasks : tasks.slice(0, COLUMN_TASK_LIMIT);
+	const hiddenCount = tasks.length - visibleTasks.length;
+
 	return (
 		<>
 		<div
@@ -339,7 +351,7 @@ function KanbanColumn({
 					onAddTask();
 				} : undefined}
 			>
-				{tasks.map((task, index) => (
+				{visibleTasks.map((task, index) => (
 					<div key={task.id} data-task-id={task.id}>
 						{isSameColumnDrag && dropIndex === index && task.id !== draggedTaskId && (
 							<div className="h-0.5 bg-accent rounded-full mx-1 mb-2 transition-all" />
@@ -362,8 +374,28 @@ function KanbanColumn({
 						/>
 					</div>
 				))}
-				{isSameColumnDrag && dropIndex === tasks.length && (
+				{isSameColumnDrag && dropIndex === visibleTasks.length && (
 					<div className="h-0.5 bg-accent rounded-full mx-1 mt-0 transition-all" />
+				)}
+
+				{hiddenCount > 0 && (
+					<button
+						onClick={() => setExpanded(true)}
+						className="w-full text-fg-muted hover:text-fg-2 text-xs text-center py-2 mt-1 rounded-lg hover:bg-raised-hover transition-colors"
+					>
+						{t("kanban.showMore", { count: String(hiddenCount) })}
+					</button>
+				)}
+				{expanded && tasks.length > COLUMN_TASK_LIMIT && (
+					<button
+						onClick={() => {
+							setExpanded(false);
+							taskListRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+						}}
+						className="w-full text-fg-muted hover:text-fg-2 text-xs text-center py-2 mt-1 rounded-lg hover:bg-raised-hover transition-colors"
+					>
+						{t("kanban.showLess")}
+					</button>
 				)}
 
 				{tasks.length === 0 && !tip && (

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -5,6 +5,8 @@ const kanban = {
 	"kanban.cancel": "Cancel",
 	"kanban.newTask": "+ New Task",
 	"kanban.failedCreate": "Failed to create task: {error}",
+	"kanban.showMore": "Show more ({count})",
+	"kanban.showLess": "Show less",
 
 	// CreateTaskModal
 	"createTask.title": "New Task",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.forkBranchSupport.body": "Type user:branch in the branch field (e.g. yanive:feat/new-tab) and click Fetch to pull a branch from a GitHub fork.",
 	"tip.taskDropPosition.title": "New tasks land on top",
 	"tip.taskDropPosition.body": "By default new and moved tasks appear at the top of a column. Switch to bottom in Global Settings → Task Drop Position.",
+	"tip.columnLoadMore.title": "Large columns auto-collapse",
+	"tip.columnLoadMore.body": "Columns with 15+ tasks show only the most recent ones. Click \"Show more\" at the bottom to reveal the rest.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -5,6 +5,8 @@ const kanban = {
 	"kanban.cancel": "Cancelar",
 	"kanban.newTask": "+ Nueva tarea",
 	"kanban.failedCreate": "Error al crear tarea: {error}",
+	"kanban.showMore": "Mostrar más ({count})",
+	"kanban.showLess": "Mostrar menos",
 
 	// CreateTaskModal
 	"createTask.title": "Nueva tarea",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.forkBranchSupport.body": "Escribe user:branch en el campo de rama (ej. yanive:feat/new-tab) y haz clic en Actualizar para descargar la rama de un fork de GitHub.",
 	"tip.taskDropPosition.title": "Tareas nuevas arriba",
 	"tip.taskDropPosition.body": "Por defecto las tareas nuevas y movidas aparecen arriba de la columna. Cámbialo en Ajustes globales → Posición al mover tareas.",
+	"tip.columnLoadMore.title": "Columnas grandes se colapsan",
+	"tip.columnLoadMore.body": "Las columnas con 15+ tareas muestran solo las más recientes. Haz clic en \"Mostrar más\" abajo para ver el resto.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -5,6 +5,8 @@ const kanban = {
 	"kanban.cancel": "Отмена",
 	"kanban.newTask": "+ Новая задача",
 	"kanban.failedCreate": "Не удалось создать задачу: {error}",
+	"kanban.showMore": "Показать ещё ({count})",
+	"kanban.showLess": "Свернуть",
 
 	// CreateTaskModal
 	"createTask.title": "Новая задача",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.forkBranchSupport.body": "Введите user:branch в поле ветки (напр. yanive:feat/new-tab) и нажмите Обновить, чтобы загрузить ветку из форка на GitHub.",
 	"tip.taskDropPosition.title": "Новые задачи — наверх",
 	"tip.taskDropPosition.body": "По умолчанию новые и перемещённые задачи появляются вверху колонки. Переключите на «Вниз» в Глобальных настройках → Позиция при перемещении.",
+	"tip.columnLoadMore.title": "Большие колонки сворачиваются",
+	"tip.columnLoadMore.body": "Колонки с 15+ задачами показывают только свежие. Нажмите «Показать ещё» внизу, чтобы увидеть остальные.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -371,6 +371,13 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.taskDropPosition.body",
 		icon: "\u{F0140}", // nf-md-arrow_up_down
 	},
+	// Batch 15: column load more
+	{
+		id: "column-load-more",
+		titleKey: "tip.columnLoadMore.title",
+		bodyKey: "tip.columnLoadMore.body",
+		icon: "\u{F0063}", // nf-md-arrow_down
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days


### PR DESCRIPTION
## Summary

- Kanban columns now show only the **15 most recent tasks** by default, dramatically improving render performance for columns with hundreds of tasks (e.g. 360 in "completed")
- A **"Show more (N)"** button at the bottom reveals hidden tasks; **"Show less"** collapses back and scrolls to top
- Expanded state auto-resets on project/column switch
- i18n support for EN/RU/ES, plus a "Did you know?" tip