### PR TITLE
Fix changelog date groups appearing out of order

### DIFF
--- a/change-logs/2026/03/12/fix-changelog-date-sort.md
+++ b/change-logs/2026/03/12/fix-changelog-date-sort.md
@@ -1,0 +1,1 @@
+Fixed changelog date groups appearing out of order. The type-based sort (feature before fix) was breaking Map insertion order, causing some dates to display below older ones instead of in descending chronological order.

--- a/src/mainview/components/Changelog.tsx
+++ b/src/mainview/components/Changelog.tsx
@@ -95,7 +95,9 @@ function Changelog({ navigate, previousRoute }: ChangelogProps) {
 			group.push(entry);
 			map.set(entry.date, group);
 		}
-		return Array.from(map.entries()).map(([date, items]) => ({ date, items }));
+		return Array.from(map.entries())
+			.map(([date, items]) => ({ date, items }))
+			.sort((a, b) => b.date.localeCompare(a.date));
 	}, [entries, activeFilter]);
 
 	if (loading) {

--- a/src/mainview/components/__tests__/Changelog.test.tsx
+++ b/src/mainview/components/__tests__/Changelog.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import Changelog from "../Changelog";
+import { I18nProvider } from "../../i18n";
+import type { ChangelogEntry } from "../../../shared/types";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			getChangelogs: vi.fn(),
+		},
+	},
+}));
+
+import { api } from "../../rpc";
+
+const mockedApi = vi.mocked(api, true);
+
+function renderChangelog() {
+	return render(
+		<I18nProvider>
+			<Changelog navigate={vi.fn()} previousRoute={null} />
+		</I18nProvider>,
+	);
+}
+
+describe("Changelog", () => {
+	it("sorts date groups in descending order even when type sort reorders entries", async () => {
+		// Feb 25 has only a "fix" entry, Feb 24 has a "feature" entry, Feb 26 has a "fix" entry.
+		// After type-based sort, "feature" (24th) would come before "fix" (25th, 26th),
+		// causing Map insertion order to put Feb 24 first — breaking date order.
+		const entries: ChangelogEntry[] = [
+			{ date: "2026-02-26", type: "fix", slug: "fix-26", title: "Fix on 26th" },
+			{ date: "2026-02-25", type: "fix", slug: "fix-25", title: "Fix on 25th" },
+			{ date: "2026-02-24", type: "feature", slug: "feat-24", title: "Feature on 24th" },
+		];
+
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+
+		renderChangelog();
+
+		// Wait for entries to load
+		await screen.findByText("Fix on 26th");
+
+		// Get all date headings — they should be in descending order
+		const headings = screen.getAllByRole("heading", { level: 3 });
+		const headingTexts = headings.map((h) => h.textContent);
+
+		// Verify order: Feb 26 → Feb 25 → Feb 24 (descending)
+		expect(headingTexts).toHaveLength(3);
+		expect(headingTexts[0]).toContain("26");
+		expect(headingTexts[1]).toContain("25");
+		expect(headingTexts[2]).toContain("24");
+	});
+});


### PR DESCRIPTION
## Summary

- The type-based sort (feature → fix → refactor) in the Changelog component reordered entries before grouping by date via `Map`. Since `Map` preserves insertion order, dates with only "fix" entries could appear below older dates that had "feature" entries — breaking chronological order (e.g., Feb 25 showing below Feb 24).
- Added an explicit descending date sort on the final grouped array to ensure correct chronological display regardless of entry types.

Hey, this is Claude — the AI assistant working on this fix.