### PR TITLE
Fix branch search to support GitHub fork colon notation

### DIFF
--- a/change-logs/2026/03/12/fix-fork-branch-colon-search.md
+++ b/change-logs/2026/03/12/fix-fork-branch-colon-search.md
@@ -1,0 +1,1 @@
+Branch selector now finds fork branches when using GitHub's colon notation (e.g., "user:feat/branch"). Previously only the slash format ("user/feat/branch") matched in the dropdown filter.

--- a/src/mainview/components/BranchSelector.tsx
+++ b/src/mainview/components/BranchSelector.tsx
@@ -29,13 +29,15 @@ export function splitBranchWords(name: string): string[] {
 /** Check if any word in the branch name starts with any query token. */
 export function matchesBranchQuery(branchName: string, query: string): boolean {
 	if (!query) return true;
+	// Normalize fork ref format: "user:branch" → "user/branch" for matching
+	const normalizedQuery = query.replace(":", "/");
 	const nameLower = branchName.toLowerCase();
 	const words = splitBranchWords(branchName);
-	const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+	const tokens = normalizedQuery.toLowerCase().split(/\s+/).filter(Boolean);
 	return tokens.every((token) => {
 		// Word-level prefix match (default behavior)
 		if (words.some((w) => w.startsWith(token))) return true;
-		// Substring fallback for tokens containing "/" (e.g., "origin/dev")
+		// Substring fallback for tokens containing "/" (e.g., "origin/dev", "user:branch")
 		if (token.includes("/") && nameLower.includes(token)) return true;
 		return false;
 	});

--- a/src/mainview/components/__tests__/BranchSelector.test.ts
+++ b/src/mainview/components/__tests__/BranchSelector.test.ts
@@ -89,4 +89,12 @@ describe("matchesBranchQuery", () => {
 	it("matches slash-containing query via substring fallback", () => {
 		expect(matchesBranchQuery("origin/feat/login", "origin/feat")).toBe(true);
 	});
+
+	it("matches fork ref with colon by normalizing to slash", () => {
+		expect(matchesBranchQuery("roiros/feat/collapsible-kanban-columns", "roiros:feat/collapsible-kanban-columns")).toBe(true);
+	});
+
+	it("matches partial fork ref with colon", () => {
+		expect(matchesBranchQuery("roiros/feat/collapsible-kanban-columns", "roiros:feat")).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

- Branch selector now matches fork references in GitHub's colon format (e.g., `roiros:feat/collapsible-kanban-columns`)
- Previously only the slash format (`roiros/feat/collapsible-kanban-columns`) was found in the dropdown filter
- Fix: normalize `:` → `/` in the query before matching

Hi, this is Claude — the AI assistant working on this fix.