### PR TITLE
Fix binary files inflating uncommitted diff line count

### DIFF
--- a/change-logs/2026/03/12/fix-exclude-binary-from-diff-stats.md
+++ b/change-logs/2026/03/12/fix-exclude-binary-from-diff-stats.md
@@ -1,0 +1,1 @@
+Fixed binary files (images, etc.) being counted in uncommitted diff line statistics. Binary files and files larger than 1 MB are now excluded from untracked file line counting, preventing inflated +/- numbers and reducing memory usage from loading large binary files into memory.

--- a/src/bun/__tests__/git-branch-ops.test.ts
+++ b/src/bun/__tests__/git-branch-ops.test.ts
@@ -5,7 +5,10 @@
  * spinning up real git repos, we mock spawn() with recorded responses
  * — making tests instant (~0ms each).
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 
 vi.mock("../logger", () => ({
 	createLogger: () => ({
@@ -205,6 +208,53 @@ describe("getUncommittedChanges", () => {
 		const result = await getUncommittedChanges("/repo");
 		expect(result.insertions).toBe(2);
 		expect(result.deletions).toBe(1);
+	});
+
+	// Tests for untracked file handling require real files on disk
+	describe("untracked files", () => {
+		const tmpDir = join(tmpdir(), `git-branch-ops-test-${Date.now()}`);
+
+		beforeEach(() => {
+			mkdirSync(tmpDir, { recursive: true });
+		});
+
+		afterAll(() => {
+			rmSync(tmpDir, { recursive: true, force: true });
+		});
+
+		it("counts lines in untracked text files", async () => {
+			writeFileSync(join(tmpDir, "readme.txt"), "line1\nline2\nline3\n");
+			queueResponse(0, "");               // git diff --numstat HEAD
+			queueResponse(0, "readme.txt\n");   // git ls-files --others
+			const result = await getUncommittedChanges(tmpDir);
+			expect(result.insertions).toBe(3);
+			expect(result.deletions).toBe(0);
+		});
+
+		it("skips untracked binary files (null bytes)", async () => {
+			// Binary file with null bytes — should be excluded
+			const binaryContent = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00]);
+			writeFileSync(join(tmpDir, "image.png"), binaryContent);
+			// Text file — should be counted
+			writeFileSync(join(tmpDir, "app.ts"), "const x = 1;\n");
+			queueResponse(0, "");                           // git diff --numstat HEAD
+			queueResponse(0, "image.png\napp.ts\n");       // git ls-files --others
+			const result = await getUncommittedChanges(tmpDir);
+			expect(result.insertions).toBe(1); // only app.ts line, not binary
+			expect(result.deletions).toBe(0);
+		});
+
+		it("skips untracked files larger than 1 MB", async () => {
+			// Create a file larger than 1 MB
+			const largeContent = "x".repeat(1_048_577) + "\n";
+			writeFileSync(join(tmpDir, "huge.txt"), largeContent);
+			writeFileSync(join(tmpDir, "small.ts"), "ok\n");
+			queueResponse(0, "");                           // git diff --numstat HEAD
+			queueResponse(0, "huge.txt\nsmall.ts\n");      // git ls-files --others
+			const result = await getUncommittedChanges(tmpDir);
+			expect(result.insertions).toBe(1); // only small.ts
+			expect(result.deletions).toBe(0);
+		});
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -509,7 +509,7 @@ export async function getUncommittedChanges(
 		}
 	}
 
-	// Untracked files — every line counts as an insertion
+	// Untracked files — count lines for text files only, skip binary
 	const untrackedResult = await run(
 		["git", "ls-files", "--others", "--exclude-standard"],
 		worktreePath,
@@ -518,7 +518,23 @@ export async function getUncommittedChanges(
 		const files = untrackedResult.stdout.trim().split("\n");
 		for (const file of files) {
 			try {
-				const content = await Bun.file(`${worktreePath}/${file}`).text();
+				const bunFile = Bun.file(`${worktreePath}/${file}`);
+				const size = bunFile.size;
+
+				// Skip empty files and files larger than 1 MB (likely binary or generated)
+				if (size === 0 || size > 1_048_576) continue;
+
+				// Detect binary: check first 8 KB for null bytes
+				const chunk = new Uint8Array(
+					await bunFile.slice(0, Math.min(size, 8192)).arrayBuffer(),
+				);
+				let isBinary = false;
+				for (let i = 0; i < chunk.length; i++) {
+					if (chunk[i] === 0) { isBinary = true; break; }
+				}
+				if (isBinary) continue;
+
+				const content = await bunFile.text();
 				const lines = content.split("\n");
 				// Don't count trailing empty line from final newline
 				insertions += content.endsWith("\n") ? lines.length - 1 : lines.length;
@@ -725,8 +741,8 @@ export async function saveDiffSnapshot(
 	const dir = `${taskDir(project, task)}/diffs`;
 	mkdirSync(dir, { recursive: true });
 
-	// Get full diff
-	const result = await run(["git", "diff", `${ref}...HEAD`], task.worktreePath!);
+	// Get full diff (text only — skip binary content to avoid memory bloat)
+	const result = await run(["git", "diff", "--no-ext-diff", `${ref}...HEAD`], task.worktreePath!);
 	const diff = result.ok ? result.stdout : "";
 
 	// Skip if empty (no changes)

--- a/src/bun/test-setup.ts
+++ b/src/bun/test-setup.ts
@@ -12,7 +12,30 @@
 	}),
 	spawnSync: () => ({ exitCode: 0, stdout: new Uint8Array(0) }),
 	write: () => Promise.resolve(0),
-	file: () => ({ exists: () => Promise.resolve(false), json: () => Promise.resolve({}) }),
+	file: (path: string) => {
+		const fs = require("node:fs");
+		let stat: any = null;
+		try { stat = fs.statSync(path); } catch { /* file doesn't exist */ }
+		return {
+			exists: () => Promise.resolve(stat !== null),
+			json: () => {
+				if (!stat) return Promise.resolve({});
+				return Promise.resolve(JSON.parse(fs.readFileSync(path, "utf-8")));
+			},
+			get size() { return stat ? stat.size : 0; },
+			text: () => Promise.resolve(stat ? fs.readFileSync(path, "utf-8") : ""),
+			slice: (start: number, end: number) => ({
+				arrayBuffer: () => {
+					if (!stat) return Promise.resolve(new ArrayBuffer(0));
+					const buf = Buffer.alloc(end - start);
+					const fd = fs.openSync(path, "r");
+					fs.readSync(fd, buf, 0, end - start, start);
+					fs.closeSync(fd);
+					return Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
+				},
+			}),
+		};
+	},
 };
 
 // Stub process.env if needed


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this branch.

- Binary files (images, compiled assets) were being read as text via `Bun.file().text()` in `getUncommittedChanges()`, causing inflated line counts (e.g. a PNG showing +3919 lines)
- Now detects binary files by checking first 8KB for null bytes and skips them entirely; also skips files >1MB to prevent memory pressure
- Added `--no-ext-diff` to `saveDiffSnapshot` to guard against external diff drivers
- Improved `Bun.file()` mock in test-setup to support real file operations in tests