### PR TITLE
Fix 5 memory leaks: LRU cache, pollers, zombies, stale Sets

### DIFF
--- a/change-logs/2026/03/12/fix-memory-leaks-pollers-zombies.md
+++ b/change-logs/2026/03/12/fix-memory-leaks-pollers-zombies.md
@@ -1,0 +1,1 @@
+Fix 5 memory-related issues: add LRU eviction to ImageLightbox data URL cache (max 30 entries), add stop functions for merge/PR detection pollers to prevent interval stacking, await fire-and-forget tmux spawn calls to prevent zombie processes, and add periodic sweep to clean stale entries from mergeNotifiedTasks/prPromotedTasks Sets.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -155,6 +155,10 @@ const {
 	getPushMessage,
 	checkOpenPRsForPromotion,
 	_resetPRPollerState,
+	startMergeDetectionPoller,
+	stopMergeDetectionPoller,
+	startPRDetectionPoller,
+	stopPRDetectionPoller,
 } = await import("../rpc-handlers");
 
 // ---- Test helpers ----
@@ -3197,5 +3201,81 @@ describe("getChangelogs", () => {
 
 		const result = await handlers.getChangelogs();
 		expect(result).toEqual(fakeEntries);
+	});
+});
+
+describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stopMergeDetectionPoller();
+	});
+
+	afterEach(() => {
+		stopMergeDetectionPoller();
+		vi.useRealTimers();
+	});
+
+	it("can be stopped after starting", () => {
+		startMergeDetectionPoller();
+		// Should not throw
+		stopMergeDetectionPoller();
+	});
+
+	it("stopMergeDetectionPoller is a no-op when not started", () => {
+		// Should not throw
+		stopMergeDetectionPoller();
+	});
+
+	it("does not stack intervals when called multiple times", () => {
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+		startMergeDetectionPoller();
+		startMergeDetectionPoller();
+		startMergeDetectionPoller();
+
+		// Each start clears the previous, so setInterval called 3 times, clearInterval called 3 times (once per start)
+		expect(setIntervalSpy).toHaveBeenCalledTimes(3);
+		// First call: stop before start (no-op since null), second: clears first, third: clears second
+		expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+
+		setIntervalSpy.mockRestore();
+		clearIntervalSpy.mockRestore();
+	});
+});
+
+describe("startPRDetectionPoller / stopPRDetectionPoller", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stopPRDetectionPoller();
+	});
+
+	afterEach(() => {
+		stopPRDetectionPoller();
+		vi.useRealTimers();
+	});
+
+	it("can be stopped after starting", () => {
+		startPRDetectionPoller();
+		stopPRDetectionPoller();
+	});
+
+	it("stopPRDetectionPoller is a no-op when not started", () => {
+		stopPRDetectionPoller();
+	});
+
+	it("does not stack intervals when called multiple times", () => {
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+		startPRDetectionPoller();
+		startPRDetectionPoller();
+		startPRDetectionPoller();
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(3);
+		expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+
+		setIntervalSpy.mockRestore();
+		clearIntervalSpy.mockRestore();
 	});
 });

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -302,7 +302,8 @@ export function isActive(status: TaskStatus): boolean {
 let mergePollerInterval: ReturnType<typeof setInterval> | null = null;
 
 export function startMergeDetectionPoller(): void {
-	if (mergePollerInterval) return;
+	// Clear any existing poller to prevent stacking
+	stopMergeDetectionPoller();
 	const POLL_INTERVAL = 5 * 60_000; // 5 minutes
 
 	mergePollerInterval = setInterval(async () => {
@@ -316,10 +317,35 @@ export function startMergeDetectionPoller(): void {
 	log.info("Merge detection poller started", { intervalMs: POLL_INTERVAL });
 }
 
+export function stopMergeDetectionPoller(): void {
+	if (mergePollerInterval) {
+		clearInterval(mergePollerInterval);
+		mergePollerInterval = null;
+		log.info("Merge detection poller stopped");
+	}
+}
+
 async function checkMergedBranches(): Promise<void> {
 	if (!pushMessage) return;
 
 	const projects = await data.loadProjects();
+
+	// Sweep: remove stale entries from mergeNotifiedTasks and prPromotedTasks
+	// for task IDs that no longer exist in any project.
+	if (mergeNotifiedTasks.size > 0 || prPromotedTasks.size > 0) {
+		const allTaskIds = new Set<string>();
+		for (const p of projects) {
+			const tasks = await data.loadTasks(p);
+			for (const t of tasks) allTaskIds.add(t.id);
+		}
+		for (const id of mergeNotifiedTasks) {
+			if (!allTaskIds.has(id)) mergeNotifiedTasks.delete(id);
+		}
+		for (const id of prPromotedTasks) {
+			if (!allTaskIds.has(id)) prPromotedTasks.delete(id);
+		}
+	}
+
 	for (const project of projects) {
 		const tasks = await data.loadTasks(project);
 		const reviewTasks = tasks.filter(
@@ -379,7 +405,8 @@ let prPollerInterval: ReturnType<typeof setInterval> | null = null;
 const prPromotedTasks = new Set<string>();
 
 export function startPRDetectionPoller(): void {
-	if (prPollerInterval) return;
+	// Clear any existing poller to prevent stacking
+	stopPRDetectionPoller();
 	const POLL_INTERVAL = 5 * 60_000; // 5 minutes
 
 	prPollerInterval = setInterval(async () => {
@@ -391,6 +418,14 @@ export function startPRDetectionPoller(): void {
 	}, POLL_INTERVAL);
 
 	log.info("PR detection poller started", { intervalMs: POLL_INTERVAL });
+}
+
+export function stopPRDetectionPoller(): void {
+	if (prPollerInterval) {
+		clearInterval(prPollerInterval);
+		prPollerInterval = null;
+		log.info("PR detection poller stopped");
+	}
 }
 
 export function _resetPRPollerState(): void {
@@ -1374,9 +1409,11 @@ export const handlers = {
 				// Track so killDevServerSession can kill this pane before the dev session
 				devViewerPaneIds.set(task.id, viewerPaneId);
 				// Label the pane so the user knows Ctrl+b is captured by the outer session
-				spawn(pty.tmuxArgs(socket, "select-pane", "-t", viewerPaneId, "-T", "Dev Server  (Ctrl+b Ctrl+b to control inner)"));
+				const selectPane = spawn(pty.tmuxArgs(socket, "select-pane", "-t", viewerPaneId, "-T", "Dev Server  (Ctrl+b Ctrl+b to control inner)"));
+				await selectPane.exited;
 				// Enable pane border titles for the task session
-				spawn(pty.tmuxArgs(socket, "set-option", "-t", taskSession, "pane-border-status", "top"));
+				const setOption = spawn(pty.tmuxArgs(socket, "set-option", "-t", taskSession, "pane-border-status", "top"));
+				await setOption.exited;
 			}
 
 			log.info("← runDevServer done", { devSession, viewerPaneId });
@@ -1413,7 +1450,8 @@ export const handlers = {
 			await killDevServerSession(task.id, socket);
 			// Remove pane border titles from the task session now that the viewer pane is gone
 			const taskSession = `dev3-${task.id.slice(0, 8)}`;
-			spawn(pty.tmuxArgs(socket, "set-option", "-t", taskSession, "pane-border-status", "off"));
+			const setOption = spawn(pty.tmuxArgs(socket, "set-option", "-t", taskSession, "pane-border-status", "off"));
+			await setOption.exited;
 			log.info("← stopDevServer done");
 		} catch (err) {
 			log.error("stopDevServer FAILED", {

--- a/src/mainview/components/ImageLightbox.tsx
+++ b/src/mainview/components/ImageLightbox.tsx
@@ -3,7 +3,32 @@ import { createPortal } from "react-dom";
 import { api } from "../rpc";
 import { useT } from "../i18n";
 
-const dataUrlCache = new Map<string, string>();
+export const DATA_URL_CACHE_MAX = 30;
+export const dataUrlCache = new Map<string, string>();
+
+/** Move key to end (most-recently-used) and evict oldest if over limit. */
+export function cacheSet(key: string, value: string): void {
+	// Re-insert to move to end of iteration order
+	dataUrlCache.delete(key);
+	dataUrlCache.set(key, value);
+	// Evict oldest entries (first in iteration order)
+	while (dataUrlCache.size > DATA_URL_CACHE_MAX) {
+		const oldest = dataUrlCache.keys().next().value;
+		if (oldest !== undefined) dataUrlCache.delete(oldest);
+		else break;
+	}
+}
+
+/** Touch key to mark as recently used. */
+export function cacheGet(key: string): string | undefined {
+	const value = dataUrlCache.get(key);
+	if (value !== undefined) {
+		// Re-insert to move to end
+		dataUrlCache.delete(key);
+		dataUrlCache.set(key, value);
+	}
+	return value;
+}
 
 interface ImageLightboxProps {
 	paths: string[];
@@ -24,8 +49,9 @@ export function ImageLightbox({ paths, currentIndex, onClose }: ImageLightboxPro
 	}, [currentIndex]);
 
 	useEffect(() => {
-		if (dataUrlCache.has(path)) {
-			setDataUrl(dataUrlCache.get(path)!);
+		const cached = cacheGet(path);
+		if (cached !== undefined) {
+			setDataUrl(cached);
 			setLoading(false);
 			return;
 		}
@@ -36,7 +62,7 @@ export function ImageLightbox({ paths, currentIndex, onClose }: ImageLightboxPro
 		api.request.readImageBase64({ path }).then((result) => {
 			if (cancelled) return;
 			if (result) {
-				dataUrlCache.set(path, result.dataUrl);
+				cacheSet(path, result.dataUrl);
 				setDataUrl(result.dataUrl);
 			}
 			setLoading(false);

--- a/src/mainview/components/__tests__/ImageLightbox.test.tsx
+++ b/src/mainview/components/__tests__/ImageLightbox.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ImageLightbox } from "../ImageLightbox";
+import { ImageLightbox, cacheSet, cacheGet, dataUrlCache, DATA_URL_CACHE_MAX } from "../ImageLightbox";
 import { I18nProvider } from "../../i18n";
 
 vi.mock("../../rpc", () => ({
@@ -68,5 +68,53 @@ describe("ImageLightbox keyboard shortcuts", () => {
 		await userEvent.keyboard("{ArrowRight}");
 		await userEvent.keyboard("{ArrowRight}");
 		expect(screen.getByText("3 / 3")).toBeInTheDocument();
+	});
+});
+
+describe("ImageLightbox LRU cache", () => {
+	beforeEach(() => {
+		dataUrlCache.clear();
+	});
+
+	it("stores and retrieves values", () => {
+		cacheSet("a", "data-a");
+		expect(cacheGet("a")).toBe("data-a");
+	});
+
+	it("returns undefined for missing keys", () => {
+		expect(cacheGet("missing")).toBeUndefined();
+	});
+
+	it("evicts oldest entries when exceeding max size", () => {
+		for (let i = 0; i < DATA_URL_CACHE_MAX + 5; i++) {
+			cacheSet(`key-${i}`, `val-${i}`);
+		}
+		expect(dataUrlCache.size).toBe(DATA_URL_CACHE_MAX);
+		// First 5 keys should be evicted
+		for (let i = 0; i < 5; i++) {
+			expect(cacheGet(`key-${i}`)).toBeUndefined();
+		}
+		// Last entries should still exist
+		expect(cacheGet(`key-${DATA_URL_CACHE_MAX + 4}`)).toBe(`val-${DATA_URL_CACHE_MAX + 4}`);
+	});
+
+	it("accessing a key promotes it (LRU behavior)", () => {
+		for (let i = 0; i < DATA_URL_CACHE_MAX; i++) {
+			cacheSet(`key-${i}`, `val-${i}`);
+		}
+		// Access the oldest key to promote it
+		cacheGet("key-0");
+		// Add one more to trigger eviction — key-1 should be evicted, not key-0
+		cacheSet("new-key", "new-val");
+		expect(dataUrlCache.size).toBe(DATA_URL_CACHE_MAX);
+		expect(cacheGet("key-0")).toBe("val-0");
+		expect(cacheGet("key-1")).toBeUndefined();
+	});
+
+	it("updating an existing key does not increase size", () => {
+		cacheSet("a", "v1");
+		cacheSet("a", "v2");
+		expect(dataUrlCache.size).toBe(1);
+		expect(cacheGet("a")).toBe("v2");
 	});
 });


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI assistant working on this one.

Fixes 5 out of 6 reported memory issues from the codebase audit (Issue #2 was already resolved):

- **ImageLightbox unbounded cache**: Added LRU eviction (max 30 entries) to `dataUrlCache` Map that stored multi-MB base64 data URLs forever
- **Merge/PR poller stacking**: Added `stopMergeDetectionPoller()` / `stopPRDetectionPoller()` and clear-before-start logic to prevent interval accumulation
- **Zombie tmux processes**: Awaited 3 fire-and-forget `spawn()` calls in `runDevServer`/`stopDevServer` that leaked process handles
- **Stale mergeNotifiedTasks/prPromotedTasks**: Added periodic sweep in `checkMergedBranches()` to remove IDs for tasks that no longer exist