### PR TITLE
feat: add Plan then Bypass configs for Claude, Cursor, and Codex

### DIFF
--- a/change-logs/2026/03/12/feature-plan-then-bypass-mode.md
+++ b/change-logs/2026/03/12/feature-plan-then-bypass-mode.md
@@ -1,0 +1,1 @@
+Added "Plan then Bypass" agent configurations for Claude (Opus and Sonnet), Cursor (Opus 4.6), and Codex (GPT-5.4). These configs start in plan mode so the agent presents a plan for review, then execute without per-action permission prompts once approved.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,6 +128,8 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		configurations: [
 			{ id: "claude-default", name: "Default", model: "sonnet" },
 			{ id: "claude-plan", name: "Plan (Opus)", model: "opus", permissionMode: "plan" },
+			{ id: "claude-plan-then-bypass-opus", name: "Plan then Bypass (Opus)", model: "opus", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"] },
+			{ id: "claude-plan-then-bypass-sonnet", name: "Plan then Bypass (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"] },
 			{ id: "claude-approvals-opus", name: "Approvals (Opus)", model: "opus", permissionMode: "acceptEdits" },
 			{ id: "claude-approvals-sonnet", name: "Approvals (Sonnet)", model: "sonnet", permissionMode: "acceptEdits" },
 			{ id: "claude-bypass-opus", name: "Bypass (Opus)", model: "opus", permissionMode: "bypassPermissions" },
@@ -167,6 +169,13 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 				additionalArgs: ["--search", "--no-alt-screen", "-c", 'model_reasoning_effort="high"'],
 			},
 			{
+				id: "codex-plan-then-bypass",
+				name: "Plan then Bypass (GPT-5.4)",
+				model: "gpt-5.4",
+				appendPrompt: "First, produce a concrete implementation plan with risks and checkpoints. Do not start making code changes until that plan is complete.",
+				additionalArgs: ["--search", "--full-auto", "--no-alt-screen", "-c", 'model_reasoning_effort="high"'],
+			},
+			{
 				id: "codex-codex-medium",
 				name: "GPT-5.3 Codex Medium",
 				model: "gpt-5.3-codex",
@@ -197,6 +206,7 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		configurations: [
 			{ id: "cursor-default", name: "Default (Opus 4.6)", model: "opus-4.6-thinking" },
 			{ id: "cursor-plan", name: "Plan (Opus 4.6)", model: "opus-4.6-thinking", permissionMode: "plan" },
+			{ id: "cursor-plan-then-bypass", name: "Plan then Bypass (Opus 4.6)", model: "opus-4.6-thinking", permissionMode: "plan", additionalArgs: ["--force"] },
 			{ id: "cursor-yolo", name: "YOLO (Opus 4.6)", model: "opus-4.6-thinking", permissionMode: "bypassPermissions" },
 			{ id: "cursor-gpt", name: "GPT-5.3 Codex High", model: "gpt-5.3-codex-high" },
 			{ id: "cursor-yolo-gpt", name: "YOLO GPT-5.3 Codex", model: "gpt-5.3-codex-high", permissionMode: "bypassPermissions" },


### PR DESCRIPTION
## Summary

- Added **Plan then Bypass** agent configurations for Claude (Opus + Sonnet), Cursor (Opus 4.6), and Codex (GPT-5.4)
- Agent presents a plan for user review first, then executes without per-action permission prompts
- Pure data change — only `src/shared/types.ts` (`DEFAULT_AGENTS`) modified

## How it works

| Agent | Mechanism |
|---|---|
| Claude | `permissionMode: "plan"` + `--allow-dangerously-skip-permissions` |
| Cursor | `permissionMode: "plan"` + `--force` |
| Codex | `appendPrompt` (plan first instruction) + `--full-auto` |

## Test plan

- [ ] All existing tests pass (agents.test.ts — no count assertions broken)
- [ ] Manual: create task → select "Plan then Bypass (Sonnet)" → confirm plan mode starts, then executes without prompts after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)