### PR TITLE
fix: remove mini pipeline badge overlays

### DIFF
--- a/change-logs/2026/03/13/fix-mini-pipeline-badges.md
+++ b/change-logs/2026/03/13/fix-mini-pipeline-badges.md
@@ -1,0 +1,2 @@
+Removed the side-branch badge overlay from the compact status pipeline so the mini pipeline only shows stage dots.
+Added a regression test to keep question and cancel markers from reappearing in the mini pipeline.

--- a/src/mainview/components/MiniPipeline.tsx
+++ b/src/mainview/components/MiniPipeline.tsx
@@ -1,6 +1,6 @@
 import type { TaskStatus } from "../../shared/types";
 import { useStatusColors } from "../hooks/useStatusColors";
-import { PIPELINE_STAGES, getStageStates, isSideBranch } from "./StatusPipeline";
+import { PIPELINE_STAGES, getStageStates } from "./StatusPipeline";
 
 interface MiniPipelineProps {
 	status: TaskStatus;
@@ -14,7 +14,6 @@ interface MiniPipelineProps {
 export default function MiniPipeline({ status }: MiniPipelineProps) {
 	const statusColors = useStatusColors();
 	const states = getStageStates(status);
-	const isSide = isSideBranch(status);
 	const isCancelled = status === "cancelled";
 	const cancelledColor = statusColors["cancelled"];
 
@@ -60,18 +59,6 @@ export default function MiniPipeline({ status }: MiniPipelineProps) {
 										: undefined,
 								}}
 							/>
-							{/* Side-branch indicator on current dot (not for cancelled) */}
-							{isCurrent && isSide && !isCancelled && (
-								<div
-									className="absolute -top-1 -right-1 w-2 h-2 rounded-full flex items-center justify-center text-[5px] font-bold leading-none"
-									style={{
-										background: statusColors[status],
-										color: "#000",
-									}}
-								>
-									{status === "user-questions" ? "?" : "×"}
-								</div>
-							)}
 						</div>
 					</div>
 				);

--- a/src/mainview/components/__tests__/MiniPipeline.test.tsx
+++ b/src/mainview/components/__tests__/MiniPipeline.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MiniPipeline from "../MiniPipeline";
+
+describe("MiniPipeline", () => {
+	it("does not render a question badge for user-questions", () => {
+		const { container } = render(<MiniPipeline status="user-questions" />);
+
+		expect(container.textContent).toBe("");
+	});
+
+	it("does not render a cancelled badge marker", () => {
+		const { container } = render(<MiniPipeline status="cancelled" />);
+
+		expect(container.textContent).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary
- remove the side-branch badge overlay from the compact MiniPipeline dots
- keep the mini pipeline clean in both task cards and the task info panel
- add a regression test covering user-questions and cancelled states

## Testing
- bun run lint
- bun run test