### PR TITLE
Add Gemini CLI auto-trust and presets

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -2,7 +2,7 @@
 
 Feature compatibility across supported AI coding agents.
 
-Last updated: 2026-03-09
+Last updated: 2026-03-13
 
 ## Agents
 
@@ -21,11 +21,11 @@ Last updated: 2026-03-09
 | **Skill injection** | Yes (`!` command syntax) | Yes (generic) | Yes (generic) | Yes (generic) |
 | **System prompt injection** | `--append-system-prompt` | via prompt arg | — | — |
 | **Session resume** | `--continue` | `--continue` | `resume --last` | `--resume latest` |
-| **Permission mode** | `--permission-mode` | `--mode plan` / `--force` | `--permission-mode` | `--permission-mode` |
-| **Effort level** | `--effort` | — | `--effort` | `--effort` |
-| **Max budget** | `--max-budget-usd` | — | `--max-budget-usd` | `--max-budget-usd` |
+| **Permission mode** | `--permission-mode` | `--mode plan` / `--force` | `--permission-mode` | `--approval-mode` |
+| **Effort level** | `--effort` | — | `--effort` | — |
+| **Max budget** | `--max-budget-usd` | — | `--max-budget-usd` | — |
 | **Model selection** | `--model` | `--model` | `--model` | `--model` |
-| **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | — | — |
+| **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | — | Yes (`ensureGeminiTrust`) |
 | **Status hooks (automatic)** | Yes (4 hooks) | — | — | — |
 | **Status management** | Automatic via hooks | Manual (SKILL.md) | Manual (SKILL.md) | Manual (SKILL.md) |
 

--- a/change-logs/2026/03/13/feature-gemini-trust-presets.md
+++ b/change-logs/2026/03/13/feature-gemini-trust-presets.md
@@ -1,0 +1,1 @@
+Add Gemini CLI auto-trust and configuration presets. New worktrees are automatically registered in ~/.gemini/trustedFolders.json, eliminating the trust dialog. Gemini now has 9 presets across three model tiers (3.1 Pro, 3 Flash, 3.1 Flash Lite) with approval mode mapping (default, plan, yolo, auto_edit).

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -73,6 +73,8 @@ vi.mock("../pty-server", () => ({
 
 vi.mock("../agents", () => ({
 	ensureClaudeTrust: vi.fn(),
+	ensureGeminiTrust: vi.fn(),
+	isGeminiCommand: vi.fn(() => false),
 	resolveCommandForAgent: vi.fn(() => ({ command: "claude", extraEnv: {} })),
 	resolveCommandForProject: vi.fn(() => ({ command: "claude", extraEnv: {} })),
 	getAllAgents: vi.fn(() => []),

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -231,6 +231,7 @@ export function resolveAgentCommand(
 	}
 
 	const cursorAgent = isCursorCommand(baseCmd);
+	const geminiAgent = isGeminiCommand(baseCmd);
 
 	if (config?.permissionMode && config.permissionMode !== "default" && !codexAgent) {
 		if (cursorAgent) {
@@ -241,16 +242,25 @@ export function resolveAgentCommand(
 				args.push("--force");
 			}
 			// "acceptEdits" and "dontAsk" have no cursor equivalent — skip
+		} else if (geminiAgent) {
+			// Gemini CLI uses --approval-mode with its own value set
+			const geminiModeMap: Record<string, string> = {
+				acceptEdits: "auto_edit",
+				bypassPermissions: "yolo",
+				dontAsk: "yolo",
+				plan: "plan",
+			};
+			args.push("--approval-mode", geminiModeMap[config.permissionMode] ?? config.permissionMode);
 		} else {
 			args.push("--permission-mode", config.permissionMode);
 		}
 	}
 
-	if (config?.effort && !cursorAgent && !codexAgent) {
+	if (config?.effort && !cursorAgent && !codexAgent && !geminiAgent) {
 		args.push("--effort", config.effort);
 	}
 
-	if (config?.maxBudgetUsd != null && config.maxBudgetUsd > 0 && !cursorAgent && !codexAgent) {
+	if (config?.maxBudgetUsd != null && config.maxBudgetUsd > 0 && !cursorAgent && !codexAgent && !geminiAgent) {
 		args.push("--max-budget-usd", String(config.maxBudgetUsd));
 	}
 
@@ -408,6 +418,38 @@ export function buildTaskEnv(
 	}
 
 	return env;
+}
+
+// ---- Gemini Trust ----
+
+const GEMINI_TRUSTED_FOLDERS = `${homedir()}/.gemini/trustedFolders.json`;
+
+/**
+ * Ensure a directory is marked as trusted in ~/.gemini/trustedFolders.json so
+ * that `gemini` CLI skips the "Do you trust the files in this folder?" dialog.
+ * Resolves symlinks (e.g. /tmp → /private/tmp on macOS).
+ */
+export async function ensureGeminiTrust(dirPath: string): Promise<void> {
+	try {
+		const resolved = await realpath(dirPath);
+		const file = Bun.file(GEMINI_TRUSTED_FOLDERS);
+		let data: Record<string, string> = {};
+		if (await file.exists()) {
+			data = await file.json();
+		}
+
+		if (data[resolved] === "TRUST_FOLDER") {
+			return; // already trusted
+		}
+
+		data[resolved] = "TRUST_FOLDER";
+
+		await Bun.write(GEMINI_TRUSTED_FOLDERS, JSON.stringify(data, null, 2));
+		log.info("Registered worktree as trusted in ~/.gemini/trustedFolders.json", { path: resolved });
+	} catch (err) {
+		// Non-fatal — worst case the user sees the trust dialog
+		log.warn("Failed to register Gemini worktree trust", { error: String(err) });
+	}
 }
 
 // ---- Claude Trust ----

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -738,6 +738,20 @@ export async function launchTaskPty(
 		});
 	}
 
+	// Pre-register worktree as trusted so gemini skips the trust dialog
+	if (agents.isGeminiCommand(resolvedBaseCmd)) {
+		try {
+			await agents.ensureGeminiTrust(worktreePath);
+			log.info("Gemini trust ensured", { worktreePath });
+		} catch (err) {
+			log.error("ensureGeminiTrust failed (non-fatal)", {
+				worktreePath,
+				error: String(err),
+				stack: (err as Error)?.stack ?? "no stack",
+			});
+		}
+	}
+
 	// Install agent-native hooks (e.g., Claude Code PermissionRequest/Stop)
 	try {
 		setupAgentHooks(worktreePath, task.id, resolvedBaseCmd);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -236,7 +236,20 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		name: "Gemini",
 		baseCommand: "gemini",
 		isDefault: true,
-		configurations: [{ id: "gemini-default", name: "Default" }],
+		configurations: [
+			// --- Gemini 3.1 Pro (heavy) ---
+			{ id: "gemini-default", name: "Default (3.1 Pro)", model: "gemini-3.1-pro-preview", version: 1 },
+			{ id: "gemini-plan", name: "Plan (3.1 Pro)", model: "gemini-3.1-pro-preview", permissionMode: "plan", version: 1 },
+			{ id: "gemini-yolo", name: "YOLO (3.1 Pro)", model: "gemini-3.1-pro-preview", permissionMode: "bypassPermissions", version: 1 },
+			{ id: "gemini-auto-edit", name: "Auto Edit (3.1 Pro)", model: "gemini-3.1-pro-preview", permissionMode: "acceptEdits", version: 1 },
+			// --- Gemini 3 Flash (medium) ---
+			{ id: "gemini-flash", name: "Default (3 Flash)", model: "gemini-3-flash-preview", version: 1 },
+			{ id: "gemini-flash-yolo", name: "YOLO (3 Flash)", model: "gemini-3-flash-preview", permissionMode: "bypassPermissions", version: 1 },
+			{ id: "gemini-flash-auto-edit", name: "Auto Edit (3 Flash)", model: "gemini-3-flash-preview", permissionMode: "acceptEdits", version: 1 },
+			// --- Gemini 3.1 Flash Lite (light) ---
+			{ id: "gemini-flash-lite", name: "Default (3.1 Flash Lite)", model: "gemini-3.1-flash-lite-preview", version: 1 },
+			{ id: "gemini-flash-lite-yolo", name: "YOLO (3.1 Flash Lite)", model: "gemini-3.1-flash-lite-preview", permissionMode: "bypassPermissions", version: 1 },
+		],
 		defaultConfigId: "gemini-default",
 	},
 	{


### PR DESCRIPTION
## Summary

Hey there! Claude here (the AI assistant on this task).

- Add `ensureGeminiTrust()` to auto-register worktrees in `~/.gemini/trustedFolders.json`, eliminating the "Do you trust the files in this folder?" dialog for Gemini CLI
- Map Gemini's `--approval-mode` flag (`auto_edit`, `yolo`, `plan`) instead of the generic `--permission-mode`; exclude Gemini from unsupported `--effort` and `--max-budget-usd` flags
- Expand Gemini presets from 1 ("Default") to 9 configurations across three model tiers: Gemini 3.1 Pro, Gemini 3 Flash, and Gemini 3.1 Flash Lite — with approval mode variants (Default, Plan, YOLO, Auto Edit)
- Update agent support matrix to reflect Gemini's auto-trust, approval-mode, and unsupported flags