### PR TITLE
fix: tmux backslash split binding

### DIFF
--- a/change-logs/2026/03/13/fix-tmux-backslash-binding.md
+++ b/change-logs/2026/03/13/fix-tmux-backslash-binding.md
@@ -1,0 +1,1 @@
+Make the bundled tmux config use String.raw so the backslash split binding is emitted as a literal `bind \\ split-window ...` line. Added a regression test for the generated config text and kept the shift-keys e2e tmux fixture in sync.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -748,5 +748,41 @@ describe("pty-server", () => {
 		it("equals /tmp/dev3-tmux.conf", () => {
 			expect(TMUX_CONF_PATH).toBe("/tmp/dev3-tmux.conf");
 		});
+
+		it("writes a backslash split binding with a literal double backslash", async () => {
+			vi.resetModules();
+
+			const writeFileSyncMock = vi.fn();
+
+			vi.doMock("node:fs", async (importOriginal) => {
+				const actual = await importOriginal<typeof import("node:fs")>();
+				return {
+					...actual,
+					existsSync: vi.fn(() => true),
+					writeFileSync: writeFileSyncMock,
+				};
+			});
+
+			vi.doMock("../logger", () => ({
+				createLogger: () => ({
+					debug: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+				}),
+			}));
+
+			vi.doMock("../spawn", () => ({
+				spawn: vi.fn(),
+				spawnSync: vi.fn(),
+			}));
+
+			const { TMUX_CONF_PATH: configPath } = await import("../pty-server");
+
+			expect(writeFileSyncMock).toHaveBeenCalledWith(
+				configPath,
+				expect.stringContaining(String.raw`bind \\ split-window -h -c "#{pane_current_path}"`),
+			);
+		});
 	});
 });

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -9,7 +9,7 @@ import { spawn, spawnSync } from "./spawn";
 
 export const TMUX_CONF_PATH = "/tmp/dev3-tmux.conf";
 
-const TMUX_CONFIG = `# Mouse support
+const TMUX_CONFIG = String.raw`# Mouse support
 setw -g mouse on
 
 # Window/pane numbering starts at 1
@@ -33,7 +33,7 @@ set -g renumber-windows on
 
 # Intuitive splits (open in same directory)
 bind | split-window -h -c "#{pane_current_path}"
-bind \\\\ split-window -h -c "#{pane_current_path}"
+bind \\ split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"
 
 # Alt+arrow pane switching (no prefix required)

--- a/src/mainview/__tests__/shift-keys-e2e.test.ts
+++ b/src/mainview/__tests__/shift-keys-e2e.test.ts
@@ -36,7 +36,7 @@ import { join, resolve } from "node:path";
 // The test must use the identical config so we catch regressions that only
 // manifest with the real settings (e.g. escape-time 0, mouse on).
 // If you change pty-server.ts, keep this in sync.
-const TMUX_CONFIG_FOR_TEST = `# Mouse support
+const TMUX_CONFIG_FOR_TEST = String.raw`# Mouse support
 setw -g mouse on
 
 # Window/pane numbering starts at 1
@@ -60,7 +60,7 @@ set -g renumber-windows on
 
 # Intuitive splits (open in same directory)
 bind | split-window -h -c "#{pane_current_path}"
-bind \\\\ split-window -h -c "#{pane_current_path}"
+bind \\ split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"
 
 # Alt+arrow pane switching (no prefix required)


### PR DESCRIPTION
## Summary
- make the bundled tmux config use String.raw so the backslash split binding is emitted as `bind \\ split-window ...`
- add a regression test for the generated config text in pty-server
- keep the shift-keys e2e tmux fixture in sync with the backend config

## Testing
- bun run lint
- bun run test
- bunx vitest run -c vitest.config.bun.ts src/bun/__tests__/pty-server.test.ts