### PR TITLE
feat: add iTerm2 compatibility toggle to tmux hints popover

### DIFF
--- a/change-logs/2026/03/13/feature-iterm-toggle-in-tmux-hints.md
+++ b/change-logs/2026/03/13/feature-iterm-toggle-in-tmux-hints.md
@@ -1,0 +1,1 @@
+Added iTerm2 compatibility toggle to the tmux shortcuts popover (the ⓘ info button in the task panel header). Users can now enable or disable the iTerm2 keymap preset directly from the hints tooltip without navigating to global settings.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -9,6 +9,7 @@ import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
 import { useT, statusKey } from "../i18n";
 import { trackEvent } from "../analytics";
+import { getKeymapPreset, setKeymapPreset, KEYMAP_CHANGED_EVENT } from "../terminal-keymaps";
 import { confirmTaskCompletion } from "../utils/confirmTaskCompletion";
 import { ImageAttachmentsStrip } from "./ImageAttachmentsStrip";
 import OpenInMenu from "./OpenInMenu";
@@ -288,6 +289,21 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 	}
 
 	// ---- Tmux hints popover state ----
+	const [keymapPreset, setKeymapPresetState] = useState(() => getKeymapPreset());
+
+	useEffect(() => {
+		function onKeymapChanged(e: Event) {
+			setKeymapPresetState((e as CustomEvent).detail);
+		}
+		window.addEventListener(KEYMAP_CHANGED_EVENT, onKeymapChanged);
+		return () => window.removeEventListener(KEYMAP_CHANGED_EVENT, onKeymapChanged);
+	}, []);
+
+	function toggleItermCompat(e: React.MouseEvent) {
+		e.stopPropagation();
+		setKeymapPreset(keymapPreset === "iterm2" ? "default" : "iterm2");
+	}
+
 	const [hintsOpen, setHintsOpen] = useState(false);
 	const [hintsPos, setHintsPos] = useState({ top: 0, left: 0 });
 	const [hintsVisible, setHintsVisible] = useState(false);
@@ -1378,6 +1394,33 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 				<kbd className={popoverKbd}>⌃B x</kbd><span className={popoverDesc}>{t("tmux.closePaneDesc")}</span>
 				<span className={popoverDesc + " col-span-2 mt-1.5 text-fg-muted"}>{t("tmux.selectPaneDesc")}</span>
 				<span className={popoverDesc + " col-span-2 text-fg-muted"}>{t("tmux.resizePaneDesc")}</span>
+			</div>
+
+			{/* iTerm2 compatibility toggle */}
+			<div className="border-t border-edge mt-3 pt-3">
+				<div className={popoverSection}>{t("tmux.keyboardMode")}</div>
+				<button
+					onClick={toggleItermCompat}
+					className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left transition-colors ${
+						keymapPreset === "iterm2"
+							? "bg-accent/10 border border-accent/20"
+							: "hover:bg-elevated border border-transparent"
+					}`}
+				>
+					<div className={`w-3.5 h-3.5 rounded flex items-center justify-center flex-shrink-0 border transition-colors ${
+						keymapPreset === "iterm2" ? "border-accent bg-accent" : "border-edge-active"
+					}`}>
+						{keymapPreset === "iterm2" && (
+							<svg width="7" height="6" viewBox="0 0 7 6" fill="none">
+								<path d="M0.5 3L2.5 5L6.5 1" stroke="white" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+							</svg>
+						)}
+					</div>
+					<div>
+						<div className={`text-xs font-medium ${keymapPreset === "iterm2" ? "text-accent" : "text-fg-2"}`}>{t("settings.keymapIterm2")}</div>
+						<div className="text-[0.625rem] text-fg-muted mt-0.5">{t("settings.keymapIterm2Desc")}</div>
+					</div>
+				</button>
 			</div>
 		</div>,
 		document.body,

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -22,6 +22,7 @@ const terminal = {
 	"tmux.closePaneDesc": "Close pane",
 	"tmux.selectPaneDesc": "Click on a pane to select it",
 	"tmux.resizePaneDesc": "Drag pane border to resize",
+	"tmux.keyboardMode": "Keyboard Mode",
 
 	// Tmux Session Manager
 	"tmuxSessions.title": "tmux Sessions",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -22,6 +22,7 @@ const terminal = {
 	"tmux.closePaneDesc": "Cerrar panel",
 	"tmux.selectPaneDesc": "Haz clic en un panel para seleccionarlo",
 	"tmux.resizePaneDesc": "Arrastra el borde del panel para redimensionar",
+	"tmux.keyboardMode": "Modo de teclado",
 
 	// Tmux Session Manager
 	"tmuxSessions.title": "Sesiones tmux",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -22,6 +22,7 @@ const terminal = {
 	"tmux.closePaneDesc": "Закрыть панель",
 	"tmux.selectPaneDesc": "Кликните на панель для выбора",
 	"tmux.resizePaneDesc": "Перетащите границу для ресайза",
+	"tmux.keyboardMode": "Режим клавиш",
 
 	// Tmux Session Manager
 	"tmuxSessions.title": "Сессии tmux",


### PR DESCRIPTION
## Summary

- Added an iTerm2 compatibility toggle to the tmux shortcuts popover (the ⓘ info button in the task panel header)
- Users can now enable/disable the iTerm2 keymap preset directly from the hints tooltip — no need to navigate to global settings
- The toggle stays in sync with GlobalSettings; changing it in either place updates the other
- Added `"tmux.keyboardMode"` translation key to all 3 locales (en/ru/es)

## Test plan

- [ ] Open a task with a terminal, hover over the ⓘ info button → hints popover appears
- [ ] Scroll to the "Keyboard Mode" section at the bottom of the popover
- [ ] Click the iTerm2 toggle — checkbox turns blue/checked, ⌘ shortcuts become active
- [ ] Click again — checkbox unchecks, shortcuts revert to default
- [ ] Open Global Settings → Terminal Keymap — verify state matches the toggle
- [ ] Change setting in GlobalSettings → verify popover reflects the change