### PR TITLE
Fix Todo column to be expanded by default

### DIFF
--- a/change-logs/2026/03/14/fix-todo-column-default-open.md
+++ b/change-logs/2026/03/14/fix-todo-column-default-open.md
@@ -1,0 +1,1 @@
+The Todo column is now expanded by default on the Kanban board. Previously it was collapsed along with Completed and Cancelled, making new tasks less visible.

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -311,10 +311,10 @@ describe("collapsible columns", () => {
 		localStorage.clear();
 	});
 
-	it("renders todo, completed, cancelled as collapsed by default", async () => {
+	it("renders completed, cancelled as collapsed by default", async () => {
 		await renderBoardWith();
 		const collapsedCols = document.querySelectorAll("[data-collapsed-column]");
-		expect(collapsedCols.length).toBe(3);
+		expect(collapsedCols.length).toBe(2);
 	});
 
 	it("active columns are always expanded", async () => {

--- a/src/mainview/hooks/__tests__/useColumnCollapse.test.ts
+++ b/src/mainview/hooks/__tests__/useColumnCollapse.test.ts
@@ -6,51 +6,51 @@ beforeEach(() => {
 });
 
 describe("useColumnCollapse", () => {
-	it("defaults todo, completed, cancelled to collapsed", () => {
+	it("defaults completed, cancelled to collapsed", () => {
 		const { result } = renderHook(() => useColumnCollapse("proj-1"));
-		expect(result.current.isCollapsed("todo")).toBe(true);
 		expect(result.current.isCollapsed("completed")).toBe(true);
 		expect(result.current.isCollapsed("cancelled")).toBe(true);
 	});
 
-	it("active statuses are expanded by default", () => {
+	it("todo and active statuses are expanded by default", () => {
 		const { result } = renderHook(() => useColumnCollapse("proj-1"));
+		expect(result.current.isCollapsed("todo")).toBe(false);
 		expect(result.current.isCollapsed("in-progress")).toBe(false);
 		expect(result.current.isCollapsed("user-questions")).toBe(false);
 		expect(result.current.isCollapsed("review-by-user")).toBe(false);
 	});
 
-	it("toggle: collapsed → expanded", () => {
+	it("toggle: expanded → collapsed", () => {
 		const { result } = renderHook(() => useColumnCollapse("proj-1"));
-		expect(result.current.isCollapsed("todo")).toBe(true);
-		act(() => result.current.toggle("todo"));
 		expect(result.current.isCollapsed("todo")).toBe(false);
+		act(() => result.current.toggle("todo"));
+		expect(result.current.isCollapsed("todo")).toBe(true);
 	});
 
-	it("toggle: expanded → re-collapsed", () => {
+	it("toggle: collapsed → expanded → re-collapsed", () => {
 		const { result } = renderHook(() => useColumnCollapse("proj-1"));
-		act(() => result.current.toggle("todo")); // expand
-		act(() => result.current.toggle("todo")); // collapse again
-		expect(result.current.isCollapsed("todo")).toBe(true);
+		act(() => result.current.toggle("todo")); // collapse
+		act(() => result.current.toggle("todo")); // expand again
+		expect(result.current.isCollapsed("todo")).toBe(false);
 	});
 
 	it("persists collapse state in localStorage", () => {
 		const { result, unmount } = renderHook(() => useColumnCollapse("proj-1"));
-		act(() => result.current.toggle("todo")); // expand todo
+		act(() => result.current.toggle("todo")); // collapse todo
 		unmount();
 
 		// Re-mount and check persisted state
 		const { result: result2 } = renderHook(() => useColumnCollapse("proj-1"));
-		expect(result2.current.isCollapsed("todo")).toBe(false);
+		expect(result2.current.isCollapsed("todo")).toBe(true); // persisted as collapsed
 		expect(result2.current.isCollapsed("completed")).toBe(true); // still collapsed
 	});
 
 	it("per-project isolation", () => {
 		const { result: r1 } = renderHook(() => useColumnCollapse("proj-1"));
-		act(() => r1.current.toggle("todo"));
+		act(() => r1.current.toggle("todo")); // collapse in proj-1
 
 		const { result: r2 } = renderHook(() => useColumnCollapse("proj-2"));
-		expect(r2.current.isCollapsed("todo")).toBe(true); // proj-2 has defaults
+		expect(r2.current.isCollapsed("todo")).toBe(false); // proj-2 has defaults (expanded)
 	});
 
 	it("toggle on expanded column collapses it", () => {

--- a/src/mainview/hooks/useColumnCollapse.ts
+++ b/src/mainview/hooks/useColumnCollapse.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { TaskStatus } from "../../shared/types";
 
-const DEFAULT_COLLAPSED: TaskStatus[] = ["todo", "completed", "cancelled"];
+const DEFAULT_COLLAPSED: TaskStatus[] = ["completed", "cancelled"];
 
 function storageKey(projectId: string) {
 	return `dev3-kanban-collapsed-${projectId}`;


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this one.

- Removed `"todo"` from `DEFAULT_COLLAPSED` in `useColumnCollapse.ts` so the Todo column is expanded by default on the Kanban board
- Previously Todo was collapsed alongside Completed and Cancelled, making new tasks less visible
- Updated unit and integration tests to match the new default