### PR TITLE
Fix custom column status not reflected in task info panel

### DIFF
--- a/change-logs/2026/03/14/fix-custom-column-status-display.md
+++ b/change-logs/2026/03/14/fix-custom-column-status-display.md
@@ -1,0 +1,3 @@
+Fixed task info panel and task card showing the built-in status instead of the custom column name when a task is in a custom column. Also fixed the MOVE TO dropdown hiding the current custom column entirely — it now shows with a "current" marker, consistent with built-in statuses.
+
+Suggested by @barvolovski (h0x91b/dev-3.0#311)

--- a/src/mainview/components/PipelineDropdown.tsx
+++ b/src/mainview/components/PipelineDropdown.tsx
@@ -148,21 +148,35 @@ export default function PipelineDropdown({
 				<>
 					<div className="border-t border-edge-active mx-3 my-1" />
 					<div className="px-3 pb-1">
-						{customColumns
-							.filter((col) => col.id !== currentCustomColumnId)
-							.map((col) => (
+						{customColumns.map((col) => {
+							const isCurrent = col.id === currentCustomColumnId;
+							return (
 								<button
 									key={col.id}
-									onClick={() => onMoveToCustomColumn?.(col.id)}
-									className="w-full text-left flex items-center gap-2.5 py-1.5 px-1.5 text-sm text-fg-2 hover:bg-elevated-hover hover:text-fg rounded-md transition-colors cursor-pointer"
+									onClick={!isCurrent ? () => onMoveToCustomColumn?.(col.id) : undefined}
+									disabled={isCurrent}
+									className={`w-full text-left flex items-center gap-2.5 py-1.5 px-1.5 text-sm rounded-md transition-colors ${
+										isCurrent
+											? "text-fg font-semibold cursor-default"
+											: "text-fg-2 hover:bg-elevated-hover hover:text-fg cursor-pointer"
+									}`}
 								>
 									<div
 										className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-										style={{ background: col.color }}
+										style={{
+											background: col.color,
+											boxShadow: isCurrent ? `0 0 6px ${col.color}60` : undefined,
+										}}
 									/>
 									{col.name}
+									{isCurrent && (
+										<span className="ml-1 text-[0.625rem] text-fg-3 font-normal">
+											{"\u2190"} {t("pipeline.current")}
+										</span>
+									)}
 								</button>
-							))}
+							);
+						})}
 					</div>
 				</>
 			)}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -552,17 +552,31 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			{/* Bottom row */}
 			<div data-testid="task-card-footer" className="mt-3 flex min-w-0 flex-wrap items-center gap-2">
 				{/* Status dropdown trigger with mini-pipeline */}
-				<button
-					ref={triggerRef}
-					onClick={toggleMenu}
-					className="mr-auto flex min-w-0 items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-fg/5"
-					disabled={isDisabled}
-				>
-					<MiniPipeline status={task.status} />
-					<span className="min-w-0 truncate text-xs text-fg-2">
-						{t(statusKey(task.status))}
-					</span>
-				</button>
+				{(() => {
+					const activeCol = task.customColumnId
+						? (project.customColumns ?? []).find((c) => c.id === task.customColumnId)
+						: null;
+					return (
+						<button
+							ref={triggerRef}
+							onClick={toggleMenu}
+							className="mr-auto flex min-w-0 items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-fg/5"
+							disabled={isDisabled}
+						>
+							{activeCol ? (
+								<div
+									className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+									style={{ background: activeCol.color, boxShadow: `0 0 6px ${activeCol.color}60` }}
+								/>
+							) : (
+								<MiniPipeline status={task.status} />
+							)}
+							<span className="min-w-0 truncate text-xs text-fg-2">
+								{activeCol ? activeCol.name : t(statusKey(task.status))}
+							</span>
+						</button>
+					);
+				})()}
 
 				<div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
 					{/* PR badge */}

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -819,6 +819,10 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 
 	const height = collapsed ? `${COLLAPSED_HEIGHT_REM}rem` : panelHeight;
 
+	const activeCustomColumn = task.customColumnId
+		? (project.customColumns ?? []).find((c) => c.id === task.customColumnId)
+		: null;
+
 	const statusDropdownButton = (
 		<button
 			ref={statusTriggerRef}
@@ -826,9 +830,16 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, isFullPag
 			disabled={movingStatus}
 			className="flex items-center gap-2 px-2.5 py-1 rounded-lg hover:bg-elevated transition-colors flex-shrink-0"
 		>
-			<MiniPipeline status={task.status} />
+			{activeCustomColumn ? (
+				<div
+					className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+					style={{ background: activeCustomColumn.color, boxShadow: `0 0 6px ${activeCustomColumn.color}60` }}
+				/>
+			) : (
+				<MiniPipeline status={task.status} />
+			)}
 			<span className="text-[0.6875rem] font-medium text-fg-2">
-				{t(statusKey(task.status))}
+				{activeCustomColumn ? activeCustomColumn.name : t(statusKey(task.status))}
 			</span>
 			<svg className="w-3 h-3 text-fg-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1092,19 +1092,27 @@ describe("TaskCard", () => {
 			});
 		});
 
-		it("excludes the current custom column from the dropdown", async () => {
+		it("shows the current custom column as disabled with current marker", async () => {
 			const user = userEvent.setup();
 			renderCard(
 				makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test", customColumnId: "col-1" }),
 				{ projectOverride: projectWithCustomColumns },
 			);
 
-			await user.click(screen.getByText("Agent is Working"));
+			// Card status button now shows custom column name instead of built-in status
+			await user.click(screen.getByText("On Hold"));
 
 			await waitFor(() => {
 				expect(screen.getByText("Blocked")).toBeInTheDocument();
 			});
-			expect(screen.queryByText("On Hold")).not.toBeInTheDocument();
+			// Current custom column is shown in dropdown but disabled
+			const onHoldButtons = screen.getAllByText("On Hold");
+			// One is the card button, others are in the dropdown
+			const dropdownOnHold = onHoldButtons.find((el) => {
+				const btn = el.closest("button");
+				return btn?.disabled;
+			});
+			expect(dropdownOnHold).toBeTruthy();
 		});
 	});
 

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1585,4 +1585,37 @@ describe("TaskInfoPanel", () => {
 			expect(mockedApi.request.renameTask).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("custom column status display", () => {
+		const projectWithCustomColumns: Project = {
+			...project,
+			customColumns: [
+				{ id: "col-1", name: "On Hold", color: "#f59e0b", llmInstruction: "" },
+				{ id: "col-2", name: "Blocked", color: "#ef4444", llmInstruction: "" },
+			],
+		};
+
+		it("shows custom column name instead of built-in status when task is in a custom column", async () => {
+			await act(async () => {
+				renderPanel(
+					makeTask({ status: "review-by-user", customColumnId: "col-1" }),
+					{ project: projectWithCustomColumns },
+				);
+			});
+			// Should show the custom column name, not the built-in status
+			expect(screen.getByText("On Hold")).toBeInTheDocument();
+			// The built-in status "Your Review" should NOT appear in the status button
+			expect(screen.queryByText("Your Review")).not.toBeInTheDocument();
+		});
+
+		it("shows built-in status when task is not in a custom column", async () => {
+			await act(async () => {
+				renderPanel(
+					makeTask({ status: "review-by-user" }),
+					{ project: projectWithCustomColumns },
+				);
+			});
+			expect(screen.getByText("Your Review")).toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this fix.

- **TaskInfoPanel** and **TaskCard** now show the custom column name and color (e.g. "On Hold") instead of the underlying built-in status (e.g. "Your Review") when a task is in a custom column
- **PipelineDropdown** (MOVE TO menu) no longer hides the current custom column — it shows it with a "← current" marker, consistent with built-in statuses
- Tests updated + new tests for custom column status display

Closes #311