### PR TITLE
fix: make Codex default preset bypass-heavy

### DIFF
--- a/change-logs/2026/03/14/fix-codex-default-bypass-preset.md
+++ b/change-logs/2026/03/14/fix-codex-default-bypass-preset.md
@@ -1,0 +1,1 @@
+Changed the built-in Codex default preset to GPT-5.4 Heavy Bypass and bumped its preset version so existing stored default configs pick up the new sandbox arguments automatically. Updated tests to lock in the new default selection and naming.

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -208,13 +208,16 @@ describe("mergeWithDefaults", () => {
 	});
 
 	it("user overrides still win over defaults when versions match", () => {
+		const defCodex = DEFAULT_AGENTS.find((a) => a.id === "builtin-codex")!;
+		const defCfg = defCodex.configurations.find((c) => c.id === "codex-default")!;
+
 		const stored: CodingAgent[] = [
 			{
 				id: "builtin-codex",
 				name: "Codex",
 				baseCommand: "codex",
 				configurations: [
-					{ id: "codex-default", name: "My Codex", model: "o3", additionalArgs: ["--my-custom-flag"], version: 2 },
+					{ id: "codex-default", name: "My Codex", model: "o3", additionalArgs: ["--my-custom-flag"], version: defCfg.version },
 				],
 				defaultConfigId: "codex-default",
 			},
@@ -222,8 +225,6 @@ describe("mergeWithDefaults", () => {
 		const result = mergeWithDefaults(stored);
 		const codex = result.find((a) => a.id === "builtin-codex")!;
 		const cfg = codex.configurations.find((c) => c.id === "codex-default")!;
-		const defCodex = DEFAULT_AGENTS.find((a) => a.id === "builtin-codex")!;
-		const defCfg = defCodex.configurations.find((c) => c.id === "codex-default")!;
 
 		// When stored version matches default version, user overrides win
 		expect(cfg.name).toBe("My Codex");

--- a/src/mainview/__tests__/types.test.ts
+++ b/src/mainview/__tests__/types.test.ts
@@ -288,6 +288,19 @@ describe("DEFAULT_AGENTS", () => {
 		expect(claude).toBeDefined();
 		expect(claude!.baseCommand).toBe("claude");
 	});
+
+	it("uses a heavy bypass preset as the default Codex configuration", () => {
+		const codex = DEFAULT_AGENTS.find((a) => a.id === "builtin-codex");
+		expect(codex).toBeDefined();
+
+		const cfg = codex!.configurations.find((c) => c.id === "codex-default");
+		expect(cfg).toBeDefined();
+		expect(cfg!.name).toBe("Default (GPT-5.4 Heavy Bypass)");
+		expect(cfg!.additionalArgs).toContain("--sandbox");
+		expect(cfg!.additionalArgs).toContain("danger-full-access");
+		expect(cfg!.additionalArgs).toContain('model_reasoning_effort="high"');
+		expect(cfg!.additionalArgs).not.toContain('default_permissions="dev3"');
+	});
 });
 
 // ---- Constants: LABEL_COLORS ----

--- a/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
+++ b/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
@@ -44,9 +44,9 @@ const codexAgent: CodingAgent = {
 	configurations: [
 		{
 			id: "codex-default",
-			name: "Default (GPT-5.4 Medium)",
+			name: "Default (GPT-5.4 Heavy Bypass)",
 			model: "gpt-5.4",
-			additionalArgs: ["--search", "--full-auto", "--no-alt-screen", "-c", 'model_reasoning_effort="medium"'],
+			additionalArgs: ["--search", "--no-alt-screen", "--sandbox", "danger-full-access", "-c", 'model_reasoning_effort="high"'],
 		},
 		{
 			id: "codex-plan",
@@ -293,7 +293,7 @@ describe("LaunchVariantsModal", () => {
 
 			const options = await getDropdownOptions(user, getConfigButtons()[0]);
 			expect(options).toHaveLength(6);
-			expect(options[0]).toBe("Default (GPT-5.4 Medium)");
+			expect(options[0]).toBe("Default (GPT-5.4 Heavy Bypass)");
 			expect(options[1]).toBe("Plan (GPT-5.4)");
 			expect(options[2]).toBe("Heavy (GPT-5.4 High)");
 			expect(options[3]).toBe("Heavy (GPT-5.4 High Confirm)");
@@ -332,12 +332,12 @@ describe("LaunchVariantsModal", () => {
 			await selectOption(user, agentBtn, "Codex");
 
 			const configBtnAfter = getConfigButtons()[0];
-			expect(getSelectedText(configBtnAfter)).toBe("Default (GPT-5.4 Medium)");
+			expect(getSelectedText(configBtnAfter)).toBe("Default (GPT-5.4 Heavy Bypass)");
 
 			// Config dropdown should show Codex curated configs
 			const options = await getDropdownOptions(user, configBtnAfter);
 			expect(options).toHaveLength(6);
-			expect(options[0]).toBe("Default (GPT-5.4 Medium)");
+			expect(options[0]).toBe("Default (GPT-5.4 Heavy Bypass)");
 		});
 
 		it("switching back to Claude restores all Claude configs", async () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,10 +162,10 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 			// --- General ---
 			{
 				id: "codex-default",
-				name: "Default (GPT-5.4 Medium)",
+				name: "Default (GPT-5.4 Heavy Bypass)",
 				model: "gpt-5.4",
-				version: 2,
-				additionalArgs: ["-p", "dev3", "-a", "on-request", "--no-alt-screen", "-c", 'default_permissions="dev3"', "-c", 'model_reasoning_effort="medium"'],
+				version: 3,
+				additionalArgs: ["-p", "dev3", "-a", "on-request", "--no-alt-screen", "--sandbox", "danger-full-access", "-c", 'model_reasoning_effort="high"'],
 			},
 			{
 				id: "codex-plan",


### PR DESCRIPTION
## Summary
- switch the built-in Codex default preset to GPT-5.4 Heavy Bypass
- bump the preset version so stored codex-default configs refresh their sandbox args automatically
- update tests for the default preset name, args, and version-aware merge behavior

## Testing
- bun run lint
- bun run test