### PR TITLE
Fix broken status column order in pipeline dropdown

### DIFF
--- a/change-logs/2026/03/15/fix-status-order-dropdown.md
+++ b/change-logs/2026/03/15/fix-status-order-dropdown.md
@@ -1,0 +1,1 @@
+Fixed "Has Questions" (user-questions) status appearing at the bottom of the pipeline dropdown instead of its correct position after "Agent is Working". The status is now part of the main pipeline stages, matching the board column order.

--- a/src/mainview/components/PipelineDropdown.tsx
+++ b/src/mainview/components/PipelineDropdown.tsx
@@ -15,7 +15,7 @@ interface PipelineDropdownProps {
 }
 
 /** Side-branch statuses that aren't in PIPELINE_STAGES but still need to be selectable */
-const SIDE_STATUSES: TaskStatus[] = ["user-questions", "cancelled"];
+const SIDE_STATUSES: TaskStatus[] = ["cancelled"];
 
 export default function PipelineDropdown({
 	currentStatus,

--- a/src/mainview/components/StatusPipeline.tsx
+++ b/src/mainview/components/StatusPipeline.tsx
@@ -2,12 +2,13 @@ import type { TaskStatus } from "../../shared/types";
 
 /**
  * The "happy path" pipeline stages — the main linear flow a task goes through.
- * Statuses not in this list (user-questions, cancelled) are side-branches
+ * Statuses not in this list (cancelled) are side-branches
  * shown as modifiers, not pipeline nodes.
  */
 export const PIPELINE_STAGES: TaskStatus[] = [
 	"todo",
 	"in-progress",
+	"user-questions",
 	"review-by-ai",
 	"review-by-user",
 	"review-by-colleague",
@@ -17,13 +18,11 @@ export const PIPELINE_STAGES: TaskStatus[] = [
 /**
  * Returns the pipeline stage index for a given status.
  * Side-branch statuses map to their "parent" stage:
- *   user-questions → in-progress (index 1)
  *   cancelled → in-progress (index 1) — task was stopped, not completed
  */
 export function getPipelineIndex(status: TaskStatus): number {
 	const direct = PIPELINE_STAGES.indexOf(status);
 	if (direct >= 0) return direct;
-	if (status === "user-questions") return PIPELINE_STAGES.indexOf("in-progress");
 	if (status === "cancelled") return PIPELINE_STAGES.indexOf("in-progress");
 	return 0;
 }
@@ -46,5 +45,5 @@ export function getStageStates(currentStatus: TaskStatus): StageState[] {
  * Whether the current status is a "side-branch" (not on the main pipeline line).
  */
 export function isSideBranch(status: TaskStatus): boolean {
-	return status === "user-questions" || status === "cancelled";
+	return status === "cancelled";
 }

--- a/src/mainview/components/__tests__/StatusPipeline.test.ts
+++ b/src/mainview/components/__tests__/StatusPipeline.test.ts
@@ -10,16 +10,11 @@ describe("getPipelineIndex", () => {
 	it("returns correct index for each main stage", () => {
 		expect(getPipelineIndex("todo")).toBe(0);
 		expect(getPipelineIndex("in-progress")).toBe(1);
-		expect(getPipelineIndex("review-by-ai")).toBe(2);
-		expect(getPipelineIndex("review-by-user")).toBe(3);
-		expect(getPipelineIndex("review-by-colleague")).toBe(4);
-		expect(getPipelineIndex("completed")).toBe(5);
-	});
-
-	it("maps user-questions to in-progress index", () => {
-		expect(getPipelineIndex("user-questions")).toBe(
-			PIPELINE_STAGES.indexOf("in-progress"),
-		);
+		expect(getPipelineIndex("user-questions")).toBe(2);
+		expect(getPipelineIndex("review-by-ai")).toBe(3);
+		expect(getPipelineIndex("review-by-user")).toBe(4);
+		expect(getPipelineIndex("review-by-colleague")).toBe(5);
+		expect(getPipelineIndex("completed")).toBe(6);
 	});
 
 	it("maps cancelled to in-progress index, not completed", () => {
@@ -35,34 +30,37 @@ describe("getPipelineIndex", () => {
 describe("getStageStates", () => {
 	it("marks all stages as future for todo", () => {
 		const states = getStageStates("todo");
-		expect(states).toEqual(["current", "future", "future", "future", "future", "future"]);
+		expect(states).toEqual(["current", "future", "future", "future", "future", "future", "future"]);
 	});
 
 	it("marks previous stages as done, current as current, rest as future", () => {
 		const states = getStageStates("review-by-ai");
-		expect(states).toEqual(["done", "done", "current", "future", "future", "future"]);
+		expect(states).toEqual(["done", "done", "done", "current", "future", "future", "future"]);
 	});
 
 	it("marks all stages as done for completed except last", () => {
 		const states = getStageStates("completed");
-		expect(states).toEqual(["done", "done", "done", "done", "done", "current"]);
+		expect(states).toEqual(["done", "done", "done", "done", "done", "done", "current"]);
 	});
 
 	it("cancelled shows pipeline stopped at in-progress, not at completed", () => {
 		const states = getStageStates("cancelled");
-		expect(states).toEqual(["done", "current", "future", "future", "future", "future"]);
+		expect(states).toEqual(["done", "current", "future", "future", "future", "future", "future"]);
 	});
 
-	it("user-questions shows pipeline at in-progress", () => {
+	it("user-questions shows pipeline at user-questions stage", () => {
 		const states = getStageStates("user-questions");
-		expect(states).toEqual(["done", "current", "future", "future", "future", "future"]);
+		expect(states).toEqual(["done", "done", "current", "future", "future", "future", "future"]);
 	});
 });
 
 describe("isSideBranch", () => {
-	it("returns true for user-questions and cancelled", () => {
-		expect(isSideBranch("user-questions")).toBe(true);
+	it("returns true for cancelled only", () => {
 		expect(isSideBranch("cancelled")).toBe(true);
+	});
+
+	it("returns false for user-questions (now part of pipeline)", () => {
+		expect(isSideBranch("user-questions")).toBe(false);
 	});
 
 	it("returns false for main pipeline stages", () => {


### PR DESCRIPTION
## Summary

- **"Has Questions"** (`user-questions`) was treated as a side-branch in the pipeline dropdown, appearing at the bottom below "Completed" instead of its correct position after "Agent is Working"
- Moved `user-questions` into `PIPELINE_STAGES` between `in-progress` and `review-by-ai` to match the Kanban board column order
- Updated tests accordingly