### PR TITLE
Fix hook not resuming task from Your Review

### DIFF
--- a/change-logs/2026/03/15/fix-hook-review-resume.md
+++ b/change-logs/2026/03/15/fix-hook-review-resume.md
@@ -1,0 +1,1 @@
+Fixed UserPromptSubmit/PreToolUse hooks not moving tasks from "Your Review" back to "Agent is Working" when the user leaves feedback and the agent resumes. The `--if-status-not` guard now only excludes `review-by-ai` (the AI review agent), allowing the primary agent to correctly transition out of `review-by-user`.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -29,7 +29,8 @@ describe("buildClaudeHooks", () => {
 		expect(cmd).toContain(DEV3_CLI);
 		expect(cmd).toContain(TASK_ID);
 		expect(cmd).toContain("--status in-progress");
-		expect(cmd).toContain("--if-status-not review-by-ai,review-by-user");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+		expect(cmd).not.toContain("review-by-user");
 	});
 
 	it("PreToolUse hook moves to in-progress with --if-status-not guard", () => {
@@ -39,7 +40,8 @@ describe("buildClaudeHooks", () => {
 		expect(cmd).toContain(DEV3_CLI);
 		expect(cmd).toContain(TASK_ID);
 		expect(cmd).toContain("--status in-progress");
-		expect(cmd).toContain("--if-status-not review-by-ai,review-by-user");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+		expect(cmd).not.toContain("review-by-user");
 	});
 
 	it("uses correct three-level nesting (event → matcher group → hooks)", () => {
@@ -96,14 +98,26 @@ describe("buildClaudeHooks", () => {
 		expect(hooks.Stop[1].hooks[0].command).toContain("--status review-by-user --if-status review-by-ai");
 	});
 
+	it("working hooks allow transition from review-by-user (user feedback resumes agent)", () => {
+		const hooks = buildClaudeHooks(TASK_ID);
+		const cmd = hooks.UserPromptSubmit[0].hooks[0].command;
+
+		// review-by-user must NOT be excluded — when user leaves feedback
+		// and the agent resumes, the hook should move the task back to in-progress
+		expect(cmd).not.toContain("review-by-user");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+	});
+
 	it("working hooks use --if-status-not to skip during AI review", () => {
 		const hooks = buildClaudeHooks(TASK_ID, { stopTarget: "review-by-ai" });
 
 		const preCmd = hooks.PreToolUse[0].hooks[0].command;
 		const userCmd = hooks.UserPromptSubmit[0].hooks[0].command;
 
-		expect(preCmd).toContain("--status in-progress --if-status-not review-by-ai,review-by-user");
-		expect(userCmd).toContain("--status in-progress --if-status-not review-by-ai,review-by-user");
+		expect(preCmd).toContain("--status in-progress --if-status-not review-by-ai");
+		expect(userCmd).toContain("--status in-progress --if-status-not review-by-ai");
+		expect(preCmd).not.toContain("review-by-user");
+		expect(userCmd).not.toContain("review-by-user");
 	});
 
 	it("all hooks use command type", () => {
@@ -266,8 +280,10 @@ describe("writeClaudeHooks", () => {
 		const content = JSON.parse(readFileSync(settingsPath, "utf-8"));
 		const hooks = content.hooks as Record<string, MatcherGroup[]>;
 
-		expect(hooks.PreToolUse[0].hooks[0].command).toContain("--if-status-not review-by-ai,review-by-user");
-		expect(hooks.UserPromptSubmit[0].hooks[0].command).toContain("--if-status-not review-by-ai,review-by-user");
+		expect(hooks.PreToolUse[0].hooks[0].command).toContain("--if-status-not review-by-ai");
+		expect(hooks.PreToolUse[0].hooks[0].command).not.toContain("review-by-user");
+		expect(hooks.UserPromptSubmit[0].hooks[0].command).toContain("--if-status-not review-by-ai");
+		expect(hooks.UserPromptSubmit[0].hooks[0].command).not.toContain("review-by-user");
 	});
 
 	it("overwrites corrupted JSON gracefully", () => {

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -35,9 +35,11 @@ export function buildClaudeHooks(
 	const move = (status: string, extra?: string) =>
 		`${DEV3_CLI} task move ${taskId} --status ${status}${extra ? ` ${extra}` : ""}`;
 
-	// Working hook: move to in-progress, but NOT when in review stages
-	// (the review agent shares the same hooks file)
-	const workingCmd = move("in-progress", "--if-status-not review-by-ai,review-by-user");
+	// Working hook: move to in-progress, but NOT when in review-by-ai
+	// (the review agent shares the same hooks file and must not flip status).
+	// review-by-user is intentionally allowed: when the user leaves feedback
+	// and the primary agent resumes, UserPromptSubmit should move the task back.
+	const workingCmd = move("in-progress", "--if-status-not review-by-ai");
 
 	// Primary Stop hook: only fires when task is in-progress (primary agent working).
 	// This prevents it from firing after the review agent has already moved the task.


### PR DESCRIPTION
## Summary

- The `UserPromptSubmit` and `PreToolUse` hooks had `--if-status-not review-by-ai,review-by-user`, which blocked the task from moving back to "Agent is Working" when the user left review feedback and the agent resumed.
- Removed `review-by-user` from the exclusion list — now only `review-by-ai` is skipped (protecting the AI review agent from flipping status).
- Added a dedicated test for the new behavior.