### PR TITLE
Fix setup script not running for variant/attempt launches

### DIFF
--- a/change-logs/2026/03/17/fix-setup-script-variants.md
+++ b/change-logs/2026/03/17/fix-setup-script-variants.md
@@ -1,0 +1,1 @@
+Fixed setup script not running when tasks are launched via spawnVariants or addAttempts. These code paths passed the raw project object (with empty setupScript) to launchTaskPty instead of resolving the .dev3/config.json first. Now both paths call resolveProjectConfig from the worktree, matching the behavior of activateTask.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1509,6 +1509,41 @@ describe("handlers.spawnVariants", () => {
 		expect(createWtCalls[1][2]).toBe("feature/login");
 		expect(createWtCalls[1][3]).toBe("feature/login-v2");
 	});
+
+	it("resolves project config from worktree path for setup script", async () => {
+		const project = makeProject({ setupScript: "" });
+		const sourceTask = makeTask({ status: "todo", seq: 5 });
+		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true });
+		const updatedVariant = makeTask({ id: "variant-1", status: "in-progress", worktreePath: "/tmp/vwt" });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
+		vi.mocked(data.addTask).mockResolvedValue(variantTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/vwt", branchName: "dev3/v1" });
+		vi.mocked(data.updateTask).mockResolvedValue(updatedVariant);
+
+		const repoConfig = await import("../repo-config");
+		vi.mocked(repoConfig.resolveProjectConfig).mockResolvedValueOnce({
+			...project,
+			setupScript: "./scripts/dev3-setup.sh",
+		});
+
+		await handlers.spawnVariants({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		await vi.waitFor(() => {
+			expect(git.createWorktree).toHaveBeenCalledOnce();
+		});
+
+		// Must resolve config from worktree path (not just project.path)
+		await vi.waitFor(() => {
+			expect(repoConfig.resolveProjectConfig).toHaveBeenCalledWith(project, "/tmp/vwt");
+		});
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1702,11 +1702,13 @@ export const handlers = {
 							? `${srcBranch.replace(/^origin\//, "")}-v${i + 1}`
 							: undefined;
 						const wt = await git.createWorktree(project, task, task.existingBranch ?? undefined, variantBranchName);
-						if (project.sparseCheckoutEnabled && project.sparseCheckoutPaths?.length) {
-							await git.applySparseCheckout(wt.worktreePath, project.sparseCheckoutPaths);
+						// Re-resolve from worktree to pick up .dev3/config.json (setupScript, sparse checkout, etc.)
+						const resolved = await repoConfig.resolveProjectConfig(project, wt.worktreePath);
+						if (resolved.sparseCheckoutEnabled && resolved.sparseCheckoutPaths?.length) {
+							await git.applySparseCheckout(wt.worktreePath, resolved.sparseCheckoutPaths);
 						}
-						await runCowClones(project, wt.worktreePath);
-						await launchTaskPty(project, task, wt.worktreePath, variant.agentId, variant.configId, true);
+						await runCowClones(resolved, wt.worktreePath);
+						await launchTaskPty(resolved, task, wt.worktreePath, variant.agentId, variant.configId, true);
 
 						const updated = await data.updateTask(project, task.id, {
 							worktreePath: wt.worktreePath,
@@ -1798,11 +1800,13 @@ export const handlers = {
 					const variant = params.variants[i];
 					try {
 						const wt = await git.createWorktree(project, task);
-						if (project.sparseCheckoutEnabled && project.sparseCheckoutPaths?.length) {
-							await git.applySparseCheckout(wt.worktreePath, project.sparseCheckoutPaths);
+						// Re-resolve from worktree to pick up .dev3/config.json (setupScript, sparse checkout, etc.)
+						const resolved = await repoConfig.resolveProjectConfig(project, wt.worktreePath);
+						if (resolved.sparseCheckoutEnabled && resolved.sparseCheckoutPaths?.length) {
+							await git.applySparseCheckout(wt.worktreePath, resolved.sparseCheckoutPaths);
 						}
-						await runCowClones(project, wt.worktreePath);
-						await launchTaskPty(project, task, wt.worktreePath, variant.agentId, variant.configId, true);
+						await runCowClones(resolved, wt.worktreePath);
+						await launchTaskPty(resolved, task, wt.worktreePath, variant.agentId, variant.configId, true);
 
 						const updated = await data.updateTask(project, task.id, {
 							worktreePath: wt.worktreePath,


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI fixing this one.

- **Bug:** `spawnVariants` and `addAttempts` passed the raw `project` object (with empty `setupScript` from `projects.json`) to `launchTaskPty`, bypassing `.dev3/config.json` resolution. This meant setup scripts, sparse checkout paths, and clone paths from repo config were silently ignored.
- **Fix:** Both paths now call `resolveProjectConfig(project, worktreePath)` after worktree creation, matching the existing `activateTask` behavior.
- Added a test verifying `resolveProjectConfig` is called with the worktree path during `spawnVariants`.