### PR TITLE
Simplify config helpers, remove dead code, add design tokens

### DIFF
--- a/src/bun/repo-config.ts
+++ b/src/bun/repo-config.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
 import type { Project, Dev3RepoConfig, ConfigSourceEntry } from "../shared/types";
 import { DEV3_REPO_CONFIG_KEYS } from "../shared/types";
 import { createLogger } from "./logger";
@@ -99,7 +100,7 @@ export function loadAppConfig(projectPath: string): Dev3RepoConfig {
 /** Save app-level config to ~/.dev3.0/data/<slug>/config.json. */
 export async function saveAppConfig(projectPath: string, config: Dev3RepoConfig): Promise<void> {
 	const filePath = appConfigPath(projectPath);
-	const dir = filePath.slice(0, filePath.lastIndexOf("/"));
+	const dir = dirname(filePath);
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n");
 	log.info("Saved app config", { path: filePath });

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -1087,12 +1087,13 @@ export async function triggerColumnAgentIfNeeded(
 	let onExitCommand: string | undefined;
 
 	if (newStatus === "review-by-ai") {
-		// Built-in review-by-ai column
+		// Resolve config from worktree to pick up local overrides (#341)
+		const resolved = await repoConfig.resolveProjectConfig(project, task.worktreePath);
 		// When builtinColumnAgents exists but has no "review-by-ai" key → explicitly disabled
-		if (project.builtinColumnAgents && !project.builtinColumnAgents["review-by-ai"]) {
+		if (resolved.builtinColumnAgents && !resolved.builtinColumnAgents["review-by-ai"]) {
 			return;
 		}
-		const config = project.builtinColumnAgents?.["review-by-ai"];
+		const config = resolved.builtinColumnAgents?.["review-by-ai"];
 		agentConfig = config ?? {
 			agentId: "builtin-claude",
 			configId: "claude-bypass-sonnet",
@@ -1202,6 +1203,18 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 }
 
 const rendererLog = createLogger("renderer");
+
+/** Extract Dev3RepoConfig fields from a flat params object. */
+function extractConfigFromParams(params: Record<string, any>): Dev3RepoConfig {
+	const config: Dev3RepoConfig = {};
+	for (const key of DEV3_REPO_CONFIG_KEYS) {
+		const val = (params as any)[key];
+		if (val !== undefined) {
+			(config as any)[key] = val;
+		}
+	}
+	return config;
+}
 
 export const handlers = {
 	async logRendererError(params: { description: string; source: "error" | "unhandledrejection" }): Promise<void> {
@@ -1376,37 +1389,17 @@ export const handlers = {
 		};
 	},
 
-	async getAppConfig(params: { projectId: string }): Promise<Dev3RepoConfig> {
-		log.info("→ getAppConfig", { projectId: params.projectId });
-		const project = await data.getProject(params.projectId);
-		const config = repoConfig.loadAppConfig(project.path);
-		log.info("← getAppConfig");
-		return config;
-	},
-
 	async saveAppConfig(params: { projectId: string } & Dev3RepoConfig): Promise<void> {
 		log.info("→ saveAppConfig", { projectId: params.projectId });
 		const project = await data.getProject(params.projectId);
-		const config: Dev3RepoConfig = {};
-		for (const key of DEV3_REPO_CONFIG_KEYS) {
-			const val = (params as any)[key];
-			if (val !== undefined) {
-				(config as any)[key] = val;
-			}
-		}
+		const config = extractConfigFromParams(params);
 		await repoConfig.saveAppConfig(project.path, config);
 		log.info("← saveAppConfig done");
 	},
 
 	async updateProjectSettings(params: { projectId: string } & Dev3RepoConfig): Promise<Project> {
 		log.info("→ updateProjectSettings", { projectId: params.projectId });
-		const updates: Partial<Pick<Project, "setupScript" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "clonePaths" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents">> = {};
-		for (const key of DEV3_REPO_CONFIG_KEYS) {
-			const val = (params as any)[key];
-			if (val !== undefined) {
-				(updates as any)[key] = val;
-			}
-		}
+		const updates = extractConfigFromParams(params);
 		const updated = await data.updateProject(params.projectId, updates);
 		pushMessage?.("projectUpdated", { project: updated });
 		log.info("← updateProjectSettings done");
@@ -1417,13 +1410,7 @@ export const handlers = {
 		log.info("→ saveRepoConfig", { projectId: params.projectId, worktreePath: params.worktreePath, autoCommit: params.autoCommit });
 		const project = await data.getProject(params.projectId);
 		const configPath = params.worktreePath || project.path;
-		const config: Dev3RepoConfig = {};
-		for (const key of DEV3_REPO_CONFIG_KEYS) {
-			const val = (params as any)[key];
-			if (val !== undefined) {
-				(config as any)[key] = val;
-			}
-		}
+		const config = extractConfigFromParams(params);
 		await repoConfig.saveRepoConfig(configPath, config);
 		// Auto-commit .dev3/config.json in the worktree if requested
 		if (params.autoCommit && params.worktreePath) {
@@ -1446,13 +1433,7 @@ export const handlers = {
 		log.info("→ saveLocalConfig", { projectId: params.projectId, worktreePath: params.worktreePath });
 		const project = await data.getProject(params.projectId);
 		const configPath = params.worktreePath || project.path;
-		const config: Dev3RepoConfig = {};
-		for (const key of DEV3_REPO_CONFIG_KEYS) {
-			const val = (params as any)[key];
-			if (val !== undefined) {
-				(config as any)[key] = val;
-			}
-		}
+		const config = extractConfigFromParams(params);
 		await repoConfig.saveRepoLocalConfig(configPath, config);
 		log.info("← saveLocalConfig done");
 	},
@@ -1672,9 +1653,8 @@ export const handlers = {
 		}, dropOpts);
 		pushMessage?.("taskUpdated", { projectId: project.id, task: updated });
 
-		// Trigger column agent if entering review-by-ai — resolve config from worktree
-		const resolvedForAgent = await repoConfig.resolveProjectConfig(project, updated.worktreePath ?? undefined);
-		await triggerColumnAgentIfNeeded(newStatus, resolvedForAgent, updated);
+		// Trigger column agent if entering review-by-ai or custom column
+		await triggerColumnAgentIfNeeded(newStatus, project, updated);
 
 		log.info("← moveTask done (status only)", { taskId: task.id });
 		return updated;

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -709,7 +709,7 @@ function GlobalSettings() {
 												<span
 													className={`text-xs px-1.5 py-0.5 rounded ${
 														availability.installed
-															? "bg-green-400/15 text-green-400"
+															? "bg-success/15 text-success"
 															: "bg-danger/15 text-danger"
 													}`}
 												>
@@ -733,10 +733,10 @@ function GlobalSettings() {
 											<div className="border-t border-edge px-4 py-4 space-y-4">
 												{/* Agent availability status */}
 												{availability && (
-													<div className={`p-3 rounded-lg ${availability.installed ? "bg-green-400/5 border border-green-400/20" : "bg-danger/5 border border-danger/20"}`}>
+													<div className={`p-3 rounded-lg ${availability.installed ? "bg-success/5 border border-success/20" : "bg-danger/5 border border-danger/20"}`}>
 														{availability.installed ? (
 															<div className="flex items-center gap-2">
-																<span className="text-green-400 text-sm">&#10003;</span>
+																<span className="text-success text-sm">&#10003;</span>
 																<span className="text-fg-2 text-xs">{t("settings.agentInstalled")}</span>
 																{availability.resolvedPath && (
 																	<span className="text-fg-muted text-xs font-mono truncate">{availability.resolvedPath}</span>
@@ -752,7 +752,7 @@ function GlobalSettings() {
 																	<div>
 																		<p className="text-fg-3 text-xs mb-1">{t("settings.agentInstallHint")}</p>
 																		<div className="flex items-center gap-1.5">
-																			<code className="text-yellow-400 bg-yellow-400/10 px-2 py-1 rounded text-xs font-mono">
+																			<code className="text-warning bg-warning/10 px-2 py-1 rounded text-xs font-mono">
 																				{availability.installCommand}
 																			</code>
 																			<button

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -524,6 +524,15 @@ interface NavigationGuard {
 	onSave: () => Promise<void>;
 }
 
+/** Strip empty strings from clonePaths and sparseCheckoutPaths before saving. */
+function sanitizeConfigPaths(config: Dev3RepoConfig): Dev3RepoConfig {
+	return {
+		...config,
+		clonePaths: (config.clonePaths ?? []).filter((p) => p.trim() !== ""),
+		sparseCheckoutPaths: (config.sparseCheckoutPaths ?? []).filter((p) => p.trim() !== ""),
+	};
+}
+
 interface ProjectSettingsProps {
 	projectId: string;
 	projects: Project[];
@@ -792,12 +801,7 @@ function ProjectSettings({
 					},
 				}
 				: {};
-			const toSave = {
-				...projectConfig,
-				clonePaths: (projectConfig.clonePaths ?? []).filter((p) => p.trim() !== ""),
-				sparseCheckoutPaths: (projectConfig.sparseCheckoutPaths ?? []).filter((p) => p.trim() !== ""),
-				builtinColumnAgents,
-			};
+			const toSave = { ...sanitizeConfigPaths(projectConfig), builtinColumnAgents };
 			const updated = await api.request.updateProjectSettings({ projectId, ...toSave });
 			dispatch({ type: "updateProject", project: updated });
 			loadedProjectConfig.current = toSave;
@@ -813,11 +817,7 @@ function ProjectSettings({
 		if (!selectedTask?.worktreePath) return;
 		setSavingWtRepo(true);
 		try {
-			const toSave = {
-				...wtRepoConfig,
-				clonePaths: (wtRepoConfig.clonePaths ?? []).filter((p) => p.trim() !== ""),
-				sparseCheckoutPaths: (wtRepoConfig.sparseCheckoutPaths ?? []).filter((p) => p.trim() !== ""),
-			};
+			const toSave = sanitizeConfigPaths(wtRepoConfig);
 			await api.request.saveRepoConfig({ projectId, worktreePath: selectedTask.worktreePath, autoCommit: true, ...toSave });
 			loadedWtRepoConfig.current = toSave;
 			const updatedProjects = await api.request.getProjects();
@@ -832,11 +832,7 @@ function ProjectSettings({
 		if (!selectedTask?.worktreePath) return;
 		setSavingWtLocal(true);
 		try {
-			const toSave = {
-				...wtLocalConfig,
-				clonePaths: (wtLocalConfig.clonePaths ?? []).filter((p) => p.trim() !== ""),
-				sparseCheckoutPaths: (wtLocalConfig.sparseCheckoutPaths ?? []).filter((p) => p.trim() !== ""),
-			};
+			const toSave = sanitizeConfigPaths(wtLocalConfig);
 			await api.request.saveLocalConfig({ projectId, worktreePath: selectedTask.worktreePath, ...toSave });
 			loadedWtLocalConfig.current = toSave;
 			const updatedProjects = await api.request.getProjects();

--- a/src/mainview/components/SpawnAgentModal.tsx
+++ b/src/mainview/components/SpawnAgentModal.tsx
@@ -139,12 +139,12 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 
 						{/* Warning for uninstalled agents */}
 						{agentNotInstalled && selectedAgent && (
-							<div className="p-3 rounded-lg bg-yellow-400/10 border border-yellow-400/20">
-								<p className="text-yellow-400 text-xs font-medium mb-1">
+							<div className="p-3 rounded-lg bg-warning/10 border border-warning/20">
+								<p className="text-warning text-xs font-medium mb-1">
 									{t("spawnAgent.notInstalled", { name: selectedAgent.name })}
 								</p>
 								{selectedAvailability?.installCommand && (
-									<code className="text-yellow-400/80 bg-yellow-400/5 px-2 py-0.5 rounded text-xs font-mono">
+									<code className="text-warning/80 bg-warning/5 px-2 py-0.5 rounded text-xs font-mono">
 										{selectedAvailability.installCommand}
 									</code>
 								)}

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -112,7 +112,7 @@ describe("ProjectSettings", () => {
 	});
 
 	describe("project config form (app-level)", () => {
-		it("populates form from getAppConfig", async () => {
+		it("populates form from project settings", async () => {
 			await renderProjectSettings(mockProject, {
 				setupScript: "bun install",
 				defaultBaseBranch: "develop",

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -45,6 +45,7 @@
 	--danger: 255 130 130;
 	--success: 74 222 128;
 	--success-hover: 34 197 94;
+	--warning: 250 204 21;
 
 	/* ---- Background gradient ---- */
 	--bg-grad-angle: 115deg;
@@ -106,6 +107,7 @@
 	--danger: 220 38 38;
 	--success: 22 163 74;
 	--success-hover: 21 128 61;
+	--warning: 202 138 4;
 
 	/* ---- Background gradient ---- */
 	--bg-grad-angle: 135deg;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -660,11 +660,6 @@ export type AppRPCSchema = {
 				params: { projectId: string };
 				response: { hasRepoConfig: boolean; hasLocalConfig: boolean };
 			};
-			/** Load app-level config (~/.dev3.0/data/<slug>/config.json). */
-			getAppConfig: {
-				params: { projectId: string };
-				response: Dev3RepoConfig;
-			};
 			/** Save app-level config (~/.dev3.0/data/<slug>/config.json). */
 			saveAppConfig: {
 				params: { projectId: string } & Dev3RepoConfig;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,7 @@ export default {
 					hover: "rgb(var(--accent-hover) / <alpha-value>)",
 				},
 				danger: "rgb(var(--danger) / <alpha-value>)",
+				warning: "rgb(var(--warning) / <alpha-value>)",
 				success: {
 					DEFAULT: "rgb(var(--success) / <alpha-value>)",
 					hover: "rgb(var(--success-hover) / <alpha-value>)",


### PR DESCRIPTION
## Summary

- Extract `extractConfigFromParams()` helper — replaces 4 identical config extraction loops in rpc-handlers
- Extract `sanitizeConfigPaths()` helper — replaces 3 identical filter calls in ProjectSettings
- Use `dirname()` from node:path instead of manual string slice in repo-config
- Move `resolveProjectConfig` inside `triggerColumnAgentIfNeeded` — avoids 3 JSON file reads on every `moveTask` call
- Remove dead `getAppConfig` RPC handler and schema entry (unused by renderer)
- Add `--warning` CSS design token (both themes) and replace hardcoded `green-400`/`yellow-400` with `success`/`warning` tokens in GlobalSettings and SpawnAgentModal