### PR TITLE
Fix tmux session list showing stale task titles

### DIFF
--- a/change-logs/2026/03/17/fix-tmux-session-title-refresh.md
+++ b/change-logs/2026/03/17/fix-tmux-session-title-refresh.md
@@ -1,0 +1,1 @@
+Fixed tmux session list showing stale task titles after rename. The list now uses `getTaskTitle()` (which respects `customTitle`) instead of the auto-generated `title`. Also added `rpc:taskUpdated` event listener so titles refresh immediately when a task is renamed, without waiting for the 30-second poll.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2922,6 +2922,46 @@ describe("handlers.listTmuxSessions", () => {
 		expect(names).toContain("dev3-xyz99999");
 		expect(names).not.toContain("dev3-dev-abc12345");
 	});
+
+	it("uses customTitle over auto-generated title when present", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "abc12345-full-uuid-here",
+			title: "Auto-generated title from description",
+			customTitle: "Short custom title",
+		});
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		mockSpawn.mockReturnValue({
+			stdout: "dev3-abc12345|/tmp/wt|1|1700000001",
+			stderr: new Response(""),
+			exited: Promise.resolve(0),
+		});
+
+		const result = await handlers.listTmuxSessions();
+		expect(result).toHaveLength(1);
+		expect(result[0].taskTitle).toBe("Short custom title");
+	});
+
+	it("falls back to auto-generated title when customTitle is not set", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "abc12345-full-uuid-here",
+			title: "Auto-generated title",
+			customTitle: null,
+		});
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		mockSpawn.mockReturnValue({
+			stdout: "dev3-abc12345|/tmp/wt|1|1700000001",
+			stderr: new Response(""),
+			exited: Promise.resolve(0),
+		});
+
+		const result = await handlers.listTmuxSessions();
+		expect(result).toHaveLength(1);
+		expect(result[0].taskTitle).toBe("Auto-generated title");
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { PATHS, Utils } from "electrobun/bun";
 import type { AgentCheckResult, BranchStatus, ChangelogEntry, CodingAgent, ColumnAgentConfig, ConfigSourceEntry, CustomColumn, Dev3RepoConfig, ExternalApp, GlobalSettings, Label, NoteSource, PortInfo, PRInfo, Project, RequirementCheckResult, Task, TaskNote, TaskStatus, TipState, TmuxSessionInfo } from "../shared/types";
-import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, DEFAULT_EXTERNAL_APPS, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, titleFromDescription, extractRepoName } from "../shared/types";
+import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, DEFAULT_EXTERNAL_APPS, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, titleFromDescription, extractRepoName, getTaskTitle } from "../shared/types";
 import * as data from "./data";
 import * as git from "./git";
 import * as pty from "./pty-server";
@@ -2809,7 +2809,7 @@ export const handlers = {
 				const tasks = await data.loadTasks(project);
 				for (const task of tasks) {
 					taskMap.set(task.id.slice(0, 8), {
-						title: task.title,
+						title: getTaskTitle(task),
 						taskId: task.id,
 						projectId: project.id,
 					});

--- a/src/mainview/components/TmuxSessionManager.tsx
+++ b/src/mainview/components/TmuxSessionManager.tsx
@@ -52,6 +52,15 @@ function TmuxSessionManager({ navigate }: TmuxSessionManagerProps) {
 		if (popoverOpen) fetchSessions();
 	}, [popoverOpen, fetchSessions]);
 
+	// Refresh when any task is updated (e.g. title renamed)
+	useEffect(() => {
+		function onTaskUpdated() {
+			fetchSessions();
+		}
+		window.addEventListener("rpc:taskUpdated", onTaskUpdated);
+		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
+	}, [fetchSessions]);
+
 	async function handleRefresh() {
 		setRefreshing(true);
 		await fetchSessions();


### PR DESCRIPTION
## Summary

Hey, Claude here — the AI working on this one.

- **Root cause:** `listTmuxSessions` used `task.title` (auto-generated from first 80 chars of description) instead of `getTaskTitle(task)` which respects `customTitle` set by rename operations
- **Fix:** Switched to `getTaskTitle()` in the taskMap builder, so renamed tasks show the correct title
- **Bonus:** Added `rpc:taskUpdated` event listener to `TmuxSessionManager` so the session list refreshes immediately when any task is updated (instead of waiting for the 30s poll)
- Two new tests verifying `customTitle` override and fallback behavior