### PR TITLE
Improve project terminal tips: clearer text, add dashboard tip

### DIFF
--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -155,7 +155,9 @@ const tips = {
 	"tip.diffCompareDefault.title": "Pick your diff baseline",
 	"tip.diffCompareDefault.body": "In Project Settings, choose whether branch status and Show Diff compare against origin/<base> or your local base branch.",
 	"tip.projectTerminal.title": "Project Terminal",
-	"tip.projectTerminal.body": "Click the terminal icon on the Kanban board to open a shell at the project root.",
+	"tip.projectTerminal.body": "Need a quick shell at the repo root? Click the terminal icon in the breadcrumbs bar, right next to the project name.",
+	"tip.projectTerminalDashboard.title": "Terminal from Dashboard",
+	"tip.projectTerminalDashboard.body": "You can also open a project terminal straight from the Dashboard — click the terminal icon on any project card.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -155,7 +155,9 @@ const tips = {
 	"tip.diffCompareDefault.title": "Elige la base del diff",
 	"tip.diffCompareDefault.body": "En Ajustes del proyecto puedes elegir si el estado de rama y Show Diff comparan contra origin/<base> o la rama base local.",
 	"tip.projectTerminal.title": "Terminal del proyecto",
-	"tip.projectTerminal.body": "Haz clic en el icono de terminal en el tablero Kanban para abrir un shell en la raíz del proyecto.",
+	"tip.projectTerminal.body": "¿Necesitas un shell rápido en la raíz del repo? Haz clic en el icono de terminal en la barra de navegación, justo al lado del nombre del proyecto.",
+	"tip.projectTerminalDashboard.title": "Terminal desde el Dashboard",
+	"tip.projectTerminalDashboard.body": "También puedes abrir el terminal del proyecto directamente desde el Dashboard — haz clic en el icono de terminal de cualquier tarjeta de proyecto.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -155,7 +155,9 @@ const tips = {
 	"tip.diffCompareDefault.title": "Выберите базу для diff",
 	"tip.diffCompareDefault.body": "В Project Settings можно выбрать, сравнивать ли статус ветки и Show Diff с origin/<base> или с локальной базовой веткой.",
 	"tip.projectTerminal.title": "Терминал проекта",
-	"tip.projectTerminal.body": "Нажмите иконку терминала на Kanban-доске, чтобы открыть shell в корне проекта.",
+	"tip.projectTerminal.body": "Нужен быстрый shell в корне репо? Нажми иконку терминала в панели навигации, прямо рядом с именем проекта.",
+	"tip.projectTerminalDashboard.title": "Терминал с дашборда",
+	"tip.projectTerminalDashboard.body": "Терминал проекта можно открыть прямо с Dashboard — нажми иконку терминала на карточке проекта.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -488,6 +488,12 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.projectTerminal.body",
 		icon: "\u{F0489}", // nf-md-console
 	},
+	{
+		id: "project-terminal-dashboard",
+		titleKey: "tip.projectTerminalDashboard.title",
+		bodyKey: "tip.projectTerminalDashboard.body",
+		icon: "\u{F0489}", // nf-md-console
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days


### PR DESCRIPTION
## Summary

Follow-up to #356 — improves the "Did you know?" tips for the project terminal feature.

- Rewritten first tip to explain *where* to find the icon ("in the breadcrumbs bar, right next to the project name")
- Added a second tip about opening the terminal from the Dashboard project card
- All three locales updated (en/ru/es)