### PR TITLE
Fix auto-update retry and make project terminal a proper route

### DIFF
--- a/change-logs/2026/03/18/fix-autoupdate-and-terminal-route.md
+++ b/change-logs/2026/03/18/fix-autoupdate-and-terminal-route.md
@@ -1,0 +1,1 @@
+Auto-update download retry now uses exponential backoff (500ms to 30s) instead of a single 1-second retry, giving Electrobun more time to finalize the update state. Project terminal is now a proper route (`project-terminal`) instead of a localStorage toggle, fixing incorrect page restore after update-restart and enabling proper back/forward navigation.

--- a/src/bun/updater.ts
+++ b/src/bun/updater.ts
@@ -118,24 +118,32 @@ export async function downloadUpdateForChannel(
 
 			// Step 3: verify the update is actually ready after download.
 			// Electrobun may not mark updateReady synchronously after downloadUpdate resolves.
-			const postDownload = Updater.updateInfo?.();
-			if (postDownload?.updateReady) {
+			// Use exponential backoff: 500ms, 1s, 2s, 4s, 8s, 16s, 30s (~61.5s total).
+			const backoffDelays = [500, 1000, 2000, 4000, 8000, 16000, 30000];
+			for (let i = 0; i < backoffDelays.length; i++) {
+				const info = i === 0 ? Updater.updateInfo?.() : await Updater.checkForUpdate();
+				if (info?.updateReady) {
+					log.info("Update ready", { attempt: i + 1 });
+					onProgress?.("complete", 100);
+					return { ok: true };
+				}
+				log.warn("updateReady is false, retrying...", {
+					attempt: i + 1,
+					delayMs: backoffDelays[i],
+				});
+				await new Promise((r) => setTimeout(r, backoffDelays[i]));
+			}
+
+			// Final check after last delay
+			const final = await Updater.checkForUpdate();
+			if (final?.updateReady) {
+				log.info("Update ready after final re-check");
 				onProgress?.("complete", 100);
 				return { ok: true };
 			}
 
-			// Give Electrobun a moment to finalize, then re-check
-			log.warn("downloadUpdate resolved but updateReady is false, retrying check...");
-			await new Promise((r) => setTimeout(r, 1000));
-			const refreshed = await Updater.checkForUpdate();
-			if (refreshed?.updateReady) {
-				log.info("Update ready after re-check");
-				onProgress?.("complete", 100);
-				return { ok: true };
-			}
-
-			const msg = "Download completed but update not marked as ready";
-			log.error(msg, { updateReady: refreshed?.updateReady });
+			const msg = "Download completed but update not marked as ready after retries";
+			log.error(msg, { updateReady: final?.updateReady, totalRetries: backoffDelays.length });
 			onProgress?.("error");
 			return { ok: false, error: msg };
 		} catch (err) {

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -12,6 +12,7 @@ import GlobalSettings from "./components/GlobalSettings";
 import Dashboard from "./components/Dashboard";
 import ProjectView from "./components/ProjectView";
 import TaskTerminal from "./components/TaskTerminal";
+import ProjectTerminal from "./components/ProjectTerminal";
 import ProjectSettings from "./components/ProjectSettings";
 import RequirementsCheck from "./components/RequirementsCheck";
 import GhWarningBanner, { isGhWarningDismissed } from "./components/GhWarningBanner";
@@ -20,23 +21,6 @@ import GaugeDemo from "./components/gauges/GaugeDemo";
 import ViewportLab from "./components/ViewportLab";
 
 const SKIP_QUIT_DIALOG_KEY = "dev3-skip-quit-dialog";
-const LS_PROJECT_TERMINAL_PREFIX = "dev3-project-terminal-";
-
-function readProjectTerminalState(projectId: string): boolean {
-	try {
-		return localStorage.getItem(LS_PROJECT_TERMINAL_PREFIX + projectId) === "true";
-	} catch { return false; }
-}
-
-function writeProjectTerminalState(projectId: string, open: boolean): void {
-	try {
-		if (open) {
-			localStorage.setItem(LS_PROJECT_TERMINAL_PREFIX + projectId, "true");
-		} else {
-			localStorage.removeItem(LS_PROJECT_TERMINAL_PREFIX + projectId);
-		}
-	} catch { /* ignore */ }
-}
 
 function App() {
 	const [state, dispatch] = useAppState();
@@ -58,29 +42,6 @@ function App() {
 	const [reqStatus, setReqStatus] = useState<"checking" | "failed" | "passed">("checking");
 	const [reqResults, setReqResults] = useState<RequirementCheckResult[]>([]);
 	const [reqChecking, setReqChecking] = useState(false);
-
-	// Project terminal toggle state (lifted here so GlobalHeader can control it)
-	const currentProjectId = "projectId" in state.route ? state.route.projectId : null;
-	const hasActiveTask = state.route.screen === "project" && !!(state.route as { activeTaskId?: string }).activeTaskId;
-	const [showProjectTerminal, setShowProjectTerminal] = useState(false);
-
-	// Sync with localStorage when switching projects
-	useEffect(() => {
-		if (currentProjectId && !hasActiveTask) {
-			setShowProjectTerminal(readProjectTerminalState(currentProjectId));
-		} else {
-			setShowProjectTerminal(false);
-		}
-	}, [currentProjectId, hasActiveTask]);
-
-	const toggleProjectTerminal = useCallback(() => {
-		if (!currentProjectId) return;
-		setShowProjectTerminal((prev) => {
-			const next = !prev;
-			writeProjectTerminalState(currentProjectId, next);
-			return next;
-		});
-	}, [currentProjectId]);
 
 	// GitHub CLI availability warning
 	const [ghWarning, setGhWarning] = useState<{ notInstalled: boolean } | null>(null);
@@ -418,6 +379,8 @@ function App() {
 				navigate({ screen: "dashboard" });
 			} else if (route.screen === "project-settings") {
 				navigate({ screen: "project", projectId: route.projectId });
+			} else if (route.screen === "project-terminal") {
+				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project" && route.activeTaskId) {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project") {
@@ -471,8 +434,6 @@ function App() {
 				navigate={navigate}
 				updateVersion={updateVersion}
 				updateDownloadStatus={updateDownloadStatus}
-				showProjectTerminal={!hasActiveTask ? showProjectTerminal : undefined}
-				onToggleProjectTerminal={!hasActiveTask ? toggleProjectTerminal : undefined}
 			/>
 			{ghWarning && (
 				<GhWarningBanner
@@ -588,9 +549,16 @@ function App() {
 						bellCounts={state.bellCounts}
 						taskPorts={state.taskPorts}
 						activeTaskId={route.activeTaskId}
-						showProjectTerminal={showProjectTerminal}
 					/>
 				);
+			case "project-terminal": {
+				const proj = state.projects.find((p) => p.id === route.projectId);
+				return proj ? (
+					<div className="flex-1 min-h-0 flex flex-col">
+						<ProjectTerminal projectId={route.projectId} projectPath={proj.path} />
+					</div>
+				) : null;
+			}
 			case "task":
 				return (
 					<TaskTerminal

--- a/src/mainview/components/Dashboard.tsx
+++ b/src/mainview/components/Dashboard.tsx
@@ -186,10 +186,7 @@ function Dashboard({ projects, dispatch, navigate, bellCounts }: DashboardProps)
 												<button
 													onClick={(e) => {
 														e.stopPropagation();
-														try {
-															localStorage.setItem(`dev3-project-terminal-${project.id}`, "true");
-														} catch { /* ignore */ }
-														navigate({ screen: "project", projectId: project.id });
+														navigate({ screen: "project-terminal", projectId: project.id });
 													}}
 													className="text-fg-3 hover:text-fg transition-colors p-1.5 rounded-lg hover:bg-elevated"
 													title={t("projectTerminal.tooltip")}

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -14,8 +14,6 @@ interface GlobalHeaderProps {
 	navigate: (route: Route) => void;
 	updateVersion?: string | null;
 	updateDownloadStatus?: string | null;
-	showProjectTerminal?: boolean;
-	onToggleProjectTerminal?: () => void;
 }
 
 interface BreadcrumbSegment {
@@ -29,7 +27,7 @@ interface BreadcrumbSegment {
 /** Cache TTL for project task counts (30 seconds) */
 const COUNTS_CACHE_TTL = 30_000;
 
-function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateDownloadStatus, showProjectTerminal, onToggleProjectTerminal }: GlobalHeaderProps) {
+function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateDownloadStatus }: GlobalHeaderProps) {
 	const t = useT();
 	const [showUpdateDropdown, setShowUpdateDropdown] = useState(false);
 	const [restarting, setRestarting] = useState(false);
@@ -169,23 +167,19 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 	if ("projectId" in route) {
 		const project = projects.find((p) => p.id === route.projectId);
 		if (project) {
-			// In terminal view: clicking project name closes the terminal (returns to kanban)
-			// Otherwise: navigate to project board only when coming from a sub-screen
-			const projectNameonClick = showProjectTerminal && onToggleProjectTerminal
-				? onToggleProjectTerminal
-				: (route.screen !== "project" || (route.screen === "project" && route.activeTaskId))
-					? handleProjectNameClick
-					: undefined;
+			// Clickable when not already on the kanban board (no activeTaskId, not on terminal)
+			const isOnKanban = route.screen === "project" && !route.activeTaskId;
+			const projectNameOnClick = !isOnKanban ? handleProjectNameClick : undefined;
 			segments.push({
 				label: project.name,
 				isProjectDropdown: true,
-				onClick: projectNameonClick,
+				onClick: projectNameOnClick,
 			});
 		}
 	}
 
 	// Project terminal breadcrumb segment
-	if (route.screen === "project" && !route.activeTaskId && showProjectTerminal) {
+	if (route.screen === "project-terminal") {
 		segments.push({ label: t("projectTerminal.label") });
 	}
 
@@ -265,15 +259,11 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 								) : (
 									<span className="text-fg font-semibold truncate">{seg.label}</span>
 								)}
-								{onToggleProjectTerminal && !showProjectTerminal && (
+								{"projectId" in route && route.screen === "project" && !route.activeTaskId && (
 									<button
-										onClick={(e) => { e.stopPropagation(); onToggleProjectTerminal(); }}
-										title={showProjectTerminal ? t("projectTerminal.close") : t("projectTerminal.tooltip")}
-										className={`flex-shrink-0 ml-1.5 mr-0.5 px-1 py-0.5 rounded transition-colors ${
-											showProjectTerminal
-												? "text-accent hover:text-accent-hover"
-												: "text-fg-muted hover:text-fg hover:bg-elevated"
-										}`}
+										onClick={(e) => { e.stopPropagation(); navigate({ screen: "project-terminal", projectId: route.projectId }); }}
+										title={t("projectTerminal.tooltip")}
+										className="flex-shrink-0 ml-1.5 mr-0.5 px-1 py-0.5 rounded transition-colors text-fg-muted hover:text-fg hover:bg-elevated"
 									>
 										<span
 											className="text-[0.95rem] leading-none"

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -4,7 +4,6 @@ import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
 import KanbanBoard from "./KanbanBoard";
 import TaskTerminal from "./TaskTerminal";
-import ProjectTerminal from "./ProjectTerminal";
 import TaskInfoPanel from "./TaskInfoPanel";
 import SplitLayout from "./SplitLayout";
 import ActiveTasksSidebar from "./ActiveTasksSidebar";
@@ -31,7 +30,6 @@ interface ProjectViewProps {
 	bellCounts: Map<string, number>;
 	taskPorts: Map<string, PortInfo[]>;
 	activeTaskId?: string;
-	showProjectTerminal: boolean;
 }
 
 function ProjectView({
@@ -43,7 +41,6 @@ function ProjectView({
 	bellCounts,
 	taskPorts,
 	activeTaskId,
-	showProjectTerminal,
 }: ProjectViewProps) {
 	const t = useT();
 	const project = projects.find((p) => p.id === projectId);
@@ -120,14 +117,6 @@ function ProjectView({
 					}
 					mode={sidebarMode}
 				/>
-			</div>
-		);
-	}
-
-	if (showProjectTerminal) {
-		return (
-			<div className="flex-1 min-h-0 flex flex-col">
-				<ProjectTerminal projectId={projectId} projectPath={project.path} />
 			</div>
 		);
 	}

--- a/src/mainview/components/TmuxSessionManager.tsx
+++ b/src/mainview/components/TmuxSessionManager.tsx
@@ -164,10 +164,7 @@ function TmuxSessionManager({ navigate }: TmuxSessionManagerProps) {
 
 	function handleSessionClick(session: TmuxSessionInfo) {
 		if (session.isProjectTerminal && session.projectId) {
-			try {
-				localStorage.setItem(`dev3-project-terminal-${session.projectId}`, "true");
-			} catch { /* ignore */ }
-			navigate({ screen: "project", projectId: session.projectId });
+			navigate({ screen: "project-terminal", projectId: session.projectId });
 			setPopoverOpen(false);
 		} else if (session.taskId && session.projectId) {
 			navigate({ screen: "project", projectId: session.projectId, activeTaskId: session.taskId });

--- a/src/mainview/hooks/useViewport.ts
+++ b/src/mainview/hooks/useViewport.ts
@@ -7,7 +7,7 @@ const MOBILE_VIEWPORT = "width=device-width, initial-scale=1.0, viewport-fit=cov
 
 /** Screens that require desktop-width viewport even on mobile (terminal). */
 function needsDesktopViewport(route: Route): boolean {
-	return route.screen === "task" || (route.screen === "project" && !!route.activeTaskId);
+	return route.screen === "task" || route.screen === "project-terminal" || (route.screen === "project" && !!route.activeTaskId);
 }
 
 /**

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -6,6 +6,7 @@ import type { PortInfo, Project, Task } from "../shared/types";
 export type Route =
 	| { screen: "dashboard" }
 	| { screen: "project"; projectId: string; activeTaskId?: string }
+	| { screen: "project-terminal"; projectId: string }
 	| { screen: "task"; projectId: string; taskId: string }
 	| { screen: "project-settings"; projectId: string; tab?: "global" | "project" | "worktree"; worktreeTaskId?: string }
 	| { screen: "settings" }


### PR DESCRIPTION
## Summary

Hey, Claude here (the AI working on this branch).

- **Auto-update exponential backoff**: the overnight logs showed `downloadUpdate()` resolving with `updateReady=false` every 30 minutes for 8+ hours straight. Replaced the single 1-second retry with exponential backoff (500ms → 1s → 2s → 4s → 8s → 16s → 30s, ~61s total), giving Electrobun more time to finalize its internal state before giving up.
- **Project terminal as a proper route**: promoted from a `localStorage` toggle (`showProjectTerminal` boolean) to a first-class route `{ screen: "project-terminal", projectId }`. This fixes the bug where the project terminal would re-appear after an update-restart (localStorage persisted independently from the saved route), and enables proper back/forward navigation + Escape key handling.