### PR TITLE
Fix project terminal split panes opening in wrong directory

### DIFF
--- a/change-logs/2026/03/18/fix-split-pane-pwd.md
+++ b/change-logs/2026/03/18/fix-split-pane-pwd.md
@@ -1,0 +1,1 @@
+Fixed project terminal split panes opening in the wrong directory. New panes were inheriting the tmux server's start directory (e.g. the app bundle path) instead of the project root. Added `-c` flag to all `split-window` calls in `setupProjectLayout` so every pane starts in the correct project directory.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -861,6 +861,47 @@ describe("pty-server", () => {
 			expect(killCall![0]).toContain("dev3-pt-cccccccc");
 		});
 
+		it("creates split panes with correct cwd (-c flag)", () => {
+			vi.useFakeTimers();
+			const key = track("project-eeeeeeee-1111-2222-3333-444444444444");
+			// Simulate single-pane session (freshly created)
+			mockSpawnSync.mockImplementation((cmd: any) => {
+				if (Array.isArray(cmd) && cmd.includes("list-panes")) {
+					return {
+						exitCode: 0,
+						stdout: new TextEncoder().encode("0: [200x50]\n"),
+					} as any;
+				}
+				return { exitCode: 0, stdout: new Uint8Array(0) } as any;
+			});
+
+			createSession(key, "eeeeeeee", "/tmp/my-project-root", "bash", {}, "dev3", "project");
+			mockSpawnSync.mockClear();
+			mockSpawnSync.mockImplementation((cmd: any) => {
+				if (Array.isArray(cmd) && cmd.includes("list-panes")) {
+					return {
+						exitCode: 0,
+						stdout: new TextEncoder().encode("0: [200x50]\n"),
+					} as any;
+				}
+				return { exitCode: 0, stdout: new Uint8Array(0) } as any;
+			});
+
+			vi.advanceTimersByTime(300);
+
+			// All three split-window calls must include -c with the project root
+			const splitCalls = mockSpawnSync.mock.calls.filter(
+				(c) => Array.isArray(c[0]) && c[0].includes("split-window"),
+			);
+			expect(splitCalls).toHaveLength(3);
+			for (const call of splitCalls) {
+				expect(call[0]).toContain("-c");
+				expect(call[0]).toContain("/tmp/my-project-root");
+			}
+
+			vi.useRealTimers();
+		});
+
 		it("capturePane works for project sessions", () => {
 			const key = track("project-dddddddd-1111-2222-3333-444444444444");
 			createSession(key, "dddddddd", "/tmp/root", "bash", {}, "dev3", "project");

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -466,9 +466,11 @@ function setupProjectLayout(session: PtySession): void {
 		// Create 3 more panes (4 total), then apply tiled layout for 2×2 grid.
 		// We always split the active pane — no pane-index arithmetic needed,
 		// so pane-base-index setting doesn't matter.
-		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s));
-		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s));
-		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s));
+		// -c sets the working directory — without it, new panes inherit the
+		// tmux server's start dir (e.g. /Applications/dev-3.0.app/Contents/MacOS/).
+		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s, "-c", session.cwd));
+		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s, "-c", session.cwd));
+		spawnSync(tmuxArgs(sock, "split-window", "-v", "-t", s, "-c", session.cwd));
 		// tiled layout arranges 4 panes as a 2×2 grid automatically
 		spawnSync(tmuxArgs(sock, "select-layout", "-t", s, "tiled"));
 		// Return focus to pane 1 (base-index 1 in tmux config)


### PR DESCRIPTION
## Summary

- Project terminal split panes were opening in the tmux server's start directory (e.g. `/Applications/dev-3.0.app/Contents/MacOS/`) instead of the project root
- Added `-c` flag with `session.cwd` to all `split-window` calls in `setupProjectLayout` so every pane starts in the correct project directory
- Added regression test verifying all split-window calls include the correct working directory