### PR TITLE
Fix dashboard defaulting to Projects tab instead of Activity

### DIFF
--- a/change-logs/2026/03/19/fix-dashboard-default-tab.md
+++ b/change-logs/2026/03/19/fix-dashboard-default-tab.md
@@ -1,0 +1,1 @@
+Dashboard tab preference now uses sessionStorage instead of localStorage, so the Activity tab is always shown by default when the app starts. Within a session, the selected tab is still remembered when navigating away and back.

--- a/src/mainview/components/Dashboard.tsx
+++ b/src/mainview/components/Dashboard.tsx
@@ -21,11 +21,11 @@ function Dashboard({ projects, dispatch, navigate, bellCounts }: DashboardProps)
 	const [showAddModal, setShowAddModal] = useState(false);
 	const [tab, setTabRaw] = useState<DashboardTab>(() => {
 		if (projects.length === 0) return "projects";
-		const saved = localStorage.getItem("dev3-dashboard-tab");
+		const saved = sessionStorage.getItem("dev3-dashboard-tab");
 		return saved === "activity" || saved === "projects" ? saved : "activity";
 	});
 	const setTab = (t: DashboardTab) => {
-		localStorage.setItem("dev3-dashboard-tab", t);
+		sessionStorage.setItem("dev3-dashboard-tab", t);
 		setTabRaw(t);
 	};
 

--- a/src/mainview/components/__tests__/Dashboard.test.tsx
+++ b/src/mainview/components/__tests__/Dashboard.test.tsx
@@ -60,7 +60,7 @@ const mockProject: Project = {
 describe("Dashboard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		localStorage.removeItem("dev3-dashboard-tab");
+		sessionStorage.removeItem("dev3-dashboard-tab");
 	});
 
 	describe("empty state", () => {
@@ -200,23 +200,31 @@ describe("Dashboard", () => {
 			expect(activityBtn.className).toContain("bg-elevated");
 		});
 
-		it("restores saved tab from localStorage", () => {
-			localStorage.setItem("dev3-dashboard-tab", "projects");
+		it("restores saved tab from sessionStorage", () => {
+			sessionStorage.setItem("dev3-dashboard-tab", "projects");
 			renderDashboard([mockProject]);
 			const projectsBtn = screen.getByText("Projects");
 			expect(projectsBtn.className).toContain("bg-elevated");
 		});
 
-		it("saves tab to localStorage when switched", async () => {
+		it("saves tab to sessionStorage when switched", async () => {
 			const user = userEvent.setup();
 			renderDashboard([mockProject]);
 			await user.click(screen.getByText("Projects"));
-			expect(localStorage.getItem("dev3-dashboard-tab")).toBe("projects");
+			expect(sessionStorage.getItem("dev3-dashboard-tab")).toBe("projects");
 		});
 
 		it("ignores invalid saved tab values", () => {
-			localStorage.setItem("dev3-dashboard-tab", "bogus");
+			sessionStorage.setItem("dev3-dashboard-tab", "bogus");
 			renderDashboard([mockProject]);
+			const activityBtn = screen.getByText("Activity");
+			expect(activityBtn.className).toContain("bg-elevated");
+		});
+
+		it("does not persist tab across app restarts (localStorage)", () => {
+			localStorage.setItem("dev3-dashboard-tab", "projects");
+			renderDashboard([mockProject]);
+			// Should ignore localStorage and default to activity
 			const activityBtn = screen.getByText("Activity");
 			expect(activityBtn.className).toContain("bg-elevated");
 		});


### PR DESCRIPTION
## Summary

- Dashboard tab preference (`Activity` / `Projects`) was stored in `localStorage`, which persists across app restarts — so once a user clicked "Projects", it stuck forever.
- Switched to `sessionStorage` so the tab resets to **Activity** on every app launch, while still remembering the user's choice within a session.

Hey, this is Claude — the AI assistant working on this task.