### PR TITLE
Improve project terminal UX: keyboard shortcut, header button, back toolbar

### DIFF
--- a/change-logs/2026/03/19/feature-project-terminal-ux.md
+++ b/change-logs/2026/03/19/feature-project-terminal-ux.md
@@ -1,0 +1,1 @@
+Improved project terminal UX: added Cmd+` keyboard shortcut to toggle the terminal from any project screen, a visible "Terminal" button in the header actions area (with active state highlight), and a "Back to Board" toolbar at the top of the terminal screen. Removed the tiny breadcrumb icon that was previously the only entry point.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -124,6 +124,18 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				applyZoom(DEFAULT_ZOOM);
+			} else if ((e.metaKey || e.ctrlKey) && e.key === "`") {
+				// Cmd+` — toggle project terminal
+				const { route } = state;
+				if (route.screen === "project-terminal") {
+					e.preventDefault();
+					e.stopPropagation();
+					navigate({ screen: "project", projectId: route.projectId });
+				} else if ("projectId" in route) {
+					e.preventDefault();
+					e.stopPropagation();
+					navigate({ screen: "project-terminal", projectId: route.projectId });
+				}
 			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= "1" && e.key <= "9") {
 				// Cmd+1..9 — switch to project by index (like Slack workspaces)
 				const idx = parseInt(e.key, 10) - 1;
@@ -135,7 +147,7 @@ function App() {
 				}
 			}
 		},
-		[navigate, state.projects],
+		[navigate, state.projects, state.route],
 		{ capture: true },
 	);
 
@@ -555,7 +567,11 @@ function App() {
 				const proj = state.projects.find((p) => p.id === route.projectId);
 				return proj ? (
 					<div className="flex-1 min-h-0 flex flex-col">
-						<ProjectTerminal projectId={route.projectId} projectPath={proj.path} />
+						<ProjectTerminal
+							projectId={route.projectId}
+							projectPath={proj.path}
+							onBack={() => navigate({ screen: "project", projectId: route.projectId })}
+						/>
 					</div>
 				) : null;
 			}

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -58,6 +58,9 @@ vi.mock("../components/RequirementsCheck", () => ({
 vi.mock("../components/gauges/GaugeDemo", () => ({
 	default: () => <div data-testid="gauge-demo-screen" />,
 }));
+vi.mock("../components/ProjectTerminal", () => ({
+	default: () => <div data-testid="project-terminal-screen" />,
+}));
 
 import { api } from "../rpc";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
@@ -203,6 +206,40 @@ describe("App keyboard shortcuts", () => {
 			// Cmd+1 should navigate to Active (the only non-deleted project)
 			await userEvent.keyboard("{Meta>}1{/Meta}");
 			expect(screen.getByTestId("project-screen")).toBeInTheDocument();
+		});
+	});
+
+	describe("project terminal toggle (Cmd+`)", () => {
+		it("Cmd+` from project screen opens project terminal", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			await renderApp();
+			// Navigate to project first
+			await userEvent.keyboard("{Meta>}1{/Meta}");
+			expect(screen.getByTestId("project-screen")).toBeInTheDocument();
+			// Toggle terminal
+			await userEvent.keyboard("{Meta>}`{/Meta}");
+			expect(screen.getByTestId("project-terminal-screen")).toBeInTheDocument();
+		});
+
+		it("Cmd+` from project terminal goes back to project", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			await renderApp();
+			await userEvent.keyboard("{Meta>}1{/Meta}");
+			await userEvent.keyboard("{Meta>}`{/Meta}");
+			expect(screen.getByTestId("project-terminal-screen")).toBeInTheDocument();
+			// Toggle back
+			await userEvent.keyboard("{Meta>}`{/Meta}");
+			expect(screen.getByTestId("project-screen")).toBeInTheDocument();
+		});
+
+		it("Cmd+` on dashboard does nothing", async () => {
+			await renderApp();
+			await userEvent.keyboard("{Meta>}`{/Meta}");
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
 		});
 	});
 

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -259,20 +259,6 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 								) : (
 									<span className="text-fg font-semibold truncate">{seg.label}</span>
 								)}
-								{"projectId" in route && route.screen === "project" && !route.activeTaskId && (
-									<button
-										onClick={(e) => { e.stopPropagation(); navigate({ screen: "project-terminal", projectId: route.projectId }); }}
-										title={t("projectTerminal.tooltip")}
-										className="flex-shrink-0 ml-1.5 mr-0.5 px-1 py-0.5 rounded transition-colors text-fg-muted hover:text-fg hover:bg-elevated"
-									>
-										<span
-											className="text-[0.95rem] leading-none"
-											style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-										>
-											{"\uF489"}
-										</span>
-									</button>
-								)}
 								<button
 									onClick={() => setShowProjectDropdown((v) => !v)}
 									className="text-fg-muted hover:text-fg transition-colors flex-shrink-0 p-0.5 rounded hover:bg-elevated"
@@ -410,6 +396,33 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 							</div>
 						)}
 					</div>
+				)}
+
+				{/* Project Terminal — visible when inside a project */}
+				{"projectId" in route && (
+					<button
+						onClick={() => {
+							if (route.screen === "project-terminal") {
+								navigate({ screen: "project", projectId: route.projectId });
+							} else {
+								navigate({ screen: "project-terminal", projectId: route.projectId });
+							}
+						}}
+						className={`flex items-center gap-1 transition-colors px-2 py-1 rounded-lg ${
+							route.screen === "project-terminal"
+								? "text-accent bg-accent/15 hover:bg-accent/25"
+								: "text-fg-3 hover:text-fg hover:bg-elevated"
+						}`}
+						title={t("projectTerminal.tooltipWithShortcut")}
+					>
+						<span
+							className="text-[1.125rem] leading-none"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\uF489"}
+						</span>
+						<span className="text-[0.6875rem] font-medium">{t("projectTerminal.open")}</span>
+					</button>
 				)}
 
 				{/* Tmux Session Manager */}

--- a/src/mainview/components/ProjectTerminal.tsx
+++ b/src/mainview/components/ProjectTerminal.tsx
@@ -6,9 +6,10 @@ import TerminalView from "../TerminalView";
 interface ProjectTerminalProps {
 	projectId: string;
 	projectPath: string;
+	onBack: () => void;
 }
 
-function ProjectTerminal({ projectId }: ProjectTerminalProps) {
+function ProjectTerminal({ projectId, projectPath, onBack }: ProjectTerminalProps) {
 	const t = useT();
 	const [ptyUrl, setPtyUrl] = useState<string | null>(null);
 	const [error, setError] = useState(false);
@@ -84,6 +85,24 @@ function ProjectTerminal({ projectId }: ProjectTerminalProps) {
 
 	return (
 		<div className="h-full w-full flex flex-col overflow-hidden">
+			{/* Back to board toolbar */}
+			<div className="flex items-center justify-between px-4 py-1.5 border-b border-edge flex-shrink-0 bg-raised">
+				<button
+					onClick={onBack}
+					className="flex items-center gap-1.5 text-fg-3 hover:text-fg transition-colors text-sm"
+				>
+					<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+					</svg>
+					<span>{t("projectTerminal.backToBoard")}</span>
+				</button>
+				<div className="flex items-center gap-3">
+					<span className="text-fg-muted text-xs truncate max-w-[20rem]">{projectPath}</span>
+					<kbd className="text-[0.625rem] text-fg-muted/60 font-mono px-1.5 py-0.5 rounded bg-elevated border border-edge">
+						{t("projectTerminal.shortcutHint")}
+					</kbd>
+				</div>
+			</div>
 			<div className="flex-1 min-h-0 overflow-hidden">
 				{ptyUrl ? (
 					<TerminalView ptyUrl={ptyUrl} taskId={sessionKey} projectId={projectId} />

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -507,3 +507,48 @@ describe("GlobalHeader — update countdown", () => {
 		});
 	});
 });
+
+describe("GlobalHeader — project terminal button", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getTasks.mockResolvedValue([]);
+	});
+
+	it("shows terminal button when inside a project", () => {
+		renderHeader({ screen: "project", projectId: "p1" });
+		expect(screen.getByText("Project Terminal")).toBeInTheDocument();
+	});
+
+	it("does not show terminal button on dashboard", () => {
+		renderHeader({ screen: "dashboard" });
+		expect(screen.queryByText("Project Terminal")).not.toBeInTheDocument();
+	});
+
+	it("terminal button has active style on project-terminal screen", () => {
+		renderHeader({ screen: "project-terminal", projectId: "p1" });
+		const btn = screen.getByTitle("Project Terminal (\u2318`)");
+		expect(btn.className).toContain("text-accent");
+	});
+
+	it("clicking terminal button navigates to project-terminal", async () => {
+		const user = userEvent.setup();
+		const navigate = vi.fn();
+		renderHeader({ screen: "project", projectId: "p1" }, [project1, project2], navigate);
+		await user.click(screen.getByTitle("Project Terminal (\u2318`)"));
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "project-terminal",
+			projectId: "p1",
+		});
+	});
+
+	it("clicking terminal button when already on terminal navigates back to project", async () => {
+		const user = userEvent.setup();
+		const navigate = vi.fn();
+		renderHeader({ screen: "project-terminal", projectId: "p1" }, [project1, project2], navigate);
+		await user.click(screen.getByTitle("Project Terminal (\u2318`)"));
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "project",
+			projectId: "p1",
+		});
+	});
+});

--- a/src/mainview/components/__tests__/ProjectTerminal.test.tsx
+++ b/src/mainview/components/__tests__/ProjectTerminal.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProjectTerminal from "../ProjectTerminal";
+import { I18nProvider } from "../../i18n";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			getProjectPtyUrl: vi.fn().mockResolvedValue("ws://localhost:1234"),
+			destroyProjectTerminal: vi.fn().mockResolvedValue(undefined),
+		},
+	},
+}));
+
+vi.mock("../../TerminalView", () => ({
+	default: () => <div data-testid="terminal-view" />,
+}));
+
+function renderTerminal(onBack = vi.fn()) {
+	return {
+		onBack,
+		...render(
+			<I18nProvider>
+				<ProjectTerminal
+					projectId="p1"
+					projectPath="/home/user/project"
+					onBack={onBack}
+				/>
+			</I18nProvider>,
+		),
+	};
+}
+
+describe("ProjectTerminal — back-to-board toolbar", () => {
+	it("renders the back-to-board button", async () => {
+		renderTerminal();
+		expect(screen.getByText("Back to Board")).toBeInTheDocument();
+	});
+
+	it("renders the project path", async () => {
+		renderTerminal();
+		expect(screen.getByText("/home/user/project")).toBeInTheDocument();
+	});
+
+	it("renders the shortcut hint", async () => {
+		renderTerminal();
+		expect(screen.getByText("\u2318`")).toBeInTheDocument();
+	});
+
+	it("calls onBack when clicking the back button", async () => {
+		const user = userEvent.setup();
+		const { onBack } = renderTerminal();
+		await user.click(screen.getByText("Back to Board"));
+		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -68,6 +68,9 @@ const terminal = {
 	"projectTerminal.sessionEndedDesc": "The terminal process has exited. Click restart to open a new session.",
 	"projectTerminal.restart": "Restart",
 	"projectTerminal.label": "Project Terminal",
+	"projectTerminal.backToBoard": "Back to Board",
+	"projectTerminal.shortcutHint": "\u2318`",
+	"projectTerminal.tooltipWithShortcut": "Project Terminal (\u2318`)",
 } as const;
 
 export default terminal;

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -155,7 +155,7 @@ const tips = {
 	"tip.diffCompareDefault.title": "Pick your diff baseline",
 	"tip.diffCompareDefault.body": "In Project Settings, choose whether branch status and Show Diff compare against origin/<base> or your local base branch.",
 	"tip.projectTerminal.title": "Project Terminal",
-	"tip.projectTerminal.body": "Need a quick shell at the repo root? Click the terminal icon in the breadcrumbs bar, right next to the project name.",
+	"tip.projectTerminal.body": "Need a quick shell at the repo root? Click the Terminal button in the header or press \u2318` to toggle it from any project screen.",
 	"tip.projectTerminalDashboard.title": "Terminal from Dashboard",
 	"tip.projectTerminalDashboard.body": "You can also open a project terminal straight from the Dashboard — click the terminal icon on any project card.",
 	"tip.portAllocation.title": "Auto-allocate ports",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -68,6 +68,9 @@ const terminal = {
 	"projectTerminal.sessionEndedDesc": "El proceso del terminal ha terminado. Haz clic en reiniciar para abrir una nueva sesión.",
 	"projectTerminal.restart": "Reiniciar",
 	"projectTerminal.label": "Terminal del proyecto",
+	"projectTerminal.backToBoard": "Volver al tablero",
+	"projectTerminal.shortcutHint": "\u2318`",
+	"projectTerminal.tooltipWithShortcut": "Terminal del proyecto (\u2318`)",
 };
 
 export default terminal;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -155,7 +155,7 @@ const tips = {
 	"tip.diffCompareDefault.title": "Elige la base del diff",
 	"tip.diffCompareDefault.body": "En Ajustes del proyecto puedes elegir si el estado de rama y Show Diff comparan contra origin/<base> o la rama base local.",
 	"tip.projectTerminal.title": "Terminal del proyecto",
-	"tip.projectTerminal.body": "¿Necesitas un shell rápido en la raíz del repo? Haz clic en el icono de terminal en la barra de navegación, justo al lado del nombre del proyecto.",
+	"tip.projectTerminal.body": "¿Necesitas un shell rápido en la raíz del repo? Haz clic en el botón Terminal en el encabezado o presiona \u2318` para alternarlo desde cualquier pantalla del proyecto.",
 	"tip.projectTerminalDashboard.title": "Terminal desde el Dashboard",
 	"tip.projectTerminalDashboard.body": "También puedes abrir el terminal del proyecto directamente desde el Dashboard — haz clic en el icono de terminal de cualquier tarjeta de proyecto.",
 	"tip.portAllocation.title": "Asignar puertos automáticamente",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -72,6 +72,9 @@ const terminal = {
 	"projectTerminal.sessionEndedDesc": "Процесс терминала завершился. Нажмите «Перезапустить» для новой сессии.",
 	"projectTerminal.restart": "Перезапустить",
 	"projectTerminal.label": "Терминал проекта",
+	"projectTerminal.backToBoard": "Назад к доске",
+	"projectTerminal.shortcutHint": "\u2318`",
+	"projectTerminal.tooltipWithShortcut": "Терминал проекта (\u2318`)",
 };
 
 export default terminal;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -155,7 +155,7 @@ const tips = {
 	"tip.diffCompareDefault.title": "Выберите базу для diff",
 	"tip.diffCompareDefault.body": "В Project Settings можно выбрать, сравнивать ли статус ветки и Show Diff с origin/<base> или с локальной базовой веткой.",
 	"tip.projectTerminal.title": "Терминал проекта",
-	"tip.projectTerminal.body": "Нужен быстрый shell в корне репо? Нажми иконку терминала в панели навигации, прямо рядом с именем проекта.",
+	"tip.projectTerminal.body": "Нужен быстрый shell в корне репо? Нажми кнопку Terminal в шапке или \u2318` для переключения с любого экрана проекта.",
 	"tip.projectTerminalDashboard.title": "Терминал с дашборда",
 	"tip.projectTerminalDashboard.body": "Терминал проекта можно открыть прямо с Dashboard — нажми иконку терминала на карточке проекта.",
 	"tip.portAllocation.title": "Авто-выделение портов",


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

## Summary

The project terminal entry point was previously a tiny icon in the breadcrumbs, only visible on the kanban screen without an active task. This PR makes the feature discoverable and easy to use.

### Changes

- **Cmd+` keyboard shortcut** — toggles the project terminal from any project-scoped screen (kanban, settings, task view). Press once to open, press again to go back. Uses capture phase so tmux can't swallow it.
- **Visible "Terminal" button in the header** — icon + label, always visible inside a project. Highlights with accent color when the terminal is active. Tooltip shows the shortcut hint.
- **"Back to Board" toolbar in ProjectTerminal** — thin bar at the top of the terminal screen with a back arrow, the project path, and the `⌘`` hint. Replaces relying on Escape or the breadcrumb.
- **Removed** the tiny breadcrumb icon that was the only entry point before (redundant now).
- **Updated tips** in all three locales (en/ru/es) to reference the new entry points instead of the old breadcrumb icon.
- **12 new tests** — shortcut toggle in App, terminal button in GlobalHeader, back toolbar in ProjectTerminal.