### PR TITLE
Fix swapped even-layout button actions

### DIFF
--- a/change-logs/2026/03/19/fix-layout-even-buttons-swapped.md
+++ b/change-logs/2026/03/19/fix-layout-even-buttons-swapped.md
@@ -1,0 +1,1 @@
+Fix swapped layout buttons: the "even horizontal" icon (rows) was sending tmux `even-horizontal` (columns) and vice versa. Swapped the tmux layout names so each button matches its icon.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -3097,6 +3097,34 @@ describe("handlers.tmuxAction", () => {
 		);
 	});
 
+	it("sends even-vertical layout for layoutEvenH action", async () => {
+		mockSpawn.mockReturnValue({
+			stderr: new Response(""),
+			stdout: new Response(""),
+			exited: Promise.resolve(0),
+		});
+
+		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenH" });
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "select-layout", "-t", "dev3-abcd1234", "even-vertical"],
+			expect.any(Object),
+		);
+	});
+
+	it("sends even-horizontal layout for layoutEvenV action", async () => {
+		mockSpawn.mockReturnValue({
+			stderr: new Response(""),
+			stdout: new Response(""),
+			exited: Promise.resolve(0),
+		});
+
+		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenV" });
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "select-layout", "-t", "dev3-abcd1234", "even-horizontal"],
+			expect.any(Object),
+		);
+	});
+
 	it("sends resize-pane -Z for zoom action", async () => {
 		mockSpawn.mockReturnValue({
 			stderr: new Response(""),

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -3416,10 +3416,10 @@ export const handlers = {
 				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "tiled");
 				break;
 			case "layoutEvenH":
-				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "even-horizontal");
+				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "even-vertical");
 				break;
 			case "layoutEvenV":
-				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "even-vertical");
+				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "even-horizontal");
 				break;
 			case "layoutMainH":
 				args = pty.tmuxArgs(socket, "select-layout", "-t", tmuxSession, "main-horizontal");


### PR DESCRIPTION
## Summary

- The `layoutEvenH` button (horizontal rows icon) was sending tmux `even-horizontal` (which arranges panes side by side), and `layoutEvenV` (vertical columns icon) was sending `even-vertical` (which stacks panes). Swapped the tmux layout names so each button matches its icon.

Hey, this is Claude — the AI assistant working on this fix.