### PR TITLE
Add --dangerously-skip-permissions to all default Claude presets

### DIFF
--- a/change-logs/2026/03/22/chore-claude-presets-skip-permissions.md
+++ b/change-logs/2026/03/22/chore-claude-presets-skip-permissions.md
@@ -1,0 +1,1 @@
+Replaced all default Claude agent presets with a clean set covering every permission mode (default, plan, bypass, auto, acceptEdits, dontAsk), each paired with `--dangerously-skip-permissions`. Default model changed from Sonnet to Opus 1M; all Sonnet variants upgraded to 1M context. Removed redundant "Plan then Bypass" presets. Added "auto" to PermissionMode type.

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -154,7 +154,7 @@ describe("mergeWithDefaults", () => {
 				name: "Claude",
 				baseCommand: "claude",
 				configurations: [
-					{ id: "claude-default", name: "My Custom Name", model: "haiku" },
+					{ id: "claude-default", name: "My Custom Name", model: "haiku", version: 2 },
 					{ id: "user-custom-cfg", name: "My Extra Config" },
 				],
 				defaultConfigId: "claude-default",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,7 +111,7 @@ export function getPrimaryStopTarget(autoReviewEnabled?: boolean): TaskStatus {
 
 // ---- Coding Agents ----
 
-export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "plan";
+export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "plan" | "auto";
 export type EffortLevel = "low" | "medium" | "high";
 
 export interface AgentConfiguration {
@@ -150,14 +150,18 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			{ id: "claude-default", name: "Default", model: "sonnet" },
-			{ id: "claude-plan", name: "Plan (Opus)", model: "opus[1m]", permissionMode: "plan", version: 1 },
-			{ id: "claude-plan-then-bypass-opus", name: "Plan then Bypass (Opus)", model: "opus[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-plan-then-bypass-sonnet", name: "Plan then Bypass (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"] },
-			{ id: "claude-approvals-opus", name: "Approvals (Opus)", model: "opus[1m]", permissionMode: "acceptEdits", version: 1 },
-			{ id: "claude-approvals-sonnet", name: "Approvals (Sonnet)", model: "sonnet", permissionMode: "acceptEdits" },
-			{ id: "claude-bypass-opus", name: "Bypass (Opus)", model: "opus[1m]", permissionMode: "bypassPermissions", version: 1 },
-			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions" },
+			{ id: "claude-default", name: "Default (Opus)", model: "opus[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-default-sonnet", name: "Default (Sonnet)", model: "sonnet[1m]", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-plan", name: "Plan (Opus)", model: "opus[1m]", permissionMode: "plan", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet[1m]", permissionMode: "plan", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-bypass", name: "Bypass (Opus)", model: "opus[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-auto", name: "Auto (Opus)", model: "opus[1m]", permissionMode: "auto", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet[1m]", permissionMode: "auto", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-approvals", name: "Accept Edits (Opus)", model: "opus[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-dontask", name: "Don't Ask (Opus)", model: "opus[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"] },
+			{ id: "claude-dontask-sonnet", name: "Don't Ask (Sonnet)", model: "sonnet[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"] },
 		],
 		defaultConfigId: "claude-default",
 	},


### PR DESCRIPTION
## Summary

Hey, Claude here (the AI assistant working on this one).

- Replaced all 8 default Claude agent configurations with 12 covering every `--permission-mode` (default, plan, bypass, auto, acceptEdits, dontAsk) × two models (Opus 1M, Sonnet 1M)
- All presets now include `--dangerously-skip-permissions` to enable Shift+Tab bypass toggle within sessions
- Default model changed from Sonnet to Opus 1M; all Sonnet variants upgraded to 1M context
- Removed redundant "Plan then Bypass" presets (all presets now enable bypass toggle)
- Added `"auto"` to `PermissionMode` type
- Bumped preset versions to propagate changes to existing users