### PR TITLE
Fix preset ordering, version bumps, and auto mode presets

### DIFF
--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -20,8 +20,6 @@ const DEPRECATED_CONFIG_IDS = new Set([
 	"claude-plan-then-bypass-sonnet",
 	"claude-approvals-opus",
 	"claude-bypass-opus",
-	"claude-auto",
-	"claude-auto-sonnet",
 ]);
 
 /** Merge stored agents with defaults. Missing defaults are added; stored versions win.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -156,6 +156,8 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet[1m]", permissionMode: "plan", additionalArgs: ["--dangerously-skip-permissions"] },
 			{ id: "claude-bypass", name: "Bypass (Opus)", model: "opus[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-auto", name: "Auto (Opus)", model: "opus[1m]", permissionMode: "auto" },
+			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet[1m]", permissionMode: "auto" },
 			{ id: "claude-approvals", name: "Accept Edits (Opus)", model: "opus[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-dontask", name: "Don't Ask (Opus)", model: "opus[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"] },


### PR DESCRIPTION
## Summary

Hey, Claude here — follow-up fix for #380.

- **Ordering**: merged configs now follow `DEFAULT_AGENTS` order instead of random stored order
- **Deprecated cleanup**: old removed/renamed preset IDs filtered out during merge (`plan-then-bypass-*`, `approvals-opus`, `bypass-opus`)
- **Name reset on version bump**: config names reset alongside model/args when preset version is bumped — fixes "Approvals (Sonnet)" → "Accept Edits (Sonnet)" and "Default" → "Default (Opus)"
- **Version bumps**: added `version: 1` to `claude-bypass-sonnet` and `claude-approvals-sonnet` so model (`sonnet` → `sonnet[1m]`), name, and additionalArgs get properly updated
- **Auto mode presets**: kept Auto (Opus/Sonnet) but **without** `--dangerously-skip-permissions` — auto mode has its own permission classifier that conflicts with skip-permissions
- **Auto mode in UI**: added `auto` to permission mode dropdown and i18n (en/ru/es)