### PR TITLE
feat: add Codex worktree hooks

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -2,7 +2,7 @@
 
 Feature compatibility across supported AI coding agents.
 
-Last updated: 2026-03-26
+Last updated: 2026-03-27
 
 ## Agents
 
@@ -19,7 +19,7 @@ Last updated: 2026-03-26
 | Feature | Claude Code | Cursor Agent | Codex | Gemini CLI | OpenCode |
 |---------|:-----------:|:------------:|:-----:|:----------:|:--------:|
 | **Skill injection** | Yes (`!` command syntax) | Yes (generic) | Yes (generic) | Yes (generic) | Yes (generic) |
-| **System prompt injection** | `--append-system-prompt` | via prompt arg | — | — | via `--prompt` |
+| **System prompt injection** | `--append-system-prompt` | via prompt arg | via prompt arg | — | via `--prompt` |
 | **Session resume** | `--continue` | `--continue` | `resume --last` | `--resume latest` | `--continue` |
 | **Permission mode** | `--permission-mode` | `--mode plan` / `--force` | `--permission-mode` | `--approval-mode` | — |
 | **Effort level** | `--effort` | — | `--effort` | — | — |
@@ -27,18 +27,33 @@ Last updated: 2026-03-26
 | **Model selection** | `--model` | `--model` | `--model` | `--model` | `--model` |
 | **Agent selection** | — | — | — | — | `--agent` |
 | **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | — | Yes (`ensureGeminiTrust`) | — |
-| **Status hooks (automatic)** | Yes (4 hooks) | — | — | — | — |
-| **Status management** | Automatic via hooks | Manual (SKILL.md) | Manual (SKILL.md) | Manual (SKILL.md) | Manual (SKILL.md) |
+| **Status hooks (automatic)** | Yes (4 hooks) | — | Yes (4 hooks) | — | — |
+| **Status management** | Automatic via hooks | Manual (SKILL.md) | Automatic via hooks with `user-questions`/legacy-session fallback | Manual (SKILL.md) | Manual (SKILL.md) |
 
-## Status Hooks (Claude Code only)
+## Status Hooks
 
-Injected into `.claude/settings.local.json` per-worktree at task launch.
+Injected per-worktree at task launch.
+
+### Claude Code
+
+Injected into `.claude/settings.local.json`.
 
 | Hook event | Status transition | Purpose |
 |------------|------------------|---------|
 | `UserPromptSubmit` | → `in-progress` | User sent a message, agent starts working |
 | `PreToolUse` | → `in-progress` | Agent is about to call a tool (also catches post-permission resume) |
 | `PermissionRequest` | → `user-questions` | Agent needs user approval for a tool call |
+| `Stop` | → `review-by-user` | Agent finished its turn |
+
+### Codex
+
+Injected into `.codex/hooks.json` and enabled via `~/.codex/config.toml` (`[features] codex_hooks = true`).
+
+| Hook event | Status transition | Purpose |
+|------------|------------------|---------|
+| `SessionStart` | → `in-progress` | Marks startup/resume turns as active |
+| `UserPromptSubmit` | → `in-progress` | User sent a message, agent starts working |
+| `PreToolUse` (`Bash`) | → `in-progress` | Agent is about to run a shell command |
 | `Stop` | → `review-by-user` | Agent finished its turn |
 
 ## Skill Differences
@@ -48,6 +63,7 @@ Injected into `.claude/settings.local.json` per-worktree at task launch.
 The dev3 skill (`SKILL.md`) is installed into each agent's skill directory. Two variants exist:
 
 - **Claude variant** — simplified status section (hooks handle transitions automatically), uses `!` command injection for zero-tool-call startup
+- **Codex variant** — hook-aware status section with manual fallback for older sessions, keeps the `/bin/bash` shell note
 - **Generic variant** — full manual status management instructions ("CRITICAL — NON-NEGOTIABLE"), requires agents to run `dev3 task move` at start/end of every turn
 
 ### dev3-project-config (project configuration)
@@ -60,4 +76,5 @@ A supplementary skill that teaches agents about `.dev3/config.json` and `.dev3/c
 |-------------|--------|---------|
 | `~/.agents/AGENTS.md` | All (fallback) | Appended rule block for agents that read `AGENTS.md` |
 | `~/.claude/settings.json` | Claude Code | Auto-adds `Bash(~/.dev3.0/bin/dev3 *)` permission |
-| `~/.codex/config.toml` | Codex | Configures `allowed_dirs` for worktrees and socket paths |
+| `~/.codex/config.toml` | Codex | Configures trust, sandbox access, and enables `codex_hooks` |
+| `<worktree>/.codex/hooks.json` | Codex | Auto-installs SessionStart/UserPromptSubmit/PreToolUse(Bash)/Stop lifecycle hooks |

--- a/change-logs/2026/03/27/feature-codex-worktree-hooks.md
+++ b/change-logs/2026/03/27/feature-codex-worktree-hooks.md
@@ -1,0 +1,1 @@
+Codex tasks now install worktree-local dev3 hooks and enable the `codex_hooks` feature automatically, so `in-progress` and review transitions work like Claude without relying only on manual skill instructions. Codex also gets a hook-aware dev3 skill plus a launch-time fallback reminder for `user-questions` and older sessions.

--- a/decisions/023-codex-hooks-lifecycle.md
+++ b/decisions/023-codex-hooks-lifecycle.md
@@ -1,0 +1,22 @@
+# 023 — Codex Uses Worktree-Local Hooks for dev3 Task Lifecycle
+
+## Context
+
+Codex already had dev3-specific sandbox and permission profile setup, but task status transitions still depended on the generic SKILL instructions. That was weaker than the Claude path and made automatic AI review unreliable for Codex tasks.
+
+## Investigation
+
+Codex hooks can run from repo-local `.codex/hooks.json`, but only when `[features] codex_hooks = true` is enabled in `~/.codex/config.toml`. Codex does not expose a `PermissionRequest` hook, so exact Claude parity is impossible for the "waiting for approval" transition.
+
+## Decision
+
+dev3 now writes worktree-local Codex hooks from [src/shared/agent-hooks.ts](src/shared/agent-hooks.ts) and installs them during task launch via [src/bun/agent-hooks.ts](src/bun/agent-hooks.ts). The lifecycle uses `SessionStart`, `UserPromptSubmit`, `PreToolUse` (matcher `Bash`), and `Stop`; `user-questions` stays an explicit fallback instruction in [src/bun/agent-skills.ts](src/bun/agent-skills.ts) and the Codex launch prompt in [src/bun/agents.ts](src/bun/agents.ts).
+
+## Risks
+
+Codex reads `config.toml` at startup, so existing sessions will not see new hooks until restart. The `Stop` dual-hook review path still depends on concurrent matching hook execution, although Codex documents that behavior today.
+
+## Alternatives considered
+
+- Keep Codex on manual status management only: rejected because it leaves Codex behind Claude and keeps auto-review inconsistent.
+- Emulate `PermissionRequest` with a heuristic script: rejected for now because parsing assistant text to infer blocked approvals would be brittle and hard to trust.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildClaudeHooks, mergeClaudeHooks, writeClaudeHooks } from "../agent-hooks";
+import {
+	buildClaudeHooks,
+	buildCodexHooks,
+	mergeClaudeHooks,
+	mergeCodexHooks,
+	writeClaudeHooks,
+	writeCodexHooks,
+} from "../agent-hooks";
 import type { MatcherGroup } from "../../shared/agent-hooks";
 import { DEV3_BASH_PERMISSION } from "../../shared/agent-hooks";
 
@@ -223,6 +230,104 @@ describe("mergeClaudeHooks", () => {
 	});
 });
 
+describe("buildCodexHooks", () => {
+	it("returns SessionStart, UserPromptSubmit, PreToolUse, and Stop matcher groups", () => {
+		const hooks = buildCodexHooks();
+
+		expect(hooks).toHaveProperty("SessionStart");
+		expect(hooks).toHaveProperty("UserPromptSubmit");
+		expect(hooks).toHaveProperty("PreToolUse");
+		expect(hooks).toHaveProperty("Stop");
+		expect(hooks).not.toHaveProperty("PermissionRequest");
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
+	it("SessionStart hook uses startup|resume matcher and moves to in-progress", () => {
+		const hooks = buildCodexHooks();
+		const group = hooks.SessionStart[0];
+		const cmd = group.hooks[0].command;
+
+		expect(group.matcher).toBe("startup|resume");
+		expect(cmd).toContain(DEV3_CLI);
+		expect(cmd).toContain("--status in-progress");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+	});
+
+	it("PreToolUse hook is scoped to Bash and moves to in-progress", () => {
+		const hooks = buildCodexHooks();
+		const group = hooks.PreToolUse[0];
+		const cmd = group.hooks[0].command;
+
+		expect(group.matcher).toBe("Bash");
+		expect(cmd).toContain(DEV3_CLI);
+		expect(cmd).toContain("--status in-progress");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+	});
+
+	it("Stop hook with review-by-ai stopTarget creates two matcher groups", () => {
+		const hooks = buildCodexHooks({ stopTarget: "review-by-ai" });
+
+		expect(hooks.Stop).toHaveLength(2);
+		expect(hooks.Stop[0].hooks[0].command).toContain("--status review-by-ai --if-status in-progress");
+		expect(hooks.Stop[1].hooks[0].command).toContain("--status review-by-user --if-status review-by-ai");
+	});
+});
+
+describe("mergeCodexHooks", () => {
+	it("adds hooks to empty settings", () => {
+		const result = mergeCodexHooks({});
+
+		expect(result.hooks).toBeDefined();
+		const hooks = result.hooks as Record<string, MatcherGroup[]>;
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
+	it("preserves existing hooks on unrelated events", () => {
+		const existing = {
+			hooks: {
+				PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo post" }] }],
+			},
+		};
+		const result = mergeCodexHooks(existing);
+		const hooks = result.hooks as Record<string, MatcherGroup[]>;
+
+		expect(hooks.PostToolUse).toHaveLength(1);
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
+	it("preserves non-dev3 matcher groups on the same events", () => {
+		const existing = {
+			hooks: {
+				PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo audit" }] }],
+				Stop: [{ hooks: [{ type: "command", command: "echo done" }] }],
+			},
+		};
+		const result = mergeCodexHooks(existing);
+		const hooks = result.hooks as Record<string, MatcherGroup[]>;
+
+		expect(hooks.PreToolUse).toHaveLength(2);
+		expect(hooks.Stop).toHaveLength(2);
+	});
+
+	it("is idempotent", () => {
+		const first = mergeCodexHooks({}, { stopTarget: "review-by-ai" });
+		const second = mergeCodexHooks(first as Record<string, unknown>, { stopTarget: "review-by-ai" });
+		const hooks = second.hooks as Record<string, MatcherGroup[]>;
+
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(2);
+	});
+});
+
 describe("writeClaudeHooks", () => {
 	let tmp: string;
 
@@ -367,6 +472,78 @@ describe("writeClaudeHooks", () => {
 
 		writeClaudeHooks(tmp);
 		const second = readFileSync(settingsPath, "utf-8");
+
+		expect(first).toBe(second);
+	});
+});
+
+describe("writeCodexHooks", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "agent-hooks-codex-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it("creates .codex dir and hooks file from scratch", () => {
+		writeCodexHooks(tmp);
+
+		const hooksPath = join(tmp, ".codex", "hooks.json");
+		const content = JSON.parse(readFileSync(hooksPath, "utf-8"));
+		const hooks = content.hooks as Record<string, MatcherGroup[]>;
+
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
+	it("writes hooks with stopTarget review-by-ai", () => {
+		writeCodexHooks(tmp, { stopTarget: "review-by-ai" });
+
+		const hooksPath = join(tmp, ".codex", "hooks.json");
+		const content = JSON.parse(readFileSync(hooksPath, "utf-8"));
+		const hooks = content.hooks as Record<string, MatcherGroup[]>;
+
+		expect(hooks.Stop).toHaveLength(2);
+		expect(hooks.Stop[0].hooks[0].command).toContain("--status review-by-ai --if-status in-progress");
+		expect(hooks.Stop[1].hooks[0].command).toContain("--status review-by-user --if-status review-by-ai");
+	});
+
+	it("preserves existing non-hook settings when merging", () => {
+		const codexDir = join(tmp, ".codex");
+		mkdirSync(codexDir, { recursive: true });
+		writeFileSync(join(codexDir, "hooks.json"), JSON.stringify({ version: 1 }));
+
+		writeCodexHooks(tmp);
+
+		const content = JSON.parse(readFileSync(join(codexDir, "hooks.json"), "utf-8"));
+		expect(content.version).toBe(1);
+		expect(content.hooks).toBeDefined();
+	});
+
+	it("overwrites corrupted JSON gracefully", () => {
+		const codexDir = join(tmp, ".codex");
+		mkdirSync(codexDir, { recursive: true });
+		writeFileSync(join(codexDir, "hooks.json"), "NOT VALID JSON{{{");
+
+		writeCodexHooks(tmp);
+
+		const content = JSON.parse(readFileSync(join(codexDir, "hooks.json"), "utf-8"));
+		const hooks = content.hooks as Record<string, MatcherGroup[]>;
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
+	it("produces identical output on repeated writes", () => {
+		writeCodexHooks(tmp, { stopTarget: "review-by-ai" });
+		const hooksPath = join(tmp, ".codex", "hooks.json");
+		const first = readFileSync(hooksPath, "utf-8");
+
+		writeCodexHooks(tmp, { stopTarget: "review-by-ai" });
+		const second = readFileSync(hooksPath, "utf-8");
 
 		expect(first).toBe(second);
 	});

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -149,6 +149,18 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("Some task");
 	});
 
+	it("Codex: injects the dev3 reminder into new-session prompts", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("Fresh Codex sessions use hooks");
+		expect(cmd).toContain("shell=\"/bin/bash\"");
+		expect(cmd).toContain("user-questions");
+	});
+
 	// ---- Gemini ----
 	it("Gemini: adds --resume latest when resume=true", () => {
 		const cmd = resolveAgentCommand(

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -24,6 +24,8 @@ describe("ensureCodexConfig", () => {
 			// Config profile
 			expect(result).toContain("[profiles.dev3]");
 			expect(result).toContain('web_search = "live"');
+			expect(result).toContain("[features]");
+			expect(result).toContain("codex_hooks = true");
 		});
 
 		it("does NOT set default_permissions", () => {
@@ -70,6 +72,9 @@ allow_unix_sockets = ["${SOCKETS_PATH}"]
 
 [profiles.dev3]
 web_search = "live"
+
+[features]
+codex_hooks = true
 `;
 			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
 			const projectMatches = result.match(/\[projects\."[^"]*worktrees"\]/g);
@@ -78,6 +83,31 @@ web_search = "live"
 			expect(netMatches).toHaveLength(1);
 			const profileMatches = result.match(/\[profiles\.dev3\]/g);
 			expect(profileMatches).toHaveLength(1);
+			const featuresMatches = result.match(/\[features\]/g);
+			expect(featuresMatches).toHaveLength(1);
+		});
+	});
+
+	describe("when features section exists", () => {
+		it("adds codex_hooks without removing other feature flags", () => {
+			const existing = `[features]
+experimental_resume = true
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+
+			expect(result).toContain("[features]");
+			expect(result).toContain("experimental_resume = true");
+			expect(result).toContain("codex_hooks = true");
+		});
+
+		it("updates codex_hooks to true when it was false", () => {
+			const existing = `[features]
+codex_hooks = false
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+
+			expect(result).toContain("codex_hooks = true");
+			expect(result).not.toContain("codex_hooks = false");
 		});
 	});
 

--- a/src/bun/agent-hooks.ts
+++ b/src/bun/agent-hooks.ts
@@ -10,10 +10,17 @@
 
 import type { TaskStatus } from "../shared/types";
 import { createLogger } from "./logger";
-import { isClaudeCommand } from "./agents";
-import { writeClaudeHooks } from "../shared/agent-hooks";
+import { isClaudeCommand, isCodexCommand } from "./agents";
+import { writeClaudeHooks, writeCodexHooks } from "../shared/agent-hooks";
 
-export { buildClaudeHooks, mergeClaudeHooks, writeClaudeHooks } from "../shared/agent-hooks";
+export {
+	buildClaudeHooks,
+	buildCodexHooks,
+	mergeClaudeHooks,
+	mergeCodexHooks,
+	writeClaudeHooks,
+	writeCodexHooks,
+} from "../shared/agent-hooks";
 
 const log = createLogger("agent-hooks");
 
@@ -29,6 +36,13 @@ export function setupAgentHooks(
 	if (isClaudeCommand(baseCommand)) {
 		writeClaudeHooks(worktreePath, options);
 		log.info("Claude hooks installed", {
+			worktreePath,
+		});
+		return;
+	}
+	if (isCodexCommand(baseCommand)) {
+		writeCodexHooks(worktreePath, options);
+		log.info("Codex hooks installed", {
 			worktreePath,
 		});
 		return;

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -74,7 +74,7 @@ const SKILL_PROJECT_CONFIG_REDIRECT = `
 For ANY question about project configuration — setting up scripts (setup, dev, cleanup), clone paths, base branch, sparse checkout, or anything related to \`.dev3/config.json\` / \`.dev3/config.local.json\` — you MUST invoke the \`/dev3-project-config\` skill. Do NOT attempt to configure the project without it. The dedicated skill knows the full schema, auto-detection logic, and correct workflow.
 `;
 
-// Full manual status management — for agents without hooks (Cursor, Codex, Gemini, etc.)
+// Full manual status management — for agents without hooks (Cursor, Gemini, etc.)
 const SKILL_STATUS_MANUAL = `
 ## Task status management (CRITICAL — NON-NEGOTIABLE)
 
@@ -99,6 +99,14 @@ Hooks automatically manage task status transitions (\`in-progress\`, \`user-ques
 Do NOT call \`dev3 task move\` for status changes — hooks handle it. On projects with Automatic AI Review enabled, completed work passes through \`review-by-ai\` before \`review-by-user\`. You can still use \`dev3 task move\` for custom columns.
 ${SKILL_CUSTOM_COLUMNS}`;
 
+// Codex also uses hooks, but the session must be restarted after config changes.
+const SKILL_STATUS_CODEX_HOOKS = `
+## Task status management
+
+Hooks automatically manage task status transitions (\`in-progress\`, \`review-by-ai\`, \`review-by-user\`) for Codex sessions started after the dev3 config was installed.
+Do NOT call \`dev3 task move\` for normal active/review transitions when hooks are active. If you need user input or clarification, move the task to \`user-questions\` before your final response. If you are in an older Codex session where hooks clearly are not firing yet, fall back to manual status management: move to \`in-progress\` when you start, \`user-questions\` when blocked, and \`review-by-user\` when finished.
+${SKILL_CUSTOM_COLUMNS}`;
+
 const SKILL_CODEX_SHELL = `
 ## Codex shell note
 
@@ -107,6 +115,7 @@ For \`exec_command\` calls, always set \`shell="/bin/bash"\` and \`login=false\`
 
 // Composed bodies for each agent type
 const CLAUDE_SKILL_BODY = SKILL_HEADER + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_HOOKS + SKILL_NOTES + SKILL_PROJECT_CONFIG_REDIRECT;
+const CODEX_SKILL_BODY = SKILL_HEADER + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_CODEX_HOOKS + SKILL_NOTES + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_CODEX_SHELL;
 const GENERIC_SKILL_BODY = SKILL_HEADER + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_MANUAL + SKILL_NOTES + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_CODEX_SHELL;
 
 const SKILL_DESCRIPTION = "MANDATORY — invoke BEFORE doing anything else. Trigger: your working directory (PWD) is inside ~/.dev3.0/worktrees/ (i.e. $HOME/.dev3.0/worktrees/). Regular git worktrees or other worktree paths do NOT qualify — only the dev-3.0 managed path. Step 1: invoke this skill (for Codex exec_command calls, always set shell=\\\"/bin/bash\\\" and login=false). Step 2: handle the user's request. NEVER skip step 1, even if the user gives a direct command.";
@@ -137,7 +146,24 @@ ${CLAUDE_SKILL_BODY}
 \\\`\\\`\\\`
 `;
 
-// ---- Generic skill for other agents (Cursor, Codex, Gemini, etc.) ----
+// ---- Codex and generic skills (no command injection support) ----
+
+const CODEX_SKILL_CONTENT = `---
+name: dev3
+description: "${SKILL_DESCRIPTION}"
+user-invocable: true
+---
+
+${CODEX_SKILL_BODY}
+## On session start
+
+Run these two commands to learn about available CLI commands and your current task:
+
+- \`~/.dev3.0/bin/dev3 --help\` — learn all available CLI commands
+- \`~/.dev3.0/bin/dev3 current\` — see your current project, task, and status
+
+Then begin working. If hooks are not active in this Codex session yet, set \`in-progress\` manually and continue.
+`;
 
 const GENERIC_SKILL_CONTENT = `---
 name: dev3
@@ -159,11 +185,13 @@ Then set \`in-progress\` and begin working.
 /** Claude Code skill directory (supports !`command` injection). */
 const CLAUDE_SKILL_DIR = ".claude/skills/dev3";
 
+/** Codex skill directory (hook-aware, but no command injection support). */
+const CODEX_SKILL_DIR = ".codex/skills/dev3";
+
 /** Generic agent skill directories (no command injection support). */
 const GENERIC_SKILL_DIRS = [
 	".cursor/skills/dev3",
 	".agents/skills/dev3",
-	".codex/skills/dev3",
 	".gemini/skills/dev3",
 	".opencode/skills/dev3",
 	".config/opencode/skills/dev3",
@@ -435,6 +463,20 @@ export function installAgentSkills(): void {
 	} catch (err) {
 		log.warn("Failed to install Claude skill (non-fatal)", {
 			path: claudeSkillFile,
+			error: String(err),
+		});
+	}
+
+	// Install Codex-specific skill (hook-aware + shell note)
+	const codexSkillDir = `${home}/${CODEX_SKILL_DIR}`;
+	const codexSkillFile = `${codexSkillDir}/SKILL.md`;
+	try {
+		mkdirSync(codexSkillDir, { recursive: true });
+		writeFileSync(codexSkillFile, CODEX_SKILL_CONTENT, "utf-8");
+		log.info("Codex skill installed", { path: codexSkillFile });
+	} catch (err) {
+		log.warn("Failed to install Codex skill (non-fatal)", {
+			path: codexSkillFile,
 			error: String(err),
 		});
 	}

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -208,6 +208,19 @@ export const DEV3_SYSTEM_PROMPT_GENERIC =
 	"when you start working, `dev3 task move --status user-questions` when you need " +
 	"user input, and `dev3 task move --status review-by-user` when you finish.";
 
+/**
+ * Codex uses automatic hooks for active/review transitions, but still needs
+ * explicit fallback instructions because skill loading is not guaranteed and
+ * Codex has no PermissionRequest hook for user-questions.
+ */
+export const DEV3_SYSTEM_PROMPT_CODEX =
+	"MANDATORY: You are inside a dev-3.0 managed worktree. " +
+	"Invoke the /dev3 skill BEFORE doing any other work. Do NOT skip this step. " +
+	"Fresh Codex sessions use hooks for `in-progress` and review transitions. " +
+	"If you need user input, move the task to `user-questions` before your final response. " +
+	"If hooks appear inactive in this session, manage statuses manually with `dev3 task move`. " +
+	"For exec_command calls, always set `shell=\"/bin/bash\"` and `login=false`.";
+
 /** Returns true when the resolved base command is the Claude CLI. */
 export function isClaudeCommand(baseCmd: string): boolean {
 	const name = baseCmd.split("/").pop() ?? "";
@@ -340,7 +353,10 @@ export function resolveAgentCommand(
 
 		// Cursor Agent / OpenCode have no --append-system-prompt and no automatic
 		// hooks, so inject the generic system prompt via the prompt argument.
-		if (cursorAgent || openCodeAgent) {
+		// Codex also gets a prompt reminder because skill loading is not guaranteed.
+		if (codexAgent) {
+			prompt = prompt ? `${prompt}\n\n${DEV3_SYSTEM_PROMPT_CODEX}` : DEV3_SYSTEM_PROMPT_CODEX;
+		} else if (cursorAgent || openCodeAgent) {
 			prompt = prompt ? `${prompt}\n\n${DEV3_SYSTEM_PROMPT_GENERIC}` : DEV3_SYSTEM_PROMPT_GENERIC;
 		}
 

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -21,6 +21,7 @@ interface CodexPermissionsProfile {
 
 interface CodexConfig {
 	default_permissions?: string;
+	features?: Record<string, unknown>;
 	projects?: Record<string, { trust_level?: string; sandbox_mode?: string }>;
 	profiles?: Record<string, Record<string, unknown>>;
 	permissions?: Record<string, CodexPermissionsProfile | undefined>;
@@ -157,6 +158,17 @@ export function ensureCodexConfig(
 		config = appendBlock(config, block);
 	}
 
+	// --- 4. Ensure [features] codex_hooks = true ---
+	const codexHooksEnabled = parsed.features?.codex_hooks === true;
+	if (!codexHooksEnabled) {
+		const featuresHeader = "[features]";
+		if (!config.includes(featuresHeader)) {
+			config = appendBlock(config, `\n${featuresHeader}\ncodex_hooks = true\n`);
+		} else {
+			config = upsertSectionLine(config, featuresHeader, "codex_hooks", "true");
+		}
+	}
+
 	return config;
 }
 
@@ -247,6 +259,29 @@ function insertAfterSectionHeader(
 		"\n" +
 		config.slice(nextNewline + 1)
 	);
+}
+
+function upsertSectionLine(
+	config: string,
+	sectionHeader: string,
+	key: string,
+	value: string,
+): string {
+	const escapedHeader = sectionHeader.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const sectionPattern = new RegExp(`(${escapedHeader}\\n)([\\s\\S]*?)(?=\\n\\[|$)`);
+	const existingKeyPattern = new RegExp(`^${escapedKey}\\s*=\\s*.*$`, "m");
+
+	if (!sectionPattern.test(config)) {
+		return appendBlock(config, `\n${sectionHeader}\n${key} = ${value}\n`);
+	}
+
+	return config.replace(sectionPattern, (_match, header, body) => {
+		if (existingKeyPattern.test(body)) {
+			return `${header}${body.replace(existingKeyPattern, `${key} = ${value}`)}`;
+		}
+		return `${header}${key} = ${value}\n${body}`;
+	});
 }
 
 /**

--- a/src/cli/commands/install-hooks.ts
+++ b/src/cli/commands/install-hooks.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from "node:path";
 import { exitError } from "../output";
-import { writeClaudeHooks } from "../../shared/agent-hooks";
+import { writeClaudeHooks, writeCodexHooks } from "../../shared/agent-hooks";
 
 const WORKTREES_DIR = `${process.env.HOME || "/tmp"}/.dev3.0/worktrees`;
 
@@ -31,13 +31,20 @@ export async function handleInstallHooks(): Promise<void> {
 		exitError("Cannot detect worktree path", "Run this command from inside a dev-3.0 worktree.");
 	}
 
-	const settingsPath = join(worktreePath, ".claude", "settings.local.json");
+	const claudeSettingsPath = join(worktreePath, ".claude", "settings.local.json");
+	const codexHooksPath = join(worktreePath, ".codex", "hooks.json");
 
 	writeClaudeHooks(worktreePath);
+	writeCodexHooks(worktreePath);
 
-	process.stdout.write(`Installed Claude Code hooks → ${settingsPath}\n`);
+	process.stdout.write(`Installed Claude Code hooks → ${claudeSettingsPath}\n`);
 	process.stdout.write(`  UserPromptSubmit → in-progress\n`);
 	process.stdout.write(`  PreToolUse → in-progress\n`);
 	process.stdout.write(`  PermissionRequest → user-questions\n`);
+	process.stdout.write(`  Stop → review-by-user\n`);
+	process.stdout.write(`Installed Codex hooks → ${codexHooksPath}\n`);
+	process.stdout.write(`  SessionStart → in-progress\n`);
+	process.stdout.write(`  UserPromptSubmit → in-progress\n`);
+	process.stdout.write(`  PreToolUse(Bash) → in-progress\n`);
 	process.stdout.write(`  Stop → review-by-user\n`);
 }

--- a/src/cli/commands/install-skills.ts
+++ b/src/cli/commands/install-skills.ts
@@ -21,5 +21,5 @@ export async function handleInstallSkills(): Promise<void> {
 	}
 	process.stdout.write(`  ~/.agents/AGENTS.md (dev3 block)\n`);
 	process.stdout.write(`  ~/.claude/settings.json (Bash permission)\n`);
-	process.stdout.write(`  ~/.codex/config.toml (trust + socket access)\n`);
+	process.stdout.write(`  ~/.codex/config.toml (trust + socket access + codex_hooks)\n`);
 }

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -11,6 +11,9 @@ export const DEV3_CLI = "~/.dev3.0/bin/dev3";
 export interface HookEntry {
 	type: string;
 	command: string;
+	timeout?: number;
+	timeoutSec?: number;
+	statusMessage?: string;
 }
 
 /**
@@ -24,12 +27,50 @@ export interface HookEntry {
  * - Stop: primary agent → stopTarget; review agent → review-by-user
  */
 export interface MatcherGroup {
+	matcher?: string;
 	hooks: HookEntry[];
+}
+
+type HookMap = Record<string, MatcherGroup[]>;
+
+function buildStopGroups(stopTarget: TaskStatus): MatcherGroup[] {
+	const move = (status: string, extra?: string) =>
+		`${DEV3_CLI} task move --status ${status}${extra ? ` ${extra}` : ""}`;
+
+	const stopGroups: MatcherGroup[] = [
+		{
+			hooks: [{ type: "command", command: move(stopTarget, "--if-status in-progress") }],
+		},
+	];
+
+	if (stopTarget !== "review-by-user") {
+		stopGroups.push({
+			hooks: [{ type: "command", command: move("review-by-user", "--if-status review-by-ai") }],
+		});
+	}
+
+	return stopGroups;
+}
+
+function mergeHookMaps(
+	existing: Record<string, unknown>,
+	newHooks: HookMap,
+): Record<string, unknown> {
+	const existingHooks = (existing.hooks ?? {}) as HookMap;
+	const merged: HookMap = { ...existingHooks };
+
+	for (const [event, groups] of Object.entries(newHooks)) {
+		const current = merged[event] ?? [];
+		const filtered = current.filter((g) => !isDev3Entry(g));
+		merged[event] = [...filtered, ...groups];
+	}
+
+	return { ...existing, hooks: merged };
 }
 
 export function buildClaudeHooks(
 	options?: { stopTarget?: TaskStatus },
-): Record<string, MatcherGroup[]> {
+): HookMap {
 	const stopTarget: TaskStatus = options?.stopTarget ?? "review-by-user";
 	const move = (status: string, extra?: string) =>
 		`${DEV3_CLI} task move --status ${status}${extra ? ` ${extra}` : ""}`;
@@ -39,22 +80,6 @@ export function buildClaudeHooks(
 	// review-by-user is intentionally allowed: when the user leaves feedback
 	// and the primary agent resumes, UserPromptSubmit should move the task back.
 	const workingCmd = move("in-progress", "--if-status-not review-by-ai");
-
-	// Primary Stop hook: only fires when task is in-progress (primary agent working).
-	// This prevents it from firing after the review agent has already moved the task.
-	const stopGroups: MatcherGroup[] = [
-		{
-			hooks: [{ type: "command", command: move(stopTarget, "--if-status in-progress") }],
-		},
-	];
-	// When AI review is enabled (stopTarget != review-by-user), add a second
-	// Stop hook for the review agent: move to review-by-user only if currently
-	// in review-by-ai.
-	if (stopTarget !== "review-by-user") {
-		stopGroups.push({
-			hooks: [{ type: "command", command: move("review-by-user", "--if-status review-by-ai") }],
-		});
-	}
 
 	return {
 		UserPromptSubmit: [
@@ -66,7 +91,42 @@ export function buildClaudeHooks(
 		PermissionRequest: [
 			{ hooks: [{ type: "command", command: move("user-questions") }] },
 		],
-		Stop: stopGroups,
+		Stop: buildStopGroups(stopTarget),
+	};
+}
+
+/**
+ * Build the Codex hooks object for a given task.
+ *
+ * Codex currently lacks a PermissionRequest event, so we mirror the Claude
+ * behavior as closely as possible with:
+ *
+ * - SessionStart/UserPromptSubmit/PreToolUse(Bash): → in-progress
+ * - Stop: primary agent → stopTarget; review agent → review-by-user
+ */
+export function buildCodexHooks(
+	options?: { stopTarget?: TaskStatus },
+): HookMap {
+	const stopTarget: TaskStatus = options?.stopTarget ?? "review-by-user";
+	const workingCmd = `${DEV3_CLI} task move --status in-progress --if-status-not review-by-ai`;
+
+	return {
+		SessionStart: [
+			{
+				matcher: "startup|resume",
+				hooks: [{ type: "command", command: workingCmd }],
+			},
+		],
+		UserPromptSubmit: [
+			{ hooks: [{ type: "command", command: workingCmd }] },
+		],
+		PreToolUse: [
+			{
+				matcher: "Bash",
+				hooks: [{ type: "command", command: workingCmd }],
+			},
+		],
+		Stop: buildStopGroups(stopTarget),
 	};
 }
 
@@ -94,18 +154,14 @@ export function mergeClaudeHooks(
 	existing: Record<string, unknown>,
 	options?: { stopTarget?: TaskStatus },
 ): Record<string, unknown> {
-	const newHooks = buildClaudeHooks(options);
-	const existingHooks = (existing.hooks ?? {}) as Record<string, MatcherGroup[]>;
-	const merged: Record<string, MatcherGroup[]> = { ...existingHooks };
+	return mergeHookMaps(existing, buildClaudeHooks(options));
+}
 
-	for (const [event, groups] of Object.entries(newHooks)) {
-		const current = merged[event] ?? [];
-		// Remove any previous dev3 matcher groups (idempotency)
-		const filtered = current.filter((g) => !isDev3Entry(g));
-		merged[event] = [...filtered, ...groups];
-	}
-
-	return { ...existing, hooks: merged };
+export function mergeCodexHooks(
+	existing: Record<string, unknown>,
+	options?: { stopTarget?: TaskStatus },
+): Record<string, unknown> {
+	return mergeHookMaps(existing, buildCodexHooks(options));
 }
 
 /**
@@ -181,4 +237,27 @@ export function writeClaudeHooks(worktreePath: string, options?: { stopTarget?: 
 			writeFileSync(permPath, JSON.stringify(updatedPerm, null, 2) + "\n", "utf-8");
 		}
 	}
+}
+
+/**
+ * Read .codex/hooks.json, merge dev3 hooks, and write it back.
+ * Creates the .codex/ directory if it doesn't exist.
+ */
+export function writeCodexHooks(worktreePath: string, options?: { stopTarget?: TaskStatus }): void {
+	const codexDir = join(worktreePath, ".codex");
+	mkdirSync(codexDir, { recursive: true });
+
+	const hooksPath = join(codexDir, "hooks.json");
+
+	let settings: Record<string, unknown> = {};
+	try {
+		if (existsSync(hooksPath)) {
+			settings = JSON.parse(readFileSync(hooksPath, "utf-8"));
+		}
+	} catch {
+		// Corrupted file — overwrite
+	}
+
+	const updated = mergeCodexHooks(settings, options);
+	writeFileSync(hooksPath, JSON.stringify(updated, null, 2) + "\n", "utf-8");
 }


### PR DESCRIPTION
## Summary
- add worktree-local Codex hooks for dev3 task lifecycle
- enable `codex_hooks` in Codex config and install a Codex-specific dev3 skill
- cover the new hook/config behavior with tests and update docs

## Testing
- bun run lint
- bun run test