### PR TITLE
Add Trivy GitHub scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,6 @@ jobs:
         run: bunx vite build && bun run build:cli
 
   trivy-scan:
-    needs: [lint, test, build-check]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/change-logs/2026/03/27/chore-add-trivy-github-scan.md
+++ b/change-logs/2026/03/27/chore-add-trivy-github-scan.md
@@ -1,1 +1,1 @@
-Add the same Trivy filesystem scan used in the neighboring repository to the pull request build workflow. The scan posts or updates a PR comment with a markdown summary table after lint, tests, and build checks pass.
+Add the same Trivy filesystem scan used in the neighboring repository to the pull request build workflow. The scan now runs in parallel with the other PR checks and posts or updates a PR comment with a markdown summary table.


### PR DESCRIPTION
## Summary
- add the same Trivy PR scan flow used in tech-voice-recognition-tool
- run the scan after lint, test, and build-check in the Build workflow
- post or update a PR comment with the Trivy report

## Testing
- bun run lint
- bun run test