### PR TITLE
chore: ignore only .codex/hooks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules/
 /dist/
 /artifacts/
 .claude/settings.local.json
-.codex/
+.codex/hooks.json
 src/shared/build-info.generated.ts
 src/bun/changelog-bundled.ts
 changelog.json

--- a/change-logs/2026/03/27/chore-ignore-codex-local-state.md
+++ b/change-logs/2026/03/27/chore-ignore-codex-local-state.md
@@ -1,1 +1,1 @@
-Ignore local `.codex/` state so Codex hook config created during agent sessions does not show up as untracked worktree noise.
+Ignore only `.codex/hooks.json` so the Codex hook config created during agent sessions does not show up as untracked worktree noise without hiding other future `.codex` files.


### PR DESCRIPTION
## Summary
- ignore only `.codex/hooks.json` instead of the whole `.codex/` directory
- keep Codex hook state out of `git status` without hiding future repo-managed `.codex` files
- update the existing changelog entry to match the narrower ignore rule

## Testing
- bun run lint
- bun run test