### PR TITLE
Fix dev3 current custom titles

### DIFF
--- a/change-logs/2026/03/28/fix-current-custom-title.md
+++ b/change-logs/2026/03/28/fix-current-custom-title.md
@@ -1,0 +1,1 @@
+Fixed `dev3 current` so it shows the effective task title, including `customTitle` overrides set by `dev3 task update --title`. Added CLI tests covering both live-socket and offline output paths to prevent regressions.

--- a/src/cli/__tests__/current.test.ts
+++ b/src/cli/__tests__/current.test.ts
@@ -8,8 +8,15 @@ vi.mock("../socket-client", () => ({
 
 vi.mock("../context", () => ({
 	detectContext: vi.fn(),
+	detectContextDiagnostics: vi.fn(() => "mock diagnostics"),
 	readProjectDirect: vi.fn(),
 	readTaskDirect: vi.fn(),
+}));
+
+vi.mock("../../shared/build-info.generated", () => ({
+	BUILD_TIME: "Sat, 28 Mar 2026 · 00:00:00",
+	BUILD_COMMIT: "deadbeef",
+	BUILD_VERSION: "test",
 }));
 
 import { handleCurrent } from "../commands/current";
@@ -109,6 +116,24 @@ describe("handleCurrent", () => {
 			expect(stdoutOutput).toContain("dev3/task-aaaaaaaa");
 		});
 
+		it("shows custom title from live task data when present", async () => {
+			mockDetect.mockReturnValue({
+				projectId: "proj-001",
+				taskId: FAKE_TASK.id,
+				socketPath: SOCKET,
+			});
+			mockSend.mockResolvedValue(okResp({
+				...FAKE_TASK,
+				customTitle: "Test 1",
+			}));
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+
+			await handleCurrent(SOCKET);
+
+			expect(stdoutOutput).toContain("Test 1");
+			expect(stdoutOutput).not.toContain("Implement auth");
+		});
+
 		it("shows description when different from title", async () => {
 			mockDetect.mockReturnValue({
 				projectId: "proj-001",
@@ -203,6 +228,24 @@ describe("handleCurrent", () => {
 			expect(stdoutOutput).toContain("(offline)");
 			// Should NOT call sendRequest
 			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it("shows custom title from offline task data when present", async () => {
+			mockDetect.mockReturnValue({
+				projectId: "proj-001",
+				taskId: FAKE_TASK.id,
+				socketPath: "",
+			});
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+			mockReadTask.mockReturnValue({
+				...FAKE_TASK,
+				customTitle: "Test 1",
+			});
+
+			await handleCurrent(null);
+
+			expect(stdoutOutput).toContain("Test 1");
+			expect(stdoutOutput).not.toContain("Implement auth");
 		});
 
 		it("shows minimal info when task data not available offline", async () => {

--- a/src/cli/commands/current.ts
+++ b/src/cli/commands/current.ts
@@ -1,5 +1,5 @@
 import type { Project, Task } from "../../shared/types";
-import { STATUS_LABELS } from "../../shared/types";
+import { STATUS_LABELS, getTaskTitle } from "../../shared/types";
 import { detectContext, detectContextDiagnostics, readProjectDirect, readTaskDirect } from "../context";
 import { sendRequest } from "../socket-client";
 import { printDetail, exitError } from "../output";
@@ -31,6 +31,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 			if (resp.ok) {
 				const task = resp.data as Task;
 				const project = readProjectDirect(context.projectId);
+				const displayTitle = getTaskTitle(task);
 
 				const statusDisplay = task.customColumnId
 					? `${STATUS_LABELS[task.status] || task.status} (in custom column)`
@@ -41,21 +42,21 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 					["Project ID:", context.projectId],
 					["Task ID:", task.id],
 					["Seq:", String(task.seq)],
-					["Title:", task.title],
+					["Title:", displayTitle],
 					["Status:", statusDisplay],
 				];
 				if (task.customColumnId) fields.push(["Custom Column:", task.customColumnId.slice(0, 8)]);
 				if (task.branchName) fields.push(["Branch:", task.branchName]);
 				if (task.worktreePath) fields.push(["Worktree:", task.worktreePath]);
 
-				if (task.description && task.description !== task.title) {
+				if (task.description && task.description !== displayTitle) {
 					fields.push(["", ""]);
 					fields.push(["Description:", ""]);
 				}
 
 				printDetail(fields);
 
-				if (task.description && task.description !== task.title) {
+				if (task.description && task.description !== displayTitle) {
 					for (const line of task.description.split("\n")) {
 						process.stdout.write(`  ${line}\n`);
 					}
@@ -94,14 +95,17 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 	];
 
 	if (task) {
+		const displayTask = task as Pick<Task, "title" | "customTitle">;
+		const displayTitle = getTaskTitle(displayTask as Task);
+
 		if (task.seq !== undefined) fields.push(["Seq:", String(task.seq)]);
-		if (task.title) fields.push(["Title:", task.title as string]);
+		if (displayTitle) fields.push(["Title:", displayTitle]);
 		if (task.status) fields.push(["Status:", STATUS_LABELS[task.status as keyof typeof STATUS_LABELS] || (task.status as string)]);
 		if (task.branchName) fields.push(["Branch:", task.branchName as string]);
 		if (task.worktreePath) fields.push(["Worktree:", task.worktreePath as string]);
 
 		const desc = task.description as string | undefined;
-		if (desc && desc !== (task.title as string)) {
+		if (desc && desc !== displayTitle) {
 			fields.push(["", ""]);
 			fields.push(["Description:", ""]);
 		}
@@ -111,7 +115,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 
 		printDetail(fields);
 
-		if (desc && desc !== (task.title as string)) {
+		if (desc && desc !== displayTitle) {
 			for (const line of desc.split("\n")) {
 				process.stdout.write(`  ${line}\n`);
 			}


### PR DESCRIPTION
## Summary
- reproduce the stale title bug in `dev3 current` with CLI tests for live and offline paths
- use the effective task title in `current` output so `customTitle` overrides are shown consistently
- add a changelog entry for the CLI fix

## Testing
- bunx vitest run -c vitest.config.cli.ts src/cli/__tests__/current.test.ts
- bun run test:cli
- bun run lint
- bun run test