### PR TITLE
docs: clean up AGENTS command guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,13 +135,7 @@ Non-obvious architectural decisions, hacks, and workarounds are documented in `d
 ## Commands
 
 ```bash
-# Main development workflow with HMR (Vite dev server + main watcher)
-bun run watch
-
-# Vite HMR server only
-bun run hmr
-
-# Development without HMR (build, package, then launch locally)
+# Main local development flow (build, package, then launch locally)
 bun run dev
 
 # Alternative local launch path (reuses existing Vite output)

--- a/change-logs/2026/03/28/docs-agents-command-workflows.md
+++ b/change-logs/2026/03/28/docs-agents-command-workflows.md
@@ -1,1 +1,1 @@
-Updated AGENTS.md to match the current package scripts, removed the stale dev:once reference, and replaced the incorrect no-linter note with the real lint workflow.
+Updated AGENTS.md to match the current package scripts, removed the stale dev:once and HMR guidance, and replaced the incorrect no-linter note with the real lint workflow.


### PR DESCRIPTION
## Summary
- align AGENTS.md command docs with the current package scripts
- remove stale dev:once and HMR guidance from the documented workflow
- replace the incorrect no-linter note with the real lint validation step

## Testing
- bun run lint
- bun run test