### PR TITLE
fix: stop empty Trivy PR comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,52 +138,13 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let body = '## 🔍 Trivy Vulnerability Scan\n\n';
+            const { buildTrivyCommentBody } = require('./src/bun/trivy-pr-comment.js');
+            let body = null;
             if (fs.existsSync('trivy-results.txt')) {
-              const results = fs.readFileSync('trivy-results.txt', 'utf8').trim();
-              if (results.length === 0) {
-                body += '✅ No vulnerabilities found.\n';
-              } else {
-                const lines = results
-                  .split('\n')
-                  .map((line) => line.trim())
-                  .filter(Boolean);
-                const tableLines = lines.filter((line) => line.startsWith('│'));
-                const legendIndex = lines.findIndex((line) => line === 'Legend:');
-
-                if (tableLines.length >= 2) {
-                  const parseRow = (line) =>
-                    line
-                      .split('│')
-                      .slice(1, -1)
-                      .map((cell) => cell.trim());
-
-                  const header = parseRow(tableLines[0]);
-                  const rows = tableLines.slice(1).map(parseRow);
-
-                  body += '### Report Summary\n\n';
-                  body += `| ${header.join(' | ')} |\n`;
-                  body += `| ${header.map(() => '---').join(' | ')} |\n`;
-                  body += rows.map((row) => `| ${row.join(' | ')} |`).join('\n');
-                  body += '\n';
-
-                  if (legendIndex !== -1) {
-                    const legendLines = lines
-                      .slice(legendIndex + 1)
-                      .filter((line) => line.startsWith('-'));
-                    if (legendLines.length > 0) {
-                      body += '\n';
-                      body += legendLines.join('\n');
-                      body += '\n';
-                    }
-                  }
-                } else {
-                  body += '### Raw Output\n\n';
-                  body += '```\n' + results + '\n```\n';
-                }
-              }
+              const results = fs.readFileSync('trivy-results.txt', 'utf8');
+              body = buildTrivyCommentBody(results);
             } else {
-              body += '⚠️ Trivy results file not found.\n';
+              body = '## 🔍 Trivy Vulnerability Scan\n\n⚠️ Trivy results file not found.\n';
             }
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -194,6 +155,16 @@ jobs:
             const trivyComment = comments.find((comment) =>
               comment.body.includes('Trivy Vulnerability Scan'),
             );
+            if (!body) {
+              if (trivyComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: trivyComment.id,
+                });
+              }
+              return;
+            }
             if (trivyComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/change-logs/2026/03/28/fix-trivy-empty-pr-comment.md
+++ b/change-logs/2026/03/28/fix-trivy-empty-pr-comment.md
@@ -1,0 +1,1 @@
+Stop posting or updating the Trivy PR comment when the scan report is clean. The workflow now deletes any stale Trivy comment after a clean scan, so PRs stop generating useless notification spam.

--- a/src/bun/__tests__/trivy-pr-comment.test.ts
+++ b/src/bun/__tests__/trivy-pr-comment.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+const {
+	buildTrivyCommentBody,
+	shouldSkipTrivyComment,
+} = require("../trivy-pr-comment.js") as {
+	buildTrivyCommentBody: (results: string) => string | null;
+	shouldSkipTrivyComment: (results: string) => boolean;
+};
+
+describe("shouldSkipTrivyComment", () => {
+	it("skips clean summary tables with zero findings", () => {
+		const results = `
+Report Summary
+
+┌────────┬──────┬─────────────────┬─────────┐
+│ Target │ Type │ Vulnerabilities │ Secrets │
+├────────┼──────┼─────────────────┼─────────┤
+│ .      │ fs   │ 0               │ -       │
+└────────┴──────┴─────────────────┴─────────┘
+Legend:
+- '-': Not scanned
+- '0': Clean (no security findings detected)
+`;
+
+		expect(shouldSkipTrivyComment(results)).toBe(true);
+		expect(buildTrivyCommentBody(results)).toBeNull();
+	});
+
+	it("does not skip tables with actual findings", () => {
+		const results = `
+Report Summary
+
+┌────────┬──────┬─────────────────┬─────────┐
+│ Target │ Type │ Vulnerabilities │ Secrets │
+├────────┼──────┼─────────────────┼─────────┤
+│ .      │ fs   │ 2               │ -       │
+└────────┴──────┴─────────────────┴─────────┘
+`;
+
+		expect(shouldSkipTrivyComment(results)).toBe(false);
+		expect(buildTrivyCommentBody(results)).toContain("| . | fs | 2 | - |");
+	});
+
+	it("renders raw output for non-table reports that should be posted", () => {
+		const results = "scanner failed to produce a table";
+
+		expect(shouldSkipTrivyComment(results)).toBe(false);
+		expect(buildTrivyCommentBody(results)).toContain("### Raw Output");
+	});
+});

--- a/src/bun/trivy-pr-comment.js
+++ b/src/bun/trivy-pr-comment.js
@@ -1,0 +1,141 @@
+const COMMENT_HEADER = "## 🔍 Trivy Vulnerability Scan\n\n";
+
+const FINDING_FREE_HEADERS = new Set([
+	"vulnerabilities",
+	"misconfigurations",
+	"secrets",
+	"licenses",
+]);
+
+function normalizeCell(value) {
+	return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function isFindingFreeCell(value) {
+	const normalized = normalizeCell(value);
+
+	if (
+		normalized === "" ||
+		normalized === "-" ||
+		normalized === "none" ||
+		normalized === "n/a"
+	) {
+		return true;
+	}
+
+	if (/^0+([./]0+)?$/.test(normalized)) {
+		return true;
+	}
+
+	return (
+		normalized.includes("clean") ||
+		normalized.includes("not scanned") ||
+		normalized.includes("no security findings")
+	);
+}
+
+function parseRow(line) {
+	return line
+		.split("│")
+		.slice(1, -1)
+		.map((cell) => cell.trim());
+}
+
+function parseTrivyTable(results) {
+	const lines = results
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const tableLines = lines.filter((line) => line.startsWith("│"));
+
+	if (tableLines.length < 2) {
+		return null;
+	}
+
+	const header = parseRow(tableLines[0]);
+	const rows = tableLines
+		.slice(1)
+		.map(parseRow)
+		.filter((row) => row.some((cell) => cell.length > 0));
+	const legendIndex = lines.findIndex((line) => line === "Legend:");
+	const legendLines =
+		legendIndex === -1
+			? []
+			: lines.slice(legendIndex + 1).filter((line) => line.startsWith("-"));
+
+	return { header, rows, legendLines };
+}
+
+function hasOnlyFindingFreeSummaryRows(header, rows) {
+	const relevantIndexes = header
+		.map((cell, index) =>
+			FINDING_FREE_HEADERS.has(normalizeCell(cell)) ? index : -1,
+		)
+		.filter((index) => index !== -1);
+
+	if (relevantIndexes.length === 0 || rows.length === 0) {
+		return false;
+	}
+
+	return rows.every((row) =>
+		relevantIndexes.every((index) => isFindingFreeCell(row[index] ?? "")),
+	);
+}
+
+function shouldSkipTrivyComment(results) {
+	const normalizedResults = results.trim();
+
+	if (normalizedResults.length === 0) {
+		return true;
+	}
+
+	const normalizedText = normalizeCell(normalizedResults);
+	if (
+		normalizedText.includes("no vulnerabilities found") ||
+		normalizedText.includes("clean (no security findings detected)")
+	) {
+		return true;
+	}
+
+	const table = parseTrivyTable(normalizedResults);
+	return table
+		? hasOnlyFindingFreeSummaryRows(table.header, table.rows)
+		: false;
+}
+
+function buildTrivyCommentBody(results) {
+	const normalizedResults = results.trim();
+
+	if (shouldSkipTrivyComment(normalizedResults)) {
+		return null;
+	}
+
+	let body = COMMENT_HEADER;
+	const table = parseTrivyTable(normalizedResults);
+
+	if (table) {
+		body += "### Report Summary\n\n";
+		body += `| ${table.header.join(" | ")} |\n`;
+		body += `| ${table.header.map(() => "---").join(" | ")} |\n`;
+		body += table.rows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+		body += "\n";
+
+		if (table.legendLines.length > 0) {
+			body += "\n";
+			body += table.legendLines.join("\n");
+			body += "\n";
+		}
+
+		return body;
+	}
+
+	body += "### Raw Output\n\n";
+	body += `\`\`\`\n${normalizedResults}\n\`\`\`\n`;
+	return body;
+}
+
+module.exports = {
+	buildTrivyCommentBody,
+	parseTrivyTable,
+	shouldSkipTrivyComment,
+};


### PR DESCRIPTION
## Summary
- skip Trivy PR comments when the scan summary is clean
- delete stale Trivy comments after a clean scan to stop email spam
- cover clean and non-clean report parsing with tests

## Testing
- bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/trivy-pr-comment.test.ts
- bun run lint
- bun run test