### PR TITLE
fix: auto-trust Codex worktrees

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -2,7 +2,7 @@
 
 Feature compatibility across supported AI coding agents.
 
-Last updated: 2026-03-27
+Last updated: 2026-03-29
 
 ## Agents
 
@@ -26,7 +26,7 @@ Last updated: 2026-03-27
 | **Max budget** | `--max-budget-usd` | — | `--max-budget-usd` | — | — |
 | **Model selection** | `--model` | `--model` | `--model` | `--model` | `--model` |
 | **Agent selection** | — | — | — | — | `--agent` |
-| **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | — | Yes (`ensureGeminiTrust`) | — |
+| **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | Yes (`ensureCodexTrust`) | Yes (`ensureGeminiTrust`) | — |
 | **Status hooks (automatic)** | Yes (4 hooks) | — | Yes (4 hooks) | — | — |
 | **Status management** | Automatic via hooks | Manual (SKILL.md) | Automatic via hooks with `user-questions`/legacy-session fallback | Manual (SKILL.md) | Manual (SKILL.md) |
 

--- a/change-logs/2026/03/29/fix-codex-worktree-trust-prompt.md
+++ b/change-logs/2026/03/29/fix-codex-worktree-trust-prompt.md
@@ -1,0 +1,1 @@
+Fix Codex spawned worktrees asking for the trust prompt again by pre-registering the exact worktree path in `~/.codex/config.toml` before launch. The dev3 Codex config patcher now keeps the shared worktrees root trust entry and can add per-worktree trust entries without duplicating the permission profile logic.

--- a/decisions/024-codex-exact-worktree-trust.md
+++ b/decisions/024-codex-exact-worktree-trust.md
@@ -1,0 +1,22 @@
+# 024 — Codex Requires Exact Worktree Trust Entries
+
+## Context
+
+Fresh Codex sessions in dev3 worktrees started showing the terminal trust prompt again even though `~/.codex/config.toml` already trusted the shared `~/.dev3.0/worktrees` root. That broke the expected zero-click launch path for spawned Codex task worktrees.
+
+## Investigation
+
+The current dev3 startup patch only wrote `[projects."<home>/.dev3.0/worktrees"]` plus the dev3 permission/profile blocks. A live config check showed there was no exact `[projects."<worktreePath>"]` entry for the newly spawned worktree path that Codex displayed in the prompt.
+
+## Decision
+
+dev3 now keeps the shared worktrees root trust entry and also patches the exact resolved worktree path into `~/.codex/config.toml` via `ensureCodexTrust()` in [src/bun/agents.ts](src/bun/agents.ts) before launching Codex from [src/bun/rpc-handlers.ts](src/bun/rpc-handlers.ts). `ensureCodexConfig()` in [src/bun/codex-config.ts](src/bun/codex-config.ts) now accepts additional trusted paths so startup patching and per-launch patching share the same logic.
+
+## Risks
+
+This assumes Codex matches trust by exact project path rather than inheriting trust from a parent directory. If Codex changes that behavior again, the extra trust entries may become redundant but remain harmless.
+
+## Alternatives considered
+
+- Keep trusting only the shared `worktrees` root: rejected because current Codex behavior still shows the prompt for fresh per-task worktrees.
+- Hardcode worktree trust edits directly in the launch path: rejected because it would duplicate TOML patch logic and drift from startup config patching.

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -32,6 +32,14 @@ describe("ensureCodexConfig", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH);
 			expect(result).not.toContain("default_permissions");
 		});
+
+		it("can trust an exact worktree path in addition to the shared worktrees root", () => {
+			const worktreePath = "/Users/testuser/.dev3.0/worktrees/proj/abcd1234/worktree";
+			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [worktreePath]);
+
+			expect(result).toContain(`[projects."${WORKTREES_PATH}"]`);
+			expect(result).toContain(`[projects."${worktreePath}"]`);
+		});
 	});
 
 	describe("when config exists with user settings", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -77,7 +77,9 @@ vi.mock("../pty-server", () => ({
 
 vi.mock("../agents", () => ({
 	ensureClaudeTrust: vi.fn(),
+	ensureCodexTrust: vi.fn(),
 	ensureGeminiTrust: vi.fn(),
+	isCodexCommand: vi.fn((cmd: string) => cmd === "codex"),
 	isGeminiCommand: vi.fn(() => false),
 	resolveCommandForAgent: vi.fn(() => ({ command: "claude", extraEnv: {} })),
 	resolveCommandForProject: vi.fn(() => ({ command: "claude", extraEnv: {} })),
@@ -3415,6 +3417,26 @@ describe("launchTaskPty", () => {
 		} finally {
 			writeSpy.mockRestore();
 		}
+	});
+
+	it("pre-registers the exact worktree as trusted before launching Codex", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		mockSpawnSync.mockReturnValue({
+			exitCode: 0,
+			stdout: new TextEncoder().encode("/usr/local/bin/codex\n"),
+			stderr: new Uint8Array(),
+		});
+		(agents.resolveCommandForAgent as any).mockResolvedValueOnce({
+			command: "codex",
+			extraEnv: {},
+			agent: { baseCommand: "codex" },
+			config: {},
+		});
+
+		await launchTaskPty(project, task, "/tmp/codex-wt", "builtin-codex", "codex-default");
+
+		expect((agents as any).ensureCodexTrust).toHaveBeenCalledWith("/tmp/codex-wt");
 	});
 });
 

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -1,9 +1,10 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import type { AgentConfiguration, CodingAgent, Project } from "../shared/types";
 import { DEFAULT_AGENTS } from "../shared/types";
 import { createLogger } from "./logger";
+import { ensureCodexConfig } from "./codex-config";
 import { DEV3_HOME } from "./paths";
 import { loadSettings } from "./settings";
 
@@ -510,6 +511,8 @@ export function buildTaskEnv(
 
 // ---- Gemini Trust ----
 
+const CODEX_CONFIG = `${homedir()}/.codex/config.toml`;
+
 const GEMINI_TRUSTED_FOLDERS = `${homedir()}/.gemini/trustedFolders.json`;
 
 /**
@@ -537,6 +540,40 @@ export async function ensureGeminiTrust(dirPath: string): Promise<void> {
 	} catch (err) {
 		// Non-fatal — worst case the user sees the trust dialog
 		log.warn("Failed to register Gemini worktree trust", { error: String(err) });
+	}
+}
+
+// ---- Codex Trust ----
+
+/**
+ * Ensure a directory is marked as trusted in ~/.codex/config.toml so that
+ * `codex` CLI skips the "Do you trust the contents of this directory?" dialog.
+ * Resolves symlinks (e.g. /tmp → /private/tmp on macOS).
+ */
+export async function ensureCodexTrust(dirPath: string): Promise<void> {
+	try {
+		const resolved = await realpath(dirPath);
+		const home = homedir();
+		const worktreesPath = `${home}/.dev3.0/worktrees`;
+		const socketsPath = `${home}/.dev3.0/sockets`;
+
+		let content: string | null = null;
+		try {
+			content = readFileSync(CODEX_CONFIG, "utf-8");
+		} catch {
+			// File doesn't exist yet — create with defaults below.
+		}
+
+		const updated = ensureCodexConfig(content, worktreesPath, socketsPath, [worktreesPath, resolved]);
+		if (updated === content) {
+			return;
+		}
+
+		writeFileSync(CODEX_CONFIG, updated, "utf-8");
+		log.info("Registered worktree as trusted in ~/.codex/config.toml", { path: resolved });
+	} catch (err) {
+		// Non-fatal — worst case the user sees the trust dialog
+		log.warn("Failed to register Codex worktree trust", { error: String(err) });
 	}
 }
 

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -43,6 +43,7 @@ export function ensureCodexConfig(
 	content: string | null,
 	worktreesPath: string,
 	socketsPath: string,
+	trustedPaths: string[] = [],
 ): string {
 	let config = content ?? "";
 	let parsed: CodexConfig = {};
@@ -70,10 +71,11 @@ export function ensureCodexConfig(
 		}
 	}
 
-	// --- 1. Ensure [projects."<worktreesPath>"] with trust_level = "trusted" ---
-	const hasProject = parsed.projects?.[worktreesPath] != null;
-	if (!hasProject) {
-		const block = `\n[projects."${worktreesPath}"]\ntrust_level = "trusted"\n`;
+	// --- 1. Ensure trusted [projects."<path>"] entries ---
+	for (const trustedPath of new Set([worktreesPath, ...trustedPaths])) {
+		if (!trustedPath) continue;
+		if (parsed.projects?.[trustedPath] != null) continue;
+		const block = `\n[projects."${trustedPath}"]\ntrust_level = "trusted"\n`;
 		config = appendBlock(config, block);
 	}
 

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -972,6 +972,20 @@ export async function launchTaskPty(
 		});
 	}
 
+	// Pre-register worktree as trusted so codex skips the trust dialog
+	if (agents.isCodexCommand(resolvedBaseCmd)) {
+		try {
+			await agents.ensureCodexTrust(worktreePath);
+			log.info("Codex trust ensured", { worktreePath });
+		} catch (err) {
+			log.error("ensureCodexTrust failed (non-fatal)", {
+				worktreePath,
+				error: String(err),
+				stack: (err as Error)?.stack ?? "no stack",
+			});
+		}
+	}
+
 	// Pre-register worktree as trusted so gemini skips the trust dialog
 	if (agents.isGeminiCommand(resolvedBaseCmd)) {
 		try {


### PR DESCRIPTION
## Summary
- auto-trust exact Codex worktree paths before launch so fresh spawned sessions skip the trust prompt
- extend the Codex config patcher to preserve the shared worktrees root trust entry while adding per-worktree entries
- add regression coverage, update the support matrix, and document the behavior change

## Testing
- bun run lint
- bun run test