### PR TITLE
fix: play task completion sound immediately

### DIFF
--- a/change-logs/2026/03/29/fix-immediate-task-completion-sound.md
+++ b/change-logs/2026/03/29/fix-immediate-task-completion-sound.md
@@ -1,0 +1,1 @@
+Task completion and cancellation sounds now play immediately when the status change is accepted instead of waiting for tmux cleanup and worktree teardown. Added regression coverage for both RPC and CLI task move flows so delayed audio feedback does not creep back in.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -69,7 +69,7 @@ vi.mock("node:fs", () => ({
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
-import { activateTask, runCleanupScript, getPushMessage } from "../rpc-handlers";
+import { activateTask, runCleanupScript, playTaskCompleteSound, getPushMessage } from "../rpc-handlers";
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 
 const { handleRequest, getSocketPath, startSocketServer, stopSocketServer } = await import(
@@ -964,6 +964,30 @@ describe("task.move", () => {
 			branchName: null,
 			customColumnId: null,
 		}, { dropPosition: "top" });
+	});
+
+	it("active → completed: plays sound before cleanup starts", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress" });
+		const updated = { ...task, status: "completed" as const, worktreePath: null, branchName: null };
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.move", {
+				taskId: task.id,
+				projectId: "proj-1",
+				newStatus: "completed",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(vi.mocked(playTaskCompleteSound).mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(runCleanupScript).mock.invocationCallOrder[0],
+		);
 	});
 
 	it("active → cancelled: same cleanup flow", async () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -163,7 +163,7 @@ import * as pty from "../pty-server";
 import * as agents from "../agents";
 import * as updater from "../updater";
 import { setupAgentHooks } from "../agent-hooks";
-import { loadSettings, saveSettings } from "../settings";
+import { loadSettings, loadSettingsSync, saveSettings } from "../settings";
 import * as repoConfig from "../repo-config";
 import { Utils } from "electrobun/bun";
 import { existsSync } from "node:fs";
@@ -1172,6 +1172,31 @@ describe("handlers.moveTask", () => {
 		expect(result.status).toBe("completed");
 		expect(pty.destroySession).toHaveBeenCalledWith("task-1", undefined);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
+	});
+
+	it("in-progress → completed: plays sound before cleanup finishes", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
+		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(loadSettingsSync).mockReturnValue({ playSoundOnTaskComplete: true } as any);
+		mockSpawn.mockImplementation(() => {
+			return { stdout: "", stderr: new Response(""), exited: Promise.resolve(0) };
+		});
+
+		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
+
+		const spawnCalls = mockSpawn.mock.calls.map(([args]) => args as string[]);
+		const afplayCall = spawnCalls.findIndex((args) => args[0] === "afplay");
+		const cleanupCall = spawnCalls.findIndex((args) => args.includes("new-session"));
+		expect(afplayCall).toBeGreaterThanOrEqual(0);
+		expect(cleanupCall).toBeGreaterThanOrEqual(0);
+		expect(afplayCall).toBeLessThan(cleanupCall);
+		expect(result.status).toBe("completed");
 	});
 
 	it("in-progress → cancelled: same cleanup as completed", async () => {

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -469,9 +469,9 @@ const handlers: Record<string, Handler> = {
 
 		// active → completed/cancelled: destroy PTY, cleanup, remove worktree
 		if (isActive(oldStatus) && (builtinStatus === "completed" || builtinStatus === "cancelled")) {
+			playTaskCompleteSound(builtinStatus as "completed" | "cancelled");
 			try { pty.destroySession(task.id, task.tmuxSocket ?? undefined); } catch {}
 			try { await runCleanupScript(task, project); } catch {}
-			playTaskCompleteSound(builtinStatus as "completed" | "cancelled");
 			try { await git.removeWorktree(project, task); } catch {}
 
 			const updated = await data.updateTask(project, task.id, {

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -810,8 +810,10 @@ export function playTaskCompleteSound(status: "completed" | "cancelled"): void {
 	const filename = status === "completed" ? "task-completed.mp3" : "task-cancelled.mp3";
 	const volume = status === "completed" ? "0.3" : "0.7";
 	const prodPath = join(PATHS.VIEWS_FOLDER, "..", "sounds", filename);
-	const devPath = join(import.meta.dir, "..", "assets", "sounds", filename);
-	const soundPath = existsSync(prodPath) ? prodPath : existsSync(devPath) ? devPath : null;
+	const devPath = typeof import.meta.dir === "string"
+		? join(import.meta.dir, "..", "assets", "sounds", filename)
+		: null;
+	const soundPath = existsSync(prodPath) ? prodPath : devPath && existsSync(devPath) ? devPath : null;
 
 	if (!soundPath) {
 		log.warn("Task complete sound file not found", { prodPath, devPath, status });
@@ -1785,6 +1787,8 @@ export const handlers = {
 		if (newStatus === "completed" || newStatus === "cancelled") {
 			cleanupTaskState(task.id);
 			portPool.releasePorts(task.id);
+			// Confirm the user's action immediately; cleanup can take a few seconds.
+			playTaskCompleteSound(newStatus as "completed" | "cancelled");
 			if (params.force) {
 				// Force mode: skip PTY destruction, cleanup script, and worktree removal.
 				// The environment is already broken — just update the status.
@@ -1820,8 +1824,6 @@ export const handlers = {
 						error: String(err),
 					});
 				}
-
-				playTaskCompleteSound(newStatus as "completed" | "cancelled");
 
 				try {
 					await git.removeWorktree(project, task);


### PR DESCRIPTION
## Summary
- play completion and cancellation sounds as soon as the status change is accepted
- keep cleanup and worktree teardown running after the immediate audio confirmation
- add backend regression coverage for RPC and CLI task move flows

## Testing
- bun run lint
- bun run test
