### PR TITLE
Fix restored task sessions replaying initial prompt

### DIFF
--- a/change-logs/2026/03/30/fix-resume-active-task-restore.md
+++ b/change-logs/2026/03/30/fix-resume-active-task-restore.md
@@ -1,3 +1,3 @@
-Restore active task terminals in resume mode after app relaunch by treating persisted worktree-backed tasks as already launched sessions. This prevents the original task prompt from being replayed when reopening review or question-waiting tasks after a reboot or app restart.
+Restore active task terminals in resume mode after app relaunch by treating persisted worktree-backed tasks as already launched sessions. Dead in-memory PTY sessions are now discarded before restore so reopening does not reuse the stale launch command and replay the original task prompt.
 
 Suggested by @genrym (h0x91b/dev-3.0#379)

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2010,7 +2010,7 @@ describe("handlers.getPtyUrl", () => {
 		expect(url).toBe("ws://localhost:9999?session=task-1");
 	});
 
-	it("does not destroy dead session when resume is not set", async () => {
+	it("destroys dead sessions even when resume is not set", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
 
@@ -2022,7 +2022,15 @@ describe("handlers.getPtyUrl", () => {
 
 		await handlers.getPtyUrl({ taskId: "task-1" });
 
-		expect(pty.destroySession).not.toHaveBeenCalled();
+		expect(pty.destroySession).toHaveBeenCalledWith("task-1");
+		expect(agents.resolveCommandForProject).toHaveBeenCalledWith(
+			project,
+			task.title,
+			task.description,
+			"/tmp/wt",
+			undefined,
+			{ resume: true },
+		);
 	});
 
 	it("passes task agentId and configId when restoring session", async () => {

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -2731,14 +2731,17 @@ export const handlers = {
 		log.info("→ getPtyUrl", {
 			taskId: params.taskId,
 			hasExistingSession: pty.hasSession(params.taskId),
+			hasDeadSession: pty.hasDeadSession(params.taskId),
 			ptyPort: pty.getPtyPort(),
 		});
 
-		// If resuming and the session is dead (proc exited but still in map),
-		// destroy it so launchTaskPty recreates it with the resume flag.
-		if (params.resume && pty.hasDeadSession(params.taskId)) {
-			log.info("Resume requested on dead session — destroying to force recreation", {
+		// Dead in-memory sessions keep the original tmux command, which would
+		// replay the initial prompt if the websocket path respawns them directly.
+		// Always destroy them and go through the normal restore path instead.
+		if (pty.hasDeadSession(params.taskId)) {
+			log.info("Dead session detected — destroying to force clean restoration", {
 				taskId: params.taskId.slice(0, 8),
+				resumeRequested: !!params.resume,
 			});
 			pty.destroySession(params.taskId);
 		}


### PR DESCRIPTION
## Summary
- restore active worktree-backed tasks in resume mode instead of replaying the initial task prompt
- destroy dead in-memory PTY sessions before restore so reopen/relaunch cannot reuse a stale launch command
- add coverage for the automatic restore path and the dead-session path that previously bypassed resume

This complements #302. That PR handles hibernate/relaunch flow; this one fixes the underlying dead-session restore path so reopen after reboot/app relaunch does not start from scratch.

Closes #379

## Root Cause
When a PTY/tmux-backed task session died, the dead session could remain in the in-memory PTY map with its original launch command. Reopening the task could then recreate tmux from that stale command instead of going through the resume-aware restore path, which replayed the original task prompt.

## Test Plan
- [x] `bun run lint`
- [x] `bun run test`
- [x] Manual: create a task, let the agent answer once, kill the backing session / relaunch the app, reopen the task, verify it resumes instead of re-sending the original prompt
- [x] Manual: move task to `Cancelled` then back to `To Do`, launch again, verify intentional fresh start still works