### PR TITLE
fix: add codex workspace default permissions fallback

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -76,5 +76,5 @@ A supplementary skill that teaches agents about `.dev3/config.json` and `.dev3/c
 |-------------|--------|---------|
 | `~/.agents/AGENTS.md` | All (fallback) | Appended rule block for agents that read `AGENTS.md` |
 | `~/.claude/settings.json` | Claude Code | Auto-adds `Bash(~/.dev3.0/bin/dev3 *)` permission |
-| `~/.codex/config.toml` | Codex | Configures trust, sandbox access, and enables `codex_hooks` |
+| `~/.codex/config.toml` | Codex | Configures trust, creates a fallback `permissions.workspace` default when missing, patches dev3 sandbox access, and enables `codex_hooks` |
 | `<worktree>/.codex/hooks.json` | Codex | Auto-installs SessionStart/UserPromptSubmit/PreToolUse(Bash)/Stop lifecycle hooks |

--- a/change-logs/2026/04/01/fix-codex-default-permissions.md
+++ b/change-logs/2026/04/01/fix-codex-default-permissions.md
@@ -1,0 +1,1 @@
+Fix Codex startup failures caused by dev3-managed `config.toml` files that defined permission profiles without `default_permissions`. dev3 now creates a minimal fallback `permissions.workspace` profile, sets it as the default when missing, and covers the migration with Codex config tests.

--- a/decisions/025-codex-default-permissions-fallback.md
+++ b/decisions/025-codex-default-permissions-fallback.md
@@ -1,0 +1,22 @@
+# 025 — Codex config default_permissions fallback
+
+## Context
+
+Codex 0.117.0 rejects `~/.codex/config.toml` when it contains `[permissions.*]` profiles without a top-level `default_permissions`. dev3 already injects `[permissions.dev3]`, so users could hit a startup failure before any launch-time overrides were applied.
+
+## Investigation
+
+Reproducing with `codex exec` showed the config file itself was rejected with `config defines [permissions] profiles but does not set default_permissions`. A CLI override such as `-c 'default_permissions="dev3"'` worked, but only after startup had already parsed a valid config.
+
+## Decision
+
+`ensureCodexConfig()` in [src/bun/codex-config.ts](src/bun/codex-config.ts) now preserves an existing `default_permissions`, but if it is missing it creates a generic `[permissions.workspace]` profile and writes `default_permissions = "workspace"`. The generated `workspace` profile is intentionally minimal: read access to the default minimal scope, write access to project roots, and network enabled.
+
+## Risks
+
+This introduces a dev3-managed fallback for plain Codex sessions, so future Codex changes to `workspace` semantics may require updates here. If a user expected no default profile at all, dev3 now chooses one explicitly, but only in configs that were already invalid for current Codex.
+
+## Alternatives considered
+
+- Set `default_permissions = "dev3"`: rejected because the chosen fallback should behave like a generic Codex workspace profile, not a dev3-specific one.
+- Rely only on launch-time `-c 'default_permissions="dev3"'`: rejected because Codex validates the config file before interactive or exec runs can proceed.

--- a/src/bun/__tests__/codex-config-cleanup.test.ts
+++ b/src/bun/__tests__/codex-config-cleanup.test.ts
@@ -104,6 +104,8 @@ trust_level = "trusted"
 			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
 			// Old section removed
 			expect(result).not.toMatch(/^\[permissions\.network\]$/m);
+			expect(result).toContain('default_permissions = "workspace"');
+			expect(result).toContain("[permissions.workspace.filesystem]");
 			// New dev3 profile added
 			expect(result).toContain("[permissions.dev3.network]");
 			expect(result).toContain("[profiles.dev3]");

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -6,10 +6,14 @@ describe("ensureCodexConfig", () => {
 	const SOCKETS_PATH = "/Users/testuser/.dev3.0/sockets";
 
 	describe("when config does not exist", () => {
-		it("creates config with project trust, permissions.dev3, and profiles.dev3", () => {
+		it("creates config with project trust, workspace default permissions, permissions.dev3, and profiles.dev3", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH);
 			expect(result).toContain(`[projects."${WORKTREES_PATH}"]`);
 			expect(result).toContain('trust_level = "trusted"');
+			expect(result).toContain('default_permissions = "workspace"');
+			expect(result).toContain("[permissions.workspace.filesystem]");
+			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain("[permissions.workspace.network]");
 			// Permission profile
 			expect(result).toContain("[permissions.dev3.filesystem]");
 			expect(result).toContain('":minimal" = "read"');
@@ -28,9 +32,15 @@ describe("ensureCodexConfig", () => {
 			expect(result).toContain("codex_hooks = true");
 		});
 
-		it("does NOT set default_permissions", () => {
+		it("creates a generic workspace profile and uses it as default_permissions when missing", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH);
-			expect(result).not.toContain("default_permissions");
+			expect(result).toContain('default_permissions = "workspace"');
+			expect(result).toContain("[permissions.workspace.filesystem]");
+			expect(result).toContain('":minimal" = "read"');
+			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain('"." = "write"');
+			expect(result).toContain("[permissions.workspace.network]");
+			expect(result).toContain("enabled = true");
 		});
 
 		it("can trust an exact worktree path in addition to the shared worktrees root", () => {
@@ -56,6 +66,43 @@ trust_level = "trusted"
 			expect(result).toContain(`[projects."${WORKTREES_PATH}"]`);
 			expect(result).toContain("[permissions.dev3.network]");
 			expect(result).toContain("[profiles.dev3]");
+		});
+
+		it("adds default_permissions = workspace when permissions exist but no default is set", () => {
+			const existing = `model = "gpt-5.4"
+
+[permissions.dev3.filesystem]
+":minimal" = "read"
+
+[permissions.dev3.filesystem.":project_roots"]
+"." = "write"
+
+[permissions.dev3.network]
+enabled = true
+allow_unix_sockets = ["${SOCKETS_PATH}"]
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+			expect(result).toContain('default_permissions = "workspace"');
+			expect(result).toContain("[permissions.workspace.filesystem]");
+			expect(result).toContain("[permissions.workspace.network]");
+			expect(result).toContain("[permissions.dev3.network]");
+		});
+
+		it("fills missing workspace entries before setting default_permissions = workspace", () => {
+			const existing = `[permissions.workspace.filesystem]
+"/tmp/custom" = "read"
+
+[permissions.workspace.network]
+enabled = false
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+			expect(result).toContain('default_permissions = "workspace"');
+			expect(result).toContain("[permissions.workspace.filesystem]");
+			expect(result).toContain('":minimal" = "read"');
+			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain('"." = "write"');
+			expect(result).toContain("[permissions.workspace.network]");
+			expect(result).toContain("enabled = true");
 		});
 	});
 

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -10,6 +10,7 @@ const log = createLogger("codex-config");
  * Used as [permissions.dev3] and [profiles.dev3].
  */
 export const DEV3_CODEX_PROFILE = "dev3";
+export const WORKSPACE_CODEX_PROFILE = "workspace";
 
 interface CodexPermissionsProfile {
 	filesystem?: Record<string, unknown>;
@@ -30,11 +31,13 @@ interface CodexConfig {
 /**
  * Ensure the Codex config.toml has:
  * 1. The dev3 worktree project trusted
- * 2. A dedicated [permissions.dev3] permission profile with filesystem + network access
- * 3. A dedicated [profiles.dev3] config profile for dev3 launches
+ * 2. A generic [permissions.workspace] fallback profile + default_permissions
+ * 3. A dedicated [permissions.dev3] permission profile with filesystem + network access
+ * 4. A dedicated [profiles.dev3] config profile for dev3 launches
  *
- * Does NOT touch the user's `default_permissions` — dev3 selects its own
- * permission profile at launch time via `-c 'default_permissions="dev3"'`.
+ * Preserves the user's `default_permissions` when already set. If missing,
+ * creates a generic `workspace` permission profile and sets it as the default
+ * so Codex accepts configs that define [permissions.*] profiles.
  *
  * Uses js-toml to parse and inspect the config, but writes via text
  * manipulation to preserve comments and user formatting.
@@ -148,7 +151,54 @@ export function ensureCodexConfig(
 		}
 	}
 
-	// --- 3. Ensure [profiles.dev3] config profile ---
+	// --- 3. Ensure default_permissions points to a valid generic workspace profile ---
+	if (parsed.default_permissions == null) {
+		const workspacePerm = parsed.permissions?.[WORKSPACE_CODEX_PROFILE] as CodexPermissionsProfile | undefined;
+		const workspaceFsHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem]`;
+		const workspaceProjectRootsHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem.":project_roots"]`;
+		const workspaceNetworkHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.network]`;
+
+		if (workspacePerm == null) {
+			const block = [
+				"",
+				`[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem]`,
+				'":minimal" = "read"',
+				"",
+				workspaceProjectRootsHeader,
+				'"." = "write"',
+				"",
+				workspaceNetworkHeader,
+				"enabled = true",
+				"",
+			].join("\n");
+			config = appendBlock(config, block);
+		} else {
+			if (workspacePerm.filesystem == null) {
+				const block = `\n${workspaceFsHeader}\n":minimal" = "read"\n`;
+				config = appendBlock(config, block);
+			} else {
+				config = upsertSectionLine(config, workspaceFsHeader, '":minimal"', '"read"');
+			}
+
+			if (!config.includes(workspaceProjectRootsHeader)) {
+				const block = `\n${workspaceProjectRootsHeader}\n"." = "write"\n`;
+				config = appendBlock(config, block);
+			} else {
+				config = upsertSectionLine(config, workspaceProjectRootsHeader, '"."', '"write"');
+			}
+
+			if (workspacePerm.network == null) {
+				const block = `\n${workspaceNetworkHeader}\nenabled = true\n`;
+				config = appendBlock(config, block);
+			} else if (workspacePerm.network.enabled !== true) {
+				config = upsertSectionLine(config, workspaceNetworkHeader, "enabled", "true");
+			}
+		}
+
+		config = upsertRootLine(config, "default_permissions", '"workspace"');
+	}
+
+	// --- 4. Ensure [profiles.dev3] config profile ---
 	const dev3Profile = parsed.profiles?.[DEV3_CODEX_PROFILE];
 	if (dev3Profile == null) {
 		const block = [
@@ -160,7 +210,7 @@ export function ensureCodexConfig(
 		config = appendBlock(config, block);
 	}
 
-	// --- 4. Ensure [features] codex_hooks = true ---
+	// --- 5. Ensure [features] codex_hooks = true ---
 	const codexHooksEnabled = parsed.features?.codex_hooks === true;
 	if (!codexHooksEnabled) {
 		const featuresHeader = "[features]";
@@ -223,6 +273,30 @@ function removeSectionByHeader(content: string, header: string): string {
 	}
 
 	return out.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+function upsertRootLine(config: string, key: string, value: string): string {
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const keyPattern = new RegExp(`^${escapedKey}\\s*=\\s*.*$`, "m");
+
+	if (keyPattern.test(config)) {
+		return config.replace(keyPattern, `${key} = ${value}`);
+	}
+
+	const lines = config.split("\n");
+	let insertIndex = 0;
+
+	while (insertIndex < lines.length) {
+		const line = lines[insertIndex];
+		if (line.trim() === "" || line.trim().startsWith("#")) {
+			insertIndex++;
+			continue;
+		}
+		break;
+	}
+
+	lines.splice(insertIndex, 0, `${key} = ${value}`);
+	return lines.join("\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a fallback `permissions.workspace` profile when Codex config defines permissions without `default_permissions`
- preserve existing `default_permissions` values and keep dev3-specific Codex profiles intact
- cover the migration with Codex config tests and document the decision

## Testing
- bun run lint
- bun run test