### PR TITLE
fix: move PR badge to lower row

### DIFF
--- a/change-logs/2026/04/01/fix-pr-badge-centering.md
+++ b/change-logs/2026/04/01/fix-pr-badge-centering.md
@@ -1,1 +1,1 @@
-Centered the PR badge text in task card footers by giving the badge a fixed height and zero-leading text. Added a regression test so the PR number stays aligned with the rest of the footer controls.
+Moved the PR badge off the crowded footer row and into the lower action row of active task cards, with centered badge text and spacing. Added regression coverage so active cards keep the PR badge in the lower row instead of squeezing it into the footer.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -386,6 +386,19 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 	const displayTitle = getTaskTitle(task);
 	const hasLongDescription = task.description !== displayTitle;
+	const prBadge = prInfo ? (
+		<button
+			onClick={(e) => {
+				e.stopPropagation();
+				window.open(prInfo.url, "_blank");
+			}}
+			className="inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded bg-green-500/10 px-1.5 py-0.5 font-mono text-[0.625rem] font-semibold leading-none text-green-400 transition-colors hover:bg-green-500/20"
+			title={t("task.openPR", { number: String(prInfo.number) })}
+		>
+			<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0401}"}</span>
+			<span className="leading-none">#{prInfo.number}</span>
+		</button>
+	) : null;
 
 	function handleShowDescription(e: React.MouseEvent) {
 		e.stopPropagation();
@@ -659,20 +672,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					);
 				})()}
 
-				{/* PR badge */}
-				{prInfo && (
-					<button
-						onClick={(e) => {
-							e.stopPropagation();
-							window.open(prInfo.url, "_blank");
-						}}
-						className="inline-flex h-5 max-w-full flex-shrink-0 self-center items-center gap-1 rounded bg-green-500/10 px-1.5 py-0.5 font-mono text-[0.625rem] font-semibold leading-none text-green-400 transition-colors hover:bg-green-500/20"
-						title={t("task.openPR", { number: String(prInfo.number) })}
-					>
-						<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0401}"}</span>
-						<span className="leading-none">#{prInfo.number}</span>
-					</button>
-				)}
+				{/* PR badge for non-active cards */}
+				{!isActive && prBadge}
 
 				{/* Sibling variant dots */}
 				{hasSiblings && (
@@ -762,8 +763,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 			{/* Action row for active tasks — Open in... | Watch | + Variant */}
 			{isActive && (
-				<div className="mt-1 flex items-center justify-between">
-					<div className="flex items-center gap-1">
+				<div data-testid="task-card-action-row" className="mt-1 grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+					<div className="flex min-w-0 items-center gap-1">
 						{task.worktreePath && (
 							<button
 								onClick={(e) => {
@@ -806,13 +807,16 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 							<span className="text-[0.6875rem]">{task.watched ? t("task.watching") : t("task.watch")}</span>
 						</button>
 					</div>
+					<div className="flex min-w-0 justify-center">
+						{prBadge}
+					</div>
 					<button
 						onClick={(e) => {
 							e.stopPropagation();
 							preview.close();
 							onAddAttempts(task);
 						}}
-						className="flex flex-shrink-0 items-center rounded-lg px-2 py-1 text-xs font-medium text-accent transition-all hover:bg-accent/15"
+						className="flex flex-shrink-0 justify-self-end items-center rounded-lg px-2 py-1 text-xs font-medium text-accent transition-all hover:bg-accent/15"
 						title={t("task.addVariant")}
 						disabled={isDisabled}
 					>

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1137,13 +1137,14 @@ describe("TaskCard", () => {
 	});
 
 	describe("PR badge", () => {
-		it("keeps the footer layout stable when a PR badge is shown", () => {
+		it("renders the PR badge in the lower action row for active tasks", () => {
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "feat/test" }), {
 				prInfo: { number: 42, url: "https://github.com/test/repo/pull/42" },
 			});
 
-			expect(screen.getByTestId("task-card-footer")).toHaveClass("flex", "items-center");
-			expect(screen.getByRole("button", { name: "Agent is Working" })).toHaveClass("min-w-0");
+			const badge = screen.getByText("#42").closest("button");
+			expect(screen.getByTestId("task-card-action-row")).toContainElement(badge);
+			expect(screen.getByTestId("task-card-footer")).not.toContainElement(badge);
 		});
 
 		it("shows PR badge when prInfo is provided", () => {
@@ -1153,13 +1154,14 @@ describe("TaskCard", () => {
 			expect(screen.getByText("#42")).toBeInTheDocument();
 		});
 
-		it("keeps the PR badge vertically centered in the footer row", () => {
+		it("keeps the PR badge centered inside the lower action row", () => {
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "feat/test" }), {
 				prInfo: { number: 42, url: "https://github.com/test/repo/pull/42" },
 			});
 
+			expect(screen.getByTestId("task-card-action-row")).toHaveClass("grid", "grid-cols-[auto_minmax(0,1fr)_auto]");
 			const badge = screen.getByText("#42").closest("button");
-			expect(badge).toHaveClass("h-5", "self-center", "items-center", "leading-none");
+			expect(badge).toHaveClass("h-5", "items-center", "leading-none");
 			expect(screen.getByText("#42")).toHaveClass("leading-none");
 		});
 


### PR DESCRIPTION
## Summary
- move the PR badge off the crowded footer row and into the lower action row on active task cards
- keep the PR badge available on non-active cards without changing their existing layout
- add regression coverage for badge placement and update the changelog entry

## Testing
- bun run lint
- bun run test