### PR TITLE
fix: prevent terminal corruption when dev server pane closes

### DIFF
--- a/change-logs/2026/04/02/fix-dev-server-terminal-corruption.md
+++ b/change-logs/2026/04/02/fix-dev-server-terminal-corruption.md
@@ -1,0 +1,3 @@
+Fix terminal rendering corruption when a dev server pane closes inside a nested tmux session. The wrappedScript now calls `tmux detach-client` before its pane exits, so inner tmux redraws without a watching client and the escape sequences never reach the outer tmux. The viewer pane's attach command is now a while-loop that re-attaches if the inner session is still alive (e.g. a frontend pane is still running after the backend closes).
+
+Suggested by @dolev (h0x91b/dev-3.0#116)

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -447,6 +447,9 @@ async function runDevServer(params: { taskId: string; projectId: string }): Prom
 			`  echo "Process exited with code $EXIT_CODE. Press any key to close."`,
 			`  read -n 1 -s`,
 			`fi`,
+			`# Detach the outer viewer pane before this pane closes so inner tmux redraws`,
+			`# without a watching client — prevents escape sequence corruption in outer tmux.`,
+			`tmux detach-client 2>/dev/null || true`,
 		].join("\n") + "\n";
 		await Bun.write(devScriptPath, wrappedScript);
 
@@ -471,9 +474,13 @@ async function runDevServer(params: { taskId: string; projectId: string }): Prom
 		const tmuxKill = socket
 			? `tmux -L "${socket}" kill-session -t "${devSession}" 2>/dev/null`
 			: `tmux kill-session -t "${devSession}" 2>/dev/null`;
+		// Re-attach loop: after a deliberate detach (e.g. wrappedScript called
+		// tmux detach-client before its pane closed), re-attach if the inner
+		// session still exists (e.g. a frontend pane is still running).
+		// The HUP trap lets kill-pane from stopDevServer exit cleanly.
 		const attachCmd = socket
-			? `bash -c 'trap "${tmuxKill}" EXIT; TMUX= tmux -L "${socket}" attach-session -t "${devSession}"'`
-			: `bash -c 'trap "${tmuxKill}" EXIT; TMUX= tmux attach-session -t "${devSession}"'`;
+			? `bash -c 'trap "${tmuxKill}" EXIT; trap "exit" HUP; while TMUX= tmux -L "${socket}" has-session -t "${devSession}" 2>/dev/null; do TMUX= tmux -L "${socket}" attach-session -t "${devSession}"; done'`
+			: `bash -c 'trap "${tmuxKill}" EXIT; trap "exit" HUP; while TMUX= tmux has-session -t "${devSession}" 2>/dev/null; do TMUX= tmux attach-session -t "${devSession}"; done'`;
 		const viewerProc = spawn(pty.tmuxArgs(socket,
 			"split-window", "-h",
 			"-t", taskSession,


### PR DESCRIPTION
## Summary

- When a pane inside the nested dev server session exits, inner tmux redraws its layout and sends escape sequences through the viewer pane to the outer tmux, which can't reconcile them — causing cascade rendering corruption across all visible panes.
- `wrappedScript` now calls `tmux detach-client` before exiting so the outer viewer disconnects *before* the pane closes; inner tmux redraws without a watching client and no corrupting sequences reach the outer terminal.
- `attachCmd` is now a while-loop that re-attaches if the inner session is still alive (e.g. frontend pane still running after backend closed). A `trap "exit" HUP` ensures `kill-pane` from `stopDevServer` exits cleanly without spinning.

Fixes the reproduction reported by @dolev: backend/frontend dev server panes → Ctrl+C backend → "Press any key to close" → Enter → terminal corruption.

## Test plan

- [x] Create a dev script with two panes (e.g. `tmux split-window -h "sleep 9999"` + `sleep 9999`)
- [x] Start dev server, switch to backend pane (`Ctrl+B` + arrow), press `Ctrl+C`
- [x] Press Enter at "Press any key to close" — viewer should briefly detach/reattach showing only the frontend; **outer terminal must have no rendering corruption**
- [x] Click Stop Dev Server — viewer pane closes cleanly
- [x] Single-pane dev server (no split): start → Ctrl+C → Enter → viewer pane closes, no corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)