### PR TITLE
fix: pass process.env.PATH to Bun.which() for shell-resolved PATH

### DIFF
--- a/change-logs/2026/04/02/fix-bun-which-path.md
+++ b/change-logs/2026/04/02/fix-bun-which-path.md
@@ -1,0 +1,1 @@
+Fixed PATH resolution for binary lookups (tmux, gh, git). Bun.which() was reading the OS-level PATH instead of the shell-resolved PATH, causing binaries outside /usr/bin to not be found in macOS .app bundles. The fix explicitly passes process.env.PATH to Bun.which().

--- a/src/bun/__tests__/which.test.ts
+++ b/src/bun/__tests__/which.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../spawn", () => ({
+	spawn: vi.fn(),
+	spawnSync: vi.fn(),
+}));
+
+describe("which — PATH resolution", () => {
+	let originalPath: string | undefined;
+	const mockBunWhich = vi.fn();
+
+	beforeEach(() => {
+		originalPath = process.env.PATH;
+		vi.resetModules();
+
+		// Inject a fake Bun.which into the global so the module prefers it
+		(globalThis as any).Bun = { which: mockBunWhich };
+	});
+
+	afterEach(() => {
+		process.env.PATH = originalPath;
+		delete (globalThis as any).Bun;
+		mockBunWhich.mockReset();
+	});
+
+	it("whichSync passes process.env.PATH explicitly to Bun.which", async () => {
+		process.env.PATH = "/custom/resolved/path:/usr/bin";
+		mockBunWhich.mockReturnValue("/custom/resolved/path/tmux");
+
+		const { whichSync } = await import("../which");
+
+		const result = whichSync("tmux");
+
+		expect(result).toBe("/custom/resolved/path/tmux");
+		expect(mockBunWhich).toHaveBeenCalledWith("tmux", {
+			PATH: "/custom/resolved/path:/usr/bin",
+		});
+	});
+
+	it("which (async) passes process.env.PATH explicitly to Bun.which", async () => {
+		process.env.PATH = "/nix/store/bin:/usr/bin";
+		mockBunWhich.mockReturnValue("/nix/store/bin/gh");
+
+		const { which } = await import("../which");
+
+		const result = await which("gh");
+
+		expect(result).toBe("/nix/store/bin/gh");
+		expect(mockBunWhich).toHaveBeenCalledWith("gh", {
+			PATH: "/nix/store/bin:/usr/bin",
+		});
+	});
+
+	it("whichSync reads process.env.PATH at call time, not import time", async () => {
+		process.env.PATH = "/initial/path";
+		mockBunWhich.mockReturnValue(null);
+
+		const { whichSync } = await import("../which");
+
+		// Simulate shell-env resolution updating PATH after module load
+		process.env.PATH = "/resolved/shell/path:/usr/local/bin";
+		mockBunWhich.mockReturnValue("/usr/local/bin/tmux");
+
+		whichSync("tmux");
+
+		expect(mockBunWhich).toHaveBeenCalledWith("tmux", {
+			PATH: "/resolved/shell/path:/usr/local/bin",
+		});
+	});
+
+	it("whichSync returns null when Bun.which returns null", async () => {
+		process.env.PATH = "/usr/bin:/bin";
+		mockBunWhich.mockReturnValue(null);
+
+		const { whichSync } = await import("../which");
+
+		expect(whichSync("nonexistent")).toBeNull();
+	});
+});

--- a/src/bun/which.ts
+++ b/src/bun/which.ts
@@ -41,10 +41,16 @@ const bunWhich =
 		? Bun.which
 		: null;
 
+// Bun.which() is a native Zig call that reads PATH from the OS process
+// environment block, NOT from the JS process.env proxy.  In a macOS .app
+// bundle the OS-level PATH is the minimal /usr/bin:/bin:/usr/sbin:/sbin —
+// shell-env.ts resolves the user's real PATH and patches process.env.PATH,
+// but that patch is invisible to Bun.which().  Passing { PATH } explicitly
+// makes Bun.which() honour the resolved PATH.
 export const which: (command: string) => Promise<string | null> = bunWhich
-	? async (command) => bunWhich(command)
+	? async (command) => bunWhich(command, { PATH: process.env.PATH ?? "" })
 	: whichNodeAsync;
 
 export const whichSync: (command: string) => string | null = bunWhich
-	? bunWhich
+	? (command) => bunWhich(command, { PATH: process.env.PATH ?? "" })
 	: whichNodeSync;


### PR DESCRIPTION
## Summary

- `Bun.which()` (introduced in PR #420) reads PATH from the OS process environment block, not the JS `process.env` proxy. In macOS `.app` bundles the OS-level PATH is always the minimal `/usr/bin:/bin:/usr/sbin:/sbin`, so `tmux`, `gh`, and other binaries installed outside standard system dirs were not found.
- Fix: explicitly pass `{ PATH: process.env.PATH }` to both `which()` and `whichSync()` wrappers so they honour the shell-resolved PATH.
- Added tests verifying PATH is passed at call time (not import time).

## Test plan

- [ ] Build the app, launch it on macOS — verify `tmux` and `gh` are detected (check Settings → System Requirements)
- [ ] Create a task — terminal should open in tmux
- [ ] Open a project with a GitHub remote — GitHub integration should work
- [ ] Verify `git` resolves to the user's installed git, not just `/usr/bin/git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)