### PR TITLE
fix: dedupe Gemini managed skills

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -2,7 +2,7 @@
 
 Feature compatibility across supported AI coding agents.
 
-Last updated: 2026-03-29
+Last updated: 2026-04-02
 
 ## Agents
 
@@ -11,7 +11,7 @@ Last updated: 2026-03-29
 | Claude Code | `claude` | `~/.claude/skills/dev3/`, `~/.claude/skills/dev3-project-config/` |
 | Cursor Agent | `agent` | `~/.cursor/skills/dev3/`, `~/.cursor/skills/dev3-project-config/` |
 | Codex | `codex` | `~/.codex/skills/dev3/`, `~/.codex/skills/dev3-project-config/` |
-| Gemini CLI | `gemini` | `~/.gemini/skills/dev3/`, `~/.gemini/skills/dev3-project-config/` |
+| Gemini CLI | `gemini` | `~/.agents/skills/dev3/`, `~/.agents/skills/dev3-project-config/` |
 | OpenCode | — | `~/.opencode/skills/dev3/`, `~/.config/opencode/skills/dev3/`, `~/.opencode/skills/dev3-project-config/`, `~/.config/opencode/skills/dev3-project-config/` |
 
 ## Feature Matrix
@@ -69,6 +69,8 @@ The dev3 skill (`SKILL.md`) is installed into each agent's skill directory. Two 
 ### dev3-project-config (project configuration)
 
 A supplementary skill that teaches agents about `.dev3/config.json` and `.dev3/config.local.json`. Covers the schema, merge priority, when to create/modify config files, and CLI commands (`dev3 config show`, `dev3 config export`). Same content for all agents (no variant differences).
+
+For Gemini CLI specifically, dev-3.0 installs these managed skills only via the shared `~/.agents/skills/` alias. Gemini also discovers `~/.gemini/skills/`, but duplicating the same skill name in both user-scope directories triggers same-tier conflict warnings and the alias already has precedence.
 
 ## Additional Integrations
 

--- a/change-logs/2026/04/02/fix-gemini-skill-alias-conflicts.md
+++ b/change-logs/2026/04/02/fix-gemini-skill-alias-conflicts.md
@@ -1,0 +1,1 @@
+Stop installing managed `dev3` and `dev3-project-config` skills into `~/.gemini/skills` now that Gemini CLI already loads the shared `~/.agents/skills` alias first. Startup and `dev3 install-skills` also remove stale Gemini-specific copies of those two managed skills so existing users stop seeing duplicate skill conflict warnings.

--- a/decisions/028-gemini-skill-alias-dedup.md
+++ b/decisions/028-gemini-skill-alias-dedup.md
@@ -1,0 +1,21 @@
+# Gemini Skill Alias Dedup
+
+## Context
+
+dev-3.0 was installing the managed `dev3` and `dev3-project-config` skills into both `~/.agents/skills/` and `~/.gemini/skills/`. Gemini CLI loads both user-scope directories, so users started seeing conflict warnings every session even though the skill content was identical.
+
+## Investigation
+
+Gemini CLI documents user-scope discovery in both `~/.gemini/skills/` and `~/.agents/skills/`, with the `.agents` alias taking precedence within the same tier. Its skill manager also emits a warning when one non-built-in skill overrides another with the same name.
+
+## Decision
+
+Keep Gemini on the shared `~/.agents/skills/` alias only and stop writing managed dev3 skills into `~/.gemini/skills/`. `src/bun/agent-skills.ts` now handles this in `installAgentSkills()` and `cleanupLegacyGeminiSkillDuplicates()`, removing stale Gemini-specific copies of `dev3` and `dev3-project-config` after the shared alias files are installed.
+
+## Risks
+
+If a user intentionally customized `~/.gemini/skills/dev3*`, dev-3.0 will now delete those two managed directories once the shared alias copies exist. That is acceptable because these skills are generated and overwritten by dev-3.0 on startup, and the shared alias remains the active source for Gemini.
+
+## Alternatives considered
+
+Keep installing to both paths and tolerate the warnings: rejected because Gemini warns on every session and the duplicate path provides no benefit. Install only to `~/.gemini/skills/`: rejected because the shared `~/.agents/skills/` alias is already supported by Gemini and is the higher-precedence cross-agent location we use elsewhere.

--- a/src/bun/__tests__/agent-skills-install.test.ts
+++ b/src/bun/__tests__/agent-skills-install.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("installAgentSkills", () => {
+	let tempHome = "";
+
+	beforeEach(() => {
+		tempHome = mkdtempSync(join(tmpdir(), "dev3-agent-skills-"));
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	async function loadModule() {
+		const ensureCodexConfigFile = vi.fn();
+
+		vi.doMock("node:os", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("node:os")>();
+			return { ...actual, homedir: () => tempHome };
+		});
+		vi.doMock("../logger", () => ({
+			createLogger: () => ({
+				info: vi.fn(),
+				warn: vi.fn(),
+			}),
+		}));
+		vi.doMock("../codex-config", () => ({
+			ensureCodexConfigFile,
+		}));
+
+		const mod = await import("../agent-skills");
+		return { installAgentSkills: mod.installAgentSkills, ensureCodexConfigFile };
+	}
+
+	it("removes legacy Gemini-specific copies when shared .agents skills are installed", async () => {
+		mkdirSync(join(tempHome, ".gemini/skills/dev3"), { recursive: true });
+		writeFileSync(join(tempHome, ".gemini/skills/dev3/SKILL.md"), "legacy dev3", "utf-8");
+		mkdirSync(join(tempHome, ".gemini/skills/dev3-project-config"), { recursive: true });
+		writeFileSync(
+			join(tempHome, ".gemini/skills/dev3-project-config/SKILL.md"),
+			"legacy project config",
+			"utf-8",
+		);
+
+		const { installAgentSkills, ensureCodexConfigFile } = await loadModule();
+		installAgentSkills();
+
+		expect(existsSync(join(tempHome, ".agents/skills/dev3/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempHome, ".agents/skills/dev3-project-config/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempHome, ".gemini/skills/dev3"))).toBe(false);
+		expect(existsSync(join(tempHome, ".gemini/skills/dev3-project-config"))).toBe(false);
+		expect(ensureCodexConfigFile).toHaveBeenCalledWith(tempHome);
+	});
+});

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { createLogger } from "./logger";
 import { ensureCodexConfigFile } from "./codex-config";
@@ -202,7 +202,6 @@ const CODEX_SKILL_DIR = ".codex/skills/dev3";
 const GENERIC_SKILL_DIRS = [
 	".cursor/skills/dev3",
 	".agents/skills/dev3",
-	".gemini/skills/dev3",
 	".opencode/skills/dev3",
 	".config/opencode/skills/dev3",
 ];
@@ -364,9 +363,19 @@ const GENERIC_PROJECT_CONFIG_DIRS = [
 	".cursor/skills/dev3-project-config",
 	".agents/skills/dev3-project-config",
 	".codex/skills/dev3-project-config",
-	".gemini/skills/dev3-project-config",
 	".opencode/skills/dev3-project-config",
 	".config/opencode/skills/dev3-project-config",
+];
+
+const LEGACY_GEMINI_SKILL_DUPLICATES = [
+	{
+		agentsSkillFile: ".agents/skills/dev3/SKILL.md",
+		geminiSkillDir: ".gemini/skills/dev3",
+	},
+	{
+		agentsSkillFile: ".agents/skills/dev3-project-config/SKILL.md",
+		geminiSkillDir: ".gemini/skills/dev3-project-config",
+	},
 ];
 
 // ---- ~/.agents/AGENTS.md rule block ----
@@ -467,6 +476,30 @@ function ensureClaudePermission(): void {
 	}
 }
 
+function cleanupLegacyGeminiSkillDuplicates(home: string): void {
+	for (const entry of LEGACY_GEMINI_SKILL_DUPLICATES) {
+		const agentsSkillFile = `${home}/${entry.agentsSkillFile}`;
+		const geminiSkillDir = `${home}/${entry.geminiSkillDir}`;
+
+		if (!existsSync(agentsSkillFile) || !existsSync(geminiSkillDir)) {
+			continue;
+		}
+
+		try {
+			rmSync(geminiSkillDir, { recursive: true, force: true });
+			log.info("Removed legacy Gemini skill duplicate", {
+				path: geminiSkillDir,
+				replacedBy: agentsSkillFile,
+			});
+		} catch (err) {
+			log.warn("Failed to remove legacy Gemini skill duplicate (non-fatal)", {
+				path: geminiSkillDir,
+				error: String(err),
+			});
+		}
+	}
+}
+
 /**
  * Install the dev3 skill into all supported AI agent directories
  * and update ~/.agents/AGENTS.md.
@@ -549,6 +582,7 @@ export function installAgentSkills(): void {
 		}
 	}
 
+	cleanupLegacyGeminiSkillDuplicates(home);
 	installAgentsMd();
 	ensureClaudePermission();
 	ensureCodexConfigFile(home);

--- a/src/cli/__tests__/install-skills.test.ts
+++ b/src/cli/__tests__/install-skills.test.ts
@@ -35,8 +35,8 @@ describe("install-skills", () => {
 		expect(stdoutOutput).toContain(".cursor/skills/dev3/SKILL.md");
 		expect(stdoutOutput).toContain(".agents/skills/dev3/SKILL.md");
 		expect(stdoutOutput).toContain(".codex/skills/dev3/SKILL.md");
-		expect(stdoutOutput).toContain(".gemini/skills/dev3/SKILL.md");
 		expect(stdoutOutput).toContain(".opencode/skills/dev3/SKILL.md");
+		expect(stdoutOutput).not.toContain(".gemini/skills/dev3/SKILL.md");
 		expect(stdoutOutput).toContain("AGENTS.md");
 		expect(stdoutOutput).toContain("settings.json");
 		expect(stdoutOutput).toContain("config.toml");

--- a/src/cli/commands/install-skills.ts
+++ b/src/cli/commands/install-skills.ts
@@ -6,7 +6,6 @@ const SKILL_PATHS = [
 	".cursor/skills/dev3/SKILL.md",
 	".agents/skills/dev3/SKILL.md",
 	".codex/skills/dev3/SKILL.md",
-	".gemini/skills/dev3/SKILL.md",
 	".opencode/skills/dev3/SKILL.md",
 	".config/opencode/skills/dev3/SKILL.md",
 ];


### PR DESCRIPTION
## Summary
- stop installing managed dev3 Gemini skills into ~/.gemini/skills when ~/.agents/skills already covers Gemini
- remove stale legacy Gemini-specific dev3 skill directories during skill installation
- update docs and tests for the new Gemini skill alias behavior

## Testing
- bun run lint
- bun run test