### PR TITLE
docs: define decision-first agent response format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,17 @@ When replying to the user, optimize for fast scanning and minimum necessary text
 
 Rules:
 - Start with the answer or decision, not with setup or filler.
-- Use at most 3 short sections when structure helps: `Decision:`, `Why:`, `Next:`.
+- Use fixed ASCII section dividers for scan-friendly structure when sections are present:
+  `========== [DECISION] ==========`
+  `========== [WHY] ==========`
+  `========== [NEXT] ==========`
+  `========== [TEST INSTRUCTIONS] ==========`
 - Keep each section to 1-2 short paragraphs or a flat list of concrete steps.
 - Prefer short sentences, concrete nouns, and direct verbs.
 - Do not repeat the same point in different words.
 - Do not add background unless it changes the decision.
 - For code changes, always end the final reply with a short `## Test instructions` block.
+- Keep the section labels uppercase and the divider format identical every time.
 - If a sentence does not add new information, remove it.
 - Aim for something the user can read in 10-15 seconds for normal task updates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,22 @@ This file provides guidance to AI coding agents when working with code in this r
 
 > **Note:** `CLAUDE.md` is a symbolic link to this file (`AGENTS.md`). This is intentional — it ensures all agents (Claude Code, Cursor, Codex, etc.) read the same instructions regardless of which filename convention they follow. If you see both files changed in a diff, that's expected.
 
+## Response style
+
+**Default writing style: Concise.**
+
+When replying to the user, optimize for fast scanning and minimum necessary text.
+
+Rules:
+- Start with the answer or decision, not with setup or filler.
+- Use at most 3 short sections when structure helps: `Decision:`, `Why:`, `Next:`.
+- Keep each section to 1-2 short paragraphs or a flat list of concrete steps.
+- Prefer short sentences, concrete nouns, and direct verbs.
+- Do not repeat the same point in different words.
+- Do not add background unless it changes the decision.
+- If a sentence does not add new information, remove it.
+- Aim for something the user can read in 10-15 seconds for normal task updates.
+
 ## What is this
 
 A **terminal-centric project manager** — iTerm2 meets Kanban. Desktop app for managing multiple AI coding agents and terminal-based tools across tasks and projects. Built with **Electrobun** (not Electron), React 18, Tailwind CSS, and Vite. Runtime is Bun. Supports **macOS and Linux** (Windows support is planned).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,23 +6,27 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Response style
 
-**Default writing style: Concise.**
+**Default writing style: Decision-First.**
 
 When replying to the user, optimize for fast scanning and minimum necessary text.
 
 Rules:
-- Start with the answer or decision, not with setup or filler.
-- Use fixed ASCII section dividers for scan-friendly structure when sections are present:
-  `========== [DECISION] ==========`
-  `========== [WHY] ==========`
-  `========== [NEXT] ==========`
-  `========== [TEST INSTRUCTIONS] ==========`
-- Keep each section to 1-2 short paragraphs or a flat list of concrete steps.
+- Use this section order when structure is needed:
+  `============= [CANDIDATES] =============`
+  `============== [DECISION] ==============`
+  `================ [WHY] =================`
+  `================ [NEXT] ================`
+- Show `2-5` candidates in `CANDIDATES`.
+- Mark the selected candidate with `(chosen)`.
+- Each candidate may use up to 5 short lines.
+- `CANDIDATES` is for concise option framing, not full justification.
+- `DECISION` is where the chosen option is explained in more detail.
+- Keep each section to short paragraphs or a flat list of concrete steps.
 - Prefer short sentences, concrete nouns, and direct verbs.
 - Do not repeat the same point in different words.
 - Do not add background unless it changes the decision.
-- For code changes, always end the final reply with a short `## Test instructions` block.
-- Keep the section labels uppercase and the divider format identical every time.
+- For code changes, always end the final reply with the repo-mandated `## Test instructions` block.
+- Keep the section labels uppercase and the divider width visually consistent every time.
 - If a sentence does not add new information, remove it.
 - Aim for something the user can read in 10-15 seconds for normal task updates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Rules:
 - Prefer short sentences, concrete nouns, and direct verbs.
 - Do not repeat the same point in different words.
 - Do not add background unless it changes the decision.
+- For code changes, always end the final reply with a short `## Test instructions` block.
 - If a sentence does not add new information, remove it.
 - Aim for something the user can read in 10-15 seconds for normal task updates.
 

--- a/change-logs/2026/04/06/docs-concise-agent-writing-style.md
+++ b/change-logs/2026/04/06/docs-concise-agent-writing-style.md
@@ -1,0 +1,1 @@
+Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, keep structure minimal, and avoid filler.

--- a/change-logs/2026/04/06/docs-concise-agent-writing-style.md
+++ b/change-logs/2026/04/06/docs-concise-agent-writing-style.md
@@ -1,1 +1,1 @@
-Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, keep structure minimal, and avoid filler.
+Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, keep structure minimal, avoid filler, and still end code-change replies with a short `## Test instructions` block.

--- a/change-logs/2026/04/06/docs-concise-agent-writing-style.md
+++ b/change-logs/2026/04/06/docs-concise-agent-writing-style.md
@@ -1,1 +1,1 @@
-Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, keep structure minimal, avoid filler, and still end code-change replies with a short `## Test instructions` block.
+Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, use fixed `========== [SECTION] ==========` ASCII dividers, avoid filler, and still end code-change replies with a short `## Test instructions` block.

--- a/change-logs/2026/04/06/docs-concise-agent-writing-style.md
+++ b/change-logs/2026/04/06/docs-concise-agent-writing-style.md
@@ -1,1 +1,1 @@
-Added a top-level AGENTS.md rule for a concise default response style. The guidance now tells agents to lead with the decision, use fixed `========== [SECTION] ==========` ASCII dividers, avoid filler, and still end code-change replies with a short `## Test instructions` block.
+Updated the top-level AGENTS.md response-style rule to a Decision-First format. The default now uses ordered `CANDIDATES`, `DECISION`, `WHY`, and `NEXT` sections with equal-width ASCII dividers, plus the repo-mandated `## Test instructions` block for code changes.


### PR DESCRIPTION
## Summary
- add a top-level AGENTS.md rule for the default agent response style
- switch the default to a decision-first structure with `CANDIDATES`, `DECISION`, `WHY`, and `NEXT`
- document equal-width ASCII dividers and keep the repo-mandated `## Test instructions` block for code changes

## Testing
- bun run lint
- bun run test