### PR TITLE
feat: add cleanup lifecycle env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ Each project has three lifecycle scripts, configurable in Project Settings (`src
 |---|---|
 | `setupScript` | After a new worktree is created for a task |
 | `devScript` | When starting the dev server for the project (not yet wired up — reserved for future use) |
-| `cleanupScript` | When a task is moved to `cancelled` status (and `archived` once that status is added) |
+| `cleanupScript` | Before a task worktree is removed after `completed` or `cancelled` (and `archived` once that status is added) |
 
 All three are free-form shell scripts. They are saved via the `updateProjectSettings` RPC handler in `src/bun/rpc-handlers.ts`.
 

--- a/change-logs/2026/04/06/feature-task-completion-hook-env.md
+++ b/change-logs/2026/04/06/feature-task-completion-hook-env.md
@@ -1,0 +1,3 @@
+Cleanup Script now runs as a teardown hook for completed and cancelled tasks with lifecycle env vars such as DEV3_TASK_STATUS, DEV3_TASK_FROM_STATUS, DEV3_TASK_TO_STATUS, DEV3_PROJECT_PATH, and DEV3_WORKTREE_PATH. Project Settings text and agent-facing docs now describe the real behavior, and a new tip highlights branching cleanup logic by task status.
+
+Suggested by @genrym (h0x91b/dev-3.0#361)

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1016,7 +1016,10 @@ describe("task.move", () => {
 
 		expect(resp.ok).toBe(true);
 		expect(pty.destroySession).toHaveBeenCalledWith(task.id, undefined);
-		expect(runCleanupScript).toHaveBeenCalledWith(task, project);
+		expect(runCleanupScript).toHaveBeenCalledWith(task, project, {
+			fromStatus: "in-progress",
+			toStatus: "completed",
+		});
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, {
 			status: "completed",
@@ -1070,7 +1073,10 @@ describe("task.move", () => {
 
 		expect(resp.ok).toBe(true);
 		expect(pty.destroySession).toHaveBeenCalled();
-		expect(runCleanupScript).toHaveBeenCalled();
+		expect(runCleanupScript).toHaveBeenCalledWith(task, project, {
+			fromStatus: "in-progress",
+			toStatus: "cancelled",
+		});
 		expect(git.removeWorktree).toHaveBeenCalled();
 	});
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -210,6 +210,7 @@ const {
 	triggerColumnAgentIfNeeded,
 	notifyWatchedTaskStatusChange,
 	emitTaskSound,
+	runCleanupScript,
 } = await import("../rpc-handlers");
 
 // ---- Test helpers ----
@@ -314,6 +315,49 @@ describe("handleBellAutoStatus", () => {
 		vi.mocked(data.loadTasks).mockResolvedValue([]);
 
 		await expect(handleBellAutoStatus("unknown-task")).resolves.toBeUndefined();
+	});
+});
+
+describe("runCleanupScript", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSpawn.mockReturnValue({
+			stdout: new Response(""),
+			stderr: new Response(""),
+			exited: Promise.resolve(0),
+		});
+	});
+
+	it("passes lifecycle env vars to the cleanup shell", async () => {
+		const project = makeProject({ path: "/tmp/project-root", name: "Alpha Project", cleanupScript: "echo cleanup" });
+		const task = makeTask({
+			id: "task-123",
+			title: "Ship it",
+			worktreePath: "/tmp/test-worktree",
+			status: "in-progress",
+		});
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		await runCleanupScript(task, project, {
+			fromStatus: "in-progress",
+			toStatus: "completed",
+		});
+
+		expect(mockSpawn).toHaveBeenCalledTimes(1);
+		expect(mockSpawn.mock.calls[0]?.[1]).toMatchObject({
+			cwd: "/tmp/test-worktree",
+			env: expect.objectContaining({
+				TERM: "xterm-256color",
+				DEV3_TASK_TITLE: "Ship it",
+				DEV3_TASK_ID: "task-123",
+				DEV3_PROJECT_NAME: "Alpha Project",
+				DEV3_PROJECT_PATH: "/tmp/project-root",
+				DEV3_WORKTREE_PATH: "/tmp/test-worktree",
+				DEV3_TASK_STATUS: "completed",
+				DEV3_TASK_FROM_STATUS: "in-progress",
+				DEV3_TASK_TO_STATUS: "completed",
+			}),
+		});
 	});
 });
 
@@ -4830,4 +4874,3 @@ describe("toggleTaskWatch", () => {
 		expect(result.watched).toBe(false);
 	});
 });
-

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -258,7 +258,7 @@ is genuinely ambiguous (e.g., multiple possible dev servers, unclear base branch
    |-------|-----------------|
    | \`setupScript\` | Package manager install command. Detect from lockfile: \`bun.lockb\` → \`bun install\`, \`pnpm-lock.yaml\` → \`pnpm install\`, \`yarn.lock\` → \`yarn\`, \`package-lock.json\` → \`npm install\`. For Python: \`pip install -e .\` or \`poetry install\`. For Rust: \`cargo build\`. Chain multiple steps with \`&&\` if needed. |
    | \`devScript\` | The dev server command. Check \`package.json\` scripts for \`dev\`, \`start\`, \`serve\`. Use the full command: \`bun run dev\`, \`npm run dev\`, etc. If no dev server exists, leave empty. |
-   | \`cleanupScript\` | Clean build artifacts and caches. E.g., \`rm -rf node_modules/.cache dist .next\`. Tailor to what the project actually generates. If unsure, leave empty. |
+   | \`cleanupScript\` | Teardown hook that runs before the task worktree is removed after \`completed\` or \`cancelled\`. Useful for copy-back, exports, and cache cleanup. Inside the script you can branch on \`$DEV3_TASK_STATUS\`, \`$DEV3_TASK_FROM_STATUS\`, and \`$DEV3_TASK_TO_STATUS\`. |
    | \`clonePaths\` | Heavy directories that should be CoW-cloned into new worktrees instead of re-downloaded. Common: \`node_modules\`, \`.venv\`, \`target\`, \`.next\`, \`build\`. Only include dirs that actually exist in the project. |
    | \`defaultBaseBranch\` | Check \`git symbolic-ref refs/remotes/origin/HEAD\` or look at common branches. Usually \`main\` or \`master\`. |
    | \`defaultCompareRefMode\` | Default diff comparison target. Use \`"remote"\` for \`origin/<baseBranch>\` (recommended default) or \`"local"\` for the local base branch. |
@@ -318,7 +318,7 @@ EOF
 |-------|------|-------------|
 | \`setupScript\` | string | Runs after a new worktree is created (install deps, generate code, etc.) |
 | \`devScript\` | string | Dev server command (powers the "Dev Server" button in the UI) |
-| \`cleanupScript\` | string | Runs when a task is cancelled or archived |
+| \`cleanupScript\` | string | Runs before the task worktree is removed after \`completed\` or \`cancelled\` |
 | \`clonePaths\` | string[] | Dirs to CoW-clone into worktrees (faster than re-downloading) |
 | \`defaultBaseBranch\` | string | Base branch for new task branches (default: \`main\`) |
 | \`defaultCompareRefMode\` | \`"remote" \| "local"\` | Default diff comparison target (\`origin/<baseBranch>\` vs local base branch) |

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -489,7 +489,12 @@ const handlers: Record<string, Handler> = {
 		if (isActive(oldStatus) && (builtinStatus === "completed" || builtinStatus === "cancelled")) {
 			emitTaskSound(builtinStatus as "completed" | "cancelled");
 			try { pty.destroySession(task.id, task.tmuxSocket ?? undefined); } catch {}
-			try { await runCleanupScript(task, project); } catch {}
+			try {
+				await runCleanupScript(task, project, {
+					fromStatus: oldStatus,
+					toStatus: builtinStatus,
+				});
+			} catch {}
 			try { await git.removeWorktree(project, task); } catch {}
 
 			const updated = await data.updateTask(project, task.id, {

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -93,7 +93,35 @@ export async function isTaskInProgress(taskId: string): Promise<boolean> {
 
 const DEFAULT_CLEANUP_SCRIPT = 'echo "Task finished"';
 
-export async function runCleanupScript(task: Task, project: Project): Promise<void> {
+type CleanupTransition = {
+	fromStatus: TaskStatus;
+	toStatus: Extract<TaskStatus, "completed" | "cancelled">;
+};
+
+function buildCleanupScriptEnv(
+	task: Task,
+	project: Project,
+	transition: CleanupTransition,
+): Record<string, string> {
+	return {
+		TERM: "xterm-256color",
+		HOME: process.env.HOME || "/",
+		DEV3_TASK_TITLE: task.title,
+		DEV3_TASK_ID: task.id,
+		DEV3_PROJECT_NAME: project.name,
+		DEV3_PROJECT_PATH: project.path,
+		DEV3_WORKTREE_PATH: task.worktreePath || "",
+		DEV3_TASK_STATUS: transition.toStatus,
+		DEV3_TASK_FROM_STATUS: transition.fromStatus,
+		DEV3_TASK_TO_STATUS: transition.toStatus,
+	};
+}
+
+export async function runCleanupScript(
+	task: Task,
+	project: Project,
+	transition: CleanupTransition,
+): Promise<void> {
 	if (!task.worktreePath) return;
 
 	if (!existsSync(task.worktreePath)) {
@@ -119,7 +147,7 @@ export async function runCleanupScript(task: Task, project: Project): Promise<vo
 		cleanupArgs,
 		{
 			terminal: { cols: 220, rows: 50, data: () => {} },
-			env: { TERM: "xterm-256color", HOME: process.env.HOME || "/" },
+			env: buildCleanupScriptEnv(task, project, transition),
 			cwd: task.worktreePath,
 		},
 	);
@@ -292,7 +320,10 @@ async function moveTask(params: { taskId: string; projectId: string; newStatus: 
 
 			try {
 				log.info("Running cleanup script before removing worktree", { taskId: task.id });
-				await runCleanupScript(task, project);
+				await runCleanupScript(task, project, {
+					fromStatus: oldStatus,
+					toStatus: newStatus,
+				});
 			} catch (err) {
 				log.error("Cleanup script failed, continuing with task move", {
 					taskId: task.id,

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -141,7 +141,7 @@ const settings = {
 		"Runs when starting the dev server for this project",
 	"projectSettings.cleanupScript": "Cleanup Script",
 	"projectSettings.cleanupScriptDesc":
-		"Runs when a task is moved to Cancelled (or Archived in the future)",
+		"Runs before the worktree is removed after a task is marked Completed or Cancelled",
 	"projectSettings.clonePaths": "Clone Paths (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Directories and files to clone from the root project into each worktree using Copy-on-Write (instant, no disk space duplication on APFS/btrfs). Falls back to regular copy on unsupported filesystems.",
 	"projectSettings.addClonePath": "Add Path",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.languageSwitching.body": "Open global settings to switch between English, Russian, and Spanish — your choice is remembered across sessions.",
 	"tip.setupScriptPanes.title": "Setup can block startup",
 	"tip.setupScriptPanes.body": "In Project Config -> Setup Script, choose whether the agent launches immediately or waits for setup to finish.",
+	"tip.cleanupScriptStatus.title": "Cleanup sees task status",
+	"tip.cleanupScriptStatus.body": "Use $DEV3_TASK_STATUS in Cleanup Script to branch between completed and cancelled teardown steps.",
 	"tip.customTaskTitle.title": "Rename any task",
 	"tip.customTaskTitle.body": "Task titles are auto-generated from the first words of the description so you don't fill two fields. But you can always click the title to set a custom name.",
 	"tip.spawnExtraAgent.title": "Run multiple agents on one task",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -141,7 +141,7 @@ const settings = {
 		"Se ejecuta al iniciar el servidor de desarrollo de este proyecto",
 	"projectSettings.cleanupScript": "Script de limpieza",
 	"projectSettings.cleanupScriptDesc":
-		"Se ejecuta cuando una tarea se mueve a Cancelled (o Archived en el futuro)",
+		"Se ejecuta antes de eliminar el worktree cuando una tarea se marca como Completed o Cancelled",
 	"projectSettings.clonePaths": "Rutas de clonación (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Directorios y archivos que se clonan del proyecto raíz a cada worktree usando Copy-on-Write (instantáneo, sin duplicar espacio en APFS/btrfs). En sistemas de archivos no compatibles se hace una copia normal.",
 	"projectSettings.addClonePath": "Agregar ruta",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.languageSwitching.body": "Abre los ajustes globales para cambiar entre inglés, ruso y español — tu elección se recuerda entre sesiones.",
 	"tip.setupScriptPanes.title": "El setup puede bloquear el inicio",
 	"tip.setupScriptPanes.body": "En Config del proyecto -> Script de configuración, elige si el agente arranca ya o espera al setup.",
+	"tip.cleanupScriptStatus.title": "Cleanup ve el estado",
+	"tip.cleanupScriptStatus.body": "Usa $DEV3_TASK_STATUS en Cleanup Script para separar pasos de completed y cancelled.",
 	"tip.customTaskTitle.title": "Renombra cualquier tarea",
 	"tip.customTaskTitle.body": "El título se genera automáticamente a partir de las primeras palabras de la descripción para no llenar dos campos. Pero siempre puedes hacer clic en el título para personalizarlo.",
 	"tip.spawnExtraAgent.title": "Varios agentes en una tarea",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -141,7 +141,7 @@ const settings = {
 		"Запускается при старте dev-сервера для этого проекта",
 	"projectSettings.cleanupScript": "Скрипт очистки",
 	"projectSettings.cleanupScriptDesc":
-		"Запускается при переводе таски в статус Cancelled (или Archived в будущем)",
+		"Запускается перед удалением worktree, когда задача помечена как Completed или Cancelled",
 	"projectSettings.clonePaths": "Clone-пути (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Директории и файлы, которые клонируются из корневого проекта в каждый worktree через Copy-on-Write (мгновенно, без дублирования на APFS/btrfs). На неподдерживаемых ФС делается обычная копия.",
 	"projectSettings.addClonePath": "Добавить путь",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -120,6 +120,8 @@ const tips = {
 	"tip.languageSwitching.body": "Откройте глобальные настройки, чтобы выбрать English, Русский или Español — выбор сохраняется между сессиями.",
 	"tip.setupScriptPanes.title": "Setup может блокировать старт",
 	"tip.setupScriptPanes.body": "В Конфиге проекта -> Скрипт настройки выберите: запускать агента сразу или ждать завершения setup-скрипта.",
+	"tip.cleanupScriptStatus.title": "Cleanup видит статус",
+	"tip.cleanupScriptStatus.body": "Используйте $DEV3_TASK_STATUS в Cleanup Script, чтобы развести шаги для completed и cancelled.",
 	"tip.customTaskTitle.title": "Переименуйте любую задачу",
 	"tip.customTaskTitle.body": "Название задачи автоматически берётся из первых слов описания, чтобы не заполнять два поля. Но вы всегда можете нажать на заголовок и задать своё название.",
 	"tip.spawnExtraAgent.title": "Несколько агентов на одну задачу",

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -368,6 +368,12 @@ const ALL_TIPS: Tip[] = [
 		icon: "\u{F0259}", // nf-md-console
 	},
 	{
+		id: "cleanup-script-status",
+		titleKey: "tip.cleanupScriptStatus.title",
+		bodyKey: "tip.cleanupScriptStatus.body",
+		icon: "\u{F0259}", // nf-md-console
+	},
+	{
 		id: "custom-task-title",
 		titleKey: "tip.customTaskTitle.title",
 		bodyKey: "tip.customTaskTitle.body",


### PR DESCRIPTION
## Summary
- add lifecycle env vars to Cleanup Script for completed and cancelled teardown runs
- keep cleanup behavior aligned across RPC and CLI completion paths
- update settings/docs text and add a tip for status-aware cleanup scripts

## Testing
- bun run lint
- bun run test

Closes #361