### PR TITLE
chore: use RTK for test runner when available

### DIFF
--- a/change-logs/2026/04/06/chore-rtk-test-runner.md
+++ b/change-logs/2026/04/06/chore-rtk-test-runner.md
@@ -1,0 +1,1 @@
+Use RTK (Rust Token Killer) as the vitest runner when available, falling back to bunx otherwise. This reduces test output noise by 60-90% during local development while keeping CI behavior unchanged.

--- a/change-logs/2026/04/06/chore-rtk-test-runner.md
+++ b/change-logs/2026/04/06/chore-rtk-test-runner.md
@@ -1,1 +1,1 @@
-Use RTK (Rust Token Killer) as the vitest runner when available, falling back to bunx otherwise. This reduces test output noise by 60-90% during local development while keeping CI behavior unchanged.
+Use RTK (Rust Token Killer) as the vitest runner when available, falling back to bunx otherwise. Applies to all test scripts: `test`, `test:full`, `test:bun`, `test:cli`. This reduces test output noise by ~90% during local development while keeping CI behavior unchanged.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build:cli": "bun build src/cli/main.ts --compile --outfile dist/dev3",
 		"start": "bun scripts/generate-build-info.ts && bun scripts/generate-changelog.ts && bun run build:cli && electrobun build && electrobun dev",
 		"lint": "bun scripts/lint.ts",
-		"test": "concurrently --group --names mainview,bun \"vitest run --exclude '**/shift-keys-e2e*'\" \"vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*'\"",
+		"test": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && concurrently --group --names mainview,bun \"$VT vitest run --exclude '**/shift-keys-e2e*'\" \"$VT vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*'\"",
 		"test:full": "concurrently --group --names mainview,bun \"vitest run\" \"vitest run --config vitest.config.bun.ts\"",
 		"test:bun": "vitest run --config vitest.config.bun.ts",
 		"test:cli": "vitest run --config vitest.config.cli.ts",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
 		"start": "bun scripts/generate-build-info.ts && bun scripts/generate-changelog.ts && bun run build:cli && electrobun build && electrobun dev",
 		"lint": "bun scripts/lint.ts",
 		"test": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && concurrently --group --names mainview,bun \"$VT vitest run --exclude '**/shift-keys-e2e*'\" \"$VT vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*'\"",
-		"test:full": "concurrently --group --names mainview,bun \"vitest run\" \"vitest run --config vitest.config.bun.ts\"",
-		"test:bun": "vitest run --config vitest.config.bun.ts",
-		"test:cli": "vitest run --config vitest.config.cli.ts",
+		"test:full": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && concurrently --group --names mainview,bun \"$VT vitest run\" \"$VT vitest run --config vitest.config.bun.ts\"",
+		"test:bun": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.bun.ts",
+		"test:cli": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.cli.ts",
 		"test:pane-e2e": "bun --preload ./src/bun/__tests__/pane-exit-e2e-preload.ts src/bun/__tests__/pane-exit-e2e.ts",
 		"test:watch": "vitest",
 		"bump": "bun run scripts/bump.ts"


### PR DESCRIPTION
## Summary

- `bun run test` now detects RTK (Rust Token Killer) at runtime and uses it as the vitest runner when available
- Falls back to `bunx` when RTK is not installed (CI, other devs)
- Reduces local test output noise by ~90% while preserving full failure details