### PR TITLE
Fix Unicode Git filenames

### DIFF
--- a/change-logs/2026/04/11/fix-git-unicode-filenames.md
+++ b/change-logs/2026/04/11/fix-git-unicode-filenames.md
@@ -1,1 +1,3 @@
 Fixed Git-backed filename handling so Unicode and Cyrillic paths stay readable in branch diff stats and untracked file scans instead of showing escaped octal sequences. Added regression tests with a real Git repo to cover both branch diffs and untracked files.
+
+Added and committed a repository file with a Russian filename to validate the end-to-end flow with a real tracked path.

--- a/change-logs/2026/04/11/fix-git-unicode-filenames.md
+++ b/change-logs/2026/04/11/fix-git-unicode-filenames.md
@@ -1,0 +1,1 @@
+Fixed Git-backed filename handling so Unicode and Cyrillic paths stay readable in branch diff stats and untracked file scans instead of showing escaped octal sequences. Added regression tests with a real Git repo to cover both branch diffs and untracked files.

--- a/change-logs/2026/04/11/fix-git-unicode-filenames.md
+++ b/change-logs/2026/04/11/fix-git-unicode-filenames.md
@@ -1,3 +1,3 @@
 Fixed Git-backed filename handling so Unicode and Cyrillic paths stay readable in branch diff stats and untracked file scans instead of showing escaped octal sequences. Added regression tests with a real Git repo to cover both branch diffs and untracked files.
 
-Added and committed a repository file with a Russian filename to validate the end-to-end flow with a real tracked path.
+Temporarily added a Russian-named repository file to validate the tracked-path flow end to end, then removed it after verification.

--- a/src/bun/__tests__/git-unicode-filenames.test.ts
+++ b/src/bun/__tests__/git-unicode-filenames.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test",
+}));
+
+vi.mock("../spawn", async () => {
+	const { createSpawnMock } = await import("./git-test-helpers");
+	return createSpawnMock();
+});
+
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { createTestRepo, cleanup, g, type TestRepo } from "./git-test-helpers";
+import { getBranchDiffStats, getUncommittedChanges, _resetFetchState } from "../git";
+
+describe("git Unicode filenames", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+		_resetFetchState();
+		g("git config core.quotePath true", repo.local);
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("returns branch diff filenames as readable Unicode paths", async () => {
+		g("git checkout -b fix/unicode-diff-names", repo.local);
+		writeFileSync(join(repo.local, "Справочник.md"), "hello\n");
+		g("git add Справочник.md", repo.local);
+		g('git commit -m "add unicode file"', repo.local);
+
+		const result = await getBranchDiffStats(repo.local, "origin/main");
+
+		expect(result.files).toBe(1);
+		expect(result.fileNames).toEqual(["Справочник.md"]);
+	});
+
+	it("counts untracked Unicode files in uncommitted stats", async () => {
+		writeFileSync(join(repo.local, "Индекс.md"), "line 1\nline 2\n");
+
+		const result = await getUncommittedChanges(repo.local);
+
+		expect(result.insertions).toBe(2);
+		expect(result.deletions).toBe(0);
+	});
+});

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -37,12 +37,20 @@ type DiffRenderSource =
 	| { kind: "git"; buildArgs: (entry: ParsedNameStatusEntry) => string[] }
 	| { kind: "file" };
 
+function withGitFilenameEncoding(cmd: string[]): string[] {
+	if (cmd[0] !== "git") {
+		return cmd;
+	}
+	return ["git", "-c", "core.quotepath=false", ...cmd.slice(1)];
+}
+
 export async function run(
 	cmd: string[],
 	cwd: string,
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
-	log.debug(`exec: ${cmd.join(" ")}`, { cwd });
-	const proc = spawn(cmd, {
+	const finalCmd = withGitFilenameEncoding(cmd);
+	log.debug(`exec: ${finalCmd.join(" ")}`, { cwd });
+	const proc = spawn(finalCmd, {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
@@ -54,7 +62,7 @@ export async function run(
 	const code = await proc.exited;
 	const result = { ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() };
 	if (!result.ok) {
-		log.warn(`Command failed (exit ${code}): ${cmd.join(" ")}`, {
+		log.warn(`Command failed (exit ${code}): ${finalCmd.join(" ")}`, {
 			stderr: result.stderr,
 		});
 	}
@@ -65,8 +73,9 @@ async function runBinary(
 	cmd: string[],
 	cwd: string,
 ): Promise<BinaryRunResult> {
-	log.debug(`exec(binary): ${cmd.join(" ")}`, { cwd });
-	const proc = spawn(cmd, {
+	const finalCmd = withGitFilenameEncoding(cmd);
+	log.debug(`exec(binary): ${finalCmd.join(" ")}`, { cwd });
+	const proc = spawn(finalCmd, {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
@@ -82,7 +91,7 @@ async function runBinary(
 		stderr: stderr.trim(),
 	};
 	if (!result.ok) {
-		log.warn(`Binary command failed (exit ${code}): ${cmd.join(" ")}`, {
+		log.warn(`Binary command failed (exit ${code}): ${finalCmd.join(" ")}`, {
 			stderr: result.stderr,
 		});
 	}
@@ -93,8 +102,9 @@ async function runWithCode(
 	cmd: string[],
 	cwd: string,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
-	log.debug(`exec(code): ${cmd.join(" ")}`, { cwd });
-	const proc = spawn(cmd, {
+	const finalCmd = withGitFilenameEncoding(cmd);
+	log.debug(`exec(code): ${finalCmd.join(" ")}`, { cwd });
+	const proc = spawn(finalCmd, {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",

--- a/Русский-файл.md
+++ b/Русский-файл.md
@@ -1,0 +1,1 @@
+This file verifies that the repository can store and commit a filename written in Russian.

--- a/Русский-файл.md
+++ b/Русский-файл.md
@@ -1,1 +1,0 @@
-This file verifies that the repository can store and commit a filename written in Russian.


### PR DESCRIPTION
## Summary
- force backend git wrapper calls to use `core.quotepath=false`
- add regression coverage for Unicode/Cyrillic paths in branch diff stats and untracked file scans
- document the fix in the changelog

## Testing
- bunx vitest run src/bun/__tests__/git-unicode-filenames.test.ts --config vitest.config.bun.ts
- bun run lint
- bun run test