### PR TITLE
Fix Codex hooks when dev3 app is offline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,16 @@ bun run build:prod
 
 Use `bun run lint` for the repository's TypeScript/type-check validation step before committing.
 
+## CLI exit codes
+
+Public `dev3` CLI exit codes are a documented contract.
+
+Rules:
+- Define them only in `src/shared/cli-exit-codes.ts`.
+- Keep every non-zero code unique.
+- Do not inline non-zero exit numbers in `src/cli/`.
+- Update `docs/cli-exit-codes.md` and `src/cli/__tests__/exit-codes.test.ts` whenever a code is added or changed.
+
 ## Architecture
 
 Two-process model:

--- a/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
+++ b/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
@@ -1,3 +1,3 @@
-Make generated Codex lifecycle hooks treat `dev3` exit code 2 ("app not running") as a non-blocking no-op, so prompt submission, Bash tool execution, and Stop still work when the desktop app is closed. The fallback is selective: other CLI failures still surface instead of being hidden, and the Stop hook now avoids zsh's read-only `status` variable so the shell wrapper does not crash with exit code 1.
+Make generated Codex lifecycle hooks treat `dev3` exit code 2 ("app not running") as a non-blocking no-op, so prompt submission, Bash tool execution, and Stop still work when the desktop app is closed. The fallback is selective: other CLI failures still surface instead of being hidden, the Stop hook now avoids zsh's read-only `status` variable so the shell wrapper does not crash with exit code 1, and the CLI now keeps its public exit codes in a shared registry plus `docs/cli-exit-codes.md`.
 
 Suggested by @AboMokh-Wix (h0x91b/dev-3.0#443)

--- a/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
+++ b/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
@@ -1,0 +1,3 @@
+Make generated Codex lifecycle hooks treat `dev3` exit code 2 ("app not running") as a non-blocking no-op, so prompt submission, Bash tool execution, and Stop still work when the desktop app is closed. The fallback is selective: other CLI failures still surface instead of being hidden.
+
+Suggested by @AboMokh-Wix (h0x91b/dev-3.0#443)

--- a/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
+++ b/change-logs/2026/04/12/fix-codex-hooks-app-offline.md
@@ -1,3 +1,3 @@
-Make generated Codex lifecycle hooks treat `dev3` exit code 2 ("app not running") as a non-blocking no-op, so prompt submission, Bash tool execution, and Stop still work when the desktop app is closed. The fallback is selective: other CLI failures still surface instead of being hidden.
+Make generated Codex lifecycle hooks treat `dev3` exit code 2 ("app not running") as a non-blocking no-op, so prompt submission, Bash tool execution, and Stop still work when the desktop app is closed. The fallback is selective: other CLI failures still surface instead of being hidden, and the Stop hook now avoids zsh's read-only `status` variable so the shell wrapper does not crash with exit code 1.
 
 Suggested by @AboMokh-Wix (h0x91b/dev-3.0#443)

--- a/decisions/032-codex-hooks-ignore-app-offline.md
+++ b/decisions/032-codex-hooks-ignore-app-offline.md
@@ -6,11 +6,11 @@ dev3-generated Codex hooks call `~/.dev3.0/bin/dev3 task move ...` from repo-loc
 
 ## Investigation
 
-Changing `exitAppNotRunning()` globally would make normal human CLI usage report success for a real failure, which is the wrong contract outside hooks. The bug is specific to generated Codex hook commands, so the fix needs to live in [src/shared/agent-hooks.ts](src/shared/agent-hooks.ts), not in the general CLI exit path in [src/cli/output.ts](src/cli/output.ts).
+Changing `exitAppNotRunning()` globally would make normal human CLI usage report success for a real failure, which is the wrong contract outside hooks. The bug is specific to generated Codex hook commands, so the fix needs to live in [src/shared/agent-hooks.ts](src/shared/agent-hooks.ts), not in the general CLI exit path in [src/cli/output.ts](src/cli/output.ts). During verification we also found the first Stop wrapper revision used `status=$?`, which crashes under zsh because `status` is a read-only special parameter there.
 
 ## Decision
 
-Codex `SessionStart`, `UserPromptSubmit`, and `PreToolUse` hooks now wrap `dev3 task move` with a shell fallback that only treats exit code `2` as success. The `Stop` hook keeps returning `{}` JSON, but now does so both on normal success and on the same app-offline exit code while still re-throwing any other failure status.
+Codex `SessionStart`, `UserPromptSubmit`, and `PreToolUse` hooks now wrap `dev3 task move` with a shell fallback that only treats exit code `2` as success. The `Stop` hook keeps returning `{}` JSON, but now does so both on normal success and on the same app-offline exit code while still re-throwing any other failure status, using a neutral shell variable name (`hook_exit_code`) that works in zsh.
 
 ## Risks
 

--- a/decisions/032-codex-hooks-ignore-app-offline.md
+++ b/decisions/032-codex-hooks-ignore-app-offline.md
@@ -1,0 +1,22 @@
+# 032 — Codex Hooks Ignore App-Offline Exit Code
+
+## Context
+
+dev3-generated Codex hooks call `~/.dev3.0/bin/dev3 task move ...` from repo-local `.codex/hooks.json`. When the desktop app is closed, the CLI exits with code `2` via `exitAppNotRunning()`, and Codex interprets that hook failure as an intentional block for prompt submission and tool execution.
+
+## Investigation
+
+Changing `exitAppNotRunning()` globally would make normal human CLI usage report success for a real failure, which is the wrong contract outside hooks. The bug is specific to generated Codex hook commands, so the fix needs to live in [src/shared/agent-hooks.ts](src/shared/agent-hooks.ts), not in the general CLI exit path in [src/cli/output.ts](src/cli/output.ts).
+
+## Decision
+
+Codex `SessionStart`, `UserPromptSubmit`, and `PreToolUse` hooks now wrap `dev3 task move` with a shell fallback that only treats exit code `2` as success. The `Stop` hook keeps returning `{}` JSON, but now does so both on normal success and on the same app-offline exit code while still re-throwing any other failure status.
+
+## Risks
+
+This relies on the CLI keeping `exitAppNotRunning()` on exit code `2`; if that code changes, the shell guard must be updated with it. The workaround is shell-string based, so future Codex hook execution changes could require revisiting quoting or exit-code handling.
+
+## Alternatives considered
+
+- Change `exitAppNotRunning()` to exit `0`: rejected because it would hide a real failure for normal CLI users and scripts.
+- Append `|| true` to generated Codex hooks: rejected because it would swallow unrelated errors and could mask real hook regressions.

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -1,0 +1,17 @@
+# CLI Exit Codes
+
+Public `dev3` CLI exit codes are defined in `src/shared/cli-exit-codes.ts`.
+
+| Code | Constant | Meaning |
+| --- | --- | --- |
+| `0` | `CLI_EXIT_CODE_SUCCESS` | Command completed successfully, or exited intentionally without an error (`--help`, `--version`). |
+| `1` | `CLI_EXIT_CODE_COMMAND_FAILED` | A handled command failure occurred after parsing succeeded. |
+| `2` | `CLI_EXIT_CODE_APP_NOT_RUNNING` | The desktop app or CLI socket was unavailable for a command that requires it. |
+| `3` | `CLI_EXIT_CODE_USAGE_ERROR` | The CLI invocation was invalid: bad command, bad subcommand, or missing required args. |
+| `4` | `CLI_EXIT_CODE_INTERNAL_ERROR` | An unexpected internal CLI failure escaped normal command handling. |
+
+Rules:
+
+- Every non-zero public `dev3` CLI exit code must be unique.
+- Add or change codes only in `src/shared/cli-exit-codes.ts`.
+- Keep this file and `src/cli/__tests__/exit-codes.test.ts` in sync with the registry.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -258,6 +258,7 @@ describe("buildCodexHooks", () => {
 		expect(cmd).toContain(DEV3_CLI);
 		expect(cmd).toContain("--status in-progress");
 		expect(cmd).toContain("--if-status-not review-by-ai");
+		expect(cmd).toContain("|| [ $? -eq 2 ]");
 	});
 
 	it("PreToolUse hook is scoped to Bash and moves to in-progress", () => {
@@ -269,6 +270,19 @@ describe("buildCodexHooks", () => {
 		expect(cmd).toContain(DEV3_CLI);
 		expect(cmd).toContain("--status in-progress");
 		expect(cmd).toContain("--if-status-not review-by-ai");
+		expect(cmd).toContain("|| [ $? -eq 2 ]");
+		expect(cmd).not.toContain("|| true");
+	});
+
+	it("UserPromptSubmit hook also ignores app-not-running without swallowing other failures", () => {
+		const hooks = buildCodexHooks();
+		const cmd = hooks.UserPromptSubmit[0].hooks[0].command;
+
+		expect(cmd).toContain(DEV3_CLI);
+		expect(cmd).toContain("--status in-progress");
+		expect(cmd).toContain("--if-status-not review-by-ai");
+		expect(cmd).toContain("|| [ $? -eq 2 ]");
+		expect(cmd).not.toContain("|| true");
 	});
 
 	it("Stop hook with review-by-ai stopTarget creates two matcher groups", () => {
@@ -278,21 +292,28 @@ describe("buildCodexHooks", () => {
 		expect(hooks.Stop[0].hooks[0].command).toContain("--status review-by-ai --if-status in-progress");
 		expect(hooks.Stop[0].hooks[0].command).toContain("--codex-stop-hook");
 		expect(hooks.Stop[0].hooks[0].command).toContain(">/dev/null");
+		expect(hooks.Stop[0].hooks[0].command).toContain('status=$?');
+		expect(hooks.Stop[0].hooks[0].command).toContain('[ "$status" -eq 2 ]');
 		expect(hooks.Stop[0].hooks[0].command).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
 		expect(hooks.Stop[1].hooks[0].command).toContain("--status review-by-user --if-status review-by-ai");
 		expect(hooks.Stop[1].hooks[0].command).toContain("--codex-stop-hook");
 		expect(hooks.Stop[1].hooks[0].command).toContain(">/dev/null");
+		expect(hooks.Stop[1].hooks[0].command).toContain('status=$?');
+		expect(hooks.Stop[1].hooks[0].command).toContain('[ "$status" -eq 2 ]');
 		expect(hooks.Stop[1].hooks[0].command).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
 	});
 
-	it("Stop hook wraps Codex move commands with a JSON success envelope", () => {
+	it("Stop hook wraps Codex move commands with a JSON success envelope and app-offline fallback", () => {
 		const hooks = buildCodexHooks();
 		const cmd = hooks.Stop[0].hooks[0].command;
 
 		expect(cmd).toContain("--status review-by-user --if-status in-progress");
 		expect(cmd).toContain("--codex-stop-hook");
 		expect(cmd).toContain(">/dev/null");
+		expect(cmd).toContain('status=$?');
+		expect(cmd).toContain('[ "$status" -eq 2 ]');
 		expect(cmd).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
+		expect(cmd).not.toContain("|| true");
 	});
 });
 

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -292,14 +292,14 @@ describe("buildCodexHooks", () => {
 		expect(hooks.Stop[0].hooks[0].command).toContain("--status review-by-ai --if-status in-progress");
 		expect(hooks.Stop[0].hooks[0].command).toContain("--codex-stop-hook");
 		expect(hooks.Stop[0].hooks[0].command).toContain(">/dev/null");
-		expect(hooks.Stop[0].hooks[0].command).toContain('status=$?');
-		expect(hooks.Stop[0].hooks[0].command).toContain('[ "$status" -eq 2 ]');
+		expect(hooks.Stop[0].hooks[0].command).toContain('hook_exit_code=$?');
+		expect(hooks.Stop[0].hooks[0].command).toContain('[ "$hook_exit_code" -eq 2 ]');
 		expect(hooks.Stop[0].hooks[0].command).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
 		expect(hooks.Stop[1].hooks[0].command).toContain("--status review-by-user --if-status review-by-ai");
 		expect(hooks.Stop[1].hooks[0].command).toContain("--codex-stop-hook");
 		expect(hooks.Stop[1].hooks[0].command).toContain(">/dev/null");
-		expect(hooks.Stop[1].hooks[0].command).toContain('status=$?');
-		expect(hooks.Stop[1].hooks[0].command).toContain('[ "$status" -eq 2 ]');
+		expect(hooks.Stop[1].hooks[0].command).toContain('hook_exit_code=$?');
+		expect(hooks.Stop[1].hooks[0].command).toContain('[ "$hook_exit_code" -eq 2 ]');
 		expect(hooks.Stop[1].hooks[0].command).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
 	});
 
@@ -310,8 +310,9 @@ describe("buildCodexHooks", () => {
 		expect(cmd).toContain("--status review-by-user --if-status in-progress");
 		expect(cmd).toContain("--codex-stop-hook");
 		expect(cmd).toContain(">/dev/null");
-		expect(cmd).toContain('status=$?');
-		expect(cmd).toContain('[ "$status" -eq 2 ]');
+		expect(cmd).toContain('hook_exit_code=$?');
+		expect(cmd).toContain('[ "$hook_exit_code" -eq 2 ]');
+		expect(cmd).not.toContain('status=$?');
 		expect(cmd).toContain(`printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`);
 		expect(cmd).not.toContain("|| true");
 	});

--- a/src/cli/__tests__/exit-codes.test.ts
+++ b/src/cli/__tests__/exit-codes.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CLI_EXIT_CODE_DEFINITIONS } from "../../shared/cli-exit-codes";
+
+const DOC_PATH = resolve(import.meta.dirname, "../../../docs/cli-exit-codes.md");
+
+describe("CLI exit code registry", () => {
+	it("uses unique non-zero exit codes", () => {
+		const nonZeroCodes = CLI_EXIT_CODE_DEFINITIONS
+			.map((def) => def.code)
+			.filter((code) => code !== 0);
+
+		expect(new Set(nonZeroCodes).size).toBe(nonZeroCodes.length);
+	});
+
+	it("documents every registered exit code in docs/cli-exit-codes.md", () => {
+		const doc = readFileSync(DOC_PATH, "utf-8");
+
+		for (const def of CLI_EXIT_CODE_DEFINITIONS) {
+			expect(doc).toContain(`\`${def.code}\``);
+			expect(doc).toContain(`\`${def.constant}\``);
+		}
+	});
+});

--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { printTable, printDetail, exitError, exitAppNotRunning, exitUsage } from "../output";
+import { printTable, printDetail, exitError, exitAppNotRunning, exitInternalError, exitUsage } from "../output";
+import {
+	CLI_EXIT_CODE_APP_NOT_RUNNING,
+	CLI_EXIT_CODE_COMMAND_FAILED,
+	CLI_EXIT_CODE_INTERNAL_ERROR,
+	CLI_EXIT_CODE_USAGE_ERROR,
+} from "../../shared/cli-exit-codes";
 
 let stdoutOutput: string;
 let stderrOutput: string;
@@ -115,10 +121,10 @@ describe("printDetail", () => {
 });
 
 describe("exitError", () => {
-	it("writes error to stderr and exits with code 1 by default", () => {
-		expect(() => exitError("something broke")).toThrow("EXIT_1");
+	it("writes error to stderr and exits with the default command-failed code", () => {
+		expect(() => exitError("something broke")).toThrow(`EXIT_${CLI_EXIT_CODE_COMMAND_FAILED}`);
 		expect(stderrOutput).toContain("error: something broke");
-		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_COMMAND_FAILED);
 	});
 
 	it("exits with custom code", () => {
@@ -135,17 +141,25 @@ describe("exitError", () => {
 });
 
 describe("exitAppNotRunning", () => {
-	it("exits with code 2 and app-not-running message", () => {
-		expect(() => exitAppNotRunning()).toThrow("EXIT_2");
+	it("exits with the app-not-running code and message", () => {
+		expect(() => exitAppNotRunning()).toThrow(`EXIT_${CLI_EXIT_CODE_APP_NOT_RUNNING}`);
 		expect(stderrOutput).toContain("app not running");
-		expect(exitSpy).toHaveBeenCalledWith(2);
+		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_APP_NOT_RUNNING);
 	});
 });
 
 describe("exitUsage", () => {
-	it("exits with code 3", () => {
-		expect(() => exitUsage("bad command")).toThrow("EXIT_3");
+	it("exits with the usage code", () => {
+		expect(() => exitUsage("bad command")).toThrow(`EXIT_${CLI_EXIT_CODE_USAGE_ERROR}`);
 		expect(stderrOutput).toContain("error: bad command");
-		expect(exitSpy).toHaveBeenCalledWith(3);
+		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_USAGE_ERROR);
+	});
+});
+
+describe("exitInternalError", () => {
+	it("exits with the internal-error code", () => {
+		expect(() => exitInternalError("boom")).toThrow(`EXIT_${CLI_EXIT_CODE_INTERNAL_ERROR}`);
+		expect(stderrOutput).toContain("error: boom");
+		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_INTERNAL_ERROR);
 	});
 });

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,5 +1,5 @@
 import { sendRequest } from "../socket-client";
-import { printTable, exitError } from "../output";
+import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 import type { CliContext } from "../context";
 
@@ -47,5 +47,5 @@ export async function handleConfig(
 		return;
 	}
 
-	exitError(`Unknown subcommand: config ${subcommand}`, "Available: config show, config export", 3);
+	exitUsage(`Unknown subcommand: config ${subcommand}\nAvailable: config show, config export`);
 }

--- a/src/cli/commands/projects.ts
+++ b/src/cli/commands/projects.ts
@@ -1,6 +1,6 @@
 import type { Project } from "../../shared/types";
 import { sendRequest } from "../socket-client";
-import { printTable, exitError } from "../output";
+import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 
 export async function handleProjects(subcommand: string | undefined, _args: ParsedArgs, socketPath: string): Promise<void> {
@@ -21,5 +21,5 @@ export async function handleProjects(subcommand: string | undefined, _args: Pars
 		return;
 	}
 
-	exitError(`Unknown subcommand: projects ${subcommand}`, "Available: projects list", 3);
+	exitUsage(`Unknown subcommand: projects ${subcommand}\nAvailable: projects list`);
 }

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -67,5 +67,5 @@ export async function handleTasks(
 		return;
 	}
 
-	exitError(`Unknown subcommand: tasks ${subcommand}`, "Available: tasks list", 3);
+	exitUsage(`Unknown subcommand: tasks ${subcommand}\nAvailable: tasks list`);
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,6 @@
 import { parseArgs, resolveFileArgs } from "./args";
 import { detectContext, resolveSocketPath } from "./context";
-import { exitAppNotRunning, exitUsage } from "./output";
+import { exitAppNotRunning, exitInternalError, exitUsage } from "./output";
 import { handleProjects } from "./commands/projects";
 import { handleTasks } from "./commands/tasks";
 import { handleTask } from "./commands/task";
@@ -12,6 +12,7 @@ import { handleInstallSkills } from "./commands/install-skills";
 import { handleConfig } from "./commands/config";
 import { handleDevServer } from "./commands/dev-server";
 import { BUILD_TIME, BUILD_COMMIT, BUILD_VERSION } from "../shared/build-info.generated";
+import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
 
 const HELP = `dev3 — AI-facing CLI for the dev-3.0 Kanban board.
 Auto-detects project and task from the worktree context.
@@ -56,12 +57,12 @@ async function main(): Promise<void> {
 
 	if (rawArgs.length === 0 || rawArgs.includes("--help") || rawArgs.includes("-h")) {
 		process.stdout.write(HELP);
-		process.exit(0);
+		process.exit(CLI_EXIT_CODE_SUCCESS);
 	}
 
 	if (rawArgs.includes("--version") || rawArgs.includes("-v")) {
 		process.stdout.write(`dev3 v${BUILD_VERSION} (${BUILD_COMMIT}) ${BUILD_TIME}\n`);
-		process.exit(0);
+		process.exit(CLI_EXIT_CODE_SUCCESS);
 	}
 
 	const command = rawArgs[0];
@@ -116,6 +117,5 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-	process.stderr.write(`error: ${err.message || String(err)}\n`);
-	process.exit(1);
+	exitInternalError(err instanceof Error ? err.message : String(err));
 });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,3 +1,10 @@
+import {
+	CLI_EXIT_CODE_APP_NOT_RUNNING,
+	CLI_EXIT_CODE_COMMAND_FAILED,
+	CLI_EXIT_CODE_INTERNAL_ERROR,
+	CLI_EXIT_CODE_USAGE_ERROR,
+} from "../shared/cli-exit-codes";
+
 /**
  * Print a table with column headers and rows.
  * Auto-sizes columns based on content width.
@@ -27,7 +34,7 @@ export function printDetail(fields: Array<[string, string]>): void {
 	}
 }
 
-export function exitError(message: string, detail?: string, code = 1): never {
+export function exitError(message: string, detail?: string, code = CLI_EXIT_CODE_COMMAND_FAILED): never {
 	process.stderr.write(`error: ${message}\n`);
 	if (detail) {
 		for (const line of detail.split("\n")) {
@@ -41,10 +48,14 @@ export function exitAppNotRunning(): never {
 	exitError(
 		"app not running",
 		"The dev3.0 desktop app must be running to use the CLI.\nStart the app and try again.",
-		2,
+		CLI_EXIT_CODE_APP_NOT_RUNNING,
 	);
 }
 
 export function exitUsage(message: string): never {
-	exitError(message, undefined, 3);
+	exitError(message, undefined, CLI_EXIT_CODE_USAGE_ERROR);
+}
+
+export function exitInternalError(message: string): never {
+	exitError(message, undefined, CLI_EXIT_CODE_INTERNAL_ERROR);
 }

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -5,11 +5,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { TaskStatus } from "./types";
+import { CLI_EXIT_CODE_APP_NOT_RUNNING } from "./cli-exit-codes";
 
 export const DEV3_CLI = "~/.dev3.0/bin/dev3";
 export const CODEX_STOP_HOOK_FLAG = "--codex-stop-hook";
 export const CODEX_STOP_HOOK_SUCCESS_JSON = "{}";
-const APP_NOT_RUNNING_EXIT_CODE = 2;
 
 export interface HookEntry {
 	type: string;
@@ -48,11 +48,11 @@ function buildMoveCommand(
 }
 
 function wrapCodexAppOfflineFallback(command: string): string {
-	return `${command} || [ $? -eq ${APP_NOT_RUNNING_EXIT_CODE} ]`;
+	return `${command} || [ $? -eq ${CLI_EXIT_CODE_APP_NOT_RUNNING} ]`;
 }
 
 function wrapCodexStopHookCommand(command: string): string {
-	return `if ${command} >/dev/null; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else hook_exit_code=$?; if [ "$hook_exit_code" -eq ${APP_NOT_RUNNING_EXIT_CODE} ]; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else exit "$hook_exit_code"; fi; fi`;
+	return `if ${command} >/dev/null; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else hook_exit_code=$?; if [ "$hook_exit_code" -eq ${CLI_EXIT_CODE_APP_NOT_RUNNING} ]; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else exit "$hook_exit_code"; fi; fi`;
 }
 
 function buildStopGroups(

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -52,7 +52,7 @@ function wrapCodexAppOfflineFallback(command: string): string {
 }
 
 function wrapCodexStopHookCommand(command: string): string {
-	return `if ${command} >/dev/null; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else status=$?; if [ "$status" -eq ${APP_NOT_RUNNING_EXIT_CODE} ]; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else exit "$status"; fi; fi`;
+	return `if ${command} >/dev/null; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else hook_exit_code=$?; if [ "$hook_exit_code" -eq ${APP_NOT_RUNNING_EXIT_CODE} ]; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else exit "$hook_exit_code"; fi; fi`;
 }
 
 function buildStopGroups(

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -9,6 +9,7 @@ import type { TaskStatus } from "./types";
 export const DEV3_CLI = "~/.dev3.0/bin/dev3";
 export const CODEX_STOP_HOOK_FLAG = "--codex-stop-hook";
 export const CODEX_STOP_HOOK_SUCCESS_JSON = "{}";
+const APP_NOT_RUNNING_EXIT_CODE = 2;
 
 export interface HookEntry {
 	type: string;
@@ -46,8 +47,12 @@ function buildMoveCommand(
 	return parts.join(" ");
 }
 
+function wrapCodexAppOfflineFallback(command: string): string {
+	return `${command} || [ $? -eq ${APP_NOT_RUNNING_EXIT_CODE} ]`;
+}
+
 function wrapCodexStopHookCommand(command: string): string {
-	return `${command} >/dev/null && printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'`;
+	return `if ${command} >/dev/null; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else status=$?; if [ "$status" -eq ${APP_NOT_RUNNING_EXIT_CODE} ]; then printf '${CODEX_STOP_HOOK_SUCCESS_JSON}'; else exit "$status"; fi; fi`;
 }
 
 function buildStopGroups(
@@ -130,7 +135,9 @@ export function buildCodexHooks(
 	options?: { stopTarget?: TaskStatus },
 ): HookMap {
 	const stopTarget: TaskStatus = options?.stopTarget ?? "review-by-user";
-	const workingCmd = buildMoveCommand("in-progress", "--if-status-not review-by-ai");
+	const workingCmd = wrapCodexAppOfflineFallback(
+		buildMoveCommand("in-progress", "--if-status-not review-by-ai"),
+	);
 
 	return {
 		SessionStart: [

--- a/src/shared/cli-exit-codes.ts
+++ b/src/shared/cli-exit-codes.ts
@@ -1,0 +1,33 @@
+export const CLI_EXIT_CODE_SUCCESS = 0;
+export const CLI_EXIT_CODE_COMMAND_FAILED = 1;
+export const CLI_EXIT_CODE_APP_NOT_RUNNING = 2;
+export const CLI_EXIT_CODE_USAGE_ERROR = 3;
+export const CLI_EXIT_CODE_INTERNAL_ERROR = 4;
+
+export const CLI_EXIT_CODE_DEFINITIONS = [
+	{
+		constant: "CLI_EXIT_CODE_SUCCESS",
+		code: CLI_EXIT_CODE_SUCCESS,
+		description: "Command completed successfully, or exited intentionally without an error.",
+	},
+	{
+		constant: "CLI_EXIT_CODE_COMMAND_FAILED",
+		code: CLI_EXIT_CODE_COMMAND_FAILED,
+		description: "A handled command failure occurred after parsing succeeded.",
+	},
+	{
+		constant: "CLI_EXIT_CODE_APP_NOT_RUNNING",
+		code: CLI_EXIT_CODE_APP_NOT_RUNNING,
+		description: "The desktop app or CLI socket was unavailable for a command that requires it.",
+	},
+	{
+		constant: "CLI_EXIT_CODE_USAGE_ERROR",
+		code: CLI_EXIT_CODE_USAGE_ERROR,
+		description: "The CLI invocation was invalid: bad command, bad subcommand, or missing required args.",
+	},
+	{
+		constant: "CLI_EXIT_CODE_INTERNAL_ERROR",
+		code: CLI_EXIT_CODE_INTERNAL_ERROR,
+		description: "An unexpected internal CLI failure escaped normal command handling.",
+	},
+] as const;


### PR DESCRIPTION
## Summary
- make generated Codex hooks treat app-offline exit code `2` as a non-blocking no-op
- fix the Codex Stop hook wrapper to avoid zsh's read-only `status` variable
- move public CLI exit codes into a shared registry, document them, and add an AGENTS rule to keep non-zero codes unique

## Why
Codex was treating `dev3` exit code `2` from installed hooks as a blocking failure when the desktop app was not running. That could break prompt submission, Bash tool execution, and Stop handling in any repo with dev3-installed Codex hooks.

## Implementation notes
- kept `exitAppNotRunning()` on code `2` for normal CLI callers
- applied the fallback only in generated Codex hook commands
- avoided `|| true` so unrelated failures still surface
- documented CLI exit-code ownership in `docs/cli-exit-codes.md`

## Testing
- `bun run lint`
- `bun run test`
- `bun run test:cli`
- manual Codex retest with the desktop app closed after reinstalling hooks

Closes #443