### PR TITLE
Fix preparing cards text recovery

### DIFF
--- a/change-logs/2026/04/12/fix-preparing-task-text-recovery.md
+++ b/change-logs/2026/04/12/fix-preparing-task-text-recovery.md
@@ -1,0 +1,3 @@
+Preparing task cards now keep a dedicated "Show full description" recovery action in the loading overlay, so the original task text stays reachable even if preparation hangs. Added TaskCard regression coverage to keep read-only recovery available while state-changing actions remain disabled.
+
+Suggested by @alonkochba (h0x91b/dev-3.0#442)

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -389,7 +389,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
-			} ${isCompleting ? "grayscale opacity-40 pointer-events-none" : isPreparing ? "opacity-60 pointer-events-none" : isDisabled ? "opacity-50 pointer-events-none" : ""}`}
+			} ${isCompleting ? "grayscale opacity-40 pointer-events-none" : isPreparing ? "opacity-60" : isDisabled ? "opacity-50 pointer-events-none" : ""}`}
 			style={{ borderLeftColor: isCompleting ? "#888" : color }}
 			onClick={handleClick}
 		>
@@ -402,9 +402,20 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 			{/* Preparing spinner overlay — worktree is being created */}
 			{isPreparing && (
-				<div className="absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-xl bg-base/40">
-					<div className="w-3.5 h-3.5 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
-					<span className="text-xs text-fg-2 font-medium">{t("task.preparing")}</span>
+				<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-xl bg-base/40">
+					<div className="flex items-center gap-2">
+						<div className="w-3.5 h-3.5 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
+						<span className="text-xs text-fg-2 font-medium">{t("task.preparing")}</span>
+					</div>
+					{hasLongDescription && (
+						<button
+							onClick={handleShowDescription}
+							className="rounded-lg border border-edge bg-elevated/90 px-2.5 py-1 text-[0.6875rem] text-fg-2 transition-colors hover:border-edge-active hover:text-fg"
+							title={t("task.showDescription")}
+						>
+							{t("task.showDescription")}
+						</button>
+					)}
 				</div>
 			)}
 

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -653,6 +653,38 @@ describe("TaskCard", () => {
 
 			expect(screen.getByTestId("task-detail-modal")).toBeInTheDocument();
 		});
+
+		it("keeps description accessible while preparing", async () => {
+			const user = userEvent.setup();
+			renderCard(makeTask({
+				status: "todo",
+				preparing: true,
+				title: "Short title",
+				description: "This is a much longer description that differs from title",
+			}));
+
+			await user.click(screen.getByText("Show full description"));
+
+			expect(screen.getByTestId("task-detail-modal")).toBeInTheDocument();
+		});
+
+		it("keeps run action disabled while preparing", async () => {
+			const user = userEvent.setup();
+			const onLaunchVariants = vi.fn();
+			renderCard(makeTask({
+				status: "todo",
+				preparing: true,
+				title: "Short title",
+				description: "This is a much longer description that differs from title",
+			}), { onLaunchVariants });
+
+			const runButton = screen.getByRole("button", { name: "Run" });
+			expect(runButton).toBeDisabled();
+
+			await user.click(screen.getByText("Show full description"));
+
+			expect(onLaunchVariants).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("bell badge", () => {


### PR DESCRIPTION
## Summary
- keep stuck Preparing cards readable by exposing Show full description in the loading overlay
- preserve blocked state-changing actions while preparation is active
- add regression coverage for description recovery and disabled Run behavior

Fixes #448
Related to #442