### PR TITLE
fix: stabilize inline diff rendering in wkwebview

### DIFF
--- a/change-logs/2026/04/13/fix-inline-diff-wkwebview-paint-glitch.md
+++ b/change-logs/2026/04/13/fix-inline-diff-wkwebview-paint-glitch.md
@@ -1,0 +1,1 @@
+Applied a WKWebView-specific inline diff workaround so split/unified views do not visually drift into fake rows after mode switches or horizontal scrolling. The viewer now remounts on diff payload changes and uses WebKit-safe diff table styling.

--- a/decisions/033-inline-diff-wkwebview-paint-workaround.md
+++ b/decisions/033-inline-diff-wkwebview-paint-workaround.md
@@ -1,0 +1,21 @@
+# 033 — Inline Diff WKWebView Paint Workaround
+
+## Context
+
+The inline diff viewer sometimes showed obviously wrong row content in the desktop app even though the underlying git patch and parsed diff data were correct. The corruption reproduced only in the Electrobun renderer (WKWebView), not in isolated diff data inspection.
+
+## Investigation
+
+`git diff`, merge-base content, `@git-diff-view/core` split/unified line data, and isolated React renders all produced the expected rows. The visible corruption only appeared in the app shell, which pointed to a WebKit paint/layout issue rather than bad diff data.
+
+## Decision
+
+In [src/mainview/components/TaskDiffViewer.css](../src/mainview/components/TaskDiffViewer.css), override `@git-diff-view` tables from `border-collapse: collapse` to `separate` with zero spacing and force the diff scroll layer onto its own compositing layer. In [src/mainview/components/TaskDiffViewer.tsx](../src/mainview/components/TaskDiffViewer.tsx), force `DiffView` to remount when the mode/theme/diff payload hash changes so stale paint/state cannot survive view transitions.
+
+## Risks
+
+The workaround is intentionally narrow but still changes third-party table layout behavior, so subtle spacing differences are possible. The visual bug is WKWebView-specific, so automated DOM tests do not fully cover it.
+
+## Alternatives considered
+
+Leaving the bug alone was not acceptable because the viewer displayed fake code. Rewriting the diff renderer or patching `@git-diff-view` directly was too expensive for a renderer-specific paint issue with a smaller CSS/remount workaround available.

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -50,3 +50,21 @@
 	background: rgb(var(--surface-base));
 	border-color: rgb(var(--border-default));
 }
+
+/* WKWebView sometimes mispaints git-diff-view rows when sticky cells live
+   inside collapsed tables. Keep zero spacing, but switch the diff tables to
+   separate borders and isolate the scroll layer so WebKit repaints rows
+   consistently after mode switches and horizontal scrolling. */
+.diff-tailwindcss-wrapper .diff-table,
+.diff-tailwindcss-wrapper .unified-diff-table,
+.diff-tailwindcss-wrapper .old-diff-table,
+.diff-tailwindcss-wrapper .new-diff-table {
+	border-collapse: separate !important;
+	border-spacing: 0;
+}
+
+.diff-tailwindcss-wrapper .diff-table-scroll-container,
+.diff-tailwindcss-wrapper .diff-view-wrapper {
+	transform: translateZ(0);
+	backface-visibility: hidden;
+}

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -871,6 +871,7 @@ function TaskDiffFileSection({
 
 	const DiffView = diffLib.DiffView;
 	const diffMode = viewMode === "split" ? diffLib.DiffModeEnum.Split : diffLib.DiffModeEnum.Unified;
+	const diffRenderKey = `${file.id}:${viewMode}:${resolvedTheme}:${hashText(file.hunks?.join("\n") ?? `${file.oldContent}\u0000${file.newContent}`)}`;
 
 	return (
 		<div
@@ -933,6 +934,7 @@ function TaskDiffFileSection({
 					<div className="px-4 py-5 text-sm text-danger">{buildError}</div>
 				) : diffFile ? (
 					<DiffView
+						key={diffRenderKey}
 						diffFile={diffFile}
 						diffViewTheme={resolvedTheme}
 						diffViewMode={diffMode}


### PR DESCRIPTION
## Summary\n- stabilize inline diff rendering in the desktop renderer\n- apply a narrow WKWebView-safe diff table styling workaround\n- remount the diff view when mode, theme, or payload changes\n\n## Testing\n- bun run lint\n- bun run test