### PR TITLE
Fix agent config save race

### DIFF
--- a/change-logs/2026/04/13/fix-agent-config-save-race.md
+++ b/change-logs/2026/04/13/fix-agent-config-save-race.md
@@ -1,0 +1,1 @@
+Fixed a race in Global Settings agent config editing where overlapping save requests could persist an older payload after a newer one. Agent edits now serialize writes and keep only the latest pending state, so new tasks launch with the command you actually saved.

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -66,6 +66,8 @@ function GlobalSettings() {
 
 	const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
 	const globalSettingsRef = useRef<GlobalSettingsType>(DEFAULT_GLOBAL_SETTINGS);
+	const pendingAgentsSaveRef = useRef<CodingAgent[] | null>(null);
+	const agentsSaveInFlightRef = useRef(false);
 
 	const setGlobalSettingsState = useCallback((next: GlobalSettingsType) => {
 		globalSettingsRef.current = next;
@@ -353,14 +355,32 @@ function GlobalSettings() {
 		[persistSettingChange],
 	);
 
-	const persistAgents = useCallback(async (updated: CodingAgent[]) => {
-		setAgents(updated);
+	const flushPendingAgentsSave = useCallback(async () => {
+		if (agentsSaveInFlightRef.current) {
+			return;
+		}
+
+		agentsSaveInFlightRef.current = true;
 		try {
-			await api.request.saveAgents({ agents: updated });
-		} catch {
-			// Best-effort save; UI state is already updated.
+			while (pendingAgentsSaveRef.current) {
+				const next = pendingAgentsSaveRef.current;
+				pendingAgentsSaveRef.current = null;
+				try {
+					await api.request.saveAgents({ agents: next });
+				} catch {
+					// Best-effort save; keep local UI state and continue with the newest pending payload.
+				}
+			}
+		} finally {
+			agentsSaveInFlightRef.current = false;
 		}
 	}, []);
+
+	const persistAgents = useCallback((updated: CodingAgent[]) => {
+		setAgents(updated);
+		pendingAgentsSaveRef.current = updated;
+		void flushPendingAgentsSave();
+	}, [flushPendingAgentsSave]);
 
 	const handleLocaleChange = useCallback((nextLocale: "en" | "ru" | "es") => {
 		setLocale(nextLocale);

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import GlobalSettings from "../GlobalSettings";
 import { I18nProvider } from "../../i18n";
@@ -716,6 +716,51 @@ describe("GlobalSettings", () => {
 			await user.type(textareas[0], "extra prompt");
 
 			expect(mockedApi.request.saveAgents).toHaveBeenCalled();
+		});
+
+		it("serializes config saves so the latest base command override wins", async () => {
+			setupMocks();
+			const pending: Array<{
+				resolve: () => void;
+				payload: { agents: CodingAgent[] };
+			}> = [];
+			let persistedAgents: CodingAgent[] | null = null;
+
+			mockedApi.request.saveAgents.mockImplementation(
+				(payload: { agents: CodingAgent[] }) =>
+					new Promise<void>((resolve) => {
+						pending.push({
+							payload,
+							resolve: () => {
+								persistedAgents = payload.agents;
+								resolve();
+							},
+						});
+					}) as any,
+			);
+
+			const user = await expandFirstConfig();
+			const overrideLabel = screen.getByText("Base Command Override");
+			const overrideInput = overrideLabel.closest("div")!.querySelector("input")!;
+
+			await user.type(overrideInput, "xy");
+
+			expect(mockedApi.request.saveAgents).toHaveBeenCalledTimes(1);
+			expect(pending).toHaveLength(1);
+
+			pending[0].resolve();
+
+			await waitFor(() => {
+				expect(mockedApi.request.saveAgents).toHaveBeenCalledTimes(2);
+			});
+			expect(pending).toHaveLength(2);
+
+			pending[1].resolve();
+
+			await waitFor(() => {
+				const claude = persistedAgents?.find((agent) => agent.id === "agent-1");
+				expect(claude?.configurations[0]?.baseCommandOverride).toBe("xy");
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary
- serialize agent config saves in Global Settings so overlapping RPCs do not persist stale payloads
- keep only the latest pending agent payload while a save is in flight
- add a regression test that reproduces the save race around Base Command Override

## Testing
- bunx vitest run src/mainview/components/__tests__/GlobalSettings.test.tsx -t "serializes config saves so the latest base command override wins"
- bun run lint
- bun run test