### PR TITLE
Add preparing cancel flow and timing logs

### DIFF
--- a/change-logs/2026/04/13/fix-preparing-cancel-and-profiling.md
+++ b/change-logs/2026/04/13/fix-preparing-cancel-and-profiling.md
@@ -1,0 +1,3 @@
+Preparing tasks now emit step-by-step timing logs for project config resolution, worktree creation, sparse checkout, clone-path reuse, PTY launch, and key git substeps so slow or stuck setup leaves a usable performance trail. Added a Cancel action on Preparing cards that kills tracked setup subprocesses with `kill -9`, cleans up partial task state, and returns the task to To Do instead of leaving it hung forever.
+
+Suggested by @alonkochba (h0x91b/dev-3.0#442)

--- a/decisions/034-preparing-process-tracking.md
+++ b/decisions/034-preparing-process-tracking.md
@@ -1,0 +1,19 @@
+## Context
+
+Tasks in `Preparing...` could hang for a long time with no reliable way to abort them. The expensive part spans multiple modules (`task-lifecycle`, `git`, `cow-clone`, `tmux-pty`) and each one spawns its own subprocesses through `src/bun/spawn.ts`.
+
+## Investigation
+
+Tracking only the top-level background promise was not enough because the actual time is spent inside child processes (`git`, `cp`, `tmux`). Adding per-call cancel plumbing to every function in the chain would have scattered task-specific state across unrelated modules.
+
+## Decision
+
+We track active preparation runs in `src/bun/preparation-runtime.ts` and attach task context with `AsyncLocalStorage`. `src/bun/spawn.ts` records every spawned PID when a command runs inside that context, so `cancelTaskPreparation` in `src/bun/rpc-handlers/task-lifecycle.ts` can `kill -9` the exact preparation subprocesses for one task and then revert the task to `todo`.
+
+## Risks
+
+This assumes preparation subprocesses are created through the shared `spawn()` wrapper. A long-running `spawnSync()` or direct `Bun.spawn()` call inside the preparing path would bypass tracking and would not be killable from the new cancel action.
+
+## Alternatives considered
+
+Passing a cancellation token through every prep helper was rejected because it would touch too many modules and still would not identify which OS PIDs to kill. Killing by task worktree path alone was rejected because it is less precise and can miss processes that start before the worktree path is persisted.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -184,6 +184,7 @@ import * as repoConfig from "../repo-config";
 import * as cowClone from "../cow-clone";
 import { Utils } from "electrobun/bun";
 import { existsSync } from "node:fs";
+import { createTaskPreparation, registerPreparationSpawn } from "../preparation-runtime";
 
 // Import handlers and pure helper functions after all mocks are set up
 const {
@@ -2036,6 +2037,66 @@ describe("handlers.addAttempts", () => {
 			branchName: "dev3/a3",
 			preparing: false,
 		});
+	});
+});
+
+describe("handlers.cancelTaskPreparation", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("kills tracked preparation processes and moves the task back to todo", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "variant-1",
+			status: "in-progress",
+			preparing: true,
+			baseBranch: "main",
+			worktreePath: null,
+			branchName: null,
+		});
+		const revertedTask = makeTask({
+			...task,
+			status: "todo",
+			preparing: false,
+			worktreePath: null,
+			branchName: null,
+			customColumnId: null,
+		});
+
+		createTaskPreparation(task.id, "test");
+		registerPreparationSpawn(task.id, 111, ["git", "fetch", "origin"]);
+		registerPreparationSpawn(task.id, 222, ["cp", "-R", "src", "dst"]);
+
+		mockSpawn.mockReturnValue({
+			pid: 999,
+			stdout: new Response(""),
+			stderr: new Response(""),
+			exited: Promise.resolve(0),
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(revertedTask);
+		vi.mocked(git.removeWorktree).mockResolvedValue(undefined);
+		vi.mocked(git.taskDir).mockReturnValue("/tmp/test-dev3/worktrees/tmp-test-project/variant-1");
+
+		const result = await handlers.cancelTaskPreparation({
+			taskId: task.id,
+			projectId: project.id,
+		});
+
+		expect(result).toEqual(revertedTask);
+		expect(mockSpawn).toHaveBeenCalledWith(["kill", "-9", "111"], expect.anything());
+		expect(mockSpawn).toHaveBeenCalledWith(["kill", "-9", "222"], expect.anything());
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, {
+			status: "todo",
+			preparing: false,
+			worktreePath: null,
+			branchName: null,
+			customColumnId: null,
+		});
+		expect(git.removeWorktree).toHaveBeenCalledWith(project, expect.objectContaining({
+			id: task.id,
+			worktreePath: "/tmp/test-dev3/worktrees/tmp-test-project/variant-1/worktree",
+		}));
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -69,6 +69,31 @@ export async function run(
 	return result;
 }
 
+async function measureGitStep<T>(
+	step: string,
+	meta: Record<string, unknown>,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const startedAt = performance.now();
+	try {
+		const result = await fn();
+		log.info("Git step finished", {
+			step,
+			durationMs: Math.round(performance.now() - startedAt),
+			...meta,
+		});
+		return result;
+	} catch (err) {
+		log.warn("Git step failed", {
+			step,
+			durationMs: Math.round(performance.now() - startedAt),
+			error: String(err),
+			...meta,
+		});
+		throw err;
+	}
+}
+
 async function runBinary(
 	cmd: string[],
 	cwd: string,
@@ -530,6 +555,7 @@ export async function createWorktree(
 	existingBranch?: string,
 	variantBranchName?: string,
 ): Promise<{ worktreePath: string; branchName: string }> {
+	const startedAt = performance.now();
 	const wtPath = worktreePath(project, task);
 	const tDir = taskDir(project, task);
 
@@ -544,9 +570,13 @@ export async function createWorktree(
 			wtPath, variantBranchName, base: resolvedBase, taskId: task.id,
 		});
 
-		const result = await run(
-			["git", "worktree", "add", "-b", variantBranchName, wtPath, resolvedBase],
-			project.path,
+		const result = await measureGitStep(
+			"createWorktree.variant.worktreeAdd",
+			{ taskId: task.id.slice(0, 8), wtPath, variantBranchName, base: resolvedBase },
+			() => run(
+				["git", "worktree", "add", "-b", variantBranchName, wtPath, resolvedBase],
+				project.path,
+			),
 		);
 
 		if (!result.ok) {
@@ -554,7 +584,11 @@ export async function createWorktree(
 			throw new Error(`Failed to create worktree: ${result.stderr}`);
 		}
 
-		log.info("Variant worktree created", { wtPath, branch: variantBranchName });
+		log.info("Variant worktree created", {
+			wtPath,
+			branch: variantBranchName,
+			durationMs: Math.round(performance.now() - startedAt),
+		});
 		return { worktreePath: wtPath, branchName: variantBranchName };
 	}
 
@@ -574,9 +608,13 @@ export async function createWorktree(
 			wtPath, existingBranch, resolvedBranch, isRemoteRef, taskId: task.id,
 		});
 
-		const result = await run(
-			["git", "worktree", "add", wtPath, resolvedBranch],
-			project.path,
+		const result = await measureGitStep(
+			"createWorktree.existing.worktreeAdd",
+			{ taskId: task.id.slice(0, 8), wtPath, resolvedBranch, isRemoteRef },
+			() => run(
+				["git", "worktree", "add", wtPath, resolvedBranch],
+				project.path,
+			),
 		);
 
 		if (!result.ok) {
@@ -585,9 +623,13 @@ export async function createWorktree(
 			if (isRemoteRef && !isAlreadyCheckedOut) {
 				// Remote branch without a local tracking branch yet — create one
 				log.info("Retrying with tracking branch creation", { existingBranch });
-				const trackResult = await run(
-					["git", "worktree", "add", "--track", "-b", resolvedBranch, wtPath, existingBranch],
-					project.path,
+				const trackResult = await measureGitStep(
+					"createWorktree.existing.trackRemoteBranch",
+					{ taskId: task.id.slice(0, 8), wtPath, resolvedBranch, existingBranch },
+					() => run(
+						["git", "worktree", "add", "--track", "-b", resolvedBranch, wtPath, existingBranch],
+						project.path,
+					),
 				);
 				if (!trackResult.ok) {
 					log.error("Failed to create worktree from existing branch", { stderr: trackResult.stderr, taskId: task.id });
@@ -603,9 +645,13 @@ export async function createWorktree(
 				log.info("Branch already checked out, creating task branch based on it", {
 					existingBranch: resolvedBranch, taskBranch, taskId: task.id,
 				});
-				const fallbackResult = await run(
-					["git", "worktree", "add", "-b", taskBranch, wtPath, resolvedBranch],
-					project.path,
+				const fallbackResult = await measureGitStep(
+					"createWorktree.existing.fallbackBranch",
+					{ taskId: task.id.slice(0, 8), wtPath, taskBranch, resolvedBranch },
+					() => run(
+						["git", "worktree", "add", "-b", taskBranch, wtPath, resolvedBranch],
+						project.path,
+					),
 				);
 				if (!fallbackResult.ok) {
 					log.error("Failed to create worktree from existing branch (fallback)", { stderr: fallbackResult.stderr, taskId: task.id });
@@ -624,7 +670,12 @@ export async function createWorktree(
 					);
 					log.info("Set remote tracking branch for fallback task branch", { taskBranch, remoteRef });
 				}
-				log.info("Worktree created with task branch based on existing", { wtPath, branch: taskBranch, base: resolvedBranch });
+				log.info("Worktree created with task branch based on existing", {
+					wtPath,
+					branch: taskBranch,
+					base: resolvedBranch,
+					durationMs: Math.round(performance.now() - startedAt),
+				});
 				return { worktreePath: wtPath, branchName: taskBranch };
 			}
 
@@ -632,7 +683,11 @@ export async function createWorktree(
 			throw new Error(`Failed to create worktree: ${result.stderr}`);
 		}
 
-		log.info("Worktree created from existing branch", { wtPath, branch: resolvedBranch });
+		log.info("Worktree created from existing branch", {
+			wtPath,
+			branch: resolvedBranch,
+			durationMs: Math.round(performance.now() - startedAt),
+		});
 		return { worktreePath: wtPath, branchName: resolvedBranch };
 	}
 
@@ -642,7 +697,11 @@ export async function createWorktree(
 
 	// Fetch origin so the worktree starts from the latest remote commit,
 	// not a potentially stale local branch.
-	const fetched = await fetchOrigin(project.path);
+	const fetched = await measureGitStep(
+		"createWorktree.fetchOrigin",
+		{ taskId: task.id.slice(0, 8), projectPath: project.path },
+		() => fetchOrigin(project.path),
+	);
 	const remoteBase = `origin/${baseBranch}`;
 	const refCheckResult = fetched
 		? await run(["git", "rev-parse", "--verify", remoteBase], project.path)
@@ -663,9 +722,13 @@ export async function createWorktree(
 
 	log.info("Creating worktree", { wtPath, branch, baseBranch, resolvedBase, taskId: task.id, taskDir: tDir });
 
-	const result = await run(
-		["git", "worktree", "add", "-b", branch, wtPath, resolvedBase],
-		project.path,
+	const result = await measureGitStep(
+		"createWorktree.default.worktreeAdd",
+		{ taskId: task.id.slice(0, 8), wtPath, branch, resolvedBase },
+		() => run(
+			["git", "worktree", "add", "-b", branch, wtPath, resolvedBase],
+			project.path,
+		),
 	);
 
 	if (!result.ok) {
@@ -673,7 +736,11 @@ export async function createWorktree(
 		throw new Error(`Failed to create worktree: ${result.stderr}`);
 	}
 
-	log.info("Worktree created", { wtPath, branch });
+	log.info("Worktree created", {
+		wtPath,
+		branch,
+		durationMs: Math.round(performance.now() - startedAt),
+	});
 
 	return { worktreePath: wtPath, branchName: branch };
 }
@@ -809,12 +876,21 @@ export async function fetchOrigin(projectPath: string): Promise<boolean> {
 	}
 
 	const promise = (async () => {
+		const startedAt = performance.now();
 		log.debug("Fetching origin", { projectPath });
 		const result = await run(["git", "fetch", "origin", "--quiet"], projectPath);
 		if (result.ok) {
 			fetchLastSuccess.set(projectPath, Date.now());
+			log.info("fetchOrigin finished", {
+				projectPath,
+				durationMs: Math.round(performance.now() - startedAt),
+			});
 		} else {
-			log.warn("fetchOrigin failed", { projectPath, stderr: result.stderr });
+			log.warn("fetchOrigin failed", {
+				projectPath,
+				stderr: result.stderr,
+				durationMs: Math.round(performance.now() - startedAt),
+			});
 		}
 		return result.ok;
 	})();

--- a/src/bun/preparation-runtime.ts
+++ b/src/bun/preparation-runtime.ts
@@ -1,0 +1,158 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createLogger } from "./logger";
+
+const log = createLogger("preparing");
+
+type PreparationProcess = {
+	pid: number;
+	cmd: string[];
+	startedAt: number;
+};
+
+type PreparationEntry = {
+	taskId: string;
+	runId: string;
+	label: string;
+	startedAt: number;
+	cancelled: boolean;
+	processes: Map<number, PreparationProcess>;
+};
+
+type PreparationContext = {
+	taskId: string;
+	runId: string;
+};
+
+const activePreparations = new Map<string, PreparationEntry>();
+const preparationContext = new AsyncLocalStorage<PreparationContext>();
+
+export class TaskPreparationCancelledError extends Error {
+	constructor(taskId: string) {
+		super(`Task preparation was cancelled for ${taskId}`);
+		this.name = "TaskPreparationCancelledError";
+	}
+}
+
+export function createTaskPreparation(taskId: string, label: string): { runId: string } {
+	const existing = activePreparations.get(taskId);
+	if (existing) {
+		log.warn("Replacing existing task preparation entry", {
+			taskId: taskId.slice(0, 8),
+			prevRunId: existing.runId,
+			label: existing.label,
+		});
+	}
+
+	const entry: PreparationEntry = {
+		taskId,
+		runId: crypto.randomUUID(),
+		label,
+		startedAt: Date.now(),
+		cancelled: false,
+		processes: new Map(),
+	};
+	activePreparations.set(taskId, entry);
+	log.info("Task preparation started", {
+		taskId: taskId.slice(0, 8),
+		runId: entry.runId,
+		label,
+	});
+	return { runId: entry.runId };
+}
+
+export function finishTaskPreparation(taskId: string, runId: string, extra?: Record<string, unknown>): void {
+	const entry = activePreparations.get(taskId);
+	if (!entry || entry.runId !== runId) return;
+	activePreparations.delete(taskId);
+	log.info("Task preparation finished", {
+		taskId: taskId.slice(0, 8),
+		runId,
+		label: entry.label,
+		cancelled: entry.cancelled,
+		durationMs: Date.now() - entry.startedAt,
+		processCount: entry.processes.size,
+		...(extra ?? {}),
+	});
+}
+
+export async function withTaskPreparation<T>(
+	taskId: string,
+	label: string,
+	fn: (runId: string) => Promise<T>,
+): Promise<T> {
+	const { runId } = createTaskPreparation(taskId, label);
+	try {
+		return await preparationContext.run({ taskId, runId }, () => fn(runId));
+	} finally {
+		finishTaskPreparation(taskId, runId);
+	}
+}
+
+export function markTaskPreparationCancelled(taskId: string): { runId: string | null; pids: number[] } {
+	const entry = activePreparations.get(taskId);
+	if (!entry) {
+		return { runId: null, pids: [] };
+	}
+	entry.cancelled = true;
+	const pids = [...entry.processes.keys()];
+	log.warn("Task preparation cancellation requested", {
+		taskId: taskId.slice(0, 8),
+		runId: entry.runId,
+		processCount: pids.length,
+	});
+	return { runId: entry.runId, pids };
+}
+
+export function forgetTaskPreparation(taskId: string, runId?: string): void {
+	const entry = activePreparations.get(taskId);
+	if (!entry) return;
+	if (runId && entry.runId !== runId) return;
+	activePreparations.delete(taskId);
+}
+
+export function isTaskPreparationActive(taskId: string, runId: string): boolean {
+	const entry = activePreparations.get(taskId);
+	return !!entry && entry.runId === runId && !entry.cancelled;
+}
+
+export function assertTaskPreparationActive(taskId: string, runId: string): void {
+	if (!isTaskPreparationActive(taskId, runId)) {
+		throw new TaskPreparationCancelledError(taskId);
+	}
+}
+
+export function registerPreparationSpawn(taskId: string, pid: number | undefined, cmd: string[]): void {
+	if (!pid || pid <= 0) return;
+	const entry = activePreparations.get(taskId);
+	if (!entry || entry.cancelled) return;
+	entry.processes.set(pid, { pid, cmd: [...cmd], startedAt: Date.now() });
+	log.debug("Tracking preparation process", {
+		taskId: taskId.slice(0, 8),
+		runId: entry.runId,
+		pid,
+		cmd: cmd.join(" "),
+	});
+}
+
+export function unregisterPreparationSpawn(taskId: string, pid: number | undefined): void {
+	if (!pid || pid <= 0) return;
+	activePreparations.get(taskId)?.processes.delete(pid);
+}
+
+export function registerCurrentPreparationSpawn(pid: number | undefined, cmd: string[]): PreparationContext | null {
+	const ctx = preparationContext.getStore();
+	if (!ctx) return null;
+	registerPreparationSpawn(ctx.taskId, pid, cmd);
+	return ctx;
+}
+
+export function getTaskPreparationSnapshot(taskId: string): { runId: string; pids: number[]; cancelled: boolean; label: string } | null {
+	const entry = activePreparations.get(taskId);
+	if (!entry) return null;
+	return {
+		runId: entry.runId,
+		pids: [...entry.processes.keys()],
+		cancelled: entry.cancelled,
+		label: entry.label,
+	};
+}

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -8,6 +8,15 @@ import * as portPool from "../port-pool";
 import * as repoConfig from "../repo-config";
 import { clonePaths } from "../cow-clone";
 import { DEV3_HOME } from "../paths";
+import {
+	assertTaskPreparationActive,
+	forgetTaskPreparation,
+	getTaskPreparationSnapshot,
+	isTaskPreparationActive,
+	markTaskPreparationCancelled,
+	TaskPreparationCancelledError,
+	withTaskPreparation,
+} from "../preparation-runtime";
 import { loadSettings, loadSettingsSync } from "../settings";
 import { spawn } from "../spawn";
 import { getPushMessage, isActive, log, notifyWatchedTaskStatusChange } from "./shared";
@@ -34,6 +43,255 @@ async function clearPreparingTasks(project: Project, tasks: Task[]): Promise<voi
 			// Best effort — do not crash background preparation cleanup.
 		}
 	}
+}
+
+function preparingResetUpdates(): Partial<Task> {
+	return {
+		status: "todo",
+		preparing: false,
+		worktreePath: null,
+		branchName: null,
+		customColumnId: null,
+	};
+}
+
+async function killTrackedPreparationProcesses(taskId: string, pids: number[]): Promise<void> {
+	for (const pid of pids) {
+		try {
+			log.warn("Killing preparation process", {
+				taskId: taskId.slice(0, 8),
+				pid,
+				signal: "SIGKILL",
+			});
+			const proc = spawn(["kill", "-9", String(pid)], { stdout: "pipe", stderr: "pipe" });
+			const code = await proc.exited;
+			if (code !== 0) {
+				log.warn("kill -9 exited non-zero for preparation process", {
+					taskId: taskId.slice(0, 8),
+					pid,
+					code,
+				});
+			}
+		} catch (err) {
+			log.warn("kill -9 failed for preparation process", {
+				taskId: taskId.slice(0, 8),
+				pid,
+				error: String(err),
+			});
+		}
+	}
+}
+
+async function revertPreparingTaskToTodo(project: Project, task: Task): Promise<Task> {
+	cleanupTaskState(task.id);
+	portPool.releasePorts(task.id);
+
+	try {
+		pty.destroySession(task.id, task.tmuxSocket ?? undefined);
+	} catch (err) {
+		log.warn("destroySession failed while cancelling preparation", {
+			taskId: task.id.slice(0, 8),
+			error: String(err),
+		});
+	}
+
+	killDevServerSession(task.id, task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET).catch((err) => {
+		log.warn("killDevServerSession failed while cancelling preparation", {
+			taskId: task.id.slice(0, 8),
+			error: String(err),
+		});
+	});
+
+	const cleanupTask: Task = {
+		...task,
+		worktreePath: task.worktreePath ?? `${git.taskDir(project, task)}/worktree`,
+	};
+
+	try {
+		await git.removeWorktree(project, cleanupTask);
+	} catch (err) {
+		log.warn("removeWorktree failed while cancelling preparation", {
+			taskId: task.id.slice(0, 8),
+			worktreePath: cleanupTask.worktreePath,
+			error: String(err),
+		});
+	}
+
+	const updated = await data.updateTask(project, task.id, preparingResetUpdates());
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	return updated;
+}
+
+async function measurePreparationStep<T>(
+	task: Task,
+	runId: string,
+	step: string,
+	fn: () => Promise<T>,
+	extra?: Record<string, unknown>,
+): Promise<T> {
+	assertTaskPreparationActive(task.id, runId);
+	const startedAt = performance.now();
+	log.info("Preparing step started", {
+		taskId: task.id.slice(0, 8),
+		runId,
+		step,
+		...(extra ?? {}),
+	});
+	try {
+		const result = await fn();
+		const durationMs = Math.round(performance.now() - startedAt);
+		log.info("Preparing step finished", {
+			taskId: task.id.slice(0, 8),
+			runId,
+			step,
+			durationMs,
+			...(extra ?? {}),
+		});
+		assertTaskPreparationActive(task.id, runId);
+		return result;
+	} catch (err) {
+		const durationMs = Math.round(performance.now() - startedAt);
+		const logFn = err instanceof TaskPreparationCancelledError ? log.warn : log.error;
+		logFn("Preparing step failed", {
+			taskId: task.id.slice(0, 8),
+			runId,
+			step,
+			durationMs,
+			error: String(err),
+			...(extra ?? {}),
+		});
+		throw err;
+	}
+}
+
+async function prepareTaskInBackground(
+	project: Project,
+	task: Task,
+	options: {
+		label: string;
+		agentId: string | null;
+		configId: string | null;
+		existingBranch?: string;
+		variantBranchName?: string;
+	},
+): Promise<void> {
+	await withTaskPreparation(task.id, options.label, async (runId) => {
+		try {
+			const resolvedProject = await measurePreparationStep(
+				task,
+				runId,
+				"resolveProjectConfig",
+				() => repoConfig.resolveProjectConfig(project),
+			);
+			const wt = await measurePreparationStep(
+				task,
+				runId,
+				"createWorktree",
+				() => git.createWorktree(
+					resolvedProject,
+					task,
+					options.existingBranch ?? undefined,
+					options.variantBranchName,
+				),
+				{
+					existingBranch: options.existingBranch ?? null,
+					variantBranchName: options.variantBranchName ?? null,
+				},
+			);
+			const resolved = await measurePreparationStep(
+				task,
+				runId,
+				"resolveOperationalProjectConfig",
+				() => resolveOperationalProjectConfig(resolvedProject, wt.worktreePath),
+				{ worktreePath: wt.worktreePath },
+			);
+
+			if (resolved.sparseCheckoutEnabled && resolved.sparseCheckoutPaths?.length) {
+				await measurePreparationStep(
+					task,
+					runId,
+					"applySparseCheckout",
+					() => git.applySparseCheckout(wt.worktreePath, resolved.sparseCheckoutPaths!),
+					{ pathCount: resolved.sparseCheckoutPaths.length },
+				);
+			} else {
+				log.info("Preparing step skipped", {
+					taskId: task.id.slice(0, 8),
+					runId,
+					step: "applySparseCheckout",
+					enabled: resolved.sparseCheckoutEnabled,
+					pathCount: resolved.sparseCheckoutPaths?.length ?? 0,
+				});
+			}
+
+			await measurePreparationStep(
+				task,
+				runId,
+				"runCowClones",
+				() => runCowClones(resolved, wt.worktreePath),
+			);
+			await measurePreparationStep(
+				task,
+				runId,
+				"launchTaskPty",
+				() => launchTaskPty(
+					resolved,
+					task,
+					wt.worktreePath,
+					options.agentId,
+					options.configId,
+					true,
+				),
+			);
+
+			assertTaskPreparationActive(task.id, runId);
+			const updated = await data.updateTask(project, task.id, {
+				worktreePath: wt.worktreePath,
+				branchName: wt.branchName,
+				preparing: false,
+			});
+
+			if (!isTaskPreparationActive(task.id, runId)) {
+				log.warn("Preparation completed after cancellation; reverting task", {
+					taskId: task.id.slice(0, 8),
+					runId,
+				});
+				await revertPreparingTaskToTodo(project, task);
+				return;
+			}
+
+			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+			log.info("Task preparation ready", {
+				taskId: task.id.slice(0, 8),
+				runId,
+				worktreePath: wt.worktreePath,
+			});
+		} catch (err) {
+			if (err instanceof TaskPreparationCancelledError) {
+				log.warn("Task preparation stopped after cancellation", {
+					taskId: task.id.slice(0, 8),
+					runId,
+					label: options.label,
+				});
+				return;
+			}
+
+			log.error("Failed to prepare task", {
+				taskId: task.id,
+				runId,
+				label: options.label,
+				error: String(err),
+			});
+			try {
+				if (isTaskPreparationActive(task.id, runId)) {
+					const updated = await data.updateTask(project, task.id, { preparing: false });
+					getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+				}
+			} catch {
+				// Best effort — the original error is already logged.
+			}
+		}
+	});
 }
 
 export async function activateTask(
@@ -366,6 +624,33 @@ async function moveTask(params: { taskId: string; projectId: string; newStatus: 
 	return updated;
 }
 
+async function cancelTaskPreparation(params: { taskId: string; projectId: string }): Promise<Task> {
+	log.info("→ cancelTaskPreparation", params);
+	const project = await data.getProject(params.projectId);
+	const task = await data.getTask(project, params.taskId);
+	const snapshot = getTaskPreparationSnapshot(task.id);
+
+	if (task.preparing !== true && !snapshot) {
+		log.info("cancelTaskPreparation skipped — task is not preparing", {
+			taskId: task.id.slice(0, 8),
+		});
+		return task;
+	}
+
+	const { runId, pids } = markTaskPreparationCancelled(task.id);
+	const killList = pids.length > 0 ? pids : (snapshot?.pids ?? []);
+	await killTrackedPreparationProcesses(task.id, killList);
+	const updated = await revertPreparingTaskToTodo(project, task);
+	if (runId) {
+		forgetTaskPreparation(task.id, runId);
+	}
+	log.info("← cancelTaskPreparation done", {
+		taskId: task.id.slice(0, 8),
+		killed: killList.length,
+	});
+	return updated;
+}
+
 async function reorderTask(params: { taskId: string; projectId: string; targetIndex: number }): Promise<Task[]> {
 	log.info("→ reorderTask", params);
 	const project = await data.getProject(params.projectId);
@@ -452,36 +737,19 @@ async function spawnVariants(params: {
 	if (needsWorktree) {
 		(async () => {
 			try {
-				const resolvedProject = await repoConfig.resolveProjectConfig(project);
 				for (let i = 0; i < resultTasks.length; i++) {
 					const task = resultTasks[i];
 					const variant = params.variants[i];
-					try {
-						const variantBranchName = (isMultiVariant && srcBranch)
-							? `${srcBranch.replace(/^origin\//, "")}-v${i + 1}`
-							: undefined;
-						const wt = await git.createWorktree(resolvedProject, task, task.existingBranch ?? undefined, variantBranchName);
-						const resolved = await resolveOperationalProjectConfig(resolvedProject, wt.worktreePath);
-						if (resolved.sparseCheckoutEnabled && resolved.sparseCheckoutPaths?.length) {
-							await git.applySparseCheckout(wt.worktreePath, resolved.sparseCheckoutPaths);
-						}
-						await runCowClones(resolved, wt.worktreePath);
-						await launchTaskPty(resolved, task, wt.worktreePath, variant.agentId, variant.configId, true);
-
-						const updated = await data.updateTask(project, task.id, {
-							worktreePath: wt.worktreePath,
-							branchName: wt.branchName,
-							preparing: false,
-						});
-						getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-						log.info("Variant ready", { taskId: task.id, worktreePath: wt.worktreePath });
-					} catch (err) {
-						log.error("Failed to prepare variant", { taskId: task.id, error: String(err) });
-						try {
-							const updated = await data.updateTask(project, task.id, { preparing: false });
-							getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-						} catch {}
-					}
+					const variantBranchName = (isMultiVariant && srcBranch)
+						? `${srcBranch.replace(/^origin\//, "")}-v${i + 1}`
+						: undefined;
+					await prepareTaskInBackground(project, task, {
+						label: "variant",
+						agentId: variant.agentId,
+						configId: variant.configId,
+						existingBranch: task.existingBranch ?? undefined,
+						variantBranchName,
+					});
 				}
 			} catch (err) {
 				log.error("Failed to start variant preparation", { projectId: project.id, error: String(err) });
@@ -552,33 +820,14 @@ async function addAttempts(params: {
 	if (needsWorktree) {
 		(async () => {
 			try {
-				const resolvedProject = await repoConfig.resolveProjectConfig(project);
 				for (let i = 0; i < resultTasks.length; i++) {
 					const task = resultTasks[i];
 					const variant = params.variants[i];
-					try {
-						const wt = await git.createWorktree(resolvedProject, task);
-						const resolved = await resolveOperationalProjectConfig(resolvedProject, wt.worktreePath);
-						if (resolved.sparseCheckoutEnabled && resolved.sparseCheckoutPaths?.length) {
-							await git.applySparseCheckout(wt.worktreePath, resolved.sparseCheckoutPaths);
-						}
-						await runCowClones(resolved, wt.worktreePath);
-						await launchTaskPty(resolved, task, wt.worktreePath, variant.agentId, variant.configId, true);
-
-						const updated = await data.updateTask(project, task.id, {
-							worktreePath: wt.worktreePath,
-							branchName: wt.branchName,
-							preparing: false,
-						});
-						getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-						log.info("Attempt ready", { taskId: task.id, worktreePath: wt.worktreePath });
-					} catch (err) {
-						log.error("Failed to prepare attempt", { taskId: task.id, error: String(err) });
-						try {
-							const updated = await data.updateTask(project, task.id, { preparing: false });
-							getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-						} catch {}
-					}
+					await prepareTaskInBackground(project, task, {
+						label: "attempt",
+						agentId: variant.agentId,
+						configId: variant.configId,
+					});
 				}
 			} catch (err) {
 				log.error("Failed to start attempt preparation", { projectId: project.id, error: String(err) });
@@ -631,6 +880,7 @@ export const taskLifecycleHandlers = {
 	getAllProjectTasks,
 	createTask,
 	moveTask,
+	cancelTaskPreparation,
 	reorderTask,
 	deleteTask,
 	spawnVariants,

--- a/src/bun/spawn.ts
+++ b/src/bun/spawn.ts
@@ -12,12 +12,21 @@
  * RULE: Never use Bun.spawn / Bun.spawnSync directly — always use these.
  */
 
+import { registerCurrentPreparationSpawn, unregisterPreparationSpawn } from "./preparation-runtime";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function spawn(cmd: string[], opts?: any) {
-	return Bun.spawn(cmd, {
+	const proc = Bun.spawn(cmd, {
 		...opts,
 		env: { ...process.env, ...(opts?.env ?? {}) },
 	});
+	const ctx = registerCurrentPreparationSpawn(proc.pid, cmd);
+	if (ctx && proc.pid) {
+		proc.exited.finally(() => {
+			unregisterPreparationSpawn(ctx.taskId, proc.pid);
+		});
+	}
+	return proc;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -45,6 +45,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const t = useT();
 	const statusColors = useStatusColors();
 	const [moving, setMoving] = useState(false);
+	const [cancellingPreparation, setCancellingPreparation] = useState(false);
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
 	const [menuVisible, setMenuVisible] = useState(false);
@@ -78,7 +79,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const [ctxMenuPos, setCtxMenuPos] = useState({ top: 0, left: 0 });
 
 	const isPreparing = task.preparing === true;
-	const isDisabled = moving || isMovingProp || isPreparing;
+	const isDisabled = moving || isMovingProp || isPreparing || cancellingPreparation;
 	const isTodo = task.status === "todo";
 	const isCancelled = task.status === "cancelled";
 	const isActive = ACTIVE_STATUSES.includes(task.status);
@@ -282,6 +283,24 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		}
 	}
 
+	async function handleCancelPreparation(e: React.MouseEvent) {
+		e.stopPropagation();
+		if (cancellingPreparation) return;
+		setCancellingPreparation(true);
+		try {
+			const updated = await api.request.cancelTaskPreparation({
+				taskId: task.id,
+				projectId: project.id,
+			});
+			dispatch({ type: "updateTask", task: updated });
+		} catch (err) {
+			alert(t("task.failedMove", { error: String(err) }));
+			setCancellingPreparation(false);
+			return;
+		}
+		setCancellingPreparation(false);
+	}
+
 	/** X button handler: cancel (from todo) or delete (from cancelled), with confirmation */
 	async function handleDismiss(e: React.MouseEvent) {
 		e.stopPropagation();
@@ -407,6 +426,14 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 						<div className="w-3.5 h-3.5 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
 						<span className="text-xs text-fg-2 font-medium">{t("task.preparing")}</span>
 					</div>
+					<button
+						onClick={handleCancelPreparation}
+						disabled={cancellingPreparation}
+						className="rounded-lg border border-danger/50 bg-danger/10 px-2.5 py-1 text-[0.6875rem] text-danger transition-colors hover:border-danger hover:bg-danger/15 disabled:cursor-not-allowed disabled:opacity-60"
+						title={t("task.cancel")}
+					>
+						{t("task.cancel")}
+					</button>
 					{hasLongDescription && (
 						<button
 							onClick={handleShowDescription}

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -9,6 +9,7 @@ vi.mock("../../rpc", () => ({
 	api: {
 		request: {
 			moveTask: vi.fn(),
+			cancelTaskPreparation: vi.fn(),
 			moveTaskToCustomColumn: vi.fn(),
 			deleteTask: vi.fn(),
 			showConfirm: vi.fn(),
@@ -684,6 +685,35 @@ describe("TaskCard", () => {
 			await user.click(screen.getByText("Show full description"));
 
 			expect(onLaunchVariants).not.toHaveBeenCalled();
+		});
+
+		it("shows cancel action while preparing and reverts task to todo", async () => {
+			const user = userEvent.setup();
+			const dispatch = vi.fn();
+			const preparingTask = makeTask({
+				status: "in-progress",
+				preparing: true,
+				worktreePath: null,
+				branchName: null,
+				title: "Short title",
+				description: "Long description different from title",
+			});
+			const updatedTask = {
+				...preparingTask,
+				status: "todo" as TaskStatus,
+				preparing: false,
+			};
+			mockedApi.request.cancelTaskPreparation.mockResolvedValue(updatedTask);
+
+			renderCard(preparingTask, { dispatch });
+
+			await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+			expect(mockedApi.request.cancelTaskPreparation).toHaveBeenCalledWith({
+				taskId: preparingTask.id,
+				projectId: project.id,
+			});
+			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: updatedTask });
 		});
 	});
 

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -192,6 +192,8 @@ const tips = {
 	"tip.preventSleep.body": "Enable Prevent Sleep in Settings to keep your Mac awake while agents work.",
 	"tip.copyWorktreePath.title": "Copy worktree path",
 	"tip.copyWorktreePath.body": "Click the folder+clipboard icon in the task header bar, or right-click a task card and choose Copy Path.",
+	"tip.cancelPreparing.title": "Abort stuck prep",
+	"tip.cancelPreparing.body": "On a Preparing card, click Cancel to kill setup and send the task back to To Do.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -192,6 +192,8 @@ const tips = {
 	"tip.preventSleep.body": "Activa Evitar suspensión en Ajustes para que tu Mac no duerma mientras los agentes trabajan.",
 	"tip.copyWorktreePath.title": "Copiar ruta del worktree",
 	"tip.copyWorktreePath.body": "Haz clic en el icono de carpeta+portapapeles en la barra de la tarea, o clic derecho en la tarjeta → Copy Path.",
+	"tip.cancelPreparing.title": "Aborta la preparación",
+	"tip.cancelPreparing.body": "En una tarjeta Preparing, pulsa Cancel para matar el setup y devolver la tarea a To Do.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -192,6 +192,8 @@ const tips = {
 	"tip.preventSleep.body": "Включите «Не давать уснуть» в настройках, чтобы Mac не засыпал пока работают агенты.",
 	"tip.copyWorktreePath.title": "Копирование пути worktree",
 	"tip.copyWorktreePath.body": "Нажмите иконку папки с буфером обмена в заголовке задачи, или правый клик по карточке → Copy Path.",
+	"tip.cancelPreparing.title": "Прервать подготовку",
+	"tip.cancelPreparing.body": "На карточке Preparing нажмите Cancel, чтобы прибить setup и вернуть задачу в To Do.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -600,6 +600,12 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.copyWorktreePath.body",
 		icon: "\u{F0198}", // nf-md-content_copy
 	},
+	{
+		id: "cancel-preparing",
+		titleKey: "tip.cancelPreparing.title",
+		bodyKey: "tip.cancelPreparing.body",
+		icon: "\u{F0159}", // nf-md-cancel
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -909,6 +909,10 @@ export type AppRPCSchema = {
 				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean };
 				response: Task;
 			};
+			cancelTaskPreparation: {
+				params: { taskId: string; projectId: string };
+				response: Task;
+			};
 			reorderTask: {
 				params: { taskId: string; projectId: string; targetIndex: number };
 				response: Task[];


### PR DESCRIPTION
## Summary
- add step-level timing logs for preparing and key git worktree/fetch steps
- add a Cancel action for Preparing cards that kills tracked setup subprocesses and returns the task to To Do
- add runtime tracking, regression tests, a decision record, and changelog credit for #442

## Testing
- bun run lint
- bun run test

Closes #442