### PR TITLE
fix: make task move --if-status atomic

### DIFF
--- a/change-logs/2026/04/15/fix-task-move-if-status-cas-race.md
+++ b/change-logs/2026/04/15/fix-task-move-if-status-cas-race.md
@@ -1,0 +1,1 @@
+Moved `task move --if-status/--if-status-not` compare-and-set checks into `data.updateTask()` so the guard now runs under the per-task file lock. Added regression coverage for concurrent `task.move` requests and direct concurrent `updateTask()` calls on the same task.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -874,6 +874,72 @@ describe("task.move", () => {
 		expect(data.updateTask).not.toHaveBeenCalled();
 	});
 
+	it("allows only one concurrent --if-status move to win", async () => {
+		const project = makeProject();
+		let storedTask = makeTask({ status: "in-progress" });
+		let loadCount = 0;
+		let releaseLoads!: () => void;
+		const loadsReady = new Promise<void>((resolve) => {
+			releaseLoads = resolve;
+		});
+		let updateQueue = Promise.resolve();
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockImplementation(async () => {
+			loadCount += 1;
+			if (loadCount === 2) {
+				releaseLoads();
+			}
+			await loadsReady;
+			return [{ ...storedTask }];
+		});
+		vi.mocked(data.updateTask).mockImplementation(async (_project, _taskId, updates, options: any) => {
+			const run = async () => {
+				const allowedStatuses = typeof options?.ifStatus === "string"
+					? options.ifStatus.split(",")
+					: null;
+				const blockedStatuses = typeof options?.ifStatusNot === "string"
+					? options.ifStatusNot.split(",")
+					: null;
+				if (allowedStatuses && !allowedStatuses.includes(storedTask.status)) {
+					return { ...storedTask };
+				}
+				if (blockedStatuses && blockedStatuses.includes(storedTask.status)) {
+					return { ...storedTask };
+				}
+				storedTask = { ...storedTask, ...updates };
+				return { ...storedTask };
+			};
+			const result = updateQueue.then(run);
+			updateQueue = result.then(() => undefined, () => undefined);
+			return result;
+		});
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const [moveToReview, moveToQuestions] = await Promise.all([
+			handleRequest(makeRequest("task.move", {
+				taskId: storedTask.id,
+				projectId: project.id,
+				newStatus: "review-by-ai",
+				ifStatus: "in-progress",
+			})),
+			handleRequest(makeRequest("task.move", {
+				taskId: storedTask.id,
+				projectId: project.id,
+				newStatus: "user-questions",
+				ifStatus: "in-progress",
+			})),
+		]);
+
+		expect(moveToReview.ok).toBe(true);
+		expect(moveToQuestions.ok).toBe(true);
+		expect(new Set([
+			(moveToReview.data as Task).status,
+			(moveToQuestions.data as Task).status,
+		])).toEqual(new Set([storedTask.status]));
+		expect(["review-by-ai", "user-questions"]).toContain(storedTask.status);
+	});
+
 	it("errors on disallowed transition (todo cannot go to review-by-user)", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "todo" });

--- a/src/bun/__tests__/data-concurrency.test.ts
+++ b/src/bun/__tests__/data-concurrency.test.ts
@@ -254,6 +254,37 @@ describe("concurrent updateTask on different tasks — no lost updates", () => {
 	});
 });
 
+describe("concurrent conditional updateTask on the same task", () => {
+	it("allows only one compare-and-set status transition to win", async () => {
+		const existing = [
+			makeTask({ id: "task-race", seq: 1, status: "in-progress" }),
+		];
+		mockFileStore[tasksFilePath()] = JSON.stringify(existing);
+
+		const [moveToReview, moveToQuestions] = await Promise.all([
+			updateTask(
+				testProject,
+				"task-race",
+				{ status: "review-by-ai" },
+				{ ifStatus: "in-progress" },
+			),
+			updateTask(
+				testProject,
+				"task-race",
+				{ status: "user-questions" },
+				{ ifStatus: "in-progress" },
+			),
+		]);
+
+		const tasks = await loadTasks(testProject);
+		expect(tasks).toHaveLength(1);
+		expect(new Set([moveToReview.status, moveToQuestions.status])).toEqual(
+			new Set([tasks[0].status]),
+		);
+		expect(["review-by-ai", "user-questions"]).toContain(tasks[0].status);
+	});
+});
+
 // ============================================================
 // Concurrent project operations
 // ============================================================

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -402,16 +402,12 @@ const handlers: Record<string, Handler> = {
 			task = found.task;
 		}
 
-		// Conditional move guards — silent no-op when condition is not met.
-		// Both flags support comma-separated values (e.g. "review-by-ai,review-by-user").
 		const ifStatus = params.ifStatus as string | undefined;
-		if (ifStatus && !ifStatus.split(",").includes(task.status)) {
-			return task;
-		}
 		const ifStatusNot = params.ifStatusNot as string | undefined;
-		if (ifStatusNot && ifStatusNot.split(",").includes(task.status)) {
-			return task;
-		}
+		const guardOpts = {
+			...(ifStatus ? { ifStatus } : {}),
+			...(ifStatusNot ? { ifStatusNot } : {}),
+		};
 
 		// Check if this is a custom column ID
 		const customColumns = project.customColumns ?? [];
@@ -426,18 +422,22 @@ const handlers: Record<string, Handler> = {
 					worktreePath: wt.worktreePath,
 					branchName: wt.branchName,
 					customColumnId: customColumn.id,
-				}, { dropPosition: settings.taskDropPosition });
-				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+				}, { dropPosition: settings.taskDropPosition, ...guardOpts });
+				if (updated.status === "in-progress" && updated.customColumnId === customColumn.id) {
+					getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+				}
 				// Trigger column agent if configured
-				if (customColumn.agentConfig && updated.worktreePath) {
+				if (customColumn.agentConfig && updated.worktreePath && updated.customColumnId === customColumn.id) {
 					await triggerColumnAgentIfNeeded(updated.status, project, updated, { customColumn });
 				}
 				return updated;
 			}
-			const updated = await data.updateTask(project, task.id, { customColumnId: customColumn.id });
-			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+			const updated = await data.updateTask(project, task.id, { customColumnId: customColumn.id }, guardOpts);
+			if (updated.customColumnId === customColumn.id) {
+				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+			}
 			// Trigger column agent if configured
-			if (customColumn.agentConfig && updated.worktreePath) {
+			if (customColumn.agentConfig && updated.worktreePath && updated.customColumnId === customColumn.id) {
 				await triggerColumnAgentIfNeeded(updated.status, project, updated, { customColumn });
 			}
 			return updated;
@@ -467,7 +467,7 @@ const handlers: Record<string, Handler> = {
 			}
 		}
 		const settings = await loadSettings();
-		const dropOpts = { dropPosition: settings.taskDropPosition } as const;
+		const moveOpts = { dropPosition: settings.taskDropPosition, ...guardOpts } as const;
 
 		// inactive → active: create worktree + PTY
 		if (!isActive(oldStatus) && isActive(builtinStatus)) {
@@ -479,9 +479,11 @@ const handlers: Record<string, Handler> = {
 				worktreePath: wt.worktreePath,
 				branchName: wt.branchName,
 				customColumnId: null,
-			}, dropOpts);
-			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-			notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
+			}, moveOpts);
+			if (updated.status === builtinStatus && !updated.customColumnId) {
+				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+				notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
+			}
 			return updated;
 		}
 
@@ -502,18 +504,22 @@ const handlers: Record<string, Handler> = {
 				worktreePath: null,
 				branchName: null,
 				customColumnId: null,
-			}, dropOpts);
-			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-			notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
+			}, moveOpts);
+			if (updated.status === builtinStatus && !updated.customColumnId) {
+				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+				notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
+			}
 			return updated;
 		}
 
 		// active → active or status-only change
-		const updated = await data.updateTask(project, task.id, { status: builtinStatus, customColumnId: null }, dropOpts);
-		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-		notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
+		const updated = await data.updateTask(project, task.id, { status: builtinStatus, customColumnId: null }, moveOpts);
+		if (updated.status === builtinStatus && !updated.customColumnId) {
+			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+			notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
 
-		await triggerColumnAgentIfNeeded(builtinStatus, project, updated);
+			await triggerColumnAgentIfNeeded(builtinStatus, project, updated);
+		}
 
 		return updated;
 	},

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -322,7 +322,11 @@ export async function updateTask(
 	project: Project,
 	taskId: string,
 	updates: Partial<Task>,
-	options?: { dropPosition?: "top" | "bottom" },
+	options?: {
+		dropPosition?: "top" | "bottom";
+		ifStatus?: string;
+		ifStatusNot?: string;
+	},
 ): Promise<Task> {
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
@@ -330,8 +334,23 @@ export async function updateTask(
 		const tasks = await rawLoadTasks(project);
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
+		const currentTask = tasks[idx];
+		const allowedStatuses = options?.ifStatus
+			?.split(",")
+			.map((status) => status.trim())
+			.filter(Boolean);
+		if (allowedStatuses && !allowedStatuses.includes(currentTask.status)) {
+			return currentTask;
+		}
+		const blockedStatuses = options?.ifStatusNot
+			?.split(",")
+			.map((status) => status.trim())
+			.filter(Boolean);
+		if (blockedStatuses && blockedStatuses.includes(currentTask.status)) {
+			return currentTask;
+		}
 		const now = new Date().toISOString();
-		const statusChanged = updates.status && updates.status !== tasks[idx].status;
+		const statusChanged = updates.status && updates.status !== currentTask.status;
 
 		if (statusChanged) {
 			const newStatus = updates.status!;


### PR DESCRIPTION
## Summary
- move task.move conditional guards into data.updateTask() under the per-task file lock
- remove the stale pre-check in cli-socket-server and only emit move side effects when the guarded update actually applied
- add concurrent regression coverage for task.move and updateTask compare-and-set behavior

## Testing
- bun run lint
- bun run test