### PR TITLE
fix: make settings saves atomic

### DIFF
--- a/change-logs/2026/04/15/fix-settings-atomic-save.md
+++ b/change-logs/2026/04/15/fix-settings-atomic-save.md
@@ -1,0 +1,1 @@
+Hardened global settings persistence with a file lock, parent directory creation, and atomic temp-file rename to prevent corrupted `settings.json` writes. Added backend tests covering interrupted writes and first-write directory creation.

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const { TEST_HOME } = vi.hoisted(() => ({
+	TEST_HOME: require("node:fs").mkdtempSync(
+		require("node:path").join(require("node:os").tmpdir(), "dev3-settings-test-"),
+	),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: TEST_HOME,
+}));
+
+import { saveSettings, type GlobalSettings } from "../settings";
+
+function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
+	return {
+		defaultAgentId: "builtin-claude",
+		defaultConfigId: "claude-default",
+		taskDropPosition: "top",
+		updateChannel: "stable",
+		...overrides,
+	};
+}
+
+describe("saveSettings", () => {
+	const settingsPath = join(TEST_HOME, "settings.json");
+
+	beforeEach(() => {
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(TEST_HOME, { recursive: true, force: true });
+	});
+
+	it("does not corrupt the existing settings file if a write crashes mid-save", async () => {
+		const previousSettings = makeSettings({ updateChannel: "canary" });
+		writeFileSync(settingsPath, JSON.stringify(previousSettings, null, 2), "utf-8");
+
+		vi.spyOn(Bun, "write").mockImplementation(async (target) => {
+			writeFileSync(String(target), '{"defaultAgentId":"broken', "utf-8");
+			throw new Error("simulated crash");
+		});
+
+		await expect(
+			saveSettings(makeSettings({ defaultAgentId: "builtin-codex" })),
+		).rejects.toThrow("simulated crash");
+
+		expect(() => JSON.parse(readFileSync(settingsPath, "utf-8"))).not.toThrow();
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toEqual(previousSettings);
+	});
+
+	it("creates the settings directory before writing the file", async () => {
+		vi.spyOn(Bun, "write").mockImplementation(async (target, data) => {
+			writeFileSync(String(target), String(data), "utf-8");
+			return 0;
+		});
+
+		await saveSettings(makeSettings({ defaultAgentId: "builtin-codex" }));
+
+		expect(existsSync(settingsPath)).toBe(true);
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toEqual(
+			makeSettings({ defaultAgentId: "builtin-codex" }),
+		);
+	});
+});

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import type { ExternalApp } from "../shared/types";
+import { withFileLock } from "./file-lock";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
 
@@ -60,7 +61,12 @@ export async function loadSettings(): Promise<GlobalSettings> {
 
 export async function saveSettings(settings: GlobalSettings): Promise<void> {
 	log.info("Saving global settings", { settings });
-	await Bun.write(SETTINGS_FILE, JSON.stringify(settings, null, 2));
+	await withFileLock(SETTINGS_FILE, async () => {
+		mkdirSync(DEV3_HOME, { recursive: true });
+		const tempFile = `${SETTINGS_FILE}.tmp`;
+		await Bun.write(tempFile, JSON.stringify(settings, null, 2));
+		renameSync(tempFile, SETTINGS_FILE);
+	});
 	log.info("Global settings saved");
 }
 


### PR DESCRIPTION
## Summary
- protect global settings writes with a file lock
- write through a temporary file and rename into place atomically
- add regression tests for interrupted writes and first-write directory creation

## Testing
- bun run lint
- bun run test