### PR TITLE
fix: route CLI socket destructive moves through moveTask

### DIFF
--- a/change-logs/2026/04/15/fix-cli-socket-destructive-cleanup.md
+++ b/change-logs/2026/04/15/fix-cli-socket-destructive-cleanup.md
@@ -1,0 +1,1 @@
+Routed destructive CLI socket `task.move` transitions through the shared task lifecycle handler so task state cleanup, port release, and dev-server teardown stay aligned with the canonical RPC path. Added a focused regression test that fails unless the socket move path delegates cleanup through the shared `moveTask` flow.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -33,6 +33,7 @@ vi.mock("../rpc-handlers", () => {
 	return {
 		isActive: vi.fn((status: string) => ACTIVE.includes(status)),
 		activateTask: vi.fn(),
+		moveTask: vi.fn(),
 		runCleanupScript: vi.fn(),
 		emitTaskSound: vi.fn(),
 		getPushMessage: vi.fn(() => null),
@@ -75,7 +76,7 @@ vi.mock("node:fs", () => ({
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
-import { activateTask, runCleanupScript, emitTaskSound, getPushMessage } from "../rpc-handlers";
+import { activateTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage } from "../rpc-handlers";
 import { runDevServer, stopDevServer, getDevServerStatus } from "../rpc-handlers/tmux-pty";
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 
@@ -831,6 +832,36 @@ describe("note.delete", () => {
 });
 
 describe("task.move", () => {
+	function mockDestructiveMoveTask(): void {
+		vi.mocked(moveTask).mockImplementation(async ({ taskId, projectId, newStatus }: any) => {
+			const project = await data.getProject(projectId);
+			const tasks = await data.loadTasks(project);
+			const task = tasks.find((candidate) => candidate.id === taskId);
+			if (!task) throw new Error(`Task not found: ${taskId}`);
+
+			emitTaskSound(newStatus as "completed" | "cancelled");
+			try {
+				pty.destroySession(task.id, task.tmuxSocket ?? undefined);
+			} catch {}
+			try {
+				await runCleanupScript(task, project, {
+					fromStatus: task.status,
+					toStatus: newStatus,
+				});
+			} catch {}
+			try {
+				await git.removeWorktree(project, task);
+			} catch {}
+
+			return data.updateTask(project, task.id, {
+				status: newStatus,
+				worktreePath: null,
+				branchName: null,
+				customColumnId: null,
+			}, { dropPosition: "top" });
+		});
+	}
+
 	it("errors when taskId is missing", async () => {
 		const resp = await handleRequest(makeRequest("task.move", { newStatus: "todo" }));
 		expect(resp.ok).toBe(false);
@@ -1071,6 +1102,7 @@ describe("task.move", () => {
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(data.updateTask).mockResolvedValue(updated);
 		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+		mockDestructiveMoveTask();
 
 		const resp = await handleRequest(
 			makeRequest("task.move", {
@@ -1104,6 +1136,7 @@ describe("task.move", () => {
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(data.updateTask).mockResolvedValue(updated);
 		vi.mocked(getPushMessage).mockReturnValue(null);
+		mockDestructiveMoveTask();
 
 		const resp = await handleRequest(
 			makeRequest("task.move", {
@@ -1128,6 +1161,7 @@ describe("task.move", () => {
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(data.updateTask).mockResolvedValue(updated);
 		vi.mocked(getPushMessage).mockReturnValue(null);
+		mockDestructiveMoveTask();
 
 		const resp = await handleRequest(
 			makeRequest("task.move", {
@@ -1164,6 +1198,7 @@ describe("task.move", () => {
 			branchName: null,
 		});
 		vi.mocked(getPushMessage).mockReturnValue(null);
+		mockDestructiveMoveTask();
 
 		const resp = await handleRequest(
 			makeRequest("task.move", {

--- a/src/bun/__tests__/cli-socket-task-move-cleanup.test.ts
+++ b/src/bun/__tests__/cli-socket-task-move-cleanup.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliRequest, Project, Task } from "../../shared/types";
+
+const mockMoveTask = vi.fn();
+const mockCleanupTaskState = vi.fn();
+const mockReleasePorts = vi.fn();
+const mockKillDevServerSession = vi.fn();
+
+vi.mock("../data", () => ({
+	loadProjects: vi.fn(),
+	getProject: vi.fn(),
+	loadTasks: vi.fn(),
+	updateTask: vi.fn(),
+}));
+
+vi.mock("../git", () => ({
+	createWorktree: vi.fn(),
+	removeWorktree: vi.fn(),
+}));
+
+vi.mock("../pty-server", () => ({
+	destroySession: vi.fn(),
+	DEFAULT_TMUX_SOCKET: "dev3",
+}));
+
+vi.mock("../port-pool", () => ({
+	releasePorts: (...args: unknown[]) => mockReleasePorts(...args),
+}));
+
+vi.mock("../rpc-handlers/tmux-pty", () => ({
+	runDevServer: vi.fn(),
+	stopDevServer: vi.fn(),
+	getDevServerStatus: vi.fn(),
+	killDevServerSession: (...args: unknown[]) => mockKillDevServerSession(...args),
+}));
+
+vi.mock("../rpc-handlers", () => {
+	const ACTIVE = ["in-progress", "user-questions", "review-by-user", "review-by-ai"];
+	return {
+		isActive: vi.fn((status: string) => ACTIVE.includes(status)),
+		activateTask: vi.fn(),
+		runCleanupScript: vi.fn(),
+		emitTaskSound: vi.fn(),
+		getPushMessage: vi.fn(() => null),
+		getPushMessageLocal: vi.fn(() => null),
+		moveTask: (...args: unknown[]) => mockMoveTask(...args),
+		triggerColumnAgentIfNeeded: vi.fn(),
+		notifyWatchedTaskStatusChange: vi.fn(),
+	};
+});
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../settings", () => ({
+	loadSettings: vi.fn(() => ({ updateChannel: "stable", taskDropPosition: "top" })),
+}));
+
+vi.mock("../repo-config", () => ({
+	migrateProjectConfig: vi.fn(),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/test-dev3",
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: vi.fn(() => false),
+	readdirSync: vi.fn(() => []),
+	unlinkSync: vi.fn(),
+	mkdirSync: vi.fn(),
+}));
+
+import * as data from "../data";
+
+const { handleRequest } = await import("../cli-socket-server");
+
+function makeProject(overrides?: Partial<Project>): Project {
+	return {
+		id: "proj-1",
+		name: "Test Project",
+		path: "/tmp/test-project",
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-abc12345-1111-2222-3333-444444444444",
+		seq: 1,
+		projectId: "proj-1",
+		title: "Test task",
+		description: "A test task",
+		status: "in-progress",
+		baseBranch: "main",
+		worktreePath: "/tmp/wt",
+		branchName: "dev3/task-test",
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+function makeRequest(method: string, params: Record<string, unknown> = {}): CliRequest {
+	return { id: "req-1", method, params };
+}
+
+describe("task.move destructive cleanup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("delegates destructive cleanup to task-lifecycle moveTask", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress", tmuxSocket: "sock-1" });
+		const updated = {
+			...task,
+			status: "completed" as const,
+			worktreePath: null,
+			branchName: null,
+		};
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+		mockMoveTask.mockImplementation(async () => {
+			mockCleanupTaskState(task.id);
+			mockReleasePorts(task.id);
+			mockKillDevServerSession(task.id, task.tmuxSocket);
+			return updated;
+		});
+
+		const resp = await handleRequest(
+			makeRequest("task.move", {
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: "completed",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(mockMoveTask).toHaveBeenCalledWith({
+			taskId: task.id,
+			projectId: project.id,
+			newStatus: "completed",
+			ifStatus: undefined,
+			ifStatusNot: undefined,
+		});
+		expect(mockCleanupTaskState).toHaveBeenCalledWith(task.id);
+		expect(mockReleasePorts).toHaveBeenCalledWith(task.id);
+		expect(mockKillDevServerSession).toHaveBeenCalledWith(task.id, task.tmuxSocket);
+	});
+});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -2,9 +2,7 @@ import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 import type { CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource } from "../shared/types";
 import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, getAllowedTransitions, titleFromDescription } from "../shared/types";
 import * as data from "./data";
-import * as git from "./git";
-import * as pty from "./pty-server";
-import { isActive, activateTask, runCleanupScript, emitTaskSound, getPushMessage, getPushMessageLocal, triggerColumnAgentIfNeeded, notifyWatchedTaskStatusChange } from "./rpc-handlers";
+import { isActive, activateTask, getPushMessage, getPushMessageLocal, moveTask, triggerColumnAgentIfNeeded, notifyWatchedTaskStatusChange } from "./rpc-handlers";
 import { getDevServerStatus, runDevServer, stopDevServer } from "./rpc-handlers/tmux-pty";
 import * as repoConfig from "./repo-config";
 import { loadSettings } from "./settings";
@@ -487,29 +485,14 @@ const handlers: Record<string, Handler> = {
 			return updated;
 		}
 
-		// active → completed/cancelled: destroy PTY, cleanup, remove worktree
 		if (isActive(oldStatus) && (builtinStatus === "completed" || builtinStatus === "cancelled")) {
-			emitTaskSound(builtinStatus as "completed" | "cancelled");
-			try { pty.destroySession(task.id, task.tmuxSocket ?? undefined); } catch {}
-			try {
-				await runCleanupScript(task, project, {
-					fromStatus: oldStatus,
-					toStatus: builtinStatus,
-				});
-			} catch {}
-			try { await git.removeWorktree(project, task); } catch {}
-
-			const updated = await data.updateTask(project, task.id, {
-				status: builtinStatus,
-				worktreePath: null,
-				branchName: null,
-				customColumnId: null,
-			}, moveOpts);
-			if (updated.status === builtinStatus && !updated.customColumnId) {
-				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-				notifyWatchedTaskStatusChange(updated, oldStatus, builtinStatus, project.name);
-			}
-			return updated;
+			return moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: builtinStatus,
+				ifStatus,
+				ifStatusNot,
+			});
 		}
 
 		// active → active or status-only change

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -23,6 +23,7 @@ export {
 	activateTask,
 	handleBellAutoStatus,
 	isTaskInProgress,
+	moveTask,
 	runCleanupScript,
 	emitTaskSound,
 	triggerColumnAgentIfNeeded,

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -556,14 +556,25 @@ async function createTask(params: { projectId: string; description: string; stat
 	return task;
 }
 
-async function moveTask(params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean }): Promise<Task> {
+export async function moveTask(params: {
+	taskId: string;
+	projectId: string;
+	newStatus: TaskStatus;
+	force?: boolean;
+	ifStatus?: string;
+	ifStatusNot?: string;
+}): Promise<Task> {
 	log.info("→ moveTask", params);
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
 	const oldStatus = task.status;
 	const newStatus = params.newStatus;
 	const settings = await loadSettings();
-	const dropOpts = { dropPosition: settings.taskDropPosition } as const;
+	const guardOpts = {
+		...(params.ifStatus ? { ifStatus: params.ifStatus } : {}),
+		...(params.ifStatusNot ? { ifStatusNot: params.ifStatusNot } : {}),
+	};
+	const dropOpts = { dropPosition: settings.taskDropPosition, ...guardOpts } as const;
 
 	log.info(`Moving task ${oldStatus} → ${newStatus}`, { taskId: task.id, force: !!params.force });
 


### PR DESCRIPTION
## Summary
- route destructive CLI socket `task.move` transitions through shared `moveTask`
- keep cleanup behavior aligned with the canonical task lifecycle path
- add regression coverage for destructive cleanup delegation

## Testing
- bun run lint
- bun run test