### PR TITLE
test: fix settings directory-creation regression test

### DIFF
--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -55,6 +55,9 @@ describe("saveSettings", () => {
 	});
 
 	it("creates the settings directory before writing the file", async () => {
+		// Remove the directory so saveSettings must create it from scratch
+		rmSync(TEST_HOME, { recursive: true, force: true });
+
 		vi.spyOn(Bun, "write").mockImplementation(async (target, data) => {
 			writeFileSync(String(target), String(data), "utf-8");
 			return 0;


### PR DESCRIPTION
## Summary
- rebase the branch on current `main`
- fix the settings regression test so the directory-creation case starts without the settings directory
- keep the interrupted-write regression coverage intact

## Testing
- bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/settings.test.ts