### PR TITLE
fix: avoid migration writes during unlocked loads

### DIFF
--- a/change-logs/2026/04/15/fix-migration-lock-race.md
+++ b/change-logs/2026/04/15/fix-migration-lock-race.md
@@ -1,0 +1,1 @@
+Stopped `loadProjects()` and `loadTasks()` from writing schema backfills during unlocked reads, and limited migration persistence to locked mutators. Added regression tests that reproduce the reader-vs-writer race and verify stale migration writes cannot clobber concurrent project or task updates.

--- a/src/bun/__tests__/data-migration-race.test.ts
+++ b/src/bun/__tests__/data-migration-race.test.ts
@@ -72,6 +72,7 @@ function tasksFilePath(): string {
 
 function makeTask(overrides: Partial<Task> & { id: string; seq?: number }): Task {
 	return {
+		seq: 1,
 		projectId: "proj-1",
 		title: "Task",
 		description: "desc",

--- a/src/bun/__tests__/data-migration-race.test.ts
+++ b/src/bun/__tests__/data-migration-race.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Task, TaskStatus } from "../../shared/types";
+
+const { mockFileStore, lockQueues, fsPromises } = vi.hoisted(() => ({
+	mockFileStore: {} as Record<string, string>,
+	lockQueues: new Map<string, Promise<void>>(),
+	fsPromises: {
+		mkdir: vi.fn(),
+		readFile: vi.fn(),
+		unlink: vi.fn(),
+		writeFile: vi.fn(),
+	},
+}));
+
+vi.mock("node:fs/promises", () => fsPromises);
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test",
+}));
+
+vi.mock("../cow-clone", () => ({
+	detectClonePaths: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("../file-lock", () => ({
+	withFileLock: async <T>(filePath: string, fn: () => Promise<T>): Promise<T> => {
+		const prev = lockQueues.get(filePath) ?? Promise.resolve();
+		let resolve!: () => void;
+		const next = new Promise<void>((r) => {
+			resolve = r;
+		});
+		lockQueues.set(filePath, next);
+
+		await prev;
+		try {
+			return await fn();
+		} finally {
+			resolve();
+		}
+	},
+}));
+
+import { addProject, addTask, loadProjects, loadTasks } from "../data";
+
+const PROJECTS_FILE = "/tmp/dev3-test/projects.json";
+const WRITE_DELAY_MS = 5;
+
+const testProject: Project = {
+	id: "proj-1",
+	name: "Test",
+	path: "/tmp/test-project",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-01T00:00:00Z",
+	labels: [],
+};
+
+function tasksFilePath(): string {
+	return "/tmp/dev3-test/data/tmp-test-project/tasks.json";
+}
+
+function makeTask(overrides: Partial<Task> & { id: string; seq?: number }): Task {
+	return {
+		projectId: "proj-1",
+		title: "Task",
+		description: "desc",
+		status: "todo" as TaskStatus,
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2025-01-01T00:00:00Z",
+		updatedAt: "2025-01-01T00:00:00Z",
+		labelIds: [],
+		...overrides,
+	};
+}
+
+function defer(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+beforeEach(() => {
+	for (const key of Object.keys(mockFileStore)) {
+		delete mockFileStore[key];
+	}
+	lockQueues.clear();
+	fsPromises.mkdir.mockResolvedValue(undefined);
+	fsPromises.unlink.mockImplementation(async (path: string | URL | Buffer) => {
+		delete mockFileStore[String(path)];
+	});
+	fsPromises.readFile.mockImplementation(async (path: string | URL | Buffer) => {
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		const key = String(path);
+		if (!(key in mockFileStore)) {
+			const err = new Error(`ENOENT: ${key}`) as NodeJS.ErrnoException;
+			err.code = "ENOENT";
+			throw err;
+		}
+		return mockFileStore[key];
+	});
+	fsPromises.writeFile.mockImplementation(async (path: string | URL | Buffer, content: string | ArrayBuffer | SharedArrayBuffer | DataView) => {
+		await new Promise((resolve) => setTimeout(resolve, WRITE_DELAY_MS));
+		mockFileStore[String(path)] = String(content);
+	});
+});
+
+describe("migration readers racing with writers", () => {
+	it("loadProjects backfill does not clobber a concurrent addProject", async () => {
+		mockFileStore[PROJECTS_FILE] = JSON.stringify([
+			{
+				id: "legacy-project",
+				name: "Legacy",
+				path: "/tmp/legacy",
+				setupScript: "",
+				devScript: "",
+				cleanupScript: "say done",
+				defaultBaseBranch: "main",
+				createdAt: "2025-01-01T00:00:00Z",
+				labels: [],
+			},
+		]);
+
+		const firstReaderWrite = defer();
+		const releaseReaderWrite = defer();
+		const originalWrite = fsPromises.writeFile.getMockImplementation()!;
+		let mutatorStarted = false;
+
+		fsPromises.writeFile.mockImplementation(async (path: string | URL | Buffer, content: string | ArrayBuffer | SharedArrayBuffer | DataView) => {
+			const key = String(path);
+			const text = String(content);
+			if (!mutatorStarted && key === PROJECTS_FILE && text.includes('"cleanupScript": ""')) {
+				firstReaderWrite.resolve();
+				await releaseReaderWrite.promise;
+			}
+			return originalWrite(path, content);
+		});
+
+		const migratingLoad = loadProjects();
+		const writeOutcome = await Promise.race([
+			firstReaderWrite.promise.then(() => "write" as const),
+			new Promise<"no-write">((resolve) => setTimeout(() => resolve("no-write"), 20)),
+		]);
+
+		mutatorStarted = true;
+		const addedProject = await addProject("/tmp/new-project", "New Project");
+		if (writeOutcome === "write") {
+			releaseReaderWrite.resolve();
+		}
+		await migratingLoad;
+
+		const projects = await loadProjects();
+		expect(writeOutcome).toBe("no-write");
+		expect(projects.find((project) => project.id === addedProject.id)).toBeDefined();
+	});
+
+	it("loadTasks seq backfill does not clobber a concurrent addTask", async () => {
+		const tasksPath = tasksFilePath();
+		mockFileStore[tasksPath] = JSON.stringify([
+			makeTask({ id: "legacy-task", seq: undefined }),
+		]);
+
+		const firstReaderWrite = defer();
+		const releaseReaderWrite = defer();
+		const originalWrite = fsPromises.writeFile.getMockImplementation()!;
+		let mutatorStarted = false;
+
+		fsPromises.writeFile.mockImplementation(async (path: string | URL | Buffer, content: string | ArrayBuffer | SharedArrayBuffer | DataView) => {
+			const key = String(path);
+			const text = String(content);
+			if (!mutatorStarted && key === tasksPath && text.includes('"seq": 1')) {
+				firstReaderWrite.resolve();
+				await releaseReaderWrite.promise;
+			}
+			return originalWrite(path, content);
+		});
+
+		const migratingLoad = loadTasks(testProject);
+		const writeOutcome = await Promise.race([
+			firstReaderWrite.promise.then(() => "write" as const),
+			new Promise<"no-write">((resolve) => setTimeout(() => resolve("no-write"), 20)),
+		]);
+
+		mutatorStarted = true;
+		const addedTask = await addTask(testProject, "Task created during migration");
+		if (writeOutcome === "write") {
+			releaseReaderWrite.resolve();
+		}
+		await migratingLoad;
+
+		const tasks = await loadTasks(testProject);
+		expect(writeOutcome).toBe("no-write");
+		expect(tasks.find((task) => task.id === addedTask.id)).toBeDefined();
+	});
+});

--- a/src/bun/__tests__/data-projects.test.ts
+++ b/src/bun/__tests__/data-projects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Project } from "../../shared/types";
 
 vi.mock("../logger", () => ({
@@ -102,5 +102,29 @@ describe("updateProject", () => {
 
 		const all = await loadProjects();
 		expect(all[0].autoReviewEnabled).toBe(true);
+	});
+});
+
+describe("loadProjects migration reads", () => {
+	it("normalizes legacy cleanupScript in memory without writing during read", async () => {
+		writeFileSync(PROJECTS_FILE, JSON.stringify([
+			{
+				id: "legacy-proj",
+				name: "Legacy",
+				path: "/tmp/legacy",
+				setupScript: "",
+				devScript: "",
+				cleanupScript: "say old-default",
+				defaultBaseBranch: "main",
+				createdAt: "2025-01-01T00:00:00Z",
+				labels: [],
+			},
+		]));
+
+		const loaded = await loadProjects();
+
+		expect(loaded[0].cleanupScript).toBe("");
+		const saved = JSON.parse(readFileSync(PROJECTS_FILE, "utf8"));
+		expect(saved[0].cleanupScript).toBe("say old-default");
 	});
 });

--- a/src/bun/__tests__/data-seq.test.ts
+++ b/src/bun/__tests__/data-seq.test.ts
@@ -120,15 +120,14 @@ describe("loadTasks — seq backfill", () => {
 		expect(result[2].seq).not.toBe(result[0].seq);
 	});
 
-	it("persists backfilled seq to disk", async () => {
+	it("keeps backfilled seq in memory during loadTasks without writing to disk", async () => {
 		const tasks = [makeRawTask({ id: "a" })];
 		seedTasks(tasks);
 
-		await loadTasks(testProject);
-
-		// File should be updated
+		const loaded = await loadTasks(testProject);
 		const saved = readSavedTasks();
-		expect(saved[0].seq).toBe(1);
+		expect(loaded[0].seq).toBe(1);
+		expect(saved[0].seq).toBeUndefined();
 	});
 
 	it("second load returns same seq values (no re-backfill)", async () => {

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -23,7 +23,9 @@ async function ensureDir(filePath: string): Promise<void> {
 
 // ---- Projects (raw internal helpers — no locking) ----
 
-async function rawLoadAllProjects(): Promise<Project[]> {
+async function rawLoadAllProjects(
+	persistMigrations = false,
+): Promise<Project[]> {
 	log.debug("Loading all projects", { file: PROJECTS_FILE });
 	try {
 		const projects = JSON.parse(await readFile(PROJECTS_FILE, "utf8")) as Project[];
@@ -57,7 +59,7 @@ async function rawLoadAllProjects(): Promise<Project[]> {
 				needsSave = true;
 			}
 		}
-		if (needsSave) {
+		if (needsSave && persistMigrations) {
 			log.info("Migrated legacy 'say' cleanup scripts, saving projects");
 			await rawSaveProjects(projects);
 		}
@@ -98,7 +100,7 @@ export async function addProject(
 ): Promise<Project> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Adding project", { name, path });
-		const projects = await rawLoadAllProjects();
+		const projects = await rawLoadAllProjects(true);
 		const normalizedPath = path.replace(/\/+$/, "");
 
 		const existingIdx = projects.findIndex(
@@ -147,7 +149,7 @@ export async function addProject(
 export async function removeProject(projectId: string): Promise<void> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Soft-deleting project", { projectId });
-		const projects = await rawLoadAllProjects();
+		const projects = await rawLoadAllProjects(true);
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) {
 			log.warn("Project not found for soft-delete", { projectId });
@@ -164,7 +166,7 @@ export async function updateProject(
 ): Promise<Project> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Updating project", { projectId, updates });
-		const projects = await rawLoadAllProjects();
+		const projects = await rawLoadAllProjects(true);
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) throw new Error(`Project not found: ${projectId}`);
 		projects[idx] = { ...projects[idx], ...updates };
@@ -179,7 +181,7 @@ export async function updateProjectWith<T>(
 ): Promise<{ project: Project; result: T }> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Updating project with mutator", { projectId });
-		const projects = await rawLoadAllProjects();
+		const projects = await rawLoadAllProjects(true);
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) throw new Error(`Project not found: ${projectId}`);
 		const { updates, result } = await mutator(projects[idx]);
@@ -207,7 +209,10 @@ function nextSeq(tasks: Task[]): number {
 	return max + 1;
 }
 
-async function rawLoadTasks(project: Project): Promise<Task[]> {
+async function rawLoadTasks(
+	project: Project,
+	persistMigrations = false,
+): Promise<Task[]> {
 	const file = tasksFile(project);
 	log.debug("Loading tasks", { projectId: project.id, file });
 	try {
@@ -249,8 +254,10 @@ async function rawLoadTasks(project: Project): Promise<Task[]> {
 				}
 			}
 
-			log.info("Backfilled seq for tasks", { projectId: project.id });
-			await rawSaveTasks(project, tasks);
+			if (persistMigrations) {
+				log.info("Backfilled seq for tasks", { projectId: project.id });
+				await rawSaveTasks(project, tasks);
+			}
 		}
 
 		log.info(`Loaded ${tasks.length} task(s)`, { projectId: project.id });
@@ -311,7 +318,7 @@ export async function addTask(
 	return withFileLock(file, async () => {
 		const title = titleFromDescription(description);
 		log.info("Creating task", { projectId: project.id, title, status });
-		const tasks = await rawLoadTasks(project);
+		const tasks = await rawLoadTasks(project, true);
 		const now = new Date().toISOString();
 		const task: Task = {
 			id: crypto.randomUUID(),
@@ -357,7 +364,7 @@ export async function updateTask(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Updating task", { taskId, updates });
-		const tasks = await rawLoadTasks(project);
+		const tasks = await rawLoadTasks(project, true);
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		const updatedTask = applyTaskUpdate(tasks, idx, updates, options);
@@ -379,7 +386,7 @@ export async function updateTaskWith<T>(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Updating task with mutator", { projectId: project.id, taskId });
-		const tasks = await rawLoadTasks(project);
+		const tasks = await rawLoadTasks(project, true);
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		const { updates, result } = await mutator(tasks[idx]);
@@ -396,7 +403,7 @@ export async function deleteTask(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Deleting task", { taskId, projectId: project.id });
-		const tasks = await rawLoadTasks(project);
+		const tasks = await rawLoadTasks(project, true);
 		const filtered = tasks.filter((t) => t.id !== taskId);
 		await rawSaveTasks(project, filtered);
 	});
@@ -523,7 +530,7 @@ export async function reorderTasksInColumn(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Reordering task in column", { taskId, targetIndex, projectId: project.id });
-		const tasks = await rawLoadTasks(project);
+		const tasks = await rawLoadTasks(project, true);
 		const task = tasks.find((t) => t.id === taskId);
 		if (!task) throw new Error(`Task not found: ${taskId}`);
 


### PR DESCRIPTION
## Summary
- stop project/task migration backfills from writing during unlocked read paths
- persist migration backfills only inside locked mutators, including mutator helper APIs
- add regression tests for reader-vs-writer migration races after rebasing onto the new fs/promises test layout

## Testing
- bun run lint
- bun run test