### PR TITLE
fix: guard mutators against corrupt JSON

### DIFF
--- a/change-logs/2026/04/15/fix-corrupt-json-mutator-guard.md
+++ b/change-logs/2026/04/15/fix-corrupt-json-mutator-guard.md
@@ -1,0 +1,1 @@
+Prevented `addProject`/`updateProject` and task mutators from overwriting persisted state after a JSON parse failure in `projects.json` or `tasks.json`. Added regression tests that reproduce the previous destructive overwrite path and verify mutators now throw a typed read error instead of saving over corrupted files.

--- a/src/bun/__tests__/data-corruption.test.ts
+++ b/src/bun/__tests__/data-corruption.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { Project, Task } from "../../shared/types";
+
+const tempHome = mkdtempSync(join(tmpdir(), "dev3-data-corruption-"));
+const dev3Home = join(tempHome, ".dev3.0");
+const originalHome = process.env.HOME;
+
+function makeProject(overrides?: Partial<Project>): Project {
+	return {
+		id: "proj-1",
+		name: "Existing Project",
+		path: "/tmp/existing-project",
+		setupScript: "",
+		setupScriptLaunchMode: "parallel",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: "2026-04-15T00:00:00.000Z",
+		labels: [],
+		customColumns: [],
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "proj-1",
+		title: "Existing task",
+		description: "Existing task",
+		status: "todo",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2026-04-15T00:00:00.000Z",
+		updatedAt: "2026-04-15T00:00:00.000Z",
+		labelIds: [],
+		notes: [],
+		customTitle: null,
+		customColumnId: null,
+		...overrides,
+	};
+}
+
+describe("data corruption guards", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		process.env.HOME = tempHome;
+		rmSync(tempHome, { recursive: true, force: true });
+		mkdirSync(dev3Home, { recursive: true });
+	});
+
+	afterAll(() => {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	it("refuses to overwrite projects.json after a parse failure", async () => {
+		const existingProject = makeProject();
+		const projectsFile = join(dev3Home, "projects.json");
+		writeFileSync(projectsFile, JSON.stringify([existingProject], null, 2));
+		writeFileSync(projectsFile, "{");
+
+		const data = await import("../data");
+
+		await expect(data.loadProjects()).resolves.toEqual([]);
+		await expect(data.addProject("/tmp/new-project", "New Project")).rejects.toThrow(data.DataFileReadError);
+		expect(readFileSync(projectsFile, "utf8")).toBe("{");
+	});
+
+	it("refuses to overwrite tasks.json after a parse failure", async () => {
+		const project = makeProject();
+		const existingTask = makeTask();
+		const tasksDir = join(dev3Home, "data", "tmp-existing-project");
+		const tasksFile = join(tasksDir, "tasks.json");
+
+		writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+		mkdirSync(tasksDir, { recursive: true });
+		writeFileSync(tasksFile, JSON.stringify([existingTask], null, 2));
+		writeFileSync(tasksFile, "{");
+
+		const data = await import("../data");
+
+		await expect(data.loadTasks(project)).resolves.toEqual([]);
+		await expect(data.addTask(project, "New task")).rejects.toThrow(data.DataFileReadError);
+		expect(readFileSync(tasksFile, "utf8")).toBe("{");
+	});
+});

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -12,6 +12,19 @@ const log = createLogger("data");
 const PROJECTS_FILE = `${DEV3_HOME}/projects.json`;
 type ProjectUpdates = Partial<Pick<Project, "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels">>;
 
+export class DataFileReadError extends Error {
+	override name = "DataFileReadError";
+
+	constructor(
+		message: string,
+		public readonly filePath: string,
+		public readonly operation: "projects" | "tasks",
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+	}
+}
+
 function tasksFile(project: Project): string {
 	return `${DEV3_HOME}/data/${projectSlug(project.path)}/tasks.json`;
 }
@@ -23,9 +36,21 @@ async function ensureDir(filePath: string): Promise<void> {
 
 // ---- Projects (raw internal helpers — no locking) ----
 
-async function rawLoadAllProjects(
-	persistMigrations = false,
-): Promise<Project[]> {
+function toDataFileReadError(
+	filePath: string,
+	operation: "projects" | "tasks",
+	err: unknown,
+): DataFileReadError {
+	const reason = err instanceof Error ? err.message : String(err);
+	return new DataFileReadError(
+		`Failed to load ${operation} from ${filePath}: ${reason}`,
+		filePath,
+		operation,
+		{ cause: err },
+	);
+}
+
+async function rawLoadAllProjects(options?: { strict?: boolean; persistMigrations?: boolean }): Promise<Project[]> {
 	log.debug("Loading all projects", { file: PROJECTS_FILE });
 	try {
 		const projects = JSON.parse(await readFile(PROJECTS_FILE, "utf8")) as Project[];
@@ -59,7 +84,7 @@ async function rawLoadAllProjects(
 				needsSave = true;
 			}
 		}
-		if (needsSave && persistMigrations) {
+		if (needsSave && options?.persistMigrations) {
 			log.info("Migrated legacy 'say' cleanup scripts, saving projects");
 			await rawSaveProjects(projects);
 		}
@@ -71,6 +96,9 @@ async function rawLoadAllProjects(
 			return [];
 		}
 		log.error("Failed to load projects", { error: String(err) });
+		if (options?.strict) {
+			throw toDataFileReadError(PROJECTS_FILE, "projects", err);
+		}
 		return [];
 	}
 }
@@ -100,7 +128,7 @@ export async function addProject(
 ): Promise<Project> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Adding project", { name, path });
-		const projects = await rawLoadAllProjects(true);
+		const projects = await rawLoadAllProjects({ strict: true, persistMigrations: true });
 		const normalizedPath = path.replace(/\/+$/, "");
 
 		const existingIdx = projects.findIndex(
@@ -149,7 +177,7 @@ export async function addProject(
 export async function removeProject(projectId: string): Promise<void> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Soft-deleting project", { projectId });
-		const projects = await rawLoadAllProjects(true);
+		const projects = await rawLoadAllProjects({ strict: true, persistMigrations: true });
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) {
 			log.warn("Project not found for soft-delete", { projectId });
@@ -166,7 +194,7 @@ export async function updateProject(
 ): Promise<Project> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Updating project", { projectId, updates });
-		const projects = await rawLoadAllProjects(true);
+		const projects = await rawLoadAllProjects({ strict: true, persistMigrations: true });
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) throw new Error(`Project not found: ${projectId}`);
 		projects[idx] = { ...projects[idx], ...updates };
@@ -181,7 +209,7 @@ export async function updateProjectWith<T>(
 ): Promise<{ project: Project; result: T }> {
 	return withFileLock(PROJECTS_FILE, async () => {
 		log.info("Updating project with mutator", { projectId });
-		const projects = await rawLoadAllProjects(true);
+		const projects = await rawLoadAllProjects({ strict: true, persistMigrations: true });
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) throw new Error(`Project not found: ${projectId}`);
 		const { updates, result } = await mutator(projects[idx]);
@@ -209,10 +237,7 @@ function nextSeq(tasks: Task[]): number {
 	return max + 1;
 }
 
-async function rawLoadTasks(
-	project: Project,
-	persistMigrations = false,
-): Promise<Task[]> {
+async function rawLoadTasks(project: Project, options?: { strict?: boolean; persistMigrations?: boolean }): Promise<Task[]> {
 	const file = tasksFile(project);
 	log.debug("Loading tasks", { projectId: project.id, file });
 	try {
@@ -254,7 +279,7 @@ async function rawLoadTasks(
 				}
 			}
 
-			if (persistMigrations) {
+			if (options?.persistMigrations) {
 				log.info("Backfilled seq for tasks", { projectId: project.id });
 				await rawSaveTasks(project, tasks);
 			}
@@ -268,6 +293,9 @@ async function rawLoadTasks(
 			return [];
 		}
 		log.error("Failed to load tasks", { projectId: project.id, error: String(err) });
+		if (options?.strict) {
+			throw toDataFileReadError(file, "tasks", err);
+		}
 		return [];
 	}
 }
@@ -318,7 +346,7 @@ export async function addTask(
 	return withFileLock(file, async () => {
 		const title = titleFromDescription(description);
 		log.info("Creating task", { projectId: project.id, title, status });
-		const tasks = await rawLoadTasks(project, true);
+		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const now = new Date().toISOString();
 		const task: Task = {
 			id: crypto.randomUUID(),
@@ -364,7 +392,7 @@ export async function updateTask(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Updating task", { taskId, updates });
-		const tasks = await rawLoadTasks(project, true);
+		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		const updatedTask = applyTaskUpdate(tasks, idx, updates, options);
@@ -386,7 +414,7 @@ export async function updateTaskWith<T>(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Updating task with mutator", { projectId: project.id, taskId });
-		const tasks = await rawLoadTasks(project, true);
+		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		const { updates, result } = await mutator(tasks[idx]);
@@ -403,7 +431,7 @@ export async function deleteTask(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Deleting task", { taskId, projectId: project.id });
-		const tasks = await rawLoadTasks(project, true);
+		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const filtered = tasks.filter((t) => t.id !== taskId);
 		await rawSaveTasks(project, filtered);
 	});
@@ -530,7 +558,7 @@ export async function reorderTasksInColumn(
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
 		log.info("Reordering task in column", { taskId, targetIndex, projectId: project.id });
-		const tasks = await rawLoadTasks(project, true);
+		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const task = tasks.find((t) => t.id === taskId);
 		if (!task) throw new Error(`Task not found: ${taskId}`);
 


### PR DESCRIPTION
## Summary

- `rawLoadAllProjects` and `rawLoadTasks` now accept a `strict` option that throws `DataFileReadError` instead of returning `[]` when the file exists but fails to parse
- All 9 write mutators (`addProject`, `removeProject`, `updateProject`, `updateProjectWith`, `addTask`, `updateTask`, `updateTaskWith`, `deleteTask`, `reorderTasksInColumn`) pass `strict: true`, blocking any save over a corrupt file
- Added regression tests that reproduce the old destructive-overwrite path and verify mutators now throw instead of wiping data