### PR TITLE
fix: declare desktop RPC schema messages

### DIFF
--- a/change-logs/2026/04/15/fix-desktop-rpc-schema-messages.md
+++ b/change-logs/2026/04/15/fix-desktop-rpc-schema-messages.md
@@ -1,0 +1,2 @@
+Declared the desktop-only RPC message ids for zoom controls and QR token consumption in the shared Electrobun schema.
+Updated the main-process desktop send calls to use typed message dispatch for those routes and added regression tests for the schema and renderer transport handlers.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -321,7 +321,11 @@ setTimeout(() => {
 // Wire push messages to renderer (Electrobun + browser clients)
 setPushMessage((name, payload) => {
 	log.debug("Push to renderer", { name });
-	(mainWindow.webview.rpc as any).send[name]?.(payload);
+	if (name === "qrTokenConsumed") {
+		mainWindow.webview.rpc?.send("qrTokenConsumed", {});
+	} else {
+		(mainWindow.webview.rpc as any).send[name]?.(payload);
+	}
 	pushToBrowserClients(name, payload);
 });
 
@@ -487,13 +491,13 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 			buttons: ["OK"],
 		});
 	} else if (e.data.action === "open-settings") {
-		(mainWindow.webview.rpc as any).send.navigateToSettings?.({});
+		mainWindow.webview.rpc?.send("navigateToSettings", {});
 	} else if (e.data.action === "open-add-project") {
-		(mainWindow.webview.rpc as any).send.openAddProjectModal?.({});
+		mainWindow.webview.rpc?.send("openAddProjectModal", {});
 	} else if (e.data.action === "gauge-demo") {
-		(mainWindow.webview.rpc as any).send.navigateToGaugeDemo?.({});
+		mainWindow.webview.rpc?.send("navigateToGaugeDemo", {});
 	} else if (e.data.action === "viewport-lab") {
-		(mainWindow.webview.rpc as any).send.navigateToViewportLab?.({});
+		mainWindow.webview.rpc?.send("navigateToViewportLab", {});
 	} else if (e.data.action === "check-for-updates") {
 		try {
 			const settings = await loadSettings();
@@ -566,25 +570,25 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 			});
 		}
 	} else if (e.data.action === "terminal-soft-reset") {
-		(mainWindow.webview.rpc as any).send.terminalSoftReset?.({});
+		mainWindow.webview.rpc?.send("terminalSoftReset", {});
 	} else if (e.data.action === "terminal-hard-reset") {
-		(mainWindow.webview.rpc as any).send.terminalHardReset?.({});
+		mainWindow.webview.rpc?.send("terminalHardReset", {});
 	} else if (e.data.action === "toggle-devtools") {
 		mainWindow.webview.openDevTools();
 	} else if (e.data.action === "open-logs-directory") {
 		openLogsDirectory();
 	} else if (e.data.action === "zoom-in") {
-		(mainWindow.webview.rpc as any).send.zoomIn?.({});
+		mainWindow.webview.rpc?.send("zoomIn", {});
 	} else if (e.data.action === "zoom-out") {
-		(mainWindow.webview.rpc as any).send.zoomOut?.({});
+		mainWindow.webview.rpc?.send("zoomOut", {});
 	} else if (e.data.action === "zoom-reset") {
-		(mainWindow.webview.rpc as any).send.zoomReset?.({});
+		mainWindow.webview.rpc?.send("zoomReset", {});
 	} else if (e.data.action === "show-remote-qr") {
 		try {
 			const qrDataUrl = await generateQrDataUrl();
 			const accessUrl = await getAccessUrl();
 			const { isCloudflaredAvailable, getTunnelState } = await import("./cloudflare-tunnel");
-			(mainWindow.webview.rpc as any).send.showRemoteAccessQR?.({ qrDataUrl, accessUrl, tunnelState: getTunnelState(), cloudflaredInstalled: isCloudflaredAvailable() });
+			mainWindow.webview.rpc?.send("showRemoteAccessQR", { qrDataUrl, accessUrl, tunnelState: getTunnelState(), cloudflaredInstalled: isCloudflaredAvailable() });
 		} catch (err) {
 			log.error("Failed to generate QR code", { error: String(err) });
 		}

--- a/src/mainview/__tests__/rpc-schema.test.ts
+++ b/src/mainview/__tests__/rpc-schema.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sharedTypesPath = resolve(process.cwd(), "src/shared/types.ts");
+const sharedTypesSource = readFileSync(sharedTypesPath, "utf8");
+
+describe("AppRPCSchema webview messages", () => {
+	it("declares desktop-only message ids used by the main process", () => {
+		expect(sharedTypesSource).toContain("zoomIn: {};");
+		expect(sharedTypesSource).toContain("zoomOut: {};");
+		expect(sharedTypesSource).toContain("zoomReset: {};");
+		expect(sharedTypesSource).toContain("qrTokenConsumed: {};");
+	});
+});

--- a/src/mainview/__tests__/rpc-transport.test.ts
+++ b/src/mainview/__tests__/rpc-transport.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { defineRPCMock, adjustZoomMock, applyZoomMock } = vi.hoisted(() => ({
+	defineRPCMock: vi.fn(),
+	adjustZoomMock: vi.fn(),
+	applyZoomMock: vi.fn(),
+}));
+
+vi.mock("electrobun/view", () => {
+	class ElectroviewMock {
+		static defineRPC = defineRPCMock;
+		rpc = { request: {} };
+
+		constructor(_options: unknown) {}
+	}
+
+	return { Electroview: ElectroviewMock };
+});
+
+vi.mock("../zoom", () => ({
+	adjustZoom: adjustZoomMock,
+	applyZoom: applyZoomMock,
+	ZOOM_STEP: 0.1,
+	DEFAULT_ZOOM: 1,
+}));
+
+describe("Electrobun RPC transport", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		defineRPCMock.mockReset();
+		adjustZoomMock.mockReset();
+		applyZoomMock.mockReset();
+		(window as any).__electrobunWebviewId = "test-webview";
+	});
+
+	afterEach(() => {
+		delete (window as any).__electrobunWebviewId;
+	});
+
+	it("registers desktop-only message handlers for zoom and QR token consumption", async () => {
+		const qrTokenConsumedListener = vi.fn();
+		window.addEventListener("rpc:qrTokenConsumed", qrTokenConsumedListener);
+
+		await import("../rpc");
+
+		const rpcConfig = defineRPCMock.mock.calls[0]?.[0];
+		expect(rpcConfig).toBeDefined();
+
+		rpcConfig.handlers.messages.zoomIn({});
+		rpcConfig.handlers.messages.zoomOut({});
+		rpcConfig.handlers.messages.zoomReset({});
+		rpcConfig.handlers.messages.qrTokenConsumed({});
+
+		expect(adjustZoomMock).toHaveBeenNthCalledWith(1, 0.1);
+		expect(adjustZoomMock).toHaveBeenNthCalledWith(2, -0.1);
+		expect(applyZoomMock).toHaveBeenCalledWith(1);
+		expect(qrTokenConsumedListener).toHaveBeenCalledTimes(1);
+
+		window.removeEventListener("rpc:qrTokenConsumed", qrTokenConsumedListener);
+	});
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1276,6 +1276,10 @@ export type AppRPCSchema = {
 			navigateToViewportLab: {};
 			terminalSoftReset: {};
 			terminalHardReset: {};
+			zoomIn: {};
+			zoomOut: {};
+			zoomReset: {};
+			qrTokenConsumed: {};
 			showRemoteAccessQR: { qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean };
 		};
 	}>;


### PR DESCRIPTION
## Summary

- Added `zoomIn`, `zoomOut`, `zoomReset`, and `qrTokenConsumed` to `AppRPCSchema["webview"]["messages"]` in `src/shared/types.ts`
- Removed `as any` casts from menu action handlers in `src/bun/index.ts`, replacing with typed `rpc.send("name", payload)` calls
- Added regression tests: schema-level check (`rpc-schema.test.ts`) and transport-level handler test (`rpc-transport.test.ts`)