### PR TITLE
fix: clarify partial macOS release artifact failures

### DIFF
--- a/change-logs/2026/04/15/fix-release-artifact-notary-diagnostic.md
+++ b/change-logs/2026/04/15/fix-release-artifact-notary-diagnostic.md
@@ -1,0 +1,1 @@
+Improved the release artifact recovery script so macOS CI failures that leave only `dev-3.0.app.zip` now report a likely post-packaging/notarization failure instead of the misleading "build failed before tarring" message. Added a regression test for the partial macOS artifact case.

--- a/scripts/create-release-artifacts.sh
+++ b/scripts/create-release-artifacts.sh
@@ -151,8 +151,15 @@ fi
 echo "Electrobun artifacts not found, recovering from build dir..."
 TAR_ZST="${BUILD_DIR}/${TAR_NAME}.zst"
 TAR="${BUILD_DIR}/${TAR_NAME}"
+PARTIAL_APP_ZIP="${BUILD_DIR}/${APP_BUNDLE}.zip"
 
 if [ ! -f "$TAR_ZST" ] && [ ! -f "$TAR" ]; then
+  if [ "$OS" = "macos" ] && [ -f "$PARTIAL_APP_ZIP" ]; then
+    echo "::error::Found ${PARTIAL_APP_ZIP} but no ${TAR_NAME}(.zst). Electrobun likely failed after packaging the app, for example during notarization. Check the earlier electrobun output for the real error."
+    find "${BUILD_DIR}" -maxdepth 2 -type f 2>/dev/null || true
+    exit 1
+  fi
+
   echo "::error::Neither tar.zst nor tar found — build failed before tarring"
   find ./build -maxdepth 3 -type f 2>/dev/null || true
   exit 1

--- a/src/bun/__tests__/create-release-artifacts.test.ts
+++ b/src/bun/__tests__/create-release-artifacts.test.ts
@@ -1,0 +1,41 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../../../scripts/create-release-artifacts.sh",
+);
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("create-release-artifacts.sh", () => {
+	it("surfaces partial macOS app zips as a post-package electrobun failure", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dev3-release-artifacts-"));
+		tempDirs.push(tempDir);
+
+		const buildDir = join(tempDir, "build", "stable-macos-arm64");
+		mkdirSync(buildDir, { recursive: true });
+		writeFileSync(join(buildDir, "dev-3.0.app.zip"), "fake zip");
+
+		const result = spawnSync("bash", [SCRIPT_PATH, "macos", "arm64"], {
+			cwd: tempDir,
+			encoding: "utf8",
+		});
+
+		expect(result.status).toBe(1);
+		expect(result.stdout).toContain("Electrobun likely failed after packaging the app");
+		expect(result.stdout).toContain("notarization");
+		expect(result.stdout).toContain("dev-3.0.app.zip");
+		expect(result.stdout).not.toContain("build failed before tarring");
+	});
+});


### PR DESCRIPTION
## Summary
- clarify macOS release artifact recovery when electrobun leaves only `dev-3.0.app.zip`
- surface likely post-packaging/notarization failures instead of the misleading tar error
- add a regression test for the partial macOS artifact case

## Testing
- bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/create-release-artifacts.test.ts
- bun run lint
- bun run test