### PR TITLE
fix: sign dev3-server for macOS release notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,13 +96,6 @@ jobs:
           bun scripts/generate-changelog.ts
           bunx vite build
           bun run build:cli
-          if [ -n "$ELECTROBUN_DEVELOPER_ID" ] && [ -f dist/dev3 ]; then
-            echo "Signing dist/dev3 with Developer ID..."
-            codesign --force --verbose --timestamp \
-              --sign "$ELECTROBUN_DEVELOPER_ID" \
-              --options runtime \
-              dist/dev3
-          fi
           bunx electrobun build --env=stable || echo "::warning::electrobun build exited with $? (recovering artifacts)"
 
       - name: Debug build output
@@ -201,13 +194,6 @@ jobs:
           bun scripts/generate-changelog.ts
           bunx vite build
           bun run build:cli
-          if [ -n "$ELECTROBUN_DEVELOPER_ID" ] && [ -f dist/dev3 ]; then
-            echo "Signing dist/dev3 with Developer ID..."
-            codesign --force --verbose --timestamp \
-              --sign "$ELECTROBUN_DEVELOPER_ID" \
-              --options runtime \
-              dist/dev3
-          fi
           bunx electrobun build --env=stable || echo "::warning::electrobun build exited with $? (recovering artifacts)"
 
       - name: Debug build output

--- a/change-logs/2026/04/15/fix-dev3-server-release-signing.md
+++ b/change-logs/2026/04/15/fix-dev3-server-release-signing.md
@@ -1,0 +1,1 @@
+Fixed the macOS release signing flow so both bundled CLI binaries, `dev3` and `dev3-server`, are signed with the Developer ID certificate before notarization. Added a regression test covering the release-signing mode of `scripts/sign-cli-binaries.sh`.

--- a/scripts/sign-cli-binaries.sh
+++ b/scripts/sign-cli-binaries.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
-# Apply an ad-hoc codesign to the locally-built CLI binaries on macOS.
+# Sign the locally-built CLI binaries on macOS.
 #
 # Why: `bun build --compile` produces a Mach-O with an embedded payload that
 # Apple's `codesign` rejects with "invalid or unsupported format for signature".
 # On macOS Sequoia (24+) AMFI then SIGKILLs unsigned binaries even when run
 # locally — the symptom is `[1] killed ./dist/dev3` with no output.
 # The fix is to first strip the bun-emitted pseudo-blob with
-# `codesign --remove-signature`, then ad-hoc sign with `codesign --sign -`.
+# `codesign --remove-signature`, then sign the clean Mach-O.
 #
-# This is an ad-hoc signature only — enough to satisfy AMFI for local
-# testing on the dev machine. Release builds are signed with a real Developer
-# ID via the Electrobun bundle pipeline (see electrobun.config.ts).
+# Default mode is an ad-hoc signature — enough to satisfy AMFI for local
+# testing on the dev machine. When `ELECTROBUN_DEVELOPER_ID` is present
+# (release CI), sign both CLI binaries with the real Developer ID before
+# Electrobun copies them into the app bundle.
 #
 # No-op on Linux/Windows/CI without macOS — they don't need a signature.
 
@@ -30,10 +31,20 @@ sign_one() {
   if [ ! -f "$bin" ]; then
     return 0
   fi
-  # Strip any pre-existing pseudo-blob from bun's output. Both stdout and
-  # stderr noise are silenced; the rebind below is what matters.
+
+  # Strip any pre-existing pseudo-blob from bun's output before re-signing.
   codesign --remove-signature "$bin" 2>/dev/null || true
-  codesign --force --sign - "$bin" 2>/dev/null
+
+  if [ -n "${ELECTROBUN_DEVELOPER_ID:-}" ]; then
+    codesign --force --verbose --timestamp \
+      --sign "$ELECTROBUN_DEVELOPER_ID" \
+      --options runtime \
+      "$bin"
+    echo "[sign-cli-binaries] Developer ID signed: $bin"
+    return 0
+  fi
+
+  codesign --force --sign - "$bin"
   echo "[sign-cli-binaries] ad-hoc signed: $bin"
 }
 

--- a/src/bun/__tests__/sign-cli-binaries.test.ts
+++ b/src/bun/__tests__/sign-cli-binaries.test.ts
@@ -1,0 +1,80 @@
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../../../scripts/sign-cli-binaries.sh",
+);
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function writeExecutable(path: string, content: string) {
+	writeFileSync(path, content);
+	chmodSync(path, 0o755);
+}
+
+describe("sign-cli-binaries.sh", () => {
+	it("uses Developer ID signing for both CLI binaries during release builds", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dev3-sign-cli-"));
+		tempDirs.push(tempDir);
+
+		const distDir = join(tempDir, "dist");
+		const binDir = join(tempDir, "bin");
+		const logPath = join(tempDir, "codesign.log");
+
+		mkdirSync(distDir, { recursive: true });
+		mkdirSync(binDir, { recursive: true });
+
+		writeFileSync(join(distDir, "dev3"), "fake");
+		writeFileSync(join(distDir, "dev3-server"), "fake");
+
+		writeExecutable(join(binDir, "uname"), "#!/bin/bash\necho Darwin\n");
+		writeExecutable(
+			join(binDir, "codesign"),
+			`#!/bin/bash
+echo "$@" >> "${logPath}"
+exit 0
+`,
+		);
+
+		const result = spawnSync("bash", [SCRIPT_PATH], {
+			cwd: tempDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				PATH: `${binDir}:${process.env.PATH ?? ""}`,
+				ELECTROBUN_DEVELOPER_ID: "Developer ID Application: Example Corp (TEAMID)",
+			},
+		});
+
+		expect(result.status).toBe(0);
+
+		const log = readFileSync(logPath, "utf8");
+		expect(log).toContain("--remove-signature dist/dev3");
+		expect(log).toContain("--remove-signature dist/dev3-server");
+		expect(log).toContain(
+			'--force --verbose --timestamp --sign Developer ID Application: Example Corp (TEAMID) --options runtime dist/dev3',
+		);
+		expect(log).toContain(
+			'--force --verbose --timestamp --sign Developer ID Application: Example Corp (TEAMID) --options runtime dist/dev3-server',
+		);
+		expect(log).not.toContain("--sign - dist/dev3-server");
+	});
+});


### PR DESCRIPTION
## Summary
- sign both bundled CLI binaries with Developer ID in release CI when ELECTROBUN_DEVELOPER_ID is set
- remove the duplicated release.yml re-sign step that only handled dist/dev3
- add a regression test for scripts/sign-cli-binaries.sh release mode

## Testing
- bunx vitest run src/bun/__tests__/sign-cli-binaries.test.ts --config vitest.config.bun.ts
- bun run lint
- bun run test