### PR TITLE
fix: persist theme preference for remote access

### DIFF
--- a/change-logs/2026/04/16/fix-remote-theme-persistence.md
+++ b/change-logs/2026/04/16/fix-remote-theme-persistence.md
@@ -1,0 +1,1 @@
+Persist the resolved UI theme and the selected theme preference when tmux theme changes, then inject that state into remote HTML bootstrap. Remote clients now reuse the last user-selected light or dark mode instead of falling back to a fresh browser default.

--- a/src/bun/__tests__/remote-access-server.test.ts
+++ b/src/bun/__tests__/remote-access-server.test.ts
@@ -53,6 +53,17 @@ vi.mock("../cloudflare-tunnel", () => ({
 	getTunnelUrl: vi.fn().mockReturnValue(null),
 }));
 
+vi.mock("../settings", () => ({
+	loadSettingsSync: vi.fn(() => ({
+		theme: "light",
+		resolvedTheme: "light",
+	})),
+}));
+
+vi.mock("../theme-state", () => ({
+	getCurrentUiTheme: vi.fn(() => "dark"),
+}));
+
 vi.mock("qrcode", () => ({
 	default: { toDataURL: vi.fn().mockResolvedValue("data:image/png;base64,test") },
 }));
@@ -123,6 +134,16 @@ describe("serveStatic path traversal protection", () => {
 // ================================================================
 
 import { exchangeQrForSession, refreshSession, verifySessionToken } from "../jwt";
+import { injectInitialThemeBootstrap } from "../remote-access-server";
+
+describe("injectInitialThemeBootstrap", () => {
+	it("injects the persisted theme state into the initial HTML", () => {
+		const html = injectInitialThemeBootstrap("<html><head></head><body></body></html>");
+
+		expect(html).toContain('window.__DEV3_INITIAL_THEME__="light"');
+		expect(html).toContain('window.__DEV3_INITIAL_RESOLVED_THEME__="light"');
+	});
+});
 
 describe("auth endpoint logic", () => {
 	it("exchangeQrForSession returns session token for valid QR token", async () => {
@@ -308,4 +329,3 @@ describe("uploadImageBase64 size limit", () => {
 		expect(smallPayload.length).toBeLessThan(MAX_BASE64_SIZE);
 	});
 });
-

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -92,6 +92,7 @@ vi.mock("../pty-server", () => ({
 	getSessionTmuxName: vi.fn((key: string) => `dev3-${key.slice(0, 8)}`),
 	getSessionType: vi.fn(() => null),
 	capturePane: vi.fn(),
+	applyTmuxTheme: vi.fn(),
 	tmuxArgs: vi.fn((_socket: string, ...args: string[]) => ["tmux", "-L", _socket, ...args]),
 	setTmuxBinary: vi.fn(),
 	getTmuxBinary: vi.fn(() => "tmux"),
@@ -980,6 +981,27 @@ describe("handlers.saveGlobalSettings", () => {
 		const settings = { updateChannel: "stable" } as GlobalSettings;
 		await handlers.saveGlobalSettings(settings);
 		expect(saveSettings).toHaveBeenCalledWith(settings);
+	});
+});
+
+describe("handlers.setTmuxTheme", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("persists the theme preference and resolved theme before applying tmux theme", async () => {
+		vi.mocked(loadSettings).mockResolvedValue({
+			defaultAgentId: "builtin-claude",
+			defaultConfigId: "claude-default",
+			taskDropPosition: "top",
+			updateChannel: "stable",
+		} as GlobalSettings);
+
+		await handlers.setTmuxTheme({ theme: "light", preference: "system" });
+
+		expect(saveSettings).toHaveBeenCalledWith(expect.objectContaining({
+			theme: "system",
+			resolvedTheme: "light",
+		}));
+		expect(pty.applyTmuxTheme).toHaveBeenCalledWith("light");
 	});
 });
 

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -20,6 +20,8 @@ import { PATHS } from "./electrobun-platform";
 import { createLogger } from "./logger";
 import { initSecret, createQrToken, createSessionToken, exchangeQrForSession, refreshSession, verifySessionToken } from "./jwt";
 import { getTunnelUrl } from "./cloudflare-tunnel";
+import { loadSettingsSync } from "./settings";
+import { getCurrentUiTheme } from "./theme-state";
 
 const log = createLogger("remote-access");
 
@@ -128,12 +130,40 @@ export async function serveStatic(pathname: string): Promise<Response | null> {
 	const contentType = MIME_TYPES[ext] || "application/octet-stream";
 	const file = Bun.file(filePath);
 
+	if (contentType.startsWith("text/html")) {
+		const html = await file.text();
+		return new Response(injectInitialThemeBootstrap(html), {
+			headers: {
+				"Content-Type": contentType,
+				"Cache-Control": "no-cache, no-store, must-revalidate",
+			},
+		});
+	}
+
 	return new Response(file, {
 		headers: {
 			"Content-Type": contentType,
 			"Cache-Control": "no-cache, no-store, must-revalidate",
 		},
 	});
+}
+
+function getInitialThemeBootstrap(): { preference: "dark" | "light" | "system"; resolved: "dark" | "light" } {
+	const settings = loadSettingsSync();
+	const resolved = settings.resolvedTheme ?? getCurrentUiTheme();
+	const preference = settings.theme ?? resolved;
+	return { preference, resolved };
+}
+
+export function injectInitialThemeBootstrap(html: string): string {
+	const { preference, resolved } = getInitialThemeBootstrap();
+	const script =
+		`<script>window.__DEV3_INITIAL_THEME__=${JSON.stringify(preference)};` +
+		`window.__DEV3_INITIAL_RESOLVED_THEME__=${JSON.stringify(resolved)};</script>`;
+
+	return html.includes("</head>")
+		? html.replace("</head>", `${script}</head>`)
+		: `${script}${html}`;
 }
 
 // ── PTY proxy ───────────────────────────────────────────────────────

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -318,8 +318,14 @@ async function setAgentBinaryPath(params: { agentId: string; path: string }): Pr
 	log.info("<- setAgentBinaryPath saved");
 }
 
-async function setTmuxTheme(params: { theme: "dark" | "light" }): Promise<void> {
+async function setTmuxTheme(params: { theme: "dark" | "light"; preference?: "dark" | "light" | "system" }): Promise<void> {
 	log.info("→ setTmuxTheme", params);
+	const settings = await loadSettings();
+	await saveSettings({
+		...settings,
+		...(params.preference !== undefined ? { theme: params.preference } : {}),
+		resolvedTheme: params.theme,
+	});
 	setCurrentUiTheme(params.theme);
 	pty.applyTmuxTheme(params.theme);
 }

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -13,6 +13,8 @@ export interface GlobalSettings {
 	defaultConfigId: string;
 	taskDropPosition: "top" | "bottom";
 	updateChannel: "stable" | "canary";
+	theme?: "dark" | "light" | "system";
+	resolvedTheme?: "dark" | "light";
 	cloneBaseDirectory?: string;
 	customBinaryPaths?: Record<string, string>;
 	agentBinaryPaths?: Record<string, string>;
@@ -43,6 +45,8 @@ export async function loadSettings(): Promise<GlobalSettings> {
 			defaultConfigId: data.defaultConfigId ?? DEFAULT_SETTINGS.defaultConfigId,
 			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
 			updateChannel: data.updateChannel === "canary" ? "canary" : "stable",
+			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
+			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
 			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
 			customBinaryPaths: data.customBinaryPaths ?? undefined,
 			agentBinaryPaths: data.agentBinaryPaths ?? undefined,
@@ -81,6 +85,8 @@ export function loadSettingsSync(): GlobalSettings {
 			defaultConfigId: data.defaultConfigId ?? DEFAULT_SETTINGS.defaultConfigId,
 			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
 			updateChannel: data.updateChannel === "canary" ? "canary" : "stable",
+			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
+			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
 			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
 			customBinaryPaths: data.customBinaryPaths ?? undefined,
 			agentBinaryPaths: data.agentBinaryPaths ?? undefined,

--- a/src/mainview/__tests__/theme-bootstrap.test.ts
+++ b/src/mainview/__tests__/theme-bootstrap.test.ts
@@ -43,4 +43,21 @@ describe("getInitialThemeState", () => {
 			resolved: "light",
 		});
 	});
+
+	it("falls back to localStorage after injected state is cleared (OS theme change scenario)", () => {
+		// Simulates what happens when the user manually picks a theme after remote page load,
+		// then the OS switches modes. By that point injectedTheme has been consumed (set to
+		// undefined) so localStorage must win — otherwise the user's choice gets overwritten.
+		expect(
+			getInitialThemeState({
+				localStorageTheme: "dark",
+				injectedTheme: undefined,
+				injectedResolvedTheme: undefined,
+				prefersDark: true,
+			}),
+		).toEqual({
+			preference: "dark",
+			resolved: "dark",
+		});
+	});
 });

--- a/src/mainview/__tests__/theme-bootstrap.test.ts
+++ b/src/mainview/__tests__/theme-bootstrap.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { getInitialThemeState } from "../theme-bootstrap";
+
+describe("getInitialThemeState", () => {
+	it("uses the injected remote theme when browser storage is empty", () => {
+		expect(
+			getInitialThemeState({
+				localStorageTheme: null,
+				injectedTheme: "light",
+				injectedResolvedTheme: "light",
+				prefersDark: true,
+			}),
+		).toEqual({
+			preference: "light",
+			resolved: "light",
+		});
+	});
+
+	it("prefers the injected remote theme over stale browser storage", () => {
+		expect(
+			getInitialThemeState({
+				localStorageTheme: "dark",
+				injectedTheme: "light",
+				injectedResolvedTheme: "light",
+				prefersDark: false,
+			}),
+		).toEqual({
+			preference: "light",
+			resolved: "light",
+		});
+	});
+
+	it("uses the injected resolved theme for system preference", () => {
+		expect(
+			getInitialThemeState({
+				localStorageTheme: null,
+				injectedTheme: "system",
+				injectedResolvedTheme: "light",
+				prefersDark: true,
+			}),
+		).toEqual({
+			preference: "system",
+			resolved: "light",
+		});
+	});
+});

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -13,6 +13,7 @@ import type {
 import { invalidateAvailableApps } from "../hooks/useAvailableApps";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { api } from "../rpc";
+import { getInitialThemeState, getWindowInjectedThemeState } from "../theme-bootstrap";
 import { getZoom, ZOOM_CHANGED_EVENT } from "../zoom";
 import { getKeymapPreset, setKeymapPreset } from "../terminal-keymaps";
 import { trackEvent } from "../analytics";
@@ -48,9 +49,15 @@ interface SettingChangeOptions extends PersistOptions {
 function GlobalSettings() {
 	const t = useT();
 	const [locale, setLocale] = useLocale();
+	const injectedThemeState = getWindowInjectedThemeState();
 
 	const [theme, setTheme] = useState<Theme>(
-		() => (localStorage.getItem("dev3-theme") as Theme) || "dark",
+		() =>
+			getInitialThemeState({
+				localStorageTheme: localStorage.getItem("dev3-theme"),
+				prefersDark: window.matchMedia("(prefers-color-scheme: dark)").matches,
+				...injectedThemeState,
+			}).preference,
 	);
 	const [zoomLevel, setZoomLevel] = useState(() => getZoom());
 	const [cliInstallStatus, setCliInstallStatus] = useState<string | null>(null);
@@ -152,7 +159,7 @@ function GlobalSettings() {
 		const resolvedTheme = resolveTheme(nextTheme, prefersDark);
 		document.documentElement.dataset.theme = resolvedTheme;
 		localStorage.setItem("dev3-theme", nextTheme);
-		api.request.setTmuxTheme({ theme: resolvedTheme }).catch(() => {});
+		api.request.setTmuxTheme({ theme: resolvedTheme, preference: nextTheme }).catch(() => {});
 		trackEvent("theme_changed", { theme: nextTheme });
 	}, []);
 

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -150,6 +150,7 @@ describe("GlobalSettings", () => {
 
 			expect(document.documentElement.dataset.theme).toBe("dark");
 			expect(localStorage.getItem("dev3-theme")).toBe("dark");
+			expect(mockedApi.request.setTmuxTheme).toHaveBeenCalledWith({ theme: "dark", preference: "dark" });
 		});
 
 		it("applies light theme", async () => {
@@ -162,6 +163,7 @@ describe("GlobalSettings", () => {
 
 			expect(document.documentElement.dataset.theme).toBe("light");
 			expect(localStorage.getItem("dev3-theme")).toBe("light");
+			expect(mockedApi.request.setTmuxTheme).toHaveBeenCalledWith({ theme: "light", preference: "light" });
 		});
 
 		it("applies system theme based on prefers-color-scheme", async () => {
@@ -183,6 +185,7 @@ describe("GlobalSettings", () => {
 
 			expect(document.documentElement.dataset.theme).toBe("dark");
 			expect(localStorage.getItem("dev3-theme")).toBe("system");
+			expect(mockedApi.request.setTmuxTheme).toHaveBeenCalledWith({ theme: "dark", preference: "system" });
 		});
 	});
 

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -33,7 +33,8 @@ window.addEventListener("unhandledrejection", (event) => {
 
 // Apply saved theme before React mounts & keep in sync with OS
 const systemThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
-const injectedThemeState = getWindowInjectedThemeState();
+// Consumed once on first call so OS-change reruns don't override the user's manual choice.
+let injectedThemeState = getWindowInjectedThemeState();
 
 function applySavedTheme() {
 	const { preference, resolved } = getInitialThemeState({
@@ -41,6 +42,7 @@ function applySavedTheme() {
 		prefersDark: systemThemeMq.matches,
 		...injectedThemeState,
 	});
+	injectedThemeState = {};
 	document.documentElement.dataset.theme = resolved;
 	localStorage.setItem("dev3-theme", preference);
 	api.request.setTmuxTheme({ theme: resolved, preference }).catch(() => {});

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -9,6 +9,7 @@ import { MobileProvider } from "./hooks/useMobile";
 import { initAnalytics } from "./analytics";
 import { api } from "./rpc";
 import { bootstrapZoom } from "./zoom";
+import { getInitialThemeState, getWindowInjectedThemeState } from "./theme-bootstrap";
 
 // ── Global crash handlers (renderer) ──
 // Catch unhandled errors that would otherwise silently kill the page.
@@ -32,13 +33,17 @@ window.addEventListener("unhandledrejection", (event) => {
 
 // Apply saved theme before React mounts & keep in sync with OS
 const systemThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
+const injectedThemeState = getWindowInjectedThemeState();
 
 function applySavedTheme() {
-	const saved = localStorage.getItem("dev3-theme") || "dark";
-	const resolved: "dark" | "light" =
-		saved === "system" ? (systemThemeMq.matches ? "dark" : "light") : (saved as "dark" | "light");
+	const { preference, resolved } = getInitialThemeState({
+		localStorageTheme: localStorage.getItem("dev3-theme"),
+		prefersDark: systemThemeMq.matches,
+		...injectedThemeState,
+	});
 	document.documentElement.dataset.theme = resolved;
-	api.request.setTmuxTheme({ theme: resolved }).catch(() => {});
+	localStorage.setItem("dev3-theme", preference);
+	api.request.setTmuxTheme({ theme: resolved, preference }).catch(() => {});
 }
 
 applySavedTheme();

--- a/src/mainview/theme-bootstrap.ts
+++ b/src/mainview/theme-bootstrap.ts
@@ -1,0 +1,55 @@
+export type ThemePreference = "dark" | "light" | "system";
+export type ResolvedTheme = "dark" | "light";
+
+interface ThemeBootstrapOptions {
+	localStorageTheme: string | null;
+	injectedTheme?: string | null;
+	injectedResolvedTheme?: string | null;
+	prefersDark: boolean;
+}
+
+interface ThemeBootstrapWindow {
+	__DEV3_INITIAL_THEME__?: string;
+	__DEV3_INITIAL_RESOLVED_THEME__?: string;
+}
+
+function parseThemePreference(value: string | null | undefined): ThemePreference | undefined {
+	if (value === "dark" || value === "light" || value === "system") {
+		return value;
+	}
+	return undefined;
+}
+
+function parseResolvedTheme(value: string | null | undefined): ResolvedTheme | undefined {
+	if (value === "dark" || value === "light") {
+		return value;
+	}
+	return undefined;
+}
+
+export function getWindowInjectedThemeState(win: Window & typeof globalThis = window): {
+	injectedTheme?: ThemePreference;
+	injectedResolvedTheme?: ResolvedTheme;
+} {
+	const bootstrapWindow = win as Window & typeof globalThis & ThemeBootstrapWindow;
+	return {
+		injectedTheme: parseThemePreference(bootstrapWindow.__DEV3_INITIAL_THEME__),
+		injectedResolvedTheme: parseResolvedTheme(bootstrapWindow.__DEV3_INITIAL_RESOLVED_THEME__),
+	};
+}
+
+export function getInitialThemeState(options: ThemeBootstrapOptions): {
+	preference: ThemePreference;
+	resolved: ResolvedTheme;
+} {
+	const injectedTheme = parseThemePreference(options.injectedTheme);
+	const localStorageTheme = parseThemePreference(options.localStorageTheme);
+	const injectedResolvedTheme = parseResolvedTheme(options.injectedResolvedTheme);
+	const preference = injectedTheme ?? localStorageTheme ?? "dark";
+	const resolved =
+		preference === "system"
+			? injectedResolvedTheme ?? (options.prefersDark ? "dark" : "light")
+			: preference;
+
+	return { preference, resolved };
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -359,6 +359,8 @@ export interface GlobalSettings {
 	defaultConfigId: string;
 	taskDropPosition: "top" | "bottom";
 	updateChannel: "stable" | "canary";
+	theme?: "dark" | "light" | "system";
+	resolvedTheme?: "dark" | "light";
 	cloneBaseDirectory?: string;
 	customBinaryPaths?: Record<string, string>; // requirementId → custom binary path
 	agentBinaryPaths?: Record<string, string>; // agentId → resolved binary path
@@ -1224,7 +1226,7 @@ export type AppRPCSchema = {
 				response: PRInfo[];
 			};
 			setTmuxTheme: {
-				params: { theme: "dark" | "light" };
+				params: { theme: "dark" | "light"; preference?: "dark" | "light" | "system" };
 				response: void;
 			};
 			checkCaffeinateAvailable: {


### PR DESCRIPTION
## Summary

- Saves the user's theme preference (`dark` / `light` / `system`) and the resolved theme to settings whenever `setTmuxTheme` is called, so the choice survives across sessions.
- When serving static HTML in remote mode, the server injects `window.__DEV3_INITIAL_THEME__` / `window.__DEV3_INITIAL_RESOLVED_THEME__` into `<head>` so the renderer bootstraps with the correct theme before React mounts (no flash of wrong theme).
- Fixes a bug where the injected theme state was not cleared after first use — causing the server's original theme to silently override the user's manual choice whenever the OS switched dark/light mode.