### PR TITLE
Fix OSC 52 clipboard forwarding to client

### DIFF
--- a/change-logs/2026/04/16/fix-client-side-osc52-clipboard.md
+++ b/change-logs/2026/04/16/fix-client-side-osc52-clipboard.md
@@ -1,0 +1,1 @@
+Moved OSC 52 clipboard handling from the PTY server to the renderer by forwarding decoded payloads over RPC and writing them with navigator.clipboard on the client. Removed the tmux pbcopy copy-pipe bindings so remote access and Linux terminals no longer depend on server-side macOS clipboard tooling.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -43,6 +43,7 @@ import {
 	getPtyPort,
 	setOnPtyDied,
 	setOnBell,
+	setOnOsc52Copy,
 	TMUX_CONF_PATH,
 } from "../pty-server";
 
@@ -88,6 +89,7 @@ afterEach(() => {
 	activeSessions.length = 0;
 	setOnPtyDied(() => {});
 	setOnBell(() => {});
+	setOnOsc52Copy(() => {});
 });
 
 // ================================================================
@@ -630,37 +632,40 @@ describe("pty-server", () => {
 			expect(bellCb).toHaveBeenCalledWith(id);
 		});
 
-		it("handles OSC 52 clipboard data and calls pbcopy", () => {
+		it("emits OSC 52 clipboard data to the client instead of spawning pbcopy", () => {
 			const id = track("task-osc52-01");
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
+			const osc52Cb = vi.fn();
+			setOnOsc52Copy(osc52Cb);
 
 			const testText = "Hello clipboard";
 			const b64 = Buffer.from(testText).toString("base64");
 			const osc52Seq = `\x1b]52;c;${b64}\x07`;
 
-			// Reset spawn mock to track pbcopy call
 			mockSpawn.mockClear();
-			const mockStdin = { write: vi.fn(), end: vi.fn() };
-			mockSpawn.mockReturnValue({ pid: 999, stdin: mockStdin } as any);
 
 			capturedDataCb!(null, osc52Seq);
 
-			expect(mockSpawn).toHaveBeenCalledWith(
-				["pbcopy"],
-				expect.objectContaining({ stdin: "pipe" }),
-			);
+			expect(osc52Cb).toHaveBeenCalledWith({
+				taskId: id,
+				text: testText,
+				len: testText.length,
+			});
+			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 
 		it("ignores OSC 52 query (b64 is '?')", () => {
 			const id = track("task-osc52-02");
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
+			const osc52Cb = vi.fn();
+			setOnOsc52Copy(osc52Cb);
 
 			mockSpawn.mockClear();
 
 			// OSC 52 query: base64 content is "?"
 			capturedDataCb!(null, "\x1b]52;c;?\x07");
 
-			// pbcopy should NOT be called
+			expect(osc52Cb).not.toHaveBeenCalled();
 			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -114,7 +114,7 @@ const cliSocketPath = startSocketServer();
 log.info("CLI socket server ready", { path: cliSocketPath });
 
 // ── PTY / port scanner / resource monitor (dynamic import so PATH is patched first) ──
-const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, getActiveSessionIds, getPtyPort } = await import("./pty-server");
+const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");
 const { startResourceMonitor, stopResourceMonitor } = await import("./resource-monitor");
 
@@ -227,6 +227,17 @@ setOnIdle((sessionKey) => {
 	}).catch((err) => {
 		log.error("isTaskInProgress failed in idle handler", { error: String(err) });
 	});
+});
+
+setOnOsc52Copy((payload) => {
+	try {
+		pushToBrowserClients("osc52Clipboard", payload);
+	} catch (err) {
+		log.error("Failed to forward OSC 52 clipboard payload", {
+			taskId: payload.taskId.slice(0, 8),
+			error: String(err),
+		});
+	}
 });
 
 setOnPaneExited((taskId, paneId) => {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -180,7 +180,7 @@ const cliSocketPath = startSocketServer();
 log.info("CLI socket server ready", { path: cliSocketPath });
 
 // Side-effect: starts the PTY WebSocket server (dynamic import so PATH is patched first)
-const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, getActiveSessionIds, getPtyPort } = await import("./pty-server");
+const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");
 const { startResourceMonitor, stopResourceMonitor } = await import("./resource-monitor");
 
@@ -445,6 +445,18 @@ setOnIdle((sessionKey) => {
 	}).catch((err) => {
 		log.error("isTaskInProgress failed in idle handler", { error: String(err) });
 	});
+});
+
+setOnOsc52Copy((payload) => {
+	try {
+		(mainWindow.webview.rpc as any).send.osc52Clipboard?.(payload);
+		pushToBrowserClients("osc52Clipboard", payload);
+	} catch (err) {
+		log.error("Failed to forward OSC 52 clipboard payload", {
+			taskId: payload.taskId.slice(0, 8),
+			error: String(err),
+		});
+	}
 });
 
 // Wire pane-exited notifications — remove dead pane entries from sessionState

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -75,8 +75,6 @@ set -g pane-border-lines double
 
 # Clipboard support
 set -s set-clipboard on
-bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 
 # Bell pass-through
 set -g visual-bell off
@@ -211,6 +209,7 @@ let onPtyDiedCallback: ((taskId: string) => void) | null = null;
 let onBellCallback: ((taskId: string) => void) | null = null;
 let onIdleCallback: ((taskId: string) => void) | null = null;
 let onPaneExitedCallback: ((taskId: string, paneId: string) => void) | null = null;
+let onOsc52CopyCallback: ((payload: { taskId: string; text: string; len: number }) => void) | null = null;
 
 export function setOnPtyDied(fn: (taskId: string) => void): void {
 	onPtyDiedCallback = fn;
@@ -226,6 +225,10 @@ export function setOnIdle(fn: (taskId: string) => void): void {
 
 export function setOnPaneExited(fn: (taskId: string, paneId: string) => void): void {
 	onPaneExitedCallback = fn;
+}
+
+export function setOnOsc52Copy(fn: (payload: { taskId: string; text: string; len: number }) => void): void {
+	onOsc52CopyCallback = fn;
 }
 
 
@@ -450,16 +453,16 @@ const OSC52_RE = /\x1b\]52;[^;]*;([A-Za-z0-9+/=]*)(?:\x07|\x1b\\)/g;
 // before checking for standalone BEL (\x07)
 const OSC_ANY_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
-function handleOsc52(data: string): string {
+function handleOsc52(data: string, taskId: string): string {
 	return data.replace(OSC52_RE, (_match, b64: string) => {
 		if (b64 && b64 !== "?") {
 			try {
 				const text = Buffer.from(b64, "base64").toString("utf-8");
-				const proc = spawn(["pbcopy"], { stdin: "pipe" });
-				const pbcopyStdin = proc.stdin as unknown as import("bun").FileSink;
-				pbcopyStdin.write(text);
-				pbcopyStdin.end();
-				log.info("OSC 52: copied to clipboard", { len: text.length });
+				onOsc52CopyCallback?.({ taskId, text, len: text.length });
+				log.info("OSC 52: forwarded clipboard payload to client", {
+					taskId: shortId(taskId),
+					len: text.length,
+				});
 			} catch {
 				// ignore
 			}
@@ -623,7 +626,7 @@ function spawnPty(session: PtySession, cols: number, rows: number): void {
 							session.lastOutputTime = Date.now();
 							session.idleNotified = false;
 							checkForBell(str, session.taskId);
-							const cleaned = handleOsc52(str);
+							const cleaned = handleOsc52(str, session.taskId);
 							if (cleaned && session.clients.size > 0) {
 								enqueuePtyData(session, cleaned);
 							}

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -139,6 +139,17 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 	}, []);
 
 	useEffect(() => {
+		function handleOsc52Clipboard(event: Event) {
+			const detail = (event as CustomEvent<{ taskId?: string; text?: string }>).detail;
+			if (detail?.taskId !== taskId || typeof detail.text !== "string") return;
+			navigator.clipboard?.writeText(detail.text).catch(() => {});
+		}
+
+		window.addEventListener("rpc:osc52Clipboard", handleOsc52Clipboard);
+		return () => window.removeEventListener("rpc:osc52Clipboard", handleOsc52Clipboard);
+	}, [taskId]);
+
+	useEffect(() => {
 		let disposed = false;
 		let fitAddon: FitAddon | null = null;
 		let ws: WebSocket | null = null;

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -137,6 +137,12 @@ beforeEach(() => {
 		configurable: true,
 		value: { load: vi.fn().mockReturnValue(Promise.resolve([])) },
 	});
+	Object.defineProperty(navigator, "clipboard", {
+		configurable: true,
+		value: {
+			writeText: vi.fn().mockResolvedValue(undefined),
+		},
+	});
 });
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -434,6 +440,38 @@ describe("TerminalView – drag-and-drop", () => {
 		await waitFor(() => {
 			expect(lastWebSocket?.send).toHaveBeenCalledWith("/tmp/uploaded-drop.jpg");
 		});
+	});
+});
+
+describe("TerminalView – OSC 52 clipboard", () => {
+	it("writes OSC 52 payloads for the active terminal to navigator.clipboard", async () => {
+		await renderAndSetup();
+		const writeText = vi.mocked(navigator.clipboard.writeText);
+
+		await act(async () => {
+			window.dispatchEvent(
+				new CustomEvent("rpc:osc52Clipboard", {
+					detail: { taskId: "t1", text: "copied from osc52", len: 17 },
+				}),
+			);
+		});
+
+		expect(writeText).toHaveBeenCalledWith("copied from osc52");
+	});
+
+	it("ignores OSC 52 payloads for other terminals", async () => {
+		await renderAndSetup();
+		const writeText = vi.mocked(navigator.clipboard.writeText);
+
+		await act(async () => {
+			window.dispatchEvent(
+				new CustomEvent("rpc:osc52Clipboard", {
+					detail: { taskId: "someone-else", text: "nope", len: 4 },
+				}),
+			);
+		});
+
+		expect(writeText).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/mainview/__tests__/rpc-schema.test.ts
+++ b/src/mainview/__tests__/rpc-schema.test.ts
@@ -11,5 +11,6 @@ describe("AppRPCSchema webview messages", () => {
 		expect(sharedTypesSource).toContain("zoomOut: {};");
 		expect(sharedTypesSource).toContain("zoomReset: {};");
 		expect(sharedTypesSource).toContain("qrTokenConsumed: {};");
+		expect(sharedTypesSource).toContain("osc52Clipboard: { taskId: string; text: string; len: number };");
 	});
 });

--- a/src/mainview/__tests__/rpc-transport.test.ts
+++ b/src/mainview/__tests__/rpc-transport.test.ts
@@ -37,9 +37,11 @@ describe("Electrobun RPC transport", () => {
 		delete (window as any).__electrobunWebviewId;
 	});
 
-	it("registers desktop-only message handlers for zoom and QR token consumption", async () => {
+	it("registers desktop-only message handlers for zoom, OSC 52 clipboard, and QR token consumption", async () => {
 		const qrTokenConsumedListener = vi.fn();
+		const osc52ClipboardListener = vi.fn();
 		window.addEventListener("rpc:qrTokenConsumed", qrTokenConsumedListener);
+		window.addEventListener("rpc:osc52Clipboard", osc52ClipboardListener);
 
 		await import("../rpc");
 
@@ -49,13 +51,19 @@ describe("Electrobun RPC transport", () => {
 		rpcConfig.handlers.messages.zoomIn({});
 		rpcConfig.handlers.messages.zoomOut({});
 		rpcConfig.handlers.messages.zoomReset({});
+		rpcConfig.handlers.messages.osc52Clipboard({ taskId: "task-1", text: "copied", len: 6 });
 		rpcConfig.handlers.messages.qrTokenConsumed({});
 
 		expect(adjustZoomMock).toHaveBeenNthCalledWith(1, 0.1);
 		expect(adjustZoomMock).toHaveBeenNthCalledWith(2, -0.1);
 		expect(applyZoomMock).toHaveBeenCalledWith(1);
+		expect(osc52ClipboardListener).toHaveBeenCalledTimes(1);
+		expect(osc52ClipboardListener.mock.calls[0]?.[0]).toMatchObject({
+			detail: { taskId: "task-1", text: "copied", len: 6 },
+		});
 		expect(qrTokenConsumedListener).toHaveBeenCalledTimes(1);
 
 		window.removeEventListener("rpc:qrTokenConsumed", qrTokenConsumedListener);
+		window.removeEventListener("rpc:osc52Clipboard", osc52ClipboardListener);
 	});
 });

--- a/src/mainview/__tests__/shift-keys-e2e.test.ts
+++ b/src/mainview/__tests__/shift-keys-e2e.test.ts
@@ -75,8 +75,6 @@ set -g status-right-length 150
 
 # Clipboard support
 set -s set-clipboard on
-bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 
 # Bell pass-through
 set -g visual-bell off

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -24,6 +24,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	zoomIn: () => adjustZoom(ZOOM_STEP),
 	zoomOut: () => adjustZoom(-ZOOM_STEP),
 	zoomReset: () => applyZoom(DEFAULT_ZOOM),
+	osc52Clipboard: (payload) => window.dispatchEvent(new CustomEvent("rpc:osc52Clipboard", { detail: payload })),
 	showRemoteAccessQR: (payload) => window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", { detail: payload })),
 	qrTokenConsumed: () => window.dispatchEvent(new CustomEvent("rpc:qrTokenConsumed")),
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1281,6 +1281,7 @@ export type AppRPCSchema = {
 			zoomIn: {};
 			zoomOut: {};
 			zoomReset: {};
+			osc52Clipboard: { taskId: string; text: string; len: number };
 			qrTokenConsumed: {};
 			showRemoteAccessQR: { qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean };
 		};


### PR DESCRIPTION
## Summary

- Remove server-side `pbcopy` handling for OSC 52 escape sequences — Linux-incompatible and wrong for remote mode
- Parse OSC 52 in `pty-server.ts` and forward decoded text to clients via callback, then push through Electrobun RPC (desktop) and/or WebSocket (remote/headless)
- Handle clipboard write in `TerminalView.tsx` via `navigator.clipboard.writeText()`, filtered by `taskId`
- Removes macOS dependency in PTY layer; Linux and headless remote mode now work without `pbcopy`/`xclip`