### PR TITLE
fix: upload dropped files into worktree

### DIFF
--- a/change-logs/2026/04/16/fix-dropped-files-upload-to-worktree.md
+++ b/change-logs/2026/04/16/fix-dropped-files-upload-to-worktree.md
@@ -1,0 +1,1 @@
+Dropped files now upload their content into the task worktree uploads directory and use the returned server path instead of trying to resolve a host-system filename. This removes the macOS Spotlight dependency from drag-and-drop and makes the flow work the same in local and remote sessions.

--- a/decisions/005-dnd-file-path-heuristic.md
+++ b/decisions/005-dnd-file-path-heuristic.md
@@ -1,5 +1,7 @@
 # 005 — Drag-and-drop file path resolution is heuristic
 
+> Superseded on 2026-04-16 by [decision 036](036-worktree-uploaded-dnd-files.md). Dropped files are now uploaded into the task worktree instead of resolving host-system paths.
+
 ## Context
 
 The terminal supports drag-and-drop: user drops a file onto the terminal, and the app pastes the full file path. However, WKWebView (Electrobun's renderer) does not expose native file paths in drag-and-drop events — the browser File API only provides `file.name`, `file.size`, and `file.lastModified`.

--- a/decisions/036-worktree-uploaded-dnd-files.md
+++ b/decisions/036-worktree-uploaded-dnd-files.md
@@ -1,0 +1,21 @@
+# 036 — Drag-and-drop files are uploaded into the task worktree
+
+## Context
+
+Drag-and-drop in WKWebView never exposes the original host path. The previous `resolveFilename()` workaround depended on macOS Spotlight, was heuristic by design, and could not work consistently in remote/browser sessions.
+
+## Investigation
+
+The renderer already had a reliable upload path for pasted images and remote RPC traffic. Reusing that flow for dropped files gives us the file bytes directly in the browser, which is the only stable cross-platform input we actually control.
+
+## Decision
+
+We removed `resolveFilename()` from `src/bun/rpc-handlers/app-handlers.ts` and replaced the drop flow with `uploadFileBase64()`. `src/mainview/hooks/useFileDrop.ts`, `src/mainview/TerminalView.tsx`, and `src/mainview/utils/uploadDroppedFile.ts` now upload dropped files into `~/.dev3.0/worktrees/<slug>/uploads/` and use the returned server path.
+
+## Risks
+
+This duplicates dropped files into the worktree-managed uploads directory, so disk usage grows with large uploads. The RPC payload is still capped at 10 MB, which keeps the browser/WebSocket path sane but rejects larger drops until we add a streaming path.
+
+## Alternatives considered
+
+Maintaining per-OS path lookup backends (`mdfind`, `locate`, `find`, platform APIs) would stay fragile and still fail in remote/browser mode. Asking the user for extra filesystem permissions would add friction to a basic drag-and-drop action for a result we can already get by uploading the file content.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -415,6 +415,24 @@ describe("uploadFileBase64", () => {
 		const [path] = (globalThis as any).Bun.write.mock.calls[0];
 		expect(path).toMatch(/^\/tmp\/test-dev3\/worktrees\/tmp-project-root\/uploads\/upload-\d+-[0-9a-f]{4}\.png$/);
 	});
+
+	it("truncates filenames that would exceed NAME_MAX", async () => {
+		// 250-char ASCII name — combined with the ~26-char prefix would exceed 255-byte NAME_MAX
+		const longName = `${"a".repeat(240)}.txt`;
+		await handlers.uploadFileBase64({
+			projectId: "proj-1",
+			base64: "YQ==",
+			filename: longName,
+		});
+
+		const [path] = (globalThis as any).Bun.write.mock.calls[0];
+		const basename = path.split("/").pop() as string;
+		// The full filename (prefix + suffix) must be under 255 bytes
+		expect(Buffer.byteLength(basename, "utf8")).toBeLessThanOrEqual(255);
+		// The suffix itself must be at most 200 bytes
+		const suffix = basename.replace(/^upload-\d+-[0-9a-f]{4}-/, "");
+		expect(Buffer.byteLength(suffix, "utf8")).toBeLessThanOrEqual(200);
+	});
 });
 
 describe("setPushMessage / getPushMessage", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -378,6 +378,45 @@ describe("runCleanupScript", () => {
 	});
 });
 
+describe("uploadFileBase64", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(data.getProject).mockResolvedValue(makeProject({ path: "/tmp/project-root" }));
+		mockSpawn.mockReturnValue({
+			exited: Promise.resolve(0),
+		});
+		(globalThis as any).Bun.write = vi.fn().mockResolvedValue(undefined);
+	});
+
+	it("stores dropped files inside the worktree uploads directory", async () => {
+		const result = await handlers.uploadFileBase64({
+			projectId: "proj-1",
+			base64: "bm90ZXM=",
+			filename: "notes.txt",
+			mimeType: "text/plain",
+		});
+
+		expect(mockSpawn).toHaveBeenCalledWith(["mkdir", "-p", "/tmp/test-dev3/worktrees/tmp-project-root/uploads"]);
+		expect((globalThis as any).Bun.write).toHaveBeenCalledTimes(1);
+
+		const [path, fileData] = (globalThis as any).Bun.write.mock.calls[0];
+		expect(path).toMatch(/^\/tmp\/test-dev3\/worktrees\/tmp-project-root\/uploads\/upload-\d+-[0-9a-f]{4}-notes\.txt$/);
+		expect(Buffer.from(fileData).toString()).toBe("notes");
+		expect(result).toEqual({ path });
+	});
+
+	it("uses the mime-derived extension when no filename is provided", async () => {
+		await handlers.uploadFileBase64({
+			projectId: "proj-1",
+			base64: "YQ==",
+			mimeType: "image/png",
+		});
+
+		const [path] = (globalThis as any).Bun.write.mock.calls[0];
+		expect(path).toMatch(/^\/tmp\/test-dev3\/worktrees\/tmp-project-root\/uploads\/upload-\d+-[0-9a-f]{4}\.png$/);
+	});
+});
+
 describe("setPushMessage / getPushMessage", () => {
 	beforeEach(() => {
 		// Reset to null

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { PATHS, Utils } from "../electrobun-platform";
@@ -11,7 +11,7 @@ import { loadSettings } from "../settings";
 import { BUNDLED_CHANGELOG } from "../changelog-bundled";
 import * as repoConfig from "../repo-config";
 import { DEV3_HOME } from "../paths";
-import { spawn, spawnSync } from "../spawn";
+import { spawn } from "../spawn";
 import { getUploadedImageExtension, hideAppNative, log, logRendererError } from "./shared";
 
 async function quitApp(): Promise<void> {
@@ -143,57 +143,6 @@ async function detectClonePaths(params: { projectId: string }): Promise<string[]
 	return paths;
 }
 
-async function resolveFilename(params: { filename: string; size: number; lastModified: number }): Promise<string | null> {
-	const home = homedir();
-	const searchDirs = [
-		`${home}/Desktop`,
-		`${home}/Downloads`,
-		`${home}/Documents`,
-		`${home}/Projects`,
-		`${home}/src`,
-		`${home}/dev`,
-		`${home}/work`,
-		`${home}/code`,
-		"/tmp",
-	].filter((dir) => {
-		try { return statSync(dir).isDirectory(); } catch { return false; }
-	});
-
-	const query = `kMDItemFSName == "${params.filename}"`;
-	const candidates: string[] = [];
-	for (const dir of searchDirs) {
-		const proc = spawnSync(["mdfind", "-onlyin", dir, query]);
-		const out = proc.stdout.toString().trim();
-		if (out) candidates.push(...out.split("\n"));
-	}
-	if (candidates.length === 0) return null;
-	if (candidates.length === 1) return candidates[0];
-
-	const sizeMatches: string[] = [];
-	for (const path of candidates) {
-		try {
-			const file = Bun.file(path);
-			if (file.size === params.size) {
-				sizeMatches.push(path);
-			}
-		} catch {}
-	}
-
-	if (sizeMatches.length === 1) return sizeMatches[0];
-
-	const pool = sizeMatches.length > 0 ? sizeMatches : candidates;
-	for (const path of pool) {
-		try {
-			const file = Bun.file(path);
-			if (file.lastModified === params.lastModified) {
-				return path;
-			}
-		} catch {}
-	}
-
-	return sizeMatches[0] ?? candidates[0];
-}
-
 async function getChangelogs(): Promise<ChangelogEntry[]> {
 	log.info("-> getChangelogs");
 
@@ -282,9 +231,27 @@ async function getChangelogs(): Promise<ChangelogEntry[]> {
 	return entries;
 }
 
-async function saveUploadedImage(
+function sanitizeUploadedFilename(filename?: string): string | null {
+	if (!filename) return null;
+	const baseName = filename.split(/[/\\]/).pop()?.trim() ?? "";
+	const sanitized = baseName.replace(/[\0-\x1f\x7f]/g, "");
+	return sanitized || null;
+}
+
+function buildUploadedFilename(opts?: { filename?: string; mimeType?: string }): string {
+	const hex = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, "0");
+	const prefix = `upload-${Date.now()}-${hex}`;
+	const safeName = sanitizeUploadedFilename(opts?.filename);
+	if (safeName) {
+		return `${prefix}-${safeName}`;
+	}
+
+	return `${prefix}${getUploadedImageExtension(undefined, opts?.mimeType)}`;
+}
+
+async function saveUploadedFile(
 	projectId: string,
-	imageData: Buffer | Uint8Array,
+	fileData: Buffer | Uint8Array,
 	opts?: { filename?: string; mimeType?: string },
 ): Promise<{ path: string }> {
 	const project = await data.getProject(projectId);
@@ -292,12 +259,10 @@ async function saveUploadedImage(
 	const uploadsDir = `${DEV3_HOME}/worktrees/${slug}/uploads`;
 	const mkdirProc = spawn(["mkdir", "-p", uploadsDir]);
 	await mkdirProc.exited;
-	const hex = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, "0");
-	const extension = getUploadedImageExtension(opts?.filename, opts?.mimeType);
-	const filename = `img-${Date.now()}-${hex}${extension}`;
+	const filename = buildUploadedFilename(opts);
 	const fullPath = `${uploadsDir}/${filename}`;
-	await Bun.write(fullPath, imageData);
-	log.info("Image saved", { path: fullPath, size: imageData.length });
+	await Bun.write(fullPath, fileData);
+	log.info("Uploaded file saved", { path: fullPath, size: fileData.length });
 	return { path: fullPath };
 }
 
@@ -313,22 +278,30 @@ async function pasteClipboardImage(params: { projectId: string }): Promise<{ pat
 		log.warn("← pasteClipboardImage: clipboardReadImage returned empty");
 		return null;
 	}
-	return saveUploadedImage(params.projectId, pngData);
+	return saveUploadedFile(params.projectId, pngData, { mimeType: "image/png" });
 }
 
 async function uploadImageBase64(params: { projectId: string; base64: string; filename?: string; mimeType?: string }): Promise<{ path: string } | null> {
+	return uploadFileBase64(params);
+}
+
+async function uploadFileBase64(params: { projectId: string; base64: string; filename?: string; mimeType?: string }): Promise<{ path: string } | null> {
 	const MAX_BASE64_SIZE = 10 * 1024 * 1024;
 	if (params.base64.length > MAX_BASE64_SIZE) {
-		log.warn("← uploadImageBase64: payload too large", { len: params.base64.length });
-		throw new Error("Image too large (max 10 MB)");
+		log.warn("← uploadFileBase64: payload too large", { len: params.base64.length });
+		throw new Error("File too large (max 10 MB)");
 	}
-	log.info("→ uploadImageBase64", { projectId: params.projectId.slice(0, 8), len: params.base64.length });
-	const pngData = Buffer.from(params.base64, "base64");
-	if (pngData.length === 0) {
-		log.warn("← uploadImageBase64: empty image data");
+	log.info("→ uploadFileBase64", {
+		projectId: params.projectId.slice(0, 8),
+		len: params.base64.length,
+		filename: params.filename,
+	});
+	const fileData = Buffer.from(params.base64, "base64");
+	if (fileData.length === 0) {
+		log.warn("← uploadFileBase64: empty file data");
 		return null;
 	}
-	return saveUploadedImage(params.projectId, pngData, {
+	return saveUploadedFile(params.projectId, fileData, {
 		filename: params.filename,
 		mimeType: params.mimeType,
 	});
@@ -444,9 +417,9 @@ export const appHandlers = {
 	cloneAndAddProject,
 	removeProject,
 	detectClonePaths,
-	resolveFilename,
 	getChangelogs,
 	pasteClipboardImage,
+	uploadFileBase64,
 	uploadImageBase64,
 	readImageBase64,
 	openImageFile,

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -235,7 +235,16 @@ function sanitizeUploadedFilename(filename?: string): string | null {
 	if (!filename) return null;
 	const baseName = filename.split(/[/\\]/).pop()?.trim() ?? "";
 	const sanitized = baseName.replace(/[\0-\x1f\x7f]/g, "");
-	return sanitized || null;
+	if (!sanitized) return null;
+	// Prefix "upload-<13digits>-<4hex>-" is ~26 ASCII bytes; NAME_MAX is 255 bytes.
+	// Cap the suffix at 200 bytes to stay well within the limit on any OS/encoding.
+	const MAX_BYTES = 200;
+	if (Buffer.byteLength(sanitized, "utf8") <= MAX_BYTES) return sanitized;
+	const buf = Buffer.from(sanitized, "utf8");
+	// Walk back from the cut point to avoid slicing a multibyte UTF-8 sequence.
+	let end = MAX_BYTES;
+	while (end > 0 && (buf[end]! & 0xc0) === 0x80) end--;
+	return buf.subarray(0, end).toString("utf8") || null;
 }
 
 function buildUploadedFilename(opts?: { filename?: string; mimeType?: string }): string {

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -295,17 +295,17 @@ async function uploadImageBase64(params: { projectId: string; base64: string; fi
 }
 
 async function uploadFileBase64(params: { projectId: string; base64: string; filename?: string; mimeType?: string }): Promise<{ path: string } | null> {
-	const MAX_BASE64_SIZE = 10 * 1024 * 1024;
-	if (params.base64.length > MAX_BASE64_SIZE) {
-		log.warn("← uploadFileBase64: payload too large", { len: params.base64.length });
-		throw new Error("File too large (max 10 MB)");
-	}
 	log.info("→ uploadFileBase64", {
 		projectId: params.projectId.slice(0, 8),
 		len: params.base64.length,
 		filename: params.filename,
 	});
 	const fileData = Buffer.from(params.base64, "base64");
+	const MAX_FILE_SIZE = 100 * 1024 * 1024;
+	if (fileData.length > MAX_FILE_SIZE) {
+		log.warn("← uploadFileBase64: payload too large", { len: fileData.length });
+		throw new Error("File too large (max 100 MB)");
+	}
 	if (fileData.length === 0) {
 		log.warn("← uploadFileBase64: empty file data");
 		return null;

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -20,6 +20,7 @@ import GhWarningBanner, { isGhWarningDismissed } from "./components/GhWarningBan
 import Changelog from "./components/Changelog";
 import GaugeDemo from "./components/gauges/GaugeDemo";
 import ViewportLab from "./components/ViewportLab";
+import { ErrorToast } from "./components/ErrorToast";
 import { initTaskSoundPlayback, playTaskSound } from "./task-sounds";
 
 const SKIP_QUIT_DIALOG_KEY = "dev3-skip-quit-dialog";
@@ -774,6 +775,7 @@ function App() {
 					</div>
 				</div>
 			)}
+			<ErrorToast />
 		</div>
 	);
 

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -4,7 +4,7 @@ import { api, isElectrobun } from "./rpc";
 import { getShiftKeySequence } from "./shift-key-sequences";
 import { getZoom, ZOOM_CHANGED_EVENT } from "./zoom";
 import { TERMINAL_KEYMAPS, getKeymapPreset, KEYMAP_CHANGED_EVENT } from "./terminal-keymaps";
-import { uploadDroppedImage } from "./utils/uploadDroppedImage";
+import { uploadDroppedFile } from "./utils/uploadDroppedFile";
 
 const DARK_TERMINAL_THEME = {
 	background: "#1a1b26",
@@ -852,30 +852,23 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 		const files = Array.from(e.dataTransfer.files);
 		if (files.length === 0) return;
 
-		// WKWebView doesn't expose native file paths — resolve via Spotlight in main process.
 		const paths = await Promise.all(
 			files.map(async (f) => {
 				try {
-					const resolved = await api.request.resolveFilename({
-						filename: f.name,
-						size: f.size,
-						lastModified: f.lastModified,
-					});
-					const uploadedPath = resolved ? null : await uploadDroppedImage(projectId, f);
-					const p = resolved ?? uploadedPath ?? f.name;
-					return p.replace(/ /g, "\\ ");
+					const uploadedPath = await uploadDroppedFile(projectId, f);
+					return uploadedPath ? uploadedPath.replace(/ /g, "\\ ") : null;
 				} catch (err) {
-					console.error(`[TerminalView] resolveFilename failed for "${f.name}":`, err);
-					try {
-						const uploadedPath = await uploadDroppedImage(projectId, f);
-						return (uploadedPath ?? f.name).replace(/ /g, "\\ ");
-					} catch {
-						return f.name.replace(/ /g, "\\ ");
-					}
+					console.error(`[TerminalView] file upload failed for "${f.name}":`, err);
+					return null;
 				}
 			}),
 		);
-		const text = paths.join(" ");
+		const text = paths.filter((path): path is string => Boolean(path)).join(" ");
+
+		if (!text) {
+			try { termRef.current?.focus(); } catch { /* disposed */ }
+			return;
+		}
 
 		if (wsRef.current?.readyState === WebSocket.OPEN) {
 			wsRef.current.send(text);

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Terminal, FitAddon } from "ghostty-web";
 import { useT } from "./i18n";
+import { dispatchErrorToast } from "./components/ErrorToast";
 import { api, isElectrobun } from "./rpc";
 import { getShiftKeySequence } from "./shift-key-sequences";
 import { getZoom, ZOOM_CHANGED_EVENT } from "./zoom";
@@ -861,7 +862,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 					return uploadedPath ? uploadedPath.replace(/ /g, "\\ ") : null;
 				} catch (err) {
 					console.error(`[TerminalView] file upload failed for "${f.name}":`, err);
-					alert(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
+					dispatchErrorToast(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
 					return null;
 				}
 			}),

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Terminal, FitAddon } from "ghostty-web";
+import { useT } from "./i18n";
 import { api, isElectrobun } from "./rpc";
 import { getShiftKeySequence } from "./shift-key-sequences";
 import { getZoom, ZOOM_CHANGED_EVENT } from "./zoom";
@@ -67,6 +68,7 @@ interface TerminalViewProps {
 }
 
 function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps) {
+	const t = useT();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
@@ -859,6 +861,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 					return uploadedPath ? uploadedPath.replace(/ /g, "\\ ") : null;
 				} catch (err) {
 					console.error(`[TerminalView] file upload failed for "${f.name}":`, err);
+					alert(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
 					return null;
 				}
 			}),

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -61,7 +61,7 @@ vi.mock("ghostty-web", () => ({
 }));
 
 vi.mock("../rpc", () => ({
-	api: { request: { resolveFilename: vi.fn(), uploadImageBase64: vi.fn(), tmuxAction: vi.fn() } },
+	api: { request: { uploadFileBase64: vi.fn(), tmuxAction: vi.fn() } },
 }));
 
 vi.mock("../zoom", () => ({
@@ -294,8 +294,7 @@ describe("TerminalView – focus-on-type", () => {
 // ── Terminal keymap shortcuts ─────────────────────────────────────────────────
 
 const mockedTmuxAction = vi.mocked(api.request.tmuxAction);
-const mockedResolveFilename = vi.mocked(api.request.resolveFilename);
-const mockedUploadImageBase64 = vi.mocked(api.request.uploadImageBase64);
+const mockedUploadFileBase64 = vi.mocked(api.request.uploadFileBase64);
 
 /** Focus a child element inside the terminal container so the keymap guard passes. */
 function focusInsideTerminal(): HTMLElement {
@@ -332,8 +331,7 @@ describe("TerminalView – keymap shortcuts", () => {
 		localStorage.clear();
 		mockedTmuxAction.mockClear();
 		mockedTmuxAction.mockResolvedValue(undefined as any);
-		mockedResolveFilename.mockReset();
-		mockedUploadImageBase64.mockReset();
+		mockedUploadFileBase64.mockReset();
 		lastWebSocket = null;
 	});
 
@@ -416,29 +414,28 @@ describe("TerminalView – keymap shortcuts", () => {
 });
 
 describe("TerminalView – drag-and-drop", () => {
-	it("uploads dropped images when resolveFilename cannot find the original path", async () => {
-		mockedResolveFilename.mockResolvedValue(null);
-		mockedUploadImageBase64.mockResolvedValue({ path: "/tmp/uploaded-drop.jpg" } as any);
+	it("uploads dropped files and pastes the returned worktree path", async () => {
+		mockedUploadFileBase64.mockResolvedValue({ path: "/tmp/uploads/notes.txt" } as any);
 
 		await renderAndSetup();
 		const terminal = document.querySelector("[data-terminal='true']")!;
-		const file = new File(["abc"], "Screenshot 2026-03-28 at 7.13.32.jpg", {
-			type: "image/jpeg",
+		const file = new File(["notes"], "notes.txt", {
+			type: "text/plain",
 			lastModified: 1711600000000,
 		});
 
 		dispatchDrop(terminal, [file]);
 
 		await waitFor(() => {
-			expect(mockedUploadImageBase64).toHaveBeenCalledWith({
+			expect(mockedUploadFileBase64).toHaveBeenCalledWith({
 				projectId: "p1",
-				base64: "YWJj",
-				filename: "Screenshot 2026-03-28 at 7.13.32.jpg",
-				mimeType: "image/jpeg",
+				base64: "bm90ZXM=",
+				filename: "notes.txt",
+				mimeType: "text/plain",
 			});
 		});
 		await waitFor(() => {
-			expect(lastWebSocket?.send).toHaveBeenCalledWith("/tmp/uploaded-drop.jpg");
+			expect(lastWebSocket?.send).toHaveBeenCalledWith("/tmp/uploads/notes.txt");
 		});
 	});
 });

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,5 +1,6 @@
 import { render, act, waitFor } from "@testing-library/react";
 import TerminalView from "../TerminalView";
+import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
 import { KEYMAP_LS_KEY } from "../terminal-keymaps";
 
@@ -154,7 +155,7 @@ beforeEach(() => {
 async function renderAndSetup() {
 	let result!: ReturnType<typeof render>;
 	await act(async () => {
-		result = render(<TerminalView ptyUrl="ws://localhost:1234" taskId="t1" projectId="p1" />);
+		result = render(<I18nProvider><TerminalView ptyUrl="ws://localhost:1234" taskId="t1" projectId="p1" /></I18nProvider>);
 		// Flush the microtask queue so the fonts.load() .then() runs → setup()
 		await Promise.resolve();
 		await Promise.resolve();

--- a/src/mainview/components/ErrorToast.tsx
+++ b/src/mainview/components/ErrorToast.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef } from "react";
+
+const ERROR_EVENT = "app:error";
+
+export function dispatchErrorToast(message: string) {
+	window.dispatchEvent(new CustomEvent(ERROR_EVENT, { detail: { message } }));
+}
+
+interface ToastEntry {
+	id: number;
+	message: string;
+}
+
+const AUTO_DISMISS_MS = 6000;
+
+export function ErrorToast() {
+	const [toasts, setToasts] = useState<ToastEntry[]>([]);
+	const nextId = useRef(0);
+
+	useEffect(() => {
+		function handler(e: Event) {
+			const { message } = (e as CustomEvent<{ message: string }>).detail;
+			const id = ++nextId.current;
+			setToasts(prev => [...prev, { id, message }]);
+			setTimeout(() => {
+				setToasts(prev => prev.filter(t => t.id !== id));
+			}, AUTO_DISMISS_MS);
+		}
+		window.addEventListener(ERROR_EVENT, handler);
+		return () => window.removeEventListener(ERROR_EVENT, handler);
+	}, []);
+
+	if (!toasts.length) return null;
+
+	return (
+		<div className="fixed top-14 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+			{toasts.map(({ id, message }) => (
+				<div key={id} className="pointer-events-auto animate-slide-in-right">
+					<div className="bg-overlay border border-danger/40 rounded-xl shadow-2xl p-4 w-80 flex items-start gap-3">
+						<span
+							className="text-danger text-xl leading-none mt-0.5 flex-shrink-0"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\uf071"}
+						</span>
+						<div className="flex-1 min-w-0 text-fg text-sm break-words">{message}</div>
+						<button
+							onClick={() => setToasts(prev => prev.filter(t => t.id !== id))}
+							className="text-fg-muted hover:text-fg transition-colors flex-shrink-0 ml-1"
+						>
+							<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -14,8 +14,8 @@ vi.mock("../../rpc", () => ({
 			fetchBranches: vi.fn(),
 			setTaskLabels: vi.fn(),
 			getProjectCurrentBranch: vi.fn(),
+			uploadFileBase64: vi.fn(),
 			uploadImageBase64: vi.fn(),
-			resolveFilename: vi.fn(),
 			readImageBase64: vi.fn(),
 		},
 	},
@@ -101,8 +101,8 @@ describe("CreateTaskModal", () => {
 		vi.clearAllMocks();
 		mockedApi.request.createTask.mockResolvedValue(mockTask);
 		mockedApi.request.getProjectCurrentBranch.mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false });
+		mockedApi.request.uploadFileBase64.mockResolvedValue({ path: "/tmp/uploaded-drop.png" });
 		mockedApi.request.uploadImageBase64.mockResolvedValue({ path: "/tmp/uploaded-drop.png" });
-		mockedApi.request.resolveFilename.mockResolvedValue("/tmp/fallback-path.txt");
 		mockedApi.request.readImageBase64.mockResolvedValue({ dataUrl: "data:image/png;base64,abc" });
 	});
 
@@ -352,7 +352,7 @@ describe("CreateTaskModal", () => {
 		dispatchDrop(textarea.parentElement!, [file]);
 
 		await waitFor(() => {
-			expect(mockedApi.request.uploadImageBase64).toHaveBeenCalledWith({
+			expect(mockedApi.request.uploadFileBase64).toHaveBeenCalledWith({
 				projectId: "p1",
 				base64: "YWJj",
 				filename: "drop.jpg",
@@ -362,10 +362,11 @@ describe("CreateTaskModal", () => {
 		await waitFor(() => {
 			expect(textarea.value).toBe("/tmp/uploaded-drop.png\n");
 		});
-		expect(mockedApi.request.resolveFilename).not.toHaveBeenCalled();
+		expect(mockedApi.request.uploadImageBase64).not.toHaveBeenCalled();
 	});
 
-	it("falls back to resolveFilename for non-image drops", async () => {
+	it("uploads non-image drops and inserts the saved path", async () => {
+		mockedApi.request.uploadFileBase64.mockResolvedValue({ path: "/tmp/uploaded-notes.txt" });
 		renderModal();
 
 		const textarea = screen.getByPlaceholderText("Describe what needs to be done...") as HTMLTextAreaElement;
@@ -374,16 +375,16 @@ describe("CreateTaskModal", () => {
 		dispatchDrop(textarea.parentElement!, [file]);
 
 		await waitFor(() => {
-			expect(mockedApi.request.resolveFilename).toHaveBeenCalledWith({
+			expect(mockedApi.request.uploadFileBase64).toHaveBeenCalledWith({
+				projectId: "p1",
+				base64: "bm90ZXM=",
 				filename: "notes.txt",
-				size: 5,
-				lastModified: 1712222222222,
+				mimeType: "text/plain",
 			});
 		});
 		await waitFor(() => {
-			expect(textarea.value).toBe("/tmp/fallback-path.txt\n");
+			expect(textarea.value).toBe("/tmp/uploaded-notes.txt\n");
 		});
-		expect(mockedApi.request.uploadImageBase64).not.toHaveBeenCalled();
 	});
 
 	// ---- Branch selector ----

--- a/src/mainview/hooks/useFileDrop.ts
+++ b/src/mainview/hooks/useFileDrop.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { useT } from "../i18n";
+import { dispatchErrorToast } from "../components/ErrorToast";
 import { uploadDroppedFile } from "../utils/uploadDroppedFile";
 
 export function useFileDrop(
@@ -52,7 +53,7 @@ export function useFileDrop(
 					}
 				} catch (err) {
 					console.error(`[useFileDrop] file upload failed for "${file.name}":`, err);
-					alert(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
+					dispatchErrorToast(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
 				}
 			}));
 		},

--- a/src/mainview/hooks/useFileDrop.ts
+++ b/src/mainview/hooks/useFileDrop.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { useT } from "../i18n";
 import { uploadDroppedFile } from "../utils/uploadDroppedFile";
 
 export function useFileDrop(
@@ -11,6 +12,7 @@ export function useFileDrop(
 	handleDrop: (e: React.DragEvent) => void;
 	isDragging: boolean;
 } {
+	const t = useT();
 	const [isDragging, setIsDragging] = useState(false);
 	const dragCounter = useRef(0);
 
@@ -50,6 +52,7 @@ export function useFileDrop(
 					}
 				} catch (err) {
 					console.error(`[useFileDrop] file upload failed for "${file.name}":`, err);
+					alert(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
 				}
 			}));
 		},

--- a/src/mainview/hooks/useFileDrop.ts
+++ b/src/mainview/hooks/useFileDrop.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import { api } from "../rpc";
-import { uploadDroppedImage } from "../utils/uploadDroppedImage";
+import { uploadDroppedFile } from "../utils/uploadDroppedFile";
 
 export function useFileDrop(
 	projectId: string,
@@ -44,29 +43,13 @@ export function useFileDrop(
 			if (!files.length) return;
 
 			void Promise.all(files.map(async (file) => {
-				if (projectId && file.type.startsWith("image/")) {
-					try {
-						const uploadedPath = await uploadDroppedImage(projectId, file);
-						if (uploadedPath) {
-							onFileDropped(uploadedPath);
-							return;
-						}
-					} catch (err) {
-						console.error(`[useFileDrop] image upload failed for "${file.name}":`, err);
-					}
-				}
-
 				try {
-					const resolvedPath = await api.request.resolveFilename({
-						filename: file.name,
-						size: file.size,
-						lastModified: file.lastModified,
-					});
-					if (resolvedPath) {
-						onFileDropped(resolvedPath);
+					const uploadedPath = await uploadDroppedFile(projectId, file);
+					if (uploadedPath) {
+						onFileDropped(uploadedPath);
 					}
 				} catch (err) {
-					console.error(`[useFileDrop] resolveFilename failed for "${file.name}":`, err);
+					console.error(`[useFileDrop] file upload failed for "${file.name}":`, err);
 				}
 			}));
 		},

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -83,6 +83,7 @@ const terminal = {
 	"projectTerminal.backToBoard": "Back to Board",
 	"projectTerminal.shortcutHint": "\u2318`",
 	"projectTerminal.tooltipWithShortcut": "Project Terminal (\u2318`)",
+	"fileDrop.uploadFailed": "File upload failed: {error}",
 } as const;
 
 export default terminal;

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -83,6 +83,7 @@ const terminal = {
 	"projectTerminal.backToBoard": "Volver al tablero",
 	"projectTerminal.shortcutHint": "\u2318`",
 	"projectTerminal.tooltipWithShortcut": "Terminal del proyecto (\u2318`)",
+	"fileDrop.uploadFailed": "Error al subir el archivo: {error}",
 };
 
 export default terminal;

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -87,6 +87,7 @@ const terminal = {
 	"projectTerminal.backToBoard": "Назад к доске",
 	"projectTerminal.shortcutHint": "\u2318`",
 	"projectTerminal.tooltipWithShortcut": "Терминал проекта (\u2318`)",
+	"fileDrop.uploadFailed": "Ошибка загрузки файла: {error}",
 };
 
 export default terminal;

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -292,7 +292,7 @@ function initBrowserApi(): ApiShape {
 						const base64 = btoa(
 							new Uint8Array(buffer).reduce((s, b) => s + String.fromCharCode(b), ""),
 						);
-						return rpcRequest("uploadImageBase64", {
+						return rpcRequest("uploadFileBase64", {
 							projectId: params.projectId,
 							base64,
 							mimeType: imageType,

--- a/src/mainview/utils/uploadDroppedFile.ts
+++ b/src/mainview/utils/uploadDroppedFile.ts
@@ -13,13 +13,13 @@ async function fileToBase64(file: File): Promise<string> {
 	return btoa(chunks.join(""));
 }
 
-export async function uploadDroppedImage(projectId: string, file: File): Promise<string | null> {
-	if (!projectId || !file.type.startsWith("image/")) {
+export async function uploadDroppedFile(projectId: string, file: File): Promise<string | null> {
+	if (!projectId) {
 		return null;
 	}
 
 	const base64 = await fileToBase64(file);
-	const uploaded = await api.request.uploadImageBase64({
+	const uploaded = await api.request.uploadFileBase64({
 		projectId,
 		base64,
 		filename: file.name,

--- a/src/mainview/utils/uploadDroppedFile.ts
+++ b/src/mainview/utils/uploadDroppedFile.ts
@@ -13,9 +13,15 @@ async function fileToBase64(file: File): Promise<string> {
 	return btoa(chunks.join(""));
 }
 
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+
 export async function uploadDroppedFile(projectId: string, file: File): Promise<string | null> {
 	if (!projectId) {
 		return null;
+	}
+
+	if (file.size > MAX_FILE_SIZE) {
+		throw new Error(`File too large (max 100 MB)`);
 	}
 
 	const base64 = await fileToBase64(file);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -997,10 +997,6 @@ export type AppRPCSchema = {
 				params: { projectId: string };
 				response: void;
 			};
-			resolveFilename: {
-				params: { filename: string; size: number; lastModified: number };
-				response: string | null;
-			};
 			runDevServer: {
 				params: { taskId: string; projectId: string };
 				response: DevServerStatus;
@@ -1232,6 +1228,10 @@ export type AppRPCSchema = {
 			checkCaffeinateAvailable: {
 				params: void;
 				response: { available: boolean };
+			};
+			uploadFileBase64: {
+				params: { projectId: string; base64: string; filename?: string; mimeType?: string };
+				response: { path: string } | null;
 			};
 			uploadImageBase64: {
 				params: { projectId: string; base64: string; filename?: string; mimeType?: string };


### PR DESCRIPTION
## Summary

- Removes `resolveFilename` (macOS Spotlight heuristic) — replaced with proper file upload flow that works on any OS and in remote/browser mode
- Dropped files are read in the browser, uploaded via `uploadFileBase64`, and saved to `~/.dev3.0/worktrees/<slug>/uploads/`
- Upload limit raised to **100 MB** (checked on decoded file size, not base64 string length)
- Long filenames clamped to 200 UTF-8 bytes to prevent `ENAMETOOLONG` filesystem errors
- Added `ErrorToast` component — floating in-app notification for upload errors (replaces `window.alert()` which WKWebView silently suppresses)
- Client-side file size check in `uploadDroppedFile` ensures errors throw in renderer context and reach the toast

Closes #005 decision superseded (mdfind heuristic removed).