### PR TITLE
fix: prevent duplicate project entries in state

### DIFF
--- a/change-logs/2026/04/20/fix-prevent-duplicate-project-entries.md
+++ b/change-logs/2026/04/20/fix-prevent-duplicate-project-entries.md
@@ -1,0 +1,1 @@
+Fixed duplicate project entries in the renderer state when the same repository is added more than once. Re-adding a project now replaces the existing entry by project ID or normalized path instead of appending a duplicate card.

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -401,6 +401,41 @@ describe("reducer", () => {
 		expect(next.projects).toEqual([mockProject]);
 	});
 
+	it("addProject: replaces existing project with the same id", () => {
+		const state: AppState = {
+			...initialState,
+			projects: [mockProject],
+		};
+		const updated = { ...mockProject, defaultBaseBranch: "develop" };
+
+		const next = reducer(state, {
+			type: "addProject",
+			project: updated,
+		});
+
+		expect(next.projects).toEqual([updated]);
+	});
+
+	it("addProject: replaces existing project with the same normalized path", () => {
+		const state: AppState = {
+			...initialState,
+			projects: [mockProject],
+		};
+		const duplicatePathProject: Project = {
+			...mockProject,
+			id: "p2",
+			path: "/tmp/test/",
+			name: "Renamed Project",
+		};
+
+		const next = reducer(state, {
+			type: "addProject",
+			project: duplicatePathProject,
+		});
+
+		expect(next.projects).toEqual([duplicatePathProject]);
+	});
+
 	it("removeProject: removes by id", () => {
 		const state: AppState = {
 			...initialState,

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -81,6 +81,10 @@ function clearBellForRoute(bellCounts: Map<string, number>, route: Route): Map<s
 	return bellCounts;
 }
 
+function normalizeProjectPath(path: string): string {
+	return path.replace(/\/+$/, "");
+}
+
 export function reducer(state: AppState, action: AppAction): AppState {
 	switch (action.type) {
 		case "navigate": {
@@ -174,8 +178,22 @@ export function reducer(state: AppState, action: AppAction): AppState {
 				],
 			};
 		}
-		case "addProject":
-			return { ...state, projects: [...state.projects, action.project] };
+		case "addProject": {
+			const normalizedPath = normalizeProjectPath(action.project.path);
+			const existingIndex = state.projects.findIndex((project) =>
+				project.id === action.project.id ||
+				normalizeProjectPath(project.path) === normalizedPath,
+			);
+			if (existingIndex === -1) {
+				return { ...state, projects: [...state.projects, action.project] };
+			}
+			return {
+				...state,
+				projects: state.projects.map((project, index) =>
+					index === existingIndex ? action.project : project,
+				),
+			};
+		}
 		case "removeProject":
 			return {
 				...state,


### PR DESCRIPTION
## Summary

- Add `normalizeProjectPath()` helper that strips trailing slashes before comparison
- Change `addProject` reducer from blind-append to upsert: deduplicates by `id` or normalized `path`
- Add two new tests covering both deduplication paths (same id, same normalized path)