### PR TITLE
docs: freeze the ~/.dev3.0/ on-disk layout as a hard invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,20 @@ The user may communicate with agents in Russian, but everything written into the
 
 **If in doubt, use `TeamCreate`.** Defaulting to `Agent` out of habit is exactly what this rule prevents.
 
+## On-disk data layout — hard invariants (MANDATORY)
+
+The `~/.dev3.0/` directory is shared between **every installed version** of the app on the user's machine: production (`~/Applications/dev-3.0.app`), dev builds, `bun run dev` runs, side-by-side channels. Any change that breaks forward/backward compatibility of that directory breaks whichever version happens to open it next. This has already burned us once (PR #486 → reverted in #488); see `decisions/039-revert-project-slug-dash-escape.md`.
+
+**The following are not negotiable. Do not violate them, even for "clean" fixes.**
+
+1. **`projectSlug()` algorithm is frozen.** The function in `src/bun/git.ts` maps `/a/b/c` → `a-b-c` and must not change. This is the canonical name used for `~/.dev3.0/data/<slug>/`, `~/.dev3.0/worktrees/<slug>/`, and for CLI worktree context detection. If you think you have a good reason to change it — stop. Discuss it with the user first, with a concrete migration plan that does not touch existing data on disk.
+2. **No automatic renames of anything under `~/.dev3.0/`.** Never call `renameSync`, `rename`, `mv`, or any equivalent on `~/.dev3.0/data/*`, `~/.dev3.0/worktrees/*`, `~/.dev3.0/projects.json`, `~/.dev3.0/tasks.json`, `~/.dev3.0/sockets/*`, or any sibling. Not at startup, not in a migration hook, not "just this once". An older version of the app still running on the same machine will look in the pre-rename path, find nothing, and silently show an empty Kanban board.
+3. **No destructive migrations of user state at load time.** `rawLoadAllProjects` and friends may **rewrite file contents** in place if the schema genuinely evolves (see the `say` cleanup-script migration) — that is fine because the file path is unchanged. They must **never** move, rename, or delete directories or files. If a migration cannot be done in place, it is not allowed; design it differently.
+4. **CLI worktree detection relies on the plain slug.** `src/cli/context.ts` reads `projects.json` and recomputes `path.replace(/^\//, "").replaceAll("/", "-")` inline. If the slug algorithm ever drifts from this, CLI auto-detection of `taskId` from `cwd` breaks, and every agent hook that relies on it (`dev3 task move --status in-progress --if-status-not review-by-ai`, etc.) starts failing. Keep the two in lockstep — but see rule 1: the preferred solution is to not change the algorithm at all.
+5. **If you are convinced a change is unavoidable,** do it behind a new parallel path (e.g. write a new file alongside the old one, read both, prefer the new), keep the old path readable by at least N-2 versions, and document the sunset plan in a decision record before writing code. No silent in-place rewrites.
+
+These rules apply to any new code that touches `~/.dev3.0/`, any refactor of `src/bun/data.ts` / `src/bun/git.ts` / `src/bun/paths.ts` / `src/cli/context.ts`, and any "cleanup" that thinks it can tidy up the data directory.
+
 ## Git
 
 ### Worktree

--- a/change-logs/2026/04/20/docs-freeze-dev3-home-layout.md
+++ b/change-logs/2026/04/20/docs-freeze-dev3-home-layout.md
@@ -1,0 +1,1 @@
+Freeze the `~/.dev3.0/` on-disk layout as a hard invariant. Add a MANDATORY section to AGENTS.md and decision 040 forbidding any automatic rename or move of `projectSlug`-derived directories, since doing so in PR #486 silently broke cross-version installs (v1.8.2 ↔ v1.8.3) until the revert in #488. In-place file-content migrations remain allowed; path moves do not.

--- a/decisions/040-freeze-dev3-home-layout.md
+++ b/decisions/040-freeze-dev3-home-layout.md
@@ -1,0 +1,82 @@
+# 040 — Freeze the `~/.dev3.0/` on-disk layout
+
+## Context
+
+PR #486 shipped a two-part change: (a) a "safer" `projectSlug` that escaped
+literal dashes before replacing slashes, and (b) a one-shot `renameSync` at
+app startup that migrated `~/.dev3.0/data/<legacy-slug>` to the new slug so
+tasks from v1.8.2 would still be found by v1.8.3.
+
+The migration broke any machine that still had v1.8.2 installed (the
+production channel at the time). On first launch of v1.8.3 the `data/`
+directory was silently renamed; on the next launch of v1.8.2 the slug was
+recomputed with the old algorithm, the pre-rename path was looked up, and
+every Kanban column showed empty — same project, same tasks, but invisible.
+
+The same regression also killed CLI worktree auto-detection. `src/cli/context.ts`
+computes the slug inline with the pre-escape algorithm and reads
+`~/.dev3.0/data/<slug>/tasks.json`. After the rename, that file no longer
+existed under the legacy slug, so `resolveFromWorktreePath` returned `null`,
+and agent hooks like `dev3 task move --status in-progress --if-status-not review-by-ai`
+(which rely on `cwd`-derived `taskId`) started failing with
+`Usage: dev3 task move <id> ...`.
+
+## Investigation
+
+The slug collision that PR #486 was guarding against is a theoretical edge
+case: two distinct project paths that differ only in the placement of
+dashes vs slashes (e.g. `/foo/bar-baz` vs `/foo-bar/baz`). It has never been
+reported by a real user. The cost of the "fix" was an immediate, silent,
+100% regression for the production channel on every multi-version install.
+
+Reverting the code alone was not enough — users who ran v1.8.3 had their
+`data/<slug>` directory already renamed on disk and needed a one-off manual
+rename to get back. There is no safe way to automate that undo without
+committing the same class of sin.
+
+## Decision
+
+`~/.dev3.0/` is treated as **shared operating-system state** owned jointly
+by every installed version of the app. The layout is frozen:
+
+1. `projectSlug` in `src/bun/git.ts` is `path.replace(/^\//, "").replaceAll("/", "-")`.
+   It must not change.
+2. No automatic renames or moves of anything under `~/.dev3.0/`. In-place
+   content rewrites of individual files (e.g. the `say` cleanup-script
+   migration in `rawLoadAllProjects`) are still fine — the file *path*
+   is what must stay stable.
+3. `src/cli/context.ts` inlines the same slug algorithm. These two must
+   stay in lockstep; if the slug ever legitimately needs to change, both
+   sides are updated together with a compatibility story for at least the
+   last two released versions.
+4. Any future change that genuinely needs a new on-disk structure is
+   written as a **parallel path** (new file / new directory alongside the
+   old), with the old location kept readable for N-2 versions. No silent
+   in-place rewrites.
+
+These rules are also captured in `AGENTS.md` under "On-disk data layout —
+hard invariants (MANDATORY)" so every coding agent reads them before
+touching `src/bun/data.ts`, `src/bun/git.ts`, `src/bun/paths.ts`, or
+`src/cli/context.ts`.
+
+## Risks
+
+- The original theoretical slug collision remains unfixed. Accepted —
+  we have no reports of it. If it ever surfaces, the fix is a new
+  parallel layout with an explicit opt-in, not a rename.
+- Future agents may still propose a slug change because the reasoning
+  "it's cleaner" is tempting. The guardrail in `AGENTS.md` and this
+  decision record are the backstop — anyone who wants to change it
+  must first justify why the freeze rule does not apply.
+
+## Alternatives considered
+
+- **Symlink-based migration** (legacy dir → new dir). Cleaner than
+  `renameSync` but still writes into user state and still creates a
+  cross-version dependency on a specific filesystem layout. Rejected.
+- **Hash-based slug** that is collision-free by construction. Plausible
+  if we ever genuinely need it, but at that point we would do it as a
+  parallel layout, not as an in-place swap of the directory name.
+- **Silently stop caring about multi-version installs.** Rejected:
+  users routinely keep production and `bun run dev` side by side, and
+  the stable channel is the one that must never break.


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Codify the lesson from PR #486 → #488 so the next refactor does not reach for the same shortcut.

- #486 changed `projectSlug` and auto-renamed `~/.dev3.0/data/<slug>` on v1.8.3 startup. It silently broke every machine that still had v1.8.2 installed — the production version recomputed the old slug, looked in the pre-rename path, and showed every Kanban column empty. Same mechanism also killed CLI worktree auto-detection (`dev3 task move` from inside a worktree).
- #488 reverted the code.
- This PR turns the lesson into durable project policy.

## What changed (docs-only)

- `AGENTS.md` — new MANDATORY section **"On-disk data layout — hard invariants"** with five rules:
  1. `projectSlug` algorithm is frozen.
  2. No automatic renames/moves/deletes under `~/.dev3.0/`.
  3. In-place file-*content* migrations are still fine; path moves are not.
  4. `src/cli/context.ts` must stay in lockstep with the slug algorithm.
  5. Any genuinely unavoidable layout change must be a parallel path with N-2 version compatibility, documented in a decision record first.
- `decisions/040-freeze-dev3-home-layout.md` — full context, investigation, decision, risks, and rejected alternatives (symlink migration, hash-based slug, ignoring multi-version installs).
- `change-logs/2026/04/20/docs-freeze-dev3-home-layout.md`.

No code changes.