### PR TITLE
fix: align startup gh auth warning with shell config

### DIFF
--- a/change-logs/2026/04/21/fix-gh-auth-shell-env.md
+++ b/change-logs/2026/04/21/fix-gh-auth-shell-env.md
@@ -1,0 +1,1 @@
+Import `GH_CONFIG_DIR` and `XDG_CONFIG_HOME` from the user's login shell during app startup so backend `gh` auth checks use the same config directory as interactive terminals. Added a regression test for shell environment bootstrapping to keep the startup warning aligned with real `gh auth status`.

--- a/decisions/041-gh-auth-shell-env-bootstrap.md
+++ b/decisions/041-gh-auth-shell-env-bootstrap.md
@@ -1,0 +1,36 @@
+# 041 — Bootstrap gh auth config from the login shell
+
+## Context
+
+Issue #491 reported that dev-3.0 could keep showing the startup banner
+`GitHub CLI (gh) is not signed in` even after `gh auth login` succeeded in
+an app terminal. The main process already imported `PATH` and `LANG` from the
+user's login shell, but `gh` also depends on config-location variables.
+
+## Investigation
+
+`gh` resolves its config directory from `GH_CONFIG_DIR`, then
+`$XDG_CONFIG_HOME/gh`, then `$HOME/.config/gh`. A login shell can export one
+of the first two, while the GUI app process still runs without them, so the
+backend auth check and the terminal shell can read different credential stores.
+
+## Decision
+
+`src/bun/shell-env.ts` now reads `XDG_CONFIG_HOME` and `GH_CONFIG_DIR` from the
+login shell alongside `PATH` and `LANG`. `src/bun/index.ts` and
+`src/bun/headless-entry.ts` apply those values to `process.env` before any `gh`
+checks or spawned subprocesses run.
+
+## Risks
+
+If a user's shell exports a broken `GH_CONFIG_DIR`, dev-3.0 will now inherit
+that breakage instead of silently falling back to `$HOME/.config/gh`. That is
+acceptable because matching the user's actual shell behavior is less confusing
+than inventing a second auth context inside the app.
+
+## Alternatives considered
+
+- Hardcode `~/.config/gh` in dev-3.0. Rejected because it ignores documented
+  `gh` environment overrides and preserves the mismatch with shell sessions.
+- Re-check auth only from PTY shells. Rejected because the backend also needs
+  the same environment for non-interactive `gh` commands and remote mode.

--- a/src/bun/__tests__/shell-env.test.ts
+++ b/src/bun/__tests__/shell-env.test.ts
@@ -13,6 +13,25 @@ vi.mock("../spawn", () => ({
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 
+function fakeProc(stdout: string, stderr = "", exitCode = 0) {
+	const encoder = new TextEncoder();
+	return {
+		exited: Promise.resolve(exitCode),
+		stdout: new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode(stdout));
+				controller.close();
+			},
+		}),
+		stderr: new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode(stderr));
+				controller.close();
+			},
+		}),
+	};
+}
+
 describe("shell environment bootstrap", () => {
 	let originalShell: string | undefined;
 
@@ -34,6 +53,26 @@ describe("shell environment bootstrap", () => {
 
 		expect(result).toEqual({});
 		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	it("captures gh-related config variables from the login shell", async () => {
+		process.env.SHELL = "/bin/zsh";
+		spawnMock.mockReturnValue(fakeProc([
+			"___PATH=/opt/homebrew/bin:/usr/bin:/bin",
+			"___LANG=en_US.UTF-8",
+			"___XDG_CONFIG_HOME=/Users/tester/.config-xdg",
+			"___GH_CONFIG_DIR=/Users/tester/.config-gh",
+		].join("\n")));
+
+		const { resolveShellEnv } = await import("../shell-env");
+		const result = await resolveShellEnv();
+
+		expect(result).toEqual({
+			path: "/opt/homebrew/bin:/usr/bin:/bin",
+			lang: "en_US.UTF-8",
+			xdgConfigHome: "/Users/tester/.config-xdg",
+			ghConfigDir: "/Users/tester/.config-gh",
+		});
 	});
 
 	it("main-process PATH bootstrap uses an explicit shell-profile helper instead of defaulting to zsh", () => {

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -78,9 +78,11 @@ if (!process.env.DEV3_VIEWS_DIR) {
 	}
 }
 
-// ── Resolve shell PATH + LANG (same as GUI entry — needed for spawned tmux/git/bun) ──
+// ── Resolve shell PATH + LANG + key gh config vars (same as GUI entry) ──
 const originalPath = process.env.PATH;
 const originalLang = process.env.LANG;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalGhConfigDir = process.env.GH_CONFIG_DIR;
 const shellEnv = await resolveShellEnv();
 if (shellEnv.path) {
 	process.env.PATH = shellEnv.path;
@@ -107,6 +109,16 @@ if (shellEnv.lang) {
 	log.info("Shell LANG resolved", { original: originalLang, resolved: shellEnv.lang });
 } else if (!process.env.LANG) {
 	process.env.LANG = "en_US.UTF-8";
+}
+
+if (shellEnv.xdgConfigHome) {
+	process.env.XDG_CONFIG_HOME = shellEnv.xdgConfigHome;
+	log.info("Shell XDG_CONFIG_HOME resolved", { original: originalXdgConfigHome, resolved: shellEnv.xdgConfigHome });
+}
+
+if (shellEnv.ghConfigDir) {
+	process.env.GH_CONFIG_DIR = shellEnv.ghConfigDir;
+	log.info("Shell GH_CONFIG_DIR resolved", { original: originalGhConfigDir, resolved: shellEnv.ghConfigDir });
 }
 
 // ── CLI socket server (required — CLI tool talks to the app over this) ──

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -130,12 +130,14 @@ log.info("Log files", { dir: getLogPath() });
 	}
 }
 
-// ── Resolve user's shell environment (PATH + LANG) ──
+// ── Resolve user's shell environment (PATH + LANG + key gh config vars) ──
 // macOS .app bundles inherit a minimal env: PATH=/usr/bin:/bin:/usr/sbin:/sbin,
 // no LANG. Without LANG, tmux replaces non-ASCII chars (Cyrillic, etc.) with
 // underscores. Resolve both from the user's login shell BEFORE starting the PTY.
 const originalPath = process.env.PATH;
 const originalLang = process.env.LANG;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalGhConfigDir = process.env.GH_CONFIG_DIR;
 const shellEnv = await resolveShellEnv();
 if (shellEnv.path) {
 	process.env.PATH = shellEnv.path;
@@ -176,6 +178,22 @@ if (shellEnv.lang) {
 	// Fallback: ensure UTF-8 even if the shell doesn't export LANG
 	process.env.LANG = "en_US.UTF-8";
 	log.info("LANG not found in shell, using fallback", { lang: "en_US.UTF-8" });
+}
+
+if (shellEnv.xdgConfigHome) {
+	process.env.XDG_CONFIG_HOME = shellEnv.xdgConfigHome;
+	log.info("Shell XDG_CONFIG_HOME resolved", {
+		original: originalXdgConfigHome,
+		resolved: shellEnv.xdgConfigHome,
+	});
+}
+
+if (shellEnv.ghConfigDir) {
+	process.env.GH_CONFIG_DIR = shellEnv.ghConfigDir;
+	log.info("Shell GH_CONFIG_DIR resolved", {
+		original: originalGhConfigDir,
+		resolved: shellEnv.ghConfigDir,
+	});
 }
 
 // ── CLI socket server ──

--- a/src/bun/shell-env.ts
+++ b/src/bun/shell-env.ts
@@ -29,16 +29,23 @@ export function getShellRcFile(shell: string, home: string): string | null {
 }
 
 /**
- * Resolve the user's full shell environment (PATH, LANG) by spawning their login shell.
+ * Resolve the user's shell environment by spawning their login shell.
  *
  * macOS .app bundles launch with a minimal environment:
  * - PATH: /usr/bin:/bin:/usr/sbin:/sbin (no homebrew, nvm, etc.)
  * - LANG: undefined (causes tmux to replace non-ASCII with underscores)
+ * - GH_CONFIG_DIR / XDG_CONFIG_HOME: undefined (gh auth can look unauthenticated
+ *   in the main process while working fine inside terminal shells)
  *
  * This function gets the real values from the user's configured shell so that
- * spawned processes (tmux, git, pbcopy, etc.) work correctly.
+ * spawned processes (tmux, git, gh, pbcopy, etc.) work correctly.
  */
-export async function resolveShellEnv(): Promise<{ path?: string; lang?: string }> {
+export async function resolveShellEnv(): Promise<{
+	path?: string;
+	lang?: string;
+	xdgConfigHome?: string;
+	ghConfigDir?: string;
+}> {
 	const shell = process.env.SHELL || "/bin/zsh";
 	const timeout = 5_000;
 	const supportedShell = getSupportedShell(shell);
@@ -49,7 +56,12 @@ export async function resolveShellEnv(): Promise<{ path?: string; lang?: string 
 	}
 
 	try {
-		const proc = spawn([shell, "-ilc", 'echo "___PATH=$PATH";echo "___LANG=$LANG"'], {
+		const proc = spawn([shell, "-ilc", [
+			'echo "___PATH=$PATH"',
+			'echo "___LANG=$LANG"',
+			'echo "___XDG_CONFIG_HOME=$XDG_CONFIG_HOME"',
+			'echo "___GH_CONFIG_DIR=$GH_CONFIG_DIR"',
+		].join(";")], {
 			stdout: "pipe",
 			stderr: "pipe",
 		});
@@ -70,6 +82,8 @@ export async function resolveShellEnv(): Promise<{ path?: string; lang?: string 
 
 		let path: string | undefined;
 		let lang: string | undefined;
+		let xdgConfigHome: string | undefined;
+		let ghConfigDir: string | undefined;
 
 		for (const line of lines) {
 			if (line.startsWith("___PATH=")) {
@@ -78,10 +92,16 @@ export async function resolveShellEnv(): Promise<{ path?: string; lang?: string 
 			} else if (line.startsWith("___LANG=")) {
 				const val = line.slice("___LANG=".length).trim();
 				if (val) lang = val;
+			} else if (line.startsWith("___XDG_CONFIG_HOME=")) {
+				const val = line.slice("___XDG_CONFIG_HOME=".length).trim();
+				if (val) xdgConfigHome = val;
+			} else if (line.startsWith("___GH_CONFIG_DIR=")) {
+				const val = line.slice("___GH_CONFIG_DIR=".length).trim();
+				if (val) ghConfigDir = val;
 			}
 		}
 
-		return { path, lang };
+		return { path, lang, xdgConfigHome, ghConfigDir };
 	} catch (err) {
 		log.warn("Failed to resolve shell environment", {
 			shell,


### PR DESCRIPTION
## Summary
- import `GH_CONFIG_DIR` and `XDG_CONFIG_HOME` from the user login shell during startup
- apply the same gh config environment in both GUI and headless entrypoints
- add a regression test for shell environment bootstrapping

## Testing
- bun run lint
- bun run test

Closes #491