### PR TITLE
fix: open diff from top summary badge

### DIFF
--- a/change-logs/2026/04/21/fix-topbar-diff-click.md
+++ b/change-logs/2026/04/21/fix-topbar-diff-click.md
@@ -1,0 +1,1 @@
+Made the top changed-files badge in the task header open the same inline branch diff as the `Show Diff` button. Added a regression test to keep the badge click wired to the diff dialog while preserving the hover popover.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -85,7 +85,7 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, taskResou
 	const dragging = useRef(false);
 	const statusTriggerRef = useRef<HTMLButtonElement>(null);
 	const statusMenuRef = useRef<HTMLDivElement>(null);
-	const diffFilesTriggerRef = useRef<HTMLSpanElement>(null);
+	const diffFilesTriggerRef = useRef<HTMLButtonElement>(null);
 	const diffFilesHoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const allocatedPorts = useTaskAllocatedPorts(task);
 	const isTaskActive = ACTIVE_STATUSES.includes(task.status);
@@ -364,35 +364,41 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, taskResou
 		});
 	}
 
+	function openBranchDiff(focusFile?: string) {
+		if (!onOpenInlineDiff) {
+			return;
+		}
+		onOpenInlineDiff({
+			mode: "branch",
+			compareRef: metadataBranchState?.compareRef,
+			compareLabel: metadataBranchState?.compareLabel ?? `origin/${task.baseBranch || project.defaultBaseBranch || "main"}`,
+			focusFile,
+		});
+	}
+
 	function handleFileDiff(event: ReactMouseEvent<HTMLButtonElement>, relativePath: string) {
 		event.stopPropagation();
 		setDiffFilesHover(false);
 		setFileOpenInMenu(null);
-		if (!onOpenInlineDiff) {
-			return;
-		}
-		const compareLabel = metadataBranchState?.compareLabel ?? `origin/${task.baseBranch || project.defaultBaseBranch || "main"}`;
-		onOpenInlineDiff({
-			mode: "branch",
-			compareRef: metadataBranchState?.compareRef,
-			compareLabel,
-			focusFile: relativePath,
-		});
+		openBranchDiff(relativePath);
 	}
 
 	const metadataBranchStatus = metadataBranchState?.branchStatus ?? null;
 	const diffSummaryBadge = metadataBranchStatus && metadataBranchStatus.diffFiles > 0 ? (
-		<span
+		<button
+			type="button"
 			ref={diffFilesTriggerRef}
-			className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg bg-elevated border border-edge text-[0.6875rem] font-mono text-fg-2 flex-shrink-0 cursor-default"
+			className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg bg-elevated border border-edge text-[0.6875rem] font-mono text-fg-2 flex-shrink-0 cursor-pointer transition-colors hover:bg-elevated-hover"
+			onClick={() => openBranchDiff()}
 			onMouseEnter={showDiffFilesPopover}
 			onMouseLeave={hideDiffFilesPopover}
+			title={t("infoPanel.showDiff")}
 		>
 			<span className="text-fg-muted text-[0.8rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF0CB"}</span>
 			<span>{metadataBranchStatus.diffFiles} {metadataBranchStatus.diffFiles === 1 ? "file" : "files"}</span>
 			<span className="text-success">+{metadataBranchStatus.diffInsertions}</span>
 			<span className="text-danger">−{metadataBranchStatus.diffDeletions}</span>
-		</span>
+		</button>
 	) : null;
 	const diffFilesPopover = diffFilesHover && metadataBranchStatus && metadataBranchStatus.diffFileNames.length > 0 && createPortal(
 		<div

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -214,6 +214,30 @@ describe("TaskInfoPanel", () => {
 			expect(screen.getByText("src/mainview/App.tsx")).toBeInTheDocument();
 		});
 
+		it("opens inline diff when clicking the top diff summary badge", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const onOpenInlineDiff = vi.fn();
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				diffFiles: 2,
+				diffInsertions: 12,
+				diffDeletions: 4,
+				diffFileNames: ["bun.lock", "src/mainview/App.tsx"],
+			});
+
+			await act(async () => {
+				renderPanel(makeTask(), { onOpenInlineDiff });
+			});
+
+			await user.click(screen.getByText("2 files").closest("button")!);
+
+			expect(onOpenInlineDiff).toHaveBeenCalledWith({
+				mode: "branch",
+				compareRef: undefined,
+				compareLabel: "origin/main",
+			});
+		});
+
 		it("opens inline diff focused on the selected changed file from the popup", async () => {
 			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 			const onOpenInlineDiff = vi.fn();


### PR DESCRIPTION
## Summary
- make the top changed-files badge open the same inline diff as Show Diff
- keep the changed-files hover popover working
- add a regression test for badge click behavior