### PR TITLE
fix: use account shell for task startup wrappers

### DIFF
--- a/change-logs/2026/04/21/fix-task-shell-startup.md
+++ b/change-logs/2026/04/21/fix-task-shell-startup.md
@@ -1,0 +1,1 @@
+Detect the user's real account shell from system user records instead of trusting a stale `SHELL` environment variable. Task setup, startup, cleanup, and fallback shells now launch through that resolved shell so shell-managed tools like `bun` and `gh` keep working in dev-3.0 terminals.

--- a/decisions/042-account-shell-over-stale-shell-env.md
+++ b/decisions/042-account-shell-over-stale-shell-env.md
@@ -1,0 +1,37 @@
+# 042 — Prefer the account shell over a stale `SHELL` env
+
+## Context
+
+Issue #491 looked fixed after importing more `gh` config environment from the
+login shell, but the warning still reproduced for a user whose app-launched
+terminals started in `/bin/bash` while their actual macOS login shell was
+`/bin/zsh`. Setup scripts also failed with `bun: command not found`.
+
+## Investigation
+
+dev-3.0 trusted `process.env.SHELL` in several places. On macOS that value can
+be stale for GUI-launched apps, so we ended up resolving PATH and `gh` config
+from bash while the user's real shell configuration lived in zsh. The task
+wrappers also hardcoded `bash`, which made the mismatch visible in startup and
+failure panes.
+
+## Decision
+
+`src/bun/shell-env.ts` now reads the account shell from system user records
+(`dscl` on macOS, `getent passwd` on Linux) and falls back to `SHELL` only if
+that lookup fails. `src/bun/index.ts`, `src/bun/headless-entry.ts`,
+`src/bun/rpc-handlers/tmux-pty.ts`, and `src/bun/rpc-handlers/task-lifecycle.ts`
+use that resolved shell for shell-env bootstrap and task wrapper execution.
+
+## Risks
+
+The system lookup adds a small startup dependency on `dscl` or `getent`. If the
+lookup fails, we intentionally fall back to the old `SHELL` behavior, so the
+app degrades safely instead of blocking startup.
+
+## Alternatives considered
+
+- Keep trusting `process.env.SHELL`. Rejected because it is exactly what let
+  GUI app launches drift away from the user's real login shell.
+- Hardcode zsh on macOS. Rejected because bash is still valid for some users
+  and Linux needs a portable account-shell lookup instead of Apple-only logic.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -160,7 +160,8 @@ describe("pty-server", () => {
 			expect(tmuxCall![0]).toContain(TMUX_CONF_PATH);
 		});
 
-		it("uses 'bash' when tmuxCommand is empty", () => {
+		it("uses the user shell when tmuxCommand is empty", () => {
+			process.env.SHELL = "/bin/zsh";
 			const id = track("task-defcmd-01");
 			createSession(id, "proj-1", "/tmp/cwd", "", {});
 
@@ -168,8 +169,8 @@ describe("pty-server", () => {
 				(c) => Array.isArray(c[0]) && c[0].includes("new-session"),
 			);
 			expect(tmuxCall).toBeDefined();
-			// last arg should be "bash" (default)
-			expect(tmuxCall![0][tmuxCall![0].length - 1]).toBe("bash");
+			// last arg should be the resolved user shell
+			expect(tmuxCall![0][tmuxCall![0].length - 1]).toBe("/bin/zsh");
 		});
 
 		it("calls onPtyDied when cwd does not exist", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -541,19 +541,19 @@ describe("buildCmdScript", () => {
 		expect(result).not.toContain(`exec ${cmd}`);
 	});
 
-	it("defaults to keepShell=false: drops into bash only on failure", () => {
-		const result = buildCmdScript("claude");
+	it("defaults to keepShell=false: drops into the selected shell on failure", () => {
+		const result = buildCmdScript("claude", undefined, { shellPath: "/bin/zsh" });
 		expect(result).toContain("__EC=$?");
 		expect(result).toContain("if [ $__EC -ne 0 ]; then");
-		expect(result).toContain("exec bash");
-		expect(result).not.toContain('exec "${SHELL:-bash}"');
+		expect(result).toContain("exec '/bin/zsh'");
+		expect(result).not.toContain("exec bash");
 	});
 
 	it("keepShell=true: always drops into user shell after command finishes", () => {
-		const result = buildCmdScript("claude", undefined, { keepShell: true });
+		const result = buildCmdScript("claude", undefined, { keepShell: true, shellPath: "/bin/zsh" });
 		expect(result).toContain("__EC=$?");
-		expect(result).toContain('exec "${SHELL:-bash}"');
-		expect(result).not.toContain("exec bash\n");
+		expect(result).toContain("exec '/bin/zsh'");
+		expect(result).not.toContain("exec bash");
 	});
 
 	it("keepShell=true: shows error message on non-zero exit", () => {
@@ -4462,6 +4462,7 @@ describe("launchTaskPty", () => {
 	});
 
 	it("waits for setup completion before opening the agent pane in blocking mode", async () => {
+		process.env.SHELL = "/bin/zsh";
 		const project = makeProject({
 			setupScript: "bun install",
 			...( { setupScriptLaunchMode: "blocking" } as any ),
@@ -4474,8 +4475,8 @@ describe("launchTaskPty", () => {
 
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
-			const setupIndex = script.indexOf('bash -x "/tmp/dev3-task-1-setup.sh"');
-			const splitIndex = script.indexOf('tmux split-window -v -c "/tmp/wt" "bash \'/tmp/dev3-task-1-cmd.sh\'"');
+			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '/tmp/dev3-task-1-setup.sh'`);
+			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '/tmp/dev3-task-1-cmd.sh'"`);
 
 			expect(setupIndex).toBeGreaterThanOrEqual(0);
 			expect(splitIndex).toBeGreaterThanOrEqual(0);
@@ -4486,6 +4487,7 @@ describe("launchTaskPty", () => {
 	});
 
 	it("opens the agent pane immediately in parallel mode", async () => {
+		process.env.SHELL = "/bin/zsh";
 		const project = makeProject({
 			setupScript: "bun install",
 			...( { setupScriptLaunchMode: "parallel" } as any ),
@@ -4498,8 +4500,8 @@ describe("launchTaskPty", () => {
 
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
-			const splitIndex = script.indexOf('tmux split-window -v -c "/tmp/wt" "bash \'/tmp/dev3-task-1-cmd.sh\'"');
-			const setupIndex = script.indexOf('bash -x "/tmp/dev3-task-1-setup.sh"');
+			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '/tmp/dev3-task-1-cmd.sh'"`);
+			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '/tmp/dev3-task-1-setup.sh'`);
 
 			expect(splitIndex).toBeGreaterThanOrEqual(0);
 			expect(setupIndex).toBeGreaterThanOrEqual(0);

--- a/src/bun/__tests__/shell-env.test.ts
+++ b/src/bun/__tests__/shell-env.test.ts
@@ -3,12 +3,14 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const { spawnMock } = vi.hoisted(() => ({
+const { spawnMock, spawnSyncMock } = vi.hoisted(() => ({
 	spawnMock: vi.fn(),
+	spawnSyncMock: vi.fn(),
 }));
 
 vi.mock("../spawn", () => ({
 	spawn: spawnMock,
+	spawnSync: spawnSyncMock,
 }));
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
@@ -34,15 +36,19 @@ function fakeProc(stdout: string, stderr = "", exitCode = 0) {
 
 describe("shell environment bootstrap", () => {
 	let originalShell: string | undefined;
+	let originalPlatform: string;
 
 	beforeEach(() => {
 		originalShell = process.env.SHELL;
+		originalPlatform = process.platform;
 		vi.resetModules();
 		spawnMock.mockReset();
+		spawnSyncMock.mockReset();
 	});
 
 	afterEach(() => {
 		process.env.SHELL = originalShell;
+		Object.defineProperty(process, "platform", { value: originalPlatform });
 	});
 
 	it("skips unsupported shells like fish instead of running bash/zsh login commands", async () => {
@@ -73,6 +79,27 @@ describe("shell environment bootstrap", () => {
 			xdgConfigHome: "/Users/tester/.config-xdg",
 			ghConfigDir: "/Users/tester/.config-gh",
 		});
+	});
+
+	it("prefers the account shell from macOS user records over a stale SHELL env", async () => {
+		process.env.SHELL = "/bin/bash";
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		spawnSyncMock.mockReturnValue({
+			exitCode: 0,
+			stdout: new TextEncoder().encode("UserShell: /bin/zsh\n"),
+			stderr: new Uint8Array(),
+		});
+		spawnMock.mockReturnValue(fakeProc("___PATH=/opt/homebrew/bin:/usr/bin\n"));
+
+		const { getUserShell, resolveShellEnv } = await import("../shell-env");
+		expect(getUserShell()).toBe("/bin/zsh");
+
+		await resolveShellEnv();
+
+		expect(spawnMock).toHaveBeenCalledWith(
+			expect.arrayContaining(["/bin/zsh", "-ilc"]),
+			expect.any(Object),
+		);
 	});
 
 	it("main-process PATH bootstrap uses an explicit shell-profile helper instead of defaulting to zsh", () => {

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -19,7 +19,7 @@ import { resolve } from "node:path";
 import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited } from "./rpc-handlers";
 import { createLogger, getLogPath } from "./logger";
 import { DEV3_HOME } from "./paths";
-import { resolveShellEnv } from "./shell-env";
+import { getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
 import { startRemoteAccessServer, pushToBrowserClients, getServerPort, getAccessUrl } from "./remote-access-server";
 import { startTunnel, stopTunnel, isCloudflaredAvailable, getTunnelUrl } from "./cloudflare-tunnel";
@@ -79,6 +79,7 @@ if (!process.env.DEV3_VIEWS_DIR) {
 }
 
 // ── Resolve shell PATH + LANG + key gh config vars (same as GUI entry) ──
+process.env.SHELL = getUserShell();
 const originalPath = process.env.PATH;
 const originalLang = process.env.LANG;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -13,7 +13,7 @@ import { startAutoCheck, checkForUpdateWithChannel, getLocalVersion, downloadUpd
 import { loadSettings } from "./settings";
 import { createLogger, getLogPath } from "./logger";
 import { DEV3_HOME } from "./paths";
-import { getShellRcFile, resolveShellEnv } from "./shell-env";
+import { getShellRcFile, getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
 import { startRemoteAccessServer, pushToBrowserClients, generateQrDataUrl, getAccessUrl } from "./remote-access-server";
 import { stopTunnel } from "./cloudflare-tunnel";
@@ -109,7 +109,8 @@ log.info("Log files", { dir: getLogPath() });
 
 	// Append ~/.dev3.0/bin to the user's shell RC file (idempotent).
 	// This makes `dev3` available in all terminals, not just worktree tmux sessions.
-	const shell = process.env.SHELL || "/bin/zsh";
+	const shell = getUserShell();
+	process.env.SHELL = shell;
 	const home = process.env.HOME || "/tmp";
 	const marker = ".dev3.0/bin";
 	const rcFile = getShellRcFile(shell, home);

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -1,6 +1,7 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { createLogger } from "./logger";
 import { spawn, spawnSync } from "./spawn";
+import { getUserShell } from "./shell-env";
 import { CATPPUCCIN_PLUGIN_DIR, writeCatppuccinPlugin } from "./tmux-themes";
 import { writeShellInit } from "./shell-init";
 
@@ -570,7 +571,7 @@ function setupProjectLayout(session: PtySession): void {
 
 function spawnPty(session: PtySession, cols: number, rows: number): void {
 	const tmuxSessionName = session.tmuxSessionName;
-	const tmuxCmd = session.tmuxCommand || "bash";
+	const tmuxCmd = session.tmuxCommand || getUserShell();
 
 	if (!existsSync(session.cwd)) {
 		log.error("Cannot spawn PTY — cwd does not exist", {

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -21,6 +21,22 @@ export function shellQuote(s: string): string {
 	return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+export function getScriptShellPath(shellPath?: string): string {
+	return shellPath?.trim() || process.env.SHELL || "/bin/zsh";
+}
+
+export function buildScriptRunnerCommand(
+	scriptPath: string,
+	options?: { shellPath?: string; trace?: boolean },
+): string {
+	const parts = [shellQuote(getScriptShellPath(options?.shellPath))];
+	if (options?.trace) {
+		parts.push("-x");
+	}
+	parts.push(shellQuote(scriptPath));
+	return parts.join(" ");
+}
+
 export function buildEnvExports(env: Record<string, string>): string[] {
 	return Object.entries(env).map(([key, value]) => `export ${key}=${shellQuote(value)}`);
 }
@@ -28,13 +44,14 @@ export function buildEnvExports(env: Record<string, string>): string[] {
 export function buildCmdScript(
 	tmuxCmd: string,
 	env?: Record<string, string>,
-	options?: { paneTitle?: string; keepShell?: boolean; onExitCommand?: string },
+	options?: { paneTitle?: string; keepShell?: boolean; onExitCommand?: string; shellPath?: string },
 ): string {
 	const escaped = escapeForDoubleQuotes(tmuxCmd);
 	const exportLines = env && Object.keys(env).length > 0 ? buildEnvExports(env) : [];
 	const safePaneTitle = options?.paneTitle?.replace(/'/g, "") ?? "";
 	const titleLine = safePaneTitle ? `printf '\\033]2;${safePaneTitle}\\033\\\\'` : "";
 	const onExitLines = options?.onExitCommand ? [options.onExitCommand] : [];
+	const shellPath = getScriptShellPath(options?.shellPath);
 	if (options?.keepShell) {
 		return [
 			"#!/bin/bash",
@@ -48,7 +65,7 @@ export function buildCmdScript(
 			`  printf '\\n\\033[2mAgent session ended (exit 0). You are in the worktree shell.\\033[0m\\n'`,
 			...onExitLines,
 			"fi",
-			`exec "\${SHELL:-bash}"`,
+			`exec ${shellQuote(shellPath)}`,
 			"",
 		].join("\n");
 	}
@@ -60,7 +77,7 @@ export function buildCmdScript(
 		"__EC=$?",
 		"if [ $__EC -ne 0 ]; then",
 		`  printf '\\n\\033[1;31m✗ Process exited with code %s\\033[0m\\n' "$__EC"`,
-		"  exec bash",
+		`  exec ${shellQuote(shellPath)}`,
 		...(onExitLines.length > 0 ? ["else", ...onExitLines] : []),
 		"fi",
 		"",

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -3,6 +3,8 @@ export {
 	log,
 	escapeForDoubleQuotes,
 	shellQuote,
+	getScriptShellPath,
+	buildScriptRunnerCommand,
 	buildEnvExports,
 	buildCmdScript,
 	resolveBinaryPath,

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -19,8 +19,9 @@ import {
 	withTaskPreparation,
 } from "../preparation-runtime";
 import { loadSettings, loadSettingsSync } from "../settings";
+import { getUserShell } from "../shell-env";
 import { spawn } from "../spawn";
-import { getPushMessage, isActive, log, notifyWatchedTaskStatusChange } from "./shared";
+import { buildScriptRunnerCommand, getPushMessage, isActive, log, notifyWatchedTaskStatusChange } from "./shared";
 import { clearMergeNotification, cleanupTaskGitState } from "./git-operations";
 import { resolveOperationalProjectConfig } from "./settings-config";
 import { cleanupTaskTmuxState, killDevServerSession, launchColumnAgent, launchTaskPty } from "./tmux-pty";
@@ -433,13 +434,14 @@ export async function runCleanupScript(
 	const script = resolved.cleanupScript?.trim() || DEFAULT_CLEANUP_SCRIPT;
 	const scriptPath = `/tmp/dev3-${task.id}-cleanup.sh`;
 	const sessionName = `dev3-cl-${task.id.slice(0, 8)}`;
+	const userShell = getUserShell();
 
 	await Bun.write(scriptPath, `#!/bin/bash\n${script}\n`);
 
 	log.info("Starting cleanup tmux session", { session: sessionName, worktreePath: task.worktreePath });
 
 	const cleanupSocket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
-	const cleanupArgs = pty.tmuxArgs(cleanupSocket, "-f", pty.TMUX_CONF_PATH, "new-session", "-s", sessionName, "-c", task.worktreePath, `bash "${scriptPath}"`);
+	const cleanupArgs = pty.tmuxArgs(cleanupSocket, "-f", pty.TMUX_CONF_PATH, "new-session", "-s", sessionName, "-c", task.worktreePath, buildScriptRunnerCommand(scriptPath, { shellPath: userShell }));
 	const proc = spawn(
 		cleanupArgs,
 		{

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -9,9 +9,10 @@ import * as repoConfig from "../repo-config";
 import { getPortsForTask, getSessionPanePids, scanTaskPorts } from "../port-scanner";
 import { getResourceUsage } from "../resource-monitor";
 import { loadSettings } from "../settings";
+import { getUserShell } from "../shell-env";
 import { spawn, spawnSync } from "../spawn";
 import { setupAgentHooks } from "../agent-hooks";
-import { isActive, buildAgentEnv, buildCmdScript, buildEnvExports, escapeForDoubleQuotes, log, resolveBinaryPath, shellQuote } from "./shared-pure";
+import { isActive, buildAgentEnv, buildCmdScript, buildEnvExports, buildScriptRunnerCommand, escapeForDoubleQuotes, log, resolveBinaryPath, shellQuote } from "./shared-pure";
 import { resolveOperationalProjectConfig } from "./settings-config";
 
 const devViewerPaneIds = new Map<string, string>();
@@ -222,6 +223,7 @@ export async function launchTaskPty(
 	}
 
 	const env = buildAgentEnv(extraEnv, task.id);
+	const userShell = getUserShell();
 
 	const portCount = project.portCount ?? 0;
 	if (portCount > 0) {
@@ -251,7 +253,7 @@ export async function launchTaskPty(
 			log.warn("Agent binary not found, creating retry wrapper", { binaryName, installCmd });
 
 			const originalCmdPath = `/tmp/dev3-${task.id}-original-cmd.sh`;
-			await Bun.write(originalCmdPath, buildCmdScript(tmuxCmd, env, { keepShell: true }));
+			await Bun.write(originalCmdPath, buildCmdScript(tmuxCmd, env, { keepShell: true, shellPath: userShell }));
 
 			const retryScript = [
 				"#!/bin/bash",
@@ -259,7 +261,7 @@ export async function launchTaskPty(
 				"check_and_run() {",
 				`  if command -v ${shellQuote(binaryName)} &>/dev/null; then`,
 				`    printf '\\n\\033[1;32m✓ Found %s\\033[0m\\n\\n' ${shellQuote(binaryName)}`,
-				`    exec bash "${originalCmdPath}"`,
+				`    exec ${buildScriptRunnerCommand(originalCmdPath, { shellPath: userShell })}`,
 				"  fi",
 				"}",
 				"",
@@ -277,7 +279,7 @@ export async function launchTaskPty(
 
 			const retryScriptPath = `/tmp/dev3-${task.id}-agent-check.sh`;
 			await Bun.write(retryScriptPath, retryScript);
-			tmuxCmd = `bash "${retryScriptPath}"`;
+			tmuxCmd = buildScriptRunnerCommand(retryScriptPath, { shellPath: userShell });
 			log.info("Replaced tmuxCmd with agent-check retry wrapper");
 		}
 	}
@@ -338,12 +340,12 @@ export async function launchTaskPty(
 		const startupPath = `${prefix}-startup.sh`;
 
 		await Bun.write(setupPath, project.setupScript + "\n");
-		await Bun.write(cmdPath, buildCmdScript(tmuxCmd, env, { keepShell: true }));
+		await Bun.write(cmdPath, buildCmdScript(tmuxCmd, env, { keepShell: true, shellPath: userShell }));
 
-		const splitCmd = `tmux split-window -v -c "${escapeForDoubleQuotes(worktreePath)}" "bash '${cmdPath}'"`;
+		const splitCmd = `tmux split-window -v -c "${escapeForDoubleQuotes(worktreePath)}" "${escapeForDoubleQuotes(buildScriptRunnerCommand(cmdPath, { shellPath: userShell }))}"`;
 		const setupFail = [
 			"  printf '\\033[1;31m✗ Setup failed (exit %s)\\033[0m\\n' \"$S\"",
-			"  exec bash",
+			`  exec ${shellQuote(userShell)}`,
 		].join("\n");
 		const setupOkClose = [
 			"printf '\\033[1;32m✓ Setup done\\033[0m\\n'",
@@ -355,7 +357,7 @@ export async function launchTaskPty(
 		const startupLines = [
 			"#!/bin/bash",
 			...(setupScriptLaunchMode === "parallel" ? [splitCmd] : []),
-			`bash -x "${setupPath}"`,
+			buildScriptRunnerCommand(setupPath, { shellPath: userShell, trace: true }),
 			"S=$?",
 			`if [ $S -ne 0 ]; then`,
 			setupFail,
@@ -364,13 +366,13 @@ export async function launchTaskPty(
 			setupOkClose,
 		];
 		await Bun.write(startupPath, startupLines.join("\n") + "\n");
-		tmuxCmd = `bash "${startupPath}"`;
+		tmuxCmd = buildScriptRunnerCommand(startupPath, { shellPath: userShell });
 		isSetupWrapper = true;
 	}
 
 	const runScriptPath = `/tmp/dev3-${task.id}-run.sh`;
-	await Bun.write(runScriptPath, buildCmdScript(tmuxCmd, env, { keepShell: !isSetupWrapper }));
-	const wrapperCmd = `bash "${runScriptPath}"`;
+	await Bun.write(runScriptPath, buildCmdScript(tmuxCmd, env, { keepShell: !isSetupWrapper, shellPath: userShell }));
+	const wrapperCmd = buildScriptRunnerCommand(runScriptPath, { shellPath: userShell });
 
 	log.info("Creating PTY session", {
 		taskId: task.id.slice(0, 8),
@@ -982,8 +984,7 @@ async function getProjectPtyUrl(params: { projectId: string }): Promise<string> 
 		if (!existsSync(project.path)) {
 			throw new Error(`Project path does not exist: ${project.path}`);
 		}
-		const userShell = process.env.SHELL || "/bin/zsh";
-		pty.createSession(sessionKey, params.projectId, project.path, userShell, {}, pty.DEFAULT_TMUX_SOCKET, "project");
+		pty.createSession(sessionKey, params.projectId, project.path, getUserShell(), {}, pty.DEFAULT_TMUX_SOCKET, "project");
 	}
 
 	const url = `ws://localhost:${pty.getPtyPort()}?session=${sessionKey}`;

--- a/src/bun/shell-env.ts
+++ b/src/bun/shell-env.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "./logger";
-import { spawn } from "./spawn";
+import { spawn, spawnSync } from "./spawn";
 
 const log = createLogger("shell-env");
 
@@ -28,6 +28,49 @@ export function getShellRcFile(shell: string, home: string): string | null {
 	return null;
 }
 
+function decodeStdout(stdout?: Uint8Array): string {
+	return stdout ? new TextDecoder().decode(stdout).trim() : "";
+}
+
+function readAccountShell(): string | null {
+	const user = process.env.USER || process.env.LOGNAME;
+	if (!user) return null;
+
+	try {
+		if (process.platform === "darwin") {
+			const result = spawnSync(["dscl", ".", "-read", `/Users/${user}`, "UserShell"], {
+				stdout: "pipe",
+				stderr: "ignore",
+			});
+			if (result.exitCode === 0) {
+				const match = decodeStdout(result.stdout).match(/^UserShell:\s+(.+)$/m);
+				return match?.[1]?.trim() || null;
+			}
+			return null;
+		}
+
+		if (process.platform === "linux") {
+			const result = spawnSync(["getent", "passwd", user], {
+				stdout: "pipe",
+				stderr: "ignore",
+			});
+			if (result.exitCode === 0) {
+				const line = decodeStdout(result.stdout);
+				const shell = line.split(":")[6]?.trim();
+				return shell || null;
+			}
+		}
+	} catch (err) {
+		log.debug("Failed to read account shell", { user, error: String(err) });
+	}
+
+	return null;
+}
+
+export function getUserShell(): string {
+	return readAccountShell() || process.env.SHELL || "/bin/zsh";
+}
+
 /**
  * Resolve the user's shell environment by spawning their login shell.
  *
@@ -46,7 +89,7 @@ export async function resolveShellEnv(): Promise<{
 	xdgConfigHome?: string;
 	ghConfigDir?: string;
 }> {
-	const shell = process.env.SHELL || "/bin/zsh";
+	const shell = getUserShell();
 	const timeout = 5_000;
 	const supportedShell = getSupportedShell(shell);
 


### PR DESCRIPTION
## Summary
- resolve the actual account shell from system user records instead of trusting a stale `SHELL` env
- run task startup, setup, cleanup, and fallback wrappers through that resolved shell
- add regression coverage for shell detection and task wrapper shell selection

## Testing
- bun run lint
- bun run test

Fixes #491