### PR TITLE
feat: hourly tasks.json backups (72h retention)

### DIFF
--- a/change-logs/2026/04/22/feature-tasks-json-hourly-backups.md
+++ b/change-logs/2026/04/22/feature-tasks-json-hourly-backups.md
@@ -1,0 +1,1 @@
+Added hourly pre-save backups for each project's `tasks.json` under a new `tasks-backups/` directory in `~/.dev3.0/data/<slug>/`. The data layer now keeps one snapshot per UTC hour and prunes the set to the newest 72 files, with regression tests covering snapshot creation, hourly deduping, and retention trimming.

--- a/decisions/043-tasks-json-hourly-backups.md
+++ b/decisions/043-tasks-json-hourly-backups.md
@@ -1,0 +1,35 @@
+# 043 — Hourly `tasks.json` backups live in a parallel path
+
+## Context
+
+`tasks.json` is the only persisted task store for a project, so a bad write or
+manual corruption can wipe the board state in one shot. We wanted automatic
+recovery points without touching the canonical file path or breaking older app
+versions that still read `~/.dev3.0/data/<slug>/tasks.json`.
+
+## Investigation
+
+Per-write versioning would create many near-duplicate snapshots during active
+sessions and would grow without a hard retention cap. Rewriting or renaming the
+main file was off-limits because `~/.dev3.0/` is shared state across app
+versions and `AGENTS.md` explicitly freezes the existing layout.
+
+## Decision
+
+`src/bun/data.ts` now writes hourly pre-save snapshots of the current
+`tasks.json` into `~/.dev3.0/data/<slug>/tasks-backups/<YYYY-MM-DDTHHZ>.json`
+before normal task writes. The snapshot is created at most once per UTC hour,
+and the same code prunes the directory down to the newest 72 files.
+
+## Risks
+
+Backups are opportunistic, not timer-driven: if nothing writes `tasks.json`,
+there is nothing new to snapshot. This is acceptable because the goal is to
+preserve recent write-time recovery points, not to run a background daemon.
+
+## Alternatives considered
+
+- Snapshot on every write. Rejected because it produces noisy duplicate files
+  during heavy task churn.
+- Replace `tasks.json` with a rolling file scheme. Rejected because it changes
+  the canonical path and risks cross-version breakage.

--- a/src/bun/__tests__/data-migration-race.test.ts
+++ b/src/bun/__tests__/data-migration-race.test.ts
@@ -7,6 +7,7 @@ const { mockFileStore, lockQueues, fsPromises } = vi.hoisted(() => ({
 	fsPromises: {
 		mkdir: vi.fn(),
 		readFile: vi.fn(),
+		readdir: vi.fn(),
 		unlink: vi.fn(),
 		writeFile: vi.fn(),
 	},
@@ -105,6 +106,14 @@ beforeEach(() => {
 	}
 	lockQueues.clear();
 	fsPromises.mkdir.mockResolvedValue(undefined);
+	fsPromises.readdir.mockImplementation(async (dirPath: string | URL | Buffer) => {
+		const prefix = `${String(dirPath)}/`;
+		return Object.keys(mockFileStore)
+			.filter((path) => path.startsWith(prefix))
+			.map((path) => path.slice(prefix.length))
+			.filter((entry) => !entry.includes("/"))
+			.sort();
+	});
 	fsPromises.unlink.mockImplementation(async (path: string | URL | Buffer) => {
 		delete mockFileStore[String(path)];
 	});

--- a/src/bun/__tests__/data-seq.test.ts
+++ b/src/bun/__tests__/data-seq.test.ts
@@ -332,6 +332,23 @@ describe("tasks.json hourly backups", () => {
 		expect(backupFiles[backupFiles.length - 1]).toBe("2026-04-23T00Z.json");
 		expect(backupFiles).not.toContain("2026-04-20T00Z.json");
 	});
+
+	it("does not block task save when backup write fails", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-22T10:00:00.000Z"));
+
+		const originalTasks = [{ ...makeRawTask({ id: "a", title: "Original", description: "Original" }), seq: 1 }];
+		seedTasks(originalTasks);
+
+		// Make the backup dir unwritable by pre-creating a file where mkdir would put the dir
+		const backupDir = tasksBackupDirPath();
+		writeFileSync(backupDir, "block"); // file in place of directory → mkdir will fail
+
+		await expect(updateTask(testProject, "a", { title: "Updated" })).resolves.toBeDefined();
+		expect(readSavedTasks()[0].title).toBe("Updated");
+
+		rmSync(backupDir);
+	});
 });
 
 // ============================================================

--- a/src/bun/__tests__/data-seq.test.ts
+++ b/src/bun/__tests__/data-seq.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Project, Task } from "../../shared/types";
 
@@ -25,7 +25,11 @@ beforeEach(() => {
 	mkdirSync("/tmp/dev3-test-seq", { recursive: true });
 });
 
-import { loadTasks, addTask, updateTask } from "../data";
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+import { addTask, loadTasks, saveTasks, updateTask } from "../data";
 
 const testProject: Project = {
 	id: "proj-1",
@@ -40,6 +44,18 @@ const testProject: Project = {
 
 function tasksFilePath(): string {
 	return "/tmp/dev3-test-seq/data/tmp-test-project/tasks.json";
+}
+
+function tasksBackupDirPath(): string {
+	return "/tmp/dev3-test-seq/data/tmp-test-project/tasks-backups";
+}
+
+function readBackupFileNames(): string[] {
+	try {
+		return readdirSync(tasksBackupDirPath()).sort();
+	} catch {
+		return [];
+	}
 }
 
 function seedTasks(tasks: unknown[]): void {
@@ -263,6 +279,58 @@ describe("addTask — seq assignment", () => {
 		// New task should get seq=3
 		const newTask = await addTask(testProject, "New task");
 		expect(newTask.seq).toBe(3);
+	});
+});
+
+describe("tasks.json hourly backups", () => {
+	it("captures the previous tasks.json once per hour before overwriting it", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-22T10:15:00.000Z"));
+
+		const originalTasks = [{ ...makeRawTask({ id: "a", title: "Original", description: "Original" }), seq: 1 }];
+		seedTasks(originalTasks);
+
+		await updateTask(testProject, "a", { title: "Updated title" });
+
+		const backupFiles = readBackupFileNames();
+		expect(backupFiles).toEqual(["2026-04-22T10Z.json"]);
+		expect(JSON.parse(readFileSync(`${tasksBackupDirPath()}/2026-04-22T10Z.json`, "utf8"))).toEqual(originalTasks);
+		expect(readSavedTasks()[0].title).toBe("Updated title");
+	});
+
+	it("does not create a second backup file within the same hour", async () => {
+		vi.useFakeTimers();
+
+		const originalTasks = [{ ...makeRawTask({ id: "a", title: "Original", description: "Original" }), seq: 1 }];
+		seedTasks(originalTasks);
+
+		vi.setSystemTime(new Date("2026-04-22T10:05:00.000Z"));
+		await updateTask(testProject, "a", { title: "First update" });
+
+		vi.setSystemTime(new Date("2026-04-22T10:45:00.000Z"));
+		await updateTask(testProject, "a", { title: "Second update" });
+
+		const backupFiles = readBackupFileNames();
+		expect(backupFiles).toEqual(["2026-04-22T10Z.json"]);
+		expect(JSON.parse(readFileSync(`${tasksBackupDirPath()}/2026-04-22T10Z.json`, "utf8"))).toEqual(originalTasks);
+		expect(readSavedTasks()[0].title).toBe("Second update");
+	});
+
+	it("keeps only the latest 72 hourly backups", async () => {
+		vi.useFakeTimers();
+
+		seedTasks([{ ...makeRawTask({ id: "a", title: "Task 0", description: "Task 0" }), seq: 1 }]);
+
+		for (let hour = 0; hour < 73; hour++) {
+			vi.setSystemTime(new Date(`2026-04-${String(20 + Math.floor(hour / 24)).padStart(2, "0")}T${String(hour % 24).padStart(2, "0")}:00:00.000Z`));
+			await saveTasks(testProject, readSavedTasks());
+		}
+
+		const backupFiles = readBackupFileNames();
+		expect(backupFiles).toHaveLength(72);
+		expect(backupFiles[0]).toBe("2026-04-20T01Z.json");
+		expect(backupFiles[backupFiles.length - 1]).toBe("2026-04-23T00Z.json");
+		expect(backupFiles).not.toContain("2026-04-20T00Z.json");
 	});
 });
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
 import type { Project, Task, TaskStatus, TipState } from "../shared/types";
 import { titleFromDescription } from "../shared/types";
 import { createLogger } from "./logger";
@@ -10,6 +10,9 @@ import { projectSlug } from "./git";
 const log = createLogger("data");
 
 const PROJECTS_FILE = `${DEV3_HOME}/projects.json`;
+const TASK_BACKUPS_DIR = "tasks-backups";
+const TASK_BACKUP_RETENTION_HOURS = 72;
+const TASK_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
 type ProjectUpdates = Partial<Pick<Project, "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels">>;
 
 export class DataFileReadError extends Error {
@@ -27,6 +30,14 @@ export class DataFileReadError extends Error {
 
 function tasksFile(project: Project): string {
 	return `${DEV3_HOME}/data/${projectSlug(project.path)}/tasks.json`;
+}
+
+function tasksBackupDir(project: Project): string {
+	return `${DEV3_HOME}/data/${projectSlug(project.path)}/${TASK_BACKUPS_DIR}`;
+}
+
+function tasksBackupFileName(now: Date = new Date()): string {
+	return `${now.toISOString().slice(0, 13)}Z.json`;
 }
 
 function deriveTaskBaseBranch(project: Project, existingBranch?: string | null): string {
@@ -314,8 +325,43 @@ async function rawSaveTasks(
 	const file = tasksFile(project);
 	log.debug("Saving tasks", { projectId: project.id, count: tasks.length });
 	await ensureDir(file);
+	await writeHourlyTasksBackup(project, file);
 	await writeFile(file, JSON.stringify(tasks, null, 2));
 	log.info(`Saved ${tasks.length} task(s)`, { projectId: project.id });
+}
+
+async function writeHourlyTasksBackup(project: Project, filePath: string): Promise<void> {
+	let currentContent: string;
+	try {
+		currentContent = await readFile(filePath, "utf8");
+	} catch (err: any) {
+		if (err.code === "ENOENT") {
+			return;
+		}
+		throw err;
+	}
+
+	const backupDir = tasksBackupDir(project);
+	const backupFile = `${backupDir}/${tasksBackupFileName()}`;
+
+	await mkdir(backupDir, { recursive: true });
+
+	try {
+		await readFile(backupFile, "utf8");
+	} catch (err: any) {
+		if (err.code !== "ENOENT") {
+			throw err;
+		}
+		await writeFile(backupFile, currentContent);
+	}
+
+	const backupFiles = (await readdir(backupDir))
+		.filter((entry) => TASK_BACKUP_FILE_PATTERN.test(entry))
+		.sort();
+
+	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - TASK_BACKUP_RETENTION_HOURS))) {
+		await unlink(`${backupDir}/${staleFile}`);
+	}
 }
 
 // ---- Tasks (public API — all mutators use file lock) ----

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -325,7 +325,9 @@ async function rawSaveTasks(
 	const file = tasksFile(project);
 	log.debug("Saving tasks", { projectId: project.id, count: tasks.length });
 	await ensureDir(file);
-	await writeHourlyTasksBackup(project, file);
+	await writeHourlyTasksBackup(project, file).catch((err) => {
+		log.warn("Failed to write hourly tasks backup (non-fatal)", { projectId: project.id, err });
+	});
 	await writeFile(file, JSON.stringify(tasks, null, 2));
 	log.info(`Saved ${tasks.length} task(s)`, { projectId: project.id });
 }


### PR DESCRIPTION
## Summary

- Before each `tasks.json` write, saves the current file as a timestamped hourly snapshot under `~/.dev3.0/data/<project>/tasks-backups/YYYY-MM-DDTHH Z.json`
- One backup per hour — subsequent writes within the same hour are skipped
- Keeps the latest 72 snapshots (~3 days of continuous use, more in practice)
- Backup failures are non-fatal: logged as `warn`, task save proceeds normally