### PR TITLE
fix: restore merge completion prompts outside AI review

### DIFF
--- a/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
+++ b/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
@@ -1,1 +1,1 @@
-Restore merge-completion prompts across all review columns. Merged branches are now checked every 60 seconds again, and tasks in AI Review, Your Review, and PR Review all offer completion when their changes are already in the base branch.
+Restore merge-completion prompts for Your Review and PR Review. Merged branches are checked every 60 seconds again, and AI Review is explicitly excluded for now because its review agent may still be running long after the branch becomes stale.

--- a/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
+++ b/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
@@ -1,1 +1,1 @@
-Restore merge-completion prompts for Your Review and PR Review. Merged branches are checked every 60 seconds again, and AI Review is explicitly excluded for now because its review agent may still be running long after the branch becomes stale.
+Restore merge-completion prompts for Has Questions, Your Review, and PR Review. Merged branches are checked every 60 seconds again, and AI Review is explicitly excluded for now because its review agent may still be running long after the branch becomes stale.

--- a/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
+++ b/change-logs/2026/04/24/fix-merge-completion-review-statuses.md
@@ -1,0 +1,1 @@
+Restore merge-completion prompts across all review columns. Merged branches are now checked every 60 seconds again, and tasks in AI Review, Your Review, and PR Review all offer completion when their changes are already in the base branch.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5037,6 +5037,35 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		});
 	});
 
+	it("notifies about merged Has Questions tasks on the first 60-second poll", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-user-questions",
+			status: "user-questions",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).toHaveBeenCalledWith("branchMerged", {
+			taskId: task.id,
+			projectId: project.id,
+			taskTitle: task.title,
+			branchName: "dev3/task-test",
+		});
+	});
+
 	it("does not notify about merged AI Review tasks", async () => {
 		const project = makeProject();
 		const task = makeTask({

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -4971,6 +4971,7 @@ describe("getChangelogs", () => {
 
 describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		vi.useFakeTimers();
 		stopMergeDetectionPoller();
 	});
@@ -5034,6 +5035,30 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 			taskTitle: task.title,
 			branchName: "dev3/task-test",
 		});
+	});
+
+	it("does not notify about merged AI Review tasks", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			status: "review-by-ai",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).not.toHaveBeenCalled();
+		expect(git.isContentMergedInto).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5007,6 +5007,34 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		setIntervalSpy.mockRestore();
 		clearIntervalSpy.mockRestore();
 	});
+
+	it("notifies about merged PR Review tasks on the first 60-second poll", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			status: "review-by-colleague",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).toHaveBeenCalledWith("branchMerged", {
+			taskId: task.id,
+			projectId: project.id,
+			taskTitle: task.title,
+			branchName: "dev3/task-test",
+		});
+	});
 });
 
 describe("startPRDetectionPoller / stopPRDetectionPoller", () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -1,4 +1,10 @@
-import type { BranchStatus, PRInfo, TaskDiffMode, TaskDiffResponse } from "../../shared/types";
+import {
+	type BranchStatus,
+	type PRInfo,
+	type TaskDiffMode,
+	type TaskDiffResponse,
+	MERGE_COMPLETE_ELIGIBLE_STATUSES,
+} from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
 import * as github from "../github";
@@ -112,7 +118,7 @@ let mergePollerInterval: ReturnType<typeof setInterval> | null = null;
 
 export function startMergeDetectionPoller(): void {
 	stopMergeDetectionPoller();
-	const POLL_INTERVAL = 5 * 60_000;
+	const POLL_INTERVAL = 60_000;
 
 	mergePollerInterval = setInterval(async () => {
 		try {
@@ -155,7 +161,7 @@ async function checkMergedBranches(): Promise<void> {
 	for (const project of projects) {
 		const tasks = await data.loadTasks(project);
 		const reviewTasks = tasks.filter(
-			(task) => (task.status === "review-by-user" || task.status === "review-by-colleague") && task.worktreePath && !mergeNotifiedTasks.has(task.id),
+			(task) => MERGE_COMPLETE_ELIGIBLE_STATUSES.includes(task.status) && task.worktreePath && !mergeNotifiedTasks.has(task.id),
 		);
 
 		if (reviewTasks.length === 0) continue;

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1588,7 +1588,7 @@ describe("TaskInfoPanel", () => {
 	});
 
 	describe("post-merge auto-complete", () => {
-		it("offers auto-complete for merged AI Review tasks", async () => {
+		it("does not offer auto-complete for merged AI Review tasks", async () => {
 			const dispatch = vi.fn();
 			const navigate = vi.fn();
 			const task = makeTask({ status: "review-by-ai" });
@@ -1603,16 +1603,12 @@ describe("TaskInfoPanel", () => {
 				renderPanel(task, { dispatch, navigate });
 			});
 
-			await waitFor(() => {
-				expect(mockedApi.request.showConfirm).toHaveBeenCalled();
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
 			});
-			await waitFor(() => {
-				expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
-					taskId: "t1",
-					projectId: "p1",
-					newStatus: "completed",
-				});
-			});
+
+			expect(mockedApi.request.showConfirm).not.toHaveBeenCalled();
+			expect(mockedApi.request.moveTask).not.toHaveBeenCalled();
 		});
 
 		it("offers auto-complete for merged PR Review tasks", async () => {

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1588,6 +1588,60 @@ describe("TaskInfoPanel", () => {
 	});
 
 	describe("post-merge auto-complete", () => {
+		it("offers auto-complete for merged AI Review tasks", async () => {
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "review-by-ai" });
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				mergedByContent: true,
+			});
+			mockedApi.request.showConfirm.mockResolvedValue(true);
+			mockedApi.request.moveTask.mockResolvedValue({ ...task, status: "completed" });
+
+			await act(async () => {
+				renderPanel(task, { dispatch, navigate });
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.showConfirm).toHaveBeenCalled();
+			});
+			await waitFor(() => {
+				expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
+					taskId: "t1",
+					projectId: "p1",
+					newStatus: "completed",
+				});
+			});
+		});
+
+		it("offers auto-complete for merged PR Review tasks", async () => {
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "review-by-colleague" });
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				mergedByContent: true,
+			});
+			mockedApi.request.showConfirm.mockResolvedValue(true);
+			mockedApi.request.moveTask.mockResolvedValue({ ...task, status: "completed" });
+
+			await act(async () => {
+				renderPanel(task, { dispatch, navigate });
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.showConfirm).toHaveBeenCalled();
+			});
+			await waitFor(() => {
+				expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
+					taskId: "t1",
+					projectId: "p1",
+					newStatus: "completed",
+				});
+			});
+		});
+
 		it("sets movedAt when auto-completing after merge", async () => {
 			const dispatch = vi.fn();
 			const navigate = vi.fn();

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1638,6 +1638,33 @@ describe("TaskInfoPanel", () => {
 			});
 		});
 
+		it("offers auto-complete for merged Has Questions tasks", async () => {
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "user-questions" });
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				mergedByContent: true,
+			});
+			mockedApi.request.showConfirm.mockResolvedValue(true);
+			mockedApi.request.moveTask.mockResolvedValue({ ...task, status: "completed" });
+
+			await act(async () => {
+				renderPanel(task, { dispatch, navigate });
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.showConfirm).toHaveBeenCalled();
+			});
+			await waitFor(() => {
+				expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
+					taskId: "t1",
+					projectId: "p1",
+					newStatus: "completed",
+				});
+			});
+		});
+
 		it("sets movedAt when auto-completing after merge", async () => {
 			const dispatch = vi.fn();
 			const navigate = vi.fn();

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -123,18 +123,18 @@ export function useTaskBranchStatus({
 						!mergeDialogShownRef.current
 					) {
 						mergeDialogShownRef.current = true;
-						const shouldComplete = await api.request.showConfirm({
-							title: t("app.branchMergedTitle"),
-							message: t("app.branchMergedMessage", {
-								taskTitle: task.customTitle || task.title,
-								branchName: task.branchName || "",
-							}),
-						});
-						if (shouldComplete) {
-							completeTask("review-by-user");
+							const shouldComplete = await api.request.showConfirm({
+								title: t("app.branchMergedTitle"),
+								message: t("app.branchMergedMessage", {
+									taskTitle: task.customTitle || task.title,
+									branchName: task.branchName || "",
+								}),
+							});
+							if (shouldComplete) {
+								completeTask(task.status);
+							}
 						}
 					}
-				}
 			} catch {
 				// Polling retries on the next tick.
 			}

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch } from "react";
-import type { BranchStatus, Project, Task } from "../../../shared/types";
+import {
+	type BranchStatus,
+	type Project,
+	type Task,
+	MERGE_COMPLETE_ELIGIBLE_STATUSES,
+} from "../../../shared/types";
 import type { AppAction, Route } from "../../state";
 import { api } from "../../rpc";
 import { useT } from "../../i18n";
@@ -114,7 +119,7 @@ export function useTaskBranchStatus({
 
 					if (
 						status.mergedByContent &&
-						task.status === "review-by-user" &&
+						MERGE_COMPLETE_ELIGIBLE_STATUSES.includes(task.status) &&
 						!mergeDialogShownRef.current
 					) {
 						mergeDialogShownRef.current = true;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,7 +33,6 @@ export const ACTIVE_STATUSES: TaskStatus[] = [
 ];
 
 export const MERGE_COMPLETE_ELIGIBLE_STATUSES: TaskStatus[] = [
-	"review-by-ai",
 	"review-by-user",
 	"review-by-colleague",
 ];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,6 +33,7 @@ export const ACTIVE_STATUSES: TaskStatus[] = [
 ];
 
 export const MERGE_COMPLETE_ELIGIBLE_STATUSES: TaskStatus[] = [
+	"user-questions",
 	"review-by-user",
 	"review-by-colleague",
 ];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,12 @@ export const ACTIVE_STATUSES: TaskStatus[] = [
 	"review-by-ai",
 ];
 
+export const MERGE_COMPLETE_ELIGIBLE_STATUSES: TaskStatus[] = [
+	"review-by-ai",
+	"review-by-user",
+	"review-by-colleague",
+];
+
 export const ALL_STATUSES: TaskStatus[] = [
 	"todo",
 	"in-progress",


### PR DESCRIPTION
## Summary
- restore merge-completion prompts for merged tasks in Has Questions, Your Review, and PR Review
- keep AI Review excluded for now because its long-running review agent can still be active after the branch becomes stale
- add regression coverage for UI prompt gating and the background merge poller

## Repro
- task seq 573 / branch `feat/dev3-overview-and-test-steps` from merged PR #498 had no diff against `origin/main`, but no completion prompt appeared because `user-questions` was excluded from the eligible statuses

## Testing
- bun run lint
- bun run test