### PR TITLE
Add global task/project shortcuts

### DIFF
--- a/change-logs/2026/04/24/feature-global-new-task-shortcut.md
+++ b/change-logs/2026/04/24/feature-global-new-task-shortcut.md
@@ -1,1 +1,1 @@
-Command+N now opens the New Task dialog from any project screen, including full task views, and File now includes a matching New Task item. Add Project in the File menu now uses Command+P, and the menu wiring is covered by tests.
+Command+N now opens the New Task dialog from any project screen, including full task views, and File now includes a matching New Task item. Command+P now returns to the projects dashboard and opens Add Project, with tests covering both the keyboard shortcut and the shared menu event flow.

--- a/change-logs/2026/04/24/feature-global-new-task-shortcut.md
+++ b/change-logs/2026/04/24/feature-global-new-task-shortcut.md
@@ -1,0 +1,1 @@
+Command+N now opens the New Task dialog from any project screen, including full task views, and File now includes a matching New Task item. Add Project in the File menu now uses Command+P, and the menu wiring is covered by tests.

--- a/src/bun/__tests__/application-menu.test.ts
+++ b/src/bun/__tests__/application-menu.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildApplicationMenu, MENU_ACTIONS } from "../application-menu";
+
+function findLabeledMenu(menu: ReturnType<typeof buildApplicationMenu>, label: string) {
+	return menu.find((item) => "label" in item && item.label === label) as { submenu?: Array<{ action?: string; label?: string; accelerator?: string }> } | undefined;
+}
+
+describe("buildApplicationMenu", () => {
+	it("adds File > New Task with Command+N", () => {
+		const menu = buildApplicationMenu();
+		const fileMenu = findLabeledMenu(menu, "File");
+		const newTaskItem = fileMenu?.submenu?.find((item: any) => item.action === MENU_ACTIONS.openNewTask);
+
+		expect(newTaskItem).toMatchObject({
+			label: "New Task",
+			action: MENU_ACTIONS.openNewTask,
+			accelerator: "n",
+		});
+	});
+
+	it("moves Add Project to Command+P", () => {
+		const menu = buildApplicationMenu();
+		const fileMenu = findLabeledMenu(menu, "File");
+		const addProjectItem = fileMenu?.submenu?.find((item: any) => item.action === MENU_ACTIONS.openAddProject);
+
+		expect(addProjectItem).toMatchObject({
+			label: "Add Project...",
+			action: MENU_ACTIONS.openAddProject,
+			accelerator: "p",
+		});
+	});
+});

--- a/src/bun/application-menu.ts
+++ b/src/bun/application-menu.ts
@@ -1,0 +1,94 @@
+import type { ApplicationMenuItemConfig } from "electrobun/bun";
+
+export const MENU_ACTIONS = {
+	about: "about",
+	checkForUpdates: "check-for-updates",
+	openSettings: "open-settings",
+	openNewTask: "open-new-task",
+	openAddProject: "open-add-project",
+	hardRefresh: "hard-refresh",
+	toggleDevtools: "toggle-devtools",
+	openLogsDirectory: "open-logs-directory",
+	terminalSoftReset: "terminal-soft-reset",
+	terminalHardReset: "terminal-hard-reset",
+	gaugeDemo: "gauge-demo",
+	viewportLab: "viewport-lab",
+	zoomIn: "zoom-in",
+	zoomOut: "zoom-out",
+	zoomReset: "zoom-reset",
+	showRemoteQr: "show-remote-qr",
+} as const;
+
+export function buildApplicationMenu(): ApplicationMenuItemConfig[] {
+	return [
+		{
+			label: "dev-3.0",
+			submenu: [
+				{ label: "About dev-3.0", action: MENU_ACTIONS.about },
+				{ label: "Check for Updates...", action: MENU_ACTIONS.checkForUpdates },
+				{ type: "separator" },
+				{ label: "Settings...", action: MENU_ACTIONS.openSettings, accelerator: "," },
+				{ type: "separator" },
+				{ role: "hide" },
+				{ role: "hideOthers" },
+				{ role: "showAll" },
+				{ type: "separator" },
+				{ role: "quit" },
+			],
+		},
+		{
+			label: "File",
+			submenu: [
+				{ label: "New Task", action: MENU_ACTIONS.openNewTask, accelerator: "n" },
+				{ label: "Add Project...", action: MENU_ACTIONS.openAddProject, accelerator: "p" },
+			],
+		},
+		{
+			label: "Edit",
+			submenu: [
+				{ role: "undo" },
+				{ role: "redo" },
+				{ type: "separator" },
+				{ role: "cut" },
+				{ role: "copy" },
+				{ role: "paste" },
+				{ role: "pasteAndMatchStyle" },
+				{ role: "delete" },
+				{ role: "selectAll" },
+			],
+		},
+		{
+			label: "View",
+			submenu: [
+				{ label: "Hard Refresh", action: MENU_ACTIONS.hardRefresh, accelerator: "r" },
+				{ label: "Toggle Developer Tools", action: MENU_ACTIONS.toggleDevtools },
+				{ label: "Open Logs Directory", action: MENU_ACTIONS.openLogsDirectory },
+				{ type: "separator" },
+				{ label: "Soft Reset Terminal", action: MENU_ACTIONS.terminalSoftReset },
+				{ label: "Hard Reset Terminal", action: MENU_ACTIONS.terminalHardReset },
+				{ type: "separator" },
+				{ label: "Gauge Demo", action: MENU_ACTIONS.gaugeDemo },
+				{ label: "Viewport Lab", action: MENU_ACTIONS.viewportLab },
+				{ type: "separator" },
+				{ label: "Zoom In", action: MENU_ACTIONS.zoomIn, accelerator: "=" },
+				{ label: "Zoom Out", action: MENU_ACTIONS.zoomOut, accelerator: "-" },
+				{ label: "Reset Zoom", action: MENU_ACTIONS.zoomReset, accelerator: "0" },
+				{ type: "separator" },
+				{ label: "Remote Access QR Code", action: MENU_ACTIONS.showRemoteQr },
+				{ type: "separator" },
+				{ role: "toggleFullScreen" },
+			],
+		},
+		{
+			label: "Window",
+			submenu: [
+				{ role: "minimize" },
+				{ role: "zoom" },
+				{ type: "separator" },
+				{ role: "bringAllToFront" },
+				{ role: "cycleThroughWindows" },
+				{ role: "close" },
+			],
+		},
+	];
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -19,6 +19,7 @@ import { startRemoteAccessServer, pushToBrowserClients, generateQrDataUrl, getAc
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
 import { makeTitle } from "./app-utils";
+import { buildApplicationMenu, MENU_ACTIONS } from "./application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import electrobunConfig from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
@@ -244,76 +245,7 @@ log.info("RPC handlers registered");
 
 // --- Application Menu ---
 
-ApplicationMenu.setApplicationMenu([
-	{
-		label: "dev-3.0",
-		submenu: [
-			{ label: "About dev-3.0", action: "about" },
-			{ label: "Check for Updates...", action: "check-for-updates" },
-			{ type: "separator" },
-			{ label: "Settings...", action: "open-settings", accelerator: "," },
-			{ type: "separator" },
-			{ role: "hide" },
-			{ role: "hideOthers" },
-			{ role: "showAll" },
-			{ type: "separator" },
-			{ role: "quit" },
-		],
-	},
-	{
-		label: "File",
-		submenu: [
-			{ label: "Add Project...", action: "open-add-project" },
-		],
-	},
-	{
-		label: "Edit",
-		submenu: [
-			{ role: "undo" },
-			{ role: "redo" },
-			{ type: "separator" },
-			{ role: "cut" },
-			{ role: "copy" },
-			{ role: "paste" },
-			{ role: "pasteAndMatchStyle" },
-			{ role: "delete" },
-			{ role: "selectAll" },
-		],
-	},
-	{
-		label: "View",
-		submenu: [
-			{ label: "Hard Refresh", action: "hard-refresh", accelerator: "r" },
-			{ label: "Toggle Developer Tools", action: "toggle-devtools" },
-			{ label: "Open Logs Directory", action: "open-logs-directory" },
-			{ type: "separator" },
-			{ label: "Soft Reset Terminal", action: "terminal-soft-reset" },
-			{ label: "Hard Reset Terminal", action: "terminal-hard-reset" },
-			{ type: "separator" },
-			{ label: "Gauge Demo", action: "gauge-demo" },
-			{ label: "Viewport Lab", action: "viewport-lab" },
-			{ type: "separator" },
-			{ label: "Zoom In", action: "zoom-in", accelerator: "=" },
-			{ label: "Zoom Out", action: "zoom-out", accelerator: "-" },
-			{ label: "Reset Zoom", action: "zoom-reset", accelerator: "0" },
-			{ type: "separator" },
-			{ label: "Remote Access QR Code", action: "show-remote-qr" },
-			{ type: "separator" },
-			{ role: "toggleFullScreen" },
-		],
-	},
-	{
-		label: "Window",
-		submenu: [
-			{ role: "minimize" },
-			{ role: "zoom" },
-			{ type: "separator" },
-			{ role: "bringAllToFront" },
-			{ role: "cycleThroughWindows" },
-			{ role: "close" },
-		],
-	},
-]);
+ApplicationMenu.setApplicationMenu(buildApplicationMenu());
 
 // --- Main Window ---
 
@@ -528,10 +460,10 @@ const sendUpdateProgress = (status: string, progress?: number) => {
 // --- Menu Event Handlers ---
 
 Electrobun.events.on("application-menu-clicked", async (e) => {
-	if (e.data.action === "hard-refresh") {
+	if (e.data.action === MENU_ACTIONS.hardRefresh) {
 		log.info("Hard refresh — navigating to home page");
 		mainWindow.webview.loadURL(url);
-	} else if (e.data.action === "about") {
+	} else if (e.data.action === MENU_ACTIONS.about) {
 		Utils.showMessageBox({
 			type: "info",
 			title: "About",
@@ -539,15 +471,17 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 			detail: "Terminal-centric project manager\nBuilt with Electrobun, React, and Bun.",
 			buttons: ["OK"],
 		});
-	} else if (e.data.action === "open-settings") {
+	} else if (e.data.action === MENU_ACTIONS.openSettings) {
 		mainWindow.webview.rpc?.send("navigateToSettings", {});
-	} else if (e.data.action === "open-add-project") {
+	} else if (e.data.action === MENU_ACTIONS.openNewTask) {
+		mainWindow.webview.rpc?.send("openCreateTaskModal", {});
+	} else if (e.data.action === MENU_ACTIONS.openAddProject) {
 		mainWindow.webview.rpc?.send("openAddProjectModal", {});
-	} else if (e.data.action === "gauge-demo") {
+	} else if (e.data.action === MENU_ACTIONS.gaugeDemo) {
 		mainWindow.webview.rpc?.send("navigateToGaugeDemo", {});
-	} else if (e.data.action === "viewport-lab") {
+	} else if (e.data.action === MENU_ACTIONS.viewportLab) {
 		mainWindow.webview.rpc?.send("navigateToViewportLab", {});
-	} else if (e.data.action === "check-for-updates") {
+	} else if (e.data.action === MENU_ACTIONS.checkForUpdates) {
 		try {
 			const settings = await loadSettings();
 			sendUpdateProgress("checking");

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -11,6 +11,7 @@ import GlobalHeader from "./components/GlobalHeader";
 import GlobalSettings from "./components/GlobalSettings";
 import Dashboard from "./components/Dashboard";
 import AddProjectModal from "./components/AddProjectModal";
+import CreateTaskModal from "./components/CreateTaskModal";
 import ProjectView from "./components/ProjectView";
 import TaskWorkspaceView from "./components/TaskWorkspaceView";
 import ProjectTerminal from "./components/ProjectTerminal";
@@ -55,6 +56,7 @@ function App() {
 	// GitHub CLI availability warning
 	const [ghWarning, setGhWarning] = useState<{ notInstalled: boolean } | null>(null);
 	const [showAddProjectModal, setShowAddProjectModal] = useState(false);
+	const [createTaskProjectId, setCreateTaskProjectId] = useState<string | null>(null);
 
 	// Auth failure for browser remote access (expired/invalid QR token)
 	const [authFailed, setAuthFailed] = useState(false);
@@ -116,7 +118,27 @@ function App() {
 		[dispatch],
 	);
 
-	// Cmd/Ctrl+Q, Cmd/Ctrl+,, Cmd/Ctrl+=/- (zoom) — capture phase so terminal can't swallow them
+	const getProjectIdForRoute = useCallback((route: Route): string | null => {
+		switch (route.screen) {
+			case "project":
+			case "project-terminal":
+			case "task":
+			case "project-settings":
+				return route.projectId;
+			default:
+				return null;
+		}
+	}, []);
+
+	const openCreateTaskModal = useCallback(() => {
+		const projectId = getProjectIdForRoute(state.route);
+		if (!projectId) return false;
+		if (document.querySelector('[data-create-task-modal="true"]')) return false;
+		setCreateTaskProjectId((current) => current ?? projectId);
+		return true;
+	}, [getProjectIdForRoute, state.route]);
+
+	// Cmd/Ctrl+Q, Cmd/Ctrl+N, Cmd/Ctrl+,, Cmd/Ctrl+=/- (zoom) — capture phase so terminal can't swallow them
 	useGlobalShortcut(
 		(e) => {
 			if ((e.metaKey || e.ctrlKey) && e.key === "q") {
@@ -131,6 +153,11 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				api.request.hideApp().catch(() => {});
+			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "n") {
+				if (createTaskProjectId || showAddProjectModal || showQuitDialog) return;
+				if (!openCreateTaskModal()) return;
+				e.preventDefault();
+				e.stopPropagation();
 			} else if ((e.metaKey || e.ctrlKey) && e.key === ",") {
 				e.preventDefault();
 				e.stopPropagation();
@@ -170,7 +197,7 @@ function App() {
 				}
 			}
 		},
-		[navigate, state.projects, state.route],
+		[createTaskProjectId, navigate, openCreateTaskModal, showAddProjectModal, showQuitDialog, state.projects, state.route],
 		{ capture: true },
 	);
 
@@ -412,6 +439,14 @@ function App() {
 	}, [navigate]);
 
 	useEffect(() => {
+		function onOpenCreateTaskModal() {
+			openCreateTaskModal();
+		}
+		window.addEventListener("rpc:openCreateTaskModal", onOpenCreateTaskModal);
+		return () => window.removeEventListener("rpc:openCreateTaskModal", onOpenCreateTaskModal);
+	}, [openCreateTaskModal]);
+
+	useEffect(() => {
 		function onOpenAddProjectModal() {
 			setShowAddProjectModal(true);
 		}
@@ -560,6 +595,9 @@ function App() {
 	}
 
 	const { route } = state;
+	const createTaskProject = createTaskProjectId
+		? state.projects.find((project) => project.id === createTaskProjectId) ?? null
+		: null;
 
 	return (
 		<div className="h-full w-full flex flex-col">
@@ -582,6 +620,13 @@ function App() {
 				<AddProjectModal
 					dispatch={dispatch}
 					onClose={() => setShowAddProjectModal(false)}
+				/>
+			)}
+			{createTaskProject && (
+				<CreateTaskModal
+					project={createTaskProject}
+					dispatch={dispatch}
+					onClose={() => setCreateTaskProjectId(null)}
 				/>
 			)}
 			{pendingNavigation && (

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -56,6 +56,7 @@ function App() {
 	// GitHub CLI availability warning
 	const [ghWarning, setGhWarning] = useState<{ notInstalled: boolean } | null>(null);
 	const [showAddProjectModal, setShowAddProjectModal] = useState(false);
+	const [openAddProjectOnDashboard, setOpenAddProjectOnDashboard] = useState(false);
 	const [createTaskProjectId, setCreateTaskProjectId] = useState<string | null>(null);
 
 	// Auth failure for browser remote access (expired/invalid QR token)
@@ -138,6 +139,16 @@ function App() {
 		return true;
 	}, [getProjectIdForRoute, state.route]);
 
+	const openAddProject = useCallback(() => {
+		if (state.route.screen === "dashboard") {
+			setOpenAddProjectOnDashboard(false);
+			setShowAddProjectModal(true);
+			return;
+		}
+		setOpenAddProjectOnDashboard(true);
+		navigate({ screen: "dashboard" });
+	}, [navigate, state.route.screen]);
+
 	// Cmd/Ctrl+Q, Cmd/Ctrl+N, Cmd/Ctrl+,, Cmd/Ctrl+=/- (zoom) — capture phase so terminal can't swallow them
 	useGlobalShortcut(
 		(e) => {
@@ -158,6 +169,11 @@ function App() {
 				if (!openCreateTaskModal()) return;
 				e.preventDefault();
 				e.stopPropagation();
+			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
+				e.preventDefault();
+				e.stopPropagation();
+				if (showQuitDialog) return;
+				openAddProject();
 			} else if ((e.metaKey || e.ctrlKey) && e.key === ",") {
 				e.preventDefault();
 				e.stopPropagation();
@@ -197,7 +213,7 @@ function App() {
 				}
 			}
 		},
-		[createTaskProjectId, navigate, openCreateTaskModal, showAddProjectModal, showQuitDialog, state.projects, state.route],
+		[createTaskProjectId, navigate, openAddProject, openCreateTaskModal, showAddProjectModal, showQuitDialog, state.projects, state.route],
 		{ capture: true },
 	);
 
@@ -431,6 +447,18 @@ function App() {
 
 	// Listen for Cmd+, (Settings menu item)
 	useEffect(() => {
+		if (!openAddProjectOnDashboard) return;
+		if (state.route.screen === "dashboard") {
+			setShowAddProjectModal(true);
+			setOpenAddProjectOnDashboard(false);
+			return;
+		}
+		if (pendingNavigation === null) {
+			setOpenAddProjectOnDashboard(false);
+		}
+	}, [openAddProjectOnDashboard, pendingNavigation, state.route.screen]);
+
+	useEffect(() => {
 		function onNavigateToSettings() {
 			navigate({ screen: "settings" });
 		}
@@ -448,11 +476,11 @@ function App() {
 
 	useEffect(() => {
 		function onOpenAddProjectModal() {
-			setShowAddProjectModal(true);
+			openAddProject();
 		}
 		window.addEventListener("rpc:openAddProjectModal", onOpenAddProjectModal);
 		return () => window.removeEventListener("rpc:openAddProjectModal", onOpenAddProjectModal);
-	}, []);
+	}, [openAddProject]);
 
 	// Listen for View > Gauge Demo menu item
 	useEffect(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -191,6 +191,43 @@ describe("App keyboard shortcuts", () => {
 			await act(async () => {
 				window.dispatchEvent(new CustomEvent("rpc:openAddProjectModal"));
 			});
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+			expect(await screen.findByTestId("add-project-modal")).toBeInTheDocument();
+		});
+
+		it("Cmd+P returns to dashboard and opens Add Project from the full task screen", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}p{/Meta}");
+
+			expect(await screen.findByTestId("dashboard-screen")).toBeInTheDocument();
+			expect(await screen.findByTestId("add-project-modal")).toBeInTheDocument();
+		});
+
+		it("rpc:openAddProjectModal returns to dashboard and opens Add Project from the full task screen", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:openAddProjectModal"));
+			});
+
+			expect(await screen.findByTestId("dashboard-screen")).toBeInTheDocument();
 			expect(await screen.findByTestId("add-project-modal")).toBeInTheDocument();
 		});
 

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -9,6 +9,7 @@ vi.mock("../rpc", () => ({
 			checkSystemRequirements: vi.fn().mockResolvedValue([]),
 			checkGhAvailable: vi.fn().mockResolvedValue({ available: true, notInstalled: false }),
 			getProjects: vi.fn().mockResolvedValue([]),
+			getUpdateRoute: vi.fn().mockResolvedValue({ route: null }),
 			quitApp: vi.fn().mockResolvedValue(undefined),
 			hideApp: vi.fn().mockResolvedValue(undefined),
 			listTmuxSessions: vi.fn().mockResolvedValue([]),
@@ -60,6 +61,9 @@ vi.mock("../components/Changelog", () => ({
 vi.mock("../components/ProjectView", () => ({
 	default: () => <div data-testid="project-screen" />,
 }));
+vi.mock("../components/TaskWorkspaceView", () => ({
+	default: () => <div data-testid="task-screen" />,
+}));
 vi.mock("../components/TaskTerminal", () => ({
 	default: () => <div data-testid="task-screen" />,
 }));
@@ -90,7 +94,14 @@ async function renderApp() {
 		</I18nProvider>,
 	);
 	await waitFor(() =>
-		expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument(),
+		expect(
+			screen.queryByTestId("dashboard-screen")
+			|| screen.queryByTestId("project-screen")
+			|| screen.queryByTestId("task-screen")
+			|| screen.queryByTestId("settings-screen")
+			|| screen.queryByTestId("project-settings-screen")
+			|| screen.queryByTestId("project-terminal-screen"),
+		).toBeInTheDocument(),
 	);
 }
 
@@ -99,6 +110,7 @@ describe("App keyboard shortcuts", () => {
 		vi.clearAllMocks();
 		vi.mocked(api.request.checkSystemRequirements).mockResolvedValue([]);
 		vi.mocked(api.request.getProjects).mockResolvedValue([]);
+		vi.mocked(api.request.getUpdateRoute).mockResolvedValue({ route: null });
 		vi.mocked(api.request.listTmuxSessions).mockResolvedValue([]);
 	});
 
@@ -197,6 +209,42 @@ describe("App keyboard shortcuts", () => {
 				window.dispatchEvent(new CustomEvent("rpc:taskSound", { detail: { status: "completed" } }));
 			});
 			expect(playTaskSound).toHaveBeenCalledWith("completed");
+		});
+	});
+
+	describe("New Task modal", () => {
+		it("opens from the full task screen with Cmd+N", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}n{/Meta}");
+
+			expect(await screen.findByText("New Task")).toBeInTheDocument();
+		});
+
+		it("opens from the full task screen when rpc:openCreateTaskModal fires", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:openCreateTaskModal"));
+			});
+
+			expect(await screen.findByText("New Task")).toBeInTheDocument();
 		});
 	});
 

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -265,6 +265,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun }: CreateT
 
 	return (
 		<div
+			data-create-task-modal="true"
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 			onClick={handleRequestClose}
 		>

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -123,20 +123,6 @@ function KanbanBoard({
 		});
 	}, []);
 
-	// Cmd+N — open create task modal (capture phase to intercept before terminal)
-	const handleCmdN = useCallback((e: KeyboardEvent) => {
-		if (!((e.metaKey || e.ctrlKey) && e.key === "n")) return;
-		if (showCreateModal || launchModal !== null) return;
-		e.preventDefault();
-		e.stopPropagation();
-		setShowCreateModal(true);
-	}, [showCreateModal, launchModal]);
-
-	useEffect(() => {
-		window.addEventListener("keydown", handleCmdN, { capture: true });
-		return () => window.removeEventListener("keydown", handleCmdN, { capture: true });
-	}, [handleCmdN]);
-
 	function recordMove(taskId: string) {
 		moveCounterRef.current += 1;
 		setMoveOrderMap((prev) => new Map(prev).set(taskId, moveCounterRef.current));

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -1,5 +1,4 @@
 import { act, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import KanbanBoard from "../KanbanBoard";
 import { I18nProvider } from "../../i18n";
 import type { CustomColumn, Project } from "../../../shared/types";
@@ -36,25 +35,6 @@ const project: Project = {
 	defaultBaseBranch: "main",
 	createdAt: "2025-01-01T00:00:00Z",
 };
-
-async function renderBoard() {
-	let result: ReturnType<typeof render>;
-	await act(async () => {
-		result = render(
-			<I18nProvider>
-				<KanbanBoard
-					project={project}
-					tasks={[]}
-					dispatch={vi.fn()}
-					navigate={vi.fn()}
-					bellCounts={new Map()}
-					taskPorts={new Map()}
-				/>
-			</I18nProvider>,
-		);
-	});
-	return result!;
-}
 
 const customColA: CustomColumn = { id: "col-a", name: "Alpha", color: "#ff0000", llmInstruction: "" };
 const customColB: CustomColumn = { id: "col-b", name: "Beta", color: "#00ff00", llmInstruction: "" };
@@ -332,42 +312,5 @@ describe("collapsible columns", () => {
 			// Collapsed columns should not contain TipCard content
 			expect(col.querySelector("[class*='tip']")).toBeNull();
 		}
-	});
-});
-
-describe("KanbanBoard keyboard shortcuts", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
-	it("Cmd+N opens the create task modal", async () => {
-		await renderBoard();
-		expect(screen.queryByText("New Task")).not.toBeInTheDocument();
-		await userEvent.keyboard("{Meta>}n{/Meta}");
-		expect(screen.getByText("New Task")).toBeInTheDocument();
-	});
-
-	it("Ctrl+N opens the create task modal", async () => {
-		await renderBoard();
-		expect(screen.queryByText("New Task")).not.toBeInTheDocument();
-		await userEvent.keyboard("{Control>}n{/Control}");
-		expect(screen.getByText("New Task")).toBeInTheDocument();
-	});
-
-	it("Cmd+N does nothing when the modal is already open", async () => {
-		await renderBoard();
-		await userEvent.keyboard("{Meta>}n{/Meta}");
-		expect(screen.getByText("New Task")).toBeInTheDocument();
-		// Second press should not open a second modal
-		await userEvent.keyboard("{Meta>}n{/Meta}");
-		expect(screen.getAllByText("New Task")).toHaveLength(1);
-	});
-
-	it("Escape closes the create task modal after Cmd+N", async () => {
-		await renderBoard();
-		await userEvent.keyboard("{Meta>}n{/Meta}");
-		expect(screen.getByText("New Task")).toBeInTheDocument();
-		await userEvent.keyboard("{Escape}");
-		expect(screen.queryByText("New Task")).not.toBeInTheDocument();
 	});
 });

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -188,6 +188,8 @@ const tips = {
 	"tip.activityProjectActions.body": "Use the Activity row buttons to open project settings, the repo folder, or the project terminal directly.",
 	"tip.addProjectMenu.title": "Add projects from the menu",
 	"tip.addProjectMenu.body": "Use File > Add Project... to open the import dialog from anywhere in the app.",
+	"tip.newTaskMenu.title": "Create tasks from File",
+	"tip.newTaskMenu.body": "From any project screen, use File > New Task or press \u2318N to open the task form.",
 	"tip.openLogsMenu.title": "Open logs quickly",
 	"tip.openLogsMenu.body": "Use View > Open Logs Directory to jump straight to the app log folder in Finder.",
 	"tip.portAllocation.title": "Auto-allocate ports",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -188,6 +188,8 @@ const tips = {
 	"tip.activityProjectActions.body": "Usa los botones de la fila Activity para abrir ajustes del proyecto, la carpeta del repo o el terminal del proyecto.",
 	"tip.addProjectMenu.title": "Agrega proyectos desde el menú",
 	"tip.addProjectMenu.body": "Usa File > Add Project... para abrir el diálogo de importación desde cualquier parte de la app.",
+	"tip.newTaskMenu.title": "Crea tareas desde File",
+	"tip.newTaskMenu.body": "Desde cualquier pantalla del proyecto, usa File > New Task o pulsa \u2318N para abrir el formulario.",
 	"tip.openLogsMenu.title": "Abre logs rápido",
 	"tip.openLogsMenu.body": "Usa View > Open Logs Directory para abrir al instante la carpeta de logs de la app en Finder.",
 	"tip.portAllocation.title": "Asignar puertos automáticamente",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -188,6 +188,8 @@ const tips = {
 	"tip.activityProjectActions.body": "Кнопки в строке Activity сразу открывают настройки проекта, папку репо или терминал проекта.",
 	"tip.addProjectMenu.title": "Добавление проекта через меню",
 	"tip.addProjectMenu.body": "Используй File > Add Project..., чтобы открыть импорт проекта из любого экрана приложения.",
+	"tip.newTaskMenu.title": "Создавай задачи из меню",
+	"tip.newTaskMenu.body": "На любом экране проекта жми File > New Task или \u2318N, чтобы открыть форму задачи.",
 	"tip.openLogsMenu.title": "Быстрый доступ к логам",
 	"tip.openLogsMenu.body": "Используй View > Open Logs Directory, чтобы сразу открыть папку с логами приложения в Finder.",
 	"tip.portAllocation.title": "Авто-выделение портов",

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -17,6 +17,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	resourceUsageUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:resourceUsageUpdated", { detail: payload })),
 	updateDownloadProgress: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateDownloadProgress", { detail: payload })),
 	columnAgentFailed: (payload) => window.dispatchEvent(new CustomEvent("rpc:columnAgentFailed", { detail: payload })),
+	openCreateTaskModal: () => window.dispatchEvent(new CustomEvent("rpc:openCreateTaskModal")),
 	navigateToSettings: () => window.dispatchEvent(new CustomEvent("rpc:navigateToSettings")),
 	navigateToGaugeDemo: () => window.dispatchEvent(new CustomEvent("rpc:navigateToGaugeDemo")),
 	navigateToViewportLab: () => window.dispatchEvent(new CustomEvent("rpc:navigateToViewportLab")),

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -585,6 +585,12 @@ const ALL_TIPS: Tip[] = [
 		icon: "\u{F0415}", // nf-md-plus_box
 	},
 	{
+		id: "new-task-menu",
+		titleKey: "tip.newTaskMenu.title",
+		bodyKey: "tip.newTaskMenu.body",
+		icon: "\u{F0415}", // nf-md-plus_box
+	},
+	{
 		id: "open-logs-menu",
 		titleKey: "tip.openLogsMenu.title",
 		bodyKey: "tip.openLogsMenu.body",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1337,6 +1337,7 @@ export type AppRPCSchema = {
 	webview: RPCSchema<{
 		requests: Record<string, never>;
 		messages: {
+			openCreateTaskModal: {};
 			openAddProjectModal: {};
 			navigateToSettings: {};
 			navigateToGaugeDemo: {};


### PR DESCRIPTION
## Summary
- open New Task from any project screen, including full task views, and add File > New Task with Cmd+N
- make Add Project use Cmd+P and route back to the projects dashboard before opening the modal
- cover both flows with renderer and menu tests

## Testing
- bun run lint
- bun run test