### PR TITLE
feat: global/project scope toggle for Active Tasks sidebar

### DIFF
--- a/change-logs/2026/04/24/feature-sidebar-global-scope-toggle.md
+++ b/change-logs/2026/04/24/feature-sidebar-global-scope-toggle.md
@@ -1,0 +1,1 @@
+Add a slider switch to the Active Tasks sidebar header that toggles between project-only and global scope. In global mode the sidebar lists every active task across all dev-3.0 projects, tags each card with its project name, and clicking a card jumps directly into the task's home project. The preference is persisted in localStorage so it survives app restarts.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect, useMemo, type Dispatch } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, type Dispatch } from "react";
 import type { CodingAgent, PortInfo, Project, Task, TaskStatus } from "../../shared/types";
 import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
 import { useStatusColors } from "../hooks/useStatusColors";
 import { useTerminalPreview } from "../hooks/useTerminalPreview";
+import { api } from "../rpc";
 import type { AppAction, Route } from "../state";
 import { useT } from "../i18n";
 import { getStatusLabel } from "../utils/statusLabel";
@@ -13,9 +14,27 @@ import AgentLauncherBadge from "./AgentLauncherBadge";
 import VariantDots from "./VariantDots";
 import { getTaskAgentMeta } from "../utils/taskAgentMeta";
 
+type SidebarScope = "project" | "global";
+const LS_SIDEBAR_SCOPE = "dev3-sidebar-scope";
+
+function readScope(): SidebarScope {
+	try {
+		const v = localStorage.getItem(LS_SIDEBAR_SCOPE);
+		if (v === "global" || v === "project") return v;
+	} catch { /* ignore */ }
+	return "project";
+}
+
+function writeScope(scope: SidebarScope) {
+	try {
+		localStorage.setItem(LS_SIDEBAR_SCOPE, scope);
+	} catch { /* ignore */ }
+}
+
 interface ActiveTasksSidebarProps {
 	project: Project;
 	tasks: Task[];
+	allProjects?: Project[];
 	activeTaskId?: string;
 	dispatch: Dispatch<AppAction>;
 	navigate: (route: Route) => void;
@@ -38,6 +57,7 @@ const STATUS_ORDER: TaskStatus[] = [
 function ActiveTasksSidebar({
 	project,
 	tasks,
+	allProjects,
 	activeTaskId,
 	navigate,
 	agents,
@@ -50,7 +70,15 @@ function ActiveTasksSidebar({
 	const statusColors = useStatusColors();
 	const preview = useTerminalPreview();
 	const [searchQuery, setSearchQuery] = useState("");
+	const [scope, setScopeState] = useState<SidebarScope>(readScope);
+	const [globalTasks, setGlobalTasks] = useState<Task[]>([]);
+	const [globalLoading, setGlobalLoading] = useState(false);
 	const searchRef = useRef<HTMLInputElement>(null);
+
+	const setScope = useCallback((next: SidebarScope) => {
+		setScopeState(next);
+		writeScope(next);
+	}, []);
 
 	// Ctrl/Cmd+F focuses the search input when sidebar is visible
 	useEffect(() => {
@@ -68,14 +96,80 @@ function ActiveTasksSidebar({
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [disableGlobalFindShortcut]);
 
-	let activeTasks = tasks.filter((task) => ACTIVE_STATUSES.includes(task.status));
+	// Fetch active tasks from all projects when in global scope.
+	useEffect(() => {
+		if (scope !== "global") return;
+		let cancelled = false;
+		setGlobalLoading(true);
+		(async () => {
+			try {
+				const results = await api.request.getAllProjectTasks();
+				if (cancelled) return;
+				const flat: Task[] = [];
+				for (const { tasks: projectTasks } of results) {
+					for (const task of projectTasks) flat.push(task);
+				}
+				setGlobalTasks(flat);
+			} catch (err) {
+				if (!cancelled) {
+					console.error("Failed to load global active tasks:", err);
+				}
+			} finally {
+				if (!cancelled) setGlobalLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [scope]);
+
+	// Keep global tasks live across all projects.
+	useEffect(() => {
+		if (scope !== "global") return;
+		function onTaskUpdated(e: Event) {
+			const { task } = (e as CustomEvent).detail as { task: Task };
+			setGlobalTasks((prev) => {
+				const idx = prev.findIndex((t) => t.id === task.id);
+				const isActive = ACTIVE_STATUSES.includes(task.status);
+				if (isActive) {
+					if (idx >= 0) {
+						const next = prev.slice();
+						next[idx] = task;
+						return next;
+					}
+					return [...prev, task];
+				}
+				if (idx >= 0) {
+					const next = prev.slice();
+					next.splice(idx, 1);
+					return next;
+				}
+				return prev;
+			});
+		}
+		window.addEventListener("rpc:taskUpdated", onTaskUpdated);
+		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
+	}, [scope]);
+
+	const sourceTasks = scope === "global" ? globalTasks : tasks;
+
+	let activeTasks = sourceTasks.filter((task) => ACTIVE_STATUSES.includes(task.status));
 	if (searchQuery.trim()) {
 		activeTasks = activeTasks.filter((task) => matchesSearchQuery(task, searchQuery));
 	}
 
+	const projectById = useMemo(() => {
+		const map = new Map<string, Project>();
+		if (allProjects) {
+			for (const p of allProjects) map.set(p.id, p);
+		}
+		map.set(project.id, project);
+		return map;
+	}, [allProjects, project]);
+
 	const siblingMap = useMemo(() => {
 		const map = new Map<string, Task[]>();
-		for (const task of tasks) {
+		for (const task of sourceTasks) {
 			if (!task.groupId) continue;
 			const existing = map.get(task.groupId);
 			if (existing) {
@@ -85,7 +179,7 @@ function ActiveTasksSidebar({
 			}
 		}
 		return map;
-	}, [tasks]);
+	}, [sourceTasks]);
 
 	// Group by status in display order
 	const grouped = STATUS_ORDER
@@ -97,12 +191,13 @@ function ActiveTasksSidebar({
 
 	function handleTaskClick(task: Task) {
 		preview.close();
-		if (task.id === activeTaskId) {
+		const targetProjectId = task.projectId || project.id;
+		if (task.id === activeTaskId && targetProjectId === project.id) {
 			navigate({ screen: "project", projectId: project.id });
 		} else {
 			navigate({
 				screen: "project",
-				projectId: project.id,
+				projectId: targetProjectId,
 				activeTaskId: task.id,
 			});
 		}
@@ -113,18 +208,58 @@ function ActiveTasksSidebar({
 	return (
 		<div className="h-full flex flex-col bg-base">
 			{/* Header */}
-			<div className="flex items-center justify-between px-3 py-2.5 border-b border-edge flex-shrink-0">
-				<span className="text-xs font-semibold text-fg-2 uppercase tracking-wider">
+			<div className="flex items-center justify-between gap-2 px-3 py-2.5 border-b border-edge flex-shrink-0">
+				<span className="text-xs font-semibold text-fg-2 uppercase tracking-wider truncate">
 					{t("sidebar.activeTasks")}
 				</span>
-				<button
-					onClick={onSwitchToBoard}
-					className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5"
-					title={t("sidebar.switchToBoard")}
-				>
-					{/* Nerd Font: fa-columns (U+F0DB) */}
-					<span className="text-sm font-mono leading-none">{"\uF0DB"}</span>
-				</button>
+				<div className="flex items-center gap-1.5 flex-shrink-0">
+					<button
+						type="button"
+						role="switch"
+						aria-checked={scope === "global"}
+						onClick={() => setScope(scope === "global" ? "project" : "global")}
+						title={t("sidebar.scopeToggleTitle")}
+						className={`relative inline-flex items-center h-4 w-8 rounded-full transition-colors ${
+							scope === "global" ? "bg-accent" : "bg-fg/20"
+						}`}
+						data-testid="sidebar-scope-toggle"
+					>
+						<span
+							aria-hidden
+							className={`absolute top-1/2 -translate-y-1/2 left-0.5 text-[0.5rem] leading-none transition-opacity ${
+								scope === "project" ? "opacity-0" : "text-white/90"
+							}`}
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\u{F0A43}"}
+						</span>
+						<span
+							aria-hidden
+							className={`absolute top-1/2 -translate-y-1/2 right-0.5 text-[0.5rem] leading-none transition-opacity ${
+								scope === "global" ? "opacity-0" : "text-fg-3"
+							}`}
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\u{F024B}"}
+						</span>
+						<span
+							className={`absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white shadow transform transition-transform ${
+								scope === "global" ? "translate-x-[1.125rem]" : "translate-x-0.5"
+							}`}
+						/>
+						<span className="sr-only">
+							{scope === "global" ? t("sidebar.scopeGlobal") : t("sidebar.scopeProject")}
+						</span>
+					</button>
+					<button
+						onClick={onSwitchToBoard}
+						className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5"
+						title={t("sidebar.switchToBoard")}
+					>
+						{/* Nerd Font: fa-columns (U+F0DB) */}
+						<span className="text-sm font-mono leading-none">{"\uF0DB"}</span>
+					</button>
+				</div>
 			</div>
 
 			{/* Search input */}
@@ -168,7 +303,11 @@ function ActiveTasksSidebar({
 
 			{/* Task list */}
 			<div className="flex-1 overflow-y-auto overflow-x-hidden">
-				{grouped.length === 0 ? (
+				{scope === "global" && globalLoading && grouped.length === 0 ? (
+					<div className="px-3 py-6 text-center text-xs text-fg-muted">
+						{t("sidebar.globalLoading")}
+					</div>
+				) : grouped.length === 0 ? (
 					<div className="px-3 py-6 text-center text-xs text-fg-muted">
 						{searchQuery.trim() ? t("sidebar.noSearchResults") : t("sidebar.noActiveTasks")}
 					</div>
@@ -196,16 +335,20 @@ function ActiveTasksSidebar({
 
 							{/* Tasks in this status */}
 							{groupTasks.map((task, idx) => {
-								const isActive = task.id === activeTaskId;
+								const isActive = task.id === activeTaskId && task.projectId === project.id;
 								const bellCount = bellCounts.get(task.id) ?? 0;
 								const displayTitle = getTaskTitle(task);
 								const { agent, configLabel } = getTaskAgentMeta(task, agents);
 								const taskLabelIds = task.labelIds ?? [];
+								const taskProject = projectById.get(task.projectId);
+								const labelsPool = (taskProject?.labels ?? projectLabels) as typeof projectLabels;
 								const assignedLabels = taskLabelIds
-									.map((id) => projectLabels.find((l) => l.id === id))
+									.map((id) => labelsPool.find((l) => l.id === id))
 									.filter(Boolean) as typeof projectLabels;
 								const groupMembers = task.groupId ? siblingMap.get(task.groupId) ?? [task] : [task];
 								const agentSummary = [agent?.name, configLabel].filter(Boolean).join(" · ");
+								const showProjectBadge = scope === "global" && task.projectId !== project.id;
+								const projectBadgeName = taskProject?.name ?? t("sidebar.unknownProject");
 
 								return (
 									<div key={task.id}>
@@ -254,6 +397,24 @@ function ActiveTasksSidebar({
 														/>
 													)}
 												</div>
+
+												{/* Project badge (global scope only) */}
+												{showProjectBadge && (
+													<div
+														className="mb-1 inline-flex items-center gap-1 max-w-full text-[0.5625rem] text-fg-3 bg-fg/5 rounded px-1 py-[1px]"
+														title={projectBadgeName}
+														data-testid={`sidebar-project-badge-${task.id}`}
+													>
+														<span
+															aria-hidden
+															style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+															className="leading-none"
+														>
+															{"\u{F024B}"}
+														</span>
+														<span className="truncate">{projectBadgeName}</span>
+													</div>
+												)}
 
 												{/* Title */}
 												<div className={`text-xs leading-snug break-words ${

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -213,63 +213,65 @@ function ActiveTasksSidebar({
 					{t("sidebar.activeTasks")}
 				</span>
 				<div className="flex items-center gap-1.5 flex-shrink-0 h-5">
-					<button
-						type="button"
-						onClick={() => setScope("project")}
-						title={t("sidebar.scopeProject")}
-						className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
-							scope === "project" ? "text-fg" : "text-fg-muted hover:text-fg-2"
-						}`}
-						data-testid="sidebar-scope-project"
-					>
-						{/* Nerd Font: nf-fa-folder_open (U+F07C) */}
-						<span
-							className="text-sm leading-none"
-							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						>
-							{"\uF07C"}
-						</span>
-					</button>
-					<button
-						type="button"
-						role="switch"
-						aria-checked={scope === "global"}
-						onClick={() => setScope(scope === "global" ? "project" : "global")}
-						title={t("sidebar.scopeToggleTitle")}
-						className={`relative inline-flex items-center h-4 w-8 rounded-full transition-colors ${
-							scope === "global" ? "bg-accent" : "bg-fg/20"
-						}`}
-						data-testid="sidebar-scope-toggle"
-					>
-						<span
-							className={`absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white shadow transform transition-transform ${
-								scope === "global" ? "translate-x-[1.125rem]" : "translate-x-0.5"
+					<div className="inline-flex items-center gap-px" aria-label={t("sidebar.scopeToggleTitle")}>
+						<button
+							type="button"
+							onClick={() => setScope("project")}
+							title={t("sidebar.scopeProject")}
+							className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
+								scope === "project" ? "text-fg" : "text-fg-muted hover:text-fg-2"
 							}`}
-						/>
-						<span className="sr-only">
-							{scope === "global" ? t("sidebar.scopeGlobal") : t("sidebar.scopeProject")}
-						</span>
-					</button>
-					<button
-						type="button"
-						onClick={() => setScope("global")}
-						title={t("sidebar.scopeGlobal")}
-						className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
-							scope === "global" ? "text-fg" : "text-fg-muted hover:text-fg-2"
-						}`}
-						data-testid="sidebar-scope-global"
-					>
-						{/* Nerd Font: nf-cod-globe (U+EB01) */}
-						<span
-							className="text-sm leading-none"
-							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+							data-testid="sidebar-scope-project"
 						>
-							{"\uEB01"}
-						</span>
-					</button>
+							{/* Nerd Font: nf-fa-folder_open (U+F07C) */}
+							<span
+								className="text-sm leading-none"
+								style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+							>
+								{"\uF07C"}
+							</span>
+						</button>
+						<button
+							type="button"
+							role="switch"
+							aria-checked={scope === "global"}
+							onClick={() => setScope(scope === "global" ? "project" : "global")}
+							title={t("sidebar.scopeToggleTitle")}
+							className={`relative inline-flex items-center h-4 w-8 rounded-full transition-colors ${
+								scope === "global" ? "bg-accent" : "bg-fg/20"
+							}`}
+							data-testid="sidebar-scope-toggle"
+						>
+							<span
+								className={`absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white shadow transform transition-transform ${
+									scope === "global" ? "translate-x-[1.125rem]" : "translate-x-0.5"
+								}`}
+							/>
+							<span className="sr-only">
+								{scope === "global" ? t("sidebar.scopeGlobal") : t("sidebar.scopeProject")}
+							</span>
+						</button>
+						<button
+							type="button"
+							onClick={() => setScope("global")}
+							title={t("sidebar.scopeGlobal")}
+							className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
+								scope === "global" ? "text-fg" : "text-fg-muted hover:text-fg-2"
+							}`}
+							data-testid="sidebar-scope-global"
+						>
+							{/* Nerd Font: nf-cod-globe (U+EB01) */}
+							<span
+								className="text-sm leading-none"
+								style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+							>
+								{"\uEB01"}
+							</span>
+						</button>
+					</div>
 					<button
 						onClick={onSwitchToBoard}
-						className="inline-flex items-center justify-center h-5 w-5 text-fg-muted hover:text-accent transition-colors rounded hover:bg-fg/5 ml-0.5"
+						className="inline-flex items-center justify-center h-5 w-5 text-fg-muted hover:text-accent transition-colors rounded hover:bg-fg/5"
 						title={t("sidebar.switchToBoard")}
 					>
 						{/* Nerd Font: fa-columns (U+F0DB) */}

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -215,6 +215,23 @@ function ActiveTasksSidebar({
 				<div className="flex items-center gap-1.5 flex-shrink-0">
 					<button
 						type="button"
+						onClick={() => setScope("project")}
+						title={t("sidebar.scopeProject")}
+						className={`leading-none transition-colors ${
+							scope === "project" ? "text-fg" : "text-fg-muted hover:text-fg-2"
+						}`}
+						data-testid="sidebar-scope-project"
+					>
+						{/* Nerd Font: folder (U+F07BB) */}
+						<span
+							className="text-sm leading-none"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\u{F07BB}"}
+						</span>
+					</button>
+					<button
+						type="button"
 						role="switch"
 						aria-checked={scope === "global"}
 						onClick={() => setScope(scope === "global" ? "project" : "global")}
@@ -225,24 +242,6 @@ function ActiveTasksSidebar({
 						data-testid="sidebar-scope-toggle"
 					>
 						<span
-							aria-hidden
-							className={`absolute top-1/2 -translate-y-1/2 left-0.5 text-[0.5rem] leading-none transition-opacity ${
-								scope === "project" ? "opacity-0" : "text-white/90"
-							}`}
-							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						>
-							{"\u{F0A43}"}
-						</span>
-						<span
-							aria-hidden
-							className={`absolute top-1/2 -translate-y-1/2 right-0.5 text-[0.5rem] leading-none transition-opacity ${
-								scope === "global" ? "opacity-0" : "text-fg-3"
-							}`}
-							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						>
-							{"\u{F024B}"}
-						</span>
-						<span
 							className={`absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white shadow transform transition-transform ${
 								scope === "global" ? "translate-x-[1.125rem]" : "translate-x-0.5"
 							}`}
@@ -252,8 +251,25 @@ function ActiveTasksSidebar({
 						</span>
 					</button>
 					<button
+						type="button"
+						onClick={() => setScope("global")}
+						title={t("sidebar.scopeGlobal")}
+						className={`leading-none transition-colors ${
+							scope === "global" ? "text-fg" : "text-fg-muted hover:text-fg-2"
+						}`}
+						data-testid="sidebar-scope-global"
+					>
+						{/* Nerd Font: earth (U+F024B) */}
+						<span
+							className="text-sm leading-none"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\u{F024B}"}
+						</span>
+					</button>
+					<button
 						onClick={onSwitchToBoard}
-						className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5"
+						className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5 ml-0.5"
 						title={t("sidebar.switchToBoard")}
 					>
 						{/* Nerd Font: fa-columns (U+F0DB) */}

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -212,22 +212,22 @@ function ActiveTasksSidebar({
 				<span className="text-xs font-semibold text-fg-2 uppercase tracking-wider truncate">
 					{t("sidebar.activeTasks")}
 				</span>
-				<div className="flex items-center gap-1.5 flex-shrink-0">
+				<div className="flex items-center gap-1.5 flex-shrink-0 h-5">
 					<button
 						type="button"
 						onClick={() => setScope("project")}
 						title={t("sidebar.scopeProject")}
-						className={`leading-none transition-colors ${
+						className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
 							scope === "project" ? "text-fg" : "text-fg-muted hover:text-fg-2"
 						}`}
 						data-testid="sidebar-scope-project"
 					>
-						{/* Nerd Font: folder (U+F07BB) */}
+						{/* Nerd Font: nf-fa-folder_open (U+F07C) */}
 						<span
 							className="text-sm leading-none"
 							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 						>
-							{"\u{F07BB}"}
+							{"\uF07C"}
 						</span>
 					</button>
 					<button
@@ -254,26 +254,31 @@ function ActiveTasksSidebar({
 						type="button"
 						onClick={() => setScope("global")}
 						title={t("sidebar.scopeGlobal")}
-						className={`leading-none transition-colors ${
+						className={`inline-flex items-center justify-center h-5 w-5 leading-none transition-colors ${
 							scope === "global" ? "text-fg" : "text-fg-muted hover:text-fg-2"
 						}`}
 						data-testid="sidebar-scope-global"
 					>
-						{/* Nerd Font: earth (U+F024B) */}
+						{/* Nerd Font: nf-cod-globe (U+EB01) */}
 						<span
 							className="text-sm leading-none"
 							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 						>
-							{"\u{F024B}"}
+							{"\uEB01"}
 						</span>
 					</button>
 					<button
 						onClick={onSwitchToBoard}
-						className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5 ml-0.5"
+						className="inline-flex items-center justify-center h-5 w-5 text-fg-muted hover:text-accent transition-colors rounded hover:bg-fg/5 ml-0.5"
 						title={t("sidebar.switchToBoard")}
 					>
 						{/* Nerd Font: fa-columns (U+F0DB) */}
-						<span className="text-sm font-mono leading-none">{"\uF0DB"}</span>
+						<span
+							className="text-sm leading-none"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						>
+							{"\uF0DB"}
+						</span>
 					</button>
 				</div>
 			</div>
@@ -426,7 +431,7 @@ function ActiveTasksSidebar({
 															style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 															className="leading-none"
 														>
-															{"\u{F024B}"}
+															{"\uEB01"}
 														</span>
 														<span className="truncate">{projectBadgeName}</span>
 													</div>

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -128,6 +128,7 @@ function ProjectView({
 			<ActiveTasksSidebar
 				project={project}
 				tasks={tasks}
+				allProjects={projects}
 				activeTaskId={activeTaskId}
 				dispatch={dispatch}
 				navigate={navigate}

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "../../i18n";
 import ActiveTasksSidebar from "../ActiveTasksSidebar";
@@ -8,9 +8,14 @@ vi.mock("../../rpc", () => ({
 	api: {
 		request: {
 			getTerminalPreview: vi.fn(),
+			getAllProjectTasks: vi.fn(() => Promise.resolve([])),
 		},
 	},
 }));
+
+beforeEach(() => {
+	localStorage.removeItem("dev3-sidebar-scope");
+});
 
 const claudeAgent: CodingAgent = {
 	id: "builtin-claude",
@@ -98,6 +103,71 @@ describe("ActiveTasksSidebar", () => {
 		expect(screen.getByText("Codex · GPT-5.4 Heavy Bypass")).toBeInTheDocument();
 		expect(screen.getByTestId("variant-indicator-t1")).toBeInTheDocument();
 		expect(screen.getAllByText("#494")).toHaveLength(2);
+	});
+
+	it("toggles between project and global scope and fetches all-project tasks", async () => {
+		const user = userEvent.setup();
+		const { api } = await import("../../rpc");
+		const otherProject: Project = {
+			id: "p2",
+			name: "Other Project",
+			path: "/tmp/other",
+			setupScript: "",
+			devScript: "",
+			cleanupScript: "",
+			defaultBaseBranch: "main",
+			createdAt: "2025-01-01T00:00:00Z",
+		};
+		const otherTask = makeTask({
+			id: "t99",
+			seq: 777,
+			projectId: "p2",
+			title: "Cross-project task",
+			description: "Cross-project task",
+			groupId: null as unknown as string,
+			variantIndex: null,
+		});
+		(api.request.getAllProjectTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{ projectId: "p1", tasks: [makeTask()] },
+			{ projectId: "p2", tasks: [otherTask] },
+		]);
+
+		const navigate = vi.fn();
+		render(
+			<I18nProvider>
+				<ActiveTasksSidebar
+					project={project}
+					tasks={[makeTask()]}
+					allProjects={[project, otherProject]}
+					activeTaskId="t1"
+					dispatch={vi.fn()}
+					navigate={navigate}
+					agents={[claudeAgent]}
+					bellCounts={new Map()}
+					taskPorts={new Map()}
+					onSwitchToBoard={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		// Cross-project task is hidden in project scope.
+		expect(screen.queryByText("Cross-project task")).not.toBeInTheDocument();
+
+		await user.click(screen.getByTestId("sidebar-scope-toggle"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Cross-project task")).toBeInTheDocument();
+		});
+		expect(screen.getByTestId("sidebar-project-badge-t99")).toHaveTextContent("Other Project");
+		expect(localStorage.getItem("dev3-sidebar-scope")).toBe("global");
+
+		// Clicking cross-project task navigates to its home project.
+		await user.click(screen.getByText("Cross-project task"));
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "project",
+			projectId: "p2",
+			activeTaskId: "t99",
+		});
 	});
 
 	it("does not hijack Cmd+F when disabled", async () => {

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -38,6 +38,11 @@ const common = {
 	"sidebar.searchPlaceholder": "Search tasks...",
 	"sidebar.switchToBoard": "Show board",
 	"sidebar.switchToSidebar": "Show sidebar",
+	"sidebar.scopeProject": "Only this project",
+	"sidebar.scopeGlobal": "All projects",
+	"sidebar.scopeToggleTitle": "Toggle task scope (this project / all projects)",
+	"sidebar.globalLoading": "Loading tasks from all projects…",
+	"sidebar.unknownProject": "Unknown project",
 
 	// Open in...
 	"openIn.menuTitle": "Open in...",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -214,6 +214,8 @@ const tips = {
 	"tip.initNewProject.body": "Add Project → New lets you pick an empty folder; dev-3.0 runs git init, writes .dev3/README.md, and makes the first commit for you.",
 	"tip.folderPickerNewFolder.title": "Create folders while picking",
 	"tip.folderPickerNewFolder.body": "In the New-project folder picker, click \"New folder\" above the tree to create a subfolder on the spot without leaving the app.",
+	"tip.sidebarGlobalScope.title": "See tasks from every project",
+	"tip.sidebarGlobalScope.body": "Flip the toggle next to Active Tasks to switch between this project only and every active task in dev-3.0 — click any card to jump straight into its project.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -38,6 +38,11 @@ const common = {
 	"sidebar.searchPlaceholder": "Buscar tareas...",
 	"sidebar.switchToBoard": "Mostrar tablero",
 	"sidebar.switchToSidebar": "Mostrar panel",
+	"sidebar.scopeProject": "Solo este proyecto",
+	"sidebar.scopeGlobal": "Todos los proyectos",
+	"sidebar.scopeToggleTitle": "Alternar alcance (este proyecto / todos los proyectos)",
+	"sidebar.globalLoading": "Cargando tareas de todos los proyectos…",
+	"sidebar.unknownProject": "Proyecto desconocido",
 
 	// Open in...
 	"openIn.menuTitle": "Abrir en...",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -214,6 +214,8 @@ const tips = {
 	"tip.initNewProject.body": "Add Project → Nuevo te deja elegir una carpeta vacía: dev-3.0 ejecuta git init, crea .dev3/README.md y hace el primer commit por ti.",
 	"tip.folderPickerNewFolder.title": "Crea carpetas desde el picker",
 	"tip.folderPickerNewFolder.body": "En el selector para un nuevo proyecto, pulsa \"Nueva carpeta\" sobre el árbol para crear una subcarpeta al vuelo, sin salir de la app.",
+	"tip.sidebarGlobalScope.title": "Tareas de todos los proyectos",
+	"tip.sidebarGlobalScope.body": "El interruptor junto a Active Tasks alterna entre solo este proyecto y todas las tareas activas de dev-3.0 — haz clic en una tarjeta para saltar a su proyecto.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -38,6 +38,11 @@ const common = {
 	"sidebar.searchPlaceholder": "Поиск задач...",
 	"sidebar.switchToBoard": "Показать доску",
 	"sidebar.switchToSidebar": "Показать панель",
+	"sidebar.scopeProject": "Только этот проект",
+	"sidebar.scopeGlobal": "Все проекты",
+	"sidebar.scopeToggleTitle": "Переключить область задач (этот проект / все проекты)",
+	"sidebar.globalLoading": "Загрузка задач изо всех проектов…",
+	"sidebar.unknownProject": "Неизвестный проект",
 
 	// Open in...
 	"openIn.menuTitle": "Открыть в...",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -214,6 +214,8 @@ const tips = {
 	"tip.initNewProject.body": "Add Project → New позволяет выбрать пустую папку: dev-3.0 сам сделает git init, создаст .dev3/README.md и первый коммит.",
 	"tip.folderPickerNewFolder.title": "Создавай папки прямо в пикере",
 	"tip.folderPickerNewFolder.body": "В пикере для нового проекта над деревом есть кнопка \"Новая папка\" — можно создать подпапку на месте, не выходя из приложения.",
+	"tip.sidebarGlobalScope.title": "Все задачи изо всех проектов",
+	"tip.sidebarGlobalScope.body": "Переключатель рядом с Active Tasks меняет область между текущим проектом и всеми активными задачами dev-3.0 — клик по карточке сразу прыгает в её проект.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -670,6 +670,13 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.folderPickerNewFolder.body",
 		icon: "\u{F0770}", // nf-md-folder_open
 	},
+	// Batch 32: sidebar global task scope toggle
+	{
+		id: "sidebar-global-scope",
+		titleKey: "tip.sidebarGlobalScope.title",
+		bodyKey: "tip.sidebarGlobalScope.body",
+		icon: "\u{F024B}", // nf-md-earth
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -675,7 +675,7 @@ const ALL_TIPS: Tip[] = [
 		id: "sidebar-global-scope",
 		titleKey: "tip.sidebarGlobalScope.title",
 		bodyKey: "tip.sidebarGlobalScope.body",
-		icon: "\u{F024B}", // nf-md-earth
+		icon: "\uEB01", // nf-cod-globe
 	},
 ];
 


### PR DESCRIPTION
## Summary

- Adds a slider switch to the **Active Tasks** sidebar header that flips between showing tasks from the current project only and every active task across all dev-3.0 projects.
- Folder and globe icons sit on either side of the slider as quick-jump shortcuts; clicking any card in global mode navigates directly into its home project.
- Each cross-project card gets a small project-name badge; live updates stream via `rpc:taskUpdated`; scope is persisted in `localStorage`.
- Reuses the existing `getAllProjectTasks` RPC — no backend changes.