### PR TITLE
Fix custom column ordering scope

### DIFF
--- a/change-logs/2026/04/24/fix-custom-column-ordering-scope.md
+++ b/change-logs/2026/04/24/fix-custom-column-ordering-scope.md
@@ -1,0 +1,1 @@
+Fixed task ordering so custom columns keep independent columnOrder values even when they share the same built-in status. Reordering or reopening a task now renumbers only the rendered column it belongs to.

--- a/src/bun/__tests__/data-reorder.test.ts
+++ b/src/bun/__tests__/data-reorder.test.ts
@@ -211,6 +211,23 @@ describe("reorderTasksInColumn — disk persistence", () => {
 		const xTask = saved.find((t) => t.id === "X")!;
 		expect(xTask.columnOrder).toBe(5); // unchanged
 	});
+
+	it("does not modify tasks in other rendered columns with the same status", async () => {
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+			makeTask({ id: "B", seq: 2, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-02T00:00:00Z", columnOrder: 1 }),
+			makeTask({ id: "C", seq: 3, status: "in-progress", customColumnId: "col-b", createdAt: "2025-01-03T00:00:00Z", columnOrder: 7 }),
+			makeTask({ id: "D", seq: 4, status: "in-progress", customColumnId: null, createdAt: "2025-01-04T00:00:00Z", columnOrder: 9 }),
+		];
+		seedTasks(tasks);
+
+		const result = await reorderTasksInColumn(testProject, "B", 0);
+
+		expect(result.map((t) => t.id)).toEqual(["B", "A"]);
+		const saved = readSavedTasks();
+		expect(saved.find((t) => t.id === "C")!.columnOrder).toBe(7);
+		expect(saved.find((t) => t.id === "D")!.columnOrder).toBe(9);
+	});
 });
 
 // ============================================================
@@ -584,6 +601,28 @@ describe("updateTask — columnOrder lifecycle", () => {
 			.filter((t) => t.status === "todo")
 			.sort((a, b) => (a.columnOrder ?? 999) - (b.columnOrder ?? 999));
 		expect(todoTasks.map((t) => t.id)).toEqual(["B", "A", "C"]);
+	});
+
+	it("moving into a custom column with dropPosition does not modify other rendered columns with the same status", async () => {
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+			makeTask({ id: "B", seq: 2, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-02T00:00:00Z", columnOrder: 1 }),
+			makeTask({ id: "C", seq: 3, status: "in-progress", customColumnId: "col-b", createdAt: "2025-01-03T00:00:00Z", columnOrder: 7 }),
+			makeTask({ id: "D", seq: 4, status: "in-progress", customColumnId: null, createdAt: "2025-01-04T00:00:00Z", columnOrder: 9 }),
+			makeTask({ id: "E", seq: 5, status: "completed", customColumnId: null, createdAt: "2025-01-05T00:00:00Z", columnOrder: 3 }),
+		];
+		seedTasks(tasks);
+
+		const updated = await updateTask(testProject, "E", { status: "in-progress", customColumnId: "col-a" }, { dropPosition: "top" });
+
+		expect(updated.columnOrder).toBe(0);
+		const saved = readSavedTasks();
+		const colATasks = saved
+			.filter((t) => t.status === "in-progress" && t.customColumnId === "col-a")
+			.sort((a, b) => (a.columnOrder ?? 999) - (b.columnOrder ?? 999));
+		expect(colATasks.map((t) => t.id)).toEqual(["E", "A", "B"]);
+		expect(saved.find((t) => t.id === "C")!.columnOrder).toBe(7);
+		expect(saved.find((t) => t.id === "D")!.columnOrder).toBe(9);
 	});
 
 	it("without dropPosition, columnOrder is cleared (backward compat)", async () => {

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -539,8 +539,9 @@ function applyTaskUpdate(
 		tasks[idx] = { ...tasks[idx], ...updates, movedAt: now, columnOrder: undefined, updatedAt: now };
 
 		if (dropPosition) {
+			const targetCustomColumnId = tasks[idx].customColumnId ?? null;
 			const columnTasks = tasks
-				.filter((t) => t.status === newStatus && t.id !== tasks[idx].id)
+				.filter((t) => t.status === newStatus && (t.customColumnId ?? null) === targetCustomColumnId && t.id !== tasks[idx].id)
 				.sort((a, b) => {
 					if (a.columnOrder !== undefined && b.columnOrder !== undefined) {
 						return a.columnOrder - b.columnOrder;
@@ -565,6 +566,10 @@ function applyTaskUpdate(
 	}
 
 	return tasks[idx];
+}
+
+function isInSameRenderedColumn(task: Task, status: string, customColumnId: string | null | undefined): boolean {
+	return task.status === status && (task.customColumnId ?? null) === (customColumnId ?? null);
 }
 
 // ---- Preferences ----
@@ -620,9 +625,10 @@ export async function reorderTasksInColumn(
 		if (!task) throw new Error(`Task not found: ${taskId}`);
 
 		const columnStatus = task.status;
+		const columnCustomColumnId = task.customColumnId ?? null;
 
 		const columnTasks = tasks
-			.filter((t) => t.status === columnStatus)
+			.filter((t) => isInSameRenderedColumn(t, columnStatus, columnCustomColumnId))
 			.sort((a, b) => {
 				if (a.columnOrder !== undefined && b.columnOrder !== undefined) {
 					return a.columnOrder - b.columnOrder;


### PR DESCRIPTION
## Summary
- Scope backend columnOrder operations by rendered column: built-in status plus customColumnId/null.
- Add regression tests for custom-column drag reorder and dropPosition reopen paths.
- Add changelog entry.

## Tests
- bun run lint
- bun run test