### PR TITLE
Fix diff viewer cache keys

### DIFF
--- a/change-logs/2026/04/24/fix-diff-viewer-refresh-cache-keys.md
+++ b/change-logs/2026/04/24/fix-diff-viewer-refresh-cache-keys.md
@@ -1,0 +1,1 @@
+Refresh the inline diff viewer when the same diff request is opened again, and include full file content in read-state and render cache keys so repeated commits cannot reuse stale UI state for changed files.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -747,9 +747,7 @@ function hashText(value: string): string {
 }
 
 function getFileReadSignature(taskId: string, file: TaskDiffFile): string {
-	const payload = file.hunks?.join("\n")
-		?? `${file.oldContent}\u0000${file.newContent}`;
-	return `${taskId}:${file.oldPath ?? ""}:${file.newPath ?? ""}:${hashText(payload)}`;
+	return `${taskId}:${file.oldPath ?? ""}:${file.newPath ?? ""}:${getDiffFileContentHash(file)}`;
 }
 
 // Hash of the diff payload (hunks + both sides of content). Combined with `file.id`,
@@ -1119,7 +1117,7 @@ function TaskDiffFileSection({
 
 	const DiffView = diffLib.DiffView;
 	const diffMode = viewMode === "split" ? diffLib.DiffModeEnum.Split : diffLib.DiffModeEnum.Unified;
-	const diffRenderKey = `${file.id}:${viewMode}:${resolvedTheme}:${hashText(file.hunks?.join("\n") ?? `${file.oldContent}\u0000${file.newContent}`)}`;
+	const diffRenderKey = `${file.id}:${viewMode}:${resolvedTheme}:${getDiffFileContentHash(file)}`;
 	const copiedFilePath = getCopiedFilePath(worktreePath, file);
 
 	function handleCopyPath() {
@@ -1291,6 +1289,7 @@ function TaskDiffViewer({ task, project, request, onBack }: TaskDiffViewerProps)
 	const [diffLib, setDiffLib] = useState<DiffLibrary | null>(null);
 	const [payload, setPayload] = useState<TaskDiffResponse | null>(null);
 	const [currentRequest, setCurrentRequest] = useState<TaskInlineDiffRequest>(request);
+	const [requestVersion, setRequestVersion] = useState(0);
 	const [collapsedFolders, setCollapsedFolders] = useState<Record<string, boolean>>({});
 	const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>({});
 	const [readFiles, setReadFiles] = useState<Record<string, boolean>>({});
@@ -1315,9 +1314,16 @@ function TaskDiffViewer({ task, project, request, onBack }: TaskDiffViewerProps)
 	);
 	const currentSearchMatch = searchMatches[activeSearchIndex] ?? null;
 
+	const isInitialRequestSyncRef = useRef(true);
+
 	useEffect(() => {
 		setCurrentRequest(request);
-	}, [request.compareLabel, request.compareRef, request.focusFile, request.mode]);
+		if (isInitialRequestSyncRef.current) {
+			isInitialRequestSyncRef.current = false;
+			return;
+		}
+		setRequestVersion((version) => version + 1);
+	}, [request]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -1469,7 +1475,7 @@ function TaskDiffViewer({ task, project, request, onBack }: TaskDiffViewerProps)
 		return () => {
 			cancelled = true;
 		};
-	}, [currentRequest.compareLabel, currentRequest.compareRef, currentRequest.mode, project.id, task.id]);
+	}, [currentRequest.compareLabel, currentRequest.compareRef, currentRequest.mode, project.id, requestVersion, task.id]);
 
 	useEffect(() => {
 		if (!payload) {

--- a/src/mainview/components/__tests__/TaskDiffViewer.stale-cache.test.ts
+++ b/src/mainview/components/__tests__/TaskDiffViewer.stale-cache.test.ts
@@ -94,6 +94,13 @@ describe("getDiffFileContentHash", () => {
 		expect(getDiffFileContentHash(base)).not.toBe(getDiffFileContentHash(mutated));
 	});
 
+	it("detects content-only changes even if hunk strings happen to match", () => {
+		const stableHunk = "@@ -1 +1 @@\n-old value\n+new value\n";
+		const base = fileFor("old value\ncontext one\n", "new value\ncontext one\n", stableHunk);
+		const mutated = fileFor("old value\ncontext two\n", "new value\ncontext two\n", stableHunk);
+		expect(getDiffFileContentHash(base)).not.toBe(getDiffFileContentHash(mutated));
+	});
+
 	it("renders fresh content when uuid includes the content hash", () => {
 		const v4File = fileFor(OLD_CONTENT_COMMON, V4_NEW_CONTENT, V4_HUNK);
 		const v5File = fileFor(OLD_CONTENT_COMMON, V5_NEW_CONTENT, V5_HUNK);

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -751,7 +751,7 @@ describe("TaskDiffViewer", () => {
 		await waitFor(() => {
 			expect(screen.getByRole("checkbox", { name: /mark src\/app\.ts as read/i })).not.toBeChecked();
 		});
-		expect(screen.getAllByText("context two").length).toBeGreaterThan(0);
+		expect((await screen.findAllByText("context two")).length).toBeGreaterThan(0);
 	});
 
 	it("refetches when the same diff request is opened again", async () => {

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -252,6 +252,33 @@ const diffPayload: TaskDiffResponse = {
 	skippedFiles: [],
 };
 
+function singleFilePayload(newContent: string, hunk: string, oldContent = "base\n"): TaskDiffResponse {
+	return {
+		mode: "branch",
+		compareRef: "origin/main",
+		compareLabel: "origin/main",
+		fallbackReason: null,
+		summary: {
+			files: 1,
+			insertions: 1,
+			deletions: 1,
+		},
+		files: [
+			{
+				id: "src/app.ts",
+				status: "modified",
+				displayPath: "src/app.ts",
+				oldPath: "src/app.ts",
+				newPath: "src/app.ts",
+				oldContent,
+				newContent,
+				hunks: [hunk],
+			},
+		],
+		skippedFiles: [],
+	};
+}
+
 describe("TaskDiffViewer", () => {
 	let scrollIntoViewMock: ReturnType<typeof vi.fn>;
 	let lastScrolledText: string | null;
@@ -682,6 +709,88 @@ describe("TaskDiffViewer", () => {
 			expect(screen.getAllByText("src/app.ts")[0]).toHaveClass("line-through");
 			expect(screen.queryAllByTestId("mock-diff")).toHaveLength(1);
 		});
+	});
+
+	it("does not reuse read state when file content changes behind the same hunk", async () => {
+		const user = userEvent.setup();
+		const stableHunk = "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old value\n+new value\n";
+		vi.mocked(api.request.getTaskDiff)
+			.mockResolvedValueOnce(singleFilePayload("new value\ncontext one\n", stableHunk, "old value\ncontext one\n"))
+			.mockResolvedValueOnce(singleFilePayload("new value\ncontext two\n", stableHunk, "old value\ncontext two\n"));
+
+		const view = render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await screen.findAllByText("context one");
+		await user.click(screen.getByRole("checkbox", { name: /mark src\/app\.ts as read/i }));
+		await waitFor(() => {
+			expect(screen.queryAllByText("context one")).toHaveLength(0);
+		});
+
+		view.unmount();
+
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("checkbox", { name: /mark src\/app\.ts as read/i })).not.toBeChecked();
+		});
+		expect(screen.getAllByText("context two").length).toBeGreaterThan(0);
+	});
+
+	it("refetches when the same diff request is opened again", async () => {
+		const firstHunk = "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-base\n+commit one\n";
+		const secondHunk = "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-base\n+commit two\n";
+		vi.mocked(api.request.getTaskDiff)
+			.mockResolvedValueOnce(singleFilePayload("commit one\n", firstHunk))
+			.mockResolvedValueOnce(singleFilePayload("commit two\n", secondHunk));
+
+		const { rerender } = render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await screen.findByText("commit one");
+		expect(vi.mocked(api.request.getTaskDiff)).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await waitFor(() => {
+			expect(vi.mocked(api.request.getTaskDiff)).toHaveBeenCalledTimes(2);
+		});
+		await screen.findByText("commit two");
+		expect(screen.queryByText("commit one")).not.toBeInTheDocument();
 	});
 
 	it("scrolls to a requested file when opened from changed files popup", async () => {


### PR DESCRIPTION
Summary:
- Refetch the inline diff payload when the same diff request is opened again.
- Include full file content in diff read-state and render cache keys.
- Add regression coverage for repeated opens and same-hunk/different-content diffs.

Tests:
- bun run lint
- bun run test
- bunx vitest run src/mainview/components/__tests__/TaskDiffViewer.test.tsx src/mainview/components/__tests__/TaskDiffViewer.stale-cache.test.ts