### PR TITLE
Fix git fetch failing in SSH-authenticated repos

### DIFF
--- a/change-logs/2026/04/26/fix-git-fetch-ssh-auth-sock.md
+++ b/change-logs/2026/04/26/fix-git-fetch-ssh-auth-sock.md
@@ -1,0 +1,1 @@
+Fixed git fetch failing silently in repos that use SSH authentication (e.g., git@github.com: remotes). The app now captures SSH_AUTH_SOCK from the user's login shell during startup, so the SSH agent socket is available to git and other spawned processes.

--- a/src/bun/__tests__/shell-env.test.ts
+++ b/src/bun/__tests__/shell-env.test.ts
@@ -61,13 +61,14 @@ describe("shell environment bootstrap", () => {
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
 
-	it("captures gh-related config variables from the login shell", async () => {
+	it("captures gh-related config variables and SSH_AUTH_SOCK from the login shell", async () => {
 		process.env.SHELL = "/bin/zsh";
 		spawnMock.mockReturnValue(fakeProc([
 			"___PATH=/opt/homebrew/bin:/usr/bin:/bin",
 			"___LANG=en_US.UTF-8",
 			"___XDG_CONFIG_HOME=/Users/tester/.config-xdg",
 			"___GH_CONFIG_DIR=/Users/tester/.config-gh",
+			"___SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.abc/Listeners",
 		].join("\n")));
 
 		const { resolveShellEnv } = await import("../shell-env");
@@ -78,6 +79,7 @@ describe("shell environment bootstrap", () => {
 			lang: "en_US.UTF-8",
 			xdgConfigHome: "/Users/tester/.config-xdg",
 			ghConfigDir: "/Users/tester/.config-gh",
+			sshAuthSock: "/private/tmp/com.apple.launchd.abc/Listeners",
 		});
 	});
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -140,6 +140,7 @@ const originalPath = process.env.PATH;
 const originalLang = process.env.LANG;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 const originalGhConfigDir = process.env.GH_CONFIG_DIR;
+const originalSshAuthSock = process.env.SSH_AUTH_SOCK;
 const shellEnv = await resolveShellEnv();
 if (shellEnv.path) {
 	process.env.PATH = shellEnv.path;
@@ -195,6 +196,14 @@ if (shellEnv.ghConfigDir) {
 	log.info("Shell GH_CONFIG_DIR resolved", {
 		original: originalGhConfigDir,
 		resolved: shellEnv.ghConfigDir,
+	});
+}
+
+if (shellEnv.sshAuthSock) {
+	process.env.SSH_AUTH_SOCK = shellEnv.sshAuthSock;
+	log.info("Shell SSH_AUTH_SOCK resolved", {
+		original: originalSshAuthSock,
+		resolved: shellEnv.sshAuthSock,
 	});
 }
 

--- a/src/bun/shell-env.ts
+++ b/src/bun/shell-env.ts
@@ -88,6 +88,7 @@ export async function resolveShellEnv(): Promise<{
 	lang?: string;
 	xdgConfigHome?: string;
 	ghConfigDir?: string;
+	sshAuthSock?: string;
 }> {
 	const shell = getUserShell();
 	const timeout = 5_000;
@@ -104,6 +105,7 @@ export async function resolveShellEnv(): Promise<{
 			'echo "___LANG=$LANG"',
 			'echo "___XDG_CONFIG_HOME=$XDG_CONFIG_HOME"',
 			'echo "___GH_CONFIG_DIR=$GH_CONFIG_DIR"',
+			'echo "___SSH_AUTH_SOCK=$SSH_AUTH_SOCK"',
 		].join(";")], {
 			stdout: "pipe",
 			stderr: "pipe",
@@ -127,6 +129,7 @@ export async function resolveShellEnv(): Promise<{
 		let lang: string | undefined;
 		let xdgConfigHome: string | undefined;
 		let ghConfigDir: string | undefined;
+		let sshAuthSock: string | undefined;
 
 		for (const line of lines) {
 			if (line.startsWith("___PATH=")) {
@@ -141,10 +144,13 @@ export async function resolveShellEnv(): Promise<{
 			} else if (line.startsWith("___GH_CONFIG_DIR=")) {
 				const val = line.slice("___GH_CONFIG_DIR=".length).trim();
 				if (val) ghConfigDir = val;
+			} else if (line.startsWith("___SSH_AUTH_SOCK=")) {
+				const val = line.slice("___SSH_AUTH_SOCK=".length).trim();
+				if (val) sshAuthSock = val;
 			}
 		}
 
-		return { path, lang, xdgConfigHome, ghConfigDir };
+		return { path, lang, xdgConfigHome, ghConfigDir, sshAuthSock };
 	} catch (err) {
 		log.warn("Failed to resolve shell environment", {
 			shell,


### PR DESCRIPTION
## Summary

- `resolveShellEnv()` now captures `SSH_AUTH_SOCK` from the user's login shell alongside PATH, LANG, XDG_CONFIG_HOME, and GH_CONFIG_DIR
- Applied to `process.env` at startup so all spawned processes (git, etc.) inherit the SSH agent socket
- Fixes `git fetch origin --quiet` silently failing for repos with SSH remotes (`git@github.com:...`), while HTTPS repos were unaffected

**Root cause:** macOS `.app` bundles launch with a stripped environment. The app recovered most needed vars but missed `SSH_AUTH_SOCK`, which git needs to authenticate via SSH keys through the agent.

## Test plan

- [ ] Restart the app
- [ ] Open a project whose remote is `git@github.com:...` (SSH)
- [ ] Create a new task — the Fetch step during worktree setup should succeed
- [ ] In the branch picker, click **Fetch** — remote branches should populate
- [ ] `bun run lint` passes (no new type errors)