### PR TITLE
Fix terminal selection copy to clipboard

### DIFF
--- a/change-logs/2026/04/26/fix-tmux-selection-copy.md
+++ b/change-logs/2026/04/26/fix-tmux-selection-copy.md
@@ -1,0 +1,1 @@
+Keep the terminal behavior aligned with the previous implementation and only add one change: when terminal selection changes, copy the selected text through the app's native clipboard API. This preserves the existing tmux mouse and context-menu behavior while making selection-to-clipboard more reliable.

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -486,6 +486,10 @@ async function pasteClipboardImage(params: { projectId: string }): Promise<{ pat
 	return saveUploadedFile(params.projectId, pngData, { mimeType: "image/png" });
 }
 
+async function writeClipboardText(params: { text: string }): Promise<void> {
+	Utils.clipboardWriteText(params.text);
+}
+
 async function uploadImageBase64(params: { projectId: string; base64: string; filename?: string; mimeType?: string }): Promise<{ path: string } | null> {
 	return uploadFileBase64(params);
 }
@@ -628,6 +632,7 @@ export const appHandlers = {
 	detectClonePaths,
 	getChangelogs,
 	pasteClipboardImage,
+	writeClipboardText,
 	uploadFileBase64,
 	uploadImageBase64,
 	readImageBase64,

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -197,7 +197,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 			logCopyEvent("info", "osc52 clipboard payload received", {
 				len: detail.text.length,
 			});
-			navigator.clipboard?.writeText(detail.text).catch(() => {});
+			api.request.writeClipboardText({ text: detail.text }).catch(() => {});
 		}
 
 		window.addEventListener("rpc:osc52Clipboard", handleOsc52Clipboard);
@@ -448,10 +448,12 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 										copyDiagnosticsRef.current?.clearSelection();
 										return;
 									}
+									const selection = term.getSelection();
 									copyDiagnosticsRef.current?.markSelection(
-										term.getSelection().length,
+										selection.length,
 										term.hasMouseTracking(),
 									);
+									api.request.writeClipboardText({ text: selection }).catch(() => {});
 								} catch {
 									copyDiagnosticsRef.current?.clearSelection();
 								}

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -81,7 +81,14 @@ vi.mock("ghostty-web", () => ({
 }));
 
 vi.mock("../rpc", () => ({
-	api: { request: { uploadFileBase64: vi.fn(), tmuxAction: vi.fn(), logRendererEvent: vi.fn().mockResolvedValue(undefined) } },
+	api: {
+		request: {
+			uploadFileBase64: vi.fn(),
+			tmuxAction: vi.fn(),
+			logRendererEvent: vi.fn().mockResolvedValue(undefined),
+			writeClipboardText: vi.fn().mockResolvedValue(undefined),
+		},
+	},
 }));
 
 vi.mock("../zoom", () => ({
@@ -474,7 +481,7 @@ describe("TerminalView – OSC 52 clipboard", () => {
 			);
 		});
 
-		expect(clipboardWriteTextMock).toHaveBeenCalledWith("copied from osc52");
+		expect(api.request.writeClipboardText).toHaveBeenCalledWith({ text: "copied from osc52" });
 	});
 
 	it("ignores OSC 52 payloads for other terminals", async () => {
@@ -489,6 +496,24 @@ describe("TerminalView – OSC 52 clipboard", () => {
 		});
 
 		expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+		expect(api.request.writeClipboardText).not.toHaveBeenCalled();
+	});
+
+	it("writes the current selection to navigator.clipboard when terminal selection changes", async () => {
+		mockTermInstance.hasSelection.mockReturnValue(true);
+		mockTermInstance.getSelection.mockReturnValue("selected text");
+
+		await renderAndSetup();
+
+		const selectionChangeCallback = (mockTermInstance.onSelectionChange.mock.calls as unknown[][])[0]?.[0] as
+			| (() => void)
+			| undefined;
+
+		await act(async () => {
+			selectionChangeCallback?.();
+		});
+
+		expect(api.request.writeClipboardText).toHaveBeenCalledWith({ text: "selected text" });
 	});
 });
 

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -313,6 +313,10 @@ function initBrowserApi(): ApiShape {
 			}
 		},
 
+		async writeClipboardText(params: { text: string }): Promise<void> {
+			await navigator.clipboard.writeText(params.text);
+		},
+
 		async getPtyUrl(params: { taskId: string; resume?: boolean }) {
 			const result = await rpcRequest("getPtyUrl", params);
 			// If the server signals a recoverable session, pass it through

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1255,6 +1255,10 @@ export type AppRPCSchema = {
 				params: { projectId: string };
 				response: { path: string } | null;
 			};
+			writeClipboardText: {
+				params: { text: string };
+				response: void;
+			};
 			readImageBase64: {
 				params: { path: string };
 				response: { dataUrl: string } | null;


### PR DESCRIPTION
Fix terminal text selection copy in embedded tmux sessions.

The terminal now writes selected text through the app's native clipboard API instead of relying on the browser clipboard path, which restores reliable selected-text copy without changing right-click menu behavior.