### PR TITLE
Fix tmux selection-to-clipboard regression (server-side pbcopy)

### DIFF
--- a/change-logs/2026/04/27/fix-tmux-copy-clipboard-regression.md
+++ b/change-logs/2026/04/27/fix-tmux-copy-clipboard-regression.md
@@ -1,0 +1,1 @@
+Fix tmux selection-to-clipboard regression introduced by PR #473. Mouse-drag copy in the terminal now actually lands in the host clipboard again — the desktop main process pipes OSC 52 payloads directly into pbcopy/wl-copy/xclip, instead of relying on the renderer's `navigator.clipboard.writeText()`, which silently fails in Electrobun WKWebView without a user gesture.

--- a/decisions/045-osc52-clipboard-server-side.md
+++ b/decisions/045-osc52-clipboard-server-side.md
@@ -1,0 +1,62 @@
+# 045 — OSC 52 clipboard write must stay server-side on desktop
+
+## Context
+
+Three users reported that selecting text with the mouse in the embedded tmux
+terminal stopped landing in the system clipboard. The regression was
+bisected to PR #473 (commit `33b6af9a`, 16 Apr 2026 — *Fix OSC 52 clipboard
+forwarding*), which:
+
+1. Removed the explicit tmux bindings
+   `bind -T copy-mode{,-vi} MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"`.
+2. Replaced the server-side `spawn(["pbcopy"])` call inside `handleOsc52`
+   with an IPC forward to the renderer, which then invoked
+   `navigator.clipboard.writeText(text).catch(() => {})`.
+
+## Investigation
+
+`navigator.clipboard.writeText()` in Electrobun's WKWebView requires
+[transient activation](https://www.w3.org/TR/clipboard-apis/#dom-clipboard-writetext)
+— a fresh user gesture. An asynchronous WebSocket message handler does
+**not** carry that activation, so the call rejects with `NotAllowedError`.
+The `.catch(() => {})` swallowed the rejection, and the diagnostics added
+in PR #499 confirmed the call was hitting that exact path.
+
+`tmux set -s set-clipboard on` (still present in the config) does cause tmux
+to emit OSC 52 sequences when copying to its buffer, so the data was reaching
+`handleOsc52`; the failure was strictly on the renderer side.
+
+## Decision
+
+Restore server-side clipboard writes on the desktop main process, while
+keeping the renderer/browser forward path for remote-access browser clients.
+
+- New helper `src/bun/system-clipboard.ts` → `writeSystemClipboard(text)`
+  picks the right host tool: `pbcopy` on macOS, `wl-copy` under Wayland on
+  Linux, `xclip -selection clipboard` on X11. The resolved tool is cached.
+- The desktop entry-point callback (`src/bun/index.ts`) calls
+  `writeSystemClipboard()` first, then still forwards via webview RPC and
+  `pushToBrowserClients()` for diagnostics + remote browser users.
+- The headless entry-point (`src/bun/headless-entry.ts`) is unchanged: it
+  only forwards, because the user is the remote browser, not the host.
+
+## Risks
+
+- Linux desktops without `wl-copy` or `xclip` get `null` from the helper and
+  no clipboard write — this matches pre-#473 behaviour for those hosts.
+- If `pbcopy` is missing from PATH inside an `.app` bundle, the helper falls
+  back to bare `"pbcopy"`; macOS always ships it under `/usr/bin/pbcopy`.
+- Remote-browser clipboard write is still subject to the same gesture
+  restriction. That's a separate, smaller user population and out of scope
+  here; the diagnostics added in PR #499 are kept to track it.
+
+## Alternatives considered
+
+- **Re-add the tmux `MouseDragEnd1Pane copy-pipe-and-cancel "pbcopy"`
+  bindings.** Rejected: hard-codes `pbcopy`, breaks on Linux, and is
+  redundant once OSC 52 is handled server-side.
+- **Only forward to the renderer and try to grab a user gesture there**
+  (e.g. on `mouseup`). Rejected: complex, still flaky on Electrobun, and
+  doesn't cover the inner-app OSC 52 cases (vim `"+y`, claude code copy).
+- **Block the WS message until a synthetic user gesture fires.** Rejected:
+  there is no reliable cross-process gesture forwarding in Electrobun.

--- a/src/bun/__tests__/system-clipboard.test.ts
+++ b/src/bun/__tests__/system-clipboard.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---- Mocks ----
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../spawn", () => ({
+	spawn: vi.fn(),
+	spawnSync: vi.fn(),
+}));
+
+vi.mock("../which", () => ({
+	whichSync: vi.fn(),
+}));
+
+import { spawn } from "../spawn";
+import { whichSync } from "../which";
+import { writeSystemClipboard, _resetClipboardToolForTests } from "../system-clipboard";
+
+const mockSpawn = vi.mocked(spawn);
+const mockWhichSync = vi.mocked(whichSync);
+
+const originalPlatform = process.platform;
+const originalWaylandDisplay = process.env.WAYLAND_DISPLAY;
+
+function setPlatform(p: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+function makeProc() {
+	const sink = { write: vi.fn(), end: vi.fn() };
+	return {
+		pid: 1,
+		stdin: sink,
+		stdout: null,
+		exited: Promise.resolve(0),
+	} as any;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	_resetClipboardToolForTests();
+	mockSpawn.mockReturnValue(makeProc());
+	delete process.env.WAYLAND_DISPLAY;
+});
+
+afterEach(() => {
+	setPlatform(originalPlatform);
+	if (originalWaylandDisplay !== undefined) {
+		process.env.WAYLAND_DISPLAY = originalWaylandDisplay;
+	} else {
+		delete process.env.WAYLAND_DISPLAY;
+	}
+});
+
+describe("writeSystemClipboard", () => {
+	it("uses pbcopy on macOS", () => {
+		setPlatform("darwin");
+		mockWhichSync.mockReturnValue("/usr/bin/pbcopy");
+
+		const tool = writeSystemClipboard("hello");
+
+		expect(tool).toBe("pbcopy");
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["/usr/bin/pbcopy"],
+			expect.objectContaining({ stdin: "pipe" }),
+		);
+		const proc = mockSpawn.mock.results[0]!.value;
+		expect(proc.stdin.write).toHaveBeenCalledWith("hello");
+		expect(proc.stdin.end).toHaveBeenCalled();
+	});
+
+	it("falls back to bare 'pbcopy' when which fails on macOS", () => {
+		setPlatform("darwin");
+		mockWhichSync.mockReturnValue(null);
+
+		const tool = writeSystemClipboard("x");
+
+		expect(tool).toBe("pbcopy");
+		expect(mockSpawn).toHaveBeenCalledWith(["pbcopy"], expect.any(Object));
+	});
+
+	it("uses wl-copy on Linux Wayland when available", () => {
+		setPlatform("linux");
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+		mockWhichSync.mockImplementation((c: string) => (c === "wl-copy" ? "/usr/bin/wl-copy" : null));
+
+		const tool = writeSystemClipboard("hi");
+
+		expect(tool).toBe("wl-copy");
+		expect(mockSpawn).toHaveBeenCalledWith(["/usr/bin/wl-copy"], expect.any(Object));
+	});
+
+	it("uses xclip on Linux X11 when wl-copy unavailable", () => {
+		setPlatform("linux");
+		mockWhichSync.mockImplementation((c: string) => (c === "xclip" ? "/usr/bin/xclip" : null));
+
+		const tool = writeSystemClipboard("hi");
+
+		expect(tool).toBe("xclip");
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["/usr/bin/xclip", "-selection", "clipboard"],
+			expect.any(Object),
+		);
+	});
+
+	it("returns null on Linux when no clipboard tool exists", () => {
+		setPlatform("linux");
+		mockWhichSync.mockReturnValue(null);
+
+		const tool = writeSystemClipboard("hi");
+
+		expect(tool).toBeNull();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	it("returns null on win32 (unsupported)", () => {
+		setPlatform("win32");
+		mockWhichSync.mockReturnValue(null);
+
+		const tool = writeSystemClipboard("hi");
+
+		expect(tool).toBeNull();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	it("caches the resolved tool — only resolves once across calls", () => {
+		setPlatform("darwin");
+		mockWhichSync.mockReturnValue("/usr/bin/pbcopy");
+
+		writeSystemClipboard("a");
+		writeSystemClipboard("b");
+		writeSystemClipboard("c");
+
+		expect(mockWhichSync).toHaveBeenCalledTimes(1);
+		expect(mockSpawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("returns null and does not throw if spawn fails", () => {
+		setPlatform("darwin");
+		mockWhichSync.mockReturnValue("/usr/bin/pbcopy");
+		mockSpawn.mockImplementation(() => {
+			throw new Error("ENOENT");
+		});
+
+		expect(() => writeSystemClipboard("x")).not.toThrow();
+		expect(writeSystemClipboard("x")).toBeNull();
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -16,6 +16,7 @@ import { DEV3_HOME } from "./paths";
 import { getShellRcFile, getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
 import { startRemoteAccessServer, pushToBrowserClients, generateQrDataUrl, getAccessUrl } from "./remote-access-server";
+import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
 import { makeTitle } from "./app-utils";
@@ -412,6 +413,19 @@ setOnIdle((sessionKey) => {
 });
 
 setOnOsc52Copy((payload) => {
+	// Write directly to the host clipboard. The renderer cannot do this
+	// reliably — navigator.clipboard.writeText() in Electrobun WKWebView
+	// requires a user gesture, and an async WS message is not one.
+	const tool = writeSystemClipboard(payload.text);
+	if (tool) {
+		log.info("OSC 52 written to host clipboard", {
+			taskId: payload.taskId.slice(0, 8),
+			len: payload.len,
+			tool,
+		});
+	}
+	// Still forward to renderer (diagnostics) and remote browser clients
+	// (where the user's clipboard is the browser, not the host).
 	try {
 		(mainWindow.webview.rpc as any).send.osc52Clipboard?.(payload);
 		pushToBrowserClients("osc52Clipboard", payload);

--- a/src/bun/system-clipboard.ts
+++ b/src/bun/system-clipboard.ts
@@ -62,15 +62,43 @@ function getClipboardTool(): ClipboardTool | null {
 /**
  * Pipe `text` into the host clipboard. Returns the tool used, or `null` if
  * unsupported / failed.
+ *
+ * Spawn returns synchronously, so callers don't need to await — but we attach
+ * a deferred handler that logs the eventual exit code + stderr. This makes it
+ * possible to diagnose silent failures (broken pbcopy, missing permissions,
+ * "no display" on Linux, etc.) from logs alone.
  */
 export function writeSystemClipboard(text: string): string | null {
 	const tool = getClipboardTool();
 	if (!tool) return null;
 	try {
-		const proc = spawn(tool.cmd, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+		const proc = spawn(tool.cmd, { stdin: "pipe", stdout: "ignore", stderr: "pipe" });
 		const sink = proc.stdin as unknown as import("bun").FileSink;
 		sink.write(text);
 		sink.end();
+		// Deferred diagnostics — observe whether the tool actually accepted the
+		// payload. Non-zero exit or stderr output is the smoking gun for the
+		// "pbcopy is broken on user's machine" class of bug reports.
+		(async () => {
+			try {
+				const [exitCode, stderr] = await Promise.all([
+					proc.exited,
+					proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(""),
+				]);
+				if (exitCode === 0 && !stderr) {
+					log.debug("clipboard wrote", { tool: tool.label, len: text.length });
+				} else {
+					log.warn("clipboard tool exited non-cleanly", {
+						tool: tool.label,
+						exitCode,
+						stderr: stderr.slice(0, 500),
+						len: text.length,
+					});
+				}
+			} catch (err) {
+				log.warn("clipboard tool exit observation failed", { tool: tool.label, error: String(err) });
+			}
+		})();
 		return tool.label;
 	} catch (err) {
 		log.warn("clipboard write failed", { tool: tool.label, error: String(err) });

--- a/src/bun/system-clipboard.ts
+++ b/src/bun/system-clipboard.ts
@@ -1,0 +1,84 @@
+/**
+ * Write text to the host system clipboard from the desktop main process.
+ *
+ * Used to handle OSC 52 copy payloads that arrive from inner apps (vim, tmux,
+ * etc.) via the PTY data stream. The renderer cannot do this reliably:
+ * `navigator.clipboard.writeText()` in Electrobun's WKWebView requires a user
+ * gesture / transient activation, and an async WebSocket message handler is
+ * not a gesture — calls fail silently with NotAllowedError. So the desktop
+ * process pipes directly to `pbcopy` / `wl-copy` / `xclip`.
+ *
+ * Headless mode (`headless-entry.ts`) does NOT call into here: there's no
+ * interactive user on the host machine; the OSC 52 payload is forwarded to
+ * the remote browser instead.
+ */
+
+import { spawn } from "./spawn";
+import { whichSync } from "./which";
+import { createLogger } from "./logger";
+
+const log = createLogger("system-clipboard");
+
+interface ClipboardTool {
+	cmd: string[];
+	label: string;
+}
+
+let resolved: ClipboardTool | null | undefined;
+
+function resolveClipboardTool(): ClipboardTool | null {
+	if (process.platform === "darwin") {
+		const pbcopy = whichSync("pbcopy") ?? "pbcopy"; // pbcopy is in /usr/bin always
+		return { cmd: [pbcopy], label: "pbcopy" };
+	}
+	if (process.platform === "linux") {
+		// Prefer wl-copy under Wayland sessions, fall back to xclip on X11.
+		if (process.env.WAYLAND_DISPLAY) {
+			const wl = whichSync("wl-copy");
+			if (wl) return { cmd: [wl], label: "wl-copy" };
+		}
+		const xclip = whichSync("xclip");
+		if (xclip) return { cmd: [xclip, "-selection", "clipboard"], label: "xclip" };
+		const wlFallback = whichSync("wl-copy");
+		if (wlFallback) return { cmd: [wlFallback], label: "wl-copy" };
+		return null;
+	}
+	// win32 / others — not supported here yet.
+	return null;
+}
+
+function getClipboardTool(): ClipboardTool | null {
+	if (resolved === undefined) {
+		resolved = resolveClipboardTool();
+		if (resolved) {
+			log.info("clipboard tool resolved", { tool: resolved.label, cmd: resolved.cmd.join(" ") });
+		} else {
+			log.warn("no system clipboard tool found", { platform: process.platform });
+		}
+	}
+	return resolved;
+}
+
+/**
+ * Pipe `text` into the host clipboard. Returns the tool used, or `null` if
+ * unsupported / failed.
+ */
+export function writeSystemClipboard(text: string): string | null {
+	const tool = getClipboardTool();
+	if (!tool) return null;
+	try {
+		const proc = spawn(tool.cmd, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+		const sink = proc.stdin as unknown as import("bun").FileSink;
+		sink.write(text);
+		sink.end();
+		return tool.label;
+	} catch (err) {
+		log.warn("clipboard write failed", { tool: tool.label, error: String(err) });
+		return null;
+	}
+}
+
+/** Test hook — reset cached tool so a unit test can re-resolve under a stub. */
+export function _resetClipboardToolForTests(): void {
+	resolved = undefined;
+}


### PR DESCRIPTION
## Summary

- Restore server-side host-clipboard write on the desktop main process for OSC 52 payloads — regression introduced by #473 (Apr 16) replaced `spawn(["pbcopy"])` with a renderer-side `navigator.clipboard.writeText().catch(() => {})`, which silently fails with `NotAllowedError` in Electrobun's WKWebView (the WS message handler is not a gesture-bearing task; see `decisions/045-osc52-clipboard-server-side.md` for the full task-chain analysis).
- New helper `src/bun/system-clipboard.ts` resolves the right host tool per platform (`pbcopy` on macOS, `wl-copy` under Wayland, `xclip` on X11) and caches it. Headless mode (`headless-entry.ts`) is untouched — it still forwards to the remote browser, since there is no interactive user on the headless host.
- Logs the clipboard tool's exit code + stderr (deferred, non-blocking) so future "copy still doesn't work" reports can be diagnosed from logs alone — silent broken-tool failures are no longer invisible.

The browser-remote / Linux-remote-worker case (inner-app OSC 52 → no host clipboard) is **not** addressed here and is tracked separately in task `f68d922b`. Drag-selection in browser remote already works via ghostty-web's internal `mouseup` auto-copy.