### PR TITLE
Fix model name quoting in agent run script for zsh

### DIFF
--- a/change-logs/2026/04/29/fix-dev3-model-bracket-quoting.md
+++ b/change-logs/2026/04/29/fix-dev3-model-bracket-quoting.md
@@ -1,0 +1,1 @@
+Shell-quote the `--model` argument value when building the agent run script so that model names containing special characters (e.g. `sonnet[1m]` with square brackets) are not misinterpreted as glob patterns by zsh.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -136,7 +136,7 @@ describe("resolveAgentCommand — resume", () => {
 		);
 
 		expect(cmd).toMatch(/^codex resume --last/);
-		expect(cmd).toContain("--model gpt-5");
+		expect(cmd).toContain("--model 'gpt-5'");
 		expect(cmd).not.toContain("--permission-mode");
 		expect(cmd).not.toContain("--effort");
 		expect(cmd).not.toContain("--max-budget-usd");
@@ -292,6 +292,16 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("--append-system-prompt");
 	});
 
+	it("Claude: shell-quotes model names with special chars (e.g. brackets)", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "claude" }),
+			makeConfig({ model: "claude-sonnet-4-6[1m]" }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("--model 'claude-sonnet-4-6[1m]'");
+	});
+
 	// ---- OpenCode ----
 	it("OpenCode: adds --continue when resume=true", () => {
 		const cmd = resolveAgentCommand(
@@ -314,7 +324,7 @@ describe("resolveAgentCommand — resume", () => {
 
 		expect(cmd).toContain("--prompt");
 		expect(cmd).toContain("Fix the login bug");
-		expect(cmd).toContain("--model anthropic/claude-opus-4-6");
+		expect(cmd).toContain("--model 'anthropic/claude-opus-4-6'");
 	});
 
 	it("OpenCode: injects generic system prompt (not Claude hooks variant)", () => {
@@ -366,7 +376,7 @@ describe("resolveAgentCommand — resume", () => {
 		);
 
 		expect(cmd).toContain("--agent sisyphus");
-		expect(cmd).toContain("--model anthropic/claude-opus-4-6");
+		expect(cmd).toContain("--model 'anthropic/claude-opus-4-6'");
 		expect(cmd).toContain("--prompt");
 	});
 

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -356,7 +356,7 @@ export function resolveAgentCommand(
 	}
 
 	if (config?.model) {
-		args.push("--model", config.model);
+		args.push("--model", shellEscape(config.model));
 	}
 
 	const cursorAgent = isCursorCommand(baseCmd);


### PR DESCRIPTION
## Summary

- Shell-quote the `--model` argument value when building the agent run script
- Fixes `zsh: no matches found: sonnet[1m]` error when starting a task with the default Sonnet model
- Root cause: `[1m]` in `sonnet[1m]` was treated as a zsh glob pattern since the value was unquoted in the generated `.sh` file

## Test plan

- [ ] Start a task using the default (Sonnet) agent — should launch without the `no matches found` error
- [ ] Verify other model names (e.g. plain strings without brackets) still work correctly