### PR TITLE
feat: Home Terminal — project-free 2x2 tmux grid in $HOME

### DIFF
--- a/change-logs/2026/05/02/feature-home-terminal.md
+++ b/change-logs/2026/05/02/feature-home-terminal.md
@@ -1,0 +1,1 @@
+Add Home Terminal — a project-free 2×2 tmux grid that opens in the user's home directory. Available from the global header (house icon) or via the Cmd+Shift+` shortcut from any screen, complementing the existing Project Terminal.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -100,6 +100,8 @@ vi.mock("../pty-server", () => ({
 	getTmuxBinary: vi.fn(() => "tmux"),
 	TMUX_CONF_PATH: "/tmp/dev3-tmux.conf",
 	DEFAULT_TMUX_SOCKET: "dev3",
+	HOME_TERMINAL_SESSION_KEY: "home",
+	HOME_TERMINAL_TMUX_NAME: "dev3-home",
 }));
 
 vi.mock("../agents", () => ({
@@ -4663,6 +4665,62 @@ describe("handlers.destroyProjectTerminal", () => {
 	it("destroys the project terminal session", async () => {
 		await handlers.destroyProjectTerminal({ projectId: "proj-123" });
 		expect(pty.destroySession).toHaveBeenCalledWith("project-proj-123");
+	});
+});
+
+// ================================================================
+// handlers.getHomePtyUrl / destroyHomeTerminal
+// ================================================================
+
+describe("handlers.getHomePtyUrl", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("creates a home PTY session in the user's home directory", async () => {
+		vi.mocked(pty.hasSession).mockReturnValue(false);
+		vi.mocked(pty.hasDeadSession).mockReturnValue(false);
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		const url = await handlers.getHomePtyUrl({});
+
+		expect(pty.createSession).toHaveBeenCalledWith(
+			"home",
+			"",
+			expect.any(String),
+			process.env.SHELL || "/bin/zsh",
+			{},
+			"dev3",
+			"home",
+		);
+		expect(url).toBe("ws://localhost:9999?session=home");
+	});
+
+	it("reuses existing home session without creating a new one", async () => {
+		vi.mocked(pty.hasSession).mockReturnValue(true);
+		vi.mocked(pty.hasDeadSession).mockReturnValue(false);
+
+		await handlers.getHomePtyUrl({});
+
+		expect(pty.createSession).not.toHaveBeenCalled();
+	});
+
+	it("destroys dead home session before creating a new one", async () => {
+		vi.mocked(pty.hasDeadSession).mockReturnValue(true);
+		vi.mocked(pty.hasSession).mockReturnValue(false);
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		await handlers.getHomePtyUrl({});
+
+		expect(pty.destroySession).toHaveBeenCalledWith("home");
+		expect(pty.createSession).toHaveBeenCalled();
+	});
+});
+
+describe("handlers.destroyHomeTerminal", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("destroys the home terminal session", async () => {
+		await handlers.destroyHomeTerminal({});
+		expect(pty.destroySession).toHaveBeenCalledWith("home");
 	});
 });
 

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -216,7 +216,10 @@ startResourceMonitor((name, payload) => {
 // ── PTY event wiring (no mainWindow.webview.rpc — just push to browser) ──
 setOnPtyDied((sessionKey) => {
 	try {
-		if (sessionKey.startsWith("project-")) {
+		if (sessionKey === "home") {
+			log.info("Home terminal died");
+			pushToBrowserClients("homePtyDied", {});
+		} else if (sessionKey.startsWith("project-")) {
 			const projectId = sessionKey.slice(8);
 			log.info("Project terminal died", { projectId: projectId.slice(0, 8) });
 			pushToBrowserClients("projectPtyDied", { projectId });
@@ -231,6 +234,7 @@ setOnPtyDied((sessionKey) => {
 
 setOnBell((sessionKey) => {
 	try {
+		if (sessionKey === "home") return;
 		if (sessionKey.startsWith("project-")) return;
 		log.debug("Terminal bell", { taskId: sessionKey.slice(0, 8) });
 		pushToBrowserClients("terminalBell", { taskId: sessionKey });
@@ -243,6 +247,7 @@ setOnBell((sessionKey) => {
 });
 
 setOnIdle((sessionKey) => {
+	if (sessionKey === "home") return;
 	if (sessionKey.startsWith("project-")) return;
 	isTaskInProgress(sessionKey).then((inProgress) => {
 		if (!inProgress) return;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -351,7 +351,10 @@ startResourceMonitor((name, payload) => {
 // Wire PTY death notifications
 setOnPtyDied((sessionKey) => {
 	try {
-		if (sessionKey.startsWith("project-")) {
+		if (sessionKey === "home") {
+			log.info("Home terminal died, notifying renderer");
+			(mainWindow.webview.rpc as any).send.homePtyDied?.({});
+		} else if (sessionKey.startsWith("project-")) {
 			const projectId = sessionKey.slice(8);
 			log.info("Project terminal died, notifying renderer", { projectId: projectId.slice(0, 8) });
 			(mainWindow.webview.rpc as any).send.projectPtyDied?.({ projectId });
@@ -371,7 +374,8 @@ setOnPtyDied((sessionKey) => {
 // Wire terminal bell notifications
 setOnBell((sessionKey) => {
 	try {
-		// Project terminals are plain shells — skip bell/auto-status logic
+		// Project and home terminals are plain shells — skip bell/auto-status logic
+		if (sessionKey === "home") return;
 		if (sessionKey.startsWith("project-")) return;
 
 		log.debug("Terminal bell, notifying renderer", { taskId: sessionKey.slice(0, 8) });
@@ -393,7 +397,8 @@ setOnBell((sessionKey) => {
 // Only fires for tasks that are currently "in-progress" — idle terminals
 // in other statuses (review, todo, etc.) are expected and not noteworthy.
 setOnIdle((sessionKey) => {
-	// Project terminals have no task status — skip idle notifications
+	// Project and home terminals have no task status — skip idle notifications
+	if (sessionKey === "home") return;
 	if (sessionKey.startsWith("project-")) return;
 
 	isTaskInProgress(sessionKey).then((inProgress) => {

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -180,7 +180,10 @@ let ptyWsPort = 0;
 // by 10-100x while maintaining perceptual smoothness.
 const PTY_BATCH_INTERVAL_MS = 16;
 
-export type PtySessionType = "task" | "project";
+export type PtySessionType = "task" | "project" | "home";
+
+export const HOME_TERMINAL_SESSION_KEY = "home";
+export const HOME_TERMINAL_TMUX_NAME = "dev3-home";
 
 interface PtySession {
 	taskId: string;
@@ -238,6 +241,9 @@ function computeTmuxSessionName(key: string, type: PtySessionType): string {
 	if (type === "project") {
 		const projectId = key.startsWith("project-") ? key.slice(8) : key;
 		return `dev3-pt-${projectId.slice(0, 8)}`;
+	}
+	if (type === "home") {
+		return HOME_TERMINAL_TMUX_NAME;
 	}
 	return `dev3-${shortId(key)}`;
 }
@@ -534,18 +540,18 @@ function configureTmux(tmuxSessionName: string, socket: string): void {
 }
 
 /**
- * Create a 2×2 pane grid for project terminals.
+ * Create a 2×2 pane grid for project and home terminals.
  * Only runs if the session currently has exactly one pane (i.e. freshly created).
  * Uses `select-layout tiled` to avoid pane-index arithmetic.
  */
-function setupProjectLayout(session: PtySession): void {
+function setupTiledLayout(session: PtySession): void {
 	const s = session.tmuxSessionName;
 	const sock = session.tmuxSocket;
 	try {
 		const listResult = spawnSync(tmuxArgs(sock, "list-panes", "-t", s));
 		const paneCount = new TextDecoder().decode(listResult.stdout).trim().split("\n").filter(Boolean).length;
 		if (paneCount !== 1) {
-			log.info("Project layout: session already has multiple panes, skipping", { tmuxSession: s, paneCount });
+			log.info("Tiled layout: session already has multiple panes, skipping", { tmuxSession: s, paneCount });
 			return;
 		}
 		// Create 3 more panes (4 total), then apply tiled layout for 2×2 grid.
@@ -560,9 +566,9 @@ function setupProjectLayout(session: PtySession): void {
 		spawnSync(tmuxArgs(sock, "select-layout", "-t", s, "tiled"));
 		// Return focus to pane 1 (base-index 1 in tmux config)
 		spawnSync(tmuxArgs(sock, "select-pane", "-t", `${s}:1.1`));
-		log.info("Project terminal 2×2 layout created", { tmuxSession: s });
+		log.info("Tiled 2×2 layout created", { tmuxSession: s, sessionType: session.sessionType });
 	} catch (err) {
-		log.error("Failed to create project terminal layout", {
+		log.error("Failed to create tiled terminal layout", {
 			tmuxSession: s,
 			error: String(err),
 		});
@@ -699,8 +705,8 @@ function spawnPty(session: PtySession, cols: number, rows: number): void {
 			if (envKeys.length > 0) {
 				log.info("tmux session env vars set", { tmuxSession: tmuxSessionName, keys: envKeys });
 			}
-			if (session.sessionType === "project") {
-				setupProjectLayout(session);
+			if (session.sessionType === "project" || session.sessionType === "home") {
+				setupTiledLayout(session);
 			}
 
 		} catch (err) {

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import type { ColumnAgentConfig, DevServerStatus, PortInfo, Project, Task, TmuxSessionInfo } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
 import * as data from "../data";
@@ -999,6 +1000,34 @@ async function destroyProjectTerminal(params: { projectId: string }): Promise<vo
 	log.info("← destroyProjectTerminal done");
 }
 
+async function getHomePtyUrl(_params: {}): Promise<string> {
+	const sessionKey = pty.HOME_TERMINAL_SESSION_KEY;
+	log.info("→ getHomePtyUrl", { hasExistingSession: pty.hasSession(sessionKey) });
+
+	if (pty.hasDeadSession(sessionKey)) {
+		log.info("Dead home terminal session — destroying to recreate");
+		pty.destroySession(sessionKey);
+	}
+
+	if (!pty.hasSession(sessionKey)) {
+		const home = homedir();
+		if (!existsSync(home)) {
+			throw new Error(`Home directory does not exist: ${home}`);
+		}
+		pty.createSession(sessionKey, "", home, getUserShell(), {}, pty.DEFAULT_TMUX_SOCKET, "home");
+	}
+
+	const url = `ws://localhost:${pty.getPtyPort()}?session=${sessionKey}`;
+	log.info("← getHomePtyUrl", { url });
+	return url;
+}
+
+async function destroyHomeTerminal(_params: {}): Promise<void> {
+	log.info("→ destroyHomeTerminal");
+	pty.destroySession(pty.HOME_TERMINAL_SESSION_KEY);
+	log.info("← destroyHomeTerminal done");
+}
+
 async function getTaskPorts(params: { taskId: string }): Promise<PortInfo[]> {
 	log.info("→ getTaskPorts", { taskId: params.taskId.slice(0, 8) });
 	const ports = getPortsForTask(params.taskId);
@@ -1032,6 +1061,7 @@ async function listTmuxSessions(): Promise<TmuxSessionInfo[]> {
 		windowCount: number;
 		isCleanup: boolean;
 		isProjectTerminal: boolean;
+		isHomeTerminal: boolean;
 		shortId: string;
 	}> = [];
 
@@ -1043,7 +1073,14 @@ async function listTmuxSessions(): Promise<TmuxSessionInfo[]> {
 
 		const isCleanup = name.startsWith("dev3-cl-");
 		const isProjectTerminal = name.startsWith("dev3-pt-");
-		const shortId = isProjectTerminal ? name.slice(8) : isCleanup ? name.slice(8) : name.slice(5);
+		const isHomeTerminal = name === pty.HOME_TERMINAL_TMUX_NAME;
+		const shortId = isHomeTerminal
+			? "home"
+			: isProjectTerminal
+				? name.slice(8)
+				: isCleanup
+					? name.slice(8)
+					: name.slice(5);
 		if (!shortId) continue;
 
 		rawSessions.push({
@@ -1053,12 +1090,13 @@ async function listTmuxSessions(): Promise<TmuxSessionInfo[]> {
 			windowCount: parseInt(windowsStr, 10) || 1,
 			isCleanup,
 			isProjectTerminal,
+			isHomeTerminal,
 			shortId,
 		});
 
 		if (isProjectTerminal) {
 			projectShortIds.add(shortId);
-		} else {
+		} else if (!isHomeTerminal) {
 			taskShortIds.add(shortId);
 		}
 	}
@@ -1103,7 +1141,18 @@ async function listTmuxSessions(): Promise<TmuxSessionInfo[]> {
 
 	const sessions: TmuxSessionInfo[] = [];
 	for (const rawSession of rawSessions) {
-		const { name, cwd, windowCount, createdAt, isCleanup, isProjectTerminal, shortId } = rawSession;
+		const { name, cwd, windowCount, createdAt, isCleanup, isProjectTerminal, isHomeTerminal, shortId } = rawSession;
+		if (isHomeTerminal) {
+			sessions.push({
+				name,
+				cwd,
+				createdAt,
+				windowCount,
+				isCleanup: false,
+				isHomeTerminal: true,
+			});
+			continue;
+		}
 		if (isProjectTerminal) {
 			const projectInfo = projectMap.get(shortId);
 			sessions.push({
@@ -1403,6 +1452,8 @@ export const tmuxPtyHandlers = {
 	getPtyUrl,
 	getProjectPtyUrl,
 	destroyProjectTerminal,
+	getHomePtyUrl,
+	destroyHomeTerminal,
 	getTaskPorts,
 	getPortAllocations,
 	listTmuxSessions,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -15,6 +15,7 @@ import CreateTaskModal from "./components/CreateTaskModal";
 import ProjectView from "./components/ProjectView";
 import TaskWorkspaceView from "./components/TaskWorkspaceView";
 import ProjectTerminal from "./components/ProjectTerminal";
+import HomeTerminal from "./components/HomeTerminal";
 import ProjectSettings from "./components/ProjectSettings";
 import RequirementsCheck from "./components/RequirementsCheck";
 import GhWarningBanner, { isGhWarningDismissed } from "./components/GhWarningBanner";
@@ -190,6 +191,15 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				applyZoom(DEFAULT_ZOOM);
+			} else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "~") {
+				// Cmd+Shift+` — toggle home terminal (key="~" because Shift+` produces ~)
+				e.preventDefault();
+				e.stopPropagation();
+				if (state.route.screen === "home-terminal") {
+					navigate({ screen: "dashboard" });
+				} else {
+					navigate({ screen: "home-terminal" });
+				}
 			} else if ((e.metaKey || e.ctrlKey) && e.key === "`") {
 				// Cmd+` — toggle project terminal
 				const { route } = state;
@@ -568,6 +578,8 @@ function App() {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project-terminal") {
 				navigate({ screen: "project", projectId: route.projectId });
+			} else if (route.screen === "home-terminal") {
+				navigate({ screen: "dashboard" });
 			} else if (route.screen === "project" && route.activeTaskId) {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project") {
@@ -910,6 +922,12 @@ function App() {
 					</div>
 				) : null;
 			}
+			case "home-terminal":
+				return (
+					<div className="flex-1 min-h-0 flex flex-col">
+						<HomeTerminal onBack={() => navigate({ screen: "dashboard" })} />
+					</div>
+				);
 			case "task":
 				return (
 					<TaskWorkspaceView

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -926,6 +926,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 				}
 			}
 			if (!hasImage) return;
+			// No project context (e.g. home terminal) — image paste is unsupported,
+			// let the default text paste behavior run.
+			if (!projectId) return;
 
 			e.preventDefault();
 			e.stopPropagation();

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -7,6 +7,7 @@ import { api } from "../rpc";
 import TmuxSessionManager from "./TmuxSessionManager";
 import InlineRename from "./InlineRename";
 import GitPullButton from "./GitPullButton";
+import HomeTerminalIcon from "./HomeTerminalIcon";
 
 interface GlobalHeaderProps {
 	route: Route;
@@ -182,6 +183,11 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 	// Project terminal breadcrumb segment
 	if (route.screen === "project-terminal") {
 		segments.push({ label: t("projectTerminal.label") });
+	}
+
+	// Home terminal breadcrumb segment
+	if (route.screen === "home-terminal") {
+		segments.push({ label: t("homeTerminal.label") });
 	}
 
 	// Task segment for split view
@@ -425,6 +431,26 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 						<span className="text-[0.6875rem] font-medium">{t("projectTerminal.open")}</span>
 					</button>
 				)}
+
+				{/* Home Terminal — always visible (rootless tmux in $HOME) */}
+				<button
+					onClick={() => {
+						if (route.screen === "home-terminal") {
+							navigate({ screen: "dashboard" });
+						} else {
+							navigate({ screen: "home-terminal" });
+						}
+					}}
+					className={`flex items-center gap-1 transition-colors px-2 py-1 rounded-lg ${
+						route.screen === "home-terminal"
+							? "text-accent bg-accent/15 hover:bg-accent/25"
+							: "text-fg-3 hover:text-fg hover:bg-elevated"
+					}`}
+					title={t("homeTerminal.tooltipWithShortcut")}
+				>
+					<HomeTerminalIcon className="w-[1.125rem] h-[1.125rem]" />
+					<span className="text-[0.6875rem] font-medium">{t("homeTerminal.open")}</span>
+				</button>
 
 				{/* Git Pull — quick pull of origin/{main|master} into project main worktree */}
 				{"projectId" in route && (

--- a/src/mainview/components/HomeTerminal.tsx
+++ b/src/mainview/components/HomeTerminal.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { api } from "../rpc";
+import { useT } from "../i18n";
+import TerminalView from "../TerminalView";
+
+interface HomeTerminalProps {
+	onBack: () => void;
+}
+
+const SESSION_KEY = "home";
+
+function HomeTerminal({ onBack }: HomeTerminalProps) {
+	const t = useT();
+	const [ptyUrl, setPtyUrl] = useState<string | null>(null);
+	const [error, setError] = useState(false);
+	const [restarting, setRestarting] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const url = await api.request.getHomePtyUrl({});
+				if (cancelled) return;
+				setPtyUrl(url);
+			} catch (err) {
+				if (cancelled) return;
+				console.error("[HomeTerminal] getHomePtyUrl FAILED:", err);
+				setError(true);
+			}
+		})();
+		return () => { cancelled = true; };
+	}, []);
+
+	useEffect(() => {
+		function onHomePtyDied() {
+			setError(true);
+		}
+		window.addEventListener("rpc:homePtyDied", onHomePtyDied);
+		return () => window.removeEventListener("rpc:homePtyDied", onHomePtyDied);
+	}, []);
+
+	async function handleRestart() {
+		setRestarting(true);
+		try {
+			await api.request.destroyHomeTerminal({}).catch(() => {});
+			const url = await api.request.getHomePtyUrl({});
+			setPtyUrl(url);
+			setError(false);
+		} catch (err) {
+			console.error("[HomeTerminal] Restart failed:", err);
+			setError(true);
+		} finally {
+			setRestarting(false);
+		}
+	}
+
+	if (error) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="bg-raised border border-edge rounded-lg p-6 max-w-md w-full space-y-4">
+					<div className="flex items-center gap-2 font-medium text-fg">
+						<span className="text-lg">{"⏹"}</span>
+						<span>{t("homeTerminal.sessionEnded")}</span>
+					</div>
+					<p className="text-fg-3 text-sm">{t("homeTerminal.sessionEndedDesc")}</p>
+					<div className="flex gap-3 pt-2">
+						<button
+							onClick={handleRestart}
+							disabled={restarting}
+							className="flex-1 px-4 py-2 bg-accent text-white rounded text-sm font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+						>
+							{restarting ? t("terminal.connecting") : t("homeTerminal.restart")}
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="h-full w-full flex flex-col overflow-hidden">
+			<div className="flex items-center justify-between px-4 py-1.5 border-b border-edge flex-shrink-0 bg-raised">
+				<button
+					onClick={onBack}
+					className="flex items-center gap-1.5 text-fg-3 hover:text-fg transition-colors text-sm"
+				>
+					<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+					</svg>
+					<span>{t("homeTerminal.back")}</span>
+				</button>
+				<div className="flex items-center gap-3">
+					<span className="text-fg-muted text-xs truncate max-w-[20rem]">~</span>
+					<kbd className="text-[0.625rem] text-fg-muted/60 font-mono px-1.5 py-0.5 rounded bg-elevated border border-edge">
+						{t("homeTerminal.shortcutHint")}
+					</kbd>
+				</div>
+			</div>
+			<div className="flex-1 min-h-0 overflow-hidden">
+				{ptyUrl ? (
+					<TerminalView ptyUrl={ptyUrl} taskId={SESSION_KEY} projectId="" />
+				) : (
+					<div className="flex items-center justify-center h-full">
+						<div className="flex items-center gap-3">
+							<div className="w-2 h-2 rounded-full bg-accent animate-pulse" />
+							<span className="text-fg-3 text-sm">{t("terminal.connecting")}</span>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export default HomeTerminal;

--- a/src/mainview/components/HomeTerminalIcon.tsx
+++ b/src/mainview/components/HomeTerminalIcon.tsx
@@ -1,0 +1,49 @@
+interface HomeTerminalIconProps {
+	className?: string;
+}
+
+function HomeTerminalIcon({ className }: HomeTerminalIconProps) {
+	return (
+		<svg
+			className={className}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 100 100"
+			fill="currentColor"
+		>
+			<defs>
+				<mask id="home-terminal-icon-doorway">
+					<rect width="100" height="100" fill="white" />
+					<rect x="34" y="54" width="32" height="40" rx="4" fill="black" />
+				</mask>
+			</defs>
+			<path
+				d="M 16 52 L 50 18 L 84 52 L 72 52 L 72 86 L 28 86 L 28 52 Z"
+				fill="currentColor"
+				stroke="currentColor"
+				strokeWidth={5}
+				strokeLinejoin="round"
+				strokeLinecap="round"
+				mask="url(#home-terminal-icon-doorway)"
+			/>
+			<path
+				d="M 40 65 L 47 72.5 L 40 80"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={6}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<line
+				x1="51"
+				y1="80"
+				x2="60"
+				y2="80"
+				stroke="currentColor"
+				strokeWidth={6}
+				strokeLinecap="round"
+			/>
+		</svg>
+	);
+}
+
+export default HomeTerminalIcon;

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -83,6 +83,16 @@ const terminal = {
 	"projectTerminal.backToBoard": "Back to Board",
 	"projectTerminal.shortcutHint": "\u2318`",
 	"projectTerminal.tooltipWithShortcut": "Project Terminal (\u2318`)",
+
+	// Home Terminal
+	"homeTerminal.open": "Home Terminal",
+	"homeTerminal.label": "Home Terminal",
+	"homeTerminal.tooltipWithShortcut": "Home Terminal (\u2318\u21e7`)",
+	"homeTerminal.shortcutHint": "\u2318\u21e7`",
+	"homeTerminal.back": "Back",
+	"homeTerminal.sessionEnded": "Home terminal session ended",
+	"homeTerminal.sessionEndedDesc": "The terminal process has exited. Click restart to open a new session.",
+	"homeTerminal.restart": "Restart",
 	"fileDrop.uploadFailed": "File upload failed: {error}",
 } as const;
 

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -190,6 +190,8 @@ const tips = {
 	"tip.projectTerminal.body": "Need a quick shell at the repo root? Click the Terminal button in the header or press \u2318` to toggle it from any project screen.",
 	"tip.projectTerminalDashboard.title": "Terminal from Dashboard",
 	"tip.projectTerminalDashboard.body": "You can also open a project terminal straight from the Dashboard — click the terminal icon on any project card.",
+	"tip.homeTerminal.title": "Home Terminal",
+	"tip.homeTerminal.body": "Need a project-free shell? Click the home-shaped icon in the header or press ⌘⇧` to open a 2×2 tmux grid in your home directory.",
 	"tip.activityProjectActions.title": "Project actions in Activity",
 	"tip.activityProjectActions.body": "Use the Activity row buttons to open project settings, the repo folder, or the project terminal directly.",
 	"tip.addProjectMenu.title": "Add projects from the menu",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -81,8 +81,18 @@ const terminal = {
 	"projectTerminal.restart": "Reiniciar",
 	"projectTerminal.label": "Terminal del proyecto",
 	"projectTerminal.backToBoard": "Volver al tablero",
-	"projectTerminal.shortcutHint": "\u2318`",
-	"projectTerminal.tooltipWithShortcut": "Terminal del proyecto (\u2318`)",
+	"projectTerminal.shortcutHint": "⌘`",
+	"projectTerminal.tooltipWithShortcut": "Terminal del proyecto (⌘`)",
+
+	// Home Terminal
+	"homeTerminal.open": "Terminal de inicio",
+	"homeTerminal.label": "Terminal de inicio",
+	"homeTerminal.tooltipWithShortcut": "Terminal de inicio (⌘⇧`)",
+	"homeTerminal.shortcutHint": "⌘⇧`",
+	"homeTerminal.back": "Volver",
+	"homeTerminal.sessionEnded": "Sesión del terminal de inicio finalizada",
+	"homeTerminal.sessionEndedDesc": "El proceso del terminal ha terminado. Haz clic en reiniciar para abrir una nueva sesión.",
+	"homeTerminal.restart": "Reiniciar",
 	"fileDrop.uploadFailed": "Error al subir el archivo: {error}",
 };
 

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -190,6 +190,8 @@ const tips = {
 	"tip.projectTerminal.body": "¿Necesitas un shell rápido en la raíz del repo? Haz clic en el botón Terminal en el encabezado o presiona \u2318` para alternarlo desde cualquier pantalla del proyecto.",
 	"tip.projectTerminalDashboard.title": "Terminal desde el Dashboard",
 	"tip.projectTerminalDashboard.body": "También puedes abrir el terminal del proyecto directamente desde el Dashboard — haz clic en el icono de terminal de cualquier tarjeta de proyecto.",
+	"tip.homeTerminal.title": "Terminal de inicio",
+	"tip.homeTerminal.body": "¿Necesitas un shell sin proyecto? Haz clic en el icono de casa en el encabezado o pulsa ⌘⇧` para abrir una cuadrícula tmux 2×2 en tu directorio home.",
 	"tip.activityProjectActions.title": "Acciones del proyecto en Activity",
 	"tip.activityProjectActions.body": "Usa los botones de la fila Activity para abrir ajustes del proyecto, la carpeta del repo o el terminal del proyecto.",
 	"tip.addProjectMenu.title": "Agrega proyectos desde el menú",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -85,8 +85,18 @@ const terminal = {
 	"projectTerminal.restart": "Перезапустить",
 	"projectTerminal.label": "Терминал проекта",
 	"projectTerminal.backToBoard": "Назад к доске",
-	"projectTerminal.shortcutHint": "\u2318`",
-	"projectTerminal.tooltipWithShortcut": "Терминал проекта (\u2318`)",
+	"projectTerminal.shortcutHint": "⌘`",
+	"projectTerminal.tooltipWithShortcut": "Терминал проекта (⌘`)",
+
+	// Home Terminal
+	"homeTerminal.open": "Домашний терминал",
+	"homeTerminal.label": "Домашний терминал",
+	"homeTerminal.tooltipWithShortcut": "Домашний терминал (⌘⇧`)",
+	"homeTerminal.shortcutHint": "⌘⇧`",
+	"homeTerminal.back": "Назад",
+	"homeTerminal.sessionEnded": "Сессия домашнего терминала завершена",
+	"homeTerminal.sessionEndedDesc": "Процесс терминала завершился. Нажмите «Перезапустить» для новой сессии.",
+	"homeTerminal.restart": "Перезапустить",
 	"fileDrop.uploadFailed": "Ошибка загрузки файла: {error}",
 };
 

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -190,6 +190,8 @@ const tips = {
 	"tip.projectTerminal.body": "Нужен быстрый shell в корне репо? Нажми кнопку Terminal в шапке или \u2318` для переключения с любого экрана проекта.",
 	"tip.projectTerminalDashboard.title": "Терминал с дашборда",
 	"tip.projectTerminalDashboard.body": "Терминал проекта можно открыть прямо с Dashboard — нажми иконку терминала на карточке проекта.",
+	"tip.homeTerminal.title": "Домашний терминал",
+	"tip.homeTerminal.body": "Нужен shell без привязки к проекту? Нажми иконку домика в шапке или ⌘⇧` — откроется tmux-сетка 2×2 в твоём home-каталоге.",
 	"tip.activityProjectActions.title": "Действия проекта в Activity",
 	"tip.activityProjectActions.body": "Кнопки в строке Activity сразу открывают настройки проекта, папку репо или терминал проекта.",
 	"tip.addProjectMenu.title": "Добавление проекта через меню",

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -7,6 +7,7 @@ export type Route =
 	| { screen: "dashboard" }
 	| { screen: "project"; projectId: string; activeTaskId?: string }
 	| { screen: "project-terminal"; projectId: string }
+	| { screen: "home-terminal" }
 	| { screen: "task"; projectId: string; taskId: string }
 	| { screen: "project-settings"; projectId: string; tab?: "global" | "project" | "worktree"; worktreeTaskId?: string }
 	| { screen: "settings" }

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -591,6 +591,12 @@ const ALL_TIPS: Tip[] = [
 		icon: "\u{F0489}", // nf-md-console
 	},
 	{
+		id: "home-terminal",
+		titleKey: "tip.homeTerminal.title",
+		bodyKey: "tip.homeTerminal.body",
+		icon: "\u{F02DC}", // nf-md-home
+	},
+	{
 		id: "activity-project-actions",
 		titleKey: "tip.activityProjectActions.title",
 		bodyKey: "tip.activityProjectActions.body",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -803,6 +803,7 @@ export interface TmuxSessionInfo {
 	windowCount: number;
 	isCleanup: boolean;
 	isProjectTerminal?: boolean;
+	isHomeTerminal?: boolean;
 	projectName?: string;
 	taskTitle?: string;
 	taskId?: string;
@@ -1087,6 +1088,14 @@ export type AppRPCSchema = {
 				params: { projectId: string };
 				response: void;
 			};
+			getHomePtyUrl: {
+				params: {};
+				response: string;
+			};
+			destroyHomeTerminal: {
+				params: {};
+				response: void;
+			};
 			runDevServer: {
 				params: { taskId: string; projectId: string };
 				response: DevServerStatus;
@@ -1364,6 +1373,7 @@ export type AppRPCSchema = {
 			taskSound: { status: "completed" | "cancelled" };
 			ptyDied: { taskId: string };
 			projectPtyDied: { projectId: string };
+			homePtyDied: {};
 			terminalBell: { taskId: string };
 			gitOpCompleted: { taskId: string; projectId: string; operation: string; ok: boolean };
 			updateAvailable: { version: string };


### PR DESCRIPTION
## Summary

Adds **Home Terminal** — a global terminal that mirrors the Project Terminal layout (4-pane tiled tmux session) but is not tied to any project. It opens in the user's home directory and is reachable from any screen via a header button (custom house-with-prompt icon) or the `Cmd+Shift+\`` shortcut.

The motivation: until now you needed a project context to get a terminal inside dev-3.0 — sometimes you just want a scratch shell with the same 2×2 tmux comfort, in `$HOME`, no strings attached.

## What's in the change

- **Backend**: extend `PtySessionType` with `"home"`, reuse the existing 2×2 tiled layout (renamed `setupProjectLayout` → `setupTiledLayout` to reflect both project and home terminals), add `getHomePtyUrl` / `destroyHomeTerminal` RPC handlers and a `homePtyDied` push event. Singleton tmux session named `dev3-home`, cleanly skipped by bell/idle/dev-server logic.
- **Frontend**: new `home-terminal` route + `HomeTerminal.tsx` component, custom `HomeTerminalIcon.tsx` (house silhouette with a `>_` prompt cut into the doorway), always-visible Global Header button, and the `Cmd+Shift+\`` toggle from anywhere. Escape and back behaviors mirror Project Terminal.
- **TerminalView**: image paste is now skipped when `projectId` is empty so the home terminal cleanly degrades (file-drop already no-ops on empty `projectId`).
- **i18n**: keys for `en` / `ru` / `es` plus a "Did you know?" tip.
- **Tests**: 4 new unit tests on `getHomePtyUrl` / `destroyHomeTerminal`. All `bun run lint` / `bun run test` green (1080 bun + 1101 mainview).

## Notes

- The `dev3-home` tmux session is shown in the Tmux Session Manager and reuses the same kill/refresh flow.
- The shortcut `Cmd+Shift+\`` was chosen so it doesn't collide with the existing Project Terminal `Cmd+\``.
- No on-disk layout changes (`~/.dev3.0/` invariants intact).