### PR TITLE
fix(ci): BSD tar compatibility + bump deprecated Node 20 actions

### DIFF
--- a/scripts/create-cli-tarball.sh
+++ b/scripts/create-cli-tarball.sh
@@ -50,14 +50,11 @@ cp ./dist/index.html "$STAGE_DIR/dist/"
 [ -d ./dist/assets ] && cp -r ./dist/assets "$STAGE_DIR/dist/assets"
 
 # Pack contents (no leading ./dev3-cli/ wrapper — extracts straight into CWD).
-# `--sort=name` + fixed `--mtime`/`--owner`/`--group` keeps the tarball
-# deterministic-ish across CI runs (gzip itself still embeds OS and timestamp).
-tar -C "$STAGE_DIR" \
-    --sort=name \
-    --owner=0 --group=0 --numeric-owner \
-    --mtime='2026-01-01 00:00:00 UTC' \
-    -czf "$TARBALL" \
-    .
+# Plain `tar czf` — works on both GNU tar (Linux) and BSD tar (macOS).
+# We deliberately don't use --sort=name / --mtime / --owner / --group: they're
+# GNU-only and macOS runners ship BSD tar. The Formula updater hashes the same
+# tarball it just produced, so per-run reproducibility doesn't matter here.
+tar -C "$STAGE_DIR" -czf "$TARBALL" .
 
 ls -lh "$TARBALL"
 echo "SHA-256: $(shasum -a 256 "$TARBALL" | awk '{print $1}')"


### PR DESCRIPTION
## Summary

Hi, this is Claude (the AI assistant working on this branch).

Two CI fixes in the same neighbourhood, surfaced by the v1.11.2 release run:

### 1. `create-cli-tarball.sh` — BSD tar compatibility (caused `build-macos-arm64` to fail)

`build-macos-arm64` in v1.11.2 died with:

```
=== Creating CLI tarball for macos-arm64 ===
tar: Option --sort=name is not supported
```

The script was using GNU-only flags (`--sort=name`, `--owner`, `--group`, `--numeric-owner`, `--mtime=...`) for tarball reproducibility. macOS runners ship BSD tar, which doesn't accept any of those — Linux passed because it has GNU tar.

Switched to plain `tar czf`. The reproducibility flags weren't load-bearing: the Formula updater hashes the same tarball it just produced, so per-run determinism wasn't needed in the first place.

### 2. Bump Node 20 actions to Node 24 (`prepare` job annotation)

GitHub started annotating runs with: *"Node.js 20 actions are deprecated. Actions will be forced to Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026."*

Bumped every pinned action that ships a Node 20 runtime:

- `actions/checkout@v4` → `@v5`
- `actions/cache/restore@v4` → `@v5`
- `actions/cache/save@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v5`
- `actions/download-artifact@v4` → `@v5`
- `actions/github-script@v7` → `@v8`

`oven-sh/setup-bun@v2` and `aquasecurity/trivy-action@master` aren't on Node 20, left untouched.

After this lands, retag (e.g. `v1.11.3`) to redrive the publish flow — Linux S3 already has the v1.11.2 tarball; macOS arm64/x64 + Formula update will go through cleanly on the next tag.