### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 (@v5 / @v8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -20,7 +20,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -45,7 +45,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -54,7 +54,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -79,7 +79,7 @@ jobs:
   build-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -88,7 +88,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -116,7 +116,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -134,7 +134,7 @@ jobs:
 
       - name: Post Trivy results to PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine version tag
         id: version
@@ -32,7 +32,7 @@ jobs:
     needs: prepare
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -41,7 +41,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-macos-arm64-${{ hashFiles('bun.lock') }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-macos-arm64-${{ hashFiles('bun.lock') }}
@@ -124,7 +124,7 @@ jobs:
             --exclude "*.dmg" --exclude "*Setup*.tar.gz" --exclude "dev3-cli-*.tar.gz"
 
       - name: Upload artifacts for release job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-macos-arm64
           path: ./artifacts-macos-arm64/
@@ -133,7 +133,7 @@ jobs:
     needs: prepare
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -142,7 +142,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-macos-x64-${{ hashFiles('bun.lock') }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-macos-x64-${{ hashFiles('bun.lock') }}
@@ -225,7 +225,7 @@ jobs:
             --exclude "*.dmg" --exclude "*Setup*.tar.gz" --exclude "dev3-cli-*.tar.gz"
 
       - name: Upload artifacts for release job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-macos-x64
           path: ./artifacts-macos-x64/
@@ -234,7 +234,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -252,7 +252,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-deps
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -263,7 +263,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./node_modules
           key: bun-deps-linux-x64-${{ hashFiles('bun.lock') }}
@@ -308,7 +308,7 @@ jobs:
             --exclude "*.dmg" --exclude "*Setup*.tar.gz" --exclude "dev3-cli-*.tar.gz"
 
       - name: Upload artifacts for release job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-linux-x64
           path: ./artifacts-linux-x64/
@@ -320,10 +320,10 @@ jobs:
     needs: [prepare, build-macos-arm64, build-macos-x64, build-linux-x64]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: all-artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

Hi, this is Claude (the AI assistant working on this branch).

GitHub started annotating workflow runs with: *"Node.js 20 actions are deprecated. Actions will be forced to Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026."* Visible on the v1.11.2 release run's `prepare` job.

Bumped every pinned action that ships a Node 20 runtime:

- `actions/checkout@v4` → `@v5`
- `actions/cache/restore@v4` → `@v5`
- `actions/cache/save@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v5`
- `actions/download-artifact@v4` → `@v5`
- `actions/github-script@v7` → `@v8`

`oven-sh/setup-bun@v2` and `aquasecurity/trivy-action@master` aren't on Node 20, so they're untouched. No functional changes — same inputs, same step semantics, just a newer Node runtime under the hood.

This is a leftover from PR #525, which got squash-merged before this commit was pushed. Splitting into its own PR.