### PR TITLE
chore(agents): NO_FLICKER env + fix Plan preset --dangerously-skip

### DIFF
--- a/change-logs/2026/05/02/chore-claude-no-flicker-env.md
+++ b/change-logs/2026/05/02/chore-claude-no-flicker-env.md
@@ -1,0 +1,1 @@
+Inject `CLAUDE_CODE_NO_FLICKER=1` into all Claude-based agent presets via `CLAUDE_DEFAULT_ENV`, so every Claude launch (Default, Plan, Bypass, Auto, Accept Edits, Don't Ask — Opus and Sonnet variants) inherits the flag automatically.

--- a/change-logs/2026/05/02/chore-claude-no-flicker-env.md
+++ b/change-logs/2026/05/02/chore-claude-no-flicker-env.md
@@ -1,1 +1,3 @@
 Inject `CLAUDE_CODE_NO_FLICKER=1` into all Claude-based agent presets via `CLAUDE_DEFAULT_ENV`, so every Claude launch (Default, Plan, Bypass, Auto, Accept Edits, Don't Ask — Opus and Sonnet variants) inherits the flag automatically.
+
+Also fix the Plan presets: replace `--dangerously-skip-permissions` with `--allow-dangerously-skip-permissions` for `claude-plan` / `claude-plan-sonnet`, since auto-bypassing all permission checks defeats Plan mode's approve-the-plan gate. The `--allow-` variant keeps the flag *available* for the user to flip on demand without enabling it by default.

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -467,6 +467,7 @@ export function findConfig(
 /** Default env vars injected for Claude-based agents. */
 export const CLAUDE_DEFAULT_ENV: Record<string, string> = {
 	CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1",
+	CLAUDE_CODE_NO_FLICKER: "1",
 };
 
 /** Build default env vars for an agent based on its base command. */

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -1103,6 +1103,7 @@ describe("getDefaultEnvForAgent", () => {
 		const env = getDefaultEnvForAgent(agent);
 		expect(env).toEqual(CLAUDE_DEFAULT_ENV);
 		expect(env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe("1");
+		expect(env.CLAUDE_CODE_NO_FLICKER).toBe("1");
 	});
 
 	it("returns CLAUDE_DEFAULT_ENV for full-path claude command", () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -168,8 +168,8 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		configurations: [
 			{ id: "claude-default", name: "Default (Opus 4.7)", additionalArgs: ["--dangerously-skip-permissions"], version: 4 },
 			{ id: "claude-default-sonnet", name: "Default (Sonnet)", model: "sonnet", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-plan", name: "Plan (Opus 4.7)", permissionMode: "plan", additionalArgs: ["--dangerously-skip-permissions"], version: 4 },
-			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-plan", name: "Plan (Opus 4.7)", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-bypass", name: "Bypass (Opus 4.7)", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 4 },
 			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-auto", name: "Auto (Opus 4.7)", permissionMode: "auto", version: 4 },


### PR DESCRIPTION
## Summary

- **`CLAUDE_CODE_NO_FLICKER=1` for all Claude presets**: added to `CLAUDE_DEFAULT_ENV` in `src/bun/agents.ts`, so every Claude-based preset (Default / Plan / Bypass / Auto / Accept Edits / Don't Ask — Opus + Sonnet) inherits the flag automatically. Per-config `envVars` overrides still win; non-Claude agents are unaffected.
- **Plan preset bug fix**: `claude-plan` / `claude-plan-sonnet` were launched with `--permission-mode plan` together with `--dangerously-skip-permissions`. The latter bypasses ALL permission checks and defeats Plan mode's approve-the-plan gate, so the preset effectively did not operate in Plan mode. Switched both to `--allow-dangerously-skip-permissions` (the flag is available for the user to enable on demand but is not on by default). Bumped preset versions (5 / 2) so existing stored user copies pick up the new default via `mergeWithDefaults`.