### PR TITLE
fix: unify Cmd+N to a single New Task dialog (with Scratch button)

### DIFF
--- a/change-logs/2026/05/03/fix-cmd-n-duplicate-dialog.md
+++ b/change-logs/2026/05/03/fix-cmd-n-duplicate-dialog.md
@@ -1,0 +1,1 @@
+Cmd+N now opens the same New Task dialog everywhere (with Scratch + Save & Start buttons), regardless of whether the user is on the Kanban board or inside a task. Removed the duplicate CreateTaskModal instance from KanbanBoard and made the "+" button route through the same App-level modal.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -3,7 +3,7 @@ import { useAppState, type Route } from "./state";
 import { api } from "./rpc";
 import { useT } from "./i18n";
 import { trackPageView, trackEvent } from "./analytics";
-import type { RequirementCheckResult } from "../shared/types";
+import type { CodingAgent, GlobalSettings as GlobalSettingsType, Project, RequirementCheckResult, Task, TaskStatus } from "../shared/types";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
@@ -12,6 +12,7 @@ import GlobalSettings from "./components/GlobalSettings";
 import Dashboard from "./components/Dashboard";
 import AddProjectModal from "./components/AddProjectModal";
 import CreateTaskModal from "./components/CreateTaskModal";
+import LaunchVariantsModal from "./components/LaunchVariantsModal";
 import ProjectView from "./components/ProjectView";
 import TaskWorkspaceView from "./components/TaskWorkspaceView";
 import ProjectTerminal from "./components/ProjectTerminal";
@@ -59,6 +60,14 @@ function App() {
 	const [showAddProjectModal, setShowAddProjectModal] = useState(false);
 	const [openAddProjectOnDashboard, setOpenAddProjectOnDashboard] = useState(false);
 	const [createTaskProjectId, setCreateTaskProjectId] = useState<string | null>(null);
+	const [launchModal, setLaunchModal] = useState<{ task: Task; targetStatus: TaskStatus; project: Project } | null>(null);
+	const [agents, setAgents] = useState<CodingAgent[]>([]);
+	const [globalSettings, setGlobalSettings] = useState<GlobalSettingsType>({
+		defaultAgentId: "builtin-claude",
+		defaultConfigId: "claude-default",
+		taskDropPosition: "top",
+		updateChannel: "stable",
+	});
 
 	// Auth failure for browser remote access (expired/invalid QR token)
 	const [authFailed, setAuthFailed] = useState(false);
@@ -484,6 +493,16 @@ function App() {
 		return () => window.removeEventListener("rpc:openCreateTaskModal", onOpenCreateTaskModal);
 	}, [openCreateTaskModal]);
 
+	// Load agents + global settings the first time the create-task modal opens.
+	// Needed by the LaunchVariantsModal that follows "Create & Run" / "Scratch".
+	const agentsLoadedRef = useRef(false);
+	useEffect(() => {
+		if (!createTaskProjectId || agentsLoadedRef.current) return;
+		agentsLoadedRef.current = true;
+		api.request.getAgents().then(setAgents).catch(() => {});
+		api.request.getGlobalSettings().then(setGlobalSettings).catch(() => {});
+	}, [createTaskProjectId]);
+
 	useEffect(() => {
 		function onOpenAddProjectModal() {
 			openAddProject();
@@ -667,6 +686,21 @@ function App() {
 					project={createTaskProject}
 					dispatch={dispatch}
 					onClose={() => setCreateTaskProjectId(null)}
+					onCreateAndRun={(task) => {
+						setCreateTaskProjectId(null);
+						setLaunchModal({ task, targetStatus: "in-progress", project: createTaskProject });
+					}}
+				/>
+			)}
+			{launchModal && (
+				<LaunchVariantsModal
+					task={launchModal.task}
+					project={launchModal.project}
+					targetStatus={launchModal.targetStatus}
+					agents={agents}
+					globalSettings={globalSettings}
+					dispatch={dispatch}
+					onClose={() => setLaunchModal(null)}
 				/>
 			)}
 			{pendingNavigation && (

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -15,6 +15,13 @@ vi.mock("../rpc", () => ({
 			listTmuxSessions: vi.fn().mockResolvedValue([]),
 			getProjectCurrentBranch: vi.fn().mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false }),
 			pullProjectMain: vi.fn(),
+			getAgents: vi.fn().mockResolvedValue([]),
+			getGlobalSettings: vi.fn().mockResolvedValue({
+				defaultAgentId: "builtin-claude",
+				defaultConfigId: "claude-default",
+				taskDropPosition: "top",
+				updateChannel: "stable",
+			}),
 		},
 	},
 }));
@@ -264,6 +271,25 @@ describe("App keyboard shortcuts", () => {
 			await userEvent.keyboard("{Meta>}n{/Meta}");
 
 			expect(await screen.findByText("New Task")).toBeInTheDocument();
+		});
+
+		it("Cmd+N from a task shows the Scratch button (same dialog as Kanban)", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}n{/Meta}");
+
+			expect(await screen.findByText("New Task")).toBeInTheDocument();
+			// Scratch + Save & Start are the markers that onCreateAndRun was passed
+			expect(await screen.findByText("Scratch Task")).toBeInTheDocument();
+			expect(await screen.findByText("Save & Start")).toBeInTheDocument();
 		});
 
 		it("opens from the full task screen when rpc:openCreateTaskModal fires", async () => {

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -15,7 +15,6 @@ import { useT, statusKey, statusDescKey } from "../i18n";
 import { api } from "../rpc";
 import { trackEvent } from "../analytics";
 import KanbanColumn from "./KanbanColumn";
-import CreateTaskModal from "./CreateTaskModal";
 import LaunchVariantsModal from "./LaunchVariantsModal";
 import { sortTasksForColumn } from "./sortTasks";
 import LabelFilterBar from "./LabelFilterBar";
@@ -50,7 +49,6 @@ function KanbanBoard({
 	disableGlobalFindShortcut = false,
 }: KanbanBoardProps) {
 	const t = useT();
-	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const [globalSettings, setGlobalSettings] = useState<GlobalSettings>({
 		defaultAgentId: "builtin-claude",
@@ -521,7 +519,7 @@ function KanbanBoard({
 						project,
 						dispatch,
 						navigate,
-						onAddTask: () => setShowCreateModal(true),
+						onAddTask: () => window.dispatchEvent(new CustomEvent("rpc:openCreateTaskModal")),
 						agents,
 						onLaunchVariants: (task: Task, targetStatus: TaskStatus) =>
 							setLaunchModal({ task, targetStatus }),
@@ -587,18 +585,6 @@ function KanbanBoard({
 					);
 				})}
 			</div>
-
-			{showCreateModal && (
-				<CreateTaskModal
-					project={project}
-					dispatch={dispatch}
-					onClose={() => setShowCreateModal(false)}
-					onCreateAndRun={(task) => {
-						setShowCreateModal(false);
-						setLaunchModal({ task, targetStatus: "in-progress" });
-					}}
-				/>
-			)}
 
 			{launchModal && (
 				<LaunchVariantsModal


### PR DESCRIPTION
## Summary

Cmd+N opened a different modal than the Kanban "+ New Task" button: the App-level CreateTaskModal had no `onCreateAndRun`, so the **Scratch Task** and **Save & Start** buttons were missing — most visible when pressing Cmd+N from inside a task.

Lifted the New Task flow to `App.tsx` as the single owner: it now passes `onCreateAndRun` and renders `LaunchVariantsModal`. Removed the duplicate `<CreateTaskModal>` instance from `KanbanBoard`; the "+" button there now dispatches `rpc:openCreateTaskModal` so both paths render the same modal once.

— Hi, this is Claude (the AI assistant working on this PR).