### PR TITLE
Fix terminal button order

### DIFF
--- a/change-logs/2026/05/05/fix-terminal-button-order.md
+++ b/change-logs/2026/05/05/fix-terminal-button-order.md
@@ -1,0 +1,1 @@
+Swap the Home Terminal and Project Terminal buttons in the global header so Home Terminal appears first and Project Terminal sits to its right.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -405,6 +405,26 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 					</div>
 				)}
 
+				{/* Home Terminal — always visible (rootless tmux in $HOME) */}
+				<button
+					onClick={() => {
+						if (route.screen === "home-terminal") {
+							navigate({ screen: "dashboard" });
+						} else {
+							navigate({ screen: "home-terminal" });
+						}
+					}}
+					className={`flex items-center gap-1 transition-colors px-2 py-1 rounded-lg ${
+						route.screen === "home-terminal"
+							? "text-accent bg-accent/15 hover:bg-accent/25"
+							: "text-fg-3 hover:text-fg hover:bg-elevated"
+					}`}
+					title={t("homeTerminal.tooltipWithShortcut")}
+				>
+					<HomeTerminalIcon className="w-[1.125rem] h-[1.125rem]" />
+					<span className="text-[0.6875rem] font-medium">{t("homeTerminal.open")}</span>
+				</button>
+
 				{/* Project Terminal — visible when inside a project */}
 				{"projectId" in route && (
 					<button
@@ -431,26 +451,6 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 						<span className="text-[0.6875rem] font-medium">{t("projectTerminal.open")}</span>
 					</button>
 				)}
-
-				{/* Home Terminal — always visible (rootless tmux in $HOME) */}
-				<button
-					onClick={() => {
-						if (route.screen === "home-terminal") {
-							navigate({ screen: "dashboard" });
-						} else {
-							navigate({ screen: "home-terminal" });
-						}
-					}}
-					className={`flex items-center gap-1 transition-colors px-2 py-1 rounded-lg ${
-						route.screen === "home-terminal"
-							? "text-accent bg-accent/15 hover:bg-accent/25"
-							: "text-fg-3 hover:text-fg hover:bg-elevated"
-					}`}
-					title={t("homeTerminal.tooltipWithShortcut")}
-				>
-					<HomeTerminalIcon className="w-[1.125rem] h-[1.125rem]" />
-					<span className="text-[0.6875rem] font-medium">{t("homeTerminal.open")}</span>
-				</button>
 
 				{/* Git Pull — quick pull of origin/{main|master} into project main worktree */}
 				{"projectId" in route && (

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -521,6 +521,17 @@ describe("GlobalHeader — project terminal button", () => {
 		expect(screen.getByText("Project Terminal")).toBeInTheDocument();
 	});
 
+	it("shows home terminal before project terminal", () => {
+		renderHeader({ screen: "project", projectId: "p1" });
+
+		const homeButton = screen.getByTitle("Home Terminal (\u2318\u21e7`)");
+		const projectButton = screen.getByTitle("Project Terminal (\u2318`)");
+
+		expect(
+			homeButton.compareDocumentPosition(projectButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
 	it("does not show terminal button on dashboard", () => {
 		renderHeader({ screen: "dashboard" });
 		expect(screen.queryByText("Project Terminal")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Move Home Terminal before Project Terminal in the global header.
- Add a regression test for the terminal button DOM order.
- Add changelog entry.

## Tests
- bunx vitest run src/mainview/components/__tests__/GlobalHeader.test.tsx --testNamePattern "shows home terminal before project terminal"
- bun run lint
- bun run test