### PR TITLE
Fix long terminal selection copy

### DIFF
--- a/change-logs/2026/05/05/fix-terminal-long-selection-copy.md
+++ b/change-logs/2026/05/05/fix-terminal-long-selection-copy.md
@@ -1,0 +1,1 @@
+Fixed terminal clipboard handling for long drag selections, including Home Terminal selections that scroll beyond one screen. OSC 52 clipboard payloads are now buffered across PTY chunks before decoding, and native ghostty selections also use a backend clipboard bridge on desktop.

--- a/decisions/046-stream-osc52-clipboard.md
+++ b/decisions/046-stream-osc52-clipboard.md
@@ -1,0 +1,21 @@
+# 046 — Buffer OSC 52 clipboard sequences across PTY chunks
+
+## Context
+
+Long terminal selections can produce OSC 52 clipboard payloads that are larger than a single PTY data chunk. `pty-server.ts` previously parsed OSC 52 with a per-chunk regex, so split payloads were forwarded as ordinary terminal output and never reached the clipboard callback.
+
+## Investigation
+
+Short selections worked because tmux emitted the complete OSC 52 sequence in one callback. Drag-selecting through scrollback, especially in Home Terminal, made the base64 payload large enough to split before the BEL/ST terminator, so `handleOsc52` saw only fragments.
+
+## Decision
+
+`src/bun/pty-server.ts` now keeps a per-session `osc52Buffer`, waits until a full OSC 52 sequence is available, then decodes it and strips it from the output stream. `src/mainview/TerminalView.tsx` also sends native ghostty selections through a backend clipboard RPC so WKWebView clipboard permission quirks are not the only copy path.
+
+## Risks
+
+Malformed OSC 52 sequences without a terminator stay buffered until more PTY data arrives. This mirrors the existing UTF-8 streaming decoder trade-off: correctness for split control sequences is more important than immediately flushing a broken sequence to the terminal.
+
+## Alternatives considered
+
+Re-adding tmux `copy-pipe-and-cancel "pbcopy"` bindings was rejected because it duplicates the server-side clipboard abstraction and is macOS-specific. Relying only on `navigator.clipboard.writeText()` was also rejected because Electrobun's WKWebView can reject it outside a direct user activation.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -655,6 +655,30 @@ describe("pty-server", () => {
 			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 
+		it("emits OSC 52 clipboard data split across PTY chunks", () => {
+			const id = track("task-osc52-split");
+			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
+			const osc52Cb = vi.fn();
+			setOnOsc52Copy(osc52Cb);
+
+			const testText = `${"long clipboard line\n".repeat(200)}done`;
+			const b64 = Buffer.from(testText).toString("base64");
+			const osc52Seq = `\x1b]52;c;${b64}\x07`;
+			const splitAt = 120;
+
+			mockSpawn.mockClear();
+
+			capturedDataCb!(null, osc52Seq.slice(0, splitAt));
+			capturedDataCb!(null, osc52Seq.slice(splitAt));
+
+			expect(osc52Cb).toHaveBeenCalledWith({
+				taskId: id,
+				text: testText,
+				len: testText.length,
+			});
+			expect(mockSpawn).not.toHaveBeenCalled();
+		});
+
 		it("ignores OSC 52 query (b64 is '?')", () => {
 			const id = track("task-osc52-02");
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -104,6 +104,10 @@ vi.mock("../pty-server", () => ({
 	HOME_TERMINAL_TMUX_NAME: "dev3-home",
 }));
 
+vi.mock("../system-clipboard", () => ({
+	writeSystemClipboard: vi.fn(() => "pbcopy"),
+}));
+
 vi.mock("../agents", () => ({
 	ensureClaudeTrust: vi.fn(),
 	ensureCodexTrust: vi.fn(),
@@ -198,6 +202,7 @@ import * as data from "../data";
 import * as git from "../git";
 import * as github from "../github";
 import * as pty from "../pty-server";
+import * as systemClipboard from "../system-clipboard";
 import * as agents from "../agents";
 import * as updater from "../updater";
 import { setupAgentHooks } from "../agent-hooks";
@@ -3386,6 +3391,39 @@ describe("handlers.showConfirm", () => {
 		vi.mocked(Utils.showMessageBox).mockResolvedValue({ response: 1 } as any);
 		const result = await handlers.showConfirm({ title: "Confirm", message: "Are you sure?" });
 		expect(result).toBe(false);
+	});
+});
+
+describe("handlers.copyTerminalSelection", () => {
+	beforeEach(() => {
+		vi.mocked(systemClipboard.writeSystemClipboard).mockReset();
+		vi.mocked(systemClipboard.writeSystemClipboard).mockReturnValue("pbcopy");
+		delete process.env.DEV3_HEADLESS;
+	});
+
+	it("writes terminal selections through the system clipboard helper", async () => {
+		const result = await handlers.copyTerminalSelection({
+			taskId: "home",
+			text: "selected terminal text",
+			mouseTracking: false,
+		});
+
+		expect(systemClipboard.writeSystemClipboard).toHaveBeenCalledWith("selected terminal text");
+		expect(result).toEqual({ ok: true, tool: "pbcopy" });
+	});
+
+	it("does not write host clipboard from headless mode", async () => {
+		process.env.DEV3_HEADLESS = "1";
+
+		const result = await handlers.copyTerminalSelection({
+			taskId: "home",
+			text: "remote browser text",
+			mouseTracking: false,
+		});
+
+		expect(systemClipboard.writeSystemClipboard).not.toHaveBeenCalled();
+		expect(result).toEqual({ ok: false, tool: null });
+		delete process.env.DEV3_HEADLESS;
 	});
 });
 

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -206,6 +206,8 @@ interface PtySession {
 	pendingData: string;
 	/** Timer handle for the batch flush interval. */
 	batchTimer: ReturnType<typeof setTimeout> | null;
+	/** Partial OSC 52 clipboard sequence buffered across PTY chunks. */
+	osc52Buffer: string;
 }
 
 const sessions = new Map<string, PtySession>();
@@ -275,6 +277,7 @@ export function createSession(
 		decoder: new TextDecoder("utf-8", { fatal: false }),
 		pendingData: "",
 		batchTimer: null,
+		osc52Buffer: "",
 	};
 	sessions.set(taskId, session);
 	// Spawn immediately in the background — don't wait for WS connection
@@ -455,27 +458,75 @@ export function tmuxSessionExists(taskId: string, socket: string = DEFAULT_TMUX_
 	}
 }
 
-const OSC52_RE = /\x1b\]52;[^;]*;([A-Za-z0-9+/=]*)(?:\x07|\x1b\\)/g;
+const OSC52_PREFIX = "\x1b]52;";
+const OSC52_RE = /^\x1b\]52;[^;]*;([A-Za-z0-9+/=]*|\?)(?:\x07|\x1b\\)$/;
 // Matches any OSC sequence terminated by BEL or ST — used to strip them
 // before checking for standalone BEL (\x07)
 const OSC_ANY_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
-function handleOsc52(data: string, taskId: string): string {
-	return data.replace(OSC52_RE, (_match, b64: string) => {
-		if (b64 && b64 !== "?") {
-			try {
-				const text = Buffer.from(b64, "base64").toString("utf-8");
-				onOsc52CopyCallback?.({ taskId, text, len: text.length });
-				log.info("OSC 52: forwarded clipboard payload to client", {
-					taskId: shortId(taskId),
-					len: text.length,
-				});
-			} catch {
-				// ignore
+function findOscTerminator(data: string, start: number): { index: number; length: number } | null {
+	const bel = data.indexOf("\x07", start);
+	const st = data.indexOf("\x1b\\", start);
+	if (bel === -1 && st === -1) return null;
+	if (bel !== -1 && (st === -1 || bel < st)) return { index: bel, length: 1 };
+	return { index: st, length: 2 };
+}
+
+function trailingOsc52PrefixLength(data: string): number {
+	const max = Math.min(OSC52_PREFIX.length - 1, data.length);
+	for (let len = max; len > 0; len--) {
+		if (data.endsWith(OSC52_PREFIX.slice(0, len))) return len;
+	}
+	return 0;
+}
+
+function emitOsc52(seq: string, taskId: string): void {
+	const match = OSC52_RE.exec(seq);
+	const b64 = match?.[1];
+	if (!b64 || b64 === "?") return;
+	try {
+		const text = Buffer.from(b64, "base64").toString("utf-8");
+		onOsc52CopyCallback?.({ taskId, text, len: text.length });
+		log.info("OSC 52: forwarded clipboard payload to client", {
+			taskId: shortId(taskId),
+			len: text.length,
+		});
+	} catch {
+		// ignore malformed clipboard payloads
+	}
+}
+
+function handleOsc52(data: string, session: PtySession): string {
+	let input = session.osc52Buffer + data;
+	session.osc52Buffer = "";
+	let output = "";
+
+	while (input.length > 0) {
+		const start = input.indexOf(OSC52_PREFIX);
+		if (start === -1) {
+			const trailing = trailingOsc52PrefixLength(input);
+			if (trailing > 0) {
+				output += input.slice(0, -trailing);
+				session.osc52Buffer = input.slice(-trailing);
+			} else {
+				output += input;
 			}
+			break;
 		}
-		return "";
-	});
+
+		output += input.slice(0, start);
+		const terminator = findOscTerminator(input, start + OSC52_PREFIX.length);
+		if (!terminator) {
+			session.osc52Buffer = input.slice(start);
+			break;
+		}
+
+		const end = terminator.index + terminator.length;
+		emitOsc52(input.slice(start, end), session.taskId);
+		input = input.slice(end);
+	}
+
+	return output;
 }
 
 function checkForBell(data: string, taskId: string): void {
@@ -632,11 +683,11 @@ function spawnPty(session: PtySession, cols: number, rows: number): void {
 									: session.decoder.decode(data, { stream: true });
 							session.lastOutputTime = Date.now();
 							session.idleNotified = false;
-							checkForBell(str, session.taskId);
-							const cleaned = handleOsc52(str, session.taskId);
-							if (cleaned && session.clients.size > 0) {
-								enqueuePtyData(session, cleaned);
-							}
+								const cleaned = handleOsc52(str, session);
+								checkForBell(cleaned, session.taskId);
+								if (cleaned && session.clients.size > 0) {
+									enqueuePtyData(session, cleaned);
+								}
 						} catch (err) {
 							log.error("PTY data callback error", {
 								taskId: shortId(session.taskId),

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -12,6 +12,7 @@ import { BUNDLED_CHANGELOG } from "../changelog-bundled";
 import * as repoConfig from "../repo-config";
 import { DEV3_HOME } from "../paths";
 import { spawn } from "../spawn";
+import { writeSystemClipboard } from "../system-clipboard";
 import { getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererEvent } from "./shared";
 
 async function quitApp(): Promise<void> {
@@ -619,6 +620,19 @@ async function checkCaffeinateAvailable(): Promise<{ available: boolean }> {
 	return { available };
 }
 
+async function copyTerminalSelection(params: { taskId: string; text: string; mouseTracking: boolean }): Promise<{ ok: boolean; tool: string | null }> {
+	if (!params.text) return { ok: false, tool: null };
+	if (process.env.DEV3_HEADLESS === "1") return { ok: false, tool: null };
+	const tool = writeSystemClipboard(params.text);
+	log.info("terminal selection copied through backend", {
+		taskId: params.taskId.slice(0, 8),
+		len: params.text.length,
+		mouseTracking: params.mouseTracking,
+		tool,
+	});
+	return { ok: Boolean(tool), tool };
+}
+
 export const appHandlers = {
 	logRendererError,
 	// TEMP DIAGNOSTIC: remove with logRendererEvent after terminal copy bug cleanup.
@@ -648,4 +662,5 @@ export const appHandlers = {
 	updateTipState,
 	resetTipState,
 	checkCaffeinateAvailable,
+	copyTerminalSelection,
 };

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -210,6 +210,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 		let ws: WebSocket | null = null;
 		let layoutObserver: ResizeObserver | null = null;
 		let mouseCleanup: (() => void) | undefined;
+		let nativeSelectionClipboardCleanup: (() => void) | undefined;
 		const termSubs: Array<{ dispose(): void }> = [];
 		const diagnosticsId = `terminal-copy-${taskId}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -423,6 +424,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 							fitAddon!.observeResize();
 							term.focus();
 							mouseCleanup = setupMouseTracking(term);
+							nativeSelectionClipboardCleanup = setupNativeSelectionClipboardBridge(term);
 
 							// Fix Shift+functional keys — intercept before
 							// ghostty-web's buggy shortcut swallows the modifier.
@@ -601,6 +603,59 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 			};
 		}
 
+		function setupNativeSelectionClipboardBridge(term: Terminal): () => void {
+			let selectionGestureActive = false;
+
+			function onMouseDown(event: MouseEvent) {
+				if (disposed) return;
+				try {
+					const container = containerRef.current;
+					selectionGestureActive =
+						!!container &&
+						event.target instanceof Node &&
+						container.contains(event.target) &&
+						!term.hasMouseTracking();
+				} catch {
+					selectionGestureActive = false;
+				}
+			}
+
+			function onMouseUp() {
+				if (disposed) return;
+				if (!selectionGestureActive) return;
+				selectionGestureActive = false;
+				queueMicrotask(() => {
+					if (disposed) return;
+					try {
+						const mouseTracking = term.hasMouseTracking();
+						if (mouseTracking || !term.hasSelection()) return;
+						const text = term.getSelection();
+						if (!text) return;
+						copyDiagnosticsRef.current?.markSelection(text.length, mouseTracking);
+						api.request.copyTerminalSelection({
+							taskId,
+							text,
+							mouseTracking,
+						}).catch((err) => {
+							logCopyEvent("warn", "backend terminal selection copy failed", {
+								len: text.length,
+								error: String(err),
+							});
+						});
+					} catch {
+						// Selection bridge is best effort; ghostty may be disposed.
+					}
+				});
+			}
+
+			document.addEventListener("mousedown", onMouseDown);
+			document.addEventListener("mouseup", onMouseUp);
+			return () => {
+				document.removeEventListener("mousedown", onMouseDown);
+				document.removeEventListener("mouseup", onMouseUp);
+			};
+		}
+
 		// Strip any remaining OSC 52 sequences (already handled server-side)
 		const OSC52_RE =
 			/\x1b\]52;[^;]*;[A-Za-z0-9+/=]*(?:\x07|\x1b\\)/g;
@@ -727,6 +782,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 			pendingWrite = "";
 			layoutObserver?.disconnect();
 			mouseCleanup?.();
+			nativeSelectionClipboardCleanup?.();
 			// Dispose terminal event subscriptions (onData, onResize) before
 			// closing the WebSocket or disposing the terminal to prevent
 			// callbacks from firing on a disposed terminal.

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -81,7 +81,14 @@ vi.mock("ghostty-web", () => ({
 }));
 
 vi.mock("../rpc", () => ({
-	api: { request: { uploadFileBase64: vi.fn(), tmuxAction: vi.fn(), logRendererEvent: vi.fn().mockResolvedValue(undefined) } },
+	api: {
+		request: {
+			uploadFileBase64: vi.fn(),
+			tmuxAction: vi.fn(),
+			logRendererEvent: vi.fn().mockResolvedValue(undefined),
+			copyTerminalSelection: vi.fn().mockResolvedValue({ ok: true, tool: "pbcopy" }),
+		},
+	},
 }));
 
 vi.mock("../zoom", () => ({
@@ -317,6 +324,7 @@ describe("TerminalView – focus-on-type", () => {
 
 const mockedTmuxAction = vi.mocked(api.request.tmuxAction);
 const mockedUploadFileBase64 = vi.mocked(api.request.uploadFileBase64);
+const mockedCopyTerminalSelection = vi.mocked(api.request.copyTerminalSelection);
 
 /** Focus a child element inside the terminal container so the keymap guard passes. */
 function focusInsideTerminal(): HTMLElement {
@@ -489,6 +497,49 @@ describe("TerminalView – OSC 52 clipboard", () => {
 		});
 
 		expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("TerminalView – selection clipboard bridge", () => {
+	beforeEach(() => {
+		mockedCopyTerminalSelection.mockClear();
+		mockedCopyTerminalSelection.mockResolvedValue({ ok: true, tool: "pbcopy" });
+	});
+
+	it("copies native terminal selections through the backend on mouseup", async () => {
+		mockTermInstance.hasSelection.mockReturnValue(true);
+		mockTermInstance.getSelection.mockReturnValue("line 1\nline 2\nline 3");
+		mockTermInstance.hasMouseTracking.mockReturnValue(false);
+
+		await renderAndSetup();
+		const terminal = document.querySelector("[data-terminal='true']")!;
+
+		await act(async () => {
+			terminal.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+		});
+
+		expect(mockedCopyTerminalSelection).toHaveBeenCalledWith({
+			text: "line 1\nline 2\nline 3",
+			taskId: "t1",
+			mouseTracking: false,
+		});
+	});
+
+	it("does not use the backend bridge when tmux mouse tracking owns the drag", async () => {
+		mockTermInstance.hasSelection.mockReturnValue(true);
+		mockTermInstance.getSelection.mockReturnValue("tmux-owned selection");
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+
+		await renderAndSetup();
+		const terminal = document.querySelector("[data-terminal='true']")!;
+
+		await act(async () => {
+			terminal.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+		});
+
+		expect(mockedCopyTerminalSelection).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1260,6 +1260,10 @@ export type AppRPCSchema = {
 				params: { taskId: string; action: "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV" };
 				response: void;
 			};
+			copyTerminalSelection: {
+				params: { taskId: string; text: string; mouseTracking: boolean };
+				response: { ok: boolean; tool: string | null };
+			};
 			spawnAgentInTask: {
 				params: { taskId: string; projectId: string; agentId: string | null; configId: string | null };
 				response: void;


### PR DESCRIPTION
## Summary
- Buffer OSC 52 clipboard sequences across PTY chunks so long terminal selections copy reliably.
- Add a desktop backend clipboard bridge for native ghostty selections.
- Document the streaming OSC 52 decision and add a changelog entry.

## Tests
- bun run lint
- bun run test

Note: the first full test run hit unrelated flaky failures in TaskDiffViewer/data tests; rerunning bun run test passed.