### PR TITLE
Fix PyCharm external app defaults

### DIFF
--- a/change-logs/2026/05/06/fix-pycharm-external-app.md
+++ b/change-logs/2026/05/06/fix-pycharm-external-app.md
@@ -1,0 +1,3 @@
+Added PyCharm to the built-in Open In app list and kept incomplete custom External Apps rows visible while their debounced settings save filters them from persistence.
+
+Suggested by @nadavsheinbein (h0x91b/dev-3.0#530)

--- a/change-logs/2026/05/06/fix-pycharm-external-app.md
+++ b/change-logs/2026/05/06/fix-pycharm-external-app.md
@@ -1,3 +1,3 @@
-Added PyCharm to the built-in Open In app list and kept incomplete custom External Apps rows visible while their debounced settings save filters them from persistence.
+Added PyCharm to the built-in Open In app list, kept incomplete custom External Apps rows visible while their debounced settings save filters them from persistence, and fixed file-level Open In menus closing before lower entries can be clicked.
 
 Suggested by @nadavsheinbein (h0x91b/dev-3.0#530)

--- a/src/mainview/__tests__/types.test.ts
+++ b/src/mainview/__tests__/types.test.ts
@@ -9,6 +9,7 @@ import {
 	STATUS_COLORS,
 	STATUS_COLORS_LIGHT,
 	DEFAULT_AGENTS,
+	DEFAULT_EXTERNAL_APPS,
 	getPrimaryStopTarget,
 	LABEL_COLORS,
 } from "../../shared/types";
@@ -325,6 +326,18 @@ describe("DEFAULT_AGENTS", () => {
 		expect(cfg!.additionalArgs).toContain("danger-full-access");
 		expect(cfg!.additionalArgs).toContain('model_reasoning_effort="high"');
 		expect(cfg!.additionalArgs).not.toContain('default_permissions="dev3"');
+	});
+});
+
+// ---- Constants: DEFAULT_EXTERNAL_APPS ----
+
+describe("DEFAULT_EXTERNAL_APPS", () => {
+	it("includes PyCharm as a built-in external app", () => {
+		expect(DEFAULT_EXTERNAL_APPS).toContainEqual({
+			id: "pycharm",
+			name: "PyCharm",
+			macAppName: "PyCharm",
+		});
 	});
 });
 

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -274,17 +274,14 @@ function GlobalSettings() {
 
 	const saveExternalApps = useCallback(
 		(apps: ExternalApp[]) => {
-			persistGlobalSettings(
-				(prev) => ({
-					...prev,
-					externalApps: normalizeExternalApps(apps),
-				}),
-				{
-					onLocalUpdate: () => invalidateAvailableApps(),
-				},
-			);
+			api.request.saveGlobalSettings({
+				...globalSettingsRef.current,
+				externalApps: normalizeExternalApps(apps),
+			}).then(() => {
+				invalidateAvailableApps();
+			}).catch(() => {});
 		},
-		[persistGlobalSettings],
+		[],
 	);
 
 	const debouncedSaveExternalApps = useDebouncedCallback(saveExternalApps, 500);

--- a/src/mainview/components/OpenInMenu.tsx
+++ b/src/mainview/components/OpenInMenu.tsx
@@ -16,6 +16,7 @@ const APP_ICONS: Record<string, string> = {
 	intellij: "\u{F0184}",    // nf-md-diamond_stone (IntelliJ)
 	"intellij-ultimate": "\u{F0184}",
 	"intellij-ce": "\u{F0184}",
+	pycharm: "\u{F0184}",
 	zed: "\u{F0599}",            // nf-md-lightning_bolt (Zed)
 	sublime: "\u{F0CC5}",        // nf-md-text_box (Sublime Text)
 };

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -343,7 +343,6 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, taskResou
 	function hideDiffFilesPopover() {
 		diffFilesHoverTimer.current = setTimeout(() => {
 			setDiffFilesHover(false);
-			setFileOpenInMenu(null);
 		}, 150);
 	}
 

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -129,6 +129,29 @@ describe("GlobalSettings", () => {
 			expect(screen.getByText("ES")).toBeInTheDocument();
 		});
 
+		it("keeps incomplete external app rows visible while saving valid rows only", async () => {
+			const user = userEvent.setup();
+			setupMocks();
+
+			renderGlobalSettings();
+			await waitForLoad();
+
+			await user.click(screen.getByRole("button", { name: /Add App/ }));
+			const displayNameInput = screen.getByPlaceholderText("Display name");
+			await user.type(displayNameInput, "PyCharm");
+
+			expect(displayNameInput).toHaveValue("PyCharm");
+
+			await waitFor(() => {
+				expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalled();
+			});
+			expect(screen.getByDisplayValue("PyCharm")).toBeInTheDocument();
+
+			const saveCalls = mockedApi.request.saveGlobalSettings.mock.calls;
+			const savedSettings = saveCalls[saveCalls.length - 1]?.[0];
+			expect(savedSettings?.externalApps).toBeUndefined();
+		});
+
 		it("renders agent list", async () => {
 			setupMocks();
 			renderGlobalSettings();

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, act, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TaskInfoPanel from "../TaskInfoPanel";
 import { I18nProvider } from "../../i18n";
@@ -27,6 +27,11 @@ vi.mock("../../rpc", () => ({
 			renameTask: vi.fn(),
 			getPortAllocations: vi.fn().mockResolvedValue([]),
 			getGlobalSettings: vi.fn().mockResolvedValue({ defaultAgentId: "builtin-claude", defaultConfigId: "claude-default", taskDropPosition: "top", updateChannel: "stable" }),
+			getAvailableApps: vi.fn().mockResolvedValue([
+				{ id: "finder", name: "Finder", macAppName: "Finder" },
+				{ id: "text-mate", name: "TextMate", macAppName: "TextMate" },
+			]),
+			openInApp: vi.fn().mockResolvedValue(undefined),
 		},
 	},
 }));
@@ -263,6 +268,37 @@ describe("TaskInfoPanel", () => {
 				compareLabel: "origin/main",
 				focusFile: "bun.lock",
 			});
+		});
+
+		it("keeps a file Open In menu open after leaving the changed files popup", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				diffFiles: 1,
+				diffInsertions: 12,
+				diffDeletions: 4,
+				diffFileNames: ["src/mainview/App.tsx"],
+			});
+
+			await act(async () => {
+				renderPanel(makeTask());
+			});
+
+			await user.hover(screen.getByText("1 file").closest("span")!);
+			const changedFilesHeader = await screen.findByText("Changed files");
+			const popover = changedFilesHeader.parentElement!;
+			const fileRow = screen.getByText("src/mainview/App.tsx").closest("div")!;
+			await user.click(within(fileRow).getByRole("button", { name: "Open in..." }));
+
+			expect(screen.getAllByText("Open in...").length).toBeGreaterThanOrEqual(2);
+
+			fireEvent.mouseLeave(popover);
+			await act(async () => {
+				vi.advanceTimersByTime(150);
+			});
+
+			expect(screen.getAllByText("Open in...").length).toBeGreaterThanOrEqual(2);
+			expect(await screen.findByText("TextMate")).toBeInTheDocument();
 		});
 
 		it("skips unknown label IDs", async () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -366,6 +366,7 @@ export const DEFAULT_EXTERNAL_APPS: ExternalApp[] = [
 	{ id: "intellij", name: "IntelliJ", macAppName: "IntelliJ IDEA" },
 	{ id: "intellij-ultimate", name: "IntelliJ", macAppName: "IntelliJ IDEA Ultimate" },
 	{ id: "intellij-ce", name: "IntelliJ", macAppName: "IntelliJ IDEA CE" },
+	{ id: "pycharm", name: "PyCharm", macAppName: "PyCharm" },
 	{ id: "zed", name: "Zed", macAppName: "Zed" },
 	{ id: "sublime", name: "Sublime Text", macAppName: "Sublime Text" },
 ];


### PR DESCRIPTION
## Summary
- add PyCharm to the built-in Open In app list
- keep incomplete custom External Apps rows visible while persisting only valid entries
- keep file-level Open In menus clickable after the changed-files popup closes

Fixes #530.

## Tests
- bunx vitest run src/mainview/components/__tests__/GlobalSettings.test.tsx src/mainview/__tests__/types.test.ts
- bunx vitest run src/mainview/components/__tests__/TaskInfoPanel.test.tsx src/mainview/components/__tests__/OpenInMenu.test.tsx
- bun run lint
- bun run test