### PR TITLE
Fix numpad Shift Enter and Codex config

### DIFF
--- a/change-logs/2026/05/09/fix-numpad-shift-enter.md
+++ b/change-logs/2026/05/09/fix-numpad-shift-enter.md
@@ -1,1 +1,1 @@
-Shift+Enter handling in terminals now matches Enter by keyboard meaning instead of only physical key code, so the main Return key and numpad Enter both preserve the newline shortcut on extended keyboards.
+Shift+Enter handling in terminals now matches Enter by keyboard meaning instead of only physical key code, so the main Return key and numpad Enter both preserve the newline shortcut on extended keyboards. dev3 also stops writing the now-invalid Codex profile `tui.theme` setting and comments out stale managed theme lines in existing Codex configs.

--- a/change-logs/2026/05/09/fix-numpad-shift-enter.md
+++ b/change-logs/2026/05/09/fix-numpad-shift-enter.md
@@ -1,0 +1,1 @@
+Shift+Enter handling in terminals now matches Enter by keyboard meaning instead of only physical key code, so the main Return key and numpad Enter both preserve the newline shortcut on extended keyboards.

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -6,7 +6,7 @@ describe("ensureCodexConfig", () => {
 	const SOCKETS_PATH = "/Users/testuser/.dev3.0/sockets";
 
 	describe("when config does not exist", () => {
-		it("creates config with project trust, workspace default permissions, permissions.dev3, and themed dev3 profiles", () => {
+		it("creates config with project trust, workspace default permissions, permissions.dev3, and dev3 profiles", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH);
 			expect(result).toContain(`[projects."${WORKTREES_PATH}"]`);
 			expect(result).toContain('trust_level = "trusted"');
@@ -29,9 +29,9 @@ describe("ensureCodexConfig", () => {
 			expect(result).toContain("[profiles.dev3]");
 			expect(result).toContain('web_search = "live"');
 			expect(result).toContain("[profiles.dev3-light]");
-			expect(result).toContain('tui.theme = "github"');
 			expect(result).toContain("[profiles.dev3-dark]");
-			expect(result).toContain('tui.theme = "dracula"');
+			expect(result).not.toContain('tui.theme = "github"');
+			expect(result).not.toContain('tui.theme = "dracula"');
 			expect(result).toContain("[features]");
 			expect(result).toContain("codex_hooks = true");
 		});
@@ -134,11 +134,11 @@ web_search = "live"
 
 [profiles.dev3-light]
 web_search = "live"
-tui.theme = "github"
+# tui.theme = "github"
 
 [profiles.dev3-dark]
 web_search = "live"
-tui.theme = "dracula"
+# tui.theme = "dracula"
 
 [features]
 codex_hooks = true
@@ -160,7 +160,7 @@ codex_hooks = true
 	});
 
 	describe("when themed dev3 profiles exist with stale values", () => {
-		it("updates them to the managed theme ids", () => {
+		it("comments out stale profile theme settings", () => {
 			const existing = `[profiles.dev3-light]
 web_search = "disabled"
 tui.theme = "old-light"
@@ -172,11 +172,10 @@ tui.theme = "old-dark"
 
 			expect(result).toContain("[profiles.dev3-light]");
 			expect(result).toContain('web_search = "live"');
-			expect(result).toContain('tui.theme = "github"');
 			expect(result).toContain("[profiles.dev3-dark]");
-			expect(result).toContain('tui.theme = "dracula"');
-			expect(result).not.toContain('tui.theme = "old-light"');
-			expect(result).not.toContain('tui.theme = "old-dark"');
+			expect(result).toContain('# tui.theme = "old-light"');
+			expect(result).toContain('# tui.theme = "old-dark"');
+			expect(result).not.toMatch(/^tui\.theme =/m);
 		});
 	});
 

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -66,6 +66,7 @@ export function ensureCodexConfig(
 
 	// --- 0. Clean up legacy sections ---
 	config = cleanupLegacySections(config);
+	config = commentOutManagedProfileThemeLines(config);
 	// Re-parse after cleanup
 	if (config.trim().length > 0) {
 		try {
@@ -205,11 +206,13 @@ export function ensureCodexConfig(
 	});
 	config = ensureProfileSettings(config, DEV3_CODEX_LIGHT_PROFILE, {
 		web_search: '"live"',
-		"tui.theme": '"github"',
+		// Codex 0.130 rejects `tui.theme` inside profiles. Leave theme
+		// wiring disabled until we map the new Codex theme schema.
 	});
 	config = ensureProfileSettings(config, DEV3_CODEX_DARK_PROFILE, {
 		web_search: '"live"',
-		"tui.theme": '"dracula"',
+		// Codex 0.130 rejects `tui.theme` inside profiles. Leave theme
+		// wiring disabled until we map the new Codex theme schema.
 	});
 
 	// --- 5. Ensure [features] codex_hooks = true ---
@@ -237,6 +240,26 @@ function cleanupLegacySections(content: string): string {
 		content = removeSectionByHeader(content, "[permissions.network]");
 	}
 	return content;
+}
+
+function commentOutManagedProfileThemeLines(content: string): string {
+	const managedHeaders = new Set([
+		`[profiles.${DEV3_CODEX_LIGHT_PROFILE}]`,
+		`[profiles.${DEV3_CODEX_DARK_PROFILE}]`,
+	]);
+	const lines = content.split("\n");
+	let inManagedProfile = false;
+
+	return lines.map((line) => {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			inManagedProfile = managedHeaders.has(trimmed);
+		}
+		if (inManagedProfile && trimmed.startsWith("tui.theme")) {
+			return `${line.slice(0, line.indexOf("tui.theme"))}# ${trimmed}`;
+		}
+		return line;
+	}).join("\n");
 }
 
 /**

--- a/src/mainview/__tests__/shift-keys.test.ts
+++ b/src/mainview/__tests__/shift-keys.test.ts
@@ -103,6 +103,18 @@ describe("Shift+key integration (ghostty-web InputHandler)", () => {
 		expect(sent).toEqual(["\x1b\r"]);
 	});
 
+	it("Shift+NumpadEnter sends ESC+CR (newline without submit)", () => {
+		const { sent, fire } = setup();
+		fire(keyEvent("NumpadEnter", "Enter", SHIFT));
+		expect(sent).toEqual(["\x1b\r"]);
+	});
+
+	it("Shift+Enter is matched by key even when code is unexpected", () => {
+		const { sent, fire } = setup();
+		fire(keyEvent("Return", "Enter", SHIFT));
+		expect(sent).toEqual(["\x1b\r"]);
+	});
+
 	it("Shift+Home sends modified Home sequence", () => {
 		const { sent, fire } = setup();
 		fire(keyEvent("Home", "Home", SHIFT));

--- a/src/mainview/shift-key-sequences.ts
+++ b/src/mainview/shift-key-sequences.ts
@@ -11,9 +11,11 @@
  *
  * Keys are KeyboardEvent.code values (physical key identifiers).
  */
+export const SHIFT_ENTER_SEQUENCE = "\x1b\r";
+
 export const SHIFT_KEY_SEQUENCES: Record<string, string> = {
 	Tab:      "\x1b[Z",       // Back-tab (CBT)
-	Enter:    "\x1b\r",        // ESC+CR — Claude Code recognizes this as "insert newline" through tmux
+	Enter:    SHIFT_ENTER_SEQUENCE, // ESC+CR — Claude Code recognizes this as "insert newline" through tmux
 	Home:     "\x1b[1;2H",
 	End:      "\x1b[1;2F",
 	Insert:   "\x1b[2;2~",
@@ -41,5 +43,10 @@ export const SHIFT_KEY_SEQUENCES: Record<string, string> = {
 export function getShiftKeySequence(event: KeyboardEvent): string | null {
 	if (event.type !== "keydown" || !event.shiftKey) return null;
 	if (event.ctrlKey || event.altKey || event.metaKey) return null;
+
+	// Both the main Return key and numpad Enter report key="Enter", while
+	// code differs across physical keys and can vary in embedded WebKit.
+	if (event.key === "Enter") return SHIFT_ENTER_SEQUENCE;
+
 	return SHIFT_KEY_SEQUENCES[event.code] ?? null;
 }


### PR DESCRIPTION
## Summary
- Treat main Return and numpad Enter the same for Shift+Enter handling in the terminal.
- Stop writing invalid Codex profile tui.theme settings and comment out stale managed theme lines.

## Tests
- bun run lint
- bun run test