### PR TITLE
chore: bump TypeScript 5.9.3 → 6.0.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "happy-dom": "^20.5.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.16",
-        "typescript": "^5.9.3",
+        "typescript": "6.0.3",
         "vite": "^6.0.3",
         "vitest": "^4.0.18",
       },
@@ -1676,7 +1676,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 

--- a/change-logs/2026/05/15/chore-bump-typescript-6.md
+++ b/change-logs/2026/05/15/chore-bump-typescript-6.md
@@ -1,0 +1,1 @@
+Bumped TypeScript 5.9.3 → 6.0.3. No source code changes required — `bun run lint` clean, full test suite green.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"happy-dom": "^20.5.0",
 		"postcss": "^8.4.49",
 		"tailwindcss": "^3.4.16",
-		"typescript": "^5.9.3",
+		"typescript": "6.0.3",
 		"vite": "^6.0.3",
 		"vitest": "^4.0.18"
 	}


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

## Summary

TypeScript major bump 5.9.3 → 6.0.3. **Zero source changes needed** — the type-checker ran clean on the existing codebase on the first try, and the full test suite is green.

## Validation

- `bun run lint` — clean, no errors in `src/`
- `bun run test` — 1130 mainview + 1105 bun, all green
- Branched from `origin/main` (not stacked on #549) so it can be merged in any order

## Notes

Independent of #549 (electrobun + minor/patch bumps). Either can land first.

Did not run e2e / app-launch validation locally — `bun run dev` should still build, but if CI catches anything around the TS compile flow, we'll know.