### PR TITLE
chore: bump React 18 → 19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Rules:
 
 ## What is this
 
-A **terminal-centric project manager** — iTerm2 meets Kanban. Desktop app for managing multiple AI coding agents and terminal-based tools across tasks and projects. Built with **Electrobun** (not Electron), React 18, Tailwind CSS, and Vite. Runtime is Bun. Supports **macOS and Linux** (Windows support is planned).
+A **terminal-centric project manager** — iTerm2 meets Kanban. Desktop app for managing multiple AI coding agents and terminal-based tools across tasks and projects. Built with **Electrobun** (not Electron), React 19, Tailwind CSS, and Vite. Runtime is Bun. Supports **macOS and Linux** (Windows support is planned).
 
 Key idea: each project is a git repo, each task gets its own **git worktree** + **terminal** running inside **tmux** with a preconfigured command (e.g., `claude`).
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,8 @@
         "ghostty-web": "^0.4.0",
         "js-toml": "1.1.0",
         "qrcode": "^1.5.4",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -23,8 +23,8 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "latest",
         "@types/qrcode": "^1.5.6",
-        "@types/react": "^18.3.12",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "10.5.0",
         "concurrently": "9.2.1",
@@ -594,13 +594,11 @@
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
-
     "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
 
-    "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
-    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -1402,13 +1400,13 @@
 
     "re-resizable": ["re-resizable@6.11.2", "", { "peerDependencies": { "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A=="],
 
-    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
     "react-avatar-editor": ["react-avatar-editor@14.0.0", "", { "peerDependencies": { "react": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-NaQM3oo4u0a1/Njjutc2FjwKX35vQV+t6S8hovsbAlMpBN1ntIwP/g+Yr9eDIIfaNtRXL0AqboTnPmRxhD/i8A=="],
 
     "react-colorful": ["react-colorful@5.6.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw=="],
 
-    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "react-draggable": ["react-draggable@4.5.0", "", { "dependencies": { "clsx": "^2.1.1", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw=="],
 
@@ -1510,7 +1508,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "screenfull": ["screenfull@5.2.0", "", {}, "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="],
 

--- a/change-logs/2026/05/15/chore-bump-react-19.md
+++ b/change-logs/2026/05/15/chore-bump-react-19.md
@@ -1,0 +1,1 @@
+Bumped React 18.3.1 → 19.2.6 (react, react-dom, @types/react, @types/react-dom). Fixed three TypeScript errors caused by stricter @types/react@19: useRef<T>() now requires an initial value (two call sites) and the global `JSX` namespace was replaced with `ReactElement` (one call site in TaskDiffViewer). Lint clean, full test suite green (1130 mainview + 1105 bun).

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 		"ghostty-web": "^0.4.0",
 		"js-toml": "1.1.0",
 		"qrcode": "^1.5.4",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "19.2.6",
+		"react-dom": "19.2.6"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.9.1",
@@ -43,8 +43,8 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@types/bun": "latest",
 		"@types/qrcode": "^1.5.6",
-		"@types/react": "^18.3.12",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "19.2.14",
+		"@types/react-dom": "19.2.3",
 		"@vitejs/plugin-react": "^4.3.4",
 		"autoprefixer": "10.5.0",
 		"concurrently": "9.2.1",

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -72,7 +72,7 @@ function GlobalSettings() {
 	const [tipsResetDone, setTipsResetDone] = useState(false);
 	const [caffeinateAvailable, setCaffeinateAvailable] = useState(true);
 
-	const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+	const resetTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const globalSettingsRef = useRef<GlobalSettingsType>(DEFAULT_GLOBAL_SETTINGS);
 	const pendingAgentsSaveRef = useRef<CodingAgent[] | null>(null);
 	const agentsSaveInFlightRef = useRef(false);

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -80,7 +80,7 @@ function KanbanBoard({
 
 	// Load tip state on mount + auto-rotate every 60s
 	const tipMountedRef = useRef(true);
-	const tipTimerRef = useRef<ReturnType<typeof setTimeout>>();
+	const tipTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	useEffect(() => {
 		tipMountedRef.current = true;
 		if (globalSettings.tipsDisabled) return;

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type MutableRefObject, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type MutableRefObject, type ReactElement, type ReactNode } from "react";
 import type { NavigationGuard } from "../navigation-guard";
 import type {
 	Project,
@@ -2157,7 +2157,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		? (searchMatches.length > 0 ? `${activeSearchIndex + 1} / ${searchMatches.length}` : t("infoPanel.diffSearchNoMatches"))
 		: null;
 
-	function renderFileTreeNode(node: DiffTreeNode, depth = 0): JSX.Element {
+	function renderFileTreeNode(node: DiffTreeNode, depth = 0): ReactElement {
 		if (node.type === "folder") {
 			const collapsed = collapsedFolders[node.key] ?? false;
 			const isCurrentPathMatch = currentSearchMatch?.kind === "path" && currentSearchMatch.filePath === node.path;


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

## Summary

React major bump: 18.3.1 → 19.2.6 (react, react-dom, @types/react, @types/react-dom).

## Type-checker fixes

`@types/react@19` is stricter; three call sites needed adjusting:

| Site | Change |
|---|---|
| `GlobalSettings.tsx:75` | `useRef<T>()` → `useRef<T \| undefined>(undefined)` |
| `KanbanBoard.tsx:83` | `useRef<T>()` → `useRef<T \| undefined>(undefined)` |
| `TaskDiffViewer.tsx:2160` | Global `JSX.Element` → `ReactElement` (imported) |

No runtime / behavioral changes — pure type adjustments.

## Validation

- `bun run lint` — clean
- `bun run test` — 1130 mainview + 1105 bun, all green

## Side benefit

Drops the `@lobehub/icons` peer-deps warning we saw in #549 — that package required `react@19`.

## Compatibility check (manual)

All third-party react peers verified compatible with react 19:
- `@git-diff-view/react` → supports 16/17/18/19
- `@headless-tree/react` → wildcard
- `@lobehub/icons` → requires 19 ✓
- `@testing-library/react@16` → supports 18/19
- `ghostty-web` → no react dep

## Branched from main

Branched from current `origin/main` (after #549 + #550 merged).