### PR TITLE
fix(diff): match search toggle button size to other toolbar buttons

### DIFF
--- a/change-logs/2026/05/15/fix-diff-search-toggle-button-size.md
+++ b/change-logs/2026/05/15/fix-diff-search-toggle-button-size.md
@@ -1,0 +1,1 @@
+Make the diff toolbar search-toggle button match the size of the other mode buttons (Branch / Uncommitted / Unpushed / Unified / Split). It now uses the same compact padding and text size, so it no longer towers over its neighbors. The expanded search input panel itself is unchanged.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -2386,7 +2386,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 							}}
 							aria-label={t("infoPanel.diffSearchOpen")}
 							title={`${t("infoPanel.diffSearchOpen")} (⌘F)`}
-							className={`inline-flex h-8 w-8 items-center justify-center rounded-md border transition-colors ${
+							className={`inline-flex items-center justify-center px-2.5 py-0.5 rounded-md border text-[0.6875rem] font-semibold transition-colors ${
 								isSearchOpen
 									? "border-accent bg-accent text-white"
 									: "border-edge bg-raised text-fg-2 hover:bg-elevated-hover"
@@ -2394,7 +2394,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 						>
 							<span
 								aria-hidden="true"
-								className="text-[0.95rem] leading-none"
+								className="text-[0.8125rem] leading-none"
 								style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 							>
 								{"\uF002"}


### PR DESCRIPTION
## Summary
- Diff viewer toolbar search-toggle button visually towered over its neighbors (Branch / Uncommitted / Unpushed / Unified / Split) because it used `h-8 w-8` while the others use `px-2.5 py-0.5 text-[0.6875rem]`.
- Switched the search toggle to the same compact styling so the row reads as one consistent group. The expanded search input panel itself is unchanged (it still has the larger input field and nav buttons).

Hi, this is Claude (the AI assistant working on this PR).