### PR TITLE
fix: navigate back to Kanban after merged-PR complete popup

### DIFF
--- a/change-logs/2026/05/16/fix-merged-popup-navigate-back-to-kanban.md
+++ b/change-logs/2026/05/16/fix-merged-popup-navigate-back-to-kanban.md
@@ -1,0 +1,1 @@
+Fix the "Branch merged → mark as completed?" popup so it navigates the user back to the Kanban view when they confirm from inside the full task screen. Previously the worktree was destroyed while the task screen was still mounted, causing the TaskTerminal to flip to its "session ended / restart session" error state.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -117,6 +117,13 @@ function App() {
 	const navigationGuardRef = useRef<NavigationGuard | null>(null);
 	const [pendingNavigation, setPendingNavigation] = useState<Route | null>(null);
 
+	// Latest route mirror — async event handlers read this to make routing decisions
+	// without re-subscribing every navigation.
+	const routeRef = useRef<Route>(state.route);
+	useEffect(() => {
+		routeRef.current = state.route;
+	}, [state.route]);
+
 	const navigate = useCallback(
 		(route: Route) => {
 			if (navigationGuardRef.current?.isDirty()) {
@@ -376,6 +383,14 @@ function App() {
 			});
 			if (shouldComplete === null) return;
 			if (shouldComplete) {
+				// If the user is currently inside this task's full screen, navigate them
+				// back to the Kanban view BEFORE the worktree is destroyed. Otherwise
+				// TaskTerminal reacts to ptyDied / missing worktree and shows the
+				// "session ended / restart session" screen.
+				const currentRoute = routeRef.current;
+				if (currentRoute.screen === "task" && currentRoute.taskId === taskId) {
+					navigate({ screen: "project", projectId });
+				}
 				dispatch({
 					type: "updateTask",
 					task: {
@@ -412,7 +427,7 @@ function App() {
 		}
 		window.addEventListener("rpc:branchMerged", onBranchMerged);
 		return () => window.removeEventListener("rpc:branchMerged", onBranchMerged);
-	}, [dispatch, t]);
+	}, [dispatch, navigate, t]);
 
 	// Listen for silent update ready notification
 	useEffect(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -22,6 +22,9 @@ vi.mock("../rpc", () => ({
 				taskDropPosition: "top",
 				updateChannel: "stable",
 			}),
+			showConfirm: vi.fn().mockResolvedValue(false),
+			moveTask: vi.fn().mockResolvedValue({}),
+			dismissMergeCompletionPrompt: vi.fn().mockResolvedValue(undefined),
 		},
 	},
 }));
@@ -503,6 +506,94 @@ describe("App keyboard shortcuts", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Session Expired")).toBeInTheDocument();
 			});
+		});
+	});
+
+	describe("branch-merged completion popup", () => {
+		const fireBranchMerged = (taskId: string, projectId: string, fingerprint: string) =>
+			act(async () => {
+				window.dispatchEvent(
+					new CustomEvent("rpc:branchMerged", {
+						detail: {
+							taskId,
+							projectId,
+							taskTitle: "Some task",
+							branchName: "feat/whatever",
+							fingerprint,
+						},
+					}),
+				);
+			});
+
+		it("navigates from full task screen back to project view when user confirms completion", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+			vi.mocked(api.request.showConfirm).mockResolvedValue(true);
+			vi.mocked(api.request.moveTask).mockResolvedValue({} as never);
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await fireBranchMerged("t1", "p1", "fp-confirm-1");
+
+			await waitFor(() => {
+				expect(screen.getByTestId("project-screen")).toBeInTheDocument();
+			});
+			expect(screen.queryByTestId("task-screen")).not.toBeInTheDocument();
+			expect(api.request.moveTask).toHaveBeenCalledWith(
+				expect.objectContaining({ taskId: "t1", projectId: "p1", newStatus: "completed" }),
+			);
+		});
+
+		it("stays on task screen when user declines the popup", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+			vi.mocked(api.request.showConfirm).mockResolvedValue(false);
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await fireBranchMerged("t1", "p1", "fp-decline-1");
+
+			// Give event handlers a tick to resolve
+			await waitFor(() => {
+				expect(api.request.dismissMergeCompletionPrompt).toHaveBeenCalled();
+			});
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+			expect(screen.queryByTestId("project-screen")).not.toBeInTheDocument();
+			expect(api.request.moveTask).not.toHaveBeenCalled();
+		});
+
+		it("does not navigate when user is on a different task's screen", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t2" }),
+			});
+			vi.mocked(api.request.showConfirm).mockResolvedValue(true);
+			vi.mocked(api.request.moveTask).mockResolvedValue({} as never);
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			// Event is for t1, but user is viewing t2
+			await fireBranchMerged("t1", "p1", "fp-other-task-1");
+
+			await waitFor(() => {
+				expect(api.request.moveTask).toHaveBeenCalled();
+			});
+			// Still on task screen (for t2)
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+			expect(screen.queryByTestId("project-screen")).not.toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
Hey, Claude here (AI assistant on this branch).

## Summary
- When the "Branch merged — mark task as completed?" popup is confirmed from inside the full task screen, `App.tsx`'s `onBranchMerged` handler now navigates the user back to the project (Kanban) view **before** the worktree is destroyed.
- Without this, `TaskTerminal` reacted to `ptyDied` / missing worktree and flipped to its "session ended / restart session" error screen.
- Symmetric with the existing path in `useTaskBranchStatus.completeTask` (which already navigates).
- Covered by 3 new tests in `App.test.tsx` (confirm → navigate, decline → stay, other-task → stay).