### PR TITLE
feat(tmux): exit copy-mode on task view re-entry

### DIFF
--- a/change-logs/2026/05/16/feature-exit-copy-mode-on-task-nav.md
+++ b/change-logs/2026/05/16/feature-exit-copy-mode-on-task-nav.md
@@ -1,0 +1,1 @@
+Auto-exit tmux copy-mode in every pane of a task's session whenever the terminal becomes the visible view — entering a task from the dashboard, switching between tasks, or returning from the inline diff. Prevents the silent "copy-mode at scroll position 0" state where a pane looks live but swallows keystrokes.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -4671,6 +4671,89 @@ describe("handlers.tmuxAction", () => {
 });
 
 // ================================================================
+// handlers.exitCopyModeAllPanes
+// ================================================================
+
+describe("handlers.exitCopyModeAllPanes", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("sends -X cancel only to panes currently in copy-mode", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+
+		let spawnCall = 0;
+		mockSpawn.mockImplementation(() => {
+			spawnCall += 1;
+			return {
+				stderr: new Response("").body,
+				stdout: new Response(spawnCall === 1 ? "%0 1\n%1 0\n%2 1\n" : "").body,
+				exited: Promise.resolve(0),
+			};
+		});
+
+		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
+
+		expect(result).toEqual({ panesExited: 2 });
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "list-panes", "-s", "-t", "dev3-abcd1234", "-F", "#{pane_id} #{pane_in_mode}"],
+			expect.any(Object),
+		);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "send-keys", "-t", "%0", "-X", "cancel"],
+			expect.any(Object),
+		);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "send-keys", "-t", "%2", "-X", "cancel"],
+			expect.any(Object),
+		);
+		// %1 was not in copy-mode → no cancel sent for it
+		expect(mockSpawn).not.toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "send-keys", "-t", "%1", "-X", "cancel"],
+			expect.any(Object),
+		);
+	});
+
+	it("no-op when tmux session does not exist", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(false);
+
+		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
+
+		expect(result).toEqual({ panesExited: 0 });
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	it("returns zero when no pane is in copy-mode", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+
+		mockSpawn.mockReturnValueOnce({
+			stderr: new Response("").body,
+			stdout: new Response("%0 0\n%1 0\n").body,
+			exited: Promise.resolve(0),
+		});
+
+		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
+
+		expect(result).toEqual({ panesExited: 0 });
+		// Only list-panes was spawned — no send-keys calls
+		expect(mockSpawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns zero when list-panes fails", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+
+		mockSpawn.mockReturnValueOnce({
+			stderr: new Response("error").body,
+			stdout: new Response("").body,
+			exited: Promise.resolve(1),
+		});
+
+		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
+
+		expect(result).toEqual({ panesExited: 0 });
+		expect(mockSpawn).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ================================================================
 // handlers.getProjectPtyUrl / destroyProjectTerminal
 // ================================================================
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -4677,17 +4677,46 @@ describe("handlers.tmuxAction", () => {
 describe("handlers.exitCopyModeAllPanes", () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it("sends -X cancel only to panes currently in copy-mode", async () => {
-		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+	// Spawn router: matches by tmux subcommand so individual tests can declare
+	// what each tmux command should return without ordering fragility.
+	function setupSpawnRouter(routes: {
+		hasSession?: number; // exit code for has-session (dev-server check)
+		listTaskPanes?: { exit: number; out: string };
+		listDevPanes?: { exit: number; out: string };
+	}) {
+		mockSpawn.mockImplementation((args: string[]) => {
+			const sub = args[3]; // ["tmux", "-L", "dev3", <subcommand>, ...]
+			const sessionArg = args[args.indexOf("-t") + 1] ?? "";
 
-		let spawnCall = 0;
-		mockSpawn.mockImplementation(() => {
-			spawnCall += 1;
+			if (sub === "has-session") {
+				return {
+					stderr: new Response("").body,
+					stdout: new Response("").body,
+					exited: Promise.resolve(routes.hasSession ?? 1),
+				};
+			}
+			if (sub === "list-panes") {
+				const route = sessionArg.startsWith("dev3-dev-") ? routes.listDevPanes : routes.listTaskPanes;
+				return {
+					stderr: new Response("").body,
+					stdout: new Response(route?.out ?? "").body,
+					exited: Promise.resolve(route?.exit ?? 0),
+				};
+			}
+			// send-keys etc. — always succeed
 			return {
 				stderr: new Response("").body,
-				stdout: new Response(spawnCall === 1 ? "%0 1\n%1 0\n%2 1\n" : "").body,
+				stdout: new Response("").body,
 				exited: Promise.resolve(0),
 			};
+		});
+	}
+
+	it("sends -X cancel only to panes currently in copy-mode", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+		setupSpawnRouter({
+			hasSession: 1, // dev-server not running
+			listTaskPanes: { exit: 0, out: "%0 1\n%1 0\n%2 1\n" },
 		});
 
 		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
@@ -4712,44 +4741,67 @@ describe("handlers.exitCopyModeAllPanes", () => {
 		);
 	});
 
-	it("no-op when tmux session does not exist", async () => {
+	it("also cleans the dev-server session (dev3-dev-<id>)", async () => {
+		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
+		setupSpawnRouter({
+			hasSession: 0, // dev-server IS running
+			listTaskPanes: { exit: 0, out: "%10 0\n" },
+			listDevPanes: { exit: 0, out: "%99 1\n" }, // dev-server pane in copy-mode
+		});
+
+		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
+
+		expect(result).toEqual({ panesExited: 1 });
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "list-panes", "-s", "-t", "dev3-dev-abcd1234", "-F", "#{pane_id} #{pane_in_mode}"],
+			expect.any(Object),
+		);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "send-keys", "-t", "%99", "-X", "cancel"],
+			expect.any(Object),
+		);
+	});
+
+	it("no-op when neither task nor dev-server session exists", async () => {
 		vi.mocked(pty.tmuxSessionExists).mockReturnValue(false);
+		setupSpawnRouter({ hasSession: 1 });
 
 		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
 
 		expect(result).toEqual({ panesExited: 0 });
-		expect(mockSpawn).not.toHaveBeenCalled();
+		// Only the has-session check (for dev-server) was spawned; no list-panes
+		expect(mockSpawn).not.toHaveBeenCalledWith(
+			expect.arrayContaining(["list-panes"]),
+			expect.any(Object),
+		);
 	});
 
 	it("returns zero when no pane is in copy-mode", async () => {
 		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
-
-		mockSpawn.mockReturnValueOnce({
-			stderr: new Response("").body,
-			stdout: new Response("%0 0\n%1 0\n").body,
-			exited: Promise.resolve(0),
+		setupSpawnRouter({
+			hasSession: 1,
+			listTaskPanes: { exit: 0, out: "%0 0\n%1 0\n" },
 		});
 
 		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
 
 		expect(result).toEqual({ panesExited: 0 });
-		// Only list-panes was spawned — no send-keys calls
-		expect(mockSpawn).toHaveBeenCalledTimes(1);
+		expect(mockSpawn).not.toHaveBeenCalledWith(
+			expect.arrayContaining(["send-keys"]),
+			expect.any(Object),
+		);
 	});
 
 	it("returns zero when list-panes fails", async () => {
 		vi.mocked(pty.tmuxSessionExists).mockReturnValue(true);
-
-		mockSpawn.mockReturnValueOnce({
-			stderr: new Response("error").body,
-			stdout: new Response("").body,
-			exited: Promise.resolve(1),
+		setupSpawnRouter({
+			hasSession: 1,
+			listTaskPanes: { exit: 1, out: "" },
 		});
 
 		const result = await handlers.exitCopyModeAllPanes({ taskId: "abcd1234-full-id" });
 
 		expect(result).toEqual({ panesExited: 0 });
-		expect(mockSpawn).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1295,14 +1295,7 @@ async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" 
 	log.info("← tmuxAction done", { taskId: params.taskId.slice(0, 8), action: params.action });
 }
 
-async function exitCopyModeAllPanes(params: { taskId: string }): Promise<{ panesExited: number }> {
-	const socket = pty.getSessionSocket(params.taskId);
-	const tmuxSession = pty.getSessionTmuxName(params.taskId);
-
-	if (!pty.tmuxSessionExists(params.taskId, socket)) {
-		return { panesExited: 0 };
-	}
-
+async function exitCopyModeInSession(socket: string, tmuxSession: string): Promise<number> {
 	const listProc = spawn(
 		pty.tmuxArgs(socket, "list-panes", "-s", "-t", tmuxSession, "-F", "#{pane_id} #{pane_in_mode}"),
 		{ stdout: "pipe", stderr: "pipe" },
@@ -1310,7 +1303,7 @@ async function exitCopyModeAllPanes(params: { taskId: string }): Promise<{ panes
 	const listOutput = await new Response(listProc.stdout).text();
 	const listExit = await listProc.exited;
 	if (listExit !== 0) {
-		return { panesExited: 0 };
+		return 0;
 	}
 
 	const panesInMode: string[] = [];
@@ -1330,10 +1323,33 @@ async function exitCopyModeAllPanes(params: { taskId: string }): Promise<{ panes
 		await cancelProc.exited;
 	}
 
-	if (panesInMode.length > 0) {
-		log.info("Exited copy-mode in panes", { taskId: params.taskId.slice(0, 8), count: panesInMode.length });
+	return panesInMode.length;
+}
+
+async function exitCopyModeAllPanes(params: { taskId: string }): Promise<{ panesExited: number }> {
+	const socket = pty.getSessionSocket(params.taskId);
+	const taskSession = pty.getSessionTmuxName(params.taskId);
+	const devSession = devServerSessionName(params.taskId);
+
+	// dev-server lives in a separate tmux session (dev3-dev-<id>) — the user's
+	// scroll-mode is typically there, not in the agent session. Hit both.
+	const sessions: string[] = [];
+	if (pty.tmuxSessionExists(params.taskId, socket)) {
+		sessions.push(taskSession);
 	}
-	return { panesExited: panesInMode.length };
+	if (await isDevServerRunning(params.taskId, socket)) {
+		sessions.push(devSession);
+	}
+
+	let total = 0;
+	for (const session of sessions) {
+		total += await exitCopyModeInSession(socket, session);
+	}
+
+	if (total > 0) {
+		log.info("Exited copy-mode in panes", { taskId: params.taskId.slice(0, 8), count: total, sessions });
+	}
+	return { panesExited: total };
 }
 
 async function spawnAgentInTask(params: { taskId: string; projectId: string; agentId: string | null; configId: string | null }): Promise<void> {

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1295,6 +1295,47 @@ async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" 
 	log.info("← tmuxAction done", { taskId: params.taskId.slice(0, 8), action: params.action });
 }
 
+async function exitCopyModeAllPanes(params: { taskId: string }): Promise<{ panesExited: number }> {
+	const socket = pty.getSessionSocket(params.taskId);
+	const tmuxSession = pty.getSessionTmuxName(params.taskId);
+
+	if (!pty.tmuxSessionExists(params.taskId, socket)) {
+		return { panesExited: 0 };
+	}
+
+	const listProc = spawn(
+		pty.tmuxArgs(socket, "list-panes", "-s", "-t", tmuxSession, "-F", "#{pane_id} #{pane_in_mode}"),
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	const listOutput = await new Response(listProc.stdout).text();
+	const listExit = await listProc.exited;
+	if (listExit !== 0) {
+		return { panesExited: 0 };
+	}
+
+	const panesInMode: string[] = [];
+	for (const line of listOutput.trim().split("\n")) {
+		if (!line) continue;
+		const [paneId, inMode] = line.split(" ");
+		if (paneId && inMode === "1") {
+			panesInMode.push(paneId);
+		}
+	}
+
+	for (const paneId of panesInMode) {
+		const cancelProc = spawn(
+			pty.tmuxArgs(socket, "send-keys", "-t", paneId, "-X", "cancel"),
+			{ stdout: "pipe", stderr: "pipe" },
+		);
+		await cancelProc.exited;
+	}
+
+	if (panesInMode.length > 0) {
+		log.info("Exited copy-mode in panes", { taskId: params.taskId.slice(0, 8), count: panesInMode.length });
+	}
+	return { panesExited: panesInMode.length };
+}
+
 async function spawnAgentInTask(params: { taskId: string; projectId: string; agentId: string | null; configId: string | null }): Promise<void> {
 	log.info("→ spawnAgentInTask", { taskId: params.taskId.slice(0, 8), agentId: params.agentId, configId: params.configId });
 
@@ -1459,6 +1500,7 @@ export const tmuxPtyHandlers = {
 	listTmuxSessions,
 	killTmuxSession,
 	tmuxAction,
+	exitCopyModeAllPanes,
 	spawnAgentInTask,
 	resumeTask,
 	restartTask,

--- a/src/mainview/components/TaskWorkspacePane.tsx
+++ b/src/mainview/components/TaskWorkspacePane.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import type { Dispatch, MutableRefObject } from "react";
 import type { Project, Task } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import type { NavigationGuard } from "../navigation-guard";
+import { api } from "../rpc";
 import TaskTerminal from "./TaskTerminal";
 import TaskDiffViewer from "./TaskDiffViewer";
 import type { TaskInlineDiffRequest } from "./task-inline-diff";
@@ -31,6 +33,17 @@ function TaskWorkspacePane({
 }: TaskWorkspacePaneProps) {
 	const task = tasks.find((item) => item.id === taskId);
 	const project = projects.find((item) => item.id === projectId);
+
+	// A pane stuck in copy-mode at scroll position 0 is visually identical to a
+	// live pane — silently swallows keystrokes until cleared. Reset on every
+	// re-entry into the terminal view.
+	const terminalVisible = !inlineDiffRequest;
+	useEffect(() => {
+		if (!terminalVisible) return;
+		api.request.exitCopyModeAllPanes({ taskId }).catch(() => {
+			// best effort — session may not exist yet for brand-new tasks
+		});
+	}, [taskId, terminalVisible]);
 
 	return (
 		<div className="h-full w-full relative overflow-hidden">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1283,6 +1283,10 @@ export type AppRPCSchema = {
 				params: { taskId: string; action: "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV" };
 				response: void;
 			};
+			exitCopyModeAllPanes: {
+				params: { taskId: string };
+				response: { panesExited: number };
+			};
 			copyTerminalSelection: {
 				params: { taskId: string; text: string; mouseTracking: boolean };
 				response: { ok: boolean; tool: string | null };


### PR DESCRIPTION
## Summary

Hey, Claude here (the AI assistant on this branch) — auto-exits tmux copy-mode in every pane of a task's sessions whenever the terminal becomes the visible view (entering a task from the dashboard, switching between tasks, returning from inline diff).

The motivating scenario: a pane stuck in copy-mode at scroll position 0 is visually identical to a live pane — it silently swallows keystrokes until the user presses `q`. Easy to miss after going to the inline diff and back.

- New RPC `exitCopyModeAllPanes(taskId)` iterates panes via `list-panes -s`, filters `pane_in_mode=1`, sends `-X cancel`.
- Covers **both** the agent session `dev3-<taskId>` **and** the dev-server session `dev3-dev-<taskId>` — the second one was the most common offender (scroll back through dev-server logs, navigate away, return → stuck).
- Wired into `TaskWorkspacePane` via `useEffect` on `[taskId, terminalVisible]` so it fires on first mount, task switch, and inline-diff close.
- 5 unit tests with a subcommand-aware spawn router (mixed copy-mode panes, dev-server-only, no panes in mode, no session, list-panes failure).