### PR TITLE
fix: align diff right-panel order with the left file tree

### DIFF
--- a/change-logs/2026/05/18/fix-diff-panel-file-order.md
+++ b/change-logs/2026/05/18/fix-diff-panel-file-order.md
@@ -1,0 +1,1 @@
+Fix file ordering mismatch between the diff file tree (left panel) and the diff section list (right panel). Untracked files were appended at the end of the right-panel list by the backend, while the tree showed them in their alphabetical position. Both panels now use the same alphabetical full-path order.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -959,6 +959,24 @@ function getFileDiffStats(file: TaskDiffFile): { insertions: number; deletions: 
 	};
 }
 
+function diffFileFullPath(file: TaskDiffFile | TaskDiffSkippedFile): string {
+	return file.newPath ?? file.oldPath ?? file.displayPath;
+}
+
+// The backend assembles `files` by concatenating tracked-modified entries with untracked entries
+// (see git.ts: `[...entries, ...untrackedEntries]`). This makes the right-panel list order out of
+// sync with the alphabetical file tree on the left. Sorting both lists by their full path keeps
+// the tree click → right-panel scroll mapping monotonic.
+function sortTaskDiffResponse(response: TaskDiffResponse): TaskDiffResponse {
+	const byPath = (left: TaskDiffFile | TaskDiffSkippedFile, right: TaskDiffFile | TaskDiffSkippedFile) =>
+		diffFileFullPath(left).localeCompare(diffFileFullPath(right));
+	return {
+		...response,
+		files: [...response.files].sort(byPath),
+		skippedFiles: [...response.skippedFiles].sort(byPath),
+	};
+}
+
 function buildDiffTree(files: TaskDiffFile[], skippedFiles: TaskDiffSkippedFile[]): DiffTreeNode[] {
 	const root: DiffTreeNode[] = [];
 
@@ -1596,7 +1614,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 			if (cancelled) {
 				return;
 			}
-			setPayload(result);
+			setPayload(sortTaskDiffResponse(result));
 			setLoading(false);
 		}).catch((err) => {
 			if (cancelled) {

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -241,14 +241,14 @@ const diffPayload: TaskDiffResponse = {
 			hunks: ["diff --git a/src/utils/format.ts b/src/utils/format.ts\n@@ -0,0 +1 @@\n+export const ok = true;\n"],
 		},
 		{
-			id: "docs/readme.md",
+			id: "zzz/readme.md",
 			status: "modified",
-			displayPath: "docs/readme.md",
-			oldPath: "docs/readme.md",
-			newPath: "docs/readme.md",
+			displayPath: "zzz/readme.md",
+			oldPath: "zzz/readme.md",
+			newPath: "zzz/readme.md",
 			oldContent: "old\n",
 			newContent: "new\n",
-			hunks: ["diff --git a/docs/readme.md b/docs/readme.md\n@@ -1 +1 @@\n-old\n+new\n"],
+			hunks: ["diff --git a/zzz/readme.md b/zzz/readme.md\n@@ -1 +1 @@\n-old\n+new\n"],
 		},
 	],
 	skippedFiles: [],
@@ -352,6 +352,72 @@ describe("TaskDiffViewer", () => {
 		await waitFor(() => {
 			expect(screen.getAllByTestId("mock-diff")).toHaveLength(2);
 		});
+	});
+
+	it("sorts the right-panel file list alphabetically by full path", async () => {
+		// Regression: git.ts assembles `files` as `[...trackedEntries, ...untrackedEntries]`,
+		// so untracked files always end up at the bottom of the right panel while the left tree
+		// shows them in their alphabetical position. The right panel must match the tree order.
+		vi.mocked(api.request.getTaskDiff).mockResolvedValue({
+			mode: "uncommitted",
+			compareRef: null,
+			compareLabel: "Working tree",
+			fallbackReason: null,
+			summary: { files: 3, insertions: 0, deletions: 0 },
+			files: [
+				{
+					id: "src/management/handler.ts",
+					status: "modified",
+					displayPath: "src/management/handler.ts",
+					oldPath: "src/management/handler.ts",
+					newPath: "src/management/handler.ts",
+					oldContent: "x\n",
+					newContent: "y\n",
+					hunks: ["diff --git a/src/management/handler.ts b/src/management/handler.ts\n@@ -1 +1 @@\n-x\n+y\n"],
+				},
+				{
+					id: "src/utils/helper.ts",
+					status: "modified",
+					displayPath: "src/utils/helper.ts",
+					oldPath: "src/utils/helper.ts",
+					newPath: "src/utils/helper.ts",
+					oldContent: "a\n",
+					newContent: "b\n",
+					hunks: ["diff --git a/src/utils/helper.ts b/src/utils/helper.ts\n@@ -1 +1 @@\n-a\n+b\n"],
+				},
+				// Backend appends untracked entries last — must be re-sorted into alphabetical position.
+				{
+					id: "src/migrations/0001_init.ts",
+					status: "untracked",
+					displayPath: "src/migrations/0001_init.ts",
+					oldPath: null,
+					newPath: "src/migrations/0001_init.ts",
+					oldContent: "",
+					newContent: "export {};\n",
+					hunks: ["diff --git a/src/migrations/0001_init.ts b/src/migrations/0001_init.ts\n@@ -0,0 +1 @@\n+export {};\n"],
+				},
+			],
+			skippedFiles: [],
+		});
+
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "uncommitted" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await screen.findAllByTestId("mock-diff");
+		const sections = Array.from(document.querySelectorAll<HTMLElement>("[data-file-id]"));
+		expect(sections.map((node) => node.dataset.fileId)).toEqual([
+			"src/management/handler.ts",
+			"src/migrations/0001_init.ts",
+			"src/utils/helper.ts",
+		]);
 	});
 
 	it("renders binary and oversized skipped files with status, old→new sizes and reason badges", async () => {
@@ -1047,7 +1113,7 @@ describe("TaskDiffViewer", () => {
 			}),
 		});
 
-		const targetSection = document.querySelector('[data-file-id="docs/readme.md"]') as HTMLDivElement | null;
+		const targetSection = document.querySelector('[data-file-id="zzz/readme.md"]') as HTMLDivElement | null;
 		expect(targetSection).not.toBeNull();
 		let targetRectCall = 0;
 		Object.defineProperty(targetSection as HTMLDivElement, "getBoundingClientRect", {
@@ -1069,7 +1135,7 @@ describe("TaskDiffViewer", () => {
 			},
 		});
 
-		await user.click(screen.getByRole("button", { name: /open diff file docs\/readme\.md/i }));
+		await user.click(screen.getByRole("button", { name: /open diff file zzz\/readme\.md/i }));
 
 		while (rafQueue.length > 0) {
 			const callback = rafQueue.shift();


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this PR).

## Summary
- The backend (`git.ts`) assembles `files` as `[...trackedEntries, ...untrackedEntries]`, so untracked entries always landed at the bottom of the right-panel diff list while the left file tree placed them in their alphabetical position. Clicking the last entry in the tree left more files scrolled below it on the right.
- After receiving a diff response, `payload.files` and `payload.skippedFiles` are now sorted by full path, so the right panel mirrors the alphabetical tree order. Tree structure itself (folders-first, then alphabetical) is unchanged.
- Added a regression test that mimics the untracked-at-end case.