### PR TITLE
fix(agents): add `--` separator before positional prompt (claude/codex/gemini/cursor)

### DIFF
--- a/change-logs/2026/05/22/fix-claude-prompt-arg-escape.md
+++ b/change-logs/2026/05/22/fix-claude-prompt-arg-escape.md
@@ -1,0 +1,3 @@
+Fixed agent CLIs (claude, codex, gemini, cursor) crashing with `error: unknown option '---…'` when a task description starts with `---` (markdown frontmatter or horizontal rule). We now emit `--` before the positional prompt so the agent's argument parser stops scanning for options.
+
+Suggested by @Capibara- (h0x91b/dev-3.0#570)

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -388,6 +388,70 @@ describe("resolveAgentCommand — resume", () => {
 	});
 });
 
+describe("resolveAgentCommand — positional prompt separator (-- guard)", () => {
+	// Regression: GitHub #570. Task descriptions starting with "---" (markdown
+	// frontmatter, horizontal rules) were treated as long options by the
+	// agent CLI (commander/clap/yargs) and the agent process exited immediately
+	// with "error: unknown option '---…'". A literal "--" before the positional
+	// prompt terminates option parsing.
+
+	it.each(["claude", "codex", "gemini", "agent"])(
+		"%s: emits `-- <prompt>` so a '---'-prefixed description is not parsed as a flag",
+		(baseCmd) => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: baseCmd }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "---hello frontmatter" }),
+			baseCmd === "claude" ? { sessionId: "11111111-1111-1111-1111-111111111111" } : undefined,
+		);
+
+		// Codex / Cursor agents append skill bodies onto the prompt, so we
+		// match the prefix `-- '---hello frontmatter` (no closing quote).
+		expect(cmd).toContain("-- '---hello frontmatter");
+		// The prompt token must not be at the head of args where it could be
+		// scanned as an option — it must come strictly after the "--" guard.
+		const dashDashIdx = cmd.indexOf(" -- '");
+		const promptIdx = cmd.indexOf("'---hello frontmatter");
+		expect(dashDashIdx).toBeGreaterThan(0);
+		expect(promptIdx).toBeGreaterThan(dashDashIdx);
+		},
+	);
+
+	it("OpenCode: uses --prompt <value>, so no -- separator is added (value form is unambiguous)", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "opencode" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "---hello frontmatter" }),
+		);
+
+		expect(cmd).toContain("--prompt");
+		expect(cmd).toContain("'---hello frontmatter");
+		expect(cmd).not.toMatch(/ -- '/);
+	});
+
+	it("Claude: -- guard is still present for plain descriptions (no regression for normal prompts)", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "claude" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "Fix the login bug" }),
+		);
+
+		expect(cmd).toContain("-- 'Fix the login bug'");
+	});
+
+	it("does not add -- when resuming (no positional prompt is emitted on resume)", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "claude" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "---hello frontmatter" }),
+			{ resume: true, sessionId: "11111111-1111-1111-1111-111111111111" },
+		);
+
+		expect(cmd).not.toContain("---hello frontmatter");
+		expect(cmd).not.toMatch(/ -- '/);
+	});
+});
+
 describe("resolveAgentCommand — sessionId", () => {
 	it("Claude: injects --session-id for fresh launch", () => {
 		const cmd = resolveAgentCommand(

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -436,7 +436,9 @@ export function resolveAgentCommand(
 			if (openCodeAgent) {
 				args.push("--prompt", shellEscape(prompt));
 			} else {
-				args.push(shellEscape(prompt));
+				// `--` terminates option parsing so prompts starting with "---"
+				// (e.g. markdown frontmatter) are not treated as unknown flags.
+				args.push("--", shellEscape(prompt));
 			}
 		}
 	}

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -880,55 +880,55 @@ describe("resolveAgentCommand", () => {
 		it("escapes single quotes in task description", () => {
 			const c = makeCtx({ taskDescription: "Fix it's broken flow" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Fix it'\\''s broken flow'");
+			expect(cmd).toBe("bash-agent -- 'Fix it'\\''s broken flow'");
 		});
 
 		it("preserves double quotes in task description (safe inside single quotes)", () => {
 			const c = makeCtx({ taskDescription: 'Fix the "login" page' });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Fix the \"login\" page'");
+			expect(cmd).toBe("bash-agent -- 'Fix the \"login\" page'");
 		});
 
 		it("preserves dollar signs in task description", () => {
 			const c = makeCtx({ taskDescription: "Check $HOME and $PATH vars" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Check $HOME and $PATH vars'");
+			expect(cmd).toBe("bash-agent -- 'Check $HOME and $PATH vars'");
 		});
 
 		it("preserves backticks in task description", () => {
 			const c = makeCtx({ taskDescription: "Run `whoami` and check" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Run `whoami` and check'");
+			expect(cmd).toBe("bash-agent -- 'Run `whoami` and check'");
 		});
 
 		it("preserves command substitution syntax in task description", () => {
 			const c = makeCtx({ taskDescription: "Value is $(cat /etc/passwd)" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Value is $(cat /etc/passwd)'");
+			expect(cmd).toBe("bash-agent -- 'Value is $(cat /etc/passwd)'");
 		});
 
 		it("preserves semicolons and pipes in task description", () => {
 			const c = makeCtx({ taskDescription: "step1; step2 | step3" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'step1; step2 | step3'");
+			expect(cmd).toBe("bash-agent -- 'step1; step2 | step3'");
 		});
 
 		it("preserves backslashes in task description", () => {
 			const c = makeCtx({ taskDescription: "path\\to\\file" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'path\\to\\file'");
+			expect(cmd).toBe("bash-agent -- 'path\\to\\file'");
 		});
 
 		it("preserves newlines in task description", () => {
 			const c = makeCtx({ taskDescription: "line1\nline2\nline3" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'line1\nline2\nline3'");
+			expect(cmd).toBe("bash-agent -- 'line1\nline2\nline3'");
 		});
 
 		it("handles injection attempt via single-quote breakout", () => {
 			const c = makeCtx({ taskDescription: "'; rm -rf / #" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent ''\\''; rm -rf / #'");
+			expect(cmd).toBe("bash-agent -- ''\\''; rm -rf / #'");
 		});
 
 		it("handles complex real-world task with mixed special chars", () => {
@@ -936,32 +936,32 @@ describe("resolveAgentCommand", () => {
 			const c = makeCtx({ taskDescription: desc });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe(
-				"bash-agent 'Fix the \"login\" bug (it'\\''s broken); check $PATH & `env` | grep HOME'",
+				"bash-agent -- 'Fix the \"login\" bug (it'\\''s broken); check $PATH & `env` | grep HOME'",
 			);
 		});
 
 		it("handles unicode and emoji in task description", () => {
 			const c = makeCtx({ taskDescription: "Исправь баг 🐛 в компоненте" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Исправь баг 🐛 в компоненте'");
+			expect(cmd).toBe("bash-agent -- 'Исправь баг 🐛 в компоненте'");
 		});
 
 		it("escapes task description with only single quotes", () => {
 			const c = makeCtx({ taskDescription: "'''" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent ''\\'''\\'''\\'''");
+			expect(cmd).toBe("bash-agent -- ''\\'''\\'''\\'''");
 		});
 
 		it("preserves redirect operators in task description", () => {
 			const c = makeCtx({ taskDescription: "output > /dev/null 2>&1" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'output > /dev/null 2>&1'");
+			expect(cmd).toBe("bash-agent -- 'output > /dev/null 2>&1'");
 		});
 
 		it("preserves glob patterns in task description", () => {
 			const c = makeCtx({ taskDescription: "Fix *.ts files in src/**/" });
 			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
-			expect(cmd).toBe("bash-agent 'Fix *.ts files in src/**/'");
+			expect(cmd).toBe("bash-agent -- 'Fix *.ts files in src/**/'");
 		});
 	});
 
@@ -987,7 +987,7 @@ describe("resolveAgentCommand", () => {
 			});
 			const cmd = resolveAgentCommand(simpleAgent, config, c);
 			// The interpolated prompt "Title: Fix it's problem" gets shellEscape'd
-			expect(cmd).toBe("bash-agent 'Title: Fix it'\\''s problem'");
+			expect(cmd).toBe("bash-agent -- 'Title: Fix it'\\''s problem'");
 		});
 
 		it("escapes task title with dollar signs when interpolated via template", () => {
@@ -1001,7 +1001,7 @@ describe("resolveAgentCommand", () => {
 				taskDescription: "",
 			});
 			const cmd = resolveAgentCommand(simpleAgent, config, c);
-			expect(cmd).toBe("bash-agent 'Work on: Check $HOME path'");
+			expect(cmd).toBe("bash-agent -- 'Work on: Check $HOME path'");
 		});
 
 		it("escapes combined description + appendPrompt with special chars", () => {
@@ -1017,7 +1017,7 @@ describe("resolveAgentCommand", () => {
 			const cmd = resolveAgentCommand(simpleAgent, config, c);
 			// Description + \n\n + interpolated appendPrompt, all shellEscape'd
 			expect(cmd).toBe(
-				"bash-agent 'The $user can'\\''t login\n\nTitle: Fix '\\''auth'\\'' bug'",
+				"bash-agent -- 'The $user can'\\''t login\n\nTitle: Fix '\\''auth'\\'' bug'",
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

Task descriptions starting with `---` (markdown frontmatter, horizontal rule) caused the spawned agent process (claude / codex / gemini / cursor) to exit immediately with `error: unknown option '---…'`. The argument parser (commander / clap / yargs) interpreted the leading `---` as a long option.

Fix: emit a literal `--` before the positional prompt so option parsing is terminated.

OpenCode uses `--prompt <value>` (unambiguous value form) and is unaffected.

Fixes #570