### PR TITLE
fix(tmux): refuse to kill the last remaining pane

### DIFF
--- a/change-logs/2026/05/22/fix-prevent-last-pane-close.md
+++ b/change-logs/2026/05/22/fix-prevent-last-pane-close.md
@@ -1,0 +1,1 @@
+Refuse to kill the last remaining tmux pane in a task session. Repeated clicks on the red kill-pane button no longer take down the agent's own pane — once a single pane is left, the action becomes a no-op.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -4678,6 +4678,45 @@ describe("handlers.tmuxAction", () => {
 			handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "zoom" }),
 		).rejects.toThrow("tmux zoom failed");
 	});
+
+	it("killPane refuses to kill the last remaining pane in the session", async () => {
+		// list-panes returns a single pane → killPane must NOT call kill-pane
+		mockSpawnSync.mockImplementation((args: string[]) => {
+			if (args.includes("list-panes")) {
+				return { exitCode: 0, stdout: new TextEncoder().encode("%1\n"), stderr: new Uint8Array() };
+			}
+			return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array() };
+		});
+
+		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
+
+		const spawnCalls = mockSpawn.mock.calls.map((c) => c[0] as string[]);
+		expect(spawnCalls.some((a) => a.includes("kill-pane"))).toBe(false);
+	});
+
+	it("killPane proceeds normally when more than one pane exists", async () => {
+		mockSpawnSync.mockImplementation((args: string[]) => {
+			if (args.includes("list-panes")) {
+				return { exitCode: 0, stdout: new TextEncoder().encode("%1\n%2\n"), stderr: new Uint8Array() };
+			}
+			if (args.includes("display-message")) {
+				return { exitCode: 0, stdout: new TextEncoder().encode("%2\n"), stderr: new Uint8Array() };
+			}
+			return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array() };
+		});
+		mockSpawn.mockReturnValue({
+			stderr: new Response(""),
+			stdout: new Response(""),
+			exited: Promise.resolve(0),
+		});
+
+		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			["tmux", "-L", "dev3", "kill-pane", "-t", "dev3-abcd1234"],
+			expect.any(Object),
+		);
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1223,8 +1223,21 @@ async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" 
 
 	// For killPane, capture the active pane ID before killing — kill-pane
 	// does NOT trigger tmux's pane-exited hook, so we must clean up sessionState here.
+	// Also refuse to kill the last remaining pane in the session — otherwise repeated
+	// clicks on the red button take down the agent's own pane.
 	let killedPaneId: string | null = null;
 	if (params.action === "killPane") {
+		try {
+			const countResult = spawnSync(pty.tmuxArgs(socket, "list-panes", "-s", "-t", tmuxSession, "-F", "#{pane_id}"));
+			if (countResult.exitCode === 0) {
+				const paneCount = new TextDecoder().decode(countResult.stdout).trim().split("\n").filter((l) => l.length > 0).length;
+				if (paneCount <= 1) {
+					log.info("tmuxAction killPane refused — last pane in session", { taskId: params.taskId.slice(0, 8), paneCount });
+					return;
+				}
+			}
+		} catch { /* best effort — if counting fails, fall through to the normal kill */ }
+
 		try {
 			const idResult = spawnSync(pty.tmuxArgs(socket, "display-message", "-t", tmuxSession, "-p", "#{pane_id}"));
 			if (idResult.exitCode === 0) {


### PR DESCRIPTION
## Summary
- Repeated clicks on the red kill-pane button were closing every pane in the task session, including the one running the agent itself.
- Before invoking `tmux kill-pane`, count panes with `list-panes -s -F '#{pane_id}'`; if only one remains, log and bail out.
- Guard lives in the backend RPC so it covers both the UI button and the `Cmd+W` keymap path.