### PR TITLE
Preserve user-edited task title across agent sessions (#564)

### DIFF
--- a/change-logs/2026/05/22/fix-preserve-user-edited-task-title.md
+++ b/change-logs/2026/05/22/fix-preserve-user-edited-task-title.md
@@ -1,0 +1,3 @@
+Fix task titles being overwritten by the agent on session start when the user had manually renamed them via the UI. The agent skill now sees a `(user-edited)` marker in `dev3 current` and is told to never rename; as a backstop, the CLI's `dev3 task update --title` silently refuses to overwrite a non-empty `customTitle` unless `--force` is passed.
+
+Suggested by @genrym (h0x91b/dev-3.0#564)

--- a/decisions/052-preserve-user-edited-task-title.md
+++ b/decisions/052-preserve-user-edited-task-title.md
@@ -1,0 +1,61 @@
+# 052 — Preserve user-edited task titles across agent sessions
+
+## Context
+
+GitHub issue #564: a user renames a task via the UI, then the agent starts and
+the title gets reverted to a freshly synthesized auto-title. The dev3 skill
+instructs agents to "synthesize a concise title and update it via
+`dev3 task update --title`" if the existing title is long or truncated. The
+agent doesn't know the title was already deliberately set by the user.
+
+## Investigation
+
+- `customTitle` field already exists (`src/shared/types.ts`) and `getTaskTitle`
+  prefers it over the auto-generated `title`. The UI rename flow
+  (`InlineRename`, `TaskDetailModal`) correctly writes `customTitle`.
+- The CLI path `dev3 task update --title` (`cli-socket-server.ts` `task.update`)
+  already set `customTitle` rather than `title`, but unconditionally
+  overwrote whatever was there.
+- `dev3 current` output exposed only the resolved title, so the agent had no
+  way to know the title was user-edited.
+- Net effect: the agent was *technically* following its skill ("rename if too
+  long") with no signal that the user had already chosen a title intentionally.
+
+## Decision
+
+Three-layer defense (`src/bun/cli-socket-server.ts`, `src/cli/commands/current.ts`,
+`src/cli/commands/task.ts`, `src/bun/agent-skills.ts`):
+
+1. **Surface the signal.** `dev3 current` and `dev3 task show` now render the
+   title as `<title> (user-edited — do NOT rename)` whenever `customTitle` is
+   non-empty.
+2. **Tell the agent.** `SKILL_TITLE_GENERATION` in `agent-skills.ts` instructs
+   agents to skip the rename step entirely when the marker is present.
+3. **CLI backstop.** `task.update` RPC silently refuses to overwrite a
+   non-empty `customTitle` when `--title` is passed; the new `--force` flag
+   exists for diagnostics but the skill tells agents never to use it.
+   `--title ""` still clears the custom title (explicit reset).
+
+`task.update` response shape changes from `Task` to
+`{ task: Task; titlePreserved: boolean }`. The CLI handler accepts both
+shapes for forward/backward compatibility with stale binaries.
+
+## Risks
+
+- Response-shape change is internal (only consumer is the dev3 CLI shipped
+  from the same build), but a stale `dev3` binary against a newer app would
+  still work because the CLI handler accepts both shapes.
+- Agents that legitimately want to rename via CLI now need to pass `--force`.
+  This is intentional; agents should not rename in practice — the UI is the
+  rename surface.
+
+## Alternatives considered
+
+- **Prefix-matching the description** (reporter's first suggestion) was rejected
+  because `customTitle` is a stronger, explicit signal than guessing whether
+  the current title looks "user-y".
+- **Skill-only fix.** Insufficient because older / different agents may
+  silently ignore the marker; the CLI guard makes the protection robust.
+- **Server returns an error** instead of preserving silently. Rejected — that
+  would force callers to handle a new error path; preservation with a stderr
+  notice gets the right behavior on the happy path.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -579,6 +579,88 @@ describe("task.update", () => {
 		expect(call.description).toBe("New desc");
 		expect(call.title).toBeUndefined();
 	});
+
+	// Issue #564 — agent following its skill must not overwrite a title the user
+	// already set via the UI. The CLI is the agent-facing entry point; refuse to
+	// overwrite a non-empty customTitle unless --force is passed.
+	it("preserves user-edited customTitle when --title is provided without --force", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "User-set title" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				title: "Agent-proposed rename",
+			}),
+		);
+		expect(resp.ok).toBe(true);
+		// updateTask must NOT be called — nothing to write.
+		expect(data.updateTask).not.toHaveBeenCalled();
+		const result = resp.data as { task: Task; titlePreserved: boolean };
+		expect(result.titlePreserved).toBe(true);
+		expect(result.task.customTitle).toBe("User-set title");
+	});
+
+	it("overwrites user-edited customTitle when --force is set", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "User-set title" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: "Agent override" });
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				title: "Agent override",
+				force: true,
+			}),
+		);
+		expect(resp.ok).toBe(true);
+		const call = vi.mocked(data.updateTask).mock.calls[0][2];
+		expect(call.customTitle).toBe("Agent override");
+		const result = resp.data as { task: Task; titlePreserved: boolean };
+		expect(result.titlePreserved).toBe(false);
+	});
+
+	it("still allows --title to clear customTitle (--title \"\") without --force", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "User-set title" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: null });
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", { taskId: task.id, projectId: "proj-1", title: "" }),
+		);
+		expect(resp.ok).toBe(true);
+		const call = vi.mocked(data.updateTask).mock.calls[0][2];
+		expect(call.customTitle).toBeNull();
+	});
+
+	it("returns task in new envelope shape", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		const updated = { ...task, customTitle: "Updated" };
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		const resp = await handleRequest(
+			makeRequest("task.update", { taskId: task.id, projectId: "proj-1", title: "Updated" }),
+		);
+		expect(resp.ok).toBe(true);
+		const result = resp.data as { task: Task; titlePreserved: boolean };
+		expect(result.task.id).toBe(task.id);
+		expect(result.titlePreserved).toBe(false);
+	});
 });
 
 describe("note.add", () => {

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -50,6 +50,14 @@ longer than ~6 words, synthesize a concise title and update it:
 Good titles: "Fix auth race condition", "Map missing keyboard bindings", "Add drag-to-reorder support"
 Bad titles: copies of the description, vague summaries, titles with ellipsis
 
+**Respect user-edited titles.** If \`dev3 current\` shows the title marked
+\`(user-edited — do NOT rename)\`, the user has explicitly set it via the UI.
+**Skip the rename step entirely** — do NOT call \`dev3 task update --title\`,
+regardless of length or wording. The user's title must be preserved for the
+entire task lifetime. As a backstop, the CLI also silently refuses to overwrite
+a user-edited title; \`--force\` exists for diagnostics only and you must never
+pass it.
+
 When targeting a task other than the auto-detected current worktree task, pass
 \`--task <id>\` or \`--task-id <id>\` explicitly. This works for \`task show\`,
 \`task update\`, \`task move\`, \`note\`, \`overview\`, and \`label set\`.

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -207,8 +207,22 @@ const handlers: Record<string, Handler> = {
 		}
 
 		const updates: Partial<Task> = {};
+		const force = Boolean(params.force);
+		let titlePreserved = false;
 		if (params.title !== undefined) {
-			updates.customTitle = (params.title as string) || null;
+			const newTitle = (params.title as string) || null;
+			const existing = task.customTitle?.trim() || "";
+			// Defensive guard: refuse to overwrite a user-edited customTitle from
+			// the CLI unless --force is passed. The agent skill instructs agents
+			// to leave user-edited titles alone, and this is the backstop.
+			// Empty string (--title "") is treated as an explicit reset and still
+			// goes through, since clearing customTitle restores the auto-generated
+			// title rather than overwriting the user's wording.
+			if (newTitle && existing && newTitle !== existing && !force) {
+				titlePreserved = true;
+			} else {
+				updates.customTitle = newTitle;
+			}
 		}
 		if (params.description !== undefined) {
 			updates.description = params.description as string;
@@ -218,13 +232,16 @@ const handlers: Record<string, Handler> = {
 			}
 		}
 
-		if (Object.keys(updates).length === 0) {
+		if (Object.keys(updates).length === 0 && !titlePreserved) {
 			throw new Error("Nothing to update. Provide --title or --description.");
 		}
 
-		const updated = await data.updateTask(project, task.id, updates);
-		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-		return updated;
+		let updated = task;
+		if (Object.keys(updates).length > 0) {
+			updated = await data.updateTask(project, task.id, updates);
+			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+		}
+		return { task: updated, titlePreserved };
 	},
 
 	"overview.set": async (params) => {

--- a/src/cli/__tests__/current.test.ts
+++ b/src/cli/__tests__/current.test.ts
@@ -132,6 +132,22 @@ describe("handleCurrent", () => {
 
 			expect(stdoutOutput).toContain("Test 1");
 			expect(stdoutOutput).not.toContain("Implement auth");
+			// Issue #564 — agent must see that the title is user-edited.
+			expect(stdoutOutput).toContain("user-edited");
+		});
+
+		it("does not mark the title as user-edited when customTitle is absent", async () => {
+			mockDetect.mockReturnValue({
+				projectId: "proj-001",
+				taskId: FAKE_TASK.id,
+				socketPath: SOCKET,
+			});
+			mockSend.mockResolvedValue(okResp(FAKE_TASK));
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+
+			await handleCurrent(SOCKET);
+
+			expect(stdoutOutput).not.toContain("user-edited");
 		});
 
 		it("shows description when different from title", async () => {

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -285,6 +285,55 @@ describe("task update", () => {
 		).rejects.toThrow("EXIT_3");
 	});
 
+	it("--force flag passes force=true to the server", async () => {
+		mockSend.mockResolvedValue(okResp({ task: FAKE_TASK, titlePreserved: false }));
+
+		await handleTask(
+			"update",
+			args(["aaaaaaaa"], { title: "T", force: "true" }),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.force).toBe(true);
+	});
+
+	it("prints a notice when the server reports titlePreserved=true (issue #564)", async () => {
+		mockSend.mockResolvedValue(okResp({
+			task: { ...FAKE_TASK, customTitle: "User-set title" },
+			titlePreserved: true,
+		}));
+
+		await handleTask(
+			"update",
+			args(["aaaaaaaa"], { title: "Agent rename attempt" }),
+			SOCKET,
+			null,
+		);
+
+		expect(stderrOutput).toContain("title preserved");
+		expect(stderrOutput).toContain("user-edited");
+		expect(stdoutOutput).toContain("Updated task");
+		expect(stdoutOutput).toContain("User-set title");
+	});
+
+	it("accepts legacy Task-shape response without envelope", async () => {
+		// Backward compatibility while old servers may still return Task directly.
+		const updated = { ...FAKE_TASK, customTitle: "Renamed" };
+		mockSend.mockResolvedValue(okResp(updated));
+
+		await handleTask(
+			"update",
+			args(["aaaaaaaa"], { title: "Renamed" }),
+			SOCKET,
+			null,
+		);
+
+		expect(stdoutOutput).toContain("Renamed");
+		expect(stderrOutput).not.toContain("title preserved");
+	});
+
 	it("--project flag overrides context projectId", async () => {
 		mockSend.mockResolvedValue(okResp(FAKE_TASK));
 

--- a/src/cli/commands/current.ts
+++ b/src/cli/commands/current.ts
@@ -32,6 +32,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 				const task = resp.data as Task;
 				const project = readProjectDirect(context.projectId);
 				const displayTitle = getTaskTitle(task);
+				const titleMarker = task.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
 
 				const statusDisplay = task.customColumnId
 					? `${STATUS_LABELS[task.status] || task.status} (in custom column)`
@@ -42,7 +43,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 					["Project ID:", context.projectId],
 					["Task ID:", task.id],
 					["Seq:", String(task.seq)],
-					["Title:", displayTitle],
+					["Title:", `${displayTitle}${titleMarker}`],
 					["Status:", statusDisplay],
 				];
 				if (task.customColumnId) fields.push(["Custom Column:", task.customColumnId.slice(0, 8)]);
@@ -106,9 +107,10 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 	if (task) {
 		const displayTask = task as Pick<Task, "title" | "customTitle">;
 		const displayTitle = getTaskTitle(displayTask as Task);
+		const titleMarker = displayTask.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
 
 		if (task.seq !== undefined) fields.push(["Seq:", String(task.seq)]);
-		if (displayTitle) fields.push(["Title:", displayTitle]);
+		if (displayTitle) fields.push(["Title:", `${displayTitle}${titleMarker}`]);
 		if (task.status) fields.push(["Status:", STATUS_LABELS[task.status as keyof typeof STATUS_LABELS] || (task.status as string)]);
 		if (task.branchName) fields.push(["Branch:", task.branchName as string]);
 		if (task.worktreePath) fields.push(["Worktree:", task.worktreePath as string]);

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -24,10 +24,11 @@ function formatDate(iso: string): string {
 }
 
 function printTask(task: Task): void {
+	const titleMarker = task.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
 	const fields: Array<[string, string]> = [
 		["ID:", task.id],
 		["Seq:", String(task.seq)],
-		["Title:", getTaskTitle(task)],
+		["Title:", `${getTaskTitle(task)}${titleMarker}`],
 		["Status:", STATUS_LABELS[task.status] || task.status],
 	];
 
@@ -113,7 +114,7 @@ async function createTask(args: ParsedArgs, socketPath: string, context: CliCont
 }
 
 async function updateTask(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
-	rejectUnknownFlags(args, ["id", "task", "task-id", "project", "title", "description"]);
+	rejectUnknownFlags(args, ["id", "task", "task-id", "project", "title", "description", "force"]);
 	const taskId = resolveTaskId(args, context);
 	if (!taskId) {
 		exitUsage("Usage: dev3 task update <id|--task id|--task-id id|--id id> --title '...' [--description '...']");
@@ -138,6 +139,9 @@ async function updateTask(args: ParsedArgs, socketPath: string, context: CliCont
 	if (rawDesc !== undefined) {
 		params.description = rawDesc.trim();
 	}
+	if (args.flags.force === "true") {
+		params.force = true;
+	}
 
 	if (params.title === undefined && params.description === undefined) {
 		exitUsage("Provide --title or --description to update");
@@ -146,7 +150,14 @@ async function updateTask(args: ParsedArgs, socketPath: string, context: CliCont
 	const resp = await sendRequest(socketPath, "task.update", params);
 	if (!resp.ok) exitError(resp.error || "Failed to update task");
 
-	const task = resp.data as Task;
+	const result = resp.data as Task | { task: Task; titlePreserved?: boolean };
+	const task = "task" in result ? result.task : result;
+	const titlePreserved = "task" in result ? Boolean(result.titlePreserved) : false;
+	if (titlePreserved) {
+		process.stderr.write(
+			`Note: title preserved — task ${task.id.slice(0, 8)} has a user-edited title that the CLI will not overwrite. Pass --force to override.\n`,
+		);
+	}
 	process.stdout.write(`Updated task ${task.id.slice(0, 8)}: ${getTaskTitle(task)}\n`);
 }
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Fixes #564 — when a user manually renamed a task via the UI, the agent would overwrite the custom title on session start by following its "rename if too long" skill instruction.

Three-layer defense:

1. **Signal to the agent** — `dev3 current` and `dev3 task show` now mark the title `(user-edited — do NOT rename)` whenever `customTitle` is set.
2. **Skill instruction** — `SKILL_TITLE_GENERATION` in `agent-skills.ts` tells agents to skip the rename step entirely when that marker is present.
3. **CLI backstop** — `task.update` RPC silently refuses to overwrite a non-empty `customTitle` from `--title` unless `--force` is passed (skill tells agents never to use it). `--title ""` still clears the custom title as before.

`task.update` response shape changed from `Task` to `{ task: Task; titlePreserved: boolean }`; the CLI handler accepts both shapes for compatibility.

## Tests

- `cli-socket-handlers.test.ts`: +4 (preservation without force, override with force, empty reset, response envelope shape).
- `cli/__tests__/current.test.ts`: +2 (marker visible / not visible).
- `cli/__tests__/task.test.ts`: +3 (--force passthrough, titlePreserved notice, legacy shape backward compat).

All bun (1176), CLI (283), and mainview (1157) tests pass. `bun run lint` clean.

See `decisions/052-preserve-user-edited-task-title.md` for the full rationale.