### PR TITLE
fix: detect gh CLI auth on older versions without --json (#569)

### DIFF
--- a/change-logs/2026/05/22/fix-gh-old-version-auth-detection.md
+++ b/change-logs/2026/05/22/fix-gh-old-version-auth-detection.md
@@ -1,0 +1,3 @@
+Fix GitHub CLI auth detection on older `gh` versions (e.g. v2.45.0) where `gh auth status --json hosts` exits with `unknown flag: --json`. The app now falls back to parsing the plain `gh auth status` text output, so authenticated users no longer see a false "GitHub CLI is not signed in" banner.
+
+Suggested by @eyalizhaki (h0x91b/dev-3.0#569)

--- a/src/bun/__tests__/github.test.ts
+++ b/src/bun/__tests__/github.test.ts
@@ -110,6 +110,77 @@ describe("github", () => {
 		});
 	});
 
+	it("falls back to plain gh auth status when --json flag is unsupported (old gh)", async () => {
+		whichMock.mockResolvedValue("/usr/bin/gh");
+		spawnMock.mockImplementation((cmd: string[]) => {
+			if (cmd.join(" ") === "gh auth status --json hosts") {
+				return fakeProc("", "unknown flag: --json\n\nUsage:\n  gh auth status [flags]\n", 1);
+			}
+			if (cmd.join(" ") === "gh auth status") {
+				// Old gh writes auth status output to stderr.
+				const text =
+					"github.com\n" +
+					"  ✓ Logged in to github.com as h0x91b (oauth_token)\n" +
+					"  ✓ Git operations for github.com configured to use https protocol.\n" +
+					"  ✓ Token: gho_******\n";
+				return fakeProc("", text, 0);
+			}
+			throw new Error(`Unexpected command: ${cmd.join(" ")}`);
+		});
+
+		const { getGitHubCliStatus } = await import("../github");
+		await expect(getGitHubCliStatus()).resolves.toEqual({
+			authStatus: "authenticated",
+			binaryPath: "/usr/bin/gh",
+			accounts: [{ login: "h0x91b", host: "github.com", active: true }],
+		});
+	});
+
+	it("fallback parses plain output written to stdout instead of stderr", async () => {
+		whichMock.mockResolvedValue("/usr/bin/gh");
+		spawnMock.mockImplementation((cmd: string[]) => {
+			if (cmd.join(" ") === "gh auth status --json hosts") {
+				return fakeProc("", "unknown flag: --json\n", 1);
+			}
+			if (cmd.join(" ") === "gh auth status") {
+				const text =
+					"github.com\n" +
+					"  ✓ Logged in to github.com as h0x91b-wix (keyring)\n" +
+					"  ✓ Logged in to github.com as h0x91b (oauth_token)\n";
+				return fakeProc(text, "", 0);
+			}
+			throw new Error(`Unexpected command: ${cmd.join(" ")}`);
+		});
+
+		const { getGitHubCliStatus } = await import("../github");
+		const status = await getGitHubCliStatus();
+		expect(status.authStatus).toBe("authenticated");
+		expect(status.accounts).toEqual([
+			{ login: "h0x91b-wix", host: "github.com", active: true },
+			{ login: "h0x91b", host: "github.com", active: false },
+		]);
+	});
+
+	it("returns not_authenticated when fallback gh auth status also fails", async () => {
+		whichMock.mockResolvedValue("/usr/bin/gh");
+		spawnMock.mockImplementation((cmd: string[]) => {
+			if (cmd.join(" ") === "gh auth status --json hosts") {
+				return fakeProc("", "unknown flag: --json\n", 1);
+			}
+			if (cmd.join(" ") === "gh auth status") {
+				return fakeProc("", "You are not logged into any GitHub hosts.\n", 1);
+			}
+			throw new Error(`Unexpected command: ${cmd.join(" ")}`);
+		});
+
+		const { getGitHubCliStatus } = await import("../github");
+		await expect(getGitHubCliStatus()).resolves.toEqual({
+			authStatus: "not_authenticated",
+			binaryPath: "/usr/bin/gh",
+			accounts: [],
+		});
+	});
+
 	it("builds shell exports for the resolved account", async () => {
 		whichMock.mockResolvedValue("/opt/homebrew/bin/gh");
 		spawnMock.mockReturnValue(fakeProc(JSON.stringify({

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -70,6 +70,31 @@ async function runGh(
 	};
 }
 
+const UNSUPPORTED_JSON_FLAG_PATTERN = /unknown (flag|command|option)/i;
+
+function isJsonFlagUnsupported(result: GitHubCommandResult): boolean {
+	if (result.ok) return false;
+	return UNSUPPORTED_JSON_FLAG_PATTERN.test(result.stderr);
+}
+
+function parsePlainAuthStatus(output: string): GitHubAccount[] {
+	const accounts: GitHubAccount[] = [];
+	const seen = new Set<string>();
+	const loggedInPattern = /Logged in to (\S+) as ([^\s(]+)/g;
+	let match: RegExpExecArray | null;
+	let isFirst = true;
+	while ((match = loggedInPattern.exec(output)) !== null) {
+		const host = match[1];
+		const login = match[2];
+		const key = `${host}\0${login}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		accounts.push({ host, login, active: isFirst });
+		isFirst = false;
+	}
+	return accounts;
+}
+
 function parseAccounts(payload: GhAuthStatusResponse): GitHubAccount[] {
 	const seen = new Set<string>();
 	const accounts: GitHubAccount[] = [];
@@ -111,6 +136,29 @@ export async function getGitHubCliStatus(): Promise<GitHubCliStatus> {
 	}
 
 	const result = await runGh(["auth", "status", "--json", "hosts"]);
+
+	// Older gh versions (e.g. v2.45.0) don't support --json. Fall back to plain text parsing.
+	if (isJsonFlagUnsupported(result)) {
+		log.info("gh --json unsupported, falling back to plain `gh auth status`", { stderr: result.stderr });
+		const fallback = await runGh(["auth", "status"]);
+		// Old gh writes auth status to stderr; newer versions to stdout. Check both.
+		const text = `${fallback.stdout}\n${fallback.stderr}`;
+		const accounts = parsePlainAuthStatus(text);
+		if (accounts.length === 0) {
+			log.warn("gh auth status (plain) reported no accounts", { code: fallback.code, stderr: fallback.stderr });
+			return {
+				authStatus: "not_authenticated",
+				binaryPath,
+				accounts: [],
+			};
+		}
+		return {
+			authStatus: "authenticated",
+			binaryPath,
+			accounts,
+		};
+	}
+
 	if (!result.ok || !result.stdout) {
 		log.warn("gh auth status failed", { code: result.code, stderr: result.stderr });
 		return {


### PR DESCRIPTION
## Summary

- Older `gh` versions (e.g. v2.45.0) reject `gh auth status --json hosts` with `unknown flag: --json`, which made the app treat fully-authenticated users as "not signed in" and show the warning banner.
- When stderr matches `unknown (flag|command|option)`, fall back to plain `gh auth status` and parse the human-readable `Logged in to <host> as <login>` lines.
- Old `gh` writes auth status to stderr, newer versions to stdout — we now check both streams.
- Behavior for installed-but-not-authenticated and not-installed paths is unchanged.

Closes #569