### PR TITLE
Fix merge-complete popup completion

### DIFF
--- a/change-logs/2026/05/24/fix-merge-complete-popup.md
+++ b/change-logs/2026/05/24/fix-merge-complete-popup.md
@@ -1,0 +1,1 @@
+Fixed the merge-complete popup inside the full task view so confirming it immediately moves the task to completed while cleanup runs in the background, matching the existing manual complete flow.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1823,10 +1823,44 @@ describe("TaskInfoPanel", () => {
 			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
 		});
 
-		it("shows an error and skips the optimistic completion when both completion RPC attempts fail", async () => {
+		it("optimistically completes after merge even while the move RPC is still pending", async () => {
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "review-by-user" });
+			mockedApi.request.showConfirm.mockResolvedValue(true);
+			mockedApi.request.moveTask.mockReturnValue(new Promise(() => {}) as never);
+
+			await act(async () => {
+				renderPanel(task, { dispatch, navigate });
+			});
+
+			await act(async () => {
+				window.dispatchEvent(
+					new CustomEvent("rpc:gitOpCompleted", {
+						detail: { taskId: "t1", operation: "merge", ok: true },
+					}),
+				);
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.showConfirm).toHaveBeenCalled();
+			});
+
+			await waitFor(() => {
+				const completedUpdate = dispatch.mock.calls.find(
+					(call: unknown[]) => (call[0] as AppAction).type === "updateTask"
+						&& ((call[0] as { task: Task }).task).status === "completed",
+				);
+				expect(completedUpdate).toBeDefined();
+			});
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+		});
+
+		it("keeps the optimistic completion when both background completion RPC attempts fail", async () => {
 			const dispatch = vi.fn();
 			const navigate = vi.fn();
 			const alertSpy = vi.fn();
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 			const task = makeTask({ status: "review-by-user" });
 
 			window.alert = alertSpy;
@@ -1853,17 +1887,17 @@ describe("TaskInfoPanel", () => {
 			await waitFor(() => {
 				expect(mockedApi.request.moveTask).toHaveBeenCalledTimes(2);
 			});
-			await waitFor(() => {
-				expect(alertSpy).toHaveBeenCalled();
-			});
 
 			const completedUpdate = dispatch.mock.calls.find(
 				(call: unknown[]) => (call[0] as AppAction).type === "updateTask"
 					&& ((call[0] as { task: Task }).task).status === "completed",
 			);
 
-			expect(completedUpdate).toBeUndefined();
-			expect(navigate).not.toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(completedUpdate).toBeDefined();
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(alertSpy).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+			consoleErrorSpy.mockRestore();
 		});
 	});
 

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -59,27 +59,7 @@ export function useTaskBranchStatus({
 		setCompareRef(defaultCompareRef);
 	}, [defaultCompareRef, task.id]);
 
-	const completeTask = useCallback(async (fromStatus: Task["status"]) => {
-		try {
-			await api.request.moveTask({
-				taskId: task.id,
-				projectId: project.id,
-				newStatus: "completed",
-			});
-		} catch {
-			try {
-				await api.request.moveTask({
-					taskId: task.id,
-					projectId: project.id,
-					newStatus: "completed",
-					force: true,
-				});
-			} catch (err) {
-				alert(t("task.failedMove", { error: String(err) }));
-				return;
-			}
-		}
-
+	const completeTask = useCallback((fromStatus: Task["status"]) => {
 		dispatch({
 			type: "updateTask",
 			task: {
@@ -94,7 +74,20 @@ export function useTaskBranchStatus({
 		dispatch({ type: "clearBell", taskId: task.id });
 		trackEvent("task_moved", { from_status: fromStatus, to_status: "completed" });
 		navigate({ screen: "project", projectId: project.id });
-	}, [dispatch, navigate, project.id, t, task]);
+
+		api.request.moveTask({
+			taskId: task.id,
+			projectId: project.id,
+			newStatus: "completed",
+		}).catch(() => {
+			api.request.moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: "completed",
+				force: true,
+			}).catch((err) => console.error("moveTask (merge-complete popup) failed:", err));
+		});
+	}, [dispatch, navigate, project.id, task]);
 
 	useEffect(() => {
 		if (!isTaskActive || !task.worktreePath) {


### PR DESCRIPTION
## Summary
- make the merge-complete popup use the same optimistic completion flow as manual completion
- keep cleanup running in the background with the existing force fallback
- add regression coverage for a pending completion RPC

## Tests
- bun run test