### PR TITLE
docs(skill): clarify "open a pane" means a tmux pane in dev3 session

### DIFF
--- a/change-logs/2026/05/25/docs-tmux-pane-placement-guidance.md
+++ b/change-logs/2026/05/25/docs-tmux-pane-placement-guidance.md
@@ -1,0 +1,1 @@
+Clarified the tmux guidance in the dev3 agent skills: spelled out that "open a pane" means splitting the agent's current dev3 tmux pane, and added a short placement hint (check `list-panes` first, default to the right of the agent, fall back to below or a new window). Applied to both the short `/dev3` summary and the full `/dev3-tmux` reference.

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -155,7 +155,7 @@ You are running **inside a tmux session** managed by dev-3.0 (socket \`dev3\`, s
 
 **Be proactive:**
 
-- For long-running or streaming commands (dev server, log tail, watcher, debug loop), open a pane and run it there — the user can watch it live. Quick one-shot commands stay inline.
+- For long-running or streaming commands (dev server, log tail, watcher, debug loop), **split your current dev3 tmux pane and run the command in the new one** — the user watches it live next to your agent. Check the existing layout with \`list-panes\` first and pick a sensible spot (usually right of the agent; below if the right is taken). Quick one-shot commands stay inline.
 - If the user asks to open/split/reorder/resize tabs or panes — just do it via \`tmux -L dev3 ...\`, do not ask which terminal.
 - Always use \`-L dev3\` (the default socket is a different tmux server and will not see dev3 sessions).
 - For \`send-keys\`, pass \`Enter\` as a separate argument — otherwise the command is typed but not executed.
@@ -503,6 +503,8 @@ Keep using **inline Bash** for quick one-shot commands (file reads, short git, t
 **Do NOT use a tmux pane as a substitute for the canonical dev server** — the project has \`dev3 dev-server start\` for that, which is wired to \`devScript\` and the UI. Use ad-hoc panes for things the user wants to *watch alongside* the dev server, not to replace it.
 
 ## 4. Open a pane or window and run a command
+
+**Pick the location before splitting.** Run \`list-panes\` first to see what's already open. Default: split to the right of your agent pane. If the right is occupied, split below or open a new window. Prefer splits over new windows unless the user asks for a tab or the window is already full.
 
 ### Vertical split (new pane on the right)
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Tightened the tmux guidance in the dev3 agent skills so it's unambiguous what "open a pane" means.

- **`/dev3` skill (short summary):** the bullet about long-running / streaming commands now says explicitly "split your current dev3 tmux pane and run the command in the new one" — instead of the ambiguous "open a pane". Added a one-line placement hint: check `list-panes` first, default to the right of the agent pane, fall back to below if the right is taken.
- **`/dev3-tmux` skill (full reference):** the `## 4. Open a pane or window` section now opens with one short paragraph on picking the location (default right of the agent, fall back to below or a new window), instead of a longer 5-bullet heuristics list with `$SESSION` placeholders and explicit `split-window -h/-v` examples — the LLM already knows those commands.

No behavior change, no code touched outside `src/bun/agent-skills.ts` and the corresponding changelog entry.