### PR TITLE
fix: update Codex config patcher for 0.133 schema renames

### DIFF
--- a/change-logs/2026/05/25/fix-codex-0.133-config-keys.md
+++ b/change-logs/2026/05/25/fix-codex-0.133-config-keys.md
@@ -1,0 +1,1 @@
+Updated the auto-managed `~/.codex/config.toml` patcher to match Codex 0.133 schema: `[permissions.*.filesystem.":project_roots"]` → `":workspace_roots"` and `[features].codex_hooks` → `[features].hooks`. Existing user configs are migrated on next app startup so the deprecation warnings stop appearing.

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -12,7 +12,7 @@ describe("ensureCodexConfig", () => {
 			expect(result).toContain('trust_level = "trusted"');
 			expect(result).toContain('default_permissions = "workspace"');
 			expect(result).toContain("[permissions.workspace.filesystem]");
-			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain('[permissions.workspace.filesystem.":workspace_roots"]');
 			expect(result).toContain("[permissions.workspace.network]");
 			// Permission profile
 			expect(result).toContain("[permissions.dev3.filesystem]");
@@ -20,7 +20,7 @@ describe("ensureCodexConfig", () => {
 			expect(result).toContain('"/Users/testuser/.codex/skills" = "read"');
 			expect(result).toContain('"/Users/testuser/.agents/skills" = "read"');
 			expect(result).toContain('"/Users/testuser/.dev3.0" = "write"');
-			expect(result).toContain('[permissions.dev3.filesystem.":project_roots"]');
+			expect(result).toContain('[permissions.dev3.filesystem.":workspace_roots"]');
 			expect(result).toContain('"." = "write"');
 			expect(result).toContain("[permissions.dev3.network]");
 			expect(result).toContain("enabled = true");
@@ -33,7 +33,8 @@ describe("ensureCodexConfig", () => {
 			expect(result).not.toContain('tui.theme = "github"');
 			expect(result).not.toContain('tui.theme = "dracula"');
 			expect(result).toContain("[features]");
-			expect(result).toContain("codex_hooks = true");
+			expect(result).toContain("hooks = true");
+			expect(result).not.toContain("codex_hooks");
 		});
 
 		it("creates a generic workspace profile and uses it as default_permissions when missing", () => {
@@ -41,7 +42,7 @@ describe("ensureCodexConfig", () => {
 			expect(result).toContain('default_permissions = "workspace"');
 			expect(result).toContain("[permissions.workspace.filesystem]");
 			expect(result).toContain('":minimal" = "read"');
-			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain('[permissions.workspace.filesystem.":workspace_roots"]');
 			expect(result).toContain('"." = "write"');
 			expect(result).toContain("[permissions.workspace.network]");
 			expect(result).toContain("enabled = true");
@@ -78,7 +79,7 @@ trust_level = "trusted"
 [permissions.dev3.filesystem]
 ":minimal" = "read"
 
-[permissions.dev3.filesystem.":project_roots"]
+[permissions.dev3.filesystem.":workspace_roots"]
 "." = "write"
 
 [permissions.dev3.network]
@@ -103,7 +104,7 @@ enabled = false
 			expect(result).toContain('default_permissions = "workspace"');
 			expect(result).toContain("[permissions.workspace.filesystem]");
 			expect(result).toContain('":minimal" = "read"');
-			expect(result).toContain('[permissions.workspace.filesystem.":project_roots"]');
+			expect(result).toContain('[permissions.workspace.filesystem.":workspace_roots"]');
 			expect(result).toContain('"." = "write"');
 			expect(result).toContain("[permissions.workspace.network]");
 			expect(result).toContain("enabled = true");
@@ -122,7 +123,7 @@ trust_level = "trusted"
 "~/.codex/skills" = "read"
 "~/.agents/skills" = "read"
 
-[permissions.dev3.filesystem.":project_roots"]
+[permissions.dev3.filesystem.":workspace_roots"]
 "." = "write"
 
 [permissions.dev3.network]
@@ -141,7 +142,7 @@ web_search = "live"
 # tui.theme = "dracula"
 
 [features]
-codex_hooks = true
+hooks = true
 `;
 			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
 			const projectMatches = result.match(/\[projects\."[^"]*worktrees"\]/g);
@@ -180,7 +181,7 @@ tui.theme = "old-dark"
 	});
 
 	describe("when features section exists", () => {
-		it("adds codex_hooks without removing other feature flags", () => {
+		it("adds hooks without removing other feature flags", () => {
 			const existing = `[features]
 experimental_resume = true
 `;
@@ -188,17 +189,46 @@ experimental_resume = true
 
 			expect(result).toContain("[features]");
 			expect(result).toContain("experimental_resume = true");
-			expect(result).toContain("codex_hooks = true");
+			expect(result).toContain("hooks = true");
 		});
 
-		it("updates codex_hooks to true when it was false", () => {
+		it("updates hooks to true when it was false", () => {
 			const existing = `[features]
-codex_hooks = false
+hooks = false
 `;
 			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
 
-			expect(result).toContain("codex_hooks = true");
-			expect(result).not.toContain("codex_hooks = false");
+			expect(result).toContain("hooks = true");
+			expect(result).not.toContain("hooks = false");
+		});
+
+		it("renames deprecated codex_hooks → hooks", () => {
+			const existing = `[features]
+codex_hooks = true
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+
+			expect(result).toContain("hooks = true");
+			expect(result).not.toContain("codex_hooks");
+		});
+	});
+
+	describe("legacy :project_roots migration", () => {
+		it("renames dev3 :project_roots → :workspace_roots", () => {
+			const existing = `[permissions.dev3.filesystem]
+":minimal" = "read"
+
+[permissions.dev3.filesystem.":project_roots"]
+"." = "write"
+
+[permissions.dev3.network]
+enabled = true
+allow_unix_sockets = ["${SOCKETS_PATH}"]
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+
+			expect(result).toContain('[permissions.dev3.filesystem.":workspace_roots"]');
+			expect(result).not.toContain(':project_roots');
 		});
 	});
 

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -211,6 +211,22 @@ codex_hooks = true
 			expect(result).toContain("hooks = true");
 			expect(result).not.toContain("codex_hooks");
 		});
+
+		it("drops codex_hooks when hooks is already present alongside it", () => {
+			// Codex 0.133+ silently mirrors the deprecated alias into `hooks`,
+			// so both keys can end up in the file at once.
+			const existing = `[features]
+codex_hooks = true
+hooks = true
+js_repl = false
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH);
+
+			expect(result).toContain("hooks = true");
+			expect(result).toContain("js_repl = false");
+			expect(result).not.toContain("codex_hooks");
+			expect(result.match(/^hooks\s*=/gm)).toHaveLength(1);
+		});
 	});
 
 	describe("legacy :project_roots migration", () => {

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -97,7 +97,7 @@ export function ensureCodexConfig(
 			`"${userHome}/.agents/skills" = "read"`,
 			`"${dev3Home}" = "write"`,
 			"",
-			`[permissions.${DEV3_CODEX_PROFILE}.filesystem.":project_roots"]`,
+			`[permissions.${DEV3_CODEX_PROFILE}.filesystem.":workspace_roots"]`,
 			'"." = "write"',
 			"",
 			`[permissions.${DEV3_CODEX_PROFILE}.network]`,
@@ -157,7 +157,7 @@ export function ensureCodexConfig(
 	if (parsed.default_permissions == null) {
 		const workspacePerm = parsed.permissions?.[WORKSPACE_CODEX_PROFILE] as CodexPermissionsProfile | undefined;
 		const workspaceFsHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem]`;
-		const workspaceProjectRootsHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem.":project_roots"]`;
+		const workspaceProjectRootsHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem.":workspace_roots"]`;
 		const workspaceNetworkHeader = `[permissions.${WORKSPACE_CODEX_PROFILE}.network]`;
 
 		if (workspacePerm == null) {
@@ -215,14 +215,15 @@ export function ensureCodexConfig(
 		// wiring disabled until we map the new Codex theme schema.
 	});
 
-	// --- 5. Ensure [features] codex_hooks = true ---
-	const codexHooksEnabled = parsed.features?.codex_hooks === true;
-	if (!codexHooksEnabled) {
+	// --- 5. Ensure [features] hooks = true ---
+	// Codex 0.133+ renamed `codex_hooks` → `hooks` (the old name is a deprecated alias).
+	const hooksEnabled = parsed.features?.hooks === true;
+	if (!hooksEnabled) {
 		const featuresHeader = "[features]";
 		if (!config.includes(featuresHeader)) {
-			config = appendBlock(config, `\n${featuresHeader}\ncodex_hooks = true\n`);
+			config = appendBlock(config, `\n${featuresHeader}\nhooks = true\n`);
 		} else {
-			config = upsertSectionLine(config, featuresHeader, "codex_hooks", "true");
+			config = upsertSectionLine(config, featuresHeader, "hooks", "true");
 		}
 	}
 
@@ -239,7 +240,47 @@ function cleanupLegacySections(content: string): string {
 	if (content.includes(".dev3.0/sockets")) {
 		content = removeSectionByHeader(content, "[permissions.network]");
 	}
+
+	// Codex 0.133+ renamed `:project_roots` → `:workspace_roots` in filesystem
+	// permission paths. Rewrite the headers we manage (dev3 + workspace).
+	content = content.replaceAll(
+		`[permissions.${DEV3_CODEX_PROFILE}.filesystem.":project_roots"]`,
+		`[permissions.${DEV3_CODEX_PROFILE}.filesystem.":workspace_roots"]`,
+	);
+	content = content.replaceAll(
+		`[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem.":project_roots"]`,
+		`[permissions.${WORKSPACE_CODEX_PROFILE}.filesystem.":workspace_roots"]`,
+	);
+
+	// Codex 0.133+ renamed `[features].codex_hooks` → `[features].hooks`
+	// (`codex_hooks` is still parsed as a deprecated alias but emits a warning).
+	content = renameFeaturesKey(content, "codex_hooks", "hooks");
+
 	return content;
+}
+
+/**
+ * Rename a key inside the [features] table, preserving its value. No-op if
+ * the section or key does not exist, or if the new key already exists.
+ */
+function renameFeaturesKey(content: string, oldKey: string, newKey: string): string {
+	const featuresHeader = "[features]";
+	const headerIdx = content.indexOf(featuresHeader);
+	if (headerIdx === -1) return content;
+
+	const sectionStart = headerIdx + featuresHeader.length;
+	const nextSection = content.indexOf("\n[", sectionStart);
+	const sectionEnd = nextSection === -1 ? content.length : nextSection;
+	const section = content.slice(sectionStart, sectionEnd);
+
+	const newKeyPattern = new RegExp(`^\\s*${newKey}\\s*=`, "m");
+	if (newKeyPattern.test(section)) return content;
+
+	const oldKeyPattern = new RegExp(`^(\\s*)${oldKey}(\\s*=)`, "m");
+	if (!oldKeyPattern.test(section)) return content;
+
+	const updatedSection = section.replace(oldKeyPattern, `$1${newKey}$2`);
+	return content.slice(0, sectionStart) + updatedSection + content.slice(sectionEnd);
 }
 
 function commentOutManagedProfileThemeLines(content: string): string {

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -254,16 +254,19 @@ function cleanupLegacySections(content: string): string {
 
 	// Codex 0.133+ renamed `[features].codex_hooks` → `[features].hooks`
 	// (`codex_hooks` is still parsed as a deprecated alias but emits a warning).
-	content = renameFeaturesKey(content, "codex_hooks", "hooks");
+	content = migrateCodexHooksKey(content);
 
 	return content;
 }
 
 /**
- * Rename a key inside the [features] table, preserving its value. No-op if
- * the section or key does not exist, or if the new key already exists.
+ * Migrate the deprecated `[features].codex_hooks` key to `[features].hooks`.
+ * - If only `codex_hooks` exists: rename it.
+ * - If both exist (Codex 0.133+ silently mirrors the alias into `hooks`):
+ *   delete the `codex_hooks` line so Codex stops warning.
+ * - If neither or only `hooks` exists: no-op.
  */
-function renameFeaturesKey(content: string, oldKey: string, newKey: string): string {
+function migrateCodexHooksKey(content: string): string {
 	const featuresHeader = "[features]";
 	const headerIdx = content.indexOf(featuresHeader);
 	if (headerIdx === -1) return content;
@@ -273,13 +276,14 @@ function renameFeaturesKey(content: string, oldKey: string, newKey: string): str
 	const sectionEnd = nextSection === -1 ? content.length : nextSection;
 	const section = content.slice(sectionStart, sectionEnd);
 
-	const newKeyPattern = new RegExp(`^\\s*${newKey}\\s*=`, "m");
-	if (newKeyPattern.test(section)) return content;
+	const codexHooksLinePattern = /^[ \t]*codex_hooks[ \t]*=[^\n]*\n?/m;
+	if (!codexHooksLinePattern.test(section)) return content;
 
-	const oldKeyPattern = new RegExp(`^(\\s*)${oldKey}(\\s*=)`, "m");
-	if (!oldKeyPattern.test(section)) return content;
+	const hooksPresent = /^[ \t]*hooks[ \t]*=/m.test(section);
+	const updatedSection = hooksPresent
+		? section.replace(codexHooksLinePattern, "")
+		: section.replace(codexHooksLinePattern, (line) => line.replace("codex_hooks", "hooks"));
 
-	const updatedSection = section.replace(oldKeyPattern, `$1${newKey}$2`);
 	return content.slice(0, sectionStart) + updatedSection + content.slice(sectionEnd);
 }
 

--- a/src/cli/commands/install-skills.ts
+++ b/src/cli/commands/install-skills.ts
@@ -33,5 +33,5 @@ export async function handleInstallSkills(): Promise<void> {
 	process.stdout.write(`  ~/.agents/skills/*/agents/openai.yaml (managed skill metadata)\n`);
 	process.stdout.write(`  ~/.agents/AGENTS.md (dev3 block)\n`);
 	process.stdout.write(`  ~/.claude/settings.json (Bash permission)\n`);
-	process.stdout.write(`  ~/.codex/config.toml (trust + socket access + codex_hooks)\n`);
+	process.stdout.write(`  ~/.codex/config.toml (trust + socket access + hooks)\n`);
 }


### PR DESCRIPTION
## Summary

Codex 0.133 renamed two keys in `config.toml` and emits deprecation warnings (and silently ignores) the old names:

- `permissions.*.filesystem.":project_roots"` → `":workspace_roots"`
- `[features].codex_hooks` → `[features].hooks`

This was visible on launch as:

```
⚠ Configured filesystem path `:project_roots` is not recognized by this version of Codex and will be ignored.
⚠ `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.
```

The `:project_roots` warning was more than cosmetic — it meant the `[permissions.dev3.filesystem.":project_roots"] "." = "write"` rule we install was being silently ignored on Codex 0.133+, so the dev3 permission profile lost its in-worktree write grant.

Changes:

- `src/bun/codex-config.ts`
  - Emit the new key names when creating sections (`:workspace_roots`, `hooks`).
  - `cleanupLegacySections` migrates existing files in place:
    - Rewrite the two `:project_roots` headers we manage (`permissions.dev3.*` and `permissions.workspace.*`) to `:workspace_roots`. User-owned profiles are left alone.
    - Inside `[features]`: rename `codex_hooks` → `hooks` when only the deprecated alias exists. If both already exist (Codex 0.133+ silently mirrors the alias into `hooks`, so users can end up with duplicates), drop the `codex_hooks` line so Codex stops warning.
- `src/cli/commands/install-skills.ts`: updated the trailing summary line to say `hooks` instead of `codex_hooks`.
- Tests: updated existing assertions to the new key names, added coverage for the rename + the dedupe case.

## Test plan

- [x] `bun run lint`
- [x] `bun run test` (46 backend files / 1175 tests + 62 mainview files / 1162 tests — all green)
- [x] Manual: relaunched the app from this branch against a real `~/.codex/config.toml` containing both legacy keys → patcher rewrote `:project_roots` → `:workspace_roots` and removed the duplicate `codex_hooks`. New Codex panes start without either warning.
- [ ] Reviewer: confirm no third-party `[permissions.<custom>.filesystem.":project_roots"]` sections are touched (only `dev3` + `workspace` are migrated).