### PR TITLE
Preserve customTitle through spawnVariants and addAttempts (#583)

### DIFF
--- a/change-logs/2026/05/27/fix-spawn-variants-preserve-custom-title.md
+++ b/change-logs/2026/05/27/fix-spawn-variants-preserve-custom-title.md
@@ -1,0 +1,3 @@
+Preserve the user-edited customTitle when the source task is replaced by spawnVariants (Save and Run) and when addAttempts creates new attempts. Previously the new tasks were created from `description` only, silently dropping the title the user had typed in the Create-Task modal.
+
+Suggested by @genrym (h0x91b/dev-3.0#583)

--- a/decisions/055-spawn-variants-preserve-custom-title.md
+++ b/decisions/055-spawn-variants-preserve-custom-title.md
@@ -1,0 +1,37 @@
+# 055 — spawnVariants / addAttempts must preserve customTitle
+
+## Context
+
+Issue [#583](https://github.com/h0x91b/dev-3.0/issues/583) — reopen of [#564](https://github.com/h0x91b/dev-3.0/issues/564). User reported that even on v1.15.2 a custom title typed in the Create-Task modal still got overwritten as soon as the agent started running.
+
+The earlier fix (decision [052](./052-preserve-user-edited-task-title.md)) protected only the agent-facing CLI path: the skill instructs agents to skip the rename and `task.update` refuses to overwrite `customTitle` without `--force`. Those guards were correct but did not cover the regression path.
+
+## Investigation
+
+The Create-Task modal flow is:
+
+1. `createTaskWithBranch` (`src/mainview/components/CreateTaskModal.tsx:174`) calls `api.request.createTask({ description })`.
+2. If the user typed a custom title, it calls `api.request.renameTask({ customTitle })`. At this point the task has `customTitle` set correctly.
+3. On "Save and Run" the modal hands the task off to `LaunchVariantsModal`, which calls `api.request.spawnVariants` (`src/bun/rpc-handlers/task-lifecycle.ts:788`).
+4. `spawnVariants` calls `data.addTask(project, sourceTask.description, ...)` for each variant and then deletes the original source task (line 841 pre-fix). The new tasks are seeded from `description` only — `customTitle` is not in the extras object passed to `addTask`, so the new task's `title` is recomputed via `titleFromDescription(description)` and `customTitle` is left null.
+
+`addAttempts` (`src/bun/rpc-handlers/task-lifecycle.ts:876`) had the same shape and the same defect.
+
+## Decision
+
+Carry `customTitle` from the source task onto every new task created by `spawnVariants` and `addAttempts`.
+
+1. Extended the `extras` parameter of `data.addTask` (`src/bun/data.ts`) with an optional `customTitle?: string | null` and forwarded it onto the new `Task`.
+2. Passed `customTitle: sourceTask.customTitle` in both spawn paths (`src/bun/rpc-handlers/task-lifecycle.ts`).
+
+Tests added in `src/bun/__tests__/rpc-handlers.test.ts` cover both call sites and assert `data.addTask` is invoked with the inherited `customTitle`.
+
+## Risks
+
+- `customTitle` is the only user-edited field carried across the source → variant boundary. `labelIds`, `overview`, `userOverview`, and `notes` are still reset on every variant. That matches the prior behaviour and is out of scope for #583, but it is the next logical follow-up if users report the same surprise for labels.
+- The fix only takes effect for variants spawned *after* the build that contains it. Tasks already broken on disk still need a manual rename (or `dev3 task update --title ...` from the user side).
+
+## Alternatives considered
+
+- **Carry every user-edited field on the source task (labels, overviews, notes).** Larger blast radius, no user signal that this was wanted, and would have to make a call on per-variant divergence. Rejected — keep the change minimal and tied to the reported bug.
+- **Have `spawnVariants` call `renameTask` after `addTask`.** Two writes per variant for a single inherited string, plus the second write would have to dodge the `task.update` guard. Rejected in favour of a single `addTask` call.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2534,6 +2534,36 @@ describe("handlers.spawnVariants", () => {
 		});
 		expect(cowClone.clonePaths).toHaveBeenCalledWith(project.path, "/tmp/vwt", ["branch-cache"]);
 	});
+
+	// Issue #583 — spawnVariants used to drop the user-edited customTitle from
+	// the source task. The new variants must inherit it so the title the user
+	// typed in the Create-Task modal survives "Save and Run".
+	it("preserves customTitle from the source task on spawned variants", async () => {
+		const project = makeProject();
+		const sourceTask = makeTask({ status: "todo", seq: 5, customTitle: "User-set title" });
+		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true, customTitle: "User-set title" });
+		const updatedVariant = makeTask({ id: "variant-1", status: "in-progress", worktreePath: "/tmp/vwt", customTitle: "User-set title" });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
+		vi.mocked(data.addTask).mockResolvedValue(variantTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/vwt", branchName: "dev3/v1" });
+		vi.mocked(data.updateTask).mockResolvedValue(updatedVariant);
+
+		await handlers.spawnVariants({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		expect(data.addTask).toHaveBeenCalledWith(
+			project,
+			sourceTask.description,
+			"in-progress",
+			expect.objectContaining({ customTitle: "User-set title" }),
+		);
+	});
 });
 
 describe("handlers.addAttempts", () => {
@@ -2663,6 +2693,50 @@ describe("handlers.addAttempts", () => {
 				undefined,
 			);
 		});
+	});
+
+	// Issue #583 — same root cause as the spawnVariants case: addAttempts must
+	// carry the user-edited customTitle from the source task onto every new
+	// attempt, otherwise re-running a task throws away the title the user typed.
+	it("preserves customTitle from the source task on added attempts", async () => {
+		const project = makeProject();
+		const sourceTask = makeTask({
+			status: "in-progress",
+			seq: 5,
+			groupId: "group-1",
+			variantIndex: 1,
+			customTitle: "User-set title",
+		});
+		const attemptTask = makeTask({
+			id: "attempt-2",
+			status: "in-progress",
+			groupId: "group-1",
+			variantIndex: 2,
+			customTitle: "User-set title",
+			preparing: true,
+		});
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask)
+			.mockResolvedValueOnce(sourceTask)
+			.mockResolvedValueOnce(sourceTask);
+		vi.mocked(data.loadTasks).mockResolvedValue([sourceTask]);
+		vi.mocked(data.addTask).mockResolvedValue(attemptTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/attempt-2", branchName: "dev3/x" });
+		vi.mocked(data.updateTask).mockResolvedValue(attemptTask);
+
+		await handlers.addAttempts({
+			taskId: "task-1",
+			projectId: "proj-1",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		expect(data.addTask).toHaveBeenCalledWith(
+			project,
+			sourceTask.description,
+			"in-progress",
+			expect.objectContaining({ customTitle: "User-set title" }),
+		);
 	});
 
 	it("clears preparing when project config resolution fails before attempt setup starts", async () => {

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -429,6 +429,7 @@ export async function addTask(
 		preparingStartedAt?: Task["preparingStartedAt"];
 		watched?: boolean;
 		scratch?: boolean;
+		customTitle?: string | null;
 	},
 ): Promise<Task> {
 	const file = tasksFile(project);
@@ -462,6 +463,7 @@ export async function addTask(
 			...(extras?.preparingStartedAt ? { preparingStartedAt: extras.preparingStartedAt } : {}),
 			...(extras?.watched ? { watched: true } : {}),
 			...(extras?.scratch ? { scratch: true } : {}),
+			...(extras?.customTitle ? { customTitle: extras.customTitle } : {}),
 		};
 		tasks.push(task);
 		await rawSaveTasks(project, tasks);

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -829,6 +829,9 @@ async function spawnVariants(params: {
 				// on every variant, but the flag tells the launch path (see
 				// prepareTaskInBackground → launchTaskPty) to blank the prompt.
 				scratch: sourceTask.scratch,
+				// Issue #583 — carry the user-edited title onto every variant
+				// so "Save and Run" does not silently revert to the description prefix.
+				customTitle: sourceTask.customTitle,
 			},
 		);
 
@@ -924,6 +927,9 @@ async function addAttempts(params: {
 				preparingProgress: needsWorktree ? getPreparingStageProgress(INITIAL_PREPARING_STAGE) : null,
 				preparingStartedAt: needsWorktree ? new Date().toISOString() : null,
 				watched: sourceTask.watched,
+				// Issue #583 — carry the user-edited title onto every added attempt
+				// so re-running a task does not throw away the title the user typed.
+				customTitle: sourceTask.customTitle,
 			},
 		);
 


### PR DESCRIPTION
## Summary

Fixes #583 (reopen of #564) — a user-typed title in the Create-Task modal still gets overwritten as soon as the agent starts running.

The earlier fix (decision 052) protected only the agent-facing CLI path: the skill instructs the agent to skip rename, and `task.update` refuses to overwrite `customTitle` without `--force`. The regression path is in the renderer.

`CreateTaskModal` stores the typed title via `renameTask`. Then "Save and Run" hands the task off to `LaunchVariantsModal` → `spawnVariants`. `spawnVariants` creates new tasks via `data.addTask(project, sourceTask.description, ...)` and deletes the source task — `customTitle` was never in the extras, so the new task's `title` is recomputed from the description prefix and `customTitle` is left `null`. Same defect in `addAttempts`.

## Fix

- Extend `data.addTask` extras with optional `customTitle?: string | null`.
- Pass `customTitle: sourceTask.customTitle` in `spawnVariants` and `addAttempts`.

Other user-edited fields (`labelIds`, `overview`, `userOverview`, `notes`) remain reset on variants — out of scope for #583.

Tests: two new unit tests on both call sites assert `data.addTask` is invoked with the inherited `customTitle`. Both failed before the fix and pass after.

See decision [055](decisions/055-spawn-variants-preserve-custom-title.md) for the full write-up.