### PR TITLE
fix: suppress terminal preview popovers during drag-and-drop

### DIFF
--- a/change-logs/2026/05/29/fix-disable-terminal-previews-during-dnd.md
+++ b/change-logs/2026/05/29/fix-disable-terminal-previews-during-dnd.md
@@ -1,0 +1,1 @@
+Terminal preview popovers in the active tasks sidebar and on task cards no longer pop up while a drag-and-drop is in progress. A global dragstart listener now closes any open preview and blocks new ones until dragend/drop fires, so previews stop fighting the user's drag.

--- a/src/mainview/hooks/__tests__/useTerminalPreview.test.ts
+++ b/src/mainview/hooks/__tests__/useTerminalPreview.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { useTerminalPreview } from "../useTerminalPreview";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			getTerminalPreview: vi.fn().mockResolvedValue("hello"),
+		},
+	},
+}));
+
+import { api } from "../../rpc";
+
+const mockedApi = vi.mocked(api, true);
+
+function makeAnchor() {
+	const el = document.createElement("div");
+	document.body.appendChild(el);
+	return el;
+}
+
+describe("useTerminalPreview — drag-and-drop interaction", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		document.body.innerHTML = "";
+	});
+
+	it("blocks new previews while a drag is in progress", async () => {
+		const { result } = renderHook(() => useTerminalPreview());
+		const anchor = makeAnchor();
+
+		act(() => {
+			window.dispatchEvent(new Event("dragstart"));
+		});
+
+		act(() => {
+			result.current.handlers.onMouseEnter("task-1", anchor);
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(500);
+		});
+
+		expect(result.current.state.open).toBe(false);
+		expect(mockedApi.request.getTerminalPreview).not.toHaveBeenCalled();
+	});
+
+	it("closes an open preview immediately on dragstart", async () => {
+		const { result } = renderHook(() => useTerminalPreview());
+		const anchor = makeAnchor();
+
+		act(() => {
+			result.current.handlers.onMouseEnter("task-1", anchor);
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(500);
+		});
+
+		expect(result.current.state.open).toBe(true);
+
+		act(() => {
+			window.dispatchEvent(new Event("dragstart"));
+		});
+
+		expect(result.current.state.open).toBe(false);
+		expect(result.current.state.activeTaskId).toBeNull();
+	});
+
+	it("re-enables previews after dragend", async () => {
+		const { result } = renderHook(() => useTerminalPreview());
+		const anchor = makeAnchor();
+
+		act(() => {
+			window.dispatchEvent(new Event("dragstart"));
+		});
+		act(() => {
+			window.dispatchEvent(new Event("dragend"));
+		});
+
+		act(() => {
+			result.current.handlers.onMouseEnter("task-1", anchor);
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(500);
+		});
+
+		expect(result.current.state.open).toBe(true);
+		expect(result.current.state.activeTaskId).toBe("task-1");
+	});
+});

--- a/src/mainview/hooks/useTerminalPreview.ts
+++ b/src/mainview/hooks/useTerminalPreview.ts
@@ -60,6 +60,7 @@ export function useTerminalPreview() {
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const activeTaskIdRef = useRef<string | null>(null);
+	const isDraggingRef = useRef(false);
 
 	const cancelTimers = useCallback(() => {
 		if (openTimerRef.current) {
@@ -103,6 +104,7 @@ export function useTerminalPreview() {
 	 * (either a ref.current or e.currentTarget).
 	 */
 	function onMouseEnter(taskId: string, anchorEl: HTMLElement) {
+		if (isDraggingRef.current) return;
 		cancelTimers();
 		if (activeTaskIdRef.current && activeTaskIdRef.current !== taskId) {
 			close();
@@ -164,6 +166,25 @@ export function useTerminalPreview() {
 			}
 		};
 	}, [cancelTimers]);
+
+	// Disable previews while a drag-and-drop is in progress.
+	useEffect(() => {
+		const onDragStart = () => {
+			isDraggingRef.current = true;
+			close();
+		};
+		const onDragEnd = () => {
+			isDraggingRef.current = false;
+		};
+		window.addEventListener("dragstart", onDragStart, true);
+		window.addEventListener("dragend", onDragEnd, true);
+		window.addEventListener("drop", onDragEnd, true);
+		return () => {
+			window.removeEventListener("dragstart", onDragStart, true);
+			window.removeEventListener("dragend", onDragEnd, true);
+			window.removeEventListener("drop", onDragEnd, true);
+		};
+	}, [close]);
 
 	return {
 		state: { open, html, loading, pos, activeTaskId, cancelClose, scheduleClose },


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

- Terminal preview popovers (TaskCard hover + Active Tasks sidebar) no longer open while a drag-and-drop is in progress.
- Adds a global \`dragstart\` listener in \`useTerminalPreview\` that closes any open popover and blocks new opens until \`dragend\` / \`drop\` fires.
- Covered by 3 new unit tests in \`useTerminalPreview.test.ts\`.

Closes #589