### PR TITLE
Fix #583 again: titles set by agents shouldn't lock against later agent renames

### DIFF
--- a/change-logs/2026/05/29/fix-title-edited-by-user-flag.md
+++ b/change-logs/2026/05/29/fix-title-edited-by-user-flag.md
@@ -1,0 +1,1 @@
+Fixed task titles freezing on whatever the first agent named them: the "user-edited — do NOT rename" lock used to fire on any non-null `customTitle`, including agent renames through `dev3 task update --title`. A new `titleEditedByUser` flag is set only by the UI rename path, so follow-up agents can still refine agent-set titles while real user-typed titles stay protected.

--- a/decisions/056-title-edited-by-user-flag.md
+++ b/decisions/056-title-edited-by-user-flag.md
@@ -1,0 +1,44 @@
+# 056 — Separate `titleEditedByUser` flag from `customTitle`
+
+## Context
+
+Re-opened bug from issue #583 (originally #564): a task's title freezes forever and is never refined by later agents. The user can see `customTitle = null` on a freshly created task — yet on tasks that have lived for a while, the title locks on whatever the first agent named it.
+
+Decision 052 introduced `customTitle` and used `customTitle != null` as the proxy for "user edited the title — never overwrite". Decision 055 carried `customTitle` across `spawnVariants` / `addAttempts`. Both made the original UI bug go away, but they kept conflating two distinct write sources behind the same field.
+
+## Investigation
+
+`customTitle` is written from four places:
+
+1. `CreateTaskModal` → `api.request.renameTask` — **user** edit through the UI
+2. `InlineRename` → `api.request.renameTask` — **user** edit through the UI
+3. `dev3 task update --title …` (`cli-socket-server.ts` `task.update`) — **agent** rename via CLI
+4. `spawnVariants` / `addAttempts` — propagation from source task to the new variants/attempts
+
+Cases 1, 2 must lock the title. Case 3 must NOT — it is the agent renaming a too-long auto-title to something short, and a follow-up agent in a later session should still be free to do the same. Case 4 should inherit whichever state the source task had.
+
+Because the marker shown to agents (`dev3 current` → "(user-edited — do NOT rename)") and the CLI overwrite-guard in `task.update` both keyed off `customTitle != null`, case 3 silently set the lock on its own writes. From then on every later agent saw the marker and refused to rename — exactly the user-reported symptom of "the title never changes anymore".
+
+## Decision
+
+Add a separate boolean `titleEditedByUser` to `Task` and drive every "is this title user-owned?" decision off the flag, not off `customTitle`.
+
+- `src/shared/types.ts` — new `titleEditedByUser?: boolean` on `Task`.
+- `src/bun/data.ts` — backfill missing values to `false` in `rawLoadTasks`; accept it in `addTask` extras.
+- `src/bun/rpc-handlers/task-lifecycle.ts` — `renameTask` (only callable from the UI) writes `titleEditedByUser: true` for any non-null custom title, and `false` when the user resets it. `spawnVariants` and `addAttempts` carry the flag along with `customTitle`.
+- `src/bun/cli-socket-server.ts` — `task.update` guards on `task.titleEditedByUser`, NOT `customTitle`. CLI writes never set the flag; clearing the title via `--title ""` also drops the flag.
+- `src/cli/commands/current.ts`, `src/cli/commands/task.ts` — the "(user-edited — do NOT rename)" marker is shown only when the flag is `true`.
+
+Migration is mild: existing tasks default `titleEditedByUser` to `false`, so agent-set `customTitle`s become rewritable again, while legitimately user-typed titles will be re-locked the next time the user renames through the UI. There is no programmatic way to recover the original intent for legacy data — that is acceptable.
+
+## Risks
+
+- Tasks whose `customTitle` was actually typed by the user in the UI before this change are no longer flagged. Until the user renames them again, an agent could rewrite them. Low impact in practice — most legacy `customTitle`s in this repo's data are agent-set.
+- A test or external script that called `data.updateTask` with a manual `titleEditedByUser` write will still work, but should normally go through `renameTask` to stay future-proof.
+
+## Alternatives considered
+
+- **Tag `customTitle` with a discriminated union** (`{ value, source: "user"|"agent" }`). More expressive but forces a migration of every reader of `task.customTitle` across renderer, CLI, and backend.
+- **Stop writing `customTitle` from the CLI entirely; let agents write `title` directly.** Breaks the invariant that `title` is the auto-generated description prefix, and complicates the description-edit code paths in `editTask`.
+
+A separate boolean is the smallest surface change that splits the two semantics cleanly.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -582,10 +582,10 @@ describe("task.update", () => {
 
 	// Issue #564 — agent following its skill must not overwrite a title the user
 	// already set via the UI. The CLI is the agent-facing entry point; refuse to
-	// overwrite a non-empty customTitle unless --force is passed.
-	it("preserves user-edited customTitle when --title is provided without --force", async () => {
+	// overwrite the title when titleEditedByUser is true, unless --force is passed.
+	it("preserves user-edited title when --title is provided without --force", async () => {
 		const project = makeProject();
-		const task = makeTask({ customTitle: "User-set title" });
+		const task = makeTask({ customTitle: "User-set title", titleEditedByUser: true });
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(getPushMessage).mockReturnValue(null);
@@ -605,9 +605,36 @@ describe("task.update", () => {
 		expect(result.task.customTitle).toBe("User-set title");
 	});
 
-	it("overwrites user-edited customTitle when --force is set", async () => {
+	// Re-opened #583 — a customTitle set by a previous agent (titleEditedByUser
+	// is false) is NOT protected, otherwise the title gets frozen forever on
+	// whatever the first agent wrote. Later agents must be able to rewrite it.
+	it("overwrites agent-set customTitle (titleEditedByUser=false) without --force", async () => {
 		const project = makeProject();
-		const task = makeTask({ customTitle: "User-set title" });
+		const task = makeTask({ customTitle: "Old agent title", titleEditedByUser: false });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: "New agent title" });
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				title: "New agent title",
+			}),
+		);
+		expect(resp.ok).toBe(true);
+		const call = vi.mocked(data.updateTask).mock.calls[0][2];
+		expect(call.customTitle).toBe("New agent title");
+		// CLI must never claim a user edit — only the UI rename RPC sets that flag.
+		expect(call.titleEditedByUser).toBeUndefined();
+		const result = resp.data as { task: Task; titlePreserved: boolean };
+		expect(result.titlePreserved).toBe(false);
+	});
+
+	it("overwrites user-edited title when --force is set", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "User-set title", titleEditedByUser: true });
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: "Agent override" });
@@ -628,12 +655,12 @@ describe("task.update", () => {
 		expect(result.titlePreserved).toBe(false);
 	});
 
-	it("still allows --title to clear customTitle (--title \"\") without --force", async () => {
+	it("still allows --title to clear customTitle (--title \"\") without --force, and drops the user-edit flag", async () => {
 		const project = makeProject();
-		const task = makeTask({ customTitle: "User-set title" });
+		const task = makeTask({ customTitle: "User-set title", titleEditedByUser: true });
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.loadTasks).mockResolvedValue([task]);
-		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: null });
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: null, titleEditedByUser: false });
 		vi.mocked(getPushMessage).mockReturnValue(null);
 
 		const resp = await handleRequest(
@@ -642,6 +669,7 @@ describe("task.update", () => {
 		expect(resp.ok).toBe(true);
 		const call = vi.mocked(data.updateTask).mock.calls[0][2];
 		expect(call.customTitle).toBeNull();
+		expect(call.titleEditedByUser).toBe(false);
 	});
 
 	it("returns task in new envelope shape", async () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2026,6 +2026,67 @@ describe("handlers.editTask", () => {
 	});
 });
 
+// ================================================================
+// handlers.renameTask
+// ================================================================
+
+describe("handlers.renameTask", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	// Re-opened #583 — the renameTask RPC is the ONLY entry point that should
+	// mark a title as user-edited, because it is invoked only from the UI
+	// (CreateTaskModal + InlineRename). The CLI `task.update` path must not
+	// touch the flag, so later agents can still rename agent-set titles.
+	it("sets titleEditedByUser=true when the UI writes a non-empty custom title", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		const updated = makeTask({ customTitle: "User picked this", titleEditedByUser: true });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+
+		const result = await handlers.renameTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			customTitle: "User picked this",
+		});
+		expect(result).toEqual(updated);
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			customTitle: "User picked this",
+			titleEditedByUser: true,
+		});
+	});
+
+	it("clears titleEditedByUser when the UI resets the custom title to null", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "Old", titleEditedByUser: true });
+		const updated = makeTask({ customTitle: null, titleEditedByUser: false });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+
+		await handlers.renameTask({ taskId: "task-1", projectId: "proj-1", customTitle: null });
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			customTitle: null,
+			titleEditedByUser: false,
+		});
+	});
+
+	it("treats whitespace-only customTitle as a reset", async () => {
+		const project = makeProject();
+		const task = makeTask({ customTitle: "Old", titleEditedByUser: true });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+
+		await handlers.renameTask({ taskId: "task-1", projectId: "proj-1", customTitle: "   " });
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			customTitle: null,
+			titleEditedByUser: false,
+		});
+	});
+});
+
 describe("resolveOperationalProjectConfig", () => {
 	beforeEach(() => vi.clearAllMocks());
 
@@ -2568,11 +2629,11 @@ describe("handlers.spawnVariants", () => {
 	// Issue #583 — spawnVariants used to drop the user-edited customTitle from
 	// the source task. The new variants must inherit it so the title the user
 	// typed in the Create-Task modal survives "Save and Run".
-	it("preserves customTitle from the source task on spawned variants", async () => {
+	it("preserves customTitle and titleEditedByUser from the source task on spawned variants", async () => {
 		const project = makeProject();
-		const sourceTask = makeTask({ status: "todo", seq: 5, customTitle: "User-set title" });
-		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true, customTitle: "User-set title" });
-		const updatedVariant = makeTask({ id: "variant-1", status: "in-progress", worktreePath: "/tmp/vwt", customTitle: "User-set title" });
+		const sourceTask = makeTask({ status: "todo", seq: 5, customTitle: "User-set title", titleEditedByUser: true });
+		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true, customTitle: "User-set title", titleEditedByUser: true });
+		const updatedVariant = makeTask({ id: "variant-1", status: "in-progress", worktreePath: "/tmp/vwt", customTitle: "User-set title", titleEditedByUser: true });
 
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
@@ -2591,7 +2652,7 @@ describe("handlers.spawnVariants", () => {
 			project,
 			sourceTask.description,
 			"in-progress",
-			expect.objectContaining({ customTitle: "User-set title" }),
+			expect.objectContaining({ customTitle: "User-set title", titleEditedByUser: true }),
 		);
 	});
 });
@@ -2728,7 +2789,7 @@ describe("handlers.addAttempts", () => {
 	// Issue #583 — same root cause as the spawnVariants case: addAttempts must
 	// carry the user-edited customTitle from the source task onto every new
 	// attempt, otherwise re-running a task throws away the title the user typed.
-	it("preserves customTitle from the source task on added attempts", async () => {
+	it("preserves customTitle and titleEditedByUser from the source task on added attempts", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({
 			status: "in-progress",
@@ -2736,6 +2797,7 @@ describe("handlers.addAttempts", () => {
 			groupId: "group-1",
 			variantIndex: 1,
 			customTitle: "User-set title",
+			titleEditedByUser: true,
 		});
 		const attemptTask = makeTask({
 			id: "attempt-2",
@@ -2743,6 +2805,7 @@ describe("handlers.addAttempts", () => {
 			groupId: "group-1",
 			variantIndex: 2,
 			customTitle: "User-set title",
+			titleEditedByUser: true,
 			preparing: true,
 		});
 
@@ -2765,7 +2828,7 @@ describe("handlers.addAttempts", () => {
 			project,
 			sourceTask.description,
 			"in-progress",
-			expect.objectContaining({ customTitle: "User-set title" }),
+			expect.objectContaining({ customTitle: "User-set title", titleEditedByUser: true }),
 		);
 	});
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -211,17 +211,21 @@ const handlers: Record<string, Handler> = {
 		let titlePreserved = false;
 		if (params.title !== undefined) {
 			const newTitle = (params.title as string) || null;
-			const existing = task.customTitle?.trim() || "";
-			// Defensive guard: refuse to overwrite a user-edited customTitle from
-			// the CLI unless --force is passed. The agent skill instructs agents
-			// to leave user-edited titles alone, and this is the backstop.
-			// Empty string (--title "") is treated as an explicit reset and still
-			// goes through, since clearing customTitle restores the auto-generated
-			// title rather than overwriting the user's wording.
-			if (newTitle && existing && newTitle !== existing && !force) {
+			// Defensive guard: refuse to overwrite a UI-set title from the CLI
+			// unless --force is passed. The agent skill instructs agents to
+			// leave user-edited titles alone, and this is the backstop.
+			// We key off `titleEditedByUser` — NOT `customTitle != null` — so
+			// that titles previously set by another agent (via this same CLI
+			// path) remain rewritable. Empty string (--title "") still goes
+			// through as an explicit reset, even when the user edited it.
+			if (newTitle && task.titleEditedByUser && !force) {
 				titlePreserved = true;
 			} else {
 				updates.customTitle = newTitle;
+				// CLI writes never claim a user edit — only the UI rename RPC does.
+				// When the user explicitly clears their title via --title "" we
+				// also drop the user-edit flag so future agents can rename again.
+				if (!newTitle) updates.titleEditedByUser = false;
 			}
 		}
 		if (params.description !== undefined) {

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -302,6 +302,7 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 			if ((task as any).labelIds === undefined) task.labelIds = [];
 			if ((task as any).notes === undefined) task.notes = [];
 			if ((task as any).customTitle === undefined) task.customTitle = null;
+			if ((task as any).titleEditedByUser === undefined) task.titleEditedByUser = false;
 			if ((task as any).customColumnId === undefined) task.customColumnId = null;
 			if ((task as any).overview === undefined) task.overview = null;
 			if ((task as any).userOverview === undefined) task.userOverview = null;
@@ -430,6 +431,7 @@ export async function addTask(
 		watched?: boolean;
 		scratch?: boolean;
 		customTitle?: string | null;
+		titleEditedByUser?: boolean;
 	},
 ): Promise<Task> {
 	const file = tasksFile(project);
@@ -464,6 +466,7 @@ export async function addTask(
 			...(extras?.watched ? { watched: true } : {}),
 			...(extras?.scratch ? { scratch: true } : {}),
 			...(extras?.customTitle ? { customTitle: extras.customTitle } : {}),
+			...(extras?.titleEditedByUser ? { titleEditedByUser: true } : {}),
 		};
 		tasks.push(task);
 		await rawSaveTasks(project, tasks);

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -840,6 +840,7 @@ async function spawnVariants(params: {
 				// Issue #583 — carry the user-edited title onto every variant
 				// so "Save and Run" does not silently revert to the description prefix.
 				customTitle: sourceTask.customTitle,
+				titleEditedByUser: sourceTask.titleEditedByUser,
 			},
 		);
 
@@ -938,6 +939,7 @@ async function addAttempts(params: {
 				// Issue #583 — carry the user-edited title onto every added attempt
 				// so re-running a task does not throw away the title the user typed.
 				customTitle: sourceTask.customTitle,
+				titleEditedByUser: sourceTask.titleEditedByUser,
 			},
 		);
 
@@ -995,7 +997,14 @@ async function renameTask(params: { taskId: string; projectId: string; customTit
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
 	const trimmed = params.customTitle?.trim() || null;
-	const updated = await data.updateTask(project, task.id, { customTitle: trimmed });
+	// This RPC is invoked only from the UI (Create Task modal + InlineRename) —
+	// so any non-null write here is a real user edit and must lock the title
+	// against future agent renames. Clearing the title (`null`) also clears
+	// the user-edit flag so the auto-generated title is back in play.
+	const updated = await data.updateTask(project, task.id, {
+		customTitle: trimmed,
+		titleEditedByUser: trimmed !== null,
+	});
 	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 	log.info("← renameTask done", { taskId: task.id });
 	return updated;

--- a/src/cli/__tests__/current.test.ts
+++ b/src/cli/__tests__/current.test.ts
@@ -125,6 +125,7 @@ describe("handleCurrent", () => {
 			mockSend.mockResolvedValue(okResp({
 				...FAKE_TASK,
 				customTitle: "Test 1",
+				titleEditedByUser: true,
 			}));
 			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
 
@@ -147,6 +148,28 @@ describe("handleCurrent", () => {
 
 			await handleCurrent(SOCKET);
 
+			expect(stdoutOutput).not.toContain("user-edited");
+		});
+
+		// Re-opened #583 — a customTitle set by a previous agent (no user edit)
+		// must NOT show the "user-edited" marker, otherwise the next agent
+		// believes the title is sacred and never renames it again.
+		it("does not mark the title as user-edited when customTitle is set but titleEditedByUser is false", async () => {
+			mockDetect.mockReturnValue({
+				projectId: "proj-001",
+				taskId: FAKE_TASK.id,
+				socketPath: SOCKET,
+			});
+			mockSend.mockResolvedValue(okResp({
+				...FAKE_TASK,
+				customTitle: "Agent-named title",
+				titleEditedByUser: false,
+			}));
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+
+			await handleCurrent(SOCKET);
+
+			expect(stdoutOutput).toContain("Agent-named title");
 			expect(stdoutOutput).not.toContain("user-edited");
 		});
 
@@ -256,12 +279,14 @@ describe("handleCurrent", () => {
 			mockReadTask.mockReturnValue({
 				...FAKE_TASK,
 				customTitle: "Test 1",
+				titleEditedByUser: true,
 			});
 
 			await handleCurrent(null);
 
 			expect(stdoutOutput).toContain("Test 1");
 			expect(stdoutOutput).not.toContain("Implement auth");
+			expect(stdoutOutput).toContain("user-edited");
 		});
 
 		it("shows minimal info when task data not available offline", async () => {

--- a/src/cli/commands/current.ts
+++ b/src/cli/commands/current.ts
@@ -32,7 +32,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 				const task = resp.data as Task;
 				const project = readProjectDirect(context.projectId);
 				const displayTitle = getTaskTitle(task);
-				const titleMarker = task.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
+				const titleMarker = task.titleEditedByUser ? " (user-edited — do NOT rename)" : "";
 
 				const statusDisplay = task.customColumnId
 					? `${STATUS_LABELS[task.status] || task.status} (in custom column)`
@@ -105,7 +105,7 @@ export async function handleCurrent(socketPath: string | null): Promise<void> {
 	];
 
 	if (task) {
-		const displayTask = task as Pick<Task, "title" | "customTitle">;
+		const displayTask = task as Pick<Task, "title" | "customTitle" | "titleEditedByUser">;
 		const displayTitle = getTaskTitle(displayTask as Task);
 		const titleMarker = displayTask.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -24,7 +24,7 @@ function formatDate(iso: string): string {
 }
 
 function printTask(task: Task): void {
-	const titleMarker = task.customTitle?.trim() ? " (user-edited — do NOT rename)" : "";
+	const titleMarker = task.titleEditedByUser ? " (user-edited — do NOT rename)" : "";
 	const fields: Array<[string, string]> = [
 		["ID:", task.id],
 		["Seq:", String(task.seq)],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -570,6 +570,16 @@ export interface Task {
 	 */
 	userOverview?: string | null;
 	customTitle?: string | null;
+	/**
+	 * True only when the user typed/edited the title through the UI (Create
+	 * Task modal or inline rename). Titles set by an agent through
+	 * `dev3 task update --title` leave this flag at `false`. The user-edited
+	 * marker shown to agents and the CLI overwrite-guard both key off this
+	 * flag — NOT off `customTitle != null` — so agent-set titles can still
+	 * be re-rewritten by later agents while a real user-typed title is
+	 * preserved for the entire task lifetime.
+	 */
+	titleEditedByUser?: boolean;
 	status: TaskStatus;
 	baseBranch: string;
 	worktreePath: string | null;


### PR DESCRIPTION
## Summary

Re-opened #583 (orig #564): on tasks that have lived for a while the title locks on whatever the first agent named it, and the user-edited marker shows up in every later session even though the user never touched the title.

Root cause: the marker and the CLI overwrite-guard both keyed off `customTitle != null`. But `customTitle` is also written by `dev3 task update --title …` — the path agents use to refine the auto-generated 80-char prefix into something readable. So the first agent rename silently set the lock on its own write, and from then on every later agent at `dev3 current` saw `(user-edited — do NOT rename)` and refused to touch the title.

## Fix

Split the two write sources behind a new `Task.titleEditedByUser` flag:

- `renameTask` RPC (invoked only from `CreateTaskModal` + `InlineRename`) sets the flag to `true` on a non-null write, and back to `false` when the user resets the title.
- `dev3 task update --title` (`cli-socket-server.ts`) writes `customTitle` but never the flag — CLI writes are always agent renames.
- `spawnVariants` / `addAttempts` carry the flag along with `customTitle`, so real user-typed titles still survive Save-and-Run and re-runs.
- CLI `current` / `task` printers show the marker only when the flag is `true`. The backstop guard in `task.update` also keys off the flag now.

Migration: legacy `customTitle`s default to `titleEditedByUser=false`, so agent-set titles become rewritable again. Real user-typed legacy titles will be re-locked on the next UI rename. No on-disk renames or destructive migrations.

Tests: new regression cases on all 5 call sites (CLI rename, RPC rename, spawnVariants, addAttempts, CLI current marker). Decision record at [`decisions/056-title-edited-by-user-flag.md`](decisions/056-title-edited-by-user-flag.md).