### PR TITLE
Fix diff badge showing 'Showing N of M' with N > M when tests hidden

### DIFF
--- a/change-logs/2026/05/29/fix-diff-shown-count-badge-inverted.md
+++ b/change-logs/2026/05/29/fix-diff-shown-count-badge-inverted.md
@@ -1,0 +1,1 @@
+Fixed the diff toolbar "Showing N of M changed files" badge that could render with N > M when "Include tests" was off and the diff contained binary or oversized files. The badge now uses the full payload summary as the total and counts both rendered and skipped files as visible.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1425,8 +1425,8 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 			insertions += stats.insertions;
 			deletions += stats.deletions;
 		}
-		return { files: visibleFiles.length, insertions, deletions };
-	}, [payload, includeTests, visibleFiles]);
+		return { files: visibleFiles.length + visibleSkippedFiles.length, insertions, deletions };
+	}, [payload, includeTests, visibleFiles, visibleSkippedFiles]);
 	const fileTree = payload ? buildDiffTree(visibleFiles, visibleSkippedFiles) : [];
 	const reviewExportEntries = payload ? buildInlineReviewExportEntries(visibleFiles, inlineComments) : [];
 	const reviewExportXml = buildInlineReviewXml(reviewExportEntries);
@@ -2412,11 +2412,11 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 									</span>
 								)}
 							</label>
-							{totalFileCount !== visibleSummary.files && (
+							{totalFileCount !== payload.summary.files && (
 								<span className="px-2 py-1 rounded-md bg-raised text-fg-3 border border-edge text-[0.6875rem]">
 									{t("infoPanel.diffShownCount", {
 										shown: String(totalFileCount),
-										total: String(visibleSummary.files),
+										total: String(payload.summary.files),
 									})}
 								</span>
 							)}

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -562,6 +562,72 @@ describe("TaskDiffViewer", () => {
 		expect(within(treeButton).getByText("logo.png")).toHaveClass("line-through");
 	});
 
+	it("shows 'Showing N of M' badge with N <= M when 'Include tests' is off and there are skipped binary files", async () => {
+		const user = userEvent.setup();
+		vi.mocked(api.request.getTaskDiff).mockImplementation(async ({ mode }) => ({
+			mode,
+			compareRef: mode === "uncommitted" ? null : "origin/main",
+			compareLabel: mode === "uncommitted" ? "Working tree" : "origin/main",
+			fallbackReason: null,
+			summary: { files: 3, insertions: 1, deletions: 1 },
+			files: [
+				{
+					id: "src/app.ts",
+					status: "modified",
+					displayPath: "src/app.ts",
+					oldPath: "src/app.ts",
+					newPath: "src/app.ts",
+					oldContent: "a\n",
+					newContent: "b\n",
+					hunks: ["diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-a\n+b\n"],
+				},
+				{
+					id: "src/app.test.ts",
+					status: "modified",
+					displayPath: "src/app.test.ts",
+					oldPath: "src/app.test.ts",
+					newPath: "src/app.test.ts",
+					oldContent: "t\n",
+					newContent: "u\n",
+					hunks: ["diff --git a/src/app.test.ts b/src/app.test.ts\n@@ -1 +1 @@\n-t\n+u\n"],
+				},
+			],
+			skippedFiles: [
+				{
+					id: "assets/logo.png",
+					status: "added",
+					reason: "binary",
+					displayPath: "assets/logo.png",
+					oldPath: null,
+					newPath: "assets/logo.png",
+					oldSize: null,
+					newSize: 12_000,
+				},
+			],
+		}));
+
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		const checkbox = await screen.findByRole("checkbox", { name: /include tests/i });
+		expect(checkbox).toBeChecked();
+		await user.click(checkbox);
+		expect(checkbox).not.toBeChecked();
+
+		// Badge must read "Showing 2 of 3" — 1 code file + 1 skipped binary visible, 1 test file hidden.
+		// Regression: previously rendered "Showing 2 of 1" because the total excluded skipped files.
+		const badge = await screen.findByText(/Showing\s+2\s+of\s+3\s+changed files/i);
+		expect(badge).toBeInTheDocument();
+	});
+
 	it("uses unified as the initial layout when configured in global settings", async () => {
 		vi.mocked(api.request.getGlobalSettings).mockResolvedValue({
 			defaultAgentId: "builtin-claude",


### PR DESCRIPTION
## Summary

- Toolbar badge `Showing N of M changed files` could invert (`N > M`) when "Include tests" was off and the diff contained binary or oversized (skipped) files.
- Root cause: `visibleSummary.files` only counted text diff files in the `includeTests=false` branch, while `totalFileCount` also included skipped files. The badge formula compared the two, producing nonsense like "Showing 12 of 10".
- Fix: `visibleSummary.files` now includes `visibleSkippedFiles.length` (consistent with the `includeTests=true` branch where it falls back to `payload.summary`), and the badge formula compares the visible count against `payload.summary.files` — the original total before any filtering.
- Added a regression test that asserts a 2-of-3 reading on a diff with one code file, one test file, and one binary file when "Include tests" is off.

Origin: found by Agent L during bug hunt on PR #586.