### PR TITLE
fix(diff): bulk read/unread covers hidden test files

### DIFF
--- a/change-logs/2026/05/29/fix-mark-all-unread-hidden-tests.md
+++ b/change-logs/2026/05/29/fix-mark-all-unread-hidden-tests.md
@@ -1,0 +1,1 @@
+Fixed "Mark all read/unread" in the diff viewer to update read state for hidden test files too. Previously the bulk action iterated only over visible files, so toggling "Include tests" back on revealed previously read test files still marked as read. Now read state in both in-memory and localStorage covers the full payload, while expand/collapse stays scoped to visible files.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -2186,7 +2186,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 			return;
 		}
 		const storedReadState = readStoredReadState();
-		for (const file of visibleFiles) {
+		for (const file of payload.files) {
 			const signature = getFileReadSignature(task.id, file);
 			if (nextRead) {
 				storedReadState[signature] = true;
@@ -2194,7 +2194,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 				delete storedReadState[signature];
 			}
 		}
-		for (const skipped of visibleSkippedFiles) {
+		for (const skipped of payload.skippedFiles) {
 			const signature = getSkippedFileReadSignature(task.id, skipped);
 			if (nextRead) {
 				storedReadState[signature] = true;
@@ -2205,10 +2205,10 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		writeStoredReadState(storedReadState);
 		setReadFiles((prev) => {
 			const next = { ...prev };
-			for (const file of visibleFiles) {
+			for (const file of payload.files) {
 				next[file.id] = nextRead;
 			}
-			for (const skipped of visibleSkippedFiles) {
+			for (const skipped of payload.skippedFiles) {
 				next[skipped.id] = nextRead;
 			}
 			return next;

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -1102,6 +1102,77 @@ describe("TaskDiffViewer", () => {
 		});
 	});
 
+	it("'Mark all unread' clears read state for hidden test files too", async () => {
+		// Regression: setAllFilesRead used to iterate only over visibleFiles, so
+		// when "Include tests" was OFF, clicking "Mark all unread" left previously
+		// read test files marked as read in both in-memory state and localStorage.
+		const payloadWithTest: TaskDiffResponse = {
+			mode: "branch",
+			compareRef: "origin/main",
+			compareLabel: "origin/main",
+			fallbackReason: null,
+			summary: { files: 2, insertions: 2, deletions: 0 },
+			files: [
+				{
+					id: "src/app.ts",
+					status: "modified",
+					displayPath: "src/app.ts",
+					oldPath: "src/app.ts",
+					newPath: "src/app.ts",
+					oldContent: "a\n",
+					newContent: "a\nb\n",
+					hunks: ["diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1,2 @@\n a\n+b\n"],
+				},
+				{
+					id: "src/app.test.ts",
+					status: "modified",
+					displayPath: "src/app.test.ts",
+					oldPath: "src/app.test.ts",
+					newPath: "src/app.test.ts",
+					oldContent: "x\n",
+					newContent: "x\ny\n",
+					hunks: ["diff --git a/src/app.test.ts b/src/app.test.ts\n@@ -1 +1,2 @@\n x\n+y\n"],
+				},
+			],
+			skippedFiles: [],
+		};
+		vi.mocked(api.request.getTaskDiff).mockResolvedValue(payloadWithTest);
+
+		const user = userEvent.setup();
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getAllByTestId("mock-diff")).toHaveLength(2);
+		});
+
+		// Step 1: with "Include tests" ON (default), mark all files as read.
+		expect(screen.getByText("0/2 Read")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "Mark all read" }));
+		expect(screen.getByText("2/2 Read")).toBeInTheDocument();
+
+		// Step 2: toggle "Include tests" OFF — only the production file is visible.
+		await user.click(screen.getByTestId("diff-toolbar-include-tests").querySelector("input")!);
+		expect(screen.getByText("1/1 Read")).toBeInTheDocument();
+
+		// Step 3: with the test file hidden, click "Mark all unread".
+		await user.click(screen.getByRole("button", { name: "Mark all unread" }));
+		expect(screen.getByText("0/1 Read")).toBeInTheDocument();
+
+		// Step 4: toggle "Include tests" back ON — the previously hidden test
+		// file must also be unread now (this was the bug: it stayed "1/2 Read").
+		await user.click(screen.getByTestId("diff-toolbar-include-tests").querySelector("input")!);
+		expect(screen.getByText("0/2 Read")).toBeInTheDocument();
+	});
+
 	it("retries sidebar file navigation until the target lands under the sticky toolbar", async () => {
 		const user = userEvent.setup();
 		const rafQueue: FrameRequestCallback[] = [];


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this PR).

## Summary

- `setAllFilesRead` iterated only over `visibleFiles` / `visibleSkippedFiles`, so test files filtered out by **Include tests** kept their previous read state in both the in-memory map and `localStorage`. Toggling **Include tests** back on revealed stale "read" markers.
- Switched the bulk read-state loops to iterate over the full payload (`payload.files` / `payload.skippedFiles`). Kept `setExpandedFiles` scoped to visible files — we don't want to expand hidden test files.
- Added a regression test that fails without the source fix.

Found by Agent L during a bug hunt on #586.