### PR TITLE
fix(sounds): inline task sounds as data: URLs to fix packaged playback

### DIFF
--- a/change-logs/2026/05/29/fix-task-sound-views-range.md
+++ b/change-logs/2026/05/29/fix-task-sound-views-range.md
@@ -1,0 +1,1 @@
+Fixed task completion/cancellation sounds silently failing in packaged builds. The MP3s were served via the Electrobun `views://` scheme, which does not honor the Range request WKWebView's media loader issues, so playback failed with `NotSupportedError`. They are now inlined as base64 `data:` URLs (`?inline`), bypassing the scheme handler entirely.

--- a/decisions/057-task-sound-inline-data-url.md
+++ b/decisions/057-task-sound-inline-data-url.md
@@ -1,0 +1,21 @@
+# Task Sounds Inlined as data: URLs
+
+## Context
+
+Task completion/cancellation sounds stopped playing in packaged builds. Console showed `[task-sounds] playback failed — NotSupportedError: The operation is not supported.` and `Failed to load resource: Resource not found`.
+
+## Investigation
+
+The DevTools Network tab showed the `<audio>` element (AppleCoreMedia user agent) requesting `views://mainview/assets/task-completed-*.mp3` with `Range: bytes=0-1` and getting an empty response (no headers, no status). WKWebView's media loader always fetches media with Range requests, but the Electrobun `views://` scheme handler does not satisfy them — so the MP3 never loads. This contradicts decision 030's assumption that the renderer gets working asset bundling "for free". Likely surfaced by the Electrobun 1.14.4 → 1.18.1 bump (#549), which changed scheme-handler behavior; not verified by version rollback.
+
+## Decision
+
+Import the MP3s with Vite's `?inline` suffix (`src/mainview/task-sounds.ts`) so they are emitted as base64 `data:` URLs embedded in the JS bundle instead of files served via `views://`. A `data:` URL is loaded directly by the media element with no scheme handler and no Range request, so playback works in packaged builds on every OS. Regression guard in `src/mainview/__tests__/task-sounds.test.ts` asserts the URLs start with `data:audio/`.
+
+## Risks
+
+The two MP3s (~67 KB) are base64-inlined into the main JS chunk (~+90 KB raw). Negligible for a desktop app. Any future audio asset must also use `?inline` or it will silently break the same way.
+
+## Alternatives considered
+
+Raise `build.assetsInlineLimit`: rejected — would inline unrelated assets globally. Revert to native `afplay` on the Bun side: rejected — macOS-only, breaks Linux support (see decision 030). Patch the `views://` handler for Range: rejected — it is Electrobun-internal and out of our control.

--- a/src/mainview/__tests__/task-sounds.test.ts
+++ b/src/mainview/__tests__/task-sounds.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { SOUND_DEFS } from "../task-sounds";
+
+// Regression guard for the `views://` range-request bug: task sounds must be
+// inlined as base64 `data:` URLs (via the `?inline` import suffix), never served
+// as separate files through the Electrobun `views://` scheme. WKWebView's media
+// loader fetches <audio> sources with a Range request that the scheme handler
+// does not satisfy, so a file URL silently fails with `NotSupportedError`.
+describe("task sound assets", () => {
+	for (const [status, def] of Object.entries(SOUND_DEFS)) {
+		it(`serves "${status}" as an inlined data: URL`, () => {
+			expect(def.url.startsWith("data:audio/")).toBe(true);
+		});
+	}
+});

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -1,9 +1,15 @@
-import completedSoundUrl from "../assets/sounds/task-completed.mp3";
-import cancelledSoundUrl from "../assets/sounds/task-cancelled.mp3";
+// `?inline` forces Vite to emit these as base64 `data:` URLs instead of files
+// served via the `views://` scheme. WKWebView's media loader (AppleCoreMedia)
+// fetches <audio> sources with a Range request (`bytes=0-1`), which the
+// Electrobun `views://` scheme handler does not satisfy — the request returns no
+// body and playback fails with `NotSupportedError`. A data: URL sidesteps the
+// scheme handler entirely, so playback works in packaged builds on every OS.
+import completedSoundUrl from "../assets/sounds/task-completed.mp3?inline";
+import cancelledSoundUrl from "../assets/sounds/task-cancelled.mp3?inline";
 
 type TaskSoundStatus = "completed" | "cancelled";
 
-const SOUND_DEFS: Record<TaskSoundStatus, { url: string; volume: number }> = {
+export const SOUND_DEFS: Record<TaskSoundStatus, { url: string; volume: number }> = {
 	completed: { url: completedSoundUrl, volume: 0.3 },
 	cancelled: { url: cancelledSoundUrl, volume: 0.7 },
 };


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Task completion/cancellation sounds silently failed in packaged builds. WKWebView's media loader fetches `<audio>` sources with a `Range: bytes=0-1` request that the Electrobun `views://` scheme handler does not satisfy, so the MP3s never loaded — playback died with `NotSupportedError` (visible in the console as `Failed to load resource: Resource not found`).

Fix: import the MP3s with Vite's `?inline` suffix so they are emitted as base64 `data:` URLs embedded in the JS bundle. A `data:` URL is loaded directly by the media element — no scheme handler, no Range request — so playback works in packaged builds on every OS.

- `src/mainview/task-sounds.ts` — `?inline` on both imports + comment explaining why.
- `src/mainview/__tests__/task-sounds.test.ts` — regression guard asserting the URLs are `data:audio/` (genuine WKWebView range behavior is impractical to reproduce in happy-dom).
- `decisions/057-task-sound-inline-data-url.md`, changelog entry.

Likely surfaced by the Electrobun 1.14.4 → 1.18.1 bump (#549) changing scheme-handler behavior; the `data:` URL approach is version-independent regardless.