### PR TITLE
docs: small README polish (React 19, no-HMR, Linux webview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,21 +193,21 @@ bun build src/bun/headless-bootstrap.ts --compile --outfile dist/dev3-server
 
 | Component | Technology |
 |---|---|
-| Desktop runtime | [Electrobun](https://electrobun.dev) — native macOS webview, no Chromium |
+| Desktop runtime | [Electrobun](https://electrobun.dev) — native webview (WKWebView on macOS, WebKitGTK on Linux), no Chromium |
 | JS runtime | [Bun](https://bun.sh) |
 | Terminal | [ghostty-web](https://github.com/nichochar/ghostty-web) — GPU-accelerated rendering |
-| Frontend | React 18, Tailwind CSS, Vite |
+| Frontend | React 19, Tailwind CSS, Vite |
 | Multiplexer | tmux |
 
 ## Development
 
 ```bash
 bun install
-bun run dev          # HMR mode (Vite dev server + Electrobun)
+bun run dev          # Build + launch the app locally (no HMR)
 bun run build        # Staging build
 bun run build:prod   # Production build
 bun run lint         # TypeScript type-check
-bun run test         # Run tests
+bun run test         # Run tests (fast subset; use `bun run test:full` for CI parity)
 ```
 
 See [AGENTS.md](AGENTS.md) for full architecture docs and coding guidelines.

--- a/change-logs/2026/05/29/docs-readme-polish.md
+++ b/change-logs/2026/05/29/docs-readme-polish.md
@@ -1,0 +1,1 @@
+Polish README: bump tech stack row to React 19, clarify that `bun run dev` builds + launches (no HMR), broaden Electrobun description to mention both WKWebView on macOS and WebKitGTK on Linux, and point at `bun run test:full` for CI-parity test runs.


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — small factual cleanup of `README.md`.

## Summary

- Tech stack row: React `18 → 19` (matches what the project actually uses).
- Development section: `bun run dev` is now described as *Build + launch the app locally (no HMR)* — `AGENTS.md` explicitly states the HMR/Vite watch workflow is not used.
- Tech stack row: broadened the Electrobun description to mention both `WKWebView on macOS` and `WebKitGTK on Linux`, since Linux is already supported.
- Mentioned `bun run test:full` as the CI-parity full run alongside `bun run test`.

No code changes; pure documentation. `bun run lint` passes.