### PR TITLE
Reorder Claude presets to Auto/Bypass/Default and default to Auto

### DIFF
--- a/change-logs/2026/05/29/chore-reorder-claude-presets-auto-default.md
+++ b/change-logs/2026/05/29/chore-reorder-claude-presets-auto-default.md
@@ -1,0 +1,1 @@
+Reordered the Claude Opus 4.8 presets so Auto comes first, then Bypass, then Default (Plan/Accept Edits/Don't Ask follow, Opus 4.7 group stays at the bottom), and made the Auto (Opus 4.8) preset the default selection for fresh installs.

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -28,7 +28,7 @@ export interface GlobalSettings {
 
 const DEFAULT_SETTINGS: GlobalSettings = {
 	defaultAgentId: "builtin-claude",
-	defaultConfigId: "claude-default",
+	defaultConfigId: "claude-auto",
 	taskDropPosition: "top",
 	updateChannel: "stable",
 };

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -107,7 +107,7 @@ function App() {
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const [globalSettings, setGlobalSettings] = useState<GlobalSettingsType>({
 		defaultAgentId: "builtin-claude",
-		defaultConfigId: "claude-default",
+		defaultConfigId: "claude-auto",
 		taskDropPosition: "top",
 		updateChannel: "stable",
 	});

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -52,7 +52,7 @@ function KanbanBoard({
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const [globalSettings, setGlobalSettings] = useState<GlobalSettings>({
 		defaultAgentId: "builtin-claude",
-		defaultConfigId: "claude-default",
+		defaultConfigId: "claude-auto",
 		taskDropPosition: "top",
 		updateChannel: "stable",
 	});

--- a/src/mainview/components/global-settings/utils.ts
+++ b/src/mainview/components/global-settings/utils.ts
@@ -8,7 +8,7 @@ export type Theme = "dark" | "light" | "system";
 
 export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
 	defaultAgentId: "builtin-claude",
-	defaultConfigId: "claude-default",
+	defaultConfigId: "claude-auto",
 	taskDropPosition: "top",
 	updateChannel: "stable",
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -166,15 +166,15 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			// --- Opus 4.8 (new default) ---
+			// --- Opus 4.8 (new default) — order: Auto, Bypass, Default, then the rest ---
+			{ id: "claude-auto", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 5 },
+			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
+			{ id: "claude-bypass", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-default", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
 			{ id: "claude-default-sonnet", name: "Default (Sonnet)", model: "sonnet", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 2 },
-			{ id: "claude-bypass", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
-			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
-			{ id: "claude-auto", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 5 },
-			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
 			{ id: "claude-approvals", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
 			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-dontask", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
@@ -187,7 +187,7 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 			{ id: "claude-approvals-opus47", name: "Accept Edits (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-dontask-opus47", name: "Don't Ask (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 		],
-		defaultConfigId: "claude-default",
+		defaultConfigId: "claude-auto",
 	},
 	{
 		id: "builtin-codex",


### PR DESCRIPTION
## Summary

- Reorder the Claude **Opus 4.8** preset group so the order is **Auto → Bypass → Default** (then Plan, Accept Edits, Don't Ask; the Opus 4.7 group stays at the bottom). Each Opus preset keeps its Sonnet sibling directly beneath it.
- Make **Auto (Opus 4.8)** the default selection for fresh installs — `defaultConfigId` on the Claude agent and every global-settings fallback now points at `claude-auto` instead of `claude-default`.