### PR TITLE
Fix dev server restart: stop then start with delay

### DIFF
--- a/change-logs/2026/05/29/fix-dev-server-restart-sequence.md
+++ b/change-logs/2026/05/29/fix-dev-server-restart-sequence.md
@@ -1,0 +1,1 @@
+Fixed the dev server Restart button: it now fully stops the running server, waits ~1s for ports and the inner tmux session to release, then starts fresh — instead of starting immediately and racing the dying process.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -25,6 +25,7 @@ vi.mock("../pty-server", () => ({
 vi.mock("../rpc-handlers/tmux-pty", () => ({
 	runDevServer: vi.fn(),
 	stopDevServer: vi.fn(),
+	restartDevServer: vi.fn(),
 	getDevServerStatus: vi.fn(),
 }));
 
@@ -77,7 +78,7 @@ import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
 import { activateTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage } from "../rpc-handlers";
-import { runDevServer, stopDevServer, getDevServerStatus } from "../rpc-handlers/tmux-pty";
+import { runDevServer, stopDevServer, restartDevServer, getDevServerStatus } from "../rpc-handlers/tmux-pty";
 import { flushAndEnd } from "../socket-backpressure";
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 
@@ -358,6 +359,25 @@ describe("devServer.*", () => {
 
 		expect(resp.ok).toBe(true);
 		expect(stopDevServer).toHaveBeenCalledWith({ taskId: task.id, projectId: project.id });
+	});
+
+	it("restarts via restartDevServer (stop → delay → start), not a bare start", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "task-abc12345-1111-2222-3333-444444444444" });
+		const status = { taskId: task.id, running: true, devSessionName: "dev3-dev-task-abc1" };
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(restartDevServer).mockResolvedValue(status as any);
+
+		const resp = await handleRequest(makeRequest("devServer.restart", {
+			projectId: "proj-1",
+			taskId: "task-abc1",
+		}));
+
+		expect(resp.ok).toBe(true);
+		expect(restartDevServer).toHaveBeenCalledWith({ taskId: task.id, projectId: project.id });
+		expect(runDevServer).not.toHaveBeenCalled();
+		expect(resp.data).toEqual(status);
 	});
 
 	it("returns current dev server status", async () => {

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -3,7 +3,7 @@ import type { CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskS
 import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, getAllowedTransitions, titleFromDescription } from "../shared/types";
 import * as data from "./data";
 import { isActive, activateTask, getPushMessage, getPushMessageLocal, moveTask, triggerColumnAgentIfNeeded, notifyWatchedTaskStatusChange } from "./rpc-handlers";
-import { getDevServerStatus, runDevServer, stopDevServer } from "./rpc-handlers/tmux-pty";
+import { getDevServerStatus, runDevServer, stopDevServer, restartDevServer } from "./rpc-handlers/tmux-pty";
 import * as repoConfig from "./repo-config";
 import { loadSettings } from "./settings";
 import { createLogger } from "./logger";
@@ -577,7 +577,7 @@ const handlers: Record<string, Handler> = {
 
 	"devServer.restart": async (params) => {
 		const { project, task } = await resolveTaskFromParams(params);
-		return runDevServer({ taskId: task.id, projectId: project.id });
+		return restartDevServer({ taskId: task.id, projectId: project.id });
 	},
 
 	"devServer.status": async (params) => {

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -639,6 +639,21 @@ export async function stopDevServer(params: { taskId: string; projectId: string 
 	}
 }
 
+// Restart must fully stop the old server, wait for the OS to release its
+// ports (and for the inner tmux session to tear down), then start fresh.
+// Starting immediately after a kill races the dying dev process — the new
+// server fails to bind or tmux glitches mid-teardown.
+const DEV_SERVER_RESTART_DELAY_MS = 1000;
+
+export async function restartDevServer(params: { taskId: string; projectId: string }): Promise<DevServerStatus> {
+	log.info("→ restartDevServer", params);
+	await stopDevServer(params);
+	await new Promise((resolve) => setTimeout(resolve, DEV_SERVER_RESTART_DELAY_MS));
+	const status = await runDevServer(params);
+	log.info("← restartDevServer done");
+	return status;
+}
+
 export async function getDevServerStatus(params: { taskId: string; projectId: string }): Promise<DevServerStatus> {
 	log.info("→ getDevServerStatus", params);
 	const project = await data.getProject(params.projectId);
@@ -1743,6 +1758,7 @@ export const tmuxPtyHandlers = {
 	runDevServer,
 	checkDevServer,
 	stopDevServer,
+	restartDevServer,
 	getDevServerStatus,
 	openFileBrowser,
 	getTerminalPreview,

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../rpc", () => ({
 			runDevServer: vi.fn(),
 			checkDevServer: vi.fn(),
 			stopDevServer: vi.fn(),
+			restartDevServer: vi.fn(),
 			getBranchStatus: vi.fn(),
 			prepareMergeCompletionPrompt: vi.fn(),
 			dismissMergeCompletionPrompt: vi.fn(),
@@ -868,10 +869,10 @@ describe("TaskInfoPanel", () => {
 			expect(mockedApi.request.runDevServer).not.toHaveBeenCalled();
 		});
 
-		it("restarts dev server from running menu", async () => {
+		it("restarts dev server via restartDevServer (stop → delay → start)", async () => {
 			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 			mockedApi.request.checkDevServer.mockResolvedValue({ running: true });
-			mockedApi.request.runDevServer.mockResolvedValue(defaultDevServerStatus);
+			mockedApi.request.restartDevServer.mockResolvedValue(defaultDevServerStatus);
 
 			await act(async () => {
 				renderPanel(makeTask(), { project: { ...project, devScript: "bun run dev" } });
@@ -883,10 +884,11 @@ describe("TaskInfoPanel", () => {
 
 			await user.click(screen.getByText("Restart"));
 
-			await waitFor(() => expect(mockedApi.request.runDevServer).toHaveBeenCalledWith({
+			await waitFor(() => expect(mockedApi.request.restartDevServer).toHaveBeenCalledWith({
 				taskId: "t1",
 				projectId: "p1",
 			}));
+			expect(mockedApi.request.runDevServer).not.toHaveBeenCalled();
 		});
 
 		it("stops dev server from running menu", async () => {

--- a/src/mainview/components/task-info-panel/TaskDevServer.tsx
+++ b/src/mainview/components/task-info-panel/TaskDevServer.tsx
@@ -171,7 +171,7 @@ export default function TaskDevServer({ task, project, isTaskActive }: TaskDevSe
 	async function handleDevServerRestart() {
 		setDevServerMenuOpen(false);
 		try {
-			await api.request.runDevServer({ taskId: task.id, projectId: project.id });
+			await api.request.restartDevServer({ taskId: task.id, projectId: project.id });
 		} catch (err) {
 			alert(t("infoPanel.devServerFailed", { error: String(err) }));
 		}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1199,6 +1199,10 @@ export type AppRPCSchema = {
 				params: { taskId: string; projectId: string };
 				response: DevServerStatus;
 			};
+			restartDevServer: {
+				params: { taskId: string; projectId: string };
+				response: DevServerStatus;
+			};
 			getDevServerStatus: {
 				params: { taskId: string; projectId: string };
 				response: DevServerStatus;


### PR DESCRIPTION
## Summary

The **Restart** button for the dev server was glitchy and didn't always work. Root cause: restart called `runDevServer` directly, which killed the running session and **immediately** recreated it — racing the dying dev process (ports still held) and the tmux session teardown.

This PR adds a dedicated `restartDevServer` that does it properly: **stop → wait ~1s → start**.

- New `restartDevServer` in `tmux-pty.ts` (stop, 1000ms delay, start).
- `devServer.restart` RPC and the Restart button now route through it.
- Added `restartDevServer` to the webview RPC schema.
- Tests at both the RPC layer and the component assert restart goes through `restartDevServer`, not a bare `runDevServer`.

🤖 Opened by Claude (the AI assistant working on this branch).