### PR TITLE
fix: launch Codex with --profile-v2 on Codex 0.131+

### DIFF
--- a/change-logs/2026/05/31/fix-codex-profile-v2-launch-flag.md
+++ b/change-logs/2026/05/31/fix-codex-profile-v2-launch-flag.md
@@ -1,0 +1,1 @@
+Fix Codex 0.131+ launch failing with "config profile `dev3-dark` not found". dev-3.0 writes per-profile settings to `~/.codex/<name>.config.toml`, which Codex only loads via `--profile-v2 <name>` — but the launch command still passed the legacy `-p`/`--profile` flag. On profile-v2 Codex the flag is now rewritten to `--profile-v2`; older Codex keeps `-p`.

--- a/decisions/055-codex-profile-v2.md
+++ b/decisions/055-codex-profile-v2.md
@@ -22,6 +22,12 @@ The existing `getCodexSyntaxForVersion()` in `src/bun/codex-config.ts` already g
 
 A user who already had a per-profile `~/.codex/dev3-light.config.toml` with `web_search` set to a different value will see it overwritten to `"live"`. This matches the previous behavior under the `[profiles.dev3-light]` block, so it is not a regression. The cleanup only strips the three managed `[profiles.dev3*]` sections — user-owned profiles like `[profiles.ro]` are untouched.
 
+## Follow-up: launch flag (the other half)
+
+Writing the per-profile files was only half the fix. Codex exposes **two** flags: `-p`/`--profile <name>` loads an in-config `[profiles.<name>]` block, while `--profile-v2 <name>` layers `$CODEX_HOME/<name>.config.toml` on top of the base config. dev-3.0 launched with `-p dev3-dark`, so on Codex ≥0.131 (where we no longer write the in-config block) Codex reported `config profile dev3-dark not found`.
+
+`applyCodexThemeProfile()` in `src/bun/agents.ts` now rewrites the flag to `--profile-v2` (in addition to swapping the value to the themed profile) when `isCodexProfileV2()` is true. profile-v2 detection is cached per process and overridable in tests via `__setCodexProfileV2Override()`. Legacy Codex keeps `-p`. The base config still carries `default_permissions = "dev3"`, so the `[permissions.dev3]` sandbox/network grants apply regardless of which profile flag is used.
+
 ## Alternatives considered
 
 - **Always use profile-v2** — rejected: older Codex doesn't know about per-profile files, so `--profile dev3-light` would fail on legacy installs.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, isOpenCodeCommand, mergeMcpApproval, mergeWithDefaults, type TemplateContext } from "../agents";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, isOpenCodeCommand, mergeMcpApproval, mergeWithDefaults, __setCodexProfileV2Override, type TemplateContext } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 import { setCurrentUiTheme } from "../theme-state";
@@ -31,6 +31,13 @@ const makeCtx = (overrides?: Partial<TemplateContext>): TemplateContext => ({
 
 beforeEach(() => {
 	setCurrentUiTheme("dark");
+	// Default to legacy (pre-0.131) profile semantics so codex theme tests are
+	// deterministic regardless of the Codex version installed on the machine.
+	__setCodexProfileV2Override(false);
+});
+
+afterEach(() => {
+	__setCodexProfileV2Override(null);
 });
 
 describe("isOpenCodeCommand", () => {
@@ -218,6 +225,49 @@ describe("resolveAgentCommand — resume", () => {
 
 		expect(cmd).toContain("-p my-custom-profile");
 		expect(cmd).not.toContain("-p dev3-light");
+	});
+
+	it("Codex: rewrites -p to --profile-v2 on profile-v2 Codex (dark)", () => {
+		setCurrentUiTheme("dark");
+		__setCodexProfileV2Override(true);
+
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("--profile-v2 dev3-dark");
+		expect(cmd).not.toContain("-p dev3-dark");
+		expect(cmd).not.toContain("-p dev3 ");
+	});
+
+	it("Codex: rewrites --profile to --profile-v2 on profile-v2 Codex (light)", () => {
+		setCurrentUiTheme("light");
+		__setCodexProfileV2Override(true);
+
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined, additionalArgs: ["--profile", "dev3"] }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("--profile-v2 dev3-light");
+		expect(cmd).not.toContain("--profile dev3-light");
+	});
+
+	it("Codex: leaves custom profile names untouched on profile-v2 Codex", () => {
+		setCurrentUiTheme("dark");
+		__setCodexProfileV2Override(true);
+
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined, additionalArgs: ["-p", "my-custom-profile"] }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("-p my-custom-profile");
+		expect(cmd).not.toContain("--profile-v2");
 	});
 
 	// ---- Gemini ----

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentConfiguration, CodingAgent, Project } from "../shared/types";
 import { DEFAULT_AGENTS } from "../shared/types";
 import { createLogger } from "./logger";
-import { detectCodexVersion, ensureCodexConfig } from "./codex-config";
+import { detectCodexVersion, ensureCodexConfig, getCodexSyntaxForVersion } from "./codex-config";
 import { DEV3_HOME } from "./paths";
 import { loadSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme } from "./theme-state";
@@ -253,11 +253,40 @@ export function quoteIfUnsafe(s: string): string {
 	return /^[A-Za-z0-9_\-./:]+$/.test(s) ? s : shellEscape(s);
 }
 
+let codexProfileV2Override: boolean | null = null;
+let cachedCodexProfileV2: boolean | undefined;
+
+/** Test-only override for codex profile-v2 detection. Pass `null` to clear. */
+export function __setCodexProfileV2Override(value: boolean | null): void {
+	codexProfileV2Override = value;
+	cachedCodexProfileV2 = undefined;
+}
+
+/**
+ * True when the installed Codex (≥0.131) uses profile-v2 semantics: per-profile
+ * settings live in `~/.codex/<name>.config.toml` and are only loaded via
+ * `--profile-v2 <name>`. Detected once and cached for the process lifetime.
+ */
+function isCodexProfileV2(): boolean {
+	if (codexProfileV2Override !== null) return codexProfileV2Override;
+	if (cachedCodexProfileV2 === undefined) {
+		cachedCodexProfileV2 = getCodexSyntaxForVersion(detectCodexVersion()).profileV2;
+	}
+	return cachedCodexProfileV2;
+}
+
 function applyCodexThemeProfile(args: string[]): void {
 	const themedProfile = getCodexProfileForCurrentUiTheme();
+	const profileV2 = isCodexProfileV2();
 	for (let i = 0; i < args.length - 1; i++) {
 		if ((args[i] === "-p" || args[i] === "--profile") && args[i + 1] === "dev3") {
 			args[i + 1] = themedProfile;
+			// Codex ≥0.131 only loads the per-profile file
+			// `~/.codex/<name>.config.toml` via `--profile-v2 <name>`. The legacy
+			// `-p`/`--profile` flag looks for an in-config `[profiles.<name>]` block
+			// that we no longer write on profile-v2, causing
+			// "config profile `dev3-dark` not found". See decision 055.
+			if (profileV2) args[i] = "--profile-v2";
 			return;
 		}
 	}


### PR DESCRIPTION
## Problem

Starting a Codex task on Codex ≥0.131 failed with:

```
Error loading configuration: config profile `dev3-dark` not found
✗ Process exited with code 1
```

Codex ≥0.131 exposes **two** profile flags:
- `-p`/`--profile <name>` — loads an in-config `[profiles.<name>]` block from `~/.codex/config.toml`
- `--profile-v2 <name>` — layers the per-profile file `~/.codex/<name>.config.toml` on top of the base config

Decision 055 already switched dev-3.0 to write the per-profile **files** (and stop writing the in-config blocks) on Codex ≥0.131. But the launch command still passed `-p dev3-dark`, so Codex looked for an in-config block that no longer exists → "config profile not found".

## Fix

`applyCodexThemeProfile()` in `src/bun/agents.ts` now rewrites the flag to `--profile-v2` (in addition to swapping the value to the themed `dev3-dark`/`dev3-light` profile) when profile-v2 Codex is detected. Legacy Codex (<0.131) keeps `-p`. profile-v2 detection is cached per process and overridable in tests via `__setCodexProfileV2Override()`.

The base config still carries `default_permissions = "dev3"`, so the `[permissions.dev3]` sandbox/network grants apply regardless of which profile flag is used.

## Testing

- `bun run lint` clean; full fast suite green (2419 tests), incl. 3 new profile-v2 launch tests.
- Reproduced before the fix (`codex --profile dev3-dark exec` → error) and confirmed `codex --profile-v2 dev3-dark exec` loads the profile.
- I manually verified a new Codex task opens and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)