### PR TITLE
Add "PR + auto-merge" button to task git actions

### DIFF
--- a/change-logs/2026/06/03/feature-create-pr-auto-merge.md
+++ b/change-logs/2026/06/03/feature-create-pr-auto-merge.md
@@ -1,0 +1,1 @@
+Added a "Create PR + auto-merge" button next to "Create PR" in the task git actions. It does the same push + open PR flow via the task pane agent, but also asks the agent to enable auto-merge (gh pr merge --auto) so the PR lands automatically once checks pass.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6922,6 +6922,46 @@ describe("handlers.createPullRequest", () => {
 		vi.useRealTimers();
 	});
 
+	it("sends the auto-merge variant prompt when autoMerge is set", async () => {
+		vi.useFakeTimers();
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			stdout: args.includes("display-message") ? "%3\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id, autoMerge: true });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]?.some((a) => a.includes("gh pr create"))).toBe(true);
+		expect(paste[0]?.some((a) => a.includes("gh pr merge --auto"))).toBe(true);
+		vi.useRealTimers();
+	});
+
+	it("does not enable auto-merge in the default prompt", async () => {
+		vi.useFakeTimers();
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			stdout: args.includes("display-message") ? "%3\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste[0]?.some((a) => a.includes("gh pr merge --auto"))).toBe(false);
+		vi.useRealTimers();
+	});
+
 	it("silently does nothing when there is no active pane", async () => {
 		const project = makeProject();
 		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -725,7 +725,10 @@ const CREATE_PR_ENTER_DELAY_MS = 800;
 const CREATE_PR_AGENT_PROMPT =
 	"Please push this branch and open a pull request for it using the gh CLI (first run git push, then gh pr create). Choose an appropriate title and description based on the work in this conversation.";
 
-async function createPullRequest(params: { taskId: string; projectId: string }): Promise<void> {
+const CREATE_PR_AUTO_MERGE_AGENT_PROMPT =
+	"Please push this branch and open a pull request for it using the gh CLI (first run git push, then gh pr create). Choose an appropriate title and description based on the work in this conversation. Finally, enable auto-merge on the PR with gh pr merge --auto so it merges automatically once checks pass.";
+
+async function createPullRequest(params: { taskId: string; projectId: string; autoMerge?: boolean }): Promise<void> {
 	log.info("→ createPullRequest", params);
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
@@ -751,8 +754,9 @@ async function createPullRequest(params: { taskId: string; projectId: string }):
 	}
 
 	const pane = activePane;
+	const prompt = params.autoMerge ? CREATE_PR_AUTO_MERGE_AGENT_PROMPT : CREATE_PR_AGENT_PROMPT;
 	try {
-		const pasteProc = spawn(pty.tmuxArgs(socket, "send-keys", "-t", pane, CREATE_PR_AGENT_PROMPT), { stdout: "pipe", stderr: "pipe" });
+		const pasteProc = spawn(pty.tmuxArgs(socket, "send-keys", "-t", pane, prompt), { stdout: "pipe", stderr: "pipe" });
 		pasteProc.exited.catch(() => {});
 	} catch (err) {
 		log.warn("createPullRequest send-keys paste failed", { paneId: pane, error: String(err) });

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1534,7 +1534,7 @@ describe("TaskInfoPanel", () => {
 			});
 		});
 
-		it("calls createPullRequest with autoMerge when 'Create PR + auto-merge' is clicked", async () => {
+		it("calls createPullRequest with autoMerge when 'PR + auto-merge' is clicked", async () => {
 			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 			mockedApi.request.getBranchStatus.mockResolvedValue({
 				...defaultBranchStatus,
@@ -1548,7 +1548,7 @@ describe("TaskInfoPanel", () => {
 				renderPanel(makeTask());
 			});
 
-			const autoMergeButtons = screen.getAllByText("Create PR + auto-merge");
+			const autoMergeButtons = screen.getAllByText("PR + auto-merge");
 			const enabledBtn = autoMergeButtons.find(b => !b.closest("button")!.disabled);
 			expect(enabledBtn).toBeTruthy();
 			await user.click(enabledBtn!.closest("button")!);

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1530,6 +1530,33 @@ describe("TaskInfoPanel", () => {
 			expect(mockedApi.request.createPullRequest).toHaveBeenCalledWith({
 				taskId: "t1",
 				projectId: "p1",
+				autoMerge: false,
+			});
+		});
+
+		it("calls createPullRequest with autoMerge when 'Create PR + auto-merge' is clicked", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				ahead: 3,
+				unpushed: 0,
+				prNumber: null,
+			});
+			mockedApi.request.createPullRequest.mockResolvedValue(undefined);
+
+			await act(async () => {
+				renderPanel(makeTask());
+			});
+
+			const autoMergeButtons = screen.getAllByText("Create PR + auto-merge");
+			const enabledBtn = autoMergeButtons.find(b => !b.closest("button")!.disabled);
+			expect(enabledBtn).toBeTruthy();
+			await user.click(enabledBtn!.closest("button")!);
+
+			expect(mockedApi.request.createPullRequest).toHaveBeenCalledWith({
+				taskId: "t1",
+				projectId: "p1",
+				autoMerge: true,
 			});
 		});
 

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -230,6 +230,12 @@ export default function TaskGitActions({
 		return t("infoPanel.createPRAgentTooltip");
 	}
 
+	function getPRAutoMergeTooltip(): string {
+		if (!branchStatus) return t("infoPanel.statusLoading");
+		if (branchStatus.ahead === 0) return t("infoPanel.createPRDisabledNoCommits");
+		return t("infoPanel.createPRAutoMergeTooltip");
+	}
+
 	const mergeDisabled = !branchStatus || branchStatus.ahead === 0 || branchStatus.behind > 0 || merging;
 	const mergeTooltip = !branchStatus
 		? t("infoPanel.statusLoading")
@@ -298,21 +304,38 @@ export default function TaskGitActions({
 					{t("infoPanel.openPR")}
 				</button>
 			) : (
-				<button
-					onClick={() => void handleCreatePR()}
-					disabled={createPRDisabled}
-					className={`px-1.5 py-0.5 rounded text-[0.625rem] font-medium transition-colors ${
-						createPRDisabled ? disabledBtnClass : enabledBtnClass
-					}`}
-					title={getPRTooltip()}
-				>
-					<span className="inline-flex items-center gap-1.5">
-						<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-							{"\u{F16A6}"}
+				<>
+					<button
+						onClick={() => void handleCreatePR(false)}
+						disabled={createPRDisabled}
+						className={`px-1.5 py-0.5 rounded text-[0.625rem] font-medium transition-colors ${
+							createPRDisabled ? disabledBtnClass : enabledBtnClass
+						}`}
+						title={getPRTooltip()}
+					>
+						<span className="inline-flex items-center gap-1.5">
+							<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+								{"\u{F16A6}"}
+							</span>
+							<span>{getPRButtonLabel()}</span>
 						</span>
-						<span>{getPRButtonLabel()}</span>
-					</span>
-				</button>
+					</button>
+					<button
+						onClick={() => void handleCreatePR(true)}
+						disabled={createPRDisabled}
+						className={`px-1.5 py-0.5 rounded text-[0.625rem] font-medium transition-colors ${
+							createPRDisabled ? disabledBtnClass : enabledBtnClass
+						}`}
+						title={getPRAutoMergeTooltip()}
+					>
+						<span className="inline-flex items-center gap-1.5">
+							<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+								{"\u{F0623}"}
+							</span>
+							<span>{creatingPR ? t("infoPanel.creatingPR") : t("infoPanel.createPRAutoMerge")}</span>
+						</span>
+					</button>
+				</>
 			)}
 			<button
 				onClick={handleMerge}

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -330,7 +330,7 @@ export default function TaskGitActions({
 					>
 						<span className="inline-flex items-center gap-1.5">
 							<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-								{"\u{F0623}"}
+								{"\u{F16A6}"}
 							</span>
 							<span>{creatingPR ? t("infoPanel.creatingPR") : t("infoPanel.createPRAutoMerge")}</span>
 						</span>

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -175,7 +175,7 @@ export function useTaskBranchStatus({
 		t,
 	]);
 
-	const handleCreatePR = useCallback(async () => {
+	const handleCreatePR = useCallback(async (autoMerge = false) => {
 		if (creatingPR) {
 			return;
 		}
@@ -185,6 +185,7 @@ export function useTaskBranchStatus({
 			await api.request.createPullRequest({
 				taskId: task.id,
 				projectId: project.id,
+				autoMerge,
 			});
 		} catch (err) {
 			alert(t("infoPanel.createPRFailed", { error: String(err) }));

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -29,7 +29,7 @@ const infoPanel = {
 	"infoPanel.pushing": "Pushing...",
 	"infoPanel.pushFailed": "Push failed: {error}",
 	"infoPanel.createPR": "Create PR",
-	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMerge": "PR + auto-merge",
 	"infoPanel.createPRAutoMergeTooltip": "Ask the agent to push, open a PR with gh, and enable auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Open existing PR #{number}",

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -29,6 +29,8 @@ const infoPanel = {
 	"infoPanel.pushing": "Pushing...",
 	"infoPanel.pushFailed": "Push failed: {error}",
 	"infoPanel.createPR": "Create PR",
+	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMergeTooltip": "Ask the agent to push, open a PR with gh, and enable auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Open existing PR #{number}",
 	"infoPanel.openPRFailed": "Open PR failed: {error}",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -32,6 +32,8 @@ const tips = {
 	"tip.taskSearch.body": "Press Ctrl/Cmd+F to search on the board and sidebar by name, #ID, PR number, or description.",
 	"tip.pushAndCreatePr.title": "Let the agent open your PR",
 	"tip.pushAndCreatePr.body": "Click \"Create PR\" and the agent in your task pane pushes the branch and opens a pull request with gh — no extra window.",
+	"tip.createPrAutoMerge.title": "Open a PR and auto-merge it",
+	"tip.createPrAutoMerge.body": "Click \"Create PR + auto-merge\" to push, open the PR, and enable auto-merge so it lands as soon as checks pass.",
 	"tip.projectGitHubAccount.title": "Pick gh per project",
 	"tip.projectGitHubAccount.body": "Open Project Settings and choose the gh account for that repo before creating PRs or checking PR status.",
 	"tip.prBadgeOnCard.title": "PR number on every card",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -33,7 +33,7 @@ const tips = {
 	"tip.pushAndCreatePr.title": "Let the agent open your PR",
 	"tip.pushAndCreatePr.body": "Click \"Create PR\" and the agent in your task pane pushes the branch and opens a pull request with gh — no extra window.",
 	"tip.createPrAutoMerge.title": "Open a PR and auto-merge it",
-	"tip.createPrAutoMerge.body": "Click \"Create PR + auto-merge\" to push, open the PR, and enable auto-merge so it lands as soon as checks pass.",
+	"tip.createPrAutoMerge.body": "Click \"PR + auto-merge\" to push, open the PR, and enable auto-merge so it lands as soon as checks pass.",
 	"tip.projectGitHubAccount.title": "Pick gh per project",
 	"tip.projectGitHubAccount.body": "Open Project Settings and choose the gh account for that repo before creating PRs or checking PR status.",
 	"tip.prBadgeOnCard.title": "PR number on every card",

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -29,6 +29,8 @@ const infoPanel = {
 	"infoPanel.pushing": "Push...",
 	"infoPanel.pushFailed": "Push falló: {error}",
 	"infoPanel.createPR": "Create PR",
+	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMergeTooltip": "Pedir al agente que haga push, abra un PR con gh y active auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Abrir PR existente #{number}",
 	"infoPanel.openPRFailed": "Error al abrir PR: {error}",

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -29,7 +29,7 @@ const infoPanel = {
 	"infoPanel.pushing": "Push...",
 	"infoPanel.pushFailed": "Push falló: {error}",
 	"infoPanel.createPR": "Create PR",
-	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMerge": "PR + auto-merge",
 	"infoPanel.createPRAutoMergeTooltip": "Pedir al agente que haga push, abra un PR con gh y active auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Abrir PR existente #{number}",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -32,6 +32,8 @@ const tips = {
 	"tip.taskSearch.body": "Usa Ctrl/Cmd+F para buscar en el tablero y panel lateral por nombre, #ID, número de PR o descripción.",
 	"tip.pushAndCreatePr.title": "Deja que el agente abra el PR",
 	"tip.pushAndCreatePr.body": "Haz clic en \"Create PR\" y el agente en el panel de la tarea hace push de la rama y abre un pull request con gh, sin ventanas extra.",
+	"tip.createPrAutoMerge.title": "Abre un PR y auto-merge",
+	"tip.createPrAutoMerge.body": "Haz clic en \"Create PR + auto-merge\" para hacer push, abrir el PR y activar auto-merge para que se fusione en cuanto pasen los checks.",
 	"tip.projectGitHubAccount.title": "Elige gh por proyecto",
 	"tip.projectGitHubAccount.body": "Abre Config del proyecto y elige la cuenta de gh de ese repo antes de crear PRs o revisar su estado.",
 	"tip.prBadgeOnCard.title": "Número de PR en la tarjeta",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -33,7 +33,7 @@ const tips = {
 	"tip.pushAndCreatePr.title": "Deja que el agente abra el PR",
 	"tip.pushAndCreatePr.body": "Haz clic en \"Create PR\" y el agente en el panel de la tarea hace push de la rama y abre un pull request con gh, sin ventanas extra.",
 	"tip.createPrAutoMerge.title": "Abre un PR y auto-merge",
-	"tip.createPrAutoMerge.body": "Haz clic en \"Create PR + auto-merge\" para hacer push, abrir el PR y activar auto-merge para que se fusione en cuanto pasen los checks.",
+	"tip.createPrAutoMerge.body": "Haz clic en \"PR + auto-merge\" para hacer push, abrir el PR y activar auto-merge para que se fusione en cuanto pasen los checks.",
 	"tip.projectGitHubAccount.title": "Elige gh por proyecto",
 	"tip.projectGitHubAccount.body": "Abre Config del proyecto y elige la cuenta de gh de ese repo antes de crear PRs o revisar su estado.",
 	"tip.prBadgeOnCard.title": "Número de PR en la tarjeta",

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -29,6 +29,8 @@ const infoPanel = {
 	"infoPanel.pushing": "Push...",
 	"infoPanel.pushFailed": "Push не удался: {error}",
 	"infoPanel.createPR": "Create PR",
+	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMergeTooltip": "Попросить агента запушить ветку, открыть PR через gh и включить auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Открыть существующий PR #{number}",
 	"infoPanel.openPRFailed": "Не удалось открыть PR: {error}",

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -29,7 +29,7 @@ const infoPanel = {
 	"infoPanel.pushing": "Push...",
 	"infoPanel.pushFailed": "Push не удался: {error}",
 	"infoPanel.createPR": "Create PR",
-	"infoPanel.createPRAutoMerge": "Create PR + auto-merge",
+	"infoPanel.createPRAutoMerge": "PR + auto-merge",
 	"infoPanel.createPRAutoMergeTooltip": "Попросить агента запушить ветку, открыть PR через gh и включить auto-merge",
 	"infoPanel.openPR": "Open PR",
 	"infoPanel.openPRTooltip": "Открыть существующий PR #{number}",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -33,7 +33,7 @@ const tips = {
 	"tip.pushAndCreatePr.title": "Пусть PR откроет агент",
 	"tip.pushAndCreatePr.body": "Нажмите «Create PR» — агент в pane задачи сам запушит ветку и откроет pull request через gh, без отдельного окна.",
 	"tip.createPrAutoMerge.title": "Открыть PR и сразу auto-merge",
-	"tip.createPrAutoMerge.body": "Нажмите «Create PR + auto-merge» — агент запушит, откроет PR и включит auto-merge, чтобы он влился сразу после прохождения проверок.",
+	"tip.createPrAutoMerge.body": "Нажмите «PR + auto-merge» — агент запушит, откроет PR и включит auto-merge, чтобы он влился сразу после прохождения проверок.",
 	"tip.projectGitHubAccount.title": "Выбери gh для проекта",
 	"tip.projectGitHubAccount.body": "Откройте настройки проекта и выберите gh-аккаунт для этого репо перед созданием PR или проверкой статуса PR.",
 	"tip.prBadgeOnCard.title": "Номер PR на карточке",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -32,6 +32,8 @@ const tips = {
 	"tip.taskSearch.body": "Ctrl/Cmd+F для поиска на доске и в боковой панели — по названию, #ID, номеру PR или описанию.",
 	"tip.pushAndCreatePr.title": "Пусть PR откроет агент",
 	"tip.pushAndCreatePr.body": "Нажмите «Create PR» — агент в pane задачи сам запушит ветку и откроет pull request через gh, без отдельного окна.",
+	"tip.createPrAutoMerge.title": "Открыть PR и сразу auto-merge",
+	"tip.createPrAutoMerge.body": "Нажмите «Create PR + auto-merge» — агент запушит, откроет PR и включит auto-merge, чтобы он влился сразу после прохождения проверок.",
 	"tip.projectGitHubAccount.title": "Выбери gh для проекта",
 	"tip.projectGitHubAccount.body": "Откройте настройки проекта и выберите gh-аккаунт для этого репо перед созданием PR или проверкой статуса PR.",
 	"tip.prBadgeOnCard.title": "Номер PR на карточке",

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -95,6 +95,12 @@ const ALL_TIPS: Tip[] = [
 		icon: "\u{F06A9}", // nf-md-robot
 	},
 	{
+		id: "create-pr-auto-merge",
+		titleKey: "tip.createPrAutoMerge.title",
+		bodyKey: "tip.createPrAutoMerge.body",
+		icon: "\u{F0623}", // nf-md-source_merge
+	},
+	{
 		id: "project-github-account",
 		titleKey: "tip.projectGitHubAccount.title",
 		bodyKey: "tip.projectGitHubAccount.body",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1246,7 +1246,7 @@ export type AppRPCSchema = {
 				response: void;
 			};
 			createPullRequest: {
-				params: { taskId: string; projectId: string };
+				params: { taskId: string; projectId: string; autoMerge?: boolean };
 				response: void;
 			};
 			openPullRequest: {


### PR DESCRIPTION
## Summary

Adds a second PR button next to **Create PR** in the task git actions row. It runs the same push + `gh pr create` flow through the task pane agent, but also instructs the agent to enable auto-merge (`gh pr merge --auto`) so the PR lands automatically once checks pass.

- New `autoMerge?: boolean` param on the `createPullRequest` RPC handler; when set, the agent prompt asks to enable auto-merge after opening the PR.
- New **PR + auto-merge** button in `TaskGitActions` (same robot glyph as Create PR, shortened label), shown alongside Create PR when no open PR exists.
- i18n keys + tooltip for en/ru/es, plus a "Did you know?" tip.
- Unit tests for the auto-merge prompt variant (backend) and the button click (UI).

Hi, this is Claude (the AI assistant that worked on this branch) — happy to adjust anything on request.