### PR TITLE
Fix notification click-to-open: respect open-mode, gate on foreground

### DIFF
--- a/change-logs/2026/06/03/fix-notification-zoom.md
+++ b/change-logs/2026/06/03/fix-notification-zoom.md
@@ -1,0 +1,1 @@
+Fixed watched-task notification click-to-open: it now respects the user's task-open-mode preference (split by default instead of always forcing fullscreen zoom), and no longer fires on an unrelated in-app click. Click-to-open is only armed when the app was in the background when the notification was shown, tracked via a renderer-reported window foreground flag.

--- a/decisions/062-notification-click-foreground-gate.md
+++ b/decisions/062-notification-click-foreground-gate.md
@@ -1,0 +1,49 @@
+# 062 — Notification click-to-open: foreground gate + open-mode
+
+## Context
+
+Watched-task notifications support click-to-open: clicking the macOS notification
+focuses the task. Two bugs: (1) it always navigated to the fullscreen `task`
+screen (zoom), hiding the board, regardless of how the user normally opens tasks;
+(2) **any** in-app click shortly after a notification would teleport the user into
+the task.
+
+## Investigation
+
+Electrobun's `Utils.showNotification` exposes no click callback (confirmed in
+`vendor-docs/electrobun/apis/utils.md`). The feature approximates a click by
+treating a window `focus` event within a TTL after the notification as the click.
+This is fundamentally ambiguous: focus also fires when the user clicks back into
+the app for unrelated reasons (e.g. after devtools/another window had key). The
+only reliable discriminator is **whether the app was in the foreground when the
+notification was posted** — if the user was already looking at the app, the banner
+is informational and no navigation should be armed. Electrobun emits no native
+"resign active" event, so the backend cannot know foreground state on its own.
+
+## Decision
+
+- Renderer reports window focus/blur to the backend via a new `setWindowForeground`
+  RPC (`app-handlers.ts`); `index.ts`'s `onFocus` hook also flips it true. State
+  lives in `rpc-handlers/shared.ts` (`setAppForeground`/`isAppForeground`).
+- `notifyWatchedTaskStatusChange` (`shared.ts`) only arms the click-to-open slot
+  when `!appForeground`. The banner is always shown.
+- TTL reduced 5000ms → 3000ms (`NOTIFICATION_CLICK_TTL_MS`).
+- `onOpenTaskFromNotification` (`App.tsx`) now honors `dev3-task-open-mode`
+  (default `split`), matching a normal `TaskCard` click instead of forcing
+  fullscreen zoom.
+
+## Risks
+
+- Dev-only edge case: with native devtools focused, the renderer window reports
+  blur, so a notification then arms; clicking the main window navigates. Harmless
+  in production (no devtools window).
+- Multi-window focus/blur ordering can briefly set a wrong foreground value; worst
+  case it matches today's behavior, never worse.
+
+## Alternatives considered
+
+- Deciding entirely in the renderer (track recent blur→focus): rejected — clicking
+  the notification and clicking back into the app both produce the same renderer
+  focus transition, so it cannot discriminate. The post-time foreground check can.
+- Dropping the focus proxy and using only `app.reopen`: rejected — `reopen` does
+  not fire reliably for notification activations, which is why focus was added.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -242,6 +242,8 @@ const {
 	consumeRecentWatchedNotification,
 	_resetWatchedNotificationState,
 	NOTIFICATION_CLICK_TTL_MS,
+	setAppForeground,
+	isAppForeground,
 	emitTaskSound,
 	runCleanupScript,
 } = await import("../rpc-handlers");
@@ -6863,6 +6865,46 @@ describe("notifyWatchedTaskStatusChange", () => {
 		const task = makeTask({ watched: false });
 		notifyWatchedTaskStatusChange(task, "in-progress", "review-by-user", "MyProject");
 		expect(consumeRecentWatchedNotification()).toBeNull();
+	});
+
+	it("shows the banner but does NOT arm click-to-open when the app is in the foreground", () => {
+		setAppForeground(true);
+		const task = makeTask({ watched: true, projectId: "proj-fg" });
+		notifyWatchedTaskStatusChange(task, "in-progress", "review-by-user", "MyProject");
+
+		// Banner still shown — the user is just informed, not teleported.
+		expect(Utils.showNotification).toHaveBeenCalledTimes(1);
+		// Slot must stay empty so a later in-app click cannot trigger navigation.
+		expect(consumeRecentWatchedNotification()).toBeNull();
+	});
+
+	it("arms click-to-open when the app is in the background", () => {
+		setAppForeground(false);
+		const task = makeTask({ watched: true, projectId: "proj-bg" });
+		notifyWatchedTaskStatusChange(task, "in-progress", "review-by-user", "MyProject");
+
+		expect(consumeRecentWatchedNotification()).toEqual({ taskId: task.id, projectId: "proj-bg" });
+	});
+});
+
+describe("setAppForeground / isAppForeground", () => {
+	beforeEach(() => {
+		_resetWatchedNotificationState();
+	});
+
+	it("defaults to false after reset and toggles with setAppForeground", () => {
+		expect(isAppForeground()).toBe(false);
+		setAppForeground(true);
+		expect(isAppForeground()).toBe(true);
+		setAppForeground(false);
+		expect(isAppForeground()).toBe(false);
+	});
+
+	it("handlers.setWindowForeground forwards the renderer's focus state", async () => {
+		await handlers.setWindowForeground({ focused: true });
+		expect(isAppForeground()).toBe(true);
+		await handlers.setWindowForeground({ focused: false });
+		expect(isAppForeground()).toBe(false);
 	});
 });
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -4,7 +4,7 @@ import Electrobun, {
 	Updater,
 	Utils,
 } from "electrobun/bun";
-import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited, consumeRecentWatchedNotification } from "./rpc-handlers";
+import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited, consumeRecentWatchedNotification, setAppForeground } from "./rpc-handlers";
 import { startAutoCheck, checkForUpdateWithChannel, getLocalVersion, downloadUpdateForChannel, applyUpdate } from "./updater";
 import { loadSettings, loadSettingsSync } from "./settings";
 import { isQuitConfirmed, markQuitDialogPending } from "./quit-manager";
@@ -269,7 +269,13 @@ async function openMainWindow() {
 			log.info("Opening external URL", { url: externalUrl });
 			Utils.openExternal(externalUrl);
 		},
-		onFocus: () => tryNavigateFromRecentNotification("window-focus"),
+		onFocus: () => {
+			// A window gaining key focus means the app is foreground. The renderer
+			// also reports this via setWindowForeground, but the native focus event
+			// is the authoritative source and never races renderer mount timing.
+			setAppForeground(true);
+			tryNavigateFromRecentNotification("window-focus");
+		},
 	});
 }
 

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -12,6 +12,8 @@ export {
 	consumeRecentWatchedNotification,
 	_resetWatchedNotificationState,
 	NOTIFICATION_CLICK_TTL_MS,
+	setAppForeground,
+	isAppForeground,
 } from "./rpc-handlers/shared";
 export {
 	startMergeDetectionPoller,

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -14,7 +14,7 @@ import * as repoConfig from "../repo-config";
 import { DEV3_HOME } from "../paths";
 import { spawn } from "../spawn";
 import { writeSystemClipboard } from "../system-clipboard";
-import { getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererEvent } from "./shared";
+import { getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererEvent, setAppForeground } from "./shared";
 import { applyMenuContext, type MenuContext } from "../application-menu";
 
 async function updateMenuContext(params: MenuContext): Promise<void> {
@@ -69,6 +69,15 @@ async function openNewWindow(): Promise<void> {
 async function hideApp(): Promise<void> {
 	log.info("→ hideApp (Cmd+H from renderer)");
 	hideAppNative();
+}
+
+/**
+ * The renderer reports its window focus state so the backend knows whether the
+ * app is in the foreground. Used to suppress notification click-to-open arming
+ * while the user is already looking at the app (see `notifyWatchedTaskStatusChange`).
+ */
+async function setWindowForeground(params: { focused: boolean }): Promise<void> {
+	setAppForeground(params.focused);
 }
 
 async function showConfirm(params: { title: string; message: string }): Promise<boolean> {
@@ -740,6 +749,7 @@ export const appHandlers = {
 	consumePendingQuitDialog,
 	openNewWindow,
 	hideApp,
+	setWindowForeground,
 	showConfirm,
 	updateMenuContext,
 	getProjects,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -88,10 +88,30 @@ export function getSystemRequirements(): RequirementCheckResult[] {
  * macOS activates the app when a notification is clicked, which fires our BrowserWindow
  * `focus` event. We use this as a proxy for click-to-open since Electrobun's
  * `Utils.showNotification` does not expose a click callback.
+ *
+ * Kept deliberately short: the smaller this window, the smaller the chance that an
+ * unrelated app activation (cmd-tab, dock click) within it is misread as a click-through.
  */
-export const NOTIFICATION_CLICK_TTL_MS = 5000;
+export const NOTIFICATION_CLICK_TTL_MS = 3000;
 
 let lastWatchedNotification: { taskId: string; projectId: string; timestamp: number } | null = null;
+
+/**
+ * Whether the app is currently in the foreground (any window has key focus).
+ * The renderer reports this via `setWindowForeground`; `index.ts`'s window-focus
+ * hook also flips it true. We need it because Electrobun exposes no native
+ * "did resign active" signal — without it the focus proxy below cannot tell a
+ * genuine notification click from an in-app re-focus.
+ */
+let appForeground = false;
+
+export function setAppForeground(value: boolean): void {
+	appForeground = value;
+}
+
+export function isAppForeground(): boolean {
+	return appForeground;
+}
 
 export function notifyWatchedTaskStatusChange(task: Task, oldStatus: string, newStatus: string, projectName: string): void {
 	if (!task.watched || oldStatus === newStatus) return;
@@ -101,6 +121,12 @@ export function notifyWatchedTaskStatusChange(task: Task, oldStatus: string, new
 		subtitle: projectName,
 		silent: true,
 	});
+	// Only arm click-to-open when the app is NOT already in the foreground. If the
+	// user is actively looking at the app, the banner is purely informational — a
+	// subsequent in-app click that happens to re-key the window must not be misread
+	// as "clicked the notification" and teleport them to the task. This is the core
+	// fix for the "any click after a notification zooms me into the task" bug.
+	if (appForeground) return;
 	lastWatchedNotification = {
 		taskId: task.id,
 		projectId: task.projectId,
@@ -123,9 +149,10 @@ export function consumeRecentWatchedNotification(now: number = Date.now()): { ta
 	return { taskId: recent.taskId, projectId: recent.projectId };
 }
 
-/** For tests only — resets the last-watched-notification slot. */
+/** For tests only — resets the last-watched-notification slot and foreground flag. */
 export function _resetWatchedNotificationState(): void {
 	lastWatchedNotification = null;
+	appForeground = false;
 }
 
 const IMAGE_MIME_EXTENSIONS: Record<string, string> = {

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -519,11 +519,41 @@ function App() {
 		function onOpenTaskFromNotification(e: Event) {
 			const { taskId, projectId } = (e as CustomEvent).detail as { taskId: string; projectId: string };
 			if (!taskId || !projectId) return;
-			navigate({ screen: "task", projectId, taskId });
+			// Open the task the same way a normal card click does — honoring the user's
+			// `dev3-task-open-mode` preference. Default is "split" (task terminal next to
+			// the board), NOT fullscreen zoom. Only users who chose fullscreen get zoomed.
+			const openMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";
+			if (openMode === "fullscreen") {
+				navigate({ screen: "task", projectId, taskId });
+			} else {
+				navigate({ screen: "project", projectId, activeTaskId: taskId });
+			}
 		}
 		window.addEventListener("rpc:openTaskFromNotification", onOpenTaskFromNotification);
 		return () => window.removeEventListener("rpc:openTaskFromNotification", onOpenTaskFromNotification);
 	}, [navigate]);
+
+	// Report window focus state to the backend. It uses this to suppress
+	// notification click-to-open arming while the app is already in the foreground —
+	// otherwise an in-app click that re-keys the window gets misread as a
+	// notification click and zooms the user into the task.
+	useEffect(() => {
+		const report = (focused: boolean) => {
+			// Optional-chained: best-effort telemetry, and some tests mock `api`
+			// without this method.
+			void api.request.setWindowForeground?.({ focused })?.catch?.(() => { /* best-effort */ });
+		};
+		const onFocus = () => report(true);
+		const onBlur = () => report(false);
+		window.addEventListener("focus", onFocus);
+		window.addEventListener("blur", onBlur);
+		// Sync the initial state on mount (the window may already be focused).
+		report(document.hasFocus());
+		return () => {
+			window.removeEventListener("focus", onFocus);
+			window.removeEventListener("blur", onBlur);
+		};
+	}, []);
 
 	// Notify user when a column-agent launch fails (custom columns have no automatic fallback)
 	useEffect(() => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1594,6 +1594,15 @@ export type AppRPCSchema = {
 				params: { ports: number[] };
 				response: { command: string; hostGuess: string | null };
 			};
+			/**
+			 * Renderer reports its window focus state so the backend can tell whether
+			 * the app is in the foreground. Used to suppress notification click-to-open
+			 * arming while the user is already looking at the app.
+			 */
+			setWindowForeground: {
+				params: { focused: boolean };
+				response: void;
+			};
 		};
 		messages: {
 			taskUpdated: { projectId: string; task: Task };


### PR DESCRIPTION
## Summary

Fixes two bugs in watched-task notification click-to-open.

- **Always forced fullscreen zoom.** Opening a task from a notification now honors the user's `dev3-task-open-mode` preference (default `split`, board stays visible on the left), exactly like a normal task-card click — instead of always navigating to the fullscreen `task` screen.
- **Any in-app click after a notification teleported into the task.** Electrobun's `Utils.showNotification` has no click callback, so click-to-open is approximated via a window `focus` event within a TTL. That fired on unrelated in-app clicks too. Click-to-open is now armed only when the app was in the **background** at notification time — tracked via a new `setWindowForeground` RPC the renderer reports on window focus/blur (backend `onFocus` also flips it true). The banner is still always shown. TTL reduced 5s → 3s.

See `decisions/062-notification-click-foreground-gate.md` for the rationale and the dev-only devtools caveat.

🤖 PR opened by Claude (the AI assistant working on this branch).