### PR TITLE
Preserve task view when switching projects via Cmd+1..9

### DIFF
--- a/change-logs/2026/06/03/feature-cmd-switch-keep-task-view.md
+++ b/change-logs/2026/06/03/feature-cmd-switch-keep-task-view.md
@@ -1,1 +1,3 @@
 Cmd/Ctrl+1..9 project switching now preserves your current view mode. If you're in a task view (sidebar + terminal), switching projects keeps the task view — the left sidebar shows the new project's active tasks and the terminal pane shows "Select a task to see its terminal" until you pick one. On the Kanban board it still switches to the board.
+
+Suggested by Alexander Kiselev.

--- a/change-logs/2026/06/03/feature-cmd-switch-keep-task-view.md
+++ b/change-logs/2026/06/03/feature-cmd-switch-keep-task-view.md
@@ -1,0 +1,1 @@
+Cmd/Ctrl+1..9 project switching now preserves your current view mode. If you're in a task view (sidebar + terminal), switching projects keeps the task view — the left sidebar shows the new project's active tasks and the terminal pane shows "Select a task to see its terminal" until you pick one. On the Kanban board it still switches to the board.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -2,6 +2,12 @@
 
 Append-only log of UX architecture decisions. Each entry: date, decision, rationale, evidence/status.
 
+## 2026-06-03 — Cmd+1..9 preserves the current view mode (task-view vs board)
+
+- **Decision:** The `Cmd/Ctrl+1..9` project-switch shortcut now preserves the user's current *view mode* instead of always dropping them on the Kanban board. If the user is in a task view when they switch (split layout: `screen: "project"` with `activeTaskId`, or the full-page `screen: "task"`), the target project opens in task view too — `ActiveTasksSidebar` shows the new project's active tasks and, because no task is selected there yet, the terminal pane shows a centered empty-state: «Select a task to see its terminal». If the user is on the board (no active task), switching keeps the board. A new `taskView?: boolean` flag on the `project` route models "task-view layout with no task selected". The empty-state is a *status surface* (Toast/empty-state family), not an action — centered `text-fg-muted` text, no button (selecting a task in the sidebar fills the terminal).
+- **Rationale:** The app is keyboard-heavy and users live inside the task view; yanking them to the board on every workspace switch breaks flow. Preserving view mode matches how Slack-style `Cmd+N` switching should feel. Empty terminal must be explicit ("pick a task") rather than auto-selecting one — the user asked for an empty pane, not a guessed task, so no implicit selection happens.
+- **Status:** `Observed` (implemented: `App.tsx` Cmd+1..9 + Escape handlers, `ProjectView.tsx` split layout + empty-state, `state.ts` `taskView` flag, i18n key `project.selectTaskForTerminal`).
+
 ## 2026-05-29 — Initial manifest derived from repository
 
 - **Decision:** Treat dev-3.0 as a full-screen desktop web app with a **screen-based navigation model** (the `Route` union in `src/mainview/state.ts`), not a URL-routed site. The manifest's "routes" are screen ids.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -308,13 +308,25 @@ function App() {
 					navigate({ screen: "project-terminal", projectId: route.projectId });
 				}
 			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= "1" && e.key <= "9") {
-				// Cmd+1..9 — switch to project by index (like Slack workspaces)
+				// Cmd+1..9 — switch to project by index (like Slack workspaces).
+				// Preserve the current view mode: if the user is in a task view
+				// (split sidebar+terminal, or full-page task screen), land in the
+				// target project's task view with no task selected (empty terminal),
+				// instead of yanking them to the Kanban board.
 				const idx = parseInt(e.key, 10) - 1;
 				const available = state.projects.filter((p) => !p.deleted);
 				if (idx < available.length) {
 					e.preventDefault();
 					e.stopPropagation();
-					navigate({ screen: "project", projectId: available[idx].id });
+					const { route } = state;
+					const inTaskView =
+						route.screen === "task" ||
+						(route.screen === "project" && (Boolean(route.activeTaskId) || Boolean(route.taskView)));
+					navigate(
+						inTaskView
+							? { screen: "project", projectId: available[idx].id, taskView: true }
+							: { screen: "project", projectId: available[idx].id },
+					);
 				}
 			}
 		},
@@ -772,7 +784,7 @@ function App() {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "home-terminal") {
 				navigate({ screen: "dashboard" });
-			} else if (route.screen === "project" && route.activeTaskId) {
+			} else if (route.screen === "project" && (route.activeTaskId || route.taskView)) {
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project") {
 				navigate({ screen: "dashboard" });
@@ -1121,6 +1133,7 @@ function App() {
 						taskPorts={state.taskPorts}
 						taskResourceUsage={state.taskResourceUsage}
 						activeTaskId={route.activeTaskId}
+						taskView={route.taskView}
 						navigationGuardRef={navigationGuardRef}
 					/>
 				);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -73,7 +73,14 @@ vi.mock("../components/Changelog", () => ({
 	default: (_props: { navigate: unknown; goBack: unknown; canGoBack: unknown }) => <div data-testid="changelog-screen" />,
 }));
 vi.mock("../components/ProjectView", () => ({
-	default: () => <div data-testid="project-screen" />,
+	default: (props: { projectId: string; activeTaskId?: string; taskView?: boolean }) => (
+		<div
+			data-testid="project-screen"
+			data-project-id={props.projectId}
+			data-active-task-id={props.activeTaskId ?? ""}
+			data-task-view={props.taskView ? "true" : "false"}
+		/>
+	),
 }));
 vi.mock("../components/TaskWorkspaceView", () => ({
 	default: () => <div data-testid="task-screen" />,
@@ -237,6 +244,67 @@ describe("App keyboard shortcuts", () => {
 			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
 			await userEvent.keyboard("{Escape}");
 			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+		});
+	});
+
+	describe("switch project (Cmd+1..9)", () => {
+		const twoProjects = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			{ id: "p2", name: "Beta", path: "/b", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+
+		it("preserves task view: Cmd+2 from a task switches project and keeps task-view layout with no task selected", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
+			});
+
+			await renderApp();
+			const before = screen.getByTestId("project-screen");
+			expect(before).toHaveAttribute("data-project-id", "p1");
+			expect(before).toHaveAttribute("data-active-task-id", "t1");
+
+			await userEvent.keyboard("{Meta>}2{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "true");
+			expect(after).toHaveAttribute("data-active-task-id", "");
+		});
+
+		it("preserves task view from the full-page task screen too", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}2{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "true");
+		});
+
+		it("keeps board view: Cmd+2 from the Kanban board switches project without task view", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			const before = screen.getByTestId("project-screen");
+			expect(before).toHaveAttribute("data-project-id", "p1");
+			expect(before).toHaveAttribute("data-task-view", "false");
+
+			await userEvent.keyboard("{Meta>}2{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "false");
+			expect(after).toHaveAttribute("data-active-task-id", "");
 		});
 	});
 

--- a/src/mainview/components/ActiveTasksStrip.tsx
+++ b/src/mainview/components/ActiveTasksStrip.tsx
@@ -10,7 +10,7 @@ import { getTaskAgentMeta } from "../utils/taskAgentMeta";
 interface ActiveTasksStripProps {
 	project: Project;
 	tasks: Task[];
-	activeTaskId: string;
+	activeTaskId?: string;
 	navigate: (route: Route) => void;
 	agents: CodingAgent[];
 	bellCounts: Map<string, number>;

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -34,6 +34,7 @@ interface ProjectViewProps {
 	taskPorts: Map<string, PortInfo[]>;
 	taskResourceUsage?: Map<string, ResourceUsage>;
 	activeTaskId?: string;
+	taskView?: boolean;
 	navigationGuardRef?: MutableRefObject<NavigationGuard | null>;
 }
 
@@ -47,6 +48,7 @@ function ProjectView({
 	taskPorts,
 	taskResourceUsage,
 	activeTaskId,
+	taskView,
 	navigationGuardRef,
 }: ProjectViewProps) {
 	const t = useT();
@@ -85,9 +87,29 @@ function ProjectView({
 		);
 	}
 
-	if (activeTaskId) {
-		const activeTask = tasks.find((t) => t.id === activeTaskId);
+	if (activeTaskId || taskView) {
+		const activeTask = activeTaskId ? tasks.find((t) => t.id === activeTaskId) : undefined;
 		const isBrowserMode = !isElectrobun;
+
+		// Terminal pane: a selected task shows its workspace; otherwise (task-view
+		// reached via a project switch with no task picked yet) an empty placeholder.
+		const terminalPane = activeTaskId ? (
+			<TaskWorkspacePane
+				projectId={projectId}
+				taskId={activeTaskId}
+				tasks={tasks}
+				projects={projects}
+				navigate={navigate}
+				dispatch={dispatch}
+				inlineDiffRequest={inlineDiff.request}
+				onCloseInlineDiff={inlineDiff.close}
+				navigationGuardRef={navigationGuardRef}
+			/>
+		) : (
+			<div className="h-full w-full flex items-center justify-center bg-base px-6 text-center">
+				<span className="text-fg-muted text-sm">{t("project.selectTaskForTerminal")}</span>
+			</div>
+		);
 
 		// Browser mode: stack sidebar on top for full-width terminal
 		if (isBrowserMode) {
@@ -112,17 +134,7 @@ function ProjectView({
 						bellCounts={bellCounts}
 					/>
 					<div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
-						<TaskWorkspacePane
-							projectId={projectId}
-							taskId={activeTaskId}
-							tasks={tasks}
-							projects={projects}
-							navigate={navigate}
-							dispatch={dispatch}
-							inlineDiffRequest={inlineDiff.request}
-							onCloseInlineDiff={inlineDiff.close}
-							navigationGuardRef={navigationGuardRef}
-						/>
+						{terminalPane}
 					</div>
 				</div>
 			);
@@ -172,19 +184,7 @@ function ProjectView({
 				)}
 				<SplitLayout
 					kanbanContent={leftContent}
-					terminalContent={
-						<TaskWorkspacePane
-							projectId={projectId}
-							taskId={activeTaskId}
-							tasks={tasks}
-							projects={projects}
-							navigate={navigate}
-							dispatch={dispatch}
-							inlineDiffRequest={inlineDiff.request}
-							onCloseInlineDiff={inlineDiff.close}
-							navigationGuardRef={navigationGuardRef}
-						/>
-					}
+					terminalContent={terminalPane}
 					mode={sidebarMode}
 				/>
 			</div>

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Project, Task } from "../../../shared/types";
+import { I18nProvider } from "../../i18n";
+import ProjectView from "../ProjectView";
+
+vi.mock("../../rpc", () => ({
+	api: { request: { getTasks: vi.fn().mockResolvedValue([]), getAgents: vi.fn().mockResolvedValue([]) } },
+	isElectrobun: true,
+}));
+
+// Heavy children — stub so the test focuses on ProjectView's own layout logic.
+vi.mock("../KanbanBoard", () => ({ default: () => <div data-testid="kanban" /> }));
+vi.mock("../TaskInfoPanel", () => ({ default: () => <div data-testid="info-panel" /> }));
+vi.mock("../ActiveTasksSidebar", () => ({ default: () => <div data-testid="sidebar" /> }));
+vi.mock("../ActiveTasksStrip", () => ({ default: () => <div data-testid="strip" /> }));
+vi.mock("../TaskWorkspacePane", () => ({ default: () => <div data-testid="workspace" /> }));
+vi.mock("../SplitLayout", () => ({
+	default: (props: { kanbanContent: React.ReactNode; terminalContent: React.ReactNode }) => (
+		<div>
+			<div data-testid="left">{props.kanbanContent}</div>
+			<div data-testid="right">{props.terminalContent}</div>
+		</div>
+	),
+}));
+
+const project: Project = {
+	id: "p1",
+	name: "Alpha",
+	path: "/a",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "",
+};
+
+function renderView(props: Partial<React.ComponentProps<typeof ProjectView>>) {
+	const tasks: Task[] = props.tasks ?? [];
+	return render(
+		<I18nProvider>
+			<ProjectView
+				projectId="p1"
+				projects={[project]}
+				tasks={tasks}
+				dispatch={vi.fn()}
+				navigate={vi.fn()}
+				bellCounts={new Map()}
+				taskPorts={new Map()}
+				{...props}
+			/>
+		</I18nProvider>,
+	);
+}
+
+describe("ProjectView task-view layout", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("shows the empty-terminal placeholder when taskView is set but no task is selected", async () => {
+		renderView({ taskView: true });
+		await waitFor(() => expect(screen.getByTestId("sidebar")).toBeInTheDocument());
+		expect(screen.getByText("Select a task to see its terminal")).toBeInTheDocument();
+		expect(screen.queryByTestId("workspace")).not.toBeInTheDocument();
+	});
+
+	it("renders the task workspace (no placeholder) when a task is active", async () => {
+		const task = { id: "t1", projectId: "p1", title: "T", status: "in-progress" } as unknown as Task;
+		renderView({ activeTaskId: "t1", tasks: [task] });
+		await waitFor(() => expect(screen.getByTestId("workspace")).toBeInTheDocument());
+		expect(screen.queryByText("Select a task to see its terminal")).not.toBeInTheDocument();
+	});
+
+	it("renders only the Kanban board when neither activeTaskId nor taskView is set", async () => {
+		renderView({});
+		await waitFor(() => expect(screen.getByTestId("kanban")).toBeInTheDocument());
+		expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
+		expect(screen.queryByText("Select a task to see its terminal")).not.toBeInTheDocument();
+	});
+});

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -233,6 +233,7 @@ const settings = {
 
 	// ProjectView
 	"project.notFound": "Project not found",
+	"project.selectTaskForTerminal": "Select a task to see its terminal",
 } as const;
 
 export default settings;

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -4,6 +4,8 @@ const tips = {
 	"tip.dismiss": "Don't show this tip",
 	"tip.snooze": "Hide tips for a while",
 	"tip.next": "Next tip",
+	"tip.cmdSwitchKeepsView.title": "Switch projects, keep your view",
+	"tip.cmdSwitchKeepsView.body": "Press Cmd/Ctrl+1..9 from a task view to jump to another project without leaving the task view — pick a task on the left to open its terminal.",
 	"tip.agentCreateTasks.title": "Agents can create tasks",
 	"tip.agentCreateTasks.body": "Just say \"create a task in dev3 about...\" in your prompt and the agent will add it to your board.",
 	"tip.agentSeesTasks.title": "Agents see your board",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -234,6 +234,7 @@ const settings = {
 
 	// ProjectView
 	"project.notFound": "Proyecto no encontrado",
+	"project.selectTaskForTerminal": "Selecciona una tarea para ver su terminal",
 };
 
 export default settings;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -4,6 +4,8 @@ const tips = {
 	"tip.dismiss": "No mostrar este consejo",
 	"tip.snooze": "Ocultar consejos por un rato",
 	"tip.next": "Siguiente consejo",
+	"tip.cmdSwitchKeepsView.title": "Cambia de proyecto sin perder la vista",
+	"tip.cmdSwitchKeepsView.body": "Pulsa Cmd/Ctrl+1..9 en la vista de tareas para saltar a otro proyecto sin salir de la vista — elige una tarea a la izquierda para abrir su terminal.",
 	"tip.agentCreateTasks.title": "Los agentes crean tareas",
 	"tip.agentCreateTasks.body": "Di \"crea una tarea en dev3 sobre...\" en tu prompt y el agente la agregará al tablero.",
 	"tip.agentSeesTasks.title": "Los agentes ven tu tablero",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -235,6 +235,7 @@ const settings = {
 
 	// ProjectView
 	"project.notFound": "Проект не найден",
+	"project.selectTaskForTerminal": "Выберите задачу, чтобы увидеть её терминал",
 };
 
 export default settings;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -4,6 +4,8 @@ const tips = {
 	"tip.dismiss": "Больше не показывать",
 	"tip.snooze": "Скрыть подсказки на время",
 	"tip.next": "Следующий совет",
+	"tip.cmdSwitchKeepsView.title": "Меняй проект, сохраняя вид",
+	"tip.cmdSwitchKeepsView.body": "Нажми Cmd/Ctrl+1..9 в режиме задач, чтобы перейти в другой проект, не покидая этот вид — выбери задачу слева, чтобы открыть её терминал.",
 	"tip.agentCreateTasks.title": "Агенты создают задачи",
 	"tip.agentCreateTasks.body": "Скажите «создай задачу в dev3 про...» в промпте — агент добавит её на доску.",
 	"tip.agentSeesTasks.title": "Агенты видят вашу доску",

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -5,7 +5,7 @@ import type { PortInfo, Project, Task, ResourceUsage } from "../shared/types";
 
 export type Route =
 	| { screen: "dashboard" }
-	| { screen: "project"; projectId: string; activeTaskId?: string }
+	| { screen: "project"; projectId: string; activeTaskId?: string; taskView?: boolean }
 	| { screen: "project-terminal"; projectId: string }
 	| { screen: "home-terminal" }
 	| { screen: "task"; projectId: string; taskId: string }

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -10,6 +10,12 @@ export interface Tip {
 
 const ALL_TIPS: Tip[] = [
 	{
+		id: "cmd-switch-keeps-view",
+		titleKey: "tip.cmdSwitchKeepsView.title",
+		bodyKey: "tip.cmdSwitchKeepsView.body",
+		icon: "\u{F0600}", // nf-md-keyboard
+	},
+	{
 		id: "agent-create-tasks",
 		titleKey: "tip.agentCreateTasks.title",
 		bodyKey: "tip.agentCreateTasks.body",


### PR DESCRIPTION
## Summary

- `Cmd/Ctrl+1..9` now preserves the current **view mode** instead of always dropping you on the Kanban board.
- When you're in a **task view** (split sidebar + terminal, or the full-page task screen), switching projects keeps the task view: the left `ActiveTasksSidebar` shows the target project's active tasks, and since no task is selected there yet, the terminal pane shows an empty placeholder — *"Select a task to see its terminal"*. Pick a task on the left to open its terminal.
- On the **Kanban board** (no active task), the shortcut still switches to the board as before.
- Adds a `taskView?: boolean` flag to the `project` route to model the "task-view layout with no task selected" state. `Escape` from that state collapses to the project board.

Includes i18n (en/ru/es), a "Did you know?" tip, a UX decision record, and tests (App navigation behavior + ProjectView empty-state layout). Feature suggested by Alexander Kiselev.

🤖 Opened by Claude (the AI assistant working on this branch).