### PR TITLE
Focus window before showing quit-confirmation dialog

### DIFF
--- a/change-logs/2026/06/03/fix-focus-window-on-dock-quit.md
+++ b/change-logs/2026/06/03/fix-focus-window-on-dock-quit.md
@@ -1,0 +1,1 @@
+Focus the app window before showing the quit-confirmation dialog. A dock right-click → Quit does not activate the app on macOS, so the confirmation box used to sit hidden behind other apps and the app looked frozen.

--- a/src/bun/__tests__/window-manager.test.ts
+++ b/src/bun/__tests__/window-manager.test.ts
@@ -10,6 +10,7 @@ type FakeWindow = {
 	};
 	getSize: ReturnType<typeof vi.fn>;
 	setSize: ReturnType<typeof vi.fn>;
+	focus: ReturnType<typeof vi.fn>;
 	on: ReturnType<typeof vi.fn>;
 	handlers: Record<string, () => void>;
 	frame?: { x: number; y: number; width: number; height: number };
@@ -28,6 +29,7 @@ vi.mock("electrobun/bun", () => {
 		webview: any;
 		getSize: ReturnType<typeof vi.fn>;
 		setSize: ReturnType<typeof vi.fn>;
+		focus: ReturnType<typeof vi.fn>;
 		on: ReturnType<typeof vi.fn>;
 		handlers: Record<string, () => void>;
 		frame?: { x: number; y: number; width: number; height: number };
@@ -50,6 +52,7 @@ vi.mock("electrobun/bun", () => {
 			};
 			this.getSize = vi.fn(() => ({ width: 800, height: 600 }));
 			this.setSize = vi.fn();
+			this.focus = vi.fn();
 			this.on = vi.fn((name: string, handler: () => void) => {
 				handlers[name] = handler;
 			});
@@ -83,6 +86,7 @@ import {
 	createAppWindow,
 	broadcastToAllWindows,
 	sendToFocusedWindow,
+	focusFocusedWindow,
 	getFocusedWindow,
 	getAllWindows,
 	getWindowCount,
@@ -136,6 +140,22 @@ describe("window-manager", () => {
 
 		expect(secondWin.webview.rpc.send.navigateToSettings).toHaveBeenCalledWith({});
 		expect(second.webview.rpc.send.navigateToSettings).not.toHaveBeenCalled();
+	});
+
+	it("focusFocusedWindow brings the focused window to the front", () => {
+		spawn();
+		spawn();
+
+		const secondWin = createdWindows[1];
+		secondWin.handlers.focus?.();
+
+		expect(focusFocusedWindow()).toBe(true);
+		expect(secondWin.focus).toHaveBeenCalledTimes(1);
+		expect(createdWindows[0].focus).not.toHaveBeenCalled();
+	});
+
+	it("focusFocusedWindow returns false when no window is open", () => {
+		expect(focusFocusedWindow()).toBe(false);
 	});
 
 	it("removes windows on close and falls back to another focused window", () => {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -20,7 +20,7 @@ import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "./application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import { startLoopMonitor } from "./loop-monitor";
-import { createAppWindow, broadcastToAllWindows, getFocusedWindow, getWindowCount, sendToFocusedWindow, setOpenNewWindow } from "./window-manager";
+import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, sendToFocusedWindow, setOpenNewWindow } from "./window-manager";
 import electrobunConfig from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
 import { existsSync } from "node:fs";
@@ -472,10 +472,12 @@ function runGlobalQuitCleanup(): void {
 //
 // With `exitOnLastWindowClosed: false`, closing the last window keeps the app
 // alive in the dock — it does NOT trigger a quit. So a quit here is always
-// deliberate (Cmd+Q, menu Quit, dock Quit). If a window is open we push the
-// dialog to it; if none is (the app was sitting window-less in the dock) we
-// reopen one and let it PULL the pending flag on mount — a push would race the
-// not-yet-mounted renderer and get lost.
+// deliberate (Cmd+Q, menu Quit, dock Quit). If a window is open we focus it
+// (a dock right-click → Quit does not activate the app, so the dialog would
+// otherwise sit hidden behind other apps) and push the dialog to it; if none
+// is (the app was sitting window-less in the dock) we reopen one and let it
+// PULL the pending flag on mount — a push would race the not-yet-mounted
+// renderer and get lost.
 Electrobun.events.on("before-quit", (e: { response?: { allow: boolean } }) => {
 	if (isQuitConfirmed()) {
 		runGlobalQuitCleanup();
@@ -496,7 +498,11 @@ Electrobun.events.on("before-quit", (e: { response?: { allow: boolean } }) => {
 	e.response = { allow: false };
 
 	if (getFocusedWindow()) {
-		log.info("Quit intercepted — asking the focused window to confirm");
+		// Bring the window to the front first. A dock right-click → Quit does NOT
+		// activate the app on macOS, so without this the dialog would sit behind
+		// other apps and the app would look frozen.
+		log.info("Quit intercepted — focusing window and asking it to confirm");
+		focusFocusedWindow();
 		sendToFocusedWindow("showQuitDialog");
 	} else {
 		// App is window-less in the dock. Reopen a window to host the dialog;

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -192,6 +192,25 @@ export function broadcastToAllWindows(name: string, payload: any): void {
 	}
 }
 
+/**
+ * Bring the focused (or any open) window to the front with key focus, and
+ * activate the app. Used when a quit is triggered from the dock context menu
+ * (right-click → Quit): macOS does NOT activate the app in that case, so a
+ * confirmation dialog shown in the window would sit behind other apps and look
+ * like the app froze. Returns true if a window was focused.
+ */
+export function focusFocusedWindow(): boolean {
+	const win = getFocusedWindow();
+	if (!win) return false;
+	try {
+		win.focus();
+		return true;
+	} catch (err) {
+		log.debug("focusFocusedWindow failed", { error: String(err) });
+		return false;
+	}
+}
+
 /** Send a push message to the focused window only (menu-action pattern). */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function sendToFocusedWindow(name: string, payload: any = {}): void {


### PR DESCRIPTION
## Summary

- On macOS, a dock right-click → **Quit** does not activate the app. The quit-confirmation dialog was rendered inside an unfocused window that sat behind other apps, so it looked like the app had frozen.
- The `before-quit` gate now calls `focusFocusedWindow()` to bring the window to the front *before* pushing `showQuitDialog`.
- Added a `focusFocusedWindow()` helper in `window-manager.ts` (focuses the focused/first window, returns whether one was focused) plus unit tests.