### PR TITLE
Gate Cmd+1..9 task-view preservation on Task Open Mode

### DIFF
--- a/change-logs/2026/06/05/fix-cmd-switch-fullscreen-board.md
+++ b/change-logs/2026/06/05/fix-cmd-switch-fullscreen-board.md
@@ -1,0 +1,1 @@
+Cmd+1..9 project switching now respects the Task Open Mode setting. In Full screen mode it jumps straight to the Kanban board (the pre-#619 behavior) instead of an empty "Select a task" split; Split mode keeps preserving the task view as before.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -309,21 +309,25 @@ function App() {
 				}
 			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= "1" && e.key <= "9") {
 				// Cmd+1..9 — switch to project by index (like Slack workspaces).
-				// Preserve the current view mode: if the user is in a task view
-				// (split sidebar+terminal, or full-page task screen), land in the
-				// target project's task view with no task selected (empty terminal),
-				// instead of yanking them to the Kanban board.
+				// View-mode preservation is gated on the `dev3-task-open-mode` setting:
+				//  - "split"      users live in the sidebar+terminal layout, so if they
+				//                 are in a task view we land in the target project's task
+				//                 view with no task selected (empty terminal placeholder).
+				//  - "fullscreen" users have no task to show full-page after a switch, so
+				//                 dropping them into a split they never use is jarring —
+				//                 land on the Kanban board instead (pre-#619 behavior).
 				const idx = parseInt(e.key, 10) - 1;
 				const available = state.projects.filter((p) => !p.deleted);
 				if (idx < available.length) {
 					e.preventDefault();
 					e.stopPropagation();
 					const { route } = state;
+					const taskOpenMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";
 					const inTaskView =
 						route.screen === "task" ||
 						(route.screen === "project" && (Boolean(route.activeTaskId) || Boolean(route.taskView)));
 					navigate(
-						inTaskView
+						inTaskView && taskOpenMode === "split"
 							? { screen: "project", projectId: available[idx].id, taskView: true }
 							: { screen: "project", projectId: available[idx].id },
 					);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -253,6 +253,12 @@ describe("App keyboard shortcuts", () => {
 			{ id: "p2", name: "Beta", path: "/b", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 		];
 
+		// Task-view preservation is gated on the `dev3-task-open-mode` setting.
+		// Remove it between tests so the default ("split") applies unless a test opts in.
+		afterEach(() => {
+			localStorage.removeItem("dev3-task-open-mode");
+		});
+
 		it("preserves task view: Cmd+2 from a task switches project and keeps task-view layout with no task selected", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
 			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
@@ -305,6 +311,41 @@ describe("App keyboard shortcuts", () => {
 			expect(after).toHaveAttribute("data-project-id", "p2");
 			expect(after).toHaveAttribute("data-task-view", "false");
 			expect(after).toHaveAttribute("data-active-task-id", "");
+		});
+
+		it("fullscreen open-mode: Cmd+2 from a task jumps to the board, not an empty split", async () => {
+			localStorage.setItem("dev3-task-open-mode", "fullscreen");
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t1");
+
+			await userEvent.keyboard("{Meta>}2{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "false");
+			expect(after).toHaveAttribute("data-active-task-id", "");
+		});
+
+		it("fullscreen open-mode: Cmd+2 from the full-page task screen jumps to the board", async () => {
+			localStorage.setItem("dev3-task-open-mode", "fullscreen");
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}2{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "false");
 		});
 	});
 

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -88,7 +88,7 @@ const settings = {
 	"settings.taskCompleteSound": "Task Complete Sound",
 	"settings.taskCompleteSoundDesc": "Play a sound when a task is completed or cancelled",
 	"settings.taskOpenMode": "Task Open Mode",
-	"settings.taskOpenModeDesc": "How active tasks open when you click on them",
+	"settings.taskOpenModeDesc": "How active tasks open when you click on them. Also affects Cmd+1..9: Split keeps the task view, Full screen switches to the board.",
 	"settings.taskOpenModeSplit": "Split view (sidebar + terminal)",
 	"settings.taskOpenModeFullscreen": "Full screen (terminal only)",
 	"settings.defaultDiffViewMode": "Default Diff Layout",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -88,7 +88,7 @@ const settings = {
 	"settings.taskCompleteSound": "Sonido de tarea completada",
 	"settings.taskCompleteSoundDesc": "Reproducir un sonido al completar o cancelar una tarea",
 	"settings.taskOpenMode": "Modo de apertura de tarea",
-	"settings.taskOpenModeDesc": "Cómo se abren las tareas activas al hacer clic en ellas",
+	"settings.taskOpenModeDesc": "Cómo se abren las tareas activas al hacer clic en ellas. También afecta a Cmd+1..9: Vista dividida mantiene la vista de tarea, Pantalla completa cambia al tablero.",
 	"settings.taskOpenModeSplit": "Vista dividida (barra lateral + terminal)",
 	"settings.taskOpenModeFullscreen": "Pantalla completa (solo terminal)",
 	"settings.defaultDiffViewMode": "Layout de diff por defecto",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -88,7 +88,7 @@ const settings = {
 	"settings.taskCompleteSound": "Звук завершения задачи",
 	"settings.taskCompleteSoundDesc": "Воспроизводить звук при завершении или отмене задачи",
 	"settings.taskOpenMode": "Режим открытия задачи",
-	"settings.taskOpenModeDesc": "Как открываются активные задачи при нажатии на них",
+	"settings.taskOpenModeDesc": "Как открываются активные задачи при нажатии на них. Также влияет на Cmd+1..9: «Разделённый вид» сохраняет вид задачи, «Полный экран» переключает на доску.",
 	"settings.taskOpenModeSplit": "Разделённый вид (боковая панель + терминал)",
 	"settings.taskOpenModeFullscreen": "Полный экран (только терминал)",
 	"settings.defaultDiffViewMode": "Diff layout по умолчанию",


### PR DESCRIPTION
## Problem

PR #619 made `Cmd+1..9` (project switching) always preserve the current "task view". The side effect: when you switch to another project, **no task is selected**, so you land in a split layout with an empty "Select a task to see its terminal" placeholder — even if you never use the split layout. Previously `Cmd+1..9` jumped straight to the Kanban board.

This was especially jarring for **Full screen** users (Task Open Mode = full screen): they live in full-page task terminals, never in the split, yet `Cmd+1..9` dropped them into an empty split.

## Fix

Gate the #619 task-view preservation on the existing **Task Open Mode** setting (`dev3-task-open-mode`):

| Task Open Mode | `Cmd+1..9` from a task |
|---|---|
| **Split** | Unchanged — preserves the task view (empty "Select a task" pane, as today) |
| **Full screen** | Jumps to the Kanban board (pre-#619 behavior) |

The Kanban board → board behavior is unchanged in both modes.

Rationale: in Full screen mode there is no task to show full-page after a project switch, so the board is the natural landing. In Split mode the left pane already shows the new project's tasks to pick from, so preserving the split stays useful.

No new setting was added — this reuses the existing Behavior setting to avoid settings bloat. The setting's description now mentions the `Cmd+1..9` effect (EN/RU/ES).

## Implementation

- `src/mainview/App.tsx` — `Cmd+1..9` keydown handler now reads `dev3-task-open-mode` and only sets `taskView: true` when the mode is `split`.
- `src/mainview/i18n/translations/{en,ru,es}/settings.ts` — added the `Cmd+1..9` note to `settings.taskOpenModeDesc`.

## Tests

Test-first: added two failing tests (Full screen → board, from both the split task view and the full-page task screen), confirmed red, then implemented to green.

- `bun run lint` — clean
- mainview suite — 1269/1269 pass
- bun suite (run directly) — 1321/1321 pass

> Note: `bun run test` shows 2 flaky failures in `src/bun/__tests__/pty-server.test.ts` (a backend tmux/fake-timer test) only under the parallel mainview+bun orchestration; it passes 73/73 in isolation and 1321/1321 when the bun config runs directly. Pre-existing and unrelated to this change.

## Test instructions

1. Settings → Behavior → Task Open Mode: confirm the description mentions `Cmd+1..9`.
2. Set Full screen, open a task, press `Cmd+2` (≥2 projects) → lands on the board, no empty split.
3. Set Split, open a task, press `Cmd+2` → unchanged: split with the "Select a task" placeholder.
4. From the board (no task open), `Cmd+2` in either mode → switches to the target project's board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
