### PR TITLE
Cmd+1..9 project switch always lands on the Kanban board

### DIFF
--- a/change-logs/2026/06/07/fix-cmd-number-switch-lands-on-board.md
+++ b/change-logs/2026/06/07/fix-cmd-number-switch-lands-on-board.md
@@ -1,0 +1,1 @@
+Cmd/Ctrl+1..9 project switching now always lands on the target project's Kanban board, including when the current view is inside a task. This removes the split-mode task-view preservation introduced in #619/#623 — switching projects from a task previously left the user in an empty task layout.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -309,28 +309,16 @@ function App() {
 				}
 			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= "1" && e.key <= "9") {
 				// Cmd+1..9 — switch to project by index (like Slack workspaces).
-				// View-mode preservation is gated on the `dev3-task-open-mode` setting:
-				//  - "split"      users live in the sidebar+terminal layout, so if they
-				//                 are in a task view we land in the target project's task
-				//                 view with no task selected (empty terminal placeholder).
-				//  - "fullscreen" users have no task to show full-page after a switch, so
-				//                 dropping them into a split they never use is jarring —
-				//                 land on the Kanban board instead (pre-#619 behavior).
+				// Always lands on the target project's Kanban board, even when the
+				// current view is inside a task — there is no task to show in the
+				// other project, so preserving the task layout only yields an empty
+				// split (see #623 → reverted here).
 				const idx = parseInt(e.key, 10) - 1;
 				const available = state.projects.filter((p) => !p.deleted);
 				if (idx < available.length) {
 					e.preventDefault();
 					e.stopPropagation();
-					const { route } = state;
-					const taskOpenMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";
-					const inTaskView =
-						route.screen === "task" ||
-						(route.screen === "project" && (Boolean(route.activeTaskId) || Boolean(route.taskView)));
-					navigate(
-						inTaskView && taskOpenMode === "split"
-							? { screen: "project", projectId: available[idx].id, taskView: true }
-							: { screen: "project", projectId: available[idx].id },
-					);
+					navigate({ screen: "project", projectId: available[idx].id });
 				}
 			}
 		},

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -253,13 +253,14 @@ describe("App keyboard shortcuts", () => {
 			{ id: "p2", name: "Beta", path: "/b", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 		];
 
-		// Task-view preservation is gated on the `dev3-task-open-mode` setting.
-		// Remove it between tests so the default ("split") applies unless a test opts in.
+		// Cmd+1..9 always lands on the Kanban board, regardless of the
+		// `dev3-task-open-mode` setting. Remove it between tests anyway so
+		// no test leaks the setting to its siblings.
 		afterEach(() => {
 			localStorage.removeItem("dev3-task-open-mode");
 		});
 
-		it("preserves task view: Cmd+2 from a task switches project and keeps task-view layout with no task selected", async () => {
+		it("Cmd+2 from a task in split view switches project and lands on the board", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
 			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
@@ -274,11 +275,11 @@ describe("App keyboard shortcuts", () => {
 
 			const after = screen.getByTestId("project-screen");
 			expect(after).toHaveAttribute("data-project-id", "p2");
-			expect(after).toHaveAttribute("data-task-view", "true");
+			expect(after).toHaveAttribute("data-task-view", "false");
 			expect(after).toHaveAttribute("data-active-task-id", "");
 		});
 
-		it("preserves task view from the full-page task screen too", async () => {
+		it("Cmd+2 from the full-page task screen lands on the board too", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
 			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
@@ -291,7 +292,7 @@ describe("App keyboard shortcuts", () => {
 
 			const after = screen.getByTestId("project-screen");
 			expect(after).toHaveAttribute("data-project-id", "p2");
-			expect(after).toHaveAttribute("data-task-view", "true");
+			expect(after).toHaveAttribute("data-task-view", "false");
 		});
 
 		it("keeps board view: Cmd+2 from the Kanban board switches project without task view", async () => {
@@ -313,7 +314,7 @@ describe("App keyboard shortcuts", () => {
 			expect(after).toHaveAttribute("data-active-task-id", "");
 		});
 
-		it("fullscreen open-mode: Cmd+2 from a task jumps to the board, not an empty split", async () => {
+		it("fullscreen open-mode setting does not change it: Cmd+2 from a task jumps to the board", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
 			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
@@ -331,7 +332,7 @@ describe("App keyboard shortcuts", () => {
 			expect(after).toHaveAttribute("data-active-task-id", "");
 		});
 
-		it("fullscreen open-mode: Cmd+2 from the full-page task screen jumps to the board", async () => {
+		it("fullscreen open-mode setting: Cmd+2 from the full-page task screen jumps to the board", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
 			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({


### PR DESCRIPTION
## Summary

Switching projects with Cmd/Ctrl+1..9 from inside a task view previously preserved the task layout in split open-mode (#619, gated in #623), landing the user in an empty split with no task selected. There is no task to show in the other project, so the switch now **always navigates to the target project's Kanban board**, regardless of the Task Open Mode setting.

## Changes

- `src/mainview/App.tsx` — removed the `dev3-task-open-mode` gating from the Cmd+1..9 handler; always navigate to `{ screen: "project" }`.
- `src/mainview/__tests__/App.test.tsx` — updated the "switch project (Cmd+1..9)" tests to expect the board landing (reproduce-first: tests went red, then the fix turned them green).
- Changelog entry added.

## Testing

- `bun run lint` — clean
- `bun run test` — 122 files / 2524 tests green (mainview + bun)
- Verified manually via `bun run dev`: Cmd+2 from a split task view, from the full-page task screen, and in fullscreen open-mode all land on the target board; board→board switching and Cmd+9 no-op unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)