### PR TITLE
docs: changelog date is the PR merge date

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ This is a no-op for collaborators who don't have the `h0x91b` account — `gh` w
 
 **Path:** `change-logs/YYYY/MM/DD/<type>-<short-slug>.md`
 
+**The `YYYY/MM/DD` is the expected PR merge date — not the date you started.** If a task spans more than one day, do not leave the entry under the day you created it. Before opening/merging the PR, move (rename) the file/folder so the date matches the actual merge day. The changelog UI groups entries by ship date, so a stale start-date silently files the feature under the wrong day.
+
 **Type prefixes:** `feature-`, `fix-`, `refactor-`, `docs-`, `chore-`
 
 **Content:** Plain text, 1-3 sentences describing what was done. No frontmatter, no headers. **Keep it short — one paragraph max.**

--- a/change-logs/2026/06/07/docs-changelog-merge-date.md
+++ b/change-logs/2026/06/07/docs-changelog-merge-date.md
@@ -1,0 +1,1 @@
+Clarify the changelog policy: the YYYY/MM/DD path segment is the expected PR merge date, not the day work started. Tasks spanning more than one day must have their file/folder renamed to the actual merge day so entries group under the correct ship date.

--- a/change-logs/README.md
+++ b/change-logs/README.md
@@ -6,6 +6,8 @@ Conflict-free changelog for parallel agent workflows. Each change gets its own f
 
 **Path:** `change-logs/YYYY/MM/DD/<type>-<short-slug>.md`
 
+The `YYYY/MM/DD` is the **expected PR merge date**, not the day you started. If a task spans more than one day, rename the file/folder to the actual merge day before merging — entries are grouped by ship date in the UI.
+
 **Type prefixes:** `feature-`, `fix-`, `refactor-`, `docs-`, `chore-`
 
 **Content:** Plain text, 1-3 sentences describing what was done. No frontmatter, no headers.


### PR DESCRIPTION
## Summary
- Clarify the changelog policy in `AGENTS.md`: the `YYYY/MM/DD` path segment is the **expected PR merge date**, not the day work started.
- Tasks spanning more than one day must rename the file/folder to the actual merge day so entries group under the correct ship date in the changelog UI.
- Mirror the same clarification in `change-logs/README.md` so both sources stay in sync.