### PR TITLE
Fix unclickable project breadcrumb in activity/task view

### DIFF
--- a/change-logs/2026/06/07/fix-activity-view-breadcrumb-click.md
+++ b/change-logs/2026/06/07/fix-activity-view-breadcrumb-click.md
@@ -1,0 +1,1 @@
+Fixed the project name in the global header breadcrumb being unclickable on the activity/task view when no task was selected, so you can now return to the kanban board from there. The isOnKanban check now also accounts for taskView mode.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -187,8 +187,8 @@ function GlobalHeader({ route, projects, tasks, navigate, updateVersion, updateD
 	if ("projectId" in route) {
 		const project = projects.find((p) => p.id === route.projectId);
 		if (project) {
-			// Clickable when not already on the kanban board (no activeTaskId, not on terminal)
-			const isOnKanban = route.screen === "project" && !route.activeTaskId;
+			// Clickable when not already on the kanban board (no activeTaskId, not in task/activity view)
+			const isOnKanban = route.screen === "project" && !route.activeTaskId && !route.taskView;
 			const projectNameOnClick = !isOnKanban ? handleProjectNameClick : undefined;
 			segments.push({
 				label: project.name,

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -146,6 +146,24 @@ describe("GlobalHeader — project switcher dropdown", () => {
 		});
 	});
 
+	it("project name is clickable in activity/task view with no task selected", async () => {
+		const user = userEvent.setup();
+		const navigate = vi.fn();
+		renderHeader(
+			{ screen: "project", projectId: "p1", taskView: true },
+			[project1, project2],
+			navigate,
+		);
+
+		// In task/activity view (taskView), the project name must navigate back to the kanban board
+		await user.click(screen.getByText("Project Alpha"));
+
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "project",
+			projectId: "p1",
+		});
+	});
+
 	it("opens dropdown on chevron click and shows all non-deleted projects", async () => {
 		const user = userEvent.setup();
 		renderHeader(


### PR DESCRIPTION
## Summary

In the activity/task view (`taskView: true`) with no task selected, the project name in the global header breadcrumb was rendered as a non-clickable `<span>`, so there was no way to return to the kanban board from there.

The `isOnKanban` check in `GlobalHeader.tsx` only looked at `route.screen === "project" && !route.activeTaskId`, which is also true for `taskView` mode. Added `&& !route.taskView` so the project name stays a button that navigates back to the kanban board.

Includes a reproduction test (red before the fix, green after).