### PR TITLE
Default task overview language to English in dev3 skill

### DIFF
--- a/change-logs/2026/06/08/fix-overview-default-english.md
+++ b/change-logs/2026/06/08/fix-overview-default-english.md
@@ -1,0 +1,1 @@
+Fixed the dev3 skill overview instruction that led with a Russian example and explicitly forbade defaulting to English, which caused non-Russian users to occasionally get a Russian task overview. The overview now defaults to English and only mirrors another language when the user is clearly communicating in it.

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -118,7 +118,7 @@ Every task MUST have an \`overview\` written by you. Think **sticky note** or ho
 **Good:** \`"Fixing auth race condition in login flow; reproduced, working on the lock."\`
 **Bad:**  \`"This task involves investigating and resolving an authentication race condition that occurs during the login flow when multiple concurrent requests..."\`
 
-**Language — IMPORTANT:** Write the overview in the **same language the user is using with you in this task**. If the user writes in Russian, the overview is in Russian. If in Spanish, in Spanish. If in English, in English. Look at the task \`description\` and the user's messages in this session — match that language. Do NOT default to English.
+**Language — IMPORTANT:** Default to **English**. Only write the overview in another language when the user is clearly and consistently communicating with you in that language in this task — in which case mirror their language. When in doubt, use English. Never switch language based on stray non-English text in the codebase, file names, comments, or auto-generated content.
 
 **When to set it:**
 - Within the first minute after starting a task — initial overview based on what you understood. Set it in the **same pass as the title and labels** (Session-start checklist) — they share one moment, so if you are setting the overview you should already be setting the title too.
@@ -130,7 +130,7 @@ Every task MUST have an \`overview\` written by you. Think **sticky note** or ho
 
 **How:**
 
-    dev3 overview set "1–2 sentences, user's language. What we're doing + current state."
+    dev3 overview set "1–2 sentences, English by default. What we're doing + current state."
 
 Plain text, no markdown headers.
 `;


### PR DESCRIPTION
## Summary

- The dev3 skill's Overview instruction led with a Russian example and explicitly told agents **not** to default to English. This nudged non-Russian users into occasionally getting a Russian task overview out of nowhere.
- Rewrote the instruction in `src/bun/agent-skills.ts` so the overview **defaults to English** and only mirrors another language when the user is clearly and consistently communicating in it. Added an explicit guard against switching language based on stray non-English text in the codebase / file names / auto-generated content.
- Verified there is no other Cyrillic or "Russian"/"same language"/"default to English" wording anywhere in `src/` or in the installed skills.

The installed `~/.claude/skills/dev3/SKILL.md` regenerates from this source on app startup, so no manual skill-file edit is needed.