### PR TITLE
Fix Codex launch on newer codex: feature-detect profile flag

### DIFF
--- a/change-logs/2026/06/08/fix-codex-profile-v2-flag-removed.md
+++ b/change-logs/2026/06/08/fix-codex-profile-v2-flag-removed.md
@@ -1,0 +1,3 @@
+Fixed Codex agents failing to launch on newer codex (`error: unexpected argument '--profile-v2'`). The `--profile-v2` flag was removed from codex and folded into `--profile`, so dev-3.0 now feature-detects the correct profile flag from `codex --help` instead of guessing from the version number.
+
+Suggested by @eladharitanwix (h0x91b/dev-3.0#611)

--- a/decisions/055-codex-profile-v2.md
+++ b/decisions/055-codex-profile-v2.md
@@ -28,6 +28,8 @@ Writing the per-profile files was only half the fix. Codex exposes **two** flags
 
 `applyCodexThemeProfile()` in `src/bun/agents.ts` now rewrites the flag to `--profile-v2` (in addition to swapping the value to the themed profile) when `isCodexProfileV2()` is true. profile-v2 detection is cached per process and overridable in tests via `__setCodexProfileV2Override()`. Legacy Codex keeps `-p`. The base config still carries `default_permissions = "dev3"`, so the `[permissions.dev3]` sandbox/network grants apply regardless of which profile flag is used.
 
+> **Superseded (launch flag only) — see [decision 064](./064-codex-profile-v2-flag-removed.md).** Codex later removed the `--profile-v2` flag and folded its file-based semantics into `-p`/`--profile`, so the version-gated rewrite above started crashing newer codex (issue #611). The launch flag is now feature-detected from `codex --help` instead of a version threshold. The per-profile-file config writing described above is unchanged and still correct.
+
 ## Alternatives considered
 
 - **Always use profile-v2** — rejected: older Codex doesn't know about per-profile files, so `--profile dev3-light` would fail on legacy installs.

--- a/decisions/064-codex-profile-v2-flag-removed.md
+++ b/decisions/064-codex-profile-v2-flag-removed.md
@@ -1,0 +1,24 @@
+# 064 — Codex `--profile-v2` flag removed: feature-detect the launch flag
+
+## Context
+
+Issue [#611](https://github.com/h0x91b/dev-3.0/issues/611). Decision 055 made dev-3.0 launch Codex agents with `--profile-v2 <name>` for codex ≥0.131. But `--profile-v2` existed only briefly: codex added it on 2026-05-14 (#17141) and renamed it to `--profile`/`-p` on 2026-05-21 (#23883), keeping the same file-based semantics. Newer codex rejects `--profile-v2` with `error: unexpected argument '--profile-v2' found` (exit 2), breaking every Codex launch (codex self-updates).
+
+## Decision
+
+Stop deciding the launch flag from a version threshold. Feature-detect it from `codex --help`:
+
+- `pickCodexProfileLaunchFlag(helpText)` in `src/bun/codex-config.ts` returns `--profile-v2` iff the help lists `--profile-v2` (word-boundary match), else `--profile`.
+- `detectCodexProfileLaunchFlag()` spawns `codex --help` and applies the picker; falls back to `--profile` on any failure (it is the safe default — `--profile-v2` is the flag that crashes).
+- `applyCodexThemeProfile()` in `src/bun/agents.ts` only rewrites `-p`/`--profile` to `--profile-v2` when the detected flag is `--profile-v2`; otherwise it keeps the user's flag and just swaps the value to the themed profile. Detection is cached per process; `__setCodexProfileV2Override(true|false|null)` overrides it in tests.
+
+The per-profile-file config writing (`profileV2` in `CodexSyntax`, gated at version ≥0.131) is unchanged — those file-based semantics still apply on both `--profile-v2` and the renamed `--profile`.
+
+## Risks
+
+`codex --help` is spawned once per process. If a codex build emits help without either flag, we fall back to `--profile` (keeps `-p`), which is correct for every real codex since legacy v1 also accepted `--profile`. Order matters: transition-window binaries list both flags, so `--profile-v2` is preferred when present.
+
+## Alternatives considered
+
+- **Version-gate `--profile-v2` to 0.131–0.133** (per issue #611's suggestion) — rejected: version numbers do not map reliably to the rename PR (alphas, forks), and the repo owner explicitly asked for feature detection.
+- **Drop the profile flag entirely when help lacks it** — rejected: the `-p dev3` arg comes from agent config; removing it is more invasive and the no-flag case is unreachable for real codex.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -270,6 +270,22 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--profile-v2");
 	});
 
+	it("Codex: never emits --profile-v2 on newer codex that removed it (issue #611)", () => {
+		setCurrentUiTheme("dark");
+		// false => launch flag is the post-rename `--profile`, so the user's `-p`
+		// must be kept as-is and `--profile-v2` must never appear (it aborts codex).
+		__setCodexProfileV2Override(false);
+
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain("-p dev3-dark");
+		expect(cmd).not.toContain("--profile-v2");
+	});
+
 	// ---- Gemini ----
 	it("Gemini: adds --resume latest when resume=true", () => {
 		const cmd = resolveAgentCommand(

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -4,6 +4,7 @@ import {
 	ensureCodexProfileFile,
 	getCodexSyntaxForVersion,
 	parseCodexVersion,
+	pickCodexProfileLaunchFlag,
 } from "../codex-config";
 
 describe("ensureCodexConfig", () => {
@@ -72,6 +73,39 @@ describe("ensureCodexConfig", () => {
 				major: 0,
 				minor: 131,
 				patch: 2,
+			});
+		});
+
+		describe("pickCodexProfileLaunchFlag (issue #611)", () => {
+			it("prefers --profile-v2 when the help text lists both flags (transition window)", () => {
+				const help = [
+					"Options:",
+					"  -p, --profile <CONFIG_PROFILE>      Configuration profile",
+					"      --profile-v2 <CONFIG_PROFILE_V2>  File-based profile",
+				].join("\n");
+				expect(pickCodexProfileLaunchFlag(help)).toBe("--profile-v2");
+			});
+
+			it("uses --profile when --profile-v2 was removed (codex >= post-rename)", () => {
+				const help = [
+					"Options:",
+					"  -p, --profile <CONFIG_PROFILE_V2>  Configuration profile",
+				].join("\n");
+				expect(pickCodexProfileLaunchFlag(help)).toBe("--profile");
+			});
+
+			it("uses --profile for legacy help that only lists --profile", () => {
+				const help = "  -p, --profile <CONFIG_PROFILE>  Configuration profile to use";
+				expect(pickCodexProfileLaunchFlag(help)).toBe("--profile");
+			});
+
+			it("does not match a --profile-v2-foo substring as --profile-v2", () => {
+				const help = "  --profile-v2-foo <X>  unrelated flag";
+				expect(pickCodexProfileLaunchFlag(help)).toBe("--profile");
+			});
+
+			it("falls back to --profile when help is empty", () => {
+				expect(pickCodexProfileLaunchFlag("")).toBe("--profile");
 			});
 		});
 

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentConfiguration, CodingAgent, Project } from "../shared/types";
 import { DEFAULT_AGENTS } from "../shared/types";
 import { createLogger } from "./logger";
-import { detectCodexVersion, ensureCodexConfig, getCodexSyntaxForVersion } from "./codex-config";
+import { detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
 import { DEV3_HOME } from "./paths";
 import { loadSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme } from "./theme-state";
@@ -253,40 +253,46 @@ export function quoteIfUnsafe(s: string): string {
 	return /^[A-Za-z0-9_\-./:]+$/.test(s) ? s : shellEscape(s);
 }
 
-let codexProfileV2Override: boolean | null = null;
-let cachedCodexProfileV2: boolean | undefined;
+let codexProfileLaunchFlagOverride: CodexProfileLaunchFlag | null = null;
+let cachedCodexProfileLaunchFlag: CodexProfileLaunchFlag | undefined;
 
-/** Test-only override for codex profile-v2 detection. Pass `null` to clear. */
+/**
+ * Test-only override for codex profile launch-flag detection.
+ * `true` forces `--profile-v2`, `false` forces `--profile`, `null` clears.
+ */
 export function __setCodexProfileV2Override(value: boolean | null): void {
-	codexProfileV2Override = value;
-	cachedCodexProfileV2 = undefined;
+	codexProfileLaunchFlagOverride = value === null ? null : value ? "--profile-v2" : "--profile";
+	cachedCodexProfileLaunchFlag = undefined;
 }
 
 /**
- * True when the installed Codex (≥0.131) uses profile-v2 semantics: per-profile
- * settings live in `~/.codex/<name>.config.toml` and are only loaded via
- * `--profile-v2 <name>`. Detected once and cached for the process lifetime.
+ * The flag the installed Codex accepts to select a dev3 profile. `--profile-v2`
+ * existed only in a short transition window before it was renamed to
+ * `--profile`/`-p` (same file-based semantics); newer codex rejects it outright.
+ * Feature-detected from `codex --help` and cached for the process lifetime —
+ * version numbers do not map reliably to the rename. See issue #611.
  */
-function isCodexProfileV2(): boolean {
-	if (codexProfileV2Override !== null) return codexProfileV2Override;
-	if (cachedCodexProfileV2 === undefined) {
-		cachedCodexProfileV2 = getCodexSyntaxForVersion(detectCodexVersion()).profileV2;
+function getCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
+	if (codexProfileLaunchFlagOverride !== null) return codexProfileLaunchFlagOverride;
+	if (cachedCodexProfileLaunchFlag === undefined) {
+		cachedCodexProfileLaunchFlag = detectCodexProfileLaunchFlag();
 	}
-	return cachedCodexProfileV2;
+	return cachedCodexProfileLaunchFlag;
 }
 
 function applyCodexThemeProfile(args: string[]): void {
 	const themedProfile = getCodexProfileForCurrentUiTheme();
-	const profileV2 = isCodexProfileV2();
+	const launchFlag = getCodexProfileLaunchFlag();
 	for (let i = 0; i < args.length - 1; i++) {
 		if ((args[i] === "-p" || args[i] === "--profile") && args[i + 1] === "dev3") {
 			args[i + 1] = themedProfile;
-			// Codex ≥0.131 only loads the per-profile file
-			// `~/.codex/<name>.config.toml` via `--profile-v2 <name>`. The legacy
-			// `-p`/`--profile` flag looks for an in-config `[profiles.<name>]` block
-			// that we no longer write on profile-v2, causing
-			// "config profile `dev3-dark` not found". See decision 055.
-			if (profileV2) args[i] = "--profile-v2";
+			// During the codex transition window the per-profile file
+			// `~/.codex/<name>.config.toml` was loaded only via `--profile-v2`.
+			// After the rename (#23883) `--profile-v2` was removed and `-p`/`--profile`
+			// carries the same file-based semantics, so we keep the user's flag there.
+			// Passing `--profile-v2` to a newer codex aborts with exit 2.
+			// See decision 055 + issue #611.
+			if (launchFlag === "--profile-v2") args[i] = "--profile-v2";
 			return;
 		}
 	}

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -47,6 +47,8 @@ interface CodexSyntax {
 	 * profile-v2: per-profile settings live in `~/.codex/<name>.config.toml`,
 	 * and Codex rejects `[profiles.<name>]` blocks or top-level `profile = "<name>"`
 	 * in the main config when `--profile <name>` is used. See codex PR #22647.
+	 * Stays true for codex ≥0.131 — the file-based semantics did not go away when
+	 * the `--profile-v2` *launch flag* was later removed (see issue #611).
 	 */
 	profileV2: boolean;
 }
@@ -100,6 +102,41 @@ export function getCodexSyntaxForVersion(versionText: string | null | undefined)
 			: LEGACY_CODEX_SYNTAX.hooksFeatureKey,
 		profileV2: isVersionAtLeast(version, CODEX_PROFILE_V2_VERSION),
 	};
+}
+
+export type CodexProfileLaunchFlag = "--profile" | "--profile-v2";
+
+/**
+ * Decide which profile-selection flag a Codex binary accepts, from its `--help`
+ * text. `--profile-v2` existed only in a short transition window: it was added
+ * 2026-05-14 (#17141) and renamed to `--profile`/`-p` on 2026-05-21 (#23883),
+ * keeping the same file-based semantics. Newer codex rejects `--profile-v2`
+ * outright (exit 2).
+ *
+ * Order matters: transition-window binaries list BOTH `--profile` (legacy v1)
+ * and `--profile-v2` (new file-based), so `--profile-v2` must be preferred when
+ * present. Version numbers do not map reliably to the rename, so we feature-
+ * detect from help text instead. See issue #611.
+ */
+export function pickCodexProfileLaunchFlag(helpText: string): CodexProfileLaunchFlag {
+	if (/--profile-v2(?![\w-])/.test(helpText)) return "--profile-v2";
+	return "--profile";
+}
+
+/**
+ * Probe the installed Codex's `--help` to pick the profile launch flag.
+ * Falls back to `--profile` (the modern, post-rename flag) when help can't be
+ * read — it is the safe default since `--profile-v2` is the flag that crashes.
+ */
+export function detectCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
+	try {
+		const result = spawnSync(["codex", "--help"], { stdout: "pipe", stderr: "pipe" });
+		const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
+		const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "";
+		return pickCodexProfileLaunchFlag(`${stdout}\n${stderr}`);
+	} catch {
+		return "--profile";
+	}
 }
 
 export function detectCodexVersion(): string | null {


### PR DESCRIPTION
## Summary

Codex removed the `--profile-v2` flag and folded its file-based semantics into `--profile`/`-p`, so dev-3.0's version-gated rewrite in `applyCodexThemeProfile` started aborting every Codex launch with `error: unexpected argument '--profile-v2'` (exit 2). Since Codex self-updates, this broke Codex agent launches for effectively every user.

The launch flag is now **feature-detected from `codex --help`** instead of a version threshold:

- `pickCodexProfileLaunchFlag(helpText)` returns `--profile-v2` only when the binary actually lists it (word-boundary match), else `--profile`.
- `detectCodexProfileLaunchFlag()` probes `codex --help`, falls back to `--profile` on any failure (the safe default — `--profile-v2` is the flag that crashes).
- `applyCodexThemeProfile()` rewrites `-p`/`--profile` to `--profile-v2` only when the detected flag is `--profile-v2`; otherwise it keeps the user's flag and just swaps the value to the themed profile. Cached per process; overridable in tests.

The per-profile-file config writing (`profileV2`, gated at codex ≥0.131) is unchanged — those file-based semantics still apply on both `--profile-v2` and the renamed `--profile`. See decision 064 (and the superseded note on 055).

Huge thanks to @eladharitanwix for the detailed report, the empirical version testing, and the resolved-command dump — it made the root cause obvious. (This PR was written by Claude, the AI assistant working on this branch.)

Closes #611