### PR TITLE
Fix false "Branch Merged" prompt on PR-review tasks

### DIFF
--- a/change-logs/2026/06/09/fix-review-task-false-merge.md
+++ b/change-logs/2026/06/09/fix-review-task-false-merge.md
@@ -1,0 +1,1 @@
+Fixed a false "Branch Merged" prompt on PR-review tasks. Such tasks use the reviewed branch as their base branch, so the merge-detection poller was comparing the branch against itself (trivially "merged"); it now skips tasks whose base branch equals the current branch.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6214,6 +6214,35 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		});
 	});
 
+	it("does not notify PR-review tasks whose base branch is the reviewed branch itself", async () => {
+		// PR-review tasks are created from an existing branch; deriveTaskBaseBranch
+		// sets their baseBranch to that same branch. The poller would then compare
+		// the branch against origin/<itself>, which is trivially "merged" — producing
+		// a false "Branch Merged" prompt even though nothing reached the real base.
+		const project = makeProject();
+		const task = makeTask({
+			status: "review-by-colleague",
+			worktreePath: "/tmp/test-worktree",
+			baseBranch: "fix/deepseek-reasoning-dsml-recovery",
+			branchName: "fix/deepseek-reasoning-dsml-recovery",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("fix/deepseek-reasoning-dsml-recovery");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).not.toHaveBeenCalledWith("branchMerged", expect.anything());
+		expect(git.isContentMergedInto).not.toHaveBeenCalled();
+	});
+
 	it("notifies about merged Has Questions tasks on the first 60-second poll", async () => {
 		const project = makeProject();
 		const task = makeTask({

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -280,6 +280,13 @@ async function checkMergedBranches(): Promise<void> {
 
 				const branchName = await git.getCurrentBranch(task.worktreePath!);
 				if (!branchName) continue;
+
+				// PR-review tasks check out an existing branch, and deriveTaskBaseBranch
+				// sets their baseBranch to that same branch. Comparing a branch against
+				// origin/<itself> is trivially "merged" and produced a false "Branch
+				// Merged" prompt — skip when there is no distinct base to merge into.
+				if (baseBranch === branchName) continue;
+
 				const hasRemote = await git.getUnpushedCount(task.worktreePath!, branchName);
 				if (hasRemote === -1) continue;
 


### PR DESCRIPTION
## Summary

PR-review tasks are created from an existing branch (`existingBranch`). `deriveTaskBaseBranch` sets their `baseBranch` to that same branch, so the backend merge-detection poller (`checkMergedBranches`) compared the branch against `origin/<itself>` — a comparison that is trivially "merged" — and fired a false **Branch Merged** completion prompt even though nothing reached the real base branch.

The frontend path (`getBranchStatus`) was already protected by its `status.ahead > 0` guard, so the bug only surfaced through the backend poller.

Fix: skip the merge check in the poller when the resolved base branch equals the current branch (no distinct base to merge into).

Includes a regression test in `rpc-handlers.test.ts` verifying the poller does not push `branchMerged` (and never even calls `isContentMergedInto`) when base branch == current branch.