### PR TITLE
Fix false-positive Branch Merged prompt on PR-review tasks

### DIFF
--- a/change-logs/2026/06/09/fix-merge-detection-gh-pr-false-positive.md
+++ b/change-logs/2026/06/09/fix-merge-detection-gh-pr-false-positive.md
@@ -1,0 +1,1 @@
+Fixed a false-positive "Branch Merged" prompt on PR-review tasks. The GitHub PR fallback in merge detection trusted any merged PR matching the head branch name; it now requires the merged PR's head commit to equal the current local HEAD, so a stale/reused-name PR with new unmerged work no longer triggers the prompt.

--- a/decisions/065-merge-detection-gh-pr-head-match.md
+++ b/decisions/065-merge-detection-gh-pr-head-match.md
@@ -1,0 +1,37 @@
+# 065 — Gate the gh-PR merge-detection fallback on head commit match
+
+## Context
+
+The merge-detection poller showed a false-positive "Branch Merged — mark this task as
+completed?" prompt on a PR-review task whose branch was *not* merged. Review tasks are the
+common trigger because their worktree sits on an existing (often reused) branch tied to a PR.
+
+## Investigation
+
+`isContentMergedInto` (`src/bun/git.ts`) has three strategies. Strategies 1 (merge-tree) and 2
+(patch-id) are content-based and were empirically confirmed to correctly return `false` for a
+genuinely unmerged branch. Strategy 3 was the culprit: `gh pr list --head <branch> --state merged`
+returned `true` for *any* merged PR matching the head branch *name*, with no check that the current
+HEAD content was actually merged. A previously merged PR for a reused branch name (or an old merged
+PR coexisting with new unmerged work / an open PR) produced the false positive.
+
+## Decision
+
+Strategy 3 now fetches `headRefOid` and only returns `true` when it equals the current local HEAD
+(`git rev-parse HEAD`). In every GitHub merge method (merge / squash / rebase) the head ref tip is
+left untouched, so a genuine merge always matches, while stale/reused-name PRs do not. See
+`isContentMergedInto` in `src/bun/git.ts`. Repro tests in
+`src/bun/__tests__/git-merge-detection.test.ts`.
+
+## Risks
+
+A genuine merge where the local branch was amended *after* merging would no longer be detected via
+gh — but content strategies 1/2 still catch real merges, and a false negative (no prompt) is far
+less harmful than a false positive (wrong "completed" prompt).
+
+## Alternatives considered
+
+- Also query open PRs and bail if one exists — weaker (doesn't cover branch-name reuse without an
+  open PR) and needs an extra gh call.
+- Drop Strategy 3 entirely — loses the legitimate "main diverged before AND after squash" detection
+  that motivated it (decision history around PR #500/#536).

--- a/src/bun/__tests__/git-merge-detection.test.ts
+++ b/src/bun/__tests__/git-merge-detection.test.ts
@@ -189,9 +189,54 @@ describe("isContentMergedInto", () => {
 
 		g("git checkout task-branch", repo.local);
 
-		ghPrListResponse = JSON.stringify([{ number: 42 }]);
+		// A genuine merge leaves the head ref tip untouched, so the merged PR's
+		// headRefOid equals the current local HEAD.
+		const headSha = g("git rev-parse HEAD", repo.local).trim();
+		ghPrListResponse = JSON.stringify([{ number: 42, headRefOid: headSha }]);
 		const result = await isContentMergedInto(repo.local, "origin/main");
 		expect(result).toBe(true);
+	});
+
+	it("returns false when gh reports a merged PR for the head branch name but its head commit does not match current HEAD (reused branch name / stale PR — the PR-review false positive)", async () => {
+		// Genuinely unmerged work: the branch's changes are NOT in main.
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		// main diverges with an unrelated commit so the local patch-id strategy
+		// reaches the gh fallback (Strategy 3) instead of bailing out early.
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "unrelated.ts"), "export const x = 1;\n");
+		g("git add unrelated.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		// A previously-merged PR exists for the SAME branch name, but it merged a
+		// different (older) head commit — not the current HEAD. This must NOT be
+		// treated as merged.
+		ghPrListResponse = JSON.stringify([
+			{ number: 7, headRefOid: "0000000000000000000000000000000000000000" },
+		]);
+		const result = await isContentMergedInto(repo.local, "origin/main");
+		expect(result).toBe(false);
+	});
+
+	it("returns false when gh reports a merged PR with no headRefOid", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "unrelated.ts"), "export const x = 1;\n");
+		g("git add unrelated.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		ghPrListResponse = JSON.stringify([{ number: 9 }]);
+		const result = await isContentMergedInto(repo.local, "origin/main");
+		expect(result).toBe(false);
 	});
 
 	it("returns false when only some task commits are present in main (partial merge)", async () => {

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1302,25 +1302,49 @@ export async function isContentMergedInto(
 	// When both local strategies fail (main diverged before AND after the squash
 	// on the same files), ask GitHub directly if a merged PR exists for this branch.
 	// This is the definitive source of truth for GitHub-hosted repos.
-	const branchResult = await run(["git", "rev-parse", "--abbrev-ref", "HEAD"], worktreePath);
-	if (branchResult.ok && branchResult.stdout) {
+	//
+	// CRITICAL: a merged PR matching the head branch *name* is NOT enough. Branch
+	// names get reused — a previously merged PR can coexist with brand-new unmerged
+	// work pushed to the same branch, or an open PR for the same head. This bites
+	// PR-review tasks especially. We only trust the merged-PR signal when the PR's
+	// merged head commit (headRefOid) equals the current local HEAD; in every
+	// GitHub merge method (merge/squash/rebase) the head ref tip is left untouched,
+	// so a genuine merge always satisfies this, while stale/reused-name PRs do not.
+	const [branchResult, headShaResult] = await Promise.all([
+		run(["git", "rev-parse", "--abbrev-ref", "HEAD"], worktreePath),
+		run(["git", "rev-parse", "HEAD"], worktreePath),
+	]);
+	if (branchResult.ok && branchResult.stdout && headShaResult.ok && headShaResult.stdout) {
+		const headSha = headShaResult.stdout.trim();
 		try {
 			const ghResult = project
 				? await github.runGitHub(
 					project,
 					worktreePath,
-					["pr", "list", "--head", branchResult.stdout, "--state", "merged", "--json", "number", "--limit", "1"],
+					["pr", "list", "--head", branchResult.stdout, "--state", "merged", "--json", "number,headRefOid", "--limit", "1"],
 				)
 				: await run(
-					["gh", "pr", "list", "--head", branchResult.stdout, "--state", "merged", "--json", "number", "--limit", "1"],
+					["gh", "pr", "list", "--head", branchResult.stdout, "--state", "merged", "--json", "number,headRefOid", "--limit", "1"],
 					worktreePath,
 				);
 			if (ghResult.ok && ghResult.stdout) {
 				try {
 					const prs = JSON.parse(ghResult.stdout);
 					if (Array.isArray(prs) && prs.length > 0) {
-						log.info("isContentMergedInto", { ref, method: "github-pr", pr: prs[0].number, merged: true });
-						return true;
+						const pr = prs[0];
+						if (pr?.headRefOid && pr.headRefOid === headSha) {
+							log.info("isContentMergedInto", { ref, method: "github-pr", pr: pr.number, merged: true });
+							return true;
+						}
+						log.info("isContentMergedInto", {
+							ref,
+							method: "github-pr",
+							pr: pr?.number,
+							headRefOid: pr?.headRefOid,
+							headSha,
+							merged: false,
+							reason: "merged PR head does not match current HEAD",
+						});
 					}
 				} catch { /* ignore parse errors */ }
 			}


### PR DESCRIPTION
## Summary

The merge-detection poller showed a false-positive **"Branch Merged — mark this task as completed?"** prompt on a PR-review task whose branch was *not* merged.

Root cause is in `isContentMergedInto` (`src/bun/git.ts`), **Strategy 3 — the GitHub PR fallback**. It returned `true` for *any* merged PR matching the head branch *name*, with no check that the current HEAD content was actually merged. This bites PR-review tasks specifically, since their worktree sits on an existing/reused branch tied to a PR: a previously-merged PR for a reused branch name (or an old merged PR coexisting with new unmerged work / an open PR) produced the false positive.

Strategies 1 (merge-tree) and 2 (patch-id) are content-based and were empirically confirmed to correctly return `false` for a genuinely unmerged branch.

## Fix

Strategy 3 now fetches `headRefOid` and only returns `true` when it equals the current local HEAD (`git rev-parse HEAD`). In every GitHub merge method (merge / squash / rebase) the head ref tip is left untouched, so a genuine merge always matches, while stale/reused-name PRs do not.

## Tests

Added two repro tests in `src/bun/__tests__/git-merge-detection.test.ts` (real git repo). Confirmed they fail on the old code (false `true`) and pass after the fix. The legitimate "main diverged before AND after squash" detection still returns `true`. Full suite green.

Decision record: `decisions/065-merge-detection-gh-pr-head-match.md`.

---
🤖 This PR was prepared by Claude (the AI assistant working on this branch).