### PR TITLE
Don't auto-send first message on scratch tasks for Codex/Cursor/OpenCode

### DIFF
--- a/change-logs/2026/06/08/fix-scratch-no-autosend-codex.md
+++ b/change-logs/2026/06/08/fix-scratch-no-autosend-codex.md
@@ -1,0 +1,1 @@
+Scratch tasks no longer auto-fire a first message on Codex, Cursor, and OpenCode. When the task description is empty, the dev3 system prompt is no longer injected as the positional prompt, so the agent opens an empty interactive window like Claude — protocol adherence relies on the auto-installed dev3 skill and hooks.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -465,6 +465,60 @@ describe("resolveAgentCommand — resume", () => {
 	});
 });
 
+describe("resolveAgentCommand — empty description (scratch task) opens interactive window", () => {
+	// Regression: scratch tasks force an empty description (task-lifecycle.ts).
+	// Codex/Cursor/OpenCode have no --append-system-prompt, so the system prompt
+	// used to be injected as the positional prompt — which the agent then
+	// auto-ran as turn 1. With an empty prompt it must NOT be injected, so the
+	// agent opens an empty interactive window (matching Claude).
+
+	it("Codex: empty description → no positional prompt, no system prompt injected", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "" }),
+		);
+
+		expect(cmd).not.toContain("Task Lifecycle Protocol");
+		expect(cmd).not.toContain("shell=\"/bin/bash\"");
+		expect(cmd).not.toMatch(/ -- /);
+		expect(cmd).toBe("codex");
+	});
+
+	it("Cursor Agent: empty description → no positional prompt, no system prompt injected", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "agent" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "" }),
+		);
+
+		expect(cmd).not.toContain("Task Lifecycle Protocol");
+		expect(cmd).not.toMatch(/ -- /);
+	});
+
+	it("OpenCode: empty description → no --prompt, no system prompt injected", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "opencode" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "" }),
+		);
+
+		expect(cmd).not.toContain("Task Lifecycle Protocol");
+		expect(cmd).not.toContain("--prompt");
+	});
+
+	it("Codex: non-empty description still injects description + system prompt", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "Fix the login bug" }),
+		);
+
+		expect(cmd).toContain("Fix the login bug");
+		expect(cmd).toContain("Task Lifecycle Protocol");
+	});
+});
+
 describe("resolveAgentCommand — positional prompt separator (-- guard)", () => {
 	// Regression: GitHub #570. Task descriptions starting with "---" (markdown
 	// frontmatter, horizontal rules) were treated as long options by the

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -469,10 +469,18 @@ export function resolveAgentCommand(
 		// Cursor Agent / OpenCode have no --append-system-prompt and no automatic
 		// hooks, so inject the generic system prompt via the prompt argument.
 		// Codex also gets a prompt reminder because skill loading is not guaranteed.
-		if (codexAgent) {
-			prompt = prompt ? `${prompt}\n\n${DEV3_SYSTEM_PROMPT_CODEX}` : DEV3_SYSTEM_PROMPT_CODEX;
-		} else if (cursorAgent || openCodeAgent) {
-			prompt = prompt ? `${prompt}\n\n${DEV3_SYSTEM_PROMPT_GENERIC}` : DEV3_SYSTEM_PROMPT_GENERIC;
+		//
+		// Only append it when there is an actual task prompt. On scratch / empty
+		// description launches we keep the prompt empty so the agent opens an
+		// interactive window instead of auto-running the system prompt as turn 1
+		// (matching Claude, which delivers it out-of-band). Protocol adherence
+		// then relies on the auto-installed dev3 skill + hooks.
+		if (prompt) {
+			if (codexAgent) {
+				prompt = `${prompt}\n\n${DEV3_SYSTEM_PROMPT_CODEX}`;
+			} else if (cursorAgent || openCodeAgent) {
+				prompt = `${prompt}\n\n${DEV3_SYSTEM_PROMPT_GENERIC}`;
+			}
 		}
 
 		if (prompt) {


### PR DESCRIPTION
## Summary

On a Scratch Task, Codex/Cursor/OpenCode used to immediately fire a first message while Claude opened an empty window. Root cause: those agents have no `--append-system-prompt`, so the dev3 system prompt was injected as the **positional** prompt. Scratch tasks force an empty description, so the prompt became just the system-prompt body and the agent auto-ran it as turn 1.

Fix: the system prompt is now appended to the positional prompt **only when there is an actual task prompt**. Empty-description launches (scratch / reopen) keep the prompt empty, so the agent opens an empty interactive window like Claude — protocol adherence relies on the auto-installed dev3 skill + hooks.

- `src/bun/agents.ts` — gate system-prompt injection on a non-empty prompt.
- `src/bun/__tests__/agents.test.ts` — new tests: empty description on codex/cursor/opencode emits no positional prompt and no system prompt; non-empty description still injects both.
- Changelog entry added.