### PR TITLE
Color-code Active Tasks sidebar by status

### DIFF
--- a/change-logs/2026/06/09/feature-active-tasks-status-color-rails.md
+++ b/change-logs/2026/06/09/feature-active-tasks-status-color-rails.md
@@ -1,0 +1,1 @@
+Active Tasks sidebar now color-codes every task by its status: a colored left rail plus a faint status wash on each card, and a tinted, color-barred group header. Makes it obvious at a glance which tasks are running, waiting for review, or asking questions — without hunting for the tiny status dot. Works in both dark and light themes.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -17,6 +17,14 @@ import { getTaskAgentMeta } from "../utils/taskAgentMeta";
 type SidebarScope = "project" | "global";
 const LS_SIDEBAR_SCOPE = "dev3-sidebar-scope";
 
+/** Build a translucent fill from a "#rrggbb" status color for subtle tints. */
+function statusTint(hex: string, alpha: number): string {
+	const r = parseInt(hex.slice(1, 3), 16);
+	const g = parseInt(hex.slice(3, 5), 16);
+	const b = parseInt(hex.slice(5, 7), 16);
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 function readScope(): SidebarScope {
 	try {
 		const v = localStorage.getItem(LS_SIDEBAR_SCOPE);
@@ -359,9 +367,18 @@ function ActiveTasksSidebar({
 							)}
 
 							{/* Status group header */}
-							<div className="px-3 py-1.5 flex items-center gap-2 sticky top-0 bg-base/95 backdrop-blur-sm z-10">
+							<div className="relative px-3 py-1.5 flex items-center gap-2 sticky top-0 bg-base/95 backdrop-blur-sm z-10">
+								{/* Faint status wash + left bar so the group reads as one color zone */}
+								<span
+									className="absolute inset-0 pointer-events-none"
+									style={{ background: statusTint(statusColors[status], 0.1) }}
+								/>
+								<span
+									className="absolute left-0 top-0 bottom-0 w-[3px]"
+									style={{ background: statusColors[status] }}
+								/>
 								<div
-									className="w-2 h-2 rounded-full flex-shrink-0"
+									className="w-2 h-2 rounded-full flex-shrink-0 relative"
 									style={{ background: statusColors[status] }}
 								/>
 								<span className="text-[0.625rem] font-semibold text-fg-3 uppercase tracking-wider">
@@ -403,11 +420,22 @@ function ActiveTasksSidebar({
 												isActive ? "bg-accent/10" : "hover:bg-elevated-hover"
 											}`}
 										>
-											{/* Active-task indicator — absolute so it does not shift content
-											    horizontally; keeps card padding symmetric on both sides. */}
-											{isActive && (
-												<span className="absolute left-0 top-0 bottom-0 w-0.5 bg-accent" />
+											{/* Faint status wash so the whole card carries its column color
+											    (non-active cards only; active keeps its accent tint). */}
+											{!isActive && (
+												<span
+													className="absolute inset-0 pointer-events-none"
+													style={{ background: statusTint(statusColors[task.status], 0.06) }}
+												/>
 											)}
+
+											{/* Left rail: status color per card, accent when active. Absolute
+											    so it does not shift content; keeps padding symmetric. */}
+											<span
+												className={`absolute left-0 top-0 bottom-0 w-[3px] ${isActive ? "bg-accent" : ""}`}
+												style={isActive ? undefined : { background: statusColors[task.status] }}
+												data-testid={`sidebar-status-rail-${task.id}`}
+											/>
 
 											{/* Bell badge */}
 											{bellCount > 0 && (

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -105,6 +105,42 @@ describe("ActiveTasksSidebar", () => {
 		expect(screen.getAllByText("#494")).toHaveLength(2);
 	});
 
+	it("renders a per-card status color rail (status hue for inactive, accent for active)", () => {
+		render(
+			<I18nProvider>
+				<ActiveTasksSidebar
+					project={project}
+					tasks={[
+						makeTask({ id: "t1", status: "in-progress" }),
+						makeTask({
+							id: "t2",
+							status: "review-by-user",
+							variantIndex: 2,
+							agentId: "builtin-codex",
+							configId: "codex-default",
+						}),
+					]}
+					activeTaskId="t1"
+					dispatch={vi.fn()}
+					navigate={vi.fn()}
+					agents={[claudeAgent, codexAgent]}
+					bellCounts={new Map()}
+					taskPorts={new Map()}
+					onSwitchToBoard={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		// Active task's rail uses the accent token, not a status hex.
+		const activeRail = screen.getByTestId("sidebar-status-rail-t1");
+		expect(activeRail.className).toContain("bg-accent");
+
+		// Inactive task's rail is tinted inline with its status color.
+		const inactiveRail = screen.getByTestId("sidebar-status-rail-t2");
+		expect(inactiveRail.className).not.toContain("bg-accent");
+		expect(inactiveRail.getAttribute("style")).toMatch(/background/);
+	});
+
 	it("toggles between project and global scope and fetches all-project tasks", async () => {
 		const user = userEvent.setup();
 		const { api } = await import("../../rpc");

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -206,6 +206,8 @@ const tips = {
 	"tip.quitConfirm.body": "Quitting via Cmd+Q, the menu, or the dock shows a confirmation so your background tmux sessions don't vanish by surprise.",
 	"tip.sidebarHide.title": "Hide the Active Tasks panel",
 	"tip.sidebarHide.body": "Click the fullscreen icon in the sidebar header to collapse it and give the terminal the whole window.",
+	"tip.statusColorRails.title": "Tasks are color-coded by status",
+	"tip.statusColorRails.body": "Each task in the Active Tasks list has a colored left rail matching its status — scan who's working vs. waiting at a glance.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -206,6 +206,8 @@ const tips = {
 	"tip.quitConfirm.body": "Salir con Cmd+Q, el menú o el dock muestra una confirmación para que tus sesiones tmux en segundo plano no desaparezcan por sorpresa.",
 	"tip.sidebarHide.title": "Ocultar el panel de Tareas activas",
 	"tip.sidebarHide.body": "Pulsa el icono de pantalla completa en la cabecera del panel para plegarlo y dar al terminal toda la ventana.",
+	"tip.statusColorRails.title": "Tareas codificadas por color de estado",
+	"tip.statusColorRails.body": "Cada tarea de la lista Tareas activas tiene una barra de color a la izquierda según su estado: distingue de un vistazo quién trabaja y quién espera.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -206,6 +206,8 @@ const tips = {
 	"tip.quitConfirm.body": "Выход через Cmd+Q, меню или док показывает подтверждение, чтобы фоновые tmux-сессии не исчезли внезапно.",
 	"tip.sidebarHide.title": "Скрыть панель Active Tasks",
 	"tip.sidebarHide.body": "Нажмите иконку полноэкранного режима в шапке панели, чтобы свернуть её и отдать всё окно терминалу.",
+	"tip.statusColorRails.title": "Задачи окрашены по статусу",
+	"tip.statusColorRails.body": "У каждой задачи в списке Active Tasks слева цветная полоса по её статусу — сразу видно, кто работает, а кто ждёт.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -654,6 +654,13 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.sidebarHide.body",
 		icon: "\u{F0294}", // nf-md-fullscreen
 	},
+	// Batch 42: status color rails
+	{
+		id: "status-color-rails",
+		titleKey: "tip.statusColorRails.title",
+		bodyKey: "tip.statusColorRails.body",
+		icon: "\u{F0766}", // nf-md-format_color_fill
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days


### PR DESCRIPTION
## Summary

Make task status obvious at a glance in the **Active Tasks** sidebar instead of relying on the tiny status dot.

- Per-card **left rail** colored by the task's status; active task keeps the accent rail so the selection stays crisp.
- Faint **status wash** on each card so the whole row subtly carries its column color.
- Group header gets a status-colored left bar + light tint so the block reads as one color zone while scrolling.
- Colors resolve per theme via `useStatusColors()` — works in both dark and light.
- Accessibility preserved: the textual group header + dot remain, so color is reinforcement, not the sole signal.

Adds a "Did you know?" tip (en/ru/es), a changelog entry, and a test covering the per-card rail.