### PR TITLE
Fix diff rendering renamed files as full delete + add

### DIFF
--- a/change-logs/2026/06/09/fix-diff-rename-detection.md
+++ b/change-logs/2026/06/09/fix-diff-rename-detection.md
@@ -1,0 +1,1 @@
+Fixed the diff view showing renamed files as a full delete + add (every line changed) instead of the few lines that actually differ. Rename/copy detection is now passed explicitly to every git diff call at git's default 50% similarity, so it works regardless of the user's `diff.renames` config and no longer drops renames with moderate edits.

--- a/decisions/065-diff-rename-detection-explicit-50pct.md
+++ b/decisions/065-diff-rename-detection-explicit-50pct.md
@@ -1,0 +1,35 @@
+# 065 — Explicit 50% rename detection for diffs
+
+## Context
+The task diff view rendered renamed files as a full delete of the old path plus a
+full add of the new path — making it look like the entire file changed when only a
+few lines actually differed.
+
+## Investigation
+Two independent causes in `src/bun/git.ts`:
+1. **Config dependence.** The per-file patch commands (`buildArgs` in `getTaskDiff`)
+   and the numstat/shortstat summary calls did not pass any rename flag, so they
+   inherited the user's `diff.renames` setting. With `diff.renames=false`, git emits
+   a delete + add patch.
+2. **Threshold too strict.** `listDiffEntries` used `--find-renames=90%`. A rename
+   carrying moderate edits (e.g. ~70% similar) falls below 90%, so git split it into
+   separate `D` + `A` name-status entries → two diff cards, each showing the whole file.
+
+## Decision
+Introduced `RENAME_DETECTION_ARGS = ["--find-renames", "--find-copies"]` (git's
+default 50% similarity, passed explicitly) and applied it to every diff invocation:
+`listDiffEntries`, all four per-file `buildArgs`, `getDiffShortStat`,
+`getUncommittedChanges`, and `getBranchDiffStats`. The name-status classification and
+the per-file patch now use the same detection, so a rename-with-edits is one
+`renamed` entry with a minimal patch.
+
+## Risks
+50% is more permissive than 90%, so unrelated files with ~50%+ overlap could be
+paired as a rename. This matches git's own default (git log/show, GitHub) and is the
+expected behavior, so the risk is low and consistent with user expectations.
+
+## Alternatives considered
+- Keep 90% but pass it explicitly — rejected: still drops moderate-edit renames.
+- Recompute the diff in the renderer from `oldContent`/`newContent` — rejected:
+  duplicates git's rename logic and the backend already produces the correct patch
+  once the flag is passed.

--- a/src/bun/__tests__/git-diff-rename.test.ts
+++ b/src/bun/__tests__/git-diff-rename.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test",
+}));
+
+vi.mock("../spawn", async () => {
+	const { createSpawnMock } = await import("./git-test-helpers");
+	return createSpawnMock();
+});
+
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { createTestRepo, cleanup, g, type TestRepo } from "./git-test-helpers";
+import { getTaskDiff, _resetFetchState } from "../git";
+
+const TEN_LINES = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+// Same 10 lines but with a single line changed → ~90% similar content.
+const TEN_LINES_ONE_CHANGED = TEN_LINES.replace("line 5", "line 5 CHANGED");
+
+describe("getTaskDiff rename detection", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+		_resetFetchState();
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("reports a renamed-with-edits file as a single rename, not delete + add", async () => {
+		// Worst case for the previous implementation: the user disabled rename
+		// detection globally. The diff must still detect the rename because the
+		// flag is now passed explicitly.
+		g("git config diff.renames false", repo.local);
+
+		writeFileSync(join(repo.local, "module.ts"), TEN_LINES);
+		g("git add module.ts", repo.local);
+		g('git commit -m "add module"', repo.local);
+
+		g("git mv module.ts renamed.ts", repo.local);
+		writeFileSync(join(repo.local, "renamed.ts"), TEN_LINES_ONE_CHANGED);
+		g("git add -A", repo.local);
+
+		const result = await getTaskDiff(repo.local, "uncommitted", { baseBranch: "main" });
+
+		const renamed = result.files.filter((f) => f.status === "renamed");
+		const deleted = result.files.filter((f) => f.status === "deleted");
+		const added = result.files.filter((f) => f.status === "added");
+
+		expect(renamed).toHaveLength(1);
+		expect(deleted).toHaveLength(0);
+		expect(added).toHaveLength(0);
+
+		const entry = renamed[0];
+		expect(entry.oldPath).toBe("module.ts");
+		expect(entry.newPath).toBe("renamed.ts");
+
+		// The patch must contain only the single changed line, not the whole file.
+		const patch = (entry.hunks ?? []).join("\n");
+		const addedLines = patch.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+		const removedLines = patch.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---"));
+		expect(addedLines).toHaveLength(1);
+		expect(removedLines).toHaveLength(1);
+		expect(addedLines[0]).toContain("line 5 CHANGED");
+	});
+
+	it("detects a rename with a moderate edit below the old 90% threshold", async () => {
+		// ~70% similar: 3 of 10 lines changed. The previous 90% threshold split
+		// this into delete + add; git's default 50% threshold pairs them.
+		writeFileSync(join(repo.local, "service.ts"), TEN_LINES);
+		g("git add service.ts", repo.local);
+		g('git commit -m "add service"', repo.local);
+
+		const moderatelyEdited = TEN_LINES
+			.replace("line 2", "line 2 X")
+			.replace("line 5", "line 5 Y")
+			.replace("line 8", "line 8 Z");
+		g("git mv service.ts moved-service.ts", repo.local);
+		writeFileSync(join(repo.local, "moved-service.ts"), moderatelyEdited);
+		g("git add -A", repo.local);
+
+		const result = await getTaskDiff(repo.local, "uncommitted", { baseBranch: "main" });
+
+		const renamed = result.files.filter((f) => f.status === "renamed");
+		expect(renamed).toHaveLength(1);
+		expect(renamed[0].oldPath).toBe("service.ts");
+		expect(renamed[0].newPath).toBe("moved-service.ts");
+		expect(result.files.some((f) => f.status === "deleted" || f.status === "added")).toBe(false);
+	});
+});

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -11,6 +11,18 @@ const log = createLogger("git");
 const MAX_INLINE_DIFF_FILE_BYTES = 250_000;
 const MAX_BINARY_CHECK_BYTES = 8_192;
 
+// Rename/copy detection at git's default similarity (50%). These flags must be
+// passed explicitly and kept identical between the name-status listing
+// (listDiffEntries) and the per-file patch (buildArgs in getTaskDiff):
+//   - The default must be EXPLICIT because users may disable it globally via
+//     `diff.renames=false`; without the flag a rename renders as a full
+//     delete + add, making it look like the whole file changed.
+//   - The threshold must be git's default (50%), not a stricter value. A high
+//     threshold (e.g. 90%) splits a rename-with-edits into separate delete/add
+//     entries, again showing the entire file as changed instead of the few
+//     lines that actually differ.
+const RENAME_DETECTION_ARGS = ["--find-renames", "--find-copies"] as const;
+
 type BinaryRunResult = {
 	ok: boolean;
 	stdout: Uint8Array;
@@ -241,8 +253,7 @@ async function listDiffEntries(
 			"diff",
 			"--name-status",
 			"-z",
-			"--find-renames=90%",
-			"--find-copies=90%",
+			...RENAME_DETECTION_ARGS,
 			"--diff-filter=ACDMRT",
 			...diffArgs,
 		],
@@ -276,7 +287,7 @@ async function getDiffShortStat(
 	diffArgs: string[],
 ): Promise<TaskDiffSummary> {
 	const result = await run(
-		["git", "diff", "--shortstat", ...diffArgs],
+		["git", "diff", "--shortstat", ...RENAME_DETECTION_ARGS, ...diffArgs],
 		worktreePath,
 	);
 	return result.ok && result.stdout ? parseShortStat(result.stdout) : { files: 0, insertions: 0, deletions: 0 };
@@ -1117,7 +1128,7 @@ export async function getUncommittedChanges(
 ): Promise<{ insertions: number; deletions: number }> {
 	// Tracked file changes (staged + unstaged)
 	const trackedResult = await run(
-		["git", "diff", "--numstat", "HEAD"],
+		["git", "diff", "--numstat", ...RENAME_DETECTION_ARGS, "HEAD"],
 		worktreePath,
 	);
 
@@ -1175,7 +1186,7 @@ export async function getBranchDiffStats(
 	worktreePath: string,
 	ref: string,
 ): Promise<{ files: number; insertions: number; deletions: number; fileStats: Array<{ path: string; insertions: number; deletions: number }> }> {
-	const result = await run(["git", "diff", "--numstat", `${ref}...HEAD`], worktreePath);
+	const result = await run(["git", "diff", "--numstat", ...RENAME_DETECTION_ARGS, `${ref}...HEAD`], worktreePath);
 	if (!result.ok || !result.stdout.trim()) {
 		return { files: 0, insertions: 0, deletions: 0, fileStats: [] };
 	}
@@ -1407,7 +1418,7 @@ export async function getTaskDiff(
 						const path = entry.newPath ?? entry.displayPath;
 						return ["diff", "--no-index", "--no-ext-diff", "--no-color", "--", "/dev/null", path];
 					}
-					return ["diff", "--no-ext-diff", "--no-color", "HEAD", "--", ...getEntryPathArgs(entry)];
+					return ["diff", "--no-ext-diff", "--no-color", ...RENAME_DETECTION_ARGS, "HEAD", "--", ...getEntryPathArgs(entry)];
 				},
 			},
 		);
@@ -1442,6 +1453,7 @@ export async function getTaskDiff(
 							"diff",
 							"--no-ext-diff",
 							"--no-color",
+							...RENAME_DETECTION_ARGS,
 							upstreamRef,
 							"HEAD",
 							"--",
@@ -1477,6 +1489,7 @@ export async function getTaskDiff(
 						"diff",
 						"--no-ext-diff",
 						"--no-color",
+						...RENAME_DETECTION_ARGS,
 						`${defaultCompareRef}...HEAD`,
 						"--",
 						...getEntryPathArgs(entry),


### PR DESCRIPTION
## Summary

The task diff view rendered a renamed file as a full delete of the old path plus a full add of the new path — making it look like the entire file changed when only a few lines actually differed.

Two independent causes in `src/bun/git.ts`:

- **Config dependence:** the per-file patch commands (`buildArgs`) and the numstat/shortstat summary calls passed no rename flag, inheriting the user's `diff.renames` setting. With `diff.renames=false`, git emits a delete + add patch.
- **Threshold too strict:** `listDiffEntries` used `--find-renames=90%`. A rename carrying moderate edits (~70% similar) fell below 90%, so git split it into separate `D` + `A` name-status entries → two diff cards, each showing the whole file.

Introduced `RENAME_DETECTION_ARGS = ["--find-renames", "--find-copies"]` (git's default 50% similarity, passed explicitly) and applied it to every diff invocation: `listDiffEntries`, all four per-file `buildArgs`, `getDiffShortStat`, `getUncommittedChanges`, `getBranchDiffStats`. Name-status classification and the per-file patch now use the same detection, so a rename-with-edits becomes one `renamed` entry with a minimal patch — regardless of the user's `diff.renames` config.

Added two reproduction tests (`git-diff-rename.test.ts`), a changelog entry, and decision record 065. Verified both tests fail without the fix and pass with it; full `bun run test` is green.