### PR TITLE
Add Fable 5 model and make it the default Claude preset

### DIFF
--- a/change-logs/2026/06/09/feature-fable-5-default-model.md
+++ b/change-logs/2026/06/09/feature-fable-5-default-model.md
@@ -1,0 +1,1 @@
+Added the new Claude model Fable 5 (claude-fable-5) to the Claude agent presets and promoted it to the default launch model across all permission modes (Auto, Bypass, Default, Plan, Accept Edits, Don't Ask). The previous Opus 4.8 presets are kept as a fallback block.

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -120,7 +120,7 @@ describe("mergeWithDefaults", () => {
 
 		// Original config is first (name reset by version bump)
 		expect(claude.configurations[0].id).toBe("claude-default");
-		expect(claude.configurations[0].name).toBe("Default (Opus 4.8)");
+		expect(claude.configurations[0].name).toBe("Default (Fable 5)");
 
 		// All new defaults appended
 		for (const expected of expectedNewConfigs) {
@@ -148,13 +148,16 @@ describe("mergeWithDefaults", () => {
 	});
 
 	it("preserves user-modified configs while appending new defaults", () => {
+		// Use the current default version so overrides win (version match, not a preset bump).
+		const claudeDefaultVersion = DEFAULT_AGENTS.find((a) => a.id === "builtin-claude")!
+			.configurations.find((c) => c.id === "claude-default")!.version;
 		const stored: CodingAgent[] = [
 			{
 				id: "builtin-claude",
 				name: "Claude",
 				baseCommand: "claude",
 				configurations: [
-					{ id: "claude-default", name: "My Custom Name", model: "haiku", version: 5 },
+					{ id: "claude-default", name: "My Custom Name", model: "haiku", version: claudeDefaultVersion },
 					{ id: "user-custom-cfg", name: "My Extra Config" },
 				],
 				defaultConfigId: "claude-default",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -166,19 +166,26 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			// --- Opus 4.8 (new default) — order: Auto, Bypass, Default, then the rest ---
-			{ id: "claude-auto", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 5 },
+			// --- Fable 5 (new default) — order: Auto, Bypass, Default, then the rest ---
+			{ id: "claude-auto", name: "Auto (Fable 5)", model: "claude-fable-5", permissionMode: "auto", version: 6 },
 			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
-			{ id: "claude-bypass", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-bypass", name: "Bypass (Fable 5)", model: "claude-fable-5", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
-			{ id: "claude-default", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-default", name: "Default (Fable 5)", model: "claude-fable-5", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-default-sonnet", name: "Default (Sonnet)", model: "sonnet", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-plan", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 6 },
+			{ id: "claude-plan", name: "Plan (Fable 5)", model: "claude-fable-5", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 7 },
 			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 2 },
-			{ id: "claude-approvals", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-approvals", name: "Accept Edits (Fable 5)", model: "claude-fable-5", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
-			{ id: "claude-dontask", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 5 },
+			{ id: "claude-dontask", name: "Don't Ask (Fable 5)", model: "claude-fable-5", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-dontask-sonnet", name: "Don't Ask (Sonnet)", model: "sonnet", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			// --- Opus 4.8 (previous default, kept for fallback) ---
+			{ id: "claude-default-opus48", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-plan-opus48", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-bypass-opus48", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-auto-opus48", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 1 },
+			{ id: "claude-approvals-opus48", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-dontask-opus48", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			// --- Opus 4.7 (previous generation, kept for fallback) ---
 			{ id: "claude-default-opus47", name: "Default (Opus 4.7)", model: "claude-opus-4-7[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan-opus47", name: "Plan (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },


### PR DESCRIPTION
## Summary

- Add the new Claude model **Fable 5** (`claude-fable-5`) and promote it to the default launch model.
- Repoint the main `claude-*` preset chain (Auto, Bypass, Default, Plan, Accept Edits, Don't Ask) to `claude-fable-5` and bump their versions so the change propagates to already-stored `agents.json` via the existing version-reset logic.
- The default config id (`claude-auto`, referenced by both the agent and global settings) is unchanged — it now resolves to Fable 5, so new tasks launch with `claude --model claude-fable-5`.
- Preserve the previous **Opus 4.8** presets as a `*-opus48` fallback block, mirroring the existing `*-opus47` block. Opus 4.7 block is untouched.
- Updated the two affected merge tests and added a changelog entry.