### PR TITLE
Expand short project IDs in CLI --project flag

### DIFF
--- a/change-logs/2026/06/09/fix-cli-short-project-id.md
+++ b/change-logs/2026/06/09/fix-cli-short-project-id.md
@@ -1,0 +1,1 @@
+Fixed the dev3 CLI rejecting 8-char short project IDs (the form shown by `projects list`) on the `--project` flag. Short project IDs are now expanded to the full UUID across task, note, label, overview, dev-server, config, and tasks commands, matching how short task IDs already work.

--- a/src/cli/__tests__/context.test.ts
+++ b/src/cli/__tests__/context.test.ts
@@ -381,3 +381,46 @@ describe("detectFromWorktreePath — realDev3Home extraction", () => {
 		expect(result!.realDev3Home).toBe("/home/user/.dev3.0");
 	});
 });
+
+describe("expandShortProjectId", () => {
+	it("expands a short project ID prefix to the full project ID", async () => {
+		const { expandShortProjectId } = await import("../context");
+		// TEST_PROJECT_ID is "proj-test-123" — a short prefix must resolve to it.
+		expect(expandShortProjectId("proj-tes", null)).toBe(TEST_PROJECT_ID);
+	});
+
+	it("returns a full-length ID (>=36 chars) unchanged without scanning", async () => {
+		const { expandShortProjectId } = await import("../context");
+		const fullId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+		expect(expandShortProjectId(fullId, null)).toBe(fullId);
+	});
+
+	it("prefers the context project when its ID matches the prefix", async () => {
+		const { expandShortProjectId } = await import("../context");
+		const ctx = { projectId: "ctx-proj-999", taskId: TEST_TASK_ID, socketPath: "" };
+		expect(expandShortProjectId("ctx-pro", ctx)).toBe("ctx-proj-999");
+	});
+
+	it("returns the input unchanged when no project matches", async () => {
+		const { expandShortProjectId } = await import("../context");
+		expect(expandShortProjectId("zzzzzzzz", null)).toBe("zzzzzzzz");
+	});
+});
+
+describe("resolveProjectId", () => {
+	it("expands a short --project flag value", async () => {
+		const { resolveProjectId } = await import("../context");
+		expect(resolveProjectId("proj-tes", null)).toBe(TEST_PROJECT_ID);
+	});
+
+	it("falls back to context project when flag is absent", async () => {
+		const { resolveProjectId } = await import("../context");
+		const ctx = { projectId: TEST_PROJECT_ID, taskId: TEST_TASK_ID, socketPath: "" };
+		expect(resolveProjectId(undefined, ctx)).toBe(TEST_PROJECT_ID);
+	});
+
+	it("returns undefined when neither flag nor context is present", async () => {
+		const { resolveProjectId } = await import("../context");
+		expect(resolveProjectId(undefined, null)).toBeUndefined();
+	});
+});

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,7 +1,7 @@
 import { sendRequest } from "../socket-client";
 import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import type { CliContext } from "../context";
+import { resolveProjectId, type CliContext } from "../context";
 
 export async function handleConfig(
 	subcommand: string | undefined,
@@ -9,7 +9,7 @@ export async function handleConfig(
 	socketPath: string,
 	context: CliContext | null,
 ): Promise<void> {
-	const projectId = args.flags?.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags?.project, context);
 	const worktreePath = context?.worktreePath;
 
 	if (subcommand === "export") {

--- a/src/cli/commands/dev-server.ts
+++ b/src/cli/commands/dev-server.ts
@@ -2,7 +2,7 @@ import type { DevServerStatus } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { printDetail, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import { expandShortId, type CliContext } from "../context";
+import { expandShortId, resolveProjectId, type CliContext } from "../context";
 
 function resolveTaskId(args: ParsedArgs, context: CliContext | null): string | undefined {
 	const raw = args.positional[0] || args.flags.id || context?.taskId;
@@ -75,8 +75,8 @@ async function runAction(
 	}
 
 	const params: Record<string, unknown> = { taskId };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, `devServer.${action}`, params);
 	if (!resp.ok) exitError(resp.error || `Failed to ${action} dev server`);

--- a/src/cli/commands/label.ts
+++ b/src/cli/commands/label.ts
@@ -2,12 +2,12 @@ import type { Label, Task } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import { expandShortId, type CliContext } from "../context";
+import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
 
 async function listLabels(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["project"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
@@ -29,7 +29,7 @@ async function listLabels(args: ParsedArgs, socketPath: string, context: CliCont
 
 async function createLabel(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["project", "name", "color"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
@@ -51,7 +51,7 @@ async function createLabel(args: ParsedArgs, socketPath: string, context: CliCon
 
 async function deleteLabel(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["project", "id"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
@@ -69,7 +69,7 @@ async function deleteLabel(args: ParsedArgs, socketPath: string, context: CliCon
 
 async function setTaskLabels(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["task", "task-id", "project"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
@@ -95,7 +95,7 @@ async function setTaskLabels(args: ParsedArgs, socketPath: string, context: CliC
 
 async function clearTaskLabels(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["task", "task-id", "project", "clear"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}

--- a/src/cli/commands/note.ts
+++ b/src/cli/commands/note.ts
@@ -2,7 +2,7 @@ import type { Task, TaskNote, NoteSource } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import { expandShortId, type CliContext } from "../context";
+import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
 
 const VALID_SOURCES: NoteSource[] = ["user", "ai"];
@@ -43,8 +43,8 @@ async function addNote(args: ParsedArgs, socketPath: string, context: CliContext
 	}
 
 	const params: Record<string, unknown> = { taskId, content, source };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "note.add", params);
 	if (!resp.ok) exitError(resp.error || "Failed to add note");
@@ -63,8 +63,8 @@ async function listNotes(args: ParsedArgs, socketPath: string, context: CliConte
 	const taskId = expandShortId(rawTaskId, context);
 
 	const params: Record<string, unknown> = { taskId };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "note.list", params);
 	if (!resp.ok) exitError(resp.error || "Failed to list notes");
@@ -99,8 +99,8 @@ async function deleteNote(args: ParsedArgs, socketPath: string, context: CliCont
 	const taskId = expandShortId(rawTaskId, context);
 
 	const params: Record<string, unknown> = { taskId, noteId };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "note.delete", params);
 	if (!resp.ok) exitError(resp.error || "Failed to delete note");

--- a/src/cli/commands/overview.ts
+++ b/src/cli/commands/overview.ts
@@ -2,7 +2,7 @@ import type { Task } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import { expandShortId, type CliContext } from "../context";
+import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
 
 const OVERVIEW_MAX_LEN = 500;
@@ -16,7 +16,7 @@ function resolveTargetIds(
 		exitUsage("No task in context. Run from inside a worktree or pass --task <id> / --task-id <id>.");
 	}
 	const taskId = expandShortId(rawTaskId, context);
-	const projectId = args.flags.project || context?.projectId || undefined;
+	const projectId = resolveProjectId(args.flags.project, context);
 	return { taskId, projectId };
 }
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -4,7 +4,7 @@ import { CODEX_STOP_HOOK_FLAG, CODEX_STOP_HOOK_SUCCESS_JSON } from "../../shared
 import { sendRequest } from "../socket-client";
 import { printDetail, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import { expandShortId, type CliContext } from "../context";
+import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
 
 // Statuses that destroy the worktree + terminal are forbidden via CLI.
@@ -73,8 +73,8 @@ async function showTask(args: ParsedArgs, socketPath: string, context: CliContex
 	}
 
 	const params: Record<string, unknown> = { taskId };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "task.show", params);
 	if (!resp.ok) exitError(resp.error || "Failed to get task");
@@ -84,7 +84,7 @@ async function showTask(args: ParsedArgs, socketPath: string, context: CliContex
 
 async function createTask(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
 	rejectUnknownFlags(args, ["project", "title", "description"]);
-	const projectId = args.flags.project || context?.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
 	if (!projectId) {
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
@@ -121,8 +121,8 @@ async function updateTask(args: ParsedArgs, socketPath: string, context: CliCont
 	}
 
 	const params: Record<string, unknown> = { taskId };
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 	// Tri-state semantics:
 	//   flag absent           → leave field untouched (not in params)
 	//   flag present+empty    → clear the field (empty string in params)
@@ -187,8 +187,8 @@ async function moveTask(args: ParsedArgs, socketPath: string, context: CliContex
 	const params: Record<string, unknown> = { taskId, newStatus };
 	if (ifStatus) params.ifStatus = ifStatus;
 	if (ifStatusNot) params.ifStatusNot = ifStatusNot;
-	if (args.flags.project) params.projectId = args.flags.project;
-	else if (context?.projectId) params.projectId = context.projectId;
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "task.move", params);
 	if (!resp.ok) exitError(resp.error || "Failed to move task");

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -3,7 +3,7 @@ import { STATUS_LABELS, ALL_STATUSES } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
-import type { CliContext } from "../context";
+import { resolveProjectId, type CliContext } from "../context";
 
 export async function handleTasks(
 	subcommand: string | undefined,
@@ -12,7 +12,7 @@ export async function handleTasks(
 	context: CliContext | null,
 ): Promise<void> {
 	if (subcommand === "list" || !subcommand) {
-		const projectId = args.flags.project || context?.projectId;
+		const projectId = resolveProjectId(args.flags.project, context);
 		if (!projectId) {
 			exitUsage("--project <id> is required (or run from inside a worktree)");
 		}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -245,6 +245,36 @@ export function expandShortId(id: string, context: CliContext | null): string {
 }
 
 /**
+ * Expand a short project ID (e.g. 8-char prefix from `projects list`) to full UUID.
+ * Mirrors expandShortId for tasks: the server matches projects by exact ID, so the
+ * CLI must resolve short prefixes before sending them.
+ */
+export function expandShortProjectId(id: string, context: CliContext | null): string {
+	// Already a full UUID
+	if (id.length >= 36) return id;
+	// Check if context project matches the prefix
+	if (context?.projectId?.startsWith(id)) return context.projectId;
+	// Fall back to scanning projects.json
+	try {
+		const projects = JSON.parse(readFileSync(PROJECTS_FILE, "utf-8")) as Array<{ id: string }>;
+		const match = projects.find((p) => p.id.startsWith(id));
+		if (match) return match.id;
+	} catch {
+		// Data files not available — return as-is
+	}
+	return id;
+}
+
+/**
+ * Resolve the target project ID from a parsed --project flag (expanding short IDs)
+ * or fall back to the worktree context. Returns undefined when neither is present.
+ */
+export function resolveProjectId(flagValue: string | undefined, context: CliContext | null): string | undefined {
+	if (flagValue) return expandShortProjectId(flagValue, context);
+	return context?.projectId;
+}
+
+/**
  * Read project info directly from data files (no socket needed).
  */
 export function readProjectDirect(projectId: string): { id: string; name: string; path: string } | null {


### PR DESCRIPTION
## Summary

The `dev3` server matches projects by exact UUID, but `dev3 projects list` only displays the 8-char short ID. Passing that short ID to `--project` failed with `Project not found` — even though it's the only ID form the CLI shows the user.

Short **task** IDs were already expanded via `expandShortId`; project IDs had no equivalent, so the bug affected every `--project` consumer.

- Added `expandShortProjectId` + `resolveProjectId` helpers in `src/cli/context.ts` (mirroring the existing short task-ID expansion).
- Applied `resolveProjectId` across all commands that accept `--project`: `task` (show/create/update/move), `note`, `label`, `overview`, `dev-server`, `config`, and `tasks list`.
- Full-length UUIDs (≥36 chars) pass through unchanged; unknown prefixes are returned as-is so the server still produces a clear `Project not found` error.
- Added unit tests for both helpers.

🤖 This PR was authored by Claude (the AI assistant working on this branch).