### PR TITLE
Bring back Opus as a first-class built-in Claude preset

### DIFF
--- a/change-logs/2026/06/12/feature-opus-builtin-presets.md
+++ b/change-logs/2026/06/12/feature-opus-builtin-presets.md
@@ -1,0 +1,1 @@
+Brought Opus back as a first-class built-in Claude preset: every mode (Auto, Bypass, Default, Plan, Accept Edits, Don't Ask) now offers an "(Opus)" variant using the `opus` alias model, placed right next to the Fable 5 and Sonnet entries. The pinned Opus 4.8 / 4.7 fallback blocks remain unchanged.

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -18,12 +18,13 @@ const AGENTS_FILE = `${DEV3_HOME}/agents.json`;
 // ---- Storage ----
 
 /** Old default config IDs that were removed or renamed. These are filtered out
- *  during merge so they don't linger as phantom "user" configs. */
+ *  during merge so they don't linger as phantom "user" configs.
+ *  Note: claude-approvals-opus / claude-bypass-opus were deprecated here once,
+ *  but are now live default presets again (Opus alias chain) — the version bump
+ *  in DEFAULT_AGENTS resets any ancient stored copies instead. */
 const DEPRECATED_CONFIG_IDS = new Set([
 	"claude-plan-then-bypass-opus",
 	"claude-plan-then-bypass-sonnet",
-	"claude-approvals-opus",
-	"claude-bypass-opus",
 ]);
 
 /** Merge stored agents with defaults. Missing defaults are added; stored versions win.

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -317,6 +317,46 @@ describe("mergeWithDefaults", () => {
 		expect(cfg.version).toBe(defCfg.version);
 	});
 
+	it("offers an Opus alias preset next to Fable and Sonnet for every Claude mode", () => {
+		const defClaude = DEFAULT_AGENTS.find((a) => a.id === "builtin-claude")!;
+		const ids = defClaude.configurations.map((c) => c.id);
+
+		for (const mode of ["auto", "bypass", "default", "plan", "approvals", "dontask"]) {
+			const opusCfg = defClaude.configurations.find((c) => c.id === `claude-${mode}-opus`);
+			expect(opusCfg).toBeDefined();
+			expect(opusCfg!.model).toBe("opus");
+			// Sits directly after its Sonnet sibling in the main preset chain
+			expect(ids.indexOf(`claude-${mode}-opus`)).toBe(ids.indexOf(`claude-${mode}-sonnet`) + 1);
+		}
+	});
+
+	it("revives ancient stored claude-bypass-opus copies as the new Opus preset (not filtered as deprecated)", () => {
+		const defClaude = DEFAULT_AGENTS.find((a) => a.id === "builtin-claude")!;
+		const defCfg = defClaude.configurations.find((c) => c.id === "claude-bypass-opus")!;
+
+		// Shape of the pre-#381 preset that DEPRECATED_CONFIG_IDS used to filter out
+		const stored: CodingAgent[] = [
+			{
+				id: "builtin-claude",
+				name: "Claude",
+				baseCommand: "claude",
+				configurations: [
+					{ id: "claude-bypass-opus", name: "Bypass (Opus)", model: "opus[1m]", permissionMode: "bypassPermissions", version: 1 },
+				],
+				defaultConfigId: "claude-bypass-opus",
+			},
+		];
+		const result = mergeWithDefaults(stored);
+		const claude = result.find((a) => a.id === "builtin-claude")!;
+		const matches = claude.configurations.filter((c) => c.id === "claude-bypass-opus");
+
+		// Kept (no longer deprecated), not duplicated, and reset to the new preset by the version bump
+		expect(matches.length).toBe(1);
+		expect(matches[0].model).toBe("opus");
+		expect(matches[0].additionalArgs).toEqual(defCfg.additionalArgs);
+		expect(matches[0].version).toBe(defCfg.version);
+	});
+
 	it("preserves user additionalArgs when stored version == default version", () => {
 		const defCodex = DEFAULT_AGENTS.find((a) => a.id === "builtin-codex")!;
 		const defCfg = defCodex.configurations.find((c) => c.id === "codex-default")!;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -166,19 +166,27 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			// --- Fable 5 (new default) — order: Auto, Bypass, Default, then the rest ---
+			// --- Fable 5 (new default) — order: Auto, Bypass, Default, then the rest; each mode offers Fable, Sonnet, Opus ---
+			// "Opus" uses the alias model (tracks the latest Opus), like "Sonnet". Pinned generations live in the fallback blocks below.
+			// claude-bypass-opus / claude-approvals-opus reuse pre-#381 IDs at version 2 so ancient stored copies (version 1) reset cleanly.
 			{ id: "claude-auto", name: "Auto (Fable 5)", model: "claude-fable-5", permissionMode: "auto", version: 6 },
 			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
+			{ id: "claude-auto-opus", name: "Auto (Opus)", model: "opus", permissionMode: "auto", version: 1 },
 			{ id: "claude-bypass", name: "Bypass (Fable 5)", model: "claude-fable-5", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-bypass-sonnet", name: "Bypass (Sonnet)", model: "sonnet", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-bypass-opus", name: "Bypass (Opus)", model: "opus", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-default", name: "Default (Fable 5)", model: "claude-fable-5", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-default-sonnet", name: "Default (Sonnet)", model: "sonnet", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-default-opus", name: "Default (Opus)", model: "opus", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan", name: "Plan (Fable 5)", model: "claude-fable-5", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 7 },
 			{ id: "claude-plan-sonnet", name: "Plan (Sonnet)", model: "sonnet", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-plan-opus", name: "Plan (Opus)", model: "opus", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-approvals", name: "Accept Edits (Fable 5)", model: "claude-fable-5", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
+			{ id: "claude-approvals-opus", name: "Accept Edits (Opus)", model: "opus", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-dontask", name: "Don't Ask (Fable 5)", model: "claude-fable-5", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-dontask-sonnet", name: "Don't Ask (Sonnet)", model: "sonnet", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-dontask-opus", name: "Don't Ask (Opus)", model: "opus", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			// --- Opus 4.8 (previous default, kept for fallback) ---
 			{ id: "claude-default-opus48", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan-opus48", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },


### PR DESCRIPTION
## Why

Fable 5 is a great default — but I often just want Opus. Since #640 promoted Fable, Opus only survives as the pinned "Opus 4.8 / 4.7 (kept for fallback)" blocks buried at the bottom of a 24-item preset list, and those entries are version-pinned so they go stale on every model bump. Opus deserves a first-class spot next to Fable and Sonnet.

## What

- Every Claude mode (Auto, Bypass, Default, Plan, Accept Edits, Don't Ask) now has an **"(Opus)"** preset using the `opus` alias model, placed directly after its Sonnet sibling — mirroring how the Sonnet presets track the latest Sonnet.
- `claude-bypass-opus` / `claude-approvals-opus` reuse the pre-#381 config IDs, so they are removed from `DEPRECATED_CONFIG_IDS`; their `version: 2` bump resets any ancient stored copies through the normal merge path instead.
- The pinned Opus 4.8 / 4.7 fallback blocks are unchanged.

## Tests

- New merge tests: an Opus preset sits next to Fable/Sonnet for every mode; ancient stored `claude-bypass-opus` copies revive as the new preset instead of being filtered as deprecated.
- `bun run lint` + `bun run test` green (1351 bun tests).