### PR TITLE
Make button text non-selectable

### DIFF
--- a/change-logs/2026/06/12/fix-non-selectable-button-text.md
+++ b/change-logs/2026/06/12/fix-non-selectable-button-text.md
@@ -1,0 +1,1 @@
+Button labels are no longer selectable as text: a global `user-select: none` rule on `button` elements prevents accidental text highlighting when dragging the mouse across toolbar and header controls.

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -284,6 +284,13 @@ body, #root {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+/* ---- Buttons are controls, not selectable text ---- */
+
+button {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
 /* ---- Toast auto-dismiss progress bar ---- */
 
 @keyframes toast-shrink {


### PR DESCRIPTION
## Summary

- Toolbar/header button labels were selectable as text — dragging the mouse across them highlighted the label.
- Added a global `user-select: none` rule on `button` elements in `src/mainview/index.css` so button labels behave like controls, not text.
- Project/task title and other non-button text in the header remain selectable.