### PR TITLE
Add Cmd+Shift+1..9 to switch project to the opposite view

### DIFF
--- a/change-logs/2026/06/15/feature-cmd-shift-switch-opposite-view.md
+++ b/change-logs/2026/06/15/feature-cmd-shift-switch-opposite-view.md
@@ -1,0 +1,1 @@
+Added Cmd/Ctrl+Shift+1..9 to switch to a project by index and land on the opposite view of the current one — from the Kanban board you get the project's task view, from a task view you get its board. This mirrors Cmd+1..9, which preserves the current view.

--- a/decisions/068-cmd-shift-switch-opposite-view.md
+++ b/decisions/068-cmd-shift-switch-opposite-view.md
@@ -1,0 +1,37 @@
+# 068 — Cmd+Shift+1..9 switches project to the opposite view
+
+## Context
+
+`Cmd/Ctrl+1..9` switches to a project by index while *preserving* the current
+view mode (decision in `UX_DECISIONS.md`, 2026-06-03). We wanted a sibling chord
+that switches to a project but *flips* to the other view: board → task view,
+task view → board.
+
+## Decision
+
+Added a `Cmd/Ctrl+Shift+1..9` branch to the global keydown handler in
+`src/mainview/App.tsx` (right next to the `Cmd+1..9` branch). In a task view it
+navigates to `{ screen: "project", projectId }` (board); on the board it
+navigates to `{ screen: "project", projectId, taskView: true }` (split task-view
+layout with an empty terminal placeholder, the same surface Cmd+1..9 uses).
+
+## Risks
+
+- **macOS reserves Cmd+Shift+3/4/5 for screenshots.** Those combos may be
+  intercepted by the OS before reaching the renderer unless the user disabled the
+  system shortcut. Cmd+Shift+1/2 (and 6..9) are unaffected. This is an OS
+  limitation, not a bug — documented here so future agents don't chase it.
+- The split task-view empty-state is shown even for `dev3-task-open-mode =
+  fullscreen` users. This is intentional: the explicit Shift means "give me the
+  other view" and overrides the open-mode preference (unlike Cmd+1..9, which
+  respects it).
+
+## Alternatives considered
+
+- **Match the digit via `e.key`** (like the Cmd+1..9 branch): rejected. With
+  Shift held, `e.key` is the shifted symbol (`!`, `@`, …), not the digit — the
+  same reason the Cmd+Shift+` toggle keys on `e.key === "~"`. We match `e.code`
+  (`Digit1`..`Digit9`) instead, which is layout/shift independent.
+- **Respect open-mode and no-op from the board in fullscreen mode**: rejected —
+  it would make Cmd+Shift+N do nothing from the board for fullscreen users,
+  defeating the purpose of the chord.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -2,6 +2,12 @@
 
 Append-only log of UX architecture decisions. Each entry: date, decision, rationale, evidence/status.
 
+## 2026-06-15 — Cmd+Shift+1..9 switches project to the OPPOSITE view
+
+- **Decision:** Added `Cmd/Ctrl+Shift+1..9` as the mirror of `Cmd/Ctrl+1..9`. Where the unshifted chord *preserves* the current view mode, the shifted chord *flips* it: from the Kanban board it opens the target project's task view (split layout, empty-terminal placeholder, reusing the `taskView` route flag), and from a task view it opens the target project's board. Feature class is `expert_shortcut`/keyboard — no new visible controls, buttons, or tokens. Not bound in the application menu (consistent with Cmd+1..9; Electrobun can't bind chord accelerators, decision 044). Unlike Cmd+1..9, this chord intentionally ignores the `dev3-task-open-mode` preference — the explicit Shift means "give me the other view".
+- **Rationale:** Keyboard-heavy users wanted a one-chord way to reach a project *and* the other layout in a single keystroke, instead of switching then toggling the view. Mirroring the existing shortcut (Shift = inverse) is a predictable expert pattern. macOS reserves Cmd+Shift+3/4/5 for screenshots, so those indices may be swallowed by the OS — documented as a known limitation, not worked around.
+- **Status:** `Observed` (implemented: `App.tsx` Cmd+Shift+1..9 handler keyed on `e.code` Digit1..9, reuses `state.ts` `taskView` flag and `ProjectView.tsx` split empty-state; tip `cmd-shift-switch-flips-view`; decision record 068).
+
 ## 2026-06-03 — Cmd+1..9 preserves the current view mode (task-view vs board)
 
 - **Decision:** The `Cmd/Ctrl+1..9` project-switch shortcut now preserves the user's current *view mode* instead of always dropping them on the Kanban board. If the user is in a task view when they switch (split layout: `screen: "project"` with `activeTaskId`, or the full-page `screen: "task"`), the target project opens in task view too — `ActiveTasksSidebar` shows the new project's active tasks and, because no task is selected there yet, the terminal pane shows a centered empty-state: «Select a task to see its terminal». If the user is on the board (no active task), switching keeps the board. A new `taskView?: boolean` flag on the `project` route models "task-view layout with no task selected". The empty-state is a *status surface* (Toast/empty-state family), not an action — centered `text-fg-muted` text, no button (selecting a task in the sidebar fills the terminal).

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -307,6 +307,33 @@ function App() {
 					e.stopPropagation();
 					navigate({ screen: "project-terminal", projectId: route.projectId });
 				}
+			} else if ((e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && /^Digit[1-9]$/.test(e.code)) {
+				// Cmd+Shift+1..9 — switch to project by index landing on the
+				// OPPOSITE view of the current one (the mirror of Cmd+1..9, which
+				// PRESERVES the view):
+				//  - on the Kanban board  → target project's task view (split layout,
+				//                            empty terminal placeholder, no task picked).
+				//  - in a task view       → target project's Kanban board.
+				// `e.code` (not `e.key`) because Shift+digit yields the shifted symbol
+				// ("!", "@", …) in `e.key`. Open-mode is intentionally ignored here —
+				// the explicit Shift means "give me the other view" regardless of the
+				// `dev3-task-open-mode` preference. Note: macOS reserves Cmd+Shift+3/4/5
+				// for screenshots, so those may be swallowed by the OS before reaching us.
+				const idx = parseInt(e.code.slice(5), 10) - 1;
+				const available = state.projects.filter((p) => !p.deleted);
+				if (idx < available.length) {
+					e.preventDefault();
+					e.stopPropagation();
+					const { route } = state;
+					const inTaskView =
+						route.screen === "task" ||
+						(route.screen === "project" && (Boolean(route.activeTaskId) || Boolean(route.taskView)));
+					navigate(
+						inTaskView
+							? { screen: "project", projectId: available[idx].id }
+							: { screen: "project", projectId: available[idx].id, taskView: true },
+					);
+				}
 			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= "1" && e.key <= "9") {
 				// Cmd+1..9 — switch to project by index (like Slack workspaces).
 				// View-mode preservation is gated on the `dev3-task-open-mode` setting:

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -351,6 +351,86 @@ describe("App keyboard shortcuts", () => {
 		});
 	});
 
+	describe("switch project to opposite view (Cmd+Shift+1..9)", () => {
+		const twoProjects = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			{ id: "p2", name: "Beta", path: "/b", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+
+		afterEach(() => {
+			localStorage.removeItem("dev3-task-open-mode");
+		});
+
+		it("from the board: Cmd+Shift+2 switches project and opens task view", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			const before = screen.getByTestId("project-screen");
+			expect(before).toHaveAttribute("data-project-id", "p1");
+			expect(before).toHaveAttribute("data-task-view", "false");
+
+			await userEvent.keyboard("{Meta>}{Shift>}2{/Shift}{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "true");
+			expect(after).toHaveAttribute("data-active-task-id", "");
+		});
+
+		it("from a task: Cmd+Shift+2 switches project and drops to the board", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t1");
+
+			await userEvent.keyboard("{Meta>}{Shift>}2{/Shift}{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "false");
+			expect(after).toHaveAttribute("data-active-task-id", "");
+		});
+
+		it("from the full-page task screen: Cmd+Shift+2 drops to the board", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("task-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Meta>}{Shift>}2{/Shift}{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "false");
+		});
+
+		it("ignores open-mode: from the board in fullscreen mode it still opens task view", async () => {
+			localStorage.setItem("dev3-task-open-mode", "fullscreen");
+			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
+			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-task-view", "false");
+
+			await userEvent.keyboard("{Meta>}{Shift>}2{/Shift}{/Meta}");
+
+			const after = screen.getByTestId("project-screen");
+			expect(after).toHaveAttribute("data-project-id", "p2");
+			expect(after).toHaveAttribute("data-task-view", "true");
+		});
+	});
+
 	describe("Add Project modal", () => {
 		it("initializes task sound playback on mount", async () => {
 			await renderApp();

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -6,6 +6,8 @@ const tips = {
 	"tip.next": "Next tip",
 	"tip.cmdSwitchKeepsView.title": "Switch projects, keep your view",
 	"tip.cmdSwitchKeepsView.body": "Press Cmd/Ctrl+1..9 from a task view to jump to another project without leaving the task view — pick a task on the left to open its terminal.",
+	"tip.cmdShiftSwitchFlipsView.title": "Switch projects, flip the view",
+	"tip.cmdShiftSwitchFlipsView.body": "Add Shift — Cmd/Ctrl+Shift+1..9 jumps to a project and opens the opposite view: board → task view, task view → board.",
 	"tip.agentCreateTasks.title": "Agents can create tasks",
 	"tip.agentCreateTasks.body": "Just say \"create a task in dev3 about...\" in your prompt and the agent will add it to your board.",
 	"tip.agentSeesTasks.title": "Agents see your board",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -6,6 +6,8 @@ const tips = {
 	"tip.next": "Siguiente consejo",
 	"tip.cmdSwitchKeepsView.title": "Cambia de proyecto sin perder la vista",
 	"tip.cmdSwitchKeepsView.body": "Pulsa Cmd/Ctrl+1..9 en la vista de tareas para saltar a otro proyecto sin salir de la vista — elige una tarea a la izquierda para abrir su terminal.",
+	"tip.cmdShiftSwitchFlipsView.title": "Cambia de proyecto, invierte la vista",
+	"tip.cmdShiftSwitchFlipsView.body": "Añade Shift — Cmd/Ctrl+Shift+1..9 salta a un proyecto y abre la vista opuesta: tablero → vista de tareas, vista de tareas → tablero.",
 	"tip.agentCreateTasks.title": "Los agentes crean tareas",
 	"tip.agentCreateTasks.body": "Di \"crea una tarea en dev3 sobre...\" en tu prompt y el agente la agregará al tablero.",
 	"tip.agentSeesTasks.title": "Los agentes ven tu tablero",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -6,6 +6,8 @@ const tips = {
 	"tip.next": "Следующий совет",
 	"tip.cmdSwitchKeepsView.title": "Меняй проект, сохраняя вид",
 	"tip.cmdSwitchKeepsView.body": "Нажми Cmd/Ctrl+1..9 в режиме задач, чтобы перейти в другой проект, не покидая этот вид — выбери задачу слева, чтобы открыть её терминал.",
+	"tip.cmdShiftSwitchFlipsView.title": "Меняй проект, переключая вид",
+	"tip.cmdShiftSwitchFlipsView.body": "Добавь Shift — Cmd/Ctrl+Shift+1..9 переходит в проект и открывает противоположный вид: доска → режим задач, режим задач → доска.",
 	"tip.agentCreateTasks.title": "Агенты создают задачи",
 	"tip.agentCreateTasks.body": "Скажите «создай задачу в dev3 про...» в промпте — агент добавит её на доску.",
 	"tip.agentSeesTasks.title": "Агенты видят вашу доску",

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -16,6 +16,12 @@ const ALL_TIPS: Tip[] = [
 		icon: "\u{F0600}", // nf-md-keyboard
 	},
 	{
+		id: "cmd-shift-switch-flips-view",
+		titleKey: "tip.cmdShiftSwitchFlipsView.title",
+		bodyKey: "tip.cmdShiftSwitchFlipsView.body",
+		icon: "\u{F0600}", // nf-md-keyboard
+	},
+	{
 		id: "agent-create-tasks",
 		titleKey: "tip.agentCreateTasks.title",
 		bodyKey: "tip.agentCreateTasks.body",


### PR DESCRIPTION
## Summary

- Adds `Cmd/Ctrl+Shift+1..9` as the mirror of the existing `Cmd/Ctrl+1..9` project switch. Where the unshifted chord *preserves* the current view mode, the shifted chord *flips* it: from the Kanban board it opens the target project's task view (split layout, empty-terminal placeholder, reusing the `taskView` route flag); from a task view it opens the target project's board.
- Keyed on `e.code` (`Digit1`..`Digit9`) rather than `e.key`, because Shift+digit yields the shifted symbol (`!`, `@`, …) in `e.key`.
- Intentionally ignores the `dev3-task-open-mode` preference — the explicit Shift means "give me the other view".

## Notes

- macOS reserves `Cmd+Shift+3/4/5` for screenshots, so those indices may be swallowed by the OS before reaching the app. `Cmd+Shift+1/2` (and 6..9) are unaffected. Documented as a known limitation, not worked around.
- Verified against the UX manifest (`expert_shortcut`/keyboard class; no new visible controls or tokens). UX decision logged in `docs/ux/UX_DECISIONS.md`, plus decision record `068` and a feature-discovery tip.

Hi — this is Claude (the AI assistant working on this branch). Tests (`bun run test`) and type-check (`bun run lint`) are green; 4 new tests cover the shortcut.