### PR TITLE
Recover task and surface error when worktree prep fails (#629)

### DIFF
--- a/change-logs/2026/06/15/fix-worktree-prep-failure-recover.md
+++ b/change-logs/2026/06/15/fix-worktree-prep-failure-recover.md
@@ -1,0 +1,3 @@
+Fixed tasks getting stuck in-progress with a misleading "[session ended]" terminal when worktree preparation fails (empty repo or missing base branch). The task is now reverted to To Do and the real error is shown as a toast. Empty repositories also get a clearer "no commits yet" message.
+
+Suggested by @sworgkh (h0x91b/dev-3.0#629)

--- a/decisions/069-worktree-prep-failure-revert.md
+++ b/decisions/069-worktree-prep-failure-revert.md
@@ -1,0 +1,37 @@
+# 069 — Revert task to todo when background worktree prep fails
+
+## Context
+
+Issue #629: when background worktree/PTY preparation fails (empty repo, missing
+base branch), the variant/attempt flow persisted the task as `in-progress` up
+front, then `prepareTaskInBackground` only cleared the preparing spinner on
+failure. The task stayed `in-progress` with no worktree and no PTY, so the
+terminal showed a misleading dim "[session ended]" and the state survived app
+restarts. No error reached the user.
+
+## Decision
+
+In `prepareTaskInBackground`'s catch block (`src/bun/rpc-handlers/task-lifecycle.ts`)
+a genuine (non-cancellation) failure now calls `revertPreparingTaskToTodo` —
+the same cleanup the cancellation path uses — moving the task back to `todo`,
+removing any half-created worktree, and releasing ports. It then pushes a new
+`taskPreparationFailed` message (schema in `src/shared/types.ts`), which the
+renderer (`App.tsx`) surfaces as a `toast.error`, mirroring `columnAgentFailed`.
+
+Separately, `git.createWorktree` now distinguishes an empty repository
+(no commits) from a missing base branch and gives a "no commits yet" message.
+
+## Risks
+
+Reverting to `todo` is per-task, so a failed variant in a group lands in `todo`
+while siblings may succeed — acceptable and recoverable. The drag-drop launch
+path (`moveTask`) was already safe (renderer reverts optimistic update on throw);
+this change targets only the fire-and-forget background prep path.
+
+## Alternatives considered
+
+- Keep the task `in-progress` and add a persisted `preparationError` field shown
+  in the card/terminal — more invasive (new state, UI), and still leaves the task
+  in a column where it can't run. Rejected.
+- Only push a toast without reverting — leaves the strand (still `in-progress`,
+  still "[session ended]"). Rejected.

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -530,7 +530,7 @@ describe("createWorktree edge cases", () => {
 		}
 	});
 
-	it("throws when repo has no commits at all", async () => {
+	it("throws a clear empty-repo error when repo has no commits at all", async () => {
 		const r = createEmptyRepo();
 		try {
 			const project = makeProject(r.local);
@@ -538,8 +538,11 @@ describe("createWorktree edge cases", () => {
 				id: "33333333-4444-5555-6666-777777777777",
 			});
 
+			// Empty repos get an empty-repo-specific message (create an initial
+			// commit), not the generic "branch does not exist" guidance which
+			// misleads the user into changing their base-branch setting.
 			await expect(createWorktree(project, task)).rejects.toThrow(
-				'Branch "main" does not exist',
+				/no commits yet/i,
 			);
 		} finally {
 			cleanupLocal(r);

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2611,17 +2611,20 @@ describe("handlers.spawnVariants", () => {
 		});
 	});
 
-	it("clears preparing when project config resolution fails before variant setup starts", async () => {
+	it("reverts variant to todo and notifies when project config resolution fails before setup starts", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({ status: "todo", seq: 5 });
 		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true });
-		const unstuckVariant = makeTask({ id: "variant-1", status: "in-progress", preparing: false, preparingStage: null, preparingProgress: null });
+		const revertedVariant = makeTask({ id: "variant-1", status: "todo", preparing: false, preparingStage: null, preparingProgress: null });
 
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
 		vi.mocked(data.addTask).mockResolvedValue(variantTask);
-		vi.mocked(data.updateTask).mockResolvedValue(unstuckVariant);
+		vi.mocked(data.updateTask).mockResolvedValue(revertedVariant);
 		vi.mocked(repoConfig.resolveProjectConfig).mockRejectedValueOnce(new Error("bad repo config"));
+
+		const push = vi.fn();
+		setPushMessage(push);
 
 		await handlers.spawnVariants({
 			taskId: "task-1",
@@ -2631,28 +2634,31 @@ describe("handlers.spawnVariants", () => {
 		});
 
 		await vi.waitFor(() => {
-			expect(data.updateTask).toHaveBeenCalledWith(project, "variant-1", {
-				preparing: false,
-				preparingStage: null,
-				preparingProgress: null,
-				preparingStartedAt: null,
-			});
+			expect(data.updateTask).toHaveBeenCalledWith(
+				project,
+				"variant-1",
+				expect.objectContaining({ status: "todo", preparing: false, worktreePath: null, branchName: null }),
+			);
 		});
+
+		const failedEvent = push.mock.calls.find((c) => c[0] === "taskPreparationFailed");
+		expect(failedEvent?.[1]).toMatchObject({ taskId: "variant-1", projectId: project.id });
+		expect(String(failedEvent?.[1].error)).toContain("bad repo config");
 
 		expect(git.createWorktree).not.toHaveBeenCalled();
 	});
 
-	it("clears preparing when PTY launch fails after the worktree is created", async () => {
+	it("reverts variant to todo and cleans up the worktree when PTY launch fails after the worktree is created", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({ status: "todo", seq: 5 });
 		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true });
-		const unstuckVariant = makeTask({ id: "variant-1", status: "in-progress", preparing: false, preparingStage: null, preparingProgress: null });
+		const revertedVariant = makeTask({ id: "variant-1", status: "todo", preparing: false, preparingStage: null, preparingProgress: null });
 
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
 		vi.mocked(data.addTask).mockResolvedValue(variantTask);
 		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/vwt", branchName: "dev3/v1" });
-		vi.mocked(data.updateTask).mockResolvedValue(unstuckVariant);
+		vi.mocked(data.updateTask).mockResolvedValue(revertedVariant);
 		vi.mocked(pty.createSession).mockImplementationOnce(() => {
 			throw new Error("pty boom");
 		});
@@ -2665,13 +2671,14 @@ describe("handlers.spawnVariants", () => {
 		});
 
 		await vi.waitFor(() => {
-			expect(data.updateTask).toHaveBeenCalledWith(project, "variant-1", {
-				preparing: false,
-				preparingStage: null,
-				preparingProgress: null,
-				preparingStartedAt: null,
-			});
+			expect(data.updateTask).toHaveBeenCalledWith(
+				project,
+				"variant-1",
+				expect.objectContaining({ status: "todo", preparing: false, worktreePath: null, branchName: null }),
+			);
 		});
+		// The half-created worktree must be cleaned up, not left dangling.
+		expect(git.removeWorktree).toHaveBeenCalled();
 	});
 
 	it("uses worktree-resolved sparse checkout and clone paths while preparing variants", async () => {
@@ -2992,7 +2999,7 @@ describe("handlers.addAttempts", () => {
 		);
 	});
 
-	it("clears preparing when project config resolution fails before attempt setup starts", async () => {
+	it("reverts attempt to todo and notifies when project config resolution fails before setup starts", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({ status: "in-progress", seq: 5, groupId: "group-1", variantIndex: 1 });
 		const attemptTask = makeTask({
@@ -3002,9 +3009,9 @@ describe("handlers.addAttempts", () => {
 			variantIndex: 2,
 			preparing: true,
 		});
-		const unstuckAttempt = makeTask({
+		const revertedAttempt = makeTask({
 			id: "attempt-2",
-			status: "in-progress",
+			status: "todo",
 			groupId: "group-1",
 			variantIndex: 2,
 			preparing: false,
@@ -3018,8 +3025,11 @@ describe("handlers.addAttempts", () => {
 			.mockResolvedValueOnce(sourceTask);
 		vi.mocked(data.loadTasks).mockResolvedValue([sourceTask]);
 		vi.mocked(data.addTask).mockResolvedValue(attemptTask);
-		vi.mocked(data.updateTask).mockResolvedValue(unstuckAttempt);
+		vi.mocked(data.updateTask).mockResolvedValue(revertedAttempt);
 		vi.mocked(repoConfig.resolveProjectConfig).mockRejectedValueOnce(new Error("bad repo config"));
+
+		const push = vi.fn();
+		setPushMessage(push);
 
 		await handlers.addAttempts({
 			taskId: "task-1",
@@ -3027,19 +3037,26 @@ describe("handlers.addAttempts", () => {
 			variants: [{ agentId: "agent-1", configId: null }],
 		});
 
+		// A failed preparation must not strand the task in-progress: it is moved
+		// back to todo (status: "todo", worktree/branch cleared).
 		await vi.waitFor(() => {
-			expect(data.updateTask).toHaveBeenCalledWith(project, "attempt-2", {
-				preparing: false,
-				preparingStage: null,
-				preparingProgress: null,
-				preparingStartedAt: null,
-			});
+			expect(data.updateTask).toHaveBeenCalledWith(
+				project,
+				"attempt-2",
+				expect.objectContaining({ status: "todo", preparing: false, worktreePath: null, branchName: null }),
+			);
 		});
+
+		// The real error is surfaced to the renderer as a toast.
+		const failedEvent = push.mock.calls.find((c) => c[0] === "taskPreparationFailed");
+		expect(failedEvent).toBeDefined();
+		expect(failedEvent?.[1]).toMatchObject({ taskId: "attempt-2", projectId: project.id });
+		expect(String(failedEvent?.[1].error)).toContain("bad repo config");
 
 		expect(git.createWorktree).not.toHaveBeenCalled();
 	});
 
-	it("keeps preparing isolated per attempt when one attempt fails and another succeeds", async () => {
+	it("reverts only the failed attempt to todo while a sibling attempt succeeds", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({ status: "in-progress", seq: 5, groupId: "group-1", variantIndex: 1 });
 		const firstAttempt = makeTask({
@@ -3068,17 +3085,10 @@ describe("handlers.addAttempts", () => {
 		vi.mocked(git.createWorktree)
 			.mockRejectedValueOnce(new Error("wt boom"))
 			.mockResolvedValueOnce({ worktreePath: "/tmp/attempt-3", branchName: "dev3/a3" });
-		vi.mocked(data.updateTask)
-			.mockResolvedValueOnce({ ...firstAttempt, preparing: false, preparingStage: null, preparingProgress: null })
-			.mockResolvedValueOnce({
-				...secondAttempt,
-				worktreePath: "/tmp/attempt-3",
-				branchName: "dev3/a3",
-				preparing: false,
-				preparingStage: null,
-				preparingProgress: null,
-				preparingStartedAt: null,
-			});
+		vi.mocked(data.updateTask).mockImplementation(async (_p, id, updates) => {
+			if (id === "attempt-2") return { ...firstAttempt, ...updates } as typeof firstAttempt;
+			return { ...secondAttempt, ...updates } as typeof secondAttempt;
+		});
 
 		await handlers.addAttempts({
 			taskId: "task-1",
@@ -3092,12 +3102,13 @@ describe("handlers.addAttempts", () => {
 		await vi.waitFor(() => {
 			expect(git.createWorktree).toHaveBeenCalledTimes(2);
 		});
-		expect(data.updateTask).toHaveBeenCalledWith(project, "attempt-2", {
-			preparing: false,
-			preparingStage: null,
-			preparingProgress: null,
-			preparingStartedAt: null,
-		});
+		// Failed attempt → reverted to todo.
+		expect(data.updateTask).toHaveBeenCalledWith(
+			project,
+			"attempt-2",
+			expect.objectContaining({ status: "todo", preparing: false, worktreePath: null, branchName: null }),
+		);
+		// Succeeded attempt → stays in-progress with its worktree.
 		expect(data.updateTask).toHaveBeenCalledWith(project, "attempt-3", {
 			worktreePath: "/tmp/attempt-3",
 			branchName: "dev3/a3",

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -755,6 +755,18 @@ export async function createWorktree(
 	if (!refCheckResult.ok) {
 		const localCheck = await run(["git", "rev-parse", "--verify", baseBranch], project.path);
 		if (!localCheck.ok) {
+			// An empty repository (no commits at all) needs a different fix —
+			// create an initial commit — than a repo that simply lacks the
+			// configured base branch (fix the base-branch setting). The generic
+			// "branch does not exist" message misleads in the empty-repo case.
+			const hasAnyCommit = (await run(["git", "rev-parse", "--verify", "HEAD"], project.path)).ok;
+			if (!hasAnyCommit) {
+				log.error("Repository has no commits", { baseBranch, taskId: task.id });
+				throw new Error(
+					`Repository has no commits yet, so there is no "${baseBranch}" branch to start from. ` +
+					`Create an initial commit in the repository before starting a task.`,
+				);
+			}
 			log.error("Base branch does not exist", { baseBranch, taskId: task.id });
 			throw new Error(
 				`Branch "${baseBranch}" does not exist locally or on the remote. ` +

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { ColumnAgentConfig, CustomColumn, PreparingStage, Project, Task, TaskStatus } from "../../shared/types";
-import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, getPreparingStageProgress, titleFromDescription } from "../../shared/types";
+import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, getPreparingStageProgress, getTaskTitle, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
@@ -329,11 +329,25 @@ async function prepareTaskInBackground(
 			});
 			try {
 				if (isTaskPreparationActive(task.id, runId)) {
-					const updated = await data.updateTask(project, task.id, clearPreparingState());
-					getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+					// Don't strand the task in its active column with no worktree and no
+					// PTY — that surfaces as a misleading "[session ended]" terminal and
+					// survives app restarts. Move it back to todo (cleaning up any
+					// half-created worktree) so it is recoverable, and surface the real
+					// preparation error to the renderer as a toast.
+					const reverted = await revertPreparingTaskToTodo(project, task);
+					getPushMessage()?.("taskPreparationFailed", {
+						taskId: task.id,
+						projectId: project.id,
+						taskTitle: getTaskTitle(reverted),
+						error: err instanceof Error ? err.message : String(err),
+					});
 				}
-			} catch {
-				// Best effort — the original error is already logged.
+			} catch (revertErr) {
+				log.error("Failed to revert task after preparation failure", {
+					taskId: task.id.slice(0, 8),
+					runId,
+					error: String(revertErr),
+				});
 			}
 		}
 	}, (stage) => pushPreparingStage(project, task.id, stage));

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -692,6 +692,23 @@ function App() {
 		return () => window.removeEventListener("rpc:columnAgentFailed", onColumnAgentFailed);
 	}, []);
 
+	// Notify user when background worktree/PTY preparation fails (e.g. empty repo,
+	// missing base branch). The task is reverted to todo on the backend; surface
+	// the real error so the user isn't left with a misleading "[session ended]".
+	useEffect(() => {
+		function onTaskPreparationFailed(e: Event) {
+			const { taskTitle, error } = (e as CustomEvent).detail as {
+				taskId: string;
+				projectId: string;
+				taskTitle: string;
+				error: string;
+			};
+			toast.error(t("kanban.taskPreparationFailed", { taskTitle, error }));
+		}
+		window.addEventListener("rpc:taskPreparationFailed", onTaskPreparationFailed);
+		return () => window.removeEventListener("rpc:taskPreparationFailed", onTaskPreparationFailed);
+	}, []);
+
 	// Listen for update download progress (minimum 5s display time)
 	useEffect(() => {
 		const MIN_DISPLAY_MS = 5_000;

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -6,6 +6,7 @@ const kanban = {
 	"kanban.newTask": "+ New Task",
 	"kanban.failedCreate": "Failed to create task: {error}",
 	"kanban.columnAgentFailed": "Column agent failed to launch for \"{columnName}\": {error}",
+	"kanban.taskPreparationFailed": "Couldn't prepare \"{taskTitle}\" — moved back to To Do: {error}",
 	"kanban.failedReorderColumns": "Failed to reorder columns: {error}",
 	"kanban.showMore": "Show more ({count})",
 	"kanban.showLess": "Show less",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -6,6 +6,7 @@ const kanban = {
 	"kanban.newTask": "+ Nueva tarea",
 	"kanban.failedCreate": "Error al crear tarea: {error}",
 	"kanban.columnAgentFailed": "No se pudo iniciar el agente de la columna \"{columnName}\": {error}",
+	"kanban.taskPreparationFailed": "No se pudo preparar \"{taskTitle}\" — devuelta a Por hacer: {error}",
 	"kanban.failedReorderColumns": "No se pudo reordenar las columnas: {error}",
 	"kanban.showMore": "Mostrar más ({count})",
 	"kanban.showLess": "Mostrar menos",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -6,6 +6,7 @@ const kanban = {
 	"kanban.newTask": "+ Новая задача",
 	"kanban.failedCreate": "Не удалось создать задачу: {error}",
 	"kanban.columnAgentFailed": "Не удалось запустить агента для колонки «{columnName}»: {error}",
+	"kanban.taskPreparationFailed": "Не удалось подготовить «{taskTitle}» — задача возвращена в To Do: {error}",
 	"kanban.failedReorderColumns": "Не удалось изменить порядок колонок: {error}",
 	"kanban.showMore": "Показать ещё ({count})",
 	"kanban.showLess": "Свернуть",

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -19,6 +19,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	resourceUsageUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:resourceUsageUpdated", { detail: payload })),
 	updateDownloadProgress: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateDownloadProgress", { detail: payload })),
 	columnAgentFailed: (payload) => window.dispatchEvent(new CustomEvent("rpc:columnAgentFailed", { detail: payload })),
+	taskPreparationFailed: (payload) => window.dispatchEvent(new CustomEvent("rpc:taskPreparationFailed", { detail: payload })),
 	openTaskFromNotification: (payload) => window.dispatchEvent(new CustomEvent("rpc:openTaskFromNotification", { detail: payload })),
 	openCreateTaskModal: () => window.dispatchEvent(new CustomEvent("rpc:openCreateTaskModal")),
 	navigateToSettings: () => window.dispatchEvent(new CustomEvent("rpc:navigateToSettings")),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1657,6 +1657,13 @@ export type AppRPCSchema = {
 			/** Emitted when a column-agent launch fails (custom columns have no automatic fallback). */
 			columnAgentFailed: { taskId: string; projectId: string; columnName: string; error: string };
 			/**
+			 * Emitted when background worktree/PTY preparation for a task fails (e.g.
+			 * empty repo, missing base branch). The task is reverted to todo so it is
+			 * recoverable; the renderer surfaces this as a toast instead of leaving a
+			 * misleading "[session ended]" terminal.
+			 */
+			taskPreparationFailed: { taskId: string; projectId: string; taskTitle: string; error: string };
+			/**
 			 * Emitted when the main window gains focus shortly after a watched-task notification fired.
 			 * The renderer navigates to the referenced task — implements click-to-open for native notifications.
 			 */


### PR DESCRIPTION
## Summary

Fixes #629. When background worktree/PTY preparation failed (empty repo with no commits, or a configured base branch that doesn't exist), the task was left stranded in `in-progress` with no worktree and no PTY. The terminal showed a misleading dim "[session ended]", the state survived app restarts, and no error reached the user.

- `prepareTaskInBackground` now reverts the task to `todo` via `revertPreparingTaskToTodo` on a genuine prep failure (cleaning up any half-created worktree and releasing ports) instead of only clearing the preparing spinner.
- New `taskPreparationFailed` push message → the renderer surfaces the real error as a `toast.error` (mirrors the existing `columnAgentFailed` pattern); i18n added for en/ru/es.
- `git.createWorktree` now distinguishes an empty repository (no commits) from a missing base branch and returns a clearer "no commits yet — create an initial commit" message.
- The drag-drop launch path (`moveTask`) was already safe (renderer reverts the optimistic update on throw); this change targets the fire-and-forget background prep path used by Launch Variants / Add Attempts.

Reproduce-first: updated the empty-repo test in `git-worktree.test.ts` and rewrote the four prep-failure tests in `rpc-handlers.test.ts` to assert revert-to-todo + the new push event. `bun run lint` and `bun run test` are green.

Reported by @sworgkh.

Decision record: `decisions/069-worktree-prep-failure-revert.md`.