### PR TITLE
Fix flaky configureTmux timeout tests with vi.waitFor

### DIFF
--- a/change-logs/2026/06/15/fix-flaky-pty-server-configuretmux-tests.md
+++ b/change-logs/2026/06/15/fix-flaky-pty-server-configuretmux-tests.md
@@ -1,0 +1,1 @@
+Fixed flaky pty-server configureTmux timeout tests by replacing fixed two-microtask flushes with vi.waitFor polling, so assertions no longer depend on the exact async promise-chain depth under CI load. Test-only change; production code untouched.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -827,8 +827,12 @@ describe("pty-server", () => {
 			mockSpawn.mockClear();
 
 			await vi.advanceTimersByTimeAsync(200);
-			await Promise.resolve();
-			await Promise.resolve();
+			await vi.waitFor(() => {
+				const call = mockSpawn.mock.calls.find(
+					(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
+				);
+				expect(call).toBeDefined();
+			});
 
 			// configureTmux now uses async `spawn` rather than `spawnSync`.
 			const sourceCall = mockSpawn.mock.calls.find(
@@ -850,8 +854,12 @@ describe("pty-server", () => {
 			mockSpawn.mockClear();
 
 			await vi.advanceTimersByTimeAsync(200);
-			await Promise.resolve();
-			await Promise.resolve();
+			await vi.waitFor(() => {
+				const call = mockSpawn.mock.calls.find(
+					(c) => Array.isArray(c[0]) && c[0].includes("set-environment") && c[0].includes("PATH") && !c[0].includes("DEV3_WORKTREE_ROOT"),
+				);
+				expect(call).toBeDefined();
+			});
 
 			const envCall = mockSpawn.mock.calls.find(
 				(c) => Array.isArray(c[0]) && c[0].includes("set-environment") && c[0].includes("PATH") && !c[0].includes("DEV3_WORKTREE_ROOT"),
@@ -871,8 +879,12 @@ describe("pty-server", () => {
 			mockSpawn.mockClear();
 
 			await vi.advanceTimersByTimeAsync(200);
-			await Promise.resolve();
-			await Promise.resolve();
+			await vi.waitFor(() => {
+				const call = mockSpawn.mock.calls.find(
+					(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
+				);
+				expect(call).toBeDefined();
+			});
 
 			const sourceCall = mockSpawn.mock.calls.find(
 				(c) => Array.isArray(c[0]) && c[0].includes("source-file"),


### PR DESCRIPTION
## Summary

The three "after timeout" cases in the `configureTmux via spawnPty` describe block (`src/bun/__tests__/pty-server.test.ts`) were flaky on CI. They hard-coded the async promise-chain depth — after `vi.advanceTimersByTimeAsync(200)` they flushed exactly two microtasks via `await Promise.resolve()` twice. The production code schedules a `setTimeout(...,200)` that kicks off `configureTmux()` → two awaited `spawn` exits → a `set-environment` loop, so under CI load two fixed ticks weren't always enough and the asserted `spawn` call hadn't been recorded yet.

This replaces the fixed flush pairs with `vi.waitFor`, which pumps microtasks and retries until the expected `spawn` call appears, removing the dependency on the exact tick count. Production code (`src/bun/pty-server.ts`) is untouched.

- Test-only change across the three affected tests
- `bun run test:bun` green 3/3 consecutive runs (1443 passed)
- `bun run lint` clean

This is an AI-authored change (Claude, the AI assistant working on this branch).