### PR TITLE
Fix frozen "Did you know?" tip rotation (stale closure)

### DIFF
--- a/change-logs/2026/06/15/fix-frozen-tip-rotation.md
+++ b/change-logs/2026/06/15/fix-frozen-tip-rotation.md
@@ -1,0 +1,1 @@
+Fixed the "Did you know?" tip card never rotating: the 60s rotation timer captured a stale (null) tipState in its closure, so it rescheduled forever and never marked tips seen. The timer now reads the latest tip state via refs, so tips rotate and the seen-cooldown is recorded.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -70,6 +70,12 @@ function KanbanBoard({
 	const draggedColumnIdRef = useRef<string | null>(null);
 	const [tipState, setTipState] = useState<TipState | null>(null);
 	const currentTip = useMemo(() => tipState ? selectTip(tipState) : null, [tipState]);
+	// Mirror tipState/currentTip in refs so the rotation timer reads the latest
+	// values instead of the (null) closure captured when the effect first ran.
+	const tipStateRef = useRef<TipState | null>(null);
+	const currentTipRef = useRef(currentTip);
+	useEffect(() => { tipStateRef.current = tipState; }, [tipState]);
+	useEffect(() => { currentTipRef.current = currentTip; }, [currentTip]);
 	const collapseState = useColumnCollapse(project.id);
 
 	// PR numbers for task cards: taskId → { number, url }
@@ -89,13 +95,15 @@ function KanbanBoard({
 		function scheduleRotation() {
 			tipTimerRef.current = setTimeout(() => {
 				if (!tipMountedRef.current) return;
-				if (!tipState) {
+				const state = tipStateRef.current;
+				if (!state) {
 					scheduleRotation();
 					return;
 				}
+				const tip = currentTipRef.current;
 				api.request.updateTipState({
-					seen: currentTip ? { [currentTip.id]: Date.now() } : {},
-					rotationIndex: (tipState?.rotationIndex ?? 0) + 1,
+					seen: tip ? { [tip.id]: Date.now() } : {},
+					rotationIndex: state.rotationIndex + 1,
 				}).then((state) => {
 					if (!tipMountedRef.current) return;
 					setTipState(state);

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -1,7 +1,9 @@
 import { act, render, screen } from "@testing-library/react";
 import KanbanBoard from "../KanbanBoard";
 import { I18nProvider } from "../../i18n";
-import type { CustomColumn, Project } from "../../../shared/types";
+import { api } from "../../rpc";
+import { ROTATION_INTERVAL_MS } from "../../tips";
+import type { CustomColumn, Project, TipState } from "../../../shared/types";
 
 vi.mock("../../rpc", () => ({
 	api: {
@@ -282,6 +284,82 @@ describe("column ordering", () => {
 		const betaIdx = newOrder.indexOf("col-b");
 		// Alpha moved after Beta
 		expect(alphaIdx).toBeGreaterThan(betaIdx);
+	});
+});
+
+describe("tip rotation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.clear();
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function renderForRotation() {
+		await act(async () => {
+			render(
+				<I18nProvider>
+					<KanbanBoard
+						project={project}
+						tasks={[]}
+						dispatch={vi.fn()}
+						navigate={vi.fn()}
+						bellCounts={new Map()}
+						taskPorts={new Map()}
+					/>
+				</I18nProvider>,
+			);
+		});
+		// Flush async getTipState / getGlobalSettings before the first timer fires.
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+	}
+
+	it("rotates tips every ROTATION_INTERVAL_MS with an advancing rotationIndex", async () => {
+		const getTipState = vi.mocked(api.request.getTipState);
+		const updateTipState = vi.mocked(api.request.updateTipState);
+		getTipState.mockResolvedValue({ snoozedUntil: 0, seen: {}, rotationIndex: 0 });
+		// Echo params back so setTipState advances the persisted rotationIndex.
+		updateTipState.mockImplementation((params: Partial<TipState>) =>
+			Promise.resolve({ snoozedUntil: 0, seen: {}, rotationIndex: 0, ...params } as TipState),
+		);
+
+		await renderForRotation();
+
+		// First rotation tick.
+		await act(async () => { await vi.advanceTimersByTimeAsync(ROTATION_INTERVAL_MS); });
+		expect(updateTipState).toHaveBeenCalledTimes(1);
+		expect(updateTipState.mock.calls[0][0].rotationIndex).toBe(1);
+
+		// Second rotation tick — index must keep advancing, not stick.
+		await act(async () => { await vi.advanceTimersByTimeAsync(ROTATION_INTERVAL_MS); });
+		expect(updateTipState).toHaveBeenCalledTimes(2);
+		expect(updateTipState.mock.calls[1][0].rotationIndex).toBe(2);
+	});
+
+	it("persists TipState with the unchanged shape (seen[tipId]=timestamp, advancing rotationIndex)", async () => {
+		const getTipState = vi.mocked(api.request.getTipState);
+		const updateTipState = vi.mocked(api.request.updateTipState);
+		getTipState.mockResolvedValue({ snoozedUntil: 0, seen: {}, rotationIndex: 0 });
+		updateTipState.mockImplementation((params: Partial<TipState>) =>
+			Promise.resolve({ snoozedUntil: 0, seen: {}, rotationIndex: 0, ...params } as TipState),
+		);
+
+		await renderForRotation();
+		await act(async () => { await vi.advanceTimersByTimeAsync(ROTATION_INTERVAL_MS); });
+
+		expect(updateTipState).toHaveBeenCalledTimes(1);
+		const payload = updateTipState.mock.calls[0][0];
+		// Only the two writable keys are sent — no new/renamed fields that an older version can't read.
+		expect(Object.keys(payload).sort()).toEqual(["rotationIndex", "seen"]);
+		expect(payload.rotationIndex).toBe(1);
+		// seen maps a tip id → a numeric timestamp.
+		const seenEntries = Object.entries(payload.seen ?? {});
+		expect(seenEntries.length).toBe(1);
+		const [tipId, ts] = seenEntries[0];
+		expect(typeof tipId).toBe("string");
+		expect(typeof ts).toBe("number");
 	});
 });
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this PR).

## Summary
- The KanbanBoard tip rotation timer captured `tipState`/`currentTip` in its closure at effect-run time, when `tipState` was still `null` (it loads asynchronously). Every 60s tick hit `if (!tipState)` and just rescheduled, so tips never rotated and the 3-day `seen` cooldown was never persisted.
- Fix mirrors `tipState` and `currentTip` in refs that the timer reads at fire time, so rotation advances and `seen[tipId]=timestamp` is recorded. Renderer-logic only.
- The persisted `TipState` shape and the `updateTipState` RPC contract are unchanged, so a downgrade to a previous version stays safe.
- Added two fake-timer repro tests in `KanbanBoard.test.tsx` (`tip rotation`): one asserts an advancing `rotationIndex`, one pins the unchanged persisted shape. Both were red before the fix.

`bun run lint` clean; full `bun run test` green (1386 + 1393).