### PR TITLE
Record task title/overview change history

### DIFF
--- a/change-logs/2026/06/16/feature-task-title-overview-history.md
+++ b/change-logs/2026/06/16/feature-task-title-overview-history.md
@@ -1,0 +1,1 @@
+Tasks now keep an append-only history of their title and overview as they change over time, recorded automatically in the data layer (seeded at creation, updated whenever the displayed title or overview changes). Not shown in the UI yet — stored for a future history view and search.

--- a/src/bun/__tests__/data-history.test.ts
+++ b/src/bun/__tests__/data-history.test.ts
@@ -87,7 +87,7 @@ describe("task title/overview history", () => {
 		const task = await addTask(testProject, "Task");
 		await updateTask(testProject, task.id, { overview: "agent overview" });
 		const updated = await updateTask(testProject, task.id, { userOverview: "user overview" });
-		expect(updated.history!.at(-1)).toMatchObject({
+		expect(updated.history![updated.history!.length - 1]).toMatchObject({
 			overview: "user overview",
 			changed: "overview",
 		});

--- a/src/bun/__tests__/data-history.test.ts
+++ b/src/bun/__tests__/data-history.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import type { Project } from "../../shared/types";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test-history",
+}));
+
+vi.mock("../file-lock", () => ({
+	withFileLock: async <T>(_filePath: string, fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+beforeEach(() => {
+	rmSync("/tmp/dev3-test-history", { recursive: true, force: true });
+	mkdirSync("/tmp/dev3-test-history", { recursive: true });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+import { addTask, updateTask } from "../data";
+
+const testProject: Project = {
+	id: "proj-1",
+	name: "Test",
+	path: "/tmp/test-project",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-01T00:00:00Z",
+};
+
+describe("task title/overview history", () => {
+	it("seeds a 'created' entry capturing the initial title", async () => {
+		const task = await addTask(testProject, "Fix the login flow");
+		expect(task.history).toHaveLength(1);
+		expect(task.history![0]).toMatchObject({
+			title: "Fix the login flow",
+			overview: null,
+			changed: "created",
+		});
+		expect(typeof task.history![0].at).toBe("string");
+	});
+
+	it("appends an entry when the overview changes", async () => {
+		const task = await addTask(testProject, "Build feature");
+		const updated = await updateTask(testProject, task.id, { overview: "Working on the parser" });
+		expect(updated.history).toHaveLength(2);
+		expect(updated.history![1]).toMatchObject({
+			title: "Build feature",
+			overview: "Working on the parser",
+			changed: "overview",
+		});
+	});
+
+	it("appends an entry when the custom title changes", async () => {
+		const task = await addTask(testProject, "Some long auto generated description");
+		const updated = await updateTask(testProject, task.id, { customTitle: "Short title" });
+		expect(updated.history).toHaveLength(2);
+		expect(updated.history![1]).toMatchObject({
+			title: "Short title",
+			changed: "title",
+		});
+	});
+
+	it("records 'both' when title and overview change together", async () => {
+		const task = await addTask(testProject, "Initial");
+		const updated = await updateTask(testProject, task.id, {
+			customTitle: "Renamed",
+			overview: "New overview",
+		});
+		expect(updated.history![1]).toMatchObject({ changed: "both", title: "Renamed", overview: "New overview" });
+	});
+
+	it("uses the user override as the effective overview", async () => {
+		const task = await addTask(testProject, "Task");
+		await updateTask(testProject, task.id, { overview: "agent overview" });
+		const updated = await updateTask(testProject, task.id, { userOverview: "user overview" });
+		expect(updated.history!.at(-1)).toMatchObject({
+			overview: "user overview",
+			changed: "overview",
+		});
+	});
+
+	it("does not append an entry for status-only changes", async () => {
+		const task = await addTask(testProject, "Task");
+		const updated = await updateTask(testProject, task.id, { status: "in-progress" });
+		expect(updated.history).toHaveLength(1);
+	});
+
+	it("does not append an entry when the effective overview is unchanged", async () => {
+		const task = await addTask(testProject, "Task");
+		await updateTask(testProject, task.id, { userOverview: "pinned" });
+		// Agent rewrites the hidden overview — effective value stays "pinned".
+		const updated = await updateTask(testProject, task.id, { overview: "hidden agent text" });
+		const overviewEntries = updated.history!.filter((entry) => entry.changed !== "created");
+		expect(overviewEntries).toHaveLength(1);
+		expect(overviewEntries[0].overview).toBe("pinned");
+	});
+
+	it("keeps a chronological, append-only log across several edits", async () => {
+		const task = await addTask(testProject, "v1");
+		await updateTask(testProject, task.id, { customTitle: "v2" });
+		await updateTask(testProject, task.id, { overview: "o1" });
+		const updated = await updateTask(testProject, task.id, { customTitle: "v3" });
+		expect(updated.history!.map((entry) => entry.changed)).toEqual(["created", "title", "overview", "title"]);
+		expect(updated.history!.map((entry) => entry.title)).toEqual(["v1", "v2", "v2", "v3"]);
+	});
+});

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
-import type { Project, Task, TaskStatus, TipState } from "../shared/types";
-import { titleFromDescription } from "../shared/types";
+import type { Project, Task, TaskHistoryChange, TaskHistoryEntry, TaskStatus, TipState } from "../shared/types";
+import { getTaskOverview, getTaskTitle, titleFromDescription } from "../shared/types";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
 import { detectClonePaths } from "./cow-clone";
@@ -405,6 +405,7 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 			if ((task as any).customColumnId === undefined) task.customColumnId = null;
 			if ((task as any).overview === undefined) task.overview = null;
 			if ((task as any).userOverview === undefined) task.userOverview = null;
+				if ((task as any).history === undefined) task.history = [];
 		}
 
 		// Backfill seq for tasks created before seq existed
@@ -571,6 +572,7 @@ export async function addTask(
 			...(extras?.customTitle ? { customTitle: extras.customTitle } : {}),
 			...(extras?.titleEditedByUser ? { titleEditedByUser: true } : {}),
 		};
+		task.history = [{ at: now, title: getTaskTitle(task), overview: getTaskOverview(task), changed: "created" }];
 		tasks.push(task);
 		await rawSaveTasks(project, tasks);
 		log.info("Task created", { taskId: task.id, seq: task.seq, title });
@@ -673,6 +675,8 @@ function applyTaskUpdate(
 	}
 	const now = new Date().toISOString();
 	const statusChanged = updates.status && updates.status !== currentTask.status;
+	const prevTitle = getTaskTitle(currentTask);
+	const prevOverview = getTaskOverview(currentTask);
 
 	if (statusChanged) {
 		const newStatus = updates.status!;
@@ -707,7 +711,31 @@ function applyTaskUpdate(
 		tasks[idx] = { ...tasks[idx], ...updates, updatedAt: now };
 	}
 
+	recordTitleOverviewHistory(tasks, idx, prevTitle, prevOverview, now);
+
 	return tasks[idx];
+}
+
+/**
+ * Append a snapshot to the task's history when its effective (displayed) title
+ * or overview changed. Each entry captures both values so it stands alone. No
+ * entry is written when neither changed (e.g. status-only moves).
+ */
+function recordTitleOverviewHistory(
+	tasks: Task[],
+	idx: number,
+	prevTitle: string,
+	prevOverview: string | null,
+	now: string,
+): void {
+	const nextTitle = getTaskTitle(tasks[idx]);
+	const nextOverview = getTaskOverview(tasks[idx]);
+	const titleChanged = nextTitle !== prevTitle;
+	const overviewChanged = nextOverview !== prevOverview;
+	if (!titleChanged && !overviewChanged) return;
+	const changed: TaskHistoryChange = titleChanged && overviewChanged ? "both" : titleChanged ? "title" : "overview";
+	const entry: TaskHistoryEntry = { at: now, title: nextTitle, overview: nextOverview, changed };
+	tasks[idx] = { ...tasks[idx], history: [...(tasks[idx].history ?? []), entry] };
 }
 
 function isInSameRenderedColumn(task: Task, status: string, customColumnId: string | null | undefined): boolean {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -613,6 +613,14 @@ export interface Task {
 	existingBranch?: string | null;
 	notes?: TaskNote[];
 	customColumnId?: string | null;
+	/**
+	 * Append-only log of the task's title/overview as they changed over time.
+	 * Written automatically by the data layer whenever the *effective*
+	 * (displayed) title or overview changes — and seeded once at creation. Each
+	 * entry is a full snapshot of both values, so it is self-contained. Not
+	 * surfaced in the UI yet; kept for a future history view and for search.
+	 */
+	history?: TaskHistoryEntry[];
 	/** True while the worktree is being created (heavy I/O in progress). */
 	preparing?: boolean;
 	/** Current preparation stage shown while the task is still being set up. */
@@ -740,6 +748,33 @@ export interface TaskSessionState {
 /** Returns the display title: custom override if set, otherwise auto-generated. */
 export function getTaskTitle(task: Task): string {
 	return task.customTitle || task.title;
+}
+
+/**
+ * Returns the effective displayed overview: the user override if set, otherwise
+ * the agent-written overview. Mirrors the precedence used in the task cards and
+ * CLI. Returns null when neither is present.
+ */
+export function getTaskOverview(task: Task): string | null {
+	return task.userOverview?.trim() || task.overview?.trim() || null;
+}
+
+/** What changed in a {@link TaskHistoryEntry}. */
+export type TaskHistoryChange = "created" | "title" | "overview" | "both";
+
+/**
+ * One immutable snapshot of a task's displayed title + overview, captured at the
+ * moment either of them changed. Append-only; see {@link Task.history}.
+ */
+export interface TaskHistoryEntry {
+	/** ISO timestamp of the change. */
+	at: string;
+	/** Effective title at this point (custom override or auto-generated). */
+	title: string;
+	/** Effective overview at this point (user override or agent overview), or null. */
+	overview: string | null;
+	/** Which displayed value(s) changed and triggered this snapshot. */
+	changed: TaskHistoryChange;
 }
 
 /** Humanize a status slug for display in notifications (e.g. "in-progress" → "In Progress"). */


### PR DESCRIPTION
## Summary

- Adds an append-only `TaskHistoryEntry[]` log to `Task` that captures the task's displayed title and overview as they change over time — like notes, but historical.
- History is written centrally in `applyTaskUpdate` (the single chokepoint all task field mutations flow through), so it covers every path: UI rename, `dev3 task update --title`, `overview set/clear`, `setUserOverview`, and description-driven title regeneration.
- An entry is appended only when the *effective* (displayed) title (`customTitle || title`) or overview (`userOverview || overview`) actually changes; status-only moves and hidden agent overview rewrites behind a user override don't produce noise.
- A `created` entry is seeded at task creation so each task has a complete, self-contained timeline.
- Old tasks are migrated to an empty `history` array. Not surfaced in the UI yet — stored for a future history view and search.

Includes unit tests (`data-history.test.ts`) and a changelog entry.