### PR TITLE
Reorder built-in Claude presets: Opus 4.8 on top + default

### DIFF
--- a/change-logs/2026/06/16/chore-reorder-opus48-presets.md
+++ b/change-logs/2026/06/16/chore-reorder-opus48-presets.md
@@ -1,0 +1,1 @@
+Reordered the built-in Claude presets so the Opus 4.8 variants sit at the top of the list and made an Opus 4.8 preset the default, since Fable 5 is temporarily unavailable. Fable 5 and Sonnet presets remain below for when Fable 5 returns.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -167,7 +167,14 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			// --- Fable 5 (new default) — order: Auto, Bypass, Default, then the rest ---
+			// --- Opus 4.8 (current default — Fable 5 temporarily unavailable) — order: Auto, Bypass, Default, then the rest ---
+			{ id: "claude-auto-opus48", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 1 },
+			{ id: "claude-bypass-opus48", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-default-opus48", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-plan-opus48", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-approvals-opus48", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			{ id: "claude-dontask-opus48", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
+			// --- Fable 5 (temporarily unavailable, kept for when it returns) — order: Auto, Bypass, Default, then the rest ---
 			{ id: "claude-auto", name: "Auto (Fable 5)", model: "claude-fable-5", permissionMode: "auto", version: 6 },
 			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
 			{ id: "claude-bypass", name: "Bypass (Fable 5)", model: "claude-fable-5", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
@@ -180,13 +187,6 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 			{ id: "claude-approvals-sonnet", name: "Accept Edits (Sonnet)", model: "sonnet", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 2 },
 			{ id: "claude-dontask", name: "Don't Ask (Fable 5)", model: "claude-fable-5", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
 			{ id: "claude-dontask-sonnet", name: "Don't Ask (Sonnet)", model: "sonnet", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			// --- Opus 4.8 (previous default, kept for fallback) ---
-			{ id: "claude-default-opus48", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-plan-opus48", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-bypass-opus48", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-auto-opus48", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 1 },
-			{ id: "claude-approvals-opus48", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			{ id: "claude-dontask-opus48", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			// --- Opus 4.7 (previous generation, kept for fallback) ---
 			{ id: "claude-default-opus47", name: "Default (Opus 4.7)", model: "claude-opus-4-7[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan-opus47", name: "Plan (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
@@ -195,7 +195,7 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 			{ id: "claude-approvals-opus47", name: "Accept Edits (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-dontask-opus47", name: "Don't Ask (Opus 4.7)", model: "claude-opus-4-7[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 		],
-		defaultConfigId: "claude-auto",
+		defaultConfigId: "claude-auto-opus48",
 	},
 	{
 		id: "builtin-codex",


### PR DESCRIPTION
## Summary

Fable 5 (Anthropic) is temporarily unavailable, so the Opus 4.8 presets are now the priority.

- Move the **Opus 4.8** preset block to the top of the built-in Claude configurations in `src/shared/types.ts` (order: Auto, Bypass, Default, then the rest), above the Fable 5 / Sonnet block.
- Switch `defaultConfigId` for Claude to `claude-auto-opus48`.
- Fable 5 / Sonnet and Opus 4.7 presets remain below, ready for when Fable 5 returns.

Note: this only affects fresh installs without a stored `agents.json` — existing users keep their saved preset order via the merge logic in `agents.ts`.