### PR TITLE
Raise large-text paste-as-file threshold from 1 KB to 4 KB

### DIFF
--- a/change-logs/2026/06/17/chore-raise-paste-as-file-threshold.md
+++ b/change-logs/2026/06/17/chore-raise-paste-as-file-threshold.md
@@ -1,0 +1,1 @@
+Raised the large-text-paste threshold from 1 KB to 4 KB, so pasting text into a task description, note, or the agent terminal only saves it as a .txt attachment once it exceeds 4 KB.

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -415,7 +415,7 @@ describe("CreateTaskModal", () => {
 		renderModal();
 
 		const textarea = screen.getByPlaceholderText("Describe what needs to be done...") as HTMLTextAreaElement;
-		const bigText = "x".repeat(2000);
+		const bigText = "x".repeat(5000);
 		const event = dispatchTextPaste(textarea, bigText);
 
 		expect(event.defaultPrevented).toBe(true);
@@ -438,7 +438,7 @@ describe("CreateTaskModal", () => {
 		renderModal();
 
 		const textarea = screen.getByPlaceholderText("Describe what needs to be done...") as HTMLTextAreaElement;
-		dispatchTextPaste(textarea, "y".repeat(2000));
+		dispatchTextPaste(textarea, "y".repeat(5000));
 
 		const card = await screen.findByText("upload-1781612040314-24b3-pasted-text.txt");
 		expect(card).toBeInTheDocument();

--- a/src/mainview/utils/__tests__/uploadPastedText.test.ts
+++ b/src/mainview/utils/__tests__/uploadPastedText.test.ts
@@ -37,8 +37,8 @@ describe("isLargeTextPaste", () => {
 	});
 
 	it("uses byte length, not character count, for multibyte text", () => {
-		// 300 four-byte chars = 1200 bytes > 1024, even though JS length is only 600.
-		const text = "💡".repeat(300);
+		// 1100 four-byte chars = 4400 bytes > 4096, even though JS length is only 2200.
+		const text = "💡".repeat(1100);
 		expect(text.length).toBeLessThan(LARGE_TEXT_PASTE_THRESHOLD);
 		expect(textByteLength(text)).toBeGreaterThan(LARGE_TEXT_PASTE_THRESHOLD);
 		expect(isLargeTextPaste(text)).toBe(true);

--- a/src/mainview/utils/uploadPastedText.ts
+++ b/src/mainview/utils/uploadPastedText.ts
@@ -2,7 +2,7 @@ import { uploadDroppedFile } from "./uploadDroppedFile";
 
 // Text pastes larger than this (in UTF-8 bytes) are saved to a .txt file in the
 // worktree uploads dir instead of being dumped raw into the task / terminal.
-export const LARGE_TEXT_PASTE_THRESHOLD = 1024;
+export const LARGE_TEXT_PASTE_THRESHOLD = 4096;
 
 export function textByteLength(text: string): number {
 	return new TextEncoder().encode(text).length;


### PR DESCRIPTION
## Summary
- Raised `LARGE_TEXT_PASTE_THRESHOLD` from 1 KB to 4 KB in `src/mainview/utils/uploadPastedText.ts`.
- Pastes (CMD+V) into a task description, note, or the agent terminal now stay inline up to 4 KB and only get saved as a `.txt` attachment beyond that.
- Updated the paste-size regression tests (`uploadPastedText`, `CreateTaskModal`) to the new threshold.

(PR opened by Claude, the AI assistant working on this branch.)