### PR TITLE
Count large-text-paste threshold by characters and raise to 8192

### DIFF
--- a/change-logs/2026/06/17/chore-paste-threshold-by-characters.md
+++ b/change-logs/2026/06/17/chore-paste-threshold-by-characters.md
@@ -1,0 +1,1 @@
+Changed the large-text-paste threshold to count characters instead of UTF-8 bytes and raised it to 8192, so pasting text into a task description, note, or the agent terminal is saved as a .txt attachment only once it exceeds 8192 characters — the limit is now language-independent and no longer penalizes Cyrillic or other multibyte text.

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -415,7 +415,7 @@ describe("CreateTaskModal", () => {
 		renderModal();
 
 		const textarea = screen.getByPlaceholderText("Describe what needs to be done...") as HTMLTextAreaElement;
-		const bigText = "x".repeat(5000);
+		const bigText = "x".repeat(9000);
 		const event = dispatchTextPaste(textarea, bigText);
 
 		expect(event.defaultPrevented).toBe(true);
@@ -438,7 +438,7 @@ describe("CreateTaskModal", () => {
 		renderModal();
 
 		const textarea = screen.getByPlaceholderText("Describe what needs to be done...") as HTMLTextAreaElement;
-		dispatchTextPaste(textarea, "y".repeat(5000));
+		dispatchTextPaste(textarea, "y".repeat(9000));
 
 		const card = await screen.findByText("upload-1781612040314-24b3-pasted-text.txt");
 		expect(card).toBeInTheDocument();

--- a/src/mainview/utils/__tests__/uploadPastedText.test.ts
+++ b/src/mainview/utils/__tests__/uploadPastedText.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
 	LARGE_TEXT_PASTE_THRESHOLD,
 	isLargeTextPaste,
-	textByteLength,
+	textCharLength,
 	uploadPastedText,
 } from "../uploadPastedText";
 import { api } from "../../rpc";
@@ -15,15 +15,15 @@ const mockedApi = api as unknown as {
 	request: { uploadFileBase64: ReturnType<typeof vi.fn> };
 };
 
-describe("textByteLength", () => {
-	it("counts ASCII bytes", () => {
-		expect(textByteLength("abc")).toBe(3);
+describe("textCharLength", () => {
+	it("counts ASCII characters", () => {
+		expect(textCharLength("abc")).toBe(3);
 	});
 
-	it("counts multibyte UTF-8 characters by byte length", () => {
-		// "é" is 2 bytes, "💡" is 4 bytes in UTF-8.
-		expect(textByteLength("é")).toBe(2);
-		expect(textByteLength("💡")).toBe(4);
+	it("counts each multibyte character as one, regardless of UTF-8 byte size", () => {
+		// "é" is 2 bytes but 1 character; "💡" is 4 bytes / 2 UTF-16 units but 1 code point.
+		expect(textCharLength("é")).toBe(1);
+		expect(textCharLength("💡")).toBe(1);
 	});
 });
 
@@ -36,12 +36,21 @@ describe("isLargeTextPaste", () => {
 		expect(isLargeTextPaste("a".repeat(LARGE_TEXT_PASTE_THRESHOLD + 1))).toBe(true);
 	});
 
-	it("uses byte length, not character count, for multibyte text", () => {
-		// 1100 four-byte chars = 4400 bytes > 4096, even though JS length is only 2200.
-		const text = "💡".repeat(1100);
-		expect(text.length).toBeLessThan(LARGE_TEXT_PASTE_THRESHOLD);
-		expect(textByteLength(text)).toBeGreaterThan(LARGE_TEXT_PASTE_THRESHOLD);
-		expect(isLargeTextPaste(text)).toBe(true);
+	it("counts characters language-independently — Cyrillic is not penalized for byte size", () => {
+		// A Cyrillic paragraph well under the character threshold must NOT be saved
+		// to a file, even though its UTF-8 byte size is ~2x its character count.
+		const text = "Короткий абзац на русском языке для проверки порога вставки. ".repeat(100);
+		expect(textCharLength(text)).toBeLessThan(LARGE_TEXT_PASTE_THRESHOLD);
+		expect(isLargeTextPaste(text)).toBe(false);
+	});
+
+	it("counts code points, not UTF-16 code units, for astral characters", () => {
+		// Each "💡" is 2 UTF-16 units but 1 code point. 5000 of them = 5000 chars
+		// (below the threshold), even though string.length reports 10000.
+		const text = "💡".repeat(5000);
+		expect(text.length).toBeGreaterThan(LARGE_TEXT_PASTE_THRESHOLD);
+		expect(textCharLength(text)).toBeLessThan(LARGE_TEXT_PASTE_THRESHOLD);
+		expect(isLargeTextPaste(text)).toBe(false);
 	});
 });
 

--- a/src/mainview/utils/uploadPastedText.ts
+++ b/src/mainview/utils/uploadPastedText.ts
@@ -1,15 +1,17 @@
 import { uploadDroppedFile } from "./uploadDroppedFile";
 
-// Text pastes larger than this (in UTF-8 bytes) are saved to a .txt file in the
-// worktree uploads dir instead of being dumped raw into the task / terminal.
-export const LARGE_TEXT_PASTE_THRESHOLD = 4096;
+// Text pastes longer than this (in characters / Unicode code points) are saved
+// to a .txt file in the worktree uploads dir instead of being dumped raw into
+// the task / terminal. Counting characters (not UTF-8 bytes) keeps the limit
+// language-independent — the same paste size triggers it in English and Cyrillic.
+export const LARGE_TEXT_PASTE_THRESHOLD = 8192;
 
-export function textByteLength(text: string): number {
-	return new TextEncoder().encode(text).length;
+export function textCharLength(text: string): number {
+	return [...text].length;
 }
 
 export function isLargeTextPaste(text: string): boolean {
-	return textByteLength(text) > LARGE_TEXT_PASTE_THRESHOLD;
+	return textCharLength(text) > LARGE_TEXT_PASTE_THRESHOLD;
 }
 
 export async function uploadPastedText(projectId: string, text: string): Promise<string | null> {


### PR DESCRIPTION
## Summary
- `isLargeTextPaste` now counts characters (Unicode code points) instead of UTF-8 bytes, so the "save paste as .txt" limit is language-independent and no longer penalizes Cyrillic / multibyte text (which is ~2 bytes per letter).
- Raised the threshold to **8192 characters** (`LARGE_TEXT_PASTE_THRESHOLD`).
- Renamed `textByteLength` → `textCharLength` and updated all call sites and tests.