### PR TITLE
Syntax highlighting in the diff viewer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "electrobun-react-tailwind-vite",
       "dependencies": {
+        "@git-diff-view/core": "^0.1.3",
         "@git-diff-view/file": "^0.1.3",
         "@git-diff-view/react": "^0.1.3",
         "@headless-tree/core": "^1.6.3",

--- a/change-logs/2026/06/18/feature-diff-syntax-highlighting.md
+++ b/change-logs/2026/06/18/feature-diff-syntax-highlighting.md
@@ -1,0 +1,3 @@
+Added syntax highlighting to the task diff viewer. Code is now colored by language (detected from the file extension) and follows the active light/dark theme. The library's 2000-line cap that left large files plain was raised so big source files are highlighted too.
+
+Suggested by @h0x91b (h0x91b/dev-3.0#543)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"bump": "bun run scripts/bump.ts"
 	},
 	"dependencies": {
+		"@git-diff-view/core": "^0.1.3",
 		"@git-diff-view/file": "^0.1.3",
 		"@git-diff-view/react": "^0.1.3",
 		"@headless-tree/core": "^1.6.3",

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -26,6 +26,11 @@ const LS_DIFF_MODE_PREFERENCE = "dev3-inline-diff-mode-v1";
 const LS_DIFF_FILES_COLLAPSED = "dev3-inline-diff-files-collapsed-v1";
 const DEFAULT_DIFF_MODE: TaskDiffMode = "uncommitted";
 const EAGER_FILE_COUNT = 2;
+// @git-diff-view skips syntax highlighting for files longer than this many lines
+// (library default is 2000, which left large source files — e.g. this one — plain).
+// Raise it so realistic source files still get highlighted; the per-line node guard
+// inside the library still protects against pathologically long single lines.
+const SYNTAX_HIGHLIGHT_MAX_LINES = 50000;
 
 function readFilesCollapsed(): boolean {
 	try {
@@ -82,6 +87,7 @@ type DiffViewMode = "unified" | "split";
 type DiffInstance = {
 	initTheme: (theme?: "light" | "dark") => void;
 	initRaw: () => void;
+	initSyntax: () => void;
 	buildSplitDiffLines: () => void;
 	buildUnifiedDiffLines: () => void;
 };
@@ -1327,6 +1333,11 @@ function TaskDiffFileSection({
 						: diffLib.generateDiffFile(oldPath, file.oldContent, newPath, file.newContent);
 					nextDiffFile.initTheme(resolvedTheme);
 					nextDiffFile.initRaw();
+					// Populate syntax-highlight data up front so the first render of
+					// <DiffView diffViewHighlight> already reads colored tokens. The
+					// library's own post-mount initSyntax + notifyAll does not reliably
+					// re-render the memoized line rows, leaving the diff unhighlighted.
+					nextDiffFile.initSyntax();
 					diffInstanceRef.current = nextDiffFile;
 				} else {
 					nextDiffFile.initTheme(resolvedTheme);
@@ -1470,7 +1481,7 @@ function TaskDiffFileSection({
 						diffViewTheme={resolvedTheme}
 						diffViewMode={diffMode}
 						diffViewWrap={false}
-						diffViewHighlight={false}
+						diffViewHighlight={true}
 						diffViewAddWidget
 						extendData={comments}
 						onCreateUseWidgetHook={(hook: typeof widgetHookRef.current) => { widgetHookRef.current = hook; }}
@@ -1756,10 +1767,14 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		Promise.all([
 			import("@git-diff-view/react"),
 			import("@git-diff-view/file"),
-		]).then(([reactLib, fileLib]) => {
+			import("@git-diff-view/core"),
+		]).then(([reactLib, fileLib, coreLib]) => {
 			if (cancelled) {
 				return;
 			}
+			// The highlighter is a shared singleton; raise its line cap so large
+			// files get syntax-highlighted instead of falling back to plain text.
+			coreLib.highlighter.setMaxLineToIgnoreSyntax(SYNTAX_HIGHLIGHT_MAX_LINES);
 			setDiffLib({
 				DiffView: reactLib.DiffView,
 				DiffFile: reactLib.DiffFile,

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@git-diff-view/react", async () => {
 			diffViewTheme,
 			diffFile,
 			diffViewAddWidget,
+			diffViewHighlight,
 			renderWidgetLine,
 			renderExtendLine,
 			extendData,
@@ -42,6 +43,7 @@ vi.mock("@git-diff-view/react", async () => {
 			diffViewTheme: "dark" | "light";
 			diffFile?: { __mockLines?: MockDiffLine[] };
 			diffViewAddWidget?: boolean;
+			diffViewHighlight?: boolean;
 			renderWidgetLine?: (props: { lineNumber: number; side: number; onClose: () => void; diffFile: object }) => React.ReactNode;
 			renderExtendLine?: (props: { lineNumber: number; side: number; data: unknown; onUpdate: () => void; diffFile: object }) => React.ReactNode;
 			extendData?: {
@@ -83,7 +85,7 @@ vi.mock("@git-diff-view/react", async () => {
 
 			return (
 				<div className="diff-table-scroll-container overflow-x-auto" data-testid="mock-diff-scroll">
-					<div data-testid="mock-diff">
+					<div data-testid="mock-diff" data-diff-highlight={diffViewHighlight ? "1" : "0"}>
 						mode:{diffViewMode} theme:{diffViewTheme}
 						<div className="space-y-1">
 							{(() => {
@@ -183,6 +185,7 @@ vi.mock("@git-diff-view/react", async () => {
 
 			initTheme() {}
 			initRaw() {}
+			initSyntax() {}
 			buildSplitDiffLines() {}
 			buildUnifiedDiffLines() {}
 		},
@@ -210,9 +213,17 @@ vi.mock("@git-diff-view/file", () => ({
 		],
 		initTheme() {},
 		initRaw() {},
+		initSyntax() {},
 		buildSplitDiffLines() {},
 		buildUnifiedDiffLines() {},
 	}),
+}));
+
+const mockSetMaxLineToIgnoreSyntax = vi.fn();
+vi.mock("@git-diff-view/core", () => ({
+	highlighter: {
+		setMaxLineToIgnoreSyntax: (value: number) => mockSetMaxLineToIgnoreSyntax(value),
+	},
 }));
 
 import { api } from "../../rpc";
@@ -402,6 +413,34 @@ describe("TaskDiffViewer", () => {
 		await waitFor(() => {
 			expect(screen.getAllByTestId("mock-diff")).toHaveLength(2);
 		});
+	});
+
+	it("enables syntax highlighting on the rendered diff view", async () => {
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getAllByTestId("mock-diff").length).toBeGreaterThan(0);
+		});
+
+		for (const diff of screen.getAllByTestId("mock-diff")) {
+			expect(diff).toHaveAttribute("data-diff-highlight", "1");
+		}
+
+		// The library skips highlighting files longer than 2000 lines by default;
+		// the viewer raises that cap so large source files stay highlighted.
+		expect(mockSetMaxLineToIgnoreSyntax).toHaveBeenCalled();
+		const calls = mockSetMaxLineToIgnoreSyntax.mock.calls;
+		const raisedTo = calls[calls.length - 1]?.[0] ?? 0;
+		expect(raisedTo).toBeGreaterThan(2000);
 	});
 
 	it("sorts the right-panel file list alphabetically by full path", async () => {

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -232,6 +232,8 @@ const tips = {
 	"tip.taskSwitcherGlobal.body": "Option+Shift+Tab opens the switcher across all projects, not just the current one.",
 	"tip.pasteLargeText.title": "Paste big logs as files",
 	"tip.pasteLargeText.body": "Paste a large text block and it's saved as a .txt attachment, keeping the task light instead of bloated.",
+	"tip.diffSyntaxHighlight.title": "Diffs are syntax-highlighted",
+	"tip.diffSyntaxHighlight.body": "The diff viewer colors code by language and follows your light/dark theme, so changes are easier to scan.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -232,6 +232,8 @@ const tips = {
 	"tip.taskSwitcherGlobal.body": "Option+Shift+Tab abre el selector en todos los proyectos, no solo en el actual.",
 	"tip.pasteLargeText.title": "Pega registros grandes como archivos",
 	"tip.pasteLargeText.body": "Pega un bloque de texto grande y se guarda como adjunto .txt, manteniendo la tarea ligera en vez de sobrecargada.",
+	"tip.diffSyntaxHighlight.title": "Resaltado de sintaxis en los diffs",
+	"tip.diffSyntaxHighlight.body": "El visor de diffs colorea el código según el lenguaje y sigue tu tema claro/oscuro, así los cambios son más fáciles de leer.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -232,6 +232,8 @@ const tips = {
 	"tip.taskSwitcherGlobal.body": "Option+Shift+Tab открывает переключатель по всем проектам, а не только по текущему.",
 	"tip.pasteLargeText.title": "Вставляйте большие логи файлами",
 	"tip.pasteLargeText.body": "Вставьте большой блок текста — он сохранится как .txt-вложение, и задача останется лёгкой, а не раздутой.",
+	"tip.diffSyntaxHighlight.title": "Подсветка синтаксиса в диффах",
+	"tip.diffSyntaxHighlight.body": "Просмотрщик диффов подсвечивает код по языку и следует светлой/тёмной теме — изменения легче читать.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -739,6 +739,12 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.pasteLargeText.body",
 		icon: "\u{F0192}", // nf-md-file_document_outline
 	},
+	{
+		id: "diff-syntax-highlight",
+		titleKey: "tip.diffSyntaxHighlight.title",
+		bodyKey: "tip.diffSyntaxHighlight.body",
+		icon: "\u{F0626}", // nf-md-palette_outline
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — opening this on Arseny's behalf.

## Summary

Adds syntax highlighting to the task diff viewer (closes #543). Diff content is now colored by language (detected from the file extension) and follows the active light/dark theme. Covers both the per-task diff view and the review/export screen, since both render through `TaskDiffViewer`.

The underlying `@git-diff-view` library already ships a lowlight highlighter (all highlight.js languages) and token CSS for both themes, but three things were needed to make it actually render:

- **Call `DiffFile.initSyntax()` before the lines render.** Relying on the library's own post-mount `initSyntax` + `notifyAll` did not reliably re-render the memoized rows, so diffs stayed plain.
- **Raise `highlighter.maxLineToIgnoreSyntax` (default 2000).** Large source files — e.g. the ~3.1k-line `TaskDiffViewer.tsx` itself — were silently falling back to plain text. This was the reason highlighting looked broken for `.tsx` while working for shorter `.ts` files; it was purely file size, not the extension. The per-line node guard (`nodeList > 150`) still protects against pathologically long single lines.
- **Depend on `@git-diff-view/core` directly** to reach that shared highlighter singleton.

## Notes

- Language is auto-detected from the filename; `.ts/.tsx/.jsx/.js/.css/.json/.md/.sh` all resolve, unknown extensions fall back to `highlightAuto`.
- No new UI controls — highlighting is always on.
- Adds a "Did you know?" tip (en/ru/es) and a changelog entry.
- `bun run lint` and `bun run test` are green.