### PR TITLE
Migrate task search to shared fzf-style fuzzy matcher

### DIFF
--- a/change-logs/2026/06/18/refactor-taskSearch-fuzzy.md
+++ b/change-logs/2026/06/18/refactor-taskSearch-fuzzy.md
@@ -1,0 +1,1 @@
+Task search now uses the shared fzf-style fuzzy matcher (fuzzyMatch) for title and description instead of a naive substring check, so it behaves consistently with the project quick-switch palette. Identifier fields (seq, UUID, PR number) keep strict prefix matching.

--- a/decisions/073-task-search-shared-fuzzy-matcher.md
+++ b/decisions/073-task-search-shared-fuzzy-matcher.md
@@ -1,0 +1,36 @@
+# 073 — Unify task search on the shared fuzzy matcher
+
+## Context
+
+`src/mainview/utils/taskSearch.ts` (`matchesSearchQuery`) filtered tasks with a
+naive `String.includes()` substring check on title and description. The project
+quick-switch palette (`ProjectQuickSwitchModal.tsx`) already used an fzf-style
+fuzzy matcher (`src/mainview/utils/fuzzyMatch.ts`). Two different matchers for
+two short-entity searches was inconsistent UX.
+
+## Decision
+
+Title and description now go through `fuzzyScore().matched` (subsequence match),
+so task search matches the quick-switch behavior. Identifier fields — `seq`,
+UUID, and PR number — intentionally keep strict `startsWith` prefix matching:
+fuzzy subsequence on short numeric/hex IDs is meaningless (e.g. "135" would
+match seq "12345"). The function still returns a boolean; both callers
+(`KanbanBoard`, `ActiveTasksSidebar`) only filter, so no ranking was added.
+
+BM25 (`src/shared/conversation-search-core.ts`) remains reserved for long
+transcripts only — fuzzy is for short UI entities, BM25 for long text.
+
+## Risks
+
+Fuzzy subsequence is looser than substring, so a query can match a long
+`description` via scattered chars (more false positives than before). Acceptable
+for an interactive filter where the user refines the query live; titles are
+short and dominate relevance in practice.
+
+## Alternatives considered
+
+- Keep `includes()` — rejected: leaves two divergent matchers.
+- Fuzzy-match identifiers too — rejected: meaningless on short IDs, breaks
+  intuitive #seq / UUID-prefix lookups.
+- Add scoring/ranking to the callers — rejected: out of scope, both callers
+  only filter (boolean), no sorted result list today.

--- a/src/mainview/utils/__tests__/taskSearch.test.ts
+++ b/src/mainview/utils/__tests__/taskSearch.test.ts
@@ -47,6 +47,32 @@ describe("matchesSearchQuery", () => {
 		expect(matchesSearchQuery(makeTask({ title: "Refactor database" }), "auth")).toBe(false);
 	});
 
+	// ---- Fuzzy (subsequence) title matching ----
+
+	it("matches title by fuzzy subsequence (non-contiguous)", () => {
+		// "fxbug" is a subsequence of "Fix authentication bug" but not a substring.
+		expect(matchesSearchQuery(makeTask({ title: "Fix authentication bug" }), "fxbug")).toBe(true);
+	});
+
+	it("matches title by acronym-style subsequence", () => {
+		expect(matchesSearchQuery(makeTask({ title: "Migrate task search", description: "" }), "mts")).toBe(true);
+	});
+
+	it("does not match title when query is not a subsequence", () => {
+		expect(
+			matchesSearchQuery(makeTask({ title: "Fix authentication bug", description: "" }), "xyzq"),
+		).toBe(false);
+	});
+
+	it("matches description by fuzzy subsequence", () => {
+		expect(
+			matchesSearchQuery(
+				makeTask({ title: "Unrelated", description: "The login flow breaks when session expires" }),
+				"lgnflw",
+			),
+		).toBe(true);
+	});
+
 	// ---- Description matching ----
 
 	it("matches by description substring", () => {
@@ -98,6 +124,16 @@ describe("matchesSearchQuery", () => {
 		expect(matchesSearchQuery(makeTask({ seq: 1, title: "No numbers here", description: "" }), "1")).toBe(true);
 	});
 
+	it("treats seq as prefix-only, not fuzzy subsequence", () => {
+		// "135" is a subsequence of "12345" but not a prefix — must NOT match.
+		expect(
+			matchesSearchQuery(
+				makeTask({ seq: 12345, title: "No numbers", description: "none", id: "00000000-0000-0000-0000-000000000000" }),
+				"135",
+			),
+		).toBe(false);
+	});
+
 	// ---- Full UUID (long ID) matching ----
 
 	it("matches by full UUID", () => {
@@ -112,6 +148,16 @@ describe("matchesSearchQuery", () => {
 				"a1b2c3d4-e5f6",
 			),
 		).toBe(true);
+	});
+
+	it("treats UUID as prefix-only, not fuzzy subsequence", () => {
+		// "b2c3" appears inside the UUID but is not a prefix — must NOT match.
+		expect(
+			matchesSearchQuery(
+				makeTask({ id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", title: "No match", description: "none", seq: 1 }),
+				"b2c3",
+			),
+		).toBe(false);
 	});
 
 	it("matches UUID case-insensitively", () => {

--- a/src/mainview/utils/taskSearch.ts
+++ b/src/mainview/utils/taskSearch.ts
@@ -1,5 +1,6 @@
 import type { Task } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
+import { fuzzyScore } from "./fuzzyMatch";
 
 interface SearchOptions {
 	/** PR number associated with the task's branch (from BranchStatus), if available. */
@@ -8,8 +9,12 @@ interface SearchOptions {
 
 /**
  * Check if a task matches a search query.
- * Searches across: title, description, seq (numeric ID), UUID (full + short prefix),
- * and optionally PR number (when provided via options).
+ *
+ * Textual fields (title, description) use the shared fzf-style fuzzy matcher
+ * (`fuzzyScore`) so task search behaves like the project quick-switch palette:
+ * a query matches when its chars appear in order (subsequence), not only as a
+ * contiguous substring. Identifier fields (seq, UUID, PR number) keep strict
+ * prefix matching — fuzzy subsequence on short numeric IDs would be meaningless.
  * All comparisons are case-insensitive.
  */
 export function matchesSearchQuery(task: Task, query: string, options?: SearchOptions): boolean {
@@ -19,11 +24,11 @@ export function matchesSearchQuery(task: Task, query: string, options?: SearchOp
 	// Strip leading # for numeric ID search
 	const qNormalized = q.startsWith("#") ? q.slice(1) : q;
 
-	// Match against title (custom or auto-generated)
-	if (getTaskTitle(task).toLowerCase().includes(q)) return true;
+	// Fuzzy match against title (custom or auto-generated)
+	if (fuzzyScore(q, getTaskTitle(task)).matched) return true;
 
-	// Match against description
-	if (task.description.toLowerCase().includes(q)) return true;
+	// Fuzzy match against description
+	if (fuzzyScore(q, task.description).matched) return true;
 
 	// Match against seq (numeric human-readable ID) — prefix match on string representation
 	const seqStr = String(task.seq);


### PR DESCRIPTION
## Summary

- `matchesSearchQuery` (`src/mainview/utils/taskSearch.ts`) now fuzzy-matches **title** and **description** via the shared `fuzzyScore` (fzf-style subsequence + scoring) from `fuzzyMatch.ts`, so task search behaves consistently with the project quick-switch palette.
- **seq, UUID, and PR number** intentionally keep strict prefix matching — fuzzy subsequence on short numeric/hex IDs is meaningless (e.g. `135` would match seq `12345`).
- API stays boolean; both callers (`KanbanBoard`, `ActiveTasksSidebar`) only filter, so no ranking was added.
- BM25 (`conversation-search-core.ts`) remains reserved for long transcripts only — fuzzy is the single matcher for short UI entities.
- Updated tests (fuzzy-subsequence cases + guards that seq/UUID stay prefix-only) and added decision record `073`.

🤖 Opened by Claude (the AI assistant working on this branch).