### PR TITLE
Make projects.json/tasks.json saves atomic to survive crashes

### DIFF
--- a/change-logs/2026/06/18/fix-atomic-json-writes.md
+++ b/change-logs/2026/06/18/fix-atomic-json-writes.md
@@ -1,0 +1,1 @@
+Made projects.json and tasks.json saves crash-safe by writing to a sibling temp file and renaming it over the final path. A crash or power loss mid-write can no longer truncate the live file and silently empty the dashboard or board.

--- a/src/bun/__tests__/data-atomic-write.test.ts
+++ b/src/bun/__tests__/data-atomic-write.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import type { Project, Task } from "../../shared/types";
+
+// Mock node:fs/promises so we can simulate a crash *during* the JSON payload
+// write (power loss / kill -9 between truncate and full write). Backups and
+// every other fs operation use the real implementation. The crash is injected
+// only when explicitly armed, and only for the main projects.json / tasks.json
+// payload write (NOT the *.bak sibling).
+let crashArmed = false;
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	const isMainPayloadWrite = (p: string): boolean => {
+		if (p.includes(".bak")) return false;
+		return p.includes("projects.json") || p.includes("tasks.json");
+	};
+	return {
+		...actual,
+		writeFile: vi.fn(async (path: any, data: any, opts?: any) => {
+			const p = String(path);
+			if (crashArmed && isMainPayloadWrite(p)) {
+				// Emulate truncate + partial write, then the process dies.
+				await actual.writeFile(p, String(data).slice(0, 3));
+				throw new Error("simulated crash mid-write");
+			}
+			return actual.writeFile(path, data, opts);
+		}),
+	};
+});
+
+const tempHome = mkdtempSync(join(tmpdir(), "dev3-atomic-write-"));
+const dev3Home = join(tempHome, ".dev3.0");
+const originalHome = process.env.HOME;
+
+function makeProject(overrides?: Partial<Project>): Project {
+	return {
+		id: "proj-1",
+		name: "Existing Project",
+		path: "/tmp/existing-project",
+		setupScript: "",
+		setupScriptLaunchMode: "parallel",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: "2026-04-15T00:00:00.000Z",
+		labels: [],
+		customColumns: [],
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "proj-1",
+		title: "Existing task",
+		description: "Existing task",
+		status: "todo",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2026-04-15T00:00:00.000Z",
+		updatedAt: "2026-04-15T00:00:00.000Z",
+		labelIds: [],
+		notes: [],
+		customTitle: null,
+		customColumnId: null,
+		...overrides,
+	};
+}
+
+function listTempSiblings(dir: string): string[] {
+	return readdirSync(dir).filter((f) => f.includes(".tmp"));
+}
+
+describe("atomic JSON writes survive a crash mid-write", () => {
+	beforeEach(() => {
+		crashArmed = false;
+		vi.resetModules();
+		process.env.HOME = tempHome;
+		rmSync(tempHome, { recursive: true, force: true });
+		mkdirSync(dev3Home, { recursive: true });
+	});
+
+	afterEach(() => {
+		crashArmed = false;
+	});
+
+	afterAll(() => {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	it("keeps projects.json valid when the save crashes mid-write", async () => {
+		const original = [makeProject()];
+		const projectsFile = join(dev3Home, "projects.json");
+		writeFileSync(projectsFile, JSON.stringify(original, null, 2));
+
+		const data = await import("../data");
+
+		crashArmed = true;
+		await expect(data.saveProjects([makeProject(), makeProject({ id: "proj-2", path: "/tmp/p2" })])).rejects.toThrow();
+		crashArmed = false;
+
+		// The atomic write must NOT have corrupted the live file.
+		const content = readFileSync(projectsFile, "utf8");
+		expect(() => JSON.parse(content)).not.toThrow();
+		expect(JSON.parse(content)).toEqual(original);
+
+		// No leftover temp file after the failed save.
+		expect(listTempSiblings(dev3Home)).toHaveLength(0);
+	});
+
+	it("keeps tasks.json valid when the save crashes mid-write", async () => {
+		const project = makeProject();
+		const original = [makeTask()];
+		const tasksDir = join(dev3Home, "data", "tmp-existing-project");
+		const tasksFile = join(tasksDir, "tasks.json");
+		writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+		mkdirSync(tasksDir, { recursive: true });
+		writeFileSync(tasksFile, JSON.stringify(original, null, 2));
+
+		const data = await import("../data");
+
+		crashArmed = true;
+		await expect(
+			data.saveTasks(project, [makeTask(), makeTask({ id: "task-2", seq: 2 })]),
+		).rejects.toThrow();
+		crashArmed = false;
+
+		const content = readFileSync(tasksFile, "utf8");
+		expect(() => JSON.parse(content)).not.toThrow();
+		expect(JSON.parse(content)).toEqual(original);
+
+		expect(listTempSiblings(tasksDir)).toHaveLength(0);
+	});
+});
+
+describe("atomic JSON writes stay backward-compatible on success", () => {
+	beforeEach(() => {
+		crashArmed = false;
+		vi.resetModules();
+		process.env.HOME = tempHome;
+		rmSync(tempHome, { recursive: true, force: true });
+		mkdirSync(dev3Home, { recursive: true });
+	});
+
+	afterAll(() => {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	it("writes projects.json with the exact same JSON format as the old in-place path", async () => {
+		const projects = [makeProject(), makeProject({ id: "proj-2", path: "/tmp/p2" })];
+		const projectsFile = join(dev3Home, "projects.json");
+
+		const data = await import("../data");
+		await data.saveProjects(projects);
+
+		const content = readFileSync(projectsFile, "utf8");
+		// Byte-identical to what an older version writes (JSON.stringify(.., null, 2)).
+		expect(content).toBe(JSON.stringify(projects, null, 2));
+		// Old read path parses it unchanged.
+		expect(JSON.parse(content)).toEqual(projects);
+		// No temp file leftover after a successful save.
+		expect(listTempSiblings(dev3Home)).toHaveLength(0);
+	});
+
+	it("writes tasks.json with the exact same JSON format and keeps the backup layout", async () => {
+		const project = makeProject();
+		const tasksDir = join(dev3Home, "data", "tmp-existing-project");
+		const tasksFile = join(tasksDir, "tasks.json");
+		mkdirSync(tasksDir, { recursive: true });
+		// Seed an existing tasks.json so a backup is produced on the next save.
+		writeFileSync(tasksFile, JSON.stringify([makeTask()], null, 2));
+
+		const tasks = [makeTask(), makeTask({ id: "task-2", seq: 2 })];
+
+		const data = await import("../data");
+		await data.saveTasks(project, tasks);
+
+		const content = readFileSync(tasksFile, "utf8");
+		expect(content).toBe(JSON.stringify(tasks, null, 2));
+		expect(JSON.parse(content)).toEqual(tasks);
+		expect(listTempSiblings(tasksDir)).toHaveLength(0);
+
+		// Backup dir + filename pattern unchanged: tasks-backups/YYYY-MM-DDTHHZ.json
+		const backupDir = join(tasksDir, "tasks-backups");
+		const backups = readdirSync(backupDir);
+		expect(backups).toHaveLength(1);
+		expect(backups[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/);
+	});
+});

--- a/src/bun/__tests__/data-migration-race.test.ts
+++ b/src/bun/__tests__/data-migration-race.test.ts
@@ -10,6 +10,7 @@ const { mockFileStore, lockQueues, fsPromises } = vi.hoisted(() => ({
 		readdir: vi.fn(),
 		unlink: vi.fn(),
 		writeFile: vi.fn(),
+		rename: vi.fn(),
 	},
 }));
 
@@ -131,6 +132,14 @@ beforeEach(() => {
 		await new Promise((resolve) => setTimeout(resolve, WRITE_DELAY_MS));
 		mockFileStore[String(path)] = String(content);
 	});
+	fsPromises.rename.mockImplementation(async (from: string | URL | Buffer, to: string | URL | Buffer) => {
+		const fromKey = String(from);
+		const toKey = String(to);
+		if (fromKey in mockFileStore) {
+			mockFileStore[toKey] = mockFileStore[fromKey];
+			delete mockFileStore[fromKey];
+		}
+	});
 });
 
 describe("migration readers racing with writers", () => {
@@ -157,7 +166,7 @@ describe("migration readers racing with writers", () => {
 		fsPromises.writeFile.mockImplementation(async (path: string | URL | Buffer, content: string | ArrayBuffer | SharedArrayBuffer | DataView) => {
 			const key = String(path);
 			const text = String(content);
-			if (!mutatorStarted && key === PROJECTS_FILE && text.includes('"cleanupScript": ""')) {
+			if (!mutatorStarted && key.startsWith(PROJECTS_FILE) && text.includes('"cleanupScript": ""')) {
 				firstReaderWrite.resolve();
 				await releaseReaderWrite.promise;
 			}
@@ -196,7 +205,7 @@ describe("migration readers racing with writers", () => {
 		fsPromises.writeFile.mockImplementation(async (path: string | URL | Buffer, content: string | ArrayBuffer | SharedArrayBuffer | DataView) => {
 			const key = String(path);
 			const text = String(content);
-			if (!mutatorStarted && key === tasksPath && text.includes('"seq": 1')) {
+			if (!mutatorStarted && key.startsWith(tasksPath) && text.includes('"seq": 1')) {
 				firstReaderWrite.resolve();
 				await releaseReaderWrite.promise;
 			}

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import type { Project, Task, TaskHistoryChange, TaskHistoryEntry, TaskStatus, TipState } from "../shared/types";
 import { getTaskOverview, getTaskTitle, titleFromDescription } from "../shared/types";
 import { createLogger } from "./logger";
@@ -52,6 +52,27 @@ function deriveTaskBaseBranch(project: Project, existingBranch?: string | null):
 async function ensureDir(filePath: string): Promise<void> {
 	const dir = filePath.slice(0, filePath.lastIndexOf("/"));
 	await mkdir(dir, { recursive: true });
+}
+
+/**
+ * Crash-safe write: write `content` to a sibling temp file in the SAME
+ * directory, then rename() it over `filePath`. rename() within one filesystem
+ * is atomic on POSIX, so a crash/power-loss can only ever leave the temp file
+ * truncated — never the live file. The temp name (`<file>.tmp-<pid>`) never
+ * matches the exact filenames or backup patterns older versions read, so a
+ * leftover is harmless; we still clean it up on failure. The final path and
+ * byte content are identical to the old in-place writeFile, so older app
+ * versions read/write these files unchanged.
+ */
+async function atomicWriteFile(filePath: string, content: string): Promise<void> {
+	const tmpPath = `${filePath}.tmp-${process.pid}`;
+	try {
+		await writeFile(tmpPath, content);
+		await rename(tmpPath, filePath);
+	} catch (err) {
+		await unlink(tmpPath).catch(() => {});
+		throw err;
+	}
 }
 
 // ---- Read cache (mtime/size keyed) ----
@@ -182,7 +203,7 @@ async function rawSaveProjects(projects: Project[]): Promise<void> {
 	await backupProjectsDaily().catch((err) => {
 		log.warn("Failed to write daily projects backup (non-fatal)", { err });
 	});
-	await writeFile(PROJECTS_FILE, JSON.stringify(projects, null, 2));
+	await atomicWriteFile(PROJECTS_FILE, JSON.stringify(projects, null, 2));
 	projectsCache.delete(PROJECTS_FILE);
 	log.info(`Saved ${projects.length} project(s)`);
 }
@@ -464,7 +485,7 @@ async function rawSaveTasks(
 	await writeHourlyTasksBackup(project, file).catch((err) => {
 		log.warn("Failed to write hourly tasks backup (non-fatal)", { projectId: project.id, err });
 	});
-	await writeFile(file, JSON.stringify(tasks, null, 2));
+	await atomicWriteFile(file, JSON.stringify(tasks, null, 2));
 	tasksCache.delete(file);
 	log.info(`Saved ${tasks.length} task(s)`, { projectId: project.id });
 }


### PR DESCRIPTION
## Summary

- `projects.json` and `tasks.json` were written in place with `writeFile` (truncate + write). A crash / `kill -9` / power loss mid-write left a truncated JSON file; on next load `JSON.parse` threw and non-strict loaders silently returned `[]`, so the user opened the app to an empty dashboard / empty board. `projects.json` has no backup at all.
- New `atomicWriteFile()` in `src/bun/data.ts` writes the JSON payload to a sibling temp file (`<file>.tmp-<pid>`) and `rename()`s it over the final path. `rename()` within one filesystem is atomic on POSIX, so a crash mid-write can only ever leave the temp file truncated — never the live file. The temp file is cleaned up on failure.
- Backward compatible: final paths and byte content (`JSON.stringify(.., null, 2)`) are unchanged, so an older app version reads/writes these files unchanged and downgrade is safe. The `*.tmp-*` name matches neither the exact filenames nor the backup patterns older code reads.
- Scope: only `projects.json` / `tasks.json` (as requested). The silent-`[]` fallback of non-strict loaders is intentionally left unchanged — it's a separate UX question.

Reproduced first with a failing test (`data-atomic-write.test.ts`) that simulates a crash mid-write, then fixed. Also added a `rename` mock to `data-migration-race.test.ts` whose `node:fs/promises` mock predates the atomic write.

🤖 This PR was authored by Claude (the AI assistant working on this branch).