### PR TITLE
Reset column order on same-status column moves

### DIFF
--- a/change-logs/2026/06/19/fix-reset-column-order-same-status-move.md
+++ b/change-logs/2026/06/19/fix-reset-column-order-same-status-move.md
@@ -1,0 +1,1 @@
+Fixed task cards landing at a stale mid-column position after moving between a builtin column and a custom column that share the same status (e.g. In Progress <-> On hold). Such moves now reset columnOrder, refresh movedAt, and honor the taskDropPosition setting, so the card sits at the top/bottom as configured after an app reload.

--- a/src/bun/__tests__/data-reorder.test.ts
+++ b/src/bun/__tests__/data-reorder.test.ts
@@ -625,6 +625,83 @@ describe("updateTask — columnOrder lifecycle", () => {
 		expect(saved.find((t) => t.id === "D")!.columnOrder).toBe(9);
 	});
 
+	it("builtin -> custom column (same status) resets columnOrder + movedAt and honors dropPosition", async () => {
+		// Task D sits mid-column in In Progress (builtin, columnOrder=9). Moving it
+		// into custom column "col-a" keeps status in-progress but changes the rendered
+		// column. It must land at the top of col-a, not keep its stale columnOrder.
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+			makeTask({ id: "B", seq: 2, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-02T00:00:00Z", columnOrder: 1 }),
+			makeTask({ id: "D", seq: 4, status: "in-progress", customColumnId: null, createdAt: "2025-01-04T00:00:00Z", columnOrder: 9, movedAt: "2025-01-04T00:00:00Z" }),
+		];
+		seedTasks(tasks);
+
+		const updated = await updateTask(testProject, "D", { customColumnId: "col-a" }, { dropPosition: "top" });
+
+		expect(updated.columnOrder).toBe(0);
+		expect(updated.movedAt).toBeDefined();
+		expect(updated.movedAt).not.toBe("2025-01-04T00:00:00Z");
+		const saved = readSavedTasks();
+		const colATasks = saved
+			.filter((t) => t.status === "in-progress" && t.customColumnId === "col-a")
+			.sort((a, b) => (a.columnOrder ?? 999) - (b.columnOrder ?? 999));
+		expect(colATasks.map((t) => t.id)).toEqual(["D", "A", "B"]);
+	});
+
+	it("custom column -> builtin (same status) resets columnOrder + movedAt and honors dropPosition", async () => {
+		// Task C is in custom column "col-b" (status in-progress, columnOrder=7).
+		// Moving it back to the builtin In Progress column keeps status in-progress
+		// but changes the rendered column → must land at top of the builtin column.
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: null, createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+			makeTask({ id: "B", seq: 2, status: "in-progress", customColumnId: null, createdAt: "2025-01-02T00:00:00Z", columnOrder: 1 }),
+			makeTask({ id: "C", seq: 3, status: "in-progress", customColumnId: "col-b", createdAt: "2025-01-03T00:00:00Z", columnOrder: 7, movedAt: "2025-01-03T00:00:00Z" }),
+		];
+		seedTasks(tasks);
+
+		const updated = await updateTask(testProject, "C", { status: "in-progress", customColumnId: null }, { dropPosition: "top" });
+
+		expect(updated.columnOrder).toBe(0);
+		expect(updated.movedAt).toBeDefined();
+		expect(updated.movedAt).not.toBe("2025-01-03T00:00:00Z");
+		const saved = readSavedTasks();
+		const builtinTasks = saved
+			.filter((t) => t.status === "in-progress" && (t.customColumnId ?? null) === null)
+			.sort((a, b) => (a.columnOrder ?? 999) - (b.columnOrder ?? 999));
+		expect(builtinTasks.map((t) => t.id)).toEqual(["C", "A", "B"]);
+	});
+
+	it("custom column A -> custom column B (same status) resets columnOrder + movedAt", async () => {
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: "col-b", createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+			makeTask({ id: "C", seq: 3, status: "in-progress", customColumnId: "col-a", createdAt: "2025-01-03T00:00:00Z", columnOrder: 7, movedAt: "2025-01-03T00:00:00Z" }),
+		];
+		seedTasks(tasks);
+
+		const updated = await updateTask(testProject, "C", { customColumnId: "col-b" }, { dropPosition: "bottom" });
+
+		expect(updated.columnOrder).toBe(1);
+		expect(updated.movedAt).not.toBe("2025-01-03T00:00:00Z");
+		const saved = readSavedTasks();
+		const colBTasks = saved
+			.filter((t) => t.status === "in-progress" && t.customColumnId === "col-b")
+			.sort((a, b) => (a.columnOrder ?? 999) - (b.columnOrder ?? 999));
+		expect(colBTasks.map((t) => t.id)).toEqual(["A", "C"]);
+	});
+
+	it("same rendered column (no status/customColumnId change) preserves columnOrder", async () => {
+		// Guard: a true no-op (e.g. title edit) must NOT reset columnOrder.
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: "col-a", columnOrder: 5, createdAt: "2025-01-01T00:00:00Z" }),
+		];
+		seedTasks(tasks);
+
+		await updateTask(testProject, "A", { customColumnId: "col-a" }, { dropPosition: "top" });
+
+		const loaded = await loadTasks(testProject);
+		expect(loaded[0].columnOrder).toBe(5);
+	});
+
 	it("without dropPosition, columnOrder is cleared (backward compat)", async () => {
 		const tasks = [
 			makeTask({ id: "A", seq: 1, status: "todo", createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
@@ -722,6 +799,71 @@ describe("columnOrder serialization — undefined handling", () => {
 
 		const loaded = await loadTasks(testProject);
 		expect(loaded[0].columnOrder).toBeUndefined();
+	});
+});
+
+// ============================================================
+// Backward compatibility — same-status column move writes only known fields
+// ============================================================
+
+describe("same-status move — backward compatibility", () => {
+	// Every key the Task type may legitimately carry. A same-status column move
+	// must NOT introduce any field outside this set, so older app versions keep
+	// reading tasks.json without choking on unknown keys.
+	const KNOWN_TASK_KEYS = new Set([
+		"id", "seq", "projectId", "title", "description", "overview", "userOverview",
+		"customTitle", "titleEditedByUser", "status", "baseBranch", "worktreePath",
+		"branchName", "groupId", "variantIndex", "agentId", "configId", "createdAt",
+		"updatedAt", "movedAt", "columnOrder", "tmuxSocket", "labelIds", "existingBranch",
+		"notes", "customColumnId", "history", "preparing", "preparingStage",
+		"preparingProgress", "preparingStartedAt", "watched", "sessionState",
+		"mergeCompletionPrompt", "scratch", "scriptLastRunAt", "scriptLastPlacement",
+	]);
+
+	it("introduces no new task fields when moving builtin -> custom column", async () => {
+		const tasks = [
+			makeTask({ id: "A", seq: 1, status: "in-progress", customColumnId: null, createdAt: "2025-01-01T00:00:00Z", columnOrder: 0 }),
+		];
+		seedTasks(tasks);
+
+		await updateTask(testProject, "A", { customColumnId: "col-a" }, { dropPosition: "top" });
+
+		const saved = readSavedTasks();
+		for (const key of Object.keys(saved[0])) {
+			expect(KNOWN_TASK_KEYS.has(key)).toBe(true);
+		}
+	});
+
+	it("old-version-shaped task (no movedAt/columnOrder) still loads and moves correctly", async () => {
+		// Raw JSON as written by an older app version: no movedAt, no columnOrder,
+		// already sitting in a custom column. The fix must move it without crashing.
+		const raw = [{
+			id: "A",
+			seq: 1,
+			projectId: "proj-1",
+			title: "Old",
+			description: "desc",
+			status: "in-progress",
+			baseBranch: "main",
+			worktreePath: null,
+			branchName: null,
+			groupId: null,
+			variantIndex: null,
+			agentId: null,
+			configId: null,
+			createdAt: "2025-01-01T00:00:00Z",
+			updatedAt: "2025-01-01T00:00:00Z",
+			labelIds: [],
+			customColumnId: "col-a",
+		}];
+		mkdirSync(dirname(tasksFilePath()), { recursive: true });
+		writeFileSync(tasksFilePath(), JSON.stringify(raw));
+
+		const updated = await updateTask(testProject, "A", { customColumnId: null }, { dropPosition: "top" });
+
+		expect(updated.columnOrder).toBe(0);
+		expect(updated.movedAt).toBeDefined();
+		expect(updated.customColumnId).toBeNull();
 	});
 });
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6037,7 +6037,7 @@ describe("moveTaskToCustomColumn — resume logic", () => {
 		const result = await handlers.moveTaskToCustomColumn({ taskId: "task-1", projectId: "proj-1", customColumnId: "col-aaa" });
 
 		expect(git.createWorktree).not.toHaveBeenCalled();
-		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { customColumnId: "col-aaa" });
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { customColumnId: "col-aaa" }, { dropPosition: "top" });
 		expect(result.customColumnId).toBe("col-aaa");
 	});
 
@@ -6102,7 +6102,7 @@ describe("moveTaskToCustomColumn — resume logic", () => {
 
 		const result = await handlers.moveTaskToCustomColumn({ taskId: "task-1", projectId: "proj-1", customColumnId: null });
 
-		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { customColumnId: null });
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { customColumnId: null }, { dropPosition: "top" });
 		expect(result.customColumnId).toBeNull();
 	});
 });

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -503,7 +503,13 @@ const handlers: Record<string, Handler> = {
 				}
 				return updated;
 			}
-			const updated = await data.updateTask(project, task.id, { customColumnId: customColumn.id }, guardOpts);
+			const settings = await loadSettings();
+			const updated = await data.updateTask(
+				project,
+				task.id,
+				{ customColumnId: customColumn.id },
+				{ dropPosition: settings.taskDropPosition, ...guardOpts },
+			);
 			if (updated.customColumnId === customColumn.id) {
 				getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 			}

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -675,17 +675,24 @@ function applyTaskUpdate(
 		return currentTask;
 	}
 	const now = new Date().toISOString();
-	const statusChanged = updates.status && updates.status !== currentTask.status;
+	// A move to a different RENDERED column happens either when the builtin status
+	// changes, or when only customColumnId changes (builtin <-> custom column that
+	// share the same status). Both must reset columnOrder, refresh movedAt and honor
+	// dropPosition — otherwise a stale columnOrder pins the card mid-column on reload.
+	const statusChanged = updates.status !== undefined && updates.status !== currentTask.status;
+	const customColumnChanged =
+		updates.customColumnId !== undefined && (updates.customColumnId ?? null) !== (currentTask.customColumnId ?? null);
+	const renderedColumnChanged = statusChanged || customColumnChanged;
 	const prevTitle = getTaskTitle(currentTask);
 	const prevOverview = getTaskOverview(currentTask);
 
-	if (statusChanged) {
-		const newStatus = updates.status!;
+	if (renderedColumnChanged) {
 		const dropPosition = options?.dropPosition;
 
 		tasks[idx] = { ...tasks[idx], ...updates, movedAt: now, columnOrder: undefined, updatedAt: now };
 
 		if (dropPosition) {
+			const newStatus = tasks[idx].status;
 			const targetCustomColumnId = tasks[idx].customColumnId ?? null;
 			const columnTasks = tasks
 				.filter((t) => t.status === newStatus && (t.customColumnId ?? null) === targetCustomColumnId && t.id !== tasks[idx].id)

--- a/src/bun/rpc-handlers/notes-labels.ts
+++ b/src/bun/rpc-handlers/notes-labels.ts
@@ -184,7 +184,13 @@ async function moveTaskToCustomColumn(params: { taskId: string; projectId: strin
 		return updated;
 	}
 
-	const updated = await data.updateTask(project, params.taskId, { customColumnId: params.customColumnId });
+	const settings = await loadSettings();
+	const updated = await data.updateTask(
+		project,
+		params.taskId,
+		{ customColumnId: params.customColumnId },
+		{ dropPosition: settings.taskDropPosition },
+	);
 	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 	if (column?.agentConfig && updated.worktreePath) {
 		await triggerColumnAgentIfNeeded(updated.status, project, updated, { customColumn: column });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary
- `applyTaskUpdate` only reset `columnOrder`, refreshed `movedAt`, and applied `dropPosition` when the builtin **status** changed. Moving a task between a builtin column and a custom column that share the same status (e.g. In Progress ↔ On hold) changes only `customColumnId`, so the stale `columnOrder` persisted and the card landed mid-column after an app reload instead of at the configured top/bottom.
- Gate the move logic on `renderedColumnChanged` = (status changed) **OR** (`customColumnId` changed), and pass `dropPosition` from the two callers that previously omitted it (`moveTaskToCustomColumn` in `notes-labels.ts`, active→custom in `cli-socket-server.ts`).
- Writes only existing `Task` fields (`columnOrder`, `movedAt`, `updatedAt`, `customColumnId`) — fully backward/forward compatible on disk; downgrade-safe.
- Added failing-first reproduction tests for both directions (builtin→custom, custom→builtin) plus custom→custom and a no-op guard, and explicit backward-compat tests (no new fields written; old-version-shaped task still loads and moves).