### PR TITLE
Fix lost-update race in CLI socket label.delete

### DIFF
--- a/change-logs/2026/06/19/fix-label-delete-lost-update-race.md
+++ b/change-logs/2026/06/19/fix-label-delete-lost-update-race.md
@@ -1,0 +1,1 @@
+Fixed a lost-update race in the CLI socket `label.delete` handler: it recomputed each task's labelIds from a stale snapshot taken outside the per-task lock, so a concurrent labelIds change (e.g. setting labels from the UI) could be silently clobbered. It now recomputes inside the lock via updateTaskWith, mirroring the RPC deleteLabel handler.

--- a/decisions/074-cli-label-delete-locked-recompute.md
+++ b/decisions/074-cli-label-delete-locked-recompute.md
@@ -1,0 +1,36 @@
+# 074 — CLI `label.delete` recomputes labelIds inside the per-task lock
+
+## Context
+The CLI socket `label.delete` handler (`src/bun/cli-socket-server.ts`) removed a
+deleted label from every task by filtering `task.labelIds` from a snapshot loaded
+via `data.loadTasks()` *outside* the lock, then writing it back with
+`data.updateTask()`. Any concurrent `labelIds` mutation landing between the load
+and the write (e.g. `task.setLabels` from the UI) was silently clobbered —
+a classic lost update. The RPC twin `deleteLabel` in
+`src/bun/rpc-handlers/notes-labels.ts` already does it correctly; the two had
+drifted.
+
+## Decision
+The handler now removes the label per task via `data.updateTaskWith(project,
+task.id, currentTask => ...)`, recomputing `labelIds` from `currentTask` *inside*
+the file lock — mirroring the RPC handler. `loadTasks()` is still used only to
+pick which tasks are affected; the authoritative filter happens under the lock.
+
+We deliberately did **not** delegate to the shared `deleteLabel`: it is not
+exported standalone, lacks the CLI's short-prefix resolution and
+`{ deleted: id }` response shape, and importing it would drag the electrobun
+chain into the CLI test setup. The surgical mirror keeps the CLI protocol
+byte-identical (method, params, response) and the on-disk format unchanged, so
+downgrades stay safe.
+
+## Risks
+Low. No format/protocol change. The extra `updateTaskWith` mutator runs the same
+filter as before, just on fresh state.
+
+## Alternatives considered
+- **Delegate to shared `deleteLabel`** — kills duplication but changes response
+  shape / prefix behavior and complicates tests; rejected.
+- **`task.setLabels` unknown-ID passthrough** (same file, line ~446) still
+  persists unresolved IDs ("validation is caller's job"). Left as-is on purpose:
+  tightening it could reject valid full-UUID writes for labels not yet in the
+  loaded project snapshot. Noted here, not changed.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -10,6 +10,7 @@ vi.mock("../data", () => ({
 	getTask: vi.fn(),
 	addTask: vi.fn(),
 	updateTask: vi.fn(),
+	updateTaskWith: vi.fn(),
 	updateProject: vi.fn(),
 }));
 
@@ -1500,7 +1501,7 @@ describe("label.delete", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.updateProject).mockResolvedValue(undefined as any);
 		vi.mocked(data.loadTasks).mockResolvedValue([taskWithLabel, taskWithout]);
-		vi.mocked(data.updateTask).mockResolvedValue(taskWithLabel);
+		vi.mocked(data.updateTaskWith).mockResolvedValue({ task: taskWithLabel, result: undefined } as any);
 
 		const resp = await handleRequest(
 			makeRequest("label.delete", { projectId: "proj-1", labelId: "lbl-full-uuid-1234" }),
@@ -1510,12 +1511,16 @@ describe("label.delete", () => {
 		expect(data.updateProject).toHaveBeenCalledWith("proj-1", {
 			labels: [labels[1]],
 		});
-		// Should update affected task
-		expect(data.updateTask).toHaveBeenCalledWith(project, "t1", {
-			labelIds: ["lbl-2"],
-		});
+		// Should update affected task via the locked mutator (no lost-update race)
+		expect(data.updateTaskWith).toHaveBeenCalledWith(project, "t1", expect.any(Function));
 		// Should NOT update task that didn't have the label
-		expect(data.updateTask).toHaveBeenCalledTimes(1);
+		expect(data.updateTaskWith).toHaveBeenCalledTimes(1);
+		// The mutator must recompute labelIds from the CURRENT task, not a stale snapshot
+		const mutator = vi.mocked(data.updateTaskWith).mock.calls[0][2];
+		expect(await mutator({ ...taskWithLabel, labelIds: ["lbl-full-uuid-1234", "lbl-2", "lbl-3"] } as any)).toEqual({
+			updates: { labelIds: ["lbl-2", "lbl-3"] },
+			result: undefined,
+		});
 	});
 
 	it("matches label by prefix", async () => {

--- a/src/bun/__tests__/cli-socket-label-delete-race.test.ts
+++ b/src/bun/__tests__/cli-socket-label-delete-race.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { CliRequest, Label, Project, Task } from "../../shared/types";
+
+const tempHome = mkdtempSync(join(tmpdir(), "dev3-label-race-"));
+const dev3Home = join(tempHome, ".dev3.0");
+const originalHome = process.env.HOME;
+
+const PROJECT_PATH = "/tmp/label-race-project";
+const PROJECT_SLUG = "tmp-label-race-project";
+
+const LABEL_DELETED = "label-deleted-1111";
+const LABEL_KEPT = "label-kept-2222";
+const LABEL_CONCURRENT = "label-concurrent-3333";
+
+// Injected once, right after the handler reads its (now stale) task snapshot
+// inside `label.delete` — simulates a concurrent UI label change landing in the
+// window between loadTasks() and the per-task update.
+let injectAfterLoad: (() => Promise<void>) | null = null;
+
+vi.mock("../data", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../data")>();
+	return {
+		...actual,
+		loadTasks: vi.fn(async (project: Project) => {
+			const snapshot = await actual.loadTasks(project);
+			if (injectAfterLoad) {
+				const run = injectAfterLoad;
+				injectAfterLoad = null;
+				await run();
+			}
+			return snapshot;
+		}),
+	};
+});
+
+// Break the electrobun import chain (../rpc-handlers → rpc-handlers/shared →
+// ../electrobun-platform) so cli-socket-server can be imported under vitest.
+// The label.delete handler only consumes getPushMessage from this barrel.
+vi.mock("../rpc-handlers", () => ({
+	isActive: vi.fn(() => true),
+	activateTask: vi.fn(),
+	getPushMessage: vi.fn(() => null),
+	getPushMessageLocal: vi.fn(() => null),
+	moveTask: vi.fn(),
+	triggerColumnAgentIfNeeded: vi.fn(),
+	notifyWatchedTaskStatusChange: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/tmux-pty", () => ({
+	getDevServerStatus: vi.fn(),
+	runDevServer: vi.fn(),
+	stopDevServer: vi.fn(),
+	restartDevServer: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+function makeProject(overrides?: Partial<Project>): Project {
+	return {
+		id: "proj-1",
+		name: "Label Race Project",
+		path: PROJECT_PATH,
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: "2026-04-15T00:00:00.000Z",
+		labels: [],
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "proj-1",
+		title: "Label race task",
+		description: "Label race task",
+		status: "in-progress",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2026-04-15T00:00:00.000Z",
+		updatedAt: "2026-04-15T00:00:00.000Z",
+		notes: [],
+		...overrides,
+	};
+}
+
+const LABELS: Label[] = [
+	{ id: LABEL_DELETED, name: "Deleted", color: "#ef4444" },
+	{ id: LABEL_KEPT, name: "Kept", color: "#3b82f6" },
+	{ id: LABEL_CONCURRENT, name: "Concurrent", color: "#22c55e" },
+];
+
+function seed(tasks: Task[], labels: Label[] = LABELS): Project {
+	const project = makeProject({ labels });
+	writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+	mkdirSync(join(dev3Home, "data", PROJECT_SLUG), { recursive: true });
+	writeFileSync(join(dev3Home, "data", PROJECT_SLUG, "tasks.json"), JSON.stringify(tasks, null, 2));
+	return project;
+}
+
+function readTasksRaw(): Task[] {
+	return JSON.parse(readFileSync(join(dev3Home, "data", PROJECT_SLUG, "tasks.json"), "utf8")) as Task[];
+}
+
+function makeRequest(method: string, params: Record<string, unknown>): CliRequest {
+	return { id: "req-1", method, params };
+}
+
+describe("cli-socket label.delete — lost-update race", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		injectAfterLoad = null;
+		process.env.HOME = tempHome;
+		rmSync(tempHome, { recursive: true, force: true });
+		mkdirSync(dev3Home, { recursive: true });
+	});
+
+	afterAll(() => {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	it("does not clobber a concurrent labelIds change made after the snapshot is read", async () => {
+		const data = await import("../data");
+		const { handleRequest } = await import("../cli-socket-server");
+
+		const project = seed([makeTask({ id: "task-1", labelIds: [LABEL_DELETED, LABEL_KEPT] })]);
+
+		// Concurrent UI write: user adds LABEL_CONCURRENT to the task in the window
+		// between the handler's loadTasks() and its per-task update.
+		injectAfterLoad = async () => {
+			await data.updateTask(project, "task-1", {
+				labelIds: [LABEL_DELETED, LABEL_KEPT, LABEL_CONCURRENT],
+			});
+		};
+
+		const resp = await handleRequest(makeRequest("label.delete", { projectId: "proj-1", labelId: LABEL_DELETED }));
+		expect(resp.ok).toBe(true);
+
+		const [task] = readTasksRaw();
+		// The deleted label must be gone...
+		expect(task.labelIds).not.toContain(LABEL_DELETED);
+		// ...and the kept label must survive...
+		expect(task.labelIds).toContain(LABEL_KEPT);
+		// ...and crucially the concurrently-added label must NOT be lost.
+		expect(task.labelIds).toContain(LABEL_CONCURRENT);
+	});
+
+	it("deletes the label from project and all tasks (no concurrency)", async () => {
+		await import("../data");
+		const { handleRequest } = await import("../cli-socket-server");
+
+		seed([
+			makeTask({ id: "task-1", labelIds: [LABEL_DELETED, LABEL_KEPT] }),
+			makeTask({ id: "task-2", seq: 2, labelIds: [LABEL_KEPT] }),
+		]);
+
+		const resp = await handleRequest(makeRequest("label.delete", { projectId: "proj-1", labelId: LABEL_DELETED }));
+		expect(resp.ok).toBe(true);
+
+		const tasks = readTasksRaw();
+		expect(tasks.find((t) => t.id === "task-1")?.labelIds).toEqual([LABEL_KEPT]);
+		expect(tasks.find((t) => t.id === "task-2")?.labelIds).toEqual([LABEL_KEPT]);
+
+		const projects = JSON.parse(readFileSync(join(dev3Home, "projects.json"), "utf8")) as Project[];
+		expect(projects[0].labels?.map((l) => l.id)).toEqual([LABEL_KEPT, LABEL_CONCURRENT]);
+	});
+
+	it("keeps the CLI protocol response shape stable (backward compat)", async () => {
+		await import("../data");
+		const { handleRequest } = await import("../cli-socket-server");
+
+		seed([makeTask({ id: "task-1", labelIds: [LABEL_DELETED] })]);
+
+		const resp = await handleRequest(makeRequest("label.delete", { projectId: "proj-1", labelId: LABEL_DELETED }));
+		expect(resp.id).toBe("req-1");
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toEqual({ deleted: LABEL_DELETED });
+	});
+
+	it("persists tasks.json within the Task schema, readable after a downgrade (backward compat)", async () => {
+		const data = await import("../data");
+		const { handleRequest } = await import("../cli-socket-server");
+
+		const seeded = makeTask({ id: "task-1", labelIds: [LABEL_DELETED, LABEL_KEPT] });
+		seed([seeded]);
+
+		await handleRequest(makeRequest("label.delete", { projectId: "proj-1", labelId: LABEL_DELETED }));
+
+		const [task] = readTasksRaw();
+		// Every originally-seeded field is still present — nothing dropped, so an
+		// older app version reading this file sees no missing data.
+		for (const key of Object.keys(seeded)) {
+			expect(task).toHaveProperty(key);
+		}
+		// labelIds stays a plain string[] (no shape change) with the deleted id removed.
+		expect(Array.isArray(task.labelIds)).toBe(true);
+		expect(task.labelIds).toEqual([LABEL_KEPT]);
+
+		// The on-disk JSON round-trips cleanly back through the data layer.
+		const project = await data.getProject("proj-1");
+		const reloaded = (await data.loadTasks(project)).find((t) => t.id === "task-1");
+		expect(reloaded?.labelIds).toEqual([LABEL_KEPT]);
+	});
+});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -417,12 +417,17 @@ const handlers: Record<string, Handler> = {
 		if (!label) throw new Error(`Label not found: ${labelId}`);
 
 		await data.updateProject(projectId, { labels: labels.filter((l) => l.id !== label.id) });
-		// Remove from all tasks
+		// Remove from all tasks. Recompute labelIds from the CURRENT task inside the
+		// per-task lock (updateTaskWith) — filtering a pre-lock snapshot would clobber
+		// any concurrent labelIds change. Mirrors the RPC deleteLabel handler.
 		const tasks = await data.loadTasks(project);
 		for (const task of tasks.filter((t) => t.labelIds?.includes(label.id))) {
-			await data.updateTask(project, task.id, {
-				labelIds: (task.labelIds ?? []).filter((id) => id !== label.id),
-			});
+			await data.updateTaskWith(project, task.id, async (currentTask) => ({
+				updates: {
+					labelIds: (currentTask.labelIds ?? []).filter((id) => id !== label.id),
+				},
+				result: undefined,
+			}));
 		}
 		getPushMessage()?.("projectUpdated", { project: await data.getProject(projectId) });
 		return { deleted: label.id };


### PR DESCRIPTION
## Summary

The CLI socket `label.delete` handler removed a deleted label from every affected task by filtering each task's `labelIds` from a snapshot loaded **outside** the per-task file lock (`data.loadTasks()`), then writing it back with `data.updateTask()`. Any concurrent `labelIds` change landing in the window between the load and the write (e.g. `task.setLabels` from the UI) was silently clobbered — a classic lost update. The RPC twin `deleteLabel` (`src/bun/rpc-handlers/notes-labels.ts`) already did this correctly; the two implementations had drifted.

The handler now recomputes `labelIds` from the **current** task inside the lock via `data.updateTaskWith`, mirroring the RPC handler. `loadTasks()` is still used only to pick which tasks are affected; the authoritative filter happens under the lock.

Surgical fix rather than full delegation to the shared `deleteLabel`, to keep the CLI protocol byte-identical (method, params, `{ deleted: id }` response) and the on-disk format unchanged — downgrades stay safe. The `task.setLabels` unknown-ID passthrough is left as-is on purpose (noted in decision 074).

## Verification

- New repro test `cli-socket-label-delete-race.test.ts` deterministically interleaves a concurrent `labelIds` write between the handler's snapshot read and its per-task update — fails on the old code (concurrent label lost), passes after the fix.
- Backward-compat tests added: `label.delete` response shape unchanged, persisted task JSON stays within the Task schema and round-trips through the data layer.
- `bun run lint` clean; full `bun run test` green (mainview 1486, bun 1459).

Decision record: `decisions/074-cli-label-delete-locked-recompute.md`.