### PR TITLE
Evaluate move guards before activateTask to prevent leaked worktrees

### DIFF
--- a/change-logs/2026/06/19/fix-guard-before-activate-task.md
+++ b/change-logs/2026/06/19/fix-guard-before-activate-task.md
@@ -1,0 +1,1 @@
+Fixed a leaked git worktree and tmux/PTY session that occurred when a conditional task move (--if-status / --if-status-not) was blocked: the guard is now evaluated before activateTask, so no worktree is created when the move is rejected. The authoritative in-lock guard inside updateTask is unchanged.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1229,6 +1229,91 @@ describe("task.move", () => {
 		expect(activateTask).toHaveBeenCalledWith(project, task, { isReopen: true });
 	});
 
+	it("blocked guard (todo, --if-status-not todo): does NOT activate worktree, returns unchanged task", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null, branchName: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		// updateTask is the authoritative guard; if reached with a blocking guard
+		// it would return the unchanged task. The pre-check must prevent activateTask.
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		const resp = await handleRequest(
+			makeRequest("task.move", {
+				taskId: task.id,
+				projectId: "proj-1",
+				newStatus: "in-progress",
+				ifStatusNot: "todo",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toEqual(task);
+		expect(activateTask).not.toHaveBeenCalled();
+	});
+
+	it("passing guard (todo, --if-status-not completed): still activates worktree", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null, branchName: null });
+		const wtResult = { worktreePath: "/tmp/new-wt", branchName: "dev3/task-new" };
+		const updated = { ...task, status: "in-progress" as const, ...wtResult };
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(activateTask).mockResolvedValue(wtResult);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		const resp = await handleRequest(
+			makeRequest("task.move", {
+				taskId: task.id,
+				projectId: "proj-1",
+				newStatus: "in-progress",
+				ifStatusNot: "completed",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(activateTask).toHaveBeenCalledWith(project, task, { isReopen: false });
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, {
+			status: "in-progress",
+			worktreePath: "/tmp/new-wt",
+			branchName: "dev3/task-new",
+			customColumnId: null,
+		}, { dropPosition: "top", ifStatusNot: "completed" });
+	});
+
+	it("blocked guard (completed → custom column, --if-status-not completed): does NOT reactivate worktree", async () => {
+		const customColumn = {
+			id: "col-1234abcd-0000-0000-0000-000000000000",
+			name: "Review",
+			color: "#3b82f6",
+			llmInstruction: "",
+		};
+		const project = makeProject({ customColumns: [customColumn] });
+		const task = makeTask({ status: "completed", worktreePath: null, branchName: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		const resp = await handleRequest(
+			makeRequest("task.move", {
+				taskId: task.id,
+				projectId: "proj-1",
+				newStatus: customColumn.id,
+				ifStatusNot: "completed",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toEqual(task);
+		expect(activateTask).not.toHaveBeenCalled();
+	});
+
 	it("active → completed: destroys PTY, runs cleanup, removes worktree", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress" });

--- a/src/bun/__tests__/data-race.test.ts
+++ b/src/bun/__tests__/data-race.test.ts
@@ -114,4 +114,34 @@ describe("data race-safe mutators", () => {
 		const mergedNotes = results.find(({ task: updatedTask }) => (updatedTask.notes?.length ?? 0) === 3)?.task.notes;
 		expect(mergedNotes?.map((note) => note.content).sort()).toEqual(["Base", "One", "Two"]);
 	});
+
+	it("authoritative guard: blocked updateTask returns the unchanged task without throwing", async () => {
+		const data = await import("../data");
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null });
+		writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+		mkdirSync(join(dev3Home, "data", "tmp-race-test-project"), { recursive: true });
+		writeFileSync(join(dev3Home, "data", "tmp-race-test-project", "tasks.json"), JSON.stringify([task], null, 2));
+
+		const result = await data.updateTask(project, task.id, { status: "in-progress" }, { ifStatusNot: "todo" });
+
+		expect(result.status).toBe("todo");
+		const persisted = await data.loadTasks(project);
+		expect(persisted[0].status).toBe("todo");
+	});
+
+	it("authoritative guard: passing updateTask applies the change", async () => {
+		const data = await import("../data");
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null });
+		writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+		mkdirSync(join(dev3Home, "data", "tmp-race-test-project"), { recursive: true });
+		writeFileSync(join(dev3Home, "data", "tmp-race-test-project", "tasks.json"), JSON.stringify([task], null, 2));
+
+		const result = await data.updateTask(project, task.id, { status: "in-progress" }, { ifStatusNot: "completed" });
+
+		expect(result.status).toBe("in-progress");
+		const persisted = await data.loadTasks(project);
+		expect(persisted[0].status).toBe("in-progress");
+	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1717,6 +1717,50 @@ describe("handlers.moveTask", () => {
 		expect(pty.createSession).toHaveBeenCalled();
 	});
 
+	it("blocked guard (todo, --if-status-not todo): does NOT create worktree, returns unchanged task", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/wt", branchName: "dev3/t" });
+		// Authoritative in-lock guard would return the unchanged task; the pre-check
+		// must short-circuit before activateTask so no worktree is created.
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+
+		const result = await handlers.moveTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			newStatus: "in-progress",
+			ifStatusNot: "todo",
+		});
+
+		expect(result.status).toBe("todo");
+		expect(git.createWorktree).not.toHaveBeenCalled();
+		expect(pty.createSession).not.toHaveBeenCalled();
+	});
+
+	it("passing guard (todo, --if-status-not completed): still creates worktree", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", worktreePath: null });
+		const updatedTask = makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/t" });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/wt", branchName: "dev3/t" });
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+
+		const result = await handlers.moveTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			newStatus: "in-progress",
+			ifStatusNot: "completed",
+		});
+
+		expect(result.status).toBe("in-progress");
+		expect(git.createWorktree).toHaveBeenCalled();
+	});
+
 	it("todo → in-progress defaults agent stop target to review-by-user when automatic review is off", async () => {
 		const project = makeProject({ autoReviewEnabled: false });
 		const task = makeTask({ status: "todo", worktreePath: null });

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 import type { CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource } from "../shared/types";
-import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, getAllowedTransitions, getTaskTitle, titleFromDescription } from "../shared/types";
+import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, LABEL_COLORS, getAllowedTransitions, getTaskTitle, isStatusGuardBlocked, titleFromDescription } from "../shared/types";
 import { createCompletionRequest } from "./completion-requests";
 import * as data from "./data";
 import { isActive, activateTask, getPushMessage, getPushMessageLocal, moveTask, triggerColumnAgentIfNeeded, notifyWatchedTaskStatusChange } from "./rpc-handlers";
@@ -486,6 +486,11 @@ const handlers: Record<string, Handler> = {
 		if (customColumn) {
 			// Moving from completed/cancelled into a custom column resumes the task
 			if (task.status === "completed" || task.status === "cancelled") {
+				// Pre-check the guard before activateTask so a blocked move does not
+				// leak a worktree/PTY. The authoritative check still runs inside the lock.
+				if (isStatusGuardBlocked(task.status, guardOpts)) {
+					return task;
+				}
 				const settings = await loadSettings();
 				const wt = await activateTask(project, task, { isReopen: true });
 				const updated = await data.updateTask(project, task.id, {
@@ -542,6 +547,11 @@ const handlers: Record<string, Handler> = {
 
 		// inactive → active: create worktree + PTY
 		if (!isActive(oldStatus) && isActive(builtinStatus)) {
+			// Pre-check the guard before activateTask so a blocked move does not
+			// leak a worktree/PTY. The authoritative check still runs inside the lock.
+			if (isStatusGuardBlocked(oldStatus, guardOpts)) {
+				return task;
+			}
 			const isReopen = oldStatus === "completed" || oldStatus === "cancelled";
 			const wt = await activateTask(project, task, { isReopen });
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import type { Project, Task, TaskHistoryChange, TaskHistoryEntry, TaskStatus, TipState } from "../shared/types";
-import { getTaskOverview, getTaskTitle, titleFromDescription } from "../shared/types";
+import { getTaskOverview, getTaskTitle, isStatusGuardBlocked, titleFromDescription } from "../shared/types";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
 import { detectClonePaths } from "./cow-clone";
@@ -681,18 +681,8 @@ function applyTaskUpdate(
 	},
 ): Task {
 	const currentTask = tasks[idx];
-	const allowedStatuses = options?.ifStatus
-		?.split(",")
-		.map((status) => status.trim())
-		.filter(Boolean);
-	if (allowedStatuses && !allowedStatuses.includes(currentTask.status)) {
-		return currentTask;
-	}
-	const blockedStatuses = options?.ifStatusNot
-		?.split(",")
-		.map((status) => status.trim())
-		.filter(Boolean);
-	if (blockedStatuses && blockedStatuses.includes(currentTask.status)) {
+	// Authoritative guard check (runs inside the file lock).
+	if (isStatusGuardBlocked(currentTask.status, options)) {
 		return currentTask;
 	}
 	const now = new Date().toISOString();

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { ColumnAgentConfig, CustomColumn, PreparingStage, Project, Task, TaskStatus } from "../../shared/types";
-import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, getPreparingStageProgress, getTaskTitle, titleFromDescription } from "../../shared/types";
+import { ACTIVE_STATUSES, DEFAULT_REVIEW_PROMPT, getPreparingStageProgress, getTaskTitle, isStatusGuardBlocked, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
@@ -661,6 +661,12 @@ export async function moveTask(params: {
 	clearMergeNotification(task.id);
 
 	if (!isActive(oldStatus) && isActive(newStatus)) {
+		// Pre-check the move guard before activateTask so a blocked move does not
+		// leak a worktree/PTY. The authoritative check still runs inside the lock.
+		if (isStatusGuardBlocked(oldStatus, guardOpts)) {
+			log.info("Move guard blocked inactive → active; skipping activateTask", { taskId: task.id, oldStatus });
+			return task;
+		}
 		const isReopen = oldStatus === "completed" || oldStatus === "cancelled";
 		log.info("Transition: inactive → active, creating worktree + PTY", { isReopen });
 		const wt = await activateTask(project, task, { isReopen });

--- a/src/mainview/__tests__/transitions.test.ts
+++ b/src/mainview/__tests__/transitions.test.ts
@@ -1,4 +1,4 @@
-import { getAllowedTransitions } from "../../shared/types";
+import { getAllowedTransitions, isStatusGuardBlocked } from "../../shared/types";
 import type { TaskStatus } from "../../shared/types";
 
 describe("getAllowedTransitions", () => {
@@ -43,5 +43,32 @@ describe("getAllowedTransitions", () => {
 		for (const s of statuses) {
 			expect(getAllowedTransitions(s)).not.toContain(s);
 		}
+	});
+});
+
+describe("isStatusGuardBlocked", () => {
+	it("no guard options → never blocked", () => {
+		expect(isStatusGuardBlocked("todo")).toBe(false);
+		expect(isStatusGuardBlocked("todo", {})).toBe(false);
+	});
+
+	it("ifStatus: blocks when current status not in the allow-list", () => {
+		expect(isStatusGuardBlocked("todo", { ifStatus: "in-progress" })).toBe(true);
+		expect(isStatusGuardBlocked("in-progress", { ifStatus: "in-progress" })).toBe(false);
+	});
+
+	it("ifStatus: supports comma-separated lists with whitespace", () => {
+		expect(isStatusGuardBlocked("user-questions", { ifStatus: "in-progress, user-questions" })).toBe(false);
+		expect(isStatusGuardBlocked("todo", { ifStatus: "in-progress, user-questions" })).toBe(true);
+	});
+
+	it("ifStatusNot: blocks when current status is in the deny-list", () => {
+		expect(isStatusGuardBlocked("todo", { ifStatusNot: "todo" })).toBe(true);
+		expect(isStatusGuardBlocked("in-progress", { ifStatusNot: "todo" })).toBe(false);
+	});
+
+	it("ifStatusNot: supports comma-separated lists", () => {
+		expect(isStatusGuardBlocked("completed", { ifStatusNot: "completed,cancelled" })).toBe(true);
+		expect(isStatusGuardBlocked("in-progress", { ifStatusNot: "completed,cancelled" })).toBe(false);
 	});
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,32 @@ export function getAllowedTransitions(current: TaskStatus): TaskStatus[] {
 	return ALL_STATUSES.filter((s) => s !== current);
 }
 
+// Conditional-move guards (--if-status / --if-status-not). Returns true when a
+// move should be blocked given the task's current status. This is the single
+// source of truth, used both by the authoritative in-lock check in data.ts and
+// by pre-checks at call sites that must avoid side effects (worktree/PTY) when a
+// guarded move is blocked.
+export function isStatusGuardBlocked(
+	status: string,
+	options?: { ifStatus?: string; ifStatusNot?: string },
+): boolean {
+	const allowedStatuses = options?.ifStatus
+		?.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	if (allowedStatuses && !allowedStatuses.includes(status)) {
+		return true;
+	}
+	const blockedStatuses = options?.ifStatusNot
+		?.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	if (blockedStatuses && blockedStatuses.includes(status)) {
+		return true;
+	}
+	return false;
+}
+
 // ---- Column Agents ----
 
 export interface ColumnAgentConfig {


### PR DESCRIPTION
## Summary

Conditional task moves (`--if-status` / `--if-status-not`) only evaluated the guard **inside** `data.updateTask` → `applyTaskUpdate`, but every inactive→active caller ran `activateTask` (git worktree + PTY + tmux session) **before** that check. When the guard blocked the move, the worktree and terminal session were already created and silently orphaned while the task stayed in its old status.

This adds a single `isStatusGuardBlocked` helper in `src/shared/types.ts` (one source of truth) and pre-checks it **before** `activateTask` at all three call sites:
- `cli-socket-server.ts` — builtin `task.move` inactive→active branch
- `cli-socket-server.ts` — completed/cancelled → custom-column reopen branch
- `task-lifecycle.ts` — `moveTask` inactive→active branch

The authoritative in-lock check inside `applyTaskUpdate` is preserved and now reuses the same helper.

## Behavior / compatibility

- Blocked-move response shape is unchanged (the unchanged task is returned, no error thrown).
- Successful-move behavior is unchanged.
- No CLI exit-code, socket-method, or on-disk-layout changes — older CLI binaries keep working and the app can be downgraded safely.

## Tests

- New failing-first tests reproduce the leak (guard blocked → `activateTask`/`createWorktree` was invoked), now green.
- Added coverage: `isStatusGuardBlocked` unit tests, cli-socket guarded builtin + custom-column branches, `moveTask` guarded branch, and authoritative in-lock `data.updateTask` guard tests.
- `bun run lint` clean; `bun run test` green (mainview 1491, bun 1462).

---
Hi, this is Claude (the AI assistant working on this PR).