### PR TITLE
Force merge-completion prompt on manual git refresh

### DIFF
--- a/change-logs/2026/06/19/feature-git-refresh-force-merge-check.md
+++ b/change-logs/2026/06/19/feature-git-refresh-force-merge-check.md
@@ -1,0 +1,1 @@
+The git refresh button in a task now force-checks whether the branch is fully merged into its base. If it is, the "Branch Merged — complete the task?" prompt reappears even after you dismissed it earlier (bypassing the usual suppression), and you get a toast when nothing is mergeable yet.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6881,6 +6881,95 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 	});
 });
 
+describe("prepareMergeCompletionPrompt (force re-check)", () => {
+	const FINGERPRINT = "v1:dev3/task-test:abc123";
+	let project: Project;
+
+	function dismissedTask(): Task {
+		return makeTask({
+			status: "review-by-user",
+			mergeCompletionPrompt: {
+				fingerprint: FINGERPRINT,
+				promptedAt: "2026-06-01T08:00:00.000Z",
+				dismissedAt: "2026-06-01T08:01:00.000Z",
+				precise: true,
+			},
+		});
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		_resetMergePollerState();
+		project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.updateTask).mockImplementation(async (_p: Project, _id: string, patch: Partial<Task>) => makeTask(patch));
+	});
+
+	afterEach(() => {
+		_resetMergePollerState();
+	});
+
+	it("suppresses a dismissed precise head on a normal (non-forced) check", async () => {
+		vi.mocked(data.getTask).mockResolvedValue(dismissedTask());
+		const res = await handlers.prepareMergeCompletionPrompt({
+			taskId: "task-1",
+			projectId: "proj-1",
+			fingerprint: FINGERPRINT,
+		});
+		expect(res.shouldPrompt).toBe(false);
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("re-offers a dismissed precise head when force is set (user clicked git refresh)", async () => {
+		vi.mocked(data.getTask).mockResolvedValue(dismissedTask());
+		const res = await handlers.prepareMergeCompletionPrompt({
+			taskId: "task-1",
+			projectId: "proj-1",
+			fingerprint: FINGERPRINT,
+			force: true,
+		});
+		expect(res.shouldPrompt).toBe(true);
+		// The forced reservation clears the prior dismissal so the popup can show.
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			mergeCompletionPrompt: {
+				fingerprint: FINGERPRINT,
+				promptedAt: expect.any(String),
+				dismissedAt: null,
+				precise: true,
+			},
+		});
+	});
+
+	it("force bypasses the in-memory reservation that mutes back-to-back non-forced checks", async () => {
+		// A fresh, never-dismissed merged head.
+		vi.mocked(data.getTask).mockResolvedValue(makeTask({ status: "review-by-user" }));
+
+		const first = await handlers.prepareMergeCompletionPrompt({
+			taskId: "task-1",
+			projectId: "proj-1",
+			fingerprint: FINGERPRINT,
+		});
+		expect(first.shouldPrompt).toBe(true);
+
+		// A second non-forced check is throttled by the in-memory reservation.
+		const second = await handlers.prepareMergeCompletionPrompt({
+			taskId: "task-1",
+			projectId: "proj-1",
+			fingerprint: FINGERPRINT,
+		});
+		expect(second.shouldPrompt).toBe(false);
+
+		// Forcing it re-offers despite the reservation.
+		const forced = await handlers.prepareMergeCompletionPrompt({
+			taskId: "task-1",
+			projectId: "proj-1",
+			fingerprint: FINGERPRINT,
+			force: true,
+		});
+		expect(forced.shouldPrompt).toBe(true);
+	});
+});
+
 describe("startPRDetectionPoller / stopPRDetectionPoller", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -94,14 +94,19 @@ async function getMergeCompletionFingerprint(task: Pick<Task, "id" | "worktreePa
 	};
 }
 
-async function reserveMergeCompletionPrompt(project: Project, task: Task, fingerprint: MergeCompletionFingerprint, now = new Date()): Promise<boolean> {
+async function reserveMergeCompletionPrompt(project: Project, task: Task, fingerprint: MergeCompletionFingerprint, now = new Date(), force = false): Promise<boolean> {
 	const promptKey = mergePromptKey(task.id, fingerprint.fingerprint);
 	const nowMs = now.getTime();
-	if (isPromptKeyReserved(promptKey, nowMs)) return false;
+	// A forced re-check (user clicked the git refresh button) deliberately
+	// ignores the in-memory reservation and any prior dismissal: an explicit
+	// click means "ask me again, regardless of what I answered before".
+	if (!force) {
+		if (isPromptKeyReserved(promptKey, nowMs)) return false;
 
-	if (shouldSuppressMergePrompt(task.mergeCompletionPrompt, fingerprint, nowMs)) {
-		mergeNotifiedPromptKeys.set(promptKey, nowMs);
-		return false;
+		if (shouldSuppressMergePrompt(task.mergeCompletionPrompt, fingerprint, nowMs)) {
+			mergeNotifiedPromptKeys.set(promptKey, nowMs);
+			return false;
+		}
 	}
 
 	// Reserve the slot before awaiting so concurrent callers see the key immediately
@@ -118,13 +123,13 @@ async function reserveMergeCompletionPrompt(project: Project, task: Task, finger
 	return true;
 }
 
-async function prepareMergeCompletionPrompt(params: { taskId: string; projectId: string; fingerprint?: string | null }): Promise<{ shouldPrompt: boolean; fingerprint: string | null }> {
+async function prepareMergeCompletionPrompt(params: { taskId: string; projectId: string; fingerprint?: string | null; force?: boolean }): Promise<{ shouldPrompt: boolean; fingerprint: string | null }> {
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
 	const fingerprint = params.fingerprint
 		? { fingerprint: params.fingerprint, precise: params.fingerprint.startsWith("v1:") }
 		: await getMergeCompletionFingerprint(task, task.branchName);
-	const shouldPrompt = await reserveMergeCompletionPrompt(project, task, fingerprint);
+	const shouldPrompt = await reserveMergeCompletionPrompt(project, task, fingerprint, new Date(), params.force === true);
 	return { shouldPrompt, fingerprint: fingerprint.fingerprint };
 }
 

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -51,7 +51,6 @@ export function useTaskBranchStatus({
 	const [creatingPR, setCreatingPR] = useState(false);
 	const [refreshingStatus, setRefreshingStatus] = useState(false);
 	const mergeDialogShownRef = useRef(false);
-	const fetchStatusRef = useRef<(() => Promise<void>) | null>(null);
 
 	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
 	const defaultCompareRef = getDefaultTaskCompareRef(baseBranch, project);
@@ -74,22 +73,94 @@ export function useTaskBranchStatus({
 		});
 	}, [dispatch, navigate, project, task, t]);
 
+	// Offers the "Branch Merged → complete the task?" popup when the branch is
+	// fully merged into its base. `force` is set when the user explicitly clicks
+	// the git refresh button: it re-asks even after a prior dismissal or within
+	// the same session (bypassing both the in-memory once-guard and the backend
+	// suppression), and gives an explicit toast when nothing is mergeable yet.
+	const offerMergeCompletionIfMerged = useCallback(
+		async (status: BranchStatus, { force }: { force: boolean }) => {
+			// mergedByContent is computed against whatever ref the user selected in
+			// the compare dropdown. The completion prompt is only meaningful against
+			// the task's real base branch.
+			const isDefaultBaseCompare =
+				!compareRef || compareRef === baseBranch || compareRef === `origin/${baseBranch}`;
+			const eligible =
+				status.mergedByContent &&
+				isDefaultBaseCompare &&
+				// The popup claims "no changes left" — uncommitted changes mean that's
+				// false, and completing would destroy them.
+				status.insertions === 0 &&
+				status.deletions === 0 &&
+				MERGE_COMPLETE_ELIGIBLE_STATUSES.includes(task.status);
+
+			if (!eligible) {
+				if (force) {
+					toast.info(t("infoPanel.mergeCheckNotMerged", { branch: baseBranch }));
+				}
+				return;
+			}
+
+			if (!force && mergeDialogShownRef.current) {
+				return;
+			}
+
+			const promptState = await api.request.prepareMergeCompletionPrompt({
+				taskId: task.id,
+				projectId: project.id,
+				fingerprint: status.mergeCompletionFingerprint,
+				force,
+			});
+			if (!force) {
+				mergeDialogShownRef.current = true;
+			}
+			if (!promptState.shouldPrompt) {
+				return;
+			}
+
+			const runPrompt = () =>
+				confirm({
+					title: t("app.branchMergedTitle"),
+					message: t("app.branchMergedMessage", {
+						taskTitle: task.customTitle || task.title,
+						branchName: task.branchName || "",
+					}),
+				});
+			const shouldComplete = force
+				? await runPrompt()
+				: await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, runPrompt);
+			if (shouldComplete) {
+				completeTask();
+			} else if (shouldComplete === false) {
+				await api.request.dismissMergeCompletionPrompt({
+					taskId: task.id,
+					projectId: project.id,
+					fingerprint: promptState.fingerprint,
+				});
+			}
+		},
+		[
+			baseBranch,
+			compareRef,
+			completeTask,
+			project.id,
+			task.branchName,
+			task.customTitle,
+			task.id,
+			task.status,
+			task.title,
+			t,
+		],
+	);
+
 	useEffect(() => {
 		if (!isTaskActive || !task.worktreePath) {
 			setBranchStatus(null);
-			fetchStatusRef.current = null;
 			return;
 		}
 
 		mergeDialogShownRef.current = false;
 		let cancelled = false;
-
-		// mergedByContent is computed against whatever ref the user selected in
-		// the compare dropdown. The completion prompt is only meaningful against
-		// the task's real base branch — comparing against another ref must never
-		// trigger a "Branch Merged" popup.
-		const isDefaultBaseCompare =
-			!compareRef || compareRef === baseBranch || compareRef === `origin/${baseBranch}`;
 
 		const fetchStatus = async () => {
 			try {
@@ -101,51 +172,13 @@ export function useTaskBranchStatus({
 
 				if (!cancelled) {
 					setBranchStatus(status);
-
-					if (
-						status.mergedByContent &&
-						isDefaultBaseCompare &&
-						// The popup claims "no changes left" — uncommitted changes
-						// mean that's false, and completing would destroy them.
-						status.insertions === 0 &&
-						status.deletions === 0 &&
-						MERGE_COMPLETE_ELIGIBLE_STATUSES.includes(task.status) &&
-						!mergeDialogShownRef.current
-					) {
-						const promptState = await api.request.prepareMergeCompletionPrompt({
-							taskId: task.id,
-							projectId: project.id,
-							fingerprint: status.mergeCompletionFingerprint,
-						});
-						mergeDialogShownRef.current = true;
-						if (promptState.shouldPrompt) {
-							const shouldComplete = await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, () =>
-								confirm({
-									title: t("app.branchMergedTitle"),
-									message: t("app.branchMergedMessage", {
-										taskTitle: task.customTitle || task.title,
-										branchName: task.branchName || "",
-									}),
-								}),
-							);
-							if (shouldComplete) {
-								completeTask();
-							} else if (shouldComplete === false) {
-								await api.request.dismissMergeCompletionPrompt({
-									taskId: task.id,
-									projectId: project.id,
-									fingerprint: promptState.fingerprint,
-								});
-							}
-						}
-					}
+					await offerMergeCompletionIfMerged(status, { force: false });
 				}
 			} catch {
 				// Polling retries on the next tick.
 			}
 		};
 
-		fetchStatusRef.current = fetchStatus;
 		const stop = startVisibilityAwarePoll({ fn: fetchStatus, intervalMs: 15_000 });
 
 		return () => {
@@ -153,18 +186,12 @@ export function useTaskBranchStatus({
 			stop();
 		};
 	}, [
-		baseBranch,
 		compareRef,
-		completeTask,
 		isTaskActive,
+		offerMergeCompletionIfMerged,
 		project.id,
-		task.branchName,
-		task.customTitle,
 		task.id,
-		task.status,
-		task.title,
 		task.worktreePath,
-		t,
 	]);
 
 	const handleCreatePR = useCallback(async (autoMerge = false) => {
@@ -247,14 +274,26 @@ export function useTaskBranchStatus({
 	}, [compareRef, completeTask, handleCreatePR, project.id, task.id, task.status, t]);
 
 	const handleRefreshStatus = useCallback(async () => {
-		if (refreshingStatus || !fetchStatusRef.current) {
+		if (refreshingStatus || !isTaskActive || !task.worktreePath) {
 			return;
 		}
 
 		setRefreshingStatus(true);
-		await fetchStatusRef.current();
+		try {
+			const status = await api.request.getBranchStatus({
+				taskId: task.id,
+				projectId: project.id,
+				compareRef: compareRef || undefined,
+			});
+			setBranchStatus(status);
+			// A manual click is a force re-check: re-offer completion even if the
+			// user dismissed the popup earlier for this same merged head.
+			await offerMergeCompletionIfMerged(status, { force: true });
+		} catch (err) {
+			toast.error(t("infoPanel.refreshStatusFailed", { error: String(err) }));
+		}
 		setRefreshingStatus(false);
-	}, [refreshingStatus]);
+	}, [compareRef, isTaskActive, offerMergeCompletionIfMerged, project.id, refreshingStatus, task.id, task.worktreePath, t]);
 
 	const handleRebase = useCallback(async () => {
 		if (rebasing) {

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -59,6 +59,8 @@ const infoPanel = {
 	"infoPanel.fileBrowserFailed": "Failed to open file browser: {error}",
 	"infoPanel.uncommittedChanges": "+{ins} / −{del}",
 	"infoPanel.refreshStatus": "Refresh branch status",
+	"infoPanel.refreshStatusFailed": "Failed to refresh branch status: {error}",
+	"infoPanel.mergeCheckNotMerged": "Branch isn't fully merged into {branch} yet",
 	"infoPanel.movedAt": "Moved",
 	"infoPanel.baseBranch": "Base Branch",
 	"infoPanel.copyPath": "Copy path to this git worktree",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -242,6 +242,8 @@ const tips = {
 	"tip.diffSyntaxHighlight.body": "The diff viewer colors code by language and follows your light/dark theme, so changes are easier to scan.",
 	"tip.sidebarAttentionMode.title": "Bell = needs your eyes",
 	"tip.sidebarAttentionMode.body": "Click the bell icon in the sidebar to see every task waiting for your input across all projects, sorted oldest-first.",
+	"tip.gitRefreshForceMergeCheck.title": "Refresh re-checks the merge",
+	"tip.gitRefreshForceMergeCheck.body": "Click the git refresh icon to re-check the merge — if your branch is fully merged, the completion prompt comes back even if you dismissed it before.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -59,6 +59,8 @@ const infoPanel = {
 	"infoPanel.fileBrowserFailed": "Error al abrir el explorador de archivos: {error}",
 	"infoPanel.uncommittedChanges": "+{ins} / −{del}",
 	"infoPanel.refreshStatus": "Actualizar estado de la rama",
+	"infoPanel.refreshStatusFailed": "Error al actualizar el estado de la rama: {error}",
+	"infoPanel.mergeCheckNotMerged": "La rama aún no está completamente fusionada en {branch}",
 	"infoPanel.movedAt": "Movido",
 	"infoPanel.baseBranch": "Rama base",
 	"infoPanel.copyPath": "Copiar la ruta de este git worktree",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -242,6 +242,8 @@ const tips = {
 	"tip.diffSyntaxHighlight.body": "El visor de diffs colorea el código según el lenguaje y sigue tu tema claro/oscuro, así los cambios son más fáciles de leer.",
 	"tip.sidebarAttentionMode.title": "Campana = necesita tu atención",
 	"tip.sidebarAttentionMode.body": "Pulsa el icono de campana en el panel para ver todas las tareas esperando tu respuesta en todos los proyectos, ordenadas de más antigua a más reciente.",
+	"tip.gitRefreshForceMergeCheck.title": "Refresh revisa la fusión de nuevo",
+	"tip.gitRefreshForceMergeCheck.body": "Pulsa el icono de git refresh para revisar la fusión de nuevo — si tu rama está totalmente fusionada, el aviso de finalización vuelve a aparecer aunque lo hayas descartado antes.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -59,6 +59,8 @@ const infoPanel = {
 	"infoPanel.fileBrowserFailed": "Не удалось открыть файловый браузер: {error}",
 	"infoPanel.uncommittedChanges": "+{ins} / −{del}",
 	"infoPanel.refreshStatus": "Обновить статус ветки",
+	"infoPanel.refreshStatusFailed": "Не удалось обновить статус ветки: {error}",
+	"infoPanel.mergeCheckNotMerged": "Ветка ещё не полностью влита в {branch}",
 	"infoPanel.movedAt": "Перемещено",
 	"infoPanel.baseBranch": "Базовая ветка",
 	"infoPanel.copyPath": "Скопировать путь к этому git worktree",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -242,6 +242,8 @@ const tips = {
 	"tip.diffSyntaxHighlight.body": "Просмотрщик диффов подсвечивает код по языку и следует светлой/тёмной теме — изменения легче читать.",
 	"tip.sidebarAttentionMode.title": "Колокол = ждёт твоих глаз",
 	"tip.sidebarAttentionMode.body": "Кликни иконку колокола в панели, чтобы увидеть все задачи, ожидающие твоего ответа по всем проектам, начиная с самых старых.",
+	"tip.gitRefreshForceMergeCheck.title": "Refresh заново проверяет merge",
+	"tip.gitRefreshForceMergeCheck.body": "Нажми иконку git refresh, чтобы заново проверить merge — если ветка полностью влита, окно завершения вернётся, даже если ты его раньше закрыл.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -769,6 +769,12 @@ const ALL_TIPS: Tip[] = [
 		bodyKey: "tip.sidebarAttentionMode.body",
 		icon: "\u{F0A2}", // nf-fa-bell
 	},
+	{
+		id: "git-refresh-force-merge-check",
+		titleKey: "tip.gitRefreshForceMergeCheck.title",
+		bodyKey: "tip.gitRefreshForceMergeCheck.body",
+		icon: "\u{F0450}", // nf-md-refresh
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1243,7 +1243,7 @@ export type AppRPCSchema = {
 				response: Task[];
 			};
 			prepareMergeCompletionPrompt: {
-				params: { taskId: string; projectId: string; fingerprint?: string | null };
+				params: { taskId: string; projectId: string; fingerprint?: string | null; force?: boolean };
 				response: { shouldPrompt: boolean; fingerprint: string | null };
 			};
 			dismissMergeCompletionPrompt: {


### PR DESCRIPTION
## Summary

- The git refresh button in a task now **force-re-checks** whether the branch is fully merged into its base and re-offers the "Branch Merged → complete the task?" prompt **even after a prior dismissal**, bypassing both the in-memory once-guard and the backend suppression. A manual click means "ask me again, regardless of what I answered before".
- Adds a `force` flag to the `prepareMergeCompletionPrompt` RPC; `reserveMergeCompletionPrompt` skips `isPromptKeyReserved` + `shouldSuppressMergePrompt` when forced.
- Frontend `useTaskBranchStatus` extracts a shared `offerMergeCompletionIfMerged(status, { force })` used by both the 15s poll (`force: false`, unchanged behavior) and the refresh button (`force: true`); the forced path also bypasses `mergeDialogShownRef` and `runMergeCompletionPromptOnce`.
- A manual force-click on a not-yet-merged branch now shows an explicit toast instead of doing nothing silently.
- Includes backend tests for the force flow, en/ru/es i18n strings, a discovery tip, and a changelog entry.