### PR TITLE
fix: show task title + overview in unsaved-changes completion dialog

### DIFF
--- a/change-logs/2026/06/20/fix-completion-modal-task-details.md
+++ b/change-logs/2026/06/20/fix-completion-modal-task-details.md
@@ -1,0 +1,1 @@
+The "Unsaved Changes" confirmation shown when completing or cancelling a task with uncommitted changes now displays the task's title and overview in an info card, so you can tell which task's worktree and branch are about to be deleted.

--- a/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
+++ b/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Task, Project } from "../../../shared/types";
+
+vi.mock("../../rpc", () => ({
+	api: { request: { getBranchStatus: vi.fn() } },
+}));
+vi.mock("../../confirm", () => ({
+	confirm: vi.fn().mockResolvedValue(true),
+}));
+
+import { confirmTaskCompletion } from "../confirmTaskCompletion";
+import { api } from "../../rpc";
+import { confirm } from "../../confirm";
+
+const mockedBranchStatus = vi.mocked(api.request.getBranchStatus);
+const mockedConfirm = vi.mocked(confirm);
+
+const t = ((key: string) => key) as never;
+
+const baseTask = {
+	id: "t1",
+	projectId: "p1",
+	status: "in-progress",
+	worktreePath: "/wt",
+	title: "Auto generated title",
+	overview: "Agent overview line",
+} as Task;
+const project = { id: "p1", name: "P", path: "/p" } as Project;
+
+const dirtyStatus = {
+	insertions: 0,
+	deletions: 408381,
+	unpushed: 0,
+	ahead: 0,
+	mergedByContent: false,
+} as Awaited<ReturnType<typeof api.request.getBranchStatus>>;
+
+describe("confirmTaskCompletion", () => {
+	beforeEach(() => {
+		mockedBranchStatus.mockResolvedValue(dirtyStatus);
+		mockedConfirm.mockResolvedValue(true);
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it("passes the task title + overview as the info card so the user knows which task is deleted", async () => {
+		await confirmTaskCompletion(baseTask, project, "completed", t);
+
+		expect(mockedConfirm).toHaveBeenCalledWith(
+			expect.objectContaining({
+				info: { title: "Auto generated title", body: "Agent overview line" },
+			}),
+		);
+	});
+
+	it("prefers the user-edited title/overview overrides in the info card", async () => {
+		const task = {
+			...baseTask,
+			customTitle: "Custom title",
+			userOverview: "User overview",
+		} as Task;
+		await confirmTaskCompletion(task, project, "cancelled", t);
+
+		expect(mockedConfirm).toHaveBeenCalledWith(
+			expect.objectContaining({
+				info: { title: "Custom title", body: "User overview" },
+			}),
+		);
+	});
+
+	it("omits the info body when the task has no overview", async () => {
+		const task = { ...baseTask, overview: null } as Task;
+		await confirmTaskCompletion(task, project, "completed", t);
+
+		expect(mockedConfirm).toHaveBeenCalledWith(
+			expect.objectContaining({
+				info: { title: "Auto generated title", body: undefined },
+			}),
+		);
+	});
+
+	it("does not prompt (and renders no card) when there are no warnings", async () => {
+		mockedBranchStatus.mockResolvedValue({
+			insertions: 0,
+			deletions: 0,
+			unpushed: 0,
+			ahead: 0,
+			mergedByContent: false,
+		} as Awaited<ReturnType<typeof api.request.getBranchStatus>>);
+
+		const ok = await confirmTaskCompletion(baseTask, project, "completed", t);
+
+		expect(ok).toBe(true);
+		expect(mockedConfirm).not.toHaveBeenCalled();
+	});
+});

--- a/src/mainview/utils/confirmTaskCompletion.ts
+++ b/src/mainview/utils/confirmTaskCompletion.ts
@@ -1,5 +1,6 @@
 import { api } from "../rpc";
 import { confirm } from "../confirm";
+import { getTaskOverview, getTaskTitle } from "../../shared/types";
 import type { Task, Project, TaskStatus } from "../../shared/types";
 import type { TFunction } from "../i18n";
 
@@ -67,6 +68,7 @@ export async function confirmTaskCompletion(
 
 	return confirm({
 		title: t("task.warnCompletionTitle"),
+		info: { title: getTaskTitle(task), body: getTaskOverview(task) ?? undefined },
 		message,
 	});
 }


### PR DESCRIPTION
## What

The "Unsaved Changes" confirmation — shown when completing or cancelling a task that still has uncommitted/unpushed/unmerged changes — now renders the task's title and overview in an info card, so the user can tell **which** task's worktree and branch are about to be deleted.

## Why

The dialog only showed the diff counts and "The worktree and branch will be deleted. Continue?" — no task context. The `confirm()` service already supports an `info: { title, body }` card (used by the agent-completion modal in `App.tsx`); this was the one place calling `confirm()` *about a specific task* without it.

## How

- `confirmTaskCompletion.ts`: pass `info: { title: getTaskTitle(task), body: getTaskOverview(task) ?? undefined }`. Honors user-edited title/overview overrides; omits the body when there is no overview.
- New `confirmTaskCompletion.test.ts`: covers the info card (auto / override / no-overview) and the no-warning early return.

## Test

1. Take a task with uncommitted changes; move it to Completed/Cancelled.
2. Expected: the dialog now shows an accent card with the task title + overview above the warning lines.
3. Edit the title/overview first — the card shows the edited values.
4. A clean task moves through with no dialog.
