### PR TITLE
Show preparing loading state in main task view

### DIFF
--- a/change-logs/2026/06/21/fix-preparing-task-loading-view.md
+++ b/change-logs/2026/06/21/fix-preparing-task-loading-view.md
@@ -1,0 +1,1 @@
+Opening a task that is still cloning/setting up now shows a loading state (stage progress + Cancel) in the main task view instead of leaving the previously-active task's terminal on screen. Still-preparing cards are now clickable so the loading view can surface.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useLayoutEffect, type Dispatch } from "react";
 import { toast } from "../toast";
 import { createPortal } from "react-dom";
-import type { CodingAgent, PortInfo, PreparingStage, Project, ResourceUsage, Task, TaskStatus } from "../../shared/types";
+import type { CodingAgent, PortInfo, Project, ResourceUsage, Task, TaskStatus } from "../../shared/types";
 import { ACTIVE_STATUSES, getPreparingStageProgress, getTaskTitle } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
@@ -22,6 +22,7 @@ import TaskDetailModal from "./TaskDetailModal";
 import MiniPipeline from "./MiniPipeline";
 import PipelineDropdown from "./PipelineDropdown";
 import AgentLauncherBadge, { resolveAgentLauncherIcon } from "./AgentLauncherBadge";
+import { PREPARING_STAGE_LABELS } from "./TaskPreparingView";
 
 interface TaskCardProps {
 	task: Task;
@@ -42,15 +43,6 @@ interface TaskCardProps {
 	siblingMap?: Map<string, Task[]>;
 	prInfo?: { number: number; url: string };
 }
-
-const PREPARING_STAGE_LABELS = {
-	"resolving-config": "task.preparingStage.resolvingConfig",
-	"fetching-origin": "task.preparingStage.fetchingOrigin",
-	"creating-worktree": "task.preparingStage.creatingWorktree",
-	"applying-sparse-checkout": "task.preparingStage.applyingSparseCheckout",
-	"cloning-shared-paths": "task.preparingStage.cloningSharedPaths",
-	"launching-pty": "task.preparingStage.launchingPty",
-} as const satisfies Record<PreparingStage, string>;
 
 function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo }: TaskCardProps) {
 	const t = useT();
@@ -298,7 +290,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const preparingStageLabel = t(PREPARING_STAGE_LABELS[preparingStage]);
 
 	function handleClick() {
-		if (isDisabled) return;
+		// A still-preparing task is `isDisabled` (no drag, dimmed) but must remain
+		// openable so the main view can show its loading state instead of leaving
+		// the previously-active task's terminal on screen.
+		if (isDisabled && !isPreparing) return;
+		if (cancellingPreparation) return;
 		if (isActive && !menuOpen) {
 			preview.close();
 			const openMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";

--- a/src/mainview/components/TaskPreparingView.tsx
+++ b/src/mainview/components/TaskPreparingView.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import type { PreparingStage, Project, Task } from "../../shared/types";
+import { getPreparingStageProgress } from "../../shared/types";
+import { api } from "../rpc";
+import { toast } from "../toast";
+import { useT } from "../i18n";
+
+export const PREPARING_STAGE_LABELS = {
+	"resolving-config": "task.preparingStage.resolvingConfig",
+	"fetching-origin": "task.preparingStage.fetchingOrigin",
+	"creating-worktree": "task.preparingStage.creatingWorktree",
+	"applying-sparse-checkout": "task.preparingStage.applyingSparseCheckout",
+	"cloning-shared-paths": "task.preparingStage.cloningSharedPaths",
+	"launching-pty": "task.preparingStage.launchingPty",
+} as const satisfies Record<PreparingStage, string>;
+
+interface TaskPreparingViewProps {
+	task: Task;
+	project: Project;
+	/** Called with the reverted (todo) task after the user cancels preparation. */
+	onCancelled?: (task: Task) => void;
+}
+
+/**
+ * Full-pane loading state shown in the main task view while a task's worktree
+ * is still being created (git clone, sparse checkout, etc.). Mirrors the
+ * compact preparing overlay on the Kanban card so clicking a still-preparing
+ * task surfaces progress instead of a stale/empty terminal.
+ */
+function TaskPreparingView({ task, project, onCancelled }: TaskPreparingViewProps) {
+	const t = useT();
+	const [cancelling, setCancelling] = useState(false);
+
+	const stage = task.preparingStage ?? "resolving-config";
+	const progress = Math.max(
+		4,
+		Math.min(
+			100,
+			typeof task.preparingProgress === "number" ? task.preparingProgress : getPreparingStageProgress(stage),
+		),
+	);
+	const stageLabel = t(PREPARING_STAGE_LABELS[stage]);
+
+	async function handleCancel() {
+		if (cancelling) return;
+		setCancelling(true);
+		try {
+			const updated = await api.request.cancelTaskPreparation({ taskId: task.id, projectId: project.id });
+			onCancelled?.(updated);
+		} catch (err) {
+			toast.error(t("task.failedMove", { error: String(err) }));
+			setCancelling(false);
+		}
+	}
+
+	return (
+		<div className="flex items-center justify-center h-full">
+			<div className="bg-raised border border-edge rounded-lg p-6 max-w-md w-full space-y-4">
+				<div className="flex items-center gap-2 font-medium text-fg">
+					<div className="w-4 h-4 border-2 border-fg-muted/30 border-t-accent rounded-full animate-spin" />
+					<span>{t("task.preparing")}</span>
+				</div>
+				<div className="text-fg-2 text-sm">{stageLabel}</div>
+				<div
+					className="h-1.5 w-full overflow-hidden rounded-full bg-fg/10"
+					role="progressbar"
+					aria-label={t("task.preparing")}
+					aria-valuemin={0}
+					aria-valuemax={100}
+					aria-valuenow={progress}
+					aria-valuetext={stageLabel}
+				>
+					<div
+						className="h-full rounded-full bg-accent transition-[width] duration-300 ease-out"
+						style={{ width: `${progress}%` }}
+					/>
+				</div>
+				<div className="flex justify-end pt-2">
+					<button
+						onClick={handleCancel}
+						disabled={cancelling}
+						className="px-4 py-2 bg-danger/10 text-danger rounded text-sm font-medium hover:bg-danger/20 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+					>
+						{t("task.cancel")}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default TaskPreparingView;

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -8,6 +8,7 @@ import { moveTaskToStatus } from "../utils/moveTaskToStatus";
 import TerminalView from "../TerminalView";
 import type { TerminalHandle } from "../TerminalView";
 import TaskInfoPanel from "./TaskInfoPanel";
+import TaskPreparingView from "./TaskPreparingView";
 import ExtraKeyBar from "./ExtraKeyBar";
 import { isElectrobun } from "../rpc";
 
@@ -40,6 +41,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 
 	const task = tasks.find((t) => t.id === taskId);
 	const project = projects.find((p) => p.id === projectId);
+	const isPreparing = task?.preparing === true;
 
 	async function classifyAndSetError() {
 		const worktreePath = task?.worktreePath;
@@ -56,6 +58,10 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	}
 
 	useEffect(() => {
+		// While the worktree is still being created there is no PTY to connect
+		// to. Skip the request entirely and let the preparing view render; once
+		// `preparing` flips false this effect re-runs and connects normally.
+		if (isPreparing) return;
 		let cancelled = false;
 		(async () => {
 			console.log("[TaskTerminal] Requesting PTY URL for task", taskId.slice(0, 8));
@@ -82,7 +88,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			}
 		})();
 		return () => { cancelled = true; };
-	}, [taskId]);
+	}, [taskId, isPreparing]);
 
 	// For getPtyUrl success + broken session: listen for ptyDied.
 	useEffect(() => {
@@ -174,6 +180,24 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		} finally {
 			setRestarting(false);
 		}
+	}
+
+	if (isPreparing && task && project) {
+		return (
+			<div className="h-full w-full flex flex-col overflow-hidden">
+				{!hideInfoPanel && <TaskInfoPanel task={task} project={project} dispatch={dispatch} navigate={navigate} isFullPage />}
+				<div className="flex-1 min-h-0 overflow-hidden">
+					<TaskPreparingView
+						task={task}
+						project={project}
+						onCancelled={(updated) => {
+							dispatch({ type: "updateTask", task: updated });
+							navigate({ screen: "project", projectId });
+						}}
+					/>
+				</div>
+			</div>
+		);
 	}
 
 	if (recoverable) {

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -718,6 +718,27 @@ describe("TaskCard", () => {
 			);
 		});
 
+		it("opens a still-preparing active task so the main view can show its loading state", async () => {
+			const user = userEvent.setup();
+			const navigate = vi.fn();
+			renderCard(makeTask({
+				id: "prep-1",
+				status: "in-progress",
+				preparing: true,
+				preparingStage: "fetching-origin",
+				worktreePath: null,
+				branchName: null,
+			}), { navigate });
+
+			await user.click(screen.getByText("Fetching origin"));
+
+			expect(navigate).toHaveBeenCalledWith({
+				screen: "project",
+				projectId: project.id,
+				activeTaskId: "prep-1",
+			});
+		});
+
 		it("shows cancel action while preparing and reverts task to todo", async () => {
 			const user = userEvent.setup();
 			const dispatch = vi.fn();

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../rpc", () => ({
 			resumeTask: vi.fn(),
 			restartTask: vi.fn(),
 			moveTask: vi.fn(),
+			cancelTaskPreparation: vi.fn(),
 			checkWorktreeExists: vi.fn(),
 			getResolvedProject: vi.fn().mockResolvedValue({}),
 			getBranchStatus: vi.fn().mockResolvedValue({}),
@@ -385,6 +386,96 @@ describe("TaskTerminal", () => {
 			});
 
 			expect(screen.queryByText("Resume Session")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("Preparing state", () => {
+		it("shows preparing loading view and skips getPtyUrl while task is preparing", async () => {
+			const preparingTask = makeTask({
+				preparing: true,
+				preparingStage: "fetching-origin",
+				preparingProgress: 24,
+			});
+
+			await act(async () => {
+				renderTerminal({ tasks: [preparingTask] });
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText("Preparing…")).toBeInTheDocument();
+			});
+			expect(screen.getByText("Fetching origin")).toBeInTheDocument();
+			expect(screen.queryByTestId("terminal-view")).not.toBeInTheDocument();
+			expect(mockedApi.request.getPtyUrl).not.toHaveBeenCalled();
+		});
+
+		it("cancels preparation, dispatches the reverted task, and navigates back", async () => {
+			const user = userEvent.setup();
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const preparingTask = makeTask({ preparing: true, preparingStage: "creating-worktree" });
+			const revertedTask = makeTask({ status: "todo", preparing: false, worktreePath: null });
+			mockedApi.request.cancelTaskPreparation.mockResolvedValue(revertedTask);
+
+			await act(async () => {
+				renderTerminal({ tasks: [preparingTask], dispatch, navigate });
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText("Preparing…")).toBeInTheDocument();
+			});
+
+			await act(async () => {
+				await user.click(screen.getByText("Cancel"));
+			});
+
+			expect(mockedApi.request.cancelTaskPreparation).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1" });
+			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: revertedTask });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+		});
+
+		it("connects to the PTY once preparing flips to false", async () => {
+			mockedApi.request.getPtyUrl.mockResolvedValue({ url: "ws://localhost:1234?session=t1" });
+			const navigate = vi.fn();
+			const dispatch = vi.fn();
+
+			const { rerender } = render(
+				<I18nProvider>
+					<TaskTerminal
+						projectId="p1"
+						taskId="t1"
+						tasks={[makeTask({ preparing: true })]}
+						projects={[project]}
+						navigate={navigate}
+						dispatch={dispatch}
+					/>
+				</I18nProvider>,
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText("Preparing…")).toBeInTheDocument();
+			});
+			expect(mockedApi.request.getPtyUrl).not.toHaveBeenCalled();
+
+			await act(async () => {
+				rerender(
+					<I18nProvider>
+						<TaskTerminal
+							projectId="p1"
+							taskId="t1"
+							tasks={[makeTask({ preparing: false })]}
+							projects={[project]}
+							navigate={navigate}
+							dispatch={dispatch}
+						/>
+					</I18nProvider>,
+				);
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.getPtyUrl).toHaveBeenCalledWith({ taskId: "t1" });
+				expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Opening a task that is still cloning/setting up (`preparing: true`) used to leave the previously-active task's terminal on screen in the main view, because `getPtyUrl` returned a websocket URL for a session that didn't exist yet.
- The main task view (`TaskTerminal`) now renders a full-pane preparing state — spinner, current stage label, progress bar, and a **Cancel** button — and skips the PTY request entirely while preparing. Once `preparing` flips to `false`, it connects to the live terminal automatically.
- Still-preparing cards are now clickable so this loading view can actually surface (drag/run actions remain disabled).
- Extracted the shared `PREPARING_STAGE_LABELS` and the loading UI into a new `TaskPreparingView` component, reused by both the Kanban card and the main view.

Added component tests for the preparing view, cancel flow, the PTY-connects-after-preparing transition, and preparing-card navigation. `bun run lint` and `bun run test` are green.