### PR TITLE
Fix stale terminal selection on alt-screen redraw

### DIFF
--- a/change-logs/2026/06/22/fix-terminal-stale-altscreen-selection.md
+++ b/change-logs/2026/06/22/fix-terminal-stale-altscreen-selection.md
@@ -1,0 +1,3 @@
+Fixed a terminal selection that stayed glued to the screen while a full-screen TUI (Claude Code, vim, htop) repainted underneath it. ghostty-web never clears the selection on write, so on the alternate screen the highlight floated over the wrong text; we now drop any alt-screen selection on each write. Primary-screen scrollback selections are unaffected.
+
+Suggested by @shaharitzko (https://github.com/shaharitzko)

--- a/decisions/077-clear-stale-altscreen-selection.md
+++ b/decisions/077-clear-stale-altscreen-selection.md
@@ -1,0 +1,35 @@
+# 077 — Clear stale terminal selection on alt-screen writes
+
+## Context
+Double-clicking a word in the terminal selects it, but the blue highlight stayed
+glued to the same screen cells while a full-screen TUI (Claude Code, vim, htop)
+repainted under it — a stale highlight floating over the wrong characters.
+
+## Investigation
+Verified in the built `ghostty-web` 0.4.0 (`node_modules/ghostty-web/dist/ghostty-web.js`):
+the selection is stored by absolute buffer row and `normalizeSelection()` converts
+absolute↔viewport correctly, so on the **primary** screen the highlight scrolls away
+with its text. But the `write()` path never touches the selection — `clearSelection()`
+is only called on new mousedown, click-outside, resize, and dispose. On the
+**alternate** screen there is no scrollback (`viewportY` stays 0), so the selection's
+absolute row maps to the same screen cells forever while the TUI rewrites them in
+place. xterm.js clears/trims selection on changed lines; ghostty-web does not.
+
+## Decision
+Added `clearStaleSelectionOnWrite(term)` in `src/mainview/TerminalView.tsx`, called
+right after the batched `batchTerm.write()` in `enqueueTermWrite`. It clears the
+selection only when `term.isAlternateScreen() && term.hasSelection()`. Primary-screen
+scrollback selections are deliberately left untouched.
+
+## Risks
+On the alternate screen the selection is dropped on the next program output, so
+select-to-copy during active streaming is harder. Acceptable: copy normally happens
+while idle (no writes), and a stale wrong highlight is worse. Mouseup already copies
+via the native selection bridge at gesture end.
+
+## Alternatives considered
+- Clear only when dirty rows intersect the selection — more precise but needs wasm
+  dirty-row access and more code; Claude's TUI repaints the whole screen anyway.
+- Patch/upgrade ghostty-web upstream — it's an external `^0.4.0` dep; patching
+  `node_modules` is not durable.
+- Clear on any scroll/wheel — only addresses scrollback, not the alt-screen case.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -117,6 +117,32 @@ export function buildResizeDance(cols: number, rows: number): [string, string] {
 	];
 }
 
+// ghostty-web 0.4.0 never invalidates the selection when the terminal content
+// changes. On the primary screen that's fine — the selection is anchored to an
+// absolute buffer row and scrolls away with its text. But on the ALTERNATE
+// screen (full-screen TUIs like Claude Code, vim, htop) there is no scrollback:
+// the app repaints the same cells in place. The selection overlay stays glued
+// to those screen cells while fresh text is drawn under it — a stale highlight
+// floating over the wrong characters. Clear the selection on any alt-screen
+// write so the overlay never outlives the content it was made over. Primary
+// screen / scrollback selections are intentionally left untouched.
+export function clearStaleSelectionOnWrite(term: {
+	isAlternateScreen?: () => boolean;
+	hasSelection?: () => boolean;
+	clearSelection?: () => void;
+}): void {
+	try {
+		if (
+			term.isAlternateScreen?.() &&
+			term.hasSelection?.()
+		) {
+			term.clearSelection?.();
+		}
+	} catch {
+		// Selection bridge is best effort; ghostty may be disposed.
+	}
+}
+
 export interface TerminalHandle {
 	sendInput: (data: string) => void;
 	focus: () => void;
@@ -723,6 +749,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady }: TerminalViewProps)
 					if (!batch) return;
 					try {
 						batchTerm.write(batch);
+						// Drop any stale alt-screen selection left floating over
+						// the just-repainted cells (ghostty-web won't do it).
+						clearStaleSelectionOnWrite(batchTerm);
 					} catch {
 						// Swallow ghostty-web rendering errors
 					}

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, waitFor } from "@testing-library/react";
-import TerminalView, { buildResizeDance } from "../TerminalView";
+import TerminalView, { buildResizeDance, clearStaleSelectionOnWrite } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
 import { KEYMAP_LS_KEY } from "../terminal-keymaps";
@@ -698,5 +698,52 @@ describe("buildResizeDance", () => {
 		const nudgeRows = Number(nudge.match(/resize;\d+;(\d+)/)![1]);
 		const correctRows = Number(correct.match(/resize;\d+;(\d+)/)![1]);
 		expect(nudgeRows - correctRows).toBe(1);
+	});
+});
+
+describe("clearStaleSelectionOnWrite", () => {
+	function makeTerm(over: {
+		alt: boolean;
+		hasSelection: boolean;
+	}) {
+		const clearSelection = vi.fn();
+		return {
+			term: {
+				isAlternateScreen: vi.fn(() => over.alt),
+				hasSelection: vi.fn(() => over.hasSelection),
+				clearSelection,
+			},
+			clearSelection,
+		};
+	}
+
+	// Repro: the floating-selection bug. On the alternate screen a TUI repaints
+	// the same cells, so a selection made over them must be dropped on write.
+	it("clears the selection on alt-screen when one exists", () => {
+		const { term, clearSelection } = makeTerm({ alt: true, hasSelection: true });
+		clearStaleSelectionOnWrite(term);
+		expect(clearSelection).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT clear selection on the primary screen (scrollback stays anchored)", () => {
+		const { term, clearSelection } = makeTerm({ alt: false, hasSelection: true });
+		clearStaleSelectionOnWrite(term);
+		expect(clearSelection).not.toHaveBeenCalled();
+	});
+
+	it("does nothing on alt-screen when there is no selection", () => {
+		const { term, clearSelection } = makeTerm({ alt: true, hasSelection: false });
+		clearStaleSelectionOnWrite(term);
+		expect(clearSelection).not.toHaveBeenCalled();
+	});
+
+	it("never throws if the terminal is disposed / lacks the APIs", () => {
+		expect(() => clearStaleSelectionOnWrite({})).not.toThrow();
+		const throwing = {
+			isAlternateScreen: () => {
+				throw new Error("disposed");
+			},
+		};
+		expect(() => clearStaleSelectionOnWrite(throwing)).not.toThrow();
 	});
 });


### PR DESCRIPTION
## Summary

Double-clicking a word in the terminal selected it, but the highlight stayed glued to the same screen cells while a full-screen TUI (Claude Code, vim, htop) repainted underneath — a stale blue rectangle floating over the wrong text.

Root cause: `ghostty-web` 0.4.0 never invalidates the selection on `write()`. On the **primary** screen this is harmless (the selection is anchored to an absolute buffer row and scrolls away with its text), but on the **alternate** screen there is no scrollback (`viewportY` stays 0), so the selection maps to the same cells forever while the TUI rewrites them in place.

Fix: `clearStaleSelectionOnWrite(term)` in `TerminalView.tsx`, called after each batched write, gated on `isAlternateScreen() && hasSelection()`. Primary-screen scrollback selections are left untouched. See decision 077.

Includes 4 repro/edge unit tests.

Suggested by @shaharitzko (https://github.com/shaharitzko)