### PR TITLE
Add per-command and per-subcommand --help to the CLI

### DIFF
--- a/change-logs/2026/06/22/feature-cli-subcommand-help.md
+++ b/change-logs/2026/06/22/feature-cli-subcommand-help.md
@@ -1,0 +1,1 @@
+The dev3 CLI now prints command- and subcommand-specific help. `dev3 task create --help`, `dev3 note add --help`, `dev3 label set --help`, etc. show focused usage and flags for that exact command instead of dumping the generic top-level help. A new declarative help registry (src/cli/help.ts) is the single source of truth; `remote`/`gui` keep their own richer help.

--- a/src/cli/__tests__/help.test.ts
+++ b/src/cli/__tests__/help.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { hasCommandHelp, getCommandHelp, renderHelp } from "../help";
+import { hasCommandHelp, getCommandHelp, renderHelp, resolveHelp } from "../help";
 
 describe("hasCommandHelp", () => {
 	it("knows registered commands", () => {
@@ -72,6 +72,46 @@ describe("renderHelp — leaf command", () => {
 
 	it("ignores a stray subcommand arg for a leaf command", () => {
 		expect(renderHelp("vents", "whatever")).toEqual(renderHelp("vents"));
+	});
+});
+
+describe("resolveHelp — routing decision", () => {
+	it("no args → top-level help", () => {
+		expect(resolveHelp([])).toEqual({ action: "top" });
+	});
+
+	it("bare --help → top-level help", () => {
+		expect(resolveHelp(["--help"])).toEqual({ action: "top" });
+		expect(resolveHelp(["-h"])).toEqual({ action: "top" });
+	});
+
+	it("'<command> --help' → command-specific help text", () => {
+		const res = resolveHelp(["task", "--help"]);
+		expect(res.action).toBe("command");
+		if (res.action === "command") {
+			expect(res.text).toBe(renderHelp("task"));
+		}
+	});
+
+	it("'<command> <subcommand> --help' → subcommand-specific help text", () => {
+		const res = resolveHelp(["task", "create", "--help"]);
+		expect(res.action).toBe("command");
+		if (res.action === "command") {
+			expect(res.text).toBe(renderHelp("task", "create"));
+		}
+	});
+
+	it("remote/gui --help fall through to their own handlers (none)", () => {
+		expect(resolveHelp(["remote", "--help"])).toEqual({ action: "none" });
+		expect(resolveHelp(["gui", "--help"])).toEqual({ action: "none" });
+	});
+
+	it("unknown '<command> --help' → top-level help", () => {
+		expect(resolveHelp(["bogus", "--help"])).toEqual({ action: "top" });
+	});
+
+	it("a real invocation without --help is not a help request (none)", () => {
+		expect(resolveHelp(["task", "create", "--title", "x"])).toEqual({ action: "none" });
 	});
 });
 

--- a/src/cli/__tests__/help.test.ts
+++ b/src/cli/__tests__/help.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { hasCommandHelp, getCommandHelp, renderHelp } from "../help";
+
+describe("hasCommandHelp", () => {
+	it("knows registered commands", () => {
+		expect(hasCommandHelp("task")).toBe(true);
+		expect(hasCommandHelp("note")).toBe(true);
+		expect(hasCommandHelp("vents")).toBe(true);
+	});
+
+	it("does not claim unknown commands", () => {
+		expect(hasCommandHelp("bogus")).toBe(false);
+		// remote/gui render their own help inside their handlers and are
+		// intentionally absent from the registry.
+		expect(hasCommandHelp("remote")).toBe(false);
+		expect(hasCommandHelp("gui")).toBe(false);
+	});
+});
+
+describe("renderHelp — unknown command", () => {
+	it("returns null", () => {
+		expect(renderHelp("bogus")).toBeNull();
+		expect(renderHelp("bogus", "sub")).toBeNull();
+	});
+});
+
+describe("renderHelp — group listing", () => {
+	it("lists every subcommand for a group command", () => {
+		const out = renderHelp("task")!;
+		expect(out).toContain("dev3 task — Inspect and manage individual tasks.");
+		expect(out).toContain("Subcommands:");
+		for (const name of ["show", "create", "update", "move"]) {
+			expect(out).toContain(`dev3 task ${name}`);
+		}
+		expect(out).toContain('Run "dev3 task <subcommand> --help" for details');
+		expect(out).toContain("Global options:");
+	});
+
+	it("falls back to the group listing for an unknown subcommand", () => {
+		const out = renderHelp("task", "frobnicate")!;
+		expect(out).toContain("dev3 task — Inspect and manage individual tasks.");
+		expect(out).toContain("Subcommands:");
+	});
+});
+
+describe("renderHelp — subcommand detail", () => {
+	it("renders the targeted subcommand's usage and details", () => {
+		const out = renderHelp("task", "create")!;
+		expect(out).toContain("dev3 task create — Create a new task in the To Do column.");
+		expect(out).toContain("Usage:");
+		expect(out).toContain('dev3 task create --title "..." [--description "..."]');
+		expect(out).toContain("--title <text>");
+		expect(out).toContain("Global options:");
+	});
+
+	it("renders a subcommand without details (no empty Details block)", () => {
+		const out = renderHelp("note", "list")!;
+		expect(out).toContain("dev3 note list — List a task's notes");
+		expect(out).not.toContain("Details:");
+	});
+});
+
+describe("renderHelp — leaf command", () => {
+	it("renders usage/details directly for a leaf command", () => {
+		const out = renderHelp("vents")!;
+		expect(out).toContain("dev3 vents — File anonymous dev3-platform feedback");
+		expect(out).toContain("Usage:");
+		expect(out).toContain('dev3 vents "short name" "markdown body"');
+		// A leaf command has no subcommand listing.
+		expect(out).not.toContain("Subcommands:");
+	});
+
+	it("ignores a stray subcommand arg for a leaf command", () => {
+		expect(renderHelp("vents", "whatever")).toEqual(renderHelp("vents"));
+	});
+});
+
+describe("registry coverage", () => {
+	// Every command dispatched in main.ts (except remote/gui, which own their
+	// help) must have a registry entry so `dev3 <cmd> --help` works.
+	const dispatched = [
+		"current",
+		"install-hooks",
+		"install-skills",
+		"conversations",
+		"projects",
+		"tasks",
+		"task",
+		"note",
+		"vents",
+		"overview",
+		"label",
+		"config",
+		"dev-server",
+	];
+
+	for (const cmd of dispatched) {
+		it(`has help for "${cmd}"`, () => {
+			expect(hasCommandHelp(cmd)).toBe(true);
+			expect(renderHelp(cmd)).not.toBeNull();
+		});
+	}
+
+	it("every subcommand renders a non-empty detail view", () => {
+		for (const cmd of dispatched) {
+			const spec = getCommandHelp(cmd)!;
+			for (const sub of spec.subcommands) {
+				const out = renderHelp(cmd, sub.name)!;
+				expect(out).toContain(`dev3 ${cmd} ${sub.name} —`);
+				expect(out).toContain(sub.usage);
+			}
+		}
+	});
+});

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,357 @@
+// Declarative help registry — the single source of truth for per-command and
+// per-subcommand `--help` output. main.ts routes `dev3 <cmd> [<sub>] --help`
+// here so every command-with-subcommands prints its own focused usage instead
+// of falling back to the generic top-level help.
+//
+// `remote` and `gui` intentionally render their own richer, hand-written help
+// inside their handlers and are NOT listed here (see `ownsHelp` in main.ts).
+
+/** One subcommand of a command group (e.g. `task create`). */
+export interface SubcommandHelp {
+	/** Subcommand keyword, e.g. "create". */
+	name: string;
+	/** Full usage line, e.g. `dev3 task create --title "..." [--description "..."]`. */
+	usage: string;
+	/** One-line summary shown in the group listing and the detail header. */
+	summary: string;
+	/** Extra lines (flag descriptions, notes, examples) for the detail view. */
+	details?: string[];
+}
+
+/** A top-level command. Leaf commands (no subcommands) use `usage`/`details`. */
+export interface CommandHelp {
+	/** Command keyword, e.g. "task". */
+	name: string;
+	/** One-line summary of the command group. */
+	summary: string;
+	/** Subcommands; empty for leaf commands like `vents` or `current`. */
+	subcommands: SubcommandHelp[];
+	/** Usage line for a leaf command (only when `subcommands` is empty). */
+	usage?: string;
+	/** Detail lines for a leaf command. */
+	details?: string[];
+}
+
+const GLOBAL_OPTIONS = [
+	"--project <id>            Override project auto-detection",
+	"--task <id> / --task-id   Override the target task (else auto-detected from the worktree)",
+	"-h, --help                Show help",
+	"-v, --version             Show CLI version",
+];
+
+const COMMANDS: CommandHelp[] = [
+	{
+		name: "current",
+		summary: "Show the current project, task, status, and overview.",
+		subcommands: [],
+		usage: "dev3 current [--brief]",
+		details: [
+			"--brief    Hide the full task description (use when you already have it in your prompt).",
+		],
+	},
+	{
+		name: "task",
+		summary: "Inspect and manage individual tasks.",
+		subcommands: [
+			{
+				name: "show",
+				usage: "dev3 task show [<id>] [--task <id>] [--notes] [--history]",
+				summary: "Show full task details (always includes the current overview).",
+				details: [
+					"--notes      Inline the task's note bodies.",
+					"--history    Show the title/overview change log.",
+					"Without an id, targets the current worktree's task.",
+				],
+			},
+			{
+				name: "create",
+				usage: 'dev3 task create --title "..." [--description "..."]',
+				summary: "Create a new task in the To Do column.",
+				details: [
+					"--title <text>        Task title (required).",
+					"--description <text>  Longer description (optional).",
+					"Positional content (or @file) becomes the description; its first line",
+					"is used as the title when --title is omitted.",
+				],
+			},
+			{
+				name: "update",
+				usage: 'dev3 task update [<id>] --title "..." [--description "..."]',
+				summary: "Update a task's title and/or description.",
+				details: [
+					"--title <text>        New title (cannot be empty).",
+					'--description <text>  New description ("" clears it).',
+					"--force               Overwrite a user-edited title (diagnostics only — avoid).",
+				],
+			},
+			{
+				name: "move",
+				usage: "dev3 task move [<id>] --status <status>",
+				summary: "Change a task's status / column.",
+				details: [
+					"--status <status>        Target status or custom column id (required).",
+					"--if-status <status>     Only move if the current status matches.",
+					"--if-status-not <s>      Only move if the current status differs.",
+					"Built-in: todo, in-progress, user-questions, review-by-ai, review-by-user.",
+					'"completed" asks the user for approval; "cancelled" is forbidden via CLI.',
+				],
+			},
+		],
+	},
+	{
+		name: "tasks",
+		summary: "List tasks on the board.",
+		subcommands: [
+			{
+				name: "list",
+				usage: "dev3 tasks list [--status <s>] [--label <id>] [--limit <n>] [--offset <n>]",
+				summary: "List tasks newest-first (default 50 per page).",
+				details: [
+					"--status <s>   Filter by status.",
+					"--label <id>   Filter by label id (8-char prefix works).",
+					"--limit <n>    Page size (default 50).",
+					"--offset <n>   Skip n tasks, for paging.",
+				],
+			},
+		],
+	},
+	{
+		name: "note",
+		summary: "Per-task scratchpad notes — durable, surfaced to future agents.",
+		subcommands: [
+			{
+				name: "add",
+				usage: 'dev3 note add "..." [--task <id>] [--source user|ai]',
+				summary: "Add a note to a task.",
+				details: ["--source user|ai   Note author (default ai)."],
+			},
+			{
+				name: "list",
+				usage: "dev3 note list [--task <id>]",
+				summary: "List a task's notes (one line each).",
+			},
+			{
+				name: "show",
+				usage: "dev3 note show <id> [--task <id>]",
+				summary: "Show one note's full body (8-char prefix works).",
+			},
+			{
+				name: "delete",
+				usage: "dev3 note delete <id> [--task <id>]",
+				summary: "Delete a note (8-char prefix works).",
+			},
+		],
+	},
+	{
+		name: "overview",
+		summary: "The task overview — a 1-2 sentence sticky-note summary.",
+		subcommands: [
+			{
+				name: "set",
+				usage: 'dev3 overview set "..." [--task <id>]',
+				summary: "Set the task overview (max 500 chars, one paragraph).",
+			},
+			{
+				name: "show",
+				usage: "dev3 overview show [--task <id>]",
+				summary: "Show the overview (falls back to the description).",
+			},
+			{
+				name: "clear",
+				usage: "dev3 overview clear [--task <id>]",
+				summary: "Remove the task overview.",
+			},
+		],
+	},
+	{
+		name: "label",
+		summary: "Manage project labels and task label assignments.",
+		subcommands: [
+			{
+				name: "list",
+				usage: "dev3 label list",
+				summary: "List the project's labels.",
+			},
+			{
+				name: "create",
+				usage: 'dev3 label create "name" [--color "#hex"]',
+				summary: "Create a label.",
+			},
+			{
+				name: "delete",
+				usage: "dev3 label delete <id>",
+				summary: "Delete a label.",
+			},
+			{
+				name: "set",
+				usage: "dev3 label set <id> [<id>...] [--task <id>]",
+				summary: "Assign labels to a task.",
+				details: ["--clear    Remove all labels from the task (dev3 label set --clear)."],
+			},
+		],
+	},
+	{
+		name: "conversations",
+		summary: "Search past task conversations (transcripts + notes/overview).",
+		subcommands: [
+			{
+				name: "search",
+				usage: 'dev3 conversations search "<query>" [--limit N] [--all-statuses] [--json]',
+				summary: "Search completed/cancelled task conversations for relevant prior work.",
+				details: [
+					"--limit N        Max results (default 5).",
+					"--all-statuses   Include active tasks too.",
+					"--json           Machine-readable output.",
+				],
+			},
+		],
+	},
+	{
+		name: "dev-server",
+		summary: "Control a task's dev server (runs in a tmux window).",
+		subcommands: [
+			{
+				name: "start",
+				usage: "dev3 dev-server start [task-id]",
+				summary: "Start a task's dev server.",
+			},
+			{
+				name: "stop",
+				usage: "dev3 dev-server stop [task-id]",
+				summary: "Stop a task's dev server.",
+			},
+			{
+				name: "restart",
+				usage: "dev3 dev-server restart [task-id]",
+				summary: "Restart a task's dev server.",
+			},
+			{
+				name: "status",
+				usage: "dev3 dev-server status [task-id]",
+				summary: "Show a task's dev server status (default subcommand).",
+			},
+		],
+	},
+	{
+		name: "config",
+		summary: "Inspect and export effective project settings.",
+		subcommands: [
+			{
+				name: "show",
+				usage: "dev3 config show",
+				summary: "Show effective (merged) project settings (default subcommand).",
+			},
+			{
+				name: "export",
+				usage: "dev3 config export",
+				summary: "Export settings to .dev3/config.json.",
+			},
+		],
+	},
+	{
+		name: "projects",
+		summary: "Inspect configured projects.",
+		subcommands: [
+			{
+				name: "list",
+				usage: "dev3 projects list",
+				summary: "List all configured projects (default subcommand).",
+			},
+		],
+	},
+	{
+		name: "vents",
+		summary: "File anonymous dev3-platform feedback. No PII, no project specifics.",
+		subcommands: [],
+		usage: 'dev3 vents "short name" "markdown body"',
+		details: [
+			"Writes one local markdown file for the dev3 maintainer.",
+			"Describe ONLY dev3 the tool — never include code, paths, or task content.",
+		],
+	},
+	{
+		name: "install-hooks",
+		summary: "Install agent status-sync hooks in the current worktree.",
+		subcommands: [],
+		usage: "dev3 install-hooks",
+		details: ["Writes Claude Code and Codex hook configs into the worktree."],
+	},
+	{
+		name: "install-skills",
+		summary: "Install / refresh the dev3 agent skills globally.",
+		subcommands: [],
+		usage: "dev3 install-skills",
+		details: ["Writes the dev3 skill files into ~/.claude, ~/.codex, ~/.cursor, etc."],
+	},
+];
+
+const COMMAND_INDEX: Map<string, CommandHelp> = new Map(COMMANDS.map((c) => [c.name, c]));
+
+/** Whether the registry knows how to render help for this command. */
+export function hasCommandHelp(command: string): boolean {
+	return COMMAND_INDEX.has(command);
+}
+
+/** Look up a command's help spec (mainly for tests). */
+export function getCommandHelp(command: string): CommandHelp | undefined {
+	return COMMAND_INDEX.get(command);
+}
+
+function indentLines(lines: string[], pad = "  "): string {
+	return lines.map((l) => `${pad}${l}`).join("\n");
+}
+
+function renderGlobalOptions(): string {
+	return `\nGlobal options:\n${indentLines(GLOBAL_OPTIONS)}\n`;
+}
+
+/** Render the detail view for a single subcommand or a leaf command. */
+function renderLeaf(title: string, usage: string, summary: string, details?: string[]): string {
+	let out = `${title} — ${summary}\n\nUsage:\n  ${usage}\n`;
+	if (details && details.length > 0) {
+		out += `\nDetails:\n${indentLines(details)}\n`;
+	}
+	out += renderGlobalOptions();
+	return out;
+}
+
+/** Render the listing view for a command group (all its subcommands). */
+function renderGroup(cmd: CommandHelp): string {
+	const usageWidth = Math.max(...cmd.subcommands.map((s) => s.usage.length));
+	const rows = cmd.subcommands
+		.map((s) => `  ${s.usage.padEnd(usageWidth)}   ${s.summary}`)
+		.join("\n");
+	let out = `dev3 ${cmd.name} — ${cmd.summary}\n\nSubcommands:\n${rows}\n`;
+	out += `\nRun "dev3 ${cmd.name} <subcommand> --help" for details on a subcommand.\n`;
+	out += renderGlobalOptions();
+	return out;
+}
+
+/**
+ * Render help for `dev3 <command> [<subcommand>] --help`.
+ * Returns the formatted help text, or null if the command is unknown.
+ *
+ * - Leaf command (no subcommands): renders its own usage/details.
+ * - Group + known subcommand: renders that subcommand's detail view.
+ * - Group + unknown/no subcommand: renders the group listing.
+ */
+export function renderHelp(command: string, subcommand?: string): string | null {
+	const cmd = COMMAND_INDEX.get(command);
+	if (!cmd) return null;
+
+	// Leaf command — no subcommands to list.
+	if (cmd.subcommands.length === 0) {
+		return renderLeaf(`dev3 ${cmd.name}`, cmd.usage ?? `dev3 ${cmd.name}`, cmd.summary, cmd.details);
+	}
+
+	if (subcommand) {
+		const sub = cmd.subcommands.find((s) => s.name === subcommand);
+		if (sub) {
+			return renderLeaf(`dev3 ${cmd.name} ${sub.name}`, sub.usage, sub.summary, sub.details);
+		}
+		// Unknown subcommand — fall through to the group listing (more helpful
+		// than an error, and surfaces the valid subcommands).
+	}
+
+	return renderGroup(cmd);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -355,3 +355,41 @@ export function renderHelp(command: string, subcommand?: string): string | null 
 
 	return renderGroup(cmd);
 }
+
+/** Commands that render their own (richer) --help inside their handlers. */
+const OWNS_HELP = new Set(["remote", "gui"]);
+
+/**
+ * What `main()` should do about `--help` for a given argv (minus the leading
+ * "dev3"). Pure so the routing decision is unit-testable without process.exit:
+ *
+ * - `command` → print `text` (command/subcommand-specific help) and exit.
+ * - `top`     → print the generic top-level help and exit.
+ * - `none`    → not a help request we handle here; continue normal routing
+ *               (also covers `remote`/`gui --help`, which own their help).
+ */
+export type HelpResolution =
+	| { action: "command"; text: string }
+	| { action: "top" }
+	| { action: "none" };
+
+export function resolveHelp(rawArgs: string[]): HelpResolution {
+	const wantsHelp = rawArgs.includes("--help") || rawArgs.includes("-h");
+	const positionals = rawArgs.filter((a) => !a.startsWith("-"));
+	const command = positionals[0];
+	const subcommand = positionals[1];
+
+	// `dev3 <command> [<subcommand>] --help` → command/subcommand-specific help.
+	if (wantsHelp && command && !OWNS_HELP.has(command) && hasCommandHelp(command)) {
+		const text = renderHelp(command, subcommand);
+		if (text) return { action: "command", text };
+	}
+
+	// remote/gui own their --help; let those fall through to their handlers.
+	const routeToOwnHelp = wantsHelp && Boolean(command) && OWNS_HELP.has(command);
+	if (rawArgs.length === 0 || (wantsHelp && !routeToOwnHelp)) {
+		return { action: "top" };
+	}
+
+	return { action: "none" };
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,6 +18,7 @@ import { handleGui } from "./commands/gui";
 import { handleConversations } from "./commands/conversations";
 import { BUILD_TIME, BUILD_COMMIT, BUILD_VERSION } from "../shared/build-info.generated";
 import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
+import { hasCommandHelp, renderHelp } from "./help";
 
 const HELP = `dev3 — AI-facing CLI for the dev-3.0 Kanban board.
 Auto-detects project and task from the worktree context.
@@ -67,19 +68,37 @@ Statuses: todo, in-progress, user-questions, review-by-ai, review-by-user
   Double @@ for literal @.
 
 Options: --project <id> (override auto-detect), --task <id> / --task-id <id> (override task target), --help, --version
+
+Run "dev3 <command> --help" (e.g. "dev3 task --help") for command-specific usage,
+or "dev3 <command> <subcommand> --help" (e.g. "dev3 task create --help") for a single subcommand.
 `;
 
 
 async function main(): Promise<void> {
 	const rawArgs = process.argv.slice(2);
 
-	// Subcommands that own their own --help output. Route to them before
-	// we swallow --help as the generic top-level help.
+	// `remote` and `gui` render their own (richer) --help inside their handlers,
+	// so we let --help fall through to them. Every other command-with-subcommands
+	// gets focused help from the declarative registry (src/cli/help.ts); anything
+	// else falls back to the generic top-level help.
 	const ownsHelp = new Set(["remote", "gui"]);
-	const firstPositional = rawArgs.find((a) => !a.startsWith("-"));
-	const routeToSubcommand = firstPositional && ownsHelp.has(firstPositional);
+	const wantsHelp = rawArgs.includes("--help") || rawArgs.includes("-h");
+	const positionals = rawArgs.filter((a) => !a.startsWith("-"));
+	const helpCommand = positionals[0];
+	const helpSubcommand = positionals[1];
 
-	if (rawArgs.length === 0 || ((rawArgs.includes("--help") || rawArgs.includes("-h")) && !routeToSubcommand)) {
+	// `dev3 <command> [<subcommand>] --help` → command/subcommand-specific help.
+	if (wantsHelp && helpCommand && !ownsHelp.has(helpCommand) && hasCommandHelp(helpCommand)) {
+		const text = renderHelp(helpCommand, helpSubcommand);
+		if (text) {
+			process.stdout.write(text);
+			process.exit(CLI_EXIT_CODE_SUCCESS);
+		}
+	}
+
+	// No args, or a top-level / unknown-command --help that nobody else owns.
+	const routeToOwnHelp = wantsHelp && Boolean(helpCommand) && ownsHelp.has(helpCommand);
+	if (rawArgs.length === 0 || (wantsHelp && !routeToOwnHelp)) {
 		process.stdout.write(HELP);
 		process.exit(CLI_EXIT_CODE_SUCCESS);
 	}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,7 +18,7 @@ import { handleGui } from "./commands/gui";
 import { handleConversations } from "./commands/conversations";
 import { BUILD_TIME, BUILD_COMMIT, BUILD_VERSION } from "../shared/build-info.generated";
 import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
-import { hasCommandHelp, renderHelp } from "./help";
+import { resolveHelp } from "./help";
 
 const HELP = `dev3 — AI-facing CLI for the dev-3.0 Kanban board.
 Auto-detects project and task from the worktree context.
@@ -77,28 +77,16 @@ or "dev3 <command> <subcommand> --help" (e.g. "dev3 task create --help") for a s
 async function main(): Promise<void> {
 	const rawArgs = process.argv.slice(2);
 
-	// `remote` and `gui` render their own (richer) --help inside their handlers,
-	// so we let --help fall through to them. Every other command-with-subcommands
-	// gets focused help from the declarative registry (src/cli/help.ts); anything
-	// else falls back to the generic top-level help.
-	const ownsHelp = new Set(["remote", "gui"]);
-	const wantsHelp = rawArgs.includes("--help") || rawArgs.includes("-h");
-	const positionals = rawArgs.filter((a) => !a.startsWith("-"));
-	const helpCommand = positionals[0];
-	const helpSubcommand = positionals[1];
-
-	// `dev3 <command> [<subcommand>] --help` → command/subcommand-specific help.
-	if (wantsHelp && helpCommand && !ownsHelp.has(helpCommand) && hasCommandHelp(helpCommand)) {
-		const text = renderHelp(helpCommand, helpSubcommand);
-		if (text) {
-			process.stdout.write(text);
-			process.exit(CLI_EXIT_CODE_SUCCESS);
-		}
+	// `--help` routing (pure decision in help.ts so it stays unit-testable):
+	// a known command/subcommand gets focused help from the declarative registry,
+	// `remote`/`gui --help` fall through to their own handlers, and everything
+	// else (incl. no args) prints the generic top-level help.
+	const help = resolveHelp(rawArgs);
+	if (help.action === "command") {
+		process.stdout.write(help.text);
+		process.exit(CLI_EXIT_CODE_SUCCESS);
 	}
-
-	// No args, or a top-level / unknown-command --help that nobody else owns.
-	const routeToOwnHelp = wantsHelp && Boolean(helpCommand) && ownsHelp.has(helpCommand);
-	if (rawArgs.length === 0 || (wantsHelp && !routeToOwnHelp)) {
+	if (help.action === "top") {
 		process.stdout.write(HELP);
 		process.exit(CLI_EXIT_CODE_SUCCESS);
 	}


### PR DESCRIPTION
## Summary

`dev3 <command> [<subcommand>] --help` now prints **focused, command-specific help** instead of dumping the generic top-level help.

- `dev3 task create --help` → usage + flags + details for exactly `task create`
- `dev3 task --help` → lists all subcommands of the `task` group
- Leaf commands (`vents`, `current`, `install-hooks`, `install-skills`) print their own usage
- Unknown subcommand (e.g. `dev3 task bogus --help`) gracefully falls back to the group listing
- `remote` / `gui` keep their own richer, hand-written help (untouched)
- Top-level `dev3 --help` is unchanged, plus a hint pointing at per-command help

## Implementation

- New declarative help registry `src/cli/help.ts` — single source of truth for command/subcommand summaries, usage lines, and flag details, with a renderer.
- The `--help` routing decision is extracted into a pure `resolveHelp(rawArgs)` so it's unit-testable without `process.exit`; `main.ts` just maps the result to output.
- Covers every dispatched command: `current`, `task`, `tasks`, `note`, `overview`, `label`, `conversations`, `dev-server`, `config`, `projects`, `vents`, `install-hooks`, `install-skills`.

## Tests

30 unit tests in `src/cli/__tests__/help.test.ts` — renderer output (group/subcommand/leaf), registry coverage of all dispatched commands, and the `resolveHelp` routing decision. `bun run lint`, `bun run test`, and `bun run test:cli` all green.

---
🤖 This PR was opened by Claude (the AI assistant working on this branch).