### PR TITLE
fix(cli): retry transient socket failures + DEV3_DEBUG diagnostics (#714)

### DIFF
--- a/change-logs/2026/06/23/fix-cli-transient-app-not-running.md
+++ b/change-logs/2026/06/23/fix-cli-transient-app-not-running.md
@@ -1,0 +1,3 @@
+Fixed the dev3 CLI intermittently reporting "app not running" while the desktop app was alive. The CLI now retries transient Unix-socket failures — both connect (ECONNREFUSED/ENOENT/EAGAIN) and socket discovery — with short backoff before giving up, instead of declaring the app offline on the first hiccup (common when agent hooks fire many CLI calls in bursts, especially on macOS). Running any command with DEV3_DEBUG=1 now prints why resolution failed (HOME, sockets dir, each socket's pid/liveness, failing stage, last errno).
+
+Suggested by @banuni (h0x91b/dev-3.0#714)

--- a/decisions/078-cli-socket-connect-retry.md
+++ b/decisions/078-cli-socket-connect-retry.md
@@ -1,0 +1,59 @@
+# 078 — Retry transient CLI socket connect failures
+
+## Context
+
+Users reported the `dev3` CLI intermittently claiming the desktop app is "not
+running" (exit code 2 / `APP_NOT_RUNNING`) while the app was clearly alive
+(issue #714, macOS Tahoe). Agents would then refuse to update task state or open
+PRs via dev3 ("the dev3 desktop app is offline").
+
+## Investigation
+
+`sendRequest` in `src/cli/socket-client.ts` connected to the app's Unix-domain
+socket and, on the **first** `ECONNREFUSED`/`ENOENT`, immediately rejected with
+`APP_NOT_RUNNING` — no retry. A live app can momentarily fail to `accept()` when
+its single event loop is busy and the socket's accept backlog briefly fills;
+the kernel returns `ECONNREFUSED` even though the socket file exists and the app
+is running. macOS's small default backlog makes this likely, and agent hooks
+fire many `dev3` invocations in tight bursts (every prompt / tool use), so the
+race triggers "too often". The socket file itself is stable for the app's
+lifetime, so discovery (`discoverSocket`) is reliable — only the connect step
+was fragile.
+
+## Decision
+
+There are two paths to `APP_NOT_RUNNING` in `main.ts`: discovery
+(`resolveSocketPath()` returns `null` — no live socket) and connect
+(`sendRequest` fails to connect). Both are now hardened:
+
+- **Connect** (`src/cli/socket-client.ts`): `sendRequest` retries transient
+  connect failures (`ECONNREFUSED`/`ENOENT`/`EAGAIN`, wrapped in
+  `TransientConnectError`) up to 4 attempts with short increasing backoff
+  (~75/150/225 ms) before throwing `APP_NOT_RUNNING`. Non-transient errors,
+  socket timeouts, and real server responses (including error responses)
+  propagate immediately. The last errno is attached as `connectCode`.
+- **Discovery** (`src/cli/context.ts`): `resolveSocketPathWithRetry` re-probes a
+  few times with backoff so a one-off empty `readdir`/`kill(pid,0)` doesn't
+  declare the app offline.
+- **Diagnostics**: `socketDiagnostics()` reports `HOME`, sockets dir, each
+  socket's pid + liveness, and worktree-context detection. `exitAppNotRunning`
+  prints it (plus the failing stage and last connect errno) only under
+  `DEV3_DEBUG=1`, so a future report can prove the real cause — wrong `HOME`
+  vs busy app vs stale socket — instead of guessing. `connectAttempts`/
+  `retryDelayMs`/`attempts` are exposed for tests.
+
+## Risks
+
+- A genuinely-down app now costs ~450 ms extra before reporting `APP_NOT_RUNNING`
+  — negligible and only on the failure path.
+- Retrying does not mask a real bug because only connection-level errors retry;
+  a server that responds (even with an error) is never retried.
+
+## Alternatives considered
+
+- Increase the server listen backlog — Bun.listen exposes no backlog option, and
+  it would not cover the `ENOENT` (re)creation race or be unit-testable.
+- Try multiple candidate sockets in `discoverSocketIn` — addresses a different
+  (PID-reuse) edge case, not the reported burst/transient failure.
+- A pre-flight health ping with retry in `main.ts` — adds a round-trip to every
+  invocation for the same effect as retrying the actual request.

--- a/src/cli/__tests__/context-sockets.test.ts
+++ b/src/cli/__tests__/context-sockets.test.ts
@@ -91,4 +91,54 @@ describe("detectContext socket selection", () => {
 		expect(killSpy).toHaveBeenCalledWith(67566, 0);
 		expect(killSpy).toHaveBeenCalledWith(44818, 0);
 	});
+
+	it("resolveSocketPathWithRetry returns a socket on the first successful probe", async () => {
+		mockReaddirSync.mockReturnValue(["999.sock"]);
+		mockStatSync.mockReturnValue({ mtimeMs: 100 });
+
+		const { resolveSocketPathWithRetry } = await import("../context");
+		const result = await resolveSocketPathWithRetry(TEST_CWD, { attempts: 3, retryDelayMs: 5 });
+
+		expect(result).toBe(`${SOCKETS_DIR}/999.sock`);
+	});
+
+	it("resolveSocketPathWithRetry gives up (null) after attempts when no socket appears", async () => {
+		mockExistsSync.mockImplementation(() => false);
+		mockReaddirSync.mockReturnValue([]);
+
+		const { resolveSocketPathWithRetry } = await import("../context");
+		const start = Date.now();
+		const result = await resolveSocketPathWithRetry(TEST_CWD, { attempts: 3, retryDelayMs: 5 });
+
+		expect(result).toBeNull();
+		expect(Date.now() - start).toBeLessThan(2000);
+	});
+
+	it("socketDiagnostics distinguishes live from stale sockets", async () => {
+		mockReaddirSync.mockReturnValue(["123.sock", "456.sock"]);
+		killSpy.mockImplementation((pid: number) => {
+			if (pid === 456) {
+				const error = new Error("gone") as NodeJS.ErrnoException;
+				error.code = "ESRCH";
+				throw error;
+			}
+			return true;
+		});
+
+		const { socketDiagnostics } = await import("../context");
+		const out = socketDiagnostics(TEST_CWD);
+
+		expect(out).toContain(`HOME: ${TEST_HOME}`);
+		expect(out).toContain("socket 123.sock: pid=123 → process alive");
+		expect(out).toContain("socket 456.sock: pid=456 → process dead (stale socket)");
+	});
+
+	it("socketDiagnostics flags a missing sockets dir (likely wrong HOME)", async () => {
+		mockExistsSync.mockImplementation(() => false);
+
+		const { socketDiagnostics } = await import("../context");
+		const out = socketDiagnostics(TEST_CWD);
+
+		expect(out).toContain("sockets dir status: NOT FOUND");
+	});
 });

--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -146,6 +146,22 @@ describe("exitAppNotRunning", () => {
 		expect(stderrOutput).toContain("app not running");
 		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_APP_NOT_RUNNING);
 	});
+
+	it("stays terse when no diagnostics are provided", () => {
+		expect(() => exitAppNotRunning()).toThrow();
+		expect(stderrOutput).not.toContain("DEV3_DEBUG");
+		expect(stderrOutput).not.toContain("stage:");
+	});
+
+	it("appends stage and diagnostics when provided", () => {
+		expect(() =>
+			exitAppNotRunning({ stage: "discovery", diagnostics: "  HOME: /tmp\n  sockets: none present" }),
+		).toThrow(`EXIT_${CLI_EXIT_CODE_APP_NOT_RUNNING}`);
+		expect(stderrOutput).toContain("DEV3_DEBUG");
+		expect(stderrOutput).toContain("stage: discovery");
+		expect(stderrOutput).toContain("HOME: /tmp");
+		expect(stderrOutput).toContain("sockets: none present");
+	});
 });
 
 describe("exitUsage", () => {

--- a/src/cli/__tests__/socket-client.test.ts
+++ b/src/cli/__tests__/socket-client.test.ts
@@ -126,6 +126,59 @@ describe("sendRequest", () => {
 		}
 	});
 
+	it("recovers from a transient connect failure once the app socket accepts (issue #714)", async () => {
+		// Reproduces the false "app not running" verdict: the socket is briefly
+		// unavailable (no listener yet, like a busy app that can't accept()), then
+		// the app starts accepting. Without retry, sendRequest gives up on the very
+		// first ECONNREFUSED/ENOENT; with retry it must eventually connect.
+		cleanSocket();
+		const serverPromise = new Promise<Server>((resolve) => {
+			setTimeout(() => {
+				const srv = createServer((conn) => {
+					conn.on("data", (chunk) => {
+						const req = JSON.parse(chunk.toString().trim());
+						conn.write(JSON.stringify({ id: req.id, ok: true, data: { recovered: true } }) + "\n");
+						conn.end();
+					});
+				});
+				srv.listen(TEST_SOCKET, () => resolve(srv));
+			}, 120);
+		});
+
+		try {
+			const resp = await sendRequest(TEST_SOCKET, "test", {}, { connectAttempts: 10, retryDelayMs: 40 });
+			expect(resp.ok).toBe(true);
+			expect(resp.data).toEqual({ recovered: true });
+		} finally {
+			(await serverPromise).close();
+		}
+	});
+
+	it("gives up with APP_NOT_RUNNING after exhausting connect retries", async () => {
+		const start = Date.now();
+		await expect(
+			sendRequest("/tmp/dev3-nonexistent-socket.sock", "test", {}, { connectAttempts: 3, retryDelayMs: 20 }),
+		).rejects.toThrow("APP_NOT_RUNNING");
+		expect(Date.now() - start).toBeLessThan(5000);
+	});
+
+	it("does not retry a real error response from the server", async () => {
+		let calls = 0;
+		const server = await createMockServer((data) => {
+			calls++;
+			const req = JSON.parse(data);
+			return JSON.stringify({ id: req.id, ok: false, error: "Task not found" });
+		});
+
+		try {
+			const resp = await sendRequest(TEST_SOCKET, "task.show", { taskId: "bad" }, { connectAttempts: 5 });
+			expect(resp.ok).toBe(false);
+			expect(calls).toBe(1);
+		} finally {
+			server.close();
+		}
+	});
+
 	it("handles large responses without truncation", async () => {
 		// Generate a large payload (~50KB) similar to tasks.list with many tasks
 		const largeTasks = Array.from({ length: 100 }, (_, i) => ({

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -219,6 +219,72 @@ export function resolveSocketPath(cwd?: string): string | null {
 }
 
 /**
+ * Like resolveSocketPath, but retries a few times with short backoff before
+ * giving up. Discovery normally succeeds immediately (the app's socket file is
+ * stable for its lifetime), but a tight race — the app momentarily recreating
+ * its socket, or a filesystem hiccup right as a burst of CLI calls fires — can
+ * make a single readdir/`kill(pid,0)` probe come up empty. Retrying turns that
+ * transient miss into a successful resolve instead of a false "app not running"
+ * (mirrors the connect-level retry in socket-client; see issue #714).
+ */
+export async function resolveSocketPathWithRetry(
+	cwd?: string,
+	opts: { attempts?: number; retryDelayMs?: number } = {},
+): Promise<string | null> {
+	const attempts = Math.max(1, opts.attempts ?? 4);
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		const found = resolveSocketPath(cwd);
+		if (found) return found;
+		if (attempt === attempts - 1) break;
+		await new Promise((resolve) => setTimeout(resolve, opts.retryDelayMs ?? 75 * (attempt + 1)));
+	}
+	return null;
+}
+
+/**
+ * Human-readable diagnostics for why socket resolution failed. Printed by the
+ * CLI's "app not running" path when DEV3_DEBUG is set, so a future bug report
+ * can distinguish a real-offline app from a wrong HOME / sandboxed-signal /
+ * stale-socket situation instead of guessing. Never throws.
+ */
+export function socketDiagnostics(cwd: string = process.cwd()): string {
+	const lines: string[] = [];
+	lines.push(`  HOME: ${HOME}`);
+	lines.push(`  cwd: ${cwd}`);
+	lines.push(`  sockets dir: ${SOCKETS_DIR}`);
+
+	if (!existsSync(SOCKETS_DIR)) {
+		lines.push(`  sockets dir status: NOT FOUND (app never started, or HOME differs from the app's)`);
+	} else {
+		let files: string[] = [];
+		try {
+			files = readdirSync(SOCKETS_DIR).filter((f) => f.endsWith(".sock"));
+		} catch (e) {
+			lines.push(`  readdir error: ${e}`);
+		}
+		if (files.length === 0) {
+			lines.push(`  sockets: none present`);
+		}
+		for (const f of files) {
+			const pid = parseInt(f.replace(".sock", ""), 10);
+			let state = "unknown";
+			try {
+				process.kill(pid, 0);
+				state = "process alive";
+			} catch (e) {
+				const code = (e as NodeJS.ErrnoException).code;
+				state = code === "EPERM" ? "EPERM (sandboxed — cannot probe, may be alive)" : "process dead (stale socket)";
+			}
+			lines.push(`  socket ${f}: pid=${isNaN(pid) ? "?" : pid} → ${state}`);
+		}
+	}
+
+	const pathInfo = detectFromWorktreePath(cwd);
+	lines.push(`  worktree context: ${pathInfo ? `slug=${pathInfo.projectSlug} task=${pathInfo.taskShortId}` : "not detected from cwd"}`);
+	return lines.join("\n");
+}
+
+/**
  * Expand a short task ID (e.g. 8-char prefix from `tasks list`) to full UUID.
  * First checks the current context, then falls back to reading data files.
  */

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,5 @@
 import { parseArgs, resolveFileArgs } from "./args";
-import { detectContext, resolveSocketPath } from "./context";
+import { detectContext, resolveSocketPath, resolveSocketPathWithRetry, socketDiagnostics } from "./context";
 import { exitAppNotRunning, exitInternalError, exitUsage } from "./output";
 import { handleProjects } from "./commands/projects";
 import { handleTasks } from "./commands/tasks";
@@ -102,7 +102,7 @@ async function main(): Promise<void> {
 	const args = resolveFileArgs(parseArgs(restArgs));
 
 	const context = detectContext();
-	const socketPath = resolveSocketPath();
+	let socketPath = resolveSocketPath();
 
 	// Commands that work without the app running
 	if (command === "current") {
@@ -130,9 +130,14 @@ async function main(): Promise<void> {
 		return await handleGui(subcommand, args);
 	}
 
-	// All other commands require the socket
+	// All other commands require the socket. A single discovery probe can miss
+	// transiently (filesystem hiccup, app momentarily recreating its socket),
+	// so retry briefly before declaring the app offline (see issue #714).
 	if (!socketPath) {
-		exitAppNotRunning();
+		socketPath = await resolveSocketPathWithRetry();
+	}
+	if (!socketPath) {
+		exitAppNotRunning(debugAppNotRunning("discovery"));
 	}
 
 	try {
@@ -162,10 +167,26 @@ async function main(): Promise<void> {
 		}
 	} catch (err) {
 		if (err instanceof Error && err.message === "APP_NOT_RUNNING") {
-			exitAppNotRunning();
+			const connectCode = (err as Error & { connectCode?: string }).connectCode;
+			exitAppNotRunning(debugAppNotRunning("connect", connectCode));
 		}
 		throw err;
 	}
+}
+
+/**
+ * Build the diagnostics payload for exitAppNotRunning. Returns the stage + full
+ * socket diagnostics only when DEV3_DEBUG is set, so normal output stays terse
+ * while bug reporters can rerun with DEV3_DEBUG=1 to capture the actual cause.
+ */
+function debugAppNotRunning(
+	stage: "discovery" | "connect",
+	connectCode?: string,
+): { stage?: "discovery" | "connect"; diagnostics?: string } {
+	if (process.env.DEV3_DEBUG !== "1" && process.env.DEV3_DEBUG !== "true") return {};
+	const parts = [socketDiagnostics()];
+	if (connectCode) parts.push(`  last connect errno: ${connectCode}`);
+	return { stage, diagnostics: parts.join("\n") };
 }
 
 main().catch((err) => {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -44,12 +44,24 @@ export function exitError(message: string, detail?: string, code = CLI_EXIT_CODE
 	process.exit(code);
 }
 
-export function exitAppNotRunning(): never {
-	exitError(
-		"app not running",
-		"The dev3.0 desktop app must be running to use the CLI.\nStart the app and try again.",
-		CLI_EXIT_CODE_APP_NOT_RUNNING,
-	);
+export function exitAppNotRunning(opts: { stage?: "discovery" | "connect"; diagnostics?: string } = {}): never {
+	let detail = "The dev3.0 desktop app must be running to use the CLI.\nStart the app and try again.";
+
+	// Under DEV3_DEBUG, append why resolution failed so bug reports are
+	// actionable: "no live socket" (discovery — often a wrong HOME) vs "socket
+	// found but connection refused" (connect — busy app / transient backlog).
+	if (opts.diagnostics || opts.stage) {
+		detail += "\n\n[DEV3_DEBUG] app-not-running diagnostics:";
+		if (opts.stage) {
+			detail +=
+				opts.stage === "discovery"
+					? "\n  stage: discovery — no live socket found in the sockets dir"
+					: "\n  stage: connect — a socket was found but the connection was refused";
+		}
+		if (opts.diagnostics) detail += `\n${opts.diagnostics}`;
+	}
+
+	exitError("app not running", detail, CLI_EXIT_CODE_APP_NOT_RUNNING);
 }
 
 export function exitUsage(message: string): never {

--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -3,18 +3,32 @@ import type { CliRequest, CliResponse } from "../shared/types";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-export async function sendRequest(
-	socketPath: string,
-	method: string,
-	params: Record<string, unknown> = {},
-	opts: { timeoutMs?: number } = {},
-): Promise<CliResponse> {
-	const req: CliRequest = {
-		id: crypto.randomUUID(),
-		method,
-		params,
-	};
+// A live desktop app can momentarily fail to accept() a new connection — the
+// Unix-domain socket's accept backlog briefly fills while the app's single
+// event loop is busy (GC, a sync burst, or many `dev3` invocations firing at
+// once from agent hooks). macOS's small default backlog makes this far more
+// likely than on Linux. The kernel returns ECONNREFUSED even though the socket
+// file exists and the app is alive; ENOENT can likewise appear in a tight race
+// between socket (re)creation and connect. Treat these as transient and retry a
+// few times with short backoff before concluding the app is actually down —
+// otherwise a single hiccup is misreported as "app not running" (issue #714).
+const TRANSIENT_CONNECT_CODES = new Set(["ECONNREFUSED", "ENOENT", "EAGAIN"]);
+const DEFAULT_CONNECT_ATTEMPTS = 4;
+const CONNECT_RETRY_BASE_MS = 75;
 
+/** Connect failed with a code that may clear on retry while the app is alive. */
+class TransientConnectError extends Error {
+	constructor(readonly code: string) {
+		super(`Transient connect failure: ${code}`);
+		this.name = "TransientConnectError";
+	}
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sendOnce(socketPath: string, req: CliRequest, timeoutMs: number): Promise<CliResponse> {
 	return new Promise((resolve, reject) => {
 		const socket = connect({ path: socketPath });
 		// Accumulate raw buffers to avoid corrupting multi-byte UTF-8
@@ -45,18 +59,53 @@ export async function sendRequest(
 
 		socket.on("error", (err) => {
 			socket.destroy();
-			if ((err as NodeJS.ErrnoException).code === "ECONNREFUSED" ||
-				(err as NodeJS.ErrnoException).code === "ENOENT") {
-				reject(new Error("APP_NOT_RUNNING"));
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code && TRANSIENT_CONNECT_CODES.has(code)) {
+				reject(new TransientConnectError(code));
 			} else {
 				reject(err);
 			}
 		});
 
-		const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		socket.setTimeout(timeoutMs, () => {
 			socket.destroy();
 			reject(new Error(`Socket timeout (${Math.round(timeoutMs / 1000)}s)`));
 		});
 	});
+}
+
+export async function sendRequest(
+	socketPath: string,
+	method: string,
+	params: Record<string, unknown> = {},
+	opts: { timeoutMs?: number; connectAttempts?: number; retryDelayMs?: number } = {},
+): Promise<CliResponse> {
+	const req: CliRequest = {
+		id: crypto.randomUUID(),
+		method,
+		params,
+	};
+
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const attempts = Math.max(1, opts.connectAttempts ?? DEFAULT_CONNECT_ATTEMPTS);
+
+	let lastCode = "ECONNREFUSED";
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		try {
+			return await sendOnce(socketPath, req, timeoutMs);
+		} catch (err) {
+			// Only connection-level hiccups are retried. A real response (even an
+			// error one), a timeout, or a malformed payload propagates immediately.
+			if (!(err instanceof TransientConnectError)) throw err;
+			lastCode = err.code;
+			if (attempt === attempts - 1) break;
+			await delay(opts.retryDelayMs ?? CONNECT_RETRY_BASE_MS * (attempt + 1));
+		}
+	}
+
+	// Every connection attempt failed transiently — the app is genuinely down.
+	// Attach the last errno so the CLI can surface it under DEV3_DEBUG.
+	const appDown = new Error("APP_NOT_RUNNING") as Error & { connectCode?: string };
+	appDown.connectCode = lastCode;
+	throw appDown;
 }


### PR DESCRIPTION
Fixes #714 — the `dev3` CLI intermittently reporting "app not running" while the desktop app was alive.

## Summary

There are two paths to `APP_NOT_RUNNING` in `main.ts` — *discovery* (no live socket found) and *connect* (socket found but connection refused). A live app can momentarily fail to `accept()` when its event loop is busy and the Unix-socket accept backlog briefly fills — common when agent hooks fire `dev3` in bursts. macOS's small default backlog makes the kernel return `ECONNREFUSED` even though the app is alive, which the CLI was misreporting as offline on the very first hiccup.

- **connect** (`socket-client.ts`): `sendRequest` retries `ECONNREFUSED`/`ENOENT`/`EAGAIN` with short backoff before giving up. Real responses, timeouts, and non-transient errors are not retried; the last errno is attached as `connectCode`.
- **discovery** (`context.ts`): `resolveSocketPathWithRetry` re-probes briefly so a one-off empty `readdir`/`kill(pid,0)` doesn't falsely declare the app offline.
- **diagnostics**: `socketDiagnostics()` surfaced via `exitAppNotRunning` under `DEV3_DEBUG=1` (HOME, sockets dir, each socket's pid + liveness, failing stage, last errno) so future reports can prove the real cause instead of guessing.

Decision record `078`, changelog, and tests included (connect-recovery, discovery retry, diagnostics, debug output).