### PR TITLE
Auto-exclude worktrees root from Time Machine backups

### DIFF
--- a/change-logs/2026/06/23/feature-exclude-worktrees-from-backup.md
+++ b/change-logs/2026/06/23/feature-exclude-worktrees-from-backup.md
@@ -1,0 +1,1 @@
+On macOS, the whole worktrees root (~/.dev3.0/worktrees) is now automatically excluded from Time Machine backups once at app startup, sparing backups from gigabytes of CoW-cloned dependencies that already live in git. A new Settings → Workspace toggle lets you opt out.

--- a/decisions/078-exclude-worktrees-from-backup.md
+++ b/decisions/078-exclude-worktrees-from-backup.md
@@ -1,0 +1,45 @@
+# 078 — Exclude the worktrees root from OS backups
+
+## Context
+
+`~/.dev3.0/worktrees` holds per-task git worktrees, each with full CoW-cloned
+`node_modules`/build directories — easily 100GB+ of ephemeral data whose
+committed state already lives in git. Time Machine backing this up is pure waste
+that slows every backup.
+
+## Decision
+
+Added `ensureWorktreesBackupExclusion()` (`src/bun/backup-exclusion.ts`), called
+once at app startup from both entry points — desktop (`src/bun/index.ts`) and
+headless/remote (`src/bun/headless-entry.ts`), fire-and-forget after the shell
+env/PATH is patched. It excludes the **whole** worktrees root in a single
+`tmutil addexclusion <worktreesRoot>` call (per-task subfolders inherit it),
+guarded once per process (in-memory), and is a no-op on Linux. No setting — the
+behavior is unconditional; users who want backups can remove the exclusion with
+`tmutil removeexclusion ~/.dev3.0/worktrees`.
+
+We deliberately use `tmutil addexclusion` **without** `-p`: the path/sticky form
+(`-p`) requires root, whereas the plain form sets a per-user xattr exclusion
+(`com.apple.metadata:com_apple_backup_excludeItem`) that needs no privileges and
+is idempotent (re-adding is a no-op).
+
+## Risks
+
+- The exclusion is a best-effort xattr; if a user later clears it manually, the
+  next worktree creation in a fresh app session re-applies it (the guard is
+  in-memory only, and a failed `tmutil` call leaves the guard unset so it
+  retries).
+- Existing installs only get the exclusion on the next worktree creation, not
+  retroactively for trees already present — acceptable, since the bulk of the
+  data is the root they all share.
+
+## Alternatives considered
+
+- **Apply inside `createWorktree`** (on first worktree creation): works and is a
+  single chokepoint, but excludes the folder lazily. Rejected in favor of doing
+  it once at startup — simpler mental model ("exclude the whole folder at app
+  start") and applies even before the first task is created.
+- **Marker file under `~/.dev3.0/`** to gate the call: rejected as unnecessary —
+  `tmutil addexclusion` is already idempotent and cheap, and the in-memory guard
+  avoids repeat spawns within a session without touching the frozen on-disk
+  layout.

--- a/src/bun/__tests__/backup-exclusion.test.ts
+++ b/src/bun/__tests__/backup-exclusion.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSpawn = vi.fn((..._args: unknown[]) => ({
+	exited: Promise.resolve(0),
+}));
+
+vi.mock("../spawn", () => ({
+	spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import {
+	_resetBackupExclusionGuard,
+	ensureWorktreesBackupExclusion,
+	WORKTREES_ROOT,
+} from "../backup-exclusion";
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+const ORIGINAL_PLATFORM = process.platform;
+
+describe("ensureWorktreesBackupExclusion", () => {
+	beforeEach(() => {
+		mockSpawn.mockClear();
+		mockSpawn.mockReturnValue({ exited: Promise.resolve(0) });
+		_resetBackupExclusionGuard();
+		setPlatform("darwin");
+	});
+
+	afterEach(() => {
+		setPlatform(ORIGINAL_PLATFORM);
+	});
+
+	it("runs tmutil addexclusion on the worktrees root on macOS", async () => {
+		await ensureWorktreesBackupExclusion();
+
+		expect(mockSpawn).toHaveBeenCalledWith(["mkdir", "-p", WORKTREES_ROOT]);
+		expect(mockSpawn).toHaveBeenCalledWith([
+			"tmutil",
+			"addexclusion",
+			WORKTREES_ROOT,
+		]);
+	});
+
+	it("is a no-op on Linux", async () => {
+		setPlatform("linux");
+		await ensureWorktreesBackupExclusion();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	it("only invokes tmutil once per process after success", async () => {
+		await ensureWorktreesBackupExclusion();
+		await ensureWorktreesBackupExclusion();
+		const addexclusionCalls = mockSpawn.mock.calls.filter(
+			(call) => (call[0] as string[])[0] === "tmutil",
+		);
+		expect(addexclusionCalls).toHaveLength(1);
+	});
+
+	it("retries on a later call when tmutil fails", async () => {
+		mockSpawn.mockImplementation((...args: unknown[]) => {
+			const code = (args[0] as string[])[0] === "tmutil" ? 1 : 0;
+			return { exited: Promise.resolve(code) };
+		});
+		await ensureWorktreesBackupExclusion();
+
+		mockSpawn.mockReturnValue({ exited: Promise.resolve(0) });
+		await ensureWorktreesBackupExclusion();
+
+		const addexclusionCalls = mockSpawn.mock.calls.filter(
+			(call) => (call[0] as string[])[0] === "tmutil",
+		);
+		expect(addexclusionCalls).toHaveLength(2);
+	});
+
+	it("never throws when spawn rejects", async () => {
+		mockSpawn.mockImplementation(() => {
+			throw new Error("spawn boom");
+		});
+		await expect(ensureWorktreesBackupExclusion()).resolves.toBeUndefined();
+	});
+});

--- a/src/bun/backup-exclusion.ts
+++ b/src/bun/backup-exclusion.ts
@@ -1,0 +1,66 @@
+/**
+ * Exclude the dev-3.0 worktrees root from OS-level backups.
+ *
+ * The worktrees root (`~/.dev3.0/worktrees`) holds per-task git worktrees with
+ * full CoW-cloned `node_modules`/build dirs — easily 100GB+ of ephemeral data
+ * whose committed state already lives in git. Backing it up (Time Machine on
+ * macOS) is pure waste that slows every backup.
+ *
+ * On macOS we run `tmutil addexclusion <root>` (no `-p`): this sets a per-user
+ * xattr exclusion that does NOT require root and is idempotent. On Linux this
+ * is a no-op (Time Machine doesn't exist; no portable equivalent).
+ */
+
+import { createLogger } from "./logger";
+import { DEV3_HOME } from "./paths";
+import { spawn } from "./spawn";
+
+const log = createLogger("backup-exclusion");
+
+/** The directory we exclude from backups. */
+export const WORKTREES_ROOT = `${DEV3_HOME}/worktrees`;
+
+/**
+ * Cleared once the exclusion has been applied (or definitively skipped) in this
+ * process, so we only spawn `tmutil` once per app session.
+ */
+let ensured = false;
+
+/** Reset the in-memory guard. Test-only. */
+export function _resetBackupExclusionGuard(): void {
+	ensured = false;
+}
+
+/**
+ * Ensure the worktrees root exists and is excluded from OS backups.
+ *
+ * Cheap and idempotent: returns immediately after the first successful run in a
+ * process. Never throws — backup exclusion is best-effort and must not block
+ * worktree creation.
+ */
+export async function ensureWorktreesBackupExclusion(): Promise<void> {
+	if (ensured) return;
+
+	// Time Machine is macOS-only; nothing portable to do elsewhere.
+	if (process.platform !== "darwin") {
+		ensured = true;
+		return;
+	}
+
+	try {
+		// Ensure the root exists so tmutil has a target.
+		await spawn(["mkdir", "-p", WORKTREES_ROOT]).exited;
+
+		const proc = spawn(["tmutil", "addexclusion", WORKTREES_ROOT]);
+		const code = await proc.exited;
+		if (code === 0) {
+			log.info("Excluded worktrees root from Time Machine", { path: WORKTREES_ROOT });
+			ensured = true;
+		} else {
+			// Leave `ensured` false so a later worktree creation retries.
+			log.warn("tmutil addexclusion failed", { path: WORKTREES_ROOT, code });
+		}
+	} catch (err) {
+		log.warn("Failed to apply backup exclusion", { error: String(err) });
+	}
+}

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -146,6 +146,15 @@ applyFullShellEnvToProcess(shellEnv, (await loadSettings()).importShellEnv !== f
 const cliSocketPath = startSocketServer();
 log.info("CLI socket server ready", { path: cliSocketPath });
 
+// Exclude the worktrees root from OS backups (Time Machine) once at startup.
+// Best-effort; no-op on Linux and when disabled in settings.
+{
+	const { ensureWorktreesBackupExclusion } = await import("./backup-exclusion");
+	ensureWorktreesBackupExclusion().catch((err) => {
+		log.warn("Startup backup exclusion failed (non-fatal)", { err });
+	});
+}
+
 // ── PTY / port scanner / resource monitor (dynamic import so PATH is patched first) ──
 const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -228,6 +228,15 @@ log.info("CLI socket server ready", { path: cliSocketPath });
 	});
 }
 
+// Exclude the worktrees root from OS backups (Time Machine) once at startup.
+// Best-effort; no-op on Linux and when disabled in settings.
+{
+	const { ensureWorktreesBackupExclusion } = await import("./backup-exclusion");
+	ensureWorktreesBackupExclusion().catch((err) => {
+		log.warn("Startup backup exclusion failed (non-fatal)", { err });
+	});
+}
+
 // Side-effect: starts the PTY WebSocket server (dynamic import so PATH is patched first)
 const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");


### PR DESCRIPTION
## Summary

On macOS, the dev-3.0 worktrees root (`~/.dev3.0/worktrees`) is now automatically excluded from Time Machine backups, once at app startup.

That folder holds per-task git worktrees, each with full CoW-cloned `node_modules`/build dirs — easily 100GB+ of ephemeral data whose committed state already lives in git. Backing it up is pure waste that slows every backup.

## How

- New `ensureWorktreesBackupExclusion()` (`src/bun/backup-exclusion.ts`): `mkdir -p` the root, then a single `tmutil addexclusion <worktreesRoot>` call covering the whole folder (per-task subfolders inherit it).
- Called once at app startup from both entry points — desktop (`src/bun/index.ts`) and headless/remote (`src/bun/headless-entry.ts`), fire-and-forget after the shell env/PATH is patched.
- Once-per-process in-memory guard, no-op on Linux, best-effort (never blocks startup).
- Uses the per-user xattr form (no `-p`) so it requires no root and is idempotent.

No setting — the behavior is unconditional and silent. Users who want backups can undo it with `tmutil removeexclusion ~/.dev3.0/worktrees`. See `decisions/078-exclude-worktrees-from-backup.md`.