### PR TITLE
fix: clear stale git status line when switching tasks

### DIFF
--- a/change-logs/2026/06/23/fix-stale-git-line-on-task-switch.md
+++ b/change-logs/2026/06/23/fix-stale-git-line-on-task-switch.md
@@ -1,0 +1,1 @@
+Fixed the task info panel briefly showing the previous task's branch/commit status when switching tasks. The git line now clears and shows a loading state until fresh branch status arrives.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1316,6 +1316,32 @@ describe("TaskInfoPanel", () => {
 			});
 		});
 
+		it("does not show the previous task's branch status while switching to another task", async () => {
+			const view = renderPanel(makeTask({ id: "t1" }));
+			await waitFor(() => {
+				expect(screen.getByText("3 commits ahead")).toBeInTheDocument();
+			});
+
+			// New task's status never resolves — the panel must clear the stale
+			// badge and show the loading state instead of the old task's data.
+			mockedApi.request.getBranchStatus.mockImplementation(() => new Promise(() => {}));
+
+			await act(async () => {
+				view.rerender(
+					<I18nProvider>
+						<TaskInfoPanel
+							task={makeTask({ id: "t2", branchName: "dev3/task-t2" })}
+							project={project}
+							dispatch={vi.fn()}
+							navigate={vi.fn()}
+						/>
+					</I18nProvider>,
+				);
+			});
+
+			expect(screen.queryByText("3 commits ahead")).not.toBeInTheDocument();
+		});
+
 			it("uses the project's default comparison ref when configured", async () => {
 				const localCompareProject = {
 					...project,

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -60,6 +60,14 @@ export function useTaskBranchStatus({
 		setCompareRef(defaultCompareRef);
 	}, [defaultCompareRef, task.id]);
 
+	// Switching tasks reuses this component instance (no `key={task.id}`), so the
+	// previous task's branch status would otherwise linger on screen until the
+	// new fetch resolves. Clear it eagerly so the git line shows the loading
+	// state instead of stale data from the task we just left.
+	useEffect(() => {
+		setBranchStatus(null);
+	}, [task.id]);
+
 	const completeTask = useCallback(() => {
 		void moveTaskToStatus({
 			task,


### PR DESCRIPTION
Hi — Claude here (the AI assistant working on this branch).

## Summary

When switching between tasks, the info panel's git line briefly showed the **previous** task's branch status (ahead/behind, PR badge, action buttons) until the new branch status finished loading.

Root cause: `TaskInfoPanel` is reused across tasks **without** `key={task.id}`, so the local `branchStatus` state in `useTaskBranchStatus` lingered from the task we just left. Since `statusLoading` derives from `!branchStatus`, the loading spinner never showed either.

Fix: reset `branchStatus` to `null` on `task.id` change in `useTaskBranchStatus`. The git line now clears and shows the loading state until fresh data arrives. Done as a dedicated `task.id`-keyed effect (not inside the polling effect) to avoid spurious spinner flashes when only `task.status`/`compareRef` change on the same task.

Includes a regression test that fails without the fix.