### PR TITLE
fix: keep current view after completing a task

### DIFF
--- a/change-logs/2026/06/23/fix-stay-in-view-after-complete.md
+++ b/change-logs/2026/06/23/fix-stay-in-view-after-complete.md
@@ -1,0 +1,1 @@
+Completing or cancelling a task no longer kicks you back to the bare Kanban board. If you were in a task view it now stays in task view with nothing selected; if you were on the Kanban board it stays there.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { useAppState, routeTaskId, projectIdForRoute, type Route } from "./state";
+import { useAppState, routeTaskId, projectIdForRoute, routeAfterTaskClosed, type Route } from "./state";
 import { api } from "./rpc";
 import { useT, useLocale } from "./i18n";
 import { handleMenuAction } from "./menuRouter";
@@ -827,14 +827,13 @@ function App() {
 			});
 			if (shouldComplete === null) return;
 			if (shouldComplete) {
-				// If the user is currently inside this task's full screen, navigate them
-				// back to the Kanban view BEFORE the worktree is destroyed. Otherwise
-				// TaskTerminal reacts to ptyDied / missing worktree and shows the
-				// "session ended / restart session" screen.
-				const currentRoute = routeRef.current;
-				if (currentRoute.screen === "task" && currentRoute.taskId === taskId) {
-					navigate({ screen: "project", projectId });
-				}
+				// If the user is currently inside this task's view, leave it BEFORE the
+				// worktree is destroyed (otherwise TaskTerminal reacts to ptyDied /
+				// missing worktree and shows the "session ended / restart session"
+				// screen). Stay on the same surface: a task view collapses to "no task
+				// selected", a Kanban board is left untouched.
+				const dest = routeAfterTaskClosed(routeRef.current, taskId);
+				if (dest) navigate(dest);
 				dispatch({
 					type: "updateTask",
 					task: {
@@ -877,10 +876,9 @@ function App() {
 	// socket waiting for the user's decision, so always respond, even on cancel.
 	useEffect(() => {
 		async function onAgentCompletionRequested(e: Event) {
-			const { requestId, taskId, projectId, taskTitle, taskOverview } = (e as CustomEvent).detail as {
+			const { requestId, taskId, taskTitle, taskOverview } = (e as CustomEvent).detail as {
 				requestId: string;
 				taskId: string;
-				projectId: string;
 				taskTitle: string;
 				taskOverview?: string;
 			};
@@ -899,12 +897,11 @@ function App() {
 				console.error("[App] confirm (agent-completion) failed:", err);
 			}
 			if (approved) {
-				// Leave the task's full-screen terminal BEFORE the worktree is
-				// destroyed (same reasoning as the branch-merged flow above).
-				const currentRoute = routeRef.current;
-				if (currentRoute.screen === "task" && currentRoute.taskId === taskId) {
-					navigate({ screen: "project", projectId });
-				}
+				// Leave the task's view BEFORE the worktree is destroyed (same
+				// reasoning as the branch-merged flow above). Stay on the same
+				// surface: a task view collapses to "no task selected".
+				const dest = routeAfterTaskClosed(routeRef.current, taskId);
+				if (dest) navigate(dest);
 				dispatch({ type: "clearBell", taskId });
 				trackEvent("task_moved", { to_status: "completed", agent_requested: true });
 			}

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -1,4 +1,4 @@
-import { reducer, initialState, routeTaskId, projectIdForRoute, HISTORY_LIMIT, canGoBack, canGoForward } from "../state";
+import { reducer, initialState, routeTaskId, projectIdForRoute, routeAfterTaskClosed, HISTORY_LIMIT, canGoBack, canGoForward } from "../state";
 import type { AppState, AppAction } from "../state";
 import type { Project, Task } from "../../shared/types";
 
@@ -811,6 +811,37 @@ describe("routeTaskId", () => {
 	it("returns null for a project route with no active task", () => {
 		expect(routeTaskId({ screen: "project", projectId: "p1" })).toBeNull();
 		expect(routeTaskId({ screen: "dashboard" })).toBeNull();
+	});
+});
+
+describe("routeAfterTaskClosed", () => {
+	it("collapses a full-page task view to task-view with no task selected", () => {
+		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "t9" }, "t9")).toEqual({
+			screen: "project",
+			projectId: "p1",
+			taskView: true,
+		});
+	});
+
+	it("deselects the task in a split task view", () => {
+		expect(
+			routeAfterTaskClosed({ screen: "project", projectId: "p1", taskView: true, activeTaskId: "t5" }, "t5"),
+		).toEqual({ screen: "project", projectId: "p1", taskView: true });
+	});
+
+	it("returns null on the bare Kanban board (no navigation)", () => {
+		expect(routeAfterTaskClosed({ screen: "project", projectId: "p1" }, "t9")).toBeNull();
+	});
+
+	it("returns null when viewing a different task", () => {
+		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "other" }, "t9")).toBeNull();
+		expect(
+			routeAfterTaskClosed({ screen: "project", projectId: "p1", activeTaskId: "other" }, "t9"),
+		).toBeNull();
+	});
+
+	it("returns null for non-project screens", () => {
+		expect(routeAfterTaskClosed({ screen: "dashboard" }, "t9")).toBeNull();
 	});
 });
 

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -204,11 +204,14 @@ function TaskInfoPanel({ task, project, dispatch, navigate, taskPorts, taskResou
 			// Terminal moves leave the screen immediately (fire-and-forget); other
 			// screen-leaving moves wait for the server to confirm so a failed +
 			// reverted move doesn't kick the user off the task screen.
+			// Stay in task view with nothing selected instead of dropping to the bare
+			// Kanban board — the panel only renders on a task surface (full-page or
+			// split), so taskView keeps the user where they were.
 			afterOptimistic: terminal && leaveScreen
-				? () => navigate({ screen: "project", projectId: project.id })
+				? () => navigate({ screen: "project", projectId: project.id, taskView: true })
 				: undefined,
 			onSuccess: !terminal && leaveScreen
-				? () => navigate({ screen: "project", projectId: project.id })
+				? () => navigate({ screen: "project", projectId: project.id, taskView: true })
 				: undefined,
 		});
 	}

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -129,7 +129,9 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			t,
 			confirm: false,
 			revertOnFailure: false,
-			afterOptimistic: () => navigate({ screen: "project", projectId }),
+			// Stay in task view with nothing selected, rather than dropping to the
+			// bare Kanban board (works for both full-page and split task surfaces).
+			afterOptimistic: () => navigate({ screen: "project", projectId, taskView: true }),
 		});
 	}
 
@@ -192,7 +194,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 						project={project}
 						onCancelled={(updated) => {
 							dispatch({ type: "updateTask", task: updated });
-							navigate({ screen: "project", projectId });
+							navigate({ screen: "project", projectId, taskView: true });
 						}}
 					/>
 				</div>

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -649,7 +649,7 @@ describe("TaskInfoPanel", () => {
 			await user.click(screen.getByText("Agent is Working"));
 			await user.click(screen.getByText("Completed"));
 
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 			expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
 				type: "updateTask",
 				task: expect.objectContaining({ status: "completed", worktreePath: null, branchName: null }),
@@ -1987,7 +1987,7 @@ describe("TaskInfoPanel", () => {
 				expect(dispatchedTask.branchName).toBeNull();
 			});
 
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 		});
 
 		it("optimistically completes after merge even while the move RPC is still pending", async () => {
@@ -2020,7 +2020,7 @@ describe("TaskInfoPanel", () => {
 				);
 				expect(completedUpdate).toBeDefined();
 			});
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 		});
 
 		it("keeps the optimistic completion when both background completion RPC attempts fail", async () => {
@@ -2060,7 +2060,7 @@ describe("TaskInfoPanel", () => {
 			);
 
 			expect(completedUpdate).toBeDefined();
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 			expect(alertSpy).not.toHaveBeenCalled();
 			expect(consoleErrorSpy).toHaveBeenCalled();
 			consoleErrorSpy.mockRestore();

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -178,7 +178,7 @@ describe("TaskTerminal", () => {
 			const movedAtMs = new Date(dispatchedTask.movedAt!).getTime();
 			expect(movedAtMs).toBeGreaterThan(Date.now() - 5000);
 
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 			expect(mockedTrackEvent).toHaveBeenCalledWith("task_moved", {
 				from_status: "in-progress",
 				to_status: "completed",
@@ -215,7 +215,7 @@ describe("TaskTerminal", () => {
 			expect(dispatchedTask.worktreePath).toBeNull();
 			expect(dispatchedTask.branchName).toBeNull();
 
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 		});
 
 		it("fires moveTask API call in background", async () => {
@@ -431,7 +431,7 @@ describe("TaskTerminal", () => {
 
 			expect(mockedApi.request.cancelTaskPreparation).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1" });
 			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: revertedTask });
-			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1", taskView: true });
 		});
 
 		it("connects to the PTY once preparing flips to false", async () => {

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -69,7 +69,8 @@ export function useTaskBranchStatus({
 			t,
 			confirm: false,
 			revertOnFailure: false,
-			afterOptimistic: () => navigate({ screen: "project", projectId: project.id }),
+			// Keep the user in task view (no task selected) rather than the bare board.
+			afterOptimistic: () => navigate({ screen: "project", projectId: project.id, taskView: true }),
 		});
 	}, [dispatch, navigate, project, task, t]);
 

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -59,6 +59,30 @@ export function routeTaskId(route: Route): string | null {
 	return null;
 }
 
+/**
+ * Where to land after `taskId` is completed/cancelled and its worktree is
+ * destroyed. The point is to preserve the surface the user is on instead of
+ * always dropping them onto the Kanban board:
+ *
+ *  - full-page task view of this task        → task split view, no task selected
+ *  - split task view showing this task        → same split view, task deselected
+ *  - anything else (Kanban, a different task) → no navigation (returns null)
+ *
+ * Both task surfaces collapse to `{ screen: "project", taskView: true }` with
+ * no `activeTaskId`, which renders the "select a task" placeholder pane — i.e.
+ * "stay in task view, nothing selected". Returning null means the caller should
+ * not navigate at all (the completed card simply leaves the board).
+ */
+export function routeAfterTaskClosed(route: Route, taskId: string): Route | null {
+	if (route.screen === "task" && route.taskId === taskId) {
+		return { screen: "project", projectId: route.projectId, taskView: true };
+	}
+	if (route.screen === "project" && route.activeTaskId === taskId) {
+		return { screen: "project", projectId: route.projectId, taskView: true };
+	}
+	return null;
+}
+
 /** The project id a route lands on, or null for project-less screens (dashboard, settings…). */
 export function projectIdForRoute(route: Route): string | null {
 	switch (route.screen) {


### PR DESCRIPTION
Completing or cancelling a task no longer always drops the user onto the bare Kanban board.

**Before:** finishing a task from a task view (full-page terminal or split view) navigated to the plain `{ screen: "project" }` Kanban board.

**After:** the user stays on the same surface:
- A task view (full-page or split) collapses to **task view with no task selected** (`taskView: true`, no `activeTaskId`) — the "select a task" placeholder pane.
- The Kanban board is left untouched (the completed card just leaves the board).

Centralized the routing decision in a new pure helper `routeAfterTaskClosed(route, taskId)` in `state.ts` (returns `null` when no navigation is needed), and applied the new behaviour to every completion/teardown surface:
- agent completion request popup (`App.tsx`)
- branch-merged completion prompt (`App.tsx`)
- terminal toolbar complete/cancel + preparation cancel (`TaskTerminal.tsx`)
- status move from the info panel (`TaskInfoPanel.tsx`)
- auto-complete after branch merge (`useTaskBranchStatus.ts`)

Added unit tests for `routeAfterTaskClosed` and updated the affected navigation assertions.