### PR TITLE
docs: reposition README and landing around the One Person Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">dev-3.0</h1>
 
 <p align="center">
-  <strong>Terminal-centric project manager for AI coding agents</strong><br>
-  Kanban board meets terminal. Each task gets its own git worktree, tmux session, and full terminal.
+  <strong>Mission control for the One Person Studio</strong><br>
+  AI writes the code now — your job is commanding the fleet. dev-3.0 is the Kanban-first cockpit for running dozens of AI coding agents at full speed, while one board keeps you focused. Each task gets its own git worktree, tmux session, and terminal.
 </p>
 
 <p align="center">
@@ -27,6 +27,33 @@
 <p align="center">
   <img src="docs/screenshots/kanban-board.jpg" width="800" alt="Kanban board — tasks across To Do, Working, Review and Done columns">
 </p>
+
+## Philosophy
+
+AI writes the code now. It commits, opens PRs, reviews. Your job changed —
+from *writing* to *commanding* a fleet of agents across more tasks and projects
+than any one head can hold. The bottleneck moved: it's not your editor anymore,
+it's your **focus**. Everything in dev-3.0 is built around that. Two things we
+optimize for, above all:
+
+**1. Your speed — as one person.**
+dev-3.0 optimizes a single developer: *you*. The unit is always the individual,
+never the org. It works fine on a team — but it's not a tool for managing other
+people; it's a tool for each person to command their own fleet and hit their own
+top speed. Everyone focuses on themselves, and the whole moves faster.
+
+**2. Beautiful, and built around you.**
+A cockpit you stare at all day should be fast, gorgeous, and keyboard-first — and
+it should bend to *your* way of working, not force one on you. Great tooling
+doesn't just make you productive; it makes the work fun again. We sweat the polish.
+
+**And what we refuse: dev-3.0 is not an IDE — and won't become one.**
+
+- **The code is the agent's job.** No embedded editor; one click to your real
+  VS Code or Cursor when you truly need it — and the goal is to need it less.
+- **Git is the agent's job too.** No manual staging, no hand-written commits.
+- **Integrate through your agent.** Claude Code, Codex & co. already speak MCP to
+  Linear, Jira, and the rest. dev-3.0 is the cockpit; your agent is the adapter.
 
 ## The problem
 
@@ -81,6 +108,17 @@ dev-3.0 gives you a Kanban board where each task is a fully isolated environment
 <p align="center">
   <img src="docs/screenshots/global-settings.jpg" width="600" alt="Global settings — agents, configs, languages">
 </p>
+
+## Which is for you?
+
+Other tools in this space are great — if you want to live in an editor.
+dev-3.0 makes a different bet. Pick by your goal, not a feature checklist:
+
+| If you want to… | Reach for… |
+|---|---|
+| Stay in an editor, hands on the code and git | an **agent IDE** |
+| Buy a platform for a whole team (SSO, seats, audit) | a **team orchestrator** |
+| Run a fleet of agents **solo**, at speed, without drowning | **dev-3.0** |
 
 ## Keyboard shortcuts
 

--- a/change-logs/2026/06/24/docs-positioning-one-person-studio.md
+++ b/change-logs/2026/06/24/docs-positioning-one-person-studio.md
@@ -1,0 +1,1 @@
+Reframed the README and landing page (docs/index.html) around dev-3.0's positioning: mission control for the One Person Studio, deliberately not an IDE. Added Philosophy, Ways to work, and "Which is for you?" sections plus a refreshed hero, meta tags, and CTA copy. See decisions/080-positioning-not-an-ide.md.

--- a/decisions/080-positioning-not-an-ide.md
+++ b/decisions/080-positioning-not-an-ide.md
@@ -1,0 +1,21 @@
+# 080 — Positioning: mission control, not an IDE
+
+## Context
+
+Two close competitors — one an "Agent IDE", one a "Code Editor for AI agents" team/enterprise SaaS — look superficially similar to dev-3.0. We needed a sharp, durable positioning that tells a comparing visitor who each product is for, and that keeps dev-3.0 from drifting into IDE territory (the market's gravity pulls there; one competitor publicly admits it morphed from a terminal-orchestrator into an IDE).
+
+## Decision
+
+Position dev-3.0 as **"Mission control for the One Person Studio"** — a Kanban-first cockpit for a solo developer commanding a fleet of AI agents. Optimize for two things: the individual's **speed** (via focus, not editor time) and **beauty/ergonomics**; and explicitly **not be an IDE**. Applied to `README.md` (new `## Philosophy` and `## Which is for you?` sections, new subtitle) and `docs/index.html` (hero H1/subtitle + flow descriptor, `#philosophy`, `#ways-to-work`, `#compare` sections, `Why` nav link, title/OG/Twitter meta, CTA → "Ready to take command?"). Headline and subhead are founder-approved.
+
+## Risks
+
+The hard "not an IDE" stance constrains future feature choices on purpose: no embedded editor, no manual git UI, no native Jira/Linear/etc. integrations (those go through the agent's MCP). Comparison copy uses generic categories ("agent IDE", "team orchestrator") rather than naming rivals — safer, but may need revisiting if the market shifts.
+
+## Alternatives considered
+
+- Anti-IDE-contrast headline ("IDE manages your code, dev3 manages you") — rejected for the positive mission-control framing the founder picked.
+- Naming competitors directly in the comparison — rejected as defensive; kept generic.
+- Building toward an IDE (embedded editor, git UI, PM integrations) to match competitors — explicitly rejected; it contradicts the thesis.
+
+See the positioning memory (`dev3-positioning-one-person-studio`) and the competitor-analysis notes on the orca-mapping task for the full 3-way analysis.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>dev-3.0 — Terminal-Centric Project Manager for AI Agents</title>
-<meta name="description" content="Manage dozens of AI coding agents in parallel. Kanban board meets terminal. Each task gets its own git worktree, tmux session, and full terminal — all from one interface.">
-<meta property="og:title" content="dev-3.0 — Terminal-Centric Project Manager for AI Agents">
-<meta property="og:description" content="Manage dozens of AI coding agents in parallel. Kanban board meets terminal.">
+<title>dev-3.0 — Mission Control for the One Person Studio</title>
+<meta name="description" content="AI writes the code. You command the fleet. dev-3.0 is the Kanban-first cockpit for running dozens of AI coding agents at full speed — focused, isolated, never lost.">
+<meta property="og:title" content="dev-3.0 — Mission Control for the One Person Studio">
+<meta property="og:description" content="AI writes the code. You command the fleet. dev-3.0 is the Kanban-first cockpit for running dozens of AI coding agents at full speed.">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="dev-3.0">
 <meta property="og:url" content="https://dev3.h0x91b.com/">
@@ -15,8 +15,8 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="dev-3.0 — terminal-centric project manager for AI coding agents">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="dev-3.0 — Terminal-Centric Project Manager for AI Agents">
-<meta name="twitter:description" content="Manage dozens of AI coding agents in parallel. Kanban board meets terminal.">
+<meta name="twitter:title" content="dev-3.0 — Mission Control for the One Person Studio">
+<meta name="twitter:description" content="AI writes the code. You command the fleet. dev-3.0 is the Kanban-first cockpit for running dozens of AI coding agents at full speed.">
 <meta name="twitter:image" content="https://dev3.h0x91b.com/og-image.jpg">
 <meta name="theme-color" content="#060915">
 <link rel="canonical" href="https://dev3.h0x91b.com/">
@@ -1256,6 +1256,7 @@ footer {
       <span>dev-3.0</span>
     </a>
     <ul class="nav-links">
+      <li><a href="#philosophy">Why</a></li>
       <li><a href="#features">Features</a></li>
       <li><a href="#how-it-works">How it works</a></li>
       <li><a href="#get-started">Install</a></li>
@@ -1282,17 +1283,18 @@ footer {
   <div class="hero-orb hero-orb-3"></div>
 
   <h1 class="reveal reveal-delay-1">
-    One app to manage<br>
-    <span class="gradient-text">all your AI agents</span>
+    Mission control for the<br>
+    <span class="gradient-text">One Person Studio</span>
   </h1>
 
-  <p class="hero-subtitle reveal reveal-delay-2">
-    Think <strong style="color:var(--text-1)">iTerm2</strong> meets
-    <strong style="color:var(--text-1)">Kanban</strong> meets
-    <strong style="color:var(--text-1)">tmux</strong>.
-    A next-gen terminal with built-in task management for any shell-based
-    AI coding agent. No opinionated workflows, no magic &mdash;
-    just proper infrastructure for running N agents at once.
+  <p class="hero-subtitle reveal reveal-delay-2" style="margin-bottom:16px">
+    You're the whole team now &mdash; code, product, QA, all of it.
+    dev-3.0 is the cockpit for commanding a fleet of AI coding agents
+    at full speed, while one board keeps you focused.
+    <strong style="color:var(--text-1)">Without losing your mind.</strong>
+  </p>
+  <p class="reveal reveal-delay-2" style="font-family:var(--font-mono);font-size:14px;color:var(--text-3);letter-spacing:0.3px;margin:0 auto 48px">
+    Your projects, your boards, your agents &mdash; your flow.
   </p>
 
   <div class="hero-actions reveal reveal-delay-3">
@@ -1391,7 +1393,8 @@ footer {
       You're running 5+ agents across different terminals, repos, and branches.
       Switching context takes forever. You lose track of what&rsquo;s where.
       We tried every tool in the space &mdash; each had cool ideas, but something
-      was always missing. So we built our own.
+      was always missing. So we built our own. The hard part was never typing
+      code &mdash; it&rsquo;s keeping your focus across all of it.
     </p>
 
     <div class="problem-grid">
@@ -1934,6 +1937,113 @@ footer {
   </div>
 </section>
 
+<!-- PHILOSOPHY -->
+<section class="features" id="philosophy">
+  <div class="container">
+    <div class="section-eyebrow reveal">Philosophy</div>
+    <h2 class="section-title reveal reveal-delay-1">
+      Built for you. Not your org chart.
+    </h2>
+    <p class="section-desc reveal reveal-delay-2">
+      AI writes the code now &mdash; your job is to command the fleet. The bottleneck
+      moved from your editor to your focus. Two things we optimize for, above all.
+    </p>
+    <div class="problem-grid">
+      <div class="problem-card reveal reveal-delay-1">
+        <div class="problem-icon problem-icon-orange">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        </div>
+        <h3>Your speed &mdash; as one person</h3>
+        <p>dev-3.0 optimizes a single developer: you. The unit is always the individual, never the org. Use it on a team if you like &mdash; but it&rsquo;s not for managing other people; it&rsquo;s for each person to command their own fleet at their own top speed.</p>
+      </div>
+      <div class="problem-card reveal reveal-delay-2">
+        <div class="problem-icon problem-icon-purple">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 5.8L20 10l-5.1 1.2L12 17l-1.9-5.8L5 10l5.1-1.2L12 3z"/></svg>
+        </div>
+        <h3>Beautiful, and built around you</h3>
+        <p>A cockpit you stare at all day should be fast, gorgeous, and keyboard-first &mdash; and bend to your way of working, not force one on you. Great tooling doesn&rsquo;t just make you productive; it makes the work fun again. We sweat the polish.</p>
+      </div>
+    </div>
+    <p class="section-desc reveal" style="margin-top:40px">
+      And what we refuse:
+      <strong style="color:var(--text-1)">dev-3.0 is not an IDE &mdash; and won&rsquo;t become one.</strong>
+      Code and git are the agent&rsquo;s job. Need an editor? One click to your real
+      VS Code or Cursor &mdash; the goal is to need it less. Integrations? Your agent
+      already speaks MCP to Linear, Jira and the rest. dev-3.0 is the cockpit;
+      your agent is the adapter.
+    </p>
+  </div>
+</section>
+
+<!-- WAYS TO WORK -->
+<section class="features" id="ways-to-work">
+  <div class="container">
+    <div class="section-eyebrow reveal">Ways to work</div>
+    <h2 class="section-title reveal reveal-delay-1">
+      One tool, your workflow
+    </h2>
+    <p class="section-desc reveal reveal-delay-2">
+      dev-3.0 doesn&rsquo;t impose a flow. Size your tasks and arrange your space
+      around how you actually work. A few of the ways people run it:
+    </p>
+    <div class="features-grid">
+      <div class="feature-card reveal reveal-delay-1" style="--card-accent: var(--accent);">
+        <div class="feature-icon fi-blue">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        </div>
+        <h3>Solo at full speed</h3>
+        <p>One task, one worktree; spin up many in parallel and let agents run to done. Size each task so you can verify it in ~90 seconds &mdash; if you can&rsquo;t, it&rsquo;s too big. AI review, one-click dev server and live preview make checking instant.</p>
+      </div>
+      <div class="feature-card reveal reveal-delay-2" style="--card-accent: var(--purple);">
+        <div class="feature-icon fi-purple">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </div>
+        <h3>Research swarm</h3>
+        <p>Barely writing code? Fan many tasks &mdash; each with several variants &mdash; at a question: measure, analyze, search. Then a roll-up task merges the findings, surfaces conflicts, and spawns the next round. A whole investigation, parallelized.</p>
+      </div>
+      <div class="feature-card reveal reveal-delay-3" style="--card-accent: var(--green);">
+        <div class="feature-icon fi-green">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+        </div>
+        <h3>One big feature, many small steps</h3>
+        <p>Branch off your own branch instead of main, then knock out small, isolated sub-tasks &mdash; each trivial to verify &mdash; that merge back up. The big branch assembles itself into your feature, with near-zero cognitive load per step.</p>
+      </div>
+    </div>
+    <p class="section-desc reveal" style="margin-top:32px">
+      &hellip;and more &mdash; multiple windows, multiple boards, many projects, many
+      agents per task. Arrange it however fits you.
+    </p>
+  </div>
+</section>
+
+<!-- WHICH IS FOR YOU -->
+<section class="features" id="compare">
+  <div class="container">
+    <div class="section-eyebrow reveal">Which is for you?</div>
+    <h2 class="section-title reveal reveal-delay-1">
+      We didn&rsquo;t build another editor.
+    </h2>
+    <p class="section-desc reveal reveal-delay-2">
+      Everyone else is building an editor for agents. We&rsquo;re building mission
+      control for <em>you</em>. Pick by your goal, not a feature checklist.
+    </p>
+    <div class="problem-grid">
+      <div class="problem-card reveal reveal-delay-1">
+        <h3>You want to live in the code</h3>
+        <p>Hands on the editor and git, reviewing every line yourself? An <strong style="color:var(--text-1)">agent IDE</strong> will feel like home.</p>
+      </div>
+      <div class="problem-card reveal reveal-delay-2">
+        <h3>You&rsquo;re buying for a team</h3>
+        <p>Need SSO, seats, audit logs and a managed platform? A <strong style="color:var(--text-1)">team orchestrator</strong> fits better.</p>
+      </div>
+      <div class="problem-card reveal reveal-delay-3">
+        <h3>You&rsquo;re a One Person Studio</h3>
+        <p>AI writes the code; your job is running the fleet at full speed without drowning. <strong style="color:var(--text-1)">That&rsquo;s dev-3.0.</strong></p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- GET STARTED -->
 <section class="terminal-demo" id="get-started">
   <div class="container" style="text-align:center">
@@ -2160,7 +2270,7 @@ footer {
   <div class="container">
     <div class="cta-card reveal">
       <div class="cta-glow"></div>
-      <h2>Ready to tame the chaos?</h2>
+      <h2>Ready to take command?</h2>
       <p>dev-3.0 is free and open source. Star the repo, build from source, start shipping.</p>
       <div class="hero-actions">
         <a href="https://github.com/h0x91b/dev-3.0" class="btn btn-primary" target="_blank" rel="noopener">


### PR DESCRIPTION
Hey, Claude here — the AI assistant working on this branch.

Repositions the README and landing page (`docs/index.html`) from a feature-list framing into the product's actual positioning: **dev-3.0 is mission control for the One Person Studio — deliberately not an IDE.**

### What changed
- **Hero** (landing + README): new headline "Mission control for the One Person Studio", new subtitle, and a "your projects, your boards, your agents — your flow" descriptor.
- **New sections**: Philosophy (individual speed + beauty/ergonomics + the "not an IDE" stance), Ways to work (solo speed-run / research swarm / big-feature sub-tasking), and "Which is for you?" (goal-based framing vs agent IDEs and team orchestrators).
- **Meta/OG/Twitter** tags, a `Why` nav link, and CTA refreshed to "Ready to take command?".
- Adds `decisions/080-positioning-not-an-ide.md` and a changelog entry.

Background: came out of a 3-way competitive analysis (vs orca and superset). Docs-only change — `bun run lint` and `bun run test` are green, and all new landing sections were verified rendering in a headless browser.