### PR TITLE
fix: auto-allowlist dev3 socket for Claude Code & Codex sandboxes (#726)

### DIFF
--- a/change-logs/2026/06/25/fix-claude-codex-sandbox-socket.md
+++ b/change-logs/2026/06/25/fix-claude-codex-sandbox-socket.md
@@ -1,0 +1,3 @@
+Fixed the dev3 CLI falsely reporting "app not running" inside sandboxed agents. dev3 now auto-allowlists the sockets directory in Claude Code's sandbox (~/.claude/settings.json sandbox.network.allowUnixSockets), migrates Codex's config to the new [permissions.*.network.unix_sockets] map form that codex >= 0.119 actually reads (the old allow_unix_sockets array was silently ignored), and the CLI now explains a blocked connection points at the sandbox instead of a stopped app.
+
+Suggested by @banuni (h0x91b/dev-3.0#726)

--- a/decisions/081-sandbox-unix-socket-allowlist.md
+++ b/decisions/081-sandbox-unix-socket-allowlist.md
@@ -1,0 +1,49 @@
+# 081 — Sandbox unix-socket allowlist for Claude Code + Codex map-form migration
+
+## Context
+
+Sandboxed agents (Claude Code seatbelt, Codex) block the `connect()` to the app's
+Unix socket (`~/.dev3.0/sockets/<pid>.sock`). The CLI then falls back to cached reads
+and falsely reports `app not running` (issue #726, the Claude Code counterpart of the
+Codex fix in #100). Two gaps: (1) dev3 had no auto-config for Claude Code, and (2) dev3's
+Codex auto-config still wrote the legacy `allow_unix_sockets = [...]` array, which codex
+≥ 0.119 silently ignores.
+
+## Investigation
+
+Verified against codex source (`codex-rs/config/src/permissions_toml.rs`,
+`network-proxy/src/config.rs`) at codex-cli 0.141.0: PR openai/codex#15120 replaced the
+`allow_unix_sockets` array with a `[permissions.<profile>.network.unix_sockets]` map
+(path → `"allow"|"deny"`). `NetworkToml` has no `serde(deny_unknown_fields)`, so the old
+array key is dropped silently → allowlist empty → socket blocked. Confirmed a generated
+config round-trips through `js-toml` into the expected `{ path: "allow" }` map.
+
+## Decision
+
+1. **Claude Code** — `applyClaudeSettings()` / `ensureClaudeSettings()` in
+   `src/bun/agent-skills.ts` patch `~/.claude/settings.json` on startup, adding the dev3
+   CLI permission and the sockets **directory** to `sandbox.network.allowUnixSockets`.
+2. **Codex** — `src/bun/codex-config.ts` gains a `CODEX_UNIX_SOCKETS_MAP_VERSION` (0.119)
+   syntax threshold; for codex ≥ 0.119 it emits the `unix_sockets` map and migrates away
+   any stale `allow_unix_sockets` array (preserving its entries as `"allow"`).
+3. **CLI message** — `exitAppNotRunning()` (connect stage) now says the app is likely
+   running but the sandbox is blocking the socket, prints the socket path, and gives the
+   fix; `socket-client.ts` treats EPERM/EACCES as a deterministic block (fail fast).
+
+Always the sockets **directory**, never a `*.sock` glob: each entry compiles to a seatbelt
+`(subpath ...)` rule (literal prefix, no `*` expansion), so the dir covers the PID-named
+socket across restarts.
+
+## Risks
+
+- The seatbelt profile is compiled at `claude` startup, so a new `allowUnixSockets` entry
+  needs a fully fresh Claude Code launch (resume/`--continue` does not rebuild it).
+- Codex version detection drives the array-vs-map choice; unknown version defaults to the
+  legacy array (consistent with the other version-gated syntax features).
+
+## Alternatives considered
+
+- `dangerously_allow_all_unix_sockets` (codex) / no allowlist — rejected, too broad.
+- A `*.sock` glob in `allowUnixSockets` — rejected, seatbelt `subpath` does not expand `*`.
+- Changing the CLI exit code for the connect case — rejected; the exit code is a contract,
+  only the human-facing message changed.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	applyClaudeSettings,
 	getBugHunterSkillContent,
 	getClaudeSkillContent,
 	getCodexSkillContent,
@@ -234,5 +235,63 @@ describe("dev3 Bug Hunter skill content", () => {
 		expect(skill).toContain(
 			"I could not reproduce this bug, so I did not attempt a fix. Please verify it manually; the issue may be invalid.",
 		);
+	});
+});
+
+describe("applyClaudeSettings (Claude Code sandbox socket allowlist, issue #726)", () => {
+	const SOCKETS = "/Users/testuser/.dev3.0/sockets";
+
+	it("adds the dev3 CLI permission and the sockets dir to a fresh settings object", () => {
+		const settings: Record<string, unknown> = {};
+		const changed = applyClaudeSettings(settings, SOCKETS);
+
+		expect(changed).toBe(true);
+		const permissions = settings.permissions as { allow: string[] };
+		expect(permissions.allow).toContain("Bash(~/.dev3.0/bin/dev3 *)");
+		const sandbox = settings.sandbox as { network: { allowUnixSockets: string[] } };
+		expect(sandbox.network.allowUnixSockets).toEqual([SOCKETS]);
+	});
+
+	it("allow-lists the sockets DIRECTORY, not a *.sock glob", () => {
+		const settings: Record<string, unknown> = {};
+		applyClaudeSettings(settings, SOCKETS);
+		const sandbox = settings.sandbox as { network: { allowUnixSockets: string[] } };
+		expect(sandbox.network.allowUnixSockets[0]).toBe(SOCKETS);
+		expect(sandbox.network.allowUnixSockets[0]).not.toContain("*");
+	});
+
+	it("is a no-op (returns false) when both entries are already present", () => {
+		const settings: Record<string, unknown> = {
+			permissions: { allow: ["Bash(~/.dev3.0/bin/dev3 *)"] },
+			sandbox: { network: { allowUnixSockets: [SOCKETS] } },
+		};
+		expect(applyClaudeSettings(settings, SOCKETS)).toBe(false);
+	});
+
+	it("preserves unrelated settings and existing allow/socket entries", () => {
+		const settings: Record<string, unknown> = {
+			model: "claude-opus-4-8",
+			permissions: { allow: ["Bash(ls *)"], deny: ["Bash(rm *)"] },
+			sandbox: { network: { allowUnixSockets: ["/tmp/other.sock"] } },
+		};
+		const changed = applyClaudeSettings(settings, SOCKETS);
+
+		expect(changed).toBe(true);
+		expect(settings.model).toBe("claude-opus-4-8");
+		const permissions = settings.permissions as { allow: string[]; deny: string[] };
+		expect(permissions.allow).toEqual(["Bash(ls *)", "Bash(~/.dev3.0/bin/dev3 *)"]);
+		expect(permissions.deny).toEqual(["Bash(rm *)"]);
+		const sandbox = settings.sandbox as { network: { allowUnixSockets: string[] } };
+		expect(sandbox.network.allowUnixSockets).toEqual(["/tmp/other.sock", SOCKETS]);
+	});
+
+	it("does not duplicate the socket when only the permission is missing", () => {
+		const settings: Record<string, unknown> = {
+			sandbox: { network: { allowUnixSockets: [SOCKETS] } },
+		};
+		const changed = applyClaudeSettings(settings, SOCKETS);
+		expect(changed).toBe(true); // permission was added
+		const sandbox = settings.sandbox as { network: { allowUnixSockets: string[] } };
+		expect(sandbox.network.allowUnixSockets).toEqual([SOCKETS]);
 	});
 });

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -114,17 +114,26 @@ describe("ensureCodexConfig", () => {
 				filesystemRootKey: ":project_roots",
 				hooksFeatureKey: "codex_hooks",
 				profileV2: false,
+				unixSocketsAsMap: true,
 			});
 			expect(getCodexSyntaxForVersion("codex-cli 0.130.0")).toEqual({
 				filesystemRootKey: ":project_roots",
 				hooksFeatureKey: "hooks",
 				profileV2: false,
+				unixSocketsAsMap: true,
 			});
 			expect(getCodexSyntaxForVersion("codex-cli 0.131.0")).toEqual({
 				filesystemRootKey: ":workspace_roots",
 				hooksFeatureKey: "hooks",
 				profileV2: true,
+				unixSocketsAsMap: true,
 			});
+		});
+
+		it("switches the unix-socket allowlist to map form at codex 0.119", () => {
+			expect(getCodexSyntaxForVersion("codex-cli 0.118.9").unixSocketsAsMap).toBe(false);
+			expect(getCodexSyntaxForVersion("codex-cli 0.119.0").unixSocketsAsMap).toBe(true);
+			expect(getCodexSyntaxForVersion(null).unixSocketsAsMap).toBe(false);
 		});
 
 		it("uses workspace_roots and hooks for Codex 0.131+", () => {
@@ -592,5 +601,84 @@ sandbox_mode = "workspace-write"
 			expect(result).toContain('web_search = "live"');
 			expect(result).not.toContain('web_search = "disabled"');
 		});
+	});
+});
+
+describe("ensureCodexConfig unix-socket allowlist (codex >= 0.119 map form)", () => {
+	const WORKTREES_PATH = "/Users/testuser/.dev3.0/worktrees";
+	const SOCKETS_PATH = "/Users/testuser/.dev3.0/sockets";
+	const NEW = { codexVersion: "0.141.0" };
+	const count = (hay: string, needle: string) => hay.split(needle).length - 1;
+
+	it("writes the unix_sockets map (not the legacy array) on a fresh config", () => {
+		const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		expect(result).toContain("[permissions.dev3.network]");
+		expect(result).toContain("enabled = true");
+		expect(result).toContain("[permissions.dev3.network.unix_sockets]");
+		expect(result).toContain(`"${SOCKETS_PATH}" = "allow"`);
+		expect(result).not.toContain("allow_unix_sockets");
+	});
+
+	it("keeps the legacy array form when the codex version is below 0.119", () => {
+		const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [], { codexVersion: "0.118.0" });
+		expect(result).toContain(`allow_unix_sockets = ["${SOCKETS_PATH}"]`);
+		expect(result).not.toContain("[permissions.dev3.network.unix_sockets]");
+	});
+
+	it("defaults to the legacy array form when the codex version is unknown", () => {
+		const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH);
+		expect(result).toContain(`allow_unix_sockets = ["${SOCKETS_PATH}"]`);
+		expect(result).not.toContain("[permissions.dev3.network.unix_sockets]");
+	});
+
+	it("migrates a stale legacy array to the map and drops the array line", () => {
+		const existing = `[permissions.dev3.filesystem]
+":minimal" = "read"
+
+[permissions.dev3.filesystem.":project_roots"]
+"." = "write"
+
+[permissions.dev3.network]
+enabled = true
+allow_unix_sockets = ["${SOCKETS_PATH}"]
+`;
+		const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		expect(result).not.toContain("allow_unix_sockets");
+		expect(result).toContain("[permissions.dev3.network.unix_sockets]");
+		expect(result).toContain(`"${SOCKETS_PATH}" = "allow"`);
+		// The network table still carries enabled = true after the array is stripped.
+		expect(result).toMatch(/\[permissions\.dev3\.network\]\nenabled = true/);
+	});
+
+	it("preserves a foreign socket from the legacy array during migration", () => {
+		const existing = `[permissions.dev3.network]
+enabled = true
+allow_unix_sockets = ["/tmp/other.sock"]
+`;
+		const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		expect(result).not.toContain("allow_unix_sockets =");
+		expect(result).toContain(`"${SOCKETS_PATH}" = "allow"`);
+		expect(result).toContain('"/tmp/other.sock" = "allow"');
+	});
+
+	it("adds the socket to an existing unix_sockets map that lacks it", () => {
+		const existing = `[permissions.dev3.network]
+enabled = true
+
+[permissions.dev3.network.unix_sockets]
+"/tmp/other.sock" = "allow"
+`;
+		const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		expect(result).toContain('"/tmp/other.sock" = "allow"');
+		expect(result).toContain(`"${SOCKETS_PATH}" = "allow"`);
+		expect(count(result, "[permissions.dev3.network.unix_sockets]")).toBe(1);
+	});
+
+	it("is idempotent — a second pass adds no duplicate map table or entry", () => {
+		const once = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		const twice = ensureCodexConfig(once, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
+		expect(count(twice, "[permissions.dev3.network.unix_sockets]")).toBe(1);
+		expect(count(twice, `"${SOCKETS_PATH}" = "allow"`)).toBe(1);
+		expect(twice).not.toContain("allow_unix_sockets");
 	});
 });

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { dirname } from "node:path";
 import { createLogger } from "./logger";
 import { ensureCodexConfigFile } from "./codex-config";
 
@@ -1107,33 +1108,76 @@ function installAgentsMd(): void {
 const CLAUDE_BASH_PERMISSION = "Bash(~/.dev3.0/bin/dev3 *)";
 
 /**
- * Ensure ~/.claude/settings.json has the dev3 CLI in permissions.allow
- * so Claude Code never prompts for approval on dev3 commands.
+ * Pure: ensure a parsed Claude Code settings object has both
+ *   1. the dev3 CLI bash command allow-listed (no approval prompt), and
+ *   2. the dev3 sockets DIRECTORY in `sandbox.network.allowUnixSockets`, so
+ *      Claude Code's macOS seatbelt sandbox lets the CLI connect to the running
+ *      app's Unix socket (`~/.dev3.0/sockets/<pid>.sock`). Without it the connect
+ *      is denied and the CLI falsely reports "app not running" (issue #726, the
+ *      Claude Code counterpart of the Codex fix in #100).
+ *
+ * Uses the sockets DIRECTORY, not a `*.sock` glob: each allowUnixSockets entry
+ * compiles to a seatbelt `(subpath ...)` rule — a literal directory-prefix match
+ * with no `*` expansion — so the directory covers the PID-named socket across app
+ * restarts while a glob would match nothing. Mutates `settings` in place and
+ * returns whether anything changed (so the caller can skip a needless write).
  */
-function ensureClaudePermission(): void {
-	const settingsPath = `${homedir()}/.claude/settings.json`;
+export function applyClaudeSettings(settings: Record<string, unknown>, socketsPath: string): boolean {
+	let changed = false;
+
+	// 1. permissions.allow — auto-approve the dev3 CLI.
+	const permissions = (settings.permissions ?? {}) as Record<string, unknown>;
+	const allow = Array.isArray(permissions.allow) ? (permissions.allow as string[]) : [];
+	if (!allow.includes(CLAUDE_BASH_PERMISSION)) {
+		allow.push(CLAUDE_BASH_PERMISSION);
+		changed = true;
+	}
+	permissions.allow = allow;
+	settings.permissions = permissions;
+
+	// 2. sandbox.network.allowUnixSockets — let the seatbelt reach the app socket.
+	const sandbox = (settings.sandbox ?? {}) as Record<string, unknown>;
+	const network = (sandbox.network ?? {}) as Record<string, unknown>;
+	const sockets = Array.isArray(network.allowUnixSockets) ? (network.allowUnixSockets as string[]) : [];
+	if (!sockets.includes(socketsPath)) {
+		sockets.push(socketsPath);
+		changed = true;
+	}
+	network.allowUnixSockets = sockets;
+	sandbox.network = network;
+	settings.sandbox = sandbox;
+
+	return changed;
+}
+
+/**
+ * Read, patch, and write ~/.claude/settings.json so the dev3 CLI is auto-approved
+ * and the dev3 socket directory is allow-listed in the Claude Code sandbox.
+ * Non-fatal on any error. Note: the seatbelt profile is compiled when `claude`
+ * starts, so a freshly-launched Claude Code session is required for a new
+ * allowUnixSockets entry to take effect (resume/--continue does not rebuild it).
+ */
+function ensureClaudeSettings(home: string): void {
+	const settingsPath = `${home}/.claude/settings.json`;
+	const socketsPath = `${home}/.dev3.0/sockets`;
 	try {
 		let settings: Record<string, unknown> = {};
 		try {
 			const raw = readFileSync(settingsPath, "utf-8");
-			settings = JSON.parse(raw);
+			settings = JSON.parse(raw) as Record<string, unknown>;
 		} catch {
 			// File doesn't exist or is invalid — start fresh
 		}
 
-		const permissions = (settings.permissions ?? {}) as Record<string, unknown>;
-		const allow = Array.isArray(permissions.allow) ? (permissions.allow as string[]) : [];
-
-		if (allow.includes(CLAUDE_BASH_PERMISSION)) {
-			return; // Already present
+		if (!applyClaudeSettings(settings, socketsPath)) {
+			return; // Already up to date
 		}
 
-		allow.push(CLAUDE_BASH_PERMISSION);
-		permissions.allow = allow;
-		settings.permissions = permissions;
-
+		mkdirSync(dirname(settingsPath), { recursive: true });
 		writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
-		log.info("Claude permission added", { pattern: CLAUDE_BASH_PERMISSION });
+		log.info("Claude settings patched (dev3 CLI permission + sandbox socket allowlist)", {
+			path: settingsPath,
+		});
 	} catch (err) {
 		log.warn("Failed to update Claude settings (non-fatal)", {
 			error: String(err),
@@ -1313,6 +1357,6 @@ export function installAgentSkills(): void {
 	cleanupLegacyGeminiSkillDuplicates(home);
 	installOpenAiMetadata(home);
 	installAgentsMd();
-	ensureClaudePermission();
+	ensureClaudeSettings(home);
 	ensureCodexConfigFile(home);
 }

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -18,7 +18,17 @@ interface CodexPermissionsProfile {
 	filesystem?: Record<string, unknown>;
 	network?: {
 		enabled?: boolean;
+		/** Legacy form (codex < 0.119): array of allowed socket paths. */
 		allow_unix_sockets?: string[];
+		/**
+		 * Current form (codex >= 0.119, PR openai/codex#15120): a sub-table mapping
+		 * each socket path to "allow" | "deny" under
+		 * `[permissions.<profile>.network.unix_sockets]`. The legacy array key is
+		 * silently ignored by codex >= 0.119 (serde drops the unknown field), so on
+		 * those versions the socket must be written as this map or it is never
+		 * allowlisted. See decision record 081.
+		 */
+		unix_sockets?: Record<string, "allow" | "deny">;
 	};
 }
 
@@ -51,17 +61,26 @@ interface CodexSyntax {
 	 * the `--profile-v2` *launch flag* was later removed (see issue #611).
 	 */
 	profileV2: boolean;
+	/**
+	 * unix-sockets-map: codex >= 0.119 reads the socket allowlist from a
+	 * `[permissions.<profile>.network.unix_sockets]` map (path -> "allow"|"deny")
+	 * instead of the legacy `allow_unix_sockets = [...]` array. The old array key
+	 * is silently ignored on those versions. See codex PR #15120 and decision 081.
+	 */
+	unixSocketsAsMap: boolean;
 }
 
 const LEGACY_CODEX_SYNTAX: CodexSyntax = {
 	filesystemRootKey: ":project_roots",
 	hooksFeatureKey: "codex_hooks",
 	profileV2: false,
+	unixSocketsAsMap: false,
 };
 
 const CODEX_HOOKS_RENAME_VERSION: CodexVersion = { major: 0, minor: 129, patch: 0 };
 const CODEX_WORKSPACE_ROOTS_RENAME_VERSION: CodexVersion = { major: 0, minor: 131, patch: 0 };
 const CODEX_PROFILE_V2_VERSION: CodexVersion = { major: 0, minor: 131, patch: 0 };
+const CODEX_UNIX_SOCKETS_MAP_VERSION: CodexVersion = { major: 0, minor: 119, patch: 0 };
 
 const MANAGED_DEV3_PROFILES = [
 	DEV3_CODEX_PROFILE,
@@ -101,6 +120,7 @@ export function getCodexSyntaxForVersion(versionText: string | null | undefined)
 			? "hooks"
 			: LEGACY_CODEX_SYNTAX.hooksFeatureKey,
 		profileV2: isVersionAtLeast(version, CODEX_PROFILE_V2_VERSION),
+		unixSocketsAsMap: isVersionAtLeast(version, CODEX_UNIX_SOCKETS_MAP_VERSION),
 	};
 }
 
@@ -239,7 +259,7 @@ export function ensureCodexConfig(
 			"",
 			`[permissions.${DEV3_CODEX_PROFILE}.network]`,
 			"enabled = true",
-			`allow_unix_sockets = ["${socketsPath}"]`,
+			...dev3NetworkSocketLines(socketsPath, syntax),
 			"",
 		].join("\n");
 		config = appendBlock(config, block);
@@ -249,31 +269,15 @@ export function ensureCodexConfig(
 		const netHeader = `[permissions.${DEV3_CODEX_PROFILE}.network]`;
 
 		if (dev3Net == null) {
-			const block = `\n${netHeader}\nenabled = true\nallow_unix_sockets = ["${socketsPath}"]\n`;
+			const block = `\n${netHeader}\nenabled = true\n${dev3NetworkSocketLines(socketsPath, syntax).join("\n")}\n`;
 			config = appendBlock(config, block);
 		} else {
 			if (dev3Net.enabled !== true) {
 				config = insertAfterSectionHeader(config, netHeader, "enabled = true");
 			}
-			const existingSockets = dev3Net.allow_unix_sockets ?? [];
-			if (!existingSockets.includes(socketsPath)) {
-				if (existingSockets.length === 0 && !config.includes("allow_unix_sockets")) {
-					config = insertAfterSectionHeader(config, netHeader, `allow_unix_sockets = ["${socketsPath}"]`);
-				} else {
-					// Append to existing array under dev3.network specifically
-					const pattern = new RegExp(
-						`(\\[permissions\\.${DEV3_CODEX_PROFILE}\\.network\\][^\\[]*?)allow_unix_sockets\\s*=\\s*\\[([^\\]]*)\\]`,
-						"s",
-					);
-					config = config.replace(pattern, (_match, prefix, inner) => {
-						const trimmed = inner.trim();
-						const newValue = trimmed
-							? `${trimmed}, "${socketsPath}"`
-							: `"${socketsPath}"`;
-						return `${prefix}allow_unix_sockets = [${newValue}]`;
-					});
-				}
-			}
+			config = syntax.unixSocketsAsMap
+				? ensureDev3UnixSocketsMap(config, dev3Net, socketsPath)
+				: ensureDev3UnixSocketsArray(config, dev3Net, socketsPath);
 		}
 
 		// Ensure skill directories are readable and dev3 data dir is writable
@@ -465,6 +469,92 @@ function ensureFilesystemRootAccess(
 		return appendBlock(config, `\n${header}\n"." = "write"\n`);
 	}
 	return upsertSectionLine(config, header, '"."', '"write"');
+}
+
+/**
+ * Build the socket-allowlist line(s) placed under [permissions.dev3.network] in
+ * a fresh dev3 network block. codex >= 0.119 (syntax.unixSocketsAsMap) uses a
+ * `[...network.unix_sockets]` sub-table (path -> "allow"); older codex uses the
+ * legacy `allow_unix_sockets = [...]` array. The sub-table form is returned with
+ * a leading blank line + its own header so it sits *after* the parent table's
+ * inline keys (`enabled = true`), as TOML requires.
+ */
+function dev3NetworkSocketLines(socketsPath: string, syntax: CodexSyntax): string[] {
+	if (syntax.unixSocketsAsMap) {
+		return [
+			"",
+			`[permissions.${DEV3_CODEX_PROFILE}.network.unix_sockets]`,
+			`"${socketsPath}" = "allow"`,
+		];
+	}
+	return [`allow_unix_sockets = ["${socketsPath}"]`];
+}
+
+/** Legacy (codex < 0.119): ensure the socket is in the allow_unix_sockets array. */
+function ensureDev3UnixSocketsArray(
+	config: string,
+	dev3Net: NonNullable<CodexPermissionsProfile["network"]>,
+	socketsPath: string,
+): string {
+	const netHeader = `[permissions.${DEV3_CODEX_PROFILE}.network]`;
+	const existingSockets = dev3Net.allow_unix_sockets ?? [];
+	if (existingSockets.includes(socketsPath)) return config;
+
+	if (existingSockets.length === 0 && !config.includes("allow_unix_sockets")) {
+		return insertAfterSectionHeader(config, netHeader, `allow_unix_sockets = ["${socketsPath}"]`);
+	}
+	// Append to the existing array under dev3.network specifically.
+	const pattern = new RegExp(
+		`(\\[permissions\\.${DEV3_CODEX_PROFILE}\\.network\\][^\\[]*?)allow_unix_sockets\\s*=\\s*\\[([^\\]]*)\\]`,
+		"s",
+	);
+	return config.replace(pattern, (_match, prefix, inner) => {
+		const trimmed = inner.trim();
+		const newValue = trimmed ? `${trimmed}, "${socketsPath}"` : `"${socketsPath}"`;
+		return `${prefix}allow_unix_sockets = [${newValue}]`;
+	});
+}
+
+/**
+ * Current (codex >= 0.119): ensure the socket is allow-listed in the
+ * `[permissions.dev3.network.unix_sockets]` map. Migrates any stale legacy
+ * `allow_unix_sockets = [...]` line away (codex >= 0.119 silently ignores it),
+ * preserving its entries as "allow" map entries. Idempotent.
+ */
+function ensureDev3UnixSocketsMap(
+	config: string,
+	dev3Net: NonNullable<CodexPermissionsProfile["network"]>,
+	socketsPath: string,
+): string {
+	const mapHeader = `[permissions.${DEV3_CODEX_PROFILE}.network.unix_sockets]`;
+
+	// Desired allow paths: our socket + any legacy-array entries + existing map
+	// "allow" entries. Existing "deny" entries are left untouched in the file.
+	const desired = new Set<string>([socketsPath]);
+	for (const p of dev3Net.allow_unix_sockets ?? []) desired.add(p);
+	for (const [p, perm] of Object.entries(dev3Net.unix_sockets ?? {})) {
+		if (perm === "allow") desired.add(p);
+	}
+
+	// Drop the legacy array line — codex >= 0.119 no longer reads it.
+	config = stripDev3LegacyAllowUnixSockets(config);
+
+	// Upsert each desired path into the map sub-table (creates the table if absent).
+	for (const p of desired) {
+		config = upsertSectionLine(config, mapHeader, `"${p}"`, '"allow"');
+	}
+	return config;
+}
+
+/** Remove an `allow_unix_sockets = [...]` line from inside [permissions.dev3.network]. */
+function stripDev3LegacyAllowUnixSockets(config: string): string {
+	const netHeader = `[permissions.${DEV3_CODEX_PROFILE}.network]`;
+	const escapedHeader = netHeader.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const sectionPattern = new RegExp(`(${escapedHeader}\\n)([\\s\\S]*?)(?=\\n\\[|$)`);
+	return config.replace(sectionPattern, (_m, header: string, body: string) => {
+		const cleaned = body.replace(/^[ \t]*allow_unix_sockets[ \t]*=[ \t]*\[[^\]]*\][ \t]*\r?\n?/m, "");
+		return `${header}${cleaned}`;
+	});
 }
 
 /**

--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -162,6 +162,27 @@ describe("exitAppNotRunning", () => {
 		expect(stderrOutput).toContain("HOME: /tmp");
 		expect(stderrOutput).toContain("sockets: none present");
 	});
+
+	it("on a connect-stage failure, blames the sandbox instead of 'start the app' (issue #726)", () => {
+		expect(() =>
+			exitAppNotRunning({ stage: "connect", socketPath: "/Users/me/.dev3.0/sockets/123.sock" }),
+		).toThrow(`EXIT_${CLI_EXIT_CODE_APP_NOT_RUNNING}`);
+		// Different headline than the truly-down case, and points at the sandbox.
+		expect(stderrOutput).toContain("cannot reach the dev3.0 app");
+		expect(stderrOutput).toContain("sandbox");
+		expect(stderrOutput).toContain("allowUnixSockets");
+		// Prints the socket path that was attempted.
+		expect(stderrOutput).toContain("/Users/me/.dev3.0/sockets/123.sock");
+		// Not the misleading "must be running / start the app" wording.
+		expect(stderrOutput).not.toContain("Start the app and try again");
+		expect(exitSpy).toHaveBeenCalledWith(CLI_EXIT_CODE_APP_NOT_RUNNING);
+	});
+
+	it("stays terse on a connect-stage failure without DEV3_DEBUG diagnostics", () => {
+		expect(() => exitAppNotRunning({ stage: "connect", socketPath: "/x/y.sock" })).toThrow();
+		expect(stderrOutput).not.toContain("DEV3_DEBUG");
+		expect(stderrOutput).not.toContain("stage:");
+	});
 });
 
 describe("exitUsage", () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -141,7 +141,7 @@ async function main(): Promise<void> {
 		socketPath = await resolveSocketPathWithRetry();
 	}
 	if (!socketPath) {
-		exitAppNotRunning(debugAppNotRunning("discovery"));
+		exitAppNotRunning({ stage: "discovery", ...debugAppNotRunning("discovery") });
 	}
 
 	try {
@@ -181,7 +181,7 @@ async function main(): Promise<void> {
 	} catch (err) {
 		if (err instanceof Error && err.message === "APP_NOT_RUNNING") {
 			const connectCode = (err as Error & { connectCode?: string }).connectCode;
-			exitAppNotRunning(debugAppNotRunning("connect", connectCode));
+			exitAppNotRunning({ stage: "connect", socketPath, ...debugAppNotRunning("connect", connectCode) });
 		}
 		throw err;
 	}
@@ -195,11 +195,14 @@ async function main(): Promise<void> {
 function debugAppNotRunning(
 	stage: "discovery" | "connect",
 	connectCode?: string,
-): { stage?: "discovery" | "connect"; diagnostics?: string } {
+): { diagnostics?: string } {
 	if (process.env.DEV3_DEBUG !== "1" && process.env.DEV3_DEBUG !== "true") return {};
+	// The human-readable stage line is added by exitAppNotRunning; here we only
+	// attach the raw socket diagnostics + last connect errno.
+	void stage;
 	const parts = [socketDiagnostics()];
 	if (connectCode) parts.push(`  last connect errno: ${connectCode}`);
-	return { stage, diagnostics: parts.join("\n") };
+	return { diagnostics: parts.join("\n") };
 }
 
 main().catch((err) => {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -44,24 +44,47 @@ export function exitError(message: string, detail?: string, code = CLI_EXIT_CODE
 	process.exit(code);
 }
 
-export function exitAppNotRunning(opts: { stage?: "discovery" | "connect"; diagnostics?: string } = {}): never {
-	let detail = "The dev3.0 desktop app must be running to use the CLI.\nStart the app and try again.";
+export function exitAppNotRunning(
+	opts: { stage?: "discovery" | "connect"; diagnostics?: string; socketPath?: string } = {},
+): never {
+	let message: string;
+	let detail: string;
+
+	if (opts.stage === "connect") {
+		// A socket file was found but the live connection failed. The app is
+		// almost certainly running — the usual cause is the calling agent's
+		// sandbox (Claude Code seatbelt / Codex) blocking the Unix-socket connect,
+		// not the app being down (issue #726). Say so instead of "start the app".
+		message = "cannot reach the dev3.0 app";
+		const where = opts.socketPath ? ` (${opts.socketPath})` : "";
+		detail =
+			`A dev3.0 socket was found${where}, but the live connection was refused or blocked.\n` +
+			"The app is likely running; your agent's sandbox may be blocking the Unix socket.\n" +
+			"  • Claude Code: add the dev3 sockets dir to sandbox.network.allowUnixSockets in\n" +
+			"    ~/.claude/settings.json, then fully restart Claude Code (resume does not reapply it).\n" +
+			"  • Codex (>= 0.119): under [permissions.<profile>.network.unix_sockets] set the\n" +
+			'    dev3 sockets dir = "allow".\n' +
+			"dev3 patches both automatically on app startup — restarting the desktop app re-applies them.";
+	} else {
+		message = "app not running";
+		detail = "The dev3.0 desktop app must be running to use the CLI.\nStart the app and try again.";
+	}
 
 	// Under DEV3_DEBUG, append why resolution failed so bug reports are
 	// actionable: "no live socket" (discovery — often a wrong HOME) vs "socket
-	// found but connection refused" (connect — busy app / transient backlog).
-	if (opts.diagnostics || opts.stage) {
+	// found but connection refused/blocked" (connect — busy app / sandbox denial).
+	if (opts.diagnostics) {
 		detail += "\n\n[DEV3_DEBUG] app-not-running diagnostics:";
 		if (opts.stage) {
 			detail +=
 				opts.stage === "discovery"
 					? "\n  stage: discovery — no live socket found in the sockets dir"
-					: "\n  stage: connect — a socket was found but the connection was refused";
+					: "\n  stage: connect — a socket was found but the connection was refused/blocked";
 		}
-		if (opts.diagnostics) detail += `\n${opts.diagnostics}`;
+		detail += `\n${opts.diagnostics}`;
 	}
 
-	exitError("app not running", detail, CLI_EXIT_CODE_APP_NOT_RUNNING);
+	exitError(message, detail, CLI_EXIT_CODE_APP_NOT_RUNNING);
 }
 
 export function exitUsage(message: string): never {

--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -13,6 +13,12 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // few times with short backoff before concluding the app is actually down —
 // otherwise a single hiccup is misreported as "app not running" (issue #714).
 const TRANSIENT_CONNECT_CODES = new Set(["ECONNREFUSED", "ENOENT", "EAGAIN"]);
+// A sandbox (Claude Code seatbelt / Codex) that denies the Unix-socket connect
+// surfaces as EPERM/EACCES. Unlike a busy-backlog ECONNREFUSED, this is
+// deterministic — retrying never clears it (issue #726) — so we fail fast and
+// route to the same "can't reach the app" path with the errno attached, rather
+// than spinning through the retry budget or bubbling a raw EPERM.
+const BLOCKED_CONNECT_CODES = new Set(["EPERM", "EACCES"]);
 const DEFAULT_CONNECT_ATTEMPTS = 4;
 const CONNECT_RETRY_BASE_MS = 75;
 
@@ -21,6 +27,14 @@ class TransientConnectError extends Error {
 	constructor(readonly code: string) {
 		super(`Transient connect failure: ${code}`);
 		this.name = "TransientConnectError";
+	}
+}
+
+/** Connect was deterministically denied (sandbox) — retrying is pointless. */
+class BlockedConnectError extends Error {
+	constructor(readonly code: string) {
+		super(`Blocked connect: ${code}`);
+		this.name = "BlockedConnectError";
 	}
 }
 
@@ -62,6 +76,8 @@ function sendOnce(socketPath: string, req: CliRequest, timeoutMs: number): Promi
 			const code = (err as NodeJS.ErrnoException).code;
 			if (code && TRANSIENT_CONNECT_CODES.has(code)) {
 				reject(new TransientConnectError(code));
+			} else if (code && BLOCKED_CONNECT_CODES.has(code)) {
+				reject(new BlockedConnectError(code));
 			} else {
 				reject(err);
 			}
@@ -94,6 +110,14 @@ export async function sendRequest(
 		try {
 			return await sendOnce(socketPath, req, timeoutMs);
 		} catch (err) {
+			// A deterministic sandbox denial never clears on retry — surface it
+			// immediately as APP_NOT_RUNNING (connect stage) with the errno so the
+			// CLI prints the sandbox-aware message instead of bubbling a raw EPERM.
+			if (err instanceof BlockedConnectError) {
+				const blocked = new Error("APP_NOT_RUNNING") as Error & { connectCode?: string };
+				blocked.connectCode = err.code;
+				throw blocked;
+			}
 			// Only connection-level hiccups are retried. A real response (even an
 			// error one), a timeout, or a malformed payload propagates immediately.
 			if (!(err instanceof TransientConnectError)) throw err;


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

Fixes the dev3 CLI falsely reporting `app not running` inside sandboxed agents, where the seatbelt sandbox blocks the `connect()` to `~/.dev3.0/sockets/<pid>.sock` (cached reads still work, so it looks "read-only").

- **Claude Code**: auto-patch `~/.claude/settings.json` to add the sockets directory to `sandbox.network.allowUnixSockets` — the missing counterpart of the Codex fix in #100.
- **Codex**: emit the `[permissions.*.network.unix_sockets]` map for codex ≥ 0.119 and migrate away the legacy `allow_unix_sockets` array that current codex silently ignores (verified against codex-cli 0.141.0 / PR openai/codex#15120).
- **CLI message**: a blocked live connection now points at the sandbox and prints the socket path instead of "start the app"; `EPERM`/`EACCES` is treated as a deterministic block and fails fast.

Always allowlists the sockets **directory** (seatbelt `subpath`, no glob), which covers the PID-named socket across restarts. Note: the seatbelt profile is compiled at `claude` startup, so a fully fresh Claude Code launch is needed for it to take effect. See decision record `081`.

Closes #726
