### PR TITLE
fix: cancel deferred configureTmux timer on session destroy (flaky pty-server test)

### DIFF
--- a/change-logs/2026/06/25/fix-pty-configure-timer-leak.md
+++ b/change-logs/2026/06/25/fix-pty-configure-timer-leak.md
@@ -1,0 +1,1 @@
+Fixed a flaky pty-server test by cancelling the deferred post-spawn configureTmux timer when a session is destroyed. Previously the 200ms setTimeout fired even for torn-down sessions, leaking a default-socket tmux source-file spawn that could bleed into a later test and pick the wrong socket. Hardened the related tests to match the source-file call for their own socket.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -826,22 +826,49 @@ describe("pty-server", () => {
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {}, "conf-socket");
 			mockSpawn.mockClear();
 
+			// Match the source-file call for THIS session's socket specifically.
+			// A generic `includes("source-file")` would also match a stale
+			// configureTmux timer leaked from a prior test (default "dev3"
+			// socket), which made this assertion flaky on slow CI runners.
+			const findSourceCall = (socket: string) =>
+				mockSpawn.mock.calls.find(
+					(c) => Array.isArray(c[0]) && c[0].includes("source-file") && c[0].includes(socket),
+				);
+
 			await vi.advanceTimersByTimeAsync(200);
 			await vi.waitFor(() => {
-				const call = mockSpawn.mock.calls.find(
-					(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
-				);
-				expect(call).toBeDefined();
+				expect(findSourceCall("conf-socket")).toBeDefined();
 			});
 
 			// configureTmux now uses async `spawn` rather than `spawnSync`.
-			const sourceCall = mockSpawn.mock.calls.find(
-				(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
-			);
+			const sourceCall = findSourceCall("conf-socket");
 			expect(sourceCall).toBeDefined();
 			expect(sourceCall![0]).toContain("-L");
 			expect(sourceCall![0]).toContain("conf-socket");
 			expect(sourceCall![0]).toContain(TMUX_CONF_PATH);
+
+			vi.useRealTimers();
+		});
+
+		it("does not configure tmux when the session is destroyed before the timeout", async () => {
+			vi.useFakeTimers();
+
+			const id = track("task-conf-destroy");
+			createSession(id, "proj-1", "/tmp/cwd", "bash", {}, "destroy-sock");
+			mockSpawn.mockClear();
+
+			// Tear the session down before the deferred 200ms configureTmux fires.
+			// The pending timer must be cancelled — otherwise it fires later and
+			// sources tmux config for a dead session (and, in the test suite,
+			// leaks a stray source-file spawn into whatever test runs next).
+			destroySession(id);
+
+			await vi.advanceTimersByTimeAsync(400);
+
+			const sourceCall = mockSpawn.mock.calls.find(
+				(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
+			);
+			expect(sourceCall).toBeUndefined();
 
 			vi.useRealTimers();
 		});
@@ -878,19 +905,19 @@ describe("pty-server", () => {
 			createSession(id, "proj-1", "/tmp/cwd", "bash", {});
 			mockSpawn.mockClear();
 
+			const findDefaultSourceCall = () =>
+				mockSpawn.mock.calls.find(
+					(c) => Array.isArray(c[0]) && c[0].includes("source-file") && c[0].includes("dev3"),
+				);
+
 			await vi.advanceTimersByTimeAsync(200);
 			await vi.waitFor(() => {
-				const call = mockSpawn.mock.calls.find(
-					(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
-				);
-				expect(call).toBeDefined();
+				expect(findDefaultSourceCall()).toBeDefined();
 			});
 
-			const sourceCall = mockSpawn.mock.calls.find(
-				(c) => Array.isArray(c[0]) && c[0].includes("source-file"),
-			);
-			expect(sourceCall).toBeDefined();
 			// Should use the default "dev3" socket
+			const sourceCall = findDefaultSourceCall();
+			expect(sourceCall).toBeDefined();
 			expect(sourceCall![0]).toContain("dev3");
 
 			vi.useRealTimers();

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -236,6 +236,10 @@ interface PtySession {
 	pendingData: string;
 	/** Timer handle for the batch flush interval. */
 	batchTimer: ReturnType<typeof setTimeout> | null;
+	/** Timer handle for the deferred post-spawn configureTmux() call.
+	 *  Cleared on destroy so a torn-down session never sources its tmux
+	 *  config 200ms later (also prevents stale spawns leaking across tests). */
+	configureTimer: ReturnType<typeof setTimeout> | null;
 	/** Partial OSC 52 clipboard sequence buffered across PTY chunks. */
 	osc52Buffer: string;
 	/** Size last applied to the shared PTY (min across all clients). Used to
@@ -308,6 +312,7 @@ export function createSession(
 		decoder: new TextDecoder("utf-8", { fatal: false }),
 		pendingData: "",
 		batchTimer: null,
+		configureTimer: null,
 		osc52Buffer: "",
 	};
 	sessions.set(taskId, session);
@@ -337,6 +342,10 @@ export function destroySession(taskId: string, fallbackSocket?: string): void {
 		if (session.batchTimer) {
 			clearTimeout(session.batchTimer);
 			session.batchTimer = null;
+		}
+		if (session.configureTimer) {
+			clearTimeout(session.configureTimer);
+			session.configureTimer = null;
 		}
 		session.pendingData = "";
 		if (session.proc) {
@@ -982,7 +991,9 @@ function spawnPty(session: PtySession, cols: number, rows: number): void {
 	// new-session above. The set-environment loop below stays as a safety
 	// net for the `-A` (attach to existing session) path, where `-e` is
 	// ignored by tmux.
-	setTimeout(() => {
+	if (session.configureTimer) clearTimeout(session.configureTimer);
+	session.configureTimer = setTimeout(() => {
+		session.configureTimer = null;
 		(async () => {
 			try {
 				await configureTmux(tmuxSessionName, session.tmuxSocket);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

Fixes the flaky `pty-server` test `configureTmux via spawnPty › sources tmux config after timeout when socket is provided`, which failed intermittently on slow CI runners with `expected [ 'tmux', '-L', 'dev3', ... ] to include 'conf-socket'`.

**Root cause** — not a fake-timer race, but a leaked *real* timer across tests. `createSession` → `spawnPty` schedules `setTimeout(() => configureTmux(...), 200)`, but the handle was never stored, so `destroySession()` could not cancel it. Tests that use real timers tear the session down in `afterEach` before the 200ms fires; the stale timer then fires *during a later test*, calling `spawn('source-file')` with that session's socket (usually the default `dev3`). `vi.clearAllMocks()` resets `mock.calls` per test but not pending OS timers, so the leaked spawn lands in the current test's `mock.calls`, and `.find(c => includes('source-file'))` returned the wrong call.

**Fix**
- Store the deferred `configureTmux` timer on the session (`configureTimer`) and `clearTimeout` it in `destroySession`. A torn-down session no longer sources its tmux config 200ms later — a genuine correctness fix that also removes the cross-test leak at the source.
- Make the affected tests match the `source-file` call for *their own* socket instead of the first one found.
- Add a deterministic regression test: destroy the session before the timeout → no `source-file` spawn.

Verified the regression test fails without the production fix, then passes with it. `bun run lint` clean; full suite green (mainview 1636, bun 1548).
