### PR TITLE
fix(pty): stop logging bogus 'PTY cwd missing' for valid directories

### DIFF
--- a/change-logs/2026/06/27/fix-pty-cwd-false-error.md
+++ b/change-logs/2026/06/27/fix-pty-cwd-false-error.md
@@ -1,0 +1,1 @@
+Fixed a bogus "PTY cwd missing" error that was logged for every valid terminal directory: the existence probe now uses fs.access instead of Bun.file().exists(), which always returns false for directories.

--- a/decisions/081-pty-cwd-exists-fs-access.md
+++ b/decisions/081-pty-cwd-exists-fs-access.md
@@ -1,0 +1,44 @@
+# 081 — PTY cwd existence check must use fs.access, not Bun.file().exists()
+
+## Context
+
+Production logs showed `ERROR [pty] PTY cwd missing` many times a day for cwds
+that demonstrably existed (e.g. the project terminal's `cwd = project.path`).
+The check never blocked spawning, so terminals worked anyway — it was pure
+diagnostic noise polluting the ERROR log and masking any genuine missing-cwd
+race.
+
+## Investigation
+
+A PTY's `session.cwd` is always a DIRECTORY (worktree / project path / ops
+`.../work`). The check used `Bun.file(session.cwd).exists()`. Verified at runtime:
+
+```
+Bun.file(existing DIR).exists()  => false   // Bun.file has file semantics
+Bun.file(existing FILE).exists() => true
+fs.access(existing DIR)          => ok
+```
+
+So the check returned `false` for every valid directory, logging a bogus
+"missing" each spawn — and it couldn't distinguish a real missing cwd either.
+
+## Decision
+
+Extracted an exported `cwdExists(cwd)` helper in `src/bun/pty-server.ts` that
+uses `fs.access` (from `node:fs/promises`), which resolves directories
+correctly. `spawnPty` now calls it. Still best-effort and non-blocking — only
+the existence probe changed. Covered by `cwdExists` tests in
+`src/bun/__tests__/pty-server.test.ts`.
+
+## Risks
+
+Minimal. `fs.access` with no mode arg checks F_OK (existence) — same intent as
+before, now correct for dirs. Spawn behaviour is unchanged; only the log fires
+accurately. Genuinely missing cwds are still logged.
+
+## Alternatives considered
+
+- `stat(cwd).isDirectory()` — stricter (rejects a file cwd) but the probe only
+  needs reachability, and `access` is cheaper. Rejected as over-specific.
+- Keeping `Bun.file().exists()` and suppressing the log — hides real races too.
+  Rejected.

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -28,9 +28,13 @@ vi.mock("../spawn", () => ({
 // ---- Imports ----
 
 import { existsSync } from "node:fs";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { spawn, spawnSync } from "../spawn";
 import {
 	tmuxArgs,
+	cwdExists,
 	createSession,
 	destroySession,
 	hasSession,
@@ -1159,6 +1163,37 @@ describe("pty-server", () => {
 			expect(
 				smallestClientSize([{ cols: 0, rows: 0 }, { cols: 80, rows: 24 }]),
 			).toEqual({ cols: 80, rows: 24 });
+		});
+	});
+
+	// ------- cwdExists -------
+
+	describe("cwdExists", () => {
+		// Regression: a PTY cwd is always a DIRECTORY, and the old check used
+		// `Bun.file(cwd).exists()`, which returns false for directories — so every
+		// valid worktree/project dir produced a bogus "PTY cwd missing" error.
+		it("returns true for an existing directory", async () => {
+			const dir = await mkdtemp(join(tmpdir(), "dev3-cwd-"));
+			try {
+				expect(await cwdExists(dir)).toBe(true);
+			} finally {
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns true for an existing file", async () => {
+			const dir = await mkdtemp(join(tmpdir(), "dev3-cwd-"));
+			const file = join(dir, "f.txt");
+			await writeFile(file, "x");
+			try {
+				expect(await cwdExists(file)).toBe(true);
+			} finally {
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns false for a path that does not exist", async () => {
+			expect(await cwdExists(join(tmpdir(), "dev3-cwd-nope-zzzzzzzz"))).toBe(false);
 		});
 	});
 });

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { access } from "node:fs/promises";
 import type { TmuxLayout, TmuxWindowInfo, TmuxPaneInfo } from "../shared/types";
 import { createLogger } from "./logger";
 import { spawn } from "./spawn";
@@ -855,6 +856,22 @@ async function setupTiledLayout(session: PtySession): Promise<void> {
 	}
 }
 
+/**
+ * True when `cwd` exists and is reachable. A PTY's cwd is always a DIRECTORY
+ * (worktree / project path / ops work dir). Do NOT use `Bun.file(cwd).exists()`
+ * here: Bun.file has file semantics and returns `false` for directories, so it
+ * reported a bogus "PTY cwd missing" for every valid dir. `fs.access` resolves
+ * directories correctly. See decisions/081-pty-cwd-exists-fs-access.md.
+ */
+export async function cwdExists(cwd: string): Promise<boolean> {
+	try {
+		await access(cwd);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function spawnPty(session: PtySession, cols: number, rows: number): void {
 	const tmuxSessionName = session.tmuxSessionName;
 	const tmuxCmd = session.tmuxCommand || getUserShell();
@@ -862,7 +879,7 @@ function spawnPty(session: PtySession, cols: number, rows: number): void {
 	// cwd existence is checked asynchronously (best-effort log) — if cwd is
 	// missing, the child fork will fail and `proc.exited` will fire with a
 	// non-zero exit, triggering onPtyDiedCallback. We do NOT block here.
-	Bun.file(session.cwd).exists().then((exists) => {
+	cwdExists(session.cwd).then((exists) => {
 		if (!exists) {
 			log.error("PTY cwd missing", { taskId: shortId(session.taskId), cwd: session.cwd });
 		}


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

The PTY existence check used `Bun.file(session.cwd).exists()` to verify a terminal's working directory. But a PTY's cwd is always a **directory** (worktree / project path / ops work dir), and `Bun.file().exists()` has *file* semantics — it returns `false` for every directory. So `ERROR [pty] PTY cwd missing` was logged on every spawn for valid dirs, flooding the ERROR log and masking any genuine missing-cwd race. The check never blocked spawning, so terminals worked anyway — it was pure diagnostic noise.

Fix: extract an exported `cwdExists(cwd)` helper in `src/bun/pty-server.ts` that uses `fs.access` (from `node:fs/promises`), which resolves directories correctly. `spawnPty` now calls it. Still best-effort and non-blocking — only the existence probe changed; genuinely missing cwds are still logged.

Found while investigating a UI "stuck on loading" incident; this is the one clean, self-contained fix from that investigation.

- `src/bun/pty-server.ts` — `cwdExists()` helper + use it in `spawnPty`
- `src/bun/__tests__/pty-server.test.ts` — 3 regression tests (existing dir, existing file, nonexistent path)
- `decisions/081-pty-cwd-exists-fs-access.md` — rationale
- `change-logs/2026/06/27/fix-pty-cwd-false-error.md`