### PR TITLE
Fix tipsDisabled lost on restart; unify drifted GlobalSettings type

### DIFF
--- a/change-logs/2026/06/27/fix-tips-disabled-persist.md
+++ b/change-logs/2026/06/27/fix-tips-disabled-persist.md
@@ -1,0 +1,1 @@
+Fixed the "Disable feature tips" setting being silently lost on app restart (and then erased from settings.json on the next settings change). loadSettings now reads tipsDisabled, and the drifted duplicate GlobalSettings interface in src/bun/settings.ts was removed in favor of the single shared type, with a round-trip test guarding against the same class of dropped-field bug.

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -12,7 +12,7 @@ vi.mock("../paths", () => ({
 	DEV3_HOME: TEST_HOME,
 }));
 
-import { saveSettings, loadSettings, type GlobalSettings } from "../settings";
+import { saveSettings, loadSettings, loadSettingsSync, type GlobalSettings } from "../settings";
 
 function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
 	return {
@@ -65,6 +65,80 @@ describe("saveSettings", () => {
 		// Explicit true normalizes back to undefined (the default-on representation).
 		writeFileSync(settingsPath, JSON.stringify(makeSettings({ importShellEnv: true }), null, 2), "utf-8");
 		expect((await loadSettings()).importShellEnv).toBeUndefined();
+	});
+
+	it("reads tipsDisabled back from disk (async + sync)", async () => {
+		// User toggled "Disable feature tips" → the flag lives in settings.json.
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ tipsDisabled: true }), null, 2), "utf-8");
+		expect((await loadSettings()).tipsDisabled).toBe(true);
+		expect(loadSettingsSync().tipsDisabled).toBe(true);
+	});
+
+	it("does not erase tipsDisabled on the next settings save", async () => {
+		// Reproduces the erase-on-next-save path: load the flag, persist the full
+		// object back (as the renderer does on ANY setting change), reload.
+		vi.spyOn(Bun, "write").mockImplementation(async (target, data) => {
+			writeFileSync(String(target), String(data), "utf-8");
+			return 0;
+		});
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ tipsDisabled: true }), null, 2), "utf-8");
+
+		const loaded = await loadSettings();
+		await saveSettings(loaded);
+
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8")).tipsDisabled).toBe(true);
+		expect((await loadSettings()).tipsDisabled).toBe(true);
+	});
+
+	it("upgrade-safe: an older settings.json without tipsDisabled loads with the flag absent", async () => {
+		writeFileSync(settingsPath, JSON.stringify(makeSettings(), null, 2), "utf-8");
+		expect((await loadSettings()).tipsDisabled).toBeUndefined();
+	});
+
+	it("preserves every GlobalSettings field across a save→load round-trip (drift guard + downgrade safety)", async () => {
+		// `Required<>` forces this object to enumerate EVERY field of the shared
+		// GlobalSettings type. Adding a field to the type without handling it in
+		// loadSettings breaks compilation here (missing key) or this test at
+		// runtime (dropped value) — so the tipsDisabled class of bug cannot recur.
+		// Values are chosen so each one survives loadSettings normalization as-is.
+		vi.spyOn(Bun, "write").mockImplementation(async (target, data) => {
+			writeFileSync(String(target), String(data), "utf-8");
+			return 0;
+		});
+		const full: Required<GlobalSettings> = {
+			defaultAgentId: "builtin-codex",
+			defaultConfigId: "codex-default",
+			taskDropPosition: "bottom",
+			updateChannel: "canary",
+			theme: "light",
+			resolvedTheme: "light",
+			cloneBaseDirectory: "/tmp/clones",
+			customBinaryPaths: { git: "/usr/bin/git" },
+			agentBinaryPaths: { "builtin-codex": "/usr/bin/codex" },
+			terminalKeymap: "iterm2",
+			playSoundOnTaskComplete: false,
+			externalApps: [{ id: "x", name: "X", macAppName: "X" }],
+			tipsDisabled: true,
+			taskOpenMode: "fullscreen",
+			defaultDiffViewMode: "unified",
+			preventSleepWhileRunning: true,
+			skipQuitDialog: true,
+			importShellEnv: false,
+			focusMode: true,
+		};
+
+		await saveSettings(full);
+
+		// Downgrade safety: the file is a plain JSON superset of all pre-existing keys.
+		const onDisk = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		for (const key of Object.keys(full) as (keyof GlobalSettings)[]) {
+			expect(onDisk[key], `field "${key}" was not written to disk`).toEqual(full[key]);
+		}
+
+		const loaded = await loadSettings();
+		for (const key of Object.keys(full) as (keyof GlobalSettings)[]) {
+			expect(loaded[key], `field "${key}" was dropped by loadSettings`).toEqual(full[key]);
+		}
 	});
 
 	it("creates the settings directory before writing the file", async () => {

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
-import type { ExternalApp } from "../shared/types";
+import type { GlobalSettings } from "../shared/types";
 import { withFileLock } from "./file-lock";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
@@ -8,37 +8,12 @@ const log = createLogger("settings");
 
 const SETTINGS_FILE = `${DEV3_HOME}/settings.json`;
 
-export interface GlobalSettings {
-	defaultAgentId: string;
-	defaultConfigId: string;
-	taskDropPosition: "top" | "bottom";
-	updateChannel: "stable" | "canary";
-	theme?: "dark" | "light" | "system";
-	resolvedTheme?: "dark" | "light";
-	cloneBaseDirectory?: string;
-	customBinaryPaths?: Record<string, string>;
-	agentBinaryPaths?: Record<string, string>;
-	playSoundOnTaskComplete?: boolean;
-	externalApps?: ExternalApp[];
-	terminalKeymap?: "default" | "iterm2";
-	taskOpenMode?: "split" | "fullscreen";
-	defaultDiffViewMode?: "split" | "unified" | "auto";
-	preventSleepWhileRunning?: boolean;
-	skipQuitDialog?: boolean;
-	/**
-	 * Inherit the user's full exported login-shell environment into agent/MCP
-	 * sessions (so env-based MCP servers, SDK keys, etc. set in `.zshrc`/`.bashrc`
-	 * work). Default on; set to `false` to fall back to importing only the typed
-	 * vars (PATH/LANG/...) for an isolated environment.
-	 */
-	importShellEnv?: boolean;
-	/**
-	 * Focus mode: when true, agent-initiated attention UI (`dev3 notify` toasts /
-	 * native notifications and `dev3 attention` badges) is suppressed. For users
-	 * who find the pings distracting.
-	 */
-	focusMode?: boolean;
-}
+// `GlobalSettings` has a single source of truth in `src/shared/types.ts` (it is
+// the RPC schema type shared with the renderer). Re-export it here so this
+// module's consumers can keep importing it from "./settings", but never define
+// a second copy — a drifted local interface is what silently dropped
+// `tipsDisabled` on load and then erased it from disk on the next save.
+export type { GlobalSettings };
 
 const DEFAULT_SETTINGS: GlobalSettings = {
 	defaultAgentId: "builtin-claude",
@@ -67,6 +42,7 @@ export async function loadSettings(): Promise<GlobalSettings> {
 			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
 			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
 			terminalKeymap: data.terminalKeymap === "iterm2" ? "iterm2" : undefined,
+			tipsDisabled: data.tipsDisabled === true ? true : undefined,
 			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
 			defaultDiffViewMode:
 				data.defaultDiffViewMode === "unified"
@@ -117,6 +93,7 @@ export function loadSettingsSync(): GlobalSettings {
 			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
 			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
 			terminalKeymap: data.terminalKeymap === "iterm2" ? "iterm2" : undefined,
+			tipsDisabled: data.tipsDisabled === true ? true : undefined,
 			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
 			defaultDiffViewMode:
 				data.defaultDiffViewMode === "unified"

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -431,6 +431,13 @@ export interface GlobalSettings {
 	defaultDiffViewMode?: "split" | "unified" | "auto"; // default inline diff layout; "auto" picks based on screen size
 	preventSleepWhileRunning?: boolean; // spawn caffeinate when agents are active
 	skipQuitDialog?: boolean; // suppress the "tmux keeps running" quit confirmation
+	/**
+	 * Inherit the user's full exported login-shell environment into agent/MCP
+	 * sessions (so env-based MCP servers, SDK keys, etc. set in `.zshrc`/`.bashrc`
+	 * work). Default on; set to `false` to fall back to importing only the typed
+	 * vars (PATH/LANG/...) for an isolated environment.
+	 */
+	importShellEnv?: boolean;
 	focusMode?: boolean; // when true, suppress agent-initiated attention UI (dev3 notify/attention)
 }
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

The **"Disable feature tips"** setting was silently lost on app restart, and then erased from `settings.json` on the next settings change.

Root cause: `GlobalSettings` had **two drifted definitions** — the shared RPC type in `src/shared/types.ts` and a duplicate local interface in `src/bun/settings.ts`. TypeScript never caught the drift because the RPC boundary only requires structural compatibility of the few *required* fields; extra/missing *optional* fields assign silently. As a result `tipsDisabled` existed in the shared type but not the bun copy, while `importShellEnv` existed only in the bun copy.

`loadSettings`/`loadSettingsSync` rebuild the object field-by-field from an allow-list, so they never read `data.tipsDisabled` — dropping it on load, after which the renderer persisted the full (flag-less) object on any change and erased it from disk.

## Changes

- Read `tipsDisabled` in both `loadSettings` and `loadSettingsSync`.
- Remove the duplicate, drifted `GlobalSettings` interface in `src/bun/settings.ts`; it now imports + re-exports the single shared type.
- Add the bun-only `importShellEnv` field to the shared `GlobalSettings` so it is a true superset.
- Add a `Required<GlobalSettings>` save→load round-trip test that fails (at compile **or** runtime) if any shared field is dropped on load — closing the whole class of bug.

## Backward compatibility

Additive and downgrade-safe: `settings.json` stays a plain JSON superset, the file path is unchanged, and older versions keep ignoring unknown keys. Tests explicitly cover both upgrade (old file without the flag) and downgrade (every field round-trips intact) safety.

Lint clean; full test suite green (mainview 1636, bun 1570).