### PR TITLE
fix(kanban): render tasks with a dangling customColumnId instead of dropping them

### DIFF
--- a/change-logs/2026/06/28/fix-dangling-custom-column-vanish.md
+++ b/change-logs/2026/06/28/fix-dangling-custom-column-vanish.md
@@ -1,0 +1,1 @@
+Fixed tasks silently vanishing from the Kanban board when their customColumnId pointed to a deleted custom column. The board now falls back to rendering such a task in its underlying status column, and the data layer self-heals the dangling id to null on the next task mutation (in-place, fully backward-compatible).

--- a/decisions/083-dangling-custom-column-fallback.md
+++ b/decisions/083-dangling-custom-column-fallback.md
@@ -1,0 +1,48 @@
+# 083 — Dangling customColumnId: render fallback + load-time self-heal
+
+## Context
+
+A task whose `customColumnId` pointed to a custom column that no longer exists
+rendered in **no** column and silently disappeared from the Kanban board while
+still living in `tasks.json`. Dangling state is reachable two ways: the
+`deleteCustomColumn` snapshot race (a concurrent `moveTaskToCustomColumn` stamps
+the id after the cleanup snapshot), and multi-instance writes (the shared
+`~/.dev3.0/` is edited by another app version / the CLI with a stale project).
+
+## Decision
+
+Two defensive layers:
+
+1. **Render fallback (mandatory).** `KanbanBoard.tsx` now classifies a task as
+   "in a custom column" only if that column still exists
+   (`isInCustomColumn`). A dangling task falls into `tasksByStatus` and renders
+   in its underlying status column. `aiReviewHasItems` uses the same predicate
+   so a dangling review-by-ai task can't be hidden by the AI-review toggle.
+2. **Load-time self-heal.** `rawLoadTasks` (`src/bun/data.ts`) clears a dangling
+   `customColumnId` to `null` — an in-place content rewrite mirroring the legacy
+   `say` cleanup migration. It persists **only on mutator reads**
+   (`persistMigrations`, which run under the file lock and bypass the cache), so
+   pure reads never cache a transformed value. Guarded on
+   `Array.isArray(project.customColumns)` so a partial project object can't wipe
+   valid assignments.
+
+## Risks
+
+- The multi-instance race can't be fully eliminated; the render fallback is the
+  permanent safety net, so this is acceptable. Worst residual case (a column
+  re-added by another instance with an identical id while a heal is cached) only
+  misplaces a task into its status column — never hides it — and self-corrects.
+- `customColumnId` stays `string | null` with unchanged meaning. `null` is the
+  value old versions already produce via the `rawLoadTasks` backfill, so files
+  written by the fixed version stay loadable after a downgrade.
+
+## Alternatives considered
+
+- **Lock the whole `deleteCustomColumn` operation** to close the race at the
+  source — rejected as insufficient on its own (doesn't touch the multi-instance
+  path) and unnecessary once the two layers make dangling state benign.
+- **Heal on every read (incl. pure reads) + cache the healed value** — rejected:
+  it caches a value derived from a *separate* entity (`project.customColumns`)
+  that can change without the tasks file changing, introducing a (benign but
+  avoidable) stale-cache window. Gating the heal behind `persistMigrations`
+  sidesteps it entirely.

--- a/src/bun/__tests__/data-dangling-custom-column.test.ts
+++ b/src/bun/__tests__/data-dangling-custom-column.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { CustomColumn, Project, Task } from "../../shared/types";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test-dangling-col",
+}));
+
+vi.mock("../file-lock", () => ({
+	withFileLock: async <T>(_filePath: string, fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+beforeEach(() => {
+	rmSync("/tmp/dev3-test-dangling-col", { recursive: true, force: true });
+	mkdirSync("/tmp/dev3-test-dangling-col", { recursive: true });
+});
+
+import { loadTasks, updateTask } from "../data";
+
+const colX: CustomColumn = { id: "col-x", name: "Alpha", color: "#ff0000", llmInstruction: "" };
+
+const testProject: Project = {
+	id: "proj-1",
+	name: "Test",
+	path: "/tmp/test-project",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-01T00:00:00Z",
+	customColumns: [colX],
+};
+
+function tasksFilePath(): string {
+	return "/tmp/dev3-test-dangling-col/data/tmp-test-project/tasks.json";
+}
+
+function seedTasks(tasks: unknown[]): void {
+	mkdirSync(dirname(tasksFilePath()), { recursive: true });
+	writeFileSync(tasksFilePath(), JSON.stringify(tasks));
+}
+
+function readSavedTasks(): Task[] {
+	return JSON.parse(readFileSync(tasksFilePath(), "utf8"));
+}
+
+function makeRawTask(overrides: Partial<Task> & { id: string }): Record<string, unknown> {
+	return {
+		seq: 1,
+		projectId: "proj-1",
+		title: "Task",
+		description: "desc",
+		status: "todo",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2025-01-01T00:00:00Z",
+		updatedAt: "2025-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("loadTasks — dangling customColumnId self-heal", () => {
+	it("clears a dangling customColumnId to null on a mutator read and persists it", async () => {
+		seedTasks([
+			makeRawTask({ id: "dangling", seq: 1, customColumnId: "col-gone" }),
+			makeRawTask({ id: "valid", seq: 2, customColumnId: "col-x" }),
+		]);
+
+		// updateTask reads with persistMigrations (under the file lock), heals all
+		// dangling ids, then writes the full array back.
+		await updateTask(testProject, "dangling", { title: "renamed" });
+
+		const saved = readSavedTasks();
+		const dangling = saved.find((t) => t.id === "dangling")!;
+		const valid = saved.find((t) => t.id === "valid")!;
+		expect(dangling.customColumnId).toBeNull();
+		// A valid assignment is untouched.
+		expect(valid.customColumnId).toBe("col-x");
+	});
+
+	it("treats every assignment as dangling when the project has no custom columns", async () => {
+		seedTasks([makeRawTask({ id: "orphan", seq: 1, customColumnId: "col-x" })]);
+
+		await updateTask({ ...testProject, customColumns: [] }, "orphan", { title: "renamed" });
+
+		expect(readSavedTasks().find((t) => t.id === "orphan")!.customColumnId).toBeNull();
+	});
+
+	// --- Backward compatibility (definition of done) ---
+
+	it("(compat a) loads a tasks.json with a dangling id without error and renders via the task list", async () => {
+		// As written by a current/older version: the column id is still present on disk.
+		seedTasks([makeRawTask({ id: "dangling", seq: 1, customColumnId: "col-gone" })]);
+
+		// A pure read must not throw and must return the task. It does NOT rewrite
+		// disk (only mutator reads heal) — the renderer falls back to the status
+		// column, so the task is never lost.
+		const before = statSync(tasksFilePath()).mtimeMs;
+		const loaded = await loadTasks(testProject);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].id).toBe("dangling");
+		expect(statSync(tasksFilePath()).mtimeMs).toBe(before);
+	});
+
+	it("(compat b) a tasks.json written after the heal adds no new fields beyond the existing Task shape", async () => {
+		seedTasks([
+			makeRawTask({ id: "dangling", seq: 1, customColumnId: "col-gone" }),
+			makeRawTask({ id: "valid", seq: 2, customColumnId: "col-x" }),
+		]);
+
+		await updateTask(testProject, "valid", { title: "renamed" });
+
+		const saved = readSavedTasks();
+		const healed = saved.find((t) => t.id === "dangling")!;
+		const untouched = saved.find((t) => t.id === "valid")!;
+
+		// The heal only flips an existing field's VALUE to null (a value older
+		// versions already tolerate via the backfill) — it must not introduce any
+		// new key. Both tasks pass through identical backfills, so a field added
+		// only on the healed task would surface as a key-set difference.
+		expect(Object.keys(healed).sort()).toEqual(Object.keys(untouched).sort());
+		expect(healed.customColumnId).toBeNull();
+		// No bespoke heal-marker field leaked into the schema.
+		expect(healed).not.toHaveProperty("customColumnIdHealed");
+		expect(healed).not.toHaveProperty("danglingCustomColumnId");
+	});
+});

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -646,6 +646,32 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 			}
 		}
 
+		// Heal dangling customColumnId — the task references a custom column that
+		// no longer exists in this project. Reachable via the deleteCustomColumn
+		// snapshot race, or a multi-instance / CLI write that stamped a column id
+		// this instance never had. Clearing it to null (the documented "no custom
+		// column" value, already produced by the backfill above) is a content-only
+		// in-place rewrite — same shape as the legacy `say` cleanup migration — that
+		// keeps the file fully loadable by older app versions. We only persist on
+		// mutator reads (persistMigrations), which run under the file lock and skip
+		// the cache, so pure reads never transform cached values; the renderer falls
+		// back defensively regardless. Guarded on a real customColumns array so a
+		// partially-built project object can never wipe valid assignments.
+		if (options?.persistMigrations && Array.isArray(project.customColumns)) {
+			const validCustomColumnIds = new Set(project.customColumns.map((c) => c.id));
+			let danglingCount = 0;
+			for (const t of tasks) {
+				if (t.customColumnId != null && !validCustomColumnIds.has(t.customColumnId)) {
+					t.customColumnId = null;
+					danglingCount++;
+				}
+			}
+			if (danglingCount > 0) {
+				log.info("Cleared dangling customColumnId on tasks", { projectId: project.id, count: danglingCount });
+				await rawSaveTasks(project, tasks);
+			}
+		}
+
 		log.info(`Loaded ${tasks.length} task(s)`, { projectId: project.id });
 		if (useCache && preReadStat) {
 			tasksCache.set(file, { ...preReadStat, value: tasks.map((t) => ({ ...t })) });

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -279,6 +279,12 @@ function KanbanBoard({
 	const projectLabels = project.labels ?? [];
 	const customColumns: CustomColumn[] = project.customColumns ?? [];
 	const customStatusLabels = project.customStatusLabels ?? {};
+	const customColumnIds = new Set(customColumns.map((c) => c.id));
+	// A task belongs to a custom column only if that column still exists. A
+	// dangling customColumnId (its column was deleted, or a multi-instance write
+	// referenced a column this instance never had) falls back to the task's
+	// underlying status column so the task can never silently vanish from the board.
+	const isInCustomColumn = (task: Task) => !!task.customColumnId && customColumnIds.has(task.customColumnId);
 
 	async function handleRenameBuiltinColumn(status: TaskStatus, name: string | null) {
 		try {
@@ -298,13 +304,14 @@ function KanbanBoard({
 		displayTasks = displayTasks.filter((t) => matchesSearchQuery(t, searchQuery, { prNumber: taskPrMap.get(t.id)?.number }));
 	}
 
-	// Built-in column tasks (exclude tasks in custom columns)
+	// Built-in column tasks (exclude tasks in an existing custom column; tasks
+	// with a dangling customColumnId fall back here into their status column).
 	const tasksByStatus = new Map<TaskStatus, Task[]>();
 	for (const status of ALL_STATUSES) {
 		tasksByStatus.set(status, []);
 	}
 	for (const task of displayTasks) {
-		if (!task.customColumnId) {
+		if (!isInCustomColumn(task)) {
 			tasksByStatus.get(task.status)?.push(task);
 		}
 	}
@@ -323,7 +330,7 @@ function KanbanBoard({
 		const peerReviewEnabled = project.peerReviewEnabled !== false;
 		// Show AI Review column by default (on when builtinColumnAgents is unset or has review-by-ai config)
 		const aiReviewEnabled = project.builtinColumnAgents === undefined || !!project.builtinColumnAgents?.["review-by-ai"];
-		const aiReviewHasItems = tasks.some((t) => t.status === "review-by-ai" && !t.customColumnId);
+		const aiReviewHasItems = tasks.some((t) => t.status === "review-by-ai" && !isInCustomColumn(t));
 		// Virtual ("Operations") boards have no diff/PR, so all review columns are
 		// hidden — the flow is todo → in-progress → user-questions → done.
 		const isVirtual = project.kind === "virtual";
@@ -427,8 +434,8 @@ function KanbanBoard({
 		tasksByCustomColumn.set(col.id, []);
 	}
 	for (const task of displayTasks) {
-		if (task.customColumnId) {
-			tasksByCustomColumn.get(task.customColumnId)?.push(task);
+		if (isInCustomColumn(task)) {
+			tasksByCustomColumn.get(task.customColumnId!)?.push(task);
 		}
 	}
 

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -2,7 +2,7 @@ import { act, render, screen, fireEvent, waitFor } from "@testing-library/react"
 import KanbanBoard from "../KanbanBoard";
 import { I18nProvider } from "../../i18n";
 import { api } from "../../rpc";
-import type { CustomColumn, Project, TipState } from "../../../shared/types";
+import type { CustomColumn, Project, Task, TipState } from "../../../shared/types";
 
 vi.mock("../../rpc", () => ({
 	api: {
@@ -39,6 +39,31 @@ const project: Project = {
 
 const customColA: CustomColumn = { id: "col-a", name: "Alpha", color: "#ff0000", llmInstruction: "" };
 const customColB: CustomColumn = { id: "col-b", name: "Beta", color: "#00ff00", llmInstruction: "" };
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "p1",
+		title: "Test Task",
+		description: "Test Task",
+		status: "in-progress",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2025-01-01T00:00:00Z",
+		updatedAt: "2025-01-01T00:00:00Z",
+		customColumnId: null,
+		labelIds: [],
+		notes: [],
+		history: [],
+		...overrides,
+	};
+}
 
 function makeDt(data: Record<string, string> = {}): DataTransfer {
 	return {
@@ -408,5 +433,74 @@ describe("collapsible columns", () => {
 			// Collapsed columns should not contain TipCard content
 			expect(col.querySelector("[class*='tip']")).toBeNull();
 		}
+	});
+});
+
+describe("dangling customColumnId render fallback", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.clear();
+	});
+
+	// Returns the header label of the column that currently renders the given task,
+	// or null if the task is not rendered in any column. Scoped to the card's own
+	// column so it never trips over duplicate label text elsewhere on the board.
+	function columnLabelOf(taskId: string): string | null {
+		const card = document.querySelector(`[data-task-id="${taskId}"]`);
+		const col = card?.closest("[class*='glass-column']");
+		return col?.querySelector(".text-fg.text-sm.font-semibold")?.textContent ?? null;
+	}
+
+	it("renders a task whose customColumnId points to a deleted column in its underlying status column", async () => {
+		// "col-deleted" is NOT in project.customColumns — simulates a column that
+		// was deleted (or a multi-instance write referencing a column this instance
+		// never had). The task must NOT vanish from the board.
+		const danglingTask = makeTask({
+			id: "task-dangling",
+			status: "in-progress",
+			customColumnId: "col-deleted",
+		});
+		await renderBoardWith({
+			project: { ...project, customColumns: [customColA] },
+			tasks: [danglingTask],
+		});
+		// Invariant: every non-deleted task renders in SOME column.
+		expect(document.querySelector('[data-task-id="task-dangling"]')).not.toBeNull();
+		// Specifically, in its underlying status column ("Agent is Working").
+		expect(columnLabelOf("task-dangling")).toBe("Agent is Working");
+	});
+
+	it("keeps the AI Review column visible for a dangling-custom-column task in review-by-ai", async () => {
+		// AI review disabled + no other review-by-ai items: the column is normally
+		// hidden. A dangling-custom-column task in review-by-ai must still surface.
+		const danglingReview = makeTask({
+			id: "task-dangling-review",
+			status: "review-by-ai",
+			customColumnId: "col-deleted",
+		});
+		await renderBoardWith({
+			project: {
+				...project,
+				customColumns: [customColA],
+				builtinColumnAgents: {},
+			},
+			tasks: [danglingReview],
+		});
+		expect(document.querySelector('[data-task-id="task-dangling-review"]')).not.toBeNull();
+	});
+
+	it("still renders a task with a valid customColumnId in its custom column", async () => {
+		// Regression guard: the fallback must not pull a valid custom-column task
+		// into its status column.
+		const validTask = makeTask({
+			id: "task-valid",
+			status: "in-progress",
+			customColumnId: "col-a",
+		});
+		await renderBoardWith({
+			project: { ...project, customColumns: [customColA] },
+			tasks: [validTask],
+		});
+		expect(columnLabelOf("task-valid")).toBe("Alpha");
 	});
 });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

A task whose `customColumnId` pointed to a deleted custom column rendered in **no** column and silently vanished from the Kanban board, while still living in `tasks.json` (the CLI still listed it). Dangling state is reachable two ways: the `deleteCustomColumn` snapshot race (a concurrent `moveTaskToCustomColumn` stamps the id after the cleanup snapshot), and multi-instance writes to the shared `~/.dev3.0/`.

Two defensive layers:

- **Render fallback (`KanbanBoard.tsx`)** — a new `isInCustomColumn()` predicate treats a task as belonging to a custom column only if that column still exists. A dangling task falls back into its underlying status column, so it can never disappear. `aiReviewHasItems` uses the same predicate so a dangling `review-by-ai` task isn't hidden by the AI-review toggle.
- **Load-time self-heal (`rawLoadTasks`)** — clears a dangling `customColumnId` to `null` in place (mirroring the legacy `say` cleanup migration). It persists **only on mutator reads** (`persistMigrations`, under the file lock, bypassing the cache), so pure reads never cache a value derived from `project.customColumns`.

## Backward compatibility

No schema change: `customColumnId` stays `string | null` with the same meaning. `null` is the value the existing backfill already produces, so files written by this version remain loadable after a **downgrade**. Explicit compat tests cover both directions (a dangling id loads & renders; a healed file adds no new fields).

See `decisions/083-dangling-custom-column-fallback.md` for the rationale and rejected alternatives.