### PR TITLE
Extend update auto-restart countdown from 5 to 15 minutes

### DIFF
--- a/change-logs/2026/06/28/fix-update-countdown-15min.md
+++ b/change-logs/2026/06/28/fix-update-countdown-15min.md
@@ -1,0 +1,1 @@
+Extended the update toast auto-restart countdown from 5 minutes to 15 minutes, giving users more time before the app restarts itself to install a downloaded update.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -50,11 +50,11 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 	const projectDropdownRef = useRef<HTMLDivElement>(null);
 	const countsCacheTimeRef = useRef<number>(0);
 
-	// Show toast with 60s countdown when updateVersion first appears
+	// Show toast with 15min countdown when updateVersion first appears
 	useEffect(() => {
 		if (updateVersion) {
 			setShowToast(true);
-			setCountdown(300);
+			setCountdown(900);
 			countdownRef.current = setInterval(() => {
 				setCountdown((prev) => {
 					if (prev <= 1) return 0;

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -484,7 +484,7 @@ describe("GlobalHeader — update countdown", () => {
 			[],
 			{ updateVersion: "1.2.3" },
 		);
-		expect(screen.getByText(/Restart to Update \(300s\)/)).toBeInTheDocument();
+		expect(screen.getByText(/Restart to Update \(900s\)/)).toBeInTheDocument();
 	});
 
 	it("decrements countdown every second", () => {
@@ -495,10 +495,10 @@ describe("GlobalHeader — update countdown", () => {
 			[],
 			{ updateVersion: "1.2.3" },
 		);
-		expect(screen.getByText(/\(300s\)/)).toBeInTheDocument();
+		expect(screen.getByText(/\(900s\)/)).toBeInTheDocument();
 
 		act(() => { vi.advanceTimersByTime(3000); });
-		expect(screen.getByText(/\(297s\)/)).toBeInTheDocument();
+		expect(screen.getByText(/\(897s\)/)).toBeInTheDocument();
 	});
 
 	it("shows Postpone button instead of Later", () => {
@@ -538,7 +538,7 @@ describe("GlobalHeader — update countdown", () => {
 			{ updateVersion: "1.2.3" },
 		);
 
-		act(() => { vi.advanceTimersByTime(300_000); });
+		act(() => { vi.advanceTimersByTime(900_000); });
 		// Flush the async handleRestart (saveUpdateRoute → applyUpdate)
 		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
 
@@ -554,7 +554,7 @@ describe("GlobalHeader — update countdown", () => {
 			{ updateVersion: "1.2.3" },
 		);
 
-		act(() => { vi.advanceTimersByTime(300_000); });
+		act(() => { vi.advanceTimersByTime(900_000); });
 
 		expect(mockedApi.request.saveUpdateRoute).toHaveBeenCalledWith({
 			route: JSON.stringify({ screen: "project", projectId: "p1" }),


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The "update ready" toast shows an auto-restart countdown before the app restarts itself to install a downloaded update. That countdown was hardcoded to 5 minutes (`300`s) in `GlobalHeader.tsx`, which is too aggressive — users could get restarted out from under their work. This bumps it to 15 minutes (`900`s).

- `setCountdown(300)` → `setCountdown(900)` in `GlobalHeader.tsx`
- Fixed a stale comment that claimed "60s countdown"
- Updated the affected `GlobalHeader.test.tsx` assertions (300/300_000 → 900/900_000)