### PR TITLE
Show PR Review and custom-column tasks as rows on the dashboard

### DIFF
--- a/change-logs/2026/06/28/fix-dashboard-show-pr-review-custom-columns.md
+++ b/change-logs/2026/06/28/fix-dashboard-show-pr-review-custom-columns.md
@@ -1,0 +1,1 @@
+The main dashboard's per-project activity now lists PR Review tasks and tasks parked in custom columns as their own rows, instead of burying them in the collapsed background summary. PR Review rows show the "PR Review" status; custom-column rows are labeled and colored by their column.

--- a/src/mainview/components/ActivityOverview.tsx
+++ b/src/mainview/components/ActivityOverview.tsx
@@ -18,11 +18,13 @@ interface ActivityOverviewProps {
 	onReorderProjects?: (projectIds: string[]) => void | Promise<void>;
 }
 
-/** Statuses that require the user's attention — shown as individual task rows. */
-const ATTENTION_STATUSES: TaskStatus[] = ["user-questions", "review-by-user"];
+/** Statuses worth their own row — they're waiting on a human (questions, your
+ * review, or an open PR review). Tasks parked in a custom column always get a
+ * row too, regardless of status (see columnOf below). */
+const ATTENTION_STATUSES: TaskStatus[] = ["user-questions", "review-by-user", "review-by-colleague"];
 
 /** Statuses that are "background work" — collapsed into a summary line. */
-const BACKGROUND_STATUSES: TaskStatus[] = ["in-progress", "review-by-ai", "review-by-colleague"];
+const BACKGROUND_STATUSES: TaskStatus[] = ["in-progress", "review-by-ai"];
 
 type DropSide = "before" | "after";
 
@@ -185,9 +187,23 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 					const showDropBefore = dropTarget?.projectId === project.id && dropTarget.side === "before";
 					const showDropAfter = dropTarget?.projectId === project.id && dropTarget.side === "after";
 
-					// Split into attention tasks (shown individually) and background tasks (summarized)
-					const attentionTasks = tasks.filter((t) => ATTENTION_STATUSES.includes(t.status));
-					const backgroundTasks = tasks.filter((t) => BACKGROUND_STATUSES.includes(t.status));
+					// A task is "in" a custom column only when its customColumnId still
+					// resolves to a live column; a dangling id (deleted column) falls back
+					// to status-based bucketing, mirroring the kanban (PR #737).
+					const customColumnById = new Map((project.customColumns ?? []).map((c) => [c.id, c] as const));
+					const columnOf = (task: Task) =>
+						task.customColumnId ? customColumnById.get(task.customColumnId) ?? null : null;
+
+					// Rows shown individually: attention statuses (questions / your review /
+					// PR review) plus any task parked in a custom column. Custom-column
+					// tasks carry the column's identity, not their underlying status, and
+					// are never collapsed into the summary line below.
+					const rowTasks = tasks.filter(
+						(task) => columnOf(task) !== null || ATTENTION_STATUSES.includes(task.status),
+					);
+					const backgroundTasks = tasks.filter(
+						(task) => columnOf(task) === null && BACKGROUND_STATUSES.includes(task.status),
+					);
 
 					// Build summary segments: "3 in-progress · 2 AI review"
 					const summarySegments: { status: TaskStatus; count: number }[] = [];
@@ -325,8 +341,12 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 
 							{hasActiveTasks && (
 								<div className="border-t border-edge">
-									{/* Attention tasks — shown individually */}
-									{attentionTasks.map((task) => (
+									{/* Attention + custom-column tasks — shown individually */}
+									{rowTasks.map((task) => {
+										const col = columnOf(task);
+										const rowColor = col ? col.color : statusColors[task.status];
+										const rowLabel = col ? col.name : getStatusLabel(task.status, t, project);
+										return (
 										<button
 											key={task.id}
 											data-hint-id={`task:${task.id}`}
@@ -335,8 +355,8 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 										>
 											<span
 												className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-												style={{ backgroundColor: statusColors[task.status] }}
-												title={getStatusLabel(task.status, t, project)}
+												style={{ backgroundColor: rowColor }}
+												title={rowLabel}
 											/>
 											<span className="text-fg-2 text-sm truncate flex-1">
 												{getTaskTitle(task)}
@@ -346,9 +366,9 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 											)}
 											<span
 												className="text-xs flex-shrink-0"
-												style={{ color: statusColors[task.status] }}
+												style={{ color: rowColor }}
 											>
-												{getStatusLabel(task.status, t, project)}
+												{rowLabel}
 											</span>
 											{task.movedAt && (
 												<span className="text-fg-muted text-xs flex-shrink-0 w-16 text-right">
@@ -356,7 +376,8 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 												</span>
 											)}
 										</button>
-									))}
+										);
+									})}
 
 									{/* Background tasks — collapsed summary line */}
 									{summarySegments.length > 0 && (

--- a/src/mainview/components/__tests__/ActivityOverview.test.tsx
+++ b/src/mainview/components/__tests__/ActivityOverview.test.tsx
@@ -206,6 +206,72 @@ describe("ActivityOverview", () => {
 		expect(ops.compareDocumentPosition(repo) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 	});
 
+	it("shows PR Review tasks as individual rows, not collapsed into the summary", async () => {
+		mockedApi.request.getAllProjectTasks.mockResolvedValue([
+			{
+				projectId: "p1",
+				tasks: [
+					{ ...mockTask, id: "pr1", title: "Ship the parser", status: "review-by-colleague" },
+				],
+			},
+		]);
+
+		renderActivityOverview();
+
+		// The task title is rendered as its own row...
+		expect(await screen.findByText("Ship the parser")).toBeInTheDocument();
+		// ...with the "PR Review" status pill, instead of being folded into the
+		// background summary line.
+		expect(screen.getByText("PR Review")).toBeInTheDocument();
+	});
+
+	it("shows custom-column tasks as rows labeled with the column name", async () => {
+		const projWithColumn: Project = {
+			...mockProject,
+			customColumns: [{ id: "col1", name: "Blocked", color: "#ff0000", llmInstruction: "" }],
+		};
+		// An in-progress task would normally be summarized; parking it in a custom
+		// column promotes it to its own row carrying the column's identity.
+		mockedApi.request.getAllProjectTasks.mockResolvedValue([
+			{
+				projectId: "p1",
+				tasks: [
+					{ ...mockTask, id: "c1", title: "Parked work", status: "in-progress", customColumnId: "col1" },
+				],
+			},
+		]);
+
+		render(
+			<I18nProvider>
+				<ActivityOverview projects={[projWithColumn]} navigate={vi.fn()} bellCounts={new Map()} />
+			</I18nProvider>,
+		);
+
+		expect(await screen.findByText("Parked work")).toBeInTheDocument();
+		// Labeled by the custom column, not its underlying "Agent is Working" status.
+		expect(screen.getByText("Blocked")).toBeInTheDocument();
+		expect(screen.queryByText("Agent is Working")).not.toBeInTheDocument();
+	});
+
+	it("ignores a dangling customColumnId and falls back to status bucketing", async () => {
+		// Column "ghost" no longer exists on the project → the task must not be
+		// treated as a custom-column row; an in-progress task stays in the summary.
+		mockedApi.request.getAllProjectTasks.mockResolvedValue([
+			{
+				projectId: "p1",
+				tasks: [
+					{ ...mockTask, id: "g1", title: "Orphan task", status: "in-progress", customColumnId: "ghost" },
+				],
+			},
+		]);
+
+		renderActivityOverview();
+
+		await screen.findByText("My Project");
+		// Background in-progress task is summarized, never shown as a titled row.
+		expect(screen.queryByText("Orphan task")).not.toBeInTheDocument();
+	});
+
 	it("opens the add project flow from the activity header", async () => {
 		const user = userEvent.setup();
 		const onOpenAddProject = vi.fn();


### PR DESCRIPTION
## Summary

The main dashboard's per-project activity overview only promoted `user-questions` and `review-by-user` tasks to individual rows. PR Review (`review-by-colleague`) and any task parked in a custom column were folded into the collapsed background summary line ("N working · M pr review"), so they were easy to miss.

This change:
- Treats **PR Review** (`review-by-colleague`) as an attention status — it now gets its own row instead of being summarized.
- Gives **custom-column tasks** their own row, labeled and colored by the column (mirroring the kanban / active-tasks sidebar), regardless of their underlying status. They are no longer collapsed into the summary.
- Keeps `in-progress` and `review-by-ai` in the collapsed summary line, so a project with many working agents doesn't blow up the dashboard.
- Falls back to status-based bucketing for a dangling `customColumnId` (deleted column), consistent with the kanban fix in #737.

Backend `getAllProjectTasks` already returns these tasks (they retain an active status), so the fix is entirely in `ActivityOverview.tsx`.

Adds tests covering the PR Review row, the custom-column row, and the dangling-columnId fallback.