### PR TITLE
Fix double complete/cancel sound in remote mode

### DIFF
--- a/change-logs/2026/06/28/fix-remote-double-completion-sound.md
+++ b/change-logs/2026/06/28/fix-remote-double-completion-sound.md
@@ -1,0 +1,1 @@
+Fixed the task complete/cancel sound playing twice in remote mode when the desktop app and a browser are both connected to the same machine. UI-initiated terminal moves now play the sound locally and tell the backend to skip its broadcast `taskSound` push, so it is heard exactly once.

--- a/decisions/084-remote-double-completion-sound.md
+++ b/decisions/084-remote-double-completion-sound.md
@@ -1,0 +1,38 @@
+# 084 — Completion sound plays once across all connected renderers
+
+## Context
+In remote mode the desktop app and a browser can both be connected to the same
+backend (and on the same physical machine, sharing speakers). Completing or
+cancelling a task played the sound twice.
+
+## Investigation
+Two sources play the sound: the UI plays it optimistically the instant a card is
+dropped (`playTaskCompletionSound` in `src/mainview/task-sounds.ts`, called from
+`moveTaskToStatus`), and the backend pushes a `taskSound` event
+(`emitTaskSound` in `src/bun/rpc-handlers/task-lifecycle.ts`). The old de-dup
+remembered the task id per renderer and swallowed the matching push — but that
+state lives in each renderer's JS heap. The backend push fans out to EVERY
+connected renderer (`broadcastToAllWindows` + `pushToBrowserClients` in
+`src/bun/index.ts`), so only the initiating renderer suppressed its echo; every
+other one had no token and played the push.
+
+## Decision
+The two playback paths are made mutually exclusive at the source. UI-initiated
+terminal moves play locally and pass `clientPlayedSound: true` on the `moveTask`
+RPC; `moveTask` then skips `emitTaskSound` entirely (no push to anyone). Non-UI
+completions (CLI, branch-merge auto-complete, agent approval) never set the flag,
+so the backend push remains the single sound. The per-renderer echo machinery
+(`expectedEchoes` / `markEchoExpected` / `isEchoExpected`) is removed.
+
+## Risks
+Non-UI completions still broadcast `taskSound` to all renderers, so a CLI /
+branch-merge / agent-approval completion can still double on one machine with two
+renderers connected. Accepted: those paths have no single initiating renderer to
+own the sound, and the reported issue was manual complete/cancel.
+
+## Alternatives considered
+- Backend nominates a single renderer (focused window, else one browser) for the
+  push: covers the non-UI paths too, but needs dedicated single-target routing in
+  the window manager and remote server — more surface area and risk.
+- Drop the optimistic local play and rely solely on a single-target backend push:
+  most unified, but sacrifices the deliberately-instant local feedback.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1967,6 +1967,29 @@ describe("handlers.moveTask", () => {
 		expect(push).not.toHaveBeenCalledWith("taskSound", expect.anything());
 	});
 
+	it("moveTask: skips the taskSound push when the client already played it (remote double-sound fix)", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
+		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
+		const push = vi.fn();
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(loadSettingsSync).mockReturnValue({ playSoundOnTaskComplete: true } as any);
+		setPushMessage(push);
+
+		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed", clientPlayedSound: true });
+
+		// The UI played the sound locally; the backend must NOT broadcast a second
+		// one (which a remote browser on the same machine would also play).
+		expect(push).not.toHaveBeenCalledWith("taskSound", expect.anything());
+		// The board still syncs via taskUpdated — only the sound push is skipped.
+		expect(push).toHaveBeenCalledWith("taskUpdated", expect.objectContaining({ projectId: project.id }));
+		expect(result.status).toBe("completed");
+	});
+
 	it("in-progress → cancelled: same cleanup as completed", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress" });

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -747,6 +747,7 @@ export async function moveTask(params: {
 	force?: boolean;
 	ifStatus?: string;
 	ifStatusNot?: string;
+	clientPlayedSound?: boolean;
 }): Promise<Task> {
 	log.info("→ moveTask", params);
 	const project = await data.getProject(params.projectId);
@@ -790,7 +791,15 @@ export async function moveTask(params: {
 	if (newStatus === "completed" || newStatus === "cancelled") {
 		cleanupTaskState(task.id);
 		portPool.releasePorts(task.id);
-		emitTaskSound(newStatus as "completed" | "cancelled", task.id);
+		// When a UI renderer initiates the move it plays the sound optimistically
+		// and sets `clientPlayedSound`, so we must NOT also push `taskSound`: that
+		// push broadcasts to every connected renderer (a desktop window AND a remote
+		// browser on the same machine), which would play a second time. CLI /
+		// branch-merge / agent-approval completions never set it, so the push is the
+		// only sound and still fires.
+		if (!params.clientPlayedSound) {
+			emitTaskSound(newStatus as "completed" | "cancelled", task.id);
+		}
 		if (params.force) {
 			log.info("Force mode: skipping PTY/cleanup/worktree", { taskId: task.id });
 		} else if (isActive(oldStatus) || task.worktreePath) {

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -828,8 +828,8 @@ function App() {
 
 	useEffect(() => {
 		function onTaskSound(e: Event) {
-			const { status, taskId } = (e as CustomEvent).detail;
-			playTaskSoundFromPush(status, taskId);
+			const { status } = (e as CustomEvent).detail;
+			playTaskSoundFromPush(status);
 		}
 		window.addEventListener("rpc:taskSound", onTaskSound);
 		return () => window.removeEventListener("rpc:taskSound", onTaskSound);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -503,7 +503,7 @@ describe("App keyboard shortcuts", () => {
 			await act(async () => {
 				window.dispatchEvent(new CustomEvent("rpc:taskSound", { detail: { status: "completed", taskId: "task-9" } }));
 			});
-			expect(playTaskSoundFromPush).toHaveBeenCalledWith("completed", "task-9");
+			expect(playTaskSoundFromPush).toHaveBeenCalledWith("completed");
 		});
 	});
 

--- a/src/mainview/__tests__/task-sounds.test.ts
+++ b/src/mainview/__tests__/task-sounds.test.ts
@@ -19,11 +19,13 @@ describe("task sound assets", () => {
 	}
 });
 
-// The UI plays the completion sound client-side the instant a card is dropped,
-// while the bun process pushes a `taskSound` echo for the SAME move a moment
-// later. The echo is suppressed precisely by task id — not by status+time — so
-// the sound is heard exactly once AND two different tasks both ring.
-describe("completion-sound echo suppression", () => {
+// The sound plays in exactly one place per move: UI-initiated moves play it
+// locally (and signal `clientPlayedSound` so the backend skips its push), while
+// non-UI completions play it from the backend push. `playTaskCompletionSound`
+// returns whether the UI owns the sound so the caller can suppress the push —
+// this is what prevents the double-play in remote mode (desktop window + browser
+// on the same machine both receiving a broadcast push).
+describe("completion sound playback", () => {
 	let playSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
@@ -37,33 +39,27 @@ describe("completion-sound echo suppression", () => {
 		playSpy.mockRestore();
 	});
 
-	it("swallows the bun echo for a task the UI already played", () => {
-		playTaskCompletionSound("completed", "task-A");
-		playTaskSoundFromPush("completed", "task-A"); // the echo
+	it("plays locally and reports the UI owns the sound when enabled", () => {
+		const played = playTaskCompletionSound("completed");
+		expect(played).toBe(true);
+		expect(playSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not play and reports false when the setting is disabled", () => {
+		setTaskCompletionSoundEnabled(false);
+		const played = playTaskCompletionSound("completed");
+		expect(played).toBe(false);
+		expect(playSpy).not.toHaveBeenCalled();
+	});
+
+	it("plays the backend push (CLI / branch-merge / agent approval)", () => {
+		playTaskSoundFromPush("completed");
 		expect(playSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("rings for two different tasks completing back-to-back", () => {
-		playTaskCompletionSound("completed", "task-1");
-		playTaskCompletionSound("completed", "task-2");
+		expect(playTaskCompletionSound("completed")).toBe(true);
+		expect(playTaskCompletionSound("cancelled")).toBe(true);
 		expect(playSpy).toHaveBeenCalledTimes(2);
-	});
-
-	it("swallows a repeated echo (force-retry can emit the push twice)", () => {
-		playTaskCompletionSound("completed", "task-R");
-		playTaskSoundFromPush("completed", "task-R");
-		playTaskSoundFromPush("completed", "task-R");
-		expect(playSpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("plays a push for a task the UI never played locally (CLI/other window)", () => {
-		playTaskSoundFromPush("completed", "remote-task");
-		expect(playSpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("does not play locally when the setting is disabled", () => {
-		setTaskCompletionSoundEnabled(false);
-		playTaskCompletionSound("completed", "task-off");
-		expect(playSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -361,6 +361,7 @@ describe("TaskCard", () => {
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "cancelled",
+				clientPlayedSound: true,
 			});
 		});
 
@@ -867,6 +868,7 @@ describe("TaskCard", () => {
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
+					clientPlayedSound: true,
 				});
 			});
 
@@ -924,12 +926,14 @@ describe("TaskCard", () => {
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "in-progress",
+				clientPlayedSound: false,
 			});
 			expect(mockedApi.request.moveTask).toHaveBeenNthCalledWith(2, {
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "in-progress",
 				force: true,
+				clientPlayedSound: false,
 			});
 			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: updated });
 			expect(onTaskMoved).toHaveBeenCalledWith("t1");

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -575,6 +575,7 @@ describe("TaskInfoPanel", () => {
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "user-questions",
+				clientPlayedSound: false,
 			});
 			expect(dispatch).toHaveBeenCalledWith({
 				type: "updateTask",
@@ -610,6 +611,7 @@ describe("TaskInfoPanel", () => {
 				projectId: "p1",
 				newStatus: "review-by-user",
 				force: true,
+				clientPlayedSound: false,
 			});
 			expect(dispatch).toHaveBeenCalledWith({
 				type: "updateTask",
@@ -1793,6 +1795,7 @@ describe("TaskInfoPanel", () => {
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
+					clientPlayedSound: true,
 				});
 			});
 		});
@@ -1820,6 +1823,7 @@ describe("TaskInfoPanel", () => {
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
+					clientPlayedSound: true,
 				});
 			});
 		});

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -243,6 +243,7 @@ describe("TaskTerminal", () => {
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "completed",
+				clientPlayedSound: true,
 			});
 		});
 	});

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -18,33 +18,19 @@ const SOUND_UNLOCK_EVENTS: Array<keyof WindowEventMap> = ["pointerdown", "keydow
 const pendingQueue: TaskSoundStatus[] = [];
 const templates = new Map<TaskSoundStatus, HTMLAudioElement>();
 
-// The UI plays the completion sound client-side the instant a card is dropped
-// onto completed/cancelled (so it feels immediate), but the bun process ALSO
-// pushes a `taskSound` event for the SAME move a moment later. To play exactly
-// once we suppress the bun echo precisely by task id (not by status+time): when
-// the UI plays locally for a task we remember its id, and any bun `taskSound`
-// push for that id is swallowed. A genuinely different task — or a completion
-// from the CLI / another window with no local play — has no token, so it plays.
-// Keyed by id rather than status so two tasks completing back-to-back both ring.
-const ECHO_TTL_MS = 10_000;
-const expectedEchoes = new Map<string, number>(); // taskId -> expiry timestamp
-
-function markEchoExpected(taskId: string): void {
-	expectedEchoes.set(taskId, Date.now() + ECHO_TTL_MS);
-}
-
-// Returns true (and keeps the token until TTL) if a bun push for this task is
-// our own echo. Kept rather than consumed so the force-retry path — which can
-// emit the push twice — is swallowed both times.
-function isEchoExpected(taskId: string): boolean {
-	const expiry = expectedEchoes.get(taskId);
-	if (expiry === undefined) return false;
-	if (Date.now() > expiry) {
-		expectedEchoes.delete(taskId);
-		return false;
-	}
-	return true;
-}
+// The completion/cancel sound is played in exactly one place per move:
+//
+//  - UI-initiated moves (drag, card menu, info panel, terminal toolbar) play it
+//    locally and instantly via `playTaskCompletionSound`, then tell the backend
+//    (`clientPlayedSound` on the moveTask RPC) to skip its `taskSound` push.
+//    The push would otherwise fan out to EVERY connected renderer — a desktop
+//    window AND a remote browser on the same machine — and play a second time.
+//  - Non-UI completions (CLI, branch-merge auto-complete, agent approval) have no
+//    renderer that played locally, so the backend pushes `taskSound` and
+//    `playTaskSoundFromPush` plays it.
+//
+// Because the two paths are mutually exclusive at the source, no client-side
+// echo de-dup is needed.
 
 // Client-side mirror of the `playSoundOnTaskComplete` setting, kept in sync by
 // App.tsx. The bun process also gates its `taskSound` push on the same setting;
@@ -57,21 +43,22 @@ export function setTaskCompletionSoundEnabled(enabled: boolean): void {
 
 /**
  * Play the completion/cancellation sound immediately from the UI (respecting the
- * user setting) and remember the task id so the matching bun `taskSound` push is
- * suppressed — the sound is heard exactly once.
+ * user setting). Returns true if the UI owns the sound for this move, so the
+ * caller can pass `clientPlayedSound` to the backend and suppress the redundant
+ * `taskSound` push. Returns false when the sound setting is off (the backend is
+ * gated on the same setting, so nothing plays either way).
  */
-export function playTaskCompletionSound(status: TaskSoundStatus, taskId: string): void {
-	if (!completionSoundEnabled) return;
-	markEchoExpected(taskId);
+export function playTaskCompletionSound(status: TaskSoundStatus): boolean {
+	if (!completionSoundEnabled) return false;
 	void playTaskSound(status);
+	return true;
 }
 
 /**
- * Handle a bun `taskSound` push. Swallows the echo of a move the UI already
- * played locally; plays for any other completion (CLI, background, other window).
+ * Handle a bun `taskSound` push. Only fired for completions no renderer played
+ * locally (CLI, branch-merge, agent approval), so it always plays.
  */
-export function playTaskSoundFromPush(status: TaskSoundStatus, taskId?: string): void {
-	if (taskId && isEchoExpected(taskId)) return;
+export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 	void playTaskSound(status);
 }
 

--- a/src/mainview/utils/__tests__/moveTaskToStatus.test.ts
+++ b/src/mainview/utils/__tests__/moveTaskToStatus.test.ts
@@ -15,7 +15,7 @@ vi.mock("../confirmTaskCompletion", () => ({
 	confirmTaskCompletion: vi.fn().mockResolvedValue(true),
 }));
 vi.mock("../../task-sounds", () => ({
-	playTaskCompletionSound: vi.fn(),
+	playTaskCompletionSound: vi.fn(() => true),
 }));
 
 import { moveTaskToStatus } from "../moveTaskToStatus";
@@ -43,6 +43,7 @@ describe("moveTaskToStatus", () => {
 	beforeEach(() => {
 		mockedMoveTask.mockResolvedValue({ ...task, status: "completed" } as Task);
 		mockedConfirm.mockResolvedValue(true);
+		mockedSound.mockReturnValue(true);
 	});
 	afterEach(() => vi.clearAllMocks());
 
@@ -51,12 +52,22 @@ describe("moveTaskToStatus", () => {
 		const ok = await moveTaskToStatus({ task, project, newStatus: "completed", dispatch, t });
 
 		expect(ok).toBe(true);
-		// Sound fires before the RPC resolves (instant feedback), keyed by task id.
-		expect(mockedSound).toHaveBeenCalledWith("completed", "t1");
+		// Sound fires before the RPC resolves (instant feedback).
+		expect(mockedSound).toHaveBeenCalledWith("completed");
 		// Optimistic + clearBell + server-confirmed update.
 		expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: "clearBell", taskId: "t1" }));
 		expect(dispatchedStatuses(dispatch)).toEqual(["completed", "completed"]);
-		expect(mockedMoveTask).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", newStatus: "completed" });
+		// Because the UI played the sound, the backend is told to skip its push —
+		// otherwise a second connected renderer (remote browser on the same
+		// machine) would play it again.
+		expect(mockedMoveTask).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", newStatus: "completed", clientPlayedSound: true });
+	});
+
+	it("tells the backend NOT to suppress the push when the UI did not play (sound off)", async () => {
+		mockedSound.mockReturnValue(false);
+		const dispatch = vi.fn();
+		await moveTaskToStatus({ task, project, newStatus: "completed", dispatch, t });
+		expect(mockedMoveTask).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", newStatus: "completed", clientPlayedSound: false });
 	});
 
 	it("aborts without any change when the confirmation is declined", async () => {
@@ -70,10 +81,11 @@ describe("moveTaskToStatus", () => {
 		expect(mockedMoveTask).not.toHaveBeenCalled();
 	});
 
-	it("does not play a sound for non-terminal moves", async () => {
+	it("does not play a sound for non-terminal moves and does not suppress the push", async () => {
 		const dispatch = vi.fn();
 		await moveTaskToStatus({ task, project, newStatus: "review-by-user", dispatch, t });
 		expect(mockedSound).not.toHaveBeenCalled();
+		expect(mockedMoveTask).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", newStatus: "review-by-user", clientPlayedSound: false });
 	});
 
 	it("retries with force when the normal move fails", async () => {
@@ -83,8 +95,8 @@ describe("moveTaskToStatus", () => {
 		const dispatch = vi.fn();
 		await moveTaskToStatus({ task, project, newStatus: "completed", dispatch, t });
 
-		expect(mockedMoveTask).toHaveBeenNthCalledWith(1, { taskId: "t1", projectId: "p1", newStatus: "completed" });
-		expect(mockedMoveTask).toHaveBeenNthCalledWith(2, { taskId: "t1", projectId: "p1", newStatus: "completed", force: true });
+		expect(mockedMoveTask).toHaveBeenNthCalledWith(1, { taskId: "t1", projectId: "p1", newStatus: "completed", clientPlayedSound: true });
+		expect(mockedMoveTask).toHaveBeenNthCalledWith(2, { taskId: "t1", projectId: "p1", newStatus: "completed", force: true, clientPlayedSound: true });
 		expect(mockedToastError).not.toHaveBeenCalled();
 	});
 

--- a/src/mainview/utils/moveTaskToStatus.ts
+++ b/src/mainview/utils/moveTaskToStatus.ts
@@ -95,9 +95,13 @@ export async function moveTaskToStatus({
 		}
 		: { ...task, status: newStatus, customColumnId: null };
 	dispatch({ type: "updateTask", task: optimisticTask });
+	// When the UI plays the completion sound here, tell the backend to skip its
+	// own `taskSound` push — otherwise it fans out to every other connected
+	// renderer (e.g. a remote browser on the same machine) and plays twice.
+	let clientPlayedSound = false;
 	if (terminal) {
 		dispatch({ type: "clearBell", taskId: task.id });
-		playTaskCompletionSound(newStatus as "completed" | "cancelled", task.id);
+		clientPlayedSound = playTaskCompletionSound(newStatus as "completed" | "cancelled");
 	}
 	onMoved?.();
 	trackEvent("task_moved", { from_status: fromStatus, to_status: newStatus, agent_name: agentNameFromId(task.agentId) });
@@ -107,10 +111,10 @@ export async function moveTaskToStatus({
 	try {
 		let updated: Task;
 		try {
-			updated = await api.request.moveTask({ taskId: task.id, projectId: project.id, newStatus });
+			updated = await api.request.moveTask({ taskId: task.id, projectId: project.id, newStatus, clientPlayedSound });
 		} catch {
 			// Environment is likely broken (missing worktree, etc.) — force it through.
-			updated = await api.request.moveTask({ taskId: task.id, projectId: project.id, newStatus, force: true });
+			updated = await api.request.moveTask({ taskId: task.id, projectId: project.id, newStatus, force: true, clientPlayedSound });
 		}
 		dispatch({ type: "updateTask", task: updated });
 		onSuccess?.();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -85,7 +85,7 @@ export const STATUS_COLORS_LIGHT: Record<TaskStatus, string> = {
 	cancelled: "#dc2626",
 };
 
-/** Convert "#rrggbb" → "R G B" for use as CSS variable value */
+/** Convert "#rrggbb" â "R G B" for use as CSS variable value */
 export function hexToRgb(hex: string): string {
 	const r = parseInt(hex.slice(1, 3), 16);
 	const g = parseInt(hex.slice(3, 5), 16);
@@ -141,9 +141,9 @@ For medium/high severity: fix directly and commit.
 For minor/cosmetic: leave alone. Do NOT break existing functionality.
 
 As the very last step (after any commits), you MUST hand the task back to the user by moving it yourself:
-- If you found problems, committed fixes, or have anything worth surfacing — add a short \`dev3 note add "<1–3 sentence summary>"\` and then run:
+- If you found problems, committed fixes, or have anything worth surfacing â add a short \`dev3 note add "<1â3 sentence summary>"\` and then run:
     dev3 task move --status user-questions
-- If the diff is clean and nothing needed changing — run:
+- If the diff is clean and nothing needed changing â run:
     dev3 task move --status review-by-user
 
 Do not skip this step. Move the task exactly once, at the end.`;
@@ -193,14 +193,14 @@ export const DEFAULT_AGENTS: CodingAgent[] = [
 		installCommand: "brew install claude-code",
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code",
 		configurations: [
-			// --- Opus 4.8 (current default — Fable 5 temporarily unavailable) — order: Auto, Bypass, Default, then the rest ---
+			// --- Opus 4.8 (current default â Fable 5 temporarily unavailable) â order: Auto, Bypass, Default, then the rest ---
 			{ id: "claude-auto-opus48", name: "Auto (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "auto", version: 1 },
 			{ id: "claude-bypass-opus48", name: "Bypass (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-default-opus48", name: "Default (Opus 4.8)", model: "claude-opus-4-8[1m]", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-plan-opus48", name: "Plan (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "plan", additionalArgs: ["--allow-dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-approvals-opus48", name: "Accept Edits (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "acceptEdits", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
 			{ id: "claude-dontask-opus48", name: "Don't Ask (Opus 4.8)", model: "claude-opus-4-8[1m]", permissionMode: "dontAsk", additionalArgs: ["--dangerously-skip-permissions"], version: 1 },
-			// --- Fable 5 (temporarily unavailable, kept for when it returns) — order: Auto, Bypass, Default, then the rest ---
+			// --- Fable 5 (temporarily unavailable, kept for when it returns) â order: Auto, Bypass, Default, then the rest ---
 			{ id: "claude-auto", name: "Auto (Fable 5)", model: "claude-fable-5", permissionMode: "auto", version: 6 },
 			{ id: "claude-auto-sonnet", name: "Auto (Sonnet)", model: "sonnet", permissionMode: "auto", version: 1 },
 			{ id: "claude-bypass", name: "Bypass (Fable 5)", model: "claude-fable-5", permissionMode: "bypassPermissions", additionalArgs: ["--dangerously-skip-permissions"], version: 6 },
@@ -421,8 +421,8 @@ export interface GlobalSettings {
 	theme?: "dark" | "light" | "system";
 	resolvedTheme?: "dark" | "light";
 	cloneBaseDirectory?: string;
-	customBinaryPaths?: Record<string, string>; // requirementId → custom binary path
-	agentBinaryPaths?: Record<string, string>; // agentId → resolved binary path
+	customBinaryPaths?: Record<string, string>; // requirementId â custom binary path
+	agentBinaryPaths?: Record<string, string>; // agentId â resolved binary path
 	terminalKeymap?: TerminalKeymapPreset;
 	playSoundOnTaskComplete?: boolean;
 	externalApps?: ExternalApp[]; // user-configured apps for "Open in..." menus
@@ -442,14 +442,14 @@ export interface GlobalSettings {
 	/**
 	 * Remembered state of the Watch toggle in the launch/create-variant modal.
 	 * When a task is launched, the toggle's on/off choice is persisted here and
-	 * reused as the default for the next launch. Undefined → default to unwatched.
+	 * reused as the default for the next launch. Undefined â default to unwatched.
 	 */
 	watchByDefault?: boolean;
 }
 
 export interface TipState {
-	snoozedUntil: number; // timestamp — all tips hidden until this time
-	seen: Record<string, number>; // tipId → last-seen timestamp
+	snoozedUntil: number; // timestamp â all tips hidden until this time
+	seen: Record<string, number>; // tipId â last-seen timestamp
 	rotationIndex: number;
 }
 
@@ -485,20 +485,20 @@ export interface CustomColumn {
 }
 
 // Colors ordered to maximize perceptual distance between consecutive picks
-// (each step jumps ~150° around the color wheel: warm→cool→warm→cool…)
+// (each step jumps ~150Â° around the color wheel: warmâcoolâwarmâcoolâ¦)
 export const LABEL_COLORS = [
-	"#ef4444", // red       0°
-	"#14b8a6", // teal    174°
-	"#f97316", // orange   25°
-	"#8b5cf6", // violet  258°
-	"#84cc16", // lime     80°
-	"#ec4899", // pink    322°
-	"#06b6d4", // cyan    188°
-	"#eab308", // yellow   50°
-	"#3b82f6", // blue    217°
-	"#22c55e", // green   142°
-	"#f43f5e", // rose    350°
-	"#6366f1", // indigo  239°
+	"#ef4444", // red       0Â°
+	"#14b8a6", // teal    174Â°
+	"#f97316", // orange   25Â°
+	"#8b5cf6", // violet  258Â°
+	"#84cc16", // lime     80Â°
+	"#ec4899", // pink    322Â°
+	"#06b6d4", // cyan    188Â°
+	"#eab308", // yellow   50Â°
+	"#3b82f6", // blue    217Â°
+	"#22c55e", // green   142Â°
+	"#f43f5e", // rose    350Â°
+	"#6366f1", // indigo  239Â°
 ] as const;
 
 // ---- Repo-local config (.dev3/config.json) ----
@@ -538,7 +538,7 @@ export interface Dev3RepoConfig {
 	portCount?: number;
 }
 
-/** Keys of Dev3RepoConfig — used for merge logic. */
+/** Keys of Dev3RepoConfig â used for merge logic. */
 export const DEV3_REPO_CONFIG_KEYS: (keyof Dev3RepoConfig)[] = [
 	"setupScript",
 	"setupScriptLaunchMode",
@@ -619,9 +619,9 @@ export interface Project {
 }
 
 /**
- * True for the single hardcoded "Operations" board — the special, pinned virtual
+ * True for the single hardcoded "Operations" board â the special, pinned virtual
  * project. Distinct from user-created virtual boards (which have `kind: "virtual"`
- * but `builtin` unset). Used for pin-first ordering, the ⌘0 shortcut, and the
+ * but `builtin` unset). Used for pin-first ordering, the â0 shortcut, and the
  * special `[ Operations ]` / SYSTEM identity treatment.
  */
 export function isBuiltinOpsProject(p: Pick<Project, "kind" | "builtin">): boolean {
@@ -650,7 +650,7 @@ export interface Task {
 	 * Surfaced in the hover-preview popover above the terminal snapshot so
 	 * the user can re-enter focus fast after a long break. `description` is
 	 * the raw original user request and must NOT be used as a substitute.
-	 * When `userOverview` is set, it takes precedence for display — agents
+	 * When `userOverview` is set, it takes precedence for display â agents
 	 * keep writing here freely, but the user won't see it until they revert.
 	 */
 	overview?: string | null;
@@ -667,7 +667,7 @@ export interface Task {
 	 * Task modal or inline rename). Titles set by an agent through
 	 * `dev3 task update --title` leave this flag at `false`. The user-edited
 	 * marker shown to agents and the CLI overwrite-guard both key off this
-	 * flag — NOT off `customTitle != null` — so agent-set titles can still
+	 * flag â NOT off `customTitle != null` â so agent-set titles can still
 	 * be re-rewritten by later agents while a real user-typed title is
 	 * preserved for the entire task lifetime.
 	 */
@@ -692,7 +692,7 @@ export interface Task {
 	/**
 	 * Append-only log of the task's title/overview as they changed over time.
 	 * Written automatically by the data layer whenever the *effective*
-	 * (displayed) title or overview changes — and seeded once at creation. Each
+	 * (displayed) title or overview changes â and seeded once at creation. Each
 	 * entry is a full snapshot of both values, so it is self-contained. Not
 	 * surfaced in the UI yet; kept for a future history view and for search.
 	 */
@@ -717,7 +717,7 @@ export interface Task {
 	mergeCompletionPrompt?: MergeCompletionPromptState | null;
 	/**
 	 * True when the task was created via the "Scratch Task" button with no
-	 * initial prompt. The `description` holds only a `Scratch — HH:mm`
+	 * initial prompt. The `description` holds only a `Scratch â HH:mm`
 	 * placeholder used for the title; at launch time the agent receives an
 	 * empty prompt instead of the placeholder. The flag propagates from the
 	 * source todo task into every variant spawned from it.
@@ -731,9 +731,9 @@ export interface Task {
 	 * removed but a fixed folder is never auto-removed. Ignored for git projects.
 	 */
 	opsWorkDir?: string | null;
-	/** Last-launch timestamps (ISO) per package.json script — used to sort the Scripts dropdown. */
+	/** Last-launch timestamps (ISO) per package.json script â used to sort the Scripts dropdown. */
 	scriptLastRunAt?: Record<string, string>;
-	/** Last-used placement per package.json script — pre-selects it in the placement picker. */
+	/** Last-used placement per package.json script â pre-selects it in the placement picker. */
 	scriptLastPlacement?: Record<string, ScriptPlacement>;
 }
 
@@ -761,7 +761,7 @@ export interface PackageScripts {
 	runner: ScriptRunner;
 	/** Runner was auto-detected from a lockfile (vs falling back to npm). */
 	runnerAutoDetected: boolean;
-	/** Multiple lockfiles found — runner is ambiguous. */
+	/** Multiple lockfiles found â runner is ambiguous. */
 	multipleLockfiles: boolean;
 	/** Lockfiles actually present in the worktree. */
 	lockfiles: string[];
@@ -811,7 +811,7 @@ export const STUCK_PREPARATION_FETCH_THRESHOLD_MS = 60 * 1000;
 
 /** Per-pane session info for recovery. */
 export interface PaneSessionEntry {
-	/** tmux pane ID (e.g. "%0", "%5") — stable within a tmux server lifetime, unique across sessions. */
+	/** tmux pane ID (e.g. "%0", "%5") â stable within a tmux server lifetime, unique across sessions. */
 	paneId?: string | null;
 	/** The resolved agent base command (e.g. "claude", "/usr/local/bin/codex"). */
 	agentCmd: string;
@@ -825,7 +825,7 @@ export interface PaneSessionEntry {
 
 /** Captured session state for agent recovery after tmux death / app restart. */
 export interface TaskSessionState {
-	/** Panes in order — index 0 is the main pane, rest are extra agent panes. */
+	/** Panes in order â index 0 is the main pane, rest are extra agent panes. */
 	panes: PaneSessionEntry[];
 }
 
@@ -861,7 +861,7 @@ export interface TaskHistoryEntry {
 	changed: TaskHistoryChange;
 }
 
-/** Humanize a status slug for display in notifications (e.g. "in-progress" → "In Progress"). */
+/** Humanize a status slug for display in notifications (e.g. "in-progress" â "In Progress"). */
 export function formatStatus(status: string): string {
 	return status
 		.split("-")
@@ -1014,13 +1014,13 @@ export type ExposedPortKind = "quick" | "shared";
 /**
  * A dev-server port (or group of ports) being shared publicly through a
  * Cloudflare quick-tunnel. `kind: "quick"` is one cloudflared per port
- * → its own random `*.trycloudflare.com` URL. `kind: "shared"` is one
- * cloudflared shared between multiple ports of the same task — those ports
+ * â its own random `*.trycloudflare.com` URL. `kind: "shared"` is one
+ * cloudflared shared between multiple ports of the same task â those ports
  * are reached via `<url>/p/<port>/...` on the headless server which proxies
  * the request to localhost:<port>. Shared mode lets a frontend and backend
  * talk to each other via relative URLs (no CORS, no hardcoded URLs).
  *
- * State is runtime-only — never persists to tasks.json. Tunnels are torn
+ * State is runtime-only â never persists to tasks.json. Tunnels are torn
  * down on explicit stop, after two consecutive port-scan misses (~20 s),
  * on task removal, and on app shutdown.
  */
@@ -1028,7 +1028,7 @@ export interface ExposedPort {
 	taskId: string;
 	kind: ExposedPortKind;
 	/**
-	 * For `quick`, exactly one element — the dev-server port. For `shared`,
+	 * For `quick`, exactly one element â the dev-server port. For `shared`,
 	 * the full set of ports reachable through this tunnel.
 	 */
 	ports: number[];
@@ -1338,7 +1338,13 @@ export type AppRPCSchema = {
 				response: Task;
 			};
 			moveTask: {
-				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean };
+				// `clientPlayedSound`: the UI already played the completion/cancel sound
+				// optimistically in the initiating renderer, so the backend must NOT
+				// also push `taskSound` (that push fans out to every connected renderer
+				// — a desktop window AND a remote browser on the same machine — and
+				// would play a second time). Unset for CLI / branch-merge / agent
+				// approval, where no renderer played locally and the push is the sound.
+				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean; clientPlayedSound?: boolean };
 				response: Task;
 			};
 			cancelTaskPreparation: {
@@ -1863,7 +1869,7 @@ export type AppRPCSchema = {
 			taskPreparationFailed: { taskId: string; projectId: string; taskTitle: string; error: string };
 			/**
 			 * Emitted when the main window gains focus shortly after a watched-task notification fired.
-			 * The renderer navigates to the referenced task — implements click-to-open for native notifications.
+			 * The renderer navigates to the referenced task â implements click-to-open for native notifications.
 			 */
 			openTaskFromNotification: { taskId: string; projectId: string };
 			/**
@@ -1889,7 +1895,7 @@ export type AppRPCSchema = {
 			/**
 			 * CI/checks + PR-review state for a task's open PR, emitted by the
 			 * background PR poller (`checkOpenPRsForPromotion`). Drives the CI and
-			 * review badges on the task card. Passive status — NOT gated by Focus
+			 * review badges on the task card. Passive status â NOT gated by Focus
 			 * Mode (only the bell/notification raised alongside it is).
 			 */
 			taskPrStatus: {
@@ -1926,7 +1932,7 @@ export type AppRPCSchema = {
 			 * RPC call, state mutation) based on its `current` view/task/project.
 			 *
 			 * Bun-side side effects (open external URL, dialog, display-popup) do
-			 * not go through this channel — they execute in `src/bun/index.ts`.
+			 * not go through this channel â they execute in `src/bun/index.ts`.
 			 */
 			menuAction: { action: string };
 			/**


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

In remote mode, the task complete/cancel sound played **twice** when a desktop window and a remote browser were both connected to the same backend on one machine.

The sound is produced in two places: the UI plays it optimistically the instant a card is dropped (`playTaskCompletionSound`), and the backend pushes a `taskSound` event (`emitTaskSound`). The per-renderer echo de-dup only suppressed the echo inside the *initiating* renderer, but the backend push fans out to **every** connected renderer (`broadcastToAllWindows` + `pushToBrowserClients`) — so the other renderer had no token and played a second time on the same speakers.

## Fix

The two playback paths are now mutually exclusive at the source:

- UI-initiated terminal moves pass `clientPlayedSound` on the `moveTask` RPC, and the backend then **skips** `emitTaskSound` entirely (no push to anyone).
- Non-UI completions (CLI, branch-merge auto-complete, agent approval) don't set the flag, so the backend push remains the single sound.
- The now-dead per-renderer echo machinery (`expectedEchoes` / `markEchoExpected` / `isEchoExpected`) is removed.

Added reproduce tests on both sides (frontend sends the flag for terminal moves; backend skips the push when the flag is set) and updated sibling component tests. See `decisions/084-remote-double-completion-sound.md` for the trade-off (non-UI paths still broadcast and can double on one machine with two renderers — out of scope here).