### PR TITLE
fix(ui): make Escape close overlays instead of exiting native fullscreen

### DIFF
--- a/change-logs/2026/06/28/fix-modal-escape-fullscreen.md
+++ b/change-logs/2026/06/28/fix-modal-escape-fullscreen.md
@@ -1,0 +1,1 @@
+Escape now reliably closes any open modal, lightbox, or popover instead of dropping the app out of native fullscreen. Added a shared `useEscapeKey` hook (capture-phase listener that calls preventDefault + stopImmediatePropagation) and routed every overlay through it; the About dialog now also closes on Escape.

--- a/decisions/084-modal-escape-preventdefault.md
+++ b/decisions/084-modal-escape-preventdefault.md
@@ -1,0 +1,44 @@
+# 084 — Escape must call preventDefault to close overlays in native fullscreen
+
+## Context
+When the app ran in macOS native fullscreen, pressing Escape often exited
+fullscreen instead of closing the open modal/lightbox. Many overlays had an
+Escape handler that called `onClose()` but never `e.preventDefault()`.
+
+## Investigation
+In WKWebView (Electrobun), a keydown that the web layer does not consume is
+forwarded up the AppKit responder chain. For a fullscreen `NSWindow`, AppKit
+interprets the Escape key as `cancelOperation:` → exit fullscreen. `onClose()`
+alone closes the React overlay but leaves the native default intact;
+`stopPropagation`/`stopImmediatePropagation` only stop JS listeners, not the
+native default action. Only `e.preventDefault()` suppresses it. This explained
+why some overlays "worked" — those whose focused input already preventDefaulted
+Escape (e.g. textarea edit handlers, the command palette) — and most did not.
+
+## Decision
+Added `src/mainview/hooks/useEscapeKey.ts`: a capture-phase `window` keydown
+listener that, on Escape, calls `preventDefault()` + `stopImmediatePropagation()`
+then a ref-held callback (no deps array). Capture beats App's global bubble-phase
+back-nav handler (`App.tsx`) and focused elements; staging (dropdown → inline
+edit → close) lives inside the callback. Routed every overlay through it
+(TaskDetailModal, ImageLightbox, BugHuntersLightbox, Add/CreateTask, FolderPicker,
+Spawn/LaunchVariants, KeyboardShortcuts, AboutModal, LabelPicker, OpenInMenu,
+SiblingPopover, Tmux popovers, GlobalHeader dropdowns, Changelog, task-info-panel
+menus). Inline editors that are not stacked overlays (InlineRename, KanbanColumn
+rename, sidebar/filter search, ProjectSettings dropdown, TaskDiffViewer search)
+keep their element-level handlers but now also call `preventDefault()`. App's
+back-nav handler preventDefaults in the branches where it acts.
+
+## Risks
+Capture + `stopImmediatePropagation` pre-empts descendant element Escape handlers
+while an overlay is mounted, so any inner sub-state (autocomplete, inline rename)
+must be staged inside `onEscape`. Nested overlays unwind outermost-first
+(registration order), which matches prior behavior. The terminal still receives
+Escape because no overlay listener is active when none is open.
+
+## Alternatives considered
+- Add `e.preventDefault()` to each handler in place — fixes fullscreen but leaves
+  ~25 ad-hoc handlers that future modals copy, re-introducing the bug.
+- A single global listener + LIFO stack (topmost-wins) — cleaner nesting but a
+  capture listener forces it to pre-empt all inner element handlers, breaking
+  inline editors inside modals; rejected for higher risk.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1331,19 +1331,28 @@ function App() {
 			const terminalEl = document.querySelector('[data-terminal="true"]');
 			if (terminalEl?.contains(document.activeElement)) return;
 			if (showQuitDialog) {
+				// preventDefault so Escape closes the dialog instead of dropping the
+				// app out of native fullscreen (WKWebView forwards an unconsumed
+				// Escape to AppKit's cancelOperation: → exit fullscreen).
+				e.preventDefault();
 				setShowQuitDialog(false);
 				return;
 			}
 			const { route } = state;
 			if (route.screen === "settings") {
+				e.preventDefault();
 				navigate({ screen: "dashboard" });
 			} else if (route.screen === "project-settings") {
+				e.preventDefault();
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project-terminal") {
+				e.preventDefault();
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project" && (route.activeTaskId || route.taskView)) {
+				e.preventDefault();
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project") {
+				e.preventDefault();
 				navigate({ screen: "dashboard" });
 			}
 		},

--- a/src/mainview/components/AboutModal.tsx
+++ b/src/mainview/components/AboutModal.tsx
@@ -1,5 +1,6 @@
 import { useT } from "../i18n";
 import { useFocusTrap } from "../utils/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 
 interface AboutModalProps {
 	version: string;
@@ -13,6 +14,7 @@ interface AboutModalProps {
 export default function AboutModal({ version, onClose }: AboutModalProps) {
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
+	useEscapeKey(onClose);
 	return (
 		<div
 			className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -478,6 +478,7 @@ function ActiveTasksSidebar({
 						onChange={(e) => setSearchQuery(e.target.value)}
 						onKeyDown={(e) => {
 							if (e.key === "Escape") {
+								e.preventDefault();
 								e.stopPropagation();
 								setSearchQuery("");
 								searchRef.current?.blur();

--- a/src/mainview/components/AddProjectModal.tsx
+++ b/src/mainview/components/AddProjectModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, type Dispatch } from "react";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { extractRepoName } from "../../shared/types";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
@@ -43,13 +44,7 @@ function AddProjectModal({ dispatch, onClose }: AddProjectModalProps) {
 		}
 	}, [activeTab]);
 
-	useEffect(() => {
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") onClose();
-		}
-		window.addEventListener("keydown", handleKey);
-		return () => window.removeEventListener("keydown", handleKey);
-	}, [onClose]);
+	useEscapeKey(onClose);
 
 	const inferredName = gitUrl.trim() ? extractRepoName(gitUrl.trim()) : "";
 	const displayName = repoName.trim() || inferredName;

--- a/src/mainview/components/BugHuntersLightbox.tsx
+++ b/src/mainview/components/BugHuntersLightbox.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { AgentCheckResult, CodingAgent, GlobalSettings, Project, Task } from "../../shared/types";
 import { api } from "../rpc";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useT } from "../i18n";
 import { trackAgentLaunched, trackEvent } from "../analytics";
 import Select, { useAgentRenderOption } from "./Select";
@@ -54,11 +55,10 @@ function BugHuntersLightbox({ task, project, onClose }: BugHuntersLightboxProps)
 		}).catch(() => {});
 	}, []);
 
+	useEscapeKey(onClose);
 	useEffect(() => {
 		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				onClose();
-			} else if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+			if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
 				const tag = (document.activeElement as HTMLElement | null)?.tagName;
 				if (tag === "INPUT" || tag === "TEXTAREA") return;
 				if (!launching && globalSettings) handleLaunch();
@@ -67,7 +67,7 @@ function BugHuntersLightbox({ task, project, onClose }: BugHuntersLightboxProps)
 		window.addEventListener("keydown", handleKey);
 		return () => window.removeEventListener("keydown", handleKey);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [onClose, launching, globalSettings, agentId, configId, count]);
+	}, [launching, globalSettings, agentId, configId, count]);
 
 	function handleAgentChange(newAgentId: string | null) {
 		setAgentId(newAgentId);

--- a/src/mainview/components/Changelog.tsx
+++ b/src/mainview/components/Changelog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useT } from "../i18n";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Route } from "../state";
 import type { ChangelogEntry } from "../../shared/types";
 import { api } from "../rpc";
@@ -66,19 +67,13 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 	}, []);
 
 	// Escape → go back to previous page
-	useEffect(() => {
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				if (canGoBack) {
-					goBack();
-				} else {
-					navigate({ screen: "dashboard" });
-				}
-			}
+	useEscapeKey(() => {
+		if (canGoBack) {
+			goBack();
+		} else {
+			navigate({ screen: "dashboard" });
 		}
-		document.addEventListener("keydown", handleKey);
-		return () => document.removeEventListener("keydown", handleKey);
-	}, [navigate, goBack, canGoBack]);
+	});
 
 	const toggleFilter = useCallback((type: EntryType) => {
 		setActiveFilter((prev) => (prev === type ? null : type));

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, type Dispatch } from "react";
 import { toast } from "../toast";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Label, Project, Task } from "../../shared/types";
 import { titleFromDescription } from "../../shared/types";
 import type { AppAction } from "../state";
@@ -184,29 +185,20 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun }: CreateT
 		}
 	}, [confirmDiscard]);
 
-	useEffect(() => {
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				e.stopImmediatePropagation();
-				if (skillAutocomplete.open) {
-					skillAutocomplete.close();
-				} else if (addingLabel) {
-					cancelLabelInput();
-				} else if (pendingBranchChoice) {
-					setPendingBranchChoice(null);
-					setPendingSubmitMode(null);
-				} else if (confirmDiscard) {
-					setConfirmDiscard(false);
-				} else {
-					handleRequestClose();
-				}
-			}
+	useEscapeKey(() => {
+		if (skillAutocomplete.open) {
+			skillAutocomplete.close();
+		} else if (addingLabel) {
+			cancelLabelInput();
+		} else if (pendingBranchChoice) {
+			setPendingBranchChoice(null);
+			setPendingSubmitMode(null);
+		} else if (confirmDiscard) {
+			setConfirmDiscard(false);
+		} else {
+			handleRequestClose();
 		}
-		// Use capture phase so we intercept ESC before App's global handler
-		window.addEventListener("keydown", handleKey, true);
-		return () => window.removeEventListener("keydown", handleKey, true);
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [description, onClose, confirmDiscard, pendingBranchChoice, skillAutocomplete.open, skillAutocomplete.close, addingLabel]);
+	});
 
 	async function createTaskWithBranch(branch: string | null, mode: "save" | "run" | "scratch") {
 		const trimmed = description.trim();

--- a/src/mainview/components/FolderPickerModal.tsx
+++ b/src/mainview/components/FolderPickerModal.tsx
@@ -10,6 +10,7 @@ import { useTree } from "@headless-tree/react";
 import type { FolderListing } from "../../shared/types";
 import { api } from "../rpc";
 import { useT } from "../i18n";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useFocusTrap } from "../utils/useFocusTrap";
 import {
 	subscribeFolderPicker,
@@ -225,16 +226,15 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 		return () => { cancelled = true; };
 	}, [options.initialPath]);
 
-	useEffect(() => {
-		function onKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				e.stopPropagation();
-				onClose(null);
-			}
+	// Escape cancels the inline "new folder" input first, otherwise closes the modal.
+	useEscapeKey(() => {
+		if (newFolderInput !== null) {
+			setNewFolderInput(null);
+			setNewFolderError(null);
+		} else {
+			onClose(null);
 		}
-		window.addEventListener("keydown", onKey, true);
-		return () => window.removeEventListener("keydown", onKey, true);
-	}, [onClose]);
+	});
 
 	const navigateTo = useCallback(async (path: string) => {
 		setListingError(null);

--- a/src/mainview/components/GitPullErrorModal.tsx
+++ b/src/mainview/components/GitPullErrorModal.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useT } from "../i18n";
 import { useFocusTrap } from "../utils/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 
 interface GitPullErrorModalProps {
 	branch: string;
@@ -15,16 +15,7 @@ function GitPullErrorModal({ branch, error, retrying, onRetry, onClose }: GitPul
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
 
-	useEffect(() => {
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				e.preventDefault();
-				onClose();
-			}
-		}
-		window.addEventListener("keydown", handleKey, true);
-		return () => window.removeEventListener("keydown", handleKey, true);
-	}, [onClose]);
+	useEscapeKey(onClose);
 
 	// Render through a portal into document.body — the kanban GlobalHeader uses
 	// `backdrop-filter`, which establishes a containing block for `position:

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -4,6 +4,7 @@ import { getTaskTitle, ACTIVE_STATUSES, isBuiltinOpsProject, orderProjectsForDis
 import type { Route } from "../state";
 import { useT } from "../i18n";
 import { useCompact } from "../utils/useCompact";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { api } from "../rpc";
 import TmuxSessionManager from "./TmuxSessionManager";
 import InlineRename from "./InlineRename";
@@ -75,7 +76,16 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 		}
 	}, [countdown, showToast]);
 
-	// Close dropdowns on outside click or Escape
+	// Close whichever header dropdown is open on Escape.
+	useEscapeKey(
+		() => {
+			if (showProjectDropdown) setShowProjectDropdown(false);
+			if (showUpdateDropdown) setShowUpdateDropdown(false);
+			if (showOverflowMenu) setShowOverflowMenu(false);
+		},
+		{ enabled: showUpdateDropdown || showProjectDropdown || showOverflowMenu },
+	);
+	// Close dropdowns on outside click
 	useEffect(() => {
 		if (!showUpdateDropdown && !showProjectDropdown && !showOverflowMenu) return;
 		function handleClick(e: MouseEvent) {
@@ -89,18 +99,9 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				setShowOverflowMenu(false);
 			}
 		}
-		function handleKeydown(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				if (showProjectDropdown) setShowProjectDropdown(false);
-				if (showUpdateDropdown) setShowUpdateDropdown(false);
-				if (showOverflowMenu) setShowOverflowMenu(false);
-			}
-		}
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeydown);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeydown);
 		};
 	}, [showUpdateDropdown, showProjectDropdown, showOverflowMenu]);
 

--- a/src/mainview/components/ImageLightbox.tsx
+++ b/src/mainview/components/ImageLightbox.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { api } from "../rpc";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useT } from "../i18n";
 
 export const DATA_URL_CACHE_MAX = 30;
@@ -81,15 +82,15 @@ export function ImageLightbox({ paths, currentIndex, onClose }: ImageLightboxPro
 		if (index > 0) setIndex(index - 1);
 	}, [index]);
 
+	useEscapeKey(onClose);
 	useEffect(() => {
 		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") onClose();
 			if (e.key === "ArrowRight") goNext();
 			if (e.key === "ArrowLeft") goPrev();
 		}
 		document.addEventListener("keydown", handleKey);
 		return () => document.removeEventListener("keydown", handleKey);
-	}, [onClose, goNext, goPrev]);
+	}, [goNext, goPrev]);
 
 	function handleOpenExternal() {
 		api.request.openImageFile({ path }).catch(() => {});

--- a/src/mainview/components/InlineRename.tsx
+++ b/src/mainview/components/InlineRename.tsx
@@ -91,7 +91,7 @@ export default function InlineRename({
 					onChange={(e) => setValue(e.target.value)}
 					onKeyDown={(e) => {
 						if (e.key === "Enter") save(value);
-						if (e.key === "Escape") { e.stopPropagation(); setEditing(false); }
+						if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); setEditing(false); }
 					}}
 					disabled={saving}
 					className={inputClassName}

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -510,7 +510,7 @@ function KanbanColumn({
 							onBlur={commitRename}
 							onKeyDown={(e) => {
 								if (e.key === "Enter") e.currentTarget.blur();
-								if (e.key === "Escape") { setEditing(false); }
+								if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); setEditing(false); }
 							}}
 							className="text-fg text-sm font-semibold bg-transparent outline-none border-b border-accent flex-1 min-w-0"
 							autoFocus

--- a/src/mainview/components/KeyboardShortcutsModal.tsx
+++ b/src/mainview/components/KeyboardShortcutsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactElement } from "react";
 import { createPortal } from "react-dom";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useT, type TranslationKey } from "../i18n";
 import {
 	APP_SHORTCUTS,
@@ -146,18 +147,17 @@ export default function KeyboardShortcutsModal({ open, tab, onTabChange, onClose
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
 
+	useEscapeKey(onClose, { enabled: open });
 	useEffect(() => {
 		if (!open) return;
 		function onKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				onClose();
-			} else if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+			if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
 				onTabChange(tab === "app" ? "terminal" : "app");
 			}
 		}
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [open, tab, onClose, onTabChange]);
+	}, [open, tab, onTabChange]);
 
 	if (!open) return null;
 

--- a/src/mainview/components/LabelFilterBar.tsx
+++ b/src/mainview/components/LabelFilterBar.tsx
@@ -65,6 +65,7 @@ function LabelFilterBar({
 					onChange={(e) => onSearchChange(e.target.value)}
 					onKeyDown={(e) => {
 						if (e.key === "Escape") {
+							e.preventDefault();
 							e.stopPropagation();
 							onSearchChange("");
 							inputRef.current?.blur();

--- a/src/mainview/components/LabelPicker.tsx
+++ b/src/mainview/components/LabelPicker.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "../toast";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Label, Project, Task } from "../../shared/types";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
@@ -77,6 +78,7 @@ function LabelPicker({ project, task, dispatch, onClose, anchorEl }: LabelPicker
 		inputRef.current?.focus();
 	}, [anchorEl]);
 
+	useEscapeKey(onClose);
 	// Close on click outside
 	useEffect(() => {
 		function handleClick(e: MouseEvent) {
@@ -88,14 +90,9 @@ function LabelPicker({ project, task, dispatch, onClose, anchorEl }: LabelPicker
 				onClose();
 			}
 		}
-		function handleKeyDown(e: KeyboardEvent) {
-			if (e.key === "Escape") onClose();
-		}
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown);
 		};
 	}, [anchorEl, onClose]);
 

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type Dispatch } from "react";
 import type { AgentCheckResult, CodingAgent, GlobalSettings, Project, Task, TaskStatus } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
@@ -89,12 +90,11 @@ function LaunchVariantsModal({
 	// operate hidden UI.
 	const trapRef = useFocusTrap<HTMLDivElement>();
 
-	// Escape → close; Enter → launch (when no text input is focused)
+	useEscapeKey(onClose);
+	// Enter → launch (when no text input is focused)
 	useEffect(() => {
 		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				onClose();
-			} else if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+			if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
 				// Only an "implicit" Enter (nothing interactive focused) should launch.
 				// If the user tab-focused a control, Enter must trigger that control's
 				// own action — the agent/config pickers render as <button> (Select.tsx),
@@ -109,7 +109,7 @@ function LaunchVariantsModal({
 		window.addEventListener("keydown", handleKey);
 		return () => window.removeEventListener("keydown", handleKey);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [onClose, launching, variants]);
+	}, [launching, variants]);
 
 	function addVariant() {
 		setVariants((prev) => [...prev, makeDefaultVariant()]);

--- a/src/mainview/components/OpenInMenu.tsx
+++ b/src/mainview/components/OpenInMenu.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useLayoutEffect, useState } from "react";
 import { toast } from "../toast";
 import { createPortal } from "react-dom";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { ExternalApp } from "../../shared/types";
 import { useAvailableApps } from "../hooks/useAvailableApps";
 import { useT } from "../i18n";
@@ -39,6 +40,7 @@ export default function OpenInMenu({ position, path, onClose }: OpenInMenuProps)
 	const [visible, setVisible] = useState(false);
 	const [copied, setCopied] = useState(false);
 
+	useEscapeKey(onClose);
 	// Close on click outside
 	useEffect(() => {
 		function handleClick(e: MouseEvent) {
@@ -46,14 +48,9 @@ export default function OpenInMenu({ position, path, onClose }: OpenInMenuProps)
 				onClose();
 			}
 		}
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") onClose();
-		}
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKey);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKey);
 		};
 	}, [onClose]);
 

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -377,6 +377,8 @@ function BranchPicker({
 				}}
 				onKeyDown={(event) => {
 					if (event.key === "Escape") {
+						event.preventDefault();
+						event.stopPropagation();
 						setDropdownOpen(false);
 						setEditing(false);
 						setQuery("");

--- a/src/mainview/components/SiblingPopover.tsx
+++ b/src/mainview/components/SiblingPopover.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { CodingAgent, Task } from "../../shared/types";
 import { ACTIVE_STATUSES } from "../../shared/types";
 import { useStatusColors } from "../hooks/useStatusColors";
@@ -47,7 +48,8 @@ function SiblingPopover({ siblings, agents, navigate, onClose, anchorEl, project
 		setVisible(true);
 	}, [anchorEl]);
 
-	// Close on click outside or Escape
+	useEscapeKey(onClose);
+	// Close on click outside
 	useEffect(() => {
 		function handleClick(e: MouseEvent) {
 			if (
@@ -58,14 +60,9 @@ function SiblingPopover({ siblings, agents, navigate, onClose, anchorEl, project
 				onClose();
 			}
 		}
-		function handleKeyDown(e: KeyboardEvent) {
-			if (e.key === "Escape") onClose();
-		}
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown);
 		};
 	}, [anchorEl, onClose]);
 

--- a/src/mainview/components/SpawnAgentModal.tsx
+++ b/src/mainview/components/SpawnAgentModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { AgentCheckResult, CodingAgent, GlobalSettings, Project, Task } from "../../shared/types";
 import { api } from "../rpc";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useT } from "../i18n";
 import { trackAgentLaunched, trackEvent } from "../analytics";
 import Select, { useAgentRenderOption } from "./Select";
@@ -53,11 +54,10 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 		}).catch(() => {});
 	}, []);
 
+	useEscapeKey(onClose);
 	useEffect(() => {
 		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				onClose();
-			} else if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+			if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
 				// Only an "implicit" Enter (nothing interactive focused) should spawn.
 				// The agent/config pickers render as <button> (Select.tsx), so a
 				// keyboard user tab-focusing one and pressing Enter must open that
@@ -71,7 +71,7 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 		window.addEventListener("keydown", handleKey);
 		return () => window.removeEventListener("keydown", handleKey);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [onClose, spawning, globalSettings, agentId, configId]);
+	}, [spawning, globalSettings, agentId, configId]);
 
 	function handleAgentChange(newAgentId: string | null) {
 		setAgentId(newAgentId);

--- a/src/mainview/components/TaskDetailModal.tsx
+++ b/src/mainview/components/TaskDetailModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, type Dispatch } from "react";
 import { toast } from "../toast";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Project, Task, TaskStatus } from "../../shared/types";
 import { titleFromDescription, getAllowedTransitions, getTaskTitle } from "../../shared/types";
 import { useStatusColors } from "../hooks/useStatusColors";
@@ -37,23 +38,17 @@ function TaskDetailModal({ task, project, dispatch, onClose }: TaskDetailModalPr
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const renameInputRef = useRef<HTMLInputElement>(null);
 
-	useEffect(() => {
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				if (statusMenuOpen) {
-					setStatusMenuOpen(false);
-				} else if (isRenaming) {
-					setIsRenaming(false);
-				} else if (isEditing) {
-					setIsEditing(false);
-				} else {
-					onClose();
-				}
-			}
+	useEscapeKey(() => {
+		if (statusMenuOpen) {
+			setStatusMenuOpen(false);
+		} else if (isRenaming) {
+			setIsRenaming(false);
+		} else if (isEditing) {
+			setIsEditing(false);
+		} else {
+			onClose();
 		}
-		window.addEventListener("keydown", handleKey);
-		return () => window.removeEventListener("keydown", handleKey);
-	}, [onClose, isEditing, isRenaming, statusMenuOpen]);
+	});
 
 	useEffect(() => {
 		if (isEditing) {

--- a/src/mainview/components/TerminalPreviewPopover.tsx
+++ b/src/mainview/components/TerminalPreviewPopover.tsx
@@ -239,6 +239,7 @@ function TerminalPreviewPopover({
 								onFocus={cancelClose}
 								onKeyDown={(e) => {
 									if (e.key === "Escape") {
+										e.preventDefault();
 										e.stopPropagation();
 										cancelEditing();
 									} else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {

--- a/src/mainview/components/TmuxSessionManager.tsx
+++ b/src/mainview/components/TmuxSessionManager.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useLayoutEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { TmuxSessionInfo } from "../../shared/types";
 import type { Route } from "../state";
 import { api } from "../rpc";
@@ -108,14 +109,7 @@ function TmuxSessionManager({ navigate }: TmuxSessionManagerProps) {
 	}, [popoverOpen]);
 
 	// Escape to close
-	useEffect(() => {
-		if (!popoverOpen) return;
-		function handleKey(e: KeyboardEvent) {
-			if (e.key === "Escape") setPopoverOpen(false);
-		}
-		document.addEventListener("keydown", handleKey);
-		return () => document.removeEventListener("keydown", handleKey);
-	}, [popoverOpen]);
+	useEscapeKey(() => setPopoverOpen(false), { enabled: popoverOpen });
 
 	// Viewport clamping
 	useLayoutEffect(() => {

--- a/src/mainview/components/__tests__/AboutModal.test.tsx
+++ b/src/mainview/components/__tests__/AboutModal.test.tsx
@@ -32,6 +32,14 @@ describe("AboutModal", () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
+	it("closes on Escape and prevents the default (native fullscreen exit)", () => {
+		const onClose = renderAbout();
+		const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+		window.dispatchEvent(event);
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
 	it("opens the website in a new tab", async () => {
 		const user = userEvent.setup();
 		const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);

--- a/src/mainview/components/task-info-panel/TaskDevServer.tsx
+++ b/src/mainview/components/task-info-panel/TaskDevServer.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import type { Project, Task } from "../../../shared/types";
 import { api } from "../../rpc";
 import { useT } from "../../i18n";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 import { useResolvedTaskProject } from "./useResolvedTaskProject";
 
 interface TaskDevServerProps {
@@ -25,25 +26,16 @@ function DevServerMenu({ position, onRestart, onStop, onClose }: DevServerMenuPr
 	const [menuPos, setMenuPos] = useState(position);
 	const [visible, setVisible] = useState(false);
 
+	useEscapeKey(onClose);
 	useEffect(() => {
 		function handleClick(event: MouseEvent) {
 			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
 				onClose();
 			}
 		}
-
-		function handleKey(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				onClose();
-			}
-		}
-
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKey);
-
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKey);
 		};
 	}, [onClose]);
 

--- a/src/mainview/components/task-info-panel/TaskExposedPorts.tsx
+++ b/src/mainview/components/task-info-panel/TaskExposedPorts.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import type { ExposedPort, Task } from "../../../shared/types";
 import { api } from "../../rpc";
 import { useT } from "../../i18n";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 import { useTaskAllocatedPorts } from "./useTaskAllocatedPorts";
 
 interface TaskExposedPortsProps {
@@ -162,13 +163,7 @@ function ExposedPortsMenu({ taskId, allocatedPorts, exposed, position, onClose }
 	const [busyPort, setBusyPort] = useState<number | null>(null);
 	const [toast, setToast] = useState<string | null>(null);
 
-	useEffect(() => {
-		function handleKey(event: KeyboardEvent) {
-			if (event.key === "Escape") onClose();
-		}
-		document.addEventListener("keydown", handleKey);
-		return () => document.removeEventListener("keydown", handleKey);
-	}, [onClose]);
+	useEscapeKey(onClose);
 
 	useLayoutEffect(() => {
 		if (!menuRef.current) return;

--- a/src/mainview/components/task-info-panel/TaskScripts.tsx
+++ b/src/mainview/components/task-info-panel/TaskScripts.tsx
@@ -11,6 +11,7 @@ import type {
 import { SCRIPT_PLACEMENTS } from "../../../shared/types";
 import { api } from "../../rpc";
 import { useT } from "../../i18n";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 
 const DEFAULT_PLACEMENT_IDX = SCRIPT_PLACEMENTS.indexOf("right");
 
@@ -75,19 +76,13 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 		if (open) refresh();
 	}, [open, refresh]);
 
-	useEffect(() => {
-		if (!open) return;
-		function onKey(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				if (pickerFor) setPickerFor(null);
-				else setOpen(false);
-			}
-		}
-		document.addEventListener("keydown", onKey);
-		return () => {
-			document.removeEventListener("keydown", onKey);
-		};
-	}, [open, pickerFor]);
+	useEscapeKey(
+		() => {
+			if (pickerFor) setPickerFor(null);
+			else setOpen(false);
+		},
+		{ enabled: open },
+	);
 
 	// Auto-focus the search input as soon as the dropdown opens (and not in picker mode).
 	// On the very first open `pkg` is still null while parsePackageScripts runs, so the

--- a/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
+++ b/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
@@ -4,6 +4,7 @@ import { useT } from "../../i18n";
 import { api } from "../../rpc";
 import { confirm } from "../../confirm";
 import { getKeymapPreset, KEYMAP_CHANGED_EVENT, setKeymapPreset } from "../../terminal-keymaps";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 
 interface TaskTmuxControlsProps {
 	taskId: string;
@@ -77,21 +78,13 @@ export default function TaskTmuxControls({ taskId }: TaskTmuxControlsProps) {
 
 	useEffect(() => clearHintsTimeout, []);
 
-	useEffect(() => {
-		if (!hintsOpen) {
-			return;
-		}
-
-		function handleKey(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				setHintsOpen(false);
-				setHintsVisible(false);
-			}
-		}
-
-		document.addEventListener("keydown", handleKey);
-		return () => document.removeEventListener("keydown", handleKey);
-	}, [hintsOpen]);
+	useEscapeKey(
+		() => {
+			setHintsOpen(false);
+			setHintsVisible(false);
+		},
+		{ enabled: hintsOpen },
+	);
 
 	useLayoutEffect(() => {
 		if (!hintsOpen || !hintsPopoverRef.current || !hintsTriggerRef.current) {
@@ -147,21 +140,13 @@ export default function TaskTmuxControls({ taskId }: TaskTmuxControlsProps) {
 
 	useEffect(() => clearLayoutTimeout, []);
 
-	useEffect(() => {
-		if (!layoutOpen) {
-			return;
-		}
-
-		function handleKey(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				setLayoutOpen(false);
-				setLayoutVisible(false);
-			}
-		}
-
-		document.addEventListener("keydown", handleKey);
-		return () => document.removeEventListener("keydown", handleKey);
-	}, [layoutOpen]);
+	useEscapeKey(
+		() => {
+			setLayoutOpen(false);
+			setLayoutVisible(false);
+		},
+		{ enabled: layoutOpen },
+	);
 
 	useLayoutEffect(() => {
 		if (!layoutOpen || !layoutMenuRef.current || !layoutTriggerRef.current) {

--- a/src/mainview/hooks/__tests__/useEscapeKey.test.tsx
+++ b/src/mainview/hooks/__tests__/useEscapeKey.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useEscapeKey } from "../useEscapeKey";
+
+/** Dispatch a cancelable, bubbling Escape (or other key) from a node. */
+function pressKey(key: string, from: EventTarget = window): KeyboardEvent {
+	const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+	from.dispatchEvent(event);
+	return event;
+}
+
+describe("useEscapeKey", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("invokes the callback on Escape", () => {
+		const onEscape = vi.fn();
+		renderHook(() => useEscapeKey(onEscape));
+		pressKey("Escape");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls preventDefault so Escape never reaches native fullscreen exit", () => {
+		renderHook(() => useEscapeKey(() => {}));
+		const event = pressKey("Escape");
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("ignores keys other than Escape", () => {
+		const onEscape = vi.fn();
+		renderHook(() => useEscapeKey(onEscape));
+		pressKey("Enter");
+		pressKey("a");
+		expect(onEscape).not.toHaveBeenCalled();
+	});
+
+	it("does not register while disabled", () => {
+		const onEscape = vi.fn();
+		renderHook(() => useEscapeKey(onEscape, { enabled: false }));
+		const event = pressKey("Escape");
+		expect(onEscape).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("re-registers when enabled flips from false to true", () => {
+		const onEscape = vi.fn();
+		const { rerender } = renderHook(
+			({ enabled }: { enabled: boolean }) => useEscapeKey(onEscape, { enabled }),
+			{ initialProps: { enabled: false } },
+		);
+		pressKey("Escape");
+		expect(onEscape).not.toHaveBeenCalled();
+
+		rerender({ enabled: true });
+		pressKey("Escape");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes the listener on unmount", () => {
+		const onEscape = vi.fn();
+		const { unmount } = renderHook(() => useEscapeKey(onEscape));
+		unmount();
+		pressKey("Escape");
+		expect(onEscape).not.toHaveBeenCalled();
+	});
+
+	it("always calls the latest callback without a dependency array", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const { rerender } = renderHook(
+			({ cb }: { cb: () => void }) => useEscapeKey(cb),
+			{ initialProps: { cb: first } },
+		);
+		rerender({ cb: second });
+		pressKey("Escape");
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops propagation so other window listeners do not also fire", () => {
+		const onEscape = vi.fn();
+		const other = vi.fn();
+		// A bubble-phase window listener stands in for App's global back-nav handler.
+		window.addEventListener("keydown", other);
+		renderHook(() => useEscapeKey(onEscape));
+
+		// Dispatch from a child node so the hook's capture listener fires first.
+		const child = document.createElement("div");
+		document.body.appendChild(child);
+		pressKey("Escape", child);
+		child.remove();
+
+		window.removeEventListener("keydown", other);
+		expect(onEscape).toHaveBeenCalledTimes(1);
+		expect(other).not.toHaveBeenCalled();
+	});
+});

--- a/src/mainview/hooks/useEscapeKey.ts
+++ b/src/mainview/hooks/useEscapeKey.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Close an overlay (modal / lightbox / popover) when Escape is pressed.
+ *
+ * Registers a **capture-phase** `window` keydown listener while `enabled` and,
+ * on Escape, calls:
+ *   - `e.preventDefault()` — so the key never reaches macOS/WKWebView, which
+ *     would otherwise treat Escape as `cancelOperation:` and exit the app's
+ *     native fullscreen *instead of* closing the overlay. This is the bug this
+ *     hook exists to fix: without preventDefault, an unconsumed Escape bubbles
+ *     out of the web view to AppKit and drops you out of fullscreen.
+ *   - `e.stopImmediatePropagation()` — so the app-level back-navigation Escape
+ *     handler (and any other window listener) does not also fire.
+ *
+ * Capture phase is required so this beats App's global (bubble-phase) handler
+ * and any focused element. As a consequence, descendant element-level Escape
+ * handlers are pre-empted — overlays with an inner sub-state that should be
+ * dismissed first (an open dropdown, an inline rename, an autocomplete popup)
+ * must encode that staging inside `onEscape` rather than relying on a child's
+ * own handler.
+ *
+ * The callback is read through a ref, so it is always current without needing a
+ * dependency array — only `enabled` gates the listener.
+ *
+ * @example
+ *   useEscapeKey(onClose);                       // simple modal
+ *   useEscapeKey(() => menuOpen ? closeMenu() : onClose()); // staged
+ *   useEscapeKey(onClose, { enabled: popoverOpen });        // gated popover
+ */
+export function useEscapeKey(
+	onEscape: () => void,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	const onEscapeRef = useRef(onEscape);
+	onEscapeRef.current = onEscape;
+
+	useEffect(() => {
+		if (!enabled) return;
+		function handleKey(e: KeyboardEvent) {
+			if (e.key !== "Escape") return;
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			onEscapeRef.current();
+		}
+		window.addEventListener("keydown", handleKey, true);
+		return () => window.removeEventListener("keydown", handleKey, true);
+	}, [enabled]);
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

In macOS native fullscreen, pressing **Escape** often exited fullscreen instead of closing the open modal/lightbox. Root cause: WKWebView (Electrobun) forwards an unconsumed `keydown` up the AppKit responder chain, and for a fullscreen `NSWindow` Escape becomes `cancelOperation:` → exit fullscreen. Closing the React overlay via `onClose()` doesn't help — only `e.preventDefault()` suppresses the native default (`stopPropagation`/`stopImmediatePropagation` only stop JS listeners). That's why it failed "in many cases" — only overlays whose focused input already preventDefaulted Escape worked.

## What changed

- New shared hook `src/mainview/hooks/useEscapeKey.ts`: capture-phase `window` keydown listener that calls `preventDefault()` + `stopImmediatePropagation()` then a ref-held callback. Capture beats App's global bubble-phase back-navigation handler and focused elements; per-overlay staging (open dropdown → inline edit → close) lives inside the callback.
- Routed every modal / lightbox / popover through it: TaskDetailModal, ImageLightbox, BugHuntersLightbox, Add/CreateTask, FolderPicker, Spawn/LaunchVariants, KeyboardShortcuts, **AboutModal (previously had no Escape handler)**, LabelPicker, OpenInMenu, SiblingPopover, tmux popovers, GlobalHeader dropdowns, Changelog, task-info-panel menus.
- Inline editors that are not stacked overlays (InlineRename, column rename, sidebar/filter search, ProjectSettings dropdown, TaskDiffViewer search) keep element-level handlers but now also `preventDefault()`.
- `App.tsx` global back-nav handler now `preventDefault()`s in the branches where it actually navigates.

## Tests

- New `useEscapeKey` unit tests (callback fired, `defaultPrevented`, `enabled` gating, cleanup, latest-callback-via-ref, propagation pre-emption).
- AboutModal Escape test added.
- `bun run lint` clean; full `bun run test` green.

Decision record: `decisions/084-modal-escape-preventdefault.md`.