### PR TITLE
fix(operations): keep Your Review column on virtual boards

### DIFF
--- a/change-logs/2026/06/29/fix-operations-your-review-column.md
+++ b/change-logs/2026/06/29/fix-operations-your-review-column.md
@@ -1,0 +1,1 @@
+Restore the "Your Review" column on Operations (virtual) boards. Finished operations tasks are handed back via review-by-user, but the board hid that column for virtual projects, so the task disappeared. Now only AI Review and PR Review stay hidden on Operations boards.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -331,11 +331,14 @@ function KanbanBoard({
 		// Show AI Review column by default (on when builtinColumnAgents is unset or has review-by-ai config)
 		const aiReviewEnabled = project.builtinColumnAgents === undefined || !!project.builtinColumnAgents?.["review-by-ai"];
 		const aiReviewHasItems = tasks.some((t) => t.status === "review-by-ai" && !isInCustomColumn(t));
-		// Virtual ("Operations") boards have no diff/PR, so all review columns are
-		// hidden — the flow is todo → in-progress → user-questions → done.
+		// Virtual ("Operations") boards have no diff/PR, so the AI Review and PR
+		// Review columns are hidden. "Your Review" stays: a finished ops task is
+		// handed back via review-by-user, so without the column it would vanish
+		// from the board entirely. Flow: todo → in-progress → user-questions →
+		// review-by-user → done.
 		const isVirtual = project.kind === "virtual";
 		const shouldHide = (s: TaskStatus) =>
-			(isVirtual && (s === "review-by-ai" || s === "review-by-colleague" || s === "review-by-user")) ||
+			(isVirtual && (s === "review-by-ai" || s === "review-by-colleague")) ||
 			(s === "review-by-colleague" && !peerReviewEnabled) ||
 			(s === "review-by-ai" && !aiReviewEnabled && !aiReviewHasItems);
 		const filterBuiltin = (statuses: TaskStatus[]) =>

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -151,12 +151,12 @@ describe("column ordering", () => {
 		expect(labels).not.toContain("PR Review");
 	});
 
-	it("virtual board hides all review columns (todo → in-progress → user-questions → done)", async () => {
+	it("virtual board hides AI/PR review but keeps Your Review (finished ops tasks land there)", async () => {
 		await renderBoardWith({ project: { ...project, kind: "virtual" } });
 		const labels = getColumnLabels();
 		expect(labels).not.toContain("AI Review");
-		expect(labels).not.toContain("Your Review");
 		expect(labels).not.toContain("PR Review");
+		expect(labels).toContain("Your Review");
 		expect(labels).toContain("To Do");
 		expect(labels).toContain("Agent is Working");
 		expect(labels).toContain("Completed");


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Operations (virtual) boards hid **all three** review columns (`review-by-ai`, `review-by-colleague`, `review-by-user`). But finished operations tasks are handed back via `review-by-user` (the primary stop target), so the task landed in a status with no column and vanished from the board.

This restores the **"Your Review"** column on Operations boards. AI Review and PR Review stay hidden there (no diff/PR in operations). Flow is now: To Do → Agent is Working → Has Questions → Your Review → Completed.

The change is a one-line fix in `getOrderedColumns` (`KanbanBoard.tsx`): `review-by-user` is no longer hidden for `kind === "virtual"` boards. The existing test that asserted the column was hidden is updated to assert it stays visible.
