### PR TITLE
fix(dev-server): reap orphaned child process tree on Stop

### DIFF
--- a/change-logs/2026/06/29/fix-dev-server-orphan-children.md
+++ b/change-logs/2026/06/29/fix-dev-server-orphan-children.md
@@ -1,0 +1,1 @@
+Stopping a task's dev server now kills its entire child process tree, not just the tmux pane. Previously the underlying server (e.g. the launched app or a process holding a port) kept running orphaned after Stop. The same reap also runs when a task session is destroyed.

--- a/decisions/092-dev-server-kill-process-tree.md
+++ b/decisions/092-dev-server-kill-process-tree.md
@@ -1,0 +1,40 @@
+# 092 — Kill the dev server's whole process tree on Stop
+
+## Context
+Pressing **Stop** on a task's dev server removed its tmux pane but left the real
+workload running (e.g. the launched Electrobun `.app`, or a `vite`/`webpack`
+process still holding its port). The orphaned processes kept running with no
+visible owner.
+
+## Investigation
+The dev server runs in a detached tmux session `dev3-dev-<id>` whose single pane
+executes `bash <devScriptPath>` (the user's `devScript`). `stopDevServer` →
+`killDevServerSession` only did `tmux kill-session`, which delivers **SIGHUP to
+the pane's foreground process only**. Deep children that run in their own
+process group or get reparented to init survive the teardown. The viewer pane
+lives in a *separate* task session, so nothing reaped the dev session's child
+tree.
+
+## Decision
+In `src/bun/rpc-handlers/tmux-pty.ts`, `killDevServerSession` now snapshots the
+dev session's pane PIDs **plus all descendants** (`getSessionPanePids` +
+`getDescendantPids` from `port-scanner.ts`) *before* tearing down the session,
+then `reapDevServerTree()` sends SIGTERM, waits `DEV_SERVER_KILL_GRACE_MS`
+(600 ms) for a graceful exit, and SIGKILLs survivors. The same reap is applied
+in `killTmuxSession`'s dev-session cleanup branch (same orphan bug when a whole
+task session is destroyed). All signalling is best-effort (ESRCH ignored).
+
+## Risks
+- A fully *daemonized* child (double-fork → reparented before we snapshot, no
+  ppid link) won't be captured — inherent to any ppid-walk approach.
+- Tiny TOCTOU window: a snapshotted PID could be recycled before SIGKILL. The
+  grace is sub-second and the PID set is scoped strictly to the dev session, so
+  the risk is negligible.
+- Adds ~600 ms to a stop/restart; acceptable and helps ports release cleanly.
+
+## Alternatives considered
+- **Launch devScript in its own process group and `kill -- -PGID`** — cleaner
+  semantically but misses already-detached processes and complicates the
+  attach/detach viewer flow.
+- **`pkill -f <devScriptPath>`** — fragile (false matches, misses children with
+  no marker in their cmdline).

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5455,6 +5455,59 @@ describe("handlers.stopDevServer", () => {
 		expect(result.running).toBe(false);
 	});
 
+	it("reaps the dev server's orphaned child process tree, not just the tmux session", async () => {
+		// Regression: the Stop button used to only `tmux kill-session`, which SIGHUPs
+		// the pane's foreground shell but leaves deep children (vite / electrobun +
+		// the launched .app) running. We must SIGTERM/SIGKILL the whole descendant
+		// tree captured from the dev session before teardown.
+		const project = makeProject();
+		const task = makeTask({ id: "abcd1234-0000-0000-0000-000000000000" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+
+		const enc = (s: string) => new TextEncoder().encode(s);
+		// dev session pane pid = 1111, with children 2222 and 3333 (no grandchildren).
+		mockSpawnSync.mockImplementation((args: string[]) => {
+			if (args.includes("list-panes") && args.includes("dev3-dev-abcd1234")) {
+				return { exitCode: 0, stdout: enc("1111\n") };
+			}
+			if (args[0] === "pgrep" && args.includes("1111")) {
+				return { exitCode: 0, stdout: enc("2222\n3333\n") };
+			}
+			return { exitCode: 1, stdout: enc("") };
+		});
+		// has-session reports "not running" so buildDevServerStatus short-circuits.
+		mockSpawn.mockImplementation((args: string[]) => ({
+			stdout: "",
+			stderr: new Response(""),
+			exited: Promise.resolve(args.includes("has-session") ? 1 : 0),
+		}));
+
+		const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+		vi.useFakeTimers();
+		// Capture calls before mockRestore() — restoring a spy also clears its
+		// recorded calls, so snapshot them while the spy is still live.
+		let killCalls: [number | NodeJS.Signals, ...unknown[]][] = [];
+		try {
+			const pending = handlers.stopDevServer({ taskId: task.id, projectId: "proj-1" });
+			// Drive past the SIGTERM→SIGKILL grace delay without a real sleep.
+			await vi.advanceTimersByTimeAsync(1000);
+			await pending;
+			killCalls = [...killSpy.mock.calls] as typeof killCalls;
+		} finally {
+			vi.useRealTimers();
+			killSpy.mockRestore();
+		}
+
+		const killedPids = killCalls.map((c) => c[0]);
+		// Both children (and the pane shell) must have been signalled.
+		expect(killedPids).toContain(1111);
+		expect(killedPids).toContain(2222);
+		expect(killedPids).toContain(3333);
+		// And escalated to SIGKILL for survivors.
+		expect(killCalls.some((c) => c[0] === 2222 && c[1] === "SIGKILL")).toBe(true);
+	});
+
 	it("throws when kill-session fails", async () => {
 		const project = makeProject();
 		const task = makeTask();

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -6,7 +6,7 @@ import * as pty from "../pty-server";
 import * as agents from "../agents";
 import * as portPool from "../port-pool";
 import * as repoConfig from "../repo-config";
-import { getPortsForTask, getSessionPanePids, scanTaskPorts } from "../port-scanner";
+import { getDescendantPids, getPortsForTask, getSessionPanePids, scanTaskPorts } from "../port-scanner";
 import { getResourceUsage } from "../resource-monitor";
 import { loadSettings } from "../settings";
 import { getUserShell } from "../shell-env";
@@ -60,12 +60,58 @@ async function killDevServerViewerPane(taskId: string, taskSession: string, devS
 	log.info("Killed dev server viewer pane", { taskId: taskId.slice(0, 8), viewerPaneId });
 }
 
+// tmux `kill-session` only delivers SIGHUP to each pane's *foreground* process
+// (here: the `bash devScriptPath` wrapper). A dev server's real workload —
+// vite/webpack/next, or electrobun plus the GUI `.app` bundle it launches —
+// usually lives in deeper children that run in their own process group or get
+// reparented to init when the wrapper dies, so they survive the teardown and
+// keep holding ports (or windows) open. Snapshot the dev session's full
+// descendant tree and reap it explicitly. See decision 092.
+const DEV_SERVER_KILL_GRACE_MS = 600;
+
+function collectDevServerTreePids(devSession: string, socket: string): number[] {
+	const panePids = getSessionPanePids(socket, devSession);
+	if (panePids.length === 0) return [];
+	const tree = new Set<number>();
+	for (const pid of panePids) {
+		tree.add(pid);
+		for (const child of getDescendantPids(pid)) tree.add(child);
+	}
+	return [...tree];
+}
+
+function signalPids(pids: number[], signal: NodeJS.Signals): void {
+	for (const pid of pids) {
+		try {
+			process.kill(pid, signal);
+		} catch {
+			// Process already gone or not permitted — best-effort reaping.
+		}
+	}
+}
+
+// Reap a previously-captured PID set: SIGTERM for a graceful shutdown (lets dev
+// servers release ports / flush state), then SIGKILL the survivors after a
+// short grace. Pass the PIDs captured *before* the tmux session was torn down —
+// they stay valid after the wrapper dies (children just reparent to init).
+async function reapDevServerTree(pids: number[], devSession: string): Promise<void> {
+	if (pids.length === 0) return;
+	signalPids(pids, "SIGTERM");
+	await new Promise((resolve) => setTimeout(resolve, DEV_SERVER_KILL_GRACE_MS));
+	signalPids(pids, "SIGKILL");
+	log.info("Reaped dev server process tree", { devSession, count: pids.length });
+}
+
 export async function killDevServerSession(taskId: string, socket: string): Promise<void> {
 	const devSession = devServerSessionName(taskId);
 	const taskSession = `dev3-${taskId.slice(0, 8)}`;
+	// Snapshot the process tree while the dev session still exists — afterwards
+	// its pane PIDs are unreachable via tmux.
+	const treePids = collectDevServerTreePids(devSession, socket);
 	await killDevServerViewerPane(taskId, taskSession, devSession, socket);
 	const kill = spawn(pty.tmuxArgs(socket, "kill-session", "-t", devSession), { stdout: "pipe", stderr: "pipe" });
 	await kill.exited;
+	await reapDevServerTree(treePids, devSession);
 	log.info("Killed dev server session", { taskId: taskId.slice(0, 8), devSession });
 }
 
@@ -1283,8 +1329,12 @@ async function killTmuxSession(params: { sessionName: string }): Promise<void> {
 
 	if (!params.sessionName.startsWith("dev3-dev-")) {
 		const devSession = `dev3-dev-${params.sessionName.slice("dev3-".length)}`;
+		// Same orphaned-children problem as the Stop button: snapshot the dev
+		// server's process tree before tearing the session down, then reap it.
+		const treePids = collectDevServerTreePids(devSession, pty.DEFAULT_TMUX_SOCKET);
 		const devKill = spawn(pty.tmuxArgs(pty.DEFAULT_TMUX_SOCKET, "kill-session", "-t", devSession), { stdout: "pipe", stderr: "pipe" });
 		await devKill.exited;
+		await reapDevServerTree(treePids, devSession);
 		log.info("killTmuxSession: killed dev server session (best-effort)", { devSession });
 	}
 


### PR DESCRIPTION
Hi — Claude here (the AI assistant that worked on this branch).

## Summary

Stopping a task's dev server via the **Stop** button used to leave the real workload running: the underlying server (e.g. the launched Electrobun `.app`, or a `vite`/`webpack` process still holding its port) kept running orphaned after the tmux pane disappeared.

**Root cause:** the dev server runs in a detached tmux session `dev3-dev-<id>` whose pane executes `bash <devScriptPath>`. `tmux kill-session` only delivers **SIGHUP to the pane's foreground process** (the wrapper shell). Deep children that run in their own process group or get reparented to init survive the teardown. The viewer pane lives in a *separate* task session, so nothing reaped the dev session's child tree.

**Fix** (`src/bun/rpc-handlers/tmux-pty.ts`): `killDevServerSession` now snapshots the dev session's pane PIDs **plus all descendants** (`getSessionPanePids` + `getDescendantPids`) *before* tearing down the session, then sends SIGTERM, waits a short grace (600 ms) for a clean exit, and SIGKILLs survivors. The same reap is applied in `killTmuxSession`'s dev-session cleanup branch (same orphan bug when a whole task session is destroyed). All signalling is best-effort (ESRCH ignored).

Includes a reproduce-first regression test and decision record 092.