### PR TITLE
fix: land on configured home surface when a task completes (not always split view)

### DIFF
--- a/change-logs/2026/06/26/fix-fullscreen-task-completion-returns-to-board.md
+++ b/change-logs/2026/06/26/fix-fullscreen-task-completion-returns-to-board.md
@@ -1,0 +1,1 @@
+Fixed completing a task jumping users to the wrong surface. Where you land after a task completes now follows your Task Open Mode: full-screen users return to the Kanban board (instead of being dumped into the split task view they never use), while split-view users stay in the split task view with the task deselected — even if they had temporarily zoomed the task to full screen.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -916,9 +916,11 @@ function App() {
 				// If the user is currently inside this task's view, leave it BEFORE the
 				// worktree is destroyed (otherwise TaskTerminal reacts to ptyDied /
 				// missing worktree and shows the "session ended / restart session"
-				// screen). Stay on the same surface: a task view collapses to "no task
-				// selected", a Kanban board is left untouched.
-				const dest = routeAfterTaskClosed(routeRef.current, taskId);
+				// screen). routeAfterTaskClosed sends the user back to their configured
+				// home surface: fullscreen open-mode → the board, split open-mode → the
+				// split task view (task deselected). A Kanban board is left untouched.
+				const openMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";
+				const dest = routeAfterTaskClosed(routeRef.current, taskId, openMode);
 				if (dest) navigate(dest);
 				dispatch({
 					type: "updateTask",
@@ -984,9 +986,11 @@ function App() {
 			}
 			if (approved) {
 				// Leave the task's view BEFORE the worktree is destroyed (same
-				// reasoning as the branch-merged flow above). Stay on the same
-				// surface: a task view collapses to "no task selected".
-				const dest = routeAfterTaskClosed(routeRef.current, taskId);
+				// reasoning as the branch-merged flow above). routeAfterTaskClosed sends
+				// the user to their configured home (fullscreen → board, split → split
+				// task view, deselected).
+				const openMode = localStorage.getItem("dev3-task-open-mode") === "fullscreen" ? "fullscreen" : "split";
+				const dest = routeAfterTaskClosed(routeRef.current, taskId, openMode);
 				if (dest) navigate(dest);
 				dispatch({ type: "clearBell", taskId });
 				trackEvent("task_moved", { to_status: "completed", agent_requested: true });

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -885,33 +885,44 @@ describe("routeTaskId", () => {
 });
 
 describe("routeAfterTaskClosed", () => {
-	it("collapses a full-page task view to task-view with no task selected", () => {
-		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "t9" }, "t9")).toEqual({
+	it("fullscreen open-mode: a full-page task view returns to the Kanban board (no split task list)", () => {
+		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "t9" }, "t9", "fullscreen")).toEqual({
+			screen: "project",
+			projectId: "p1",
+		});
+	});
+
+	it("split open-mode: deselects the task in a split task view", () => {
+		expect(
+			routeAfterTaskClosed({ screen: "project", projectId: "p1", taskView: true, activeTaskId: "t5" }, "t5", "split"),
+		).toEqual({ screen: "project", projectId: "p1", taskView: true });
+	});
+
+	it("split open-mode: a zoomed (full-page) task returns to the split task view, not the board", () => {
+		// A split-mode user can temporarily "zoom" a task to full-page (screen: "task").
+		// On completion they must land back in their split view, not the bare board.
+		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "t9" }, "t9", "split")).toEqual({
 			screen: "project",
 			projectId: "p1",
 			taskView: true,
 		});
 	});
 
-	it("deselects the task in a split task view", () => {
-		expect(
-			routeAfterTaskClosed({ screen: "project", projectId: "p1", taskView: true, activeTaskId: "t5" }, "t5"),
-		).toEqual({ screen: "project", projectId: "p1", taskView: true });
-	});
-
-	it("returns null on the bare Kanban board (no navigation)", () => {
-		expect(routeAfterTaskClosed({ screen: "project", projectId: "p1" }, "t9")).toBeNull();
+	it("returns null on the bare Kanban board (no navigation), regardless of open-mode", () => {
+		expect(routeAfterTaskClosed({ screen: "project", projectId: "p1" }, "t9", "split")).toBeNull();
+		expect(routeAfterTaskClosed({ screen: "project", projectId: "p1" }, "t9", "fullscreen")).toBeNull();
 	});
 
 	it("returns null when viewing a different task", () => {
-		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "other" }, "t9")).toBeNull();
+		expect(routeAfterTaskClosed({ screen: "task", projectId: "p1", taskId: "other" }, "t9", "fullscreen")).toBeNull();
 		expect(
-			routeAfterTaskClosed({ screen: "project", projectId: "p1", activeTaskId: "other" }, "t9"),
+			routeAfterTaskClosed({ screen: "project", projectId: "p1", activeTaskId: "other" }, "t9", "split"),
 		).toBeNull();
 	});
 
 	it("returns null for non-project screens", () => {
-		expect(routeAfterTaskClosed({ screen: "dashboard" }, "t9")).toBeNull();
+		expect(routeAfterTaskClosed({ screen: "dashboard" }, "t9", "split")).toBeNull();
+		expect(routeAfterTaskClosed({ screen: "dashboard" }, "t9", "fullscreen")).toBeNull();
 	});
 });
 

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -70,28 +70,37 @@ export function routeTaskId(route: Route): string | null {
 	return null;
 }
 
+/** The task open-mode preference (`dev3-task-open-mode`); "split" is the default. */
+export type TaskOpenMode = "split" | "fullscreen";
+
 /**
  * Where to land after `taskId` is completed/cancelled and its worktree is
- * destroyed. The point is to preserve the surface the user is on instead of
- * always dropping them onto the Kanban board:
+ * destroyed. The destination is driven by the user's *configured* open-mode,
+ * not the transient route, so each user lands back on the surface they live in:
  *
- *  - full-page task view of this task        → task split view, no task selected
- *  - split task view showing this task        → same split view, task deselected
- *  - anything else (Kanban, a different task) → no navigation (returns null)
+ *  - fullscreen open-mode → that project's Kanban board (their home surface)
+ *  - split open-mode      → the split task view with the task deselected
+ *                           (`{ screen: "project", taskView: true }`, no
+ *                           `activeTaskId`) — the "select a task" placeholder pane
+ *  - not viewing this task (Kanban, a different task) → null (don't navigate)
  *
- * Both task surfaces collapse to `{ screen: "project", taskView: true }` with
- * no `activeTaskId`, which renders the "select a task" placeholder pane — i.e.
- * "stay in task view, nothing selected". Returning null means the caller should
+ * Why gate on the preference and not the route: a full-page task view
+ * (`screen: "task"`) is reached both by fullscreen-mode users *and* by a
+ * split-mode user who temporarily "zoomed" a task. Fullscreen users have no
+ * split task list, so collapsing to `{ taskView: true }` would dump them into a
+ * layout (board columns / task-list sidebar on the left) they never use — they
+ * want the board. A split-mode user, even mid-zoom, should return to their
+ * split task view, not the bare board. Returning null means the caller should
  * not navigate at all (the completed card simply leaves the board).
  */
-export function routeAfterTaskClosed(route: Route, taskId: string): Route | null {
-	if (route.screen === "task" && route.taskId === taskId) {
-		return { screen: "project", projectId: route.projectId, taskView: true };
-	}
-	if (route.screen === "project" && route.activeTaskId === taskId) {
-		return { screen: "project", projectId: route.projectId, taskView: true };
-	}
-	return null;
+export function routeAfterTaskClosed(route: Route, taskId: string, openMode: TaskOpenMode): Route | null {
+	const viewingClosingTask =
+		(route.screen === "task" && route.taskId === taskId) ||
+		(route.screen === "project" && route.activeTaskId === taskId);
+	if (!viewingClosingTask) return null;
+	return openMode === "fullscreen"
+		? { screen: "project", projectId: route.projectId }
+		: { screen: "project", projectId: route.projectId, taskView: true };
 }
 
 /** The project id a route lands on, or null for project-less screens (dashboard, settings…). */


### PR DESCRIPTION
## Problem

When a task completed while the user was in the **full-page** task view, the screen jumped into the **split task view** (board columns / task-list sidebar on the left). `routeAfterTaskClosed` always collapsed to `{ screen: "project", taskView: true }`, assuming everyone uses the split task list. Full-screen open-mode users — who have no split task list — got dumped into a layout they never use.

## Fix

The post-completion destination now follows the user's configured **Task Open Mode** (`dev3-task-open-mode`) instead of the transient route:

- **Fullscreen** → the project's Kanban board (their home surface).
- **Split** → the split task view with the task deselected (the "select a task" placeholder).

Gating on the persisted preference rather than the route also handles a subtle case: a **split-mode** user can temporarily *zoom* a task to full-page (`screen: "task"`). On completion they now return to their split view, instead of bouncing to the board.

## Changes

- `src/mainview/state.ts` — `routeAfterTaskClosed(route, taskId, openMode)` now branches on `openMode`; added `TaskOpenMode` type.
- `src/mainview/App.tsx` — both completion handlers (branch-merged + agent-initiated) read `dev3-task-open-mode` and pass it in.
- `src/mainview/__tests__/state.test.ts` — covers fullscreen→board, split→deselect, and the zoomed-split→split edge case.
- Changelog entry.

## Testing

- `bun run lint` — green.
- Full mainview vitest suite — 1637/1637 passing.
- Empirical red/green: reverting only the fix makes the bug test fail with `+ "taskView": true`; the fix turns it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
