### PR TITLE
fix(dev-server): reap orphaned process tree via ps, not pgrep (.app quirk)

### DIFF
--- a/change-logs/2026/06/30/fix-dev-server-stop-orphan-reap.md
+++ b/change-logs/2026/06/30/fix-dev-server-stop-orphan-reap.md
@@ -1,0 +1,1 @@
+Fixed Stop (and Restart) leaving the dev server running: the process-tree reap used `pgrep -P`, which returns nothing when spawned from the packaged GUI `.app` (sandbox blocks its sysctl), so only the tmux pane was killed and the launched app stayed alive. Descendant collection now uses a single `ps` snapshot, reaping the whole tree.

--- a/decisions/095-dev-server-reap-uses-ps-not-pgrep.md
+++ b/decisions/095-dev-server-reap-uses-ps-not-pgrep.md
@@ -1,0 +1,52 @@
+# 095 — Reap the dev server tree via `ps`, not `pgrep` (`.app` quirk)
+
+## Context
+Even after [decision 092](092-dev-server-kill-process-tree.md) added a process-tree
+reap on **Stop**, the dev server's real workload kept running — pressing Stop removed
+the tmux pane but the launched Electrobun `.app` (and `bun run dev` and everything
+under it) stayed alive, reparented to launchd. The user reported the app "никуда не
+девается" after stopping the dev server.
+
+## Investigation
+Reproduced with a fresh build and instrumented `killDevServerSession`. The reap log
+showed `count: 1` — the snapshot captured **only the pane PID** (which `tmux
+kill-session` already SIGHUPs), so the entire subtree was never signalled. A
+side-by-side probe at the moment of Stop was decisive:
+
+```
+[DEVKILL] descendants pid=64270
+  viaPgrep (getDescendantPids, per-PID `pgrep -P`): []        ← EMPTY
+  viaPs (buildProcessTree + collectDescendants):  [8 pids]    ← FULL TREE
+```
+
+Root cause: `getDescendantPids` shelled out to `pgrep -P`, and **`pgrep` returns
+nothing when spawned from the packaged GUI `.app` process** (hardened runtime /
+sandbox blocks its `KERN_PROC_PPID` sysctl). `ps -eo pid,ppid` from the *same*
+process at the *same* instant returns the full table. Confirmed `pgrep` works fine
+from a plain `bun`/CLI process — the failure is specific to the `.app` runtime, which
+is exactly where `stopDevServer` runs. A `pgrep` BFS also truncates the whole subtree
+the moment any single spawn returns non-zero, so the failure is silent and total.
+
+## Decision
+In `src/bun/port-scanner.ts`, `getDescendantPids` now delegates to
+`collectDescendants(pid, buildProcessTree())` — a single `ps -eo pid,ppid` snapshot
+walked in memory. `pgrep` is removed entirely (it was a footgun for every caller in
+the `.app`). `collectDevServerTreePids` in `src/bun/rpc-handlers/tmux-pty.ts` builds
+the tree once via `buildProcessTree()` and walks each pane PID with
+`collectDescendants`. The `ps` walk also crosses the new process group Electrobun
+puts the launched app in (ppid links stay intact). Verified end-to-end: after Stop,
+the `dev-3.0-dev.app`, `bun run dev`, launcher and app-bun are all gone.
+
+## Risks
+- One `ps -eo pid,ppid` spawn per `getDescendantPids` call. Dev sessions have a
+  single pane, so the reap does one `ps`; negligible.
+- A child that re-parents to launchd *before* the snapshot still escapes — but the
+  snapshot runs before `kill-session` while the tree is intact, so in practice it is
+  complete (verified).
+
+## Alternatives considered
+- **Make `pgrep` reliable in the `.app`** — not possible from userspace; the sysctl
+  restriction is imposed by the runtime.
+- **Kill by process group (`kill -- -PGID`)** — Electrobun spawns the app in its own
+  process group, so a single PGID kill misses it; would need to collect multiple
+  groups. The `ps` ppid-walk catches everything in one pass, so this was unnecessary.

--- a/src/bun/__tests__/port-scanner.test.ts
+++ b/src/bun/__tests__/port-scanner.test.ts
@@ -154,31 +154,57 @@ describe("getDescendantPids", () => {
 		vi.clearAllMocks();
 	});
 
+	// getDescendantPids walks a single `ps -eo pid,ppid` snapshot (NOT `pgrep -P`,
+	// which returns nothing when spawned from the packaged GUI .app — see
+	// decision 095). The mocks below provide that one ps table.
+
 	it("returns children for a single level", () => {
-		mockSpawnSync
-			.mockReturnValueOnce(makeResult("200\n201\n"))
-			.mockReturnValueOnce(makeResult("", 1))
-			.mockReturnValueOnce(makeResult("", 1));
+		mockSpawnSync.mockReturnValue(makeResult("100 1\n200 100\n201 100\n"));
 
 		const result = getDescendantPids(100);
 		expect(result).toEqual([200, 201]);
 	});
 
 	it("returns empty for no children", () => {
-		mockSpawnSync.mockReturnValue(makeResult("", 1));
+		mockSpawnSync.mockReturnValue(makeResult("100 1\n"));
 
 		const result = getDescendantPids(100);
 		expect(result).toEqual([]);
 	});
 
 	it("handles deep nesting", () => {
-		mockSpawnSync
-			.mockReturnValueOnce(makeResult("200\n"))
-			.mockReturnValueOnce(makeResult("300\n"))
-			.mockReturnValueOnce(makeResult("", 1));
+		mockSpawnSync.mockReturnValue(makeResult("100 1\n200 100\n300 200\n"));
 
 		const result = getDescendantPids(100);
 		expect(result).toEqual([200, 300]);
+	});
+
+	it("collects a deep dev-server tree via ONE ps call, not pgrep (decision 095)", () => {
+		// Mirrors the real orphaned tree: bash → bun → electrobun → launcher →
+		// app-bun → caffeinate, where the app subtree is in a different process
+		// group. A `ps` walk must still capture every descendant.
+		mockSpawnSync.mockReturnValue(
+			makeResult(
+				[
+					"10 1", // pane: bash dev.sh
+					"20 10", // bun run dev
+					"30 20", // bash -c
+					"40 30", // node electrobun
+					"50 40", // electrobun bun (new process group)
+					"60 50", // launcher
+					"70 60", // app bun (main.js)
+					"80 70", // caffeinate
+				].join("\n") + "\n",
+			),
+		);
+
+		const result = getDescendantPids(10);
+		expect(result).toEqual([20, 30, 40, 50, 60, 70, 80]);
+		// Exactly one spawn — the ps snapshot. No per-PID pgrep fan-out.
+		expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+		const [argv] = mockSpawnSync.mock.calls[0];
+		expect(argv[0]).toBe("ps");
+		expect(argv).not.toContain("pgrep");
 	});
 });
 
@@ -327,16 +353,18 @@ describe("collectTaskPids", () => {
 		vi.clearAllMocks();
 	});
 
+	// The fallback path (no processTree arg) resolves descendants through
+	// getDescendantPids, which now reads ONE `ps -eo pid,ppid` snapshot per pane
+	// PID instead of per-PID `pgrep` (decision 095).
+
 	it("returns pane PIDs plus descendants", () => {
 		mockSpawnSync
 			// tmux list-panes for main session
 			.mockReturnValueOnce(makeResult("100\n"))
 			// tmux list-panes for dev server session (none)
 			.mockReturnValueOnce(makeResult("", 1))
-			// pgrep -P 100
-			.mockReturnValueOnce(makeResult("200\n"))
-			// pgrep -P 200
-			.mockReturnValueOnce(makeResult("", 1));
+			// ps snapshot for getDescendantPids(100) → child 200
+			.mockReturnValueOnce(makeResult("100 1\n200 100\n"));
 
 		const pids = collectTaskPids("dev3", "dev3-abc12345");
 		expect(pids).toEqual(new Set([100, 200]));
@@ -354,14 +382,10 @@ describe("collectTaskPids", () => {
 			.mockReturnValueOnce(makeResult("100\n"))
 			// tmux list-panes for dev3-dev-abc12345 (dev server session)
 			.mockReturnValueOnce(makeResult("500\n"))
-			// pgrep -P 100
-			.mockReturnValueOnce(makeResult("200\n"))
-			// pgrep -P 200
-			.mockReturnValueOnce(makeResult("", 1))
-			// pgrep -P 500
-			.mockReturnValueOnce(makeResult("600\n"))
-			// pgrep -P 600
-			.mockReturnValueOnce(makeResult("", 1));
+			// ps snapshot for getDescendantPids(100) → child 200
+			.mockReturnValueOnce(makeResult("100 1\n200 100\n500 1\n600 500\n"))
+			// ps snapshot for getDescendantPids(500) → child 600
+			.mockReturnValueOnce(makeResult("100 1\n200 100\n500 1\n600 500\n"));
 
 		const pids = collectTaskPids("dev3", "dev3-abc12345");
 		expect(pids).toEqual(new Set([100, 200, 500, 600]));
@@ -379,8 +403,8 @@ describe("collectTaskPids", () => {
 		mockSpawnSync
 			// tmux list-panes for dev3-dev-abc12345
 			.mockReturnValueOnce(makeResult("500\n"))
-			// pgrep -P 500
-			.mockReturnValueOnce(makeResult("", 1));
+			// ps snapshot for getDescendantPids(500) — no children
+			.mockReturnValueOnce(makeResult("500 1\n"));
 
 		const pids = collectTaskPids("dev3", "dev3-dev-abc12345");
 		expect(pids).toEqual(new Set([500]));
@@ -398,8 +422,8 @@ describe("collectTaskPids", () => {
 			.mockReturnValueOnce(makeResult("100\n"))
 			// tmux list-panes for dev3-dev-abc12345 (no session → exit 1)
 			.mockReturnValueOnce(makeResult("", 1))
-			// pgrep -P 100
-			.mockReturnValueOnce(makeResult("", 1));
+			// ps snapshot for getDescendantPids(100) — no children
+			.mockReturnValueOnce(makeResult("100 1\n"));
 
 		const pids = collectTaskPids("dev3", "dev3-abc12345");
 		expect(pids).toEqual(new Set([100]));
@@ -443,10 +467,8 @@ describe("scanTaskPorts", () => {
 			.mockReturnValueOnce(makeResult("100\n"))
 			// tmux list-panes for dev server session (none)
 			.mockReturnValueOnce(makeResult("", 1))
-			// pgrep -P 100 (descendants)
-			.mockReturnValueOnce(makeResult("200\n"))
-			// pgrep -P 200 (no more descendants)
-			.mockReturnValueOnce(makeResult("", 1))
+			// ps snapshot for getDescendantPids(100) → child 200
+			.mockReturnValueOnce(makeResult("100 1\n200 100\n"))
 			// lsof
 			.mockReturnValueOnce(makeResult("p200\ncnode\nn*:3000\n"));
 
@@ -462,15 +484,15 @@ describe("scanTaskPorts", () => {
 			.mockReturnValueOnce(makeResult("100\n"))
 			// tmux list-panes for dev server session (none)
 			.mockReturnValueOnce(makeResult("", 1))
-			// pgrep -P 100
-			.mockReturnValueOnce(makeResult("", 1));
+			// ps snapshot for getDescendantPids(100) — no children
+			.mockReturnValueOnce(makeResult("100 1\n"));
 
 		const lsofOutput = "p100\ncbun\nn*:8080\n";
 		const result = scanTaskPorts("dev3", "dev3-abc12345", lsofOutput);
 		expect(result).toEqual([
 			{ port: 8080, pid: 100, processName: "bun" },
 		]);
-		// tmux list-panes (main) + tmux list-panes (dev) + pgrep = 3 calls
+		// tmux list-panes (main) + tmux list-panes (dev) + ps = 3 calls
 		expect(mockSpawnSync).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5378,12 +5378,14 @@ describe("handlers.stopDevServer", () => {
 
 		const enc = (s: string) => new TextEncoder().encode(s);
 		// dev session pane pid = 1111, with children 2222 and 3333 (no grandchildren).
+		// Descendants are collected from a single `ps -eo pid,ppid` snapshot, not
+		// `pgrep -P` (which returns nothing from the packaged .app — decision 095).
 		mockSpawnSync.mockImplementation((args: string[]) => {
 			if (args.includes("list-panes") && args.includes("dev3-dev-abcd1234")) {
 				return { exitCode: 0, stdout: enc("1111\n") };
 			}
-			if (args[0] === "pgrep" && args.includes("1111")) {
-				return { exitCode: 0, stdout: enc("2222\n3333\n") };
+			if (args[0] === "ps") {
+				return { exitCode: 0, stdout: enc("1111 1\n2222 1111\n3333 1111\n") };
 			}
 			return { exitCode: 1, stdout: enc("") };
 		});

--- a/src/bun/port-scanner.ts
+++ b/src/bun/port-scanner.ts
@@ -87,30 +87,16 @@ export function getSessionPanePids(socket: string, sessionName: string): number[
 }
 
 /**
- * Recursively get all descendant PIDs of a given PID using pgrep.
+ * Recursively get all descendant PIDs of a given PID.
+ *
+ * Built on a single `ps -eo pid,ppid` snapshot (via {@link buildProcessTree}),
+ * NOT `pgrep -P`. `pgrep` returns nothing when spawned from the packaged GUI
+ * `.app` (its KERN_PROC_PPID sysctl is blocked under the hardened runtime /
+ * sandbox), whereas `ps` enumerates the full table unaffected. Using `pgrep`
+ * here silently orphaned the dev-server process tree on Stop. See decision 095.
  */
 export function getDescendantPids(pid: number): number[] {
-	const descendants: number[] = [];
-	const queue = [pid];
-	while (queue.length > 0) {
-		const current = queue.shift()!;
-		try {
-			const result = spawnSync(["pgrep", "-P", String(current)]);
-			if (result.exitCode !== 0) continue;
-			const output = decoder.decode(result.stdout).trim();
-			if (!output) continue;
-			for (const line of output.split("\n")) {
-				const childPid = parseInt(line.trim(), 10);
-				if (!isNaN(childPid)) {
-					descendants.push(childPid);
-					queue.push(childPid);
-				}
-			}
-		} catch {
-			// ignore
-		}
-	}
-	return descendants;
+	return collectDescendants(pid, buildProcessTree());
 }
 
 /**
@@ -225,7 +211,7 @@ export function collectDescendants(pid: number, tree: Map<number, number[]>): nu
  * if one exists, so that ports opened by `runDevServer` are detected.
  *
  * When `processTree` is provided, uses in-memory BFS (no extra spawns).
- * Otherwise falls back to per-PID `pgrep -P` calls.
+ * Otherwise falls back to {@link getDescendantPids} (one `ps` snapshot per pane).
  */
 export function collectTaskPids(socket: string, sessionName: string, processTree?: Map<number, number[]>): Set<number> {
 	const panePids = getSessionPanePids(socket, sessionName);

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -6,7 +6,7 @@ import * as pty from "../pty-server";
 import * as agents from "../agents";
 import * as portPool from "../port-pool";
 import * as repoConfig from "../repo-config";
-import { getDescendantPids, getPortsForTask, getSessionPanePids, scanTaskPorts } from "../port-scanner";
+import { buildProcessTree, collectDescendants, getPortsForTask, getSessionPanePids, scanTaskPorts } from "../port-scanner";
 import { getResourceUsage } from "../resource-monitor";
 import { loadSettings } from "../settings";
 import { getUserShell } from "../shell-env";
@@ -72,10 +72,20 @@ const DEV_SERVER_KILL_GRACE_MS = 600;
 function collectDevServerTreePids(devSession: string, socket: string): number[] {
 	const panePids = getSessionPanePids(socket, devSession);
 	if (panePids.length === 0) return [];
+	// Walk the descendant tree from a SINGLE `ps -eo pid,ppid` snapshot rather
+	// than per-PID `pgrep -P`. When spawned from the packaged GUI `.app`,
+	// `pgrep` returns nothing (its KERN_PROC_PPID sysctl is blocked under the
+	// hardened runtime / sandbox), while `ps` is unaffected. With `pgrep`, the
+	// reap captured ONLY the pane PID (which `tmux kill-session` already SIGHUPs)
+	// and orphaned the entire dev-server tree — the Electrobun `.app` (and any
+	// vite/webpack) kept running after Stop. A `ps`-based walk also crosses the
+	// process-group boundary Electrobun creates for the launched app. See
+	// decision 095.
+	const processTree = buildProcessTree();
 	const tree = new Set<number>();
 	for (const pid of panePids) {
 		tree.add(pid);
-		for (const child of getDescendantPids(pid)) tree.add(child);
+		for (const child of collectDescendants(pid, processTree)) tree.add(child);
 	}
 	return [...tree];
 }


### PR DESCRIPTION
## Summary

Stopping (or restarting) a task's dev server removed the tmux pane but left the real workload running — the launched Electrobun `.app`, `bun run dev`, and the `launcher` kept running as orphans (reparented to launchd).

**Root cause (confirmed with instrumented logs, not a guess):** the orphan reap added in #755 collected the descendant tree through `getDescendantPids`, which shelled out to `pgrep -P`. `pgrep` returns **nothing** when spawned from the packaged GUI `.app` process — the hardened runtime / sandbox blocks its `KERN_PROC_PPID` sysctl — while `ps -eo pid,ppid` from the same process at the same instant returns the full table. So the reap captured only the pane PID (`count:1` in the logs), which `tmux kill-session` had already SIGHUP'd, and the entire app subtree survived. `pgrep` works fine from a plain `bun`/CLI process, which is why it was missed — the failure is specific to the `.app` runtime, exactly where `stopDevServer` runs.

Observed in the instrumented build:
```
[DEVKILL] descendants pid=64270
  viaPgrep: []                                ← old method, empty
  viaPs:    [64280,64281,...,65733,65964]     ← ps snapshot, full 8-process tree
```

## Fix

- `getDescendantPids` now delegates to `collectDescendants(buildProcessTree())` — a single `ps -eo pid,ppid` snapshot walked in memory. `pgrep` is removed from all code paths (it was a footgun for every in-`.app` caller). The `ps` walk also crosses the separate process group Electrobun puts the launched app in.
- `collectDevServerTreePids` builds the tree once and walks each pane PID with `collectDescendants`.

Verified end-to-end on a build from this branch: after Stop, `dev-3.0-dev.app`, `bun run dev`, the launcher and the app-bun are all gone (only the unrelated host app survives). Tests + lint green. See `decisions/095-dev-server-reap-uses-ps-not-pgrep.md`.