### PR TITLE
fix(setup): shell-portable read in setup pane close prompt

### DIFF
--- a/change-logs/2026/07/02/fix-setup-pane-zsh-read.md
+++ b/change-logs/2026/07/02/fix-setup-pane-zsh-read.md
@@ -1,0 +1,1 @@
+Fixed the task setup pane crashing with "not an identifier: -s" when pressing a key at the "press any key to close" prompt. The bash-only `read -n 1 -s` was running under zsh; replaced it with a shell-portable read that branches on `$ZSH_VERSION`.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -283,6 +283,7 @@ const {
 	setActiveContext,
 	emitTaskSound,
 	runCleanupScript,
+	portableReadKey,
 } = await import("../rpc-handlers");
 
 // ---- Test helpers ----
@@ -800,6 +801,34 @@ describe("buildCmdScript", () => {
 	it("does not include onExitCommand when not provided", () => {
 		const result = buildCmdScript("claude", undefined, { keepShell: true });
 		expect(result).not.toContain("dev3 task move");
+	});
+});
+
+// ================================================================
+// portableReadKey
+// ================================================================
+
+describe("portableReadKey", () => {
+	// Regression for the setup pane crash: the wrapper carries a #!/bin/bash
+	// shebang but runs under the user's login shell (usually zsh). A bare
+	// `read -t 15 -n 1 -s` makes zsh die with "not an identifier: -s".
+	it("branches on $ZSH_VERSION so it is safe under both bash and zsh", () => {
+		const snippet = portableReadKey({ timeoutSeconds: 15 });
+		expect(snippet).toContain('[ -n "$ZSH_VERSION" ]');
+		// zsh spells "read N chars" as -k, bash as -n
+		expect(snippet).toContain("read -t 15 -k 1 -s");
+		expect(snippet).toContain("read -t 15 -n 1 -s");
+	});
+
+	it("is a single line (safe to inline in a wrapper script)", () => {
+		expect(portableReadKey({ timeoutSeconds: 15 })).not.toContain("\n");
+	});
+
+	it("omits the timeout flag when no timeout is given", () => {
+		const snippet = portableReadKey();
+		expect(snippet).not.toContain("-t ");
+		expect(snippet).toContain("read -k 1 -s");
+		expect(snippet).toContain("read -n 1 -s");
 	});
 });
 

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -2,6 +2,7 @@ export {
 	escapeForDoubleQuotes,
 	shellQuote,
 	buildEnvExports,
+	portableReadKey,
 	buildCmdScript,
 	setPushMessage,
 	getPushMessage,

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -41,6 +41,21 @@ export function buildEnvExports(env: Record<string, string>): string[] {
 	return Object.entries(env).map(([key, value]) => `export ${key}=${shellQuote(value)}`);
 }
 
+/**
+ * Emit a shell-portable "read a single keypress silently" snippet.
+ *
+ * The setup/startup wrapper scripts carry a `#!/bin/bash` shebang but are
+ * executed via the user's login shell (`buildScriptRunnerCommand` → `zsh script`,
+ * shebang ignored). bash-only `read -n 1 -s` then breaks under zsh with
+ * "not an identifier: -s", because zsh spells "read N chars" as `-k N` (not `-n N`).
+ * Branch on `$ZSH_VERSION` so the snippet works under both shells.
+ */
+export function portableReadKey(options?: { timeoutSeconds?: number }): string {
+	const t = options?.timeoutSeconds;
+	const timeout = typeof t === "number" ? `-t ${t} ` : "";
+	return `if [ -n "$ZSH_VERSION" ]; then read ${timeout}-k 1 -s; else read ${timeout}-n 1 -s; fi`;
+}
+
 export function buildCmdScript(
 	tmuxCmd: string,
 	env?: Record<string, string>,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -6,6 +6,7 @@ export {
 	getScriptShellPath,
 	buildScriptRunnerCommand,
 	buildEnvExports,
+	portableReadKey,
 	buildCmdScript,
 	resolveBinaryPath,
 	setPushMessage,

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -12,7 +12,7 @@ import { loadSettings } from "../settings";
 import { getUserShell } from "../shell-env";
 import { spawn } from "../spawn";
 import { setupAgentHooks } from "../agent-hooks";
-import { isActive, buildAgentEnv, buildCmdScript, buildEnvExports, buildScriptRunnerCommand, buildTaskLifecycleEnv, escapeForDoubleQuotes, log, resolveBinaryPath, shellQuote } from "./shared-pure";
+import { isActive, buildAgentEnv, buildCmdScript, buildEnvExports, buildScriptRunnerCommand, buildTaskLifecycleEnv, escapeForDoubleQuotes, log, portableReadKey, resolveBinaryPath, shellQuote } from "./shared-pure";
 import { resolveOperationalProjectConfig } from "./settings-config";
 
 const devViewerPaneIds = new Map<string, string>();
@@ -417,7 +417,9 @@ export async function launchTaskPty(
 		const setupOkClose = [
 			"printf '\\033[1;32m✓ Setup done\\033[0m\\n'",
 			"printf '\\033[2mClosing in 15s — press any key to close now\\033[0m\\n'",
-			"read -t 15 -n 1 -s",
+			// Wrapper runs under the user's login shell (often zsh), so use a
+			// shell-portable read — bash's `read -n 1 -s` crashes zsh.
+			portableReadKey({ timeoutSeconds: 15 }),
 			"exit 0",
 		].join("\n");
 


### PR DESCRIPTION
## Summary

The task setup pane crashed with `not an identifier: -s` and `✗ Process exited with code 1` whenever the user pressed a key at the `Closing in 15s — press any key to close now` prompt — even on a fully successful setup.

**Root cause:** the setup/startup wrapper scripts carry a `#!/bin/bash` shebang but are executed via the user's login shell (`buildScriptRunnerCommand` → `zsh script`), so the shebang is ignored. The bash-only `read -t 15 -n 1 -s` then runs under zsh, which spells "read N chars" as `-k N` (not `-n N`) and dies on the `-s` token.

**Fix:** add a `portableReadKey()` helper (in `shared-pure.ts`) that branches on `$ZSH_VERSION` — `read -t 15 -k 1 -s` under zsh, `read -t 15 -n 1 -s` under bash — and use it in the setup wrapper. The `git-operations.ts` and dev-server wrappers launch via `bash "$script"` explicitly, so their `read -n 1 -s` is unaffected and left untouched.

Added unit tests for `portableReadKey()`; full test suite and lint are green.