### PR TITLE
Restore last route across app restarts (quit/reboot/update)

### DIFF
--- a/change-logs/2026/07/02/fix-restore-last-route.md
+++ b/change-logs/2026/07/02/fix-restore-last-route.md
@@ -1,0 +1,1 @@
+Restore the last route (project/task/screen) across app restarts — quit, reboot, and auto-update — not just the window position. The current route is persisted to ~/.dev3.0/last-route.json (debounced on navigation) and reopened at launch, falling back to the dashboard if the saved project no longer exists.

--- a/src/bun/__tests__/data-last-route.test.ts
+++ b/src/bun/__tests__/data-last-route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test-last-route",
+}));
+
+vi.mock("../file-lock", () => ({
+	withFileLock: async <T>(_filePath: string, fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+beforeEach(() => {
+	rmSync("/tmp/dev3-test-last-route", { recursive: true, force: true });
+	mkdirSync("/tmp/dev3-test-last-route", { recursive: true });
+});
+
+import { saveLastRoute, loadLastRoute } from "../data";
+
+const LAST_ROUTE_FILE = "/tmp/dev3-test-last-route/last-route.json";
+
+describe("last route persistence", () => {
+	it("returns null when no route has been saved", async () => {
+		expect(await loadLastRoute()).toBeNull();
+	});
+
+	it("persists a saved route and reads it back", async () => {
+		const route = JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" });
+		await saveLastRoute(route);
+		expect(existsSync(LAST_ROUTE_FILE)).toBe(true);
+		expect(await loadLastRoute()).toBe(route);
+	});
+
+	it("does NOT clear the route on read — survives repeated launches", async () => {
+		// Regression: the old update-route helper cleared the file on read, so a
+		// second restart (quit → reboot) lost the route. It must persist until
+		// the next navigation overwrites it.
+		const route = JSON.stringify({ screen: "project", projectId: "p1" });
+		await saveLastRoute(route);
+
+		expect(await loadLastRoute()).toBe(route);
+		expect(await loadLastRoute()).toBe(route);
+		expect(existsSync(LAST_ROUTE_FILE)).toBe(true);
+	});
+
+	it("overwrites the previous route on the next save", async () => {
+		await saveLastRoute(JSON.stringify({ screen: "dashboard" }));
+		const next = JSON.stringify({ screen: "settings" });
+		await saveLastRoute(next);
+		expect(await loadLastRoute()).toBe(next);
+	});
+});

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1142,23 +1142,27 @@ export async function resetTipState(): Promise<TipState> {
 	});
 }
 
-// ---- Update Route (persisted across app restarts for auto-update) ----
+// ---- Last Route (persisted across every app restart: quit, reboot, update) ----
+//
+// The renderer persists the current route here (debounced on navigation) so the
+// app reopens on the surface the user last had open, mirroring the window
+// position restore. Unlike a one-shot update handoff, this file is NOT cleared
+// on read — it always reflects the last known route until the next navigation
+// overwrites it.
 
-const UPDATE_ROUTE_FILE = `${DEV3_HOME}/update-route.json`;
+const LAST_ROUTE_FILE = `${DEV3_HOME}/last-route.json`;
 
-export async function saveUpdateRoute(route: string): Promise<void> {
-	await ensureDir(UPDATE_ROUTE_FILE);
-	await Bun.write(UPDATE_ROUTE_FILE, route);
+export async function saveLastRoute(route: string): Promise<void> {
+	await ensureDir(LAST_ROUTE_FILE);
+	await writeFile(LAST_ROUTE_FILE, route, "utf-8");
 }
 
-export async function loadAndClearUpdateRoute(): Promise<string | null> {
+export async function loadLastRoute(): Promise<string | null> {
 	try {
-		const file = Bun.file(UPDATE_ROUTE_FILE);
-		if (!(await file.exists())) return null;
-		const data = await file.text();
-		await unlink(UPDATE_ROUTE_FILE);
+		const data = await readFile(LAST_ROUTE_FILE, "utf-8");
 		return data || null;
 	} catch {
+		// Missing/unreadable file — no route to restore.
 		return null;
 	}
 }

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -178,14 +178,14 @@ async function applyUpdate(): Promise<void> {
 	await updater.applyUpdate();
 }
 
-async function saveUpdateRoute({ route }: { route: string }): Promise<void> {
-	log.info("-> saveUpdateRoute");
-	await data.saveUpdateRoute(route);
+async function saveLastRoute({ route }: { route: string }): Promise<void> {
+	log.info("-> saveLastRoute");
+	await data.saveLastRoute(route);
 }
 
-async function getUpdateRoute(): Promise<{ route: string | null }> {
-	log.info("-> getUpdateRoute");
-	const route = await data.loadAndClearUpdateRoute();
+async function getLastRoute(): Promise<{ route: string | null }> {
+	log.info("-> getLastRoute");
+	const route = await data.loadLastRoute();
 	return { route };
 }
 
@@ -330,8 +330,8 @@ export const settingsConfigHandlers = {
 	checkForUpdate,
 	downloadUpdate,
 	applyUpdate,
-	saveUpdateRoute,
-	getUpdateRoute,
+	saveLastRoute,
+	getLastRoute,
 	getAppVersion,
 	checkSystemRequirements,
 	checkGhAvailable,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -263,6 +263,28 @@ function App() {
 		routeRef.current = state.route;
 	}, [state.route]);
 
+	// Route persistence is enabled only after the initial restore attempt has
+	// run (see the projects-load effect). Without this gate, the bootstrap
+	// dashboard render would immediately overwrite the persisted last route
+	// before we get a chance to read it back.
+	const routePersistEnabledRef = useRef(false);
+
+	// Persist the current route (debounced) so the app reopens on the same
+	// surface after any restart — quit, reboot, or auto-update — mirroring the
+	// window position restore. Read back once at launch by the projects-load
+	// effect below.
+	useEffect(() => {
+		if (!routePersistEnabledRef.current) return;
+		const route = state.route;
+		const id = setTimeout(() => {
+			api.request.saveLastRoute({ route: JSON.stringify(route) }).catch(() => {
+				// Best-effort persistence — a failed write just means the next
+				// launch falls back to the previous saved route (or dashboard).
+			});
+		}, 400);
+		return () => clearTimeout(id);
+	}, [state.route]);
+
 	// Close the task-hint overlay on any navigation so it never lingers with
 	// detached card references (e.g. after a hint commits or an async route change).
 	useEffect(() => {
@@ -799,18 +821,29 @@ function App() {
 				const projects = await api.request.getProjects();
 				dispatch({ type: "setProjects", projects });
 
-				// Restore route saved before an update restart
+				// Restore the last route the user was on (persisted across quit,
+				// reboot, and update restarts). Guard against a stale project route
+				// whose project no longer exists — fall back to the dashboard.
 				try {
-					const { route: savedRoute } = await api.request.getUpdateRoute();
+					const { route: savedRoute } = await api.request.getLastRoute();
 					if (savedRoute) {
 						const route = JSON.parse(savedRoute) as Route;
-						dispatch({ type: "navigate", route });
+						const projectId = projectIdForRoute(route);
+						const projectExists =
+							!projectId || projects.some((p) => p.id === projectId && !p.deleted);
+						if (projectExists && route.screen !== "dashboard") {
+							dispatch({ type: "navigate", route });
+						}
 					}
 				} catch {
-					// Ignore — file may not exist or be malformed
+					// Ignore — file may not exist or be malformed.
 				}
 			} catch (err) {
 				console.error("Failed to load projects:", err);
+			} finally {
+				// Enable route persistence now that the restore attempt is done,
+				// so subsequent navigations (and the restored route) are saved.
+				routePersistEnabledRef.current = true;
 			}
 			dispatch({ type: "setLoading", loading: false });
 		})();

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -11,7 +11,8 @@ vi.mock("../rpc", () => ({
 			checkSystemRequirements: vi.fn().mockResolvedValue([]),
 			checkGhAvailable: vi.fn().mockResolvedValue({ available: true, notInstalled: false }),
 			getProjects: vi.fn().mockResolvedValue([]),
-			getUpdateRoute: vi.fn().mockResolvedValue({ route: null }),
+			getLastRoute: vi.fn().mockResolvedValue({ route: null }),
+			saveLastRoute: vi.fn().mockResolvedValue(undefined),
 			quitApp: vi.fn().mockResolvedValue(undefined),
 			requestQuit: vi.fn().mockResolvedValue(undefined),
 			consumePendingQuitDialog: vi.fn().mockResolvedValue(false),
@@ -159,7 +160,7 @@ describe("App keyboard shortcuts", () => {
 		vi.clearAllMocks();
 		vi.mocked(api.request.checkSystemRequirements).mockResolvedValue([]);
 		vi.mocked(api.request.getProjects).mockResolvedValue([]);
-		vi.mocked(api.request.getUpdateRoute).mockResolvedValue({ route: null });
+		vi.mocked(api.request.getLastRoute).mockResolvedValue({ route: null });
 		vi.mocked(api.request.listTmuxSessions).mockResolvedValue([]);
 	});
 
@@ -283,7 +284,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("preserves task view: Cmd+2 from a task switches project and keeps task-view layout with no task selected", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
 			});
 
@@ -302,7 +303,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("preserves task view from the full-page task screen too", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -318,7 +319,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("keeps board view: Cmd+2 from the Kanban board switches project without task view", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1" }),
 			});
 
@@ -338,7 +339,7 @@ describe("App keyboard shortcuts", () => {
 		it("fullscreen open-mode: Cmd+2 from a task jumps to the board, not an empty split", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
 			});
 
@@ -356,7 +357,7 @@ describe("App keyboard shortcuts", () => {
 		it("fullscreen open-mode: Cmd+2 from the full-page task screen jumps to the board", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -368,6 +369,62 @@ describe("App keyboard shortcuts", () => {
 			const after = screen.getByTestId("project-screen");
 			expect(after).toHaveAttribute("data-project-id", "p2");
 			expect(after).toHaveAttribute("data-task-view", "false");
+		});
+	});
+
+	describe("route restore on launch", () => {
+		const oneProject = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+
+		it("restores the saved project route on launch", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-project-id", "p1");
+			expect(screen.queryByTestId("dashboard-screen")).not.toBeInTheDocument();
+		});
+
+		it("falls back to the dashboard when the saved project no longer exists", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([]); // p1 was completed/removed
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+
+			await renderApp();
+
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+			expect(screen.queryByTestId("task-screen")).not.toBeInTheDocument();
+		});
+
+		it("restores a non-project screen (settings)", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "settings" }),
+			});
+
+			await renderApp();
+
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+		});
+
+		it("persists the current route to disk on navigation", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({ route: null });
+
+			await renderApp();
+			await userEvent.keyboard("{Meta>},{/Meta}");
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+
+			await waitFor(() =>
+				expect(api.request.saveLastRoute).toHaveBeenCalledWith({
+					route: JSON.stringify({ screen: "settings" }),
+				}),
+			);
 		});
 	});
 
@@ -383,7 +440,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("from the board: Cmd+Shift+2 switches project and opens task view", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1" }),
 			});
 
@@ -402,7 +459,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("from a task: Cmd+Shift+2 switches project and drops to the board", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
 			});
 
@@ -419,7 +476,7 @@ describe("App keyboard shortcuts", () => {
 
 		it("from the full-page task screen: Cmd+Shift+2 drops to the board", async () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -436,7 +493,7 @@ describe("App keyboard shortcuts", () => {
 		it("ignores open-mode: from the board in fullscreen mode it still opens task view", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "project", projectId: "p1" }),
 			});
 
@@ -470,7 +527,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -487,7 +544,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -548,7 +605,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -564,7 +621,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -583,7 +640,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 
@@ -894,7 +951,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 			vi.mocked(confirm).mockResolvedValue(true);
@@ -922,7 +979,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 			vi.mocked(confirm).mockResolvedValue(false);
@@ -945,7 +1002,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t2" }),
 			});
 			vi.mocked(confirm).mockResolvedValue(true);
@@ -980,7 +1037,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 			vi.mocked(confirm).mockResolvedValue(true);
@@ -1007,7 +1064,7 @@ describe("App keyboard shortcuts", () => {
 			vi.mocked(api.request.getProjects).mockResolvedValue([
 				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
 			]);
-			vi.mocked(api.request.getUpdateRoute).mockResolvedValue({
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
 				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
 			});
 			vi.mocked(confirm).mockResolvedValue(false);

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -172,7 +172,11 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 			countdownRef.current = null;
 		}
 		try {
-			await api.request.saveUpdateRoute({ route: JSON.stringify(route) });
+			// Belt-and-suspenders: the route is already persisted (debounced) on
+			// every navigation, but flush the exact current route synchronously
+			// here so an update triggered right after a navigation still restores
+			// to the correct surface.
+			await api.request.saveLastRoute({ route: JSON.stringify(route) });
 			await api.request.applyUpdate();
 		} catch {
 			setRestarting(false);

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -10,7 +10,7 @@ vi.mock("../../rpc", () => ({
 		request: {
 			getTasks: vi.fn(),
 			applyUpdate: vi.fn(),
-			saveUpdateRoute: vi.fn(),
+			saveLastRoute: vi.fn(),
 			renameTask: vi.fn(),
 			getProjectCurrentBranch: vi.fn().mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false }),
 			pullProjectMain: vi.fn(),
@@ -483,7 +483,7 @@ describe("GlobalHeader — update countdown", () => {
 		vi.useFakeTimers();
 		mockedApi.request.getTasks.mockResolvedValue([]);
 		mockedApi.request.applyUpdate.mockResolvedValue(undefined as any);
-		mockedApi.request.saveUpdateRoute.mockResolvedValue(undefined as any);
+		mockedApi.request.saveLastRoute.mockResolvedValue(undefined as any);
 	});
 
 	afterEach(() => {
@@ -553,7 +553,7 @@ describe("GlobalHeader — update countdown", () => {
 		);
 
 		act(() => { vi.advanceTimersByTime(300_000); });
-		// Flush the async handleRestart (saveUpdateRoute → applyUpdate)
+		// Flush the async handleRestart (saveLastRoute → applyUpdate)
 		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
 
 		expect(mockedApi.request.applyUpdate).toHaveBeenCalled();
@@ -570,7 +570,7 @@ describe("GlobalHeader — update countdown", () => {
 
 		act(() => { vi.advanceTimersByTime(300_000); });
 
-		expect(mockedApi.request.saveUpdateRoute).toHaveBeenCalledWith({
+		expect(mockedApi.request.saveLastRoute).toHaveBeenCalledWith({
 			route: JSON.stringify({ screen: "project", projectId: "p1" }),
 		});
 	});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1658,11 +1658,11 @@ export type AppRPCSchema = {
 				params: void;
 				response: void;
 			};
-			saveUpdateRoute: {
+			saveLastRoute: {
 				params: { route: string };
 				response: void;
 			};
-			getUpdateRoute: {
+			getLastRoute: {
 				params: void;
 				response: { route: string | null };
 			};


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

After the recent window screen/position restore (#769), the app reopens on the correct display but always lands on the dashboard — it doesn't return to the project/task/screen the user last had open. The route was never persisted; the only route handoff was the one-shot `update-route` file, used exclusively for the auto-update restart.

## What changed

- Generalize the one-shot update-route into a persistent **last route** stored at `~/.dev3.0/last-route.json` (sibling of `window-state.json`).
- The renderer saves the current route (debounced on navigation) and restores it at launch, so the app reopens where the user left off across **quit, reboot, and auto-update**.
- Guard against stale routes: if the saved route points at a project that no longer exists, fall back to the dashboard.
- Persistence is gated until the launch restore has run, so the bootstrap dashboard render can't clobber the saved route before it's read back.
- Rename `saveUpdateRoute`/`getUpdateRoute` → `saveLastRoute`/`getLastRoute` and switch the data helpers from `Bun.write`/`Bun.file` to node `fs` so they're covered by tests (Bun.* file writes silently no-op in the vitest worker).
- `GlobalHeader` still flushes the exact route synchronously before applying an update, as a belt-and-suspenders on top of the debounced save.

## Tests

- New `data-last-route.test.ts`: persistence, read-does-not-clear regression, overwrite-on-save.
- New App-level tests: restore on launch, fallback to dashboard when the project is gone, restore a non-project screen, and persist-on-navigation.
- Full suite green (`bun run test`), lint clean.
