### PR TITLE
Include project-local skills in New Task autocomplete

### DIFF
--- a/change-logs/2026/07/02/fix-project-local-skills-autocomplete.md
+++ b/change-logs/2026/07/02/fix-project-local-skills-autocomplete.md
@@ -1,0 +1,1 @@
+Fixed the New Task slash-command autocomplete so it now also lists project-local skills (`.agents/.claude/.codex/skills` inside the repo, e.g. `/debug-ui`), not only the global ones under the home directory. A project-local skill wins over a same-named global one.

--- a/src/bun/__tests__/skills-catalog.test.ts
+++ b/src/bun/__tests__/skills-catalog.test.ts
@@ -31,21 +31,32 @@ describe("parseSkillFrontmatter", () => {
 
 describe("listAgentSkills", () => {
 	let home: string;
+	let project: string;
 
 	beforeEach(() => {
 		home = mkdtempSync(join(tmpdir(), "dev3-skills-test-"));
+		project = mkdtempSync(join(tmpdir(), "dev3-skills-proj-"));
 	});
 
 	afterEach(() => {
 		rmSync(home, { recursive: true, force: true });
+		rmSync(project, { recursive: true, force: true });
 	});
 
-	function addSkill(dir: string, slug: string, frontmatter: string | null) {
-		const skillDir = join(home, dir, slug);
+	function addSkillIn(base: string, dir: string, slug: string, frontmatter: string | null) {
+		const skillDir = join(base, dir, slug);
 		mkdirSync(skillDir, { recursive: true });
 		if (frontmatter !== null) {
 			writeFileSync(join(skillDir, "SKILL.md"), frontmatter);
 		}
+	}
+
+	function addSkill(dir: string, slug: string, frontmatter: string | null) {
+		addSkillIn(home, dir, slug, frontmatter);
+	}
+
+	function addProjectSkill(dir: string, slug: string, frontmatter: string | null) {
+		addSkillIn(project, dir, slug, frontmatter);
 	}
 
 	it("returns empty when no skill directories exist", () => {
@@ -82,5 +93,28 @@ describe("listAgentSkills", () => {
 		addSkill(".claude/skills", ".hidden", "---\nname: hidden\n---\n");
 		const result = listAgentSkills(home);
 		expect(result.map((s) => s.name)).toEqual(["real"]);
+	});
+
+	it("includes project-local skills alongside global ones", () => {
+		addSkill(".claude/skills", "global-skill", "---\nname: global-skill\ndescription: G\n---\n");
+		addProjectSkill(".claude/skills", "debug-ui", "---\nname: debug-ui\ndescription: Drive the UI\n---\n");
+		const result = listAgentSkills(home, project);
+		expect(result).toEqual([
+			{ name: "debug-ui", description: "Drive the UI", source: "claude" },
+			{ name: "global-skill", description: "G", source: "claude" },
+		]);
+	});
+
+	it("prefers a project-local skill over a same-named global one", () => {
+		addSkill(".claude/skills", "shared", "---\nname: shared\ndescription: from global\n---\n");
+		addProjectSkill(".claude/skills", "shared", "---\nname: shared\ndescription: from project\n---\n");
+		const result = listAgentSkills(home, project);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ name: "shared", description: "from project", source: "claude" });
+	});
+
+	it("ignores project scanning when projectPath is not given", () => {
+		addProjectSkill(".claude/skills", "debug-ui", "---\nname: debug-ui\ndescription: Drive the UI\n---\n");
+		expect(listAgentSkills(home)).toEqual([]);
 	});
 });

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -235,10 +235,14 @@ async function listDirectory(params?: { path?: string | null; includeFiles?: boo
 	}
 }
 
-/** List skills found in the global agent skill directories for autocomplete. */
-async function listAgentSkills(): Promise<AgentSkillInfo[]> {
+/**
+ * List skills for autocomplete: project-local `.agents/.claude/.codex/skills`
+ * (when `projectPath` is given) plus the global home directories. Project-local
+ * skills win over same-named global ones.
+ */
+async function listAgentSkills(params?: { projectPath?: string | null }): Promise<AgentSkillInfo[]> {
 	try {
-		const skills = scanAgentSkills();
+		const skills = scanAgentSkills(undefined, params?.projectPath ?? null);
 		log.info("← listAgentSkills", { count: skills.length });
 		return skills;
 	} catch (err) {

--- a/src/bun/skills-catalog.ts
+++ b/src/bun/skills-catalog.ts
@@ -47,39 +47,54 @@ export function parseSkillFrontmatter(content: string): { name: string | null; d
 	return result;
 }
 
-/**
- * Scan the global agent skill directories (`~/.agents/skills`,
- * `~/.claude/skills`, `~/.codex/skills`) for `<skill>/SKILL.md` entries.
- * Skills with the same name are deduplicated; the first source in the
- * priority order above wins. Result is sorted by name.
- */
-export function listAgentSkills(home: string = homedir()): AgentSkillInfo[] {
-	const byName = new Map<string, AgentSkillInfo>();
-
-	for (const { dir, source } of SOURCE_DIRS) {
-		const root = join(home, dir);
-		if (!existsSync(root)) continue;
-		let entries: string[];
+/** Scan one `<root>/<skill>/SKILL.md` tree into `byName` (first name wins). */
+function scanSkillRoot(root: string, source: AgentSkillInfo["source"], byName: Map<string, AgentSkillInfo>): void {
+	if (!existsSync(root)) return;
+	let entries: string[];
+	try {
+		entries = readdirSync(root);
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (entry.startsWith(".")) continue;
+		const skillFile = join(root, entry, "SKILL.md");
 		try {
-			entries = readdirSync(root);
+			if (!statSync(join(root, entry)).isDirectory()) continue;
+			if (!existsSync(skillFile)) continue;
+			const parsed = parseSkillFrontmatter(readFileSync(skillFile, "utf8"));
+			const name = parsed.name ?? entry;
+			if (byName.has(name)) continue;
+			byName.set(name, { name, description: parsed.description ?? "", source });
 		} catch {
+			// Unreadable skill dir/file (permissions, broken symlink) — skip it.
 			continue;
 		}
-		for (const entry of entries) {
-			if (entry.startsWith(".")) continue;
-			const skillFile = join(root, entry, "SKILL.md");
-			try {
-				if (!statSync(join(root, entry)).isDirectory()) continue;
-				if (!existsSync(skillFile)) continue;
-				const parsed = parseSkillFrontmatter(readFileSync(skillFile, "utf8"));
-				const name = parsed.name ?? entry;
-				if (byName.has(name)) continue;
-				byName.set(name, { name, description: parsed.description ?? "", source });
-			} catch {
-				// Unreadable skill dir/file (permissions, broken symlink) — skip it.
-				continue;
-			}
+	}
+}
+
+/**
+ * Scan agent skill directories for `<skill>/SKILL.md` entries.
+ *
+ * When `projectPath` is given, its project-local `.agents/skills`,
+ * `.claude/skills`, `.codex/skills` are scanned **first** so a project-local
+ * skill wins over a same-named global one. Then the global directories under
+ * `home` (`~/.agents/skills`, `~/.claude/skills`, `~/.codex/skills`) are added.
+ * Skills with the same name are deduplicated (first seen wins). Result is
+ * sorted by name.
+ */
+export function listAgentSkills(home: string = homedir(), projectPath?: string | null): AgentSkillInfo[] {
+	const byName = new Map<string, AgentSkillInfo>();
+
+	// Project-local skills first — they win dedup over global ones.
+	if (projectPath) {
+		for (const { dir, source } of SOURCE_DIRS) {
+			scanSkillRoot(join(projectPath, dir), source, byName);
 		}
+	}
+
+	for (const { dir, source } of SOURCE_DIRS) {
+		scanSkillRoot(join(home, dir), source, byName);
 	}
 
 	return [...byName.values()].sort((a, b) =>

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -97,7 +97,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun }: CreateT
 		});
 	}, []);
 
-	const skillAutocomplete = useSkillAutocomplete(textareaRef, description, setDescription);
+	const skillAutocomplete = useSkillAutocomplete(textareaRef, description, setDescription, project.path);
 
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
 	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor);

--- a/src/mainview/hooks/useSkillAutocomplete.ts
+++ b/src/mainview/hooks/useSkillAutocomplete.ts
@@ -37,13 +37,16 @@ export function filterSkills(skills: AgentSkillInfo[], query: string): AgentSkil
 
 /**
  * Slash-trigger skill-name autocomplete for a textarea. Typing "/" at a word
- * boundary opens a suggestion list of globally installed agent skills
- * (~/.agents/skills, ~/.claude/skills, ~/.codex/skills via `listAgentSkills`).
+ * boundary opens a suggestion list of installed agent skills — the project's
+ * local `.agents/.claude/.codex/skills` (when `projectPath` is given) plus the
+ * global home directories, via `listAgentSkills`. Project-local skills win over
+ * same-named global ones.
  */
 export function useSkillAutocomplete(
 	textareaRef: RefObject<HTMLTextAreaElement | null>,
 	value: string,
 	setValue: (next: string) => void,
+	projectPath?: string | null,
 ) {
 	const [skills, setSkills] = useState<AgentSkillInfo[]>([]);
 	const [token, setToken] = useState<SlashToken | null>(null);
@@ -53,7 +56,7 @@ export function useSkillAutocomplete(
 	useEffect(() => {
 		let cancelled = false;
 		api.request
-			.listAgentSkills()
+			.listAgentSkills({ projectPath })
 			.then((result) => {
 				if (!cancelled) setSkills(result);
 			})
@@ -63,7 +66,7 @@ export function useSkillAutocomplete(
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [projectPath]);
 
 	const sync = useCallback(() => {
 		const el = textareaRef.current;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1281,13 +1281,13 @@ export interface FolderListing {
 
 // ---- Agent skills catalog ----
 
-/** A skill discovered in one of the global agent skill directories. */
+/** A skill discovered in a project-local or global agent skill directory. */
 export interface AgentSkillInfo {
 	/** Skill name from SKILL.md frontmatter (falls back to the directory name). */
 	name: string;
 	/** First-line description from SKILL.md frontmatter; empty when absent. */
 	description: string;
-	/** Which global directory the skill was found in. */
+	/** Which skill directory kind the skill was found in. */
 	source: "agents" | "claude" | "codex";
 }
 
@@ -1348,7 +1348,7 @@ export type AppRPCSchema = {
 				response: FolderListing;
 			};
 			listAgentSkills: {
-				params: void;
+				params: { projectPath?: string | null };
 				response: AgentSkillInfo[];
 			};
 			createCustomColumn: {


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

The New Task slash-command autocomplete only scanned the global agent skill directories under `$HOME` (`~/.agents/skills`, `~/.claude/skills`, `~/.codex/skills`), so project-local skills checked into the repo — e.g. `.claude/skills/debug-ui/` (`/debug-ui`) — never appeared in the dropdown.

This threads the active project's path from `CreateTaskModal` → the `listAgentSkills` RPC → the catalog scanner, which now scans the project-local `.agents/.claude/.codex/skills` **first** (a project-local skill wins dedup over a same-named global one), then the global ones.

Verified end-to-end in a browser: typing `/de` in New Task now surfaces `/debug-ui` at the top of the list. Added unit tests for project-local scanning, the project-wins-dedup rule, and the no-`projectPath` case.
