### PR TITLE
fix(remote): force cloudflared http2 transport so Cloudflare tunnels work when QUIC is blocked

### DIFF
--- a/change-logs/2026/07/02/fix-cloudflare-tunnel-http2.md
+++ b/change-logs/2026/07/02/fix-cloudflare-tunnel-http2.md
@@ -1,0 +1,1 @@
+Fixed remote access via the Cloudflare tunnel silently failing (QR/link showed as active but the trycloudflare.com URL never resolved) on networks that block outbound QUIC/UDP 7844. cloudflared quick tunnels now use the http2 transport by default (override with DEV3_CLOUDFLARED_PROTOCOL=quic|http2|auto).

--- a/decisions/097-cloudflared-http2-protocol.md
+++ b/decisions/097-cloudflared-http2-protocol.md
@@ -1,0 +1,61 @@
+# 097 — Force cloudflared quick tunnels onto the http2 transport
+
+## Context
+
+Remote access via the Cloudflare tunnel (QR code / public link) silently stopped
+working: the modal showed a `*.trycloudflare.com` URL and a green "Public tunnel
+active" badge, but the URL was `NXDOMAIN` on every resolver (including Cloudflare's
+own `1.1.1.1`) and no request ever reached the server (all logged requests were
+`ip: direct`, i.e. LAN/local — none carried `cf-connecting-ip`).
+
+## Investigation
+
+Starting a fresh quick tunnel by hand and reading cloudflared's full stderr showed
+the root cause. cloudflared's pre-check reported:
+
+```
+UDP Connectivity  region1.v2.argotunnel.com  FAIL  QUIC connection failed
+WARNING: Allow outbound QUIC traffic on port 7844 or use HTTP2.
+ERR Failed to dial a quic connection error="failed to dial to edge with quic: timeout: no recent network activity"
+Retrying connection in up to 2s … 4s … 8s … 1m4s
+```
+
+`Registered tunnel connection` count = **0**. Quick tunnels pin `protocol:quic`
+(UDP/7844). On any network that blocks outbound UDP/7844 (corporate/VPN/hotel
+Wi-Fi — very common), cloudflared prints the assigned URL optimistically ("it may
+take some time to be reachable"), then never registers with the edge and retries
+QUIC forever without falling back to http2 — so the hostname is never provisioned
+in DNS. Re-running with `--protocol http2` (TCP/443, already reachable per the
+pre-check's TCP row) registered immediately and the tunnel served end-to-end
+(`/` → 200, `/health` → 401 through the public URL).
+
+## Decision
+
+Default the cloudflared transport to **http2** instead of its own `quic` default.
+`src/bun/cloudflare-tunnel.ts` now spawns `cloudflared tunnel --protocol <p> --url …`
+where `<p>` comes from `resolveTunnelProtocol()` (default `http2`, overridable via
+`DEV3_CLOUDFLARED_PROTOCOL=quic|http2|auto`). This is the single spawn choke point,
+so it covers the main web-UI tunnel and per-task port/shared tunnels alike.
+
+## Risks
+
+- Marginally higher latency where QUIC would have worked; negligible for our
+  WebSocket-based (RPC + PTY) remote UI, which http2 tunnels carry transparently.
+- `--protocol auto` was rejected: observed to stick on QUIC and not downgrade for
+  quick tunnels, so it would not have fixed the blocked-UDP case.
+
+## Alternatives considered
+
+- **`--protocol auto`** — should fall back to http2 but empirically doesn't for
+  quick tunnels on this network; unreliable.
+- **Try QUIC, detect non-registration, restart with http2** — adds startup latency
+  and complexity for a transport that has no functional benefit here.
+- **Named tunnel + Cloudflare account** — stable but requires user credentials and
+  breaks the zero-config nature of the feature.
+
+## Follow-up (not in this change)
+
+The tunnel is marked `connected` as soon as the URL is parsed from stderr, before
+edge registration — that is why the UI showed a live URL while the tunnel was dead.
+Gating `state = "connected"` on a `Registered tunnel connection` line would remove
+that false positive; left as a separate change.

--- a/src/bun/__tests__/cloudflare-tunnel.test.ts
+++ b/src/bun/__tests__/cloudflare-tunnel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 
 vi.mock("../spawn", () => ({
 	spawn: vi.fn(),
@@ -22,9 +22,41 @@ import {
 	getTunnelUrl,
 	getTunnelState,
 	parseTunnelUrl,
+	resolveTunnelProtocol,
 	tunnelManager,
 	_resetState,
 } from "../cloudflare-tunnel";
+
+// ================================================================
+// resolveTunnelProtocol — QUIC/UDP-7844-blocked networks need http2
+// ================================================================
+
+describe("resolveTunnelProtocol", () => {
+	const orig = process.env.DEV3_CLOUDFLARED_PROTOCOL;
+	afterEach(() => {
+		if (orig === undefined) delete process.env.DEV3_CLOUDFLARED_PROTOCOL;
+		else process.env.DEV3_CLOUDFLARED_PROTOCOL = orig;
+	});
+
+	it("defaults to http2 (QUIC is blocked on many corporate networks)", () => {
+		delete process.env.DEV3_CLOUDFLARED_PROTOCOL;
+		expect(resolveTunnelProtocol()).toBe("http2");
+	});
+
+	it("honours a valid override", () => {
+		process.env.DEV3_CLOUDFLARED_PROTOCOL = "quic";
+		expect(resolveTunnelProtocol()).toBe("quic");
+		process.env.DEV3_CLOUDFLARED_PROTOCOL = "auto";
+		expect(resolveTunnelProtocol()).toBe("auto");
+		process.env.DEV3_CLOUDFLARED_PROTOCOL = "HTTP2";
+		expect(resolveTunnelProtocol()).toBe("http2");
+	});
+
+	it("falls back to http2 for an unknown/garbage value", () => {
+		process.env.DEV3_CLOUDFLARED_PROTOCOL = "wireguard";
+		expect(resolveTunnelProtocol()).toBe("http2");
+	});
+});
 
 // ================================================================
 // parseTunnelUrl — unit tests for stderr parser
@@ -152,7 +184,7 @@ describe("startTunnel", () => {
 		expect(getTunnelState()).toBe("connected");
 
 		expect(mockSpawn).toHaveBeenCalledWith(
-			["cloudflared", "tunnel", "--url", "http://localhost:8080"],
+			["cloudflared", "tunnel", "--protocol", "http2", "--url", "http://localhost:8080"],
 			{ stdout: "ignore", stderr: "pipe" },
 		);
 	});

--- a/src/bun/cloudflare-tunnel.ts
+++ b/src/bun/cloudflare-tunnel.ts
@@ -56,6 +56,29 @@ export function isCloudflaredAvailable(): boolean {
 }
 
 /**
+ * Transport protocol cloudflared uses to reach Cloudflare's edge.
+ *
+ * We default to **http2** (TCP/443) instead of cloudflared's own default of
+ * `quic` (UDP/7844). Quick tunnels pin `protocol:quic` and, on any network that
+ * blocks outbound UDP/7844 — extremely common on corporate/VPN/hotel Wi-Fi —
+ * cloudflared prints the `*.trycloudflare.com` URL optimistically ("it may take
+ * some time to be reachable"), then fails to dial the edge over QUIC and retries
+ * forever WITHOUT falling back to http2. The tunnel never registers, so the
+ * hostname is never provisioned → NXDOMAIN → the QR/link silently never works
+ * even though the UI shows a URL. http2 uses TCP/443, which is effectively
+ * always allowed, and carries WebSockets (our RPC + PTY) transparently, so there
+ * is no functional downside for the remote-access use case.
+ *
+ * Override via `DEV3_CLOUDFLARED_PROTOCOL` (`quic` | `http2` | `auto`) for users
+ * on networks where QUIC works and lower latency is wanted. See decision 097.
+ */
+export function resolveTunnelProtocol(): string {
+	const raw = process.env.DEV3_CLOUDFLARED_PROTOCOL?.trim().toLowerCase();
+	if (raw === "quic" || raw === "http2" || raw === "auto") return raw;
+	return "http2";
+}
+
+/**
  * Parse a Cloudflare Tunnel URL from a line of cloudflared stderr output.
  * cloudflared prints lines like:
  *   INF |  https://something-random.trycloudflare.com
@@ -147,7 +170,7 @@ async function startEntry(opts: StartTunnelOptions): Promise<TunnelEntry> {
 
 	try {
 		const proc = spawn(
-			["cloudflared", "tunnel", "--url", `http://localhost:${opts.targetPort}`],
+			["cloudflared", "tunnel", "--protocol", resolveTunnelProtocol(), "--url", `http://localhost:${opts.targetPort}`],
 			{ stdout: "ignore", stderr: "pipe" },
 		);
 		entry.process = proc;


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — writing up the fix.

## Summary

Remote access via the Cloudflare tunnel (QR code / public link) silently stopped working: the modal showed a `*.trycloudflare.com` URL with a green "Public tunnel active" badge, but the URL was `NXDOMAIN` on every resolver (including Cloudflare's own `1.1.1.1`) and no request ever reached the server.

**Root cause:** cloudflared quick tunnels pin the `quic` transport (UDP port 7844). On any network that blocks outbound UDP/7844 (corporate/VPN/hotel Wi-Fi), cloudflared prints the assigned URL optimistically ("it may take some time to be reachable"), then fails to dial the edge over QUIC and retries forever **without** falling back to http2. The tunnel never registers (`Registered tunnel connection` count = 0), so the hostname is never provisioned in DNS.

Diagnosis was confirmed straight from cloudflared's own precheck on a fresh tunnel:

```
UDP Connectivity  region1.v2.argotunnel.com  FAIL  QUIC connection failed
WARNING: Allow outbound QUIC traffic on port 7844 or use HTTP2.
ERR Failed to dial a quic connection: timeout: no recent network activity
```

Re-running with `--protocol http2` (TCP/443) registered immediately and served end-to-end through the public URL (`/` → 200, `/health` → 401).

## Change

- `src/bun/cloudflare-tunnel.ts`: the single cloudflared spawn point now passes `--protocol <p>`, where `<p>` comes from a new `resolveTunnelProtocol()` — **default `http2`**, overridable via `DEV3_CLOUDFLARED_PROTOCOL=quic|http2|auto`. Covers the main web-UI tunnel plus per-task port/shared tunnels.
- Tests for `resolveTunnelProtocol()` + updated the spawn-argv assertion.
- Decision record `097` and a changelog entry.

`--protocol auto` was rejected: it was observed to stick on QUIC and not downgrade for quick tunnels, so it would not have fixed the blocked-UDP case. http2 carries our WebSocket traffic (RPC + PTY) transparently, so there is no functional downside.

## Follow-up (not in this PR)

The tunnel is marked `connected` as soon as the URL is parsed from stderr, before edge registration — that is why the UI showed a live URL while the tunnel was dead. Gating `state = "connected"` on a `Registered tunnel connection` line would remove that false positive; noted in decision 097 as a separate change.
