### PR TITLE
feat(bug-hunter): route in-task findings to dev3 notes for the main agent

### DIFF
--- a/change-logs/2026/07/02/feature-bug-hunter-task-notes.md
+++ b/change-logs/2026/07/02/feature-bug-hunter-task-notes.md
@@ -1,0 +1,1 @@
+In-task bug hunters now report findings as dev3 notes instead of leaving them trapped in their own tmux pane. Each confirmed critical/high/medium finding is recorded as a `[bug-hunt]`-prefixed dev3 note, so the main task agent can pick them all up with `dev3 note list` and fix them. Standalone `/dev3-bug-hunter` keeps its human-facing stdout report unchanged.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -236,6 +236,24 @@ describe("dev3 Bug Hunter skill content", () => {
 			"I could not reproduce this bug, so I did not attempt a fix. Please verify it manually; the issue may be invalid.",
 		);
 	});
+
+	it("documents the in-task note reporting channel", () => {
+		const skill = getBugHunterSkillContent();
+
+		expect(skill).toContain("## Task mode: record findings as dev3 notes");
+		// The main agent, not the pane, is the real consumer in task mode.
+		expect(skill).toContain(
+			"the **main agent that will actually fix the bugs never sees it**",
+		);
+		// One note per finding, marker-prefixed, via the dev3 note CLI.
+		expect(skill).toContain('dev3 note add "[bug-hunt] <severity> <path:lines>');
+		expect(skill).toContain("one note per finding, never batched");
+		expect(skill).toContain("The literal `[bug-hunt]` marker at the very start is mandatory");
+		// Note mode suppresses the standalone task-creation offer.
+		expect(skill).toContain(
+			'do NOT emit the "Next step offer" question and do NOT create dev3 tasks yourself',
+		);
+	});
 });
 
 describe("applyClaudeSettings (Claude Code sandbox socket allowlist, issue #726)", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6232,6 +6232,12 @@ describe("handlers.spawnBugHuntersInTask", () => {
 			expect(prompt).toContain('git diff --name-only "$BASE" HEAD');
 			expect(prompt).not.toContain("origin/main...HEAD");
 			expect(prompt).toContain("dev3/task-test");
+			// In-task hunters must route findings to the main agent via dev3
+			// notes — their on-screen report is trapped in their own pane.
+			expect(prompt).toContain("record it as dev3 notes instead");
+			expect(prompt).toContain("dev3 note add");
+			expect(prompt).toContain("[bug-hunt]");
+			expect(prompt).toContain("do NOT create any");
 		}
 
 		// Enter not pressed yet.

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -961,6 +961,29 @@ I could not reproduce this bug, so I did not attempt a fix. Please verify it man
 \`\`\`
 
 When you create these follow-up tasks in dev3, include enough detail that a separate agent can execute them without re-reading the original bug-hunt report.
+
+## Task mode: record findings as dev3 notes
+
+Sometimes you are launched inside a dev3 task (for example as one of several parallel hunters split into their own tmux panes). In that case the invocation tells you explicitly to record your findings as dev3 notes. This matters because your on-screen report stays trapped in your own pane — the **main agent that will actually fix the bugs never sees it**. dev3 notes are your report channel to that agent.
+
+When instructed to record findings as dev3 notes:
+
+- Still print the identity line, Findings summary, Finding details, and Coverage on screen as usual — a human may be watching your pane.
+- ADDITIONALLY, record every confirmed \`critical\`, \`high\`, or \`medium\` finding as its own dev3 note — one note per finding, never batched:
+
+  \`\`\`bash
+  dev3 note add "[bug-hunt] <severity> <path:lines> — <short title>. Why it breaks: <failure mode>. Repro hint: <validation idea>."
+  \`\`\`
+
+  The literal \`[bug-hunt]\` marker at the very start is mandatory — it is how the main agent locates these notes with \`dev3 note list\` among any pre-existing task notes. Do NOT record low-confidence suspicions as notes; keep those on screen only.
+- In this mode, do NOT emit the "Next step offer" question and do NOT create dev3 tasks yourself. Recording the notes replaces both.
+- Finish with exactly one line:
+
+  \`\`\`text
+  Recorded N finding(s) as dev3 notes ([bug-hunt] prefix). Main agent: run \`dev3 note list\`, then \`dev3 note show <id>\` for each, and fix them.
+  \`\`\`
+
+If you found no confirmed bugs, record no notes and print \`No confirmed bugs found — no notes recorded.\`
 `;
 
 const BUG_HUNTER_OPENAI_YAML = `interface:

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1971,7 +1971,16 @@ export function buildBugHunterPrompt(task: Task, project: Project): string {
 		`Use that merge-base two-dot form — do NOT diff against ${ref} directly, because if this branch is not rebased that pulls in unrelated files changed only on ${ref}. ` +
 		`Hunt for bugs ONLY in those changed files and the code paths they touch. ` +
 		`Do NOT inspect files changed only on ${ref}, and do NOT inspect unrelated parts of the codebase. ` +
-		`Branch: ${branch}. Base: ${ref}.`
+		`Branch: ${branch}. Base: ${ref}. ` +
+		// In-task hunters run in their own pane, so their stdout report never reaches
+		// the main agent — route findings into `[bug-hunt]` dev3 notes instead. Injected
+		// only here; standalone `/dev3-bug-hunter` keeps its stdout report.
+		`You are running inside a dev3 task, so your on-screen report will NOT reach the main agent — record it as dev3 notes instead. ` +
+		`After presenting your normal report, add EACH confirmed critical/high/medium finding as its own dev3 note (one note per finding) via ` +
+		`\`dev3 note add "..."\`, starting every note body with the literal marker "[bug-hunt]" followed by the severity, the "path:lines" location, a short title, the failure mode, and a repro hint. ` +
+		`The "[bug-hunt]" marker is mandatory so the main agent can find them. ` +
+		`Do NOT ask whether to create dev3 tasks and do NOT create any — recording the notes replaces the Next step offer. ` +
+		`Finish with one line: the count of findings recorded and the instruction for the main agent to run \`dev3 note list\` then \`dev3 note show <id>\` and fix each.`
 	);
 }
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

When bug hunters are spawned **inside a task** (the swarm split into their own tmux panes via `spawnBugHuntersInTask`), each hunter's report was trapped in its own pane — the main task agent that actually fixes the bugs never saw it. This wires that gap.

- `buildBugHunterPrompt` (`src/bun/rpc-handlers/tmux-pty.ts`) now injects a **task-mode directive** into the pasted prompt: each hunter records every confirmed critical/high/medium finding as its own dev3 note via `dev3 note add`, prefixed with the literal marker `[bug-hunt]`. In this mode the hunter skips the interactive "create dev3 tasks?" offer and ends with a one-line pointer telling the main agent to run `dev3 note list` / `dev3 note show <id>` and fix each.
- `BUG_HUNTER_SKILL_CONTENT` (`src/bun/agent-skills.ts`) gains a documented **"Task mode: record findings as dev3 notes"** section describing the contract (one note per finding, mandatory `[bug-hunt]` marker, no self-created tasks).
- The directive is injected **only on the in-task path** — standalone `/dev3-bug-hunter` keeps its existing human-facing stdout ASCII report unchanged.

Notes were chosen over files as the sink: writes go through the dev3 socket and are serialized (no concurrent-write races across parallel hunters), and the main agent already has `dev3 note list` / `note show` for discovery.

## Tests

- New assertions that the in-task prompt carries the note directive (`[bug-hunt]`, `dev3 note add`, no self-created tasks).
- New test that the skill content documents the task-mode note channel.
- `bun run lint` and full `bun run test` green (mainview 1884, bun 1713).