### PR TITLE
fix(cli): harden dev-server status against version-skew crash

### DIFF
--- a/change-logs/2026/07/03/fix-dev-server-status-version-skew-crash.md
+++ b/change-logs/2026/07/03/fix-dev-server-status-version-skew-crash.md
@@ -1,0 +1,1 @@
+Fixed `dev3 dev-server status` crashing with "undefined is not an object (evaluating 'ports.length')" when a newer CLI talks to an older running app that never sent the `devPorts`/`portConflicts` fields. The CLI now normalizes the status payload, defaulting missing array fields to empty, so status renders cleanly regardless of CLI/app version skew.

--- a/src/cli/__tests__/dev-server.test.ts
+++ b/src/cli/__tests__/dev-server.test.ts
@@ -97,6 +97,40 @@ describe("dev-server status", () => {
 			projectId: CTX.projectId,
 		});
 	});
+
+	// Regression: `dev3 dev-server status` used to crash with
+	// "undefined is not an object (evaluating 'ports.length')" when a CLI newer
+	// than the running app received a status payload missing the array fields the
+	// older backend never sent (`devPorts`/`portConflicts`, added after v1.27.4).
+	it("renders a clean stopped status when the backend omits newer array fields", async () => {
+		// Shape produced by a pre-v1.27.4 backend: no devPorts / portConflicts.
+		const legacyStopped = {
+			projectId: "proj-001",
+			taskId: "aaaaaaaa-1111-2222-3333-444444444444",
+			running: false,
+			hasDevScript: true,
+			worktreePath: "/tmp/worktrees/proj/aaaaaaaa/worktree",
+			tmuxSocket: "dev3",
+			taskSessionName: "dev3-aaaaaaaa",
+			devSessionName: "dev3-dev-aaaaaaaa",
+			viewerPaneId: null,
+			panePids: [],
+			assignedPorts: [],
+			ports: [],
+			resourceUsage: undefined,
+		};
+		mockSend.mockResolvedValue(okResp(legacyStopped));
+
+		await expect(
+			handleDevServer("status", { positional: [], flags: {} }, SOCKET, CTX),
+		).resolves.toBeUndefined();
+
+		expect(stdoutOutput).toContain("Dev server is stopped");
+		expect(stdoutOutput).toContain("Detected Ports:");
+		expect(stdoutOutput).toContain("Dev Ports:");
+		expect(stdoutOutput).toContain("(none detected)");
+		expect(stdoutOutput).not.toContain("WARNING: port");
+	});
 });
 
 describe("dev-server start/stop/restart", () => {

--- a/src/cli/commands/dev-server.ts
+++ b/src/cli/commands/dev-server.ts
@@ -7,6 +7,28 @@ import { expandShortId, resolveProjectId, type CliContext } from "../context";
 const WAIT_POLL_MS = 500;
 const WAIT_DEFAULT_TIMEOUT_S = 120;
 
+/**
+ * Coerce a raw `devServer.*` RPC payload into a DevServerStatus with every
+ * array field guaranteed present. Guards against version skew: the `dev3` CLI
+ * and the running app are versioned independently, so a CLI newer than the app
+ * receives a status missing fields the older backend never sent (e.g.
+ * `devPorts`/`portConflicts`, added after v1.27.4). Without this, the rendering
+ * helpers below dereference `undefined.length` and the whole command crashes
+ * with "undefined is not an object (evaluating 'ports.length')" instead of
+ * printing a clean status.
+ */
+function asStatus(data: unknown): DevServerStatus {
+	const raw = (data ?? {}) as DevServerStatus;
+	return {
+		...raw,
+		panePids: raw.panePids ?? [],
+		assignedPorts: raw.assignedPorts ?? [],
+		ports: raw.ports ?? [],
+		devPorts: raw.devPorts ?? [],
+		portConflicts: raw.portConflicts ?? [],
+	};
+}
+
 function resolveTaskId(args: ParsedArgs, context: CliContext | null): string | undefined {
 	const raw = args.positional[0] || args.flags.id || context?.taskId;
 	if (!raw) return undefined;
@@ -92,7 +114,7 @@ async function waitForDevServerReady(
 	for (let waited = 0; ; waited += WAIT_POLL_MS) {
 		const resp = await sendRequest(socketPath, "devServer.status", params);
 		if (!resp.ok) exitError(resp.error || "Failed to poll dev server status");
-		const status = resp.data as DevServerStatus;
+		const status = asStatus(resp.data);
 		if (!status.running) {
 			exitError("Dev server exited before opening a port — check the dev server pane for errors");
 		}
@@ -135,8 +157,9 @@ async function runAction(
 	const resp = await sendRequest(socketPath, `devServer.${action}`, params);
 	if (!resp.ok) exitError(resp.error || `Failed to ${action} dev server`);
 
-	printStatusLine(action, resp.data as DevServerStatus);
-	printStatusDetails(resp.data as DevServerStatus);
+	const status = asStatus(resp.data);
+	printStatusLine(action, status);
+	printStatusDetails(status);
 
 	if ((action === "start" || action === "restart") && args.flags.wait !== undefined) {
 		await waitForDevServerReady(socketPath, params, parseWaitTimeout(args));


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

`dev3 dev-server status` crashed with `undefined is not an object (evaluating 'ports.length')` when the CLI was newer than the running app.

Root cause is **CLI/app version skew**, not a stopped-server bug. `buildDevServerStatus()` always returns `[]` for the port arrays (even when stopped), so a same-version CLI never crashes. But the CLI and the running app are versioned independently: a CLI newer than the app receives a `DevServerStatus` missing fields the older backend never sent (`devPorts`/`portConflicts`, added after v1.27.4 in #784). The status renderer dereferenced those arrays' `.length` unconditionally → crash.

## Fix

- Add `asStatus()` in `src/cli/commands/dev-server.ts` that normalizes the raw RPC payload, defaulting every array field (`panePids`, `assignedPorts`, `ports`, `devPorts`, `portConflicts`) to `[]`.
- Apply it at both cast sites: `runAction` (status/start/stop/restart rendering) and the `--wait` poll loop in `waitForDevServerReady`. One boundary fix covers every current and future consumer, in both skew directions.
- Regression test reproducing the pre-v1.27.4 stopped-server payload shape (missing `devPorts`/`portConflicts`) — red without the fix, green with it.