### PR TITLE
fix(cli): accurate per-field source in dev3 config show

### DIFF
--- a/change-logs/2026/07/03/fix-config-show-source-provenance.md
+++ b/change-logs/2026/07/03/fix-config-show-source-provenance.md
@@ -1,0 +1,1 @@
+`dev3 config show` now reports an accurate source for every setting — local, repo, project, default, or unset — instead of collapsing project-object values, defaults, and truly-unset keys into a misleading "global". Object-valued fields like builtinColumnAgents render as a readable summary rather than "[object Object]".

--- a/src/bun/__tests__/repo-config.test.ts
+++ b/src/bun/__tests__/repo-config.test.ts
@@ -23,6 +23,7 @@ import {
 	saveRepoLocalConfig,
 	ensureGitignore,
 	getConfigSources,
+	resolveConfigProvenance,
 	resolveProjectConfig,
 	resolveOperationalProjectConfig,
 	migrateProjectConfig,
@@ -247,6 +248,67 @@ describe("getConfigSources", () => {
 
 		const setupSource = sources.find((s) => s.field === "setupScript");
 		expect(setupSource?.source).toBe("local");
+	});
+});
+
+describe("resolveConfigProvenance", () => {
+	it("attributes every key when no config files exist (project / default / unset)", async () => {
+		const project = makeProject();
+		const resolved = await resolveProjectConfig(project);
+		const prov = resolveConfigProvenance(resolved, project);
+
+		// Values carried on the Project object (projects.json) → "project"
+		expect(prov.setupScript).toBe("project");
+		expect(prov.cleanupScript).toBe("project");
+		expect(prov.defaultBaseBranch).toBe("project");
+		expect(prov.clonePaths).toBe("project");
+		expect(prov.peerReviewEnabled).toBe("project");
+
+		// Values that only exist because of DEFAULTS / derivation → "default"
+		expect(prov.setupScriptLaunchMode).toBe("default");
+		expect(prov.autoReviewEnabled).toBe("default");
+		expect(prov.sparseCheckoutEnabled).toBe("default");
+		expect(prov.sparseCheckoutPaths).toBe("default");
+		expect(prov.defaultCompareRef).toBe("default"); // derived origin/main
+
+		// No value at any layer and no default → "unset" (CLI renders "(not set)")
+		expect(prov.defaultCompareRefMode).toBe("unset");
+		expect(prov.portCount).toBe("unset");
+		expect(prov.builtinColumnAgents).toBe("unset");
+	});
+
+	it("labels file-backed keys local/repo and treats a phantom empty array as unconfigured", async () => {
+		const configDir = join(TEST_DIR, ".dev3");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.json"), JSON.stringify({
+			setupScript: "bun install",
+			clonePaths: [], // empty array must NOT claim the key (see effective())
+			portCount: 2,
+		}));
+		writeFileSync(join(configDir, "config.local.json"), JSON.stringify({
+			devScript: "bun run dev:local",
+		}));
+
+		const project = makeProject();
+		const resolved = await resolveProjectConfig(project);
+		const prov = resolveConfigProvenance(resolved, project);
+
+		expect(prov.setupScript).toBe("repo");
+		expect(prov.devScript).toBe("local"); // local layer wins over project
+		expect(prov.portCount).toBe("repo");
+		// clonePaths [] in the file is "not configured" → falls through to the project value
+		expect(prov.clonePaths).toBe("project");
+		expect(resolved.clonePaths).toEqual(["node_modules"]);
+	});
+
+	it("does not label a field 'default' when its value came from the project object", async () => {
+		// defaultBaseBranch lives on the Project object, not in any file — the source
+		// must be "project", never a blanket "default"/"global".
+		const project = makeProject({ defaultBaseBranch: "develop" });
+		const resolved = await resolveProjectConfig(project);
+		const prov = resolveConfigProvenance(resolved, project);
+		expect(resolved.defaultBaseBranch).toBe("develop");
+		expect(prov.defaultBaseBranch).toBe("project");
 	});
 });
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -830,7 +830,11 @@ const handlers: Record<string, Handler> = {
 		const project = await data.getProject(projectId);
 		const configPath = worktreePath || project.path;
 		const resolved = await repoConfig.resolveProjectConfig(project, configPath);
-		const sources = await repoConfig.getConfigSources(configPath);
+		// Full provenance for every key (local/repo/project/default/unset) — the CLI
+		// renders it verbatim, so it never has to guess a blanket "global" fallback
+		// that would hide whether a value is a real default, a project setting, or
+		// genuinely unset. Wider than getConfigSources (repo/local, for the UI badge).
+		const provenance = repoConfig.resolveConfigProvenance(resolved, project, configPath);
 		const hasRepoFile = repoConfig.hasRepoConfig(configPath);
 		return {
 			// Map unset fields (no value at any layer and no default — e.g. portCount)
@@ -841,7 +845,7 @@ const handlers: Record<string, Handler> = {
 			settings: Object.fromEntries(
 				DEV3_REPO_CONFIG_KEYS.map((key) => [key, (resolved as any)[key] ?? null]),
 			),
-			sources: Object.fromEntries(sources.map((s) => [s.field, s.source])),
+			sources: provenance,
 			hasRepoConfig: hasRepoFile,
 		};
 	},

--- a/src/bun/repo-config.ts
+++ b/src/bun/repo-config.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
-import type { Project, Dev3RepoConfig, ConfigSourceEntry } from "../shared/types";
+import type { Project, Dev3RepoConfig, ConfigSourceEntry, ResolvedConfigSource } from "../shared/types";
 import { DEV3_REPO_CONFIG_KEYS } from "../shared/types";
 import { createLogger } from "./logger";
 import * as git from "./git";
@@ -136,6 +136,49 @@ export async function getConfigSources(projectPath: string): Promise<ConfigSourc
 		}
 	}
 	return entries;
+}
+
+/**
+ * Full per-field provenance for the resolved config cascade — used by
+ * `dev3 config show` so every key shows exactly where its value came from,
+ * never a blanket fallback that hides project/default/unset behind one label.
+ *
+ * Unlike getConfigSources (repo/local only, for the UI badge), this attributes
+ * EVERY key in DEV3_REPO_CONFIG_KEYS to one origin, mirroring applyConfigCascade
+ * so the label always matches the value the cascade actually resolved:
+ *   local   → effective value in .dev3/config.local.json
+ *   repo    → effective value in .dev3/config.json
+ *   project → value on the Project object (projects.json), no file value
+ *   default → value from DEFAULTS or a derived field (e.g. defaultCompareRef)
+ *   unset   → no value at any layer (the CLI renders this "(not set)")
+ *
+ * `resolved` is the output of resolveProjectConfig for the same project+path;
+ * `project` is the raw Project object. Empty arrays count as "not configured"
+ * for file layers (matches effective()), so a phantom `[]` can't claim a key.
+ */
+export function resolveConfigProvenance(
+	resolved: Project,
+	project: Project,
+	configPath?: string,
+): Record<string, ResolvedConfigSource> {
+	const basePath = configPath ?? project.path;
+	const localConfig = readJsonFile<Dev3RepoConfig>(`${basePath}/${LOCAL_CONFIG_FILE}`);
+	const repoConfig = readJsonFile<Dev3RepoConfig>(`${basePath}/${CONFIG_FILE}`);
+	const provenance: Record<string, ResolvedConfigSource> = {};
+	for (const key of DEV3_REPO_CONFIG_KEYS) {
+		if (effective(localConfig?.[key]) !== undefined) {
+			provenance[key] = "local";
+		} else if (effective(repoConfig?.[key]) !== undefined) {
+			provenance[key] = "repo";
+		} else if ((project as any)[key] != null) {
+			provenance[key] = "project";
+		} else if ((resolved as any)[key] != null) {
+			provenance[key] = "default";
+		} else {
+			provenance[key] = "unset";
+		}
+	}
+	return provenance;
 }
 
 /**

--- a/src/cli/__tests__/config.test.ts
+++ b/src/cli/__tests__/config.test.ts
@@ -126,6 +126,51 @@ describe("config show", () => {
 		expect(stdoutOutput).toContain("(not set)");
 		expect(stdoutOutput).not.toContain("null");
 	});
+
+	// The backend now sends a real source for every key (local/repo/project/
+	// default/unset). The CLI must print those verbatim and never fall back to
+	// the old misleading blanket "global" label.
+	it("renders per-field sources verbatim and never prints 'global'", async () => {
+		mockSend.mockResolvedValue(okResp({
+			settings: {
+				setupScript: "bun install",
+				setupScriptLaunchMode: "blocking",
+				defaultBaseBranch: "main",
+				defaultCompareRefMode: null,
+			},
+			sources: {
+				setupScript: "repo",
+				setupScriptLaunchMode: "project",
+				defaultBaseBranch: "default",
+				defaultCompareRefMode: "unset",
+			},
+			hasRepoConfig: true,
+		}));
+
+		await handleConfig("show", EMPTY_ARGS, SOCKET, CTX_WITH_WT);
+
+		expect(stdoutOutput).toContain("project");
+		expect(stdoutOutput).toContain("default");
+		expect(stdoutOutput).toContain("unset");
+		expect(stdoutOutput).not.toContain("global");
+	});
+
+	// A non-null object field (builtinColumnAgents) must render as a readable
+	// summary, not the opaque "[object Object]".
+	it("renders an object-valued field as a readable summary, not [object Object]", async () => {
+		mockSend.mockResolvedValue(okResp({
+			settings: {
+				builtinColumnAgents: { "review-by-ai": { agentId: "builtin-claude" } },
+			},
+			sources: { builtinColumnAgents: "repo" },
+			hasRepoConfig: true,
+		}));
+
+		await handleConfig("show", EMPTY_ARGS, SOCKET, CTX_WITH_WT);
+
+		expect(stdoutOutput).toContain("1 column");
+		expect(stdoutOutput).not.toContain("[object Object]");
+	});
 });
 
 describe("config export", () => {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -3,6 +3,27 @@ import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 import { resolveProjectId, type CliContext } from "../context";
 
+/**
+ * Render a resolved config value for the `dev3 config show` table. Handles every
+ * shape a config field can take so nothing prints as an opaque "[object Object]":
+ * arrays → comma list, empty → "(empty)", objects → a readable summary (e.g. the
+ * builtin column-agent map as a count), null/undefined → "(not set)".
+ */
+function formatConfigValue(field: string, value: unknown): string {
+	if (Array.isArray(value)) return value.join(", ") || "(empty)";
+	if (typeof value === "boolean") return String(value);
+	if (typeof value === "number") return String(value);
+	if (typeof value === "string") return value || "(empty)";
+	if (value !== null && typeof value === "object") {
+		const keys = Object.keys(value as Record<string, unknown>);
+		if (field === "builtinColumnAgents") {
+			return keys.length === 1 ? "1 column" : `${keys.length} columns`;
+		}
+		return JSON.stringify(value);
+	}
+	return "(not set)";
+}
+
 export async function handleConfig(
 	subcommand: string | undefined,
 	args: ParsedArgs,
@@ -37,11 +58,10 @@ export async function handleConfig(
 		printTable(
 			["FIELD", "VALUE", "SOURCE"],
 			Object.entries(result.settings).map(([field, value]) => {
-				const display = Array.isArray(value) ? value.join(", ") || "(empty)" :
-					typeof value === "boolean" ? String(value) :
-					typeof value === "string" ? (value || "(empty)") :
-					String(value ?? "(not set)");
-				return [field, display.length > 60 ? display.slice(0, 57) + "..." : display, result.sources[field] || "global"];
+				const display = formatConfigValue(field, value);
+				// The backend sends a source for every key (local/repo/project/default/
+				// unset); "unset" is only a defensive fallback if one is ever missing.
+				return [field, display.length > 60 ? display.slice(0, 57) + "..." : display, result.sources[field] || "unset"];
 			}),
 		);
 		return;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -592,6 +592,19 @@ export interface ConfigSourceEntry {
 	source: ConfigSource;
 }
 
+/**
+ * Full provenance of a resolved config field, for `dev3 config show`.
+ * Wider than ConfigSource (repo/local, used for the UI badge): it attributes
+ * EVERY key to exactly one origin so the CLI never falls back to a blanket
+ * label that hides where a value actually came from.
+ *   local   → .dev3/config.local.json
+ *   repo    → .dev3/config.json
+ *   project → projects.json Project object (Project Settings → Project tab)
+ *   default → built-in DEFAULTS or a derived value (e.g. defaultCompareRef)
+ *   unset   → no value at any layer (rendered "(not set)")
+ */
+export type ResolvedConfigSource = "local" | "repo" | "project" | "default" | "unset";
+
 export interface ProjectSettingsUpdate extends Dev3RepoConfig {
 	githubAuthHost?: string | null;
 	githubAuthLogin?: string | null;


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

`dev3 config show` now reports an accurate provenance for **every** setting instead of collapsing several distinct origins into one misleading `global` label.

Previously the SOURCE column only knew `repo`/`local` (from config files) and fell back to `global` for everything else — so a value coming from the projects.json Project object, a built-in default, or a truly-unset key all read identically as `global`. That defeated the whole point of the command: you couldn't tell a real default from a project setting from a genuinely-unset field.

## Changes

- **`src/bun/repo-config.ts`** — new `resolveConfigProvenance(resolved, project, configPath)` that attributes every key in `DEV3_REPO_CONFIG_KEYS` to exactly one origin: `local` / `repo` / `project` / `default` / `unset`, mirroring `applyConfigCascade` (empty arrays in a file layer count as "not configured", matching `effective()`).
- **`src/bun/cli-socket-server.ts`** — `config.show` now returns this full provenance map instead of `getConfigSources`. `getConfigSources` (repo/local only) is intentionally kept for the Project Settings UI badge and left untouched.
- **`src/cli/commands/config.ts`** — renders the source verbatim (defensive `unset` fallback, no more `global`); object-valued fields like `builtinColumnAgents` render as a readable summary (e.g. `1 column`) instead of `[object Object]`.
- **`src/shared/types.ts`** — new `ResolvedConfigSource` type.
- Tests: 3 new cases in `repo-config.test.ts` (provenance across all five sources + phantom-empty-array handling) and 2 in the CLI `config.test.ts` (verbatim source rendering, object summary).

Note: the literal "(not set)" rendering for unset keys already landed in #760; this PR completes the remaining half — the source column.
