### PR TITLE
feat(terminal): surface Ctrl+D close-pane shortcut in hotkeys reference

### DIFF
--- a/change-logs/2026/07/03/feature-close-pane-hotkey-hints.md
+++ b/change-logs/2026/07/03/feature-close-pane-hotkey-hints.md
@@ -1,0 +1,1 @@
+Surface how to close a terminal pane in the hotkeys reference: the "i" tmux hints popover and the ⌘/ Keyboard Shortcuts overlay now list Ctrl+D (exit shell → close pane) alongside the existing ⌃B x. Added a matching "Did you know?" tip. Cmd+W already closes a pane in iTerm2 keyboard mode (shown under the popover's Keyboard Mode toggle).

--- a/src/mainview/components/KeyboardShortcutsModal.tsx
+++ b/src/mainview/components/KeyboardShortcutsModal.tsx
@@ -75,6 +75,7 @@ function buildTmuxSections(t: T): Section[] {
 				{ keys: "⌃B |", desc: t("tmux.splitVDesc") },
 				{ keys: "⌃B z", desc: t("tmux.zoomDesc") },
 				{ keys: "⌃B x", desc: t("tmux.closePaneDesc") },
+				{ keys: "⌃D", desc: t("tmux.closePaneEofDesc") },
 				{ keys: "⌃B o", desc: t("cheatSheet.nextPane") },
 				{ keys: "⌃B ;", desc: t("cheatSheet.lastPane") },
 				{ keys: "⌃B q", desc: t("cheatSheet.showPaneNumbers") },

--- a/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
+++ b/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
@@ -477,6 +477,7 @@ export default function TaskTmuxControls({ taskId }: TaskTmuxControlsProps) {
 						<kbd className={popoverKbd}>⌃B z</kbd><span className={popoverDesc}>{t("tmux.zoomDesc")}</span>
 						<kbd className={popoverKbd}>⌃B ␣</kbd><span className={popoverDesc}>{t("tmux.nextLayoutDesc")}</span>
 						<kbd className={popoverKbd}>⌃B x</kbd><span className={popoverDesc}>{t("tmux.closePaneDesc")}</span>
+						<kbd className={popoverKbd}>⌃D</kbd><span className={popoverDesc}>{t("tmux.closePaneEofDesc")}</span>
 						<kbd className={popoverKbd}>⌃B M-1</kbd><span className={popoverDesc}>{t("tmux.layoutEvenHDesc")}</span>
 						<kbd className={popoverKbd}>⌃B M-2</kbd><span className={popoverDesc}>{t("tmux.layoutEvenVDesc")}</span>
 						<kbd className={popoverKbd}>⌃B M-3</kbd><span className={popoverDesc}>{t("tmux.layoutMainHDesc")}</span>

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -70,6 +70,7 @@ const terminal = {
 	"tmux.layoutMenuTitle": "tmux layouts",
 	"tmux.chooseLayout": "Choose tmux layout",
 	"tmux.closePaneDesc": "Close pane",
+	"tmux.closePaneEofDesc": "Close pane (exit shell)",
 	"tmux.pickPaneHint": "Click a pane to close it",
 	"tmux.pickPaneCancel": "Esc to cancel",
 	"tmux.pickPaneClose": "Close",

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -272,6 +272,8 @@ const tips = {
 	"tip.mobileComposer.body": "On a phone, type prompts in the box above the key bar — Send pastes them into the terminal with Enter.",
 	"tip.closePanePicker.title": "Pick the pane to close",
 	"tip.closePanePicker.body": "Click Close Pane, then hover the split you mean — it turns red — and click to close exactly that pane.",
+	"tip.closePaneEof.title": "Close a pane fast",
+	"tip.closePaneEof.body": "Press Ctrl+D in a terminal pane to exit the shell and close the pane instantly.",
 } as const;
 
 export default tips;

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -70,6 +70,7 @@ const terminal = {
 	"tmux.layoutMenuTitle": "Distribuciones tmux",
 	"tmux.chooseLayout": "Elegir distribución tmux",
 	"tmux.closePaneDesc": "Cerrar panel",
+	"tmux.closePaneEofDesc": "Cerrar panel (salir del shell)",
 	"tmux.pickPaneHint": "Haz clic en un panel para cerrarlo",
 	"tmux.pickPaneCancel": "Esc para cancelar",
 	"tmux.pickPaneClose": "Cerrar",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -272,6 +272,8 @@ const tips = {
 	"tip.mobileComposer.body": "En un móvil, escribe prompts en el cuadro sobre la barra de teclas — Enviar los pega en el terminal con Enter.",
 	"tip.closePanePicker.title": "Elige el panel a cerrar",
 	"tip.closePanePicker.body": "Pulsa Cerrar panel, pasa el ratón por la división que quieras — se pone roja — y haz clic para cerrar ese panel.",
+	"tip.closePaneEof.title": "Cierra un panel rápido",
+	"tip.closePaneEof.body": "Pulsa Ctrl+D en un panel de terminal para salir del shell y cerrarlo al instante.",
 };
 
 export default tips;

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -72,6 +72,7 @@ const terminal = {
 	"tmux.layoutMenuTitle": "Раскладки tmux",
 	"tmux.chooseLayout": "Выбрать раскладку tmux",
 	"tmux.closePaneDesc": "Закрыть панель",
+	"tmux.closePaneEofDesc": "Закрыть панель (выход из shell)",
 	"tmux.pickPaneHint": "Нажмите на панель, чтобы закрыть её",
 	"tmux.pickPaneCancel": "Esc — отмена",
 	"tmux.pickPaneClose": "Закрыть",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -272,6 +272,8 @@ const tips = {
 	"tip.mobileComposer.body": "На телефоне пишите промпты в поле над рядом клавиш — «Отправить» вставит их в терминал с Enter.",
 	"tip.closePanePicker.title": "Выберите панель для закрытия",
 	"tip.closePanePicker.body": "Нажмите «Закрыть панель», наведите на нужный сплит — он станет красным — и кликните, чтобы закрыть именно его.",
+	"tip.closePaneEof.title": "Быстро закрыть панель",
+	"tip.closePaneEof.body": "Нажмите Ctrl+D в терминальной панели — shell выйдет, и панель закроется мгновенно.",
 };
 
 export default tips;

--- a/src/mainview/tips.ts
+++ b/src/mainview/tips.ts
@@ -1109,6 +1109,14 @@ const ALL_TIPS: Tip[] = [
 		score: 3,
 		contexts: ["terminal"],
 	},
+	{
+		id: "close-pane-eof",
+		titleKey: "tip.closePaneEof.title",
+		bodyKey: "tip.closePaneEof.body",
+		icon: "\u{F030C}", // nf-md-keyboard
+		score: 3,
+		contexts: ["terminal"],
+	},
 ];
 
 const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

Many users don't know how to close a terminal pane. This surfaces the shortcuts in the two places the app documents keybindings:

- **tmux "i" hints popover** (terminal controls) — adds `⌃D` → *Close pane (exit shell)* right under the existing `⌃B x`.
- **⌘/ Keyboard Shortcuts overlay** (Terminal tab, Panes section) — same `⌃D` row.

`⌃D` is the shell EOF: at an empty prompt the shell exits and the tmux pane closes. It isn't an app-level binding (it passes straight through to the pty), so the label says *exit shell* to stay accurate.

`⌘W` already closes a pane in **iTerm2 keyboard mode** (`terminal-keymaps.ts`) and is already documented under the popover's *Keyboard Mode* toggle — no new binding needed.

Also adds a matching "Did you know?" tip and i18n strings for all three locales (en/ru/es).