### PR TITLE
feat(terminal): enable iTerm2 keymap hotkeys by default

### DIFF
--- a/change-logs/2026/07/03/feature-iterm2-keymap-default.md
+++ b/change-logs/2026/07/03/feature-iterm2-keymap-default.md
@@ -1,0 +1,1 @@
+iTerm2 terminal hotkeys (⌘D/⌘⇧D split, ⌘W close pane, ⌘T new window, ⌘[/⌘] navigate) now ship on by default instead of being opt-in. Anyone who explicitly picked the plain "Default" keymap keeps it, and the opt-out now survives a settings round-trip.

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -67,6 +67,22 @@ describe("saveSettings", () => {
 		expect((await loadSettings()).importShellEnv).toBeUndefined();
 	});
 
+	it("defaults terminalKeymap to iTerm2 (undefined) and preserves an explicit opt-out", async () => {
+		// No file → undefined means "iTerm2 on" (the renderer treats a missing
+		// preset as the iterm2 default).
+		expect((await loadSettings()).terminalKeymap).toBeUndefined();
+
+		// Explicit "default" is a real opt-out and must survive a round-trip —
+		// collapsing it to undefined would silently re-enable the hotkeys.
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ terminalKeymap: "default" }), null, 2), "utf-8");
+		expect((await loadSettings()).terminalKeymap).toBe("default");
+		expect(loadSettingsSync().terminalKeymap).toBe("default");
+
+		// Explicit "iterm2" is preserved as well.
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ terminalKeymap: "iterm2" }), null, 2), "utf-8");
+		expect((await loadSettings()).terminalKeymap).toBe("iterm2");
+	});
+
 	it("reads tipsDisabled back from disk (async + sync)", async () => {
 		// User toggled "Disable feature tips" → the flag lives in settings.json.
 		writeFileSync(settingsPath, JSON.stringify(makeSettings({ tipsDisabled: true }), null, 2), "utf-8");

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -63,7 +63,15 @@ export async function loadSettings(): Promise<GlobalSettings> {
 			agentBinaryPaths: data.agentBinaryPaths ?? undefined,
 			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
 			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
-			terminalKeymap: data.terminalKeymap === "iterm2" ? "iterm2" : undefined,
+			// iTerm2 is the default (undefined ⇒ iterm2 in the renderer), so an
+			// explicit "default" is a real opt-out that must survive a round-trip;
+			// collapsing it to undefined would silently re-enable the hotkeys.
+			terminalKeymap:
+				data.terminalKeymap === "iterm2"
+					? "iterm2"
+					: data.terminalKeymap === "default"
+						? "default"
+						: undefined,
 			tipsDisabled: data.tipsDisabled === true ? true : undefined,
 			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
 			defaultDiffViewMode:
@@ -118,7 +126,15 @@ export function loadSettingsSync(): GlobalSettings {
 			agentBinaryPaths: data.agentBinaryPaths ?? undefined,
 			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
 			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
-			terminalKeymap: data.terminalKeymap === "iterm2" ? "iterm2" : undefined,
+			// iTerm2 is the default (undefined ⇒ iterm2 in the renderer), so an
+			// explicit "default" is a real opt-out that must survive a round-trip;
+			// collapsing it to undefined would silently re-enable the hotkeys.
+			terminalKeymap:
+				data.terminalKeymap === "iterm2"
+					? "iterm2"
+					: data.terminalKeymap === "default"
+						? "default"
+						: undefined,
 			tipsDisabled: data.tipsDisabled === true ? true : undefined,
 			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
 			defaultDiffViewMode:

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -415,8 +415,21 @@ describe("TerminalView – keymap shortcuts", () => {
 		target.remove();
 	});
 
-	it("dev3 mode: Cmd+W does NOT call tmuxAction", async () => {
-		// dev3 is the default — no localStorage entry needed
+	it("default preset (nothing stored): Cmd+W calls tmuxAction (iTerm2 is the default)", async () => {
+		// No localStorage entry — iTerm2 hotkeys ship on by default.
+		await renderAndSetup();
+		const target = focusInsideTerminal();
+
+		await act(async () => {
+			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
+		});
+
+		expect(mockedTmuxAction).toHaveBeenCalledWith({ taskId: "t1", action: "killPane" });
+		target.remove();
+	});
+
+	it("default mode (explicit opt-out): Cmd+W does NOT call tmuxAction", async () => {
+		localStorage.setItem(KEYMAP_LS_KEY, "default");
 		await renderAndSetup();
 		const target = focusInsideTerminal();
 

--- a/src/mainview/__tests__/terminal-keymaps.test.ts
+++ b/src/mainview/__tests__/terminal-keymaps.test.ts
@@ -11,13 +11,18 @@ beforeEach(() => {
 });
 
 describe("getKeymapPreset", () => {
-	it("returns 'default' when nothing is stored", () => {
-		expect(getKeymapPreset()).toBe("default");
+	it("returns 'iterm2' when nothing is stored (iTerm2 is the default)", () => {
+		expect(getKeymapPreset()).toBe("iterm2");
 	});
 
 	it("returns 'iterm2' when iterm2 is stored", () => {
 		localStorage.setItem(KEYMAP_LS_KEY, "iterm2");
 		expect(getKeymapPreset()).toBe("iterm2");
+	});
+
+	it("returns 'default' when 'default' is explicitly stored (opt-out)", () => {
+		localStorage.setItem(KEYMAP_LS_KEY, "default");
+		expect(getKeymapPreset()).toBe("default");
 	});
 
 	it("normalizes legacy 'dev3' value to 'default'", () => {

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -915,40 +915,16 @@ describe("GlobalSettings", () => {
 			expect(getKeymapToggle()).toBeInTheDocument();
 		});
 
-		it("toggle is inactive by default", async () => {
+		it("toggle is active by default (iTerm2 ships on)", async () => {
 			setupMocks();
 			renderGlobalSettings();
 			await waitForLoad();
 
-			expect(getKeymapToggle().className).not.toContain("border-accent");
+			expect(getKeymapToggle().className).toContain("border-accent");
 		});
 
-		it("clicking the toggle saves terminalKeymap iterm2 to backend", async () => {
+		it("clicking the toggle opts out, saving terminalKeymap default to backend", async () => {
 			setupMocks();
-			const user = userEvent.setup();
-			renderGlobalSettings();
-			await waitForLoad();
-
-			await user.click(getKeymapToggle());
-
-			expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalledWith(
-				expect.objectContaining({ terminalKeymap: "iterm2" }),
-			);
-		});
-
-		it("clicking the toggle persists iterm2 preset to localStorage", async () => {
-			setupMocks();
-			const user = userEvent.setup();
-			renderGlobalSettings();
-			await waitForLoad();
-
-			await user.click(getKeymapToggle());
-
-			expect(localStorage.getItem(KEYMAP_LS_KEY)).toBe("iterm2");
-		});
-
-		it("clicking the toggle again reverts to default", async () => {
-			setupMocks(mockAgents, { ...mockGlobalSettings, terminalKeymap: "iterm2" });
 			const user = userEvent.setup();
 			renderGlobalSettings();
 			await waitForLoad();
@@ -957,6 +933,30 @@ describe("GlobalSettings", () => {
 
 			expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalledWith(
 				expect.objectContaining({ terminalKeymap: "default" }),
+			);
+		});
+
+		it("clicking the toggle persists the default (opt-out) preset to localStorage", async () => {
+			setupMocks();
+			const user = userEvent.setup();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			await user.click(getKeymapToggle());
+
+			expect(localStorage.getItem(KEYMAP_LS_KEY)).toBe("default");
+		});
+
+		it("clicking the toggle from an explicit opt-out turns iTerm2 back on", async () => {
+			setupMocks(mockAgents, { ...mockGlobalSettings, terminalKeymap: "default" });
+			const user = userEvent.setup();
+			renderGlobalSettings();
+			await waitForLoad();
+
+			await user.click(getKeymapToggle());
+
+			expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalledWith(
+				expect.objectContaining({ terminalKeymap: "iterm2" }),
 			);
 		});
 

--- a/src/mainview/terminal-keymaps.ts
+++ b/src/mainview/terminal-keymaps.ts
@@ -33,10 +33,13 @@ export const TERMINAL_KEYMAPS: Record<TerminalKeymapPreset, KeyBinding[]> = {
 export const KEYMAP_LS_KEY = "dev3-terminal-keymap";
 export const KEYMAP_CHANGED_EVENT = "dev3-terminal-keymap-changed";
 
-/** Normalizes legacy preset values saved before the simplified two-option model. */
+/** Resolves the stored preset. iTerm2 hotkeys ship on by default, so a value
+ *  that was never chosen (null) resolves to "iterm2". Any explicitly-stored
+ *  value is honored: "iterm2" stays iterm2, while "default" and legacy preset
+ *  names (e.g. "tmux-native", "dev3") mean the plain no-app-shortcuts baseline. */
 function normalize(raw: string | null): TerminalKeymapPreset {
-	if (raw === "iterm2") return "iterm2";
-	return "default";
+	if (raw === null) return "iterm2";
+	return raw === "iterm2" ? "iterm2" : "default";
 }
 
 export function getKeymapPreset(): TerminalKeymapPreset {


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

Makes the iTerm2 terminal keymap the default instead of an opt-in setting. Fresh installs (and anyone who never touched the setting) now get the ⌘-based pane/tab hotkeys out of the box:

- **⌘D** / **⌘⇧D** — split vertical / horizontal
- **⌘W** — close pane
- **⌘T** — new window
- **⌘[** / **⌘]** — navigate panes

## How

- `terminal-keymaps.ts`: `getKeymapPreset()`/`normalize()` now resolves an unset preset (`null`) to `iterm2`. Any explicitly-stored value is still honored — `"default"` and legacy names (`tmux-native`, `dev3`) keep the plain no-app-shortcuts baseline, so users who deliberately opted out are unaffected.
- `settings.ts`: an explicit `"default"` is now persisted through `loadSettings`/`loadSettingsSync`. Previously it collapsed to `undefined`; now that `undefined` means "iterm2 default", that would have silently re-enabled the hotkeys — so the opt-out has to survive the round-trip.

## Tests

- Updated `terminal-keymaps`, `TerminalView`, `GlobalSettings`, and `settings` specs for the flipped default, plus new cases covering the default-on behavior and the durable opt-out.
- `bun run lint` clean; full `bun run test` green (mainview 1971 / bun 1778, 0 failures).
- Changelog entry added.

Note: the native Terminal → Keyboard Mode menu items were already dead (no handler wired), so they're untouched here.