### PR TITLE
feat(kanban): 'shutting down' state for tasks awaiting teardown

### DIFF
--- a/change-logs/2026/07/03/feature-shutting-down-card-state.md
+++ b/change-logs/2026/07/03/feature-shutting-down-card-state.md
@@ -1,0 +1,1 @@
+Task cards now show a muted "Shutting down…" state (the opposite of the blue "preparing" loader) while a completed/cancelled task tears down its session and worktree — a window that can last several seconds. The card is greyed and locked (not openable, no context menu) until teardown finishes, so you no longer click a card whose worktree is being destroyed.

--- a/decisions/102-shutting-down-transient-not-persisted.md
+++ b/decisions/102-shutting-down-transient-not-persisted.md
@@ -1,0 +1,30 @@
+# 102 — "Shutting down" is a transient, non-persisted task flag
+
+## Context
+Completing/cancelling a task runs a multi-second teardown in `moveTask`
+(`task-lifecycle.ts`: `destroySession` → `runCleanupScript` → `removeWorktree`).
+Until it finishes, the board card sat in its column, fully clickable, with no
+indication — the agent-approved completion path (`App.tsx` `onAgentCompletionRequested`)
+sets no local `moving` flag, so the existing `isCompleting` grayscale never fired.
+We wanted a "shutting down" card state that also blocks opening.
+
+## Decision
+Added `Task.shuttingDown?: boolean` but kept it **transient**: `moveTask` decorates
+`{ ...task, shuttingDown: true }` onto a `taskUpdated` push at the *start* of the
+teardown branch, and the terminal `taskUpdated` (fresh task from `data.updateTask`,
+no flag) replaces it wholesale in the reducer and clears it. The flag is **never**
+passed to `data.updateTask`, so it never touches disk. `TaskCard` renders a muted,
+indeterminate overlay (grey, no progress bar) and folds `isShuttingDown` into
+`isDisabled` + the `handleClick` open-guard.
+
+## Risks
+An unrelated `taskUpdated` push for the same task mid-teardown (e.g. PR-status poll)
+would clear the overlay early; acceptable — it self-heals and teardown is short.
+A crash mid-teardown loses the flag, which is the *desired* outcome (no stuck card).
+
+## Alternatives considered
+- **Persist it like `preparing`** — rejected: violates the `~/.dev3.0/` no-stuck-state
+  intent (a crash/reload would strand a card as "shutting down"), and `preparing`
+  already needs `preparingStartedAt` + stuck-detection to compensate.
+- **Reuse `isCompleting` only** — rejected: it is local React state, so it misses the
+  agent-approved path and other clients (remote browser) watching the same board.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2121,6 +2121,36 @@ describe("handlers.moveTask", () => {
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 	});
 
+	it("in-progress → completed: pushes a transient shuttingDown snapshot before teardown, never persisting it", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
+		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
+		const push = vi.fn();
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updatedTask);
+		vi.mocked(existsSync).mockReturnValue(true);
+		setPushMessage(push);
+
+		await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
+
+		// A shuttingDown snapshot is pushed to renderers…
+		const idx = push.mock.calls.findIndex(
+			(call: any[]) => call[0] === "taskUpdated" && call[1]?.task?.shuttingDown === true,
+		);
+		expect(idx).toBeGreaterThanOrEqual(0);
+		// …before the slow teardown (removeWorktree) runs.
+		expect(push.mock.invocationCallOrder[idx]).toBeLessThan(
+			vi.mocked(git.removeWorktree).mock.invocationCallOrder[0],
+		);
+
+		// The transient flag is NEVER written to disk (patch is data.updateTask's 3rd arg).
+		for (const call of vi.mocked(data.updateTask).mock.calls) {
+			expect(call[2]).not.toHaveProperty("shuttingDown");
+		}
+	});
+
 	it("in-progress → completed: emits renderer sound before cleanup finishes", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -876,6 +876,13 @@ export async function moveTask(params: {
 				oldStatus,
 				hasWorktree: !!task.worktreePath,
 			});
+			// Announce the "shutting down" window BEFORE the slow teardown below
+			// (destroySession → cleanup script → removeWorktree can take many
+			// seconds). This decorates a transient, NEVER-persisted `shuttingDown`
+			// flag onto the pushed snapshot so every renderer (board + remote
+			// browser) shows the muted card state and blocks opening. The terminal
+			// `taskUpdated` push below replaces the task wholesale and clears it.
+			getPushMessage()?.("taskUpdated", { projectId: project.id, task: { ...task, shuttingDown: true } });
 			try {
 				pty.destroySession(task.id, task.tmuxSocket ?? undefined);
 			} catch (err) {

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -88,7 +88,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const [ctxMenuPos, setCtxMenuPos] = useState({ top: 0, left: 0 });
 
 	const isPreparing = task.preparing === true;
-	const isDisabled = moving || isMovingProp || isPreparing || cancellingPreparation;
+	// Transient teardown window pushed by the server while completing/cancelling
+	// (destroy session → cleanup script → remove worktree). Unlike `preparing`,
+	// the card is NOT openable — the worktree/session are being destroyed.
+	const isShuttingDown = task.shuttingDown === true;
+	const isDisabled = moving || isMovingProp || isPreparing || cancellingPreparation || isShuttingDown;
 	const isTodo = task.status === "todo";
 	const isCancelled = task.status === "cancelled";
 	const isActive = ACTIVE_STATUSES.includes(task.status);
@@ -372,6 +376,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	}
 
 	function handleContextMenu(e: React.MouseEvent) {
+		if (isShuttingDown) return;
 		if (!task.worktreePath) return;
 		e.preventDefault();
 		e.stopPropagation();
@@ -464,7 +469,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	}
 
 	function handleCardMouseEnter() {
-		if (!isActive || menuOpen) return;
+		if (!isActive || menuOpen || isShuttingDown) return;
 		if (!cardRef.current) return;
 		preview.handlers.onMouseEnter(task.id, cardRef.current);
 	}
@@ -490,8 +495,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
-			} ${isCompleting ? "grayscale opacity-40 pointer-events-none" : isPreparing ? "opacity-60" : isDisabled ? "opacity-50 pointer-events-none" : ""}`}
-			style={{ borderLeftColor: isCompleting ? "#888" : color }}
+			} ${isCompleting || isShuttingDown ? "grayscale opacity-40 pointer-events-none" : isPreparing ? "opacity-60" : isDisabled ? "opacity-50 pointer-events-none" : ""}`}
+			style={{ borderLeftColor: isCompleting || isShuttingDown ? "#888" : color }}
 			onClick={handleClick}
 		>
 			{/* Moving spinner overlay */}
@@ -548,6 +553,31 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 									{t("task.cancel")}
 								</button>
 							</Tooltip>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* Shutting-down overlay — muted, indeterminate "powering down" while the
+			    session/worktree are torn down. The opposite of the preparing loader:
+			    grey (not accent), no progress bar (teardown duration is unknowable),
+			    no actions. The card is pointer-events-none, so it is not openable. */}
+			{isShuttingDown && (
+				<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-base/55 px-3 backdrop-blur-[2px]">
+					<div
+						className="flex max-w-full items-center gap-2 rounded-xl border border-edge bg-overlay/95 px-3 py-2 shadow-xl shadow-black/30"
+						role="status"
+						aria-live="polite"
+						aria-busy="true"
+					>
+						<div className="h-3.5 w-3.5 flex-shrink-0 rounded-full border-2 border-fg-muted/30 border-t-fg-muted animate-spin motion-reduce:animate-none" />
+						<div className="min-w-0">
+							<div className="text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-fg-3">
+								{t("task.shuttingDown")}
+							</div>
+							<div className="truncate text-xs text-fg-muted">
+								{t("task.shuttingDownDetail")}
+							</div>
 						</div>
 					</div>
 				</div>

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -788,6 +788,54 @@ describe("TaskCard", () => {
 		});
 	});
 
+	describe("shutting down state", () => {
+		it("shows the muted shutting-down overlay while tearing down", () => {
+			renderCard(makeTask({
+				status: "review-by-user",
+				shuttingDown: true,
+				worktreePath: "/tmp/wt",
+				branchName: "dev3/test",
+			}));
+
+			const status = screen.getByRole("status");
+			expect(status).toHaveAttribute("aria-busy", "true");
+			expect(screen.getByText("Shutting down…")).toBeInTheDocument();
+			expect(screen.getByText("Closing session & worktree")).toBeInTheDocument();
+			// No fake progress bar — teardown duration is unknowable.
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+		});
+
+		it("does not open a shutting-down task on click", async () => {
+			const user = userEvent.setup();
+			const navigate = vi.fn();
+			renderCard(makeTask({
+				id: "sd-1",
+				status: "review-by-user",
+				shuttingDown: true,
+				worktreePath: "/tmp/wt",
+				branchName: "dev3/test",
+			}), { navigate });
+
+			await user.click(screen.getByText("Shutting down…"));
+			await user.click(screen.getByText("My task"));
+
+			expect(navigate).not.toHaveBeenCalled();
+			expect(screen.queryByTestId("task-detail-modal")).not.toBeInTheDocument();
+		});
+
+		it("is not draggable while shutting down", () => {
+			const { container } = renderCard(makeTask({
+				status: "review-by-user",
+				shuttingDown: true,
+				worktreePath: "/tmp/wt",
+				branchName: "dev3/test",
+			}));
+
+			const card = container.querySelector("[data-task-id]");
+			expect(card).toHaveAttribute("draggable", "false");
+		});
+	});
+
 	describe("bell badge", () => {
 		it("shows bell badge when bellCount > 0", () => {
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }), {

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -68,6 +68,8 @@ const kanban = {
 	"task.run": "Run",
 	"task.addVariant": "+ Variant",
 	"task.preparing": "Preparing…",
+	"task.shuttingDown": "Shutting down…",
+	"task.shuttingDownDetail": "Closing session & worktree",
 	"task.preparingStage.resolvingConfig": "Resolving project config",
 	"task.preparingStage.fetchingOrigin": "Fetching origin",
 	"task.preparingStage.creatingWorktree": "Creating worktree",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -68,6 +68,8 @@ const kanban = {
 	"task.run": "Ejecutar",
 	"task.addVariant": "+ Variante",
 	"task.preparing": "Preparando…",
+	"task.shuttingDown": "Cerrando…",
+	"task.shuttingDownDetail": "Cerrando sesión y worktree",
 	"task.preparingStage.resolvingConfig": "Resolviendo la configuración del proyecto",
 	"task.preparingStage.fetchingOrigin": "Obteniendo origin",
 	"task.preparingStage.creatingWorktree": "Creando worktree",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -68,6 +68,8 @@ const kanban = {
 	"task.run": "Запустить",
 	"task.addVariant": "+ Вариант",
 	"task.preparing": "Подготовка…",
+	"task.shuttingDown": "Завершение…",
+	"task.shuttingDownDetail": "Закрытие сессии и рабочего дерева",
 	"task.preparingStage.resolvingConfig": "Читаю конфиг проекта",
 	"task.preparingStage.fetchingOrigin": "Тяну origin",
 	"task.preparingStage.creatingWorktree": "Создаю worktree",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1146,6 +1146,19 @@ export interface Task {
 	preparingProgress?: number | null;
 	/** ISO timestamp when preparation started. Used to detect stuck clones. */
 	preparingStartedAt?: string | null;
+	/**
+	 * True while a terminal move (→ completed/cancelled) is tearing the task down
+	 * server-side: destroying the tmux session, running the cleanup script, and
+	 * removing the git worktree. This window can last many seconds and is the
+	 * "opposite" of {@link preparing} — the card shows a muted "shutting down"
+	 * state and is not openable (there is nothing left to open).
+	 *
+	 * TRANSIENT — decorated only onto the pushed task snapshot at teardown start
+	 * and cleared by the terminal `taskUpdated` push. It is **never persisted**
+	 * (unlike `preparing`): the data layer must not receive it, so a crash
+	 * mid-teardown or an app reload can never leave a task stuck "shutting down".
+	 */
+	shuttingDown?: boolean;
 	/** When true, native macOS notifications fire on status changes. */
 	watched?: boolean;
 	/** Persisted agent session state for recovery after tmux/app crash. */


### PR DESCRIPTION
## Problem
There is often a long delay (up to the multi-second worktree/tmux teardown) between clicking "move to complete" and the task actually moving. The teardown runs synchronously in `moveTask` (`destroySession` → cleanup script → `removeWorktree`). Until now the board card sat **fully clickable** in its column with no indication until it abruptly moved — most visible on the **agent-approved completion** path (`App.tsx onAgentCompletionRequested`), which sets no local `moving` flag.

## What this does
Adds a **"shutting down"** card state — the visual/interaction opposite of the blue todo→in-progress "preparing" loader.

- **Backend:** `moveTask` decorates a **transient, never-persisted** `shuttingDown` flag onto a `taskUpdated` push at the *start* of the teardown branch; the terminal `taskUpdated` clears it. Works for every client (board + remote browser) and both completion paths.
- **Card:** muted / grayscale "powering down" overlay — grey spinner, `SHUTTING DOWN` + `Closing session & worktree`, **no progress bar** (teardown duration is unknowable; a draining bar would be fake progress, violating the manifest's forward-only-honesty rule).
- **Interaction guard:** while shutting down the card is **not openable** (unlike `preparing`, which stays openable — here the worktree/session are being destroyed), not draggable, no context menu, no hover preview.

## UX plan (via `/ux-principal`)
Manifest-**compliant** (Task-card `status` state, Bible §5/§6/§8/§11, §1.1 honesty) — no new destination/surface/token/object, so **zero manifest doc writes**. Visual direction ("powering down", muted + indeterminate) confirmed with the requester.

## Why transient, not persisted like `preparing`
See `decisions/102-shutting-down-transient-not-persisted.md`: a persisted flag could strand a card as "shutting down" after a crash/reload (violates the `~/.dev3.0/` no-stuck-state intent). The flag never reaches `data.updateTask`.

## Tests
- Backend: `shuttingDown` push fires **before** teardown (`removeWorktree`) and is **never** passed to `data.updateTask`.
- Card: overlay renders (`role=status`, `aria-busy`, no progressbar); click does not open; not draggable.
- Full suite green (mainview 1974 + bun 1779).

## Browser QA
Verified in a real browser (headless Chromium) by injecting the state client-side via the real `rpc:taskUpdated` push path (no backend teardown, no data mutated). Overlay renders muted/greyed with spinner; `pointer-events:none`; click does not open; no console errors. Screenshots attached to the task.

## Test instructions
1. On a project board, take a task with a worktree (in-progress / review) and move it to **Completed** (drag to the column, or the card status menu → Completed) — or approve an agent's `dev3 task move --status completed` dialog.
2. Expected: while the worktree/session tear down, the card greys out and shows a small **"Shutting down… / Closing session & worktree"** overlay with a spinner (no progress bar).
3. Try to **click** the shutting-down card → nothing opens. Try to **drag** it → it won't drag. **Right-click** → no context menu.
4. When teardown finishes, the card moves to Completed and the overlay is gone.
5. Reload mid-teardown (or after a crash): no card is ever stuck in "shutting down".

🤖 Generated with [Claude Code](https://claude.com/claude-code)