### PR TITLE
Fix dead Restart-to-Update button (self-heal wiped updateReady flag)

### DIFF
--- a/change-logs/2026/07/05/fix-stuck-restart-to-update.md
+++ b/change-logs/2026/07/05/fix-stuck-restart-to-update.md
@@ -1,0 +1,3 @@
+Fixed the "Restart to Update" button silently doing nothing. Electrobun's checkForUpdate() overwrites its in-memory state with the remote update.json (which has no updateReady field), so any periodic or manual check after a download wiped the ready flag and made apply refuse to run. The apply path now self-heals by re-running the (cheap, idempotent) download before restarting, download/apply are serialized so a background check can't wipe state mid-click, and an apply failure now surfaces as an error toast instead of being swallowed.
+
+Suggested by @genrym (h0x91b/dev-3.0#813)

--- a/decisions/106-updater-ready-flag-self-heal.md
+++ b/decisions/106-updater-ready-flag-self-heal.md
@@ -1,0 +1,29 @@
+# 106 — Self-healing applyUpdate: Electrobun checkForUpdate() wipes updateReady
+
+## Context
+
+Issues #788/#813: the "Restart to Update" header button sometimes did nothing, and the app updated only after the plaque re-appeared minutes later. Restarting dev3 also "fixed" it.
+
+## Investigation
+
+Electrobun's `Updater.checkForUpdate()` (node_modules/electrobun/dist/api/bun/core/Updater.ts) **overwrites** its module-level `updateInfo` with the parsed remote `update.json`, which only contains `{version, hash}` — so every successful check resets `updateReady` to `undefined`. Our 30-min auto-check, the menu "Check for Updates", and even our own recovery code all call it. Consequences in `src/bun/updater.ts`:
+
+1. `applyUpdate()`'s old "refresh via checkForUpdate()" recovery branch could **never** return `updateReady: true` — a wiped flag meant a permanently dead button (error thrown, silently swallowed by the renderer).
+2. If a newer release shipped after the download, `updateReady` was true but stale; Electrobun's `applyUpdate()` silently no-ops on the missing latest tar, leaving the UI stuck on "Restarting...".
+
+## Decision
+
+In `src/bun/updater.ts`:
+- `applyUpdate()` always re-runs `Updater.downloadUpdate()` before applying — it is the only call that can (re)set `updateReady`, and it is cheap/idempotent when the tar is already on disk (re-marks ready without downloading). Heals both wiped-flag and stale-version states.
+- The post-download readiness poll uses `Updater.updateInfo()` only — polling via `checkForUpdate()` was self-defeating (each poll wiped the flag it waited for).
+- `withUpdaterLock()` serializes download/apply so a background auto-check cannot wipe state under a user click.
+- Renderer (`GlobalHeader.handleRestart`) surfaces apply failures via `toast.error` instead of swallowing them.
+
+## Risks
+
+Depends on `downloadUpdate()` staying idempotent-when-cached in Electrobun; if that changes, the pre-apply repair becomes a full re-download (correct but slow). Offline clicks now fail with a visible error (previously a silent no-op).
+
+## Alternatives considered
+
+- Patching/vendoring Electrobun's Updater to not wipe `updateReady` — correct upstream fix but a vendor fork that breaks on every electrobun bump; better as an upstream PR.
+- "Quit & reinstall" fallback UI — treats the symptom, adds manual work for the user.

--- a/src/bun/__tests__/updater.test.ts
+++ b/src/bun/__tests__/updater.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Electrobun's real Updater.checkForUpdate() overwrites its in-memory state
+// with the parsed remote update.json, which only contains {version, hash} —
+// so every check wipes the `updateReady` flag (issue #813). These mocks
+// reproduce that exact behavior so the tests exercise the real failure mode.
+const { mockUpdater, markQuitConfirmed } = vi.hoisted(() => ({
+	mockUpdater: {
+		localInfo: {
+			version: vi.fn(async () => "1.29.0"),
+			hash: vi.fn(async () => "aaaa1111aaaa1111"),
+			channel: vi.fn(async () => "stable"),
+		},
+		updateInfo: vi.fn(),
+		checkForUpdate: vi.fn(),
+		downloadUpdate: vi.fn(),
+		applyUpdate: vi.fn(),
+	},
+	markQuitConfirmed: vi.fn(),
+}));
+
+vi.mock("../electrobun-platform", () => ({
+	Updater: mockUpdater,
+	Utils: {},
+	PATHS: {},
+}));
+vi.mock("../quit-manager", () => ({ markQuitConfirmed }));
+
+import { applyUpdate, downloadUpdateForChannel } from "../updater";
+
+/** Remote state as Electrobun's checkForUpdate() returns it: no updateReady. */
+const remoteState = {
+	version: "1.30.0",
+	hash: "bbbb2222bbbb2222",
+	updateAvailable: true,
+	updateReady: undefined as boolean | undefined,
+	error: "",
+};
+
+describe("applyUpdate", () => {
+	let ready: boolean;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ready = false;
+		mockUpdater.updateInfo.mockImplementation(() => ({ ...remoteState, updateReady: ready }));
+		// checkForUpdate can never restore updateReady — update.json has no such field
+		mockUpdater.checkForUpdate.mockImplementation(async () => {
+			ready = false;
+			return { ...remoteState };
+		});
+		// downloadUpdate finds the tar on disk (or re-downloads) and re-marks ready
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			ready = true;
+		});
+	});
+
+	it("recovers when updateReady was wiped by a later checkForUpdate (issue #813)", async () => {
+		ready = false;
+
+		await applyUpdate();
+
+		expect(mockUpdater.downloadUpdate).toHaveBeenCalled();
+		expect(mockUpdater.applyUpdate).toHaveBeenCalledOnce();
+		expect(markQuitConfirmed).toHaveBeenCalledOnce();
+	});
+
+	it("re-validates the downloaded artifact even when updateReady is already true", async () => {
+		// A newer release may have shipped since the download: the ready flag is
+		// stale and Electrobun's applyUpdate would silently no-op on the missing
+		// tar. The repair download must always run before applying.
+		ready = true;
+
+		await applyUpdate();
+
+		expect(mockUpdater.downloadUpdate).toHaveBeenCalledOnce();
+		expect(mockUpdater.applyUpdate).toHaveBeenCalledOnce();
+		const dlOrder = mockUpdater.downloadUpdate.mock.invocationCallOrder[0];
+		const applyOrder = mockUpdater.applyUpdate.mock.invocationCallOrder[0];
+		expect(dlOrder).toBeLessThan(applyOrder);
+	});
+
+	it("throws and does not restart when the repair download fails to produce a ready update", async () => {
+		ready = false;
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			// download failed — ready flag stays false
+		});
+
+		await expect(applyUpdate()).rejects.toThrow("Update not ready");
+
+		expect(mockUpdater.applyUpdate).not.toHaveBeenCalled();
+		expect(markQuitConfirmed).not.toHaveBeenCalled();
+	});
+
+	it("propagates a repair download crash without restarting", async () => {
+		ready = false;
+		mockUpdater.downloadUpdate.mockRejectedValue(new Error("network down"));
+
+		await expect(applyUpdate()).rejects.toThrow("network down");
+
+		expect(mockUpdater.applyUpdate).not.toHaveBeenCalled();
+		expect(markQuitConfirmed).not.toHaveBeenCalled();
+	});
+});
+
+describe("downloadUpdateForChannel (same channel)", () => {
+	let ready: boolean;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ready = false;
+		mockUpdater.updateInfo.mockImplementation(() => ({ ...remoteState, updateReady: ready }));
+		mockUpdater.checkForUpdate.mockImplementation(async () => {
+			ready = false;
+			return { ...remoteState };
+		});
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			ready = true;
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports ok when the download marks the update ready", async () => {
+		const onProgress = vi.fn();
+
+		const result = await downloadUpdateForChannel("stable", onProgress);
+
+		expect(result.ok).toBe(true);
+		expect(onProgress).toHaveBeenCalledWith("complete", 100);
+	});
+
+	it("never polls readiness via checkForUpdate — that call itself wipes the flag", async () => {
+		vi.useFakeTimers();
+		// Ready flag appears only after one poll interval (slow propagation)
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			setTimeout(() => {
+				ready = true;
+			}, 400);
+		});
+
+		const promise = downloadUpdateForChannel("stable", vi.fn());
+		await vi.advanceTimersByTimeAsync(2000);
+		const result = await promise;
+
+		expect(result.ok).toBe(true);
+		// Exactly one check (the initial state-populating one) — polling must
+		// use updateInfo(), because checkForUpdate resets updateReady.
+		expect(mockUpdater.checkForUpdate).toHaveBeenCalledOnce();
+	});
+});
+
+describe("updater single-flight lock", () => {
+	it("applyUpdate waits for an in-flight download instead of racing it", async () => {
+		vi.clearAllMocks();
+		let ready = false;
+		mockUpdater.updateInfo.mockImplementation(() => ({ ...remoteState, updateReady: ready }));
+		mockUpdater.checkForUpdate.mockImplementation(async () => {
+			ready = false;
+			return { ...remoteState };
+		});
+
+		let releaseDownload!: () => void;
+		const firstDownload = new Promise<void>((resolve) => {
+			releaseDownload = () => {
+				ready = true;
+				resolve();
+			};
+		});
+		mockUpdater.downloadUpdate.mockImplementationOnce(() => firstDownload);
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			ready = true;
+		});
+
+		const downloadPromise = downloadUpdateForChannel("stable", vi.fn());
+		// Let the download reach the blocked downloadUpdate() call
+		await new Promise((r) => setTimeout(r, 10));
+
+		const applyPromise = applyUpdate();
+		await new Promise((r) => setTimeout(r, 10));
+
+		// While the download is blocked, apply must not have restarted the app
+		expect(mockUpdater.applyUpdate).not.toHaveBeenCalled();
+
+		releaseDownload();
+		await downloadPromise;
+		await applyPromise;
+
+		expect(mockUpdater.applyUpdate).toHaveBeenCalledOnce();
+	});
+});

--- a/src/bun/updater.ts
+++ b/src/bun/updater.ts
@@ -8,6 +8,24 @@ const log = createLogger("updater");
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const BASE_URL = "https://h0x91b-releases.s3.eu-west-1.amazonaws.com/dev-3.0";
 
+// Electrobun's Updater keeps its state (updateReady flag, downloaded tar
+// bookkeeping) in module-level memory, and its checkForUpdate() OVERWRITES
+// that state with the parsed remote update.json — which has no `updateReady`
+// field. Any check that runs after a download therefore wipes the ready flag
+// (issue #813: dead "Restart to Update" button). Serialize every download /
+// apply through a single-flight queue so a periodic auto-check can never
+// interleave with (and wipe state under) a user-initiated apply.
+let updaterQueue: Promise<unknown> = Promise.resolve();
+
+function withUpdaterLock<T>(fn: () => Promise<T>): Promise<T> {
+	const run = updaterQueue.then(fn, fn);
+	updaterQueue = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
+
 interface UpdateJson {
 	version: string;
 	hash: string;
@@ -78,7 +96,14 @@ export async function checkForUpdateWithChannel(channel: string): Promise<Update
 	}
 }
 
-export async function downloadUpdateForChannel(
+export function downloadUpdateForChannel(
+	channel: string,
+	onProgress?: (status: string, progress?: number) => void,
+): Promise<{ ok: boolean; error?: string }> {
+	return withUpdaterLock(() => doDownloadUpdateForChannel(channel, onProgress));
+}
+
+async function doDownloadUpdateForChannel(
 	channel: string,
 	onProgress?: (status: string, progress?: number) => void,
 ): Promise<{ ok: boolean; error?: string }> {
@@ -101,28 +126,26 @@ export async function downloadUpdateForChannel(
 				hash: checkResult?.hash?.slice(0, 12),
 			});
 
-			if (checkResult?.updateReady) {
-				// Already downloaded from a previous attempt
-				log.info("Update already downloaded and ready");
-				onProgress?.("complete", 100);
-				return { ok: true };
-			}
-
 			if (!checkResult?.updateAvailable) {
 				const msg = "Built-in updater reports no update available";
 				log.warn(msg);
 				return { ok: false, error: msg };
 			}
 
-			// Step 2: download the update (patch or full bundle)
+			// Step 2: download the update (patch or full bundle). If the tar is
+			// already on disk from a previous attempt, this just re-marks the
+			// update as ready without downloading anything.
 			await Updater.downloadUpdate();
 
 			// Step 3: verify the update is actually ready after download.
 			// Electrobun may not mark updateReady synchronously after downloadUpdate resolves.
+			// Poll via updateInfo() ONLY — calling checkForUpdate() here would itself
+			// wipe the updateReady flag we are waiting for (it overwrites Electrobun's
+			// state with the remote update.json, which has no such field).
 			// Use exponential backoff: 500ms, 1s, 2s, 4s, 8s, 16s, 30s (~61.5s total).
 			const backoffDelays = [500, 1000, 2000, 4000, 8000, 16000, 30000];
 			for (let i = 0; i < backoffDelays.length; i++) {
-				const info = i === 0 ? Updater.updateInfo?.() : await Updater.checkForUpdate();
+				const info = Updater.updateInfo?.();
 				if (info?.updateReady) {
 					log.info("Update ready", { attempt: i + 1 });
 					onProgress?.("complete", 100);
@@ -136,7 +159,7 @@ export async function downloadUpdateForChannel(
 			}
 
 			// Final check after last delay
-			const final = await Updater.checkForUpdate();
+			const final = Updater.updateInfo?.();
 			if (final?.updateReady) {
 				log.info("Update ready after final re-check");
 				onProgress?.("complete", 100);
@@ -204,28 +227,39 @@ export async function downloadUpdateForChannel(
 	}
 }
 
-export async function applyUpdate(): Promise<void> {
-	// Verify the update is actually ready before attempting to apply.
-	// Without this guard, applyUpdate() may just restart the app
-	// without applying anything — causing an infinite update loop.
-	let info = Updater.updateInfo?.();
+export function applyUpdate(): Promise<void> {
+	return withUpdaterLock(doApplyUpdate);
+}
+
+async function doApplyUpdate(): Promise<void> {
+	const info = Updater.updateInfo?.();
 	log.info("Applying update...", {
 		updateReady: info?.updateReady,
 		version: info?.version,
 	});
 
-	if (info && !info.updateReady) {
-		// Try refreshing Electrobun's internal state — the download may have
-		// completed but the ready flag wasn't propagated yet.
-		log.warn("updateReady is false, refreshing via checkForUpdate...");
-		const refreshed = await Updater.checkForUpdate();
-		if (refreshed?.updateReady) {
-			log.info("Update now ready after re-check");
-			info = refreshed;
-		} else {
-			log.error("applyUpdate called but updateReady is still false after re-check — skipping to avoid restart loop");
-			throw new Error("Update not ready to apply");
-		}
+	// Always re-run downloadUpdate() before applying — it is the ONLY call that
+	// can (re)set Electrobun's in-memory updateReady flag, and it is cheap when
+	// the downloaded tar is already on disk (one update.json fetch + a stat).
+	// This heals two dead-button states in one move:
+	//   1. updateReady wiped by any checkForUpdate() that ran after the
+	//      download (periodic auto-check, menu check) — the tar is still on
+	//      disk, so this just re-marks it ready.
+	//   2. A newer release shipped after the download: updateReady points at a
+	//      stale tar and Electrobun's applyUpdate() would silently no-op on the
+	//      missing latest tar, leaving the UI stuck on "Restarting...". Here
+	//      the fresh tar gets downloaded instead.
+	if (!info?.updateReady) {
+		log.warn("updateReady is false, repairing via downloadUpdate...");
+	}
+	await Updater.downloadUpdate();
+
+	const repaired = Updater.updateInfo?.();
+	if (!repaired?.updateReady) {
+		log.error("applyUpdate: update still not ready after repair download — aborting to avoid a no-op restart", {
+			error: repaired?.error,
+		});
+		throw new Error("Update not ready to apply");
 	}
 
 	// The updater restarts the app via Utils.quit(). Mark the quit as confirmed
@@ -268,7 +302,7 @@ export function startAutoCheck(
 	// Check on startup (slight delay to not block init)
 	setTimeout(doCheck, 10_000);
 
-	// Then every 3 hours
+	// Then every CHECK_INTERVAL_MS
 	setInterval(doCheck, CHECK_INTERVAL_MS);
 
 	log.info("Auto-update check scheduled", { intervalMs: CHECK_INTERVAL_MS });

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -6,6 +6,7 @@ import { useT } from "../i18n";
 import { useCompact } from "../utils/useCompact";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { api } from "../rpc";
+import { toast } from "../toast";
 import TmuxSessionManager from "./TmuxSessionManager";
 import InlineRename from "./InlineRename";
 import GitPullButton from "./GitPullButton";
@@ -196,8 +197,9 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 			// to the correct surface.
 			await api.request.saveLastRoute({ route: JSON.stringify(route) });
 			await api.request.applyUpdate();
-		} catch {
+		} catch (err) {
 			setRestarting(false);
+			toast.error(t("update.applyFailed", { error: String(err) }));
 		}
 	}
 

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -24,7 +24,16 @@ vi.mock("../../analytics", () => ({
 	trackEvent: vi.fn(),
 }));
 
+vi.mock("../../toast", () => ({
+	toast: {
+		error: vi.fn(),
+		info: vi.fn(),
+		success: vi.fn(),
+	},
+}));
+
 import { api } from "../../rpc";
+import { toast } from "../../toast";
 
 const mockedApi = vi.mocked(api, true);
 
@@ -557,6 +566,25 @@ describe("GlobalHeader — update countdown", () => {
 		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
 
 		expect(mockedApi.request.applyUpdate).toHaveBeenCalled();
+	});
+
+	it("shows an error toast and re-enables restart when applyUpdate fails (issue #813)", async () => {
+		mockedApi.request.applyUpdate.mockRejectedValue(new Error("Update not ready to apply"));
+		renderHeader(
+			{ screen: "dashboard" },
+			[project1],
+			vi.fn(),
+			[],
+			{ updateVersion: "1.2.3" },
+		);
+
+		act(() => { fireEvent.click(screen.getByText(/Restart to Update \(\d+s\)/)); });
+		// Flush the async handleRestart (saveLastRoute → applyUpdate rejection)
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+		expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Update not ready to apply"));
+		// The UI must not stay stuck on "Restarting..."
+		expect(screen.queryByText("Restarting...")).not.toBeInTheDocument();
 	});
 
 	it("saves current route via RPC before applying update", () => {

--- a/src/mainview/i18n/translations/en/updates.ts
+++ b/src/mainview/i18n/translations/en/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Downloading...",
 	"update.upToDateVersion": "You're up to date — v{version}",
 	"update.checkFailedDetail": "Update check failed: {error}",
+	"update.applyFailed": "Couldn't apply the update: {error}",
 
 	// Requirements
 	"requirements.title": "System Requirements",

--- a/src/mainview/i18n/translations/es/updates.ts
+++ b/src/mainview/i18n/translations/es/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Descargando...",
 	"update.upToDateVersion": "Tienes la última versión — v{version}",
 	"update.checkFailedDetail": "Error al buscar actualizaciones: {error}",
+	"update.applyFailed": "No se pudo aplicar la actualización: {error}",
 
 	// Requirements
 	"requirements.title": "Requisitos del sistema",

--- a/src/mainview/i18n/translations/ru/updates.ts
+++ b/src/mainview/i18n/translations/ru/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Загрузка...",
 	"update.upToDateVersion": "У вас последняя версия — v{version}",
 	"update.checkFailedDetail": "Не удалось проверить обновления: {error}",
+	"update.applyFailed": "Не удалось применить обновление: {error}",
 
 	// Requirements
 	"requirements.title": "Системные требования",


### PR DESCRIPTION
Fixes #813 (and the earlier #788).

## Summary

The "Restart to Update" button could silently do nothing until dev3 was restarted. Root cause is in Electrobun's updater, not in a broken release:

`Updater.checkForUpdate()` **overwrites** its in-memory `updateInfo` with the parsed remote `update.json`, which only carries `{version, hash}` — so every check resets the `updateReady` flag to `undefined`. Our 30-min auto-check (and the menu "Check for Updates") therefore wiped the ready flag after a download completed. The old `applyUpdate()` recovery branch tried to refresh via `checkForUpdate()`, which by construction can never restore `updateReady` — so the button stayed dead. Restarting dev3 "fixed" it only because a fresh download cycle re-set the flag long enough to click.

## Changes (`src/bun/updater.ts`, `src/mainview/components/GlobalHeader.tsx`)

- `applyUpdate()` now always re-runs `downloadUpdate()` before applying. It is the only call that (re)sets `updateReady`, and it is cheap/idempotent when the tar is already on disk. This also heals a second stuck state: when a newer release shipped after the download, Electrobun's `applyUpdate()` silently no-ops on the missing latest tar (UI stuck on "Restarting…") — now the fresh tar is fetched instead.
- Post-download readiness polling uses `updateInfo()` instead of `checkForUpdate()` — polling via the latter was wiping the very flag it waited for.
- Download/apply are serialized through a single-flight lock so a background auto-check can't wipe state under a user-initiated apply.
- The renderer surfaces apply failures as an error toast instead of swallowing them.

Repro-first tests: `src/bun/__tests__/updater.test.ts` (5 of 7 failed against the old code) plus a `GlobalHeader` toast test. Decision record in `decisions/106-updater-ready-flag-self-heal.md`.

Suggested by @genrym (#813).
