### PR TITLE
Make rate-limit hourglass hover animation pronounced

### DIFF
--- a/src/mainview/components/HeaderIcons.tsx
+++ b/src/mainview/components/HeaderIcons.tsx
@@ -271,16 +271,19 @@ export function SlidersIcon({ className }: HeaderIconProps) {
 	);
 }
 
-// 21 — Rate limit: hourglass; sand grains drip while the limit window runs down.
+// 21 — Rate limit: hourglass; sand pours down, then the glass flips over.
+// The outline is 180°-symmetric, so the end-of-cycle flip lands pixel-identical.
 export function RateLimitIcon({ className }: HeaderIconProps) {
 	return (
 		<svg {...svgBase(className)}>
-			<path d="M6 3h12" />
-			<path d="M6 21h12" />
-			<path d="M16.5 3v3.172a2 2 0 0 1-.586 1.414L12 12 8.086 7.586A2 2 0 0 1 7.5 6.172V3" />
-			<path d="M16.5 21v-3.172a2 2 0 0 0-.586-1.414L12 12l-3.914 4.414a2 2 0 0 0-.586 1.414V21" />
-			<path d="M12 13.2v.01" className="hdr hdr-hg-drop" />
-			<path d="M12 13.2v.01" className="hdr hdr-hg-drop-ghost" opacity="0" />
+			<g className="hdr hdr-hg-body">
+				<path d="M6 3h12" />
+				<path d="M6 21h12" />
+				<path d="M16.5 3v3.172a2 2 0 0 1-.586 1.414L12 12 8.086 7.586A2 2 0 0 1 7.5 6.172V3" />
+				<path d="M16.5 21v-3.172a2 2 0 0 0-.586-1.414L12 12l-3.914 4.414a2 2 0 0 0-.586 1.414V21" />
+				<path d="M12 12.9v1" strokeWidth={2.2} className="hdr hdr-hg-drop" />
+				<path d="M12 12.9v1" strokeWidth={2.2} className="hdr hdr-hg-drop-ghost" opacity="0" />
+			</g>
 		</svg>
 	);
 }

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -1020,20 +1020,28 @@ svg .hdr-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 }
 .header-anim:hover .hdr-needle { transform-origin: 12px 14px; animation: hdr-needle 2.6s ease-in-out infinite; }
 
-/* -- Rate-limit hourglass: sand grains drip down into the lower bulb -- */
+/* -- Rate-limit hourglass: sand pours down, then the glass flips over.
+   The outline is 180°-symmetric so the flip lands pixel-identical. -- */
 @keyframes hdr-hg-drop {
-	0%, 10% { transform: translateY(0); opacity: 1; }
-	55% { transform: translateY(4.5px); opacity: 1; }
-	70%, 100% { transform: translateY(5.5px); opacity: 0; }
+	0%, 8% { transform: translateY(0); opacity: 1; }
+	38% { transform: translateY(5.6px); opacity: 1; }
+	46%, 100% { transform: translateY(6.4px); opacity: 0; }
 }
 @keyframes hdr-hg-drop-ghost {
-	0%, 35% { transform: translateY(0); opacity: 0; }
-	45% { opacity: .7; }
-	85% { transform: translateY(4.5px); opacity: .7; }
-	95%, 100% { transform: translateY(5.5px); opacity: 0; }
+	0%, 22% { transform: translateY(0); opacity: 0; }
+	30% { opacity: .8; }
+	52% { transform: translateY(5.6px); opacity: .8; }
+	60%, 100% { transform: translateY(6.4px); opacity: 0; }
+}
+@keyframes hdr-hg-flip {
+	0%, 62% { transform: rotate(0deg); }
+	84% { transform: rotate(189deg); }
+	92% { transform: rotate(176deg); }
+	100% { transform: rotate(180deg); }
 }
 .header-anim:hover .hdr-hg-drop { animation: hdr-hg-drop 2.4s ease-in-out infinite; }
 .header-anim:hover .hdr-hg-drop-ghost { animation: hdr-hg-drop-ghost 2.4s ease-in-out infinite; }
+.header-anim:hover .hdr-hg-body { transform-origin: 12px 12px; animation: hdr-hg-flip 2.4s ease-in-out infinite; }
 
 /* -- GitHub: the octocat takes a polite bow -- */
 @keyframes hdr-gh {


### PR DESCRIPTION
## Summary

Follow-up to #815 — the sand-grain drip was barely visible at header icon size. The hover animation is now clearly readable: a thicker sand stream (2.2 stroke) falls through the full lower bulb, and at the end of each 2.4s cycle the whole hourglass flips 180° with a slight overshoot. The outline is 180°-symmetric, so the flip lands pixel-identical and the loop restarts seamlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)