### PR TITLE
Never delete a regular file at the tmux shim path

### DIFF
--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -1474,15 +1474,33 @@ describe("dereferenceTmuxShim", () => {
 	});
 
 	it("resolves the shim to its symlink target", () => {
+		vi.mocked(lstatSync).mockReturnValue({ isSymbolicLink: () => true } as any);
 		vi.mocked(realpathSync).mockReturnValue(PATH_TMUX);
 		vi.mocked(readlinkSync).mockReturnValue(PATH_TMUX);
 		expect(dereferenceTmuxShim(TMUX_SHIM_PATH)).toBe(PATH_TMUX);
 	});
 
 	it("removes a broken/cyclic shim and returns undefined", () => {
+		vi.mocked(lstatSync).mockReturnValue({ isSymbolicLink: () => true } as any);
 		vi.mocked(realpathSync).mockImplementation(() => { throw new Error("ELOOP"); });
 		expect(dereferenceTmuxShim(TMUX_SHIM_PATH)).toBeUndefined();
 		expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith(TMUX_SHIM_PATH);
+	});
+
+	it("leaves a regular file at the shim path alone and uses it as-is", () => {
+		// The app only ever creates a symlink there — a regular file is the
+		// user's own binary and must never be deleted.
+		vi.mocked(lstatSync).mockReturnValue({ isSymbolicLink: () => false } as any);
+		mockExistsSync.mockReturnValue(true);
+		expect(dereferenceTmuxShim(TMUX_SHIM_PATH)).toBe(TMUX_SHIM_PATH);
+		expect(vi.mocked(unlinkSync)).not.toHaveBeenCalled();
+	});
+
+	it("returns undefined for a missing shim path that is not a symlink", () => {
+		vi.mocked(lstatSync).mockImplementation(() => { throw new Error("ENOENT"); });
+		mockExistsSync.mockReturnValue(false);
+		expect(dereferenceTmuxShim(TMUX_SHIM_PATH)).toBeUndefined();
+		expect(vi.mocked(unlinkSync)).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -234,6 +234,10 @@ export const TMUX_SHIM_PATH = `${DEV3_HOME}/bin/tmux`;
  */
 export function dereferenceTmuxShim(binaryPath: string): string | undefined {
 	if (binaryPath !== TMUX_SHIM_PATH) return binaryPath;
+	// A regular file here is not ours — the app only ever creates a symlink.
+	// Treat it as the user's own tmux binary: use it as-is, never delete it
+	// (updateTmuxShim likewise leaves non-symlinks alone).
+	if (!isSymlink(binaryPath)) return existsSync(binaryPath) ? binaryPath : undefined;
 	try {
 		realpathSync(binaryPath); // throws on ELOOP cycles and dangling targets
 		return readlinkSync(binaryPath);


### PR DESCRIPTION
## Summary

Follow-up hardening to #818 (was pushed to that PR a minute after auto-merge fired, so it needs its own PR).

`dereferenceTmuxShim` treated any unreadable-link state at `~/.dev3.0/bin/tmux` as a broken shim and deleted it. For a **regular file** at that path, `realpathSync` succeeds but `readlinkSync` throws EINVAL — so a tmux binary the user placed there by hand would get unlinked. The app only ever creates a symlink there: a non-symlink is the user's own binary. Now it is used as-is and never deleted, matching the existing courtesy in `updateTmuxShim` (which already leaves non-symlinks alone).

Covered by two new unit tests (regular file → used as-is, never unlinked; missing non-symlink path → `undefined`, no unlink). `bun run lint` clean, full `bun run test` green (2023 + 1882 + 482, 0 failed).
