### PR TITLE
Render mobile terminal/diff screens denser (1.5x) via scoped zoom factor

### DIFF
--- a/change-logs/2026/07/05/fix-mobile-dense-terminal-zoom.md
+++ b/change-logs/2026/07/05/fix-mobile-dense-terminal-zoom.md
@@ -1,0 +1,1 @@
+On mobile devices the task terminal and diff screens now render at ~2/3 scale (1.5× denser), fitting noticeably more content where space is scarce. Board, dashboard, and settings keep the regular mobile scale. The dense factor multiplies the user's zoom setting without changing it, and the terminal font follows automatically.

--- a/decisions/107-mobile-dense-terminal-zoom.md
+++ b/decisions/107-mobile-dense-terminal-zoom.md
@@ -1,0 +1,17 @@
+# 107 — Mobile terminal/diff screens render denser (dense zoom)
+
+## Context
+
+On phones the task terminal screen (and the diff viewer) had no room — chrome ate the screen and little terminal content fit. The rest of the mobile UI (board carousel, dashboard, settings) is already adapted and should keep its scale, so a global mobile zoom was rejected after trying it.
+
+## Decision
+
+`retainDenseZoom()` in `src/mainview/zoom.ts`: a refcounted request for a `MOBILE_DENSE_FACTOR = 0.67` multiplier (1.5× denser; started at 0.5, relaxed after user feedback) on top of the user's zoom. It reuses the root-font-size scaling, so px-based media queries (`useNarrowViewport`, 768px carousel breakpoint) are untouched and the mobile layout stays mobile. `useMobileDenseZoom(route)` in App retains it on terminal-bearing routes (`task`, `project-terminal`, `project` with `activeTaskId`/`taskView` — same predicate family as `needsDesktopViewport`/`inTaskView`); the diff viewer lives inside those routes. The factor only applies when `detectMobile()` (shared `screen.width < 1024` check); on desktop `retainDenseZoom` is a visual no-op. `ZOOM_CHANGED_EVENT` detail now carries the *effective* zoom (user × factor) — `TerminalView` sizes its font from `getEffectiveZoom()`, while `GlobalSettings` displays `getZoom()` (the saved setting).
+
+## Risks
+
+Navigating into/out of a task visibly re-scales the UI on mobile (accepted — full-screen transition anyway). The persisted zoom setting is never multiplied in; if a future call site writes `getEffectiveZoom()` into `applyZoom`, the factor would compound — keep the two APIs distinct. Refcounting exists because StrictMode double-mounts effects and diff/terminal screens can overlap.
+
+## Alternatives considered
+
+Global mobile zoom 0.5 (implemented first, reverted — board/dashboard got too small and looked broken). Viewport `initial-scale=0.5` — doubles layout width past the 768px breakpoint, silently flipping phones to the desktop layout. CSS `zoom: 0.5` on the task container — bitmap-scales the canvas terminal (blur) and skews `getBoundingClientRect` math.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -11,6 +11,7 @@ import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 import { isRemote } from "./utils/platform";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
+import { useMobileDenseZoom } from "./hooks/useMobileDenseZoom";
 import GlobalHeader from "./components/GlobalHeader";
 import AppMenuBar from "./components/AppMenuBar";
 import GlobalSettings from "./components/GlobalSettings";
@@ -82,6 +83,7 @@ function App() {
 	const t = useT();
 	const [, setLocale] = useLocale();
 	useViewport(state.route);
+	useMobileDenseZoom(state.route);
 
 	// Listen for menu actions routed from the bun side. Any menu item that the
 	// renderer is responsible for arrives here as `rpc:menuAction` with

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -7,7 +7,7 @@ import { getShiftKeySequence } from "./shift-key-sequences";
 // TEMP DIAGNOSTIC: remove these imports after the terminal copy bug is fixed.
 import type { TerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
 import { installTerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
-import { getZoom, ZOOM_CHANGED_EVENT } from "./zoom";
+import { getEffectiveZoom, ZOOM_CHANGED_EVENT } from "./zoom";
 import { getScrollThreshold } from "./scroll-speed";
 import { TERMINAL_KEYMAPS, getKeymapPreset, KEYMAP_CHANGED_EVENT } from "./terminal-keymaps";
 import { uploadDroppedFile } from "./utils/uploadDroppedFile";
@@ -367,7 +367,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			}
 
 			console.log("[TerminalView] Creating ghostty-web Terminal instance...");
-			const zoomLevel = getZoom();
+			const zoomLevel = getEffectiveZoom();
 			const term = new Terminal({
 				fontSize: Math.round(TERMINAL_BASE_FONT_SIZE * zoomLevel),
 				fontFamily: TERMINAL_FONT,

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -62,6 +62,7 @@ vi.mock("../zoom", () => ({
 	DEFAULT_ZOOM: 1.0,
 	getZoom: vi.fn().mockReturnValue(1.0),
 	bootstrapZoom: vi.fn(),
+	retainDenseZoom: vi.fn(() => vi.fn()),
 	ZOOM_CHANGED_EVENT: "zoom-changed",
 	MIN_ZOOM: 0.5,
 	MAX_ZOOM: 2.0,

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -103,7 +103,7 @@ vi.mock("../toast", () => ({
 }));
 
 vi.mock("../zoom", () => ({
-	getZoom: () => 1,
+	getEffectiveZoom: () => 1,
 	ZOOM_CHANGED_EVENT: "dev3-zoom-changed",
 }));
 

--- a/src/mainview/__tests__/zoom.test.ts
+++ b/src/mainview/__tests__/zoom.test.ts
@@ -15,17 +15,28 @@ Object.defineProperty(globalThis, "localStorage", { value: localStorageMock, wri
 import {
 	applyZoom,
 	getZoom,
+	getEffectiveZoom,
 	adjustZoom,
 	bootstrapZoom,
+	retainDenseZoom,
 	DEFAULT_ZOOM,
+	MOBILE_DENSE_FACTOR,
 	MIN_ZOOM,
 	MAX_ZOOM,
 	ZOOM_STEP,
 	ZOOM_CHANGED_EVENT,
 } from "../zoom";
 
+const DESKTOP_SCREEN_WIDTH = 1920;
+const MOBILE_SCREEN_WIDTH = 390;
+
+function setScreenWidth(width: number) {
+	Object.defineProperty(window.screen, "width", { value: width, configurable: true });
+}
+
 describe("zoom", () => {
 	beforeEach(() => {
+		setScreenWidth(DESKTOP_SCREEN_WIDTH);
 		storage.clear();
 		localStorageMock.getItem.mockClear();
 		localStorageMock.setItem.mockClear();
@@ -149,10 +160,92 @@ describe("zoom", () => {
 	describe("constants", () => {
 		it("has expected default values", () => {
 			expect(DEFAULT_ZOOM).toBe(1.0);
+			expect(MOBILE_DENSE_FACTOR).toBe(0.67);
 			expect(MIN_ZOOM).toBe(0.5);
 			expect(MAX_ZOOM).toBe(2.0);
 			expect(ZOOM_STEP).toBe(0.1);
 			expect(ZOOM_CHANGED_EVENT).toBe("zoom-changed");
+		});
+	});
+
+	describe("retainDenseZoom on mobile", () => {
+		beforeEach(() => {
+			setScreenWidth(MOBILE_SCREEN_WIDTH);
+		});
+
+		it("scales the root font-size by the dense factor while retained and restores on release", () => {
+			const release = retainDenseZoom();
+			expect(getEffectiveZoom()).toBe(MOBILE_DENSE_FACTOR);
+			expect(document.documentElement.style.fontSize).toBe(`${16 * MOBILE_DENSE_FACTOR}px`);
+			release();
+			expect(getEffectiveZoom()).toBe(DEFAULT_ZOOM);
+			expect(document.documentElement.style.fontSize).toBe("16px");
+		});
+
+		it("does not change the persisted user zoom", () => {
+			const release = retainDenseZoom();
+			expect(getZoom()).toBe(DEFAULT_ZOOM);
+			expect(storage.get("dev3-zoom")).toBe("1");
+			release();
+		});
+
+		it("multiplies on top of the user's zoom", () => {
+			applyZoom(1.2);
+			const expected = Math.round(1.2 * MOBILE_DENSE_FACTOR * 100) / 100;
+			const release = retainDenseZoom();
+			expect(getEffectiveZoom()).toBe(expected);
+			expect(document.documentElement.style.fontSize).toBe(`${16 * expected}px`);
+			release();
+			applyZoom(DEFAULT_ZOOM);
+		});
+
+		it("is refcounted — overlapping retains keep the dense scale", () => {
+			const releaseA = retainDenseZoom();
+			const releaseB = retainDenseZoom();
+			releaseB();
+			expect(getEffectiveZoom()).toBe(MOBILE_DENSE_FACTOR);
+			releaseA();
+			expect(getEffectiveZoom()).toBe(DEFAULT_ZOOM);
+		});
+
+		it("release is idempotent", () => {
+			const releaseA = retainDenseZoom();
+			const releaseB = retainDenseZoom();
+			releaseA();
+			releaseA();
+			expect(getEffectiveZoom()).toBe(MOBILE_DENSE_FACTOR);
+			releaseB();
+			expect(getEffectiveZoom()).toBe(DEFAULT_ZOOM);
+		});
+
+		it("dispatches the zoom-changed event with the effective zoom", () => {
+			const handler = vi.fn();
+			window.addEventListener(ZOOM_CHANGED_EVENT, handler);
+			const release = retainDenseZoom();
+			expect((handler.mock.calls[0][0] as CustomEvent).detail).toBe(MOBILE_DENSE_FACTOR);
+			release();
+			expect((handler.mock.calls[1][0] as CustomEvent).detail).toBe(DEFAULT_ZOOM);
+			window.removeEventListener(ZOOM_CHANGED_EVENT, handler);
+		});
+
+		it("applyZoom while dense keeps the dense factor applied", () => {
+			const release = retainDenseZoom();
+			applyZoom(1.0);
+			expect(document.documentElement.style.fontSize).toBe(`${16 * MOBILE_DENSE_FACTOR}px`);
+			release();
+		});
+	});
+
+	describe("retainDenseZoom on desktop", () => {
+		it("is a visual no-op on wide screens", () => {
+			const handler = vi.fn();
+			window.addEventListener(ZOOM_CHANGED_EVENT, handler);
+			const release = retainDenseZoom();
+			expect(getEffectiveZoom()).toBe(DEFAULT_ZOOM);
+			expect(document.documentElement.style.fontSize).toBe("16px");
+			expect(handler).not.toHaveBeenCalled();
+			release();
+			window.removeEventListener(ZOOM_CHANGED_EVENT, handler);
 		});
 	});
 });

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -120,8 +120,10 @@ function GlobalSettings() {
 	);
 
 	useEffect(() => {
-		function onZoomChanged(event: Event) {
-			setZoomLevel((event as CustomEvent<number>).detail);
+		function onZoomChanged() {
+			// The event detail carries the effective zoom (incl. the mobile dense
+			// factor); settings display the user's saved zoom setting.
+			setZoomLevel(getZoom());
 		}
 
 		window.addEventListener(ZOOM_CHANGED_EVENT, onZoomChanged);

--- a/src/mainview/hooks/__tests__/useMobileDenseZoom.test.tsx
+++ b/src/mainview/hooks/__tests__/useMobileDenseZoom.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Route } from "../../state";
+import { isTerminalRoute, useMobileDenseZoom } from "../useMobileDenseZoom";
+import { retainDenseZoom } from "../../zoom";
+
+const { releaseMock, retainMock } = vi.hoisted(() => {
+	const releaseMock = vi.fn();
+	return { releaseMock, retainMock: vi.fn(() => releaseMock) };
+});
+
+vi.mock("../../zoom", () => ({
+	retainDenseZoom: retainMock,
+}));
+
+const mockedRetain = vi.mocked(retainDenseZoom);
+
+describe("isTerminalRoute", () => {
+	it("matches the full-screen task view", () => {
+		expect(isTerminalRoute({ screen: "task", projectId: "p1", taskId: "t1" })).toBe(true);
+	});
+
+	it("matches the standalone project terminal", () => {
+		expect(isTerminalRoute({ screen: "project-terminal", projectId: "p1" })).toBe(true);
+	});
+
+	it("matches the board with an open task", () => {
+		expect(isTerminalRoute({ screen: "project", projectId: "p1", activeTaskId: "t1" })).toBe(true);
+		expect(isTerminalRoute({ screen: "project", projectId: "p1", taskView: true })).toBe(true);
+	});
+
+	it("does not match board, dashboard, or settings", () => {
+		expect(isTerminalRoute({ screen: "project", projectId: "p1" })).toBe(false);
+		expect(isTerminalRoute({ screen: "dashboard" })).toBe(false);
+		expect(isTerminalRoute({ screen: "settings" })).toBe(false);
+		expect(isTerminalRoute({ screen: "stats" })).toBe(false);
+	});
+});
+
+describe("useMobileDenseZoom", () => {
+	beforeEach(() => {
+		mockedRetain.mockClear();
+		releaseMock.mockClear();
+	});
+
+	it("does not retain on non-terminal routes", () => {
+		renderHook((route: Route) => useMobileDenseZoom(route), {
+			initialProps: { screen: "dashboard" } as Route,
+		});
+		expect(mockedRetain).not.toHaveBeenCalled();
+	});
+
+	it("retains on a terminal route and releases on leave", () => {
+		const { rerender } = renderHook((route: Route) => useMobileDenseZoom(route), {
+			initialProps: { screen: "dashboard" } as Route,
+		});
+		rerender({ screen: "task", projectId: "p1", taskId: "t1" });
+		expect(mockedRetain).toHaveBeenCalledTimes(1);
+		expect(releaseMock).not.toHaveBeenCalled();
+		rerender({ screen: "dashboard" });
+		expect(releaseMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps a single retain when moving between terminal routes", () => {
+		const { rerender } = renderHook((route: Route) => useMobileDenseZoom(route), {
+			initialProps: { screen: "task", projectId: "p1", taskId: "t1" } as Route,
+		});
+		rerender({ screen: "project", projectId: "p1", activeTaskId: "t2" });
+		expect(mockedRetain).toHaveBeenCalledTimes(1);
+		expect(releaseMock).not.toHaveBeenCalled();
+	});
+
+	it("releases on unmount", () => {
+		const { unmount } = renderHook((route: Route) => useMobileDenseZoom(route), {
+			initialProps: { screen: "task", projectId: "p1", taskId: "t1" } as Route,
+		});
+		unmount();
+		expect(releaseMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/mainview/hooks/useMobile.tsx
+++ b/src/mainview/hooks/useMobile.tsx
@@ -9,7 +9,7 @@ import { createContext, useContext, useMemo, type ReactNode } from "react";
  */
 const MOBILE_BREAKPOINT = 1024;
 
-function detectMobile(): boolean {
+export function detectMobile(): boolean {
 	if (typeof window === "undefined") return false;
 	return screen.width < MOBILE_BREAKPOINT;
 }

--- a/src/mainview/hooks/useMobileDenseZoom.ts
+++ b/src/mainview/hooks/useMobileDenseZoom.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import type { Route } from "../state";
+import { retainDenseZoom } from "../zoom";
+
+/**
+ * Screens that show a task workspace (terminal / diff): the full-screen task
+ * view, the standalone project terminal, and the board with an open task.
+ */
+export function isTerminalRoute(route: Route): boolean {
+	return (
+		route.screen === "task" ||
+		route.screen === "project-terminal" ||
+		(route.screen === "project" && (Boolean(route.activeTaskId) || Boolean(route.taskView)))
+	);
+}
+
+/**
+ * While a terminal/diff screen is shown, request the dense UI scale
+ * (mobile-only — see MOBILE_DENSE_FACTOR in zoom.ts). Board, dashboard and
+ * settings keep the regular scale; they are already mobile-adapted.
+ */
+export function useMobileDenseZoom(route: Route): void {
+	const dense = isTerminalRoute(route);
+	useEffect(() => {
+		if (!dense) return;
+		return retainDenseZoom();
+	}, [dense]);
+}

--- a/src/mainview/zoom.ts
+++ b/src/mainview/zoom.ts
@@ -4,24 +4,45 @@
 // the new size — no bitmap scaling, so text stays crisp in WKWebView.
 // Terminal canvases handle zoom separately (see TerminalView).
 
+import { detectMobile } from "./hooks/useMobile";
+
 const ZOOM_KEY = "dev3-zoom";
 export const DEFAULT_ZOOM = 1.0;
 export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 2.0;
 export const ZOOM_STEP = 0.1;
 export const ZOOM_CHANGED_EVENT = "zoom-changed" as const;
+// On mobile devices the terminal/diff screens have no room — they render at
+// ~2/3 scale (1.5× denser) so more content fits. Applied as a multiplier on top
+// of the user's zoom while such a screen is mounted; the saved setting is untouched.
+export const MOBILE_DENSE_FACTOR = 0.67;
 
 const BASE_FONT_SIZE = 16; // browser default root font-size in px
 
 /** In-memory cache — avoids localStorage reads on every call. */
 let currentZoom = DEFAULT_ZOOM;
+/** Refcount of mounted screens requesting the dense (mobile terminal) scale. */
+let denseScreens = 0;
+
+function denseFactor(): number {
+	return denseScreens > 0 && detectMobile() ? MOBILE_DENSE_FACTOR : 1;
+}
+
+/** User zoom × dense-screen factor — what the root font-size and terminal font actually use. */
+export function getEffectiveZoom(): number {
+	return Math.round(currentZoom * denseFactor() * 100) / 100;
+}
+
+function syncRootFontSize() {
+	document.documentElement.style.fontSize = `${BASE_FONT_SIZE * getEffectiveZoom()}px`;
+}
 
 export function applyZoom(level: number) {
 	const clamped = Math.round(Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, level)) * 100) / 100;
 	currentZoom = clamped;
-	document.documentElement.style.fontSize = `${BASE_FONT_SIZE * clamped}px`;
+	syncRootFontSize();
 	localStorage.setItem(ZOOM_KEY, String(clamped));
-	window.dispatchEvent(new CustomEvent(ZOOM_CHANGED_EVENT, { detail: clamped }));
+	window.dispatchEvent(new CustomEvent(ZOOM_CHANGED_EVENT, { detail: getEffectiveZoom() }));
 }
 
 export function getZoom(): number {
@@ -32,12 +53,39 @@ export function adjustZoom(delta: number) {
 	applyZoom(currentZoom + delta);
 }
 
+/**
+ * Request the dense scale while a screen that needs it (mobile terminal/diff)
+ * is mounted. Returns a release function; refcounted so overlapping screens
+ * (e.g. diff opened inside the task view) don't fight over the factor.
+ * No-op visually on non-mobile devices.
+ */
+export function retainDenseZoom(): () => void {
+	const before = getEffectiveZoom();
+	denseScreens++;
+	notifyIfChanged(before);
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		const prev = getEffectiveZoom();
+		denseScreens = Math.max(0, denseScreens - 1);
+		notifyIfChanged(prev);
+	};
+}
+
+function notifyIfChanged(previousEffective: number) {
+	const effective = getEffectiveZoom();
+	if (effective === previousEffective) return;
+	syncRootFontSize();
+	window.dispatchEvent(new CustomEvent(ZOOM_CHANGED_EVENT, { detail: effective }));
+}
+
 /** Call once before React mounts to apply saved zoom and expose the API globally. */
 export function bootstrapZoom() {
 	const parsed = parseFloat(localStorage.getItem(ZOOM_KEY) ?? "");
 	const saved = Number.isFinite(parsed) ? parsed : DEFAULT_ZOOM;
 	currentZoom = Math.round(Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, saved)) * 100) / 100;
 	// Apply without dispatching event (no listeners exist yet)
-	document.documentElement.style.fontSize = `${BASE_FONT_SIZE * currentZoom}px`;
+	syncRootFontSize();
 	localStorage.setItem(ZOOM_KEY, String(currentZoom));
 }


### PR DESCRIPTION
Hi, this is Claude — the AI assistant working on this branch.

## Summary

On phones the task terminal and diff screens had no room: chrome ate the screen and little content fit. This PR makes those screens render at ~2/3 scale (1.5× denser) on mobile devices, while the board, dashboard, and settings keep their regular mobile scale (they are already adapted).

- `retainDenseZoom()` in `zoom.ts`: a refcounted `MOBILE_DENSE_FACTOR = 0.67` multiplier applied on top of the user's zoom via the existing root-font-size mechanism — px media queries (768px carousel breakpoint) are untouched, so the mobile layout stays mobile, just denser. The saved zoom setting is never modified.
- `useMobileDenseZoom(route)` retains the factor while a terminal-bearing route is shown (`task`, `project-terminal`, `project` with an open task); the diff viewer lives inside those routes. Visual no-op on desktop (`detectMobile()` gate).
- `ZOOM_CHANGED_EVENT` detail now carries the *effective* zoom: `TerminalView` sizes its font from `getEffectiveZoom()`, `GlobalSettings` displays the saved setting via `getZoom()`.

A global mobile zoom (0.5 for the whole UI) was tried first and rejected — it shrank the already-adapted board/dashboard and looked broken. See `decisions/107-mobile-dense-terminal-zoom.md` for the trade-offs (viewport `initial-scale` and CSS `zoom` were also considered and rejected).

Verified in headless Chromium with iPhone 14 Pro emulation: terminal screen renders at 10.72px root font-size, board restores to 16px on navigation back; refcount survives route changes and StrictMode double-mounts. Full test suite green.