### PR TITLE
Fix bump script: push only the new release tag

### DIFF
--- a/change-logs/2026/07/06/fix-bump-push-single-tag.md
+++ b/change-logs/2026/07/06/fix-bump-push-single-tag.md
@@ -1,0 +1,1 @@
+Fixed the version bump script pushing all local tags (`git push --tags`) instead of just the new release tag. GitHub silently drops the push event when more than 3 tags are pushed at once, so a bulk push containing stale local tags could swallow the Release workflow trigger entirely (this bit the v1.30.0 release).

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -54,6 +54,9 @@ await $`git commit -m ${"v" + newVersion}`;
 await $`git tag ${"v" + newVersion}`;
 
 await $`git push`;
-await $`git push --tags`;
+// Push ONLY the new tag — never `git push --tags`. A bulk tag push can sweep
+// up stale/foreign local tags, and GitHub silently drops the push event (and
+// thus the Release workflow) when more than 3 tags arrive at once.
+await $`git push origin ${"refs/tags/v" + newVersion}`;
 
 console.log(`Tag v${newVersion} pushed.`);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this repo).

`bun run bump` used `git push --tags`, which pushes every local tag. Today that swept two stale test tags plus an accidental `v1.29.4` along with `v1.30.0` — 4 tags in one push — and GitHub silently drops the push event (and the Release workflow trigger) when more than 3 tags arrive at once, so no release build started. Now the script pushes only `refs/tags/v<newVersion>`.