### PR TITLE
Unify git-pull spinner with the update-check SVG spinner

### DIFF
--- a/change-logs/2026/07/06/refactor-git-pull-spinner-unify.md
+++ b/change-logs/2026/07/06/refactor-git-pull-spinner-unify.md
@@ -1,0 +1,1 @@
+Replaced the git-pull button's CSS ring spinner with the smoother SVG spinner already used by the "checking for updates" header indicator, so both loading states look identical.

--- a/src/mainview/components/GitPullButton.tsx
+++ b/src/mainview/components/GitPullButton.tsx
@@ -215,17 +215,22 @@ function GitPullButton({ projectId, compact = false }: GitPullButtonProps) {
 			>
 				<span className="relative inline-flex items-center justify-center w-[1.125rem] h-[1.125rem]" aria-hidden="true">
 					{iconSpin ? (
-						// Pull in progress: a circular ring spinner. A ring is radially symmetric, so
-						// animate-spin rotates it perfectly around its own center — zero wobble. (A
-						// spinning Nerd Font glyph wobbles instead, because its ink center never lines
-						// up with its advance-width × line-height layout box.) The fixed-size icon slot
-						// above is shared by the idle glyph and this ring, so the icon does not shift
-						// sideways when the spin starts; the ring is sized below the slot so it reads no
-						// larger than the neighboring toolbar icons.
-						<span
+						// Pull in progress: reuse the exact SVG spinner from the "checking for updates"
+						// header indicator (see GlobalHeader) so both loading states look identical.
+						// An <svg> centered on its own viewBox spins cleanly around its center with
+						// animate-spin — smooth, no wobble. (A spinning Nerd Font glyph wobbles instead,
+						// because its ink center never lines up with its advance-width × line-height
+						// layout box.) The fixed-size icon slot above is shared by the idle glyph and
+						// this spinner, so the icon does not shift sideways when the spin starts.
+						<svg
 							data-testid="git-pull-spinner"
-							className={`w-3.5 h-3.5 rounded-full border-2 border-current/30 border-t-current${reducedMotion ? "" : " animate-spin"}`}
-						/>
+							className={`w-3.5 h-3.5${reducedMotion ? "" : " animate-spin"}`}
+							viewBox="0 0 24 24"
+							fill="none"
+						>
+							<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+							<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+						</svg>
 					) : (
 						<IconComp className="w-[1.125rem] h-[1.125rem]" />
 					)}

--- a/src/mainview/components/__tests__/GitPullButton.test.tsx
+++ b/src/mainview/components/__tests__/GitPullButton.test.tsx
@@ -128,7 +128,7 @@ describe("GitPullButton", () => {
 		expect(alertMock).not.toHaveBeenCalled();
 	});
 
-	it("shows a centered circular ring spinner while a pull is in progress", async () => {
+	it("shows the shared SVG spinner while a pull is in progress", async () => {
 		(api.request.getProjectCurrentBranch as any).mockResolvedValue({
 			branch: "main",
 			isBaseBranch: true,
@@ -144,15 +144,18 @@ describe("GitPullButton", () => {
 		const btn = await screen.findByTestId("git-pull-button");
 		await waitFor(() => expect(btn).not.toBeDisabled());
 		await userEvent.click(btn);
-		// While pulling we show a circular ring spinner instead of a spinning Nerd Font glyph.
-		// A ring is radially symmetric, so it rotates perfectly around its own center (no wobble),
-		// and it carries no text content.
+		// While pulling we show the same SVG spinner as the "checking for updates" header
+		// indicator instead of a spinning Nerd Font glyph — it spins cleanly around its own
+		// center (no wobble) and carries no text content.
 		const spinner = await screen.findByTestId("git-pull-spinner");
+		expect(spinner.tagName.toLowerCase()).toBe("svg");
 		expect(spinner.textContent).toBe("");
-		expect(spinner.className).toMatch(/rounded-full/);
-		expect(spinner.className).toMatch(/border-t-current/);
-		expect(spinner.className).toMatch(/w-3\.5/);
-		expect(spinner.className).toMatch(/h-3\.5/);
+		// Same markup as the "checking for updates" header spinner: a circle track + arc.
+		expect(spinner.querySelector("circle")).not.toBeNull();
+		expect(spinner.querySelector("path")).not.toBeNull();
+		const spinnerClass = spinner.getAttribute("class") ?? "";
+		expect(spinnerClass).toMatch(/w-3\.5/);
+		expect(spinnerClass).toMatch(/h-3\.5/);
 		// Settle the pending promise to avoid act() warnings.
 		await act(async () => {
 			resolvePull({ ok: true, branch: "main", output: "Already up to date.", error: "" });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

The git-pull button used a CSS border-ring spinner (`rounded-full border-2 … border-t-current`) while a pull was in progress, which looked slightly off compared to the smoother SVG spinner already used by the "checking for updates" header indicator in `GlobalHeader`.

This swaps the git-pull spinner for that exact same SVG spinner (a circle track + rotating arc) so both loading states are visually identical. The `data-testid`, `prefers-reduced-motion` handling, and the fixed-size icon slot (so the button doesn't shift when the spin starts) are all preserved. The `GitPullButton` test was updated to assert the new SVG markup.