### PR TITLE
Isolate unit-test logging from the real ~/.dev3.0/logs

### DIFF
--- a/change-logs/2026/07/06/fix-test-log-isolation.md
+++ b/change-logs/2026/07/06/fix-test-log-isolation.md
@@ -1,0 +1,1 @@
+Unit tests no longer pollute the real ~/.dev3.0/logs with fake ERROR/WARN lines: logger.ts now redirects to an isolated tmp dir under vitest (or a DEV3_LOG_DIR override), so no test worker touches the production daily log.

--- a/decisions/108-test-log-isolation.md
+++ b/decisions/108-test-log-isolation.md
@@ -1,0 +1,38 @@
+# 108 — Isolate unit-test logging from the real ~/.dev3.0/logs
+
+## Context
+
+`src/bun/logger.ts` unconditionally wrote daily logs to `${DEV3_HOME}/logs`.
+Any vitest worker that imported a module calling `createLogger` (updater.ts,
+data.ts, git.ts, …) *without* a per-file `vi.mock("../logger")` therefore
+appended its synthetic INFO/WARN/ERROR lines to the **real user log**. During a
+live incident these fake `[NNNN:updater] applyUpdate … aborting` errors and
+`bbbb2222` update hashes (from `updater.test.ts` fixtures) were mistaken for a
+broken production updater and cost real investigation time.
+
+## Decision
+
+`resolveLogDir(env)` (pure, testable — mirrors the existing `resolveLogLevel`)
+now picks the log directory, first match wins: (1) explicit `DEV3_LOG_DIR`
+override, (2) under a test runner (`VITEST` / `NODE_ENV=test`) → an isolated
+`${os.tmpdir()}/dev3-test-logs`, (3) otherwise the real `${DEV3_HOME}/logs`.
+`getLogDir()` in `src/bun/logger.ts` calls it. This fixes every current and
+future bun/cli test at once with no per-file logger mock. The write path is
+unchanged (appendFileSync still runs, just against tmp), so the existing
+`logger.test.ts` fs-mocked assertions keep passing.
+
+## Risks
+
+If the real app is ever launched with `NODE_ENV=test` its logs would misroute to
+tmp — but nothing in the app sets that; only vitest does. `VITEST` is the
+primary signal. Real subprocesses spawned by tests that run compiled code
+without inheriting `VITEST` would still write to the real dir, but no current
+test does this (verified: a full `bun run test:full` appended zero test-worker
+lines — only the concurrently-running live app kept logging).
+
+## Alternatives considered
+
+- **Global vitest setup mocking `../logger`** — the CLI config has no
+  `setupFiles`, and mocks don't cover spawned child processes.
+- **Per-file `vi.mock("../logger")`** — must touch dozens of files and is easy
+  to forget in new tests; this bug was exactly that omission.

--- a/src/bun/__tests__/logger.test.ts
+++ b/src/bun/__tests__/logger.test.ts
@@ -8,7 +8,39 @@ vi.mock("node:fs", () => ({
 	mkdirSync: (...args: unknown[]) => mkdirSync(...args),
 }));
 
-import { createLogger, getMinLevel, resolveLogLevel, setMinLevel } from "../logger";
+import { createLogger, getLogPath, getMinLevel, resolveLogDir, resolveLogLevel, setMinLevel } from "../logger";
+
+describe("resolveLogDir", () => {
+	it("honors an explicit DEV3_LOG_DIR override above everything else", () => {
+		expect(resolveLogDir({ DEV3_LOG_DIR: "/custom/logs", VITEST: "true" })).toBe("/custom/logs");
+		expect(resolveLogDir({ DEV3_LOG_DIR: "  /trimmed  " })).toBe("/trimmed");
+	});
+
+	it("redirects to an isolated tmp dir under a test runner (never the real ~/.dev3.0/logs)", () => {
+		const underVitest = resolveLogDir({ VITEST: "true" });
+		const underNodeEnv = resolveLogDir({ NODE_ENV: "test" });
+		expect(underVitest).toContain("dev3-test-logs");
+		expect(underNodeEnv).toContain("dev3-test-logs");
+		expect(underVitest).not.toContain("/.dev3.0/logs");
+	});
+
+	it("uses the real ${DEV3_HOME}/logs for the app / CLI (no test signal, no override)", () => {
+		expect(resolveLogDir({})).toMatch(/\.dev3\.0\/logs$/);
+	});
+
+	it("ignores a blank DEV3_LOG_DIR and falls through to the next rule", () => {
+		expect(resolveLogDir({ DEV3_LOG_DIR: "   ", VITEST: "true" })).toContain("dev3-test-logs");
+	});
+});
+
+describe("test-run log isolation (regression: fake ERROR/WARN pollution)", () => {
+	// The whole suite runs under vitest (VITEST=true), so the live logger sink
+	// must already point away from the real user log. If this ever fails, unit
+	// tests are appending synthetic lines to ~/.dev3.0/logs again.
+	it("never resolves the live log directory inside the real ~/.dev3.0/logs", () => {
+		expect(getLogPath()).not.toContain("/.dev3.0/logs");
+	});
+});
 
 describe("resolveLogLevel", () => {
 	it("honors an explicit DEV3_LOG_LEVEL override (case-insensitive)", () => {

--- a/src/bun/logger.ts
+++ b/src/bun/logger.ts
@@ -1,4 +1,5 @@
 import { appendFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { DEV3_HOME } from "./paths";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
@@ -47,6 +48,32 @@ export function resolveLogLevel(env: Record<string, string | undefined>): LogLev
 	return env.DEV3_CHANNEL === "dev" ? "debug" : "info";
 }
 
+/**
+ * Resolve the directory the daily log files live in.
+ *
+ * History: this used to be hard-coded to `${DEV3_HOME}/logs`. Every vitest
+ * worker that imported a module calling `createLogger` (updater.ts, data.ts,
+ * git.ts, …) without a per-file `vi.mock("../logger")` therefore appended its
+ * synthetic INFO/WARN/ERROR lines to the *real* user log — polluting it with
+ * fake `[NNNN:updater] applyUpdate` errors and `bbbb2222` update hashes that
+ * cost real time to misdiagnose during a live incident. See decision 108.
+ *
+ * Rules (first match wins):
+ *   1. `DEV3_LOG_DIR` — explicit override, always honored (tests, sandboxes).
+ *   2. under a test runner (`VITEST` / `NODE_ENV=test`) — an isolated tmp dir,
+ *      so unit tests never touch `${DEV3_HOME}/logs`. This fixes every current
+ *      and future bun/cli test at once, with no per-file logger mock needed.
+ *   3. everything else (the real app / CLI) — `${DEV3_HOME}/logs`.
+ */
+export function resolveLogDir(env: Record<string, string | undefined>): string {
+	const override = env.DEV3_LOG_DIR?.trim();
+	if (override) return override;
+	if (env.VITEST || env.NODE_ENV === "test") {
+		return `${tmpdir()}/dev3-test-logs`;
+	}
+	return `${DEV3_HOME}/logs`;
+}
+
 let minLevel: LogLevel = resolveLogLevel(process.env);
 let logDir: string | null = null;
 let currentLogFile: string | null = null;
@@ -57,7 +84,7 @@ const ensuredDirs = new Set<string>();
 
 function getLogDir(): string {
 	if (!logDir) {
-		logDir = `${DEV3_HOME}/logs`;
+		logDir = resolveLogDir(process.env);
 	}
 	return logDir;
 }


### PR DESCRIPTION
## Summary

`src/bun/logger.ts` unconditionally wrote daily logs to `${DEV3_HOME}/logs`. Any vitest worker that imported a module calling `createLogger` (updater.ts, data.ts, git.ts, …) **without** a per-file `vi.mock("../logger")` therefore appended its synthetic INFO/WARN/ERROR lines to the **real user log** — polluting it with fake `[NNNN:updater] applyUpdate … aborting` errors and `bbbb2222` update hashes (from `updater.test.ts` fixtures) that were mistaken for a broken production updater during a live incident.

Fix: a pure, testable `resolveLogDir(env)` (mirrors the existing `resolveLogLevel`) now picks the log directory, first match wins:
1. `DEV3_LOG_DIR` — explicit override, always honored.
2. Under a test runner (`VITEST` / `NODE_ENV=test`) → an isolated `${os.tmpdir()}/dev3-test-logs`.
3. Otherwise → the real `${DEV3_HOME}/logs`.

This fixes every current and future bun/cli test at once, with no per-file logger mock. The write path is unchanged (`appendFileSync` still runs, just against tmp), so the existing fs-mocked `logger.test.ts` assertions keep passing.

## Verification

- Reproduced: today's real log had 320 `:updater]` lines + 40 `bbbb2222` hashes from test workers.
- After the fix, a full `bun run test:full` appended **32 lines** to the real log — **all** from the concurrently-running live app (PID of `/Applications/dev-3.0.app`), **zero** from any test worker, **zero** updater/`bbbb2222` markers. Test logs landed in `${os.tmpdir()}/dev3-test-logs`.
- `bun run test`, `bun run test:full`, and `bun run lint` all green.

Regression guards: `resolveLogDir` unit tests (override, tmp under VITEST/NODE_ENV, prod path, blank override) + a live assertion that the test-run sink never resolves inside `~/.dev3.0/logs`.

See `decisions/108-test-log-isolation.md`.