### PR TITLE
Fix scripts runner dropdown overflowing viewport on narrow windows

### DIFF
--- a/change-logs/2026/07/06/fix-scripts-dropdown-overflow.md
+++ b/change-logs/2026/07/06/fix-scripts-dropdown-overflow.md
@@ -1,0 +1,1 @@
+Fixed the Scripts runner dropdown overflowing past the right screen edge on narrow windows (mobile/remote browser). The popover now shrinks its width to fit the viewport and keeps a 16px gutter on both sides instead of using a fixed 24rem width.

--- a/src/mainview/components/task-info-panel/TaskScripts.tsx
+++ b/src/mainview/components/task-info-panel/TaskScripts.tsx
@@ -18,6 +18,27 @@ import { ScriptsIcon } from "../TaskIcons";
 
 const DEFAULT_PLACEMENT_IDX = SCRIPT_PLACEMENTS.indexOf("right");
 
+/** Desired popover width (24rem) and the gutter kept on both sides of the viewport. */
+const MAX_DROPDOWN_WIDTH = 384;
+const VIEWPORT_MARGIN = 16;
+
+/**
+ * Compute the popover placement so it never overflows the viewport.
+ * On a narrow window the width shrinks to fit the gutter — clamping `left`
+ * alone (the old behavior) is not enough when the width is fixed. Exported for tests.
+ */
+export function computeScriptsDropdownGeometry(
+	rect: { left: number; bottom: number },
+	viewportWidth: number,
+): { top: number; left: number; width: number } {
+	const width = Math.min(MAX_DROPDOWN_WIDTH, Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2));
+	const left = Math.max(
+		VIEWPORT_MARGIN,
+		Math.min(rect.left, viewportWidth - width - VIEWPORT_MARGIN),
+	);
+	return { top: rect.bottom + 6, left, width };
+}
+
 interface TaskScriptsProps {
 	task: Task;
 	project: Project;
@@ -27,6 +48,7 @@ interface TaskScriptsProps {
 interface DropdownPosition {
 	top: number;
 	left: number;
+	width: number;
 }
 
 /** A single runnable row: an npm script or a Makefile target. */
@@ -61,7 +83,7 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 	const btnRef = useRef<HTMLButtonElement>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
 	const [open, setOpen] = useState(false);
-	const [pos, setPos] = useState<DropdownPosition>({ top: 0, left: 0 });
+	const [pos, setPos] = useState<DropdownPosition>({ top: 0, left: 0, width: MAX_DROPDOWN_WIDTH });
 	const [data, setData] = useState<WorktreeScripts | null>(null);
 	const [runner, setRunner] = useState<ScriptRunner | null>(null);
 	const [pickerFor, setPickerFor] = useState<PickerTarget | null>(null);
@@ -165,8 +187,7 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 		if (!isTaskActive) return;
 		const rect = btnRef.current?.getBoundingClientRect();
 		if (!rect) return;
-		const width = 380;
-		setPos({ top: rect.bottom + 6, left: Math.max(8, Math.min(rect.left, window.innerWidth - width - 8)) });
+		setPos(computeScriptsDropdownGeometry(rect, window.innerWidth));
 		setOpen(true);
 		setPickerFor(null);
 		setQuery("");
@@ -298,10 +319,11 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 			/>
 			<div
 				data-task-scripts-popover
-				className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active w-[24rem] flex flex-col"
+				className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active flex flex-col"
 				style={{
 					top: pos.top,
 					left: pos.left,
+					width: pos.width,
 					maxHeight: `calc(100vh - ${pos.top + 16}px)`,
 				}}
 				onMouseDown={(e) => e.stopPropagation()}

--- a/src/mainview/components/task-info-panel/__tests__/TaskScripts.test.ts
+++ b/src/mainview/components/task-info-panel/__tests__/TaskScripts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { computeScriptsDropdownGeometry } from "../TaskScripts";
+
+const MARGIN = 16;
+
+describe("computeScriptsDropdownGeometry", () => {
+	it("positions the popover just below the button", () => {
+		const g = computeScriptsDropdownGeometry({ left: 100, bottom: 40 }, 1440);
+		expect(g.top).toBe(46);
+	});
+
+	it("keeps full width on a wide viewport", () => {
+		const g = computeScriptsDropdownGeometry({ left: 100, bottom: 40 }, 1440);
+		expect(g.width).toBe(384);
+		expect(g.left).toBe(100);
+	});
+
+	it("never lets the popover overflow the right edge on a narrow viewport", () => {
+		// Regression: a fixed 384px width overflowed narrow (mobile/remote) windows
+		// even after clamping `left` — the right side of the dropdown got cut off.
+		const viewport = 375;
+		const g = computeScriptsDropdownGeometry({ left: 300, bottom: 40 }, viewport);
+		expect(g.left).toBeGreaterThanOrEqual(MARGIN);
+		expect(g.left + g.width).toBeLessThanOrEqual(viewport - MARGIN);
+	});
+
+	it("shrinks the width to leave a gutter on both sides when the viewport is narrower than the max", () => {
+		const viewport = 320;
+		const g = computeScriptsDropdownGeometry({ left: 0, bottom: 40 }, viewport);
+		expect(g.left).toBe(MARGIN);
+		expect(g.width).toBe(viewport - MARGIN * 2);
+	});
+
+	it("clamps a button near the right edge so the popover stays on screen", () => {
+		const viewport = 1000;
+		const g = computeScriptsDropdownGeometry({ left: 980, bottom: 40 }, viewport);
+		expect(g.left + g.width).toBeLessThanOrEqual(viewport - MARGIN);
+		expect(g.width).toBe(384);
+	});
+
+	it("never returns a negative width for a degenerate viewport", () => {
+		const g = computeScriptsDropdownGeometry({ left: 0, bottom: 40 }, 10);
+		expect(g.width).toBeGreaterThanOrEqual(0);
+	});
+});


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

The Scripts runner dropdown ran off the right edge of the screen on narrow windows (mobile / remote browser, or a shrunk desktop window). The popover used a fixed `w-[24rem]` (384px) width and `openDropdown()` only clamped its `left` position — never the width — so once the viewport got narrow enough the right side (search box / runner chip / list) was cut off.

## Fix

- Extracted the positioning math into a pure, exported `computeScriptsDropdownGeometry()` helper that computes **both** `left` and `width`.
- The popover now shrinks its width to fit the viewport and keeps a **16px gutter on both sides** (previously 8px, left-only), so it can never overflow.
- Replaced the fixed `w-[24rem]` class with the computed width.
- Added unit tests covering wide, right-edge, and narrow (375/320px) viewports plus a degenerate-viewport guard.

Verified live in the browser: at 768px the dropdown sits fully on-screen with a 16px right gutter (the old code left only 4px). `bun run lint` and the full test suite are green.