### PR TITLE
Stop false GitHub Pages deploy-failure emails

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy landing page
+
+# Replaces GitHub's auto-generated "pages build and deployment" (legacy
+# "Deploy from a branch") workflow, which fired on EVERY push to main and,
+# on parallel PR merges, raced the Pages API — the superseded run died with
+# "Deployment failed, try again later." and emailed a false "Run failed".
+#
+# Two changes kill that spam:
+#   1. path filter — only run when the landing page (docs/**) actually changes,
+#      so ordinary code merges no longer trigger a Pages deploy at all.
+#   2. concurrency group — serialize deploys so two runs never hit the Pages
+#      API at once; a superseded run ends as "cancelled" (no failure email),
+#      never as "failure".
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Only one Pages deployment at a time. Queue (don't cancel) so an in-flight
+# production deploy always completes; the queued run then deploys the latest.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload docs/ as Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/change-logs/2026/07/06/fix-pages-deploy-spam.md
+++ b/change-logs/2026/07/06/fix-pages-deploy-spam.md
@@ -1,0 +1,1 @@
+Replace GitHub's auto legacy "Deploy from a branch" Pages workflow with a custom Actions workflow that only runs when docs/ changes and serializes deploys via a concurrency group, eliminating the false "Run failed" deployment emails that fired on parallel PR merges.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- deploy-marker: pages-actions-migration-2026w28 -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

The repo's Pages site was on the legacy "Deploy from a branch" mode, whose auto-generated `pages-build-deployment` workflow fires on **every** push to `main`. On parallel PR merges, two deployments race the Pages API and the superseded one dies with `Deployment failed, try again later.`, emailing a false "Run failed" notification.

This replaces it with a custom Actions workflow (`.github/workflows/pages.yml`) that:
- runs **only** when `docs/**` changes (ordinary code merges no longer trigger a Pages deploy at all), and
- serializes deploys via a `concurrency: { group: pages, cancel-in-progress: false }` group, so runs queue instead of racing — no more failure emails.

The repo Pages `build_type` has been flipped from `legacy` to `workflow` to activate this. Custom domain (`docs/CNAME` → dev3.h0x91b.com) is preserved.

Also adds a temporary invisible `deploy-marker` HTML comment in `docs/index.html` to confirm the new pipeline actually deploys (can be removed later).