### PR TITLE
Tell agents to name tmux windows with a human purpose

### DIFF
--- a/change-logs/2026/07/06/feature-name-tmux-windows.md
+++ b/change-logs/2026/07/06/feature-name-tmux-windows.md
@@ -1,0 +1,1 @@
+Agents are now told to give any tmux window they open a short human name (dev-server, logs, tests) via -n or rename-window, and to proactively rename windows still stuck on a generic auto-name (node/zsh/bash/claude) whenever they list the session — so the terminal tabs read clearly instead of "node"/"zsh".

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -140,6 +140,19 @@ describe("dev3-tmux skill content", () => {
 		expect(skill).toContain("Default: split-window (pane). Use new-window only when the user explicitly asks for a tab.");
 		expect(skill).toMatch(/always.*split-window.*never.*new-window/i);
 	});
+
+	it("tells the agent to give windows human names instead of the auto command-name", () => {
+		const skill = getTmuxSkillContent();
+		expect(skill).toContain("**Always name a window you open**");
+		expect(skill).toMatch(/turns off automatic-rename/i);
+	});
+
+	it("tells the agent to proactively rename generic windows it did not open", () => {
+		const skill = getTmuxSkillContent();
+		expect(skill).toContain("**Also tidy windows you did not open.**");
+		expect(skill).toMatch(/list-windows/);
+		expect(skill).toMatch(/proactively/i);
+	});
 });
 
 describe("dev3-project-config skill content", () => {

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -701,6 +701,10 @@ PANE=$(tmux -L dev3 display-message -p -t "$SESSION:dev-server" '#{pane_id}')
 tmux -L dev3 send-keys -t "$PANE" 'bun run dev' Enter
 \`\`\`
 
+**Always name a window you open** with a short human purpose — pass \`-n <name>\` (\`dev-server\`, \`logs\`, \`tests\`), or \`rename-window\` it right after. Never leave it on the auto command-name (\`node\`, \`zsh\`): a manual name **sticks** (it turns off automatic-rename for that window), so the user reads clean tabs instead of \`[1: node] [2: zsh]\`.
+
+**Also tidy windows you did not open.** Any time you \`list-windows\` — before a split, on discovery, whenever you look at the session — glance at the names. If a window is still stuck on a generic auto-name (\`node\`, \`zsh\`, \`bash\`, \`claude\`) and you can tell what it is running, \`rename-window\` it to that purpose too. Do it proactively, not only for windows you created. Leave windows the user already gave a real name alone.
+
 ### Sending input
 
 - \`send-keys ... Enter\` — typed text + execute. Without \`Enter\` you just type without pressing return.


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

Teaches AI agents to give tmux **windows** human-readable names instead of the generic auto command-name (`node`, `zsh`, `bash`, `claude`) that `automatic-rename on` produces — so the terminal tabs read like `[1: dev-server] [2: logs]` rather than `[1: node] [2: zsh]`.

The change is a single, targeted addition to the **`dev3-tmux` reference skill** (`src/bun/agent-skills.ts`) — the always-loaded main skill is intentionally left untouched to avoid bloat. Two directives were added to the "Open a pane or window" section:

- **Name windows you open** — pass `-n <purpose>` to `new-window`, or `rename-window` right after. A manual name sticks because it turns off `automatic-rename` for that window (verified against tmux behavior).
- **Proactively tidy windows you did not open** — whenever the agent runs `list-windows` (before a split, on discovery, etc.), rename any window still stuck on a generic auto-name to its real purpose, while leaving windows the user already named alone.

Includes matching skill-content tests and a changelog entry.
