### PR TITLE
Route hand-off prompt to the sole agent pane (#609)

### DIFF
--- a/change-logs/2026/07/06/fix-agent-pane-prompt-routing.md
+++ b/change-logs/2026/07/06/fix-agent-pane-prompt-routing.md
@@ -1,0 +1,3 @@
+Fixed the Create-PR / auto-merge / rebase-conflict hand-off writing its prompt into whatever pane happened to be focused. When a task has exactly one live agent pane, the prompt now always goes there even if a shell or dev-server split is active; with two or more agent panes it still respects the active pane.
+
+Suggested by @genrym (h0x91b/dev-3.0#609)

--- a/decisions/109-agent-pane-prompt-routing.md
+++ b/decisions/109-agent-pane-prompt-routing.md
@@ -1,0 +1,34 @@
+# 109 — Route hand-off prompts by the agent-pane registry, not the active pane
+
+## Context
+Create-PR / auto-merge / rebase-conflict hand-offs type a plain-language prompt
+into the task's tmux session (`sendPromptToAgentPane` in
+`src/bun/rpc-handlers/git-operations.ts`). It used to always target the
+session's *active* pane. When a user split off a shell or dev-server pane and
+left it focused, the prompt landed there instead of the agent — issue #609.
+
+## Investigation
+`pane_current_command` cannot identify the agent pane: an agent constantly
+spawns child processes, so a live Claude pane reports `zsh`/`node`/`make` at
+random moments (verified on a running session). The reliable source of "which
+panes run an agent" is the task's `sessionState.panes` registry — populated on
+launch and every `spawnAgentInTask`, pruned on pane exit, pane IDs refreshed on
+recovery.
+
+## Decision
+`resolveAgentPromptTargetPane` intersects `sessionState.panes[].paneId` with the
+live pane IDs (`tmux list-panes -s`). Exactly one live agent pane → target it
+unconditionally (ignore focus). Two or more → ambiguous, so respect the active
+pane. Zero known agent panes (legacy tasks with no sessionState) → fall back to
+the active pane, preserving old behavior.
+
+## Risks
+A manually-launched agent (user typed `claude` in a raw split, not via the app)
+is not in `sessionState`, so it doesn't count — with one recorded agent pane the
+prompt goes to the recorded one, not the manual one. Acceptable: the app only
+knows about panes it launched.
+
+## Alternatives considered
+Match `pane_current_command` against known agent names — rejected as unreliable
+(see Investigation). Always target `panes[0]` (the main pane) — rejected because
+it breaks the deliberate multi-agent case where focus should decide.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -8539,6 +8539,90 @@ describe("handlers.createPullRequest", () => {
 		expect(sendKeysCalls()).toHaveLength(0);
 	});
 
+	// Issue #609: with a single agent pane the prompt must land in that pane even
+	// when a different (non-agent) pane is focused — the active pane must NOT win.
+	it("routes to the sole agent pane, ignoring a different active pane", async () => {
+		vi.useFakeTimers();
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-1",
+			worktreePath: "/tmp/test-worktree",
+			sessionState: { panes: [{ paneId: "%5", agentCmd: "claude", sessionId: null, agentId: null, configId: null }] },
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			// Active pane is a non-agent split (%3); the agent lives in %5.
+			stdout: args.includes("display-message") ? "%3\n" : args.includes("list-panes") ? "%3\n%5\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%5"]));
+
+		vi.advanceTimersByTime(800);
+		const all = sendKeysCalls();
+		expect(all[1]).toEqual(["tmux", "-L", "dev3", "send-keys", "-t", "%5", "Enter"]);
+		vi.useRealTimers();
+	});
+
+	// With two or more agent panes the target is ambiguous, so respect focus.
+	it("routes to the active pane when there are two agent panes", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-1",
+			worktreePath: "/tmp/test-worktree",
+			sessionState: {
+				panes: [
+					{ paneId: "%5", agentCmd: "claude", sessionId: null, agentId: null, configId: null },
+					{ paneId: "%7", agentCmd: "codex", sessionId: null, agentId: null, configId: null },
+				],
+			},
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			stdout: args.includes("display-message") ? "%3\n" : args.includes("list-panes") ? "%3\n%5\n%7\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%3"]));
+	});
+
+	// A registered agent pane that no longer exists must not hijack the routing —
+	// fall back to the active pane (preserves the legacy behavior).
+	it("falls back to the active pane when the recorded agent pane is dead", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-1",
+			worktreePath: "/tmp/test-worktree",
+			sessionState: { panes: [{ paneId: "%5", agentCmd: "claude", sessionId: null, agentId: null, configId: null }] },
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			// %5 is gone; only the active pane %3 is live.
+			stdout: args.includes("display-message") ? "%3\n" : args.includes("list-panes") ? "%3\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%3"]));
+	});
+
 	it("throws when the task has no worktree", async () => {
 		const project = makeProject();
 		const task = makeTask({ id: "task-1", worktreePath: null });

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -1,5 +1,6 @@
 import {
 	type BranchStatus,
+	type PaneSessionEntry,
 	type PRInfo,
 	type Project,
 	type Task,
@@ -966,15 +967,28 @@ async function pushTask(params: { taskId: string; projectId: string }): Promise<
 const AGENT_PROMPT_ENTER_DELAY_MS = 800;
 
 /**
- * Hand a task off to the AI agent running in its tmux session: find the session's
- * currently-focused pane (that's where the agent's prompt lives) and type `prompt`
- * into it, then send Enter as a discrete keypress after a short delay. Returns
- * false when no active pane could be resolved (nothing was sent). This is the
- * shared mechanism behind the Create-PR / auto-merge buttons and the
- * rebase-conflict handoff — the agent is a continuation of the user's
- * conversation, so a plain-language instruction is enough.
+ * Resolve the pane a hand-off prompt should be typed into.
+ *
+ * `agentPanes` is the task's recorded agent-pane registry (`sessionState.panes`),
+ * the only reliable source of "which panes run an agent" — `pane_current_command`
+ * is useless here because an agent constantly spawns child processes (a live
+ * Claude pane reports `zsh`/`node` at random moments). Routing rules (issue #609):
+ *
+ *  - Exactly ONE live agent pane → target it unconditionally, even if a
+ *    non-agent pane (a shell, a dev server) is currently focused. There is no
+ *    ambiguity about where the agent lives, so focus must not misroute the prompt.
+ *  - TWO OR MORE live agent panes → ambiguous; respect the user's focus and use
+ *    the session's active pane.
+ *  - ZERO known agent panes (legacy tasks with no sessionState) → fall back to
+ *    the active pane, preserving the historical behavior.
+ *
+ * Returns the pane id, or null when nothing usable could be resolved.
  */
-async function sendPromptToActiveAgentPane(tmuxSession: string, socket: string, prompt: string): Promise<boolean> {
+async function resolveAgentPromptTargetPane(
+	tmuxSession: string,
+	socket: string,
+	agentPanes: PaneSessionEntry[] | undefined,
+): Promise<string | null> {
 	let activePane: string | null = null;
 	try {
 		const proc = spawn(pty.tmuxArgs(socket, "display-message", "-t", tmuxSession, "-p", "#{pane_id}"), { stdout: "pipe", stderr: "pipe" });
@@ -982,16 +996,55 @@ async function sendPromptToActiveAgentPane(tmuxSession: string, socket: string, 
 		if ((await proc.exited) === 0) activePane = stdout.trim() || null;
 	} catch { /* best effort */ }
 
-	if (!activePane) {
+	const registeredIds = (agentPanes ?? [])
+		.map((p) => p.paneId)
+		.filter((id): id is string => Boolean(id));
+
+	if (registeredIds.length > 0) {
+		let livePaneIds = new Set<string>();
+		try {
+			const proc = spawn(pty.tmuxArgs(socket, "list-panes", "-s", "-t", tmuxSession, "-F", "#{pane_id}"), { stdout: "pipe", stderr: "pipe" });
+			const stdout = await new Response(proc.stdout).text();
+			if ((await proc.exited) === 0) {
+				livePaneIds = new Set(stdout.split("\n").map((l) => l.trim()).filter(Boolean));
+			}
+		} catch { /* best effort */ }
+
+		const liveAgentPanes = [...new Set(registeredIds.filter((id) => livePaneIds.has(id)))];
+		if (liveAgentPanes.length === 1) return liveAgentPanes[0] ?? null;
+		// ≥2 or 0 live agent panes → fall through to the active pane below.
+	}
+
+	return activePane;
+}
+
+/**
+ * Hand a task off to the AI agent running in its tmux session: pick the pane the
+ * agent lives in (see {@link resolveAgentPromptTargetPane}), type `prompt` into
+ * it, then send Enter as a discrete keypress after a short delay. Returns false
+ * when no target pane could be resolved (nothing was sent). This is the shared
+ * mechanism behind the Create-PR / auto-merge buttons and the rebase-conflict
+ * handoff — the agent is a continuation of the user's conversation, so a
+ * plain-language instruction is enough.
+ */
+async function sendPromptToAgentPane(
+	tmuxSession: string,
+	socket: string,
+	prompt: string,
+	agentPanes: PaneSessionEntry[] | undefined,
+): Promise<boolean> {
+	const targetPane = await resolveAgentPromptTargetPane(tmuxSession, socket, agentPanes);
+
+	if (!targetPane) {
 		return false;
 	}
 
-	const pane = activePane;
+	const pane = targetPane;
 	try {
 		const pasteProc = spawn(pty.tmuxArgs(socket, "send-keys", "-t", pane, prompt), { stdout: "pipe", stderr: "pipe" });
 		pasteProc.exited.catch(() => {});
 	} catch (err) {
-		log.warn("sendPromptToActiveAgentPane send-keys paste failed", { paneId: pane, error: String(err) });
+		log.warn("sendPromptToAgentPane send-keys paste failed", { paneId: pane, error: String(err) });
 		return false;
 	}
 	setTimeout(() => {
@@ -999,7 +1052,7 @@ async function sendPromptToActiveAgentPane(tmuxSession: string, socket: string, 
 			const enterProc = spawn(pty.tmuxArgs(socket, "send-keys", "-t", pane, "Enter"), { stdout: "pipe", stderr: "pipe" });
 			enterProc.exited.catch(() => {});
 		} catch (err) {
-			log.warn("sendPromptToActiveAgentPane send-keys Enter failed", { paneId: pane, error: String(err) });
+			log.warn("sendPromptToAgentPane send-keys Enter failed", { paneId: pane, error: String(err) });
 		}
 	}, AGENT_PROMPT_ENTER_DELAY_MS);
 
@@ -1027,7 +1080,7 @@ async function createPullRequest(params: { taskId: string; projectId: string; au
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 
 	const prompt = params.autoMerge ? CREATE_PR_AUTO_MERGE_AGENT_PROMPT : CREATE_PR_AGENT_PROMPT;
-	const handedOff = await sendPromptToActiveAgentPane(tmuxSession, socket, prompt);
+	const handedOff = await sendPromptToAgentPane(tmuxSession, socket, prompt, task.sessionState?.panes);
 	if (!handedOff) {
 		log.info("← createPullRequest skipped — no active pane", { taskId: task.id.slice(0, 8) });
 		return;
@@ -1055,7 +1108,7 @@ async function rebaseTaskViaAgent(params: { taskId: string; projectId: string; c
 	const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 
-	const handedOff = await sendPromptToActiveAgentPane(tmuxSession, socket, rebaseConflictAgentPrompt(rebaseTarget));
+	const handedOff = await sendPromptToAgentPane(tmuxSession, socket, rebaseConflictAgentPrompt(rebaseTarget), task.sessionState?.panes);
 	log.info("← rebaseTaskViaAgent", { taskId: task.id.slice(0, 8), handedOff });
 	return { handedOff };
 }


### PR DESCRIPTION
Fixes the Create-PR / auto-merge / rebase-conflict hand-off writing its prompt into whatever tmux pane happened to be focused (issue #609).

## What changed
The hand-off used to always target the session's **active** pane, so a focused shell or dev-server split hijacked the prompt. It now routes by the task's agent-pane registry (`sessionState.panes`) instead:

- **Exactly one live agent pane** → target it unconditionally, even if a non-agent pane is focused.
- **Two or more live agent panes** → ambiguous, so respect the user's focus (active pane, same as before).
- **No recorded agent panes** (legacy tasks) → fall back to the active pane, preserving old behavior.

`pane_current_command` can't be used to detect the agent pane — a live agent constantly spawns child processes and reports `zsh`/`node`/`make` at random moments — so the recorded registry is the only reliable source.

Includes 3 reproduction tests, a changelog entry, and decision record 109.

Closes #609

---
_Hi — this is Claude (the AI assistant) that worked on this branch._
