### PR TITLE
Fix Codex crash when spawning an extra agent / bug-hunter

### DIFF
--- a/change-logs/2026/07/06/fix-spawn-agent-codex-trust.md
+++ b/change-logs/2026/07/06/fix-spawn-agent-codex-trust.md
@@ -1,0 +1,1 @@
+Fixed spawning an extra Codex agent (Spawn Agent modal) or a Codex bug-hunter crashing with "--profile dev3-dark cannot be used while config.toml contains legacy profile". The spawn paths now run the same worktree-trust / Codex config re-patch step the primary task launch does, so the stale legacy profile table is stripped before Codex launches.

--- a/decisions/109-ensure-agent-trust-on-every-spawn.md
+++ b/decisions/109-ensure-agent-trust-on-every-spawn.md
@@ -1,0 +1,35 @@
+# 109 — Run agent trust/config-ensure on every spawn path
+
+## Context
+Spawning an extra Codex agent via the Spawn Agent modal (or a Codex bug-hunter)
+crashed with `--profile dev3-dark cannot be used while /Users/.../.codex/config.toml
+contains legacy profile = "dev3-dark" or [profiles.dev3-dark]`. A plain Codex task
+launched fine.
+
+## Investigation
+`ensureCodexTrust` (in `agents.ts`) re-patches `~/.codex/config.toml` on codex ≥0.131:
+it strips the legacy `[profiles.dev3-*]` tables / top-level `profile = "..."` selector
+that codex now rejects and (re)writes the per-profile files. The primary launch
+(`launchTaskPty` in `tmux-pty.ts`) called it before every codex launch, so config.toml
+was self-healed each time. `spawnAgentInTask` and `spawnSingleBugHunterPane` resolved
+the command and spawned directly, skipping the trust step entirely — so a spawned
+Codex pane launched against a stale config.toml and crashed. Logs confirmed
+"Codex trust ensured" only ever fired on the primary path.
+
+## Decision
+Extracted `ensureAgentTrust(worktreePath, projectPath, resolvedBaseCmd)` in
+`tmux-pty.ts` (Claude trust always; Codex/Gemini gated on the resolved CLI; all
+idempotent + non-fatal) and call it from all three spawn paths: `launchTaskPty`
+(refactor, no behavior change), `spawnAgentInTask`, and `spawnSingleBugHunterPane`.
+
+## Risks
+The extra `ensureCodexTrust` on spawn does a synchronous version probe + a config
+read/write, adding a few ms to each spawn — negligible and already paid on the
+primary path. All calls stay wrapped in try/catch so a trust hiccup never blocks
+a spawn.
+
+## Alternatives considered
+- Only add `ensureCodexTrust` to `spawnAgentInTask` (minimal): rejected — leaves the
+  bug-hunter pane and Claude/Gemini trust gaps, and lets the two paths drift again.
+- Heal config.toml only at startup: rejected — codex/config state can go stale mid-
+  session; the primary path already re-heals per launch, spawns must match it.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6450,6 +6450,41 @@ describe("handlers.spawnAgentInTask", () => {
 			handlers.spawnAgentInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: null }),
 		).rejects.toThrow("Failed to spawn agent");
 	});
+
+	// Regression: the primary launch path re-patches ~/.codex/config.toml via
+	// ensureCodexTrust before every codex launch (strips the legacy
+	// [profiles.dev3-*] tables codex ≥0.131 rejects). Spawning an extra Codex
+	// agent used to skip that step, so the pane crashed with
+	// "--profile dev3-dark cannot be used while config.toml contains legacy profile".
+	it("ensures Codex trust before spawning a Codex agent", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/codex-wt" });
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockResolvedValue(task);
+		(agents.resolveCommandForAgent as any).mockResolvedValue({
+			command: "codex -p dev3-dark",
+			extraEnv: {},
+			config: { baseCommandOverride: "codex" },
+		});
+		mockSpawn.mockReturnValue({ stderr: new Response(""), stdout: new Response(""), exited: Promise.resolve(0) });
+
+		await handlers.spawnAgentInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-codex", configId: null });
+
+		expect(agents.ensureCodexTrust).toHaveBeenCalledWith("/tmp/codex-wt");
+	});
+
+	it("ensures Claude trust before spawning any agent", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/wt" });
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockResolvedValue(task);
+		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude --resume", extraEnv: {} });
+		mockSpawn.mockReturnValue({ stderr: new Response(""), stdout: new Response(""), exited: Promise.resolve(0) });
+
+		await handlers.spawnAgentInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default" });
+
+		expect(agents.ensureClaudeTrust).toHaveBeenCalledWith("/tmp/wt", project.path);
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -274,6 +274,63 @@ async function setTmuxSessionPortEnv(taskId: string, socket: string): Promise<vo
 	log.info("Port env vars set on tmux session", { taskId: taskId.slice(0, 8), vars: Object.keys(envVars) });
 }
 
+/**
+ * Register worktree trust for the resolved agent's CLI before spawning it.
+ * Claude trust (with MCP pre-approval) is always ensured; Codex/Gemini trust
+ * only for their respective CLIs. Codex trust also re-patches ~/.codex/config.toml
+ * — stripping the legacy `[profiles.dev3-*]` tables / top-level `profile = "..."`
+ * selectors that codex ≥0.131 rejects and (re)writing the per-profile files. All
+ * calls are idempotent and non-fatal: a failure logs and continues so a trust
+ * hiccup never blocks the launch.
+ *
+ * MUST run before EVERY agent spawn. It used to be inlined only in the primary
+ * task launch; the extra-agent (`spawnAgentInTask`) and bug-hunter panes skipped
+ * it, so a spawned Codex pane launched against a stale config.toml and crashed
+ * with `--profile dev3-dark cannot be used while ... contains legacy profile`.
+ */
+async function ensureAgentTrust(
+	worktreePath: string,
+	projectPath: string,
+	resolvedBaseCmd: string,
+): Promise<void> {
+	try {
+		await agents.ensureClaudeTrust(worktreePath, projectPath);
+		log.info("Claude trust ensured", { worktreePath });
+	} catch (err) {
+		log.error("ensureClaudeTrust failed (non-fatal)", {
+			worktreePath,
+			error: String(err),
+			stack: (err as Error)?.stack ?? "no stack",
+		});
+	}
+
+	if (agents.isCodexCommand(resolvedBaseCmd)) {
+		try {
+			await agents.ensureCodexTrust(worktreePath);
+			log.info("Codex trust ensured", { worktreePath });
+		} catch (err) {
+			log.error("ensureCodexTrust failed (non-fatal)", {
+				worktreePath,
+				error: String(err),
+				stack: (err as Error)?.stack ?? "no stack",
+			});
+		}
+	}
+
+	if (agents.isGeminiCommand(resolvedBaseCmd)) {
+		try {
+			await agents.ensureGeminiTrust(worktreePath);
+			log.info("Gemini trust ensured", { worktreePath });
+		} catch (err) {
+			log.error("ensureGeminiTrust failed (non-fatal)", {
+				worktreePath,
+				error: String(err),
+				stack: (err as Error)?.stack ?? "no stack",
+			});
+		}
+	}
+}
+
 export async function launchTaskPty(
 	project: Project,
 	task: Task,
@@ -449,42 +506,7 @@ export async function launchTaskPty(
 		}
 	}
 
-	try {
-		await agents.ensureClaudeTrust(worktreePath, project.path);
-		log.info("Claude trust ensured", { worktreePath });
-	} catch (err) {
-		log.error("ensureClaudeTrust failed (non-fatal)", {
-			worktreePath,
-			error: String(err),
-			stack: (err as Error)?.stack ?? "no stack",
-		});
-	}
-
-	if (agents.isCodexCommand(resolvedBaseCmd)) {
-		try {
-			await agents.ensureCodexTrust(worktreePath);
-			log.info("Codex trust ensured", { worktreePath });
-		} catch (err) {
-			log.error("ensureCodexTrust failed (non-fatal)", {
-				worktreePath,
-				error: String(err),
-				stack: (err as Error)?.stack ?? "no stack",
-			});
-		}
-	}
-
-	if (agents.isGeminiCommand(resolvedBaseCmd)) {
-		try {
-			await agents.ensureGeminiTrust(worktreePath);
-			log.info("Gemini trust ensured", { worktreePath });
-		} catch (err) {
-			log.error("ensureGeminiTrust failed (non-fatal)", {
-				worktreePath,
-				error: String(err),
-				stack: (err as Error)?.stack ?? "no stack",
-			});
-		}
-	}
+	await ensureAgentTrust(worktreePath, project.path, resolvedBaseCmd);
 
 	const stopTarget = project.autoReviewEnabled ? "review-by-ai" : "review-by-user";
 	try {
@@ -2069,6 +2091,11 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 		resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 	}
 
+	// Register trust / re-patch the agent's config before spawning. The primary
+	// task launch does this; without it a spawned Codex pane runs against a stale
+	// config.toml and crashes on the legacy-profile check (see ensureAgentTrust).
+	await ensureAgentTrust(task.worktreePath, project.path, resolvedBaseCmd);
+
 	const env: Record<string, string> = buildAgentEnv(extraEnv, task.id);
 
 	const existingPorts = portPool.getPortAssignments(task.id);
@@ -2200,6 +2227,10 @@ async function spawnSingleBugHunterPane(opts: {
 		extraEnv = resolved.extraEnv;
 		resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 	}
+
+	// Same trust/config-ensure the primary launch does — a Codex bug-hunter pane
+	// otherwise launches against a stale config.toml and crashes.
+	await ensureAgentTrust(opts.worktreePath, opts.project.path, resolvedBaseCmd);
 
 	const env: Record<string, string> = buildAgentEnv(extraEnv, opts.task.id);
 	const existingPorts = portPool.getPortAssignments(opts.task.id);


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

Spawning an extra Codex agent via the **Spawn Agent** modal (or a Codex bug-hunter) crashed with:

> `--profile dev3-dark cannot be used while /Users/.../.codex/config.toml contains legacy profile = "dev3-dark" or [profiles.dev3-dark]`

…while a plain Codex task launched fine.

**Root cause:** `ensureCodexTrust` re-patches `~/.codex/config.toml` on codex ≥0.131 — stripping the legacy `[profiles.dev3-*]` tables / top-level `profile = "..."` selector that codex now rejects, and (re)writing the per-profile files. The primary task launch (`launchTaskPty`) ran it before every codex launch, so config.toml was self-healed each time. `spawnAgentInTask` and `spawnSingleBugHunterPane` resolved the command and spawned directly, skipping all trust-ensure — so a spawned Codex pane launched against a stale config.toml and crashed.

**Fix:** extracted `ensureAgentTrust(worktreePath, projectPath, resolvedBaseCmd)` (Claude trust always; Codex/Gemini gated on the resolved CLI; all idempotent + non-fatal) and call it from all three spawn paths — `launchTaskPty` (refactor, no behavior change), `spawnAgentInTask`, and `spawnSingleBugHunterPane`. This also closes the latent Claude/Gemini trust gap on spawned panes and keeps the paths from drifting again.

Adds a regression test (verified red→green), a changelog entry, and decision record 109.