### PR TITLE
Fix branch search returning nothing when query contains a dash

### DIFF
--- a/change-logs/2026/07/06/fix-branch-search-dash.md
+++ b/change-logs/2026/07/06/fix-branch-search-dash.md
@@ -1,0 +1,1 @@
+Fixed the "use existing branch" search in the new-task modal returning no results once the typed query contained a dash. The query is now tokenized on the same separators as branch names (/, -, _, .), so a dashed query like "login-page" matches instead of falling through.

--- a/src/mainview/components/BranchSelector.tsx
+++ b/src/mainview/components/BranchSelector.tsx
@@ -35,16 +35,15 @@ export function matchesBranchQuery(branchName: string, query: string): boolean {
 	if (!query) return true;
 	// Normalize fork ref format: "user:branch" → "user/branch" for matching
 	const normalizedQuery = normalizeBranchQuery(query);
-	const nameLower = branchName.toLowerCase();
 	const words = splitBranchWords(branchName);
-	const tokens = normalizedQuery.toLowerCase().split(/\s+/).filter(Boolean);
-	return tokens.every((token) => {
-		// Word-level prefix match (default behavior)
-		if (words.some((w) => w.startsWith(token))) return true;
-		// Substring fallback for tokens containing "/" (e.g., "origin/dev", "user:branch")
-		if (token.includes("/") && nameLower.includes(token)) return true;
-		return false;
-	});
+	// Tokenize the query on the same separators as branch names (/, -, _, ., space)
+	// so a dashed query like "login-page" splits into ["login", "page"] instead of
+	// staying one token that prefix-matches nothing and finds no branch. (camelCase
+	// is intentionally NOT split here — the user's raw query casing must not fragment
+	// their input the way it does for the branch names being searched.)
+	const tokens = normalizedQuery.toLowerCase().split(/[/\-_.]+|\s+/).filter(Boolean);
+	// Every query token must prefix-match some word in the branch name.
+	return tokens.every((token) => words.some((w) => w.startsWith(token)));
 }
 
 function isForkRemoteBranch(branch: BranchInfo): boolean {

--- a/src/mainview/components/__tests__/BranchSelector.test.ts
+++ b/src/mainview/components/__tests__/BranchSelector.test.ts
@@ -107,6 +107,22 @@ describe("matchesBranchQuery", () => {
 	it("matches partial fork ref with colon", () => {
 		expect(matchesBranchQuery("roiros/feat/collapsible-kanban-columns", "roiros:feat")).toBe(true);
 	});
+
+	it("matches a query that contains a dash spanning word boundaries", () => {
+		expect(matchesBranchQuery("feat/login-page", "login-page")).toBe(true);
+	});
+
+	it("matches a multi-word dashed query against a dashed branch", () => {
+		expect(matchesBranchQuery("sworgkh/fix/dev3-tmux-switch-glitch", "dev3-tmux")).toBe(true);
+	});
+
+	it("matches a dashed query with underscore/dot separators in the branch", () => {
+		expect(matchesBranchQuery("feat/login_page", "login-page")).toBe(true);
+	});
+
+	it("keeps matching while the user is mid-typing a trailing dash", () => {
+		expect(matchesBranchQuery("feat/dev3-auth", "dev3-")).toBe(true);
+	});
 });
 
 describe("sortBranchesForDisplay", () => {


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch).

## Summary

The **Use existing branch** search in the new-task modal returned zero results as soon as the typed query contained a dash (e.g. `login-page`, `dev3-tmux`).

Root cause was in `matchesBranchQuery` (`src/mainview/components/BranchSelector.tsx`): the **branch name** was split into words on `/ - _ .`, but the **query** was split only on whitespace. A dashed query therefore stayed a single token (`"login-page"`) that prefix-matched no word, and the substring fallback only covered tokens containing `/`.

The query is now tokenized on the same separators as branch names (`/ - _ .` + whitespace), so `login-page` splits into `["login", "page"]` and each token prefix-matches a branch word. camelCase is intentionally not split on the query side to avoid fragmenting the user's raw input. Added regression tests for dashed / mid-typing queries and a changelog entry.