### PR TITLE
Fix blank desktop window: stop chdir-ing away from the .app bundle

### DIFF
--- a/change-logs/2026/07/06/fix-desktop-blank-window-chdir.md
+++ b/change-logs/2026/07/06/fix-desktop-blank-window-chdir.md
@@ -1,0 +1,1 @@
+Fixed the desktop window opening blank grey with "Resource not found" errors. A recent startup change moved the process working directory away from the .app bundle, which broke electrobun's views:// asset resolution and the native bridge. The process now stays put; child processes are instead pinned to ~/.dev3.0 so the original brew-upgrade resilience is preserved.

--- a/decisions/110-no-chdir-pin-child-cwd.md
+++ b/decisions/110-no-chdir-pin-child-cwd.md
@@ -1,0 +1,50 @@
+# 110 — Don't chdir the process; pin child cwd to DEV3_HOME instead
+
+## Context
+
+PR #834 (commit `64fefde6`) added `process.chdir(DEV3_HOME)` at startup in
+`src/bun/index.ts` to survive a brew upgrade / in-app update deleting the `.app`
+bundle dir from under a running instance (any spawn without an explicit `cwd`
+would then ENOENT, since `posix_spawn` resolves the child cwd from ours). This
+blanked the **desktop** window: a large grey screen, console spamming
+`Resource not found` and `window.__electrobun.receiveMessageFromBun is undefined`.
+The browser/remote mode was unaffected.
+
+## Investigation
+
+`git bisect` between a known-good 07-05 commit and `origin/main` landed squarely
+on `64fefde6`. Its only runtime change is the `chdir`. electrobun resolves its
+native wrapper via `join(process.cwd(), "libNativeWrapper.dylib")`
+(`node_modules/electrobun/dist/api/bun/proc/native.ts:86`) and resolves the
+`views://` custom protocol (which loads the renderer `index.html` + `/assets/*`)
+relative to `process.cwd()` as well. The dlopen runs at module import (before the
+chdir), so it survived — but the `views://` load happens later, at window
+creation, after the chdir. With cwd moved to `~/.dev3.0`, electrobun could no
+longer find `views/mainview/index.html` → renderer never loads → the injected
+bridge never initializes.
+
+## Decision
+
+Never `process.chdir()` away from the bundle. Removed the chdir block from
+`src/bun/index.ts`. The ENOENT hazard it targeted is handled where it belongs:
+`src/bun/spawn.ts` now defaults every cwd-less child to `DEV3_HOME`
+(`withDefaults()`), so children never inherit the vanishing bundle cwd while the
+process itself stays put. All app spawns go through `spawn.ts`; the CLI does not
+import it, so CLI git-in-user-cwd behavior is untouched.
+
+## Risks
+
+A child that genuinely relied on inheriting the bundle cwd would now get
+DEV3_HOME — but none do (they either pass an explicit `cwd` or use absolute
+paths). If electrobun itself lazily spawns a child without cwd after the bundle
+is deleted, that path is outside our wrappers and unaffected by this change.
+
+## Alternatives considered
+
+- **Keep the chdir, pass an absolute `viewsRoot` captured pre-chdir.** Fixes
+  `views://` only; leaves the process cwd off-bundle so any other cwd-relative
+  electrobun resolution (new webviews, tray, native modules) stays fragile.
+- **Delay the chdir until after the window's DOM is ready.** Timing-fragile:
+  early spawns (existing tmux sessions) and any later-created webview would still
+  break.
+- **Revert #834 entirely.** Loses the brew-upgrade resilience; more than needed.

--- a/src/bun/__tests__/spawn.test.ts
+++ b/src/bun/__tests__/spawn.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { spawn, spawnSync } from "../spawn";
+import { DEV3_HOME } from "../paths";
+
+// The main process keeps its cwd inside the .app bundle (electrobun resolves the
+// `views://` protocol relative to process.cwd()), so child processes must NOT
+// inherit that bundle cwd — a brew upgrade can delete it from under us and every
+// cwd-less spawn would ENOENT. spawn.ts pins cwd-less children to DEV3_HOME.
+// See decision 109.
+describe("spawn/spawnSync cwd defaulting", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const Bun = globalThis.Bun as any;
+
+	it("defaults child cwd to DEV3_HOME when the caller passes none", () => {
+		const spy = vi.spyOn(Bun, "spawn");
+		spawn(["true"]);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy.mock.calls[0][1]).toMatchObject({ cwd: DEV3_HOME });
+	});
+
+	it("honours an explicit cwd over the DEV3_HOME default", () => {
+		const spy = vi.spyOn(Bun, "spawn");
+		spawn(["true"], { cwd: "/some/worktree" });
+		expect(spy.mock.calls[0][1]).toMatchObject({ cwd: "/some/worktree" });
+	});
+
+	it("falls back to DEV3_HOME when cwd is explicitly undefined", () => {
+		const spy = vi.spyOn(Bun, "spawn");
+		spawn(["true"], { cwd: undefined, stdout: "pipe" });
+		expect(spy.mock.calls[0][1]).toMatchObject({ cwd: DEV3_HOME, stdout: "pipe" });
+	});
+
+	it("spawnSync also defaults cwd to DEV3_HOME", () => {
+		const spy = vi.spyOn(Bun, "spawnSync");
+		spawnSync(["true"]);
+		expect(spy.mock.calls[0][1]).toMatchObject({ cwd: DEV3_HOME });
+	});
+
+	it("still merges process.env into the child env", () => {
+		const spy = vi.spyOn(Bun, "spawn");
+		spawn(["true"], { env: { FOO: "bar" } });
+		const opts = spy.mock.calls[0][1] as { env: Record<string, string> };
+		expect(opts.env.FOO).toBe("bar");
+		expect(opts.env.PATH).toBe(process.env.PATH);
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -25,7 +25,7 @@ import { startLoopMonitor } from "./loop-monitor";
 import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
 import electrobunConfig from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 
 const log = createLogger("main");
 
@@ -59,20 +59,13 @@ log.info(`=== dev-3.0 starting [${lastBuildTime}] ===`);
 log.info("All data at", { dir: DEV3_HOME });
 log.info("Log files", { dir: getLogPath() });
 
-// ── Detach cwd from the .app bundle ──
-// The process starts with cwd inside the bundle (Contents/MacOS). A brew
-// upgrade or in-app update can remove that directory from under a running
-// instance, after which EVERY spawn without an explicit `cwd` fails with
-// ENOENT (posix_spawn resolves the child's cwd from ours) — tmux dies while
-// git keeps working. Move to DEV3_HOME, which lives as long as our data does.
-// Safe at this point: electrobun's dlopen(join(process.cwd(), "libNativeWrapper..."))
-// runs at module import, i.e. before this line.
-try {
-	mkdirSync(DEV3_HOME, { recursive: true });
-	process.chdir(DEV3_HOME);
-} catch (err) {
-	log.warn("chdir to DEV3_HOME failed (non-fatal)", { error: String(err) });
-}
+// NOTE: We deliberately do NOT process.chdir() away from the .app bundle.
+// electrobun resolves native resources and the `views://` protocol relative to
+// process.cwd(), so moving cwd blanks the desktop window ("Resource not found").
+// The brew-upgrade/in-app-update ENOENT hazard it was meant to fix — a child
+// inheriting a since-deleted bundle cwd — is instead handled in spawn.ts, which
+// pins cwd-less children to DEV3_HOME without ever moving the process. See
+// decision 109.
 
 // ── CLI binary + agent skills + shell PATH (FIRST — before any async work) ──
 // These must run before resolveShellEnv() because existing tmux sessions

--- a/src/bun/spawn.ts
+++ b/src/bun/spawn.ts
@@ -9,17 +9,34 @@
  * These wrappers ensure every child process sees the full user PATH
  * (homebrew, nvm, etc.) by always merging process.env into the env option.
  *
+ * They also default the child `cwd` to DEV3_HOME when the caller passes none.
+ * The main process keeps its OWN cwd inside the .app bundle: electrobun resolves
+ * native resources and the `views://` protocol relative to process.cwd(), so
+ * chdir-ing the process away from the bundle blanks the desktop window with
+ * "Resource not found". But a brew upgrade / in-app update can delete the bundle
+ * dir from under a running instance, after which any child that inherits our
+ * bundle cwd dies with ENOENT (posix_spawn resolves the child cwd from ours).
+ * Pinning cwd-less children to DEV3_HOME — which lives as long as our data does —
+ * sidesteps that without ever moving the process. See decision 109.
+ *
  * RULE: Never use Bun.spawn / Bun.spawnSync directly — always use these.
  */
 
 import { registerCurrentPreparationSpawn, unregisterPreparationSpawn } from "./preparation-runtime";
+import { DEV3_HOME } from "./paths";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function withDefaults(opts?: any) {
+	return {
+		...opts,
+		cwd: opts?.cwd ?? DEV3_HOME,
+		env: { ...process.env, ...(opts?.env ?? {}) },
+	};
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function spawn(cmd: string[], opts?: any) {
-	const proc = Bun.spawn(cmd, {
-		...opts,
-		env: { ...process.env, ...(opts?.env ?? {}) },
-	});
+	const proc = Bun.spawn(cmd, withDefaults(opts));
 	const ctx = registerCurrentPreparationSpawn(proc.pid, cmd);
 	if (ctx && proc.pid) {
 		proc.exited.finally(() => {
@@ -40,10 +57,7 @@ const SLOW_SPAWN_SYNC_MS = 250;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function spawnSync(cmd: string[], opts?: any) {
 	const startedAt = Date.now();
-	const result = Bun.spawnSync(cmd, {
-		...opts,
-		env: { ...process.env, ...(opts?.env ?? {}) },
-	});
+	const result = Bun.spawnSync(cmd, withDefaults(opts));
 	const elapsedMs = Date.now() - startedAt;
 	if (elapsedMs >= SLOW_SPAWN_SYNC_MS) {
 		import("./logger")


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The desktop (Electrobun) window started opening as a large blank grey screen, with the console spamming `Resource not found` and `window.__electrobun.receiveMessageFromBun is undefined`. Browser/remote mode was unaffected.

`git bisect` pinned it to #834, whose only runtime change was `process.chdir(DEV3_HOME)` at startup. Electrobun resolves the `views://` protocol (the renderer `index.html` + `/assets/*`) **and** its native wrapper `dlopen` relative to `process.cwd()`. The `dlopen` runs at module import (before the chdir, so it survived), but the `views://` load happens later at window creation — after the chdir — so with cwd moved to `~/.dev3.0` the bundle assets could no longer be found and the renderer never loaded.

## Fix

- Remove the `process.chdir(DEV3_HOME)` from `src/bun/index.ts` — the process now stays inside the `.app` bundle where Electrobun expects it.
- Preserve #834's original intent (a brew upgrade / in-app update deleting the bundle dir from under a running instance would ENOENT any cwd-less spawn) by defaulting the child `cwd` to `DEV3_HOME` in `src/bun/spawn.ts`. All app spawns route through that wrapper; the CLI does not import it, so CLI git-in-user-cwd behavior is untouched.
- Added `spawn.ts` unit tests for the cwd defaulting and a decision record (110).

Verified on the real packaged desktop app: the window renders normally, no console errors.