### PR TITLE
Fix stale branch name in GUI after worktree branch rename

### DIFF
--- a/change-logs/2026/07/06/fix-branch-rename-gui-desync.md
+++ b/change-logs/2026/07/06/fix-branch-rename-gui-desync.md
@@ -1,0 +1,1 @@
+Fixed the task branch name shown in the GUI (header, cards, detail modal) staying stale after the branch was renamed inside the worktree. getBranchStatus already re-synced the stored name but never notified the renderer; it now broadcasts a taskUpdated push so every open surface re-renders with the live branch.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -3817,12 +3817,21 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 
+		const push = vi.fn();
+		setPushMessage(push);
+
 		await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 
 		// Should have synced the stored branchName
 		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { branchName: "dev3/fix-login" });
 		// Should pass live branch name to getUnpushedCount
 		expect(git.getUnpushedCount).toHaveBeenCalledWith("/tmp/wt", "dev3/fix-login");
+		// Must notify the renderer so the header/cards re-render with the new
+		// branch instead of showing the stale name until a reload.
+		expect(push).toHaveBeenCalledWith("taskUpdated", {
+			projectId: "proj-1",
+			task: expect.objectContaining({ branchName: "dev3/fix-login" }),
+		});
 	});
 
 	it("does not update branchName when live matches stored", async () => {
@@ -3837,9 +3846,13 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 
+		const push = vi.fn();
+		setPushMessage(push);
+
 		await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 
 		expect(data.updateTask).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalledWith("taskUpdated", expect.anything());
 	});
 
 	it("returns prNumber when gh pr list finds an open non-draft PR", async () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -649,7 +649,12 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 
 	if (liveBranch && liveBranch !== task.branchName) {
 		log.info("getBranchStatus: branch renamed, syncing stored name", { old: task.branchName, new: liveBranch });
-		await data.updateTask(project, task.id, { branchName: liveBranch });
+		const updated = await data.updateTask(project, task.id, { branchName: liveBranch });
+		// Persisting alone leaves the renderer's in-memory task with the stale
+		// branch name (it only refreshes on a taskUpdated push), so the header,
+		// task cards, and detail modal keep showing the old branch until reload.
+		// Broadcast the update so every open surface re-renders with the new name.
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 	}
 
 	log.debug("getBranchStatus: fetching origin", { worktreePath: task.worktreePath, baseBranch, branchName: branchForPush });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

Fixes the task branch name in the GUI staying stale after the branch is renamed inside the worktree (header, task cards, and Task Detail modal kept showing the old name until a full reload).

Root cause: the renderer only refreshes a task's `branchName` on a `taskUpdated` push. `getBranchStatus` already re-synced the renamed branch to disk via `data.updateTask`, but never broadcast the change — so the in-memory task kept the stale name.

Fix: after `getBranchStatus` re-syncs the renamed branch, it now emits a `taskUpdated` push. Since `getBranchStatus` polls every 15s for the active task (and on git-op completion / manual refresh), the branch name updates automatically without a reload.

Also strengthened the existing `getBranchStatus` unit tests to assert the push is emitted on rename (and not emitted when the branch is unchanged).
