### PR TITLE
Remove Kanban board split-view mode from task view

### DIFF
--- a/change-logs/2026/07/06/refactor-remove-board-split-mode.md
+++ b/change-logs/2026/07/06/refactor-remove-board-split-mode.md
@@ -1,0 +1,1 @@
+Removed the Kanban board split-view mode from the task view. The "Show board" / "Show sidebar" toggle buttons are gone; the task view now always shows the Active Tasks sidebar next to the terminal. The full Kanban board is still reachable via the breadcrumb.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -56,7 +56,6 @@ interface ActiveTasksSidebarProps {
 	bellCounts: Map<string, number>;
 	bellReasons?: Map<string, string[]>;
 	taskPorts: Map<string, PortInfo[]>;
-	onSwitchToBoard: () => void;
 	disableGlobalFindShortcut?: boolean;
 }
 
@@ -103,7 +102,6 @@ function ActiveTasksSidebar({
 	bellCounts,
 	bellReasons,
 	taskPorts,
-	onSwitchToBoard,
 	disableGlobalFindShortcut = false,
 }: ActiveTasksSidebarProps) {
 	const t = useT();
@@ -426,19 +424,6 @@ function ActiveTasksSidebar({
 							)}
 						</button>
 					</div>
-					<button
-						onClick={onSwitchToBoard}
-						className="inline-flex items-center justify-center h-5 w-5 text-fg-muted hover:text-accent transition-colors rounded hover:bg-fg/5"
-						title={t("sidebar.switchToBoard")}
-					>
-						{/* Nerd Font: fa-columns (U+F0DB) */}
-						<span
-							className="text-sm leading-none"
-							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						>
-							{"\uF0DB"}
-						</span>
-					</button>
 					{activeTaskId && (
 						<button
 							type="button"

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -37,7 +37,6 @@ interface KanbanBoardProps {
 	taskPorts: Map<string, PortInfo[]>;
 	taskResourceUsage?: Map<string, ResourceUsage>;
 	activeTaskId?: string;
-	onSwitchToSidebar?: () => void;
 	disableGlobalFindShortcut?: boolean;
 }
 
@@ -51,7 +50,6 @@ function KanbanBoard({
 	taskPorts,
 	taskResourceUsage,
 	activeTaskId,
-	onSwitchToSidebar,
 	disableGlobalFindShortcut = false,
 }: KanbanBoardProps) {
 	const t = useT();
@@ -569,19 +567,6 @@ function KanbanBoard({
 
 	return (
 		<>
-			{onSwitchToSidebar && (
-				<div className="flex items-center px-3 pt-2">
-					<button
-						onClick={onSwitchToSidebar}
-						className="text-[0.625rem] text-fg-muted hover:text-accent transition-colors px-1.5 py-0.5 rounded hover:bg-fg/5 flex items-center gap-1"
-						title={t("sidebar.switchToSidebar")}
-					>
-						{/* Nerd Font: fa-list (U+F03A) */}
-						<span className="text-sm font-mono leading-none">{"\uF03A"}</span>
-						<span>{t("sidebar.switchToSidebar")}</span>
-					</button>
-				</div>
-			)}
 			<LabelFilterBar
 				labels={projectLabels}
 				activeFilters={activeFilters}

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -7,24 +7,13 @@ import KanbanBoard from "./KanbanBoard";
 import TaskInfoPanel from "./TaskInfoPanel";
 import SplitLayout from "./SplitLayout";
 import ActiveTasksSidebar from "./ActiveTasksSidebar";
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { useT } from "../i18n";
 import ActiveTasksStrip from "./ActiveTasksStrip";
 import TaskWorkspacePane from "./TaskWorkspacePane";
 import { useTaskInlineDiffState } from "./task-inline-diff";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
-
-type SidebarMode = "sidebar" | "board";
-const LS_SIDEBAR_MODE = "dev3-split-sidebar-mode";
-
-function readSidebarMode(): SidebarMode {
-	try {
-		const v = localStorage.getItem(LS_SIDEBAR_MODE);
-		if (v === "board" || v === "sidebar") return v;
-	} catch { /* ignore */ }
-	return "sidebar";
-}
 
 interface ProjectViewProps {
 	projectId: string;
@@ -57,17 +46,9 @@ function ProjectView({
 }: ProjectViewProps) {
 	const t = useT();
 	const project = projects.find((p) => p.id === projectId);
-	const [sidebarMode, setSidebarMode] = useState<SidebarMode>(readSidebarMode);
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const inlineDiff = useTaskInlineDiffState(activeTaskId);
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
-
-	const toggleSidebarMode = useCallback((mode: SidebarMode) => {
-		setSidebarMode(mode);
-		try {
-			localStorage.setItem(LS_SIDEBAR_MODE, mode);
-		} catch { /* ignore */ }
-	}, []);
 
 	useEffect(() => {
 		(async () => {
@@ -169,37 +150,6 @@ function ProjectView({
 			);
 		}
 
-		const leftContent = sidebarMode === "sidebar" ? (
-			<ActiveTasksSidebar
-				project={project}
-				tasks={tasks}
-				allProjects={projects}
-				activeTaskId={activeTaskId}
-				dispatch={dispatch}
-				navigate={navigate}
-				agents={agents}
-				bellCounts={bellCounts}
-				bellReasons={bellReasons}
-				taskPorts={taskPorts}
-				onSwitchToBoard={() => toggleSidebarMode("board")}
-				disableGlobalFindShortcut={inlineDiff.isOpen}
-			/>
-		) : (
-			<KanbanBoard
-				project={project}
-				tasks={tasks}
-				dispatch={dispatch}
-				navigate={navigate}
-				bellCounts={bellCounts}
-				bellReasons={bellReasons}
-				taskPorts={taskPorts}
-				taskResourceUsage={taskResourceUsage}
-				activeTaskId={activeTaskId}
-				onSwitchToSidebar={() => toggleSidebarMode("sidebar")}
-				disableGlobalFindShortcut={inlineDiff.isOpen}
-			/>
-		);
-
 		return (
 			<div className="flex-1 min-h-0 flex flex-col">
 				{activeTask && (
@@ -214,9 +164,22 @@ function ProjectView({
 					/>
 				)}
 				<SplitLayout
-					kanbanContent={leftContent}
+					kanbanContent={
+						<ActiveTasksSidebar
+							project={project}
+							tasks={tasks}
+							allProjects={projects}
+							activeTaskId={activeTaskId}
+							dispatch={dispatch}
+							navigate={navigate}
+							agents={agents}
+							bellCounts={bellCounts}
+							bellReasons={bellReasons}
+							taskPorts={taskPorts}
+							disableGlobalFindShortcut={inlineDiff.isOpen}
+						/>
+					}
 					terminalContent={terminalPane}
-					mode={sidebarMode}
 				/>
 			</div>
 		);

--- a/src/mainview/components/SplitLayout.tsx
+++ b/src/mainview/components/SplitLayout.tsx
@@ -1,11 +1,9 @@
 import { useState, useRef, useCallback, useEffect, type ReactNode } from "react";
 
-const DEFAULT_BOARD_WIDTH = 320;
 const DEFAULT_SIDEBAR_WIDTH = 240;
 const MIN_KANBAN_WIDTH = 200;
 const MAX_KANBAN_RATIO = 0.6;
 const DRAG_THRESHOLD_PX = 3;
-const LS_KEY_BOARD = "dev3-split-kanban-width";
 const LS_KEY_SIDEBAR = "dev3-split-sidebar-width";
 
 function readStoredWidth(key: string, fallback: number): number {
@@ -22,28 +20,19 @@ function readStoredWidth(key: string, fallback: number): number {
 interface SplitLayoutProps {
 	kanbanContent: ReactNode;
 	terminalContent: ReactNode;
-	mode?: "sidebar" | "board";
 }
 
-function SplitLayout({ kanbanContent, terminalContent, mode = "board" }: SplitLayoutProps) {
-	const lsKey = mode === "sidebar" ? LS_KEY_SIDEBAR : LS_KEY_BOARD;
-	const defaultWidth = mode === "sidebar" ? DEFAULT_SIDEBAR_WIDTH : DEFAULT_BOARD_WIDTH;
-
-	const [kanbanWidth, setKanbanWidth] = useState(() => readStoredWidth(lsKey, defaultWidth));
+function SplitLayout({ kanbanContent, terminalContent }: SplitLayoutProps) {
+	const [kanbanWidth, setKanbanWidth] = useState(() => readStoredWidth(LS_KEY_SIDEBAR, DEFAULT_SIDEBAR_WIDTH));
 	const panelRef = useRef<HTMLDivElement>(null);
 	const dragging = useRef(false);
-
-	// Reset width when mode changes
-	useEffect(() => {
-		setKanbanWidth(readStoredWidth(lsKey, defaultWidth));
-	}, [lsKey, defaultWidth]);
 
 	// Persist width to localStorage
 	useEffect(() => {
 		try {
-			localStorage.setItem(lsKey, String(Math.round(kanbanWidth)));
+			localStorage.setItem(LS_KEY_SIDEBAR, String(Math.round(kanbanWidth)));
 		} catch { /* ignore */ }
-	}, [kanbanWidth, lsKey]);
+	}, [kanbanWidth]);
 
 	// Clamp width on window resize
 	useEffect(() => {
@@ -93,9 +82,9 @@ function SplitLayout({ kanbanContent, terminalContent, mode = "board" }: SplitLa
 	}, [kanbanWidth]);
 
 	function handleDoubleClick() {
-		setKanbanWidth(defaultWidth);
+		setKanbanWidth(DEFAULT_SIDEBAR_WIDTH);
 		if (panelRef.current) {
-			panelRef.current.style.width = `${defaultWidth}px`;
+			panelRef.current.style.width = `${DEFAULT_SIDEBAR_WIDTH}px`;
 		}
 	}
 

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -96,7 +96,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent, codexAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -130,7 +129,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent, codexAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -186,7 +184,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -268,7 +265,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -324,7 +320,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map([["pr-signal", 1]])}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -354,7 +349,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -381,7 +375,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -414,7 +407,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent, codexAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -439,7 +431,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -456,7 +447,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -481,7 +471,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -512,7 +501,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -535,7 +523,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 					disableGlobalFindShortcut
 				/>
 			</I18nProvider>,
@@ -562,7 +549,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -582,7 +568,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -603,7 +588,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -626,7 +610,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -667,7 +650,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -724,7 +706,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);
@@ -760,7 +741,6 @@ describe("ActiveTasksSidebar", () => {
 					agents={[claudeAgent]}
 					bellCounts={new Map()}
 					taskPorts={new Map()}
-					onSwitchToBoard={vi.fn()}
 				/>
 			</I18nProvider>,
 		);

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -63,8 +63,6 @@ const common = {
 	"sidebar.noActiveTasks": "No active tasks",
 	"sidebar.noSearchResults": "No tasks match your search",
 	"sidebar.searchPlaceholder": "Search tasks...",
-	"sidebar.switchToBoard": "Show board",
-	"sidebar.switchToSidebar": "Show sidebar",
 	"sidebar.hide": "Zoom terminal (hide Active Tasks)",
 	"sidebar.scopeProject": "Only this project",
 	"sidebar.scopeGlobal": "All projects",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -63,8 +63,6 @@ const common = {
 	"sidebar.noActiveTasks": "Sin tareas activas",
 	"sidebar.noSearchResults": "No se encontraron tareas",
 	"sidebar.searchPlaceholder": "Buscar tareas...",
-	"sidebar.switchToBoard": "Mostrar tablero",
-	"sidebar.switchToSidebar": "Mostrar panel",
 	"sidebar.hide": "Zoom del terminal (ocultar Tareas activas)",
 	"sidebar.scopeProject": "Solo este proyecto",
 	"sidebar.scopeGlobal": "Todos los proyectos",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -63,8 +63,6 @@ const common = {
 	"sidebar.noActiveTasks": "Нет активных задач",
 	"sidebar.noSearchResults": "Ничего не найдено",
 	"sidebar.searchPlaceholder": "Поиск задач...",
-	"sidebar.switchToBoard": "Показать доску",
-	"sidebar.switchToSidebar": "Показать панель",
 	"sidebar.hide": "Zoom терминала (скрыть Active Tasks)",
 	"sidebar.scopeProject": "Только этот проект",
 	"sidebar.scopeGlobal": "Все проекты",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

Removes the Kanban board split-view mode from the task view. The task view no longer lets you switch its left pane between the Active Tasks sidebar and an embedded Kanban board — it now always shows the Active Tasks sidebar next to the terminal.

This mode was easy to trigger accidentally (the "Show board" button) and, once in it, the way back to the task view was unclear, so it's removed entirely.

## Changes

- Drop the **"Show board"** button (`onSwitchToBoard`) from `ActiveTasksSidebar` and the **"Show sidebar"** button (`onSwitchToSidebar`) from `KanbanBoard`.
- Remove the `sidebarMode` state, its `localStorage` key, and the `readSidebarMode`/`toggleSidebarMode` logic from `ProjectView`.
- Simplify `SplitLayout` to sidebar-only (drop the dead board-width branch, `mode` prop, and board `localStorage` key).
- Remove the now-unused `sidebar.switchToBoard` / `sidebar.switchToSidebar` i18n keys (en/ru/es) and the corresponding test props.

The full Kanban board is still reachable via the breadcrumb. Note the toggle buttons only rendered in desktop (Electrobun) mode — the browser/remote layout already used the Active Tasks strip and never had them.

`bun run lint` and `bun run test` are green.