### PR TITLE
Fix Quick Shell opening scratch op in chrome-less task view

### DIFF
--- a/change-logs/2026/07/06/fix-quick-shell-chromeless-view.md
+++ b/change-logs/2026/07/06/fix-quick-shell-chromeless-view.md
@@ -1,0 +1,1 @@
+Fixed Quick Shell (⇧⌘`) opening a scratch op in a chrome-less terminal with no task header or tmux controls. The full-page task view now loads its project's tasks so the header always renders, and Quick Shell honors the task open-mode preference (split by default) instead of forcing a bare fullscreen terminal.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -366,10 +366,19 @@ function App() {
 
 	// Quick shell (⇧⌘`): spawn a fresh scratch op in the built-in Operations board
 	// and jump to it. The backend launches it with the default agent + config.
+	// Honor the `dev3-task-open-mode` preference like every other task-open path
+	// (card click, notification, toast) — default "split" lands on the Operations
+	// board with the task's workspace beside it (matching what the user sees when
+	// they open the same task from the board), NOT a bare fullscreen terminal.
 	const openQuickShell = useCallback(async () => {
 		try {
 			const task = await api.request.openQuickShell({});
-			navigate({ screen: "task", projectId: task.projectId, taskId: task.id });
+			const openMode = getTaskOpenMode();
+			if (openMode === "fullscreen") {
+				navigate({ screen: "task", projectId: task.projectId, taskId: task.id });
+			} else {
+				navigate({ screen: "project", projectId: task.projectId, activeTaskId: task.id });
+			}
 		} catch (err) {
 			toast.error(String(err));
 		}

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -32,6 +32,7 @@ vi.mock("../rpc", () => ({
 				updateChannel: "stable",
 			}),
 			moveTask: vi.fn().mockResolvedValue({}),
+			openQuickShell: vi.fn().mockResolvedValue({ id: "op-task-1", projectId: "ops-proj" }),
 			dismissMergeCompletionPrompt: vi.fn().mockResolvedValue(undefined),
 			listAgentSkills: vi.fn().mockResolvedValue([]),
 			respondToAgentCompletionRequest: vi.fn().mockResolvedValue(undefined),
@@ -371,6 +372,44 @@ describe("App keyboard shortcuts", () => {
 			const after = screen.getByTestId("project-screen");
 			expect(after).toHaveAttribute("data-project-id", "p2");
 			expect(after).toHaveAttribute("data-task-view", "false");
+		});
+	});
+
+	// Quick shell (⇧⌘`) spawns a scratch op in the built-in Operations board and
+	// jumps to it. Regression: it used to hardcode the full-page task route, which
+	// (a) ignored the user's open-mode preference and (b) dropped them onto a
+	// chrome-less terminal (the target project's tasks were never loaded). It must
+	// honor `dev3-task-open-mode` like every other task-open path.
+	describe("quick shell (⇧⌘`) navigation", () => {
+		afterEach(() => {
+			localStorage.removeItem("dev3-task-open-mode");
+		});
+
+		function triggerQuickShell() {
+			act(() => {
+				window.dispatchEvent(new CustomEvent("menu:open-quick-shell"));
+			});
+		}
+
+		it("split open-mode: opens the scratch op beside its board (activeTaskId), not a bare fullscreen terminal", async () => {
+			vi.mocked(api.request.openQuickShell).mockResolvedValue({ id: "op-task-1", projectId: "ops-proj" } as never);
+			await renderApp();
+
+			triggerQuickShell();
+
+			const view = await screen.findByTestId("project-screen");
+			expect(view).toHaveAttribute("data-project-id", "ops-proj");
+			expect(view).toHaveAttribute("data-active-task-id", "op-task-1");
+		});
+
+		it("fullscreen open-mode: opens the scratch op in the full-page task view", async () => {
+			localStorage.setItem("dev3-task-open-mode", "fullscreen");
+			vi.mocked(api.request.openQuickShell).mockResolvedValue({ id: "op-task-1", projectId: "ops-proj" } as never);
+			await renderApp();
+
+			triggerQuickShell();
+
+			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
 		});
 	});
 

--- a/src/mainview/components/TaskWorkspaceView.tsx
+++ b/src/mainview/components/TaskWorkspaceView.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import type { Dispatch, MutableRefObject } from "react";
 import type { Project, Task } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import type { NavigationGuard } from "../navigation-guard";
+import { api } from "../rpc";
 import TaskInfoPanel from "./TaskInfoPanel";
 import TaskWorkspacePane from "./TaskWorkspacePane";
 import { useTaskInlineDiffState } from "./task-inline-diff";
@@ -28,6 +30,25 @@ function TaskWorkspaceView({
 	const task = tasks.find((item) => item.id === taskId);
 	const project = projects.find((item) => item.id === projectId);
 	const inlineDiff = useTaskInlineDiffState(taskId);
+
+	// The fullscreen task view can be entered for a task whose project's tasks
+	// were never loaded into `currentProjectTasks` — e.g. quick-shell jumps
+	// straight to a fresh scratch op in the built-in Operations board, or a
+	// toast / notification click opens a task in a different project. Without the
+	// matching task object the header chrome (TaskInfoPanel: task id, Watch,
+	// status, tmux controls) silently vanishes and only the bare terminal shows.
+	// Load the project's tasks on mount, mirroring ProjectView, so the chrome
+	// always renders regardless of the entry point.
+	useEffect(() => {
+		(async () => {
+			try {
+				const loaded = await api.request.getTasks({ projectId });
+				dispatch({ type: "setTasks", tasks: loaded });
+			} catch (err) {
+				console.error("Failed to load tasks:", err);
+			}
+		})();
+	}, [projectId, dispatch]);
 
 	return (
 		<div className="flex-1 min-h-0 flex flex-col">

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -1,8 +1,21 @@
 import { useEffect } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Project, Task } from "../../../shared/types";
 import TaskWorkspaceView from "../TaskWorkspaceView";
+
+const getTasksMock = vi.fn();
+const exitCopyModeAllPanesMock = vi.fn((_params: { taskId: string }) => Promise.resolve());
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			getTasks: (params: { projectId: string }) => getTasksMock(params),
+			exitCopyModeAllPanes: (params: { taskId: string }) => exitCopyModeAllPanesMock(params),
+		},
+	},
+	isElectrobun: false,
+}));
 
 // Tracks TaskTerminal mount lifecycle so the `key={taskId}` regression
 // test below can assert that a fresh instance is mounted per task.
@@ -71,6 +84,36 @@ describe("TaskWorkspaceView", () => {
 	beforeEach(() => {
 		mountLog.length = 0;
 		unmountLog.length = 0;
+		getTasksMock.mockReset();
+		getTasksMock.mockResolvedValue([]);
+		exitCopyModeAllPanesMock.mockClear();
+	});
+
+	// Regression: the fullscreen task view can be entered for a task whose
+	// project's tasks were never loaded into currentProjectTasks (quick-shell
+	// scratch op, toast / notification click into another project). Before the
+	// fix the view never fetched them, so `task` stayed undefined and the header
+	// chrome (TaskInfoPanel) silently disappeared. It must load its project's
+	// tasks on mount and hydrate the store so the chrome renders.
+	it("loads its project's tasks on mount and hydrates the store", async () => {
+		const dispatch = vi.fn();
+		getTasksMock.mockResolvedValue([task]);
+
+		render(
+			<TaskWorkspaceView
+				projectId="p1"
+				taskId="t1"
+				tasks={[]}
+				projects={[project]}
+				navigate={vi.fn()}
+				dispatch={dispatch}
+			/>,
+		);
+
+		await waitFor(() => expect(getTasksMock).toHaveBeenCalledWith({ projectId: "p1" }));
+		await waitFor(() =>
+			expect(dispatch).toHaveBeenCalledWith({ type: "setTasks", tasks: [task] }),
+		);
 	});
 
 	it("toggles between terminal and inline diff", async () => {


### PR DESCRIPTION
## Summary

Quick Shell (⌘⇧\`) spawned a scratch op in the built-in Operations board but dropped the user onto a bare terminal with no task header — no task ID, no Watch/status controls, no tmux layout buttons. Opening the same task from the Operations list showed the full chrome.

Root cause: the full-page task view (`screen:"task"` → `TaskWorkspaceView`) never loaded `currentProjectTasks` for its own project — unlike `ProjectView` (`screen:"project"`), which fetches `getTasks` on mount. Jumping straight into a fullscreen task whose project's tasks were never loaded (quick-shell scratch op, or a toast/notification click into another project) left the task lookup `undefined`, so `TaskInfoPanel` silently rendered nothing and only the terminal showed.

## Changes

- `TaskWorkspaceView` now fetches `getTasks({ projectId })` on mount, mirroring `ProjectView`, so the header chrome renders regardless of entry point.
- `openQuickShell` now honors the `dev3-task-open-mode` preference (split by default) like every other task-open path (card click, notification, toast), landing on the Operations board beside the task instead of forcing a bare fullscreen terminal.
- Regression tests for both paths (fullscreen view self-loads tasks; quick shell respects open-mode).

Verified in a headless browser: Quick Shell now opens the scratch op in the correct split view with task ID in the breadcrumb, Active Tasks sidebar, and tmux controls.