### PR TITLE
Fold stateful header widgets into the kebab sheet on mobile

### DIFF
--- a/change-logs/2026/07/06/feature-mobile-header-fold-stateful-widgets.md
+++ b/change-logs/2026/07/06/feature-mobile-header-fold-stateful-widgets.md
@@ -1,0 +1,1 @@
+On narrow (mobile) viewports the global header no longer shows the prevent-sleep, rate-limit, git-pull, and tmux-sessions widgets inline; they now fold into the kebab (⋮) bottom sheet as a controls strip, decluttering the mobile header. Their popovers/modals layer above the sheet.

--- a/src/mainview/components/GitPullErrorModal.tsx
+++ b/src/mainview/components/GitPullErrorModal.tsx
@@ -25,7 +25,9 @@ function GitPullErrorModal({ branch, error, retrying, onRetry, onClose }: GitPul
 	return createPortal(
 		<div
 			data-git-pull-error-modal="true"
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			// z-[80] so the error modal layers above the narrow header bottom sheet
+			// (z-[70]) when Git Pull is folded into it on mobile.
+			className="fixed inset-0 z-[80] flex items-center justify-center bg-black/50"
 			onClick={onClose}
 		>
 			{/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -147,6 +147,10 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 
 	useEffect(() => {
 		setShowOverflowMenu(false);
+		// Navigating from inside the narrow action sheet (e.g. tapping a tmux
+		// session) dismisses the sheet too — the row handlers close it directly,
+		// but tmux navigates on its own, so close it here for that path.
+		setShowActionSheet(false);
 	}, [route]);
 
 	// Fetch active task counts when project dropdown opens (with cache)
@@ -539,11 +543,13 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 					</div>
 				)}
 
-				{/* Prevent-sleep toggle — keeps the machine awake while dev-3.0 runs */}
-				<PreventSleepToggle compact={compact} />
+				{/* Prevent-sleep toggle — keeps the machine awake while dev-3.0 runs.
+				    Folded into the kebab bottom sheet on narrow. */}
+				{!isNarrow && <PreventSleepToggle compact={compact} />}
 
-				{/* Ambient agent rate-limit indicator — hidden until any limit data exists */}
-				<RateLimitIndicator compact={compact} />
+				{/* Ambient agent rate-limit indicator — hidden until any limit data exists
+				    (folded into the kebab bottom sheet on narrow). */}
+				{!isNarrow && <RateLimitIndicator compact={compact} />}
 
 				{/* Quick Shell — opens the built-in Operations shell in $HOME (folded into the kebab on narrow) */}
 				{!isNarrow && (
@@ -587,8 +593,9 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				)}
 
 				{/* Git Pull — quick pull of origin/{main|master} into project main worktree.
-				    Hidden for virtual ("Operations") boards, which have no git repo. */}
-				{"projectId" in route && !isVirtualProject && (
+				    Hidden for virtual ("Operations") boards, which have no git repo.
+				    Folded into the kebab bottom sheet on narrow. */}
+				{"projectId" in route && !isVirtualProject && !isNarrow && (
 					<GitPullButton projectId={route.projectId} compact={compact} />
 				)}
 
@@ -613,8 +620,8 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				</Tooltip>
 				)}
 
-				{/* Tmux Session Manager */}
-				<TmuxSessionManager navigate={navigate} />
+				{/* Tmux Session Manager — folded into the kebab bottom sheet on narrow. */}
+				{!isNarrow && <TmuxSessionManager navigate={navigate} />}
 
 				{/* External / low-frequency actions: inline when roomy, folded into an overflow menu when compact */}
 				{!compact && (
@@ -816,6 +823,18 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				testId="header-action-sheet"
 			>
 				<div className="flex flex-col">
+					{/* Stateful widgets folded off the header on narrow: prevent-sleep,
+					    rate-limit, git-pull, tmux sessions. Reused verbatim so their live
+					    state / popovers / modals keep working (those overlays layer above
+					    the sheet — see the z-index in TmuxSessionManager / GitPullErrorModal). */}
+					<div className="flex flex-wrap items-center gap-1.5 pb-3 mb-1 border-b border-edge/60">
+						<PreventSleepToggle compact={false} />
+						<RateLimitIndicator compact={false} />
+						{currentProjectId && !isVirtualProject && (
+							<GitPullButton projectId={currentProjectId} compact={false} />
+						)}
+						<TmuxSessionManager navigate={navigate} />
+					</div>
 					{headerSheetRows.map((row) => (
 						<button
 							key={row.key}

--- a/src/mainview/components/TmuxSessionManager.tsx
+++ b/src/mainview/components/TmuxSessionManager.tsx
@@ -217,7 +217,9 @@ function TmuxSessionManager({ navigate }: TmuxSessionManagerProps) {
 				createPortal(
 					<div
 						ref={popoverRef}
-						className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active py-2 min-w-[22.5rem] max-w-[30rem] max-h-[25rem] flex flex-col"
+						// z-[80] so the popover layers above the narrow header bottom sheet
+						// (z-[70]) when the tmux manager is folded into it on mobile.
+						className="fixed z-[80] bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active py-2 min-w-[22.5rem] max-w-[30rem] max-h-[25rem] flex flex-col"
 						style={{
 							top: popoverPos.top,
 							left: popoverPos.left,

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -886,4 +886,20 @@ describe("GlobalHeader — narrow viewport action sheet", () => {
 		await user.click(screen.getByText("Project Terminal"));
 		expect(navigate).toHaveBeenCalledWith({ screen: "project-terminal", projectId: "p1" });
 	});
+
+	it("keeps the stateful widgets (git pull, tmux) out of the inline header", () => {
+		renderHeader({ screen: "project", projectId: "p1" });
+		// Folded into the kebab sheet — not sitting inline in the header row.
+		expect(screen.queryByTestId("git-pull-button")).not.toBeInTheDocument();
+		expect(screen.queryByTitle("tmux Sessions")).not.toBeInTheDocument();
+	});
+
+	it("surfaces the stateful widgets inside the bottom sheet", async () => {
+		const user = userEvent.setup();
+		renderHeader({ screen: "project", projectId: "p1" });
+		await user.click(screen.getByLabelText("More"));
+		// Git pull + tmux manager now live in the sheet's controls strip.
+		expect(screen.getByTestId("git-pull-button")).toBeInTheDocument();
+		expect(screen.getByTitle("tmux Sessions")).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

On narrow (mobile) viewports the global header was crowded: the prevent-sleep (☕), rate-limit (⏳), git-pull (☁), and tmux-sessions (▦ count) widgets all rendered inline next to the kebab (⋮). This folds those four stateful widgets off the inline header on narrow viewports and surfaces them inside the existing kebab bottom sheet as a controls strip above the action list.

- Narrow header now shows only the ⋮ kebab (plus the rare "Update ready" pill).
- The four widgets are reused verbatim inside the bottom sheet, so their live state, popovers, and modals keep working.
- Bumped the tmux popover and the git-pull error modal to `z-[80]` so their overlays layer above the sheet (`z-[70]`) when triggered from within it.
- The narrow action sheet now also closes on route change (so navigating from the tmux popover dismisses it).
- Desktop / roomy layout is unchanged — the widgets stay inline there.

Verified in a headless mobile viewport (390×844): controls strip renders, the tmux popover opens above the sheet, and the console is clean. `bun run lint` and `bun run test` are green; added two tests to the narrow-viewport suite.
