### PR TITLE
Retry pull once on 'Cannot fast-forward to multiple branches'

### DIFF
--- a/change-logs/2026/07/07/fix-pull-multiple-branches-retry.md
+++ b/change-logs/2026/07/07/fix-pull-multiple-branches-retry.md
@@ -1,0 +1,1 @@
+Pulling origin now retries once when git fails with "Cannot fast-forward to multiple branches" — a transient race with a concurrent background fetch rewriting FETCH_HEAD. The single retry re-fetches a clean state and clears the error; unrelated pull failures are returned immediately without retrying.

--- a/src/bun/__tests__/git-branch-ops.test.ts
+++ b/src/bun/__tests__/git-branch-ops.test.ts
@@ -145,6 +145,32 @@ describe("pullOrigin", () => {
 		expect(result.ok).toBe(true);
 		expect(result.stdout).toMatch(/Fast-forward/);
 	});
+
+	it("retries once when pull fails with 'Cannot fast-forward to multiple branches'", async () => {
+		queueResponse(128, "", "fatal: Cannot fast-forward to multiple branches.\n");
+		queueResponse(0, "Updating abc..def\nFast-forward\n");
+		const result = await pullOrigin("/repo", "main", { retryDelayMs: 0 });
+		expect(result.ok).toBe(true);
+		expect(result.stdout).toMatch(/Fast-forward/);
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("retries at most once — a second multiple-branches failure is returned", async () => {
+		queueResponse(128, "", "fatal: Cannot fast-forward to multiple branches.\n");
+		queueResponse(128, "", "fatal: Cannot fast-forward to multiple branches.\n");
+		const result = await pullOrigin("/repo", "main", { retryDelayMs: 0 });
+		expect(result.ok).toBe(false);
+		expect(result.stderr).toMatch(/Cannot fast-forward to multiple branches/);
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry on unrelated pull failures", async () => {
+		queueResponse(1, "", "fatal: unable to access 'https://...': Could not resolve host\n");
+		const result = await pullOrigin("/repo", "main", { retryDelayMs: 0 });
+		expect(result.ok).toBe(false);
+		expect(result.stderr).toMatch(/unable to access/);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
 });
 
 // ─── isWorktreeDirty ────────────────────────────────────────────────────────

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1262,13 +1262,33 @@ export async function fetchOrigin(
 	}
 }
 
+// `git pull --ff-only` intermittently dies with "fatal: Cannot fast-forward to
+// multiple branches." — a transient race where a concurrent background fetch
+// (see the fetchOrigin dedup machinery above) rewrites FETCH_HEAD between the
+// pull's own fetch and merge steps, leaving several branches flagged for-merge.
+// Re-running the pull re-fetches a clean FETCH_HEAD, so a single retry clears it.
+const MULTIPLE_BRANCHES_FF_ERROR = /Cannot fast-forward to multiple branches/i;
+const PULL_RETRY_DELAY_MS = 400;
+
 export async function pullOrigin(
 	projectPath: string,
 	branch: string,
+	opts?: { retryDelayMs?: number },
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
 	const startedAt = performance.now();
 	log.info("pullOrigin", { projectPath, branch });
-	const result = await run(["git", "pull", "--ff-only", "origin", branch], projectPath);
+	let result = await run(["git", "pull", "--ff-only", "origin", branch], projectPath);
+	// One (and only one) retry, scoped to the multiple-branches fast-forward race.
+	if (!result.ok && MULTIPLE_BRANCHES_FF_ERROR.test(result.stderr)) {
+		const delayMs = opts?.retryDelayMs ?? PULL_RETRY_DELAY_MS;
+		log.warn("pullOrigin: 'cannot fast-forward to multiple branches' — retrying once", {
+			projectPath,
+			branch,
+			delayMs,
+		});
+		if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+		result = await run(["git", "pull", "--ff-only", "origin", branch], projectPath);
+	}
 	log.info("pullOrigin finished", {
 		projectPath,
 		branch,


### PR DESCRIPTION
`git pull --ff-only origin <branch>` intermittently dies with `fatal: Cannot fast-forward to multiple branches.` — a transient race where a concurrent background fetch (the `fetchOrigin` dedup machinery) rewrites `FETCH_HEAD` between the pull's own fetch and merge steps, leaving several branches flagged for-merge.

`pullOrigin` (`src/bun/git.ts`) now performs a single, scoped retry: on that specific stderr it waits ~400ms and re-runs the pull once (re-fetching a clean `FETCH_HEAD`). All other pull failures return immediately, with no retry. Added tests covering the retry, the at-most-once bound, and the no-retry path for unrelated errors.