### PR TITLE
Fix Automation modal rendered partially off-screen (#845)

### DIFF
--- a/change-logs/2026/07/07/fix-automation-modal-offscreen.md
+++ b/change-logs/2026/07/07/fix-automation-modal-offscreen.md
@@ -1,0 +1,3 @@
+Fixed the automation create/edit modal rendering partially off-screen. It was nested inside the Project Settings blur-backed card, whose backdrop-filter trapped the modal's fixed positioning; it now portals to the document body and anchors to the viewport like every other modal.
+
+Suggested by @EvgenyAlterman (h0x91b/dev-3.0#845)

--- a/src/mainview/components/AutomationEditModal.tsx
+++ b/src/mainview/components/AutomationEditModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Automation, AutomationCatchUpPolicy, CodingAgent, Project } from "../../shared/types";
 import { AUTOMATION_TEMPLATES } from "../../shared/automation-templates";
 import { formatRRule, parseRRule, type RRuleSpec } from "../../shared/rrule";
@@ -165,14 +166,19 @@ function AutomationEditModal({ project, automation, onClose, onSaved }: Automati
 			mode === m ? "bg-accent/15 text-accent" : "text-fg-3 hover:text-fg-2 hover:bg-raised-hover"
 		}`;
 
-	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+	// Portal to <body>: this modal is rendered inside ProjectSettings' `backdrop-blur`
+	// card, and `backdrop-filter` establishes a containing block for `position: fixed`
+	// descendants — an inline `fixed inset-0` would anchor to that ~672px card and land
+	// partially off-screen (#845). Portaling detaches it from that subtree so it re-anchors
+	// to the viewport.
+	return createPortal(
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4" onClick={onClose}>
 			<div
 				ref={trapRef}
 				role="dialog"
 				aria-modal="true"
 				tabIndex={-1}
-				className="bg-overlay rounded-2xl shadow-2xl shadow-black/50 border border-edge-active w-full max-w-2xl max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-2rem)] mx-4 overflow-y-auto outline-none"
+				className="bg-overlay rounded-2xl shadow-2xl shadow-black/50 border border-edge-active w-full max-w-2xl max-h-[calc(100dvh-2rem)] overflow-y-auto outline-none"
 				onClick={(e) => e.stopPropagation()}
 			>
 				<div className="px-6 py-4 border-b border-edge">
@@ -366,7 +372,8 @@ function AutomationEditModal({ project, automation, onClose, onSaved }: Automati
 					</button>
 				</div>
 			</div>
-		</div>
+		</div>,
+		document.body,
 	);
 }
 

--- a/src/mainview/components/__tests__/AutomationsPanel.test.tsx
+++ b/src/mainview/components/__tests__/AutomationsPanel.test.tsx
@@ -92,6 +92,21 @@ describe("AutomationsPanel", () => {
 		expect(screen.getByText("New automation", { selector: "h2" })).toBeTruthy();
 	});
 
+	it("portals the modal to <body> so it escapes ancestor containing blocks (#845)", async () => {
+		// The modal is rendered deep inside ProjectSettings' `backdrop-blur` card.
+		// `backdrop-filter` establishes a containing block for `position: fixed`
+		// descendants, so an inline `fixed inset-0` modal anchors to that ~672px
+		// card instead of the viewport and lands partially off-screen. Portaling to
+		// document.body detaches it from the panel subtree and re-anchors to the viewport.
+		vi.mocked(api.request.listAutomations).mockResolvedValue([]);
+		const { container } = renderPanel();
+		await screen.findByText("No automations yet.");
+		await userEvent.click(screen.getByText("New automation"));
+		const dialog = await screen.findByRole("dialog");
+		expect(container.contains(dialog)).toBe(false);
+		expect(document.body.contains(dialog)).toBe(true);
+	});
+
 	it("fires runAutomationNow from the Run now button", async () => {
 		vi.mocked(api.request.listAutomations).mockResolvedValue([automation]);
 		vi.mocked(api.request.runAutomationNow).mockResolvedValue({ taskId: "task-1" });


### PR DESCRIPTION
Hi — this is Claude (the AI assistant working on this branch) 👋

## Summary

Fixes the Automation create/edit modal rendering partially off-screen when opened from **Project Settings → Automations**.

**Root cause:** the modal uses `fixed inset-0`, but it's rendered inside the Project Settings card which has `backdrop-blur-sm`. A non-`none` `backdrop-filter` establishes a containing block for `position: fixed` descendants, so the modal anchored to that ~672px settings card instead of the viewport — landing off-screen.

**Fix:** portal the modal to `document.body` (matching every other modal in the app — `KeyboardShortcutsModal`, `PaletteShell`, `ImageLightbox`, …) so it re-anchors to the viewport regardless of any transformed/filtered ancestor. Also dropped a conflicting duplicate `max-width` utility and moved the horizontal inset to the container's `px-4`, so the modal stays within bounds on narrow viewports too.

Added a regression test asserting the modal is portaled out of the panel subtree onto `<body>`, and verified the result in a browser at both 1440px and 420px widths.

Closes #845