### PR TITLE
Add "Start in…" deferred task launch with countdown badge

### DIFF
--- a/src/bun/__tests__/duration.test.ts
+++ b/src/bun/__tests__/duration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCountdown, parseDelay } from "../../shared/duration";
+
+const M = 60_000;
+const H = 3_600_000;
+const D = 86_400_000;
+
+describe("parseDelay", () => {
+	it("parses bare numbers as minutes", () => {
+		expect(parseDelay("90")).toBe(90 * M);
+		expect(parseDelay("1")).toBe(M);
+	});
+
+	it("parses single-unit segments", () => {
+		expect(parseDelay("45m")).toBe(45 * M);
+		expect(parseDelay("2h")).toBe(2 * H);
+		expect(parseDelay("1d")).toBe(D);
+	});
+
+	it("parses compound segments", () => {
+		expect(parseDelay("1h30m")).toBe(H + 30 * M);
+		expect(parseDelay("1d2h")).toBe(D + 2 * H);
+		expect(parseDelay("1d2h15m")).toBe(D + 2 * H + 15 * M);
+	});
+
+	it("ignores whitespace and case", () => {
+		expect(parseDelay(" 1H 30M ")).toBe(H + 30 * M);
+		expect(parseDelay("2 h")).toBe(2 * H);
+	});
+
+	it("rejects a repeated unit", () => {
+		expect(parseDelay("1h2h")).toBeNull();
+		expect(parseDelay("10m5m")).toBeNull();
+	});
+
+	it("rejects zero and non-positive delays", () => {
+		expect(parseDelay("0")).toBeNull();
+		expect(parseDelay("0m")).toBeNull();
+		expect(parseDelay("0h0m")).toBeNull();
+	});
+
+	it("rejects garbage", () => {
+		expect(parseDelay("")).toBeNull();
+		expect(parseDelay("abc")).toBeNull();
+		expect(parseDelay("5x")).toBeNull();
+		expect(parseDelay("h30")).toBeNull();
+		expect(parseDelay("-5m")).toBeNull();
+		expect(parseDelay("1.5h")).toBeNull();
+	});
+});
+
+describe("formatCountdown", () => {
+	it("clamps below one minute (including negatives)", () => {
+		expect(formatCountdown(0)).toBe("<1m");
+		expect(formatCountdown(59_999)).toBe("<1m");
+		expect(formatCountdown(-5 * M)).toBe("<1m");
+	});
+
+	it("formats minutes only", () => {
+		expect(formatCountdown(12 * M)).toBe("12m");
+		expect(formatCountdown(M)).toBe("1m");
+	});
+
+	it("formats hours with zero-padded minutes", () => {
+		expect(formatCountdown(H + 5 * M)).toBe("1h 05m");
+		expect(formatCountdown(2 * H)).toBe("2h");
+	});
+
+	it("formats days with hours, dropping minutes", () => {
+		expect(formatCountdown(2 * D + 3 * H + 40 * M)).toBe("2d 3h");
+		expect(formatCountdown(D)).toBe("1d");
+	});
+
+	it("round-trips parseDelay output", () => {
+		expect(formatCountdown(parseDelay("1h30m")!)).toBe("1h 30m");
+		expect(formatCountdown(parseDelay("2d3h")!)).toBe("2d 3h");
+	});
+});

--- a/src/bun/__tests__/scheduled-launch-scheduler.test.ts
+++ b/src/bun/__tests__/scheduled-launch-scheduler.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The scheduler imports the task-creation pipeline (which transitively pulls in
+// Electrobun); stub the heavy modules out and drive ticks via fake timers.
+vi.mock("../data", () => ({
+	loadProjects: vi.fn(async () => []),
+	loadVirtualProjects: vi.fn(async () => []),
+	loadTasks: vi.fn(async () => []),
+	updateTask: vi.fn(async () => undefined),
+}));
+vi.mock("../rpc-handlers/task-lifecycle", () => ({ fireScheduledLaunch: vi.fn(async () => undefined) }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import * as data from "../data";
+import { fireScheduledLaunch } from "../rpc-handlers/task-lifecycle";
+import { startScheduledLaunchScheduler, stopScheduledLaunchScheduler } from "../scheduled-launch-scheduler";
+
+const project = { id: "proj-1" } as never;
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "task-12345678",
+		status: "todo",
+		scheduledLaunch: { at: new Date(Date.now() - 1000).toISOString() },
+		...overrides,
+	};
+}
+
+async function flush() {
+	// Let the immediate first tick's promise chain settle.
+	for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+	vi.mocked(data.loadProjects).mockResolvedValue([project]);
+	vi.mocked(data.loadVirtualProjects).mockResolvedValue([]);
+});
+
+afterEach(() => {
+	stopScheduledLaunchScheduler();
+	vi.clearAllMocks();
+	vi.useRealTimers();
+});
+
+describe("scheduled-launch scheduler", () => {
+	it("fires a due launch on the first (startup) tick — offline catch-up", async () => {
+		const task = makeTask();
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		startScheduledLaunchScheduler();
+		await flush();
+		expect(fireScheduledLaunch).toHaveBeenCalledTimes(1);
+		expect(fireScheduledLaunch).toHaveBeenCalledWith(project, task);
+	});
+
+	it("does not fire launches scheduled in the future", async () => {
+		const task = makeTask({ scheduledLaunch: { at: new Date(Date.now() + 3_600_000).toISOString() } });
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		startScheduledLaunchScheduler();
+		await flush();
+		expect(fireScheduledLaunch).not.toHaveBeenCalled();
+	});
+
+	it("ignores stale scheduledLaunch on non-todo tasks", async () => {
+		const task = makeTask({ status: "in-progress" });
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		startScheduledLaunchScheduler();
+		await flush();
+		expect(fireScheduledLaunch).not.toHaveBeenCalled();
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("clears an unparseable schedule instead of firing", async () => {
+		const task = makeTask({ scheduledLaunch: { at: "not-a-date" } });
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		startScheduledLaunchScheduler();
+		await flush();
+		expect(fireScheduledLaunch).not.toHaveBeenCalled();
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { scheduledLaunch: null });
+	});
+
+	it("clears the schedule when firing fails (no retry-forever)", async () => {
+		const task = makeTask();
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		vi.mocked(fireScheduledLaunch).mockRejectedValueOnce(new Error("boom"));
+		startScheduledLaunchScheduler();
+		await flush();
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { scheduledLaunch: null });
+	});
+
+	it("start is idempotent and a failing project does not block others", async () => {
+		const project2 = { id: "proj-2" } as never;
+		vi.mocked(data.loadProjects).mockResolvedValue([project, project2]);
+		const task = makeTask();
+		vi.mocked(data.loadTasks)
+			.mockRejectedValueOnce(new Error("proj-1 unreadable"))
+			.mockResolvedValueOnce([task] as never);
+		startScheduledLaunchScheduler();
+		startScheduledLaunchScheduler(); // second call must be a no-op
+		await flush();
+		expect(fireScheduledLaunch).toHaveBeenCalledTimes(1);
+		expect(fireScheduledLaunch).toHaveBeenCalledWith(project2, task);
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -421,6 +421,11 @@ startRateLimitMonitor((name, payload) => {
 const { startAutomationsScheduler } = await import("./automations-scheduler");
 startAutomationsScheduler();
 
+// Start the scheduled-launch scheduler ("Start in…" deferred task launches).
+// One-shot fires; the first tick catches up launches that came due offline.
+const { startScheduledLaunchScheduler } = await import("./scheduled-launch-scheduler");
+startScheduledLaunchScheduler();
+
 // Wire PTY death notifications
 setOnPtyDied((sessionKey) => {
 	try {

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1399,6 +1399,89 @@ export async function createAutomationTask(
 	return task;
 }
 
+/**
+ * "Start in…" — persist a deferred launch on a todo task. Nothing spawns yet:
+ * the scheduled-launch scheduler (or "Start now") fires the stored variants
+ * later via {@link fireScheduledLaunch}, which reuses the exact spawnVariants
+ * pipeline of an immediate launch.
+ */
+async function scheduleTaskLaunch(params: {
+	taskId: string;
+	projectId: string;
+	at: string;
+	targetStatus: TaskStatus;
+	variants: Array<{ agentId: string | null; configId: string | null }>;
+}): Promise<Task> {
+	log.info("→ scheduleTaskLaunch", { taskId: params.taskId, at: params.at, count: params.variants.length });
+	const project = await data.getProject(params.projectId);
+	const task = await data.getTask(project, params.taskId);
+	if (task.status !== "todo") {
+		throw new Error(`Task must be in todo status to schedule a launch (got ${task.status})`);
+	}
+	if (params.variants.length === 0) {
+		throw new Error("Scheduled launch needs at least one variant");
+	}
+	const at = new Date(params.at);
+	if (!Number.isFinite(at.getTime()) || at.getTime() <= Date.now()) {
+		throw new Error("Scheduled launch time must be in the future");
+	}
+	const updated = await data.updateTask(project, task.id, {
+		scheduledLaunch: {
+			at: at.toISOString(),
+			targetStatus: params.targetStatus,
+			variants: params.variants,
+		},
+	});
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	log.info("← scheduleTaskLaunch done", { taskId: task.id.slice(0, 8), at: at.toISOString() });
+	return updated;
+}
+
+/** Clear a pending deferred launch without firing it (badge → "Cancel"). */
+async function cancelScheduledLaunch(params: { taskId: string; projectId: string }): Promise<Task> {
+	log.info("→ cancelScheduledLaunch", { taskId: params.taskId });
+	const project = await data.getProject(params.projectId);
+	const updated = await data.updateTask(project, params.taskId, { scheduledLaunch: null });
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	log.info("← cancelScheduledLaunch done", { taskId: params.taskId.slice(0, 8) });
+	return updated;
+}
+
+/**
+ * Fire a pending deferred launch NOW. Shared by the scheduler tick and the
+ * `startScheduledLaunchNow` RPC. Delegates to spawnVariants (same validation,
+ * same variant pipeline, deletes the source task), then broadcasts the
+ * server-initiated changes: clients did not call an RPC, so they learn about
+ * the consumed source via `taskRemoved` and about each variant via `taskUpdated`.
+ */
+export async function fireScheduledLaunch(project: Project, task: Task): Promise<Task[]> {
+	const sched = task.scheduledLaunch;
+	if (!sched) throw new Error("Task has no scheduled launch");
+	const spawned = await spawnVariants({
+		taskId: task.id,
+		projectId: project.id,
+		targetStatus: sched.targetStatus,
+		variants: sched.variants,
+	});
+	getPushMessage()?.("taskRemoved", { projectId: project.id, taskId: task.id });
+	for (const t of spawned) {
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: t });
+	}
+	log.info("Scheduled launch fired", {
+		taskId: task.id.slice(0, 8),
+		scheduledFor: sched.at,
+		count: spawned.length,
+	});
+	return spawned;
+}
+
+async function startScheduledLaunchNow(params: { taskId: string; projectId: string }): Promise<Task[]> {
+	log.info("→ startScheduledLaunchNow", { taskId: params.taskId });
+	const project = await data.getProject(params.projectId);
+	const task = await data.getTask(project, params.taskId);
+	return fireScheduledLaunch(project, task);
+}
+
 export const taskLifecycleHandlers = {
 	getTasks,
 	getAllProjectTasks,
@@ -1415,5 +1498,8 @@ export const taskLifecycleHandlers = {
 	setUserOverview,
 	clearUserOverview,
 	toggleTaskWatch,
+	scheduleTaskLaunch,
+	cancelScheduledLaunch,
+	startScheduledLaunchNow,
 	respondToAgentCompletionRequest,
 };

--- a/src/bun/scheduled-launch-scheduler.ts
+++ b/src/bun/scheduled-launch-scheduler.ts
@@ -1,0 +1,87 @@
+import type { Project } from "../shared/types";
+import * as data from "./data";
+import { fireScheduledLaunch } from "./rpc-handlers/task-lifecycle";
+import { createLogger } from "./logger";
+
+const log = createLogger("scheduled-launch-scheduler");
+
+/** How often the scheduler wakes up to check for due deferred launches. */
+const TICK_INTERVAL_MS = 30_000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let tickInFlight = false;
+
+/**
+ * Fires "Start in…" deferred launches (see {@link Task.scheduledLaunch}).
+ *
+ * Unlike Automations these are one-shot, so there is no missed/catch-up
+ * taxonomy: an occurrence that passed while the app was offline simply fires
+ * on the first tick after startup (late but never lost — the user asked for
+ * exactly one launch). Firing consumes the source todo task via the same
+ * spawnVariants pipeline as an immediate launch, so a crash between delete
+ * and spawn is bounded to the same guarantees spawnVariants already has.
+ */
+export function startScheduledLaunchScheduler(): void {
+	if (timer) return;
+	log.info("Scheduled-launch scheduler started", { tickMs: TICK_INTERVAL_MS });
+	// First tick runs immediately: it is also the offline late-fire catch-up.
+	void tick();
+	timer = setInterval(() => void tick(), TICK_INTERVAL_MS);
+}
+
+export function stopScheduledLaunchScheduler(): void {
+	if (timer) {
+		clearInterval(timer);
+		timer = null;
+	}
+}
+
+async function tick(): Promise<void> {
+	if (tickInFlight) return; // never overlap ticks — the double-fire guard
+	tickInFlight = true;
+	try {
+		const projects = [...await data.loadProjects(), ...await data.loadVirtualProjects()];
+		for (const project of projects) {
+			try {
+				await tickProject(project);
+			} catch (err) {
+				log.error("Scheduled-launch tick failed for project", { projectId: project.id, error: String(err) });
+			}
+		}
+	} catch (err) {
+		log.error("Scheduled-launch tick failed", { error: String(err) });
+	} finally {
+		tickInFlight = false;
+	}
+}
+
+async function tickProject(project: Project): Promise<void> {
+	const tasks = await data.loadTasks(project);
+	const now = Date.now();
+	for (const task of tasks) {
+		const sched = task.scheduledLaunch;
+		if (!sched) continue;
+		// Only todo tasks can spawn variants; a stale field on any other status
+		// is inert (spawnVariants would reject it anyway).
+		if (task.status !== "todo") continue;
+		const at = new Date(sched.at).getTime();
+		if (!Number.isFinite(at)) {
+			log.error("Scheduled launch has an unparseable time; clearing it", { taskId: task.id.slice(0, 8), at: sched.at });
+			await data.updateTask(project, task.id, { scheduledLaunch: null });
+			continue;
+		}
+		if (at > now) continue;
+		try {
+			await fireScheduledLaunch(project, task);
+		} catch (err) {
+			// Clear the field so a permanently-failing launch does not retry every
+			// tick forever; the task itself stays in todo for the user to relaunch.
+			log.error("Scheduled launch fire failed; clearing schedule", { taskId: task.id.slice(0, 8), error: String(err) });
+			try {
+				await data.updateTask(project, task.id, { scheduledLaunch: null });
+			} catch {
+				// task may have been consumed mid-failure; nothing left to clear
+			}
+		}
+	}
+}

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -930,6 +930,17 @@ function App() {
 		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
 	}, [dispatch]);
 
+	// Server-initiated deletion: a scheduled launch firing consumes its source
+	// todo task (the spawned variants arrive as ordinary taskUpdated pushes).
+	useEffect(() => {
+		function onTaskRemoved(e: Event) {
+			const { taskId } = (e as CustomEvent).detail;
+			dispatch({ type: "removeTask", taskId });
+		}
+		window.addEventListener("rpc:taskRemoved", onTaskRemoved);
+		return () => window.removeEventListener("rpc:taskRemoved", onTaskRemoved);
+	}, [dispatch]);
+
 	useEffect(() => {
 		function onProjectUpdated(e: Event) {
 			const { project } = (e as CustomEvent).detail;

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type Dispatch } from "react";
 import type { AgentCheckResult, CodingAgent, GlobalSettings, Project, Task, TaskStatus } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
+import { parseDelay } from "../../shared/duration";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
@@ -124,26 +125,29 @@ function LaunchVariantsModal({
 		);
 	}
 
+	// Apply the (possibly preference-derived) Watch choice to the source task
+	// before spawning/scheduling, so the toggle actually watches/unwatches it —
+	// even when the user never clicked it. Variants inherit `watched` from the
+	// source, so this must run first. Best-effort; never blocks the launch.
+	async function applyWatchPreference() {
+		if (watched === !!task.watched) return;
+		try {
+			const updated = await api.request.toggleTaskWatch({
+				taskId: task.id,
+				projectId: project.id,
+				watched,
+			});
+			dispatch({ type: "updateTask", task: updated });
+		} catch {
+			// Watch is best-effort; never block the launch on it.
+		}
+	}
+
 	async function handleLaunch() {
 		setLaunching(true);
 		setError(null);
 		try {
-			// Apply the (possibly preference-derived) Watch choice to the source
-			// task before spawning, so launching with the toggle on/off actually
-			// watches/unwatches it — even when the user never clicked the toggle.
-			// Variants inherit `watched` from the source, so this must run first.
-			if (watched !== !!task.watched) {
-				try {
-					const updated = await api.request.toggleTaskWatch({
-						taskId: task.id,
-						projectId: project.id,
-						watched,
-					});
-					dispatch({ type: "updateTask", task: updated });
-				} catch {
-					// Watch is best-effort; never block the launch on it.
-				}
-			}
+			await applyWatchPreference();
 			if (mode === "addAttempts") {
 				const result = await api.request.addAttempts({
 					taskId: task.id,
@@ -170,6 +174,35 @@ function LaunchVariantsModal({
 					trackAgentLaunched(agents, variant.agentId, variant.configId);
 				}
 			}
+			onClose();
+		} catch (err) {
+			setError(String(err));
+		}
+		setLaunching(false);
+	}
+
+	// "Start in…" — persist a deferred launch instead of spawning now. The task
+	// stays in To Do with a countdown badge; the bun scheduler fires the exact
+	// variants captured here when the delay elapses.
+	const [scheduleOpen, setScheduleOpen] = useState(false);
+	const [delayText, setDelayText] = useState("1h");
+	const delayMs = parseDelay(delayText);
+
+	async function handleSchedule() {
+		if (!delayMs) return;
+		setLaunching(true);
+		setError(null);
+		try {
+			await applyWatchPreference();
+			const updated = await api.request.scheduleTaskLaunch({
+				taskId: task.id,
+				projectId: project.id,
+				at: new Date(Date.now() + delayMs).toISOString(),
+				targetStatus,
+				variants,
+			});
+			dispatch({ type: "updateTask", task: updated });
+			trackEvent("task_launch_scheduled", { project_id: project.id, variant_count: variants.length, delay_ms: delayMs });
 			onClose();
 		} catch (err) {
 			setError(String(err));
@@ -315,13 +348,65 @@ function LaunchVariantsModal({
 						>
 							{t("kanban.cancel")}
 						</button>
-						<button
-							onClick={handleLaunch}
-							disabled={launching || variants.length === 0}
-							className="bg-accent hover:bg-accent-hover text-white text-sm font-medium px-5 py-2 rounded-xl transition-colors disabled:opacity-50"
-						>
-							{launchLabel}
-						</button>
+						{!isAddVariant && (
+							scheduleOpen ? (
+								<div className="flex items-center gap-2">
+									{["15m", "1h", "3h"].map((preset) => (
+										<button
+											key={preset}
+											onClick={() => setDelayText(preset)}
+											className={`text-xs px-2 py-1 rounded-md border transition-colors ${
+												delayText === preset
+													? "border-accent text-accent"
+													: "border-edge text-fg-3 hover:text-fg"
+											}`}
+										>
+											{preset}
+										</button>
+									))}
+									<input
+										value={delayText}
+										onChange={(e) => setDelayText(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter" && delayMs && !launching) handleSchedule();
+										}}
+										placeholder={t("launch.delayPlaceholder")}
+										className={`w-20 bg-transparent border rounded-md px-2 py-1 text-sm text-fg outline-none focus:border-accent ${
+											delayMs ? "border-edge" : "border-danger"
+										}`}
+									/>
+									<button
+										onClick={handleSchedule}
+										disabled={launching || !delayMs || variants.length === 0}
+										className="bg-accent hover:bg-accent-hover text-white text-sm font-medium px-4 py-2 rounded-xl transition-colors disabled:opacity-50"
+									>
+										{t("launch.schedule")}
+									</button>
+								</div>
+							) : (
+								<button
+									onClick={() => setScheduleOpen(true)}
+									disabled={launching}
+									className="text-fg-3 hover:text-fg text-sm transition-colors px-3 py-1.5 flex items-center gap-1.5"
+									title={t("launch.startInHint")}
+								>
+									<svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+										<circle cx="12" cy="12" r="9" />
+										<path d="M12 7v5l3 2" />
+									</svg>
+									{t("launch.startIn")}
+								</button>
+							)
+						)}
+						{!scheduleOpen && (
+							<button
+								onClick={handleLaunch}
+								disabled={launching || variants.length === 0}
+								className="bg-accent hover:bg-accent-hover text-white text-sm font-medium px-5 py-2 rounded-xl transition-colors disabled:opacity-50"
+							>
+								{launchLabel}
+							</button>
+						)}
 					</div>
 				</div>
 			</div>

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, type Dispatch } from "react";
 import type { AgentCheckResult, CodingAgent, GlobalSettings, Project, Task, TaskStatus } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
-import { parseDelay } from "../../shared/duration";
+import { formatCountdown } from "../../shared/duration";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
@@ -33,6 +33,82 @@ interface LaunchVariantsModalProps {
 	 * (the next modal open then reflects the new default).
 	 */
 	onGlobalSettingsChange?: (settings: GlobalSettings) => void;
+}
+
+/** Format a Date as the `HH:MM` value expected by `<input type="time">`. */
+function toTimeInputValue(d: Date): string {
+	return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * `− [ n ] +` stepper for the "in X" schedule mode. Buttons step by `step`
+ * (minutes wrap around, hours clamp); typing accepts any value in range and
+ * ArrowUp/ArrowDown mirror the buttons.
+ */
+function NumberStepper({
+	label,
+	value,
+	max,
+	step,
+	wrap = false,
+	disabled = false,
+	onChange,
+}: {
+	label: string;
+	value: number;
+	max: number;
+	step: number;
+	wrap?: boolean;
+	disabled?: boolean;
+	onChange: (v: number) => void;
+}) {
+	const bump = (dir: 1 | -1) => {
+		const next = value + dir * step;
+		if (wrap) {
+			const range = max + 1;
+			onChange(((next % range) + range) % range);
+		} else {
+			onChange(Math.min(max, Math.max(0, next)));
+		}
+	};
+	return (
+		<div className="flex items-center gap-2">
+			<span className="text-fg-3 text-xs">{label}</span>
+			<div className="flex items-center gap-1">
+				<button
+					onClick={() => bump(-1)}
+					disabled={disabled}
+					aria-label={`${label} −`}
+					className="w-8 h-8 rounded-lg border border-edge text-fg-3 hover:text-fg hover:border-edge-active transition-colors text-base leading-none disabled:opacity-50"
+				>
+					−
+				</button>
+				<input
+					value={String(value)}
+					disabled={disabled}
+					inputMode="numeric"
+					aria-label={label}
+					onChange={(e) => {
+						const digits = e.target.value.replace(/\D/g, "");
+						onChange(Math.min(max, digits ? Number.parseInt(digits, 10) : 0));
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "ArrowUp") { e.preventDefault(); bump(1); }
+						if (e.key === "ArrowDown") { e.preventDefault(); bump(-1); }
+					}}
+					className="w-12 h-8 bg-transparent border border-edge rounded-lg text-center text-fg text-base outline-none focus:border-accent"
+				/>
+				<button
+					onClick={() => bump(1)}
+					disabled={disabled}
+					aria-label={`${label} +`}
+					className="w-8 h-8 rounded-lg border border-edge text-fg-3 hover:text-fg hover:border-edge-active transition-colors text-base leading-none disabled:opacity-50"
+				>
+					+
+				</button>
+			</div>
+		</div>
+	);
 }
 
 function LaunchVariantsModal({
@@ -183,13 +259,43 @@ function LaunchVariantsModal({
 
 	// "Start in…" — persist a deferred launch instead of spawning now. The task
 	// stays in To Do with a countdown badge; the bun scheduler fires the exact
-	// variants captured here when the delay elapses.
+	// variants captured here when the moment arrives. Two modes:
+	//   "in" — relative delay via hour/minute steppers (e.g. 3h 45m);
+	//   "at" — absolute local wall-clock time; next occurrence (today if still
+	//          ahead, otherwise tomorrow).
 	const [scheduleOpen, setScheduleOpen] = useState(false);
-	const [delayText, setDelayText] = useState("1h");
-	const delayMs = parseDelay(delayText);
+	const [scheduleMode, setScheduleMode] = useState<"in" | "at">("in");
+	const [delayHours, setDelayHours] = useState(1);
+	const [delayMinutes, setDelayMinutes] = useState(0);
+	const [atTime, setAtTime] = useState(() => toTimeInputValue(new Date(Date.now() + 3_600_000)));
+	// Re-render every 30s while the picker is open so the today/tomorrow hint
+	// and countdown stay honest (the actual target is resolved at submit time).
+	const [nowTick, setNowTick] = useState(() => Date.now());
+	useEffect(() => {
+		if (!scheduleOpen) return;
+		setNowTick(Date.now());
+		const timer = setInterval(() => setNowTick(Date.now()), 30_000);
+		return () => clearInterval(timer);
+	}, [scheduleOpen]);
+
+	/** Resolve the picker state to a concrete launch Date (null = invalid/zero). */
+	function resolveScheduleTarget(nowMs: number): Date | null {
+		if (scheduleMode === "in") {
+			const ms = delayHours * 3_600_000 + delayMinutes * 60_000;
+			return ms > 0 ? new Date(nowMs + ms) : null;
+		}
+		const m = /^(\d{1,2}):(\d{2})$/.exec(atTime);
+		if (!m) return null;
+		const d = new Date(nowMs);
+		d.setHours(Number(m[1]), Number(m[2]), 0, 0);
+		if (d.getTime() <= nowMs) d.setDate(d.getDate() + 1); // already passed → tomorrow
+		return d;
+	}
 
 	async function handleSchedule() {
-		if (!delayMs) return;
+		const target = resolveScheduleTarget(Date.now());
+		if (!target) return;
+		const delayMs = target.getTime() - Date.now();
 		setLaunching(true);
 		setError(null);
 		try {
@@ -197,18 +303,35 @@ function LaunchVariantsModal({
 			const updated = await api.request.scheduleTaskLaunch({
 				taskId: task.id,
 				projectId: project.id,
-				at: new Date(Date.now() + delayMs).toISOString(),
+				at: target.toISOString(),
 				targetStatus,
 				variants,
 			});
 			dispatch({ type: "updateTask", task: updated });
-			trackEvent("task_launch_scheduled", { project_id: project.id, variant_count: variants.length, delay_ms: delayMs });
+			trackEvent("task_launch_scheduled", {
+				project_id: project.id,
+				variant_count: variants.length,
+				delay_ms: delayMs,
+				schedule_mode: scheduleMode,
+			});
 			onClose();
 		} catch (err) {
 			setError(String(err));
 		}
 		setLaunching(false);
 	}
+
+	const scheduleTarget = scheduleOpen ? resolveScheduleTarget(nowTick) : null;
+	const scheduleHint = (() => {
+		if (!scheduleOpen) return null;
+		if (!scheduleTarget) return t("launch.scheduleInvalid");
+		const now = new Date(nowTick);
+		const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+		const dayDiff = Math.round((startOfDay(scheduleTarget) - startOfDay(now)) / 86_400_000);
+		const day = dayDiff === 0 ? t("launch.today") : dayDiff === 1 ? t("launch.tomorrow") : scheduleTarget.toLocaleDateString();
+		const time = scheduleTarget.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+		return t("launch.scheduleHint", { day, time, rel: formatCountdown(scheduleTarget.getTime() - nowTick) });
+	})();
 
 	const isAddVariant = mode === "addAttempts";
 	const title = isAddVariant ? t("launch.retryTitle") : t("launch.title");
@@ -327,6 +450,71 @@ function LaunchVariantsModal({
 					</div>
 				)}
 
+				{/* Schedule picker — roomy panel instead of a cramped footer row */}
+				{!isAddVariant && scheduleOpen && (
+					<div className="px-6 py-3 border-t border-edge bg-raised/40">
+						{/* Single compact row: mode switch + inputs, no labels above */}
+						<div className="flex items-center gap-4">
+							<div className="inline-flex h-8 items-center rounded-lg border border-edge p-0.5">
+								{(["in", "at"] as const).map((m) => (
+									<button
+										key={m}
+										onClick={() => setScheduleMode(m)}
+										className={`text-sm px-2.5 py-1 rounded-md transition-colors ${
+											scheduleMode === m
+												? "bg-elevated text-fg font-medium"
+												: "text-fg-3 hover:text-fg"
+										}`}
+									>
+										{m === "in" ? t("launch.modeIn") : t("launch.modeAt")}
+									</button>
+								))}
+							</div>
+
+							{scheduleMode === "in" ? (
+								<div className="flex items-center gap-4">
+									<NumberStepper
+										label={t("launch.hours")}
+										value={delayHours}
+										max={99}
+										step={1}
+										disabled={launching}
+										onChange={setDelayHours}
+									/>
+									<NumberStepper
+										label={t("launch.minutes")}
+										value={delayMinutes}
+										max={59}
+										step={5}
+										wrap
+										disabled={launching}
+										onChange={setDelayMinutes}
+									/>
+								</div>
+							) : (
+								<input
+									type="time"
+									value={atTime}
+									disabled={launching}
+									aria-label={t("launch.atTimeLabel")}
+									onChange={(e) => setAtTime(e.target.value)}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && scheduleTarget && !launching) handleSchedule();
+									}}
+									className="bg-transparent border border-edge rounded-lg px-2.5 h-8 text-fg text-base outline-none focus:border-accent"
+								/>
+							)}
+						</div>
+
+						<p className={`text-sm mt-2 ${scheduleTarget ? "text-fg-3" : "text-danger"}`}>
+							{scheduleHint}
+							{scheduleMode === "at" && scheduleTarget && (
+								<span className="text-fg-3"> · {t("launch.atTimeLabel").toLowerCase()}</span>
+							)}
+						</p>
+					</div>
+				)}
+
 				{/* Footer */}
 				<div className="px-6 py-4 border-t border-edge flex items-center justify-between">
 					{isVirtual ? (
@@ -349,56 +537,32 @@ function LaunchVariantsModal({
 							{t("kanban.cancel")}
 						</button>
 						{!isAddVariant && (
-							scheduleOpen ? (
-								<div className="flex items-center gap-2">
-									{["15m", "1h", "3h"].map((preset) => (
-										<button
-											key={preset}
-											onClick={() => setDelayText(preset)}
-											className={`text-xs px-2 py-1 rounded-md border transition-colors ${
-												delayText === preset
-													? "border-accent text-accent"
-													: "border-edge text-fg-3 hover:text-fg"
-											}`}
-										>
-											{preset}
-										</button>
-									))}
-									<input
-										value={delayText}
-										onChange={(e) => setDelayText(e.target.value)}
-										onKeyDown={(e) => {
-											if (e.key === "Enter" && delayMs && !launching) handleSchedule();
-										}}
-										placeholder={t("launch.delayPlaceholder")}
-										className={`w-20 bg-transparent border rounded-md px-2 py-1 text-sm text-fg outline-none focus:border-accent ${
-											delayMs ? "border-edge" : "border-danger"
-										}`}
-									/>
-									<button
-										onClick={handleSchedule}
-										disabled={launching || !delayMs || variants.length === 0}
-										className="bg-accent hover:bg-accent-hover text-white text-sm font-medium px-4 py-2 rounded-xl transition-colors disabled:opacity-50"
-									>
-										{t("launch.schedule")}
-									</button>
-								</div>
-							) : (
-								<button
-									onClick={() => setScheduleOpen(true)}
-									disabled={launching}
-									className="text-fg-3 hover:text-fg text-sm transition-colors px-3 py-1.5 flex items-center gap-1.5"
-									title={t("launch.startInHint")}
-								>
-									<svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-										<circle cx="12" cy="12" r="9" />
-										<path d="M12 7v5l3 2" />
-									</svg>
-									{t("launch.startIn")}
-								</button>
-							)
+							<button
+								onClick={() => setScheduleOpen((v) => !v)}
+								disabled={launching}
+								className={`text-sm transition-colors px-3 py-1.5 rounded-lg flex items-center gap-1.5 border ${
+									scheduleOpen
+										? "text-accent border-accent/40 bg-accent/10"
+										: "text-fg-3 hover:text-fg border-transparent"
+								}`}
+								title={t("launch.startInHint")}
+							>
+								<svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+									<circle cx="12" cy="12" r="9" />
+									<path d="M12 7v5l3 2" />
+								</svg>
+								{t("launch.startIn")}
+							</button>
 						)}
-						{!scheduleOpen && (
+						{scheduleOpen ? (
+							<button
+								onClick={handleSchedule}
+								disabled={launching || !scheduleTarget || variants.length === 0}
+								className="bg-accent hover:bg-accent-hover text-white text-sm font-medium px-5 py-2 rounded-xl transition-colors disabled:opacity-50"
+							>
+								{t("launch.schedule")}
+							</button>
+						) : (
 							<button
 								onClick={handleLaunch}
 								disabled={launching || variants.length === 0}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -9,6 +9,7 @@ import { confirm } from "../confirm";
 import { useT } from "../i18n";
 import type { TranslationKey } from "../i18n";
 import { formatBytes } from "../utils/formatBytes";
+import { formatCountdown } from "../../shared/duration";
 import { getStatusLabel } from "../utils/statusLabel";
 import { trackEvent, agentNameFromId } from "../analytics";
 import { useStatusColors } from "../hooks/useStatusColors";
@@ -92,6 +93,41 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const isActive = ACTIVE_STATUSES.includes(task.status);
 	const isCompleting = (moving || isMovingProp) && (task.status === "completed" || task.status === "cancelled");
 	const color = statusColors[task.status];
+
+	// Deferred launch ("Start in…") — countdown badge with Start now / Cancel.
+	// Only meaningful on todo cards; the field vanishes when the launch fires.
+	const sched = isTodo ? task.scheduledLaunch : null;
+	const [schedPopoverOpen, setSchedPopoverOpen] = useState(false);
+	const [, setSchedTick] = useState(0);
+	useEffect(() => {
+		if (!sched) return;
+		// Re-render every 30s so the countdown stays fresh without a per-second tick.
+		const id = setInterval(() => setSchedTick((n) => n + 1), 30_000);
+		return () => clearInterval(id);
+	}, [sched?.at]);
+
+	async function handleCancelSchedule(e: React.MouseEvent) {
+		e.stopPropagation();
+		setSchedPopoverOpen(false);
+		try {
+			const updated = await api.request.cancelScheduledLaunch({ taskId: task.id, projectId: project.id });
+			dispatch({ type: "updateTask", task: updated });
+		} catch (err) {
+			toast.error(t("task.scheduleCancelFailed", { error: String(err) }));
+		}
+	}
+
+	async function handleStartScheduledNow(e: React.MouseEvent) {
+		e.stopPropagation();
+		setSchedPopoverOpen(false);
+		try {
+			// Spawned/updated tasks arrive via the taskUpdated push broadcast;
+			// no local dispatch needed beyond kicking off the RPC.
+			await api.request.startScheduledLaunchNow({ taskId: task.id, projectId: project.id });
+		} catch (err) {
+			toast.error(t("launch.failedLaunch", { error: String(err) }));
+		}
+	}
 
 	// Close menu on click outside
 	useEffect(() => {
@@ -768,6 +804,44 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 						</button>
 					);
 				})()}
+
+				{/* Deferred-launch countdown badge (todo cards with a pending "Start in…") */}
+				{sched && (
+					<div className="relative flex-shrink-0">
+						<Tooltip content={t("task.scheduledTooltip")}>
+							<button
+								data-testid="task-card-scheduled-badge"
+								onClick={(e) => { e.stopPropagation(); setSchedPopoverOpen(!schedPopoverOpen); }}
+								className="flex items-center gap-1 rounded-lg px-1.5 py-1 text-xs text-accent transition-colors hover:bg-fg/5"
+							>
+								<svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+									<circle cx="12" cy="12" r="9" />
+									<path d="M12 7v5l3 2" />
+								</svg>
+								{formatCountdown(new Date(sched.at).getTime() - Date.now())}
+							</button>
+						</Tooltip>
+						{schedPopoverOpen && (
+							<div
+								className="absolute bottom-full left-0 mb-1 z-30 min-w-[10rem] rounded-lg border border-edge bg-elevated shadow-lg py-1"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<button
+									onClick={handleStartScheduledNow}
+									className="w-full text-left px-3 py-1.5 text-xs text-fg hover:bg-fg/5 transition-colors"
+								>
+									{t("task.startNow")}
+								</button>
+								<button
+									onClick={handleCancelSchedule}
+									className="w-full text-left px-3 py-1.5 text-xs text-danger hover:bg-fg/5 transition-colors"
+								>
+									{t("task.cancelSchedule")}
+								</button>
+							</div>
+						)}
+					</div>
+				)}
 
 				{/* PR + CI/review badges for non-active cards */}
 				{!isActive && prBadge}

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -121,6 +121,10 @@ const kanban = {
 	"launch.launchVariant": "Launch",
 	"launch.launching": "Launching...",
 	"launch.failedLaunch": "Failed to launch: {error}",
+	"launch.startIn": "Start in…",
+	"launch.startInHint": "Schedule this launch for later",
+	"launch.schedule": "Schedule",
+	"launch.delayPlaceholder": "e.g. 1h30m",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Spawn Agent",
@@ -133,6 +137,10 @@ const kanban = {
 	"task.watch": "Watch",
 	"task.watching": "Watching",
 	"task.watchTooltip": "Watch — notify on status changes",
+	"task.scheduledTooltip": "Scheduled launch — click for options",
+	"task.startNow": "Start now",
+	"task.cancelSchedule": "Cancel schedule",
+	"task.scheduleCancelFailed": "Failed to cancel schedule: {error}",
 	"task.unwatchTooltip": "Unwatch — stop notifications",
 
 	// Pipeline

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -124,7 +124,15 @@ const kanban = {
 	"launch.startIn": "Start in…",
 	"launch.startInHint": "Schedule this launch for later",
 	"launch.schedule": "Schedule",
-	"launch.delayPlaceholder": "e.g. 1h30m",
+	"launch.modeIn": "In…",
+	"launch.modeAt": "At time",
+	"launch.hours": "Hours",
+	"launch.minutes": "Minutes",
+	"launch.atTimeLabel": "Local time",
+	"launch.today": "today",
+	"launch.tomorrow": "tomorrow",
+	"launch.scheduleHint": "Will launch {day} at {time} — in {rel}",
+	"launch.scheduleInvalid": "Pick a delay or time first",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Spawn Agent",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -121,6 +121,10 @@ const kanban = {
 	"launch.launchVariant": "Lanzar",
 	"launch.launching": "Lanzando...",
 	"launch.failedLaunch": "Error al lanzar: {error}",
+	"launch.startIn": "Iniciar en…",
+	"launch.startInHint": "Programar este lanzamiento para más tarde",
+	"launch.schedule": "Programar",
+	"launch.delayPlaceholder": "ej. 1h30m",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Lanzar agente",
@@ -133,6 +137,10 @@ const kanban = {
 	"task.watch": "Vigilar",
 	"task.watching": "Vigilando",
 	"task.watchTooltip": "Vigilar — notificar al cambiar estado",
+	"task.scheduledTooltip": "Lanzamiento programado — clic para opciones",
+	"task.startNow": "Iniciar ahora",
+	"task.cancelSchedule": "Cancelar programación",
+	"task.scheduleCancelFailed": "Error al cancelar la programación: {error}",
 	"task.unwatchTooltip": "Dejar de vigilar — detener notificaciones",
 
 	// Pipeline

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -124,7 +124,15 @@ const kanban = {
 	"launch.startIn": "Iniciar en…",
 	"launch.startInHint": "Programar este lanzamiento para más tarde",
 	"launch.schedule": "Programar",
-	"launch.delayPlaceholder": "ej. 1h30m",
+	"launch.modeIn": "En…",
+	"launch.modeAt": "A la hora",
+	"launch.hours": "Horas",
+	"launch.minutes": "Minutos",
+	"launch.atTimeLabel": "Hora local",
+	"launch.today": "hoy",
+	"launch.tomorrow": "mañana",
+	"launch.scheduleHint": "Se lanzará {day} a las {time} — en {rel}",
+	"launch.scheduleInvalid": "Elige primero un retraso o una hora",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Lanzar agente",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -123,6 +123,10 @@ const kanban = {
 	"launch.launchVariant": "Запустить",
 	"launch.launching": "Запускается...",
 	"launch.failedLaunch": "Не удалось запустить: {error}",
+	"launch.startIn": "Запустить через…",
+	"launch.startInHint": "Отложить запуск на потом",
+	"launch.schedule": "Запланировать",
+	"launch.delayPlaceholder": "напр. 1h30m",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Запустить агента",
@@ -135,6 +139,10 @@ const kanban = {
 	"task.watch": "Следить",
 	"task.watching": "Слежу",
 	"task.watchTooltip": "Следить — уведомлять при смене статуса",
+	"task.scheduledTooltip": "Отложенный запуск — нажмите для опций",
+	"task.startNow": "Запустить сейчас",
+	"task.cancelSchedule": "Отменить запуск",
+	"task.scheduleCancelFailed": "Не удалось отменить запуск: {error}",
 	"task.unwatchTooltip": "Не следить — отключить уведомления",
 
 	// Pipeline

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -126,7 +126,15 @@ const kanban = {
 	"launch.startIn": "Запустить через…",
 	"launch.startInHint": "Отложить запуск на потом",
 	"launch.schedule": "Запланировать",
-	"launch.delayPlaceholder": "напр. 1h30m",
+	"launch.modeIn": "Через…",
+	"launch.modeAt": "Ко времени",
+	"launch.hours": "Часы",
+	"launch.minutes": "Минуты",
+	"launch.atTimeLabel": "Локальное время",
+	"launch.today": "сегодня",
+	"launch.tomorrow": "завтра",
+	"launch.scheduleHint": "Запустится {day} в {time} — через {rel}",
+	"launch.scheduleInvalid": "Укажите задержку или время",
 
 	// SpawnAgentModal
 	"spawnAgent.title": "Запустить агента",

--- a/src/shared/duration.ts
+++ b/src/shared/duration.ts
@@ -1,0 +1,51 @@
+/**
+ * Human-friendly delay parsing/formatting for the "Start in…" deferred-launch
+ * UI (Launch modal → schedule picker; task-card countdown badge).
+ * Shared so the mainview and any future CLI surface agree on the grammar.
+ */
+
+const UNIT_MS: Record<string, number> = {
+	m: 60_000,
+	h: 3_600_000,
+	d: 86_400_000,
+};
+
+/**
+ * Parse a delay like `45m`, `2h`, `1h30m`, `1d2h` into milliseconds.
+ * A bare number means minutes (`90` → 90 min). Whitespace is ignored.
+ * Returns null for anything unparseable or non-positive.
+ */
+export function parseDelay(input: string): number | null {
+	const s = input.trim().toLowerCase().replace(/\s+/g, "");
+	if (!s) return null;
+	// Bare number → minutes
+	if (/^\d+$/.test(s)) {
+		const min = Number.parseInt(s, 10);
+		return min > 0 ? min * UNIT_MS.m : null;
+	}
+	// Sequence of <number><unit> segments, each unit at most once (m/h/d)
+	if (!/^(\d+[mhd])+$/.test(s)) return null;
+	let total = 0;
+	const seen = new Set<string>();
+	for (const match of s.matchAll(/(\d+)([mhd])/g)) {
+		const unit = match[2];
+		if (seen.has(unit)) return null;
+		seen.add(unit);
+		total += Number.parseInt(match[1], 10) * UNIT_MS[unit];
+	}
+	return total > 0 ? total : null;
+}
+
+/**
+ * Compact countdown for the task-card badge: `2d 3h`, `1h 05m`, `12m`, `<1m`.
+ * Clamps at zero (a due-but-not-yet-fired launch shows `<1m`, never negative).
+ */
+export function formatCountdown(ms: number): string {
+	if (ms < UNIT_MS.m) return "<1m";
+	const d = Math.floor(ms / UNIT_MS.d);
+	const h = Math.floor((ms % UNIT_MS.d) / UNIT_MS.h);
+	const m = Math.floor((ms % UNIT_MS.h) / UNIT_MS.m);
+	if (d > 0) return h > 0 ? `${d}d ${h}h` : `${d}d`;
+	if (h > 0) return m > 0 ? `${h}h ${String(m).padStart(2, "0")}m` : `${h}h`;
+	return `${m}m`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -961,6 +961,25 @@ export interface Task {
 	 * links the task back to its automation's run history.
 	 */
 	automationId?: string | null;
+	/**
+	 * Deferred launch ("Start in…"). Set from the Launch modal when the user
+	 * schedules the spawn instead of firing it immediately. Only meaningful on
+	 * a `todo` task; the bun scheduled-launch scheduler fires the stored
+	 * variants when `at` passes (late fires catch up after app restart) and
+	 * the field disappears together with the consumed source task. Cancelled
+	 * by setting it back to null.
+	 */
+	scheduledLaunch?: ScheduledLaunch | null;
+}
+
+/** A one-shot deferred launch persisted on a `todo` task. See {@link Task.scheduledLaunch}. */
+export interface ScheduledLaunch {
+	/** ISO timestamp when the launch should fire. */
+	at: string;
+	/** Column the spawned variants land in (same as an immediate launch). */
+	targetStatus: TaskStatus;
+	/** Agent/config variants captured from the Launch modal at schedule time. */
+	variants: Array<{ agentId: string | null; configId: string | null }>;
 }
 
 /** Per-task cap on retained shared images; oldest are pruned (files deleted) past this. */
@@ -2209,6 +2228,28 @@ export type AppRPCSchema = {
 				params: { taskId: string; projectId: string; watched: boolean };
 				response: Task;
 			};
+			/** Persist a deferred launch on a todo task ("Start in…"). */
+			scheduleTaskLaunch: {
+				params: {
+					taskId: string;
+					projectId: string;
+					/** ISO timestamp; must be in the future. */
+					at: string;
+					targetStatus: TaskStatus;
+					variants: Array<{ agentId: string | null; configId: string | null }>;
+				};
+				response: Task;
+			};
+			/** Clear a pending deferred launch without firing it. */
+			cancelScheduledLaunch: {
+				params: { taskId: string; projectId: string };
+				response: Task;
+			};
+			/** Fire a pending deferred launch immediately (badge → "Start now"). */
+			startScheduledLaunchNow: {
+				params: { taskId: string; projectId: string };
+				response: Task[];
+			};
 			addTaskNote: {
 				params: { taskId: string; projectId: string; content: string; source?: NoteSource };
 				response: Task;
@@ -2487,6 +2528,13 @@ export type AppRPCSchema = {
 		};
 		messages: {
 			taskUpdated: { projectId: string; task: Task };
+			/**
+			 * Server-initiated task deletion (currently: a scheduled launch firing
+			 * consumes its source todo task, exactly like spawnVariants does for an
+			 * immediate launch). Client-initiated deletes don't need this — the
+			 * caller updates its own state from the RPC response.
+			 */
+			taskRemoved: { projectId: string; taskId: string };
 			projectUpdated: { project: Project };
 			taskSound: { status: "completed" | "cancelled"; taskId: string };
 			ptyDied: { taskId: string };


### PR DESCRIPTION
## Summary
- Adds a **Start in…** option to the Launch Task modal: schedule a task launch instead of running it immediately
- Two scheduling modes: **In…** (relative delay via hours/minutes steppers) and **At time** (absolute local time, rolls over to tomorrow when the time has already passed today)
- Live forecast hint under the picker, e.g. "Will launch tomorrow at 03:00 AM — in 16h 26m · local time"
- Scheduled tasks show a live **countdown badge** on the task card, with cancel support
- Backend: scheduler tick pipeline with catch-up for missed occurrences (`MISSED_GRACE_MS`), idempotent launch on restart, persisted schedule state
- Compact one-row picker layout after a UX iteration (inline labels, mode switch + steppers + forecast on a single row)
- i18n for en/es/ru

## Testing
- `bun vitest` — scheduler tick pipeline, duration parsing/formatting, scheduled-launch lifecycle tests pass
- Typecheck clean
- Verified end-to-end via Playwright screenshots against the live dev server (modal, both picker modes, countdown badge on card, cancel flow)