### PR TITLE
Tolerate broken stdout pipe in the dev3 CLI (EPIPE guard)

### DIFF
--- a/change-logs/2026/07/07/fix-cli-epipe-broken-pipe.md
+++ b/change-logs/2026/07/07/fix-cli-epipe-broken-pipe.md
@@ -1,0 +1,1 @@
+Fixed the dev3 CLI dumping a raw "EPIPE: broken pipe" stack trace when its output was piped into a consumer that closes early (`dev3 ui state | head`, `| grep -m1`, quitting a pager). The CLI now tolerates a broken stdout/stderr pipe and exits cleanly, so piping through head/grep no longer pollutes otherwise-clean tool output.

--- a/decisions/113-cli-epipe-broken-pipe-guard.md
+++ b/decisions/113-cli-epipe-broken-pipe-guard.md
@@ -22,10 +22,13 @@ production signal.
 
 Added `src/cli/epipe.ts`: `isEpipeError()` + `installEpipeGuard()`. The guard registers
 `process.stdout`/`process.stderr` `'error'` listeners and an `uncaughtException` handler that
-`process.exit(0)` on EPIPE and rethrow everything else (preserving normal fatal handling).
+`process.exit(0)` on EPIPE; any other error is printed and exits with
+`CLI_EXIT_CODE_INTERNAL_ERROR` (4). Rethrowing from the `uncaughtException` listener was
+rejected: Bun then terminates with exit code 7, which collides with
+`CLI_EXIT_CODE_DOCTOR_PROBLEMS` in the documented exit-code contract.
 `src/cli/main.ts` installs it at the top of `main()` for every command **except** `remote`
-and `gui` (long-running; they register their own log-and-continue crash handlers, which a
-rethrowing listener would defeat), and `main().catch` also exits 0 on an EPIPE rejection.
+and `gui` (long-running; they register their own log-and-continue crash handlers, which an
+exiting listener would defeat), and `main().catch` also exits 0 on an EPIPE rejection.
 
 The guard matches **only** `code === "EPIPE"`, deliberately not `ECONNRESET`/`ENOTCONN`:
 those can also come from the app Unix-socket client, and swallowing them globally would mask

--- a/decisions/113-cli-epipe-broken-pipe-guard.md
+++ b/decisions/113-cli-epipe-broken-pipe-guard.md
@@ -1,0 +1,46 @@
+# 113 — Tolerate a broken stdout pipe in the dev3 CLI (EPIPE guard)
+
+## Context
+
+Piping CLI output into a consumer that closes the read end early — `dev3 ui state | head`,
+`| grep -m1`, quitting a pager mid-output — made the CLI print a raw
+`EPIPE: broken pipe, write` stack trace and exit non-zero. Piping through head/grep is an
+extremely common agent pattern, so the trace polluted otherwise-clean tool output and read
+like a real failure. Reported twice (2026-07-04, 2026-07-05).
+
+## Investigation
+
+Bun throws a **synchronous** EPIPE from `process.stdout.write` once the read end is gone.
+Because stdout is flushed on a later tick, the throw escapes the awaited handler chain and
+lands in `process.on("uncaughtException")` — not in `main().catch` (verified: a heavy-write
+loop piped to `head` surfaced via `uncaughtException`, not the promise rejection). A real
+shell pipe always yields code `EPIPE`; Node's macOS socketpair-based `stdio: "pipe"` can
+instead surface `ENOTCONN` under load, but that is a test-harness artifact, not the
+production signal.
+
+## Decision
+
+Added `src/cli/epipe.ts`: `isEpipeError()` + `installEpipeGuard()`. The guard registers
+`process.stdout`/`process.stderr` `'error'` listeners and an `uncaughtException` handler that
+`process.exit(0)` on EPIPE and rethrow everything else (preserving normal fatal handling).
+`src/cli/main.ts` installs it at the top of `main()` for every command **except** `remote`
+and `gui` (long-running; they register their own log-and-continue crash handlers, which a
+rethrowing listener would defeat), and `main().catch` also exits 0 on an EPIPE rejection.
+
+The guard matches **only** `code === "EPIPE"`, deliberately not `ECONNRESET`/`ENOTCONN`:
+those can also come from the app Unix-socket client, and swallowing them globally would mask
+a genuine socket failure as success.
+
+## Risks
+
+- Exit 0 (not 141/SIGPIPE) on a broken pipe — chosen for clean agent tooling; the consumer
+  asked us to stop, so success is correct.
+- The `uncaughtException` handler is process-wide; scoped away from `remote`/`gui` to avoid
+  clobbering the headless server's own handlers.
+
+## Alternatives considered
+
+- **Wrap every `process.stdout.write` call site** in a helper — rejected: invasive across all
+  command files; the ask was an explicitly central fix.
+- **Broaden the guard to the whole broken-pipe family** (ECONNRESET/ENOTCONN) — rejected: risks
+  masking real app-socket errors. Kept strict to the production EPIPE signal.

--- a/src/cli/__tests__/epipe.test.ts
+++ b/src/cli/__tests__/epipe.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { CLI_EXIT_CODE_INTERNAL_ERROR } from "../../shared/cli-exit-codes";
 import { isEpipeError } from "../epipe";
 
 const FIXTURE = resolve(import.meta.dirname, "fixtures/epipe-writer.ts");
@@ -59,5 +60,15 @@ describe("broken-pipe guard (subprocess)", () => {
 		const { code, stderr } = runBrokenPipe(true);
 		expect(code).toBe(0);
 		expect(stderr).toBe("");
+	}, 20_000);
+
+	// A guarded process must NOT swallow non-EPIPE crashes as success, and must
+	// exit with the documented internal-error code (4) — rethrowing from the
+	// uncaughtException listener would make Bun exit 7, colliding with
+	// CLI_EXIT_CODE_DOCTOR_PROBLEMS.
+	it("prints non-EPIPE uncaught exceptions and exits with the internal-error code", () => {
+		const res = spawnSync(BUN, [FIXTURE, "--guard", "--boom"], { encoding: "utf8" });
+		expect(res.stderr).toContain("boom-not-epipe");
+		expect(res.status).toBe(CLI_EXIT_CODE_INTERNAL_ERROR);
 	}, 20_000);
 });

--- a/src/cli/__tests__/epipe.test.ts
+++ b/src/cli/__tests__/epipe.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { isEpipeError } from "../epipe";
+
+const FIXTURE = resolve(import.meta.dirname, "fixtures/epipe-writer.ts");
+// vitest runs this suite under node, but the fixture is TS importing project
+// source — run it with bun (the project runtime; on PATH via setup-bun in CI).
+const BUN = /(?:^|\/)bun$/.test(process.execPath) ? process.execPath : "bun";
+
+/**
+ * Run the writer fixture through a real shell pipe into `head -c`, which reads a
+ * little then closes its read end — exactly `dev3 … | head`. The writer's next
+ * write to the now-broken pipe hits EPIPE. We capture the WRITER's exit code
+ * (PIPESTATUS[0], not head's) and its stderr, so we can tell a clean exit from a
+ * raw broken-pipe crash.
+ */
+function runBrokenPipe(guard: boolean): { code: number; stderr: string } {
+	const dir = mkdtempSync(join(tmpdir(), "dev3-epipe-"));
+	const errFile = join(dir, "stderr.txt");
+	try {
+		const cmd =
+			`${JSON.stringify(BUN)} ${JSON.stringify(FIXTURE)}${guard ? " --guard" : ""} ` +
+			`2>${JSON.stringify(errFile)} | head -c 200 >/dev/null; echo \${PIPESTATUS[0]}`;
+		const res = spawnSync("bash", ["-c", cmd], { encoding: "utf8" });
+		return { code: Number(res.stdout.trim()), stderr: readFileSync(errFile, "utf8") };
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("isEpipeError", () => {
+	it("recognizes an EPIPE-coded error", () => {
+		expect(isEpipeError(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }))).toBe(true);
+		expect(isEpipeError({ code: "EPIPE" })).toBe(true);
+	});
+
+	it("rejects non-EPIPE and non-object values", () => {
+		expect(isEpipeError(Object.assign(new Error("nope"), { code: "ECONNRESET" }))).toBe(false);
+		expect(isEpipeError(new Error("plain"))).toBe(false);
+		expect(isEpipeError(null)).toBe(false);
+		expect(isEpipeError(undefined)).toBe(false);
+		expect(isEpipeError("EPIPE")).toBe(false);
+	});
+});
+
+describe("broken-pipe guard (subprocess)", () => {
+	// The control run proves the pipeline actually triggers a broken pipe — so a
+	// green guarded run below means "handled", not "EPIPE never happened".
+	it("crashes with a raw EPIPE trace WITHOUT the guard (control)", () => {
+		const { code, stderr } = runBrokenPipe(false);
+		expect(stderr).toContain("EPIPE");
+		expect(code).not.toBe(0);
+	}, 20_000);
+
+	it("exits 0 silently WITH the guard", () => {
+		const { code, stderr } = runBrokenPipe(true);
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+	}, 20_000);
+});

--- a/src/cli/__tests__/fixtures/epipe-writer.ts
+++ b/src/cli/__tests__/fixtures/epipe-writer.ts
@@ -4,7 +4,10 @@
  * Writes far more to stdout than a pipe buffer can hold, so once the reader
  * closes its end a subsequent write hits EPIPE. Pass `--guard` to install the
  * CLI's EPIPE guard first (expected: clean exit 0, no stack trace); omit it to
- * observe Bun's raw broken-pipe crash (the control case).
+ * observe Bun's raw broken-pipe crash (the control case). Pass `--boom` (with
+ * `--guard`) to throw a non-EPIPE uncaught exception instead of writing —
+ * expected: the error is printed and the process exits with the internal-error
+ * code, NOT swallowed as success.
  */
 import { installEpipeGuard } from "../../epipe";
 
@@ -12,9 +15,21 @@ if (process.argv.includes("--guard")) {
 	installEpipeGuard();
 }
 
-const line = `${"x".repeat(120)}\n`;
-// ~36 MB total — far past any pipe buffer, so a flush after the reader closes
-// is guaranteed to hit EPIPE, while staying small enough to run fast.
-for (let i = 0; i < 300_000; i++) {
-	process.stdout.write(line);
+if (process.argv.includes("--boom")) {
+	setTimeout(() => {
+		throw new Error("boom-not-epipe");
+	}, 0);
+	// Skip the pipe-flooding writes; this run only exercises the crash path.
+	process.stdout.write("boom fixture running\n");
+} else {
+	floodStdout();
+}
+
+function floodStdout(): void {
+	const line = `${"x".repeat(120)}\n`;
+	// ~36 MB total — far past any pipe buffer, so a flush after the reader closes
+	// is guaranteed to hit EPIPE, while staying small enough to run fast.
+	for (let i = 0; i < 300_000; i++) {
+		process.stdout.write(line);
+	}
 }

--- a/src/cli/__tests__/fixtures/epipe-writer.ts
+++ b/src/cli/__tests__/fixtures/epipe-writer.ts
@@ -1,0 +1,20 @@
+/**
+ * Test fixture for the broken-pipe guard (see ../epipe.test.ts).
+ *
+ * Writes far more to stdout than a pipe buffer can hold, so once the reader
+ * closes its end a subsequent write hits EPIPE. Pass `--guard` to install the
+ * CLI's EPIPE guard first (expected: clean exit 0, no stack trace); omit it to
+ * observe Bun's raw broken-pipe crash (the control case).
+ */
+import { installEpipeGuard } from "../../epipe";
+
+if (process.argv.includes("--guard")) {
+	installEpipeGuard();
+}
+
+const line = `${"x".repeat(120)}\n`;
+// ~36 MB total — far past any pipe buffer, so a flush after the reader closes
+// is guaranteed to hit EPIPE, while staying small enough to run fast.
+for (let i = 0; i < 300_000; i++) {
+	process.stdout.write(line);
+}

--- a/src/cli/epipe.ts
+++ b/src/cli/epipe.ts
@@ -1,0 +1,43 @@
+import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
+
+/**
+ * True when `err` is a broken-pipe (EPIPE) error, however it surfaced — a thrown
+ * Error with `.code === "EPIPE"`, or a raw stream 'error' payload.
+ */
+export function isEpipeError(err: unknown): boolean {
+	return err != null && typeof err === "object" && (err as { code?: unknown }).code === "EPIPE";
+}
+
+/**
+ * Make the CLI tolerate its stdout/stderr consumer closing the pipe early —
+ * `dev3 … | head`, `| grep -m1`, quitting a pager mid-output. Bun throws a
+ * SYNCHRONOUS EPIPE from process.stdout.write once the read end is gone; because
+ * stdout is flushed on a later tick the throw escapes the awaited call chain and
+ * lands in `uncaughtException`, where Bun prints a raw "EPIPE: broken pipe"
+ * stack trace and exits non-zero. Piping CLI output through head/grep is an
+ * extremely common agent pattern, so that noise reads like a real failure in
+ * otherwise-clean tool output (reported twice: 2026-07-04 and 2026-07-05).
+ *
+ * We swallow EPIPE wherever it can appear and exit 0 silently — the consumer
+ * asked us to stop, so a clean exit is correct. Every other error keeps its
+ * existing behavior (rethrown → the normal crash / fatal handling path).
+ *
+ * NOT installed for `dev3 remote` / `dev3 gui`: those are long-running and
+ * register their own crash handlers that log-and-continue, so an extra
+ * rethrowing uncaughtException listener would defeat that (see main.ts).
+ */
+export function installEpipeGuard(): void {
+	const swallowEpipe = (err: unknown): void => {
+		if (isEpipeError(err)) {
+			// The reader is gone; abandon the rest of the output and exit cleanly.
+			process.exit(CLI_EXIT_CODE_SUCCESS);
+		}
+		// Preserve default behavior for anything that is not a broken pipe.
+		throw err;
+	};
+	// Async 'error' events (a buffered flush fails after the reader closed).
+	process.stdout.on("error", swallowEpipe);
+	process.stderr.on("error", swallowEpipe);
+	// Bun's synchronous write throw escapes the awaited chain and lands here.
+	process.on("uncaughtException", swallowEpipe);
+}

--- a/src/cli/epipe.ts
+++ b/src/cli/epipe.ts
@@ -1,4 +1,4 @@
-import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
+import { CLI_EXIT_CODE_INTERNAL_ERROR, CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
 
 /**
  * True when `err` is a broken-pipe (EPIPE) error, however it surfaced — a thrown
@@ -19,12 +19,14 @@ export function isEpipeError(err: unknown): boolean {
  * otherwise-clean tool output (reported twice: 2026-07-04 and 2026-07-05).
  *
  * We swallow EPIPE wherever it can appear and exit 0 silently — the consumer
- * asked us to stop, so a clean exit is correct. Every other error keeps its
- * existing behavior (rethrown → the normal crash / fatal handling path).
+ * asked us to stop, so a clean exit is correct. Every other error is printed
+ * and exits with the documented internal-error code. (Rethrowing from an
+ * uncaughtException listener is NOT an option: Bun then exits with code 7,
+ * which collides with CLI_EXIT_CODE_DOCTOR_PROBLEMS in the exit-code contract.)
  *
  * NOT installed for `dev3 remote` / `dev3 gui`: those are long-running and
  * register their own crash handlers that log-and-continue, so an extra
- * rethrowing uncaughtException listener would defeat that (see main.ts).
+ * exiting uncaughtException listener would defeat that (see main.ts).
  */
 export function installEpipeGuard(): void {
 	const swallowEpipe = (err: unknown): void => {
@@ -32,8 +34,10 @@ export function installEpipeGuard(): void {
 			// The reader is gone; abandon the rest of the output and exit cleanly.
 			process.exit(CLI_EXIT_CODE_SUCCESS);
 		}
-		// Preserve default behavior for anything that is not a broken pipe.
-		throw err;
+		// Anything that is not a broken pipe is a genuine crash: surface it and
+		// exit with the documented internal-error code.
+		console.error(err);
+		process.exit(CLI_EXIT_CODE_INTERNAL_ERROR);
 	};
 	// Async 'error' events (a buffered flush fails after the reader closed).
 	process.stdout.on("error", swallowEpipe);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -23,6 +23,7 @@ import { handleStatusLine } from "./commands/statusline";
 import { handleDoctor } from "./commands/doctor";
 import { BUILD_TIME, BUILD_COMMIT, BUILD_VERSION } from "../shared/build-info.generated";
 import { CLI_EXIT_CODE_SUCCESS } from "../shared/cli-exit-codes";
+import { installEpipeGuard, isEpipeError } from "./epipe";
 import { resolveHelp } from "./help";
 
 const HELP = `dev3 — AI-facing CLI for the dev-3.0 Kanban board.
@@ -95,6 +96,15 @@ or "dev3 <command> <subcommand> --help" (e.g. "dev3 task create --help") for a s
 
 async function main(): Promise<void> {
 	const rawArgs = process.argv.slice(2);
+
+	// Every short print-and-exit command may have its stdout closed early by a
+	// downstream consumer (`dev3 … | head`, `| grep -m1`, quitting a pager).
+	// Install the broken-pipe guard so that turns into a clean exit instead of a
+	// raw Bun EPIPE stack trace. `remote`/`gui` are long-running and install
+	// their own crash handlers, so we leave them untouched.
+	if (rawArgs[0] !== "remote" && rawArgs[0] !== "gui") {
+		installEpipeGuard();
+	}
 
 	// `--help` routing (pure decision in help.ts so it stays unit-testable):
 	// a known command/subcommand gets focused help from the declarative registry,
@@ -239,5 +249,8 @@ function debugAppNotRunning(
 }
 
 main().catch((err) => {
+	// A broken pipe that surfaced as a promise rejection (rather than the
+	// uncaughtException the guard already handles) is still a clean stop.
+	if (isEpipeError(err)) process.exit(CLI_EXIT_CODE_SUCCESS);
 	exitInternalError(err instanceof Error ? err.message : String(err));
 });


### PR DESCRIPTION
## Summary

Piping dev3 CLI output into a consumer that closes early (`dev3 ui state | head -8`, `| grep -m1`, quitting a pager) dumped a raw Bun `EPIPE: broken pipe` stack trace and exited non-zero. Piping through head/grep is an extremely common agent pattern, so the noise polluted otherwise-clean tool output and read like a real failure. Reported twice (2026-07-04, 2026-07-05).

- New `src/cli/epipe.ts`: `isEpipeError()` + `installEpipeGuard()` — registers stdout/stderr `'error'` listeners and an `uncaughtException` handler that exits 0 silently on EPIPE (Bun's synchronous write throw escapes the awaited chain and lands in `uncaughtException`, not `main().catch`).
- Installed centrally in `main()` for every command except the long-running `remote`/`gui`, which own their crash handlers; `main().catch` also treats an EPIPE rejection as a clean stop.
- Guard matches only `code === "EPIPE"` — not `ECONNRESET`/`ENOTCONN`, which can come from the app Unix-socket client and must not be masked as success.
- Non-EPIPE crashes are printed and exit with the documented `CLI_EXIT_CODE_INTERNAL_ERROR` (4); rethrowing from the `uncaughtException` listener was rejected because Bun then exits 7, colliding with `CLI_EXIT_CODE_DOCTOR_PROBLEMS`.
- Subprocess tests cover the raw crash (control), the guarded clean exit through a real shell pipe, and the non-EPIPE crash path. Decision record: `decisions/113-cli-epipe-broken-pipe-guard.md`.