### PR TITLE
Fix Codex AI Git command routing

### DIFF
--- a/change-logs/2026/07/08/fix-codex-ai-git-command-routing.md
+++ b/change-logs/2026/07/08/fix-codex-ai-git-command-routing.md
@@ -1,0 +1,1 @@
+AI-assisted Git actions now follow the active Codex pane when the task also has another registered agent pane, instead of sending the prompt to the wrong agent.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -8654,6 +8654,33 @@ describe("handlers.createPullRequest", () => {
 		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%3"]));
 	});
 
+	it("routes to the active Codex main pane when its pane id is not persisted", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-1",
+			worktreePath: "/tmp/test-worktree",
+			sessionState: {
+				panes: [
+					{ paneId: null, agentCmd: "codex", sessionId: null, agentId: "builtin-codex", configId: null },
+					{ paneId: "%7", agentCmd: "claude", sessionId: null, agentId: "builtin-claude", configId: null },
+				],
+			},
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			stdout: args.includes("display-message") ? "%3\n" : args.includes("list-panes") ? "%3\n%7\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%3"]));
+	});
+
 	// A registered agent pane that no longer exists must not hijack the routing —
 	// fall back to the active pane (preserves the legacy behavior).
 	it("falls back to the active pane when the recorded agent pane is dead", async () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -982,8 +982,9 @@ const AGENT_PROMPT_ENTER_DELAY_MS = 800;
  *  - Exactly ONE live agent pane → target it unconditionally, even if a
  *    non-agent pane (a shell, a dev server) is currently focused. There is no
  *    ambiguity about where the agent lives, so focus must not misroute the prompt.
- *  - TWO OR MORE live agent panes → ambiguous; respect the user's focus and use
- *    the session's active pane.
+ *  - TWO OR MORE live agent panes, including a main pane whose id was not
+ *    persisted → ambiguous; respect the user's focus and use the session's
+ *    active pane.
  *  - ZERO known agent panes (legacy tasks with no sessionState) → fall back to
  *    the active pane, preserving the historical behavior.
  *
@@ -1004,6 +1005,7 @@ async function resolveAgentPromptTargetPane(
 	const registeredIds = (agentPanes ?? [])
 		.map((p) => p.paneId)
 		.filter((id): id is string => Boolean(id));
+	const hasUnresolvedAgentPane = (agentPanes ?? []).some((pane) => !pane.paneId);
 
 	if (registeredIds.length > 0) {
 		let livePaneIds = new Set<string>();
@@ -1016,7 +1018,7 @@ async function resolveAgentPromptTargetPane(
 		} catch { /* best effort */ }
 
 		const liveAgentPanes = [...new Set(registeredIds.filter((id) => livePaneIds.has(id)))];
-		if (liveAgentPanes.length === 1) return liveAgentPanes[0] ?? null;
+		if (liveAgentPanes.length === 1 && !hasUnresolvedAgentPane) return liveAgentPanes[0] ?? null;
 		// ≥2 or 0 live agent panes → fall through to the active pane below.
 	}
 

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1221,6 +1221,23 @@ describe("TaskInfoPanel", () => {
 			expect(screen.getAllByText("Merge").length).toBeGreaterThanOrEqual(1);
 		});
 
+		it("shows agent-assisted git actions for an active Codex task", async () => {
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				ahead: 3,
+				behind: 2,
+				canRebase: false,
+			});
+
+			await act(async () => {
+				renderPanel(makeTask({ agentId: "builtin-codex" }));
+			});
+
+			expect(screen.getAllByText("Rebase (AI)").length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText("PR").length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText("Auto PR").length).toBeGreaterThanOrEqual(1);
+		});
+
 		it("does not show git buttons for inactive task", async () => {
 			await act(async () => {
 				renderPanel(makeTask({ status: "todo", worktreePath: null, branchName: null }));


### PR DESCRIPTION
## Summary

- Route AI-assisted Git prompts to the active Codex pane when the primary pane has no persisted pane ID and another agent pane is registered.
- Preserve direct routing to a sole resolved agent pane.
- Add backend regression coverage for the Codex pane topology and renderer coverage for `Rebase (AI)`, `PR`, and `Auto PR` visibility on active Codex tasks.

## Test Coverage

Coverage audit: 100% of changed behavioral paths covered, 0 gaps.

```text
PR / Auto PR / Rebase (AI)
  -> RPC handler
  -> shared prompt router
  -> one live known pane, no unresolved pane: known pane
  -> otherwise: active tmux pane
  -> send prompt, then Enter
```

## Pre-Landing Review

No issues found.

## Design Review

No production frontend code changed. Browser QA confirmed the Codex task Git action row and no console errors.

## Eval Results

No prompt-related files changed; evals were skipped.

## Scope Drift

Scope Check: CLEAN. All changed files are implementation, targeted tests, or the required changelog entry.

## Plan Completion

No plan file detected. All three requirements from the task conversation were addressed.

## Verification Results

- [x] TypeScript lint passes
- [x] Mainview: 2,140 tests passed
- [x] Backend: 2,156 tests passed, 1 skipped
- [x] CLI: 509 tests passed
- [x] Production build passes
- [x] Browser QA passes with no console errors

## Test plan

- [x] Verify an unresolved primary Codex pane plus a registered secondary agent routes the prompt to the active Codex pane.
- [x] Verify active Codex tasks expose `Rebase (AI)`, `PR`, and `Auto PR` when the Git state allows them.
- [x] Verify existing single-agent, multi-agent, dead-pane, and no-pane routing cases remain green.

Generated with OpenAI Codex.
