### PR TITLE
Track Codex usage and monthly credit limits

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -30,7 +30,7 @@ Last updated: 2026-07-06
 | **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | Yes (`ensureCodexTrust`) | Yes (`ensureGeminiTrust`) | — |
 | **Status hooks (automatic)** | Yes (4 hooks) | — | Yes (4 hooks) | — | — |
 | **Status management** | Automatic via hooks | Manual (SKILL.md) | Automatic via hooks with `user-questions`/legacy-session fallback | Manual (SKILL.md) | Manual (SKILL.md) |
-| **Rate-limit tracking** | Yes (statusLine wrapper injected via `--settings`, `dev3 statusline`) | — | Yes (parsed from `~/.codex/sessions` rollout files) | — | — |
+| **Rate-limit tracking** | Yes (statusLine wrapper injected via `--settings`, `dev3 statusline`) | — | Yes (rollout files + cached live monthly credits via `codex app-server`) | — | — |
 
 ## Status Hooks
 

--- a/change-logs/2026/07/08/feature-codex-agent-usage.md
+++ b/change-logs/2026/07/08/feature-codex-agent-usage.md
@@ -1,1 +1,1 @@
-Velocity Cockpit now includes local Codex rollout token usage and API-equivalent model costs alongside Claude usage, with cached input priced separately and unknown preview models reported without guessed rates.
+Velocity Cockpit now includes local Codex rollout token usage and API-equivalent model costs alongside Claude usage, with cached input priced separately and unknown preview models reported without guessed rates. The header rate-limit widget also shows live Codex monthly credit usage, remaining percentage, and reset time with graceful rollout fallback.

--- a/change-logs/2026/07/08/feature-codex-agent-usage.md
+++ b/change-logs/2026/07/08/feature-codex-agent-usage.md
@@ -1,0 +1,1 @@
+Velocity Cockpit now includes local Codex rollout token usage and API-equivalent model costs alongside Claude usage, with cached input priced separately and unknown preview models reported without guessed rates.

--- a/decisions/115-codex-rollout-usage-deltas.md
+++ b/decisions/115-codex-rollout-usage-deltas.md
@@ -1,0 +1,21 @@
+# Codex rollout usage uses per-turn deltas
+
+## Context
+
+Codex writes local `token_count` events under `~/.codex/sessions/YYYY/MM/DD/`. Each event contains both cumulative session totals and the latest turn's token usage, while model selection arrives separately in `turn_context` events.
+
+## Investigation
+
+Real rollouts showed `total_token_usage` increasing cumulatively while `last_token_usage` exactly matched each increment. `input_tokens` includes `cached_input_tokens`; a frozen local-day comparison against `ccusage codex daily` confirmed the split and totals.
+
+## Decision
+
+`foldCodexEntry` in `src/bun/rpc-handlers/agent-usage-parse.ts` sums only `last_token_usage`, tracks the current `turn_context` model, and records non-cached input as `input_tokens - cached_input_tokens`. Unknown preview models retain their token totals but contribute no guessed cost and mark the report partially unpriced.
+
+## Risks
+
+Codex rollout fields are local implementation details and may evolve. Defensive field checks, per-file model reset, and malformed-line tolerance keep an absent or changed format from breaking the usage RPC.
+
+## Alternatives considered
+
+Summing cumulative totals overcounts every multi-turn session. Taking only the last cumulative event loses model changes and makes cross-day sessions inaccurate, while assigning preview models a nearby public rate would present speculation as cost.

--- a/decisions/116-codex-app-server-credit-limits.md
+++ b/decisions/116-codex-app-server-credit-limits.md
@@ -1,0 +1,21 @@
+# Codex monthly credits come from app-server
+
+## Context
+
+Enterprise Codex rollouts expose `credits.has_credits` but leave the balance and primary/secondary windows null. The TUI still shows an effective monthly credit limit, usage, and reset time that users need in the existing rate-limit indicator.
+
+## Investigation
+
+Codex 0.143's stable `account/rateLimits/read` app-server method returns `individualLimit` with `limit`, `used`, `remainingPercent`, and `resetsAt`. The request must keep app-server stdin open until response ID 7 arrives; closing it immediately cancels the asynchronous account read after initialization.
+
+## Decision
+
+`src/bun/codex-rate-limits.ts` performs a read-only stdio handshake through the spawn wrapper, reads only response ID 7, and never persists account data. `rate-limit-monitor.ts` caches successful snapshots for five minutes, merges them over rollout data, and lets monthly utilization participate in the existing warning/danger calculation.
+
+## Risks
+
+The feature depends on a Codex binary, valid ChatGPT authentication, network access, and a compatible stable app-server schema. Every failure returns null, retains the last successful cache when available, and otherwise falls back to rollout-only behavior without breaking the header.
+
+## Alternatives considered
+
+Deriving credits from token pricing would not match server-side enterprise accounting. Polling the web dashboard or reading auth tokens directly would duplicate private APIs and expand the trust boundary, while spawning app-server every 30 seconds would create needless processes and requests.

--- a/src/bun/__tests__/agent-pricing.test.ts
+++ b/src/bun/__tests__/agent-pricing.test.ts
@@ -23,6 +23,21 @@ describe("resolveModelRate", () => {
 		expect(resolveModelRate("claude-fable-5")).toMatchObject({ input: 10, output: 50 });
 	});
 
+	it("prices Codex models with OpenAI cached-input rates", () => {
+		expect(resolveModelRate("gpt-5.5")).toMatchObject({ input: 5, output: 30, cacheRead: 0.5 });
+		expect(resolveModelRate("gpt-5.4-mini")).toMatchObject({ input: 0.75, output: 4.5, cacheRead: 0.075 });
+		expect(resolveModelRate("gpt-5.3-codex")).toMatchObject({ input: 1.75, output: 14, cacheRead: 0.175 });
+		expect(resolveModelRate("openai/gpt-5.2-codex")).toMatchObject({ input: 1.75, output: 14, cacheRead: 0.175 });
+		expect(resolveModelRate("gpt-5.1-codex-max")).toMatchObject({ input: 1.25, output: 10, cacheRead: 0.125 });
+		expect(resolveModelRate("gpt-5-codex")).toMatchObject({ input: 1.25, output: 10, cacheRead: 0.125 });
+	});
+
+	it("leaves unpriced Codex preview models unresolved", () => {
+		expect(resolveModelRate("gpt-5.5-cyber")).toBeNull();
+		expect(resolveModelRate("gpt-5.3-codex-spark-preview")).toBeNull();
+		expect(resolveModelRate("gpt-5.6-sol")).toBeNull();
+	});
+
 	it("returns null for an unknown model", () => {
 		expect(resolveModelRate("some-other-llm")).toBeNull();
 		expect(resolveModelRate("")).toBeNull();

--- a/src/bun/__tests__/codex-rate-limits.test.ts
+++ b/src/bun/__tests__/codex-rate-limits.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchCodexRateLimitSnapshot } from "../codex-rate-limits";
+
+function stream(text: string): ReadableStream<Uint8Array> {
+	return new Response(text).body!;
+}
+
+describe("fetchCodexRateLimitSnapshot", () => {
+	it("handshakes with codex app-server and parses account/rateLimits/read", async () => {
+		let input = "";
+		let inputClosed = false;
+		let inputClosedBeforeResponse = false;
+		const response = `${JSON.stringify({ id: 0, result: { userAgent: "test" } })}\n${JSON.stringify({
+			id: 7,
+			result: {
+				rateLimits: {
+					primary: null,
+					secondary: null,
+					individualLimit: { limit: "8824", used: "329.53", remainingPercent: 96, resetsAt: 1_785_542_400 },
+				},
+			},
+		})}\n`;
+		const spawnProcess = vi.fn(() => ({
+			stdin: {
+				write: vi.fn((chunk: string) => {
+					input += chunk;
+				}),
+				end: vi.fn(() => {
+					inputClosed = true;
+				}),
+			},
+			stdout: new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					await Promise.resolve();
+					inputClosedBeforeResponse = inputClosed;
+					if (!inputClosed) controller.enqueue(new TextEncoder().encode(response));
+					controller.close();
+				},
+			}),
+			stderr: stream(""),
+			exited: Promise.resolve(0),
+			kill: vi.fn(),
+		}));
+
+		const snapshot = await fetchCodexRateLimitSnapshot(spawnProcess as never, 1000, 1_783_200_000_000);
+
+		expect(spawnProcess).toHaveBeenCalledWith(
+			["codex", "app-server", "--stdio"],
+			expect.objectContaining({ stdin: "pipe", stdout: "pipe", stderr: "pipe" }),
+		);
+		expect(input).toContain('"method":"initialize"');
+		expect(input).toContain('"method":"account/rateLimits/read"');
+		expect(snapshot?.monthlyCredits?.limit).toBe(8824);
+		expect(inputClosedBeforeResponse).toBe(false);
+		expect(inputClosed).toBe(true);
+	});
+
+	it("returns null when Codex is unavailable", async () => {
+		const spawnProcess = vi.fn(() => {
+			throw new Error("ENOENT");
+		});
+		expect(await fetchCodexRateLimitSnapshot(spawnProcess as never, 1000)).toBeNull();
+	});
+});

--- a/src/bun/__tests__/rate-limits.test.ts
+++ b/src/bun/__tests__/rate-limits.test.ts
@@ -3,7 +3,9 @@ import {
 	extractCodexSnapshotFromRolloutLines,
 	formatResetDelta,
 	formatStatusLineSegment,
+	mergeCodexRateLimitSnapshots,
 	parseClaudeStatusLinePayload,
+	parseCodexAppServerRateLimits,
 	parseCodexRateLimits,
 	windowLabel,
 	worstWindow,
@@ -83,6 +85,45 @@ describe("parseCodexRateLimits", () => {
 	});
 });
 
+describe("parseCodexAppServerRateLimits", () => {
+	it("parses the live monthly individual credit limit and makes it a constraint", () => {
+		const snap = parseCodexAppServerRateLimits(
+			{
+				limitId: "codex",
+				primary: null,
+				secondary: null,
+				credits: { hasCredits: true, unlimited: false, balance: null },
+				individualLimit: { limit: "8824", used: "329.5322287082672", remainingPercent: 96, resetsAt: 1_785_542_400 },
+				planType: "enterprise_cbp_usage_based",
+			},
+			NOW,
+		);
+
+		expect(snap?.monthlyCredits).toEqual({ limit: 8824, used: 329.5322287082672, remainingPercent: 96, resetsAt: 1_785_542_400_000 });
+		expect(snap?.windows).toContainEqual({ id: "monthly_credits", usedPercent: 4, resetsAt: 1_785_542_400_000, windowMinutes: null });
+	});
+
+	it("returns null when the live response carries no usable limit data", () => {
+		expect(parseCodexAppServerRateLimits({ individualLimit: null, primary: null, secondary: null }, NOW)).toBeNull();
+		expect(parseCodexAppServerRateLimits(null, NOW)).toBeNull();
+	});
+});
+
+describe("mergeCodexRateLimitSnapshots", () => {
+	it("adds live monthly credits while retaining rollout windows as fallback", () => {
+		const rollout = parseCodexRateLimits({ primary: { used_percent: 55, window_minutes: 300 } }, NOW)!;
+		const live = parseCodexAppServerRateLimits(
+			{ individualLimit: { limit: "1000", used: "250", remainingPercent: 75, resetsAt: 1_785_542_400 } },
+			NOW + 1000,
+		)!;
+
+		const merged = mergeCodexRateLimitSnapshots(rollout, live);
+		expect(merged?.windows.map((window) => window.id)).toEqual(["primary", "monthly_credits"]);
+		expect(merged?.monthlyCredits?.used).toBe(250);
+		expect(merged?.capturedAt).toBe(NOW + 1000);
+	});
+});
+
 describe("extractCodexSnapshotFromRolloutLines", () => {
 	const event = (ts: string, percent: number) =>
 		JSON.stringify({
@@ -147,6 +188,16 @@ describe("worstWindow", () => {
 
 	it("returns null when no snapshot has windows", () => {
 		expect(worstWindow({ generatedAt: NOW, snapshots: [] })).toBeNull();
+	});
+
+	it("lets a nearly exhausted monthly credit limit drive the indicator", () => {
+		const monthly = parseCodexAppServerRateLimits(
+			{ individualLimit: { limit: "1000", used: "970", remainingPercent: 3, resetsAt: 1_785_542_400 } },
+			NOW,
+		)!;
+		const worst = worstWindow({ generatedAt: NOW, snapshots: [monthly] });
+		expect(worst?.window.id).toBe("monthly_credits");
+		expect(worst?.window.usedPercent).toBe(97);
 	});
 });
 

--- a/src/bun/codex-rate-limits.ts
+++ b/src/bun/codex-rate-limits.ts
@@ -1,0 +1,78 @@
+import type { AgentRateLimitSnapshot } from "../shared/rate-limits";
+import { parseCodexAppServerRateLimits } from "../shared/rate-limits";
+import { createLogger } from "./logger";
+import { spawn } from "./spawn";
+
+const log = createLogger("codex-rate-limits");
+const RATE_LIMITS_REQUEST_ID = 7;
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+type SpawnProcess = typeof spawn;
+
+/**
+ * Read the authenticated Codex account limit snapshot through the stable local
+ * app-server protocol. Returns null for missing binaries, auth/network errors,
+ * timeouts, or protocol drift so rollout parsing remains a complete fallback.
+ */
+export async function fetchCodexRateLimitSnapshot(
+	spawnProcess: SpawnProcess = spawn,
+	timeoutMs: number = DEFAULT_TIMEOUT_MS,
+	capturedAt: number = Date.now(),
+): Promise<AgentRateLimitSnapshot | null> {
+	let proc: ReturnType<SpawnProcess> | null = null;
+	let stdin: import("bun").FileSink | null = null;
+	let timeout: ReturnType<typeof setTimeout> | null = null;
+	try {
+		proc = spawnProcess(["codex", "app-server", "--stdio"], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		stdin = proc.stdin as unknown as import("bun").FileSink;
+		stdin.write(
+			`${JSON.stringify({ method: "initialize", id: 0, params: { clientInfo: { name: "dev3", title: "dev-3.0", version: "1" } } })}\n`,
+		);
+		stdin.write(`${JSON.stringify({ method: "initialized", params: {} })}\n`);
+		stdin.write(`${JSON.stringify({ method: "account/rateLimits/read", id: RATE_LIMITS_REQUEST_ID, params: {} })}\n`);
+
+		// Drain stderr so a verbose child cannot block on a full pipe. Its contents
+		// may include account diagnostics, so never copy them into logs.
+		void new Response(proc.stderr as unknown as ReadableStream<Uint8Array>).text().catch(() => {});
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeout = setTimeout(() => {
+				proc?.kill();
+				reject(new Error("Codex app-server rate-limit request timed out"));
+			}, timeoutMs);
+		});
+		const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+		const decoder = new TextDecoder();
+		let buffered = "";
+		while (true) {
+			const chunk = await Promise.race([reader.read(), timeoutPromise]);
+			buffered += chunk.value ? decoder.decode(chunk.value, { stream: !chunk.done }) : "";
+			const lines = buffered.split("\n");
+			buffered = chunk.done ? "" : lines.pop() ?? "";
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				try {
+					const message = JSON.parse(line) as { id?: number; result?: { rateLimits?: unknown } };
+					if (message.id !== RATE_LIMITS_REQUEST_ID) continue;
+					return message.result?.rateLimits
+						? parseCodexAppServerRateLimits(message.result.rateLimits, capturedAt)
+						: null;
+				} catch {
+					// Ignore notifications and malformed diagnostic lines.
+				}
+			}
+			if (chunk.done) break;
+		}
+		return null;
+	} catch (error) {
+		log.warn("Codex live rate limits unavailable; using rollout fallback", { error: String(error) });
+		return null;
+	} finally {
+		if (timeout) clearTimeout(timeout);
+		stdin?.end();
+		proc?.kill();
+	}
+}

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -331,7 +331,7 @@ startResourceMonitor((name, payload) => {
 	pushToBrowserClients(name, payload);
 });
 
-// ── Agent rate-limit monitor (Claude statusLine dump / Codex rollouts) ──
+// ── Agent rate-limit monitor (Claude dump / Codex rollouts + monthly credits) ──
 startRateLimitMonitor((name, payload) => {
 	pushToBrowserClients(name, payload);
 });

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -406,7 +406,7 @@ startResourceMonitor((name, payload) => {
 	}
 });
 
-// Start background agent rate-limit monitor (Claude statusLine dump / Codex rollouts)
+// Start background agent rate-limit monitor (Claude dump / Codex rollouts + monthly credits)
 startRateLimitMonitor((name, payload) => {
 	try {
 		broadcastToAllWindows(name, payload);

--- a/src/bun/rate-limit-monitor.ts
+++ b/src/bun/rate-limit-monitor.ts
@@ -1,12 +1,14 @@
 /**
- * Agent rate-limit monitor — periodically reads the two LOCAL rate-limit
- * sources (no API calls) and pushes changes to the renderer:
+ * Agent rate-limit monitor — periodically reads local rate-limit sources and
+ * pushes changes to the renderer:
  *
  * - Claude: ~/.dev3.0/data/rate-limits/claude.json, written by the injected
  *   `dev3 statusline` wrapper on every statusLine refresh of any dev3-launched
  *   Claude session (see src/cli/commands/statusline.ts).
  * - Codex: the newest rollout file under ~/.codex/sessions/YYYY/MM/DD/ — the
  *   tail contains `token_count` events with a `rate_limits` object.
+ * - Codex monthly credits: a cached read-only request through the locally
+ *   authenticated `codex app-server`, with rollout-only fallback.
  *
  * Also owns the static `--settings` file injected into Claude launches, which
  * routes the session's statusLine through `dev3 statusline`.
@@ -16,13 +18,16 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, openSync, r
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentRateLimitSnapshot, AgentRateLimitsReport } from "../shared/rate-limits";
-import { extractCodexSnapshotFromRolloutLines, parseClaudeStatusLinePayload } from "../shared/rate-limits";
+import { extractCodexSnapshotFromRolloutLines, mergeCodexRateLimitSnapshots, parseClaudeStatusLinePayload } from "../shared/rate-limits";
+import { fetchCodexRateLimitSnapshot } from "./codex-rate-limits";
 import { DEV3_HOME } from "./paths";
 import { createLogger } from "./logger";
 import { loadSettings } from "./settings";
 
 const log = createLogger("rate-limit-monitor");
 const POLL_INTERVAL_MS = 30_000;
+/** Avoid spawning app-server and hitting the account endpoint every poll. */
+const CODEX_LIVE_REFRESH_MS = 5 * 60_000;
 /** How much of a rollout file tail to scan for the last rate_limits event. */
 const CODEX_TAIL_BYTES = 256 * 1024;
 /** How many most-recent day directories to consider when locating the live rollout. */
@@ -39,6 +44,9 @@ let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let pushMessageFn: PushMessageFn | null = null;
 let lastPushedKey = "";
 let cachedReport: AgentRateLimitsReport | null = null;
+let cachedCodexLiveSnapshot: AgentRateLimitSnapshot | null = null;
+let codexLiveAttemptedAt = 0;
+let codexLiveRequest: Promise<AgentRateLimitSnapshot | null> | null = null;
 
 /**
  * Write (once) the settings file whose statusLine routes through
@@ -159,6 +167,21 @@ export function readCodexSnapshot(root: string = codexSessionsRoot()): AgentRate
 	}
 }
 
+async function readCodexLiveSnapshot(now: number = Date.now()): Promise<AgentRateLimitSnapshot | null> {
+	if (now - codexLiveAttemptedAt < CODEX_LIVE_REFRESH_MS) return cachedCodexLiveSnapshot;
+	if (codexLiveRequest) return codexLiveRequest;
+	codexLiveAttemptedAt = now;
+	codexLiveRequest = fetchCodexRateLimitSnapshot()
+		.then((snapshot) => {
+			if (snapshot) cachedCodexLiveSnapshot = snapshot;
+			return cachedCodexLiveSnapshot;
+		})
+		.finally(() => {
+			codexLiveRequest = null;
+		});
+	return codexLiveRequest;
+}
+
 async function trackingEnabled(): Promise<boolean> {
 	try {
 		const settings = await loadSettings();
@@ -175,7 +198,7 @@ export async function getAgentRateLimitsReport(): Promise<AgentRateLimitsReport>
 	const snapshots: AgentRateLimitSnapshot[] = [];
 	const claude = readClaudeSnapshot();
 	if (claude) snapshots.push(claude);
-	const codex = readCodexSnapshot();
+	const codex = mergeCodexRateLimitSnapshots(readCodexSnapshot(), await readCodexLiveSnapshot());
 	if (codex) snapshots.push(codex);
 	const report: AgentRateLimitsReport = { snapshots, generatedAt: Date.now() };
 	cachedReport = report;
@@ -185,7 +208,10 @@ export async function getAgentRateLimitsReport(): Promise<AgentRateLimitsReport>
 /** Change-detection key: pushes happen only when the meaningful bits move. */
 function reportKey(report: AgentRateLimitsReport): string {
 	return report.snapshots
-		.map((s) => `${s.source}:${s.capturedAt}:${s.windows.map((w) => `${w.id}=${w.usedPercent}@${w.resetsAt}`).join(",")}:${s.creditsBalance}`)
+		.map(
+			(s) =>
+				`${s.source}:${s.capturedAt}:${s.windows.map((w) => `${w.id}=${w.usedPercent}@${w.resetsAt}`).join(",")}:${s.creditsBalance}:${s.monthlyCredits ? `${s.monthlyCredits.used}/${s.monthlyCredits.limit}@${s.monthlyCredits.resetsAt}` : ""}`,
+		)
 		.join("|");
 }
 
@@ -219,6 +245,9 @@ export function stopRateLimitMonitor(): void {
 	pushMessageFn = null;
 	lastPushedKey = "";
 	cachedReport = null;
+	cachedCodexLiveSnapshot = null;
+	codexLiveAttemptedAt = 0;
+	codexLiveRequest = null;
 }
 
 /** Last computed report (may be null before the first poll/RPC). */

--- a/src/bun/rpc-handlers/__tests__/agent-usage-handler.test.ts
+++ b/src/bun/rpc-handlers/__tests__/agent-usage-handler.test.ts
@@ -1,0 +1,82 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../rate-limit-monitor", () => ({
+	getAgentRateLimitsReport: vi.fn(),
+}));
+
+import { getAgentUsage } from "../agent-usage";
+
+let tempRoot: string;
+
+function writeJsonl(path: string, entries: unknown[]): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, entries.map((entry) => JSON.stringify(entry)).join("\n"));
+}
+
+beforeEach(() => {
+	tempRoot = mkdtempSync(join(tmpdir(), "dev3-agent-usage-"));
+	vi.stubEnv("CLAUDE_CONFIG_DIR", join(tempRoot, "claude"));
+	vi.stubEnv("CODEX_HOME", join(tempRoot, "codex"));
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("getAgentUsage", () => {
+	it("merges Claude transcripts and Codex rollouts into one source-tagged feed", async () => {
+		writeJsonl(join(tempRoot, "claude", "projects", "repo", "session.jsonl"), [
+			{
+				type: "assistant",
+				requestId: "request-1",
+				timestamp: "2026-07-01T12:00:00Z",
+				message: { id: "message-1", model: "claude-sonnet-4-6", usage: { input_tokens: 1_000_000 } },
+			},
+		]);
+		writeJsonl(join(tempRoot, "codex", "sessions", "2026", "07", "01", "rollout-test.jsonl"), [
+			{ type: "turn_context", timestamp: "2026-07-01T12:00:00Z", payload: { model: "gpt-5.1-codex" } },
+			{
+				type: "event_msg",
+				timestamp: "2026-07-01T12:05:00Z",
+				payload: {
+					type: "token_count",
+					info: {
+						last_token_usage: { input_tokens: 1_500_000, cached_input_tokens: 500_000, output_tokens: 1_000_000 },
+						total_token_usage: { input_tokens: 20_000_000, cached_input_tokens: 10_000_000, output_tokens: 5_000_000 },
+					},
+				},
+			},
+		]);
+		writeJsonl(join(tempRoot, "codex", "sessions", "2026", "07", "01", "ignored.jsonl"), [
+			{ type: "event_msg", timestamp: "2026-07-01T12:10:00Z", payload: { type: "token_count", info: { last_token_usage: { input_tokens: 99 } } } },
+		]);
+
+		const report = await getAgentUsage();
+
+		expect(report.days).toHaveLength(2);
+		expect(report.days[0]).toMatchObject({ source: "claude", inputTokens: 1_000_000, costUsd: 3, fullyPriced: true });
+		expect(report.days[1]).toMatchObject({
+			source: "codex",
+			inputTokens: 1_000_000,
+			outputTokens: 1_000_000,
+			cacheReadInputTokens: 500_000,
+			costUsd: 11.3125,
+			fullyPriced: true,
+		});
+		expect(report.hasUnpricedModels).toBe(false);
+	});
+
+	it("returns an empty report when both local agent directories are absent", async () => {
+		const report = await getAgentUsage();
+		expect(report.days).toEqual([]);
+		expect(report.hasUnpricedModels).toBe(false);
+	});
+});

--- a/src/bun/rpc-handlers/__tests__/agent-usage.test.ts
+++ b/src/bun/rpc-handlers/__tests__/agent-usage.test.ts
@@ -1,4 +1,4 @@
-import { buildClaudeUsageDays } from "../agent-usage-parse";
+import { buildClaudeUsageDays, buildCodexUsageDays } from "../agent-usage-parse";
 
 // Midday-UTC timestamps so local-day bucketing is stable across test-runner timezones.
 function assistant(
@@ -53,5 +53,66 @@ describe("buildClaudeUsageDays", () => {
 		const { days, hasUnpriced } = buildClaudeUsageDays([{ type: "user" }, null, 42]);
 		expect(days).toEqual([]);
 		expect(hasUnpriced).toBe(false);
+	});
+});
+
+function codexModel(model: string, timestamp: string) {
+	return { type: "turn_context", timestamp, payload: { model } };
+}
+
+function codexUsage(timestamp: string, last: Record<string, unknown>, total: Record<string, unknown> = {}) {
+	return {
+		type: "event_msg",
+		timestamp,
+		payload: {
+			type: "token_count",
+			info: { last_token_usage: last, total_token_usage: total },
+		},
+	};
+}
+
+describe("buildCodexUsageDays", () => {
+	it("sums per-turn deltas, tracks model changes, and dedups repeated rollout events", () => {
+		const duplicate = codexUsage(
+			"2026-07-01T12:05:00Z",
+			{ input_tokens: 1_500_000, cached_input_tokens: 500_000, output_tokens: 1_000_000 },
+			{ input_tokens: 99_000_000, cached_input_tokens: 80_000_000, output_tokens: 40_000_000 },
+		);
+		const { days, hasUnpriced } = buildCodexUsageDays([
+			codexModel("gpt-5.1-codex", "2026-07-01T12:00:00Z"),
+			duplicate,
+			duplicate,
+			codexModel("gpt-5.4-mini", "2026-07-01T12:10:00Z"),
+			codexUsage("2026-07-01T12:15:00Z", { input_tokens: 1_000_000, output_tokens: 1_000_000 }),
+		]);
+
+		expect(days).toHaveLength(1);
+		expect(days[0]).toMatchObject({
+			date: "2026-07-01",
+			source: "codex",
+			inputTokens: 2_000_000,
+			outputTokens: 2_000_000,
+			cacheCreationInputTokens: 0,
+			cacheReadInputTokens: 500_000,
+			fullyPriced: true,
+		});
+		// gpt-5.1-codex: $1.25 input + $0.0625 cached + $10 output;
+		// gpt-5.4-mini: $0.75 input + $4.50 output.
+		expect(days[0].costUsd).toBeCloseTo(16.5625, 6);
+		expect(hasUnpriced).toBe(false);
+	});
+
+	it("counts unknown-model tokens without pricing and ignores malformed events", () => {
+		const { days, hasUnpriced } = buildCodexUsageDays([
+			codexModel("gpt-5.6-sol", "2026-07-02T12:00:00Z"),
+			codexUsage("2026-07-02T12:05:00Z", { input_tokens: 10, cached_input_tokens: 4, output_tokens: 3 }),
+			codexUsage("not-a-timestamp", { input_tokens: 100 }),
+			{ type: "event_msg", timestamp: "2026-07-02T12:10:00Z", payload: { type: "token_count" } },
+			null,
+		]);
+
+		expect(days).toHaveLength(1);
+		expect(days[0]).toMatchObject({ inputTokens: 6, outputTokens: 3, cacheReadInputTokens: 4, costUsd: 0, fullyPriced: false });
+		expect(hasUnpriced).toBe(true);
 	});
 });

--- a/src/bun/rpc-handlers/agent-usage-parse.ts
+++ b/src/bun/rpc-handlers/agent-usage-parse.ts
@@ -2,8 +2,9 @@ import { computeTokenCostUsd, type TokenCounts } from "../../shared/agent-pricin
 import type { AgentUsageDay, AgentUsageSource } from "../../shared/types";
 
 /**
- * Pure aggregation of Claude Code transcript usage — no fs, no logging, no
- * electrobun. Kept separate from the handler so it is trivially unit-testable.
+ * Pure aggregation of Claude Code transcripts and Codex rollouts — no fs, no
+ * logging, no electrobun. Kept separate from the handler so it is trivially
+ * unit-testable.
  *
  * Each `type:"assistant"` transcript line carries `message.usage` (input/output/
  * cache tokens), `message.model`, `message.id`, `requestId`, and a `timestamp`.
@@ -18,10 +19,12 @@ export interface UsageState {
 	startMsByDate: Map<string, number>;
 	/** dedup: `${message.id}:${requestId}` already counted */
 	seen: Set<string>;
+	/** Model selected by the latest Codex turn_context in the current rollout. */
+	codexModel: string;
 }
 
 export function newUsageState(): UsageState {
-	return { byDateModel: new Map(), startMsByDate: new Map(), seen: new Set() };
+	return { byDateModel: new Map(), startMsByDate: new Map(), seen: new Set(), codexModel: "gpt-5" };
 }
 
 function pad2(n: number): string {
@@ -49,6 +52,25 @@ function emptyCounts(): TokenCounts {
 	};
 }
 
+function finiteNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function countsFor(state: UsageState, date: string, startMs: number, model: string): TokenCounts {
+	let models = state.byDateModel.get(date);
+	if (!models) {
+		models = new Map();
+		state.byDateModel.set(date, models);
+		state.startMsByDate.set(date, startMs);
+	}
+	let acc = models.get(model);
+	if (!acc) {
+		acc = emptyCounts();
+		models.set(model, acc);
+	}
+	return acc;
+}
+
 /** Fold one parsed transcript line into the accumulator. Ignores non-assistant / malformed lines. */
 export function foldClaudeEntry(state: UsageState, entry: unknown): void {
 	if (!entry || typeof entry !== "object") return;
@@ -67,26 +89,61 @@ export function foldClaudeEntry(state: UsageState, entry: unknown): void {
 	if (!day) return;
 	const model = typeof msg.model === "string" ? msg.model : "unknown";
 
-	let models = state.byDateModel.get(day.date);
-	if (!models) {
-		models = new Map();
-		state.byDateModel.set(day.date, models);
-		state.startMsByDate.set(day.date, day.startMs);
-	}
-	let acc = models.get(model);
-	if (!acc) {
-		acc = emptyCounts();
-		models.set(model, acc);
+	const acc = countsFor(state, day.date, day.startMs, model);
+	const cacheCreation = usage.cache_creation as Record<string, unknown> | undefined;
+	acc.inputTokens += finiteNumber(usage.input_tokens);
+	acc.outputTokens += finiteNumber(usage.output_tokens);
+	acc.cacheCreationInputTokens += finiteNumber(usage.cache_creation_input_tokens);
+	acc.cacheReadInputTokens += finiteNumber(usage.cache_read_input_tokens);
+	acc.cacheCreation5mInputTokens! += finiteNumber(cacheCreation?.ephemeral_5m_input_tokens);
+	acc.cacheCreation1hInputTokens! += finiteNumber(cacheCreation?.ephemeral_1h_input_tokens);
+}
+
+/** Reset per-file Codex context while preserving accumulated usage and dedup state. */
+export function beginCodexRollout(state: UsageState): void {
+	// Very old rollouts predate turn_context; ccusage also falls back to gpt-5 for them.
+	state.codexModel = "gpt-5";
+}
+
+/**
+ * Fold one Codex rollout entry. `last_token_usage` is the per-turn delta;
+ * `total_token_usage` is cumulative for the session and must never be summed.
+ */
+export function foldCodexEntry(state: UsageState, entry: unknown): void {
+	if (!entry || typeof entry !== "object") return;
+	const e = entry as Record<string, unknown>;
+	const payload = e.payload as Record<string, unknown> | undefined;
+	if (!payload) return;
+
+	if (e.type === "turn_context") {
+		if (typeof payload.model === "string" && payload.model.trim()) state.codexModel = payload.model;
+		return;
 	}
 
-	const num = (v: unknown): number => (typeof v === "number" && Number.isFinite(v) ? v : 0);
-	const cacheCreation = usage.cache_creation as Record<string, unknown> | undefined;
-	acc.inputTokens += num(usage.input_tokens);
-	acc.outputTokens += num(usage.output_tokens);
-	acc.cacheCreationInputTokens += num(usage.cache_creation_input_tokens);
-	acc.cacheReadInputTokens += num(usage.cache_read_input_tokens);
-	acc.cacheCreation5mInputTokens! += num(cacheCreation?.ephemeral_5m_input_tokens);
-	acc.cacheCreation1hInputTokens! += num(cacheCreation?.ephemeral_1h_input_tokens);
+	if (e.type !== "event_msg" || payload.type !== "token_count" || typeof e.timestamp !== "string") return;
+	const info = payload.info as Record<string, unknown> | undefined;
+	const usage = info?.last_token_usage as Record<string, unknown> | undefined;
+	if (!usage) return;
+	const day = localDayOf(e.timestamp);
+	if (!day) return;
+
+	const input = Math.max(0, finiteNumber(usage.input_tokens));
+	const cachedInput = Math.min(input, Math.max(0, finiteNumber(usage.cached_input_tokens)));
+	const output = Math.max(0, finiteNumber(usage.output_tokens));
+	if (input === 0 && cachedInput === 0 && output === 0) return;
+
+	// Rollouts have no message id. Timestamp + delta + active model is stable across
+	// copied/resumed rollout files while still distinguishing ordinary turns.
+	const dedupKey = `codex:${e.timestamp}:${state.codexModel}:${input}:${cachedInput}:${output}`;
+	if (state.seen.has(dedupKey)) return;
+	state.seen.add(dedupKey);
+
+	const acc = countsFor(state, day.date, day.startMs, state.codexModel);
+	// Codex input_tokens includes cached input. Split it so dashboard totals and
+	// pricing count every token exactly once.
+	acc.inputTokens += Math.max(0, input - cachedInput);
+	acc.outputTokens += output;
+	acc.cacheReadInputTokens += cachedInput;
 }
 
 /** Collapse the per-(date,model) accumulator into per-day rows with priced cost. */
@@ -133,4 +190,12 @@ export function buildClaudeUsageDays(entries: unknown[]): { days: AgentUsageDay[
 	const state = newUsageState();
 	for (const entry of entries) foldClaudeEntry(state, entry);
 	return finalizeUsage(state, "claude");
+}
+
+/** Pure convenience for tests: fold one rollout's entries into Codex day rows. */
+export function buildCodexUsageDays(entries: unknown[]): { days: AgentUsageDay[]; hasUnpriced: boolean } {
+	const state = newUsageState();
+	beginCodexRollout(state);
+	for (const entry of entries) foldCodexEntry(state, entry);
+	return finalizeUsage(state, "codex");
 }

--- a/src/bun/rpc-handlers/agent-usage.ts
+++ b/src/bun/rpc-handlers/agent-usage.ts
@@ -4,15 +4,14 @@ import { join } from "node:path";
 import type { AgentUsageReport } from "../../shared/types";
 import type { AgentRateLimitsReport } from "../../shared/rate-limits";
 import { getAgentRateLimitsReport } from "../rate-limit-monitor";
-import { finalizeUsage, foldClaudeEntry, newUsageState } from "./agent-usage-parse";
+import { beginCodexRollout, finalizeUsage, foldClaudeEntry, foldCodexEntry, newUsageState, type UsageState } from "./agent-usage-parse";
 import { log } from "./shared";
 
 /**
  * Agent usage (tokens + API-equivalent cost) reconstructed from LOCAL on-disk
- * agent state — no API calls. v1 covers Claude Code by parsing its transcript
- * JSONL files (`~/.claude/projects/<slug>/<uuid>.jsonl`), the same source the
- * `ccusage` tool uses. Pure aggregation lives in `agent-usage-parse.ts`; this
- * file only walks the filesystem. Codex (rollouts) is a planned follow-up.
+ * agent state — no API calls. Covers Claude Code transcripts and Codex rollout
+ * JSONL files, the same local sources the `ccusage` tool uses. Pure aggregation
+ * lives in `agent-usage-parse.ts`; this file only walks the filesystem.
  */
 
 /** Root of Claude Code's projects dir, honouring CLAUDE_CONFIG_DIR (used by the account switcher). */
@@ -21,8 +20,14 @@ function claudeProjectsDir(): string {
 	return join(base, "projects");
 }
 
+/** Root of Codex rollout sessions, honouring CODEX_HOME. */
+function codexSessionsDir(): string {
+	const base = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+	return join(base, "sessions");
+}
+
 /** Recursively collect every *.jsonl transcript under the projects dir. Never throws. */
-function collectTranscriptFiles(dir: string, out: string[]): void {
+function collectTranscriptFiles(dir: string, out: string[], codex = false): void {
 	let entries: import("node:fs").Dirent[];
 	try {
 		entries = readdirSync(dir, { withFileTypes: true });
@@ -31,17 +36,19 @@ function collectTranscriptFiles(dir: string, out: string[]): void {
 	}
 	for (const entry of entries) {
 		const full = join(dir, entry.name);
-		if (entry.isDirectory()) collectTranscriptFiles(full, out);
-		else if (entry.isFile() && entry.name.endsWith(".jsonl")) out.push(full);
+		if (entry.isDirectory()) collectTranscriptFiles(full, out, codex);
+		else if (entry.isFile() && entry.name.endsWith(".jsonl") && (!codex || entry.name.startsWith("rollout-"))) out.push(full);
 	}
 }
 
-export async function getAgentUsage(): Promise<AgentUsageReport> {
-	const state = newUsageState();
-	const files: string[] = [];
-	collectTranscriptFiles(claudeProjectsDir(), files);
-
+function foldJsonlFiles(
+	files: string[],
+	state: UsageState,
+	fold: (state: UsageState, entry: unknown) => void,
+	beforeFile?: (state: UsageState) => void,
+): void {
 	for (const file of files) {
+		beforeFile?.(state);
 		let text: string;
 		try {
 			text = readFileSync(file, "utf8");
@@ -53,15 +60,37 @@ export async function getAgentUsage(): Promise<AgentUsageReport> {
 			const trimmed = line.trim();
 			if (!trimmed) continue;
 			try {
-				foldClaudeEntry(state, JSON.parse(trimmed));
+				fold(state, JSON.parse(trimmed));
 			} catch {
 				// tolerate a truncated / partially-written last line
 			}
 		}
 	}
+}
 
-	const { days, hasUnpriced } = finalizeUsage(state, "claude");
-	log.info("getAgentUsage computed", { files: files.length, days: days.length, hasUnpriced });
+export async function getAgentUsage(): Promise<AgentUsageReport> {
+	const claudeState = newUsageState();
+	const claudeFiles: string[] = [];
+	collectTranscriptFiles(claudeProjectsDir(), claudeFiles);
+	foldJsonlFiles(claudeFiles, claudeState, foldClaudeEntry);
+
+	const codexState = newUsageState();
+	const codexFiles: string[] = [];
+	collectTranscriptFiles(codexSessionsDir(), codexFiles, true);
+	foldJsonlFiles(codexFiles, codexState, foldCodexEntry, beginCodexRollout);
+
+	const claude = finalizeUsage(claudeState, "claude");
+	const codex = finalizeUsage(codexState, "codex");
+	const days = [...claude.days, ...codex.days].sort(
+		(a, b) => a.startMs - b.startMs || a.source.localeCompare(b.source),
+	);
+	const hasUnpriced = claude.hasUnpriced || codex.hasUnpriced;
+	log.info("getAgentUsage computed", {
+		claudeFiles: claudeFiles.length,
+		codexFiles: codexFiles.length,
+		days: days.length,
+		hasUnpriced,
+	});
 	return { days, generatedAt: new Date().toISOString(), hasUnpricedModels: hasUnpriced };
 }
 

--- a/src/bun/rpc-handlers/agent-usage.ts
+++ b/src/bun/rpc-handlers/agent-usage.ts
@@ -94,7 +94,7 @@ export async function getAgentUsage(): Promise<AgentUsageReport> {
 	return { days, generatedAt: new Date().toISOString(), hasUnpricedModels: hasUnpriced };
 }
 
-/** Current agent rate-limit windows (Claude statusLine dump / Codex rollouts). */
+/** Current agent rate limits (local dumps/rollouts plus cached Codex monthly credits). */
 async function getAgentRateLimits(): Promise<AgentRateLimitsReport> {
 	return getAgentRateLimitsReport();
 }

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../rpc";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import Tooltip from "./Tooltip";
 import { RateLimitIcon } from "./HeaderIcons";
 import type { AgentRateLimitsReport } from "../../shared/rate-limits";
@@ -23,10 +23,12 @@ const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" 
  * dev running many parallel agents is never blindsided by hitting a limit.
  * Hidden until any data exists; escalates color at ≥80% / ≥95% of the most
  * constrained window. Details (per-window % + time-to-reset) live in the
- * tooltip. Data comes from local files only — see rate-limit-monitor.ts.
+ * tooltip. Codex monthly credits come from a cached app-server account read;
+ * all other data comes from local files — see rate-limit-monitor.ts.
  */
 function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const t = useT();
+	const [locale] = useLocale();
 	const [report, setReport] = useState<AgentRateLimitsReport | null>(null);
 
 	useEffect(() => {
@@ -53,6 +55,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	for (const snap of report.snapshots) {
 		const sourceName = SOURCE_NAMES[snap.source] ?? snap.source;
 		for (const win of snap.windows) {
+			if (win.id === "monthly_credits") continue;
 			const reset = formatResetDelta(win.resetsAt, now);
 			rows.push(
 				`${sourceName} ${windowLabel(win)} — ${Math.round(win.usedPercent)}%${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
@@ -61,13 +64,26 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		if (snap.creditsBalance != null) {
 			rows.push(`${sourceName} — ${t("rateLimits.credits", { balance: snap.creditsBalance })}`);
 		}
+		if (snap.monthlyCredits) {
+			const monthly = snap.monthlyCredits;
+			const reset = formatResetDelta(monthly.resetsAt, now);
+			const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+			rows.push(
+				`${sourceName} ${t("rateLimits.monthlyLabel")} — ${t("rateLimits.monthlyUsage", {
+					used: numberFormat.format(monthly.used),
+					limit: numberFormat.format(monthly.limit),
+					remaining: Math.round(monthly.remainingPercent),
+				})}${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
+			);
+		}
 		if (now - snap.capturedAt > STALE_AFTER_MS && (staleCapturedAt == null || snap.capturedAt < staleCapturedAt)) {
 			staleCapturedAt = snap.capturedAt;
 		}
 	}
 
 	const worstReset = formatResetDelta(worst.window.resetsAt, now);
-	const ariaLabel = `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[worst.source] ?? worst.source} ${windowLabel(worst.window)} ${percent}%${worstReset ? `, ${t("rateLimits.resetsIn", { time: worstReset })}` : ""}`;
+	const worstLabel = worst.window.id === "monthly_credits" ? t("rateLimits.monthlyLabel") : windowLabel(worst.window);
+	const ariaLabel = `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[worst.source] ?? worst.source} ${worstLabel} ${percent}%${worstReset ? `, ${t("rateLimits.resetsIn", { time: worstReset })}` : ""}`;
 
 	const colorClasses = danger
 		? "text-danger bg-danger/15 border-danger/30"
@@ -93,6 +109,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		>
 			<div
 				role="status"
+				tabIndex={0}
 				aria-label={ariaLabel}
 				data-help-id="header.rateLimits"
 				className={`header-anim flex cursor-pointer select-none items-center gap-1 px-1.5 py-1 rounded-lg border transition-colors ${colorClasses}`}

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
 import RateLimitIndicator from "../RateLimitIndicator";
@@ -28,6 +29,7 @@ function report(percent: number): AgentRateLimitsReport {
 					{ id: "seven_day", usedPercent: percent, resetsAt: Date.now() + 86_400_000, windowMinutes: 10080 },
 				],
 				creditsBalance: null,
+				monthlyCredits: null,
 				planType: null,
 			},
 		],
@@ -91,5 +93,28 @@ describe("RateLimitIndicator", () => {
 		const { container } = renderIndicator();
 		await act(async () => {});
 		expect(container.querySelector("[role='status']")).toBeNull();
+	});
+
+	it("shows a monthly-only Codex limit and its detailed credit usage", async () => {
+		mockedGet.mockResolvedValue({
+			generatedAt: Date.now(),
+			snapshots: [
+				{
+					source: "codex",
+					capturedAt: Date.now(),
+					windows: [{ id: "monthly_credits", usedPercent: 97, resetsAt: Date.now() + 86_400_000, windowMinutes: null }],
+					creditsBalance: null,
+					monthlyCredits: { limit: 8824, used: 329.532, remainingPercent: 3, resetsAt: Date.now() + 86_400_000 },
+					planType: "enterprise_cbp_usage_based",
+				},
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+
+		expect(screen.getByText("97%")).toBeTruthy();
+		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("monthly credits");
+		await userEvent.tab();
+		expect(await screen.findByText(/329.53 \/ 8,824/)).toBeTruthy();
 	});
 });

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -106,6 +106,8 @@ const dashboard = {
 	"rateLimits.tooltipTitle": "Agent rate limits",
 	"rateLimits.resetsIn": "resets in {time}",
 	"rateLimits.credits": "credits: {balance}",
+	"rateLimits.monthlyLabel": "monthly credits",
+	"rateLimits.monthlyUsage": "{used} / {limit} used · {remaining}% left",
 	"rateLimits.stale": "Data from {time} ago — refreshes while an agent session is active",
 
 	// Remote Access QR Modal

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -106,6 +106,8 @@ const dashboard = {
 	"rateLimits.tooltipTitle": "Límites de agentes",
 	"rateLimits.resetsIn": "se restablece en {time}",
 	"rateLimits.credits": "créditos: {balance}",
+	"rateLimits.monthlyLabel": "créditos mensuales",
+	"rateLimits.monthlyUsage": "{used} / {limit} usados · {remaining}% restantes",
 	"rateLimits.stale": "Datos de hace {time} — se actualizan mientras hay una sesión de agente activa",
 
 	// Remote Access QR Modal

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -114,6 +114,8 @@ const dashboard = {
 	"rateLimits.tooltipTitle": "Лимиты агентов",
 	"rateLimits.resetsIn": "сброс через {time}",
 	"rateLimits.credits": "кредиты: {balance}",
+	"rateLimits.monthlyLabel": "месячные кредиты",
+	"rateLimits.monthlyUsage": "использовано {used} / {limit} · осталось {remaining}%",
 	"rateLimits.stale": "Данные {time} назад — обновляются, пока активна сессия агента",
 
 	// Remote Access QR Modal

--- a/src/shared/agent-pricing.ts
+++ b/src/shared/agent-pricing.ts
@@ -8,9 +8,9 @@
  * if you paid per-token at public API rates" — a proxy for how much value the
  * subscription is delivering, not a bill. Always label it that way.
  *
- * Prices are USD per 1,000,000 tokens. Cache multipliers follow Anthropic's
- * public model: 5-minute cache write = 1.25x base input, 1-hour cache write =
- * 2x base input, cache read = 0.1x base input.
+ * Prices are USD per 1,000,000 tokens. Anthropic cache writes use the public
+ * 5-minute/1-hour multipliers; cache reads use the model's explicit public
+ * rate when supplied (OpenAI) or default to 0.1x base input (Anthropic).
  *
  * Unknown models resolve to `null` (graceful absence) — the caller still counts
  * their tokens but contributes 0 cost and should surface an "unpriced" flag
@@ -21,6 +21,8 @@
 export interface ModelBaseRate {
 	input: number;
 	output: number;
+	/** Explicit prompt-cache read rate. Defaults to 10% of input when omitted. */
+	cacheRead?: number;
 }
 
 /** Fully-resolved per-model rates including derived cache rates. */
@@ -52,6 +54,20 @@ const PER_MILLION = 1_000_000;
  * resolver matches by prefix so `opus-4-8` wins before a generic `opus`.
  */
 const BASE_RATES: ReadonlyArray<{ match: (id: string) => boolean; rate: ModelBaseRate }> = [
+	// --- OpenAI / Codex ---
+	// Preview models without public API pricing are deliberately omitted.
+	{ match: (id) => id.includes("gpt-5.5") && !id.includes("cyber"), rate: { input: 5, output: 30, cacheRead: 0.5 } },
+	{ match: (id) => id.includes("gpt-5.4-mini"), rate: { input: 0.75, output: 4.5, cacheRead: 0.075 } },
+	{ match: (id) => id.includes("gpt-5.4"), rate: { input: 2.5, output: 15, cacheRead: 0.25 } },
+	{
+		match: (id) => id.includes("gpt-5.3-codex") && !id.includes("spark"),
+		rate: { input: 1.75, output: 14, cacheRead: 0.175 },
+	},
+	{ match: (id) => id.includes("gpt-5.2"), rate: { input: 1.75, output: 14, cacheRead: 0.175 } },
+	{ match: (id) => id.includes("gpt-5.1-codex-mini"), rate: { input: 0.25, output: 2, cacheRead: 0.025 } },
+	{ match: (id) => id.includes("gpt-5.1"), rate: { input: 1.25, output: 10, cacheRead: 0.125 } },
+	{ match: (id) => id.includes("gpt-5-codex-mini"), rate: { input: 0.25, output: 2, cacheRead: 0.025 } },
+	{ match: (id) => id.includes("gpt-5-codex") || id === "gpt-5", rate: { input: 1.25, output: 10, cacheRead: 0.125 } },
 	// --- Anthropic / Claude ---
 	{ match: (id) => id.includes("fable-5") || id.includes("mythos-5") || id.includes("mythos-preview"), rate: { input: 10, output: 50 } },
 	// Current Opus tier (4.5 – 4.8): $5 / $25
@@ -89,7 +105,7 @@ export function resolveModelRate(modelId: string): ModelRate | null {
 		output: base.output,
 		cacheWrite5m: base.input * 1.25,
 		cacheWrite1h: base.input * 2,
-		cacheRead: base.input * 0.1,
+		cacheRead: base.cacheRead ?? base.input * 0.1,
 	};
 }
 

--- a/src/shared/rate-limits.ts
+++ b/src/shared/rate-limits.ts
@@ -2,7 +2,7 @@
  * Agent rate-limit parsing — pure functions shared by the bun process, the CLI
  * (`dev3 statusline`) and the renderer.
  *
- * Data sources (all local, no API calls):
+ * Data sources:
  * - Claude Code: the statusLine stdin JSON carries `rate_limits.{five_hour,seven_day}`
  *   with `used_percentage` + `resets_at` (unix seconds). dev3 injects a statusLine
  *   wrapper (`dev3 statusline`) via `--settings` that dumps that JSON to
@@ -11,6 +11,8 @@
  *   contain `event_msg`/`token_count` events with a `rate_limits` object
  *   (`primary`/`secondary` windows + `credits`). Windows may be null on
  *   usage-based/enterprise plans.
+ * - Codex monthly credits: a read-only `account/rateLimits/read` request to the
+ *   locally authenticated `codex app-server`; this is cached and optional.
  */
 
 export type RateLimitSource = "claude" | "codex";
@@ -26,6 +28,15 @@ export interface RateLimitWindow {
 	windowMinutes: number | null;
 }
 
+export interface MonthlyCreditLimit {
+	limit: number;
+	used: number;
+	/** Percentage remaining, as reported by Codex. */
+	remainingPercent: number;
+	/** Absolute reset time in epoch ms, when known. */
+	resetsAt: number | null;
+}
+
 export interface AgentRateLimitSnapshot {
 	source: RateLimitSource;
 	/** When this data was captured locally (epoch ms). */
@@ -33,6 +44,8 @@ export interface AgentRateLimitSnapshot {
 	windows: RateLimitWindow[];
 	/** Codex credits balance display string, when the plan exposes credits. */
 	creditsBalance: string | null;
+	/** Effective per-user monthly Codex credit limit, available from app-server. */
+	monthlyCredits: MonthlyCreditLimit | null;
 	/** Codex plan type, e.g. "enterprise_cbp_usage_based". */
 	planType: string | null;
 }
@@ -55,6 +68,15 @@ function asFiniteNumber(v: unknown): number | null {
 	return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
+function asNumeric(v: unknown): number | null {
+	if (typeof v === "number" && Number.isFinite(v)) return v;
+	if (typeof v === "string" && v.trim()) {
+		const parsed = Number(v);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return null;
+}
+
 /** Human label for a window id ("five_hour" → "5h", codex "primary" → by minutes). */
 export function windowLabel(w: RateLimitWindow): string {
 	switch (w.id) {
@@ -62,6 +84,8 @@ export function windowLabel(w: RateLimitWindow): string {
 			return "5h";
 		case "seven_day":
 			return "7d";
+		case "monthly_credits":
+			return "monthly credits";
 	}
 	if (w.windowMinutes != null) {
 		const mins = w.windowMinutes;
@@ -113,7 +137,7 @@ export function parseClaudeStatusLinePayload(payload: unknown, capturedAt: numbe
 		}
 	}
 	if (windows.length === 0) return null;
-	return { source: "claude", capturedAt, windows, creditsBalance: null, planType: null };
+	return { source: "claude", capturedAt, windows, creditsBalance: null, monthlyCredits: null, planType: null };
 }
 
 /**
@@ -150,7 +174,80 @@ export function parseCodexRateLimits(rateLimits: unknown, eventAtMs: number): Ag
 
 	const planType = typeof root.plan_type === "string" ? root.plan_type : null;
 	if (windows.length === 0 && creditsBalance == null) return null;
-	return { source: "codex", capturedAt: eventAtMs, windows, creditsBalance, planType };
+	return { source: "codex", capturedAt: eventAtMs, windows, creditsBalance, monthlyCredits: null, planType };
+}
+
+/** Parse the camelCase rateLimits object returned by Codex app-server. */
+export function parseCodexAppServerRateLimits(rateLimits: unknown, capturedAt: number): AgentRateLimitSnapshot | null {
+	const root = asRecord(rateLimits);
+	if (!root) return null;
+
+	const windows: RateLimitWindow[] = [];
+	for (const id of ["primary", "secondary"]) {
+		const win = asRecord(root[id]);
+		const usedPercent = asFiniteNumber(win?.usedPercent);
+		if (win && usedPercent != null) {
+			const resetsAtSec = asFiniteNumber(win.resetsAt);
+			windows.push({
+				id,
+				usedPercent,
+				resetsAt: resetsAtSec != null ? resetsAtSec * 1000 : null,
+				windowMinutes: asFiniteNumber(win.windowDurationMins),
+			});
+		}
+	}
+
+	const credits = asRecord(root.credits);
+	let creditsBalance: string | null = null;
+	if (credits?.hasCredits === true) {
+		creditsBalance = credits.unlimited === true ? "unlimited" : credits.balance != null ? String(credits.balance) : null;
+	}
+
+	const individual = asRecord(root.individualLimit);
+	const limit = asNumeric(individual?.limit);
+	const used = asNumeric(individual?.used);
+	const reportedRemaining = asFiniteNumber(individual?.remainingPercent);
+	let monthlyCredits: MonthlyCreditLimit | null = null;
+	if (limit != null && limit > 0 && used != null && used >= 0) {
+		const remainingPercent = reportedRemaining ?? Math.max(0, 100 - (used / limit) * 100);
+		const resetsAtSec = asFiniteNumber(individual?.resetsAt);
+		monthlyCredits = {
+			limit,
+			used,
+			remainingPercent,
+			resetsAt: resetsAtSec != null ? resetsAtSec * 1000 : null,
+		};
+		windows.push({
+			id: "monthly_credits",
+			usedPercent: Math.max(0, 100 - remainingPercent),
+			resetsAt: monthlyCredits.resetsAt,
+			windowMinutes: null,
+		});
+	}
+
+	const planType = typeof root.planType === "string" ? root.planType : null;
+	if (windows.length === 0 && creditsBalance == null) return null;
+	return { source: "codex", capturedAt, windows, creditsBalance, monthlyCredits, planType };
+}
+
+/** Merge a fresh app-server snapshot over the rollout fallback without losing rollout-only windows. */
+export function mergeCodexRateLimitSnapshots(
+	rollout: AgentRateLimitSnapshot | null,
+	live: AgentRateLimitSnapshot | null,
+): AgentRateLimitSnapshot | null {
+	if (!live) return rollout;
+	if (!rollout) return live;
+	const windows = new Map<string, RateLimitWindow>();
+	for (const window of rollout.windows) windows.set(window.id, window);
+	for (const window of live.windows) windows.set(window.id, window);
+	return {
+		source: "codex",
+		capturedAt: live.capturedAt,
+		windows: [...windows.values()],
+		creditsBalance: live.creditsBalance ?? rollout.creditsBalance,
+		monthlyCredits: live.monthlyCredits,
+		planType: live.planType ?? rollout.planType,
+	};
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2579,7 +2579,7 @@ export type AppRPCSchema = {
 			exposedPortsChanged: { taskId: string; ports: ExposedPort[] };
 			resourceUsageUpdated: { taskId: string; usage: ResourceUsage };
 			/**
-			 * Fresh agent rate-limit data (Claude statusLine dump / Codex rollouts).
+			 * Fresh agent rate-limit data (Claude dump / Codex rollouts + monthly credits).
 			 * Pushed by the rate-limit monitor whenever the parsed windows change.
 			 */
 			agentRateLimitsUpdated: AgentRateLimitsReport;


### PR DESCRIPTION
## Summary

- parse local Codex rollout token deltas into the existing agent usage feed
- add OpenAI model pricing and aggregate Claude plus Codex in Velocity Cockpit
- show live Codex monthly credit usage and reset time in Agent rate limits via cached app-server reads
- preserve rollout-only fallback when Codex, authentication, or network access is unavailable

## Tests

- bun run lint
- bun run test
- browser QA of the Agent rate limits tooltip