### PR TITLE
Deliver dev3 protocol to Codex via -c developer_instructions

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-06
 | Feature | Claude Code | Cursor Agent | Codex | Gemini CLI | OpenCode |
 |---------|:-----------:|:------------:|:-----:|:----------:|:--------:|
 | **Skill injection** | Yes (`!` command syntax) | Yes (generic) | Yes (generic) | Yes (generic) | Yes (generic) |
-| **System prompt injection** | `--append-system-prompt` | via prompt arg | via prompt arg | — | via `--prompt` |
+| **System prompt injection** | `--append-system-prompt` | via prompt arg | `-c developer_instructions=...` (developer-role message; covers scratch + resume — see decision 115) | — | via `--prompt` |
 | **Session resume** | `--continue` | `--continue` | `resume --last` | `--resume latest` | `--continue` |
 | **Permission mode** | `--permission-mode` | `--mode plan` / `--force` | `--permission-mode` | `--approval-mode` | — |
 | **Effort level** | `--effort` | — | `--effort` | — | — |
@@ -65,7 +65,7 @@ Injected into `.codex/hooks.json` and enabled via `~/.codex/config.toml` (`[feat
 The dev3 skill (`SKILL.md`) is installed into each agent's skill directory. Three variants exist:
 
 - **Claude variant** — deliberately short: the full protocol body is already injected into the system prompt via `--append-system-prompt`, so `SKILL.md` only auto-sets the status and shows `dev3 current --brief` (via `!` command injection, zero tool calls). The full body is written to `PROTOCOL.md` next to it as a fallback for sessions started outside the dev3 launcher. See decision 114.
-- **Codex variant** — full body (load-bearing for scratch tasks, which get no prompt injection); hook-aware status section with manual fallback for older sessions, keeps the `/bin/bash` shell note
+- **Codex variant** — full body; hook-aware status section with manual fallback for older sessions, keeps the `/bin/bash` shell note. The same body is also injected out-of-band as a developer message via `-c developer_instructions=...` on every dev3 launch, including scratch tasks and resume (decision 115); the skill file remains the fallback for sessions started outside the dev3 launcher
 - **Generic variant** — full body (for Gemini it is the only protocol channel); full manual status management instructions ("CRITICAL — NON-NEGOTIABLE"), requires agents to run `dev3 task move` at start/end of every turn
 
 ### dev3-project-config (project configuration)

--- a/change-logs/2026/07/08/feature-codex-developer-instructions.md
+++ b/change-logs/2026/07/08/feature-codex-developer-instructions.md
@@ -1,0 +1,1 @@
+Codex now receives the dev3 task-lifecycle protocol as a developer-role message via the `-c developer_instructions=...` config override instead of having it appended to the first user prompt. This keeps the opening message clean and, more importantly, delivers the protocol on scratch tasks (empty prompt) and resumed sessions, which previously got no injection at all.

--- a/decisions/115-codex-developer-instructions-injection.md
+++ b/decisions/115-codex-developer-instructions-injection.md
@@ -1,0 +1,24 @@
+# 115 — Deliver the dev3 protocol to Codex via `-c developer_instructions=...`
+
+## Context
+
+Codex CLI has no `--append-system-prompt` (an upstream PR adding one was closed unmerged). Until now the dev3 protocol reached Codex only by appending `CODEX_SKILL_BODY` to the turn-1 user prompt (`buildAgentCommand` in `src/bun/agents.ts`), which (a) polluted the first user message, (b) delivered nothing on scratch tasks (empty prompt → no append, protocol adherence relied solely on the skill file + hooks), and (c) delivered nothing on `codex resume`.
+
+## Investigation
+
+Codex 0.143.0 supports a top-level `developer_instructions` config key (verified in the binary and in codex-rs sources: "Developer instructions that **supplement** the base instructions"). It is injected as a `role=developer` message — above user/AGENTS.md, below system. `-c key=value` parses the value as TOML; a JSON-stringified string is a valid TOML basic string, so multi-line bodies with quotes/backticks survive (verified end-to-end with `codex exec` marker tests). `codex resume` accepts `-c` as well. `model_instructions_file` was rejected: it REPLACES Codex's built-in base instructions rather than supplementing them.
+
+## Decision
+
+In `buildAgentCommand` (src/bun/agents.ts), for Codex launches (unless `skipSystemPrompt`): push `-c developer_instructions=<JSON.stringify(CODEX_SKILL_BODY)>` on both fresh and resume commands, and stop appending the body to the user prompt (Cursor/OpenCode keep the prompt-append fallback). This closes the scratch-task and resume gaps and keeps the turn-1 message clean.
+
+## Risks
+
+- `developer_instructions` set via `-c` overrides a user's own `developer_instructions` from `~/.codex/config.toml` for dev3-launched sessions (config override precedence).
+- The key is version-gated: older codex builds ignore unknown config keys silently (we don't pass `--strict-config`), so on very old codex the protocol falls back to skill file + hooks — same as the previous scratch-task behavior, no crash.
+
+## Alternatives considered
+
+- Keep prompt-append (status quo): leaves scratch/resume uncovered, pollutes turn 1.
+- `model_instructions_file`: replaces the entire base prompt — maintenance trap, rejected.
+- AGENTS.md injection: lands as user-level instructions, weaker priority than developer role.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -194,19 +194,47 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("--model 'claude-opus-4-8[1m]'");
 	});
 
-	it("Codex: injects the dev3 reminder into new-session prompts", () => {
+	it("Codex: injects the dev3 protocol via -c developer_instructions, not the prompt", () => {
 		const cmd = resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
 		);
 
-		// Codex skill body includes the hook-aware status section and the
-		// codex shell note (`shell="/bin/bash"`).
+		// Protocol is delivered as a developer-role message via config override.
+		// The value is a JSON-stringified TOML basic string, so inner double
+		// quotes appear escaped (shell="/bin/bash" → shell=\"/bin/bash\").
+		expect(cmd).toContain("-c 'developer_instructions=");
 		expect(cmd).toContain("Task Lifecycle Protocol");
 		expect(cmd).toContain("Codex sessions started after the dev3 config was installed");
-		expect(cmd).toContain("shell=\"/bin/bash\"");
+		expect(cmd).toContain('shell=\\"/bin/bash\\"');
 		expect(cmd).toContain("user-questions");
+		// The user prompt stays clean — no skill body appended to it.
+		expect(cmd).toContain("-- 'Some task'");
+	});
+
+	it("Codex: resume also carries -c developer_instructions", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "Some task" }),
+			{ resume: true },
+		);
+
+		expect(cmd).toMatch(/^codex resume --last/);
+		expect(cmd).toContain("-c 'developer_instructions=");
+	});
+
+	it("Codex: skipSystemPrompt suppresses -c developer_instructions", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({ model: undefined }),
+			makeCtx({ taskDescription: "Some task" }),
+			{ skipSystemPrompt: true },
+		);
+
+		expect(cmd).not.toContain("developer_instructions");
+		expect(cmd).not.toContain("Task Lifecycle Protocol");
 	});
 
 	it("Codex: uses dracula theme when dev3 UI theme is dark", () => {
@@ -493,17 +521,19 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 	// auto-ran as turn 1. With an empty prompt it must NOT be injected, so the
 	// agent opens an empty interactive window (matching Claude).
 
-	it("Codex: empty description → no positional prompt, no system prompt injected", () => {
+	it("Codex: empty description → no positional prompt; protocol still arrives via -c", () => {
 		const cmd = resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "" }),
 		);
 
-		expect(cmd).not.toContain("Task Lifecycle Protocol");
-		expect(cmd).not.toContain("shell=\"/bin/bash\"");
+		// No positional prompt — codex opens an empty interactive window …
 		expect(cmd).not.toMatch(/ -- /);
-		expect(cmd).toBe("codex");
+		// … but the protocol is still delivered out-of-band (developer message),
+		// which is exactly what scratch tasks were missing with prompt-append.
+		expect(cmd).toContain("-c 'developer_instructions=");
+		expect(cmd).toContain("Task Lifecycle Protocol");
 	});
 
 	it("Cursor Agent: empty description → no positional prompt, no system prompt injected", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -295,7 +295,10 @@ export const DEV3_SYSTEM_PROMPT_GENERIC = GENERIC_SKILL_BODY;
 
 /**
  * Codex skill body. Uses hook-aware status section and includes the Codex
- * shell note (`shell="/bin/bash"`, `login=false`).
+ * shell note (`shell="/bin/bash"`, `login=false`). Delivered out-of-band as a
+ * developer-role message via `-c developer_instructions=...` (additive — it
+ * supplements Codex's base instructions, unlike `model_instructions_file`
+ * which would REPLACE them).
  */
 export const DEV3_SYSTEM_PROMPT_CODEX = CODEX_SKILL_BODY;
 
@@ -412,7 +415,8 @@ export interface CommandOptions {
 	 *  support targeted resume (e.g. Claude --resume <id>) use this instead of
 	 *  --continue. For fresh launches, Claude uses --session-id <id>. */
 	sessionId?: string;
-	/** When true, skip injecting the DEV3_SYSTEM_PROMPT via --append-system-prompt.
+	/** When true, skip injecting the dev3 protocol out-of-band (Claude:
+	 *  --append-system-prompt; Codex: `-c developer_instructions=...`).
 	 *  Used for review agents that rely on hooks instead of system-prompt instructions. */
 	skipSystemPrompt?: boolean;
 	/** Path to the generated settings file that routes the Claude statusLine
@@ -587,6 +591,15 @@ export function resolveAgentCommand(
 
 	if (codexAgent) {
 		applyCodexThemeProfile(args);
+		// Codex has no --append-system-prompt; deliver the dev3 protocol as a
+		// developer-role message via the `-c developer_instructions=...` config
+		// override instead. Unlike the old prompt-append this also covers scratch
+		// launches (empty prompt) and resumed sessions, and keeps the turn-1 user
+		// message clean. JSON.stringify emits a valid TOML basic string, which is
+		// what `-c` expects for the value portion.
+		if (!options?.skipSystemPrompt) {
+			args.push("-c", shellEscape(`developer_instructions=${JSON.stringify(DEV3_SYSTEM_PROMPT_CODEX)}`));
+		}
 	}
 
 	// When resuming, skip the prompt — we don't want to inject a new
@@ -603,19 +616,16 @@ export function resolveAgentCommand(
 
 		// Cursor Agent / OpenCode have no --append-system-prompt and no automatic
 		// hooks, so inject the generic system prompt via the prompt argument.
-		// Codex also gets a prompt reminder because skill loading is not guaranteed.
+		// (Codex gets the protocol out-of-band via `-c developer_instructions=...`
+		// above, so its prompt stays clean.)
 		//
 		// Only append it when there is an actual task prompt. On scratch / empty
 		// description launches we keep the prompt empty so the agent opens an
 		// interactive window instead of auto-running the system prompt as turn 1
 		// (matching Claude, which delivers it out-of-band). Protocol adherence
 		// then relies on the auto-installed dev3 skill + hooks.
-		if (prompt) {
-			if (codexAgent) {
-				prompt = `${prompt}\n\n${DEV3_SYSTEM_PROMPT_CODEX}`;
-			} else if (cursorAgent || openCodeAgent) {
-				prompt = `${prompt}\n\n${DEV3_SYSTEM_PROMPT_GENERIC}`;
-			}
+		if (prompt && (cursorAgent || openCodeAgent)) {
+			prompt = `${prompt}\n\n${DEV3_SYSTEM_PROMPT_GENERIC}`;
 		}
 
 		if (prompt) {


### PR DESCRIPTION
Hi, Claude here — the AI agent working on this branch.

## Summary

Codex CLI has no `--append-system-prompt`, so until now the dev3 task-lifecycle protocol reached Codex only by appending the skill body to the turn-1 user prompt. That polluted the first message and — worse — delivered nothing at all on scratch tasks (empty prompt) and on `codex resume`.

This PR injects `CODEX_SKILL_BODY` as a **developer-role message** via the `-c developer_instructions=<TOML string>` config override instead:

- Verified end-to-end against codex 0.143.0 (`codex exec` marker tests, incl. a multi-line body with quotes/backticks; `codex resume` accepts `-c` too).
- `developer_instructions` *supplements* Codex's base instructions (per codex-rs sources) — unlike `model_instructions_file`, which would replace them.
- Applied on both fresh and resume launches; respects `skipSystemPrompt` (column/review agents).
- Cursor/OpenCode keep the prompt-append fallback; Claude is unchanged.
- Older codex builds silently ignore the unknown key → graceful fallback to skill file + hooks.

Details in `decisions/115-codex-developer-instructions-injection.md`.