### PR TITLE
Fix Codex diff colors across dev3 themes

### DIFF
--- a/change-logs/2026/07/08/fix-codex-dark-theme-diff-colors.md
+++ b/change-logs/2026/07/08/fix-codex-dark-theme-diff-colors.md
@@ -1,1 +1,1 @@
-Fixed Codex tool-call diffs in the dark theme by replacing its glaring GitHub-light red and green backgrounds with muted dark variants while preserving readable syntax colors.
+Fixed Codex terminal colors by launching it with GitHub in the light theme and Dracula in the dark theme, while preserving user configuration outside dev3. A renderer fallback also replaces legacy glaring GitHub-light diff backgrounds with muted dark variants and readable syntax colors.

--- a/change-logs/2026/07/08/fix-codex-dark-theme-diff-colors.md
+++ b/change-logs/2026/07/08/fix-codex-dark-theme-diff-colors.md
@@ -1,0 +1,1 @@
+Fixed Codex tool-call diffs in the dark theme by replacing its glaring GitHub-light red and green backgrounds with muted dark variants while preserving readable syntax colors.

--- a/decisions/115-codex-theme-launch-override.md
+++ b/decisions/115-codex-theme-launch-override.md
@@ -1,0 +1,21 @@
+# 115 — Select the Codex syntax theme at launch
+
+## Context
+
+dev3 already selects `dev3-light` or `dev3-dark` profiles, but Codex 0.130 rejected `tui.theme` inside those profiles and the managed values were disabled. A user's global `[tui] theme` could therefore pin a light syntax theme while dev3 rendered a dark terminal, producing glaring diff backgrounds.
+
+## Investigation
+
+Current Codex exposes `tui.theme` as a root config value and accepts root config overrides through repeated `-c key=value` launch arguments. Codex themes can also provide `markup.inserted` and `markup.deleted` backgrounds, so selecting the compatible theme at the source is more reliable than translating every possible theme palette in the PTY stream.
+
+## Decision
+
+`applyCodexThemeProfile()` in `src/bun/agents.ts` continues selecting the theme-specific dev3 profile, then appends `-c 'tui.theme="github"'` for light mode or `-c 'tui.theme="dracula"'` for dark mode. The override is appended after preset `additionalArgs`, making the dev3 UI theme authoritative without rewriting the user's global Codex config.
+
+## Risks
+
+Using `/theme` can still change the active Codex session, but the next dev3 launch restores the app-matched theme. Codex sessions launched outside dev3 keep the user's global theme unchanged; older Codex versions that do not understand `tui.theme` remain a compatibility risk, mitigated by the same root setting having existed before profile-based theme injection.
+
+## Alternatives considered
+
+Putting `tui.theme` back into managed profiles was rejected because affected Codex versions reject that schema. Rewriting the user's global config was rejected because it would change unrelated Codex sessions, and relying only on terminal background detection was rejected because an explicit global syntax theme can override adaptive defaults and supply its own diff backgrounds.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -248,6 +248,7 @@ describe("resolveAgentCommand — resume", () => {
 
 		expect(cmd).toContain("-p dev3-dark");
 		expect(cmd).not.toContain("-p dev3 ");
+		expect(cmd).toContain(`-c 'tui.theme="dracula"'`);
 	});
 
 	it("Codex: uses github theme when dev3 UI theme is light", () => {
@@ -261,6 +262,33 @@ describe("resolveAgentCommand — resume", () => {
 
 		expect(cmd).toContain("-p dev3-light");
 		expect(cmd).not.toContain("-p dev3 ");
+		expect(cmd).toContain(`-c 'tui.theme="github"'`);
+	});
+
+	it("Codex: preserves unrelated config overrides when injecting the theme", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({
+				model: undefined,
+				additionalArgs: ["-p", "dev3", "-c", 'model_reasoning_effort="high"'],
+			}),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd).toContain(`-c model_reasoning_effort="high" -c 'tui.theme="dracula"'`);
+	});
+
+	it("Codex: appends the dev3 theme after a conflicting user override", () => {
+		const cmd = resolveAgentCommand(
+			makeAgent({ baseCommand: "codex" }),
+			makeConfig({
+				model: undefined,
+				additionalArgs: ["-p", "dev3", "-c", 'tui.theme="nord"'],
+			}),
+			makeCtx({ taskDescription: "Some task" }),
+		);
+
+		expect(cmd.indexOf('tui.theme="nord"')).toBeLessThan(cmd.indexOf('tui.theme="dracula"'));
 	});
 
 	it("Codex: leaves custom profile names untouched", () => {
@@ -534,6 +562,7 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 		// which is exactly what scratch tasks were missing with prompt-append.
 		expect(cmd).toContain("-c 'developer_instructions=");
 		expect(cmd).toContain("Task Lifecycle Protocol");
+		expect(cmd).toContain(`-c 'tui.theme="dracula"'`);
 	});
 
 	it("Cursor Agent: empty description → no positional prompt, no system prompt injected", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -9,7 +9,7 @@ import { createLogger } from "./logger";
 import { detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
 import { DEV3_HOME } from "./paths";
 import { loadSettings, saveSettings } from "./settings";
-import { getCodexProfileForCurrentUiTheme } from "./theme-state";
+import { getCodexProfileForCurrentUiTheme, getCodexThemeForCurrentUiTheme } from "./theme-state";
 import { ensureClaudeStatusLineSettings } from "./rate-limit-monitor";
 import { getActiveClaudeConfigDir, getActiveClaudeSessionEnv } from "./agent-accounts";
 import { ENV_UNSET } from "../shared/agent-accounts";
@@ -430,9 +430,17 @@ function applyCodexThemeProfile(args: string[]): void {
 			// Passing `--profile-v2` to a newer codex aborts with exit 2.
 			// See decision 055 + issue #611.
 			if (launchFlag === "--profile-v2") args[i] = "--profile-v2";
-			return;
+			break;
 		}
 	}
+
+	// Codex 0.130 rejected `tui.theme` inside config profiles, so keep the
+	// managed profiles focused on permissions/web search and select the visual
+	// theme through the supported per-launch config override instead. Append it
+	// after additionalArgs so every dev3 Codex session follows the active app
+	// theme even when the user's global config or preset selects another theme.
+	const theme = getCodexThemeForCurrentUiTheme();
+	args.push("-c", shellEscape(`tui.theme="${theme}"`));
 }
 
 export interface CommandOptions {

--- a/src/mainview/utils/__tests__/ansi-theme-adapt.test.ts
+++ b/src/mainview/utils/__tests__/ansi-theme-adapt.test.ts
@@ -290,6 +290,31 @@ describe("createAnsiThemeFilter — white backgrounds (dark)", () => {
 	});
 });
 
+describe("createAnsiThemeFilter — Codex diff backgrounds (dark)", () => {
+	it("replaces GitHub-light removal and addition backgrounds with dark diff colors", () => {
+		expect(filterAll([`${ESC}[48;2;255;221;221mremoved`], "dark")).toBe(
+			`${ESC}[48;2;63;37;42mremoved`,
+		);
+		expect(filterAll([`${ESC}[48;2;221;255;221madded`], "dark")).toBe(
+			`${ESC}[48;2;36;61;46madded`,
+		);
+	});
+
+	it("brightens GitHub-light code foregrounds on remapped diff backgrounds", () => {
+		expect(
+			filterAll([`${ESC}[48;2;255;221;221;38;2;51;51;51mremoved`], "dark"),
+		).toBe(`${ESC}[48;2;63;37;42;38;2;108;108;108mremoved`);
+		expect(
+			filterAll([`${ESC}[48;2;221;255;221m${ESC}[38;2;24;54;145madded`], "dark"),
+		).toMatch(/^\x1b\[48;2;36;61;46m\x1b\[38;2;\d+;\d+;\d+madded$/);
+	});
+
+	it("keeps Codex GitHub-light diff backgrounds unchanged in light mode", () => {
+		const input = `${ESC}[48;2;255;221;221mremoved${ESC}[48;2;221;255;221madded`;
+		expect(filterAll([input], "light")).toBe(input);
+	});
+});
+
 describe("createAnsiThemeFilter — bg/reverse gating", () => {
 	it("does not adjust fg while an explicit background is active (dark)", () => {
 		const input = `${ESC}[44m${ESC}[38;2;51;51;51mfoo`;

--- a/src/mainview/utils/ansi-theme-adapt.ts
+++ b/src/mainview/utils/ansi-theme-adapt.ts
@@ -34,7 +34,10 @@
  *   pale lavender — default-fg text on it is unreadable. The remap targets
  *   Claude Code's own dark theme bar colors (55/70), and explicit dark ANSI
  *   foregrounds (30/90) on those bars are flipped to light grays so
- *   dark-text-on-white bars stay legible as light-text-on-dark bars.
+ *   dark-text-on-white bars stay legible as light-text-on-dark bars. Codex's
+ *   GitHub-light diff backgrounds are remapped to muted dark red/green and
+ *   then treated as dark backgrounds so its light-theme code foregrounds are
+ *   brightened by the same contrast path.
  * Foreground adjustment is gated by the *luminance* of the active explicit
  * background: a fg chosen for an opposite-polarity bg (vim themes, highlight
  * bars) passes through untouched, but a bad-contrast fg on a same-polarity
@@ -129,6 +132,33 @@ const DARK_BRIGHT_WHITE_BG = ["48", "2", "70", "70", "70"];
 // Light replacements for dark ANSI fg (30/90) on a dark-remapped white bar
 const DARK_BAR_FG_30 = ["38", "2", "220", "220", "220"];
 const DARK_BAR_FG_90 = ["38", "2", "160", "160", "160"];
+
+// Codex renders tool-call diffs with GitHub-light backgrounds even after it
+// correctly learns that the terminal background is dark. Match only the two
+// observed source colors so unrelated app-owned highlight backgrounds retain
+// their intended polarity.
+const CODEX_LIGHT_DIFF_REMOVAL_BG = [255, 221, 221] as const;
+const CODEX_LIGHT_DIFF_ADDITION_BG = [221, 255, 221] as const;
+const CODEX_DARK_DIFF_REMOVAL_BG = ["48", "2", "63", "37", "42"];
+const CODEX_DARK_DIFF_ADDITION_BG = ["48", "2", "36", "61", "46"];
+
+function codexDarkDiffBgReplacement(r: number, g: number, b: number): string[] | null {
+	if (
+		r === CODEX_LIGHT_DIFF_REMOVAL_BG[0] &&
+		g === CODEX_LIGHT_DIFF_REMOVAL_BG[1] &&
+		b === CODEX_LIGHT_DIFF_REMOVAL_BG[2]
+	) {
+		return CODEX_DARK_DIFF_REMOVAL_BG;
+	}
+	if (
+		r === CODEX_LIGHT_DIFF_ADDITION_BG[0] &&
+		g === CODEX_LIGHT_DIFF_ADDITION_BG[1] &&
+		b === CODEX_LIGHT_DIFF_ADDITION_BG[2]
+	) {
+		return CODEX_DARK_DIFF_ADDITION_BG;
+	}
+	return null;
+}
 
 // Emulated dim foreground. ghostty renders SGR dim as 50% alpha, which is too
 // faint to read on dark and washes out on white; full intensity (dropping dim)
@@ -368,12 +398,17 @@ function transformSgrParams(raw: string, mode: ThemeMode, gate: GateState): stri
 			}
 			if (introducer === "2" && tokens[i + 4] !== undefined) {
 				if (token === "48") {
-					gate.bg = classifyBgRgb(
-						Number(tokens[i + 2]),
-						Number(tokens[i + 3]),
-						Number(tokens[i + 4]),
-					);
-					out.push(token, tokens[i + 1], tokens[i + 2], tokens[i + 3], tokens[i + 4]);
+					const r = Number(tokens[i + 2]);
+					const g = Number(tokens[i + 3]);
+					const b = Number(tokens[i + 4]);
+					const codexDiffBg = mode === "dark" ? codexDarkDiffBgReplacement(r, g, b) : null;
+					if (codexDiffBg !== null) {
+						gate.bg = "dark";
+						out.push(...codexDiffBg);
+					} else {
+						gate.bg = classifyBgRgb(r, g, b);
+						out.push(token, tokens[i + 1], tokens[i + 2], tokens[i + 3], tokens[i + 4]);
+					}
 					restorePendingFg();
 					i += 5;
 					continue;


### PR DESCRIPTION
## Summary

- Launch Codex with GitHub in dev3 light mode and Dracula in dev3 dark mode using a per-launch config override.
- Preserve the user's global Codex theme and existing preset config overrides.
- Remap legacy GitHub-light diff backgrounds to muted dark red and green as a renderer fallback.
- Add regression coverage for theme selection, override precedence, scratch sessions, foreground contrast, and light-mode passthrough.

## Why

Codex could remain pinned to a light syntax theme while dev3 rendered a dark terminal, producing glaring pastel diff backgrounds. Theme selection inside managed Codex profiles is rejected by affected Codex versions, so dev3 now applies the compatible theme at launch and retains the ANSI filter as a compatibility safety net.

## Testing

- `bun run lint`
- `bun run test` — 4,835 tests passed after rebasing onto `origin/main`
- Browser QA with Codex 0.143.0 confirmed `dracula (current)` and dark diff preview colors
