### PR TITLE
Fix scheduled task board refresh

### DIFF
--- a/change-logs/2026/07/09/fix-live-scheduled-task-refresh.md
+++ b/change-logs/2026/07/09/fix-live-scheduled-task-refresh.md
@@ -1,0 +1,1 @@
+Scheduled task launches now stay visible when their live update races the project board's initial task load.

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type Dispatch, type MutableRefObject } from "react";
+import { useEffect, useRef, type Dispatch, type MutableRefObject } from "react";
 import type { CodingAgent, PortInfo, Project, Task, ResourceUsage } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import type { NavigationGuard } from "../navigation-guard";
@@ -51,16 +51,34 @@ function ProjectView({
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const inlineDiff = useTaskInlineDiffState(activeTaskId);
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
+	const taskUpdateEpochRef = useRef(0);
+
+	// A scheduled launch can push its new task while this view's initial fetch is
+	// in flight. Keep the live update instead of letting the older disk snapshot
+	// overwrite it when the request returns.
+	useEffect(() => {
+		function onTaskUpdated(e: Event) {
+			const { task } = (e as CustomEvent<{ task: Task }>).detail;
+			if (task?.projectId === projectId) taskUpdateEpochRef.current += 1;
+		}
+		window.addEventListener("rpc:taskUpdated", onTaskUpdated);
+		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
+	}, [projectId]);
 
 	useEffect(() => {
+		const taskUpdateEpoch = taskUpdateEpochRef.current;
+		let cancelled = false;
 		(async () => {
 			try {
 				const tasks = await api.request.getTasks({ projectId });
-				dispatch({ type: "setTasks", tasks });
+				if (!cancelled && taskUpdateEpoch === taskUpdateEpochRef.current) {
+					dispatch({ type: "setTasks", tasks });
+				}
 			} catch (err) {
 				console.error("Failed to load tasks:", err);
 			}
 		})();
+		return () => { cancelled = true; };
 	}, [projectId, dispatch]);
 
 	useEffect(() => {

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -56,6 +56,27 @@ function renderView(props: Partial<React.ComponentProps<typeof ProjectView>>) {
 describe("ProjectView task-view layout", () => {
 	beforeEach(() => vi.clearAllMocks());
 
+	it("does not replace a pushed scheduled task with an older initial task snapshot", async () => {
+		let resolveTasks: (tasks: Task[]) => void;
+		const pendingTasks = new Promise<Task[]>((resolve) => {
+			resolveTasks = resolve;
+		});
+		const { api } = await import("../../rpc");
+		vi.mocked(api.request.getTasks).mockReturnValueOnce(pendingTasks);
+		const dispatch = vi.fn();
+
+		renderView({ dispatch });
+		await waitFor(() => expect(api.request.getTasks).toHaveBeenCalledWith({ projectId: "p1" }));
+
+		window.dispatchEvent(new CustomEvent("rpc:taskUpdated", {
+			detail: { task: { id: "scheduled-task", projectId: "p1" } },
+		}));
+		resolveTasks!([]);
+
+		await Promise.resolve();
+		expect(dispatch).not.toHaveBeenCalledWith({ type: "setTasks", tasks: [] });
+	});
+
 	it("shows the empty-terminal placeholder when taskView is set but no task is selected", async () => {
 		renderView({ taskView: true });
 		await waitFor(() => expect(screen.getByTestId("sidebar")).toBeInTheDocument());


### PR DESCRIPTION
## Summary
- preserve live task updates when the project board's initial task load is still in flight
- prevent scheduled task launches from disappearing until the board is revisited
- add a regression test for the push-versus-initial-load race

## Validation
- bun run lint
- bun run test