### PR TITLE
Fix GA4 Page path empty: send page_location as https URL

### DIFF
--- a/change-logs/2026/07/09/fix-ga-page-location-https-scheme.md
+++ b/change-logs/2026/07/09/fix-ga-page-location-https-scheme.md
@@ -1,0 +1,1 @@
+Fixed GA4 "Page path" being empty by sending page_location as a real https URL (https://dev3.local/app/...) instead of the custom app:// scheme, which GA4's URL parser cannot turn into a Page path. Page titles were already arriving; only the derived path dimension was affected.

--- a/decisions/114-ga-page-paths-use-project-id-not-name.md
+++ b/decisions/114-ga-page-paths-use-project-id-not-name.md
@@ -8,6 +8,16 @@ Measurement Protocol (`src/mainview/analytics.ts`). The marketing landing page
 paths (`/project/<x>/kanban`, `/task/<id>`, `/diff/<id>`) instead of the old flat
 `app://dev3/<screen>`, and to tell app hits apart from landing-page hits.
 
+## Update — page_location must be a real https URL
+
+The first cut built `page_location` as `app://dev3<path>`. GA4 derives the **Page
+path** dimension by parsing `page_location` as a URL, but only for `http(s)` — a
+custom scheme leaves Page path "(not set)" (page_title, sent explicitly, still
+arrived, which masked it). Fixed by emitting `https://dev3.local<path>`
+(`APP_LOCATION_ORIGIN` in `analytics.ts`); the synthetic host stays distinct from
+the landing host so the two remain separable. A regression test asserts
+`new URL(page_location).protocol === "https:"`.
+
 ## Decision
 
 `analyticsLocationForRoute(route, taskLabel?)` maps every `Route` to an

--- a/src/mainview/__tests__/analytics.test.ts
+++ b/src/mainview/__tests__/analytics.test.ts
@@ -417,21 +417,32 @@ describe("trackPageView / trackDiffView", () => {
 		trackPageView({ screen: "task", projectId: "p1", taskId: "hash-xyz" }, "981-1");
 		const hit = gaHits(fetchMock)[0];
 		expect(hit.events[0].name).toBe("page_view");
-		expect(hit.events[0].params.page_location).toBe("app://dev3/app/project/p1/task/981-1");
+		expect(hit.events[0].params.page_location).toBe("https://dev3.local/app/project/p1/task/981-1");
 		expect(hit.events[0].params.page_title).toBe("Task");
 	});
 
 	it("falls back to the raw task id when no seq label is available", () => {
 		trackPageView({ screen: "task", projectId: "p1", taskId: "hash-xyz" });
 		const hit = gaHits(fetchMock)[0];
-		expect(hit.events[0].params.page_location).toBe("app://dev3/app/project/p1/task/hash-xyz");
+		expect(hit.events[0].params.page_location).toBe("https://dev3.local/app/project/p1/task/hash-xyz");
 	});
 
 	it("emits a diff page_view under /app/project/<id>/diff/<seqLabel>", () => {
 		trackDiffView("p1", "981-1");
 		const hit = gaHits(fetchMock)[0];
 		expect(hit.events[0].name).toBe("page_view");
-		expect(hit.events[0].params.page_location).toBe("app://dev3/app/project/p1/diff/981-1");
+		expect(hit.events[0].params.page_location).toBe("https://dev3.local/app/project/p1/diff/981-1");
+	});
+
+	// Regression guard: GA4 only derives the "Page path" dimension when
+	// page_location is a real http(s) URL. A custom scheme (the old app://dev3)
+	// left Page path "(not set)". Keep page_location parseable as https.
+	it("emits a page_location that parses as an https URL (Page path works)", () => {
+		trackPageView({ screen: "dashboard" });
+		const loc = gaHits(fetchMock)[0].events[0].params.page_location as string;
+		const url = new URL(loc);
+		expect(url.protocol).toBe("https:");
+		expect(url.pathname).toBe("/app/dashboard");
 	});
 });
 

--- a/src/mainview/analytics.ts
+++ b/src/mainview/analytics.ts
@@ -364,9 +364,17 @@ export function analyticsLocationForRoute(route: Route, taskLabel?: string): Ana
 	}
 }
 
-/** Build a full GA4 `page_location` from an /app path (host stays `dev3`). */
+// Synthetic host for the desktop/browser app's page_location. GA4 derives the
+// "Page path" dimension by parsing page_location as a URL — but ONLY when it is a
+// real http(s) URL; a custom scheme (the old `app://dev3/…`) leaves Page path
+// "(not set)" even though page_title still arrives. Kept distinct from the
+// landing page host (dev3.h0x91b.com) so the two are separable in the shared
+// GA4 property (the `/app` path prefix separates them too).
+const APP_LOCATION_ORIGIN = "https://dev3.local";
+
+/** Build a full GA4 `page_location` (a parseable https URL) from an /app path. */
 function pageLocation(path: string): string {
-	return `app://dev3${path}`;
+	return `${APP_LOCATION_ORIGIN}${path}`;
 }
 
 /**


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — follow-up fix to #868.

**Symptom:** in GA4 the "Page path and screen class" report (incl. Realtime) shows *No data available*, even though "Views by Page title" correctly lists Task / Kanban / Dashboard.

**Cause:** GA4 derives the Page path dimension by parsing `page_location` as a URL — but only when it's a real `http(s)` URL. We were sending the custom scheme `app://dev3/…`, which GA4's parser can't turn into a path, so Page path stayed "(not set)". `page_title` is sent explicitly as a param, which is why it arrived and masked the issue.

**Fix:** emit `page_location` as `https://dev3.local<path>` (new `APP_LOCATION_ORIGIN`). The synthetic host is kept distinct from the landing host (`dev3.h0x91b.com`) so the two stay separable in the shared property; the `/app` path prefix and task seq labels are unchanged. Added a regression test asserting `page_location` parses as an `https:` URL.

Full suite + type-check green.