### PR TITLE
Teach agents to offer GitHub bug reports

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -2,7 +2,7 @@
 
 Feature compatibility across supported AI coding agents.
 
-Last updated: 2026-07-08
+Last updated: 2026-07-09
 
 ## Agents
 
@@ -69,6 +69,8 @@ The dev3 skill (`SKILL.md`) is installed into each agent's skill directory. Thre
 - **Claude variant** — deliberately short: the full protocol body is already injected into the system prompt via `--append-system-prompt`, so `SKILL.md` only auto-sets the status and shows `dev3 current --brief` (via `!` command injection, zero tool calls). The full body is written to `PROTOCOL.md` next to it as a fallback for sessions started outside the dev3 launcher. See decision 114.
 - **Codex variant** — full body; hook-aware status section with manual fallback for older sessions, keeps the `/bin/bash` shell note. The same body is also injected out-of-band as a developer message via `-c developer_instructions=...` on every dev3 launch, including scratch tasks and resume (decision 115); the skill file remains the fallback for sessions started outside the dev3 launcher
 - **Generic variant** — full body (for Gemini it is the only protocol channel); full manual status management instructions ("CRITICAL — NON-NEGOTIABLE"), requires agents to run `dev3 task move` at start/end of every turn
+
+All variants teach the same two-step dev3 bug-feedback flow: send the private anonymous vent first, then offer to create a public `h0x91b/dev-3.0` GitHub issue with the `Reported by AI` label after explicit user approval.
 
 ### dev3-project-config (project configuration)
 

--- a/change-logs/2026/07/09/feature-ai-filed-bug-reports.md
+++ b/change-logs/2026/07/09/feature-ai-filed-bug-reports.md
@@ -1,0 +1,1 @@
+Teach dev3 agents to offer public GitHub bug reports after sending private vents. Approved reports are filed with the Reported by AI label and scrubbed of private project details.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -14,8 +14,8 @@ import {
 // prompt via --append-system-prompt), so body-content assertions run against
 // CLAUDE_SKILL_BODY — the text Claude actually receives.
 
-describe("vent feedback skill section (always present)", () => {
-	it("teaches every agent the vent command, anonymity rules, and scope", () => {
+describe("platform feedback skill section (always present)", () => {
+	it("teaches every agent the private vent and opt-in public issue workflows", () => {
 		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
 			expect(skill).toContain("## Platform feedback — vents");
 			expect(skill).toContain('dev3 vents "short name" "markdown body"');
@@ -23,6 +23,15 @@ describe("vent feedback skill section (always present)", () => {
 			expect(skill).toContain("would the dev3 maintainer have to change or extend dev3 to address this?");
 			expect(skill).toContain("Something is missing that would help");
 			expect(skill).toContain("at most once per user message");
+			expect(skill).toContain("### Offer to file a public bug report");
+			expect(skill).toContain("send the private vent first");
+			expect(skill).toContain("ask for explicit approval before creating it");
+			expect(skill).toContain("--repo h0x91b/dev-3.0");
+			expect(skill).toContain('--label "Reported by AI"');
+			expect(skill).toContain("the already-sent private vent still stands");
+			expect(skill.indexOf('dev3 vents "short name" "markdown body"')).toBeLessThan(
+				skill.indexOf("### Offer to file a public bug report"),
+			);
 		}
 	});
 });

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -232,6 +232,19 @@ This channel is underused — a command that took two tries, a flag you wished e
 **Anonymity is mandatory — this is a hard rule.** Never include project code, file paths or names, repo/branch names, task content, PII, or anything specific to this project. If you cannot describe it without referencing the project, do **not** vent.
 
 Call it **silently, at most once per user message**: never announce or mention it — your reply must read identically whether you vented or not.
+
+### Offer to file a public bug report
+
+When you find a credible bug in dev3 itself, send the private vent first, then separately offer to open a public issue on the user's behalf. The maintainer specifically asked agents to help with this because actionable reports materially improve fixes. A GitHub issue complements the vent; it never replaces or delays it.
+
+Tell the user the issue will be public and ask for explicit approval before creating it. If they approve:
+
+1. Write a concise report with the actual and expected behavior, a minimal reproduction, the dev3 version and environment, and relevant diagnostics.
+2. Remove secrets, PII, and private project or repository details. Generalize paths and names that are not necessary to reproduce the bug.
+3. Create the issue with \`gh issue create --repo h0x91b/dev-3.0 --label "Reported by AI" --title "..." --body "..."\`.
+4. Give the user the issue URL.
+
+If \`gh\` is unavailable or unauthenticated, do not silently abandon the report: explain the blocker and provide the prepared title and body. If the user declines, stop there; the already-sent private vent still stands.
 `;
 
 // Composed bodies for each agent type


### PR DESCRIPTION
## Summary

- keep anonymous dev3 vents as the first feedback channel for platform bugs
- offer to create a public GitHub issue only after explicit user approval
- label AI-filed issues as Reported by AI and scrub private project details
- document the shared behavior across agent variants and add a changelog entry

## Test plan

- bun run lint
- bun run test (4,931 tests passed)