### PR TITLE
Fix Codex prompts in multi-variant launches

### DIFF
--- a/change-logs/2026/07/09/fix-edited-scratch-variant-prompts.md
+++ b/change-logs/2026/07/09/fix-edited-scratch-variant-prompts.md
@@ -1,0 +1,1 @@
+Preserve meaningful task descriptions when launching multiple variants from an edited scratch task, while still keeping untouched scratch placeholders out of the agent prompt.

--- a/change-logs/2026/07/09/fix-edited-scratch-variant-prompts.md
+++ b/change-logs/2026/07/09/fix-edited-scratch-variant-prompts.md
@@ -1,1 +1,1 @@
-Preserve meaningful task descriptions when launching multiple variants from an edited scratch task, while still keeping untouched scratch placeholders out of the agent prompt.
+Convert scratch tasks into normal tasks when their description is edited, so multi-variant launches deliver the meaningful prompt to every agent. Untouched scratch placeholders remain excluded from agent prompts.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1018,6 +1018,33 @@ describe("task.update", () => {
 		expect(call.title).toBeDefined();
 	});
 
+	it("clears the scratch flag when the description becomes a real task prompt", async () => {
+		const project = makeProject();
+		const task = makeTask({ scratch: true, description: "Scratch — 15:50" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({
+			...task,
+			description: "Plan HTML artifacts",
+			scratch: false,
+		});
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				description: "Plan HTML artifacts",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(vi.mocked(data.updateTask).mock.calls[0][2]).toEqual(expect.objectContaining({
+			description: "Plan HTML artifacts",
+			scratch: false,
+		}));
+	});
+
 	it("does not auto-generate title when explicit title provided", async () => {
 		const project = makeProject();
 		const task = makeTask();

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2559,6 +2559,26 @@ describe("handlers.editTask", () => {
 		}));
 	});
 
+	it("converts a scratch task into a normal task when its description is edited", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", scratch: true, description: "Scratch — 15:50" });
+		const updated = makeTask({ status: "todo", scratch: false, description: "Plan HTML artifacts" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+
+		await handlers.editTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			description: "Plan HTML artifacts",
+		});
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", expect.objectContaining({
+			description: "Plan HTML artifacts",
+			scratch: false,
+		}));
+	});
+
 	it("throws when task is not in todo status", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress" });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -3118,6 +3118,50 @@ describe("handlers.spawnVariants", () => {
 		expect(ctxArg.taskDescription).toBe("");
 	});
 
+	it("preserves a meaningful prompt when launching variants from an edited scratch task", async () => {
+		const project = makeProject();
+		const description = "Design an embedded HTML artifact viewer";
+		const sourceTask = makeTask({ status: "todo", seq: 5, scratch: true, description });
+		const variantTasks = [
+			makeTask({ id: "variant-1", status: "in-progress", preparing: true, scratch: true, description }),
+			makeTask({ id: "variant-2", status: "in-progress", preparing: true, scratch: true, description }),
+		];
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
+		vi.mocked(data.addTask)
+			.mockResolvedValueOnce(variantTasks[0])
+			.mockResolvedValueOnce(variantTasks[1]);
+		vi.mocked(git.createWorktree)
+			.mockResolvedValueOnce({ worktreePath: "/tmp/vwt-1", branchName: "dev3/v1" })
+			.mockResolvedValueOnce({ worktreePath: "/tmp/vwt-2", branchName: "dev3/v2" });
+		vi.mocked(data.updateTask).mockImplementation(async (_project, taskId) => (
+			makeTask({
+				id: taskId,
+				status: "in-progress",
+				worktreePath: taskId === "variant-1" ? "/tmp/vwt-1" : "/tmp/vwt-2",
+				scratch: true,
+				description,
+			})
+		));
+
+		await handlers.spawnVariants({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			variants: [
+				{ agentId: "agent-1", configId: null },
+				{ agentId: "agent-1", configId: null },
+			],
+		});
+
+		await vi.waitFor(() => {
+			expect(agents.resolveCommandForAgent).toHaveBeenCalledTimes(2);
+		});
+		expect(vi.mocked(agents.resolveCommandForAgent).mock.calls.map((call) => call[2].taskDescription))
+			.toEqual([description, description]);
+	});
+
 	// Issue #583 — spawnVariants used to drop the user-edited customTitle from
 	// the source task. The new variants must inherit it so the title the user
 	// typed in the Create-Task modal survives "Save and Run".

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -262,10 +262,18 @@ const handlers: Record<string, Handler> = {
 			}
 		}
 		if (params.description !== undefined) {
-			updates.description = params.description as string;
+			const description = params.description as string;
+			updates.description = description;
+			if (
+				task.scratch === true
+				&& description.trim()
+				&& !/^Scratch — \d{2}:\d{2}$/.test(description.trim())
+			) {
+				updates.scratch = false;
+			}
 			// Only recompute auto-title if there's no custom override
 			if (!task.customTitle && !updates.customTitle) {
-				updates.title = titleFromDescription(params.description as string);
+				updates.title = titleFromDescription(description);
 			}
 		}
 

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -487,9 +487,13 @@ function scratchPlaceholder(now: Date = new Date()): string {
 	return `Scratch — ${hh}:${mm}`;
 }
 
+function isScratchPlaceholderDescription(description: string): boolean {
+	return /^Scratch — \d{2}:\d{2}$/.test(description.trim());
+}
+
 function taskWithLaunchDescription(task: Task, forceBlank = false): Task {
 	const hasScratchPlaceholder = task.scratch === true
-		&& /^Scratch — \d{2}:\d{2}$/.test(task.description.trim());
+		&& isScratchPlaceholderDescription(task.description);
 	return forceBlank || hasScratchPlaceholder ? { ...task, description: "" } : task;
 }
 
@@ -1255,6 +1259,13 @@ async function editTask(params: { taskId: string; projectId: string; description
 		throw new Error(`Can only edit tasks in todo status (got ${task.status})`);
 	}
 	const updates: Partial<Task> = { description: params.description };
+	if (
+		task.scratch === true
+		&& params.description.trim()
+		&& !isScratchPlaceholderDescription(params.description)
+	) {
+		updates.scratch = false;
+	}
 	if (!task.customTitle) {
 		updates.title = titleFromDescription(params.description);
 	}

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -248,7 +248,7 @@ async function prepareTaskInBackground(
 					"creating-worktree",
 					{ opsWorkDir: task.opsWorkDir ?? null },
 				);
-				const taskForVirtualLaunch = task.scratch ? { ...task, description: "" } : task;
+				const taskForVirtualLaunch = taskWithLaunchDescription(task);
 				await measurePreparationStep(
 					task,
 					runId,
@@ -340,11 +340,10 @@ async function prepareTaskInBackground(
 				() => runCowClones(resolved, wt.worktreePath),
 				"cloning-shared-paths",
 			);
-			// Scratch tasks carry a placeholder `description` used only to
-			// derive the card title. At launch time we blank it so the agent
-			// receives an empty prompt (same mechanism as the reopen path in
-			// activateTask).
-			const taskForLaunch = task.scratch ? { ...task, description: "" } : task;
+			// Fresh scratch tasks carry a placeholder `description` used only to
+			// derive the card title. Blank that placeholder, but preserve a real
+			// description if the scratch task was edited before launching variants.
+			const taskForLaunch = taskWithLaunchDescription(task);
 			await measurePreparationStep(
 				task,
 				runId,
@@ -449,11 +448,10 @@ export async function activateTask(
 	// being handed a prompt, in two cases:
 	//   - reopen (completed/cancelled → active): don't replay the original prompt.
 	//     Original intent: commit a2b87778 ("Skip task prompt when reopening …").
-	//   - scratch tasks: `description` is only a `Scratch — HH:mm` placeholder used
-	//     for the card title, never a real instruction. Direct launches land here
-	//     (not just the prepareTaskInBackground / Launch Variants flow), so we must
-	//     blank it here too — otherwise the placeholder is sent as the prompt.
-	const taskForLaunch = isReopen || task.scratch ? { ...task, description: "" } : task;
+	//   - untouched scratch tasks: `description` is only the generated
+	//     `Scratch — HH:mm` placeholder used for the card title. An edited scratch
+	//     task may contain a real instruction, which must survive launch.
+	const taskForLaunch = taskWithLaunchDescription(task, isReopen);
 	await launchTaskPty(resolved, taskForLaunch, wt.worktreePath, task.agentId, task.configId, true, isReopen, { branchName: wt.branchName });
 	return { worktreePath: wt.worktreePath, branchName: wt.branchName };
 }
@@ -477,8 +475,8 @@ async function activateVirtualTask(
 	const workDir = fixed || git.virtualWorkDir(project, task);
 	await mkdir(workDir, { recursive: true });
 	log.info("Activating virtual task", { taskId: task.id.slice(0, 8), workDir, fixed: !!fixed });
-	// Scratch/reopen → blank prompt so the agent idles (the shell pane is usable).
-	const taskForLaunch = isReopen || task.scratch ? { ...task, description: "" } : task;
+	// Reopen or untouched scratch placeholder → blank prompt so the agent idles.
+	const taskForLaunch = taskWithLaunchDescription(task, isReopen);
 	await launchTaskPty(project, taskForLaunch, workDir, task.agentId, task.configId, true, isReopen);
 	return { worktreePath: workDir, branchName: null };
 }
@@ -487,6 +485,12 @@ function scratchPlaceholder(now: Date = new Date()): string {
 	const hh = String(now.getHours()).padStart(2, "0");
 	const mm = String(now.getMinutes()).padStart(2, "0");
 	return `Scratch — ${hh}:${mm}`;
+}
+
+function taskWithLaunchDescription(task: Task, forceBlank = false): Task {
+	const hasScratchPlaceholder = task.scratch === true
+		&& /^Scratch — \d{2}:\d{2}$/.test(task.description.trim());
+	return forceBlank || hasScratchPlaceholder ? { ...task, description: "" } : task;
 }
 
 export async function handleBellAutoStatus(taskId: string): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -993,11 +993,11 @@ export interface Task {
 	 */
 	mergeCompletionPrompt?: MergeCompletionPromptState | null;
 	/**
-	 * True when the task was created via the "Scratch Task" button with no
-	 * initial prompt. The `description` holds only a `Scratch â HH:mm`
+	 * True while a task created via the "Scratch Task" button still has no
+	 * initial prompt. The `description` holds only a `Scratch — HH:mm`
 	 * placeholder used for the title; at launch time the agent receives an
-	 * empty prompt instead of the placeholder. The flag propagates from the
-	 * source todo task into every variant spawned from it.
+	 * empty prompt instead of the placeholder. Editing in a meaningful
+	 * description converts it into a normal task and clears this flag.
 	 */
 	scratch?: boolean;
 	/**


### PR DESCRIPTION
## Summary

- Clear stale scratch state when a task description becomes a real prompt through the UI or CLI.
- Preserve meaningful prompts for legacy edited scratch tasks during variant launches.
- Add regression coverage for UI edits, CLI edits, and multi-variant Codex preparation.

## Validation

- `bun run lint`
- `bun run test` (4,934 tests passed)