### PR TITLE
Support image drag-and-drop and paste when editing a todo task

### DIFF
--- a/change-logs/2026/07/10/feature-edit-task-image-dnd.md
+++ b/change-logs/2026/07/10/feature-edit-task-image-dnd.md
@@ -1,0 +1,1 @@
+Editing a todo task's description now supports drag-and-drop and clipboard-paste image/file upload, with an inline attachments strip — matching the create-task modal. Previously the edit textarea in the task detail modal was plain text only.

--- a/src/mainview/components/TaskDetailModal.tsx
+++ b/src/mainview/components/TaskDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type Dispatch } from "react";
+import { useState, useEffect, useRef, useCallback, type Dispatch } from "react";
 import { toast } from "../toast";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Project, Task, TaskStatus } from "../../shared/types";
@@ -7,6 +7,7 @@ import { useStatusColors } from "../hooks/useStatusColors";
 import LabelChip from "./LabelChip";
 import LabelPicker from "./LabelPicker";
 import { NoteItem, formatDate } from "./NoteItem";
+import { ImageAttachmentsStrip } from "./ImageAttachmentsStrip";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
 import { confirm } from "../confirm";
@@ -15,6 +16,9 @@ import { getStatusLabel } from "../utils/statusLabel";
 import { moveTaskToStatus } from "../utils/moveTaskToStatus";
 import { trackEvent, agentNameFromId } from "../analytics";
 import { useFocusTrap } from "../utils/useFocusTrap";
+import { useClipboardPaste } from "../hooks/useClipboardPaste";
+import { useFileDrop } from "../hooks/useFileDrop";
+import { removeImagePath } from "../utils/imageAttachments";
 
 interface TaskDetailModalProps {
 	task: Task;
@@ -69,6 +73,36 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 		setEditValue(task.description);
 		setIsEditing(true);
 	}
+
+	// Insert an uploaded/pasted path into the edit textarea at the caret, mirroring
+	// CreateTaskModal so editing a todo task supports drag-drop and paste image upload.
+	const insertPathAtCursor = useCallback((path: string) => {
+		setEditValue((prev) => {
+			const el = textareaRef.current;
+			if (!el) {
+				return prev + (prev && !prev.endsWith("\n") ? "\n" : "") + path + "\n";
+			}
+			const start = el.selectionStart;
+			const end = el.selectionEnd;
+			const prefix = start > 0 && prev[start - 1] !== "\n" ? "\n" : "";
+			const insert = prefix + path + "\n";
+			const next = prev.slice(0, start) + insert + prev.slice(end);
+			requestAnimationFrame(() => {
+				const pos = start + insert.length;
+				el.selectionStart = pos;
+				el.selectionEnd = pos;
+				el.focus();
+			});
+			return next;
+		});
+	}, []);
+
+	const handleRemovePath = useCallback((path: string) => {
+		setEditValue((prev) => removeImagePath(prev, path));
+	}, []);
+
+	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
+	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor);
 
 	async function handleSave() {
 		const trimmed = editValue.trim();
@@ -432,15 +466,38 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 
 						{isEditing ? (
 							<div className="space-y-2">
-								<textarea
-									ref={textareaRef}
-									value={editValue}
-									onChange={(e) => setEditValue(e.target.value)}
-									onKeyDown={handleEditKeyDown}
-									rows={8}
-									className="w-full bg-elevated border border-edge-active rounded-xl px-3 py-2.5 text-sm text-fg leading-relaxed resize-y outline-none focus:border-accent/60 transition-colors min-h-[7.5rem] max-h-[25rem]"
-									disabled={saving}
-								/>
+								<div
+									className="relative"
+									onDragOver={handleDragOver}
+									onDragEnter={handleDragEnter}
+									onDragLeave={handleDragLeave}
+									onDrop={handleDrop}
+								>
+									{isDragging && (
+										<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-accent bg-accent/10 pointer-events-none">
+											<div className="flex items-center gap-2 text-accent font-medium text-sm">
+												<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+													<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+												</svg>
+												{t("images.dropHere")}
+											</div>
+										</div>
+									)}
+									<textarea
+										ref={textareaRef}
+										value={editValue}
+										onChange={(e) => setEditValue(e.target.value)}
+										onKeyDown={handleEditKeyDown}
+										onPaste={handlePaste}
+										rows={8}
+										className="w-full bg-elevated border border-edge-active rounded-xl px-3 py-2.5 text-sm text-fg leading-relaxed resize-y outline-none focus:border-accent/60 transition-colors min-h-[7.5rem] max-h-[25rem]"
+										disabled={saving}
+									/>
+								</div>
+								{isPasting && (
+									<span className="text-[0.6875rem] text-accent animate-pulse">{t(pasteKind === "text" ? "paste.savingText" : "images.pasting")}</span>
+								)}
+								<ImageAttachmentsStrip text={editValue} onRemovePath={handleRemovePath} />
 								{generatedTitle && generatedTitle !== editValue.trim() && (
 									<div className="text-fg-3 text-xs">
 										{t("createTask.generatedTitle")}{" "}

--- a/src/mainview/components/__tests__/TaskDetailModal.test.tsx
+++ b/src/mainview/components/__tests__/TaskDetailModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TaskDetailModal from "../TaskDetailModal";
 import { I18nProvider } from "../../i18n";
@@ -17,6 +17,9 @@ vi.mock("../../rpc", () => ({
 			deleteTaskNote: vi.fn(),
 			deleteTask: vi.fn(),
 			setTaskLabels: vi.fn(),
+			uploadFileBase64: vi.fn(),
+			pasteClipboardImage: vi.fn(),
+			readImageBase64: vi.fn(),
 		},
 	},
 }));
@@ -66,6 +69,27 @@ function makeTodoTask(overrides: Partial<Task> = {}): Task {
 		updatedAt: "2025-01-01T00:00:00Z",
 		...overrides,
 	};
+}
+
+function makeFileList(files: File[]): FileList {
+	return {
+		length: files.length,
+		item: (index: number) => files[index] ?? null,
+		...Object.fromEntries(files.map((file, index) => [index, file])),
+	} as unknown as FileList;
+}
+
+function dispatchDrop(target: Element, files: File[]) {
+	const event = new MouseEvent("drop", { bubbles: true, cancelable: true });
+	Object.defineProperty(event, "dataTransfer", {
+		value: {
+			files: makeFileList(files),
+			dropEffect: "copy" as const,
+		},
+	});
+	act(() => {
+		target.dispatchEvent(event);
+	});
 }
 
 function renderModal(
@@ -183,6 +207,36 @@ describe("TaskDetailModal", () => {
 			renderModal(task);
 
 			expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+		});
+
+		it("uploads an image dropped into the edit textarea and appends the saved path", async () => {
+			mockedApi.request.uploadFileBase64.mockResolvedValue({ path: "/tmp/uploaded-drop.png" });
+			mockedApi.request.readImageBase64.mockResolvedValue({ dataUrl: "data:image/png;base64,AAAA" });
+			const task = makeTodoTask({ description: "original" });
+			renderModal(task);
+			const user = userEvent.setup();
+
+			await user.click(screen.getByText("Edit"));
+			const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+			// Caret at end so the inserted path is appended deterministically.
+			textarea.selectionStart = textarea.value.length;
+			textarea.selectionEnd = textarea.value.length;
+			const file = new File(["abc"], "drop.jpg", { type: "image/jpeg", lastModified: 1711111111111 });
+
+			// The textarea's parent is the drop-zone wrapper carrying the DnD handlers.
+			dispatchDrop(textarea.parentElement!, [file]);
+
+			await waitFor(() => {
+				expect(mockedApi.request.uploadFileBase64).toHaveBeenCalledWith({
+					projectId: "p1",
+					base64: "YWJj",
+					filename: "drop.jpg",
+					mimeType: "image/jpeg",
+				});
+			});
+			await waitFor(() => {
+				expect(textarea.value).toBe("original\n/tmp/uploaded-drop.png\n");
+			});
 		});
 	});
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

## Summary

The description edit textarea in `TaskDetailModal` (opened via **Edit** on a todo task) was plain text only — unlike the create-task modal, it had no drag-and-drop or clipboard-paste image/file upload. This brings it to parity.

Wired the existing shared pieces into the todo edit flow:

- `useFileDrop` — drag-and-drop file/image upload into the worktree; the saved path is inserted at the caret.
- `useClipboardPaste` — paste image from clipboard (and large-text → file), inserted at the caret.
- `ImageAttachmentsStrip` — inline thumbnails below the textarea with per-item remove.
- A "Drop images here" overlay with a dashed accent border while dragging, matching `CreateTaskModal`.

No new i18n keys (reuses the create-modal keys), no new dependencies — a faithful replication of the established pattern.

Added a unit test covering the drop → upload → caret-insert path, and manually QA'd in a browser (edit mode renders cleanly, drag overlay appears, no console errors).