### PR TITLE
Show active account identity in rate-limit tooltip

### DIFF
--- a/change-logs/2026/07/10/feature-rate-limit-account-info.md
+++ b/change-logs/2026/07/10/feature-rate-limit-account-info.md
@@ -1,0 +1,1 @@
+The agent rate-limit indicator tooltip in the global header now shows which account each Claude/Codex limit belongs to — the active account's email/label plus its plan tier (or an API-profile marker) — so it is clear whose limits you are looking at.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -26,6 +26,10 @@ vi.mock("../rpc", () => ({
 			getPreventSleepState: vi.fn().mockResolvedValue({ enabled: false, available: false, forcedByRemote: false }),
 			setPreventSleep: vi.fn(),
 			getAgentRateLimits: vi.fn().mockResolvedValue({ generatedAt: 0, snapshots: [] }),
+			listAgentAccounts: vi.fn().mockResolvedValue({
+				claude: { accounts: [], activeId: null, systemIdentity: null },
+				codex: { accounts: [], activeId: null, currentIdentity: null },
+			}),
 			getAgents: vi.fn().mockResolvedValue([]),
 			getGlobalSettings: vi.fn().mockResolvedValue({
 				defaultAgentId: "builtin-claude",

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -3,7 +3,7 @@ import { api } from "../rpc";
 import { useLocale, useT } from "../i18n";
 import Tooltip from "./Tooltip";
 import { RateLimitIcon } from "./HeaderIcons";
-import type { AgentRateLimitsReport } from "../../shared/rate-limits";
+import type { AgentRateLimitSnapshot, AgentRateLimitsReport, RateLimitSource } from "../../shared/rate-limits";
 import {
 	RATE_LIMIT_DANGER_PERCENT,
 	RATE_LIMIT_WARN_PERCENT,
@@ -11,11 +11,78 @@ import {
 	windowLabel,
 	worstWindow,
 } from "../../shared/rate-limits";
+import type { AgentAccountsState } from "../../shared/agent-accounts";
+import { AGENT_ACCOUNTS_CHANGED_EVENT } from "./AgentAccountIndicator";
 
 /** Data older than this gets a staleness note in the tooltip. */
 const STALE_AFTER_MS = 10 * 60 * 1000;
 
 const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" };
+
+/** Which account the rate-limit windows for a source are drawn from. */
+interface AccountLine {
+	/** Email / user-set label of the active account (null when identity unknown). */
+	name: string | null;
+	/** Plan/tier badge (e.g. "Max 5x", "Plus"), when known. */
+	planLabel: string | null;
+	/** Active account is an API/custom-endpoint profile rather than an OAuth login. */
+	isApi: boolean;
+}
+
+/**
+ * Resolve the active account behind a source's limits from the account switcher
+ * state: the active managed account, else the system/current login identity.
+ * The rate-limit windows always reflect whichever account launched the session,
+ * so surfacing it answers "whose limit is this?" at a glance.
+ */
+function resolveAccount(source: RateLimitSource, state: AgentAccountsState | null): AccountLine | null {
+	if (!state) return null;
+	const kindState = state[source];
+	const active = kindState.accounts.find((a) => a.id === kindState.activeId) ?? null;
+	if (active) {
+		return {
+			name: active.label,
+			planLabel: active.auth === "api" ? null : (active.identity?.planLabel ?? null),
+			isApi: active.auth === "api",
+		};
+	}
+	const fallback = source === "claude" ? state.claude.systemIdentity : state.codex.currentIdentity;
+	if (fallback) {
+		return { name: fallback.email, planLabel: fallback.planLabel, isApi: false };
+	}
+	return null;
+}
+
+/** Build the detail rows (windows + credits + monthly usage) for one snapshot. */
+function snapshotRows(
+	snap: AgentRateLimitSnapshot,
+	now: number,
+	t: ReturnType<typeof useT>,
+	locale: string,
+): string[] {
+	const rows: string[] = [];
+	for (const win of snap.windows) {
+		if (win.id === "monthly_credits") continue;
+		const reset = formatResetDelta(win.resetsAt, now);
+		rows.push(`${windowLabel(win)} — ${Math.round(win.usedPercent)}%${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`);
+	}
+	if (snap.creditsBalance != null) {
+		rows.push(t("rateLimits.credits", { balance: snap.creditsBalance }));
+	}
+	if (snap.monthlyCredits) {
+		const monthly = snap.monthlyCredits;
+		const reset = formatResetDelta(monthly.resetsAt, now);
+		const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+		rows.push(
+			`${t("rateLimits.monthlyLabel")} — ${t("rateLimits.monthlyUsage", {
+				used: numberFormat.format(monthly.used),
+				limit: numberFormat.format(monthly.limit),
+				remaining: Math.round(monthly.remainingPercent),
+			})}${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
+		);
+	}
+	return rows;
+}
 
 /**
  * Ambient agent rate-limit indicator (global header, stateful-indicators zone).
@@ -30,6 +97,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const t = useT();
 	const [locale] = useLocale();
 	const [report, setReport] = useState<AgentRateLimitsReport | null>(null);
+	const [accounts, setAccounts] = useState<AgentAccountsState | null>(null);
 
 	useEffect(() => {
 		api.request.getAgentRateLimits().then(setReport).catch(() => {
@@ -42,6 +110,21 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		return () => window.removeEventListener("rpc:agentRateLimitsUpdated", onUpdate);
 	}, []);
 
+	useEffect(() => {
+		function reload() {
+			api.request
+				.listAgentAccounts()
+				.then(setAccounts)
+				.catch(() => {
+					// switcher unavailable — the tooltip just omits the account line
+				});
+		}
+		reload();
+		// An account switch elsewhere changes which login these limits belong to.
+		window.addEventListener(AGENT_ACCOUNTS_CHANGED_EVENT, reload);
+		return () => window.removeEventListener(AGENT_ACCOUNTS_CHANGED_EVENT, reload);
+	}, []);
+
 	const worst = report ? worstWindow(report) : null;
 	if (!report || !worst) return null;
 
@@ -50,32 +133,8 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const danger = percent >= RATE_LIMIT_DANGER_PERCENT;
 	const warn = !danger && percent >= RATE_LIMIT_WARN_PERCENT;
 
-	const rows: string[] = [];
 	let staleCapturedAt: number | null = null;
 	for (const snap of report.snapshots) {
-		const sourceName = SOURCE_NAMES[snap.source] ?? snap.source;
-		for (const win of snap.windows) {
-			if (win.id === "monthly_credits") continue;
-			const reset = formatResetDelta(win.resetsAt, now);
-			rows.push(
-				`${sourceName} ${windowLabel(win)} — ${Math.round(win.usedPercent)}%${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
-			);
-		}
-		if (snap.creditsBalance != null) {
-			rows.push(`${sourceName} — ${t("rateLimits.credits", { balance: snap.creditsBalance })}`);
-		}
-		if (snap.monthlyCredits) {
-			const monthly = snap.monthlyCredits;
-			const reset = formatResetDelta(monthly.resetsAt, now);
-			const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
-			rows.push(
-				`${sourceName} ${t("rateLimits.monthlyLabel")} — ${t("rateLimits.monthlyUsage", {
-					used: numberFormat.format(monthly.used),
-					limit: numberFormat.format(monthly.limit),
-					remaining: Math.round(monthly.remainingPercent),
-				})}${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
-			);
-		}
 		if (now - snap.capturedAt > STALE_AFTER_MS && (staleCapturedAt == null || snap.capturedAt < staleCapturedAt)) {
 			staleCapturedAt = snap.capturedAt;
 		}
@@ -95,10 +154,32 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		<Tooltip
 			content={t("rateLimits.tooltipTitle")}
 			detail={
-				<div className="flex flex-col gap-0.5">
-					{rows.map((row) => (
-						<span key={row}>{row}</span>
-					))}
+				<div className="flex flex-col gap-2">
+					{report.snapshots.map((snap) => {
+						const account = resolveAccount(snap.source, accounts);
+						const rows = snapshotRows(snap, now, t, locale);
+						return (
+							<div key={snap.source} className="flex flex-col gap-0.5">
+								<div className="flex items-center gap-1.5">
+									<span className="text-fg-2 font-medium">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
+									{account?.name && <span className="text-fg-3">{account.name}</span>}
+									{account?.planLabel && (
+										<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded">
+											{account.planLabel}
+										</span>
+									)}
+									{account?.isApi && (
+										<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded">API</span>
+									)}
+								</div>
+								{rows.map((row) => (
+									<span key={row} className="text-fg-3 pl-0.5">
+										{row}
+									</span>
+								))}
+							</div>
+						);
+					})}
 					{staleCapturedAt != null && (
 						<span className="text-fg-muted">
 							{t("rateLimits.stale", { time: formatAge(now - staleCapturedAt) })}

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -17,6 +17,10 @@ vi.mock("../../rpc", () => ({
 			getPreventSleepState: vi.fn().mockResolvedValue({ enabled: false, available: false, forcedByRemote: false }),
 			setPreventSleep: vi.fn(),
 			getAgentRateLimits: vi.fn().mockResolvedValue({ generatedAt: 0, snapshots: [] }),
+			listAgentAccounts: vi.fn().mockResolvedValue({
+				claude: { accounts: [], activeId: null, systemIdentity: null },
+				codex: { accounts: [], activeId: null, currentIdentity: null },
+			}),
 		},
 	},
 }));

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
 import RateLimitIndicator from "../RateLimitIndicator";
 import type { AgentRateLimitsReport } from "../../../shared/rate-limits";
+import type { AgentAccountsState } from "../../../shared/agent-accounts";
 
 vi.mock("../../rpc", () => ({
 	api: {
 		request: {
 			getAgentRateLimits: vi.fn(),
+			listAgentAccounts: vi.fn(),
 		},
 	},
 }));
@@ -16,6 +18,14 @@ vi.mock("../../rpc", () => ({
 import { api } from "../../rpc";
 
 const mockedGet = api.request.getAgentRateLimits as ReturnType<typeof vi.fn>;
+const mockedAccounts = api.request.listAgentAccounts as ReturnType<typeof vi.fn>;
+
+function emptyAccounts(): AgentAccountsState {
+	return {
+		claude: { accounts: [], activeId: null, systemIdentity: null },
+		codex: { accounts: [], activeId: null, currentIdentity: null },
+	};
+}
 
 function report(percent: number): AgentRateLimitsReport {
 	return {
@@ -46,6 +56,8 @@ function renderIndicator() {
 
 beforeEach(() => {
 	mockedGet.mockReset();
+	mockedAccounts.mockReset();
+	mockedAccounts.mockResolvedValue(emptyAccounts());
 });
 
 describe("RateLimitIndicator", () => {
@@ -116,5 +128,61 @@ describe("RateLimitIndicator", () => {
 		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("monthly credits");
 		await userEvent.tab();
 		expect(await screen.findByText(/329.53 \/ 8,824/)).toBeTruthy();
+	});
+
+	it("shows the system-login account identity and plan in the tooltip", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		mockedAccounts.mockResolvedValue({
+			claude: {
+				accounts: [],
+				activeId: null,
+				systemIdentity: {
+					email: "alice@example.com",
+					organization: null,
+					plan: "default_claude_max_5x",
+					planLabel: "Max 5x",
+					accountId: "uuid-1",
+				},
+			},
+			codex: { accounts: [], activeId: null, currentIdentity: null },
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		expect(await screen.findByText("alice@example.com")).toBeTruthy();
+		expect(screen.getByText("Max 5x")).toBeTruthy();
+	});
+
+	it("shows the active managed account label for its source", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		mockedAccounts.mockResolvedValue({
+			claude: {
+				accounts: [
+					{
+						id: "acc-1",
+						kind: "claude",
+						label: "Work account",
+						identity: {
+							email: "work@corp.com",
+							organization: "Corp",
+							plan: "default_claude_pro",
+							planLabel: "Pro",
+							accountId: "uuid-2",
+						},
+						auth: "oauth",
+						api: null,
+						createdAt: 0,
+					},
+				],
+				activeId: "acc-1",
+				systemIdentity: null,
+			},
+			codex: { accounts: [], activeId: null, currentIdentity: null },
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		expect(await screen.findByText("Work account")).toBeTruthy();
+		expect(screen.getByText("Pro")).toBeTruthy();
 	});
 });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The agent rate-limit indicator tooltip in the global header now shows **which account** each Claude/Codex limit belongs to — previously it only listed the windows with no way to tell whose quota you were looking at.

- The tooltip is now grouped by source; each group prepends the **active account** resolved from the account-switcher state (`listAgentAccounts`): the active managed account, else the system/current login identity.
- The account line shows the email/label plus a plan-tier badge (e.g. `Max 5x`, `Enterprise`), or an `API` marker for custom API-profile accounts.
- The line refreshes on `AGENT_ACCOUNTS_CHANGED_EVENT`, so switching accounts elsewhere updates it live.
- Reuses existing i18n/design tokens; no new user-facing strings, no new controls.

Added unit tests for the account line (system-login identity + active managed account) and updated the `App`/`GlobalHeader` test mocks now that the indicator also calls `listAgentAccounts`. Verified in a browser against real data (Claude · Max 5x and Codex · Enterprise both rendering correctly); `bun run lint` and the full `bun run test` suite are green.