### PR TITLE
fix(codex): re-detect profile launch flag when codex is upgraded mid-session

### DIFF
--- a/change-logs/2026/07/11/fix-codex-profile-flag-redetect.md
+++ b/change-logs/2026/07/11/fix-codex-profile-flag-redetect.md
@@ -1,0 +1,1 @@
+Fixed Codex agents failing to launch (exit 2, "unexpected argument --profile-v2") after codex was upgraded while dev3 kept running. dev3 now re-detects the codex profile launch flag whenever the installed codex version changes, instead of caching it for the whole app-process lifetime, so a mid-session codex upgrade no longer requires restarting dev3.

--- a/decisions/125-codex-profile-flag-redetect-on-upgrade.md
+++ b/decisions/125-codex-profile-flag-redetect-on-upgrade.md
@@ -1,0 +1,26 @@
+# 125 — Re-detect the Codex profile flag when codex is upgraded mid-session
+
+## Context
+
+Decision [064](./064-codex-profile-v2-flag-removed.md) (issue [#611](https://github.com/h0x91b/dev-3.0/issues/611)) fixed the `--profile-v2` → `--profile` rename by feature-detecting the launch flag from `codex --help` — but cached the result for the **whole dev3 process lifetime**. Codex self-updates (and users upgrade it) while dev3 keeps running. When an upgrade crosses the rename boundary, the cached flag goes stale: dev3 keeps launching every new Codex pane with `--profile-v2`, which the new binary rejects (`error: unexpected argument '--profile-v2' found`, exit 2). The failure looks like a broken integration but is fixed only by restarting dev3. Observed live with codex `0.144.1` (which dropped `--profile-v2`).
+
+## Investigation
+
+`getCodexProfileLaunchFlag()` in `src/bun/agents.ts` memoized `detectCodexProfileLaunchFlag()` once and never invalidated it. #611's own scenario re-fires on any future codex flag change. Two installs at different versions (`~/.bun/bin/codex` vs an fnm/npm copy) make it worse: detection can probe one binary while the launch resolves another.
+
+## Decision
+
+Re-detect the flag whenever the installed codex **version** changes, in `src/bun/agents.ts`:
+
+- New pure helper `resolveProfileFlagForVersion(currentVersion, cached, detect)` returns the cached `{ flag, version }` while `currentVersion` is unchanged, else calls `detect()` and re-keys — so the cache-invalidation logic is unit-tested without spawning.
+- `getCodexProfileLaunchFlag()` now reads `detectCodexVersion()` on each call and passes it through the helper. The `codex --version` probe is cheap and runs only on a user-initiated launch; the pricier `codex --help` parse re-runs only when the version actually changed. The test override (`__setCodexProfileV2Override`) still short-circuits before any probe.
+
+## Risks
+
+Adds one `codex --version` child spawn per Codex launch. Launches are user-initiated and infrequent, so the cost is imperceptible; this is deliberately narrower than caching-once. Scope is limited to the launch flag (pure command-arg construction, no on-disk effects). **Follow-up:** `getCodexVersionCached()` — used for config-syntax gating in `ensureCodexTrust` — is still cached for the process lifetime, so a mid-session upgrade could still mis-gate `~/.codex/config.toml` syntax. Left untouched here because that path writes to the shared `~/.codex` config (higher blast radius); worth the same version-keying later.
+
+## Alternatives considered
+
+- **TTL-based cache invalidation** — rejected: only eventually-correct, time-based (harder to test deterministically), and no better than version-keying for the actual failure.
+- **Spawn `codex --help` on every launch (no cache)** — rejected: re-parses help needlessly when nothing changed; version-keying keeps the `--help` parse on the change edge only.
+- **Reset the cache on a dev3 lifecycle event** — rejected: external codex upgrades emit no signal dev3 can hook.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, isOpenCodeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyLayoutResync, applyModelOverride, claudeModelFamily, __setCodexProfileV2Override, type TemplateContext } from "../agents";
+import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, isOpenCodeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyLayoutResync, applyModelOverride, claudeModelFamily, __setCodexProfileV2Override, resolveProfileFlagForVersion, type TemplateContext } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 import { ENV_UNSET } from "../../shared/agent-accounts";
@@ -554,6 +554,74 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("resume --last");
 		// Unsupported agent still gets the prompt (no resume behavior)
 		expect(cmd).toContain("Some task");
+	});
+});
+
+// Cache-invalidation for the codex profile flag: a mid-session `codex` upgrade
+// must re-run detection, otherwise the flag is stale and every launch fails
+// (issue #611 follow-up — the original fix cached the flag for the whole
+// process lifetime, so an upgrade across the --profile-v2 → --profile rename
+// kept launching with a flag the new binary rejects until dev3 restarted).
+describe("resolveProfileFlagForVersion (codex mid-session upgrade)", () => {
+	it("detects on first read (no cache) and remembers the version", () => {
+		let calls = 0;
+		const detect = () => {
+			calls++;
+			return "--profile-v2" as const;
+		};
+		const result = resolveProfileFlagForVersion("codex-cli 0.131.0", undefined, detect);
+		expect(result).toEqual({ flag: "--profile-v2", version: "codex-cli 0.131.0" });
+		expect(calls).toBe(1);
+	});
+
+	it("reuses the cached flag while the version is unchanged (no re-detect)", () => {
+		let calls = 0;
+		const detect = () => {
+			calls++;
+			return "--profile-v2" as const;
+		};
+		const cached = { flag: "--profile-v2" as const, version: "codex-cli 0.131.0" };
+		const result = resolveProfileFlagForVersion("codex-cli 0.131.0", cached, detect);
+		expect(result).toBe(cached);
+		expect(calls).toBe(0);
+	});
+
+	it("re-detects when the version changed across the --profile-v2 rename", () => {
+		let calls = 0;
+		const detect = () => {
+			calls++;
+			return "--profile" as const;
+		};
+		// Cached as --profile-v2 for old codex; codex upgraded to 0.144.1 which
+		// dropped the flag. Must re-detect and land on --profile.
+		const cached = { flag: "--profile-v2" as const, version: "codex-cli 0.133.0" };
+		const result = resolveProfileFlagForVersion("codex-cli 0.144.1", cached, detect);
+		expect(result).toEqual({ flag: "--profile", version: "codex-cli 0.144.1" });
+		expect(calls).toBe(1);
+	});
+
+	it("re-detects when the version becomes unknown (null)", () => {
+		let calls = 0;
+		const detect = () => {
+			calls++;
+			return "--profile" as const;
+		};
+		const cached = { flag: "--profile-v2" as const, version: "codex-cli 0.133.0" };
+		const result = resolveProfileFlagForVersion(null, cached, detect);
+		expect(result).toEqual({ flag: "--profile", version: null });
+		expect(calls).toBe(1);
+	});
+
+	it("does not re-detect while the version stays unknown (null === null)", () => {
+		let calls = 0;
+		const detect = () => {
+			calls++;
+			return "--profile" as const;
+		};
+		const cached = { flag: "--profile" as const, version: null };
+		const result = resolveProfileFlagForVersion(null, cached, detect);
+		expect(result).toBe(cached);
+		expect(calls).toBe(0);
 	});
 });
 

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -374,7 +374,7 @@ export function quoteIfUnsafe(s: string): string {
 }
 
 let codexProfileLaunchFlagOverride: CodexProfileLaunchFlag | null = null;
-let cachedCodexProfileLaunchFlag: CodexProfileLaunchFlag | undefined;
+let cachedProfileFlag: { flag: CodexProfileLaunchFlag; version: string | null } | undefined;
 
 /**
  * Test-only override for codex profile launch-flag detection.
@@ -382,22 +382,42 @@ let cachedCodexProfileLaunchFlag: CodexProfileLaunchFlag | undefined;
  */
 export function __setCodexProfileV2Override(value: boolean | null): void {
 	codexProfileLaunchFlagOverride = value === null ? null : value ? "--profile-v2" : "--profile";
-	cachedCodexProfileLaunchFlag = undefined;
+	cachedProfileFlag = undefined;
+}
+
+/**
+ * Decide the profile flag, reusing the cached result only while the installed
+ * codex version is unchanged. Pure so the cache-invalidation logic is testable
+ * without spawning: `detect` is called only on a first read or a version change.
+ */
+export function resolveProfileFlagForVersion(
+	currentVersion: string | null,
+	cached: { flag: CodexProfileLaunchFlag; version: string | null } | undefined,
+	detect: () => CodexProfileLaunchFlag,
+): { flag: CodexProfileLaunchFlag; version: string | null } {
+	if (cached !== undefined && cached.version === currentVersion) return cached;
+	return { flag: detect(), version: currentVersion };
 }
 
 /**
  * The flag the installed Codex accepts to select a dev3 profile. `--profile-v2`
  * existed only in a short transition window before it was renamed to
  * `--profile`/`-p` (same file-based semantics); newer codex rejects it outright.
- * Feature-detected from `codex --help` and cached for the process lifetime —
- * version numbers do not map reliably to the rename. See issue #611.
+ * Feature-detected from `codex --help`; version numbers do not map reliably to
+ * the rename. See issue #611.
+ *
+ * The detection is re-run whenever the installed codex version changes so a
+ * mid-session `codex` upgrade under a long-running dev3 is picked up. Caching it
+ * for the whole process lifetime (the original #611 fix) left the flag stale
+ * across an upgrade that crossed the rename, so every new Codex pane launched
+ * with a flag the new binary rejects (exit 2) until dev3 was restarted. The
+ * `codex --version` probe is cheap; the pricier `--help` parse only re-runs when
+ * the version actually changed.
  */
 function getCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
 	if (codexProfileLaunchFlagOverride !== null) return codexProfileLaunchFlagOverride;
-	if (cachedCodexProfileLaunchFlag === undefined) {
-		cachedCodexProfileLaunchFlag = detectCodexProfileLaunchFlag();
-	}
-	return cachedCodexProfileLaunchFlag;
+	cachedProfileFlag = resolveProfileFlagForVersion(detectCodexVersion(), cachedProfileFlag, detectCodexProfileLaunchFlag);
+	return cachedProfileFlag.flag;
 }
 
 /**


### PR DESCRIPTION
## Problem

Codex agents fail to launch with `error: unexpected argument '--profile-v2' found` (exit 2) after codex is upgraded **while dev3 is running**. Restarting dev3 fixes it — which is the tell.

Root cause: decision 064 (issue #611) feature-detects the `--profile-v2` vs `--profile` launch flag from `codex --help`, but caches the result for the **whole dev3 process lifetime**. Codex self-updates; an upgrade that crosses the `--profile-v2` → `--profile` rename leaves the cached flag stale, so every new Codex pane launches with a flag the new binary rejects until dev3 restarts. Reproduced live with codex `0.144.1`.

This is the residual gap #611's fix left: it fixed *detection*, not *cache invalidation*.

## Fix

Re-detect the flag whenever the installed codex **version** changes:

- New pure helper `resolveProfileFlagForVersion(currentVersion, cached, detect)` in `src/bun/agents.ts` — reuses the cached `{ flag, version }` while the version is unchanged, otherwise re-runs detection and re-keys. Pure, so the invalidation logic is unit-tested without spawning.
- `getCodexProfileLaunchFlag()` reads `detectCodexVersion()` per launch and routes through the helper. The `codex --version` probe is cheap and only on user-initiated launches; the pricier `codex --help` parse re-runs only on a version change.

Scope is limited to the launch flag (pure arg construction, no on-disk effects). Decision 125 documents a follow-up: `getCodexVersionCached()` (config-syntax gating in `ensureCodexTrust`) is still process-cached and could be version-keyed the same way later.

## Tests

- 5 new unit tests for `resolveProfileFlagForVersion` (first read, unchanged version reuses cache, re-detect on version change across the rename, unknown-version handling).
- `bun run lint` clean; full `bun run test` green (mainview 2328, bun 2297, cli 528). Rebased on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)