### PR TITLE
Show per-label task counts in project Labels settings

### DIFF
--- a/change-logs/2026/07/10/feature-label-task-counts.md
+++ b/change-logs/2026/07/10/feature-label-task-counts.md
@@ -1,0 +1,1 @@
+Project Settings → Labels now shows a task-count badge next to each label, so you can see at a glance how many project tasks currently carry it (0 is dimmed to flag unused labels).

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, type Dispatch, type MutableRefObject } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type MutableRefObject } from "react";
 import { toast } from "../toast";
 import type { CodingAgent, ColumnAgentConfig, CustomColumn, Dev3RepoConfig, GitHubAccount, GitHubCliStatus, Label, Project, SetupScriptLaunchMode, Task } from "../../shared/types";
 import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
@@ -36,9 +36,12 @@ interface LabelRowProps {
 	onDelete: () => void;
 	nameLabel: string;
 	deleteLabel: string;
+	/** Number of project tasks currently carrying this label (any status). */
+	taskCount: number;
 }
 
-function LabelRow({ label, saving, onUpdate, onDelete, nameLabel, deleteLabel }: LabelRowProps) {
+function LabelRow({ label, saving, onUpdate, onDelete, nameLabel, deleteLabel, taskCount }: LabelRowProps) {
+	const t = useT();
 	const [name, setName] = useState(label.name);
 	const [color, setColor] = useState(label.color);
 
@@ -71,6 +74,17 @@ function LabelRow({ label, saving, onUpdate, onDelete, nameLabel, deleteLabel }:
 				disabled={saving}
 				className="flex-1 bg-transparent text-fg text-sm outline-none placeholder-fg-muted min-w-0"
 			/>
+			{/* Task-count badge: how many project tasks carry this label. Quiet,
+			    read-only; dimmed at 0 to flag an unused label. */}
+			<span
+				className={`flex-shrink-0 text-xs font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-base ${
+					taskCount === 0 ? "text-fg-muted" : "text-fg-3"
+				}`}
+				title={t.plural("labels.taskCount", taskCount)}
+				aria-label={t.plural("labels.taskCount", taskCount)}
+			>
+				{taskCount}
+			</span>
 			{/* Color palette */}
 			<div className="flex items-center gap-1 flex-shrink-0">
 				{LABEL_COLORS.map((c) => (
@@ -867,6 +881,38 @@ function ProjectSettings({
 	const t = useT();
 	const project = projects.find((p) => p.id === projectId);
 
+	// Ensure this project's tasks are loaded. Settings can be opened straight from
+	// the dashboard gear without ever mounting ProjectView (which is the only other
+	// loader), leaving `currentProjectTasks` empty/stale — which would show every
+	// label count as 0 and empty the Worktree Config task list. Mirror ProjectView's
+	// fetch so both are correct regardless of entry path.
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const loaded = await api.request.getTasks({ projectId });
+				if (!cancelled) dispatch({ type: "setTasks", tasks: loaded });
+			} catch (err) {
+				console.error("Failed to load tasks for project settings:", err);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [projectId, dispatch]);
+
+	// labelId → number of project tasks (any status) carrying it. Shown as a
+	// quiet count badge next to each label in the Labels settings list.
+	const labelTaskCounts = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const task of tasks) {
+			for (const id of task.labelIds ?? []) {
+				counts.set(id, (counts.get(id) ?? 0) + 1);
+			}
+		}
+		return counts;
+	}, [tasks]);
+
 	// Operations boards only have the Board tab (no git → no Project/Worktree
 	// config); never let a deep-linked initialTab strand them on a hidden git tab.
 	const [activeTab, setActiveTab] = useState<ConfigTab>(
@@ -1384,6 +1430,7 @@ function ProjectSettings({
 											onDelete={() => handleDeleteLabel(label.id)}
 											nameLabel={t("labels.labelName")}
 											deleteLabel={t("labels.deleteLabel")}
+											taskCount={labelTaskCounts.get(label.id) ?? 0}
 										/>
 									))}
 									{(project.labels ?? []).length === 0 && (

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProjectSettings from "../ProjectSettings";
+import { api } from "../../rpc";
 import { I18nProvider } from "../../i18n";
 import type { Project, Task } from "../../../shared/types";
 import type { AppAction, Route } from "../../state";
@@ -11,6 +12,7 @@ vi.mock("../../rpc", () => ({
 			createLabel: vi.fn(),
 			updateLabel: vi.fn(),
 			deleteLabel: vi.fn(),
+			getTasks: vi.fn().mockResolvedValue([]),
 			detectClonePaths: vi.fn().mockResolvedValue([]),
 			listBranches: vi.fn().mockResolvedValue([]),
 			getProjectConfigs: vi.fn().mockResolvedValue({ repo: {}, local: {} }),
@@ -613,6 +615,57 @@ describe("ProjectSettings", () => {
 					expect(payload.setupScript).not.toBe("A-EDITED");
 				}
 			}
+		});
+	});
+
+	describe("label task counts", () => {
+		const labeledProject: Project = {
+			...mockProject,
+			labels: [
+				{ id: "l1", name: "Bug", color: "#ef4444" },
+				{ id: "l2", name: "Feature", color: "#84cc16" },
+				{ id: "l3", name: "Docs", color: "#a855f7" },
+			],
+		};
+		// No worktreePath: keeps these out of the worktree-config auto-load path
+		// (irrelevant to label counts) so the test stays free of async effects.
+		const labeledTasks: Task[] = [
+			{ ...mockTaskWithWorktree, id: "t1", status: "todo", worktreePath: null, labelIds: ["l1"] },
+			{ ...mockTaskWithWorktree, id: "t2", status: "todo", worktreePath: null, labelIds: ["l1", "l2"] },
+			// completed task still counts — "how many tasks in total carry it"
+			{ ...mockTaskWithWorktree, id: "t3", status: "completed", worktreePath: null, labelIds: ["l1"] },
+		];
+
+		it("shows the per-label task count next to each label", async () => {
+			await renderProjectSettings(labeledProject, {}, labeledTasks);
+			// l1 → 3 tasks, l2 → 1 task, l3 → 0 (unused)
+			expect(screen.getByTitle("3 tasks")).toHaveTextContent("3");
+			expect(screen.getByTitle("1 task")).toHaveTextContent("1");
+			expect(screen.getByTitle("0 tasks")).toHaveTextContent("0");
+		});
+
+		it("shows 0 for every label when there are no tasks", async () => {
+			await renderProjectSettings(labeledProject, {}, []);
+			expect(screen.getAllByTitle("0 tasks")).toHaveLength(3);
+		});
+
+		it("loads the project's tasks on mount so counts survive dashboard entry", async () => {
+			// Reached from the dashboard gear, ProjectView never runs — ProjectSettings
+			// must fetch tasks itself, otherwise every count would read 0.
+			(api.request.getTasks as ReturnType<typeof vi.fn>).mockClear();
+			const dispatch = vi.fn() as unknown as React.Dispatch<AppAction>;
+			(api.request.getTasks as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+				{ ...mockTaskWithWorktree, id: "x1", worktreePath: null, labelIds: ["l1"] },
+			]);
+			await act(async () => {
+				render(
+					<I18nProvider>
+						<ProjectSettings projectId={labeledProject.id} projects={[labeledProject]} tasks={[]} dispatch={dispatch} navigate={vi.fn() as (route: Route) => void} />
+					</I18nProvider>,
+				);
+			});
+			expect(api.request.getTasks).toHaveBeenCalledWith({ projectId: labeledProject.id });
+			expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: "setTasks" }));
 		});
 	});
 

--- a/src/mainview/i18n/translations/en/columns.ts
+++ b/src/mainview/i18n/translations/en/columns.ts
@@ -32,6 +32,8 @@ const columns = {
 	"labels.failedDelete": "Failed to delete label: {error}",
 	"labels.failedSetLabels": "Failed to update task labels: {error}",
 	"labels.taskLabels": "Labels",
+	"labels.taskCount_one": "{count} task",
+	"labels.taskCount_other": "{count} tasks",
 
 	// Priority
 	"priority.label": "Priority",

--- a/src/mainview/i18n/translations/es/columns.ts
+++ b/src/mainview/i18n/translations/es/columns.ts
@@ -32,6 +32,8 @@ const columns = {
 	"labels.failedDelete": "Error al eliminar etiqueta: {error}",
 	"labels.failedSetLabels": "Error al actualizar etiquetas de tarea: {error}",
 	"labels.taskLabels": "Etiquetas",
+	"labels.taskCount_one": "{count} tarea",
+	"labels.taskCount_other": "{count} tareas",
 
 	// Priority
 	"priority.label": "Prioridad",

--- a/src/mainview/i18n/translations/ru/columns.ts
+++ b/src/mainview/i18n/translations/ru/columns.ts
@@ -32,6 +32,10 @@ const columns = {
 	"labels.failedDelete": "Не удалось удалить метку: {error}",
 	"labels.failedSetLabels": "Не удалось обновить метки задачи: {error}",
 	"labels.taskLabels": "Метки",
+	"labels.taskCount_one": "{count} задача",
+	"labels.taskCount_few": "{count} задачи",
+	"labels.taskCount_many": "{count} задач",
+	"labels.taskCount_other": "{count} задач",
 
 	// Priority
 	"priority.label": "Приоритет",


### PR DESCRIPTION
Adds a quiet, read-only count badge next to each label in **Project Settings → Labels**, showing how many project tasks currently carry that label (any status). The `0` is dimmed to flag unused labels. Tabular-nums keeps the numbers aligned; the tooltip reads "N tasks" (localized en/ru/es).

While QA'ing this I found the counts always read `0` when Settings is opened straight from the dashboard gear: `state.currentProjectTasks` is populated only by `ProjectView`, which never mounts on that path — so the list was empty/stale (this also emptied the Worktree Config task list). `ProjectSettings` now loads its project's tasks on mount, mirroring `ProjectView`, fixing both.

Counts are computed with a `useMemo` over the project tasks, reusing the same label-count logic already present in `KanbanBoard`.