### PR TITLE
Fix image-share toast: navigate to owning task on click

### DIFF
--- a/change-logs/2026/07/10/fix-image-share-toast-task-focus.md
+++ b/change-logs/2026/07/10/fix-image-share-toast-task-focus.md
@@ -1,0 +1,1 @@
+Clicking the "Agent shared an image" toast now navigates to the task that produced the image (honoring your task open-mode) before opening the lightbox, instead of opening the viewer without switching focus. Matches how shared HTML artifacts already behave.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1057,7 +1057,7 @@ function App() {
 	// the lightbox ONLY when the user is already looking at this task (never steal focus).
 	useEffect(() => {
 		function onCliShowImage(e: Event) {
-			const { taskId, images, newCount, taskSeq, taskTitle, projectName } = (e as CustomEvent).detail as {
+			const { taskId, projectId, images, newCount, taskSeq, taskTitle, projectName } = (e as CustomEvent).detail as {
 				taskId: string;
 				projectId: string;
 				images: SharedImage[];
@@ -1083,18 +1083,24 @@ function App() {
 				return;
 			}
 
-			// Elsewhere: don't steal focus — a clickable toast opens the viewer.
+			// Elsewhere: don't steal focus automatically — a clickable toast both
+			// navigates to the owning task and opens the viewer (honoring open-mode).
 			const context = taskSeq !== undefined
 				? [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ")
 				: undefined;
 			toast.info(t.plural("showImage.toast", newCount ?? 1), {
 				context,
-				onClick: () => setImageViewer({ taskId, images, index: images.length - 1 }),
+				onClick: () => {
+					const openMode = getTaskOpenMode();
+					if (openMode === "fullscreen") navigate({ screen: "task", projectId, taskId });
+					else navigate({ screen: "project", projectId, activeTaskId: taskId });
+					setImageViewer({ taskId, images, index: images.length - 1 });
+				},
 			});
 		}
 		window.addEventListener("rpc:cliShowImage", onCliShowImage);
 		return () => window.removeEventListener("rpc:cliShowImage", onCliShowImage);
-	}, [dispatch, t, state.route]);
+	}, [dispatch, navigate, t, state.route]);
 
 	// Reopen the image viewer from a task-scoped trigger (the inspector image badge).
 	useEffect(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -128,6 +128,9 @@ vi.mock("../components/gauges/GaugeDemo", () => ({
 vi.mock("../components/ProjectTerminal", () => ({
 	default: () => <div data-testid="project-terminal-screen" />,
 }));
+vi.mock("../components/TaskImageViewer", () => ({
+	default: () => <div data-testid="image-viewer" />,
+}));
 
 import { api } from "../rpc";
 import { confirm } from "../confirm";
@@ -416,6 +419,81 @@ describe("App keyboard shortcuts", () => {
 			triggerQuickShell();
 
 			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
+		});
+	});
+
+	// `dev3 show-image` while the user is elsewhere raises a clickable toast.
+	// Regression: clicking it opened the lightbox but stayed on the current
+	// screen, so the user never knew which task produced the image. The toast
+	// must navigate to the owning task (honoring open-mode) before opening it.
+	describe("CLI shared-image toast navigation", () => {
+		const oneProject = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+		const sharedImage = {
+			id: "img1",
+			storedPath: "/a/shared-images/img1.png",
+			originalPath: "/tmp/img1.png",
+			name: "img1.png",
+			mime: "image/png",
+			bytes: 123,
+			createdAt: 0,
+		};
+
+		function dispatchShowImage() {
+			act(() => {
+				window.dispatchEvent(
+					new CustomEvent("rpc:cliShowImage", {
+						detail: {
+							taskId: "t-img",
+							projectId: "p1",
+							images: [sharedImage],
+							newCount: 1,
+							taskSeq: 42,
+							taskTitle: "Some task",
+							projectName: "Alpha",
+						},
+					}),
+				);
+			});
+		}
+
+		afterEach(() => {
+			localStorage.removeItem("dev3-task-open-mode");
+		});
+
+		it("split open-mode: clicking the toast navigates to the owning task and opens the viewer", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			// On the board, no task focused.
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "");
+
+			dispatchShowImage();
+			await userEvent.click(await screen.findByText("Agent shared an image"));
+
+			const view = screen.getByTestId("project-screen");
+			expect(view).toHaveAttribute("data-project-id", "p1");
+			expect(view).toHaveAttribute("data-active-task-id", "t-img");
+			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+		});
+
+		it("fullscreen open-mode: clicking the toast opens the full-page task view", async () => {
+			localStorage.setItem("dev3-task-open-mode", "fullscreen");
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			dispatchShowImage();
+			await userEvent.click(await screen.findByText("Agent shared an image"));
+
+			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
+			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Clicking the "Agent shared an image" toast (raised by `dev3 show-image` when you're not viewing the owning task) opened the lightbox but never switched focus to the task that produced the image — so you lost track of where it came from.

The fix mirrors the already-correct shared-artifact handler: on toast click, navigate to the owning task first (honoring the `dev3-task-open-mode` preference — split vs fullscreen), then open the viewer.

- `src/mainview/App.tsx` — `onCliShowImage` toast `onClick` now navigates before `setImageViewer`; added `projectId` to the push destructure and `navigate` to the effect deps.
- Regression tests for both open-modes in `App.test.tsx` (verified red before the fix, green after).

Backend for `show-image` only pushes the in-app toast (`cliShowImage`), no native OS notification, so the fix is renderer-only — no second broken path.