### PR TITLE
Design: scheduled agent message ("Send later")

### DIFF
--- a/decisions/124-scheduled-agent-message.md
+++ b/decisions/124-scheduled-agent-message.md
@@ -1,0 +1,72 @@
+# 124 — Scheduled agent message ("Send later")
+
+## Context
+
+Glossary — **Scheduled message**: a one-shot piece of text the user (or the agent
+via CLI) queues to be delivered into a task's **live agent** at a later moment
+("send at 14:00" / "send in 30 min"). It is the messaging counterpart to a
+**deferred launch** (`scheduledLaunch`, "Start in…"), which defers *spawning* a
+task — a scheduled message instead pokes an **already-running** agent. Users
+wanted to feed a follow-up, remind, or say "continue when CI is green" without
+babysitting the terminal. The two primitives already exist: delivery into a live
+agent pane (`sendPromptToAgentPane` in `src/bun/rpc-handlers/git-operations.ts`,
+used by the Create-PR / rebase-conflict handoffs) and the one-shot timer pattern
+(`src/bun/scheduled-launch-scheduler.ts`).
+
+## Decision
+
+Persist a `scheduledMessages: ScheduledMessage[]` **queue** on the `Task`
+(mirrors `scheduledLaunch`; explicitly NOT designed to survive a tmux-server or
+host restart). Each item is `{ id, text, at, target }`. `target` is either
+`{ kind: "agent" }` (default — resolved dynamically at fire time via
+`resolveAgentPromptTargetPane`, because the agent pane is recreated with fresh
+ids) or `{ kind: "pane", paneId }` (a concrete live pane picked from a list;
+raw, ephemeral id). A new `src/bun/scheduled-message-scheduler.ts` (30 s tick,
+structural copy of the launch scheduler) fires due items by typing the text and
+then Enter (auto-submit) into the resolved pane.
+
+Entry points: (1) a `ScheduleMessageModal` opened from the active task (card
+menu / info panel), built on a shared `SchedulePicker` extracted from
+`LaunchVariantsModal` (in/at modes, range ≤ 99 h / today–tomorrow); (2) a clock
+button in `TerminalComposer` (browser/touch) that opens the same modal seeded
+with the composer text; (3) CLI `dev3 message [--in <dur>|--at <hh:mm>] "text"`
+— bare form sends immediately, `--in`/`--at` schedules, task auto-detected from
+cwd. The action is offered only when the task has a **live agent session**.
+Pending items support **cancel** and **send-now** (no inline edit — cancel and
+recreate).
+
+Fire-time semantics:
+- **Agent busy** (mid-generation, not at a prompt) → send anyway, best-effort;
+  the agent queues the input. Identical to the existing PR/rebase handoff.
+- **Target unresolvable** (agent exited / pane dead / task in a terminal status /
+  tmux dead) → mark undelivered, **notify + drop**, never retry.
+- **App offline at due time** but the session survived the restart → fire late
+  and notify it slipped; if tmux itself died there is nothing to deliver to, so
+  this collapses into the notify + drop path.
+- **Successful fire while the app is open** is silent (the user sees it land in
+  the terminal); only late-fire and drop raise a toast/attention.
+
+## Risks
+
+`send-keys` into a busy or prompt-waiting agent can land text in an unexpected
+input state (a y/n confirmation, a menu) — accepted, because the existing
+Create-PR / rebase handoff buttons already carry exactly this risk. A stored
+`paneId` is valid only within one tmux-server lifetime; by decision we do not
+attempt restart survival, so a stale id simply takes the notify + drop path.
+Agent-authored `dev3 message --in` lets an agent schedule a poke to itself —
+intended ("wake me later"), so no loop guard.
+
+## Alternatives considered
+
+- **Extend Automations to target an existing task's agent** — Automations
+  *create new tasks* on an rrule; retargeting them to inject into a live agent
+  conflates recurring task-creation with one-shot messaging and is a much larger
+  refactor. Rejected.
+- **Symbolic-role target only** (`agent` / `active-pane` / `dev-server`, resolved
+  at fire) — more robust across restarts, but the user explicitly dropped the
+  restart-survival requirement, so a concrete `paneId` is simpler and sufficient
+  (agent still stays a dynamic role).
+- **Single scheduled message that overwrites** (like `scheduledLaunch`) —
+  rejected; a queue is natural for messages ("in 5m X, in 30m Y").
+- **Wait-until-idle before delivering** — idle detection is unreliable and delays
+  delivery; best-effort send chosen instead.

--- a/docs/ux/PRODUCT_UX_BIBLE.md
+++ b/docs/ux/PRODUCT_UX_BIBLE.md
@@ -138,7 +138,7 @@ The inspector header (`TaskInfoPanel.tsx`, both collapsed and expanded states) i
 | Bar | Position | Domain | Contents | Evidence |
 |---|---|---|---|---|
 | Context | row 1, left | task identity & lifecycle | watch toggle, status dropdown, diff-summary badge, include-tests toggle, label strip | `TaskInfoPanel.tsx` (row 1 left cluster) |
-| Session/Agent | row 1, right | drive the session & agents | spawn extra agent, bug hunters, tmux controls | `TaskInfoPanel.tsx` (row 1 right cluster), `TaskTmuxControls.tsx` |
+| Session/Agent | row 1, right | drive the session & agents | spawn extra agent, bug hunters, tmux controls, send message later (scheduled agent message) | `TaskInfoPanel.tsx` (row 1 right cluster), `TaskTmuxControls.tsx` |
 | Git | row 2, left | branch & PR | branch name/status, show diff, refresh, copy worktree path, open PR | `task-info-panel/TaskGitActions.tsx` |
 | Runtime & access | row 2, right | project runtime outputs + access to them | open-in, scripts, dev server, ports, separate conditional Images and Artifacts controls (count>0 only); ports/resources also render as detail in the expanded body | `task-info-panel/TaskOpenIn.tsx`, `TaskSharedImages.tsx`, `TaskArtifacts.tsx` |
 

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -4,6 +4,12 @@ Compact index of UX architecture decisions — the *why* behind rules that live 
 `PRODUCT_UX_BIBLE.md` / `ux-architecture.yaml`. Max ~5 lines per entry; details live in
 git history, PRs, and `decisions/NNN-*.md`. Newest first.
 
+## 2026-07-11 — Scheduled agent message ("Send later")
+
+- **Rule:** A one-shot text queued to a task's **live agent** (deliver at a wall-clock time / after a delay; type + Enter) is a **session action**. Create it from the **Session/Agent inspector bar**, the card **context menu**, and a **clock button in the browser/touch `TerminalComposer`**; plus CLI `dev3 message [--in|--at] "…"` (bare = send now). Pending items render as a **card timer-chip** (popover: cancel / send-now) that **shares the single deferred-timer slot with deferred launch** — the two never coexist (`todo` vs live-agent). Reuses the `LaunchVariantsModal` in/at picker via an extracted shared `SchedulePicker`. Offered only when a live agent session exists.
+- **Why:** it pokes a *running* agent, so it belongs to the session domain, not Runtime; reusing the launch picker + the one deferred-timer chip adds no new badge class and no budget exception. Excluded from the ⇧⌘P palette (modal/inline-flow policy, same as spawn) and it is not a destination. Rejected: extending Automations (they create *new tasks*, not message a live agent) and a bespoke "Reminders" panel.
+- **Status:** Planned. Evidence: `decisions/124-scheduled-agent-message.md`; bible §5.1 (session_agent bar); `LaunchVariantsModal.tsx`, `TerminalComposer.tsx`, `scheduled-launch-scheduler.ts`.
+
 ## 2026-07-10 — Token-DSL task filters: search string is the single source of truth
 
 - **Rule:** Structured filtering on the board and sidebar is a token DSL (`priority:` `label:` `agent:` `status:` `is:attention` `has:port`) living inside the *one* search string; a shared `FilterFunnel` dropdown (grouped PRIORITY/STATUS/LABELS/AGENTS/FLAGS, PRIORITY first, values-in-pool only, empty groups hidden), the P0–P4 priority quick-chips, and the kanban label chips are all *views* of that string — checking/clicking edits a token, none holds separate filter state. Funnel is a `ghost` icon button snug against the search box with an accent count badge; one `HelpSpot` teaches the operators. Filter/checked use different comparisons: substring match filters, exact (case-insensitive) token presence drives checked/active. Board shows the most-popular labels inline (`+N more` opens the funnel). Ephemeral (resets on unmount), renderer-only, extensible registry.

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -204,8 +204,9 @@ ux_architecture:
       evidence: ["src/mainview/components/KanbanBoard.tsx", "src/mainview/components/KanbanColumn.tsx", "src/mainview/components/LabelFilterBar.tsx"]
     task_card:
       purpose: "Compact object summary on the board with the most relevant per-task affordances."
-      allowed: ["status_dot", "label_chip", "variant_dots", "open_action", "context_menu", "git_status_badge"]
+      allowed: ["status_dot", "label_chip", "variant_dots", "open_action", "context_menu", "git_status_badge", "deferred_timer_chip"]
       forbidden: ["full_settings", "global_destination"]
+      deferred_timer_chip: "One shared countdown-chip slot (popover with cancel / run-now, 30s re-render) for deferred agent interactions. Content depends on state and the two NEVER coexist: scheduledLaunch on a `todo` card, scheduledMessages on a live-agent card. Do not add a second timer badge class."
       visible_budget:
         max_inline_actions: 2
         overflow_to: "context_menu"
@@ -231,7 +232,8 @@ ux_architecture:
           session_agent:
             position: "row1.right"
             domain: "drive the session & agents"
-            contents: ["spawn_agent", "bug_hunters", "tmux_controls"]
+            contents: ["spawn_agent", "bug_hunters", "tmux_controls", "send_scheduled_message"]
+            note: "send_scheduled_message (\"Send later\") queues a one-shot prompt to the live agent; it drives the session, so it lives here, NOT in the runtime bar. Offered only when a live agent session exists. See UX_DECISIONS 2026-07-11 + decisions/124."
           git:
             position: "row2.left"
             domain: "branch & PR"


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — a design/docs-only PR, no product code.

## Summary

Captures the design for a **scheduled message**: a one-shot text queued to a task's **live agent**, delivered at a wall-clock time or after a delay (type + Enter into the agent pane) — the messaging counterpart to the existing deferred *launch* (`scheduledLaunch`, "Start in…"). Produced from a grilling + domain-modeling + `ux-principal` session.

- **`decisions/124-scheduled-agent-message.md`** — ADR: a `scheduledMessages[]` queue on `Task`, `{kind:"agent"}` (dynamic resolve) or `{kind:"pane",paneId}` target, best-effort delivery via the existing `sendPromptToAgentPane`, and fire-time semantics (busy → send anyway; unresolvable → notify + drop; offline → late-fire + notify; success is silent). Not designed to survive a tmux/host restart.
- **UX manifest** — placement recorded once: `send_scheduled_message` in the inspector Session/Agent bar, a shared card **deferred-timer chip** slot (mutually exclusive with the deferred-launch badge), a browser/touch composer clock, and CLI `dev3 message [--in|--at]`. Excluded from the ⇧⌘P palette (modal-flow policy) and not a new destination. `docs/ux/ux-architecture.yaml`, `PRODUCT_UX_BIBLE.md` §5.1, one `UX_DECISIONS.md` entry.

Implementation is tracked separately as a `ready-for-agent` spec task on the dev3 board; no `src/` changes here. `bun run lint` and `bun run test` are green.