### PR TITLE
Fix mobile RPC and PTY reconnect

### DIFF
--- a/change-logs/2026/07/12/fix-mobile-rpc-pty-reconnect.md
+++ b/change-logs/2026/07/12/fix-mobile-rpc-pty-reconnect.md
@@ -1,0 +1,1 @@
+Mobile remote sessions now recover both RPC requests and the active tmux terminal after the browser returns from the background. Reconnects replace stale sockets without duplicating listeners, requests made during an outage are delivered when the replacement RPC socket opens, and authenticated PTY URLs are redacted from reconnect logs.

--- a/decisions/126-mobile-websocket-resume-reconnect.md
+++ b/decisions/126-mobile-websocket-resume-reconnect.md
@@ -1,0 +1,21 @@
+# 126 — Replace mobile WebSockets after resume
+
+## Context
+
+Mobile browsers suspend JavaScript and networking when the screen closes. On resume, a WebSocket can remain reported as `OPEN` or `CONNECTING` without delivering another close event, while the PTY client previously treated any close as a permanent session end and the RPC client could lose requests created between close and reconnect.
+
+## Investigation
+
+Deterministic renderer tests reproduced both failures: `TerminalView` created no replacement socket after a `1006` close, and an RPC request created during the reconnect delay was never sent after the replacement opened. The RPC loss came from awaiting a previously resolved socket-ready promise, while the PTY had no reconnect path at all.
+
+## Decision
+
+`src/mainview/rpc.ts` queues unsent request packets until the current socket opens, deduplicates reconnect timers, ignores events from replaced sockets, and replaces stale sockets on `visibilitychange`, `pageshow`, and `online`. `src/mainview/TerminalView.tsx` applies the same lifecycle triggers with bounded backoff, preserves one set of terminal input subscriptions, and reserves the permanent session-ended state for clean `1000` closes.
+
+## Risks
+
+Returning from the background intentionally replaces even an apparently open socket, so an in-flight RPC request can reject and be retried by its caller. This is preferable to trusting a mobile socket whose browser-visible state can be stale indefinitely.
+
+## Alternatives considered
+
+Relying only on reconnect timers was rejected because mobile browsers throttle or freeze them in the background. Reloading the task screen was rejected because it discards renderer state and hides the transport bug instead of recovering both connections in place.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -330,6 +330,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		let disposed = false;
 		let fitAddon: FitAddon | null = null;
 		let ws: WebSocket | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+		let reconnectAttempt = 0;
+		let terminalInputBound = false;
+		let wasHidden = document.visibilityState === "hidden";
 		let layoutObserver: ResizeObserver | null = null;
 		let mouseCleanup: (() => void) | undefined;
 		let nativeSelectionClipboardCleanup: (() => void) | undefined;
@@ -1041,37 +1045,49 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		}
 
 		function connectPty(term: Terminal, fit: FitAddon) {
+			if (disposed || ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+			if (reconnectTimer !== null) {
+				clearTimeout(reconnectTimer);
+				reconnectTimer = null;
+			}
 			batchTerm = term;
-			console.log("[TerminalView] Creating WebSocket connection to", ptyUrl);
+			const diagnosticPtyUrl = ptyUrl.replace(/([?&]token=)[^&]+/, "$1***");
+			console.log("[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
+			let socket: WebSocket;
 			try {
-				ws = new WebSocket(ptyUrl);
+				socket = new WebSocket(ptyUrl);
 			} catch (err) {
 				console.error("[TerminalView] WebSocket constructor FAILED:", err);
-				console.error("[TerminalView] URL was:", ptyUrl);
+				console.error("[TerminalView] URL was:", diagnosticPtyUrl);
+				schedulePtyReconnect(term, fit);
 				return;
 			}
+			ws = socket;
 			wsRef.current = ws;
 			console.log("[TerminalView] WebSocket created, readyState:", ws.readyState);
 
-			ws.onopen = () => {
+			socket.onopen = () => {
+				if (socket !== ws) return;
 				console.log("[TerminalView] WebSocket OPEN");
 				if (disposed) return;
+				reconnectAttempt = 0;
 				const dims = fit.proposeDimensions();
 				console.log("[TerminalView] Proposed dimensions:", dims);
 				if (dims) {
 					// See buildResizeDance() — row-nudge keeps text wrapping
 					// identical between the two paints. See decision 041.
 					const [nudge, correct] = buildResizeDance(dims.cols, dims.rows);
-					ws?.send(nudge);
+					socket.send(nudge);
 					setTimeout(() => {
-						if (ws?.readyState === WebSocket.OPEN) {
-							ws.send(correct);
+						if (socket === ws && socket.readyState === WebSocket.OPEN) {
+							socket.send(correct);
 						}
 					}, 50);
 				}
 			};
 
-			ws.onmessage = (event) => {
+			socket.onmessage = (event) => {
+				if (socket !== ws) return;
 				if (disposed) return;
 				try {
 					if (typeof event.data === "string") {
@@ -1088,23 +1104,29 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 				}
 			};
 
-			ws.onclose = (event) => {
+			socket.onclose = (event) => {
+				if (socket !== ws) return;
+				ws = null;
+				wsRef.current = null;
 				console.warn("[TerminalView] WebSocket CLOSED", {
 					code: event.code,
 					reason: event.reason,
 					wasClean: event.wasClean,
 				});
 				if (disposed) return;
-				try { term.writeln("\r\n\x1b[2m[session ended]\x1b[0m"); } catch { /* disposed */ }
+				if (event.code === 1000 && event.wasClean) {
+					try { term.writeln("\r\n\x1b[2m[session ended]\x1b[0m"); } catch { /* disposed */ }
+					return;
+				}
+				schedulePtyReconnect(term, fit);
 			};
 
-			ws.onerror = (event) => {
+			socket.onerror = (event) => {
+				if (socket !== ws) return;
 				console.error("[TerminalView] WebSocket ERROR", event);
-				if (disposed) return;
-				try { term.writeln("\x1b[31mFailed to connect to PTY server\x1b[0m"); } catch { /* disposed */ }
 			};
 
-			termSubs.push(
+			if (!terminalInputBound) termSubs.push(
 				term.onData((data) => {
 					if (disposed) return;
 					if (ws?.readyState === WebSocket.OPEN) {
@@ -1118,13 +1140,58 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					}
 				}),
 			);
+			terminalInputBound = true;
 		}
+
+		function schedulePtyReconnect(term: Terminal, fit: FitAddon): void {
+			if (disposed || reconnectTimer !== null) return;
+			if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+			const delayMs = Math.min(1_000 * 2 ** reconnectAttempt, 15_000);
+			reconnectAttempt += 1;
+			reconnectTimer = setTimeout(() => {
+				reconnectTimer = null;
+				connectPty(term, fit);
+			}, delayMs);
+		}
+
+		function reconnectPtyOnResume(event: Event): void {
+			if (disposed) return;
+			if (document.visibilityState === "hidden") {
+				wasHidden = true;
+				return;
+			}
+			const term = termRef.current;
+			const fit = fitAddonRef.current;
+			if (!term || !fit) return;
+			const returnedFromBackground = wasHidden;
+			wasHidden = false;
+			// Ignore the non-persisted pageshow fired during initial page load. A
+			// persisted pageshow is a bfcache resume and must replace the socket.
+			if (event.type === "pageshow" && !(event as PageTransitionEvent).persisted && !returnedFromBackground) return;
+			if (ws?.readyState === WebSocket.OPEN && event.type === "visibilitychange" && !returnedFromBackground) return;
+			// Mobile browsers can suspend a socket while it is CONNECTING and never
+			// emit its eventual close; an OPEN socket can be stale for the same reason.
+			// Foregrounding explicitly replaces either state.
+			const stale = ws;
+			ws = null;
+			wsRef.current = null;
+			try { stale?.close(); } catch { /* already closed */ }
+			connectPty(term, fit);
+		}
+
+		document.addEventListener("visibilitychange", reconnectPtyOnResume);
+		window.addEventListener("pageshow", reconnectPtyOnResume);
+		window.addEventListener("online", reconnectPtyOnResume);
 
 		// setup() is called after font preload above — not here directly
 
 		return () => {
 			console.log("[TerminalView] Cleanup (unmount/re-render)", { taskId: taskId.slice(0, 8) });
 			disposed = true;
+			document.removeEventListener("visibilitychange", reconnectPtyOnResume);
+			window.removeEventListener("pageshow", reconnectPtyOnResume);
+			window.removeEventListener("online", reconnectPtyOnResume);
+			if (reconnectTimer !== null) clearTimeout(reconnectTimer);
 			// Cancel pending write batch to prevent writing to disposed terminal
 			if (writeRafId !== null) {
 				cancelAnimationFrame(writeRafId);
@@ -1286,11 +1353,11 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			try { dims = fit.proposeDimensions(); } catch { return; /* disposed */ }
 			if (!dims) return;
 
-			const nudgeCols = Math.max(2, dims.cols - 1);
-			ws.send(`\x1b]resize;${nudgeCols};${dims.rows}\x07`);
+			const [nudge, correct] = buildResizeDance(dims.cols, dims.rows);
+			ws.send(nudge);
 			setTimeout(() => {
 				if (ws.readyState === WebSocket.OPEN) {
-					ws.send(`\x1b]resize;${dims.cols};${dims.rows}\x07`);
+					ws.send(correct);
 				}
 			}, 50);
 		}

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -122,10 +122,14 @@ vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
 
 // Minimal WebSocket stub (just needs to not throw during connectPty)
 let lastWebSocket: MockWebSocket | null = null;
+let webSockets: MockWebSocket[] = [];
 let clipboardWriteTextMock: ReturnType<typeof vi.fn>;
 
 class MockWebSocket {
+	static CONNECTING = 0;
 	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
 	readyState = MockWebSocket.OPEN;
 	send = vi.fn();
 	close = vi.fn();
@@ -136,6 +140,7 @@ class MockWebSocket {
 
 	constructor() {
 		lastWebSocket = this;
+		webSockets.push(this);
 	}
 }
 vi.stubGlobal("WebSocket", class extends MockWebSocket {});
@@ -171,6 +176,9 @@ beforeAll(() => {
 beforeEach(() => {
 	vi.clearAllMocks();
 	fireResize = null;
+	lastWebSocket = null;
+	webSockets = [];
+	Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
 
 	// document.fonts.load must resolve immediately so setup() runs in tests
 	Object.defineProperty(document, "fonts", {
@@ -206,6 +214,47 @@ async function renderAndSetup() {
 	});
 	return result;
 }
+
+describe("TerminalView – PTY reconnect", () => {
+	it("ignores initial pageshow but reconnects after a bfcache restore", async () => {
+		await renderAndSetup();
+		const initialPageShow = new Event("pageshow");
+		Object.defineProperty(initialPageShow, "persisted", { value: false });
+		window.dispatchEvent(initialPageShow);
+		expect(webSockets).toHaveLength(1);
+
+		const restoredPageShow = new Event("pageshow");
+		Object.defineProperty(restoredPageShow, "persisted", { value: true });
+		window.dispatchEvent(restoredPageShow);
+		expect(webSockets).toHaveLength(2);
+	});
+
+	it("replaces an apparently-open PTY socket after a mobile background cycle", async () => {
+		await renderAndSetup();
+		expect(webSockets).toHaveLength(1);
+
+		Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+		document.dispatchEvent(new Event("visibilitychange"));
+		Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+		document.dispatchEvent(new Event("visibilitychange"));
+
+		expect(webSockets).toHaveLength(2);
+		expect(webSockets[0].close).toHaveBeenCalledTimes(1);
+	});
+
+	it("reconnects the PTY when a dropped mobile connection returns to the foreground", async () => {
+		await renderAndSetup();
+		expect(webSockets).toHaveLength(1);
+
+		await act(async () => {
+			webSockets[0].readyState = WebSocket.CLOSED;
+			webSockets[0].onclose?.({ code: 1006, reason: "network gone", wasClean: false } as CloseEvent);
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+
+		expect(webSockets).toHaveLength(2);
+	});
+});
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/src/mainview/__tests__/rpc-transport.test.ts
+++ b/src/mainview/__tests__/rpc-transport.test.ts
@@ -92,6 +92,7 @@ describe("Browser RPC transport", () => {
 		vi.resetModules();
 		vi.clearAllMocks();
 		vi.unstubAllGlobals();
+		localStorage.clear();
 		delete (window as any).__electrobunWebviewId;
 		document.documentElement.classList.remove("browser-mode");
 	});
@@ -156,5 +157,64 @@ describe("Browser RPC transport", () => {
 		await Promise.resolve();
 		expect(rejection).toBeInstanceOf(Error);
 		expect((rejection as Error).message).toContain("RPC connection closed");
+	});
+
+	it("delivers requests started while reconnecting after the replacement socket opens", async () => {
+		vi.useFakeTimers();
+		const sockets: MockWebSocket[] = [];
+		localStorage.setItem("dev3-remote-session", "stored-token");
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ token: "refreshed-token" }),
+		}));
+
+		class MockWebSocket {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSING = 2;
+			static CLOSED = 3;
+
+			readyState = MockWebSocket.CONNECTING;
+			readonly send = vi.fn();
+			readonly close = vi.fn();
+			private readonly listeners = new Map<string, Array<(event: any) => void>>();
+
+			constructor(public readonly url: string) {
+				sockets.push(this);
+			}
+
+			addEventListener(type: string, listener: (event: any) => void) {
+				const current = this.listeners.get(type) ?? [];
+				current.push(listener);
+				this.listeners.set(type, current);
+			}
+
+			dispatch(type: string, event: any = {}) {
+				for (const listener of this.listeners.get(type) ?? []) listener(event);
+			}
+		}
+
+		vi.stubGlobal("WebSocket", MockWebSocket);
+
+		const { api } = await import("../rpc");
+		await Promise.resolve();
+		await Promise.resolve();
+		const first = sockets[0];
+		first.readyState = MockWebSocket.OPEN;
+		first.dispatch("open");
+		first.readyState = MockWebSocket.CLOSED;
+		first.dispatch("close", { code: 1006, reason: "network gone" });
+
+		void (api.request as any).getAvailableApps();
+		await vi.advanceTimersByTimeAsync(2_000);
+		const replacement = sockets[1];
+		expect(replacement).toBeDefined();
+		replacement.readyState = MockWebSocket.OPEN;
+		replacement.dispatch("open");
+		await Promise.resolve();
+
+		expect(replacement.send).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(sockets).toHaveLength(2);
 	});
 });

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -419,20 +419,29 @@ function initBrowserApi(): ApiShape {
 
 	let ws: WebSocket | null = null;
 	let requestId = 0;
-	const pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
-	// Promise that resolves when WS is open — reset on each connect
-	let wsReady: Promise<void>;
-	let wsReadyResolve: (() => void) | null = null;
+	let authComplete = false;
+	let wasHidden = document.visibilityState === "hidden";
+	const pending = new Map<number, {
+		resolve: (v: any) => void;
+		reject: (e: Error) => void;
+		packet: string;
+		sent: boolean;
+	}>();
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-	function resetWsReady() {
-		wsReady = new Promise((resolve) => { wsReadyResolve = resolve; });
-	}
-	resetWsReady();
-
-	function rejectPendingRequests(error: Error) {
+	function rejectSentRequests(error: Error) {
 		for (const [id, entry] of pending.entries()) {
+			if (!entry.sent) continue;
 			pending.delete(id);
 			entry.reject(error);
+		}
+	}
+
+	function flushQueuedRequests(socket: WebSocket): void {
+		for (const entry of pending.values()) {
+			if (entry.sent) continue;
+			socket.send(entry.packet);
+			entry.sent = true;
 		}
 	}
 
@@ -440,21 +449,36 @@ function initBrowserApi(): ApiShape {
 	// "connecting" from a post-drop "reconnecting" (better wording for the user).
 	let hasConnected = false;
 
+	function scheduleReconnect(delayMs = 2_000): void {
+		if (reconnectTimer !== null) return;
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			connect();
+		}, delayMs);
+	}
+
 	function connect() {
+		if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
 		const wsUrl = buildWsUrl("/rpc");
 		console.log("[browser-rpc] Connecting WS to", wsUrl.replace(/token=[^&]+/, "token=***"));
 		setRpcState(hasConnected ? "reconnecting" : "connecting");
-		resetWsReady();
-		ws = new WebSocket(wsUrl);
+		const socket = new WebSocket(wsUrl);
+		ws = socket;
 
-		ws.addEventListener("open", () => {
+		socket.addEventListener("open", () => {
+			if (socket !== ws) return;
 			console.log("[browser-rpc] WS OPEN");
 			hasConnected = true;
 			setRpcState("connected");
-			wsReadyResolve?.();
+			flushQueuedRequests(socket);
 		});
 
-		ws.addEventListener("message", (event) => {
+		socket.addEventListener("message", (event) => {
+			if (socket !== ws) return;
 			try {
 				const packet = JSON.parse(event.data);
 
@@ -477,9 +501,11 @@ function initBrowserApi(): ApiShape {
 			}
 		});
 
-		ws.addEventListener("close", (event) => {
+		socket.addEventListener("close", (event) => {
+			if (socket !== ws) return;
+			ws = null;
 			console.warn("[browser-rpc] WS CLOSED", { code: event.code, reason: event.reason, hasToken: !!sessionToken });
-			rejectPendingRequests(
+			rejectSentRequests(
 				new Error(`RPC connection closed (code ${event.code}${event.reason ? `: ${event.reason}` : ""})`),
 			);
 			// Only reconnect if we have a valid session token (or are in Vite dev mode).
@@ -492,7 +518,7 @@ function initBrowserApi(): ApiShape {
 					message: `Connection to the server dropped (code ${event.code})${event.reason ? `: ${event.reason}` : ""}`,
 					source: "websocket",
 				});
-				setTimeout(connect, 2000);
+				scheduleReconnect();
 			} else {
 				console.warn("[browser-rpc] No session token — skipping reconnect");
 				setRpcState("closed");
@@ -505,7 +531,8 @@ function initBrowserApi(): ApiShape {
 			}
 		});
 
-		ws.addEventListener("error", (event) => {
+		socket.addEventListener("error", (event) => {
+			if (socket !== ws) return;
 			console.error("[browser-rpc] WS ERROR", event);
 			recordDiagnostic({
 				kind: "rpc",
@@ -520,15 +547,47 @@ function initBrowserApi(): ApiShape {
 	// Soft reconnect for the bootstrap "Retry": drop the current socket (its close
 	// handler schedules a reconnect) and, if it was already closed, open a fresh one.
 	reconnectImpl = () => {
-		if (ws && ws.readyState === WebSocket.OPEN) {
-			ws.close();
-		} else {
-			connect();
+		rejectSentRequests(new Error("RPC connection restarted"));
+		const stale = ws;
+		ws = null;
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
 		}
+		try { stale?.close(); } catch { /* already closed */ }
+		connect();
 	};
 
+	function reconnectOnResume(event: Event): void {
+		if (document.visibilityState === "hidden") {
+			wasHidden = true;
+			return;
+		}
+		if (!authComplete) return;
+		const returnedFromBackground = wasHidden;
+		wasHidden = false;
+		// `pageshow` also fires once on a normal first load. Only its persisted
+		// (bfcache restore) form is a resume signal; initial auth owns first connect.
+		if (event.type === "pageshow" && !(event as PageTransitionEvent).persisted && !returnedFromBackground) return;
+		if (ws?.readyState === WebSocket.OPEN && event.type === "visibilitychange" && !returnedFromBackground) return;
+		// A CONNECTING socket created before mobile suspension can remain stuck
+		// indefinitely, and an apparently OPEN socket may already be dead underneath.
+		// Replace either one after a real background/pageshow/online transition.
+		rejectSentRequests(new Error("RPC connection replaced after resume"));
+		const stale = ws;
+		ws = null;
+		try { stale?.close(); } catch { /* already closed */ }
+		connect();
+	}
+	document.addEventListener("visibilitychange", reconnectOnResume);
+	window.addEventListener("pageshow", reconnectOnResume);
+	window.addEventListener("online", reconnectOnResume);
+
 	// Gate WS connection behind auth
-	authReady.then(connect);
+	authReady.then(() => {
+		authComplete = true;
+		connect();
+	});
 
 	function rpcRequest(method: string, params: any): Promise<any> {
 		return new Promise((resolve, reject) => {
@@ -544,20 +603,19 @@ function initBrowserApi(): ApiShape {
 				reject(new Error(`RPC request "${method}" timed out`));
 			}, RPC_TIMEOUT_MS);
 
-			pending.set(id, {
-				resolve: (v) => { clearTimeout(timeout); resolve(v); },
-				reject: (e) => { clearTimeout(timeout); reject(e); },
-			});
-
 			const packet = JSON.stringify({ type: "request", id, method, params });
+			const entry = {
+				resolve: (v: any) => { clearTimeout(timeout); resolve(v); },
+				reject: (e: Error) => { clearTimeout(timeout); reject(e); },
+				packet,
+				sent: false,
+			};
+			pending.set(id, entry);
 
-			// Wait for WS to be open before sending (no polling)
-			wsReady.then(() => {
-				if (!pending.has(id)) return; // already timed out
-				if (ws?.readyState === WebSocket.OPEN) {
-					ws.send(packet);
-				}
-			});
+			if (ws?.readyState === WebSocket.OPEN) {
+				ws.send(packet);
+				entry.sent = true;
+			}
 		});
 	}
 


### PR DESCRIPTION
## Summary

- reconnect the active PTY in place after mobile background, bfcache, and network resume events
- queue RPC requests made during reconnect and deliver them through the replacement socket
- replace stale OPEN or CONNECTING sockets without duplicating timers or terminal subscriptions
- redact authenticated PTY URLs in reconnect logs
- document the mobile WebSocket resume strategy and add regression coverage

## Testing

- bun run lint
- bun run test (5200 passed, 0 failed)
- mobile browser QA with an active task terminal and synthetic resume event