### PR TITLE
Fix mobile project/task state desync

### DIFF
--- a/change-logs/2026/07/12/fix-mobile-project-task-desync.md
+++ b/change-logs/2026/07/12/fix-mobile-project-task-desync.md
@@ -1,0 +1,1 @@
+Fixed mobile project switching so stale task cards cannot open under another project's breadcrumb. Late task-load responses are now ignored after navigating away.

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -58,6 +58,42 @@ describe("reducer", () => {
 		expect(next.route).toEqual({ screen: "project", projectId: "p1" });
 	});
 
+	it("navigate: clears tasks from the previous project immediately", () => {
+		const state: AppState = {
+			...initialState,
+			route: { screen: "project", projectId: "p1" },
+			currentProjectTasks: [mockTask],
+		};
+
+		const next = reducer(state, {
+			type: "navigate",
+			route: { screen: "project", projectId: "p2" },
+		});
+
+		expect(next.currentProjectTasks).toEqual([]);
+	});
+
+	it("history navigation: clears tasks when crossing project boundaries", () => {
+		const taskForSecondProject = { ...mockTask, id: "t2", projectId: "p2" };
+		const secondProjectRoute = { screen: "project" as const, projectId: "p2" };
+		const state: AppState = {
+			...initialState,
+			route: secondProjectRoute,
+			routeHistory: [{ screen: "project", projectId: "p1" }, secondProjectRoute],
+			historyIndex: 1,
+			currentProjectTasks: [taskForSecondProject],
+		};
+
+		const previousProject = reducer(state, { type: "goBack" });
+		expect(previousProject.currentProjectTasks).toEqual([]);
+
+		const nextProject = reducer(
+			{ ...previousProject, currentProjectTasks: [mockTask] },
+			{ type: "goForward" },
+		);
+		expect(nextProject.currentProjectTasks).toEqual([]);
+	});
+
 	it("navigate: pushes to routeHistory and advances historyIndex", () => {
 		const next = reducer(initialState, {
 			type: "navigate",
@@ -259,11 +295,33 @@ describe("reducer", () => {
 	});
 
 	it("setTasks: replaces currentProjectTasks", () => {
-		const next = reducer(initialState, {
+		const state: AppState = {
+			...initialState,
+			route: { screen: "project", projectId: "p1" },
+		};
+		const next = reducer(state, {
 			type: "setTasks",
+			projectId: "p1",
 			tasks: [mockTask],
 		});
 		expect(next.currentProjectTasks).toEqual([mockTask]);
+	});
+
+	it("setTasks: ignores a late response from a different project", () => {
+		const taskForCurrentProject = { ...mockTask, id: "t2", projectId: "p2" };
+		const state: AppState = {
+			...initialState,
+			route: { screen: "project", projectId: "p2" },
+			currentProjectTasks: [taskForCurrentProject],
+		};
+
+		const next = reducer(state, {
+			type: "setTasks",
+			projectId: "p1",
+			tasks: [mockTask],
+		});
+
+		expect(next).toBe(state);
 	});
 
 	it("updateTask: updates matching task", () => {

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -975,7 +975,7 @@ function ProjectSettings({
 		(async () => {
 			try {
 				const loaded = await api.request.getTasks({ projectId });
-				if (!cancelled) dispatch({ type: "setTasks", tasks: loaded });
+				if (!cancelled) dispatch({ type: "setTasks", projectId, tasks: loaded });
 			} catch (err) {
 				console.error("Failed to load tasks for project settings:", err);
 			}

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -76,7 +76,7 @@ function ProjectView({
 			try {
 				const tasks = await api.request.getTasks({ projectId });
 				if (!cancelled && taskUpdateEpoch === taskUpdateEpochRef.current) {
-					dispatch({ type: "setTasks", tasks });
+					dispatch({ type: "setTasks", projectId, tasks });
 				}
 			} catch (err) {
 				console.error("Failed to load tasks:", err);

--- a/src/mainview/components/TaskWorkspaceView.tsx
+++ b/src/mainview/components/TaskWorkspaceView.tsx
@@ -46,14 +46,18 @@ function TaskWorkspaceView({
 	// Load the project's tasks on mount, mirroring ProjectView, so the chrome
 	// always renders regardless of the entry point.
 	useEffect(() => {
+		let cancelled = false;
 		(async () => {
 			try {
 				const loaded = await api.request.getTasks({ projectId });
-				dispatch({ type: "setTasks", tasks: loaded });
+				if (!cancelled) dispatch({ type: "setTasks", projectId, tasks: loaded });
 			} catch (err) {
 				console.error("Failed to load tasks:", err);
 			}
 		})();
+		return () => {
+			cancelled = true;
+		};
 	}, [projectId, dispatch]);
 
 	// The inline diff opens in-place (not a route) — fire its page view once per

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -74,7 +74,7 @@ describe("ProjectView task-view layout", () => {
 		resolveTasks!([]);
 
 		await Promise.resolve();
-		expect(dispatch).not.toHaveBeenCalledWith({ type: "setTasks", tasks: [] });
+		expect(dispatch).not.toHaveBeenCalledWith({ type: "setTasks", projectId: "p1", tasks: [] });
 	});
 
 	it("shows the empty-terminal placeholder when taskView is set but no task is selected", async () => {

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -133,7 +133,7 @@ describe("TaskWorkspaceView", () => {
 
 		await waitFor(() => expect(getTasksMock).toHaveBeenCalledWith({ projectId: "p1" }));
 		await waitFor(() =>
-			expect(dispatch).toHaveBeenCalledWith({ type: "setTasks", tasks: [task] }),
+			expect(dispatch).toHaveBeenCalledWith({ type: "setTasks", projectId: "p1", tasks: [task] }),
 		);
 	});
 

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -166,7 +166,7 @@ export type AppAction =
 	| { type: "goForward" }
 	| { type: "setProjects"; projects: Project[] }
 	| { type: "reorderProjects"; projectIds: string[] }
-	| { type: "setTasks"; tasks: Task[] }
+	| { type: "setTasks"; projectId: string; tasks: Task[] }
 	| { type: "updateTask"; task: Task }
 	| { type: "addTask"; task: Task }
 	| { type: "removeTask"; taskId: string }
@@ -216,6 +216,8 @@ export function reducer(state: AppState, action: AppAction): AppState {
 	switch (action.type) {
 		case "navigate": {
 			const { bellCounts, bellReasons } = clearBellForRoute(state.bellCounts, state.bellReasons, action.route);
+			const currentProjectId = projectIdForRoute(state.route);
+			const nextProjectId = projectIdForRoute(action.route);
 			// Truncate any forward history beyond the current index, then push
 			const base = state.routeHistory.slice(0, state.historyIndex + 1);
 			base.push(action.route);
@@ -223,7 +225,16 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			const routeHistory = base.length > HISTORY_LIMIT ? base.slice(base.length - HISTORY_LIMIT) : base;
 			const historyIndex = routeHistory.length - 1;
 			const taskMru = bumpMru(state.taskMru, action.route);
-			return { ...state, route: action.route, routeHistory, historyIndex, bellCounts, bellReasons, taskMru };
+			return {
+				...state,
+				route: action.route,
+				routeHistory,
+				historyIndex,
+				bellCounts,
+				bellReasons,
+				taskMru,
+				currentProjectTasks: currentProjectId === nextProjectId ? state.currentProjectTasks : [],
+			};
 		}
 		case "goBack": {
 			if (state.historyIndex <= 0) return state;
@@ -231,7 +242,16 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			const route = state.routeHistory[newIndex];
 			const { bellCounts, bellReasons } = clearBellForRoute(state.bellCounts, state.bellReasons, route);
 			const taskMru = bumpMru(state.taskMru, route);
-			return { ...state, route, historyIndex: newIndex, bellCounts, bellReasons, taskMru };
+			return {
+				...state,
+				route,
+				historyIndex: newIndex,
+				bellCounts,
+				bellReasons,
+				taskMru,
+				currentProjectTasks:
+					projectIdForRoute(state.route) === projectIdForRoute(route) ? state.currentProjectTasks : [],
+			};
 		}
 		case "goForward": {
 			if (state.historyIndex >= state.routeHistory.length - 1) return state;
@@ -239,7 +259,16 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			const route = state.routeHistory[newIndex];
 			const { bellCounts, bellReasons } = clearBellForRoute(state.bellCounts, state.bellReasons, route);
 			const taskMru = bumpMru(state.taskMru, route);
-			return { ...state, route, historyIndex: newIndex, bellCounts, bellReasons, taskMru };
+			return {
+				...state,
+				route,
+				historyIndex: newIndex,
+				bellCounts,
+				bellReasons,
+				taskMru,
+				currentProjectTasks:
+					projectIdForRoute(state.route) === projectIdForRoute(route) ? state.currentProjectTasks : [],
+			};
 		}
 		case "setProjects":
 			return { ...state, projects: action.projects };
@@ -259,6 +288,10 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			return { ...state, projects: reordered };
 		}
 		case "setTasks":
+			// Task fetches are asynchronous. Ignore a response that belongs to a
+			// project the user has already left instead of repopulating the new
+			// project's board with stale cards.
+			if (projectIdForRoute(state.route) !== action.projectId) return state;
 			return { ...state, currentProjectTasks: action.tasks };
 		case "updateTask": {
 			const exists = state.currentProjectTasks.some((t) => t.id === action.task.id);


### PR DESCRIPTION
## Summary
- Clear cached task cards immediately when the active project changes.
- Associate task-load responses with their project and discard late results from a project the user left.
- Cover direct project switches and Back/Forward history navigation.

## Testing
- bun run lint
- bun run test