### PR TITLE
Fix Codex PR prompt pane routing

### DIFF
--- a/change-logs/2026/07/12/fix-codex-create-pr-pane.md
+++ b/change-logs/2026/07/12/fix-codex-create-pr-pane.md
@@ -1,0 +1,1 @@
+Create PR and other agent hand-offs now target the initial Codex pane before its first lifecycle hook runs.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -9200,6 +9200,31 @@ describe("handlers.createPullRequest", () => {
 		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%3"]));
 	});
 
+	it("routes a legacy Codex main pane before a focused shell split", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			id: "task-1",
+			worktreePath: "/tmp/test-worktree",
+			sessionState: {
+				panes: [{ paneId: null, agentCmd: "codex", sessionId: null, agentId: "builtin-codex", configId: null }],
+			},
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		mockSpawn.mockImplementation((args: string[]) => ({
+			// The initial agent pane is listed first, but a shell split is focused.
+			stdout: args.includes("display-message") ? "%3\n" : args.includes("list-panes") ? "%5\n%3\n" : "",
+			stderr: "",
+			exited: Promise.resolve(0),
+		}));
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const paste = sendKeysCalls();
+		expect(paste).toHaveLength(1);
+		expect(paste[0]).toEqual(expect.arrayContaining(["send-keys", "-t", "%5"]));
+	});
+
 	// A registered agent pane that no longer exists must not hijack the routing —
 	// fall back to the active pane (preserves the legacy behavior).
 	it("falls back to the active pane when the recorded agent pane is dead", async () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -101,6 +101,7 @@ vi.mock("../pty-server", () => ({
 	hasSession: vi.fn(),
 	hasDeadSession: vi.fn(),
 	tmuxSessionExists: vi.fn(() => true),
+	listPaneIds: vi.fn(() => Promise.resolve(["%5"])),
 	getPtyPort: vi.fn(() => 9999),
 	getSessionProjectId: vi.fn(() => null),
 	getSessionSocket: vi.fn(() => "dev3"),
@@ -7132,6 +7133,32 @@ describe("launchTaskPty", () => {
 		await launchTaskPty(project, task, "/tmp/codex-wt", "builtin-codex", "codex-default");
 
 		expect((agents as any).ensureCodexTrust).toHaveBeenCalledWith("/tmp/codex-wt");
+	});
+
+	it("persists the initial Codex pane ID before its first lifecycle hook", async () => {
+		const project = makeProject();
+		const task = makeTask({ agentId: "builtin-codex", configId: "codex-default" });
+		(agents.resolveCommandForAgent as any).mockResolvedValueOnce({
+			command: "codex --model gpt-test",
+			extraEnv: {},
+			agent: { baseCommand: "codex" },
+			config: {},
+		});
+		vi.mocked(pty.listPaneIds).mockResolvedValueOnce(["%42"]);
+
+		await launchTaskPty(project, task, "/tmp/codex-wt", "builtin-codex", "codex-default");
+
+		expect(data.updateTask).toHaveBeenLastCalledWith(project, task.id, {
+			sessionState: {
+				panes: [{
+					paneId: "%42",
+					agentCmd: "codex",
+					sessionId: null,
+					agentId: "builtin-codex",
+					configId: "codex-default",
+				}],
+			},
+		});
 	});
 
 	it("adds the generated Codex hook override only to the launched session", async () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -982,6 +982,9 @@ const AGENT_PROMPT_ENTER_DELAY_MS = 800;
  *  - Exactly ONE live agent pane → target it unconditionally, even if a
  *    non-agent pane (a shell, a dev server) is currently focused. There is no
  *    ambiguity about where the agent lives, so focus must not misroute the prompt.
+ *  - Exactly ONE unresolved main-agent entry → target tmux's first pane. This
+ *    covers legacy tasks and the brief Codex pre-hook interval, when pane[0]'s
+ *    ID has not been persisted yet but a shell split may be focused.
  *  - TWO OR MORE live agent panes, including a main pane whose id was not
  *    persisted → ambiguous; respect the user's focus and use the session's
  *    active pane.
@@ -1007,18 +1010,24 @@ async function resolveAgentPromptTargetPane(
 		.filter((id): id is string => Boolean(id));
 	const hasUnresolvedAgentPane = (agentPanes ?? []).some((pane) => !pane.paneId);
 
-	if (registeredIds.length > 0) {
+	if (registeredIds.length > 0 || hasUnresolvedAgentPane) {
 		let livePaneIds = new Set<string>();
+		let orderedLivePaneIds: string[] = [];
 		try {
 			const proc = spawn(pty.tmuxArgs(socket, "list-panes", "-s", "-t", tmuxSession, "-F", "#{pane_id}"), { stdout: "pipe", stderr: "pipe" });
 			const stdout = await new Response(proc.stdout).text();
 			if ((await proc.exited) === 0) {
-				livePaneIds = new Set(stdout.split("\n").map((l) => l.trim()).filter(Boolean));
+				orderedLivePaneIds = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+				livePaneIds = new Set(orderedLivePaneIds);
 			}
 		} catch { /* best effort */ }
 
 		const liveAgentPanes = [...new Set(registeredIds.filter((id) => livePaneIds.has(id)))];
 		if (liveAgentPanes.length === 1 && !hasUnresolvedAgentPane) return liveAgentPanes[0] ?? null;
+		// Legacy main panes and a newly launched Codex pane can briefly have no
+		// recorded pane ID. Their session-state entry is pane[0], and tmux lists
+		// that initial pane first, so prefer it over an unrelated focused shell.
+		if (agentPanes?.length === 1 && hasUnresolvedAgentPane) return orderedLivePaneIds[0] ?? null;
 		// ≥2 or 0 live agent panes → fall through to the active pane below.
 	}
 

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -20,6 +20,8 @@ import { resolveOperationalProjectConfig } from "./settings-config";
 
 const devViewerPaneIds = new Map<string, string>();
 const fileBrowserPaneIds = new Map<string, string>();
+const MAIN_AGENT_PANE_CAPTURE_ATTEMPTS = 10;
+const MAIN_AGENT_PANE_CAPTURE_INTERVAL_MS = 100;
 
 function devServerSessionName(taskId: string): string {
 	return `dev3-dev-${taskId.slice(0, 8)}`;
@@ -314,6 +316,41 @@ async function setTmuxSessionPortEnv(taskId: string, socket: string): Promise<vo
 }
 
 /**
+ * Store the initial agent pane before Codex has emitted its first lifecycle
+ * hook. Otherwise Create PR may fall back to a focused shell pane.
+ *
+ * Setup wrappers are excluded because they initially run in a non-agent pane;
+ * their eventual agent pane is captured by the lifecycle hook or exit
+ * reconciliation instead.
+ */
+async function persistInitialAgentPaneId(
+	project: Project,
+	task: Task,
+	socket: string,
+	paneEntry: NonNullable<Task["sessionState"]>["panes"][number],
+): Promise<void> {
+	for (let attempt = 0; attempt < MAIN_AGENT_PANE_CAPTURE_ATTEMPTS; attempt++) {
+		const paneIds = await pty.listPaneIds(task.id, socket);
+		if (paneIds.length === 1 && paneIds[0]) {
+			await data.updateTask(project, task.id, {
+				sessionState: { panes: [{ ...paneEntry, paneId: paneIds[0] }] },
+			});
+			log.info("Persisted initial agent pane ID", {
+				taskId: task.id.slice(0, 8),
+				paneId: paneIds[0],
+			});
+			return;
+		}
+
+		if (attempt < MAIN_AGENT_PANE_CAPTURE_ATTEMPTS - 1) {
+			await new Promise((resolve) => setTimeout(resolve, MAIN_AGENT_PANE_CAPTURE_INTERVAL_MS));
+		}
+	}
+
+	log.warn("Could not capture initial agent pane ID", { taskId: task.id.slice(0, 8) });
+}
+
+/**
  * Register worktree trust for the resolved agent's CLI before spawning it.
  * Claude trust (with MCP pre-approval) is always ensured; Codex/Gemini trust
  * only for their respective CLIs. Codex trust also re-patches ~/.codex/config.toml
@@ -428,6 +465,7 @@ export async function launchTaskPty(
 	let extraEnv: Record<string, string>;
 	let resolvedBaseCmd = "";
 	let resolvedPermissionMode: PermissionMode | undefined;
+	let mainPaneEntry: NonNullable<Task["sessionState"]>["panes"][number] | null = null;
 
 	try {
 		const cmdOptions: agents.CommandOptions = {};
@@ -478,6 +516,7 @@ export async function launchTaskPty(
 				agentId: agentId ?? task.agentId,
 				configId: configId ?? task.configId,
 			};
+			mainPaneEntry = paneEntry;
 			const sessionState = { panes: [paneEntry] };
 			try {
 				await data.updateTask(project, task.id, { sessionState });
@@ -639,6 +678,9 @@ export async function launchTaskPty(
 		}
 		pty.createSession(task.id, project.id, worktreePath, wrapperCmd, env, sessionSocket);
 		log.info("launchTaskPty DONE — PTY session created", { taskId: task.id.slice(0, 8) });
+		if (!skipSessionPersist && !isSetupWrapper && mainPaneEntry) {
+			await persistInitialAgentPaneId(project, task, sessionSocket, mainPaneEntry);
+		}
 		await setTmuxSessionPortEnv(task.id, sessionSocket);
 		if (project.kind === "virtual" && !sessionPreexisted) {
 			await addVirtualShellPane(task, worktreePath, sessionSocket, userShell);


### PR DESCRIPTION
## Summary
- persist the main agent pane ID immediately after tmux starts
- route legacy single-agent Codex sessions to their initial pane instead of a focused shell split
- cover fresh and legacy routing paths with regression tests

## Root cause
The main pane was stored without a pane ID until Codex emitted its first lifecycle hook. During that gap, Create PR and related agent hand-offs could use tmux's active pane, which may be a shell.

## Verification
- bun run lint
- bun run test