### PR TITLE
Fix mobile header after keyboard dismissal

### DIFF
--- a/change-logs/2026/07/12/fix-mobile-composer-header.md
+++ b/change-logs/2026/07/12/fix-mobile-composer-header.md
@@ -1,0 +1,1 @@
+Restore the mobile terminal header when Android dismisses the composer keyboard without blurring its textarea. The composer now tracks visual viewport changes and has regression coverage for that focus state.

--- a/src/mainview/components/TerminalComposer.tsx
+++ b/src/mainview/components/TerminalComposer.tsx
@@ -8,6 +8,8 @@ interface TerminalComposerProps {
 
 /** Collapsed autogrow ceiling — roughly 4 lines of 16px text. */
 const MAX_COLLAPSED_HEIGHT_PX = 120;
+/** Ignore minor browser-chrome viewport shifts; a keyboard consumes much more space. */
+const KEYBOARD_VIEWPORT_DELTA_PX = 80;
 
 const NERD_FONT = "'JetBrainsMono Nerd Font Mono'";
 
@@ -27,6 +29,7 @@ function TerminalComposer({ handle }: TerminalComposerProps) {
 	const [text, setText] = useState("");
 	const [expanded, setExpanded] = useState(false);
 	const taRef = useRef<HTMLTextAreaElement>(null);
+	const focusedViewportHeightRef = useRef<number | null>(null);
 
 	function autogrow() {
 		const ta = taRef.current;
@@ -55,6 +58,43 @@ function TerminalComposer({ handle }: TerminalComposerProps) {
 		if (on) document.documentElement.dataset.composerFocused = "true";
 		else delete document.documentElement.dataset.composerFocused;
 	}
+
+	function handleFocus() {
+		focusedViewportHeightRef.current = window.visualViewport?.height ?? null;
+		markFocused(true);
+	}
+
+	function handleBlur() {
+		focusedViewportHeightRef.current = null;
+		markFocused(false);
+	}
+
+	useEffect(() => {
+		const viewport = window.visualViewport;
+		if (!viewport) return;
+		const activeViewport = viewport as VisualViewport;
+
+		function syncComposerChrome() {
+			const textarea = taRef.current;
+			if (!textarea || document.activeElement !== textarea) {
+				focusedViewportHeightRef.current = null;
+				markFocused(false);
+				return;
+			}
+
+			const focusedHeight = focusedViewportHeightRef.current;
+			if (focusedHeight === null || activeViewport.height > focusedHeight) {
+				focusedViewportHeightRef.current = activeViewport.height;
+				markFocused(true);
+				return;
+			}
+
+			markFocused(activeViewport.height < focusedHeight - KEYBOARD_VIEWPORT_DELTA_PX);
+		}
+
+		activeViewport.addEventListener("resize", syncComposerChrome);
+		return () => activeViewport.removeEventListener("resize", syncComposerChrome);
+	}, []);
 
 	function deliver(withEnter: boolean) {
 		if (!text) return;
@@ -136,8 +176,8 @@ function TerminalComposer({ handle }: TerminalComposerProps) {
 				autogrow();
 			}}
 			onKeyDown={onKeyDown}
-			onFocus={() => markFocused(true)}
-			onBlur={() => markFocused(false)}
+			onFocus={handleFocus}
+			onBlur={handleBlur}
 			placeholder={t("terminal.composerPlaceholder")}
 			rows={1}
 			autoCapitalize="off"

--- a/src/mainview/components/__tests__/TerminalComposer.test.tsx
+++ b/src/mainview/components/__tests__/TerminalComposer.test.tsx
@@ -5,6 +5,33 @@ import TerminalComposer from "../TerminalComposer";
 import type { TerminalHandle } from "../../TerminalView";
 import { I18nProvider } from "../../i18n";
 
+let restoreVisualViewport: (() => void) | undefined;
+
+function installVisualViewport(initialHeight: number) {
+	let height = initialHeight;
+	const viewport = new EventTarget() as VisualViewport;
+	const descriptor = Object.getOwnPropertyDescriptor(window, "visualViewport");
+	Object.defineProperty(viewport, "height", {
+		configurable: true,
+		get: () => height,
+	});
+	Object.defineProperty(window, "visualViewport", {
+		configurable: true,
+		value: viewport,
+	});
+	restoreVisualViewport = () => {
+		if (descriptor) Object.defineProperty(window, "visualViewport", descriptor);
+		else Reflect.deleteProperty(window, "visualViewport");
+	};
+
+	return {
+		resize(nextHeight: number) {
+			height = nextHeight;
+			viewport.dispatchEvent(new Event("resize"));
+		},
+	};
+}
+
 function makeHandle(): TerminalHandle {
 	return {
 		sendInput: vi.fn(),
@@ -24,6 +51,8 @@ function renderComposer(handle: TerminalHandle) {
 
 afterEach(() => {
 	cleanup();
+	restoreVisualViewport?.();
+	restoreVisualViewport = undefined;
 	delete document.documentElement.dataset.composerFocused;
 });
 
@@ -86,6 +115,21 @@ describe("TerminalComposer", () => {
 		expect(document.documentElement.dataset.composerFocused).toBe("true");
 
 		(input as HTMLTextAreaElement).blur();
+		expect(document.documentElement.dataset.composerFocused).toBeUndefined();
+	});
+
+	it("restores chrome when Android closes the keyboard without blurring the textarea", async () => {
+		const viewport = installVisualViewport(900);
+		const handle = makeHandle();
+		renderComposer(handle);
+		const input = screen.getByTestId("terminal-composer-input");
+
+		await userEvent.click(input);
+		viewport.resize(450);
+		expect(document.documentElement.dataset.composerFocused).toBe("true");
+
+		viewport.resize(900);
+		expect(document.activeElement).toBe(input);
 		expect(document.documentElement.dataset.composerFocused).toBeUndefined();
 	});
 


### PR DESCRIPTION
## Summary
- restore terminal chrome when Android dismisses the composer keyboard without blurring its textarea
- reconcile the composer focus marker with visual viewport resizing
- add regression coverage for keyboard close without blur

## Testing
- bun run lint
- bun run test