### PR TITLE
Widen Launch Task modal so agent dropdowns fit

### DIFF
--- a/change-logs/2026/07/12/fix-widen-launch-modal.md
+++ b/change-logs/2026/07/12/fix-widen-launch-modal.md
@@ -1,0 +1,1 @@
+Widened the Launch Task / Retry modal so the Provider, Model, and Mode dropdowns have enough room to show their full labels instead of truncating them (e.g. "GPT-5.6 …", "Bypass [X…").

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -354,7 +354,7 @@ function LaunchVariantsModal({
 				role="dialog"
 				aria-modal="true"
 				tabIndex={-1}
-				className="bg-overlay rounded-2xl shadow-2xl shadow-black/50 border border-edge-active w-full max-w-xl mx-4 overflow-hidden outline-none"
+				className="bg-overlay rounded-2xl shadow-2xl shadow-black/50 border border-edge-active w-full max-w-3xl mx-4 overflow-hidden outline-none"
 				onClick={(e) => e.stopPropagation()}
 			>
 				{/* Header */}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this PR).

## Summary

The Launch Task / Retry modal (`LaunchVariantsModal`) was capped at `max-w-xl` (576px), which left too little room for its four columns — Favorites, Provider, Model, Mode. Longer labels like "Gemini 3.1 Flash Lite" or "Accept Edits · X-High" got truncated in the dropdown triggers (showing "GPT-5.6 …", "Bypass [X…").

This widens the modal container to `max-w-3xl` (768px). No internal layout changes — the dropdowns already use `flex-1 min-w-0`, so each column simply gets ~190px instead of ~130px, enough to show the full labels. `mx-4` + `w-full` keep it responsive on narrow screens.