### PR TITLE
Resume task status after Claude questions

### DIFF
--- a/change-logs/2026/07/12/fix-claude-question-status-hooks.md
+++ b/change-logs/2026/07/12/fix-claude-question-status-hooks.md
@@ -1,0 +1,1 @@
+Claude Code task hooks now move a task to in-progress as soon as AskUserQuestion completes, rather than waiting for the next tool call.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -21,15 +21,17 @@ import {
 const DEV3_CLI = "~/.dev3.0/bin/dev3";
 
 describe("buildClaudeHooks", () => {
-	it("returns UserPromptSubmit, PreToolUse, PermissionRequest and Stop matcher groups", () => {
+	it("returns UserPromptSubmit, tool, PermissionRequest and Stop matcher groups", () => {
 		const hooks = buildClaudeHooks();
 
 		expect(hooks).toHaveProperty("UserPromptSubmit");
 		expect(hooks).toHaveProperty("PreToolUse");
+		expect(hooks).toHaveProperty("PostToolUse");
 		expect(hooks).toHaveProperty("PermissionRequest");
 		expect(hooks).toHaveProperty("Stop");
 		expect(hooks.UserPromptSubmit).toHaveLength(1);
 		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.PostToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
 		expect(hooks.Stop).toHaveLength(1);
 	});
@@ -52,6 +54,16 @@ describe("buildClaudeHooks", () => {
 		expect(cmd).toContain("--status in-progress");
 		expect(cmd).toContain("--if-status-not review-by-ai");
 		expect(cmd).not.toContain("review-by-user");
+	});
+
+	it("PostToolUse resumes work after AskUserQuestion receives an answer", () => {
+		const hooks = buildClaudeHooks();
+
+		expect(hooks).toHaveProperty("PostToolUse");
+		const cmd = hooks.PostToolUse[0].hooks[0].command;
+		expect(cmd).toContain(DEV3_CLI);
+		expect(cmd).toContain("--status in-progress");
+		expect(cmd).toContain("--if-status-not review-by-ai");
 	});
 
 	it("uses correct three-level nesting (event → matcher group → hooks)", () => {
@@ -174,10 +186,10 @@ describe("buildClaudeHooks", () => {
 		}
 	});
 
-	it("working hooks (PreToolUse/UserPromptSubmit) keep the move guard before the offline fallback", () => {
+	it("working hooks keep the move guard before the offline fallback", () => {
 		const hooks = buildClaudeHooks();
 
-		for (const event of ["PreToolUse", "UserPromptSubmit"] as const) {
+		for (const event of ["PreToolUse", "PostToolUse", "UserPromptSubmit"] as const) {
 			const cmd = hooks[event][0].hooks[0].command;
 			expect(cmd).toContain("--status in-progress --if-status-not review-by-ai || [ $? -eq 2 ]");
 		}
@@ -199,6 +211,7 @@ describe("mergeClaudeHooks", () => {
 		const hooks = result.hooks as Record<string, MatcherGroup[]>;
 		expect(hooks.UserPromptSubmit).toHaveLength(1);
 		expect(hooks.PreToolUse).toHaveLength(1);
+		expect(hooks.PostToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
 		expect(hooks.Stop).toHaveLength(1);
 	});
@@ -212,7 +225,7 @@ describe("mergeClaudeHooks", () => {
 		expect(result.hooks).toBeDefined();
 	});
 
-	it("preserves existing hooks on unrelated events", () => {
+	it("preserves user-defined hooks when a dev3 hook shares the event", () => {
 		const existing = {
 			hooks: {
 				PostToolUse: [{ hooks: [{ type: "command", command: "echo post" }] }],
@@ -221,7 +234,9 @@ describe("mergeClaudeHooks", () => {
 		const result = mergeClaudeHooks(existing);
 		const hooks = result.hooks as Record<string, MatcherGroup[]>;
 
-		expect(hooks.PostToolUse).toHaveLength(1);
+		expect(hooks.PostToolUse).toHaveLength(2);
+		expect(hooks.PostToolUse[0].hooks[0].command).toBe("echo post");
+		expect(hooks.PostToolUse[1].hooks[0].command).toContain("--status in-progress");
 		expect(hooks.PreToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
 		expect(hooks.Stop).toHaveLength(1);
@@ -476,6 +491,8 @@ describe("writeClaudeHooks", () => {
 
 		expect(hooks.PreToolUse[0].hooks[0].command).toContain("--if-status-not review-by-ai");
 		expect(hooks.PreToolUse[0].hooks[0].command).not.toContain("review-by-user");
+		expect(hooks.PostToolUse[0].hooks[0].command).toContain("--if-status-not review-by-ai");
+		expect(hooks.PostToolUse[0].hooks[0].command).not.toContain("review-by-user");
 		expect(hooks.UserPromptSubmit[0].hooks[0].command).toContain("--if-status-not review-by-ai");
 		expect(hooks.UserPromptSubmit[0].hooks[0].command).not.toContain("review-by-user");
 	});

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -61,7 +61,7 @@ export interface HookEntry {
  * Unified hooks that work for both the primary agent and the review agent
  * running in the same worktree (they share .claude/settings.local.json).
  *
- * - PreToolUse/UserPromptSubmit: → in-progress (skipped when in review-by-ai)
+ * - UserPromptSubmit/PreToolUse/PostToolUse: → in-progress (skipped when in review-by-ai)
  * - PermissionRequest: → user-questions
  * - Stop: primary agent → stopTarget; review agent → review-by-user
  */
@@ -88,7 +88,7 @@ function buildMoveCommand(
 // ALSO how both Claude Code and Codex signal a *blocking* hook error (Claude:
 // blocks the tool call / erases the prompt / blocks Stop; Codex: blocks prompt
 // and tool execution). So a closed app would otherwise wedge the agent on every
-// PreToolUse/UserPromptSubmit/Stop. This guard collapses ONLY the app-offline
+// PreToolUse/PostToolUse/UserPromptSubmit/Stop. This guard collapses ONLY the app-offline
 // exit code into success; any other failure still propagates. It is deliberately
 // selective rather than `|| true`, which would mask real regressions (see
 // decisions 032 and 089). The CLI still prints its "app not running" notice to
@@ -147,6 +147,8 @@ export function buildClaudeHooks(
 	// (the review agent shares the same hooks file and must not flip status).
 	// review-by-user is intentionally allowed: when the user leaves feedback
 	// and the primary agent resumes, UserPromptSubmit should move the task back.
+	// PostToolUse also covers answers submitted to AskUserQuestion, which resume
+	// an existing tool call without emitting a new user prompt event.
 	const workingCmd = move("in-progress", "--if-status-not review-by-ai");
 
 	return {
@@ -154,6 +156,9 @@ export function buildClaudeHooks(
 			{ hooks: [{ type: "command", command: workingCmd }] },
 		],
 		PreToolUse: [
+			{ hooks: [{ type: "command", command: workingCmd }] },
+		],
+		PostToolUse: [
 			{ hooks: [{ type: "command", command: workingCmd }] },
 		],
 		PermissionRequest: [


### PR DESCRIPTION
## Summary
- Move Claude Code tasks back to in-progress when AskUserQuestion completes.
- Preserve user-defined PostToolUse hooks and cover the new lifecycle hook with regression tests.

## Testing
- bun run lint
- bun run test