### PR TITLE
Fix Codex skill autocomplete before agent selection

### DIFF
--- a/change-logs/2026/07/12/fix-codex-skill-autocomplete.md
+++ b/change-logs/2026/07/12/fix-codex-skill-autocomplete.md
@@ -1,0 +1,1 @@
+Task descriptions now autocomplete Codex skills with `$` even when Codex is selected only at launch. The typed prefix is preserved when inserting the skill.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -244,19 +244,13 @@ function App() {
 		});
 	}, []);
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
-	const [agentSettingsReady, setAgentSettingsReady] = useState(false);
+	const [agentSettingsLoaded, setAgentSettingsLoaded] = useState(false);
 	const [globalSettings, setGlobalSettings] = useState<GlobalSettingsType>({
 		defaultAgentId: "builtin-claude",
 		defaultConfigId: "claude-auto",
 		taskDropPosition: "top",
 		updateChannel: "stable",
 	});
-	const defaultAgent = agents.find((agent) => agent.id === globalSettings.defaultAgentId) ?? agents[0];
-	const defaultAgentConfig = defaultAgent?.configurations.find((config) => config.id === globalSettings.defaultConfigId)
-		?? defaultAgent?.configurations.find((config) => config.id === defaultAgent?.defaultConfigId)
-		?? defaultAgent?.configurations[0];
-	const defaultSkillBaseCommand = defaultAgentConfig?.baseCommandOverride ?? defaultAgent?.baseCommand ?? "";
-
 	// Auth failure for browser remote access (expired/invalid QR token)
 	const [authFailed, setAuthFailed] = useState(false);
 
@@ -1560,24 +1554,23 @@ function App() {
 		return () => window.removeEventListener("rpc:openCreateTaskModal", onOpenCreateTaskModal);
 	}, [openCreateTaskModal]);
 
-	// Load the agent selection before enabling task-prompt skill autocomplete.
-	// A slash fallback is unsafe: Codex requires `$`, so autocomplete stays inert
-	// until its target agent is known.
+	// Load agents before the subsequent launch dialog opens. Skill autocomplete
+	// accepts both agent syntaxes because that dialog chooses the final agent.
 	const agentSettingsLoadingRef = useRef(false);
 	useEffect(() => {
-		if (!createTaskProjectId || agentSettingsReady || agentSettingsLoadingRef.current) return;
+		if (!createTaskProjectId || agentSettingsLoaded || agentSettingsLoadingRef.current) return;
 		agentSettingsLoadingRef.current = true;
 		Promise.all([api.request.getAgents(), api.request.getGlobalSettings()])
 			.then(([nextAgents, nextSettings]) => {
 				setAgents(nextAgents);
 				setGlobalSettings(nextSettings);
-				setAgentSettingsReady(true);
+				setAgentSettingsLoaded(true);
 			})
 			.catch(() => {})
 			.finally(() => {
 				agentSettingsLoadingRef.current = false;
 			});
-	}, [agentSettingsReady, createTaskProjectId]);
+	}, [agentSettingsLoaded, createTaskProjectId]);
 
 	// Register agents with analytics on mount so events like `task_moved` can
 	// carry a human-readable agent name (the modal load above is lazy).
@@ -1834,8 +1827,6 @@ function App() {
 			{createTaskProject && (
 				<CreateTaskModal
 					project={createTaskProject}
-					skillBaseCommand={defaultSkillBaseCommand}
-					skillAutocompleteEnabled={agentSettingsReady}
 					dispatch={dispatch}
 					onClose={() => setCreateTaskProjectId(null)}
 					onCreateAndRun={(task) => {

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, type Dispatch } from "react";
 import { toast } from "../toast";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import { DEFAULT_PRIORITY, skillInvocationPrefix, titleFromDescription, type Project, type Task, type TaskPriority } from "../../shared/types";
+import { DEFAULT_PRIORITY, titleFromDescription, type Project, type Task, type TaskPriority } from "../../shared/types";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
@@ -32,11 +32,9 @@ interface CreateTaskModalProps {
 	onClose: () => void;
 	onCreateAndRun?: (task: Task) => void;
 	onOpenAutomations?: () => void;
-	skillBaseCommand?: string;
-	skillAutocompleteEnabled?: boolean;
 }
 
-function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAutomations, skillBaseCommand = "", skillAutocompleteEnabled = true }: CreateTaskModalProps) {
+function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAutomations }: CreateTaskModalProps) {
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
 	const [description, setDescription] = useState("");
@@ -104,8 +102,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 		});
 	}, []);
 
-	const skillPrefix = skillInvocationPrefix(skillBaseCommand);
-	const skillAutocomplete = useSkillAutocomplete(textareaRef, description, setDescription, project.path, skillPrefix, skillAutocompleteEnabled);
+	const skillAutocomplete = useSkillAutocomplete(textareaRef, description, setDescription, project.path);
 
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
 	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor);
@@ -453,7 +450,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 								activeIndex={skillAutocomplete.activeIndex}
 								onHover={skillAutocomplete.setActiveIndex}
 								onSelect={skillAutocomplete.accept}
-								invocationPrefix={skillPrefix}
+								invocationPrefix={skillAutocomplete.invocationPrefix}
 							/>
 						)}
 					</div>

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -68,8 +68,6 @@ function renderModal(props: {
 	onClose?: () => void;
 	onCreateAndRun?: (task: Task) => void;
 	project?: Project;
-	skillBaseCommand?: string;
-	skillAutocompleteEnabled?: boolean;
 } = {}) {
 	return render(
 		<I18nProvider>
@@ -78,8 +76,6 @@ function renderModal(props: {
 				dispatch={props.dispatch ?? vi.fn()}
 				onClose={props.onClose ?? vi.fn()}
 				onCreateAndRun={props.onCreateAndRun}
-				skillBaseCommand={props.skillBaseCommand}
-				skillAutocompleteEnabled={props.skillAutocompleteEnabled}
 			/>
 		</I18nProvider>,
 	);
@@ -1352,7 +1348,7 @@ describe("CreateTaskModal skill autocomplete", () => {
 	});
 
 	it("inserts Codex skills with a dollar prefix", async () => {
-		renderModal({ skillBaseCommand: "codex" });
+		renderModal();
 		const textarea = await typeInDescription("$dev");
 		await waitFor(() => {
 			expect(screen.getByText("$dev3")).toBeInTheDocument();
@@ -1364,27 +1360,23 @@ describe("CreateTaskModal skill autocomplete", () => {
 	});
 
 	it("opens autocomplete for a dollar-prefixed skill", async () => {
-		renderModal({ skillBaseCommand: "codex" });
+		renderModal();
 		await typeInDescription("$dev");
 		await waitFor(() => {
 			expect(screen.getByText("$dev3")).toBeInTheDocument();
 		});
 	});
 
-	it("does not intercept dollar-prefixed text for slash agents", async () => {
-		renderModal({ skillBaseCommand: "claude" });
-		const textarea = await typeInDescription("$dev3");
-		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-		await userEvent.keyboard("{Enter}");
-		expect(textarea.value).toBe("$dev3\n");
-	});
-
-	it("does not autocomplete until the target agent is known", async () => {
-		renderModal({ skillBaseCommand: "codex", skillAutocompleteEnabled: false });
+	it("shows Codex suggestions when the default agent uses slash skills", async () => {
+		renderModal();
 		const textarea = await typeInDescription("$dev");
-		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.getByText("$dev3")).toBeInTheDocument();
+		});
 		await userEvent.keyboard("{Enter}");
-		expect(textarea.value).toBe("$dev\n");
+		await waitFor(() => {
+			expect(textarea.value).toBe("$dev3 ");
+		});
 	});
 
 	it("Escape closes the dropdown but keeps the modal open", async () => {

--- a/src/mainview/hooks/useSkillAutocomplete.ts
+++ b/src/mainview/hooks/useSkillAutocomplete.ts
@@ -3,22 +3,28 @@ import type { AgentSkillInfo } from "../../shared/types";
 import { api } from "../rpc";
 
 const MAX_SUGGESTIONS = 8;
+export type SkillInvocationPrefix = "$" | "/";
+
+const SKILL_INVOCATION_PREFIXES: readonly SkillInvocationPrefix[] = ["/", "$"];
 
 interface SkillToken {
 	/** Index of the leading skill prefix in the text. */
 	start: number;
+	/** Prefix the user typed, preserved when accepting a suggestion. */
+	invocationPrefix: SkillInvocationPrefix;
 	/** Text typed after the prefix (may be empty). */
 	query: string;
 }
 
-/** Find an active skill token with the selected agent's prefix, or null. */
-export function findSkillToken(text: string, caret: number, invocationPrefix: "$" | "/"): SkillToken | null {
+/** Find an active skill token with a supported agent prefix, or null. */
+export function findSkillToken(text: string, caret: number, invocationPrefixes = SKILL_INVOCATION_PREFIXES): SkillToken | null {
 	let start = caret;
 	while (start > 0 && !/[\s]/.test(text[start - 1])) start--;
-	if (text[start] !== invocationPrefix) return null;
+	const invocationPrefix = text[start] as SkillInvocationPrefix;
+	if (!invocationPrefixes.includes(invocationPrefix)) return null;
 	const token = text.slice(start, caret);
 	if (!/^[\w-]*$/.test(token.slice(1))) return null;
-	return { start, query: token.slice(1) };
+	return { start, invocationPrefix, query: token.slice(1) };
 }
 
 /** Filter skills by query: prefix matches first, then substring matches. */
@@ -36,19 +42,18 @@ export function filterSkills(skills: AgentSkillInfo[], query: string): AgentSkil
 }
 
 /**
- * Slash-trigger skill-name autocomplete for a textarea. Typing "/" at a word
- * boundary opens a suggestion list of installed agent skills — the project's
- * local `.agents/.claude/.codex/skills` (when `projectPath` is given) plus the
- * global home directories, via `listAgentSkills`. Project-local skills win over
- * same-named global ones.
+ * Skill-name autocomplete for a textarea. Typing "/" or "$" at a word boundary
+ * opens a suggestion list of installed agent skills — the project's local
+ * `.agents/.claude/.codex/skills` (when `projectPath` is given) plus the global
+ * home directories, via `listAgentSkills`. Project-local skills win over
+ * same-named global ones. The prefix is user-selected because the launch agent
+ * is chosen after the task description is written.
  */
 export function useSkillAutocomplete(
 	textareaRef: RefObject<HTMLTextAreaElement | null>,
 	value: string,
 	setValue: (next: string) => void,
 	projectPath?: string | null,
-	invocationPrefix: "$" | "/" = "/",
-	enabled = true,
 ) {
 	const [skills, setSkills] = useState<AgentSkillInfo[]>([]);
 	const [token, setToken] = useState<SkillToken | null>(null);
@@ -73,16 +78,16 @@ export function useSkillAutocomplete(
 	const sync = useCallback(() => {
 		const el = textareaRef.current;
 		if (!el) return;
-		const next = findSkillToken(el.value, el.selectionStart, invocationPrefix);
+		const next = findSkillToken(el.value, el.selectionStart);
 		setToken((prev) => {
 			if (prev?.start !== next?.start) setDismissed(false);
-			if (prev?.start === next?.start && prev?.query === next?.query) return prev;
+			if (prev?.start === next?.start && prev?.invocationPrefix === next?.invocationPrefix && prev?.query === next?.query) return prev;
 			setActiveIndex(0);
 			return next;
 		});
-	}, [textareaRef, invocationPrefix]);
+	}, [textareaRef]);
 
-	const items = enabled && token && !dismissed ? filterSkills(skills, token.query) : [];
+	const items = token && !dismissed ? filterSkills(skills, token.query) : [];
 	const open = items.length > 0;
 
 	const close = useCallback(() => setDismissed(true), []);
@@ -92,7 +97,7 @@ export function useSkillAutocomplete(
 			const el = textareaRef.current;
 			if (!el || !token) return;
 			const caret = el.selectionStart;
-			const insert = `${invocationPrefix}${skill.name} `;
+			const insert = `${token.invocationPrefix}${skill.name} `;
 			const next = value.slice(0, token.start) + insert + value.slice(caret);
 			setValue(next);
 			setToken(null);
@@ -103,7 +108,7 @@ export function useSkillAutocomplete(
 				el.focus();
 			});
 		},
-		[textareaRef, token, value, setValue, invocationPrefix],
+		[textareaRef, token, value, setValue],
 	);
 
 	/** Returns true when the event was consumed by the autocomplete. */
@@ -135,5 +140,15 @@ export function useSkillAutocomplete(
 		[open, items, activeIndex, accept, close],
 	);
 
-	return { open, items, activeIndex, setActiveIndex, sync, accept, close, handleKeyDown };
+	return {
+		open,
+		items,
+		activeIndex,
+		setActiveIndex,
+		sync,
+		accept,
+		close,
+		handleKeyDown,
+		invocationPrefix: token?.invocationPrefix ?? "/",
+	};
 }


### PR DESCRIPTION
## Summary

- accept both /skill and $skill-name autocomplete triggers while creating a task
- preserve the prefix typed by the user when inserting the selected skill
- remove dependence on the default agent, since the launch agent is selected after the task description is written

## Verification

- bun run lint
- bun run test
- Browser QA: typing $agent shows Codex-style suggestions and Enter inserts $agent-browser