### PR TITLE
fix: carry task priority onto spawned variants and attempts

### DIFF
--- a/change-logs/2026/07/12/fix-priority-lost-on-variant-launch.md
+++ b/change-logs/2026/07/12/fix-priority-lost-on-variant-launch.md
@@ -1,0 +1,1 @@
+Fixed the task priority (e.g. P0) picked in the New Task dialog being reset to the default P3 once the task was launched with variants. Both spawnVariants and addAttempts now carry the source task's priority onto the spawned variants/attempts, since priority belongs to the whole variant group.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -3341,6 +3341,37 @@ describe("handlers.spawnVariants", () => {
 		);
 	});
 
+	// The priority the user picks in the Create-Task modal is stored on the
+	// source task, but spawnVariants deletes that source and creates fresh
+	// variants — so the variants must inherit it, otherwise "Create and Run"
+	// silently resets a P0 task back to the default P3.
+	it("preserves priority from the source task on spawned variants", async () => {
+		const project = makeProject();
+		const sourceTask = makeTask({ status: "todo", seq: 5, priority: "P0" });
+		const variantTask = makeTask({ id: "variant-1", status: "in-progress", preparing: true, priority: "P0" });
+		const updatedVariant = makeTask({ id: "variant-1", status: "in-progress", worktreePath: "/tmp/vwt", priority: "P0" });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
+		vi.mocked(data.addTask).mockResolvedValue(variantTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/vwt", branchName: "dev3/v1" });
+		vi.mocked(data.updateTask).mockResolvedValue(updatedVariant);
+
+		await handlers.spawnVariants({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		expect(data.addTask).toHaveBeenCalledWith(
+			project,
+			sourceTask.description,
+			"in-progress",
+			expect.objectContaining({ priority: "P0" }),
+		);
+	});
+
 	// A task can sit in To Do and accumulate notes + an overview before being
 	// launched with variants. spawnVariants deletes the source, so without carrying
 	// them onto the variants that context is silently lost.
@@ -3569,6 +3600,54 @@ describe("handlers.addAttempts", () => {
 			sourceTask.description,
 			"in-progress",
 			expect.objectContaining({ labelIds: ["lbl-1", "lbl-2"] }),
+		);
+	});
+
+	// Added attempts belong to the same group as the source task, so they must
+	// carry the same priority — priority belongs to the whole variant group, so
+	// re-running a P0 task must not spawn a P3 sibling.
+	it("inherits priority from the source task into added attempts", async () => {
+		const project = makeProject();
+		const sourceTask = makeTask({
+			status: "in-progress",
+			seq: 5,
+			groupId: "group-1",
+			variantIndex: 1,
+			priority: "P0",
+		});
+		const attemptTask = makeTask({
+			id: "attempt-2",
+			status: "in-progress",
+			groupId: "group-1",
+			variantIndex: 2,
+			priority: "P0",
+			preparing: true,
+		});
+		const updatedAttempt = makeTask({
+			...attemptTask,
+			worktreePath: "/tmp/attempt-2",
+		});
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask)
+			.mockResolvedValueOnce(sourceTask)
+			.mockResolvedValueOnce(sourceTask);
+		vi.mocked(data.loadTasks).mockResolvedValue([sourceTask]);
+		vi.mocked(data.addTask).mockResolvedValue(attemptTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/attempt-2", branchName: "dev3/v2" });
+		vi.mocked(data.updateTask).mockResolvedValue(updatedAttempt);
+
+		await handlers.addAttempts({
+			taskId: "task-1",
+			projectId: "proj-1",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		expect(data.addTask).toHaveBeenCalledWith(
+			project,
+			sourceTask.description,
+			"in-progress",
+			expect.objectContaining({ priority: "P0" }),
 		);
 	});
 

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1120,6 +1120,10 @@ async function spawnVariants(params: {
 				notes: sourceTask.notes,
 				overview: sourceTask.overview,
 				userOverview: sourceTask.userOverview,
+				// Carry the priority the user picked in the Create-Task modal — the
+				// source task is deleted below, so without this "Create and Run"
+				// silently resets a P0 task back to the default P3.
+				priority: sourceTask.priority,
 				// Virtual ("Operations") tasks: carry the chosen working folder onto
 				// each variant so the worktree-less launch path targets it instead
 				// of falling back to a managed dir (the source task is deleted below).
@@ -1236,6 +1240,10 @@ async function addAttempts(params: {
 				titleEditedByUser: sourceTask.titleEditedByUser,
 				// Attempts share the source task's labels (same group).
 				labelIds: sourceTask.labelIds,
+				// Attempts share the source task's priority (priority belongs to the
+				// whole variant group), otherwise re-running a P0 task spawns a P3
+				// sibling and the group's priority becomes inconsistent.
+				priority: sourceTask.priority,
 				// NOTE: notes/overview are intentionally NOT copied here — addAttempts
 				// keeps the source task (returns it alongside the new attempts), so its
 				// notes are not lost; copying them would duplicate them across siblings.


### PR DESCRIPTION
## Summary

The task priority picked in the New Task dialog (e.g. **P0**) was silently reset to the default **P3** the moment the task was launched with variants ("Create and Run").

Root cause: `createTask` persists the chosen priority, but "Create and Run" first creates the task in `todo`, then `spawnVariants` **deletes that source task and creates fresh variants**, rebuilding the `addTask` extras by hand-copying selected source-task fields (labels, notes, overview, customTitle…). `priority` was omitted from that copy, so `addTask` fell back to `DEFAULT_PRIORITY` (P3). The same gap existed in `addAttempts` (Add-attempt).

Fix: copy `sourceTask.priority` in both `spawnVariants` and `addAttempts`. Priority belongs to the whole variant group, so both spawn sites must carry it.

Covered by two new tests (red → green) in `rpc-handlers.test.ts`; full suite + lint green.