### PR TITLE
Fix Diff text scaling with app zoom

### DIFF
--- a/change-logs/2026/07/12/fix-diff-code-zoom.md
+++ b/change-logs/2026/07/12/fix-diff-code-zoom.md
@@ -1,0 +1,1 @@
+Diff code text now follows the app zoom level instead of remaining fixed at 14 pixels, so Command-Plus and Command-Minus keep code readable alongside the surrounding interface.

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -1,3 +1,9 @@
+.dev3-diff-drag-host .diff-style-root {
+	/* @git-diff-view pins code to 14px. Keep the same 100% size while making
+	   app zoom and the mobile dense-zoom factor flow into the diff text. */
+	--diff-font-size--: 0.875rem !important;
+}
+
 .diff-tailwindcss-wrapper .diff-line-widget-wrapper .dev3-inline-comment,
 .diff-tailwindcss-wrapper .diff-line-widget-wrapper .dev3-inline-comment *,
 .diff-tailwindcss-wrapper .diff-line-extend-wrapper .dev3-inline-comment,


### PR DESCRIPTION
## Summary
- make Diff code text follow the app zoom level
- preserve the existing 14px appearance at 100% zoom
- keep the override scoped to the third-party Diff renderer

## Verification
- manually verified Command-Plus and Command-Minus in the development app
- bun run lint
- bun run test (5,271 passed, 1 skipped)