### PR TITLE
Refresh Star History embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ theme = "github"
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=h0x91b/dev-3.0&type=timeline&legend=top-left)](https://www.star-history.com/?repos=h0x91b%2Fdev-3.0&type=timeline&logscale=&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=h0x91b/dev-3.0&type=date&legend=top-left&sealed_token=WnGGefyKijPrjGxSOkU0sy1POJy10qROzjxTQzjREVPRgboUHeKms8QoKfbjBhpAELRp43hLJuFfAmV8FzzqoajmuVhitbt_3JqKSxG1EJz2woJLCMrTPB-I_TYHK3f0Z3gPFlkM_nhrZe6rSBmJKso_yWZNlHbWTmZW097ch2-bCE-H5utUdU0ar_4O)](https://www.star-history.com/?repos=h0x91b%2Fdev-3.0&type=date&legend=top-left)
 
 ## License
 

--- a/change-logs/2026/07/13/docs-star-history-sealed-embed.md
+++ b/change-logs/2026/07/13/docs-star-history-sealed-embed.md
@@ -1,0 +1,1 @@
+Updated the README and public website Star History charts to use the regenerated sealed-token embed, restoring live star-history rendering after GitHub restricted anonymous stargazer data access.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1996,9 +1996,13 @@ footer {
       their agent fleets with dev-3.0 &mdash; and star the repo to keep the curve going.
     </p>
     <div class="star-history-frame reveal reveal-delay-3">
-      <a href="https://star-history.com/#h0x91b/dev-3.0&Date" target="_blank" rel="noopener">
-        <img loading="lazy" decoding="async" src="https://api.star-history.com/svg?repos=h0x91b/dev-3.0&type=Date&theme=dark" alt="Star History Chart"
+      <a href="https://www.star-history.com/?repos=h0x91b%2Fdev-3.0&type=date&legend=top-left" target="_blank" rel="noopener">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=h0x91b/dev-3.0&type=date&theme=dark&legend=top-left&sealed_token=WnGGefyKijPrjGxSOkU0sy1POJy10qROzjxTQzjREVPRgboUHeKms8QoKfbjBhpAELRp43hLJuFfAmV8FzzqoajmuVhitbt_3JqKSxG1EJz2woJLCMrTPB-I_TYHK3f0Z3gPFlkM_nhrZe6rSBmJKso_yWZNlHbWTmZW097ch2-bCE-H5utUdU0ar_4O">
+          <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=h0x91b/dev-3.0&type=date&legend=top-left&sealed_token=WnGGefyKijPrjGxSOkU0sy1POJy10qROzjxTQzjREVPRgboUHeKms8QoKfbjBhpAELRp43hLJuFfAmV8FzzqoajmuVhitbt_3JqKSxG1EJz2woJLCMrTPB-I_TYHK3f0Z3gPFlkM_nhrZe6rSBmJKso_yWZNlHbWTmZW097ch2-bCE-H5utUdU0ar_4O">
+          <img loading="lazy" decoding="async" src="https://api.star-history.com/chart?repos=h0x91b/dev-3.0&type=date&legend=top-left&sealed_token=WnGGefyKijPrjGxSOkU0sy1POJy10qROzjxTQzjREVPRgboUHeKms8QoKfbjBhpAELRp43hLJuFfAmV8FzzqoajmuVhitbt_3JqKSxG1EJz2woJLCMrTPB-I_TYHK3f0Z3gPFlkM_nhrZe6rSBmJKso_yWZNlHbWTmZW097ch2-bCE-H5utUdU0ar_4O" alt="Star History Chart"
              onerror="this.parentElement.parentElement.innerHTML='<div style=\'padding:48px;color:var(--text-3);font-family:var(--font-mono);font-size:14px\'>Star the repo to see the chart grow!<br><br><a href=&quot;https://github.com/h0x91b/dev-3.0&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot; style=&quot;color:var(--accent);text-decoration:none&quot;>github.com/h0x91b/dev-3.0</a></div>'">
+        </picture>
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace the stale README Star History image with the regenerated date-based sealed-token embed.
- Update the public docs site with matching dark/light responsive chart sources.
- Add a changelog entry for the refreshed embeds.

## Verification
- `bun run lint`
- `bun run test`
- Local browser parsing verified both `<picture>` sources.

Note: the Star History API returned rate-limit/timeout responses during live endpoint verification; the repository embed URLs match the regenerated token supplied for this repository.