### PR TITLE
Fix Cloudflare remote access link propagation

### DIFF
--- a/change-logs/2026/07/13/fix-cloudflare-remote-link-dns-delay.md
+++ b/change-logs/2026/07/13/fix-cloudflare-remote-link-dns-delay.md
@@ -1,0 +1,1 @@
+Remote Access now automatically starts a Cloudflare tunnel when `cloudflared` is installed and keeps the public URL out of the QR modal until Cloudflare DNS has had five seconds to provision the hostname. Explicit local/LAN mode remains available by disabling the tunnel.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -14,7 +14,7 @@ import { createLogger, getLogPath } from "./logger";
 import { DEV3_HOME } from "./paths";
 import { applyFullShellEnvToProcess, getShellRcFiles, getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
-import { startRemoteAccessServer, pushToBrowserClients, generateQrDataUrl, getAccessUrl } from "./remote-access-server";
+import { startRemoteAccessServer, pushToBrowserClients } from "./remote-access-server";
 import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
@@ -747,11 +747,8 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 		sendToFocusedWindow("zoomReset");
 	} else if (e.data.action === "show-remote-qr") {
 		try {
-			const qrDataUrl = await generateQrDataUrl();
-			const accessUrl = await getAccessUrl();
-			const { isCloudflaredAvailable, getTunnelState } = await import("./cloudflare-tunnel");
-			const { getLocalInterfaces, resolveAccessHost } = await import("./remote-access-server");
-			sendToFocusedWindow("showRemoteAccessQR", { qrDataUrl, accessUrl, tunnelState: getTunnelState(), cloudflaredInstalled: isCloudflaredAvailable(), interfaces: getLocalInterfaces(), selectedHost: resolveAccessHost() });
+			const remoteAccess = await handlers.getRemoteAccessQR({});
+			sendToFocusedWindow("showRemoteAccessQR", remoteAccess);
 		} catch (err) {
 			log.error("Failed to generate QR code", { error: String(err) });
 		}

--- a/src/bun/rpc-handlers/__tests__/remote-access.test.ts
+++ b/src/bun/rpc-handlers/__tests__/remote-access.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	isCloudflaredAvailable: vi.fn(),
+	getTunnelState: vi.fn(),
+	startTunnel: vi.fn(),
+	stopTunnel: vi.fn(),
+	getAccessUrl: vi.fn(),
+	generateQrDataUrl: vi.fn(),
+	getLocalInterfaces: vi.fn(),
+	resolveAccessHost: vi.fn(),
+	getServerPort: vi.fn(),
+}));
+
+vi.mock("../../cloudflare-tunnel", () => ({
+	isCloudflaredAvailable: mocks.isCloudflaredAvailable,
+	getTunnelState: mocks.getTunnelState,
+	startTunnel: mocks.startTunnel,
+	stopTunnel: mocks.stopTunnel,
+}));
+
+vi.mock("../../remote-access-server", () => ({
+	getAccessUrl: mocks.getAccessUrl,
+	generateQrDataUrl: mocks.generateQrDataUrl,
+	getLocalInterfaces: mocks.getLocalInterfaces,
+	resolveAccessHost: mocks.resolveAccessHost,
+	getServerPort: mocks.getServerPort,
+}));
+
+import { remoteAccessHandlers, TUNNEL_DNS_SETTLE_DELAY_MS } from "../remote-access";
+
+describe("remote access handler", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		mocks.isCloudflaredAvailable.mockReturnValue(true);
+		mocks.getTunnelState.mockReturnValue("idle");
+		mocks.getServerPort.mockReturnValue(12478);
+		mocks.startTunnel.mockResolvedValue("https://public.trycloudflare.com");
+		mocks.generateQrDataUrl.mockResolvedValue("data:image/png;base64,test");
+		mocks.getAccessUrl.mockResolvedValue("https://public.trycloudflare.com/?token=test");
+		mocks.getLocalInterfaces.mockReturnValue([]);
+		mocks.resolveAccessHost.mockReturnValue("127.0.0.1");
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("auto-starts an installed Cloudflare tunnel and waits for DNS propagation", async () => {
+		mocks.getTunnelState.mockReturnValueOnce("idle").mockReturnValue("connected");
+
+		const resultPromise = remoteAccessHandlers.getRemoteAccessQR({});
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(mocks.startTunnel).toHaveBeenCalledWith(12478);
+		expect(mocks.generateQrDataUrl).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(TUNNEL_DNS_SETTLE_DELAY_MS - 1);
+		expect(mocks.generateQrDataUrl).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		const result = await resultPromise;
+		expect(result.accessUrl).toBe("https://public.trycloudflare.com/?token=test");
+		expect(mocks.generateQrDataUrl).toHaveBeenCalled();
+	});
+
+	it("keeps local access when the caller explicitly disables the tunnel", async () => {
+		mocks.getAccessUrl.mockResolvedValue("http://192.168.0.1:12478/?token=test");
+
+		const result = await remoteAccessHandlers.getRemoteAccessQR({ tunnel: false, host: "192.168.0.1" });
+
+		expect(mocks.startTunnel).not.toHaveBeenCalled();
+		expect(result.accessUrl).toBe("http://192.168.0.1:12478/?token=test");
+		expect(mocks.generateQrDataUrl).toHaveBeenCalledWith("192.168.0.1");
+	});
+});

--- a/src/bun/rpc-handlers/remote-access.ts
+++ b/src/bun/rpc-handlers/remote-access.ts
@@ -1,14 +1,25 @@
 import { getAccessUrl, generateQrDataUrl, getLocalInterfaces, resolveAccessHost } from "../remote-access-server";
 import type { RemoteNetInterface } from "../../shared/types";
 
+/** Give Cloudflare's quick-tunnel hostname time to propagate before publishing it to the UI. */
+export const TUNNEL_DNS_SETTLE_DELAY_MS = 5_000;
+
 async function getRemoteAccessQR(params: { tunnel?: boolean; host?: string }): Promise<{ qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean; interfaces: RemoteNetInterface[]; selectedHost: string }> {
 	const { isCloudflaredAvailable, getTunnelState, startTunnel } = await import("../cloudflare-tunnel");
 	const { getServerPort } = await import("../remote-access-server");
 	const cloudflaredInstalled = isCloudflaredAvailable();
 	const tunnelState = getTunnelState();
 
-	if (params?.tunnel && cloudflaredInstalled && tunnelState === "idle") {
-		await startTunnel(getServerPort());
+	// Opening Remote Access is an explicit request to share the app, so the
+	// public tunnel is the default when cloudflared is available. Callers that
+	// need a local/LAN URL pass tunnel: false (for example, the interface picker).
+	if (params?.tunnel !== false && cloudflaredInstalled && tunnelState === "idle") {
+		const tunnelUrl = await startTunnel(getServerPort());
+		if (tunnelUrl) {
+			// cloudflared prints the hostname before Cloudflare's edge has finished
+			// provisioning DNS. Do not let the QR/link escape during that window.
+			await new Promise<void>((resolve) => setTimeout(resolve, TUNNEL_DNS_SETTLE_DELAY_MS));
+		}
 	}
 
 	const host = params?.host;


### PR DESCRIPTION
## Summary

- Automatically start the Cloudflare tunnel when Remote Access is opened and `cloudflared` is available.
- Wait five seconds after Cloudflare returns the quick-tunnel hostname before generating the public QR code and access URL.
- Keep explicit local/LAN mode available with the existing tunnel toggle and route the native menu through the shared handler.

## Testing

- `bun run lint`
- `bun run test`
- Browser QA confirmed the public URL is withheld during the delay, Cloudflare is enabled by default, local opt-out still works, and there are no console errors.