### PR TITLE
Recover stalled Cloudflare Quick Tunnels

### DIFF
--- a/change-logs/2026/07/13/fix-remote-tunnel-liveness.md
+++ b/change-logs/2026/07/13/fix-remote-tunnel-liveness.md
@@ -1,0 +1,1 @@
+Remote Access now records cloudflared output in the daily app logs, detects stalled edge connections, restarts stale Quick Tunnels, and refreshes rotated URLs in open QR and exposed-port surfaces.

--- a/decisions/129-cloudflare-tunnel-readiness-watchdog.md
+++ b/decisions/129-cloudflare-tunnel-readiness-watchdog.md
@@ -1,0 +1,21 @@
+# Cloudflare Tunnel readiness watchdog
+
+## Context
+
+A Quick Tunnel hostname returned `NXDOMAIN` while its `cloudflared` child process remained alive and the Remote Access modal still reported the tunnel as connected. The existing manager treated the child PID and the first printed URL as sufficient liveness signals, then stopped reading `stderr` after startup.
+
+## Investigation
+
+The live process management endpoint returned `503` with zero ready connections, while its metrics reported one successful registration followed by 48 `server_error` registration failures. Because the post-startup `stderr` stream was no longer consumed, the daily app log contained the initial URL but none of the reconnect failures needed to explain the outage.
+
+## Decision
+
+`src/bun/cloudflare-tunnel.ts` drains and level-maps `cloudflared` output into the existing daily logger for the entire child lifetime. It parses the local management `/ready` endpoint, checks it every 10 seconds, and replaces the Quick Tunnel after three consecutive failures; rotated URLs propagate through the existing exposed-port push path and the open Remote Access modal polling loop.
+
+## Risks
+
+The management routes are diagnostic interfaces owned by `cloudflared`, so a future release could change their output or endpoint shape; failure to parse the startup line degrades to logging without automatic recovery. Restarting an anonymous Quick Tunnel necessarily rotates its hostname, so disconnected clients must use the refreshed URL or QR shown by dev-3.0.
+
+## Alternatives considered
+
+Watching only the child exit was rejected because the observed failure leaves the process alive indefinitely. DNS polling was rejected because it adds external resolver and cache ambiguity, while a named tunnel would provide a stable hostname but requires a Cloudflare account and is a separate product/configuration decision.

--- a/src/bun/__tests__/cloudflare-tunnel.test.ts
+++ b/src/bun/__tests__/cloudflare-tunnel.test.ts
@@ -5,13 +5,15 @@ vi.mock("../spawn", () => ({
 	spawnSync: vi.fn(),
 }));
 
+const loggerMocks = vi.hoisted(() => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
+
 vi.mock("../logger", () => ({
-	createLogger: () => ({
-		debug: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-	}),
+	createLogger: () => loggerMocks,
 }));
 
 import { spawn as mockSpawn, spawnSync as mockSpawnSync } from "../spawn";
@@ -21,6 +23,7 @@ import {
 	stopTunnel,
 	getTunnelUrl,
 	getTunnelState,
+	parseTunnelMetricsUrl,
 	parseTunnelUrl,
 	resolveTunnelProtocol,
 	tunnelManager,
@@ -110,6 +113,18 @@ describe("parseTunnelUrl", () => {
 	});
 });
 
+describe("parseTunnelMetricsUrl", () => {
+	it("extracts the local readiness endpoint from cloudflared output", () => {
+		expect(
+			parseTunnelMetricsUrl("2026-07-13T12:54:39Z INF Starting metrics server on 127.0.0.1:20241/metrics"),
+		).toBe("http://127.0.0.1:20241/ready");
+	});
+
+	it("returns null for unrelated output", () => {
+		expect(parseTunnelMetricsUrl("INF Registered tunnel connection")).toBeNull();
+	});
+});
+
 // ================================================================
 // isCloudflaredAvailable
 // ================================================================
@@ -187,6 +202,30 @@ describe("startTunnel", () => {
 			["cloudflared", "tunnel", "--protocol", "http2", "--url", "http://localhost:8080"],
 			{ stdout: "ignore", stderr: "pipe" },
 		);
+	});
+
+	it("keeps draining and logging cloudflared stderr after finding the URL", async () => {
+		const encoder = new TextEncoder();
+		let stderrController!: ReadableStreamDefaultController<Uint8Array>;
+		(mockSpawn as Mock).mockReturnValue({
+			kill: vi.fn(),
+			exited: new Promise<void>(() => {}),
+			stderr: new ReadableStream({
+				start(controller) {
+					stderrController = controller;
+					controller.enqueue(encoder.encode("INF | https://logged.trycloudflare.com\n"));
+				},
+			}),
+		});
+
+		await startTunnel(8080);
+		stderrController.enqueue(encoder.encode("ERR registration failed after startup\n"));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(loggerMocks.error).toHaveBeenCalledWith("cloudflared", {
+			id: "main",
+			line: "ERR registration failed after startup",
+		});
 	});
 
 	it("returns null when stderr closes without URL", async () => {
@@ -392,5 +431,54 @@ describe("process exit", () => {
 
 		expect(getTunnelState()).toBe("idle");
 		expect(getTunnelUrl()).toBeNull();
+	});
+});
+
+describe("edge readiness watchdog", () => {
+	beforeEach(() => {
+		_resetState();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function mockLiveTunnel(url: string, metricsPort: number) {
+		const encoder = new TextEncoder();
+		(mockSpawn as Mock).mockReturnValueOnce({
+			kill: vi.fn(),
+			exited: new Promise<void>(() => {}),
+			stderr: new ReadableStream({
+				start(controller) {
+					controller.enqueue(encoder.encode(
+						`INF Starting metrics server on 127.0.0.1:${metricsPort}/metrics\nINF | ${url}\n`,
+					));
+				},
+			}),
+		});
+	}
+
+	it("restarts a live process after three consecutive edge-readiness failures", async () => {
+		mockLiveTunnel("https://stale.trycloudflare.com", 20241);
+		mockLiveTunnel("https://recovered.trycloudflare.com", 20242);
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+			JSON.stringify({ status: 503, readyConnections: 0 }),
+			{ status: 503, headers: { "content-type": "application/json" } },
+		)));
+
+		await startTunnel(8080);
+		expect(tunnelManager.get("main")?.metricsReadyUrl).toBe("http://127.0.0.1:20241/ready");
+
+		await tunnelManager.checkHealth("main");
+		await tunnelManager.checkHealth("main");
+		await tunnelManager.checkHealth("main");
+
+		expect(mockSpawn).toHaveBeenCalledTimes(2);
+		expect(getTunnelUrl()).toBe("https://recovered.trycloudflare.com");
+		expect(loggerMocks.warn).toHaveBeenCalledWith("Tunnel unhealthy; restarting", expect.objectContaining({
+			id: "main",
+			consecutiveFailures: 3,
+		}));
 	});
 });

--- a/src/bun/__tests__/port-tunnels.test.ts
+++ b/src/bun/__tests__/port-tunnels.test.ts
@@ -11,7 +11,7 @@ vi.mock("../logger", () => ({
 }));
 
 import { spawn as mockSpawn } from "../spawn";
-import { _resetState } from "../cloudflare-tunnel";
+import { _resetState, tunnelManager } from "../cloudflare-tunnel";
 import {
 	exposeTaskPort,
 	exposeTaskPortsShared,
@@ -36,6 +36,21 @@ function mockNextSpawn(url: string) {
 			start(controller) {
 				controller.enqueue(encoder.encode(`INF | ${url}\n`));
 				controller.close();
+			},
+		}),
+	});
+}
+
+function mockNextLiveSpawn(url: string, metricsPort: number) {
+	const encoder = new TextEncoder();
+	(mockSpawn as Mock).mockReturnValueOnce({
+		kill: vi.fn(),
+		exited: new Promise<void>(() => {}),
+		stderr: new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode(
+					`INF Starting metrics server on 127.0.0.1:${metricsPort}/metrics\nINF | ${url}\n`,
+				));
 			},
 		}),
 	});
@@ -78,6 +93,29 @@ describe("port-tunnels — exposeTaskPort", () => {
 		push.mockClear();
 		unexposeTaskPort("t", 3000);
 		expect(push).toHaveBeenCalledWith("exposedPortsChanged", { taskId: "t", ports: [] });
+	});
+
+	it("emits the rotated URL after the readiness watchdog restarts a tunnel", async () => {
+		const push = vi.fn();
+		setPortTunnelsPushHook(push);
+		mockNextLiveSpawn("https://stale-port.trycloudflare.com", 20241);
+		mockNextLiveSpawn("https://recovered-port.trycloudflare.com", 20242);
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("unready", { status: 503 })));
+		try {
+			await exposeTaskPort("t", 3000);
+			push.mockClear();
+
+			await tunnelManager.checkHealth("task:t:port:3000");
+			await tunnelManager.checkHealth("task:t:port:3000");
+			await tunnelManager.checkHealth("task:t:port:3000");
+
+			expect(push).toHaveBeenLastCalledWith("exposedPortsChanged", {
+				taskId: "t",
+				ports: [expect.objectContaining({ url: "https://recovered-port.trycloudflare.com" })],
+			});
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });
 

--- a/src/bun/cloudflare-tunnel.ts
+++ b/src/bun/cloudflare-tunnel.ts
@@ -35,6 +35,10 @@ export interface TunnelEntry {
 	process: ReturnType<typeof spawn> | null;
 	startedAt: number;
 	subToken: string;
+	metricsReadyUrl: string | null;
+	consecutiveHealthFailures: number;
+	healthCheckInFlight: boolean;
+	healthCheckTimer: ReturnType<typeof setInterval> | null;
 }
 
 export interface StartTunnelOptions {
@@ -47,6 +51,9 @@ export interface StartTunnelOptions {
 
 const MAIN_ID = "main";
 const URL_WAIT_TIMEOUT_MS = 30_000;
+const HEALTH_CHECK_INTERVAL_MS = 10_000;
+const HEALTH_CHECK_TIMEOUT_MS = 3_000;
+const HEALTH_FAILURE_LIMIT = 3;
 
 const tunnels = new Map<string, TunnelEntry>();
 
@@ -90,55 +97,106 @@ export function parseTunnelUrl(line: string): string | null {
 	return match ? match[0] : null;
 }
 
-async function waitForUrl(stderr: ReadableStream, timeoutMs: number): Promise<string | null> {
+/**
+ * Parse cloudflared's local management endpoint from its startup output.
+ * `/ready` reports 200 only while at least one edge connection is active;
+ * a running process alone is not a tunnel-liveness signal.
+ */
+export function parseTunnelMetricsUrl(line: string): string | null {
+	const match = line.match(/Starting metrics server on\s+(\S+)/i);
+	if (!match) return null;
+	let address = match[1].replace(/[),;]+$/, "").replace(/\/metrics\/?$/, "");
+	if (address.startsWith("0.0.0.0:")) address = `127.0.0.1:${address.slice("0.0.0.0:".length)}`;
+	if (address.startsWith("[::]:")) address = `[::1]:${address.slice("[::]:".length)}`;
+	const base = /^https?:\/\//i.test(address) ? address : `http://${address}`;
+	return `${base}/ready`;
+}
+
+function logCloudflaredLine(id: string, line: string): void {
+	const trimmed = line.trim();
+	if (!trimmed) return;
+	const extra = { id, line: trimmed };
+	if (/\b(ERR|ERROR|FTL|FATAL)\b/i.test(trimmed)) {
+		log.error("cloudflared", extra);
+	} else if (/\b(WRN|WARN|WARNING)\b/i.test(trimmed)) {
+		log.warn("cloudflared", extra);
+	} else {
+		log.info("cloudflared", extra);
+	}
+}
+
+/**
+ * Drain stderr for the entire child lifetime. Previously the reader lock was
+ * released as soon as the public URL appeared, which discarded every later
+ * reconnect error and could eventually back-pressure the child process.
+ */
+function monitorStderr(entry: TunnelEntry, stderr: ReadableStream): Promise<string | null> {
 	const reader = stderr.getReader();
 	const decoder = new TextDecoder();
-	const deadline = Date.now() + timeoutMs;
 	let buffer = "";
+	let urlResolved = false;
+	let resolveUrl!: (url: string | null) => void;
+	const urlPromise = new Promise<string | null>((resolve) => {
+		resolveUrl = resolve;
+	});
 
-	try {
-		while (Date.now() < deadline) {
-			const remaining = deadline - Date.now();
-			if (remaining <= 0) break;
-
-			const result = await Promise.race([
-				reader.read(),
-				new Promise<{ done: true; value: undefined }>((resolve) =>
-					setTimeout(() => resolve({ done: true, value: undefined }), remaining),
-				),
-			]);
-
-			if (result.done) break;
-
-			buffer += decoder.decode(result.value, { stream: true });
-
-			const lines = buffer.split("\n");
-			buffer = lines.pop() ?? "";
-
-			for (const line of lines) {
-				const url = parseTunnelUrl(line);
-				if (url) {
-					reader.releaseLock();
-					return url;
-				}
+	function processLine(line: string): void {
+		logCloudflaredLine(entry.id, line);
+		const metricsReadyUrl = parseTunnelMetricsUrl(line);
+		if (metricsReadyUrl) entry.metricsReadyUrl = metricsReadyUrl;
+		if (!urlResolved) {
+			const url = parseTunnelUrl(line);
+			if (url) {
+				urlResolved = true;
+				resolveUrl(url);
 			}
 		}
-
-		if (buffer) {
-			const url = parseTunnelUrl(buffer);
-			if (url) return url;
-		}
-	} finally {
-		try { reader.releaseLock(); } catch { /* already released */ }
 	}
 
-	return null;
+	void (async () => {
+		try {
+			while (true) {
+				const result = await reader.read();
+				if (result.done) break;
+				buffer += decoder.decode(result.value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+				for (const line of lines) processLine(line);
+			}
+			buffer += decoder.decode();
+			if (buffer) processLine(buffer);
+		} catch (err) {
+			log.warn("Failed to read cloudflared stderr", { id: entry.id, error: String(err) });
+		} finally {
+			if (!urlResolved) resolveUrl(null);
+			try { reader.releaseLock(); } catch { /* already released */ }
+		}
+	})();
+
+	return urlPromise;
+}
+
+async function waitForUrl(urlPromise: Promise<string | null>, timeoutMs: number): Promise<string | null> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			urlPromise,
+			new Promise<null>((resolve) => {
+				timeout = setTimeout(() => resolve(null), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
 }
 
 interface TunnelFilter {
 	kind?: TunnelKind;
 	taskId?: string;
 }
+
+type TunnelChangeHook = (entry: TunnelEntry, previousUrl: string | null) => void;
+let tunnelChangeHook: TunnelChangeHook | null = null;
 
 function matchesFilter(entry: TunnelEntry, filter?: TunnelFilter): boolean {
 	if (!filter) return true;
@@ -165,6 +223,10 @@ async function startEntry(opts: StartTunnelOptions): Promise<TunnelEntry> {
 		process: null,
 		startedAt: Date.now(),
 		subToken: randomBytes(24).toString("base64url"),
+		metricsReadyUrl: null,
+		consecutiveHealthFailures: 0,
+		healthCheckInFlight: false,
+		healthCheckTimer: null,
 	};
 	tunnels.set(opts.id, entry);
 
@@ -176,21 +238,24 @@ async function startEntry(opts: StartTunnelOptions): Promise<TunnelEntry> {
 		entry.process = proc;
 
 		// Reset state when the cloudflared process exits unexpectedly.
-		proc.exited.then(() => {
-			log.info("Tunnel process exited", { id: opts.id });
+		proc.exited.then((exitCode) => {
+			log.info("Tunnel process exited", { id: opts.id, exitCode });
 			const current = tunnels.get(opts.id);
 			if (current === entry) {
+				if (entry.healthCheckTimer) clearInterval(entry.healthCheckTimer);
+				entry.healthCheckTimer = null;
 				entry.process = null;
 				entry.url = null;
 				entry.state = "idle";
 			}
 		});
 
-		const url = await waitForUrl(proc.stderr!, URL_WAIT_TIMEOUT_MS);
+		const url = await waitForUrl(monitorStderr(entry, proc.stderr!), URL_WAIT_TIMEOUT_MS);
 		if (url) {
 			entry.url = url;
 			entry.state = "connected";
 			log.info("Tunnel connected", { id: opts.id, url });
+			startHealthMonitor(entry);
 			return entry;
 		}
 
@@ -209,6 +274,8 @@ async function startEntry(opts: StartTunnelOptions): Promise<TunnelEntry> {
 function stopEntry(id: string): void {
 	const entry = tunnels.get(id);
 	if (!entry) return;
+	if (entry.healthCheckTimer) clearInterval(entry.healthCheckTimer);
+	entry.healthCheckTimer = null;
 	if (entry.process) {
 		try {
 			entry.process.kill();
@@ -219,10 +286,90 @@ function stopEntry(id: string): void {
 	tunnels.delete(id);
 }
 
+async function restartEntry(entry: TunnelEntry): Promise<void> {
+	if (tunnels.get(entry.id) !== entry) return;
+	const previousUrl = entry.url;
+	const opts: StartTunnelOptions = {
+		id: entry.id,
+		kind: entry.kind,
+		targetPort: entry.targetPort,
+		ports: [...entry.ports],
+		taskId: entry.taskId,
+	};
+	stopEntry(entry.id);
+	const restarted = await startEntry(opts);
+	if (restarted.url) {
+		log.info("Tunnel restarted", { id: entry.id, previousUrl, url: restarted.url });
+		tunnelChangeHook?.(restarted, previousUrl);
+	} else {
+		log.error("Tunnel restart failed", { id: entry.id, previousUrl });
+	}
+}
+
+async function checkHealth(id: string): Promise<void> {
+	const entry = tunnels.get(id);
+	if (!entry || entry.state !== "connected" || !entry.metricsReadyUrl || entry.healthCheckInFlight) return;
+	entry.healthCheckInFlight = true;
+	try {
+		let response: Response | null = null;
+		let detail = "";
+		try {
+			response = await fetch(entry.metricsReadyUrl, {
+				signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+			});
+			detail = (await response.text()).slice(0, 500);
+		} catch (err) {
+			detail = String(err);
+		}
+
+		if (tunnels.get(id) !== entry) return;
+		if (response?.ok) {
+			if (entry.consecutiveHealthFailures > 0) {
+				log.info("Tunnel edge connection recovered", {
+					id,
+					previousFailures: entry.consecutiveHealthFailures,
+				});
+			}
+			entry.consecutiveHealthFailures = 0;
+			return;
+		}
+
+		entry.consecutiveHealthFailures += 1;
+		log.warn("Tunnel edge readiness check failed", {
+			id,
+			status: response?.status ?? null,
+			detail,
+			consecutiveFailures: entry.consecutiveHealthFailures,
+		});
+		if (entry.consecutiveHealthFailures >= HEALTH_FAILURE_LIMIT) {
+			log.warn("Tunnel unhealthy; restarting", {
+				id,
+				url: entry.url,
+				consecutiveFailures: entry.consecutiveHealthFailures,
+			});
+			await restartEntry(entry);
+		}
+	} finally {
+		entry.healthCheckInFlight = false;
+	}
+}
+
+function startHealthMonitor(entry: TunnelEntry): void {
+	if (entry.healthCheckTimer) clearInterval(entry.healthCheckTimer);
+	entry.healthCheckTimer = setInterval(() => {
+		void checkHealth(entry.id);
+	}, HEALTH_CHECK_INTERVAL_MS);
+	(entry.healthCheckTimer as ReturnType<typeof setInterval> & { unref?: () => void }).unref?.();
+}
+
 export const tunnelManager = {
 	start: startEntry,
 	stop: stopEntry,
 	get: (id: string): TunnelEntry | undefined => tunnels.get(id),
+	checkHealth,
+	setChangeHook: (hook: TunnelChangeHook | null): void => {
+		tunnelChangeHook = hook;
+	},
 	list: (filter?: TunnelFilter): TunnelEntry[] => {
 		const out: TunnelEntry[] = [];
 		for (const entry of tunnels.values()) {
@@ -264,5 +411,8 @@ export function getTunnelState(): TunnelState {
 
 /** Reset module state — only for tests */
 export function _resetState(): void {
+	for (const entry of tunnels.values()) {
+		if (entry.healthCheckTimer) clearInterval(entry.healthCheckTimer);
+	}
 	tunnels.clear();
 }

--- a/src/bun/port-tunnels.ts
+++ b/src/bun/port-tunnels.ts
@@ -49,6 +49,12 @@ function emitChanged(taskId: string): void {
 	pushFn("exposedPortsChanged", { taskId, ports: getExposedPorts(taskId) });
 }
 
+// A readiness-watchdog restart rotates the random Quick Tunnel hostname.
+// Reuse the existing push path so every port surface replaces the stale URL.
+tunnelManager.setChangeHook((entry) => {
+	if (entry.taskId) emitChanged(entry.taskId);
+});
+
 export function getExposedPorts(taskId?: string): ExposedPort[] {
 	const filter = taskId !== undefined ? { taskId } : undefined;
 	return tunnelManager

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1628,30 +1628,56 @@ function App() {
 	}, []);
 
 	// Auto-refresh QR code every 25 seconds while modal is open (JWT tokens expire in 30s)
-	// Stops when QR is consumed (someone connected).
+	// After a QR is consumed, keep polling without visually rotating the token:
+	// a recovered Quick Tunnel gets a new hostname, and the open modal must
+	// reactivate with that new URL instead of staying green on a dead domain.
 	const qrModalOpen = remoteQR !== null;
 	const [qrCountdown, setQrCountdown] = useState(25);
 	const tunnelWantedRef = useRef(tunnelWanted);
 	tunnelWantedRef.current = tunnelWanted;
+	const qrConsumedRef = useRef(qrConsumed);
+	qrConsumedRef.current = qrConsumed;
+	const remoteQRRef = useRef(remoteQR);
+	remoteQRRef.current = remoteQR;
 	// Preserve the chosen interface/IP across the 25s token refresh — without
 	// this, picking a host would snap back to the auto-pick on the next tick.
 	const selectedHostRef = useRef<string | undefined>(undefined);
 	selectedHostRef.current = remoteQR?.selectedHost;
 	useEffect(() => {
-		if (!qrModalOpen || qrConsumed) return;
+		if (!qrModalOpen) return;
 		setQrCountdown(25);
 		let counter = 25;
+		let refreshInFlight = false;
 		const tick = setInterval(() => {
 			counter -= 1;
 			if (counter <= 0) {
 				counter = 25;
 				const host = tunnelWantedRef.current ? undefined : selectedHostRef.current;
-				api.request.getRemoteAccessQR({ tunnel: tunnelWantedRef.current, host }).then(setRemoteQR).catch(() => {});
+				if (!refreshInFlight) {
+					refreshInFlight = true;
+					api.request.getRemoteAccessQR({ tunnel: tunnelWantedRef.current, host }).then((next) => {
+						const current = remoteQRRef.current;
+						let hostnameChanged = false;
+						if (current?.tunnelState === "connected" && next.tunnelState === "connected") {
+							try {
+								hostnameChanged = new URL(current.accessUrl).hostname !== new URL(next.accessUrl).hostname;
+							} catch {
+								hostnameChanged = current.accessUrl !== next.accessUrl;
+							}
+						}
+						if (!qrConsumedRef.current || hostnameChanged) {
+							setRemoteQR(next);
+							if (hostnameChanged) setQrConsumed(false);
+						}
+					}).catch(() => {}).finally(() => {
+						refreshInFlight = false;
+					});
+				}
 			}
-			setQrCountdown(counter);
+			if (!qrConsumedRef.current) setQrCountdown(counter);
 		}, 1000);
 		return () => clearInterval(tick);
-	}, [qrModalOpen, qrConsumed]);
+	}, [qrModalOpen]);
 
 	// Track page views on route changes. Resolve the task's human-readable seq id
 	// (e.g. "981-1") from the loaded task list so analytics paths carry the task

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1024,6 +1024,43 @@ describe("App keyboard shortcuts", () => {
 			expect(screen.queryByText("Connected")).not.toBeInTheDocument();
 		});
 
+		it("reactivates a consumed QR when the tunnel recovers with a new hostname", async () => {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			try {
+				await renderApp();
+				window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+					detail: {
+						qrDataUrl: "data:image/png;base64,stale",
+						accessUrl: "https://stale.trycloudflare.com/?token=old",
+						tunnelState: "connected",
+						cloudflaredInstalled: true,
+					},
+				}));
+				window.dispatchEvent(new CustomEvent("rpc:qrTokenConsumed"));
+				await waitFor(() => expect(screen.getByText("Copy URL")).toBeDisabled());
+
+				vi.mocked(api.request.getRemoteAccessQR).mockResolvedValue({
+					qrDataUrl: "data:image/png;base64,recovered",
+					accessUrl: "https://recovered.trycloudflare.com/?token=new",
+					tunnelState: "connected",
+					cloudflaredInstalled: true,
+					interfaces: [],
+					selectedHost: "",
+				});
+
+				await act(async () => {
+					await vi.advanceTimersByTimeAsync(25_000);
+				});
+
+				expect(api.request.getRemoteAccessQR).toHaveBeenCalledWith({ tunnel: true, host: undefined });
+				expect(screen.getByText("https://recovered.trycloudflare.com/?token=new")).toBeInTheDocument();
+				expect(screen.getByText("Copy URL")).not.toBeDisabled();
+				expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it("shows auth failed screen when rpc:authFailed fires", async () => {
 			await renderApp();
 			window.dispatchEvent(new CustomEvent("rpc:authFailed", { detail: { status: 401 } }));


### PR DESCRIPTION
## Summary\n\n- Keep draining cloudflared stderr for the full process lifetime and write level-mapped output to the daily app log.\n- Poll cloudflared's local /ready endpoint every 10 seconds and restart a tunnel after three consecutive unhealthy checks.\n- Propagate rotated Quick Tunnel hostnames to exposed ports and an open Remote Access QR modal, including consumed QR recovery.\n\n## Root cause\n\nA Quick Tunnel could remain alive while all edge connections were gone. The UI trusted the child PID and initial hostname, so it kept showing an active tunnel even though the hostname returned NXDOMAIN.\n\n## Validation\n\n- bun run lint\n- bun run test (5455 passed, 1 skipped)\n- Browser QA at a 390x844 viewport with no console errors\n