### PR TITLE
Fix Codex accounts across ChatGPT workspaces

### DIFF
--- a/change-logs/2026/07/13/fix-codex-workspace-accounts.md
+++ b/change-logs/2026/07/13/fix-codex-workspace-accounts.md
@@ -1,1 +1,1 @@
-Codex account management now identifies duplicate logins by ChatGPT workspace, so one email can keep multiple workspaces. Account rows and launch pickers show a short workspace ID, and duplicate errors name the workspace explicitly.
+Codex account management now identifies duplicate logins by ChatGPT workspace, so one email can keep multiple workspaces. Account rows, launch pickers, duplicate errors, and diagnostic logs use readable workspace names when available, with a short workspace ID as an offline fallback.

--- a/change-logs/2026/07/13/fix-codex-workspace-accounts.md
+++ b/change-logs/2026/07/13/fix-codex-workspace-accounts.md
@@ -1,0 +1,1 @@
+Codex account management now identifies duplicate logins by ChatGPT workspace, so one email can keep multiple workspaces. Account rows and launch pickers show a short workspace ID, and duplicate errors name the workspace explicitly.

--- a/decisions/129-codex-readable-workspace-names.md
+++ b/decisions/129-codex-readable-workspace-names.md
@@ -1,0 +1,21 @@
+# Codex readable workspace names
+
+## Context
+
+Codex OAuth stores the selected ChatGPT workspace as `tokens.account_id` / `chatgpt_account_id`, but the JWT does not carry its readable name. The JWT `organizations` array describes API organizations and can name a different organization than the selected ChatGPT workspace.
+
+## Investigation
+
+Two real logins for Wix and Base44 produced distinct workspace IDs while both JWTs reported Wix as the default API organization. ChatGPT's first-party accounts check endpoint returned the authoritative `account.id → account.name` mapping for both workspaces.
+
+## Decision
+
+`fetchCodexWorkspaceNames` in `src/bun/agent-accounts.ts` performs a best-effort accounts lookup after Codex login/import and once for legacy entries. The resolved name is stored additively as `workspaceName` in `accounts.json`; identity parsing itself no longer treats API organizations as workspaces.
+
+## Risks
+
+The accounts check endpoint is not a documented public API and may change, fail, or be unavailable offline. A five-second timeout and ID-based fallback keep login, listing, and account selection functional; access tokens remain only in the authorization header and are never logged or persisted again.
+
+## Alternatives considered
+
+Showing only short IDs was reliable but did not let users distinguish workspaces by sight. Reusing the JWT organization title was rejected because it caused the original mislabel, while requiring users to manually rename every account added unnecessary friction.

--- a/src/bun/__tests__/agent-accounts-parse.test.ts
+++ b/src/bun/__tests__/agent-accounts-parse.test.ts
@@ -8,6 +8,7 @@ import {
 	parseClaudeIdentity,
 	parseCodexIdentity,
 	parseEnvLines,
+	shortCodexWorkspaceId,
 } from "../../shared/agent-accounts";
 
 function makeJwt(payload: Record<string, unknown>): string {
@@ -139,6 +140,19 @@ describe("parseCodexIdentity", () => {
 	it("returns null without tokens", () => {
 		expect(parseCodexIdentity({})).toBeNull();
 		expect(parseCodexIdentity(null)).toBeNull();
+	});
+
+	it("derives a compact display id from the selected ChatGPT workspace", () => {
+		expect(
+			shortCodexWorkspaceId({
+				email: "codex@example.com",
+				organization: null,
+				plan: "plus",
+				planLabel: "Plus",
+				accountId: "81b5a3a4-9199-40e2-bcde-a6d3ebc9d654",
+			}),
+		).toBe("81b5a3a4");
+		expect(shortCodexWorkspaceId(null)).toBeNull();
 	});
 });
 

--- a/src/bun/__tests__/agent-accounts-parse.test.ts
+++ b/src/bun/__tests__/agent-accounts-parse.test.ts
@@ -121,11 +121,27 @@ describe("parseCodexIdentity", () => {
 		});
 		expect(identity).toEqual({
 			email: "codex@example.com",
-			organization: "Acme Org",
+			organization: null,
 			plan: "plus",
 			planLabel: "Plus",
 			accountId: "acc-1",
 		});
+	});
+
+	it("does not mistake the default API organization for the selected ChatGPT workspace", () => {
+		const identity = parseCodexIdentity({
+			tokens: {
+				id_token: makeJwt({
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "workspace-base44",
+						organizations: [{ id: "org-wix", title: "Wix", is_default: true }],
+					},
+				}),
+				account_id: "workspace-base44",
+			},
+		});
+
+		expect(identity).toMatchObject({ accountId: "workspace-base44", organization: null });
 	});
 
 	it("falls back to the JWT chatgpt_account_id when tokens.account_id is missing", () => {

--- a/src/bun/__tests__/agent-accounts.test.ts
+++ b/src/bun/__tests__/agent-accounts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -80,6 +80,19 @@ function seedCodexLogin(accountId: string) {
 	writeFileSync(join(paths.codexHome, "auth.json"), codexAuth(accountId));
 }
 
+function mockCodexWorkspaceNames(workspaces: Array<{ id: string; name: string }>) {
+	vi.mocked(globalThis.fetch).mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				accounts: Object.fromEntries(
+					workspaces.map(({ id, name }) => [id, { account: { account_id: id, name } }]),
+				),
+			}),
+			{ status: 200, headers: { "content-type": "application/json" } },
+		),
+	);
+}
+
 beforeEach(() => {
 	root = mkdtempSync(join(tmpdir(), "dev3-agent-accounts-"));
 	paths = {
@@ -88,9 +101,11 @@ beforeEach(() => {
 		claudeJson: join(root, ".claude.json"),
 		codexHome: join(root, ".codex"),
 	};
+	vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
 });
 
 afterEach(() => {
+	vi.unstubAllGlobals();
 	rmSync(root, { recursive: true, force: true });
 });
 
@@ -281,12 +296,56 @@ describe("codex accounts", () => {
 		expect(state.codex.accounts).toHaveLength(1);
 	});
 
+	it("resolves and persists the selected ChatGPT workspace name", async () => {
+		mockCodexWorkspaceNames([{ id: "workspace-base44", name: "Base44 ChatGPT Enterprise" }]);
+		const { accountId } = await prepareCodexLogin(paths);
+		writeFileSync(
+			join(codexAccountDir(accountId, paths), "auth.json"),
+			codexAuth("workspace-base44", "shared@example.com"),
+		);
+
+		const account = await completeCodexLogin(accountId, paths);
+
+		expect(account.identity?.organization).toBe("Base44 ChatGPT Enterprise");
+		const registry = JSON.parse(readFileSync(join(paths.accountsDir, "accounts.json"), "utf-8"));
+		expect(registry.codex.accounts[0].workspaceName).toBe("Base44 ChatGPT Enterprise");
+	});
+
 	it("completeCodexLogin rejects a login that duplicates an existing account", async () => {
 		seedCodexLogin("acc-1");
 		await importCurrentCodexAccount(paths);
 		const { accountId } = await prepareCodexLogin(paths);
 		writeFileSync(join(codexAccountDir(accountId, paths), "auth.json"), codexAuth("acc-1"));
 		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(/already added/);
+	});
+
+	it("names the selected workspace in a duplicate error", async () => {
+		mockCodexWorkspaceNames([{ id: "b8e0e9ae-workspace", name: "Base44 ChatGPT Enterprise" }]);
+		seedCodexLogin("b8e0e9ae-workspace");
+		await importCurrentCodexAccount(paths);
+		const { accountId } = await prepareCodexLogin(paths);
+		writeFileSync(
+			join(codexAccountDir(accountId, paths), "auth.json"),
+			codexAuth("b8e0e9ae-workspace", "shared@example.com"),
+		);
+
+		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(
+			'Codex workspace "Base44 ChatGPT Enterprise" (b8e0e9ae) is already added as',
+		);
+	});
+
+	it("backfills readable names for legacy Codex accounts", async () => {
+		seedCodexLogin("workspace-wix");
+		const imported = await importCurrentCodexAccount(paths);
+		expect(imported.identity?.organization).toBeNull();
+		await renameAgentAccount("codex", imported.id, "workspace-wix@example.com (Workspace workspac)", paths);
+
+		mockCodexWorkspaceNames([{ id: "workspace-wix", name: "Wix" }]);
+		const state = await listAgentAccounts(paths);
+
+		expect(state.codex.accounts[0]?.identity?.organization).toBe("Wix");
+		expect(state.codex.accounts[0]?.label).toBe("workspace-wix@example.com (Wix)");
+		expect(state.codex.currentIdentity?.organization).toBe("Wix");
 	});
 
 	it("treats the Codex workspace id as authoritative when organization metadata changes", async () => {
@@ -303,7 +362,7 @@ describe("codex accounts", () => {
 			codexAuth("workspace-same", "shared@example.com", {}, [{ id: "org-2", title: "Personal" }]),
 		);
 
-		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(/Codex workspace is already added/);
+		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(/Codex workspace .* is already added/);
 	});
 
 	it("allows the same Codex email in different ChatGPT workspaces", async () => {

--- a/src/bun/__tests__/agent-accounts.test.ts
+++ b/src/bun/__tests__/agent-accounts.test.ts
@@ -49,11 +49,23 @@ function seedClaudeLogin(email = "main@example.com", accountUuid = "claude-acc-1
 	writeFileSync(join(paths.claudeHome, "settings.json"), "{}");
 }
 
-function codexAuth(accountId: string, email = `${accountId}@example.com`, extra: Record<string, unknown> = {}) {
+function codexAuth(
+	accountId: string,
+	email = `${accountId}@example.com`,
+	extra: Record<string, unknown> = {},
+	organizations: Array<{ id: string; title: string }> = [],
+) {
 	return JSON.stringify({
 		auth_mode: "ChatGPT",
 		tokens: {
-			id_token: makeJwt({ email, "https://api.openai.com/auth": { chatgpt_plan_type: "plus", chatgpt_account_id: accountId } }),
+			id_token: makeJwt({
+				email,
+				"https://api.openai.com/auth": {
+					chatgpt_plan_type: "plus",
+					chatgpt_account_id: accountId,
+					organizations,
+				},
+			}),
 			access_token: "at",
 			refresh_token: "rt",
 			account_id: accountId,
@@ -275,6 +287,45 @@ describe("codex accounts", () => {
 		const { accountId } = await prepareCodexLogin(paths);
 		writeFileSync(join(codexAccountDir(accountId, paths), "auth.json"), codexAuth("acc-1"));
 		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(/already added/);
+	});
+
+	it("treats the Codex workspace id as authoritative when organization metadata changes", async () => {
+		mkdirSync(paths.codexHome, { recursive: true });
+		writeFileSync(
+			join(paths.codexHome, "auth.json"),
+			codexAuth("workspace-same", "shared@example.com", {}, [{ id: "org-1", title: "Wix" }]),
+		);
+		await importCurrentCodexAccount(paths);
+
+		const { accountId } = await prepareCodexLogin(paths);
+		writeFileSync(
+			join(codexAccountDir(accountId, paths), "auth.json"),
+			codexAuth("workspace-same", "shared@example.com", {}, [{ id: "org-2", title: "Personal" }]),
+		);
+
+		await expect(completeCodexLogin(accountId, paths)).rejects.toThrow(/Codex workspace is already added/);
+	});
+
+	it("allows the same Codex email in different ChatGPT workspaces", async () => {
+		seedCodexLogin("11111111-1111-1111-1111-111111111111");
+		writeFileSync(
+			join(paths.codexHome, "auth.json"),
+			codexAuth("11111111-1111-1111-1111-111111111111", "shared@example.com"),
+		);
+		await importCurrentCodexAccount(paths);
+
+		const { accountId } = await prepareCodexLogin(paths);
+		writeFileSync(
+			join(codexAccountDir(accountId, paths), "auth.json"),
+			codexAuth("22222222-2222-2222-2222-222222222222", "shared@example.com"),
+		);
+
+		await expect(completeCodexLogin(accountId, paths)).resolves.toMatchObject({
+			label: "shared@example.com (Workspace 22222222)",
+			identity: { accountId: "22222222-2222-2222-2222-222222222222", email: "shared@example.com" },
+		});
+		const state = await listAgentAccounts(paths);
+		expect(state.codex.accounts).toHaveLength(2);
 	});
 
 	it("setActiveCodexAccount only moves the default pointer — never swaps ~/.codex", async () => {

--- a/src/bun/agent-accounts.ts
+++ b/src/bun/agent-accounts.ts
@@ -105,6 +105,9 @@ export const CODEX_SHARED_ENTRIES = ["config.toml", "prompts"];
 interface RegistryEntry {
 	id: string;
 	label: string;
+	/** Resolved ChatGPT workspace name for Codex accounts. Additive metadata;
+	 *  older versions safely ignore it and the lookup can restore it. */
+	workspaceName?: string;
 	/** Absent = "oauth" (pre-API-profile registries stay readable as-is). */
 	auth?: AgentAccountAuth;
 	createdAt: number;
@@ -139,6 +142,7 @@ function loadRegistry(paths: AccountPaths): Registry {
 				? v.accounts.filter((a: any) => typeof a?.id === "string" && isSafeAccountId(a.id)).map((a: any) => ({
 						id: a.id,
 						label: typeof a.label === "string" ? a.label : a.id,
+						workspaceName: typeof a.workspaceName === "string" && a.workspaceName.trim() ? a.workspaceName.trim() : undefined,
 						auth: a.auth === "api" ? ("api" as const) : undefined,
 						createdAt: typeof a.createdAt === "number" ? a.createdAt : 0,
 					}))
@@ -186,6 +190,47 @@ function codexAccountAuthFile(id: string, paths: AccountPaths): string {
 	return join(codexAccountDir(id, paths), "auth.json");
 }
 
+const CODEX_ACCOUNTS_ENDPOINT = "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27";
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function jsonRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/** Resolve every ChatGPT workspace visible to a Codex OAuth token. The caller
+ *  owns fallback behavior because this first-party endpoint is best-effort. */
+export async function fetchCodexWorkspaceNames(
+	authJson: unknown,
+	fetchImpl: FetchLike = globalThis.fetch,
+): Promise<Record<string, string>> {
+	const root = jsonRecord(authJson);
+	const tokens = jsonRecord(root?.tokens);
+	const accessToken = nonEmptyString(tokens?.access_token);
+	if (!accessToken) throw new Error("Codex access token is missing");
+
+	const response = await fetchImpl(CODEX_ACCOUNTS_ENDPOINT, {
+		headers: { authorization: `Bearer ${accessToken}` },
+		signal: AbortSignal.timeout(5_000),
+	});
+	if (!response.ok) throw new Error(`ChatGPT workspace lookup failed (HTTP ${response.status})`);
+
+	const payload = jsonRecord(await response.json());
+	const accounts = jsonRecord(payload?.accounts);
+	const names: Record<string, string> = {};
+	for (const item of Object.values(accounts ?? {})) {
+		const account = jsonRecord(jsonRecord(item)?.account);
+		const accountId = nonEmptyString(account?.account_id);
+		const name = nonEmptyString(account?.name);
+		if (accountId && name) names[accountId] = name;
+	}
+	return names;
+}
+
 /** Make the account dir a usable CODEX_HOME: ensure it exists and symlink the
  *  shared config entries from ~/.codex (idempotent — safe to call on every env
  *  build and on import/login). auth.json is written separately and stays
@@ -220,12 +265,86 @@ function safeReadJson(path: string): unknown {
 	}
 }
 
+function withCodexWorkspaceName(
+	identity: AgentAccountIdentity | null,
+	workspaceName: string | null | undefined,
+): AgentAccountIdentity | null {
+	return identity && workspaceName ? { ...identity, organization: workspaceName } : identity;
+}
+
+async function lookupCodexWorkspaceNames(authJson: unknown): Promise<Record<string, string>> {
+	const selected = parseCodexIdentity(authJson);
+	try {
+		const names = await fetchCodexWorkspaceNames(authJson);
+		log.info("Codex workspace lookup succeeded", {
+			selectedWorkspaceId: shortCodexWorkspaceId(selected),
+			selectedWorkspaceName: selected?.accountId ? names[selected.accountId] ?? null : null,
+			workspaceCount: Object.keys(names).length,
+		});
+		return names;
+	} catch (error) {
+		log.warn("Codex workspace lookup unavailable; using id fallback", {
+			selectedWorkspaceId: shortCodexWorkspaceId(selected),
+			error: String(error),
+		});
+		return {};
+	}
+}
+
+function applyCodexWorkspaceNames(
+	registry: Registry,
+	names: Record<string, string>,
+	paths: AccountPaths,
+): boolean {
+	let changed = false;
+	for (const entry of registry.codex.accounts) {
+		const identity = parseCodexIdentity(safeReadJson(codexAccountAuthFile(entry.id, paths)));
+		const name = identity?.accountId ? names[identity.accountId] ?? entry.workspaceName : null;
+		if (!name) continue;
+		if (entry.workspaceName !== name) {
+			entry.workspaceName = name;
+			changed = true;
+		}
+		const workspaceId = shortCodexWorkspaceId(identity);
+		const email = identity?.email;
+		const legacyAutoLabel = email && workspaceId ? `${email} (Workspace ${workspaceId})` : null;
+		if (legacyAutoLabel && entry.label === legacyAutoLabel) {
+			entry.label = `${email} (${name})`;
+			changed = true;
+		}
+	}
+	return changed;
+}
+
+const codexWorkspaceBackfills = new Map<string, Promise<void>>();
+
+async function backfillCodexWorkspaceNames(registry: Registry, paths: AccountPaths): Promise<void> {
+	const missingWorkspaceIds = registry.codex.accounts
+		.filter((entry) => !entry.workspaceName)
+		.map((entry) => codexAccountIdentity(entry.id, paths)?.accountId ?? entry.id)
+		.sort();
+	if (missingWorkspaceIds.length === 0) return;
+	const key = `${paths.accountsDir}:${missingWorkspaceIds.join(",")}`;
+	let pending = codexWorkspaceBackfills.get(key);
+	if (!pending) {
+		pending = (async () => {
+			const source = registry.codex.accounts.find((entry) => existsSync(codexAccountAuthFile(entry.id, paths)));
+			if (!source) return;
+			const authJson = safeReadJson(codexAccountAuthFile(source.id, paths));
+			const names = await lookupCodexWorkspaceNames(authJson);
+			if (applyCodexWorkspaceNames(registry, names, paths)) saveRegistry(registry, paths);
+		})();
+		codexWorkspaceBackfills.set(key, pending);
+	}
+	await pending;
+}
+
 function claudeAccountIdentity(id: string, paths: AccountPaths): AgentAccountIdentity | null {
 	return parseClaudeIdentity(safeReadJson(join(claudeAccountDir(id, paths), ".claude.json")));
 }
 
-function codexAccountIdentity(id: string, paths: AccountPaths): AgentAccountIdentity | null {
-	return parseCodexIdentity(safeReadJson(codexAccountAuthFile(id, paths)));
+function codexAccountIdentity(id: string, paths: AccountPaths, workspaceName?: string): AgentAccountIdentity | null {
+	return withCodexWorkspaceName(parseCodexIdentity(safeReadJson(codexAccountAuthFile(id, paths))), workspaceName);
 }
 
 /** On-disk shape of <claude account dir>/api-profile.json (0600 — holds the key). */
@@ -301,15 +420,20 @@ function toAccount(entry: RegistryEntry, kind: AgentAccountKind, paths: AccountP
 			? null
 			: kind === "claude"
 				? claudeAccountIdentity(entry.id, paths)
-				: codexAccountIdentity(entry.id, paths),
+				: codexAccountIdentity(entry.id, paths, entry.workspaceName),
 		auth: isApi ? "api" : "oauth",
 		api: isApi ? apiProfileInfo(readApiProfile(entry.id, paths)) : null,
 		createdAt: entry.createdAt,
 	};
 }
 
-function currentCodexIdentity(paths: AccountPaths): AgentAccountIdentity | null {
-	return parseCodexIdentity(safeReadJson(join(paths.codexHome, "auth.json")));
+function currentCodexIdentity(paths: AccountPaths, registry: Registry): AgentAccountIdentity | null {
+	const identity = parseCodexIdentity(safeReadJson(join(paths.codexHome, "auth.json")));
+	if (!identity?.accountId) return identity;
+	const matchingEntry = registry.codex.accounts.find((entry) => {
+		return codexAccountIdentity(entry.id, paths)?.accountId === identity.accountId;
+	});
+	return withCodexWorkspaceName(identity, matchingEntry?.workspaceName);
 }
 
 /** Absolute dirs of every managed codex account (each a per-account CODEX_HOME).
@@ -325,7 +449,10 @@ export function listCodexAccountDirs(paths: AccountPaths = defaultAccountPaths()
 }
 
 export async function listAgentAccounts(paths: AccountPaths = defaultAccountPaths()): Promise<AgentAccountsState> {
-	const registry = loadRegistry(paths);
+	let registry = loadRegistry(paths);
+	if (applyCodexWorkspaceNames(registry, {}, paths)) saveRegistry(registry, paths);
+	await backfillCodexWorkspaceNames(registry, paths);
+	registry = loadRegistry(paths);
 	return {
 		claude: {
 			accounts: registry.claude.accounts.map((e) => toAccount(e, "claude", paths)),
@@ -335,7 +462,7 @@ export async function listAgentAccounts(paths: AccountPaths = defaultAccountPath
 		codex: {
 			accounts: registry.codex.accounts.map((e) => toAccount(e, "codex", paths)),
 			activeId: registry.codex.accounts.some((e) => e.id === registry.codex.activeId) ? registry.codex.activeId : null,
-			currentIdentity: currentCodexIdentity(paths),
+			currentIdentity: currentCodexIdentity(paths, registry),
 		},
 	};
 }
@@ -533,7 +660,10 @@ function assertNoDuplicate(
 	if (!identity?.accountId) return;
 	for (const entry of registry[kind].accounts) {
 		if (entry.id === excludeId) continue;
-		const existing = kind === "claude" ? claudeAccountIdentity(entry.id, paths) : codexAccountIdentity(entry.id, paths);
+		const existing =
+			kind === "claude"
+				? claudeAccountIdentity(entry.id, paths)
+				: codexAccountIdentity(entry.id, paths, entry.workspaceName);
 		// Codex account_id is the selected ChatGPT workspace, not the person. The
 		// same email/chatgpt_user_id may therefore own several valid accounts.
 		const isDuplicate =
@@ -543,7 +673,20 @@ function assertNoDuplicate(
 					(existing.organization ?? null) === (identity.organization ?? null);
 		if (!isDuplicate) continue;
 		if (kind === "codex") {
-			throw new Error(`This Codex workspace is already added ("${entry.label}")`);
+			const workspaceId = shortCodexWorkspaceId(identity);
+			const workspaceName = identity.organization ?? existing?.organization;
+			const workspace = workspaceName
+				? `"${workspaceName}"${workspaceId ? ` (${workspaceId})` : ""}`
+				: workspaceId
+					? `"${workspaceId}"`
+					: "with an unknown id";
+			log.warn("Codex workspace duplicate rejected", {
+				workspaceId,
+				workspaceName: workspaceName ?? null,
+				existingAccountId: entry.id.slice(0, 8),
+				existingLabel: entry.label,
+			});
+			throw new Error(`Codex workspace ${workspace} is already added as "${entry.label}".`);
 		}
 		throw new Error(`This account is already added ("${entry.label}")`);
 	}
@@ -555,7 +698,7 @@ function registerAccount(
 	id: string,
 	identity: AgentAccountIdentity | null,
 	paths: AccountPaths,
-	opts?: { auth?: AgentAccountAuth; label?: string },
+	opts?: { auth?: AgentAccountAuth; label?: string; workspaceName?: string | null },
 ): AgentAccount {
 	let label = opts?.label ?? defaultAccountLabel(identity, registry[kind].accounts.length + 1);
 	// Same login email may represent several Claude organizations or Codex
@@ -567,7 +710,8 @@ function registerAccount(
 		});
 		if (emailTaken && kind === "codex") {
 			const workspaceId = shortCodexWorkspaceId(identity);
-			if (workspaceId) label = `${identity.email} (Workspace ${workspaceId})`;
+			const workspace = identity.organization ?? (workspaceId ? `Workspace ${workspaceId}` : null);
+			if (workspace) label = `${identity.email} (${workspace})`;
 		} else if (emailTaken && identity.organization) {
 			label = `${identity.email} (${identity.organization})`;
 		}
@@ -575,6 +719,7 @@ function registerAccount(
 	const entry: RegistryEntry = {
 		id,
 		label,
+		workspaceName: kind === "codex" ? opts?.workspaceName ?? undefined : undefined,
 		auth: opts?.auth === "api" ? "api" : undefined,
 		createdAt: Date.now(),
 	};
@@ -802,11 +947,16 @@ export async function completeClaudeLogin(accountId: string, paths: AccountPaths
 /** Import the login currently in ~/.codex/auth.json as a managed snapshot. */
 export async function importCurrentCodexAccount(paths: AccountPaths = defaultAccountPaths()): Promise<AgentAccount> {
 	const authFile = join(paths.codexHome, "auth.json");
-	const identity = parseCodexIdentity(safeReadJson(authFile));
+	const authJson = safeReadJson(authFile);
+	let identity = parseCodexIdentity(authJson);
 	if (!identity?.accountId) {
 		throw new Error("No Codex login found (~/.codex/auth.json missing or not a ChatGPT login). Run `codex login` first.");
 	}
 	const registry = loadRegistry(paths);
+	const workspaceNames = await lookupCodexWorkspaceNames(authJson);
+	const workspaceName = workspaceNames[identity.accountId] ?? null;
+	identity = withCodexWorkspaceName(identity, workspaceName)!;
+	if (applyCodexWorkspaceNames(registry, workspaceNames, paths)) saveRegistry(registry, paths);
 	assertNoDuplicate(registry, "codex", identity, paths);
 
 	const id = crypto.randomUUID();
@@ -814,9 +964,14 @@ export async function importCurrentCodexAccount(paths: AccountPaths = defaultAcc
 	const target = codexAccountAuthFile(id, paths);
 	copyFileSync(authFile, target);
 	chmodSync(target, 0o600);
-	const account = registerAccount(registry, "codex", id, identity, paths);
+	const account = registerAccount(registry, "codex", id, identity, paths, { workspaceName });
 	registry.codex.activeId = id; // newly imported becomes the default preselect
 	saveRegistry(registry, paths);
+	log.info("Codex account imported", {
+		accountId: id.slice(0, 8),
+		workspaceId: shortCodexWorkspaceId(identity),
+		workspaceName,
+	});
 	return account;
 }
 
@@ -832,18 +987,29 @@ export async function prepareCodexLogin(paths: AccountPaths = defaultAccountPath
 /** Verify a prepared CODEX_HOME login dir and register it as an account. */
 export async function completeCodexLogin(accountId: string, paths: AccountPaths = defaultAccountPaths()): Promise<AgentAccount> {
 	const authFile = codexAccountAuthFile(accountId, paths);
-	const identity = parseCodexIdentity(safeReadJson(authFile));
+	const authJson = safeReadJson(authFile);
+	let identity = parseCodexIdentity(authJson);
 	if (!identity?.accountId) {
 		throw new Error("Login not detected yet. Run the login command, finish the flow, then verify again.");
 	}
 	const registry = loadRegistry(paths);
+	const workspaceNames = await lookupCodexWorkspaceNames(authJson);
+	const workspaceName = workspaceNames[identity.accountId] ?? null;
+	identity = withCodexWorkspaceName(identity, workspaceName)!;
+	if (applyCodexWorkspaceNames(registry, workspaceNames, paths)) saveRegistry(registry, paths);
+	log.info("Codex login identity detected", {
+		pendingAccountId: accountId.slice(0, 8),
+		workspaceId: shortCodexWorkspaceId(identity),
+		workspaceName,
+		managedCodexAccounts: registry.codex.accounts.length,
+	});
 	assertNoDuplicate(registry, "codex", identity, paths, accountId);
 	chmodSync(authFile, 0o600);
 	if (registry.codex.accounts.some((e) => e.id === accountId)) {
 		saveRegistry(registry, paths);
 		return toAccount(registry.codex.accounts.find((e) => e.id === accountId)!, "codex", paths);
 	}
-	const account = registerAccount(registry, "codex", accountId, identity, paths);
+	const account = registerAccount(registry, "codex", accountId, identity, paths, { workspaceName });
 	registry.codex.activeId = accountId; // newly added becomes the default preselect
 	saveRegistry(registry, paths);
 	return account;

--- a/src/bun/agent-accounts.ts
+++ b/src/bun/agent-accounts.ts
@@ -51,6 +51,7 @@ import {
 	defaultApiProfileLabel,
 	parseClaudeIdentity,
 	parseCodexIdentity,
+	shortCodexWorkspaceId,
 } from "../shared/agent-accounts";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
@@ -533,11 +534,18 @@ function assertNoDuplicate(
 	for (const entry of registry[kind].accounts) {
 		if (entry.id === excludeId) continue;
 		const existing = kind === "claude" ? claudeAccountIdentity(entry.id, paths) : codexAccountIdentity(entry.id, paths);
-		// One user (same accountUuid/email) can belong to several organizations —
-		// a duplicate is the same account in the SAME organization only.
-		if (existing?.accountId === identity.accountId && (existing.organization ?? null) === (identity.organization ?? null)) {
-			throw new Error(`This account is already added ("${entry.label}")`);
+		// Codex account_id is the selected ChatGPT workspace, not the person. The
+		// same email/chatgpt_user_id may therefore own several valid accounts.
+		const isDuplicate =
+			kind === "codex"
+				? existing?.accountId === identity.accountId
+				: existing?.accountId === identity.accountId &&
+					(existing.organization ?? null) === (identity.organization ?? null);
+		if (!isDuplicate) continue;
+		if (kind === "codex") {
+			throw new Error(`This Codex workspace is already added ("${entry.label}")`);
 		}
+		throw new Error(`This account is already added ("${entry.label}")`);
 	}
 }
 
@@ -550,14 +558,19 @@ function registerAccount(
 	opts?: { auth?: AgentAccountAuth; label?: string },
 ): AgentAccount {
 	let label = opts?.label ?? defaultAccountLabel(identity, registry[kind].accounts.length + 1);
-	// Same email registered from another organization — append the org so the
-	// two rows are distinguishable at a glance.
-	if (!opts?.label && identity?.email && identity.organization) {
+	// Same login email may represent several Claude organizations or Codex
+	// workspaces. Append the provider-specific discriminator to later rows.
+	if (!opts?.label && identity?.email) {
 		const emailTaken = registry[kind].accounts.some((existing) => {
 			const other = kind === "claude" ? claudeAccountIdentity(existing.id, paths) : codexAccountIdentity(existing.id, paths);
 			return other?.email === identity.email;
 		});
-		if (emailTaken) label = `${identity.email} (${identity.organization})`;
+		if (emailTaken && kind === "codex") {
+			const workspaceId = shortCodexWorkspaceId(identity);
+			if (workspaceId) label = `${identity.email} (Workspace ${workspaceId})`;
+		} else if (emailTaken && identity.organization) {
+			label = `${identity.email} (${identity.organization})`;
+		}
 	}
 	const entry: RegistryEntry = {
 		id,

--- a/src/bun/rpc-handlers/agent-accounts.ts
+++ b/src/bun/rpc-handlers/agent-accounts.ts
@@ -5,16 +5,29 @@
 
 import type { AgentAccount, AgentAccountKind, AgentAccountsState, ClaudeSlotModels } from "../../shared/agent-accounts";
 import type { ClaudeApiProfileDraft } from "../agent-accounts";
-import { parseEnvLines } from "../../shared/agent-accounts";
+import { parseEnvLines, shortCodexWorkspaceId } from "../../shared/agent-accounts";
 import * as accounts from "../agent-accounts";
 import { log } from "./shared";
+
+function accountLogDetails(account: AgentAccount) {
+	return {
+		id: account.id.slice(0, 8),
+		label: account.label,
+		workspaceId: account.kind === "codex" ? shortCodexWorkspaceId(account.identity) : null,
+		workspaceName: account.kind === "codex" ? account.identity?.organization ?? null : null,
+	};
+}
 
 async function listAgentAccounts(): Promise<AgentAccountsState> {
 	log.info("→ listAgentAccounts");
 	const state = await accounts.listAgentAccounts();
 	log.info("← listAgentAccounts", {
 		claude: state.claude.accounts.length,
-		codex: state.codex.accounts.length,
+		codex: {
+			count: state.codex.accounts.length,
+			activeId: state.codex.activeId?.slice(0, 8) ?? null,
+			accounts: state.codex.accounts.map(accountLogDetails),
+		},
 	});
 	return state;
 }
@@ -25,7 +38,7 @@ async function importAgentAccount(params: { kind: AgentAccountKind }): Promise<A
 		params.kind === "claude"
 			? await accounts.importCurrentClaudeAccount()
 			: await accounts.importCurrentCodexAccount();
-	log.info("← importAgentAccount", { id: account.id, label: account.label });
+	log.info("← importAgentAccount", accountLogDetails(account));
 	return account;
 }
 
@@ -97,12 +110,21 @@ async function prepareAgentAccountLogin(params: { kind: AgentAccountKind }): Pro
 async function completeAgentAccountLogin(params: { kind: AgentAccountKind; accountId?: string | null }): Promise<AgentAccount> {
 	log.info("→ completeAgentAccountLogin", params);
 	if (!params.accountId) throw new Error(`accountId is required for ${params.kind} login verification`);
-	const account =
-		params.kind === "claude"
-			? await accounts.completeClaudeLogin(params.accountId)
-			: await accounts.completeCodexLogin(params.accountId);
-	log.info("← completeAgentAccountLogin", { id: account.id, label: account.label });
-	return account;
+	try {
+		const account =
+			params.kind === "claude"
+				? await accounts.completeClaudeLogin(params.accountId)
+				: await accounts.completeCodexLogin(params.accountId);
+		log.info("← completeAgentAccountLogin", accountLogDetails(account));
+		return account;
+	} catch (error) {
+		log.warn("← completeAgentAccountLogin failed", {
+			kind: params.kind,
+			pendingAccountId: params.accountId.slice(0, 8),
+			error: String(error),
+		});
+		throw error;
+	}
 }
 
 async function setActiveAgentAccount(params: { kind: AgentAccountKind; accountId: string | null }): Promise<void> {

--- a/src/mainview/components/AgentAccountIndicator.tsx
+++ b/src/mainview/components/AgentAccountIndicator.tsx
@@ -132,7 +132,7 @@ function SwitcherPopover({
 	return createPortal(
 		<div
 			ref={menuRef}
-			className="fixed z-[10000] bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active py-1.5 w-[19rem] max-w-[calc(100vw-1rem)]"
+			className="fixed z-[10000] bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active py-1.5 w-[21rem] max-w-[calc(100vw-1rem)]"
 			style={{ top: pos.top, left: pos.left, visibility: visible ? "visible" : "hidden" }}
 			onClick={(e) => e.stopPropagation()}
 		>
@@ -146,32 +146,41 @@ function SwitcherPopover({
 					type="button"
 					disabled={busy || !row.onSelect || row.isActive}
 					onClick={row.onSelect ?? undefined}
-					className={`w-full text-left px-3 py-2 flex items-center gap-2 transition-colors ${
+					className={`w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${
 						row.onSelect && !row.isActive ? "hover:bg-elevated-hover cursor-pointer" : "cursor-default"
 					} disabled:opacity-100`}
 				>
 					<span
 						aria-hidden
-						className={`w-3 h-3 rounded-full border-2 shrink-0 ${
+						className={`w-3 h-3 mt-1 rounded-full border-2 shrink-0 ${
 							row.isActive ? "border-accent bg-accent" : "border-fg-muted/50"
 						}`}
 					/>
-					<span className="text-fg text-sm truncate">{row.label}</span>
-					{row.isApi ? (
-						<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
-					) : null}
-					{row.sub && row.sub !== row.label ? (
-						<span className="text-fg-muted text-xs font-mono truncate">{row.sub}</span>
-					) : null}
-					{row.workspaceLabel ? (
-						<span className="text-fg-3 text-[0.625rem] font-mono px-1 py-px bg-raised rounded shrink-0">
-							{row.workspaceLabel}
+					<span className="min-w-0 flex-1">
+						<span className="flex items-center gap-2 min-w-0">
+							<span className="text-fg text-sm truncate flex-1">{row.label}</span>
+							{row.isApi ? (
+								<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
+							) : null}
+							{row.planLabel ? (
+								<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">
+									{row.planLabel}
+								</span>
+							) : null}
 						</span>
-					) : null}
-					<span className="flex-1" />
-					{row.planLabel ? (
-						<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">{row.planLabel}</span>
-					) : null}
+						{(row.sub && row.sub !== row.label && !row.label.includes(row.sub)) || row.workspaceLabel ? (
+							<span className="mt-1 flex flex-wrap items-center gap-1.5 min-w-0">
+								{row.sub && row.sub !== row.label && !row.label.includes(row.sub) ? (
+									<span className="text-fg-muted text-xs font-mono truncate max-w-full">{row.sub}</span>
+								) : null}
+								{row.workspaceLabel ? (
+									<span className="text-fg-3 text-[0.625rem] px-1 py-px bg-raised rounded max-w-full">
+										{row.workspaceLabel}
+									</span>
+								) : null}
+							</span>
+						) : null}
+					</span>
 				</button>
 			))}
 			<div className="border-t border-edge mt-1 pt-1.5 px-3 pb-1">
@@ -256,7 +265,11 @@ export default function AgentAccountIndicator({
 	const fallbackLabel =
 		kind === "claude" ? t("settings.accountsSystemLogin") : t("settings.accountsUnmanaged");
 	const activeLabel = selectedAccount ? selectedAccount.label : (fallbackIdentity?.email ?? fallbackLabel);
-	const fallbackWorkspaceId = kind === "codex" ? shortCodexWorkspaceId(fallbackIdentity) : null;
+	const workspaceLabel = (identity: AgentAccountIdentity | null): string | null => {
+		if (kind !== "codex") return null;
+		const workspace = identity?.organization ?? shortCodexWorkspaceId(identity);
+		return workspace ? t("settings.accountsWorkspace", { id: workspace }) : null;
+	};
 
 	const rows: PopoverRow[] = [];
 	// System-login row: selectable for BOTH kinds in local mode (codex now has a
@@ -268,7 +281,7 @@ export default function AgentAccountIndicator({
 			label: kind === "claude" ? t("settings.accountsSystemLogin") : t("settings.accountsUnmanaged"),
 			sub: fallbackIdentity?.email ?? null,
 			planLabel: identityBadge(fallbackIdentity),
-			workspaceLabel: fallbackWorkspaceId ? t("settings.accountsWorkspace", { id: fallbackWorkspaceId }) : null,
+			workspaceLabel: workspaceLabel(fallbackIdentity),
 			isApi: false,
 			isActive: effectiveSelectedId === null,
 			onSelect: isLocal
@@ -276,28 +289,24 @@ export default function AgentAccountIndicator({
 				: () => handleSelectGlobal("claude", null),
 		});
 	} else if (kindState.activeId === null && state.codex.currentIdentity) {
-		const unmanagedWorkspaceId = shortCodexWorkspaceId(state.codex.currentIdentity);
 		rows.push({
 			key: "unmanaged",
 			label: t("settings.accountsUnmanaged"),
 			sub: state.codex.currentIdentity.email,
 			planLabel: identityBadge(state.codex.currentIdentity),
-			workspaceLabel: unmanagedWorkspaceId
-				? t("settings.accountsWorkspace", { id: unmanagedWorkspaceId })
-				: null,
+			workspaceLabel: workspaceLabel(state.codex.currentIdentity),
 			isApi: false,
 			isActive: true,
 			onSelect: null,
 		});
 	}
 	for (const account of kindState.accounts) {
-		const workspaceId = kind === "codex" ? shortCodexWorkspaceId(account.identity) : null;
 		rows.push({
 			key: account.id,
 			label: account.label,
 			sub: account.auth === "api" ? apiHost(account.api) : (account.identity?.email ?? null),
 			planLabel: account.auth === "api" ? null : identityBadge(account.identity),
-			workspaceLabel: workspaceId ? t("settings.accountsWorkspace", { id: workspaceId }) : null,
+			workspaceLabel: workspaceLabel(account.identity),
 			isApi: account.auth === "api",
 			isActive: account.id === effectiveSelectedId,
 			onSelect: isLocal

--- a/src/mainview/components/AgentAccountIndicator.tsx
+++ b/src/mainview/components/AgentAccountIndicator.tsx
@@ -7,6 +7,7 @@ import type {
 	AgentAccountsState,
 	AgentApiProfileInfo,
 } from "../../shared/agent-accounts";
+import { shortCodexWorkspaceId } from "../../shared/agent-accounts";
 import type { CodingAgent } from "../../shared/types";
 import { api } from "../rpc";
 import { toast } from "../toast";
@@ -69,6 +70,7 @@ interface PopoverRow {
 	label: string;
 	sub: string | null;
 	planLabel: string | null;
+	workspaceLabel: string | null;
 	isApi: boolean;
 	isActive: boolean;
 	/** null = row is informational only (codex unmanaged login). */
@@ -161,6 +163,11 @@ function SwitcherPopover({
 					{row.sub && row.sub !== row.label ? (
 						<span className="text-fg-muted text-xs font-mono truncate">{row.sub}</span>
 					) : null}
+					{row.workspaceLabel ? (
+						<span className="text-fg-3 text-[0.625rem] font-mono px-1 py-px bg-raised rounded shrink-0">
+							{row.workspaceLabel}
+						</span>
+					) : null}
 					<span className="flex-1" />
 					{row.planLabel ? (
 						<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">{row.planLabel}</span>
@@ -249,6 +256,7 @@ export default function AgentAccountIndicator({
 	const fallbackLabel =
 		kind === "claude" ? t("settings.accountsSystemLogin") : t("settings.accountsUnmanaged");
 	const activeLabel = selectedAccount ? selectedAccount.label : (fallbackIdentity?.email ?? fallbackLabel);
+	const fallbackWorkspaceId = kind === "codex" ? shortCodexWorkspaceId(fallbackIdentity) : null;
 
 	const rows: PopoverRow[] = [];
 	// System-login row: selectable for BOTH kinds in local mode (codex now has a
@@ -260,6 +268,7 @@ export default function AgentAccountIndicator({
 			label: kind === "claude" ? t("settings.accountsSystemLogin") : t("settings.accountsUnmanaged"),
 			sub: fallbackIdentity?.email ?? null,
 			planLabel: identityBadge(fallbackIdentity),
+			workspaceLabel: fallbackWorkspaceId ? t("settings.accountsWorkspace", { id: fallbackWorkspaceId }) : null,
 			isApi: false,
 			isActive: effectiveSelectedId === null,
 			onSelect: isLocal
@@ -267,22 +276,28 @@ export default function AgentAccountIndicator({
 				: () => handleSelectGlobal("claude", null),
 		});
 	} else if (kindState.activeId === null && state.codex.currentIdentity) {
+		const unmanagedWorkspaceId = shortCodexWorkspaceId(state.codex.currentIdentity);
 		rows.push({
 			key: "unmanaged",
 			label: t("settings.accountsUnmanaged"),
 			sub: state.codex.currentIdentity.email,
 			planLabel: identityBadge(state.codex.currentIdentity),
+			workspaceLabel: unmanagedWorkspaceId
+				? t("settings.accountsWorkspace", { id: unmanagedWorkspaceId })
+				: null,
 			isApi: false,
 			isActive: true,
 			onSelect: null,
 		});
 	}
 	for (const account of kindState.accounts) {
+		const workspaceId = kind === "codex" ? shortCodexWorkspaceId(account.identity) : null;
 		rows.push({
 			key: account.id,
 			label: account.label,
 			sub: account.auth === "api" ? apiHost(account.api) : (account.identity?.email ?? null),
 			planLabel: account.auth === "api" ? null : identityBadge(account.identity),
+			workspaceLabel: workspaceId ? t("settings.accountsWorkspace", { id: workspaceId }) : null,
 			isApi: account.auth === "api",
 			isActive: account.id === effectiveSelectedId,
 			onSelect: isLocal

--- a/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
+++ b/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
@@ -31,6 +31,13 @@ const claudeAgent: CodingAgent = {
 	configurations: [],
 };
 
+const codexAgent: CodingAgent = {
+	id: "builtin-codex",
+	name: "Codex",
+	baseCommand: "codex",
+	configurations: [],
+};
+
 function makeState(overrides?: Partial<AgentAccountsState>): AgentAccountsState {
 	return {
 		claude: {
@@ -232,5 +239,38 @@ describe("AgentAccountIndicator", () => {
 		await user.click(trigger);
 		expect(screen.getByText("openrouter.ai")).toBeTruthy();
 		expect(screen.getAllByText("API").length).toBeGreaterThan(0);
+	});
+
+	it("shows the Codex workspace id in the account popover", async () => {
+		mockedApi.request.listAgentAccounts.mockResolvedValue(
+			makeState({
+				codex: {
+					accounts: [
+						{
+							id: "codex-1",
+							kind: "codex",
+							label: "shared@example.com",
+							identity: {
+								email: "shared@example.com",
+								organization: "Wix",
+								plan: "enterprise_cbp_usage_based",
+								planLabel: "Enterprise",
+								accountId: "81b5a3a4-9199-40e2-bcde-a6d3ebc9d654",
+							},
+							auth: "oauth",
+							api: null,
+							createdAt: 1,
+						},
+					],
+					activeId: "codex-1",
+					currentIdentity: null,
+				},
+			}),
+		);
+		const user = userEvent.setup();
+		renderIndicator(codexAgent);
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+		expect(screen.getByText("Workspace 81b5a3a4")).toBeTruthy();
 	});
 });

--- a/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
+++ b/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
@@ -241,7 +241,7 @@ describe("AgentAccountIndicator", () => {
 		expect(screen.getAllByText("API").length).toBeGreaterThan(0);
 	});
 
-	it("shows the Codex workspace id in the account popover", async () => {
+	it("shows the readable Codex workspace name in the account popover", async () => {
 		mockedApi.request.listAgentAccounts.mockResolvedValue(
 			makeState({
 				codex: {
@@ -271,6 +271,6 @@ describe("AgentAccountIndicator", () => {
 		renderIndicator(codexAgent);
 
 		await user.click(await screen.findByTestId("agent-account-trigger"));
-		expect(screen.getByText("Workspace 81b5a3a4")).toBeTruthy();
+		expect(screen.getByText("Workspace Wix")).toBeTruthy();
 	});
 });

--- a/src/mainview/components/global-settings/AgentAccountsSection.tsx
+++ b/src/mainview/components/global-settings/AgentAccountsSection.tsx
@@ -66,17 +66,22 @@ function IdentityBadges({
 }) {
 	if (!identity) return null;
 	const workspaceId = kind === "codex" ? shortCodexWorkspaceId(identity) : null;
+	const workspace = kind === "codex" ? identity.organization ?? workspaceId : null;
 	return (
 		<>
 			{identity.email && identity.email !== hideEmail ? (
 				<span className="text-fg-3 text-xs font-mono truncate">{identity.email}</span>
 			) : null}
-			{identity.organization ? (
+			{kind !== "codex" && identity.organization ? (
 				<span className="text-fg-muted text-xs truncate">{identity.organization}</span>
 			) : null}
-			{workspaceId ? (
-				<span className="text-fg-3 text-[0.6875rem] font-mono px-1.5 py-0.5 bg-raised rounded shrink-0">
-					{t("settings.accountsWorkspace", { id: workspaceId })}
+			{workspace ? (
+				<span
+					className={`text-fg-3 text-[0.6875rem] px-1.5 py-0.5 bg-raised rounded max-w-full truncate ${
+						identity.organization ? "" : "font-mono"
+					}`}
+				>
+					{t("settings.accountsWorkspace", { id: workspace })}
 				</span>
 			) : null}
 			{identity.planLabel ? (

--- a/src/mainview/components/global-settings/AgentAccountsSection.tsx
+++ b/src/mainview/components/global-settings/AgentAccountsSection.tsx
@@ -9,7 +9,7 @@ import type {
 	ClaudeSlotModel,
 	ClaudeSlotModels,
 } from "../../../shared/agent-accounts";
-import { CLAUDE_MODEL_SLOTS } from "../../../shared/agent-accounts";
+import { CLAUDE_MODEL_SLOTS, shortCodexWorkspaceId } from "../../../shared/agent-accounts";
 import { api } from "../../rpc";
 import { confirm } from "../../confirm";
 import { toast } from "../../toast";
@@ -53,8 +53,19 @@ interface AddFlow {
 	verifying: boolean;
 }
 
-function IdentityBadges({ identity, hideEmail }: { identity: AgentAccountIdentity | null; hideEmail?: string }) {
+function IdentityBadges({
+	identity,
+	hideEmail,
+	kind,
+	t,
+}: {
+	identity: AgentAccountIdentity | null;
+	hideEmail?: string;
+	kind: AgentAccountKind;
+	t: TFunction;
+}) {
 	if (!identity) return null;
+	const workspaceId = kind === "codex" ? shortCodexWorkspaceId(identity) : null;
 	return (
 		<>
 			{identity.email && identity.email !== hideEmail ? (
@@ -62,6 +73,11 @@ function IdentityBadges({ identity, hideEmail }: { identity: AgentAccountIdentit
 			) : null}
 			{identity.organization ? (
 				<span className="text-fg-muted text-xs truncate">{identity.organization}</span>
+			) : null}
+			{workspaceId ? (
+				<span className="text-fg-3 text-[0.6875rem] font-mono px-1.5 py-0.5 bg-raised rounded shrink-0">
+					{t("settings.accountsWorkspace", { id: workspaceId })}
+				</span>
 			) : null}
 			{identity.planLabel ? (
 				<span className="text-accent text-xs px-1.5 py-0.5 bg-accent/10 rounded shrink-0">
@@ -95,6 +111,7 @@ function ApiProfileBadges({ api }: { api: AgentApiProfileInfo }) {
 }
 
 function AccountRow({
+	kind,
 	label,
 	identity,
 	api,
@@ -105,6 +122,7 @@ function AccountRow({
 	onRemove,
 	t,
 }: {
+	kind: AgentAccountKind;
 	label: string;
 	identity: AgentAccountIdentity | null;
 	api?: AgentApiProfileInfo | null;
@@ -128,7 +146,7 @@ function AccountRow({
 
 	return (
 		<div
-			className={`flex items-center gap-2.5 px-3 py-2 bg-elevated border rounded-lg transition-colors ${
+			className={`flex flex-wrap items-center gap-2.5 px-3 py-2 bg-elevated border rounded-lg transition-colors ${
 				isActive ? "border-accent/50" : "border-edge"
 			} ${onActivate && !isActive ? "cursor-pointer hover:bg-elevated-hover" : ""}`}
 			role={onActivate ? "button" : undefined}
@@ -147,78 +165,85 @@ function AccountRow({
 					isActive ? "border-accent bg-accent" : "border-fg-muted/50"
 				}`}
 			/>
-			{editing ? (
-				<input
-					type="text"
-					value={draft}
-					autoFocus
-					onChange={(event) => setDraft(event.target.value)}
-					onClick={(event) => event.stopPropagation()}
-					onBlur={commitRename}
-					onKeyDown={(event) => {
-						event.stopPropagation();
-						if (event.key === "Enter") commitRename();
-						if (event.key === "Escape") {
+			<div className="basis-40 min-w-0 flex-1 flex flex-wrap items-center gap-2">
+				{editing ? (
+					<input
+						type="text"
+						value={draft}
+						autoFocus
+						onChange={(event) => setDraft(event.target.value)}
+						onClick={(event) => event.stopPropagation()}
+						onBlur={commitRename}
+						onKeyDown={(event) => {
+							event.stopPropagation();
+							if (event.key === "Enter") commitRename();
+							if (event.key === "Escape") {
+								setDraft(label);
+								setEditing(false);
+							}
+						}}
+						className="flex-none w-48 max-w-full px-2 py-0.5 bg-base border border-edge rounded text-fg text-sm outline-none focus:border-accent/40"
+					/>
+				) : (
+					<span className="text-fg text-sm font-medium truncate">{label}</span>
+				)}
+				{api ? (
+					<ApiProfileBadges api={api} />
+				) : (
+					<IdentityBadges identity={identity} hideEmail={label} kind={kind} t={t} />
+				)}
+			</div>
+			<div className="ml-auto flex items-center justify-end gap-1 shrink-0">
+				{isActive ? (
+					<span className="text-success text-xs px-1.5 py-0.5 bg-success/15 rounded shrink-0">
+						{t("settings.accountsActive")}
+					</span>
+				) : null}
+				{onEditApi ? (
+					<button
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
+							onEditApi();
+						}}
+						className="p-1 rounded text-fg-muted hover:text-fg hover:bg-raised-hover transition-colors shrink-0"
+						title={t("settings.accountsEditApi")}
+						aria-label={t("settings.accountsEditApi")}
+					>
+						<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+							{"\uf044"}
+						</span>
+					</button>
+				) : onRename && !editing ? (
+					<button
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
 							setDraft(label);
-							setEditing(false);
-						}
-					}}
-					className="flex-none w-48 px-2 py-0.5 bg-base border border-edge rounded text-fg text-sm outline-none focus:border-accent/40"
-				/>
-			) : (
-				<span className="text-fg text-sm font-medium truncate">{label}</span>
-			)}
-			{api ? <ApiProfileBadges api={api} /> : <IdentityBadges identity={identity} hideEmail={label} />}
-			<span className="flex-1" />
-			{isActive ? (
-				<span className="text-success text-xs px-1.5 py-0.5 bg-success/15 rounded shrink-0">
-					{t("settings.accountsActive")}
-				</span>
-			) : null}
-			{onEditApi ? (
-				<button
-					type="button"
-					onClick={(event) => {
-						event.stopPropagation();
-						onEditApi();
-					}}
-					className="p-1 rounded text-fg-muted hover:text-fg hover:bg-raised-hover transition-colors shrink-0"
-					title={t("settings.accountsEditApi")}
-					aria-label={t("settings.accountsEditApi")}
-				>
-					<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-						{"\uf044"}
-					</span>
-				</button>
-			) : onRename && !editing ? (
-				<button
-					type="button"
-					onClick={(event) => {
-						event.stopPropagation();
-						setDraft(label);
-						setEditing(true);
-					}}
-					className="p-1 rounded text-fg-muted hover:text-fg hover:bg-raised-hover transition-colors shrink-0"
-					title={t("settings.accountsRename")}
-					aria-label={t("settings.accountsRename")}
-				>
-					<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-						{"\uf044"}
-					</span>
-				</button>
-			) : null}
-			{onRemove ? (
-				<button
-					type="button"
-					onClick={(event) => {
-						event.stopPropagation();
-						onRemove();
-					}}
-					className="text-danger text-xs hover:bg-danger/10 px-1.5 py-0.5 rounded transition-colors shrink-0"
-				>
-					{t("settings.accountsRemove")}
-				</button>
-			) : null}
+							setEditing(true);
+						}}
+						className="p-1 rounded text-fg-muted hover:text-fg hover:bg-raised-hover transition-colors shrink-0"
+						title={t("settings.accountsRename")}
+						aria-label={t("settings.accountsRename")}
+					>
+						<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+							{"\uf044"}
+						</span>
+					</button>
+				) : null}
+				{onRemove ? (
+					<button
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
+							onRemove();
+						}}
+						className="text-danger text-xs hover:bg-danger/10 px-1.5 py-0.5 rounded transition-colors shrink-0"
+					>
+						{t("settings.accountsRemove")}
+					</button>
+				) : null}
+			</div>
 		</div>
 	);
 }
@@ -742,6 +767,7 @@ export default function AgentAccountsSection({ t }: { t: TFunction }) {
 					{accounts.map((account) => (
 						<AccountRow
 							key={account.id}
+							kind={kind}
 							label={account.label}
 							identity={account.identity}
 							api={account.api}
@@ -801,6 +827,7 @@ export default function AgentAccountsSection({ t }: { t: TFunction }) {
 				state.claude.accounts,
 				state.claude.activeId,
 				<AccountRow
+					kind="claude"
 					label={t("settings.accountsSystemLogin")}
 					identity={state.claude.systemIdentity}
 					isActive={state.claude.activeId === null}
@@ -820,12 +847,13 @@ export default function AgentAccountsSection({ t }: { t: TFunction }) {
 				state.codex.activeId,
 				null,
 				codexUnmanaged ? (
-					<div className="flex items-center gap-2.5 px-3 py-2 bg-elevated/50 border border-edge border-dashed rounded-lg">
+					<div className="flex flex-wrap items-center gap-2.5 px-3 py-2 bg-elevated/50 border border-edge border-dashed rounded-lg">
 						<span aria-hidden className="w-3.5 h-3.5 rounded-full border-2 border-warning/60 shrink-0" />
-						<span className="text-fg-2 text-sm whitespace-nowrap">{t("settings.accountsUnmanaged")}</span>
-						<IdentityBadges identity={codexUnmanaged} />
-						<span className="flex-1" />
-						<span className="text-fg-muted text-xs">{t("settings.accountsUnmanagedHint")}</span>
+						<div className="basis-40 min-w-0 flex-1 flex flex-wrap items-center gap-2">
+							<span className="text-fg-2 text-sm whitespace-nowrap">{t("settings.accountsUnmanaged")}</span>
+							<IdentityBadges identity={codexUnmanaged} kind="codex" t={t} />
+						</div>
+						<span className="ml-auto text-fg-muted text-xs">{t("settings.accountsUnmanagedHint")}</span>
 					</div>
 				) : null,
 			)}

--- a/src/mainview/components/global-settings/__tests__/AgentAccountsSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/AgentAccountsSection.test.tsx
@@ -425,4 +425,36 @@ describe("AgentAccountsSection", () => {
 		expect(screen.getByText("codex@example.com")).toBeTruthy();
 		expect(screen.getByText("Workspace acc-1")).toBeTruthy();
 	});
+
+	it("shows a readable name for a resolved Codex workspace", async () => {
+		mockedApi.request.listAgentAccounts.mockResolvedValue(
+			makeState({
+				codex: {
+					accounts: [
+						{
+							id: "codex-1",
+							kind: "codex",
+							label: "shared@example.com",
+							identity: {
+								email: "shared@example.com",
+								organization: "Base44 ChatGPT Enterprise",
+								plan: "enterprise_cbp_usage_based",
+								planLabel: "Enterprise",
+								accountId: "b8e0e9ae-workspace",
+							},
+							auth: "oauth",
+							api: null,
+							createdAt: 1,
+						},
+					],
+					activeId: "codex-1",
+					currentIdentity: null,
+				},
+			}),
+		);
+
+		renderSection();
+		expect(await screen.findByText("Workspace Base44 ChatGPT Enterprise")).toBeTruthy();
+		expect(screen.queryByText("Workspace b8e0e9ae")).toBeNull();
+	});
 });

--- a/src/mainview/components/global-settings/__tests__/AgentAccountsSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/AgentAccountsSection.test.tsx
@@ -423,5 +423,6 @@ describe("AgentAccountsSection", () => {
 		renderSection();
 		expect(await screen.findByText("Unmanaged login")).toBeTruthy();
 		expect(screen.getByText("codex@example.com")).toBeTruthy();
+		expect(screen.getByText("Workspace acc-1")).toBeTruthy();
 	});
 });

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -277,6 +277,7 @@ const settings = {
 	"settings.accountsRemoveConfirmMessage": "This removes the stored credentials snapshot “{label}” from dev3. The account itself is not affected.",
 	"settings.accountsUnmanaged": "Unmanaged login",
 	"settings.accountsUnmanagedHint": "Current ~/.codex/auth.json login is not saved in dev3 yet",
+	"settings.accountsWorkspace": "Workspace {id}",
 	"settings.accountsNoneYet": "No accounts added yet.",
 	"settings.accountsNewSessionsHint": "The default account is the preselect for new launches — each launch can pick a different one; running sessions keep their current login.",
 	"settings.accountsAddApi": "API profile",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -278,6 +278,7 @@ const settings = {
 	"settings.accountsRemoveConfirmMessage": "Se elimina la copia de credenciales “{label}” de dev3. La cuenta en sí no se ve afectada.",
 	"settings.accountsUnmanaged": "Sesión no gestionada",
 	"settings.accountsUnmanagedHint": "La sesión actual de ~/.codex/auth.json aún no está guardada en dev3",
+	"settings.accountsWorkspace": "Espacio {id}",
 	"settings.accountsNoneYet": "Aún no hay cuentas añadidas.",
 	"settings.accountsNewSessionsHint": "La cuenta predeterminada es la preselección para los nuevos lanzamientos — cada lanzamiento puede elegir otra; las sesiones en ejecución mantienen su login actual.",
 	"settings.accountsAddApi": "Perfil API",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -279,6 +279,7 @@ const settings = {
 	"settings.accountsRemoveConfirmMessage": "Снимок учётных данных «{label}» будет удалён из dev3. Сам аккаунт не пострадает.",
 	"settings.accountsUnmanaged": "Неуправляемый логин",
 	"settings.accountsUnmanagedHint": "Текущий логин ~/.codex/auth.json ещё не сохранён в dev3",
+	"settings.accountsWorkspace": "Воркспейс {id}",
 	"settings.accountsNoneYet": "Аккаунты пока не добавлены.",
 	"settings.accountsNewSessionsHint": "Аккаунт по умолчанию — это преселект для новых запусков; каждый запуск может выбрать другой; запущенные сессии сохраняют текущий логин.",
 	"settings.accountsAddApi": "API-профиль",

--- a/src/shared/agent-accounts.ts
+++ b/src/shared/agent-accounts.ts
@@ -70,7 +70,7 @@ export interface AgentApiProfileInfo {
 export interface AgentAccountIdentity {
 	/** Login email, when known. */
 	email: string | null;
-	/** Organization / workspace name, when known. */
+	/** Claude organization or resolved ChatGPT workspace name, when known. */
 	organization: string | null;
 	/** Raw plan/tier string (e.g. "default_claude_max_5x", "plus"). */
 	plan: string | null;
@@ -184,12 +184,13 @@ export function parseCodexIdentity(authJson: unknown): AgentAccountIdentity | nu
 	const payload = idToken ? decodeJwtPayload(idToken) : null;
 	const authClaim = asRecord(payload?.[OPENAI_AUTH_CLAIM]);
 	const plan = asString(authClaim?.chatgpt_plan_type);
-	const orgs = Array.isArray(authClaim?.organizations) ? authClaim.organizations : [];
-	const firstOrg = asRecord(orgs[0]);
 	if (!accountId && !payload) return null;
 	return {
 		email: asString(payload?.email),
-		organization: asString(firstOrg?.title),
+		// `organizations` lists API organizations and does not identify the
+		// selected ChatGPT workspace. The readable workspace name is resolved by
+		// the bun process from the selected `chatgpt_account_id`.
+		organization: null,
 		plan,
 		planLabel: codexPlanLabel(plan),
 		accountId: accountId ?? asString(authClaim?.chatgpt_account_id),

--- a/src/shared/agent-accounts.ts
+++ b/src/shared/agent-accounts.ts
@@ -76,7 +76,8 @@ export interface AgentAccountIdentity {
 	plan: string | null;
 	/** Human-readable plan label derived from `plan` (e.g. "Max 5x", "Plus"). */
 	planLabel: string | null;
-	/** Stable provider-side account id (Claude accountUuid / Codex account_id). */
+	/** Stable provider-side account id. For Codex, `account_id` is the selected
+	 *  ChatGPT workspace id, while `chatgpt_user_id` identifies the person. */
 	accountId: string | null;
 }
 
@@ -193,6 +194,11 @@ export function parseCodexIdentity(authJson: unknown): AgentAccountIdentity | nu
 		planLabel: codexPlanLabel(plan),
 		accountId: accountId ?? asString(authClaim?.chatgpt_account_id),
 	};
+}
+
+/** Compact, display-safe prefix for a Codex ChatGPT workspace id. */
+export function shortCodexWorkspaceId(identity: AgentAccountIdentity | null): string | null {
+	return identity?.accountId?.slice(0, 8) ?? null;
 }
 
 /** Default display label for a freshly added account. */


### PR DESCRIPTION
## Summary

- Identify Codex logins by the selected ChatGPT workspace so one email can keep multiple workspaces.
- Resolve and persist readable workspace names, with a short-ID fallback and legacy label backfill.
- Include workspace details in duplicate errors and RPC logs.

## Root cause

Codex JWT `organizations` describes API organizations, not the selected ChatGPT workspace. The stable discriminator is `chatgpt_account_id`; readable names come from the ChatGPT accounts mapping.

## Verification

- `bun run lint`
- `bun run test` (5,458 passed; 1 skipped)
- Browser QA at desktop and 390px for Settings and the account picker