### PR TITLE
Show account workspace in the rate-limit popup

### DIFF
--- a/change-logs/2026/07/13/fix-ratelimit-workspace-name.md
+++ b/change-logs/2026/07/13/fix-ratelimit-workspace-name.md
@@ -1,0 +1,1 @@
+The Agent rate-limit popup now shows each account's workspace/organization name as a consistent "email · workspace" row, so two accounts sharing the same email in different workspaces are no longer indistinguishable, and the popup is widened so long rows fit on one line.

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -23,6 +23,12 @@ const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" 
 interface AccountLine {
 	/** Email / user-set label of the active account (null when identity unknown). */
 	name: string | null;
+	/** Login email, when known — used to collapse the auto-generated
+	 *  "email (workspace)" label into a consistent "email · workspace" row. */
+	email: string | null;
+	/** Organization / workspace name, when known. Disambiguates two accounts that
+	 *  share the same login email but live in different workspaces. */
+	organization: string | null;
 	/** Plan/tier badge (e.g. "Max 5x", "Plus"), when known. */
 	planLabel: string | null;
 	/** Active account is an API/custom-endpoint profile rather than an OAuth login. */
@@ -42,13 +48,21 @@ function resolveAccount(source: RateLimitSource, state: AgentAccountsState | nul
 	if (active) {
 		return {
 			name: active.label,
+			email: active.auth === "api" ? null : (active.identity?.email ?? null),
+			organization: active.auth === "api" ? null : (active.identity?.organization ?? null),
 			planLabel: active.auth === "api" ? null : (active.identity?.planLabel ?? null),
 			isApi: active.auth === "api",
 		};
 	}
 	const fallback = source === "claude" ? state.claude.systemIdentity : state.codex.currentIdentity;
 	if (fallback) {
-		return { name: fallback.email, planLabel: fallback.planLabel, isApi: false };
+		return {
+			name: fallback.email,
+			email: fallback.email,
+			organization: fallback.organization,
+			planLabel: fallback.planLabel,
+			isApi: false,
+		};
 	}
 	return null;
 }
@@ -155,16 +169,31 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	return (
 		<Tooltip
 			content={t("rateLimits.tooltipTitle")}
+			wide
 			detail={
 				<div className="flex flex-col gap-2">
 					{report.snapshots.map((snap) => {
 						const account = resolveAccount(snap.source, accounts);
 						const rows = snapshotRows(snap, now, t, locale);
+						// Collapse the auto-generated "email (workspace)" label into a plain
+						// email so every row reads consistently as "email · workspace" (the
+						// chip carries the workspace). A user-custom label is left untouched.
+						const displayName =
+							account?.email && account.organization && account.name === `${account.email} (${account.organization})`
+								? account.email
+								: (account?.name ?? null);
+						const showOrg =
+							!!account?.organization &&
+							account.organization !== displayName &&
+							!(displayName ?? "").endsWith(`(${account.organization})`);
 						return (
 							<div key={snap.source} className="flex flex-col gap-0.5">
 								<div className="flex items-center gap-1.5">
-									<span className="text-fg-2 font-medium">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
-									{account?.name && <span className="text-fg-3">{account.name}</span>}
+									<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
+									{displayName && <span className="text-fg-3">{displayName}</span>}
+									{showOrg && (
+										<span className="text-fg-muted whitespace-nowrap shrink-0">· {account?.organization}</span>
+									)}
 									{account?.planLabel && (
 										<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded">
 											{account.planLabel}

--- a/src/mainview/components/Tooltip.tsx
+++ b/src/mainview/components/Tooltip.tsx
@@ -51,6 +51,9 @@ interface TooltipProps {
 	detail?: ReactNode;
 	/** Optional keyboard-shortcut chip rendered after the text, e.g. "⌘K". */
 	kbd?: string;
+	/** Widen the detail popup (from the default 22rem to 30rem) for content with
+	 *  long single-line rows — e.g. the rate-limit popup's account/workspace line. */
+	wide?: boolean;
 	placement?: PopoverPlacement;
 	/** Render children without any tooltip (conditional escape hatch). */
 	disabled?: boolean;
@@ -77,7 +80,7 @@ function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
 	};
 }
 
-export default function Tooltip({ content, detail, kbd, placement = "top", disabled, children }: TooltipProps) {
+export default function Tooltip({ content, detail, kbd, wide, placement = "top", disabled, children }: TooltipProps) {
 	const [open, setOpen] = useState(false);
 	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 	const anchorRef = useRef<HTMLElement | null>(null);
@@ -197,7 +200,9 @@ export default function Tooltip({ content, detail, kbd, placement = "top", disab
 							id={tooltipId}
 							role="tooltip"
 							className={`fixed z-[1200] pointer-events-none bg-overlay border border-edge-active ring-1 ring-black/30 rounded-lg shadow-2xl shadow-black/60 text-xs ${
-								detail ? "px-3 py-2 max-w-[22rem]" : "px-2.5 py-1.5 max-w-[18rem]"
+								detail
+									? `px-3 py-2 ${wide ? "max-w-[30rem]" : "max-w-[22rem]"}`
+									: "px-2.5 py-1.5 max-w-[18rem]"
 							}`}
 							style={{
 								top: pos?.top ?? 0,

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -204,4 +204,69 @@ describe("RateLimitIndicator", () => {
 		expect(await screen.findByText("Work account")).toBeTruthy();
 		expect(screen.getByText("Pro")).toBeTruthy();
 	});
+
+	it("shows the workspace/organization name so same-email accounts are distinguishable", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		mockedAccounts.mockResolvedValue({
+			claude: {
+				accounts: [],
+				activeId: null,
+				systemIdentity: {
+					email: "arseny@wix.com",
+					organization: "Acme Workspace",
+					plan: "default_claude_max_5x",
+					planLabel: "Max 5x",
+					accountId: "uuid-1",
+				},
+			},
+			codex: { accounts: [], activeId: null, currentIdentity: null },
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		expect(await screen.findByText("arseny@wix.com")).toBeTruthy();
+		expect(screen.getByText("· Acme Workspace")).toBeTruthy();
+	});
+
+	it("collapses an 'email (workspace)' auto-label into a single 'email · workspace' row", async () => {
+		mockedGet.mockResolvedValue({
+			generatedAt: Date.now(),
+			snapshots: [
+				{
+					source: "codex",
+					capturedAt: Date.now(),
+					windows: [{ id: "monthly_credits", usedPercent: 10, resetsAt: Date.now() + 86_400_000, windowMinutes: null }],
+					creditsBalance: null,
+					monthlyCredits: { limit: 8824, used: 100, remainingPercent: 98, resetsAt: Date.now() + 86_400_000 },
+					planType: "enterprise_cbp_usage_based",
+				},
+			],
+		});
+		mockedAccounts.mockResolvedValue({
+			claude: { accounts: [], activeId: null, systemIdentity: null },
+			codex: {
+				accounts: [
+					{
+						id: "acc-cdx",
+						kind: "codex",
+						label: "arsenyp@wix.com (Wix)",
+						identity: { email: "arsenyp@wix.com", organization: "Wix", plan: "enterprise", planLabel: "Enterprise", accountId: "acc-cdx" },
+						auth: "oauth",
+						api: null,
+						createdAt: 0,
+					},
+				],
+				activeId: "acc-cdx",
+				currentIdentity: null,
+			},
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		// The verbose "email (workspace)" parenthetical is collapsed to email …
+		expect(await screen.findByText("arsenyp@wix.com")).toBeTruthy();
+		expect(screen.queryByText("arsenyp@wix.com (Wix)")).toBeNull();
+		// … and the workspace shows exactly once as the chip.
+		expect(screen.getAllByText("· Wix")).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

The Agent rate-limit popup listed only the login email, so two accounts sharing an email across different ChatGPT/Claude workspaces (e.g. `arsenyp@wix.com` in Base44 vs Wix) were indistinguishable.

**Changes**
- Each row now reads as a consistent `email · workspace` line for both Claude and Codex.
- The auto-generated `email (workspace)` label is collapsed so the workspace never shows twice; user-custom labels are left untouched.
- Widened the popup via a new opt-in `Tooltip` `wide` prop (22rem → 30rem) so the longer rows fit on one line.

Claude's workspace comes offline from `.claude.json`; Codex's comes from the workspace name resolved in #935.
