### PR TITLE
Fix Codex profile migration for modern versions

### DIFF
--- a/change-logs/2026/07/13/fix-codex-profile-migration.md
+++ b/change-logs/2026/07/13/fix-codex-profile-migration.md
@@ -1,0 +1,1 @@
+Codex profile migration now switches to per-profile config files at Codex 0.134.0, removes nested managed legacy profile tables, and detects the installed version after the user's shell PATH is loaded.

--- a/decisions/129-codex-profile-migration-cutoff.md
+++ b/decisions/129-codex-profile-migration-cutoff.md
@@ -1,0 +1,16 @@
+# 129 — Gate Codex profile-file migration at 0.134.0
+
+## Context
+Codex 0.134.0 rejects legacy `profile = "dev3-*"` selectors and `[profiles.dev3-*]` tables in the main config when dev3 launches a named profile. Dev3 already has a per-profile-file migration, but its version cutoff was too old and startup could fail to find Codex from an app-bundle PATH.
+
+## Investigation
+The upstream rejection landed in the 0.134.0 release line, while dev3's existing cutoff was 0.131. The startup path installed skills and patched Codex before resolving the user's shell environment, so `codex --version` could return no version and incorrectly select the legacy writer.
+
+## Decision
+Keep the existing version-gated migration, but set its profile-file cutoff to 0.134.0. Remove the complete managed dev3 profile namespace, including nested tables, from the main config on that branch; write the three per-profile files as before. Defer the startup config pass until shell PATH resolution completes, while preserving the direct install-skills path for callers that already have a normal PATH.
+
+## Risks
+Unknown or unavailable Codex versions still use the legacy fallback to avoid writing files unsupported by older installations. A missing PATH export can therefore postpone migration until a later trust/config pass, but it will not make the app write the modern format blindly.
+
+## Alternatives considered
+Always writing per-profile files was rejected because older Codex versions do not load them. Keeping the 0.131 cutoff was rejected because Codex 0.134 is the first release that enforces the legacy-config rejection relevant to the current launch flag. Running the probe before shell resolution was rejected because app bundles inherit a minimal PATH.

--- a/src/bun/__tests__/agent-skills-install.test.ts
+++ b/src/bun/__tests__/agent-skills-install.test.ts
@@ -78,6 +78,13 @@ describe("installAgentSkills", () => {
 		expect(ensureCodexConfigFile).toHaveBeenCalledWith(tempHome);
 	});
 
+	it("can defer Codex config patching until the shell PATH is resolved", async () => {
+		const { installAgentSkills, ensureCodexConfigFile } = await loadModule();
+		installAgentSkills({ configureCodex: false });
+
+		expect(ensureCodexConfigFile).not.toHaveBeenCalled();
+	});
+
 	it("writes the full-protocol PROTOCOL.md fallback next to the short Claude SKILL.md", async () => {
 		const { installAgentSkills } = await loadModule();
 		installAgentSkills();

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -125,9 +125,11 @@ describe("ensureCodexConfig", () => {
 			expect(getCodexSyntaxForVersion("codex-cli 0.131.0")).toEqual({
 				filesystemRootKey: ":workspace_roots",
 				hooksFeatureKey: "hooks",
-				profileV2: true,
+				profileV2: false,
 				unixSocketsAsMap: true,
 			});
+			expect(getCodexSyntaxForVersion("codex-cli 0.133.9").profileV2).toBe(false);
+			expect(getCodexSyntaxForVersion("codex-cli 0.134.0").profileV2).toBe(true);
 		});
 
 		it("switches the unix-socket allowlist to map form at codex 0.119", () => {
@@ -497,7 +499,7 @@ trust_level = "trusted"
 		});
 	});
 
-	describe("profile-v2 (Codex ≥0.131)", () => {
+	describe("profile-v2 (Codex ≥0.134)", () => {
 		it("does not emit [profiles.dev3*] blocks in the main config", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [], {
 				codexVersion: "codex-cli 0.134.0",
@@ -555,6 +557,35 @@ trust_level = "trusted"
 			expect(result).toContain('[projects."/Users/testuser/app"]');
 		});
 
+		it("removes nested managed profile tables while preserving user profiles", () => {
+			const existing = `model = "gpt-5.4"
+
+[profiles.dev3-dark]
+web_search = "live"
+
+[profiles.dev3-dark.tui]
+theme = "dracula"
+
+[profiles.dev3-light.tui]
+theme = "github"
+
+[profiles.dev3-dark-custom]
+web_search = "disabled"
+
+[profiles.ro]
+sandbox_mode = "read-only"
+`;
+			const result = ensureCodexConfig(existing, WORKTREES_PATH, SOCKETS_PATH, [], {
+				codexVersion: "codex-cli 0.134.0",
+			});
+
+			expect(result).not.toContain("[profiles.dev3-dark]");
+			expect(result).not.toContain("[profiles.dev3-dark.tui]");
+			expect(result).not.toContain("[profiles.dev3-light.tui]");
+			expect(result).toContain("[profiles.dev3-dark-custom]");
+			expect(result).toContain("[profiles.ro]");
+		});
+
 		it("does not strip an unrelated top-level profile selector", () => {
 			const existing = `profile = "my-custom"
 `;
@@ -565,7 +596,7 @@ trust_level = "trusted"
 			expect(result).toContain('profile = "my-custom"');
 		});
 
-		it("legacy Codex (<0.131) still gets [profiles.dev3*] in main config", () => {
+		it("legacy Codex (<0.134) still gets [profiles.dev3*] in main config", () => {
 			const result = ensureCodexConfig(null, WORKTREES_PATH, SOCKETS_PATH, [], {
 				codexVersion: "codex-cli 0.130.0",
 			});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6903,7 +6903,7 @@ describe("handlers.spawnAgentInTask", () => {
 
 	// Regression: the primary launch path re-patches ~/.codex/config.toml via
 	// ensureCodexTrust before every codex launch (strips the legacy
-	// [profiles.dev3-*] tables codex ≥0.131 rejects). Spawning an extra Codex
+	// [profiles.dev3-*] tables codex ≥0.134 rejects). Spawning an extra Codex
 	// agent used to skip that step, so the pane crashed with
 	// "--profile dev3-dark cannot be used while config.toml contains legacy profile".
 	it("ensures Codex trust before spawning a Codex agent", async () => {

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -923,7 +923,12 @@ function installOpenAiMetadata(home: string): void {
  * and update ~/.agents/AGENTS.md.
  * Overwritten on every app start to match the running version (same pattern as CLI binary).
  */
-export function installAgentSkills(): void {
+export interface InstallAgentSkillsOptions {
+	/** Skip Codex config patching when the caller has not resolved the user PATH yet. */
+	configureCodex?: boolean;
+}
+
+export function installAgentSkills(options: InstallAgentSkillsOptions = {}): void {
 	const home = homedir();
 
 	// Install Claude-specific skill (with command injection). SKILL.md is short
@@ -1052,5 +1057,7 @@ export function installAgentSkills(): void {
 	installOpenAiMetadata(home);
 	installAgentsMd();
 	ensureClaudeSettings(home);
-	ensureCodexConfigFile(home);
+	if (options.configureCodex !== false) {
+		ensureCodexConfigFile(home);
+	}
 }

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -57,7 +57,7 @@ interface CodexSyntax {
 	 * profile-v2: per-profile settings live in `~/.codex/<name>.config.toml`,
 	 * and Codex rejects `[profiles.<name>]` blocks or top-level `profile = "<name>"`
 	 * in the main config when `--profile <name>` is used. See codex PR #22647.
-	 * Stays true for codex ≥0.131 — the file-based semantics did not go away when
+	 * Stays true for codex ≥0.134 — the file-based semantics did not go away when
 	 * the `--profile-v2` *launch flag* was later removed (see issue #611).
 	 */
 	profileV2: boolean;
@@ -79,7 +79,7 @@ const LEGACY_CODEX_SYNTAX: CodexSyntax = {
 
 const CODEX_HOOKS_RENAME_VERSION: CodexVersion = { major: 0, minor: 129, patch: 0 };
 const CODEX_WORKSPACE_ROOTS_RENAME_VERSION: CodexVersion = { major: 0, minor: 131, patch: 0 };
-const CODEX_PROFILE_V2_VERSION: CodexVersion = { major: 0, minor: 131, patch: 0 };
+const CODEX_PROFILE_V2_VERSION: CodexVersion = { major: 0, minor: 134, patch: 0 };
 const CODEX_UNIX_SOCKETS_MAP_VERSION: CodexVersion = { major: 0, minor: 119, patch: 0 };
 
 const MANAGED_DEV3_PROFILES = [
@@ -212,13 +212,11 @@ export function ensureCodexConfig(
 	// --- 0. Clean up legacy sections ---
 	config = cleanupLegacySections(config);
 	if (syntax.profileV2) {
-		// Codex ≥0.131 rejects `[profiles.<name>]` blocks and top-level
+		// Codex ≥0.134 rejects `[profiles.<name>]` blocks and top-level
 		// `profile = "<name>"` selectors when `--profile <name>` is used. Per-profile
 		// settings now live in `~/.codex/<name>.config.toml` (written by
 		// ensureCodexConfigFile). Strip the legacy entries from the main config.
-		for (const name of MANAGED_DEV3_PROFILES) {
-			config = removeSectionByHeader(config, `[profiles.${name}]`);
-		}
+		config = removeManagedDev3ProfileSections(config);
 		config = removeManagedTopLevelProfileSelector(config);
 	} else {
 		config = commentOutManagedProfileThemeLines(config);
@@ -343,7 +341,7 @@ export function ensureCodexConfig(
 	}
 
 	// --- 4. Ensure [profiles.dev3*] config profiles ---
-	// On Codex ≥0.131 these profiles live in separate per-profile files (handled
+	// On Codex ≥0.134 these profiles live in separate per-profile files (handled
 	// by ensureCodexConfigFile via ensureCodexProfileFile). For older Codex we
 	// keep the legacy in-main-config form.
 	if (!syntax.profileV2) {
@@ -380,8 +378,52 @@ function cleanupLegacySections(content: string): string {
 }
 
 /**
+ * Remove the complete managed dev3 profile namespace, including nested tables
+ * such as `[profiles.dev3-dark.tui]`. Removing only the exact parent header
+ * leaves a legacy profile table behind because TOML treats nested headers as
+ * independent sections.
+ */
+function removeManagedDev3ProfileSections(content: string): string {
+	const lines = content.split("\n");
+	const out: string[] = [];
+	let removing = false;
+	let trailingBlanks = 0;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			const header = trimmed.slice(1, -1);
+			const isManaged = MANAGED_DEV3_PROFILES.some(
+				(name) => header === `profiles.${name}` || header.startsWith(`profiles.${name}.`),
+			);
+			if (isManaged) {
+				if (!removing) {
+					while (trailingBlanks > 0) {
+						out.pop();
+						trailingBlanks--;
+					}
+				}
+				removing = true;
+				continue;
+			}
+			removing = false;
+		}
+
+		if (removing) continue;
+		if (trimmed === "") {
+			trailingBlanks++;
+		} else {
+			trailingBlanks = 0;
+		}
+		out.push(line);
+	}
+
+	return out.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+/**
  * Drop a top-level `profile = "dev3"|"dev3-light"|"dev3-dark"` selector. Codex
- * ≥0.131 rejects it alongside `--profile <name>`, and we never write it from
+ * ≥0.134 rejects it alongside `--profile <name>`, and we never write it from
  * dev-3.0 — but earlier dev-3.0 versions, Codex itself, or user edits may
  * have introduced it.
  */
@@ -718,7 +760,8 @@ export function ensureCodexProfileFile(
 /**
  * Read, patch, and write the Codex config.toml.
  * Ensures a dedicated dev3 permission profile and config profile.
- * Called on app startup from installAgentSkills().
+ * Called after the app resolves the user's shell PATH during startup, and by
+ * installAgentSkills() when the skills installer is invoked directly.
  */
 export function ensureCodexConfigFile(homePath: string): void {
 	const configPath = `${homePath}/.codex/config.toml`;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -18,6 +18,7 @@ import { startRemoteAccessServer, pushToBrowserClients } from "./remote-access-s
 import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
+import { ensureCodexConfigFile } from "./codex-config";
 import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
@@ -26,6 +27,7 @@ import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedW
 import electrobunConfig from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 
 const log = createLogger("main");
 
@@ -122,7 +124,7 @@ log.info("Log files", { dir: getLogPath() });
 
 	// Install dev3 skill into all supported AI agent directories (~/.claude, ~/.codex, etc.).
 	// Overwritten on every start to match the running app version (same pattern as CLI binary).
-	installAgentSkills();
+	installAgentSkills({ configureCodex: false });
 
 	// Append ~/.dev3.0/bin to the user's shell rc files (idempotent).
 	// This makes `dev3` available in all terminals, not just worktree tmux
@@ -190,6 +192,10 @@ if (shellEnv.path) {
 		}
 	}
 }
+
+// Codex profile migration depends on `codex --version`. Run it only after the
+// user's shell PATH is available; the app bundle starts with a minimal PATH.
+ensureCodexConfigFile(homedir());
 
 if (shellEnv.lang) {
 	process.env.LANG = shellEnv.lang;

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -373,7 +373,7 @@ async function persistInitialAgentPaneId(
  * Claude trust (with MCP pre-approval) is always ensured; Codex/Gemini trust
  * only for their respective CLIs. Codex trust also re-patches ~/.codex/config.toml
  * — stripping the legacy `[profiles.dev3-*]` tables / top-level `profile = "..."`
- * selectors that codex ≥0.131 rejects and (re)writing the per-profile files. All
+ * selectors that codex ≥0.134 rejects and (re)writing the per-profile files. All
  * calls are idempotent and non-fatal: a failure logs and continues so a trust
  * hiccup never blocks the launch.
  *


### PR DESCRIPTION
## Summary

- Gate Codex profile-file migration at version 0.134.0.
- Remove managed legacy profile selectors and nested profile tables from config.toml.
- Run startup Codex version detection after resolving the user shell PATH.

## Root cause

Codex 0.134.0 rejects legacy profile selectors and tables when a named profile is selected. Dev3 could probe Codex before the app bundle PATH was resolved, fall back to legacy config generation, and leave the rejected entries in place.

## Validation

- bun run lint
- bun run test