### PR TITLE
Show and sort dashboard task priorities

### DIFF
--- a/change-logs/2026/07/15/feature-dashboard-task-priority.md
+++ b/change-logs/2026/07/15/feature-dashboard-task-priority.md
@@ -1,1 +1,1 @@
-Show P{n} badges for visible dashboard task rows and sort those rows by priority, preserving the existing status ordering within each priority band on narrow screens.
+Show P{n} badges in the leading marker slot of visible dashboard task rows and sort those rows by priority, preserving the existing status ordering within each priority band on narrow screens.

--- a/change-logs/2026/07/15/feature-dashboard-task-priority.md
+++ b/change-logs/2026/07/15/feature-dashboard-task-priority.md
@@ -1,0 +1,1 @@
+Show P{n} badges for visible dashboard task rows and sort those rows by priority, preserving the existing status ordering within each priority band on narrow screens.

--- a/src/mainview/components/ActivityOverview.tsx
+++ b/src/mainview/components/ActivityOverview.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { DragEvent } from "react";
 import type { Project, Task, TaskStatus } from "../../shared/types";
-import { getTaskTitle, isBuiltinOpsProject, orderProjectsForDisplay } from "../../shared/types";
+import { comparePriority, getTaskTitle, isBuiltinOpsProject, orderProjectsForDisplay } from "../../shared/types";
 import type { Route } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
@@ -10,6 +10,7 @@ import { useStatusColors } from "../hooks/useStatusColors";
 import ProjectActionButtons from "./ProjectActionButtons";
 import BottomSheet from "./BottomSheet";
 import HelpSpot from "./HelpSpot";
+import PriorityBadge from "./PriorityBadge";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 
@@ -309,14 +310,16 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 						}
 					}
 
-					// Narrow viewport: order attention rows so "your turn" sits first, then
-					// cap the list to NARROW_ROW_CAP behind a "show more" fold. Desktop keeps
-					// the natural order and always shows every row.
+					// Order every visible row by priority first. On narrow viewports, keep
+					// "your turn" ahead of colleague reviews within the same priority band,
+					// then cap the list to NARROW_ROW_CAP behind a "show more" fold.
 					const rankOf = (task: Task) =>
 						columnOf(task) !== null ? 3 : ATTENTION_RANK[task.status] ?? 3;
-					const orderedRowTasks = narrow
-						? [...rowTasks].sort((a, b) => rankOf(a) - rankOf(b))
-						: rowTasks;
+					const orderedRowTasks = [...rowTasks].sort((a, b) => {
+						const byPriority = comparePriority(a.priority, b.priority);
+						if (byPriority !== 0) return byPriority;
+						return narrow ? rankOf(a) - rankOf(b) : 0;
+					});
 					const isExpanded = expandedProjects.has(project.id);
 					const canCollapse = narrow && orderedRowTasks.length > NARROW_ROW_CAP;
 					const visibleRowTasks =
@@ -514,6 +517,7 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 													{bellCounts.has(task.id) && (
 														<span className="w-2 h-2 rounded-full bg-accent animate-pulse flex-shrink-0" />
 													)}
+													<PriorityBadge priority={task.priority} />
 													<span className="text-xs flex-shrink-0" style={{ color: rowColor }}>
 														{rowLabel}
 													</span>

--- a/src/mainview/components/ActivityOverview.tsx
+++ b/src/mainview/components/ActivityOverview.tsx
@@ -502,10 +502,10 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 													style={{ backgroundColor: rowColor }}
 												/>
 											)}
-											<span
-												className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${narrow ? "mt-1.5" : ""}`}
-												style={{ backgroundColor: rowColor }}
-												title={rowLabel}
+											{/* Priority replaces the status dot in the leading marker slot. */}
+											<PriorityBadge
+												priority={task.priority}
+												className={`flex-shrink-0 ${narrow ? "mt-0.5" : ""}`}
 											/>
 											<span className="min-w-0 flex-1 flex flex-col md:flex-row md:items-center gap-0.5 md:gap-3">
 												<span
@@ -517,7 +517,6 @@ function ActivityOverview({ projects, navigate, bellCounts, onRemoveProject, onO
 													{bellCounts.has(task.id) && (
 														<span className="w-2 h-2 rounded-full bg-accent animate-pulse flex-shrink-0" />
 													)}
-													<PriorityBadge priority={task.priority} />
 													<span className="text-xs flex-shrink-0" style={{ color: rowColor }}>
 														{rowLabel}
 													</span>

--- a/src/mainview/components/__tests__/ActivityOverview.test.tsx
+++ b/src/mainview/components/__tests__/ActivityOverview.test.tsx
@@ -242,10 +242,14 @@ describe("ActivityOverview", () => {
 		const high = await screen.findByText("High priority");
 		const normal = screen.getByText("Normal priority");
 		const low = screen.getByText("Low priority");
+		const highRow = high.closest("button");
+		if (!highRow) throw new Error("Expected high-priority task row");
 
 		expect(screen.getByText("P1")).toBeInTheDocument();
 		expect(screen.getByText("P2")).toBeInTheDocument();
 		expect(screen.getByText("P3")).toBeInTheDocument();
+		expect(highRow.firstElementChild).toHaveTextContent("P1");
+		expect(within(highRow).getAllByText("P1")).toHaveLength(1);
 		expect(high.compareDocumentPosition(normal) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 		expect(normal.compareDocumentPosition(low) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 	});

--- a/src/mainview/components/__tests__/ActivityOverview.test.tsx
+++ b/src/mainview/components/__tests__/ActivityOverview.test.tsx
@@ -225,6 +225,31 @@ describe("ActivityOverview", () => {
 		expect(screen.getByText("PR Review")).toBeInTheDocument();
 	});
 
+	it("shows priority badges and orders visible task rows from highest to lowest", async () => {
+		mockedApi.request.getAllProjectTasks.mockResolvedValue([
+			{
+				projectId: "p1",
+				tasks: [
+					{ ...mockTask, id: "low", title: "Low priority", priority: "P3" },
+					{ ...mockTask, id: "high", title: "High priority", priority: "P1" },
+					{ ...mockTask, id: "normal", title: "Normal priority", priority: "P2" },
+				],
+			},
+		]);
+
+		renderActivityOverview();
+
+		const high = await screen.findByText("High priority");
+		const normal = screen.getByText("Normal priority");
+		const low = screen.getByText("Low priority");
+
+		expect(screen.getByText("P1")).toBeInTheDocument();
+		expect(screen.getByText("P2")).toBeInTheDocument();
+		expect(screen.getByText("P3")).toBeInTheDocument();
+		expect(high.compareDocumentPosition(normal) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(normal.compareDocumentPosition(low) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
 	it("shows custom-column tasks as rows labeled with the column name", async () => {
 		const projWithColumn: Project = {
 			...mockProject,
@@ -428,5 +453,24 @@ describe("ActivityOverview — narrow viewport", () => {
 		const colleague = screen.getByText("Colleague PR");
 
 		expect(mine.compareDocumentPosition(colleague) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
+	it("orders by priority before status on narrow", async () => {
+		const tasks = [
+			{ ...mockTask, id: "mine", title: "My review", status: "review-by-user" as const, priority: "P3" as const },
+			{ ...mockTask, id: "colleague", title: "Colleague PR", status: "review-by-colleague" as const, priority: "P1" as const },
+		];
+		mockedApi.request.getAllProjectTasks.mockResolvedValue([{ projectId: "p1", tasks }]);
+
+		render(
+			<I18nProvider>
+				<ActivityOverview projects={[mockProject]} navigate={vi.fn()} bellCounts={new Map()} />
+			</I18nProvider>,
+		);
+
+		const colleague = await screen.findByText("Colleague PR");
+		const mine = screen.getByText("My review");
+
+		expect(colleague.compareDocumentPosition(mine) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary

- Show P0–P4 priority badges on visible dashboard task rows.
- Sort task rows by priority while preserving the existing status ordering within each priority group.
- Place the priority badge in the leading marker slot, replacing the colored status dot and avoiding duplicate right-side metadata.

## Validation

- `bun run lint`
- `bun run test`
- Browser QA completed with no console errors.