### PR TITLE
Fix active task completion animation

### DIFF
--- a/change-logs/2026/07/15/fix-active-task-completion-animation.md
+++ b/change-logs/2026/07/15/fix-active-task-completion-animation.md
@@ -1,0 +1,1 @@
+Active Tasks now shows the same muted teardown animation as Kanban while a completed or cancelled task closes its session and worktree. The task stays visible but cannot be opened until backend cleanup finishes.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -22,6 +22,7 @@ import TerminalPreviewPopover from "./TerminalPreviewPopover";
 import AgentLauncherBadge from "./AgentLauncherBadge";
 import VariantDots from "./VariantDots";
 import { getTaskAgentMeta } from "../utils/taskAgentMeta";
+import TaskShutdownOverlay from "./TaskShutdownOverlay";
 
 type SidebarScope = "project" | "global" | "attention";
 const LS_SIDEBAR_SCOPE = "dev3-sidebar-scope";
@@ -392,6 +393,7 @@ function ActiveTasksSidebar({
 	);
 
 	function handleTaskClick(task: Task) {
+		if (task.shuttingDown) return;
 		preview.close();
 		const targetProjectId = task.projectId || project.id;
 		if (task.id === activeTaskId && targetProjectId === project.id) {
@@ -625,24 +627,29 @@ function ActiveTasksSidebar({
 										<div
 											data-hint-id={`task:${task.id}`}
 											role="button"
-											tabIndex={0}
+											tabIndex={task.shuttingDown ? -1 : 0}
+											aria-disabled={task.shuttingDown || undefined}
 											aria-label={displayTitle}
-							onClick={() => handleTaskClick(task)}
-							onKeyDown={(e) => {
-								// Card is a div (so the nested PriorityBadge button is valid
-								// HTML); restore native button keyboard activation.
-								if (e.target !== e.currentTarget) return;
-								if (e.key === "Enter" || e.key === " ") {
+											onClick={() => handleTaskClick(task)}
+											onKeyDown={(e) => {
+												// Card is a div (so the nested PriorityBadge button is valid
+												// HTML); restore native button keyboard activation.
+												if (e.target !== e.currentTarget) return;
+												if (e.key === "Enter" || e.key === " ") {
 													e.preventDefault();
 													handleTaskClick(task);
 												}
 											}}
-											onMouseEnter={(e) => preview.handlers.onMouseEnter(task.id, e.currentTarget)}
+											onMouseEnter={(e) => {
+												if (!task.shuttingDown) preview.handlers.onMouseEnter(task.id, e.currentTarget);
+											}}
 											onMouseLeave={preview.handlers.onMouseLeave}
 											className={`w-full text-left px-3 py-2 transition-all relative cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent/60 ${
-												isActive
-													? "bg-accent/20 ring-1 ring-inset ring-accent/50"
-													: "hover:bg-elevated-hover"
+												task.shuttingDown
+													? "grayscale opacity-40 pointer-events-none"
+													: isActive
+														? "bg-accent/20 ring-1 ring-inset ring-accent/50"
+														: "hover:bg-elevated-hover"
 											}`}
 										>
 											{/* Faint status wash so the whole card carries its column color
@@ -679,6 +686,8 @@ function ActiveTasksSidebar({
 													</span>
 												);
 											})()}
+
+											{task.shuttingDown && <TaskShutdownOverlay />}
 
 											{/* Bell badge */}
 											{bellCount > 0 && (

--- a/src/mainview/components/ActiveTasksStrip.tsx
+++ b/src/mainview/components/ActiveTasksStrip.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import AgentLauncherBadge from "./AgentLauncherBadge";
 import VariantDots from "./VariantDots";
 import { getTaskAgentMeta } from "../utils/taskAgentMeta";
+import TaskShutdownOverlay from "./TaskShutdownOverlay";
 
 interface ActiveTasksStripProps {
 	project: Project;
@@ -48,6 +49,7 @@ function ActiveTasksStrip({
 	if (activeTasks.length <= 1) return null;
 
 	function handleTaskClick(task: Task) {
+		if (task.shuttingDown) return;
 		if (task.id === activeTaskId) {
 			navigate({ screen: "project", projectId: project.id });
 		} else {
@@ -73,7 +75,8 @@ function ActiveTasksStrip({
 					<div
 						key={task.id}
 						role="button"
-						tabIndex={0}
+						tabIndex={task.shuttingDown ? -1 : 0}
+						aria-disabled={task.shuttingDown || undefined}
 						aria-label={title}
 						onClick={() => handleTaskClick(task)}
 						onKeyDown={(event) => {
@@ -83,8 +86,10 @@ function ActiveTasksStrip({
 								handleTaskClick(task);
 							}
 						}}
-						className={`flex-shrink-0 flex items-center gap-1.5 px-2 py-1 rounded text-[0.625rem] leading-tight max-w-[220px] transition-colors ${
-							isActive
+						className={`relative flex-shrink-0 flex items-center gap-1.5 px-2 py-1 rounded text-[0.625rem] leading-tight max-w-[220px] transition-colors ${
+							task.shuttingDown
+								? "grayscale opacity-40 pointer-events-none"
+								: isActive
 								? "bg-accent/15 text-accent"
 								: "text-fg-2 hover:bg-elevated-hover"
 						}`}
@@ -116,6 +121,7 @@ function ActiveTasksStrip({
 								{bellCount > 9 ? "9+" : bellCount}
 							</span>
 						)}
+						{task.shuttingDown && <TaskShutdownOverlay strip />}
 					</div>
 				);
 			})}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -29,6 +29,7 @@ import ScheduledMessagesChip from "./ScheduledMessagesChip";
 import AgentLauncherBadge, { resolveAgentLauncherIcon } from "./AgentLauncherBadge";
 import { PREPARING_STAGE_LABELS } from "./TaskPreparingView";
 import Tooltip from "./Tooltip";
+import TaskShutdownOverlay from "./TaskShutdownOverlay";
 
 interface TaskCardProps {
 	task: Task;
@@ -561,30 +562,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				</div>
 			)}
 
-			{/* Shutting-down overlay — muted, indeterminate "powering down" while the
-			    session/worktree are torn down. The opposite of the preparing loader:
-			    grey (not accent), no progress bar (teardown duration is unknowable),
-			    no actions. The card is pointer-events-none, so it is not openable. */}
-			{isShuttingDown && (
-				<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-base/55 px-3 backdrop-blur-[2px]">
-					<div
-						className="flex max-w-full items-center gap-2 rounded-xl border border-edge bg-overlay/95 px-3 py-2 shadow-xl shadow-black/30"
-						role="status"
-						aria-live="polite"
-						aria-busy="true"
-					>
-						<div className="h-3.5 w-3.5 flex-shrink-0 rounded-full border-2 border-fg-muted/30 border-t-fg-muted animate-spin motion-reduce:animate-none" />
-						<div className="min-w-0">
-							<div className="text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-fg-3">
-								{t("task.shuttingDown")}
-							</div>
-							<div className="truncate text-xs text-fg-muted">
-								{t("task.shuttingDownDetail")}
-							</div>
-						</div>
-					</div>
-				</div>
-			)}
+			{/* Shared teardown feedback used by the active-task surfaces too. */}
+			{isShuttingDown && <TaskShutdownOverlay />}
 
 			{/* Dismiss button — top-right, visible on hover */}
 			{showDismissButton && (

--- a/src/mainview/components/TaskShutdownOverlay.tsx
+++ b/src/mainview/components/TaskShutdownOverlay.tsx
@@ -1,0 +1,49 @@
+import { useT } from "../i18n";
+
+interface TaskShutdownOverlayProps {
+	/** Use the single-line treatment for the narrow active-task strip. */
+	strip?: boolean;
+}
+
+/** Shared teardown feedback for task surfaces while the worktree is closing. */
+function TaskShutdownOverlay({ strip = false }: TaskShutdownOverlayProps) {
+	const t = useT();
+
+	if (strip) {
+		return (
+			<div
+				className="absolute inset-0 z-10 flex items-center justify-center rounded bg-base/80"
+				role="status"
+				aria-label={t("task.shuttingDown")}
+				aria-live="polite"
+				aria-busy="true"
+				title={t("task.shuttingDownDetail")}
+			>
+				<div className="h-3 w-3 rounded-full border-2 border-fg-muted/30 border-t-fg-muted animate-spin motion-reduce:animate-none" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-base/55 px-3 backdrop-blur-[2px]">
+			<div
+				className="flex max-w-full items-center gap-2 rounded-xl border border-edge bg-overlay/95 px-3 py-2 shadow-xl shadow-black/30"
+				role="status"
+				aria-live="polite"
+				aria-busy="true"
+			>
+				<div className="h-3.5 w-3.5 flex-shrink-0 rounded-full border-2 border-fg-muted/30 border-t-fg-muted animate-spin motion-reduce:animate-none" />
+				<div className="min-w-0">
+					<div className="text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-fg-3">
+						{t("task.shuttingDown")}
+					</div>
+					<div className="truncate text-xs text-fg-muted">
+						{t("task.shuttingDownDetail")}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default TaskShutdownOverlay;

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -99,6 +99,33 @@ function makeTask(overrides?: Partial<Task>): Task {
 }
 
 	describe("ActiveTasksSidebar", () => {
+	it("shows teardown feedback and blocks a shutting-down task", async () => {
+		const user = userEvent.setup();
+		const navigate = vi.fn();
+		render(
+			<I18nProvider>
+				<ActiveTasksSidebar
+					project={project}
+					tasks={[makeTask({ shuttingDown: true })]}
+					activeTaskId="t1"
+					dispatch={vi.fn()}
+					navigate={navigate}
+					agents={[claudeAgent]}
+					bellCounts={new Map()}
+					taskPorts={new Map()}
+				/>
+			</I18nProvider>,
+		);
+
+		const status = screen.getByRole("status");
+		expect(status).toHaveAttribute("aria-busy", "true");
+		expect(screen.getByText("Shutting down…")).toBeInTheDocument();
+		expect(screen.getByText("Closing session & worktree")).toBeInTheDocument();
+
+		await user.click(screen.getByText("Привет! как сам?"));
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
 	it("shows agent-first identity with compact config and variant dots", () => {
 		const navigate = vi.fn();
 		render(

--- a/src/mainview/components/__tests__/ActiveTasksStrip.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksStrip.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ActiveTasksStrip from "../ActiveTasksStrip";
 import type { CodingAgent, Project, Task } from "../../../shared/types";
 import { I18nProvider } from "../../i18n";
@@ -47,6 +48,30 @@ function makeTask(overrides?: Partial<Task>): Task {
 }
 
 describe("ActiveTasksStrip", () => {
+	it("shows a busy teardown indicator and blocks a shutting-down task", async () => {
+		const navigate = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<I18nProvider>
+				<ActiveTasksStrip
+					project={project}
+					tasks={[makeTask({ shuttingDown: true }), makeTask({ id: "t2" })]}
+					activeTaskId="t2"
+					navigate={navigate}
+					agents={[geminiAgent]}
+					bellCounts={new Map()}
+				/>
+			</I18nProvider>,
+		);
+
+		const status = screen.getByRole("status");
+		expect(status).toHaveAttribute("aria-label", "Shutting down…");
+		expect(status).toHaveAttribute("aria-busy", "true");
+
+		await user.click(screen.getAllByRole("button", { name: "Привет! как сам?" })[0]);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
 	it("renders compact agent summary and variant dots", () => {
 		render(
 			<I18nProvider>


### PR DESCRIPTION
## Summary

- Show the existing muted teardown animation in the Active Tasks sidebar and browser strip.
- Keep shutting-down tasks visible and prevent opening them until cleanup finishes.
- Share the teardown overlay component with Kanban and cover the behavior with component tests.

## Verification

- `bun run lint`
- `bun run test`
- Browser smoke test completed with no console or page errors.