### PR TITLE
Fix stale scratch flag after task edits

### DIFF
--- a/change-logs/2026/07/15/fix-clear-stale-scratch-flag.md
+++ b/change-logs/2026/07/15/fix-clear-stale-scratch-flag.md
@@ -1,0 +1,1 @@
+Clear the scratch semantic flag when UI or CLI title edits turn a scratch task into a normal task. Preserve launch-time compatibility guards so legacy stale records with real descriptions still receive their prompt.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1321,6 +1321,33 @@ describe("task.update", () => {
 		}));
 	});
 
+	it("clears the scratch flag when the title becomes a real task title", async () => {
+		const project = makeProject();
+		const task = makeTask({ scratch: true, description: "Scratch — 15:50" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({
+			...task,
+			customTitle: "Plan HTML artifacts",
+			scratch: false,
+		});
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				title: "Plan HTML artifacts",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(vi.mocked(data.updateTask).mock.calls[0][2]).toEqual(expect.objectContaining({
+			customTitle: "Plan HTML artifacts",
+			scratch: false,
+		}));
+	});
+
 	it("does not auto-generate title when explicit title provided", async () => {
 		const project = makeProject();
 		const task = makeTask();

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2746,6 +2746,31 @@ describe("handlers.renameTask", () => {
 		});
 	});
 
+	it("clears scratch when the UI assigns a real title", async () => {
+		const project = makeProject();
+		const task = makeTask({ scratch: true, description: "Scratch — 15:50" });
+		const updated = makeTask({
+			scratch: false,
+			customTitle: "Plan HTML artifacts",
+			titleEditedByUser: true,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(updated);
+
+		await handlers.renameTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			customTitle: "Plan HTML artifacts",
+		});
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			customTitle: "Plan HTML artifacts",
+			titleEditedByUser: true,
+			scratch: false,
+		});
+	});
+
 	it("treats whitespace-only customTitle as a reset", async () => {
 		const project = makeProject();
 		const task = makeTask({ customTitle: "Old", titleEditedByUser: true });
@@ -2826,6 +2851,30 @@ describe("activateTask", () => {
 		const task = makeTask({
 			status: "todo",
 			scratch: true,
+			description: "Scratch — 14:52",
+			worktreePath: null,
+			branchName: null,
+		});
+
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/wt", branchName: "dev3/task-1" });
+
+		await activateTask(project, task);
+
+		expect(agents.resolveCommandForProject).toHaveBeenCalledWith(
+			expect.objectContaining({ id: project.id, path: project.path }),
+			task.title,
+			"",
+			"/tmp/wt",
+			undefined,
+			expect.anything(),
+		);
+	});
+
+	it("does not launch a cleared scratch placeholder as a prompt", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			status: "todo",
+			scratch: false,
 			description: "Scratch — 14:52",
 			worktreePath: null,
 			branchName: null,

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -327,6 +327,7 @@ const handlers: Record<string, Handler> = {
 				titlePreserved = true;
 			} else {
 				updates.customTitle = newTitle;
+				if (newTitle && task.scratch === true) updates.scratch = false;
 				// CLI writes never claim a user edit — only the UI rename RPC does.
 				// When the user explicitly clears their title via --title "" we
 				// also drop the user-edit flag so future agents can rename again.

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -492,8 +492,7 @@ function isScratchPlaceholderDescription(description: string): boolean {
 }
 
 function taskWithLaunchDescription(task: Task, forceBlank = false): Task {
-	const hasScratchPlaceholder = task.scratch === true
-		&& isScratchPlaceholderDescription(task.description);
+	const hasScratchPlaceholder = isScratchPlaceholderDescription(task.description);
 	return forceBlank || hasScratchPlaceholder ? { ...task, description: "" } : task;
 }
 
@@ -1323,6 +1322,7 @@ async function renameTask(params: { taskId: string; projectId: string; customTit
 	const updated = await data.updateTask(project, task.id, {
 		customTitle: trimmed,
 		titleEditedByUser: trimmed !== null,
+		...(task.scratch === true && trimmed !== null ? { scratch: false } : {}),
 	});
 	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 	log.info("← renameTask done", { taskId: task.id });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1206,7 +1206,7 @@ export interface Task {
 	 * initial prompt. The `description` holds only a `Scratch — HH:mm`
 	 * placeholder used for the title; at launch time the agent receives an
 	 * empty prompt instead of the placeholder. Editing in a meaningful
-	 * description converts it into a normal task and clears this flag.
+	 * description or title converts it into a normal task and clears this flag.
 	 */
 	scratch?: boolean;
 	/**


### PR DESCRIPTION
## Summary

- Clear `scratch` when UI rename and CLI title edits turn a scratch task into a normal task.
- Keep launch compatibility keyed to the exact `Scratch — HH:mm` placeholder so legacy records with real descriptions receive their prompts.
- Add regression coverage and a changelog entry.

## Testing

- `bun run lint`
- `bun run test`