### PR TITLE
Fix Kanban custom column insertion order

### DIFF
--- a/change-logs/2026/07/15/fix-new-column-placement.md
+++ b/change-logs/2026/07/15/fix-new-column-placement.md
@@ -1,0 +1,1 @@
+New custom columns created from the Kanban board are inserted immediately before Completed and the full column order is persisted, keeping the new column beside the board's add-column affordance.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -342,16 +342,29 @@ function KanbanBoard({
 	}
 
 	// Create a custom column straight from the board (issue #222): the server picks
-	// a distinct color; we append it and flag it for inline renaming so the user
-	// names it in place instead of opening Project Settings. Advanced config
-	// (color, LLM instruction, agent) stays in Project Settings — progressive disclosure.
+	// a distinct color; insert it immediately before Completed and flag it for inline
+	// renaming so the user names it in place instead of opening Project Settings.
+	// Advanced config (color, LLM instruction, agent) stays in Project Settings —
+	// progressive disclosure.
 	async function handleCreateCustomColumn() {
 		try {
 			const column = await api.request.createCustomColumn({
 				projectId: project.id,
 				name: t("customColumns.defaultName"),
 			});
-			dispatch({ type: "updateProject", project: { ...project, customColumns: [...customColumns, column] } });
+			const currentOrder = getOrderedColumns().map((slot) => slot.type === "builtin" ? slot.status : slot.col.id);
+			const completedIndex = currentOrder.indexOf("completed");
+			const columnOrder = [...currentOrder];
+			columnOrder.splice(completedIndex === -1 ? columnOrder.length : completedIndex, 0, column.id);
+			dispatch({
+				type: "updateProject",
+				project: { ...project, customColumns: [...customColumns, column], columnOrder },
+			});
+			// The create RPC returns only the new column, so persist the full board order
+			// explicitly after creation. The server has committed the column by this point.
+			api.request.reorderColumns({ projectId: project.id, columnOrder }).catch((err) => {
+				toast.error(t("kanban.failedReorderColumns", { error: String(err) }));
+			});
 			setAutoEditColumnId(column.id);
 		} catch (err) {
 			toast.error(t("customColumns.failedCreate", { error: String(err) }));

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -587,7 +587,7 @@ describe("create custom column from board (issue #222)", () => {
 		Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
 	});
 
-	it("clicking the add-column button creates a column and appends it", async () => {
+	it("clicking the add-column button creates a column immediately before Completed", async () => {
 		const created: CustomColumn = { id: "col-new", name: "New Column", color: "#123456", llmInstruction: "" };
 		(api.request.createCustomColumn as ReturnType<typeof vi.fn>).mockResolvedValue(created);
 		const dispatch = vi.fn();
@@ -601,10 +601,40 @@ describe("create custom column from board (issue #222)", () => {
 			expect(dispatch).toHaveBeenCalledWith(
 				expect.objectContaining({
 					type: "updateProject",
-					project: expect.objectContaining({ customColumns: expect.arrayContaining([created]) }),
+					project: expect.objectContaining({
+						customColumns: expect.arrayContaining([created]),
+						columnOrder: expect.any(Array),
+					}),
 				}),
 			),
 		);
+		await waitFor(() => expect(api.request.reorderColumns).toHaveBeenCalledWith({
+			projectId: "p1",
+			columnOrder: expect.arrayContaining(["col-new", "completed"]),
+		}));
+		const { columnOrder } = (api.request.reorderColumns as ReturnType<typeof vi.fn>).mock.calls[0][0] as { columnOrder: string[] };
+		expect(columnOrder[columnOrder.indexOf("completed") - 1]).toBe("col-new");
+	});
+
+	it("inserts a new column before Completed in an existing stored order", async () => {
+		const created: CustomColumn = { id: "col-new", name: "New Column", color: "#123456", llmInstruction: "" };
+		(api.request.createCustomColumn as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+		const dispatch = vi.fn();
+		await renderBoardWith({
+			project: {
+				...project,
+				customColumns: [customColA],
+				columnOrder: ["todo", "in-progress", "user-questions", "review-by-ai", "review-by-user", "col-a", "review-by-colleague", "completed", "cancelled"],
+			},
+			dispatch,
+		});
+
+		await userEvent.click(screen.getByLabelText("Add column"));
+
+		await waitFor(() => expect(api.request.reorderColumns).toHaveBeenCalled());
+		const { columnOrder } = (api.request.reorderColumns as ReturnType<typeof vi.fn>).mock.calls[0][0] as { columnOrder: string[] };
+		expect(columnOrder[columnOrder.indexOf("completed") - 1]).toBe("col-new");
+		expect(columnOrder[columnOrder.indexOf("cancelled") - 1]).not.toBe("col-new");
 	});
 
 	it("places the add-column button immediately before the Completed column", async () => {


### PR DESCRIPTION
## Summary

- Insert new custom columns immediately before `Completed`, directly beside the board add-column affordance.
- Persist the effective `columnOrder` through the existing column reorder RPC.
- Add regression coverage and a changelog entry.

## Validation

- `bun run lint`
- `bun run test`
- Browser QA confirmed the new column appears immediately left of `+` with no console errors.