### PR TITLE
Add back/forward keyboard shortcut aliases

### DIFF
--- a/change-logs/2026/07/15/feature-history-navigation-shortcuts.md
+++ b/change-logs/2026/07/15/feature-history-navigation-shortcuts.md
@@ -1,0 +1,1 @@
+Add VS Code-style Ctrl-minus and Ctrl-Shift-minus aliases for back and forward route navigation while preserving the existing bracket shortcuts. Move non-macOS zoom-out to Ctrl+Alt-minus to keep the new alias unambiguous, and update the shortcut reference and navigation tip.

--- a/src/bun/__tests__/application-menu.test.ts
+++ b/src/bun/__tests__/application-menu.test.ts
@@ -80,6 +80,16 @@ describe("buildApplicationMenu", () => {
 		expect(actionable[1].accelerator).toBeUndefined();
 	});
 
+	it("leaves Ctrl+- available for route history instead of native zoom-out", () => {
+		const menu = buildApplicationMenu() as AnyMenuItem[];
+		const zoomOut = findItemByAction(menu, MENU_ACTIONS.zoomOut);
+		expect(zoomOut).toMatchObject({
+			label: "Zoom Out (⌘- / Ctrl+Alt+-)",
+			enabled: true,
+		});
+		expect(zoomOut?.accelerator).toBeUndefined();
+	});
+
 	it("keeps Add Local Project on Command+P", () => {
 		const menu = buildApplicationMenu() as AnyMenuItem[];
 		const fileMenu = findLabeledMenu(menu, "File");

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -81,6 +81,11 @@ function digitFromCode(code: string): number | null {
 	return m ? Number(m[1]) : null;
 }
 
+/** Match the physical minus key, including shifted layouts where `key` is `_`. */
+function isMinusKey(event: KeyboardEvent): boolean {
+	return event.code === "Minus" || event.key === "-" || event.key === "_";
+}
+
 /** First on-screen search input (board label filter, sidebar search), for the bare `/` shortcut. */
 function findVisibleSearchInput(): HTMLElement | null {
 	for (const el of document.querySelectorAll<HTMLElement>('[data-search-input="true"]')) {
@@ -668,7 +673,7 @@ function App() {
 		};
 	}, [openCreateTaskModal, openAddProject]);
 
-	// Cmd/Ctrl+Q, Cmd/Ctrl+N, Cmd/Ctrl+,, Cmd/Ctrl+=/- (zoom) — capture phase so terminal can't swallow them
+	// Global app shortcuts — capture phase so the terminal can't swallow them.
 	useGlobalShortcut(
 		(e) => {
 			const isTerminalFullscreenShortcut =
@@ -764,7 +769,21 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				adjustZoom(ZOOM_STEP);
-			} else if ((e.metaKey || e.ctrlKey) && e.key === "-") {
+			} else if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && isMinusKey(e)) {
+				// Ctrl+- — VS Code-style alias for navigating back. Match the physical
+				// minus key because Shift+- reports `_` in the US keyboard layout.
+				e.preventDefault();
+				e.stopPropagation();
+				dispatch({ type: "goBack" });
+			} else if (e.ctrlKey && !e.metaKey && e.shiftKey && !e.altKey && isMinusKey(e)) {
+				// Ctrl+Shift+- — VS Code-style alias for navigating forward.
+				e.preventDefault();
+				e.stopPropagation();
+				dispatch({ type: "goForward" });
+			} else if (
+				(e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey && isMinusKey(e)) ||
+				(e.ctrlKey && !e.metaKey && !e.shiftKey && e.altKey && isMinusKey(e))
+			) {
 				if (remote) return; // Yield to the browser's native page zoom in remote.
 				e.preventDefault();
 				e.stopPropagation();

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -283,6 +283,49 @@ describe("App keyboard shortcuts", () => {
 		});
 	});
 
+	describe("history navigation aliases", () => {
+		it("uses Ctrl+- for back and Ctrl+Shift+- for forward", async () => {
+			await renderApp();
+			await userEvent.keyboard("{Control>},{/Control}");
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Control>}-{/Control}");
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+			expect(mockedAdjustZoom).not.toHaveBeenCalled();
+
+			await userEvent.keyboard("{Control>}{Shift>}-{/Shift}{/Control}");
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+		});
+
+		it("keeps the existing command-bracket aliases", async () => {
+			await renderApp();
+			await userEvent.keyboard("{Meta>},{/Meta}");
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+
+			const back = new KeyboardEvent("keydown", {
+				code: "BracketLeft",
+				key: "[",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			act(() => window.dispatchEvent(back));
+			expect(back.defaultPrevented).toBe(true);
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+
+			const forward = new KeyboardEvent("keydown", {
+				code: "BracketRight",
+				key: "]",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			act(() => window.dispatchEvent(forward));
+			expect(forward.defaultPrevented).toBe(true);
+			expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
+		});
+	});
+
 	describe("live variant cycling", () => {
 		const project = {
 			id: "p1",
@@ -1166,9 +1209,9 @@ describe("App keyboard shortcuts", () => {
 			expect(mockedAdjustZoom).toHaveBeenCalledWith(-ZOOM_STEP);
 		});
 
-		it("Ctrl+- calls adjustZoom with -ZOOM_STEP", async () => {
+		it("Ctrl+Alt+- calls adjustZoom with -ZOOM_STEP", async () => {
 			await renderApp();
-			await userEvent.keyboard("{Control>}-{/Control}");
+			await userEvent.keyboard("{Control>}{Alt>}-{/Alt}{/Control}");
 			expect(mockedAdjustZoom).toHaveBeenCalledWith(-ZOOM_STEP);
 		});
 

--- a/src/mainview/__tests__/keymap.test.ts
+++ b/src/mainview/__tests__/keymap.test.ts
@@ -43,6 +43,24 @@ describe("keymap registry", () => {
 		expect(shortcutKeysFor(spec, false)).toBe("Ctrl+K");
 	});
 
+	it("documents both route-history shortcut aliases", () => {
+		expect(APP_SHORTCUTS.find((s) => s.id === "back")?.keys).toEqual({
+			mac: "⌘[ / Ctrl+-",
+			other: "Ctrl+[ / Ctrl+-",
+		});
+		expect(APP_SHORTCUTS.find((s) => s.id === "forward")?.keys).toEqual({
+			mac: "⌘] / Ctrl+Shift+-",
+			other: "Ctrl+] / Ctrl+Shift+-",
+		});
+	});
+
+	it("keeps zoom-out distinct from the Ctrl-minus navigation alias", () => {
+		expect(APP_SHORTCUTS.find((s) => s.id === "zoom-out")?.keys).toEqual({
+			mac: "⌘-",
+			other: "Ctrl+Alt+-",
+		});
+	});
+
 	it("shortcutsInCategory returns only that category, in registry order", () => {
 		const nav = shortcutsInCategory("navigation");
 		expect(nav.length).toBeGreaterThan(0);

--- a/src/mainview/i18n/translations/en/tips.ts
+++ b/src/mainview/i18n/translations/en/tips.ts
@@ -9,7 +9,7 @@ const tips = {
 	"tip.diffReviewPersists.title": "Your diff review is saved",
 	"tip.diffReviewPersists.body": "Inline review comments are kept for a few days, so a clipboard mishap won't lose them — reopen the diff to copy again, or hit \"Reset review\" to clear.",
 	"tip.backForwardNav.title": "Jump back and forward",
-	"tip.backForwardNav.body": "Use the ‹ › arrows top-left, ⌘[ / ⌘], or your mouse side buttons to retrace where you've been.",
+	"tip.backForwardNav.body": "Use the ‹ › arrows, ⌘[ / ⌘], Ctrl+- / Ctrl+Shift+-, or mouse side buttons to retrace your steps.",
 	"tip.statusAgeBadge.title": "How long since the move",
 	"tip.statusAgeBadge.body": "Each Active Tasks card shows a live age badge (5m, 7h, 13d) — hover it for the exact status-change time.",
 	"tip.cmdSwitchKeepsView.title": "Switch projects, keep your view",

--- a/src/mainview/i18n/translations/es/tips.ts
+++ b/src/mainview/i18n/translations/es/tips.ts
@@ -9,7 +9,7 @@ const tips = {
 	"tip.diffReviewPersists.title": "Tu revisión se guarda",
 	"tip.diffReviewPersists.body": "Los comentarios de revisión en línea se guardan unos días, así un descuido con el portapapeles no los pierde — reabre el diff y cópialos otra vez, o usa «Restablecer revisión».",
 	"tip.backForwardNav.title": "Salta atrás y adelante",
-	"tip.backForwardNav.body": "Usa las flechas ‹ › arriba a la izquierda, ⌘[ / ⌘] o los botones laterales del ratón para volver por donde estuviste.",
+	"tip.backForwardNav.body": "Usa las flechas ‹ ›, ⌘[ / ⌘], Ctrl+- / Ctrl+Shift+- o los botones laterales para volver sobre tus pasos.",
 	"tip.statusAgeBadge.title": "Cuánto desde el cambio",
 	"tip.statusAgeBadge.body": "Cada tarjeta de Active Tasks muestra una insignia de antigüedad en vivo (5m, 7h, 13d) — pasa el ratón para ver la hora exacta del cambio de estado.",
 	"tip.cmdSwitchKeepsView.title": "Cambia de proyecto sin perder la vista",

--- a/src/mainview/i18n/translations/ru/tips.ts
+++ b/src/mainview/i18n/translations/ru/tips.ts
@@ -9,7 +9,7 @@ const tips = {
 	"tip.diffReviewPersists.title": "Твоё ревью сохраняется",
 	"tip.diffReviewPersists.body": "Inline-комментарии ревью хранятся несколько дней, чтобы их не потерять при случайном затирании буфера — открой дифф и скопируй снова, или нажми «Сбросить ревью».",
 	"tip.backForwardNav.title": "Прыгай назад и вперёд",
-	"tip.backForwardNav.body": "Стрелки ‹ › слева вверху, ⌘[ / ⌘] или боковые кнопки мыши вернут тебя туда, где ты уже был.",
+	"tip.backForwardNav.body": "Стрелки ‹ ›, ⌘[ / ⌘], Ctrl+- / Ctrl+Shift+- или мышь вернут по шагам назад.",
 	"tip.statusAgeBadge.title": "Сколько прошло с момента перехода",
 	"tip.statusAgeBadge.body": "На каждой карточке Active Tasks есть живой бейдж возраста (5m, 7h, 13d) — наведи, чтобы увидеть точное время смены статуса.",
 	"tip.cmdSwitchKeepsView.title": "Меняй проект, сохраняя вид",

--- a/src/mainview/keymap.ts
+++ b/src/mainview/keymap.ts
@@ -67,8 +67,8 @@ export const APP_SHORTCUTS: ShortcutSpec[] = [
 	// ── Navigation ──
 	{ id: "go-to-project", keys: { mac: "⌘K", other: "Ctrl+K" }, descKey: "keymap.shortcut.goToProject", category: "navigation" },
 	{ id: "command-palette", keys: { mac: "⇧⌘P", other: "Ctrl+Shift+P" }, descKey: "keymap.shortcut.commandPalette", category: "navigation" },
-	{ id: "back", keys: { mac: "⌘[", other: "Ctrl+[" }, descKey: "keymap.shortcut.back", category: "navigation" },
-	{ id: "forward", keys: { mac: "⌘]", other: "Ctrl+]" }, descKey: "keymap.shortcut.forward", category: "navigation" },
+	{ id: "back", keys: { mac: "⌘[ / Ctrl+-", other: "Ctrl+[ / Ctrl+-" }, descKey: "keymap.shortcut.back", category: "navigation" },
+	{ id: "forward", keys: { mac: "⌘] / Ctrl+Shift+-", other: "Ctrl+] / Ctrl+Shift+-" }, descKey: "keymap.shortcut.forward", category: "navigation" },
 	{ id: "previous-variant", keys: { mac: "⇧⌘[", other: "Ctrl+Shift+[" }, descKey: "keymap.shortcut.previousVariant", category: "navigation" },
 	{ id: "next-variant", keys: { mac: "⇧⌘]", other: "Ctrl+Shift+]" }, descKey: "keymap.shortcut.nextVariant", category: "navigation" },
 	{ id: "switch-project", keys: { mac: "⌘1–9", other: "Ctrl+1–9" }, remoteKeys: { mac: "G then 1–9", other: "G then 1–9" }, descKey: "keymap.shortcut.switchProject", category: "navigation" },
@@ -89,7 +89,7 @@ export const APP_SHORTCUTS: ShortcutSpec[] = [
 	// ── View & Zoom ──
 	{ id: "settings", keys: { mac: "⌘,", other: "Ctrl+," }, descKey: "keymap.shortcut.settings", category: "view" },
 	{ id: "zoom-in", keys: { mac: "⌘=", other: "Ctrl+=" }, descKey: "keymap.shortcut.zoomIn", category: "view", scope: "desktop" },
-	{ id: "zoom-out", keys: { mac: "⌘-", other: "Ctrl+-" }, descKey: "keymap.shortcut.zoomOut", category: "view", scope: "desktop" },
+	{ id: "zoom-out", keys: { mac: "⌘-", other: "Ctrl+Alt+-" }, descKey: "keymap.shortcut.zoomOut", category: "view", scope: "desktop" },
 	{ id: "zoom-reset", keys: { mac: "⇧⌘0", other: "Ctrl+Shift+0" }, descKey: "keymap.shortcut.zoomReset", category: "view", scope: "desktop" },
 	{ id: "hard-refresh", keys: { mac: "⌘R", other: "Ctrl+R" }, descKey: "keymap.shortcut.hardRefresh", category: "view", scope: "desktop" },
 	{ id: "keyboard-shortcuts", keys: { mac: "⌘/", other: "Ctrl+/" }, descKey: "keymap.shortcut.keyboardShortcuts", category: "view" },

--- a/src/shared/application-menu.ts
+++ b/src/shared/application-menu.ts
@@ -648,7 +648,9 @@ function viewMenu(): ApplicationMenuItemConfig {
 			item({ label: "Keyboard Shortcuts (⌘/)", action: MENU_ACTIONS.helpKeyboardShortcuts }),
 			SEP,
 			item({ label: "Zoom In", action: MENU_ACTIONS.zoomIn, accelerator: "=" }),
-			item({ label: "Zoom Out", action: MENU_ACTIONS.zoomOut, accelerator: "-" }),
+			// Ctrl+- belongs to route history; keep zoom-out available through the
+			// renderer's Cmd+- / Ctrl+Alt+- shortcuts and this menu item.
+			item({ label: "Zoom Out (⌘- / Ctrl+Alt+-)", action: MENU_ACTIONS.zoomOut }),
 			// Reset Zoom moved off ⌘0 (now "Jump to Operations") to ⇧⌘0. Electrobun
 			// menu accelerators are single-char only (decision 044), so the ⇧⌘0 chord
 			// is owned by the renderer (App.tsx) and only hinted in the label here.


### PR DESCRIPTION
Summary:
- Add Ctrl+- and Ctrl+Shift+- aliases for route-history back and forward navigation.
- Preserve the existing bracket aliases and document all shortcuts in the keyboard-shortcuts overlay.
- Move non-macOS zoom-out to Ctrl+Alt+- so Ctrl+- remains unambiguous; Cmd+- remains on macOS.

Tests:
- bun run lint
- bun run test
- Browser QA verified both aliases and the shortcut overlay with no console errors.