### PR TITLE
Support stdin for long CLI text inputs

### DIFF
--- a/change-logs/2026/07/15/feature-cli-task-create-stdin.md
+++ b/change-logs/2026/07/15/feature-cli-task-create-stdin.md
@@ -1,1 +1,1 @@
-`dev3 task create` now accepts `--description -` and reads the full task description from stdin, preserving multiline Markdown without shell quoting. Existing inline, positional, and `@file` description inputs remain supported.
+`dev3 task create` now accepts `--description -` and reads the full task description from stdin, preserving multiline Markdown without shell quoting. The same stdin convention now covers task description updates, note content, and automation prompts; existing inline, positional, and `@file` inputs remain supported.

--- a/change-logs/2026/07/15/feature-cli-task-create-stdin.md
+++ b/change-logs/2026/07/15/feature-cli-task-create-stdin.md
@@ -1,0 +1,1 @@
+`dev3 task create` now accepts `--description -` and reads the full task description from stdin, preserving multiline Markdown without shell quoting. Existing inline, positional, and `@file` description inputs remain supported.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -7,6 +7,7 @@ Task and project are auto-detected from the worktree; pass `--task <id>` / `--pr
 ## Conventions (dev3 tasks)
 
 - **Create an issue**: `dev3 task create --title "..." --description "..."` — lands in the To Do (`todo`) column. For multiline Markdown, pipe it with `--description -`, for example: `cat plan.md | dev3 task create --title "..." --description -`.
+- **Write long text**: `task update --description -`, `note add --content -`, and `automations ... --prompt -` read the body from stdin; `@file` remains the file-based alternative.
 - **Read an issue**: `dev3 task show --task <id> --notes --history` (always prints the current overview; `--notes` inlines note bodies, `--history` shows the title/overview change log).
 - **List issues**: `dev3 tasks list [--status <s>] [--label <id>] [--limit <n>] [--offset <n>]` (newest first). Statuses: `todo`, `in-progress`, `user-questions`, `review-by-ai`, `review-by-user`.
 - **Comment on an issue**: `dev3 note add "..." --task <id>` — per-task notes are the durable comment/scratchpad analog; they survive worktree teardown and are surfaced to future agents.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,7 +6,7 @@ Task and project are auto-detected from the worktree; pass `--task <id>` / `--pr
 
 ## Conventions (dev3 tasks)
 
-- **Create an issue**: `dev3 task create --title "..." --description "..."` — lands in the To Do (`todo`) column.
+- **Create an issue**: `dev3 task create --title "..." --description "..."` — lands in the To Do (`todo`) column. For multiline Markdown, pipe it with `--description -`, for example: `cat plan.md | dev3 task create --title "..." --description -`.
 - **Read an issue**: `dev3 task show --task <id> --notes --history` (always prints the current overview; `--notes` inlines note bodies, `--history` shows the title/overview change log).
 - **List issues**: `dev3 tasks list [--status <s>] [--label <id>] [--limit <n>] [--offset <n>]` (newest first). Statuses: `todo`, `in-progress`, `user-questions`, `review-by-ai`, `review-by-user`.
 - **Comment on an issue**: `dev3 note add "..." --task <id>` — per-task notes are the durable comment/scratchpad analog; they survive worktree teardown and are surfaced to future agents.

--- a/src/cli/__tests__/automations.test.ts
+++ b/src/cli/__tests__/automations.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleAutomations } from "../commands/automations";
+import type { ParsedArgs } from "../args";
+import type { CliResponse } from "../../shared/types";
+
+vi.mock("../socket-client", () => ({
+	sendRequest: vi.fn(),
+}));
+
+vi.mock("../stdin", () => ({
+	readStdin: vi.fn(),
+}));
+
+import { sendRequest } from "../socket-client";
+import { readStdin } from "../stdin";
+
+const mockSend = vi.mocked(sendRequest);
+const mockReadStdin = vi.mocked(readStdin);
+const SOCKET = "/tmp/test.sock";
+
+function okResp(data: unknown): CliResponse {
+	return { id: "test-id", ok: true, data };
+}
+
+function args(positional: string[] = [], flags: Record<string, string> = {}): ParsedArgs {
+	return { positional, flags };
+}
+
+const AUTOMATION = {
+	id: "automation-1111-2222-3333-444444444444",
+	name: "Release digest",
+	enabled: true,
+	nextRunAt: null,
+};
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	mockSend.mockReset();
+	mockReadStdin.mockReset();
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+});
+
+describe("automation prompt stdin", () => {
+	it("reads --prompt - when creating an automation", async () => {
+		const prompt = '# Release\n\nKeep **Markdown** and "quotes" intact.';
+		mockReadStdin.mockResolvedValue(prompt);
+		mockSend.mockResolvedValue(okResp(AUTOMATION));
+
+		await handleAutomations(
+			"create",
+			args([], {
+				project: "proj-001",
+				name: "Release digest",
+				prompt: "-",
+				rrule: "FREQ=DAILY",
+			}),
+			SOCKET,
+			null,
+		);
+
+		expect(mockReadStdin).toHaveBeenCalledOnce();
+		expect(mockSend).toHaveBeenCalledWith(
+			SOCKET,
+			"automations.create",
+			expect.objectContaining({
+				projectId: "proj-001",
+				name: "Release digest",
+				prompt,
+				rrule: "FREQ=DAILY",
+			}),
+		);
+	});
+
+	it("reads --prompt - when updating an automation", async () => {
+		const prompt = "Run the release checklist.\n\n- Verify the build.";
+		mockReadStdin.mockResolvedValue(prompt);
+		mockSend.mockResolvedValue(okResp(AUTOMATION));
+
+		await handleAutomations(
+			"update",
+			args(["automation-1111"], { project: "proj-001", prompt: "-" }),
+			SOCKET,
+			null,
+		);
+
+		expect(mockReadStdin).toHaveBeenCalledOnce();
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "automations.update", {
+			projectId: "proj-001",
+			automationId: "automation-1111",
+			prompt,
+		});
+	});
+});

--- a/src/cli/__tests__/help.test.ts
+++ b/src/cli/__tests__/help.test.ts
@@ -48,8 +48,9 @@ describe("renderHelp — subcommand detail", () => {
 		const out = renderHelp("task", "create")!;
 		expect(out).toContain("dev3 task create — Create a new task in the To Do column.");
 		expect(out).toContain("Usage:");
-		expect(out).toContain('dev3 task create --title "..." [--description "..."]');
+		expect(out).toContain('dev3 task create --title "..." [--description "..." | --description -]');
 		expect(out).toContain("--title <text>");
+		expect(out).toContain("read it from stdin");
 		expect(out).toContain("Global options:");
 	});
 

--- a/src/cli/__tests__/help.test.ts
+++ b/src/cli/__tests__/help.test.ts
@@ -59,6 +59,13 @@ describe("renderHelp — subcommand detail", () => {
 		expect(out).toContain("dev3 note list — List a task's notes");
 		expect(out).not.toContain("Details:");
 	});
+
+	it("documents stdin for supported long-text fields", () => {
+		expect(renderHelp("task", "update")).toContain("--description -");
+		expect(renderHelp("note", "add")).toContain("read it from stdin");
+		expect(renderHelp("automations", "create")).toContain("--prompt -");
+		expect(renderHelp("automations", "update")).toContain("--prompt -");
+	});
 });
 
 describe("renderHelp — leaf command", () => {

--- a/src/cli/__tests__/note.test.ts
+++ b/src/cli/__tests__/note.test.ts
@@ -8,8 +8,14 @@ vi.mock("../socket-client", () => ({
 	sendRequest: vi.fn(),
 }));
 
+vi.mock("../stdin", () => ({
+	readStdin: vi.fn(),
+}));
+
 import { sendRequest } from "../socket-client";
+import { readStdin } from "../stdin";
 const mockSend = vi.mocked(sendRequest);
+const mockReadStdin = vi.mocked(readStdin);
 
 let stdoutOutput: string;
 let stderrOutput: string;
@@ -79,6 +85,7 @@ beforeEach(() => {
 		throw new Error(`EXIT_${_code ?? 0}`);
 	}) as ReturnType<typeof vi.spyOn>;
 	mockSend.mockReset();
+	mockReadStdin.mockReset();
 });
 
 afterEach(() => {
@@ -112,6 +119,17 @@ describe("note add", () => {
 
 		const params = mockSend.mock.calls[0]![2]!;
 		expect(params.content).toBe("Note via flag");
+	});
+
+	it("reads --content - from stdin without altering Markdown", async () => {
+		mockSend.mockResolvedValue(okResp(FAKE_TASK));
+		const markdown = 'Decision:\n\n- Keep "quoted" Markdown.';
+		mockReadStdin.mockResolvedValue(markdown);
+
+		await handleNote("add", args([], { content: "-", source: "user" }), SOCKET, CTX);
+
+		expect(mockReadStdin).toHaveBeenCalledOnce();
+		expect(mockSend.mock.calls[0]![2]!.content).toBe(markdown);
 	});
 
 	it("defaults source to ai", async () => {

--- a/src/cli/__tests__/stdin.test.ts
+++ b/src/cli/__tests__/stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+import { readStdin } from "../stdin";
+
+describe("readStdin", () => {
+	it("joins stream chunks and preserves UTF-8 Markdown", async () => {
+		const input = Readable.from([Buffer.from("# Plan\n\n"), Buffer.from('Quote: "keep me"\n')]);
+
+		expect(await readStdin(input)).toBe('# Plan\n\nQuote: "keep me"\n');
+	});
+
+	it("returns an empty string for empty input", async () => {
+		expect(await readStdin(Readable.from([]))).toBe("");
+	});
+});

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -392,6 +392,17 @@ describe("task update", () => {
 		expect(params.description).toBe("New description");
 	});
 
+	it("reads --description - from stdin without altering Markdown", async () => {
+		mockSend.mockResolvedValue(okResp(FAKE_TASK));
+		const markdown = '# Updated plan\n\nKeep **quotes**: "intact".';
+		mockReadStdin.mockResolvedValue(markdown);
+
+		await handleTask("update", args(["aaaaaaaa"], { description: "-" }), SOCKET, null);
+
+		expect(mockReadStdin).toHaveBeenCalledOnce();
+		expect(mockSend.mock.calls[0]![2]!.description).toBe(markdown);
+	});
+
 	it("updates both title and description at once", async () => {
 		mockSend.mockResolvedValue(okResp(FAKE_TASK));
 

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -4,13 +4,19 @@ import type { CliContext } from "../context";
 import type { ParsedArgs } from "../args";
 import type { Task, CliResponse } from "../../shared/types";
 
+vi.mock("../stdin", () => ({
+	readStdin: vi.fn(),
+}));
+
 // Mock sendRequest so we never hit a real socket
 vi.mock("../socket-client", () => ({
 	sendRequest: vi.fn(),
 }));
 
 import { sendRequest } from "../socket-client";
+import { readStdin } from "../stdin";
 const mockSend = vi.mocked(sendRequest);
+const mockReadStdin = vi.mocked(readStdin);
 
 let stdoutOutput: string;
 let stderrOutput: string;
@@ -72,6 +78,7 @@ beforeEach(() => {
 		throw new Error(`EXIT_${_code ?? 0}`);
 	}) as ReturnType<typeof vi.spyOn>;
 	mockSend.mockReset();
+	mockReadStdin.mockReset();
 });
 
 afterEach(() => {
@@ -983,6 +990,43 @@ describe("task create --description", () => {
 
 		const params = mockSend.mock.calls[0]![2]!;
 		expect(params).not.toHaveProperty("description");
+	});
+
+	it("reads --description - from stdin without altering Markdown", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+		const markdown = '# Release notes\n\nUse **bold** and quote: "quoted".\n';
+		mockReadStdin.mockResolvedValue(markdown);
+
+		await handleTask(
+			"create",
+			args([], { project: "proj-001", title: "Release notes", description: "-" }),
+			SOCKET,
+			null,
+		);
+
+		expect(mockReadStdin).toHaveBeenCalledOnce();
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.create", {
+			projectId: "proj-001",
+			title: "Release notes",
+			description: markdown,
+		});
+	});
+
+	it("uses the first stdin line as the title when --title is omitted", async () => {
+		mockSend.mockResolvedValue(okResp(createdTask));
+		const markdown = "Release notes\n\n- Preserve this line exactly.\n";
+		mockReadStdin.mockResolvedValue(markdown);
+
+		await handleTask(
+			"create",
+			args([], { project: "proj-001", description: "-" }),
+			SOCKET,
+			null,
+		);
+
+		const params = mockSend.mock.calls[0]![2]!;
+		expect(params.title).toBe("Release notes");
+		expect(params.description).toBe(markdown);
 	});
 });
 

--- a/src/cli/commands/automations.ts
+++ b/src/cli/commands/automations.ts
@@ -5,6 +5,7 @@ import { printTable, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 import { resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
+import { readStdin } from "../stdin";
 
 function requireProjectId(args: ParsedArgs, context: CliContext | null): string {
 	const projectId = resolveProjectId(args.flags.project, context);
@@ -105,11 +106,12 @@ async function createAutomation(args: ParsedArgs, socketPath: string, context: C
 	}
 
 	const name = (args.flags.name || args.positional[0] || template?.name || "").trim();
-	const prompt = args.flags.prompt || template?.prompt || "";
 	const rrule = args.flags.rrule || template?.rrule || "";
 	if (!name) exitUsage('Usage: dev3 automations create --name "..." --prompt "..." --rrule "FREQ=DAILY;BYHOUR=9" [--timezone <iana>] [--template shipped-report]');
-	if (!prompt) exitUsage("--prompt is required (or use --template). @file syntax works: --prompt @prompt.md");
 	if (!rrule) exitUsage('--rrule is required (or use --template), e.g. "FREQ=WEEKLY;BYDAY=FR;BYHOUR=17"');
+	const rawPrompt = args.flags.prompt;
+	const prompt = rawPrompt === "-" ? await readStdin() : rawPrompt || template?.prompt || "";
+	if (!prompt) exitUsage("--prompt is required (or use --template). @file syntax works: --prompt @prompt.md");
 
 	const timezone = args.flags.timezone || args.flags.tz || Intl.DateTimeFormat().resolvedOptions().timeZone;
 	const params: Record<string, unknown> = { projectId, name, prompt, rrule, timezone };
@@ -133,7 +135,9 @@ async function updateAutomation(args: ParsedArgs, socketPath: string, context: C
 
 	const params: Record<string, unknown> = { projectId, automationId };
 	if (args.flags.name !== undefined) params.name = args.flags.name;
-	if (args.flags.prompt !== undefined) params.prompt = args.flags.prompt;
+	if (args.flags.prompt !== undefined) {
+		params.prompt = args.flags.prompt === "-" ? await readStdin() : args.flags.prompt;
+	}
 	if (args.flags.rrule !== undefined) params.rrule = args.flags.rrule;
 	const tz = args.flags.timezone ?? args.flags.tz;
 	if (tz !== undefined) params.timezone = tz;

--- a/src/cli/commands/note.ts
+++ b/src/cli/commands/note.ts
@@ -4,6 +4,7 @@ import { printTable, printDetail, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
+import { readStdin } from "../stdin";
 
 const VALID_SOURCES: NoteSource[] = ["user", "ai"];
 
@@ -32,7 +33,8 @@ async function addNote(args: ParsedArgs, socketPath: string, context: CliContext
 	}
 	const taskId = expandShortId(rawTaskId, context);
 
-	const content = (args.positional[0] || args.flags.content || "").trim();
+	const rawContent = args.positional[0] || args.flags.content || "";
+	const content = (rawContent === "-" ? await readStdin() : rawContent).trim();
 	if (!content) {
 		exitUsage("Content is required. Usage: dev3 note add \"your note text\"");
 	}

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -7,6 +7,7 @@ import { printDetail, exitError, exitUsage } from "../output";
 import type { ParsedArgs } from "../args";
 import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
+import { readStdin } from "../stdin";
 
 // Statuses that destroy the worktree + terminal are not directly reachable via
 // CLI. `completed` is special-cased: it becomes a blocking approval request the
@@ -146,7 +147,11 @@ async function createTask(args: ParsedArgs, socketPath: string, context: CliCont
 		exitUsage("--project <id> is required (or run from inside a worktree)");
 	}
 
-	const positionalContent = args.positional[0]?.trim();
+	// A literal "-" is the conventional CLI sentinel for reading the value
+	// from stdin. Read it only for the description flag so title-only creates
+	// never consume an interactive shell's input unexpectedly.
+	const stdinDescription = args.flags.description === "-" ? await readStdin() : undefined;
+	const positionalContent = stdinDescription ?? args.positional[0]?.trim();
 
 	let title = args.flags.title?.trim();
 	if (!title && positionalContent) {
@@ -158,7 +163,7 @@ async function createTask(args: ParsedArgs, socketPath: string, context: CliCont
 		exitUsage("--title is required");
 	}
 
-	const description = args.flags.description || positionalContent;
+	const description = args.flags.description === "-" ? stdinDescription : args.flags.description || positionalContent;
 
 	const params: Record<string, unknown> = { projectId, title };
 	if (description) params.description = description;

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -199,7 +199,8 @@ async function updateTask(args: ParsedArgs, socketPath: string, context: CliCont
 		params.title = trimmed;
 	}
 	if (rawDesc !== undefined) {
-		params.description = rawDesc.trim();
+		const description = rawDesc === "-" ? await readStdin() : rawDesc;
+		params.description = description.trim();
 	}
 	const rawPriority = args.flags.priority;
 	if (rawPriority !== undefined) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -76,11 +76,11 @@ const COMMANDS: CommandHelp[] = [
 			},
 			{
 				name: "update",
-				usage: 'dev3 task update [<id>] [--title "..."] [--description "..."] [--priority P0..P4]',
+				usage: 'dev3 task update [<id>] [--title "..."] [--description "..." | --description -] [--priority P0..P4]',
 				summary: "Update a task's title, description, and/or priority.",
 				details: [
 					"--title <text>        New title (cannot be empty).",
-					'--description <text>  New description ("" clears it).',
+					'--description <text>  New description ("" clears it); use - to read it from stdin.',
 					"--priority <P0..P4>   Set importance (P0 highest … P4 lowest); applies to the whole variant group.",
 					"                      Only set priority when the user asks — never on your own initiative.",
 					"--force               Overwrite a user-edited title (diagnostics only — avoid).",
@@ -123,9 +123,12 @@ const COMMANDS: CommandHelp[] = [
 		subcommands: [
 			{
 				name: "add",
-				usage: 'dev3 note add "..." [--task <id>] [--source user|ai]',
+				usage: 'dev3 note add "..." [--content "..."] [--task <id>] [--source user|ai]',
 				summary: "Add a note to a task.",
-				details: ["--source user|ai   Note author (default ai)."],
+				details: [
+					"--content <text>  Alternative to positional content; use - to read it from stdin.",
+					"--source user|ai   Note author (default ai).",
+				],
 			},
 			{
 				name: "list",
@@ -208,7 +211,7 @@ const COMMANDS: CommandHelp[] = [
 			},
 			{
 				name: "create",
-				usage: 'dev3 automations create --name "..." --prompt "..." --rrule "FREQ=DAILY;BYHOUR=9" [--timezone <iana>]',
+				usage: 'dev3 automations create --name "..." [--prompt "..." | --prompt -] --rrule "FREQ=DAILY;BYHOUR=9" [--timezone <iana>]',
 				summary: "Create an automation.",
 				details: [
 					'--rrule        RFC 5545 subset: FREQ=HOURLY|DAILY|WEEKLY|MONTHLY, INTERVAL, BYDAY, BYMONTHDAY, BYHOUR, BYMINUTE.',
@@ -217,13 +220,14 @@ const COMMANDS: CommandHelp[] = [
 					"--catch-up     skip | runOnce — what to do with runs missed while the app was offline (default skip).",
 					"--template     Pre-fill from a built-in template (see: dev3 automations templates).",
 					"--disabled     Create paused.",
-					"--prompt @file reads the prompt from a file.",
+					"--prompt <text>  Use @file for a file or - to read the prompt from stdin.",
 				],
 			},
 			{
 				name: "update",
-				usage: "dev3 automations update <id> [--name ...] [--prompt ...] [--rrule ...] [--timezone ...] [--enable|--disable]",
+				usage: "dev3 automations update <id> [--name ...] [--prompt ... | --prompt -] [--rrule ...] [--timezone ...] [--enable|--disable]",
 				summary: "Update fields / pause / resume.",
+				details: ["--prompt <text>  Use @file for a file or - to read the prompt from stdin."],
 			},
 			{
 				name: "delete",

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -65,11 +65,11 @@ const COMMANDS: CommandHelp[] = [
 			},
 			{
 				name: "create",
-				usage: 'dev3 task create --title "..." [--description "..."]',
+				usage: 'dev3 task create --title "..." [--description "..." | --description -]',
 				summary: "Create a new task in the To Do column.",
 				details: [
 					"--title <text>        Task title (required).",
-					"--description <text>  Longer description (optional).",
+					"--description <text>  Longer description (optional); use - to read it from stdin.",
 					"Positional content (or @file) becomes the description; its first line",
 					"is used as the title when --title is omitted.",
 				],

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -38,9 +38,9 @@ Commands:
   dev3 task show [--task <id>] [--notes] [--history]  Full task details
                                          (always shows current overview; --notes inlines note bodies, --history shows title/overview change log)
   dev3 task move [--task <id>] --status <status>  Change task status
-  dev3 task update [--task <id>] --title "..." [--description "..."]  Update title/description
+  dev3 task update [--task <id>] --title "..." [--description "..." | --description -]  Update title/description
   dev3 task create --title "..." [--description "..." | --description -]  Create a new task (To Do)
-  dev3 note add "..." [--task <id>] [--source user]  Add note to a task
+  dev3 note add "..." [--content "..."] [--task <id>] [--source user]  Add note to a task
   dev3 note list [--task <id>]          List notes
   dev3 note show <id> [--task <task>]   Show one note's full body (8-char prefix works)
   dev3 note delete <id> [--task <task>] Delete note (8-char prefix works)
@@ -56,8 +56,8 @@ Commands:
   dev3 tasks list [--status <s>] [--label <id>] [--limit <n>] [--offset <n>]  List tasks (newest first, default 50)
   dev3 automations list                 List project automations (scheduled agent runs)
   dev3 automations show <id>            Automation details + run history
-  dev3 automations create --name "..." --prompt "..." --rrule "FREQ=DAILY;BYHOUR=9" [--template shipped-report]
-  dev3 automations update <id> [--enable|--disable] [--rrule ...] [--prompt ...]
+  dev3 automations create --name "..." [--prompt "..." | --prompt -] --rrule "FREQ=DAILY;BYHOUR=9" [--template shipped-report]
+  dev3 automations update <id> [--enable|--disable] [--rrule ...] [--prompt ... | --prompt -]
   dev3 automations delete <id>          Delete an automation
   dev3 automations run <id>             Fire an automation now (creates its task)
   dev3 automations templates            List built-in templates
@@ -91,7 +91,7 @@ Statuses: todo, in-progress, user-questions, review-by-ai, review-by-user
 
 @file syntax: any argument starting with @ reads from file (e.g. @plan.md).
   Double @@ for literal @.
-  Use --description - with task create to read a long description from stdin.
+  Use - for stdin on task descriptions, note content, and automation prompts.
 
 Options: --project <id> (override auto-detect), --task <id> / --task-id <id> (override task target), --help, --version
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -39,7 +39,7 @@ Commands:
                                          (always shows current overview; --notes inlines note bodies, --history shows title/overview change log)
   dev3 task move [--task <id>] --status <status>  Change task status
   dev3 task update [--task <id>] --title "..." [--description "..."]  Update title/description
-  dev3 task create --title "..." [--description "..."]  Create a new task (To Do)
+  dev3 task create --title "..." [--description "..." | --description -]  Create a new task (To Do)
   dev3 note add "..." [--task <id>] [--source user]  Add note to a task
   dev3 note list [--task <id>]          List notes
   dev3 note show <id> [--task <task>]   Show one note's full body (8-char prefix works)
@@ -91,6 +91,7 @@ Statuses: todo, in-progress, user-questions, review-by-ai, review-by-user
 
 @file syntax: any argument starting with @ reads from file (e.g. @plan.md).
   Double @@ for literal @.
+  Use --description - with task create to read a long description from stdin.
 
 Options: --project <id> (override auto-detect), --task <id> / --task-id <id> (override task target), --help, --version
 

--- a/src/cli/stdin.ts
+++ b/src/cli/stdin.ts
@@ -1,0 +1,12 @@
+import { Buffer } from "node:buffer";
+
+/** Read all UTF-8 text from a CLI input stream without changing its contents. */
+export async function readStdin(
+	input: AsyncIterable<Uint8Array | string> = process.stdin,
+): Promise<string> {
+	const chunks: Uint8Array[] = [];
+	for await (const chunk of input) {
+		chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+	}
+	return Buffer.concat(chunks).toString("utf-8");
+}


### PR DESCRIPTION
## Summary

- Support `--description -` for task creation and updates.
- Support `--content -` for notes and `--prompt -` for automation creation and updates.
- Document the stdin convention and cover the new paths with CLI tests.
- Preserve existing inline, positional, and `@file` inputs; multiline `message` delivery remains outside this change.

## Tests

- `bun run lint`
- `bun run test`