### PR TITLE
Fix editor focus during file drops

### DIFF
--- a/change-logs/2026/07/15/fix-chat-focus-on-file-drop.md
+++ b/change-logs/2026/07/15/fix-chat-focus-on-file-drop.md
@@ -1,0 +1,1 @@
+File drops now restore focus to the editor immediately before the asynchronous upload begins, keeping chat and task-description inputs ready for continued typing while attachments are saved.

--- a/src/mainview/components/__tests__/ScheduleMessageModal.test.tsx
+++ b/src/mainview/components/__tests__/ScheduleMessageModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { act, render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ScheduleMessageModal from "../ScheduleMessageModal";
 import { I18nProvider } from "../../i18n";
@@ -10,6 +10,8 @@ vi.mock("../../rpc", () => ({
 		request: {
 			scheduleMessage: vi.fn().mockResolvedValue({ id: "t1", scheduledMessages: [] }),
 			tmuxLayout: vi.fn().mockResolvedValue({ sessionName: "dev3-t1", exists: true, windows: [], panes: [] }),
+			uploadFileBase64: vi.fn(),
+			readImageBase64: vi.fn().mockResolvedValue(null),
 		},
 	},
 }));
@@ -37,6 +39,22 @@ function renderModal(initialText?: string) {
 		</I18nProvider>,
 	);
 	return { dispatch, onClose };
+}
+
+function makeFileList(files: File[]): FileList {
+	return {
+		length: files.length,
+		item: (index: number) => files[index] ?? null,
+		...Object.fromEntries(files.map((file, index) => [index, file])),
+	} as unknown as FileList;
+}
+
+function dispatchDrop(target: Element, files: File[]) {
+	const event = new MouseEvent("drop", { bubbles: true, cancelable: true });
+	Object.defineProperty(event, "dataTransfer", {
+		value: { files: makeFileList(files), dropEffect: "copy" as const },
+	});
+	act(() => target.dispatchEvent(event));
 }
 
 afterEach(() => {
@@ -71,6 +89,25 @@ describe("ScheduleMessageModal", () => {
 	it("seeds the textarea from initialText (composer draft)", () => {
 		renderModal("draft from composer");
 		expect((screen.getByTestId("schedule-message-input") as HTMLTextAreaElement).value).toBe("draft from composer");
+	});
+
+	it("keeps the message field focused while a dropped image uploads", async () => {
+		let resolveUpload!: (result: { path: string }) => void;
+		mockedApi.request.uploadFileBase64.mockImplementation(() => new Promise((resolve) => {
+			resolveUpload = resolve;
+		}) as never);
+		renderModal();
+		const textarea = screen.getByTestId("schedule-message-input") as HTMLTextAreaElement;
+		textarea.focus();
+		textarea.blur();
+
+		dispatchDrop(textarea.parentElement!, [new File(["image"], "photo.png", { type: "image/png" })]);
+
+		await waitFor(() => expect(mockedApi.request.uploadFileBase64).toHaveBeenCalled());
+		expect(textarea).toHaveFocus();
+		await act(async () => resolveUpload({ path: "/tmp/photo.png" }));
+		await waitFor(() => expect(textarea.value).toBe("/tmp/photo.png\n"));
+		expect(textarea).toHaveFocus();
 	});
 
 	it("offers a concrete pane target when live panes exist", async () => {

--- a/src/mainview/hooks/useFileDrop.ts
+++ b/src/mainview/hooks/useFileDrop.ts
@@ -45,6 +45,15 @@ export function useFileDrop(
 			const files = Array.from(e.dataTransfer.files);
 			if (!files.length) return;
 
+			// Native file drops can blur the editor before this event arrives. Restore
+			// focus before the asynchronous upload so the composer stays ready for the
+			// next keystroke while the attachment is being saved.
+			const dropZone = e.currentTarget as HTMLElement;
+			const editor = dropZone.matches("textarea, input, [contenteditable='true']")
+				? dropZone
+				: dropZone.querySelector<HTMLElement>("textarea, input, [contenteditable='true']");
+			editor?.focus();
+
 			void Promise.all(files.map(async (file) => {
 				try {
 					const uploadedPath = await uploadDroppedFile(projectId, file);


### PR DESCRIPTION
## Summary

- Restore focus to the text editor before asynchronous file uploads begin.
- Apply the shared behavior to task creation, task editing, notes, and scheduled agent messages.
- Add regression coverage for the scheduled-message composer.

## Testing

- TypeScript: no errors in src/
- [mainview] PASS (2441) FAIL (0)
[mainview] rtk vitest run --exclude '**/shift-keys-e2e*' exited with code 0
[bun] PASS (2545) FAIL (0) skipped (1)
[bun] rtk vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*' exited with code 0
[cli] PASS (559) FAIL (0)
[cli] rtk vitest run --config vitest.config.cli.ts exited with code 0
- Browser QA verified that dropping an image keeps the scheduled-message editor focused and produced no console errors.