### PR TITLE
Keep Active Tasks focused on repeat clicks

### DIFF
--- a/change-logs/2026/07/15/fix-active-task-sidebar-focus.md
+++ b/change-logs/2026/07/15/fix-active-task-sidebar-focus.md
@@ -1,0 +1,1 @@
+Clicking the already-focused task in Active Tasks no longer returns to the Kanban board. The same no-op behavior now applies to the compact browser task strip, preserving the current terminal focus.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -396,17 +396,16 @@ function ActiveTasksSidebar({
 
 	function handleTaskClick(task: Task) {
 		if (task.shuttingDown) return;
-		preview.close();
 		const targetProjectId = task.projectId || project.id;
 		if (task.id === activeTaskId && targetProjectId === project.id) {
-			navigate({ screen: "project", projectId: project.id });
-		} else {
-			navigate({
-				screen: "project",
-				projectId: targetProjectId,
-				activeTaskId: task.id,
-			});
+			return;
 		}
+		preview.close();
+		navigate({
+			screen: "project",
+			projectId: targetProjectId,
+			activeTaskId: task.id,
+		});
 	}
 
 	const projectLabels = project.labels ?? [];

--- a/src/mainview/components/ActiveTasksStrip.tsx
+++ b/src/mainview/components/ActiveTasksStrip.tsx
@@ -51,14 +51,13 @@ function ActiveTasksStrip({
 	function handleTaskClick(task: Task) {
 		if (task.shuttingDown) return;
 		if (task.id === activeTaskId) {
-			navigate({ screen: "project", projectId: project.id });
-		} else {
-			navigate({
-				screen: "project",
-				projectId: project.id,
-				activeTaskId: task.id,
-			});
+			return;
 		}
+		navigate({
+			screen: "project",
+			projectId: project.id,
+			activeTaskId: task.id,
+		});
 	}
 
 	return (

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -126,6 +126,29 @@ function makeTask(overrides?: Partial<Task>): Task {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
+	it("keeps the focused task open when clicked again", async () => {
+		const user = userEvent.setup();
+		const navigate = vi.fn();
+		render(
+			<I18nProvider>
+				<ActiveTasksSidebar
+					project={project}
+					tasks={[makeTask()]}
+					activeTaskId="t1"
+					dispatch={vi.fn()}
+					navigate={navigate}
+					agents={[claudeAgent]}
+					bellCounts={new Map()}
+					taskPorts={new Map()}
+				/>
+			</I18nProvider>,
+		);
+
+		await user.click(screen.getByText("Привет! как сам?"));
+		expect(navigate).not.toHaveBeenCalled();
+		expect(terminalPreview.close).not.toHaveBeenCalled();
+	});
+
 	it("shows agent-first identity with compact config and variant dots", () => {
 		const navigate = vi.fn();
 		render(

--- a/src/mainview/components/__tests__/ActiveTasksStrip.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksStrip.test.tsx
@@ -72,6 +72,26 @@ describe("ActiveTasksStrip", () => {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
+	it("keeps the focused task open when clicked again", async () => {
+		const navigate = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<I18nProvider>
+				<ActiveTasksStrip
+					tasks={[makeTask(), makeTask({ id: "t2" })]}
+					project={project}
+					activeTaskId="t1"
+					navigate={navigate}
+					agents={[geminiAgent]}
+					bellCounts={new Map()}
+				/>
+			</I18nProvider>,
+		);
+
+		await user.click(screen.getAllByRole("button", { name: "Привет! как сам?" })[0]);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
 	it("renders compact agent summary and variant dots", () => {
 		render(
 			<I18nProvider>


### PR DESCRIPTION
## Summary

- Keep repeated clicks on the already-focused Active Tasks item as a no-op.
- Preserve terminal focus and terminal previews instead of returning to the Kanban board.
- Apply the same behavior to the compact browser task strip.
- Add regression coverage and a changelog entry.

## Tests

- `bun run lint`
- `bun run test`
- Browser QA of opening a task and clicking it again from Active Tasks