### PR TITLE
Show completed and canceled columns on mobile

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-status-columns.md
+++ b/change-logs/2026/07/15/fix-mobile-status-columns.md
@@ -1,0 +1,1 @@
+Keep the Completed and Cancelled Kanban columns reachable in the narrow carousel while preserving explicit user column-collapse choices. The desktop board keeps its existing compact default presentation.

--- a/decisions/132-mobile-status-column-visibility.md
+++ b/decisions/132-mobile-status-column-visibility.md
@@ -1,0 +1,21 @@
+# 132 — Preserve default Kanban columns in the mobile carousel
+
+## Context
+
+The narrow Kanban carousel filtered every collapsed column. Because Completed and Cancelled are collapsed by default for desktop density, mobile users could not reach either lifecycle column.
+
+## Investigation
+
+`KanbanBoard` used `useColumnCollapse().isCollapsed()` as the carousel filter, while `useColumnCollapse` did not distinguish defaults from user choices. The browser repro showed a 390px pager with seven columns and no Completed or Cancelled pages.
+
+## Decision
+
+Track explicit user-collapsed columns in a separate project-local storage key and expose `isUserCollapsed`. The carousel filters only that set; desktop rendering continues to use the full collapse state, and legacy stored collapse arrays treat built-in defaults as responsive defaults.
+
+## Risks
+
+Users who intentionally collapsed Completed or Cancelled before this distinction existed may see those columns again on mobile once, but their desktop preference remains unchanged. The extra localStorage key is renderer-only and can be safely ignored by older app versions.
+
+## Alternatives considered
+
+Filtering out only Completed and Cancelled would fix the default case but ignore explicit collapse intent. Removing collapse filtering entirely would make all user-hidden columns reappear, so explicit tracking preserves the existing mobile preference rule.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -586,11 +586,12 @@ function KanbanBoard({
 		);
 	}
 
-	// Carousel mode: one column per screen. Collapsed columns are excluded from
-	// the rotation (already user-hidden); empty columns stay for position stability.
+	// Carousel mode: one column per screen. Built-in collapsed defaults remain
+	// reachable on mobile; only columns explicitly collapsed by the user are
+	// excluded from rotation. Empty columns stay for position stability.
 	const carouselColumns: CarouselColumn[] = isCarousel
 		? orderedColumns
-				.filter((slot) => !collapseState.isCollapsed(slot.type === "builtin" ? slot.status : slot.col.id))
+				.filter((slot) => !collapseState.isUserCollapsed(slot.type === "builtin" ? slot.status : slot.col.id))
 				.map((slot) =>
 					slot.type === "builtin"
 						? {

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -555,6 +555,13 @@ describe("mobile carousel mode", () => {
 		// Position text "n / N" is present
 		expect(screen.getByText(/^\d+ \/ \d+$/)).toBeTruthy();
 	});
+
+	it("keeps completed and cancelled columns in the mobile carousel", async () => {
+		await renderBoardWith();
+
+		expect(screen.getByText("Completed")).toBeTruthy();
+		expect(screen.getByText("Cancelled")).toBeTruthy();
+	});
 });
 
 describe("create custom column from board (issue #222)", () => {

--- a/src/mainview/hooks/__tests__/useColumnCollapse.test.ts
+++ b/src/mainview/hooks/__tests__/useColumnCollapse.test.ts
@@ -10,6 +10,8 @@ describe("useColumnCollapse", () => {
 		const { result } = renderHook(() => useColumnCollapse("proj-1"));
 		expect(result.current.isCollapsed("completed")).toBe(true);
 		expect(result.current.isCollapsed("cancelled")).toBe(true);
+		expect(result.current.isUserCollapsed("completed")).toBe(false);
+		expect(result.current.isUserCollapsed("cancelled")).toBe(false);
 	});
 
 	it("todo and active statuses are expanded by default", () => {
@@ -58,5 +60,18 @@ describe("useColumnCollapse", () => {
 		expect(result.current.isCollapsed("in-progress")).toBe(false);
 		act(() => result.current.toggle("in-progress"));
 		expect(result.current.isCollapsed("in-progress")).toBe(true);
+		expect(result.current.isUserCollapsed("in-progress")).toBe(true);
+	});
+
+	it("keeps user collapse separate from built-in defaults", () => {
+		const { result } = renderHook(() => useColumnCollapse("proj-1"));
+
+		act(() => result.current.toggle("completed")); // open the default-collapsed column
+		expect(result.current.isCollapsed("completed")).toBe(false);
+		expect(result.current.isUserCollapsed("completed")).toBe(false);
+
+		act(() => result.current.toggle("completed")); // explicitly collapse it again
+		expect(result.current.isCollapsed("completed")).toBe(true);
+		expect(result.current.isUserCollapsed("completed")).toBe(true);
 	});
 });

--- a/src/mainview/hooks/useColumnCollapse.ts
+++ b/src/mainview/hooks/useColumnCollapse.ts
@@ -7,20 +7,52 @@ function storageKey(projectId: string) {
 	return `dev3-kanban-collapsed-${projectId}`;
 }
 
-function loadCollapsed(projectId: string): Set<string> {
+function userCollapsedStorageKey(projectId: string) {
+	return `dev3-kanban-user-collapsed-${projectId}`;
+}
+
+function parseStoredSet(raw: string | null): Set<string> | null {
+	if (!raw) return null;
 	try {
-		const raw = localStorage.getItem(storageKey(projectId));
-		if (raw) return new Set(JSON.parse(raw));
-	} catch {}
-	return new Set(DEFAULT_COLLAPSED);
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) && parsed.every((value) => typeof value === "string")
+			? new Set(parsed)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+interface LoadedCollapseState {
+	collapsed: Set<string>;
+	userCollapsed: Set<string>;
+}
+
+function loadCollapsed(projectId: string): LoadedCollapseState {
+	const storedCollapsed = parseStoredSet(localStorage.getItem(storageKey(projectId)));
+	const collapsed = storedCollapsed ?? new Set(DEFAULT_COLLAPSED);
+	const storedUserCollapsed = parseStoredSet(localStorage.getItem(userCollapsedStorageKey(projectId)));
+	if (storedUserCollapsed) return { collapsed, userCollapsed: storedUserCollapsed };
+
+	// Older versions only persisted the complete collapsed set. Treat the built-in
+	// defaults as responsive defaults so they remain reachable in the mobile carousel.
+	const userCollapsed = new Set(
+		[...collapsed].filter((columnId) => !DEFAULT_COLLAPSED.includes(columnId as TaskStatus)),
+	);
+	return { collapsed, userCollapsed };
 }
 
 function saveCollapsed(projectId: string, collapsed: Set<string>) {
 	localStorage.setItem(storageKey(projectId), JSON.stringify([...collapsed]));
 }
 
+function saveUserCollapsed(projectId: string, userCollapsed: Set<string>) {
+	localStorage.setItem(userCollapsedStorageKey(projectId), JSON.stringify([...userCollapsed]));
+}
+
 export interface ColumnCollapseState {
 	isCollapsed: (columnId: string) => boolean;
+	isUserCollapsed: (columnId: string) => boolean;
 	toggle: (columnId: string) => void;
 	dragExpandHandlers: (columnId: string) => {
 		onDragEnter: () => void;
@@ -30,8 +62,9 @@ export interface ColumnCollapseState {
 }
 
 export function useColumnCollapse(projectId: string): ColumnCollapseState {
-	const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed(projectId));
+	const [collapseState, setCollapseState] = useState<LoadedCollapseState>(() => loadCollapsed(projectId));
 	const [dragExpanded, setDragExpanded] = useState<Set<string>>(new Set());
+	const { collapsed, userCollapsed } = collapseState;
 
 	const collapsedRef = useRef(collapsed);
 	collapsedRef.current = collapsed;
@@ -40,7 +73,7 @@ export function useColumnCollapse(projectId: string): ColumnCollapseState {
 
 	// Re-load when projectId changes
 	useEffect(() => {
-		setCollapsed(loadCollapsed(projectId));
+		setCollapseState(loadCollapsed(projectId));
 		setDragExpanded(new Set());
 	}, [projectId]);
 
@@ -60,18 +93,27 @@ export function useColumnCollapse(projectId: string): ColumnCollapseState {
 		return collapsed.has(columnId);
 	}, [collapsed, dragExpanded]);
 
+	const isUserCollapsed = useCallback((columnId: string) => {
+		if (dragExpanded.has(columnId)) return false;
+		return userCollapsed.has(columnId);
+	}, [dragExpanded, userCollapsed]);
+
 	const toggle = useCallback((columnId: string) => {
-		setCollapsed((prev) => {
-			const next = new Set(prev);
-			if (next.has(columnId)) {
-				next.delete(columnId);
+		setCollapseState((prev) => {
+			const nextCollapsed = new Set(prev.collapsed);
+			const nextUserCollapsed = new Set(prev.userCollapsed);
+			if (nextCollapsed.has(columnId)) {
+				nextCollapsed.delete(columnId);
+				nextUserCollapsed.delete(columnId);
 			} else {
-				next.add(columnId);
+				nextCollapsed.add(columnId);
+				nextUserCollapsed.add(columnId);
 			}
-			persist(next);
-			return next;
+			persist(nextCollapsed);
+			saveUserCollapsed(projectId, nextUserCollapsed);
+			return { collapsed: nextCollapsed, userCollapsed: nextUserCollapsed };
 		});
-	}, [persist]);
+	}, [persist, projectId]);
 
 	const dragExpandHandlers = useCallback((columnId: string) => ({
 		onDragEnter: () => {
@@ -107,6 +149,6 @@ export function useColumnCollapse(projectId: string): ColumnCollapseState {
 	}), []);
 
 	return useMemo(() => ({
-		isCollapsed, toggle, dragExpandHandlers,
-	}), [isCollapsed, toggle, dragExpandHandlers]);
+		isCollapsed, isUserCollapsed, toggle, dragExpandHandlers,
+	}), [isCollapsed, isUserCollapsed, toggle, dragExpandHandlers]);
 }


### PR DESCRIPTION
## Summary

- Keep Completed and Cancelled reachable in the narrow Kanban carousel.
- Preserve explicitly collapsed-column preferences while treating built-in defaults as responsive defaults.
- Add regression coverage, changelog, and decision record.

## Tests

- bun run lint
- bun run test
- Browser QA at 390px: pager exposes and navigates to Completed and Cancelled; no console errors.