### PR TITLE
Fix mobile browser menu spacing

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-browser-menu-gap.md
+++ b/change-logs/2026/07/15/fix-mobile-browser-menu-gap.md
@@ -1,0 +1,1 @@
+Removed the standalone browser application-menu row from narrow/mobile layouts, reclaiming 32px above the global header while keeping the existing More bottom sheet and command-palette touch entry available.

--- a/decisions/132-mobile-browser-menu-density.md
+++ b/decisions/132-mobile-browser-menu-density.md
@@ -1,0 +1,19 @@
+## Context
+
+The browser-mode application menu bar occupied a 32px row on phone-sized viewports. Its narrow form duplicated the GlobalHeader `More` bottom sheet and command-palette touch entry, while reducing the vertical space available to the primary screen.
+
+## Investigation
+
+The mobile header already folds utility actions into `GlobalHeader` and exposes the command palette as a touch action. The browser menu remains available on wider remote layouts, and no native desktop menu is affected.
+
+## Decision
+
+Hide `AppMenuBar` below the shared 768px narrow breakpoint. Keep the component and shared menu definition unchanged for wide browser layouts; narrow actions continue through the existing header sheet and object-specific surfaces.
+
+## Risks
+
+Any action that is only present in the application menu must remain reachable through the narrow command palette, header sheet, or its owning object surface. The AppMenuBar component test and browser QA cover the removed row and preserved wide rendering.
+
+## Alternatives considered
+
+Keeping the 32px row with a single hamburger preserved menu parity but wasted scarce mobile height and duplicated the existing touch entry. Moving all application-menu items into the header would add new header chrome and duplicate the shared menu taxonomy.

--- a/docs/ux/PRODUCT_UX_BIBLE.md
+++ b/docs/ux/PRODUCT_UX_BIBLE.md
@@ -377,6 +377,7 @@ Mobile's hardest gap: **the keyboard-first nav layer is dead on a touchscreen, a
 Doctrine:
 - **The breadcrumb spine stays the touch nav backbone**: logo→dashboard, project name→board, project chevron→switcher dropdown, back/forward. These must remain reachable (not pushed off-screen by a long task title) — give the project switcher a touch-sized target (≥44px) and a `right-0` fallback so the dropdown never clips.
 - **The command palette gains a touch entry on narrow** (a single search/jump affordance) and a responsive width. Because the native menu is gone in remote, the **action palette / per-object action sheets become the canonical action surface on mobile** — every action that on desktop lives only in the native menu must be reachable on mobile via a palette entry or an object action sheet. This is the one sanctioned exception to "palettes are keyboard-only / no button" — on narrow, a touch entry is mandatory, not button-creep.
+- **The browser application menu bar is a wide-layout surface**: hide its standalone row below 768px so the existing GlobalHeader `More` bottom sheet and command palette remain the compact touch entry points; desktop/browser menu parity is unchanged.
 - **No feature may be touch-unreachable.** If an action's only desktop path is a keyboard shortcut or the native menu, it MUST have a touch path on narrow (action sheet, palette, or inline control).
 
 ### 12.5 Overlay primitive — `BottomSheet` (new, mandated) — `Proposed`

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -191,7 +191,7 @@ ux_architecture:
       filtering: "Drop role items (clipboard/window/quit — browser owns them), actions not in menuRouter.BROWSER_HANDLED_ACTIONS (bun-only: new-window/check-for-updates/devtools/zoom/open-logs/remote-QR), and NOT_YET_IMPLEMENTED roadmap items. Context-gated items render greyed."
       dispatch: "handleMenuAction (same router as native menu + command palette)"
       labels: "English, sourced from the shared menu definition — parity with the native menu (which is not i18n'd); documented i18n exception."
-      responsive: "Collapses to a single ☰ button below 640px (mobile remote)."
+      responsive: "Visible in wide browser/remote layouts; hidden below 768px so the GlobalHeader More bottom sheet and command palette own the narrow touch action surface."
       budget:
         max_top_level_menus: 7   # mirrors the native top-levels minus native-only role menus (Edit/Window)
         dropdown_length: "unbounded — it is the overflow/expert surface"

--- a/src/mainview/components/AppMenuBar.tsx
+++ b/src/mainview/components/AppMenuBar.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApplicationMenuItemConfig } from "electrobun/bun";
 import { buildApplicationMenu, isComingSoonAction, type MenuContext } from "../../shared/application-menu";
+import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { BROWSER_HANDLED_ACTIONS } from "../menuRouter";
 import { isMac } from "../utils/platform";
 import { useT } from "../i18n";
+import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 
 /**
  * Browser-mode application menu bar.
@@ -100,19 +102,6 @@ function formatAccelerator(accel: string): string {
 	return `${prefix}${accel.length === 1 ? accel.toUpperCase() : accel}`;
 }
 
-function useNarrow(maxWidth = 640): boolean {
-	return useSyncExternalStore(
-		(cb) => {
-			if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => {};
-			const mql = window.matchMedia(`(max-width:${maxWidth}px)`);
-			mql.addEventListener("change", cb);
-			return () => mql.removeEventListener("change", cb);
-		},
-		() => (typeof window !== "undefined" && typeof window.matchMedia === "function" ? window.matchMedia(`(max-width:${maxWidth}px)`).matches : false),
-		() => false,
-	);
-}
-
 interface DropdownProps {
 	nodes: MenuNode[];
 	onRun: (action: string) => void;
@@ -181,9 +170,11 @@ interface AppMenuBarProps {
 
 export default function AppMenuBar({ context, onAction }: AppMenuBarProps) {
 	const t = useT();
-	const narrow = useNarrow();
+	const narrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	const menus = useMemo(() => buildBrowserMenu(context), [context]);
-	// `openIndex` is the open top-level menu in wide mode; `-1` is the compact ≡ menu.
+	// The wide browser menu is an app-level overflow surface. On narrow screens
+	// GlobalHeader owns the single More action sheet and its touch command-palette
+	// entry, so rendering another row would only consume scarce vertical space.
 	const [openIndex, setOpenIndex] = useState<number | null>(null);
 	const rootRef = useRef<HTMLDivElement>(null);
 
@@ -214,31 +205,9 @@ export default function AppMenuBar({ context, onAction }: AppMenuBarProps) {
 		};
 	}, [openIndex, close]);
 
-	if (menus.length === 0) return null;
+	if (menus.length === 0 || narrow) return null;
 
 	const topLevel = menus.filter((m): m is Extract<MenuNode, { kind: "submenu" }> => m.kind === "submenu");
-
-	// Compact: collapse all top-level menus behind a single ≡ button.
-	if (narrow) {
-		const open = openIndex === -1;
-		const asSubmenus: MenuNode[] = topLevel.map((m) => ({ kind: "submenu", label: m.label, children: m.children }));
-		return (
-			<div ref={rootRef} role="menubar" aria-label={t("menubar.label")} data-collapse-on-compose className="relative flex items-center h-8 px-1 bg-base border-b border-edge shrink-0">
-				<button
-					type="button"
-					role="menuitem"
-					aria-haspopup="menu"
-					aria-expanded={open}
-					aria-label={t("menubar.openMenu")}
-					onClick={() => setOpenIndex(open ? null : -1)}
-					className={`flex items-center justify-center w-8 h-6 rounded text-fg-3 hover:text-fg hover:bg-elevated ${open ? "bg-elevated text-fg" : ""}`}
-				>
-					<span className="text-base leading-none">{"☰"}</span>
-				</button>
-				{open && <Dropdown nodes={asSubmenus} onRun={run} />}
-			</div>
-		);
-	}
 
 	return (
 		<div ref={rootRef} role="menubar" aria-label={t("menubar.label")} data-collapse-on-compose className="relative flex items-center h-8 px-1 gap-0.5 bg-base border-b border-edge shrink-0">

--- a/src/mainview/components/__tests__/AppMenuBar.test.tsx
+++ b/src/mainview/components/__tests__/AppMenuBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "../../i18n";
@@ -66,6 +66,34 @@ describe("buildBrowserMenu", () => {
 });
 
 describe("AppMenuBar", () => {
+	const initialInnerWidth = window.innerWidth;
+	const initialMatchMedia = window.matchMedia;
+
+	function mockViewport(width: number) {
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+		Object.defineProperty(window, "matchMedia", {
+			configurable: true,
+			value: vi.fn((query: string) => {
+				const match = query.match(/max-width:\s*(\d+)/);
+				return {
+					matches: match ? width <= Number(match[1]) : false,
+					media: query,
+					addEventListener: vi.fn(),
+					removeEventListener: vi.fn(),
+					addListener: vi.fn(),
+					removeListener: vi.fn(),
+					dispatchEvent: vi.fn(),
+				};
+			}),
+		});
+	}
+
+	beforeEach(() => mockViewport(1024));
+	afterEach(() => {
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: initialInnerWidth });
+		Object.defineProperty(window, "matchMedia", { configurable: true, value: initialMatchMedia });
+	});
+
 	function renderBar(onAction = vi.fn()) {
 		render(
 			<I18nProvider>
@@ -103,5 +131,11 @@ describe("AppMenuBar", () => {
 		const pull = await screen.findByRole("menuitem", { name: /Pull main/ });
 		await user.click(pull);
 		expect(onAction).not.toHaveBeenCalled();
+	});
+
+	it("does not reserve a menu row on narrow viewports", () => {
+		mockViewport(390);
+		renderBar();
+		expect(screen.queryByRole("menubar")).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- Hide the standalone browser application-menu row below the shared 768px mobile breakpoint.
- Keep mobile actions available through the GlobalHeader More sheet and command palette.
- Add narrow viewport regression coverage and update UX decision docs.

## Validation
- `bun run lint`
- `bun run test`
- Browser QA at 390x844 with no console errors