### PR TITLE
Pause inactive toast timers and route overflow to task attention

### DIFF
--- a/change-logs/2026/07/15/fix-toast-timer-overflow.md
+++ b/change-logs/2026/07/15/fix-toast-timer-overflow.md
@@ -1,0 +1,1 @@
+Toast timers now pause while a renderer is hidden, unfocused, hovered, or focused, resume from their remaining budget, and cap each visible stack at five entries. Task-scoped overflow evictions now feed the existing deduplicated task attention badge while ordinary dismissal and unscoped overflow remain silent.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -29,7 +29,7 @@ import Changelog from "./components/Changelog";
 import GaugeDemo from "./components/gauges/GaugeDemo";
 import ProductivityStatsView from "./components/ProductivityStatsView";
 import ViewportLab from "./components/ViewportLab";
-import { setToastSuppressed, ToastHost, toast } from "./toast";
+import { setToastSuppressed, ToastHost, toast, type ToastEntry } from "./toast";
 import StuckPreparationPopover from "./components/StuckPreparationPopover";
 import FolderPickerHost from "./components/FolderPickerModal";
 import KeyboardShortcutsModal, { type ShortcutsTab } from "./components/KeyboardShortcutsModal";
@@ -97,6 +97,10 @@ function findVisibleSearchInput(): HTMLElement | null {
 
 function App() {
 	const [state, dispatch] = useAppState();
+	const handleToastOverflow = useCallback((entry: ToastEntry) => {
+		if (!entry.taskId) return;
+		dispatch({ type: "addBell", taskId: entry.taskId, reason: entry.message, force: true });
+	}, [dispatch]);
 	const t = useT();
 	const [, setLocale] = useLocale();
 	const [terminalImmersive, setTerminalImmersive] = useState(false);
@@ -1165,7 +1169,7 @@ function App() {
 			const context = taskSeq !== undefined
 				? [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ")
 				: undefined;
-			toast[level](message, { onClick, context });
+			toast[level](message, { onClick, context, taskId: taskId ?? undefined });
 		}
 		window.addEventListener("rpc:cliToast", onCliToast);
 		return () => window.removeEventListener("rpc:cliToast", onCliToast);
@@ -1546,7 +1550,7 @@ function App() {
 	// Notify user when a column-agent launch fails (custom columns have no automatic fallback)
 	useEffect(() => {
 		function onColumnAgentFailed(e: Event) {
-			const { columnName, error } = (e as CustomEvent).detail as {
+			const { taskId, columnName, error } = (e as CustomEvent).detail as {
 				taskId: string;
 				projectId: string;
 				columnName: string;
@@ -1554,7 +1558,7 @@ function App() {
 			};
 			// The task is parked in the target column with no running agent; surface the
 			// failure so the user can relaunch (move out and back in) or fix the column config.
-			toast.error(t("kanban.columnAgentFailed", { columnName, error }));
+			toast.error(t("kanban.columnAgentFailed", { columnName, error }), { taskId });
 		}
 		window.addEventListener("rpc:columnAgentFailed", onColumnAgentFailed);
 		return () => window.removeEventListener("rpc:columnAgentFailed", onColumnAgentFailed);
@@ -1565,13 +1569,13 @@ function App() {
 	// the real error so the user isn't left with a misleading "[session ended]".
 	useEffect(() => {
 		function onTaskPreparationFailed(e: Event) {
-			const { taskTitle, error } = (e as CustomEvent).detail as {
+			const { taskId, taskTitle, error } = (e as CustomEvent).detail as {
 				taskId: string;
 				projectId: string;
 				taskTitle: string;
 				error: string;
 			};
-			toast.error(t("kanban.taskPreparationFailed", { taskTitle, error }));
+			toast.error(t("kanban.taskPreparationFailed", { taskTitle, error }), { taskId });
 		}
 		window.addEventListener("rpc:taskPreparationFailed", onTaskPreparationFailed);
 		return () => window.removeEventListener("rpc:taskPreparationFailed", onTaskPreparationFailed);
@@ -2266,6 +2270,7 @@ function App() {
 			<ConfirmHost />
 			{imageViewer && (
 				<TaskImageViewer
+					taskId={imageViewer.taskId}
 					images={imageViewer.images}
 					initialIndex={imageViewer.index}
 					onClose={() => setImageViewer(null)}
@@ -2278,7 +2283,7 @@ function App() {
 			)}
 			{/* Toasts are transient feedback, not immersive chrome; notification toasts
 			    must remain clickable so their handler can exit fullscreen first. */}
-			<ToastHost />
+			<ToastHost onTaskOverflow={handleToastOverflow} />
 		</div>
 	);
 

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -979,7 +979,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 							try {
 								if (!localStorage.getItem(TERMINAL_COPY_HINT_SEEN_KEY)) {
 									localStorage.setItem(TERMINAL_COPY_HINT_SEEN_KEY, "1");
-									toast.info(tRef.current("terminal.copyHint"), { durationMs: 8000 });
+								toast.info(tRef.current("terminal.copyHint"), { durationMs: 8000, taskId });
 								}
 							} catch {
 								// localStorage unavailable — skip the hint, copy still worked.
@@ -1463,7 +1463,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					return uploadedPath ? uploadedPath.replace(/ /g, "\\ ") : null;
 				} catch (err) {
 					console.error(`[TerminalView] file upload failed for "${f.name}":`, err);
-					toast.error(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
+					toast.error(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }), { taskId });
 					return null;
 				}
 			}),

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -102,12 +102,18 @@ vi.mock("../components/Changelog", () => ({
 	default: (_props: { navigate: unknown; goBack: unknown; canGoBack: unknown }) => <div data-testid="changelog-screen" />,
 }));
 vi.mock("../components/ProjectView", () => ({
-	default: (props: { projectId: string; activeTaskId?: string; taskView?: boolean }) => (
+	default: (props: {
+		projectId: string;
+		activeTaskId?: string;
+		taskView?: boolean;
+		bellCounts?: Map<string, number>;
+	}) => (
 		<div
 			data-testid="project-screen"
 			data-project-id={props.projectId}
 			data-active-task-id={props.activeTaskId ?? ""}
 			data-task-view={props.taskView ? "true" : "false"}
+			data-bell-count={String(props.bellCounts?.get("t-overflow") ?? 0)}
 		/>
 	),
 }));
@@ -763,6 +769,64 @@ describe("App keyboard shortcuts", () => {
 
 			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
 			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+		});
+	});
+
+	describe("toast overflow attention routing", () => {
+		const oneProject = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+
+		function dispatchToast(message: string) {
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliToast", {
+					detail: { taskId: "t-overflow", projectId: "p1", message, level: "info" },
+				}));
+			});
+		}
+
+		it("routes task identity from renderer to forced attention on eviction", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			for (let index = 1; index <= 6; index += 1) dispatchToast(`Overflow ${index}`);
+
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-bell-count", "1"));
+			expect(screen.queryByText("Overflow 1")).not.toBeInTheDocument();
+			expect(screen.getByText("Overflow 6")).toBeInTheDocument();
+		});
+
+		it("does not double-count image or artifact attention when their toasts overflow", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliShowImage", {
+					detail: {
+						taskId: "t-overflow",
+						projectId: "p1",
+						images: [{ id: "img-1", storedPath: "/tmp/image.png", originalPath: "/tmp/image.png", name: "image.png", mime: "image/png", bytes: 1, createdAt: 0 }],
+						newCount: 1,
+					},
+				}));
+				window.dispatchEvent(new CustomEvent("rpc:cliShowArtifact", {
+					detail: {
+						taskId: "t-overflow",
+						projectId: "p1",
+						artifacts: [{ id: "artifact-1", storedPath: "/tmp/artifact.html", name: "artifact.html", mime: "text/html", bytes: 1, createdAt: 0 }],
+						newCount: 1,
+					},
+				}));
+			});
+			for (let index = 1; index <= 5; index += 1) dispatchToast(`Overflow ${index}`);
+
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-bell-count", "2"));
 		});
 	});
 

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -798,6 +798,25 @@ describe("reducer", () => {
 		expect(state.bellReasons.get("t1")).toEqual(["r3", "r4", "r5", "r6", "r7"]);
 	});
 
+	it("addBell: forced attention bypasses suppression for the focused task", () => {
+		const state: AppState = {
+			...initialState,
+			route: { screen: "task", projectId: "p1", taskId: "t1" },
+		};
+		const next = reducer(state, { type: "addBell", taskId: "t1", reason: "Overflow", force: true });
+		expect(next.bellCounts.get("t1")).toBe(1);
+		expect(next.bellReasons.get("t1")).toEqual(["Overflow"]);
+	});
+
+	it("addBell: forced attention counts every event and moves duplicate reasons to newest", () => {
+		let state = initialState;
+		for (const reason of ["one", "two", "three", "four", "five", "three", "six"]) {
+			state = reducer(state, { type: "addBell", taskId: "t1", reason, force: true });
+		}
+		expect(state.bellCounts.get("t1")).toBe(7);
+		expect(state.bellReasons.get("t1")).toEqual(["two", "four", "five", "three", "six"]);
+	});
+
 	it("addBell: without reason leaves bellReasons untouched", () => {
 		const next = reducer(initialState, { type: "addBell", taskId: "t1" });
 		expect(next.bellCounts.get("t1")).toBe(1);

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -2,8 +2,29 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setToastSuppressed, ToastHost, toast } from "../toast";
 
+function setRendererActivity(visible: boolean, focused: boolean): void {
+	Object.defineProperty(document, "visibilityState", {
+		configurable: true,
+		value: visible ? "visible" : "hidden",
+	});
+	Object.defineProperty(document, "hasFocus", {
+		configurable: true,
+		value: () => focused,
+	});
+	act(() => {
+		document.dispatchEvent(new Event("visibilitychange"));
+		window.dispatchEvent(new Event(focused ? "focus" : "blur"));
+	});
+}
+
+beforeEach(() => {
+	setRendererActivity(true, true);
+});
+
 afterEach(() => {
-	setToastSuppressed(false);
+	act(() => setToastSuppressed(false));
+	vi.useRealTimers();
+	setRendererActivity(true, true);
 });
 
 describe("toast service", () => {
@@ -46,19 +67,130 @@ describe("toast service", () => {
 
 	it("auto-dismisses after the given duration", () => {
 		vi.useFakeTimers();
-		try {
-			render(<ToastHost />);
-			act(() => {
-				toast.error("Temporary", { durationMs: 5000 });
-			});
-			expect(screen.getByText("Temporary")).toBeInTheDocument();
-			act(() => {
-				vi.advanceTimersByTime(5000);
-			});
-			expect(screen.queryByText("Temporary")).not.toBeInTheDocument();
-		} finally {
-			vi.useRealTimers();
-		}
+		render(<ToastHost />);
+		act(() => {
+			toast.error("Temporary", { durationMs: 5000 });
+		});
+		expect(screen.getByText("Temporary")).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+		expect(screen.queryByText("Temporary")).not.toBeInTheDocument();
+	});
+
+	it("pauses a toast while the renderer is hidden and resumes its remaining time", () => {
+		vi.useFakeTimers();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Hidden", { durationMs: 5000 });
+			vi.advanceTimersByTime(2000);
+		});
+
+		setRendererActivity(false, false);
+		const progress = document.querySelector("[data-toast-progress]") as HTMLElement;
+		expect(progress.style.animationPlayState).toBe("paused");
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+		expect(screen.getByText("Hidden")).toBeInTheDocument();
+
+		setRendererActivity(true, true);
+		act(() => {
+			vi.advanceTimersByTime(2999);
+		});
+		expect(screen.getByText("Hidden")).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+		expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
+	});
+
+	it("pauses on window blur and starts background toasts with a full budget", () => {
+		vi.useFakeTimers();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Background", { durationMs: 4000 });
+		});
+		setRendererActivity(true, false);
+		const progress = document.querySelector("[data-toast-progress]") as HTMLElement;
+		expect(progress.style.animationPlayState).toBe("paused");
+		act(() => {
+			vi.advanceTimersByTime(10000);
+		});
+		expect(screen.getByText("Background")).toBeInTheDocument();
+
+		setRendererActivity(true, true);
+		act(() => {
+			vi.advanceTimersByTime(3999);
+		});
+		expect(screen.getByText("Background")).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+		expect(screen.queryByText("Background")).not.toBeInTheDocument();
+	});
+
+	it("pauses and resumes the affected toast while it is hovered", async () => {
+		const user = userEvent.setup();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Hover me", { durationMs: 60_000 });
+		});
+		const alert = screen.getByRole("alert");
+		await user.hover(alert);
+		expect(document.querySelector("[data-toast-progress]") as HTMLElement).toHaveStyle({ animationPlayState: "paused" });
+		await user.unhover(alert);
+		expect(document.querySelector("[data-toast-progress]") as HTMLElement).toHaveStyle({ animationPlayState: "running" });
+	});
+
+	it("pauses while a toast contains keyboard focus and resumes when focus leaves", async () => {
+		const user = userEvent.setup();
+		render(<ToastHost />);
+		act(() => toast.info("Focus me", { durationMs: 60_000 }));
+		await user.tab();
+		expect(screen.getByRole("button", { name: "Dismiss" })).toHaveFocus();
+		expect(document.querySelector("[data-toast-progress]") as HTMLElement).toHaveStyle({ animationPlayState: "paused" });
+		await user.tab();
+		expect(document.querySelector("[data-toast-progress]") as HTMLElement).toHaveStyle({ animationPlayState: "running" });
+	});
+
+	it("keeps five newest entries and evicts the oldest regardless of variant or interaction", async () => {
+		const user = userEvent.setup();
+		const onTaskOverflow = vi.fn();
+		render(<ToastHost onTaskOverflow={onTaskOverflow} />);
+		act(() => {
+			toast.error("Oldest", { durationMs: 60_000, taskId: "task-1" });
+		});
+		await user.hover(screen.getByRole("alert"));
+		act(() => {
+			toast.success("Second", { durationMs: 60_000 });
+			toast.warning("Third", { durationMs: 60_000 });
+			toast.info("Fourth", { durationMs: 60_000 });
+			toast.error("Fifth", { durationMs: 60_000 });
+			toast.success("Newest", { durationMs: 60_000 });
+		});
+		expect(screen.getAllByRole("alert")).toHaveLength(5);
+		expect(screen.queryByText("Oldest")).not.toBeInTheDocument();
+		expect(screen.getByText("Second")).toBeInTheDocument();
+		expect(screen.getByText("Newest")).toBeInTheDocument();
+		expect(onTaskOverflow).toHaveBeenCalledOnce();
+		expect(onTaskOverflow).toHaveBeenCalledWith(expect.objectContaining({ message: "Oldest", taskId: "task-1" }));
+	});
+
+	it("does not report unscoped, manually dismissed, or timed-out eviction", () => {
+		vi.useFakeTimers();
+		const onTaskOverflow = vi.fn();
+		const { unmount } = render(<ToastHost onTaskOverflow={onTaskOverflow} />);
+		act(() => {
+			toast.info("Manual", { durationMs: 1000 });
+		});
+		act(() => screen.getByRole("button", { name: "Dismiss" }).click());
+		act(() => {
+			toast.info("Timed", { durationMs: 1000 });
+			vi.advanceTimersByTime(1000);
+		});
+		expect(onTaskOverflow).not.toHaveBeenCalled();
+		unmount();
 	});
 
 	it("does not throw when no host is mounted", () => {
@@ -76,7 +208,7 @@ describe("toast service", () => {
 		expect(screen.queryByText("First queued")).not.toBeInTheDocument();
 		expect(screen.queryByText("Second queued")).not.toBeInTheDocument();
 
-		setToastSuppressed(false);
+		act(() => setToastSuppressed(false));
 		expect(await screen.findByText("First queued")).toBeInTheDocument();
 		expect(screen.getByText("Second queued")).toBeInTheDocument();
 	});

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -388,7 +388,7 @@ function ActiveTasksSidebar({
 				const changed = await api.request.setTaskPriority({ taskId: task.id, projectId: task.projectId, priority });
 				for (const changedTask of changed) dispatch({ type: "updateTask", task: changedTask });
 			} catch (err) {
-				toast.error(t("priority.failedSet", { error: String(err) }));
+				toast.error(t("priority.failedSet", { error: String(err) }), { taskId: task.id });
 			}
 		},
 		[dispatch, t],

--- a/src/mainview/components/ClosePanePicker.tsx
+++ b/src/mainview/components/ClosePanePicker.tsx
@@ -57,7 +57,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 		try {
 			layout = await api.request.tmuxLayout({ taskId });
 		} catch {
-			toast.error(t("tmux.pickPaneError"));
+			toast.error(t("tmux.pickPaneError"), { taskId });
 			return;
 		}
 		const activeWindow = layout.exists ? layout.windows.find((w) => w.active) ?? layout.windows[0] : undefined;
@@ -65,7 +65,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 			? layout.panes.filter((p) => p.windowIndex === activeWindow.index)
 			: [];
 		if (!activeWindow || winPanes.length === 0) {
-			toast.error(t("tmux.pickPaneError"));
+			toast.error(t("tmux.pickPaneError"), { taskId });
 			return;
 		}
 
@@ -165,7 +165,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 			try {
 				await api.request.tmuxKillPane({ taskId, paneId: box.paneId, force: true });
 			} catch {
-				toast.error(t("tmux.pickPaneError"));
+				toast.error(t("tmux.pickPaneError"), { taskId });
 			}
 			cancel();
 			return;
@@ -174,7 +174,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 		try {
 			await api.request.tmuxKillPane({ taskId, paneId: box.paneId });
 		} catch {
-			toast.error(t("tmux.pickPaneError"));
+			toast.error(t("tmux.pickPaneError"), { taskId });
 		}
 		cancel();
 	}

--- a/src/mainview/components/InlineRename.tsx
+++ b/src/mainview/components/InlineRename.tsx
@@ -59,7 +59,7 @@ export default function InlineRename({
 			trackEvent("task_renamed", { project_id: projectId });
 			setEditing(false);
 		} catch (err) {
-			toast.error(t("task.failedRename", { error: String(err) }));
+			toast.error(t("task.failedRename", { error: String(err) }), { taskId });
 		}
 		setSaving(false);
 		savingRef.current = false;

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -230,7 +230,7 @@ function KanbanBoard({
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
 			dispatch({ type: "updateTask", task });
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 		} finally {
 			setMovingTaskIds((prev) => {
 				const next = new Set(prev);

--- a/src/mainview/components/LabelPicker.tsx
+++ b/src/mainview/components/LabelPicker.tsx
@@ -23,6 +23,8 @@ interface LabelPickerProps {
 	/** Toggle a label on/off. The parent owns persistence (local state for a
 	 *  not-yet-created task, or an RPC for an existing one). */
 	onToggle: (labelId: string) => void;
+	/** Optional owning task for overflow attention fallback. */
+	taskId?: string;
 }
 
 function fuzzyMatch(text: string, query: string): boolean {
@@ -36,7 +38,7 @@ function fuzzyMatch(text: string, query: string): boolean {
 	return qi === q.length;
 }
 
-function LabelPicker({ project, dispatch, onClose, anchorEl, selectedIds, onToggle }: LabelPickerProps) {
+function LabelPicker({ project, dispatch, onClose, anchorEl, selectedIds, onToggle, taskId }: LabelPickerProps) {
 	const t = useT();
 	const [query, setQuery] = useState("");
 	const [pos, setPos] = useState({ top: 0, left: 0 });
@@ -122,7 +124,7 @@ function LabelPicker({ project, dispatch, onClose, anchorEl, selectedIds, onTogg
 			onToggle(label.id);
 			setQuery("");
 		} catch (err) {
-			toast.error(t("labels.failedCreate", { error: String(err) }));
+			toast.error(t("labels.failedCreate", { error: String(err) }), { taskId });
 		}
 		setSaving(false);
 	}

--- a/src/mainview/components/NoteItem.tsx
+++ b/src/mainview/components/NoteItem.tsx
@@ -26,9 +26,10 @@ interface NoteItemProps {
 	onSave: (content: string) => void;
 	onDelete: () => void;
 	projectId?: string;
+	taskId?: string;
 }
 
-export function NoteItem({ note, onSave, onDelete, projectId }: NoteItemProps) {
+export function NoteItem({ note, onSave, onDelete, projectId, taskId }: NoteItemProps) {
 	const t = useT();
 	const [value, setValue] = useState(note.content);
 	const isAi = note.source === "ai";
@@ -59,7 +60,7 @@ export function NoteItem({ note, onSave, onDelete, projectId }: NoteItemProps) {
 	}, [onSave]);
 
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(projectId ?? "", insertPath);
-	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(projectId ?? "", insertPath);
+	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(projectId ?? "", insertPath, taskId);
 
 	const handleRemovePath = useCallback((pathToRemove: string) => {
 		const next = removeImagePath(value, pathToRemove);

--- a/src/mainview/components/OpenInMenu.tsx
+++ b/src/mainview/components/OpenInMenu.tsx
@@ -28,11 +28,13 @@ interface OpenInMenuProps {
 	position: { top: number; left: number };
 	/** Worktree or file path to open */
 	path: string;
+	/** Optional owning task for overflow attention fallback. */
+	taskId?: string;
 	/** Called when the menu should close */
 	onClose: () => void;
 }
 
-export default function OpenInMenu({ position, path, onClose }: OpenInMenuProps) {
+export default function OpenInMenu({ position, path, taskId, onClose }: OpenInMenuProps) {
 	const t = useT();
 	const apps = useAvailableApps();
 	const menuRef = useRef<HTMLDivElement>(null);
@@ -83,7 +85,7 @@ export default function OpenInMenu({ position, path, onClose }: OpenInMenuProps)
 		try {
 			await api.request.openInApp({ appName: app.macAppName, path });
 		} catch (err) {
-			toast.error(t("openIn.failedOpen", { app: app.name, error: String(err) }));
+			toast.error(t("openIn.failedOpen", { app: app.name, error: String(err) }), { taskId });
 		}
 	}
 

--- a/src/mainview/components/ScheduleMessageModal.tsx
+++ b/src/mainview/components/ScheduleMessageModal.tsx
@@ -73,7 +73,7 @@ function ScheduleMessageModal({ task, project, dispatch, onClose, initialText }:
 	}, []);
 
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
-	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor);
+	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor, task.id);
 
 	// Load the task's live panes for the (optional) concrete-pane target. Failure
 	// is non-fatal — the default agent target always works.

--- a/src/mainview/components/ScheduledMessagesChip.tsx
+++ b/src/mainview/components/ScheduledMessagesChip.tsx
@@ -102,7 +102,7 @@ function ScheduledMessagesChip({ task, project, dispatch, placement = "up" }: Sc
 			const updated = await api.request.cancelScheduledMessage({ taskId: task.id, projectId: project.id, messageId });
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("task.scheduleCancelFailed", { error: String(err) }));
+			toast.error(t("task.scheduleCancelFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -113,7 +113,7 @@ function ScheduledMessagesChip({ task, project, dispatch, placement = "up" }: Sc
 			const updated = await api.request.sendScheduledMessageNow({ taskId: task.id, projectId: project.id, messageId });
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("task.sendNowFailed", { error: String(err) }));
+			toast.error(t("task.sendNowFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 

--- a/src/mainview/components/TaskArtifactViewer.tsx
+++ b/src/mainview/components/TaskArtifactViewer.tsx
@@ -9,6 +9,7 @@ interface TaskArtifactViewerProps {
 	artifacts: SharedArtifact[];
 	initialIndex: number;
 	onClose: () => void;
+	taskId?: string;
 }
 
 type ArtifactThemeMode = "follow" | "light" | "dark";
@@ -31,7 +32,7 @@ function downloadBase64(base64: string, mime: string, fileName: string): void {
 	setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
-export default function TaskArtifactViewer({ artifacts, initialIndex, onClose }: TaskArtifactViewerProps) {
+export default function TaskArtifactViewer({ artifacts, initialIndex, onClose, taskId }: TaskArtifactViewerProps) {
 	const t = useT();
 	const [index, setIndex] = useState(() => Math.max(0, Math.min(artifacts.length - 1, initialIndex)));
 	const [srcDoc, setSrcDoc] = useState<string | null>(null);
@@ -107,7 +108,7 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, onClose }:
 			const payload = await api.request.readArtifactDownload({ artifact: current });
 			downloadBase64(payload.base64, payload.mime, payload.fileName);
 		} catch {
-			toast.error(t("artifactViewer.downloadFailed"));
+			toast.error(t("artifactViewer.downloadFailed"), { taskId });
 		} finally {
 			setDownloading(false);
 		}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -116,7 +116,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			const updated = await api.request.cancelScheduledLaunch({ taskId: task.id, projectId: project.id });
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("task.scheduleCancelFailed", { error: String(err) }));
+			toast.error(t("task.scheduleCancelFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -133,7 +133,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			const changed = await api.request.setTaskPriority({ taskId: task.id, projectId: project.id, priority });
 			for (const t of changed) dispatch({ type: "updateTask", task: t });
 		} catch (err) {
-			toast.error(t("priority.failedSet", { error: String(err) }));
+			toast.error(t("priority.failedSet", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -145,7 +145,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			// no local dispatch needed beyond kicking off the RPC.
 			await api.request.startScheduledLaunchNow({ taskId: task.id, projectId: project.id });
 		} catch (err) {
-			toast.error(t("launch.failedLaunch", { error: String(err) }));
+			toast.error(t("launch.failedLaunch", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -277,7 +277,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			onTaskMoved(task.id);
 			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}`, agent_name: agentNameFromId(task.agentId) });
 		} catch (err) {
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 		}
 		setMoving(false);
 	}
@@ -298,7 +298,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			dispatch({ type: "removeTask", taskId: task.id });
 			trackEvent("task_deleted", { project_id: project.id });
 		} catch (err) {
-			toast.error(t("task.failedDelete", { error: String(err) }));
+			toast.error(t("task.failedDelete", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -313,7 +313,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 			setCancellingPreparation(false);
 			return;
 		}
@@ -752,6 +752,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 							<LabelPicker
 								project={project}
 								dispatch={dispatch}
+								taskId={task.id}
 								onClose={() => setPickerOpen(false)}
 								anchorEl={pickerAnchorRef.current}
 								selectedIds={taskLabelIds}
@@ -1101,6 +1102,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				<OpenInMenu
 					position={ctxMenuPos}
 					path={task.worktreePath}
+					taskId={task.id}
 					onClose={() => setCtxMenuOpen(false)}
 				/>
 			)}

--- a/src/mainview/components/TaskDetailModal.tsx
+++ b/src/mainview/components/TaskDetailModal.tsx
@@ -103,7 +103,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 	}, []);
 
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
-	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor);
+	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor, task.id);
 
 	async function handleSetPriority(priority: Task["priority"]) {
 		if (!priority) return;
@@ -111,7 +111,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			const changed = await api.request.setTaskPriority({ taskId: task.id, projectId: project.id, priority });
 			for (const t of changed) dispatch({ type: "updateTask", task: t });
 		} catch (err) {
-			toast.error(t("priority.failedSet", { error: String(err) }));
+			toast.error(t("priority.failedSet", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -132,7 +132,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			trackEvent("task_edited", { project_id: project.id });
 			setIsEditing(false);
 		} catch (err) {
-			toast.error(t("task.failedEdit", { error: String(err) }));
+			toast.error(t("task.failedEdit", { error: String(err) }), { taskId: task.id });
 		}
 		setSaving(false);
 	}
@@ -160,7 +160,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			trackEvent("task_renamed", { project_id: project.id });
 			setIsRenaming(false);
 		} catch (err) {
-			toast.error(t("task.failedRename", { error: String(err) }));
+			toast.error(t("task.failedRename", { error: String(err) }), { taskId: task.id });
 		}
 		setRenameSaving(false);
 	}
@@ -176,7 +176,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			dispatch({ type: "updateTask", task: updated });
 			setIsRenaming(false);
 		} catch (err) {
-			toast.error(t("task.failedRename", { error: String(err) }));
+			toast.error(t("task.failedRename", { error: String(err) }), { taskId: task.id });
 		}
 		setRenameSaving(false);
 	}
@@ -214,7 +214,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}`, agent_name: agentNameFromId(task.agentId) });
 			onClose();
 		} catch (err) {
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 		}
 		setMovingStatus(false);
 	}
@@ -253,7 +253,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			trackEvent("task_deleted", { project_id: project.id });
 			onClose();
 		} catch (err) {
-			toast.error(t("task.failedDelete", { error: String(err) }));
+			toast.error(t("task.failedDelete", { error: String(err) }), { taskId: task.id });
 			setDeleting(false);
 		}
 	}
@@ -267,7 +267,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("labels.failedSetLabels", { error: String(err) }));
+			toast.error(t("labels.failedSetLabels", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -284,7 +284,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("labels.failedSetLabels", { error: String(err) }));
+			toast.error(t("labels.failedSetLabels", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -300,7 +300,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("notes.failedAdd", { error: String(err) }));
+			toast.error(t("notes.failedAdd", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -327,7 +327,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("notes.failedDelete", { error: String(err) }));
+			toast.error(t("notes.failedDelete", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -572,6 +572,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 								<LabelPicker
 									project={project}
 									dispatch={dispatch}
+									taskId={task.id}
 									onClose={() => setPickerOpen(false)}
 									anchorEl={pickerAnchorRef.current}
 									selectedIds={task.labelIds ?? []}
@@ -794,6 +795,7 @@ function ArchivedView({
 									<NoteItem
 										key={note.id}
 										note={note}
+										taskId={task.id}
 										onSave={(content) => onUpdateNote(note.id, content)}
 										onDelete={() => onDeleteNote(note.id)}
 									/>

--- a/src/mainview/components/TaskImageViewer.tsx
+++ b/src/mainview/components/TaskImageViewer.tsx
@@ -8,6 +8,7 @@ interface TaskImageViewerProps {
 	images: SharedImage[];
 	initialIndex: number;
 	onClose: () => void;
+	taskId?: string;
 }
 
 const ICON = "'JetBrainsMono Nerd Font Mono'";
@@ -32,7 +33,7 @@ const TALL_RATIO = 2.2;
  * promoted to a hardware overlay plane that paints ABOVE any DOM scrim, so
  * without this the live terminal would shine through around the card.
  */
-export default function TaskImageViewer({ images, initialIndex, onClose }: TaskImageViewerProps) {
+export default function TaskImageViewer({ images, initialIndex, onClose, taskId }: TaskImageViewerProps) {
 	const t = useT();
 	const [index, setIndex] = useState(() => Math.max(0, Math.min(images.length - 1, initialIndex)));
 	// Cache of image id → data URL ("__error__" marks a failed load).
@@ -150,7 +151,7 @@ export default function TaskImageViewer({ images, initialIndex, onClose }: TaskI
 			await navigator.clipboard.writeText(current.storedPath);
 			setCopied(true);
 		} catch {
-			toast.error(t("imageViewer.copyFailed"));
+			toast.error(t("imageViewer.copyFailed"), { taskId });
 		}
 	};
 
@@ -214,7 +215,7 @@ export default function TaskImageViewer({ images, initialIndex, onClose }: TaskI
 					</button>
 					<button
 						type="button"
-						onClick={() => api.request.openImageFile({ path: current.storedPath }).catch(() => toast.error(t("imageViewer.openFailed")))}
+						onClick={() => api.request.openImageFile({ path: current.storedPath }).catch(() => toast.error(t("imageViewer.openFailed"), { taskId }))}
 						title={t("imageViewer.open")}
 						aria-label={t("imageViewer.open")}
 						className={iconBtn}

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -338,7 +338,7 @@ function TaskInfoPanel({
 			dispatch({ type: "updateTask", task: updated });
 			trackEvent("task_moved", { from_status: task.status, to_status: `custom:${customColumnId}`, agent_name: agentNameFromId(task.agentId) });
 		} catch (err) {
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 		}
 		setMovingStatus(false);
 	}
@@ -576,6 +576,7 @@ function TaskInfoPanel({
 		<OpenInMenu
 			position={fileOpenInMenu.pos}
 			path={fileOpenInMenu.path}
+			taskId={task.id}
 			onClose={() => setFileOpenInMenu(null)}
 		/>
 	) : null;

--- a/src/mainview/components/TaskPreparingView.tsx
+++ b/src/mainview/components/TaskPreparingView.tsx
@@ -48,7 +48,7 @@ function TaskPreparingView({ task, project, onCancelled }: TaskPreparingViewProp
 			const updated = await api.request.cancelTaskPreparation({ taskId: task.id, projectId: project.id });
 			onCancelled?.(updated);
 		} catch (err) {
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 			setCancelling(false);
 		}
 	}

--- a/src/mainview/components/TaskWorkspacePane.tsx
+++ b/src/mainview/components/TaskWorkspacePane.tsx
@@ -227,6 +227,7 @@ function TaskWorkspacePane({
 							style={{ width: isNarrow ? "100%" : artifactWidth }}
 						>
 							<TaskArtifactViewer
+								taskId={taskId}
 								artifacts={artifactViewer.artifacts}
 								initialIndex={artifactViewer.index}
 								onClose={onCloseArtifactViewer}

--- a/src/mainview/components/TerminalPreviewPopover.tsx
+++ b/src/mainview/components/TerminalPreviewPopover.tsx
@@ -107,7 +107,7 @@ function TerminalPreviewPopover({
 			}
 			setEditing(false);
 		} catch (err) {
-			toast.error(t("overview.saveFailed", { error: String(err) }));
+			toast.error(t("overview.saveFailed", { error: String(err) }), { taskId: taskId ?? undefined });
 		}
 		setSaving(false);
 	}, [taskId, projectId, value, effectiveOverview, aiOverview, t]);
@@ -120,7 +120,7 @@ function TerminalPreviewPopover({
 			setEditing(false);
 			setValue("");
 		} catch (err) {
-			toast.error(t("overview.saveFailed", { error: String(err) }));
+			toast.error(t("overview.saveFailed", { error: String(err) }), { taskId: taskId ?? undefined });
 		}
 		setSaving(false);
 	}, [taskId, projectId, t]);

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1070,7 +1070,7 @@ describe("TaskCard", () => {
 			await user.click(screen.getByText("Agent is Working"));
 
 			await waitFor(() => {
-				expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("second"));
+				expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("second"), { taskId: "t1" });
 			});
 		});
 
@@ -1124,7 +1124,7 @@ describe("TaskCard", () => {
 			await user.click(screen.getByLabelText("Delete"));
 
 			await waitFor(() => {
-				expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("delete failed"));
+				expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("delete failed"), { taskId: "t1" });
 			});
 		});
 	});

--- a/src/mainview/components/task-info-panel/TaskDevServer.tsx
+++ b/src/mainview/components/task-info-panel/TaskDevServer.tsx
@@ -165,7 +165,7 @@ export default function TaskDevServer({ task, project, isTaskActive }: TaskDevSe
 			setDevState(status?.running === false ? "stopped" : "running");
 		} catch (err) {
 			setDevState("stopped");
-			toast.error(t("infoPanel.devServerFailed", { error: String(err) }));
+			toast.error(t("infoPanel.devServerFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -228,7 +228,7 @@ export default function TaskDevServer({ task, project, isTaskActive }: TaskDevSe
 				await startDevServerNow();
 			}
 		} catch (err) {
-			toast.error(t("infoPanel.devServerFailed", { error: String(err) }));
+			toast.error(t("infoPanel.devServerFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -240,7 +240,7 @@ export default function TaskDevServer({ task, project, isTaskActive }: TaskDevSe
 			setDevState(status?.running === false ? "stopped" : "running");
 		} catch (err) {
 			setDevState("stopped");
-			toast.error(t("infoPanel.devServerFailed", { error: String(err) }));
+			toast.error(t("infoPanel.devServerFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -250,7 +250,7 @@ export default function TaskDevServer({ task, project, isTaskActive }: TaskDevSe
 		try {
 			await api.request.stopDevServer({ taskId: task.id, projectId: project.id });
 		} catch (err) {
-			toast.error(t("infoPanel.devServerFailed", { error: String(err) }));
+			toast.error(t("infoPanel.devServerFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 

--- a/src/mainview/components/task-info-panel/TaskNotes.tsx
+++ b/src/mainview/components/task-info-panel/TaskNotes.tsx
@@ -25,7 +25,7 @@ export default function TaskNotes({ task, project, dispatch }: TaskNotesProps) {
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("notes.failedAdd", { error: String(err) }));
+			toast.error(t("notes.failedAdd", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -52,7 +52,7 @@ export default function TaskNotes({ task, project, dispatch }: TaskNotesProps) {
 			});
 			dispatch({ type: "updateTask", task: updated });
 		} catch (err) {
-			toast.error(t("notes.failedDelete", { error: String(err) }));
+			toast.error(t("notes.failedDelete", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -76,6 +76,7 @@ export default function TaskNotes({ task, project, dispatch }: TaskNotesProps) {
 				<NoteItem
 					key={note.id}
 					note={note}
+					taskId={task.id}
 					onSave={(content) => handleUpdateNote(note.id, content)}
 					onDelete={() => handleDeleteNote(note.id)}
 					projectId={project.id}

--- a/src/mainview/components/task-info-panel/TaskOpenIn.tsx
+++ b/src/mainview/components/task-info-panel/TaskOpenIn.tsx
@@ -47,7 +47,7 @@ export default function TaskOpenIn({ task, project, isTaskActive, showFileBrowse
 				setYaziInstallPopup(true);
 			}
 		} catch (err) {
-			toast.error(t("infoPanel.fileBrowserFailed", { error: String(err) }));
+			toast.error(t("infoPanel.fileBrowserFailed", { error: String(err) }), { taskId: task.id });
 		}
 	}
 
@@ -72,6 +72,7 @@ export default function TaskOpenIn({ task, project, isTaskActive, showFileBrowse
 					<OpenInMenu
 						position={openInMenuPos}
 						path={task.worktreePath}
+						taskId={task.id}
 						onClose={() => setOpenInMenuOpen(false)}
 					/>
 				)}

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -106,7 +106,7 @@ export function useTaskBranchStatus({
 
 			if (!eligible) {
 				if (force) {
-					toast.info(t("infoPanel.mergeCheckNotMerged", { branch: baseBranch }));
+					toast.info(t("infoPanel.mergeCheckNotMerged", { branch: baseBranch }), { taskId: task.id });
 				}
 				return;
 			}
@@ -217,7 +217,7 @@ export function useTaskBranchStatus({
 				autoMerge,
 			});
 		} catch (err) {
-			toast.error(t("infoPanel.createPRFailed", { error: String(err) }));
+			toast.error(t("infoPanel.createPRFailed", { error: String(err) }), { taskId: task.id });
 		}
 		setCreatingPR(false);
 	}, [creatingPR, project.id, task.id, t]);
@@ -300,7 +300,7 @@ export function useTaskBranchStatus({
 			// user dismissed the popup earlier for this same merged head.
 			await offerMergeCompletionIfMerged(status, { force: true });
 		} catch (err) {
-			toast.error(t("infoPanel.refreshStatusFailed", { error: String(err) }));
+			toast.error(t("infoPanel.refreshStatusFailed", { error: String(err) }), { taskId: task.id });
 		}
 		setRefreshingStatus(false);
 	}, [compareRef, isTaskActive, offerMergeCompletionIfMerged, project.id, refreshingStatus, task.id, task.worktreePath, t]);
@@ -322,9 +322,9 @@ export function useTaskBranchStatus({
 					compareRef: compareRef || undefined,
 				});
 				if (handedOff) {
-					toast.info(t("infoPanel.rebaseAgentStarted"));
+					toast.info(t("infoPanel.rebaseAgentStarted"), { taskId: task.id });
 				} else {
-					toast.error(t("infoPanel.rebaseAgentNoPane"));
+					toast.error(t("infoPanel.rebaseAgentNoPane"), { taskId: task.id });
 				}
 			} else {
 				await api.request.rebaseTask({
@@ -334,7 +334,7 @@ export function useTaskBranchStatus({
 				});
 			}
 		} catch (err) {
-			toast.error(t("infoPanel.rebaseFailed", { error: String(err) }));
+			toast.error(t("infoPanel.rebaseFailed", { error: String(err) }), { taskId: task.id });
 		}
 		setRebasing(false);
 	}, [branchStatus, compareRef, project.id, rebasing, task.id, t]);
@@ -351,7 +351,7 @@ export function useTaskBranchStatus({
 				projectId: project.id,
 			});
 		} catch (err) {
-			toast.error(t("infoPanel.mergeFailed", { error: String(err) }));
+			toast.error(t("infoPanel.mergeFailed", { error: String(err) }), { taskId: task.id });
 		}
 		setMerging(false);
 	}, [merging, project.id, task.id, t]);
@@ -368,7 +368,7 @@ export function useTaskBranchStatus({
 				projectId: project.id,
 			});
 		} catch (err) {
-			toast.error(t("infoPanel.pushFailed", { error: String(err) }));
+			toast.error(t("infoPanel.pushFailed", { error: String(err) }), { taskId: task.id });
 		}
 		setPushing(false);
 	}, [project.id, pushing, task.id, t]);

--- a/src/mainview/hooks/useFileDrop.ts
+++ b/src/mainview/hooks/useFileDrop.ts
@@ -6,6 +6,7 @@ import { uploadDroppedFile } from "../utils/uploadDroppedFile";
 export function useFileDrop(
 	projectId: string,
 	onFileDropped: (path: string) => void,
+	taskId?: string,
 ): {
 	handleDragOver: (e: React.DragEvent) => void;
 	handleDragEnter: (e: React.DragEvent) => void;
@@ -62,11 +63,11 @@ export function useFileDrop(
 					}
 				} catch (err) {
 					console.error(`[useFileDrop] file upload failed for "${file.name}":`, err);
-					toast.error(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }));
+					toast.error(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }), { taskId });
 				}
 			}));
 		},
-		[onFileDropped, projectId],
+		[onFileDropped, projectId, taskId, t],
 	);
 
 	return { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging };

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -50,9 +50,9 @@ export interface AppState {
 	/**
 	 * Accumulated human-readable reasons per attention badge, set by repeated
 	 * `dev3 attention "reason"` calls. Keyed by task id, mirrors `bellCounts`
-	 * lifecycle (cleared when the badge is cleared). Each call appends one entry;
-	 * the hover preview shows them all. Terminal-bell badges / empty reasons add
-	 * nothing here.
+	 * lifecycle (cleared when the badge is cleared). Repeated reasons are kept
+	 * once and moved to the newest position; terminal-bell badges / empty reasons
+	 * add nothing here.
 	 */
 	bellReasons: Map<string, string[]>;
 	taskPorts: Map<string, PortInfo[]>;
@@ -176,7 +176,7 @@ export type AppAction =
 	| { type: "removeProject"; projectId: string }
 	| { type: "updateProject"; project: Project }
 	| { type: "setLoading"; loading: boolean }
-	| { type: "addBell"; taskId: string; reason?: string }
+	| { type: "addBell"; taskId: string; reason?: string; force?: boolean }
 	| { type: "clearBell"; taskId: string }
 	| { type: "setPorts"; taskId: string; ports: PortInfo[] }
 	| { type: "clearPorts"; taskId: string }
@@ -388,14 +388,14 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			return { ...state, loading: action.loading };
 		case "addBell": {
 			// Don't add bell if user is already viewing this task's terminal
-			if (
+			if (!action.force &&
 				state.route.screen === "task" &&
 				state.route.taskId === action.taskId
 			) {
 				return state;
 			}
 			// Also suppress bell when viewing task in split view
-			if (
+			if (!action.force &&
 				state.route.screen === "project" &&
 				state.route.activeTaskId === action.taskId
 			) {
@@ -409,8 +409,12 @@ export function reducer(state: AppState, action: AppAction): AppState {
 				return { ...state, bellCounts };
 			}
 			const bellReasons = new Map(state.bellReasons);
-			// Keep only the most recent MAX_ATTENTION_REASONS; oldest drop off.
-			const nextList = [...(bellReasons.get(action.taskId) ?? []), trimmed].slice(-MAX_ATTENTION_REASONS);
+			// Keep reasons unique while moving repeated text to the newest position,
+			// then retain only the most recent MAX_ATTENTION_REASONS entries.
+			const nextList = [
+				...(bellReasons.get(action.taskId) ?? []).filter((reason) => reason !== trimmed),
+				trimmed,
+			].slice(-MAX_ATTENTION_REASONS);
 			bellReasons.set(action.taskId, nextList);
 			return { ...state, bellCounts, bellReasons };
 		}

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -1,19 +1,49 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export type ToastVariant = "error" | "success" | "info" | "warning";
 
-interface ToastEntry {
+export interface ToastEntry {
 	id: number;
 	message: string;
 	variant: ToastVariant;
 	durationMs: number;
+	/** Optional task identity used when capacity eviction needs a durable fallback. */
+	taskId?: string;
 	/** Optional click handler — makes the whole toast a button (e.g. navigate to a task). */
 	onClick?: () => void;
 	/** Optional source line shown above the message (e.g. "#804 · project · task title"). */
 	context?: string;
 }
 
+export interface ToastOpts {
+	durationMs?: number;
+	/** Task identity for task-scoped overflow fallback. */
+	taskId?: string;
+	/** When set, the toast becomes clickable and runs this on click (then dismisses). */
+	onClick?: () => void;
+	/** Optional source line shown above the message (e.g. "#804 · project · task title"). */
+	context?: string;
+}
+
+export interface ToastHostProps {
+	/** Receives only task-scoped entries evicted by the five-toast capacity limit. */
+	onTaskOverflow?: (entry: ToastEntry) => void;
+}
+
 type Listener = (entry: ToastEntry) => void;
+
+interface ToastRuntime {
+	remainingMs: number;
+	startedAtMs: number | null;
+	timeoutId: ReturnType<typeof setTimeout> | null;
+	hovered: boolean;
+	focused: boolean;
+}
+
+interface RenderedToast {
+	entry: ToastEntry;
+	paused: boolean;
+}
 
 const listeners = new Set<Listener>();
 let counter = 0;
@@ -22,17 +52,19 @@ const pendingEntries: ToastEntry[] = [];
 
 /** Default auto-dismiss delay. Long on purpose so error messages aren't missed. */
 const DEFAULT_DURATION_MS = 30_000;
+const MAX_VISIBLE_TOASTS = 5;
 
 function deliver(entry: ToastEntry): void {
 	listeners.forEach((l) => l(entry));
 }
 
-function emit(message: string, variant: ToastVariant, opts?: ToastOpts) {
+function emit(message: string, variant: ToastVariant, opts?: ToastOpts): void {
 	const entry: ToastEntry = {
 		id: ++counter,
 		message,
 		variant,
 		durationMs: opts?.durationMs ?? DEFAULT_DURATION_MS,
+		taskId: opts?.taskId,
 		onClick: opts?.onClick,
 		context: opts?.context,
 	};
@@ -42,14 +74,6 @@ function emit(message: string, variant: ToastVariant, opts?: ToastOpts) {
 	}
 	// No host mounted (e.g. in unit tests) → silently drop.
 	deliver(entry);
-}
-
-interface ToastOpts {
-	durationMs?: number;
-	/** When set, the toast becomes clickable and runs this on click (then dismisses). */
-	onClick?: () => void;
-	/** Optional source line shown above the message (e.g. "#804 · project · task title"). */
-	context?: string;
 }
 
 /**
@@ -84,32 +108,170 @@ const VARIANT: Record<ToastVariant, { icon: string; border: string; text: string
 	warning: { icon: "\uf071", border: "border-warning/40", text: "text-warning", bar: "bg-warning" },
 };
 
-export function ToastHost() {
-	const [toasts, setToasts] = useState<ToastEntry[]>([]);
+function rendererIsActive(): boolean {
+	if (typeof document === "undefined") return true;
+	const focused = typeof document.hasFocus === "function" ? document.hasFocus() : true;
+	return document.visibilityState === "visible" && focused;
+}
+
+export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
+	const [toasts, setToasts] = useState<RenderedToast[]>([]);
+	const toastsRef = useRef<RenderedToast[]>([]);
+	const runtimesRef = useRef(new Map<number, ToastRuntime>());
+	const activeRef = useRef(rendererIsActive());
+	const overflowHandlerRef = useRef(onTaskOverflow);
+	overflowHandlerRef.current = onTaskOverflow;
+
+	function publish(next: RenderedToast[]): void {
+		toastsRef.current = next;
+		setToasts(next);
+	}
+
+	function clearRuntime(id: number): void {
+		const runtime = runtimesRef.current.get(id);
+		if (!runtime) return;
+		if (runtime.timeoutId !== null) {
+			clearTimeout(runtime.timeoutId);
+			runtime.timeoutId = null;
+		}
+		runtimesRef.current.delete(id);
+	}
+
+	function removeToast(id: number): void {
+		clearRuntime(id);
+		const next = toastsRef.current.filter(({ entry }) => entry.id !== id);
+		if (next.length === toastsRef.current.length) return;
+		publish(next);
+	}
+
+	function pauseRuntime(id: number): void {
+		const runtime = runtimesRef.current.get(id);
+		if (!runtime || runtime.startedAtMs === null) return;
+		runtime.remainingMs = Math.max(0, runtime.remainingMs - (Date.now() - runtime.startedAtMs));
+		runtime.startedAtMs = null;
+		if (runtime.timeoutId !== null) {
+			clearTimeout(runtime.timeoutId);
+			runtime.timeoutId = null;
+		}
+	}
+
+	function startRuntime(id: number): void {
+		const runtime = runtimesRef.current.get(id);
+		if (
+			!runtime ||
+			!activeRef.current ||
+			runtime.hovered ||
+			runtime.focused ||
+			runtime.startedAtMs !== null
+		) {
+			return;
+		}
+		if (runtime.remainingMs <= 0) {
+			removeToast(id);
+			return;
+		}
+		runtime.startedAtMs = Date.now();
+		runtime.timeoutId = setTimeout(() => removeToast(id), runtime.remainingMs);
+	}
+
+	function publishPauseState(): void {
+		const next = toastsRef.current.map((view) => {
+			const runtime = runtimesRef.current.get(view.entry.id);
+			const paused = !activeRef.current || !!runtime?.hovered || !!runtime?.focused;
+			return view.paused === paused ? view : { ...view, paused };
+		});
+		if (next.some((view, index) => view !== toastsRef.current[index])) publish(next);
+	}
+
+	function setInteraction(id: number, kind: "hovered" | "focused", value: boolean): void {
+		const runtime = runtimesRef.current.get(id);
+		if (!runtime || runtime[kind] === value) return;
+		runtime[kind] = value;
+		const shouldPause = !activeRef.current || runtime.hovered || runtime.focused;
+		if (shouldPause) pauseRuntime(id);
+		else startRuntime(id);
+		publishPauseState();
+	}
+
+	function updateActivity(): void {
+		const active = rendererIsActive();
+		if (active === activeRef.current) return;
+		activeRef.current = active;
+		if (active) {
+			for (const id of runtimesRef.current.keys()) startRuntime(id);
+		} else {
+			for (const id of runtimesRef.current.keys()) pauseRuntime(id);
+		}
+		publishPauseState();
+	}
+
+	useEffect(() => {
+		document.addEventListener("visibilitychange", updateActivity);
+		window.addEventListener("focus", updateActivity);
+		window.addEventListener("blur", updateActivity);
+		updateActivity();
+		return () => {
+			document.removeEventListener("visibilitychange", updateActivity);
+			window.removeEventListener("focus", updateActivity);
+			window.removeEventListener("blur", updateActivity);
+		};
+	}, []);
 
 	useEffect(() => {
 		const listener: Listener = (entry) => {
-			setToasts((prev) => [...prev, entry]);
-			setTimeout(() => {
-				setToasts((prev) => prev.filter((t) => t.id !== entry.id));
-			}, entry.durationMs);
+			const runtime: ToastRuntime = {
+				remainingMs: Math.max(0, entry.durationMs),
+				startedAtMs: null,
+				timeoutId: null,
+				hovered: false,
+				focused: false,
+			};
+			runtimesRef.current.set(entry.id, runtime);
+
+			const previous = toastsRef.current;
+			const evicted = previous.length >= MAX_VISIBLE_TOASTS ? previous[0] : undefined;
+			if (evicted) clearRuntime(evicted.entry.id);
+			const next = [
+				...previous.slice(evicted ? 1 : 0),
+				{ entry, paused: !activeRef.current },
+			];
+			publish(next);
+
+			if (evicted?.entry.taskId) {
+				overflowHandlerRef.current?.(evicted.entry);
+			}
+			startRuntime(entry.id);
 		};
 		listeners.add(listener);
 		return () => {
 			listeners.delete(listener);
+			for (const id of runtimesRef.current.keys()) clearRuntime(id);
+			toastsRef.current = [];
 		};
 	}, []);
 
 	if (!toasts.length) return null;
 
-	const dismiss = (id: number) => setToasts((prev) => prev.filter((t) => t.id !== id));
-
 	return (
 		<div className="fixed top-14 right-4 z-[55] flex flex-col gap-2.5 pointer-events-none">
-			{toasts.map((toastEntry) => {
-				const v = VARIANT[toastEntry.variant];
+			{toasts.map(({ entry, paused }) => {
+				const v = VARIANT[entry.variant];
 				return (
-					<div key={toastEntry.id} className="pointer-events-auto animate-slide-in-right" role="alert">
+					<div
+						key={entry.id}
+						className="pointer-events-auto animate-slide-in-right"
+						role="alert"
+						data-toast-id={entry.id}
+						onMouseEnter={() => setInteraction(entry.id, "hovered", true)}
+						onMouseLeave={() => setInteraction(entry.id, "hovered", false)}
+						onFocusCapture={() => setInteraction(entry.id, "focused", true)}
+						onBlurCapture={(event) => {
+							const nextFocus = event.relatedTarget;
+							if (!(nextFocus instanceof Node) || !event.currentTarget.contains(nextFocus)) {
+								setInteraction(entry.id, "focused", false);
+							}
+						}}
+					>
 						<div
 							className={`relative overflow-hidden bg-overlay border ${v.border} rounded-xl shadow-2xl w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3 p-4`}
 						>
@@ -119,39 +281,39 @@ export function ToastHost() {
 							>
 								{v.icon}
 							</span>
-							{toastEntry.onClick ? (
+							{entry.onClick ? (
 								<button
 									type="button"
 									onClick={() => {
-										toastEntry.onClick?.();
-										dismiss(toastEntry.id);
+										entry.onClick?.();
+										removeToast(entry.id);
 									}}
 									className="flex-1 min-w-0 text-left pr-1 cursor-pointer group"
 								>
-									{toastEntry.context && (
+									{entry.context && (
 										<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-											{toastEntry.context}
+											{entry.context}
 										</div>
 									)}
 									<div className="text-fg text-sm leading-relaxed break-words group-hover:underline">
-										{toastEntry.message}
+										{entry.message}
 									</div>
 								</button>
 							) : (
 								<div className="flex-1 min-w-0 pr-1">
-									{toastEntry.context && (
+									{entry.context && (
 										<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-											{toastEntry.context}
+											{entry.context}
 										</div>
 									)}
 									<div className="text-fg text-sm leading-relaxed break-words">
-										{toastEntry.message}
+										{entry.message}
 									</div>
 								</div>
 							)}
 							<button
 								type="button"
-								onClick={() => dismiss(toastEntry.id)}
+								onClick={() => removeToast(entry.id)}
 								aria-label="Dismiss"
 								className="text-fg-muted hover:text-fg transition-colors flex-shrink-0"
 							>
@@ -160,8 +322,12 @@ export function ToastHost() {
 								</svg>
 							</button>
 							<div
+								data-toast-progress
 								className={`absolute bottom-0 left-0 h-0.5 ${v.bar} opacity-50`}
-								style={{ animation: `toast-shrink ${toastEntry.durationMs}ms linear forwards` }}
+								style={{
+									animation: `toast-shrink ${entry.durationMs}ms linear forwards`,
+									animationPlayState: paused ? "paused" : "running",
+								}}
 							/>
 						</div>
 					</div>

--- a/src/mainview/utils/__tests__/webNotification.test.ts
+++ b/src/mainview/utils/__tests__/webNotification.test.ts
@@ -150,6 +150,7 @@ describe("showWebNotificationOrToast", () => {
 		const [message, opts] = toastMock.info.mock.calls[0];
 		expect(message).toBe("In Progress → Review");
 		expect(opts.context).toBe("#42 · MyProject · Fix bug");
+		expect(opts.taskId).toBe("task-1");
 		opts.onClick();
 		expect(onOpen).toHaveBeenCalledWith("task-1", "proj-1");
 	});

--- a/src/mainview/utils/moveTaskToStatus.ts
+++ b/src/mainview/utils/moveTaskToStatus.ts
@@ -121,7 +121,7 @@ export async function moveTaskToStatus({
 	} catch (err) {
 		if (revertOnFailure) {
 			dispatch({ type: "updateTask", task });
-			toast.error(t("task.failedMove", { error: String(err) }));
+			toast.error(t("task.failedMove", { error: String(err) }), { taskId: task.id });
 		} else {
 			console.error("moveTaskToStatus failed:", err);
 		}

--- a/src/mainview/utils/webNotification.ts
+++ b/src/mainview/utils/webNotification.ts
@@ -132,5 +132,9 @@ export function showWebNotificationOrToast(
 		]
 			.filter(Boolean)
 			.join(" · ") || undefined;
-	toast[detail.level](detail.body, { onClick: openTask, context });
+	toast[detail.level](detail.body, {
+		onClick: openTask,
+		context,
+		taskId: detail.taskId || undefined,
+	});
 }


### PR DESCRIPTION
## Summary

- Pause toast timers whenever the renderer is hidden or unfocused, pause individual toasts during hover or focus, and resume from the exact remaining duration with synchronized progress indicators.
- Bound each visible toast stack to five entries with predictable oldest-first eviction.
- Route task-scoped capacity evictions to forced, counted, deduplicated task attention while keeping unscoped overflow, manual dismissal, and normal timeout silent.
- Propagate task identity through task-scoped toast call sites, avoid duplicate image/artifact attention, and add component, reducer, and integration coverage.

## Testing

- bun run lint
- bun run test
- Manual browser QA for focus/visibility, hover/focus pause, five-toast capacity, and console errors.