### PR TITLE
Limit notification stacking on mobile

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-toast-capacity.md
+++ b/change-logs/2026/07/15/fix-mobile-toast-capacity.md
@@ -1,0 +1,1 @@
+Mobile layouts now show only the newest in-app notification toast at a time, while desktop keeps the existing five-toast capacity and task-scoped overflow fallback.

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -17,6 +17,30 @@ function setRendererActivity(visible: boolean, focused: boolean): void {
 	});
 }
 
+function setViewport(width: number): () => void {
+	const originalInnerWidth = window.innerWidth;
+	const originalMatchMedia = window.matchMedia;
+	Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: (query: string) => ({
+			matches: query.includes("max-width: 767px") ? width < 768 : query.includes("prefers-reduced-motion"),
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		}),
+	});
+
+	return () => {
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+		Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+	};
+}
+
 beforeEach(() => {
 	setRendererActivity(true, true);
 });
@@ -51,6 +75,24 @@ describe("toast service", () => {
 		expect(await screen.findByText("First")).toBeInTheDocument();
 		expect(screen.getByText("Second")).toBeInTheDocument();
 		expect(screen.getAllByRole("alert")).toHaveLength(2);
+	});
+
+	it("shows only the newest toast in a narrow viewport", () => {
+		const restoreViewport = setViewport(390);
+		const onTaskOverflow = vi.fn();
+		const { unmount } = render(<ToastHost onTaskOverflow={onTaskOverflow} />);
+		act(() => {
+			toast.info("First", { durationMs: 60_000, taskId: "task-1" });
+			toast.success("Newest", { durationMs: 60_000 });
+		});
+
+		expect(screen.getAllByRole("alert")).toHaveLength(1);
+		expect(screen.queryByText("First")).not.toBeInTheDocument();
+		expect(screen.getByText("Newest")).toBeInTheDocument();
+		expect(onTaskOverflow).toHaveBeenCalledWith(expect.objectContaining({ message: "First", taskId: "task-1" }));
+
+		unmount();
+		restoreViewport();
 	});
 
 	it("dismisses a toast when the close button is clicked", async () => {

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useNarrowViewport } from "./hooks/useNarrowViewport";
 
 export type ToastVariant = "error" | "success" | "info" | "warning";
 
@@ -26,7 +27,7 @@ export interface ToastOpts {
 }
 
 export interface ToastHostProps {
-	/** Receives only task-scoped entries evicted by the five-toast capacity limit. */
+	/** Receives only task-scoped entries evicted by the visible toast capacity limit. */
 	onTaskOverflow?: (entry: ToastEntry) => void;
 }
 
@@ -53,6 +54,8 @@ const pendingEntries: ToastEntry[] = [];
 /** Default auto-dismiss delay. Long on purpose so error messages aren't missed. */
 const DEFAULT_DURATION_MS = 30_000;
 const MAX_VISIBLE_TOASTS = 5;
+const NARROW_MAX_VISIBLE_TOASTS = 1;
+const NARROW_VIEWPORT_PX = 768;
 
 function deliver(entry: ToastEntry): void {
 	listeners.forEach((l) => l(entry));
@@ -115,12 +118,16 @@ function rendererIsActive(): boolean {
 }
 
 export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
+	const narrow = useNarrowViewport(NARROW_VIEWPORT_PX);
+	const maxVisibleToasts = narrow ? NARROW_MAX_VISIBLE_TOASTS : MAX_VISIBLE_TOASTS;
 	const [toasts, setToasts] = useState<RenderedToast[]>([]);
 	const toastsRef = useRef<RenderedToast[]>([]);
 	const runtimesRef = useRef(new Map<number, ToastRuntime>());
 	const activeRef = useRef(rendererIsActive());
 	const overflowHandlerRef = useRef(onTaskOverflow);
+	const maxVisibleToastsRef = useRef(maxVisibleToasts);
 	overflowHandlerRef.current = onTaskOverflow;
+	maxVisibleToastsRef.current = maxVisibleToasts;
 
 	function publish(next: RenderedToast[]): void {
 		toastsRef.current = next;
@@ -218,6 +225,19 @@ export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
 	}, []);
 
 	useEffect(() => {
+		const previous = toastsRef.current;
+		const evictedCount = Math.max(0, previous.length - maxVisibleToasts);
+		if (!evictedCount) return;
+
+		const evicted = previous.slice(0, evictedCount);
+		evicted.forEach(({ entry }) => clearRuntime(entry.id));
+		publish(previous.slice(evictedCount));
+		for (const { entry } of evicted) {
+			if (entry.taskId) overflowHandlerRef.current?.(entry);
+		}
+	}, [maxVisibleToasts]);
+
+	useEffect(() => {
 		const listener: Listener = (entry) => {
 			const runtime: ToastRuntime = {
 				remainingMs: Math.max(0, entry.durationMs),
@@ -229,16 +249,18 @@ export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
 			runtimesRef.current.set(entry.id, runtime);
 
 			const previous = toastsRef.current;
-			const evicted = previous.length >= MAX_VISIBLE_TOASTS ? previous[0] : undefined;
-			if (evicted) clearRuntime(evicted.entry.id);
+			const capacity = maxVisibleToastsRef.current;
+			const evictedCount = Math.max(0, previous.length - capacity + 1);
+			const evicted = previous.slice(0, evictedCount);
+			evicted.forEach(({ entry: evictedEntry }) => clearRuntime(evictedEntry.id));
 			const next = [
-				...previous.slice(evicted ? 1 : 0),
+				...previous.slice(evictedCount),
 				{ entry, paused: !activeRef.current },
 			];
 			publish(next);
 
-			if (evicted?.entry.taskId) {
-				overflowHandlerRef.current?.(evicted.entry);
+			for (const { entry: evictedEntry } of evicted) {
+				if (evictedEntry.taskId) overflowHandlerRef.current?.(evictedEntry);
 			}
 			startRuntime(entry.id);
 		};


### PR DESCRIPTION
## Summary

- Show only the newest in-app toast below 768px so mobile content stays visible.
- Keep desktop's five-toast capacity and task-scoped overflow attention fallback.
- Add responsive regression coverage and a changelog entry.

## Testing

- `bun run lint`
- `bun run test`
- Browser QA at iPhone-sized and 1440px viewports; no console errors.