### PR TITLE
Preserve active task after terminal status changes

### DIFF
--- a/change-logs/2026/07/15/fix-preserve-new-task-selection.md
+++ b/change-logs/2026/07/15/fix-preserve-new-task-selection.md
@@ -1,0 +1,1 @@
+Finishing or cancelling one task no longer clears a different task that the user selected while the completion preflight was still running.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -162,6 +162,17 @@ function TaskInfoPanel({
 	const statusMenuRef = useRef<HTMLDivElement>(null);
 	const diffFilesTriggerRef = useRef<HTMLButtonElement>(null);
 	const diffFilesHoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Terminal moves await a git preflight. If the user switches tasks while it
+	// runs, the old task's callback must not overwrite that newer selection.
+	const latestTaskIdRef = useRef(task.id);
+	const mountedRef = useRef(true);
+	latestTaskIdRef.current = task.id;
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
 	const terminalFullscreenActive = onToggleTerminalFullscreen
 		? Boolean(isTerminalFullscreen)
 		: Boolean(isFullPage);
@@ -301,6 +312,10 @@ function TaskInfoPanel({
 		// Terminal moves leave the task screen immediately (worktree teardown runs
 		// in the background); other moves keep the panel and show a spinner.
 		const leaveScreen = terminal || !ACTIVE_STATUSES.includes(newStatus);
+		const navigateHomeIfTaskStillSelected = () => {
+			if (!mountedRef.current || latestTaskIdRef.current !== task.id) return;
+			navigate(taskClosedHomeRoute(project.id, getTaskOpenMode()));
+		};
 		await moveTaskToStatus({
 			task,
 			project,
@@ -318,10 +333,10 @@ function TaskInfoPanel({
 			// Land on the user's home surface: fullscreen open-mode → the board,
 			// split open-mode → the split task view with nothing selected.
 			afterOptimistic: terminal && leaveScreen
-				? () => navigate(taskClosedHomeRoute(project.id, getTaskOpenMode()))
+				? navigateHomeIfTaskStillSelected
 				: undefined,
 			onSuccess: !terminal && leaveScreen
-				? () => navigate(taskClosedHomeRoute(project.id, getTaskOpenMode()))
+				? navigateHomeIfTaskStillSelected
 				: undefined,
 		});
 	}

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -713,6 +713,56 @@ describe("TaskInfoPanel", () => {
 			}));
 		});
 
+		it("does not navigate away from a newer task when terminal preflight resolves late", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			const closingTask = makeTask({ id: "closing", title: "Closing task" });
+			const newerTask = makeTask({ id: "newer", title: "Newer task" });
+			let resolveConfirmation!: (confirmed: boolean) => void;
+			mockedConfirmTaskCompletion.mockReturnValue(
+				new Promise<boolean>((resolve) => {
+					resolveConfirmation = resolve;
+				}),
+			);
+			mockedApi.request.moveTask.mockResolvedValue({ ...closingTask, status: "cancelled" });
+
+			let view!: ReturnType<typeof renderPanel>;
+			await act(async () => {
+				view = renderPanel(closingTask, { dispatch, navigate });
+			});
+
+			await user.click(screen.getByText("Agent is Working"));
+			await user.click(screen.getByText("Cancelled"));
+
+			view.rerender(
+				<I18nProvider>
+					<TaskInfoPanel
+						task={newerTask}
+						project={project}
+						dispatch={dispatch}
+						navigate={navigate}
+					/>
+				</I18nProvider>,
+			);
+
+			await act(async () => {
+				resolveConfirmation(true);
+				await Promise.resolve();
+			});
+
+			await waitFor(() => {
+				expect(mockedApi.request.moveTask).toHaveBeenCalledWith(
+					expect.objectContaining({
+						taskId: "closing",
+						projectId: "p1",
+						newStatus: "cancelled",
+					}),
+				);
+			});
+			expect(navigate).not.toHaveBeenCalled();
+		});
+
 		it("navigates to the Kanban board on completed in fullscreen open-mode", async () => {
 			localStorage.setItem("dev3-task-open-mode", "fullscreen");
 			try {


### PR DESCRIPTION
## Summary

- prevent a delayed completion or cancellation preflight from navigating away from a newly selected task
- keep the original task status move running while guarding its post-preflight navigation against stale task selection
- add regression coverage and a changelog entry

## Testing

- `bun run lint`
- `bun run test`
- browser QA: cancel task A, immediately switch to task B, and verify task B remains selected after teardown