### PR TITLE
Cache GitHub PR status for Kanban

### DIFF
--- a/change-logs/2026/07/15/feature-cache-github-pr-status.md
+++ b/change-logs/2026/07/15/feature-cache-github-pr-status.md
@@ -1,0 +1,1 @@
+Kanban task cards now restore the last cached GitHub PR status, including checks and unresolved comments, while hover refreshes the latest result without blanking the popover.

--- a/decisions/135-cache-github-pr-status.md
+++ b/decisions/135-cache-github-pr-status.md
@@ -1,0 +1,19 @@
+## 1. Context
+
+The Kanban board could identify an open pull request immediately, but its checks, review state, merge state, title, and unresolved-comment count disappeared until GitHub answered again. Users need the last successful result to remain visible while the next hover-triggered refresh runs.
+
+## 2. Investigation
+
+PR identity is already persisted on `Task` and the backend already emits normalized rich status through `taskPrStatus`. The board receives task metadata before its periodic `getProjectPRs` lookup completes, so an additive task field can hydrate the existing PR popover without changing its surface or promotion logic.
+
+## 3. Decision
+
+Persist the last successful rich PR response as optional `Task.prStatusCache`, together with its PR identity and fetch timestamp. Hydrate Kanban badges from this cache first, keep the cached content rendered during the existing hover refresh, and treat cache-write failures as non-fatal so fresh push messages still update the UI.
+
+## 4. Risks
+
+The task file grows with normalized check metadata, and cached values can be stale until the next refresh. Writes are skipped when the rich payload is unchanged, and the optional field preserves compatibility with older task records and app versions.
+
+## 5. Alternatives considered
+
+Renderer-only memory or browser storage was rejected because it would not survive reloads or provide a shared source for task metadata. A separate cache file was rejected because the task already owns PR identity and an additive field keeps the existing on-disk layout and update path intact.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -7880,7 +7880,17 @@ describe("checkOpenPRsForPromotion", () => {
 
 		await checkOpenPRsForPromotion();
 
-		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { prNumber: 42, prUrl });
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, expect.objectContaining({
+			prNumber: 42,
+			prUrl,
+			prStatusCache: expect.objectContaining({
+				number: 42,
+				url: prUrl,
+				ciStatus: "failure",
+				unresolvedCount: 2,
+				cachedAt: expect.any(String),
+			}),
+		}));
 		expect(github.runGitHub).toHaveBeenNthCalledWith(
 			2,
 			project,

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -5,6 +5,7 @@ import {
 	type PRCIStatus,
 	type Project,
 	type Task,
+	type TaskPRStatusCache,
 	type TaskDiffMode,
 	type TaskDiffResponse,
 	type ScheduledMessageTarget,
@@ -512,6 +513,8 @@ interface PolledPRStatus {
 	ciStatus: PRCIStatus | null;
 }
 
+type FreshPRStatus = Omit<TaskPRStatusCache, "cachedAt">;
+
 const REVIEW_STATUS_CANDIDATES = new Set<Task["status"]>(["review-by-user", "review-by-colleague"]);
 const TERMINAL_TASK_STATUSES = new Set<Task["status"]>(["completed", "cancelled"]);
 
@@ -523,6 +526,37 @@ async function persistTaskPrIdentity(project: Project, task: Task, prNumber: num
 	if (task.prNumber === prNumber && task.prUrl === prUrl) return;
 	const updated = await data.updateTask(project, task.id, { prNumber, prUrl });
 	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+}
+
+function sameFreshPRStatus(cache: TaskPRStatusCache | null | undefined, next: FreshPRStatus): boolean {
+	return !!cache
+		&& cache.number === next.number
+		&& cache.url === next.url
+		&& cache.ciStatus === next.ciStatus
+		&& cache.reviewState === next.reviewState
+		&& cache.unresolvedCount === next.unresolvedCount
+		&& JSON.stringify(cache.mergeState) === JSON.stringify(next.mergeState)
+		&& JSON.stringify(cache.checks) === JSON.stringify(next.checks)
+		&& cache.prTitle === next.prTitle
+		&& cache.isDraft === next.isDraft;
+}
+
+/**
+ * Keep the last successful rich PR response on the task so a later board load
+ * can render it before GitHub answers. Cache persistence is best-effort: a
+ * stale cache must never prevent the fresh response from reaching the UI.
+ */
+async function persistTaskPrStatusCache(project: Project, task: Task, next: FreshPRStatus): Promise<void> {
+	if (task.prNumber === next.number && task.prUrl === next.url && sameFreshPRStatus(task.prStatusCache, next)) return;
+	try {
+		await data.updateTask(project, task.id, {
+			prNumber: next.number,
+			prUrl: next.url,
+			prStatusCache: { ...next, cachedAt: new Date().toISOString() },
+		});
+	} catch (error) {
+		log.warn("PR status cache persistence failed (non-fatal)", { taskId: task.id.slice(0, 8), error: String(error) });
+	}
 }
 
 async function persistProjectPrIdentities(project: Project, prs: PRInfo[]): Promise<void> {
@@ -693,7 +727,19 @@ async function pollTaskPrStatus(project: Project, task: Task, pushMessage: NonNu
 	const prTitle = typeof pr.title === "string" ? pr.title : null;
 	const isDraft = typeof pr.isDraft === "boolean" ? pr.isDraft : null;
 
-	if (prUrl) await persistTaskPrIdentity(project, task, prNumber, prUrl);
+	if (prUrl) {
+		await persistTaskPrStatusCache(project, task, {
+			number: prNumber,
+			url: prUrl,
+			ciStatus,
+			reviewState,
+			unresolvedCount,
+			mergeState,
+			checks,
+			prTitle,
+			isDraft,
+		});
+	}
 
 	pushMessage("taskPrStatus", {
 		projectId: project.id,

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -37,6 +37,57 @@ interface KanbanBoardProps {
 	disableGlobalFindShortcut?: boolean;
 }
 
+type PRIdentity = Pick<TaskPRBadgeInfo, "number" | "url">;
+
+function samePRIdentity(left: TaskPRBadgeInfo | null | undefined, right: PRIdentity): boolean {
+	return left?.number === right.number && left.url === right.url;
+}
+
+function taskPRBadgeFromStoredData(task: Task, identity?: PRIdentity): TaskPRBadgeInfo | null {
+	const cache = task.prStatusCache;
+	const sticky = task.prNumber != null && task.prUrl ? { number: task.prNumber, url: task.prUrl } : undefined;
+	const cachedIdentity = cache?.url ? { number: cache.number, url: cache.url } : undefined;
+	const pr = identity ?? sticky ?? cachedIdentity;
+	if (!pr) return null;
+	const cached = cache && samePRIdentity({ number: cache.number, url: cache.url }, pr) ? cache : null;
+	return {
+		number: pr.number,
+		url: pr.url,
+		ciStatus: cached?.ciStatus ?? null,
+		reviewState: cached?.reviewState ?? null,
+		unresolvedCount: cached?.unresolvedCount ?? null,
+		mergeState: cached?.mergeState ?? null,
+		checks: cached?.checks ?? [],
+		prTitle: cached?.prTitle ?? null,
+		isDraft: cached?.isDraft ?? null,
+	};
+}
+
+function mergeTaskPRBadge(task: Task, identity: PRIdentity | undefined, existing: TaskPRBadgeInfo | undefined): TaskPRBadgeInfo | null {
+	const stored = taskPRBadgeFromStoredData(task, identity);
+	if (!stored) return null;
+	if (!existing || !samePRIdentity(existing, stored)) return stored;
+	return {
+		...stored,
+		ciStatus: existing.ciStatus ?? stored.ciStatus,
+		reviewState: existing.reviewState ?? stored.reviewState,
+		unresolvedCount: existing.unresolvedCount ?? stored.unresolvedCount,
+		mergeState: existing.mergeState ?? stored.mergeState,
+		checks: existing.checks && existing.checks.length > 0 ? existing.checks : stored.checks,
+		prTitle: existing.prTitle ?? stored.prTitle,
+		isDraft: existing.isDraft ?? stored.isDraft,
+	};
+}
+
+function hydrateTaskPRMap(tasks: Task[], previous = new Map<string, TaskPRBadgeInfo>()): Map<string, TaskPRBadgeInfo> {
+	const next = new Map<string, TaskPRBadgeInfo>();
+	for (const task of tasks) {
+		const badge = mergeTaskPRBadge(task, undefined, previous.get(task.id));
+		if (badge) next.set(task.id, badge);
+	}
+	return next;
+}
+
 function KanbanBoard({
 	project,
 	tasks,
@@ -75,8 +126,9 @@ function KanbanBoard({
 	const { tip: currentTip, tipState, applyTipState } = useTipRotation("board", globalSettings.tipsDisabled);
 	const collapseState = useColumnCollapse(project.id);
 
-	// PR numbers for task cards: taskId → { number, url }
-	const [taskPrMap, setTaskPrMap] = useState<Map<string, TaskPRBadgeInfo>>(new Map());
+	// PR badge data for task cards. Seed from persisted task metadata so the board
+	// stays useful while the first live GitHub lookup is still in flight.
+	const [taskPrMap, setTaskPrMap] = useState<Map<string, TaskPRBadgeInfo>>(() => hydrateTaskPRMap(tasks));
 
 	const handleSetMoving = useCallback((taskId: string, isMoving: boolean) => {
 		setMovingTaskIds((prev) => {
@@ -97,6 +149,19 @@ function KanbanBoard({
 		api.request.getGlobalSettings().then(setGlobalSettings).catch(() => {});
 	}, []);
 
+	useEffect(() => {
+		setTaskPrMap((prev) => {
+			const next = new Map<string, TaskPRBadgeInfo>();
+			for (const task of tasks) {
+				const existing = prev.get(task.id);
+				const badge = existing ?? taskPRBadgeFromStoredData(task);
+				if (badge) next.set(task.id, badge);
+			}
+			if (next.size === prev.size && [...next.keys()].every((taskId) => prev.has(taskId))) return prev;
+			return next;
+		});
+	}, [project.id, tasks]);
+
 	// Fetch open PRs for the project and map branch names to task IDs. CI/review
 	// state is supplied separately by the background poller's `taskPrStatus`
 	// push, so preserve any already-known ci/review fields when rebuilding here.
@@ -110,23 +175,10 @@ function KanbanBoard({
 				const map = new Map<string, TaskPRBadgeInfo>();
 				for (const task of tasks) {
 					const discovered = task.branchName ? branchToPR.get(task.branchName) : undefined;
-					const sticky = task.prNumber != null && task.prUrl
-						? { number: task.prNumber, url: task.prUrl }
-						: undefined;
-					const pr = discovered ?? sticky;
-					if (!pr) continue;
+					const stored = taskPRBadgeFromStoredData(task, discovered);
 					const existing = prev.get(task.id);
-					map.set(task.id, {
-						number: pr.number,
-						url: pr.url,
-						ciStatus: existing?.ciStatus ?? null,
-						reviewState: existing?.reviewState ?? null,
-						unresolvedCount: existing?.unresolvedCount ?? null,
-						mergeState: existing?.mergeState ?? null,
-						checks: existing?.checks ?? [],
-						prTitle: existing?.prTitle ?? null,
-						isDraft: existing?.isDraft ?? null,
-					});
+					const badge = stored && existing && samePRIdentity(existing, stored) ? existing : stored;
+					if (badge) map.set(task.id, badge);
 				}
 				return map;
 			});

--- a/src/mainview/components/TaskPrStatusPopover.tsx
+++ b/src/mainview/components/TaskPrStatusPopover.tsx
@@ -96,8 +96,6 @@ export default function TaskPrStatusPopover({ prInfo, projectId, taskId, childre
 	const pointerInsideRef = useRef(false);
 	const openRef = useRef(false);
 	const refreshingRef = useRef(false);
-	const prInfoRef = useRef(prInfo);
-	prInfoRef.current = prInfo;
 
 	const cancelHide = useCallback(() => {
 		if (hideTimerRef.current !== null) {
@@ -158,7 +156,7 @@ export default function TaskPrStatusPopover({ prInfo, projectId, taskId, childre
 			autoRefreshTimerRef.current = null;
 			if (!pointerInsideRef.current || !openRef.current || autoRefreshAttemptedRef.current) return;
 			autoRefreshAttemptedRef.current = true;
-			if ((prInfoRef.current.checks ?? []).length === 0) void refresh();
+			void refresh();
 		}, AUTO_REFRESH_DELAY_MS);
 	}, [refresh]);
 

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -4,7 +4,7 @@ import KanbanBoard from "../KanbanBoard";
 import { I18nProvider } from "../../i18n";
 import { api } from "../../rpc";
 import { toast } from "../../toast";
-import type { CustomColumn, Project, Task, TipState } from "../../../shared/types";
+import type { CustomColumn, PRInfo, Project, Task, TipState } from "../../../shared/types";
 
 vi.mock("../../rpc", () => ({
 	api: {
@@ -177,6 +177,37 @@ describe("column ordering", () => {
 	it("polls getProjectPRs for a git board", async () => {
 		await renderBoardWith();
 		await waitFor(() => expect(api.request.getProjectPRs).toHaveBeenCalled());
+	});
+
+	it("shows the persisted PR status cache before the live PR lookup resolves", async () => {
+		vi.mocked(api.request.getProjectPRs).mockImplementation(() => new Promise<PRInfo[]>(() => {}));
+		const task = makeTask({
+			prStatusCache: {
+				number: 42,
+				url: "https://github.com/test/repo/pull/42",
+				ciStatus: "success",
+				reviewState: "commented",
+				unresolvedCount: 2,
+				mergeState: { mergeable: "MERGEABLE", status: "CLEAN", state: "OPEN" },
+				checks: [{ name: "cached-build", status: "COMPLETED", conclusion: "SUCCESS", detailsUrl: null }],
+				prTitle: "Cached PR",
+				isDraft: false,
+				cachedAt: "2026-07-15T12:00:00.000Z",
+			},
+		});
+		const result = await renderBoardWith({ tasks: [task] });
+		try {
+			const badge = screen.getByLabelText("Open PR #42");
+			expect(badge).toBeInTheDocument();
+			await userEvent.hover(badge);
+			const popover = await screen.findByTestId("pr-status-popover");
+			expect(popover).toHaveTextContent("Cached PR");
+			expect(popover).toHaveTextContent("2 unresolved comments");
+			expect(popover).toHaveTextContent("cached-build");
+		} finally {
+			result.unmount();
+			vi.mocked(api.request.getProjectPRs).mockResolvedValue([]);
+		}
 	});
 
 	it("review-by-colleague is inserted before completed when missing from stored columnOrder", async () => {

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1659,6 +1659,30 @@ describe("TaskCard", () => {
 			}
 		});
 
+		it("refreshes cached PR status after hover without hiding the cached data", async () => {
+			let resolveRefresh!: () => void;
+			mockedApi.request.refreshTaskPrStatus.mockImplementation(() => new Promise<void>((resolve) => {
+				resolveRefresh = resolve;
+			}));
+			renderCard(reviewTask(), {
+				prInfo: {
+					number: 12,
+					url: "https://example/pr/12",
+					unresolvedCount: 2,
+					checks: [{ name: "cached-build", status: "COMPLETED", conclusion: "SUCCESS", detailsUrl: null }],
+				},
+			});
+			await userEvent.hover(screen.getByLabelText("Open PR #12"));
+
+			await waitFor(() => expect(mockedApi.request.refreshTaskPrStatus).toHaveBeenCalledTimes(1), { timeout: 3000 });
+			expect(screen.getByTestId("pr-status-popover")).toHaveTextContent("cached-build");
+			expect(screen.getByRole("button", { name: "Refreshing PR status…" })).toBeDisabled();
+
+			await act(async () => {
+				resolveRefresh();
+			});
+		});
+
 		it("does not auto-refresh when the pointer leaves before the hover delay", async () => {
 			vi.useFakeTimers();
 			try {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1138,6 +1138,8 @@ export interface Task {
 	/** Sticky identity of the GitHub pull request detected for this task. */
 	prNumber?: number | null;
 	prUrl?: string | null;
+	/** Last rich status fetched for the task's open GitHub pull request. */
+	prStatusCache?: TaskPRStatusCache | null;
 	groupId: string | null;
 	variantIndex: number | null;
 	agentId: string | null;
@@ -1908,6 +1910,24 @@ export interface PRMergeState {
 	mergeable: string | null;
 	status: string | null;
 	state?: string | null;
+}
+
+/**
+ * Persisted rich status for a task's open pull request. This is deliberately
+ * additive task metadata: the renderer can show it immediately while the next
+ * GitHub refresh is in flight.
+ */
+export interface TaskPRStatusCache {
+	number: number;
+	url: string;
+	ciStatus: PRCIStatus | null;
+	reviewState: PRReviewState | null;
+	unresolvedCount: number | null;
+	mergeState: PRMergeState | null;
+	checks: PRCheckInfo[];
+	prTitle: string | null;
+	isDraft: boolean | null;
+	cachedAt: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Persist the latest rich GitHub PR status on each task.
- Hydrate Kanban PR badges from cached status before live lookups complete.
- Keep cached popover content visible while hover refreshes the latest status.

## Tests
- bun run lint
- bun run test
- Browser QA completed without console errors.