### PR TITLE
Fix mobile fullscreen re-entry

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-fullscreen-reentry.md
+++ b/change-logs/2026/07/15/fix-mobile-fullscreen-reentry.md
@@ -1,0 +1,1 @@
+Mobile browser fullscreen now re-arms its first-tap gesture after any exit, so tapping the app restores fullscreen while preserving the browser's user-gesture requirement.

--- a/src/mainview/__tests__/fullscreen.test.ts
+++ b/src/mainview/__tests__/fullscreen.test.ts
@@ -61,7 +61,7 @@ describe("auto fullscreen on first tap (mobile)", () => {
 		expect(requestFullscreen).toHaveBeenCalledOnce();
 	});
 
-	it("respects a manual exit: no auto re-engage on further taps", async () => {
+	it("re-arms the next tap after leaving fullscreen", () => {
 		initAutoFullscreen({ mobile: true });
 		tap();
 		expect(isFullscreenActive()).toBe(true);
@@ -70,7 +70,16 @@ describe("auto fullscreen on first tap (mobile)", () => {
 		document.dispatchEvent(new Event("fullscreenchange"));
 
 		tap();
-		expect(requestFullscreen).toHaveBeenCalledOnce();
+		expect(requestFullscreen).toHaveBeenCalledTimes(2);
+	});
+
+	it("re-arms after the explicit fullscreen toggle exits", async () => {
+		initAutoFullscreen({ mobile: true });
+		await toggleFullscreen();
+		await toggleFullscreen();
+
+		tap();
+		expect(requestFullscreen).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not arm the first-tap engage on desktop", () => {

--- a/src/mainview/fullscreen.ts
+++ b/src/mainview/fullscreen.ts
@@ -3,11 +3,10 @@
  *
  * Browser chrome (address bar + system bars) wastes a large share of a phone
  * screen, so on mobile the UI enters fullscreen on the FIRST tap after page
- * load (requestFullscreen needs a user gesture). One-shot per load: once
- * engaged — or once the user exits by any means (system gesture, Esc, the
- * menu toggle) — auto-engage stays off until the next page load, so the app
- * never fights the user's gestures. A deliberate Fullscreen toggle lives in
- * the mobile menu action sheet (GlobalHeader).
+ * load (requestFullscreen needs a user gesture). The listener is one-shot
+ * while fullscreen is active, then re-arms after an exit so the next user tap
+ * restores fullscreen. A deliberate Fullscreen toggle lives in the mobile
+ * menu action sheet (GlobalHeader).
  *
  * Explicitly NOT a PWA: the serving origin (tunnel hostname / LAN port) is
  * unstable per launch, so an installed PWA would rot immediately.
@@ -89,26 +88,32 @@ export function initAutoFullscreen(opts: { mobile: boolean }): void {
 	if (initialized || typeof document === "undefined") return;
 	initialized = true;
 
+	const canAutoEngage = opts.mobile && isFullscreenSupported();
+	const armFirstTap = () => {
+		if (!canAutoEngage || autoEngageSpent || installedFirstTap) return;
+		const onFirstTap = () => {
+			document.removeEventListener("click", onFirstTap, true);
+			installedFirstTap = null;
+			autoEngageSpent = true;
+			void enterFullscreen();
+		};
+		document.addEventListener("click", onFirstTap, true);
+		installedFirstTap = onFirstTap;
+	};
+
 	const onFullscreenChange = () => {
 		notifyListeners();
-		// Any exit — system gesture, Esc, or the menu toggle — is the user's
-		// call: never auto re-engage until the next page load.
-		if (!document.fullscreenElement) autoEngageSpent = true;
+		// A browser exit needs a fresh user gesture before requestFullscreen can
+		// succeed, so restore the one-shot listener instead of re-entering here.
+		if (!document.fullscreenElement) {
+			autoEngageSpent = false;
+			armFirstTap();
+		}
 	};
 	document.addEventListener("fullscreenchange", onFullscreenChange);
 	installedFullscreenChange = onFullscreenChange;
 
-	if (!opts.mobile || !isFullscreenSupported()) return;
-
-	const onFirstTap = () => {
-		document.removeEventListener("click", onFirstTap, true);
-		installedFirstTap = null;
-		if (autoEngageSpent) return;
-		autoEngageSpent = true;
-		void enterFullscreen();
-	};
-	document.addEventListener("click", onFirstTap, true);
-	installedFirstTap = onFirstTap;
+	armFirstTap();
 }
 
 /** Reset module state and uninstall document listeners. Tests only. */


### PR DESCRIPTION
## Summary
- Re-arm mobile fullscreen after the browser exits fullscreen.
- Restore fullscreen on the next user tap while preserving the user-gesture requirement.
- Add regressions for system exits and the explicit fullscreen toggle.

## Verification
- `bun run lint`
- `bun run test`
- Manual mobile browser QA: enter, exit, and re-enter fullscreen.