### PR TITLE
Prioritize mobile Kanban attention columns

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-kanban-initial-focus.md
+++ b/change-logs/2026/07/15/fix-mobile-kanban-initial-focus.md
@@ -1,0 +1,1 @@
+On narrow Kanban boards, the carousel now opens on Has Questions when it contains tasks and falls back to Your Review when it is empty. The focus also updates after the initial task fetch until the user navigates manually.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -683,6 +683,8 @@ function KanbanBoard({
 							},
 				)
 		: [];
+	const initialColumnId = carouselColumns.find((column) => column.id === "user-questions" && column.count > 0)?.id
+		?? carouselColumns.find((column) => column.id === "review-by-user" && column.count > 0)?.id;
 
 	return (
 		<>
@@ -694,7 +696,7 @@ function KanbanBoard({
 				disableGlobalFindShortcut={disableGlobalFindShortcut}
 			/>
 			{isCarousel ? (
-				<MobileBoardCarousel columns={carouselColumns} />
+				<MobileBoardCarousel columns={carouselColumns} initialColumnId={initialColumnId} />
 			) : (
 				<div className="flex-1 min-h-0 flex gap-5 px-6 pb-6 pt-2 overflow-x-auto overflow-y-hidden kanban-scroll">
 					{(() => {

--- a/src/mainview/components/MobileBoardCarousel.tsx
+++ b/src/mainview/components/MobileBoardCarousel.tsx
@@ -16,6 +16,12 @@ export interface CarouselColumn {
 	element: ReactNode;
 }
 
+function initialColumnIndex(columns: CarouselColumn[], initialColumnId?: string): number {
+	if (!initialColumnId) return 0;
+	const index = columns.findIndex((column) => column.id === initialColumnId);
+	return index >= 0 ? index : 0;
+}
+
 function prefersReducedMotion(): boolean {
 	return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
@@ -26,10 +32,11 @@ function prefersReducedMotion(): boolean {
  * the column body scrolls vertically. Each swipe has a button + keyboard
  * (Arrow Left/Right) equivalent and announces the active column via aria-live.
  */
-function MobileBoardCarousel({ columns }: { columns: CarouselColumn[] }) {
+function MobileBoardCarousel({ columns, initialColumnId }: { columns: CarouselColumn[]; initialColumnId?: string }) {
 	const t = useT();
 	const trackRef = useRef<HTMLDivElement>(null);
-	const [active, setActive] = useState(0);
+	const [active, setActive] = useState(() => initialColumnIndex(columns, initialColumnId));
+	const hasUserNavigatedRef = useRef(false);
 	const rafRef = useRef<number | null>(null);
 
 	// Clamp the active index when the column set shrinks (e.g. a filter hides columns).
@@ -38,7 +45,8 @@ function MobileBoardCarousel({ columns }: { columns: CarouselColumn[] }) {
 	}, [columns.length]);
 
 	const goTo = useCallback(
-		(index: number) => {
+		(index: number, userInitiated = true) => {
+			if (userInitiated) hasUserNavigatedRef.current = true;
 			const track = trackRef.current;
 			if (!track) return;
 			const clamped = Math.max(0, Math.min(index, columns.length - 1));
@@ -47,6 +55,14 @@ function MobileBoardCarousel({ columns }: { columns: CarouselColumn[] }) {
 		},
 		[columns.length],
 	);
+
+	// Tasks arrive after the board shell mounts. Until the user navigates, apply
+	// the preferred attention column as soon as it becomes available.
+	useEffect(() => {
+		if (columns.length === 0 || !initialColumnId || hasUserNavigatedRef.current) return;
+		const preferredIndex = columns.findIndex((column) => column.id === initialColumnId);
+		if (preferredIndex >= 0) goTo(preferredIndex, false);
+	}, [columns.length, goTo, initialColumnId]);
 
 	// Keep the active index in sync with manual swipes.
 	const handleScroll = useCallback(() => {
@@ -141,6 +157,7 @@ function MobileBoardCarousel({ columns }: { columns: CarouselColumn[] }) {
 			<div
 				ref={trackRef}
 				onScroll={handleScroll}
+				onPointerDown={() => { hasUserNavigatedRef.current = true; }}
 				className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden snap-x snap-mandatory kanban-carousel-track"
 			>
 				{columns.map((col) => (

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -587,6 +587,18 @@ describe("mobile carousel mode", () => {
 		expect(screen.getByText(/^\d+ \/ \d+$/)).toBeTruthy();
 	});
 
+	it("starts on Has Questions when it contains tasks", async () => {
+		await renderBoardWith({ tasks: [makeTask({ status: "user-questions" })] });
+		// Has Questions is the first mobile attention queue when it has work.
+		expect(screen.getByText("3 / 8")).toBeTruthy();
+	});
+
+	it("falls back to Your Review when Has Questions is empty", async () => {
+		await renderBoardWith({ tasks: [makeTask({ status: "review-by-user" })] });
+		// With no questions waiting, show the next human-action queue instead.
+		expect(screen.getByText("5 / 8")).toBeTruthy();
+	});
+
 	it("keeps completed and cancelled columns in the mobile carousel", async () => {
 		await renderBoardWith();
 

--- a/src/mainview/components/__tests__/MobileBoardCarousel.test.tsx
+++ b/src/mainview/components/__tests__/MobileBoardCarousel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MobileBoardCarousel, { type CarouselColumn } from "../MobileBoardCarousel";
 import { I18nProvider } from "../../i18n";
@@ -22,10 +22,10 @@ function makeColumns(): CarouselColumn[] {
 	];
 }
 
-function renderCarousel(columns: CarouselColumn[]) {
+function renderCarousel(columns: CarouselColumn[], initialColumnId?: string) {
 	return render(
 		<I18nProvider>
-			<MobileBoardCarousel columns={columns} />
+			<MobileBoardCarousel columns={columns} initialColumnId={initialColumnId} />
 		</I18nProvider>,
 	);
 }
@@ -37,6 +37,40 @@ describe("MobileBoardCarousel", () => {
 		expect(screen.getByText("1 / 3")).toBeTruthy();
 		// Prev is disabled on the first column
 		expect(screen.getByLabelText("Previous column").hasAttribute("disabled")).toBe(true);
+	});
+
+	it("starts at the requested initial column", () => {
+		renderCarousel(makeColumns(), "done");
+		expect(screen.getByText("3 / 3")).toBeTruthy();
+		expect(screen.getByLabelText("Previous column").hasAttribute("disabled")).toBe(false);
+	});
+
+	it("applies a preferred column that becomes available before the user navigates", async () => {
+		const result = renderCarousel(makeColumns());
+		expect(screen.getByText("1 / 3")).toBeTruthy();
+
+		result.rerender(
+			<I18nProvider>
+				<MobileBoardCarousel columns={makeColumns()} initialColumnId="done" />
+			</I18nProvider>,
+		);
+
+		await waitFor(() => expect(screen.getByText("3 / 3")).toBeTruthy());
+	});
+
+	it("keeps the user's column after a later preferred-column update", async () => {
+		const user = userEvent.setup();
+		const result = renderCarousel(makeColumns(), "todo");
+		await user.click(screen.getByLabelText("Next column"));
+		expect(screen.getByText("2 / 3")).toBeTruthy();
+
+		result.rerender(
+			<I18nProvider>
+				<MobileBoardCarousel columns={makeColumns()} initialColumnId="done" />
+			</I18nProvider>,
+		);
+
+		await waitFor(() => expect(screen.getByText("2 / 3")).toBeTruthy());
 	});
 
 	it("advances the active column when Next is clicked", async () => {


### PR DESCRIPTION
## Summary

- Open the narrow Kanban carousel on `Has Questions` when it contains tasks.
- Fall back to `Your Review` when `Has Questions` is empty.
- Apply the preference after the initial task fetch without overriding manual navigation.

## Testing

- `bun run lint`
- `bun run test`
- Browser QA at 390x844 for both attention-column states; no console errors.