### PR TITLE
Lock mobile layout to portrait

### DIFF
--- a/change-logs/2026/07/15/fix-mobile-portrait-lock.md
+++ b/change-logs/2026/07/15/fix-mobile-portrait-lock.md
@@ -1,0 +1,1 @@
+Keep mobile dev-3.0 sessions in portrait orientation by attempting a browser orientation lock and blocking unsupported landscape sessions with a localized rotate prompt.

--- a/decisions/135-mobile-portrait-orientation-gate.md
+++ b/decisions/135-mobile-portrait-orientation-gate.md
@@ -1,0 +1,21 @@
+# Mobile portrait orientation gate
+
+## Context
+
+The phone UI is designed around narrow portrait viewports, but rotating a phone to landscape exposes the dense desktop header and toolbar. That layout is not usable on the remote/mobile form factor.
+
+## Investigation
+
+The existing `useMobile()` device-class signal is distinct from the reactive `<768px` layout signal, so a landscape phone can cross the narrow layout breakpoint. The standard Screen Orientation API is limited and may reject locks outside fullscreen, requiring an in-app fallback.
+
+## Decision
+
+Use `usePortraitOrientation()` to attempt `screen.orientation.lock("portrait")` on mobile, fullscreen transitions, and user gestures. `MobilePortraitGate` renders a localized blocking prompt and marks the underlying app inert whenever a mobile viewport remains in landscape; desktop windows are unaffected.
+
+## Risks
+
+Unsupported browsers will require the user to rotate manually, and a rejected lock may leave the prompt visible until the viewport becomes portrait. The gate is intentionally non-dismissible because the landscape UI is not a supported mobile state.
+
+## Alternatives considered
+
+Rotating the desktop layout with CSS was rejected because it creates incorrect input and hit-target geometry. A settings toggle was rejected because portrait is a device constraint, not durable user configuration; relying only on `screen.orientation.lock()` was rejected because the API is not universally available or permitted.

--- a/docs/ux/PRODUCT_UX_BIBLE.md
+++ b/docs/ux/PRODUCT_UX_BIBLE.md
@@ -331,9 +331,11 @@ Three distinct widths exist in code; they are **not** the same thing and must no
 |---|---:|---|---|---|
 | **narrow (mobile)** | `< 768px` | `useNarrowViewport(768)` (matchMedia, `CAROUSEL_MAX_WIDTH`) | yes | **the mobile doctrine** — carousel/stack/sheet layout switch. This is THE gate. Aligns with Tailwind `md`. |
 | **compact** | `< 1600px` | `useCompact()` (`COMPACT_MAX_WIDTH`) | yes | dense-desktop label hiding + header overflow kebab; **not** mobile. A wide-but-not-huge desktop is compact, not narrow. |
-| **device-class** | `screen.width < 1024` | `useMobile()` | no (mount-once) | **only** the viewport-meta decision (`useViewport`) — is this physically a small device. NOT a layout gate. |
+| **device-class** | `screen.width < 1024` | `useMobile()` | no (mount-once) | viewport-meta decision plus the **portrait-only device guard** — is this physically a small device. NOT a layout gate. |
 
-Rules: **gate layout on `useNarrowViewport`** (reactive, viewport-width). Use `useMobile()` solely for the `<meta viewport>` choice. Never gate a layout on `isElectrobun` (transport ≠ width) — browser mode can be wide, desktop can be narrowed. `useViewport()` serves **device-width** to the browser so a phone reports its true width and the media queries fire (the old fixed `width=1024` is replaced). The earlier "sub-1024 / `useMobile`" wording was wrong — the shipped gate is **768 / `useNarrowViewport`**.
+Rules: **gate layout on `useNarrowViewport`** (reactive, viewport-width). Use `useMobile()` for the `<meta viewport>` choice and the portrait-only device guard. Never gate a layout on `isElectrobun` (transport ≠ width) — browser mode can be wide, desktop can be narrowed. `useViewport()` serves **device-width** to the browser so a phone reports its true width and the media queries fire (the old fixed `width=1024` is replaced). The earlier "sub-1024 / `useMobile`" wording was wrong for layout — the shipped layout gate is **768 / `useNarrowViewport`**.
+
+**Portrait-only device guard — `Observed`:** A physically small device is locked to portrait when the browser permits the Screen Orientation API. If the lock is unsupported or rejected outside fullscreen, `MobilePortraitGate` blocks the root shell in landscape with a localized rotate-to-portrait prompt and makes the underlying app inert. Narrowed desktop windows are unaffected because they are not the mobile device class.
 
 ### 12.2 The one-at-a-time pattern + gesture law
 
@@ -350,6 +352,7 @@ Every surface from §5 gets an explicit narrow form. "—" = unchanged.
 
 | Surface | Desktop form | Narrow (<768) form | Status |
 |---|---|---|---|
+| Mobile orientation | natural device orientation | **portrait-only device guard**; best-effort platform lock plus a blocking rotate prompt fallback in landscape | `Observed` (`MobilePortraitGate`, `usePortraitOrientation`) |
 | Kanban board | all columns side-by-side | **column carousel** (one column/screen, swipe; vertical task scroll; collapsed cols excluded, empty kept) | `Observed` |
 | Task move (drag) | drag card across columns | drag impossible → **"Move to <status>" action sheet** (long-press card) on the existing status path; completion reuses `confirmTaskCompletion` | `Proposed` |
 | Board filters/search | inline `LabelFilterBar` + `FilterFunnel` dropdown (token-DSL) | **bottom sheet** behind the funnel button (same grouped facets) | `Proposed` |

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -4,6 +4,12 @@ Compact index of UX architecture decisions — the *why* behind rules that live 
 `PRODUCT_UX_BIBLE.md` / `ux-architecture.yaml`. Max ~5 lines per entry; details live in
 git history, PRs, and `decisions/NNN-*.md`. Newest first.
 
+## 2026-07-15 — Mobile devices are portrait-only
+
+- **Rule:** `useMobile()` devices attempt a portrait Screen Orientation lock; when the browser rejects it, `MobilePortraitGate` blocks the root shell in landscape with a localized rotate prompt and inert underlying content. Narrowed desktop windows stay unchanged.
+- **Why:** The landscape desktop toolbar is not functional on phones, while the lock API is limited and commonly requires fullscreen. A blocking fallback preserves a usable portrait UI; a settings toggle or rotated desktop layout would add configuration and complexity.
+- **Status:** Implemented. Evidence: `MobilePortraitGate.tsx`, `usePortraitOrientation.ts`, bible §12.1/§12.3.
+
 ## 2026-07-13 — Terminal immersive fullscreen is app-only and ephemeral
 
 - **Rule:** The TaskInfoPanel fullscreen toggle plus F11 / Cmd/Ctrl+Shift+F enters a task-bound renderer view with only a thin `dev3` strip and a wide neutral Exit full screen button; agent-facing notifications and viewer events queue during immersive fullscreen or persistent Focus Mode and flush when the active mode ends, with notification clicks exiting immersive fullscreen before normal task navigation.

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -617,13 +617,14 @@ ux_architecture:
       device_class:
         rule: "screen.width < 1024px"
         signal: "useMobile() — mount-once, NOT reactive"
-        governs: "ONLY the <meta viewport> decision in useViewport(). NOT a layout gate."
-      reconciliation: "Gate LAYOUT on useNarrowViewport (reactive). Use useMobile ONLY for viewport-meta. NEVER gate layout on isElectrobun (transport != width). Earlier 'sub-1024 / useMobile' wording was wrong; shipped gate is 768 / useNarrowViewport."
+        governs: "the <meta viewport> decision in useViewport() plus the portrait-only device guard. NOT a layout gate."
+      reconciliation: "Gate LAYOUT on useNarrowViewport (reactive). Use useMobile for viewport-meta and the portrait-only device guard. NEVER gate layout on isElectrobun (transport != width). Earlier 'sub-1024 / useMobile' wording was wrong for layout; shipped gate is 768 / useNarrowViewport."
     gesture_law:
       scroll_body: "board columns / lists / settings sections — one sibling = 100vw via CSS scroll-snap, body scrolls the OTHER axis. FULL-SURFACE SWIPE ALLOWED (axis unambiguous; delegate to browser)."
       live_content: "terminal pane / diff stream / any canvas/TUI — one element + position indicator (dots). FULL-SURFACE SWIPE ALLOWED BUT AXIS-ARBITRATED: claim a gesture only once clearly horizontal (capture-phase preventDefault+stopPropagation, cancel nascent selection); vertical drags + taps fall through to the content. scroll-snap can't do this (no sibling slides) -> manual gesture. (Revised 2026-06-29; was 'swipe forbidden, pager only' — bottom pager bar collided with the mobile keyboard. See decision 089.)"
       always: "every swipe has a button + keyboard equivalent (chevrons/dots/Arrow Left-Right); swipe is never the only way. Focus follows the active sibling; aria-live announces it. prefers-reduced-motion snaps instantly — honour EVERYWHERE (today only MobileBoardCarousel does)."
     surface_adaptation: # every §5 surface gets a narrow form
+      mobile_orientation: { narrow: "portrait-only device guard — best-effort Screen Orientation API lock, with a blocking localized rotate prompt and inert app fallback when landscape cannot be locked", status: observed, evidence: "MobilePortraitGate.tsx, usePortraitOrientation.ts" }
       kanban_board: { narrow: "column carousel (one column/screen, swipe; vertical task scroll; collapsed cols excluded, empty kept)", status: observed, evidence: "MobileBoardCarousel.tsx, KanbanBoard.tsx useNarrowViewport(768), KanbanColumn fullWidth" }
       task_move_drag: { narrow: "drag impossible -> 'Move to <status>' bottom action sheet (long-press) on existing status path; completion reuses confirmTaskCompletion", status: proposed }
       board_filters: { narrow: "bottom sheet behind a header funnel button (LabelFilterBar + search)", status: proposed }

--- a/src/mainview/components/MobilePortraitGate.tsx
+++ b/src/mainview/components/MobilePortraitGate.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useT } from "../i18n";
+import { useMobile } from "../hooks/useMobile";
+import { usePortraitOrientation } from "../hooks/usePortraitOrientation";
+
+export default function MobilePortraitGate({ children }: { children: ReactNode }) {
+	const t = useT();
+	const isMobile = useMobile();
+	const landscape = usePortraitOrientation(isMobile);
+	const appRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const app = appRef.current;
+		if (!app) return;
+
+		if (landscape) {
+			app.setAttribute("inert", "");
+			app.setAttribute("aria-hidden", "true");
+			if (app.contains(document.activeElement)) {
+				(document.activeElement as HTMLElement).blur();
+			}
+		} else {
+			app.removeAttribute("inert");
+			app.removeAttribute("aria-hidden");
+		}
+	}, [landscape]);
+
+	return (
+		<div className="relative h-full w-full">
+			<div ref={appRef} className="h-full w-full" aria-hidden={landscape || undefined}>
+				{children}
+			</div>
+			{landscape && (
+				<div
+					data-testid="mobile-portrait-gate"
+					role="alert"
+					aria-live="assertive"
+					aria-atomic="true"
+					className="fixed inset-0 z-[200] flex items-center justify-center bg-base/95 px-6 text-center"
+				>
+					<div className="w-full max-w-sm rounded-2xl border border-edge bg-raised p-6 shadow-2xl">
+						<div
+							className="mb-4 text-4xl leading-none text-accent"
+							style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+							aria-hidden="true"
+						>
+							{"↕"}
+						</div>
+						<h1 className="text-lg font-semibold text-fg">{t("mobile.portrait.title")}</h1>
+						<p className="mt-2 text-sm leading-relaxed text-fg-2">{t("mobile.portrait.message")}</p>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/mainview/components/__tests__/MobilePortraitGate.test.tsx
+++ b/src/mainview/components/__tests__/MobilePortraitGate.test.tsx
@@ -1,0 +1,125 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "../../i18n";
+import MobilePortraitGate from "../MobilePortraitGate";
+import { useMobile } from "../../hooks/useMobile";
+
+vi.mock("../../hooks/useMobile", () => ({
+	useMobile: vi.fn(),
+}));
+
+const mockedUseMobile = vi.mocked(useMobile);
+const originalMatchMedia = window.matchMedia;
+const originalOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation");
+
+describe("MobilePortraitGate", () => {
+	let landscape = false;
+	let lock: ReturnType<typeof vi.fn>;
+	const listeners = new Set<(event: MediaQueryListEvent) => void>();
+	const mediaQuery = {
+		get matches() {
+			return landscape;
+		},
+		media: "(orientation: landscape)",
+		onchange: null,
+		addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+			listeners.add(listener);
+		},
+		removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+			listeners.delete(listener);
+		},
+		addListener: (listener: (event: MediaQueryListEvent) => void) => listeners.add(listener),
+		removeListener: (listener: (event: MediaQueryListEvent) => void) => listeners.delete(listener),
+		dispatchEvent: vi.fn(),
+	} as unknown as MediaQueryList;
+
+	beforeEach(() => {
+		landscape = false;
+		listeners.clear();
+		lock = vi.fn().mockResolvedValue(undefined);
+		mockedUseMobile.mockReturnValue(true);
+		Object.defineProperty(window, "matchMedia", {
+			configurable: true,
+			value: vi.fn(() => mediaQuery),
+		});
+		Object.defineProperty(window.screen, "orientation", {
+			configurable: true,
+			value: { lock },
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, "matchMedia", {
+			configurable: true,
+			value: originalMatchMedia,
+		});
+		if (originalOrientation) {
+			Object.defineProperty(window.screen, "orientation", originalOrientation);
+		} else {
+			Object.defineProperty(window.screen, "orientation", {
+				configurable: true,
+				value: undefined,
+			});
+		}
+	});
+
+	function renderGate() {
+		return render(
+			<I18nProvider>
+				<MobilePortraitGate>
+					<div data-testid="app-content">App content</div>
+				</MobilePortraitGate>
+			</I18nProvider>,
+		);
+	}
+
+	it("keeps the app available in portrait", () => {
+		renderGate();
+
+		expect(screen.queryByTestId("mobile-portrait-gate")).not.toBeInTheDocument();
+		expect(screen.getByTestId("app-content")).toBeInTheDocument();
+		expect(lock).toHaveBeenCalledWith("portrait");
+	});
+
+	it("blocks mobile content in landscape and asks for portrait", () => {
+		landscape = true;
+		renderGate();
+
+		expect(screen.getByTestId("mobile-portrait-gate")).toHaveTextContent("Rotate to portrait");
+		expect(screen.getByTestId("app-content").parentElement).toHaveAttribute("inert");
+		expect(screen.getByTestId("app-content").parentElement).toHaveAttribute("aria-hidden", "true");
+		expect(lock).toHaveBeenCalledWith("portrait");
+	});
+
+	it("removes the gate when the viewport returns to portrait", () => {
+		landscape = true;
+		renderGate();
+
+		act(() => {
+			landscape = false;
+			for (const listener of listeners) listener({ matches: false } as MediaQueryListEvent);
+		});
+
+		expect(screen.queryByTestId("mobile-portrait-gate")).not.toBeInTheDocument();
+		expect(screen.getByTestId("app-content").parentElement).not.toHaveAttribute("inert");
+	});
+
+	it("does not block a desktop browser window in landscape", () => {
+		landscape = true;
+		mockedUseMobile.mockReturnValue(false);
+		renderGate();
+
+		expect(screen.queryByTestId("mobile-portrait-gate")).not.toBeInTheDocument();
+		expect(lock).not.toHaveBeenCalled();
+	});
+
+	it("keeps the fallback visible when the browser rejects the lock", async () => {
+		landscape = true;
+		lock.mockRejectedValueOnce(new Error("fullscreen required"));
+		renderGate();
+
+		await act(async () => {});
+
+		expect(screen.getByTestId("mobile-portrait-gate")).toBeInTheDocument();
+	});
+});

--- a/src/mainview/hooks/usePortraitOrientation.ts
+++ b/src/mainview/hooks/usePortraitOrientation.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+
+const LANDSCAPE_QUERY = "(orientation: landscape)";
+
+/** Return whether the current viewport is wider than it is tall. */
+export function isLandscapeViewport(): boolean {
+	return typeof window !== "undefined"
+		&& typeof window.matchMedia === "function"
+		&& window.matchMedia(LANDSCAPE_QUERY).matches;
+}
+
+/**
+ * Ask the browser to keep a mobile document in portrait orientation.
+ * Browsers may reject this outside fullscreen or when the API is unsupported;
+ * the caller must keep a visible fallback for that case.
+ */
+export async function requestPortraitLock(): Promise<boolean> {
+	if (typeof window === "undefined") return false;
+	const orientation = window.screen?.orientation;
+	if (!orientation || typeof orientation.lock !== "function") return false;
+
+	try {
+		await orientation.lock("portrait");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Track a mobile viewport's orientation and retry the platform lock when a
+ * user gesture or fullscreen transition gives the browser permission to apply
+ * it. The returned state remains true when locking is unavailable so the UI
+ * can fall back to a portrait-only gate.
+ */
+export function usePortraitOrientation(isMobile: boolean): boolean {
+	const [landscape, setLandscape] = useState(() => isMobile && isLandscapeViewport());
+
+	useEffect(() => {
+		if (!isMobile || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+			setLandscape(false);
+			return;
+		}
+
+		const mediaQuery = window.matchMedia(LANDSCAPE_QUERY);
+		let lockInFlight = false;
+		let retryTimer: number | null = null;
+
+		const tryLock = () => {
+			if (lockInFlight || document.visibilityState === "hidden") return;
+			if (!window.screen?.orientation || typeof window.screen.orientation.lock !== "function") return;
+
+			lockInFlight = true;
+			void requestPortraitLock().finally(() => {
+				lockInFlight = false;
+			});
+		};
+		const refresh = () => {
+			setLandscape(mediaQuery.matches);
+			if (mediaQuery.matches) tryLock();
+		};
+		const retryAfterGesture = () => {
+			if (retryTimer !== null) window.clearTimeout(retryTimer);
+			retryTimer = window.setTimeout(() => {
+				retryTimer = null;
+				tryLock();
+			}, 0);
+		};
+		const onFullscreenChange = () => {
+			if (document.fullscreenElement) tryLock();
+		};
+
+		setLandscape(mediaQuery.matches);
+		tryLock();
+		mediaQuery.addEventListener("change", refresh);
+		window.addEventListener("resize", refresh);
+		document.addEventListener("fullscreenchange", onFullscreenChange);
+		document.addEventListener("pointerup", retryAfterGesture, true);
+		document.addEventListener("click", retryAfterGesture, true);
+
+		return () => {
+			mediaQuery.removeEventListener("change", refresh);
+			window.removeEventListener("resize", refresh);
+			document.removeEventListener("fullscreenchange", onFullscreenChange);
+			document.removeEventListener("pointerup", retryAfterGesture, true);
+			document.removeEventListener("click", retryAfterGesture, true);
+			if (retryTimer !== null) window.clearTimeout(retryTimer);
+		};
+	}, [isMobile]);
+
+	return isMobile && landscape;
+}

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -232,6 +232,8 @@ const common = {
 	"showArtifact.toast_other": "Agent shared {count} HTML artifacts",
 	"showArtifact.attention_one": "Shared an HTML artifact",
 	"showArtifact.attention_other": "Shared {count} HTML artifacts",
+	"mobile.portrait.title": "Rotate to portrait",
+	"mobile.portrait.message": "dev-3.0 works best in portrait mode on phones. Rotate your device to continue.",
 	"mobile.backExitToast": "Press Back again to exit",
 } as const;
 

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -231,6 +231,8 @@ const common = {
 	"showArtifact.toast_other": "El agente compartió {count} artefactos HTML",
 	"showArtifact.attention_one": "Compartió un artefacto HTML",
 	"showArtifact.attention_other": "Compartió {count} artefactos HTML",
+	"mobile.portrait.title": "Gira el dispositivo a vertical",
+	"mobile.portrait.message": "dev-3.0 funciona mejor en modo vertical en teléfonos. Gira el dispositivo para continuar.",
 	"mobile.backExitToast": "Pulsa Atrás de nuevo para salir",
 };
 

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -241,6 +241,8 @@ const common = {
 	"showArtifact.attention_few": "Прислал {count} HTML-артефакта",
 	"showArtifact.attention_many": "Прислал {count} HTML-артефактов",
 	"showArtifact.attention_other": "Прислал {count} HTML-артефактов",
+	"mobile.portrait.title": "Поверните телефон вертикально",
+	"mobile.portrait.message": "На телефоне dev-3.0 работает в портретном режиме. Поверните устройство, чтобы продолжить.",
 	"mobile.backExitToast": "Нажмите «Назад» ещё раз для выхода",
 };
 

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -13,6 +13,7 @@ import { bootstrapZoom } from "./zoom";
 import { bootstrapScrollSpeed } from "./scroll-speed";
 import { getInitialThemeState, getWindowInjectedThemeState } from "./theme-bootstrap";
 import RootErrorBoundary from "./components/RootErrorBoundary";
+import MobilePortraitGate from "./components/MobilePortraitGate";
 import { recordError, recordRejection } from "./diagnostics";
 
 // ── Global crash handlers (renderer) ──
@@ -128,7 +129,9 @@ async function bootstrap() {
 			<RootErrorBoundary>
 				<MobileProvider>
 					<I18nProvider>
-						<App />
+						<MobilePortraitGate>
+							<App />
+						</MobilePortraitGate>
 					</I18nProvider>
 				</MobileProvider>
 			</RootErrorBoundary>


### PR DESCRIPTION
## Summary

- Attempt a portrait Screen Orientation lock for physically small mobile devices.
- Block unsupported landscape sessions with a localized rotate-to-portrait prompt and inert underlying UI.
- Document the responsive rule and add regression coverage for mobile, desktop, and rejected locks.

## Verification

- `bun run lint`
- `bun run test`
- `bun run build`
- Browser QA in iPhone portrait and landscape viewports with no console errors.