### PR TITLE
Prefix dev-build window title with [DEV from src]

### DIFF
--- a/change-logs/2026/07/15/feature-dev-title-prefix.md
+++ b/change-logs/2026/07/15/feature-dev-title-prefix.md
@@ -1,0 +1,1 @@
+Dev builds (channel "dev", i.e. `bun run dev` from source) now show a "[DEV from src]" prefix in the window title so a locally built window is unmistakable next to an installed production/staging one.

--- a/src/bun/__tests__/app-utils.test.ts
+++ b/src/bun/__tests__/app-utils.test.ts
@@ -86,4 +86,16 @@ describe("makeTitle", () => {
 			"dev-3.0 v0.3.6-beta.1 [now]",
 		);
 	});
+
+	it("prefixes dev builds with [DEV from src]", () => {
+		expect(makeTitle("1.2.3", "Mon, 4 Mar 2024", "dev")).toBe(
+			"[DEV from src] dev-3.0 v1.2.3 [Mon, 4 Mar 2024]",
+		);
+	});
+
+	it("does not prefix non-dev channels", () => {
+		expect(makeTitle("1.2.3", "now", "prod")).toBe("dev-3.0 v1.2.3 [now]");
+		expect(makeTitle("1.2.3", "now", "stable")).toBe("dev-3.0 v1.2.3 [now]");
+		expect(makeTitle("1.2.3", "now", undefined)).toBe("dev-3.0 v1.2.3 [now]");
+	});
 });

--- a/src/bun/app-utils.ts
+++ b/src/bun/app-utils.ts
@@ -33,7 +33,9 @@ export const formatDateTime = (d: Date) => {
 };
 
 /**
- * Builds the window title string.
+ * Builds the window title string. Dev builds (channel "dev", i.e. `bun run dev`
+ * from source) get a "[DEV from src]" prefix so they are unmistakable next to an
+ * installed production/staging window.
  */
-export const makeTitle = (version: string, dt: string) =>
-	`dev-3.0 v${version} [${dt}]`;
+export const makeTitle = (version: string, dt: string, buildChannel?: string) =>
+	`${buildChannel === "dev" ? "[DEV from src] " : ""}dev-3.0 v${version} [${dt}]`;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -317,13 +317,13 @@ onMenuContextChange((ctx) => {
 // --- Main Window ---
 
 async function openMainWindow() {
+	const buildChannel = await Updater.localInfo.channel();
 	return createAppWindow({
-		title: makeTitle(APP_VERSION, lastBuildTime),
+		title: makeTitle(APP_VERSION, lastBuildTime, buildChannel),
 		url,
 		handlers: handlers as unknown as Record<string, (...args: unknown[]) => unknown>,
 		onDomReady: async (win) => {
-			const channel = await Updater.localInfo.channel();
-			if (channel === "dev") {
+			if (buildChannel === "dev") {
 				win.webview.openDevTools();
 			}
 			log.info(`DOM ready [${lastBuildTime}]`);

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -108,12 +108,15 @@ async function bootstrap() {
 	// Electrobun message loss under burst) while mobile/browser doesn't
 	// block forever if WS isn't connected.
 	try {
-		const { version } = await Promise.race([
+		const { version, buildChannel } = await Promise.race([
 			api.request.getAppVersion(),
 			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
 		]);
 		initAnalytics(version);
-		document.title = `dev-3.0 v${version}`;
+		// Dev builds (channel "dev" = `bun run dev` from source) get a visible
+		// prefix so the window is unmistakable next to an installed prod window.
+		const devPrefix = buildChannel === "dev" ? "[DEV from src] " : "";
+		document.title = `${devPrefix}dev-3.0 v${version}`;
 	} catch (err) {
 		console.warn("[main] Failed to init analytics:", err);
 		initAnalytics("unknown");


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Dev builds (channel `dev`, i.e. `bun run dev` from source) now show a `[DEV from src]` prefix in the window title — e.g. `[DEV from src] dev-3.0 v1.35.2` — so a locally built window is unmistakable next to an installed production/staging one.

Previously the window title was a hardcoded `dev-3.0 v<version>` literal that never reflected the build channel (the `-dev` suffix only lived in the `.app` bundle name / Dock / menu bar, via electrobun's channel suffix).

## Changes

- `src/bun/app-utils.ts` — `makeTitle(version, dt, buildChannel?)` prepends `[DEV from src] ` when `buildChannel === "dev"` (native title before the renderer loads).
- `src/bun/index.ts` — `openMainWindow` resolves the build channel once and passes it to `makeTitle` (also reused for the devtools check instead of a second lookup).
- `src/mainview/main.tsx` — `document.title` (which overrides the native title after the renderer mounts) gets the same prefix, using the `buildChannel` already returned by `getAppVersion`.
- Tests for the new prefix behavior + changelog entry.

Prod/staging builds are unchanged (no prefix).