### PR TITLE
Sort Completed/Cancelled Kanban columns by recency, not priority

### DIFF
--- a/change-logs/2026/07/15/fix-terminal-column-recency-sort.md
+++ b/change-logs/2026/07/15/fix-terminal-column-recency-sort.md
@@ -1,0 +1,1 @@
+Completed and Cancelled Kanban columns now sort by when each task landed there — freshest on top — instead of by priority. Priority ordering still applies to every other column.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -483,7 +483,7 @@ function KanbanBoard({
 	for (const status of ALL_STATUSES) {
 		const columnTasks = tasksByStatus.get(status);
 		if (columnTasks && columnTasks.length > 1) {
-			tasksByStatus.set(status, sortTasksForColumn(columnTasks, globalSettings.taskDropPosition, moveOrderMap));
+			tasksByStatus.set(status, sortTasksForColumn(columnTasks, globalSettings.taskDropPosition, moveOrderMap, status));
 		}
 	}
 

--- a/src/mainview/components/__tests__/sortTasksForColumn.test.ts
+++ b/src/mainview/components/__tests__/sortTasksForColumn.test.ts
@@ -478,3 +478,61 @@ describe("sortTasksForColumn — priority bands", () => {
 		expect(ids(result)).toEqual(["g-v1", "g-v2", "solo"]);
 	});
 });
+
+// ============================================================
+// Terminal columns (completed / cancelled) — recency, not priority
+// ============================================================
+
+describe("sortTasksForColumn — completed/cancelled sort by entry time (freshest on top)", () => {
+	it.each(["completed", "cancelled"] as const)("%s: most recently entered on top, ignoring priority", (status) => {
+		const tasks = [
+			// High priority but landed here first → must sink to the bottom.
+			makeTask({ id: "old-p0", priority: "P0", movedAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "mid-p4", priority: "P4", movedAt: "2025-06-01T00:00:00Z" }),
+			makeTask({ id: "new-p2", priority: "P2", movedAt: "2025-12-01T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap, status);
+		expect(ids(result)).toEqual(["new-p2", "mid-p4", "old-p0"]);
+	});
+
+	it("recency wins over the global 'bottom' drop-position setting", () => {
+		const tasks = [
+			makeTask({ id: "old", movedAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "new", movedAt: "2025-09-01T00:00:00Z" }),
+		];
+		// Even with dropPosition "bottom", terminal columns keep freshest on top.
+		const result = sortTasksForColumn(tasks, "bottom", emptyMap, "completed");
+		expect(ids(result)).toEqual(["new", "old"]);
+	});
+
+	it("variant grouping does NOT keep a group contiguous — pure recency ordering", () => {
+		const tasks = [
+			makeTask({ id: "g-v1", groupId: "g1", variantIndex: 1, movedAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "solo", movedAt: "2025-05-01T00:00:00Z" }),
+			makeTask({ id: "g-v2", groupId: "g1", variantIndex: 2, movedAt: "2025-09-01T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap, "completed");
+		expect(ids(result)).toEqual(["g-v2", "solo", "g-v1"]);
+	});
+
+	it("falls back to createdAt when movedAt is absent", () => {
+		const tasks = [
+			makeTask({ id: "a", createdAt: "2025-01-01T00:00:00Z" }),
+			makeTask({ id: "b", createdAt: "2025-08-01T00:00:00Z" }),
+		];
+		const result = sortTasksForColumn(tasks, "top", emptyMap, "cancelled");
+		expect(ids(result)).toEqual(["b", "a"]);
+	});
+
+	it("in-session move floats a just-finished card above older entries", () => {
+		const tasks = [
+			makeTask({ id: "recent", movedAt: "2025-12-01T00:00:00Z" }),
+			makeTask({ id: "just-moved", movedAt: "2025-01-01T00:00:00Z" }),
+		];
+		// `just-moved` was dropped in this session; it must jump to the top even
+		// though its persisted movedAt is older (backend refresh not yet applied).
+		const moveOrder = new Map([["just-moved", 1]]);
+		const result = sortTasksForColumn(tasks, "top", moveOrder, "completed");
+		expect(ids(result)).toEqual(["just-moved", "recent"]);
+	});
+});

--- a/src/mainview/components/sortTasks.ts
+++ b/src/mainview/components/sortTasks.ts
@@ -1,10 +1,40 @@
-import { comparePriority, type Task } from "../../shared/types";
+import { comparePriority, type Task, type TaskStatus } from "../../shared/types";
+
+/**
+ * Terminal columns are a chronological log, not a prioritized queue: the user
+ * wants the most recently finished/cancelled task on top, ignoring priority.
+ */
+const RECENCY_SORTED_STATUSES: ReadonlySet<TaskStatus> = new Set(["completed", "cancelled"]);
+
+// "When it landed in this column" — `movedAt` is stamped on every rendered-column
+// change; fall back to `createdAt` for tasks that predate movedAt tracking.
+function columnEntryTime(task: Task): string {
+	return task.movedAt ?? task.createdAt;
+}
 
 export function sortTasksForColumn(
 	tasks: Task[],
 	dropPosition: "top" | "bottom",
 	moveOrderMap: Map<string, number>,
+	status?: TaskStatus,
 ): Task[] {
+	// Completed / Cancelled: pure recency, freshest on top, regardless of priority,
+	// variant grouping, persisted column order, or the global drop-position setting.
+	if (status !== undefined && RECENCY_SORTED_STATUSES.has(status)) {
+		return [...tasks].sort((a, b) => {
+			// In-session cross-column moves win so a just-finished card jumps to the
+			// top instantly, before the backend `movedAt` refresh round-trips.
+			const aOrder = moveOrderMap.get(a.id) ?? 0;
+			const bOrder = moveOrderMap.get(b.id) ?? 0;
+			if (aOrder !== bOrder) return bOrder - aOrder;
+			// Then persisted entry time, most recent first.
+			const aTime = columnEntryTime(a);
+			const bTime = columnEntryTime(b);
+			if (aTime !== bTime) return aTime > bTime ? -1 : 1;
+			// Stable, deterministic tiebreak.
+			return a.id < b.id ? -1 : 1;
+		});
+	}
 	return [...tasks].sort((a, b) => {
 		// Strict priority bands are the TOPMOST key: every P0 above every P1, etc.
 		// A whole variant group shares one priority, so banding never splits a group.


### PR DESCRIPTION
## Summary

The **Completed** and **Cancelled** Kanban columns now behave as a chronological log: the most recently finished/cancelled task sits on top, instead of being ordered by priority.

- Terminal columns sort by `movedAt` (stamped whenever a task enters a new rendered column) — freshest first, falling back to `createdAt` for tasks predating `movedAt` tracking.
- In-session cross-column moves still win, so a just-finished card jumps to the top instantly before the backend `movedAt` refresh round-trips.
- These columns ignore priority banding, variant grouping, persisted `columnOrder`, and the global drop-position setting.
- Every other column keeps its existing priority-based ordering, unchanged.

Implemented in `sortTasks.ts` (new optional `status` param) and wired through `KanbanBoard.tsx`. Covered by 5 new unit tests; full suite green.