### PR TITLE
Fix clipped favorite labels in Favorites popover

### DIFF
--- a/change-logs/2026/07/16/fix-favorites-menu-width.md
+++ b/change-logs/2026/07/16/fix-favorites-menu-width.md
@@ -1,0 +1,1 @@
+Widen the Favorites popover so long agent, model, and mode combinations remain readable instead of being clipped.

--- a/src/mainview/components/FavoritesMenu.tsx
+++ b/src/mainview/components/FavoritesMenu.tsx
@@ -106,7 +106,7 @@ function FavoritesMenu({
 			role="menu"
 			aria-label={t("launch.favorites")}
 			className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active overflow-hidden py-1 max-w-[calc(100vw-1rem)]"
-			style={{ top: pos.top, left: pos.left, width: 260, visibility: visible ? "visible" : "hidden" }}
+			style={{ top: pos.top, left: pos.left, width: 360, visibility: visible ? "visible" : "hidden" }}
 			onClick={(e) => e.stopPropagation()}
 		>
 			{/* Save/Remove the CURRENT combo (mirrors the trigger star). Keeps the

--- a/src/mainview/components/__tests__/AgentConfigPicker.favorites.test.tsx
+++ b/src/mainview/components/__tests__/AgentConfigPicker.favorites.test.tsx
@@ -148,6 +148,19 @@ describe("AgentConfigPicker — favorites", () => {
 		expect(menuItemLabels()).toEqual(["Codex · GPT-5.5 · Default", "Claude · Opus 4.8 · Bypass · X-High"]);
 	});
 
+	it("gives the favorites menu enough width for long configuration labels", async () => {
+		const user = userEvent.setup();
+		({ container } = render(
+			<Harness
+				initial={{ agentId: "builtin-claude", configId: "fable-auto-medium" }}
+				favorites={[fav("builtin-claude", "opus-bypass-xhigh", 1, 5)]}
+			/>,
+		));
+
+		await user.click(trigger()!);
+		expect(menu()).toHaveStyle({ width: "360px" });
+	});
+
 	it("clicking a menu item selects that combo (does not launch) and closes the menu", async () => {
 		const user = userEvent.setup();
 		const onChange = vi.fn();


### PR DESCRIPTION
## Summary
- Widen the Favorites popover from 260px to 360px so long agent, model, and mode combinations remain readable.
- Preserve viewport clamping on narrow screens.
- Add a regression test for the popover width.

## Testing
- `bun run lint`
- `bun run test` (5,703 passed, 1 skipped)
- Browser QA at desktop and 320px-wide viewports with no console errors.