### PR TITLE
Add inline task priority control

### DIFF
--- a/change-logs/2026/07/16/feature-inline-task-priority-control.md
+++ b/change-logs/2026/07/16/feature-inline-task-priority-control.md
@@ -1,0 +1,1 @@
+Adds the existing compact priority picker to the task info header beside Watch, including the narrow task summary bar. Priority changes reuse the current group-wide update flow and error feedback.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -3,6 +3,7 @@ import { toast } from "../toast";
 import { createPortal } from "react-dom";
 import type { Task, Project, TaskStatus, PortInfo, ResourceUsage, Label, TaskPRBadgeInfo } from "../../shared/types";
 import LabelChip from "./LabelChip";
+import PriorityBadge from "./PriorityBadge";
 import OpenInMenu from "./OpenInMenu";
 import { formatDate } from "./NoteItem";
 import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
@@ -373,6 +374,23 @@ function TaskInfoPanel({
 		}
 	}
 
+	async function handleSetPriority(priority: Task["priority"]) {
+		if (!priority) return;
+		try {
+			const changed = await api.request.setTaskPriority({
+				taskId: task.id,
+				projectId: project.id,
+				priority,
+			});
+			// Priority is group-wide, so the RPC returns every changed variant.
+			for (const changedTask of changed) {
+				dispatch({ type: "updateTask", task: changedTask });
+			}
+		} catch (err) {
+			toast.error(t("priority.failedSet", { error: String(err) }), { taskId: task.id });
+		}
+	}
+
 	const toggleCollapsed = useCallback(() => {
 		setCollapsed((current) => !current);
 	}, []);
@@ -647,6 +665,8 @@ function TaskInfoPanel({
 		</button>
 		</Tooltip>
 	);
+
+	const priorityBadge = <PriorityBadge priority={task.priority} onChange={handleSetPriority} className="shrink-0" />;
 
 	const statusDropdownButton = (
 		<button
@@ -958,6 +978,7 @@ function TaskInfoPanel({
 				<div className="flex items-center gap-2 px-3 h-[3.25rem] min-w-0">
 					{variantSwitcher}
 					{statusDropdownButton}
+					{priorityBadge}
 					<span className="flex-1 min-w-0 truncate text-fg-2 text-sm font-semibold">{getTaskTitle(task)}</span>
 					{diffSummaryBadge}
 					<Tooltip content={t("infoPanel.actionsTitle")} detail={t("ttip.infoPanel.actions")}>
@@ -1086,6 +1107,7 @@ function TaskInfoPanel({
 					<div className="flex items-center gap-1.5 min-w-0">
 						{variantSwitcher}
 						{watchToggleButton}
+						{priorityBadge}
 						{statusDropdownButton}
 						{statusDropdownPortal}
 						{diffSummaryBadge}
@@ -1161,6 +1183,7 @@ function TaskInfoPanel({
 							<div className="flex items-center gap-1.5 min-w-0" data-help-id="inspector.context-bar">
 								{variantSwitcher}
 								{watchToggleButton}
+								{priorityBadge}
 								{statusDropdownButton}
 								{statusDropdownPortal}
 								{diffSummaryBadge}

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../rpc", () => ({
 			updateTaskNote: vi.fn(),
 			deleteTaskNote: vi.fn(),
 			getResolvedProject: vi.fn(),
+			setTaskPriority: vi.fn(),
 			runDevServer: vi.fn(),
 			checkDevServer: vi.fn(),
 			stopDevServer: vi.fn(),
@@ -266,6 +267,45 @@ describe("TaskInfoPanel", () => {
 				renderPanel(makeTask({ status: "in-progress" }));
 			});
 			expect(screen.getByText("Agent is Working")).toBeInTheDocument();
+		});
+
+		it("changes priority from the compact header badge", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const task = makeTask({ priority: "P3" });
+			const changedTask = { ...task, priority: "P1" as const };
+			const dispatch = vi.fn();
+			mockedApi.request.setTaskPriority.mockResolvedValue([changedTask]);
+
+			await act(async () => {
+				renderPanel(task, { dispatch });
+			});
+
+			const priorityButton = screen.getByRole("button", { name: "Priority P3 (Low) — change" });
+			await user.click(priorityButton);
+			await user.click(screen.getByRole("menuitemradio", { name: /P1/ }));
+
+			expect(mockedApi.request.setTaskPriority).toHaveBeenCalledWith({
+				taskId: task.id,
+				projectId: project.id,
+				priority: "P1",
+			});
+			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: changedTask });
+		});
+
+		it("shows an error toast when changing priority fails", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			mockedApi.request.setTaskPriority.mockRejectedValue(new Error("offline"));
+
+			await act(async () => {
+				renderPanel(makeTask({ priority: "P3" }));
+			});
+
+			await user.click(screen.getByRole("button", { name: "Priority P3 (Low) — change" }));
+			await user.click(screen.getByRole("menuitemradio", { name: /P1/ }));
+
+			await waitFor(() => {
+				expect(toast.error).toHaveBeenCalledWith("Failed to set priority: Error: offline", { taskId: "t1" });
+			});
 		});
 
 		it("renders labels when present", async () => {


### PR DESCRIPTION
## Summary
- Add a compact priority badge beside Watch in the task info header.
- Reuse the existing priority picker and group-wide update flow.
- Keep the control available in collapsed, expanded, and narrow task views.

## Verification
- `bun run lint`
- `bun run test`
- Browser QA at desktop and narrow view with no console errors.