### PR TITLE
Add project picker to task creation

### DIFF
--- a/change-logs/2026/07/16/feature-cross-project-task-creation.md
+++ b/change-logs/2026/07/16/feature-cross-project-task-creation.md
@@ -1,0 +1,1 @@
+Task creation now includes a project picker that defaults to the current board, allowing users to create and launch tasks in another project without navigating away.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1992,15 +1992,16 @@ function App() {
 			{createTaskProject && (
 				<CreateTaskModal
 					project={createTaskProject}
+					projects={state.projects}
 					dispatch={dispatch}
 					onClose={() => setCreateTaskProjectId(null)}
-					onCreateAndRun={(task) => {
+					onCreateAndRun={(task, project) => {
 						setCreateTaskProjectId(null);
-						setLaunchModal({ task, targetStatus: "in-progress", project: createTaskProject });
+						setLaunchModal({ task, targetStatus: "in-progress", project });
 					}}
-					onOpenAutomations={() => {
+					onOpenAutomations={(project) => {
 						setCreateTaskProjectId(null);
-						navigate({ screen: "project-settings", projectId: createTaskProject.id, tab: "automations" });
+						navigate({ screen: "project-settings", projectId: project.id, tab: "automations" });
 					}}
 				/>
 			)}

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef, useCallback, type Dispatch } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch } from "react";
 import { toast } from "../toast";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import { DEFAULT_PRIORITY, titleFromDescription, type Project, type Task, type TaskPriority } from "../../shared/types";
+import { DEFAULT_PRIORITY, isBuiltinOpsProject, orderProjectsForDisplay, titleFromDescription, type Project, type Task, type TaskPriority } from "../../shared/types";
 import type { AppAction } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
@@ -19,6 +19,7 @@ import SkillAutocompleteDropdown from "./SkillAutocompleteDropdown";
 import { openFolderPicker } from "../folder-picker";
 import { useFocusTrap } from "../utils/useFocusTrap";
 import HelpSpot from "./HelpSpot";
+import Select from "./Select";
 
 interface ProjectCurrentBranchInfo {
 	branch: string | null;
@@ -28,15 +29,26 @@ interface ProjectCurrentBranchInfo {
 
 interface CreateTaskModalProps {
 	project: Project;
+	projects?: Project[];
 	dispatch: Dispatch<AppAction>;
 	onClose: () => void;
-	onCreateAndRun?: (task: Task) => void;
-	onOpenAutomations?: () => void;
+	onCreateAndRun?: (task: Task, project: Project) => void;
+	onOpenAutomations?: (project: Project) => void;
 }
 
-function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAutomations }: CreateTaskModalProps) {
+function CreateTaskModal({ project: initialProject, projects, dispatch, onClose, onCreateAndRun, onOpenAutomations }: CreateTaskModalProps) {
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
+	const availableProjects = useMemo(() => {
+		const visibleProjects = (projects ?? []).filter((candidate) => !candidate.deleted);
+		if (!visibleProjects.some((candidate) => candidate.id === initialProject.id)) {
+			visibleProjects.push(initialProject);
+		}
+		return orderProjectsForDisplay(visibleProjects);
+	}, [initialProject, projects]);
+	const [selectedProjectId, setSelectedProjectId] = useState(initialProject.id);
+	const selectedProject = availableProjects.find((candidate) => candidate.id === selectedProjectId) ?? initialProject;
+	const project = selectedProject;
 	const [description, setDescription] = useState("");
 	const [creating, setCreating] = useState(false);
 	const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
@@ -57,6 +69,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 	// Virtual ops only: chosen fixed working folder (null = managed temp dir).
 	const [opsFolder, setOpsFolder] = useState<string | null>(null);
 	const [opsFolderConflict, setOpsFolderConflict] = useState(false);
+	const projectBranchRequestRef = useRef(0);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const titleInputRef = useRef<HTMLInputElement>(null);
 	const keepEditingRef = useRef<HTMLButtonElement>(null);
@@ -66,20 +79,42 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 	const baseBranch = project.defaultBaseBranch || "main";
 
 	const loadProjectCurrentBranch = useCallback(async (): Promise<ProjectCurrentBranchInfo | null> => {
+		const requestId = ++projectBranchRequestRef.current;
 		try {
 			const result = await api.request.getProjectCurrentBranch({ projectId: project.id });
+			if (requestId !== projectBranchRequestRef.current) return null;
 			if (!result.isBaseBranch && result.branch) {
 				setSelectedBranch((prev) => prev ?? result.branch);
 			}
 			setProjectCurrentBranch(result);
 			return result;
 		} catch {
+			if (requestId !== projectBranchRequestRef.current) return null;
 			setProjectCurrentBranch(null);
 			return null;
 		} finally {
-			setCheckedProjectCurrentBranch(true);
+			if (requestId === projectBranchRequestRef.current) {
+				setCheckedProjectCurrentBranch(true);
+			}
 		}
 	}, [project.id]);
+
+	function handleProjectChange(projectId: string) {
+		if (creating || projectId === selectedProjectId) return;
+		projectBranchRequestRef.current += 1;
+		setSelectedProjectId(projectId);
+		setSelectedLabelIds([]);
+		setLabelPickerOpen(false);
+		setSelectedBranch(null);
+		setProjectCurrentBranch(null);
+		setCheckedProjectCurrentBranch(false);
+		setPendingBranchChoice(null);
+		setPendingSubmitMode(null);
+		setDismissedPrUrl(null);
+		setOpsFolder(null);
+		setOpsFolderConflict(false);
+		if (reviewMode) handleReviewModeChange(false);
+	}
 
 	const insertPathAtCursor = useCallback((path: string) => {
 		setDescription((prev) => {
@@ -258,7 +293,12 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 			// if a follow-up (renameTask/setTaskLabels) fails, deferring the
 			// dispatch would leave an invisible orphan and tempt a duplicate on
 			// retry. Title/labels are non-fatal follow-ups on the created task.
-			dispatch({ type: "addTask", task: created });
+			// A task created in another project must not be added to the board the
+			// user is currently viewing; its persisted taskUpdated events will load
+			// it when that project is opened.
+			if (created.projectId === initialProject.id) {
+				dispatch({ type: "addTask", task: created });
+			}
 			let task = created;
 			let followUpError: unknown = null;
 			try {
@@ -291,7 +331,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 				...(mode === "scratch" ? { source: "scratch" } : {}),
 			});
 			if ((mode === "run" || mode === "scratch") && onCreateAndRun) {
-				onCreateAndRun(task);
+				onCreateAndRun(task, project);
 			} else {
 				onClose();
 			}
@@ -396,6 +436,22 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 							<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
 						</svg>
 					</button>
+				</div>
+
+				{/* Project context — defaults to the board that opened this modal. */}
+				<div className="space-y-1.5">
+					<label htmlFor="create-task-project" className="text-fg-2 text-sm font-medium">
+						{t("createTask.projectLabel")}
+					</label>
+					<Select
+						id="create-task-project"
+						value={project.id}
+						options={availableProjects.map((candidate) => ({
+							value: candidate.id,
+							label: isBuiltinOpsProject(candidate) ? t("ops.boardName") : candidate.name,
+						}))}
+						onChange={handleProjectChange}
+					/>
 				</div>
 
 				{/* Description textarea + drop zone */}
@@ -722,7 +778,7 @@ function CreateTaskModal({ project, dispatch, onClose, onCreateAndRun, onOpenAut
 								{onOpenAutomations ? (
 									<button
 										type="button"
-										onClick={onOpenAutomations}
+										onClick={() => onOpenAutomations(project)}
 										className="text-accent hover:text-accent-hover hover:underline transition-colors flex items-center gap-1"
 									>
 										<span

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -45,6 +45,17 @@ const mockProject: Project = {
 	createdAt: "2025-01-01T00:00:00Z",
 };
 
+const otherProject: Project = {
+	id: "p2",
+	name: "Other Project",
+	path: "/home/user/other-project",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-02T00:00:00Z",
+};
+
 const mockTask: Task = {
 	id: "t1",
 	seq: 1,
@@ -68,11 +79,13 @@ function renderModal(props: {
 	onClose?: () => void;
 	onCreateAndRun?: (task: Task) => void;
 	project?: Project;
+	projects?: Project[];
 } = {}) {
 	return render(
 		<I18nProvider>
 			<CreateTaskModal
 				project={props.project ?? mockProject}
+				projects={props.projects}
 				dispatch={props.dispatch ?? vi.fn()}
 				onClose={props.onClose ?? vi.fn()}
 				onCreateAndRun={props.onCreateAndRun}
@@ -147,6 +160,38 @@ describe("CreateTaskModal", () => {
 		expect(screen.queryByText("Save & Start")).not.toBeInTheDocument();
 	});
 
+	it("defaults the project selector to the board that opened the modal", async () => {
+		renderModal({ projects: [mockProject, otherProject] });
+
+		const projectSelector = screen.getByLabelText("Project");
+		expect(projectSelector).toHaveTextContent("Test Project");
+
+		await userEvent.click(projectSelector);
+		expect(screen.getByRole("button", { name: "Other Project" })).toBeInTheDocument();
+	});
+
+	it("creates the task in the selected project and passes it to Save & Start", async () => {
+		const otherTask = { ...mockTask, projectId: otherProject.id };
+		const dispatch = vi.fn();
+		const onCreateAndRun = vi.fn();
+		mockedApi.request.createTask.mockResolvedValue(otherTask);
+		renderModal({ projects: [mockProject, otherProject], dispatch, onCreateAndRun });
+
+		await userEvent.click(screen.getByLabelText("Project"));
+		await userEvent.click(screen.getByRole("button", { name: "Other Project" }));
+		await userEvent.type(screen.getByPlaceholderText("Describe what needs to be done..."), "Task for another project");
+		await userEvent.click(screen.getByText("Save & Start"));
+
+		await waitFor(() => {
+			expect(mockedApi.request.createTask).toHaveBeenCalledWith({
+				projectId: otherProject.id,
+				description: "Task for another project",
+			});
+			expect(onCreateAndRun).toHaveBeenCalledWith(otherTask, otherProject);
+		});
+		expect(dispatch).not.toHaveBeenCalledWith({ type: "addTask", task: otherTask });
+	});
+
 	it("shows dual hint text when onCreateAndRun is provided", () => {
 		renderModal({ onCreateAndRun: vi.fn() });
 		expect(screen.getByText(/\u2318\u21e7Enter/)).toBeInTheDocument();
@@ -173,7 +218,7 @@ describe("CreateTaskModal", () => {
 			});
 		});
 		expect(dispatch).toHaveBeenCalledWith({ type: "addTask", task: mockTask });
-		expect(onCreateAndRun).toHaveBeenCalledWith(mockTask);
+		expect(onCreateAndRun).toHaveBeenCalledWith(mockTask, mockProject);
 	});
 
 	it("plain Save still calls onClose", async () => {
@@ -200,7 +245,7 @@ describe("CreateTaskModal", () => {
 		await userEvent.keyboard("{Meta>}{Shift>}{Enter}{/Shift}{/Meta}");
 
 		await waitFor(() => {
-			expect(onCreateAndRun).toHaveBeenCalledWith(mockTask);
+			expect(onCreateAndRun).toHaveBeenCalledWith(mockTask, mockProject);
 		});
 	});
 
@@ -241,7 +286,7 @@ describe("CreateTaskModal", () => {
 		await userEvent.keyboard("{Control>}{Shift>}{Enter}{/Shift}{/Control}");
 
 		await waitFor(() => {
-			expect(onCreateAndRun).toHaveBeenCalledWith(mockTask);
+			expect(onCreateAndRun).toHaveBeenCalledWith(mockTask, mockProject);
 		});
 	});
 
@@ -699,7 +744,7 @@ describe("CreateTaskModal", () => {
 			});
 		});
 		expect(dispatch).toHaveBeenCalledWith({ type: "addTask", task: mockTask });
-		expect(onCreateAndRun).toHaveBeenCalledWith(mockTask);
+		expect(onCreateAndRun).toHaveBeenCalledWith(mockTask, mockProject);
 	});
 
 	it("Scratch Task ignores typed description text (backend generates placeholder)", async () => {

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -17,6 +17,7 @@ const kanban = {
 
 	// CreateTaskModal
 	"createTask.title": "New Task",
+	"createTask.projectLabel": "Project",
 	"createTask.descriptionLabel": "Description",
 	"createTask.descriptionPlaceholder": "Describe what needs to be done...",
 	"createTask.generatedTitle": "Title:",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -17,6 +17,7 @@ const kanban = {
 
 	// CreateTaskModal
 	"createTask.title": "Nueva tarea",
+	"createTask.projectLabel": "Proyecto",
 	"createTask.descriptionLabel": "Descripción",
 	"createTask.descriptionPlaceholder": "Describe lo que hay que hacer...",
 	"createTask.generatedTitle": "Título:",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -17,6 +17,7 @@ const kanban = {
 
 	// CreateTaskModal
 	"createTask.title": "Новая задача",
+	"createTask.projectLabel": "Проект",
 	"createTask.descriptionLabel": "Описание",
 	"createTask.descriptionPlaceholder": "Опишите, что нужно сделать...",
 	"createTask.generatedTitle": "Заголовок:",


### PR DESCRIPTION
## Summary

- Add a localized Project dropdown to the New Task modal, defaulting to the current project.
- Route labels, branches, worktree paths, and Save & Start/automation through the selected project.
- Keep cross-project tasks out of the current board state while preserving the existing projectId RPC flow.

## Validation

- `bun run lint`
- `bun run test`
- Manual browser QA covering the default and alternate project selection.