### PR TITLE
Show active Remote Access tunnel state

### DIFF
--- a/change-logs/2026/07/16/fix-remote-access-indicator-animation.md
+++ b/change-logs/2026/07/16/fix-remote-access-indicator-animation.md
@@ -1,0 +1,1 @@
+Keep the Remote Access QR icon animated continuously in browser remote mode so the active remote session remains visible in the global header. Desktop behavior and reduced-motion preferences remain unchanged.

--- a/change-logs/2026/07/16/fix-remote-access-indicator-animation.md
+++ b/change-logs/2026/07/16/fix-remote-access-indicator-animation.md
@@ -1,1 +1,1 @@
-Keep the Remote Access QR icon animated continuously in browser remote mode so the active remote session remains visible in the global header. Desktop behavior and reduced-motion preferences remain unchanged.
+Keep the Remote Access QR icon blue and animated continuously while the Cloudflare tunnel is starting or connected, including after the QR modal closes. The indicator returns to its neutral state when the tunnel is idle or fails.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -63,6 +63,19 @@ import { isTaskTerminalRoute } from "./utils/terminalFullscreen";
 /** Command shown when cloudflared is missing (Cloudflare Tunnel remote access). */
 const CLOUDFLARED_INSTALL_CMD = "brew install cloudflared";
 
+type RemoteAccessQRData = {
+	qrDataUrl: string;
+	accessUrl: string;
+	tunnelState: string;
+	cloudflaredInstalled: boolean;
+	interfaces?: RemoteNetInterface[];
+	selectedHost?: string;
+};
+
+function isRemoteTunnelActive(tunnelState?: string): boolean {
+	return tunnelState === "starting" || tunnelState === "connected";
+}
+
 /**
  * True when keystrokes should go to a focused field or the terminal rather than
  * trigger a bare-key shortcut (used to gate the Vimium-style hint hotkey).
@@ -265,10 +278,15 @@ function App() {
 	const updateClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// Remote access QR code modal
-	const [remoteQR, setRemoteQR] = useState<{ qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean; interfaces?: RemoteNetInterface[]; selectedHost?: string } | null>(null);
+	const [remoteQR, setRemoteQR] = useState<RemoteAccessQRData | null>(null);
+	const [remoteAccessActive, setRemoteAccessActive] = useState(false);
 	const [tunnelWanted, setTunnelWanted] = useState(false);
 	const [tunnelStarting, setTunnelStarting] = useState(false);
 	const [cloudflaredCopied, setCloudflaredCopied] = useState(false);
+	const applyRemoteQR = useCallback((next: RemoteAccessQRData) => {
+		setRemoteQR(next);
+		setRemoteAccessActive(isRemoteTunnelActive(next.tunnelState));
+	}, []);
 
 	// System requirements gate
 	const [reqStatus, setReqStatus] = useState<"checking" | "failed" | "passed">("checking");
@@ -1745,8 +1763,9 @@ function App() {
 	// Listen for View > Remote Access QR Code menu item
 	useEffect(() => {
 		function onShowRemoteQR(e: Event) {
-			const detail = (e as CustomEvent).detail;
-			setRemoteQR(detail);
+			const detail = (e as CustomEvent<RemoteAccessQRData>).detail;
+			if (!detail) return;
+			applyRemoteQR(detail);
 			setQrConsumed(false); // Reset consumed state when opening fresh QR
 			// Sync tunnel checkbox with actual tunnel state
 			setTunnelWanted(detail?.tunnelState === "connected" || detail?.tunnelState === "starting");
@@ -1754,7 +1773,7 @@ function App() {
 		}
 		window.addEventListener("rpc:showRemoteAccessQR", onShowRemoteQR);
 		return () => window.removeEventListener("rpc:showRemoteAccessQR", onShowRemoteQR);
-	}, []);
+	}, [applyRemoteQR]);
 
 	// Auto-refresh QR code every 25 seconds while modal is open (JWT tokens expire in 30s)
 	// After a QR is consumed, keep polling without visually rotating the token:
@@ -1795,8 +1814,10 @@ function App() {
 							}
 						}
 						if (!qrConsumedRef.current || hostnameChanged) {
-							setRemoteQR(next);
+							applyRemoteQR(next);
 							if (hostnameChanged) setQrConsumed(false);
+						} else {
+							setRemoteAccessActive(isRemoteTunnelActive(next.tunnelState));
 						}
 					}).catch(() => {}).finally(() => {
 						refreshInFlight = false;
@@ -1806,7 +1827,7 @@ function App() {
 			if (!qrConsumedRef.current) setQrCountdown(counter);
 		}, 1000);
 		return () => clearInterval(tick);
-	}, [qrModalOpen]);
+	}, [applyRemoteQR, qrModalOpen]);
 
 	// Track page views on route changes. Resolve the task's human-readable seq id
 	// (e.g. "981-1") from the loaded task list so analytics paths carry the task
@@ -1935,6 +1956,7 @@ function App() {
 						canGoForward={state.historyIndex < state.routeHistory.length - 1}
 						updateVersion={updateVersion}
 						updateDownloadStatus={updateDownloadStatus}
+						remoteAccessActive={remoteAccessActive}
 					/>
 					{ghWarning && (
 						<GhWarningBanner
@@ -2146,7 +2168,7 @@ function App() {
 									onChange={(e) => {
 										const host = e.target.value;
 										api.request.getRemoteAccessQR({ tunnel: false, host }).then((res) => {
-											setRemoteQR(res);
+											applyRemoteQR(res);
 											setQrCountdown(25);
 										}).catch(() => {});
 									}}
@@ -2174,16 +2196,21 @@ function App() {
 										const want = e.target.checked;
 										setTunnelWanted(want);
 										if (want && remoteQR.cloudflaredInstalled && remoteQR.tunnelState === "idle") {
+											setRemoteAccessActive(true);
 											setTunnelStarting(true);
 											api.request.getRemoteAccessQR({ tunnel: true }).then((res) => {
-												setRemoteQR(res);
+												applyRemoteQR(res);
 												setTunnelStarting(false);
 												setQrCountdown(25);
-											}).catch(() => setTunnelStarting(false));
+											}).catch(() => {
+												setTunnelStarting(false);
+												setRemoteAccessActive(false);
+											});
 										} else if (!want && remoteQR.tunnelState === "connected") {
+											setRemoteAccessActive(false);
 											api.request.stopTunnel().then(() => {
 												api.request.getRemoteAccessQR({ tunnel: false }).then((res) => {
-													setRemoteQR(res);
+													applyRemoteQR(res);
 													setQrCountdown(25);
 												}).catch(() => {});
 											}).catch(() => {});
@@ -2228,7 +2255,7 @@ function App() {
 									<button
 										onClick={() => {
 											api.request.getRemoteAccessQR({ tunnel: tunnelWanted }).then((res) => {
-												setRemoteQR(res);
+												applyRemoteQR(res);
 											}).catch(() => {});
 										}}
 										className="text-xs text-accent hover:text-accent-hover transition-colors"

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1325,6 +1325,68 @@ describe("App keyboard shortcuts", () => {
 	});
 
 	describe("QR modal consumed state", () => {
+		it("keeps the active tunnel indicator after the QR modal closes", async () => {
+			await renderApp();
+			const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
+			const qrData = {
+				qrDataUrl: "data:image/png;base64,test",
+				accessUrl: "https://public.trycloudflare.com/?token=test",
+				tunnelState: "connected",
+				cloudflaredInstalled: true,
+			};
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", { detail: qrData }));
+			await waitFor(() => {
+				expect(remoteButton.className).toContain("remote-access-active");
+				expect(remoteButton.className).toContain("text-accent");
+			});
+
+			await userEvent.click(screen.getByText("Close"));
+			await waitFor(() => expect(screen.queryByText("Copy URL")).not.toBeInTheDocument());
+			expect(remoteButton.className).toContain("remote-access-active");
+		});
+
+		it("does not activate the indicator for a local-only QR session", async () => {
+			await renderApp();
+			const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,test",
+					accessUrl: "http://192.168.0.1:1234/?token=test",
+					tunnelState: "idle",
+					cloudflaredInstalled: true,
+				},
+			}));
+			await waitFor(() => expect(screen.getByText("Copy URL")).toBeInTheDocument());
+			expect(remoteButton.className).not.toContain("remote-access-active");
+		});
+
+		it("activates while the tunnel is starting and deactivates after a failed start", async () => {
+			await renderApp();
+			const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,test",
+					accessUrl: "https://public.trycloudflare.com/?token=test",
+					tunnelState: "starting",
+					cloudflaredInstalled: true,
+				},
+			}));
+			await waitFor(() => expect(remoteButton.className).toContain("remote-access-active"));
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,test",
+					accessUrl: "https://public.trycloudflare.com/?token=test",
+					tunnelState: "failed",
+					cloudflaredInstalled: true,
+				},
+			}));
+			await waitFor(() => expect(remoteButton.className).not.toContain("remote-access-active"));
+		});
+
 		it("shows 'Connected' overlay and disables Copy when qrTokenConsumed fires", async () => {
 			await renderApp();
 

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -51,6 +51,7 @@ interface GlobalHeaderProps {
 	canGoForward: boolean;
 	updateVersion?: string | null;
 	updateDownloadStatus?: string | null;
+	remoteAccessActive: boolean;
 }
 
 interface BreadcrumbSegment {
@@ -64,11 +65,10 @@ interface BreadcrumbSegment {
 /** Cache TTL for project task counts (30 seconds) */
 const COUNTS_CACHE_TTL = 30_000;
 
-function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, canGoBack, canGoForward, updateVersion, updateDownloadStatus }: GlobalHeaderProps) {
+function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, canGoBack, canGoForward, updateVersion, updateDownloadStatus, remoteAccessActive }: GlobalHeaderProps) {
 	const t = useT();
 	const compact = useCompact();
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
-	const remoteMode = !isElectrobun;
 	// Live fullscreen state for the action-sheet toggle label (browser only).
 	const fullscreenActive = useSyncExternalStore(subscribeFullscreen, isFullscreenActive);
 	const [showActionSheet, setShowActionSheet] = useState(false);
@@ -624,7 +624,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 									// Remote access server may not be running
 								}
 							}}
-							className={`header-anim flex items-center gap-1 text-fg-3 hover:text-fg transition-colors px-1.5 py-1 rounded-lg hover:bg-elevated ${remoteMode ? "remote-access-active" : ""}`}
+							className={`header-anim flex items-center gap-1 transition-colors px-1.5 py-1 rounded-lg ${remoteAccessActive ? "text-accent bg-accent/15 hover:bg-accent/25 remote-access-active" : "text-fg-3 hover:text-fg hover:bg-elevated"}`}
 							aria-label={t("header.remoteAccessTooltip")}
 						>
 							<RemoteQRIcon className="w-[1.125rem] h-[1.125rem]" />

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -68,6 +68,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 	const t = useT();
 	const compact = useCompact();
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
+	const remoteMode = !isElectrobun;
 	// Live fullscreen state for the action-sheet toggle label (browser only).
 	const fullscreenActive = useSyncExternalStore(subscribeFullscreen, isFullscreenActive);
 	const [showActionSheet, setShowActionSheet] = useState(false);
@@ -623,7 +624,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 									// Remote access server may not be running
 								}
 							}}
-							className="header-anim flex items-center gap-1 text-fg-3 hover:text-fg transition-colors px-1.5 py-1 rounded-lg hover:bg-elevated"
+							className={`header-anim flex items-center gap-1 text-fg-3 hover:text-fg transition-colors px-1.5 py-1 rounded-lg hover:bg-elevated ${remoteMode ? "remote-access-active" : ""}`}
 							aria-label={t("header.remoteAccessTooltip")}
 						>
 							<RemoteQRIcon className="w-[1.125rem] h-[1.125rem]" />

--- a/src/mainview/components/HeaderIcons.tsx
+++ b/src/mainview/components/HeaderIcons.tsx
@@ -7,7 +7,7 @@ import type { SVGProps } from "react";
  * stroke style consistent with the tmux (TmuxIcons) and git (GitIcons) sets.
  *
  * Every icon carries `hdr-*` animation hooks: when a `.header-anim` ancestor
- * (the hosting button) is hovered, or while browser Remote Access is active for
+ * (the hosting button) is hovered, or while the Remote Access tunnel is active for
  * the QR icon, pure-CSS keyframes in index.css act out the operation the icon
  * triggers — chevrons lunge with a ghost echo, the home
  * prompt types itself, steam rises off the coffee, the lock shackle snaps shut,

--- a/src/mainview/components/HeaderIcons.tsx
+++ b/src/mainview/components/HeaderIcons.tsx
@@ -7,8 +7,9 @@ import type { SVGProps } from "react";
  * stroke style consistent with the tmux (TmuxIcons) and git (GitIcons) sets.
  *
  * Every icon carries `hdr-*` animation hooks: when a `.header-anim` ancestor
- * (the hosting button) is hovered, pure-CSS keyframes in index.css act out the
- * operation the icon triggers — chevrons lunge with a ghost echo, the home
+ * (the hosting button) is hovered, or while browser Remote Access is active for
+ * the QR icon, pure-CSS keyframes in index.css act out the operation the icon
+ * triggers — chevrons lunge with a ghost echo, the home
  * prompt types itself, steam rises off the coffee, the lock shackle snaps shut,
  * the quick-shell bolt double-flashes, the terminal cursor blinks, the pull /
  * update arrows drop into and launch out of the cloud, the check draws itself,

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -121,6 +121,7 @@ function renderHeader(
 	extra?: {
 		updateVersion?: string | null;
 		updateDownloadStatus?: string | null;
+		remoteAccessActive?: boolean;
 		goBack?: () => void;
 		goForward?: () => void;
 		canGoBack?: boolean;
@@ -140,6 +141,7 @@ function renderHeader(
 				canGoForward={extra?.canGoForward ?? false}
 				updateVersion={extra?.updateVersion}
 				updateDownloadStatus={extra?.updateDownloadStatus}
+				remoteAccessActive={extra?.remoteAccessActive ?? false}
 			/>
 		</I18nProvider>,
 	);
@@ -682,12 +684,21 @@ describe("GlobalHeader — remote access indicator", () => {
 		mockedApi.request.getTasks.mockResolvedValue([]);
 	});
 
-	it("keeps the QR icon animation active in browser remote mode", () => {
+	it("keeps the QR icon neutral until the tunnel is active", () => {
 		renderHeader({ screen: "dashboard" });
 
 		const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
-		expect(remoteButton.className).toContain("remote-access-active");
+		expect(remoteButton.className).not.toContain("remote-access-active");
 		expect(remoteButton.querySelector(".hdr-qr1")).toBeInTheDocument();
+	});
+
+	it("uses the accent active state while the tunnel is connected", () => {
+		renderHeader({ screen: "dashboard" }, undefined, undefined, [], { remoteAccessActive: true });
+
+		const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
+		expect(remoteButton.className).toContain("remote-access-active");
+		expect(remoteButton.className).toContain("text-accent");
+		expect(remoteButton.className).toContain("bg-accent/15");
 	});
 });
 

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -676,6 +676,21 @@ describe("GlobalHeader — project terminal button", () => {
 	});
 });
 
+describe("GlobalHeader — remote access indicator", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getTasks.mockResolvedValue([]);
+	});
+
+	it("keeps the QR icon animation active in browser remote mode", () => {
+		renderHeader({ screen: "dashboard" });
+
+		const remoteButton = screen.getByLabelText("Open on your phone — scan QR code for remote access");
+		expect(remoteButton.className).toContain("remote-access-active");
+		expect(remoteButton.querySelector(".hdr-qr1")).toBeInTheDocument();
+	});
+});
+
 describe("GlobalHeader — compact layout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -855,7 +855,7 @@ svg .gtx-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
    The hand-drawn header glyphs (HeaderIcons.tsx) act out their operation when
    the hosting control — any element with .header-anim (a header-row button,
    the prevent-sleep toggle, the git-pull button) — is hovered. The Remote Access
-   QR glyph also loops while browser remote mode is active. Pure CSS, pixel-identical
+   QR glyph also loops while the Remote Access tunnel is active. Pure CSS, pixel-identical
    to the static icon when idle otherwise.
    Animated design reference: design/tmux-icons-animated.html (Top header row). */
 

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -854,8 +854,9 @@ svg .gtx-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 /* ---- Animated header-row icons --------------------------------------------
    The hand-drawn header glyphs (HeaderIcons.tsx) act out their operation when
    the hosting control — any element with .header-anim (a header-row button,
-   the prevent-sleep toggle, the git-pull button) — is hovered. Pure CSS, loops
-   while hovered, pixel-identical to the static icon when idle.
+   the prevent-sleep toggle, the git-pull button) — is hovered. The Remote Access
+   QR glyph also loops while browser remote mode is active. Pure CSS, pixel-identical
+   to the static icon when idle otherwise.
    Animated design reference: design/tmux-icons-animated.html (Top header row). */
 
 /* Transform hooks resolve px origins in the 24×24 viewBox coordinate system. */
@@ -1028,6 +1029,11 @@ svg .hdr-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 .header-anim:hover .hdr-qr3 { animation: hdr-qr-blink 2.4s ease-in-out .6s infinite; }
 .header-anim:hover .hdr-qr4 { animation: hdr-qr-blink 2.4s ease-in-out .9s infinite; }
 .header-anim:hover .hdr-qr5 { animation: hdr-qr-blink 2.4s ease-in-out 1.2s infinite; }
+.header-anim.remote-access-active .hdr-qr1 { animation: hdr-qr-blink 2.4s ease-in-out infinite; }
+.header-anim.remote-access-active .hdr-qr2 { animation: hdr-qr-blink 2.4s ease-in-out .3s infinite; }
+.header-anim.remote-access-active .hdr-qr3 { animation: hdr-qr-blink 2.4s ease-in-out .6s infinite; }
+.header-anim.remote-access-active .hdr-qr4 { animation: hdr-qr-blink 2.4s ease-in-out .9s infinite; }
+.header-anim.remote-access-active .hdr-qr5 { animation: hdr-qr-blink 2.4s ease-in-out 1.2s infinite; }
 
 /* -- Gauge: the needle revs to the redline and falls back -- */
 @keyframes hdr-needle {
@@ -1143,7 +1149,9 @@ svg .hdr-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 
 @media (prefers-reduced-motion: reduce) {
 	.header-anim:hover [class^="hdr-"],
-	.header-anim:hover [class*=" hdr-"] {
+	.header-anim:hover [class*=" hdr-"],
+	.header-anim.remote-access-active [class^="hdr-"],
+	.header-anim.remote-access-active [class*=" hdr-"] {
 		animation: none;
 	}
 }


### PR DESCRIPTION
## Summary

- Keep the Remote header control blue and continuously animate its QR icon while the Cloudflare tunnel is starting or connected.
- Preserve the active indication after the QR modal closes, and return to neutral when the tunnel is idle, failed, or stopped.
- Derive the indicator from the actual tunnel lifecycle instead of browser transport mode.

## Testing

- bun run lint
- bun run test
- Manual browser QA for connected, idle, and post-close indicator states