### PR TITLE
Show rate limits for recently active agent accounts

### DIFF
--- a/change-logs/2026/07/16/feature-recent-agent-account-limits.md
+++ b/change-logs/2026/07/16/feature-recent-agent-account-limits.md
@@ -1,1 +1,1 @@
-The agent rate-limit indicator now shows every Claude and Codex account with local activity in the last 24 hours, attributing each usage row to its managed account and retaining monthly Codex credit details per account.
+The agent rate-limit indicator now shows every Claude and Codex account with local activity in the last 24 hours, attributing each usage row to its managed account and retaining monthly Codex credit details per account. Its header percentage follows the latest active account instead of the most exhausted account, with unlimited accounts shown as 0% used.

--- a/change-logs/2026/07/16/feature-recent-agent-account-limits.md
+++ b/change-logs/2026/07/16/feature-recent-agent-account-limits.md
@@ -1,0 +1,1 @@
+The agent rate-limit indicator now shows every Claude and Codex account with local activity in the last 24 hours, attributing each usage row to its managed account and retaining monthly Codex credit details per account.

--- a/decisions/136-per-account-rate-limit-activity.md
+++ b/decisions/136-per-account-rate-limit-activity.md
@@ -10,12 +10,12 @@ Claude statusline payloads run inside the launched account environment, while Co
 
 ## Decision
 
-Additive Claude snapshots live under `~/.dev3.0/data/rate-limits/claude/<accountId>.json`; the legacy `claude.json` remains a compatibility/system fallback and carries the account id when known. `AgentRateLimitSnapshot` carries `accountId` and `activeAt`, and `rate-limit-monitor.ts` deduplicates and filters snapshots to the 24-hour window before the existing header tooltip renders them.
+Additive Claude snapshots live under `~/.dev3.0/data/rate-limits/claude/<accountId>.json`; the legacy `claude.json` remains a compatibility/system fallback and carries the account id when known. `AgentRateLimitSnapshot` carries `accountId` and `activeAt`, and `rate-limit-monitor.ts` deduplicates and filters snapshots to the 24-hour window before the existing header tooltip renders them. The header badge reflects the most constrained window of the latest active snapshot, with unlimited credits represented as `0% used`; older snapshots remain detail-only.
 
 ## Risks
 
-Old global Claude dumps without attribution can only be treated as system-login data until a new statusline refresh writes the account id. Stale per-account files remain on disk but are ignored by the freshness filter and do not affect the frozen existing data paths.
+Old global Claude dumps without attribution can only be treated as system-login data until a new statusline refresh writes the account id. Stale per-account files remain on disk but are ignored by the freshness filter and do not affect the frozen existing data paths. Concurrent work on an older account may be constrained without changing the badge until that account produces the newest activity signal.
 
 ## Alternatives considered
 
-Listing every registered account was rejected because it would imply current activity and show accounts with no recent local evidence. Keeping one aggregate per provider was rejected because it loses the account identity needed to explain which subscription's limits are being consumed.
+Listing every registered account was rejected because it would imply current activity and show accounts with no recent local evidence. Aggregating percentages across accounts, including taking the maximum, was rejected because unlike quotas and unlimited plans do not form an honest combined percentage.

--- a/decisions/136-per-account-rate-limit-activity.md
+++ b/decisions/136-per-account-rate-limit-activity.md
@@ -1,0 +1,21 @@
+# 136 — Attribute recent rate limits to every active agent account
+
+## Context
+
+The header rate-limit indicator previously kept one Claude dump and one newest Codex rollout, so concurrent or recently used managed accounts collapsed into the default account row. The desired view is every account with a local activity signal from the last 24 hours.
+
+## Investigation
+
+Claude statusline payloads run inside the launched account environment, while Codex rollouts are already partitioned by each managed `CODEX_HOME`. Codex app-server data is fresher but does not prove activity, so it is used only to enrich a recent rollout and the rollout timestamp remains the activity anchor.
+
+## Decision
+
+Additive Claude snapshots live under `~/.dev3.0/data/rate-limits/claude/<accountId>.json`; the legacy `claude.json` remains a compatibility/system fallback and carries the account id when known. `AgentRateLimitSnapshot` carries `accountId` and `activeAt`, and `rate-limit-monitor.ts` deduplicates and filters snapshots to the 24-hour window before the existing header tooltip renders them.
+
+## Risks
+
+Old global Claude dumps without attribution can only be treated as system-login data until a new statusline refresh writes the account id. Stale per-account files remain on disk but are ignored by the freshness filter and do not affect the frozen existing data paths.
+
+## Alternatives considered
+
+Listing every registered account was rejected because it would imply current activity and show accounts with no recent local evidence. Keeping one aggregate per provider was rejected because it loses the account identity needed to explain which subscription's limits are being consumed.

--- a/src/bun/__tests__/rate-limit-monitor.test.ts
+++ b/src/bun/__tests__/rate-limit-monitor.test.ts
@@ -26,7 +26,22 @@ describe("readClaudeSnapshot", () => {
 		);
 		const snap = readClaudeSnapshot(dump);
 		expect(snap!.capturedAt).toBe(1_783_200_000_000);
+		expect(snap!.activeAt).toBe(1_783_200_000_000);
 		expect(snap!.windows[0].usedPercent).toBe(12);
+	});
+
+	it("keeps managed-account attribution from the dump or explicit path context", () => {
+		const dump = join(tmp, "claude.json");
+		writeFileSync(
+			dump,
+			JSON.stringify({
+				capturedAt: 1_783_200_000_000,
+				accountId: "claude-account",
+				payload: { rate_limits: { five_hour: { used_percentage: 12 } } },
+			}),
+		);
+		expect(readClaudeSnapshot(dump)?.accountId).toBe("claude-account");
+		expect(readClaudeSnapshot(dump, "explicit-account")?.accountId).toBe("explicit-account");
 	});
 
 	it("returns null for a missing file", () => {
@@ -80,8 +95,10 @@ describe("readCodexSnapshot", () => {
 		writeFileSync(join(dir, "rollout-2026-07-05T10-00-00-x.jsonl"), lines.join("\n") + "\n");
 		const snap = readCodexSnapshot(tmp);
 		expect(snap!.source).toBe("codex");
+		expect(snap!.accountId).toBeUndefined();
 		expect(snap!.windows[0].usedPercent).toBe(66);
 		expect(snap!.creditsBalance).toBe("7");
+		expect(readCodexSnapshot(tmp, "codex-account")?.accountId).toBe("codex-account");
 	});
 
 	it("returns null when no rollouts exist", () => {

--- a/src/bun/__tests__/rate-limits.test.ts
+++ b/src/bun/__tests__/rate-limits.test.ts
@@ -4,6 +4,8 @@ import {
 	formatResetDelta,
 	formatStatusLineSegment,
 	isRateLimitSnapshotRecent,
+	isUnlimitedRateLimitSnapshot,
+	latestRateLimitSnapshot,
 	mergeCodexRateLimitSnapshots,
 	parseClaudeStatusLinePayload,
 	parseCodexAppServerRateLimits,
@@ -11,6 +13,7 @@ import {
 	RATE_LIMIT_ACTIVITY_WINDOW_MS,
 	rateLimitActivityAt,
 	windowLabel,
+	worstSnapshotWindow,
 	worstWindow,
 } from "../../shared/rate-limits";
 
@@ -175,6 +178,20 @@ describe("rate-limit activity freshness", () => {
 		expect(rateLimitActivityAt(snapshot)).toBe(NOW);
 		expect(isRateLimitSnapshotRecent(snapshot, NOW + RATE_LIMIT_ACTIVITY_WINDOW_MS - 1)).toBe(true);
 		expect(isRateLimitSnapshotRecent(snapshot, NOW + RATE_LIMIT_ACTIVITY_WINDOW_MS + 1)).toBe(false);
+	});
+
+	it("selects the snapshot with the newest provider activity", () => {
+		const older = parseClaudeStatusLinePayload({ rate_limits: { five_hour: { used_percentage: 100 } } }, NOW)!;
+		const latest = parseCodexRateLimits({ primary: { used_percent: 24 } }, NOW + 1_000)!;
+		latest.capturedAt = NOW + 10_000;
+
+		expect(latestRateLimitSnapshot({ generatedAt: NOW + 10_000, snapshots: [older, latest] })).toBe(latest);
+		expect(worstSnapshotWindow(latest)?.usedPercent).toBe(24);
+	});
+
+	it("recognizes an unlimited credits snapshot", () => {
+		const unlimited = parseCodexRateLimits({ credits: { has_credits: true, unlimited: true } }, NOW)!;
+		expect(isUnlimitedRateLimitSnapshot(unlimited)).toBe(true);
 	});
 });
 

--- a/src/bun/__tests__/rate-limits.test.ts
+++ b/src/bun/__tests__/rate-limits.test.ts
@@ -3,10 +3,13 @@ import {
 	extractCodexSnapshotFromRolloutLines,
 	formatResetDelta,
 	formatStatusLineSegment,
+	isRateLimitSnapshotRecent,
 	mergeCodexRateLimitSnapshots,
 	parseClaudeStatusLinePayload,
 	parseCodexAppServerRateLimits,
 	parseCodexRateLimits,
+	RATE_LIMIT_ACTIVITY_WINDOW_MS,
+	rateLimitActivityAt,
 	windowLabel,
 	worstWindow,
 } from "../../shared/rate-limits";
@@ -27,6 +30,7 @@ describe("parseClaudeStatusLinePayload", () => {
 		expect(snap).not.toBeNull();
 		expect(snap!.source).toBe("claude");
 		expect(snap!.capturedAt).toBe(NOW);
+		expect(snap!.activeAt).toBe(NOW);
 		expect(snap!.windows).toHaveLength(2);
 		expect(snap!.windows[0]).toEqual({ id: "five_hour", usedPercent: 12, resetsAt: 1_783_246_800_000, windowMinutes: 300 });
 		expect(snap!.windows[1].usedPercent).toBe(77.4);
@@ -159,6 +163,18 @@ describe("formatResetDelta", () => {
 	it("returns empty for unknown or past resets", () => {
 		expect(formatResetDelta(null, NOW)).toBe("");
 		expect(formatResetDelta(NOW - 1000, NOW)).toBe("");
+	});
+});
+
+describe("rate-limit activity freshness", () => {
+	it("uses the provider activity timestamp when live data was captured later", () => {
+		const snapshot = parseCodexRateLimits({ primary: { used_percent: 42 } }, NOW)!;
+		snapshot.capturedAt = NOW + 10 * 60_000;
+		snapshot.activeAt = NOW;
+
+		expect(rateLimitActivityAt(snapshot)).toBe(NOW);
+		expect(isRateLimitSnapshotRecent(snapshot, NOW + RATE_LIMIT_ACTIVITY_WINDOW_MS - 1)).toBe(true);
+		expect(isRateLimitSnapshotRecent(snapshot, NOW + RATE_LIMIT_ACTIVITY_WINDOW_MS + 1)).toBe(false);
 	});
 });
 

--- a/src/bun/agent-accounts.ts
+++ b/src/bun/agent-accounts.ts
@@ -45,6 +45,7 @@ import type {
 } from "../shared/agent-accounts";
 import {
 	CLAUDE_MODEL_SLOTS,
+	DEV3_AGENT_ACCOUNT_ID_ENV,
 	ENV_UNSET,
 	claudeApiProfileEnvKeys,
 	defaultAccountLabel,
@@ -448,6 +449,16 @@ export function listCodexAccountDirs(paths: AccountPaths = defaultAccountPaths()
 	}
 }
 
+/** Absolute dirs of every managed Claude account. The rate-limit monitor uses
+ * these to locate account-attributed statusline snapshots. */
+export function listClaudeAccountDirs(paths: AccountPaths = defaultAccountPaths()): string[] {
+	try {
+		return loadRegistry(paths).claude.accounts.map((e) => claudeAccountDir(e.id, paths));
+	} catch {
+		return [];
+	}
+}
+
 export async function listAgentAccounts(paths: AccountPaths = defaultAccountPaths()): Promise<AgentAccountsState> {
 	let registry = loadRegistry(paths);
 	if (applyCodexWorkspaceNames(registry, {}, paths)) saveRegistry(registry, paths);
@@ -547,9 +558,11 @@ export async function getActiveClaudeSessionEnv(
 	const env: Record<string, string> = {};
 	const id = resolveAccountIdOverride(registry.claude.activeId, accountIdOverride);
 	const entry = id ? registry.claude.accounts.find((e) => e.id === id) : undefined;
+	let selectedDir: string | null = null;
 	if (entry) {
 		const dir = claudeAccountDir(entry.id, paths);
 		if (existsSync(join(dir, ".claude.json"))) {
+			selectedDir = dir;
 			env.CLAUDE_CONFIG_DIR = dir;
 			if (entry.auth === "api") {
 				const profile = readApiProfile(entry.id, paths);
@@ -565,6 +578,12 @@ export async function getActiveClaudeSessionEnv(
 				}
 			}
 		}
+	}
+	// This is deliberately unset for the system login and for a missing account
+	// snapshot, so a long-lived tmux server cannot attribute a later system-login
+	// session to the account that was selected before it.
+	if (registry.claude.accounts.length > 0) {
+		env[DEV3_AGENT_ACCOUNT_ID_ENV] = selectedDir && entry ? entry.id : ENV_UNSET;
 	}
 	for (const key of collectClearableEnvKeys(registry, paths)) {
 		if (!(key in env)) env[key] = ENV_UNSET;

--- a/src/bun/codex-rate-limits.ts
+++ b/src/bun/codex-rate-limits.ts
@@ -18,6 +18,7 @@ export async function fetchCodexRateLimitSnapshot(
 	spawnProcess: SpawnProcess = spawn,
 	timeoutMs: number = DEFAULT_TIMEOUT_MS,
 	capturedAt: number = Date.now(),
+	env?: Record<string, string>,
 ): Promise<AgentRateLimitSnapshot | null> {
 	let proc: ReturnType<SpawnProcess> | null = null;
 	let stdin: import("bun").FileSink | null = null;
@@ -27,6 +28,7 @@ export async function fetchCodexRateLimitSnapshot(
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
+			...(env ? { env } : {}),
 		});
 		stdin = proc.stdin as unknown as import("bun").FileSink;
 		stdin.write(

--- a/src/bun/rate-limit-monitor.ts
+++ b/src/bun/rate-limit-monitor.ts
@@ -2,11 +2,12 @@
  * Agent rate-limit monitor — periodically reads local rate-limit sources and
  * pushes changes to the renderer:
  *
- * - Claude: ~/.dev3.0/data/rate-limits/claude.json, written by the injected
- *   `dev3 statusline` wrapper on every statusLine refresh of any dev3-launched
- *   Claude session (see src/cli/commands/statusline.ts).
- * - Codex: the newest rollout file under ~/.codex/sessions/YYYY/MM/DD/ — the
- *   tail contains `token_count` events with a `rate_limits` object.
+ * - Claude: the legacy global dump plus one dump per managed account under
+ *   ~/.dev3.0/data/rate-limits/claude/, written by the injected `dev3 statusline`
+ *   wrapper on every statusLine refresh (see src/cli/commands/statusline.ts).
+ * - Codex: the newest rollout file under each system or managed CODEX_HOME's
+ *   sessions/YYYY/MM/DD/ directory — the tail contains `token_count` events
+ *   with a `rate_limits` object.
  * - Codex monthly credits: a cached read-only request through the locally
  *   authenticated `codex app-server`, with rollout-only fallback.
  *
@@ -16,11 +17,18 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, openSync, readSync, closeSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { AgentRateLimitSnapshot, AgentRateLimitsReport } from "../shared/rate-limits";
-import { extractCodexSnapshotFromRolloutLines, mergeCodexRateLimitSnapshots, parseClaudeStatusLinePayload } from "../shared/rate-limits";
+import {
+	RATE_LIMIT_ACTIVITY_WINDOW_MS,
+	extractCodexSnapshotFromRolloutLines,
+	isRateLimitSnapshotRecent,
+	mergeCodexRateLimitSnapshots,
+	parseClaudeStatusLinePayload,
+	rateLimitActivityAt,
+} from "../shared/rate-limits";
 import { fetchCodexRateLimitSnapshot } from "./codex-rate-limits";
-import { listCodexAccountDirs } from "./agent-accounts";
+import { listClaudeAccountDirs, listCodexAccountDirs } from "./agent-accounts";
 import { DEV3_HOME } from "./paths";
 import { createLogger } from "./logger";
 import { loadSettings } from "./settings";
@@ -36,6 +44,9 @@ const CODEX_DAY_DIRS_TO_SCAN = 3;
 
 export const RATE_LIMITS_DIR = join(DEV3_HOME, "data", "rate-limits");
 export const CLAUDE_RATE_LIMIT_DUMP_PATH = join(RATE_LIMITS_DIR, "claude.json");
+/** Per-managed-account Claude dumps. The legacy global dump remains the system
+ * login fallback and is also written for compatibility with older builds. */
+export const CLAUDE_ACCOUNT_RATE_LIMITS_DIR = join(RATE_LIMITS_DIR, "claude");
 /** The static settings file injected via `claude --settings <path>`. */
 export const CLAUDE_STATUSLINE_SETTINGS_PATH = join(RATE_LIMITS_DIR, "claude-statusline-settings.json");
 
@@ -45,9 +56,9 @@ let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let pushMessageFn: PushMessageFn | null = null;
 let lastPushedKey = "";
 let cachedReport: AgentRateLimitsReport | null = null;
-let cachedCodexLiveSnapshot: AgentRateLimitSnapshot | null = null;
-let codexLiveAttemptedAt = 0;
-let codexLiveRequest: Promise<AgentRateLimitSnapshot | null> | null = null;
+const cachedCodexLiveSnapshots = new Map<string, AgentRateLimitSnapshot>();
+const codexLiveAttemptedAt = new Map<string, number>();
+const codexLiveRequests = new Map<string, Promise<AgentRateLimitSnapshot | null>>();
 
 /**
  * Write (once) the settings file whose statusLine routes through
@@ -76,29 +87,53 @@ export function ensureClaudeStatusLineSettings(): string | null {
 }
 
 /** Parse the dump written by `dev3 statusline`. Null when absent/corrupt. */
-export function readClaudeSnapshot(dumpPath: string = CLAUDE_RATE_LIMIT_DUMP_PATH): AgentRateLimitSnapshot | null {
+export function readClaudeSnapshot(dumpPath: string = CLAUDE_RATE_LIMIT_DUMP_PATH, accountId?: string | null): AgentRateLimitSnapshot | null {
 	try {
 		if (!existsSync(dumpPath)) return null;
-		const parsed = JSON.parse(readFileSync(dumpPath, "utf-8")) as { capturedAt?: number; payload?: unknown };
+		const parsed = JSON.parse(readFileSync(dumpPath, "utf-8")) as {
+			capturedAt?: number;
+			accountId?: unknown;
+			payload?: unknown;
+		};
 		const capturedAt = typeof parsed.capturedAt === "number" ? parsed.capturedAt : statSync(dumpPath).mtimeMs;
-		return parseClaudeStatusLinePayload(parsed.payload, capturedAt);
+		const snapshot = parseClaudeStatusLinePayload(parsed.payload, capturedAt);
+		if (!snapshot) return null;
+		const dumpAccountId =
+			parsed.accountId === null ? null : typeof parsed.accountId === "string" && parsed.accountId.trim() ? parsed.accountId : undefined;
+		const resolvedAccountId = accountId !== undefined ? accountId : dumpAccountId;
+		return resolvedAccountId === undefined ? snapshot : { ...snapshot, accountId: resolvedAccountId };
 	} catch {
 		return null; // torn write or corrupt file — keep whatever we knew before
 	}
 }
 
+function codexHomeRoot(): string {
+	return process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+}
+
 function codexSessionsRoot(): string {
-	return process.env.CODEX_HOME ? join(process.env.CODEX_HOME, "sessions") : join(homedir(), ".codex", "sessions");
+	return join(codexHomeRoot(), "sessions");
+}
+
+interface CodexSessionRoot {
+	home: string;
+	sessions: string;
+	accountId: string | null;
 }
 
 /** Every codex session root to scan: the system login (~/.codex or $CODEX_HOME)
  *  plus each managed account's per-account CODEX_HOME — per-launch account
  *  injection scatters rollouts across those, so a single root would miss the
  *  latest session whenever it ran under a non-default account. */
-function codexSessionRoots(): string[] {
-	const roots = new Set<string>([codexSessionsRoot()]);
-	for (const dir of listCodexAccountDirs()) roots.add(join(dir, "sessions"));
-	return [...roots];
+function codexSessionRoots(): CodexSessionRoot[] {
+	const managed = listCodexAccountDirs().map((home) => ({ home, sessions: join(home, "sessions"), accountId: basename(home) }));
+	const systemHome = codexHomeRoot();
+	const system = managed.find((root) => root.home === systemHome) ?? { home: systemHome, sessions: join(systemHome, "sessions"), accountId: null };
+	const roots = [system];
+	for (const root of managed) {
+		if (!roots.some((existing) => existing.home === root.home)) roots.push(root);
+	}
+	return roots;
 }
 
 function listSortedDirs(dir: string): string[] {
@@ -171,41 +206,47 @@ function readTailLines(path: string, maxBytes: number): string[] {
  *  root + every managed-account CODEX_HOME), so the indicator reflects whichever
  *  codex session ran most recently regardless of which account it used. Pass an
  *  explicit `root` to scan just one (used by tests). */
-export function readCodexSnapshot(root?: string): AgentRateLimitSnapshot | null {
+export function readCodexSnapshot(root?: string, accountId?: string | null): AgentRateLimitSnapshot | null {
 	try {
-		const roots = root !== undefined ? [root] : codexSessionRoots();
-		let best: { path: string; mtimeMs: number } | null = null;
+		const roots = root !== undefined ? [{ sessions: root, accountId }] : codexSessionRoots();
+		let best: { path: string; mtimeMs: number; accountId?: string | null } | null = null;
 		for (const r of roots) {
-			const rollout = findLatestCodexRollout(r);
+			const rollout = findLatestCodexRollout(r.sessions);
 			if (!rollout) continue;
 			try {
 				const mtimeMs = statSync(rollout).mtimeMs;
-				if (!best || mtimeMs > best.mtimeMs) best = { path: rollout, mtimeMs };
+				if (!best || mtimeMs > best.mtimeMs) best = { path: rollout, mtimeMs, accountId: r.accountId };
 			} catch {
 				// file vanished mid-scan
 			}
 		}
 		if (!best) return null;
-		return extractCodexSnapshotFromRolloutLines(readTailLines(best.path, CODEX_TAIL_BYTES));
+		const snapshot = extractCodexSnapshotFromRolloutLines(readTailLines(best.path, CODEX_TAIL_BYTES));
+		if (!snapshot || best.accountId === undefined) return snapshot;
+		return { ...snapshot, accountId: best.accountId };
 	} catch (err) {
 		log.warn("Codex rollout scan failed", { error: String(err) });
 		return null;
 	}
 }
 
-async function readCodexLiveSnapshot(now: number = Date.now()): Promise<AgentRateLimitSnapshot | null> {
-	if (now - codexLiveAttemptedAt < CODEX_LIVE_REFRESH_MS) return cachedCodexLiveSnapshot;
-	if (codexLiveRequest) return codexLiveRequest;
-	codexLiveAttemptedAt = now;
-	codexLiveRequest = fetchCodexRateLimitSnapshot()
+async function readCodexLiveSnapshot(root: CodexSessionRoot, now: number): Promise<AgentRateLimitSnapshot | null> {
+	const key = root.accountId ?? "system";
+	const attemptedAt = codexLiveAttemptedAt.get(key) ?? 0;
+	if (now - attemptedAt < CODEX_LIVE_REFRESH_MS) return cachedCodexLiveSnapshots.get(key) ?? null;
+	const existingRequest = codexLiveRequests.get(key);
+	if (existingRequest) return existingRequest;
+	codexLiveAttemptedAt.set(key, now);
+	const request = fetchCodexRateLimitSnapshot(undefined, undefined, now, { CODEX_HOME: root.home })
 		.then((snapshot) => {
-			if (snapshot) cachedCodexLiveSnapshot = snapshot;
-			return cachedCodexLiveSnapshot;
+			if (snapshot) cachedCodexLiveSnapshots.set(key, { ...snapshot, accountId: root.accountId });
+			return cachedCodexLiveSnapshots.get(key) ?? null;
 		})
 		.finally(() => {
-			codexLiveRequest = null;
+			codexLiveRequests.delete(key);
 		});
-	return codexLiveRequest;
+	codexLiveRequests.set(key, request);
+	return request;
 }
 
 async function trackingEnabled(): Promise<boolean> {
@@ -218,15 +259,59 @@ async function trackingEnabled(): Promise<boolean> {
 }
 
 export async function getAgentRateLimitsReport(): Promise<AgentRateLimitsReport> {
+	const now = Date.now();
 	if (!(await trackingEnabled())) {
-		return { snapshots: [], generatedAt: Date.now() };
+		return { snapshots: [], generatedAt: now };
 	}
-	const snapshots: AgentRateLimitSnapshot[] = [];
-	const claude = readClaudeSnapshot();
-	if (claude) snapshots.push(claude);
-	const codex = mergeCodexRateLimitSnapshots(readCodexSnapshot(), await readCodexLiveSnapshot());
-	if (codex) snapshots.push(codex);
-	const report: AgentRateLimitsReport = { snapshots, generatedAt: Date.now() };
+	const byAccount = new Map<string, AgentRateLimitSnapshot>();
+	const knownClaudeAccountIds = new Set(listClaudeAccountDirs().map((dir) => basename(dir)));
+	const addSnapshot = (snapshot: AgentRateLimitSnapshot | null): void => {
+		if (!snapshot || !isRateLimitSnapshotRecent(snapshot, now)) return;
+		if (snapshot.source === "claude" && snapshot.accountId && !knownClaudeAccountIds.has(snapshot.accountId)) return;
+		const key = `${snapshot.source}:${snapshot.accountId ?? "system"}`;
+		const existing = byAccount.get(key);
+		if (!existing || rateLimitActivityAt(snapshot) > rateLimitActivityAt(existing) || snapshot.capturedAt > existing.capturedAt) {
+			byAccount.set(key, snapshot);
+		}
+	};
+
+	// Claude's statusline wrapper writes one legacy/system dump and one additive
+	// dump per managed account. The account id in the wrapper is the only source
+	// that can distinguish concurrent Claude sessions, so never collapse these to
+	// the active/default registry account.
+	addSnapshot(readClaudeSnapshot());
+	for (const dir of listClaudeAccountDirs()) {
+		const accountId = basename(dir);
+		addSnapshot(readClaudeSnapshot(join(CLAUDE_ACCOUNT_RATE_LIMITS_DIR, `${accountId}.json`), accountId));
+	}
+
+	// Codex sessions are naturally partitioned by CODEX_HOME. Enrich only roots
+	// with a rollout written in the activity window; querying app-server itself
+	// must not make an idle account look active.
+	for (const root of codexSessionRoots()) {
+		const latestRollout = findLatestCodexRollout(root.sessions);
+		if (!latestRollout) continue;
+		let rolloutMtime = 0;
+		try {
+			rolloutMtime = statSync(latestRollout).mtimeMs;
+		} catch {
+			continue;
+		}
+		if (rolloutMtime < now - RATE_LIMIT_ACTIVITY_WINDOW_MS) continue;
+		const rollout = readCodexSnapshot(root.sessions, root.accountId);
+		const live = await readCodexLiveSnapshot(root, now);
+		const combined = mergeCodexRateLimitSnapshots(rollout, live);
+		if (combined) {
+			const parsedActivityAt = rollout ? rateLimitActivityAt(rollout) : 0;
+			combined.activeAt = Math.max(Number.isFinite(parsedActivityAt) ? parsedActivityAt : 0, rolloutMtime);
+			addSnapshot(combined);
+		}
+	}
+
+	const snapshots = [...byAccount.values()].sort(
+		(a, b) => (a.source === b.source ? 0 : a.source === "claude" ? -1 : 1) || rateLimitActivityAt(b) - rateLimitActivityAt(a),
+	);
+	const report: AgentRateLimitsReport = { snapshots, generatedAt: now };
 	cachedReport = report;
 	return report;
 }
@@ -236,7 +321,7 @@ function reportKey(report: AgentRateLimitsReport): string {
 	return report.snapshots
 		.map(
 			(s) =>
-				`${s.source}:${s.capturedAt}:${s.windows.map((w) => `${w.id}=${w.usedPercent}@${w.resetsAt}`).join(",")}:${s.creditsBalance}:${s.monthlyCredits ? `${s.monthlyCredits.used}/${s.monthlyCredits.limit}@${s.monthlyCredits.resetsAt}` : ""}`,
+				`${s.source}:${s.accountId ?? "system"}:${s.capturedAt}:${s.activeAt ?? ""}:${s.windows.map((w) => `${w.id}=${w.usedPercent}@${w.resetsAt}`).join(",")}:${s.creditsBalance}:${s.monthlyCredits ? `${s.monthlyCredits.used}/${s.monthlyCredits.limit}@${s.monthlyCredits.resetsAt}` : ""}`,
 		)
 		.join("|");
 }
@@ -271,9 +356,9 @@ export function stopRateLimitMonitor(): void {
 	pushMessageFn = null;
 	lastPushedKey = "";
 	cachedReport = null;
-	cachedCodexLiveSnapshot = null;
-	codexLiveAttemptedAt = 0;
-	codexLiveRequest = null;
+	cachedCodexLiveSnapshots.clear();
+	codexLiveAttemptedAt.clear();
+	codexLiveRequests.clear();
 }
 
 /** Last computed report (may be null before the first poll/RPC). */

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -23,10 +23,14 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { DEV3_AGENT_ACCOUNT_ID_ENV } from "../../shared/agent-accounts";
 import { formatStatusLineSegment, parseClaudeStatusLinePayload } from "../../shared/rate-limits";
 
 export const RATE_LIMITS_DIR = join(homedir(), ".dev3.0", "data", "rate-limits");
 export const CLAUDE_RATE_LIMIT_DUMP_PATH = join(RATE_LIMITS_DIR, "claude.json");
+export const CLAUDE_ACCOUNT_RATE_LIMITS_DIR = join(RATE_LIMITS_DIR, "claude");
+
+const SAFE_ACCOUNT_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 /** Max time the user's original statusLine command may take before we drop it. */
 const ORIGINAL_STATUSLINE_TIMEOUT_MS = 2000;
@@ -88,13 +92,25 @@ function runOriginalStatusLine(original: OriginalStatusLine, input: string, cwd:
 	return "";
 }
 
+function managedAccountId(): string | null {
+	const value = process.env[DEV3_AGENT_ACCOUNT_ID_ENV]?.trim();
+	return value && SAFE_ACCOUNT_ID.test(value) ? value : null;
+}
+
 function dumpPayload(raw: string): void {
 	try {
+		const accountId = managedAccountId();
+		const capturedAt = Date.now();
+		const serialized = JSON.stringify({ capturedAt, accountId, payload: JSON.parse(raw) });
 		mkdirSync(dirname(CLAUDE_RATE_LIMIT_DUMP_PATH), { recursive: true });
 		// Single small write; the monitor tolerates a torn read by keeping the
 		// previous snapshot (deliberately no tmp+rename — see the on-disk layout
 		// invariants about renames under ~/.dev3.0/).
-		writeFileSync(CLAUDE_RATE_LIMIT_DUMP_PATH, JSON.stringify({ capturedAt: Date.now(), payload: JSON.parse(raw) }));
+		writeFileSync(CLAUDE_RATE_LIMIT_DUMP_PATH, serialized);
+		if (accountId) {
+			mkdirSync(CLAUDE_ACCOUNT_RATE_LIMITS_DIR, { recursive: true });
+			writeFileSync(join(CLAUDE_ACCOUNT_RATE_LIMITS_DIR, `${accountId}.json`), serialized);
+		}
 	} catch {
 		// disk/parse trouble must never break the visible statusLine
 	}

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -41,10 +41,15 @@ interface AccountLine {
  * The rate-limit windows always reflect whichever account launched the session,
  * so surfacing it answers "whose limit is this?" at a glance.
  */
-function resolveAccount(source: RateLimitSource, state: AgentAccountsState | null): AccountLine | null {
+function resolveAccount(source: RateLimitSource, state: AgentAccountsState | null, accountId?: string | null): AccountLine | null {
 	if (!state) return null;
 	const kindState = state[source];
-	const active = kindState.accounts.find((a) => a.id === kindState.activeId) ?? null;
+	const active =
+		accountId === undefined
+			? (kindState.accounts.find((a) => a.id === kindState.activeId) ?? null)
+			: accountId
+				? (kindState.accounts.find((a) => a.id === accountId) ?? null)
+				: null;
 	if (active) {
 		return {
 			name: active.label,
@@ -54,6 +59,10 @@ function resolveAccount(source: RateLimitSource, state: AgentAccountsState | nul
 			isApi: active.auth === "api",
 		};
 	}
+	// An attributed managed snapshot must never fall back to the default account
+	// when that account was removed or is still loading; that would mislabel the
+	// usage row. Null explicitly means the provider's system login.
+	if (accountId !== undefined && accountId !== null) return null;
 	const fallback = source === "claude" ? state.claude.systemIdentity : state.codex.currentIdentity;
 	if (fallback) {
 		return {
@@ -171,9 +180,9 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 			content={t("rateLimits.tooltipTitle")}
 			wide
 			detail={
-				<div className="flex flex-col gap-2">
+				<div className="flex max-h-[min(70vh,30rem)] flex-col gap-2 overflow-y-auto pr-1">
 					{report.snapshots.map((snap) => {
-						const account = resolveAccount(snap.source, accounts);
+						const account = resolveAccount(snap.source, accounts, snap.accountId);
 						const rows = snapshotRows(snap, now, t, locale);
 						// Collapse the auto-generated "email (workspace)" label into a plain
 						// email so every row reads consistently as "email · workspace" (the
@@ -187,7 +196,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 							account.organization !== displayName &&
 							!(displayName ?? "").endsWith(`(${account.organization})`);
 						return (
-							<div key={snap.source} className="flex flex-col gap-0.5">
+							<div key={`${snap.source}:${snap.accountId ?? "system"}`} className="flex flex-col gap-0.5">
 								<div className="flex items-center gap-1.5">
 									<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
 									{displayName && <span className="text-fg-3">{displayName}</span>}

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -8,8 +8,10 @@ import {
 	RATE_LIMIT_DANGER_PERCENT,
 	RATE_LIMIT_WARN_PERCENT,
 	formatResetDelta,
+	isUnlimitedRateLimitSnapshot,
+	latestRateLimitSnapshot,
 	windowLabel,
-	worstWindow,
+	worstSnapshotWindow,
 } from "../../shared/rate-limits";
 import type { AgentAccountsState } from "../../shared/agent-accounts";
 import { AGENT_ACCOUNTS_CHANGED_EVENT } from "./AgentAccountIndicator";
@@ -113,10 +115,11 @@ function snapshotRows(
  * Ambient agent rate-limit indicator (global header, stateful-indicators zone).
  * Passive "battery gauge" for the account-wide Claude/Codex limit windows so a
  * dev running many parallel agents is never blindsided by hitting a limit.
- * Hidden until any data exists; escalates color at ≥80% / ≥95% of the most
- * constrained window. Details (per-window % + time-to-reset) live in the
- * tooltip. Codex monthly credits come from a cached app-server account read;
- * all other data comes from local files — see rate-limit-monitor.ts.
+ * Hidden until usable data exists; shows the most constrained window for the
+ * most recently active account and treats unlimited credits as 0% used.
+ * Details for every recently active account live in the tooltip. Codex monthly
+ * credits come from a cached app-server account read; all other data comes from
+ * local files — see rate-limit-monitor.ts.
  */
 function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const t = useT();
@@ -150,11 +153,13 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		return () => window.removeEventListener(AGENT_ACCOUNTS_CHANGED_EVENT, reload);
 	}, []);
 
-	const worst = report ? worstWindow(report) : null;
-	if (!report || !worst) return null;
+	const latestSnapshot = report ? latestRateLimitSnapshot(report) : null;
+	const latestWindow = latestSnapshot ? worstSnapshotWindow(latestSnapshot) : null;
+	const unlimited = latestSnapshot ? isUnlimitedRateLimitSnapshot(latestSnapshot) : false;
+	if (!report || !latestSnapshot || (!latestWindow && !unlimited)) return null;
 
 	const now = Date.now();
-	const percent = Math.round(worst.window.usedPercent);
+	const percent = latestWindow && !unlimited ? Math.round(latestWindow.usedPercent) : 0;
 	const danger = percent >= RATE_LIMIT_DANGER_PERCENT;
 	const warn = !danger && percent >= RATE_LIMIT_WARN_PERCENT;
 
@@ -165,9 +170,13 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		}
 	}
 
-	const worstReset = formatResetDelta(worst.window.resetsAt, now);
-	const worstLabel = worst.window.id === "monthly_credits" ? t("rateLimits.monthlyLabel") : windowLabel(worst.window);
-	const ariaLabel = `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[worst.source] ?? worst.source} ${worstLabel} ${t("rateLimits.percentUsed", { percent })}${worstReset ? `, ${t("rateLimits.resetsIn", { time: worstReset })}` : ""}`;
+	const latestReset = formatResetDelta(latestWindow?.resetsAt ?? null, now);
+	const latestLabel = latestWindow
+		? latestWindow.id === "monthly_credits"
+			? t("rateLimits.monthlyLabel")
+			: windowLabel(latestWindow)
+		: null;
+	const ariaLabel = `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source}${latestLabel ? ` ${latestLabel}` : ""} ${t("rateLimits.percentUsed", { percent })}${latestReset ? `, ${t("rateLimits.resetsIn", { time: latestReset })}` : ""}`;
 
 	const colorClasses = danger
 		? "text-danger bg-danger/15 border-danger/30"

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -68,11 +68,80 @@ describe("RateLimitIndicator", () => {
 		expect(container.querySelector("[role='status']")).toBeNull();
 	});
 
-	it("shows the worst window percentage once data arrives", async () => {
+	it("shows the worst window percentage from the latest active account", async () => {
 		mockedGet.mockResolvedValue(report(42));
 		renderIndicator();
 		await act(async () => {});
 		expect(screen.getByText("42%")).toBeTruthy();
+		expect(screen.getByRole("status").className).toContain("text-fg-3");
+	});
+
+	it("ignores a more-used window from an older account", async () => {
+		const now = Date.now();
+		mockedGet.mockResolvedValue({
+			generatedAt: now,
+			snapshots: [
+				{
+					source: "codex",
+					accountId: "exhausted",
+					capturedAt: now - 1_000,
+					activeAt: now - 1_000,
+					windows: [{ id: "primary", usedPercent: 100, resetsAt: now + 3_600_000, windowMinutes: 300 }],
+					creditsBalance: null,
+					monthlyCredits: null,
+					planType: null,
+				},
+				{
+					source: "claude",
+					accountId: "latest",
+					capturedAt: now,
+					activeAt: now,
+					windows: [{ id: "five_hour", usedPercent: 29, resetsAt: now + 3_600_000, windowMinutes: 300 }],
+					creditsBalance: null,
+					monthlyCredits: null,
+					planType: null,
+				},
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+
+		expect(screen.getByText("29%")).toBeTruthy();
+		expect(screen.queryByText("100%")).toBeNull();
+		expect(screen.getByRole("status").className).toContain("text-fg-3");
+	});
+
+	it("shows unlimited latest accounts as 0% used", async () => {
+		const now = Date.now();
+		mockedGet.mockResolvedValue({
+			generatedAt: now,
+			snapshots: [
+				{
+					source: "claude",
+					capturedAt: now - 1_000,
+					activeAt: now - 1_000,
+					windows: [{ id: "five_hour", usedPercent: 100, resetsAt: now + 3_600_000, windowMinutes: 300 }],
+					creditsBalance: null,
+					monthlyCredits: null,
+					planType: null,
+				},
+				{
+					source: "codex",
+					capturedAt: now,
+					activeAt: now,
+					windows: [],
+					creditsBalance: "unlimited",
+					monthlyCredits: null,
+					planType: "enterprise",
+				},
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+
+		expect(screen.getByText("0%")).toBeTruthy();
+		expect(screen.getByText("used")).toBeTruthy();
+		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("Codex 0% used");
 		expect(screen.getByRole("status").className).toContain("text-fg-3");
 	});
 

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -205,6 +205,46 @@ describe("RateLimitIndicator", () => {
 		expect(screen.getByText("Pro")).toBeTruthy();
 	});
 
+	it("shows each recently attributed account instead of collapsing to the default", async () => {
+		const capturedAt = Date.now();
+		const snapshot = (source: "claude" | "codex", accountId: string, percent: number) => ({
+			source,
+			accountId,
+			capturedAt,
+			activeAt: capturedAt,
+			windows: [{ id: source === "claude" ? "five_hour" : "primary", usedPercent: percent, resetsAt: capturedAt + 3_600_000, windowMinutes: 300 }],
+			creditsBalance: null,
+			monthlyCredits: null,
+			planType: null,
+		});
+		mockedGet.mockResolvedValue({
+			generatedAt: capturedAt,
+			snapshots: [snapshot("claude", "claude-1", 42), snapshot("claude", "claude-2", 17), snapshot("codex", "codex-1", 28)],
+		});
+		mockedAccounts.mockResolvedValue({
+			claude: {
+				accounts: [
+					{ id: "claude-1", kind: "claude", label: "Work Claude", identity: null, auth: "oauth", api: null, createdAt: 0 },
+					{ id: "claude-2", kind: "claude", label: "Personal Claude", identity: null, auth: "oauth", api: null, createdAt: 0 },
+				],
+				activeId: "claude-1",
+				systemIdentity: null,
+			},
+			codex: {
+				accounts: [{ id: "codex-1", kind: "codex", label: "Enterprise Codex", identity: null, auth: "oauth", api: null, createdAt: 0 }],
+				activeId: "codex-1",
+				currentIdentity: null,
+			},
+		});
+
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		expect(await screen.findByText("Work Claude")).toBeTruthy();
+		expect(screen.getByText("Personal Claude")).toBeTruthy();
+		expect(screen.getByText("Enterprise Codex")).toBeTruthy();
+	});
+
 	it("shows the workspace/organization name so same-email accounts are distinguishable", async () => {
 		mockedGet.mockResolvedValue(report(42));
 		mockedAccounts.mockResolvedValue({

--- a/src/shared/agent-accounts.ts
+++ b/src/shared/agent-accounts.ts
@@ -40,6 +40,10 @@ export type ClaudeSlotModels = Partial<Record<ClaudeModelSlot, ClaudeSlotModel>>
  *  launch is not enough, they must be explicitly removed. */
 export const ENV_UNSET = "\u0000dev3:unset\u0000";
 
+/** Internal marker carried into launched Claude sessions so local statusline
+ * telemetry can attribute a snapshot to the managed account that produced it. */
+export const DEV3_AGENT_ACCOUNT_ID_ENV = "DEV3_AGENT_ACCOUNT_ID";
+
 /** Every fixed env var the Claude API-profile mechanism can set. When the
  *  active selection does not set one of these, it is actively unset so a value
  *  leaked from a previously active profile (or the ambient shell) cannot hijack

--- a/src/shared/rate-limits.ts
+++ b/src/shared/rate-limits.ts
@@ -6,7 +6,7 @@
  * - Claude Code: the statusLine stdin JSON carries `rate_limits.{five_hour,seven_day}`
  *   with `used_percentage` + `resets_at` (unix seconds). dev3 injects a statusLine
  *   wrapper (`dev3 statusline`) via `--settings` that dumps that JSON to
- *   `~/.dev3.0/data/rate-limits/claude.json`.
+ *   `~/.dev3.0/data/rate-limits/claude.json` and additive per-account files.
  * - Codex: rollout files under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
  *   contain `event_msg`/`token_count` events with a `rate_limits` object
  *   (`primary`/`secondary` windows + `credits`). Windows may be null on
@@ -39,8 +39,15 @@ export interface MonthlyCreditLimit {
 
 export interface AgentRateLimitSnapshot {
 	source: RateLimitSource;
+	/** Managed account id that produced this snapshot; null is the system login.
+	 *  Undefined keeps compatibility with reports produced before account-level
+	 *  attribution was added. */
+	accountId?: string | null;
 	/** When this data was captured locally (epoch ms). */
 	capturedAt: number;
+	/** When the provider session was active. Live Codex enrichment may be read
+	 *  later than the rollout event that proves account activity. */
+	activeAt?: number;
 	windows: RateLimitWindow[];
 	/** Codex credits balance display string, when the plan exposes credits. */
 	creditsBalance: string | null;
@@ -59,6 +66,17 @@ export interface AgentRateLimitsReport {
 export const RATE_LIMIT_WARN_PERCENT = 80;
 /** Usage percentage at which the indicator/segment escalates to danger. */
 export const RATE_LIMIT_DANGER_PERCENT = 95;
+
+/** Account activity remains visible for one day after its last local signal. */
+export const RATE_LIMIT_ACTIVITY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export function rateLimitActivityAt(snapshot: AgentRateLimitSnapshot): number {
+	return snapshot.activeAt ?? snapshot.capturedAt;
+}
+
+export function isRateLimitSnapshotRecent(snapshot: AgentRateLimitSnapshot, nowMs: number): boolean {
+	return rateLimitActivityAt(snapshot) >= nowMs - RATE_LIMIT_ACTIVITY_WINDOW_MS;
+}
 
 function asRecord(v: unknown): Record<string, unknown> | null {
 	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
@@ -137,7 +155,7 @@ export function parseClaudeStatusLinePayload(payload: unknown, capturedAt: numbe
 		}
 	}
 	if (windows.length === 0) return null;
-	return { source: "claude", capturedAt, windows, creditsBalance: null, monthlyCredits: null, planType: null };
+	return { source: "claude", capturedAt, activeAt: capturedAt, windows, creditsBalance: null, monthlyCredits: null, planType: null };
 }
 
 /**
@@ -174,7 +192,7 @@ export function parseCodexRateLimits(rateLimits: unknown, eventAtMs: number): Ag
 
 	const planType = typeof root.plan_type === "string" ? root.plan_type : null;
 	if (windows.length === 0 && creditsBalance == null) return null;
-	return { source: "codex", capturedAt: eventAtMs, windows, creditsBalance, monthlyCredits: null, planType };
+	return { source: "codex", capturedAt: eventAtMs, activeAt: eventAtMs, windows, creditsBalance, monthlyCredits: null, planType };
 }
 
 /** Parse the camelCase rateLimits object returned by Codex app-server. */
@@ -227,7 +245,7 @@ export function parseCodexAppServerRateLimits(rateLimits: unknown, capturedAt: n
 
 	const planType = typeof root.planType === "string" ? root.planType : null;
 	if (windows.length === 0 && creditsBalance == null) return null;
-	return { source: "codex", capturedAt, windows, creditsBalance, monthlyCredits, planType };
+	return { source: "codex", capturedAt, activeAt: capturedAt, windows, creditsBalance, monthlyCredits, planType };
 }
 
 /** Merge a fresh app-server snapshot over the rollout fallback without losing rollout-only windows. */
@@ -242,7 +260,9 @@ export function mergeCodexRateLimitSnapshots(
 	for (const window of live.windows) windows.set(window.id, window);
 	return {
 		source: "codex",
+		accountId: live.accountId ?? rollout.accountId,
 		capturedAt: live.capturedAt,
+		activeAt: rollout.activeAt ?? rollout.capturedAt,
 		windows: [...windows.values()],
 		creditsBalance: live.creditsBalance ?? rollout.creditsBalance,
 		monthlyCredits: live.monthlyCredits,

--- a/src/shared/rate-limits.ts
+++ b/src/shared/rate-limits.ts
@@ -78,6 +78,30 @@ export function isRateLimitSnapshotRecent(snapshot: AgentRateLimitSnapshot, nowM
 	return rateLimitActivityAt(snapshot) >= nowMs - RATE_LIMIT_ACTIVITY_WINDOW_MS;
 }
 
+/** The account snapshot with the newest provider activity signal. */
+export function latestRateLimitSnapshot(report: AgentRateLimitsReport): AgentRateLimitSnapshot | null {
+	let latest: AgentRateLimitSnapshot | null = null;
+	for (const snapshot of report.snapshots) {
+		if (!latest || rateLimitActivityAt(snapshot) > rateLimitActivityAt(latest)) {
+			latest = snapshot;
+		}
+	}
+	return latest;
+}
+
+/** The most-used window within one account snapshot. */
+export function worstSnapshotWindow(snapshot: AgentRateLimitSnapshot): RateLimitWindow | null {
+	let worst: RateLimitWindow | null = null;
+	for (const window of snapshot.windows) {
+		if (!worst || window.usedPercent > worst.usedPercent) worst = window;
+	}
+	return worst;
+}
+
+export function isUnlimitedRateLimitSnapshot(snapshot: AgentRateLimitSnapshot): boolean {
+	return snapshot.creditsBalance?.trim().toLowerCase() === "unlimited";
+}
+
 function asRecord(v: unknown): Record<string, unknown> | null {
 	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
 }
@@ -293,7 +317,7 @@ export function extractCodexSnapshotFromRolloutLines(lines: string[]): AgentRate
 	return null;
 }
 
-/** The single most-constrained window across all snapshots (drives the ambient indicator). */
+/** The single most-constrained window across all snapshots. */
 export function worstWindow(report: AgentRateLimitsReport): { source: RateLimitSource; window: RateLimitWindow } | null {
 	let worst: { source: RateLimitSource; window: RateLimitWindow } | null = null;
 	for (const snap of report.snapshots) {


### PR DESCRIPTION
## Summary

- show separate Claude and Codex rate-limit rows for every account active in the last 24 hours
- attribute snapshots to managed accounts while preserving legacy system-login data paths
- drive the header percentage and warning state from the latest active account instead of the most exhausted account
- display unlimited accounts as `0% used` while retaining all per-account details in the tooltip

## Implementation

- persist additive per-account Claude snapshots and scan each managed Codex home
- keep provider activity timestamps separate from live enrichment capture times
- filter stale snapshots, resolve account identities, and keep the tooltip scrollable for larger account sets
- document the compatibility and activity-selection decisions

## Validation

- `bun run lint`
- `bun run test`
- browser QA at desktop and narrow widths with no console errors