### PR TITLE
Warn at startup when the Intel build runs under Rosetta on Apple Silicon

### DIFF
--- a/change-logs/2026/07/16/fix-rosetta-intel-build-warning.md
+++ b/change-logs/2026/07/16/fix-rosetta-intel-build-warning.md
@@ -1,0 +1,1 @@
+The app now detects when it is the Intel (x64) build running under Rosetta 2 on an Apple Silicon Mac and shows a startup warning with a copy-pasteable reinstall command (Homebrew cask when native brew is present, otherwise the arm64 DMG). Such installs run slower, stay on x64 updates forever, and trigger the macOS "Support Ending for Intel-based Apps" notice on every launch.

--- a/decisions/137-rosetta-warning-over-auto-migration.md
+++ b/decisions/137-rosetta-warning-over-auto-migration.md
@@ -1,0 +1,21 @@
+# 137. Rosetta installs get a startup warning, not an automatic arch migration
+
+## Context
+
+A client on an M-series Mac got the macOS 26 "Support Ending for Intel-based Apps" notice: he had installed the Intel (x64) DMG manually, Rosetta 2 ran it silently, and the in-app updater kept him on x64 forever. Electrobun's `Updater` bakes its architecture from `os.arch()` at startup (`electrobun/dist/api/shared/platform.ts`), which reports `x64` under Rosetta — all its URLs (update.json, patches, tarball) permanently target the x64 channel, with no API to override the arch.
+
+## Investigation
+
+`sysctl.proc_translated` is `1` only for a Rosetta-translated process; `0` on native arm64 and `0`/missing OID on real Intel Macs. An automatic cross-arch migration was fully implemented first (custom arm64 bundle download + verify + rename-aside `.app` swap + relaunch, bypassing the built-in updater — Electrobun's own download/apply pair can't be redirected because its hash lookup uses the baked arch). It worked, but replicated Electrobun's entire apply pipeline and swapped the bundle under a running process — judged too fragile to ship.
+
+## Decision
+
+Warn instead of migrate. `src/bun/rosetta.ts` detects Rosetta (strictly `proc_translated == 1`; real Intel Macs are never flagged) and builds a copy-pasteable reinstall command — the arm64 Homebrew cask when `/opt/homebrew/bin/brew` exists (an x86_64 Rosetta brew in `/usr/local` can't install the arm64-only cask and doesn't count), otherwise curl + open of the arm64 DMG. The `getRosettaWarning` RPC (`settings-config.ts`) feeds `RosettaWarningModal.tsx`, shown once per launch from `App.tsx`; dismissal is not persisted because the condition self-clears after reinstalling the native build. User data under `~/.dev3.0/` is untouched by the reinstall.
+
+## Risks
+
+The user must run the command manually — some will dismiss the modal forever (accepted: macOS shows its own escalating notice too). The brew command embeds the running bundle path at generation time; if the app moves before the user pastes it, `rm -rf` targets a stale path and brew may refuse to install over the surviving copy.
+
+## Alternatives considered
+
+Automatic in-updater migration (implemented, then rejected — bundle swap under a running process, duplicated Electrobun internals). Universal (fat) binaries — Electrobun can't build them and every user pays double download size forever. Upstream Electrobun patch (Rosetta-aware arch) — right long-term, doesn't help already-shipped installs. Toast instead of modal — transient and missable for an "app will stop launching" condition, and can't hold a copyable command.

--- a/src/bun/__tests__/rosetta.test.ts
+++ b/src/bun/__tests__/rosetta.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../spawn", () => ({
+	spawn: vi.fn(),
+	spawnSync: vi.fn(),
+}));
+
+import { detectRosetta, buildReinstallCommand, getRosettaWarningInfo } from "../rosetta";
+import { spawnSync } from "../spawn";
+
+const spawnSyncMock = vi.mocked(spawnSync);
+
+function sysctlReturns(stdout: string, exitCode = 0): void {
+	spawnSyncMock.mockReturnValue({
+		success: exitCode === 0,
+		exitCode,
+		stdout: Buffer.from(stdout),
+	} as unknown as ReturnType<typeof spawnSync>);
+}
+
+beforeEach(() => {
+	spawnSyncMock.mockReset();
+});
+
+describe("detectRosetta", () => {
+	it("returns true only when proc_translated is exactly 1", () => {
+		sysctlReturns("1\n");
+		expect(detectRosetta("darwin", "x64")).toBe(true);
+	});
+
+	it("returns false on a real Intel Mac (proc_translated = 0)", () => {
+		sysctlReturns("0\n");
+		expect(detectRosetta("darwin", "x64")).toBe(false);
+	});
+
+	it("returns false when the sysctl OID does not exist (old Intel Macs)", () => {
+		sysctlReturns("", 1);
+		expect(detectRosetta("darwin", "x64")).toBe(false);
+	});
+
+	it("returns false when sysctl throws", () => {
+		spawnSyncMock.mockImplementation(() => {
+			throw new Error("spawn failed");
+		});
+		expect(detectRosetta("darwin", "x64")).toBe(false);
+	});
+
+	it("never probes on native arm64", () => {
+		expect(detectRosetta("darwin", "arm64")).toBe(false);
+		expect(spawnSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("never probes on non-macOS platforms", () => {
+		expect(detectRosetta("linux", "x64")).toBe(false);
+		expect(spawnSyncMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("buildReinstallCommand", () => {
+	it("prefers the arm64 Homebrew cask with the real bundle path", () => {
+		const { command, kind } = buildReinstallCommand(true, "/Applications/dev-3.0.app");
+
+		expect(kind).toBe("brew");
+		expect(command).toBe('rm -rf "/Applications/dev-3.0.app" && brew install --cask h0x91b/dev3/dev3');
+	});
+
+	it("falls back to the default bundle location when the running path is not an .app", () => {
+		const { command } = buildReinstallCommand(true, "/opt/somewhere/bin");
+
+		expect(command).toContain('rm -rf "/Applications/dev-3.0.app"');
+	});
+
+	it("falls back to the arm64 DMG when native Homebrew is absent", () => {
+		const { command, kind } = buildReinstallCommand(false, "/Applications/dev-3.0.app");
+
+		expect(kind).toBe("dmg");
+		expect(command).toContain("stable-macos-arm64-dev-3.0.dmg");
+		expect(command).toContain("open ~/Downloads/dev-3.0-arm64.dmg");
+	});
+});
+
+describe("getRosettaWarningInfo", () => {
+	it("returns null when not under Rosetta", () => {
+		expect(getRosettaWarningInfo(false)).toBeNull();
+	});
+
+	it("returns a reinstall command under Rosetta", () => {
+		const info = getRosettaWarningInfo(true);
+
+		expect(info).not.toBeNull();
+		expect(info?.command).toBeTruthy();
+		expect(info?.kind === "brew" || info?.kind === "dmg").toBe(true);
+	});
+});

--- a/src/bun/rosetta.ts
+++ b/src/bun/rosetta.ts
@@ -1,0 +1,71 @@
+/**
+ * Rosetta 2 detection — an Intel (x64) build running translated on an Apple
+ * Silicon Mac.
+ *
+ * Such installs happen when the user manually downloads the Intel DMG. They
+ * work, but run slower and macOS 26+ warns on every launch that Rosetta
+ * support is ending ("Support Ending for Intel-based Apps"). The in-app
+ * updater cannot fix this either: Electrobun's Updater bakes its architecture
+ * from os.arch() at startup, which reports "x64" under Rosetta, so the install
+ * stays on x64 artifacts forever. We surface a startup warning with a
+ * copy-pasteable reinstall command instead — see
+ * decisions/137-rosetta-warning-over-auto-migration.md.
+ */
+
+import { dirname, resolve } from "path";
+import { existsSync } from "fs";
+import type { RosettaWarningInfo } from "../shared/types";
+import { spawnSync } from "./spawn";
+
+// Native arm64 Homebrew always lives here; an x86_64 (Rosetta) brew lives in
+// /usr/local and cannot install our arm64-only cask, so it does not count.
+const ARM64_BREW = "/opt/homebrew/bin/brew";
+
+const ARM64_DMG_URL = "https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-macos-arm64-dev-3.0.dmg";
+
+/**
+ * Detects an x64 process translated by Rosetta 2 on an Apple Silicon Mac.
+ * `sysctl.proc_translated` is 1 only under Rosetta; on real Intel Macs it is
+ * 0 or the OID does not exist — those must never be flagged.
+ */
+export function detectRosetta(platform: string = process.platform, arch: string = process.arch): boolean {
+	if (platform !== "darwin" || arch !== "x64") return false;
+	try {
+		const result = spawnSync(["sysctl", "-n", "sysctl.proc_translated"]);
+		if (result.exitCode !== 0) return false;
+		return result.stdout?.toString().trim() === "1";
+	} catch {
+		return false;
+	}
+}
+
+/** macOS: the running .app bundle path (executable is at Contents/MacOS/…). */
+function getRunningAppBundlePath(): string {
+	return resolve(dirname(process.execPath), "..", "..");
+}
+
+/**
+ * Builds the reinstall command for the warning dialog. Prefers the arm64
+ * Homebrew cask (also brings the brew dependencies); falls back to
+ * downloading and opening the arm64 DMG.
+ */
+export function buildReinstallCommand(
+	brewAvailable: boolean = existsSync(ARM64_BREW),
+	appBundlePath: string = getRunningAppBundlePath(),
+): NonNullable<RosettaWarningInfo> {
+	if (brewAvailable) {
+		const bundle = appBundlePath.endsWith(".app") ? appBundlePath : "/Applications/dev-3.0.app";
+		return {
+			command: `rm -rf "${bundle}" && brew install --cask h0x91b/dev3/dev3`,
+			kind: "brew",
+		};
+	}
+	return {
+		command: `curl -fsSL ${ARM64_DMG_URL} -o ~/Downloads/dev-3.0-arm64.dmg && open ~/Downloads/dev-3.0-arm64.dmg`,
+		kind: "dmg",
+	};
+}
+
+export function getRosettaWarningInfo(translated: boolean = detectRosetta()): RosettaWarningInfo {
+	return translated ? buildReinstallCommand() : null;
+}

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -1,11 +1,12 @@
 import { chmodSync, existsSync, mkdirSync, symlinkSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { PATHS } from "../electrobun-platform";
-import type { AgentCheckResult, CodingAgent, ConfigSourceEntry, Dev3RepoConfig, GitHubCliStatus, GlobalSettings, Project, ProjectSettingsUpdate, RequirementCheckResult } from "../../shared/types";
+import type { AgentCheckResult, CodingAgent, ConfigSourceEntry, Dev3RepoConfig, GitHubCliStatus, GlobalSettings, Project, ProjectSettingsUpdate, RequirementCheckResult, RosettaWarningInfo } from "../../shared/types";
 import * as data from "../data";
 import * as agents from "../agents";
 import * as github from "../github";
 import * as updater from "../updater";
+import * as rosetta from "../rosetta";
 import * as repoConfig from "../repo-config";
 import * as pty from "../pty-server";
 import { loadSettings, saveSettings } from "../settings";
@@ -308,6 +309,14 @@ async function checkSystemRequirements(): Promise<RequirementCheckResult[]> {
 	return results;
 }
 
+async function getRosettaWarning(): Promise<RosettaWarningInfo> {
+	const info = rosetta.getRosettaWarningInfo();
+	if (info) {
+		log.warn("Rosetta-translated x64 build on Apple Silicon detected", { kind: info.kind });
+	}
+	return info;
+}
+
 async function checkGhAvailable(): Promise<{ available: boolean; notInstalled: boolean }> {
 	log.info("-> checkGhAvailable");
 	const status = await github.getGitHubCliStatus();
@@ -420,6 +429,7 @@ export const settingsConfigHandlers = {
 	getLastRoute,
 	getAppVersion,
 	checkSystemRequirements,
+	getRosettaWarning,
 	checkGhAvailable,
 	setCustomBinaryPath,
 	checkAgentAvailability,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -5,7 +5,7 @@ import { setWebNotificationsSuppressed, showWebNotificationOrToast, type WebNoti
 import { useT, useLocale } from "./i18n";
 import { handleMenuAction } from "./menuRouter";
 import { trackPageView, trackEvent, registerAgents } from "./analytics";
-import type { CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteNetInterface, RequirementCheckResult, SharedArtifact, SharedImage, Task, TaskStatus } from "../shared/types";
+import type { CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskStatus } from "../shared/types";
 import { orderProjectsForDisplay, taskSeqLabel } from "../shared/types";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 import { isRemote } from "./utils/platform";
@@ -38,6 +38,7 @@ import KeyboardShortcutsModal, { type ShortcutsTab } from "./components/Keyboard
 import RemoteAccessExposedPorts from "./components/RemoteAccessExposedPorts";
 import { ConfirmHost, confirm } from "./confirm";
 import AboutModal from "./components/AboutModal";
+import RosettaWarningModal from "./components/RosettaWarningModal";
 import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "./task-sounds";
 import { runMergeCompletionPromptOnce } from "./utils/mergeCompletionPrompt";
 import { getRecentProjectIds, orderByRecency, recordProjectJump } from "./utils/recentProjects";
@@ -393,6 +394,17 @@ function App() {
 	useEffect(() => {
 		checkRequirements();
 	}, [checkRequirements]);
+
+	// Rosetta warning: an Intel (x64) build running translated on Apple Silicon.
+	// Shown once per launch while the condition persists — it clears itself
+	// after the user reinstalls the native arm64 build.
+	const [rosettaWarning, setRosettaWarning] = useState<RosettaWarningInfo>(null);
+	useEffect(() => {
+		api.request
+			.getRosettaWarning()
+			.then(setRosettaWarning)
+			.catch((err) => console.error("Failed to check Rosetta status:", err));
+	}, []);
 
 	// Navigation guard for unsaved-changes prompts (e.g. ProjectSettings, diff viewer)
 	const navigationGuardRef = useRef<NavigationGuard | null>(null);
@@ -2327,6 +2339,13 @@ function App() {
 				/>
 			)}
 			{aboutVersion && <AboutModal version={aboutVersion} onClose={() => setAboutVersion(null)} />}
+			{rosettaWarning && (
+				<RosettaWarningModal
+					command={rosettaWarning.command}
+					kind={rosettaWarning.kind}
+					onClose={() => setRosettaWarning(null)}
+				/>
+			)}
 			<DiagnosticsIndicator />
 			{showDiagnostics && <DiagnosticsPanel onClose={() => setShowDiagnostics(false)} />}
 			</>

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../rpc", () => ({
 	api: {
 		request: {
 			checkSystemRequirements: vi.fn().mockResolvedValue([]),
+			getRosettaWarning: vi.fn().mockResolvedValue(null),
 			checkGhAvailable: vi.fn().mockResolvedValue({ available: true, notInstalled: false }),
 			getProjects: vi.fn().mockResolvedValue([]),
 			getLastRoute: vi.fn().mockResolvedValue({ route: null }),

--- a/src/mainview/components/RosettaWarningModal.tsx
+++ b/src/mainview/components/RosettaWarningModal.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import { useT } from "../i18n";
+import { copyTextToClipboard } from "../utils/clipboard";
+import { useFocusTrap } from "../utils/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+
+interface RosettaWarningModalProps {
+	command: string;
+	kind: "brew" | "dmg";
+	onClose: () => void;
+}
+
+/**
+ * Startup warning for an Intel (x64) build running under Rosetta 2 on an
+ * Apple Silicon Mac (macOS is sunsetting Rosetta). Shows a copy-pasteable
+ * reinstall command; reappears on every launch while the condition persists —
+ * it clears itself once the user reinstalls the native arm64 build.
+ */
+export default function RosettaWarningModal({ command, kind, onClose }: RosettaWarningModalProps) {
+	const t = useT();
+	const trapRef = useFocusTrap<HTMLDivElement>();
+	useEscapeKey(onClose);
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = useCallback(() => {
+		void copyTextToClipboard(command).then((ok) => {
+			if (!ok) return;
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		});
+	}, [command]);
+
+	return (
+		<div
+			className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div
+				ref={trapRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="rosetta-warning-title"
+				tabIndex={-1}
+				className="bg-overlay border border-edge rounded-2xl shadow-2xl w-[34rem] max-w-[calc(100vw-2rem)] p-6 space-y-3 outline-none"
+			>
+				<div className="flex items-center gap-3">
+					<span
+						className="text-warning text-2xl leading-none"
+						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+					>
+						{"\uf071"}
+					</span>
+					<h2 id="rosetta-warning-title" className="text-fg text-lg font-semibold">
+						{t("rosetta.title")}
+					</h2>
+				</div>
+
+				<p className="text-fg-2 text-sm">{t("rosetta.body")}</p>
+				<p className="text-fg-3 text-sm">
+					{kind === "brew" ? t("rosetta.instructionBrew") : t("rosetta.instructionDmg")}
+				</p>
+
+				<code className="block bg-base border border-edge rounded-lg px-3 py-2 text-xs font-mono text-warning break-all select-all">
+					{command}
+				</code>
+
+				<p className="text-fg-muted text-xs">{t("rosetta.dataSafe")}</p>
+
+				<div className="flex justify-end gap-2 pt-1">
+					<button
+						type="button"
+						onClick={onClose}
+						className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
+					>
+						{t("rosetta.laterBtn")}
+					</button>
+					<button
+						type="button"
+						onClick={handleCopy}
+						className="px-4 py-2 text-sm rounded-lg bg-accent text-white hover:bg-accent-hover transition-colors"
+					>
+						{copied ? t("rosetta.copiedBtn") : t("rosetta.copyBtn")}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/mainview/components/__tests__/RosettaWarningModal.test.tsx
+++ b/src/mainview/components/__tests__/RosettaWarningModal.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RosettaWarningModal from "../RosettaWarningModal";
+import { I18nProvider } from "../../i18n";
+
+const COMMAND = 'rm -rf "/Applications/dev-3.0.app" && brew install --cask h0x91b/dev3/dev3';
+
+function renderModal(kind: "brew" | "dmg" = "brew", onClose = vi.fn()) {
+	render(
+		<I18nProvider>
+			<RosettaWarningModal command={COMMAND} kind={kind} onClose={onClose} />
+		</I18nProvider>,
+	);
+	return onClose;
+}
+
+describe("RosettaWarningModal", () => {
+	it("shows the warning title and the reinstall command", () => {
+		renderModal();
+		expect(screen.getByText("Intel build on Apple Silicon")).toBeInTheDocument();
+		expect(screen.getByText(COMMAND)).toBeInTheDocument();
+	});
+
+	it("shows the brew instruction for kind=brew", () => {
+		renderModal("brew");
+		expect(screen.getByText(/Quit dev-3.0, paste this in Terminal/)).toBeInTheDocument();
+	});
+
+	it("shows the DMG instruction for kind=dmg", () => {
+		renderModal("dmg");
+		expect(screen.getByText(/drag dev-3.0 into Applications/)).toBeInTheDocument();
+	});
+
+	it("copies the command to the clipboard and confirms", async () => {
+		const user = userEvent.setup();
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+		renderModal();
+
+		await user.click(screen.getByRole("button", { name: "Copy command" }));
+
+		expect(writeText).toHaveBeenCalledWith(COMMAND);
+		expect(await screen.findByRole("button", { name: "Copied!" })).toBeInTheDocument();
+	});
+
+	it("closes via the Remind me later button", async () => {
+		const user = userEvent.setup();
+		const onClose = renderModal();
+
+		await user.click(screen.getByRole("button", { name: "Remind me later" }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("closes on Escape", () => {
+		const onClose = renderModal();
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/mainview/i18n/translations/en/updates.ts
+++ b/src/mainview/i18n/translations/en/updates.ts
@@ -21,6 +21,18 @@ const updates = {
 	"update.checkFailedDetail": "Update check failed: {error}",
 	"update.applyFailed": "Couldn't apply the update: {error}",
 
+	// Rosetta warning (Intel build on Apple Silicon)
+	"rosetta.title": "Intel build on Apple Silicon",
+	"rosetta.body":
+		"This copy of dev-3.0 is the Intel (x64) build running through Rosetta 2. It runs slower, and macOS is ending Rosetta support — soon it will stop launching entirely.",
+	"rosetta.instructionBrew": "Quit dev-3.0, paste this in Terminal, then launch dev-3.0 again:",
+	"rosetta.instructionDmg":
+		"Paste this in Terminal, then drag dev-3.0 into Applications (replacing the old one) and relaunch:",
+	"rosetta.dataSafe": "Your projects, tasks, and settings are not affected.",
+	"rosetta.copyBtn": "Copy command",
+	"rosetta.copiedBtn": "Copied!",
+	"rosetta.laterBtn": "Remind me later",
+
 	// Requirements
 	"requirements.title": "System Requirements",
 	"requirements.subtitle": "The following tools must be installed to use dev-3.0",

--- a/src/mainview/i18n/translations/es/updates.ts
+++ b/src/mainview/i18n/translations/es/updates.ts
@@ -21,6 +21,18 @@ const updates = {
 	"update.checkFailedDetail": "Error al buscar actualizaciones: {error}",
 	"update.applyFailed": "No se pudo aplicar la actualización: {error}",
 
+	// Rosetta warning (Intel build on Apple Silicon)
+	"rosetta.title": "Versión Intel en Apple Silicon",
+	"rosetta.body":
+		"Esta copia de dev-3.0 es la versión Intel (x64) ejecutándose mediante Rosetta 2. Es más lenta, y macOS está retirando el soporte de Rosetta — pronto dejará de abrirse por completo.",
+	"rosetta.instructionBrew": "Cierra dev-3.0, pega este comando en Terminal y vuelve a abrir dev-3.0:",
+	"rosetta.instructionDmg":
+		"Pega este comando en Terminal, luego arrastra dev-3.0 a Applications (reemplazando la versión anterior) y reinicia:",
+	"rosetta.dataSafe": "Tus proyectos, tareas y ajustes no se ven afectados.",
+	"rosetta.copyBtn": "Copiar comando",
+	"rosetta.copiedBtn": "¡Copiado!",
+	"rosetta.laterBtn": "Recordar más tarde",
+
 	// Requirements
 	"requirements.title": "Requisitos del sistema",
 	"requirements.subtitle": "Las siguientes herramientas deben estar instaladas para usar dev-3.0",

--- a/src/mainview/i18n/translations/ru/updates.ts
+++ b/src/mainview/i18n/translations/ru/updates.ts
@@ -21,6 +21,18 @@ const updates = {
 	"update.checkFailedDetail": "Не удалось проверить обновления: {error}",
 	"update.applyFailed": "Не удалось применить обновление: {error}",
 
+	// Rosetta warning (Intel build on Apple Silicon)
+	"rosetta.title": "Intel-сборка на Apple Silicon",
+	"rosetta.body":
+		"Эта копия dev-3.0 — Intel-сборка (x64), работающая через Rosetta 2. Она медленнее, а macOS прекращает поддержку Rosetta — скоро приложение вовсе перестанет запускаться.",
+	"rosetta.instructionBrew": "Закройте dev-3.0, вставьте команду в Терминал, затем запустите dev-3.0 снова:",
+	"rosetta.instructionDmg":
+		"Вставьте команду в Терминал, затем перетащите dev-3.0 в Applications (заменив старую версию) и перезапустите:",
+	"rosetta.dataSafe": "Ваши проекты, задачи и настройки не пострадают.",
+	"rosetta.copyBtn": "Скопировать команду",
+	"rosetta.copiedBtn": "Скопировано!",
+	"rosetta.laterBtn": "Напомнить позже",
+
 	// Requirements
 	"requirements.title": "Системные требования",
 	"requirements.subtitle": "Для работы dev-3.0 необходимы следующие инструменты",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2182,6 +2182,16 @@ export interface RequirementCheckResult {
 	optional?: boolean; // optional requirements don't block the app
 }
 
+// ---- Rosetta warning ----
+
+/**
+ * Reinstall info for an Intel (x64) build running translated under Rosetta 2
+ * on an Apple Silicon Mac; null when the process is not translated. `command`
+ * is a copy-pasteable terminal command to reinstall the native arm64 build;
+ * `kind` says which reinstall path it uses (affects the instruction copy).
+ */
+export type RosettaWarningInfo = { command: string; kind: "brew" | "dmg" } | null;
+
 // ---- Agent availability ----
 
 export interface AgentCheckResult {
@@ -2767,6 +2777,10 @@ export type AppRPCSchema = {
 			checkSystemRequirements: {
 				params: void;
 				response: RequirementCheckResult[];
+			};
+			getRosettaWarning: {
+				params: void;
+				response: RosettaWarningInfo;
 			};
 			checkGhAvailable: {
 				params: void;


### PR DESCRIPTION
## Summary

- Detect an Intel (x64) build running translated under Rosetta 2 on an Apple Silicon Mac (`src/bun/rosetta.ts`): strictly `sysctl.proc_translated == 1`, so real Intel Macs (where it is `0` or the OID is missing) are never flagged.
- Show a startup warning modal (`RosettaWarningModal.tsx`, fed by the new `getRosettaWarning` RPC) explaining the install is the Intel build — slower, and macOS is sunsetting Rosetta — with a copy-pasteable reinstall command: the arm64 Homebrew cask when native `/opt/homebrew/bin/brew` exists, otherwise curl + open of the arm64 DMG. Dismissal is not persisted; the modal reappears each launch until the user reinstalls the native build, then clears itself.
- Why a warning instead of auto-migration: Electrobun's `Updater` bakes its architecture from `os.arch()` at startup, which reports `x64` under Rosetta, so such installs can never self-heal through the updater; an automatic cross-arch migration was implemented first and rejected as too fragile (bundle swap under a running process). Details in `decisions/137-rosetta-warning-over-auto-migration.md`.
- i18n (en/ru/es), unit tests for detection/command building and the modal, changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)