### PR TITLE
Isolate tests across parallel worktrees

### DIFF
--- a/change-logs/2026/07/16/fix-parallel-worktree-test-isolation.md
+++ b/change-logs/2026/07/16/fix-parallel-worktree-test-isolation.md
@@ -1,0 +1,1 @@
+Unit and E2E test processes now sandbox HOME, temporary files, XDG state, logs, tmux configuration, and DEV3 data under a per-worktree, per-suite run directory. Fixed data fixture directories and the real CLI Unix socket no longer collide when agents test from parallel worktrees. The tmux E2Es also run reliably inside agent tmux sessions and clean up timed-out FIFO readers.

--- a/decisions/137-worktree-test-process-isolation.md
+++ b/decisions/137-worktree-test-process-isolation.md
@@ -1,0 +1,21 @@
+# 137 — Isolate test processes by worktree
+
+## Context
+
+Parallel agents run identical Vitest files from different worktrees. Several tests used fixed `/tmp/dev3-*` directories and one real Unix socket, so one run could delete, overwrite, or connect to another run's resource even though their source trees were separate.
+
+## Investigation
+
+A single `socket-client.test.ts` run passed 14/14, while two concurrent runs both failed by receiving each other's responses or losing the shared socket. The broader audit found the same pattern in data persistence, worktree creation, shared image/artifact, port-pool, log, HOME, XDG, and standalone pane E2E paths; real ports were mocked and the tmux E2Es already used globally unique PID-specific socket names.
+
+## Decision
+
+Every Vitest config now calls `configureTestIsolation` from `test-isolation.ts`, which redirects HOME, tmp, XDG, logs, and DEV3_HOME beneath a root keyed by worktree hash, suite, and PID. Stateful tests and runtime scratch files must derive explicit fixtures from `DEV3_TEST_ROOT`, and the standalone pane E2E configures the same sandbox through its preload; tmux sockets keep their shorter PID-specific names to stay below Unix socket path limits.
+
+## Risks
+
+Tests no longer inherit the developer's HOME or global Git/XDG configuration, which may expose tests that accidentally depended on local machine state. Sandboxes use more temporary directories during a run, but global teardown removes each run root after Vitest finishes.
+
+## Alternatives considered
+
+Adding a random suffix only to known hardcoded paths would fix today's collisions but leave every future implicit HOME, log, or tmux path unsafe. Serializing test runs across worktrees would remove the product's intended parallelism, while a worktree-only root without suite/PID isolation would still collide when the same suite is launched twice in one worktree.

--- a/src/bun/__tests__/agents-persistence.test.ts
+++ b/src/bun/__tests__/agents-persistence.test.ts
@@ -4,7 +4,7 @@ import type { CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 
 const { TEST_HOME, AGENTS_FILE } = vi.hoisted(() => {
-	const home = `/tmp/dev3-agents-persistence-${process.pid}`;
+	const home = `${process.env.DEV3_TEST_ROOT}/agents-persistence`;
 	return { TEST_HOME: home, AGENTS_FILE: `${home}/agents.json` };
 });
 

--- a/src/bun/__tests__/automations-data.test.ts
+++ b/src/bun/__tests__/automations-data.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Automation, Project } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/automations-data`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -12,8 +14,8 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-automations",
-	OPS_DIR: "/tmp/dev3-test-automations/ops",
+	DEV3_HOME: TEST_HOME,
+	OPS_DIR: `${TEST_HOME}/ops`,
 }));
 
 vi.mock("../cow-clone", () => ({
@@ -25,8 +27,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-automations", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-automations", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import {

--- a/src/bun/__tests__/data-cache.test.ts
+++ b/src/bun/__tests__/data-cache.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
 import type { Project, Task } from "../../shared/types";
 
-const { logDebug } = vi.hoisted(() => ({ logDebug: vi.fn() }));
+const { logDebug, testHome } = vi.hoisted(() => ({
+	logDebug: vi.fn(),
+	testHome: `${process.env.DEV3_TEST_ROOT}/data-cache`,
+}));
 
 vi.mock("../logger", () => ({
 	createLogger: () => ({
@@ -14,7 +17,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-data-cache",
+	DEV3_HOME: testHome,
 }));
 
 vi.mock("../cow-clone", () => ({
@@ -27,7 +30,7 @@ vi.mock("../file-lock", () => ({
 
 import { _resetDataCaches, loadProjects, loadTasks, saveTasks } from "../data";
 
-const HOME = "/tmp/dev3-test-data-cache";
+const HOME = testHome;
 const PROJECT_PATH = "/tmp/dev3-cache-project";
 const SLUG = "tmp-dev3-cache-project";
 

--- a/src/bun/__tests__/data-dangling-custom-column.test.ts
+++ b/src/bun/__tests__/data-dangling-custom-column.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:f
 import { dirname } from "node:path";
 import type { CustomColumn, Project, Task } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-dangling-custom-column`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -13,7 +15,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-dangling-col",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -21,8 +23,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-dangling-col", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-dangling-col", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import { loadTasks, updateTask } from "../data";
@@ -42,7 +44,7 @@ const testProject: Project = {
 };
 
 function tasksFilePath(): string {
-	return "/tmp/dev3-test-dangling-col/data/tmp-test-project/tasks.json";
+	return `${TEST_HOME}/data/tmp-test-project/tasks.json`;
 }
 
 function seedTasks(tasks: unknown[]): void {

--- a/src/bun/__tests__/data-history.test.ts
+++ b/src/bun/__tests__/data-history.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
 import type { Project } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-history`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -12,7 +14,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-history",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -20,8 +22,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-history", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-history", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 afterEach(() => {

--- a/src/bun/__tests__/data-last-route.test.ts
+++ b/src/bun/__tests__/data-last-route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-last-route`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -11,7 +13,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-last-route",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -19,13 +21,13 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-last-route", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-last-route", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import { saveLastRoute, loadLastRoute } from "../data";
 
-const LAST_ROUTE_FILE = "/tmp/dev3-test-last-route/last-route.json";
+const LAST_ROUTE_FILE = `${TEST_HOME}/last-route.json`;
 
 describe("last route persistence", () => {
 	it("returns null when no route has been saved", async () => {

--- a/src/bun/__tests__/data-priority.test.ts
+++ b/src/bun/__tests__/data-priority.test.ts
@@ -3,12 +3,14 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Project, Task, TaskStatus } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-priority`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-priority",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -16,8 +18,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-priority", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-priority", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import { addTask, setTaskPriority, reorderTasksInColumn } from "../data";
@@ -34,7 +36,7 @@ const testProject: Project = {
 };
 
 function tasksFilePath(): string {
-	return "/tmp/dev3-test-priority/data/tmp-test-project/tasks.json";
+	return `${TEST_HOME}/data/tmp-test-project/tasks.json`;
 }
 
 function makeTask(overrides: Partial<Task> & { id: string; seq: number }): Task {

--- a/src/bun/__tests__/data-projects-backup.test.ts
+++ b/src/bun/__tests__/data-projects-backup.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import type { Project } from "../../shared/types";
 
-const TEST_HOME = "/tmp/dev3-test-projects-backup";
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-projects-backup`);
 
 vi.mock("../logger", () => ({
 	createLogger: () => ({
@@ -14,7 +14,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-projects-backup",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../cow-clone", () => ({

--- a/src/bun/__tests__/data-projects.test.ts
+++ b/src/bun/__tests__/data-projects.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Project } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-projects`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -12,7 +14,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-projects",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../cow-clone", () => ({
@@ -24,13 +26,13 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-projects", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-projects", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import { addProject, loadProjects, updateProject } from "../data";
 
-const PROJECTS_FILE = "/tmp/dev3-test-projects/projects.json";
+const PROJECTS_FILE = `${TEST_HOME}/projects.json`;
 
 describe("addProject — duplicate prevention", () => {
 	it("returns existing project when adding same path twice", async () => {

--- a/src/bun/__tests__/data-reorder.test.ts
+++ b/src/bun/__tests__/data-reorder.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Project, Task, TaskStatus } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-reorder`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -13,7 +15,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-reorder",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -21,8 +23,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-reorder", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-reorder", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 import { loadTasks, addTask, updateTask, reorderTasksInColumn } from "../data";
@@ -39,7 +41,7 @@ const testProject: Project = {
 };
 
 function tasksFilePath(): string {
-	return "/tmp/dev3-test-reorder/data/tmp-test-project/tasks.json";
+	return `${TEST_HOME}/data/tmp-test-project/tasks.json`;
 }
 
 function makeTask(overrides: Partial<Task> & { id: string; seq: number }): Task {

--- a/src/bun/__tests__/data-seq.test.ts
+++ b/src/bun/__tests__/data-seq.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "nod
 import { dirname } from "node:path";
 import type { Project, Task } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-seq`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -13,7 +15,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-seq",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -21,8 +23,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-seq", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-seq", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 afterEach(() => {
@@ -43,11 +45,11 @@ const testProject: Project = {
 };
 
 function tasksFilePath(): string {
-	return "/tmp/dev3-test-seq/data/tmp-test-project/tasks.json";
+	return `${TEST_HOME}/data/tmp-test-project/tasks.json`;
 }
 
 function tasksBackupDirPath(): string {
-	return "/tmp/dev3-test-seq/data/tmp-test-project/tasks-backups";
+	return `${TEST_HOME}/data/tmp-test-project/tasks-backups`;
 }
 
 function readBackupFileNames(): string[] {

--- a/src/bun/__tests__/data-status-time.test.ts
+++ b/src/bun/__tests__/data-status-time.test.ts
@@ -3,12 +3,14 @@ import { mkdirSync, rmSync } from "node:fs";
 import type { Project } from "../../shared/types";
 import { computeTaskTimeBreakdown } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-status-time`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-status-time",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../file-lock", () => ({
@@ -16,8 +18,8 @@ vi.mock("../file-lock", () => ({
 }));
 
 beforeEach(() => {
-	rmSync("/tmp/dev3-test-status-time", { recursive: true, force: true });
-	mkdirSync("/tmp/dev3-test-status-time", { recursive: true });
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
 });
 
 afterEach(() => {

--- a/src/bun/__tests__/data-virtual-projects.test.ts
+++ b/src/bun/__tests__/data-virtual-projects.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 
+const DEV3_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-virtual-projects`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -11,8 +13,8 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test-virtual",
-	OPS_DIR: "/tmp/dev3-test-virtual/ops",
+	DEV3_HOME,
+	OPS_DIR: `${DEV3_HOME}/ops`,
 }));
 
 vi.mock("../cow-clone", () => ({
@@ -23,7 +25,6 @@ vi.mock("../file-lock", () => ({
 	withFileLock: async <T>(_filePath: string, fn: () => Promise<T>): Promise<T> => fn(),
 }));
 
-const DEV3_HOME = "/tmp/dev3-test-virtual";
 const VIRTUAL_FILE = `${DEV3_HOME}/virtual-projects.json`;
 
 beforeEach(async () => {
@@ -71,7 +72,8 @@ describe("addVirtualProject", () => {
 
 	it("never reuses a slug while its data/ dir survives", async () => {
 		// Simulate a deleted-then-recreated board: the munged data dir survives.
-		const survivingDataDir = `${DEV3_HOME}/data/tmp-dev3-test-virtual-ops-operations`;
+		const opsPath = `${DEV3_HOME}/ops/operations`;
+		const survivingDataDir = `${DEV3_HOME}/data/${opsPath.replace(/^\//, "").replaceAll("/", "-")}`;
 		mkdirSync(survivingDataDir, { recursive: true });
 		const project = await addVirtualProject("Operations");
 		expect(project.path).toBe(`${DEV3_HOME}/ops/operations-2`);
@@ -80,7 +82,7 @@ describe("addVirtualProject", () => {
 	it("does not collide with a git project's data-dir slug", async () => {
 		// A git project whose munged path equals the ops data-dir name would collide.
 		writeFileSync(`${DEV3_HOME}/projects.json`, JSON.stringify([
-			{ id: "g1", name: "g", path: "/tmp/dev3-test-virtual/ops/operations", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "2025-01-01T00:00:00Z", labels: [] },
+			{ id: "g1", name: "g", path: `${DEV3_HOME}/ops/operations`, setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "2025-01-01T00:00:00Z", labels: [] },
 		]));
 		const project = await addVirtualProject("Operations");
 		expect(project.path).toBe(`${DEV3_HOME}/ops/operations-2`);

--- a/src/bun/__tests__/git-test-helpers.ts
+++ b/src/bun/__tests__/git-test-helpers.ts
@@ -25,7 +25,7 @@ export function setupCommonMocks() {
 	}));
 
 	vi.mock("../paths", () => ({
-		DEV3_HOME: "/tmp/dev3-test",
+		DEV3_HOME: process.env.DEV3_HOME ?? `${tmpdir()}/dev3-test-home`,
 	}));
 }
 

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -4,6 +4,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import type { Project, Task } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/git-worktree`);
+
 vi.mock("../logger", () => ({
 	createLogger: () => ({
 		debug: vi.fn(),
@@ -14,7 +16,7 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-test",
+	DEV3_HOME: TEST_HOME,
 }));
 
 vi.mock("../spawn", async () => {
@@ -578,7 +580,7 @@ describe("createWorktree edge cases", () => {
 
 			// Pre-create the worktree at the path createWorktree will pick, then
 			// detach it so the path is "stale" (directory present, branch removed).
-			const stalePath = join("/tmp/dev3-test", "worktrees", "tmp-repo", "55555555", "worktree");
+			const stalePath = join(TEST_HOME, "worktrees", "tmp-repo", "55555555", "worktree");
 			mkdirSync(stalePath, { recursive: true });
 			writeFileSync(join(stalePath, "leftover.txt"), "leftover\n");
 
@@ -606,7 +608,7 @@ describe("createWorktree edge cases", () => {
 			g("git branch dev3/task-66666666 main", r.local);
 
 			// Stale worktree directory at the exact path createWorktree will pick.
-			const stalePath = join("/tmp/dev3-test", "worktrees", "tmp-repo", "66666666", "worktree");
+			const stalePath = join(TEST_HOME, "worktrees", "tmp-repo", "66666666", "worktree");
 			mkdirSync(stalePath, { recursive: true });
 			writeFileSync(join(stalePath, "leftover.txt"), "leftover\n");
 

--- a/src/bun/__tests__/pane-exit-e2e-preload.ts
+++ b/src/bun/__tests__/pane-exit-e2e-preload.ts
@@ -1,5 +1,9 @@
 import { mock } from "bun:test";
 import type { PaneSessionEntry } from "../../shared/types";
+import { cleanupTestIsolation, configureTestIsolation } from "../../../test-isolation";
+
+const testRoot = configureTestIsolation("pane-e2e");
+process.once("exit", () => cleanupTestIsolation(testRoot));
 
 mock.module("electrobun/bun", () => ({
 	PATHS: { VIEWS_FOLDER: "/fake" },
@@ -19,6 +23,7 @@ mock.module("../data", () => ({
 	},
 	getTask: async () => ({ ...(globalThis as any).__e2eTask, sessionState: (globalThis as any).__e2eSessionState }),
 	loadProjects: async () => [(globalThis as any).__e2eProject],
+	loadVirtualProjects: async () => [],
 	getProject: async () => (globalThis as any).__e2eProject,
 	addTask: async () => ({}),
 	loadTasks: async () => [],
@@ -53,6 +58,7 @@ mock.module("../agent-hooks", () => ({
 mock.module("../settings", () => ({
 	loadSettings: async () => ({}),
 	loadSettingsSync: () => ({}),
+	recordFavoriteUsages: async () => {},
 	saveSettings: async () => {},
 }));
 
@@ -63,9 +69,17 @@ mock.module("../port-pool", () => ({
 }));
 
 mock.module("../port-scanner", () => ({
+	buildProcessTree: async () => new Map(),
+	clearPortDataForTask: () => {},
+	collectDescendants: () => [],
+	collectTaskPids: async () => new Set(),
+	findPortHolders: async () => [],
+	getLsofOutput: async () => "",
 	getPortsForTask: () => [],
 	getSessionPanePids: () => [],
+	parseLsofOutput: () => [],
 	scanTaskPorts: () => [],
+	waitForPortsFree: async () => [],
 }));
 
 mock.module("../resource-monitor", () => ({
@@ -74,6 +88,7 @@ mock.module("../resource-monitor", () => ({
 
 mock.module("../repo-config", () => ({
 	resolveProjectConfig: (_proj: any) => _proj,
+	resolveOperationalProjectConfig: (_proj: any) => _proj,
 	migrateProjectConfig: () => {},
 	loadRepoConfigRaw: () => ({}),
 }));

--- a/src/bun/__tests__/pane-exit-e2e.ts
+++ b/src/bun/__tests__/pane-exit-e2e.ts
@@ -70,9 +70,15 @@ function assert(condition: boolean, msg: string): void {
 	}
 }
 
+function tmuxSync(args: string[]): ReturnType<typeof nodeSpawnSync> {
+	// Bun's node:child_process compatibility layer snapshots the launch env;
+	// pass the test-specific TMUX_TMPDIR explicitly after preload isolation.
+	return nodeSpawnSync("tmux", args, { env: { ...process.env } });
+}
+
 function cleanup(): void {
 	try { pty.destroySession(TASK_ID, TEST_SOCKET); } catch { /* ignore */ }
-	try { nodeSpawnSync("tmux", ["-L", TEST_SOCKET, "kill-server"]); } catch { /* ignore */ }
+	try { tmuxSync(["-L", TEST_SOCKET, "kill-server"]); } catch { /* ignore */ }
 }
 
 async function waitFor(fn: () => boolean, timeoutMs = 10_000, intervalMs = 100): Promise<void> {
@@ -121,7 +127,7 @@ async function main() {
 
 		// Send a keystroke to trigger `read -n 1` in the setup pane (exits immediately)
 		for (const paneId of panesBefore) {
-			nodeSpawnSync("tmux", ["-L", TEST_SOCKET, "send-keys", "-t", paneId, "x"]);
+			tmuxSync(["-L", TEST_SOCKET, "send-keys", "-t", paneId, "x"]);
 		}
 
 		// Wait for reconciliation: panes[0].paneId should become non-null

--- a/src/bun/__tests__/port-pool.test.ts
+++ b/src/bun/__tests__/port-pool.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/port-pool`);
+
 // Mock DEV3_HOME to a temp directory
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-port-pool-test",
+	DEV3_HOME: TEST_HOME,
 }));
-
-const TEST_HOME = "/tmp/dev3-port-pool-test";
 
 // Mock net/dgram to control port availability
 let portsInUse = new Set<number>();

--- a/src/bun/__tests__/pty-server.test.ts
+++ b/src/bun/__tests__/pty-server.test.ts
@@ -1322,8 +1322,8 @@ describe("pty-server", () => {
 	// ------- TMUX_CONF_PATH -------
 
 	describe("TMUX_CONF_PATH", () => {
-		it("defaults to /tmp/dev3-tmux-dark.conf", () => {
-			expect(TMUX_CONF_PATH).toBe("/tmp/dev3-tmux-dark.conf");
+		it("uses the isolated test root for the default dark config", () => {
+			expect(TMUX_CONF_PATH).toBe(`${process.env.DEV3_TEST_ROOT}/dev3-tmux-dark.conf`);
 		});
 
 		/** Helper: reimport pty-server with mocked fs and find the dark config content. */

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1057,7 +1057,7 @@ describe("end-to-end: task description → shell command escaping", () => {
 
 	// tmux 3.x limits the shell-command passed to `new-session` to ~16 320 bytes.
 	// The fix writes the full command to a temp script file, so the tmux argument
-	// is just `bash "/tmp/dev3-{taskId}-run.sh"` regardless of description length.
+	// is just `bash "<test-root>/dev3-{taskId}-run.sh"` regardless of description length.
 	const TMUX_CMD_LIMIT = 16_320;
 
 	it("keeps tmux command under the tmux limit for long task descriptions", () => {
@@ -1082,9 +1082,9 @@ describe("end-to-end: task description → shell command escaping", () => {
 		const agentCmd = `claude --model claude-sonnet-4-6 --permission-mode unrestricted --append-system-prompt ${shellEscape(realSystemPrompt)} ${shellEscaped}`;
 
 		// The fix: write the full command to a temp script file.
-		// The tmux argument is just `bash "/tmp/dev3-{taskId}-run.sh"`.
+		// The tmux argument is just `bash "<test-root>/dev3-{taskId}-run.sh"`.
 		const taskId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-		const wrapperCmd = `bash "/tmp/dev3-${taskId}-run.sh"`;
+		const wrapperCmd = `bash "${process.env.DEV3_TEST_ROOT}/dev3-${taskId}-run.sh"`;
 
 		// Script file can be arbitrarily long — no tmux limit
 		const scriptContent = buildCmdScript(agentCmd);
@@ -1092,7 +1092,9 @@ describe("end-to-end: task description → shell command escaping", () => {
 		expect(scriptContent.length).toBeGreaterThan(TMUX_CMD_LIMIT);
 
 		// But the wrapper command passed to tmux stays tiny
-		expect(wrapperCmd.length).toBeLessThan(100);
+		// The per-worktree test sandbox has a deliberately long absolute path;
+		// the wrapper still remains tiny relative to tmux's command limit.
+		expect(wrapperCmd.length).toBeLessThan(512);
 		expect(wrapperCmd.length).toBeLessThan(TMUX_CMD_LIMIT);
 	});
 });
@@ -7490,8 +7492,8 @@ describe("launchTaskPty", () => {
 
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
-			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '/tmp/dev3-task-1-setup.sh'`);
-			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '/tmp/dev3-task-1-cmd.sh'"`);
+			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '${process.env.DEV3_TEST_ROOT}/dev3-task-1-setup.sh'`);
+			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
 
 			expect(setupIndex).toBeGreaterThanOrEqual(0);
 			expect(splitIndex).toBeGreaterThanOrEqual(0);
@@ -7515,8 +7517,8 @@ describe("launchTaskPty", () => {
 
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
-			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '/tmp/dev3-task-1-cmd.sh'"`);
-			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '/tmp/dev3-task-1-setup.sh'`);
+			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
+			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '${process.env.DEV3_TEST_ROOT}/dev3-task-1-setup.sh'`);
 
 			expect(splitIndex).toBeGreaterThanOrEqual(0);
 			expect(setupIndex).toBeGreaterThanOrEqual(0);

--- a/src/bun/__tests__/shared-artifacts.test.ts
+++ b/src/bun/__tests__/shared-artifacts.test.ts
@@ -4,12 +4,13 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import type { SharedArtifact } from "../../shared/types";
 
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/shared-artifacts`);
+
 vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-shared-artifacts-test",
-	OPS_DIR: "/tmp/dev3-shared-artifacts-test/ops",
+	DEV3_HOME: TEST_HOME,
+	OPS_DIR: `${TEST_HOME}/ops`,
 }));
 
-const TEST_HOME = "/tmp/dev3-shared-artifacts-test";
 const SRC_DIR = mkdtempSync(join(tmpdir(), "dev3-artifact-src-"));
 
 import {

--- a/src/bun/__tests__/shared-images.test.ts
+++ b/src/bun/__tests__/shared-images.test.ts
@@ -4,13 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SharedImage } from "../../shared/types";
 
-// vi.mock is hoisted above module init, so the factory must use a literal path.
-vi.mock("../paths", () => ({
-	DEV3_HOME: "/tmp/dev3-shared-images-test",
-	OPS_DIR: "/tmp/dev3-shared-images-test/ops",
-}));
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/shared-images`);
 
-const TEST_HOME = "/tmp/dev3-shared-images-test";
+vi.mock("../paths", () => ({
+	DEV3_HOME: TEST_HOME,
+	OPS_DIR: `${TEST_HOME}/ops`,
+}));
 
 import {
 	SharedImageError,

--- a/src/bun/__tests__/test-isolation-audit.test.ts
+++ b/src/bun/__tests__/test-isolation-audit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const REPO_ROOT = resolve(process.cwd());
+
+function filesUnder(root: string): string[] {
+	const files: string[] = [];
+	for (const name of readdirSync(root)) {
+		const path = join(root, name);
+		if (statSync(path).isDirectory()) files.push(...filesUnder(path));
+		else if (/\.(?:ts|tsx)$/.test(name)) files.push(path);
+	}
+	return files;
+}
+
+describe("test isolation audit", () => {
+	it("keeps destructive filesystem and real socket operations off fixed /tmp paths", () => {
+		const failures: string[] = [];
+		const roots = ["src/bun/__tests__", "src/cli/__tests__", "src/mainview/__tests__"];
+
+		for (const root of roots) {
+			for (const path of filesUnder(join(REPO_ROOT, root))) {
+				const source = readFileSync(path, "utf8");
+				const directLiteral = /(?:rmSync|mkdirSync|writeFileSync|unlinkSync|rmdirSync|\.listen)\(\s*["'`]\/tmp\//;
+				if (directLiteral.test(source)) {
+					failures.push(`${relative(REPO_ROOT, path)} uses a fixed /tmp path in a stateful operation`);
+				}
+
+				for (const match of source.matchAll(/^const\s+([A-Z][A-Z0-9_]*(?:HOME|DIR|ROOT|SOCKET|FILE|PATH))\s*=\s*["'`]\/tmp\//gm)) {
+					const name = match[1];
+					const statefulUse = new RegExp(`(?:rmSync|mkdirSync|writeFileSync|unlinkSync|rmdirSync|\\.listen)\\(\\s*${name}\\b`);
+					if (statefulUse.test(source)) {
+						failures.push(`${relative(REPO_ROOT, path)} reuses fixed /tmp constant ${name}`);
+					}
+				}
+
+				for (const match of source.matchAll(/^const\s+([A-Z][A-Z0-9_]*(?:HOME|DIR|ROOT|SOCKET|FILE|PATH))\s*=\s*`\/tmp\/[^`]*\$\{/gm)) {
+					const name = match[1];
+					const statefulUse = new RegExp(`(?:rmSync|mkdirSync|writeFileSync|unlinkSync|rmdirSync|\\.listen)\\(\\s*${name}\\b`);
+					if (statefulUse.test(source)) {
+						failures.push(`${relative(REPO_ROOT, path)} reuses dynamic /tmp constant ${name}`);
+					}
+				}
+			}
+		}
+
+		expect(failures).toEqual([]);
+	});
+
+	it("routes production scratch files through the test-aware temp helper", () => {
+		const failures = filesUnder(join(REPO_ROOT, "src/bun"))
+			.filter((path) => !path.includes("/__tests__/"))
+			.filter((path) => /\/tmp\/dev3-/.test(readFileSync(path, "utf8")))
+			.map((path) => relative(REPO_ROOT, path));
+
+		expect(failures).toEqual([]);
+	});
+});

--- a/src/bun/__tests__/test-isolation.test.ts
+++ b/src/bun/__tests__/test-isolation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { tmpdir } from "node:os";
+import { deriveTestRunRoot, testWorktreeId } from "../../../test-isolation";
+
+describe("test process isolation", () => {
+	it("derives different roots for different worktrees", () => {
+		const first = deriveTestRunRoot("/repo/worktrees/alpha", "bun", 42, "/tmp");
+		const second = deriveTestRunRoot("/repo/worktrees/bravo", "bun", 42, "/tmp");
+
+		expect(first).not.toBe(second);
+		expect(first).toContain(testWorktreeId("/repo/worktrees/alpha"));
+		expect(second).toContain(testWorktreeId("/repo/worktrees/bravo"));
+	});
+
+	it("also separates suites and repeated processes in one worktree", () => {
+		const root = "/repo/worktrees/alpha";
+		expect(deriveTestRunRoot(root, "bun", 42, "/tmp"))
+			.not.toBe(deriveTestRunRoot(root, "cli", 42, "/tmp"));
+		expect(deriveTestRunRoot(root, "bun", 42, "/tmp"))
+			.not.toBe(deriveTestRunRoot(root, "bun", 43, "/tmp"));
+	});
+
+	it("sandboxes every implicit filesystem namespace in the active worker", () => {
+		const root = process.env.DEV3_TEST_ROOT;
+		expect(root).toBeTruthy();
+		expect(process.env.HOME).toContain(root);
+		expect(tmpdir()).toContain(root);
+		expect(process.env.DEV3_HOME).toContain(root);
+		expect(process.env.DEV3_LOG_DIR).toContain(root);
+		expect(process.env.XDG_CONFIG_HOME).toContain(root);
+		expect(process.env.XDG_RUNTIME_DIR).toContain(root);
+	});
+});

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -7,8 +7,9 @@ import { DEV3_HOME } from "./paths";
 import { spawn } from "./spawn";
 import { getUserShell } from "./shell-env";
 import { CATPPUCCIN_PLUGIN_DIR, writeCatppuccinPlugin } from "./tmux-themes";
-import { writeShellInit } from "./shell-init";
+import { SHELL_INIT_DIR, writeShellInit } from "./shell-init";
 import { isExecutableFile } from "./executable";
+import { dev3TempPath } from "./temp-paths";
 
 // Must be initialized before any module-load code below — sanitizeTmuxShim()
 // runs at module evaluation and logs when it finds a broken shim. Declaring
@@ -48,8 +49,8 @@ export function tmuxClientCwd(): string {
  */
 export const PANE_CWD_FORMAT = "#{?pane_current_path,#{pane_current_path},#{session_path}}";
 
-export const TMUX_CONF_DARK_PATH = "/tmp/dev3-tmux-dark.conf";
-export const TMUX_CONF_LIGHT_PATH = "/tmp/dev3-tmux-light.conf";
+export const TMUX_CONF_DARK_PATH = dev3TempPath("dev3-tmux-dark.conf");
+export const TMUX_CONF_LIGHT_PATH = dev3TempPath("dev3-tmux-light.conf");
 /** Path currently loaded — kept for configureTmux() re-source. */
 export let TMUX_CONF_PATH = TMUX_CONF_DARK_PATH;
 
@@ -128,7 +129,7 @@ set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
 
 # Shell prompt — redirect zsh to dev3 ZDOTDIR for short worktree paths
-set-environment -g ZDOTDIR /tmp/dev3-shell
+set-environment -g ZDOTDIR ${SHELL_INIT_DIR}
 `;
 
 // Status bar setup — references Catppuccin status modules built by the plugin

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -16,6 +16,7 @@ import * as git from "../git";
 import * as github from "../github";
 import * as pty from "../pty-server";
 import { spawn } from "../spawn";
+import { dev3TaskTempPath } from "../temp-paths";
 import { sendPromptToAgentPane } from "../agent-prompt";
 import {
 	scheduleMessage as scheduleMessageCore,
@@ -236,7 +237,7 @@ async function openGitOpPane(tmuxSession: string, cwd: string, scriptPath: strin
 function monitorGitPane(paneId: string | null, taskId: string, projectId: string, operation: string, socket: string): void {
 	if (!paneId) return;
 	const tmuxSession = `dev3-${taskId.slice(0, 8)}`;
-	const exitFilePath = `/tmp/dev3-${taskId}-git-${operation}.sh.exit`;
+	const exitFilePath = dev3TaskTempPath(taskId, `git-${operation}.sh.exit`);
 
 	let interval: ReturnType<typeof setInterval> | undefined;
 	let safetyTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -1073,7 +1074,7 @@ async function rebaseTask(params: { taskId: string; projectId: string; compareRe
 	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
 	const rebaseTarget = params.compareRef || `origin/${baseBranch}`;
 	const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
-	const scriptPath = `/tmp/dev3-${task.id}-git-rebase.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "git-rebase.sh");
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 	await killExistingGitPane(task.id, tmuxSession, socket);
 
@@ -1136,7 +1137,7 @@ async function mergeTask(params: { taskId: string; projectId: string }): Promise
 	if (status.behind > 0) throw new Error("Branch is not rebased — rebase first");
 
 	const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
-	const scriptPath = `/tmp/dev3-${task.id}-git-merge.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "git-merge.sh");
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 	await killExistingGitPane(task.id, tmuxSession, socket);
 
@@ -1221,7 +1222,7 @@ async function pushTask(params: { taskId: string; projectId: string }): Promise<
 	assertGitTask(project, task);
 
 	const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
-	const scriptPath = `/tmp/dev3-${task.id}-git-push.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "git-push.sh");
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 	await killExistingGitPane(task.id, tmuxSession, socket);
 
@@ -1313,7 +1314,7 @@ async function openPullRequest(params: { taskId: string; projectId: string }): P
 	assertGitTask(project, task);
 
 	const tmuxSession = `dev3-${task.id.slice(0, 8)}`;
-	const scriptPath = `/tmp/dev3-${task.id}-git-openPR.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "git-openPR.sh");
 	const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 	await killExistingGitPane(task.id, tmuxSession, socket);
 	const githubEnvExports = await github.getGitHubShellExports(project);

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -27,6 +27,7 @@ import { buildScriptRunnerCommand, buildTaskLifecycleEnv, getPushMessage, isActi
 import { clearMergeNotification, cleanupTaskGitState } from "./git-operations";
 import { resolveOperationalProjectConfig } from "./settings-config";
 import { cleanupTaskTmuxState, killDevServerSession, launchColumnAgent, launchTaskPty } from "./tmux-pty";
+import { dev3TaskTempPath } from "../temp-paths";
 
 function cleanupTaskState(taskId: string): void {
 	cleanupTaskTmuxState(taskId);
@@ -589,7 +590,7 @@ export async function runCleanupScript(
 
 	const resolved = await resolveOperationalProjectConfig(project, task.worktreePath);
 	const script = resolved.cleanupScript?.trim() || DEFAULT_CLEANUP_SCRIPT;
-	const scriptPath = `/tmp/dev3-${task.id}-cleanup.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "cleanup.sh");
 	const sessionName = `dev3-cl-${task.id.slice(0, 8)}`;
 	const userShell = getUserShell();
 

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -16,6 +16,7 @@ import { spawn } from "../spawn";
 import { setupAgentHooks } from "../agent-hooks";
 import { ensureArtifactTemplateEnv } from "../artifact-template";
 import { ALT_CLICK_PANE_FORMAT, altClickIneligibleReason, computeAltClickKeys, findAltClickPane, parseAltClickPanes } from "../tmux-alt-click";
+import { dev3TaskTempPath } from "../temp-paths";
 import { getPushMessage, isActive, buildAgentEnv, buildCmdScript, buildEnvExports, buildScriptRunnerCommand, buildTaskLifecycleEnv, escapeForDoubleQuotes, log, portableReadKey, resolveBinaryPath, shellQuote } from "./shared-pure";
 import { resolveOperationalProjectConfig } from "./settings-config";
 
@@ -594,7 +595,7 @@ export async function launchTaskPty(
 
 			log.warn("Agent binary not found, creating retry wrapper", { binaryName, installCmd });
 
-			const originalCmdPath = `/tmp/dev3-${task.id}-original-cmd.sh`;
+			const originalCmdPath = dev3TaskTempPath(task.id, "original-cmd.sh");
 			await Bun.write(originalCmdPath, buildCmdScript(tmuxCmd, env, { keepShell: true, shellPath: userShell }));
 
 			const retryScript = [
@@ -619,7 +620,7 @@ export async function launchTaskPty(
 				"",
 			].join("\n");
 
-			const retryScriptPath = `/tmp/dev3-${task.id}-agent-check.sh`;
+			const retryScriptPath = dev3TaskTempPath(task.id, "agent-check.sh");
 			await Bun.write(retryScriptPath, retryScript);
 			tmuxCmd = buildScriptRunnerCommand(retryScriptPath, { shellPath: userShell });
 			log.info("Replaced tmuxCmd with agent-check retry wrapper");
@@ -637,7 +638,7 @@ export async function launchTaskPty(
 	let isSetupWrapper = false;
 	if (runSetup && project.setupScript.trim()) {
 		const setupScriptLaunchMode = project.setupScriptLaunchMode ?? "parallel";
-		const prefix = `/tmp/dev3-${task.id}`;
+		const prefix = dev3TaskTempPath(task.id);
 		const setupPath = `${prefix}-setup.sh`;
 		const cmdPath = `${prefix}-cmd.sh`;
 		const startupPath = `${prefix}-startup.sh`;
@@ -675,7 +676,7 @@ export async function launchTaskPty(
 		isSetupWrapper = true;
 	}
 
-	const runScriptPath = `/tmp/dev3-${task.id}-run.sh`;
+	const runScriptPath = dev3TaskTempPath(task.id, "run.sh");
 	await Bun.write(runScriptPath, buildCmdScript(tmuxCmd, env, { keepShell: !isSetupWrapper, shellPath: userShell }));
 	const wrapperCmd = buildScriptRunnerCommand(runScriptPath, { shellPath: userShell });
 
@@ -826,13 +827,13 @@ export async function launchColumnAgent(
 		...buildAgentEnv(extraEnv, task.id),
 		...ensureArtifactTemplateEnv(project, task, worktreePath),
 	};
-	const scriptPath = `/tmp/dev3-${task.id}-col-agent.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, "col-agent.sh");
 	await Bun.write(scriptPath, buildCmdScript(tmuxCmd, env, {
 		paneTitle: options.paneTitle,
 		onExitCommand: options.onExitCommand,
 	}));
 
-	const paneFile = `/tmp/dev3-${task.id}-col-agent-pane`;
+	const paneFile = dev3TaskTempPath(task.id, "col-agent-pane");
 	try {
 		const oldPaneId = (await Bun.file(paneFile).text()).trim();
 		if (oldPaneId) {
@@ -894,7 +895,7 @@ export async function runDevServer(params: { taskId: string; projectId: string }
 		if (!task.worktreePath) throw new Error("Task has no worktree");
 
 		const devSession = devServerSessionName(task.id);
-		const devScriptPath = `/tmp/dev3-${task.id}-dev.sh`;
+		const devScriptPath = dev3TaskTempPath(task.id, "dev.sh");
 		const socket = task.tmuxSocket ?? pty.DEFAULT_TMUX_SOCKET;
 
 		if (await isDevServerRunning(task.id, socket)) {
@@ -1399,7 +1400,7 @@ async function resumeTask(params: { taskId: string }): Promise<string> {
 					resumeCmd = await applyAgentHooksToCommand(task.worktreePath, resumeBaseCmd, resumeCmd, {
 						stopTarget: project.autoReviewEnabled ? "review-by-ai" : "review-by-user",
 					});
-					const scriptPath = `/tmp/dev3-${params.taskId}-resume-pane-${i}.sh`;
+					const scriptPath = dev3TaskTempPath(params.taskId, `resume-pane-${i}.sh`);
 					await Bun.write(scriptPath, buildCmdScript(resumeCmd, extraEnv, { keepShell: true }));
 					const wrappedCmd = `bash "${scriptPath}"`;
 					const newPaneId = await pty.splitAndRunCommand(params.taskId, socket, wrappedCmd, task.worktreePath);
@@ -2296,7 +2297,7 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 		Object.assign(env, portPool.buildPortEnv(existingPorts));
 	}
 
-	const scriptPath = `/tmp/dev3-${task.id}-spawn-${Date.now()}.sh`;
+	const scriptPath = dev3TaskTempPath(task.id, `spawn-${Date.now()}.sh`);
 	await Bun.write(scriptPath, buildCmdScript(tmuxCmd, env));
 
 	const socket = pty.getSessionSocket(params.taskId);
@@ -2452,7 +2453,7 @@ async function spawnSingleBugHunterPane(opts: {
 		Object.assign(env, portPool.buildPortEnv(existingPorts));
 	}
 
-	const scriptPath = `/tmp/dev3-${opts.task.id}-bughunt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.sh`;
+	const scriptPath = dev3TaskTempPath(opts.task.id, `bughunt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.sh`);
 	await Bun.write(scriptPath, buildCmdScript(tmuxCmd, env));
 
 	const proc = spawn(

--- a/src/bun/shell-init.ts
+++ b/src/bun/shell-init.ts
@@ -3,8 +3,9 @@
 // paths in the prompt while still sourcing the user's own config.
 
 import { mkdirSync, writeFileSync } from "node:fs";
+import { dev3TempPath } from "./temp-paths";
 
-export const SHELL_INIT_DIR = "/tmp/dev3-shell";
+export const SHELL_INIT_DIR = dev3TempPath("dev3-shell");
 
 // ── zsh init files ──────────────────────────────────────────────────
 

--- a/src/bun/temp-paths.ts
+++ b/src/bun/temp-paths.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime scratch files stay at their historical /tmp paths in the app.
+ * Test runners redirect them so parallel worktrees cannot share scripts,
+ * tmux configuration, shell init files, or plugin state.
+ */
+export const DEV3_TEMP_ROOT = process.env.DEV3_TEST_ROOT?.trim() || "/tmp";
+
+export function dev3TempPath(name: string): string {
+	return `${DEV3_TEMP_ROOT}/${name}`;
+}
+
+export function dev3TaskTempPath(taskId: string, suffix?: string): string {
+	return dev3TempPath(`dev3-${taskId}${suffix ? `-${suffix}` : ""}`);
+}

--- a/src/bun/tmux-themes.ts
+++ b/src/bun/tmux-themes.ts
@@ -3,6 +3,7 @@
 // Source .conf files kept in src/bun/tmux-themes/ for reference.
 
 import { mkdirSync, writeFileSync } from "node:fs";
+import { dev3TempPath } from "./temp-paths";
 
 // ── Color palettes ──────────────────────────────────────────────────
 
@@ -205,7 +206,7 @@ source -F "#{d:current_file}/../utils/status_module.conf"
 
 // ── Write plugin to /tmp ────────────────────────────────────────────
 
-export const CATPPUCCIN_PLUGIN_DIR = "/tmp/dev3-catppuccin";
+export const CATPPUCCIN_PLUGIN_DIR = dev3TempPath("dev3-catppuccin");
 
 export function writeCatppuccinPlugin(): void {
 	const dir = CATPPUCCIN_PLUGIN_DIR;

--- a/src/cli/__tests__/socket-client.test.ts
+++ b/src/cli/__tests__/socket-client.test.ts
@@ -3,7 +3,8 @@ import { createServer, type Server } from "node:net";
 import { unlinkSync, existsSync } from "node:fs";
 import { sendRequest } from "../socket-client";
 
-const TEST_SOCKET = "/tmp/dev3-cli-test-socket.sock";
+const TEST_SOCKET = `${process.env.DEV3_TEST_ROOT}/socket-client.sock`;
+const NONEXISTENT_SOCKET = `${process.env.DEV3_TEST_ROOT}/nonexistent.sock`;
 
 function cleanSocket() {
 	try {
@@ -92,7 +93,7 @@ describe("sendRequest", () => {
 
 	it("throws APP_NOT_RUNNING when socket does not exist", async () => {
 		await expect(
-			sendRequest("/tmp/dev3-nonexistent-socket.sock", "test"),
+			sendRequest(NONEXISTENT_SOCKET, "test"),
 		).rejects.toThrow("APP_NOT_RUNNING");
 	});
 
@@ -101,7 +102,7 @@ describe("sendRequest", () => {
 		// the socket immediately rather than waiting for the 30s timeout.
 		const start = Date.now();
 		try {
-			await sendRequest("/tmp/dev3-nonexistent-socket.sock", "test");
+			await sendRequest(NONEXISTENT_SOCKET, "test");
 		} catch (err) {
 			// Expected to throw APP_NOT_RUNNING
 			expect((err as Error).message).toBe("APP_NOT_RUNNING");
@@ -157,7 +158,7 @@ describe("sendRequest", () => {
 	it("gives up with APP_NOT_RUNNING after exhausting connect retries", async () => {
 		const start = Date.now();
 		await expect(
-			sendRequest("/tmp/dev3-nonexistent-socket.sock", "test", {}, { connectAttempts: 3, retryDelayMs: 20 }),
+			sendRequest(NONEXISTENT_SOCKET, "test", {}, { connectAttempts: 3, retryDelayMs: 20 }),
 		).rejects.toThrow("APP_NOT_RUNNING");
 		expect(Date.now() - start).toBeLessThan(5000);
 	});

--- a/src/mainview/__tests__/shift-keys-e2e.test.ts
+++ b/src/mainview/__tests__/shift-keys-e2e.test.ts
@@ -142,10 +142,26 @@ function makeCustomHandler(sent: string[]) {
 	};
 }
 
-/** Wrap child_process.spawn exit in a Promise. */
-function waitForExit(proc: ChildProcess): Promise<void> {
-	return new Promise<void>((resolve) => {
-		proc.on("exit", () => resolve());
+function isolatedTmuxEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const env = { ...process.env, ...extra };
+	// Agents run the suite from inside dev3's own tmux session. A nested tmux
+	// client refuses to attach to the test server while the parent TMUX marker
+	// is present, even when -L selects a different socket.
+	delete env.TMUX;
+	return env;
+}
+
+/** Wrap child_process.spawn exit in a bounded Promise and reap stuck readers. */
+function waitForExit(proc: ChildProcess, label: string): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			proc.kill();
+			reject(new Error(`${label} timed out`));
+		}, 3_000);
+		proc.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
 	});
 }
 
@@ -161,6 +177,8 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 		let tmuxSocket: string;
 		let tmuxSession: string;
 		let pythonProc: ChildProcess | undefined;
+		let bridgeStderr = "";
+		let bridgeExitCode: number | null = null;
 
 		// import.meta.url is http://localhost/... in happy-dom (browser simulation),
 		// so new URL(..., import.meta.url) gives the wrong path.
@@ -195,7 +213,7 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 			const startResult = cpSpawnSync(
 				"tmux",
 				["-L", tmuxSocket, "-f", tmuxConfigPath, "new-session", "-s", tmuxSession, "-d"],
-				{ stdio: "pipe" },
+				{ stdio: "pipe", env: isolatedTmuxEnv() },
 			);
 			if (startResult.status !== 0) {
 				const stderr = startResult.stderr?.toString() ?? "";
@@ -212,23 +230,33 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 					"tmux", "-L", tmuxSocket, "attach-session", "-t", tmuxSession,
 				],
 				{
-					stdio: ["pipe", "ignore", "ignore"],
+					stdio: ["pipe", "ignore", "pipe"],
 					// Ensure TERM is set: tmux attach-session exits immediately if
 					// it cannot determine the terminal type (e.g. in CI environments).
-					env: { ...process.env, TERM: process.env.TERM || "xterm-256color" },
+					env: isolatedTmuxEnv({
+						TERM: !process.env.TERM || process.env.TERM === "dumb"
+							? "xterm-256color"
+							: process.env.TERM,
+					}),
 				},
 			);
+			pythonProc.stderr?.on("data", (chunk) => { bridgeStderr += chunk.toString(); });
+			pythonProc.once("exit", (code) => { bridgeExitCode = code; });
 
 			// Give the attach-session client time to complete its handshake with
 			// tmux and set up the PTY in raw mode before tests start sending bytes.
 			// 1000ms is conservative but necessary on loaded CI machines where
 			// the default 500ms can leave the bridge not yet connected.
 			await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+			if (pythonProc.exitCode !== null) {
+				throw new Error(`PTY bridge exited during startup: ${bridgeStderr.trim()}`);
+			}
 		}, 20_000);
 
 		afterAll(() => {
 			cpSpawnSync("tmux", ["-L", tmuxSocket, "kill-server"], {
 				stdio: "ignore",
+				env: isolatedTmuxEnv(),
 			});
 			pythonProc?.kill();
 			if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
@@ -275,6 +303,9 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 		 * drains tmux initialization bytes sent to new panes before capture starts.
 		 */
 		async function runPipelineTest(bytes: string): Promise<string> {
+			if (bridgeExitCode !== null) {
+				throw new Error(`PTY bridge exited with code ${bridgeExitCode}: ${bridgeStderr.trim()}`);
+			}
 			const N = Buffer.byteLength(bytes, "utf8");
 			const innerCmd =
 				`stty -icanon -icrnl -echo && sleep 0.2 && printf R > ${readyFifo} && ` +
@@ -284,13 +315,13 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 			// POSIX: opening a FIFO in O_RDONLY blocks until a writer arrives, so
 			// `cat` will block here until the inner process writes its ready signal.
 			const readyProc = cpSpawn("cat", [readyFifo], { stdio: "ignore" });
-			const readyDone = waitForExit(readyProc);
+			const readyDone = waitForExit(readyProc, "ready FIFO");
 
 			// Kill the current pane and start the inner command fresh.
 			const r = cpSpawnSync(
 				"tmux",
 				["-L", tmuxSocket, "respawn-pane", "-t", `${tmuxSession}:1.1`, "-k", innerCmd],
-				{ stdio: "ignore" },
+				{ stdio: "ignore", env: isolatedTmuxEnv() },
 			);
 			expect(r.status, "tmux respawn-pane failed").toBe(0);
 
@@ -300,13 +331,17 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 			// Start the done-FIFO reader BEFORE sending bytes.
 			// printf D > doneFifo blocks until this reader opens the FIFO for reading.
 			const doneProc = cpSpawn("cat", [doneFifo], { stdio: "ignore" });
-			const doneDone = waitForExit(doneProc);
+			const doneDone = waitForExit(doneProc, "done FIFO");
 
 			// Write bytes to the Python helper's stdin → PTY master → tmux → pane.
 			pythonProc!.stdin!.write(bytes, "utf8");
 
 			// Wait until head -c N captured all bytes and wrote the done signal.
-			await doneDone;
+			try {
+				await doneDone;
+			} catch (error) {
+				throw new Error(`${String(error)}; bridgeExit=${bridgeExitCode}; bridge=${bridgeStderr.trim()}`);
+			}
 
 			return readFileSync(captureFile, "utf8");
 		}

--- a/test-global-setup.ts
+++ b/test-global-setup.ts
@@ -1,0 +1,7 @@
+import { cleanupTestIsolation } from "./test-isolation";
+
+export default function setupTestSandbox(): () => void {
+	const root = process.env.DEV3_TEST_ROOT;
+	if (!root) throw new Error("DEV3_TEST_ROOT was not configured by the Vitest config");
+	return () => cleanupTestIsolation(root);
+}

--- a/test-isolation.ts
+++ b/test-isolation.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+function safeRealpath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
+
+export function testWorktreeId(worktreeRoot: string): string {
+	return createHash("sha256").update(safeRealpath(worktreeRoot)).digest("hex").slice(0, 12);
+}
+
+export function deriveTestRunRoot(
+	worktreeRoot: string,
+	suite: string,
+	pid: number,
+	tempRoot = tmpdir(),
+): string {
+	const safeSuite = suite.replace(/[^a-zA-Z0-9_-]/g, "-");
+	return join(tempRoot, "dev3-tests", testWorktreeId(worktreeRoot), `${safeSuite}-${pid}`);
+}
+
+/**
+ * Move every implicit user/global path used by a test process into a sandbox.
+ * The worktree hash prevents parallel worktrees from sharing resources; the
+ * suite and PID also isolate concurrently repeated runs in one worktree.
+ */
+export function configureTestIsolation(suite: string, worktreeRoot = process.cwd()): string {
+	const originalTempRoot = tmpdir();
+	const root = deriveTestRunRoot(worktreeRoot, suite, process.pid, originalTempRoot);
+	const home = join(root, "home");
+	const dev3Home = join(home, ".dev3.0");
+	const temp = join(root, "tmp");
+	const runtime = join(root, "runtime");
+	const xdgConfig = join(root, "xdg-config");
+	const xdgCache = join(root, "xdg-cache");
+	const xdgData = join(root, "xdg-data");
+	const xdgState = join(root, "xdg-state");
+
+	for (const dir of [home, dev3Home, temp, runtime, xdgConfig, xdgCache, xdgData, xdgState]) {
+		mkdirSync(dir, { recursive: true });
+	}
+
+	Object.assign(process.env, {
+		DEV3_TEST_ROOT: root,
+		DEV3_TEST_WORKTREE_ID: testWorktreeId(worktreeRoot),
+		DEV3_HOME: dev3Home,
+		DEV3_LOG_DIR: join(root, "logs"),
+		HOME: home,
+		TMPDIR: temp,
+		TMP: temp,
+		TEMP: temp,
+		XDG_CONFIG_HOME: xdgConfig,
+		XDG_CACHE_HOME: xdgCache,
+		XDG_DATA_HOME: xdgData,
+		XDG_STATE_HOME: xdgState,
+		XDG_RUNTIME_DIR: runtime,
+	});
+
+	return root;
+}
+
+export function cleanupTestIsolation(root: string): void {
+	if (!root.includes(`${join("dev3-tests", "")}`)) {
+		throw new Error(`Refusing to clean a non-test path: ${root}`);
+	}
+	rmSync(root, { recursive: true, force: true });
+}

--- a/vitest.config.bun.ts
+++ b/vitest.config.bun.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { configureTestIsolation } from "./test-isolation";
+
+const repoRoot = fileURLToPath(new URL(".", import.meta.url));
+configureTestIsolation("bun", repoRoot);
 
 export default defineConfig({
 	test: {
 		root: "src/bun",
 		globals: true,
 		setupFiles: ["./test-setup.ts"],
+		globalSetup: [fileURLToPath(new URL("./test-global-setup.ts", import.meta.url))],
 	},
 });

--- a/vitest.config.cli.ts
+++ b/vitest.config.cli.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { configureTestIsolation } from "./test-isolation";
+
+const repoRoot = fileURLToPath(new URL(".", import.meta.url));
+configureTestIsolation("cli", repoRoot);
 
 export default defineConfig({
 	test: {
 		root: "src/cli",
 		globals: true,
+		globalSetup: [fileURLToPath(new URL("./test-global-setup.ts", import.meta.url))],
 	},
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { configureTestIsolation } from "./test-isolation";
+
+const repoRoot = fileURLToPath(new URL(".", import.meta.url));
+configureTestIsolation("mainview", repoRoot);
 
 export default defineConfig({
 	plugins: [react()],
@@ -8,5 +13,6 @@ export default defineConfig({
 		environment: "happy-dom",
 		globals: true,
 		setupFiles: ["./test-setup.ts"],
+		globalSetup: [fileURLToPath(new URL("./test-global-setup.ts", import.meta.url))],
 	},
 });


### PR DESCRIPTION
## Summary

- Reproduce and fix collisions caused by fixed `/tmp` fixtures, shared CLI sockets, and inherited global HOME/XDG state.
- Add per-worktree, per-suite, per-process test sandboxes for HOME, TMP, XDG, logs, DEV3 data, and runtime scratch files.
- Add isolation regression/audit tests and harden the real tmux E2E helpers for nested agent sessions and FIFO cleanup.

## Validation

- `bun run lint`
- `bun run test` — 5741 passed, 1 skipped
- `bun run test:pane-e2e`
- Shift-key tmux E2E — 23/23
- Concurrent CLI socket regression — 14/14 in both parallel runs

The tmux socket names remain short and PID-specific because macOS imposes a Unix socket path-length limit.