### PR TITLE
Show live git clone progress in the Add Project modal

### DIFF
--- a/change-logs/2026/07/19/feature-clone-progress-output.md
+++ b/change-logs/2026/07/19/feature-clone-progress-output.md
@@ -1,0 +1,1 @@
+The Add Project → Clone from URL modal now shows live `git clone` output while cloning: a terminal-style box displays the last four progress lines (remote counting, receiving objects, resolving deltas), so large repository clones are no longer a silent "Cloning…" button. Clone failures also report a clean terminal-style error tail instead of raw progress spam.

--- a/src/bun/__tests__/clone-progress.test.ts
+++ b/src/bun/__tests__/clone-progress.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { CloneProgressParser } from "../clone-progress";
+
+describe("CloneProgressParser", () => {
+	it("commits lines on \\n", () => {
+		const p = new CloneProgressParser();
+		p.feed("Cloning into 'repo'...\nremote: Enumerating objects: 10, done.\n");
+		expect(p.lines(4)).toEqual([
+			"Cloning into 'repo'...",
+			"remote: Enumerating objects: 10, done.",
+		]);
+	});
+
+	it("includes the in-progress line before any terminator arrives", () => {
+		const p = new CloneProgressParser();
+		p.feed("Cloning into 'repo'...\nReceiving objects:  10%");
+		expect(p.lines(4)).toEqual([
+			"Cloning into 'repo'...",
+			"Receiving objects:  10%",
+		]);
+	});
+
+	it("\\r rewrites the live line like a terminal", () => {
+		const p = new CloneProgressParser();
+		p.feed("Receiving objects:  10% (1/10)\rReceiving objects:  50% (5/10)\rReceiving objects: 100% (10/10), done.\n");
+		expect(p.lines(4)).toEqual(["Receiving objects: 100% (10/10), done."]);
+	});
+
+	it("handles a \\r rewrite split across chunks", () => {
+		const p = new CloneProgressParser();
+		p.feed("Receiving objects:  10%\r");
+		p.feed("Receiving objects:  9");
+		p.feed("0%");
+		expect(p.lines(4)).toEqual(["Receiving objects:  90%"]);
+	});
+
+	it("returns only the last N non-empty lines", () => {
+		const p = new CloneProgressParser();
+		p.feed("one\ntwo\n\nthree\nfour\nfive\n");
+		expect(p.lines(4)).toEqual(["two", "three", "four", "five"]);
+	});
+
+	it("caps committed lines to bound memory", () => {
+		const p = new CloneProgressParser();
+		for (let i = 0; i < 200; i++) p.feed(`line ${i}\n`);
+		expect(p.lines(2)).toEqual(["line 198", "line 199"]);
+	});
+});

--- a/src/bun/__tests__/git-clone-progress.test.ts
+++ b/src/bun/__tests__/git-clone-progress.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { join } from "path";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test",
+}));
+
+vi.mock("../spawn", async () => {
+	const { createSpawnMock } = await import("./git-test-helpers");
+	return createSpawnMock();
+});
+
+import { cloneRepo } from "../git";
+import { createTestRepo, cleanup, type TestRepo } from "./git-test-helpers";
+
+describe("cloneRepo", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("clones a repo and streams progress lines to onProgress", async () => {
+		const target = join(repo.dir, "cloned");
+		const updates: string[][] = [];
+
+		const result = await cloneRepo(join(repo.dir, "origin.git"), target, (lines) => updates.push(lines));
+
+		expect(result).toEqual({ ok: true, path: target });
+		expect(existsSync(join(target, ".git"))).toBe(true);
+		expect(updates.length).toBeGreaterThan(0);
+		expect(updates.flat().join("\n")).toContain("Cloning into");
+	});
+
+	it("returns a terminal-style error tail when the clone fails", async () => {
+		const target = join(repo.dir, "cloned-fail");
+
+		const result = await cloneRepo(join(repo.dir, "no-such-repo"), target);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toBeTruthy();
+		expect(result.error).not.toContain("\r");
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1317,8 +1317,51 @@ describe("handlers.cloneAndAddProject", () => {
 		expect(git.cloneRepo).toHaveBeenCalledWith(
 			"https://github.com/user/my-repo.git",
 			"/base/my-repo",
+			undefined,
 		);
 		expect(data.addProject).toHaveBeenCalledWith("/base/my-repo", "my-repo");
+	});
+
+	it("pushes sampled cloneProgress messages when progressId is provided", async () => {
+		vi.useFakeTimers();
+		try {
+			const project = makeProject({ path: "/base/my-repo", name: "my-repo" });
+			vi.mocked(existsSync).mockReturnValue(false);
+			let resolveClone!: (v: { ok: boolean; path: string }) => void;
+			vi.mocked(git.cloneRepo).mockImplementation((_url, _dir, onProgress) => {
+				onProgress?.(["Cloning into 'my-repo'...", "Receiving objects: 50% (5/10)"]);
+				return new Promise((resolve) => { resolveClone = resolve; });
+			});
+			vi.mocked(git.isGitRepo).mockResolvedValue(true);
+			vi.mocked(data.addProject).mockResolvedValue(project);
+			vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
+			vi.mocked(data.updateProject).mockResolvedValue(project);
+
+			const push = vi.fn();
+			setPushMessage(push);
+
+			const promise = handlers.cloneAndAddProject({
+				url: "https://github.com/user/my-repo.git",
+				baseDir: "/base",
+				repoName: "my-repo",
+				progressId: "pid-1",
+			});
+
+			await vi.advanceTimersByTimeAsync(200);
+			expect(push).toHaveBeenCalledWith("cloneProgress", {
+				progressId: "pid-1",
+				lines: ["Cloning into 'my-repo'...", "Receiving objects: 50% (5/10)"],
+			});
+
+			// Unchanged output is not re-pushed on the next tick.
+			await vi.advanceTimersByTimeAsync(200);
+			expect(push).toHaveBeenCalledTimes(1);
+
+			resolveClone({ ok: true, path: "/base/my-repo" });
+			await expect(promise).resolves.toEqual({ ok: true, project });
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("returns error when clone fails", async () => {

--- a/src/bun/clone-progress.ts
+++ b/src/bun/clone-progress.ts
@@ -1,0 +1,49 @@
+/**
+ * Incremental parser for `git clone --progress` stderr output.
+ *
+ * Git renders progress by rewriting the current line in place with `\r`
+ * ("Receiving objects:  42% ...") and committing finished phases with `\n`.
+ * The parser mirrors what a terminal would display: `\n` commits the live
+ * line, `\r` marks it so the next character starts overwriting it.
+ */
+
+/** Committed lines kept in memory — enough for any error tail we report. */
+const MAX_COMMITTED_LINES = 50;
+
+export class CloneProgressParser {
+	private committed: string[] = [];
+	private live = "";
+	private overwritePending = false;
+
+	feed(chunk: string): void {
+		for (const ch of chunk) {
+			if (ch === "\n") {
+				this.commitLive();
+			} else if (ch === "\r") {
+				this.overwritePending = true;
+			} else {
+				if (this.overwritePending) {
+					this.live = "";
+					this.overwritePending = false;
+				}
+				this.live += ch;
+			}
+		}
+	}
+
+	private commitLive(): void {
+		this.committed.push(this.live);
+		if (this.committed.length > MAX_COMMITTED_LINES) this.committed.shift();
+		this.live = "";
+		this.overwritePending = false;
+	}
+
+	/**
+	 * Last `max` non-empty lines as a terminal would currently show them,
+	 * including the in-progress (`\r`-rewritten) line.
+	 */
+	lines(max: number): string[] {
+		const all = this.live ? [...this.committed, this.live] : [...this.committed];
+		return all.map((l) => l.trimEnd()).filter(Boolean).slice(-max);
+	}
+}

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -2,6 +2,7 @@ import type { Project, Task, TaskDiffFile, TaskDiffFileStatus, TaskDiffMode, Tas
 export { extractRepoName } from "../shared/types";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { createLogger } from "./logger";
+import { CloneProgressParser } from "./clone-progress";
 import { reportCurrentPreparationStage } from "./preparation-runtime";
 import { spawn } from "./spawn";
 import { DEV3_HOME } from "./paths";
@@ -1945,15 +1946,39 @@ export async function getTaskDiff(
 	};
 }
 
+/** How many output lines a clone progress update carries to the UI. */
+const CLONE_PROGRESS_LINES = 4;
+
 export async function cloneRepo(
 	url: string,
 	targetDir: string,
+	onProgress?: (lines: string[]) => void,
 ): Promise<{ ok: boolean; path: string; error?: string }> {
 	log.info("Cloning repository", { url, targetDir });
-	const result = await run(["git", "clone", url, targetDir], process.cwd());
-	if (!result.ok) {
-		log.error("Clone failed", { url, stderr: result.stderr });
-		return { ok: false, path: targetDir, error: result.stderr };
+	// `run()` buffers output until exit, so it can't surface live progress.
+	// `--progress` forces git to emit progress even though stderr is a pipe
+	// (it normally requires a TTY).
+	const proc = spawn(["git", "clone", "--progress", url, targetDir], {
+		cwd: process.cwd(),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const parser = new CloneProgressParser();
+	const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+	const stderrPromise = (async () => {
+		const decoder = new TextDecoder();
+		for await (const chunk of proc.stderr as unknown as AsyncIterable<Uint8Array>) {
+			parser.feed(decoder.decode(chunk, { stream: true }));
+			onProgress?.(parser.lines(CLONE_PROGRESS_LINES));
+		}
+		parser.feed(decoder.decode());
+	})().catch(() => {});
+	const [code] = await Promise.all([proc.exited, stderrPromise, stdoutPromise]);
+	if (code !== 0) {
+		// The raw stderr is `\r`-rewrite spam; report the terminal-style tail.
+		const error = parser.lines(8).join("\n") || `git clone exited with code ${code}`;
+		log.error("Clone failed", { url, stderr: error });
+		return { ok: false, path: targetDir, error };
 	}
 	log.info("Repository cloned successfully", { url, targetDir });
 	return { ok: true, path: targetDir };

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -17,7 +17,7 @@ import { DEV3_HOME } from "../paths";
 import { listAgentSkills as scanAgentSkills } from "../skills-catalog";
 import { spawn } from "../spawn";
 import { writeSystemClipboard } from "../system-clipboard";
-import { getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererEvent, setActiveContext, setAppForeground, setTerminalFocus } from "./shared";
+import { getPushMessage, getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererEvent, setActiveContext, setAppForeground, setTerminalFocus } from "./shared";
 import { applyMenuContext, type MenuContext } from "../../shared/application-menu";
 import { loadSharedArtifactContent, loadSharedArtifactDownload } from "../shared-artifacts";
 
@@ -309,7 +309,10 @@ async function addVirtualProject(params: { name: string }): Promise<{ ok: true; 
 	}
 }
 
-async function cloneAndAddProject(params: { url: string; baseDir: string; repoName?: string }): Promise<{ ok: true; project: Project } | { ok: false; error: string }> {
+/** How often clone output updates are pushed to the renderer. */
+const CLONE_PROGRESS_PUSH_INTERVAL_MS = 150;
+
+async function cloneAndAddProject(params: { url: string; baseDir: string; repoName?: string; progressId?: string }): Promise<{ ok: true; project: Project } | { ok: false; error: string }> {
 	log.info("→ cloneAndAddProject", params);
 	try {
 		const name = params.repoName || extractRepoName(params.url);
@@ -324,9 +327,33 @@ async function cloneAndAddProject(params: { url: string; baseDir: string; repoNa
 			return { ok: false, error: `Directory already exists: ${targetDir}` };
 		}
 
-		const cloneResult = await git.cloneRepo(params.url, targetDir);
-		if (!cloneResult.ok) {
-			return { ok: false, error: `Clone failed: ${cloneResult.error}` };
+		// Git rewrites progress many times a second; sample on an interval
+		// instead of pushing every stderr chunk over the RPC bridge.
+		const pushMessage = getPushMessage();
+		const progressId = params.progressId;
+		let latestLines: string[] = [];
+		let sentKey = "";
+		const pushLatest = () => {
+			const key = latestLines.join("\n");
+			if (key === sentKey) return;
+			sentKey = key;
+			pushMessage!("cloneProgress", { progressId, lines: latestLines });
+		};
+		const progressTimer = progressId && pushMessage
+			? setInterval(pushLatest, CLONE_PROGRESS_PUSH_INTERVAL_MS)
+			: null;
+		try {
+			const cloneResult = await git.cloneRepo(
+				params.url,
+				targetDir,
+				progressTimer ? (lines) => { latestLines = lines; } : undefined,
+			);
+			if (progressTimer) pushLatest();
+			if (!cloneResult.ok) {
+				return { ok: false, error: `Clone failed: ${cloneResult.error}` };
+			}
+		} finally {
+			if (progressTimer) clearInterval(progressTimer);
 		}
 
 		return addProjectImpl({ path: targetDir, name });

--- a/src/mainview/components/AddProjectModal.tsx
+++ b/src/mainview/components/AddProjectModal.tsx
@@ -28,7 +28,20 @@ function AddProjectModal({ dispatch, onClose }: AddProjectModalProps) {
 	const [browsing, setBrowsing] = useState(false);
 	const [initializing, setInitializing] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [cloneOutput, setCloneOutput] = useState<string[]>([]);
+	const cloneProgressIdRef = useRef<string | null>(null);
 	const urlInputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		function onCloneProgress(e: Event) {
+			const detail = (e as CustomEvent).detail as { progressId: string; lines: string[] };
+			if (detail.progressId === cloneProgressIdRef.current) {
+				setCloneOutput(detail.lines);
+			}
+		}
+		window.addEventListener("rpc:cloneProgress", onCloneProgress);
+		return () => window.removeEventListener("rpc:cloneProgress", onCloneProgress);
+	}, []);
 
 	useEffect(() => {
 		api.request.getGlobalSettings().then((settings) => {
@@ -148,11 +161,15 @@ function AddProjectModal({ dispatch, onClose }: AddProjectModalProps) {
 		if (!gitUrl.trim() || !cloneBaseDir || cloning) return;
 		setCloning(true);
 		setError(null);
+		setCloneOutput([]);
+		const progressId = crypto.randomUUID();
+		cloneProgressIdRef.current = progressId;
 		try {
 			const result = await api.request.cloneAndAddProject({
 				url: gitUrl.trim(),
 				baseDir: cloneBaseDir,
 				repoName: repoName.trim() || undefined,
+				progressId,
 			});
 			if (result.ok) {
 				dispatch({ type: "addProject", project: result.project });
@@ -164,6 +181,7 @@ function AddProjectModal({ dispatch, onClose }: AddProjectModalProps) {
 		} catch (err) {
 			setError(String(err));
 		}
+		cloneProgressIdRef.current = null;
 		setCloning(false);
 	}
 
@@ -368,6 +386,19 @@ function AddProjectModal({ dispatch, onClose }: AddProjectModalProps) {
 						{targetPath && (
 							<div className="text-fg-3 text-xs font-mono">
 								{t("addProject.targetPath")} {targetPath}
+							</div>
+						)}
+
+						{/* Live clone output (last lines of `git clone --progress`) */}
+						{cloning && (
+							<div
+								role="status"
+								aria-live="polite"
+								className="bg-raised border border-edge rounded-xl px-3 py-2 font-mono text-xs text-fg-3 leading-5 h-24 overflow-hidden"
+							>
+								{(cloneOutput.length > 0 ? cloneOutput : [t("addProject.cloning")]).map((line, i) => (
+									<div key={i} className="truncate">{line}</div>
+								))}
 							</div>
 						)}
 					</div>

--- a/src/mainview/components/__tests__/AddProjectModal.test.tsx
+++ b/src/mainview/components/__tests__/AddProjectModal.test.tsx
@@ -219,6 +219,7 @@ describe("AddProjectModal", () => {
 			url: "https://github.com/user/my-repo.git",
 			baseDir: "/base",
 			repoName: undefined,
+			progressId: expect.any(String),
 		});
 		expect(dispatch).toHaveBeenCalledWith({
 			type: "addProject",
@@ -252,6 +253,76 @@ describe("AddProjectModal", () => {
 		await user.click(screen.getByText("Clone"));
 
 		expect(screen.getByText("fatal: repo not found")).toBeInTheDocument();
+	});
+
+	it("shows live clone output pushed via rpc:cloneProgress while cloning", async () => {
+		const user = userEvent.setup();
+
+		mockedApi.request.getGlobalSettings.mockResolvedValue({
+			defaultAgentId: "builtin-claude",
+			defaultConfigId: "claude-default",
+			taskDropPosition: "top",
+			updateChannel: "stable",
+			cloneBaseDirectory: "/base",
+		});
+		let resolveClone!: (v: any) => void;
+		mockedApi.request.cloneAndAddProject.mockImplementation(
+			() => new Promise((resolve) => { resolveClone = resolve; }),
+		);
+
+		renderModal();
+		await user.click(screen.getByText("Clone from URL"));
+		await user.type(
+			screen.getByPlaceholderText("https://github.com/user/repo.git"),
+			"https://github.com/user/my-repo.git",
+		);
+		await user.click(screen.getByText("Clone"));
+
+		// Placeholder until the first progress push arrives
+		expect(screen.getByRole("status")).toHaveTextContent("Cloning...");
+
+		const progressId = vi.mocked(mockedApi.request.cloneAndAddProject).mock.calls[0][0].progressId;
+		act(() => {
+			window.dispatchEvent(new CustomEvent("rpc:cloneProgress", {
+				detail: { progressId, lines: ["Cloning into 'my-repo'...", "Receiving objects: 42% (10/24)"] },
+			}));
+		});
+		expect(screen.getByText("Receiving objects: 42% (10/24)")).toBeInTheDocument();
+
+		await act(async () => { resolveClone({ ok: true, project: mockProject }); });
+	});
+
+	it("ignores rpc:cloneProgress events with a foreign progressId", async () => {
+		const user = userEvent.setup();
+
+		mockedApi.request.getGlobalSettings.mockResolvedValue({
+			defaultAgentId: "builtin-claude",
+			defaultConfigId: "claude-default",
+			taskDropPosition: "top",
+			updateChannel: "stable",
+			cloneBaseDirectory: "/base",
+		});
+		let resolveClone!: (v: any) => void;
+		mockedApi.request.cloneAndAddProject.mockImplementation(
+			() => new Promise((resolve) => { resolveClone = resolve; }),
+		);
+
+		renderModal();
+		await user.click(screen.getByText("Clone from URL"));
+		await user.type(
+			screen.getByPlaceholderText("https://github.com/user/repo.git"),
+			"https://github.com/user/my-repo.git",
+		);
+		await user.click(screen.getByText("Clone"));
+
+		act(() => {
+			window.dispatchEvent(new CustomEvent("rpc:cloneProgress", {
+				detail: { progressId: "someone-else", lines: ["should not appear"] },
+			}));
+		});
+		expect(screen.queryByText("should not appear")).not.toBeInTheDocument();
+
+		await act(async () => { resolveClone({ ok: true, project: mockProject }); });
 	});
 
 	it("calls onClose when Cancel is clicked", async () => {

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -67,6 +67,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	resourceUsageUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:resourceUsageUpdated", { detail: payload })),
 	agentRateLimitsUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentRateLimitsUpdated", { detail: payload })),
 	updateDownloadProgress: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateDownloadProgress", { detail: payload })),
+	cloneProgress: (payload) => window.dispatchEvent(new CustomEvent("rpc:cloneProgress", { detail: payload })),
 	columnAgentFailed: (payload) => window.dispatchEvent(new CustomEvent("rpc:columnAgentFailed", { detail: payload })),
 	taskPreparationFailed: (payload) => window.dispatchEvent(new CustomEvent("rpc:taskPreparationFailed", { detail: payload })),
 	globalSettingsUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:globalSettingsUpdated", { detail: payload })),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2393,7 +2393,7 @@ export type AppRPCSchema = {
 				response: { ok: true; project: Project } | { ok: false; error: string };
 			};
 			cloneAndAddProject: {
-				params: { url: string; baseDir: string; repoName?: string };
+				params: { url: string; baseDir: string; repoName?: string; progressId?: string };
 				response: { ok: true; project: Project } | { ok: false; error: string };
 			};
 			createDirectory: {
@@ -3241,6 +3241,12 @@ export type AppRPCSchema = {
 			 */
 			agentRateLimitsUpdated: AgentRateLimitsReport;
 			updateDownloadProgress: { status: string; progress?: number };
+			/**
+			 * Live `git clone` output for the Add Project modal — the last few
+			 * stderr lines, terminal-style (`\r` rewrites collapsed). Correlated
+			 * by the `progressId` the renderer passed to `cloneAndAddProject`.
+			 */
+			cloneProgress: { progressId: string; lines: string[] };
 			/** Emitted when a column-agent launch fails (custom columns have no automatic fallback). */
 			columnAgentFailed: { taskId: string; projectId: string; columnName: string; error: string };
 			/**


### PR DESCRIPTION
Hi, this is Claude — the AI assistant working on this branch.

## Summary

The Add Project → Clone from URL flow previously showed only a static "Cloning…" button, leaving large repository clones looking stuck. This PR streams live `git clone` output into the modal:

- `cloneRepo` now spawns `git clone --progress` and streams stderr incrementally instead of buffering it (`src/bun/git.ts`).
- New `CloneProgressParser` (`src/bun/clone-progress.ts`) collapses git's `\r` line rewrites into terminal-style display lines.
- `cloneAndAddProject` samples the last 4 lines every 150 ms and pushes a new `cloneProgress` message to the renderer, correlated by a `progressId` so concurrent windows don't cross-talk.
- The modal renders a fixed-height monospace box with the live output while cloning (placeholder "Cloning…" until the first update arrives).
- Failed clones now report a clean terminal-style output tail instead of raw `\r` progress spam.

Covered by unit tests for the parser, a real-git streaming test for `cloneRepo`, handler tests for the sampled push flow, and component tests for the live output box (including foreign-`progressId` filtering). QA'd end-to-end in a browser with a real ~600 MB clone.