### PR TITLE
Fix PR-review task diff comparing branch to itself

### DIFF
--- a/change-logs/2026/07/19/fix-pr-review-diff-base.md
+++ b/change-logs/2026/07/19/fix-pr-review-diff-base.md
@@ -1,0 +1,1 @@
+Fixed the branch diff, ahead/behind status, and rebase/merge base for PR-review and other tasks created on an existing branch. These tasks stored the checked-out branch as their base branch, so the diff compared the branch against itself and showed "No changes to show"; the comparison now falls back to the project's base branch and shows the branch's actual changes.

--- a/decisions/140-pr-review-diff-base-fallback.md
+++ b/decisions/140-pr-review-diff-base-fallback.md
@@ -1,0 +1,46 @@
+# 140 — PR-review diff base falls back to the project base branch
+
+## Context
+A task created from a GitHub PR (or any "existing branch" task) checks out the PR
+head branch. `deriveTaskBaseBranch` (`src/bun/data.ts`) normalizes the task's
+`existingBranch` and stores it as `baseBranch`, so for these tasks
+`baseBranch === branchName`. Every comparison consumer then compared the branch
+against itself: the branch-mode diff ran `<branch>...HEAD` (empty), ahead/behind
+was `0/0`, and rebase/merge targeted the branch itself. Users saw "No changes to
+show" when clicking Diff on a PR-review task (issue reported for base44 PR #16484).
+
+## Investigation
+Confirmed against on-disk task data: `baseBranch === branchName ===
+codex/remote-verification-retry-safety`, `existingBranch =
+origin/codex/...`, `prNumber = 16484`. The merge-completion poller already had an
+inline workaround for exactly this (`git-operations.ts`, ~line 399) — it falls back
+to the project base branch when `baseBranch === live branch` — but the diff/status
+paths did not.
+
+## Decision
+Added a shared pure helper `resolveTaskCompareBaseBranch(task, project)` in
+`src/shared/types.ts`: returns `task.baseBranch`, except when it collapses onto
+`task.branchName`, in which case it returns `project.defaultBaseBranch` (default
+`main`). Routed the diff/status/rebase/merge base derivation through it in
+`src/bun/rpc-handlers/git-operations.ts` (`getTaskDiff`, `getBranchStatusImpl`,
+`rebaseTask`, `rebaseTaskViaAgent`, `mergeTask`) and in the renderer
+`useTaskBranchStatus.ts` (so `compareRef`, `displayRef`, and the compare-ref
+dropdown all use the real base). This fixes already-created tasks with no data
+migration — the stored `baseBranch` is unchanged; only the comparison resolution
+changed.
+
+## Risks
+The fallback assumes the PR targets the project's default base branch. If a PR
+targets a non-default base, the diff shows slightly more than the PR (commits
+between the real PR base and the default base). This mirrors the existing
+merge-completion behavior and is far better than an empty diff. We do not query
+`gh pr view --json baseRefName` to keep the path offline. The merge-completion
+poller keeps its own inline fallback (it needs to *skip* rather than fall back
+when the project base is also the branch itself).
+
+## Alternatives considered
+- **Fix `deriveTaskBaseBranch` at creation.** Would not repair existing tasks and
+  broadens the change to worktree creation semantics.
+- **Capture the PR base ref at task creation.** Most precise, but needs plumbing
+  through the PR-import flow and still needs a fallback for existing tasks. Left as
+  a future improvement.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdir, rm } from "node:fs/promises";
-import type { GlobalSettings, Project, Task } from "../../shared/types";
-import { getPreparingStageProgress } from "../../shared/types";
+import type { GlobalSettings, Project, Task, TaskDiffResponse } from "../../shared/types";
+import { getPreparingStageProgress, resolveTaskCompareBaseBranch } from "../../shared/types";
 import { ENV_UNSET } from "../../shared/agent-accounts";
 
 // ---- Mocks ----
@@ -4314,6 +4314,101 @@ describe("handlers.cancelTaskPreparation", () => {
 // handlers.getBranchStatus
 // ================================================================
 
+describe("resolveTaskCompareBaseBranch", () => {
+	it("returns the stored base branch for a normal task", () => {
+		expect(
+			resolveTaskCompareBaseBranch(
+				{ baseBranch: "main", branchName: "dev3/feature" },
+				{ defaultBaseBranch: "main" },
+			),
+		).toBe("main");
+	});
+
+	it("keeps a custom base branch that differs from the task branch", () => {
+		expect(
+			resolveTaskCompareBaseBranch(
+				{ baseBranch: "develop", branchName: "feat/x" },
+				{ defaultBaseBranch: "main" },
+			),
+		).toBe("develop");
+	});
+
+	it("falls back to the project base when base collapses onto the task branch", () => {
+		// PR-review / existing-branch task: baseBranch === branchName.
+		expect(
+			resolveTaskCompareBaseBranch(
+				{ baseBranch: "codex/pr-head", branchName: "codex/pr-head" },
+				{ defaultBaseBranch: "main" },
+			),
+		).toBe("main");
+	});
+
+	it("defaults the project base to main when unset", () => {
+		expect(
+			resolveTaskCompareBaseBranch(
+				{ baseBranch: "feat/x", branchName: "feat/x" },
+				{ defaultBaseBranch: "" },
+			),
+		).toBe("main");
+	});
+});
+
+describe("handlers.getTaskDiff base branch resolution", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	const branchDiffResponse: TaskDiffResponse = {
+		mode: "branch",
+		compareRef: "origin/main",
+		compareLabel: "origin/main",
+		fallbackReason: null,
+		recentCount: null,
+		summary: { files: 0, insertions: 0, deletions: 0 },
+		files: [],
+		skippedFiles: [],
+	};
+
+	it("resolves a PR-review task's diff base to the project base, not the branch itself", async () => {
+		const project = makeProject({ defaultBaseBranch: "main" });
+		const task = makeTask({
+			worktreePath: "/tmp/wt",
+			branchName: "codex/pr-head",
+			baseBranch: "codex/pr-head",
+			prNumber: 16484,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getTaskDiff).mockResolvedValue(branchDiffResponse);
+
+		await handlers.getTaskDiff({ taskId: task.id, projectId: project.id, mode: "branch" });
+
+		// Fetch and diff against the real base — never the branch compared to itself.
+		expect(git.fetchOrigin).toHaveBeenCalledWith(project.path, "main");
+		expect(git.getTaskDiff).toHaveBeenCalledWith(
+			"/tmp/wt",
+			"branch",
+			expect.objectContaining({ baseBranch: "main" }),
+		);
+	});
+
+	it("leaves a normal task's diff base untouched", async () => {
+		const project = makeProject({ defaultBaseBranch: "main" });
+		const task = makeTask({ worktreePath: "/tmp/wt", branchName: "dev3/feature", baseBranch: "main" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getTaskDiff).mockResolvedValue(branchDiffResponse);
+
+		await handlers.getTaskDiff({ taskId: task.id, projectId: project.id, mode: "branch" });
+
+		expect(git.getTaskDiff).toHaveBeenCalledWith(
+			"/tmp/wt",
+			"branch",
+			expect.objectContaining({ baseBranch: "main" }),
+		);
+	});
+});
+
 describe("handlers.getBranchStatus", () => {
 	beforeEach(() => vi.clearAllMocks());
 
@@ -4369,6 +4464,36 @@ describe("handlers.getBranchStatus", () => {
 		const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 		expect(result.canRebase).toBe(false);
 		expect(git.canRebaseCleanly).not.toHaveBeenCalled();
+	});
+
+	it("compares a PR-review task (baseBranch === branchName) against the project base, not itself", async () => {
+		// PR-review / existing-branch tasks check out the PR head branch and
+		// deriveTaskBaseBranch stores that same branch as baseBranch. Comparing
+		// origin/<branch> against HEAD is trivially empty (the "No changes to show"
+		// diff bug + a false "Branch Merged" prompt) — it must fall back to the base.
+		const project = makeProject({ defaultBaseBranch: "main" });
+		const task = makeTask({
+			worktreePath: "/tmp/wt",
+			branchName: "codex/pr-head",
+			baseBranch: "codex/pr-head",
+			existingBranch: "origin/codex/pr-head",
+			prNumber: 16484,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("codex/pr-head");
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 5, behind: 0 });
+		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 3, insertions: 30, deletions: 10, fileStats: [] });
+		vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", code: 0 });
+
+		await handlers.getBranchStatus({ taskId: task.id, projectId: project.id });
+
+		// The comparison ref must be the project base, never the branch against itself.
+		expect(git.getBranchStatus).toHaveBeenCalledWith("/tmp/wt", "origin/main");
+		expect(git.getBranchDiffStats).toHaveBeenCalledWith("/tmp/wt", "origin/main");
 	});
 
 	it("auto-syncs stored branchName when live branch differs", async () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -10,6 +10,7 @@ import {
 	type TaskDiffResponse,
 	type ScheduledMessageTarget,
 	MERGE_COMPLETE_ELIGIBLE_STATUSES,
+	resolveTaskCompareBaseBranch,
 } from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
@@ -920,7 +921,7 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 		return { ahead: 0, behind: 0, canRebase: false, insertions: 0, deletions: 0, unpushed: 0, mergedByContent: false, diffFiles: 0, diffInsertions: 0, diffDeletions: 0, diffFileStats: [], prNumber: null, prUrl: null, mergeCompletionFingerprint: null };
 	}
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	const liveBranch = await git.getCurrentBranch(task.worktreePath);
 	const branchForPush = liveBranch ?? task.branchName ?? "";
 
@@ -1036,7 +1037,7 @@ async function getTaskDiff(params: {
 
 	assertGitTask(project, task);
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	// `uncommitted` needs no remote ref; `recent` is purely local — it diffs
 	// `HEAD~N..HEAD` and clamps against the already on-disk `origin/<base>`
 	// merge-base — so neither pays for a network fetch.
@@ -1073,7 +1074,7 @@ async function rebaseTask(params: { taskId: string; projectId: string; compareRe
 
 	assertGitTask(project, task);
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	const rebaseTarget = params.compareRef || `origin/${baseBranch}`;
 	const tmuxSession = taskSessionName(task.id);
 	const scriptPath = dev3TaskTempPath(task.id, "git-rebase.sh");
@@ -1129,7 +1130,7 @@ async function mergeTask(params: { taskId: string; projectId: string }): Promise
 	const branchForMerge = liveBranch ?? task.branchName;
 	if (!branchForMerge) throw new Error("Task has no branch");
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	await git.fetchOrigin(project.path, baseBranch);
 	// For task-specific base branches (not the project default), compare against the local branch —
 	// consistent with what the UI displays. For the project default, check against the remote.
@@ -1298,7 +1299,7 @@ async function rebaseTaskViaAgent(params: { taskId: string; projectId: string; c
 
 	assertGitTask(project, task);
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	const rebaseTarget = params.compareRef || `origin/${baseBranch}`;
 	const tmuxSession = taskSessionName(task.id);
 	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -6,7 +6,7 @@ import LabelChip from "./LabelChip";
 import PriorityBadge from "./PriorityBadge";
 import OpenInMenu from "./OpenInMenu";
 import { formatDate } from "./NoteItem";
-import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
+import { ACTIVE_STATUSES, getTaskTitle, resolveTaskCompareBaseBranch } from "../../shared/types";
 import InlineRename from "./InlineRename";
 import { getTaskOpenMode, taskClosedHomeRoute, type AppAction, type Route } from "../state";
 import { api } from "../rpc";
@@ -507,7 +507,7 @@ function TaskInfoPanel({
 		onOpenInlineDiff({
 			mode: "branch",
 			compareRef: branchMeta?.compareRef,
-			compareLabel: branchMeta?.compareLabel ?? `origin/${task.baseBranch || project.defaultBaseBranch || "main"}`,
+			compareLabel: branchMeta?.compareLabel ?? `origin/${resolveTaskCompareBaseBranch(task, project)}`,
 			focusFile,
 		});
 	}

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -5,6 +5,7 @@ import {
 	type Project,
 	type Task,
 	MERGE_COMPLETE_ELIGIBLE_STATUSES,
+	resolveTaskCompareBaseBranch,
 } from "../../../shared/types";
 import { getTaskOpenMode, taskClosedHomeRoute, type AppAction, type Route } from "../../state";
 import { api } from "../../rpc";
@@ -61,7 +62,7 @@ export function useTaskBranchStatus({
 	const [refreshingStatus, setRefreshingStatus] = useState(false);
 	const mergeDialogShownRef = useRef(false);
 
-	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	const defaultCompareRef = getDefaultTaskCompareRef(baseBranch, project);
 	const [compareRef, setCompareRef] = useState(defaultCompareRef);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1628,6 +1628,33 @@ export function getTaskOverview(task: Task): string | null {
 	return task.userOverview?.trim() || task.overview?.trim() || null;
 }
 
+/**
+ * The branch a task's changes should be *compared against* — the base for the
+ * branch diff, ahead/behind status, and rebase/merge targets.
+ *
+ * Normally this is `task.baseBranch` (falling back to the project's default
+ * base). PR-review and other "existing branch" tasks are the exception: they
+ * check out an existing remote branch and `deriveTaskBaseBranch` (see
+ * `src/bun/data.ts`) stores that same branch as `baseBranch`, so
+ * `baseBranch === branchName`. Comparing a branch against itself is trivially
+ * empty — the "No changes to show" branch-diff bug, and a false "Branch Merged"
+ * prompt. When the stored base collapses onto the task's own branch, fall back
+ * to the project's real base branch so comparisons show the branch's actual
+ * changes. Mirrors the merge-completion poller's inline fallback in
+ * `src/bun/rpc-handlers/git-operations.ts`.
+ */
+export function resolveTaskCompareBaseBranch(
+	task: Pick<Task, "baseBranch" | "branchName">,
+	project: Pick<Project, "defaultBaseBranch">,
+): string {
+	const projectBase = project.defaultBaseBranch || "main";
+	const stored = task.baseBranch || projectBase;
+	if (task.branchName && stored === task.branchName) {
+		return projectBase;
+	}
+	return stored;
+}
+
 /** What changed in a {@link TaskHistoryEntry}. */
 export type TaskHistoryChange = "created" | "title" | "overview" | "both";
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Fixes the empty branch diff on PR-review tasks (and any task created on an existing branch).

These tasks check out the PR head branch, and `deriveTaskBaseBranch` stores that same branch as the task's `baseBranch`, so `baseBranch === branchName`. Every comparison then became self-referential: the branch-mode diff ran `<branch>...HEAD` and showed **"No changes to show"**, ahead/behind was `0/0`, and rebase/merge targeted the branch itself. The compare-ref dropdown only offered the branch itself, so the real base couldn't even be selected manually.

## Fix

- New pure helper `resolveTaskCompareBaseBranch(task, project)` in `src/shared/types.ts`: returns `task.baseBranch`, except when it collapses onto `task.branchName`, in which case it falls back to the project's default base branch.
- Routed the base-branch resolution through it in `src/bun/rpc-handlers/git-operations.ts` (`getTaskDiff`, `getBranchStatusImpl`, `rebaseTask`, `rebaseTaskViaAgent`, `mergeTask`) and in the renderer `useTaskBranchStatus.ts` (so `compareRef`, the `vs …` label, and the dropdown all use the real base).
- Resolution happens at comparison time — the stored `baseBranch` is untouched, so already-created tasks are fixed with no data migration.

Known limitation (documented in `decisions/140-pr-review-diff-base-fallback.md`): the fallback assumes the PR targets the project's default base branch; a PR targeting a non-default base will show slightly more than exactly the PR. This mirrors the existing merge-completion behavior and beats an empty diff.

Added unit tests (helper + handler-level) that would fail before the fix; `bun run lint` and the full `bun run test` suite are green.
