### PR TITLE
Fix stale PR badge leaking across task switches in task git bar

### DIFF
--- a/change-logs/2026/07/19/fix-stale-pr-badge-task-switch.md
+++ b/change-logs/2026/07/19/fix-stale-pr-badge-task-switch.md
@@ -1,0 +1,1 @@
+Fixed the task header showing the previously viewed task's PR badge (number, unresolved comment count, CI/review popover) after switching tasks. The git bar component is reused across task switches and kept the last pushed PR status in memory, so a task without its own PR displayed the stale badge indefinitely; the pushed status is now cleared on every task switch.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1890,6 +1890,57 @@ describe("TaskInfoPanel", () => {
 			expect(await screen.findAllByLabelText("4 unresolved comments")).not.toHaveLength(0);
 		});
 
+		it("does not leak the previous task's pushed PR status after switching tasks", async () => {
+			mockedApi.request.getBranchStatus.mockResolvedValue({
+				...defaultBranchStatus,
+				prNumber: 42,
+				prUrl: "https://github.com/test/repo/pull/42",
+			});
+
+			const dispatch = vi.fn();
+			const navigate = vi.fn();
+			let view!: ReturnType<typeof renderPanel>;
+			await act(async () => {
+				view = renderPanel(makeTask(), { dispatch, navigate });
+			});
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:taskPrStatus", {
+					detail: {
+						projectId: "p1",
+						taskId: "t1",
+						prNumber: 42,
+						prUrl: "https://github.com/test/repo/pull/42",
+						ciStatus: "pending",
+						reviewState: null,
+						unresolvedCount: 4,
+						mergeState: { mergeable: "MERGEABLE", status: "CLEAN" },
+						checks: [],
+						prTitle: "Status surface",
+						isDraft: false,
+					},
+				}));
+			});
+			expect(screen.getAllByText(/PR #42/).length).toBeGreaterThanOrEqual(1);
+
+			// Same panel instance re-rendered for another task without a PR — the
+			// pushed status from t1 must not keep rendering on t2.
+			mockedApi.request.getBranchStatus.mockResolvedValue(defaultBranchStatus);
+			await act(async () => {
+				view.rerender(
+					<I18nProvider>
+						<TaskInfoPanel
+							task={makeTask({ id: "t2", seq: 43, worktreePath: "/tmp/wt/t2", branchName: "dev3/task-t2" })}
+							project={project}
+							dispatch={dispatch}
+							navigate={navigate}
+						/>
+					</I18nProvider>,
+				);
+			});
+
+			expect(screen.queryByText(/PR #42/)).not.toBeInTheDocument();
+		});
+
 		it("refreshes rich PR status when opening a task with an existing PR", async () => {
 			mockedApi.request.getBranchStatus.mockResolvedValue({
 				...defaultBranchStatus,

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -127,6 +127,15 @@ export default function TaskGitActions({
 		isTaskActive,
 	});
 
+	// Switching tasks reuses this component instance (no `key={task.id}`), and
+	// `rpc:taskPrStatus` pushes arrive only for the task being viewed — so a
+	// status pushed while viewing the previous task would keep rendering its PR
+	// badge on the next task forever (a task without its own PR never gets an
+	// overwriting push). Clear it eagerly on every task switch.
+	useEffect(() => {
+		setPushedPRStatus(null);
+	}, [task.id]);
+
 	useEffect(() => {
 		function onPrStatus(event: Event) {
 			const detail = (event as CustomEvent).detail as {


### PR DESCRIPTION
## Summary

Opening a task without its own PR could show the previously viewed task's `PR #N` badge (number, unresolved comment count, status popover) in the task header git bar — indefinitely.

Root cause: `TaskGitActions` is reused across task switches (no `key={task.id}`) and kept the last `rpc:taskPrStatus` payload in `pushedPRStatus` state. Those push events only arrive for the task currently being viewed, so a task without a PR never received an overwriting push and kept rendering the stale badge. The branch counters (ahead/behind, +/− uncommitted) were unaffected — they are recomputed live per worktree and already reset on task switch.

Fix: clear `pushedPRStatus` on every `task.id` change, mirroring the existing branch-status reset in `useTaskBranchStatus`. Includes a regression test that reproduces the leak (dispatch a PR status for task A, re-render the same panel instance with task B, assert the badge is gone).