### PR TITLE
Add Shift+Tab key to mobile terminal extra key bar

### DIFF
--- a/change-logs/2026/07/20/feature-mobile-shift-tab-key.md
+++ b/change-logs/2026/07/20/feature-mobile-shift-tab-key.md
@@ -1,0 +1,1 @@
+Added a ⇧Tab button to the mobile terminal extra key bar, next to Tab. It sends the back-tab escape sequence (ESC [ Z), which lets you cycle Claude Code's agent/permission mode from a phone where Shift+Tab cannot be typed.

--- a/src/mainview/components/ExtraKeyBar.tsx
+++ b/src/mainview/components/ExtraKeyBar.tsx
@@ -20,7 +20,8 @@ interface ExtraKeyBarProps {
 /**
  * Extra key bar for mobile terminal access — provides keys
  * that are missing or hard to reach on mobile keyboards:
- * Esc, Tab, Ctrl (sticky modifier), arrows, and common shell chars.
+ * Esc, Tab, Shift+Tab (agent-mode cycling in Claude Code), Ctrl (sticky
+ * modifier), arrows, and common shell chars.
  * The leading ⌨ button (when the host wires onToggleRaw) switches between
  * compose mode (default — TerminalComposer owns text entry) and raw mode
  * (direct typing into the terminal).
@@ -133,6 +134,7 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b")}>Esc</button>
 			<button className={btnCtrl} onMouseDown={(e) => e.preventDefault()} onClick={toggleCtrl}>Ctrl</button>
 			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\t")}>Tab</button>
+			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[Z")}>{"⇧Tab"}</button>
 			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\r")}>Enter</button>
 
 			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />

--- a/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
+++ b/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
@@ -59,6 +59,14 @@ describe("ExtraKeyBar", () => {
 		expect(handle.sendInput).toHaveBeenCalledWith("\r");
 	});
 
+	it("sends the back-tab sequence for Shift+Tab (Claude agent-mode cycling)", async () => {
+		const handle = makeHandle();
+		renderBar(handle);
+
+		await userEvent.click(screen.getByRole("button", { name: "⇧Tab" }));
+		expect(handle.sendInput).toHaveBeenCalledWith("\x1b[Z");
+	});
+
 	it("sticky Ctrl turns the next key into a control character", async () => {
 		const handle = makeHandle();
 		renderBar(handle);


### PR DESCRIPTION
Adds a **⇧Tab** button to the mobile terminal extra key bar (`ExtraKeyBar`), right next to the existing Tab key. It sends the back-tab escape sequence (`ESC [ Z`) to the PTY — the sequence a physical Shift+Tab produces — so touch users can cycle the agent's permission/plan mode (Claude Code, codex) from a phone, where Shift+Tab is impossible to type.

- Same visual style and focus discipline as the existing key buttons; works with the sticky Ctrl modifier path untouched.
- Unit test asserts the button sends `\x1b[Z`; changelog entry included.
- Verified live in mobile browser QA: tapping the key switched the agent to Plan mode and a second tap cycled back to Default.