### PR TITLE
Pinch-zoom and pan for the shared-image viewer on mobile

### DIFF
--- a/change-logs/2026/07/20/feature-mobile-image-pinch-zoom.md
+++ b/change-logs/2026/07/20/feature-mobile-image-pinch-zoom.md
@@ -1,0 +1,1 @@
+The shared-image lightbox now supports pinch-to-zoom and drag-to-pan with touch, plus double-tap and ctrl-wheel to zoom, so images surfaced via `dev3 show-image` are usable on small mobile screens.

--- a/decisions/141-image-viewer-pinch-zoom.md
+++ b/decisions/141-image-viewer-pinch-zoom.md
@@ -1,0 +1,25 @@
+# 141 — Pinch-zoom / pan in the shared-image viewer via Pointer Events
+
+## Context
+On mobile / remote-browser the shared-image lightbox (`TaskImageViewer`) only offered
+fit/width toggling. Small screens made captures unreadable with no way to zoom into detail.
+
+## Decision
+Added `src/mainview/hooks/usePinchZoom.ts` — a Pointer Events based hook (touch + mouse/
+trackpad, identical in desktop and browser). Two pointers pinch-zoom around their midpoint,
+one pointer pans once zoomed, double-tap toggles fit↔2.5×, ctrl-wheel (trackpad pinch)
+zooms toward the cursor. The transform math is two pure, unit-tested functions
+(`clampTransform`, `zoomAt`); the hook is thin wiring around them. Wired into
+`TaskImageViewer` only in `fit` mode (tall images keep vertical scroll) with
+`touch-action: none` on the stage so the browser doesn't hijack the gesture.
+
+## Risks
+Pointer capture / `touch-action` differ subtly across engines; guarded with optional chaining
+and only enabled in `fit` mode so scrollable tall images are untouched. Gesture wiring is
+hard to fully exercise in happy-dom — covered by pure-function tests plus a ctrl-wheel
+component test; genuine multi-touch pinch is verified manually on device.
+
+## Alternatives considered
+- `react-zoom-pan-pinch` library — rejected, avoids a dependency for ~120 lines.
+- Native CSS `touch-action: pinch-zoom` on a scroll container — rejected, inconsistent in
+  WKWebView and no control over bounds / double-tap / reset-on-navigation.

--- a/src/mainview/components/TaskImageViewer.tsx
+++ b/src/mainview/components/TaskImageViewer.tsx
@@ -3,6 +3,7 @@ import type { SharedImage } from "../../shared/types";
 import { api } from "../rpc";
 import { useT } from "../i18n";
 import { toast } from "../toast";
+import { usePinchZoom } from "../hooks/usePinchZoom";
 
 interface TaskImageViewerProps {
 	images: SharedImage[];
@@ -59,6 +60,15 @@ export default function TaskImageViewer({ images, initialIndex, onClose, taskId 
 	}, [images.length]);
 
 	const current = images[index];
+	// Aspect-driven display mode: tall captures scroll vertically ("width"),
+	// everything else is centred + contained ("fit") and gets pinch-to-zoom.
+	const isTall = natural ? natural.h / natural.w >= TALL_RATIO : false;
+	const fit: "fit" | "width" = fitOverride ?? (isTall ? "width" : "fit");
+	const zoom = usePinchZoom(fit === "fit");
+	const setStage = useCallback((el: HTMLDivElement | null) => {
+		stageRef.current = el;
+		zoom.setNode(el);
+	}, [zoom.setNode]);
 
 	// Fetch one image's bytes as a data URL, once. Marks "__error__" on failure so
 	// the thumbnail/stage renders a placeholder instead of a perpetual spinner.
@@ -136,15 +146,14 @@ export default function TaskImageViewer({ images, initialIndex, onClose, taskId 
 		setCopied(false);
 		setNatural(null);
 		setFitOverride(null);
+		zoom.reset();
 		if (stageRef.current) stageRef.current.scrollTop = 0;
-	}, [index]);
+	}, [index, zoom.reset]);
 
 	if (!current) return null;
 
 	const currentUrl = urls[current.id];
 	const isError = currentUrl === "__error__";
-	const isTall = natural ? natural.h / natural.w >= TALL_RATIO : false;
-	const fit: "fit" | "width" = fitOverride ?? (isTall ? "width" : "fit");
 
 	const copyPath = async () => {
 		try {
@@ -237,7 +246,8 @@ export default function TaskImageViewer({ images, initialIndex, onClose, taskId 
 				{/* Stage */}
 				<div className="relative flex-1 min-h-0 bg-base">
 					<div
-						ref={stageRef}
+						ref={setStage}
+						style={{ touchAction: fit === "width" ? "pan-y" : "none" }}
 						className={`absolute inset-0 ${fit === "width" ? "overflow-y-auto overflow-x-hidden p-3" : "overflow-hidden p-4 flex items-center justify-center"}`}
 					>
 						{isError ? (
@@ -251,11 +261,11 @@ export default function TaskImageViewer({ images, initialIndex, onClose, taskId 
 								alt={current.name}
 								data-testid="viewer-main-image"
 								onLoad={(e) => setNatural({ w: e.currentTarget.naturalWidth || 1, h: e.currentTarget.naturalHeight || 1 })}
-								onClick={() => setFitOverride(fit === "width" ? "fit" : "width")}
-								className={`select-none cursor-zoom-in ${
+								style={fit === "fit" ? { transform: zoom.transform, transition: zoom.animated ? "transform 150ms ease-out" : "none" } : undefined}
+								className={`select-none ${
 									fit === "width"
 										? "block mx-auto w-full max-w-[1400px] h-auto"
-										: "w-full h-full object-contain"
+										: `w-full h-full object-contain will-change-transform ${zoom.zoomed ? "cursor-grab" : "cursor-zoom-in"}`
 								}`}
 								draggable={false}
 							/>

--- a/src/mainview/components/__tests__/TaskImageViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskImageViewer.test.tsx
@@ -138,6 +138,22 @@ describe("TaskImageViewer", () => {
 		expect(screen.getByTestId("viewer-caption")).toHaveTextContent("look at the header");
 	});
 
+	it("zooms the image in on ctrl-wheel (trackpad pinch) in fit mode", async () => {
+		renderViewer();
+		const image = await screen.findByTestId("viewer-main-image");
+		expect(image.style.transform).toContain("scale(1)");
+		const stage = image.parentElement as HTMLElement;
+		stage.getBoundingClientRect = () =>
+			({ left: 0, top: 0, width: 200, height: 100, right: 200, bottom: 100, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+		const wheel = new Event("wheel", { bubbles: true, cancelable: true });
+		Object.assign(wheel, { deltaY: -200, ctrlKey: true, clientX: 100, clientY: 50 });
+		fireEvent(stage, wheel);
+		await waitFor(() => {
+			const scale = Number(image.style.transform.match(/scale\(([\d.]+)\)/)?.[1] ?? "1");
+			expect(scale).toBeGreaterThan(1);
+		});
+	});
+
 	it("marks <html> while open so the terminal is hidden behind it", async () => {
 		const { unmount } = render(
 			<I18nProvider>

--- a/src/mainview/hooks/__tests__/usePinchZoom.test.ts
+++ b/src/mainview/hooks/__tests__/usePinchZoom.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { clampTransform, zoomAt, MIN_SCALE, MAX_SCALE, IDENTITY } from "../usePinchZoom";
+
+describe("clampTransform", () => {
+	it("snaps back to a centred identity at or below minimum scale", () => {
+		expect(clampTransform({ scale: 0.4, x: 50, y: 50 }, 200, 100)).toEqual({ scale: MIN_SCALE, x: 0, y: 0 });
+		expect(clampTransform({ scale: 1, x: 30, y: -20 }, 200, 100)).toEqual({ scale: 1, x: 0, y: 0 });
+	});
+
+	it("caps scale at MAX_SCALE", () => {
+		expect(clampTransform({ scale: 99, x: 0, y: 0 }, 200, 100).scale).toBe(MAX_SCALE);
+	});
+
+	it("bounds translation so scaled content stays within the element edges", () => {
+		// At scale 2 on a 200x100 box the reachable offset is (scale-1)*size/2.
+		const t = clampTransform({ scale: 2, x: 999, y: -999 }, 200, 100);
+		expect(t.x).toBe(100); // (2-1)*200/2
+		expect(t.y).toBe(-50); // (2-1)*100/2
+	});
+
+	it("passes through translation already inside the bounds", () => {
+		const t = clampTransform({ scale: 3, x: 40, y: 20 }, 200, 100);
+		expect(t).toEqual({ scale: 3, x: 40, y: 20 });
+	});
+});
+
+describe("zoomAt", () => {
+	it("is a no-op transform when target scale equals current scale", () => {
+		expect(zoomAt(IDENTITY, 30, 10, 1)).toEqual({ scale: 1, x: 0, y: 0 });
+	});
+
+	it("keeps the anchored point fixed while zooming in from identity", () => {
+		const px = 40, py = -20, target = 2;
+		const next = zoomAt(IDENTITY, px, py, target);
+		expect(next.scale).toBe(target);
+		// The content coordinate under the anchor must map back to the same screen point.
+		const content = { x: (px - next.x) / next.scale, y: (py - next.y) / next.scale };
+		expect(content.x * target + next.x).toBeCloseTo(px);
+		expect(content.y * target + next.y).toBeCloseTo(py);
+	});
+
+	it("zooming toward the centre point leaves translation at zero", () => {
+		expect(zoomAt(IDENTITY, 0, 0, 3)).toEqual({ scale: 3, x: 0, y: 0 });
+	});
+});

--- a/src/mainview/hooks/usePinchZoom.ts
+++ b/src/mainview/hooks/usePinchZoom.ts
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const MIN_SCALE = 1;
+export const MAX_SCALE = 6;
+/** Scale a double-tap / double-click zooms into. */
+export const DOUBLE_TAP_SCALE = 2.5;
+
+export interface ZoomTransform {
+	scale: number;
+	/** Translation in px, applied AFTER scaling around the element's centre. */
+	x: number;
+	y: number;
+}
+
+export const IDENTITY: ZoomTransform = { scale: 1, x: 0, y: 0 };
+
+/**
+ * Clamp a transform: scale into [MIN_SCALE, MAX_SCALE], and translation so the
+ * scaled content never drifts past the element edges (transform-origin centre).
+ * `rectW`/`rectH` are the on-screen size of the zoomable element.
+ */
+export function clampTransform(t: ZoomTransform, rectW: number, rectH: number): ZoomTransform {
+	const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, t.scale));
+	if (scale <= MIN_SCALE) return { scale, x: 0, y: 0 };
+	const maxX = (rectW * (scale - 1)) / 2;
+	const maxY = (rectH * (scale - 1)) / 2;
+	return {
+		scale,
+		x: Math.min(maxX, Math.max(-maxX, t.x)),
+		y: Math.min(maxY, Math.max(-maxY, t.y)),
+	};
+}
+
+/**
+ * Return a transform that scales to `targetScale` while keeping the content
+ * point currently under (`px`, `py`) — coordinates relative to the element's
+ * centre — anchored in place. Result is NOT clamped; clamp the output yourself.
+ */
+export function zoomAt(t: ZoomTransform, px: number, py: number, targetScale: number): ZoomTransform {
+	const ratio = targetScale / t.scale;
+	return {
+		scale: targetScale,
+		x: px - (px - t.x) * ratio,
+		y: py - (py - t.y) * ratio,
+	};
+}
+
+const TAP_MOVE_PX = 10;
+const TAP_MAX_MS = 300;
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_PX = 30;
+
+export interface PinchZoom {
+	/** Ref callback — attach to the element that both captures gestures and is
+	 * the reference box for centre/clamp math (usually the stage container). */
+	setNode: (node: HTMLElement | null) => void;
+	/** CSS transform for the zoomable content. */
+	transform: string;
+	/** True while zoomed in (scale > 1) — drives cursor / pan affordances. */
+	zoomed: boolean;
+	/** Reset to the neutral (unzoomed, centred) state. */
+	reset: () => void;
+	/** Whether transform changes should animate (off during an active gesture). */
+	animated: boolean;
+}
+
+/**
+ * Pinch-to-zoom + drag-to-pan + double-tap gesture handling via Pointer Events,
+ * so it works identically for touch (mobile / remote browser) and mouse/trackpad
+ * (desktop). Two pointers pinch-zoom around their midpoint; a single pointer pans
+ * once zoomed; a double-tap toggles between fit and DOUBLE_TAP_SCALE; ctrl-wheel
+ * (trackpad pinch) zooms toward the cursor. When `enabled` is false the hook is
+ * inert and the transform stays at identity.
+ */
+export function usePinchZoom(enabled: boolean): PinchZoom {
+	const [t, setT] = useState<ZoomTransform>(IDENTITY);
+	const [animated, setAnimated] = useState(true);
+	const [node, setNode] = useState<HTMLElement | null>(null);
+
+	const tRef = useRef(t);
+	tRef.current = t;
+	const enabledRef = useRef(enabled);
+	enabledRef.current = enabled;
+
+	const reset = useCallback(() => {
+		setAnimated(true);
+		setT(IDENTITY);
+	}, []);
+
+	// Snap back to identity whenever gestures get disabled (e.g. leaving fit mode).
+	useEffect(() => {
+		if (!enabled) setT(IDENTITY);
+	}, [enabled]);
+
+	useEffect(() => {
+		if (!node) return;
+
+		const pointers = new Map<number, { x: number; y: number }>();
+		let pinch: { dist: number; t: ZoomTransform; midX: number; midY: number } | null = null;
+		let pan: { px: number; py: number; x: number; y: number } | null = null;
+		let multiTouch = false;
+		let tapStart: { x: number; y: number; time: number } | null = null;
+		let lastTap: { x: number; y: number; time: number } | null = null;
+
+		const centre = () => {
+			const r = node.getBoundingClientRect();
+			return { cx: r.left + r.width / 2, cy: r.top + r.height / 2, w: r.width, h: r.height };
+		};
+		const clamp = (next: ZoomTransform) => {
+			const { w, h } = centre();
+			return clampTransform(next, w, h);
+		};
+
+		const onDown = (e: PointerEvent) => {
+			if (!enabledRef.current) return;
+			node.setPointerCapture?.(e.pointerId);
+			pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+			if (pointers.size === 2) {
+				multiTouch = true;
+				pan = null;
+				const [a, b] = [...pointers.values()];
+				pinch = {
+					dist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
+					t: tRef.current,
+					midX: (a.x + b.x) / 2,
+					midY: (a.y + b.y) / 2,
+				};
+				setAnimated(false);
+			} else if (pointers.size === 1) {
+				tapStart = { x: e.clientX, y: e.clientY, time: performance.now() };
+				if (tRef.current.scale > MIN_SCALE) {
+					pan = { px: e.clientX, py: e.clientY, x: tRef.current.x, y: tRef.current.y };
+					setAnimated(false);
+				}
+			}
+		};
+
+		const onMove = (e: PointerEvent) => {
+			if (!pointers.has(e.pointerId)) return;
+			pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+			if (pinch && pointers.size >= 2) {
+				e.preventDefault();
+				const [a, b] = [...pointers.values()];
+				const dist = Math.hypot(a.x - b.x, a.y - b.y) || 1;
+				const { cx, cy } = centre();
+				const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, (pinch.t.scale * dist) / pinch.dist));
+				// Content point anchored under the original pinch midpoint.
+				const anchorX = (pinch.midX - cx - pinch.t.x) / pinch.t.scale;
+				const anchorY = (pinch.midY - cy - pinch.t.y) / pinch.t.scale;
+				const midX = (a.x + b.x) / 2 - cx;
+				const midY = (a.y + b.y) / 2 - cy;
+				setT(clamp({ scale, x: midX - anchorX * scale, y: midY - anchorY * scale }));
+			} else if (pan && pointers.size === 1) {
+				e.preventDefault();
+				setT(clamp({ scale: tRef.current.scale, x: pan.x + (e.clientX - pan.px), y: pan.y + (e.clientY - pan.py) }));
+			}
+		};
+
+		const maybeDoubleTap = (e: PointerEvent) => {
+			if (multiTouch || !tapStart) return;
+			const moved = Math.hypot(e.clientX - tapStart.x, e.clientY - tapStart.y);
+			const dur = performance.now() - tapStart.time;
+			if (moved > TAP_MOVE_PX || dur > TAP_MAX_MS) return;
+			const now = performance.now();
+			if (lastTap && now - lastTap.time < DOUBLE_TAP_MS && Math.hypot(e.clientX - lastTap.x, e.clientY - lastTap.y) < DOUBLE_TAP_PX) {
+				lastTap = null;
+				setAnimated(true);
+				if (tRef.current.scale > MIN_SCALE) {
+					setT(IDENTITY);
+				} else {
+					const { cx, cy } = centre();
+					setT(clamp(zoomAt(tRef.current, e.clientX - cx, e.clientY - cy, DOUBLE_TAP_SCALE)));
+				}
+			} else {
+				lastTap = { x: e.clientX, y: e.clientY, time: now };
+			}
+		};
+
+		const onUp = (e: PointerEvent) => {
+			pointers.delete(e.pointerId);
+			node.releasePointerCapture?.(e.pointerId);
+			if (pointers.size < 2) pinch = null;
+			if (pointers.size === 1 && tRef.current.scale > MIN_SCALE) {
+				// Hand the surviving finger a fresh pan anchor after a pinch ends.
+				const [pt] = [...pointers.values()];
+				pan = { px: pt.x, py: pt.y, x: tRef.current.x, y: tRef.current.y };
+			}
+			if (pointers.size === 0) {
+				if (enabledRef.current) maybeDoubleTap(e);
+				pan = null;
+				tapStart = null;
+				multiTouch = false;
+				setAnimated(true);
+			}
+		};
+
+		const onWheel = (e: WheelEvent) => {
+			if (!enabledRef.current || !e.ctrlKey) return;
+			e.preventDefault();
+			const { cx, cy } = centre();
+			const factor = Math.exp(-e.deltaY / 200);
+			setAnimated(false);
+			setT(clamp(zoomAt(tRef.current, e.clientX - cx, e.clientY - cy, tRef.current.scale * factor)));
+		};
+
+		node.addEventListener("pointerdown", onDown);
+		node.addEventListener("pointermove", onMove, { passive: false });
+		node.addEventListener("pointerup", onUp);
+		node.addEventListener("pointercancel", onUp);
+		node.addEventListener("wheel", onWheel, { passive: false });
+		return () => {
+			node.removeEventListener("pointerdown", onDown);
+			node.removeEventListener("pointermove", onMove);
+			node.removeEventListener("pointerup", onUp);
+			node.removeEventListener("pointercancel", onUp);
+			node.removeEventListener("wheel", onWheel);
+		};
+	}, [node]);
+
+	return {
+		setNode,
+		transform: `translate(${t.x}px, ${t.y}px) scale(${t.scale})`,
+		zoomed: t.scale > MIN_SCALE,
+		reset,
+		animated,
+	};
+}


### PR DESCRIPTION
## Summary

Adds pinch-to-zoom and drag-to-pan to the shared-image lightbox (`TaskImageViewer`) so images surfaced via `dev3 show-image` are usable on small mobile screens.

- New `usePinchZoom` hook built on Pointer Events — works identically for touch (mobile / remote browser) and mouse/trackpad (desktop).
- Two pointers pinch-zoom around their midpoint; one pointer pans once zoomed; double-tap toggles fit ↔ 2.5×; ctrl-wheel (trackpad pinch) zooms toward the cursor.
- Zoom math lives in two pure, unit-tested functions (`clampTransform`, `zoomAt`); the hook is thin wiring around them. Translation is clamped so the image can't drift past the element edges; scale capped at 6×.
- Wired into `TaskImageViewer` only in `fit` mode with `touch-action: none` on the stage; tall/`width`-mode captures keep their vertical scroll. Zoom resets on image navigation.
- Old single-click fit/width toggle on the image removed (its role is now double-tap + the header button).

Tests: pure-function unit tests for the zoom math, plus a component test that exercises the real event wiring (ctrl-wheel zoom). Decision record in `decisions/141-image-viewer-pinch-zoom.md`.