### PR TITLE
Close mobile task-actions sheet when opening the image viewer

### DIFF
--- a/change-logs/2026/07/20/fix-mobile-actions-sheet-close-on-images.md
+++ b/change-logs/2026/07/20/fix-mobile-actions-sheet-close-on-images.md
@@ -1,0 +1,1 @@
+Fixed the mobile Task actions sheet staying open after tapping the Images row — it now closes as it already did for the Artifacts row, so the image viewer opens on a clean surface.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -1090,9 +1090,12 @@ function TaskInfoPanel({
 							{(task.sharedImages?.length ?? 0) > 0 && (
 								<button
 									type="button"
-									onClick={() => window.dispatchEvent(new CustomEvent("dev3:openImageViewer", {
-										detail: { taskId: task.id, images: task.sharedImages, index: (task.sharedImages?.length ?? 1) - 1 },
-									}))}
+									onClick={() => {
+										setActionsSheetOpen(false);
+										window.dispatchEvent(new CustomEvent("dev3:openImageViewer", {
+											detail: { taskId: task.id, images: task.sharedImages, index: (task.sharedImages?.length ?? 1) - 1 },
+										}));
+									}}
 									className={SHEET_ROW_CLASS}
 								>
 									<ImagesIcon className="h-5 w-5 shrink-0 text-fg-3" />

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -2939,6 +2939,29 @@ describe("TaskInfoPanel — virtual (Operations) tasks", () => {
 			window.removeEventListener("dev3:openArtifactViewer", openArtifact);
 		});
 
+		it("opens the image viewer and closes the actions sheet", async () => {
+			const openImage = vi.fn();
+			window.addEventListener("dev3:openImageViewer", openImage);
+			await act(async () => {
+				renderPanel(makeTask({
+					sharedImages: [{
+						id: "image-1",
+						storedPath: "/tmp/shared-images/image-1/shot.png",
+						originalPath: "/tmp/shot.png",
+						name: "shot.png",
+						mime: "image/png",
+						bytes: 10,
+						createdAt: 1,
+					}],
+				}));
+			});
+			await userEvent.click(screen.getByTestId("task-actions-kebab"));
+			await userEvent.click(within(screen.getByTestId("task-actions-sheet")).getByText("Images"));
+			expect(openImage).toHaveBeenCalledOnce();
+			expect(screen.queryByTestId("task-actions-sheet")).not.toBeInTheDocument();
+			window.removeEventListener("dev3:openImageViewer", openImage);
+		});
+
 		it("closes the sheet on the close button", async () => {
 			await act(async () => {
 				renderPanel(makeTask({ title: "Mobile task" }));


### PR DESCRIPTION
On mobile, tapping the **Images** row in the Task actions bottom sheet opened the image viewer but left the sheet itself open on top of it. The row dispatched `dev3:openImageViewer` without closing the sheet — unlike the adjacent **Artifacts** row, which already closes it.

Fix: the Images row now calls `setActionsSheetOpen(false)` before dispatching, so the viewer opens on a clean surface. Added a regression test mirroring the existing Artifacts test.