### PR TITLE
Fix Split Diff View crash after inline comments

### DIFF
--- a/change-logs/2026/07/20/fix-diff-comment-split-crash.md
+++ b/change-logs/2026/07/20/fix-diff-comment-split-crash.md
@@ -1,0 +1,1 @@
+Prevented Diff View from crashing in split mode when a persisted inline comment exists on only one side of a row. Split rows and reopened reviews now tolerate the diff library's empty counterpart payload.

--- a/decisions/142-diff-extend-data-optional.md
+++ b/decisions/142-diff-extend-data-optional.md
@@ -1,0 +1,21 @@
+# 142 — Treat diff extension payloads as optional
+
+## Context
+
+`TaskDiffViewer` uses the diff library's extension renderer for local comments and GitHub review threads. In split mode the library renders both sides of a row to synchronize their heights, even when only one side owns extension data.
+
+## Investigation
+
+The crash report pointed to `.github` inside `renderExtendLine`. Inspection of `DiffSplitExtendLineNormal` showed that it calls the renderer with `currentExtend?.data` whenever either side has data, so `undefined` is a legitimate runtime value despite the library's non-optional generic type.
+
+## Decision
+
+Treat `ExtendLineData` as optional at the `TaskDiffViewer` callback boundary and guard both local and GitHub thread reads. The component test mock renders the empty split counterpart with `undefined`, matching the library contract that caused the crash.
+
+## Risks
+
+The empty counterpart now renders no extension content, which is the intended split-row behavior. If the library later tightens its contract, the optional guard remains harmless.
+
+## Alternatives considered
+
+Normalizing `extendData` cannot cover the mirrored callback because the missing value is created inside the library. Catching the render error or clearing persisted reviews would hide the defect and risk losing the user's comments.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1600,9 +1600,9 @@ function TaskDiffFileSection({
 								/>
 							);
 						}}
-						renderExtendLine={({ data, lineNumber, side }: { data: ExtendLineData; lineNumber: number; side: number }) => (
+						renderExtendLine={({ data, lineNumber, side }: { data?: ExtendLineData; lineNumber: number; side: number }) => (
 							<>
-								{data.github?.map((thread) => (
+								{data?.github?.map((thread) => (
 									<GithubThreadView
 										key={thread.id}
 										thread={thread}
@@ -1613,7 +1613,7 @@ function TaskDiffFileSection({
 										registerRef={registerCommentRef}
 									/>
 								))}
-								{data.local && (
+								{data?.local && (
 									<InlineCommentThreadView
 										thread={data.local}
 										side={getInlineCommentSideKey(side, diffLib.SplitSide)}

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -47,7 +47,7 @@ vi.mock("@git-diff-view/react", async () => {
 			diffViewAddWidget?: boolean;
 			diffViewHighlight?: boolean;
 			renderWidgetLine?: (props: { lineNumber: number; side: number; onClose: () => void; diffFile: object }) => React.ReactNode;
-			renderExtendLine?: (props: { lineNumber: number; side: number; data: unknown; onUpdate: () => void; diffFile: object }) => React.ReactNode;
+			renderExtendLine?: (props: { lineNumber: number; side: number; data?: unknown; onUpdate: () => void; diffFile: object }) => React.ReactNode;
 			extendData?: {
 				oldFile?: Record<string, { data: unknown }>;
 				newFile?: Record<string, { data: unknown }>;
@@ -143,15 +143,28 @@ vi.mock("@git-diff-view/react", async () => {
 							</div>
 						)}
 						{threadEntries.map((entry) => (
-							<div key={entry.key} data-testid="mock-extend">
-								{renderExtendLine?.({
-									diffFile: {},
-									side: entry.side,
-									lineNumber: entry.lineNumber,
-									data: entry.data,
-									onUpdate: () => {},
-								})}
-							</div>
+							<React.Fragment key={entry.key}>
+								<div data-testid="mock-extend">
+									{renderExtendLine?.({
+										diffFile: {},
+										side: entry.side,
+										lineNumber: entry.lineNumber,
+										data: entry.data,
+										onUpdate: () => {},
+									})}
+								</div>
+								{diffViewMode === 3 && (
+									<div data-testid="mock-empty-extend-counterpart">
+										{renderExtendLine?.({
+											diffFile: {},
+											side: entry.side === SplitSide.old ? SplitSide.new : SplitSide.old,
+											lineNumber: entry.lineNumber,
+											data: undefined,
+											onUpdate: () => {},
+										})}
+									</div>
+								)}
+							</React.Fragment>
 						))}
 					</div>
 				</div>
@@ -1777,6 +1790,38 @@ describe("TaskDiffViewer", () => {
 		await user.click(within(screen.getByTestId("inline-comment-thread")).getByRole("button", { name: "Delete comment" }));
 		expect(screen.queryByText("Comment 1")).not.toBeInTheDocument();
 		expect(screen.queryByText("Rename this callback.")).not.toBeInTheDocument();
+	});
+
+	it("keeps split view open when a comment has no extension data on the opposite side", async () => {
+		const user = userEvent.setup();
+		vi.mocked(api.request.getGlobalSettings).mockResolvedValue({
+			defaultAgentId: "builtin-claude",
+			defaultConfigId: "claude-default",
+			taskDropPosition: "top",
+			updateChannel: "stable",
+			defaultDiffViewMode: "split",
+		});
+
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		const diffs = await screen.findAllByTestId("mock-diff");
+		expect(diffs[0]).toHaveTextContent("mode:3");
+		await user.click(within(diffs[0]).getByRole("button", { name: "Open inline comment composer" }));
+		await user.type(screen.getByPlaceholderText("Leave a comment on this line..."), "one-sided comment");
+		await user.click(screen.getByRole("button", { name: "Add comment" }));
+
+		expect(screen.getAllByText("one-sided comment").length).toBeGreaterThan(0);
+		expect(screen.getAllByTestId("mock-empty-extend-counterpart").length).toBeGreaterThan(0);
+		expect(screen.getAllByTestId("mock-diff")).toHaveLength(2);
 	});
 
 	it("drag-selects a line range in the gutter and comments on the whole range", async () => {


### PR DESCRIPTION
## Summary

- tolerate the empty split-side payload emitted by `@git-diff-view/react`
- preserve persisted local and GitHub review threads without crashing Diff View
- add a regression test that mirrors the library one-sided extension behavior
- document the library contract and ship a changelog entry

## Root cause

In split mode, the diff library renders both halves of an extended row for height synchronization. When only one side has an inline comment, the opposite callback receives `data` as `undefined`, but `TaskDiffViewer` read `data.github` unconditionally.

## Test plan

- `bun run lint`
- `bun run test`
- browser QA: add an inline comment, switch to Split, leave and reopen Diff View; comments remain visible and no renderer error occurs