### PR TITLE
Fix terminal focus after copying text

### DIFF
--- a/change-logs/2026/07/20/fix-terminal-click-exit-copy-mode.md
+++ b/change-logs/2026/07/20/fix-terminal-click-exit-copy-mode.md
@@ -1,1 +1,1 @@
-After selecting terminal scrollback, the next plain click now exits tmux copy mode and restores live terminal input without requiring Escape. The selection drag itself still preserves the scrollback viewport instead of jumping to the bottom.
+Terminal input now resumes without Escape after copying text: a plain terminal click exits retained tmux copy mode, and Back to Terminal restores focus after selecting text in Diff. Scrollback selection still preserves the viewport instead of jumping to live output.

--- a/change-logs/2026/07/20/fix-terminal-click-exit-copy-mode.md
+++ b/change-logs/2026/07/20/fix-terminal-click-exit-copy-mode.md
@@ -1,0 +1,1 @@
+After selecting terminal scrollback, the next plain click now exits tmux copy mode and restores live terminal input without requiring Escape. The selection drag itself still preserves the scrollback viewport instead of jumping to the bottom.

--- a/decisions/139-keep-tmux-copy-mode-after-copy.md
+++ b/decisions/139-keep-tmux-copy-mode-after-copy.md
@@ -12,10 +12,12 @@ Both tmux copy-mode tables default `MouseDragEnd1Pane` to `copy-pipe-and-cancel`
 
 Override `MouseDragEnd1Pane` in both copy-mode tables in [`TMUX_CONFIG_FUNCTIONAL`](../src/bun/tmux/config.ts) with `send-keys -X copy-selection`. `set-clipboard on` continues to deliver the copied text through OSC 52, while the viewport remains at the selected scrollback position.
 
+[`TerminalView`](../src/mainview/TerminalView.tsx) records tmux-owned upward scrolling and drag gestures as possible copy-mode entry. The drag-generated click keeps the viewport in copy mode; the next distinct plain terminal click focuses Ghostty and invokes the existing `exitCopyModeAllPanes` RPC so live input resumes without a separate Escape press.
+
 ## Risks
 
-Mouse copying now leaves the pane in copy-mode, so the user must press Escape or scroll back to live output when finished reading history. Keyboard copy bindings and copying at the live terminal are unchanged.
+Copy mode remains active after the drag until the user clicks plainly, presses Escape, or scrolls back to live output. The renderer signal is deliberately conservative: a false positive only causes the existing best-effort reset RPC to find no pane in copy mode; modifier clicks and the click emitted by the drag itself never reset the viewport.
 
 ## Alternatives considered
 
-Preserving Ghostty's viewport around PTY writes operates above the tmux-owned scrollback and did not fix this gesture. `copy-selection-no-clear` would preserve the highlight unnecessarily, and keeping `copy-pipe-and-cancel` reproduces the jump by design.
+Preserving Ghostty's viewport around PTY writes operates above the tmux-owned scrollback and did not fix this gesture. `copy-selection-no-clear` would preserve the highlight unnecessarily, keeping `copy-pipe-and-cancel` reproduces the jump by design, and requiring Escape after every copy adds avoidable keyboard friction.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -234,6 +234,11 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 	const touchComposeModeRef = useRef(touchComposeMode ?? false);
 	touchComposeModeRef.current = touchComposeMode ?? false;
 	const copyDiagnosticsRef = useRef<TerminalCopyDiagnostics | null>(null);
+	// Mouse-copy keeps tmux copy mode alive so the scrollback viewport does not
+	// jump to live output. Remember when that mode may be active so the next
+	// plain click can return to live input without requiring Escape.
+	const tmuxCopyModeMayBeActiveRef = useRef(false);
+	const mouseGestureDraggedRef = useRef(false);
 	const [resolvedTheme, setResolvedTheme] = useState<"dark" | "light">(
 		() => (document.documentElement.dataset.theme as "dark" | "light") || "dark",
 	);
@@ -774,6 +779,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		function setupMouseTracking(term: Terminal): () => void {
 			const canvas = term.renderer!.getCanvas();
 			let trackedButton = -1;
+			let mouseDownX = 0;
+			let mouseDownY = 0;
 
 			function cellCoords(e: MouseEvent): [number, number] {
 				const rect = canvas.getBoundingClientRect();
@@ -829,6 +836,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					// TEMP DIAGNOSTIC: flag mouse-mode interception because it may block normal selection copy.
 					copyDiagnosticsRef.current?.markMouseTrackingIntercept(e.button);
 					trackedButton = e.button;
+					mouseDownX = e.clientX;
+					mouseDownY = e.clientY;
+					mouseGestureDraggedRef.current = false;
 					const [col, row] = cellCoords(e);
 					sgrMouse(e.button | altBit(e), col, row, true);
 					e.preventDefault();
@@ -845,6 +855,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					if (!term.hasMouseTracking()) return;
 					const [col, row] = cellCoords(e);
 					sgrMouse(btn | altBit(e), col, row, false);
+					if (btn === 0 && mouseGestureDraggedRef.current) {
+						tmuxCopyModeMayBeActiveRef.current = true;
+					}
 				} catch { /* disposed */ }
 			}
 
@@ -852,6 +865,12 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 				if (disposed) return;
 				try {
 					if (!term.hasMouseTracking() || trackedButton < 0) return;
+					if (
+						Math.abs(e.clientX - mouseDownX) > 3 ||
+						Math.abs(e.clientY - mouseDownY) > 3
+					) {
+						mouseGestureDraggedRef.current = true;
+					}
 					const [col, row] = cellCoords(e);
 					sgrMouse((trackedButton | altBit(e)) + 32, col, row, true);
 					e.stopPropagation();
@@ -942,6 +961,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					const lines = Math.trunc(scrollAccumulator / threshold);
 					if (lines !== 0) {
 						scrollAccumulator -= lines * threshold;
+						if (lines < 0) tmuxCopyModeMayBeActiveRef.current = true;
 						const code = lines < 0 ? 64 : 65;
 						const count = Math.abs(lines);
 						for (let i = 0; i < count; i++) {
@@ -1561,6 +1581,25 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		? LIGHT_TERMINAL_THEME.background
 		: DARK_TERMINAL_THEME.background;
 
+	function handleTerminalClick(event: React.MouseEvent<HTMLDivElement>) {
+		try { termRef.current?.focus(); } catch { /* disposed */ }
+		if (touchComposeModeRef.current) return;
+		if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+
+		// A browser may emit click after a drag. Keep the copy-mode viewport for
+		// that gesture; only the next distinct plain click means "resume input".
+		if (mouseGestureDraggedRef.current) {
+			mouseGestureDraggedRef.current = false;
+			return;
+		}
+		if (!tmuxCopyModeMayBeActiveRef.current) return;
+
+		tmuxCopyModeMayBeActiveRef.current = false;
+		api.request.exitCopyModeAllPanes({ taskId }).catch(() => {
+			// Best effort — the pane may already have returned to live input.
+		});
+	}
+
 	return (
 		<div ref={wrapperRef} className="relative w-full h-full min-h-0 overflow-hidden">
 			<div
@@ -1568,7 +1607,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 				className="w-full h-full overflow-hidden"
 				data-terminal="true"
 				style={{ backgroundColor: termBg }}
-				onClick={() => { try { termRef.current?.focus(); } catch { /* disposed */ } }}
+				onClick={handleTerminalClick}
 				onContextMenu={(e) => e.preventDefault()}
 				onDragOver={handleDragOver}
 				onDrop={handleDrop}

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,4 +1,4 @@
-import { render, act, waitFor } from "@testing-library/react";
+import { render, act, fireEvent, waitFor } from "@testing-library/react";
 import TerminalView, { buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
@@ -93,6 +93,7 @@ vi.mock("../rpc", () => ({
 			uploadFileBase64: vi.fn(),
 			tmuxAction: vi.fn(),
 			tmuxAltClickMoveCursor: vi.fn().mockResolvedValue({ moved: true }),
+			exitCopyModeAllPanes: vi.fn().mockResolvedValue({ panesExited: 1 }),
 			logRendererEvent: vi.fn().mockResolvedValue(undefined),
 			copyTerminalSelection: vi.fn().mockResolvedValue({ ok: true, tool: "pbcopy" }),
 		},
@@ -386,6 +387,7 @@ describe("TerminalView – focus-on-type", () => {
 const mockedTmuxAction = vi.mocked(api.request.tmuxAction);
 const mockedUploadFileBase64 = vi.mocked(api.request.uploadFileBase64);
 const mockedCopyTerminalSelection = vi.mocked(api.request.copyTerminalSelection);
+const mockedExitCopyModeAllPanes = vi.mocked(api.request.exitCopyModeAllPanes);
 
 /** Focus a child element inside the terminal container so the keymap guard passes. */
 function focusInsideTerminal(): HTMLElement {
@@ -643,6 +645,68 @@ describe("TerminalView – selection clipboard bridge", () => {
 		});
 
 		expect(mockedCopyTerminalSelection).not.toHaveBeenCalled();
+	});
+});
+
+describe("TerminalView – tmux copy-mode focus recovery", () => {
+	afterEach(() => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(false);
+	});
+
+	it("exits retained copy mode when the user next clicks the terminal", async () => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]') as HTMLElement;
+		const wheelHandler = mockTermInstance.attachCustomWheelEventHandler.mock.calls[0]?.[0] as
+			| ((event: WheelEvent) => boolean)
+			| undefined;
+
+		// Scrolling upward through a tmux-owned terminal enters copy mode.
+		act(() => {
+			wheelHandler?.({ deltaY: -100, clientX: 20, clientY: 20 } as WheelEvent);
+		});
+		mockedExitCopyModeAllPanes.mockClear();
+
+		fireEvent.click(terminal);
+
+		expect(mockFocus).toHaveBeenCalled();
+		expect(mockedExitCopyModeAllPanes).toHaveBeenCalledWith({ taskId: "t1" });
+	});
+
+	it("keeps copy mode after a drag and exits it on the following plain click", async () => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]') as HTMLElement;
+		const canvasListeners = mockTermInstance.renderer.getCanvas().addEventListener.mock.calls;
+		const mouseDown = canvasListeners.find((call: unknown[]) => call[0] === "mousedown")?.[1] as (event: MouseEvent) => void;
+		const mouseMove = canvasListeners.find((call: unknown[]) => call[0] === "mousemove")?.[1] as (event: MouseEvent) => void;
+		const event = (x: number, y: number) => ({
+			button: 0,
+			clientX: x,
+			clientY: y,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		}) as unknown as MouseEvent;
+
+		mockedExitCopyModeAllPanes.mockClear();
+		act(() => {
+			mouseDown(event(20, 20));
+			mouseMove(event(80, 40));
+			document.dispatchEvent(new MouseEvent("mouseup", { clientX: 80, clientY: 40 }));
+		});
+		// Browsers may emit click after a drag. That synthetic click must not
+		// cancel the copy mode that intentionally preserves the viewport.
+		fireEvent.click(terminal);
+		expect(mockedExitCopyModeAllPanes).not.toHaveBeenCalled();
+
+		act(() => {
+			mouseDown(event(40, 40));
+			document.dispatchEvent(new MouseEvent("mouseup", { clientX: 40, clientY: 40 }));
+		});
+		fireEvent.click(terminal);
+
+		expect(mockedExitCopyModeAllPanes).toHaveBeenCalledTimes(1);
+		expect(mockedExitCopyModeAllPanes).toHaveBeenCalledWith({ taskId: "t1" });
 	});
 });
 

--- a/src/mainview/components/TaskWorkspacePane.tsx
+++ b/src/mainview/components/TaskWorkspacePane.tsx
@@ -70,6 +70,8 @@ function TaskWorkspacePane({
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	const [artifactWidth, setArtifactWidth] = useState(initialArtifactWidth);
 	const [artifactResizing, setArtifactResizing] = useState(false);
+	const workspaceRef = useRef<HTMLDivElement>(null);
+	const inlineDiffWasOpenRef = useRef(false);
 	const artifactPanelRef = useRef<HTMLDivElement>(null);
 	const resizeSessionRef = useRef<ArtifactResizeSession | null>(null);
 	const showArtifact = artifactViewer?.taskId === taskId && !inlineDiffRequest;
@@ -167,8 +169,23 @@ function TaskWorkspacePane({
 		});
 	}, [skipCopyModeReset, taskId, terminalVisible]);
 
+	// The diff is an in-place overlay, so closing it reveals the already-mounted
+	// terminal instead of remounting it. Restore DOM focus explicitly; otherwise
+	// keyboard shortcuts such as Cmd+V stay on <body> and never reach ghostty.
+	useEffect(() => {
+		if (inlineDiffRequest) {
+			inlineDiffWasOpenRef.current = true;
+			return;
+		}
+		if (!inlineDiffWasOpenRef.current) return;
+		inlineDiffWasOpenRef.current = false;
+		workspaceRef.current
+			?.querySelector<HTMLElement>('[data-terminal="true"]')
+			?.focus({ preventScroll: true });
+	}, [inlineDiffRequest]);
+
 	return (
-		<div className="h-full w-full relative overflow-hidden">
+		<div ref={workspaceRef} className="h-full w-full relative overflow-hidden">
 			{artifactResizing && (
 				<div data-testid="artifact-resize-shield" aria-hidden="true" className="absolute inset-0 z-[60] cursor-col-resize" />
 			)}

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -47,7 +47,7 @@ vi.mock("../TaskTerminal", () => ({
 				unmountLog.push(taskId);
 			};
 		}, [taskId]);
-		return <div data-testid="terminal-view">terminal:{taskId}</div>;
+		return <div data-testid="terminal-view" data-terminal="true" tabIndex={0}>terminal:{taskId}</div>;
 	},
 }));
 
@@ -198,6 +198,29 @@ describe("TaskWorkspaceView", () => {
 		await waitFor(() => expect(screen.getByTestId("diff-viewer")).toBeInTheDocument());
 		expect(screen.getByTestId("diff-request")).toHaveAttribute("data-focus-unresolved", "true");
 		expect(screen.getByTestId("diff-request")).toHaveAttribute("data-compare-label", "origin/main");
+	});
+
+	it("restores terminal focus after closing the inline diff", async () => {
+		const user = userEvent.setup();
+
+		renderWorkspace(
+			<TaskWorkspaceView
+				projectId="p1"
+				taskId="t1"
+				tasks={[task]}
+				projects={[project]}
+				navigate={vi.fn()}
+				dispatch={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByText("Open Inline Diff"));
+		document.body.focus();
+		expect(document.activeElement).toBe(document.body);
+
+		await user.click(screen.getByText("Back"));
+
+		expect(document.activeElement).toBe(screen.getByTestId("terminal-view"));
 	});
 
 	it("shows a task artifact beside the terminal and closes it independently", async () => {


### PR DESCRIPTION
## Summary

- preserve tmux scrollback after mouse selection, then exit retained copy mode on the next plain terminal click
- restore focus to the visible terminal when Back to Terminal closes the in-place Diff overlay
- keep drag-generated and modifier clicks from disrupting the retained scrollback viewport
- add regression coverage for both tmux copy-mode and Diff-to-terminal focus handoff

## Testing

- `bun run lint`
- `bun run test`
- browser QA: selected and copied text in Diff, returned to Terminal, pressed `Cmd+V`, and verified the text appeared in the active ordinary tmux pane
- browser console: no errors