### PR TITLE
Strip hostile CLAUDE_CODE_DISABLE_MOUSE_CLICKS env var at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ The app runs as the **Electrobun desktop** shell **and** as a **headless remote 
 
 **All code-related content MUST be in English — no exceptions:** commit messages, changelog files (`change-logs/`), code comments and docstrings, decision records (`decisions/`), PR titles/descriptions, any text written inside source files. The user may communicate in Russian; everything written into the codebase or git history is English-only.
 
+## Code comments — self-documenting first
+
+**Aim for code that explains itself** (clear names, small functions) and add comments only where they earn their place. **Cap: a comment ≤ 3 lines.** The only exception is a genuinely weird, non-obvious use case (a workaround, a subtle invariant, a "why not the obvious thing") — those may go longer, and belong in a `decisions/NNN-*.md` record if substantial. Don't restate what the code already says, don't narrate obvious steps, don't leave changelog-style history in comments.
+
 ## Parallelism — TeamCreate over Agent tool (MANDATORY)
 
 When spawning agents for research, investigation, or parallel work — **use `TeamCreate`, not the `Agent` tool.** Team members run as independent peers with full tool access and are the correct delegation mechanism in this project. The only valid direct uses of `Agent`: a team member spawning a sub-agent for its own internal sub-task, or work so trivial (single file read, single grep) that a dedicated tool (`Read`, `Grep`, `Glob`) beats any delegation. If in doubt, use `TeamCreate`.

--- a/change-logs/2026/07/20/fix-strip-claude-mouse-env.md
+++ b/change-logs/2026/07/20/fix-strip-claude-mouse-env.md
@@ -1,0 +1,1 @@
+Strip the user-global CLAUDE_CODE_DISABLE_MOUSE_CLICKS environment variable at startup so it never propagates into dev3's tmux panes. When set by users it disabled Claude Code's mouse handling and broke click/drag text selection (copy) inside managed terminals; dev3 now neutralizes it for every spawned process.

--- a/decisions/143-strip-hostile-third-party-env-vars.md
+++ b/decisions/143-strip-hostile-third-party-env-vars.md
@@ -1,0 +1,23 @@
+# 143 — Strip hostile third-party env vars (CLAUDE_CODE_DISABLE_MOUSE_CLICKS)
+
+## Context
+
+Some users export `CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1` in their login shell for their own use of the Claude Code CLI. Inside dev3's managed tmux panes (`mouse on`, drag-to-copy bound in `src/bun/tmux/config.ts`) this var changes Claude Code's mouse handling so that click/drag text selection — i.e. copying — stops working. The variable has nothing to do with dev3; it just breaks us.
+
+## Investigation
+
+dev3 inherits the user's full login-shell environment via `resolveShellEnv()` → `applyFullShellEnvToProcess()` (`src/bun/shell-env.ts`), which injects `fullEnv` into `process.env`. Every spawned process then gets it, because `src/bun/spawn.ts` merges `{ ...process.env, ...opts.env }`, and the tmux/pty session (`src/bun/pty-server.ts`) spreads `process.env` too. So the var rode from `.zshrc` → dev3 `process.env` → tmux → Claude.
+
+## Decision
+
+Introduce `NEUTRALIZED_ENV_VARS` (a set) and `stripNeutralizedEnvVars(env)` in `src/bun/shell-env.ts`. `isDeniedEnvVar()` now also excludes these from `fullEnv` (login-shell path), and `applyFullShellEnvToProcess()` calls `stripNeutralizedEnvVars(process.env)` unconditionally at startup (covers the case where dev3 was launched from a terminal that already had the var, e.g. `bun run dev`, plus the `importShellEnv=false` / unresolved-shell paths). Both GUI (`index.ts`) and headless (`headless-entry.ts`) entrypoints already call `applyFullShellEnvToProcess`, so one chokepoint covers every spawn path (tmux, agents, scripts, git).
+
+## Risks
+
+- A tmux server started by an *older* dev3 build (before this fix) keeps the polluted var in its global environment; panes it spawns still inherit it. This is a one-time upgrade transient — resolved as soon as a fixed dev3 starts the tmux server. Not worth a `set-environment -gru` scrub.
+- The strip is global (all children), which is intended: no dev3 code path wants Claude's mouse clicks disabled.
+
+## Alternatives considered
+
+- Strip only in `pty-server.ts` at tmux spawn: misses agents/scripts and requires editing both `envFlags` and `processEnv`; fragile.
+- Add to `SHELL_ENV_DENYLIST` only: keeps `fullEnv` clean but does not remove the var from `process.env` when dev3 is launched from a terminal that already exports it.

--- a/src/bun/__tests__/shell-env.test.ts
+++ b/src/bun/__tests__/shell-env.test.ts
@@ -119,6 +119,72 @@ describe("shell environment bootstrap", () => {
 		expect(result.fullEnv).toEqual({ MY_TOKEN: "keep-me" });
 	});
 
+	it("never inherits neutralized third-party vars (CLAUDE_CODE_DISABLE_MOUSE_CLICKS) into fullEnv", async () => {
+		process.env.SHELL = "/bin/zsh";
+		spawnMock.mockReturnValue(fakeProc(nullEnv({
+			MY_TOKEN: "keep-me",
+			CLAUDE_CODE_DISABLE_MOUSE_CLICKS: "1",
+		})));
+
+		const { resolveShellEnv } = await import("../shell-env");
+		const result = await resolveShellEnv();
+
+		// The var breaks copy inside dev3's tmux panes — it must never ride into
+		// dev3 via the login shell.
+		expect(result.fullEnv).toEqual({ MY_TOKEN: "keep-me" });
+	});
+
+	describe("stripNeutralizedEnvVars", () => {
+		it("deletes CLAUDE_CODE_DISABLE_MOUSE_CLICKS in place and leaves other vars", async () => {
+			const { stripNeutralizedEnvVars } = await import("../shell-env");
+			const env: Record<string, string | undefined> = {
+				CLAUDE_CODE_DISABLE_MOUSE_CLICKS: "1",
+				KEEP: "yes",
+			};
+
+			stripNeutralizedEnvVars(env);
+
+			expect(env).toEqual({ KEEP: "yes" });
+			expect("CLAUDE_CODE_DISABLE_MOUSE_CLICKS" in env).toBe(false);
+		});
+
+		it("is a no-op when no neutralized var is present", async () => {
+			const { stripNeutralizedEnvVars } = await import("../shell-env");
+			const env: Record<string, string | undefined> = { KEEP: "yes" };
+
+			stripNeutralizedEnvVars(env);
+
+			expect(env).toEqual({ KEEP: "yes" });
+		});
+	});
+
+	describe("applyFullShellEnvToProcess", () => {
+		afterEach(() => {
+			delete process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS;
+		});
+
+		it("strips neutralized vars from process.env even when import is disabled", async () => {
+			process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS = "1";
+
+			const { applyFullShellEnvToProcess } = await import("../shell-env");
+			applyFullShellEnvToProcess({ fullEnv: { FOO: "bar" } }, false);
+
+			// importEnabled=false skips fullEnv injection, but neutralized vars are
+			// obliterated unconditionally.
+			expect(process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBeUndefined();
+			expect(process.env.FOO).toBeUndefined();
+		});
+
+		it("strips neutralized vars from process.env even when shell resolution returned nothing", async () => {
+			process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS = "1";
+
+			const { applyFullShellEnvToProcess } = await import("../shell-env");
+			applyFullShellEnvToProcess({}, true);
+
+			expect(process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBeUndefined();
+		});
+	});
+
 	it("preserves multiline and '=' containing env values", async () => {
 		process.env.SHELL = "/bin/zsh";
 		spawnMock.mockReturnValue(fakeProc(nullEnv({

--- a/src/bun/shell-env.ts
+++ b/src/bun/shell-env.ts
@@ -159,8 +159,23 @@ export const SHELL_ENV_DENYLIST = new Set<string>([
 // dev3's own task wiring and the bun runtime's internals.
 const SHELL_ENV_DENIED_PREFIXES = ["DEV3_", "BUN_"];
 
+// User-global env vars unrelated to dev3 that break our managed terminals; we
+// strip them everywhere (login-shell inheritance + our own process.env).
+export const NEUTRALIZED_ENV_VARS = new Set<string>([
+	// Claude Code disables mouse handling when set, breaking click/drag copy in
+	// dev3's tmux panes (which run `mouse on`).
+	"CLAUDE_CODE_DISABLE_MOUSE_CLICKS",
+]);
+
+export function stripNeutralizedEnvVars(env: Record<string, string | undefined>): void {
+	for (const key of NEUTRALIZED_ENV_VARS) {
+		delete env[key];
+	}
+}
+
 function isDeniedEnvVar(key: string): boolean {
 	if (SHELL_ENV_DENYLIST.has(key)) return true;
+	if (NEUTRALIZED_ENV_VARS.has(key)) return true;
 	return SHELL_ENV_DENIED_PREFIXES.some((prefix) => key.startsWith(prefix));
 }
 
@@ -275,6 +290,10 @@ export async function resolveShellEnv(): Promise<ResolvedShellEnv> {
  * to avoid duplicating the injection loop and its logging.
  */
 export function applyFullShellEnvToProcess(shellEnv: ResolvedShellEnv, importEnabled: boolean): void {
+	// Strip hostile third-party vars unconditionally — they can also arrive from
+	// the launch terminal (e.g. `bun run dev`), not just the login shell.
+	stripNeutralizedEnvVars(process.env);
+
 	if (!shellEnv.fullEnv) return;
 	if (importEnabled) {
 		let injected = 0;


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Some users export `CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1` in their login shell for their own use of the Claude Code CLI. Inside dev3's managed tmux panes (`mouse on`, drag-to-copy) that var changes Claude Code's mouse handling so click/drag text selection — i.e. copying — stops working. The variable is unrelated to dev3; it just breaks us.

Root cause: dev3 inherits the user's full login-shell env (`resolveShellEnv` → `applyFullShellEnvToProcess`) into `process.env`, and every spawned process picks it up because `spawn.ts` merges `{ ...process.env }`. So the var rode from `.zshrc` → dev3 → tmux → Claude.

## Fix

In `src/bun/shell-env.ts`:
- Add `NEUTRALIZED_ENV_VARS` (set) + `stripNeutralizedEnvVars(env)`.
- Exclude these vars from the inherited `fullEnv` via `isDeniedEnvVar` (login-shell path).
- Call `stripNeutralizedEnvVars(process.env)` unconditionally in `applyFullShellEnvToProcess`, which both entrypoints (`index.ts`, `headless-entry.ts`) already invoke — this also covers dev3 launched from a terminal that already exports the var (e.g. `bun run dev`).

One chokepoint covers every spawn path (tmux, agents, scripts, git). Added unit tests, decision record `143`, and a changelog entry.

Known transient: a tmux server started by an older dev3 build keeps the var in its global env until it's restarted by a fixed build — documented in decision 143.