### PR TITLE
Fix Kanban unresolved comments link

### DIFF
--- a/change-logs/2026/07/20/fix-kanban-unresolved-comments-link.md
+++ b/change-logs/2026/07/20/fix-kanban-unresolved-comments-link.md
@@ -1,0 +1,1 @@
+Make unresolved PR comment counts on Kanban cards open the selected task's branch diff and focus the first unresolved review thread, honoring the user's split or fullscreen task-open preference.

--- a/decisions/143-kanban-unresolved-comments-deep-link.md
+++ b/decisions/143-kanban-unresolved-comments-deep-link.md
@@ -1,0 +1,21 @@
+# 143 — Carry Kanban unresolved-comment intent through task navigation
+
+## Context
+
+Task view PR popovers already open the inline branch diff at the first unresolved GitHub review thread. Kanban card popovers had no active diff surface, so their unresolved-comment row remained informational.
+
+## Investigation
+
+Selecting a task changes the `useTaskInlineDiffState` key and clears any request opened before navigation completes. The board must therefore carry a one-shot intent through the route transition while preserving the configured split/fullscreen task-open mode.
+
+## Decision
+
+Add the transient `openUnresolvedComments` route flag and consume it once in `ProjectView` or `TaskWorkspaceView`, using the shared `createUnresolvedCommentsDiffRequest` helper. Keep the existing popover row and `onShowUnresolved` callback as the only new wiring surface.
+
+## Risks
+
+The flag is part of route history, so returning to a deep-link route can reopen the diff by design. A per-route task key prevents manual diff close from immediately reopening it.
+
+## Alternatives considered
+
+Opening the GitHub PR URL would not match the existing Task view behavior. A timeout or global event would be race-prone across the route transition, so the route intent is explicit and testable.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2412,6 +2412,7 @@ function App() {
 				artifactViewer={null}
 				onCloseArtifactViewer={closeArtifactViewer}
 				skipCopyModeReset={skipTerminalCopyReset}
+				openUnresolvedComments={route.screen === "task" ? route.openUnresolvedComments : undefined}
 			/>
 		);
 	}
@@ -2448,6 +2449,7 @@ function App() {
 						isTerminalFullscreen={terminalImmersiveVisible}
 						onToggleTerminalFullscreen={toggleTerminalImmersive}
 						skipCopyModeReset={skipTerminalCopyReset}
+						openUnresolvedComments={route.openUnresolvedComments}
 					/>
 				);
 			case "project-terminal": {
@@ -2477,6 +2479,7 @@ function App() {
 						isTerminalFullscreen={terminalImmersiveVisible}
 						onToggleTerminalFullscreen={toggleTerminalImmersive}
 						skipCopyModeReset={skipTerminalCopyReset}
+						openUnresolvedComments={route.openUnresolvedComments}
 					/>
 				);
 			case "project-settings":

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -35,6 +35,7 @@ interface KanbanBoardProps {
 	taskResourceUsage?: Map<string, ResourceUsage>;
 	activeTaskId?: string;
 	disableGlobalFindShortcut?: boolean;
+	onOpenUnresolvedComments?: (task: Task) => void;
 }
 
 type PRIdentity = Pick<TaskPRBadgeInfo, "number" | "url">;
@@ -103,6 +104,7 @@ function KanbanBoard({
 	taskResourceUsage,
 	activeTaskId,
 	disableGlobalFindShortcut = false,
+	onOpenUnresolvedComments,
 }: KanbanBoardProps) {
 	const t = useT();
 	const isCarousel = useNarrowViewport(CAROUSEL_MAX_WIDTH);
@@ -615,6 +617,7 @@ function KanbanBoard({
 		siblingMap,
 		onSetMoving: handleSetMoving,
 		taskPrMap,
+		onOpenUnresolvedComments,
 	};
 
 	function renderColumnElement(slot: ColumnSlot, full: boolean) {

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -61,6 +61,7 @@ interface KanbanColumnProps {
 	onColumnDrop?: (side: "before" | "after") => void;
 	// PR numbers for task cards
 	taskPrMap?: Map<string, TaskPRBadgeInfo>;
+	onOpenUnresolvedComments?: (task: Task) => void;
 	// Feature discovery tip
 	tip?: Tip | null;
 	tipState?: TipState;
@@ -108,6 +109,7 @@ function KanbanColumn({
 	onSetMoving,
 	siblingMap,
 	taskPrMap,
+	onOpenUnresolvedComments,
 	isCustomColumn,
 	customColumnId,
 	colorOverride,
@@ -606,6 +608,7 @@ function KanbanColumn({
 							onSetMoving={onSetMoving}
 							siblingMap={siblingMap}
 							prInfo={taskPrMap?.get(task.id)}
+							onOpenUnresolvedComments={onOpenUnresolvedComments}
 						/>
 					</div>
 				))}

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, type Dispatch, type MutableRefObject } from "react";
+import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject } from "react";
 import type { CodingAgent, PortInfo, Project, SharedArtifact, Task, ResourceUsage } from "../../shared/types";
-import type { AppAction, Route } from "../state";
+import { getTaskOpenMode, type AppAction, type Route } from "../state";
 import type { NavigationGuard } from "../navigation-guard";
 import { api, isElectrobun } from "../rpc";
 import KanbanBoard from "./KanbanBoard";
@@ -10,7 +10,7 @@ import ActiveTasksSidebar from "./ActiveTasksSidebar";
 import { useState } from "react";
 import { useT } from "../i18n";
 import TaskWorkspacePane from "./TaskWorkspacePane";
-import { useTaskInlineDiffState } from "./task-inline-diff";
+import { createUnresolvedCommentsDiffRequest, useTaskInlineDiffState } from "./task-inline-diff";
 import { trackDiffView } from "../analytics";
 import { taskSeqLabel } from "../../shared/types";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
@@ -34,6 +34,7 @@ interface ProjectViewProps {
 	isTerminalFullscreen?: boolean;
 	onToggleTerminalFullscreen?: () => void;
 	skipCopyModeReset?: boolean;
+	openUnresolvedComments?: boolean;
 }
 
 function ProjectView({
@@ -54,6 +55,7 @@ function ProjectView({
 	isTerminalFullscreen,
 	onToggleTerminalFullscreen,
 	skipCopyModeReset,
+	openUnresolvedComments,
 }: ProjectViewProps) {
 	const t = useT();
 	const project = projects.find((p) => p.id === projectId);
@@ -61,6 +63,15 @@ function ProjectView({
 	const inlineDiff = useTaskInlineDiffState(activeTaskId);
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	const taskUpdateEpochRef = useRef(0);
+	const unresolvedRouteKeyRef = useRef<string | null>(null);
+
+	const openUnresolvedFromBoard = useCallback((task: Task) => {
+		if (getTaskOpenMode() === "fullscreen") {
+			navigate({ screen: "task", projectId, taskId: task.id, openUnresolvedComments: true });
+		} else {
+			navigate({ screen: "project", projectId, activeTaskId: task.id, openUnresolvedComments: true });
+		}
+	}, [navigate, projectId]);
 
 	// A scheduled launch can push its new task while this view's initial fetch is
 	// in flight. Keep the live update instead of letting the older disk snapshot
@@ -103,6 +114,20 @@ function ProjectView({
 		trackDiffView(projectId, task ? taskSeqLabel(task) : activeTaskId);
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per open
 	}, [inlineDiff.isOpen, projectId, activeTaskId]);
+
+	useEffect(() => {
+		if (!openUnresolvedComments) {
+			unresolvedRouteKeyRef.current = null;
+			return;
+		}
+		if (!activeTaskId || !project) return;
+		const task = tasks.find((candidate) => candidate.id === activeTaskId);
+		if (!task) return;
+		const routeKey = `${project.id}:${task.id}`;
+		if (unresolvedRouteKeyRef.current === routeKey) return;
+		unresolvedRouteKeyRef.current = routeKey;
+		inlineDiff.open(createUnresolvedCommentsDiffRequest(task, project));
+	}, [activeTaskId, inlineDiff.open, openUnresolvedComments, project, tasks]);
 
 	if (!project) {
 		return (
@@ -215,6 +240,7 @@ function ProjectView({
 				bellReasons={bellReasons}
 				taskPorts={taskPorts}
 				taskResourceUsage={taskResourceUsage}
+				onOpenUnresolvedComments={openUnresolvedFromBoard}
 			/>
 		</div>
 	);

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -52,9 +52,11 @@ interface TaskCardProps {
 	onSetMoving?: (taskId: string, isMoving: boolean) => void;
 	siblingMap?: Map<string, Task[]>;
 	prInfo?: TaskPRBadgeInfo;
+	/** Opens the selected task's diff at its first unresolved review thread. */
+	onOpenUnresolvedComments?: (task: Task) => void;
 }
 
-function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, bellReasons, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo }: TaskCardProps) {
+function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, bellReasons, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo, onOpenUnresolvedComments }: TaskCardProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const [moving, setMoving] = useState(false);
@@ -406,8 +408,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 	const displayTitle = getTaskTitle(task);
 	const hasLongDescription = task.description !== displayTitle;
+	const openUnresolvedInDiff = onOpenUnresolvedComments
+		? () => onOpenUnresolvedComments(task)
+		: undefined;
 	const prBadge = prInfo ? (
-		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id}>
+		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
 			<button
 				type="button"
 				onClick={(e) => {
@@ -437,7 +442,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	};
 	const ciMeta = prInfo?.ciStatus ? CI_BADGE[prInfo.ciStatus] : null;
 	const ciBadge = ciMeta ? (
-		<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id}>
+		<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
 			<button
 				type="button"
 				onClick={(e) => {
@@ -454,7 +459,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	) : null;
 	const reviewMeta = prInfo?.reviewState ? REVIEW_BADGE[prInfo.reviewState] : null;
 	const reviewBadge = reviewMeta ? (
-		<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id}>
+		<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
 			<button
 				type="button"
 				onClick={(e) => {
@@ -470,7 +475,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	) : null;
 	const unresolvedCount = prInfo?.unresolvedCount ?? 0;
 	const commentBadge = prInfo && unresolvedCount > 0 ? (
-		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id}>
+		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
 			<button
 				type="button"
 				onClick={(e) => {

--- a/src/mainview/components/TaskWorkspaceView.tsx
+++ b/src/mainview/components/TaskWorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { Dispatch, MutableRefObject } from "react";
 import type { Project, SharedArtifact, Task } from "../../shared/types";
 import type { AppAction, Route } from "../state";
@@ -6,7 +6,7 @@ import type { NavigationGuard } from "../navigation-guard";
 import { api } from "../rpc";
 import TaskInfoPanel from "./TaskInfoPanel";
 import TaskWorkspacePane from "./TaskWorkspacePane";
-import { useTaskInlineDiffState } from "./task-inline-diff";
+import { createUnresolvedCommentsDiffRequest, useTaskInlineDiffState } from "./task-inline-diff";
 import { trackDiffView } from "../analytics";
 import { taskSeqLabel } from "../../shared/types";
 
@@ -24,6 +24,7 @@ interface TaskWorkspaceViewProps {
 	isTerminalFullscreen?: boolean;
 	onToggleTerminalFullscreen?: () => void;
 	skipCopyModeReset?: boolean;
+	openUnresolvedComments?: boolean;
 }
 
 function TaskWorkspaceView({
@@ -40,10 +41,12 @@ function TaskWorkspaceView({
 	isTerminalFullscreen,
 	onToggleTerminalFullscreen,
 	skipCopyModeReset,
+	openUnresolvedComments,
 }: TaskWorkspaceViewProps) {
 	const task = tasks.find((item) => item.id === taskId);
 	const project = projects.find((item) => item.id === projectId);
 	const inlineDiff = useTaskInlineDiffState(taskId);
+	const unresolvedRouteKeyRef = useRef<string | null>(null);
 
 	// The fullscreen task view can be entered for a task whose project's tasks
 	// were never loaded into `currentProjectTasks` — e.g. quick-shell jumps
@@ -76,6 +79,18 @@ function TaskWorkspaceView({
 		trackDiffView(projectId, task ? taskSeqLabel(task) : taskId);
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per open
 	}, [inlineDiff.isOpen, projectId, taskId]);
+
+	useEffect(() => {
+		if (!openUnresolvedComments) {
+			unresolvedRouteKeyRef.current = null;
+			return;
+		}
+		if (!task || !project) return;
+		const routeKey = `${project.id}:${task.id}`;
+		if (unresolvedRouteKeyRef.current === routeKey) return;
+		unresolvedRouteKeyRef.current = routeKey;
+		inlineDiff.open(createUnresolvedCommentsDiffRequest(task, project));
+	}, [inlineDiff.open, openUnresolvedComments, project, task]);
 
 	return (
 		<div className="flex-1 min-h-0 flex flex-col">

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -116,6 +116,7 @@ async function renderBoardWith(props: Partial<React.ComponentProps<typeof Kanban
 					navigate={props.navigate ?? vi.fn()}
 					bellCounts={props.bellCounts ?? new Map()}
 					taskPorts={props.taskPorts ?? new Map()}
+					onOpenUnresolvedComments={props.onOpenUnresolvedComments}
 				/>
 			</I18nProvider>,
 		);
@@ -207,6 +208,36 @@ describe("column ordering", () => {
 		} finally {
 			result.unmount();
 			vi.mocked(api.request.getProjectPRs).mockResolvedValue([]);
+		}
+	});
+
+	it("wires unresolved comments from a card to the board deep-link handler", async () => {
+		const onOpenUnresolvedComments = vi.fn();
+		const task = makeTask({
+			status: "review-by-colleague",
+			worktreePath: "/tmp/wt",
+			prStatusCache: {
+				number: 42,
+				url: "https://github.com/test/repo/pull/42",
+				autoMergeEnabled: null,
+				ciStatus: null,
+				reviewState: null,
+				reviewDecision: null,
+				unresolvedCount: 2,
+				mergeState: null,
+				checks: [],
+				prTitle: null,
+				isDraft: false,
+				cachedAt: "2026-07-15T12:00:00.000Z",
+			},
+		});
+		const result = await renderBoardWith({ tasks: [task], onOpenUnresolvedComments });
+		try {
+			await userEvent.hover(screen.getByLabelText("2 unresolved comments"));
+			await userEvent.click(await screen.findByTestId("pr-popover-unresolved"));
+			expect(onOpenUnresolvedComments).toHaveBeenCalledWith(expect.objectContaining({ id: "task-1" }));
+		} finally {
+			result.unmount();
 		}
 	});
 

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Project, Task } from "../../../shared/types";
 import { I18nProvider } from "../../i18n";
@@ -10,10 +11,22 @@ vi.mock("../../rpc", () => ({
 }));
 
 // Heavy children — stub so the test focuses on ProjectView's own layout logic.
-vi.mock("../KanbanBoard", () => ({ default: () => <div data-testid="kanban" /> }));
+vi.mock("../KanbanBoard", () => ({
+	default: ({ onOpenUnresolvedComments }: { onOpenUnresolvedComments?: (task: Task) => void }) => (
+		<div data-testid="kanban">
+			<button type="button" data-testid="open-unresolved-from-board" onClick={() => onOpenUnresolvedComments?.({ id: "t1" } as Task)} />
+		</div>
+	),
+}));
 vi.mock("../TaskInfoPanel", () => ({ default: () => <div data-testid="info-panel" /> }));
 vi.mock("../ActiveTasksSidebar", () => ({ default: () => <div data-testid="sidebar" /> }));
-vi.mock("../TaskWorkspacePane", () => ({ default: () => <div data-testid="workspace" /> }));
+vi.mock("../TaskWorkspacePane", () => ({
+	default: ({ inlineDiffRequest }: { inlineDiffRequest?: { focusFirstUnresolvedThread?: boolean } }) => (
+		<div data-testid="workspace">
+			{inlineDiffRequest?.focusFirstUnresolvedThread && <span data-testid="workspace-unresolved-diff" />}
+		</div>
+	),
+}));
 vi.mock("../SplitLayout", () => ({
 	default: (props: { kanbanContent: React.ReactNode; terminalContent: React.ReactNode }) => (
 		<div>
@@ -53,7 +66,10 @@ function renderView(props: Partial<React.ComponentProps<typeof ProjectView>>) {
 }
 
 describe("ProjectView task-view layout", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.removeItem("dev3-task-open-mode");
+	});
 
 	it("does not replace a pushed scheduled task with an older initial task snapshot", async () => {
 		let resolveTasks: (tasks: Task[]) => void;
@@ -95,6 +111,42 @@ describe("ProjectView task-view layout", () => {
 		await waitFor(() => expect(screen.getByTestId("kanban")).toBeInTheDocument());
 		expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
 		expect(screen.queryByText("Select a task to see its terminal")).not.toBeInTheDocument();
+	});
+
+	it("opens unresolved comments from Kanban in the configured split task route", async () => {
+		const navigate = vi.fn();
+		renderView({ navigate });
+
+		await userEvent.click(screen.getByTestId("open-unresolved-from-board"));
+
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "project",
+			projectId: "p1",
+			activeTaskId: "t1",
+			openUnresolvedComments: true,
+		});
+	});
+
+	it("uses the fullscreen task route when that open mode is configured", async () => {
+		localStorage.setItem("dev3-task-open-mode", "fullscreen");
+		const navigate = vi.fn();
+		renderView({ navigate });
+
+		await userEvent.click(screen.getByTestId("open-unresolved-from-board"));
+
+		expect(navigate).toHaveBeenCalledWith({
+			screen: "task",
+			projectId: "p1",
+			taskId: "t1",
+			openUnresolvedComments: true,
+		});
+	});
+
+	it("opens the inline diff when the split route carries the unresolved-comments flag", async () => {
+		const task = { id: "t1", projectId: "p1", title: "T", status: "in-progress", baseBranch: "main", branchName: "feature/t1" } as unknown as Task;
+		renderView({ activeTaskId: "t1", tasks: [task], openUnresolvedComments: true });
+
+		await waitFor(() => expect(screen.getByTestId("workspace-unresolved-diff")).toBeInTheDocument());
 	});
 });
 

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -160,6 +160,7 @@ function renderCard(
 		isMoving?: boolean;
 		projectOverride?: Project;
 		prInfo?: TaskPRBadgeInfo;
+		onOpenUnresolvedComments?: (task: Task) => void;
 		siblingMap?: Map<string, Task[]>;
 	},
 ) {
@@ -179,6 +180,7 @@ function renderCard(
 				isActiveInSplit={opts?.isActiveInSplit}
 				isMoving={opts?.isMoving}
 				prInfo={opts?.prInfo}
+				onOpenUnresolvedComments={opts?.onOpenUnresolvedComments}
 				siblingMap={opts?.siblingMap}
 			/>
 		</I18nProvider>,
@@ -1549,6 +1551,23 @@ describe("TaskCard", () => {
 			expect(screen.getByRole("link", { name: "Open details for build" })).toHaveAttribute("href", "https://ci/build");
 			await userEvent.click(screen.getByRole("button", { name: "Refresh PR status" }));
 			expect(mockedApi.request.refreshTaskPrStatus).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1" });
+		});
+
+		it("deep-links unresolved comments through the board callback", async () => {
+			const onOpenUnresolvedComments = vi.fn();
+			renderCard(reviewTask(), {
+				prInfo: {
+					number: 12,
+					url: "https://example/pr/12",
+					unresolvedCount: 3,
+				},
+				onOpenUnresolvedComments,
+			});
+
+			await userEvent.hover(screen.getByLabelText("3 unresolved comments"));
+			await userEvent.click(await screen.findByTestId("pr-popover-unresolved"));
+
+			expect(onOpenUnresolvedComments).toHaveBeenCalledWith(expect.objectContaining({ id: "t1" }));
 		});
 
 		it("sorts failed checks first and shows merge conflicts in the popover", async () => {

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -52,9 +52,10 @@ vi.mock("../TaskTerminal", () => ({
 }));
 
 vi.mock("../TaskDiffViewer", () => ({
-	default: ({ onBack, request }: { onBack: () => void; request: { mode: string } }) => (
+	default: ({ onBack, request }: { onBack: () => void; request: { mode: string; focusFirstUnresolvedThread?: boolean; compareRef?: string; compareLabel?: string } }) => (
 		<div data-testid="diff-viewer">
 			<div>{request.mode}</div>
+			<div data-testid="diff-request" data-focus-unresolved={request.focusFirstUnresolvedThread ? "true" : "false"} data-compare-ref={request.compareRef ?? ""} data-compare-label={request.compareLabel ?? ""} />
 			<button onClick={onBack}>Back</button>
 		</div>
 	),
@@ -179,6 +180,24 @@ describe("TaskWorkspaceView", () => {
 
 		expect(screen.queryByTestId("diff-viewer")).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+	});
+
+	it("opens the branch diff at unresolved comments when deep-linked from Kanban", async () => {
+		renderWorkspace(
+			<TaskWorkspaceView
+				projectId="p1"
+				taskId="t1"
+				tasks={[task]}
+				projects={[project]}
+				navigate={vi.fn()}
+				dispatch={vi.fn()}
+				openUnresolvedComments
+			/>,
+		);
+
+		await waitFor(() => expect(screen.getByTestId("diff-viewer")).toBeInTheDocument());
+		expect(screen.getByTestId("diff-request")).toHaveAttribute("data-focus-unresolved", "true");
+		expect(screen.getByTestId("diff-request")).toHaveAttribute("data-compare-label", "origin/main");
 	});
 
 	it("shows a task artifact beside the terminal and closes it independently", async () => {

--- a/src/mainview/components/task-inline-diff.ts
+++ b/src/mainview/components/task-inline-diff.ts
@@ -1,4 +1,4 @@
-import type { TaskDiffMode } from "../../shared/types";
+import { resolveTaskCompareBaseBranch, type Project, type Task, type TaskDiffMode } from "../../shared/types";
 import { useCallback, useEffect, useState } from "react";
 
 export interface TaskInlineDiffRequest {
@@ -9,6 +9,25 @@ export interface TaskInlineDiffRequest {
 	/** Scroll to the first unresolved GitHub review thread once the branch diff
 	 * and the PR comment payload have both loaded (PR status popover deep link). */
 	focusFirstUnresolvedThread?: boolean;
+}
+
+/** Build the branch-diff request used by PR popover unresolved-comment links. */
+export function createUnresolvedCommentsDiffRequest(
+	task: Pick<Task, "baseBranch" | "branchName">,
+	project: Pick<Project, "defaultBaseBranch" | "defaultCompareRef" | "defaultCompareRefMode">,
+): TaskInlineDiffRequest {
+	const baseBranch = resolveTaskCompareBaseBranch(task, project);
+	const projectBaseBranch = project.defaultBaseBranch || "main";
+	const compareRef = baseBranch !== projectBaseBranch
+		? baseBranch
+		: project.defaultCompareRef || (project.defaultCompareRefMode === "local" ? baseBranch : undefined);
+
+	return {
+		mode: "branch",
+		compareRef,
+		compareLabel: compareRef || `origin/${baseBranch}`,
+		focusFirstUnresolvedThread: true,
+	};
 }
 
 export function useTaskInlineDiffState(taskId?: string) {

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -19,9 +19,9 @@ export const OPEN_SETTINGS_SECTION_EVENT = "dev3:openSettingsSection";
 
 export type Route =
 	| { screen: "dashboard" }
-	| { screen: "project"; projectId: string; activeTaskId?: string; taskView?: boolean }
+	| { screen: "project"; projectId: string; activeTaskId?: string; taskView?: boolean; openUnresolvedComments?: boolean }
 	| { screen: "project-terminal"; projectId: string }
-	| { screen: "task"; projectId: string; taskId: string }
+	| { screen: "task"; projectId: string; taskId: string; openUnresolvedComments?: boolean }
 	| { screen: "project-settings"; projectId: string; tab?: "global" | "project" | "worktree" | "automations"; worktreeTaskId?: string }
 	| { screen: "settings"; section?: SettingsSectionId }
 	| { screen: "changelog" }


### PR DESCRIPTION
## Summary

- Make unresolved PR comment rows in Kanban card popovers open the task diff.
- Preserve split/fullscreen task-open mode and focus the first unresolved review thread.
- Add regression coverage, an architectural decision record, and a changelog entry.

## Testing

- `bun run lint`
- `bun run test`
- Browser QA completed with no console errors.