### PR TITLE
Fix Launch modal preselecting a cross-provider default config

### DIFF
--- a/change-logs/2026/07/20/fix-launch-modal-default-config-mismatch.md
+++ b/change-logs/2026/07/20/fix-launch-modal-default-config-mismatch.md
@@ -1,0 +1,1 @@
+Fixed the Launch Task modal preselecting a broken default when the saved global default config belonged to a different provider than the default provider (which left the Mode field empty and the launch inert). The picker now falls back to the provider's own default, matching the Spawn Agent and Bug Hunters surfaces.

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -70,8 +70,14 @@ function LaunchVariantsModal({
 			agentId = agent.id;
 		}
 
+		// Settings resolution can pair defaultAgentId with a defaultConfigId from a
+		// *different* provider (stale builtin id reset to the Claude default); using
+		// it verbatim renders an empty Mode. Guard it like Spawn/Bug Hunters.
+		const globalConfigMatchesAgent =
+			!!globalSettings.defaultConfigId &&
+			!!agent?.configurations.some((c) => c.id === globalSettings.defaultConfigId);
 		const configId =
-			globalSettings.defaultConfigId ??
+			(globalConfigMatchesAgent ? globalSettings.defaultConfigId : null) ??
 			agent?.defaultConfigId ??
 			agent?.configurations[0]?.id ??
 			null;

--- a/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
+++ b/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
@@ -243,6 +243,20 @@ describe("LaunchVariantsModal", () => {
 			expect(getSelectedText(getModelButtons()[0])).toBe("Default");
 			expect(getSelectedText(getModeButtons()[0])).toBe("Alpha");
 		});
+
+		it("ignores a global defaultConfigId that belongs to another provider (no empty Mode)", () => {
+			// Reproduces the broken preselect: settings resolution can leave
+			// defaultAgentId (Codex) paired with a defaultConfigId from a different
+			// provider (a Claude preset) after a stale builtin id is reset. The
+			// picker must fall back to the provider's own default instead of a
+			// dangling config that renders an empty Mode field.
+			const gs = makeGlobalSettings({ defaultAgentId: "builtin-codex", defaultConfigId: "claude-bypass-opus" });
+			renderModal(makeProject(), { globalSettings: gs });
+
+			expect(getSelectedText(getProviderButtons()[0])).toBe("Codex");
+			expect(getSelectedText(getModelButtons()[0])).toBe("GPT-5.5");
+			expect(getSelectedText(getModeButtons()[0])).toBe("Default (Heavy Bypass)");
+		});
 	});
 
 	describe("cascade dropdown population", () => {


### PR DESCRIPTION
## Summary

The **Launch Task** modal could preselect a broken default combo — the Mode field rendered empty and the launch did nothing (see the reported screenshot: Provider=Codex, Model=GPT-5.6 Luna, Mode=blank).

Root cause: `makeDefaultVariant()` in `LaunchVariantsModal` used `globalSettings.defaultConfigId` verbatim, without checking it belongs to the resolved provider. Settings resolution (`resolveDefaultConfigId` in `settings.ts`) can reset a stale builtin `defaultConfigId` to the Claude default **without** touching `defaultAgentId`, producing a cross-provider mismatch (e.g. agent=Codex, config=`claude-*`). The dangling config then resolves to no Model group, leaving Mode empty and the spawn inert.

The fix guards the config to the resolved agent and falls back to the provider's own default — the exact guard already used by `SpawnAgentModal` and `BugHuntersLightbox`, so all three launch surfaces now preselect consistently.

Note: favorites (`GlobalSettings.favorites`) and the agent list (`getAgents`) are both global, not per-project — no per-project mechanism exists.

Added a regression test reproducing the empty-Mode case (red → green). `lint` clean; full `bun run test` green.