### PR TITLE
Fix task search over-matching on short/numeric queries

### DIFF
--- a/change-logs/2026/07/20/fix-task-search-substring.md
+++ b/change-logs/2026/07/20/fix-task-search-substring.md
@@ -1,0 +1,1 @@
+Fixed the Kanban filter bar and Active Tasks sidebar matching almost every task for short or numeric queries. Free-text search now requires each typed word to literally occur in a task's title or description (substring, any order) instead of a loose fuzzy subsequence, so a query like "1172" finds the task you meant rather than everything with those digits scattered around.

--- a/decisions/144-task-search-substring-not-fuzzy.md
+++ b/decisions/144-task-search-substring-not-fuzzy.md
@@ -1,0 +1,21 @@
+# 144 — Task search free-text uses substring, not fuzzy subsequence
+
+## Context
+
+The Kanban filter bar and Active Tasks sidebar run `matchesTaskQuery` (`src/mainview/utils/taskSearch.ts`) as a boolean filter. Its free-text step (`matchesFreeText`) used `fuzzyScore(q, ...).matched` — the fzf-style subsequence matcher from `fuzzyMatch.ts` — against both title and the full description.
+
+## Investigation
+
+`fuzzyScore().matched` only means "the query is a subsequence of the target", ignoring the score. Over long descriptions (some 13 k+ chars) almost any short/numeric query is a subsequence: against real data (1264 tasks) `"1172"` matched 171 tasks and `"abc"` matched 509. A ranking scorer meant for short candidate lists was wired in as a hard filter over long text.
+
+## Decision
+
+`matchesFreeText` now does a plain, case-insensitive **substring AND across whitespace-separated words** over `title + description`; every word must occur literally. Fuzzy matching is removed from the filter path (import dropped). Post-fix `"1172"` matches 1 task, `"abc"` matches 3. `fuzzyMatch.ts` is unchanged and still powers the quick-switch palette, where subsequence ranking over short project/task names is the right tool.
+
+## Risks
+
+Typo tolerance in the filter is gone (`fxbug` no longer finds "Fix authentication bug"). Accepted: the filter bar is a filter, not a ranker, and predictable substring behavior is what users expect from it.
+
+## Alternatives considered
+
+Score threshold on the fuzzy match (fragile to tune across query/target lengths); title-fuzzy + description-substring hybrid (two code paths, title still over-matches); word-token/BM25 filter (overkill for a boolean predicate).

--- a/src/mainview/utils/__tests__/taskSearch.test.ts
+++ b/src/mainview/utils/__tests__/taskSearch.test.ts
@@ -44,7 +44,7 @@ function ctx(overrides: Partial<TaskQueryContext> = {}): TaskQueryContext {
 	};
 }
 
-describe("matchesTaskQuery — free text (fuzzy/identifier, unchanged behavior)", () => {
+describe("matchesTaskQuery — free text (substring/identifier)", () => {
 	it("returns true for empty query", () => {
 		expect(matchesTaskQuery(makeTask(), "", ctx())).toBe(true);
 	});
@@ -57,8 +57,15 @@ describe("matchesTaskQuery — free text (fuzzy/identifier, unchanged behavior)"
 		expect(matchesTaskQuery(makeTask({ title: "Fix auth bug" }), "auth", ctx())).toBe(true);
 	});
 
-	it("matches title by fuzzy subsequence (non-contiguous)", () => {
-		expect(matchesTaskQuery(makeTask({ title: "Fix authentication bug" }), "fxbug", ctx())).toBe(true);
+	it("does NOT match a non-contiguous subsequence (fuzzy is off for the filter)", () => {
+		// "fxbug" is a subsequence of "Fix authentication bug" but not a substring.
+		expect(matchesTaskQuery(makeTask({ title: "Fix authentication bug" }), "fxbug", ctx())).toBe(false);
+	});
+
+	it("ANDs whitespace-separated words across title + description (any order)", () => {
+		const t = makeTask({ title: "Fix login", description: "session expires early" });
+		expect(matchesTaskQuery(t, "login session", ctx())).toBe(true);
+		expect(matchesTaskQuery(t, "login absent", ctx())).toBe(false);
 	});
 
 	it("does not match unrelated title/description", () => {
@@ -75,6 +82,21 @@ describe("matchesTaskQuery — free text (fuzzy/identifier, unchanged behavior)"
 				ctx(),
 			),
 		).toBe(true);
+	});
+
+	it("regression: a numeric query does not match scattered digits in a long description", () => {
+		// Bug: fuzzy subsequence matching found "1","1","7","2" scattered across a
+		// long description, so "1172" matched nearly every task. Substring filtering
+		// must reject this and only match a literal occurrence (or the seq prefix).
+		const scattered = makeTask({
+			seq: 42,
+			title: "Unrelated task",
+			description: "Started at 10:15, revised 7 times, closes issue #2 by day 1.",
+		});
+		expect(matchesTaskQuery(scattered, "1172", ctx())).toBe(false);
+
+		const literal = makeTask({ seq: 42, title: "Port work", description: "Depends on task #1172 landing first." });
+		expect(matchesTaskQuery(literal, "1172", ctx())).toBe(true);
 	});
 
 	it("matches by seq prefix and with # prefix", () => {

--- a/src/mainview/utils/taskSearch.ts
+++ b/src/mainview/utils/taskSearch.ts
@@ -1,6 +1,5 @@
 import type { Task } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
-import { fuzzyScore } from "./fuzzyMatch";
 
 /**
  * Token-DSL task search & filter engine.
@@ -177,9 +176,16 @@ export function parseTaskQuery(query: string): ParsedQuery {
 }
 
 /**
- * Free-text matcher (title/description fuzzy + seq/UUID/PR prefix). This is the
- * previous `matchesSearchQuery` behavior, now the internal free-text step of
- * `matchesTaskQuery`. All comparisons are case-insensitive.
+ * Free-text matcher (title/description substring + seq/UUID/PR prefix), the
+ * internal free-text step of `matchesTaskQuery`. All comparisons are
+ * case-insensitive.
+ *
+ * Text matching is a plain substring AND across whitespace-separated words over
+ * `title + description`: every word must literally occur somewhere in the task.
+ * Fuzzy subsequence matching is deliberately NOT used here — as a filter over
+ * long descriptions it matched almost any short/numeric query (a query like
+ * "1172" found its scattered digits in nearly every task). Fuzzy ranking still
+ * lives where it belongs, in the quick-switch palette (`fuzzyMatch.ts`).
  */
 function matchesFreeText(task: Task, freeText: string, prNumber?: number | null): boolean {
 	const q = freeText.trim().toLowerCase();
@@ -187,8 +193,9 @@ function matchesFreeText(task: Task, freeText: string, prNumber?: number | null)
 
 	const qNormalized = q.startsWith("#") ? q.slice(1) : q;
 
-	if (fuzzyScore(q, getTaskTitle(task)).matched) return true;
-	if (fuzzyScore(q, task.description).matched) return true;
+	const haystack = `${getTaskTitle(task)}\n${task.description ?? ""}`.toLowerCase();
+	const words = q.split(/\s+/).filter(Boolean);
+	if (words.length > 0 && words.every((w) => haystack.includes(w))) return true;
 
 	const seqStr = String(task.seq);
 	if (seqStr.startsWith(qNormalized)) return true;


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The Kanban filter bar and Active Tasks sidebar matched almost every task for short or numeric queries. `matchesFreeText` (`src/mainview/utils/taskSearch.ts`) used the fzf-style **fuzzy subsequence** matcher's `.matched` flag over the full (often 10k+ char) description, so any short query found its characters scattered somewhere. Measured against real data (1264 tasks): `1172` matched **171** tasks, `abc` matched **509**.

This replaces fuzzy subsequence in the free-text filter with a case-insensitive **substring AND across whitespace-separated words** over `title + description` — every typed word must literally occur in the task. Fuzzy ranking is untouched and still powers the Cmd/Ctrl+K quick-switch palette, where subsequence matching over short names is the right tool.

After the fix: `1172` → **1** task, `abc` → **3**, junk queries → **0**. Seq/UUID/PR prefix matching is unchanged.

Trade-off: the filter no longer tolerates typos (`fxbug` won't find "Fix authentication bug"). Accepted — a filter bar should be predictable; see `decisions/144-task-search-substring-not-fuzzy.md`.

Regression test added (numeric query must not match scattered digits); the old fuzzy-subsequence test was inverted to assert the new behavior. Full test suite green.