### PR TITLE
Fix active-tasks split hidden in wide remote mode

### DIFF
--- a/change-logs/2026/07/20/fix-remote-active-tasks-sidebar-wide-viewport.md
+++ b/change-logs/2026/07/20/fix-remote-active-tasks-sidebar-wide-viewport.md
@@ -1,0 +1,1 @@
+Fix the active-tasks split view disappearing in remote (browser) mode on wide screens: the task workspace now shows the ActiveTasksSidebar/SplitLayout whenever the viewport is wide (≥768px), whether desktop or remote, and only hides it on narrow mobile viewports.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -4,6 +4,12 @@ Compact index of UX architecture decisions — the *why* behind rules that live 
 `PRODUCT_UX_BIBLE.md` / `ux-architecture.yaml`. Max ~5 lines per entry; details live in
 git history, PRs, and `decisions/NNN-*.md`. Newest first.
 
+## 2026-07-20 — Active-tasks split is gated by viewport width, not browser mode
+
+- **Rule:** The task workspace shows the standard `SplitLayout` + `ActiveTasksSidebar` on wide viewports (≥768px) in **both** desktop and remote/browser mode; only narrow (<768px, mobile) viewports drop it for a full-width terminal.
+- **Why:** The 2026-07-19 strip removal over-reached — folding all browser mode into the narrow branch also hid the sidebar on wide remote screens, where there is ample room for it (`SplitLayout` only breaks ~<600px). The persistent `ActiveTasksStrip` stays gone; this only restores the sidebar for wide browsers.
+- **Status:** Implemented. Evidence: `ProjectView.tsx` (`isNarrow`-only gate), `useNarrowViewport.ts`.
+
 ## 2026-07-19 — Remove the persistent browser active-task strip
 
 - **Rule:** Browser task workspaces keep the terminal full-width without a persistent `ActiveTasksStrip`; task switching uses the existing task-switcher overlay and breadcrumb → board navigation.

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject } 
 import type { CodingAgent, PortInfo, Project, SharedArtifact, Task, ResourceUsage } from "../../shared/types";
 import { getTaskOpenMode, type AppAction, type Route } from "../state";
 import type { NavigationGuard } from "../navigation-guard";
-import { api, isElectrobun } from "../rpc";
+import { api } from "../rpc";
 import KanbanBoard from "./KanbanBoard";
 import TaskInfoPanel from "./TaskInfoPanel";
 import SplitLayout from "./SplitLayout";
@@ -139,7 +139,6 @@ function ProjectView({
 
 	if (activeTaskId || taskView) {
 		const activeTask = activeTaskId ? tasks.find((t) => t.id === activeTaskId) : undefined;
-		const isBrowserMode = !isElectrobun;
 
 		// Terminal pane: a selected task shows its workspace; otherwise (task-view
 		// reached via a project switch with no task picked yet) an empty placeholder.
@@ -164,10 +163,11 @@ function ProjectView({
 			</div>
 		);
 
-		// Browser and narrow viewports keep the terminal full-width. Task switching
-		// remains available through the breadcrumb/board and task-switcher overlay;
-		// do not add a persistent task strip above the terminal.
-		if (isNarrow || isBrowserMode) {
+		// Narrow (mobile) viewports keep the terminal full-width — there is no room
+		// for the active-tasks split. Task switching stays available via the
+		// breadcrumb/board carousel and the task-switcher overlay. Wide viewports
+		// (desktop and remote/browser alike) get the standard SplitLayout below.
+		if (isNarrow) {
 			return (
 				<div className="flex-1 min-h-0 flex flex-col">
 					{activeTask && (

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -5,9 +5,14 @@ import type { Project, Task } from "../../../shared/types";
 import { I18nProvider } from "../../i18n";
 import ProjectView from "../ProjectView";
 
+// Mutable so a test can flip to remote/browser mode; a getter proves the layout
+// no longer branches on it (regression guard for #992 over-hiding the sidebar).
+const rpcMock = vi.hoisted(() => ({ isElectrobun: true }));
 vi.mock("../../rpc", () => ({
 	api: { request: { getTasks: vi.fn().mockResolvedValue([]), getAgents: vi.fn().mockResolvedValue([]) } },
-	isElectrobun: true,
+	get isElectrobun() {
+		return rpcMock.isElectrobun;
+	},
 }));
 
 // Heavy children — stub so the test focuses on ProjectView's own layout logic.
@@ -68,6 +73,7 @@ function renderView(props: Partial<React.ComponentProps<typeof ProjectView>>) {
 describe("ProjectView task-view layout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		rpcMock.isElectrobun = true;
 		localStorage.removeItem("dev3-task-open-mode");
 	});
 
@@ -104,6 +110,14 @@ describe("ProjectView task-view layout", () => {
 		renderView({ activeTaskId: "t1", tasks: [task] });
 		await waitFor(() => expect(screen.getByTestId("workspace")).toBeInTheDocument());
 		expect(screen.queryByText("Select a task to see its terminal")).not.toBeInTheDocument();
+	});
+
+	it("keeps the active-tasks sidebar in remote/browser mode on a wide viewport", async () => {
+		rpcMock.isElectrobun = false;
+		const task = { id: "t1", projectId: "p1", title: "T", status: "in-progress" } as unknown as Task;
+		renderView({ activeTaskId: "t1", tasks: [task] });
+		await waitFor(() => expect(screen.getByTestId("sidebar")).toBeInTheDocument());
+		expect(screen.getByTestId("workspace")).toBeInTheDocument();
 	});
 
 	it("renders only the Kanban board when neither activeTaskId nor taskView is set", async () => {
@@ -156,6 +170,7 @@ describe("ProjectView narrow viewport (mobile zoom)", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		rpcMock.isElectrobun = true;
 		Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
 		Object.defineProperty(window, "matchMedia", {
 			configurable: true,
@@ -183,5 +198,13 @@ describe("ProjectView narrow viewport (mobile zoom)", () => {
 		await waitFor(() => expect(screen.getByTestId("workspace")).toBeInTheDocument());
 		expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
 		expect(screen.getByTestId("info-panel")).toBeInTheDocument();
+	});
+
+	it("still hides the sidebar in remote/browser mode when the viewport is narrow", async () => {
+		rpcMock.isElectrobun = false;
+		const task = { id: "t1", projectId: "p1", title: "T", status: "in-progress" } as unknown as Task;
+		renderView({ activeTaskId: "t1", tasks: [task] });
+		await waitFor(() => expect(screen.getByTestId("workspace")).toBeInTheDocument());
+		expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Hi — Claude here (the AI assistant working on this branch).

## Summary

In remote (browser) mode the active-tasks split view (`SplitLayout` + `ActiveTasksSidebar`) disappeared even on wide, desktop-sized screens — only the full-width terminal showed.

Root cause: PR #992 ("Remove remote active task strip") folded **all** browser mode into the narrow branch to drop the persistent `ActiveTasksStrip`, which also hid the sidebar on wide remote viewports.

This gates the full-width-terminal layout on viewport width (`isNarrow`, <768px) **only**, so wide viewports get the standard split whether desktop or remote/browser; narrow (mobile) still hides it. The removed horizontal `ActiveTasksStrip` stays gone.

- `ProjectView.tsx`: drop the `isBrowserMode` (`!isElectrobun`) coupling from the layout gate.
- Regression tests: wide browser mode shows the sidebar; narrow browser mode still hides it (mutable `isElectrobun` mock guards against re-coupling).
- `docs/ux/UX_DECISIONS.md`: 2026-07-20 entry refining the #992 decision.
- Browser-QA'd at 1440×900 (sidebar restored) and 390×844 (still hidden), no console errors.