### PR TITLE
fix: show branch-merged dialog only once, respect cancel

### DIFF
--- a/change-logs/2026/04/05/fix-branch-merged-dialog-once.md
+++ b/change-logs/2026/04/05/fix-branch-merged-dialog-once.md
@@ -1,0 +1,1 @@
+The "branch merged" confirm dialog is now shown at most once per task. A module-level set shared between `App.tsx` and `useTaskBranchStatus` deduplicates across both the push-event path and the 15-second polling path. Cancelling the dialog permanently suppresses it for that task — it will not reappear on re-mounts or subsequent events.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -20,6 +20,7 @@ import GhWarningBanner, { isGhWarningDismissed } from "./components/GhWarningBan
 import Changelog from "./components/Changelog";
 import GaugeDemo from "./components/gauges/GaugeDemo";
 import ViewportLab from "./components/ViewportLab";
+import { shownMergeDialogTasks } from "./components/task-info-panel/useTaskBranchStatus";
 
 const SKIP_QUIT_DIALOG_KEY = "dev3-skip-quit-dialog";
 
@@ -284,6 +285,8 @@ function App() {
 				taskTitle: string;
 				branchName: string;
 			};
+			if (shownMergeDialogTasks.has(taskId)) return;
+			shownMergeDialogTasks.add(taskId);
 			let shouldComplete = false;
 			try {
 				shouldComplete = await api.request.showConfirm({

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../App";
 import { I18nProvider } from "../i18n";
+import { shownMergeDialogTasks } from "../components/task-info-panel/useTaskBranchStatus";
 
 vi.mock("../rpc", () => ({
 	api: {
@@ -12,6 +13,8 @@ vi.mock("../rpc", () => ({
 			quitApp: vi.fn().mockResolvedValue(undefined),
 			hideApp: vi.fn().mockResolvedValue(undefined),
 			listTmuxSessions: vi.fn().mockResolvedValue([]),
+			showConfirm: vi.fn().mockResolvedValue(false),
+			moveTask: vi.fn().mockResolvedValue(undefined),
 		},
 	},
 }));
@@ -71,6 +74,7 @@ vi.mock("../components/ProjectTerminal", () => ({
 
 import { api } from "../rpc";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
+const mockedShowConfirm = vi.mocked(api.request.showConfirm);
 
 const mockedAdjustZoom = vi.mocked(adjustZoom);
 const mockedApplyZoom = vi.mocked(applyZoom);
@@ -89,9 +93,11 @@ async function renderApp() {
 describe("App keyboard shortcuts", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		shownMergeDialogTasks.clear();
 		vi.mocked(api.request.checkSystemRequirements).mockResolvedValue([]);
 		vi.mocked(api.request.getProjects).mockResolvedValue([]);
 		vi.mocked(api.request.listTmuxSessions).mockResolvedValue([]);
+		mockedShowConfirm.mockResolvedValue(false);
 	});
 
 	describe("quit (Cmd+Q / Ctrl+Q)", () => {
@@ -371,6 +377,50 @@ describe("App keyboard shortcuts", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Session Expired")).toBeInTheDocument();
 			});
+		});
+	});
+
+	describe("branchMerged deduplication", () => {
+		const mergedPayload = {
+			taskId: "task-abc",
+			projectId: "proj-1",
+			taskTitle: "My Feature",
+			branchName: "feat/my-feature",
+		};
+
+		it("shows the confirm dialog on the first rpc:branchMerged event", async () => {
+			await renderApp();
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: mergedPayload }));
+			});
+			await waitFor(() => expect(mockedShowConfirm).toHaveBeenCalledTimes(1));
+		});
+
+		it("does not show the dialog a second time for the same task", async () => {
+			await renderApp();
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: mergedPayload }));
+			});
+			await waitFor(() => expect(mockedShowConfirm).toHaveBeenCalledTimes(1));
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: mergedPayload }));
+			});
+			// Still only 1 call — the second event was suppressed
+			expect(mockedShowConfirm).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not show the dialog again after the user cancels", async () => {
+			mockedShowConfirm.mockResolvedValue(false); // user clicks Cancel
+			await renderApp();
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: mergedPayload }));
+			});
+			await waitFor(() => expect(mockedShowConfirm).toHaveBeenCalledTimes(1));
+			// Fire again — should be suppressed
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: mergedPayload }));
+			});
+			expect(mockedShowConfirm).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -5,6 +5,11 @@ import { api } from "../../rpc";
 import { useT } from "../../i18n";
 import { trackEvent } from "../../analytics";
 
+// Module-level set tracking tasks whose merge dialog has already been shown
+// (regardless of the user's choice). Persists across re-mounts so that
+// cancel is respected and duplicate dialogs are suppressed.
+export const shownMergeDialogTasks = new Set<string>();
+
 interface UseTaskBranchStatusParams {
 	task: Task;
 	project: Project;
@@ -28,7 +33,6 @@ export function useTaskBranchStatus({
 	const [creatingPR, setCreatingPR] = useState(false);
 	const [refreshingStatus, setRefreshingStatus] = useState(false);
 	const pushThenCreatePRRef = useRef(false);
-	const mergeDialogShownRef = useRef(false);
 	const fetchStatusRef = useRef<(() => Promise<void>) | null>(null);
 
 	const baseBranch = task.baseBranch || project.defaultBaseBranch || "main";
@@ -76,7 +80,6 @@ export function useTaskBranchStatus({
 			return;
 		}
 
-		mergeDialogShownRef.current = false;
 		let cancelled = false;
 		let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -94,9 +97,9 @@ export function useTaskBranchStatus({
 					if (
 						status.mergedByContent &&
 						task.status === "review-by-user" &&
-						!mergeDialogShownRef.current
+						!shownMergeDialogTasks.has(task.id)
 					) {
-						mergeDialogShownRef.current = true;
+						shownMergeDialogTasks.add(task.id);
 						const shouldComplete = await api.request.showConfirm({
 							title: t("app.branchMergedTitle"),
 							message: t("app.branchMergedMessage", {


### PR DESCRIPTION
## Problem

The "branch merged — complete the task?" confirm dialog could appear multiple times for the same task: both the `branchMerged` push event (App.tsx) and the 15-second polling loop (`useTaskBranchStatus`) could trigger it independently, and the per-hook `useRef` guard reset on every re-mount. Clicking Cancel didn't stop it from asking again.

## Fix

A module-level `Set` (`shownMergeDialogTasks`) shared between `App.tsx` and `useTaskBranchStatus` deduplicates across both paths. The task is marked before the dialog is shown, so cancelling suppresses the dialog for the rest of the session — re-mounts and duplicate events are silently ignored.

## Tests

Added App.test.tsx cases: dialog shows on first `rpc:branchMerged` event, is suppressed on a duplicate event, and stays suppressed after the user cancels. `bun run lint` and `bun run test` pass (1952 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)