### PR TITLE
Fix remote/browser multi-line paste submitting after the first line

### DIFF
--- a/change-logs/2026/07/20/fix-remote-multiline-paste-early-submit.md
+++ b/change-logs/2026/07/20/fix-remote-multiline-paste-early-submit.md
@@ -1,0 +1,1 @@
+Fixed multi-line paste (Ctrl+V) in the browser/remote terminal submitting after the first line — most visible on Windows where the clipboard carries CRLF. Text pastes now always route through ghostty's bracketed-paste path with newlines normalized to CR, instead of falling onto ghostty's raw container-focus paste handler.

--- a/decisions/145-terminal-paste-always-bracketed.md
+++ b/decisions/145-terminal-paste-always-bracketed.md
@@ -1,0 +1,48 @@
+# 145 — Route terminal text paste through one bracketed path
+
+## Context
+
+In remote/browser mode a multi-line `Ctrl+V` submitted after the first line
+(reported on Windows, where the clipboard carries `CRLF`). Multi-line text meant
+to land in a draft (e.g. Claude Code) was executed line-by-line.
+
+## Investigation
+
+ghostty-web has **two** paste handlers:
+
+- On the textarea (`ghostty-web.js` ~L2368): calls `term.paste()`, which wraps in
+  DEC 2004 bracketed paste when the app enabled it.
+- On the container / `InputHandler.handlePaste` (~L963): fires `onDataCallback(raw)`
+  — the **raw** clipboard bytes, ignoring bracketed-paste mode entirely.
+
+`Terminal.focus()` (~L2446) focuses the **container** (the contenteditable div),
+not the textarea. On desktop/remote `TerminalView` calls `term.focus()` after fit
+and on every click, so the container holds focus — which routes paste onto the raw
+handler. Raw `\r\n`/`\n` then reads as Enter, submitting after the first line.
+Confirmed live: with the container focused, the outgoing PTY bytes carried the
+raw newlines.
+
+## Decision
+
+`TerminalView`'s own capture-phase `paste` listener (`src/mainview/TerminalView.tsx`,
+`onPaste`) now handles ordinary text too: `preventDefault()` +
+`stopImmediatePropagation()` (pre-empting both ghostty handlers, since ours is
+registered first), then `term.paste(normalizePastedText(text))`.
+`normalizePastedText` collapses `CRLF`/`CR`/`LF` to lone `CR` (xterm.js
+convention). Image and large-text attachment paths are unchanged.
+
+## Risks
+
+Relies on our listener being registered before ghostty's — guaranteed because
+`setup()` (which calls `term.open()`) is deferred behind an async `document.fonts.load()`,
+while the `onPaste` effect runs synchronously on mount. If a future refactor makes
+setup synchronous, `stopImmediatePropagation()` would no longer pre-empt ghostty's
+raw handler.
+
+## Alternatives considered
+
+- Patch ghostty-web's `handlePaste` to bracket — rejected: editing vendored
+  `node_modules` is not durable across reinstalls.
+- Force focus onto the hidden textarea so the bracketed handler always wins —
+  rejected: fragile against the many `term.focus()` / click focus paths, and does
+  not fix Electrobun desktop.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1526,8 +1526,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		return () => window.removeEventListener(ZOOM_CHANGED_EVENT, onZoomChanged);
 	}, []);
 
-	// Intercept paste events containing images or large text blocks (clipboard → save to disk → inject path into PTY).
-	// Small text pastes are unaffected — the event propagates to ghostty-web as usual.
+	// Intercept ALL paste events: images / large text blocks are saved to disk and
+	// their path injected into the PTY; ordinary text goes through term.paste()
+	// (bracketed, CR-normalized) — never ghostty's raw container handler.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1591,10 +1591,14 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			// listener before ghostty's, so stopImmediatePropagation() pre-empts both
 			// of its handlers and gives one deterministic, bracketed path.
 			if (!text) return;
-			e.preventDefault();
-			e.stopImmediatePropagation();
+			// Check the terminal BEFORE swallowing the event: during PTY
+			// recreation termRef is briefly null while this listener is still
+			// attached. Suppressing then bailing would silently drop the paste —
+			// leave it for whatever handler is present instead.
 			const term = termRef.current;
 			if (!term) return;
+			e.preventDefault();
+			e.stopImmediatePropagation();
 			try {
 				term.paste(normalizePastedText(text));
 			} catch {

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -154,6 +154,14 @@ export function buildCursorMoveSequence(
 	return (dCol > 0 ? "\x1b[C" : "\x1b[D").repeat(Math.abs(dCol));
 }
 
+// Normalize pasted line endings to lone CR, matching xterm.js. A real Enter is
+// CR (\r), so a paste carrying CRLF (Windows) or LF (Unix) must collapse to CR;
+// otherwise the stray bytes read as extra line breaks (or, on the raw paste
+// path, as a submit after the first line). Exported for unit testing.
+export function normalizePastedText(text: string): string {
+	return text.replace(/\r\n|\r|\n/g, "\r");
+}
+
 // ghostty-web 0.4.0 never invalidates the selection when the terminal content
 // changes. A selection goes stale whenever the app OWNS THE SCREEN and repaints
 // cells in place instead of scrolling the buffer — the highlight is anchored to
@@ -1533,45 +1541,64 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 		}
 
 		function onPaste(e: ClipboardEvent) {
-			const items = e.clipboardData?.items;
+			const clip = e.clipboardData;
+			const text = clip?.getData("text/plain") ?? "";
 
-			let hasImage = false;
-			if (items) {
-				for (let i = 0; i < items.length; i++) {
-					if (items[i].type.startsWith("image/")) {
-						hasImage = true;
-						break;
+			// Attachments (images / large text) need a project to upload into.
+			if (projectId) {
+				let hasImage = false;
+				const items = clip?.items;
+				if (items) {
+					for (let i = 0; i < items.length; i++) {
+						if (items[i].type.startsWith("image/")) {
+							hasImage = true;
+							break;
+						}
 					}
+				}
+
+				if (hasImage) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					api.request.pasteClipboardImage({ projectId }).then((result) => {
+						if (result) sendPathToPty(result.path);
+					}).catch((err) => {
+						console.error("[TerminalView] Image paste failed:", err);
+					});
+					return;
+				}
+
+				// Large text paste → save to a .txt file and inject its path instead of
+				// streaming the whole block into the PTY.
+				if (isLargeTextPaste(text)) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					uploadPastedText(projectId, text).then((path) => {
+						if (path) sendPathToPty(path);
+					}).catch((err) => {
+						console.error("[TerminalView] Large text paste failed:", err);
+					});
+					return;
 				}
 			}
 
-			// No project context (e.g. home terminal) — attachments are unsupported,
-			// let the default text paste behavior run.
-			if (!projectId) return;
-
-			if (hasImage) {
-				e.preventDefault();
-				e.stopPropagation();
-				api.request.pasteClipboardImage({ projectId }).then((result) => {
-					if (result) sendPathToPty(result.path);
-				}).catch((err) => {
-					console.error("[TerminalView] Image paste failed:", err);
-				});
-				return;
-			}
-
-			// Large text paste → save to a .txt file and inject its path instead of
-			// streaming the whole block into the PTY.
-			const text = e.clipboardData?.getData("text/plain") ?? "";
-			if (!isLargeTextPaste(text)) return;
-
+			// Ordinary text paste: route it through ghostty's bracketed paste
+			// explicitly. ghostty-web has TWO paste handlers — the textarea one wraps
+			// in DEC 2004, but the container one (hit when term.focus() puts focus on
+			// the contenteditable div, i.e. desktop/remote) sends the raw clipboard
+			// bytes. Raw CRLF/LF then submits after the first line. We register this
+			// listener before ghostty's, so stopImmediatePropagation() pre-empts both
+			// of its handlers and gives one deterministic, bracketed path.
+			if (!text) return;
 			e.preventDefault();
-			e.stopPropagation();
-			uploadPastedText(projectId, text).then((path) => {
-				if (path) sendPathToPty(path);
-			}).catch((err) => {
-				console.error("[TerminalView] Large text paste failed:", err);
-			});
+			e.stopImmediatePropagation();
+			const term = termRef.current;
+			if (!term) return;
+			try {
+				term.paste(normalizePastedText(text));
+			} catch {
+				// Terminal disposed mid-paste — nothing to do.
+			}
 		}
 
 		container.addEventListener("paste", onPaste, { capture: true });

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -973,6 +973,31 @@ describe("TerminalView – paste routing", () => {
 		expect(preventDefault).not.toHaveBeenCalled();
 	});
 
+	it("does not swallow a paste while the terminal is still initializing (no term yet)", async () => {
+		// Never resolve fonts.load() → setup() never runs → termRef stays null,
+		// but the capture-phase paste listener is already attached on mount. This
+		// mirrors the brief PTY-recreation gap; the event must NOT be swallowed.
+		Object.defineProperty(document, "fonts", {
+			configurable: true,
+			value: { load: vi.fn().mockReturnValue(new Promise(() => {})) },
+		});
+
+		let result!: ReturnType<typeof render>;
+		await act(async () => {
+			result = render(
+				<I18nProvider>
+					<TerminalView ptyUrl="ws://localhost:1234" taskId="t1" projectId="p1" />
+				</I18nProvider>,
+			);
+		});
+		const terminal = result.container.querySelector('[data-terminal="true"]')!;
+
+		const { preventDefault } = dispatchPaste(terminal, "hello");
+
+		expect(mockPaste).not.toHaveBeenCalled();
+		expect(preventDefault).not.toHaveBeenCalled();
+	});
+
 	it("still diverts image pastes to the attachment uploader (not term.paste)", async () => {
 		mockedPasteClipboardImage.mockResolvedValue({ path: "/tmp/uploads/pic.png" } as any);
 		const { container } = await renderAndSetup();

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, fireEvent, waitFor } from "@testing-library/react";
-import TerminalView, { buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite } from "../TerminalView";
+import TerminalView, { buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
 import { KEYMAP_LS_KEY } from "../terminal-keymaps";
@@ -9,6 +9,7 @@ import { KEYMAP_LS_KEY } from "../terminal-keymaps";
 const {
 	mockFocus,
 	mockInput,
+	mockPaste,
 	mockTermInstance,
 	mockBufferActive,
 	mockOnDataDispose,
@@ -18,6 +19,7 @@ const {
 } = vi.hoisted(() => {
 	const mockFocus = vi.fn();
 	const mockInput = vi.fn();
+	const mockPaste = vi.fn();
 	const mockOnDataDispose = vi.fn();
 	const mockOnResizeDispose = vi.fn();
 	const mockOnSelectionChangeDispose = vi.fn();
@@ -36,6 +38,7 @@ const {
 		open: vi.fn(),
 		focus: mockFocus,
 		input: mockInput,
+		paste: mockPaste,
 		buffer: { active: mockBufferActive },
 		onData: vi.fn(() => ({ dispose: mockOnDataDispose })),
 		onResize: vi.fn(() => ({ dispose: mockOnResizeDispose })),
@@ -64,6 +67,7 @@ const {
 	return {
 		mockFocus,
 		mockInput,
+		mockPaste,
 		mockCanvas,
 		mockTermInstance,
 		mockBufferActive,
@@ -98,6 +102,7 @@ vi.mock("../rpc", () => ({
 	api: {
 		request: {
 			uploadFileBase64: vi.fn(),
+			pasteClipboardImage: vi.fn(),
 			tmuxAction: vi.fn(),
 			tmuxAltClickMoveCursor: vi.fn().mockResolvedValue({ moved: true }),
 			exitCopyModeAllPanes: vi.fn().mockResolvedValue({ panesExited: 1 }),
@@ -892,6 +897,125 @@ describe("TerminalView – disposal safety (no 'Terminal has been disposed' erro
 		}).not.toThrow();
 
 		mockFocus.mockReset();
+	});
+});
+
+// ── Paste routing — always bracketed, never raw CRLF (remote/Windows) ────────
+
+const mockedPasteClipboardImage = vi.mocked(api.request.pasteClipboardImage);
+
+function dispatchPaste(
+	target: Element,
+	text: string,
+	items: Array<{ type: string }> = [],
+) {
+	const event = new Event("paste", { bubbles: true, cancelable: true });
+	Object.defineProperty(event, "clipboardData", {
+		value: {
+			getData: (type: string) => (type === "text/plain" ? text : ""),
+			items,
+		},
+	});
+	const preventDefault = vi.spyOn(event, "preventDefault");
+	const stopImmediate = vi.spyOn(event, "stopImmediatePropagation");
+	act(() => {
+		target.dispatchEvent(event);
+	});
+	return { event, preventDefault, stopImmediate };
+}
+
+describe("TerminalView – paste routing", () => {
+	beforeEach(() => {
+		mockPaste.mockClear();
+		mockedPasteClipboardImage.mockReset();
+		mockedUploadFileBase64.mockReset();
+	});
+
+	it("routes a multi-line CRLF paste through bracketed term.paste with CR line endings", async () => {
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		const { preventDefault, stopImmediate } = dispatchPaste(terminal, "line1\r\nline2\r\nline3");
+
+		// Fix: single bracketed path, newlines collapsed to CR — never the raw
+		// container path that would submit after "line1".
+		expect(mockPaste).toHaveBeenCalledWith("line1\rline2\rline3");
+		expect(preventDefault).toHaveBeenCalled();
+		// Must pre-empt BOTH ghostty paste handlers on the same/child node.
+		expect(stopImmediate).toHaveBeenCalled();
+	});
+
+	it("normalizes lone LF newlines to CR too", async () => {
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		dispatchPaste(terminal, "a\nb\nc");
+
+		expect(mockPaste).toHaveBeenCalledWith("a\rb\rc");
+	});
+
+	it("routes ordinary single-line text through term.paste", async () => {
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		dispatchPaste(terminal, "hello world");
+
+		expect(mockPaste).toHaveBeenCalledWith("hello world");
+	});
+
+	it("ignores an empty text paste (no image, no text) without swallowing it", async () => {
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		const { preventDefault } = dispatchPaste(terminal, "");
+
+		expect(mockPaste).not.toHaveBeenCalled();
+		expect(preventDefault).not.toHaveBeenCalled();
+	});
+
+	it("still diverts image pastes to the attachment uploader (not term.paste)", async () => {
+		mockedPasteClipboardImage.mockResolvedValue({ path: "/tmp/uploads/pic.png" } as any);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		dispatchPaste(terminal, "", [{ type: "image/png" }]);
+
+		await waitFor(() => {
+			expect(mockedPasteClipboardImage).toHaveBeenCalledWith({ projectId: "p1" });
+		});
+		expect(mockPaste).not.toHaveBeenCalled();
+	});
+
+	it("still diverts large text pastes to the .txt uploader (not term.paste)", async () => {
+		mockedUploadFileBase64.mockResolvedValue({ path: "/tmp/uploads/pasted-text.txt" } as any);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		const huge = "x".repeat(9000); // > LARGE_TEXT_PASTE_THRESHOLD (8192)
+		dispatchPaste(terminal, huge);
+
+		await waitFor(() => {
+			expect(mockedUploadFileBase64).toHaveBeenCalled();
+		});
+		expect(mockPaste).not.toHaveBeenCalled();
+	});
+});
+
+describe("normalizePastedText", () => {
+	it("collapses CRLF to a single CR", () => {
+		expect(normalizePastedText("a\r\nb")).toBe("a\rb");
+	});
+	it("converts lone LF to CR", () => {
+		expect(normalizePastedText("a\nb\nc")).toBe("a\rb\rc");
+	});
+	it("leaves lone CR untouched", () => {
+		expect(normalizePastedText("a\rb")).toBe("a\rb");
+	});
+	it("handles mixed and trailing newlines", () => {
+		expect(normalizePastedText("a\r\nb\nc\r")).toBe("a\rb\rc\r");
+	});
+	it("returns plain text unchanged", () => {
+		expect(normalizePastedText("no newlines here")).toBe("no newlines here");
 	});
 });
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

In remote/browser mode a multi-line `Ctrl+V` submitted after the **first** line instead of pasting the whole block — most visible on Windows, whose clipboard carries `CRLF`.

**Root cause.** ghostty-web has two paste handlers: the textarea one wraps in DEC 2004 bracketed paste, but the container one (`InputHandler.handlePaste`) sends the **raw** clipboard bytes, ignoring bracketed-paste mode entirely. `Terminal.focus()` focuses the contenteditable **container** (not the textarea), and on desktop/remote `TerminalView` calls `term.focus()` after fit and on every click — so paste lands on the raw handler. Raw `\r\n`/`\n` then reads as Enter and submits after line one. Confirmed live in a browser: with the container focused, the outgoing PTY bytes carried the raw newlines.

**Fix.** `TerminalView`'s own capture-phase paste listener now handles ordinary text too: it pre-empts both ghostty handlers (`preventDefault` + `stopImmediatePropagation`) and routes the text through `term.paste()` (bracketed when the app enabled DEC 2004) with newlines normalized to lone `CR` (xterm.js convention). One deterministic path regardless of focus target or platform; image and large-text attachment paths are unchanged.

Also hardens the handler against a narrow PTY-recreation race: it now checks for a live terminal **before** swallowing the event, so a paste in the brief `termRef === null` gap is no longer suppressed-and-dropped.

See `decisions/145-terminal-paste-always-bracketed.md` for the reverse-engineered ghostty-web details. Covered by unit tests (paste routing, CR normalization, image/large-text/empty/no-project, and the recreation-gap edge).