### PR TITLE
Fix remote completion sound not playing on desktop Chrome

### DIFF
--- a/change-logs/2026/07/21/fix-remote-completion-sound-desktop-chrome.md
+++ b/change-logs/2026/07/21/fix-remote-completion-sound-desktop-chrome.md
@@ -1,0 +1,1 @@
+Fixed the task-completion sound not playing in remote mode on desktop Chrome (it worked on mobile). The sound now primes its audio element on the first user gesture and reuses that primed element, so the delayed completion push is honored by the desktop autoplay policy.

--- a/decisions/147-prime-task-sounds-on-first-gesture.md
+++ b/decisions/147-prime-task-sounds-on-first-gesture.md
@@ -1,0 +1,37 @@
+# 147 — Prime task-completion sounds on the first user gesture
+
+## Context
+In remote browser mode the completion sound never played on desktop Chrome,
+while the same task on mobile Chrome played fine. Non-UI completions (agent
+approval, CLI, branch-merge) reach a remote renderer only via the backend
+`taskSound` push, which lands seconds after the user's "Approve" click because
+the backend tears the worktree down first.
+
+## Investigation
+`playTaskSound` (`src/mainview/task-sounds.ts`) played a fresh
+`template.cloneNode()` `<audio>`. That clone was never user-activated, and by the
+time the push arrived the click's transient activation had expired, so desktop
+Chrome's autoplay policy rejected the delayed `.play()`. Mobile Chrome unlocks
+media stickily after a single gesture, so its delayed play was honored — hence
+the asymmetry. The old unlock handler also never primed anything: on an empty
+queue it just flipped `playbackUnlocked` and removed itself.
+
+## Decision
+Prime each sound element (a muted play/pause) synchronously inside the first
+user gesture (`primeTemplates` in `task-sounds.ts`, called from the
+`installUnlockHandlers` listener), and play by reusing the primed template
+instead of an un-activated clone. Once primed, desktop Chrome honors later
+push-driven plays.
+
+## Risks
+Same-status completions can no longer overlap (one element per status) — a
+non-issue for completion sounds. If the user never makes any gesture in the tab,
+nothing can unlock playback — an unavoidable browser-policy limit; the sound
+still queues and plays on the next gesture.
+
+## Alternatives considered
+- Rewrite to Web Audio API (`AudioContext` resumed on gesture): most robust but a
+  larger change and hard to unit-test under happy-dom. Kept as the fallback if
+  priming proves insufficient on some browser.
+- Play optimistically inside the "Approve" click handler: the outcome is unknown
+  at click time, and CLI / branch-merge completions have no gesture at all.

--- a/src/mainview/__tests__/task-sounds.test.ts
+++ b/src/mainview/__tests__/task-sounds.test.ts
@@ -63,3 +63,53 @@ describe("completion sound playback", () => {
 		expect(playSpy).toHaveBeenCalledTimes(2);
 	});
 });
+
+// Desktop Chrome rejects a delayed, programmatic `.play()` on a never-activated
+// <audio> element — and the remote `taskSound` push lands seconds after the
+// user's "Approve" click. Priming each element inside the first user gesture
+// (play/pause) marks it user-activated so the later push-driven play is honored.
+// Fresh module instances (resetModules + dynamic import) isolate this global
+// unlock/prime state from the shared-state tests above.
+describe("audio unlock priming (remote desktop browsers)", () => {
+	it("primes both sound templates on the first user gesture", async () => {
+		vi.resetModules();
+		const playSpy = vi
+			.spyOn(window.HTMLMediaElement.prototype, "play")
+			.mockResolvedValue(undefined as unknown as void);
+		const pauseSpy = vi
+			.spyOn(window.HTMLMediaElement.prototype, "pause")
+			.mockImplementation(() => {});
+		try {
+			const mod = await import("../task-sounds");
+			mod.initTaskSoundPlayback();
+			expect(playSpy).not.toHaveBeenCalled();
+
+			window.dispatchEvent(new Event("pointerdown"));
+
+			// `>=` (not exact): `window` is shared across the static import above and
+			// this fresh dynamic instance, so a leaked unlock listener may also fire.
+			expect(playSpy.mock.calls.length).toBeGreaterThanOrEqual(Object.keys(mod.SOUND_DEFS).length);
+			await Promise.resolve();
+			expect(pauseSpy).toHaveBeenCalled();
+		} finally {
+			playSpy.mockRestore();
+			pauseSpy.mockRestore();
+		}
+	});
+
+	it("reuses one <audio> element per status instead of cloning", async () => {
+		vi.resetModules();
+		const playSpy = vi
+			.spyOn(window.HTMLMediaElement.prototype, "play")
+			.mockResolvedValue(undefined as unknown as void);
+		try {
+			const mod = await import("../task-sounds");
+			mod.playTaskSoundFromPush("completed");
+			mod.playTaskSoundFromPush("completed");
+			expect(playSpy).toHaveBeenCalledTimes(2);
+			expect(playSpy.mock.instances[0]).toBe(playSpy.mock.instances[1]);
+		} finally {
+			playSpy.mockRestore();
+		}
+	});
+});

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -64,6 +64,7 @@ export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 
 let unlockHandlersInstalled = false;
 let playbackUnlocked = false;
+let templatesPrimed = false;
 
 function canPlayImmediately(): boolean {
 	if (playbackUnlocked) return true;
@@ -82,6 +83,44 @@ function getAudioTemplate(status: TaskSoundStatus): HTMLAudioElement {
 	return audio;
 }
 
+// Chrome on desktop rejects a delayed, programmatic `.play()` on an <audio>
+// element that was never activated by a user gesture. In remote mode the sound
+// arrives via the backend `taskSound` push, which lands SECONDS after the user's
+// "Approve" click (the backend tears the worktree down first), so the click's
+// transient activation has long expired by the time `.play()` runs. Priming each
+// element — a muted play/pause performed SYNCHRONOUSLY inside the first user
+// gesture — marks it as user-activated, so every later push-driven play is
+// honored. Mobile Chrome unlocks media stickily after a single gesture and never
+// needed this, which is why the bug only showed on desktop browsers.
+function primeTemplates(): void {
+	if (templatesPrimed) return;
+	templatesPrimed = true;
+
+	for (const status of Object.keys(SOUND_DEFS) as TaskSoundStatus[]) {
+		const audio = getAudioTemplate(status);
+		audio.muted = true;
+
+		let started: Promise<void> | undefined;
+		try {
+			started = audio.play() as Promise<void> | undefined;
+		} catch {
+			templatesPrimed = false;
+		}
+
+		Promise.resolve(started)
+			.then(() => {
+				audio.pause();
+				audio.currentTime = 0;
+			})
+			.catch(() => {
+				templatesPrimed = false;
+			})
+			.finally(() => {
+				audio.muted = false;
+			});
+	}
+}
+
 function flushPendingQueue(): void {
 	if (!canPlayImmediately()) return;
 	playbackUnlocked = true;
@@ -98,8 +137,11 @@ function installUnlockHandlers(): void {
 	unlockHandlersInstalled = true;
 
 	const unlock = () => {
+		// Prime inside the gesture even when nothing is queued yet — the pending
+		// completion push almost always arrives *after* the last user gesture.
+		primeTemplates();
 		flushPendingQueue();
-		if (pendingQueue.length === 0) {
+		if (templatesPrimed && pendingQueue.length === 0) {
 			for (const eventName of SOUND_UNLOCK_EVENTS) {
 				window.removeEventListener(eventName, unlock);
 			}
@@ -129,9 +171,18 @@ export async function playTaskSound(status: TaskSoundStatus): Promise<void> {
 
 	playbackUnlocked = true;
 
-	const template = getAudioTemplate(status);
-	const audio = template.cloneNode() as HTMLAudioElement;
+	// Reuse the primed template rather than a fresh clone: only the primed element
+	// carries the user-activation that lets a delayed play through on desktop
+	// Chrome. A clone would be un-activated and rejected. Completion sounds never
+	// realistically overlap, so restarting `currentTime` is fine.
+	const audio = getAudioTemplate(status);
+	audio.muted = false;
 	audio.volume = SOUND_DEFS[status].volume;
+	try {
+		audio.currentTime = 0;
+	} catch {
+		// Some engines throw on currentTime before metadata loads — harmless here.
+	}
 
 	try {
 		await audio.play();
@@ -139,6 +190,7 @@ export async function playTaskSound(status: TaskSoundStatus): Promise<void> {
 		console.warn("[task-sounds] playback failed", { status, error: String(err) });
 		pendingQueue.push(status);
 		playbackUnlocked = false;
+		templatesPrimed = false;
 		installUnlockHandlers();
 	}
 }


### PR DESCRIPTION
## Summary

In remote (browser) mode the task-completion/cancel sound never played on **desktop Chrome**, while the same task played fine on **mobile Chrome**.

Non-UI completions (agent approval, CLI, branch-merge) reach a remote renderer only via the backend `taskSound` push, which lands **seconds after** the user's "Approve" click — the backend tears the worktree down first. `playTaskSound` then played a fresh `cloneNode()` `<audio>` that was never user-activated, so by push time the click's *transient activation* had expired and desktop Chrome's autoplay policy rejected the delayed `play()`. Mobile Chrome unlocks media *stickily* after a single gesture, hence the asymmetry.

## Fix

- Prime each sound element (a muted play/pause) **synchronously inside the first user gesture** (`primeTemplates` in `src/mainview/task-sounds.ts`), which marks it user-activated.
- Play by **reusing the primed element** instead of an un-activated clone, so every later push-driven play is honored on desktop Chrome.
- Desktop app (WKWebView) and mobile are unaffected.

Rationale and the Web-Audio fallback are recorded in `decisions/147-prime-task-sounds-on-first-gesture.md`.

## Notes

Mechanism verified at the code level; the desktop-vs-mobile autoplay difference can't be reproduced in headless Chromium, so final verification is on real desktop Chrome. Added regression tests (priming on first gesture + no-clone reuse); full suite green.