### PR TITLE
Fix header Remote button needing several clicks to open

### DIFF
--- a/change-logs/2026/07/21/fix-remote-button-first-click.md
+++ b/change-logs/2026/07/21/fix-remote-button-first-click.md
@@ -1,0 +1,1 @@
+Fixed the header Remote (QR) button needing several clicks to open. It now shows the QR modal instantly on the first click and brings the public Cloudflare tunnel up in the background, instead of blocking the open on the tunnel handshake (which could freeze the button for up to ~35s when cloudflared was installed).

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -757,8 +757,10 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 		sendToFocusedWindow("zoomReset");
 	} else if (e.data.action === "show-remote-qr") {
 		try {
-			const remoteAccess = await handlers.getRemoteAccessQR({});
-			sendToFocusedWindow("showRemoteAccessQR", remoteAccess);
+			// Fetch only the local QR (no blocking tunnel handshake) so the
+			// modal opens instantly; the renderer brings the tunnel up next.
+			const remoteAccess = await handlers.getRemoteAccessQR({ tunnel: false });
+			sendToFocusedWindow("showRemoteAccessQR", { ...remoteAccess, autoStartTunnel: true });
 		} catch (err) {
 			log.error("Failed to generate QR code", { error: String(err) });
 		}

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1758,6 +1758,7 @@ function App() {
 
 	// QR token consumed — someone connected via the QR code
 	const [qrConsumed, setQrConsumed] = useState(false);
+	const [qrCountdown, setQrCountdown] = useState(25);
 
 	useEffect(() => {
 		function onQrConsumed() {
@@ -1768,28 +1769,50 @@ function App() {
 		return () => window.removeEventListener("rpc:qrTokenConsumed", onQrConsumed);
 	}, []);
 
-	// Listen for View > Remote Access QR Code menu item
+	// Bring the public Cloudflare tunnel up in the background while the modal is
+	// already open, driving the in-modal "starting…" state. Opening Remote Access
+	// must never block on this handshake — awaiting it froze the header button.
+	const startRemoteTunnel = useCallback(() => {
+		setTunnelWanted(true);
+		setRemoteAccessActive(true);
+		setTunnelStarting(true);
+		api.request.getRemoteAccessQR({ tunnel: true }).then((res) => {
+			applyRemoteQR(res);
+			setTunnelStarting(false);
+			setQrCountdown(25);
+		}).catch(() => {
+			setTunnelStarting(false);
+			setRemoteAccessActive(false);
+		});
+	}, [applyRemoteQR]);
+
+	// Listen for the Remote Access open request (header button, kebab, native menu)
 	useEffect(() => {
 		function onShowRemoteQR(e: Event) {
-			const detail = (e as CustomEvent<RemoteAccessQRData>).detail;
+			const detail = (e as CustomEvent<RemoteAccessQRData & { autoStartTunnel?: boolean }>).detail;
 			if (!detail) return;
 			applyRemoteQR(detail);
 			setRemoteUrlCopyState("idle");
 			setQrConsumed(false); // Reset consumed state when opening fresh QR
+			// A share-intent open auto-starts the public tunnel in the background
+			// rather than blocking the modal on the handshake.
+			if (detail.autoStartTunnel && detail.cloudflaredInstalled && detail.tunnelState === "idle") {
+				startRemoteTunnel();
+				return;
+			}
 			// Sync tunnel checkbox with actual tunnel state
-			setTunnelWanted(detail?.tunnelState === "connected" || detail?.tunnelState === "starting");
-			setTunnelStarting(detail?.tunnelState === "starting");
+			setTunnelWanted(detail.tunnelState === "connected" || detail.tunnelState === "starting");
+			setTunnelStarting(detail.tunnelState === "starting");
 		}
 		window.addEventListener("rpc:showRemoteAccessQR", onShowRemoteQR);
 		return () => window.removeEventListener("rpc:showRemoteAccessQR", onShowRemoteQR);
-	}, [applyRemoteQR]);
+	}, [applyRemoteQR, startRemoteTunnel]);
 
 	// Auto-refresh QR code every 25 seconds while modal is open (JWT tokens expire in 30s)
 	// After a QR is consumed, keep polling without visually rotating the token:
 	// a recovered Quick Tunnel gets a new hostname, and the open modal must
 	// reactivate with that new URL instead of staying green on a dead domain.
 	const qrModalOpen = remoteQR !== null;
-	const [qrCountdown, setQrCountdown] = useState(25);
 	const tunnelWantedRef = useRef(tunnelWanted);
 	tunnelWantedRef.current = tunnelWanted;
 	const qrConsumedRef = useRef(qrConsumed);
@@ -2216,16 +2239,7 @@ function App() {
 										const want = e.target.checked;
 										setTunnelWanted(want);
 										if (want && remoteQR.cloudflaredInstalled && remoteQR.tunnelState === "idle") {
-											setRemoteAccessActive(true);
-											setTunnelStarting(true);
-											api.request.getRemoteAccessQR({ tunnel: true }).then((res) => {
-												applyRemoteQR(res);
-												setTunnelStarting(false);
-												setQrCountdown(25);
-											}).catch(() => {
-												setTunnelStarting(false);
-												setRemoteAccessActive(false);
-											});
+											startRemoteTunnel();
 										} else if (!want && remoteQR.tunnelState === "connected") {
 											setRemoteAccessActive(false);
 											api.request.stopTunnel().then(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1506,6 +1506,59 @@ describe("App keyboard shortcuts", () => {
 			}
 		});
 
+		it("auto-starts the tunnel in the background after a fast open (no extra click)", async () => {
+			await renderApp();
+			vi.mocked(api.request.getRemoteAccessQR).mockClear();
+			vi.mocked(api.request.getRemoteAccessQR).mockResolvedValue({
+				qrDataUrl: "data:image/png;base64,tunnel",
+				accessUrl: "https://public.trycloudflare.com/?token=t",
+				tunnelState: "connected",
+				cloudflaredInstalled: true,
+				interfaces: [],
+				selectedHost: "",
+			});
+
+			// The button/menu open the modal immediately with the local QR and
+			// flag the tunnel to start in the background.
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,local",
+					accessUrl: "http://192.168.0.1:1234/?token=l",
+					tunnelState: "idle",
+					cloudflaredInstalled: true,
+					interfaces: [],
+					selectedHost: "192.168.0.1",
+					autoStartTunnel: true,
+				},
+			}));
+
+			await waitFor(() => expect(screen.getByText("Copy URL")).toBeInTheDocument());
+			await waitFor(() => expect(api.request.getRemoteAccessQR).toHaveBeenCalledWith({ tunnel: true }));
+			expect(
+				screen.getByLabelText("Open on your phone — scan QR code for remote access").className,
+			).toContain("remote-access-active");
+		});
+
+		it("does not restart the tunnel when opened while already connected", async () => {
+			await renderApp();
+			vi.mocked(api.request.getRemoteAccessQR).mockClear();
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,live",
+					accessUrl: "https://public.trycloudflare.com/?token=c",
+					tunnelState: "connected",
+					cloudflaredInstalled: true,
+					interfaces: [],
+					selectedHost: "",
+					autoStartTunnel: true,
+				},
+			}));
+
+			await waitFor(() => expect(screen.getByText("Copy URL")).toBeInTheDocument());
+			expect(api.request.getRemoteAccessQR).not.toHaveBeenCalled();
+		});
+
 		it("shows auth failed screen when rpc:authFailed fires", async () => {
 			await renderApp();
 			window.dispatchEvent(new CustomEvent("rpc:authFailed", { detail: { status: 401 } }));

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -85,6 +85,21 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 	const projectDropdownRef = useRef<HTMLDivElement>(null);
 	const countsCacheTimeRef = useRef<number>(0);
 
+	// Open Remote Access instantly: fetch only the local QR (never the blocking
+	// tunnel-start path) so the modal opens on the first click, then flag the
+	// renderer to bring the public tunnel up in the background. Awaiting a
+	// tunnel handshake here is what used to make the button need several clicks.
+	const openRemoteAccess = async () => {
+		try {
+			const result = await api.request.getRemoteAccessQR({ tunnel: false });
+			window.dispatchEvent(
+				new CustomEvent("rpc:showRemoteAccessQR", { detail: { ...result, autoStartTunnel: true } }),
+			);
+		} catch {
+			// Remote access server may not be running.
+		}
+	};
+
 	// Show toast with 5min countdown when updateVersion first appears
 	useEffect(() => {
 		if (updateVersion) {
@@ -328,14 +343,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				{
 					key: "remote",
 					label: t("header.remoteAccessLabel"),
-					run: async () => {
-						try {
-							const result = await api.request.getRemoteAccessQR({});
-							window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", { detail: result }));
-						} catch {
-							// Remote access server may not be running.
-						}
-					},
+					run: () => { void openRemoteAccess(); },
 				},
 				...(route.screen !== "changelog" ? [{ key: "changelog", label: t("header.changelogLabel"), run: () => navigate({ screen: "changelog" }) }] : []),
 				{ key: "website", label: t("header.githubLabel"), run: () => window.open("https://h0x91b.github.io/dev-3.0/", "_blank") },
@@ -616,14 +624,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 				{!isNarrow && (
 					<Tooltip content={t("header.remoteAccessTooltip")} detail={t("ttip.header.remoteAccess")}>
 						<button
-							onClick={async () => {
-								try {
-									const result = await api.request.getRemoteAccessQR({});
-									window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", { detail: result }));
-								} catch {
-									// Remote access server may not be running
-								}
-							}}
+							onClick={() => { void openRemoteAccess(); }}
 							className={`header-anim flex items-center gap-1 transition-colors px-1.5 py-1 rounded-lg ${remoteAccessActive ? "text-accent bg-accent/15 hover:bg-accent/25 remote-access-active" : "text-fg-3 hover:text-fg hover:bg-elevated"}`}
 							aria-label={t("header.remoteAccessTooltip")}
 						>

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -19,6 +19,14 @@ vi.mock("../../rpc", () => ({
 			getPreventSleepState: vi.fn().mockResolvedValue({ enabled: false, available: false, forcedByRemote: false }),
 			setPreventSleep: vi.fn(),
 			getAgentRateLimits: vi.fn().mockResolvedValue({ generatedAt: 0, snapshots: [] }),
+			getRemoteAccessQR: vi.fn().mockResolvedValue({
+				qrDataUrl: "data:image/png;base64,test",
+				accessUrl: "http://192.168.0.1:1234/?token=test",
+				tunnelState: "idle",
+				cloudflaredInstalled: true,
+				interfaces: [],
+				selectedHost: "192.168.0.1",
+			}),
 			listAgentAccounts: vi.fn().mockResolvedValue({
 				claude: { accounts: [], activeId: null, systemIdentity: null },
 				codex: { accounts: [], activeId: null, currentIdentity: null },
@@ -959,5 +967,32 @@ describe("GlobalHeader — narrow viewport action sheet", () => {
 		// Git pull + tmux manager now live in the sheet's controls strip.
 		expect(screen.getByTestId("git-pull-button")).toBeInTheDocument();
 		expect(screen.getByLabelText("tmux Sessions")).toBeInTheDocument();
+	});
+});
+
+describe("GlobalHeader — remote access button", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getTasks.mockResolvedValue([]);
+	});
+
+	it("opens instantly on the first click via a non-blocking local QR fetch", async () => {
+		const events: CustomEvent[] = [];
+		const listener = (e: Event) => events.push(e as CustomEvent);
+		window.addEventListener("rpc:showRemoteAccessQR", listener);
+		try {
+			renderHeader({ screen: "project", projectId: "p1" });
+			await userEvent.click(
+				screen.getByLabelText("Open on your phone — scan QR code for remote access"),
+			);
+
+			// The click must never trigger the blocking tunnel-start path
+			// (default tunnel:true) that made the button need several clicks.
+			expect(mockedApi.request.getRemoteAccessQR).toHaveBeenCalledWith({ tunnel: false });
+			await vi.waitFor(() => expect(events).toHaveLength(1));
+			expect(events[0].detail.autoStartTunnel).toBe(true);
+		} finally {
+			window.removeEventListener("rpc:showRemoteAccessQR", listener);
+		}
 	});
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3495,7 +3495,7 @@ export type AppRPCSchema = {
 			zoomReset: {};
 			osc52Clipboard: { taskId: string; text: string; len: number };
 			qrTokenConsumed: {};
-			showRemoteAccessQR: { qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean };
+			showRemoteAccessQR: { qrDataUrl: string; accessUrl: string; tunnelState: string; cloudflaredInstalled: boolean; autoStartTunnel?: boolean };
 			/**
 			 * Universal menu-action dispatch. The bun side fires this whenever the
 			 * native menu emits an `application-menu-clicked` event whose action is


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) — here's a summary of the fix.

## Summary

The header **Remote** (QR) button needed several clicks to open — it never opened on the first click.

**Root cause:** opening Remote Access awaited `getRemoteAccessQR({})`. With `cloudflared` installed and the tunnel idle, that call **synchronously started the tunnel and blocked for up to ~35s** (30s waiting for cloudflared's URL + 5s DNS settle) before returning the QR and showing the modal. During that dead window the button looked unresponsive, so users clicked again; the second click saw a non-idle tunnel, skipped the start, and opened instantly — hence "needs several clicks".

**Fix:** the header button, the kebab menu item and the native `View → Remote Access QR Code` menu now fetch only the local QR (`{ tunnel: false }` — non-blocking, no tunnel handshake) and flag the push with `autoStartTunnel`. The renderer opens the modal immediately and brings the public tunnel up **in the background**, reusing the existing in-modal "Starting tunnel…" state. The tunnel-start logic is extracted into a single `startRemoteTunnel` helper (the "Accessible from anywhere" checkbox now shares it).

The backend `getRemoteAccessQR` is unchanged — its blocking behaviour is still correct once the modal is already open.

## Verification

- Failing test written first (repo rule), then the fix.
- `bun run lint` clean; full `bun run test` green (mainview 2733 / bun 2766 / cli 570).
- Manually QA'd in a browser: modal opens on the first click, QR shown instantly, tunnel starts in the background, no console errors.
