### PR TITLE
Fix branch-merged popup lingering on other clients after remote resolve

### DIFF
--- a/change-logs/2026/07/20/fix-remote-merged-popup-sync.md
+++ b/change-logs/2026/07/20/fix-remote-merged-popup-sync.md
@@ -1,0 +1,1 @@
+Fixed the "Branch Merged" completion popup lingering on the desktop app after it was accepted or declined from the remote browser. The dialog now closes on every connected client once the prompt is resolved anywhere — accepting broadcasts the task completion, and declining broadcasts a new merge-prompt-resolved event.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -9310,6 +9310,39 @@ describe("prepareMergeCompletionPrompt (force re-check)", () => {
 	});
 });
 
+describe("dismissMergeCompletionPrompt broadcast", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		_resetMergePollerState();
+	});
+
+	afterEach(() => {
+		_resetMergePollerState();
+	});
+
+	it("broadcasts mergePromptResolved so other clients close their open dialog", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "review-by-user", branchName: "dev3/task-test" });
+		const push = vi.fn();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockImplementation(async (_p: Project, _id: string, patch: Partial<Task>) => makeTask(patch));
+		setPushMessage(push);
+
+		await handlers.dismissMergeCompletionPrompt({
+			taskId: task.id,
+			projectId: project.id,
+			fingerprint: "v1:dev3/task-test:abc123",
+		});
+
+		expect(push).toHaveBeenCalledWith("mergePromptResolved", {
+			taskId: task.id,
+			projectId: project.id,
+			fingerprint: "v1:dev3/task-test:abc123",
+		});
+	});
+});
+
 describe("startPRDetectionPoller / stopPRDetectionPoller", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -185,6 +185,14 @@ async function dismissMergeCompletionPrompt(params: { taskId: string; projectId:
 			precise: fingerprint.precise,
 		},
 	});
+	// Close a still-open "Branch Merged" dialog on other clients (second window
+	// or the remote browser served by this same app) that received the original
+	// broadcast prompt.
+	getPushMessage()?.("mergePromptResolved", {
+		taskId: task.id,
+		projectId: project.id,
+		fingerprint: fingerprint.fingerprint,
+	});
 	return updated;
 }
 

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -41,6 +41,7 @@ import AboutModal from "./components/AboutModal";
 import RosettaWarningModal from "./components/RosettaWarningModal";
 import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "./task-sounds";
 import { runMergeCompletionPromptOnce } from "./utils/mergeCompletionPrompt";
+import { createMergePromptAbort } from "./utils/mergePromptAbort";
 import { taskDialogInfoFromSubject } from "./utils/taskDialogInfo";
 import { getRecentProjectIds, orderByRecency, recordProjectJump } from "./utils/recentProjects";
 import type { NavigationGuard } from "./navigation-guard";
@@ -1381,18 +1382,29 @@ function App() {
 				subject?: TaskDialogSubject;
 			};
 			const fingerprint = ((e as CustomEvent).detail as { fingerprint?: string | null }).fingerprint ?? null;
-			const shouldComplete = await runMergeCompletionPromptOnce(taskId, fingerprint, async () => {
-				try {
-					return await confirm({
-						title: t("app.branchMergedTitle"),
-						message: t("app.branchMergedMessage", { taskTitle, branchName }),
-						info: taskDialogInfoFromSubject(taskTitle, subject),
-					});
-				} catch (err) {
-					console.error("[App] confirm (branch-merged) failed:", err);
-					return false;
-				}
-			});
+			// Close this dialog if the prompt is resolved on another client/device
+			// (the backend broadcasts it to every connected client).
+			const abort = createMergePromptAbort(taskId);
+			let shouldComplete: boolean | null;
+			try {
+				shouldComplete = await runMergeCompletionPromptOnce(taskId, fingerprint, async () => {
+					try {
+						return await confirm({
+							title: t("app.branchMergedTitle"),
+							message: t("app.branchMergedMessage", { taskTitle, branchName }),
+							info: taskDialogInfoFromSubject(taskTitle, subject),
+							signal: abort.signal,
+						});
+					} catch (err) {
+						console.error("[App] confirm (branch-merged) failed:", err);
+						return false;
+					}
+				});
+			} finally {
+				abort.cleanup();
+			}
+			// Resolved elsewhere: the dialog auto-closed, nothing left to do here.
+			if (abort.signal.aborted) return;
 			if (shouldComplete === null) return;
 			if (shouldComplete) {
 				// If the user is currently inside this task's view, leave it BEFORE the

--- a/src/mainview/__tests__/confirm.test.tsx
+++ b/src/mainview/__tests__/confirm.test.tsx
@@ -178,4 +178,37 @@ describe("confirm service", () => {
 		// No ConfirmHost rendered → fail-closed.
 		await expect(confirm({ title: "T", message: "M" })).resolves.toBe(false);
 	});
+
+	it("closes and resolves false when the abort signal fires", async () => {
+		renderHost();
+		const controller = new AbortController();
+
+		let result: Promise<boolean>;
+		act(() => {
+			result = confirm({ title: "Branch Merged", message: "Complete?", signal: controller.signal });
+		});
+
+		expect(await screen.findByText("Branch Merged")).toBeInTheDocument();
+
+		act(() => {
+			controller.abort();
+		});
+
+		await expect(result!).resolves.toBe(false);
+		expect(screen.queryByText("Branch Merged")).not.toBeInTheDocument();
+	});
+
+	it("closes immediately when the signal is already aborted", async () => {
+		renderHost();
+		const controller = new AbortController();
+		controller.abort();
+
+		let result: Promise<boolean>;
+		act(() => {
+			result = confirm({ title: "Already resolved", message: "x", signal: controller.signal });
+		});
+
+		await expect(result!).resolves.toBe(false);
+		expect(screen.queryByText("Already resolved")).not.toBeInTheDocument();
+	});
 });

--- a/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
+++ b/src/mainview/components/task-info-panel/useTaskBranchStatus.ts
@@ -13,6 +13,7 @@ import { confirm } from "../../confirm";
 import { useT } from "../../i18n";
 import { moveTaskToStatus } from "../../utils/moveTaskToStatus";
 import { runMergeCompletionPromptOnce } from "../../utils/mergeCompletionPrompt";
+import { createMergePromptAbort } from "../../utils/mergePromptAbort";
 import { taskDialogInfo } from "../../utils/taskDialogInfo";
 import { startVisibilityAwarePoll } from "../../utils/poll";
 
@@ -139,6 +140,7 @@ export function useTaskBranchStatus({
 				return;
 			}
 
+			const abort = createMergePromptAbort(task.id);
 			const runPrompt = () =>
 				confirm({
 					title: t("app.branchMergedTitle"),
@@ -147,10 +149,17 @@ export function useTaskBranchStatus({
 						branchName: task.branchName || "",
 					}),
 					info: taskDialogInfo(task, project),
+					signal: abort.signal,
 				});
-			const shouldComplete = force
-				? await runPrompt()
-				: await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, runPrompt);
+			let shouldComplete: boolean | null;
+			try {
+				shouldComplete = force
+					? await runPrompt()
+					: await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, runPrompt);
+			} finally {
+				abort.cleanup();
+			}
+			if (abort.signal.aborted) return;
 			if (shouldComplete) {
 				completeTask();
 			} else if (shouldComplete === false) {
@@ -275,13 +284,21 @@ export function useTaskBranchStatus({
 				});
 				if (!promptState.shouldPrompt) return;
 
-				const shouldComplete = await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, () =>
-					confirm({
-						title: t("infoPanel.mergeComplete"),
-						message: t("infoPanel.mergeCompleteMessage"),
-						info: taskDialogInfo(task, project),
-					}),
-				);
+				const abort = createMergePromptAbort(task.id);
+				let shouldComplete: boolean | null;
+				try {
+					shouldComplete = await runMergeCompletionPromptOnce(task.id, promptState.fingerprint, () =>
+						confirm({
+							title: t("infoPanel.mergeComplete"),
+							message: t("infoPanel.mergeCompleteMessage"),
+							info: taskDialogInfo(task, project),
+							signal: abort.signal,
+						}),
+					);
+				} finally {
+					abort.cleanup();
+				}
+				if (abort.signal.aborted) return;
 				if (shouldComplete) {
 					completeTask();
 				} else if (shouldComplete === false) {

--- a/src/mainview/confirm.tsx
+++ b/src/mainview/confirm.tsx
@@ -41,6 +41,14 @@ export interface ConfirmOptions {
 		/** Resolved task labels; shown as read-only chips below the body. */
 		labels?: Label[];
 	};
+	/**
+	 * Close the dialog externally, without a user choice — e.g. the underlying
+	 * task was resolved on another window or on the remote browser. When the
+	 * signal aborts, the dialog closes and the promise resolves `false`; callers
+	 * that must tell this apart from a real decline should check `signal.aborted`
+	 * after awaiting and skip their own resolution side effects.
+	 */
+	signal?: AbortSignal;
 }
 
 interface PendingConfirm extends ConfirmOptions {
@@ -102,6 +110,19 @@ function ConfirmDialog({ pending, close }: { pending: PendingConfirm; close: (re
 
 	const confirmLabel = pending.confirmLabel ?? t("confirmDialog.confirm");
 	const cancelLabel = pending.cancelLabel ?? t("confirmDialog.cancel");
+
+	// Auto-close when the caller's signal aborts (task resolved elsewhere).
+	useEffect(() => {
+		const signal = pending.signal;
+		if (!signal) return;
+		if (signal.aborted) {
+			close(false);
+			return;
+		}
+		const onAbort = () => close(false);
+		signal.addEventListener("abort", onAbort);
+		return () => signal.removeEventListener("abort", onAbort);
+	}, [pending.signal, close]);
 
 	return (
 		<div

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -60,6 +60,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	terminalBell: (payload) => window.dispatchEvent(new CustomEvent("rpc:terminalBell", { detail: payload })),
 	gitOpCompleted: (payload) => window.dispatchEvent(new CustomEvent("rpc:gitOpCompleted", { detail: payload })),
 	branchMerged: (payload) => window.dispatchEvent(new CustomEvent("rpc:branchMerged", { detail: payload })),
+	mergePromptResolved: (payload) => window.dispatchEvent(new CustomEvent("rpc:mergePromptResolved", { detail: payload })),
 	agentCompletionRequested: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentCompletionRequested", { detail: payload })),
 	updateAvailable: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateAvailable", { detail: payload })),
 	portsUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:portsUpdated", { detail: payload })),

--- a/src/mainview/utils/__tests__/mergePromptAbort.test.ts
+++ b/src/mainview/utils/__tests__/mergePromptAbort.test.ts
@@ -1,0 +1,48 @@
+import { createMergePromptAbort } from "../mergePromptAbort";
+
+function fireTaskUpdated(detail: unknown) {
+	window.dispatchEvent(new CustomEvent("rpc:taskUpdated", { detail }));
+}
+function fireMergeResolved(detail: unknown) {
+	window.dispatchEvent(new CustomEvent("rpc:mergePromptResolved", { detail }));
+}
+
+describe("createMergePromptAbort", () => {
+	it("aborts when the task is completed (worktree dropped) elsewhere", () => {
+		const { signal, cleanup } = createMergePromptAbort("t1");
+		expect(signal.aborted).toBe(false);
+		fireTaskUpdated({ task: { id: "t1", status: "completed", worktreePath: null } });
+		expect(signal.aborted).toBe(true);
+		cleanup();
+	});
+
+	it("aborts when the merge prompt is declined elsewhere", () => {
+		const { signal, cleanup } = createMergePromptAbort("t1");
+		fireMergeResolved({ taskId: "t1", projectId: "p1", fingerprint: "fp" });
+		expect(signal.aborted).toBe(true);
+		cleanup();
+	});
+
+	it("ignores updates for a different task", () => {
+		const { signal, cleanup } = createMergePromptAbort("t1");
+		fireTaskUpdated({ task: { id: "t2", status: "completed", worktreePath: null } });
+		fireMergeResolved({ taskId: "t2" });
+		expect(signal.aborted).toBe(false);
+		cleanup();
+	});
+
+	it("does not abort while the task stays in review with a live worktree", () => {
+		const { signal, cleanup } = createMergePromptAbort("t1");
+		fireTaskUpdated({ task: { id: "t1", status: "review-by-user", worktreePath: "/w" } });
+		expect(signal.aborted).toBe(false);
+		cleanup();
+	});
+
+	it("stops listening after cleanup", () => {
+		const { signal, cleanup } = createMergePromptAbort("t1");
+		cleanup();
+		fireTaskUpdated({ task: { id: "t1", status: "completed", worktreePath: null } });
+		fireMergeResolved({ taskId: "t1" });
+		expect(signal.aborted).toBe(false);
+	});
+});

--- a/src/mainview/utils/mergePromptAbort.ts
+++ b/src/mainview/utils/mergePromptAbort.ts
@@ -1,0 +1,44 @@
+import type { Task } from "../../shared/types";
+
+/**
+ * Abort signal that fires when a task's "Branch Merged" completion prompt is
+ * resolved somewhere other than this dialog — a second window, or the remote
+ * browser served by the same app. The backend broadcasts the merge prompt to
+ * every connected client, so without this a dialog left open on one client
+ * lingers after the prompt is handled on another.
+ *
+ * Two triggers:
+ *  - `rpc:taskUpdated` dropping the task's worktree or moving it to a terminal
+ *    status — covers "accepted elsewhere" (the task is completed).
+ *  - `rpc:mergePromptResolved` for this task — covers "declined elsewhere".
+ *
+ * Wire the returned `signal` into `confirm()` and, after awaiting, check
+ * `signal.aborted` to skip this client's own resolution side effects.
+ */
+export function createMergePromptAbort(taskId: string): { signal: AbortSignal; cleanup: () => void } {
+	const controller = new AbortController();
+
+	const onTaskUpdated = (e: Event) => {
+		const task = (e as CustomEvent).detail?.task as Task | undefined;
+		if (task?.id !== taskId) return;
+		// A branch-merged prompt only makes sense while the task still has a live
+		// worktree in a review state; either gone means it was resolved.
+		if (!task.worktreePath || task.status === "completed" || task.status === "cancelled") {
+			controller.abort();
+		}
+	};
+	const onResolved = (e: Event) => {
+		if ((e as CustomEvent).detail?.taskId === taskId) controller.abort();
+	};
+
+	window.addEventListener("rpc:taskUpdated", onTaskUpdated);
+	window.addEventListener("rpc:mergePromptResolved", onResolved);
+
+	return {
+		signal: controller.signal,
+		cleanup: () => {
+			window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
+			window.removeEventListener("rpc:mergePromptResolved", onResolved);
+		},
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3368,6 +3368,15 @@ export type AppRPCSchema = {
 			updateAvailable: { version: string };
 			branchMerged: { taskId: string; projectId: string; taskTitle: string; branchName: string; fingerprint: string | null; subject: TaskDialogSubject };
 			/**
+			 * A branch-merged completion prompt was resolved by declining it
+			 * (`dismissMergeCompletionPrompt`). Lets other connected clients — a
+			 * second window, or a remote browser served by the same app — close
+			 * their still-open "Branch Merged" dialog. The accept path needs no
+			 * dedicated event: it is covered by the `taskUpdated` push that moves
+			 * the task to `completed` and drops its worktree.
+			 */
+			mergePromptResolved: { taskId: string; projectId: string; fingerprint: string | null };
+			/**
 			 * Emitted when an agent runs `dev3 task move --status completed`. The CLI
 			 * blocks on the user's decision; the renderer shows an AI-styled confirm
 			 * dialog and answers via `respondToAgentCompletionRequest`. `subject`


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The "Branch Merged" completion prompt is broadcast to **every** connected client (`setPushMessage` fans out to both the desktop windows and the remote-browser clients in the same process). When the prompt was accepted or declined from the remote browser, the dialog still lingered open on the desktop app, because the imperative `confirm()` service is a detached promise with no way to be closed from outside — it only resolves on a local click.

## Changes

- Add an optional `AbortSignal` to `confirm()` — when it aborts, the dialog closes and resolves `false`.
- New `createMergePromptAbort(taskId)` helper that aborts the open branch-merged dialog when the prompt is resolved elsewhere:
  - **Accept** → covered by the existing `taskUpdated` push (worktree dropped / terminal status on completion).
  - **Decline** → new `mergePromptResolved` push emitted from `dismissMergeCompletionPrompt`.
- Wired into all three branch-merged confirm sites (App-level push handler + the two in `useTaskBranchStatus`), guarding post-await with `signal.aborted` so an externally-closed dialog skips its local resolution side effects.
- Tests: `confirm()` abort-signal behavior, `createMergePromptAbort` unit coverage, and the backend `mergePromptResolved` broadcast on dismiss.