### PR TITLE
Add Cloudflare tunnel propagation warning to Remote Access modal

### DIFF
--- a/change-logs/2026/07/21/feature-remote-tunnel-propagation-warning.md
+++ b/change-logs/2026/07/21/feature-remote-tunnel-propagation-warning.md
@@ -1,0 +1,1 @@
+Added a yellow warning note to the Remote Access modal that appears once the Cloudflare tunnel connects, reminding you to give the domain a few seconds to propagate and to re-toggle the checkbox if the link still errors with "domain not resolved".

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2325,6 +2325,19 @@ function App() {
 								</div>
 							)}
 
+							{tunnelWanted && remoteQR.tunnelState === "connected" && (
+								<div className="flex items-start gap-2 rounded-lg bg-warning/10 border border-warning/20 px-2.5 py-2 text-left">
+									<span
+										aria-hidden="true"
+										className="text-warning text-sm leading-none mt-px shrink-0"
+										style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+									>
+										{"\uF071"}
+									</span>
+									<p className="text-warning/90 text-xs leading-snug">{t("remote.tunnelPropagationHint")}</p>
+								</div>
+							)}
+
 							{tunnelWanted && remoteQR.tunnelState === "failed" && (
 								<div className="flex items-center gap-2">
 									<div className="w-2 h-2 rounded-full bg-danger" />

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -127,6 +127,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Recheck",
 	"remote.tunnelStarting": "Starting tunnel...",
 	"remote.tunnelConnected": "Public tunnel active",
+	"remote.tunnelPropagationHint": "Give Cloudflare a few seconds to publish the domain. If the link errors with “domain not resolved”, wait a moment — or toggle this off and back on — then reopen it.",
 	"remote.tunnelFailed": "Tunnel failed to start",
 	"remote.copyUrl": "Copy URL",
 	"remote.copyingUrl": "Copying URL…",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -127,6 +127,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Verificar de nuevo",
 	"remote.tunnelStarting": "Iniciando túnel...",
 	"remote.tunnelConnected": "Túnel público activo",
+	"remote.tunnelPropagationHint": "Dale a Cloudflare unos segundos para publicar el dominio. Si el enlace da el error «dominio no resuelto», espera un momento —o desactiva y vuelve a activar esta casilla— y ábrelo de nuevo.",
 	"remote.tunnelFailed": "No se pudo iniciar el túnel",
 	"remote.copyUrl": "Copiar URL",
 	"remote.copyingUrl": "Copiando URL…",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -135,6 +135,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Проверить снова",
 	"remote.tunnelStarting": "Запуск туннеля...",
 	"remote.tunnelConnected": "Публичный туннель активен",
+	"remote.tunnelPropagationHint": "Дайте Cloudflare пару секунд, чтобы опубликовать домен. Если по ссылке ошибка «домен не резолвится» — подождите немного или выключите и снова включите эту галочку, затем откройте заново.",
 	"remote.tunnelFailed": "Не удалось запустить туннель",
 	"remote.copyUrl": "Скопировать URL",
 	"remote.copyingUrl": "Копирование URL…",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

Adds a yellow warning note to the Remote Access QR modal, shown once the Cloudflare tunnel reports `connected`. It reminds the user to give the domain a few seconds to propagate, and — if the link still errors with "domain not resolved" — to wait a moment or toggle the "Accessible from anywhere" checkbox off and back on before reopening.

- Reuses the existing `warning` design tokens (matches the cloudflared install hint already in the same modal) and a Nerd Font warning glyph.
- New `remote.tunnelPropagationHint` string localized in en/ru/es.