### PR TITLE
Suppress Claude bypass-permission confirmation prompt on startup

### DIFF
--- a/change-logs/2026/07/21/fix-claude-bypass-permission-prompt.md
+++ b/change-logs/2026/07/21/fix-claude-bypass-permission-prompt.md
@@ -1,0 +1,5 @@
+Short: No more bypass-permission prompt
+
+Claude sessions launched by dev3 no longer show the one-time "bypass permissions" confirmation on startup — dev3 now injects skipDangerousModePermissionPrompt into the managed Claude settings for every session, including when rate-limit tracking is off.
+
+Reported by Ted Kostylev

--- a/src/bun/__tests__/rate-limit-monitor.test.ts
+++ b/src/bun/__tests__/rate-limit-monitor.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findLatestCodexRollout, readClaudeSnapshot, readCodexSnapshot } from "../rate-limit-monitor";
+import { buildClaudeManagedSettings, findLatestCodexRollout, readClaudeSnapshot, readCodexSnapshot } from "../rate-limit-monitor";
 
 let tmp: string;
 
@@ -12,6 +12,20 @@ beforeEach(() => {
 
 afterEach(() => {
 	rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("buildClaudeManagedSettings", () => {
+	it("always suppresses the dangerous-mode permission prompt", () => {
+		expect(buildClaudeManagedSettings("/bin/dev3", false)).toEqual({
+			skipDangerousModePermissionPrompt: true,
+		});
+	});
+
+	it("keeps the skip flag and adds the statusLine wrapper when tracking is on", () => {
+		const s = buildClaudeManagedSettings("/bin/dev3", true);
+		expect(s.skipDangerousModePermissionPrompt).toBe(true);
+		expect(s.statusLine).toEqual({ type: "command", command: '"/bin/dev3" statusline' });
+	});
 });
 
 describe("readClaudeSnapshot", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -503,14 +503,17 @@ export function getDefaultEnvForAgent(agent: CodingAgent, config?: AgentConfigur
 	return {};
 }
 
-/** Attach the statusLine-wrapper settings file to CommandOptions when
- *  rate-limit tracking is enabled (only affects Claude-based commands). */
+/** Attach the dev3-managed Claude settings file to CommandOptions. The file
+ *  always suppresses the one-time bypass-permission confirmation
+ *  (skipDangerousModePermissionPrompt), so it is injected regardless of
+ *  rate-limit tracking; the statusLine wrapper is included only when tracking is
+ *  on. Only Claude's adapter reads the option — other agents ignore it. */
 function applyStatusLineOption(
 	options: CommandOptions | undefined,
 	settings: { agentRateLimitTracking?: boolean },
 ): CommandOptions | undefined {
-	if (settings.agentRateLimitTracking === false) return options;
-	const settingsFile = ensureClaudeStatusLineSettings();
+	const includeStatusLine = settings.agentRateLimitTracking !== false;
+	const settingsFile = ensureClaudeStatusLineSettings(includeStatusLine);
 	if (!settingsFile) return options;
 	return { ...options, statuslineSettingsFile: settingsFile };
 }

--- a/src/bun/rate-limit-monitor.ts
+++ b/src/bun/rate-limit-monitor.ts
@@ -47,7 +47,9 @@ export const CLAUDE_RATE_LIMIT_DUMP_PATH = join(RATE_LIMITS_DIR, "claude.json");
 /** Per-managed-account Claude dumps. The legacy global dump remains the system
  * login fallback and is also written for compatibility with older builds. */
 export const CLAUDE_ACCOUNT_RATE_LIMITS_DIR = join(RATE_LIMITS_DIR, "claude");
-/** The static settings file injected via `claude --settings <path>`. */
+/** The dev3-managed settings file injected via `claude --settings <path>`. It
+ * always suppresses the one-time bypass-permission confirmation and optionally
+ * routes statusLine through `dev3 statusline` (see buildClaudeManagedSettings). */
 export const CLAUDE_STATUSLINE_SETTINGS_PATH = join(RATE_LIMITS_DIR, "claude-statusline-settings.json");
 
 type PushMessageFn = (name: string, payload: unknown) => void;
@@ -61,17 +63,32 @@ const codexLiveAttemptedAt = new Map<string, number>();
 const codexLiveRequests = new Map<string, Promise<AgentRateLimitSnapshot | null>>();
 
 /**
- * Write (once) the settings file whose statusLine routes through
- * `dev3 statusline`, and return its path. Returns null when writing fails —
- * callers then simply skip `--settings` injection.
+ * Build the dev3-managed Claude settings object injected via `claude --settings`.
+ * `skipDangerousModePermissionPrompt` is ALWAYS present: dev3 launches every
+ * Claude session with a dangerous-bypass flag available (`--allow-dangerously-
+ * skip-permissions` or a preset's `--dangerously-skip-permissions`), which would
+ * otherwise trigger a one-time confirmation prompt on startup. When rate-limit
+ * tracking is on, statusLine is also routed through `dev3 statusline`.
  */
-export function ensureClaudeStatusLineSettings(): string | null {
+export function buildClaudeManagedSettings(dev3Bin: string, includeStatusLine: boolean): Record<string, unknown> {
+	const settings: Record<string, unknown> = { skipDangerousModePermissionPrompt: true };
+	if (includeStatusLine) {
+		settings.statusLine = { type: "command", command: `"${dev3Bin}" statusline` };
+	}
+	return settings;
+}
+
+/**
+ * Write (once) the dev3-managed Claude settings file and return its path. Always
+ * carries skipDangerousModePermissionPrompt; includes the statusLine wrapper only
+ * when rate-limit tracking is on. Returns null when writing fails — callers then
+ * simply skip `--settings` injection.
+ */
+export function ensureClaudeStatusLineSettings(includeStatusLine = true): string | null {
 	try {
 		mkdirSync(RATE_LIMITS_DIR, { recursive: true });
 		const dev3Bin = join(homedir(), ".dev3.0", "bin", "dev3");
-		const desired = JSON.stringify({
-			statusLine: { type: "command", command: `"${dev3Bin}" statusline` },
-		});
+		const desired = JSON.stringify(buildClaudeManagedSettings(dev3Bin, includeStatusLine));
 		let current = "";
 		try {
 			current = readFileSync(CLAUDE_STATUSLINE_SETTINGS_PATH, "utf-8");
@@ -81,7 +98,7 @@ export function ensureClaudeStatusLineSettings(): string | null {
 		if (current !== desired) writeFileSync(CLAUDE_STATUSLINE_SETTINGS_PATH, desired);
 		return CLAUDE_STATUSLINE_SETTINGS_PATH;
 	} catch (err) {
-		log.warn("Failed to write statusline settings file", { error: String(err) });
+		log.warn("Failed to write claude managed settings file", { error: String(err) });
 		return null;
 	}
 }


### PR DESCRIPTION
Hi, this is Claude (the AI assistant) opening this PR on Arseny's branch.

## Summary

dev3 launches every Claude session with a dangerous-bypass flag available (`--allow-dangerously-skip-permissions`, or `--dangerously-skip-permissions` for the Bypass/Accept-Edits presets). Without `skipDangerousModePermissionPrompt` set, Claude shows a one-time confirmation prompt on startup — which users were hitting on every new session.

The fix injects the flag through the single dev3-managed `--settings` file that is already attached to Claude launches, rather than adding a second `--settings` to each preset (two `--settings` conflict, and the adapter disables ours when it sees one in `additionalArgs`).

- `src/bun/rate-limit-monitor.ts` — the managed settings file (`claude-statusline-settings.json`) now always carries `skipDangerousModePermissionPrompt: true`. Extracted a pure `buildClaudeManagedSettings()` builder; the `statusLine` wrapper is still added only when rate-limit tracking is on.
- `src/bun/agents.ts` — the settings file is now injected on every Claude launch, including when rate-limit tracking is off (previously `--settings` was skipped entirely in that case, so the prompt would have persisted).
- Unit tests for the new builder; changelog entry.

This covers all Claude presets at once, since the flag rides the single injection point instead of being duplicated across ~20 presets.

Reported by Ted Kostylev.