### PR TITLE
Add Bug Hunter task-mutation prompt guard

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -97,7 +97,7 @@ A supplementary skill that teaches agents about `.dev3/config.json` and `.dev3/c
 
 ### dev3-bug-hunter (displayed as "dev3 Bug Hunter")
 
-A user-invocable skill that turns the agent into a seeded bug hunter. It generates a random seed, derives an identity letter, chooses a starting area plus analysis style, and then forces the hunt to begin from that assigned area before branching out. The skill is read-only, uses a terminal-friendly findings format with a compact ASCII summary table plus detail sections, asks whether `critical` and `medium` findings should become separate dev3 tasks, and requires those follow-up tasks to validate and reproduce the bug before any fix is attempted. Same content for all agents.
+A user-invocable skill that turns the agent into a seeded bug hunter. It generates a random seed, derives an identity letter, chooses a starting area plus analysis style, and then forces the hunt to begin from that assigned area before branching out. The skill is read-only, uses a terminal-friendly findings format with a compact ASCII summary table plus detail sections, asks whether `critical` and `medium` findings should become separate dev3 tasks, and requires those follow-up tasks to validate and reproduce the bug before any fix is attempted. When launched inside an existing task, it skips the main agent's session-start/lifecycle duties and may write only confirmed findings through `dev3 note add`. Same content for all agents.
 
 For Gemini CLI specifically, dev-3.0 installs these managed skills only via the shared `~/.agents/skills/` alias. Gemini also discovers `~/.gemini/skills/`, but duplicating the same skill name in both user-scope directories triggers same-tier conflict warnings and the alias already has precedence.
 

--- a/change-logs/2026/07/21/fix-bug-hunter-task-isolation.md
+++ b/change-logs/2026/07/21/fix-bug-hunter-task-isolation.md
@@ -1,0 +1,5 @@
+Short: Bug Hunter mutation guard
+
+In-task Bug Hunters now receive an explicit read-only prompt guard before the normal dev3 session-start checklist. They may record confirmed findings as `[bug-hunt]` notes, but are told to leave the branch, task metadata, and lifecycle to the main agent.
+
+Suggested by @Capibara- (h0x91b/dev-3.0#1024)

--- a/decisions/149-bug-hunter-prompt-isolation.md
+++ b/decisions/149-bug-hunter-prompt-isolation.md
@@ -1,0 +1,21 @@
+# 149 — In-task Bug Hunters Skip Task Lifecycle Duties
+
+## Context
+
+In-task Bug Hunters share the originating task's worktree and task id with its main agent. The common dev3 session-start protocol therefore prompted hunters to rewrite the branch, title, overview, labels, and other task metadata even though the hunt itself is advertised as read-only.
+
+## Investigation
+
+The in-task launch prompt already limits code inspection and routes findings through `dev3 note add`, but the shared lifecycle prompt had no Bug Hunter exception. Separately, native lifecycle hooks still observe the shared task, and `spawnSingleBugHunterPane` currently records the hunter's agent configuration on that task.
+
+## Decision
+
+Add an in-task Bug Hunter isolation rule before the shared session-start checklist, repeat it in the Bug Hunter skill, and front-load it in `buildBugHunterPrompt`. Hunters may read dev3 state and add confirmed `[bug-hunt]` notes, but must leave the branch and existing task metadata/lifecycle to the main agent.
+
+## Risks
+
+This is a prompt-level safeguard, so it prevents cooperative agent actions but is not a capability boundary. Native hooks can still change status, and the spawn handler still changes task-level agent attribution; those require a later observer-role mechanism outside the prompt.
+
+## Alternatives considered
+
+Removing all dev3 access was rejected because notes are the handoff channel from hidden hunter panes. Disabling hooks or introducing scoped CLI capabilities in this change was deferred because the user explicitly chose the smallest prompt-first mitigation while the correct observer boundary is designed separately.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -40,6 +40,22 @@ describe("platform feedback skill section (always present)", () => {
 });
 
 describe("dev3 skill content", () => {
+	it("exempts in-task bug hunters from mutating the originating task", () => {
+		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
+			expect(skill).toContain("## In-task Bug Hunter isolation");
+			expect(skill).toContain("This exception overrides the session-start checklist");
+			expect(skill).toContain(
+				"Do NOT change the existing task's title, description, overview, labels, priority, status, assigned agent, or configuration.",
+			);
+			expect(skill).toContain(
+				"The only allowed write to the existing task is `dev3 note add`",
+			);
+			expect(skill.indexOf("## In-task Bug Hunter isolation")).toBeLessThan(
+				skill.indexOf("## Session-start checklist"),
+			);
+		}
+	});
+
 	it("routes unqualified artifacts to the task-local dev3 starter", () => {
 		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
 			expect(skill).toContain("## dev3 HTML artifacts");
@@ -296,6 +312,11 @@ describe("dev3 Bug Hunter skill content", () => {
 
 		expect(skill).toContain("This skill is review-only.");
 		expect(skill).toContain("Do NOT modify code, apply patches, create commits, or rewrite files.");
+		expect(skill).toContain("Do NOT run the dev3 session-start checklist");
+		expect(skill).toContain(
+			"Do NOT change the existing task's title, description, overview, labels, priority, status, assigned agent, or configuration.",
+		);
+		expect(skill).toContain("The only allowed write to the existing task is `dev3 note add`");
 		expect(skill).toContain(
 			"You MAY create dev3 tasks only after the user explicitly approves task creation for findings.",
 		);

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -7625,6 +7625,9 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		for (const args of pasteCalls) {
 			const prompt = args[args.length - 1];
 			expect(prompt).toContain("/dev3-bug-hunter");
+			expect(prompt).toContain("read-only helper inside a task owned by the main agent");
+			expect(prompt).toContain("Do NOT run the dev3 session-start checklist");
+			expect(prompt).toContain("The only permitted dev3 write is `dev3 note add`");
 			expect(prompt).toContain("Scope is locked to THIS branch only");
 			// Must pin the fork point via merge-base, not diff against the ref
 			// directly — otherwise an un-rebased branch pulls in unrelated files

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -454,9 +454,16 @@ This skill is review-only.
 - You MAY create dev3 tasks only after the user explicitly approves task creation for findings.
 - If a bug looks real but is not yet proven, say so plainly and describe the missing proof.
 
+When launched inside an existing dev3 task, that task belongs to the main agent:
+
+- Do NOT run the dev3 session-start checklist or rename the git branch.
+- Do NOT change the existing task's title, description, overview, labels, priority, status, assigned agent, or configuration.
+- The only allowed write to the existing task is \`dev3 note add\` when task mode below asks you to record confirmed findings.
+- Finish the Bug Hunter report and stop. The main agent owns every other task mutation and lifecycle transition.
+
 ## Prerequisite
 
-If your working directory is inside \`~/.dev3.0/worktrees/\`, invoke the \`/dev3\` skill before doing anything else unless it is already active in the session. For Codex shell commands, use \`shell="/bin/bash"\` and \`login=false\`.
+If your working directory is inside \`~/.dev3.0/worktrees/\`, invoke the \`/dev3\` skill before doing anything else unless it is already active in the session. Its in-task Bug Hunter isolation rule overrides its normal session-start checklist and lifecycle duties. For Codex shell commands, use \`shell="/bin/bash"\` and \`login=false\`.
 
 ## Step 1: Generate your seed
 

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -2354,6 +2354,9 @@ export function buildBugHunterPrompt(task: Task, project: Project, baseCmd = "")
 	const prefix = agents.skillInvocationPrefix(baseCmd);
 	return (
 		`${prefix}dev3-bug-hunter ` +
+		`You are a read-only helper inside a task owned by the main agent. ` +
+		`Do NOT run the dev3 session-start checklist, rename the branch, or change this task's title, description, overview, labels, priority, status, assigned agent, or configuration. ` +
+		`The only permitted dev3 write is \`dev3 note add\` for confirmed findings as instructed below; the main agent owns every other task mutation and lifecycle transition. ` +
 		`Scope is locked to THIS branch only — only the changes this branch introduced, never commits pulled in from origin. ` +
 		`First pin the fork point, then list only this branch's own changed files: ` +
 		`run \`BASE=$(git merge-base ${ref} HEAD); git diff --name-only "$BASE" HEAD\`. ` +

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -16,6 +16,18 @@ const SKILL_HEADER = `# dev3 — Task Lifecycle Protocol
 You are working inside a **dev-3.0 managed worktree** with a Kanban board task assigned to you.
 `;
 
+const SKILL_BUG_HUNTER_ISOLATION = `
+## In-task Bug Hunter isolation
+
+If the first user request invokes \`dev3-bug-hunter\` and says you are running inside an existing dev3 task, you are a read-only helper inside a task owned by the main agent. This exception overrides the session-start checklist and normal task-lifecycle duties below for the entire hunt.
+
+- Do NOT rename the git branch.
+- Do NOT change the existing task's title, description, overview, labels, priority, status, assigned agent, or configuration.
+- Do NOT run \`dev3 task update\`, \`dev3 overview set\`/\`clear\`, \`dev3 label set\`, \`dev3 task move\`, or the completion flow.
+- The only allowed write to the existing task is \`dev3 note add\` for confirmed findings when the Bug Hunter prompt requests it. Read-only \`dev3\` commands are allowed.
+- Do NOT run the session-start checklist, send task notifications, or request task completion. Finish the Bug Hunter report and stop; the main agent owns the task lifecycle.
+`;
+
 const SKILL_SESSION_START_CHECKLIST = `
 ## Session-start checklist
 
@@ -281,6 +293,6 @@ If \`gh\` is unavailable or unauthenticated, do not silently abandon the report:
 // OpenCode), so the skill rules are always in context regardless of whether
 // the agent decides to load the skill file. See `DEV3_SYSTEM_PROMPT*` in
 // `agents.ts`.
-export const CLAUDE_SKILL_BODY = SKILL_HEADER + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_HOOKS + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK;
-export const CODEX_SKILL_BODY = SKILL_HEADER + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_CODEX_HOOKS + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK + SKILL_CODEX_SHELL;
-export const GENERIC_SKILL_BODY = SKILL_HEADER + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_MANUAL + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK + SKILL_CODEX_SHELL;
+export const CLAUDE_SKILL_BODY = SKILL_HEADER + SKILL_BUG_HUNTER_ISOLATION + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_HOOKS + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK;
+export const CODEX_SKILL_BODY = SKILL_HEADER + SKILL_BUG_HUNTER_ISOLATION + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_CODEX_HOOKS + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK + SKILL_CODEX_SHELL;
+export const GENERIC_SKILL_BODY = SKILL_HEADER + SKILL_BUG_HUNTER_ISOLATION + SKILL_SESSION_START_CHECKLIST + SKILL_BRANCH_NAMING + SKILL_TITLE_GENERATION + SKILL_STATUS_MANUAL + SKILL_OVERVIEW + SKILL_SCRATCH_TASK + SKILL_NOTES + SKILL_CONVERSATION_SEARCH + SKILL_DEV_SERVER_CONTROL + SKILL_ARTIFACTS + SKILL_GET_ATTENTION + SKILL_TMUX + SKILL_PROJECT_CONFIG_REDIRECT + SKILL_VENT_FEEDBACK + SKILL_CODEX_SHELL;


### PR DESCRIPTION
Related issue: #1024

## Summary

- add an in-task Bug Hunter isolation rule before the shared dev3 session-start checklist
- reinforce the rule in the managed Bug Hunter skill and auto-typed launch prompt
- allow confirmed findings through `dev3 note add` while reserving task metadata and lifecycle for the main agent
- document the prompt-level trade-off and cover all generated prompt paths with regression tests

## Scope

This is the deliberately small prompt-first mitigation for #1024. Native lifecycle hooks and spawn-time agent attribution are unchanged; first-class run roles and capability enforcement are documented as a possible follow-up but intentionally deferred as overengineering for now.

## Tests

- `bun run lint`
- `bun run test`