### PR TITLE
Add mobile terminal editing keys

### DIFF
--- a/change-logs/2026/07/21/feature-mobile-backspace-key.md
+++ b/change-logs/2026/07/21/feature-mobile-backspace-key.md
@@ -1,1 +1,1 @@
-Add a Backspace button to the mobile terminal key bar before the arrow controls so users can delete pasted prompt text without a physical keyboard.
+Add a Backspace button to the mobile terminal key bar before the arrow controls so users can delete pasted prompt text without a physical keyboard. Reorder the mobile controls so Escape, Enter, Backspace, and arrows come before the less frequently used Tab, Shift-Tab, and Control keys.

--- a/change-logs/2026/07/21/feature-mobile-backspace-key.md
+++ b/change-logs/2026/07/21/feature-mobile-backspace-key.md
@@ -1,0 +1,1 @@
+Add a Backspace button to the mobile terminal key bar before the arrow controls so users can delete pasted prompt text without a physical keyboard.

--- a/src/mainview/components/ExtraKeyBar.tsx
+++ b/src/mainview/components/ExtraKeyBar.tsx
@@ -139,6 +139,17 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 
 			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
 
+			<button
+				className={btnNormal}
+				onMouseDown={(e) => e.preventDefault()}
+				onClick={() => send("\x7f")}
+				aria-label={t("terminal.backspace")}
+				title={t("terminal.backspace")}
+				data-testid="extra-key-backspace"
+			>
+				{"⌫"}
+			</button>
+
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[A")}>{"▲"}</button>
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[B")}>{"▼"}</button>
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[D")}>{"◀"}</button>

--- a/src/mainview/components/ExtraKeyBar.tsx
+++ b/src/mainview/components/ExtraKeyBar.tsx
@@ -20,8 +20,8 @@ interface ExtraKeyBarProps {
 /**
  * Extra key bar for mobile terminal access — provides keys
  * that are missing or hard to reach on mobile keyboards:
- * Esc, Tab, Shift+Tab (agent-mode cycling in Claude Code), Ctrl (sticky
- * modifier), arrows, and common shell chars.
+ * Esc, Enter, Backspace, arrows, Tab, Shift+Tab (agent-mode cycling in Claude
+ * Code), Ctrl (sticky modifier), and common shell chars.
  * The leading ⌨ button (when the host wires onToggleRaw) switches between
  * compose mode (default — TerminalComposer owns text entry) and raw mode
  * (direct typing into the terminal).
@@ -132,12 +132,7 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 			)}
 
 			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b")}>Esc</button>
-			<button className={btnCtrl} onMouseDown={(e) => e.preventDefault()} onClick={toggleCtrl}>Ctrl</button>
-			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\t")}>Tab</button>
-			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[Z")}>{"⇧Tab"}</button>
 			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\r")}>Enter</button>
-
-			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
 
 			<button
 				className={btnNormal}
@@ -150,10 +145,18 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 				{"⌫"}
 			</button>
 
+			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
+
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[A")}>{"▲"}</button>
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[B")}>{"▼"}</button>
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[D")}>{"◀"}</button>
 			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[C")}>{"▶"}</button>
+
+			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
+
+			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\t")}>Tab</button>
+			<button className={btnNormal} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[Z")}>{"⇧Tab"}</button>
+			<button className={btnCtrl} onMouseDown={(e) => e.preventDefault()} onClick={toggleCtrl}>Ctrl</button>
 
 			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
 

--- a/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
+++ b/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
@@ -75,6 +75,26 @@ describe("ExtraKeyBar", () => {
 		expect(handle.sendInput).toHaveBeenCalledWith("\x7f");
 	});
 
+	it("puts common controls before rarely used modifiers", () => {
+		renderBar(makeHandle());
+
+		const labels = screen.getAllByRole("button").map(
+			(button) => button.getAttribute("aria-label") ?? button.textContent?.trim(),
+		);
+		expect(labels.slice(0, 10)).toEqual([
+			"Esc",
+			"Enter",
+			"Backspace",
+			"▲",
+			"▼",
+			"◀",
+			"▶",
+			"Tab",
+			"⇧Tab",
+			"Ctrl",
+		]);
+	});
+
 	it("sticky Ctrl turns the next key into a control character", async () => {
 		const handle = makeHandle();
 		renderBar(handle);

--- a/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
+++ b/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
@@ -67,6 +67,14 @@ describe("ExtraKeyBar", () => {
 		expect(handle.sendInput).toHaveBeenCalledWith("\x1b[Z");
 	});
 
+	it("sends DEL for Backspace", async () => {
+		const handle = makeHandle();
+		renderBar(handle);
+
+		await userEvent.click(screen.getByRole("button", { name: "Backspace" }));
+		expect(handle.sendInput).toHaveBeenCalledWith("\x7f");
+	});
+
 	it("sticky Ctrl turns the next key into a control character", async () => {
 		const handle = makeHandle();
 		renderBar(handle);

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -206,6 +206,7 @@ const terminal = {
 	"terminal.composerCollapse": "Collapse editor",
 	"terminal.composerScheduleLater": "Send later",
 	"terminal.rawKeyboard": "Direct keyboard input",
+	"terminal.backspace": "Backspace",
 } as const;
 
 export default terminal;

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -206,6 +206,7 @@ const terminal = {
 	"terminal.composerCollapse": "Contraer editor",
 	"terminal.composerScheduleLater": "Enviar más tarde",
 	"terminal.rawKeyboard": "Entrada directa de teclado",
+	"terminal.backspace": "Retroceso",
 };
 
 export default terminal;

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -214,6 +214,7 @@ const terminal = {
 	"terminal.composerCollapse": "Свернуть редактор",
 	"terminal.composerScheduleLater": "Отправить позже",
 	"terminal.rawKeyboard": "Прямой ввод с клавиатуры",
+	"terminal.backspace": "Удалить слева",
 };
 
 export default terminal;


### PR DESCRIPTION
## Summary

- Add a mobile terminal Backspace button that sends DEL so pasted text can be edited without a physical keyboard.
- Reorder mobile terminal controls to prioritize Escape, Enter, Backspace, and arrow keys before Tab, Shift-Tab, and Control.
- Add regression coverage and update the changelog.

## Tests

- `bun run lint`
- `bun run test`
- Manual browser QA at a 390px touch viewport with no browser errors.