### PR TITLE
Name artifact download from its title, not the HTML basename

### DIFF
--- a/change-logs/2026/07/21/fix-artifact-download-filename.md
+++ b/change-logs/2026/07/21/fix-artifact-download-filename.md
@@ -1,0 +1,1 @@
+Artifact downloads are now named from the artifact title (sanitized) instead of the source HTML basename, so a titled report saves as "Q4 Revenue.zip" rather than "index.zip". Falls back to the HTML file name when no usable title is present.

--- a/src/bun/__tests__/shared-artifacts.test.ts
+++ b/src/bun/__tests__/shared-artifacts.test.ts
@@ -91,6 +91,23 @@ describe("saveSharedArtifact", () => {
 		expect(download.mime).toBe("text/html");
 	});
 
+	it("names the download from the title, sanitizing separators and illegal characters", () => {
+		const html = join(SRC_DIR, "index.html");
+		const image = join(SRC_DIR, "pic.png");
+		writeFileSync(html, '<!doctype html><img src="pic.png">');
+		writeFileSync(image, "PNGDATA");
+		const saved = saveSharedArtifact("/my/project", html, [image], 'Q4 Revenue / "Draft"');
+		expect(basename(saved.bundlePath!)).toBe("index.zip");
+		expect(loadSharedArtifactDownload(saved).fileName).toBe("Q4 Revenue Draft.zip");
+	});
+
+	it("falls back to the HTML basename when the title yields no usable stem", () => {
+		const html = join(SRC_DIR, "index.html");
+		writeFileSync(html, "<!doctype html><p>Hi</p>");
+		const saved = { ...saveSharedArtifact("/my/project", html, []), title: "///" };
+		expect(loadSharedArtifactDownload(saved).fileName).toBe("index.html");
+	});
+
 	it("loads copied images as data URLs and downloads the ZIP bundle", () => {
 		const html = join(SRC_DIR, "bundle.html");
 		const image = join(SRC_DIR, "bundle.png");

--- a/src/bun/shared-artifacts.ts
+++ b/src/bun/shared-artifacts.ts
@@ -212,6 +212,27 @@ export function loadSharedArtifactContent(artifact: SharedArtifact): {
 	return { html, assets };
 }
 
+/** Strip control, separator and Windows-illegal characters so a title is a safe download stem. */
+function sanitizeDownloadStem(raw: string): string {
+	return (raw ?? "")
+		.replace(/[\0-\x1f\x7f]/g, " ")
+		.replace(/[<>:"/\\|?*]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		.replace(/^\.+/, "")
+		.replace(/[.\s]+$/, "")
+		.slice(0, 100)
+		.trim();
+}
+
+/** Human-friendly download name from the artifact title, not the stored HTML basename. */
+export function sharedArtifactDownloadName(artifact: SharedArtifact): string {
+	const ext = artifact.bundlePath ? ".zip" : ".html";
+	const fromTitle = sanitizeDownloadStem(artifact.title);
+	const fallback = basename(artifact.name || artifact.storedPath).replace(/\.html$/i, "");
+	return `${fromTitle || fallback || "artifact"}${ext}`;
+}
+
 /** Read the portable download: ZIP when assets exist, otherwise the HTML. */
 export function loadSharedArtifactDownload(artifact: SharedArtifact): {
 	fileName: string;
@@ -221,7 +242,7 @@ export function loadSharedArtifactDownload(artifact: SharedArtifact): {
 	assertStoredArtifactRecord(artifact);
 	const path = artifact.bundlePath ?? artifact.storedPath;
 	return {
-		fileName: basename(path),
+		fileName: sharedArtifactDownloadName(artifact),
 		mime: artifact.bundlePath ? "application/zip" : "text/html",
 		base64: readFileSync(path).toString("base64"),
 	};


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch) 👋

## Summary

Artifact downloads were named after the source HTML file, so any artifact built from an `index.html` saved as `index.zip` (and the browser piled on `index (1).zip`, `index (2).zip`, …). The name is now derived from the artifact's **title** instead.

- `dev3 show-artifact report.html --title "Q4 Revenue"` now downloads as `Q4 Revenue.zip` rather than `report.zip`/`index.zip`.
- The title is sanitized into a safe filename: control chars and Windows/path-illegal characters (`<>:"/\|?*`) stripped, whitespace collapsed, leading/trailing dots and spaces removed, capped at 100 chars.
- Falls back to the HTML basename when the title yields no usable stem; keeps `.zip` for bundles with assets and `.html` for standalone artifacts.
- Change is isolated to `loadSharedArtifactDownload` in `src/bun/shared-artifacts.ts`; the on-disk stored paths and the renderer are untouched.

### On the "some users don't have zip" question
No tar.gz fallback was added, deliberately: dev3 never shells out to a system `zip` (bundles are built in-process by `createStoreZip`, STORE method), and `.zip` is the most universally double-clickable archive across macOS/Windows/Linux — `.tar.gz` would be a strictly worse fallback (not natively openable on older Windows).

Covered by unit tests in `src/bun/__tests__/shared-artifacts.test.ts` (title-based naming, sanitization, and basename fallback).