### PR TITLE
Add swipe-to-dismiss gesture for toast notifications

### DIFF
--- a/change-logs/2026/07/21/feature-swipe-dismiss-toasts.md
+++ b/change-logs/2026/07/21/feature-swipe-dismiss-toasts.md
@@ -1,0 +1,3 @@
+Short: Swipe toasts away
+
+Toast notifications can now be dismissed with a rightward swipe (touch or mouse drag), in addition to the existing X button — flinging a toast off the right edge is especially handy on mobile. Below-threshold swipes snap back, and a completed drag no longer triggers a clickable toast's action.

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -1,6 +1,18 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setToastSuppressed, ToastHost, toast } from "../toast";
+
+function toastCard(): Element {
+	const card = screen.getByRole("alert").querySelector("[data-toast-card]");
+	if (!card) throw new Error("toast card not found");
+	return card;
+}
+
+function swipe(el: Element, dx: number): void {
+	fireEvent.pointerDown(el, { pointerId: 1, clientX: 0 });
+	fireEvent.pointerMove(el, { pointerId: 1, clientX: dx });
+	fireEvent.pointerUp(el, { pointerId: 1, clientX: dx });
+}
 
 function setRendererActivity(visible: boolean, focused: boolean): void {
 	Object.defineProperty(document, "visibilityState", {
@@ -105,6 +117,71 @@ describe("toast service", () => {
 
 		await user.click(screen.getByRole("button", { name: "Dismiss" }));
 		expect(screen.queryByText("Closable")).not.toBeInTheDocument();
+	});
+
+	it("dismisses a toast on a rightward swipe past the threshold", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Swipe me away");
+		});
+		act(() => {
+			swipe(toastCard(), 200);
+		});
+		expect(screen.queryByText("Swipe me away")).not.toBeInTheDocument();
+	});
+
+	it("keeps a toast when the swipe stays below the dismiss threshold", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Not far enough", { durationMs: 60_000 });
+		});
+		act(() => {
+			swipe(toastCard(), 20);
+		});
+		expect(screen.getByText("Not far enough")).toBeInTheDocument();
+		expect((toastCard() as HTMLElement).style.transform).toBe("translateX(0px)");
+	});
+
+	it("ignores a leftward drag (right-anchored toast only flings right)", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Stay put", { durationMs: 60_000 });
+		});
+		act(() => {
+			swipe(toastCard(), -200);
+		});
+		expect(screen.getByText("Stay put")).toBeInTheDocument();
+	});
+
+	it("suppresses the click that follows a drag on a clickable toast", () => {
+		const onClick = vi.fn();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Open task", { onClick, durationMs: 60_000 });
+		});
+		const alert = screen.getByRole("alert");
+		const card = alert.querySelector("[data-toast-card]") as Element;
+		act(() => {
+			fireEvent.pointerDown(card, { pointerId: 1, clientX: 0 });
+			fireEvent.pointerMove(card, { pointerId: 1, clientX: 30 });
+			fireEvent.pointerUp(card, { pointerId: 1, clientX: 30 });
+		});
+		// The browser fires a click after the drag ends — it must be swallowed.
+		fireEvent.click(within(alert).getByRole("button", { name: "Open task" }));
+		expect(onClick).not.toHaveBeenCalled();
+		expect(screen.getByText("Open task")).toBeInTheDocument();
+	});
+
+	it("still runs a clickable toast's action on a plain click (no drag)", async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Go there", { onClick, durationMs: 60_000 });
+		});
+		await user.click(within(screen.getByRole("alert")).getByRole("button", { name: "Go there" }));
+		expect(onClick).toHaveBeenCalledOnce();
+		expect(screen.queryByText("Go there")).not.toBeInTheDocument();
 	});
 
 	it("auto-dismisses after the given duration", () => {

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -383,6 +383,26 @@ button {
 	to { width: 0%; }
 }
 
+/* ---- Toast swipe-to-dismiss ----
+   Horizontal drag/fling to discard (touch + mouse via Pointer Events).
+   `pan-y` keeps vertical scroll to the page and claims horizontal for us;
+   the transition animates the snap-back / commit, disabled while dragging so
+   the toast tracks the finger 1:1. */
+.toast-swipe {
+	touch-action: pan-y;
+	transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.toast-swipe[data-dragging="true"] {
+	transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.toast-swipe {
+		transition: none;
+	}
+}
+
 /* ---- Tip card rotation progress bar (drives auto-rotate via animationend) ---- */
 
 @keyframes tip-progress {

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -276,85 +276,197 @@ export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
 
 	return (
 		<div className="fixed top-14 right-4 z-[55] flex flex-col gap-2.5 pointer-events-none">
-			{toasts.map(({ entry, paused }) => {
-				const v = VARIANT[entry.variant];
-				return (
-					<div
-						key={entry.id}
-						className="pointer-events-auto animate-slide-in-right"
-						role="alert"
-						data-toast-id={entry.id}
-						onMouseEnter={() => setInteraction(entry.id, "hovered", true)}
-						onMouseLeave={() => setInteraction(entry.id, "hovered", false)}
-						onFocusCapture={() => setInteraction(entry.id, "focused", true)}
-						onBlurCapture={(event) => {
-							const nextFocus = event.relatedTarget;
-							if (!(nextFocus instanceof Node) || !event.currentTarget.contains(nextFocus)) {
-								setInteraction(entry.id, "focused", false);
-							}
+			{toasts.map(({ entry, paused }) => (
+				<ToastCard
+					key={entry.id}
+					entry={entry}
+					paused={paused}
+					onDismiss={removeToast}
+					onInteraction={setInteraction}
+				/>
+			))}
+		</div>
+	);
+}
+
+/** Movement before a press counts as a swipe, not a tap. */
+const SWIPE_DECIDE_PX = 8;
+/** Minimum rightward distance that dismisses (adaptive floor for narrow toasts). */
+const SWIPE_COMMIT_MIN_PX = 72;
+/** …or this fraction of the toast's own width, whichever is larger. */
+const SWIPE_COMMIT_FRACTION = 0.35;
+
+interface ToastCardProps {
+	entry: ToastEntry;
+	paused: boolean;
+	onDismiss: (id: number) => void;
+	onInteraction: (id: number, kind: "hovered" | "focused", value: boolean) => void;
+}
+
+/**
+ * A single toast. Swipe it right (touch or mouse drag, via Pointer Events) to
+ * dismiss — the toast slides in from the right, so flinging it back off the
+ * right edge is the natural discard gesture. The visible X button and click
+ * navigation still work; a completed drag suppresses the click that follows it.
+ */
+function ToastCard({ entry, paused, onDismiss, onInteraction }: ToastCardProps) {
+	const v = VARIANT[entry.variant];
+	const [dragX, setDragX] = useState(0);
+	const [dragging, setDragging] = useState(false);
+	const pointerIdRef = useRef<number | null>(null);
+	const startXRef = useRef(0);
+	const dragXRef = useRef(0);
+	const widthRef = useRef(0);
+	const draggedRef = useRef(false);
+
+	function beginSwipe(e: React.PointerEvent) {
+		if (pointerIdRef.current !== null) return; // ignore additional pointers (multi-touch)
+		pointerIdRef.current = e.pointerId;
+		startXRef.current = e.clientX;
+		widthRef.current = e.currentTarget.getBoundingClientRect().width || 0;
+		draggedRef.current = false;
+		dragXRef.current = 0;
+		setDragging(true);
+		try {
+			e.currentTarget.setPointerCapture(e.pointerId);
+		} catch {
+			// Pointer capture is a best-effort enhancement (absent in happy-dom).
+		}
+	}
+
+	function updateSwipe(e: React.PointerEvent) {
+		if (pointerIdRef.current !== e.pointerId) return;
+		const dx = e.clientX - startXRef.current;
+		if (Math.abs(dx) > SWIPE_DECIDE_PX) draggedRef.current = true;
+		const next = dx > 0 ? dx : 0; // right-anchored toast: only follow rightward
+		dragXRef.current = next;
+		setDragX(next);
+	}
+
+	function endSwipe(e: React.PointerEvent) {
+		if (pointerIdRef.current !== e.pointerId) return;
+		const commit = Math.max(SWIPE_COMMIT_MIN_PX, widthRef.current * SWIPE_COMMIT_FRACTION);
+		const dismiss = dragXRef.current >= commit;
+		try {
+			e.currentTarget.releasePointerCapture(e.pointerId);
+		} catch {
+			// no-op
+		}
+		pointerIdRef.current = null;
+		setDragging(false);
+		if (dismiss) {
+			onDismiss(entry.id);
+		} else {
+			dragXRef.current = 0;
+			setDragX(0);
+		}
+	}
+
+	function cancelSwipe(e: React.PointerEvent) {
+		if (pointerIdRef.current !== e.pointerId) return;
+		pointerIdRef.current = null;
+		draggedRef.current = false;
+		setDragging(false);
+		dragXRef.current = 0;
+		setDragX(0);
+	}
+
+	// A completed drag must not also fire the toast's click/dismiss actions.
+	function suppressIfDragged(): boolean {
+		if (draggedRef.current) {
+			draggedRef.current = false;
+			return true;
+		}
+		return false;
+	}
+
+	const width = widthRef.current > 0 ? widthRef.current : 400;
+	const opacity = 1 - Math.min(0.85, dragX / width);
+
+	return (
+		<div
+			className="pointer-events-auto animate-slide-in-right"
+			role="alert"
+			data-toast-id={entry.id}
+			onMouseEnter={() => onInteraction(entry.id, "hovered", true)}
+			onMouseLeave={() => onInteraction(entry.id, "hovered", false)}
+			onFocusCapture={() => onInteraction(entry.id, "focused", true)}
+			onBlurCapture={(event) => {
+				const nextFocus = event.relatedTarget;
+				if (!(nextFocus instanceof Node) || !event.currentTarget.contains(nextFocus)) {
+					onInteraction(entry.id, "focused", false);
+				}
+			}}
+		>
+			<div
+				data-toast-card
+				data-dragging={dragging ? "true" : "false"}
+				className={`toast-swipe relative overflow-hidden bg-overlay border ${v.border} rounded-xl shadow-2xl w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3 p-4`}
+				style={{ transform: `translateX(${dragX}px)`, opacity }}
+				onPointerDown={beginSwipe}
+				onPointerMove={updateSwipe}
+				onPointerUp={endSwipe}
+				onPointerCancel={cancelSwipe}
+			>
+				<span
+					className={`${v.text} text-2xl leading-none mt-0.5 flex-shrink-0`}
+					style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+				>
+					{v.icon}
+				</span>
+				{entry.onClick ? (
+					<button
+						type="button"
+						onClick={() => {
+							if (suppressIfDragged()) return;
+							entry.onClick?.();
+							onDismiss(entry.id);
 						}}
+						className="flex-1 min-w-0 text-left pr-1 cursor-pointer group"
 					>
-						<div
-							className={`relative overflow-hidden bg-overlay border ${v.border} rounded-xl shadow-2xl w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3 p-4`}
-						>
-							<span
-								className={`${v.text} text-2xl leading-none mt-0.5 flex-shrink-0`}
-								style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-							>
-								{v.icon}
-							</span>
-							{entry.onClick ? (
-								<button
-									type="button"
-									onClick={() => {
-										entry.onClick?.();
-										removeToast(entry.id);
-									}}
-									className="flex-1 min-w-0 text-left pr-1 cursor-pointer group"
-								>
-									{entry.context && (
-										<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-											{entry.context}
-										</div>
-									)}
-									<div className="text-fg text-sm leading-relaxed break-words group-hover:underline">
-										{entry.message}
-									</div>
-								</button>
-							) : (
-								<div className="flex-1 min-w-0 pr-1">
-									{entry.context && (
-										<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-											{entry.context}
-										</div>
-									)}
-									<div className="text-fg text-sm leading-relaxed break-words">
-										{entry.message}
-									</div>
-								</div>
-							)}
-							<button
-								type="button"
-								onClick={() => removeToast(entry.id)}
-								aria-label="Dismiss"
-								className="text-fg-muted hover:text-fg transition-colors flex-shrink-0"
-							>
-								<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-								</svg>
-							</button>
-							<div
-								data-toast-progress
-								className={`absolute bottom-0 left-0 h-0.5 ${v.bar} opacity-50`}
-								style={{
-									animation: `toast-shrink ${entry.durationMs}ms linear forwards`,
-									animationPlayState: paused ? "paused" : "running",
-								}}
-							/>
+						{entry.context && (
+							<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
+								{entry.context}
+							</div>
+						)}
+						<div className="text-fg text-sm leading-relaxed break-words group-hover:underline">
+							{entry.message}
+						</div>
+					</button>
+				) : (
+					<div className="flex-1 min-w-0 pr-1">
+						{entry.context && (
+							<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
+								{entry.context}
+							</div>
+						)}
+						<div className="text-fg text-sm leading-relaxed break-words">
+							{entry.message}
 						</div>
 					</div>
-				);
-			})}
+				)}
+				<button
+					type="button"
+					onClick={() => {
+						if (suppressIfDragged()) return;
+						onDismiss(entry.id);
+					}}
+					aria-label="Dismiss"
+					className="text-fg-muted hover:text-fg transition-colors flex-shrink-0"
+				>
+					<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+					</svg>
+				</button>
+				<div
+					data-toast-progress
+					className={`absolute bottom-0 left-0 h-0.5 ${v.bar} opacity-50`}
+					style={{
+						animation: `toast-shrink ${entry.durationMs}ms linear forwards`,
+						animationPlayState: paused ? "paused" : "running",
+					}}
+				/>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

Toast notifications can now be dismissed with a rightward swipe — touch or mouse drag, unified via Pointer Events — in addition to the existing X button. The toast slides in from the right, so flinging it back off the right edge is the natural discard gesture; it's especially handy on mobile.

- Extract each toast into a `ToastCard` component that holds its own drag state (`src/mainview/toast.tsx`).
- The toast tracks the pointer and fades while dragged; releasing past a width-adaptive threshold (max of 72px or 35% of the toast width) dismisses it, shorter drags snap back.
- Only rightward drags are followed (the toast is anchored to the right edge); a completed drag suppresses the click that follows, so clickable toasts (e.g. "open task") aren't accidentally activated.
- `touch-action: pan-y` keeps vertical page scroll intact; snap-back/commit animation respects `prefers-reduced-motion`.

## Tests

- 5 new unit tests in `toast.test.tsx`: dismiss on rightward swipe, snap-back below threshold, leftward drag ignored, click-suppression after a drag, plain click still fires.
- Full suite green (mainview / bun / cli), lint clean.
- Manually QA'd the live gesture in a browser (drag follow + fade, commit dismiss, snap-back).