### PR TITLE
Make PR conversation header fully clickable

### DIFF
--- a/change-logs/2026/07/21/fix-clickable-pr-conversation-row.md
+++ b/change-logs/2026/07/21/fix-clickable-pr-conversation-row.md
@@ -1,0 +1,1 @@
+Make the full pull request conversation header clickable for expanding and collapsing, while keeping resolved-thread, refresh, and GitHub link controls independent.

--- a/src/mainview/components/pr-review/PrConversationBlock.tsx
+++ b/src/mainview/components/pr-review/PrConversationBlock.tsx
@@ -61,16 +61,17 @@ export function PrConversationBlock({
 	const unresolvedCount = threads.filter((thread) => !thread.isResolved).length;
 	const resolvedCount = threads.length - unresolvedCount;
 	const unmappedCount = unmappedThreads.reduce((sum, group) => sum + group.threads.length, 0);
+	const toggleExpanded = () => setExpanded((current) => !current);
 
 	return (
 		<div className="mb-4 rounded-xl border border-edge bg-raised" data-testid="pr-conversation-block">
 			<div className="flex flex-wrap items-center gap-2 px-4 py-2.5">
 				<button
 					type="button"
-					onClick={() => setExpanded((current) => !current)}
+					onClick={toggleExpanded}
 					aria-expanded={expanded}
 					data-testid="pr-conversation-toggle"
-					className="flex min-w-0 items-center gap-2 text-left transition-colors hover:text-fg"
+					className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left transition-colors hover:bg-raised-hover hover:text-fg"
 				>
 					<span aria-hidden="true" className="text-[1rem] leading-none text-fg-2" style={{ fontFamily: NERD_FONT }}>
 						{GITHUB_GLYPH}
@@ -78,21 +79,18 @@ export function PrConversationBlock({
 					<span className="text-xs font-semibold text-fg">{t("infoPanel.prConversationTitle")}</span>
 					<span className="rounded bg-base px-1.5 py-px font-mono text-[0.6875rem] text-fg-3">{conversation.length}</span>
 					<span aria-hidden="true" className="text-[0.8rem] text-fg-3">{expanded ? "▾" : "▸"}</span>
+					{unresolvedCount > 0 && (
+						<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-[0.6875rem] font-semibold text-warning">
+							{t.plural("infoPanel.prUnresolvedCount", unresolvedCount)}
+						</span>
+					)}
+					<span className="flex-1" />
+					{payload && (
+						<span className="text-[0.6875rem] text-fg-muted" title={payload.fetchedAt}>
+							{t("infoPanel.prFetchedAt", { time: formatCommentTimestamp(payload.fetchedAt) })}
+						</span>
+					)}
 				</button>
-
-				{unresolvedCount > 0 && (
-					<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-[0.6875rem] font-semibold text-warning">
-						{t.plural("infoPanel.prUnresolvedCount", unresolvedCount)}
-					</span>
-				)}
-
-				<span className="flex-1" />
-
-				{payload && (
-					<span className="text-[0.6875rem] text-fg-muted" title={payload.fetchedAt}>
-						{t("infoPanel.prFetchedAt", { time: formatCommentTimestamp(payload.fetchedAt) })}
-					</span>
-				)}
 
 				{resolvedCount > 0 && (
 					<button

--- a/src/mainview/components/pr-review/__tests__/PrConversationBlock.test.tsx
+++ b/src/mainview/components/pr-review/__tests__/PrConversationBlock.test.tsx
@@ -87,8 +87,11 @@ describe("PrConversationBlock", () => {
 	it("shows the title, comment count, and unresolved badge", () => {
 		renderBlock();
 		const block = screen.getByTestId("pr-conversation-block");
-		expect(within(block).getByText("Conversation")).toBeInTheDocument();
-		expect(within(block).getByText("1 unresolved")).toBeInTheDocument();
+		const toggle = within(block).getByTestId("pr-conversation-toggle");
+		expect(within(toggle).getByText("Conversation")).toBeInTheDocument();
+		expect(within(toggle).getByText("1 unresolved")).toBeInTheDocument();
+		expect(within(toggle).getByText(/Updated/)).toBeInTheDocument();
+		expect(toggle).toHaveClass("flex-1");
 	});
 
 	it("expands to reveal sanitized markdown conversation comments with a GitHub link", async () => {
@@ -117,6 +120,7 @@ describe("PrConversationBlock", () => {
 		const { onRefresh } = renderBlock();
 		await user.click(screen.getByTestId("pr-comments-refresh"));
 		expect(onRefresh).toHaveBeenCalledTimes(1);
+		expect(screen.queryByTestId("pr-conversation-list")).not.toBeInTheDocument();
 	});
 
 	it("offers the show-resolved toggle only when resolved threads exist", () => {
@@ -131,6 +135,7 @@ describe("PrConversationBlock", () => {
 		});
 		await user.click(screen.getByTestId("pr-show-resolved-toggle"));
 		expect(onToggleShowResolved).toHaveBeenCalledTimes(1);
+		expect(screen.queryByTestId("pr-conversation-list")).not.toBeInTheDocument();
 	});
 
 	it("renders the error row with a retry action", async () => {


### PR DESCRIPTION
## Summary

- Make the PR conversation header toggle button span the full available row.
- Keep Show resolved, refresh, and Open on GitHub controls independent.
- Add regression coverage and a changelog entry.

## Tests

- `bun run lint`
- `bun run test`
- Browser QA on a real PR diff; verified clicking blank header space expands the conversation without console errors.