### PR TITLE
Fix dead-end empty task pane: mobile redirect + Back to Kanban button

### DIFF
--- a/change-logs/2026/07/21/fix-empty-task-pane-nav.md
+++ b/change-logs/2026/07/21/fix-empty-task-pane-nav.md
@@ -1,0 +1,1 @@
+The empty "Select a task to see its terminal" pane is no longer a dead end: on narrow (mobile) viewports it now redirects straight back to the Kanban board, and on desktop it shows a "Back to Kanban" button.

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -115,6 +115,13 @@ function ProjectView({
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per open
 	}, [inlineDiff.isOpen, projectId, activeTaskId]);
 
+	// The empty "select a task" pane is a dead end on narrow viewports — there is
+	// no split task list to pick from — so bounce straight back to the Kanban board.
+	const showingEmptyTaskPane = Boolean(taskView) && !activeTaskId;
+	useEffect(() => {
+		if (isNarrow && showingEmptyTaskPane) navigate({ screen: "project", projectId });
+	}, [isNarrow, showingEmptyTaskPane, navigate, projectId]);
+
 	useEffect(() => {
 		if (!openUnresolvedComments) {
 			unresolvedRouteKeyRef.current = null;
@@ -158,8 +165,18 @@ function ProjectView({
 				skipCopyModeReset={skipCopyModeReset}
 			/>
 		) : (
-			<div className="h-full w-full flex items-center justify-center bg-base px-6 text-center">
+			<div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-base px-6 text-center">
 				<span className="text-fg-muted text-sm">{t("project.selectTaskForTerminal")}</span>
+				<button
+					type="button"
+					onClick={() => navigate({ screen: "project", projectId })}
+					className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-edge bg-raised text-fg-3 hover:text-fg hover:bg-raised-hover hover:border-edge-active transition-colors text-sm"
+				>
+					<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+					</svg>
+					<span>{t("project.backToKanban")}</span>
+				</button>
 			</div>
 		);
 

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -105,6 +105,16 @@ describe("ProjectView task-view layout", () => {
 		expect(screen.queryByTestId("workspace")).not.toBeInTheDocument();
 	});
 
+	it("navigates back to the Kanban board from the empty-pane button (wide viewport)", async () => {
+		const navigate = vi.fn();
+		renderView({ taskView: true, navigate });
+		await waitFor(() => expect(screen.getByText("Back to Kanban")).toBeInTheDocument());
+
+		await userEvent.click(screen.getByText("Back to Kanban"));
+
+		expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+	});
+
 	it("renders the task workspace (no placeholder) when a task is active", async () => {
 		const task = { id: "t1", projectId: "p1", title: "T", status: "in-progress" } as unknown as Task;
 		renderView({ activeTaskId: "t1", tasks: [task] });
@@ -206,5 +216,11 @@ describe("ProjectView narrow viewport (mobile zoom)", () => {
 		renderView({ activeTaskId: "t1", tasks: [task] });
 		await waitFor(() => expect(screen.getByTestId("workspace")).toBeInTheDocument());
 		expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
+	});
+
+	it("redirects the useless empty task pane back to Kanban", async () => {
+		const navigate = vi.fn();
+		renderView({ taskView: true, navigate });
+		await waitFor(() => expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" }));
 	});
 });

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -348,6 +348,7 @@ const settings = {
 	// ProjectView
 	"project.notFound": "Project not found",
 	"project.selectTaskForTerminal": "Select a task to see its terminal",
+	"project.backToKanban": "Back to Kanban",
 
 	// Token-saving proxy (pxpipe) — experimental, opt-in
 	"settings.pxpipeSection": "Token-saving proxy (experimental)",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -349,6 +349,7 @@ const settings = {
 	// ProjectView
 	"project.notFound": "Proyecto no encontrado",
 	"project.selectTaskForTerminal": "Selecciona una tarea para ver su terminal",
+	"project.backToKanban": "Volver al Kanban",
 
 	// Token-saving proxy (pxpipe) — experimental, opt-in
 	"settings.pxpipeSection": "Proxy de ahorro de tokens (experimental)",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -350,6 +350,7 @@ const settings = {
 	// ProjectView
 	"project.notFound": "Проект не найден",
 	"project.selectTaskForTerminal": "Выберите задачу, чтобы увидеть её терминал",
+	"project.backToKanban": "Назад к канбану",
 
 	// Token-saving proxy (pxpipe) — experimental, opt-in
 	"settings.pxpipeSection": "Прокси для экономии токенов (эксперимент)",


### PR DESCRIPTION
## Summary

The empty **"Select a task to see its terminal"** pane (shown in split open-mode when a task view has no task selected — e.g. right after a task completes) was a dead end with no way out.

- **Narrow (mobile) viewports:** the pane is useless there (no split task list to pick from), so it now redirects straight back to the Kanban board.
- **Desktop:** the placeholder now shows a **Back to Kanban** button (chevron + label), reusing the existing "Back to Board" toolbar pattern and semantic design tokens.
- Added the `project.backToKanban` i18n key across all three locales (en/ru/es).

Both behaviors are covered by unit tests in `ProjectView.test.tsx` (wide-viewport button click → navigate to Kanban; narrow-viewport auto-redirect).