### PR TITLE
Preserve task assignment when spawning Bug Hunters

### DIFF
--- a/change-logs/2026/07/21/fix-bug-hunter-task-assignment.md
+++ b/change-logs/2026/07/21/fix-bug-hunter-task-assignment.md
@@ -1,0 +1,5 @@
+Short: Preserve task assignment
+
+Spawning an in-task Bug Hunter now keeps the originating task assigned to its primary agent and configuration while recording the hunter on its own pane.
+
+Suggested by @Capibara- (h0x91b/dev-3.0#1024)

--- a/decisions/149-bug-hunter-prompt-isolation.md
+++ b/decisions/149-bug-hunter-prompt-isolation.md
@@ -6,16 +6,16 @@ In-task Bug Hunters share the originating task's worktree and task id with its m
 
 ## Investigation
 
-The in-task launch prompt already limits code inspection and routes findings through `dev3 note add`, but the shared lifecycle prompt had no Bug Hunter exception. Separately, native lifecycle hooks still observe the shared task, and `spawnSingleBugHunterPane` currently records the hunter's agent configuration on that task.
+The in-task launch prompt already limits code inspection and routes findings through `dev3 note add`, but the shared lifecycle prompt had no Bug Hunter exception. Separately, [`spawnSingleBugHunterPane`](../src/bun/rpc-handlers/tmux-pty.ts) stored the hunter's agent configuration both on its pane and on the originating task, replacing the primary agent's assignment.
 
 ## Decision
 
-Add an in-task Bug Hunter isolation rule before the shared session-start checklist, repeat it in the Bug Hunter skill, and front-load it in `buildBugHunterPrompt`. Hunters may read dev3 state and add confirmed `[bug-hunt]` notes, but must leave the branch and existing task metadata/lifecycle to the main agent.
+Add an in-task Bug Hunter isolation rule before the shared session-start checklist, repeat it in the Bug Hunter skill, and front-load it in [`buildBugHunterPrompt`](../src/bun/rpc-handlers/tmux-pty.ts). Store hunter attribution only on its `sessionState.panes` entry; the originating task keeps the primary agent and configuration.
 
 ## Risks
 
-This is a prompt-level safeguard, so it prevents cooperative agent actions but is not a capability boundary. Native hooks can still change status, and the spawn handler still changes task-level agent attribution; those require a later observer-role mechanism outside the prompt.
+The metadata safeguard remains prompt-based rather than a capability boundary, and native hooks still observe the shared task. If cooperative isolation proves insufficient, reopen the issue and evaluate scoped capabilities or observer roles separately.
 
 ## Alternatives considered
 
-Removing all dev3 access was rejected because notes are the handoff channel from hidden hunter panes. Disabling hooks or introducing scoped CLI capabilities in this change was deferred because the user explicitly chose the smallest prompt-first mitigation while the correct observer boundary is designed separately.
+Removing all dev3 access was rejected because notes are the handoff channel from hidden hunter panes. Disabling hooks was rejected because it has a much larger lifecycle blast radius; scoped CLI capabilities and observer roles remain deferred unless the prompt safeguard fails in practice.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -7657,6 +7657,51 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		}
 	});
 
+	it("preserves the task assignment while attributing the hunter pane", async () => {
+		const project = makeProject();
+		let persistedTask = makeTask({
+			id: "abcd1234-full-id",
+			worktreePath: "/tmp/wt",
+			agentId: "primary-agent",
+			configId: "primary-config",
+		});
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockImplementation(async () => persistedTask);
+		(data.updateTask as any).mockImplementation(async (_project: Project, _taskId: string, patch: Partial<Task>) => {
+			persistedTask = { ...persistedTask, ...patch };
+			return persistedTask;
+		});
+		(agents.resolveCommandForAgent as any).mockResolvedValue({
+			command: "claude",
+			extraEnv: {},
+			agent: { id: "hunter-agent", baseCommand: "claude" },
+			config: { id: "hunter-config" },
+		});
+		makeSplitMock(["%10"]);
+
+		await handlers.spawnBugHuntersInTask({
+			taskId: persistedTask.id,
+			projectId: project.id,
+			agentId: "hunter-agent",
+			configId: "hunter-config",
+			count: 1,
+		});
+
+		expect(persistedTask).toMatchObject({
+			agentId: "primary-agent",
+			configId: "primary-config",
+			sessionState: {
+				panes: [
+					expect.objectContaining({
+						paneId: "%10",
+						agentId: "hunter-agent",
+						configId: "hunter-config",
+					}),
+				],
+			},
+		});
+	});
+
 	it("pastes the `$dev3-bug-hunter` prefix for Codex agents", async () => {
 		const project = makeProject();
 		const task = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/wt" });

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -2473,8 +2473,6 @@ async function spawnSingleBugHunterPane(opts: {
 		const freshTask = await data.getTask(opts.project, opts.task.id);
 		const existingPanes = freshTask.sessionState?.panes ?? [];
 		const updated = await data.updateTask(opts.project, opts.task.id, {
-			agentId: launchedAgentId,
-			configId: launchedConfigId,
 			sessionState: { panes: [...existingPanes, paneEntry] },
 		});
 		getPushMessage()?.("taskUpdated", { projectId: opts.project.id, task: updated });


### PR DESCRIPTION
Closes #1024

## Summary
- keep the originating task assigned to its primary agent and configuration
- retain Bug Hunter agent/config attribution on the hunter pane
- keep the prompt isolation from #1026 and leave native lifecycle hooks unchanged

## Tests
- `bun run lint`
- `bun run test`