### PR TITLE
docs: decision record for moving a To Do task between projects

### DIFF
--- a/decisions/148-move-task-between-projects.md
+++ b/decisions/148-move-task-between-projects.md
@@ -1,0 +1,93 @@
+# 148 — Move a To Do task between projects
+
+## Ubiquitous language
+
+- **Move task to project** — relocating a *single To Do (backlog) task* from its
+  current project's board to another project's board. It is a **true move**, not a
+  copy: the task keeps its identity and disappears from the source board.
+- **Portable fields** — task fields that survive the move unchanged (title,
+  description, overview/userOverview, notes, history, priority, watched,
+  provenance like `automationId`).
+- **Project-scoped fields** — fields whose values only make sense within one
+  project (`seq`, `projectId`, `baseBranch`, `labelIds`, `customColumnId`). These
+  are re-derived or remapped on move, never carried verbatim.
+
+## Context
+
+Users occasionally create a task on the wrong board. There is currently no way to
+relocate it; the only workaround is to re-type it in the right project and delete
+the original. We want a first-class "move this task to another project" action.
+
+Scope is intentionally limited to **To Do** tasks. A backlog task has
+`worktreePath: null`, `branchName: null`, and no tmux session, so relocating it is
+a pure data operation — no git worktree, branch, or terminal to migrate across
+repos. Active tasks would require migrating live git/tmux state and are out of
+scope.
+
+## Investigation
+
+- Tasks are stored per-project (`~/.dev3.0/data/<slug>/tasks.json`); `seq` is
+  assigned by `nextSeq()` scanning that project's tasks, so it is **project-scoped**
+  and must be reassigned on move. Task `id` is a UUID independent of project
+  (`src/bun/data.ts`).
+- `addTask()` already accepts `notes`, `overview`, `userOverview`, `priority`,
+  `labelIds`, `customTitle`, `titleEditedByUser`; `deleteTask()` just filters the
+  task out of the source file (safe for To Do — no worktree teardown needed).
+- `Label`s and `CustomColumn`s belong to `Project` (`src/shared/types.ts`), so a
+  moved task's `labelIds` reference labels that do not exist in the target.
+- `TaskCard.handleContextMenu` is gated `if (!task.worktreePath) return`, so To Do
+  cards have no right-click menu today; a To Do card click opens `TaskDetailModal`
+  (`TaskCard.tsx`), which is the shared desktop+mobile detail surface.
+- The modal is a fixed-width `w-[35rem]` centered dialog — an anchored popover
+  inside it is cramped on a phone. The app's established mobile pattern is a
+  bottom `BottomSheet` action sheet (`TaskInfoPanel`, `GlobalHeader`).
+
+## Decision
+
+Add a **new RPC handler `moveTaskToProject({ taskId, fromProjectId, toProjectId })`**
+(UI only for now — no CLI command). It runs under both projects' file locks and:
+
+1. Loads the source task; **rejects** if `status !== "todo"` (backlog-only).
+2. Keeps the **same `id`**; sets `projectId = target`, `seq = nextSeq(targetTasks)`,
+   `baseBranch = deriveTaskBaseBranch(targetProject)`, clears `opsWorkDir` and
+   `customColumnId`.
+3. **Labels: match by name.** For each source `labelId`, look up the source label's
+   name and attach the target project's label with the same name if one exists;
+   otherwise drop it. No labels are auto-created.
+4. **Clears `scheduledLaunch`** (a deferred "Start in…" carries an agent/branch
+   config from the old project context that must not fire in the new one).
+5. Appends the moved task to the target `tasks.json` and removes it from the source
+   `tasks.json`. Pushes `taskUpdated`/removal to all renderers.
+6. **Cross-kind allowed** (git↔git, git↔virtual, virtual↔virtual): a To Do task has
+   no git state, so the re-derived `baseBranch` / cleared `opsWorkDir` cover it.
+
+UI: a **"Move to project…"** action in `TaskDetailModal` (next to Delete). It opens
+a **searchable project list** (current + deleted projects excluded). On desktop the
+list is an anchored popover; on mobile it renders as a bottom `BottomSheet`.
+**No confirmation dialog** — picking the target is the confirmation, and the move is
+reversible by moving back; a success toast reports the destination.
+
+## Risks
+
+- **Label loss is silent.** A source label with no same-name twin in the target is
+  dropped without warning. Mitigated by the match-by-name rule keeping common tags
+  and by the move being reversible.
+- **Same-`id` move across project files** must be atomic-enough that a crash between
+  the two writes cannot duplicate or lose the task. Append-to-target-then-remove
+  order + the existing read-back verification (`addTask` pattern, decision 082)
+  bound the worst case to a harmless duplicate, never a loss.
+- **Mobile modal width** (`w-[35rem]`) is a pre-existing constraint; the BottomSheet
+  picker sidesteps it for this flow but the modal itself is not re-fitted here.
+
+## Alternatives considered
+
+- **Copy + delete with a new `id`** — literal reading of the request, but loses
+  `createdAt`/continuity; rejected in favor of a true move.
+- **Recreate missing labels in the target** — keeps all tags but breeds
+  near-duplicate labels across projects; rejected for match-by-name-or-drop.
+- **CLI command / right-click on To Do / drag onto a sidebar board** — deferred;
+  the modal action is the single home for v1.
+- **Block move when `scheduledLaunch` is set** — safe but annoying; chose to clear
+  it instead so the move always succeeds.
+- **Confirm dialog / Undo toast** — unnecessary for a reversible action; plain
+  success toast chosen.


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch) 👋

Adds decision record **148** capturing the design for a new "Move to project…" action that relocates a **To Do task** from one project's board to another. Produced from a grilling + spec session; the design is fully locked.

Highlights of the locked design:
- **Scope:** To Do (backlog) tasks only — a backlog task has no worktree/branch/tmux, so the move is a pure data operation with nothing to tear down or migrate across repos.
- **True move:** the task keeps its `id`; only project-scoped fields change (`seq` re-assigned per-project, `projectId`, base branch re-derived from the target).
- **Labels:** matched to the target project by name, otherwise dropped — no auto-created labels.
- **Cleared on move:** deferred launch (`scheduledLaunch`), `opsWorkDir`, `customColumnId`. Cross-kind (git ↔ virtual/Operations) moves are allowed.
- **UI:** a "Move to project…" action in the task detail modal with a searchable project picker — anchored popover on desktop, bottom sheet on mobile. No confirmation dialog; success toast.

This PR is **docs-only** (the decision record). The implementation is tracked separately as a dev3 task with the full spec/PRD.