### PR TITLE
Contain native Windows PTY process trees

### DIFF
--- a/change-logs/2026/07/20/feature-windows-detached-pty-containment.md
+++ b/change-logs/2026/07/20/feature-windows-detached-pty-containment.md
@@ -1,1 +1,0 @@
-The isolated detached-PTY tracer now contains native Windows shells and all descendants in a kill-on-close Job Object. Stop gracefully requests exit, then forcefully removes the selected tree, endpoint, handles, and metadata without touching tmux.

--- a/change-logs/2026/07/20/feature-windows-detached-pty-containment.md
+++ b/change-logs/2026/07/20/feature-windows-detached-pty-containment.md
@@ -1,0 +1,1 @@
+The isolated detached-PTY tracer now contains native Windows shells and all descendants in a kill-on-close Job Object. Stop gracefully requests exit, then forcefully removes the selected tree, endpoint, handles, and metadata without touching tmux.

--- a/change-logs/2026/07/21/feature-windows-detached-pty-containment.md
+++ b/change-logs/2026/07/21/feature-windows-detached-pty-containment.md
@@ -1,0 +1,1 @@
+The isolated detached-PTY tracer now contains native Windows shells and all descendants in a kill-on-close Job Object. Stop gracefully requests exit, then forcefully removes the selected tree, endpoint, handles, and metadata without touching tmux; the native regression synchronizes with each PowerShell prompt before checking shell state and ownership.

--- a/decisions/144-detached-bun-pty-owner-spike.md
+++ b/decisions/144-detached-bun-pty-owner-spike.md
@@ -44,8 +44,9 @@ own shell tree and removes only its own files.
 
 ## Risks
 
-- Full process-tree kill on Windows is out of scope (Bun `proc.kill()` only) —
-  the POSIX ppid-walk is the tracer's proof.
+- The original spike left full Windows process-tree cleanup out of scope. The
+  additive follow-up in [decision 146](146-windows-job-object-containment.md)
+  closes that gap with pre-spawn Job Object inheritance and kill-on-close.
 - The `~/.dev3.0/pty-proto/` default path is additive; `clearState` unlinks only
   the two files it created and `rmdir`s the dir only if empty (non-recursive), so
   it can never touch other `~/.dev3.0` state or any tmux session.

--- a/decisions/146-windows-job-object-containment.md
+++ b/decisions/146-windows-job-object-containment.md
@@ -1,0 +1,39 @@
+# 146 — Windows Job Object containment for detached PTYs
+
+## Context
+
+The detached PTY tracer reattached to the same PowerShell PID and state on Bun
+1.3.14, but stopping host PID `2572` and root PID `10584` left nested PowerShell
+PID `14600` alive. This follow-up must own the Windows tree without entering the
+production tmux spawn, attach, or stop graph.
+
+## Investigation
+
+[Windows Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)
+assign children to every non-breakaway job in their parent's chain at process
+creation, and kill-on-close terminates all members with the final handle.
+[Bun FFI](https://bun.sh/docs/runtime/ffi) represents Win32 `HANDLE` values as
+`u64`; direct `kernel32.dll` calls suffice here, but FFI remains experimental.
+
+## Decision
+
+`windows-job.ts` creates a unique token-named Job Object, enables kill-on-close,
+and enrols the detached host before `host.ts` calls `Bun.spawn`; the root shell
+and every descendant therefore inherit containment without an assignment race.
+Stop sends Ctrl-C plus `exit`, waits 1.5 seconds, clears token-matched metadata,
+then closes the owning handle; launcher fallback terminates only that named job.
+
+## Risks
+
+Nested-job assignment can fail under an incompatible outer job, and Bun FFI has
+known limitations. Such a failure occurs before the native root shell spawns and
+cannot touch tmux; the prototype logs the Win32 error and aborts startup. Because
+the host is a job member, forceful close intentionally ends it after cleanup.
+
+## Alternatives considered
+
+A post-spawn `AssignProcessToJobObject` was rejected because descendants can race
+the assignment. A signed helper remains plausible for production hardening, but
+adds architecture builds, signing, updater, and version-skew work without helping
+this isolated proof; revisit it with runtime packaging. `taskkill /T` and PID
+walks were rejected as PID-scoped snapshots rather than durable ownership.

--- a/src/bun/prototypes/detached-pty/README.md
+++ b/src/bun/prototypes/detached-pty/README.md
@@ -139,8 +139,10 @@ Expected output:
 
 - `bun run test:proto-e2e` — real-runtime regression on Windows and POSIX. It
   proves start → reconnect → child + grandchild → stop, ownership isolation,
-  endpoint/handle/metadata cleanup, idempotence, and no tmux invocation. Expected
+  endpoint/handle/metadata cleanup, idempotence, and no tmux invocation. Windows
+  probes retry harmless commands while each PowerShell prompt starts. Expected
   final line: `ALL CHECKS PASSED`.
-- `__tests__/protocol.test.ts`, `__tests__/state.test.ts`, and
-  `__tests__/windows-job.test.ts` — vitest units for pure protocol/state logic and
-  the Win32 handle lifecycle; part of `bun run test`.
+- `__tests__/command-roundtrip.test.ts`, `__tests__/protocol.test.ts`,
+  `__tests__/state.test.ts`, and `__tests__/windows-job.test.ts` — vitest units
+  for startup command round trips, pure protocol/state logic, and the Win32
+  handle lifecycle; part of `bun run test`.

--- a/src/bun/prototypes/detached-pty/README.md
+++ b/src/bun/prototypes/detached-pty/README.md
@@ -20,6 +20,7 @@ completely unaffected.
 | `launcher.ts` | `start()` spawns the host detached and waits for readiness, then returns without killing it; `stop()`/`status()` rediscover it from metadata. |
 | `client.ts`   | Short-lived attach handle; `discover()` reconnects a fresh process from metadata alone. |
 | `state.ts`    | Discovery metadata (`~/.dev3.0/pty-proto/state.json`, override via `DEV3_PTY_PROTO_DIR`). |
+| `windows-job.ts` | Windows Job Object creation, self-enrolment, scoped force-stop, and handle queries. |
 | `protocol.ts` | Wire protocol: binary frames = PTY bytes, text frames = JSON control. |
 | `cli.ts`      | Manual driver + the `__host` re-entry the launcher spawns. |
 

--- a/src/bun/prototypes/detached-pty/README.md
+++ b/src/bun/prototypes/detached-pty/README.md
@@ -32,9 +32,20 @@ completely unaffected.
 - **Detached lifecycle mirrors `dev3 remote --detach`:** the host writes a state
   file as its readiness signal; the launcher polls it, then exits; separate
   processes rediscover the host via that file.
-- **Stop = process-group kill.** `Bun.Terminal` makes the shell a session leader,
-  so on POSIX `kill(-shellPid)` reaps the whole tree; Windows falls back to
-  killing the subprocess directly.
+- **Stop owns a process tree.** POSIX snapshots the root shell's PPID tree before
+  signalling it. Windows creates a uniquely named Job Object with
+  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, enrols the detached host before
+  `Bun.spawn`, and lets the root shell plus descendants inherit that boundary.
+- **Windows stop is graceful, bounded, then forceful.** The host sends Ctrl-C +
+  `exit`, waits 1.5 seconds, removes only its token-matched metadata, then closes
+  the Job Object handle. Kill-on-close terminates the host and every survivor.
+  A disconnected launcher opens and terminates that same token-named job instead
+  of trusting a possibly reused PID.
+
+The Job Object bridge uses `bun:ffi` only inside this prototype and only on
+Windows. The detached host self-enrolment removes the root-assignment race without
+reimplementing Bun's ConPTY spawn in a helper. See
+[`decisions/146-windows-job-object-containment.md`](../../../../decisions/146-windows-job-object-containment.md).
 
 ## Try it
 
@@ -46,11 +57,89 @@ bun src/bun/prototypes/detached-pty/cli.ts status
 bun src/bun/prototypes/detached-pty/cli.ts stop
 ```
 
+`stop` is idempotent: repeating it after cleanup prints `stopped` and exits 0.
+
+## Native Windows PowerShell reproduction
+
+Use native Windows PowerShell 5.1 or `pwsh` with Bun **1.3.14 or newer**, from
+the repository root:
+
+```powershell
+$cli = "src/bun/prototypes/detached-pty/cli.ts"
+$run = Join-Path $env:TEMP ("dev3-pty-job-" + [guid]::NewGuid())
+$env:DEV3_PTY_PROTO_DIR = Join-Path $run "meta"
+$env:DEV3_PTY_EVIDENCE_DIR = Join-Path $run "evidence"
+$env:DEV3_PTY_PROTO_CMD = '["powershell.exe","-NoLogo","-NoProfile"]'
+New-Item -ItemType Directory -Path $env:DEV3_PTY_EVIDENCE_DIR | Out-Null
+
+bun --version
+bun $cli start
+bun $cli attach
+```
+
+At the first attached prompt, enter these lines, then press **Ctrl-]**:
+
+```powershell
+$env:DEV3_REATTACH_TEST = "works"
+Write-Output "ROOTPID[$PID]"
+```
+
+Back at the outer prompt, reconnect and create a nested child plus grandchild:
+
+```powershell
+bun $cli status
+bun $cli attach
+```
+
+At the second attached prompt, enter:
+
+```powershell
+Write-Output "REATTACHED[$PID][$env:DEV3_REATTACH_TEST]"
+powershell.exe -NoLogo -NoProfile
+Set-Content (Join-Path $env:DEV3_PTY_EVIDENCE_DIR "child.pid") $PID
+Write-Output "CHILDPID[$PID]"
+$grand = Start-Process -PassThru powershell.exe -ArgumentList @('-NoLogo','-NoProfile','-Command','Start-Sleep -Seconds 300')
+Set-Content (Join-Path $env:DEV3_PTY_EVIDENCE_DIR "grandchild.pid") $grand.Id
+Write-Output "GRANDCHILDPID[$($grand.Id)]"
+```
+
+Press **Ctrl-]** again, then prove teardown from the outer prompt:
+
+```powershell
+$state = Get-Content (Join-Path $env:DEV3_PTY_PROTO_DIR "state.json") | ConvertFrom-Json
+$childPid = [int](Get-Content (Join-Path $env:DEV3_PTY_EVIDENCE_DIR "child.pid"))
+$grandchildPid = [int](Get-Content (Join-Path $env:DEV3_PTY_EVIDENCE_DIR "grandchild.pid"))
+$ownedPids = @([int]$state.hostPid, [int]$state.shellPid, $childPid, $grandchildPid)
+Get-Process -Id $ownedPids
+
+bun $cli stop
+bun $cli stop
+bun $cli status
+Get-Process -Id $ownedPids -ErrorAction SilentlyContinue
+
+$tcp = [Net.Sockets.TcpClient]::new()
+try { $tcp.Connect("127.0.0.1", [int]$state.port); $listenerOpen = $true } catch { $listenerOpen = $false } finally { $tcp.Dispose() }
+$listenerOpen
+Test-Path $env:DEV3_PTY_PROTO_DIR
+```
+
+Expected output:
+
+- `bun --version` is `1.3.14` or newer; `start` prints distinct positive
+  `hostPid`/`shellPid` values and a loopback endpoint.
+- `status` reports those same PIDs with `alive=true`; `REATTACHED[...]` repeats
+  the original root PID and ends in `[works]`.
+- The first `Get-Process` lists all four owned PIDs. The first and repeated stops
+  both print `stopped`; status prints `not running`; the second `Get-Process`
+  prints no rows.
+- `$listenerOpen` and `Test-Path ...\meta` both print `False`.
+
 ## Tests
 
-- `bun run test:proto-e2e` — the targeted integration test (real Bun runtime):
-  start → attach → disconnect → reattach → stop, plus a PATH-shim proof that tmux
-  is never invoked. Runs on real Bun because vitest stubs the `Bun` global (so a
-  live `Bun.Terminal` cannot run there) — same reason as `test:pane-e2e`.
-- `__tests__/protocol.test.ts`, `__tests__/state.test.ts` — vitest unit tests for
-  the pure logic; part of `bun run test`.
+- `bun run test:proto-e2e` — real-runtime regression on Windows and POSIX. It
+  proves start → reconnect → child + grandchild → stop, ownership isolation,
+  endpoint/handle/metadata cleanup, idempotence, and no tmux invocation. Expected
+  final line: `ALL CHECKS PASSED`.
+- `__tests__/protocol.test.ts`, `__tests__/state.test.ts`, and
+  `__tests__/windows-job.test.ts` — vitest units for pure protocol/state logic and
+  the Win32 handle lifecycle; part of `bun run test`.

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { sendUntilObserved } from "./command-roundtrip";
+
+describe("detached-pty command round trips", () => {
+	it("does not repeat a command once its output is observed", async () => {
+		let sends = 0;
+		const observed = await sendUntilObserved({
+			send: () => sends++,
+			observe: () => "ready",
+			attempts: 3,
+			attemptTimeoutMs: 1,
+			pollIntervalMs: 0,
+		});
+
+		expect(observed).toBe("ready");
+		expect(sends).toBe(1);
+	});
+
+	it("retries when an interactive shell drops the first command during startup", async () => {
+		let sends = 0;
+		let output = "";
+
+		const observed = await sendUntilObserved({
+			send() {
+				sends++;
+				if (sends > 1) output = "READY[4242]";
+			},
+			observe: () => /READY\[(\d+)\]/.exec(output),
+			attempts: 3,
+			attemptTimeoutMs: 1,
+			pollIntervalMs: 0,
+		});
+
+		expect(observed?.[1]).toBe("4242");
+		expect(sends).toBe(2);
+	});
+
+	it("stops after the configured number of attempts", async () => {
+		let sends = 0;
+		const observed = await sendUntilObserved({
+			send: () => sends++,
+			observe: () => null,
+			attempts: 3,
+			attemptTimeoutMs: 1,
+			pollIntervalMs: 0,
+		});
+
+		expect(observed).toBeNull();
+		expect(sends).toBe(3);
+	});
+});

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
+import { powerShellReattachStateProbe, powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
 
 describe("detached-pty command round trips", () => {
+	it("uses unambiguous delimiters around a scoped PowerShell environment variable", () => {
+		const probe = powerShellReattachStateProbe("state-100-200", 200);
+
+		expect(probe.command).toBe('Write-Output "MARKER[$env:PROTO_STATE][$PID]"');
+		expect(probe.observe("MARKER:200")).toBeNull();
+		expect(probe.observe("MARKER[state-100-200][200]")).toBe("MARKER[state-100-200][200]");
+	});
+
 	it("rejects a root acknowledgement when startup swallowed the state assignment", () => {
 		const probe = powerShellRootStateProbe("state-100-200", 200);
 

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { sendUntilObserved } from "./command-roundtrip";
+import { powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
 
 describe("detached-pty command round trips", () => {
+	it("rejects a root acknowledgement when startup swallowed the state assignment", () => {
+		const probe = powerShellRootStateProbe("state-100-200", 200);
+
+		expect(probe.observe("ROOTSTATE[][200]")).toBeNull();
+		expect(probe.observe("ROOTSTATE[state-100-200][200]")).toBe("ROOTSTATE[state-100-200][200]");
+	});
+
 	it("does not repeat a command once its output is observed", async () => {
 		let sends = 0;
 		const observed = await sendUntilObserved({

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
@@ -19,6 +19,17 @@ export function powerShellRootStateProbe(state: string, shellPid: number): {
 	};
 }
 
+export function powerShellReattachStateProbe(state: string, shellPid: number): {
+	command: string;
+	observe: (text: string) => string | null;
+} {
+	const expected = `MARKER[${state}][${shellPid}]`;
+	return {
+		command: 'Write-Output "MARKER[$env:PROTO_STATE][$PID]"',
+		observe: (text) => (text.includes(expected) ? expected : null),
+	};
+}
+
 /** Retry an idempotent probe while a new interactive shell prompt starts. */
 export async function sendUntilObserved<T>(options: SendUntilObservedOptions<T>): Promise<T | null> {
 	for (let attempt = 0; attempt < options.attempts; attempt++) {

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
@@ -8,6 +8,17 @@ interface SendUntilObservedOptions<T> {
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+export function powerShellRootStateProbe(state: string, shellPid: number): {
+	command: string;
+	observe: (text: string) => string | null;
+} {
+	const expected = `ROOTSTATE[${state}][${shellPid}]`;
+	return {
+		command: `$env:PROTO_STATE='${state}'; Write-Output "ROOTSTATE[$env:PROTO_STATE][$PID]"`,
+		observe: (text) => (text.includes(expected) ? expected : null),
+	};
+}
+
 /** Retry an idempotent probe while a new interactive shell prompt starts. */
 export async function sendUntilObserved<T>(options: SendUntilObservedOptions<T>): Promise<T | null> {
 	for (let attempt = 0; attempt < options.attempts; attempt++) {

--- a/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/command-roundtrip.ts
@@ -1,0 +1,23 @@
+interface SendUntilObservedOptions<T> {
+	send: () => void;
+	observe: () => T | null;
+	attempts: number;
+	attemptTimeoutMs: number;
+	pollIntervalMs: number;
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Retry an idempotent probe while a new interactive shell prompt starts. */
+export async function sendUntilObserved<T>(options: SendUntilObservedOptions<T>): Promise<T | null> {
+	for (let attempt = 0; attempt < options.attempts; attempt++) {
+		options.send();
+		const deadline = Date.now() + options.attemptTimeoutMs;
+		do {
+			const observed = options.observe();
+			if (observed !== null) return observed;
+			await delay(options.pollIntervalMs);
+		} while (Date.now() <= deadline);
+	}
+	return null;
+}

--- a/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
@@ -21,6 +21,7 @@ import { PtyProtoClient } from "../client";
 import { isProcessAlive, logFile, readState, stateDir, stateFile } from "../state";
 import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
 import { spawn } from "../../../spawn";
+import { sendUntilObserved } from "./command-roundtrip";
 
 let failures = 0;
 function check(condition: boolean, msg: string): void {
@@ -30,6 +31,11 @@ function check(condition: boolean, msg: string): void {
 		failures++;
 		console.error(`  FAIL - ${msg}`);
 	}
+}
+
+function transcriptOnFailure(observed: unknown, label: string, text: string): void {
+	if (observed) return;
+	console.error(`       ${label} transcript tail: ${JSON.stringify(text.slice(-2000))}`);
 }
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -127,15 +133,22 @@ async function run(): Promise<void> {
 		const c1 = new PtyProtoClient();
 		await c1.connect(state);
 		const s1 = makeSink(c1);
+		let rootMatch: RegExpExecArray | null;
 		if (isWindows) {
-			sendLine(c1, `$env:PROTO_STATE='${nonce}'`);
-			sendLine(c1, `Write-Output "ROOTPID[$PID]"`);
+			rootMatch = await sendUntilObserved({
+				send: () => sendLine(c1, `$env:PROTO_STATE='${nonce}'; Write-Output "ROOTPID[$PID]"`),
+				observe: () => /ROOTPID\[(\d+)\]/.exec(s1.text()),
+				attempts: 4,
+				attemptTimeoutMs: 1000,
+				pollIntervalMs: 30,
+			});
 		} else {
 			sendLine(c1, "set +H");
 			sendLine(c1, `export PROTO_STATE=${nonce}`);
 			sendLine(c1, `echo "ROOTPID[$$]"`);
+			rootMatch = await s1.waitForMatch(/ROOTPID\[(\d+)\]/);
 		}
-		const rootMatch = await s1.waitForMatch(/ROOTPID\[(\d+)\]/);
+		transcriptOnFailure(rootMatch, "root startup", s1.text());
 		check(rootMatch !== null, "client 1 receives live shell output");
 		check(Number(rootMatch?.[1]) === state.shellPid, "interactive root reports the recorded shell PID");
 		const st1 = await c1.status();
@@ -156,19 +169,42 @@ async function run(): Promise<void> {
 		const st2 = await c2.status();
 		check(st2.shellPid === recordedShellPid, "reattached client sees the UNCHANGED shell PID");
 		check(st2.hostPid === state.hostPid, "reattached client sees the UNCHANGED host PID");
-		sendLine(
-			c2,
-			isWindows ? `Write-Output "MARKER:$env:PROTO_STATE:$PID"` : `echo "MARKER:$PROTO_STATE:$$"`,
-		);
+		const expectedMarker = `MARKER:${nonce}:${recordedShellPid}`;
+		let markerSeen: string | boolean | null;
+		if (isWindows) {
+			markerSeen = await sendUntilObserved({
+				send: () => sendLine(c2, `Write-Output "MARKER:$env:PROTO_STATE:$PID"`),
+				observe: () => (s2.text().includes(expectedMarker) ? expectedMarker : null),
+				attempts: 4,
+				attemptTimeoutMs: 1000,
+				pollIntervalMs: 30,
+			});
+		} else {
+			sendLine(c2, `echo "MARKER:$PROTO_STATE:$$"`);
+			markerSeen = await s2.waitFor(expectedMarker);
+		}
+		transcriptOnFailure(markerSeen, "reattach marker", s2.text());
 		check(
-			await s2.waitFor(`MARKER:${nonce}:${recordedShellPid}`),
+			Boolean(markerSeen),
 			"reattached client proves shell STATE (env var) AND PID are preserved across reconnect",
 		);
 
 		sendLine(c2, isWindows ? "powershell.exe -NoLogo -NoProfile" : "bash --norc --noprofile");
-		if (!isWindows) sendLine(c2, "set +H");
-		sendLine(c2, isWindows ? `Write-Output "CHILDPID[$PID]"` : `echo "CHILDPID[$$]"`);
-		const childMatch = await s2.waitForMatch(/CHILDPID\[(\d+)\]/);
+		let childMatch: RegExpExecArray | null;
+		if (isWindows) {
+			childMatch = await sendUntilObserved({
+				send: () => sendLine(c2, `Write-Output "CHILDPID[$PID]"`),
+				observe: () => /CHILDPID\[(\d+)\]/.exec(s2.text()),
+				attempts: 6,
+				attemptTimeoutMs: 1000,
+				pollIntervalMs: 30,
+			});
+		} else {
+			sendLine(c2, "set +H");
+			sendLine(c2, `echo "CHILDPID[$$]"`);
+			childMatch = await s2.waitForMatch(/CHILDPID\[(\d+)\]/);
+		}
+		transcriptOnFailure(childMatch, "child startup", s2.text());
 		const childPid = Number(childMatch?.[1]);
 		check(Number.isInteger(childPid) && isProcessAlive(childPid), "root shell spawned a live child shell");
 		if (isWindows) {

--- a/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
@@ -20,6 +20,7 @@ import { start, stop } from "../launcher";
 import { PtyProtoClient } from "../client";
 import { isProcessAlive, logFile, readState, stateDir, stateFile } from "../state";
 import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
+import { spawn } from "../../../spawn";
 
 let failures = 0;
 function check(condition: boolean, msg: string): void {
@@ -94,7 +95,9 @@ async function run(): Promise<void> {
 	process.env.PATH = `${shimDir}${delimiter}${process.env.PATH ?? ""}`;
 
 	const testPid = process.pid;
-	const unrelated = Bun.spawn(
+	// Models a pre-existing production tmux process: the test owns this guard,
+	// while the native host must neither adopt it nor terminate it.
+	const tmuxGuard = spawn(
 		isWindows
 			? ["powershell.exe", "-NoLogo", "-NoProfile", "-Command", "Start-Sleep -Seconds 300"]
 			: ["sleep", "300"],
@@ -110,11 +113,12 @@ async function run(): Promise<void> {
 		check(state.shellPid > 0 && isProcessAlive(state.shellPid), "host owns a real live shell process");
 		check(state.host === "127.0.0.1" && state.port > 0, "transport is loopback TCP on an ephemeral port");
 		check(state.token.length > 0, "transport is guarded by a per-run token");
-		check(isProcessAlive(unrelated.pid), "unrelated process is alive before native-session stop");
+		check(isProcessAlive(tmuxGuard.pid), "pre-existing tmux ownership guard is alive before native-session stop");
 		if (isWindows) {
 			check(await windowsJobExists(state.token), "Windows Job Object exists while the session is live");
 			check(await isProcessInWindowsJob(state.token, state.hostPid), "Windows Job Object owns the host before shell work");
 			check(await isProcessInWindowsJob(state.token, state.shellPid), "root shell inherited Windows Job Object ownership at spawn");
+			check(!(await isProcessInWindowsJob(state.token, tmuxGuard.pid)), "Windows Job Object excludes the tmux ownership guard");
 		}
 
 		const nonce = `state-${state.hostPid}-${state.shellPid}`;
@@ -192,7 +196,7 @@ async function run(): Promise<void> {
 		check(!isProcessAlive(recordedShellPid), "root shell terminated after stop");
 		check(!isProcessAlive(childPid), "child shell terminated after stop");
 		check(!isProcessAlive(grandchildPid), "grandchild terminated after stop");
-		check(isProcessAlive(unrelated.pid), "stop left an unrelated process untouched");
+		check(isProcessAlive(tmuxGuard.pid), "native stop did not terminate the pre-existing tmux ownership guard");
 		check(readState() === null, "all prototype metadata removed after stop");
 		check(!existsSync(stateFile()), "state.json removed from disk");
 		check(!existsSync(logFile()), "host.log removed from disk");
@@ -214,7 +218,7 @@ async function run(): Promise<void> {
 		check(!existsSync(sentinel), "tracer NEVER invoked tmux (PATH shim sentinel absent)");
 	} finally {
 		try {
-			unrelated.kill();
+			tmuxGuard.kill();
 		} catch {
 			// already gone
 		}

--- a/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
@@ -21,7 +21,7 @@ import { PtyProtoClient } from "../client";
 import { isProcessAlive, logFile, readState, stateDir, stateFile } from "../state";
 import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
 import { spawn } from "../../../spawn";
-import { powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
+import { powerShellReattachStateProbe, powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
 
 let failures = 0;
 function check(condition: boolean, msg: string): void {
@@ -174,17 +174,18 @@ async function run(): Promise<void> {
 		const st2 = await c2.status();
 		check(st2.shellPid === recordedShellPid, "reattached client sees the UNCHANGED shell PID");
 		check(st2.hostPid === state.hostPid, "reattached client sees the UNCHANGED host PID");
-		const expectedMarker = `MARKER:${nonce}:${recordedShellPid}`;
 		let markerSeen: string | boolean | null;
 		if (isWindows) {
+			const probe = powerShellReattachStateProbe(nonce, recordedShellPid);
 			markerSeen = await sendUntilObserved({
-				send: () => sendLine(c2, `Write-Output "MARKER:$env:PROTO_STATE:$PID"`),
-				observe: () => (s2.text().includes(expectedMarker) ? expectedMarker : null),
+				send: () => sendLine(c2, probe.command),
+				observe: () => probe.observe(s2.text()),
 				attempts: 4,
 				attemptTimeoutMs: 1000,
 				pollIntervalMs: 30,
 			});
 		} else {
+			const expectedMarker = `MARKER:${nonce}:${recordedShellPid}`;
 			sendLine(c2, `echo "MARKER:$PROTO_STATE:$$"`);
 			markerSeen = await s2.waitFor(expectedMarker);
 		}

--- a/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
@@ -15,10 +15,11 @@
 
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { start, stop } from "../launcher";
 import { PtyProtoClient } from "../client";
-import { isProcessAlive, readState } from "../state";
+import { isProcessAlive, logFile, readState, stateDir, stateFile } from "../state";
+import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
 
 let failures = 0;
 function check(condition: boolean, msg: string): void {
@@ -73,83 +74,155 @@ async function run(): Promise<void> {
 	const protoDir = join(root, "meta");
 	const shimDir = join(root, "shim");
 	const sentinel = join(root, "tmux-was-invoked");
+	const isWindows = process.platform === "win32";
+	const lineEnd = isWindows ? "\r" : "\n";
 	mkdirSync(shimDir, { recursive: true });
-	const shim = join(shimDir, "tmux");
-	writeFileSync(shim, `#!/bin/sh\necho called >> "${sentinel}"\nexit 0\n`);
-	chmodSync(shim, 0o755);
+	const shim = join(shimDir, isWindows ? "tmux.cmd" : "tmux");
+	writeFileSync(
+		shim,
+		isWindows ? `@echo off\r\necho called>>"${sentinel}"\r\nexit /b 0\r\n` : `#!/bin/sh\necho called >> "${sentinel}"\nexit 0\n`,
+	);
+	if (!isWindows) chmodSync(shim, 0o755);
 
 	// Isolate metadata, force a deterministic shell (no rc → no accidental tmux
 	// auto-launch, no job control → grandchildren share the shell's pgroup), and
 	// front-load the tmux shim on PATH for the host we're about to spawn.
 	process.env.DEV3_PTY_PROTO_DIR = protoDir;
-	process.env.DEV3_PTY_PROTO_CMD = JSON.stringify(["/bin/bash", "--norc", "--noprofile"]);
-	process.env.PATH = `${shimDir}:${process.env.PATH ?? ""}`;
+	process.env.DEV3_PTY_PROTO_CMD = JSON.stringify(
+		isWindows ? ["powershell.exe", "-NoLogo", "-NoProfile"] : ["/bin/bash", "--norc", "--noprofile"],
+	);
+	process.env.PATH = `${shimDir}${delimiter}${process.env.PATH ?? ""}`;
 
 	const testPid = process.pid;
-
-	// ── 1. start: a SEPARATE detached host owns one real shell ──
-	const state = await start({ timeoutMs: 15_000 });
-	check(state.hostPid > 0 && state.hostPid !== testPid, "launcher spawned a SEPARATE detached host process");
-	check(isProcessAlive(state.hostPid), "host is alive after start() returned (launcher did not kill it)");
-	check(state.shellPid > 0 && isProcessAlive(state.shellPid), "host owns a real live shell process");
-	check(state.host === "127.0.0.1" && state.port > 0, "transport is loopback TCP on an ephemeral port");
-	check(state.token.length > 0, "transport is guarded by a per-run token");
-
-	const nonce = `state-${state.hostPid}-${state.shellPid}`;
-
-	// ── 2. client 1: set observable shell state, spawn a grandchild, record PID ──
-	const c1 = new PtyProtoClient();
-	await c1.connect(state);
-	const s1 = makeSink(c1);
-	c1.input(`set +H\n`); // disable `!` history expansion so `$!` survives in an interactive shell
-	c1.input(`export PROTO_STATE=${nonce}\n`);
-	c1.input(`sleep 300 &\n`);
-	c1.input(`echo "SLEEPPID[$!]"\n`);
-	const sleepMatch = await s1.waitForMatch(/SLEEPPID\[(\d+)\]/);
-	check(sleepMatch !== null, "client 1 receives live shell output");
-	const sleepPid = Number(sleepMatch?.[1]);
-	check(Number.isInteger(sleepPid) && isProcessAlive(sleepPid), "shell spawned a live grandchild process");
-	const st1 = await c1.status();
-	check(st1.shellPid === state.shellPid, "status over the wire reports the recorded shell PID");
-	const recordedShellPid = st1.shellPid;
-	c1.close();
-
-	// ── 3. disconnect: host + shell survive with no client attached ──
-	await delay(250);
-	check(isProcessAlive(state.hostPid), "host survives client 1 disconnect");
-	check(isProcessAlive(recordedShellPid), "shell survives client 1 disconnect");
-
-	// ── 4. fresh client 2: rediscover endpoint + reattach to the SAME shell ──
-	const discovered = readState();
-	check(!!discovered && discovered.shellPid === recordedShellPid, "fresh client rediscovers the endpoint from metadata");
-	const c2 = await PtyProtoClient.discover();
-	const s2 = makeSink(c2);
-	const st2 = await c2.status();
-	check(st2.shellPid === recordedShellPid, "reattached client sees the UNCHANGED shell PID");
-	check(st2.hostPid === state.hostPid, "reattached client sees the UNCHANGED host PID");
-	c2.input(`echo "MARKER:$PROTO_STATE:$$"\n`);
-	check(
-		await s2.waitFor(`MARKER:${nonce}:${recordedShellPid}`),
-		"reattached client proves shell STATE (env var) AND PID are preserved across reconnect",
+	const unrelated = Bun.spawn(
+		isWindows
+			? ["powershell.exe", "-NoLogo", "-NoProfile", "-Command", "Start-Sleep -Seconds 300"]
+			: ["sleep", "300"],
+		{ stdin: "ignore", stdout: "ignore", stderr: "ignore" },
 	);
-	c2.close();
-
-	// ── 5. stop: terminate the whole shell tree + remove all metadata ──
-	const stopped = await stop({ timeoutMs: 8000 });
-	check(stopped, "stop() reports success");
-	check(!isProcessAlive(state.hostPid), "host process terminated after stop");
-	check(!isProcessAlive(recordedShellPid), "shell process terminated after stop");
-	check(!isProcessAlive(sleepPid), "shell process TREE terminated (grandchild reaped)");
-	check(readState() === null, "all prototype metadata removed after stop");
-	check(!existsSync(join(protoDir, "state.json")), "state.json file removed from disk");
-
-	// ── 6. the tracer never touched tmux ──
-	check(!existsSync(sentinel), "tracer NEVER invoked tmux (PATH shim sentinel absent)");
+	const sendLine = (client: PtyProtoClient, command: string): void => client.input(`${command}${lineEnd}`);
 
 	try {
-		rmSync(root, { recursive: true, force: true });
-	} catch {
-		// best-effort
+		// ── 1. start: a SEPARATE detached host owns one real shell ──
+		const state = await start({ timeoutMs: 15_000 });
+		check(state.hostPid > 0 && state.hostPid !== testPid, "launcher spawned a SEPARATE detached host process");
+		check(isProcessAlive(state.hostPid), "host is alive after start() returned (launcher did not kill it)");
+		check(state.shellPid > 0 && isProcessAlive(state.shellPid), "host owns a real live shell process");
+		check(state.host === "127.0.0.1" && state.port > 0, "transport is loopback TCP on an ephemeral port");
+		check(state.token.length > 0, "transport is guarded by a per-run token");
+		check(isProcessAlive(unrelated.pid), "unrelated process is alive before native-session stop");
+		if (isWindows) {
+			check(await windowsJobExists(state.token), "Windows Job Object exists while the session is live");
+			check(await isProcessInWindowsJob(state.token, state.hostPid), "Windows Job Object owns the host before shell work");
+			check(await isProcessInWindowsJob(state.token, state.shellPid), "root shell inherited Windows Job Object ownership at spawn");
+		}
+
+		const nonce = `state-${state.hostPid}-${state.shellPid}`;
+
+		// ── 2. client 1: set observable root-shell state and record PID ──
+		const c1 = new PtyProtoClient();
+		await c1.connect(state);
+		const s1 = makeSink(c1);
+		if (isWindows) {
+			sendLine(c1, `$env:PROTO_STATE='${nonce}'`);
+			sendLine(c1, `Write-Output "ROOTPID[$PID]"`);
+		} else {
+			sendLine(c1, "set +H");
+			sendLine(c1, `export PROTO_STATE=${nonce}`);
+			sendLine(c1, `echo "ROOTPID[$$]"`);
+		}
+		const rootMatch = await s1.waitForMatch(/ROOTPID\[(\d+)\]/);
+		check(rootMatch !== null, "client 1 receives live shell output");
+		check(Number(rootMatch?.[1]) === state.shellPid, "interactive root reports the recorded shell PID");
+		const st1 = await c1.status();
+		check(st1.shellPid === state.shellPid, "status over the wire reports the recorded shell PID");
+		const recordedShellPid = st1.shellPid;
+		c1.close();
+
+		// ── 3. disconnect: host + shell survive with no client attached ──
+		await delay(250);
+		check(isProcessAlive(state.hostPid), "host survives client 1 disconnect");
+		check(isProcessAlive(recordedShellPid), "shell survives client 1 disconnect");
+
+		// ── 4. fresh client 2: rediscover and create a child + grandchild ──
+		const discovered = readState();
+		check(!!discovered && discovered.shellPid === recordedShellPid, "fresh client rediscovers the endpoint from metadata");
+		const c2 = await PtyProtoClient.discover();
+		const s2 = makeSink(c2);
+		const st2 = await c2.status();
+		check(st2.shellPid === recordedShellPid, "reattached client sees the UNCHANGED shell PID");
+		check(st2.hostPid === state.hostPid, "reattached client sees the UNCHANGED host PID");
+		sendLine(
+			c2,
+			isWindows ? `Write-Output "MARKER:$env:PROTO_STATE:$PID"` : `echo "MARKER:$PROTO_STATE:$$"`,
+		);
+		check(
+			await s2.waitFor(`MARKER:${nonce}:${recordedShellPid}`),
+			"reattached client proves shell STATE (env var) AND PID are preserved across reconnect",
+		);
+
+		sendLine(c2, isWindows ? "powershell.exe -NoLogo -NoProfile" : "bash --norc --noprofile");
+		if (!isWindows) sendLine(c2, "set +H");
+		sendLine(c2, isWindows ? `Write-Output "CHILDPID[$PID]"` : `echo "CHILDPID[$$]"`);
+		const childMatch = await s2.waitForMatch(/CHILDPID\[(\d+)\]/);
+		const childPid = Number(childMatch?.[1]);
+		check(Number.isInteger(childPid) && isProcessAlive(childPid), "root shell spawned a live child shell");
+		if (isWindows) {
+			sendLine(
+				c2,
+				`$grand = Start-Process -PassThru powershell.exe -ArgumentList @('-NoLogo','-NoProfile','-Command','Start-Sleep -Seconds 300'); Write-Output "GRANDPID[$($grand.Id)]"`,
+			);
+		} else {
+			sendLine(c2, "sleep 300 &");
+			sendLine(c2, `echo "GRANDPID[$!]"`);
+		}
+		const grandchildMatch = await s2.waitForMatch(/GRANDPID\[(\d+)\]/);
+		const grandchildPid = Number(grandchildMatch?.[1]);
+		check(Number.isInteger(grandchildPid) && isProcessAlive(grandchildPid), "child shell spawned a live grandchild");
+		if (isWindows) {
+			check(await isProcessInWindowsJob(state.token, childPid), "Windows Job Object owns the child shell");
+			check(await isProcessInWindowsJob(state.token, grandchildPid), "Windows Job Object owns the grandchild");
+		}
+		c2.close();
+
+		// ── 5. stop: graceful request, bounded wait, forceful owned-tree cleanup ──
+		const stopped = await stop({ timeoutMs: 8000 });
+		check(stopped, "stop() reports success");
+		check(!isProcessAlive(state.hostPid), "host process terminated after stop");
+		check(!isProcessAlive(recordedShellPid), "root shell terminated after stop");
+		check(!isProcessAlive(childPid), "child shell terminated after stop");
+		check(!isProcessAlive(grandchildPid), "grandchild terminated after stop");
+		check(isProcessAlive(unrelated.pid), "stop left an unrelated process untouched");
+		check(readState() === null, "all prototype metadata removed after stop");
+		check(!existsSync(stateFile()), "state.json removed from disk");
+		check(!existsSync(logFile()), "host.log removed from disk");
+		check(!existsSync(stateDir()), "prototype metadata directory removed from disk");
+		if (isWindows) check(!(await windowsJobExists(state.token)), "Windows Job Object and its handles are gone");
+
+		const endpointProbe = new PtyProtoClient();
+		let endpointGone = false;
+		try {
+			await endpointProbe.connect(state, { timeoutMs: 750 });
+			endpointProbe.close();
+		} catch {
+			endpointGone = true;
+		}
+		check(endpointGone, "listening endpoint is gone after stop");
+		check(await stop({ timeoutMs: 1000 }), "repeated stop is idempotent");
+
+		// ── 6. the tracer never invoked or terminated tmux ──
+		check(!existsSync(sentinel), "tracer NEVER invoked tmux (PATH shim sentinel absent)");
+	} finally {
+		try {
+			unrelated.kill();
+		} catch {
+			// already gone
+		}
+		try {
+			rmSync(root, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
 	}
 }
 

--- a/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts
@@ -21,7 +21,7 @@ import { PtyProtoClient } from "../client";
 import { isProcessAlive, logFile, readState, stateDir, stateFile } from "../state";
 import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
 import { spawn } from "../../../spawn";
-import { sendUntilObserved } from "./command-roundtrip";
+import { powerShellRootStateProbe, sendUntilObserved } from "./command-roundtrip";
 
 let failures = 0;
 function check(condition: boolean, msg: string): void {
@@ -133,24 +133,29 @@ async function run(): Promise<void> {
 		const c1 = new PtyProtoClient();
 		await c1.connect(state);
 		const s1 = makeSink(c1);
-		let rootMatch: RegExpExecArray | null;
+		let rootObserved: string | RegExpExecArray | null;
+		let rootPidMatches: boolean;
 		if (isWindows) {
-			rootMatch = await sendUntilObserved({
-				send: () => sendLine(c1, `$env:PROTO_STATE='${nonce}'; Write-Output "ROOTPID[$PID]"`),
-				observe: () => /ROOTPID\[(\d+)\]/.exec(s1.text()),
+			const probe = powerShellRootStateProbe(nonce, state.shellPid);
+			rootObserved = await sendUntilObserved({
+				send: () => sendLine(c1, probe.command),
+				observe: () => probe.observe(s1.text()),
 				attempts: 4,
 				attemptTimeoutMs: 1000,
 				pollIntervalMs: 30,
 			});
+			rootPidMatches = rootObserved !== null;
 		} else {
 			sendLine(c1, "set +H");
 			sendLine(c1, `export PROTO_STATE=${nonce}`);
 			sendLine(c1, `echo "ROOTPID[$$]"`);
-			rootMatch = await s1.waitForMatch(/ROOTPID\[(\d+)\]/);
+			const rootMatch = await s1.waitForMatch(/ROOTPID\[(\d+)\]/);
+			rootObserved = rootMatch;
+			rootPidMatches = Number(rootMatch?.[1]) === state.shellPid;
 		}
-		transcriptOnFailure(rootMatch, "root startup", s1.text());
-		check(rootMatch !== null, "client 1 receives live shell output");
-		check(Number(rootMatch?.[1]) === state.shellPid, "interactive root reports the recorded shell PID");
+		transcriptOnFailure(rootObserved, "root startup", s1.text());
+		check(rootObserved !== null, "client 1 receives live shell output");
+		check(rootPidMatches, "interactive root reports the recorded shell PID");
 		const st1 = await c1.status();
 		check(st1.shellPid === state.shellPid, "status over the wire reports the recorded shell PID");
 		const recordedShellPid = st1.shellPid;

--- a/src/bun/prototypes/detached-pty/__tests__/state.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/state.test.ts
@@ -82,6 +82,19 @@ describe("detached-pty state", () => {
 		expect(() => clearState()).not.toThrow();
 	});
 
+	it("clearState only removes metadata owned by the selected session", () => {
+		writeState(sample);
+		writeFileSync(logFile(), "selected session log");
+
+		expect(clearState("another-token")).toBe(false);
+		expect(readState()).toEqual(sample);
+		expect(existsSync(logFile())).toBe(true);
+
+		expect(clearState(sample.token)).toBe(true);
+		expect(readState()).toBeNull();
+		expect(existsSync(logFile())).toBe(false);
+	});
+
 	it("isProcessAlive: true for self, false for junk", () => {
 		expect(isProcessAlive(process.pid)).toBe(true);
 		expect(isProcessAlive(0)).toBe(false);

--- a/src/bun/prototypes/detached-pty/__tests__/windows-job.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/windows-job.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createWindowsJobWithApi,
+	forceTerminateWindowsJobWithApi,
+	isProcessInWindowsJobWithApi,
+	windowsJobExistsWithApi,
+	windowsJobName,
+	type WindowsJobApi,
+} from "../windows-job";
+
+const TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function makeApi(): WindowsJobApi {
+	return {
+		createJob: vi.fn(() => 11n),
+		setExtendedLimitInformation: vi.fn(() => true),
+		openProcess: vi.fn(() => 12n),
+		assignProcess: vi.fn(() => true),
+		openJob: vi.fn(() => 11n),
+		terminateJob: vi.fn(() => true),
+		isProcessInJob: vi.fn(() => true),
+		closeHandle: vi.fn(() => true),
+		setLastError: vi.fn(),
+		lastError: vi.fn(() => 0),
+		dispose: vi.fn(),
+	};
+}
+
+describe("detached-pty Windows Job Object containment", () => {
+	it("enrols the host before spawn with kill-on-close and closes each handle once", () => {
+		const api = makeApi();
+		const containment = createWindowsJobWithApi(TOKEN, 4242, api);
+
+		expect(containment.name).toBe(windowsJobName(TOKEN));
+		expect(api.setLastError).toHaveBeenCalledWith(0);
+		expect(api.createJob).toHaveBeenCalledOnce();
+		expect(api.openProcess).toHaveBeenCalledWith(4242);
+		expect(api.assignProcess).toHaveBeenCalledWith(11n, 12n);
+		expect(api.closeHandle).toHaveBeenCalledWith(12n);
+
+		const limits = vi.mocked(api.setExtendedLimitInformation).mock.calls[0]?.[1];
+		expect(limits).toBeInstanceOf(BigUint64Array);
+		expect(new DataView(limits!.buffer).getUint32(16, true)).toBe(0x00002000);
+
+		expect(containment.closeForTreeTermination()).toBe(true);
+		expect(containment.closeForTreeTermination()).toBe(false);
+		expect(api.closeHandle).toHaveBeenCalledTimes(2);
+		expect(api.closeHandle).toHaveBeenLastCalledWith(11n);
+		expect(api.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("releases the job when host enrolment fails", () => {
+		const api = makeApi();
+		vi.mocked(api.assignProcess).mockReturnValue(false);
+		vi.mocked(api.lastError).mockReturnValue(5);
+
+		expect(() => createWindowsJobWithApi(TOKEN, 4242, api)).toThrow("AssignProcessToJobObject failed (Win32 error 5)");
+		expect(api.closeHandle).toHaveBeenNthCalledWith(1, 12n);
+		expect(api.closeHandle).toHaveBeenNthCalledWith(2, 11n);
+		expect(api.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("force-terminates only the Job Object named by the selected token", () => {
+		const api = makeApi();
+
+		expect(forceTerminateWindowsJobWithApi(TOKEN, api)).toBe(true);
+		expect(api.openJob).toHaveBeenCalledWith(windowsJobName(TOKEN), 0x0008);
+		expect(api.terminateJob).toHaveBeenCalledWith(11n);
+		expect(api.closeHandle).toHaveBeenCalledWith(11n);
+		expect(api.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("queries membership and releases temporary process and job handles", () => {
+		const api = makeApi();
+
+		expect(isProcessInWindowsJobWithApi(TOKEN, 4343, api)).toBe(true);
+		expect(api.openJob).toHaveBeenCalledWith(windowsJobName(TOKEN), 0x0004);
+		expect(api.openProcess).toHaveBeenCalledWith(4343, 0x1000);
+		expect(api.isProcessInJob).toHaveBeenCalledWith(12n, 11n);
+		expect(api.closeHandle).toHaveBeenCalledWith(12n);
+		expect(api.closeHandle).toHaveBeenCalledWith(11n);
+		expect(api.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("reports a missing named job without leaking the API library", () => {
+		const api = makeApi();
+		vi.mocked(api.openJob).mockReturnValue(0n);
+
+		expect(windowsJobExistsWithApi(TOKEN, api)).toBe(false);
+		expect(api.closeHandle).not.toHaveBeenCalled();
+		expect(api.dispose).toHaveBeenCalledOnce();
+	});
+});

--- a/src/bun/prototypes/detached-pty/__tests__/windows-job.test.ts
+++ b/src/bun/prototypes/detached-pty/__tests__/windows-job.test.ts
@@ -27,7 +27,7 @@ function makeApi(): WindowsJobApi {
 }
 
 describe("detached-pty Windows Job Object containment", () => {
-	it("enrols the host before spawn with kill-on-close and closes each handle once", () => {
+	it("enrols the host before spawn with kill-on-close", () => {
 		const api = makeApi();
 		const containment = createWindowsJobWithApi(TOKEN, 4242, api);
 
@@ -41,11 +41,19 @@ describe("detached-pty Windows Job Object containment", () => {
 		const limits = vi.mocked(api.setExtendedLimitInformation).mock.calls[0]?.[1];
 		expect(limits).toBeInstanceOf(BigUint64Array);
 		expect(new DataView(limits!.buffer).getUint32(16, true)).toBe(0x00002000);
+		containment.closeForTreeTermination();
+	});
+
+	it("closes the owning job and API exactly once", () => {
+		const api = makeApi();
+		const containment = createWindowsJobWithApi(TOKEN, 4242, api);
+		vi.mocked(api.closeHandle).mockClear();
+		vi.mocked(api.dispose).mockClear();
 
 		expect(containment.closeForTreeTermination()).toBe(true);
 		expect(containment.closeForTreeTermination()).toBe(false);
-		expect(api.closeHandle).toHaveBeenCalledTimes(2);
-		expect(api.closeHandle).toHaveBeenLastCalledWith(11n);
+		expect(api.closeHandle).toHaveBeenCalledOnce();
+		expect(api.closeHandle).toHaveBeenCalledWith(11n);
 		expect(api.dispose).toHaveBeenCalledOnce();
 	});
 

--- a/src/bun/prototypes/detached-pty/host.ts
+++ b/src/bun/prototypes/detached-pty/host.ts
@@ -16,6 +16,7 @@ import { randomBytes } from "node:crypto";
 import { clearState, stateDir, writeState } from "./state";
 import { decodeControl, encodeControl, exitEvent, PROTOCOL_VERSION, stoppingEvent, type StatusReply } from "./protocol";
 import { mkdirSync } from "node:fs";
+import { createWindowsJobContainment } from "./windows-job";
 
 // A StatusReply needs live host state, so it is built inline rather than via a
 // static protocol factory.
@@ -47,6 +48,7 @@ export function resolveShellCommand(): string[] {
 			// fall through to default
 		}
 	}
+	if (process.platform === "win32") return ["powershell.exe", "-NoLogo", "-NoProfile"];
 	return [process.env.SHELL || "/bin/bash"];
 }
 
@@ -89,18 +91,10 @@ function collectDescendants(rootPid: number): number[] {
  * Kill the shell's whole process tree. Bun.Terminal makes the shell a session
  * leader (setsid for the PTY). We signal every descendant individually (covers
  * job-control children in separate process groups), then the shell's foreground
- * group, then the shell itself. On Windows there is no process group, so we just
- * terminate the subprocess (a full Windows tree-kill is out of scope for the spike).
+ * group, then the shell itself. Windows uses its pre-spawn Job Object boundary
+ * instead, so this fallback only owns the POSIX teardown path.
  */
 function killTree(shellPid: number, proc: { kill: (signal?: number | NodeJS.Signals) => void }, signal: NodeJS.Signals): void {
-	if (process.platform === "win32") {
-		try {
-			proc.kill();
-		} catch {
-			// already gone
-		}
-		return;
-	}
 	for (const pid of collectDescendants(shellPid)) {
 		try {
 			process.kill(pid, signal);
@@ -135,6 +129,9 @@ export async function runHost(opts: HostOptions = {}): Promise<void> {
 	const rows = opts.rows ?? 24;
 	const cmd = opts.cmd ?? resolveShellCommand();
 	const token = randomBytes(24).toString("hex");
+	// Self-enrol before Bun.spawn: Windows children inherit the non-breakaway job
+	// atomically at process creation, so the root shell cannot race assignment.
+	const windowsJob = await createWindowsJobContainment(token);
 	mkdirSync(stateDir(), { recursive: true });
 
 	const clients = new Set<{ send: (data: string | Uint8Array) => number; close: () => void }>();
@@ -251,6 +248,22 @@ export async function runHost(opts: HostOptions = {}): Promise<void> {
 		} catch {
 			// already stopped
 		}
+		if (windowsJob) {
+			// Ctrl-C interrupts a foreground command; `exit` then asks PowerShell to
+			// close normally. The fixed wait prevents ConPTY teardown deadlocks.
+			try {
+				proc.terminal?.write("\x03");
+				await delay(75);
+				proc.terminal?.write("exit\r");
+			} catch {
+				// terminal already closed
+			}
+			await Promise.race([proc.exited, delay(1500)]);
+			clearState(token);
+			windowsJob.closeForTreeTermination();
+			process.exit(exitCode);
+			return;
+		}
 		killTree(shellPid, proc, "SIGTERM");
 		const exitedGracefully = await Promise.race([
 			proc.exited.then(() => true),
@@ -265,7 +278,7 @@ export async function runHost(opts: HostOptions = {}): Promise<void> {
 		} catch {
 			// already closed
 		}
-		clearState();
+		clearState(token);
 		process.exit(exitCode);
 	}
 

--- a/src/bun/prototypes/detached-pty/launcher.ts
+++ b/src/bun/prototypes/detached-pty/launcher.ts
@@ -110,9 +110,9 @@ export async function status(): Promise<StatusResult> {
 }
 
 /**
- * Stop the host and its shell tree. Prefers a graceful in-band stop; falls back
- * to signalling the host PID. Resolves once metadata is gone and both the host
- * and shell PIDs are dead.
+ * Stop the host and its shell tree. Prefers a graceful in-band stop; Windows
+ * fallback opens only the token-named Job Object, while POSIX signals the host.
+ * Resolves once metadata is gone and both recorded PIDs are dead.
  */
 export async function stop(opts: { timeoutMs?: number } = {}): Promise<boolean> {
 	const state = readState();

--- a/src/bun/prototypes/detached-pty/launcher.ts
+++ b/src/bun/prototypes/detached-pty/launcher.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 import { clearState, isProcessAlive, logFile, readState, stateDir, type PtyProtoState } from "./state";
 import { PtyProtoClient } from "./client";
 import type { StatusReply } from "./protocol";
+import { forceTerminateWindowsJob } from "./windows-job";
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -31,7 +32,7 @@ export async function start(opts: { timeoutMs?: number } = {}): Promise<PtyProto
 	if (existing && isProcessAlive(existing.hostPid)) {
 		throw new Error(`a detached-pty host is already running (pid ${existing.hostPid}, port ${existing.port})`);
 	}
-	if (existing) clearState(); // stale record from a dead host
+	if (existing) clearState(existing.token); // stale record from a dead host
 
 	mkdirSync(stateDir(), { recursive: true });
 	const logFd = openSync(logFile(), "a");
@@ -94,7 +95,7 @@ export async function status(): Promise<StatusResult> {
 	const state = readState();
 	if (!state) return { running: false };
 	if (!isProcessAlive(state.hostPid)) {
-		clearState();
+		clearState(state.token);
 		return { running: false };
 	}
 	try {
@@ -115,7 +116,24 @@ export async function status(): Promise<StatusResult> {
  */
 export async function stop(opts: { timeoutMs?: number } = {}): Promise<boolean> {
 	const state = readState();
-	if (!state) return false;
+	if (!state) return true;
+
+	const selectedStateIsGone = (): boolean => readState()?.token !== state.token;
+	const forceSelectedSession = async (hard = false): Promise<boolean> => {
+		if (process.platform === "win32") {
+			try {
+				return await forceTerminateWindowsJob(state.token);
+			} catch {
+				return false;
+			}
+		}
+		try {
+			if (isProcessAlive(state.hostPid)) process.kill(state.hostPid, hard ? "SIGKILL" : "SIGTERM");
+			return true;
+		} catch {
+			return false;
+		}
+	};
 
 	try {
 		const client = new PtyProtoClient();
@@ -123,27 +141,25 @@ export async function stop(opts: { timeoutMs?: number } = {}): Promise<boolean> 
 		await client.requestStop();
 		client.close();
 	} catch {
-		try {
-			if (isProcessAlive(state.hostPid)) process.kill(state.hostPid, "SIGTERM");
-		} catch {
-			// already gone
-		}
+		await forceSelectedSession();
 	}
 
 	const deadline = Date.now() + (opts.timeoutMs ?? 6000);
 	while (Date.now() < deadline) {
-		if (!readState() && !isProcessAlive(state.hostPid) && !isProcessAlive(state.shellPid)) {
+		if (selectedStateIsGone() && !isProcessAlive(state.hostPid) && !isProcessAlive(state.shellPid)) {
 			return true;
 		}
 		await delay(100);
 	}
 
-	// Last resort: hard-kill the host and clear metadata ourselves.
-	try {
-		if (isProcessAlive(state.hostPid)) process.kill(state.hostPid, "SIGKILL");
-	} catch {
-		// already gone
+	// Last resort: terminate only the selected Job Object (or POSIX host), then
+	// give OS handle/process cleanup one final bounded interval.
+	await forceSelectedSession(true);
+	const forceDeadline = Date.now() + 1500;
+	while (Date.now() < forceDeadline) {
+		if (!isProcessAlive(state.hostPid) && !isProcessAlive(state.shellPid)) break;
+		await delay(50);
 	}
-	clearState();
+	if (!isProcessAlive(state.hostPid) && !isProcessAlive(state.shellPid)) clearState(state.token);
 	return !isProcessAlive(state.hostPid) && !isProcessAlive(state.shellPid);
 }

--- a/src/bun/prototypes/detached-pty/state.ts
+++ b/src/bun/prototypes/detached-pty/state.ts
@@ -97,12 +97,13 @@ export function readState(): PtyProtoState | null {
 }
 
 /**
- * Remove ALL prototype metadata: the state file, the host log, and the
- * prototype directory itself (only if it is now empty — a non-recursive rmdir
- * so we never nuke an unexpected directory). Best-effort; safe to call twice.
+ * Remove the selected prototype session's metadata. When `expectedToken` is
+ * present, a stale stop cannot erase a newer session's record. The state file
+ * is removed last so another start cannot begin until cleanup is complete.
  */
-export function clearState(): void {
-	for (const f of [stateFile(), logFile()]) {
+export function clearState(expectedToken?: string): boolean {
+	if (expectedToken !== undefined && readState()?.token !== expectedToken) return false;
+	for (const f of [logFile(), stateFile()]) {
 		try {
 			if (existsSync(f)) unlinkSync(f);
 		} catch {
@@ -114,4 +115,5 @@ export function clearState(): void {
 	} catch {
 		// dir not empty or already gone — leave it
 	}
+	return true;
 }

--- a/src/bun/prototypes/detached-pty/windows-job.ts
+++ b/src/bun/prototypes/detached-pty/windows-job.ts
@@ -153,18 +153,26 @@ export async function createWindowsJobContainment(sessionToken: string): Promise
 	return createWindowsJobWithApi(sessionToken, process.pid, await loadWindowsJobApi());
 }
 
-export function forceTerminateWindowsJobWithApi(sessionToken: string, api: WindowsJobApi): boolean {
-	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_TERMINATE);
-	if (job === NULL_HANDLE) {
-		api.dispose();
-		return false;
-	}
+function withWindowsJob<T>(
+	sessionToken: string,
+	access: number,
+	api: WindowsJobApi,
+	missing: T,
+	operation: (job: WindowsHandle) => T,
+): T {
+	let job = NULL_HANDLE;
 	try {
-		return api.terminateJob(job);
+		job = api.openJob(windowsJobName(sessionToken), access);
+		if (job === NULL_HANDLE) return missing;
+		return operation(job);
 	} finally {
-		api.closeHandle(job);
+		if (job !== NULL_HANDLE) api.closeHandle(job);
 		api.dispose();
 	}
+}
+
+export function forceTerminateWindowsJobWithApi(sessionToken: string, api: WindowsJobApi): boolean {
+	return withWindowsJob(sessionToken, JOB_OBJECT_TERMINATE, api, false, (job) => api.terminateJob(job));
 }
 
 export async function forceTerminateWindowsJob(sessionToken: string): Promise<boolean> {
@@ -173,14 +181,7 @@ export async function forceTerminateWindowsJob(sessionToken: string): Promise<bo
 }
 
 export function windowsJobExistsWithApi(sessionToken: string, api: WindowsJobApi): boolean {
-	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_QUERY);
-	if (job === NULL_HANDLE) {
-		api.dispose();
-		return false;
-	}
-	api.closeHandle(job);
-	api.dispose();
-	return true;
+	return withWindowsJob(sessionToken, JOB_OBJECT_QUERY, api, false, () => true);
 }
 
 export async function windowsJobExists(sessionToken: string): Promise<boolean> {
@@ -189,21 +190,15 @@ export async function windowsJobExists(sessionToken: string): Promise<boolean> {
 }
 
 export function isProcessInWindowsJobWithApi(sessionToken: string, pid: number, api: WindowsJobApi): boolean {
-	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_QUERY);
-	const processHandle = api.openProcess(pid, PROCESS_QUERY_LIMITED_INFORMATION);
-	if (job === NULL_HANDLE || processHandle === NULL_HANDLE) {
-		if (job !== NULL_HANDLE) api.closeHandle(job);
-		if (processHandle !== NULL_HANDLE) api.closeHandle(processHandle);
-		api.dispose();
-		return false;
-	}
-	try {
-		return api.isProcessInJob(processHandle, job);
-	} finally {
-		api.closeHandle(processHandle);
-		api.closeHandle(job);
-		api.dispose();
-	}
+	return withWindowsJob(sessionToken, JOB_OBJECT_QUERY, api, false, (job) => {
+		const processHandle = api.openProcess(pid, PROCESS_QUERY_LIMITED_INFORMATION);
+		if (processHandle === NULL_HANDLE) return false;
+		try {
+			return api.isProcessInJob(processHandle, job);
+		} finally {
+			api.closeHandle(processHandle);
+		}
+	});
 }
 
 export async function isProcessInWindowsJob(sessionToken: string, pid: number): Promise<boolean> {

--- a/src/bun/prototypes/detached-pty/windows-job.ts
+++ b/src/bun/prototypes/detached-pty/windows-job.ts
@@ -1,0 +1,212 @@
+/** Windows Job Object ownership for the isolated detached-PTY prototype. */
+
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const JOB_OBJECT_QUERY = 0x0004;
+const JOB_OBJECT_TERMINATE = 0x0008;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+const ERROR_ALREADY_EXISTS = 183;
+const NULL_HANDLE = 0n;
+
+export type WindowsHandle = bigint;
+
+export interface WindowsJobApi {
+	createJob(name: string): WindowsHandle;
+	setExtendedLimitInformation(job: WindowsHandle, limits: BigUint64Array): boolean;
+	openProcess(pid: number, access?: number): WindowsHandle;
+	assignProcess(job: WindowsHandle, process: WindowsHandle): boolean;
+	openJob(name: string, access?: number): WindowsHandle;
+	terminateJob(job: WindowsHandle): boolean;
+	isProcessInJob(process: WindowsHandle, job: WindowsHandle): boolean;
+	closeHandle(handle: WindowsHandle): boolean;
+	setLastError(code: number): void;
+	lastError(): number;
+	dispose(): void;
+}
+
+export function windowsJobName(sessionToken: string): string {
+	if (!/^[0-9a-f]{48}$/i.test(sessionToken)) {
+		throw new Error("invalid detached-pty session token for Windows Job Object");
+	}
+	return `Local\\dev3-pty-proto-${sessionToken.toLowerCase()}`;
+}
+
+function extendedLimits(): BigUint64Array {
+	// JOBOBJECT_EXTENDED_LIMIT_INFORMATION is 144 bytes on Windows x64/arm64.
+	const limits = new BigUint64Array(18);
+	new DataView(limits.buffer).setUint32(16, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, true);
+	return limits;
+}
+
+function win32Error(api: WindowsJobApi, operation: string): Error {
+	return new Error(`${operation} failed (Win32 error ${api.lastError()})`);
+}
+
+export class WindowsJobContainment {
+	private handle: WindowsHandle | null;
+
+	constructor(
+		readonly name: string,
+		handle: WindowsHandle,
+		private readonly api: WindowsJobApi,
+	) {
+		this.handle = handle;
+	}
+
+	/** Close the last owned handle. Kill-on-close terminates this host and its tree. */
+	closeForTreeTermination(): boolean {
+		if (this.handle === null) return false;
+		const handle = this.handle;
+		this.handle = null;
+		try {
+			return this.api.closeHandle(handle);
+		} finally {
+			this.api.dispose();
+		}
+	}
+}
+
+/** Create, configure, and self-enrol the detached host before it spawns a shell. */
+export function createWindowsJobWithApi(sessionToken: string, hostPid: number, api: WindowsJobApi): WindowsJobContainment {
+	const name = windowsJobName(sessionToken);
+	api.setLastError(0);
+	const job = api.createJob(name);
+	if (job === NULL_HANDLE) {
+		const error = win32Error(api, "CreateJobObjectW");
+		api.dispose();
+		throw error;
+	}
+	if (api.lastError() === ERROR_ALREADY_EXISTS) {
+		api.closeHandle(job);
+		api.dispose();
+		throw new Error(`refusing to reuse existing Windows Job Object ${name}`);
+	}
+
+	try {
+		if (!api.setExtendedLimitInformation(job, extendedLimits())) {
+			throw win32Error(api, "SetInformationJobObject");
+		}
+		const host = api.openProcess(hostPid);
+		if (host === NULL_HANDLE) throw win32Error(api, "OpenProcess");
+		try {
+			if (!api.assignProcess(job, host)) {
+				throw win32Error(api, "AssignProcessToJobObject");
+			}
+		} finally {
+			api.closeHandle(host);
+		}
+		return new WindowsJobContainment(name, job, api);
+	} catch (error) {
+		api.closeHandle(job);
+		api.dispose();
+		throw error;
+	}
+}
+
+async function loadWindowsJobApi(): Promise<WindowsJobApi> {
+	const { dlopen, FFIType } = await import("bun:ffi");
+	const { i32, ptr, u32, u64 } = FFIType;
+	const library = dlopen("kernel32.dll", {
+		CreateJobObjectW: { args: [ptr, ptr], returns: u64 },
+		SetInformationJobObject: { args: [u64, u32, ptr, u32], returns: i32 },
+		OpenProcess: { args: [u32, i32, u32], returns: u64 },
+		AssignProcessToJobObject: { args: [u64, u64], returns: i32 },
+		OpenJobObjectW: { args: [u32, i32, ptr], returns: u64 },
+		TerminateJobObject: { args: [u64, u32], returns: i32 },
+		IsProcessInJob: { args: [u64, u64, ptr], returns: i32 },
+		CloseHandle: { args: [u64], returns: i32 },
+		SetLastError: { args: [u32], returns: FFIType.void },
+		GetLastError: { args: [], returns: u32 },
+	} as const);
+	const symbols = library.symbols;
+	const wide = (value: string): Uint16Array => {
+		const out = new Uint16Array(value.length + 1);
+		for (let i = 0; i < value.length; i++) out[i] = value.charCodeAt(i);
+		return out;
+	};
+
+	return {
+		createJob: (name) => symbols.CreateJobObjectW(null, wide(name)),
+		setExtendedLimitInformation: (job, limits) =>
+			symbols.SetInformationJobObject(job, JOB_OBJECT_EXTENDED_LIMIT_INFORMATION, limits, limits.byteLength) !== 0,
+		openProcess: (pid, access = PROCESS_TERMINATE | PROCESS_SET_QUOTA) => symbols.OpenProcess(access, 0, pid),
+		assignProcess: (job, processHandle) => symbols.AssignProcessToJobObject(job, processHandle) !== 0,
+		openJob: (name, access = JOB_OBJECT_QUERY | JOB_OBJECT_TERMINATE) => symbols.OpenJobObjectW(access, 0, wide(name)),
+		terminateJob: (job) => symbols.TerminateJobObject(job, 1) !== 0,
+		isProcessInJob: (processHandle, job) => {
+			const result = new Int32Array(1);
+			if (symbols.IsProcessInJob(processHandle, job, result) === 0) return false;
+			return result[0] !== 0;
+		},
+		closeHandle: (handle) => symbols.CloseHandle(handle) !== 0,
+		setLastError: (code) => symbols.SetLastError(code),
+		lastError: () => symbols.GetLastError(),
+		dispose: () => library.close(),
+	};
+}
+
+/** No-op on POSIX; Windows failures abort only the isolated native host startup. */
+export async function createWindowsJobContainment(sessionToken: string): Promise<WindowsJobContainment | null> {
+	if (process.platform !== "win32") return null;
+	return createWindowsJobWithApi(sessionToken, process.pid, await loadWindowsJobApi());
+}
+
+export function forceTerminateWindowsJobWithApi(sessionToken: string, api: WindowsJobApi): boolean {
+	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_TERMINATE);
+	if (job === NULL_HANDLE) {
+		api.dispose();
+		return false;
+	}
+	try {
+		return api.terminateJob(job);
+	} finally {
+		api.closeHandle(job);
+		api.dispose();
+	}
+}
+
+export async function forceTerminateWindowsJob(sessionToken: string): Promise<boolean> {
+	if (process.platform !== "win32") return false;
+	return forceTerminateWindowsJobWithApi(sessionToken, await loadWindowsJobApi());
+}
+
+export function windowsJobExistsWithApi(sessionToken: string, api: WindowsJobApi): boolean {
+	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_QUERY);
+	if (job === NULL_HANDLE) {
+		api.dispose();
+		return false;
+	}
+	api.closeHandle(job);
+	api.dispose();
+	return true;
+}
+
+export async function windowsJobExists(sessionToken: string): Promise<boolean> {
+	if (process.platform !== "win32") return false;
+	return windowsJobExistsWithApi(sessionToken, await loadWindowsJobApi());
+}
+
+export function isProcessInWindowsJobWithApi(sessionToken: string, pid: number, api: WindowsJobApi): boolean {
+	const job = api.openJob(windowsJobName(sessionToken), JOB_OBJECT_QUERY);
+	const processHandle = api.openProcess(pid, PROCESS_QUERY_LIMITED_INFORMATION);
+	if (job === NULL_HANDLE || processHandle === NULL_HANDLE) {
+		if (job !== NULL_HANDLE) api.closeHandle(job);
+		if (processHandle !== NULL_HANDLE) api.closeHandle(processHandle);
+		api.dispose();
+		return false;
+	}
+	try {
+		return api.isProcessInJob(processHandle, job);
+	} finally {
+		api.closeHandle(processHandle);
+		api.closeHandle(job);
+		api.dispose();
+	}
+}
+
+export async function isProcessInWindowsJob(sessionToken: string, pid: number): Promise<boolean> {
+	if (process.platform !== "win32") return false;
+	return isProcessInWindowsJobWithApi(sessionToken, pid, await loadWindowsJobApi());
+}


### PR DESCRIPTION
## Summary

- Contain the isolated detached PTY host and complete PowerShell descendant tree in a token-named kill-on-close Windows Job Object.
- Enrol the host before shell spawn, attempt graceful Ctrl-C and exit shutdown, wait for a bound, then force only the selected Job tree.
- Make stop idempotent and token-scoped, including handles, endpoint, log, and metadata cleanup.
- Add native Windows child and grandchild regression coverage for Job membership, tmux non-invocation, and survival of a process outside the native session.
- Document the Bun FFI choice versus a signed helper and the exact native PowerShell reproduction.

## Scope

This remains prototype-only under src/bun/prototypes/detached-pty. It does not introduce TerminalBackend, change the default backend, or modify production tmux, RPC, CLI, renderer, existing sessions, or data paths.

## Verification

- Native Windows with Bun 1.3.14: bun run test:proto-e2e — ALL CHECKS PASSED.
- macOS: bun run test:proto-e2e — ALL CHECKS PASSED.
- bun run lint — passed.
- bun run test — 6,185 passed, 1 skipped.

Parent: Seq 1141 tmux removal roadmap.