### PR TITLE
Suppress wide remote status notifications

### DIFF
--- a/change-logs/2026/07/21/fix-remote-status-notification-noise.md
+++ b/change-logs/2026/07/21/fix-remote-status-notification-noise.md
@@ -1,0 +1,1 @@
+Wide remote clients no longer show watched-task status-change notifications; narrow remote viewports still receive them for mobile workflows. Other remote notifications and desktop-native notifications are unchanged.

--- a/src/bun/__tests__/notify-native-path.test.ts
+++ b/src/bun/__tests__/notify-native-path.test.ts
@@ -102,7 +102,7 @@ describe("native notification channel routing", () => {
 
 		notifyFromCliDesktop({ task: makeTask(), body: "done", projectName: "MyProject" });
 
-		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: "task-1", body: "done" }));
+		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: "task-1", body: "done", kind: "event" }));
 	});
 
 	it("falls back to the legacy path and arms the focus-proxy when the shim declines", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -10096,7 +10096,7 @@ describe("notifyWatchedTaskStatusChange", () => {
 		setTerminalFocus(false);
 
 		expect(Utils.showNotification).toHaveBeenCalledTimes(1);
-		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: task.id }));
+		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: task.id, kind: "status-change" }));
 	});
 });
 
@@ -10120,6 +10120,7 @@ describe("web notification push (remote/browser mode mirror)", () => {
 			taskId: task.id,
 			projectId: "proj-x",
 			title: "#7 Fix bug",
+			kind: "status-change",
 			body: "In Progress → Review By User",
 			level: "info",
 			taskSeq: 7,
@@ -10146,6 +10147,7 @@ describe("web notification push (remote/browser mode mirror)", () => {
 			taskId: task.id,
 			projectId: "proj-y",
 			title: "#3 Ship it",
+			kind: "event",
 			body: "build done",
 			level: "info",
 			taskSeq: 3,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -25,7 +25,7 @@ export {
 import { extname } from "node:path";
 import { Utils } from "../electrobun-platform";
 import { dlopen, FFIType } from "bun:ffi";
-import type { RendererLogLevel, RequirementCheckResult, SharedArtifact, SharedImage, Task } from "../../shared/types";
+import type { RendererLogLevel, RequirementCheckResult, SharedArtifact, SharedImage, Task, WebNotificationKind } from "../../shared/types";
 import { formatStatus, getTaskTitle } from "../../shared/types";
 import { createLogger } from "../logger";
 import { postNativeTaskNotification } from "../native-notifications";
@@ -177,7 +177,7 @@ export interface TerminalFocusArtifactPayload {
 }
 
 type QueuedTerminalNotification =
-	| { kind: "task"; task: Task; body: string; projectName?: string }
+	| { kind: "task"; task: Task; body: string; projectName?: string; notificationKind: WebNotificationKind }
 	| { kind: "toast"; payload: TerminalFocusToastPayload }
 	| { kind: "attention"; payload: TerminalFocusAttentionPayload }
 	| { kind: "terminalBell"; payload: TerminalFocusBellPayload }
@@ -203,7 +203,7 @@ function flushQueuedNotifications(): void {
 	const queued = queuedTerminalNotifications.splice(0, queuedTerminalNotifications.length);
 	for (const notification of queued) {
 		if (notification.kind === "task") {
-			deliverTaskNotification(notification.task, notification.body, notification.projectName, true);
+			deliverTaskNotification(notification.task, notification.body, notification.projectName, notification.notificationKind, true);
 		} else if (notification.kind === "toast") {
 			getPushMessage()?.("cliToast", notification.payload);
 		} else if (notification.kind === "attention") {
@@ -303,11 +303,13 @@ function pushWebNotification(opts: {
 	task: Task;
 	body: string;
 	projectName: string;
+	kind: WebNotificationKind;
 	level?: "info" | "success" | "error";
 }): void {
 	getPushMessage()?.("webNotification", {
 		taskId: opts.task.id,
 		projectId: opts.task.projectId,
+		kind: opts.kind,
 		title: `#${opts.task.seq} ${getTaskTitle(opts.task)}`,
 		body: opts.body,
 		level: opts.level ?? "info",
@@ -327,9 +329,15 @@ function pushWebNotification(opts: {
  * granted) this falls back to Electrobun's fire-and-forget path and arms the
  * legacy focus-proxy slot below.
  */
-function deliverTaskNotification(task: Task, body: string, projectName?: string, bypassSuppression = false): void {
+function deliverTaskNotification(
+	task: Task,
+	body: string,
+	projectName?: string,
+	kind: WebNotificationKind = "event",
+	bypassSuppression = false,
+): void {
 	if (isNotificationSuppressed() && !bypassSuppression) {
-		queuedTerminalNotifications.push({ kind: "task", task, body, projectName });
+		queuedTerminalNotifications.push({ kind: "task", task, body, projectName, notificationKind: kind });
 		return;
 	}
 
@@ -350,7 +358,7 @@ function deliverTaskNotification(task: Task, body: string, projectName?: string,
 			silent: true,
 		});
 	}
-	pushWebNotification({ task, body, projectName: projectName ?? "" });
+	pushWebNotification({ task, body, projectName: projectName ?? "", kind });
 	if (nativePosted) return;
 	// Only arm click-to-open when the app is NOT already in the foreground. If the
 	// user is actively looking at the app, the banner is purely informational — a
@@ -367,7 +375,7 @@ function deliverTaskNotification(task: Task, body: string, projectName?: string,
 
 export function notifyWatchedTaskStatusChange(task: Task, oldStatus: string, newStatus: string, projectName: string): void {
 	if (!task.watched || oldStatus === newStatus) return;
-	deliverTaskNotification(task, `${formatStatus(oldStatus)} → ${formatStatus(newStatus)}`, projectName);
+	deliverTaskNotification(task, `${formatStatus(oldStatus)} → ${formatStatus(newStatus)}`, projectName, "status-change");
 }
 
 /**

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useAppState, routeTaskId, projectIdForRoute, routeAfterTaskClosed, getTaskOpenMode, OPEN_SETTINGS_SECTION_EVENT, type Route, type SettingsSectionId } from "./state";
 import { api, isElectrobun, getRpcConnectionState } from "./rpc";
-import { setWebNotificationsSuppressed, showWebNotificationOrToast, type WebNotificationDetail } from "./utils/webNotification";
+import { setWebNotificationsSuppressed, shouldShowRemoteWebNotification, showWebNotificationOrToast, type WebNotificationDetail } from "./utils/webNotification";
 import { useT, useLocale } from "./i18n";
 import { handleMenuAction } from "./menuRouter";
 import { trackPageView, trackEvent, registerAgents } from "./analytics";
@@ -13,6 +13,7 @@ import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
 import { useMobileDenseZoom } from "./hooks/useMobileDenseZoom";
 import { useMobile } from "./hooks/useMobile";
+import { useNarrowViewport } from "./hooks/useNarrowViewport";
 import { useAndroidBackGuard } from "./hooks/useAndroidBackGuard";
 import GlobalHeader from "./components/GlobalHeader";
 import AppMenuBar from "./components/AppMenuBar";
@@ -121,6 +122,7 @@ function App() {
 	}, [dispatch]);
 	const t = useT();
 	const [, setLocale] = useLocale();
+	const narrowViewport = useNarrowViewport(768);
 	const [terminalImmersive, setTerminalImmersive] = useState(false);
 	const terminalImmersiveVisible = terminalImmersive && isTaskTerminalRoute(state.route);
 	const skipNextTerminalCopyResetRef = useRef(false);
@@ -1350,12 +1352,12 @@ function App() {
 		if (isElectrobun) return;
 		function onWebNotification(e: Event) {
 			const detail = (e as CustomEvent).detail as WebNotificationDetail;
-			if (!detail?.body) return;
+			if (!detail?.body || !shouldShowRemoteWebNotification(detail, narrowViewport)) return;
 			showWebNotificationOrToast(detail, openTaskFromNotification);
 		}
 		window.addEventListener("rpc:webNotification", onWebNotification);
 		return () => window.removeEventListener("rpc:webNotification", onWebNotification);
-	}, [openTaskFromNotification]);
+	}, [narrowViewport, openTaskFromNotification]);
 
 	// Listen for port scan updates
 	useEffect(() => {

--- a/src/mainview/utils/__tests__/webNotification.test.ts
+++ b/src/mainview/utils/__tests__/webNotification.test.ts
@@ -14,6 +14,7 @@ import {
 	webNotificationsSupported,
 	canShowWebNotification,
 	showWebNotificationOrToast,
+	shouldShowRemoteWebNotification,
 	setWebNotificationsSuppressed,
 	BROWSER_NOTIFICATIONS_PREF_KEY,
 	type WebNotificationDetail,
@@ -50,6 +51,7 @@ function uninstallNotification() {
 const baseDetail: WebNotificationDetail = {
 	taskId: "task-1",
 	projectId: "proj-1",
+	kind: "status-change",
 	title: "#42 Fix bug",
 	body: "In Progress → Review",
 	level: "info",
@@ -181,5 +183,19 @@ describe("showWebNotificationOrToast", () => {
 		expect(FakeNotification.instances).toHaveLength(1);
 		FakeNotification.instances[0].onclick?.();
 		expect(onOpen).toHaveBeenCalledWith("task-1", "proj-1");
+	});
+});
+
+describe("shouldShowRemoteWebNotification", () => {
+	it("keeps status changes on narrow remote viewports", () => {
+		expect(shouldShowRemoteWebNotification({ kind: "status-change" }, true)).toBe(true);
+	});
+
+	it("suppresses status changes on wide remote viewports", () => {
+		expect(shouldShowRemoteWebNotification({ kind: "status-change" }, false)).toBe(false);
+	});
+
+	it("keeps non-status notifications on every viewport", () => {
+		expect(shouldShowRemoteWebNotification({ kind: "event" }, false)).toBe(true);
 	});
 });

--- a/src/mainview/utils/webNotification.ts
+++ b/src/mainview/utils/webNotification.ts
@@ -1,4 +1,5 @@
 import { toast } from "../toast";
+import type { WebNotificationKind } from "../../shared/types";
 
 /**
  * Browser Web Notifications for remote/headless mode.
@@ -57,12 +58,17 @@ export function canShowWebNotification(): boolean {
 export interface WebNotificationDetail {
 	taskId: string;
 	projectId: string;
+	kind: WebNotificationKind;
 	title: string;
 	body: string;
 	level: "info" | "success" | "error";
 	taskSeq?: number;
 	taskTitle?: string;
 	projectName?: string;
+}
+
+export function shouldShowRemoteWebNotification(detail: Pick<WebNotificationDetail, "kind">, narrowViewport: boolean): boolean {
+	return detail.kind !== "status-change" || narrowViewport;
 }
 
 interface PendingWebNotification {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,6 +52,8 @@ export interface UpdatePopoverPreview {
 
 export type RendererLogLevel = "debug" | "info" | "warn" | "error";
 
+export type WebNotificationKind = "status-change" | "event";
+
 /**
  * Minimum length of a short ID prefix (task/project/label/note) accepted for
  * prefix matching. Below this, a prefix is treated as "not a prefix" (too broad
@@ -3496,6 +3498,8 @@ export type AppRPCSchema = {
 			webNotification: {
 				taskId: string;
 				projectId: string;
+				/** Used by remote clients to apply viewport-specific notification policy. */
+				kind: WebNotificationKind;
 				/** Notification heading, e.g. "#804 Fix bug". */
 				title: string;
 				/** Notification body, e.g. a message or "In Progress → Review". */


### PR DESCRIPTION
## Summary
- Suppress watched-task status-change notifications in wide browser remote viewports.
- Keep status-change notifications on narrow/mobile remote viewports.
- Preserve notification kind through immersive/focus suppression queues; other remote notifications and desktop-native notifications are unchanged.

## Verification
- `bun run lint`
- `bun run test`
- Browser QA: wide 1280px suppressed status changes while event notifications remained visible; narrow 390px showed status changes.