### PR TITLE
Alias `dev3 task list` to plural `tasks list`

### DIFF
--- a/change-logs/2026/07/22/fix-task-list-alias.md
+++ b/change-logs/2026/07/22/fix-task-list-alias.md
@@ -1,0 +1,3 @@
+Short: `dev3 task list` now works
+
+`dev3 task list` now works as an alias for the plural `dev3 tasks list` instead of failing with "Unknown subcommand", so the common mistype just does the right thing.

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -1340,3 +1340,16 @@ describe("task (unknown subcommand)", () => {
 		).rejects.toThrow("EXIT_3");
 	});
 });
+
+describe("task list (alias for tasks list)", () => {
+	it("forwards `task list` to the plural tasks.list command", async () => {
+		mockSend.mockResolvedValue(okResp([FAKE_TASK]));
+		await handleTask("list", args([], {}), SOCKET, CTX);
+		expect(mockSend).toHaveBeenCalledWith(
+			SOCKET,
+			"tasks.list",
+			expect.objectContaining({ projectId: "proj-001" }),
+		);
+		expect(stdoutOutput).toContain("Fix the login bug");
+	});
+});

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -8,6 +8,7 @@ import type { ParsedArgs } from "../args";
 import { expandShortId, resolveProjectId, type CliContext } from "../context";
 import { rejectUnknownFlags } from "../flag-validation";
 import { readStdin } from "../stdin";
+import { handleTasks } from "./tasks";
 
 // Statuses that destroy the worktree + terminal are not directly reachable via
 // CLI. `completed` is special-cased: it becomes a blocking approval request the
@@ -355,6 +356,10 @@ export async function handleTask(
 			return updateTask(args, socketPath, context);
 		case "move":
 			return moveTask(args, socketPath, context);
+		case "list":
+			// Alias: the enumerate command lives under the plural `tasks list`.
+			// `task list` is a natural mistype, so forward it transparently.
+			return handleTasks(subcommand, args, socketPath, context);
 		default:
 			exitUsage(
 				`Unknown subcommand: task ${subcommand || "(none)"}` +


### PR DESCRIPTION
Fixes #1022.

The singular `task` command group had `show / create / update / move` but no `list`, while board enumeration lives under the plural `tasks list`. Running `dev3 task list` — a natural mistype — failed with `Unknown subcommand: task list` and the `Available:` hint didn't mention the plural form, so it was a dead end.

`task list` now forwards transparently to the plural `tasks list` handler (all the same flags: `--project`, `--status`, `--label`, `--limit`, `--offset`). No prompt, skill, or hint-text changes — pure alias in the CLI router (`src/cli/commands/task.ts`). Added a unit test covering the forward; lint and full test suite green.