### PR TITLE
Fix update-check crash on dev/source builds

### DIFF
--- a/change-logs/2026/07/22/fix-dev-channel-update-crash.md
+++ b/change-logs/2026/07/22/fix-dev-channel-update-crash.md
@@ -1,0 +1,3 @@
+Short: Fix update crash on dev builds
+
+Manual "Check for Updates" no longer crashes on dev/source builds. Electrobun's updater disables updates on the dev channel and left its state uninitialized, so the download step threw a TypeError; the dev channel now shows an informational notice instead of attempting a download.

--- a/decisions/151-dev-channel-update-guard.md
+++ b/decisions/151-dev-channel-update-guard.md
@@ -1,0 +1,23 @@
+# 151 — Guard the update flow on dev/source builds
+
+## Context
+
+Running the app from source (`bun run dev`) builds it on the `dev` channel. Triggering the manual "Check for Updates" menu action crashed with
+`Update check failed: Download failed: TypeError: undefined is not an object (evaluating 'updateInfo.error = "Failed to download latest version"')`.
+
+## Investigation
+
+Electrobun's `Updater.checkForUpdate()` (`node_modules/electrobun/dist/api/bun/core/Updater.ts`) early-returns on the `dev` channel *without* initializing its module-level `updateInfo`. A dev build with a non-dev `updateChannel` (default `stable`) takes the cross-channel branch of `doDownloadUpdateForChannel`, which calls `Updater.downloadUpdate()`; that finds no tar to unpack and executes `updateInfo.error = "Failed to download latest version"` on the still-`undefined` object → `TypeError`. The auto-check already skipped dev; the manual check/download path did not.
+
+## Decision
+
+Guard the `dev` channel in `src/bun/updater.ts`: `checkForUpdateWithChannel` returns `{ updateAvailable: false, devBuild: true }` (no network) and `doDownloadUpdateForChannel` returns a clean error before ever touching Electrobun's updater. The menu handler (`src/bun/index.ts`) surfaces `devBuild` as a new `updateCheckOutcome` status `"dev"`, shown as an info toast (`update.devBuildNotice`).
+
+## Risks
+
+Low. Dev builds could never self-update anyway (Electrobun disables it); we only replace a crash with a notice. If the build-time channel string ever stops being `"dev"` for source builds, the guard silently stops applying — but the download-layer guard still prevents the crash for any channel Electrobun disables.
+
+## Alternatives considered
+
+- Patch `node_modules/electrobun` — rejected; vendored dependency, lost on reinstall.
+- Actually implement cross-channel download — out of scope and impossible to *apply* on a dev build (Electrobun gates it).

--- a/src/bun/__tests__/updater.test.ts
+++ b/src/bun/__tests__/updater.test.ts
@@ -26,7 +26,7 @@ vi.mock("../electrobun-platform", () => ({
 }));
 vi.mock("../quit-manager", () => ({ markQuitConfirmed }));
 
-import { applyUpdate, downloadUpdateForChannel } from "../updater";
+import { applyUpdate, downloadUpdateForChannel, checkForUpdateWithChannel } from "../updater";
 
 /** Remote state as Electrobun's checkForUpdate() returns it: no updateReady. */
 const remoteState = {
@@ -149,6 +149,49 @@ describe("downloadUpdateForChannel (same channel)", () => {
 		// Exactly one check (the initial state-populating one) — polling must
 		// use updateInfo(), because checkForUpdate resets updateReady.
 		expect(mockUpdater.checkForUpdate).toHaveBeenCalledOnce();
+	});
+});
+
+describe("dev channel guard", () => {
+	// Running from source builds the app on the "dev" channel. Electrobun's
+	// built-in updater disables updates on dev: checkForUpdate() early-returns
+	// WITHOUT initializing its module-level updateInfo, so a later
+	// downloadUpdate() dereferences undefined ("updateInfo.error = …") and
+	// throws a TypeError. Our flow must never reach that call on dev.
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUpdater.localInfo.channel.mockResolvedValue("dev");
+		mockUpdater.checkForUpdate.mockImplementation(async () => {
+			throw new TypeError("undefined is not an object (evaluating 'updateInfo.error = ...')");
+		});
+		mockUpdater.downloadUpdate.mockImplementation(async () => {
+			throw new TypeError("undefined is not an object (evaluating 'updateInfo.error = ...')");
+		});
+	});
+
+	afterEach(() => {
+		mockUpdater.localInfo.channel.mockResolvedValue("stable");
+		vi.restoreAllMocks();
+	});
+
+	it("checkForUpdateWithChannel reports devBuild without hitting the network", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		const result = await checkForUpdateWithChannel("stable");
+
+		expect(result.devBuild).toBe(true);
+		expect(result.updateAvailable).toBe(false);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("downloadUpdateForChannel refuses to touch the built-in updater on dev", async () => {
+		const result = await downloadUpdateForChannel("stable", vi.fn());
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/dev/i);
+		// The crashing Electrobun calls must never run.
+		expect(mockUpdater.checkForUpdate).not.toHaveBeenCalled();
+		expect(mockUpdater.downloadUpdate).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -724,7 +724,10 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 			sendUpdateProgress("checking");
 			const result = await checkForUpdateWithChannel(settings.updateChannel);
 
-			if (result.error) {
+			if (result.devBuild) {
+				sendUpdateProgress("idle");
+				sendToFocusedWindow("updateCheckOutcome", { status: "dev" });
+			} else if (result.error) {
 				sendUpdateProgress("idle");
 				sendToFocusedWindow("updateCheckOutcome", { status: "error", detail: result.error });
 			} else if (result.updateAvailable) {

--- a/src/bun/updater.ts
+++ b/src/bun/updater.ts
@@ -38,6 +38,8 @@ interface UpdateCheckResult {
 	version: string;
 	changelog?: UpdateChangelog;
 	error?: string;
+	/** True when running a from-source "dev" build, where updates are disabled. */
+	devBuild?: boolean;
 }
 
 function getPlatformPrefix(): string {
@@ -57,6 +59,15 @@ export async function getLocalVersion(): Promise<{ version: string; hash: string
 
 export async function checkForUpdateWithChannel(channel: string): Promise<UpdateCheckResult> {
 	const local = await getLocalVersion();
+
+	// Dev/source builds have updates disabled in Electrobun's updater; a download
+	// there dereferences its uninitialized state and throws (see
+	// doDownloadUpdateForChannel). Report the dev build instead of checking.
+	if (local.channel === "dev") {
+		log.info("Skipping update check on dev channel");
+		return { updateAvailable: false, version: local.version, devBuild: true };
+	}
+
 	const platformPrefix = getPlatformPrefix();
 
 	// Construct URL for the selected channel's update.json
@@ -112,6 +123,16 @@ async function doDownloadUpdateForChannel(
 	onProgress?: (status: string, progress?: number) => void,
 ): Promise<{ ok: boolean; error?: string }> {
 	const local = await getLocalVersion();
+
+	// Crash-proof floor for dev/source builds. Electrobun's checkForUpdate()
+	// early-returns on the "dev" channel without initializing its module-level
+	// updateInfo, so the subsequent downloadUpdate() writes `updateInfo.error`
+	// on undefined and throws a TypeError. Never reach that call on dev.
+	if (local.channel === "dev") {
+		const msg = "Updates are disabled on dev builds (running from source)";
+		log.info(msg);
+		return { ok: false, error: msg };
+	}
 
 	// If selected channel matches the build-time channel, use built-in updater
 	if (channel === local.channel) {

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1535,11 +1535,13 @@ function App() {
 	useEffect(() => {
 		function onUpdateCheckOutcome(e: Event) {
 			const { status, version, detail } = (e as CustomEvent).detail as {
-				status: "none" | "error";
+				status: "none" | "error" | "dev";
 				version?: string;
 				detail?: string;
 			};
-			if (status === "none") {
+			if (status === "dev") {
+				toast.info(t("update.devBuildNotice"));
+			} else if (status === "none") {
 				toast.info(t("update.upToDateVersion", { version: version ?? "" }));
 			} else {
 				toast.error(t("update.checkFailedDetail", { error: detail ?? "" }));

--- a/src/mainview/i18n/translations/en/updates.ts
+++ b/src/mainview/i18n/translations/en/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Downloading...",
 	"update.upToDateVersion": "You're up to date — v{version}",
 	"update.checkFailedDetail": "Update check failed: {error}",
+	"update.devBuildNotice": "This is a dev build — updates are disabled. Rebuild from source to update.",
 	"update.applyFailed": "Couldn't apply the update: {error}",
 	"update.whatsNewVersion": "What's new in v{version}",
 	"update.seeAllChanges": "See all changes",

--- a/src/mainview/i18n/translations/es/updates.ts
+++ b/src/mainview/i18n/translations/es/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Descargando...",
 	"update.upToDateVersion": "Tienes la última versión — v{version}",
 	"update.checkFailedDetail": "Error al buscar actualizaciones: {error}",
+	"update.devBuildNotice": "Esta es una compilación dev — las actualizaciones están deshabilitadas. Vuelve a compilar desde el código fuente para actualizar.",
 	"update.applyFailed": "No se pudo aplicar la actualización: {error}",
 	"update.whatsNewVersion": "Novedades en v{version}",
 	"update.seeAllChanges": "Ver todos los cambios",

--- a/src/mainview/i18n/translations/ru/updates.ts
+++ b/src/mainview/i18n/translations/ru/updates.ts
@@ -19,6 +19,7 @@ const updates = {
 	"update.downloading": "Загрузка...",
 	"update.upToDateVersion": "У вас последняя версия — v{version}",
 	"update.checkFailedDetail": "Не удалось проверить обновления: {error}",
+	"update.devBuildNotice": "Это dev-сборка — обновления отключены. Чтобы обновиться, пересоберите из исходников.",
 	"update.applyFailed": "Не удалось применить обновление: {error}",
 	"update.whatsNewVersion": "Что нового в v{version}",
 	"update.seeAllChanges": "Все изменения",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3594,7 +3594,7 @@ export type AppRPCSchema = {
 			 * Result of a manual "Check for Updates" menu action, surfaced as a toast.
 			 * `available` updates flow through `updateAvailable` instead (header plaque).
 			 */
-			updateCheckOutcome: { status: "none" | "error"; version?: string; detail?: string };
+			updateCheckOutcome: { status: "none" | "error" | "dev"; version?: string; detail?: string };
 		};
 	}>;
 };


### PR DESCRIPTION
## Summary

Manual **Check for Updates** crashed on dev/source builds (running from `bun run dev`) with:

> Update check failed: Download failed: TypeError: undefined is not an object (evaluating 'updateInfo.error = "Failed to download latest version"')

Root cause is in the vendored Electrobun updater: on the `dev` channel `Updater.checkForUpdate()` early-returns *without* initializing its module-level `updateInfo`, so the subsequent `Updater.downloadUpdate()` writes `updateInfo.error` on `undefined` and throws. The auto-check already skipped dev; the manual check/download path did not, so a dev build with a non-dev `updateChannel` (default `stable`) took the cross-channel branch straight into the crash.

## Fix

- `src/bun/updater.ts` — guard the `dev` channel in both entry points: `checkForUpdateWithChannel` returns `{ updateAvailable: false, devBuild: true }` with no network call, and `downloadUpdateForChannel` returns a clean error before ever touching Electrobun's updater (crash-proof floor for every caller).
- `src/bun/index.ts` — the menu handler surfaces `devBuild` as a new `updateCheckOutcome` status `"dev"`.
- `src/mainview/App.tsx` + i18n (en/ru/es) — shows an info toast ("This is a dev build — updates are disabled…") instead of a red error.
- Reproduce-first test in `src/bun/__tests__/updater.test.ts` (reproduced the exact TypeError, then fixed); decision record `151`; changelog entry.

🤖 Hi, this is Claude (the AI assistant that worked on this branch).