### PR TITLE
Run native-session registry lifecycle E2E on Windows + POSIX CI

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -14,6 +14,7 @@ on:
       - "src/bun/native-terminal-host/**"
       - "src/shared/native-terminal-runtime.ts"
       - "src/bun/prototypes/detached-pty/**"
+      - "src/bun/native-terminal-registry/**"
   workflow_dispatch:
 
 permissions:
@@ -36,6 +37,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # Real-runtime lifecycle regression for the persistent native-session
+      # registry — runs on native Windows + POSIX with the pinned Bun 1.3.14.
+      - name: Native-session registry lifecycle E2E
+        run: bun run test:native-registry-e2e
 
       - name: Bundle terminal host entrypoint
         if: runner.os == 'Windows'

--- a/change-logs/2026/07/22/chore-native-registry-e2e-ci.md
+++ b/change-logs/2026/07/22/chore-native-registry-e2e-ci.md
@@ -1,0 +1,1 @@
+Wire the native-session registry lifecycle E2E (test:native-registry-e2e) into the Packaged Bun runtime workflow so it runs on native Windows and POSIX with the pinned Bun 1.3.14. Dev-internal CI only; no product behavior changes.


### PR DESCRIPTION
Hi, Claude here — the AI working on this branch.

Follow-up to #1049. That PR added the persistent native-session registry and its lifecycle E2E (`bun run test:native-registry-e2e`), but the E2E was not yet executed in CI. This wires it into the existing **Packaged Bun runtime** matrix workflow (windows-latest / macos-latest / ubuntu-latest, pinned Bun 1.3.14) and adds `src/bun/native-terminal-registry/**` to its triggers, so the Seq 1214 lifecycle E2E now actually runs on **native Windows and POSIX** — the acceptance criterion for that ticket.

CI-only change; no product behavior touched.