### PR TITLE
Harden native-session ownership check against malformed Windows tokens

### DIFF
--- a/change-logs/2026/07/22/fix-native-registry-win-token.md
+++ b/change-logs/2026/07/22/fix-native-registry-win-token.md
@@ -1,0 +1,1 @@
+Harden the native-session registry ownership check so a missing or malformed per-session token on Windows returns a "reused" verdict instead of throwing and aborting the whole list/cleanup sweep. Caught by the newly CI-wired Windows lifecycle E2E; dev-internal, no product behavior changes.

--- a/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
@@ -281,10 +281,12 @@ async function run(): Promise<void> {
 		check(alphaEndpointGone, "alpha listening endpoint is gone after stop");
 
 		// ── 8. passive stale/reused detection + non-destructive, token-matched cleanup ──
+		// Valid-format (48-hex) tokens whose Job Objects were never created — models
+		// a real stale/reused record (host gone / PID reused), not a corrupt token.
 		writeRecordAtomic(ghostRecord("ghost-dead", 2_000_000_000, 2_000_000_000));
-		writeToken("ghost-dead", "ghost-dead-tok");
+		writeToken("ghost-dead", "a".repeat(48));
 		writeRecordAtomic(ghostRecord("ghost-reused", tmuxGuard.pid, tmuxGuard.pid));
-		writeToken("ghost-reused", "ghost-reused-tok");
+		writeToken("ghost-reused", "b".repeat(48));
 
 		const cleanup = await cleanupStale();
 		check(cleanup.removed.includes("ghost-dead"), "cleanup removed the dead-host record");

--- a/src/bun/native-terminal-registry/__tests__/ownership.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/ownership.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { classifyOwnership, type OwnershipProbes } from "../ownership";
 import { NATIVE_SESSION_SCHEMA_VERSION, type NativeSessionRecord } from "../record";
 
+// A well-formed 48-hex session token (the Windows Job Object name requires it).
+const VALID_TOKEN = "a".repeat(48);
+
 function record(evidenceKind: "posix-start-signature" | "windows-job"): NativeSessionRecord {
 	return {
 		schemaVersion: NATIVE_SESSION_SCHEMA_VERSION,
@@ -51,22 +54,38 @@ describe("classifyOwnership — Windows Job membership", () => {
 	const rec = record("windows-job");
 
 	it("owned when host and shell are both job members", async () => {
-		expect(await classifyOwnership(rec, "tok", probes({}))).toBe("owned");
+		expect(await classifyOwnership(rec, VALID_TOKEN, probes({}))).toBe("owned");
 	});
 
 	it("reused when the live PID is not in the session job", async () => {
-		expect(await classifyOwnership(rec, "tok", probes({ isInJob: async (_t, pid) => pid === 100 }))).toBe("reused");
+		expect(await classifyOwnership(rec, VALID_TOKEN, probes({ isInJob: async (_t, pid) => pid === 100 }))).toBe("reused");
 	});
 
 	it("reused when the private token is missing (cannot open the job)", async () => {
 		expect(await classifyOwnership(rec, null, probes({}))).toBe("reused");
 	});
 
+	it("reused (never throws) when the token is malformed — one corrupt token cannot abort a sweep", async () => {
+		let jobConsulted = false;
+		const verdict = await classifyOwnership(
+			rec,
+			"not-a-valid-hex-token",
+			probes({
+				isInJob: async () => {
+					jobConsulted = true;
+					return true;
+				},
+			}),
+		);
+		expect(verdict).toBe("reused");
+		expect(jobConsulted).toBe(false);
+	});
+
 	it("dead when a recorded PID is gone (never consults the job)", async () => {
 		let jobConsulted = false;
 		const verdict = await classifyOwnership(
 			rec,
-			"tok",
+			VALID_TOKEN,
 			probes({
 				isAlive: () => false,
 				isInJob: async () => {

--- a/src/bun/native-terminal-registry/__tests__/windows-job.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/windows-job.test.ts
@@ -3,6 +3,7 @@ import {
 	createWindowsJobWithApi,
 	forceTerminateWindowsJobWithApi,
 	isProcessInWindowsJobWithApi,
+	isValidSessionToken,
 	windowsJobExistsWithApi,
 	windowsJobName,
 	type WindowsJobApi,
@@ -30,6 +31,13 @@ describe("native-session Windows Job Object containment", () => {
 	it("names jobs in a registry-specific namespace and rejects bad tokens", () => {
 		expect(windowsJobName(TOKEN)).toBe(`Local\\dev3-native-sess-${TOKEN}`);
 		expect(() => windowsJobName("short")).toThrow("invalid native-session token");
+	});
+
+	it("validates the 48-hex session token format", () => {
+		expect(isValidSessionToken(TOKEN)).toBe(true);
+		for (const bad of ["", "short", "ghost-tok", "z".repeat(48), "a".repeat(47), "a".repeat(49)]) {
+			expect(isValidSessionToken(bad)).toBe(false);
+		}
 	});
 
 	it("enrols the host before spawn with kill-on-close", () => {

--- a/src/bun/native-terminal-registry/ownership.ts
+++ b/src/bun/native-terminal-registry/ownership.ts
@@ -18,7 +18,7 @@
 import { isProcessAlive, startSignaturesMatch } from "./process-identity";
 import { readProcessStartSignature } from "./process-identity-native";
 import type { NativeSessionRecord } from "./record";
-import { isProcessInWindowsJob } from "./windows-job";
+import { isProcessInWindowsJob, isValidSessionToken } from "./windows-job";
 
 export type OwnershipVerdict = "owned" | "dead" | "reused";
 
@@ -48,7 +48,10 @@ export async function classifyOwnership(
 	if (!probes.isAlive(record.host.pid) || !probes.isAlive(record.shell.pid)) return "dead";
 
 	if (record.ownership.evidenceKind === "windows-job") {
-		if (!token) return "reused";
+		// A missing OR malformed token cannot open the ownership Job Object — treat
+		// the session as unverifiable (reused), never throw and abort the whole
+		// list/cleanup sweep on one corrupt token.
+		if (!token || !isValidSessionToken(token)) return "reused";
 		const hostOwned = await probes.isInJob(token, record.host.pid);
 		const shellOwned = await probes.isInJob(token, record.shell.pid);
 		return hostOwned && shellOwned ? "owned" : "reused";

--- a/src/bun/native-terminal-registry/windows-job.ts
+++ b/src/bun/native-terminal-registry/windows-job.ts
@@ -39,8 +39,13 @@ export interface WindowsJobApi {
 	dispose(): void;
 }
 
+/** A live session token is 24 random bytes as lowercase hex (48 chars). */
+export function isValidSessionToken(sessionToken: string): boolean {
+	return typeof sessionToken === "string" && /^[0-9a-f]{48}$/i.test(sessionToken);
+}
+
 export function windowsJobName(sessionToken: string): string {
-	if (!/^[0-9a-f]{48}$/i.test(sessionToken)) {
+	if (!isValidSessionToken(sessionToken)) {
 		throw new Error("invalid native-session token for Windows Job Object");
 	}
 	return `Local\\dev3-native-sess-${sessionToken.toLowerCase()}`;


### PR DESCRIPTION
Hi, Claude here (the AI on this branch).

Fixes a **Windows-only** crash in the native-session registry (from #1049), surfaced the moment its lifecycle E2E started running on native Windows CI (#1051).

**Bug:** `classifyOwnership`'s Windows-job branch calls `windowsJobName`, which throws on a non-48-hex token. A missing/corrupt/short per-session token therefore threw and **aborted the entire `list`/`status`/`cleanupStale` sweep** instead of failing that one session. POSIX runs never hit this branch, so it passed locally and on macOS/ubuntu CI but failed on `windows-latest`.

**Fix:** `classifyOwnership` now treats a missing **or malformed** token as an unverifiable `reused` verdict (never throws). Exported `isValidSessionToken` centralises the 48-hex format contract. The lifecycle E2E's stale-ghost records now use valid 48-hex tokens so they exercise the real job-absent path. Adds unit coverage for the malformed-token verdict and the validator.

The Windows lifecycle E2E on the Packaged Bun runtime workflow should now be green. POSIX E2E + full `bun run test` + `bun run lint` green locally.