### PR TITLE
Redesign Changelog screen as a tiered timeline with search

### DIFF
--- a/change-logs/2026/07/22/feature-changelog-timeline-redesign.md
+++ b/change-logs/2026/07/22/feature-changelog-timeline-redesign.md
@@ -1,0 +1,3 @@
+Short: Redesigned Changelog screen
+
+The Changelog screen is now a release-notes timeline: prominent feature cards with headlines, compact rows for fixes and chores, a sticky date rail, full-text search, and type filters with counts. Long histories load incrementally as you scroll instead of rendering a thousand entries at once.

--- a/src/mainview/components/Changelog.tsx
+++ b/src/mainview/components/Changelog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useT } from "../i18n";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Route } from "../state";
@@ -22,31 +22,34 @@ const TYPE_SORT_ORDER: Record<string, number> = {
 	chore: 4,
 };
 
-// Type badge on the card. feature = accent, fix = danger, rest = neutral.
-const TYPE_STYLES: Record<string, string> = {
-	feature: "bg-accent/15 text-accent",
-	fix: "bg-danger/15 text-danger",
-	refactor: "bg-elevated text-fg-3",
-	docs: "bg-elevated text-fg-3",
-	chore: "bg-elevated text-fg-3",
+// Nerd Font glyphs: fa-rocket, fa-bug, fa-refresh, fa-book, fa-wrench.
+const TYPE_GLYPHS: Record<string, string> = {
+	feature: "\uf135",
+	fix: "\uf188",
+	refactor: "\uf021",
+	docs: "\uf02d",
+	chore: "\uf0ad",
 };
 
-// Thin colored top accent, keyed by type, that gives the card grid its rhythm.
-const TYPE_ACCENT: Record<string, string> = {
-	feature: "bg-accent",
-	fix: "bg-danger",
-	refactor: "bg-edge-active",
-	docs: "bg-edge-active",
-	chore: "bg-edge-active",
+const TYPE_ICON_COLOR: Record<string, string> = {
+	feature: "text-accent",
+	fix: "text-danger",
+	refactor: "text-fg-3",
+	docs: "text-fg-3",
+	chore: "text-fg-3",
 };
 
 const FILTER_ACTIVE_STYLES: Record<string, string> = {
-	feature: "bg-accent/25 text-accent border-accent/40",
-	fix: "bg-danger/25 text-danger border-danger/40",
+	feature: "bg-accent/20 text-accent border-accent/40",
+	fix: "bg-danger/15 text-danger border-danger/40",
 	refactor: "bg-raised text-fg border-edge-active",
 	docs: "bg-raised text-fg border-edge-active",
 	chore: "bg-raised text-fg border-edge-active",
 };
+
+// Day groups render incrementally so ~1000 entries never hit the DOM at once.
+const INITIAL_DAYS = 15;
+const LOAD_MORE_DAYS = 15;
 
 function sortByType(a: ChangelogEntry, b: ChangelogEntry): number {
 	return (TYPE_SORT_ORDER[a.type] ?? 99) - (TYPE_SORT_ORDER[b.type] ?? 99);
@@ -62,6 +65,14 @@ function formatDate(dateStr: string): { label: string; weekday: string } {
 
 function entryKey(e: ChangelogEntry): string {
 	return `${e.date}-${e.type}-${e.slug}`;
+}
+
+function Glyph({ glyph, className }: { glyph: string; className?: string }) {
+	return (
+		<span aria-hidden="true" className={className} style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+			{glyph}
+		</span>
+	);
 }
 
 function Chevron({ open }: { open: boolean }) {
@@ -117,7 +128,67 @@ function CreditPrefix({ entry }: { entry: ChangelogEntry }) {
 	);
 }
 
-function EntryCard({
+/** Prominent card for `feature` entries: icon chip, optional short headline, teaser. */
+function FeatureCard({
+	entry,
+	expanded,
+	wide,
+	onToggle,
+}: {
+	entry: ChangelogEntry;
+	expanded: boolean;
+	wide: boolean;
+	onToggle: () => void;
+}) {
+	const hasBody = Boolean(entry.body);
+	const headline = entry.short?.trim();
+	const text = expanded && entry.body ? entry.body : entry.title;
+
+	const inner = (
+		<>
+			<span className="absolute inset-y-0 left-0 w-[3px] bg-accent/60" />
+			<div className="flex items-start gap-2.5">
+				<span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-accent/15">
+					<Glyph glyph={TYPE_GLYPHS.feature} className="text-accent text-[0.8125rem] leading-none" />
+				</span>
+				<span className="flex-1 min-w-0 pt-0.5">
+					{headline && <span className="block text-fg text-sm font-semibold leading-snug">{headline}</span>}
+					<span
+						className={`block text-sm leading-relaxed ${headline ? "text-fg-2 mt-1" : "text-fg"} ${
+							expanded ? "whitespace-pre-line" : "line-clamp-3"
+						}`}
+					>
+						<CreditPrefix entry={entry} />
+						{text}
+					</span>
+				</span>
+				{hasBody && <Chevron open={expanded} />}
+			</div>
+		</>
+	);
+
+	const base = "relative rounded-xl border bg-raised p-4 overflow-hidden transition-colors";
+	const span = expanded || wide ? "sm:col-span-2" : "";
+
+	if (!hasBody) {
+		return <div className={`${base} border-edge ${span}`}>{inner}</div>;
+	}
+	return (
+		<button
+			type="button"
+			onClick={onToggle}
+			aria-expanded={expanded}
+			className={`${base} ${span} w-full text-left cursor-pointer hover:bg-raised-hover ${
+				expanded ? "border-accent/40" : "border-edge hover:border-accent/40"
+			}`}
+		>
+			{inner}
+		</button>
+	);
+}
+
+/** Compact list row for fix/refactor/docs/chore entries. */
+function MinorRow({
 	entry,
 	expanded,
 	onToggle,
@@ -133,46 +204,34 @@ function EntryCard({
 
 	const inner = (
 		<>
-			<span className={`absolute inset-x-0 top-0 h-0.5 ${TYPE_ACCENT[entry.type] ?? "bg-edge-active"}`} />
-			<div className="flex items-center gap-2">
-				<span
-					className={`inline-block px-1.5 py-0.5 rounded text-[0.625rem] font-medium leading-none ${
-						TYPE_STYLES[entry.type] ?? "bg-elevated text-fg-3"
-					}`}
-				>
-					{typeLabel}
-				</span>
-				{hasBody && <Chevron open={expanded} />}
-			</div>
-			<p
-				className={`text-fg text-sm leading-snug ${
-					expanded ? "whitespace-pre-line" : "line-clamp-3"
+			<span className="mt-[3px] w-4 shrink-0 text-center" title={typeLabel}>
+				<Glyph
+					glyph={TYPE_GLYPHS[entry.type] ?? TYPE_GLYPHS.chore}
+					className={`text-xs leading-none ${TYPE_ICON_COLOR[entry.type] ?? "text-fg-3"}`}
+				/>
+			</span>
+			<span
+				className={`flex-1 min-w-0 text-sm leading-snug text-fg-2 ${
+					expanded ? "whitespace-pre-line" : "line-clamp-2"
 				}`}
 			>
 				<CreditPrefix entry={entry} />
 				{text}
-			</p>
+			</span>
+			{hasBody && <Chevron open={expanded} />}
 		</>
 	);
 
-	const base =
-		"relative flex flex-col gap-2 rounded-xl border border-edge bg-raised px-3.5 pt-4 pb-3.5 overflow-hidden transition-colors";
-	// Collapsed cards share one fixed height so the grid reads as even tiles;
-	// an expanded card drops to auto height and grows within its own cell.
-	const collapsedSize = "h-28";
-
+	const base = "flex items-start gap-3 px-4 py-2.5";
 	if (!hasBody) {
-		return <div className={`${base} ${collapsedSize}`}>{inner}</div>;
+		return <div className={base}>{inner}</div>;
 	}
-
 	return (
 		<button
 			type="button"
 			onClick={onToggle}
 			aria-expanded={expanded}
-			className={`${base} w-full text-left cursor-pointer hover:border-edge-active hover:bg-raised-hover ${
-				expanded ? "h-auto sm:col-span-2 border-edge-active" : collapsedSize
-			}`}
+			className={`${base} w-full text-left cursor-pointer hover:bg-raised-hover transition-colors`}
 		>
 			{inner}
 		</button>
@@ -183,8 +242,11 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 	const t = useT();
 	const [entries, setEntries] = useState<ChangelogEntry[]>([]);
 	const [loading, setLoading] = useState(true);
-	const [activeFilter, setActiveFilter] = useState<EntryType | null>(null);
+	const [activeTypes, setActiveTypes] = useState<Set<EntryType>>(new Set());
+	const [query, setQuery] = useState("");
 	const [expanded, setExpanded] = useState<Set<string>>(new Set());
+	const [visibleDays, setVisibleDays] = useState(INITIAL_DAYS);
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
 		api.request
@@ -198,8 +260,12 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 			});
 	}, []);
 
-	// Escape → go back to previous page
+	// Escape is staged: clear the search first, only then navigate back.
 	useEscapeKey(() => {
+		if (query) {
+			setQuery("");
+			return;
+		}
 		if (canGoBack) {
 			goBack();
 		} else {
@@ -208,7 +274,12 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 	});
 
 	const toggleFilter = useCallback((type: EntryType) => {
-		setActiveFilter((prev) => (prev === type ? null : type));
+		setActiveTypes((prev) => {
+			const next = new Set(prev);
+			if (next.has(type)) next.delete(type);
+			else next.add(type);
+			return next;
+		});
 	}, []);
 
 	const toggleExpand = useCallback((key: string) => {
@@ -220,13 +291,31 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 		});
 	}, []);
 
-	const availableTypes = useMemo(() => {
-		const typeSet = new Set(entries.map((e) => e.type));
-		return ENTRY_TYPES.filter((type) => typeSet.has(type));
+	const resetFilters = useCallback(() => {
+		setQuery("");
+		setActiveTypes(new Set());
+	}, []);
+
+	const typeCounts = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const e of entries) counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+		return counts;
 	}, [entries]);
 
+	const availableTypes = useMemo(() => ENTRY_TYPES.filter((type) => typeCounts.has(type)), [typeCounts]);
+
 	const grouped = useMemo(() => {
-		const filtered = activeFilter ? entries.filter((e) => e.type === activeFilter) : entries;
+		const q = query.trim().toLowerCase();
+		const matchesQuery = (e: ChangelogEntry) =>
+			q === "" ||
+			e.title.toLowerCase().includes(q) ||
+			(e.body?.toLowerCase().includes(q) ?? false) ||
+			(e.short?.toLowerCase().includes(q) ?? false) ||
+			e.slug.toLowerCase().includes(q) ||
+			(e.suggestedBy?.toLowerCase().includes(q) ?? false);
+		const filtered = entries.filter(
+			(e) => (activeTypes.size === 0 || activeTypes.has(e.type as EntryType)) && matchesQuery(e),
+		);
 		const sorted = [...filtered].sort(sortByType);
 		const map = new Map<string, ChangelogEntry[]>();
 		for (const entry of sorted) {
@@ -237,21 +326,64 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 		return Array.from(map.entries())
 			.map(([date, items]) => ({ date, items }))
 			.sort((a, b) => b.date.localeCompare(a.date));
-	}, [entries, activeFilter]);
+	}, [entries, activeTypes, query]);
 
+	useEffect(() => {
+		setVisibleDays(INITIAL_DAYS);
+	}, [query, activeTypes]);
+
+	const visibleGroups = grouped.slice(0, visibleDays);
+	const hasMore = grouped.length > visibleGroups.length;
 	const shownCount = useMemo(() => grouped.reduce((n, g) => n + g.items.length, 0), [grouped]);
+	const isFiltered = query.trim() !== "" || activeTypes.size > 0;
+
+	useEffect(() => {
+		if (!hasMore) return;
+		const el = sentinelRef.current;
+		if (!el || typeof IntersectionObserver === "undefined") return;
+		const observer = new IntersectionObserver(
+			(observed) => {
+				if (observed.some((o) => o.isIntersecting)) setVisibleDays((v) => v + LOAD_MORE_DAYS);
+			},
+			{ rootMargin: "800px" },
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [hasMore]);
 
 	if (loading) {
 		return (
-			<div className="h-full w-full flex items-center justify-center">
-				<span className="text-fg-3 text-sm">{t("changelog.loading")}</span>
+			<div className="h-full w-full overflow-y-auto" aria-busy="true">
+				<div className="mx-auto max-w-[72rem] px-6 sm:px-8 py-8">
+					<div className="animate-pulse">
+						<div className="h-8 w-56 rounded-lg bg-raised" />
+						<div className="mt-3 h-4 w-80 rounded bg-raised" />
+						<div className="mt-10 space-y-10">
+							{[0, 1, 2].map((i) => (
+								<div key={i} className="lg:grid lg:grid-cols-[9.5rem_minmax(0,1fr)] lg:gap-x-8">
+									<div className="mb-3 space-y-2 lg:mb-0 lg:flex lg:flex-col lg:items-end">
+										<div className="h-4 w-24 rounded bg-raised" />
+										<div className="h-3 w-16 rounded bg-raised" />
+									</div>
+									<div className="grid grid-cols-1 gap-3 border-l border-edge pl-5 sm:grid-cols-2 sm:pl-7">
+										<div className="h-24 rounded-xl bg-raised" />
+										<div className="h-24 rounded-xl bg-raised" />
+										<div className="h-16 rounded-xl bg-raised sm:col-span-2" />
+									</div>
+								</div>
+							))}
+						</div>
+					</div>
+					<span className="sr-only">{t("changelog.loading")}</span>
+				</div>
 			</div>
 		);
 	}
 
 	if (entries.length === 0) {
 		return (
-			<div className="h-full w-full flex items-center justify-center">
+			<div className="h-full w-full flex flex-col items-center justify-center gap-3">
+				<Glyph glyph={""} className="text-fg-muted text-3xl" />
 				<span className="text-fg-muted text-sm">{t("changelog.empty")}</span>
 			</div>
 		);
@@ -259,73 +391,157 @@ function Changelog({ navigate, goBack, canGoBack }: ChangelogProps) {
 
 	return (
 		<div className="h-full w-full overflow-y-auto">
-			<div className="mx-auto max-w-[90rem] px-6 sm:px-8 py-8">
-				<header className="mb-6">
-					<h1 className="text-fg text-2xl font-bold tracking-tight">{t("header.changelog")}</h1>
-					<p className="text-fg-3 text-sm mt-1">{t("changelog.subtitle")}</p>
-					<p className="text-fg-muted text-xs mt-1">{t.plural("changelog.entries", shownCount)}</p>
+			<div className="mx-auto max-w-[72rem] px-6 sm:px-8 py-8">
+				<header className="mb-5">
+					<h1 className="text-fg text-3xl font-bold tracking-tight">{t("header.changelog")}</h1>
+					<p className="text-fg-3 text-sm mt-1.5">
+						{t("changelog.subtitle")}{" "}
+						<span className="text-fg-muted">· {t.plural("changelog.entries", entries.length)}</span>
+					</p>
 				</header>
 
-				{availableTypes.length > 1 && (
-					<div className="flex items-center gap-1.5 flex-wrap mb-7">
-						<span className="text-fg-3 text-xs mr-1">{t("changelog.filterLabel")}</span>
-						{availableTypes.map((type) => {
-							const isActive = activeFilter === type;
-							return (
+				<div className="sticky top-0 z-20 -mx-2 mb-8 bg-base px-2 py-3 border-b border-edge/70">
+					<div className="flex flex-wrap items-center gap-2">
+						<div className="relative w-full sm:w-72">
+							<Glyph
+								glyph={""}
+								className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-fg-muted text-xs"
+							/>
+							<input
+								type="text"
+								value={query}
+								onChange={(e) => setQuery(e.target.value)}
+								placeholder={t("changelog.searchPlaceholder")}
+								className="w-full rounded-lg border border-edge bg-elevated py-1.5 pl-8 pr-8 text-sm text-fg placeholder-fg-muted outline-none transition-colors focus:border-accent/50"
+							/>
+							{query && (
 								<button
-									key={type}
 									type="button"
-									onClick={() => toggleFilter(type)}
-									className={`px-2 py-0.5 rounded text-[0.6875rem] font-medium leading-tight border transition-colors cursor-pointer ${
-										isActive
-											? FILTER_ACTIVE_STYLES[type]
-											: "bg-transparent text-fg-3 border-edge hover:border-edge-active hover:text-fg-2"
-									}`}
+									onClick={() => setQuery("")}
+									aria-label={t("changelog.clearSearch")}
+									className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-fg-muted transition-colors hover:text-fg-2"
 								>
-									{t(`changelog.${type}` as never) || type}
+									<Glyph glyph={""} className="text-xs" />
 								</button>
-							);
-						})}
-						{activeFilter && (
-							<button
-								type="button"
-								onClick={() => setActiveFilter(null)}
-								className="px-2 py-0.5 rounded text-[0.6875rem] text-fg-muted hover:text-fg-3 transition-colors cursor-pointer"
-							>
-								{t("changelog.clearFilter")}
-							</button>
+							)}
+						</div>
+						{availableTypes.length > 1 &&
+							availableTypes.map((type) => {
+								const isActive = activeTypes.has(type);
+								return (
+									<button
+										key={type}
+										type="button"
+										onClick={() => toggleFilter(type)}
+										aria-pressed={isActive}
+										className={`flex cursor-pointer items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium leading-tight transition-colors ${
+											isActive
+												? FILTER_ACTIVE_STYLES[type]
+												: "border-edge bg-transparent text-fg-3 hover:border-edge-active hover:text-fg-2"
+										}`}
+									>
+										<Glyph glyph={TYPE_GLYPHS[type]} className="text-[0.6875rem] leading-none" />
+										{t(`changelog.${type}` as never) || type}
+										<span className={isActive ? "opacity-70" : "text-fg-muted"}>{typeCounts.get(type)}</span>
+									</button>
+								);
+							})}
+						{isFiltered && (
+							<>
+								<button
+									type="button"
+									onClick={resetFilters}
+									className="cursor-pointer rounded px-2 py-0.5 text-xs text-fg-muted transition-colors hover:text-fg-3"
+								>
+									{t("changelog.clearFilter")}
+								</button>
+								<span className="ml-auto whitespace-nowrap text-xs text-fg-muted">
+									{t.plural("changelog.entries", shownCount)}
+								</span>
+							</>
 						)}
 					</div>
-				)}
-
-				<div className="space-y-8">
-					{grouped.map(({ date, items }) => {
-						const { label, weekday } = formatDate(date);
-						return (
-							<section key={date}>
-								<div className="sticky top-0 z-10 bg-base flex items-center gap-3 py-2 mb-3">
-									<h2 className="text-fg text-sm font-semibold whitespace-nowrap">{label}</h2>
-									<span className="text-fg-muted text-xs whitespace-nowrap hidden sm:inline">{weekday}</span>
-									<span className="flex-1 h-px bg-edge" />
-									<span className="text-fg-muted text-xs whitespace-nowrap">{items.length}</span>
-								</div>
-								<div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 items-start">
-									{items.map((entry) => {
-										const key = entryKey(entry);
-										return (
-											<EntryCard
-												key={key}
-												entry={entry}
-												expanded={expanded.has(key)}
-												onToggle={() => toggleExpand(key)}
-											/>
-										);
-									})}
-								</div>
-							</section>
-						);
-					})}
 				</div>
+
+				{grouped.length === 0 ? (
+					<div className="flex flex-col items-center gap-3 py-24 text-center">
+						<Glyph glyph={""} className="text-fg-muted text-2xl" />
+						<p className="text-fg-3 text-sm">{t("changelog.noResults")}</p>
+						<button
+							type="button"
+							onClick={resetFilters}
+							className="cursor-pointer text-sm text-accent hover:underline"
+						>
+							{t("changelog.resetFilters")}
+						</button>
+					</div>
+				) : (
+					<>
+						{visibleGroups.map(({ date, items }) => {
+							const { label, weekday } = formatDate(date);
+							const features = items.filter((e) => e.type === "feature");
+							const minors = items.filter((e) => e.type !== "feature");
+							return (
+								<section key={date} className="relative lg:grid lg:grid-cols-[9.5rem_minmax(0,1fr)] lg:gap-x-8">
+									<div className="mb-2.5 flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5 lg:mb-0 lg:block lg:sticky lg:top-20 lg:self-start lg:pr-1 lg:text-right lg:space-y-0.5">
+										<h2 className="whitespace-nowrap text-base font-semibold leading-tight text-fg">{label}</h2>
+										<p className="text-xs text-fg-muted">{weekday}</p>
+										<p className="text-xs text-fg-muted">{t.plural("changelog.entries", items.length)}</p>
+									</div>
+									<div className="relative border-l border-edge pb-10 pl-5 sm:pl-7">
+										<span className="absolute -left-[5px] top-[3px] h-2.5 w-2.5 rounded-full bg-accent ring-4 ring-base" />
+										{features.length > 0 && (
+											<div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2">
+												{features.map((entry) => {
+													const key = entryKey(entry);
+													return (
+														<FeatureCard
+															key={key}
+															entry={entry}
+															expanded={expanded.has(key)}
+															wide={features.length === 1}
+															onToggle={() => toggleExpand(key)}
+														/>
+													);
+												})}
+											</div>
+										)}
+										{minors.length > 0 && (
+											<div
+												className={`divide-y divide-edge overflow-hidden rounded-xl border border-edge bg-raised/60 ${
+													features.length > 0 ? "mt-3" : ""
+												}`}
+											>
+												{minors.map((entry) => {
+													const key = entryKey(entry);
+													return (
+														<MinorRow
+															key={key}
+															entry={entry}
+															expanded={expanded.has(key)}
+															onToggle={() => toggleExpand(key)}
+														/>
+													);
+												})}
+											</div>
+										)}
+									</div>
+								</section>
+							);
+						})}
+						{hasMore && (
+							<div ref={sentinelRef} className="flex justify-center pb-10">
+								<button
+									type="button"
+									onClick={() => setVisibleDays((v) => v + LOAD_MORE_DAYS)}
+									className="cursor-pointer rounded-lg border border-edge px-4 py-1.5 text-sm text-fg-3 transition-colors hover:border-edge-active hover:text-fg-2"
+								>
+									{t("changelog.showMore")}
+								</button>
+							</div>
+						)}
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/src/mainview/components/__tests__/Changelog.test.tsx
+++ b/src/mainview/components/__tests__/Changelog.test.tsx
@@ -16,10 +16,10 @@ import { api } from "../../rpc";
 
 const mockedApi = vi.mocked(api, true);
 
-function renderChangelog() {
+function renderChangelog(props: { goBack?: () => void; canGoBack?: boolean } = {}) {
 	return render(
 		<I18nProvider>
-			<Changelog navigate={vi.fn()} goBack={vi.fn()} canGoBack={false} />
+			<Changelog navigate={vi.fn()} goBack={props.goBack ?? vi.fn()} canGoBack={props.canGoBack ?? false} />
 		</I18nProvider>,
 	);
 }
@@ -41,7 +41,7 @@ describe("Changelog", () => {
 
 		await screen.findByText("Fix on 26th");
 
-		// Each date group is a <section>; its left column carries the formatted date.
+		// Each date group is a <section>; its rail carries the formatted date.
 		const sections = container.querySelectorAll("section");
 		expect(sections).toHaveLength(3);
 		const dateTexts = [...sections].map((s) => s.textContent ?? "");
@@ -75,6 +75,23 @@ describe("Changelog", () => {
 		expect(screen.queryByText(/full detailed body/)).not.toBeInTheDocument();
 	});
 
+	it("shows the authored short title as a feature headline", async () => {
+		const entries: ChangelogEntry[] = [
+			{
+				date: "2026-02-26",
+				type: "feature",
+				slug: "f",
+				title: "A long first sentence describing the feature.",
+				short: "Snappy headline",
+			},
+		];
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog();
+
+		await screen.findByText("Snappy headline");
+		expect(screen.getByText(/long first sentence/)).toBeInTheDocument();
+	});
+
 	it("does not make an entry without a body clickable", async () => {
 		const entries: ChangelogEntry[] = [
 			{ date: "2026-02-26", type: "fix", slug: "x", title: "Just a one-liner" },
@@ -96,9 +113,101 @@ describe("Changelog", () => {
 		renderChangelog();
 
 		await screen.findByText("A feature entry");
-		// Filter chips render for each present type; click the "fix" filter.
-		await user.click(screen.getByRole("button", { name: "fix" }));
+		// Filter chips render for each present type with a count; click the "fix" chip.
+		await user.click(screen.getByRole("button", { name: /^fix\b/ }));
 		expect(screen.queryByText("A feature entry")).not.toBeInTheDocument();
 		expect(screen.getByText("A fix entry")).toBeInTheDocument();
+	});
+
+	it("supports multi-select type filters", async () => {
+		const user = userEvent.setup();
+		const entries: ChangelogEntry[] = [
+			{ date: "2026-02-26", type: "feature", slug: "a", title: "A feature entry" },
+			{ date: "2026-02-26", type: "fix", slug: "b", title: "A fix entry" },
+			{ date: "2026-02-26", type: "chore", slug: "c", title: "A chore entry" },
+		];
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog();
+
+		await screen.findByText("A feature entry");
+		await user.click(screen.getByRole("button", { name: /^feature\b/ }));
+		await user.click(screen.getByRole("button", { name: /^fix\b/ }));
+		expect(screen.getByText("A feature entry")).toBeInTheDocument();
+		expect(screen.getByText("A fix entry")).toBeInTheDocument();
+		expect(screen.queryByText("A chore entry")).not.toBeInTheDocument();
+	});
+
+	it("filters entries with the search box", async () => {
+		const user = userEvent.setup();
+		const entries: ChangelogEntry[] = [
+			{ date: "2026-02-26", type: "feature", slug: "a", title: "Alpha thing shipped" },
+			{ date: "2026-02-25", type: "feature", slug: "b", title: "Beta thing shipped" },
+		];
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog();
+
+		await screen.findByText("Alpha thing shipped");
+		await user.type(screen.getByPlaceholderText("Search changelog…"), "alpha");
+		expect(screen.getByText("Alpha thing shipped")).toBeInTheDocument();
+		expect(screen.queryByText("Beta thing shipped")).not.toBeInTheDocument();
+	});
+
+	it("shows a no-results state whose reset button restores all entries", async () => {
+		const user = userEvent.setup();
+		const entries: ChangelogEntry[] = [
+			{ date: "2026-02-26", type: "feature", slug: "a", title: "Alpha thing shipped" },
+		];
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog();
+
+		await screen.findByText("Alpha thing shipped");
+		await user.type(screen.getByPlaceholderText("Search changelog…"), "zzz");
+		expect(screen.queryByText("Alpha thing shipped")).not.toBeInTheDocument();
+		expect(screen.getByText("Nothing matches your search or filters.")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Reset filters" }));
+		expect(screen.getByText("Alpha thing shipped")).toBeInTheDocument();
+	});
+
+	it("renders day groups incrementally with a Show more control", async () => {
+		const user = userEvent.setup();
+		// 20 distinct days — more than the initial batch of 15.
+		const entries: ChangelogEntry[] = Array.from({ length: 20 }, (_, i) => ({
+			date: `2026-01-${String(i + 1).padStart(2, "0")}`,
+			type: "fix",
+			slug: `s${i + 1}`,
+			title: `Entry ${i + 1}`,
+		}));
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog();
+
+		// Newest day (Jan 20) is in the first batch; oldest (Jan 1) is not.
+		await screen.findByText("Entry 20");
+		expect(screen.queryByText("Entry 1")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Show more" }));
+		expect(screen.getByText("Entry 1")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Show more" })).not.toBeInTheDocument();
+	});
+
+	it("stages Escape: clears the search first, then navigates back", async () => {
+		const user = userEvent.setup();
+		const goBack = vi.fn();
+		const entries: ChangelogEntry[] = [
+			{ date: "2026-02-26", type: "feature", slug: "a", title: "Alpha thing shipped" },
+		];
+		mockedApi.request.getChangelogs.mockResolvedValue(entries);
+		renderChangelog({ goBack, canGoBack: true });
+
+		await screen.findByText("Alpha thing shipped");
+		const input = screen.getByPlaceholderText("Search changelog…");
+		await user.type(input, "alpha");
+
+		await user.keyboard("{Escape}");
+		expect(input).toHaveValue("");
+		expect(goBack).not.toHaveBeenCalled();
+
+		await user.keyboard("{Escape}");
+		expect(goBack).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/mainview/i18n/translations/en/updates.ts
+++ b/src/mainview/i18n/translations/en/updates.ts
@@ -85,12 +85,15 @@ const updates = {
 	"changelog.refactor": "refactor",
 	"changelog.docs": "docs",
 	"changelog.chore": "chore",
-	"changelog.filterLabel": "Filter:",
 	"changelog.clearFilter": "clear",
 	"changelog.subtitle": "Everything we've shipped, newest first.",
 	"changelog.entries_one": "{count} entry",
 	"changelog.entries_other": "{count} entries",
-	"changelog.expandHint": "Click to read the full note",
+	"changelog.searchPlaceholder": "Search changelog…",
+	"changelog.clearSearch": "Clear search",
+	"changelog.noResults": "Nothing matches your search or filters.",
+	"changelog.resetFilters": "Reset filters",
+	"changelog.showMore": "Show more",
 } as const;
 
 export default updates;

--- a/src/mainview/i18n/translations/es/updates.ts
+++ b/src/mainview/i18n/translations/es/updates.ts
@@ -85,12 +85,15 @@ const updates = {
 	"changelog.refactor": "refactor",
 	"changelog.docs": "docs",
 	"changelog.chore": "chore",
-	"changelog.filterLabel": "Filtrar:",
 	"changelog.clearFilter": "limpiar",
 	"changelog.subtitle": "Todo lo que hemos lanzado, lo más reciente primero.",
 	"changelog.entries_one": "{count} entrada",
 	"changelog.entries_other": "{count} entradas",
-	"changelog.expandHint": "Haz clic para leer la nota completa",
+	"changelog.searchPlaceholder": "Buscar en el changelog…",
+	"changelog.clearSearch": "Borrar búsqueda",
+	"changelog.noResults": "Nada coincide con tu búsqueda o filtros.",
+	"changelog.resetFilters": "Restablecer filtros",
+	"changelog.showMore": "Mostrar más",
 };
 
 export default updates;

--- a/src/mainview/i18n/translations/ru/updates.ts
+++ b/src/mainview/i18n/translations/ru/updates.ts
@@ -89,14 +89,17 @@ const updates = {
 	"changelog.refactor": "рефакторинг",
 	"changelog.docs": "документация",
 	"changelog.chore": "служебное",
-	"changelog.filterLabel": "Фильтр:",
 	"changelog.clearFilter": "сбросить",
 	"changelog.subtitle": "Всё, что мы выпустили, — свежее сверху.",
 	"changelog.entries_one": "{count} запись",
 	"changelog.entries_few": "{count} записи",
 	"changelog.entries_many": "{count} записей",
 	"changelog.entries_other": "{count} записей",
-	"changelog.expandHint": "Нажмите, чтобы прочитать полностью",
+	"changelog.searchPlaceholder": "Поиск по изменениям…",
+	"changelog.clearSearch": "Очистить поиск",
+	"changelog.noResults": "Ничего не найдено по запросу или фильтрам.",
+	"changelog.resetFilters": "Сбросить фильтры",
+	"changelog.showMore": "Показать ещё",
 };
 
 export default updates;


### PR DESCRIPTION
Hey, Claude here — the AI assistant working on this branch.

## Summary

Redesigns the Changelog screen, replacing the uniform card grid (where a feature and a chore carried identical visual weight) with a release-notes timeline:

- **Timeline layout** — a sticky date rail (day, weekday, entry count) on the left, a vertical spine with accent dots, content on the right.
- **Two entry tiers** — `feature` entries render as prominent cards with a Nerd Font rocket chip, an accent side bar, and the authored `Short:` line as a bold headline; `fix`/`refactor`/`docs`/`chore` collapse into compact divided rows with per-type colored glyphs.
- **Full-text search** — matches title, body, short title, slug, and community credit; Escape clears the search first and only then navigates back.
- **Multi-select type filters with counts** (e.g. `feature 393`, `fix 485`), plus a clear control and a shown-entries counter in the sticky toolbar.
- **Incremental rendering** — day groups load in batches of 15 via IntersectionObserver (with a "Show more" fallback button), so ~1000 entries never hit the DOM at once.
- **Polished states** — skeleton loading, an empty state, and a no-results state with a reset button.

New i18n keys added for en/ru/es; dead keys (`changelog.filterLabel`, `changelog.expandHint`) removed. Component tests extended from 4 to 10 (search, multi-select filters, no-results reset, incremental loading, staged Escape). Verified in a browser in both dark and light themes with no console errors.