### PR TITLE
Show the what's-new changelog in the update-ready toast

### DIFF
--- a/change-logs/2026/07/22/fix-update-toast-changelog.md
+++ b/change-logs/2026/07/22/fix-update-toast-changelog.md
@@ -1,0 +1,3 @@
+Short: Update toast now lists what's new
+
+The auto-shown "update ready" toast now includes the same "what's new" feature list as the header dropdown; previously it showed only the version and restart button, so the changelog preview was easy to miss.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -11,7 +11,7 @@ import { toast } from "../toast";
 import TmuxSessionManager from "./TmuxSessionManager";
 import InlineRename from "./InlineRename";
 import GitPullButton from "./GitPullButton";
-import UpdateReadyPopover from "./UpdateReadyPopover";
+import UpdateReadyPopover, { UpdateWhatsNew } from "./UpdateReadyPopover";
 import PreventSleepToggle from "./PreventSleepToggle";
 import RateLimitIndicator from "./RateLimitIndicator";
 import BottomSheet from "./BottomSheet";
@@ -819,6 +819,15 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 						<div className="text-fg-3 text-xs mt-1">
 							{t("update.sessionsNote")}
 						</div>
+						<UpdateWhatsNew
+							version={updateVersion}
+							changelog={updateChangelog}
+							className="mt-2.5"
+							onSeeAllChanges={() => {
+								dismissToast();
+								navigate({ screen: "changelog" });
+							}}
+						/>
 						<div className="flex items-center gap-2 mt-2.5">
 							<button
 								onClick={() => { dismissToast(); handleRestart(); }}

--- a/src/mainview/components/UpdateReadyPopover.tsx
+++ b/src/mainview/components/UpdateReadyPopover.tsx
@@ -5,6 +5,52 @@ import { UpdateReadyIcon } from "./HeaderIcons";
 /** Static placeholder countdown shown in the simulator (no real timer runs). */
 const PREVIEW_COUNTDOWN_SECONDS = 205;
 
+interface UpdateWhatsNewProps {
+	version: string;
+	changelog?: UpdateChangelog | null;
+	onSeeAllChanges: () => void;
+	/** Extra classes for the root (e.g. top margin when embedded in the toast). */
+	className?: string;
+}
+
+/**
+ * The "what's new" section — version-scoped feature list + a "+N more · M fixes"
+ * rollup + a link to the full Changelog screen. Shared by the header dropdown
+ * popover and the auto-shown update toast so both surface the same preview.
+ * Renders nothing when the incoming update carries no feature titles.
+ */
+export function UpdateWhatsNew({ version, changelog, onSeeAllChanges, className }: UpdateWhatsNewProps) {
+	const t = useT();
+	if (!changelog || changelog.features.length === 0) return null;
+	const moreFeat = Math.max(0, changelog.featureCount - changelog.features.length);
+	const parts: string[] = [];
+	if (moreFeat > 0) parts.push(t.plural("update.moreFeatures", moreFeat));
+	if (changelog.fixCount > 0) parts.push(t.plural("update.fixCount", changelog.fixCount));
+	return (
+		<div className={`border-t border-edge pt-2.5 space-y-1.5${className ? ` ${className}` : ""}`}>
+			<div className="text-fg-3 text-[0.625rem] font-semibold uppercase tracking-wider">
+				{t("update.whatsNewVersion", { version })}
+			</div>
+			<div className="space-y-1">
+				{changelog.features.map((feature, i) => (
+					<div key={i} className="flex items-start gap-1.5 min-w-0">
+						<span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0" />
+						<span className="text-fg text-xs leading-snug truncate">{feature}</span>
+					</div>
+				))}
+			</div>
+			{parts.length > 0 && <div className="text-fg-muted text-[0.6875rem]">{parts.join(" · ")}</div>}
+			<button
+				type="button"
+				onClick={onSeeAllChanges}
+				className="text-accent text-xs font-medium hover:underline cursor-pointer"
+			>
+				{t("update.seeAllChanges")} →
+			</button>
+		</div>
+	);
+}
+
 interface UpdateReadyPopoverProps {
 	version: string;
 	changelog?: UpdateChangelog | null;
@@ -39,35 +85,7 @@ export default function UpdateReadyPopover({
 					<div className="text-fg-3 text-xs mt-0.5">{t("update.sessionsNote")}</div>
 				</div>
 			</div>
-			{changelog && changelog.features.length > 0 && (
-				<div className="border-t border-edge pt-2.5 space-y-1.5">
-					<div className="text-fg-3 text-[0.625rem] font-semibold uppercase tracking-wider">
-						{t("update.whatsNewVersion", { version })}
-					</div>
-					<div className="space-y-1">
-						{changelog.features.map((feature, i) => (
-							<div key={i} className="flex items-start gap-1.5 min-w-0">
-								<span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0" />
-								<span className="text-fg text-xs leading-snug truncate">{feature}</span>
-							</div>
-						))}
-					</div>
-					{(() => {
-						const moreFeat = Math.max(0, changelog.featureCount - changelog.features.length);
-						const parts: string[] = [];
-						if (moreFeat > 0) parts.push(t.plural("update.moreFeatures", moreFeat));
-						if (changelog.fixCount > 0) parts.push(t.plural("update.fixCount", changelog.fixCount));
-						return parts.length > 0 ? <div className="text-fg-muted text-[0.6875rem]">{parts.join(" · ")}</div> : null;
-					})()}
-					<button
-						type="button"
-						onClick={onSeeAllChanges}
-						className="text-accent text-xs font-medium hover:underline cursor-pointer"
-					>
-						{t("update.seeAllChanges")} →
-					</button>
-				</div>
-			)}
+			<UpdateWhatsNew version={version} changelog={changelog} onSeeAllChanges={onSeeAllChanges} />
 			{preview ? (
 				// Preview mimics the auto-shown toast layout (restart-with-countdown +
 				// Postpone) so the simulator looks like the real update prompt. The

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -390,12 +390,33 @@ describe("GlobalHeader — project switcher dropdown", () => {
 			updateChangelog: changelog,
 		});
 
+		// The auto-shown toast renders the same list; dismiss it so the queries
+		// below target the dropdown only.
+		await user.click(screen.getByText("Postpone"));
 		await user.click(screen.getByRole("button", { name: /Version 1\.38\.0 is ready/i }));
 
 		expect(screen.getByText("What's new in v1.38.0")).toBeInTheDocument();
 		expect(screen.getByText("Terminal scrollback search")).toBeInTheDocument();
 		expect(screen.getByText("PR review threads in diff")).toBeInTheDocument();
 		// 5 total features, 2 shown → "+3 more features · 4 fixes"
+		expect(screen.getByText("+3 more features · 4 fixes")).toBeInTheDocument();
+	});
+
+	it("renders the what's-new changelog section in the auto-shown update toast", () => {
+		const changelog: UpdateChangelog = {
+			features: ["Terminal scrollback search", "PR review threads in diff"],
+			featureCount: 5,
+			fixCount: 4,
+		};
+		renderHeader({ screen: "dashboard" }, [project1, project2], vi.fn(), [], {
+			updateVersion: "1.38.0",
+			updateChangelog: changelog,
+		});
+
+		// Toast auto-shows on update-ready (no dropdown click); it must surface the
+		// same preview as the dropdown — regression: the toast previously omitted it.
+		expect(screen.getByText("What's new in v1.38.0")).toBeInTheDocument();
+		expect(screen.getByText("Terminal scrollback search")).toBeInTheDocument();
 		expect(screen.getByText("+3 more features · 4 fixes")).toBeInTheDocument();
 	});
 
@@ -407,6 +428,8 @@ describe("GlobalHeader — project switcher dropdown", () => {
 			updateChangelog: { features: ["A feature"], featureCount: 1, fixCount: 0 },
 		});
 
+		// Dismiss the auto-shown toast first so "See all changes" is unambiguous.
+		await user.click(screen.getByText("Postpone"));
 		await user.click(screen.getByRole("button", { name: /Version 1\.38\.0 is ready/i }));
 		await user.click(screen.getByText(/See all changes/));
 		expect(navigate).toHaveBeenCalledWith({ screen: "changelog" });


### PR DESCRIPTION
Hi — Claude here (the AI assistant on this branch) 👋

Follow-up to #1054. That PR fixed the *data* (update.json now carries a populated changelog, and the release page shows the full grouped notes — both confirmed live on v1.39.0). But the auto-shown **"update ready" toast** still rendered only the version + Restart button — the "what's new" feature list lived only in the header dropdown popover, so anyone glancing at the toast (or dismissing it) never saw the changelog.

## What

- Extracted the shared `UpdateWhatsNew` section out of `UpdateReadyPopover` (version-scoped feature list + "+N more · M fixes" rollup + "See all changes" link).
- Rendered it in the auto-shown toast too, so the toast and the dropdown surface the same preview. Renders nothing when the update carries no features (e.g. cross-channel), so there is no empty gap.
- Added a `GlobalHeader` test asserting the toast lists the changelog; scoped the two dropdown tests so the now-shared list doesn't collide.

Verified: `bun run lint` clean; mainview / bun / cli vitest configs all green individually (the combined `bun run test` runner is flaky under concurrency on this machine — CI runs them separately).
