### PR TITLE
Remove per-task artifact history cap

### DIFF
--- a/change-logs/2026/07/22/fix-unlimited-artifact-history.md
+++ b/change-logs/2026/07/22/fix-unlimited-artifact-history.md
@@ -1,0 +1,3 @@
+Short: Unlimited artifact history
+
+Removed the per-task cap on retained HTML artifacts, so `dev3 show-artifact` keeps the full history instead of deleting the oldest entry after 20. Per-artifact size and image safeguards remain unchanged.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
-import { getAllowedTransitions, type Project, type Task, type CliRequest, type TaskNote } from "../../shared/types";
+import { getAllowedTransitions, type Project, type Task, type CliRequest, type TaskNote, type SharedArtifact } from "../../shared/types";
 
 // ---- Mocks ----
 
@@ -60,11 +60,6 @@ vi.mock("../shared-artifacts", () => ({
 			bytes: 1,
 		})),
 	})),
-	pruneSharedArtifacts: vi.fn((existing: unknown[] | undefined, incoming: unknown[]) => ({
-		kept: [...(existing ?? []), ...incoming],
-		dropped: [],
-	})),
-	deleteSharedArtifactFiles: vi.fn(),
 }));
 
 vi.mock("../pty-server", () => ({
@@ -1110,6 +1105,41 @@ describe("ui.show-image", () => {
 });
 
 describe("ui.show-artifact", () => {
+	it("retains artifact history beyond the previous per-task cap", async () => {
+		const project = makeProject();
+		const existing: SharedArtifact[] = Array.from({ length: 20 }, (_, index) => ({
+			id: `artifact-${index}`,
+			kind: "html",
+			title: `Artifact ${index}`,
+			name: `artifact-${index}.html`,
+			storedPath: `/wt/shared-artifacts/artifact-${index}/report.html`,
+			originalPath: `/tmp/artifact-${index}.html`,
+			bytes: 10,
+			createdAt: index,
+			assets: [],
+		}));
+		const task = makeTask({ sharedArtifacts: existing });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		let persisted: Task | undefined;
+		vi.mocked(data.updateTaskWith).mockImplementation(async (_project, _taskId, mutator) => {
+			const { updates, result } = await (mutator as (t: Task) => { updates: Partial<Task>; result: unknown })(task);
+			persisted = { ...task, ...updates };
+			return { task: persisted, result } as never;
+		});
+
+		await handleRequest(makeRequest("ui.show-artifact", {
+			taskId: task.id,
+			projectId: project.id,
+			htmlPath: "/tmp/report.html",
+		}));
+
+		expect(persisted?.sharedArtifacts?.map((artifact) => artifact.id)).toEqual([
+			...existing.map((artifact) => artifact.id),
+			"artifact-1",
+		]);
+	});
+
 	it("stores HTML plus images and pushes taskUpdated + cliShowArtifact", async () => {
 		const project = makeProject();
 		const task = makeTask({ seq: 14 });

--- a/src/bun/__tests__/shared-artifacts.test.ts
+++ b/src/bun/__tests__/shared-artifacts.test.ts
@@ -15,11 +15,9 @@ const SRC_DIR = mkdtempSync(join(tmpdir(), "dev3-artifact-src-"));
 
 import {
 	SharedArtifactError,
-	deleteSharedArtifactFiles,
 	injectArtifactThemeContract,
 	loadSharedArtifactContent,
 	loadSharedArtifactDownload,
-	pruneSharedArtifacts,
 	saveSharedArtifact,
 } from "../shared-artifacts";
 
@@ -149,20 +147,6 @@ describe("saveSharedArtifact", () => {
 		writeFileSync(html, '<!doctype html><img src="../outside.png">');
 		writeFileSync(image, "PNGDATA");
 		expect(() => saveSharedArtifact("/my/project", html, [image])).toThrow(/inside the HTML directory/);
-	});
-});
-
-describe("pruneSharedArtifacts / deleteSharedArtifactFiles", () => {
-	it("keeps newest records and removes an artifact directory recursively", () => {
-		const { kept, dropped } = pruneSharedArtifacts([artifact("a"), artifact("b")], [artifact("c")], 2);
-		expect(kept.map((item) => item.id)).toEqual(["b", "c"]);
-		expect(dropped.map((item) => item.id)).toEqual(["a"]);
-
-		const dir = dirname(dropped[0].storedPath);
-		mkdirSync(dir, { recursive: true });
-		writeFileSync(dropped[0].storedPath, "x");
-		deleteSharedArtifactFiles(dropped);
-		expect(existsSync(dir)).toBe(false);
 	});
 });
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -2,10 +2,10 @@ import { existsSync, readdirSync, unlinkSync, mkdirSync, writeFileSync } from "n
 import type { CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
 import { isValidNotificationDurationMs, NOTIFICATION_MAX_DURATION_MS, NOTIFICATION_MIN_DURATION_MS } from "../shared/duration";
 import { socketMetaPathFor, type SocketMeta } from "../shared/socket-meta";
-import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, MAX_SHARED_ARTIFACTS_PER_TASK, MAX_SHARED_IMAGES_PER_TASK, buildTaskDialogSubject, getTaskTitle, normalizePriority, titleFromDescription } from "../shared/types";
+import { ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, MAX_SHARED_IMAGES_PER_TASK, buildTaskDialogSubject, getTaskTitle, normalizePriority, titleFromDescription } from "../shared/types";
 import { CODEX_STATUS_HOOK_EVENTS, getCodexHookTargetStatus, type CodexStatusHookEvent } from "../shared/agent-hooks";
 import { SharedImageError, deleteSharedImageFiles, pruneSharedImages, saveSharedImage } from "./shared-images";
-import { SharedArtifactError, deleteSharedArtifactFiles, pruneSharedArtifacts, saveSharedArtifact } from "./shared-artifacts";
+import { SharedArtifactError, saveSharedArtifact } from "./shared-artifacts";
 import { addAutomation, deleteAutomation, loadAutomations, updateAutomation } from "./automations-data";
 import { createCompletionRequest } from "./completion-requests";
 import * as data from "./data";
@@ -1114,11 +1114,9 @@ const handlers: Record<string, Handler> = {
 			throw new Error(`Failed to store artifact: ${error instanceof Error ? error.message : String(error)}`);
 		}
 
-		const { task: updated, result: dropped } = await data.updateTaskWith<SharedArtifact[]>(project, task.id, (current) => {
-			const pruned = pruneSharedArtifacts(current.sharedArtifacts, [incoming], MAX_SHARED_ARTIFACTS_PER_TASK);
-			return { updates: { sharedArtifacts: pruned.kept }, result: pruned.dropped };
+		const { task: updated } = await data.updateTaskWith<void>(project, task.id, (current) => {
+			return { updates: { sharedArtifacts: [...(current.sharedArtifacts ?? []), incoming] }, result: undefined };
 		});
-		if (dropped.length > 0) deleteSharedArtifactFiles(dropped);
 		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 
 		const payload = {

--- a/src/bun/shared-artifacts.ts
+++ b/src/bun/shared-artifacts.ts
@@ -17,11 +17,9 @@ import {
 	SHARED_IMAGE_EXTS,
 } from "../shared/types";
 import { DEV3_HOME } from "./paths";
-import { createLogger } from "./logger";
 import { createStoreZip } from "./zip-store";
 import { projectSlug } from "./git";
 
-const log = createLogger("shared-artifacts");
 const IMAGE_EXTS = new Set(SHARED_IMAGE_EXTS);
 const MAX_TOTAL_ASSET_BYTES = 100 * 1024 * 1024;
 const MIME_BY_EXT: Record<string, string> = {
@@ -98,7 +96,6 @@ export function saveSharedArtifact(
 	if (imagePaths.length > MAX_SHARED_ARTIFACT_IMAGES) {
 		throw new SharedArtifactError(`Too many artifact images (max ${MAX_SHARED_ARTIFACT_IMAGES})`);
 	}
-
 	const seenNames = new Set<string>();
 	let totalAssetBytes = 0;
 	const validatedAssets = imagePaths.map((path) => {
@@ -157,26 +154,6 @@ export function saveSharedArtifact(
 		rmSync(dir, { recursive: true, force: true });
 		if (error instanceof SharedArtifactError) throw error;
 		throw new SharedArtifactError(error instanceof Error ? error.message : String(error));
-	}
-}
-
-export function pruneSharedArtifacts(
-	existing: SharedArtifact[] | undefined,
-	incoming: SharedArtifact[],
-	cap: number,
-): { kept: SharedArtifact[]; dropped: SharedArtifact[] } {
-	const all = [...(existing ?? []), ...incoming];
-	if (all.length <= cap) return { kept: all, dropped: [] };
-	return { kept: all.slice(all.length - cap), dropped: all.slice(0, all.length - cap) };
-}
-
-export function deleteSharedArtifactFiles(artifacts: SharedArtifact[]): void {
-	for (const artifact of artifacts) {
-		try {
-			rmSync(dirname(artifact.storedPath), { recursive: true, force: true });
-		} catch (error) {
-			log.debug("Failed to delete pruned artifact", { path: artifact.storedPath, error: String(error) });
-		}
 	}
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1522,9 +1522,6 @@ export const MAX_SHARED_IMAGE_BYTES = 25 * 1024 * 1024;
 /** Max images accepted in a single `dev3 show-image` invocation. */
 export const MAX_SHARED_IMAGES_PER_CALL = 20;
 
-/** Per-task cap on retained HTML artifacts; oldest directories are pruned. */
-export const MAX_SHARED_ARTIFACTS_PER_TASK = 20;
-
 /** Maximum accepted HTML source size for `dev3 show-artifact` (bytes). */
 export const MAX_SHARED_ARTIFACT_HTML_BYTES = 5 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

- Remove the per-task cap of 20 retained HTML artifacts.
- Append new artifacts without deleting older artifact directories.
- Keep HTML-size, image-count, per-image-size, and combined asset-size safeguards.
- Add regression coverage and a changelog entry.

## Tests

- TypeScript: no errors in src/ ✅
- Focused artifact backend tests: 176/176 ✅
- Mainview suite: 2834/2834 ✅
- The aggregate parallel test command still has unrelated git-diff test failures; those tests pass individually.