### PR TITLE
Improve artifact charts and PDF printing

### DIFF
--- a/change-logs/2026/07/22/feature-artifact-chart-printing.md
+++ b/change-logs/2026/07/22/feature-artifact-chart-printing.md
@@ -1,0 +1,3 @@
+Short: Better artifact charts and PDFs
+
+The artifact starter now demonstrates accessible SVG pie and radar charts alongside its area chart. Printing preserves the selected light or dark theme, keeps chart colors visible, removes interactive controls, and compacts the report into a clean PDF layout.

--- a/decisions/153-artifact-svg-print-contract.md
+++ b/decisions/153-artifact-svg-print-contract.md
@@ -1,0 +1,21 @@
+# 153 — Artifact SVG and print contract
+
+## Context
+
+The artifact starter demonstrated only an area chart and a CSS-background donut. Browser printing dropped the selected dark theme and the donut itself, producing a pale, awkwardly split PDF even when the on-screen report was dark.
+
+## Investigation
+
+Print engines may omit CSS backgrounds unless the document requests exact color adjustment, and CSS conic gradients are especially fragile in that mode. Inline SVG stays self-contained under the artifact CSP, remains crisp at PDF scale, and exposes chart structure to assistive technology through titles and descriptions.
+
+## Decision
+
+The v1 starter uses inline SVG for its area, pie, and radar charts, with every series colored by the existing `--dev3-*` semantic tokens. Its print stylesheet uses exact color adjustment, preserves the active light/dark token set, hides interactive controls, compacts the chart grid, and protects cards, table headers, and rows from accidental page breaks.
+
+## Risks
+
+Dark-theme printing intentionally consumes more ink because the exported PDF must match the user's selected theme. Browser print engines can still paginate differently at unusual paper sizes, so the layout uses flexible grids and break hints rather than assuming one fixed page format.
+
+## Alternatives considered
+
+Rejected an external charting library because artifacts must work offline without network dependencies. Rejected canvas and CSS-gradient charts because they print less reliably, and rejected a forced white print theme because it contradicts the explicit theme choice.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -8,6 +8,17 @@ cp -R "$DEV3_ARTIFACT_TEMPLATE_DIR" ./dev3-artifact-report
 
 Start from `index.html`. Replace the sample cockpit title, data, chart labels, form fields, and table rows with content for the current task. Keep the useful interaction patterns and remove sections that do not help the report.
 
+The starter demonstrates three dependency-free SVG patterns: an area chart, a pie chart, and a radar/spider chart. Reuse `renderChart`, `renderPie`, and `renderRadar`, replace their sample datasets, and keep each chart's visible legend plus its `<title>`/`<desc>` accessibility summary. Use semantic `--dev3-*` tokens for every series; do not load a charting CDN.
+
+## Print and PDF
+
+Choose Auto, Light, or Dark in the report, then print normally with Cmd/Ctrl+P. The print stylesheet preserves that selected theme and chart colors, removes interactive controls, compacts the grid, repeats table headers, and avoids splitting cards or rows where possible.
+
+- Keep `print-color-adjust: exact` on `html, body`; never force a light palette inside `@media print`.
+- Prefer inline SVG for important chart marks. Canvas and CSS-background-only charts can disappear or become blurry in PDF output.
+- Add `print-hidden` to controls that do not belong in a static report, and `print-only` to concise context that should appear only in the PDF.
+- Check print preview in both Light and Dark after changing the report layout.
+
 Preserve these contracts:
 
 - Keep `data-dev3-artifact-template="v1"` on `<html>`.
@@ -16,6 +27,7 @@ Preserve these contracts:
 - Keep the Auto → Light → Dark theme control. Auto follows the dev3 host theme and falls back to `prefers-color-scheme` outside dev3.
 - Use only the bundled `--dev3-*` semantic tokens for color. Define both dark and light values.
 - Keep the page responsive and keyboard-accessible.
+- Keep the print stylesheet responsive to the selected theme and suitable for PDF export.
 - Keep HTML, CSS, SVG, and JavaScript self-contained. Do not load CDNs, remote fonts, analytics, or network data.
 - Keep raster images beside or below `index.html` and reference them with relative paths.
 

--- a/src/assets/artifact-template/index.html
+++ b/src/assets/artifact-template/index.html
@@ -5,22 +5,390 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Agent Operations Cockpit</title>
   <style>
-    *{box-sizing:border-box}body{margin:0;padding:24px;background:rgb(var(--dev3-surface-base));color:rgb(var(--dev3-text-primary));font:14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.app{max-width:1180px;margin:auto}.topbar,.brand,.actions,.segmented,.inline,.table-tools{display:flex;align-items:center}.topbar{justify-content:space-between;gap:20px;margin-bottom:20px}.brand{gap:13px}.brand img{width:48px;height:48px;border-radius:14px;box-shadow:0 10px 28px rgb(var(--dev3-accent)/.22)}h1{font-size:22px;line-height:1.15;margin:0;letter-spacing:-.03em}.eyebrow,.muted{color:rgb(var(--dev3-text-secondary))}.eyebrow{font-size:11px;text-transform:uppercase;letter-spacing:.1em;margin-bottom:3px}.actions{gap:8px}.status{display:inline-flex;align-items:center;gap:7px;padding:7px 10px;border:1px solid rgb(var(--dev3-success)/.25);border-radius:999px;background:rgb(var(--dev3-success)/.08);color:rgb(var(--dev3-success));font-size:12px}.dot{width:7px;height:7px;border-radius:50%;background:rgb(var(--dev3-success));box-shadow:0 0 0 4px rgb(var(--dev3-success)/.12)}button,input,select{font:inherit}button{border:1px solid rgb(var(--dev3-border));border-radius:10px;padding:8px 12px;background:rgb(var(--dev3-surface-elevated));color:rgb(var(--dev3-text-primary));cursor:pointer;transition:.16s ease}button:hover{border-color:rgb(var(--dev3-accent)/.65);transform:translateY(-1px)}button.primary{border-color:rgb(var(--dev3-accent));background:rgb(var(--dev3-accent));color:rgb(var(--dev3-on-accent));font-weight:650}button.ghost{background:transparent}button.active{border-color:rgb(var(--dev3-accent)/.55);background:rgb(var(--dev3-accent)/.14);color:rgb(var(--dev3-accent))}.grid{display:grid;gap:14px}.kpis{grid-template-columns:repeat(4,minmax(0,1fr));margin-bottom:14px}.card{border:1px solid rgb(var(--dev3-border));border-radius:16px;background:rgb(var(--dev3-surface-raised));box-shadow:0 14px 34px rgb(var(--dev3-shadow)/.08)}.kpi{padding:16px}.kpi-top{display:flex;justify-content:space-between;gap:10px;color:rgb(var(--dev3-text-secondary));font-size:11px;text-transform:uppercase;letter-spacing:.06em}.kpi-value{font-size:29px;font-weight:760;letter-spacing:-.04em;margin:8px 0 3px}.trend{font-size:12px;color:rgb(var(--dev3-success))}.trend.warn{color:rgb(var(--dev3-warning))}.workspace{grid-template-columns:minmax(0,1.65fr) minmax(280px,.75fr);margin-bottom:14px}.section{padding:18px}.section-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:16px}.section-title{font-weight:700;font-size:15px}.section-copy{color:rgb(var(--dev3-text-secondary));font-size:12px;margin-top:2px}.segmented{gap:3px;padding:3px;border:1px solid rgb(var(--dev3-border));border-radius:11px;background:rgb(var(--dev3-surface-base))}.segmented button{border:0;padding:6px 9px;background:transparent}.segmented button.active{background:rgb(var(--dev3-accent));color:rgb(var(--dev3-on-accent))}.chart{height:245px;position:relative}.chart svg{width:100%;height:100%;overflow:visible}.grid-line{stroke:rgb(var(--dev3-border));stroke-width:1}.area{fill:rgb(var(--dev3-accent)/.12)}.line{fill:none;stroke:rgb(var(--dev3-accent));stroke-width:3;stroke-linecap:round;stroke-linejoin:round}.point{fill:rgb(var(--dev3-surface-raised));stroke:rgb(var(--dev3-accent));stroke-width:3;cursor:pointer}.axis-label{fill:rgb(var(--dev3-text-muted));font-size:10px}.chart-tip{position:absolute;display:none;padding:6px 8px;border:1px solid rgb(var(--dev3-border));border-radius:8px;background:rgb(var(--dev3-surface-elevated));font-size:11px;pointer-events:none;box-shadow:0 8px 24px rgb(var(--dev3-shadow)/.18)}.side-stack{display:grid;gap:14px}.donut-row{display:flex;align-items:center;gap:22px}.donut{width:130px;aspect-ratio:1;border-radius:50%;display:grid;place-items:center;background:conic-gradient(rgb(var(--dev3-accent)) 0 var(--success),rgb(var(--dev3-warning)) var(--success) var(--review),rgb(var(--dev3-danger)) var(--review) 100%)}.donut:after{content:"";width:76%;height:76%;border-radius:50%;background:rgb(var(--dev3-surface-raised))}.legend{display:grid;gap:9px;flex:1}.legend-row{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px}.legend-key{display:flex;align-items:center;gap:7px}.swatch{width:8px;height:8px;border-radius:3px}.controls{display:grid;grid-template-columns:1fr 1fr;gap:12px}.field{display:grid;gap:6px}.field.full{grid-column:1/-1}.field label{font-size:11px;color:rgb(var(--dev3-text-secondary));text-transform:uppercase;letter-spacing:.05em}.field input,.field select{width:100%;border:1px solid rgb(var(--dev3-border));border-radius:10px;padding:9px 10px;background:rgb(var(--dev3-surface-base));color:rgb(var(--dev3-text-primary));outline:none}.field input:focus,.field select:focus{border-color:rgb(var(--dev3-accent));box-shadow:0 0 0 3px rgb(var(--dev3-accent)/.12)}input[type=range]{padding:0;box-shadow:none}.range-label{display:flex;justify-content:space-between;color:rgb(var(--dev3-text-secondary));font-size:11px}.check{display:flex;align-items:center;gap:8px;color:rgb(var(--dev3-text-secondary));font-size:12px}.check input{width:auto}.form-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:2px}.table-card{overflow:hidden}.table-head{padding:16px 18px 12px}.table-tools{gap:8px}.table-tools input,.table-tools select{border:1px solid rgb(var(--dev3-border));border-radius:9px;padding:7px 9px;background:rgb(var(--dev3-surface-base));color:rgb(var(--dev3-text-primary));outline:none}.table-tools input{width:190px}table{width:100%;border-collapse:collapse}th,td{text-align:left;padding:11px 18px;border-top:1px solid rgb(var(--dev3-border));font-size:12px}th{color:rgb(var(--dev3-text-muted));font-weight:600;text-transform:uppercase;letter-spacing:.05em;cursor:pointer}tbody tr:hover{background:rgb(var(--dev3-accent)/.04)}.pill{display:inline-flex;padding:4px 8px;border-radius:999px;font-size:11px;font-weight:650}.pill.success{color:rgb(var(--dev3-success));background:rgb(var(--dev3-success)/.1)}.pill.warning{color:rgb(var(--dev3-warning));background:rgb(var(--dev3-warning)/.1)}.pill.accent{color:rgb(var(--dev3-accent));background:rgb(var(--dev3-accent)/.1)}.bar-cell{display:flex;align-items:center;gap:9px}.mini-track{width:76px;height:6px;border-radius:99px;background:rgb(var(--dev3-border));overflow:hidden}.mini-fill{height:100%;border-radius:99px;background:rgb(var(--dev3-accent))}.toast{position:fixed;right:22px;bottom:22px;transform:translateY(20px);opacity:0;pointer-events:none;padding:11px 14px;border:1px solid rgb(var(--dev3-success)/.3);border-radius:11px;background:rgb(var(--dev3-surface-elevated));color:rgb(var(--dev3-text-primary));box-shadow:0 12px 40px rgb(var(--dev3-shadow)/.24);transition:.2s}.toast.show{opacity:1;transform:none}.empty{padding:26px;text-align:center;color:rgb(var(--dev3-text-muted))}@media(max-width:900px){.kpis{grid-template-columns:repeat(2,1fr)}.workspace{grid-template-columns:1fr}.topbar{align-items:flex-start;flex-direction:column}}@media(max-width:560px){body{padding:14px}.kpis{grid-template-columns:1fr}.controls{grid-template-columns:1fr}.field.full{grid-column:auto}.table-tools{align-items:stretch;flex-direction:column}.table-tools input{width:100%}th:nth-child(3),td:nth-child(3),th:nth-child(5),td:nth-child(5){display:none}}
+    * { box-sizing: border-box; }
+    html, body {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+    body {
+      margin: 0;
+      padding: 24px;
+      background: rgb(var(--dev3-surface-base));
+      color: rgb(var(--dev3-text-primary));
+      font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .app { max-width: 1180px; margin: auto; }
+    .topbar, .brand, .actions, .segmented, .inline, .table-tools { display: flex; align-items: center; }
+    .topbar { justify-content: space-between; gap: 20px; margin-bottom: 20px; }
+    .brand { gap: 13px; }
+    .brand img {
+      width: 48px;
+      height: 48px;
+      border-radius: 14px;
+      box-shadow: 0 10px 28px rgb(var(--dev3-accent) / .22);
+    }
+    h1 { margin: 0; font-size: 22px; line-height: 1.15; letter-spacing: -.03em; }
+    .eyebrow, .muted { color: rgb(var(--dev3-text-secondary)); }
+    .eyebrow { margin-bottom: 3px; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
+    .actions { gap: 8px; }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 7px 10px;
+      border: 1px solid rgb(var(--dev3-success) / .25);
+      border-radius: 999px;
+      background: rgb(var(--dev3-success) / .08);
+      color: rgb(var(--dev3-success));
+      font-size: 12px;
+    }
+    .dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: rgb(var(--dev3-success));
+      box-shadow: 0 0 0 4px rgb(var(--dev3-success) / .12);
+    }
+    button, input, select { font: inherit; }
+    button {
+      padding: 8px 12px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 10px;
+      background: rgb(var(--dev3-surface-elevated));
+      color: rgb(var(--dev3-text-primary));
+      cursor: pointer;
+      transition: .16s ease;
+    }
+    button:hover { border-color: rgb(var(--dev3-accent) / .65); transform: translateY(-1px); }
+    button:focus-visible, input:focus-visible, select:focus-visible, th:focus-visible, .point:focus-visible {
+      outline: 2px solid rgb(var(--dev3-accent));
+      outline-offset: 2px;
+    }
+    button.primary {
+      border-color: rgb(var(--dev3-accent));
+      background: rgb(var(--dev3-accent));
+      color: rgb(var(--dev3-on-accent));
+      font-weight: 650;
+    }
+    button.ghost { background: transparent; }
+    button.active {
+      border-color: rgb(var(--dev3-accent) / .55);
+      background: rgb(var(--dev3-accent) / .14);
+      color: rgb(var(--dev3-accent));
+    }
+    .grid { display: grid; gap: 14px; }
+    .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); margin-bottom: 14px; }
+    .card {
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 16px;
+      background: rgb(var(--dev3-surface-raised));
+      box-shadow: 0 14px 34px rgb(var(--dev3-shadow) / .08);
+    }
+    .kpi { padding: 16px; }
+    .kpi-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      color: rgb(var(--dev3-text-secondary));
+      font-size: 11px;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .kpi-value { margin: 8px 0 3px; font-size: 29px; font-weight: 760; letter-spacing: -.04em; }
+    .trend { color: rgb(var(--dev3-success)); font-size: 12px; }
+    .trend.warn { color: rgb(var(--dev3-warning)); }
+    .dashboard-grid {
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      gap: 14px;
+      margin-bottom: 14px;
+    }
+    .velocity-panel { grid-column: span 8; }
+    .pie-panel { grid-column: span 4; }
+    .radar-panel { grid-column: span 7; }
+    .scenario-panel { grid-column: span 5; }
+    .section { padding: 18px; }
+    .section-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .section-title { font-size: 15px; font-weight: 700; }
+    .section-copy { margin-top: 2px; color: rgb(var(--dev3-text-secondary)); font-size: 12px; }
+    .segmented {
+      gap: 3px;
+      padding: 3px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 11px;
+      background: rgb(var(--dev3-surface-base));
+    }
+    .segmented button { padding: 6px 9px; border: 0; background: transparent; }
+    .segmented button.active { background: rgb(var(--dev3-accent)); color: rgb(var(--dev3-on-accent)); }
+    .chart { position: relative; height: 245px; }
+    .chart svg, .pie-chart, .radar-chart { display: block; width: 100%; height: 100%; overflow: visible; }
+    .grid-line, .radar-grid, .radar-axis { stroke: rgb(var(--dev3-border)); stroke-width: 1; }
+    .area { fill: rgb(var(--dev3-accent) / .12); }
+    .line {
+      fill: none;
+      stroke: rgb(var(--dev3-accent));
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .point {
+      fill: rgb(var(--dev3-surface-raised));
+      stroke: rgb(var(--dev3-accent));
+      stroke-width: 3;
+      cursor: pointer;
+    }
+    .axis-label, .radar-label { fill: rgb(var(--dev3-text-muted)); font-size: 10px; }
+    .chart-tip {
+      position: absolute;
+      display: none;
+      padding: 6px 8px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 8px;
+      background: rgb(var(--dev3-surface-elevated));
+      box-shadow: 0 8px 24px rgb(var(--dev3-shadow) / .18);
+      font-size: 11px;
+      pointer-events: none;
+    }
+    .pie-layout { display: flex; align-items: center; gap: 24px; min-height: 245px; }
+    .pie-chart { width: min(190px, 48%); aspect-ratio: 1; height: auto; flex: none; }
+    .pie-segment {
+      stroke: rgb(var(--dev3-surface-raised));
+      stroke-width: 3;
+      transition: opacity .16s ease;
+    }
+    .pie-segment:hover { opacity: .82; }
+    .fill-accent { fill: rgb(var(--dev3-accent)); }
+    .fill-warning { fill: rgb(var(--dev3-warning)); }
+    .fill-danger { fill: rgb(var(--dev3-danger)); }
+    .legend { display: grid; gap: 9px; flex: 1; }
+    .legend-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 12px; }
+    .legend-key { display: flex; align-items: center; gap: 7px; }
+    .swatch { width: 8px; height: 8px; border-radius: 3px; }
+    .radar-wrap { height: 245px; }
+    .radar-grid { fill: none; }
+    .radar-target {
+      fill: none;
+      stroke: rgb(var(--dev3-success));
+      stroke-width: 2;
+      stroke-dasharray: 6 5;
+      stroke-linejoin: round;
+    }
+    .radar-shape {
+      fill: rgb(var(--dev3-accent) / .18);
+      stroke: rgb(var(--dev3-accent));
+      stroke-width: 3;
+      stroke-linejoin: round;
+    }
+    .radar-point { fill: rgb(var(--dev3-surface-raised)); stroke: rgb(var(--dev3-accent)); stroke-width: 3; }
+    .series-legend { display: flex; justify-content: center; gap: 18px; margin-top: 2px; color: rgb(var(--dev3-text-secondary)); font-size: 11px; }
+    .series-key { display: flex; align-items: center; gap: 6px; }
+    .series-line { width: 18px; border-top: 3px solid rgb(var(--dev3-accent)); }
+    .series-line.target { border-top: 2px dashed rgb(var(--dev3-success)); }
+    .controls { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .field { display: grid; gap: 6px; }
+    .field.full { grid-column: 1 / -1; }
+    .field label {
+      color: rgb(var(--dev3-text-secondary));
+      font-size: 11px;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+    }
+    .field input, .field select {
+      width: 100%;
+      padding: 9px 10px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 10px;
+      background: rgb(var(--dev3-surface-base));
+      color: rgb(var(--dev3-text-primary));
+      outline: none;
+    }
+    .field input:focus, .field select:focus {
+      border-color: rgb(var(--dev3-accent));
+      box-shadow: 0 0 0 3px rgb(var(--dev3-accent) / .12);
+    }
+    input[type="range"] { padding: 0; box-shadow: none; }
+    .range-label { display: flex; justify-content: space-between; color: rgb(var(--dev3-text-secondary)); font-size: 11px; }
+    .check { display: flex; align-items: center; gap: 8px; color: rgb(var(--dev3-text-secondary)); font-size: 12px; }
+    .check input { width: auto; }
+    .form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 2px; }
+    .table-card { overflow: hidden; }
+    .table-head { padding: 16px 18px 12px; }
+    .table-tools { gap: 8px; }
+    .table-tools input, .table-tools select {
+      padding: 7px 9px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 9px;
+      background: rgb(var(--dev3-surface-base));
+      color: rgb(var(--dev3-text-primary));
+      outline: none;
+    }
+    .table-tools input { width: 190px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); text-align: left; font-size: 12px; }
+    th {
+      color: rgb(var(--dev3-text-muted));
+      font-weight: 600;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    tbody tr:hover { background: rgb(var(--dev3-accent) / .04); }
+    .pill { display: inline-flex; padding: 4px 8px; border-radius: 999px; font-size: 11px; font-weight: 650; }
+    .pill.success { color: rgb(var(--dev3-success)); background: rgb(var(--dev3-success) / .1); }
+    .pill.warning { color: rgb(var(--dev3-warning)); background: rgb(var(--dev3-warning) / .1); }
+    .pill.accent { color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent) / .1); }
+    .bar-cell { display: flex; align-items: center; gap: 9px; }
+    .mini-track { width: 76px; height: 6px; overflow: hidden; border-radius: 99px; background: rgb(var(--dev3-border)); }
+    .mini-fill { height: 100%; border-radius: 99px; background: rgb(var(--dev3-accent)); }
+    .toast {
+      position: fixed;
+      right: 22px;
+      bottom: 22px;
+      padding: 11px 14px;
+      border: 1px solid rgb(var(--dev3-success) / .3);
+      border-radius: 11px;
+      background: rgb(var(--dev3-surface-elevated));
+      color: rgb(var(--dev3-text-primary));
+      box-shadow: 0 12px 40px rgb(var(--dev3-shadow) / .24);
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(20px);
+      transition: .2s;
+    }
+    .toast.show { opacity: 1; transform: none; }
+    .empty { padding: 26px; color: rgb(var(--dev3-text-muted)); text-align: center; }
+    .print-only { display: none; }
+    .dev3-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 18px 4px 2px;
+      color: rgb(var(--dev3-text-muted));
+      font-size: 11px;
+    }
+    .dev3-footer strong { color: rgb(var(--dev3-text-secondary)); font-weight: 650; }
+    .dev3-footer a { color: rgb(var(--dev3-accent)); text-decoration: none; }
+    .dev3-footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 900px) {
+      .kpis { grid-template-columns: repeat(2, 1fr); }
+      .dashboard-grid { grid-template-columns: 1fr; }
+      .velocity-panel, .pie-panel, .radar-panel, .scenario-panel { grid-column: auto; }
+      .topbar { align-items: flex-start; flex-direction: column; }
+    }
+    @media (max-width: 560px) {
+      body { padding: 14px; }
+      .kpis { grid-template-columns: 1fr; }
+      .actions { flex-wrap: wrap; }
+      .pie-layout { align-items: flex-start; flex-direction: column; }
+      .pie-chart { width: min(210px, 72%); margin: auto; }
+      .controls { grid-template-columns: 1fr; }
+      .field.full { grid-column: auto; }
+      .table-tools { align-items: stretch; flex-direction: column; }
+      .table-tools input { width: 100%; }
+      th:nth-child(3), td:nth-child(3), th:nth-child(5), td:nth-child(5) { display: none; }
+      .dev3-footer { align-items: flex-start; flex-direction: column; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+    }
+    @page { margin: 10mm; }
+    @media print {
+      html, body {
+        background: rgb(var(--dev3-surface-base)) !important;
+        color: rgb(var(--dev3-text-primary)) !important;
+      }
+      body { padding: 0; font-size: 10px; }
+      .app { max-width: none; }
+      .topbar { margin-bottom: 8px; }
+      .brand { gap: 9px; }
+      .brand img { width: 34px; height: 34px; border-radius: 10px; box-shadow: none; }
+      h1 { font-size: 17px; }
+      .eyebrow { font-size: 8px; }
+      .muted, .section-copy { font-size: 9px; }
+      .actions, .scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }
+      .print-only { display: block !important; }
+      .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; }
+      .kpi { padding: 9px 10px; }
+      .kpi-top { font-size: 8px; }
+      .kpi-value { margin: 3px 0 1px; font-size: 20px; }
+      .trend { font-size: 8px; }
+      .dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; }
+      .velocity-panel { grid-column: 1 / -1; }
+      .pie-panel, .radar-panel { grid-column: auto; }
+      .card, tr { break-inside: avoid; box-shadow: none; }
+      .section { padding: 10px; }
+      .section-head { margin-bottom: 6px; }
+      .section-title { font-size: 11px; }
+      .segmented { padding: 0; border: 0; background: transparent; }
+      .segmented button { display: none; padding: 3px 6px; font-size: 8px; }
+      .segmented button.active { display: block; }
+      .chart { height: 145px; }
+      .pie-layout { min-height: 165px; gap: 12px; }
+      .pie-chart { width: 135px; }
+      .radar-wrap { height: 148px; }
+      .series-legend { margin-top: 0; font-size: 8px; }
+      .legend { gap: 5px; }
+      .legend-row { font-size: 8px; }
+      .table-head { padding: 8px 10px 6px; }
+      th, td { padding: 5px 10px; font-size: 8px; }
+      thead { display: table-header-group; }
+      .pill { padding: 2px 5px; font-size: 7px; }
+      .mini-track { width: 52px; height: 4px; }
+      .dev3-footer { padding: 8px 2px 0; font-size: 8px; }
+    }
   </style>
-  <style>
-    .dev3-footer{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:18px 4px 2px;color:rgb(var(--dev3-text-muted));font-size:11px}.dev3-footer strong{color:rgb(var(--dev3-text-secondary));font-weight:650}.dev3-footer a{color:rgb(var(--dev3-accent));text-decoration:none}.dev3-footer a:hover{text-decoration:underline}@media(max-width:560px){.dev3-footer{align-items:flex-start;flex-direction:column}}
+  <style data-dev3-artifact-shell>
+    :root, [data-theme="dark"] { color-scheme: dark; --dev3-surface-base: 6 9 21; --dev3-surface-raised: 14 18 30; --dev3-surface-elevated: 21 26 41; --dev3-text-primary: 250 252 255; --dev3-text-secondary: 170 187 212; --dev3-text-muted: 82 98 121; --dev3-border: 32 38 55; --dev3-accent: 68 150 255; --dev3-success: 74 222 128; --dev3-warning: 250 204 21; --dev3-danger: 255 130 130; --dev3-on-accent: 255 255 255; --dev3-shadow: 0 0 0; }
+    [data-theme="light"] { color-scheme: light; --dev3-surface-base: 240 242 250; --dev3-surface-raised: 255 255 255; --dev3-surface-elevated: 237 239 247; --dev3-text-primary: 15 23 42; --dev3-text-secondary: 71 85 105; --dev3-text-muted: 148 163 184; --dev3-border: 203 213 225; --dev3-accent: 59 130 246; --dev3-success: 22 163 74; --dev3-warning: 202 138 4; --dev3-danger: 220 38 38; --dev3-on-accent: 255 255 255; --dev3-shadow: 15 23 42; }
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme]) { color-scheme: light; --dev3-surface-base: 240 242 250; --dev3-surface-raised: 255 255 255; --dev3-surface-elevated: 237 239 247; --dev3-text-primary: 15 23 42; --dev3-text-secondary: 71 85 105; --dev3-text-muted: 148 163 184; --dev3-border: 203 213 225; --dev3-accent: 59 130 246; --dev3-success: 22 163 74; --dev3-warning: 202 138 4; --dev3-danger: 220 38 38; --dev3-on-accent: 255 255 255; --dev3-shadow: 15 23 42; }
+    }
+    html { background: rgb(var(--dev3-surface-base)); color: rgb(var(--dev3-text-primary)); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; }
+    .dev3-card { padding: 16px; border: 1px solid rgb(var(--dev3-border)); border-radius: 16px; background: rgb(var(--dev3-surface-raised)); }
+    .dev3-grid { display: grid; gap: 16px; }
+    .dev3-muted { color: rgb(var(--dev3-text-secondary)); }
+    .dev3-accent { color: rgb(var(--dev3-accent)); }
   </style>
-<style data-dev3-artifact-shell>
-:root,[data-theme="dark"]{color-scheme:dark;--dev3-surface-base:6 9 21;--dev3-surface-raised:14 18 30;--dev3-surface-elevated:21 26 41;--dev3-text-primary:250 252 255;--dev3-text-secondary:170 187 212;--dev3-text-muted:82 98 121;--dev3-border:32 38 55;--dev3-accent:68 150 255;--dev3-success:74 222 128;--dev3-warning:250 204 21;--dev3-danger:255 130 130;--dev3-on-accent:255 255 255;--dev3-shadow:0 0 0}
-[data-theme="light"]{color-scheme:light;--dev3-surface-base:240 242 250;--dev3-surface-raised:255 255 255;--dev3-surface-elevated:237 239 247;--dev3-text-primary:15 23 42;--dev3-text-secondary:71 85 105;--dev3-text-muted:148 163 184;--dev3-border:203 213 225;--dev3-accent:59 130 246;--dev3-success:22 163 74;--dev3-warning:202 138 4;--dev3-danger:220 38 38;--dev3-on-accent:255 255 255;--dev3-shadow:15 23 42}
-@media(prefers-color-scheme:light){:root:not([data-theme]){color-scheme:light;--dev3-surface-base:240 242 250;--dev3-surface-raised:255 255 255;--dev3-surface-elevated:237 239 247;--dev3-text-primary:15 23 42;--dev3-text-secondary:71 85 105;--dev3-text-muted:148 163 184;--dev3-border:203 213 225;--dev3-accent:59 130 246;--dev3-success:22 163 74;--dev3-warning:202 138 4;--dev3-danger:220 38 38;--dev3-on-accent:255 255 255;--dev3-shadow:15 23 42}}
-html{background:rgb(var(--dev3-surface-base));color:rgb(var(--dev3-text-primary));font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}body{margin:0}.dev3-card{background:rgb(var(--dev3-surface-raised));border:1px solid rgb(var(--dev3-border));border-radius:16px;padding:16px}.dev3-grid{display:grid;gap:16px}.dev3-muted{color:rgb(var(--dev3-text-secondary))}.dev3-accent{color:rgb(var(--dev3-accent))}
-</style><script data-dev3-artifact-shell>(function(){function setTheme(theme){if(theme==='light'||theme==='dark')document.documentElement.dataset.theme=theme}window.addEventListener('message',function(event){if(event.data&&event.data.type==='dev3-artifact-theme')setTheme(event.data.theme)});if(!document.documentElement.dataset.theme)setTheme(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark')})();</script></head>
+  <script data-dev3-artifact-shell>
+    (function () {
+      function setTheme(theme) {
+        if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
+      }
+      window.addEventListener("message", function (event) {
+        if (event.data && event.data.type === "dev3-artifact-theme") setTheme(event.data.theme);
+      });
+      if (!document.documentElement.dataset.theme) {
+        setTheme(matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+      }
+    })();
+  </script>
+</head>
 <body>
   <main class="app">
     <header class="topbar">
-      <div class="brand"><img src="dev3-icon.png" alt="dev3 logo"><div><div class="eyebrow">DEV3 ARTIFACT · OPERATIONS</div><h1>Agent Operations Cockpit</h1><div class="muted">Model throughput, risk, and delivery before launching the next swarm.</div></div></div>
-      <div class="actions"><span class="status"><span class="dot"></span>Live data</span><button class="ghost" id="artifactTheme" title="Theme: Follow host">◐ Auto</button><button class="ghost" id="refresh">↻ Refresh</button><button class="primary" id="runTop">Run scenario</button></div>
+      <div class="brand">
+        <img src="dev3-icon.png" alt="dev3 logo">
+        <div>
+          <div class="eyebrow">DEV3 ARTIFACT · OPERATIONS</div>
+          <h1>Agent Operations Cockpit</h1>
+          <div class="muted">Model throughput, risk, and delivery before launching the next swarm.</div>
+        </div>
+      </div>
+      <div class="actions">
+        <span class="status"><span class="dot"></span>Live data</span>
+        <button class="ghost" id="artifactTheme" type="button" title="Theme: Follow host">◐ Auto</button>
+        <button class="ghost" id="refresh" type="button">↻ Refresh</button>
+        <button class="primary" id="runTop" type="button">Run scenario</button>
+      </div>
     </header>
 
     <section class="grid kpis">
@@ -30,43 +398,293 @@ html{background:rgb(var(--dev3-surface-base));color:rgb(var(--dev3-text-primary)
       <article class="card kpi"><div class="kpi-top"><span>Review queue</span><span>◇</span></div><div class="kpi-value" id="queue">7</div><div class="trend warn" id="queueTrend">2 need attention</div></article>
     </section>
 
-    <section class="grid workspace">
-      <article class="card section">
-        <div class="section-head"><div><div class="section-title">Delivery velocity</div><div class="section-copy">Completed tasks and predicted capacity</div></div><div class="segmented" id="periods"><button data-period="7">7d</button><button class="active" data-period="30">30d</button><button data-period="90">90d</button></div></div>
+    <section class="dashboard-grid">
+      <article class="card section velocity-panel">
+        <div class="section-head">
+          <div><div class="section-title">Delivery velocity</div><div class="section-copy">Completed tasks and predicted capacity</div></div>
+          <div class="segmented" id="periods"><button type="button" data-period="7">7d</button><button type="button" class="active" data-period="30">30d</button><button type="button" data-period="90">90d</button></div>
+        </div>
         <div class="chart"><svg id="velocityChart" viewBox="0 0 720 240" role="img" aria-label="Delivery velocity area chart"></svg><div class="chart-tip" id="chartTip"></div></div>
       </article>
 
-      <aside class="side-stack">
-        <article class="card section"><div class="section-head"><div><div class="section-title">Pipeline health</div><div class="section-copy">Current task distribution</div></div></div><div class="donut-row"><div class="donut" id="donut" style="--success:62%;--review:86%"></div><div class="legend"><div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-accent))"></span>Running</span><strong id="runningPct">62%</strong></div><div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-warning))"></span>Review</span><strong id="reviewPct">24%</strong></div><div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-danger))"></span>Blocked</span><strong id="blockedPct">14%</strong></div></div></div></article>
+      <article class="card section pie-panel">
+        <div class="section-head"><div><div class="section-title">Pipeline health</div><div class="section-copy">Current task distribution</div></div></div>
+        <div class="pie-layout">
+          <svg class="pie-chart" id="pipelinePie" viewBox="0 0 200 200" role="img" aria-labelledby="pieTitle pieDesc"></svg>
+          <div class="legend">
+            <div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-accent))"></span>Running</span><strong id="runningPct">62%</strong></div>
+            <div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-warning))"></span>Review</span><strong id="reviewPct">24%</strong></div>
+            <div class="legend-row"><span class="legend-key"><span class="swatch" style="background:rgb(var(--dev3-danger))"></span>Blocked</span><strong id="blockedPct">14%</strong></div>
+          </div>
+        </div>
+      </article>
 
-        <article class="card section"><div class="section-head"><div><div class="section-title">Scenario builder</div><div class="section-copy">Tune the next agent run</div></div></div><form id="scenarioForm" class="controls"><div class="field"><label for="workflow">Workflow</label><select id="workflow"><option>Feature delivery</option><option>Bug hunt</option><option>PR review</option><option>Research sprint</option></select></div><div class="field"><label for="agents">Agents</label><select id="agents"><option>3 agents</option><option selected>5 agents</option><option>8 agents</option><option>12 agents</option></select></div><div class="field full"><label for="risk">Risk tolerance</label><input id="risk" type="range" min="1" max="10" value="6"><div class="range-label"><span>Conservative</span><strong id="riskValue">6 / 10</strong><span>Aggressive</span></div></div><label class="check field full"><input id="experiments" type="checkbox" checked> Include experimental agent presets</label><div class="form-actions field full"><button type="reset">Reset</button><button class="primary" type="submit">Simulate</button></div></form></article>
-      </aside>
+      <article class="card section radar-panel">
+        <div class="section-head"><div><div class="section-title">Capability profile</div><div class="section-copy">Current scenario against the delivery target</div></div></div>
+        <div class="radar-wrap"><svg class="radar-chart" id="capabilityRadar" viewBox="0 0 420 280" role="img" aria-labelledby="radarTitle radarDesc"></svg></div>
+        <div class="series-legend"><span class="series-key"><span class="series-line"></span>Current scenario</span><span class="series-key"><span class="series-line target"></span>Target</span></div>
+      </article>
+
+      <article class="card section scenario-panel">
+        <div class="section-head"><div><div class="section-title">Scenario builder</div><div class="section-copy">Tune the next agent run</div></div></div>
+        <form id="scenarioForm" class="controls">
+          <div class="field"><label for="workflow">Workflow</label><select id="workflow"><option>Feature delivery</option><option>Bug hunt</option><option>PR review</option><option>Research sprint</option></select></div>
+          <div class="field"><label for="agents">Agents</label><select id="agents"><option>3 agents</option><option selected>5 agents</option><option>8 agents</option><option>12 agents</option></select></div>
+          <div class="field full"><label for="risk">Risk tolerance</label><input id="risk" type="range" min="1" max="10" value="6"><div class="range-label"><span>Conservative</span><strong id="riskValue">6 / 10</strong><span>Aggressive</span></div></div>
+          <label class="check field full"><input id="experiments" type="checkbox" checked> Include experimental agent presets</label>
+          <div class="form-actions field full"><button type="reset">Reset</button><button class="primary" type="submit">Simulate</button></div>
+        </form>
+      </article>
     </section>
 
     <section class="card table-card">
-      <div class="section-head table-head"><div><div class="section-title">Recent agent runs</div><div class="section-copy">Click a column heading to sort</div></div><div class="table-tools"><input id="search" type="search" placeholder="Search runs…"><select id="statusFilter"><option value="all">All statuses</option><option value="Shipped">Shipped</option><option value="Review">Review</option><option value="Running">Running</option></select></div></div>
-      <table><thead><tr><th data-sort="name">Run</th><th data-sort="status">Status</th><th data-sort="agent">Agent</th><th data-sort="progress">Progress</th><th data-sort="cycle">Cycle</th></tr></thead><tbody id="runRows"></tbody></table><div class="empty" id="empty" hidden>No matching runs.</div>
+      <div class="section-head table-head">
+        <div><div class="section-title">Recent agent runs</div><div class="section-copy">Click a column heading to sort</div></div>
+        <div class="table-tools"><input id="search" type="search" placeholder="Search runs…"><select id="statusFilter" aria-label="Filter by status"><option value="all">All statuses</option><option value="Shipped">Shipped</option><option value="Review">Review</option><option value="Running">Running</option></select></div>
+      </div>
+      <table><thead><tr><th data-sort="name" tabindex="0">Run</th><th data-sort="status" tabindex="0">Status</th><th data-sort="agent" tabindex="0">Agent</th><th data-sort="progress" tabindex="0">Progress</th><th data-sort="cycle" tabindex="0">Cycle</th></tr></thead><tbody id="runRows"></tbody></table>
+      <div class="empty" id="empty" hidden>No matching runs.</div>
     </section>
     <footer class="dev3-footer"><span><strong>Built with dev3 Artifacts</strong> · interactive reports that travel with the task</span><span>Template v1 · self-contained HTML</span></footer>
   </main>
-  <div class="toast" id="toast" role="status">Scenario recalculated.</div>
+  <div class="toast" id="toast" role="status" aria-live="polite">Scenario recalculated.</div>
 
   <script>
-    const datasets={7:[12,18,15,24,21,29,35],30:[9,14,12,18,22,19,28,31,26,38,42,39],90:[8,12,10,15,14,19,17,24,22,27,31,29,35,39,37,44]};
-    const runs=[
-      {name:"Artifact workspace",status:"Shipped",agent:"Codex · Sol",progress:100,cycle:"18m"},{name:"Remote mobile QA",status:"Review",agent:"Claude · Opus",progress:88,cycle:"31m"},{name:"CLI error taxonomy",status:"Running",agent:"Codex · Terra",progress:67,cycle:"24m"},{name:"Updater dependency audit",status:"Shipped",agent:"Claude · Sonnet",progress:100,cycle:"42m"},{name:"Git race reproducer",status:"Review",agent:"Codex · Luna",progress:92,cycle:"27m"},{name:"Theme contrast sweep",status:"Running",agent:"Codex · Sol",progress:54,cycle:"16m"}
+    const datasets = {
+      7: [12, 18, 15, 24, 21, 29, 35],
+      30: [9, 14, 12, 18, 22, 19, 28, 31, 26, 38, 42, 39],
+      90: [8, 12, 10, 15, 14, 19, 17, 24, 22, 27, 31, 29, 35, 39, 37, 44],
+    };
+    const runs = [
+      { name: "Artifact workspace", status: "Shipped", agent: "Codex · Sol", progress: 100, cycle: "18m" },
+      { name: "Remote mobile QA", status: "Review", agent: "Claude · Opus", progress: 88, cycle: "31m" },
+      { name: "CLI error taxonomy", status: "Running", agent: "Codex · Terra", progress: 67, cycle: "24m" },
+      { name: "Updater dependency audit", status: "Shipped", agent: "Claude · Sonnet", progress: 100, cycle: "42m" },
+      { name: "Git race reproducer", status: "Review", agent: "Codex · Luna", progress: 92, cycle: "27m" },
+      { name: "Theme contrast sweep", status: "Running", agent: "Codex · Sol", progress: 54, cycle: "16m" },
     ];
-    let currentPeriod=30,sortKey="name",sortDirection=1,themeMode="auto",hostTheme=document.documentElement.dataset.theme||"dark";
-    const svg=document.getElementById("velocityChart"),tip=document.getElementById("chartTip");
-    function renderChart(values){const w=720,h=220,pad=24,max=Math.max(...values)*1.18,step=(w-pad*2)/(values.length-1);const points=values.map((v,i)=>[pad+i*step,h-pad-(v/max)*(h-pad*2)]);const line=points.map((p,i)=>(i?"L":"M")+p.join(" ")).join(" ");const area=`${line} L ${points.at(-1)[0]} ${h-pad} L ${pad} ${h-pad} Z`;const grid=[.25,.5,.75,1].map(n=>`<line class="grid-line" x1="${pad}" y1="${h-pad-(h-pad*2)*n}" x2="${w-pad}" y2="${h-pad-(h-pad*2)*n}"/>`).join("");const labels=points.map((p,i)=>`<text class="axis-label" x="${p[0]}" y="${h-4}" text-anchor="middle">${i+1}</text>`).join("");const dots=points.map((p,i)=>`<circle class="point" data-index="${i}" cx="${p[0]}" cy="${p[1]}" r="5"/>`).join("");svg.innerHTML=`${grid}<path class="area" d="${area}"/><path class="line" d="${line}"/>${dots}${labels}`;svg.querySelectorAll(".point").forEach(point=>{point.addEventListener("mouseenter",()=>{const i=Number(point.dataset.index);tip.textContent=`Day ${i+1}: ${values[i]} tasks`;tip.style.display="block";tip.style.left=`${Math.min(82,Number(point.getAttribute("cx"))/7.2)}%`;tip.style.top=`${Math.max(4,Number(point.getAttribute("cy"))/2.4-8)}%`});point.addEventListener("mouseleave",()=>tip.style.display="none")})}
-    function statusClass(status){return status==="Shipped"?"success":status==="Review"?"warning":"accent"}
-    function renderTable(){const query=search.value.toLowerCase(),filter=statusFilter.value;const shown=runs.filter(run=>(filter==="all"||run.status===filter)&&run.name.toLowerCase().includes(query)).sort((a,b)=>String(a[sortKey]).localeCompare(String(b[sortKey]),undefined,{numeric:true})*sortDirection);runRows.innerHTML=shown.map(run=>`<tr><td><strong>${run.name}</strong></td><td><span class="pill ${statusClass(run.status)}">${run.status}</span></td><td>${run.agent}</td><td><div class="bar-cell"><div class="mini-track"><div class="mini-fill" style="width:${run.progress}%"></div></div><span>${run.progress}%</span></div></td><td>${run.cycle}</td></tr>`).join("");empty.hidden=shown.length>0}
-    function showToast(message){toast.textContent=message;toast.classList.add("show");clearTimeout(window.toastTimer);window.toastTimer=setTimeout(()=>toast.classList.remove("show"),1800)}
-    function simulate(){const risk=Number(document.getElementById("risk").value),agentCount=Number(document.getElementById("agents").value.split(" ")[0]);shipped.textContent=118+risk*agentCount;success.textContent=(97.2-risk*.45).toFixed(1)+"%";cycle.textContent=Math.max(9,30-agentCount-risk)+"m";queue.textContent=Math.max(2,12-risk);const base=datasets[currentPeriod];renderChart(base.map((v,i)=>Math.round(v*(.82+risk*.035)+(i%3)*agentCount/3)));const running=Math.min(78,50+risk*2),review=Math.min(94,running+22);donut.style.setProperty("--success",running+"%");donut.style.setProperty("--review",review+"%");runningPct.textContent=running+"%";reviewPct.textContent=(review-running)+"%";blockedPct.textContent=(100-review)+"%";showToast("Scenario recalculated with "+agentCount+" agents")}
-    document.getElementById("periods").addEventListener("click",event=>{const button=event.target.closest("button[data-period]");if(!button)return;currentPeriod=Number(button.dataset.period);document.querySelectorAll("[data-period]").forEach(item=>item.classList.toggle("active",item===button));renderChart(datasets[currentPeriod]);showToast(currentPeriod+" day window loaded")});
-    function applyDemoTheme(){const theme=themeMode==="auto"?hostTheme:themeMode;document.documentElement.dataset.theme=theme;artifactTheme.textContent=themeMode==="auto"?"◐ Auto":themeMode==="light"?"☀ Light":"☾ Dark";artifactTheme.title=themeMode==="auto"?"Theme: Follow host":"Theme: "+themeMode;showToast(themeMode==="auto"?"Following the host theme":"Artifact theme: "+themeMode)}
-    window.addEventListener("message",event=>{if(event.data?.type!=="dev3-artifact-theme")return;hostTheme=event.data.theme;if(themeMode==="auto")document.documentElement.dataset.theme=hostTheme});artifactTheme.addEventListener("click",()=>{themeMode=themeMode==="auto"?"light":themeMode==="light"?"dark":"auto";applyDemoTheme()});
-    document.getElementById("risk").addEventListener("input",event=>riskValue.textContent=event.target.value+" / 10");document.getElementById("scenarioForm").addEventListener("submit",event=>{event.preventDefault();simulate()});document.getElementById("scenarioForm").addEventListener("reset",()=>setTimeout(()=>{riskValue.textContent="6 / 10";showToast("Scenario reset")},0));document.getElementById("runTop").addEventListener("click",simulate);document.getElementById("refresh").addEventListener("click",()=>{refresh.textContent="↻ Refreshing…";setTimeout(()=>{refresh.textContent="↻ Refresh";showToast("Live data refreshed")},650)});search.addEventListener("input",renderTable);statusFilter.addEventListener("change",renderTable);document.querySelectorAll("th[data-sort]").forEach(th=>th.addEventListener("click",()=>{sortDirection=sortKey===th.dataset.sort?-sortDirection:1;sortKey=th.dataset.sort;renderTable()}));renderChart(datasets[30]);renderTable();
+    const radarLabels = ["Speed", "Quality", "Autonomy", "Coverage", "Efficiency", "Predictability"];
+    const radarTarget = [82, 88, 80, 86, 84, 82];
+    let currentPeriod = 30;
+    let sortKey = "name";
+    let sortDirection = 1;
+    let themeMode = "auto";
+    let hostTheme = document.documentElement.dataset.theme || "dark";
+
+    const velocityChart = document.getElementById("velocityChart");
+    const pipelinePie = document.getElementById("pipelinePie");
+    const capabilityRadar = document.getElementById("capabilityRadar");
+    const chartTip = document.getElementById("chartTip");
+    const artifactTheme = document.getElementById("artifactTheme");
+    const refresh = document.getElementById("refresh");
+    const shipped = document.getElementById("shipped");
+    const success = document.getElementById("success");
+    const cycle = document.getElementById("cycle");
+    const queue = document.getElementById("queue");
+    const runningPct = document.getElementById("runningPct");
+    const reviewPct = document.getElementById("reviewPct");
+    const blockedPct = document.getElementById("blockedPct");
+    const riskValue = document.getElementById("riskValue");
+    const search = document.getElementById("search");
+    const statusFilter = document.getElementById("statusFilter");
+    const runRows = document.getElementById("runRows");
+    const empty = document.getElementById("empty");
+    const toast = document.getElementById("toast");
+
+    function renderChart(values) {
+      const width = 720;
+      const height = 220;
+      const padding = 24;
+      const max = Math.max(...values) * 1.18;
+      const step = (width - padding * 2) / (values.length - 1);
+      const points = values.map((value, index) => [padding + index * step, height - padding - (value / max) * (height - padding * 2)]);
+      const line = points.map((point, index) => `${index ? "L" : "M"}${point.join(" ")}`).join(" ");
+      const area = `${line} L ${points.at(-1)[0]} ${height - padding} L ${padding} ${height - padding} Z`;
+      const grid = [.25, .5, .75, 1].map((level) => `<line class="grid-line" x1="${padding}" y1="${height - padding - (height - padding * 2) * level}" x2="${width - padding}" y2="${height - padding - (height - padding * 2) * level}"/>`).join("");
+      const labels = points.map((point, index) => `<text class="axis-label" x="${point[0]}" y="${height - 4}" text-anchor="middle">${index + 1}</text>`).join("");
+      const dots = points.map((point, index) => `<circle class="point" data-index="${index}" cx="${point[0]}" cy="${point[1]}" r="5" tabindex="0" aria-label="Day ${index + 1}: ${values[index]} tasks"/>`).join("");
+      velocityChart.innerHTML = `<title>Delivery velocity</title><desc>Tasks completed over the selected period.</desc>${grid}<path class="area" d="${area}"/><path class="line" d="${line}"/>${dots}${labels}`;
+      velocityChart.querySelectorAll(".point").forEach((point) => {
+        const showPoint = () => {
+          const index = Number(point.dataset.index);
+          chartTip.textContent = `Day ${index + 1}: ${values[index]} tasks`;
+          chartTip.style.display = "block";
+          chartTip.style.left = `${Math.min(82, Number(point.getAttribute("cx")) / 7.2)}%`;
+          chartTip.style.top = `${Math.max(4, Number(point.getAttribute("cy")) / 2.4 - 8)}%`;
+        };
+        point.addEventListener("mouseenter", showPoint);
+        point.addEventListener("focus", showPoint);
+        point.addEventListener("mouseleave", () => { chartTip.style.display = "none"; });
+        point.addEventListener("blur", () => { chartTip.style.display = "none"; });
+      });
+    }
+
+    function polarPoint(centerX, centerY, radius, angle) {
+      const radians = (angle - 90) * Math.PI / 180;
+      return [centerX + radius * Math.cos(radians), centerY + radius * Math.sin(radians)];
+    }
+
+    function piePath(startAngle, endAngle) {
+      const start = polarPoint(100, 100, 88, startAngle);
+      const end = polarPoint(100, 100, 88, endAngle);
+      const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+      return `M 100 100 L ${start[0]} ${start[1]} A 88 88 0 ${largeArc} 1 ${end[0]} ${end[1]} Z`;
+    }
+
+    function renderPie(values) {
+      const segments = [
+        { label: "Running", value: values[0], className: "fill-accent" },
+        { label: "Review", value: values[1], className: "fill-warning" },
+        { label: "Blocked", value: values[2], className: "fill-danger" },
+      ];
+      let angle = 0;
+      const paths = segments.map((segment) => {
+        const start = angle;
+        angle += segment.value * 3.6;
+        return `<path class="pie-segment ${segment.className}" d="${piePath(start, angle)}"><title>${segment.label}: ${segment.value}%</title></path>`;
+      }).join("");
+      const summary = segments.map((segment) => `${segment.label} ${segment.value}%`).join(", ");
+      pipelinePie.innerHTML = `<title id="pieTitle">Pipeline health</title><desc id="pieDesc">${summary}</desc>${paths}`;
+      pipelinePie.setAttribute("aria-label", summary);
+    }
+
+    function radarPoint(centerX, centerY, radius, index, total) {
+      return polarPoint(centerX, centerY, radius, index * 360 / total);
+    }
+
+    function radarPolygon(values, radius, centerX, centerY) {
+      return values.map((value, index) => radarPoint(centerX, centerY, radius * value / 100, index, values.length).join(",")).join(" ");
+    }
+
+    function renderRadar(values) {
+      const centerX = 210;
+      const centerY = 138;
+      const radius = 92;
+      const levels = [25, 50, 75, 100].map((level) => `<polygon class="radar-grid" points="${radarPolygon(radarLabels.map(() => level), radius, centerX, centerY)}"/>`).join("");
+      const axes = radarLabels.map((_, index) => {
+        const point = radarPoint(centerX, centerY, radius, index, radarLabels.length);
+        return `<line class="radar-axis" x1="${centerX}" y1="${centerY}" x2="${point[0]}" y2="${point[1]}"/>`;
+      }).join("");
+      const labels = radarLabels.map((label, index) => {
+        const point = radarPoint(centerX, centerY, radius + 30, index, radarLabels.length);
+        const anchor = point[0] < centerX - 8 ? "end" : point[0] > centerX + 8 ? "start" : "middle";
+        return `<text class="radar-label" x="${point[0]}" y="${point[1]}" text-anchor="${anchor}" dominant-baseline="middle">${label}</text>`;
+      }).join("");
+      const points = values.map((value, index) => {
+        const point = radarPoint(centerX, centerY, radius * value / 100, index, values.length);
+        return `<circle class="radar-point" cx="${point[0]}" cy="${point[1]}" r="4"><title>${radarLabels[index]}: ${value}%</title></circle>`;
+      }).join("");
+      const summary = radarLabels.map((label, index) => `${label} ${values[index]}%`).join(", ");
+      capabilityRadar.innerHTML = `<title id="radarTitle">Capability profile</title><desc id="radarDesc">${summary}</desc>${levels}${axes}<polygon class="radar-target" points="${radarPolygon(radarTarget, radius, centerX, centerY)}"/><polygon class="radar-shape" points="${radarPolygon(values, radius, centerX, centerY)}"/>${points}${labels}`;
+      capabilityRadar.setAttribute("aria-label", summary);
+    }
+
+    function statusClass(status) {
+      return status === "Shipped" ? "success" : status === "Review" ? "warning" : "accent";
+    }
+
+    function renderTable() {
+      const query = search.value.toLowerCase();
+      const filter = statusFilter.value;
+      const shown = runs
+        .filter((run) => (filter === "all" || run.status === filter) && run.name.toLowerCase().includes(query))
+        .sort((a, b) => String(a[sortKey]).localeCompare(String(b[sortKey]), undefined, { numeric: true }) * sortDirection);
+      runRows.innerHTML = shown.map((run) => `<tr><td><strong>${run.name}</strong></td><td><span class="pill ${statusClass(run.status)}">${run.status}</span></td><td>${run.agent}</td><td><div class="bar-cell"><div class="mini-track"><div class="mini-fill" style="width:${run.progress}%"></div></div><span>${run.progress}%</span></div></td><td>${run.cycle}</td></tr>`).join("");
+      empty.hidden = shown.length > 0;
+    }
+
+    function showToast(message) {
+      toast.textContent = message;
+      toast.classList.add("show");
+      clearTimeout(window.toastTimer);
+      window.toastTimer = setTimeout(() => toast.classList.remove("show"), 1800);
+    }
+
+    function scenarioRadar(risk, agentCount) {
+      return [
+        Math.min(98, 54 + agentCount * 3 + risk * 2),
+        Math.max(48, 96 - risk * 3),
+        Math.min(96, 48 + agentCount * 4 + risk),
+        Math.max(52, 91 - risk * 2),
+        Math.min(97, 58 + agentCount * 2 + risk * 2),
+        Math.max(45, 94 - risk * 3 + agentCount),
+      ];
+    }
+
+    function simulate() {
+      const risk = Number(document.getElementById("risk").value);
+      const agentCount = Number(document.getElementById("agents").value.split(" ")[0]);
+      shipped.textContent = 118 + risk * agentCount;
+      success.textContent = `${(97.2 - risk * .45).toFixed(1)}%`;
+      cycle.textContent = `${Math.max(9, 30 - agentCount - risk)}m`;
+      queue.textContent = Math.max(2, 12 - risk);
+      const base = datasets[currentPeriod];
+      renderChart(base.map((value, index) => Math.round(value * (.82 + risk * .035) + (index % 3) * agentCount / 3)));
+      const running = Math.min(78, 50 + risk * 2);
+      const review = Math.min(94, running + 22);
+      const pieValues = [running, review - running, 100 - review];
+      renderPie(pieValues);
+      renderRadar(scenarioRadar(risk, agentCount));
+      runningPct.textContent = `${pieValues[0]}%`;
+      reviewPct.textContent = `${pieValues[1]}%`;
+      blockedPct.textContent = `${pieValues[2]}%`;
+      showToast(`Scenario recalculated with ${agentCount} agents`);
+    }
+
+    document.getElementById("periods").addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-period]");
+      if (!button) return;
+      currentPeriod = Number(button.dataset.period);
+      document.querySelectorAll("[data-period]").forEach((item) => item.classList.toggle("active", item === button));
+      renderChart(datasets[currentPeriod]);
+      showToast(`${currentPeriod} day window loaded`);
+    });
+
+    function applyDemoTheme() {
+      const theme = themeMode === "auto" ? hostTheme : themeMode;
+      document.documentElement.dataset.theme = theme;
+      artifactTheme.textContent = themeMode === "auto" ? "◐ Auto" : themeMode === "light" ? "☀ Light" : "☾ Dark";
+      artifactTheme.title = themeMode === "auto" ? "Theme: Follow host" : `Theme: ${themeMode}`;
+      showToast(themeMode === "auto" ? "Following the host theme" : `Artifact theme: ${themeMode}`);
+    }
+
+    window.addEventListener("message", (event) => {
+      if (event.data?.type !== "dev3-artifact-theme") return;
+      hostTheme = event.data.theme;
+      if (themeMode === "auto") document.documentElement.dataset.theme = hostTheme;
+    });
+    artifactTheme.addEventListener("click", () => {
+      themeMode = themeMode === "auto" ? "light" : themeMode === "light" ? "dark" : "auto";
+      applyDemoTheme();
+    });
+    document.getElementById("risk").addEventListener("input", (event) => { riskValue.textContent = `${event.target.value} / 10`; });
+    document.getElementById("scenarioForm").addEventListener("submit", (event) => { event.preventDefault(); simulate(); });
+    document.getElementById("scenarioForm").addEventListener("reset", () => setTimeout(() => { riskValue.textContent = "6 / 10"; showToast("Scenario reset"); }, 0));
+    document.getElementById("runTop").addEventListener("click", simulate);
+    refresh.addEventListener("click", () => {
+      refresh.textContent = "↻ Refreshing…";
+      setTimeout(() => { refresh.textContent = "↻ Refresh"; showToast("Live data refreshed"); }, 650);
+    });
+    search.addEventListener("input", renderTable);
+    statusFilter.addEventListener("change", renderTable);
+    document.querySelectorAll("th[data-sort]").forEach((heading) => {
+      const sort = () => {
+        sortDirection = sortKey === heading.dataset.sort ? -sortDirection : 1;
+        sortKey = heading.dataset.sort;
+        renderTable();
+      };
+      heading.addEventListener("click", sort);
+      heading.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        sort();
+      });
+    });
+
+    renderChart(datasets[30]);
+    renderPie([62, 24, 14]);
+    renderRadar([78, 82, 68, 88, 75, 72]);
+    renderTable();
   </script>
 </body>
 </html>

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -129,12 +129,32 @@ describe("bundled artifact starter contract", () => {
 		expect(html).toContain("☾ Dark");
 		expect(html).toContain("prefers-color-scheme");
 		expect(html).toContain("dev3-artifact-theme");
-		expect(html).toContain("@media(max-width:560px)");
+		expect(html).toContain("@media (max-width: 560px)");
 		expect(html).toContain("<form");
 		expect(html).toContain("<svg");
+		expect(html).toContain('id="pipelinePie"');
+		expect(html).toContain('id="capabilityRadar"');
+		expect(html).toContain('aria-labelledby="pieTitle pieDesc"');
+		expect(html).toContain('aria-labelledby="radarTitle radarDesc"');
+		expect(html).toContain("function renderPie");
+		expect(html).toContain("function renderRadar");
 		expect(html).toContain("data-sort");
 		expect(guide).toContain("DEV3_ARTIFACT_TEMPLATE_DIR");
 		expect(guide).toContain("dev3 show-artifact");
+		expect(guide).toContain("Print and PDF");
+		expect(guide).toContain("radar/spider chart");
+	});
+
+	it("keeps the selected theme and report structure in print output", () => {
+		const html = readFileSync(htmlPath, "utf8");
+
+		expect(html).toContain("@media print");
+		expect(html).toContain("-webkit-print-color-adjust: exact");
+		expect(html).toContain("print-color-adjust: exact");
+		expect(html).toContain("background: rgb(var(--dev3-surface-base)) !important");
+		expect(html).toContain(".scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }");
+		expect(html).toContain("break-inside: avoid");
+		expect(html).toContain("thead { display: table-header-group; }");
 	});
 
 	it("defines the complete dev3 semantic token contract without network dependencies", () => {


### PR DESCRIPTION
## Summary\n\n- add accessible, dependency-free SVG pie and radar charts to the dev3 artifact starter\n- preserve the selected Auto, Light, or Dark theme in print and compact reports into a clean PDF layout\n- document the reusable chart and print contracts and cover them with artifact-template tests\n\n## Test plan\n\n- bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/artifact-template.test.ts\n- bun run lint\n- manually verified Light and Dark one-page PDF output\n- manually verified the responsive layout at 390px without horizontal overflow