### PR TITLE
Fix toast dismiss button after swipe support

### DIFF
--- a/change-logs/2026/07/22/fix-toast-dismiss-button.md
+++ b/change-logs/2026/07/22/fix-toast-dismiss-button.md
@@ -1,0 +1,3 @@
+Short: Toast dismiss button works
+
+Fixed toast close-button handling after swipe support was added. Pressing the dismiss button no longer starts card pointer capture, while message-body swipes remain available.

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -119,6 +119,25 @@ describe("toast service", () => {
 		expect(screen.queryByText("Closable")).not.toBeInTheDocument();
 	});
 
+	it("keeps the dismiss button outside the swipe pointer capture", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Dismiss without swiping", { durationMs: 60_000 });
+		});
+
+		const card = toastCard() as HTMLElement;
+		const setPointerCapture = vi.fn();
+		Object.defineProperty(card, "setPointerCapture", { configurable: true, value: setPointerCapture });
+
+		act(() => {
+			fireEvent.pointerDown(screen.getByRole("button", { name: "Dismiss" }), { pointerId: 1, clientX: 0 });
+		});
+		expect(setPointerCapture).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+		expect(screen.queryByText("Dismiss without swiping")).not.toBeInTheDocument();
+	});
+
 	it("dismisses a toast on a rightward swipe past the threshold", () => {
 		render(<ToastHost />);
 		act(() => {

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -447,6 +447,7 @@ function ToastCard({ entry, paused, onDismiss, onInteraction }: ToastCardProps) 
 				)}
 				<button
 					type="button"
+					onPointerDown={(event) => event.stopPropagation()}
 					onClick={() => {
 						if (suppressIfDragged()) return;
 						onDismiss(entry.id);


### PR DESCRIPTION
## Summary

- Keep the toast dismiss button out of ToastCard swipe pointer capture.
- Preserve rightward swipe dismissal from the message body.
- Add regression coverage and a changelog entry.

The headless-browser event trace showed pointer capture retargeting the X compatibility click to the card div instead of the button.

## Verification

- bunx vitest run src/mainview/__tests__/toast.test.tsx src/mainview/__tests__/App.test.tsx
- bun run lint
- bunx vite build
- Verified in headless remote browser: rpc:taskPreparationFailed toast closes from X, and message-body swipe dismissal still works.