### PR TITLE
Redesign rate-limit indicator into a per-account quota panel

### DIFF
--- a/change-logs/2026/07/22/feature-quota-panel-usage-bars.md
+++ b/change-logs/2026/07/22/feature-quota-panel-usage-bars.md
@@ -1,0 +1,3 @@
+Short: Per-account quota panel with usage bars
+
+The agent rate-limit indicator's hover panel is now a real quota dashboard: one card per Claude/Codex account with a usage bar per limit window (5h, 7d, monthly credits), reset countdowns, plan badges, and an "∞ unlimited" chip for unlimited-credit accounts. The header pill stacks one mini usage bar per account (up to four) so every account's state is visible at a glance, and unlimited accounts read "∞ unlimited" with a full green line instead of a misleading 0%.

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -3,7 +3,7 @@ import { api } from "../rpc";
 import { useLocale, useT } from "../i18n";
 import Tooltip from "./Tooltip";
 import { RateLimitIcon } from "./HeaderIcons";
-import type { AgentRateLimitSnapshot, AgentRateLimitsReport, RateLimitSource } from "../../shared/rate-limits";
+import type { AgentRateLimitSnapshot, AgentRateLimitsReport, RateLimitSource, RateLimitWindow } from "../../shared/rate-limits";
 import {
 	RATE_LIMIT_DANGER_PERCENT,
 	RATE_LIMIT_WARN_PERCENT,
@@ -18,6 +18,9 @@ import { AGENT_ACCOUNTS_CHANGED_EVENT } from "./AgentAccountIndicator";
 
 /** Data older than this gets a staleness note in the tooltip. */
 const STALE_AFTER_MS = 10 * 60 * 1000;
+
+/** The pill stacks one mini bar per account, capped to keep the header slim. */
+const MAX_PILL_BARS = 4;
 
 const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" };
 
@@ -78,37 +81,131 @@ function resolveAccount(source: RateLimitSource, state: AgentAccountsState | nul
 	return null;
 }
 
-/** Build the detail rows (windows + credits + monthly usage) for one snapshot. */
-function snapshotRows(
-	snap: AgentRateLimitSnapshot,
-	now: number,
-	t: ReturnType<typeof useT>,
-	locale: string,
-): string[] {
-	const rows: string[] = [];
-	for (const win of snap.windows) {
-		if (win.id === "monthly_credits") continue;
-		const reset = formatResetDelta(win.resetsAt, now);
-		rows.push(
-			`${windowLabel(win)} — ${t("rateLimits.percentUsed", { percent: Math.round(win.usedPercent) })}${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
-		);
-	}
-	if (snap.creditsBalance != null) {
-		rows.push(t("rateLimits.credits", { balance: snap.creditsBalance }));
-	}
-	if (snap.monthlyCredits) {
-		const monthly = snap.monthlyCredits;
-		const reset = formatResetDelta(monthly.resetsAt, now);
-		const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
-		rows.push(
-			`${t("rateLimits.monthlyLabel")} — ${t("rateLimits.monthlyUsage", {
-				used: numberFormat.format(monthly.used),
-				limit: numberFormat.format(monthly.limit),
-				remaining: Math.round(monthly.remainingPercent),
-			})}${reset ? ` · ${t("rateLimits.resetsIn", { time: reset })}` : ""}`,
-		);
-	}
-	return rows;
+function severityFill(percent: number): string {
+	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "bg-danger";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "bg-warning";
+	return "bg-accent";
+}
+
+function severityText(percent: number): string {
+	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
+	return "text-fg-2";
+}
+
+/** Horizontal usage gauge: track + severity-colored fill, clamped to 0–100. */
+function UsageBar({ percent, className }: { percent: number; className: string }) {
+	const clamped = Math.max(0, Math.min(100, percent));
+	return (
+		<span aria-hidden="true" className={`relative block overflow-hidden rounded-full bg-fg/10 ${className}`}>
+			<span
+				className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${severityFill(percent)}`}
+				style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.3rem" : undefined }}
+			/>
+		</span>
+	);
+}
+
+/** One limit window inside an account card: label + reset + percent over a bar. */
+function WindowBarRow({
+	label,
+	usedPercent,
+	resetsAt,
+	now,
+	detail,
+}: {
+	label: string;
+	usedPercent: number;
+	resetsAt: number | null;
+	now: number;
+	detail?: string;
+}) {
+	const t = useT();
+	const percent = Math.round(usedPercent);
+	const reset = formatResetDelta(resetsAt, now);
+	return (
+		<div className="flex flex-col gap-[0.1875rem]">
+			<div className="flex items-baseline gap-2">
+				<span className="min-w-0 truncate font-medium text-fg-3">{label}</span>
+				{reset && <span className="ml-auto shrink-0 text-fg-muted">{t("rateLimits.resetsIn", { time: reset })}</span>}
+				<span className={`shrink-0 font-medium tabular-nums ${reset ? "" : "ml-auto"} ${severityText(percent)}`}>
+					{t("rateLimits.percentUsed", { percent })}
+				</span>
+			</div>
+			<UsageBar percent={usedPercent} className="h-1.5 w-full" />
+			{detail && <span className="text-fg-muted">{detail}</span>}
+		</div>
+	);
+}
+
+/** One account's quota card: identity header + a bar per limit window. */
+function AccountCard({
+	snap,
+	account,
+	now,
+}: {
+	snap: AgentRateLimitSnapshot;
+	account: AccountLine | null;
+	now: number;
+}) {
+	const t = useT();
+	const [locale] = useLocale();
+	const unlimited = isUnlimitedRateLimitSnapshot(snap);
+	// Collapse the auto-generated "email (workspace)" label into a plain
+	// email so every row reads consistently as "email · workspace" (the
+	// chip carries the workspace). A user-custom label is left untouched.
+	const displayName =
+		account?.email && account.organization && account.name === `${account.email} (${account.organization})`
+			? account.email
+			: (account?.name ?? null);
+	const showOrg =
+		!!account?.organization &&
+		account.organization !== displayName &&
+		!(displayName ?? "").endsWith(`(${account.organization})`);
+
+	const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+	const monthly = snap.monthlyCredits;
+	// The monthly_credits window mirrors snap.monthlyCredits; the dedicated row
+	// below renders it with its used/limit detail, so skip the duplicate here.
+	const windows = snap.windows.filter((w: RateLimitWindow) => !(w.id === "monthly_credits" && monthly));
+
+	return (
+		<div className="flex flex-col gap-1.5 rounded-md border border-edge bg-raised/65 px-2.5 py-2">
+			<div className="flex items-center gap-1.5">
+				<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
+				{displayName && <span className="min-w-0 truncate text-fg-3">{displayName}</span>}
+				{showOrg && <span className="text-fg-muted whitespace-nowrap shrink-0">· {account?.organization}</span>}
+				{account?.planLabel && (
+					<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">{account.planLabel}</span>
+				)}
+				{account?.isApi && <span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>}
+				{unlimited && (
+					<span className="ml-auto text-success text-[0.625rem] px-1 py-px bg-success/10 rounded shrink-0 font-medium">
+						{t("rateLimits.unlimited")}
+					</span>
+				)}
+			</div>
+			{windows.map((win) => (
+				<WindowBarRow key={win.id} label={windowLabel(win)} usedPercent={win.usedPercent} resetsAt={win.resetsAt} now={now} />
+			))}
+			{monthly && (
+				<WindowBarRow
+					label={t("rateLimits.monthlyLabel")}
+					usedPercent={Math.max(0, 100 - monthly.remainingPercent)}
+					resetsAt={monthly.resetsAt}
+					now={now}
+					detail={t("rateLimits.monthlyUsage", {
+						used: numberFormat.format(monthly.used),
+						limit: numberFormat.format(monthly.limit),
+						remaining: Math.round(monthly.remainingPercent),
+					})}
+				/>
+			)}
+			{snap.creditsBalance != null && !unlimited && (
+				<span className="text-fg-3">{t("rateLimits.credits", { balance: snap.creditsBalance })}</span>
+			)}
+		</div>
+	);
 }
 
 /**
@@ -117,13 +214,13 @@ function snapshotRows(
  * dev running many parallel agents is never blindsided by hitting a limit.
  * Hidden until usable data exists; shows the most constrained window for the
  * most recently active account and treats unlimited credits as 0% used.
- * Details for every recently active account live in the tooltip. Codex monthly
- * credits come from a cached app-server account read; all other data comes from
- * local files — see rate-limit-monitor.ts.
+ * Details for every recently active account live in the tooltip as per-account
+ * quota cards with usage bars. Codex monthly credits come from a cached
+ * app-server account read; all other data comes from local files — see
+ * rate-limit-monitor.ts.
  */
 function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const t = useT();
-	const [locale] = useLocale();
 	const [report, setReport] = useState<AgentRateLimitsReport | null>(null);
 	const [accounts, setAccounts] = useState<AgentAccountsState | null>(null);
 
@@ -176,7 +273,11 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 			? t("rateLimits.monthlyLabel")
 			: windowLabel(latestWindow)
 		: null;
-	const ariaLabel = `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source}${latestLabel ? ` ${latestLabel}` : ""} ${t("rateLimits.percentUsed", { percent })}${latestReset ? `, ${t("rateLimits.resetsIn", { time: latestReset })}` : ""}`;
+	const ariaLabel = unlimited
+		? `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source} ${t("rateLimits.unlimited")}`
+		: `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source}${latestLabel ? ` ${latestLabel}` : ""} ${t("rateLimits.percentUsed", { percent })}${latestReset ? `, ${t("rateLimits.resetsIn", { time: latestReset })}` : ""}`;
+
+	const pillSnapshots = report.snapshots.slice(0, MAX_PILL_BARS);
 
 	const colorClasses = danger
 		? "text-danger bg-danger/15 border-danger/30"
@@ -189,50 +290,17 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 			content={t("rateLimits.tooltipTitle")}
 			wide
 			detail={
-				<div className="flex max-h-[min(70vh,30rem)] flex-col gap-2 overflow-y-auto pr-1">
-					{report.snapshots.map((snap) => {
-						const account = resolveAccount(snap.source, accounts, snap.accountId);
-						const rows = snapshotRows(snap, now, t, locale);
-						// Collapse the auto-generated "email (workspace)" label into a plain
-						// email so every row reads consistently as "email · workspace" (the
-						// chip carries the workspace). A user-custom label is left untouched.
-						const displayName =
-							account?.email && account.organization && account.name === `${account.email} (${account.organization})`
-								? account.email
-								: (account?.name ?? null);
-						const showOrg =
-							!!account?.organization &&
-							account.organization !== displayName &&
-							!(displayName ?? "").endsWith(`(${account.organization})`);
-						return (
-							<div key={`${snap.source}:${snap.accountId ?? "system"}`} className="flex flex-col gap-0.5">
-								<div className="flex items-center gap-1.5">
-									<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
-									{displayName && <span className="text-fg-3">{displayName}</span>}
-									{showOrg && (
-										<span className="text-fg-muted whitespace-nowrap shrink-0">· {account?.organization}</span>
-									)}
-									{account?.planLabel && (
-										<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded">
-											{account.planLabel}
-										</span>
-									)}
-									{account?.isApi && (
-										<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded">API</span>
-									)}
-								</div>
-								{rows.map((row) => (
-									<span key={row} className="text-fg-3 pl-0.5">
-										{row}
-									</span>
-								))}
-							</div>
-						);
-					})}
+				<div className="flex w-[24rem] max-w-[calc(100vw-3rem)] flex-col gap-1.5">
+					{report.snapshots.map((snap) => (
+						<AccountCard
+							key={`${snap.source}:${snap.accountId ?? "system"}`}
+							snap={snap}
+							account={resolveAccount(snap.source, accounts, snap.accountId)}
+							now={now}
+						/>
+					))}
 					{staleCapturedAt != null && (
-						<span className="text-fg-muted">
-							{t("rateLimits.stale", { time: formatAge(now - staleCapturedAt) })}
-						</span>
+						<span className="text-fg-muted">{t("rateLimits.stale", { time: formatAge(now - staleCapturedAt) })}</span>
 					)}
 				</div>
 			}
@@ -242,13 +310,42 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 				tabIndex={0}
 				aria-label={ariaLabel}
 				data-help-id="header.rateLimits"
-				className={`header-anim flex cursor-pointer select-none items-center gap-1 px-1.5 py-1 rounded-lg border transition-colors ${colorClasses}`}
+				className={`header-anim flex cursor-pointer select-none items-center gap-1.5 px-1.5 py-1 rounded-lg border transition-colors ${colorClasses}`}
 			>
 				<RateLimitIcon className="w-[1.125rem] h-[1.125rem]" />
 				{!compact && (
-					<span className="text-[0.6875rem] font-medium tabular-nums">
-						{percent}%<span className="ml-0.5 text-[0.5625rem] font-normal opacity-70">{t("rateLimits.used")}</span>
-					</span>
+					<>
+						{/* One mini bar per recently active account, top-to-bottom in the
+						    same order as the tooltip cards. Unlimited accounts render a
+						    full success bar (matching the ∞ chip) instead of a fake 0%. */}
+						<span aria-hidden="true" className="flex w-7 shrink-0 flex-col gap-[0.0625rem]">
+							{pillSnapshots.map((snap) => {
+								const snapUnlimited = isUnlimitedRateLimitSnapshot(snap);
+								const snapPercent = snapUnlimited ? 100 : Math.round(worstSnapshotWindow(snap)?.usedPercent ?? 0);
+								const clamped = Math.max(0, Math.min(100, snapPercent));
+								return (
+									<span
+										key={`${snap.source}:${snap.accountId ?? "system"}`}
+										className={`relative block w-full overflow-hidden rounded-full bg-fg/15 ${pillSnapshots.length > 1 ? "h-[0.125rem]" : "h-[0.1875rem]"}`}
+									>
+										<span
+											className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${snapUnlimited ? "bg-success" : severityFill(snapPercent)}`}
+											style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.125rem" : undefined }}
+										/>
+									</span>
+								);
+							})}
+						</span>
+						<span className="text-[0.6875rem] font-medium tabular-nums">
+							{unlimited ? (
+								t("rateLimits.unlimited")
+							) : (
+								<>
+									{percent}%<span className="ml-0.5 text-[0.5625rem] font-normal opacity-70">{t("rateLimits.used")}</span>
+								</>
+							)}
+						</span>
+					</>
 				)}
 			</div>
 		</Tooltip>

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -139,9 +139,9 @@ describe("RateLimitIndicator", () => {
 		renderIndicator();
 		await act(async () => {});
 
-		expect(screen.getByText("0%")).toBeTruthy();
-		expect(screen.getByText("used")).toBeTruthy();
-		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("Codex 0% used");
+		expect(screen.getByText("∞ unlimited")).toBeTruthy();
+		expect(screen.queryByText("0%")).toBeNull();
+		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("Codex ∞ unlimited");
 		expect(screen.getByRole("status").className).toContain("text-fg-3");
 	});
 
@@ -160,8 +160,129 @@ describe("RateLimitIndicator", () => {
 		renderIndicator();
 		await act(async () => {});
 		await userEvent.tab();
-		expect(await screen.findByText(/5h — 5% used/)).toBeTruthy();
-		expect(await screen.findByText(/7d — 42% used/)).toBeTruthy();
+		expect(await screen.findByText("5h")).toBeTruthy();
+		expect(screen.getByText("5% used")).toBeTruthy();
+		expect(screen.getByText("7d")).toBeTruthy();
+		expect(screen.getByText("42% used")).toBeTruthy();
+	});
+
+	it("renders a usage bar per window with severity-colored fill and clamped width", async () => {
+		mockedGet.mockResolvedValue(report(97));
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		await screen.findByText("5h");
+		const tooltip = screen.getByRole("tooltip");
+		const fills = tooltip.querySelectorAll("[class*='rounded-full'] > span");
+		expect(fills.length).toBe(2);
+		expect((fills[0] as HTMLElement).className).toContain("bg-accent");
+		expect((fills[0] as HTMLElement).style.width).toBe("5%");
+		expect((fills[1] as HTMLElement).className).toContain("bg-danger");
+		expect((fills[1] as HTMLElement).style.width).toBe("97%");
+	});
+
+	it("shows an unlimited-credits chip instead of usage bars for unlimited accounts", async () => {
+		mockedGet.mockResolvedValue({
+			generatedAt: Date.now(),
+			snapshots: [
+				{
+					source: "codex",
+					capturedAt: Date.now(),
+					windows: [],
+					creditsBalance: "unlimited",
+					monthlyCredits: null,
+					planType: "enterprise",
+				},
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		// One match in the pill label, one as the tooltip card chip.
+		expect((await screen.findAllByText("∞ unlimited")).length).toBe(2);
+		expect(screen.queryByText(/credits: unlimited/)).toBeNull();
+	});
+
+	it("renders a mini usage bar inside the header pill", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		renderIndicator();
+		await act(async () => {});
+		const pill = screen.getByRole("status");
+		const fill = pill.querySelector('span[aria-hidden="true"] > span > span');
+		expect(fill).toBeTruthy();
+		expect((fill as HTMLElement).style.width).toBe("42%");
+		expect((fill as HTMLElement).className).toContain("bg-accent");
+	});
+
+	it("stacks one pill bar per account with its own severity color", async () => {
+		const now = Date.now();
+		const snapshot = (source: "claude" | "codex", accountId: string, percent: number, activeAt: number) => ({
+			source,
+			accountId,
+			capturedAt: activeAt,
+			activeAt,
+			windows: [{ id: source === "claude" ? "five_hour" : "primary", usedPercent: percent, resetsAt: now + 3_600_000, windowMinutes: 300 }],
+			creditsBalance: null,
+			monthlyCredits: null,
+			planType: null,
+		});
+		mockedGet.mockResolvedValue({
+			generatedAt: now,
+			snapshots: [snapshot("claude", "a", 42, now), snapshot("codex", "b", 85, now - 1_000), snapshot("codex", "c", 97, now - 2_000)],
+		});
+		renderIndicator();
+		await act(async () => {});
+		const pill = screen.getByRole("status");
+		const fills = pill.querySelectorAll('span[aria-hidden="true"] > span > span');
+		expect(fills.length).toBe(3);
+		expect((fills[0] as HTMLElement).style.width).toBe("42%");
+		expect((fills[0] as HTMLElement).className).toContain("bg-accent");
+		expect((fills[1] as HTMLElement).style.width).toBe("85%");
+		expect((fills[1] as HTMLElement).className).toContain("bg-warning");
+		expect((fills[2] as HTMLElement).style.width).toBe("97%");
+		expect((fills[2] as HTMLElement).className).toContain("bg-danger");
+		// The headline number still tracks the most recently active account.
+		expect(screen.getByText("42%")).toBeTruthy();
+	});
+
+	it("renders an unlimited account's pill bar as a full success line and caps bars at four", async () => {
+		const now = Date.now();
+		const snapshot = (accountId: string, percent: number) => ({
+			source: "codex" as const,
+			accountId,
+			capturedAt: now,
+			activeAt: now,
+			windows: [{ id: "primary", usedPercent: percent, resetsAt: now + 3_600_000, windowMinutes: 300 }],
+			creditsBalance: null,
+			monthlyCredits: null,
+			planType: null,
+		});
+		mockedGet.mockResolvedValue({
+			generatedAt: now,
+			snapshots: [
+				{
+					source: "codex",
+					accountId: "unl",
+					capturedAt: now,
+					activeAt: now,
+					windows: [],
+					creditsBalance: "unlimited",
+					monthlyCredits: null,
+					planType: "enterprise",
+				},
+				snapshot("a", 10),
+				snapshot("b", 20),
+				snapshot("c", 30),
+				snapshot("d", 40),
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+		const pill = screen.getByRole("status");
+		const fills = pill.querySelectorAll('span[aria-hidden="true"] > span > span');
+		expect(fills.length).toBe(4);
+		expect((fills[0] as HTMLElement).style.width).toBe("100%");
+		expect((fills[0] as HTMLElement).className).toContain("bg-success");
 	});
 
 	it("escalates to the warning token at ≥80%", async () => {

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -110,6 +110,7 @@ const dashboard = {
 	"rateLimits.percentUsed": "{percent}% used",
 	"rateLimits.resetsIn": "resets in {time}",
 	"rateLimits.credits": "credits: {balance}",
+	"rateLimits.unlimited": "∞ unlimited",
 	"rateLimits.monthlyLabel": "monthly credits",
 	"rateLimits.monthlyUsage": "{used} / {limit} used · {remaining}% left",
 	"rateLimits.stale": "Data from {time} ago — refreshes while an agent session is active",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -110,6 +110,7 @@ const dashboard = {
 	"rateLimits.percentUsed": "{percent}% usado",
 	"rateLimits.resetsIn": "se restablece en {time}",
 	"rateLimits.credits": "créditos: {balance}",
+	"rateLimits.unlimited": "∞ ilimitado",
 	"rateLimits.monthlyLabel": "créditos mensuales",
 	"rateLimits.monthlyUsage": "{used} / {limit} usados · {remaining}% restantes",
 	"rateLimits.stale": "Datos de hace {time} — se actualizan mientras hay una sesión de agente activa",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -118,6 +118,7 @@ const dashboard = {
 	"rateLimits.percentUsed": "{percent}% использовано",
 	"rateLimits.resetsIn": "сброс через {time}",
 	"rateLimits.credits": "кредиты: {balance}",
+	"rateLimits.unlimited": "∞ безлимит",
 	"rateLimits.monthlyLabel": "месячные кредиты",
 	"rateLimits.monthlyUsage": "использовано {used} / {limit} · осталось {remaining}%",
 	"rateLimits.stale": "Данные {time} назад — обновляются, пока активна сессия агента",


### PR DESCRIPTION
Hey, Claude here — the AI assistant that built this branch.

Redesigns the agent rate-limit (quota) surface in the global header from a plain-text hover tooltip into a proper quota dashboard.

## What changed

**Hover panel** — now one card per recently active Claude/Codex account:
- Provider + account email/workspace, plan badge (Max 5x, Enterprise, …).
- One horizontal usage bar per limit window (5h / 7d / monthly credits) with a reset countdown and `N% used`.
- Severity-colored fill: accent < 80% → warning ≥ 80% → danger ≥ 95%.
- Unlimited-credit accounts show an `∞ unlimited` chip instead of fake usage rows.

**Header pill** — stacks one mini usage bar per account (up to 4), top-to-bottom in the same order as the tooltip cards, each colored by its own severity, so the state of every account is visible at a glance without hovering. Unlimited accounts now read `∞ unlimited` with a full green line instead of a misleading `0% used`.

No backend changes — all data already flowed through `getAgentRateLimits` + the `rpc:agentRateLimitsUpdated` push. Adds a `rateLimits.unlimited` i18n key across en/ru/es.

## Notes
- All colors use semantic design tokens (no hardcoded hex).
- Browser-QA'd in both dark and light themes with three real accounts; console clean.
- `bun run lint` and full `bun run test` green; `RateLimitIndicator` tests extended to 21 cases (usage bars, stacked pill bars, 4-bar cap, unlimited rendering).
