### PR TITLE
Suppress merge notifications for manually completed tasks

### DIFF
--- a/change-logs/2026/07/22/fix-manual-merge-notification.md
+++ b/change-logs/2026/07/22/fix-manual-merge-notification.md
@@ -1,0 +1,1 @@
+Tasks marked “I’ll complete it myself” no longer show a merge notification when their branch is detected as merged. The global setting that disables completion suggestions still shows its informational merge toast.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -8862,9 +8862,9 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 	});
 
 	it.each([
-		["manual task flag", { manualCompletion: true }, undefined],
-		["global setting", {}, { suggestCompletingTasksAfterMerge: false }],
-	])("emits a notice-only merge event for %s", async (_name, taskOverrides, settingsOverride) => {
+		["manual task flag", { manualCompletion: true }, undefined, false],
+		["global setting", {}, { suggestCompletingTasksAfterMerge: false }, true],
+	])("emits the expected notice-only merge event for %s", async (_name, taskOverrides, settingsOverride, shouldNotify) => {
 		const project = makeProject();
 		const task = makeTask({
 			status: "review-by-user",
@@ -8895,7 +8895,7 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		expect(push).toHaveBeenCalledWith("branchMerged", expect.objectContaining({
 			taskId: task.id,
 			shouldPrompt: false,
-			shouldNotify: true,
+			shouldNotify,
 		}));
 		expect(data.updateTask).not.toHaveBeenCalled();
 	});
@@ -9509,7 +9509,7 @@ describe("prepareMergeCompletionPrompt (force re-check)", () => {
 			fingerprint: FINGERPRINT,
 		});
 
-		expect(first).toEqual({ shouldPrompt: false, shouldNotify: true, fingerprint: FINGERPRINT });
+		expect(first).toEqual({ shouldPrompt: false, shouldNotify: false, fingerprint: FINGERPRINT });
 		expect(second).toEqual({ shouldPrompt: false, shouldNotify: false, fingerprint: FINGERPRINT });
 		expect(data.updateTask).not.toHaveBeenCalled();
 	});

--- a/src/bun/lifecycle/__tests__/machine.test.ts
+++ b/src/bun/lifecycle/__tests__/machine.test.ts
@@ -90,7 +90,7 @@ describe("task lifecycle transition table", () => {
 		expect(result.effects).toEqual([]);
 	});
 
-	it("emits a notice without persisting a merge prompt when completion is manual", () => {
+	it("reserves without persisting a merge prompt when completion is manual", () => {
 		const current = state("review-by-user", {
 			facts: {
 				hasWorktree: true,
@@ -114,7 +114,24 @@ describe("task lifecycle transition table", () => {
 		expect(result.effects[1]).toMatchObject({
 			type: "push",
 			message: "branchMerged",
-			payload: { noticeOnly: true },
+			payload: { noticeOnly: true, shouldNotify: false },
+		});
+	});
+
+	it("keeps the informational notice when global merge suggestions are disabled", () => {
+		const result = transition(state("review-by-user"), {
+			type: "mergeDetected",
+			branchName: "refactor/lifecycle",
+			fingerprint: "v1:refactor/lifecycle:abc123",
+			precise: true,
+			detectedAt: "2026-07-21T12:00:00.000Z",
+			suggestCompletion: false,
+		});
+
+		expect(result.effects[1]).toMatchObject({
+			type: "push",
+			message: "branchMerged",
+			payload: { noticeOnly: true, shouldNotify: true },
 		});
 	});
 

--- a/src/bun/lifecycle/activities.ts
+++ b/src/bun/lifecycle/activities.ts
@@ -110,13 +110,15 @@ export async function prepareMergeCompletionPrompt(params: { taskId: string; pro
 		suggestCompletion,
 		force: params.force === true,
 	});
-	const noticeOnly = updated.manualCompletion === true || !suggestCompletion;
+	const manualCompletion = updated.manualCompletion === true;
+	const noticeOnly = manualCompletion || !suggestCompletion;
 	if (noticeOnly) {
 		const reservation = lifecycleActorRuntime(task.id).mergePromptReservation;
 		return {
 			shouldPrompt: false,
 			fingerprint: fingerprint.fingerprint,
-			shouldNotify: reservation !== previousReservation
+			shouldNotify: !manualCompletion
+				&& reservation !== previousReservation
 				&& reservation?.fingerprint === fingerprint.fingerprint
 				&& reservation.reservedAt === Date.parse(promptedAt),
 		};

--- a/src/bun/lifecycle/effects.ts
+++ b/src/bun/lifecycle/effects.ts
@@ -31,6 +31,7 @@ type LifecyclePushEffect = (
 		payload: {
 			finding: Extract<LifecycleEvent, { type: "mergeDetected" }>;
 			noticeOnly: boolean;
+			shouldNotify: boolean;
 		};
 	}
 	| {

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -517,7 +517,7 @@ function pushEffect(effect: Extract<LifecycleEffect, { type: "push" }>, ctx: Lif
 			push("taskPreparationFailed", preparationFailurePayload(ctx, effect));
 			return;
 		case "branchMerged": {
-			const { finding, noticeOnly } = effect.payload;
+			const { finding, noticeOnly, shouldNotify } = effect.payload;
 			const payload: BunMessagePayload<"branchMerged"> = {
 				taskId: ctx.sourceTask.id,
 				projectId: ctx.project.id,
@@ -525,7 +525,7 @@ function pushEffect(effect: Extract<LifecycleEffect, { type: "push" }>, ctx: Lif
 				branchName: finding.branchName,
 				fingerprint: finding.fingerprint,
 				subject: buildTaskDialogSubject(ctx.sourceTask, ctx.project),
-				...(noticeOnly ? { shouldPrompt: false, shouldNotify: true } : {}),
+				...(noticeOnly ? { shouldPrompt: false, shouldNotify } : {}),
 			};
 			push("branchMerged", payload);
 			return;

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -496,7 +496,8 @@ export function transition(state: LifecycleState, event: LifecycleEvent): Transi
 		}
 		case "mergeDetected": {
 			if (!MERGE_ELIGIBLE_STATUSES.has(state.column.status) || !state.facts.hasWorktree) return unchanged(state);
-			const noticeOnly = state.facts.manualCompletion === true || !event.suggestCompletion;
+			const manualCompletion = state.facts.manualCompletion === true;
+			const noticeOnly = manualCompletion || !event.suggestCompletion;
 			const blocked = noticeOnly
 				? mergeReservationBlocked(state, event.fingerprint, event.detectedAt)
 				: mergePromptBlocked(state, event.fingerprint, event.precise, event.detectedAt);
@@ -536,7 +537,7 @@ export function transition(state: LifecycleState, event: LifecycleEvent): Transi
 					effect({
 						type: "push",
 						message: "branchMerged",
-						payload: { finding: event, noticeOnly },
+						payload: { finding: event, noticeOnly, shouldNotify: noticeOnly && !manualCompletion },
 					}),
 				],
 			};


### PR DESCRIPTION
## Summary

- Suppress the merged-branch toast for tasks marked “I’ll complete it myself”.
- Keep the informational toast when the global merge-completion suggestion is disabled.
- Add lifecycle and poller coverage for both behaviors.

## Tests

- `bunx vitest run --config vitest.config.bun.ts src/bun/lifecycle/__tests__/machine.test.ts src/bun/__tests__/rpc-handlers.test.ts`
- `bunx vitest run src/mainview/utils/__tests__/offerMergeCompletion.test.ts src/mainview/__tests__/App.test.tsx src/mainview/components/__tests__/TaskInfoPanel.test.tsx`
- `bun run lint`