### PR TITLE
Keep every recently-used account in the rate-limit panel

### DIFF
--- a/change-logs/2026/07/22/fix-quota-panel-all-accounts.md
+++ b/change-logs/2026/07/22/fix-quota-panel-all-accounts.md
@@ -1,0 +1,3 @@
+Short: See every account's quota for a week
+
+The agent rate-limit panel now keeps every Claude/Codex account used in the last 7 days instead of dropping them after a day, and a managed account no longer overwrites another's data in the shared dump — so switching accounts stops making earlier ones vanish. Each account card shows a "captured X ago" note (highlighted when stale) so you can tell how fresh its rate-limit reading is.

--- a/decisions/155-rate-limit-per-account-dump-isolation.md
+++ b/decisions/155-rate-limit-per-account-dump-isolation.md
@@ -1,0 +1,49 @@
+# 155 — Rate-limit dumps: isolate managed accounts from the shared claude.json
+
+## Context
+
+The agent rate-limit panel kept losing Claude accounts: an account would appear,
+then vanish the moment another Claude session ran. Users with several configured
+logins could only ever see one or two at a time.
+
+## Investigation
+
+`dev3 statusline` (`src/cli/commands/statusline.ts`, `dumpPayload`) wrote the
+payload to the shared `~/.dev3.0/data/rate-limits/claude.json` on **every**
+refresh, plus a per-account file only when a managed account id env was set.
+`claude.json` is a single slot keyed by whatever `accountId` it last carried, so
+a managed session (or the system login) writing it clobbered the previous
+account's data. The monitor's 24h activity window (`RATE_LIMIT_ACTIVITY_WINDOW_MS`)
+then dropped anything not seen in a day. Confirmed on disk: `claude.json` and the
+one per-account file both held the same active-session `accountId`, while other
+recently-used accounts had no surviving record.
+
+## Decision
+
+- `claudeDumpFilePaths(accountId)` (exported, unit-tested) now routes writes:
+  a managed account writes **only** its per-account file
+  (`rate-limits/claude/<id>.json`); the system login (no managed id) writes
+  **only** `claude.json`. No session clobbers another's slot.
+- `RATE_LIMIT_ACTIVITY_WINDOW_MS` widened 24h → 7 days (`src/shared/rate-limits.ts`),
+  matching the 7-day limit windows, so every account used within a week stays.
+- The panel shows a per-account "captured {time} ago" note (warning tint past
+  `STALE_AFTER_MS`) so a reading from days ago never reads as live
+  (`RateLimitIndicator.tsx`, `CapturedNote`).
+
+## Risks
+
+- An N-2 dev3 build reading `claude.json` now sees only the system login, not
+  managed accounts (managed multi-account limits are a recent feature; degrades
+  gracefully). Additive on disk — no rename/move/delete, honouring the frozen
+  `~/.dev3.0/` layout invariants.
+- A stale `claude.json` left by an older build may still carry a managed
+  `accountId`; the monitor dedups it against the per-account file and it
+  self-heals once the system login next refreshes.
+
+## Alternatives considered
+
+- Keep writing `claude.json` for all sessions and dedup harder in the monitor —
+  cannot recover data already overwritten in the single slot.
+- Embed account identity from Claude's statusLine payload — the payload does not
+  reliably carry a stable managed-account id; the env-provided id is the only
+  distinguisher.

--- a/src/cli/__tests__/statusline.test.ts
+++ b/src/cli/__tests__/statusline.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveOriginalStatusLine } from "../commands/statusline";
+import { claudeDumpFilePaths, resolveOriginalStatusLine } from "../commands/statusline";
 
 let tmp: string;
 let projectDir: string;
@@ -70,5 +70,19 @@ describe("resolveOriginalStatusLine", () => {
 	it("works with a null projectDir (user settings only)", () => {
 		writeSettings(home, { type: "command", command: "echo user" });
 		expect(resolveOriginalStatusLine(null, home)).toEqual({ command: "echo user" });
+	});
+});
+
+describe("claudeDumpFilePaths", () => {
+	const base = "/base";
+
+	it("writes the system login (no managed id) to the shared claude.json", () => {
+		expect(claudeDumpFilePaths(null, base)).toEqual([join(base, "claude.json")]);
+	});
+
+	it("writes a managed account to its own per-account file only (never claude.json)", () => {
+		const paths = claudeDumpFilePaths("acc-123", base);
+		expect(paths).toEqual([join(base, "claude", "acc-123.json")]);
+		expect(paths).not.toContain(join(base, "claude.json"));
 	});
 });

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -97,19 +97,32 @@ function managedAccountId(): string | null {
 	return value && SAFE_ACCOUNT_ID.test(value) ? value : null;
 }
 
+/**
+ * Where a statusLine dump for `accountId` is written. A managed account writes
+ * ONLY its own per-account file; the system login (no managed id) writes the
+ * shared claude.json. Keeping them apart stops a managed session from clobbering
+ * the system login's slot in claude.json — the cause of accounts vanishing from
+ * the rate-limit panel the moment another account ran.
+ */
+export function claudeDumpFilePaths(
+	accountId: string | null,
+	baseDir: string = RATE_LIMITS_DIR,
+): string[] {
+	if (accountId) return [join(baseDir, "claude", `${accountId}.json`)];
+	return [join(baseDir, "claude.json")];
+}
+
 function dumpPayload(raw: string): void {
 	try {
 		const accountId = managedAccountId();
 		const capturedAt = Date.now();
 		const serialized = JSON.stringify({ capturedAt, accountId, payload: JSON.parse(raw) });
-		mkdirSync(dirname(CLAUDE_RATE_LIMIT_DUMP_PATH), { recursive: true });
-		// Single small write; the monitor tolerates a torn read by keeping the
-		// previous snapshot (deliberately no tmp+rename — see the on-disk layout
-		// invariants about renames under ~/.dev3.0/).
-		writeFileSync(CLAUDE_RATE_LIMIT_DUMP_PATH, serialized);
-		if (accountId) {
-			mkdirSync(CLAUDE_ACCOUNT_RATE_LIMITS_DIR, { recursive: true });
-			writeFileSync(join(CLAUDE_ACCOUNT_RATE_LIMITS_DIR, `${accountId}.json`), serialized);
+		for (const target of claudeDumpFilePaths(accountId)) {
+			// Single small write; the monitor tolerates a torn read by keeping the
+			// previous snapshot (deliberately no tmp+rename — see the on-disk layout
+			// invariants about renames under ~/.dev3.0/).
+			mkdirSync(dirname(target), { recursive: true });
+			writeFileSync(target, serialized);
 		}
 	} catch {
 		// disk/parse trouble must never break the visible statusLine

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -204,7 +204,26 @@ function AccountCard({
 			{snap.creditsBalance != null && !unlimited && (
 				<span className="text-fg-3">{t("rateLimits.credits", { balance: snap.creditsBalance })}</span>
 			)}
+			<CapturedNote capturedAt={snap.capturedAt} now={now} />
 		</div>
+	);
+}
+
+/**
+ * Per-card provenance line: how long ago this account's rate-limit reading was
+ * captured. Data is only refreshed while a session for that account is active,
+ * so anything beyond a few minutes may be stale — flagged in the warning tint
+ * once past STALE_AFTER_MS so a reading from days ago never reads as live.
+ */
+function CapturedNote({ capturedAt, now }: { capturedAt: number; now: number }) {
+	const t = useT();
+	const age = Math.max(0, now - capturedAt);
+	const stale = age > STALE_AFTER_MS;
+	const label = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
+	return (
+		<span className={`flex items-center gap-1 text-[0.625rem] ${stale ? "text-warning" : "text-fg-muted"}`}>
+			{label}
+		</span>
 	);
 }
 
@@ -260,13 +279,6 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const danger = percent >= RATE_LIMIT_DANGER_PERCENT;
 	const warn = !danger && percent >= RATE_LIMIT_WARN_PERCENT;
 
-	let staleCapturedAt: number | null = null;
-	for (const snap of report.snapshots) {
-		if (now - snap.capturedAt > STALE_AFTER_MS && (staleCapturedAt == null || snap.capturedAt < staleCapturedAt)) {
-			staleCapturedAt = snap.capturedAt;
-		}
-	}
-
 	const latestReset = formatResetDelta(latestWindow?.resetsAt ?? null, now);
 	const latestLabel = latestWindow
 		? latestWindow.id === "monthly_credits"
@@ -299,9 +311,6 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 							now={now}
 						/>
 					))}
-					{staleCapturedAt != null && (
-						<span className="text-fg-muted">{t("rateLimits.stale", { time: formatAge(now - staleCapturedAt) })}</span>
-					)}
 				</div>
 			}
 		>

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -214,6 +214,38 @@ describe("RateLimitIndicator", () => {
 		expect((fill as HTMLElement).className).toContain("bg-accent");
 	});
 
+	it("shows a per-account 'captured just now' note for a fresh reading", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		expect(await screen.findByText("captured just now")).toBeTruthy();
+	});
+
+	it("flags a stale reading with its age and the warning tint", async () => {
+		const now = Date.now();
+		mockedGet.mockResolvedValue({
+			generatedAt: now,
+			snapshots: [
+				{
+					source: "claude",
+					accountId: "old",
+					capturedAt: now - 20 * 60_000,
+					activeAt: now - 20 * 60_000,
+					windows: [{ id: "seven_day", usedPercent: 30, resetsAt: now + 86_400_000, windowMinutes: 10080 }],
+					creditsBalance: null,
+					monthlyCredits: null,
+					planType: null,
+				},
+			],
+		});
+		renderIndicator();
+		await act(async () => {});
+		await userEvent.tab();
+		const note = await screen.findByText("captured 20m ago");
+		expect(note.className).toContain("text-warning");
+	});
+
 	it("stacks one pill bar per account with its own severity color", async () => {
 		const now = Date.now();
 		const snapshot = (source: "claude" | "codex", accountId: string, percent: number, activeAt: number) => ({

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -113,7 +113,8 @@ const dashboard = {
 	"rateLimits.unlimited": "∞ unlimited",
 	"rateLimits.monthlyLabel": "monthly credits",
 	"rateLimits.monthlyUsage": "{used} / {limit} used · {remaining}% left",
-	"rateLimits.stale": "Data from {time} ago — refreshes while an agent session is active",
+	"rateLimits.captured": "captured {time} ago",
+	"rateLimits.capturedNow": "captured just now",
 
 	// Remote Access QR Modal
 	"remote.title": "Remote Access",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -113,7 +113,8 @@ const dashboard = {
 	"rateLimits.unlimited": "∞ ilimitado",
 	"rateLimits.monthlyLabel": "créditos mensuales",
 	"rateLimits.monthlyUsage": "{used} / {limit} usados · {remaining}% restantes",
-	"rateLimits.stale": "Datos de hace {time} — se actualizan mientras hay una sesión de agente activa",
+	"rateLimits.captured": "capturado hace {time}",
+	"rateLimits.capturedNow": "capturado ahora mismo",
 
 	// Remote Access QR Modal
 	"remote.title": "Acceso remoto",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -121,7 +121,8 @@ const dashboard = {
 	"rateLimits.unlimited": "∞ безлимит",
 	"rateLimits.monthlyLabel": "месячные кредиты",
 	"rateLimits.monthlyUsage": "использовано {used} / {limit} · осталось {remaining}%",
-	"rateLimits.stale": "Данные {time} назад — обновляются, пока активна сессия агента",
+	"rateLimits.captured": "снято {time} назад",
+	"rateLimits.capturedNow": "снято только что",
 
 	// Remote Access QR Modal
 	"remote.title": "Удалённый доступ",

--- a/src/shared/rate-limits.ts
+++ b/src/shared/rate-limits.ts
@@ -67,8 +67,11 @@ export const RATE_LIMIT_WARN_PERCENT = 80;
 /** Usage percentage at which the indicator/segment escalates to danger. */
 export const RATE_LIMIT_DANGER_PERCENT = 95;
 
-/** Account activity remains visible for one day after its last local signal. */
-export const RATE_LIMIT_ACTIVITY_WINDOW_MS = 24 * 60 * 60 * 1000;
+/** Account activity remains visible for a week after its last local signal —
+ *  Claude/Codex limit windows run up to 7 days, so every account used within
+ *  that span stays in the panel (the per-account "captured" note flags stale
+ *  readings). */
+export const RATE_LIMIT_ACTIVITY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function rateLimitActivityAt(snapshot: AgentRateLimitSnapshot): number {
 	return snapshot.activeAt ?? snapshot.capturedAt;


### PR DESCRIPTION
Hey, Claude here (the AI assistant on this branch) — follow-up to the quota-panel redesign (#1064).

After using it, one issue surfaced: the panel showed only one or two accounts at a time. Switching which Claude account was active made previously-seen ones disappear, and there was no way to tell how fresh a reading was.

## Root cause
`dev3 statusline` wrote every session's dump to the shared `~/.dev3.0/data/rate-limits/claude.json` — a single slot keyed by whatever `accountId` last wrote it. So a managed session (or the system login) clobbered the previous account's data. The 24h activity window then dropped anything not seen in a day.

## Fix
- **Per-account dump isolation:** a managed Claude account now writes only its own per-account file; the system login writes `claude.json`. No session clobbers another's slot. (`claudeDumpFilePaths`, unit-tested.)
- **7-day activity window** (was 24h), matching the weekly limit windows — every account used within the last week stays in the panel. Applies to both Claude per-account dumps and Codex rollouts.
- **Per-account "captured X ago" note** on each card, tinted warning once past the staleness threshold, so a reading from days ago never reads as live. Replaces the single global stale footer.

## Notes
- Additive on disk — no rename/move/delete under `~/.dev3.0/` (frozen-layout invariants respected). Details in `decisions/155-rate-limit-per-account-dump-isolation.md`.
- Semantic tokens only; browser-QA'd with three real accounts (two Claude coexisting + Codex), console clean.
- `bun run lint` + full `bun run test` green.
