### PR TITLE
Show per-account usage rings in the launch account picker

### DIFF
--- a/change-logs/2026/07/22/feature-account-picker-usage-rings.md
+++ b/change-logs/2026/07/22/feature-account-picker-usage-rings.md
@@ -1,0 +1,3 @@
+Short: See account quota before spawning
+
+The "Account for this launch" picker (Spawn Agent, Launch Variants, Bug Hunters, and the Settings default switcher) now shows each account's rate-limit state at a glance: the radio dot became a severity-colored usage ring with the worst-window percent next to it, a full green ring marks unlimited accounts, and hovering a row reveals the full quota card with per-window bars, reset countdowns, and the "captured X ago" note. No more spawning agents on a nearly exhausted account by accident.

--- a/src/mainview/components/AgentAccountIndicator.tsx
+++ b/src/mainview/components/AgentAccountIndicator.tsx
@@ -9,10 +9,19 @@ import type {
 } from "../../shared/agent-accounts";
 import { shortCodexWorkspaceId } from "../../shared/agent-accounts";
 import type { CodingAgent } from "../../shared/types";
+import type { AgentRateLimitSnapshot, AgentRateLimitsReport } from "../../shared/rate-limits";
+import {
+	RATE_LIMIT_DANGER_PERCENT,
+	RATE_LIMIT_WARN_PERCENT,
+	isUnlimitedRateLimitSnapshot,
+	worstSnapshotWindow,
+} from "../../shared/rate-limits";
 import { api } from "../rpc";
 import { toast } from "../toast";
 import { useT } from "../i18n";
 import { useEscapeKey } from "../hooks/useEscapeKey";
+import Tooltip from "./Tooltip";
+import { AccountCard, resolveAccount, type AccountLine } from "./rate-limit-ui";
 
 /** Fired on window after any account mutation (switch from this popover,
  *  add/remove/switch in Settings → Agent Accounts), so every mounted listener
@@ -52,6 +61,86 @@ function useAgentAccountsState(enabled: boolean): AgentAccountsState | null {
 	return enabled ? state : null;
 }
 
+/** Rate-limit report, fetched lazily (popover open) + refreshed by push. */
+function useAgentRateLimits(enabled: boolean): AgentRateLimitsReport | null {
+	const [report, setReport] = useState<AgentRateLimitsReport | null>(null);
+	useEffect(() => {
+		if (!enabled) return;
+		// Promise.resolve wrapper also absorbs a synchronously-missing RPC method
+		// (plain-object api mocks in tests); rows just render without usage.
+		Promise.resolve()
+			.then(() => api.request.getAgentRateLimits())
+			.then(setReport)
+			.catch(() => {});
+		function onUpdate(e: Event) {
+			setReport((e as CustomEvent).detail as AgentRateLimitsReport);
+		}
+		window.addEventListener("rpc:agentRateLimitsUpdated", onUpdate);
+		return () => window.removeEventListener("rpc:agentRateLimitsUpdated", onUpdate);
+	}, [enabled]);
+	return enabled ? report : null;
+}
+
+/** One row's rate-limit reading, joined from the report by source + account. */
+interface RowUsage {
+	/** null = OAuth account with no reading in the 7-day activity window. */
+	snap: AgentRateLimitSnapshot | null;
+	/** Identity line for the tooltip card header. */
+	account: AccountLine | null;
+	state: "used" | "unlimited" | "none";
+	/** Rounded worst-window percent; 0 for unlimited/none. */
+	percent: number;
+}
+
+function ringSeverityText(percent: number): string {
+	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
+	return "text-accent";
+}
+
+/**
+ * Circular usage gauge that doubles as the row's selection mark (variant B of
+ * the picker design exploration): the arc shows the worst rate-limit window,
+ * a full success ring means unlimited, a bare track means no recent reading,
+ * and the filled center dot preserves the radio "selected" semantics.
+ */
+function UsageRing({ usage, isActive }: { usage: RowUsage | null; isActive: boolean }) {
+	const t = useT();
+	const radius = 6;
+	const circumference = 2 * Math.PI * radius;
+	const state = usage?.state ?? "none";
+	const percent = usage?.percent ?? 0;
+	const arc =
+		state === "unlimited" ? circumference : state === "used" ? (Math.max(0, Math.min(100, percent)) / 100) * circumference : 0;
+	const colorClass = state === "unlimited" ? "text-success" : ringSeverityText(percent);
+	const label =
+		state === "unlimited"
+			? t("rateLimits.unlimited")
+			: state === "used"
+				? t("rateLimits.percentUsed", { percent })
+				: t("rateLimits.noRecentData");
+	return (
+		<svg viewBox="0 0 16 16" role="img" aria-label={label} className="mt-0.5 h-4 w-4 shrink-0">
+			<circle cx="8" cy="8" r={radius} fill="none" strokeWidth="2" className="text-fg/15" stroke="currentColor" />
+			{arc > 0 && (
+				<circle
+					cx="8"
+					cy="8"
+					r={radius}
+					fill="none"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeDasharray={`${arc} ${circumference}`}
+					transform="rotate(-90 8 8)"
+					className={colorClass}
+					stroke="currentColor"
+				/>
+			)}
+			{isActive && <circle cx="8" cy="8" r="3" className="text-accent" fill="currentColor" />}
+		</svg>
+	);
+}
+
 function identityBadge(identity: AgentAccountIdentity | null): string | null {
 	return identity?.planLabel ?? null;
 }
@@ -73,6 +162,9 @@ interface PopoverRow {
 	workspaceLabel: string | null;
 	isApi: boolean;
 	isActive: boolean;
+	/** Rate-limit reading for this account; null while the report is loading
+	 *  or for API profiles (no OAuth limit windows). */
+	usage: RowUsage | null;
 	/** null = row is informational only (codex unmanaged login). */
 	onSelect: (() => void) | null;
 }
@@ -97,6 +189,8 @@ function SwitcherPopover({
 	const menuRef = useRef<HTMLDivElement>(null);
 	const [pos, setPos] = useState({ top: anchor.top, left: anchor.left });
 	const [visible, setVisible] = useState(false);
+	const t = useT();
+	const now = Date.now();
 
 	useEscapeKey(onClose);
 	useEffect(() => {
@@ -140,49 +234,80 @@ function SwitcherPopover({
 				<div className="text-fg-2 text-xs font-semibold uppercase tracking-wider">{title}</div>
 				<p className="text-fg-muted text-[0.6875rem] leading-snug mt-1">{subtitle}</p>
 			</div>
-			{rows.map((row) => (
-				<button
-					key={row.key}
-					type="button"
-					disabled={busy || !row.onSelect || row.isActive}
-					onClick={row.onSelect ?? undefined}
-					className={`w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${
-						row.onSelect && !row.isActive ? "hover:bg-elevated-hover cursor-pointer" : "cursor-default"
-					} disabled:opacity-100`}
-				>
-					<span
-						aria-hidden
-						className={`w-3 h-3 mt-1 rounded-full border-2 shrink-0 ${
-							row.isActive ? "border-accent bg-accent" : "border-fg-muted/50"
-						}`}
-					/>
-					<span className="min-w-0 flex-1">
-						<span className="flex items-center gap-2 min-w-0">
-							<span className="text-fg text-sm truncate flex-1">{row.label}</span>
-							{row.isApi ? (
-								<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
-							) : null}
-							{row.planLabel ? (
-								<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">
-									{row.planLabel}
+			{rows.map((row) => {
+				const selectable = !!row.onSelect && !row.isActive;
+				// Rows stay enabled even when informational/selected so the usage
+				// tooltip keeps working (disabled subtrees swallow hover events);
+				// non-selectable rows simply have no onClick.
+				const button = (
+					<button
+						type="button"
+						disabled={busy}
+						onClick={selectable ? (row.onSelect ?? undefined) : undefined}
+						aria-current={row.isActive || undefined}
+						className={`w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${
+							selectable ? "hover:bg-elevated-hover cursor-pointer" : "cursor-default"
+						} disabled:opacity-100`}
+					>
+						<UsageRing usage={row.usage} isActive={row.isActive} />
+						<span className="min-w-0 flex-1">
+							<span className="flex items-center gap-2 min-w-0">
+								<span className="text-fg text-sm truncate flex-1">{row.label}</span>
+								{row.isApi ? (
+									<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
+								) : null}
+								{row.planLabel ? (
+									<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">
+										{row.planLabel}
+									</span>
+								) : null}
+								{row.usage?.state === "used" ? (
+									<span
+										className={`shrink-0 text-[0.6875rem] font-semibold tabular-nums ${ringSeverityText(row.usage.percent)}`}
+									>
+										{row.usage.percent}%
+									</span>
+								) : row.usage?.state === "unlimited" ? (
+									<span className="shrink-0 text-[0.6875rem] font-semibold text-success">∞</span>
+								) : row.usage ? (
+									<span className="shrink-0 text-[0.6875rem] text-fg-muted">—</span>
+								) : null}
+							</span>
+							{(row.sub && row.sub !== row.label && !row.label.includes(row.sub)) || row.workspaceLabel ? (
+								<span className="mt-1 flex flex-wrap items-center gap-1.5 min-w-0">
+									{row.sub && row.sub !== row.label && !row.label.includes(row.sub) ? (
+										<span className="text-fg-muted text-xs font-mono truncate max-w-full">{row.sub}</span>
+									) : null}
+									{row.workspaceLabel ? (
+										<span className="text-fg-3 text-[0.625rem] px-1 py-px bg-raised rounded max-w-full">
+											{row.workspaceLabel}
+										</span>
+									) : null}
 								</span>
 							) : null}
 						</span>
-						{(row.sub && row.sub !== row.label && !row.label.includes(row.sub)) || row.workspaceLabel ? (
-							<span className="mt-1 flex flex-wrap items-center gap-1.5 min-w-0">
-								{row.sub && row.sub !== row.label && !row.label.includes(row.sub) ? (
-									<span className="text-fg-muted text-xs font-mono truncate max-w-full">{row.sub}</span>
-								) : null}
-								{row.workspaceLabel ? (
-									<span className="text-fg-3 text-[0.625rem] px-1 py-px bg-raised rounded max-w-full">
-										{row.workspaceLabel}
-									</span>
-								) : null}
-							</span>
-						) : null}
+					</button>
+				);
+				return row.usage?.snap ? (
+					<Tooltip
+						key={row.key}
+						layer="popover"
+						placement="right"
+						content={t("rateLimits.tooltipTitle")}
+						detail={
+							<div className="flex w-[19rem] max-w-[calc(100vw-3rem)] flex-col">
+								<AccountCard snap={row.usage.snap} account={row.usage.account} now={now} />
+							</div>
+						}
+					>
+						{button}
+					</Tooltip>
+				) : (
+					<span key={row.key} className="block">
+						{button}
 					</span>
-				</button>
-			))}
+				);
+			})}
 			<div className="border-t border-edge mt-1 pt-1.5 px-3 pb-1">
 				<p className="text-fg-muted text-[0.6875rem] leading-snug">{hint}</p>
 			</div>
@@ -222,6 +347,8 @@ export default function AgentAccountIndicator({
 	const state = useAgentAccountsState(kind !== null);
 	const [anchor, setAnchor] = useState<DOMRect | null>(null);
 	const [busy, setBusy] = useState(false);
+	// Usage rings only matter while the popover is open — fetch lazily then.
+	const report = useAgentRateLimits(anchor !== null);
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const isLocal = !!onSelect;
 
@@ -271,6 +398,19 @@ export default function AgentAccountIndicator({
 		return workspace ? t("settings.accountsWorkspace", { id: workspace }) : null;
 	};
 
+	// Join the rate-limit report to a row's account: null accountId = the
+	// provider's system login. API profiles have no OAuth limit windows.
+	const usageFor = (accountId: string | null, isApi = false): RowUsage | null => {
+		if (!report || isApi) return null;
+		const snap = report.snapshots.find((s) => s.source === kind && (s.accountId ?? null) === accountId) ?? null;
+		if (!snap) return { snap: null, account: null, state: "none", percent: 0 };
+		const account = resolveAccount(kind, state, accountId);
+		if (isUnlimitedRateLimitSnapshot(snap)) return { snap, account, state: "unlimited", percent: 0 };
+		const worst = worstSnapshotWindow(snap);
+		if (!worst) return { snap, account, state: "none", percent: 0 };
+		return { snap, account, state: "used", percent: Math.round(worst.usedPercent) };
+	};
+
 	const rows: PopoverRow[] = [];
 	// System-login row: selectable for BOTH kinds in local mode (codex now has a
 	// real system-login fallback); in the global switcher it stays claude-only
@@ -284,6 +424,7 @@ export default function AgentAccountIndicator({
 			workspaceLabel: workspaceLabel(fallbackIdentity),
 			isApi: false,
 			isActive: effectiveSelectedId === null,
+			usage: usageFor(null),
 			onSelect: isLocal
 				? () => handleSelectLocal(null)
 				: () => handleSelectGlobal("claude", null),
@@ -297,6 +438,7 @@ export default function AgentAccountIndicator({
 			workspaceLabel: workspaceLabel(state.codex.currentIdentity),
 			isApi: false,
 			isActive: true,
+			usage: usageFor(null),
 			onSelect: null,
 		});
 	}
@@ -309,6 +451,7 @@ export default function AgentAccountIndicator({
 			workspaceLabel: workspaceLabel(account.identity),
 			isApi: account.auth === "api",
 			isActive: account.id === effectiveSelectedId,
+			usage: usageFor(account.id, account.auth === "api"),
 			onSelect: isLocal
 				? () => handleSelectLocal(account.id)
 				: () => handleSelectGlobal(kind, account.id),

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { api } from "../rpc";
-import { useLocale, useT } from "../i18n";
+import { useT } from "../i18n";
 import Tooltip from "./Tooltip";
 import { RateLimitIcon } from "./HeaderIcons";
-import type { AgentRateLimitSnapshot, AgentRateLimitsReport, RateLimitSource, RateLimitWindow } from "../../shared/rate-limits";
+import type { AgentRateLimitsReport } from "../../shared/rate-limits";
 import {
 	RATE_LIMIT_DANGER_PERCENT,
 	RATE_LIMIT_WARN_PERCENT,
@@ -15,217 +15,10 @@ import {
 } from "../../shared/rate-limits";
 import type { AgentAccountsState } from "../../shared/agent-accounts";
 import { AGENT_ACCOUNTS_CHANGED_EVENT } from "./AgentAccountIndicator";
-
-/** Data older than this gets a staleness note in the tooltip. */
-const STALE_AFTER_MS = 10 * 60 * 1000;
+import { AccountCard, SOURCE_NAMES, resolveAccount, severityFill } from "./rate-limit-ui";
 
 /** The pill stacks one mini bar per account, capped to keep the header slim. */
 const MAX_PILL_BARS = 4;
-
-const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" };
-
-/** Which account the rate-limit windows for a source are drawn from. */
-interface AccountLine {
-	/** Email / user-set label of the active account (null when identity unknown). */
-	name: string | null;
-	/** Login email, when known — used to collapse the auto-generated
-	 *  "email (workspace)" label into a consistent "email · workspace" row. */
-	email: string | null;
-	/** Organization / workspace name, when known. Disambiguates two accounts that
-	 *  share the same login email but live in different workspaces. */
-	organization: string | null;
-	/** Plan/tier badge (e.g. "Max 5x", "Plus"), when known. */
-	planLabel: string | null;
-	/** Active account is an API/custom-endpoint profile rather than an OAuth login. */
-	isApi: boolean;
-}
-
-/**
- * Resolve the active account behind a source's limits from the account switcher
- * state: the active managed account, else the system/current login identity.
- * The rate-limit windows always reflect whichever account launched the session,
- * so surfacing it answers "whose limit is this?" at a glance.
- */
-function resolveAccount(source: RateLimitSource, state: AgentAccountsState | null, accountId?: string | null): AccountLine | null {
-	if (!state) return null;
-	const kindState = state[source];
-	const active =
-		accountId === undefined
-			? (kindState.accounts.find((a) => a.id === kindState.activeId) ?? null)
-			: accountId
-				? (kindState.accounts.find((a) => a.id === accountId) ?? null)
-				: null;
-	if (active) {
-		return {
-			name: active.label,
-			email: active.auth === "api" ? null : (active.identity?.email ?? null),
-			organization: active.auth === "api" ? null : (active.identity?.organization ?? null),
-			planLabel: active.auth === "api" ? null : (active.identity?.planLabel ?? null),
-			isApi: active.auth === "api",
-		};
-	}
-	// An attributed managed snapshot must never fall back to the default account
-	// when that account was removed or is still loading; that would mislabel the
-	// usage row. Null explicitly means the provider's system login.
-	if (accountId !== undefined && accountId !== null) return null;
-	const fallback = source === "claude" ? state.claude.systemIdentity : state.codex.currentIdentity;
-	if (fallback) {
-		return {
-			name: fallback.email,
-			email: fallback.email,
-			organization: fallback.organization,
-			planLabel: fallback.planLabel,
-			isApi: false,
-		};
-	}
-	return null;
-}
-
-function severityFill(percent: number): string {
-	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "bg-danger";
-	if (percent >= RATE_LIMIT_WARN_PERCENT) return "bg-warning";
-	return "bg-accent";
-}
-
-function severityText(percent: number): string {
-	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
-	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
-	return "text-fg-2";
-}
-
-/** Horizontal usage gauge: track + severity-colored fill, clamped to 0–100. */
-function UsageBar({ percent, className }: { percent: number; className: string }) {
-	const clamped = Math.max(0, Math.min(100, percent));
-	return (
-		<span aria-hidden="true" className={`relative block overflow-hidden rounded-full bg-fg/10 ${className}`}>
-			<span
-				className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${severityFill(percent)}`}
-				style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.3rem" : undefined }}
-			/>
-		</span>
-	);
-}
-
-/** One limit window inside an account card: label + reset + percent over a bar. */
-function WindowBarRow({
-	label,
-	usedPercent,
-	resetsAt,
-	now,
-	detail,
-}: {
-	label: string;
-	usedPercent: number;
-	resetsAt: number | null;
-	now: number;
-	detail?: string;
-}) {
-	const t = useT();
-	const percent = Math.round(usedPercent);
-	const reset = formatResetDelta(resetsAt, now);
-	return (
-		<div className="flex flex-col gap-[0.1875rem]">
-			<div className="flex items-baseline gap-2">
-				<span className="min-w-0 truncate font-medium text-fg-3">{label}</span>
-				{reset && <span className="ml-auto shrink-0 text-fg-muted">{t("rateLimits.resetsIn", { time: reset })}</span>}
-				<span className={`shrink-0 font-medium tabular-nums ${reset ? "" : "ml-auto"} ${severityText(percent)}`}>
-					{t("rateLimits.percentUsed", { percent })}
-				</span>
-			</div>
-			<UsageBar percent={usedPercent} className="h-1.5 w-full" />
-			{detail && <span className="text-fg-muted">{detail}</span>}
-		</div>
-	);
-}
-
-/** One account's quota card: identity header + a bar per limit window. */
-function AccountCard({
-	snap,
-	account,
-	now,
-}: {
-	snap: AgentRateLimitSnapshot;
-	account: AccountLine | null;
-	now: number;
-}) {
-	const t = useT();
-	const [locale] = useLocale();
-	const unlimited = isUnlimitedRateLimitSnapshot(snap);
-	// Collapse the auto-generated "email (workspace)" label into a plain
-	// email so every row reads consistently as "email · workspace" (the
-	// chip carries the workspace). A user-custom label is left untouched.
-	const displayName =
-		account?.email && account.organization && account.name === `${account.email} (${account.organization})`
-			? account.email
-			: (account?.name ?? null);
-	const showOrg =
-		!!account?.organization &&
-		account.organization !== displayName &&
-		!(displayName ?? "").endsWith(`(${account.organization})`);
-
-	const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
-	const monthly = snap.monthlyCredits;
-	// The monthly_credits window mirrors snap.monthlyCredits; the dedicated row
-	// below renders it with its used/limit detail, so skip the duplicate here.
-	const windows = snap.windows.filter((w: RateLimitWindow) => !(w.id === "monthly_credits" && monthly));
-
-	return (
-		<div className="flex flex-col gap-1.5 rounded-md border border-edge bg-raised/65 px-2.5 py-2">
-			<div className="flex items-center gap-1.5">
-				<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
-				{displayName && <span className="min-w-0 truncate text-fg-3">{displayName}</span>}
-				{showOrg && <span className="text-fg-muted whitespace-nowrap shrink-0">· {account?.organization}</span>}
-				{account?.planLabel && (
-					<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">{account.planLabel}</span>
-				)}
-				{account?.isApi && <span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>}
-				{unlimited && (
-					<span className="ml-auto text-success text-[0.625rem] px-1 py-px bg-success/10 rounded shrink-0 font-medium">
-						{t("rateLimits.unlimited")}
-					</span>
-				)}
-			</div>
-			{windows.map((win) => (
-				<WindowBarRow key={win.id} label={windowLabel(win)} usedPercent={win.usedPercent} resetsAt={win.resetsAt} now={now} />
-			))}
-			{monthly && (
-				<WindowBarRow
-					label={t("rateLimits.monthlyLabel")}
-					usedPercent={Math.max(0, 100 - monthly.remainingPercent)}
-					resetsAt={monthly.resetsAt}
-					now={now}
-					detail={t("rateLimits.monthlyUsage", {
-						used: numberFormat.format(monthly.used),
-						limit: numberFormat.format(monthly.limit),
-						remaining: Math.round(monthly.remainingPercent),
-					})}
-				/>
-			)}
-			{snap.creditsBalance != null && !unlimited && (
-				<span className="text-fg-3">{t("rateLimits.credits", { balance: snap.creditsBalance })}</span>
-			)}
-			<CapturedNote capturedAt={snap.capturedAt} now={now} />
-		</div>
-	);
-}
-
-/**
- * Per-card provenance line: how long ago this account's rate-limit reading was
- * captured. Data is only refreshed while a session for that account is active,
- * so anything beyond a few minutes may be stale — flagged in the warning tint
- * once past STALE_AFTER_MS so a reading from days ago never reads as live.
- */
-function CapturedNote({ capturedAt, now }: { capturedAt: number; now: number }) {
-	const t = useT();
-	const age = Math.max(0, now - capturedAt);
-	const stale = age > STALE_AFTER_MS;
-	const label = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
-	return (
-		<span className={`flex items-center gap-1 text-[0.625rem] ${stale ? "text-warning" : "text-fg-muted"}`}>
-			{label}
-		</span>
-	);
-}
 
 /**
  * Ambient agent rate-limit indicator (global header, stateful-indicators zone).
@@ -359,15 +152,6 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 			</div>
 		</Tooltip>
 	);
-}
-
-/** Compact age like "12m" or "3h" for the staleness note. */
-function formatAge(ms: number): string {
-	const mins = Math.round(ms / 60000);
-	if (mins < 60) return `${mins}m`;
-	const hours = Math.floor(mins / 60);
-	if (hours < 24) return `${hours}h`;
-	return `${Math.floor(hours / 24)}d`;
 }
 
 export default RateLimitIndicator;

--- a/src/mainview/components/Tooltip.tsx
+++ b/src/mainview/components/Tooltip.tsx
@@ -54,6 +54,9 @@ interface TooltipProps {
 	/** Widen the detail popup (from the default 22rem to 30rem) for content with
 	 *  long single-line rows — e.g. the rate-limit popup's account/workspace line. */
 	wide?: boolean;
+	/** Stacking tier. "popover" lifts the tooltip above portal popovers
+	 *  (z-[10000], e.g. the account switcher) that outrank the default tier. */
+	layer?: "default" | "popover";
 	placement?: PopoverPlacement;
 	/** Render children without any tooltip (conditional escape hatch). */
 	disabled?: boolean;
@@ -80,7 +83,16 @@ function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
 	};
 }
 
-export default function Tooltip({ content, detail, kbd, wide, placement = "top", disabled, children }: TooltipProps) {
+export default function Tooltip({
+	content,
+	detail,
+	kbd,
+	wide,
+	layer = "default",
+	placement = "top",
+	disabled,
+	children,
+}: TooltipProps) {
 	const [open, setOpen] = useState(false);
 	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 	const anchorRef = useRef<HTMLElement | null>(null);
@@ -199,7 +211,7 @@ export default function Tooltip({ content, detail, kbd, wide, placement = "top",
 							ref={popRef}
 							id={tooltipId}
 							role="tooltip"
-							className={`fixed z-[1200] pointer-events-none bg-overlay border border-edge-active ring-1 ring-black/30 rounded-lg shadow-2xl shadow-black/60 text-xs ${
+							className={`fixed ${layer === "popover" ? "z-[10100]" : "z-[1200]"} pointer-events-none bg-overlay border border-edge-active ring-1 ring-black/30 rounded-lg shadow-2xl shadow-black/60 text-xs ${
 								detail
 									? `px-3 py-2 ${wide ? "max-w-[30rem]" : "max-w-[22rem]"}`
 									: "px-2.5 py-1.5 max-w-[18rem]"

--- a/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
+++ b/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { AgentAccountsState } from "../../../shared/agent-accounts";
+import type { AgentRateLimitSnapshot, AgentRateLimitsReport } from "../../../shared/rate-limits";
 import type { CodingAgent } from "../../../shared/types";
 
 vi.mock("../../rpc", () => ({
@@ -8,6 +9,7 @@ vi.mock("../../rpc", () => ({
 		request: {
 			listAgentAccounts: vi.fn(),
 			setActiveAgentAccount: vi.fn(),
+			getAgentRateLimits: vi.fn(),
 		},
 	},
 }));
@@ -83,10 +85,28 @@ function renderIndicator(
 	);
 }
 
+function makeSnapshot(overrides: Partial<AgentRateLimitSnapshot>): AgentRateLimitSnapshot {
+	return {
+		source: "claude",
+		accountId: null,
+		capturedAt: Date.now(),
+		windows: [],
+		creditsBalance: null,
+		monthlyCredits: null,
+		planType: null,
+		...overrides,
+	};
+}
+
+function makeReport(snapshots: AgentRateLimitSnapshot[]): AgentRateLimitsReport {
+	return { snapshots, generatedAt: Date.now() };
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockedApi.request.listAgentAccounts.mockResolvedValue(makeState());
 	mockedApi.request.setActiveAgentAccount.mockResolvedValue(undefined as any);
+	mockedApi.request.getAgentRateLimits.mockResolvedValue(makeReport([]));
 	mockedConfirm.mockResolvedValue(true);
 });
 
@@ -239,6 +259,105 @@ describe("AgentAccountIndicator", () => {
 		await user.click(trigger);
 		expect(screen.getByText("openrouter.ai")).toBeTruthy();
 		expect(screen.getAllByText("API").length).toBeGreaterThan(0);
+	});
+
+	it("shows per-account usage rings with severity-colored percents", async () => {
+		mockedApi.request.getAgentRateLimits.mockResolvedValue(
+			makeReport([
+				makeSnapshot({
+					accountId: null,
+					windows: [
+						{ id: "five_hour", usedPercent: 34, resetsAt: null, windowMinutes: 300 },
+						{ id: "seven_day", usedPercent: 62, resetsAt: null, windowMinutes: 10080 },
+					],
+				}),
+				makeSnapshot({
+					accountId: "cl-1",
+					windows: [{ id: "seven_day", usedPercent: 97, resetsAt: null, windowMinutes: 10080 }],
+				}),
+			]),
+		);
+		const user = userEvent.setup();
+		renderIndicator(claudeAgent, { value: null, onSelect: vi.fn() });
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+
+		// Worst window wins: 62% (7d) for the system login, colored accent (<80).
+		const okPercent = await screen.findByText("62%");
+		expect(okPercent.className).toContain("text-accent");
+		const dangerPercent = screen.getByText("97%");
+		expect(dangerPercent.className).toContain("text-danger");
+		expect(screen.getByRole("img", { name: "62% used" })).toBeTruthy();
+	});
+
+	it("shows ∞ for an unlimited account and — for one without a reading", async () => {
+		mockedApi.request.getAgentRateLimits.mockResolvedValue(
+			makeReport([makeSnapshot({ accountId: null, creditsBalance: "unlimited" })]),
+		);
+		const user = userEvent.setup();
+		renderIndicator(claudeAgent, { value: null, onSelect: vi.fn() });
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+
+		// System login is unlimited; the managed account has no snapshot at all.
+		expect(await screen.findByText("∞")).toBeTruthy();
+		expect(screen.getByText("—")).toBeTruthy();
+		expect(screen.getByRole("img", { name: "∞ unlimited" })).toBeTruthy();
+		expect(screen.getByRole("img", { name: "no recent usage data" })).toBeTruthy();
+	});
+
+	it("hovering a row shows the quota card tooltip with windows and captured note", async () => {
+		mockedApi.request.getAgentRateLimits.mockResolvedValue(
+			makeReport([
+				makeSnapshot({
+					accountId: null,
+					capturedAt: Date.now() - 20 * 60 * 1000,
+					windows: [{ id: "five_hour", usedPercent: 34, resetsAt: null, windowMinutes: 300 }],
+				}),
+			]),
+		);
+		const user = userEvent.setup();
+		renderIndicator(claudeAgent, { value: null, onSelect: vi.fn() });
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+		await screen.findByText("34%");
+		await user.hover(screen.getByText("System login (~/.claude)"));
+
+		// Tooltip opens after the hover-intent delay with the full quota card.
+		expect(await screen.findByText("5h", undefined, { timeout: 2000 })).toBeTruthy();
+		expect(screen.getByText("captured 20m ago")).toBeTruthy();
+	});
+
+	it("shows a bare ring without percent text for API profiles", async () => {
+		const base = makeState();
+		mockedApi.request.listAgentAccounts.mockResolvedValue(
+			makeState({
+				claude: {
+					...base.claude,
+					accounts: [
+						{
+							id: "api-1",
+							kind: "claude",
+							label: "OpenRouter",
+							identity: null,
+							auth: "api",
+							api: { baseUrl: "https://openrouter.ai/api", model: null, slotModels: {}, hasApiKey: true, envKeys: [] },
+							createdAt: 1,
+						},
+					],
+					activeId: "api-1",
+				},
+			}),
+		);
+		mockedApi.request.getAgentRateLimits.mockResolvedValue(
+			makeReport([makeSnapshot({ accountId: null, windows: [{ id: "five_hour", usedPercent: 34, resetsAt: null, windowMinutes: 300 }] })]),
+		);
+		const user = userEvent.setup();
+		renderIndicator(claudeAgent, { value: "api-1", onSelect: vi.fn() });
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+		await screen.findByText("34%"); // system row has data…
+		expect(screen.queryByText("—")).toBeNull(); // …but the API row shows no dash
 	});
 
 	it("shows the readable Codex workspace name in the account popover", async () => {

--- a/src/mainview/components/rate-limit-ui.tsx
+++ b/src/mainview/components/rate-limit-ui.tsx
@@ -1,0 +1,238 @@
+import { useLocale, useT } from "../i18n";
+import type { AgentRateLimitSnapshot, RateLimitSource, RateLimitWindow } from "../../shared/rate-limits";
+import {
+	RATE_LIMIT_DANGER_PERCENT,
+	RATE_LIMIT_WARN_PERCENT,
+	formatResetDelta,
+	isUnlimitedRateLimitSnapshot,
+	windowLabel,
+} from "../../shared/rate-limits";
+import type { AgentAccountsState } from "../../shared/agent-accounts";
+
+/**
+ * Shared rate-limit presentation pieces, used by the header RateLimitIndicator
+ * (quota panel) and the account switcher popover (per-row usage rings). Lives
+ * in its own module so the two indicators can share without importing each
+ * other (AgentAccountIndicator ↔ RateLimitIndicator would be a cycle).
+ */
+
+/** Data older than this gets a staleness note in the tooltip. */
+export const STALE_AFTER_MS = 10 * 60 * 1000;
+
+export const SOURCE_NAMES: Record<string, string> = { claude: "Claude", codex: "Codex" };
+
+/** Which account the rate-limit windows for a source are drawn from. */
+export interface AccountLine {
+	/** Email / user-set label of the active account (null when identity unknown). */
+	name: string | null;
+	/** Login email, when known — used to collapse the auto-generated
+	 *  "email (workspace)" label into a consistent "email · workspace" row. */
+	email: string | null;
+	/** Organization / workspace name, when known. Disambiguates two accounts that
+	 *  share the same login email but live in different workspaces. */
+	organization: string | null;
+	/** Plan/tier badge (e.g. "Max 5x", "Plus"), when known. */
+	planLabel: string | null;
+	/** Active account is an API/custom-endpoint profile rather than an OAuth login. */
+	isApi: boolean;
+}
+
+/**
+ * Resolve the active account behind a source's limits from the account switcher
+ * state: the active managed account, else the system/current login identity.
+ * The rate-limit windows always reflect whichever account launched the session,
+ * so surfacing it answers "whose limit is this?" at a glance.
+ */
+export function resolveAccount(
+	source: RateLimitSource,
+	state: AgentAccountsState | null,
+	accountId?: string | null,
+): AccountLine | null {
+	if (!state) return null;
+	const kindState = state[source];
+	const active =
+		accountId === undefined
+			? (kindState.accounts.find((a) => a.id === kindState.activeId) ?? null)
+			: accountId
+				? (kindState.accounts.find((a) => a.id === accountId) ?? null)
+				: null;
+	if (active) {
+		return {
+			name: active.label,
+			email: active.auth === "api" ? null : (active.identity?.email ?? null),
+			organization: active.auth === "api" ? null : (active.identity?.organization ?? null),
+			planLabel: active.auth === "api" ? null : (active.identity?.planLabel ?? null),
+			isApi: active.auth === "api",
+		};
+	}
+	// An attributed managed snapshot must never fall back to the default account
+	// when that account was removed or is still loading; that would mislabel the
+	// usage row. Null explicitly means the provider's system login.
+	if (accountId !== undefined && accountId !== null) return null;
+	const fallback = source === "claude" ? state.claude.systemIdentity : state.codex.currentIdentity;
+	if (fallback) {
+		return {
+			name: fallback.email,
+			email: fallback.email,
+			organization: fallback.organization,
+			planLabel: fallback.planLabel,
+			isApi: false,
+		};
+	}
+	return null;
+}
+
+export function severityFill(percent: number): string {
+	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "bg-danger";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "bg-warning";
+	return "bg-accent";
+}
+
+export function severityText(percent: number): string {
+	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
+	return "text-fg-2";
+}
+
+/** Horizontal usage gauge: track + severity-colored fill, clamped to 0–100. */
+export function UsageBar({ percent, className }: { percent: number; className: string }) {
+	const clamped = Math.max(0, Math.min(100, percent));
+	return (
+		<span aria-hidden="true" className={`relative block overflow-hidden rounded-full bg-fg/10 ${className}`}>
+			<span
+				className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${severityFill(percent)}`}
+				style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.3rem" : undefined }}
+			/>
+		</span>
+	);
+}
+
+/** One limit window inside an account card: label + reset + percent over a bar. */
+export function WindowBarRow({
+	label,
+	usedPercent,
+	resetsAt,
+	now,
+	detail,
+}: {
+	label: string;
+	usedPercent: number;
+	resetsAt: number | null;
+	now: number;
+	detail?: string;
+}) {
+	const t = useT();
+	const percent = Math.round(usedPercent);
+	const reset = formatResetDelta(resetsAt, now);
+	return (
+		<div className="flex flex-col gap-[0.1875rem]">
+			<div className="flex items-baseline gap-2">
+				<span className="min-w-0 truncate font-medium text-fg-3">{label}</span>
+				{reset && <span className="ml-auto shrink-0 text-fg-muted">{t("rateLimits.resetsIn", { time: reset })}</span>}
+				<span className={`shrink-0 font-medium tabular-nums ${reset ? "" : "ml-auto"} ${severityText(percent)}`}>
+					{t("rateLimits.percentUsed", { percent })}
+				</span>
+			</div>
+			<UsageBar percent={usedPercent} className="h-1.5 w-full" />
+			{detail && <span className="text-fg-muted">{detail}</span>}
+		</div>
+	);
+}
+
+/** One account's quota card: identity header + a bar per limit window. */
+export function AccountCard({
+	snap,
+	account,
+	now,
+}: {
+	snap: AgentRateLimitSnapshot;
+	account: AccountLine | null;
+	now: number;
+}) {
+	const t = useT();
+	const [locale] = useLocale();
+	const unlimited = isUnlimitedRateLimitSnapshot(snap);
+	// Collapse the auto-generated "email (workspace)" label into a plain
+	// email so every row reads consistently as "email · workspace" (the
+	// chip carries the workspace). A user-custom label is left untouched.
+	const displayName =
+		account?.email && account.organization && account.name === `${account.email} (${account.organization})`
+			? account.email
+			: (account?.name ?? null);
+	const showOrg =
+		!!account?.organization &&
+		account.organization !== displayName &&
+		!(displayName ?? "").endsWith(`(${account.organization})`);
+
+	const numberFormat = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+	const monthly = snap.monthlyCredits;
+	// The monthly_credits window mirrors snap.monthlyCredits; the dedicated row
+	// below renders it with its used/limit detail, so skip the duplicate here.
+	const windows = snap.windows.filter((w: RateLimitWindow) => !(w.id === "monthly_credits" && monthly));
+
+	return (
+		<div className="flex flex-col gap-1.5 rounded-md border border-edge bg-raised/65 px-2.5 py-2">
+			<div className="flex items-center gap-1.5">
+				<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[snap.source] ?? snap.source}</span>
+				{displayName && <span className="min-w-0 truncate text-fg-3">{displayName}</span>}
+				{showOrg && <span className="text-fg-muted whitespace-nowrap shrink-0">· {account?.organization}</span>}
+				{account?.planLabel && (
+					<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">{account.planLabel}</span>
+				)}
+				{account?.isApi && <span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>}
+				{unlimited && (
+					<span className="ml-auto text-success text-[0.625rem] px-1 py-px bg-success/10 rounded shrink-0 font-medium">
+						{t("rateLimits.unlimited")}
+					</span>
+				)}
+			</div>
+			{windows.map((win) => (
+				<WindowBarRow key={win.id} label={windowLabel(win)} usedPercent={win.usedPercent} resetsAt={win.resetsAt} now={now} />
+			))}
+			{monthly && (
+				<WindowBarRow
+					label={t("rateLimits.monthlyLabel")}
+					usedPercent={Math.max(0, 100 - monthly.remainingPercent)}
+					resetsAt={monthly.resetsAt}
+					now={now}
+					detail={t("rateLimits.monthlyUsage", {
+						used: numberFormat.format(monthly.used),
+						limit: numberFormat.format(monthly.limit),
+						remaining: Math.round(monthly.remainingPercent),
+					})}
+				/>
+			)}
+			{snap.creditsBalance != null && !unlimited && (
+				<span className="text-fg-3">{t("rateLimits.credits", { balance: snap.creditsBalance })}</span>
+			)}
+			<CapturedNote capturedAt={snap.capturedAt} now={now} />
+		</div>
+	);
+}
+
+/**
+ * Per-card provenance line: how long ago this account's rate-limit reading was
+ * captured. Data is only refreshed while a session for that account is active,
+ * so anything beyond a few minutes may be stale — flagged in the warning tint
+ * once past STALE_AFTER_MS so a reading from days ago never reads as live.
+ */
+export function CapturedNote({ capturedAt, now }: { capturedAt: number; now: number }) {
+	const t = useT();
+	const age = Math.max(0, now - capturedAt);
+	const stale = age > STALE_AFTER_MS;
+	const label = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
+	return (
+		<span className={`flex items-center gap-1 text-[0.625rem] ${stale ? "text-warning" : "text-fg-muted"}`}>
+			{label}
+		</span>
+	);
+}
+
+/** Compact age like "12m" or "3h" for the staleness note. */
+function formatAge(ms: number): string {
+	const mins = Math.round(ms / 60000);
+	if (mins < 60) return `${mins}m`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h`;
+	return `${Math.floor(hours / 24)}d`;
+}

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -115,6 +115,7 @@ const dashboard = {
 	"rateLimits.monthlyUsage": "{used} / {limit} used · {remaining}% left",
 	"rateLimits.captured": "captured {time} ago",
 	"rateLimits.capturedNow": "captured just now",
+	"rateLimits.noRecentData": "no recent usage data",
 
 	// Remote Access QR Modal
 	"remote.title": "Remote Access",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -115,6 +115,7 @@ const dashboard = {
 	"rateLimits.monthlyUsage": "{used} / {limit} usados · {remaining}% restantes",
 	"rateLimits.captured": "capturado hace {time}",
 	"rateLimits.capturedNow": "capturado ahora mismo",
+	"rateLimits.noRecentData": "sin datos de uso recientes",
 
 	// Remote Access QR Modal
 	"remote.title": "Acceso remoto",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -123,6 +123,7 @@ const dashboard = {
 	"rateLimits.monthlyUsage": "использовано {used} / {limit} · осталось {remaining}%",
 	"rateLimits.captured": "снято {time} назад",
 	"rateLimits.capturedNow": "снято только что",
+	"rateLimits.noRecentData": "нет свежих данных об использовании",
 
 	// Remote Access QR Modal
 	"remote.title": "Удалённый доступ",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

## Summary

The "Account for this launch" popover (Spawn Agent / Launch Variants / Bug Hunters, plus the Settings default switcher) showed account names but nothing about their remaining quota — so it was easy to spawn agents on a nearly exhausted account. This PR implements the "ring gauge" design picked from a mockup exploration:

- The radio dot becomes a small SVG **usage ring** showing the account's worst rate-limit window, colored by the existing severity thresholds (accent < 80%, warning ≥ 80%, danger ≥ 95%), with the percent readout right-aligned in the row.
- **Unlimited** accounts render a full green ring and an `∞` mark; accounts with **no reading** in the 7-day activity window render a bare track and `—`; API profiles show a plain ring with no readout (no OAuth limit windows).
- The filled accent **center dot** preserves the radio "selected" semantics.
- **Hovering a row** opens the full quota card — per-window bars, reset countdowns, and the "captured X ago" staleness note — identical to the header quota panel.

## Implementation notes

- Shared presentation pieces (`AccountCard`, `WindowBarRow`, severity helpers, `resolveAccount`) moved from `RateLimitIndicator.tsx` into a new `rate-limit-ui.tsx` so the header indicator and the picker share one implementation without an import cycle.
- `Tooltip` gains a `layer="popover"` stacking tier (z-10100) so the quota tooltip renders above the z-10000 portal popover.
- Popover rows stay enabled (informational/selected rows just have no `onClick`) because disabled subtrees swallow the hover events the tooltip needs.
- Rate limits are fetched lazily on popover open and refreshed by the `agentRateLimitsUpdated` push.
- UX plan ran through `/ux-principal`: manifest-compliant, no doc updates needed.