### PR TITLE
Slim global header: icon-only sleep toggle (zzz/eye), bar-led rate pill, icon-only Remote

### DIFF
--- a/change-logs/2026/07/22/feature-60-slimmer-header-controls.md
+++ b/change-logs/2026/07/22/feature-60-slimmer-header-controls.md
@@ -1,0 +1,3 @@
+Short: Slimmer top bar controls
+
+The global header got ~125px slimmer: the prevent-sleep toggle is now icon-only with a new metaphor (grey sleeping z's when sleep is allowed, an awake orange eye while the machine is kept awake, plus a mini lock badge when remote access forces it on), the agent rate-limit pill dropped its hourglass icon and leads with the per-account usage bars, and the Remote Access button dropped its text label leaving just the QR icon.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -560,7 +560,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 
 				{/* Prevent-sleep toggle — keeps the machine awake while dev-3.0 runs.
 				    Folded into the kebab bottom sheet on narrow. */}
-				{!isNarrow && <PreventSleepToggle compact={compact} />}
+				{!isNarrow && <PreventSleepToggle />}
 
 				{/* Ambient agent rate-limit indicator — hidden until any limit data exists
 				    (folded into the kebab bottom sheet on narrow). */}
@@ -623,7 +623,6 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 							aria-label={t("header.remoteAccessTooltip")}
 						>
 							<RemoteQRIcon className="w-[1.125rem] h-[1.125rem]" />
-							{!compact && <span className="text-[0.6875rem] font-medium">Remote</span>}
 						</button>
 				</Tooltip>
 				)}
@@ -784,7 +783,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 					    state / popovers / modals keep working (those overlays layer above
 					    the sheet — see the z-index in TmuxSessionManager / GitPullErrorModal). */}
 					<div className="flex flex-wrap items-center gap-1.5 pb-3 mb-1 border-b border-edge/60">
-						<PreventSleepToggle compact={false} />
+						<PreventSleepToggle />
 						<RateLimitIndicator compact={false} />
 						{currentProjectId && !isVirtualProject && (
 							<GitPullButton projectId={currentProjectId} compact={false} />

--- a/src/mainview/components/HeaderIcons.tsx
+++ b/src/mainview/components/HeaderIcons.tsx
@@ -10,11 +10,11 @@ import type { SVGProps } from "react";
  * (the hosting button) is hovered, or while the Remote Access tunnel is active for
  * the QR icon, pure-CSS keyframes in index.css act out the operation the icon
  * triggers — chevrons lunge with a ghost echo, the home
- * prompt types itself, steam rises off the coffee, the lock shackle snaps shut,
+ * prompt types itself, the sleep z's drift upward, the awake eye blinks,
+ * the lock shackle snaps shut,
  * the quick-shell bolt double-flashes, the terminal cursor blinks, the pull /
  * update arrows drop into and launch out of the cloud, the check draws itself,
  * the alert triangle quakes, QR marks scan in sequence, the gauge needle revs,
- * sand drips through the rate-limit hourglass,
  * the octocat bows, the bug twitches its antennae, changelog lines write
  * themselves, kebab dots wave, the wrench ratchets, slider knobs seek a new mix.
  * Idle rendering is pixel-identical to the static icon.
@@ -78,14 +78,24 @@ export function DropdownIcon({ className }: HeaderIconProps) {
 	);
 }
 
-// 05 — No Sleep (coffee, idle): fresh steam curls rise off the cup.
-export function CoffeeIcon({ className }: HeaderIconProps) {
+// 05 — No Sleep (off, sleep allowed): calm z's; on hover they drift upward.
+export function SleepZzzIcon({ className }: HeaderIconProps) {
 	return (
 		<svg {...svgBase(className)}>
-			<path d="M5.5 9.5H16v5.5a4 4 0 0 1-4 4H9.5a4 4 0 0 1-4-4z" />
-			<path d="M16 10.5h1.25a2.5 2.5 0 0 1 0 5H16" />
-			<path d="M9 6.5c0-1 .7-1 .7-2" className="hdr hdr-steam1" />
-			<path d="M12.6 6.5c0-1 .7-1 .7-2" className="hdr hdr-steam2" />
+			<path d="M4 12h6.5l-6.5 8h6.5" className="hdr hdr-z1" />
+			<path d="M14 4h6l-6 8h6" className="hdr hdr-z2" />
+		</svg>
+	);
+}
+
+// 05b — No Sleep (on, machine kept awake): open eye; on hover it blinks.
+export function AwakeEyeIcon({ className }: HeaderIconProps) {
+	return (
+		<svg {...svgBase(className)}>
+			<g className="hdr hdr-eye">
+				<path d="M2.8 12S6.5 5.8 12 5.8 21.2 12 21.2 12 17.5 18.2 12 18.2 2.8 12 2.8 12Z" />
+				<circle cx="12" cy="12" r="3.1" className="hdr hdr-eye-pupil" />
+			</g>
 		</svg>
 	);
 }
@@ -268,23 +278,6 @@ export function SlidersIcon({ className }: HeaderIconProps) {
 			<circle cx="6" cy="15.5" r="2" fill="currentColor" stroke="none" className="hdr hdr-sl1" />
 			<circle cx="12" cy="8" r="2" fill="currentColor" stroke="none" className="hdr hdr-sl2" />
 			<circle cx="18" cy="13" r="2" fill="currentColor" stroke="none" className="hdr hdr-sl3" />
-		</svg>
-	);
-}
-
-// 21 — Rate limit: hourglass; sand pours down, then the glass flips over.
-// The outline is 180°-symmetric, so the end-of-cycle flip lands pixel-identical.
-export function RateLimitIcon({ className }: HeaderIconProps) {
-	return (
-		<svg {...svgBase(className)}>
-			<g className="hdr hdr-hg-body">
-				<path d="M6 3h12" />
-				<path d="M6 21h12" />
-				<path d="M16.5 3v3.172a2 2 0 0 1-.586 1.414L12 12 8.086 7.586A2 2 0 0 1 7.5 6.172V3" />
-				<path d="M16.5 21v-3.172a2 2 0 0 0-.586-1.414L12 12l-3.914 4.414a2 2 0 0 0-.586 1.414V21" />
-				<path d="M12 12.9v1" strokeWidth={2.2} className="hdr hdr-hg-drop" />
-				<path d="M12 12.9v1" strokeWidth={2.2} className="hdr hdr-hg-drop-ghost" opacity="0" />
-			</g>
 		</svg>
 	);
 }

--- a/src/mainview/components/PreventSleepToggle.tsx
+++ b/src/mainview/components/PreventSleepToggle.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../rpc";
 import { useT } from "../i18n";
-import { CoffeeIcon, LockIcon } from "./HeaderIcons";
+import { AwakeEyeIcon, LockIcon, SleepZzzIcon } from "./HeaderIcons";
 import Tooltip from "./Tooltip";
 
 interface SleepState {
@@ -15,8 +15,10 @@ interface SleepState {
  * Default on. While remote access is active it is forced on and locked,
  * since the machine must stay reachable. Hidden when no sleep-inhibit tool
  * (caffeinate / systemd-inhibit) is available on the host.
+ * Icon-only: grey z's = sleep allowed, awake-orange eye = kept awake
+ * (plus a mini lock badge while remote access forces it on).
  */
-function PreventSleepToggle({ compact = false }: { compact?: boolean }) {
+function PreventSleepToggle() {
 	const t = useT();
 	const [state, setState] = useState<SleepState | null>(null);
 	const [busy, setBusy] = useState(false);
@@ -68,18 +70,25 @@ function PreventSleepToggle({ compact = false }: { compact?: boolean }) {
 			onClick={toggle}
 			aria-disabled={locked}
 			aria-pressed={active}
-			className={`header-anim flex items-center gap-1 transition-colors px-1.5 py-1 rounded-lg ${
+			aria-label={t("caffeine.label")}
+			className={`header-anim flex items-center transition-colors px-1.5 py-1 rounded-lg ${
 				active
 					? "text-awake bg-awake/15 border border-awake/30 hover:bg-awake/25"
 					: "text-fg-3 hover:text-fg hover:bg-elevated border border-transparent"
 			} ${locked ? "cursor-default" : ""}`}
 		>
-			{locked ? (
-				<LockIcon className="w-[1.125rem] h-[1.125rem]" />
-			) : (
-				<CoffeeIcon className="w-[1.125rem] h-[1.125rem]" />
-			)}
-			{!compact && <span className="text-[0.6875rem] font-medium">{t("caffeine.label")}</span>}
+			<span className="relative flex">
+				{active ? (
+					<AwakeEyeIcon className="w-[1.125rem] h-[1.125rem]" />
+				) : (
+					<SleepZzzIcon className="w-[1.125rem] h-[1.125rem]" />
+				)}
+				{locked && (
+					<span className="absolute -right-1.5 -bottom-1 rounded bg-raised border border-edge p-px">
+						<LockIcon className="w-2 h-2" />
+					</span>
+				)}
+			</span>
 		</button>
 		</Tooltip>
 	);

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { api } from "../rpc";
 import { useT } from "../i18n";
 import Tooltip from "./Tooltip";
-import { RateLimitIcon } from "./HeaderIcons";
 import type { AgentRateLimitsReport } from "../../shared/rate-limits";
 import {
 	RATE_LIMIT_DANGER_PERCENT,
@@ -114,40 +113,38 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 				data-help-id="header.rateLimits"
 				className={`header-anim flex cursor-pointer select-none items-center gap-1.5 px-1.5 py-1 rounded-lg border transition-colors ${colorClasses}`}
 			>
-				<RateLimitIcon className="w-[1.125rem] h-[1.125rem]" />
+				{/* One mini bar per recently active account, top-to-bottom in the
+				    same order as the tooltip cards. Unlimited accounts render a
+				    full success bar (matching the ∞ chip) instead of a fake 0%.
+				    In compact mode the bars ARE the whole pill. */}
+				<span aria-hidden="true" className="flex w-7 shrink-0 flex-col gap-[0.0625rem]">
+					{pillSnapshots.map((snap) => {
+						const snapUnlimited = isUnlimitedRateLimitSnapshot(snap);
+						const snapPercent = snapUnlimited ? 100 : Math.round(worstSnapshotWindow(snap)?.usedPercent ?? 0);
+						const clamped = Math.max(0, Math.min(100, snapPercent));
+						return (
+							<span
+								key={`${snap.source}:${snap.accountId ?? "system"}`}
+								className={`relative block w-full overflow-hidden rounded-full bg-fg/15 ${pillSnapshots.length > 1 ? "h-[0.125rem]" : "h-[0.1875rem]"}`}
+							>
+								<span
+									className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${snapUnlimited ? "bg-success" : severityFill(snapPercent)}`}
+									style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.125rem" : undefined }}
+								/>
+							</span>
+						);
+					})}
+				</span>
 				{!compact && (
-					<>
-						{/* One mini bar per recently active account, top-to-bottom in the
-						    same order as the tooltip cards. Unlimited accounts render a
-						    full success bar (matching the ∞ chip) instead of a fake 0%. */}
-						<span aria-hidden="true" className="flex w-7 shrink-0 flex-col gap-[0.0625rem]">
-							{pillSnapshots.map((snap) => {
-								const snapUnlimited = isUnlimitedRateLimitSnapshot(snap);
-								const snapPercent = snapUnlimited ? 100 : Math.round(worstSnapshotWindow(snap)?.usedPercent ?? 0);
-								const clamped = Math.max(0, Math.min(100, snapPercent));
-								return (
-									<span
-										key={`${snap.source}:${snap.accountId ?? "system"}`}
-										className={`relative block w-full overflow-hidden rounded-full bg-fg/15 ${pillSnapshots.length > 1 ? "h-[0.125rem]" : "h-[0.1875rem]"}`}
-									>
-										<span
-											className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ${snapUnlimited ? "bg-success" : severityFill(snapPercent)}`}
-											style={{ width: `${clamped}%`, minWidth: clamped > 0 ? "0.125rem" : undefined }}
-										/>
-									</span>
-								);
-							})}
-						</span>
-						<span className="text-[0.6875rem] font-medium tabular-nums">
-							{unlimited ? (
-								t("rateLimits.unlimited")
-							) : (
-								<>
-									{percent}%<span className="ml-0.5 text-[0.5625rem] font-normal opacity-70">{t("rateLimits.used")}</span>
-								</>
-							)}
-						</span>
-					</>
+					<span className="text-[0.6875rem] font-medium tabular-nums">
+						{unlimited ? (
+							t("rateLimits.unlimited")
+						) : (
+							<>
+								{percent}%<span className="ml-0.5 text-[0.5625rem] font-normal opacity-70">{t("rateLimits.used")}</span>
+							</>
+						)}
+					</span>
 				)}
 			</div>
 		</Tooltip>

--- a/src/mainview/components/__tests__/PreventSleepToggle.test.tsx
+++ b/src/mainview/components/__tests__/PreventSleepToggle.test.tsx
@@ -60,4 +60,22 @@ describe("PreventSleepToggle", () => {
 		await userEvent.click(button);
 		expect(mockedApi.request.setPreventSleep).not.toHaveBeenCalled();
 	});
+
+	it("is icon-only: no text label, but an accessible name", async () => {
+		mockedApi.request.getPreventSleepState.mockResolvedValue({ enabled: true, available: true, forcedByRemote: false });
+		renderToggle();
+
+		const button = await screen.findByRole("button");
+		expect(button.textContent).toBe("");
+		expect(button).toHaveAttribute("aria-label", "No Sleep");
+	});
+
+	it("adds a lock badge next to the eye while forced by remote access", async () => {
+		mockedApi.request.getPreventSleepState.mockResolvedValue({ enabled: true, available: true, forcedByRemote: true });
+		renderToggle();
+
+		const button = await screen.findByRole("button");
+		// eye icon + mini lock badge
+		expect(button.querySelectorAll("svg")).toHaveLength(2);
+	});
 });

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -76,6 +76,19 @@ describe("RateLimitIndicator", () => {
 		expect(screen.getByRole("status").className).toContain("text-fg-3");
 	});
 
+	it("compact mode keeps the mini bars but drops the percent text", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		render(
+			<I18nProvider>
+				<RateLimitIndicator compact />
+			</I18nProvider>,
+		);
+		await act(async () => {});
+		const pill = screen.getByRole("status");
+		expect(pill.querySelector("[aria-hidden='true']")).toBeTruthy();
+		expect(screen.queryByText("42%")).toBeNull();
+	});
+
 	it("ignores a more-used window from an older account", async () => {
 		const now = Date.now();
 		mockedGet.mockResolvedValue({

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -946,14 +946,31 @@ svg .hdr-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 .header-anim:hover .hdr-dd { animation: hdr-dd 2.4s ease-in-out infinite; }
 .header-anim:hover .hdr-dd-ghost { animation: hdr-dd-ghost 2.4s ease-in-out infinite; }
 
-/* -- Coffee: steam rises off the fresh cup -- */
-@keyframes hdr-steam {
-	0%, 10% { transform: translateY(0); opacity: .25; }
-	45% { opacity: 1; }
-	85%, 100% { transform: translateY(-2.8px); opacity: 0; }
+/* -- Sleep z's: the z's drift upward one after another, like a snore -- */
+@keyframes hdr-zfloat {
+	0%, 12% { transform: translateY(0); opacity: 1; }
+	45% { transform: translateY(-2.2px); opacity: .35; }
+	70% { transform: translateY(0); opacity: 1; }
+	100% { transform: translateY(0); opacity: 1; }
 }
-.header-anim:hover .hdr-steam1 { animation: hdr-steam 2.4s ease-in-out infinite; }
-.header-anim:hover .hdr-steam2 { animation: hdr-steam 2.4s ease-in-out .5s infinite; }
+.header-anim:hover .hdr-z1 { animation: hdr-zfloat 2.4s ease-in-out infinite; }
+.header-anim:hover .hdr-z2 { animation: hdr-zfloat 2.4s ease-in-out .45s infinite; }
+
+/* -- Awake eye: a quick double blink, then the pupil re-dilates -- */
+@keyframes hdr-eye-blink {
+	0%, 18% { transform: scaleY(1); }
+	26% { transform: scaleY(.12); }
+	34% { transform: scaleY(1); }
+	42% { transform: scaleY(.12); }
+	50%, 100% { transform: scaleY(1); }
+}
+@keyframes hdr-eye-pupil {
+	0%, 50% { transform: scale(1); }
+	62% { transform: scale(.72); }
+	78%, 100% { transform: scale(1); }
+}
+.header-anim:hover .hdr-eye { transform-origin: 12px 12px; animation: hdr-eye-blink 2.4s ease-in-out infinite; }
+.header-anim:hover .hdr-eye-pupil { transform-origin: 12px 12px; animation: hdr-eye-pupil 2.4s ease-in-out infinite; }
 
 /* -- Lock: the shackle tugs but snaps shut, the keyhole blinks "no" -- */
 @keyframes hdr-shackle {
@@ -1072,29 +1089,6 @@ svg .hdr-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 	92%, 100% { transform: rotate(0deg); }
 }
 .header-anim:hover .hdr-needle { transform-origin: 12px 14px; animation: hdr-needle 2.6s ease-in-out infinite; }
-
-/* -- Rate-limit hourglass: sand pours down, then the glass flips over.
-   The outline is 180°-symmetric so the flip lands pixel-identical. -- */
-@keyframes hdr-hg-drop {
-	0%, 8% { transform: translateY(0); opacity: 1; }
-	38% { transform: translateY(5.6px); opacity: 1; }
-	46%, 100% { transform: translateY(6.4px); opacity: 0; }
-}
-@keyframes hdr-hg-drop-ghost {
-	0%, 22% { transform: translateY(0); opacity: 0; }
-	30% { opacity: .8; }
-	52% { transform: translateY(5.6px); opacity: .8; }
-	60%, 100% { transform: translateY(6.4px); opacity: 0; }
-}
-@keyframes hdr-hg-flip {
-	0%, 62% { transform: rotate(0deg); }
-	84% { transform: rotate(189deg); }
-	92% { transform: rotate(176deg); }
-	100% { transform: rotate(180deg); }
-}
-.header-anim:hover .hdr-hg-drop { animation: hdr-hg-drop 2.4s ease-in-out infinite; }
-.header-anim:hover .hdr-hg-drop-ghost { animation: hdr-hg-drop-ghost 2.4s ease-in-out infinite; }
-.header-anim:hover .hdr-hg-body { transform-origin: 12px 12px; animation: hdr-hg-flip 2.4s ease-in-out infinite; }
 
 /* -- GitHub: the octocat takes a polite bow -- */
 @keyframes hdr-gh {


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

Frees ~125px of global-header width by slimming three existing controls (no placement changes, no new controls):

- **Prevent-sleep toggle is icon-only with a new metaphor**: grey sleeping z's while sleep is allowed, an awake-orange open eye while the machine is kept awake, and a mini lock badge on the eye while remote access forces it on. Hover animations follow the existing `hdr-*` style: the z's drift upward one after another, the eye double-blinks and its pupil re-dilates. The old coffee/lock full-size rendering and the steam animation are removed.
- **Rate-limit pill drops the hourglass icon**: the per-account mini usage bars lead the pill next to the "N% used" text, and in compact mode (≤1600px) the bars alone are the pill (previously compact showed only the hourglass). The unused `RateLimitIcon` and its hover animation are deleted.
- **Remote Access button drops its hardcoded (non-i18n) "Remote" label** — icon-only QR glyph, tooltip unchanged.

Accessibility preserved: the icon-only toggle gains an `aria-label`, and `aria-pressed`/`aria-disabled`/`role="status"` semantics are unchanged. New unit tests cover the icon-only toggle, the remote-forced lock badge, and the compact bars-only rate pill.