### PR TITLE
Replace picker usage rings with inline mini quota cards

### DIFF
--- a/change-logs/2026/07/22/feature-account-picker-quota-cards.md
+++ b/change-logs/2026/07/22/feature-account-picker-quota-cards.md
@@ -1,0 +1,3 @@
+Short: See account quota before spawning
+
+The "Account for this launch" picker (Spawn Agent, Launch Variants, Bug Hunters, and the Settings default switcher) now embeds a mini quota card in every account row: one severity-colored bar per rate-limit window (5h / 7d / monthly credits) with its percent and reset countdown, an "∞ unlimited" chip for unlimited plans, a "no recent usage data" note for idle accounts, and the "captured X ago" freshness note. No more spawning agents on a nearly exhausted account by accident.

--- a/change-logs/2026/07/22/feature-account-picker-usage-rings.md
+++ b/change-logs/2026/07/22/feature-account-picker-usage-rings.md
@@ -1,3 +1,0 @@
-Short: See account quota before spawning
-
-The "Account for this launch" picker (Spawn Agent, Launch Variants, Bug Hunters, and the Settings default switcher) now shows each account's rate-limit state at a glance: the radio dot became a severity-colored usage ring with the worst-window percent next to it, a full green ring marks unlimited accounts, and hovering a row reveals the full quota card with per-window bars, reset countdowns, and the "captured X ago" note. No more spawning agents on a nearly exhausted account by accident.

--- a/src/mainview/components/AgentAccountIndicator.tsx
+++ b/src/mainview/components/AgentAccountIndicator.tsx
@@ -13,15 +13,15 @@ import type { AgentRateLimitSnapshot, AgentRateLimitsReport } from "../../shared
 import {
 	RATE_LIMIT_DANGER_PERCENT,
 	RATE_LIMIT_WARN_PERCENT,
+	formatResetDelta,
 	isUnlimitedRateLimitSnapshot,
-	worstSnapshotWindow,
+	windowLabel,
 } from "../../shared/rate-limits";
 import { api } from "../rpc";
 import { toast } from "../toast";
 import { useT } from "../i18n";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import Tooltip from "./Tooltip";
-import { AccountCard, resolveAccount, type AccountLine } from "./rate-limit-ui";
+import { CapturedNote, UsageBar } from "./rate-limit-ui";
 
 /** Fired on window after any account mutation (switch from this popover,
  *  add/remove/switch in Settings → Agent Accounts), so every mounted listener
@@ -85,60 +85,76 @@ function useAgentRateLimits(enabled: boolean): AgentRateLimitsReport | null {
 interface RowUsage {
 	/** null = OAuth account with no reading in the 7-day activity window. */
 	snap: AgentRateLimitSnapshot | null;
-	/** Identity line for the tooltip card header. */
-	account: AccountLine | null;
 	state: "used" | "unlimited" | "none";
-	/** Rounded worst-window percent; 0 for unlimited/none. */
-	percent: number;
 }
 
-function ringSeverityText(percent: number): string {
+function usageSeverityText(percent: number): string {
 	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
 	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
 	return "text-accent";
 }
 
 /**
- * Circular usage gauge that doubles as the row's selection mark (variant B of
- * the picker design exploration): the arc shows the worst rate-limit window,
- * a full success ring means unlimited, a bare track means no recent reading,
- * and the filled center dot preserves the radio "selected" semantics.
+ * Compact per-account quota block under a picker row (variant C of the design
+ * exploration — mini quota cards): one "label · bar · % · reset" line per limit
+ * window plus the captured note; an unlimited chip or a no-data note otherwise.
  */
-function UsageRing({ usage, isActive }: { usage: RowUsage | null; isActive: boolean }) {
+function RowQuota({ usage, now }: { usage: RowUsage; now: number }) {
 	const t = useT();
-	const radius = 6;
-	const circumference = 2 * Math.PI * radius;
-	const state = usage?.state ?? "none";
-	const percent = usage?.percent ?? 0;
-	const arc =
-		state === "unlimited" ? circumference : state === "used" ? (Math.max(0, Math.min(100, percent)) / 100) * circumference : 0;
-	const colorClass = state === "unlimited" ? "text-success" : ringSeverityText(percent);
-	const label =
-		state === "unlimited"
-			? t("rateLimits.unlimited")
-			: state === "used"
-				? t("rateLimits.percentUsed", { percent })
-				: t("rateLimits.noRecentData");
-	return (
-		<svg viewBox="0 0 16 16" role="img" aria-label={label} className="mt-0.5 h-4 w-4 shrink-0">
-			<circle cx="8" cy="8" r={radius} fill="none" strokeWidth="2" className="text-fg/15" stroke="currentColor" />
-			{arc > 0 && (
-				<circle
-					cx="8"
-					cy="8"
-					r={radius}
-					fill="none"
-					strokeWidth="2"
-					strokeLinecap="round"
-					strokeDasharray={`${arc} ${circumference}`}
-					transform="rotate(-90 8 8)"
-					className={colorClass}
-					stroke="currentColor"
-				/>
-			)}
-			{isActive && <circle cx="8" cy="8" r="3" className="text-accent" fill="currentColor" />}
-		</svg>
-	);
+	if (usage.state === "unlimited" && usage.snap) {
+		return (
+			<>
+				<span className="mt-1.5 flex">
+					<span className="text-success text-[0.625rem] px-1 py-px bg-success/10 rounded font-medium">
+						{t("rateLimits.unlimited")}
+					</span>
+				</span>
+				<span className="mt-1 block">
+					<CapturedNote capturedAt={usage.snap.capturedAt} now={now} />
+				</span>
+			</>
+		);
+	}
+	if (usage.state === "used" && usage.snap) {
+		const monthly = usage.snap.monthlyCredits;
+		// Same de-dup as AccountCard: the monthly_credits window mirrors
+		// snap.monthlyCredits, which gets its own line below.
+		const lines = usage.snap.windows
+			.filter((win) => !(win.id === "monthly_credits" && monthly))
+			.map((win) => ({ key: win.id, label: windowLabel(win), usedPercent: win.usedPercent, resetsAt: win.resetsAt }));
+		if (monthly) {
+			lines.push({
+				key: "monthly",
+				label: t("rateLimits.monthlyLabel"),
+				usedPercent: Math.max(0, 100 - monthly.remainingPercent),
+				resetsAt: monthly.resetsAt,
+			});
+		}
+		return (
+			<>
+				{lines.map((line) => {
+					const percent = Math.round(line.usedPercent);
+					const reset = formatResetDelta(line.resetsAt, now);
+					return (
+						<span key={line.key} className="mt-1.5 flex items-center gap-1.5">
+							<span className="min-w-[1.125rem] shrink-0 text-[0.625rem] text-fg-muted tabular-nums whitespace-nowrap">
+								{line.label}
+							</span>
+							<UsageBar percent={line.usedPercent} className="h-1 min-w-0 flex-1" />
+							<span className="shrink-0 text-[0.625rem] tabular-nums">
+								<span className={`font-semibold ${usageSeverityText(percent)}`}>{percent}%</span>
+								{reset && <span className="text-fg-muted"> · {reset}</span>}
+							</span>
+						</span>
+					);
+				})}
+				<span className="mt-1 block">
+					<CapturedNote capturedAt={usage.snap.capturedAt} now={now} />
+				</span>
+			</>
+		);
+	}
+	return <span className="mt-1.5 block text-[0.625rem] text-fg-muted">{t("rateLimits.noRecentData")}</span>;
 }
 
 function identityBadge(identity: AgentAccountIdentity | null): string | null {
@@ -189,7 +205,6 @@ function SwitcherPopover({
 	const menuRef = useRef<HTMLDivElement>(null);
 	const [pos, setPos] = useState({ top: anchor.top, left: anchor.left });
 	const [visible, setVisible] = useState(false);
-	const t = useT();
 	const now = Date.now();
 
 	useEscapeKey(onClose);
@@ -234,80 +249,50 @@ function SwitcherPopover({
 				<div className="text-fg-2 text-xs font-semibold uppercase tracking-wider">{title}</div>
 				<p className="text-fg-muted text-[0.6875rem] leading-snug mt-1">{subtitle}</p>
 			</div>
-			{rows.map((row) => {
-				const selectable = !!row.onSelect && !row.isActive;
-				// Rows stay enabled even when informational/selected so the usage
-				// tooltip keeps working (disabled subtrees swallow hover events);
-				// non-selectable rows simply have no onClick.
-				const button = (
-					<button
-						type="button"
-						disabled={busy}
-						onClick={selectable ? (row.onSelect ?? undefined) : undefined}
-						aria-current={row.isActive || undefined}
-						className={`w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${
-							selectable ? "hover:bg-elevated-hover cursor-pointer" : "cursor-default"
-						} disabled:opacity-100`}
-					>
-						<UsageRing usage={row.usage} isActive={row.isActive} />
-						<span className="min-w-0 flex-1">
-							<span className="flex items-center gap-2 min-w-0">
-								<span className="text-fg text-sm truncate flex-1">{row.label}</span>
-								{row.isApi ? (
-									<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
-								) : null}
-								{row.planLabel ? (
-									<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">
-										{row.planLabel}
-									</span>
-								) : null}
-								{row.usage?.state === "used" ? (
-									<span
-										className={`shrink-0 text-[0.6875rem] font-semibold tabular-nums ${ringSeverityText(row.usage.percent)}`}
-									>
-										{row.usage.percent}%
-									</span>
-								) : row.usage?.state === "unlimited" ? (
-									<span className="shrink-0 text-[0.6875rem] font-semibold text-success">∞</span>
-								) : row.usage ? (
-									<span className="shrink-0 text-[0.6875rem] text-fg-muted">—</span>
-								) : null}
-							</span>
-							{(row.sub && row.sub !== row.label && !row.label.includes(row.sub)) || row.workspaceLabel ? (
-								<span className="mt-1 flex flex-wrap items-center gap-1.5 min-w-0">
-									{row.sub && row.sub !== row.label && !row.label.includes(row.sub) ? (
-										<span className="text-fg-muted text-xs font-mono truncate max-w-full">{row.sub}</span>
-									) : null}
-									{row.workspaceLabel ? (
-										<span className="text-fg-3 text-[0.625rem] px-1 py-px bg-raised rounded max-w-full">
-											{row.workspaceLabel}
-										</span>
-									) : null}
+			{rows.map((row) => (
+				<button
+					key={row.key}
+					type="button"
+					disabled={busy || !row.onSelect || row.isActive}
+					onClick={row.onSelect ?? undefined}
+					className={`w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${
+						row.onSelect && !row.isActive ? "hover:bg-elevated-hover cursor-pointer" : "cursor-default"
+					} disabled:opacity-100`}
+				>
+					<span
+						aria-hidden
+						className={`w-3 h-3 mt-1 rounded-full border-2 shrink-0 ${
+							row.isActive ? "border-accent bg-accent" : "border-fg-muted/50"
+						}`}
+					/>
+					<span className="min-w-0 flex-1">
+						<span className="flex items-center gap-2 min-w-0">
+							<span className="text-fg text-sm truncate flex-1">{row.label}</span>
+							{row.isApi ? (
+								<span className="text-warning text-[0.625rem] px-1 py-px bg-warning/10 rounded shrink-0">API</span>
+							) : null}
+							{row.planLabel ? (
+								<span className="text-accent text-[0.625rem] px-1 py-px bg-accent/10 rounded shrink-0">
+									{row.planLabel}
 								</span>
 							) : null}
 						</span>
-					</button>
-				);
-				return row.usage?.snap ? (
-					<Tooltip
-						key={row.key}
-						layer="popover"
-						placement="right"
-						content={t("rateLimits.tooltipTitle")}
-						detail={
-							<div className="flex w-[19rem] max-w-[calc(100vw-3rem)] flex-col">
-								<AccountCard snap={row.usage.snap} account={row.usage.account} now={now} />
-							</div>
-						}
-					>
-						{button}
-					</Tooltip>
-				) : (
-					<span key={row.key} className="block">
-						{button}
+						{(row.sub && row.sub !== row.label && !row.label.includes(row.sub)) || row.workspaceLabel ? (
+							<span className="mt-1 flex flex-wrap items-center gap-1.5 min-w-0">
+								{row.sub && row.sub !== row.label && !row.label.includes(row.sub) ? (
+									<span className="text-fg-muted text-xs font-mono truncate max-w-full">{row.sub}</span>
+								) : null}
+								{row.workspaceLabel ? (
+									<span className="text-fg-3 text-[0.625rem] px-1 py-px bg-raised rounded max-w-full">
+										{row.workspaceLabel}
+									</span>
+								) : null}
+							</span>
+						) : null}
+						{row.usage ? <RowQuota usage={row.usage} now={now} /> : null}
 					</span>
-				);
-			})}
+				</button>
+			))}
 			<div className="border-t border-edge mt-1 pt-1.5 px-3 pb-1">
 				<p className="text-fg-muted text-[0.6875rem] leading-snug">{hint}</p>
 			</div>
@@ -403,12 +388,9 @@ export default function AgentAccountIndicator({
 	const usageFor = (accountId: string | null, isApi = false): RowUsage | null => {
 		if (!report || isApi) return null;
 		const snap = report.snapshots.find((s) => s.source === kind && (s.accountId ?? null) === accountId) ?? null;
-		if (!snap) return { snap: null, account: null, state: "none", percent: 0 };
-		const account = resolveAccount(kind, state, accountId);
-		if (isUnlimitedRateLimitSnapshot(snap)) return { snap, account, state: "unlimited", percent: 0 };
-		const worst = worstSnapshotWindow(snap);
-		if (!worst) return { snap, account, state: "none", percent: 0 };
-		return { snap, account, state: "used", percent: Math.round(worst.usedPercent) };
+		if (!snap) return { snap: null, state: "none" };
+		if (isUnlimitedRateLimitSnapshot(snap)) return { snap, state: "unlimited" };
+		return { snap, state: snap.windows.length > 0 || snap.monthlyCredits ? "used" : "none" };
 	};
 
 	const rows: PopoverRow[] = [];

--- a/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
+++ b/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
@@ -261,7 +261,7 @@ describe("AgentAccountIndicator", () => {
 		expect(screen.getAllByText("API").length).toBeGreaterThan(0);
 	});
 
-	it("shows per-account usage rings with severity-colored percents", async () => {
+	it("shows per-window quota bars with severity-colored percents", async () => {
 		mockedApi.request.getAgentRateLimits.mockResolvedValue(
 			makeReport([
 				makeSnapshot({
@@ -282,15 +282,17 @@ describe("AgentAccountIndicator", () => {
 
 		await user.click(await screen.findByTestId("agent-account-trigger"));
 
-		// Worst window wins: 62% (7d) for the system login, colored accent (<80).
+		// System login shows both windows inline (5h 34%, 7d 62%), accent (<80).
 		const okPercent = await screen.findByText("62%");
 		expect(okPercent.className).toContain("text-accent");
+		expect(screen.getByText("34%")).toBeTruthy();
+		expect(screen.getByText("5h")).toBeTruthy();
+		// The managed account's 7d window sits in the danger tier.
 		const dangerPercent = screen.getByText("97%");
 		expect(dangerPercent.className).toContain("text-danger");
-		expect(screen.getByRole("img", { name: "62% used" })).toBeTruthy();
 	});
 
-	it("shows ∞ for an unlimited account and — for one without a reading", async () => {
+	it("shows an unlimited chip and a no-data note per account", async () => {
 		mockedApi.request.getAgentRateLimits.mockResolvedValue(
 			makeReport([makeSnapshot({ accountId: null, creditsBalance: "unlimited" })]),
 		);
@@ -300,19 +302,17 @@ describe("AgentAccountIndicator", () => {
 		await user.click(await screen.findByTestId("agent-account-trigger"));
 
 		// System login is unlimited; the managed account has no snapshot at all.
-		expect(await screen.findByText("∞")).toBeTruthy();
-		expect(screen.getByText("—")).toBeTruthy();
-		expect(screen.getByRole("img", { name: "∞ unlimited" })).toBeTruthy();
-		expect(screen.getByRole("img", { name: "no recent usage data" })).toBeTruthy();
+		expect(await screen.findByText("∞ unlimited")).toBeTruthy();
+		expect(screen.getByText("no recent usage data")).toBeTruthy();
 	});
 
-	it("hovering a row shows the quota card tooltip with windows and captured note", async () => {
+	it("shows reset countdowns and the captured note inline", async () => {
 		mockedApi.request.getAgentRateLimits.mockResolvedValue(
 			makeReport([
 				makeSnapshot({
 					accountId: null,
 					capturedAt: Date.now() - 20 * 60 * 1000,
-					windows: [{ id: "five_hour", usedPercent: 34, resetsAt: null, windowMinutes: 300 }],
+					windows: [{ id: "five_hour", usedPercent: 34, resetsAt: Date.now() + 2 * 60 * 60 * 1000, windowMinutes: 300 }],
 				}),
 			]),
 		);
@@ -320,15 +320,33 @@ describe("AgentAccountIndicator", () => {
 		renderIndicator(claudeAgent, { value: null, onSelect: vi.fn() });
 
 		await user.click(await screen.findByTestId("agent-account-trigger"));
-		await screen.findByText("34%");
-		await user.hover(screen.getByText("System login (~/.claude)"));
 
-		// Tooltip opens after the hover-intent delay with the full quota card.
-		expect(await screen.findByText("5h", undefined, { timeout: 2000 })).toBeTruthy();
+		// No hover needed — the quota line and its provenance render inline.
+		expect(await screen.findByText("34%")).toBeTruthy();
+		expect(screen.getByText(/· 2h/)).toBeTruthy();
 		expect(screen.getByText("captured 20m ago")).toBeTruthy();
 	});
 
-	it("shows a bare ring without percent text for API profiles", async () => {
+	it("renders the monthly credits line when the plan exposes it", async () => {
+		mockedApi.request.getAgentRateLimits.mockResolvedValue(
+			makeReport([
+				makeSnapshot({
+					accountId: null,
+					windows: [],
+					monthlyCredits: { limit: 1000, used: 250, remainingPercent: 75, resetsAt: null },
+				}),
+			]),
+		);
+		const user = userEvent.setup();
+		renderIndicator(claudeAgent, { value: null, onSelect: vi.fn() });
+
+		await user.click(await screen.findByTestId("agent-account-trigger"));
+
+		expect(await screen.findByText("monthly credits")).toBeTruthy();
+		expect(screen.getByText("25%")).toBeTruthy();
+	});
+
+	it("shows no quota block for API profiles", async () => {
 		const base = makeState();
 		mockedApi.request.listAgentAccounts.mockResolvedValue(
 			makeState({
@@ -357,7 +375,8 @@ describe("AgentAccountIndicator", () => {
 
 		await user.click(await screen.findByTestId("agent-account-trigger"));
 		await screen.findByText("34%"); // system row has data…
-		expect(screen.queryByText("—")).toBeNull(); // …but the API row shows no dash
+		// …but the API row gets neither bars nor a misleading "no data" note.
+		expect(screen.queryByText("no recent usage data")).toBeNull();
 	});
 
 	it("shows the readable Codex workspace name in the account popover", async () => {


### PR DESCRIPTION
Hi, Claude here — the AI working on this branch.

## Summary

Follow-up to #1074: after trying the ring-gauge picker, the design direction changed to the **mini quota cards** variant from the same exploration. The "Account for this launch" popover now shows everything inline, no hover needed:

- The radio dot returns as the selection mark.
- Each account row embeds one severity-colored bar per rate-limit window (5h / 7d / monthly credits) with its rounded percent and reset countdown (`16% · 6d2h`).
- Unlimited plans render the "∞ unlimited" chip; accounts with no reading in the 7-day activity window get a muted "no recent usage data" note; API profiles show no quota block at all.
- Every card ends with the "captured X ago" freshness note (warning tint when stale), matching the header quota panel.

The hover tooltip from #1074 is gone (nothing left to disclose), so the `Tooltip` `layer="popover"` stacking tier is reverted as unused, and popover rows go back to the original disabled semantics.