### PR TITLE
Prove deterministic native host-crash recovery

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Native-session registry lifecycle E2E
         run: bun run test:native-registry-e2e
 
+      # Seq 1236 force-kills only the recorded host while journal/parser writes
+      # are active, then proves owned-tree death and token-matched recovery.
+      - name: Native-session host crash recovery E2E
+        run: bun run test:native-crash-e2e
+
       # Seq 1228 live-parser proof. Gates ONLY the deferred path; `callback`
       # mode is printed as evidence and is EXPECTED to fail on Windows
       # Bun 1.3.14 (the preserved seq 1185 reproduction, decision 146).

--- a/change-logs/2026/07/22/chore-native-host-crash-recovery.md
+++ b/change-logs/2026/07/22/chore-native-host-crash-recovery.md
@@ -1,1 +1,1 @@
-The isolated native-session harness now proves deterministic host-crash cleanup, fail-closed journal and parser persistence, token-matched stale recovery, and same-ID restart across the pinned Windows, macOS, and Linux Bun 1.3.14 matrix without invoking tmux.
+The isolated native-session harness now proves deterministic host-crash cleanup, fail-closed journal and parser persistence, lock-serialized token-matched recovery, and same-ID restart across the pinned Windows, macOS, and Linux Bun 1.3.14 matrix without invoking tmux.

--- a/change-logs/2026/07/22/chore-native-host-crash-recovery.md
+++ b/change-logs/2026/07/22/chore-native-host-crash-recovery.md
@@ -1,0 +1,1 @@
+The isolated native-session harness now proves deterministic host-crash cleanup, fail-closed journal and parser persistence, token-matched stale recovery, and same-ID restart across the pinned Windows, macOS, and Linux Bun 1.3.14 matrix without invoking tmux.

--- a/decisions/158-native-host-crash-recovery.md
+++ b/decisions/158-native-host-crash-recovery.md
@@ -15,16 +15,18 @@ an abrupt host exit closes it and hangs up the attached interactive shell tree.
 
 ## Decision
 
-`crash-recovery.bun-e2e.ts` force-kills the recorded host during journal/parser
-activity and proves bounded host, shell, child, and grandchild death while two
-external sentinels survive. Windows relies on Job Object kill-on-close; POSIX
-relies on PTY hangup for the terminal-owned tree, preserving platform-native
-primitives rather than inventing one portable process abstraction.
+The [`run()` crash proof](../src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts)
+force-kills the recorded host during journal/parser activity and proves bounded
+owned-tree death while external sentinels survive. Windows relies on Job Object
+kill-on-close; POSIX relies on PTY hangup for the terminal-owned tree, preserving
+platform-native primitives rather than inventing one process abstraction.
 
-Registry, token, journal, and parser snapshots publish by temp-file rename, and
-parser reads validate their full structure. `cleanup-stale` removes exact-token
-state plus only the recorded host PID's temp files; list/status report the dead
-record until cleanup, after which the stable ID can start exactly one new host.
+[`JournalWriter.flush()`](../src/bun/native-terminal-registry/journal.ts) and
+[`writeParserStateAtomic()`](../src/bun/native-terminal-registry/parser-state.ts)
+publish complete snapshots by temp-file rename, while `readParserState()` rejects
+malformed nested state. [`cleanupStale()` and `start()`](../src/bun/native-terminal-registry/registry.ts)
+share the per-session lock, so exact-token removal cannot erase a concurrent
+same-ID replacement; list/status expose the dead record until cleanup succeeds.
 
 ## Risks
 

--- a/decisions/158-native-host-crash-recovery.md
+++ b/decisions/158-native-host-crash-recovery.md
@@ -1,0 +1,42 @@
+# 158 — Deterministic native host-crash recovery
+
+## Context
+
+The isolated native-session registry could stop an owned tree normally, but had
+no direct proof for a host killed before shutdown code ran. Seq 1236 requires
+that proof without selecting the native backend in production or touching tmux.
+
+## Investigation
+
+On Windows the detached host is both a member of and the sole long-lived handle
+owner for its token-named kill-on-close Job Object, so force-terminating only the
+host closes the final handle. On POSIX, a Bun.Terminal host owns the PTY master;
+an abrupt host exit closes it and hangs up the attached interactive shell tree.
+
+## Decision
+
+`crash-recovery.bun-e2e.ts` force-kills the recorded host during journal/parser
+activity and proves bounded host, shell, child, and grandchild death while two
+external sentinels survive. Windows relies on Job Object kill-on-close; POSIX
+relies on PTY hangup for the terminal-owned tree, preserving platform-native
+primitives rather than inventing one portable process abstraction.
+
+Registry, token, journal, and parser snapshots publish by temp-file rename, and
+parser reads validate their full structure. `cleanup-stale` removes exact-token
+state plus only the recorded host PID's temp files; list/status report the dead
+record until cleanup, after which the stable ID can start exactly one new host.
+
+## Risks
+
+The POSIX guarantee does not include deliberately daemonized descendants that
+detach from the terminal or ignore SIGHUP; adopting or scanning such processes
+would violate this ticket's ownership boundary. Windows evidence depends on Bun
+1.3.14 plus native Job Object semantics, so the pinned CI and PowerShell proof
+must remain a release gate while this module is experimental.
+
+## Alternatives considered
+
+Calling registry `stop` after the host kill was rejected because it would not
+prove kill-on-close. Cross-platform PID walks, `taskkill /T`, process adoption,
+and automatic resurrection were rejected because each widens ownership or hides
+the crash instead of testing the platform containment already in place.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"test:pane-e2e": "bun --preload ./src/bun/__tests__/pane-exit-e2e-preload.ts src/bun/__tests__/pane-exit-e2e.ts",
 		"test:proto-e2e": "bun src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts",
 		"test:native-registry-e2e": "bun src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts",
+		"test:native-crash-e2e": "bun src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts",
 		"test:native-live-parser-e2e": "bun src/bun/native-terminal-registry/__tests__/live-parser.bun-e2e.ts",
 		"test:terminal-state-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/terminal-state/__tests__",
 		"benchmark:terminal-state-spike": "bun src/bun/prototypes/terminal-state/benchmark.ts",

--- a/src/bun/native-terminal-registry/README.md
+++ b/src/bun/native-terminal-registry/README.md
@@ -24,7 +24,7 @@ of older dev3 versions on the same machine — are completely unaffected.
 | `ownership.ts` | Passive `owned`/`dead`/`reused` verdict — never attaches, never signals. |
 | `windows-job.ts` | Token-named Job Object containment (registry namespace). |
 | `protocol.ts` | Wire protocol: binary frames = PTY bytes, text frames = JSON control. |
-| `journal.ts` / `journal-read.ts` | Bounded, independent per-session output journal. |
+| `journal.ts` / `journal-read.ts` | Bounded, atomic, independent per-session output journal. |
 | `parser-queue.ts` | Byte-capped callback-side event queue with explicit overflow accounting (seq 1228). |
 | `ghostty-live.ts` | Registry-local Ghostty core: ingest, replies, semantic inspection (seq 1228). |
 | `live-parser.ts` | Deferred parsing pipeline — the ONLY place Ghostty runs (seq 1228). |
@@ -63,6 +63,9 @@ touched, renamed, moved, or rewritten.
 - **Token-matched cleanup.** `stop`/`cleanupStale` remove only state whose
   on-disk token matches, and never attach to or kill an unverified PID. An
   unknown-schema record (newer dev3) is left untouched.
+- **Crash honesty.** An abruptly terminated host remains discoverable as
+  `dead` until `cleanup-stale` removes its token-matched additive state. A
+  partial temp file is never published or accepted as current state.
 - **Token privacy.** The bearer token lives only in the 0600 `token` file;
   `list`/`status` output and every serialised record are token-free.
 
@@ -140,6 +143,26 @@ Proofs: `bun run test:native-live-parser-e2e` (also in the Windows/macOS/Ubuntu
 CI job), `regression-probe.ts both`, and the real-TUI matrix in
 [`LIVE-PARSER-MATRIX.md`](LIVE-PARSER-MATRIX.md) with latency/memory budgets.
 
+## Abrupt host recovery (seq 1236)
+
+The crash proof terminates the recorded host PID directly while terminal output
+and deferred parsing are active; it never calls `stop`. Windows uses the existing
+non-breakaway, kill-on-close Job Object: terminating the host closes its final
+owned handle, and Windows ends the root shell plus every child and grandchild in
+that job. POSIX uses its native PTY lifecycle instead: host death closes the PTY
+master, the kernel delivers the terminal hangup, and the attached interactive
+shell propagates it through its jobs. The POSIX claim covers the terminal-owned
+tree, not a deliberately daemonized or SIGHUP-ignoring breakaway process.
+
+`record.json`, `token`, `journal.ndjson`, and `parser-state.json` publish with a
+complete temp file plus atomic rename. Parser-state reads validate every nested
+health, counter, and semantic-state field; interrupted temp files are ignored.
+`list` and `status` still classify the session from process ownership, so a last
+good parser snapshot never makes a dead host look healthy. `cleanup-stale`
+deletes only state whose current token matches and only temp files named for the
+recorded crashed host PID; missing, changed, unknown-schema, and unrelated state
+remain untouched.
+
 ## Try it
 
 ```bash
@@ -148,6 +171,7 @@ bun src/bun/native-terminal-registry/cli.ts start bravo
 bun src/bun/native-terminal-registry/cli.ts list
 bun src/bun/native-terminal-registry/cli.ts attach alpha   # type; Ctrl-] to detach — shell keeps running
 bun src/bun/native-terminal-registry/cli.ts attach alpha   # reattach: same shell, state + journal intact
+bun src/bun/native-terminal-registry/cli.ts cleanup-stale  # remove token-matched dead session state
 bun src/bun/native-terminal-registry/cli.ts stop alpha     # stops ONLY alpha; bravo keeps running
 ```
 
@@ -162,6 +186,13 @@ bun src/bun/native-terminal-registry/cli.ts stop alpha     # stops ONLY alpha; b
   write-back exactly once, detach-boundary reconstruction equal to a
   ground-truth replay, explicit bounded overflow, contained parser faults, and
   the tmux sentinel. Expected final line: `ALL CHECKS PASSED`.
+- `bun run test:native-crash-e2e` — force-kills one recorded host during active
+  journal/parser writes, proves bounded owned-tree death, dead status/list,
+  token-matched cleanup, same-id restart, sentinel survival, and zero tmux
+  invocation. The CI matrix runs it on Windows, macOS, and Linux with Bun 1.3.14.
+- On a real Windows checkout after `bun install --frozen-lockfile`, run
+  `powershell -ExecutionPolicy Bypass -File src\bun\native-terminal-registry\__tests__\run-windows-crash-recovery.ps1`.
+  The wrapper requires native Windows and exactly Bun 1.3.14.
 - `__tests__/*.test.ts` — vitest units for paths, record serialization, locking,
   stale detection, PID identity, ownership-safe cleanup, journal, protocol, the
   Win32 handle lifecycle, and import-graph/tmux isolation; part of `bun run test`.

--- a/src/bun/native-terminal-registry/README.md
+++ b/src/bun/native-terminal-registry/README.md
@@ -57,9 +57,10 @@ touched, renamed, moved, or rewritten.
 - **Ownership over PID.** A live PID alone never proves ownership. POSIX pins the
   recorded host/shell to `ps -o lstart`; Windows to token-named Job Object
   membership. A reused PID is classified `reused` and never signalled.
-- **Serialised start.** Concurrent `start` of one id is serialised by a
-  per-session file lock; the loser observes the winner's live record and returns
-  `already-running` — never a second shell.
+- **Serialised state replacement.** Concurrent `start` and `cleanupStale`
+  operations for one id share a per-session file lock. A start loser observes
+  the winner's live record, while cleanup cannot erase a replacement between
+  classification and token-matched deletion.
 - **Token-matched cleanup.** `stop`/`cleanupStale` remove only state whose
   on-disk token matches, and never attach to or kill an unverified PID. An
   unknown-schema record (newer dev3) is left untouched.
@@ -159,9 +160,9 @@ complete temp file plus atomic rename. Parser-state reads validate every nested
 health, counter, and semantic-state field; interrupted temp files are ignored.
 `list` and `status` still classify the session from process ownership, so a last
 good parser snapshot never makes a dead host look healthy. `cleanup-stale`
-deletes only state whose current token matches and only temp files named for the
-recorded crashed host PID; missing, changed, unknown-schema, and unrelated state
-remain untouched.
+shares `start`'s per-session lock, then deletes only state whose current token
+matches and only temp files named for the recorded crashed host PID; missing,
+changed, unknown-schema, and unrelated state remain untouched.
 
 ## Try it
 

--- a/src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts
+++ b/src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+/** Real-runtime proof for abrupt native-session host termination (seq 1236).
+ * The crash phase force-kills the recorded host PID instead of asking it to stop. */
+
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "../../spawn";
+import { NativeSessionClient } from "../client";
+import { journalFile, parserStateFile, recordFile, sessionDir, tokenFile } from "../paths";
+import { readParserState } from "../parser-state";
+import { isProcessAlive } from "../process-identity";
+import { readRecord, readToken } from "../record";
+import { cleanupStale, list, start, status, stop } from "../registry";
+import { isProcessInWindowsJob, windowsJobExists } from "../windows-job";
+import { sendUntilObserved } from "./command-roundtrip";
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const isWindows = process.platform === "win32";
+const lineEnd = isWindows ? "\r" : "\n";
+const cliEntry = fileURLToPath(new URL("../cli.ts", import.meta.url));
+
+async function waitUntil(predicate: () => boolean | Promise<boolean>, timeoutMs = 8000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return true;
+		await delay(40);
+	}
+	return false;
+}
+
+function makeSink(client: NativeSessionClient): { text: () => string } {
+	let output = "";
+	const decoder = new TextDecoder();
+	client.onOutput((bytes) => {
+		output += decoder.decode(bytes, { stream: true });
+	});
+	return { text: () => output };
+}
+
+function cli(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+	const result = spawnSync([process.execPath, cliEntry, ...args], {
+		env: { ...process.env },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	return {
+		exitCode: result.exitCode,
+		stdout: new TextDecoder().decode(result.stdout),
+		stderr: new TextDecoder().decode(result.stderr),
+	};
+}
+
+function forceKillRecordedHost(hostPid: number): void {
+	if (isWindows) {
+		const result = spawnSync(["taskkill.exe", "/PID", String(hostPid), "/F"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (result.exitCode !== 0) {
+			throw new Error(`taskkill of recorded host ${hostPid} failed: ${new TextDecoder().decode(result.stderr)}`);
+		}
+		return;
+	}
+	process.kill(hostPid, "SIGKILL");
+}
+
+function readText(path: string): string {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return "";
+	}
+}
+
+async function run(): Promise<void> {
+	const root = mkdtempSync(join(tmpdir(), "dev3-native-crash-e2e-"));
+	const metadataRoot = join(root, "native-sessions");
+	const shimDir = join(root, "shim");
+	const tmuxWasInvoked = join(root, "tmux-was-invoked");
+	const unrelatedRegistryFile = join(metadataRoot, "unrelated-sentinel");
+	const sessionId = "crash-proof";
+	mkdirSync(shimDir, { recursive: true });
+	mkdirSync(metadataRoot, { recursive: true });
+	writeFileSync(unrelatedRegistryFile, "outside every session directory\n");
+	const tmuxShim = join(shimDir, isWindows ? "tmux.cmd" : "tmux");
+	writeFileSync(
+		tmuxShim,
+		isWindows
+			? `@echo off\r\necho called>>"${tmuxWasInvoked}"\r\nexit /b 0\r\n`
+			: `#!/bin/sh\necho called >> "${tmuxWasInvoked}"\nexit 0\n`,
+	);
+	if (!isWindows) chmodSync(tmuxShim, 0o755);
+
+	process.env.DEV3_NATIVE_SESSIONS_DIR = metadataRoot;
+	process.env.DEV3_NATIVE_SESSION_CMD = JSON.stringify(
+		isWindows ? ["powershell.exe", "-NoLogo", "-NoProfile"] : ["/bin/bash", "--norc", "--noprofile"],
+	);
+	process.env.PATH = `${shimDir}${delimiter}${process.env.PATH ?? ""}`;
+
+	const sentinelCommand = isWindows
+		? ["powershell.exe", "-NoLogo", "-NoProfile", "-Command", "Start-Sleep -Seconds 300"]
+		: ["sleep", "300"];
+	// Model unrelated and pre-existing tmux-owned processes without invoking tmux in the proof.
+	const unrelatedSentinel = spawn(sentinelCommand, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+	const tmuxSentinel = spawn(sentinelCommand, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+	let client: NativeSessionClient | null = null;
+
+	console.log(`  info - platform=${process.platform} bun=${Bun.version}`);
+	if (isWindows) check(Bun.version === "1.3.14", "native Windows proof runs on Bun 1.3.14");
+
+	try {
+		const started = await start(sessionId, { liveParser: true, timeoutMs: 15_000 });
+		const crashedRecord = started.record;
+		const crashedToken = readToken(sessionId);
+		check(started.status === "started", "one isolated native session started");
+		check(Boolean(crashedToken), "the crashable run published its private cleanup token");
+		check(isProcessAlive(unrelatedSentinel.pid), "unrelated process sentinel is alive outside the ownership boundary");
+		check(isProcessAlive(tmuxSentinel.pid), "tmux process sentinel is alive outside the ownership boundary");
+
+		client = new NativeSessionClient();
+		await client.connect(crashedRecord, crashedToken as string);
+		const sink = makeSink(client);
+		const sendLine = (command: string): void => client?.input(`${command}${lineEnd}`);
+
+		sendLine(isWindows ? "powershell.exe -NoLogo -NoProfile" : "bash --norc --noprofile");
+		const childMatch = isWindows
+			? await sendUntilObserved({
+					send: () => sendLine('Write-Output "CHILDPID[$PID]"'),
+					observe: () => /CHILDPID\[(\d+)\]/.exec(sink.text()),
+					attempts: 6,
+					attemptTimeoutMs: 1000,
+					pollIntervalMs: 30,
+				})
+			: await sendUntilObserved({
+					send: () => sendLine('echo "CHILDPID[$$]"'),
+					observe: () => /CHILDPID\[(\d+)\]/.exec(sink.text()),
+					attempts: 6,
+					attemptTimeoutMs: 1000,
+					pollIntervalMs: 30,
+				});
+		const childPid = Number(childMatch?.[1]);
+		check(Number.isInteger(childPid) && isProcessAlive(childPid), "root shell owns a live nested child shell");
+
+		if (isWindows) {
+			sendLine(
+				`$grand = Start-Process -PassThru powershell.exe -ArgumentList @('-NoLogo','-NoProfile','-Command','Start-Sleep -Seconds 300'); Write-Output "GRANDPID[$($grand.Id)]"`,
+			);
+		} else {
+			sendLine("set +H");
+			sendLine("sleep 300 &");
+			sendLine('echo "GRANDPID[$!]"');
+		}
+		const grandchildMatch = await sendUntilObserved({
+			send: () => {},
+			observe: () => /GRANDPID\[(\d+)\]/.exec(sink.text()),
+			attempts: 1,
+			attemptTimeoutMs: 5000,
+			pollIntervalMs: 30,
+		});
+		const grandchildPid = Number(grandchildMatch?.[1]);
+		if (!grandchildMatch) console.error(`       terminal transcript tail: ${JSON.stringify(sink.text().slice(-2000))}`);
+		check(Number.isInteger(grandchildPid) && isProcessAlive(grandchildPid), "nested child owns a live grandchild");
+
+		if (isWindows) {
+			check(await isProcessInWindowsJob(crashedToken as string, crashedRecord.host.pid), "Job Object owns the recorded host");
+			check(await isProcessInWindowsJob(crashedToken as string, crashedRecord.shell.pid), "Job Object owns the root shell");
+			check(await isProcessInWindowsJob(crashedToken as string, childPid), "Job Object owns the nested child");
+			check(await isProcessInWindowsJob(crashedToken as string, grandchildPid), "Job Object owns the grandchild");
+			check(!(await isProcessInWindowsJob(crashedToken as string, unrelatedSentinel.pid)), "Job Object excludes the unrelated sentinel");
+			check(!(await isProcessInWindowsJob(crashedToken as string, tmuxSentinel.pid)), "Job Object excludes the tmux sentinel");
+		}
+
+		const journalBeforeActivity = readText(journalFile(sessionId));
+		const watermarkBeforeActivity = readParserState(sessionId)?.watermarkSeq ?? -1;
+		sendLine(
+			isWindows
+				? 'while ($true) { Write-Output "CRASH-ACTIVITY:$PID"; Start-Sleep -Milliseconds 5 }'
+				: "i=0; while :; do printf 'CRASH-ACTIVITY:%s:%s\\n' \"$$\" \"$i\"; i=$((i+1)); for ((j=0; j<10000; j++)); do :; done; done",
+		);
+		const activePersistence = await waitUntil(() => {
+			const snapshot = readParserState(sessionId);
+			return (
+				readText(journalFile(sessionId)) !== journalBeforeActivity &&
+				Boolean(snapshot && snapshot.watermarkSeq > watermarkBeforeActivity && snapshot.health.status === "live")
+			);
+		});
+		check(activePersistence, "journal and deferred parser were actively publishing before the crash");
+
+		forceKillRecordedHost(crashedRecord.host.pid);
+		client.close();
+		client = null;
+		const ownedPids = [crashedRecord.host.pid, crashedRecord.shell.pid, childPid, grandchildPid];
+		const treeGone = await waitUntil(() => ownedPids.every((pid) => !isProcessAlive(pid)));
+		check(treeGone, "host, shell, child, and grandchild disappear within eight seconds");
+		if (isWindows) {
+			check(
+				await waitUntil(async () => !(await windowsJobExists(crashedToken as string))),
+				"the final kill-on-close Job Object handle closed after host termination",
+			);
+		}
+		check(isProcessAlive(unrelatedSentinel.pid), "force-killing the host leaves the unrelated sentinel alive");
+		check(isProcessAlive(tmuxSentinel.pid), "force-killing the host leaves the tmux sentinel alive");
+
+		for (const target of [recordFile(sessionId), tokenFile(sessionId), journalFile(sessionId), parserStateFile(sessionId)]) {
+			writeFileSync(`${target}.${crashedRecord.host.pid}.tmp`, "{ interrupted publish", { mode: 0o600 });
+		}
+		check(readRecord(sessionId)?.host.pid === crashedRecord.host.pid, "partial record temp state is never published");
+		check(NativeSessionClient.replayJournal(sessionId).length > 0, "partial journal temp state leaves the last complete tail readable");
+		check(readParserState(sessionId)?.sessionId === sessionId, "partial parser temp state leaves the last complete snapshot readable");
+
+		const crashedStatus = await status(sessionId);
+		const crashedListing = await list();
+		check(!crashedStatus.running && crashedStatus.verdict === "dead", "status reports the crashed session as dead");
+		check(
+			crashedListing.some((entry) => entry.sessionId === sessionId && entry.state === "dead"),
+			"list keeps the crashed session visible as dead until cleanup",
+		);
+		const statusCli = cli(["status", sessionId]);
+		const listCli = cli(["list"]);
+		check(statusCli.exitCode === 0 && statusCli.stdout.includes("not running (dead)"), "a fresh CLI reports dead status honestly");
+		check(listCli.exitCode === 0 && listCli.stdout.includes(`${sessionId}\tstate=dead`), "a fresh CLI lists the crashed record as dead");
+
+		const cleanupCli = cli(["cleanup-stale"]);
+		check(
+			cleanupCli.exitCode === 0 && cleanupCli.stdout.includes(`removed sessionId=${sessionId}`),
+			"fresh-process cleanup removes the token-matched crashed session",
+		);
+		check(readRecord(sessionId) === null && !existsSync(sessionDir(sessionId)), "cleanup removes record, token, journal, parser state, and owned temp files");
+		check(existsSync(unrelatedRegistryFile), "cleanup preserves unrelated registry-root state");
+		check(isProcessAlive(unrelatedSentinel.pid) && isProcessAlive(tmuxSentinel.pid), "cleanup signals no unrelated process");
+
+		const restarted = await start(sessionId, { timeoutMs: 15_000 });
+		const restartedToken = readToken(sessionId);
+		check(restarted.status === "started", "the same stable session id starts again after cleanup");
+		check(
+			restarted.record.host.pid !== crashedRecord.host.pid && restartedToken !== crashedToken,
+			"restart creates one new host with a new ownership token",
+		);
+		const duplicate = await start(sessionId, { timeoutMs: 5000 });
+		check(
+			duplicate.status === "already-running" && duplicate.record.shell.pid === restarted.record.shell.pid,
+			"a duplicate restart observes the one new shell instead of spawning another",
+		);
+		check((await list()).filter((entry) => entry.sessionId === sessionId && entry.state === "running").length === 1, "list contains one running replacement");
+		check(await stop(sessionId, { timeoutMs: 8000 }), "normal teardown removes the replacement session");
+		check(!existsSync(tmuxWasInvoked), "the registry never invoked tmux");
+	} finally {
+		client?.close();
+		try {
+			await cleanupStale();
+			await stop(sessionId, { timeoutMs: 3000 });
+		} catch {
+			// best-effort test cleanup
+		}
+		for (const sentinel of [unrelatedSentinel, tmuxSentinel]) {
+			try {
+				sentinel.kill();
+			} catch {
+				// already gone
+			}
+		}
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+run()
+	.then(() => {
+		if (failures > 0) {
+			console.error(`\n${failures} check(s) FAILED`);
+			process.exit(1);
+		}
+		console.log("\nALL CHECKS PASSED");
+		process.exit(0);
+	})
+	.catch((error) => {
+		console.error("\nERROR:", error);
+		process.exit(1);
+	});

--- a/src/bun/native-terminal-registry/__tests__/journal.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/journal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -60,6 +60,23 @@ describe("native-session journal frames", () => {
 			writer.stop();
 			const frames = parseJournal(readFileSync(path, "utf8"));
 			expect(frames.map((f) => dec(f.data))).toEqual(["one\n", "two\n"]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the last complete journal when publishing the next tail fails", () => {
+		const dir = mkdtempSync(join(tmpdir(), "dev3-native-journal-atomic-"));
+		const path = join(dir, "journal.ndjson");
+		const oldLine = encodeJournalFrame(0, "2026-07-20T00:00:00.000Z", enc("old\n"));
+		try {
+			writeFileSync(path, oldLine);
+			mkdirSync(`${path}.${process.pid}.tmp`);
+			const writer = new JournalWriter(path);
+			writer.record(enc("new\n"), "2026-07-20T00:00:01.000Z");
+			writer.stop();
+
+			expect(readFileSync(path, "utf8")).toBe(oldLine);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/src/bun/native-terminal-registry/__tests__/parser-state.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/parser-state.test.ts
@@ -74,6 +74,24 @@ describe("parser-state snapshot", () => {
 		expect(() => parseParserStateSnapshot(JSON.stringify(bad))).toThrow(/Unsupported parser-state snapshot/);
 	});
 
+	it("rejects structurally partial snapshots instead of accepting them as healthy", () => {
+		const partials = [
+			{ ...snapshot(), health: { status: "live" } },
+			{ ...snapshot(), ingested: { frames: 3 } },
+			{ ...snapshot(), latency: { drains: 3 } },
+			{ ...snapshot(), memory: { rssBytes: 100 } },
+			{ ...snapshot(), state: {} },
+		];
+		for (const partial of partials) {
+			expect(() => parseParserStateSnapshot(JSON.stringify(partial))).toThrow(/Unsupported parser-state snapshot/);
+		}
+	});
+
+	it("rejects a valid snapshot stored under a different session id", () => {
+		writeParserStateAtomic("alpha", { ...snapshot(), sessionId: "other" });
+		expect(readParserState("alpha")).toBeNull();
+	});
+
 	it("readParserState returns null for a missing or corrupt file", () => {
 		expect(readParserState("alpha")).toBeNull();
 		writeParserStateAtomic("alpha", snapshot());

--- a/src/bun/native-terminal-registry/__tests__/record.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/record.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { NATIVE_SESSIONS_DIR_ENV, recordFile, sessionDir, tokenFile } from "../paths";
+import { journalFile, NATIVE_SESSIONS_DIR_ENV, parserStateFile, recordFile, sessionDir, tokenFile } from "../paths";
 import {
 	NATIVE_SESSION_SCHEMA_VERSION,
 	parseRecord,
@@ -102,10 +102,23 @@ describe("native-session record (on disk)", () => {
 		expect(existsSync(sessionDir("alpha"))).toBe(false);
 	});
 
-	it("removeSessionState with a null guard removes state that has no token", () => {
+	it("removes only atomic temp files owned by the recorded crashed host", () => {
 		writeRecordAtomic(sample());
-		expect(removeSessionState("alpha", null)).toBe(true);
-		expect(readRecord("alpha")).toBeNull();
+		writeToken("alpha", "tok-A");
+		const targets = [recordFile("alpha"), tokenFile("alpha"), journalFile("alpha"), parserStateFile("alpha")];
+		for (const target of targets) writeFileSync(`${target}.4242.tmp`, "partial");
+		const foreignTemp = `${journalFile("alpha")}.9999.tmp`;
+		writeFileSync(foreignTemp, "leave-me");
+
+		expect(removeSessionState("alpha", "tok-A")).toBe(true);
+		for (const target of targets) expect(existsSync(`${target}.4242.tmp`)).toBe(false);
+		expect(existsSync(foreignTemp)).toBe(true);
+	});
+
+	it("removeSessionState fails closed when no expected token is available", () => {
+		writeRecordAtomic(sample());
+		expect(removeSessionState("alpha", null)).toBe(false);
+		expect(readRecord("alpha")).not.toBeNull();
 	});
 
 	it("ignores a corrupt record on read", () => {

--- a/src/bun/native-terminal-registry/__tests__/registry.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/registry.test.ts
@@ -173,6 +173,53 @@ describe("native-session registry", () => {
 		expect(readRecord("raced")).toEqual(replacement);
 	});
 
+	it("cleanup removes its empty session directory and ignores registry-root files", async () => {
+		const rootSentinel = join(root, "root-sentinel");
+		writeFileSync(rootSentinel, "unrelated\n");
+		writeToken("dead-dir", "old-token");
+		writeRecordAtomic(fakeRecord("dead-dir", 2_000_000_000));
+
+		const result = await cleanupStale(deps(async () => "dead"));
+
+		expect({
+			removed: result.removed,
+			sessionDirExists: existsSync(sessionDir("dead-dir")),
+			rootSentinelExists: existsSync(rootSentinel),
+		}).toEqual({ removed: ["dead-dir"], sessionDirExists: false, rootSentinelExists: true });
+	});
+
+	it("serialises stale cleanup against a same-id replacement start", async () => {
+		writeToken("locked-race", "old-token");
+		writeRecordAtomic(fakeRecord("locked-race", 2_000_000_000));
+		let releaseClassification: () => void = () => {};
+		const classificationBlocked = new Promise<void>((resolve) => {
+			releaseClassification = resolve;
+		});
+		let classificationEntered: () => void = () => {};
+		const entered = new Promise<void>((resolve) => {
+			classificationEntered = resolve;
+		});
+		const cleanupPromise = cleanupStale(
+			deps(async () => {
+				classificationEntered();
+				await classificationBlocked;
+				return "dead";
+			}),
+		);
+		await entered;
+		const startPromise = start("locked-race", { timeoutMs: 3000 }, deps(async () => "dead"));
+		for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+		const startedBeforeCleanupReleased = launchCalls > 0;
+		releaseClassification();
+		const [cleanup, replacement] = await Promise.all([cleanupPromise, startPromise]);
+
+		expect({ startedBeforeCleanupReleased, removed: cleanup.removed, replacement: replacement.status }).toEqual({
+			startedBeforeCleanupReleased: false,
+			removed: ["locked-race"],
+			replacement: "started",
+		});
+	});
+
 	it("stop of a non-owned session drops state without signalling the PID", async () => {
 		writeToken("z", "tz");
 		writeRecordAtomic(fakeRecord("z", process.pid));

--- a/src/bun/native-terminal-registry/__tests__/registry.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/registry.test.ts
@@ -104,6 +104,15 @@ describe("native-session registry", () => {
 		expect(result.record.host.pid).toBe(process.pid);
 	});
 
+	it("refuses to replace stale state when its cleanup token is missing", async () => {
+		writeRecordAtomic(fakeRecord("gamma", 2_000_000_000));
+		await expect(start("gamma", { timeoutMs: 3000 }, deps(async () => "dead"))).rejects.toThrow(
+			"cannot safely replace stale native session gamma",
+		);
+		expect(launchCalls).toBe(0);
+		expect(readRecord("gamma")).not.toBeNull();
+	});
+
 	it("lists sessions with verdicts and never leaks tokens", async () => {
 		writeToken("a1", "tok-A");
 		writeRecordAtomic(fakeRecord("a1", process.pid));
@@ -121,13 +130,14 @@ describe("native-session registry", () => {
 		expect(serialized).not.toContain("tok-B");
 	});
 
-	it("cleanup removes dead/reused token-matched state, keeps owned and unknown-schema", async () => {
+	it("cleanup removes dead/reused token-matched state, keeps owned, tokenless, and unknown-schema", async () => {
 		writeToken("keep", "t1");
 		writeRecordAtomic(fakeRecord("keep", process.pid));
 		writeToken("dead", "t2");
 		writeRecordAtomic(fakeRecord("dead", process.pid));
 		writeToken("reuse", "t3");
 		writeRecordAtomic(fakeRecord("reuse", process.pid));
+		writeRecordAtomic(fakeRecord("tokenless", process.pid));
 		// A record written by an unknown (newer) schema must never be deleted.
 		mkdirSync(sessionDir("weird"), { recursive: true });
 		writeFileSync(recordFile("weird"), JSON.stringify({ schemaVersion: 999 }));
@@ -140,9 +150,27 @@ describe("native-session registry", () => {
 		expect(readRecord("keep")).not.toBeNull();
 		expect(readRecord("dead")).toBeNull();
 		expect(readRecord("reuse")).toBeNull();
+		expect(readRecord("tokenless")).not.toBeNull();
+		expect(res.kept.some((entry) => entry.sessionId === "tokenless" && entry.state === "dead")).toBe(true);
 		expect(existsSync(sessionDir("weird"))).toBe(true);
 		// Cleanup is purely passive: the (alive) shell PID was never signalled.
 		expect(isProcessAlive(process.pid)).toBe(true);
+	});
+
+	it("cleanup cannot erase a newer run that replaces the token during classification", async () => {
+		writeToken("raced", "old-token");
+		writeRecordAtomic(fakeRecord("raced", 2_000_000_000));
+		const replacement = fakeRecord("raced", process.pid);
+		const d = deps(async () => {
+			writeToken("raced", "new-token");
+			writeRecordAtomic(replacement);
+			return "dead";
+		});
+
+		const result = await cleanupStale(d);
+
+		expect(result.removed).not.toContain("raced");
+		expect(readRecord("raced")).toEqual(replacement);
 	});
 
 	it("stop of a non-owned session drops state without signalling the PID", async () => {
@@ -151,6 +179,14 @@ describe("native-session registry", () => {
 		const ok = await stop("z", { timeoutMs: 1000 }, deps(async () => "reused"));
 		expect(ok).toBe(true);
 		expect(readRecord("z")).toBeNull();
+		expect(isProcessAlive(process.pid)).toBe(true);
+	});
+
+	it("stop fails closed when non-owned state has no cleanup token", async () => {
+		writeRecordAtomic(fakeRecord("tokenless-stop", process.pid));
+		const ok = await stop("tokenless-stop", { timeoutMs: 1000 }, deps(async () => "reused"));
+		expect(ok).toBe(false);
+		expect(readRecord("tokenless-stop")).not.toBeNull();
 		expect(isProcessAlive(process.pid)).toBe(true);
 	});
 

--- a/src/bun/native-terminal-registry/__tests__/run-windows-crash-recovery.ps1
+++ b/src/bun/native-terminal-registry/__tests__/run-windows-crash-recovery.ps1
@@ -1,0 +1,27 @@
+param(
+    [string]$Bun = "bun"
+)
+
+$ErrorActionPreference = "Stop"
+if ($env:OS -ne "Windows_NT") {
+    throw "This verification must run on native Windows."
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")).Path
+Push-Location $repoRoot
+try {
+    $version = (& $Bun --version).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not run Bun from '$Bun'."
+    }
+    if ($version -ne "1.3.14") {
+        throw "Expected Bun 1.3.14, found $version."
+    }
+
+    & $Bun "src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Native-session host crash recovery proof failed."
+    }
+} finally {
+    Pop-Location
+}

--- a/src/bun/native-terminal-registry/cli.ts
+++ b/src/bun/native-terminal-registry/cli.ts
@@ -8,6 +8,7 @@
  *   bun src/bun/native-terminal-registry/cli.ts status <id>         # discover + query one
  *   bun src/bun/native-terminal-registry/cli.ts attach <id>         # interactive attach (Ctrl-] detaches)
  *   bun src/bun/native-terminal-registry/cli.ts parser-state <id>   # reconstructed semantic screen (seq 1228)
+ *   bun src/bun/native-terminal-registry/cli.ts cleanup-stale       # remove token-matched dead records
  *   bun src/bun/native-terminal-registry/cli.ts stop <id>           # stop one session's tree
  *   bun src/bun/native-terminal-registry/cli.ts __host <id>         # internal: the detached host
  */
@@ -16,7 +17,7 @@ import { NativeSessionClient } from "./client";
 import { resolveHostConfig, runHost } from "./host";
 import { readParserState } from "./parser-state";
 import { readRecord, readToken } from "./record";
-import { list, start, status, stop } from "./registry";
+import { cleanupStale, list, start, status, stop } from "./registry";
 
 function requireId(): string {
 	const id = positionalArgs()[1];
@@ -134,6 +135,16 @@ async function main(): Promise<void> {
 			process.exit(0);
 			break;
 		}
+		case "cleanup-stale": {
+			const result = await cleanupStale();
+			for (const sessionId of result.removed) process.stdout.write(`removed sessionId=${sessionId}\n`);
+			for (const session of result.kept) {
+				process.stdout.write(`kept sessionId=${session.sessionId} state=${session.state}\n`);
+			}
+			if (result.removed.length === 0 && result.kept.length === 0) process.stdout.write("no native sessions\n");
+			process.exit(0);
+			break;
+		}
 		case "stop": {
 			const ok = await stop(requireId());
 			process.stdout.write(ok ? "stopped\n" : "nothing to stop (or failed)\n");
@@ -142,7 +153,7 @@ async function main(): Promise<void> {
 		}
 		default:
 			process.stdout.write(
-				"usage: cli.ts start [--live-parser] [--state-tap]|list|status|attach|parser-state|stop <sessionId>\n",
+				"usage: cli.ts start [--live-parser] [--state-tap]|list|status|attach|parser-state|cleanup-stale|stop <sessionId>\n",
 			);
 			process.exit(2);
 	}

--- a/src/bun/native-terminal-registry/journal.ts
+++ b/src/bun/native-terminal-registry/journal.ts
@@ -14,7 +14,7 @@
  * JournalWriter wraps them with buffered, debounced flushing to disk.
  */
 
-import { writeFileSync } from "node:fs";
+import { renameSync, writeFileSync } from "node:fs";
 
 export const DEFAULT_JOURNAL_MAX_BYTES = 256 * 1024;
 
@@ -109,7 +109,9 @@ export class JournalWriter {
 	flush(): void {
 		if (!this.dirty) return;
 		try {
-			writeFileSync(this.path, this.frames.join(""), { mode: 0o600 });
+			const tmp = `${this.path}.${process.pid}.tmp`;
+			writeFileSync(tmp, this.frames.join(""), { mode: 0o600 });
+			renameSync(tmp, this.path);
 			this.dirty = false;
 		} catch (err) {
 			// best-effort: a failed journal flush must never take the host down

--- a/src/bun/native-terminal-registry/parser-state.ts
+++ b/src/bun/native-terminal-registry/parser-state.ts
@@ -70,6 +70,81 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
+function isFiniteNumber(value: unknown, integer = false): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 && (!integer || Number.isInteger(value));
+}
+
+function hasNumbers(value: Record<string, unknown>, keys: string[], integer = false): boolean {
+	return keys.every((key) => isFiniteNumber(value[key], integer));
+}
+
+function isSemanticCell(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.text === "string" &&
+		isFiniteNumber(value.width, true) &&
+		typeof value.foreground === "string" &&
+		typeof value.background === "string" &&
+		Array.isArray(value.attributes) &&
+		value.attributes.every((entry) => typeof entry === "string")
+	);
+}
+
+function isSemanticLine(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.text === "string" &&
+		(value.wrapped === null || typeof value.wrapped === "boolean") &&
+		Array.isArray(value.cells) &&
+		value.cells.every(isSemanticCell)
+	);
+}
+
+function isSemanticState(value: unknown): value is NativeSemanticState {
+	if (!isRecord(value)) return false;
+	const dimensions = value.dimensions;
+	const cursor = value.cursor;
+	const modes = value.modes;
+	if (!isRecord(dimensions) || !isRecord(cursor) || !isRecord(modes)) return false;
+	const mouseTracking = modes.mouseTracking;
+	const booleanModes = [
+		"applicationCursorKeys",
+		"applicationKeypad",
+		"bracketedPaste",
+		"focusEvents",
+		"insert",
+		"origin",
+		"reverseWraparound",
+		"synchronizedOutput",
+		"wraparound",
+	];
+	return (
+		(value.activeBuffer === "normal" || value.activeBuffer === "alternate") &&
+		typeof value.title === "string" &&
+		isFiniteNumber(dimensions.cols, true) &&
+		dimensions.cols > 0 &&
+		isFiniteNumber(dimensions.rows, true) &&
+		dimensions.rows > 0 &&
+		isFiniteNumber(cursor.x, true) &&
+		isFiniteNumber(cursor.y, true) &&
+		typeof cursor.visible === "boolean" &&
+		(cursor.style === "block" || cursor.style === "underline" || cursor.style === "bar") &&
+		typeof cursor.blink === "boolean" &&
+		booleanModes.every((key) => typeof modes[key] === "boolean") &&
+		(mouseTracking === "none" ||
+			mouseTracking === "x10" ||
+			mouseTracking === "vt200" ||
+			mouseTracking === "drag" ||
+			mouseTracking === "any") &&
+		Array.isArray(value.screen) &&
+		value.screen.every(isSemanticLine) &&
+		Array.isArray(value.scrollback) &&
+		value.scrollback.every(isSemanticLine) &&
+		isFiniteNumber(value.scrollbackLength, true) &&
+		value.scrollbackLength >= value.scrollback.length
+	);
+}
+
 export function isParserStateSnapshot(value: unknown): value is ParserStateSnapshot {
 	if (!isRecord(value)) return false;
 	if (value.schema !== PARSER_STATE_SCHEMA || value.version !== PARSER_STATE_VERSION) return false;
@@ -80,7 +155,21 @@ export function isParserStateSnapshot(value: unknown): value is ParserStateSnaps
 	}
 	const status = (value.health as Record<string, unknown>).status;
 	if (status !== "live" && status !== "overflowed" && status !== "failed") return false;
-	return value.state === null || isRecord(value.state);
+	const health = value.health as Record<string, unknown>;
+	const overflow = health.overflow;
+	if (!isRecord(overflow) || !hasNumbers(overflow, ["droppedChunks", "droppedBytes", "droppedResizes"], true)) {
+		return false;
+	}
+	if (health.error !== undefined && typeof health.error !== "string") return false;
+	if (!hasNumbers(value.ingested as Record<string, unknown>, ["frames", "bytes", "resizes", "replies"], true)) {
+		return false;
+	}
+	if (!hasNumbers(value.latency as Record<string, unknown>, ["drains", "totalMs", "maxMs", "p50Ms", "p95Ms"])) {
+		return false;
+	}
+	if (!hasNumbers(value.memory as Record<string, unknown>, ["rssBytes", "heapUsedBytes"], true)) return false;
+	if (!isFiniteNumber(value.watermarkSeq, true) || typeof value.updatedAt !== "string") return false;
+	return value.state === null || isSemanticState(value.state);
 }
 
 export function parseParserStateSnapshot(serialized: string): ParserStateSnapshot {
@@ -107,7 +196,8 @@ export function writeParserStateAtomic(sessionId: string, snapshot: ParserStateS
 
 export function readParserState(sessionId: string): ParserStateSnapshot | null {
 	try {
-		return parseParserStateSnapshot(readFileSync(parserStateFile(sessionId), "utf8"));
+		const snapshot = parseParserStateSnapshot(readFileSync(parserStateFile(sessionId), "utf8"));
+		return snapshot.sessionId === sessionId ? snapshot : null;
 	} catch {
 		return null;
 	}

--- a/src/bun/native-terminal-registry/record.ts
+++ b/src/bun/native-terminal-registry/record.ts
@@ -167,7 +167,18 @@ export function readToken(sessionId: string): string | null {
  * token guard rejects the removal.
  */
 export function removeSessionState(sessionId: string, expectedToken: string | null): boolean {
-	if (expectedToken !== null && readToken(sessionId) !== expectedToken) return false;
+	if (expectedToken === null || readToken(sessionId) !== expectedToken) return false;
+	const record = readRecord(sessionId);
+	const atomicFiles = [journalFile(sessionId), parserStateFile(sessionId), tokenFile(sessionId), recordFile(sessionId)];
+	if (record && Number.isInteger(record.host.pid) && record.host.pid > 0) {
+		for (const file of atomicFiles) {
+			try {
+				unlinkSync(`${file}.${record.host.pid}.tmp`);
+			} catch {
+				// absent, already published, or not owned by this recorded host
+			}
+		}
+	}
 	const files = [
 		journalFile(sessionId),
 		parserStateFile(sessionId),

--- a/src/bun/native-terminal-registry/registry.ts
+++ b/src/bun/native-terminal-registry/registry.ts
@@ -7,9 +7,9 @@
  * purely from on-disk records + private tokens.
  *
  * Guarantees enforced here:
- *  • Concurrent start of one id is serialised by a per-session file lock — the
- *    loser observes the winner's live record and returns already-running instead
- *    of spawning a second shell.
+ *  • Start and stale cleanup of one id share a per-session file lock — a start
+ *    loser observes the winner's live record instead of spawning another shell,
+ *    and cleanup cannot erase a concurrent replacement.
  *  • Stale/dead records are detected passively (ownership.ts) and cleaned up
  *    ONLY when token-matched — never by attaching to or killing an unverified PID.
  *  • Stop tears down exactly one session through its own ownership boundary
@@ -22,7 +22,7 @@
  */
 
 import { spawn as spawnChild } from "node:child_process";
-import { closeSync, mkdirSync, openSync, readdirSync, readFileSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readdirSync, readFileSync, rmdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { withFileLock } from "../file-lock";
 import { NativeSessionClient } from "./client";
@@ -34,6 +34,8 @@ import type { StatusReply } from "./protocol";
 import { forceTerminateWindowsJob } from "./windows-job";
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const CLEANUP_LOCK_TIMEOUT_MS = 5000;
+const CLEANUP_LOCK_STALE_THRESHOLD_MS = 60 * 60_000;
 
 export interface HostSpawnOptions {
 	cmd?: string[];
@@ -215,7 +217,9 @@ export async function start(
 
 function listSessionIds(): string[] {
 	try {
-		return readdirSync(sessionsRootDir()).filter(isValidSessionId);
+		return readdirSync(sessionsRootDir(), { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && isValidSessionId(entry.name))
+			.map((entry) => entry.name);
 	} catch {
 		return [];
 	}
@@ -331,16 +335,37 @@ export async function cleanupStale(deps: RegistryDeps = defaultDeps): Promise<Cl
 	const removed: string[] = [];
 	const kept: SessionListing[] = [];
 	for (const sessionId of listSessionIds()) {
-		const record = readRecord(sessionId);
-		if (!record) continue; // corrupt / unknown-schema — never delete another version's state
-		const token = readToken(sessionId);
-		const verdict = await deps.classify(record, token);
-		if (verdict === "owned") {
-			kept.push({ sessionId, record, state: "running" });
-			continue;
+		if (!readRecord(sessionId)) continue; // avoid locking unreadable or foreign state
+		let removedState = false;
+		await withFileLock(
+			recordFile(sessionId),
+			async () => {
+				const record = readRecord(sessionId);
+				if (!record) return; // corrupt / unknown-schema — never delete another version's state
+				const token = readToken(sessionId);
+				const verdict = await deps.classify(record, token);
+				if (verdict === "owned") {
+					kept.push({ sessionId, record, state: "running" });
+					return;
+				}
+				if (removeSessionState(sessionId, token)) {
+					removed.push(sessionId);
+					removedState = true;
+				} else kept.push({ sessionId, record, state: verdict });
+			},
+			{
+				timeout: CLEANUP_LOCK_TIMEOUT_MS,
+				// Fail closed instead of breaking a plausible long-running start lock.
+				staleThreshold: CLEANUP_LOCK_STALE_THRESHOLD_MS,
+			},
+		);
+		if (removedState) {
+			try {
+				rmdirSync(sessionDir(sessionId));
+			} catch {
+				// A concurrent start or an unknown sibling now owns the directory.
+			}
 		}
-		if (removeSessionState(sessionId, token)) removed.push(sessionId);
-		else kept.push({ sessionId, record, state: verdict });
 	}
 	return { removed, kept };
 }

--- a/src/bun/native-terminal-registry/registry.ts
+++ b/src/bun/native-terminal-registry/registry.ts
@@ -168,7 +168,9 @@ export async function start(
 					return { status: "already-running", record: existing };
 				}
 				// Not ours anymore (dead/reused) — drop only our token-matched state.
-				removeSessionState(sessionId, token);
+				if (!removeSessionState(sessionId, token)) {
+					throw new Error(`cannot safely replace stale native session ${sessionId}: cleanup token is missing or changed`);
+				}
 				mkdirSync(sessionDir(sessionId), { recursive: true, mode: 0o700 });
 			}
 
@@ -269,8 +271,7 @@ export async function stop(
 
 	// Not (or no longer) ours: never signal the PID — just drop token-matched state.
 	if (verdict !== "owned") {
-		removeSessionState(sessionId, token);
-		return true;
+		return removeSessionState(sessionId, token);
 	}
 
 	const forceOwnedTree = async (hard = false): Promise<void> => {


### PR DESCRIPTION
## Summary

- add an isolated lifecycle proof that force-terminates the recorded native terminal host during journal and parser activity
- verify Windows kill-on-close Job Object containment removes the owned shell, child, and grandchild tree while unrelated and tmux sentinels survive
- make stale cleanup fail closed, serialize it against same-ID restart, and keep partial journal/parser state atomic
- document the corresponding POSIX PTY-hangup contract without changing production terminal selection, UI, RPC, schemas, or tmux
- add a native Windows Bun 1.3.14 PowerShell verifier and CI matrix coverage

## Verification

- `bun run lint`
- `bun run test` — 6,468 tests passed
- `bun run test:native-registry-e2e`
- `bun run test:native-crash-e2e` on macOS with Bun 1.3.14
- `bun run test:native-crash-e2e` on native Windows with Bun 1.3.14 — all checks passed, including final Job Object handle closure

## Scope

This remains an additive native-session proof. It does not enable a production backend, add resurrection or adoption, or modify existing tmux behavior.