### PR TITLE
Redact sensitive payloads from diagnostic logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ This installs the `dev3` CLI. Three ways to use it:
 - **Desktop GUI** — `dev3 gui` launches the full Electrobun desktop app. On the first run it lazily downloads the bundle (~88 MB) into `~/.dev3.0/gui/` and registers an XDG menu entry. If your distro is missing GTK/WebKit libraries it prints the exact `apt`/`dnf`/`pacman` command for you to copy.
 - **CLI tooling** — `dev3 task …`, `dev3 current`, `dev3 note add …` etc. when you want to script the Kanban board from a terminal.
 
+Local diagnostic logs are retained for 14 days and redact prompt-bearing payloads and command arguments. See [Local diagnostic logs](docs/diagnostic-logs.md) for the retention and payload policy.
+
 #### Pre-built CLI tarball (no Homebrew)
 
 If you don't want Homebrew at all (e.g. running inside a minimal container), grab the CLI tarball directly:

--- a/change-logs/2026/07/22/fix-diagnostic-log-privacy.md
+++ b/change-logs/2026/07/22/fix-diagnostic-log-privacy.md
@@ -1,0 +1,3 @@
+Diagnostic logs now redact task prompts, URLs, credentials, environment values, and command arguments while retaining useful local failure details. Local daily logs are bounded to the current day plus 13 previous days, and logging or cleanup failures remain non-fatal.
+
+Suggested by @nadavsheinbein (h0x91b/dev-3.0#1069)

--- a/decisions/158-redact-and-bound-diagnostic-logs.md
+++ b/decisions/158-redact-and-bound-diagnostic-logs.md
@@ -1,0 +1,21 @@
+# 158 — Redact and bound local diagnostic logs
+
+## Context
+
+The diagnostic logger serialized arbitrary RPC extras and retained daily files indefinitely. Task creation and agent launch diagnostics therefore persisted full prompts and resolved command lines, including injected instructions and credentials embedded in arguments or URLs.
+
+## Investigation
+
+The highest-risk paths were `createTask` params, PTY launch command fields, preparation spawn tracking, and direct `git`/`gh` command strings. These paths share the logger, so call-site-only redaction would leave future or less obvious log calls exposed.
+
+## Decision
+
+`src/bun/logger.ts` now sanitizes nested payloads centrally, summarizes command shape as executable plus argument count, and prunes dated files to a 14-day window after the first successful write each day. Direct command diagnostics use static event messages plus structured fields; local error messages, stacks, and command output remain available for troubleshooting, while file writes, serialization, and cleanup stay best-effort.
+
+## Risks
+
+Redaction is key-based, so a new payload field with an unrecognized name could bypass it. New diagnostics must use the existing sensitive field vocabulary or add the field to the logger policy, and commands must live in recognized command fields rather than interpolated event messages.
+
+## Alternatives considered
+
+Redacting only the known PTY and task-creation call sites was rejected because generic RPC params, git/gh helpers, and future logger users could still persist secrets. Removing all failure details was also rejected because exit codes, IDs, durations, and failure metadata are required for production diagnosis.

--- a/docs/diagnostic-logs.md
+++ b/docs/diagnostic-logs.md
@@ -1,0 +1,13 @@
+# Local diagnostic logs
+
+The Bun backend and CLI write daily diagnostic files under `~/.dev3.0/logs/YYYY/MM/YYYY-MM-DD.log`. These files are local troubleshooting data; they are not a task-history store and are not uploaded by the logger.
+
+## Retention
+
+The logger keeps the current day's file and the previous 13 calendar days (14 days total). On the first successful write of each day, it removes dated `.log` files older than that window. Missing, unreadable, or concurrently removed files do not interrupt application work.
+
+## Payload policy
+
+Log entries keep structural diagnostics such as event names, task and project IDs, counts, timings, exit codes, error messages, stacks, and command output. Prompt-bearing fields (`description`, `prompt`, `title`, and related nested values), URLs, credentials, environment values, and command arguments are replaced with redaction markers; recognized command fields retain only the executable name and argument count. New diagnostics should keep event messages static and put commands in `command`, `cmd`, or another recognized command field.
+
+File writes, serialization, and retention cleanup are best-effort. A diagnostic failure must never change the success or failure of the operation being diagnosed.

--- a/src/bun/__tests__/logger.test.ts
+++ b/src/bun/__tests__/logger.test.ts
@@ -3,12 +3,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Capture file writes without touching the real filesystem.
 const appendFileSync = vi.fn();
 const mkdirSync = vi.fn();
+const readdirSync = vi.fn();
+const unlinkSync = vi.fn();
 vi.mock("node:fs", () => ({
 	appendFileSync: (...args: unknown[]) => appendFileSync(...args),
 	mkdirSync: (...args: unknown[]) => mkdirSync(...args),
+	readdirSync: (...args: unknown[]) => readdirSync(...args),
+	unlinkSync: (...args: unknown[]) => unlinkSync(...args),
 }));
 
-import { createLogger, getLogPath, getMinLevel, resolveLogDir, resolveLogLevel, setMinLevel } from "../logger";
+import {
+	createLogger,
+	getLogPath,
+	getMinLevel,
+	pruneLogFiles,
+	resolveLogDir,
+	resolveLogLevel,
+	setMinLevel,
+} from "../logger";
 
 describe("resolveLogDir", () => {
 	it("honors an explicit DEV3_LOG_DIR override above everything else", () => {
@@ -115,6 +127,103 @@ describe("level gating", () => {
 
 		log.error("yes");
 		expect(appendFileSync).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("diagnostic payload safety", () => {
+	beforeEach(() => {
+		appendFileSync.mockClear();
+		readdirSync.mockReset();
+		readdirSync.mockReturnValue([]);
+		unlinkSync.mockReset();
+		setMinLevel("debug");
+	});
+
+	it("removes prompt and command payloads while keeping structural fields", () => {
+		const promptCanary = "PROMPT_CANARY_private-url-and-injected-instructions";
+		const commandCanary = "COMMAND_CANARY_secret-argument";
+		const urlCanary = "URL_CANARY_private-query";
+		const credentialCanary = "CREDENTIAL_CANARY_private-token";
+		const log = createLogger("privacy-test");
+
+		log.info("Agent launch", {
+			taskId: "task-structural",
+			event: "launchTaskPty",
+			durationMs: 42,
+			exitCode: 7,
+			params: { description: promptCanary },
+			tmuxCommand: `claude --prompt ${commandCanary}`,
+			installCmd: `brew install ${commandCanary}`,
+			command: `claude --prompt ${commandCanary}`,
+			url: `https://example.test/?token=${urlCanary}`,
+			extraEnv: { API_TOKEN: credentialCanary },
+			error: "ENOENT",
+			stderr: "useful local failure details",
+		});
+
+		const output = appendFileSync.mock.calls.map((call) => String(call[1])).join("\n");
+		expect(output).not.toContain(promptCanary);
+		expect(output).not.toContain(commandCanary);
+		expect(output).not.toContain(urlCanary);
+		expect(output).not.toContain(credentialCanary);
+		expect(output).toContain("task-structural");
+		expect(output).toContain("launchTaskPty");
+		expect(output).toContain('"durationMs":42');
+		expect(output).toContain('"exitCode":7');
+		expect(output).toContain('"executable":"claude"');
+		expect(output).toContain('"argumentCount":2');
+		expect(output).toContain('"error":"ENOENT"');
+		expect(output).toContain('"stderr":"useful local failure details"');
+	});
+});
+
+describe("diagnostic log retention", () => {
+	const root = "/tmp/dev3-diagnostic-logs";
+	const dirent = (name: string, directory: boolean) => ({
+		name,
+		isDirectory: () => directory,
+		isFile: () => !directory,
+	});
+
+	beforeEach(() => {
+		readdirSync.mockReset();
+		unlinkSync.mockReset();
+	});
+
+	it("removes daily files older than the documented retention window", () => {
+		const entries: Record<string, unknown[]> = {
+			[root]: [dirent("2026", true)],
+			[`${root}/2026`]: [dirent("07", true)],
+			[`${root}/2026/07`]: [
+				dirent("2026-07-08.log", false),
+				dirent("2026-07-09.log", false),
+				dirent("2026-07-22.log", false),
+			],
+		};
+		readdirSync.mockImplementation((path: string) => entries[path] ?? []);
+
+		expect(pruneLogFiles(new Date(2026, 6, 22, 12), root)).toBe(1);
+		expect(unlinkSync).toHaveBeenCalledWith(`${root}/2026/07/2026-07-08.log`);
+		expect(unlinkSync).not.toHaveBeenCalledWith(`${root}/2026/07/2026-07-09.log`);
+	});
+
+	it("does not make logging fail when the retention scan is unavailable", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 23));
+		readdirSync.mockImplementation(() => {
+			throw new Error("diagnostic directory unavailable");
+		});
+		appendFileSync.mockImplementation(() => {});
+		const log = createLogger("retention-test");
+
+		expect(() => pruneLogFiles(new Date(2026, 6, 22), root)).not.toThrow();
+		expect(() => log.info("still running", { taskId: "task-safe" })).not.toThrow();
+		expect(appendFileSync).toHaveBeenCalled();
+		expect(readdirSync).toHaveBeenCalled();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -71,7 +71,7 @@ export async function run(
 	opts?: { timeoutMs?: number; env?: Record<string, string> },
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
 	const finalCmd = withGitFilenameEncoding(cmd);
-	log.debug(`exec: ${finalCmd.join(" ")}`, { cwd });
+	log.debug("Executing git command", { cwd, command: finalCmd });
 	const proc = spawn(finalCmd, {
 		cwd,
 		stdout: "pipe",
@@ -110,7 +110,9 @@ export async function run(
 	const failure = outcome.timedOut ? `timed out after ${opts?.timeoutMs}ms` : stderr.trim();
 	const result = { ok: outcome.code === 0, stdout: stdout.trim(), stderr: failure };
 	if (!result.ok) {
-		log.warn(`Command failed (exit ${outcome.code}): ${finalCmd.join(" ")}`, {
+		log.warn("Git command failed", {
+			command: finalCmd,
+			exitCode: outcome.code,
 			stderr: result.stderr,
 		});
 	}
@@ -285,7 +287,7 @@ async function runGitStdinBinary(
 	stdin: string,
 ): Promise<{ code: number; stdout: Uint8Array }> {
 	const finalCmd = withGitFilenameEncoding(cmd);
-	log.debug(`exec(stdin): ${finalCmd.join(" ")}`, { cwd });
+	log.debug("Executing git command with stdin", { cwd, command: finalCmd });
 	const proc = spawn(finalCmd, {
 		cwd,
 		stdin: new Blob([stdin]),

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -79,7 +79,7 @@ async function runGh(
 	args: string[],
 	options?: { cwd?: string; env?: Record<string, string>; timeoutMs?: number },
 ): Promise<GitHubCommandResult> {
-	log.debug(`gh ${args.join(" ")}`, { cwd: options?.cwd });
+	log.debug("Executing GitHub CLI command", { cwd: options?.cwd, command: ["gh", ...args] });
 	const proc = spawn(["gh", ...args], {
 		cwd: options?.cwd,
 		stdout: "pipe",
@@ -110,7 +110,10 @@ async function runGh(
 		// Kill the hung process so it can't keep holding resources (e.g. a
 		// branch-status semaphore slot) after we've given up on it.
 		proc.kill();
-		log.warn(`gh ${args.join(" ")} timed out`, { timeoutMs: options?.timeoutMs });
+		log.warn("GitHub CLI command timed out", {
+			command: ["gh", ...args],
+			timeoutMs: options?.timeoutMs,
+		});
 		return { code: GH_TIMEOUT_EXIT_CODE, ok: false, stdout: "", stderr: `gh timed out after ${options?.timeoutMs}ms` };
 	}
 	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);

--- a/src/bun/logger.ts
+++ b/src/bun/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { DEV3_HOME } from "./paths";
 
@@ -20,6 +20,152 @@ const LEVEL_COLORS: Record<LogLevel, string> = {
 
 const RESET = "\x1b[0m";
 const DIM = "\x1b[2m";
+
+/** Keep today's file plus the previous 13 calendar days. */
+export const LOG_RETENTION_DAYS = 14;
+
+const REDACTED = "[redacted]";
+const LOG_FILE_RE = /^(\d{4})-(\d{2})-(\d{2})\.log$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// These values can contain the task prompt, agent instructions, credentials,
+// or command arguments. Keep the key names broad because many RPC handlers log
+// their params object directly.
+const COMMAND_KEYS = new Set([
+	"command",
+	"cmd",
+	"args",
+	"argv",
+	"agentcmd",
+	"agentcommand",
+	"tmuxcmd",
+	"tmuxcommand",
+	"installcmd",
+	"resolvedcommand",
+	"resumecommand",
+	"resumecmd",
+	"shellcommand",
+	"wrappedcommand",
+	"installcommand",
+]);
+const PAYLOAD_KEYS = new Set([
+	"description",
+	"taskdescription",
+	"prompt",
+	"taskprompt",
+	"title",
+	"tasktitle",
+	"customtitle",
+	"overview",
+	"useroverview",
+	"content",
+	"body",
+	"url",
+	"baseurl",
+	"token",
+	"secret",
+	"password",
+	"authorization",
+	"cookie",
+	"env",
+	"extraenv",
+	"envtext",
+	"input",
+]);
+
+function normalizeKey(key: string): string {
+	return key.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function stringLength(value: unknown): number | undefined {
+	if (typeof value === "string" || Array.isArray(value)) return value.length;
+	return undefined;
+}
+
+function redactedPayload(value: unknown): Record<string, unknown> {
+	const length = stringLength(value);
+	return length === undefined
+		? { redacted: true }
+		: { redacted: true, length };
+}
+
+function executableName(value: unknown): string {
+	if (typeof value !== "string") return "unknown";
+	const trimmed = value.trim();
+	if (!trimmed) return "unknown";
+	const first = trimmed.match(/^(?:'([^']+)'|"([^"]+)"|(\S+))/);
+	const token = first?.[1] ?? first?.[2] ?? first?.[3] ?? trimmed;
+	return token.split(/[\\/]/).pop() || "unknown";
+}
+
+interface CommandSummary {
+	redacted: true;
+	executable: string;
+	argumentCount: number;
+}
+
+/** Preserve command shape for diagnostics without retaining any arguments. */
+function summarizeCommand(command: unknown): CommandSummary {
+	if (Array.isArray(command)) {
+		return {
+			redacted: true,
+			executable: executableName(command[0]),
+			argumentCount: Math.max(0, command.length - 1),
+		};
+	}
+	if (typeof command === "string") {
+		const trimmed = command.trim();
+		return {
+			redacted: true,
+			executable: executableName(trimmed),
+			argumentCount: trimmed ? Math.max(0, trimmed.split(/\s+/).length - 1) : 0,
+		};
+	}
+	return { redacted: true, executable: "unknown", argumentCount: 0 };
+}
+
+type SeenObjects = WeakSet<object>;
+
+function sanitizeLogValue(value: unknown, key: string | undefined, seen: SeenObjects): unknown {
+	const normalized = key ? normalizeKey(key) : "";
+	if (COMMAND_KEYS.has(normalized)) return summarizeCommand(value);
+	if (PAYLOAD_KEYS.has(normalized)) return redactedPayload(value);
+
+	if (value === null || value === undefined) return value;
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+	if (typeof value === "bigint") return `${value}n`;
+	if (typeof value === "function" || typeof value === "symbol") return REDACTED;
+	if (typeof value !== "object") return REDACTED;
+	if (seen.has(value)) return "[circular]";
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeLogValue(item, undefined, seen));
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const [childKey, childValue] of Object.entries(value)) {
+		try {
+			result[childKey] = sanitizeLogValue(childValue, childKey, seen);
+		} catch {
+			result[childKey] = REDACTED;
+		}
+	}
+	return result;
+}
+
+/** Return a JSON-safe log payload with prompt-like values removed. */
+function sanitizeLogExtra(extra?: Record<string, unknown>): Record<string, unknown> | undefined {
+	if (!extra) return undefined;
+	try {
+		const safe = sanitizeLogValue(extra, undefined, new WeakSet<object>());
+		return safe && typeof safe === "object" && !Array.isArray(safe)
+			? safe as Record<string, unknown>
+			: { value: safe };
+	} catch {
+		return { redacted: true };
+	}
+}
 
 /**
  * Resolve the initial minimum log level.
@@ -78,6 +224,7 @@ let minLevel: LogLevel = resolveLogLevel(process.env);
 let logDir: string | null = null;
 let currentLogFile: string | null = null;
 let currentLogDate: string | null = null;
+let lastPrunedLogDate: string | null = null;
 
 // Track which directories have been created so we only mkdir once per dir.
 const ensuredDirs = new Set<string>();
@@ -120,11 +267,78 @@ function ensureDir(filePath: string): void {
 	ensuredDirs.add(dir);
 }
 
+type LogDirectoryEntry = {
+	name: string;
+	isDirectory(): boolean;
+	isFile(): boolean;
+};
+
+function readLogDirectory(path: string): LogDirectoryEntry[] {
+	return readdirSync(path, { withFileTypes: true }) as unknown as LogDirectoryEntry[];
+}
+
+function parseLogDay(fileName: string): number | null {
+	const match = LOG_FILE_RE.exec(fileName);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return null;
+	return date.getTime();
+}
+
+/** Delete dated diagnostic files outside the retention window, best-effort. */
+export function pruneLogFiles(now: Date = new Date(), root: string = getLogDir()): number {
+	const today = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+	const cutoff = today - (LOG_RETENTION_DAYS - 1) * DAY_MS;
+	let removed = 0;
+
+	try {
+		for (const yearEntry of readLogDirectory(root)) {
+			if (!yearEntry.isDirectory()) continue;
+			const yearDir = `${root}/${yearEntry.name}`;
+			for (const monthEntry of readLogDirectory(yearDir)) {
+				if (!monthEntry.isDirectory()) continue;
+				const monthDir = `${yearDir}/${monthEntry.name}`;
+				for (const fileEntry of readLogDirectory(monthDir)) {
+					if (!fileEntry.isFile()) continue;
+					const fileDay = parseLogDay(fileEntry.name);
+					if (!fileDay || fileDay >= cutoff) continue;
+					try {
+						unlinkSync(`${monthDir}/${fileEntry.name}`);
+						removed += 1;
+					} catch {
+						// A concurrent writer or a permission change must not affect logging.
+					}
+				}
+			}
+		}
+	} catch {
+		// Missing, unreadable, or partially removed log directories are harmless.
+	}
+
+	return removed;
+}
+
+function pruneLogFilesIfNeeded(): void {
+	const today = dateStr();
+	if (lastPrunedLogDate === today) return;
+	lastPrunedLogDate = today;
+	try {
+		pruneLogFiles();
+	} catch {
+		// pruneLogFiles is already defensive; keep this guard for unusual fs mocks.
+	}
+}
+
 function appendToFile(line: string): void {
 	const filePath = getLogFile();
+	let wrote = false;
 	try {
 		ensureDir(filePath);
 		appendFileSync(filePath, line + "\n");
+		wrote = true;
 	} catch {
 		// The log directory may have been removed out from under us after we
 		// cached it in `ensuredDirs` — e.g. a tmp dir wiped between tests, or a
@@ -136,10 +350,20 @@ function appendToFile(line: string): void {
 			ensuredDirs.delete(dir);
 			ensureDir(filePath);
 			appendFileSync(filePath, line + "\n");
+			wrote = true;
 		} catch (retryErr) {
 			// Last resort — don't let file logging break the app.
 			console.error("[logger] Failed to write log file:", retryErr);
 		}
+	}
+	if (wrote) pruneLogFilesIfNeeded();
+}
+
+function stringifyExtra(extra?: Record<string, unknown>): string {
+	try {
+		return JSON.stringify(extra) ?? "{}";
+	} catch {
+		return JSON.stringify({ redacted: true });
 	}
 }
 
@@ -154,7 +378,7 @@ function formatForConsole(
 	const t = timeStr();
 	let line = `${DIM}${t}${RESET} ${color}${lvl}${RESET} ${DIM}[${tag}]${RESET} ${msg}`;
 	if (extra && Object.keys(extra).length > 0) {
-		line += ` ${DIM}${JSON.stringify(extra)}${RESET}`;
+		line += ` ${DIM}${stringifyExtra(extra)}${RESET}`;
 	}
 	return line;
 }
@@ -173,7 +397,7 @@ function formatForFile(
 	// process.
 	let line = `${t} ${lvl} [${process.pid}:${tag}] ${msg}`;
 	if (extra && Object.keys(extra).length > 0) {
-		line += ` ${JSON.stringify(extra)}`;
+		line += ` ${stringifyExtra(extra)}`;
 	}
 	return line;
 }
@@ -185,9 +409,10 @@ function log(
 	extra?: Record<string, unknown>,
 ): void {
 	if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) return;
+	const safeExtra = sanitizeLogExtra(extra);
 
-	const consoleLine = formatForConsole(level, tag, msg, extra);
-	const fileLine = formatForFile(level, tag, msg, extra);
+	const consoleLine = formatForConsole(level, tag, msg, safeExtra);
+	const fileLine = formatForFile(level, tag, msg, safeExtra);
 
 	// Console output
 	switch (level) {

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -78,7 +78,15 @@ async function getAllProjectTasks(): Promise<{ projectId: string; tasks: Task[] 
 }
 
 async function createTask(params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string; scratch?: boolean; opsWorkDir?: string; priority?: TaskPriority }): Promise<Task> {
-	log.info("→ createTask", params);
+	log.info("→ createTask", {
+		projectId: params.projectId,
+		requestedStatus: params.status ?? "todo",
+		scratch: params.scratch === true,
+		descriptionLength: params.description.length,
+		hasExistingBranch: Boolean(params.existingBranch),
+		hasOpsWorkDir: Boolean(params.opsWorkDir),
+		priority: params.priority,
+	});
 	const project = await data.getProject(params.projectId);
 	const isScratch = params.scratch === true;
 	// Scratch tasks always start in "todo" with a placeholder title so the


### PR DESCRIPTION
## Summary

- redact task prompt fields, credential-bearing values, environment values, URLs, and command arguments from structured diagnostic logs
- preserve structural diagnostics and useful local failure details such as errors, stacks, stdout, and stderr
- enforce and document a best-effort 14-calendar-day retention policy
- add canary, retention, and non-fatal logging coverage

## Root cause

Production diagnostics included full task descriptions and resolved command strings, allowing prompts, credentials, URLs, and injected arguments to persist in local log files without a bounded retention policy.

## Validation

- `bun run lint`
- `bun run test` (8,462 passed; 1 skipped)
- focused logger suite (17 passed)

Closes #1069