### PR TITLE
Preserve teardown state when worktree removal fails

### DIFF
--- a/change-logs/2026/07/22/fix-worktree-removal-recovery.md
+++ b/change-logs/2026/07/22/fix-worktree-removal-recovery.md
@@ -1,0 +1,5 @@
+Short: Failed cleanups stay recoverable
+
+Task completion and cancellation now report Git worktree removal failures instead of clearing the worktree path and branch, preserving teardown state for retry or manual cleanup.
+
+Suggested by @nadavsheinbein (h0x91b/dev-3.0#1070)

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -2445,7 +2445,7 @@ describe("task.move", () => {
 		expect(git.removeWorktree).toHaveBeenCalled();
 	});
 
-	it("cleanup errors are swallowed during active → completed", async () => {
+	it("non-Git cleanup errors are swallowed during active → completed", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress" });
 
@@ -2455,7 +2455,7 @@ describe("task.move", () => {
 			throw new Error("PTY gone");
 		});
 		vi.mocked(runCleanupScript).mockRejectedValue(new Error("cleanup failed"));
-		vi.mocked(git.removeWorktree).mockRejectedValue(new Error("worktree gone"));
+		vi.mocked(git.removeWorktree).mockResolvedValue(undefined);
 		vi.mocked(data.updateTask).mockResolvedValue({
 			...task,
 			status: "completed",

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -108,6 +108,21 @@ describe("removeWorktree", () => {
 		expect(branches).not.toContain("dev3/task-aaaaaaaa");
 	});
 
+	it("rejects when Git cannot remove a present worktree", async () => {
+		const wtPath = join(repo.dir, "locked-worktree");
+		g(`git worktree add -b dev3/task-aaaaaaaa "${wtPath}" main`, repo.local);
+		g(`git worktree lock "${wtPath}"`, repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask({
+			worktreePath: wtPath,
+			branchName: "dev3/task-aaaaaaaa",
+		});
+
+		await expect(removeWorktree(project, task)).rejects.toThrow("Failed to remove worktree");
+		expect(existsSync(wtPath)).toBe(true);
+	});
+
 	it("removes worktree and deletes RENAMED branch correctly", async () => {
 		const wtPath = join(repo.dir, "worktree");
 		g(`git worktree add -b dev3/task-aaaaaaaa "${wtPath}" main`, repo.local);

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2379,7 +2379,7 @@ describe("handlers.moveTask", () => {
 	});
 
 	it.each(["completed", "cancelled"] as const)(
-		"retains cleanup metadata when Git removal fails during %s, including the forced retry",
+		"rejects %s when Git removal fails",
 		async (targetStatus) => {
 			const project = makeProject({ cleanupScript: "" });
 			const task = makeTask({
@@ -2387,28 +2387,39 @@ describe("handlers.moveTask", () => {
 				worktreePath: "/tmp/locked-worktree",
 				branchName: "dev3/task-locked",
 			});
-			const push = vi.fn();
 
 			vi.mocked(data.getProject).mockResolvedValue(project);
 			mockTaskWrites(task);
 			vi.mocked(existsSync).mockReturnValue(true);
-			setPushMessage(push);
-			const removalError = new Error("Failed to remove worktree: locked");
-			vi.mocked(git.removeWorktree)
-				.mockRejectedValueOnce(removalError)
-				.mockRejectedValueOnce(removalError);
+			vi.mocked(git.removeWorktree).mockRejectedValueOnce(new Error("Failed to remove worktree: locked"));
 
 			await expect(handlers.moveTask({
 				taskId: task.id,
 				projectId: project.id,
 				newStatus: targetStatus,
 			})).rejects.toThrow("Failed to remove worktree: locked");
-			await expect(handlers.moveTask({
+		},
+	);
+
+	it.each(["completed", "cancelled"] as const)(
+		"retains cleanup metadata when Git removal fails during %s",
+		async (targetStatus) => {
+			const project = makeProject({ cleanupScript: "" });
+			const task = makeTask({
+				status: "in-progress",
+				worktreePath: "/tmp/locked-worktree",
+				branchName: "dev3/task-locked",
+			});
+
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			mockTaskWrites(task);
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(git.removeWorktree).mockRejectedValueOnce(new Error("Failed to remove worktree: locked"));
+			await handlers.moveTask({
 				taskId: task.id,
 				projectId: project.id,
 				newStatus: targetStatus,
-				force: true,
-			})).rejects.toThrow("Failed to remove worktree: locked");
+			}).catch(() => undefined);
 
 			await expect(data.getTask(project, task.id)).resolves.toMatchObject({
 				status: "in-progress",
@@ -2419,14 +2430,66 @@ describe("handlers.moveTask", () => {
 					stage: targetStatus,
 				},
 			});
-			expect(push).toHaveBeenLastCalledWith("taskUpdated", {
-				projectId: project.id,
-				task: expect.objectContaining({
-					status: "in-progress",
-					worktreePath: task.worktreePath,
-					branchName: task.branchName,
-				}),
+		},
+	);
+
+	it("broadcasts retained cleanup metadata after Git removal fails", async () => {
+		const project = makeProject({ cleanupScript: "" });
+		const task = makeTask({
+			status: "in-progress",
+			worktreePath: "/tmp/locked-worktree",
+			branchName: "dev3/task-locked",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		mockTaskWrites(task);
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(git.removeWorktree).mockRejectedValueOnce(new Error("Failed to remove worktree: locked"));
+		setPushMessage(push);
+		await handlers.moveTask({
+			taskId: task.id,
+			projectId: project.id,
+			newStatus: "completed",
+		}).catch(() => undefined);
+
+		expect(push).toHaveBeenLastCalledWith("taskUpdated", {
+			projectId: project.id,
+			task: expect.objectContaining({
+				status: "in-progress",
+				worktreePath: task.worktreePath,
+				branchName: task.branchName,
+			}),
+		});
+	});
+
+	it.each(["completed", "cancelled"] as const)(
+		"does not bypass failed Git removal during a forced %s retry",
+		async (targetStatus) => {
+			const project = makeProject({ cleanupScript: "" });
+			const task = makeTask({
+				status: "in-progress",
+				worktreePath: "/tmp/locked-worktree",
+				branchName: "dev3/task-locked",
+				runtimeState: {
+					runtime: "tearing-down",
+					stage: targetStatus,
+					runId: "failed-run",
+					updatedAt: Date.now(),
+				},
 			});
+
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			mockTaskWrites(task);
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(git.removeWorktree).mockRejectedValueOnce(new Error("Failed to remove worktree: locked"));
+
+			await expect(handlers.moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: targetStatus,
+				force: true,
+			})).rejects.toThrow("Failed to remove worktree: locked");
 		},
 	);
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2260,7 +2260,7 @@ describe("handlers.moveTask", () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
-		expect(result.status).toBe("completed");
+		expect(result).toMatchObject({ status: "completed", worktreePath: null, branchName: null });
 		expect(pty.destroySession).toHaveBeenCalledWith("task-1", undefined);
 		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 	});
@@ -2373,9 +2373,62 @@ describe("handlers.moveTask", () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "cancelled" });
-		expect(result.status).toBe("cancelled");
+		expect(result).toMatchObject({ status: "cancelled", worktreePath: null, branchName: null });
 		expect(pty.destroySession).toHaveBeenCalled();
+		expect(git.removeWorktree).toHaveBeenCalledWith(project, task);
 	});
+
+	it.each(["completed", "cancelled"] as const)(
+		"retains cleanup metadata when Git removal fails during %s, including the forced retry",
+		async (targetStatus) => {
+			const project = makeProject({ cleanupScript: "" });
+			const task = makeTask({
+				status: "in-progress",
+				worktreePath: "/tmp/locked-worktree",
+				branchName: "dev3/task-locked",
+			});
+			const push = vi.fn();
+
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			mockTaskWrites(task);
+			vi.mocked(existsSync).mockReturnValue(true);
+			setPushMessage(push);
+			const removalError = new Error("Failed to remove worktree: locked");
+			vi.mocked(git.removeWorktree)
+				.mockRejectedValueOnce(removalError)
+				.mockRejectedValueOnce(removalError);
+
+			await expect(handlers.moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: targetStatus,
+			})).rejects.toThrow("Failed to remove worktree: locked");
+			await expect(handlers.moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: targetStatus,
+				force: true,
+			})).rejects.toThrow("Failed to remove worktree: locked");
+
+			await expect(data.getTask(project, task.id)).resolves.toMatchObject({
+				status: "in-progress",
+				worktreePath: task.worktreePath,
+				branchName: task.branchName,
+				runtimeState: {
+					runtime: "tearing-down",
+					stage: targetStatus,
+				},
+			});
+			expect(push).toHaveBeenLastCalledWith("taskUpdated", {
+				projectId: project.id,
+				task: expect.objectContaining({
+					status: "in-progress",
+					worktreePath: task.worktreePath,
+					branchName: task.branchName,
+				}),
+			});
+		},
+	);
 
 	it("in-progress → completed: kills dev server session", async () => {
 		const project = makeProject();
@@ -2463,20 +2516,6 @@ describe("handlers.moveTask", () => {
 		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
 		expect(result.status).toBe("completed");
 		expect(result.worktreePath).toBeNull();
-	});
-
-	it("should tolerate removeWorktree failure when branch is already deleted", async () => {
-		const project = makeProject({ cleanupScript: "" });
-		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/existing-worktree" });
-		vi.mocked(data.getProject).mockResolvedValue(project);
-		vi.mocked(data.getTask).mockResolvedValue(task);
-		vi.mocked(data.updateTask).mockResolvedValue({ ...task, status: "completed", worktreePath: null, branchName: null });
-		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(git.removeWorktree).mockRejectedValue(new Error("branch not found"));
-
-		const result = await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "completed" });
-		expect(result.status).toBe("completed");
-		expect(data.updateTask).toHaveBeenCalled();
 	});
 
 	it("should not throw when worktreePath is null and moving to completed", async () => {

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -2202,17 +2202,18 @@ export async function removeWorktree(
 		const removeArgs = lockedInitializing
 			? ["git", "worktree", "remove", "--force", "--force", targetPath]
 			: ["git", "worktree", "remove", "--force", targetPath];
-		const removed = await run(
+		const removeResult = await run(
 			removeArgs,
 			project.path,
 		);
-		if (!removed.ok) {
-			log.warn("Worktree removal failed; preserving its branch", {
+		if (!removeResult.ok) {
+			const detail = removeResult.stderr.trim() || "git worktree remove exited unsuccessfully";
+			log.error("Failed to remove worktree", {
 				path: targetPath,
 				taskId: task.id,
-				error: removed.stderr,
+				stderr: removeResult.stderr,
 			});
-			return;
+			throw new Error(`Failed to remove worktree at ${targetPath}: ${detail}`);
 		}
 	} else {
 		log.info("Worktree directory already missing, pruning git metadata", {

--- a/src/bun/lifecycle/__tests__/machine.test.ts
+++ b/src/bun/lifecycle/__tests__/machine.test.ts
@@ -365,6 +365,85 @@ describe("task lifecycle transition table", () => {
 		});
 	});
 
+	it.each(["completed", "cancelled"] as const)(
+		"aborts worktree removal during %s teardown with a recovery event",
+		(targetStatus) => {
+			const result = transition(state("in-progress"), {
+				type: "moveRequested",
+				target: { status: targetStatus, customColumnId: null },
+				runId: "teardown-run",
+			});
+
+			expect(result.effects.find((candidate) => candidate.type === "removeWorktree")).toMatchObject({
+				type: "removeWorktree",
+				onError: "abort",
+				compensatingEvent: {
+					type: "teardownFailed",
+					runId: "teardown-run",
+				},
+			});
+		},
+	);
+
+	it("retries worktree removal for a forced interrupted teardown", () => {
+		const result = transition(state("in-progress", {
+			runtime: {
+				phase: "tearing-down",
+				targetStatus: "completed",
+				runId: "failed-run",
+			},
+		}), {
+			type: "moveRequested",
+			target: { status: "completed", customColumnId: null },
+			runId: "retry-run",
+			force: true,
+		});
+
+		expect(result.effects.find((candidate) => candidate.type === "removeWorktree")).toMatchObject({
+			type: "removeWorktree",
+			onError: "abort",
+			compensatingEvent: { type: "teardownFailed", runId: "retry-run" },
+		});
+	});
+
+	it("publishes recovery state before rejecting a matching teardown failure", () => {
+		const current = state("in-progress", {
+			runtime: {
+				phase: "tearing-down",
+				targetStatus: "completed",
+				runId: "failed-run",
+			},
+		});
+
+		expect(transition(current, {
+			type: "teardownFailed",
+			runId: "failed-run",
+			error: "Git removal failed",
+		})).toEqual({
+			next: current,
+			effects: [
+				{ type: "push", message: "taskUpdated", view: "current", onError: "continue" },
+				{ type: "reject", message: "Git removal failed", onError: "abort" },
+			],
+		});
+	});
+
+	it("ignores a stale teardown failure event", () => {
+		const current = state("in-progress", {
+			runtime: {
+				phase: "tearing-down",
+				targetStatus: "completed",
+				runId: "current-run",
+			},
+		});
+
+		expect(transition(current, {
+			type: "teardownFailed",
+			runId: "stale-run",
+			error: "Git removal failed",
+		})).toEqual({ next: current, effects: [] });
+	});
+
 	it("allows teardown effects to derive a worktree path during preparation", () => {
 		const current = state("in-progress", {
 			runtime: {
@@ -704,5 +783,25 @@ describe("boot runtime reconciliation", () => {
 			"persistTerminalTask",
 			"push",
 		]);
+	});
+
+	it("aborts boot recovery when worktree removal fails", () => {
+		const current = state("in-progress", {
+			runtime: {
+				phase: "tearing-down",
+				targetStatus: "cancelled",
+				runId: "teardown-crash",
+			},
+		});
+		const result = transition(current, {
+			type: "bootObserved",
+			reality: { worktreeExists: true, tmuxAlive: false },
+		});
+
+		expect(result.effects.find((candidate) => candidate.type === "removeWorktree")).toMatchObject({
+			type: "removeWorktree",
+			onError: "abort",
+			compensatingEvent: { type: "teardownFailed", runId: "teardown-crash" },
+		});
 	});
 });

--- a/src/bun/lifecycle/events.ts
+++ b/src/bun/lifecycle/events.ts
@@ -112,6 +112,11 @@ export type LifecycleEvent =
 		runId: string;
 	}
 	| {
+		type: "teardownFailed";
+		runId: string;
+		error: string;
+	}
+	| {
 		type: "mergeDetected";
 		branchName: string;
 		fingerprint: string;

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -42,6 +42,14 @@ function unchanged(state: LifecycleState): TransitionResult {
 	return { next: state, effects: [] };
 }
 
+function teardownFailureEvent(runId: string): LifecycleEvent {
+	return {
+		type: "teardownFailed",
+		runId,
+		error: "Task teardown failed",
+	};
+}
+
 function resolvedTarget(state: LifecycleState, event: Extract<LifecycleEvent, { type: "moveRequested" }>): LifecycleColumn {
 	if (event.target.status) {
 		return {
@@ -233,11 +241,7 @@ function moveTransition(
 	if (event.target.status !== undefined && TERMINAL_STATUSES.has(target.status)) {
 		const terminalStatus = target.status as "completed" | "cancelled";
 		const runId = event.runId ?? "pending-run";
-		const teardownFailed: LifecycleEvent = {
-			type: "teardownFailed",
-			runId,
-			error: "Task teardown failed",
-		};
+		const teardownFailed = teardownFailureEvent(runId);
 		const runtime: LifecycleRuntime = {
 			phase: "tearing-down",
 			targetStatus: terminalStatus,
@@ -251,6 +255,8 @@ function moveTransition(
 			effect({ type: "releasePorts" }),
 			effect({ type: "persistRuntime", runtime }, "abort"),
 		];
+		// A forced retry after failed removal must resume cleanup. Bypassing it
+		// would clear the only path and branch metadata available for recovery.
 		const skipCleanup = event.force && state.runtime.phase !== "tearing-down";
 		if (!skipCleanup && (ACTIVE_STATUSES.has(oldStatus) || state.facts.hasWorktree)) {
 			const allowDerivedPath = state.runtime.phase === "preparing";
@@ -358,11 +364,7 @@ function bootTransition(
 	}
 
 	const terminalStatus = state.runtime.targetStatus;
-	const teardownFailed: LifecycleEvent = {
-		type: "teardownFailed",
-		runId: state.runtime.runId,
-		error: "Task teardown failed",
-	};
+	const teardownFailed = teardownFailureEvent(state.runtime.runId);
 	const next: LifecycleState = {
 		...state,
 		column: { status: terminalStatus, customColumnId: null },

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -233,6 +233,11 @@ function moveTransition(
 	if (event.target.status !== undefined && TERMINAL_STATUSES.has(target.status)) {
 		const terminalStatus = target.status as "completed" | "cancelled";
 		const runId = event.runId ?? "pending-run";
+		const teardownFailed: LifecycleEvent = {
+			type: "teardownFailed",
+			runId,
+			error: "Task teardown failed",
+		};
 		const runtime: LifecycleRuntime = {
 			phase: "tearing-down",
 			targetStatus: terminalStatus,
@@ -246,7 +251,8 @@ function moveTransition(
 			effect({ type: "releasePorts" }),
 			effect({ type: "persistRuntime", runtime }, "abort"),
 		];
-		if (!event.force && (ACTIVE_STATUSES.has(oldStatus) || state.facts.hasWorktree)) {
+		const skipCleanup = event.force && state.runtime.phase !== "tearing-down";
+		if (!skipCleanup && (ACTIVE_STATUSES.has(oldStatus) || state.facts.hasWorktree)) {
 			const allowDerivedPath = state.runtime.phase === "preparing";
 			effects.push(
 				effect({ type: "push", message: "taskUpdated", view: "shuttingDown" }),
@@ -256,7 +262,7 @@ function moveTransition(
 				effect({ type: "captureCompletedDiffStats", allowDerivedPath }),
 			);
 			if (state.facts.projectKind === "git") {
-				effects.push(effect({ type: "removeWorktree", allowDerivedPath }));
+				effects.push(effect({ type: "removeWorktree", allowDerivedPath }, "abort", teardownFailed));
 			}
 		}
 		effects.push(
@@ -352,6 +358,11 @@ function bootTransition(
 	}
 
 	const terminalStatus = state.runtime.targetStatus;
+	const teardownFailed: LifecycleEvent = {
+		type: "teardownFailed",
+		runId: state.runtime.runId,
+		error: "Task teardown failed",
+	};
 	const next: LifecycleState = {
 		...state,
 		column: { status: terminalStatus, customColumnId: null },
@@ -375,7 +386,7 @@ function bootTransition(
 			effect({ type: "runCleanupScript", toStatus: terminalStatus, allowDerivedPath: true }),
 			effect({ type: "captureCompletedDiffStats", allowDerivedPath: true }),
 			...(state.facts.projectKind === "git"
-				? [effect({ type: "removeWorktree", allowDerivedPath: true })]
+				? [effect({ type: "removeWorktree", allowDerivedPath: true }, "abort", teardownFailed)]
 				: []),
 			effect({ type: "persistTerminalTask", status: terminalStatus }, "abort"),
 			effect({ type: "push", message: "taskUpdated", view: "current" }),
@@ -492,6 +503,16 @@ export function transition(state: LifecycleState, event: LifecycleEvent): Transi
 					runtime: { phase: "idle" },
 				},
 				effects,
+			};
+		}
+		case "teardownFailed": {
+			if (state.runtime.phase !== "tearing-down" || state.runtime.runId !== event.runId) return unchanged(state);
+			return {
+				next: state,
+				effects: [
+					effect({ type: "push", message: "taskUpdated", view: "current" }),
+					effect({ type: "reject", message: event.error }, "abort"),
+				],
 			};
 		}
 		case "mergeDetected": {

--- a/src/bun/lifecycle/service.ts
+++ b/src/bun/lifecycle/service.ts
@@ -44,6 +44,12 @@ function errorEvent(effect: LifecycleEffect, error: unknown): LifecycleEvent | n
 			compensating: true,
 		};
 	}
+	if (effect.compensatingEvent.type === "teardownFailed") {
+		return {
+			...effect.compensatingEvent,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
 	return effect.compensatingEvent;
 }
 


### PR DESCRIPTION
## Summary

- Treat a failed `git worktree remove --force` as an explicit teardown failure.
- Preserve worktree and branch metadata plus the tearing-down runtime so cleanup can be retried or repaired manually.
- Resume forced cleanup after failure and cover cancellation, completion, boot recovery, stale events, and real locked worktrees.
- Keep successful cleanup and interrupted-initialization cleanup behavior unchanged.

## Testing

- `bun run lint`
- `bun run test`
- `bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/git-worktree.test.ts`

Closes #1070