### PR TITLE
Fix remote Chrome notification click navigation

### DIFF
--- a/change-logs/2026/07/22/fix-remote-notification-click.md
+++ b/change-logs/2026/07/22/fix-remote-notification-click.md
@@ -1,0 +1,1 @@
+Remote Chrome notifications no longer reuse the task ID as a browser notification tag, preventing Chrome from replacing a notification across remote tabs and dropping its click-to-open handler.

--- a/decisions/160-browser-notification-click-tags.md
+++ b/decisions/160-browser-notification-click-tags.md
@@ -1,0 +1,26 @@
+# 160 — Keep browser notification clicks independent
+
+## Context
+
+Remote browser notifications used the originating task ID as `Notification.tag`.
+Chrome replaces notifications with the same tag, which can leave a visible notification whose click event is owned by a different remote tab.
+
+## Investigation
+
+The in-app HTTP fallback and the renderer navigation callback both work in the browser.
+The remaining Chrome-specific boundary is native notification replacement: Chromium documents the page callback lifetime, and same-tag replacement is known to lose the original page's click callback.
+
+## Decision
+
+Create each browser notification without a task-derived `tag` in `src/mainview/utils/webNotification.ts`.
+This keeps the notification instance and its `onclick` handler owned by the page that displayed it, so clicking it can call `openTaskFromNotification` reliably.
+
+## Risks
+
+Repeated updates for one task may stack in the browser notification center instead of being coalesced by Chrome.
+This is preferable to showing a notification that cannot navigate, and the user can dismiss notifications normally.
+
+## Alternatives considered
+
+Using a unique tag would have the same cross-tab behavior as omitting the tag while making the intent less clear.
+Keeping the task ID tag preserves deduplication but retains the Chrome click-loss failure.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -3,9 +3,13 @@ import userEvent from "@testing-library/user-event";
 import App from "../App";
 import { I18nProvider } from "../i18n";
 
+const rpcTransport = vi.hoisted(() => ({ isElectrobun: true }));
+
 vi.mock("../rpc", () => ({
 	// These App tests assert the desktop layout; keep the browser menu bar unmounted.
-	isElectrobun: true,
+	get isElectrobun() {
+		return rpcTransport.isElectrobun;
+	},
 	getRpcConnectionState: vi.fn(() => "connected"),
 	reconnectRpc: vi.fn(),
 	api: {
@@ -172,12 +176,27 @@ async function renderApp() {
 	);
 }
 
+class FakeWebNotification {
+	static permission: NotificationPermission = "granted";
+	static instances: FakeWebNotification[] = [];
+	onclick: (() => void) | null = null;
+	close = vi.fn();
+
+	constructor(
+		public title: string,
+		public options?: NotificationOptions,
+	) {
+		FakeWebNotification.instances.push(this);
+	}
+}
+
 describe("App keyboard shortcuts", () => {
 	beforeEach(() => {
 		// These assert the DESKTOP keymap (⌘Q, ⌘N, zoom, ⌘1–9). happy-dom looks like
 		// a browser to `isRemote()`, where those combos are dropped/aliased, so fake
 		// the Electrobun webview flag. Safe here because rpc is mocked (above).
 		(window as Window & { __electrobunWebviewId?: number }).__electrobunWebviewId = 1;
+		rpcTransport.isElectrobun = true;
 		vi.clearAllMocks();
 		vi.mocked(api.request.checkSystemRequirements).mockResolvedValue([]);
 		vi.mocked(api.request.getProjects).mockResolvedValue([]);
@@ -556,6 +575,46 @@ describe("App keyboard shortcuts", () => {
 
 			await waitFor(() => expect(screen.getByTestId("task-screen")).toHaveAttribute("data-immersive", "false"));
 			expect(screen.queryByTestId("terminal-immersive-chrome")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("remote web notifications", () => {
+		afterEach(() => {
+			delete (window as unknown as { Notification?: unknown }).Notification;
+		});
+
+		it("opens the task when a Chrome notification is clicked", async () => {
+			rpcTransport.isElectrobun = false;
+			Object.defineProperty(window, "isSecureContext", { value: true, configurable: true });
+			FakeWebNotification.permission = "granted";
+			FakeWebNotification.instances = [];
+			(window as unknown as { Notification: unknown }).Notification = FakeWebNotification;
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:webNotification", {
+					detail: {
+						taskId: "t-web",
+						projectId: "p1",
+						kind: "event",
+						title: "#7 Task update",
+						body: "Agent finished",
+						level: "info",
+					},
+				}));
+			});
+
+			expect(FakeWebNotification.instances).toHaveLength(1);
+			expect(FakeWebNotification.instances[0].options?.tag).toBeUndefined();
+			act(() => FakeWebNotification.instances[0].onclick?.());
+
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-web"));
 		});
 	});
 

--- a/src/mainview/utils/webNotification.ts
+++ b/src/mainview/utils/webNotification.ts
@@ -110,9 +110,10 @@ export function showWebNotificationOrToast(
 
 	if (canShowWebNotification()) {
 		try {
+			// Chrome can replace same-tag notifications from another tab without
+			// delivering the click to the page that created the visible notification.
 			const n = new Notification(detail.title, {
 				body: detail.body,
-				tag: detail.taskId || undefined,
 			});
 			n.onclick = () => {
 				try {


### PR DESCRIPTION
## Summary

- Remove the task ID from the browser Notification tag so Chrome cannot replace a visible notification across remote tabs and drop its click handler.
- Add App-level browser-mode regression coverage for notification click-to-task navigation.
- Document the browser trade-off and add the release changelog entry.

## Verification

- `bun run test -- --runInBand`
- `bun run lint`
- Manual remote browser QA confirmed the HTTP fallback toast opens the originating task.