### PR TITLE
Open task status Move-to menu as a bottom sheet on narrow viewports

### DIFF
--- a/change-logs/2026/07/23/fix-mobile-status-move-bottom-sheet.md
+++ b/change-logs/2026/07/23/fix-mobile-status-move-bottom-sheet.md
@@ -1,0 +1,3 @@
+Short: Bigger mobile status controls
+
+On phones the task status "Move to" control now opens as a bottom sheet with finger-sized rows (44px touch targets) instead of a tiny anchored dropdown, both on the task screen and on Kanban board cards; the status chip in the task summary bar is also larger. Desktop behavior is unchanged.

--- a/src/mainview/components/PipelineDropdown.tsx
+++ b/src/mainview/components/PipelineDropdown.tsx
@@ -14,6 +14,10 @@ interface PipelineDropdownProps {
 	customColumns?: CustomColumn[];
 	currentCustomColumnId?: string | null;
 	project?: Pick<Project, "customStatusLabels"> | null;
+	/** "touch" bumps rows to ≥44px targets for the narrow-viewport bottom sheet. */
+	size?: "default" | "touch";
+	/** Hide the internal "Move to" header (the hosting sheet already shows one). */
+	hideHeader?: boolean;
 }
 
 /** Side-branch statuses that aren't in PIPELINE_STAGES but still need to be selectable */
@@ -27,21 +31,29 @@ export default function PipelineDropdown({
 	customColumns,
 	currentCustomColumnId,
 	project,
+	size = "default",
+	hideHeader = false,
 }: PipelineDropdownProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const states = getStageStates(currentStatus);
 	const allowed = getAllowedTransitions(currentStatus);
 	const isCancelled = currentStatus === "cancelled";
+	const touch = size === "touch";
+	const sectionPad = touch ? "px-1" : "px-3";
+	const rowText = touch ? "text-base" : "text-sm";
+	const rowPad = touch ? "min-h-[2.75rem] py-2.5 px-2" : "py-1.5 px-1.5";
 
 	return (
 		<div onClick={(e) => e.stopPropagation()}>
-			<div className="px-3 py-2 text-xs text-fg-3 uppercase tracking-wider font-semibold">
-				{t("task.moveTo")}
-			</div>
+			{!hideHeader && (
+				<div className="px-3 py-2 text-xs text-fg-3 uppercase tracking-wider font-semibold">
+					{t("task.moveTo")}
+				</div>
+			)}
 
 			{/* Main pipeline stages */}
-			<div className="px-3 pb-1">
+			<div className={`${sectionPad} pb-1`}>
 				{PIPELINE_STAGES.map((stage, i) => {
 					const state = states[i];
 					const isCurrentStage = state === "current" && !isSideBranch(currentStatus);
@@ -52,14 +64,15 @@ export default function PipelineDropdown({
 					return (
 						<div key={stage} className="flex items-stretch">
 							{/* Pipeline track (dots + line) */}
-							<div className="flex flex-col items-center w-5 flex-shrink-0">
+							<div className={`flex flex-col items-center flex-shrink-0 ${touch ? "w-6" : "w-5"}`}>
 								{/* Dot */}
-								<div className="flex items-center justify-center h-[1.875rem]">
+								<div className={`flex items-center justify-center ${touch ? "h-[2.75rem]" : "h-[1.875rem]"}`}>
 									<PipelineDot
 										state={state}
 										color={color}
 										activeColor={statusColors[currentStatus]}
 										isSideBranch={false}
+										touch={touch}
 									/>
 								</div>
 								{/* Connector line */}
@@ -80,7 +93,7 @@ export default function PipelineDropdown({
 							<button
 								onClick={canTransition ? () => onMove(stage) : undefined}
 								disabled={!canTransition}
-								className={`flex-1 text-left py-1.5 pl-1.5 pr-3 text-sm rounded-md transition-colors ${
+								className={`flex-1 text-left ${touch ? "min-h-[2.75rem] py-2.5 pl-2" : "py-1.5 pl-1.5"} pr-3 ${rowText} rounded-md transition-colors ${
 									isCurrentStage
 										? "text-fg font-semibold cursor-default"
 										: canTransition
@@ -104,7 +117,7 @@ export default function PipelineDropdown({
 			{SIDE_STATUSES.some((s) => allowed.includes(s) || currentStatus === s) && (
 				<>
 					<div className="border-t border-edge-active mx-3 my-1" />
-					<div className="px-3 pb-1">
+					<div className={`${sectionPad} pb-1`}>
 						{SIDE_STATUSES.map((stage) => {
 							const isCurrentSide = currentStatus === stage;
 							const canTransition = allowed.includes(stage) && !isCurrentSide;
@@ -117,7 +130,7 @@ export default function PipelineDropdown({
 									key={stage}
 									onClick={canTransition ? () => onMove(stage) : undefined}
 									disabled={!canTransition}
-									className={`w-full text-left flex items-center gap-2.5 py-1.5 px-1.5 text-sm rounded-md transition-colors ${
+									className={`w-full text-left flex items-center gap-2.5 ${rowPad} ${rowText} rounded-md transition-colors ${
 										isCurrentSide
 											? "text-fg font-semibold cursor-default"
 											: canTransition
@@ -126,7 +139,7 @@ export default function PipelineDropdown({
 									}`}
 								>
 									<div
-										className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+										className={`rounded-full flex-shrink-0 ${touch ? "w-3 h-3" : "w-2.5 h-2.5"}`}
 										style={{
 											background: color,
 											opacity: isCurrentSide ? 1 : 0.6,
@@ -150,7 +163,7 @@ export default function PipelineDropdown({
 			{customColumns && customColumns.length > 0 && (
 				<>
 					<div className="border-t border-edge-active mx-3 my-1" />
-					<div className="px-3 pb-1">
+					<div className={`${sectionPad} pb-1`}>
 						{customColumns.map((col) => {
 							const isCurrent = col.id === currentCustomColumnId;
 							return (
@@ -158,14 +171,14 @@ export default function PipelineDropdown({
 									key={col.id}
 									onClick={!isCurrent ? () => onMoveToCustomColumn?.(col.id) : undefined}
 									disabled={isCurrent}
-									className={`w-full text-left flex items-center gap-2.5 py-1.5 px-1.5 text-sm rounded-md transition-colors ${
+									className={`w-full text-left flex items-center gap-2.5 ${rowPad} ${rowText} rounded-md transition-colors ${
 										isCurrent
 											? "text-fg font-semibold cursor-default"
 											: "text-fg-2 hover:bg-elevated-hover hover:text-fg cursor-pointer"
 									}`}
 								>
 									<div
-										className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+										className={`rounded-full flex-shrink-0 ${touch ? "w-3 h-3" : "w-2.5 h-2.5"}`}
 										style={{
 											background: col.color,
 											boxShadow: isCurrent ? `0 0 6px ${col.color}60` : undefined,
@@ -189,10 +202,10 @@ export default function PipelineDropdown({
 				<div className="border-t border-edge-active mx-3 mt-1 pt-1 pb-1">
 					<button
 						onClick={onDelete}
-						className="w-full text-left px-1.5 py-2 text-sm text-danger hover:bg-danger/10 flex items-center gap-2.5 rounded-md transition-colors"
+						className={`w-full text-left ${touch ? "min-h-[2.75rem] px-2 py-2.5" : "px-1.5 py-2"} ${rowText} text-danger hover:bg-danger/10 flex items-center gap-2.5 rounded-md transition-colors`}
 					>
 						<svg
-							className="w-4 h-4 flex-shrink-0"
+							className={`flex-shrink-0 ${touch ? "w-5 h-5" : "w-4 h-4"}`}
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -217,14 +230,17 @@ function PipelineDot({
 	color,
 	activeColor,
 	isSideBranch: _isSide,
+	touch = false,
 }: {
 	state: StageState;
 	color: string;
 	activeColor: string;
 	isSideBranch: boolean;
+	touch?: boolean;
 }) {
-	const size = state === "current" ? 10 : 8;
-	const dotSize = state === "current" ? 10 : 6;
+	const bump = touch ? 2 : 0;
+	const size = (state === "current" ? 10 : 8) + bump;
+	const dotSize = (state === "current" ? 10 : 6) + bump;
 
 	return (
 		<div

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -24,6 +24,9 @@ import { moveTaskToStatus } from "../utils/moveTaskToStatus";
 import TaskDetailModal from "./TaskDetailModal";
 import MiniPipeline from "./MiniPipeline";
 import PipelineDropdown from "./PipelineDropdown";
+import BottomSheet from "./BottomSheet";
+import { useNarrowViewport } from "../hooks/useNarrowViewport";
+import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import ScheduleMessageModal from "./ScheduleMessageModal";
 import ScheduledMessagesChip from "./ScheduledMessagesChip";
 import AgentLauncherBadge, { resolveAgentLauncherIcon } from "./AgentLauncherBadge";
@@ -60,6 +63,7 @@ interface TaskCardProps {
 function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, bellReasons, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo, onOpenUnresolvedComments }: TaskCardProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
+	const narrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	const [moving, setMoving] = useState(false);
 	const [cancellingPreparation, setCancellingPreparation] = useState(false);
 	const [menuOpen, setMenuOpen] = useState(false);
@@ -169,6 +173,12 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		document.addEventListener("mousedown", handleClick);
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [menuOpen]);
+
+	// Crossing the narrow breakpoint must not strand the open menu — it renders
+	// as a bottom sheet on narrow and an anchored popover on desktop.
+	useEffect(() => {
+		setMenuOpen(false);
+	}, [narrow]);
 
 	// After menu renders (invisible), measure and clamp position within viewport
 	useLayoutEffect(() => {
@@ -1090,8 +1100,43 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			)}
 
 
-			{/* Status dropdown menu — portal + smart viewport clamping */}
-			{menuOpen && createPortal(
+			{/* Status dropdown menu — bottom sheet on narrow (≥44px touch rows),
+			    anchored portal + smart viewport clamping on desktop. The wrapper
+			    stops clicks bubbling through the portal back to the card. */}
+			{menuOpen && narrow && (
+				<div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()}>
+					<BottomSheet
+						open
+						onClose={() => setMenuOpen(false)}
+						title={t("task.moveTo")}
+						testId="task-status-sheet"
+					>
+						<PipelineDropdown
+							currentStatus={task.status}
+							onMove={handleMove}
+							onMoveToCustomColumn={handleMoveToCustomColumn}
+							onDelete={isCancelled ? handleDelete : undefined}
+							customColumns={project.customColumns}
+							currentCustomColumnId={task.customColumnId}
+							project={project}
+							size="touch"
+							hideHeader
+						/>
+						{hasLiveAgent && (
+							<>
+								<div className="my-1 border-t border-edge" />
+								<button
+									onClick={(e) => { e.stopPropagation(); setMenuOpen(false); setScheduleMsgOpen(true); }}
+									className="w-full text-left rounded-md min-h-[2.75rem] px-2 py-2.5 text-base text-fg-2 hover:bg-elevated-hover hover:text-fg transition-colors"
+								>
+									{t("task.sendMessageLater")}
+								</button>
+							</>
+						)}
+					</BottomSheet>
+				</div>
+			)}
+			{menuOpen && !narrow && createPortal(
 				<div
 					ref={menuRef}
 					className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active py-1.5 min-w-[11.25rem]"

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -244,9 +244,11 @@ function TaskInfoPanel({
 		setMetadataBranchState(null);
 	}, [task.id]);
 
-	// Leaving the narrow viewport (window widened) must not strand an open sheet.
+	// Crossing the narrow breakpoint must not strand an open sheet/menu — the
+	// status menu renders as a sheet on narrow and an anchored popover on desktop.
 	useEffect(() => {
 		if (!narrow) setActionsSheetOpen(false);
+		setStatusMenuOpen(false);
 	}, [narrow]);
 
 	useEffect(() => () => {
@@ -747,12 +749,15 @@ function TaskInfoPanel({
 
 	const priorityBadge = <PriorityBadge priority={task.priority} onChange={handleSetPriority} className="shrink-0" />;
 
+	// On narrow the chip is a primary touch target — bump it to ≥44px (§12.6).
 	const statusDropdownButton = (
 		<button
 			ref={statusTriggerRef}
 			onClick={toggleStatusMenu}
 			disabled={movingStatus}
-			className="flex items-center gap-2 px-2.5 py-1 rounded-lg hover:bg-elevated transition-colors flex-shrink-0"
+			className={`flex items-center gap-2 rounded-lg hover:bg-elevated transition-colors flex-shrink-0 ${
+				narrow ? "px-3 min-h-[2.75rem]" : "px-2.5 py-1"
+			}`}
 		>
 			{activeCustomColumn ? (
 				<div
@@ -762,10 +767,10 @@ function TaskInfoPanel({
 			) : (
 				<MiniPipeline status={task.status} />
 			)}
-			<span className="text-[0.6875rem] font-medium text-fg-2">
+			<span className={`font-medium text-fg-2 ${narrow ? "text-sm" : "text-[0.6875rem]"}`}>
 				{activeCustomColumn ? activeCustomColumn.name : getStatusLabel(task.status, t, project)}
 			</span>
-			<svg className="w-3 h-3 text-fg-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<svg className={`text-fg-3 ${narrow ? "w-4 h-4" : "w-3 h-3"}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
 			</svg>
 		</button>
@@ -788,6 +793,28 @@ function TaskInfoPanel({
 			/>
 		</div>,
 		document.body,
+	);
+
+	// Narrow form of the same menu: an anchored popover is a desktop idiom (small
+	// rows, edge clipping) — the manifest mandates a BottomSheet for "Move to".
+	const statusSheet = (
+		<BottomSheet
+			open={statusMenuOpen}
+			onClose={() => setStatusMenuOpen(false)}
+			title={t("task.moveTo")}
+			testId="task-status-sheet"
+		>
+			<PipelineDropdown
+				currentStatus={task.status}
+				onMove={handleStatusMove}
+				onMoveToCustomColumn={handleMoveToCustomColumn}
+				customColumns={project.customColumns}
+				currentCustomColumnId={task.customColumnId}
+				project={project}
+				size="touch"
+				hideHeader
+			/>
+		</BottomSheet>
 	);
 
 	const spawnAgentButton = isTaskActive && task.worktreePath ? (
@@ -1053,7 +1080,7 @@ function TaskInfoPanel({
 			<div className="flex-shrink-0 border-b border-edge glass-header">
 				{diffFilesPopover}
 				{fileOpenInMenuPortal}
-				{statusDropdownPortal}
+				{statusSheet}
 				{/* Wide diff counters (e.g. "9 files +451 −297") must never clip off
 				    the right edge — the bar wraps instead of keeping a fixed height,
 				    so the badge always stays fully visible and tappable. */}

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TaskCard from "../TaskCard";
 import { I18nProvider } from "../../i18n";
@@ -540,6 +540,65 @@ describe("TaskCard", () => {
 			// Click the trigger again to close — it's still the first match
 			await user.click(screen.getAllByText("Agent is Working")[0]);
 			expect(screen.queryByText("Move to")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("narrow viewport (mobile) status sheet", () => {
+		/** Stub matchMedia + innerWidth so useNarrowViewport(768) reports a phone. */
+		function mockViewport(width: number) {
+			Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width });
+			Object.defineProperty(window, "matchMedia", {
+				writable: true,
+				configurable: true,
+				value: vi.fn((query: string) => {
+					const m = query.match(/max-width:\s*(\d+)/);
+					const matches = m ? width <= Number(m[1]) : false;
+					return {
+						matches,
+						media: query,
+						addEventListener: vi.fn(),
+						removeEventListener: vi.fn(),
+						addListener: vi.fn(),
+						removeListener: vi.fn(),
+						dispatchEvent: vi.fn(),
+					};
+				}),
+			});
+		}
+
+		beforeEach(() => mockViewport(390));
+		afterEach(() => mockViewport(1024));
+
+		it("opens a bottom sheet instead of the anchored popover", async () => {
+			const user = userEvent.setup();
+			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }));
+
+			await user.click(screen.getAllByText("Agent is Working")[0]);
+
+			const sheet = screen.getByTestId("task-status-sheet");
+			expect(within(sheet).getByText("Move to")).toBeInTheDocument();
+			expect(within(sheet).getByText("Has Questions")).toBeInTheDocument();
+			expect(within(sheet).getByText("Completed")).toBeInTheDocument();
+		});
+
+		it("moves the task from the sheet without opening the card", async () => {
+			const user = userEvent.setup();
+			const navigate = vi.fn();
+			const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" });
+			mockedApi.request.moveTask.mockResolvedValue({ ...task, status: "user-questions" });
+			renderCard(task, { navigate });
+
+			await user.click(screen.getAllByText("Agent is Working")[0]);
+			await user.click(within(screen.getByTestId("task-status-sheet")).getByText("Has Questions"));
+
+			await waitFor(() => {
+				expect(mockedApi.request.moveTask).toHaveBeenCalledWith(
+					expect.objectContaining({ taskId: "t1", newStatus: "user-questions" }),
+				);
+			});
+			expect(screen.queryByTestId("task-status-sheet")).not.toBeInTheDocument();
+			// The tap inside the sheet must not bubble into the card click (navigate).
+			expect(navigate).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -3063,6 +3063,45 @@ describe("TaskInfoPanel — virtual (Operations) tasks", () => {
 			expect(screen.queryByTestId("task-actions-sheet")).not.toBeInTheDocument();
 		});
 
+		it("opens the Move to bottom sheet from the status chip (not the anchored popover)", async () => {
+			await act(async () => {
+				renderPanel(makeTask({ status: "in-progress" }));
+			});
+			await act(async () => {
+				fireEvent.click(screen.getByText("Agent is Working"));
+			});
+			const sheet = screen.getByTestId("task-status-sheet");
+			expect(within(sheet).getByText("Move to")).toBeInTheDocument();
+			expect(within(sheet).getByText("Has Questions")).toBeInTheDocument();
+			expect(within(sheet).getByText("Completed")).toBeInTheDocument();
+		});
+
+		it("moves the task from the status sheet and closes it", async () => {
+			const dispatch = vi.fn();
+			const task = makeTask({ status: "in-progress" });
+			const updatedTask = { ...task, status: "user-questions" as const };
+			mockedApi.request.moveTask.mockResolvedValue(updatedTask);
+
+			await act(async () => {
+				renderPanel(task, { dispatch });
+			});
+			await act(async () => {
+				fireEvent.click(screen.getByText("Agent is Working"));
+			});
+			await act(async () => {
+				fireEvent.click(within(screen.getByTestId("task-status-sheet")).getByText("Has Questions"));
+			});
+
+			expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
+				taskId: "t1",
+				projectId: "p1",
+				newStatus: "user-questions",
+				clientPlayedSound: false,
+			});
+			expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: updatedTask });
+			expect(screen.queryByTestId("task-status-sheet")).not.toBeInTheDocument();
+		});
+
 		it("surfaces git action rows (diff, rebase, push, create PR, merge) in the actions sheet", async () => {
 			await act(async () => {
 				renderPanel(makeTask(), { onOpenInlineDiff: vi.fn() });


### PR DESCRIPTION
Hey, Claude here — the AI working on this branch.

On phones the task status "Move to" control was nearly impossible to tap: a tiny status chip opening a small anchored dropdown. This PR makes the control touch-friendly on narrow viewports (<768px), following the UX manifest (`primitive_bottom_sheet.used_for` already mandates a BottomSheet for "Move to"; `budgets_narrow.touch_target ≥ 44px`):

- `PipelineDropdown` gains a `size="touch"` variant (≥44px rows, larger text/dots) and a `hideHeader` prop for use inside a sheet.
- `TaskInfoPanel` (narrow summary bar): the status chip grows to a 44px touch target and opens the existing `BottomSheet` primitive instead of the anchored popover.
- `TaskCard` (Kanban board): same sheet on narrow, including the "Send message later" row; taps inside the sheet no longer bubble into the card click.
- Desktop behavior is unchanged (anchored popover), verified separately.

Covered by new component tests for both call sites; manually QA'd in a headless browser at 390px and 1440px.