### PR TITLE
Add Cmd/Ctrl+O shortcut to open current project/worktree in the selected app

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ every shortcut in one panel (App + Terminal/tmux tabs). The full list is defined
 | Command palette | ⇧⌘P | Ctrl+Shift+P |
 | Keyboard shortcuts panel | ⌘/ | Ctrl+/ |
 | Help mode (explain this screen) | ⇧⌘/ | Ctrl+Shift+/ |
+| Open current project/worktree in your app | ⌘O | Ctrl+O |
 | Terminal immersive fullscreen | F11 / ⇧⌘F | F11 / Ctrl+Shift+F |
 | Back / Forward | ⌘[ / ⌘] | Ctrl+[ / Ctrl+] |
 | Previous / next live variant | ⇧⌘[ / ⇧⌘] | Ctrl+Shift+[ / Ctrl+Shift+] |

--- a/change-logs/2026/07/23/feature-cmd-o-open-in-app.md
+++ b/change-logs/2026/07/23/feature-cmd-o-open-in-app.md
@@ -1,0 +1,5 @@
+Short: Open in your app with Cmd+O
+
+Press ⌘O (macOS) or Ctrl+O (Linux) to open the current project — or the active task's worktree — in your selected app. With nothing chosen yet (or after that app is uninstalled) the shortcut opens the "Open in…" picker, and picking an app from any picker makes it the default for next time.
+
+Suggested by @Paveltarno (h0x91b/dev-3.0#1057)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2536,6 +2536,7 @@ dev3 remote</code>
           <tr><td style="padding:7px 12px">Go to project (quick switch)</td><td style="padding:7px 12px"><code>⌘K</code></td><td style="padding:7px 12px"><code>Ctrl+K</code></td></tr>
           <tr><td style="padding:7px 12px">Command palette</td><td style="padding:7px 12px"><code>⇧⌘P</code></td><td style="padding:7px 12px"><code>Ctrl+Shift+P</code></td></tr>
           <tr><td style="padding:7px 12px">Keyboard shortcuts panel</td><td style="padding:7px 12px"><code>⌘/</code></td><td style="padding:7px 12px"><code>Ctrl+/</code></td></tr>
+          <tr><td style="padding:7px 12px">Open current project/worktree in your app</td><td style="padding:7px 12px"><code>⌘O</code></td><td style="padding:7px 12px"><code>Ctrl+O</code></td></tr>
           <tr><td style="padding:7px 12px">Back / Forward</td><td style="padding:7px 12px"><code>⌘[ / ⌘]</code></td><td style="padding:7px 12px"><code>Ctrl+[ / Ctrl+]</code></td></tr>
           <tr><td style="padding:7px 12px">Switch to project 1–9 (keep view)</td><td style="padding:7px 12px"><code>⌘1–9</code></td><td style="padding:7px 12px"><code>Ctrl+1–9</code></td></tr>
           <tr><td style="padding:7px 12px">Switch to project 1–9 (flip view)</td><td style="padding:7px 12px"><code>⇧⌘1–9</code></td><td style="padding:7px 12px"><code>Ctrl+Shift+1–9</code></td></tr>

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -51,6 +51,8 @@ import { useTaskSwitcher } from "./hooks/useTaskSwitcher";
 import TaskSwitcherOverlay from "./components/TaskSwitcherOverlay";
 import ProjectQuickSwitchModal from "./components/ProjectQuickSwitchModal";
 import CommandPaletteModal from "./components/CommandPaletteModal";
+import OpenInMenu from "./components/OpenInMenu";
+import { resolveSelectedOpenInApp } from "./openInPreference";
 import TaskImageViewer from "./components/TaskImageViewer";
 import HintOverlay from "./components/HintOverlay";
 import HelpOverlay from "./components/HelpOverlay";
@@ -312,6 +314,8 @@ function App() {
 	const [showAddProjectModal, setShowAddProjectModal] = useState(false);
 	const [openAddProjectOnDashboard, setOpenAddProjectOnDashboard] = useState(false);
 	const [showProjectSwitch, setShowProjectSwitch] = useState(false);
+	// Cmd/Ctrl+O picker when no app is chosen yet (or the chosen one is gone).
+	const [openInPicker, setOpenInPicker] = useState<{ path: string; taskId?: string } | null>(null);
 	const [showCommandPalette, setShowCommandPalette] = useState(false);
 	// Vimium-style task hint navigation overlay (toggled with `f` on the board).
 	const [hintMode, setHintMode] = useState(false);
@@ -584,6 +588,28 @@ function App() {
 		return () => window.removeEventListener("menu:open-quick-shell", onOpenQuickShell);
 	}, [openQuickShell]);
 
+	// Cmd/Ctrl+O — "Open in..." the active task's worktree, or the current project
+	// when no task is active. Opens the persisted app directly; with no selection
+	// (or an app that was uninstalled) it opens the picker so a choice can be made.
+	const openInCurrent = useCallback(async () => {
+		const taskId = routeTaskId(state.route);
+		const activeTask = taskId ? state.currentProjectTasks.find((task) => task.id === taskId) : null;
+		const projectId = projectIdForRoute(state.route);
+		const project = projectId ? state.projects.find((p) => p.id === projectId) : null;
+		const path = activeTask?.worktreePath || project?.path || null;
+		if (!path) return;
+		const app = await resolveSelectedOpenInApp(() => api.request.getAvailableApps());
+		if (!app) {
+			setOpenInPicker({ path, taskId: activeTask?.id });
+			return;
+		}
+		try {
+			await api.request.openInApp({ appName: app.macAppName, path });
+		} catch (err) {
+			toast.error(t("openIn.failedOpen", { app: app.name, error: String(err) }), { taskId: activeTask?.id });
+		}
+	}, [state.route, state.currentProjectTasks, state.projects, t]);
+
 	// `g`-prefix "go to" sequence (Linear/GitHub style), kept in refs so the
 	// global keydown handler stays pure. Tiny state machine:
 	//   g          → arm "verb": expect d/p/t/s, or a 1–9 digit (= project N, keep view)
@@ -777,6 +803,14 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				api.request.hideApp().catch(() => {});
+			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "o") {
+				// Cmd/Ctrl+O — open the current project/worktree in the selected app,
+				// or the "Open in..." picker when nothing is chosen yet. In remote mode
+				// Cmd+O is the browser's Open-File dialog, so yield to it (scope: desktop).
+				if (remote) return;
+				e.preventDefault();
+				e.stopPropagation();
+				void openInCurrent();
 			} else if ((e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "n") {
 				// Cmd+Shift+N — open a new window (the native menu item has no
 				// accelerator because Electrobun can't bind chord shortcuts; see
@@ -1049,7 +1083,7 @@ function App() {
 				}
 			}
 		},
-		[armGoToIndex, armGoToVerb, clearGoTo, createTaskProjectId, cycleVariant, dispatch, goToCurrentProject, goToProjectIndex, hintMode, navigate, navigateToProject, openAddProject, openCreateTaskModal, openQuickShell, showAddProjectModal, showQuitDialog, state.projects, state.route, toggleTerminalImmersive],
+		[armGoToIndex, armGoToVerb, clearGoTo, createTaskProjectId, cycleVariant, dispatch, goToCurrentProject, goToProjectIndex, hintMode, navigate, navigateToProject, openAddProject, openCreateTaskModal, openInCurrent, openQuickShell, showAddProjectModal, showQuitDialog, state.projects, state.route, toggleTerminalImmersive],
 		{ capture: true },
 	);
 
@@ -2058,6 +2092,14 @@ function App() {
 						navigateToProject(projectId);
 					}}
 					onClose={() => setShowProjectSwitch(false)}
+				/>
+			)}
+			{openInPicker && (
+				<OpenInMenu
+					position={{ top: 76, left: Math.max(8, Math.round(window.innerWidth / 2 - 96)) }}
+					path={openInPicker.path}
+					taskId={openInPicker.taskId}
+					onClose={() => setOpenInPicker(null)}
 				/>
 			)}
 			{showCommandPalette && (

--- a/src/mainview/__tests__/keymap.test.ts
+++ b/src/mainview/__tests__/keymap.test.ts
@@ -93,10 +93,21 @@ describe("transport-aware keymap", () => {
 		expect(shortcutAppliesInMode(desktopOnly, true)).toBe(false);
 	});
 
+	it("open-in yields to the browser in remote mode (desktop-scoped)", () => {
+		// Cmd/Ctrl+O is the browser's native Open-File dialog, so the app-level
+		// shortcut must not apply in remote — it opens an app on the host the
+		// remote user can't see. Registry scope is what the handler mirrors.
+		const openIn = APP_SHORTCUTS.find((s) => s.id === "open-in")!;
+		expect(openIn.scope).toBe("desktop");
+		expect(shortcutAppliesInMode(openIn, false)).toBe(true);
+		expect(shortcutAppliesInMode(openIn, true)).toBe(false);
+		expect(appShortcutsForMode(true).map((s) => s.id)).not.toContain("open-in");
+	});
+
 	it("appShortcutsForMode(remote) excludes every desktop-only shortcut", () => {
 		const remote = appShortcutsForMode(true);
 		const ids = remote.map((s) => s.id);
-		for (const id of ["quit", "hide", "new-window", "zoom-in", "zoom-out", "zoom-reset", "hard-refresh"]) {
+		for (const id of ["quit", "hide", "new-window", "zoom-in", "zoom-out", "zoom-reset", "hard-refresh", "open-in"]) {
 			expect(ids, `${id} should be hidden in remote`).not.toContain(id);
 		}
 		// Desktop keeps them all.

--- a/src/mainview/__tests__/openInPreference.test.ts
+++ b/src/mainview/__tests__/openInPreference.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getSelectedOpenInAppId,
+	resolveSelectedOpenInApp,
+	setSelectedOpenInAppId,
+} from "../openInPreference";
+import type { ExternalApp } from "../../shared/types";
+
+const APPS: ExternalApp[] = [
+	{ id: "finder", name: "Finder", macAppName: "Finder" },
+	{ id: "vscode", name: "VS Code", macAppName: "Visual Studio Code" },
+];
+
+describe("openInPreference persistence", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("returns null before anything is selected", () => {
+		expect(getSelectedOpenInAppId()).toBeNull();
+	});
+
+	it("persists and reads back the selected app id", () => {
+		setSelectedOpenInAppId("vscode");
+		expect(getSelectedOpenInAppId()).toBe("vscode");
+	});
+
+	it("overwrites a previous selection", () => {
+		setSelectedOpenInAppId("finder");
+		setSelectedOpenInAppId("vscode");
+		expect(getSelectedOpenInAppId()).toBe("vscode");
+	});
+});
+
+describe("resolveSelectedOpenInApp (picker fallback)", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("resolves to null when no app is selected (opens the picker)", async () => {
+		const getApps = vi.fn().mockResolvedValue(APPS);
+		expect(await resolveSelectedOpenInApp(getApps)).toBeNull();
+		// No selection → no need to even query installed apps.
+		expect(getApps).not.toHaveBeenCalled();
+	});
+
+	it("resolves the selected app when it is still installed", async () => {
+		setSelectedOpenInAppId("vscode");
+		const app = await resolveSelectedOpenInApp(() => Promise.resolve(APPS));
+		expect(app).toEqual({ id: "vscode", name: "VS Code", macAppName: "Visual Studio Code" });
+	});
+
+	it("resolves to null when the selected app was uninstalled (falls back to picker)", async () => {
+		setSelectedOpenInAppId("zed");
+		const app = await resolveSelectedOpenInApp(() => Promise.resolve(APPS));
+		expect(app).toBeNull();
+	});
+});

--- a/src/mainview/components/OpenInMenu.tsx
+++ b/src/mainview/components/OpenInMenu.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { ExternalApp } from "../../shared/types";
 import { useAvailableApps } from "../hooks/useAvailableApps";
+import { setSelectedOpenInAppId } from "../openInPreference";
 import { useT } from "../i18n";
 import { api } from "../rpc";
 
@@ -82,6 +83,8 @@ export default function OpenInMenu({ position, path, taskId, onClose }: OpenInMe
 
 	async function handleOpen(app: ExternalApp) {
 		onClose();
+		// Choosing an app from any picker makes it the default for Cmd/Ctrl+O.
+		setSelectedOpenInAppId(app.id);
 		try {
 			await api.request.openInApp({ appName: app.macAppName, path });
 		} catch (err) {

--- a/src/mainview/components/__tests__/OpenInMenu.test.tsx
+++ b/src/mainview/components/__tests__/OpenInMenu.test.tsx
@@ -35,6 +35,7 @@ describe("OpenInMenu", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		invalidateAvailableApps();
+		localStorage.clear();
 	});
 
 	it("renders available apps", async () => {
@@ -70,6 +71,18 @@ describe("OpenInMenu", () => {
 				path: "/tmp/worktree",
 			});
 		});
+	});
+
+	it("persists the picked app as the default for Cmd/Ctrl+O", async () => {
+		renderMenu();
+
+		await waitFor(() => {
+			expect(screen.getByText("VS Code")).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByText("VS Code"));
+
+		expect(localStorage.getItem("dev3-open-in-app")).toBe("vscode");
 	});
 
 	it("closes on Escape key", async () => {

--- a/src/mainview/i18n/translations/en/keymap.ts
+++ b/src/mainview/i18n/translations/en/keymap.ts
@@ -39,6 +39,7 @@ const keymap = {
 	"keymap.shortcut.zoomOut": "Zoom out",
 	"keymap.shortcut.zoomReset": "Reset zoom",
 	"keymap.shortcut.hardRefresh": "Hard refresh",
+	"keymap.shortcut.openIn": "Open current project/worktree in your app (or pick one)",
 	"keymap.shortcut.keyboardShortcuts": "Show this keyboard shortcuts panel",
 	"keymap.shortcut.helpMode": "Explain this screen (help mode)",
 	"keymap.shortcut.terminalFullscreen": "Toggle terminal immersive fullscreen (task terminal only)",

--- a/src/mainview/i18n/translations/es/keymap.ts
+++ b/src/mainview/i18n/translations/es/keymap.ts
@@ -36,6 +36,7 @@ const keymap = {
 	"keymap.shortcut.zoomOut": "Alejar",
 	"keymap.shortcut.zoomReset": "Restablecer zoom",
 	"keymap.shortcut.hardRefresh": "Recarga completa",
+	"keymap.shortcut.openIn": "Abrir el proyecto/worktree actual en tu app (o elegir una)",
 	"keymap.shortcut.keyboardShortcuts": "Mostrar este panel de atajos de teclado",
 	"keymap.shortcut.helpMode": "Explicar esta pantalla (modo ayuda)",
 	"keymap.shortcut.terminalFullscreen": "Alternar pantalla inmersiva del terminal (solo en terminal de tarea)",

--- a/src/mainview/i18n/translations/ru/keymap.ts
+++ b/src/mainview/i18n/translations/ru/keymap.ts
@@ -36,6 +36,7 @@ const keymap = {
 	"keymap.shortcut.zoomOut": "Уменьшить масштаб",
 	"keymap.shortcut.zoomReset": "Сбросить масштаб",
 	"keymap.shortcut.hardRefresh": "Полная перезагрузка",
+	"keymap.shortcut.openIn": "Открыть текущий проект/worktree в вашем приложении (или выбрать)",
 	"keymap.shortcut.keyboardShortcuts": "Показать эту панель горячих клавиш",
 	"keymap.shortcut.helpMode": "Объяснить этот экран (режим подсказок)",
 	"keymap.shortcut.terminalFullscreen": "Переключить иммерсивный fullscreen терминала (только в терминале задачи)",

--- a/src/mainview/keymap.ts
+++ b/src/mainview/keymap.ts
@@ -92,6 +92,7 @@ export const APP_SHORTCUTS: ShortcutSpec[] = [
 	{ id: "zoom-out", keys: { mac: "⌘-", other: "Ctrl+Alt+-" }, descKey: "keymap.shortcut.zoomOut", category: "view", scope: "desktop" },
 	{ id: "zoom-reset", keys: { mac: "⇧⌘0", other: "Ctrl+Shift+0" }, descKey: "keymap.shortcut.zoomReset", category: "view", scope: "desktop" },
 	{ id: "hard-refresh", keys: { mac: "⌘R", other: "Ctrl+R" }, descKey: "keymap.shortcut.hardRefresh", category: "view", scope: "desktop" },
+	{ id: "open-in", keys: { mac: "⌘O", other: "Ctrl+O" }, descKey: "keymap.shortcut.openIn", category: "view", scope: "desktop" },
 	{ id: "keyboard-shortcuts", keys: { mac: "⌘/", other: "Ctrl+/" }, descKey: "keymap.shortcut.keyboardShortcuts", category: "view" },
 	{ id: "help-mode", keys: { mac: "⇧⌘/", other: "Ctrl+Shift+/" }, descKey: "keymap.shortcut.helpMode", category: "view" },
 	{ id: "terminal-fullscreen", keys: { mac: "F11 / ⇧⌘F", other: "F11 / Ctrl+Shift+F" }, descKey: "keymap.shortcut.terminalFullscreen", category: "view" },

--- a/src/mainview/openInPreference.ts
+++ b/src/mainview/openInPreference.ts
@@ -1,0 +1,36 @@
+import type { ExternalApp } from "../shared/types";
+
+/** localStorage key holding the user's selected "Open in..." app id. */
+const STORAGE_KEY = "dev3-open-in-app";
+
+/** The app id last chosen from an "Open in..." picker, or null if none yet. */
+export function getSelectedOpenInAppId(): string | null {
+	try {
+		return localStorage.getItem(STORAGE_KEY);
+	} catch {
+		return null;
+	}
+}
+
+/** Persist the chosen app so Cmd/Ctrl+O opens it directly next time. */
+export function setSelectedOpenInAppId(id: string): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, id);
+	} catch {
+		// localStorage may be unavailable (private mode); selection is best-effort.
+	}
+}
+
+/**
+ * Resolve the persisted selection against the currently installed apps. Returns
+ * null when nothing is selected yet or the chosen app is no longer available —
+ * both cases fall back to opening the picker.
+ */
+export async function resolveSelectedOpenInApp(
+	getApps: () => Promise<ExternalApp[]>,
+): Promise<ExternalApp | null> {
+	const id = getSelectedOpenInAppId();
+	if (!id) return null;
+	const apps = await getApps();
+	return apps.find((app) => app.id === id) ?? null;
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

Implements #1057. Adds a ⌘O (macOS) / Ctrl+O (Linux) app-level shortcut that opens the current project — or the active task's worktree — in the app chosen from the "Open in…" picker.

- The chosen app is persisted (localStorage `dev3-open-in-app`); picking one from any "Open in…" picker (the task-panel button or the shortcut-triggered picker) sets it as the default.
- With no selection yet — or when the chosen app was uninstalled — the shortcut opens the picker instead so a choice can be made.
- Desktop-scoped: in remote/browser mode ⌘O yields to the browser's native Open-File dialog (and is hidden in the remote shortcuts panel), since `openInApp` spawns on the host the remote user can't see.
- Registered in `keymap.ts`, localized (en/ru/es), documented in the README + landing-page shortcut tables.
- Tests cover selection persistence, picker fallback (no selection / uninstalled app), and desktop-only remote behavior.

Suggested by @Paveltarno (#1057).