### PR TITLE
Skip completion warning for PR-review tasks

### DIFF
--- a/change-logs/2026/07/23/fix-skip-completion-warning-pr-review-tasks.md
+++ b/change-logs/2026/07/23/fix-skip-completion-warning-pr-review-tasks.md
@@ -1,0 +1,1 @@
+Completing a PR-review task (created from an existing branch) no longer prompts about uncommitted, unpushed, or unmerged changes — that branch is someone else's work, not yours.

--- a/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
+++ b/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
@@ -89,6 +89,16 @@ describe("confirmTaskCompletion", () => {
 		);
 	});
 
+	it("skips the check entirely for PR-review tasks (existing branch is not the user's work)", async () => {
+		const task = { ...baseTask, existingBranch: "feature/someone-else" } as Task;
+
+		const ok = await confirmTaskCompletion(task, project, "completed", t);
+
+		expect(ok).toBe(true);
+		expect(mockedBranchStatus).not.toHaveBeenCalled();
+		expect(mockedConfirm).not.toHaveBeenCalled();
+	});
+
 	it("does not prompt (and renders no card) when there are no warnings", async () => {
 		mockedBranchStatus.mockResolvedValue({
 			insertions: 0,

--- a/src/mainview/utils/confirmTaskCompletion.ts
+++ b/src/mainview/utils/confirmTaskCompletion.ts
@@ -16,6 +16,10 @@ export async function confirmTaskCompletion(
 ): Promise<boolean> {
 	if (newStatus !== "completed" && newStatus !== "cancelled") return true;
 	if (!task.worktreePath) return true;
+	// PR-review tasks check out someone else's existing branch — the commits,
+	// unpushed and unmerged state aren't the user's work, so completing them
+	// must not warn about uncommitted/unpushed/unmerged changes.
+	if (task.existingBranch) return true;
 
 	let status;
 	try {


### PR DESCRIPTION
Completing a PR-review task no longer prompts about uncommitted, unpushed, or unmerged changes — that branch is someone else's work, not the user's.

PR-review tasks are created from an existing branch, so `task.existingBranch` is set. `confirmTaskCompletion` now short-circuits for those tasks: it skips the `getBranchStatus` check and the confirmation dialog entirely, before any warning is built. The fix lives in the single `moveTaskToStatus` code path, so every surface (board drag, card menu, info panel, terminal toolbar) behaves identically.

Regular tasks (own worktree, no existing branch) still get the warning as before.