### PR TITLE
Fix dropped openAddProjectModal push; declare cliShow* schema messages

### DIFF
--- a/change-logs/2026/07/23/fix-dropped-push-handlers.md
+++ b/change-logs/2026/07/23/fix-dropped-push-handlers.md
@@ -1,0 +1,3 @@
+Short: Fix broken Add Project menu
+
+The native "Add Project" menu item now works: its openAddProjectModal push was missing a renderer handler, so the menu did nothing. Also declared the cliShowImage / cliShowArtifact push messages in the RPC schema (they were sent and handled but undeclared).

--- a/src/mainview/__tests__/rpc-schema.test.ts
+++ b/src/mainview/__tests__/rpc-schema.test.ts
@@ -14,3 +14,12 @@ describe("AppRPCSchema webview messages", () => {
 		expect(sharedTypesSource).toContain("osc52Clipboard: { taskId: string; text: string; len: number };");
 	});
 });
+
+describe("AppRPCSchema bun messages", () => {
+	it("declares the CLI shared-image / shared-artifact push messages", () => {
+		expect(sharedTypesSource).toContain("cliShowImage: {");
+		expect(sharedTypesSource).toContain("images: SharedImage[];");
+		expect(sharedTypesSource).toContain("cliShowArtifact: {");
+		expect(sharedTypesSource).toContain("artifacts: SharedArtifact[];");
+	});
+});

--- a/src/mainview/__tests__/rpc-transport.test.ts
+++ b/src/mainview/__tests__/rpc-transport.test.ts
@@ -85,6 +85,23 @@ describe("Electrobun RPC transport", () => {
 
 		window.removeEventListener("rpc:openTaskFromNotification", listener);
 	});
+
+	it("dispatches a CustomEvent when the native menu pushes openAddProjectModal", async () => {
+		const listener = vi.fn();
+		window.addEventListener("rpc:openAddProjectModal", listener);
+
+		await import("../rpc");
+
+		const rpcConfig = defineRPCMock.mock.calls[0]?.[0];
+		expect(rpcConfig).toBeDefined();
+
+		expect(typeof rpcConfig.handlers.messages.openAddProjectModal).toBe("function");
+		rpcConfig.handlers.messages.openAddProjectModal({});
+
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		window.removeEventListener("rpc:openAddProjectModal", listener);
+	});
 });
 
 describe("Browser RPC transport", () => {

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -84,6 +84,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	automationsUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:automationsUpdated", { detail: payload })),
 	automationRunsMissed: (payload) => window.dispatchEvent(new CustomEvent("rpc:automationRunsMissed", { detail: payload })),
 	openCreateTaskModal: () => window.dispatchEvent(new CustomEvent("rpc:openCreateTaskModal")),
+	openAddProjectModal: () => window.dispatchEvent(new CustomEvent("rpc:openAddProjectModal")),
 	navigateToSettings: () => window.dispatchEvent(new CustomEvent("rpc:navigateToSettings")),
 	navigateToGaugeDemo: () => window.dispatchEvent(new CustomEvent("rpc:navigateToGaugeDemo")),
 	navigateToViewportLab: () => window.dispatchEvent(new CustomEvent("rpc:navigateToViewportLab")),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3514,6 +3514,34 @@ export type AppRPCSchema = {
 			 */
 			cliAttention: { taskId: string; reason: string };
 			/**
+			 * CLI-shared images (`dev3 show-image`). Carries the task's shared images
+			 * so the renderer can raise the attention badge and open the lightbox
+			 * (auto-open only when already viewing the task). Sole emitter:
+			 * `pushCliShowImage` in `src/bun/rpc-handlers/shared.ts`.
+			 */
+			cliShowImage: {
+				taskId: string;
+				projectId: string;
+				images: SharedImage[];
+				newCount: number;
+				taskSeq?: number;
+				taskTitle?: string;
+				projectName?: string;
+			};
+			/**
+			 * CLI-shared HTML artifacts (`dev3 show-artifact`). Same delivery model as
+			 * {@link cliShowImage} but for self-contained artifacts.
+			 */
+			cliShowArtifact: {
+				taskId: string;
+				projectId: string;
+				artifacts: SharedArtifact[];
+				newCount: number;
+				taskSeq?: number;
+				taskTitle?: string;
+				projectName?: string;
+			};
+			/**
 			 * Browser Web Notification request. Mirrors a native OS notification
 			 * (`dev3 notify --desktop`, watched-task status/event banners) for clients
 			 * running in remote/browser mode, where `Utils.showNotification` is a no-op.


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

Fixes two silently-dropped bun→renderer push messages found during the push-bus design audit (Seq 1016).

## Summary

- **`openAddProjectModal`** — the native "Add Project" menu item pushed `openAddProjectModal`, but the renderer's `pushMessageHandlers` (`src/mainview/rpc.ts`) had no entry for it, so the menu did nothing on either transport (Electrobun `defineRPC` and browser `handlePacket` both consume this shared map). Added the handler.
- **`cliShowImage` / `cliShowArtifact`** — sent from bun and handled in the renderer, but never declared in the schema message maps. Added the declarations to the `bun` channel in `src/shared/types.ts`.

## Not a bug: `taskRemoved`

The audit also flagged `taskRemoved`, but that message was intentionally removed in #989 ("Keep task id stable when launching variants"): `spawnVariants` now transforms the source todo in place into variant #1 (keeps its id, no `deleteTask`), and clients learn about it via `taskUpdated`. There is no emitter or listener for `taskRemoved` today, so it was deliberately **not** re-added.

## Tests

Bug workflow followed — failing tests first, then the fix:
- `src/mainview/__tests__/rpc-transport.test.ts` — asserts the Electrobun transport registers an `openAddProjectModal` handler that dispatches the `rpc:openAddProjectModal` CustomEvent.
- `src/mainview/__tests__/rpc-schema.test.ts` — asserts the schema declares the `cliShowImage` / `cliShowArtifact` push messages.

`bun run lint` and the full `bun run test` suite are green.