### PR TITLE
Add task relationship foundations

### DIFF
--- a/change-logs/2026/07/21/feature-task-relations-foundation.md
+++ b/change-logs/2026/07/21/feature-task-relations-foundation.md
@@ -1,0 +1,1 @@
+Added a forward-compatible task relation model with typed `blocked-by` and `relates-to` links. New and migrated tasks persist an empty relation collection, while existing UI and integrations remain unchanged.

--- a/change-logs/2026/07/21/feature-task-relations-foundation.md
+++ b/change-logs/2026/07/21/feature-task-relations-foundation.md
@@ -1,1 +1,1 @@
-Added a forward-compatible task relation model with typed `blocked-by` and `relates-to` links. New and migrated tasks persist an empty relation collection, while existing UI and integrations remain unchanged.
+Added a forward-compatible task relation model with typed `blocked-by` and `relates-to` links. New and migrated tasks persist an empty relation collection, older-reader updates preserve it, and existing UI and integrations remain unchanged.

--- a/decisions/148-task-relation-foundation.md
+++ b/decisions/148-task-relation-foundation.md
@@ -1,0 +1,21 @@
+# 148 — Task relation foundation
+
+## 1. Context
+
+Tasks need a durable place for future Jira-like links without introducing UI behavior or external synchronization yet. The first relation kinds are `blocked-by` and `relates-to`.
+
+## 2. Investigation
+
+Task state is stored as objects in `tasks.json`, and the data layer already preserves additive fields while performing content-only migrations. Existing task mutations use the same locked read-modify-write path, so a relation collection belongs on the task model rather than in a second store.
+
+## 3. Decision
+
+Represent links as optional `Task.relations`, with each entry containing a stable `taskId` and a `TaskRelationType`. New tasks initialize the collection and mutator reads backfill it to `[]`; no UI, CLI, RPC action, reverse-link materialization, or external integration is added yet.
+
+## 4. Risks
+
+Relation records can point at deleted or cross-project tasks until a future relation service adds validation and cleanup rules. Treating the field as optional keeps raw legacy files readable while allowing older app versions to preserve the additive key when they rewrite a task.
+
+## 5. Alternatives considered
+
+Separate `blockedBy` and `relatesTo` arrays were rejected because every future relation kind would require another schema field and migration. A separate relation file was rejected because it would add cross-file locking and lifecycle work before relation behavior exists.

--- a/decisions/148-task-relation-foundation.md
+++ b/decisions/148-task-relation-foundation.md
@@ -14,7 +14,7 @@ Represent links as optional `Task.relations`, with each entry containing a stabl
 
 ## 4. Risks
 
-Relation records can point at deleted or cross-project tasks until a future relation service adds validation and cleanup rules. Treating the field as optional keeps raw legacy files readable while allowing older app versions to preserve the additive key when they rewrite a task.
+Relation records can point at deleted or cross-project tasks until a future relation service adds validation and cleanup rules. Treating the field as optional keeps raw legacy files readable, and the compatibility regression test verifies an older-reader-shaped update preserves the additive key.
 
 ## 5. Alternatives considered
 

--- a/src/bun/__tests__/data-reorder.test.ts
+++ b/src/bun/__tests__/data-reorder.test.ts
@@ -819,7 +819,7 @@ describe("same-status move — backward compatibility", () => {
 		"updatedAt", "movedAt", "columnOrder", "tmuxSocket", "labelIds", "existingBranch",
 		"notes", "customColumnId", "history", "preparing", "preparingStage",
 		"preparingProgress", "preparingStartedAt", "watched", "sessionState",
-		"mergeCompletionPrompt", "manualCompletion", "scratch", "scriptLastRunAt", "scriptLastPlacement",
+		"mergeCompletionPrompt", "manualCompletion", "scratch", "scriptLastRunAt", "scriptLastPlacement", "relations",
 	]);
 
 	it("introduces no new task fields when moving builtin -> custom column", async () => {

--- a/src/bun/__tests__/data-task-relations.test.ts
+++ b/src/bun/__tests__/data-task-relations.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { TASK_RELATION_TYPES } from "../../shared/types";
+import type { Project, Task, TaskRelation } from "../../shared/types";
+
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-task-relations`);
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: TEST_HOME,
+}));
+
+vi.mock("../file-lock", () => ({
+	withFileLock: async <T>(_filePath: string, fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+beforeEach(() => {
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
+});
+
+import { addTask, loadTasks, updateTask } from "../data";
+
+const testProject: Project = {
+	id: "proj-1",
+	name: "Test",
+	path: "/tmp/test-project",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-01T00:00:00Z",
+};
+
+function tasksFilePath(): string {
+	return `${TEST_HOME}/data/tmp-test-project/tasks.json`;
+}
+
+function seedTasks(tasks: unknown[]): void {
+	mkdirSync(dirname(tasksFilePath()), { recursive: true });
+	writeFileSync(tasksFilePath(), JSON.stringify(tasks));
+}
+
+function readSavedTasks(): Task[] {
+	return JSON.parse(readFileSync(tasksFilePath(), "utf8"));
+}
+
+describe("task relation persistence", () => {
+	it("exposes the reserved relation kinds", () => {
+		expect(TASK_RELATION_TYPES).toEqual(["blocked-by", "relates-to"]);
+	});
+
+	it("initializes an empty relation collection for new tasks", async () => {
+		const task = await addTask(testProject, "Fresh task");
+
+		expect(task.relations).toEqual([]);
+		expect(readSavedTasks()[0].relations).toEqual([]);
+	});
+
+	it("persists blocked-by and relates-to relation records", async () => {
+		const blockedTask = await addTask(testProject, "Blocked task");
+		const relatedTask = await addTask(testProject, "Related task");
+		const relations: TaskRelation[] = [
+			{ type: "blocked-by", taskId: relatedTask.id },
+			{ type: "relates-to", taskId: blockedTask.id },
+		];
+
+		await updateTask(testProject, blockedTask.id, { relations });
+
+		expect((await loadTasks(testProject)).find((task) => task.id === blockedTask.id)?.relations).toEqual(relations);
+	});
+
+	it("backfills the empty relation collection when a legacy task is mutated", async () => {
+		seedTasks([
+			{
+				id: "legacy-task",
+				seq: 1,
+				projectId: testProject.id,
+				title: "Legacy task",
+				description: "Legacy task",
+				status: "todo",
+				baseBranch: "main",
+				worktreePath: null,
+				branchName: null,
+				groupId: null,
+				variantIndex: null,
+				agentId: null,
+				configId: null,
+				createdAt: "2025-01-01T00:00:00Z",
+				updatedAt: "2025-01-01T00:00:00Z",
+			},
+		]);
+
+		await updateTask(testProject, "legacy-task", { title: "Updated task" });
+
+		expect(readSavedTasks()[0].relations).toEqual([]);
+	});
+});

--- a/src/bun/__tests__/data-task-relations.test.ts
+++ b/src/bun/__tests__/data-task-relations.test.ts
@@ -74,6 +74,36 @@ describe("task relation persistence", () => {
 		expect((await loadTasks(testProject)).find((task) => task.id === blockedTask.id)?.relations).toEqual(relations);
 	});
 
+	it("preserves relation records through an older-reader-shaped task update", async () => {
+		const relations: TaskRelation[] = [{ type: "blocked-by", taskId: "blocker-task" }];
+		seedTasks([
+			{
+				id: "legacy-reader-task",
+				seq: 1,
+				projectId: testProject.id,
+				title: "Legacy reader task",
+				description: "Legacy reader task",
+				status: "todo",
+				priority: "P3",
+				baseBranch: "main",
+				worktreePath: null,
+				branchName: null,
+				groupId: null,
+				variantIndex: null,
+				agentId: null,
+				configId: null,
+				createdAt: "2025-01-01T00:00:00Z",
+				updatedAt: "2025-01-01T00:00:00Z",
+				relations,
+			},
+		]);
+
+		// Older readers ignore the unknown field; their object-preserving writes must keep it.
+		await updateTask(testProject, "legacy-reader-task", { title: "Updated task" });
+
+		expect(readSavedTasks()[0].relations).toEqual(relations);
+	});
+
 	it("backfills the empty relation collection when a legacy task is mutated", async () => {
 		seedTasks([
 			{

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -603,6 +603,7 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 		const tasks = JSON.parse(await readFile(file, "utf8")) as Task[];
 		// Backfill fields for tasks created before they existed
 		let backfilledPriority = false;
+		let backfilledRelations = false;
 		for (const task of tasks) {
 			if ((task as any).description === undefined) {
 				task.description = task.title;
@@ -625,7 +626,11 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 			if ((task as any).customColumnId === undefined) task.customColumnId = null;
 			if ((task as any).overview === undefined) task.overview = null;
 			if ((task as any).userOverview === undefined) task.userOverview = null;
-				if ((task as any).history === undefined) task.history = [];
+			if ((task as any).relations === undefined) {
+				task.relations = [];
+				backfilledRelations = true;
+			}
+			if ((task as any).history === undefined) task.history = [];
 		}
 
 		// Backfill seq for tasks created before seq existed
@@ -656,11 +661,11 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 			}
 		}
 
-		// Persist the priority backfill so the field lands on disk once (content-only,
-		// same in-place pattern as the seq migration). Only on mutator reads
-		// (persistMigrations) — pure cached reads never rewrite the file.
-		if (backfilledPriority && options?.persistMigrations) {
-			log.info("Backfilled priority for tasks", { projectId: project.id });
+		// Persist content-only backfills together so one mutator read causes one write.
+		// Pure cached reads never rewrite the file.
+		if (options?.persistMigrations && (backfilledPriority || backfilledRelations)) {
+			if (backfilledPriority) log.info("Backfilled priority for tasks", { projectId: project.id });
+			if (backfilledRelations) log.info("Backfilled relations for tasks", { projectId: project.id });
 			await rawSaveTasks(project, tasks);
 		}
 
@@ -808,6 +813,7 @@ export async function addTask(
 		userOverview?: string | null;
 		automationId?: string | null;
 		priority?: TaskPriority;
+		relations?: Task["relations"];
 	},
 ): Promise<Task> {
 	const file = tasksFile(project);
@@ -851,6 +857,7 @@ export async function addTask(
 			statusEnteredAt: now,
 			tmuxSocket: "dev3",
 			labelIds: extras?.labelIds ?? [],
+			relations: extras?.relations ?? [],
 			...(extras?.existingBranch ? { existingBranch: extras.existingBranch } : {}),
 			...(extras?.preparing ? { preparing: true } : {}),
 			...(extras?.preparingStage ? { preparingStage: extras.preparingStage } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -226,6 +226,19 @@ export function normalizePriority(input: string): TaskPriority | null {
 	return m ? (`P${m[1]}` as TaskPriority) : null;
 }
 
+// ---- Task relations ----
+
+/** Relation kinds reserved for the task-linking foundation. */
+export const TASK_RELATION_TYPES = ["blocked-by", "relates-to"] as const;
+
+export type TaskRelationType = (typeof TASK_RELATION_TYPES)[number];
+
+/** A typed link from a source task to a target task in the shared task store. */
+export interface TaskRelation {
+	type: TaskRelationType;
+	taskId: string;
+}
+
 // ---- Column Agents ----
 
 export interface ColumnAgentConfig {
@@ -1208,6 +1221,8 @@ export interface Task {
 	prStatusCache?: TaskPRStatusCache | null;
 	groupId: string | null;
 	variantIndex: number | null;
+	/** Future-facing links to other tasks; the data layer fills [] for legacy records on load. */
+	relations?: TaskRelation[];
 	agentId: string | null;
 	configId: string | null;
 	/**


### PR DESCRIPTION
## Summary

- Add typed `blocked-by` and `relates-to` task relation records.
- Persist an additive `Task.relations` collection and backfill legacy tasks without changing existing behavior.
- Cover downgrade compatibility so older-reader-shaped updates preserve relation records.
- Keep UI, CLI, RPC, and external integrations unchanged for now.

## Validation

- `bun run lint`
- `bun run test`