### PR TITLE
Fix completed card badge overlap

### DIFF
--- a/change-logs/2026/07/23/fix-completed-card-footer-overlap.md
+++ b/change-logs/2026/07/23/fix-completed-card-footer-overlap.md
@@ -1,0 +1,1 @@
+Completed task cards now wrap crowded status, PR, review, and comment badges within the card footer instead of letting them overlap in narrow columns.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -862,7 +862,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			})()}
 
 			{/* Bottom row — pipeline + badges */}
-			<div data-testid="task-card-footer" className="mt-2 flex min-w-0 items-center gap-1.5">
+			<div data-testid="task-card-footer" className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5">
 				{/* Status dropdown trigger with mini-pipeline */}
 				{(() => {
 					const activeCol = task.customColumnId

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1460,6 +1460,20 @@ describe("TaskCard", () => {
 	});
 
 	describe("PR badge", () => {
+		it("wraps crowded completed-card footer badges instead of overlapping them", () => {
+			renderCard(makeTask({ status: "completed" }), {
+				prInfo: {
+					number: 42,
+					url: "https://github.com/test/repo/pull/42",
+					mergeState: { mergeable: "CONFLICTING", status: "DIRTY" },
+					reviewState: "approved",
+					unresolvedCount: 7,
+				},
+			});
+
+			expect(screen.getByTestId("task-card-footer")).toHaveClass("flex-wrap");
+		});
+
 		it("renders the PR badge in its own status-badge row for active tasks", () => {
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "feat/test" }), {
 				prInfo: { number: 42, url: "https://github.com/test/repo/pull/42" },


### PR DESCRIPTION
## Summary\n\n- Wrap the completed task-card footer so status, PR, mergeability, review, and unresolved-comment badges stay inside narrow Kanban cards.\n- Add a regression test and changelog entry.\n\n## Verification\n\n- bunx vitest run src/mainview/components/__tests__/TaskCard.test.tsx\n- bun run lint\n- Browser QA confirmed the target completed card has no footer overlap.