### PR TITLE
Sync review diff order to file tree and add scroll spy

### DIFF
--- a/change-logs/2026/07/23/fix-diff-panel-order-and-scroll-highlight.md
+++ b/change-logs/2026/07/23/fix-diff-panel-order-and-scroll-highlight.md
@@ -1,0 +1,5 @@
+Short: Review diff order + scroll highlight
+
+The review diff panel now shows files on the right in the exact order of the left file tree (previously a flat path sort could diverge from the folder-grouped tree), and the file currently under the reading line is highlighted in the tree as you scroll the diff.
+
+Reported by @diverru (Alexander Kiselyov)

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1117,6 +1117,21 @@ function buildDiffTree(files: TaskDiffFile[], skippedFiles: TaskDiffSkippedFile[
 	return sortNodes(root);
 }
 
+// Depth-first fileId order that matches how the left tree renders (folders first, then files,
+// alphabetical within each). The right panel and skipped list follow this so their order can
+// never diverge from the tree the user reads top-to-bottom.
+export function flattenDiffTree(nodes: DiffTreeNode[]): string[] {
+	const fileIds: string[] = [];
+	for (const node of nodes) {
+		if (node.type === "folder") {
+			fileIds.push(...flattenDiffTree(node.children));
+		} else {
+			fileIds.push(node.fileId);
+		}
+	}
+	return fileIds;
+}
+
 function TaskDiffFileSection({
 	file,
 	worktreePath,
@@ -1710,7 +1725,9 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 	const scrollRegionRef = useRef<HTMLDivElement | null>(null);
 	const searchInputRef = useRef<HTMLInputElement | null>(null);
 	const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+	const fileButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 	const pendingScrollFrameRef = useRef<number | null>(null);
+	const scrollSpyFrameRef = useRef<number | null>(null);
 	const pendingCommentScrollFrameRef = useRef<number | null>(null);
 	const pendingSearchScrollFrameRef = useRef<number | null>(null);
 	const commentRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -1824,7 +1841,32 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		}
 		return { files: visibleFiles.length + visibleSkippedFiles.length, insertions, deletions };
 	}, [payload, includeTests, visibleFiles, visibleSkippedFiles]);
-	const fileTree = payload ? buildDiffTree(visibleFiles, visibleSkippedFiles) : [];
+	const fileTree = useMemo(
+		() => (payload ? buildDiffTree(visibleFiles, visibleSkippedFiles) : []),
+		[payload, visibleFiles, visibleSkippedFiles],
+	);
+	// Render the right panel and skipped list in the tree's depth-first order so they always
+	// match the left file tree the user scans top-to-bottom (folders-first tree order != flat
+	// path sort whenever a file and a subfolder share a directory level).
+	const { orderedVisibleFiles, orderedVisibleSkippedFiles } = useMemo(() => {
+		const fileOrder = flattenDiffTree(fileTree);
+		const filesById = new Map(visibleFiles.map((file) => [file.id, file]));
+		const skippedById = new Map(visibleSkippedFiles.map((file) => [file.id, file]));
+		const orderedFiles: TaskDiffFile[] = [];
+		const orderedSkipped: TaskDiffSkippedFile[] = [];
+		for (const fileId of fileOrder) {
+			const file = filesById.get(fileId);
+			if (file) {
+				orderedFiles.push(file);
+				continue;
+			}
+			const skipped = skippedById.get(fileId);
+			if (skipped) {
+				orderedSkipped.push(skipped);
+			}
+		}
+		return { orderedVisibleFiles: orderedFiles, orderedVisibleSkippedFiles: orderedSkipped };
+	}, [fileTree, visibleFiles, visibleSkippedFiles]);
 	const reviewExportEntries = payload
 		? [
 			...buildInlineReviewExportEntries(visibleFiles, inlineComments),
@@ -2108,7 +2150,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 			payload.files.map((file) => [file.id, !nextReadFiles[file.id]]),
 		);
 		const focusedFile = currentRequest.focusFile ? findDiffFileByPath(payload.files, currentRequest.focusFile) : null;
-		const initialActiveFileId = focusedFile?.id ?? payload.files[0]?.id ?? null;
+		const initialActiveFileId = focusedFile?.id ?? orderedVisibleFiles[0]?.id ?? payload.files[0]?.id ?? null;
 		setCollapsedFolders({});
 		setExpandedFiles(nextExpandedFiles);
 		setReadFiles(nextReadFiles);
@@ -2119,6 +2161,60 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		setEditingCommentId(null);
 		setEditingCommentDraft("");
 	}, [currentRequest.focusFile, payload, task.id]);
+
+	// Scroll spy: as the user scrolls the diff, highlight the file whose section is currently
+	// under the reading line (just below the sticky toolbar). rAF-throttled; only commits a
+	// state change when the active file actually changes.
+	useEffect(() => {
+		const region = scrollRegionRef.current;
+		if (!region || orderedVisibleFiles.length === 0) {
+			return;
+		}
+		const computeActiveFile = () => {
+			scrollSpyFrameRef.current = null;
+			const regionTop = region.getBoundingClientRect().top;
+			const toolbarHeight = toolbarRef.current?.getBoundingClientRect().height ?? 0;
+			const readingLine = regionTop + toolbarHeight + 8;
+			let candidate: string | null = orderedVisibleFiles[0]?.id ?? null;
+			for (const file of orderedVisibleFiles) {
+				const section = sectionRefs.current[file.id];
+				if (!section) {
+					continue;
+				}
+				if (section.getBoundingClientRect().top - 1 <= readingLine) {
+					candidate = file.id;
+				} else {
+					break;
+				}
+			}
+			if (candidate) {
+				setActiveFileId((prev) => (prev === candidate ? prev : candidate));
+			}
+		};
+		const onScroll = () => {
+			if (scrollSpyFrameRef.current !== null) {
+				return;
+			}
+			scrollSpyFrameRef.current = window.requestAnimationFrame(computeActiveFile);
+		};
+		region.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			region.removeEventListener("scroll", onScroll);
+			if (scrollSpyFrameRef.current !== null) {
+				window.cancelAnimationFrame(scrollSpyFrameRef.current);
+				scrollSpyFrameRef.current = null;
+			}
+		};
+	}, [orderedVisibleFiles]);
+
+	// Keep the active file in view in the left tree whether it changed via the scroll spy or a
+	// jump. block:"nearest" only nudges the left list (a sibling of the diff scroll region).
+	useEffect(() => {
+		if (!activeFileId) {
+			return;
+		}
+		fileButtonRefs.current[activeFileId]?.scrollIntoView({ block: "nearest" });
+	}, [activeFileId]);
 
 	// Tracks the task.id that inlineComments currently belongs to.
 	// Updated in the persist effect whenever task.id changes, so we can detect
@@ -2808,6 +2904,9 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		return (
 			<button
 				key={node.key}
+				ref={(element) => {
+					fileButtonRefs.current[node.fileId] = element;
+				}}
 				onClick={() => { scrollToFile(node.fileId, { expand: true }); onFileClick?.(); }}
 				aria-label={t("infoPanel.diffOpenFile", { file: node.path })}
 				className={`flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm transition-colors ${
@@ -3661,7 +3760,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 
 				{!error && !isBusy && payload && diffLib && viewMode && visibleFiles.length > 0 && (
 					<div className="space-y-5">
-						{visibleFiles.map((file, index) => (
+						{orderedVisibleFiles.map((file, index) => (
 							<TaskDiffFileSection
 								key={file.id}
 								file={file}
@@ -3724,7 +3823,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 								</span>
 							</div>
 							<ul className="divide-y divide-edge">
-								{visibleSkippedFiles.map((skipped) => {
+								{orderedVisibleSkippedFiles.map((skipped) => {
 									const isRead = readFiles[skipped.id] ?? false;
 									const isActive = activeFileId === skipped.id;
 									return (

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Project, Task, TaskDiffResponse } from "../../../shared/types";
+import type { Project, Task, TaskDiffFile, TaskDiffResponse } from "../../../shared/types";
 import { I18nProvider } from "../../i18n";
 import type { NavigationGuard } from "../../navigation-guard";
 import TaskDiffViewer from "../TaskDiffViewer";
@@ -531,56 +531,31 @@ describe("TaskDiffViewer", () => {
 		expect(raisedTo).toBeGreaterThan(2000);
 	});
 
-	it("sorts the right-panel file list alphabetically by full path", async () => {
-		// Regression: git.ts assembles `files` as `[...trackedEntries, ...untrackedEntries]`,
-		// so untracked files always end up at the bottom of the right panel while the left tree
-		// shows them in their alphabetical position. The right panel must match the tree order.
+	it("orders the right diff panel to match the left file tree, not a flat path sort", async () => {
+		// Regression (reported by Alexander Kiselyov): the left tree groups folders before files,
+		// so its depth-first order diverges from a flat path sort whenever a file and a subfolder
+		// share a directory level. The right panel must follow the tree the user reads top-to-bottom.
+		const mkFile = (path: string): TaskDiffFile => ({
+			id: path,
+			status: "modified",
+			displayPath: path,
+			oldPath: path,
+			newPath: path,
+			oldContent: "x\n",
+			newContent: "y\n",
+			hunks: [`diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-x\n+y\n`],
+			insertions: 1,
+			deletions: 1,
+		});
 		vi.mocked(api.request.getTaskDiff).mockResolvedValue({
 			mode: "uncommitted",
 			compareRef: null,
 			compareLabel: "Working tree",
 			fallbackReason: null,
 			recentCount: null,
-			summary: { files: 3, insertions: 0, deletions: 0 },
-			files: [
-				{
-					id: "src/management/handler.ts",
-					status: "modified",
-					displayPath: "src/management/handler.ts",
-					oldPath: "src/management/handler.ts",
-					newPath: "src/management/handler.ts",
-					oldContent: "x\n",
-					newContent: "y\n",
-					hunks: ["diff --git a/src/management/handler.ts b/src/management/handler.ts\n@@ -1 +1 @@\n-x\n+y\n"],
-					insertions: 1,
-					deletions: 1,
-				},
-				{
-					id: "src/utils/helper.ts",
-					status: "modified",
-					displayPath: "src/utils/helper.ts",
-					oldPath: "src/utils/helper.ts",
-					newPath: "src/utils/helper.ts",
-					oldContent: "a\n",
-					newContent: "b\n",
-					hunks: ["diff --git a/src/utils/helper.ts b/src/utils/helper.ts\n@@ -1 +1 @@\n-a\n+b\n"],
-					insertions: 1,
-					deletions: 1,
-				},
-				// Backend appends untracked entries last — must be re-sorted into alphabetical position.
-				{
-					id: "src/migrations/0001_init.ts",
-					status: "untracked",
-					displayPath: "src/migrations/0001_init.ts",
-					oldPath: null,
-					newPath: "src/migrations/0001_init.ts",
-					oldContent: "",
-					newContent: "export {};\n",
-					hunks: ["diff --git a/src/migrations/0001_init.ts b/src/migrations/0001_init.ts\n@@ -0,0 +1 @@\n+export {};\n"],
-					insertions: 1,
-					deletions: 0,
-				},
-			],
+			summary: { files: 3, insertions: 3, deletions: 3 },
+			// Backend order is arbitrary; the viewer must reorder it to tree order regardless.
+			files: [mkFile("readme.md"), mkFile("src/app.ts"), mkFile("src/utils/format.ts")],
 			skippedFiles: [],
 		});
 
@@ -596,12 +571,88 @@ describe("TaskDiffViewer", () => {
 		);
 
 		await screen.findAllByTestId("mock-diff");
-		const sections = Array.from(document.querySelectorAll<HTMLElement>("[data-file-id]"));
-		expect(sections.map((node) => node.dataset.fileId)).toEqual([
-			"src/management/handler.ts",
-			"src/migrations/0001_init.ts",
-			"src/utils/helper.ts",
-		]);
+
+		// Folder "src" first (folders-first), then its subfolder "utils" before the file "app.ts",
+		// then the root file "readme.md".
+		const treeOrder = ["src/utils/format.ts", "src/app.ts", "readme.md"];
+		const flatPathSort = ["readme.md", "src/app.ts", "src/utils/format.ts"];
+
+		const rightOrder = Array.from(document.querySelectorAll<HTMLElement>("[data-file-id]")).map((node) => node.dataset.fileId);
+		expect(rightOrder).toEqual(treeOrder);
+		expect(rightOrder).not.toEqual(flatPathSort);
+
+		const leftOrder = Array.from(document.querySelectorAll<HTMLElement>('[aria-label^="Open diff file"]'))
+			.map((node) => node.getAttribute("aria-label")?.replace("Open diff file ", ""));
+		expect(leftOrder).toEqual(treeOrder);
+	});
+
+	it("highlights the file currently under the reading line as the diff scrolls (scroll spy)", async () => {
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getAllByTestId("mock-diff")).toHaveLength(2);
+		});
+
+		const formatButton = screen.getByRole("button", { name: /open diff file src\/utils\/format\.ts/i });
+		const readmeButton = screen.getByRole("button", { name: /open diff file zzz\/readme\.md/i });
+		// Initial active file is the top of the tree (folders-first), not the flat-sort first file.
+		expect(formatButton.className).toContain("border-accent/30");
+		expect(readmeButton.className).not.toContain("border-accent/30");
+
+		const originalRaf = window.requestAnimationFrame;
+		const originalCancelRaf = window.cancelAnimationFrame;
+		window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+			cb(0);
+			return 0;
+		}) as typeof window.requestAnimationFrame;
+		window.cancelAnimationFrame = vi.fn();
+
+		const rect = (top: number, height: number) => () => ({
+			top,
+			bottom: top + height,
+			left: 0,
+			right: 900,
+			width: 900,
+			height,
+			x: 0,
+			y: top,
+			toJSON: () => ({}),
+		});
+
+		const scrollRegion = screen.getByTestId("inline-diff-scroll-region");
+		Object.defineProperty(scrollRegion, "getBoundingClientRect", { configurable: true, value: rect(100, 600) });
+		const toolbar = screen.getByTestId("inline-diff-toolbar");
+		Object.defineProperty(toolbar, "getBoundingClientRect", { configurable: true, value: rect(100, 40) });
+
+		// reading line = 100 + 40 + 8 = 148. Push the first two sections above it; readme straddles it.
+		const rects: Record<string, () => DOMRect> = {
+			"src/utils/format.ts": rect(-300, 160) as () => DOMRect,
+			"src/app.ts": rect(-100, 160) as () => DOMRect,
+			"zzz/readme.md": rect(120, 160) as () => DOMRect,
+		};
+		for (const [fileId, getRect] of Object.entries(rects)) {
+			const section = document.querySelector(`[data-file-id="${fileId}"]`) as HTMLElement;
+			Object.defineProperty(section, "getBoundingClientRect", { configurable: true, value: getRect });
+		}
+
+		fireEvent.scroll(scrollRegion);
+
+		await waitFor(() => {
+			expect(readmeButton.className).toContain("border-accent/30");
+		});
+		expect(formatButton.className).not.toContain("border-accent/30");
+
+		window.requestAnimationFrame = originalRaf;
+		window.cancelAnimationFrame = originalCancelRaf;
 	});
 
 	it("renders binary and oversized skipped files with status, old→new sizes and reason badges", async () => {
@@ -1722,9 +1773,10 @@ describe("TaskDiffViewer", () => {
 			</I18nProvider>,
 		);
 
-		const diffs = await screen.findAllByTestId("mock-diff");
+		await screen.findAllByTestId("mock-diff");
+		const appSection = document.querySelector('[data-file-id="src/app.ts"]') as HTMLElement;
 		expect(screen.getByRole("button", { name: "Send to Agent" })).toBeDisabled();
-		await user.click(within(diffs[0]).getByRole("button", { name: "Open inline comment composer" }));
+		await user.click(within(appSection).getByRole("button", { name: "Open inline comment composer" }));
 		expect(screen.getByTestId("mock-widget").querySelector(".dev3-inline-comment--composer")).not.toBeNull();
 
 		await user.type(
@@ -1851,8 +1903,8 @@ describe("TaskDiffViewer", () => {
 			</I18nProvider>,
 		);
 
-		const diffs = await screen.findAllByTestId("mock-diff");
-		const section = diffs[0];
+		await screen.findAllByTestId("mock-diff");
+		const section = document.querySelector('[data-file-id="src/app.ts"]') as HTMLElement;
 		const newNums = section.querySelectorAll<HTMLElement>(".diff-line-new-num [data-line-num]");
 		// src/app.ts adds two new lines (1 and 2).
 		expect(newNums.length).toBeGreaterThanOrEqual(2);
@@ -1905,7 +1957,7 @@ describe("TaskDiffViewer", () => {
 			expect(screen.getAllByTestId("mock-diff")[0]).toHaveTextContent("mode:4");
 		});
 
-		const section = screen.getAllByTestId("mock-diff")[0];
+		const section = document.querySelector('[data-file-id="src/app.ts"]') as HTMLElement;
 		// Unified gutter: a single `.diff-line-num` cell with `[data-line-new-num]` spans.
 		const newNums = section.querySelectorAll<HTMLElement>(".diff-line-num [data-line-new-num]");
 		expect(newNums.length).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

Fixes two issues in the review diff panel (reported by @diverru):

**Order mismatch.** The right diff panel rendered a flat path-sorted list, while the left file tree groups folders first — so the two orders diverged whenever a file and a subfolder shared a directory level (e.g. `src/app.ts` next to `src/utils/`). `flattenDiffTree()` now yields the tree's depth-first order, and both the diff sections and the skipped-file list are driven from that single order, so they can no longer disagree.

**Scroll-synced highlight.** A new scroll spy on the diff scroll region highlights the file currently under the reading line in the left tree as you scroll, and keeps that file in view.

Covered by unit tests (divergent-tree ordering + scroll spy) and verified in a real browser against a multi-file diff.