### PR TITLE
Fire watched-task notifications on wide remote viewports

### DIFF
--- a/change-logs/2026/07/23/fix-remote-watch-notifications-wide.md
+++ b/change-logs/2026/07/23/fix-remote-watch-notifications-wide.md
@@ -1,0 +1,3 @@
+Short: Watch notifications now fire in Chrome
+
+Watched-task status-change notifications now fire in remote/browser mode on wide desktop viewports too, not only on narrow/mobile ones. This reverses the wide-viewport suppression from #1042: if you explicitly watch a task, its status changes now notify you in a desktop Chrome tab just as they do on the phone and in the native desktop app.

--- a/decisions/163-remote-watch-notifications-always-fire.md
+++ b/decisions/163-remote-watch-notifications-always-fire.md
@@ -1,0 +1,34 @@
+# 163 — Watched-task notifications always fire in remote mode (reverses #1042's wide-viewport suppression)
+
+## Context
+PR #1042 (task seq 1211, "Hide remote status notifications") added a `WebNotificationKind`
+(`status-change` | `event`) field to the `webNotification` push and made the renderer
+suppress `status-change` notifications on wide remote viewports (≥768px), keeping them only on
+narrow/mobile ones. The intent: on a big screen you can see the board, so status banners are noise.
+
+That conflated "wide screen" with "actively looking at the board". A backgrounded desktop Chrome
+tab is wide but exactly the case where a watched-task notification is wanted — and users got nothing.
+
+## Decision
+Removed the wide-viewport suppression entirely. Watched-task status changes now notify on every
+remote viewport (wide + narrow), matching the native desktop app. Because the `kind` field existed
+only to drive that gate, it is now dead and was removed in full: `WebNotificationKind`
+(`src/shared/types.ts`), the `kind` field on the `webNotification` push and all its plumbing in
+`src/bun/rpc-handlers/shared.ts` (`pushWebNotification`, `deliverTaskNotification`, the suppression
+queue), and `shouldShowRemoteWebNotification` + `WebNotificationDetail.kind`
+(`src/mainview/utils/webNotification.ts`). `App.tsx` no longer imports `useNarrowViewport` for this.
+
+All these notifications are already gated on the per-task `watched` flag, so "always fire" means
+"fire for tasks the user explicitly opted into" — the noise concern is bounded by that opt-in.
+
+## Risks
+Re-introduces the exact noise #1042 removed: if you watch a task and stare at the wide board, you
+still get a browser banner on each status change. Accepted by the user (chose "always send" over a
+tab-visibility gate). If it becomes noisy again, the better fix is gating on
+`document.hasFocus()`/`visibilityState` (see `isTabVisibleAndFocused` in `toast.tsx`), not viewport width.
+
+## Alternatives considered
+- **Tab-visibility gate** — fire on wide only when the tab is hidden/unfocused; suppress while
+  visible+focused. Reconciles both goals but adds state; user preferred the simpler "always".
+- **Keep `kind`, neuter only the gate** — leaves a field with no consumer (dead code); rejected per
+  the repo's no-dead-code rule.

--- a/src/bun/__tests__/notify-native-path.test.ts
+++ b/src/bun/__tests__/notify-native-path.test.ts
@@ -102,7 +102,7 @@ describe("native notification channel routing", () => {
 
 		notifyFromCliDesktop({ task: makeTask(), body: "done", projectName: "MyProject" });
 
-		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: "task-1", body: "done", kind: "event" }));
+		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: "task-1", body: "done" }));
 	});
 
 	it("falls back to the legacy path and arms the focus-proxy when the shim declines", () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -10449,7 +10449,7 @@ describe("notifyWatchedTaskStatusChange", () => {
 		setTerminalFocus(false);
 
 		expect(Utils.showNotification).toHaveBeenCalledTimes(1);
-		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: task.id, kind: "status-change" }));
+		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: task.id }));
 	});
 });
 
@@ -10473,7 +10473,6 @@ describe("web notification push (remote/browser mode mirror)", () => {
 			taskId: task.id,
 			projectId: "proj-x",
 			title: "#7 Fix bug",
-			kind: "status-change",
 			body: "In Progress → Review By User",
 			level: "info",
 			taskSeq: 7,
@@ -10500,7 +10499,6 @@ describe("web notification push (remote/browser mode mirror)", () => {
 			taskId: task.id,
 			projectId: "proj-y",
 			title: "#3 Ship it",
-			kind: "event",
 			body: "build done",
 			level: "info",
 			taskSeq: 3,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -25,7 +25,7 @@ export {
 import { extname } from "node:path";
 import { Utils } from "../electrobun-platform";
 import { dlopen, FFIType } from "bun:ffi";
-import type { RendererLogLevel, RequirementCheckResult, SharedArtifact, SharedImage, Task, WebNotificationKind } from "../../shared/types";
+import type { RendererLogLevel, RequirementCheckResult, SharedArtifact, SharedImage, Task } from "../../shared/types";
 import { formatStatus, getTaskTitle } from "../../shared/types";
 import { createLogger } from "../logger";
 import { postNativeTaskNotification } from "../native-notifications";
@@ -177,7 +177,7 @@ export interface TerminalFocusArtifactPayload {
 }
 
 type QueuedTerminalNotification =
-	| { kind: "task"; task: Task; body: string; projectName?: string; notificationKind: WebNotificationKind }
+	| { kind: "task"; task: Task; body: string; projectName?: string }
 	| { kind: "toast"; payload: TerminalFocusToastPayload }
 	| { kind: "attention"; payload: TerminalFocusAttentionPayload }
 	| { kind: "terminalBell"; payload: TerminalFocusBellPayload }
@@ -203,7 +203,7 @@ function flushQueuedNotifications(): void {
 	const queued = queuedTerminalNotifications.splice(0, queuedTerminalNotifications.length);
 	for (const notification of queued) {
 		if (notification.kind === "task") {
-			deliverTaskNotification(notification.task, notification.body, notification.projectName, notification.notificationKind, true);
+			deliverTaskNotification(notification.task, notification.body, notification.projectName, true);
 		} else if (notification.kind === "toast") {
 			getPushMessage()?.("cliToast", notification.payload);
 		} else if (notification.kind === "attention") {
@@ -303,13 +303,11 @@ function pushWebNotification(opts: {
 	task: Task;
 	body: string;
 	projectName: string;
-	kind: WebNotificationKind;
 	level?: "info" | "success" | "error";
 }): void {
 	getPushMessage()?.("webNotification", {
 		taskId: opts.task.id,
 		projectId: opts.task.projectId,
-		kind: opts.kind,
 		title: `#${opts.task.seq} ${getTaskTitle(opts.task)}`,
 		body: opts.body,
 		level: opts.level ?? "info",
@@ -333,11 +331,10 @@ function deliverTaskNotification(
 	task: Task,
 	body: string,
 	projectName?: string,
-	kind: WebNotificationKind = "event",
 	bypassSuppression = false,
 ): void {
 	if (isNotificationSuppressed() && !bypassSuppression) {
-		queuedTerminalNotifications.push({ kind: "task", task, body, projectName, notificationKind: kind });
+		queuedTerminalNotifications.push({ kind: "task", task, body, projectName });
 		return;
 	}
 
@@ -358,7 +355,7 @@ function deliverTaskNotification(
 			silent: true,
 		});
 	}
-	pushWebNotification({ task, body, projectName: projectName ?? "", kind });
+	pushWebNotification({ task, body, projectName: projectName ?? "" });
 	if (nativePosted) return;
 	// Only arm click-to-open when the app is NOT already in the foreground. If the
 	// user is actively looking at the app, the banner is purely informational — a
@@ -375,7 +372,7 @@ function deliverTaskNotification(
 
 export function notifyWatchedTaskStatusChange(task: Task, oldStatus: string, newStatus: string, projectName: string): void {
 	if (!task.watched || oldStatus === newStatus) return;
-	deliverTaskNotification(task, `${formatStatus(oldStatus)} → ${formatStatus(newStatus)}`, projectName, "status-change");
+	deliverTaskNotification(task, `${formatStatus(oldStatus)} → ${formatStatus(newStatus)}`, projectName);
 }
 
 /**

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useAppState, routeTaskId, projectIdForRoute, routeAfterTaskClosed, getTaskOpenMode, OPEN_SETTINGS_SECTION_EVENT, type Route, type SettingsSectionId } from "./state";
 import { api, isElectrobun, getRpcConnectionState } from "./rpc";
-import { setWebNotificationsSuppressed, shouldShowRemoteWebNotification, showWebNotificationOrToast, type WebNotificationDetail } from "./utils/webNotification";
+import { setWebNotificationsSuppressed, showWebNotificationOrToast, type WebNotificationDetail } from "./utils/webNotification";
 import { useT, useLocale } from "./i18n";
 import { handleMenuAction } from "./menuRouter";
 import { trackPageView, trackEvent, registerAgents } from "./analytics";
@@ -13,7 +13,6 @@ import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
 import { useMobileDenseZoom } from "./hooks/useMobileDenseZoom";
 import { useMobile } from "./hooks/useMobile";
-import { useNarrowViewport } from "./hooks/useNarrowViewport";
 import { useAndroidBackGuard } from "./hooks/useAndroidBackGuard";
 import GlobalHeader from "./components/GlobalHeader";
 import AppMenuBar from "./components/AppMenuBar";
@@ -124,7 +123,6 @@ function App() {
 	}, [dispatch]);
 	const t = useT();
 	const [, setLocale] = useLocale();
-	const narrowViewport = useNarrowViewport(768);
 	const [terminalImmersive, setTerminalImmersive] = useState(false);
 	const terminalImmersiveVisible = terminalImmersive && isTaskTerminalRoute(state.route);
 	const skipNextTerminalCopyResetRef = useRef(false);
@@ -1388,12 +1386,12 @@ function App() {
 		if (isElectrobun) return;
 		function onWebNotification(e: Event) {
 			const detail = (e as CustomEvent).detail as WebNotificationDetail;
-			if (!detail?.body || !shouldShowRemoteWebNotification(detail, narrowViewport)) return;
+			if (!detail?.body) return;
 			showWebNotificationOrToast(detail, openTaskFromNotification);
 		}
 		window.addEventListener("rpc:webNotification", onWebNotification);
 		return () => window.removeEventListener("rpc:webNotification", onWebNotification);
-	}, [narrowViewport, openTaskFromNotification]);
+	}, [openTaskFromNotification]);
 
 	// Listen for port scan updates
 	useEffect(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -613,7 +613,6 @@ describe("App keyboard shortcuts", () => {
 					detail: {
 						taskId: "t-web",
 						projectId: "p1",
-						kind: "event",
 						title: "#7 Task update",
 						body: "Agent finished",
 						level: "info",
@@ -626,6 +625,39 @@ describe("App keyboard shortcuts", () => {
 			act(() => FakeWebNotification.instances[0].onclick?.());
 
 			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-web"));
+		});
+
+		// Regression for #1042 reversal: a watched status-change notification must
+		// fire on a wide desktop browser too, not only on narrow/mobile viewports.
+		it("fires a notification on a wide viewport (no status-change suppression)", async () => {
+			rpcTransport.isElectrobun = false;
+			Object.defineProperty(window, "isSecureContext", { value: true, configurable: true });
+			Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true });
+			FakeWebNotification.permission = "granted";
+			FakeWebNotification.instances = [];
+			(window as unknown as { Notification: unknown }).Notification = FakeWebNotification;
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:webNotification", {
+					detail: {
+						taskId: "t-status",
+						projectId: "p1",
+						title: "#8 Watched task",
+						body: "In Progress → Review By User",
+						level: "info",
+					},
+				}));
+			});
+
+			expect(FakeWebNotification.instances).toHaveLength(1);
+			expect(FakeWebNotification.instances[0].options?.body).toBe("In Progress → Review By User");
 		});
 	});
 

--- a/src/mainview/utils/__tests__/webNotification.test.ts
+++ b/src/mainview/utils/__tests__/webNotification.test.ts
@@ -14,7 +14,6 @@ import {
 	webNotificationsSupported,
 	canShowWebNotification,
 	showWebNotificationOrToast,
-	shouldShowRemoteWebNotification,
 	setWebNotificationsSuppressed,
 	BROWSER_NOTIFICATIONS_PREF_KEY,
 	type WebNotificationDetail,
@@ -51,7 +50,6 @@ function uninstallNotification() {
 const baseDetail: WebNotificationDetail = {
 	taskId: "task-1",
 	projectId: "proj-1",
-	kind: "status-change",
 	title: "#42 Fix bug",
 	body: "In Progress → Review",
 	level: "info",
@@ -183,19 +181,5 @@ describe("showWebNotificationOrToast", () => {
 		expect(FakeNotification.instances).toHaveLength(1);
 		FakeNotification.instances[0].onclick?.();
 		expect(onOpen).toHaveBeenCalledWith("task-1", "proj-1");
-	});
-});
-
-describe("shouldShowRemoteWebNotification", () => {
-	it("keeps status changes on narrow remote viewports", () => {
-		expect(shouldShowRemoteWebNotification({ kind: "status-change" }, true)).toBe(true);
-	});
-
-	it("suppresses status changes on wide remote viewports", () => {
-		expect(shouldShowRemoteWebNotification({ kind: "status-change" }, false)).toBe(false);
-	});
-
-	it("keeps non-status notifications on every viewport", () => {
-		expect(shouldShowRemoteWebNotification({ kind: "event" }, false)).toBe(true);
 	});
 });

--- a/src/mainview/utils/webNotification.ts
+++ b/src/mainview/utils/webNotification.ts
@@ -1,5 +1,4 @@
 import { toast } from "../toast";
-import type { WebNotificationKind } from "../../shared/types";
 
 /**
  * Browser Web Notifications for remote/headless mode.
@@ -58,17 +57,12 @@ export function canShowWebNotification(): boolean {
 export interface WebNotificationDetail {
 	taskId: string;
 	projectId: string;
-	kind: WebNotificationKind;
 	title: string;
 	body: string;
 	level: "info" | "success" | "error";
 	taskSeq?: number;
 	taskTitle?: string;
 	projectName?: string;
-}
-
-export function shouldShowRemoteWebNotification(detail: Pick<WebNotificationDetail, "kind">, narrowViewport: boolean): boolean {
-	return detail.kind !== "status-change" || narrowViewport;
 }
 
 interface PendingWebNotification {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,8 +52,6 @@ export interface UpdatePopoverPreview {
 
 export type RendererLogLevel = "debug" | "info" | "warn" | "error";
 
-export type WebNotificationKind = "status-change" | "event";
-
 /**
  * Minimum length of a short ID prefix (task/project/label/note) accepted for
  * prefix matching. Below this, a prefix is treated as "not a prefix" (too broad
@@ -3567,8 +3565,6 @@ export type AppRPCSchema = {
 			webNotification: {
 				taskId: string;
 				projectId: string;
-				/** Used by remote clients to apply viewport-specific notification policy. */
-				kind: WebNotificationKind;
 				/** Notification heading, e.g. "#804 Fix bug". */
 				title: string;
 				/** Notification body, e.g. a message or "In Progress → Review". */


### PR DESCRIPTION
## Summary
- Watched-task **status-change** notifications now fire in remote/browser mode on **wide** desktop viewports too (e.g. desktop Chrome), not only on narrow/mobile ones — matching the native desktop app.
- Reverses the wide-viewport suppression added in #1042: that logic conflated "wide screen" with "actively looking at the board", so a backgrounded Chrome tab got nothing even for tasks you explicitly watched. These notifications are already gated on the per-task `watched` flag, so "always fire" stays bounded by that opt-in.
- Removes the now-dead `WebNotificationKind` field on the `webNotification` push and the `shouldShowRemoteWebNotification` gate it fed (its only consumer), including the `useNarrowViewport` wiring in `App.tsx`.
- Rationale and the noise trade-off (with the tab-visibility gate as the fallback if noise returns) are recorded in `decisions/163-remote-watch-notifications-always-fire.md`.

Note: the OS-level browser banner still requires the user to grant permission once (Settings → Browser Notifications) and a secure context (`https` tunnel or `localhost`); otherwise it falls back to an in-app toast — unchanged behavior.