### PR TITLE
Add native single-view terminal adapter driven by the parity corpus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,20 +79,33 @@ jobs:
       - name: Generate build files
         run: bun scripts/generate-build-info.ts && bun scripts/generate-changelog.ts
 
+      # Each suite is teed to a per-suite log so the aggregate `test` job can
+      # surface the exact failing tests without anyone opening this shard job.
+      # pipefail (GitHub's default bash flags) keeps the vitest exit code, so
+      # continue-on-error still records the real outcome.
       - name: Run mainview tests
         id: mainview_tests
         continue-on-error: true
-        run: bunx vitest run --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: |
+          mkdir -p test-shard-result
+          bunx vitest run --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            2>&1 | tee "test-shard-result/shard-${{ matrix.shard }}-mainview.log"
 
       - name: Run bun tests
         id: bun_tests
         continue-on-error: true
-        run: bunx vitest run --config vitest.config.bun.ts --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: |
+          mkdir -p test-shard-result
+          bunx vitest run --config vitest.config.bun.ts --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            2>&1 | tee "test-shard-result/shard-${{ matrix.shard }}-bun.log"
 
       - name: Run CLI tests
         id: cli_tests
         continue-on-error: true
-        run: bunx vitest run --config vitest.config.cli.ts --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: |
+          mkdir -p test-shard-result
+          bunx vitest run --config vitest.config.cli.ts --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            2>&1 | tee "test-shard-result/shard-${{ matrix.shard }}-cli.log"
 
       - name: Record shard result
         if: always()
@@ -107,12 +120,34 @@ jobs:
           printf '%s %s %s %s %s\n' "$SHARD" "$SHARD_TOTAL" "$MAINVIEW_RESULT" "$BUN_RESULT" "$CLI_RESULT" \
             > "test-shard-result/shard-$SHARD.txt"
 
+          # For each failed suite, distil a concise failure summary the aggregate
+          # can print verbatim; drop the bulky raw logs so the artifact stays tiny.
+          strip_ansi() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+          for suite in mainview bun cli; do
+            case "$suite" in
+              mainview) outcome="$MAINVIEW_RESULT" ;;
+              bun) outcome="$BUN_RESULT" ;;
+              cli) outcome="$CLI_RESULT" ;;
+            esac
+            log="test-shard-result/shard-$SHARD-$suite.log"
+            fail="test-shard-result/shard-$SHARD-$suite.fail"
+            if [ "$outcome" != "success" ] && [ -f "$log" ]; then
+              strip_ansi < "$log" \
+                | grep -E ' FAIL |Test Files +[0-9]+ failed|Tests +[0-9]+ failed| × ' \
+                | head -80 > "$fail" || true
+              if [ ! -s "$fail" ]; then
+                strip_ansi < "$log" | tail -80 > "$fail" || true
+              fi
+            fi
+            rm -f "$log"
+          done
+
       - name: Upload shard result
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-shard-${{ matrix.shard }}
-          path: test-shard-result/shard-${{ matrix.shard }}.txt
+          path: test-shard-result/
           if-no-files-found: error
           retention-days: 1
 
@@ -136,6 +171,7 @@ jobs:
           failed=0
           expected_total=0
           declare -A seen=()
+          failed_suites=()   # "shard/total suite" for every non-success suite
 
           if [ "${#result_files[@]}" -eq 0 ]; then
             echo "::error::No test shard results were downloaded"
@@ -176,9 +212,17 @@ jobs:
 
             seen[$shard]=1
             echo "shard $shard/$total: mainview=$mainview bun=$bun cli=$cli"
-            if [ "$mainview" != "success" ] || [ "$bun" != "success" ] || [ "$cli" != "success" ]; then
-              failed=1
-            fi
+            for suite in mainview bun cli; do
+              case "$suite" in
+                mainview) outcome="$mainview" ;;
+                bun) outcome="$bun" ;;
+                cli) outcome="$cli" ;;
+              esac
+              if [ "$outcome" != "success" ]; then
+                failed=1
+                failed_suites+=("$shard/$total $suite")
+              fi
+            done
           done
 
           if [ "$expected_total" -eq 0 ] || [ "${#result_files[@]}" -ne "$expected_total" ]; then
@@ -190,6 +234,55 @@ jobs:
                 echo "::error::Missing result for test shard $shard/$expected_total"
                 failed=1
               fi
+            done
+          fi
+
+          # Self-contained failure report: which shard, which suite, which tests —
+          # visible right here and on the run summary, no need to open a shard job.
+          if [ "${#failed_suites[@]}" -gt 0 ]; then
+            echo ""
+            echo "=================================================================="
+            echo "  ❌ TEST SHARDS FAILED (${#failed_suites[@]} suite(s)):"
+            for entry in "${failed_suites[@]}"; do
+              echo "     ✗ shard ${entry%% *} · ${entry##* }"
+            done
+            echo "=================================================================="
+            {
+              echo "## ❌ Failing test suites"
+              echo ""
+              for entry in "${failed_suites[@]}"; do
+                echo "- **shard ${entry%% *}** · \`${entry##* }\`"
+              done
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            for entry in "${failed_suites[@]}"; do
+              shard_total="${entry%% *}"
+              suite="${entry##* }"
+              shard="${shard_total%%/*}"
+              fail="test-shard-results/shard-${shard}-${suite}.fail"
+              echo ""
+              echo "::group::❌ shard ${shard_total} · ${suite} — failing tests"
+              if [ -s "$fail" ]; then
+                cat "$fail"
+              else
+                echo "(no captured failure detail — inspect the shard job log)"
+              fi
+              echo "::endgroup::"
+
+              first_fail="$(grep -E ' FAIL | × ' "$fail" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]*//')"
+              echo "::error title=Test shard ${shard_total} (${suite})::${first_fail:-suite ${suite} failed — see the failing-tests group above}"
+
+              {
+                echo "<details><summary>shard ${shard_total} · <code>${suite}</code></summary>"
+                echo ""
+                echo '```'
+                if [ -s "$fail" ]; then cat "$fail"; else echo "(no captured detail)"; fi
+                echo '```'
+                echo ""
+                echo "</details>"
+                echo ""
+              } >> "$GITHUB_STEP_SUMMARY"
             done
           fi
 

--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -15,6 +15,8 @@ on:
       - "src/shared/native-terminal-runtime.ts"
       - "src/bun/prototypes/detached-pty/**"
       - "src/bun/native-terminal-registry/**"
+      - "src/bun/native-terminal-adapter/**"
+      - "src/bun/terminal-parity/**"
   workflow_dispatch:
 
 permissions:
@@ -62,6 +64,13 @@ jobs:
       # with a deterministic single writer and honest lost-session results.
       - name: Native-session app-restart reattach E2E
         run: bun run test:native-app-restart-e2e
+
+      # Seq 1254 single-view adapter parity. Drives the shared backend-neutral
+      # parity corpus against the native adapter on native Windows + POSIX with
+      # the pinned Bun 1.3.14 (single-view live + pure scenarios; multi-view
+      # deferred to LAY-003/LAY-004). Expected final line: ALL CHECKS PASSED.
+      - name: Native single-view adapter parity E2E
+        run: bun run test:native-parity-e2e
 
       - name: Explicit Windows shell launch matrix
         if: runner.os == 'Windows'

--- a/change-logs/2026/07/24/feature-90-native-single-view-terminal-adapter.md
+++ b/change-logs/2026/07/24/feature-90-native-single-view-terminal-adapter.md
@@ -1,0 +1,3 @@
+Short: Native single-view terminal adapter
+
+Composed the merged native terminal primitives (session registry, attach client, versioned record, ownership, bounded parser-state snapshot) into one dev-internal single-view adapter and drove it through the existing backend-neutral parity corpus — every applicable single-view scenario passes against native while the tmux runner stays green. This is an unused tracer with no product callers; tmux remains the only production terminal backend and no behavior changes for users.

--- a/change-logs/2026/07/24/feature-90-native-single-view-terminal-adapter.md
+++ b/change-logs/2026/07/24/feature-90-native-single-view-terminal-adapter.md
@@ -1,3 +1,5 @@
 Short: Native single-view terminal adapter
 
 Composed the merged native terminal primitives (session registry, attach client, versioned record, ownership, bounded parser-state snapshot) into one dev-internal single-view adapter and drove it through the existing backend-neutral parity corpus — every applicable single-view scenario passes against native while the tmux runner stays green. This is an unused tracer with no product callers; tmux remains the only production terminal backend and no behavior changes for users.
+
+Also made the sharded CI test report self-contained: when a shard's suite fails, the aggregate `test` job now names the exact shard, suite, and failing test titles inline (banner, GitHub annotations, and run summary) so failures are readable without opening any individual shard job.

--- a/decisions/162-native-single-view-adapter.md
+++ b/decisions/162-native-single-view-adapter.md
@@ -1,0 +1,72 @@
+# 162 — Native single-view terminal adapter (integration tracer)
+
+## Context
+
+Seq 1254 (parent 1141, tmux-removal roadmap) is the first integration step after
+technical feasibility reached 100%. The merged native primitives (detached Bun
+PTY host, persistent registry + protocol v1, live Ghostty parsing, bounded
+snapshots, multi-client ownership, crash/restart recovery, stream resync) each
+proved a slice in isolation. This step composes them into ONE single-view
+lifecycle and proves they work together by driving the existing backend-neutral
+parity corpus (MIG-001) against native — before any product backend contract or
+user-visible opt-in (MIG-002+).
+
+## Decision
+
+A new module `src/bun/native-terminal-adapter/` (`adapter.ts` +
+`view-reconstruction.ts` + `stream-resync.ts` + `native-runner.ts` +
+`errors.ts` + `scenario-partition.ts`). `NativeSingleViewAdapter` satisfies the
+test-only `ParityRunner` shape **structurally** — production code never imports
+`terminal-parity` (a conformance test locks the shape; the isolation test guards
+the decoupling), so the adapter stays a self-contained composition. It maps
+create/presence/list/active/input/capture/cleanup/reconnect onto
+`registry.start/stop`, `readRecord` + `classifyOwnership`, the attach client, and
+`readParserState`. `splitView` and second-view `focusView` raise a typed
+`MultiViewUnsupportedError`; single-view `killView` == `cleanupSession`.
+
+Capture and reconnect reconstruct from the host's **bounded parser-state
+snapshot** (started with `liveParser: true`), rendered to text, with the
+sequencing rule's monotonic-watermark half so a capture never rewinds and reads
+exactly one snapshot (no loop). The full decision-161 gap→one-snapshot resync
+rule is re-implemented self-contained in `stream-resync.ts` (never importing the
+removable `prototypes/` spike) and unit-tested against
+drop/duplicate/out-of-order/reconnect/overflow.
+
+Parity runs as a standalone `bun` E2E (`test:native-parity-e2e`) reusing the
+shared `LIVE_CHECKS`/`PURE_CHECKS`, wired into the existing path-gated
+`Packaged Bun runtime` workflow (Windows/macOS/Ubuntu, Bun 1.3.14). No new
+always-on all-PR matrix.
+
+## Investigation
+
+Local POSIX run (macOS, Bun 1.3.14): all 10 single-view live scenarios + 2 pure +
+the native lifecycle smoke (create/input/capture, fresh-controller reconnect,
+owned-tree cleanup + idempotent retry) pass with `ALL CHECKS PASSED`; the
+existing tmux parity corpus + live-e2e (31 tests) stay green; `bun run test`
+(mainview 2925 / bun 3221 / cli 600) and `bun run lint` clean. The E2E is
+platform-aware: on native Windows it runs the pure scenarios + the lifecycle
+smoke on a real Windows shell (the POSIX-shell shared checks are logged as n/a). The two registry/parity isolation
+tests were widened to exempt the adapter as a SANCTIONED non-production consumer;
+the adapter's own isolation test proves it has no product callers, so the registry
+stays out of the app/CLI graph transitively.
+
+## Risks
+
+- A capture reads a debounced snapshot (host persists ~250ms), so it can lag live
+  output; the corpus checks poll, and the harness widens the snapshot scrollback
+  cap so a burst fits. Acceptable for a tracer; the renderer attach path will use
+  live client output, not this poll.
+- Multi-view scenarios (`split`/`focus`/`capture.dead-view`/`cleanup.removes-session`)
+  are deferred because their shared checks open a second view; their single-view
+  slices are covered by sibling checks. Recorded in `scenario-partition.ts` and
+  enforced by a coverage test so nothing is silently skipped.
+
+## Alternatives considered
+
+- **Client-side Ghostty core fed by the host's journal replay** (byte-exact, full
+  scrollback) — rejected as the primary path: it leans on the journal rather than
+  the named bounded snapshot and adds a second WASM parser in the adapter.
+- **A bounded VT reducer (GridTerminal shape) with scrollback** — rejected:
+  re-implements Ghostty at lower fidelity when the host already parses.
+- **Running the multi-view scenarios by implementing split now** — rejected as
+  out of scope (LAY-003/LAY-004); this step is the single-view tracer only.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"test:native-shell-launch": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/__tests__/shell-launch.test.ts src/bun/native-terminal-registry/__tests__/shell-probe.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-runner.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-evidence.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-matrix-support.test.ts src/bun/native-terminal-registry/__tests__/host-config.test.ts src/bun/native-terminal-registry/__tests__/protocol.test.ts src/bun/native-terminal-registry/__tests__/registry.test.ts src/bun/native-terminal-registry/__tests__/client.test.ts src/bun/native-terminal-registry/__tests__/isolation.test.ts",
 		"test:native-live-parser-e2e": "bun src/bun/native-terminal-registry/__tests__/live-parser.bun-e2e.ts",
 		"test:native-host-images-e2e": "bun src/bun/native-terminal-registry/host-images/__tests__/lifecycle.bun-e2e.ts",
+		"test:native-parity-e2e": "bun src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts",
 		"test:terminal-state-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/terminal-state/__tests__",
 		"benchmark:terminal-state-spike": "bun src/bun/prototypes/terminal-state/benchmark.ts",
 		"test:stream-resync-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/stream-resync/__tests__",

--- a/src/bun/native-terminal-adapter/README.md
+++ b/src/bun/native-terminal-adapter/README.md
@@ -1,0 +1,103 @@
+# Native single-view terminal adapter (seq 1254)
+
+The first integration step of the tmux-removal roadmap (parent seq 1141) after
+technical feasibility hit 100%. It **composes** the already-merged native
+primitives — the persistent session registry, the attach client, the versioned
+record, passive ownership classification, and the host's bounded parser-state
+snapshot — into ONE cohesive **single-view** terminal lifecycle, and proves the
+pieces work together by driving the existing **backend-neutral parity corpus**
+against them.
+
+This is production-quality composition with **no product callers yet**
+(`__tests__/isolation.test.ts`). It is NOT the product `TerminalBackend` seam and
+introduces none of: a backend contract, backend selection, a persisted backend
+marker, a feature flag, migration, adoption, fallback, or dual ownership. It
+never inspects, attaches to, stops, or modifies any tmux session, and it writes
+only under a test-controlled temporary `~/.dev3.0/native-sessions/` namespace.
+
+## The single-view lifecycle
+
+`NativeSingleViewAdapter` satisfies the backend-neutral `ParityRunner` shape
+(`../terminal-parity/runner.ts`) **structurally** — production code never imports
+the test-only corpus (a test proves conformance and the decoupling):
+
+| ParityRunner op | Native mapping |
+|---|---|
+| `createSession` | `registry.start(id, { launch, liveParser })`; first view id = `record.paneId` |
+| `isSessionPresent` / `listViews` / `activeViewId` | `readRecord` + passive `classifyOwnership` (owned ⇒ one active view) |
+| `sendInput` | attach a writer client, write `text + CR` to the PTY |
+| `capture` | render the host's BOUNDED parser-state snapshot to text (see below) |
+| `cleanupSession` / `killView` | `registry.stop(id)` — token-matched, owned-tree only |
+| `splitView` / second-view `focusView` | typed `MultiViewUnsupportedError` (deferred, see below) |
+| `reconnect` | a fresh adapter on the same on-disk namespace (models a new process) |
+
+A fresh controller rediscovers the same host, shell, session, logical view, and
+captured state from the on-disk record + token + snapshot alone — no duplicate
+process is spawned. Missing sessions and dead views produce typed, catchable
+results (`NativeSessionNotFoundError` / `NativeViewGoneError`) or the documented
+empty result — never an uncaught crash.
+
+## Capture / reconnect: bounded snapshot + sequence-resync
+
+Reconstruction uses the host's **bounded** parser-state snapshot (the live
+Ghostty screen + capped scrollback the host already persists), never an unbounded
+journal replay:
+
+- `MonotonicSnapshotView` (`view-reconstruction.ts`) reads that snapshot and
+  applies the sequencing rule's monotonic half: a snapshot whose `watermarkSeq`
+  is at least the last applied is accepted and cached; a stale snapshot is
+  ignored so a capture never rewinds. Exactly one snapshot is read per capture —
+  there is no repeated resync loop.
+- `StreamResyncReader` (`stream-resync.ts`) is the full proven rule (decision
+  161), composed self-contained (never importing the removable `prototypes/`
+  spike): apply in-order deltas, ignore duplicates/stale, and on a gap recover
+  from ONE bounded snapshot — bounded buffer, no loop, honest `failed` on
+  overflow. Unit-tested against dropped / duplicate / out-of-order / reconnect /
+  overflow cases.
+
+## Scenario partition (`scenario-partition.ts`)
+
+Every corpus scenario is accounted for (a unit test fails if a new one is not):
+
+- **Single-view live (run now):** create (cwd/env + stable id), attach
+  (current+subsequent output, missing-session), input, capture (content+order),
+  reconnect, high-output, exit, cleanup-retry-idempotent.
+- **Deferred to LAY-003/LAY-004 (multi-view):** `split.adds-second-view`,
+  `focus.exactly-one-active-view`, `capture.dead-view-is-clean`,
+  `cleanup.removes-session`. Each shared check opens a SECOND view via
+  `splitView`. Their single-view slices are still covered by
+  `cleanup.retry-is-idempotent`, `exit.process-exit-ends-view`, and the native
+  lifecycle smoke.
+- **Pure (backend-neutral, run unchanged):** the two `resize.*` scenarios.
+- **Gaps (documented, not driven — same as the tmux runner):**
+  `attach.duplicate-attach-does-not-disrupt`, `exit.status-code-propagates`,
+  `cleanup.reaps-owned-process-tree` (the shared check needs a spawned tree; the
+  adapter proves owned-tree teardown in the native lifecycle smoke instead).
+
+The E2E's `nativeLifecycleSmoke` runs on both platforms with the real
+per-platform shell (POSIX `sh` / Windows PowerShell): create → input → snapshot
+capture → fresh-controller reconnect → owned-tree cleanup + idempotent retry. It
+is the native Windows coverage for the adapter, since the shared corpus checks
+are authored in POSIX shell.
+
+## Gaps before MIG-002
+
+MIG-002 (introduce the product backend contract) still needs, outside this
+tracer: the multi-view layout binding (LAY-003/LAY-004) so split/focus and
+dead-view semantics run through the shared corpus; a `TerminalBackend` seam with
+backend identity as backward-compatible data (MIG-003); opt-in native creation
+(MIG-004) and safe rollback (MIG-005); and exit-status propagation over the
+attach path (`exit.status-code-propagates`). None of those are started here — this
+step only proves the merged primitives compose into one working lifecycle.
+
+## Run
+
+```bash
+bun run test                 # unit tests (mapping, resync rule, rendering, isolation, partition)
+bun run test:native-parity-e2e   # real-runtime single-view parity vs native (POSIX / Bun >= 1.3.14)
+```
+
+The real-runtime E2E runs as a standalone `bun` script (vitest stubs the Bun
+global, so a live `Bun.Terminal` cannot run there) and is wired into the
+path-gated `Packaged Bun runtime` CI on Windows, macOS, and Ubuntu with the
+pinned Bun 1.3.14. See [decision 162](../../../decisions/162-native-single-view-adapter.md).

--- a/src/bun/native-terminal-adapter/__tests__/adapter.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/adapter.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Native single-view adapter mapping, driven through injected seams (no real
+ * host, socket, or WASM). Proves the ParityRunner surface: stable ids, presence,
+ * single active view, input write-through, snapshot capture, deferred multi-view,
+ * dead-view/missing-session handling, and idempotent-yet-strict cleanup.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { NativeSessionClient } from "../../native-terminal-registry/client";
+import type { OwnershipVerdict } from "../../native-terminal-registry/ownership";
+import { NATIVE_SESSION_SCHEMA_VERSION, type NativeSessionRecord } from "../../native-terminal-registry/record";
+import type { ParserStateSnapshot } from "../../native-terminal-registry/parser-state";
+import {
+	PARSER_STATE_SCHEMA,
+	PARSER_STATE_VERSION,
+} from "../../native-terminal-registry/parser-state";
+import { LIVE_PARSER_ID } from "../../native-terminal-registry/ghostty-live";
+import { NativeSingleViewAdapter, type NativeAdapterDeps } from "../adapter";
+import { MultiViewUnsupportedError, NativeSessionNotFoundError, NativeViewGoneError } from "../errors";
+
+function makeRecord(id: string): NativeSessionRecord {
+	return {
+		schemaVersion: NATIVE_SESSION_SCHEMA_VERSION,
+		sessionId: id,
+		paneId: `${id}:0`,
+		protocolVersion: 1,
+		hostArtifactVersion: "1",
+		runtimeVersion: "1.3.14",
+		platform: "linux",
+		host: { pid: 4242, executable: "/bin/bun", startSignature: "h" },
+		shell: { pid: 4243, command: ["/bin/sh"], startSignature: "s" },
+		endpoint: { transport: "ws", address: "127.0.0.1", port: 51515 },
+		ownership: { evidenceKind: "posix-start-signature" },
+		cols: 80,
+		rows: 24,
+		createdAt: "2026-07-24T00:00:00.000Z",
+		updatedAt: "2026-07-24T00:00:00.000Z",
+	};
+}
+
+function snapshotWith(lines: string[]): ParserStateSnapshot {
+	return {
+		schema: PARSER_STATE_SCHEMA,
+		version: PARSER_STATE_VERSION,
+		parser: LIVE_PARSER_ID,
+		sessionId: "alpha",
+		watermarkSeq: 1,
+		health: { status: "live", overflow: { droppedChunks: 0, droppedBytes: 0, droppedResizes: 0 } },
+		ingested: { frames: 0, bytes: 0, resizes: 0, replies: 0 },
+		latency: { drains: 0, totalMs: 0, maxMs: 0, p50Ms: 0, p95Ms: 0 },
+		memory: { rssBytes: 0, heapUsedBytes: 0 },
+		state: {
+			activeBuffer: "normal",
+			title: "",
+			dimensions: { cols: 80, rows: lines.length },
+			cursor: { x: 0, y: 0, visible: true, style: "block", blink: false },
+			modes: {
+				applicationCursorKeys: false,
+				applicationKeypad: false,
+				bracketedPaste: false,
+				focusEvents: false,
+				insert: false,
+				mouseTracking: "none",
+				origin: false,
+				reverseWraparound: false,
+				synchronizedOutput: false,
+				wraparound: true,
+			},
+			screen: lines.map((text) => ({ text, wrapped: null, cells: [] })),
+			scrollback: [],
+			scrollbackLength: 0,
+		},
+		updatedAt: "2026-07-24T00:00:00.000Z",
+	};
+}
+
+interface Harness {
+	adapter: NativeSingleViewAdapter;
+	records: Map<string, NativeSessionRecord>;
+	snapshots: Map<string, ParserStateSnapshot>;
+	verdict: { value: OwnershipVerdict };
+	client: { input: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+	stop: ReturnType<typeof vi.fn>;
+	start: ReturnType<typeof vi.fn>;
+}
+
+function harness(overrides: Partial<NativeAdapterDeps> = {}): Harness {
+	const records = new Map<string, NativeSessionRecord>();
+	const snapshots = new Map<string, ParserStateSnapshot>();
+	const verdict = { value: "owned" as OwnershipVerdict };
+	const client = { input: vi.fn(), close: vi.fn() };
+	const start = vi.fn(async (id: string) => {
+		const record = makeRecord(id);
+		records.set(id, record);
+		return { status: "started" as const, record };
+	});
+	const stop = vi.fn(async (id: string) => {
+		const existed = records.delete(id);
+		snapshots.delete(id);
+		return existed;
+	});
+	const deps: Partial<NativeAdapterDeps> = {
+		start: start as unknown as NativeAdapterDeps["start"],
+		stop: stop as unknown as NativeAdapterDeps["stop"],
+		readRecord: (id) => records.get(id) ?? null,
+		readToken: (id) => (records.has(id) ? `token-${id}` : null),
+		classifyOwnership: async () => verdict.value,
+		readSnapshot: (id) => snapshots.get(id) ?? null,
+		connect: async () => client as unknown as NativeSessionClient,
+		...overrides,
+	};
+	const adapter = new NativeSingleViewAdapter({ owner: true, deps });
+	return { adapter, records, snapshots, verdict, client, stop, start };
+}
+
+describe("NativeSingleViewAdapter — lifecycle mapping", () => {
+	it("creates a session with a live parser and returns the stable first view id", async () => {
+		const h = harness();
+		const handle = await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		expect(handle).toEqual({ id: "alpha", firstViewId: "alpha:0" });
+		expect(h.start).toHaveBeenCalledWith(
+			"alpha",
+			expect.objectContaining({ liveParser: true, cols: 80, rows: 24 }),
+			undefined,
+		);
+		const [, opts] = h.start.mock.calls[0];
+		expect(opts.launch).toEqual({ executable: "sh", argv: [], cwd: "/tmp", env: {} });
+	});
+
+	it("reports presence, a single active view, and a stable active id", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		expect(await h.adapter.isSessionPresent("alpha")).toBe(true);
+		expect(await h.adapter.listViews("alpha")).toEqual([{ id: "alpha:0", active: true }]);
+		expect(await h.adapter.activeViewId("alpha")).toBe("alpha:0");
+	});
+
+	it("treats a missing / not-owned session as absent with an empty view list", async () => {
+		const h = harness();
+		expect(await h.adapter.isSessionPresent("ghost")).toBe(false);
+		expect(await h.adapter.listViews("ghost")).toEqual([]);
+		expect(await h.adapter.activeViewId("ghost")).toBeNull();
+
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		h.verdict.value = "reused"; // a reused PID is not ours
+		expect(await h.adapter.isSessionPresent("alpha")).toBe(false);
+		expect(await h.adapter.listViews("alpha")).toEqual([]);
+	});
+
+	it("writes input as a PTY submit through an attached client", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await h.adapter.sendInput("alpha", "alpha:0", "echo hi");
+		expect(h.client.input).toHaveBeenCalledWith("echo hi\r");
+	});
+
+	it("captures the bounded snapshot text, or empty before any output", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		expect(await h.adapter.capture("alpha", "alpha:0", { includeHistory: true })).toBe("");
+		h.snapshots.set("alpha", snapshotWith(["PARITY-L1", "PARITY-L2"]));
+		expect(await h.adapter.capture("alpha", "alpha:0", { includeHistory: true })).toBe("PARITY-L1\nPARITY-L2");
+	});
+});
+
+describe("NativeSingleViewAdapter — negative + deferred handling", () => {
+	it("defers splitView to the multi-view roadmap with a typed error", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await expect(h.adapter.splitView("alpha", "alpha:0", { cwd: "/tmp" })).rejects.toBeInstanceOf(
+			MultiViewUnsupportedError,
+		);
+	});
+
+	it("focuses the sole view but rejects a second-view focus", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await expect(h.adapter.focusView("alpha", "alpha:0")).resolves.toBeUndefined();
+		await expect(h.adapter.focusView("alpha", "alpha:1")).rejects.toBeInstanceOf(MultiViewUnsupportedError);
+	});
+
+	it("raises typed errors for missing sessions and gone views", async () => {
+		const h = harness();
+		await expect(h.adapter.sendInput("ghost", "ghost:0", "x")).rejects.toBeInstanceOf(NativeSessionNotFoundError);
+		await expect(h.adapter.capture("ghost", "ghost:0")).rejects.toBeInstanceOf(NativeSessionNotFoundError);
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await expect(h.adapter.capture("alpha", "alpha:9")).rejects.toBeInstanceOf(NativeViewGoneError);
+	});
+
+	it("cleans up an owned session and reaps only its own tree", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await h.adapter.cleanupSession("alpha");
+		expect(h.stop).toHaveBeenCalledWith("alpha", {}, undefined);
+		expect(await h.adapter.isSessionPresent("alpha")).toBe(false);
+		expect(h.client.close).toHaveBeenCalledTimes(0); // no client was attached (no input)
+	});
+
+	it("is idempotent best-effort but strict on an already-gone session", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await h.adapter.cleanupSession("alpha"); // strict removal succeeds
+		await expect(h.adapter.cleanupSession("alpha", { bestEffort: true })).resolves.toBeUndefined();
+		await expect(h.adapter.cleanupSession("alpha")).rejects.toBeInstanceOf(NativeSessionNotFoundError);
+	});
+
+	it("closes the attached client on cleanup and killView tears the session down", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		await h.adapter.sendInput("alpha", "alpha:0", "echo hi"); // attaches a client
+		await h.adapter.killView("alpha", "alpha:0");
+		expect(h.client.close).toHaveBeenCalledTimes(1);
+		expect(h.stop).toHaveBeenCalledWith("alpha", {}, undefined);
+		expect(await h.adapter.isSessionPresent("alpha")).toBe(false);
+	});
+
+	it("owner dispose stops every created session; a reconnect owns nothing", async () => {
+		const h = harness();
+		await h.adapter.createSession({ id: "alpha", cwd: "/tmp", command: "sh" });
+		const fresh = h.adapter.reconnect();
+		await fresh.dispose();
+		expect(h.stop).not.toHaveBeenCalled(); // reconnect is not the owner
+		await h.adapter.dispose();
+		expect(h.stop).toHaveBeenCalledWith("alpha", {}, undefined);
+	});
+});

--- a/src/bun/native-terminal-adapter/__tests__/conformance.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/conformance.test.ts
@@ -1,0 +1,18 @@
+/**
+ * The native adapter must satisfy the backend-neutral ParityRunner shape without
+ * importing it in production code (CUT-001). This test-only assignment fails the
+ * type-check if the two ever drift, proving conformance structurally.
+ */
+import { describe, expect, it } from "vitest";
+import type { ParityRunner, ReconnectFactory } from "../../terminal-parity/runner";
+import { NativeSingleViewAdapter } from "../adapter";
+
+describe("native adapter ParityRunner conformance", () => {
+	it("structurally implements ParityRunner + ReconnectFactory", () => {
+		const adapter = new NativeSingleViewAdapter({ owner: false });
+		const runner: ParityRunner = adapter;
+		const factory: ReconnectFactory = adapter;
+		expect(runner.backend).toBe("native");
+		expect(typeof factory.reconnect).toBe("function");
+	});
+});

--- a/src/bun/native-terminal-adapter/__tests__/errors.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+	MultiViewUnsupportedError,
+	NativeAdapterError,
+	NativeSessionNotFoundError,
+	NativeViewGoneError,
+} from "../errors";
+
+describe("native adapter errors", () => {
+	it("are catchable typed Errors carrying a discriminated code", () => {
+		const notFound = new NativeSessionNotFoundError("alpha");
+		const gone = new NativeViewGoneError("alpha", "alpha:0");
+		const multi = new MultiViewUnsupportedError("splitView");
+
+		for (const err of [notFound, gone, multi]) {
+			expect(err).toBeInstanceOf(Error);
+			expect(err).toBeInstanceOf(NativeAdapterError);
+		}
+		expect(notFound.code).toBe("session-not-found");
+		expect(gone.code).toBe("view-gone");
+		expect(multi.code).toBe("multi-view-unsupported");
+	});
+
+	it("names each subclass and surfaces its context", () => {
+		const notFound = new NativeSessionNotFoundError("alpha");
+		expect(notFound.name).toBe("NativeSessionNotFoundError");
+		expect(notFound.sessionId).toBe("alpha");
+
+		const gone = new NativeViewGoneError("alpha", "alpha:1");
+		expect(gone.viewId).toBe("alpha:1");
+		expect(gone.message).toContain("alpha:1");
+
+		const multi = new MultiViewUnsupportedError("focusView");
+		expect(multi.message).toContain("LAY-003");
+	});
+
+	it("can be discriminated by code after being thrown and caught", () => {
+		const codes: string[] = [];
+		for (const throwing of [
+			() => {
+				throw new NativeSessionNotFoundError("x");
+			},
+			() => {
+				throw new MultiViewUnsupportedError("splitView");
+			},
+		]) {
+			try {
+				throwing();
+			} catch (err) {
+				if (err instanceof NativeAdapterError) codes.push(err.code);
+			}
+		}
+		expect(codes).toEqual(["session-not-found", "multi-view-unsupported"]);
+	});
+});

--- a/src/bun/native-terminal-adapter/__tests__/isolation.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/isolation.test.ts
@@ -1,10 +1,20 @@
+/**
+ * Isolation guards for the native single-view adapter (seq 1254):
+ *  - No production source imports it (it has no product callers yet). This is
+ *    what keeps the registry it consumes out of the production graph too.
+ *  - It never imports the removable prototype spikes.
+ *  - Its production (non-test) code never imports the test-only parity corpus —
+ *    the adapter conforms to the ParityRunner shape structurally; only tests
+ *    drive the corpus.
+ *  - It never imports or spawns tmux.
+ */
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const sourceRoot = resolve(fileURLToPath(new URL("../../../", import.meta.url))); // repo/src
-const moduleRoot = resolve(fileURLToPath(new URL("../", import.meta.url))); // the registry module
+const moduleRoot = resolve(fileURLToPath(new URL("../", import.meta.url))); // the adapter module
 
 function sourceFiles(directory: string): string[] {
 	const files: string[] = [];
@@ -19,18 +29,15 @@ function sourceFiles(directory: string): string[] {
 const moduleFiles = sourceFiles(moduleRoot);
 const moduleFilesNoTests = moduleFiles.filter((path) => !path.includes("__tests__"));
 
-// The native single-view adapter (seq 1254) is a SANCTIONED non-production
-// consumer of this registry: it composes these primitives but has no product
-// callers of its own (proved by its own isolation test), so it does not put the
-// registry into the app/CLI graph.
-const adapterRoot = resolve(sourceRoot, "bun/native-terminal-adapter");
-
-describe("native-session registry isolation", () => {
-	it("is absent from the production source import graph", () => {
+describe("native single-view adapter isolation", () => {
+	it("has no product callers (absent from the production import graph)", () => {
+		// Match an actual import/require of the module, not a stray mention (the
+		// registry/parity isolation tests reference the adapter path as a string to
+		// exempt this sanctioned consumer).
+		const importsModule = /(?:from|import|require\s*\()\s*['"][^'"]*native-terminal-adapter/;
 		const importers = sourceFiles(sourceRoot)
 			.filter((path) => !path.startsWith(moduleRoot))
-			.filter((path) => !path.startsWith(adapterRoot))
-			.filter((path) => readFileSync(path, "utf8").includes("native-terminal-registry"));
+			.filter((path) => importsModule.test(readFileSync(path, "utf8")));
 		expect(importers).toEqual([]);
 	});
 
@@ -40,9 +47,13 @@ describe("native-session registry isolation", () => {
 		expect(offenders).toEqual([]);
 	});
 
+	it("keeps production code decoupled from the test-only parity corpus", () => {
+		const importsCorpus = /(?:from|import|require\s*\()\s*['"][^'"]*terminal-parity/;
+		const offenders = moduleFilesNoTests.filter((path) => importsCorpus.test(readFileSync(path, "utf8")));
+		expect(offenders).toEqual([]);
+	});
+
 	it("never imports or spawns tmux (static sentinel over the module source)", () => {
-		// Flag real usage — a tmux import path or a "tmux" command literal — not the
-		// word appearing in prose that documents this module never touches tmux.
 		const usesTmux = /(?:from|require\s*\()\s*['"][^'"]*tmux|['"`]tmux(?:\.exe|\.cmd)?['"`]/i;
 		const offenders = moduleFilesNoTests.filter((path) => usesTmux.test(readFileSync(path, "utf8")));
 		expect(offenders).toEqual([]);

--- a/src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts
+++ b/src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * Native single-view parity E2E (seq 1254). Drives the SHARED, backend-neutral
+ * parity corpus (`terminal-parity/checks.ts`) against the native single-view
+ * adapter on the REAL Bun runtime — the same checks that prove the tmux backend,
+ * now proving native. vitest stubs the Bun global, so this runs as a standalone
+ * `bun` script (mirrors `test:native-registry-e2e`). Run:
+ *   bun run test:native-parity-e2e
+ *
+ * Platform coverage:
+ *  - POSIX: the shared single-view LIVE scenarios (they use a POSIX `sh`) + the
+ *    backend-neutral PURE scenarios + a native lifecycle smoke.
+ *  - Native Windows: the PURE scenarios + the native lifecycle smoke on the real
+ *    Windows shell (the POSIX `sh` shared checks are not applicable and are
+ *    logged as such). The registry's Windows lifecycle is already proven by the
+ *    sibling native e2e; this adds the adapter's capture/reconnect/cleanup on top.
+ *
+ * It records the exact multi-view scenarios deferred to LAY-003/LAY-004.
+ * Expected final line: `ALL CHECKS PASSED`.
+ */
+
+import { LIVE_CHECKS, PURE_CHECKS, type CheckContext } from "../../terminal-parity/checks";
+import { getScenario } from "../../terminal-parity/corpus";
+import { isProcessAlive } from "../../native-terminal-registry/process-identity";
+import { readRecord } from "../../native-terminal-registry/record";
+import {
+	createNativeParityHarness,
+	detectNativeRuntime,
+	NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS,
+	NATIVE_PURE_SCENARIOS,
+	NATIVE_SINGLE_VIEW_LIVE_SCENARIOS,
+} from "../index";
+
+const isWindows = process.platform === "win32";
+/** The shared corpus checks are authored in POSIX shell — applicable on POSIX. */
+const SHARED_LIVE_APPLICABLE = !isWindows;
+
+let failures = 0;
+function pass(msg: string): void {
+	console.log(`  ok   - ${msg}`);
+}
+function fail(msg: string, err?: unknown): void {
+	failures++;
+	console.error(`  FAIL - ${msg}${err ? `: ${err instanceof Error ? err.stack ?? err.message : String(err)}` : ""}`);
+}
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function runSharedLive(id: string): Promise<void> {
+	const check = LIVE_CHECKS[id];
+	if (!check) {
+		fail(`${id} (no shared check found)`);
+		return;
+	}
+	const harness = createNativeParityHarness();
+	const ctx: CheckContext = { cwd: harness.workDir, reconnect: harness.reconnect };
+	try {
+		await check(harness.runner as never, ctx);
+		pass(`live/${id}`);
+	} catch (err) {
+		fail(`live/${id}`, err);
+	} finally {
+		await harness.dispose().catch(() => {});
+	}
+}
+
+function runPure(id: string): void {
+	const check = PURE_CHECKS[id];
+	if (!check) {
+		fail(`${id} (no pure check found)`);
+		return;
+	}
+	try {
+		check();
+		pass(`pure/${id}`);
+	} catch (err) {
+		fail(`pure/${id}`, err);
+	}
+}
+
+async function captureUntil(
+	runner: ReturnType<typeof createNativeParityHarness>["runner"],
+	id: string,
+	viewId: string,
+	needle: string,
+	timeoutMs = 8000,
+): Promise<string> {
+	const deadline = Date.now() + timeoutMs;
+	let last = "";
+	while (Date.now() < deadline) {
+		last = await runner.capture(id, viewId, { includeHistory: true });
+		if (last.includes(needle)) return last;
+		await delay(100);
+	}
+	throw new Error(`capture never contained ${JSON.stringify(needle)} (last: ${JSON.stringify(last.slice(-200))})`);
+}
+
+/**
+ * The core adapter lifecycle on the real per-platform shell (POSIX `sh` /
+ * Windows PowerShell): create, presence, input → snapshot capture, fresh-process
+ * reconnect capture, then owned-tree cleanup with an idempotent retry. This is
+ * the native Windows coverage for the adapter (the shared corpus is POSIX-only).
+ */
+async function nativeLifecycleSmoke(): Promise<void> {
+	const harness = createNativeParityHarness();
+	const id = `native-smoke-${process.pid}`;
+	const marker = `NATIVE-MARKER-${process.pid}`;
+	// `command: undefined` on Windows selects the default Windows shell; `echo` is
+	// a builtin in both `sh` and PowerShell.
+	const command = isWindows ? undefined : "sh";
+	try {
+		const { firstViewId } = await harness.runner.createSession({ id, cwd: harness.workDir, command });
+		if (!(await harness.runner.isSessionPresent(id))) throw new Error("session not present after create");
+
+		const record = readRecord(id);
+		if (!record) throw new Error("no record for a freshly created native session");
+		const { pid: hostPid } = record.host;
+		const { pid: shellPid } = record.shell;
+
+		await harness.runner.sendInput(id, firstViewId, `echo ${marker}`);
+		await captureUntil(harness.runner, id, firstViewId, marker);
+		pass("native/create+input+capture");
+
+		// A fresh controller (models a new process) rediscovers the same view + state.
+		const fresh = harness.reconnect();
+		const freshViews = await fresh.listViews(id);
+		if (!freshViews.some((v) => v.id === firstViewId)) throw new Error("fresh controller lost the view id");
+		await captureUntil(fresh, id, firstViewId, marker);
+		pass("native/fresh-controller-reconnect");
+
+		await harness.runner.cleanupSession(id);
+		const deadline = Date.now() + 6000;
+		while (Date.now() < deadline && (isProcessAlive(hostPid) || isProcessAlive(shellPid))) await delay(100);
+		if (isProcessAlive(hostPid) || isProcessAlive(shellPid)) throw new Error("owned host/shell tree survived cleanup");
+		if (await harness.runner.isSessionPresent(id)) throw new Error("session still present after cleanup");
+		// Idempotent best-effort retry is quiet; strict retry reports absence.
+		await harness.runner.cleanupSession(id, { bestEffort: true });
+		let strictThrew = false;
+		try {
+			await harness.runner.cleanupSession(id);
+		} catch {
+			strictThrew = true;
+		}
+		if (!strictThrew) throw new Error("strict cleanup of a gone session did not report absence");
+		pass("native/cleanup-reaps-owned-tree+idempotent");
+	} catch (err) {
+		fail("native/lifecycle-smoke", err);
+	} finally {
+		await harness.dispose().catch(() => {});
+	}
+}
+
+async function main(): Promise<void> {
+	const runtime = detectNativeRuntime();
+	if (!runtime) {
+		console.log("SKIP: native terminal runtime unavailable (needs Bun >= 1.3.14; Windows ConPTY floor).");
+		return;
+	}
+	console.log(`Native single-view parity E2E on Bun ${runtime} (${process.platform})`);
+
+	console.log("\n# Single-view live scenarios (shared corpus checks vs native):");
+	if (SHARED_LIVE_APPLICABLE) {
+		for (const id of NATIVE_SINGLE_VIEW_LIVE_SCENARIOS) await runSharedLive(id);
+	} else {
+		for (const id of NATIVE_SINGLE_VIEW_LIVE_SCENARIOS) {
+			console.log(`  n/a  - live/${id} (POSIX-shell shared check; native Windows covered by the lifecycle smoke)`);
+		}
+	}
+
+	console.log("\n# Pure scenarios (backend-neutral):");
+	for (const id of NATIVE_PURE_SCENARIOS) runPure(id);
+
+	console.log("\n# Native lifecycle smoke (real per-platform shell):");
+	await nativeLifecycleSmoke();
+
+	console.log("\n# Deferred to multi-view layout (LAY-003/LAY-004) — shared checks open a 2nd view:");
+	for (const id of NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS) {
+		console.log(`  defer- ${id} (${getScenario(id).title})`);
+	}
+
+	console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+	if (failures > 0) process.exit(1);
+}
+
+main().catch((err) => {
+	console.error("native parity E2E crashed:", err);
+	process.exit(1);
+});

--- a/src/bun/native-terminal-adapter/__tests__/scenario-partition.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/scenario-partition.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The native adapter's corpus partition must account for EVERY scenario — the
+ * single-view scenarios it runs, the multi-view scenarios it defers, the pure
+ * scenarios, and the documented gaps must together equal the whole corpus with
+ * no overlaps. This is the enforced "record exactly what is deferred" guard: a
+ * new corpus scenario fails this test until it is explicitly classified.
+ */
+import { describe, expect, it } from "vitest";
+import { PARITY_CORPUS, getScenario } from "../../terminal-parity/corpus";
+import {
+	NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS,
+	NATIVE_GAP_SCENARIOS,
+	NATIVE_PURE_SCENARIOS,
+	NATIVE_SINGLE_VIEW_LIVE_SCENARIOS,
+} from "../scenario-partition";
+
+const sorted = (ids: readonly string[]): string[] => [...ids].sort();
+const idsByMode = (mode: string): string[] =>
+	sorted(PARITY_CORPUS.filter((s) => s.verification.mode === mode).map((s) => s.id));
+
+describe("native adapter scenario partition", () => {
+	it("runs + defers exactly the corpus's live scenarios (disjoint, complete)", () => {
+		const run = NATIVE_SINGLE_VIEW_LIVE_SCENARIOS;
+		const deferred = NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS;
+		expect(sorted([...run, ...deferred])).toEqual(idsByMode("live"));
+		const overlap = run.filter((id) => (deferred as readonly string[]).includes(id));
+		expect(overlap).toEqual([]);
+	});
+
+	it("maps the pure and gap scenarios to the corpus exactly", () => {
+		expect(sorted(NATIVE_PURE_SCENARIOS)).toEqual(idsByMode("pure"));
+		expect(sorted(NATIVE_GAP_SCENARIOS)).toEqual(idsByMode("gap"));
+	});
+
+	it("classifies every corpus scenario exactly once across the four buckets", () => {
+		const all = sorted([
+			...NATIVE_SINGLE_VIEW_LIVE_SCENARIOS,
+			...NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS,
+			...NATIVE_PURE_SCENARIOS,
+			...NATIVE_GAP_SCENARIOS,
+		]);
+		expect(all).toEqual(sorted(PARITY_CORPUS.map((s) => s.id)));
+		expect(new Set(all).size).toBe(all.length);
+	});
+
+	it("references only real scenarios with the expected verification mode", () => {
+		for (const id of [...NATIVE_SINGLE_VIEW_LIVE_SCENARIOS, ...NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS]) {
+			expect(getScenario(id).verification.mode).toBe("live");
+		}
+		for (const id of NATIVE_PURE_SCENARIOS) expect(getScenario(id).verification.mode).toBe("pure");
+		for (const id of NATIVE_GAP_SCENARIOS) expect(getScenario(id).verification.mode).toBe("gap");
+	});
+});

--- a/src/bun/native-terminal-adapter/__tests__/stream-resync.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/stream-resync.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The sequencing / resync rule (decision 161) as composed in the adapter. Proven
+ * against a recording sink through the injected-failure cases from the spike:
+ * dropped / duplicate / out-of-order frames, forced reconnect, a stale-storm,
+ * and a bounded-buffer overflow — every recovery converges in ONE snapshot with
+ * no resync loop, and the recovered op stream equals the uninterrupted one.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	StreamResyncReader,
+	type DeltaFrame,
+	type ResyncSink,
+	type SnapshotFrame,
+} from "../stream-resync";
+
+interface JournalState {
+	ops: string[];
+}
+
+/** A byte-exact reducer: its state is the ordered op journal, restorable verbatim. */
+class RecordingSink implements ResyncSink<JournalState> {
+	ops: string[] = [];
+	applyOutput(data: Uint8Array): void {
+		this.ops.push(new TextDecoder().decode(data));
+	}
+	applyResize(cols: number, rows: number): void {
+		this.ops.push(`resize:${cols}x${rows}`);
+	}
+	captureState(): JournalState {
+		return { ops: [...this.ops] };
+	}
+	restoreState(state: JournalState): void {
+		this.ops = [...state.ops];
+	}
+}
+
+function output(seq: number, text: string): DeltaFrame {
+	return { seq, op: { kind: "output", data: new TextEncoder().encode(text) } };
+}
+
+/** Ground truth: the sink fed the uninterrupted, in-order stream. */
+function groundTruth(texts: string[]): string[] {
+	const sink = new RecordingSink();
+	for (const t of texts) sink.applyOutput(new TextEncoder().encode(t));
+	return sink.ops;
+}
+
+describe("StreamResyncReader", () => {
+	it("applies strictly increasing deltas in order", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		reader.ingestDelta(output(2, "b"));
+		reader.ingestDelta(output(3, "c"));
+		expect(reader.state).toBe("live");
+		expect(reader.seq).toBe(3);
+		expect(sink.ops).toEqual(groundTruth(["a", "b", "c"]));
+	});
+
+	it("ignores duplicate and stale deltas without requesting a snapshot", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		reader.ingestDelta(output(2, "b"));
+		reader.ingestDelta(output(2, "b-dup")); // duplicate
+		reader.ingestDelta(output(1, "a-stale")); // stale
+		expect(reader.needsSnapshot()).toBe(false);
+		expect(reader.state).toBe("live");
+		expect(sink.ops).toEqual(groundTruth(["a", "b"]));
+	});
+
+	it("recovers a dropped frame from one snapshot and drops the buffered stale frame", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		// seq 2 is dropped; seq 3 arrives → gap.
+		reader.ingestDelta(output(3, "c"));
+		expect(reader.state).toBe("syncing");
+		expect(reader.needsSnapshot()).toBe(true);
+
+		// The host captured state at seq 3 (>= every buffered delta).
+		const snapshot: SnapshotFrame<JournalState> = { baseSeq: 3, state: { ops: groundTruth(["a", "b", "c"]) } };
+		reader.ingestSnapshot(snapshot);
+		expect(reader.state).toBe("live");
+		expect(reader.needsSnapshot()).toBe(false);
+		expect(reader.seq).toBe(3);
+		expect(sink.ops).toEqual(groundTruth(["a", "b", "c"]));
+
+		// Live resumes in order after recovery.
+		reader.ingestDelta(output(4, "d"));
+		expect(sink.ops).toEqual(groundTruth(["a", "b", "c", "d"]));
+	});
+
+	it("requests exactly one snapshot during a stale/gapped storm (no loop)", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		reader.ingestDelta(output(5, "e")); // gap → one request
+		reader.ingestDelta(output(6, "f")); // still gapped — must NOT re-request
+		reader.ingestDelta(output(1, "a-stale")); // stale (<= lastSeq) — must NOT re-request
+		expect(reader.needsSnapshot()).toBe(true);
+		// Satisfy once; buffered 6 replays, buffered stale drops.
+		reader.ingestSnapshot({ baseSeq: 6, state: { ops: groundTruth(["a", "b", "c", "d", "e", "f"]) } });
+		expect(reader.state).toBe("live");
+		expect(reader.needsSnapshot()).toBe(false);
+		expect(reader.seq).toBe(6);
+	});
+
+	it("ignores a stale snapshot so it never rewinds a recovered reader", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		reader.ingestDelta(output(3, "c")); // gap
+		reader.ingestSnapshot({ baseSeq: 3, state: { ops: groundTruth(["a", "b", "c"]) } });
+		reader.ingestDelta(output(4, "d"));
+		// A late duplicate snapshot at an older base must not rewind.
+		reader.ingestSnapshot({ baseSeq: 2, state: { ops: groundTruth(["a", "b"]) } });
+		expect(reader.seq).toBe(4);
+		expect(sink.ops).toEqual(groundTruth(["a", "b", "c", "d"]));
+	});
+
+	it("models reconnect: a forced snapshot restores state and resumes", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink);
+		reader.ingestDelta(output(1, "a"));
+		reader.ingestDelta(output(2, "b"));
+		// Reconnect: the fresh reader is handed the host's current snapshot.
+		reader.ingestSnapshot({ baseSeq: 2, state: { ops: groundTruth(["a", "b"]) } });
+		reader.ingestDelta(output(3, "c"));
+		expect(reader.seq).toBe(3);
+		expect(sink.ops).toEqual(groundTruth(["a", "b", "c"]));
+	});
+
+	it("fails honestly when the bounded buffer overflows and ignores later frames", () => {
+		const sink = new RecordingSink();
+		const reader = new StreamResyncReader(sink, { maxBufferedFrames: 3, maxBufferedBytes: 1024 });
+		reader.ingestDelta(output(1, "a"));
+		// A persistent gap keeps buffering until the frame bound is exceeded.
+		for (let seq = 3; seq <= 10; seq++) reader.ingestDelta(output(seq, `x${seq}`));
+		expect(reader.state).toBe("failed");
+		expect(reader.failure).toBeTruthy();
+		// A later snapshot / delta cannot revive a failed reader (no corrupt render).
+		reader.ingestSnapshot({ baseSeq: 10, state: { ops: [] } });
+		expect(reader.state).toBe("failed");
+	});
+});

--- a/src/bun/native-terminal-adapter/__tests__/view-reconstruction.test.ts
+++ b/src/bun/native-terminal-adapter/__tests__/view-reconstruction.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { NativeSemanticLine, NativeSemanticState } from "../../native-terminal-registry/ghostty-live";
+import {
+	PARSER_STATE_SCHEMA,
+	PARSER_STATE_VERSION,
+	type ParserStateSnapshot,
+} from "../../native-terminal-registry/parser-state";
+import { LIVE_PARSER_ID } from "../../native-terminal-registry/ghostty-live";
+import { MonotonicSnapshotView, renderSnapshotText } from "../view-reconstruction";
+
+function line(text: string): NativeSemanticLine {
+	return { text, wrapped: null, cells: [] };
+}
+
+function semanticState(screen: string[], scrollback: string[] = []): NativeSemanticState {
+	return {
+		activeBuffer: "normal",
+		title: "",
+		dimensions: { cols: 80, rows: screen.length },
+		cursor: { x: 0, y: 0, visible: true, style: "block", blink: false },
+		modes: {
+			applicationCursorKeys: false,
+			applicationKeypad: false,
+			bracketedPaste: false,
+			focusEvents: false,
+			insert: false,
+			mouseTracking: "none",
+			origin: false,
+			reverseWraparound: false,
+			synchronizedOutput: false,
+			wraparound: true,
+		},
+		screen: screen.map(line),
+		scrollback: scrollback.map(line),
+		scrollbackLength: scrollback.length,
+	};
+}
+
+function snapshot(watermarkSeq: number, state: NativeSemanticState | null): ParserStateSnapshot {
+	return {
+		schema: PARSER_STATE_SCHEMA,
+		version: PARSER_STATE_VERSION,
+		parser: LIVE_PARSER_ID,
+		sessionId: "alpha",
+		watermarkSeq,
+		health: { status: "live", overflow: { droppedChunks: 0, droppedBytes: 0, droppedResizes: 0 } },
+		ingested: { frames: 0, bytes: 0, resizes: 0, replies: 0 },
+		latency: { drains: 0, totalMs: 0, maxMs: 0, p50Ms: 0, p95Ms: 0 },
+		memory: { rssBytes: 0, heapUsedBytes: 0 },
+		state,
+		updatedAt: "2026-07-24T00:00:00.000Z",
+	};
+}
+
+describe("renderSnapshotText", () => {
+	it("renders the visible screen and drops trailing blank rows", () => {
+		const text = renderSnapshotText(semanticState(["hello", "world", "", ""]), false);
+		expect(text).toBe("hello\nworld");
+	});
+
+	it("prepends capped scrollback (oldest first) when history is requested", () => {
+		const state = semanticState(["screen-1", "screen-2"], ["old-1", "old-2"]);
+		expect(renderSnapshotText(state, true)).toBe("old-1\nold-2\nscreen-1\nscreen-2");
+		expect(renderSnapshotText(state, false)).toBe("screen-1\nscreen-2");
+	});
+});
+
+describe("MonotonicSnapshotView", () => {
+	it("returns null until the parser has emitted a state", () => {
+		const view = new MonotonicSnapshotView("alpha", () => null);
+		expect(view.capture(true)).toBeNull();
+		expect(view.watermark).toBe(-1);
+	});
+
+	it("renders the current bounded snapshot and advances the watermark", () => {
+		let current = snapshot(5, semanticState(["line-a"]));
+		const view = new MonotonicSnapshotView("alpha", () => current);
+		expect(view.capture(false)).toBe("line-a");
+		expect(view.watermark).toBe(5);
+		current = snapshot(9, semanticState(["line-a", "line-b"]));
+		expect(view.capture(false)).toBe("line-a\nline-b");
+		expect(view.watermark).toBe(9);
+	});
+
+	it("ignores a stale snapshot and returns the last good render (never rewinds)", () => {
+		let current = snapshot(9, semanticState(["fresh-1", "fresh-2"]));
+		const view = new MonotonicSnapshotView("alpha", () => current);
+		expect(view.capture(false)).toBe("fresh-1\nfresh-2");
+		// A snapshot with a lower watermark (e.g., a late duplicate) is ignored.
+		current = snapshot(4, semanticState(["stale"]));
+		expect(view.capture(false)).toBe("fresh-1\nfresh-2");
+		expect(view.watermark).toBe(9);
+	});
+
+	it("keeps a null-state snapshot from clobbering a prior good render", () => {
+		let current: ParserStateSnapshot = snapshot(3, semanticState(["good"]));
+		const view = new MonotonicSnapshotView("alpha", () => current);
+		expect(view.capture(false)).toBe("good");
+		current = snapshot(7, null); // parser overflowed/failed after — state null
+		expect(view.capture(false)).toBe("good");
+	});
+});

--- a/src/bun/native-terminal-adapter/adapter.ts
+++ b/src/bun/native-terminal-adapter/adapter.ts
@@ -1,0 +1,260 @@
+/**
+ * Native single-view terminal adapter (MIG-002 tracer, seq 1254).
+ *
+ * Composes the already-merged native primitives — the persistent session
+ * registry (`start`/`status`/`stop`), the attach client, the versioned record
+ * (stable session + pane ids), passive ownership classification, and the host's
+ * bounded parser-state snapshot — into ONE cohesive single-view lifecycle that
+ * satisfies the backend-neutral `ParityRunner` shape (see
+ * `../terminal-parity/runner.ts`). It is deliberately duck-typed to that shape
+ * rather than importing it, so this module stays a self-contained composition
+ * with no dependency on the test-only corpus.
+ *
+ * SCOPE: this adapter has NO product callers (guarded by
+ * `__tests__/isolation.test.ts`). It introduces no `TerminalBackend`, backend
+ * selection, persisted backend marker, feature flag, migration, or fallback,
+ * and it never inspects, attaches to, or modifies any tmux session. Multi-view
+ * (split/focus of a second view) is intentionally deferred to LAY-003/LAY-004;
+ * `splitView` raises a typed {@link MultiViewUnsupportedError}.
+ *
+ * Reconstruction uses the host's BOUNDED snapshot plus the sequencing rule's
+ * monotonic-watermark half (see `./view-reconstruction.ts`); the full
+ * gap → one-snapshot resync rule lives in `./stream-resync.ts`.
+ */
+
+import { NativeSessionClient } from "../native-terminal-registry/client";
+import { classifyOwnership } from "../native-terminal-registry/ownership";
+import { isValidSessionId } from "../native-terminal-registry/paths";
+import { readParserState } from "../native-terminal-registry/parser-state";
+import { readRecord, readToken, type NativeSessionRecord } from "../native-terminal-registry/record";
+import { start, stop, type RegistryDeps } from "../native-terminal-registry/registry";
+import {
+	defaultNativeShellLaunchSpec,
+	defineShellLaunchSpec,
+	type ShellLaunchSpec,
+} from "../native-terminal-registry/shell-launch";
+import { MonotonicSnapshotView, type SnapshotReader } from "./view-reconstruction";
+import { MultiViewUnsupportedError, NativeSessionNotFoundError, NativeViewGoneError } from "./errors";
+
+/** Carriage return = the Enter key delivered to a raw PTY (termios maps CR→LF). */
+const INPUT_SUBMIT = "\r";
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+
+export interface CreateSessionOptions {
+	id: string;
+	cwd: string;
+	env?: Record<string, string>;
+	command?: string;
+}
+
+export interface SplitViewOptions {
+	cwd: string;
+	env?: Record<string, string>;
+	command?: string;
+}
+
+export interface ViewInfo {
+	readonly id: string;
+	readonly active: boolean;
+}
+
+export interface CaptureOptions {
+	includeHistory?: boolean;
+}
+
+export interface CleanupOptions {
+	bestEffort?: boolean;
+}
+
+export interface SessionHandle {
+	readonly id: string;
+	readonly firstViewId: string;
+}
+
+/** Injectable seams so the adapter's mapping is unit-testable without real hosts. */
+export interface NativeAdapterDeps {
+	start: typeof start;
+	stop: typeof stop;
+	readRecord: typeof readRecord;
+	readToken: typeof readToken;
+	classifyOwnership: typeof classifyOwnership;
+	readSnapshot: SnapshotReader;
+	connect: (record: NativeSessionRecord, token: string) => Promise<NativeSessionClient>;
+	registryDeps?: RegistryDeps;
+}
+
+async function defaultConnect(record: NativeSessionRecord, token: string): Promise<NativeSessionClient> {
+	const client = new NativeSessionClient();
+	await client.connect(record, token, { timeoutMs: 5000 });
+	return client;
+}
+
+export interface NativeSingleViewAdapterOptions {
+	/** Only the owner tears down the sessions it created on dispose. */
+	owner?: boolean;
+	deps?: Partial<NativeAdapterDeps>;
+}
+
+interface Attachment {
+	view: MonotonicSnapshotView;
+	client: NativeSessionClient | null;
+}
+
+export class NativeSingleViewAdapter {
+	readonly backend = "native";
+	private readonly owner: boolean;
+	private readonly deps: NativeAdapterDeps;
+	private readonly created = new Set<string>();
+	private readonly attachments = new Map<string, Attachment>();
+
+	constructor(options: NativeSingleViewAdapterOptions = {}) {
+		this.owner = options.owner ?? true;
+		this.deps = {
+			start: options.deps?.start ?? start,
+			stop: options.deps?.stop ?? stop,
+			readRecord: options.deps?.readRecord ?? readRecord,
+			readToken: options.deps?.readToken ?? readToken,
+			classifyOwnership: options.deps?.classifyOwnership ?? classifyOwnership,
+			readSnapshot: options.deps?.readSnapshot ?? readParserState,
+			connect: options.deps?.connect ?? defaultConnect,
+			registryDeps: options.deps?.registryDeps,
+		};
+	}
+
+	async createSession(opts: CreateSessionOptions): Promise<SessionHandle> {
+		const launch = this.buildLaunchSpec(opts.cwd, opts.env, opts.command);
+		const result = await this.deps.start(
+			opts.id,
+			{ launch, cols: DEFAULT_COLS, rows: DEFAULT_ROWS, liveParser: true },
+			this.deps.registryDeps,
+		);
+		this.created.add(opts.id);
+		this.attachmentFor(opts.id);
+		return { id: opts.id, firstViewId: result.record.paneId };
+	}
+
+	async isSessionPresent(id: string): Promise<boolean> {
+		return (await this.ownedRecord(id)) !== null;
+	}
+
+	async listViews(id: string): Promise<ViewInfo[]> {
+		const record = await this.ownedRecord(id);
+		return record ? [{ id: record.paneId, active: true }] : [];
+	}
+
+	async activeViewId(id: string): Promise<string | null> {
+		const record = await this.ownedRecord(id);
+		return record ? record.paneId : null;
+	}
+
+	splitView(_id: string, _from: string, _opts: SplitViewOptions): Promise<ViewInfo> {
+		return Promise.reject(new MultiViewUnsupportedError("splitView"));
+	}
+
+	async focusView(id: string, view: string): Promise<void> {
+		const record = await this.ownedRecord(id);
+		if (!record) throw new NativeSessionNotFoundError(id);
+		// Focusing the sole live view is a no-op success; a second view would be
+		// multi-view territory (deferred).
+		if (view !== record.paneId) throw new MultiViewUnsupportedError("focusView on a second view");
+	}
+
+	async sendInput(id: string, view: string, text: string): Promise<void> {
+		const record = await this.ownedRecord(id);
+		if (!record) throw new NativeSessionNotFoundError(id);
+		if (view !== record.paneId) throw new NativeViewGoneError(id, view);
+		const client = await this.ensureClient(id, record);
+		client.input(text + INPUT_SUBMIT);
+	}
+
+	async capture(id: string, view: string, opts: CaptureOptions = {}): Promise<string> {
+		const record = await this.ownedRecord(id);
+		if (!record) throw new NativeSessionNotFoundError(id);
+		if (view !== record.paneId) throw new NativeViewGoneError(id, view);
+		const { view: surface } = this.attachmentFor(id);
+		return surface.capture(opts.includeHistory ?? false) ?? "";
+	}
+
+	/** Single-view: the sole view IS the session, so killing it tears down the session. */
+	killView(id: string, _view: string, opts: CleanupOptions = {}): Promise<void> {
+		return this.cleanupSession(id, opts);
+	}
+
+	async cleanupSession(id: string, opts: CleanupOptions = {}): Promise<void> {
+		const bestEffort = opts.bestEffort ?? false;
+		if (!isValidSessionId(id) || this.deps.readRecord(id) === null) {
+			if (bestEffort) return;
+			throw new NativeSessionNotFoundError(id);
+		}
+		await this.detach(id);
+		const gone = await this.deps.stop(id, {}, this.deps.registryDeps);
+		this.created.delete(id);
+		this.attachments.delete(id);
+		if (!gone && !bestEffort) {
+			throw new Error(`native session ${JSON.stringify(id)} teardown could not be confirmed`);
+		}
+	}
+
+	/** A fresh controller on the same on-disk namespace (models a new process). */
+	reconnect(): NativeSingleViewAdapter {
+		return new NativeSingleViewAdapter({ owner: false, deps: this.deps });
+	}
+
+	async dispose(): Promise<void> {
+		for (const id of this.attachments.keys()) await this.detach(id);
+		this.attachments.clear();
+		if (!this.owner) return;
+		for (const id of [...this.created]) {
+			await this.deps.stop(id, {}, this.deps.registryDeps).catch(() => {});
+		}
+		this.created.clear();
+	}
+
+	private buildLaunchSpec(cwd: string, env: Record<string, string> | undefined, command: string | undefined): ShellLaunchSpec {
+		const executable = command?.trim();
+		if (executable) {
+			return defineShellLaunchSpec({ executable, argv: [], cwd, env: env ?? {} });
+		}
+		const spec = defaultNativeShellLaunchSpec({ platform: process.platform, cwd, env: process.env });
+		return defineShellLaunchSpec({ ...spec, env: env ?? {} });
+	}
+
+	private attachmentFor(id: string): Attachment {
+		let attachment = this.attachments.get(id);
+		if (!attachment) {
+			attachment = { view: new MonotonicSnapshotView(id, this.deps.readSnapshot), client: null };
+			this.attachments.set(id, attachment);
+		}
+		return attachment;
+	}
+
+	private async ensureClient(id: string, record: NativeSessionRecord): Promise<NativeSessionClient> {
+		const attachment = this.attachmentFor(id);
+		if (attachment.client) return attachment.client;
+		const token = this.deps.readToken(id);
+		if (!token) throw new NativeSessionNotFoundError(id);
+		attachment.client = await this.deps.connect(record, token);
+		return attachment.client;
+	}
+
+	private async detach(id: string): Promise<void> {
+		const attachment = this.attachments.get(id);
+		if (!attachment?.client) return;
+		try {
+			attachment.client.close();
+		} catch {
+			// already closed
+		}
+		attachment.client = null;
+	}
+
+	/** The record iff the session is present AND still ours (owned + alive). */
+	private async ownedRecord(id: string): Promise<NativeSessionRecord | null> {
+		if (!isValidSessionId(id)) return null;
+		const record = this.deps.readRecord(id);
+		if (!record) return null;
+		const verdict = await this.deps.classifyOwnership(record, this.deps.readToken(id));
+		return verdict === "owned" ? record : null;
+	}
+}

--- a/src/bun/native-terminal-adapter/errors.ts
+++ b/src/bun/native-terminal-adapter/errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Typed, catchable errors for the native single-view terminal adapter (MIG-002
+ * tracer, seq 1254).
+ *
+ * The parity corpus's negative scenarios require that reading or operating on a
+ * missing session or an already-dead view surfaces a typed, catchable result —
+ * never an uncaught crash (`attach.missing-session-is-clean`,
+ * `cleanup.retry-is-idempotent`). A single discriminated `code` lets callers
+ * branch without instanceof chains and keeps the contract explicit.
+ */
+
+export type NativeAdapterErrorCode =
+	| "session-not-found"
+	| "view-gone"
+	| "multi-view-unsupported";
+
+export class NativeAdapterError extends Error {
+	constructor(
+		readonly code: NativeAdapterErrorCode,
+		message: string,
+	) {
+		super(message);
+		this.name = new.target.name;
+	}
+}
+
+/** A read/teardown targeted a session that is not present (or no longer ours). */
+export class NativeSessionNotFoundError extends NativeAdapterError {
+	constructor(readonly sessionId: string) {
+		super("session-not-found", `native session ${JSON.stringify(sessionId)} is not present`);
+	}
+}
+
+/** An operation targeted a view whose process has already exited. */
+export class NativeViewGoneError extends NativeAdapterError {
+	constructor(
+		readonly sessionId: string,
+		readonly viewId: string,
+	) {
+		super("view-gone", `native view ${JSON.stringify(viewId)} of session ${JSON.stringify(sessionId)} is gone`);
+	}
+}
+
+/**
+ * A multi-view operation (split/second-view focus) was requested on the
+ * single-view tracer. Multi-view layout is deferred to LAY-003/LAY-004; this is
+ * a deliberate, documented boundary, not a runtime failure of the single view.
+ */
+export class MultiViewUnsupportedError extends NativeAdapterError {
+	constructor(readonly operation: string) {
+		super(
+			"multi-view-unsupported",
+			`native single-view adapter does not support ${operation}; multi-view is deferred to LAY-003/LAY-004`,
+		);
+	}
+}

--- a/src/bun/native-terminal-adapter/index.ts
+++ b/src/bun/native-terminal-adapter/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Native single-view terminal adapter (MIG-002 tracer, seq 1254).
+ *
+ * A cohesive, production-quality composition of the merged native primitives
+ * into one single-view terminal lifecycle, driven by the existing backend-neutral
+ * parity corpus. It has NO product callers yet (guarded by the isolation test)
+ * and introduces no backend contract, selection, marker, flag, or fallback.
+ *
+ * See `README.md` for the adapter boundary and the exact gaps before MIG-002.
+ */
+
+export {
+	NativeSingleViewAdapter,
+	type CaptureOptions,
+	type CleanupOptions,
+	type CreateSessionOptions,
+	type NativeAdapterDeps,
+	type NativeSingleViewAdapterOptions,
+	type SessionHandle,
+	type SplitViewOptions,
+	type ViewInfo,
+} from "./adapter";
+export {
+	MultiViewUnsupportedError,
+	NativeAdapterError,
+	NativeSessionNotFoundError,
+	NativeViewGoneError,
+	type NativeAdapterErrorCode,
+} from "./errors";
+export {
+	MonotonicSnapshotView,
+	renderSnapshotText,
+	type SnapshotReader,
+} from "./view-reconstruction";
+export {
+	DEFAULT_RESYNC_BOUNDS,
+	StreamResyncReader,
+	deltaByteSize,
+	type DeltaFrame,
+	type ResyncBounds,
+	type ResyncSink,
+	type ResyncStatus,
+	type SnapshotFrame,
+	type StreamOp,
+} from "./stream-resync";
+export {
+	createNativeParityHarness,
+	detectNativeRuntime,
+	type NativeParityHarness,
+} from "./native-runner";
+export {
+	NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS,
+	NATIVE_GAP_SCENARIOS,
+	NATIVE_PURE_SCENARIOS,
+	NATIVE_SINGLE_VIEW_LIVE_SCENARIOS,
+} from "./scenario-partition";

--- a/src/bun/native-terminal-adapter/native-runner.ts
+++ b/src/bun/native-terminal-adapter/native-runner.ts
@@ -1,0 +1,84 @@
+/**
+ * Native `ParityRunner` harness (seq 1254). Points the registry's additive
+ * namespace at a throwaway tmpdir and hands out a fresh single-view adapter plus
+ * a `reconnect()` that models a NEW controller process rediscovering the same
+ * on-disk sessions. Mirrors `terminal-parity/tmux-runner.ts`'s harness so the
+ * shared corpus checks drive native exactly as they drive tmux.
+ *
+ * Real-runtime only: the native host owns a live `Bun.Terminal`, so this is
+ * exercised from a standalone `bun` e2e (vitest stubs the Bun global). The
+ * bounded parser-state scrollback is widened here so a large capture burst fits
+ * the snapshot the adapter reconstructs from.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NATIVE_SESSIONS_DIR_ENV } from "../native-terminal-registry/paths";
+import { assertNativeTerminalRuntime } from "../../shared/native-terminal-runtime";
+import { NativeSingleViewAdapter } from "./adapter";
+
+const PARSER_SCROLLBACK_ENV = "DEV3_NATIVE_SESSION_PARSER_SCROLLBACK";
+const SNAPSHOT_SCROLLBACK_ENV = "DEV3_NATIVE_SESSION_PARSER_SNAPSHOT_SCROLLBACK";
+/** Wide enough to hold the parity high-output burst in the bounded snapshot. */
+const HARNESS_SCROLLBACK = "4000";
+
+export interface NativeParityHarness {
+	readonly runner: NativeSingleViewAdapter;
+	/** A writable directory a check may use as a session cwd. */
+	readonly workDir: string;
+	/** A fresh controller on the same on-disk namespace (reconnect scenario). */
+	reconnect(): NativeSingleViewAdapter;
+	/** Tear down the owner runner and remove the throwaway namespace + workdir. */
+	dispose(): Promise<void>;
+}
+
+/**
+ * Detect a usable native-terminal runtime; returns the Bun version string or
+ * null (Windows below the ConPTY floor, or no Bun runtime). Mirrors
+ * `detectTmux()` so the e2e can `skip` cleanly instead of failing.
+ */
+export function detectNativeRuntime(): string | null {
+	if (typeof Bun === "undefined" || typeof Bun.version !== "string") return null;
+	try {
+		assertNativeTerminalRuntime({ platform: process.platform, bunVersion: Bun.version });
+		return Bun.version;
+	} catch {
+		return null;
+	}
+}
+
+/** Create an owner native parity harness on a fresh throwaway namespace + workdir. */
+export function createNativeParityHarness(): NativeParityHarness {
+	const previousEnv = {
+		sessions: process.env[NATIVE_SESSIONS_DIR_ENV],
+		scrollback: process.env[PARSER_SCROLLBACK_ENV],
+		snapshotScrollback: process.env[SNAPSHOT_SCROLLBACK_ENV],
+	};
+	const root = mkdtempSync(join(tmpdir(), "dev3-native-parity-"));
+	const sessionsDir = join(root, "native-sessions");
+	const workDir = join(root, "work");
+	mkdirSync(workDir, { recursive: true, mode: 0o700 });
+	process.env[NATIVE_SESSIONS_DIR_ENV] = sessionsDir;
+	process.env[PARSER_SCROLLBACK_ENV] = HARNESS_SCROLLBACK;
+	process.env[SNAPSHOT_SCROLLBACK_ENV] = HARNESS_SCROLLBACK;
+
+	const runner = new NativeSingleViewAdapter({ owner: true });
+	return {
+		runner,
+		workDir,
+		reconnect: () => runner.reconnect(),
+		async dispose() {
+			await runner.dispose().catch(() => {});
+			restoreEnv(NATIVE_SESSIONS_DIR_ENV, previousEnv.sessions);
+			restoreEnv(PARSER_SCROLLBACK_ENV, previousEnv.scrollback);
+			restoreEnv(SNAPSHOT_SCROLLBACK_ENV, previousEnv.snapshotScrollback);
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}

--- a/src/bun/native-terminal-adapter/scenario-partition.ts
+++ b/src/bun/native-terminal-adapter/scenario-partition.ts
@@ -1,0 +1,51 @@
+/**
+ * How the native single-view adapter partitions the shared parity corpus
+ * (seq 1254). This is the explicit, enforced record of which scenarios run
+ * against native now and which are intentionally deferred — no scenario is ever
+ * silently skipped (a unit test proves the partition covers the whole corpus).
+ *
+ * The single-view tracer runs every `live` scenario whose executable check stays
+ * within ONE view. The four `live` scenarios whose shared checks create a SECOND
+ * view (they call `splitView`) are deferred to the multi-view layout work
+ * (LAY-003/LAY-004); `pure` scenarios are backend-neutral and run unchanged;
+ * `gap` scenarios remain documented, not driven (as in the tmux runner).
+ */
+
+/** `live` scenarios the native single-view adapter runs today. */
+export const NATIVE_SINGLE_VIEW_LIVE_SCENARIOS = [
+	"create.session-cwd-env",
+	"create.stable-logical-id",
+	"attach.read-current-and-subsequent-output",
+	"attach.missing-session-is-clean",
+	"input.keys-reach-process",
+	"capture.content-and-ordering",
+	"reconnect.session-survives-detach",
+	"high-output.lossless-ordered",
+	"exit.process-exit-ends-view",
+	"cleanup.retry-is-idempotent",
+] as const;
+
+/**
+ * `live` scenarios deferred to LAY-003/LAY-004: each shared check opens a SECOND
+ * view via `splitView`, which the single-view tracer does not implement. The
+ * single-view slices of their intent are still covered:
+ *  - `cleanup.removes-session` → removal proved by `cleanup.retry-is-idempotent`;
+ *  - `capture.dead-view-is-clean` → single-view exit proved by
+ *    `exit.process-exit-ends-view` and a focused adapter test.
+ */
+export const NATIVE_DEFERRED_MULTI_VIEW_SCENARIOS = [
+	"split.adds-second-view",
+	"focus.exactly-one-active-view",
+	"capture.dead-view-is-clean",
+	"cleanup.removes-session",
+] as const;
+
+/** `pure` scenarios run backend-neutrally (no runner needed). */
+export const NATIVE_PURE_SCENARIOS = ["resize.min-across-clients", "resize.invalid-is-ignored"] as const;
+
+/** `gap` scenarios: documented in the corpus, not driven here (same as tmux). */
+export const NATIVE_GAP_SCENARIOS = [
+	"attach.duplicate-attach-does-not-disrupt",
+	"exit.status-code-propagates",
+	"cleanup.reaps-owned-process-tree",
+] as const;

--- a/src/bun/native-terminal-adapter/stream-resync.ts
+++ b/src/bun/native-terminal-adapter/stream-resync.ts
@@ -1,0 +1,172 @@
+/**
+ * Backend-neutral stream sequencing / resync rule for the native adapter
+ * (decision 161, seq 1249 → adopted here for MIG-002 tracer seq 1254).
+ *
+ * This is the proven "detect a gap, recover from ONE bounded snapshot, never
+ * loop" rule, re-implemented self-contained so the adapter never imports the
+ * removable `prototypes/` spike (isolation). A reconnecting or slow reader
+ * applies ordered deltas and, on a gap, restores from a single snapshot instead
+ * of rendering corrupt state:
+ *
+ *   seq == lastSeq + 1  → apply, advance
+ *   seq <= lastSeq      → duplicate / stale → ignore (NEVER resync)
+ *   seq  > lastSeq + 1  → GAP → buffer (bounded), request ONE snapshot
+ *   snapshot(baseSeq)   → restore, lastSeq = baseSeq, drain buffer, resume
+ *
+ * Convergence: `baseSeq` (the source's seq at capture) is `>=` every buffered
+ * delta, so on restore the buffered frames all drop as stale in a single pass —
+ * no resync loops. One outstanding request is guarded so a burst of gapped or
+ * stale deltas triggers at most one snapshot. Overflowing the bounded buffer
+ * fails honestly to `failed` rather than buffering without limit.
+ */
+
+/** A deterministic reducer that can apply ordered ops and capture/restore state. */
+export interface ResyncSink<S = unknown> {
+	applyOutput(data: Uint8Array): void;
+	applyResize(cols: number, rows: number): void;
+	/** Self-contained, restorable state at the current position. */
+	captureState(): S;
+	restoreState(state: S): void;
+}
+
+export type StreamOp =
+	| { kind: "output"; data: Uint8Array }
+	| { kind: "resize"; cols: number; rows: number };
+
+/** Incremental op; `seq` is strictly increasing and 1-based. */
+export interface DeltaFrame {
+	seq: number;
+	op: StreamOp;
+}
+
+/** Full state at `baseSeq`; the reader resumes with deltas whose seq > baseSeq. */
+export interface SnapshotFrame<S = unknown> {
+	baseSeq: number;
+	state: S;
+}
+
+export type ResyncStatus = "live" | "syncing" | "failed";
+
+export interface ResyncBounds {
+	maxBufferedFrames: number;
+	maxBufferedBytes: number;
+}
+
+export const DEFAULT_RESYNC_BOUNDS: ResyncBounds = {
+	maxBufferedFrames: 1024,
+	maxBufferedBytes: 4 * 1024 * 1024,
+};
+
+/** Cost a frame charges against the bounded resync buffer. */
+export function deltaByteSize(op: StreamOp): number {
+	return op.kind === "output" ? op.data.byteLength : 8;
+}
+
+/**
+ * The reader half of the sequencing rule. Feed it ordered `delta` frames; when
+ * `needsSnapshot()` turns true, hand it exactly one `snapshot` frame. The sink
+ * always reflects the recovered, in-order state (or the read stops at `failed`).
+ */
+export class StreamResyncReader<S = unknown> {
+	private lastSeq = 0;
+	private status: ResyncStatus = "live";
+	private pendingSnapshot = false;
+	private failureReason: string | null = null;
+	private readonly buffer: DeltaFrame[] = [];
+	private bufferedBytes = 0;
+	private readonly bounds: ResyncBounds;
+
+	constructor(
+		private readonly sink: ResyncSink<S>,
+		bounds: Partial<ResyncBounds> = {},
+	) {
+		this.bounds = { ...DEFAULT_RESYNC_BOUNDS, ...bounds };
+	}
+
+	get seq(): number {
+		return this.lastSeq;
+	}
+
+	get state(): ResyncStatus {
+		return this.status;
+	}
+
+	get failure(): string | null {
+		return this.failureReason;
+	}
+
+	/** True while exactly one snapshot is awaited after a detected gap. */
+	needsSnapshot(): boolean {
+		return this.pendingSnapshot;
+	}
+
+	/** Apply one ordered delta; returns the resulting status. */
+	ingestDelta(frame: DeltaFrame): ResyncStatus {
+		if (this.status === "failed") return this.status;
+		if (frame.seq <= this.lastSeq) return this.status; // duplicate / stale — never resync
+		if (frame.seq === this.lastSeq + 1) {
+			this.applyOp(frame.op);
+			this.lastSeq = frame.seq;
+			if (this.status === "syncing" && !this.pendingSnapshot && this.buffer.length === 0) this.status = "live";
+			return this.status;
+		}
+		// GAP — stop applying, buffer, request exactly one snapshot.
+		this.status = "syncing";
+		if (!this.bufferFrame(frame)) return this.status; // overflow → failed
+		if (!this.pendingSnapshot) this.pendingSnapshot = true;
+		return this.status;
+	}
+
+	/**
+	 * Restore from the single requested snapshot, then drain buffered deltas. A
+	 * stale snapshot (`baseSeq < lastSeq`) is ignored so it can never rewind a
+	 * recovered reader.
+	 */
+	ingestSnapshot(frame: SnapshotFrame<S>): ResyncStatus {
+		if (this.status === "failed") return this.status;
+		this.pendingSnapshot = false;
+		if (frame.baseSeq < this.lastSeq) return this.status; // stale snapshot — ignore, no rewind
+		this.sink.restoreState(frame.state);
+		this.lastSeq = frame.baseSeq;
+		this.drainBuffer();
+		if (!this.pendingSnapshot && this.buffer.length === 0) this.status = "live";
+		return this.status;
+	}
+
+	private drainBuffer(): void {
+		// Buffered frames are seq-ordered; after a fresh restore they are all <=
+		// baseSeq and drop in a single pass (the no-loop invariant).
+		const pending = this.buffer.splice(0).sort((a, b) => a.seq - b.seq);
+		this.bufferedBytes = 0;
+		for (const frame of pending) {
+			if (frame.seq <= this.lastSeq) continue; // stale after restore — drop
+			if (frame.seq === this.lastSeq + 1) {
+				this.applyOp(frame.op);
+				this.lastSeq = frame.seq;
+				continue;
+			}
+			// A genuine remaining gap: buffer again and await one more snapshot.
+			if (!this.bufferFrame(frame)) return;
+			this.pendingSnapshot = true;
+		}
+	}
+
+	private bufferFrame(frame: DeltaFrame): boolean {
+		this.buffer.push(frame);
+		this.bufferedBytes += deltaByteSize(frame.op);
+		if (this.buffer.length > this.bounds.maxBufferedFrames || this.bufferedBytes > this.bounds.maxBufferedBytes) {
+			this.status = "failed";
+			this.failureReason = "resync buffer exceeded its bound";
+			this.buffer.length = 0;
+			this.bufferedBytes = 0;
+			this.pendingSnapshot = false;
+			return false;
+		}
+		return true;
+	}
+
+	private applyOp(op: StreamOp): void {
+		if (op.kind === "output") this.sink.applyOutput(op.data);
+		else this.sink.applyResize(op.cols, op.rows);
+	}
+}

--- a/src/bun/native-terminal-adapter/view-reconstruction.ts
+++ b/src/bun/native-terminal-adapter/view-reconstruction.ts
@@ -1,0 +1,81 @@
+/**
+ * Bounded-snapshot view reconstruction for the native single-view adapter
+ * (seq 1254).
+ *
+ * Capture and reconnect reconstruct a view's text from the host's BOUNDED
+ * parser-state snapshot (the live Ghostty screen + capped scrollback the host
+ * already maintains and persists), NOT from an unbounded journal replay. The
+ * snapshot's `watermarkSeq` is applied with the sequencing rule's monotonic
+ * half: a forward (or equal) watermark is accepted and cached; a stale snapshot
+ * is ignored so a recovered capture never rewinds. Exactly one snapshot is read
+ * per capture — there is no repeated resync loop.
+ *
+ * Rendering is pure over the semantic state, so it is unit-testable without any
+ * WASM: the host owns Ghostty; the adapter only renders the snapshot it emits.
+ */
+
+import { readParserState, type ParserStateSnapshot } from "../native-terminal-registry/parser-state";
+import type { NativeSemanticLine, NativeSemanticState } from "../native-terminal-registry/ghostty-live";
+
+/** A snapshot reader — the registry's on-disk reader by default, faked in tests. */
+export type SnapshotReader = (sessionId: string) => ParserStateSnapshot | null;
+
+function lineText(line: NativeSemanticLine): string {
+	return line.text;
+}
+
+function trimTrailingBlankLines(lines: string[]): string[] {
+	let end = lines.length;
+	while (end > 0 && lines[end - 1].trim() === "") end--;
+	return lines.slice(0, end);
+}
+
+/**
+ * Render a semantic screen to plain text. `includeHistory` prepends the capped
+ * scrollback (oldest-first) before the visible screen, so a burst larger than
+ * the viewport is fully readable in produced order. Trailing blank rows are
+ * dropped for readable captures.
+ */
+export function renderSnapshotText(state: NativeSemanticState, includeHistory: boolean): string {
+	const lines = includeHistory
+		? [...state.scrollback.map(lineText), ...state.screen.map(lineText)]
+		: state.screen.map(lineText);
+	return trimTrailingBlankLines(lines).join("\n");
+}
+
+/**
+ * A per-session capture surface over the bounded snapshot. Enforces the
+ * monotonic-watermark rule: it accepts a snapshot whose `watermarkSeq` is at
+ * least the last one it applied and caches the render; a stale snapshot is
+ * ignored and the last good render is returned instead of rewinding.
+ */
+export class MonotonicSnapshotView {
+	private appliedWatermark = -1;
+	private cachedHistoryText: string | null = null;
+	private cachedScreenText: string | null = null;
+
+	constructor(
+		readonly sessionId: string,
+		private readonly read: SnapshotReader = readParserState,
+	) {}
+
+	/** Seq of the last accepted snapshot (−1 before any snapshot is applied). */
+	get watermark(): number {
+		return this.appliedWatermark;
+	}
+
+	/**
+	 * Read the current bounded snapshot and return the rendered view text, or
+	 * `null` when no parser state exists yet (the host is still booting / silent).
+	 * A forward snapshot refreshes the cache; a stale one returns the cache.
+	 */
+	capture(includeHistory: boolean): string | null {
+		const snapshot = this.read(this.sessionId);
+		if (snapshot?.state && snapshot.watermarkSeq >= this.appliedWatermark) {
+			this.appliedWatermark = snapshot.watermarkSeq;
+			this.cachedHistoryText = renderSnapshotText(snapshot.state, true);
+			this.cachedScreenText = renderSnapshotText(snapshot.state, false);
+		}
+		return includeHistory ? this.cachedHistoryText : this.cachedScreenText;
+	}
+}

--- a/src/bun/terminal-parity/__tests__/isolation.test.ts
+++ b/src/bun/terminal-parity/__tests__/isolation.test.ts
@@ -24,6 +24,12 @@ function sourceFiles(directory: string): string[] {
 	return files;
 }
 
+// The native single-view adapter (seq 1254, CUT-001) reuses this corpus + checks
+// to drive a native runner — but ONLY from its tests; its production code stays
+// decoupled (its own isolation test guards that). Allow its test files as a
+// sanctioned, non-production consumer.
+const adapterTestsRoot = resolve(sourceRoot, "bun/native-terminal-adapter/__tests__");
+
 describe("terminal-parity corpus isolation", () => {
 	it("is absent from the production source import graph", () => {
 		// Match an actual import/require of the module, not a stray text mention
@@ -31,6 +37,7 @@ describe("terminal-parity corpus isolation", () => {
 		const importsModule = /(?:from|import|require\s*\()\s*['"][^'"]*terminal-parity/;
 		const importers = sourceFiles(sourceRoot)
 			.filter((path) => !path.startsWith(moduleRoot))
+			.filter((path) => !path.startsWith(adapterTestsRoot))
 			.filter((path) => importsModule.test(readFileSync(path, "utf8")));
 		expect(importers).toEqual([]);
 	});


### PR DESCRIPTION
Composes the already-merged native terminal primitives — the persistent session registry (`start`/`status`/`stop`), the attach client, the versioned record, passive ownership classification, and the host's bounded parser-state snapshot — into **one native single-view adapter** (`src/bun/native-terminal-adapter/`) that satisfies the existing backend-neutral `ParityRunner` shape structurally (no import of the test-only corpus in production code). First integration step of the tmux-removal roadmap (parent seq 1141) after feasibility hit 100%.

## What it does
- **Single-view lifecycle:** create (command/cwd/env), presence, stable session/view ids, active/list view, input, bounded capture, fresh-controller reconnect, high-output ordering, process exit, session + idempotent cleanup.
- **Capture/reconnect:** render the host's **bounded** `parser-state.json` (started with `liveParser: true`) with the sequencing rule's monotonic-watermark half (one snapshot per capture, never rewinds — no repeated resync loop, no unbounded journal). The full decision-161 gap→one-snapshot resync rule is re-implemented self-contained (`stream-resync.ts`, never importing the removable prototype spike) and unit-tested.
- **Cleanup** tears down only the adapter-owned host+shell tree via token-matched `registry.stop`; it never inspects, attaches to, or modifies any tmux session.
- **Multi-view deferred:** `splitView` / second-view focus raise a typed `MultiViewUnsupportedError`. The four `live` scenarios whose shared checks open a second view (`split`, `focus`, `capture.dead-view-is-clean`, `cleanup.removes-session`) are recorded in `scenario-partition.ts` and enforced by a coverage test — nothing is silently skipped.

## Scope / invariants
- **No product callers** (isolation test). No `TerminalBackend`, backend selection, persisted marker, feature flag, migration, or fallback. tmux stays the only production backend and its runner stays green. Writes only under a test-controlled temp namespace.

## Verification (macOS, Bun 1.3.14)
- `test:native-parity-e2e`: 10 single-view live + 2 pure + 3 native lifecycle-smoke checks → `ALL CHECKS PASSED`.
- tmux parity corpus + live-e2e: 31 tests green; `bun run test` (mainview 2925 / bun 3221 / cli 600) and `bun run lint` clean.
- CI: added a path-gated step to the existing `Packaged Bun runtime` workflow (Windows/macOS/Ubuntu, Bun 1.3.14; platform-aware — native Windows runs the pure scenarios + a PowerShell lifecycle smoke). No new always-on all-PR matrix.

See `src/bun/native-terminal-adapter/README.md` and `decisions/162-native-single-view-adapter.md` for the adapter boundary and the exact gaps before MIG-002.

---
🤖 Heads up: this PR was prepared by Claude (the AI assistant working on this branch).