### PR TITLE
Fix label set task selector resolution

### DIFF
--- a/change-logs/2026/07/24/fix-label-set-task-selectors.md
+++ b/change-logs/2026/07/24/fix-label-set-task-selectors.md
@@ -1,0 +1,1 @@
+`dev3 label set` now resolves full task IDs, ID prefixes, and stable `seq:N` selectors through the shared task resolver, while unknown selectors retain a clear error without mutating a task.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -2733,6 +2733,80 @@ describe("task.setLabels", () => {
 		expect(resp.error).toContain("labelIds must be an array");
 	});
 
+	it("resolves a seq:<N> task reference before updating labels", async () => {
+		const project = makeProject({
+			labels: [{ id: "lbl-1", name: "bug", color: "#ef4444" }],
+		});
+		const task = makeTask({ seq: 42, labelIds: [] });
+		const updated = { ...task, labelIds: ["lbl-1"] };
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockImplementation(async (_project, taskId) => {
+			if (taskId !== task.id) throw new Error(`Task not found: ${taskId}`);
+			return updated;
+		});
+
+		const resp = await handleRequest(
+			makeRequest("task.setLabels", {
+				taskId: "seq:42",
+				projectId: project.id,
+				labelIds: ["lbl-1"],
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { labelIds: ["lbl-1"] });
+	});
+
+	it("resolves a valid task ID prefix before updating labels", async () => {
+		const project = makeProject({
+			labels: [{ id: "lbl-1", name: "bug", color: "#ef4444" }],
+		});
+		const task = makeTask({ labelIds: [] });
+		const updated = { ...task, labelIds: ["lbl-1"] };
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockImplementation(async (_project, taskId) => {
+			if (taskId !== task.id) throw new Error(`Task not found: ${taskId}`);
+			return updated;
+		});
+
+		const resp = await handleRequest(
+			makeRequest("task.setLabels", {
+				taskId: task.id.slice(0, 8),
+				projectId: project.id,
+				labelIds: ["lbl-1"],
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { labelIds: ["lbl-1"] });
+	});
+
+	it("rejects an unknown task selector without mutating a task", async () => {
+		const project = makeProject({
+			labels: [{ id: "lbl-1", name: "bug", color: "#ef4444" }],
+		});
+		const task = makeTask({ labelIds: [] });
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+
+		const resp = await handleRequest(
+			makeRequest("task.setLabels", {
+				taskId: "missing-task",
+				projectId: project.id,
+				labelIds: ["lbl-1"],
+			}),
+		);
+
+		expect(resp.ok).toBe(false);
+		expect(resp.error).toContain("Task not found: missing-task");
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
 	it("sets labels on task", async () => {
 		const project = makeProject({
 			labels: [
@@ -2744,6 +2818,7 @@ describe("task.setLabels", () => {
 		const updated = { ...task, labelIds: ["lbl-1", "lbl-2"] };
 
 		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
 		vi.mocked(data.updateTask).mockResolvedValue(updated);
 		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -762,7 +762,7 @@ const handlers: Record<string, Handler> = {
 		if (!projectId) throw new Error("projectId is required");
 		if (!Array.isArray(rawLabelIds)) throw new Error("labelIds must be an array");
 
-		const project = await data.getProject(projectId);
+		const { project, task } = await resolveTaskFromParams(params);
 		const projectLabels = project.labels ?? [];
 
 		// Resolve short label ID prefixes to full UUIDs, rejecting any that do not
@@ -783,9 +783,9 @@ const handlers: Record<string, Handler> = {
 			);
 		}
 
-		const task = await data.updateTask(project, taskId, { labelIds });
-		getPushMessage()?.("taskUpdated", { projectId: project.id, task });
-		return task;
+		const updated = await data.updateTask(project, task.id, { labelIds });
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+		return updated;
 	},
 
 	"task.agentHook": async (params) => {

--- a/src/cli/__tests__/label.test.ts
+++ b/src/cli/__tests__/label.test.ts
@@ -66,6 +66,18 @@ afterEach(() => {
 });
 
 describe("label set task targeting", () => {
+	it("passes stable seq selectors through to the task resolver", async () => {
+		mockSend.mockResolvedValue(okResp(FAKE_TASK));
+
+		await handleLabel("set", args(["lbl-1"], { task: "seq:42", project: "proj-001" }), SOCKET, null);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.setLabels", {
+			taskId: "seq:42",
+			projectId: "proj-001",
+			labelIds: ["lbl-1"],
+		});
+	});
+
 	it("uses --task-id flag as an explicit task target", async () => {
 		mockSend.mockResolvedValue(okResp(FAKE_TASK));
 


### PR DESCRIPTION
Fixes #1105

## Summary
- Route `task.setLabels` through `resolveTaskFromParams`, matching overview and other task commands.
- Support stable `seq:N`, full IDs, and ID prefixes while preserving clear not-found errors and preventing mutation.
- Add focused CLI/socket regression coverage and a changelog entry.

## Tests
- `bun run test:cli`
- `bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/cli-socket-handlers.test.ts`
- `bun run lint`