### PR TITLE
Show the live worktree branch in dev3 current after a rename

### DIFF
--- a/change-logs/2026/07/25/fix-current-live-branch-after-rename.md
+++ b/change-logs/2026/07/25/fix-current-live-branch-after-rename.md
@@ -1,0 +1,5 @@
+Short: dev3 current shows renamed branch instantly
+
+`dev3 current` and `dev3 task show` now reconcile the stored branch name with the branch actually checked out in the worktree, so a `git branch -m` is reflected immediately instead of waiting for the app's next branch-status poll. Offline mode reads the live branch straight from the worktree too.
+
+Suggested by @nadavsheinbein (h0x91b/dev-3.0#1003)

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -20,6 +20,7 @@ vi.mock("../data", () => ({
 vi.mock("../git", () => ({
 	createWorktree: vi.fn(),
 	removeWorktree: vi.fn(),
+	getCurrentBranch: vi.fn(async () => null),
 }));
 
 vi.mock("../shared-images", () => ({
@@ -705,6 +706,38 @@ describe("task.show", () => {
 		);
 		expect(resp.ok).toBe(true);
 		expect(resp.data).toEqual(task);
+	});
+
+	it("returns the live branch after an out-of-band `git branch -m` (issue #1003)", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("chore/dev3-example");
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, branchName: "chore/dev3-example" });
+
+		const resp = await handleRequest(
+			makeRequest("task.show", { taskId: "task-abc12345", projectId: "proj-1" }),
+		);
+		expect(resp.ok).toBe(true);
+		expect((resp.data as Task).branchName).toBe("chore/dev3-example");
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, { branchName: "chore/dev3-example" });
+	});
+
+	it("does not touch the stored branch when it already matches the worktree", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue(task.branchName);
+
+		const resp = await handleRequest(
+			makeRequest("task.show", { taskId: "task-abc12345", projectId: "proj-1" }),
+		);
+		expect(resp.ok).toBe(true);
+		expect(data.updateTask).not.toHaveBeenCalled();
 	});
 
 	it("resolves a seq:<N> reference within the project", async () => {

--- a/src/bun/__tests__/task-branch-sync.test.ts
+++ b/src/bun/__tests__/task-branch-sync.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Project, Task } from "../../shared/types";
+
+vi.mock("../data", () => ({
+	updateTask: vi.fn(),
+}));
+
+vi.mock("../git", () => ({
+	getCurrentBranch: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/shared-pure", () => ({
+	getPushMessage: vi.fn(() => null),
+}));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: vi.fn(() => true),
+}));
+
+import * as data from "../data";
+import * as git from "../git";
+import { getPushMessage } from "../rpc-handlers/shared-pure";
+import { existsSync } from "node:fs";
+import { syncTaskBranchName } from "../task-branch-sync";
+
+function makeProject(overrides?: Partial<Project>): Project {
+	return {
+		id: "proj-1",
+		name: "Test Project",
+		path: "/tmp/test-project",
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "proj-1",
+		title: "Test task",
+		description: "A test task",
+		status: "in-progress",
+		baseBranch: "main",
+		worktreePath: "/tmp/wt",
+		branchName: "dev3/task-abc12345",
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(existsSync).mockReturnValue(true);
+	vi.mocked(getPushMessage).mockReturnValue(null);
+	vi.mocked(data.updateTask).mockImplementation(
+		async (_project, _taskId, updates) => ({ ...makeTask(), ...updates }) as Task,
+	);
+});
+
+describe("syncTaskBranchName", () => {
+	it("persists the live branch when the worktree was renamed out of band", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("chore/dev3-example");
+
+		const project = makeProject();
+		const result = await syncTaskBranchName(project, makeTask());
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { branchName: "chore/dev3-example" });
+		expect(result.branchName).toBe("chore/dev3-example");
+	});
+
+	it("broadcasts taskUpdated so open surfaces re-render with the new branch", async () => {
+		const push = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(push);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("chore/dev3-example");
+
+		await syncTaskBranchName(makeProject(), makeTask());
+
+		expect(push).toHaveBeenCalledWith("taskUpdated", expect.objectContaining({ projectId: "proj-1" }));
+	});
+
+	it("does not write when the live branch already matches", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-abc12345");
+
+		const task = makeTask();
+		const result = await syncTaskBranchName(makeProject(), task);
+
+		expect(data.updateTask).not.toHaveBeenCalled();
+		expect(result).toBe(task);
+	});
+
+	it("skips detached HEAD (no live branch to store)", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue(null);
+
+		await syncTaskBranchName(makeProject(), makeTask());
+
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("skips tasks without a worktree", async () => {
+		const result = await syncTaskBranchName(makeProject(), makeTask({ worktreePath: null }));
+
+		expect(git.getCurrentBranch).not.toHaveBeenCalled();
+		expect(result.branchName).toBe("dev3/task-abc12345");
+	});
+
+	it("skips when the worktree directory is gone", async () => {
+		vi.mocked(existsSync).mockReturnValue(false);
+
+		await syncTaskBranchName(makeProject(), makeTask());
+
+		expect(git.getCurrentBranch).not.toHaveBeenCalled();
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("skips virtual projects (working dir, no git repo)", async () => {
+		await syncTaskBranchName(makeProject({ kind: "virtual" }), makeTask());
+
+		expect(git.getCurrentBranch).not.toHaveBeenCalled();
+	});
+
+	it("returns the original task when persisting fails", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("chore/dev3-example");
+		vi.mocked(data.updateTask).mockRejectedValue(new Error("disk full"));
+
+		const task = makeTask();
+		const result = await syncTaskBranchName(makeProject(), task);
+
+		expect(result).toBe(task);
+	});
+});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -18,6 +18,7 @@ import * as repoConfig from "./repo-config";
 import { loadSettings } from "./settings";
 import { addVent } from "./vents";
 import { createLogger } from "./logger";
+import { syncTaskBranchName } from "./task-branch-sync";
 import { DEV3_HOME } from "./paths";
 import { flushAndEnd, drainSocket, pendingWrites } from "./socket-backpressure";
 
@@ -317,12 +318,12 @@ const handlers: Record<string, Handler> = {
 			const tasks = await data.loadTasks(project);
 			const task = findTaskByRef(tasks, taskId);
 			if (!task) throw taskNotFoundError(taskId);
-			return task;
+			return await syncTaskBranchName(project, task);
 		}
 
 		const found = await resolveTaskAcrossProjects(taskId);
 		if (!found) throw taskNotFoundError(taskId);
-		return found.task;
+		return await syncTaskBranchName(found.project, found.task);
 	},
 
 	"task.create": async (params) => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -20,6 +20,7 @@ import {
 	sendScheduledMessageNow as sendScheduledMessageNowCore,
 } from "../scheduled-message-scheduler";
 import { Semaphore } from "../concurrency";
+import { syncTaskBranchName } from "../task-branch-sync";
 import { getPushMessage, log } from "./shared";
 import { lifecycleActorRuntime } from "../lifecycle/service";
 import {
@@ -167,13 +168,7 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 	const branchForPush = liveBranch ?? task.branchName ?? "";
 
 	if (liveBranch && liveBranch !== task.branchName) {
-		log.info("getBranchStatus: branch renamed, syncing stored name", { old: task.branchName, new: liveBranch });
-		const updated = await data.updateTask(project, task.id, { branchName: liveBranch });
-		// Persisting alone leaves the renderer's in-memory task with the stale
-		// branch name (it only refreshes on a taskUpdated push), so the header,
-		// task cards, and detail modal keep showing the old branch until reload.
-		// Broadcast the update so every open surface re-renders with the new name.
-		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+		await syncTaskBranchName(project, task);
 	}
 
 	log.debug("getBranchStatus: fetching origin", { worktreePath: task.worktreePath, baseBranch, branchName: branchForPush });

--- a/src/bun/task-branch-sync.ts
+++ b/src/bun/task-branch-sync.ts
@@ -1,0 +1,34 @@
+import { existsSync } from "node:fs";
+import type { Project, Task } from "../shared/types";
+import * as data from "./data";
+import * as git from "./git";
+import { getPushMessage } from "./rpc-handlers/shared-pure";
+import { createLogger } from "./logger";
+
+const log = createLogger("task-branch-sync");
+
+/**
+ * Reconcile `task.branchName` with the branch actually checked out in the
+ * worktree. Agents rename branches out of band (`git branch -m`), and the stored
+ * name is what `dev3 current`, the task header, and PR flows display — without
+ * this it stays stale until the renderer's next branch-status poll.
+ */
+export async function syncTaskBranchName(project: Project, task: Task): Promise<Task> {
+	if (project.kind === "virtual") return task;
+	if (!task.worktreePath || !existsSync(task.worktreePath)) return task;
+
+	const liveBranch = await git.getCurrentBranch(task.worktreePath);
+	if (!liveBranch || liveBranch === task.branchName) return task;
+
+	try {
+		const updated = await data.updateTask(project, task.id, { branchName: liveBranch });
+		// Persisting alone leaves the renderer's in-memory task stale (it only
+		// refreshes on a taskUpdated push), so broadcast the new name too.
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+		log.info("Branch renamed, synced stored name", { old: task.branchName, new: liveBranch });
+		return updated;
+	} catch (err) {
+		log.warn("Failed to sync renamed branch name", { taskId: task.id.slice(0, 8), error: String(err) });
+		return task;
+	}
+}

--- a/src/cli/__tests__/current.test.ts
+++ b/src/cli/__tests__/current.test.ts
@@ -13,6 +13,10 @@ vi.mock("../context", () => ({
 	readTaskDirect: vi.fn(),
 }));
 
+vi.mock("node:child_process", () => ({
+	spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
+}));
+
 vi.mock("../../shared/build-info.generated", () => ({
 	BUILD_TIME: "Sat, 28 Mar 2026 · 00:00:00",
 	BUILD_COMMIT: "deadbeef",
@@ -22,6 +26,9 @@ vi.mock("../../shared/build-info.generated", () => ({
 import { handleCurrent } from "../commands/current";
 import { sendRequest } from "../socket-client";
 import { detectContext, readProjectDirect, readTaskDirect } from "../context";
+import { spawnSync } from "node:child_process";
+
+const mockSpawnSync = vi.mocked(spawnSync);
 
 const mockSend = vi.mocked(sendRequest);
 const mockDetect = vi.mocked(detectContext);
@@ -76,6 +83,8 @@ beforeEach(() => {
 	mockDetect.mockReset();
 	mockReadProject.mockReset();
 	mockReadTask.mockReset();
+	mockSpawnSync.mockReset();
+	mockSpawnSync.mockReturnValue({ status: 1, stdout: "", stderr: "" } as ReturnType<typeof spawnSync>);
 });
 
 afterEach(() => {
@@ -306,6 +315,61 @@ describe("handleCurrent", () => {
 			expect(stdoutOutput).toContain("(offline)");
 			// Should NOT call sendRequest
 			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it("shows the live worktree branch after a rename, not the stored name", async () => {
+			mockDetect.mockReturnValue({ projectId: "proj-001", taskId: FAKE_TASK.id, socketPath: "" });
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+			mockReadTask.mockReturnValue({
+				id: FAKE_TASK.id,
+				seq: 7,
+				title: "Implement auth",
+				status: "in-progress",
+				branchName: "dev3/task-aaaaaaaa",
+				worktreePath: "/tmp/wt",
+			});
+			mockSpawnSync.mockReturnValue({ status: 0, stdout: "chore/dev3-example\n", stderr: "" } as ReturnType<typeof spawnSync>);
+
+			await handleCurrent(null);
+
+			expect(stdoutOutput).toContain("chore/dev3-example");
+			expect(stdoutOutput).not.toContain("dev3/task-aaaaaaaa");
+		});
+
+		it("falls back to the stored branch when the worktree git read fails", async () => {
+			mockDetect.mockReturnValue({ projectId: "proj-001", taskId: FAKE_TASK.id, socketPath: "" });
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+			mockReadTask.mockReturnValue({
+				id: FAKE_TASK.id,
+				seq: 7,
+				title: "Implement auth",
+				status: "in-progress",
+				branchName: "dev3/task-aaaaaaaa",
+				worktreePath: "/tmp/wt",
+			});
+			mockSpawnSync.mockReturnValue({ status: 128, stdout: "", stderr: "not a git repository" } as ReturnType<typeof spawnSync>);
+
+			await handleCurrent(null);
+
+			expect(stdoutOutput).toContain("dev3/task-aaaaaaaa");
+		});
+
+		it("ignores a detached HEAD and shows the stored branch", async () => {
+			mockDetect.mockReturnValue({ projectId: "proj-001", taskId: FAKE_TASK.id, socketPath: "" });
+			mockReadProject.mockReturnValue({ id: "proj-001", name: "My Project", path: "/dev/proj" });
+			mockReadTask.mockReturnValue({
+				id: FAKE_TASK.id,
+				seq: 7,
+				title: "Implement auth",
+				status: "in-progress",
+				branchName: "dev3/task-aaaaaaaa",
+				worktreePath: "/tmp/wt",
+			});
+			mockSpawnSync.mockReturnValue({ status: 0, stdout: "HEAD\n", stderr: "" } as ReturnType<typeof spawnSync>);
+
+			await handleCurrent(null);
+
+			expect(stdoutOutput).toContain("dev3/task-aaaaaaaa");
 		});
 
 		it("shows custom title from offline task data when present", async () => {

--- a/src/cli/commands/current.ts
+++ b/src/cli/commands/current.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import type { Task } from "../../shared/types";
 import { STATUS_LABELS, getTaskTitle } from "../../shared/types";
 import { detectContext, detectContextDiagnostics, readProjectDirect, readTaskDirect, type ProjectDirect } from "../context";
@@ -17,6 +18,24 @@ function printCustomColumns(project: ProjectDirect | null): void {
 	for (const col of customColumns) {
 		const instruction = col.llmInstruction ? `  → "${col.llmInstruction}"` : "";
 		process.stdout.write(`  ${col.id.slice(0, 8)}   ${col.name}${instruction}\n`);
+	}
+}
+
+/**
+ * Read the branch actually checked out in the worktree. Offline mode has no app
+ * to reconcile a `git branch -m`, so the stored name would be stale forever.
+ */
+function liveBranchName(worktreePath: string): string | null {
+	try {
+		const res = spawnSync("git", ["-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD"], {
+			encoding: "utf-8",
+			timeout: 5000,
+		});
+		if (res.status !== 0) return null;
+		const branch = (res.stdout || "").trim();
+		return branch && branch !== "HEAD" ? branch : null;
+	} catch {
+		return null;
 	}
 }
 
@@ -122,8 +141,10 @@ export async function handleCurrent(socketPath: string | null, opts: { brief?: b
 		if (task.seq !== undefined) fields.push(["Seq:", String(task.seq)]);
 		if (displayTitle) fields.push(["Title:", `${displayTitle}${titleMarker}`]);
 		if (task.status) fields.push(["Status:", STATUS_LABELS[task.status as keyof typeof STATUS_LABELS] || (task.status as string)]);
-		if (task.branchName) fields.push(["Branch:", task.branchName as string]);
-		if (task.worktreePath) fields.push(["Worktree:", task.worktreePath as string]);
+		const worktreePath = task.worktreePath as string | undefined;
+		const offlineBranch = (worktreePath ? liveBranchName(worktreePath) : null) ?? (task.branchName as string | undefined);
+		if (offlineBranch) fields.push(["Branch:", offlineBranch]);
+		if (worktreePath) fields.push(["Worktree:", worktreePath]);
 
 		fields.push(["", ""]);
 		fields.push(["(offline)", "App not running — showing cached data"]);


### PR DESCRIPTION
Fixes #1003.

`task.branchName` was only reconciled with the branch actually checked out in the worktree inside `getBranchStatusImpl`, which the renderer polls roughly every 15s for the selected task. Every other reader — `dev3 current`, `dev3 task show`, the header — kept printing the stored name until that poll landed, so an out-of-band `git branch -m` looked like a stale or cached value.

- New `src/bun/task-branch-sync.ts` (`syncTaskBranchName`): reads the live branch when the worktree exists and the project is a git project, persists it, and broadcasts `taskUpdated`; a failed write leaves the task untouched.
- The `task.show` CLI socket handler now goes through it, so `dev3 current` / `dev3 task show` are correct on the first call and the GUI refreshes at the same moment.
- `getBranchStatusImpl` reuses the same helper instead of its inline duplicate.
- Offline `dev3 current` (app not running) reads `git rev-parse --abbrev-ref HEAD` in the worktree, falling back to the stored name and ignoring detached HEAD.

Covered by new unit tests for the sync helper, the `task.show` handler, and the offline CLI path (all verified red before the fix).