### PR TITLE
Make confirmation dialog task titles clickable

### DIFF
--- a/change-logs/2026/07/25/fix-dialog-task-title-navigation.md
+++ b/change-logs/2026/07/25/fix-dialog-task-title-navigation.md
@@ -1,0 +1,1 @@
+Make the task title in unsaved-changes confirmation dialogs clickable. Clicking it now dismisses the destructive prompt without moving the task and opens the referenced task using the user's configured task view.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -7,7 +7,7 @@ import { PRIORITY_NAME_KEYS } from "./priorityStyles";
 // Column ordering + visibility lives in the shared, unit-tested getBoardColumns
 // (single source of truth for the board's column layout).
 type ColumnSlot = BoardColumnSlot;
-import type { AppAction, Route } from "../state";
+import { getTaskOpenMode, type AppAction, type Route } from "../state";
 import { useT, statusKey, statusDescKey } from "../i18n";
 import { api } from "../rpc";
 import KanbanColumn from "./KanbanColumn";
@@ -287,6 +287,12 @@ function KanbanBoard({
 			newStatus: targetStatus,
 			dispatch,
 			t,
+			onOpenTask: () => {
+				const openMode = getTaskOpenMode();
+				navigate(openMode === "fullscreen"
+					? { screen: "task", projectId: project.id, taskId: task.id }
+					: { screen: "project", projectId: project.id, activeTaskId: task.id });
+			},
 			onMoved: () => recordMove(task.id),
 			onMovingChange: (moving) => handleSetMoving(task.id, moving),
 		});

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -272,6 +272,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			newStatus,
 			dispatch,
 			t,
+			onOpenTask: openTaskFromDialog,
 			onMoved: () => onTaskMoved(task.id),
 			onMovingChange: (moving) =>
 				isTerminal ? onSetMoving?.(task.id, moving) : setMoving(moving),
@@ -390,6 +391,16 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			// this from the title; matching it here keeps clicks consistent and lets
 			// the keyboard hint ("jump to task") land somewhere for todo cards too.
 			setDetailOpen(true);
+		}
+	}
+
+	function openTaskFromDialog() {
+		setDetailOpen(false);
+		const openMode = getTaskOpenMode();
+		if (openMode === "fullscreen") {
+			navigate({ screen: "task", projectId: project.id, taskId: task.id });
+		} else {
+			navigate({ screen: "project", projectId: project.id, activeTaskId: task.id });
 		}
 	}
 
@@ -740,6 +751,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					project={project}
 					dispatch={dispatch}
 					onClose={() => setDetailOpen(false)}
+					onOpenTask={openTaskFromDialog}
 					onLaunchVariants={onLaunchVariants}
 				/>,
 				document.body

--- a/src/mainview/components/TaskDetailModal.tsx
+++ b/src/mainview/components/TaskDetailModal.tsx
@@ -28,11 +28,13 @@ interface TaskDetailModalProps {
 	project: Project;
 	dispatch: Dispatch<AppAction>;
 	onClose: () => void;
+	/** Opens the task workspace from a terminal-state confirmation card. */
+	onOpenTask?: () => void;
 	/** Opens the LaunchVariantsModal to start a todo task (agent + variant picker). */
 	onLaunchVariants: (task: Task, targetStatus: TaskStatus) => void;
 }
 
-function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }: TaskDetailModalProps) {
+function TaskDetailModal({ task, project, dispatch, onClose, onOpenTask, onLaunchVariants }: TaskDetailModalProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const trapRef = useFocusTrap<HTMLDivElement>();
@@ -234,6 +236,7 @@ function TaskDetailModal({ task, project, dispatch, onClose, onLaunchVariants }:
 			newStatus,
 			dispatch,
 			t,
+			onOpenTask,
 			afterOptimistic: () => onClose(),
 		});
 	}

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -344,6 +344,12 @@ function TaskInfoPanel({
 	async function handleStatusMove(newStatus: TaskStatus) {
 		setStatusMenuOpen(false);
 		const terminal = newStatus === "completed" || newStatus === "cancelled";
+		const openTaskFromDialog = () => {
+			const openMode = getTaskOpenMode();
+			navigate(openMode === "fullscreen"
+				? { screen: "task", projectId: project.id, taskId: task.id }
+				: { screen: "project", projectId: project.id, activeTaskId: task.id });
+		};
 		// Terminal moves leave the task screen immediately (worktree teardown runs
 		// in the background); other moves keep the panel and show a spinner.
 		const leaveScreen = terminal || !ACTIVE_STATUSES.includes(newStatus);
@@ -357,6 +363,7 @@ function TaskInfoPanel({
 			newStatus,
 			dispatch,
 			t,
+			onOpenTask: openTaskFromDialog,
 			// Terminal moves leave the screen and keep the optimistic completion on
 			// failure (matches the fire-and-forget behaviour); other moves stay and
 			// revert + toast if the RPC fails.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -892,6 +892,7 @@ describe("TaskInfoPanel", () => {
 				project,
 				"completed",
 				expect.any(Function),
+				expect.any(Function),
 			);
 			// Move was blocked
 			expect(mockedApi.request.moveTask).not.toHaveBeenCalled();

--- a/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
+++ b/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
@@ -63,6 +63,17 @@ describe("confirmTaskCompletion", () => {
 		);
 	});
 
+	it("makes the task title openable from the confirmation dialog", async () => {
+		const onOpenTask = vi.fn();
+		await confirmTaskCompletion(baseTask, project, "completed", t, onOpenTask);
+
+		expect(mockedConfirm).toHaveBeenCalledWith(
+			expect.objectContaining({
+				info: expect.objectContaining({ onClick: onOpenTask }),
+			}),
+		);
+	});
+
 	it("prefers the user-edited title/overview overrides in the info card", async () => {
 		const task = {
 			...baseTask,

--- a/src/mainview/utils/__tests__/moveTaskToStatus.test.ts
+++ b/src/mainview/utils/__tests__/moveTaskToStatus.test.ts
@@ -63,6 +63,15 @@ describe("moveTaskToStatus", () => {
 		expect(mockedMoveTask).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", newStatus: "completed", clientPlayedSound: true });
 	});
 
+	it("passes the task opener into the terminal confirmation", async () => {
+		const dispatch = vi.fn();
+		const onOpenTask = vi.fn();
+
+		await moveTaskToStatus({ task, project, newStatus: "completed", dispatch, t, onOpenTask });
+
+		expect(mockedConfirm).toHaveBeenCalledWith(task, project, "completed", t, onOpenTask);
+	});
+
 	it("tells the backend NOT to suppress the push when the UI did not play (sound off)", async () => {
 		mockedSound.mockReturnValue(false);
 		const dispatch = vi.fn();

--- a/src/mainview/utils/__tests__/taskDialogInfo.test.ts
+++ b/src/mainview/utils/__tests__/taskDialogInfo.test.ts
@@ -55,4 +55,15 @@ describe("taskDialogInfo", () => {
 			labels: [LABEL],
 		});
 	});
+
+	it("attaches an opener when the dialog can navigate to the task", () => {
+		const onClick = () => {};
+		const task = { seq: 42, customTitle: "Do the thing" } as Task;
+		const project = { id: "p1", name: "dev-3.0", path: "/p", labels: [LABEL] } as Project;
+
+		expect(taskDialogInfo(task, project, onClick)).toEqual(expect.objectContaining({
+			title: "Do the thing",
+			onClick,
+		}));
+	});
 });

--- a/src/mainview/utils/confirmTaskCompletion.ts
+++ b/src/mainview/utils/confirmTaskCompletion.ts
@@ -13,6 +13,7 @@ export async function confirmTaskCompletion(
 	project: Project,
 	newStatus: TaskStatus,
 	t: TFunction,
+	onOpenTask?: () => void,
 ): Promise<boolean> {
 	if (newStatus !== "completed" && newStatus !== "cancelled") return true;
 	if (!task.worktreePath) return true;
@@ -72,7 +73,7 @@ export async function confirmTaskCompletion(
 
 	return confirm({
 		title: t("task.warnCompletionTitle"),
-		info: taskDialogInfo(task, project),
+		info: taskDialogInfo(task, project, onOpenTask),
 		message,
 	});
 }

--- a/src/mainview/utils/moveTaskToStatus.ts
+++ b/src/mainview/utils/moveTaskToStatus.ts
@@ -18,6 +18,8 @@ export interface MoveTaskToStatusOptions {
 	newStatus: TaskStatus;
 	dispatch: Dispatch<AppAction>;
 	t: TFunction;
+	/** Open the task from the terminal-state confirmation card. */
+	onOpenTask?: () => void;
 	/** Run the unpushed/uncommitted confirmation before terminal moves. Default true. */
 	confirm?: boolean;
 	/** Toggle a per-card "moving" spinner while the background RPC is in flight. */
@@ -64,6 +66,7 @@ export async function moveTaskToStatus({
 	newStatus,
 	dispatch,
 	t,
+	onOpenTask,
 	confirm = true,
 	onMovingChange,
 	onMoved,
@@ -74,7 +77,7 @@ export async function moveTaskToStatus({
 	const terminal = isTerminalStatus(newStatus);
 
 	if (confirm && terminal && task.worktreePath) {
-		const proceed = await confirmTaskCompletion(task, project, newStatus, t);
+		const proceed = await confirmTaskCompletion(task, project, newStatus, t, onOpenTask);
 		if (!proceed) return false;
 	}
 

--- a/src/mainview/utils/taskDialogInfo.ts
+++ b/src/mainview/utils/taskDialogInfo.ts
@@ -29,6 +29,7 @@ export function taskDialogInfoFromSubject(taskTitle: string, subject?: TaskDialo
  * it to the confirm info card in one step. Equivalent to the wire path so every
  * worktree-destroying prompt renders the same context card.
  */
-export function taskDialogInfo(task: Task, project: Project): ConfirmInfo {
-	return taskDialogInfoFromSubject(getTaskTitle(task), buildTaskDialogSubject(task, project));
+export function taskDialogInfo(task: Task, project: Project, onClick?: () => void): ConfirmInfo {
+	const info = taskDialogInfoFromSubject(getTaskTitle(task), buildTaskDialogSubject(task, project));
+	return onClick ? { ...info, onClick } : info;
 }


### PR DESCRIPTION
## Summary

- Make task titles in terminal-state confirmation dialogs clickable.
- Dismiss the confirmation like `Cancel` and open the referenced task.
- Preserve the user's configured split or fullscreen task view.

## Root cause

The confirmation service already supported task navigation through `info.onClick`, but unsaved-change prompts did not pass an opener through `moveTaskToStatus`.

## Validation

- `bun run lint`
- 348 targeted component and utility tests
- Browser QA in remote mode
