### PR TITLE
Fix stale task state after auto-merged PR

### DIFF
--- a/change-logs/2026/07/24/fix-pr-auto-merge-reconciliation.md
+++ b/change-logs/2026/07/24/fix-pr-auto-merge-reconciliation.md
@@ -1,0 +1,3 @@
+Short: Sync auto-merged PRs
+
+Linked tasks now refresh sticky pull requests after GitHub auto-merge, even when the remote branch was deleted, and reuse the existing merge completion flow without repeating prompts.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -8756,6 +8756,121 @@ describe("checkOpenPRsForPromotion", () => {
 		expect(data.updateTask).not.toHaveBeenCalledWith(project, task.id, { status: "review-by-colleague" });
 	});
 
+	it("reconciles an auto-merged sticky PR after its remote branch disappears", async () => {
+		const { project, task } = setup({
+			status: "review-by-user",
+			prNumber: 42,
+			prUrl: "https://github.com/test/repo/pull/42",
+		});
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.getHeadSha).mockResolvedValue("abc123");
+		const mergedPr = {
+			number: 42,
+			isDraft: false,
+			autoMergeRequest: null,
+			url: task.prUrl,
+			statusCheckRollup: [],
+			reviewDecision: null,
+			mergeable: "UNKNOWN",
+			mergeStateStatus: "UNKNOWN",
+			state: "MERGED",
+			title: "Merged change",
+		};
+		vi.mocked(github.runGitHub)
+			.mockResolvedValueOnce({ ok: true, stdout: "[]", stderr: "", code: 0 })
+			.mockResolvedValueOnce({ ok: true, stdout: JSON.stringify(mergedPr), stderr: "", code: 0 })
+			.mockResolvedValueOnce({
+				ok: true,
+				stdout: JSON.stringify({
+					data: {
+						repository: {
+							pullRequest: {
+								reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+							},
+						},
+					},
+				}),
+				stderr: "",
+				code: 0,
+			});
+		const push = vi.fn();
+		setPushMessage(push);
+
+		await checkOpenPRsForPromotion();
+
+		expect(github.runGitHub).toHaveBeenNthCalledWith(
+			2,
+			project,
+			task.worktreePath,
+			expect.arrayContaining(["pr", "view", "42", "--json"]),
+			expect.objectContaining({ timeoutMs: expect.any(Number) }),
+		);
+		expect(data.updateTask).toHaveBeenCalledWith(project, task.id, expect.objectContaining({
+			prStatusCache: expect.objectContaining({
+				mergeState: { mergeable: "UNKNOWN", status: "UNKNOWN", state: "MERGED" },
+			}),
+		}));
+		expect(push).toHaveBeenCalledWith("branchMerged", expect.objectContaining({
+			taskId: task.id,
+			fingerprint: "v1:dev3/my-feature:abc123",
+		}));
+	});
+
+	it("does not repeat merge handling when the same merged PR is refreshed", async () => {
+		const { project, task } = setup({
+			status: "review-by-user",
+			prNumber: 42,
+			prUrl: "https://github.com/test/repo/pull/42",
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.getHeadSha).mockResolvedValue("abc123");
+		vi.mocked(github.runGitHub).mockImplementation(async (_project, _worktreePath, args) => {
+			if (args.includes("list")) return { ok: true, stdout: "[]", stderr: "", code: 0 };
+			if (args.includes("view")) {
+				return {
+					ok: true,
+					stdout: JSON.stringify({
+						number: 42,
+						isDraft: false,
+						autoMergeRequest: null,
+						url: task.prUrl,
+						statusCheckRollup: [],
+						reviewDecision: null,
+						mergeable: "UNKNOWN",
+						mergeStateStatus: "UNKNOWN",
+						state: "MERGED",
+						title: "Merged change",
+					}),
+					stderr: "",
+					code: 0,
+				};
+			}
+			return {
+				ok: true,
+				stdout: JSON.stringify({
+					data: {
+						repository: {
+							pullRequest: {
+								reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+							},
+						},
+					},
+				}),
+				stderr: "",
+				code: 0,
+			};
+		});
+		const push = vi.fn();
+		setPushMessage(push);
+
+		await handlers.refreshTaskPrStatus({ taskId: task.id, projectId: project.id });
+		await handlers.refreshTaskPrStatus({ taskId: task.id, projectId: project.id });
+
+		expect(push.mock.calls.filter(([message]) => message === "branchMerged")).toHaveLength(1);
+	});
+
 	it("uses the GraphQL review-thread page and persists the PR identity", async () => {
 		const { project, task } = setup({ status: "review-by-colleague" }, { githubAuthHost: "ghe.example.com" });
 		const prUrl = "https://ghe.example.com/test/repo/pull/42";

--- a/src/bun/lifecycle/activities.ts
+++ b/src/bun/lifecycle/activities.ts
@@ -476,13 +476,16 @@ async function fetchUnresolvedReviewThreadCount(
 	return null;
 }
 
-async function pollTaskPrStatus(project: Project, task: Task): Promise<PolledPRStatus | null> {
+async function pollTaskPrStatus(project: Project, task: Task, suggestCompletion: boolean): Promise<PolledPRStatus | null> {
 	if (!task.worktreePath) return null;
 	const branchName = await git.getCurrentBranch(task.worktreePath);
 	if (!branchName) return null;
 
 	const unpushed = await git.getUnpushedCount(task.worktreePath, branchName);
-	if (unpushed === -1) return null;
+	// A missing remote branch means "never pushed" only when the task has no
+	// sticky PR. After auto-merge, GitHub may delete the branch while the task
+	// still needs the exact PR fetched by number.
+	if (unpushed === -1 && task.prNumber == null) return null;
 
 	const ghResult = await github.runGitHub(
 		project,
@@ -610,6 +613,17 @@ async function pollTaskPrStatus(project: Project, task: Task): Promise<PolledPRS
 		signalKey,
 		...(signalReason ? { signalReason } : {}),
 	});
+	if (mergeState.state === "MERGED") {
+		const fingerprint = await getMergeCompletionFingerprint(task, branchName);
+		await dispatchLifecycleFinding(project, task, {
+			type: "mergeDetected",
+			branchName,
+			fingerprint: fingerprint.fingerprint,
+			precise: fingerprint.precise,
+			detectedAt: new Date().toISOString(),
+			suggestCompletion,
+		});
+	}
 
 	return { found: isOpenPr, ciStatus };
 }
@@ -619,6 +633,8 @@ export async function checkOpenPRsForPromotion(): Promise<void> {
 	if (!getPushMessage()) return;
 
 	const projects = await data.loadProjects();
+	const settings = await loadSettings();
+	const suggestCompletion = settings.suggestCompletingTasksAfterMerge !== false;
 	const { projectId: activeProjectId } = getActiveContext();
 	const foreground = isAppForeground();
 	const now = Date.now();
@@ -658,7 +674,7 @@ export async function checkOpenPRsForPromotion(): Promise<void> {
 
 		for (const task of dueTasks) {
 			try {
-				const result = await pollTaskPrStatus(project, task);
+				const result = await pollTaskPrStatus(project, task, suggestCompletion);
 				if (result) lifecycleActorRuntime(task.id).prPending = result.found && result.ciStatus === "pending";
 			} catch (err) {
 				log.warn("PR check failed for task", { taskId: task.id.slice(0, 8), error: String(err) });
@@ -680,7 +696,9 @@ export async function refreshTaskPrStatus(params: { taskId: string; projectId: s
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
 	if (project.kind === "virtual" || !task.worktreePath || TERMINAL_TASK_STATUSES.has(task.status)) return;
-	const result = await pollTaskPrStatus(project, task);
+	const settings = await loadSettings();
+	const suggestCompletion = settings.suggestCompletingTasksAfterMerge !== false;
+	const result = await pollTaskPrStatus(project, task, suggestCompletion);
 	const runtime = lifecycleActorRuntime(task.id);
 	if (result) runtime.prPending = result.found && result.ciStatus === "pending";
 	delete runtime.prNextDue;


### PR DESCRIPTION
## Summary

- Keep sticky PR reconciliation active after GitHub auto-merge deletes the remote branch.
- Persist the merged PR status and route it through the existing lifecycle merge/review/completion handling.
- Reuse lifecycle deduplication so repeated refreshes do not repeat merge prompts or notifications.

Closes #1104

## Tests

- Focused PR/lifecycle Vitest suites pass.
- `bun run lint` passes.
- The full suite still has unrelated baseline failures in existing TaskDiffViewer, cli-socket-codex-capture, and getTaskDiff tests.