### PR TITLE
Assert the preparation-failure toast synchronously in App tests

### DIFF
--- a/change-logs/2026/07/25/fix-flaky-task-preparation-alert-test.md
+++ b/change-logs/2026/07/25/fix-flaky-task-preparation-alert-test.md
@@ -1,0 +1,1 @@
+Made the App test for the task-preparation-failure toast deterministic. It polled for any `role="alert"` element inside the default 1s timeout even though the toast is delivered synchronously, so it could time out under concurrent test-suite load; it now asserts the exact toast message right after the dispatching `act()`.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1988,9 +1988,11 @@ describe("App keyboard shortcuts", () => {
 				}));
 			});
 
-			expect(await screen.findByRole("alert")).toHaveTextContent(
-				"Couldn't prepare \"Broken task\" — moved back to To Do: tmux failed to spawn",
-			);
+			// `toast.error` delivers synchronously, so the toast is in the DOM once act()
+			// returns — polling only spent a 1s budget concurrent suites could exhaust.
+			// Match the exact message so another role="alert" can't satisfy or break it.
+			const message = "Couldn't prepare \"Broken task\" — moved back to To Do: tmux failed to spawn";
+			expect(screen.getByText(message).closest('[role="alert"]')).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
`App.test.tsx` > "shows the backend failure reason when a Git task is reverted to To Do" was flaky: it failed only while the three vitest configs ran concurrently via `bun run test`, at ~1019ms — i.e. right at the default 1s `findBy*` timeout — and was green in isolation.

The test dispatched `rpc:taskPreparationFailed` inside a sync `act()` and then polled `findByRole("alert")`. But there is nothing to wait for: the App handler calls `toast.error` synchronously, `deliver()` invokes the mounted `ToastHost` listener synchronously, and its `setToasts` is flushed by the surrounding `act()`. So the toast is already in the DOM when `act()` returns, and the only thing the poll added was a 1s budget that concurrent suites could exhaust. The bare `role="alert"` query was also ambiguous — `TaskCard`, `MobilePortraitGate` and `RootErrorBoundary` all render that role.

It now asserts the exact toast message right after the dispatching `act()` and checks it sits inside a `[role="alert"]` node. No timeout budget to lose, no ambiguity about which alert matched.

Note: the precise trigger under load (an extra alert vs. an exhausted budget) was not reproduced — verified that only one `role="alert"` exists at assertion time in isolation — but removing the wait removes both failure modes.