### PR TITLE
Fix flaky App and git suite tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,12 +254,24 @@ jobs:
               echo "     ✗ shard ${entry%% *} · ${entry##* }"
             done
             echo "=================================================================="
+            echo ""
+            echo "  This job only reads the shard artifacts — it never runs a test."
+            echo "  Re-running ONLY this job re-reads the same artifacts and fails"
+            echo "  identically. Re-run the whole workflow instead:"
+            echo "      gh run rerun $GITHUB_RUN_ID          # all jobs"
+            echo "      gh run rerun $GITHUB_RUN_ID --failed # failed jobs (incl. shards)"
+            echo ""
             {
               echo "## ❌ Failing test suites"
               echo ""
               for entry in "${failed_suites[@]}"; do
                 echo "- **shard ${entry%% *}** · \`${entry##* }\`"
               done
+              echo ""
+              echo "> ⚠️ **Re-running the \`test\` job alone will not help.** It only reads the"
+              echo "> shard artifacts; re-run the whole workflow with"
+              echo "> \`gh run rerun $GITHUB_RUN_ID\` (or **Re-run all jobs**) so the shards"
+              echo "> actually execute again."
               echo ""
             } >> "$GITHUB_STEP_SUMMARY"
 

--- a/change-logs/2026/07/25/fix-flaky-app-and-git-tests.md
+++ b/change-logs/2026/07/25/fix-flaky-app-and-git-tests.md
@@ -1,0 +1,3 @@
+Short: Killed the merge-blocking flaky tests
+
+Fixed the flaky tests that kept blocking merges on unchanged code. Toasts raised before the toast host subscribes are now queued and delivered instead of silently dropped, which also fixes losing a `dev3 show-image`/CLI toast that arrives during startup; the git test helpers no longer hang a whole suite when a spawn fails or when a temp repo is removed under a still-running git process; and the sharded CI test gate now tells you to re-run the whole workflow instead of just the aggregate job, which only re-reads the same artifacts.

--- a/decisions/166-sharded-test-gate-needs-pipefail.md
+++ b/decisions/166-sharded-test-gate-needs-pipefail.md
@@ -33,6 +33,14 @@ propagates vitest's exit code into `outcome` (see `build.yml`, steps
 into `tee` without an explicit `shell: bash`. The guard was verified by removing
 `shell: bash` from one step and watching it name that step.
 
+## Re-running the gate
+
+The aggregate `test` job never executes a test — it only reads the shard artifacts, so
+re-running that job alone re-downloads the same artifacts and fails identically. That
+repeatedly read as "the flake is still there". The failure banner and the run summary
+now say so and print `gh run rerun <run-id>`: a red gate needs the **whole** workflow
+re-run (or `--failed`, which includes the shard jobs) for the shards to run again.
+
 ## Risks
 
 - The guard only recognises `| tee`; a different pipe construct in a gating step

--- a/decisions/167-queue-toasts-until-a-host-subscribes.md
+++ b/decisions/167-queue-toasts-until-a-host-subscribes.md
@@ -1,0 +1,57 @@
+# 167 — Queue toasts until a host subscribes
+
+## Context
+
+`App.test.tsx` failed roughly 4 times per 100 file runs on unchanged code, always in a
+test that dispatches a synthetic `rpc:*` event right after `renderApp()`: the
+shared-image toast navigation (blocked PR #1118), the New Task modal, the
+branch-merged completion popup, the preparation-failure toast. Every failure looked
+like a slow machine (a `findBy*` giving up at its 1000 ms timeout, or the 5 s test
+timeout) so a rerun always "fixed" it. It never reproduced on an idle machine — 190
+clean runs, including 450 repeats of the exact failing assertion, were green.
+
+## Investigation
+
+Reproduced by starving the CPU (16 busy loops) while looping the file: 4 failures in
+100 runs, in three different tests. Instrumenting `emit()` caught the mechanism:
+
+    [dbg emit] {"message":"Couldn't prepare ...","suppressed":false,"listeners":0}
+
+The toast *was* raised and thrown away. `ToastHost` subscribes from a passive effect,
+and `emit()` dropped any entry that arrived while `listeners` was empty ("no host
+mounted → silently drop"). App's own window listener was already attached, so a push
+message handled in that window vanished with no trace — permanently, which is why the
+polling `findBy*` never recovered and the failure read as a timeout.
+
+## Decision
+
+1. `emit()` (`src/mainview/toast.tsx`) now queues into the existing `pendingEntries`
+   buffer when no host is subscribed, bounded to `MAX_PENDING_ENTRIES`, and
+   `flushPendingEntries()` hands the queue to a host as it subscribes. This also fixes
+   the production case: a toast raised before the first `ToastHost` effect flush used
+   to be lost. `_resetPendingToastsForTests()` drops the queue from a global
+   `afterEach` in `src/mainview/test-setup.ts` so no test leaks toasts into the next.
+2. `renderApp()` in `src/mainview/__tests__/App.test.tsx` drains React's passive
+   effects (`await act(async () => {})`) after a screen testid appears. A testid is
+   visible at commit time, which can precede the effects that register App's window
+   listeners.
+3. The branch-merged test's inner `waitFor` dropped from 5000 ms to 3000 ms so it can
+   no longer collide with the 5 s test timeout — a real failure now reports the missing
+   element and a DOM dump instead of "Test timed out in 5000ms".
+
+## Risks
+
+Queued toasts are delivered to the next host that subscribes, so a toast raised long
+before any host mounts now shows up late rather than never. The `MAX_PENDING_ENTRIES`
+bound and the per-test reset keep that window small; in the app there is exactly one
+host, mounted for its whole lifetime.
+
+## Alternatives considered
+
+- Bumping the `findBy*`/test timeouts: hides the drop instead of fixing it, and the
+  entry is gone forever, so no timeout is large enough.
+- Making `ToastHost` subscribe from `useLayoutEffect`: narrows the window but does not
+  close it (the host still is not mounted during the very first render pass) and pulls
+  toast delivery into the commit phase.
+- Asserting the subscription inside `renderApp()`: needs a test-only export of
+  `listeners.size` and still leaves the production drop in place.

--- a/decisions/168-git-test-repos-outlive-their-test.md
+++ b/decisions/168-git-test-repos-outlive-their-test.md
@@ -1,0 +1,52 @@
+# 168 — Git test repos outlive their test
+
+## Context
+
+`git-merge-detection`, `git-diff-recent` and `git-unicode-filenames` flaked under
+concurrent load with a drifting failure count on identical code. The visible symptom
+was always `Error: Test timed out in 5000ms`, which reads as "these tests are just
+slow".
+
+## Investigation
+
+Reproduced under CPU pressure. The run also printed an unhandled error that named a
+*different* test than the one that failed:
+
+    Uncaught Exception: Error: spawn git ENOENT
+    { spawnargs: ['-c','core.quotepath=false','merge-base','origin/main','HEAD'] }
+
+`git.ts` coalesces fetches, so a git call can outlive the test that started it.
+`cleanup()` then `rmSync`'d the repo in `afterEach`, and the still-running child
+spawned into a cwd that no longer existed. `createSpawnMock` had no `error` handler, so
+that spawn failure became an uncaught exception *and* left `exited` pending forever —
+the next test awaiting it died on the suite timeout. Not slowness: a hang.
+
+## Decision
+
+In `src/bun/__tests__/git-test-helpers.ts`:
+
+- `createSpawnMock` resolves `exited` with `1` on the child's `error` event, guards
+  `stdout`/`stderr` being `null`, and closes (never errors) a stream that dies
+  mid-read. A spawn hiccup now fails an assertion with a readable message.
+- `cleanup()` retires the repo directory and removes every retired directory once on
+  `process.once("exit")`, together with the worker's template repo, instead of racing
+  in-flight subprocesses in `afterEach`.
+- `GIT_CONFIG_ISOLATION` (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`,
+  `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`) applies to both the helper's own
+  `git` calls and the spawns made by the code under test, so the machine's hooks,
+  commit signing, templates and `init.defaultBranch` cannot change the fixtures.
+- Removed the unused `setupCommonMocks()` — its nested `vi.mock` calls emitted hoisting
+  warnings that vitest says will become an error.
+
+## Risks
+
+Temp repos now live until the worker exits, so a full bun run holds a few dozen small
+directories in `$TMPDIR` instead of one. They are removed on exit; a hard `SIGKILL` of
+the worker leaves them for the OS to reap, exactly as the template repo already did.
+
+## Alternatives considered
+
+- Raising `testTimeout` for the git suites: the awaited promise never settles, so any
+  timeout only changes how long the suite waits before reporting the wrong thing.
+- Awaiting `git.ts`'s in-flight map before cleanup: needs production code to expose its
+  coalescing internals purely for tests, and still races anything not in that map.

--- a/src/bun/__tests__/git-test-helpers.test.ts
+++ b/src/bun/__tests__/git-test-helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { createSpawnMock, GIT_ENV } from "./git-test-helpers";
+
+// Regression guard for the git-suite flake: a spawn that never starts used to raise
+// an uncaught `error` event AND leave `exited` pending forever, so the awaiting test
+// died on the 5s suite timeout — attributed to whichever test happened to be running.
+describe("createSpawnMock", () => {
+	it("resolves exited with a non-zero code when the binary cannot be spawned", async () => {
+		const { spawn } = createSpawnMock();
+
+		const proc = spawn(["dev3-definitely-not-a-real-binary", "--version"]);
+
+		await expect(proc.exited).resolves.toBe(1);
+	});
+
+	it("yields empty output streams for a spawn that never started", async () => {
+		const { spawn } = createSpawnMock();
+
+		const proc = spawn(["dev3-definitely-not-a-real-binary"]);
+		await proc.exited;
+
+		await expect(new Response(proc.stdout).text()).resolves.toBe("");
+		await expect(new Response(proc.stderr).text()).resolves.toBe("");
+	});
+
+	it("resolves exited when the cwd no longer exists", async () => {
+		const { spawn } = createSpawnMock();
+
+		const proc = spawn(["git", "status"], { cwd: "/tmp/dev3-removed-by-a-previous-test" });
+
+		await expect(proc.exited).resolves.toBeGreaterThan(0);
+	});
+
+	it("neutralises the machine's git config", () => {
+		expect(GIT_ENV.GIT_CONFIG_GLOBAL).toBe("/dev/null");
+		expect(GIT_ENV.GIT_CONFIG_NOSYSTEM).toBe("1");
+	});
+});

--- a/src/bun/__tests__/git-test-helpers.ts
+++ b/src/bun/__tests__/git-test-helpers.ts
@@ -5,31 +5,24 @@
  * and vi.mock("../spawn") at the top level before importing git functions.
  * See git-merge-detection.test.ts for the reference pattern.
  */
-import { vi } from "vitest";
 import { execSync } from "child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { spawn as cpSpawn } from "child_process";
 
-// ─── Common mocks setup ─────────────────────────────────────────────────────
-
-export function setupCommonMocks() {
-	vi.mock("../logger", () => ({
-		createLogger: () => ({
-			debug: vi.fn(),
-			info: vi.fn(),
-			warn: vi.fn(),
-			error: vi.fn(),
-		}),
-	}));
-
-	vi.mock("../paths", () => ({
-		DEV3_HOME: process.env.DEV3_HOME ?? `${tmpdir()}/dev3-test-home`,
-	}));
-}
-
 // ─── Git helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Ignore the machine's git config so hooks, commit signing, templates or a custom
+ * `init.defaultBranch` cannot change what these repos look like — locally or on CI.
+ */
+export const GIT_CONFIG_ISOLATION = {
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+	GIT_CONFIG_NOSYSTEM: "1",
+	GIT_TERMINAL_PROMPT: "0",
+};
 
 export const GIT_ENV = {
 	...process.env,
@@ -37,6 +30,7 @@ export const GIT_ENV = {
 	GIT_AUTHOR_EMAIL: "test@test.com",
 	GIT_COMMITTER_NAME: "Test",
 	GIT_COMMITTER_EMAIL: "test@test.com",
+	...GIT_CONFIG_ISOLATION,
 };
 
 export function g(cmd: string, cwd: string): string {
@@ -82,8 +76,24 @@ export function createTestRepo(): TestRepo {
 	return { dir, local };
 }
 
+/**
+ * Removing the repo in `afterEach` races any git subprocess the previous test left
+ * running (git.ts coalesces fetches, so a call can outlive its caller): the child
+ * then dies with ENOENT on a cwd that no longer exists and poisons an unrelated
+ * test. Retire the directory instead and delete it once, after the worker's last
+ * test — the template repo already lives for the whole worker.
+ */
+const retiredDirs: string[] = [];
+let removalHookInstalled = false;
+
 export function cleanup({ dir }: TestRepo): void {
-	rmSync(dir, { recursive: true, force: true });
+	retiredDirs.push(dir);
+	if (removalHookInstalled) return;
+	removalHookInstalled = true;
+	process.once("exit", () => {
+		for (const retired of retiredDirs) rmSync(retired, { recursive: true, force: true });
+		if (_templateDir) rmSync(_templateDir, { recursive: true, force: true });
+	});
 }
 
 export function makeTaskCommits(local: string): void {
@@ -105,6 +115,10 @@ export function makeTaskCommits(local: string): void {
 
 // ─── Spawn mock factory ─────────────────────────────────────────────────────
 
+function emptyStream() {
+	return new ReadableStream({ start: (controller) => controller.close() });
+}
+
 function toWebStream(readable: NodeJS.ReadableStream) {
 	return new ReadableStream({
 		start(controller) {
@@ -112,7 +126,14 @@ function toWebStream(readable: NodeJS.ReadableStream) {
 				controller.enqueue(new Uint8Array(chunk)),
 			);
 			readable.on("end", () => controller.close());
-			readable.on("error", (err: Error) => controller.error(err));
+			// A stream error is the child dying mid-read; close instead of erroring so
+			// callers see an empty output plus the non-zero `exited`, never a rejection
+			// surfacing as an unhandled error in an unrelated test.
+			readable.on("error", () => {
+				try {
+					controller.close();
+				} catch { /* already closed */ }
+			});
 		},
 	});
 }
@@ -144,25 +165,34 @@ export function createSpawnMock(getGhResponse?: () => string) {
 
 			const child = cpSpawn(cmd[0], cmd.slice(1), {
 				cwd: opts?.cwd as string | undefined,
-				env: (opts?.env as NodeJS.ProcessEnv | undefined) ?? process.env,
+				// Isolation last: the machine's git config must not reach the code under test.
+				env: { ...(opts?.env as NodeJS.ProcessEnv | undefined ?? process.env), ...GIT_CONFIG_ISOLATION },
 				stdio: ["pipe", "pipe", "pipe"],
 			});
 
 			if (opts?.stdin instanceof Blob) {
 				(opts.stdin as Blob).arrayBuffer().then((buf) => {
-					child.stdin!.write(Buffer.from(buf));
-					child.stdin!.end();
-				});
+					child.stdin?.write(Buffer.from(buf));
+					child.stdin?.end();
+				}).catch(() => { /* the child died before stdin was writable */ });
 			} else {
 				child.stdin?.end();
 			}
 
+			// A spawn that never starts (ENOENT because a previous test already removed
+			// the cwd, EAGAIN under fork pressure…) emits `error`, not `close`. Without
+			// this the ChildProcess raises an uncaught exception AND `exited` never
+			// settles, so the awaiting test hangs until the suite-wide timeout instead
+			// of failing with a readable message.
+			const exited = new Promise<number>((resolve) => {
+				child.on("close", (code: number | null) => resolve(code ?? 1));
+				child.on("error", () => resolve(1));
+			});
+
 			return {
-				exited: new Promise<number>((resolve) =>
-					child.on("close", (code: number | null) => resolve(code ?? 1)),
-				),
-				stdout: toWebStream(child.stdout!),
-				stderr: toWebStream(child.stderr!),
+				exited,
+				stdout: child.stdout ? toWebStream(child.stdout) : emptyStream(),
+				stderr: child.stderr ? toWebStream(child.stderr) : emptyStream(),
 			};
 		},
 	};

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -177,6 +177,13 @@ async function renderApp() {
 			|| screen.queryByTestId("project-terminal-screen"),
 		).toBeInTheDocument(),
 	);
+	// A screen testid appears at commit time, which can precede React flushing the
+	// passive effects that register App's window `rpc:*` listeners. Draining them
+	// here keeps every test that dispatches a synthetic push message deterministic —
+	// an event fired into that window is lost outright, not merely late.
+	await act(async () => {
+		await Promise.resolve();
+	});
 }
 
 class FakeWebNotification {
@@ -1803,12 +1810,14 @@ describe("App keyboard shortcuts", () => {
 
 			await fireBranchMerged("t1", "p1", "fp-confirm-1");
 
-			// Slow CI runners can exceed the default 1s waitFor timeout here
+			// Slow CI runners can exceed the default 1s waitFor timeout here. Stay
+			// clear of the 5s test timeout so a genuine failure reports the missing
+			// element (with a DOM dump) instead of an opaque "test timed out".
 			await waitFor(
 				() => {
 					expect(screen.getByTestId("project-screen")).toBeInTheDocument();
 				},
-				{ timeout: 5000 },
+				{ timeout: 3000 },
 			);
 			expect(screen.queryByTestId("task-screen")).not.toBeInTheDocument();
 			expect(api.request.moveTask).toHaveBeenCalledWith(

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -335,6 +335,27 @@ describe("toast service", () => {
 		expect(() => toast.error("orphan")).not.toThrow();
 	});
 
+	// `ToastHost` subscribes from a passive effect, so a push message handled in the
+	// window before React flushes it used to drop the toast outright — invisible in
+	// production and a source of flaky assertions in tests.
+	it("delivers a toast raised before the host subscribed", async () => {
+		toast.info("Raised before mount");
+
+		render(<ToastHost />);
+
+		expect(await screen.findByText("Raised before mount")).toBeInTheDocument();
+	});
+
+	it("keeps only the newest queued entries when no host ever subscribes", async () => {
+		for (let index = 1; index <= 7; index += 1) toast.info(`Queued ${index}`);
+
+		render(<ToastHost />);
+
+		expect(await screen.findByText("Queued 7")).toBeInTheDocument();
+		expect(screen.queryByText("Queued 1")).not.toBeInTheDocument();
+		expect(screen.queryByText("Queued 2")).not.toBeInTheDocument();
+	});
+
 	it("queues toasts while suppressed and flushes them in order", async () => {
 		render(<ToastHost />);
 		setToastSuppressed(true);

--- a/src/mainview/test-setup.ts
+++ b/src/mainview/test-setup.ts
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { createElement } from "react";
+import { _resetPendingToastsForTests } from "./toast";
+
+// Toasts raised without a mounted host are queued for the next host (see toast.tsx),
+// so drop the queue between tests instead of leaking them into the next render.
+afterEach(() => {
+	_resetPendingToastsForTests();
+});
 
 // NOTE on transport detection in tests: happy-dom has no `__electrobunWebviewId`,
 // so `isRemote()` (utils/platform) reports browser-remote by default — the SAME

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -54,6 +54,8 @@ const pendingEntries: ToastEntry[] = [];
 /** Default auto-dismiss delay. Long on purpose so error messages aren't missed. */
 const DEFAULT_DURATION_MS = 30_000;
 const MAX_VISIBLE_TOASTS = 5;
+/** Queue bound for entries raised while suppressed or before a host subscribed. */
+const MAX_PENDING_ENTRIES = 5;
 const NARROW_MAX_VISIBLE_TOASTS = 1;
 const NARROW_VIEWPORT_PX = 768;
 
@@ -71,12 +73,23 @@ function emit(message: string, variant: ToastVariant, opts?: ToastOpts): void {
 		onClick: opts?.onClick,
 		context: opts?.context,
 	};
-	if (suppressed) {
+	// Queue while immersive fullscreen suppresses toasts, and also while no host is
+	// subscribed yet: `ToastHost` subscribes from a passive effect, so a toast raised
+	// from a push message that lands before React flushes it would otherwise vanish
+	// with no trace at all.
+	if (suppressed || !listeners.size) {
 		pendingEntries.push(entry);
+		if (pendingEntries.length > MAX_PENDING_ENTRIES) pendingEntries.shift();
 		return;
 	}
-	// No host mounted (e.g. in unit tests) → silently drop.
 	deliver(entry);
+}
+
+/** Hands queued entries to a host that just subscribed (see {@link emit}). */
+function flushPendingEntries(): void {
+	if (suppressed || !listeners.size) return;
+	const pending = pendingEntries.splice(0, pendingEntries.length);
+	pending.forEach(deliver);
 }
 
 /**
@@ -99,9 +112,15 @@ export function setToastSuppressed(value: boolean): void {
 	if (suppressed === value) return;
 	suppressed = value;
 	if (suppressed) return;
+	flushPendingEntries();
+}
 
-	const pending = pendingEntries.splice(0, pendingEntries.length);
-	pending.forEach(deliver);
+/**
+ * Drops queued entries so a test file that raises toasts without a mounted host
+ * cannot leak them into the next test's host.
+ */
+export function _resetPendingToastsForTests(): void {
+	pendingEntries.length = 0;
 }
 
 const VARIANT: Record<ToastVariant, { icon: string; border: string; text: string; bar: string }> = {
@@ -265,6 +284,7 @@ export function ToastHost({ onTaskOverflow }: ToastHostProps = {}) {
 			startRuntime(entry.id);
 		};
 		listeners.add(listener);
+		flushPendingEntries();
 		return () => {
 			listeners.delete(listener);
 			for (const id of runtimesRef.current.keys()) clearRuntime(id);


### PR DESCRIPTION
## Summary

The flaky tests that kept blocking merges had two distinct root causes, both found by instrumenting a reproduction rather than by bumping a timeout.

**1. Dropped toasts (`App.test.tsx`, blocked #1118).** `emit()` in `toast.tsx` threw away any entry raised while no `ToastHost` listener was subscribed. `ToastHost` subscribes from a passive effect, so a synthetic `rpc:*` event dispatched right after `renderApp()` could land between the commit (screen testid already visible) and the effect flush — the toast was gone for good, so the polling `findBy*` never recovered and the failure looked like a plain 1000 ms timeout. Instrumentation caught it verbatim: `[dbg emit] {"suppressed":false,"listeners":0}`. Entries are now queued (bounded) and flushed when a host subscribes, which also fixes the production case of a startup-window toast vanishing. `renderApp()` additionally drains passive effects, and the branch-merged test's inner `waitFor` moved off the 5 s test timeout so a real failure reports the missing element instead of "Test timed out".

**2. Hanging git suites.** `createSpawnMock` had no `error` handler: a spawn that never starts (ENOENT, because `cleanup()` removed the repo while a coalesced `git.ts` fetch was still running) raised an uncaught exception *and* left `exited` pending forever, killing an unrelated test on the suite timeout. The tell is that the unhandled-error banner names a different test than the one that failed. The mock now resolves `exited` on `error`, guards null stdio, temp repos are retired to `process.exit` instead of `afterEach`, and git config is pinned to `/dev/null` for both the helper and the code under test. The unused `setupCommonMocks()` — source of the `vi.mock` hoisting warnings — is gone.

**3. CI wart.** The aggregate `test` job only reads shard artifacts, so re-running it alone fails identically. Its failure banner and run summary now say so and print `gh run rerun <run-id>`.

Reproduction required CPU starvation: 4 failures in 100 loaded runs across three different tests, versus 0 in 190 idle runs (including 450 repeats of the exact failing assertion). Post-fix: 0 in 40 loaded runs, plus a green full suite. Details in `decisions/167` and `decisions/168`.