### PR TITLE
Render markdown diffs as a rich preview with add/remove blocks

### DIFF
--- a/change-logs/2026/07/25/feature-20-markdown-diff-preview-blocks.md
+++ b/change-logs/2026/07/25/feature-20-markdown-diff-preview-blocks.md
@@ -1,0 +1,3 @@
+Short: Markdown diffs render as rich preview
+
+Markdown files in the diff viewer now open in rendered preview mode by default, and a modified file's preview highlights what changed: added blocks sit on a green wash, removed blocks on a red one, GitHub rich-diff style. The Preview toggle still switches back to the raw source diff per file.

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -268,3 +268,35 @@
 	border-bottom: 1px solid rgb(var(--border-default));
 	padding-bottom: 0.25rem;
 }
+
+/* ---- Markdown rich diff (.dev3-md-diff) ----
+   Rendered markdown where every block carries its change state: added blocks sit
+   on a green wash, removed blocks on a red one, unchanged blocks stay plain. */
+.dev3-md-diff-block {
+	border-left: 3px solid transparent;
+	border-radius: 0.25rem;
+	padding: 0.0625rem 0.625rem;
+}
+.dev3-md-diff-block > :first-child {
+	margin-top: 0;
+}
+.dev3-md-diff-block > :last-child {
+	margin-bottom: 0;
+}
+.dev3-md-diff-added,
+.dev3-md-diff-removed {
+	margin: 0.25rem 0;
+	padding-top: 0.375rem;
+	padding-bottom: 0.375rem;
+}
+.dev3-md-diff-added {
+	background: rgb(var(--success) / 0.14);
+	border-left-color: rgb(var(--success));
+}
+.dev3-md-diff-removed {
+	background: rgb(var(--danger) / 0.14);
+	border-left-color: rgb(var(--danger));
+}
+.dev3-md-diff-removed > * {
+	opacity: 0.85;
+}

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -29,6 +29,7 @@ import { PrConversationBlock } from "./pr-review/PrConversationBlock";
 import { GithubThreadView, OutdatedThreadsGroup, type ThreadSendState } from "./pr-review/GithubThreadView";
 import { buildThreadFixPrompt, groupGithubThreadsByFile, isLineRenderedInDiff, locateThread, partitionThreadsForDiff } from "./pr-review/mapping";
 import { MarkdownDocument } from "./pr-review/markdown";
+import { MarkdownRichDiff, useMarkdownDiffBlocks } from "./pr-review/markdown-diff";
 import { isTestFile } from "../../shared/test-files";
 import { useIncludeTestsInDiff } from "../utils/includeTestsInDiff";
 import "@git-diff-view/react/styles/diff-view-pure.css";
@@ -951,6 +952,12 @@ export function isMarkdownDiffFile(file: TaskDiffFile): boolean {
 	return /\.(md|markdown)$/i.test(path);
 }
 
+/** Only a two-sided change has something to colour: added/untracked files are
+ * all-new and deleted files all-gone, so those preview as a plain document. */
+export function isMarkdownRichDiffFile(file: TaskDiffFile): boolean {
+	return isMarkdownDiffFile(file) && file.status !== "added" && file.status !== "untracked" && file.status !== "deleted";
+}
+
 /** Preview renders what the change produced: the new content, or for deletions
  * the old content (the only side that exists). */
 export function getMarkdownPreviewSource(file: TaskDiffFile): string {
@@ -1436,6 +1443,10 @@ function TaskDiffFileSection({
 	const isMdFile = isMarkdownDiffFile(file);
 	const showMdPreview = isMdFile && mdPreview;
 	const mdPreviewSource = getMarkdownPreviewSource(file);
+	// Two-sided changes preview as a GitHub-style rich diff (added blocks green,
+	// removed blocks red); pure adds/deletes have nothing to compare against.
+	const mdRichDiffBlocks = useMarkdownDiffBlocks(file.oldContent, file.newContent);
+	const mdDiffBlocks = isMarkdownRichDiffFile(file) ? mdRichDiffBlocks : null;
 
 	// The built diff instance is the only honest source of "is this line on
 	// screen" (the backend ships hunks: null — the library computes the diff
@@ -1616,7 +1627,9 @@ function TaskDiffFileSection({
 				showMdPreview ? (
 					<div className="px-4 py-4" data-testid="diff-md-preview">
 						{mdPreviewSource.trim()
-							? <MarkdownDocument body={mdPreviewSource} />
+							? mdDiffBlocks
+								? <MarkdownRichDiff blocks={mdDiffBlocks} />
+								: <MarkdownDocument body={mdPreviewSource} />
 							: <div className="text-sm text-fg-muted">{t("infoPanel.diffMdPreviewEmpty")}</div>}
 					</div>
 				) : buildError ? (
@@ -1749,8 +1762,9 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 	const [showLoadingState, setShowLoadingState] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [viewMode, setViewMode] = useState<DiffViewMode | null>(null);
-	// Per-file markdown source-diff ↔ rendered-preview switch. Ephemeral view
-	// state (like GitHub's rich-diff toggle): resets on viewer mount, never persisted.
+	// Per-file markdown source-diff ↔ rendered-preview switch, defaulting to
+	// preview (missing entry = on). Ephemeral view state (like GitHub's rich-diff
+	// toggle): resets on viewer mount, never persisted.
 	const [mdPreviewFiles, setMdPreviewFiles] = useState<Record<string, boolean>>({});
 	// Lazy-initialize from localStorage so the first persist-effect fire (when
 	// payload arrives) sees the stored review rather than `{}` — otherwise the
@@ -2618,7 +2632,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		// A content hit only exists in the source diff DOM — a file left in
 		// markdown preview mode flips back so the hit can be decorated and scrolled to.
 		if (match.kind === "content") {
-			setMdPreviewFiles((current) => (current[match.fileId] ? { ...current, [match.fileId]: false } : current));
+			setMdPreviewFiles((current) => ((current[match.fileId] ?? true) ? { ...current, [match.fileId]: false } : current));
 		}
 		scrollToFile(match.fileId, {
 			expand: true,
@@ -3785,10 +3799,10 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 								onDeleteComment={deleteInlineComment}
 								onToggleExpanded={() => toggleFileExpanded(file.id)}
 								onToggleRead={() => toggleFileRead(file.id)}
-								mdPreview={mdPreviewFiles[file.id] ?? false}
+								mdPreview={mdPreviewFiles[file.id] ?? true}
 								onToggleMdPreview={() => setMdPreviewFiles((current) => ({
 									...current,
-									[file.id]: !(current[file.id] ?? false),
+									[file.id]: !(current[file.id] ?? true),
 								}))}
 								registerCommentRef={registerCommentRef}
 								sectionRef={(element) => {

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -3422,39 +3422,57 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 			expect(toggles[0]).toHaveAccessibleName("Toggle Markdown preview for zzz/readme.md");
 		});
 
-		it("switches a markdown file between source diff and rendered preview", async () => {
+		it("opens markdown files in preview mode and toggles back to the source diff", async () => {
 			const user = userEvent.setup();
 			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({}));
 			renderViewer();
 
-			await screen.findAllByTestId("mock-diff");
-			const toggle = screen.getByRole("button", { name: /toggle markdown preview for docs\/guide\.md/i });
-			expect(toggle).toHaveAttribute("aria-pressed", "false");
-
-			await user.click(toggle);
-
 			const preview = await screen.findByTestId("diff-md-preview");
-			const document_ = within(preview).getByTestId("markdown-document");
-			expect(document_.querySelector("h1")?.textContent).toBe("Title");
-			expect(document_.querySelector("strong")?.textContent).toBe("bold");
+			const toggle = screen.getByRole("button", { name: /toggle markdown preview for docs\/guide\.md/i });
 			expect(toggle).toHaveAttribute("aria-pressed", "true");
+			expect(preview.textContent).toContain("Title");
+			expect(preview.querySelector("strong")?.textContent).toBe("bold");
 			expect(screen.queryByTestId("mock-diff")).toBeNull();
 
 			await user.click(toggle);
 
 			await screen.findAllByTestId("mock-diff");
 			expect(screen.queryByTestId("diff-md-preview")).toBeNull();
+			expect(toggle).toHaveAttribute("aria-pressed", "false");
+		});
+
+		it("marks added and removed blocks in the preview of a modified markdown file", async () => {
+			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({}));
+			renderViewer();
+
+			const preview = await screen.findByTestId("diff-md-preview");
+			const richDiff = within(preview).getByTestId("markdown-rich-diff");
+			const removed = richDiff.querySelectorAll("[data-diff-kind='removed']");
+			const added = richDiff.querySelectorAll("[data-diff-kind='added']");
+			expect(removed).toHaveLength(1);
+			expect(removed[0].textContent).toContain("Old");
+			expect(Array.from(added).map((block) => block.textContent).join(" ")).toContain("Title");
+			expect(within(preview).queryByTestId("markdown-document")).toBeNull();
+		});
+
+		it("previews an added markdown file as a plain document", async () => {
+			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
+				status: "added",
+				oldContent: "",
+				oldPath: null,
+			}));
+			renderViewer();
+
+			const preview = await screen.findByTestId("diff-md-preview");
+			expect(within(preview).getByTestId("markdown-document").querySelector("h1")?.textContent).toBe("Title");
+			expect(within(preview).queryByTestId("markdown-rich-diff")).toBeNull();
 		});
 
 		it("sanitizes markup embedded in the previewed markdown", async () => {
-			const user = userEvent.setup();
 			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
 				newContent: "safe <script>alert(1)</script> <img src=\"x\" onerror=\"alert(2)\">\n",
 			}));
 			renderViewer();
-
-			await screen.findAllByTestId("mock-diff");
-			await user.click(screen.getByRole("button", { name: /toggle markdown preview/i }));
 
 			const preview = await screen.findByTestId("diff-md-preview");
 			expect(preview.querySelector("script")).toBeNull();
@@ -3463,7 +3481,6 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 		});
 
 		it("previews the removed content for deleted markdown files", async () => {
-			const user = userEvent.setup();
 			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
 				status: "deleted",
 				oldContent: "# Gone\n",
@@ -3472,15 +3489,11 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 			}));
 			renderViewer();
 
-			await screen.findAllByTestId("mock-diff");
-			await user.click(screen.getByRole("button", { name: /toggle markdown preview/i }));
-
 			const preview = await screen.findByTestId("diff-md-preview");
 			expect(within(preview).getByTestId("markdown-document").querySelector("h1")?.textContent).toBe("Gone");
 		});
 
 		it("shows a placeholder when previewing an empty markdown file", async () => {
-			const user = userEvent.setup();
 			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
 				status: "added",
 				oldContent: "",
@@ -3489,8 +3502,6 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 				hunks: null,
 			}));
 			renderViewer();
-
-			await user.click(await screen.findByRole("button", { name: /toggle markdown preview/i }));
 
 			const preview = await screen.findByTestId("diff-md-preview");
 			expect(preview.textContent).toContain("Nothing to preview");
@@ -3505,8 +3516,6 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 			}));
 			renderViewer();
 
-			await screen.findAllByTestId("mock-diff");
-			await user.click(screen.getByRole("button", { name: /toggle markdown preview/i }));
 			await screen.findByTestId("diff-md-preview");
 
 			await user.keyboard("{Meta>}f{/Meta}");

--- a/src/mainview/components/pr-review/__tests__/markdown-diff.test.tsx
+++ b/src/mainview/components/pr-review/__tests__/markdown-diff.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { buildMarkdownDiffBlocks, MarkdownRichDiff } from "../markdown-diff";
+
+describe("buildMarkdownDiffBlocks", () => {
+	it("returns null when both sides render the same document", () => {
+		expect(buildMarkdownDiffBlocks("# Same\n\ntext\n", "# Same\n\ntext\n")).toBeNull();
+	});
+
+	it("ignores blank-line-only churn", () => {
+		expect(buildMarkdownDiffBlocks("# Same\n\ntext\n", "# Same\n\n\n\ntext\n\n")).toBeNull();
+	});
+
+	it("marks a replaced paragraph as removed then added", () => {
+		const blocks = buildMarkdownDiffBlocks("# Title\n\nold text\n", "# Title\n\nnew text\n");
+		expect(blocks?.map((block) => block.kind)).toEqual(["context", "removed", "added"]);
+		expect(blocks?.[0].html).toContain("<h1>Title</h1>");
+		expect(blocks?.[1].html).toContain("old text");
+		expect(blocks?.[2].html).toContain("new text");
+	});
+
+	it("scopes a list change to the changed item", () => {
+		const blocks = buildMarkdownDiffBlocks("- one\n- two\n", "- one\n- inserted\n- two\n");
+		expect(blocks?.filter((block) => block.kind !== "context")).toHaveLength(1);
+		const added = blocks?.find((block) => block.kind === "added");
+		expect(added?.html).toContain("inserted");
+		expect(added?.html).not.toContain("one");
+	});
+
+	it("keeps consecutive unchanged list items in one list", () => {
+		const blocks = buildMarkdownDiffBlocks("- one\n- two\n\npara\n", "- one\n- two\n\nother\n");
+		const context = blocks?.find((block) => block.kind === "context");
+		expect(context?.html.match(/<ul>/g)).toHaveLength(1);
+		expect(context?.html).toContain("<li>one</li>");
+		expect(context?.html).toContain("<li>two</li>");
+	});
+
+	it("keeps the numbering of an ordered list item", () => {
+		const blocks = buildMarkdownDiffBlocks("1. first\n2. second\n", "1. first\n2. changed\n");
+		expect(blocks?.find((block) => block.kind === "added")?.html).toContain("<ol start=\"2\">");
+	});
+
+	it("sanitizes markup on both sides", () => {
+		const blocks = buildMarkdownDiffBlocks(
+			"<script>alert(1)</script>gone\n",
+			"<img src=\"x\" onerror=\"alert(2)\">stays\n",
+		);
+		const html = blocks?.map((block) => block.html).join("");
+		expect(html).not.toContain("<script>");
+		expect(html).not.toContain("onerror");
+	});
+});
+
+describe("MarkdownRichDiff", () => {
+	it("tags every block with its change kind", () => {
+		const blocks = buildMarkdownDiffBlocks("old\n", "new\n") ?? [];
+		render(<MarkdownRichDiff blocks={blocks} />);
+
+		const host = screen.getByTestId("markdown-rich-diff");
+		expect(host.querySelector("[data-diff-kind='removed']")?.textContent).toContain("old");
+		expect(host.querySelector("[data-diff-kind='added']")?.textContent).toContain("new");
+	});
+});

--- a/src/mainview/components/pr-review/markdown-diff.tsx
+++ b/src/mainview/components/pr-review/markdown-diff.tsx
@@ -1,0 +1,139 @@
+import { useMemo } from "react";
+import { marked } from "marked";
+import { renderMarkdownDocument } from "./markdown";
+
+export type MarkdownDiffKind = "context" | "added" | "removed";
+
+export type MarkdownDiffBlock = { kind: MarkdownDiffKind; html: string };
+
+/** One diffable unit of a markdown document: a top-level block, or a single
+ * item of a list (so adding one bullet does not repaint the whole list). */
+type Chunk = { raw: string; listItem: boolean };
+
+// LCS is O(old × new); a pathological pair of huge documents would freeze the
+// webview, so past this many cells the renderer falls back to a plain preview.
+const MAX_LCS_CELLS = 4_000_000;
+
+function chunkMarkdown(source: string): Chunk[] {
+	const chunks: Chunk[] = [];
+	for (const token of marked.lexer(source, { gfm: true })) {
+		if (token.type === "space") {
+			continue;
+		}
+		const items = token.type === "list" ? (token as { items?: { raw: string }[] }).items : undefined;
+		if (items?.length) {
+			for (const item of items) {
+				chunks.push({ raw: item.raw.replace(/\n+$/, ""), listItem: true });
+			}
+			continue;
+		}
+		const raw = token.raw.replace(/\n+$/, "");
+		if (raw.trim()) {
+			chunks.push({ raw, listItem: false });
+		}
+	}
+	return chunks;
+}
+
+/** Longest common subsequence of chunk indices, matching on exact raw text. */
+function lcsMatrix(a: Chunk[], b: Chunk[]): Uint32Array {
+	const width = b.length + 1;
+	const table = new Uint32Array((a.length + 1) * width);
+	for (let i = a.length - 1; i >= 0; i--) {
+		for (let j = b.length - 1; j >= 0; j--) {
+			table[i * width + j] = a[i].raw === b[j].raw
+				? table[(i + 1) * width + j + 1] + 1
+				: Math.max(table[(i + 1) * width + j], table[i * width + j + 1]);
+		}
+	}
+	return table;
+}
+
+type Op = { kind: MarkdownDiffKind; chunk: Chunk };
+
+function diffChunks(oldChunks: Chunk[], newChunks: Chunk[]): Op[] {
+	const table = lcsMatrix(oldChunks, newChunks);
+	const width = newChunks.length + 1;
+	const ops: Op[] = [];
+	let i = 0;
+	let j = 0;
+	while (i < oldChunks.length && j < newChunks.length) {
+		if (oldChunks[i].raw === newChunks[j].raw) {
+			ops.push({ kind: "context", chunk: newChunks[j] });
+			i++;
+			j++;
+		} else if (table[(i + 1) * width + j] >= table[i * width + j + 1]) {
+			ops.push({ kind: "removed", chunk: oldChunks[i] });
+			i++;
+		} else {
+			ops.push({ kind: "added", chunk: newChunks[j] });
+			j++;
+		}
+	}
+	for (; i < oldChunks.length; i++) {
+		ops.push({ kind: "removed", chunk: oldChunks[i] });
+	}
+	for (; j < newChunks.length; j++) {
+		ops.push({ kind: "added", chunk: newChunks[j] });
+	}
+	return ops;
+}
+
+/** Consecutive same-kind chunks render as one markdown fragment so runs of list
+ * items stay a single list instead of a stack of one-item lists. */
+function groupOps(ops: Op[]): { kind: MarkdownDiffKind; source: string }[] {
+	const groups: { kind: MarkdownDiffKind; chunks: Chunk[] }[] = [];
+	for (const op of ops) {
+		const last = groups[groups.length - 1];
+		if (last && last.kind === op.kind && last.chunks[0].listItem === op.chunk.listItem) {
+			last.chunks.push(op.chunk);
+		} else {
+			groups.push({ kind: op.kind, chunks: [op.chunk] });
+		}
+	}
+	return groups.map(({ kind, chunks }) => ({
+		kind,
+		source: chunks.map((chunk) => chunk.raw).join(chunks[0].listItem ? "\n" : "\n\n"),
+	}));
+}
+
+/**
+ * GitHub-style rich diff of a markdown document: rendered markdown where each
+ * block is tagged as unchanged, added, or removed. Returns null when the diff
+ * is not worth rendering (identical sides, or documents too large to diff).
+ */
+export function buildMarkdownDiffBlocks(oldSource: string, newSource: string): MarkdownDiffBlock[] | null {
+	const oldChunks = chunkMarkdown(oldSource);
+	const newChunks = chunkMarkdown(newSource);
+	if ((oldChunks.length + 1) * (newChunks.length + 1) > MAX_LCS_CELLS) {
+		return null;
+	}
+	const ops = diffChunks(oldChunks, newChunks);
+	if (!ops.some((op) => op.kind !== "context")) {
+		return null;
+	}
+	return groupOps(ops).map(({ kind, source }) => ({ kind, html: renderMarkdownDocument(source) }));
+}
+
+export function MarkdownRichDiff({ blocks }: { blocks: MarkdownDiffBlock[] }) {
+	return (
+		<div
+			className="dev3-pr-md dev3-md-doc dev3-md-diff min-w-0 text-sm leading-relaxed text-fg"
+			data-testid="markdown-rich-diff"
+		>
+			{blocks.map((block, index) => (
+				<div
+					key={index}
+					className={`dev3-md-diff-block dev3-md-diff-${block.kind}`}
+					data-diff-kind={block.kind}
+					// eslint-disable-next-line react/no-danger -- sanitized in renderMarkdownDocument
+					dangerouslySetInnerHTML={{ __html: block.html }}
+				/>
+			))}
+		</div>
+	);
+}
+
+export function useMarkdownDiffBlocks(oldSource: string, newSource: string): MarkdownDiffBlock[] | null {
+	return useMemo(() => buildMarkdownDiffBlocks(oldSource, newSource), [oldSource, newSource]);
+}

--- a/src/mainview/components/pr-review/markdown.tsx
+++ b/src/mainview/components/pr-review/markdown.tsx
@@ -15,6 +15,8 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
 		img: ["src", "alt", "title", "width", "height"],
 		// GFM task lists render as checkbox inputs; keep them visual-only.
 		input: ["type", "checked", "disabled"],
+		// A rich-diff fragment can start mid-list, so numbering must survive.
+		ol: ["start"],
 		td: ["align"],
 		th: ["align"],
 	},


### PR DESCRIPTION
Markdown files in the diff viewer now open in rendered preview mode by default, and a modified file's preview shows what changed GitHub rich-diff style: added blocks sit on a green wash with a green rail, removed blocks on a red one. The per-file **Preview** toggle still switches back to the raw source diff.

**How the diff is built** (`src/mainview/components/pr-review/markdown-diff.tsx`): both sides are lexed with `marked` into top-level blocks — lists expanded to individual items, so editing one bullet colours only that bullet — matched with LCS, and consecutive same-kind blocks are re-joined before rendering so runs of list items stay a single `<ul>`/`<ol>`. Every fragment goes through the existing `renderMarkdownDocument` sanitize pipeline; `ol[start]` was added to the allowlist so a fragment starting mid-list keeps its numbering.

Rich diff applies only to two-sided changes (`modified`/`renamed`/`copied`); added and deleted markdown files preview as plain documents, since painting a whole file one colour carries no information. Colours come from the `--success`/`--danger` design tokens, so both themes are covered.