### PR TITLE
Fix live diff-tree artifact refresh

### DIFF
--- a/change-logs/2026/07/25/fix-diff-tree-artifact-refresh.md
+++ b/change-logs/2026/07/25/fix-diff-tree-artifact-refresh.md
@@ -1,0 +1,1 @@
+Keep the open HTML artifact workspace in sync when an agent shares a new artifact, selecting the newest item and refreshing the history counter even when the app window is not focused.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1270,6 +1270,8 @@ function App() {
 	// re-subscribing it every time the viewer opens/closes.
 	const imageViewerRef = useRef(imageViewer);
 	imageViewerRef.current = imageViewer;
+	const artifactViewerRef = useRef(artifactViewer);
+	artifactViewerRef.current = artifactViewer;
 
 	// CLI-shared images (`dev3 show-image`). Always raise the attention badge; auto-open
 	// the lightbox ONLY when the user is already looking at this task (never steal focus).
@@ -1350,7 +1352,8 @@ function App() {
 				(state.route.screen === "task" && state.route.taskId === taskId) ||
 				(state.route.screen === "project" && state.route.activeTaskId === taskId);
 			const foreground = typeof document === "undefined" || (document.visibilityState === "visible" && document.hasFocus());
-			if (viewingThisTask && foreground) {
+			const alreadyOpenForTask = artifactViewerRef.current?.taskId === taskId;
+			if (alreadyOpenForTask || (viewingThisTask && foreground)) {
 				setArtifactViewer({ taskId, artifacts, index: artifacts.length - 1 });
 				return;
 			}

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -113,6 +113,7 @@ vi.mock("../components/ProjectView", () => ({
 		activeTaskId?: string;
 		taskView?: boolean;
 		bellCounts?: Map<string, number>;
+		artifactViewer?: { artifacts: Array<{ title?: string }>; index: number } | null;
 	}) => (
 		<div
 			data-testid="project-screen"
@@ -120,6 +121,9 @@ vi.mock("../components/ProjectView", () => ({
 			data-active-task-id={props.activeTaskId ?? ""}
 			data-task-view={props.taskView ? "true" : "false"}
 			data-bell-count={String(props.bellCounts?.get("t-overflow") ?? 0)}
+			data-artifact-count={String(props.artifactViewer?.artifacts.length ?? 0)}
+			data-artifact-index={String(props.artifactViewer?.index ?? -1)}
+			data-artifact-title={props.artifactViewer?.artifacts[props.artifactViewer.index]?.title ?? ""}
 		/>
 	),
 }));
@@ -880,6 +884,58 @@ describe("App keyboard shortcuts", () => {
 
 			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
 			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+		});
+	});
+
+	describe("CLI shared-artifact updates", () => {
+		const oneProject = [
+			{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+		];
+		const artifact = (id: string) => ({
+			id,
+			kind: "html",
+			title: `Artifact ${id}`,
+			name: `${id}.html`,
+			storedPath: `/a/shared-artifacts/${id}/${id}.html`,
+			bytes: 1,
+			createdAt: 0,
+		});
+
+		it("replaces an open viewer with the latest artifact even when the window loses focus", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t-artifact" }),
+			});
+
+			await renderApp();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("dev3:openArtifactViewer", {
+					detail: { taskId: "t-artifact", artifacts: [artifact("a"), artifact("b")], index: 1 },
+				}));
+			});
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-artifact-title", "Artifact b"));
+
+			const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+			try {
+				act(() => {
+					window.dispatchEvent(new CustomEvent("rpc:cliShowArtifact", {
+						detail: {
+							taskId: "t-artifact",
+							projectId: "p1",
+							artifacts: [artifact("a"), artifact("b"), artifact("c")],
+							newCount: 1,
+						},
+					}));
+				});
+
+				await waitFor(() => {
+					expect(screen.getByTestId("project-screen")).toHaveAttribute("data-artifact-count", "3");
+					expect(screen.getByTestId("project-screen")).toHaveAttribute("data-artifact-index", "2");
+					expect(screen.getByTestId("project-screen")).toHaveAttribute("data-artifact-title", "Artifact c");
+				});
+			} finally {
+				hasFocus.mockRestore();
+			}
 		});
 	});
 

--- a/src/mainview/components/TaskArtifactViewer.tsx
+++ b/src/mainview/components/TaskArtifactViewer.tsx
@@ -83,8 +83,8 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, onClose, t
 	const current = artifacts[index];
 
 	useEffect(() => {
-		setIndex((value) => Math.max(0, Math.min(artifacts.length - 1, value)));
-	}, [artifacts.length]);
+		setIndex(Math.max(0, Math.min(artifacts.length - 1, initialIndex)));
+	}, [artifacts.length, initialIndex]);
 
 	useEffect(() => {
 		if (!current) return;

--- a/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
@@ -46,6 +46,21 @@ describe("TaskArtifactViewer", () => {
 		await waitFor(() => expect(frame.getAttribute("srcdoc")).toContain("data:image/png;base64,AAA"));
 	});
 
+	it("opens the latest artifact when the list updates while the viewer is open", async () => {
+		const { rerender } = render(
+			<I18nProvider><TaskArtifactViewer artifacts={[artifact("a"), artifact("b")]} initialIndex={1} onClose={vi.fn()} /></I18nProvider>,
+		);
+
+		rerender(
+			<I18nProvider><TaskArtifactViewer artifacts={[artifact("a"), artifact("b"), artifact("c")]} initialIndex={2} onClose={vi.fn()} /></I18nProvider>,
+		);
+
+		expect(screen.getByText("Artifact c")).toBeInTheDocument();
+		expect(screen.getByText("3 / 3")).toBeInTheDocument();
+		const frame = await screen.findByTitle("Artifact c");
+		expect(frame).toBeInTheDocument();
+	});
+
 	it("toggles fullscreen and closes", async () => {
 		const onClose = vi.fn();
 		render(<I18nProvider><TaskArtifactViewer artifacts={[artifact("a")]} initialIndex={0} onClose={onClose} /></I18nProvider>);


### PR DESCRIPTION
## Summary

- Keep an open HTML/diff-tree artifact viewer synchronized when an agent shares another artifact.
- Switch the viewer to the newest artifact and refresh the history counter immediately.
- Apply the live refresh even when the app window is not focused.

## Root cause

The CLI push handler only replaced the viewer state when the task was both visible and foregrounded, while `TaskArtifactViewer` retained its stale local index after the artifact list changed. Together, those snapshots left an open viewer on the previous artifact with an outdated position.

## Impact

Users reviewing agent-generated diff trees now see each newly shared artifact immediately, without closing or reopening the artifact workspace.

## Validation

- `bunx vitest run src/mainview/components/__tests__/TaskArtifactViewer.test.tsx src/mainview/__tests__/App.test.tsx` — 111 tests passed
- `bun run lint` — TypeScript passed
- `bun run build` — passed
- Browser end-to-end smoke test confirmed the open viewer selected the newest artifact and updated the counter to `3 / 3` while unfocused
