### PR TITLE
Fix Kanban labels to follow project order

### DIFF
--- a/change-logs/2026/07/25/fix-kanban-label-project-order.md
+++ b/change-logs/2026/07/25/fix-kanban-label-project-order.md
@@ -1,0 +1,1 @@
+Kanban label filter chips now follow the label order configured in Project Settings instead of being reordered by task usage. This keeps the board consistent with the user's project-wide label arrangement.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -413,14 +413,6 @@ function KanbanBoard({
 		[tasks, resolver, priorityCandidates, statusCandidates, t],
 	);
 
-	// Labels shown inline are ordered by popularity (how many tasks use each), so
-	// the funnel/"+N more" hides the least-used first.
-	const popularLabels = useMemo(() => {
-		const count = new Map<string, number>();
-		for (const task of tasks) for (const id of task.labelIds ?? []) count.set(id, (count.get(id) ?? 0) + 1);
-		return [...projectLabels].sort((a, b) => (count.get(b.id) ?? 0) - (count.get(a.id) ?? 0));
-	}, [tasks, projectLabels]);
-
 	async function handleRenameBuiltinColumn(status: TaskStatus, name: string | null) {
 		try {
 			const updated = await api.request.renameBuiltinColumn({ projectId: project.id, status, name });
@@ -706,7 +698,7 @@ function KanbanBoard({
 	return (
 		<>
 			<LabelFilterBar
-				labels={popularLabels}
+				labels={projectLabels}
 				searchQuery={searchQuery}
 				onSearchChange={setSearchQuery}
 				filterGroups={filterGroups}

--- a/src/mainview/components/LabelFilterBar.tsx
+++ b/src/mainview/components/LabelFilterBar.tsx
@@ -10,11 +10,11 @@ import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { PRIORITY_NAME_KEYS, PRIORITY_STYLES } from "./priorityStyles";
 
-/** How many (most-popular) label chips to show inline before the "+N more". */
+/** How many label chips to show inline before the "+N more". */
 const MAX_INLINE_LABELS = 10;
 
 interface LabelFilterBarProps {
-	/** Project labels, pre-sorted by popularity (most-used first). */
+	/** Project labels in the order configured in Project Settings. */
 	labels: Label[];
 	searchQuery: string;
 	onSearchChange: (query: string) => void;
@@ -91,8 +91,8 @@ function LabelFilterBar({
 	}, [disableGlobalFindShortcut]);
 
 	const hasLabels = labels.length > 0;
-	// Only the most-popular labels show inline; the rest live in the funnel,
-	// reachable via the "+N more" chip (labels used to clip off the right edge).
+	// Only the first labels in the project settings order show inline; the rest
+	// live in the funnel, reachable via the "+N more" chip.
 	const shownLabels = labels.slice(0, MAX_INLINE_LABELS);
 	const hiddenLabelCount = labels.length - shownLabels.length;
 
@@ -213,8 +213,8 @@ function LabelFilterBar({
 				<PriorityFilterChips query={searchQuery} onChange={onSearchChange} />
 			</div>
 
-			{/* Labels — the most-popular ones inline (wrapping to ~1.5 rows), the rest
-			    behind "+N more" which opens the funnel's full label list. */}
+			{/* Labels — the project-configured order inline (wrapping to ~1.5 rows),
+			    the rest behind "+N more" which opens the funnel's full label list. */}
 			{hasLabels && (
 				<div className="flex items-center gap-1.5 flex-wrap min-w-0">
 					<span className="flex items-center gap-1 text-xs text-fg-3 font-medium flex-shrink-0">

--- a/src/mainview/components/__tests__/KanbanBoard.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoard.test.tsx
@@ -401,6 +401,34 @@ describe("column ordering", () => {
 	});
 });
 
+describe("label filter ordering", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.clear();
+	});
+
+	it("keeps the project settings order instead of sorting by task usage", async () => {
+		const labels = [
+			{ id: "feature", name: "Feature", color: "#22c55e" },
+			{ id: "bug", name: "Bug", color: "#ef4444" },
+		];
+		const tasks = [
+			makeTask({ id: "bug-1", labelIds: ["bug"] }),
+			makeTask({ id: "bug-2", labelIds: ["bug"] }),
+		];
+
+		await renderBoardWith({ project: { ...project, labels }, tasks });
+
+		const helpButton = screen.getAllByRole("button", { name: "About this section" })[1];
+		const labelGroup = helpButton.parentElement?.parentElement;
+		expect(labelGroup).not.toBeNull();
+		const chipOrder = Array.from(labelGroup!.querySelectorAll("button[title]"))
+			.map((button) => button.getAttribute("title"));
+
+		expect(chipOrder).toEqual(["Feature", "Bug"]);
+	});
+});
+
 describe("tip rotation", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();


### PR DESCRIPTION
## Summary

- Make Kanban label filter chips use the order persisted in Project Settings.
- Remove task-usage popularity sorting so the board matches other label surfaces.
- Add a regression test where a less-used label stays first.

## Why

Project Settings lets users reorder labels. The Kanban toolbar should preserve that explicit project order instead of moving labels based on task counts.

## Validation

- `bun run lint`
- `bun run test`
- Focused Kanban, label-filter, and facet tests
- Manual remote-browser QA against Project Settings → Board → Labels and the Kanban board