### PR TITLE
Add backend-neutral terminal process and port ownership accounting

### DIFF
--- a/change-logs/2026/07/25/feature-90-terminal-process-ownership.md
+++ b/change-logs/2026/07/25/feature-90-terminal-process-ownership.md
@@ -1,0 +1,3 @@
+Short: Ownership accounting for native terminals
+
+Added a backend-neutral process/port ownership seam so a terminal session's CPU, memory, and listening ports can be accounted for on both tmux and native backends. Ownership must be proved (tmux pane PIDs, or the native session record verified against process identity); a stale or reused PID is reported explicitly and never counted, and the snapshot reuses the existing `ps`/`lsof` scanners rather than adding a second monitor.

--- a/decisions/171-terminal-process-ownership-accounting.md
+++ b/decisions/171-terminal-process-ownership-accounting.md
@@ -1,0 +1,64 @@
+# 171 — Backend-neutral terminal process/port ownership accounting
+
+## Context
+
+Resource and listening-port accounting (`resource-monitor.ts`, `port-scanner.ts`)
+is written against tmux pane PIDs. A native terminal session would therefore be
+invisible to it — no CPU/RSS, no ports — which is a safety and observability gap
+that must close before native becomes a normal backend (seq 1293, tmux-removal
+roadmap). This slice adds the accounting seam only: read-only, no launch path, no
+UI/RPC, no poller rewiring.
+
+## Decision
+
+`src/bun/terminal-process-ownership/` — a claim → snapshot seam:
+
+* `contract.ts` — pure vocabulary. A backend produces a `TerminalOwnershipClaim`:
+  proved roots plus a **proof**. No proof means an explicit `unavailable` /
+  `stale` / `reused` snapshot with a reason; ownership is never inferred from a
+  task id or a bare PID, and a verified-but-root-less claim degrades to
+  `unavailable` rather than reading as "this session is free".
+* `collector.ts` — the adapter over the **existing** scanners
+  (`collectProcessInfo`, `collectDescendants`, `aggregateResources`,
+  `getLsofOutput` + `parseLsofOutput`). No second monitoring subsystem; this
+  module only decides which PIDs those scanners may attribute. An unproved claim
+  runs no scanner at all.
+* `tmux-source.ts` — the only file here that speaks tmux, via the existing
+  pane-PID helpers over the typed client singleton.
+* `native-source.ts` — translates the persisted native session record + its
+  ownership verdict (POSIX start signature / Windows Job membership).
+
+Two non-obvious choices:
+
+1. **The native source imports nothing from the native session store.** That
+   module's isolation test forbids any outside reference to it, so this file
+   declares plain input types that are *structurally* compatible with its public
+   read APIs — the same "standalone by contract" pattern as
+   `native-terminal-diagnostics`. The caller passes the record and verdict
+   through; the seam stays out of the store's import graph.
+2. **`coverage` flags instead of an implied zero.** `ps` / `lsof` do not exist on
+   Windows, where Job membership proves identity but cannot enumerate a tree. The
+   snapshot then reports `descendants/resources/ports: false` — "not measured" —
+   while ownership still verifies. Flattening that to an empty result would read
+   as a free session.
+
+## Risks
+
+* Structural compatibility with the record/verdict shapes is not type-checked
+  (it cannot be, given the isolation rule). A future rename inside the store
+  would only surface when the caller is wired up in the launch slice.
+* Windows keeps no descendant/port accounting until a Windows process
+  enumeration primitive exists. That is explicit in the snapshot, not silent.
+
+## Alternatives considered
+
+* **Extend the tmux pollers with native branches.** Rejected: it would couple
+  accounting to the launch path and put two backends' assumptions into one
+  poller, which is what this seam exists to avoid.
+* **Import the session store directly from the native source.** Rejected: breaks
+  its isolation guard and drags the whole store into the product import graph
+  before the launch slice (seq 1292) is ready.
+* **Real-process coverage as a vitest test.** Not possible: `src/bun`'s vitest
+  setup stubs `Bun.spawn`, so a piped child never resolves. The real-scanner proof
+  runs under bun as `__tests__/ownership.bun-e2e.ts`
+  (`bun run test:ownership-e2e`), matching the existing `*.bun-e2e.ts` pattern.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"test:native-host-image": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/host-images/__tests__/artifact-manifest.test.ts src/bun/native-terminal-registry/host-images/__tests__/artifact-manifest-cli.test.ts src/bun/native-terminal-registry/host-images/__tests__/packaged-image-manifest.test.ts src/bun/native-terminal-registry/host-images/__tests__/packaged-image.test.ts",
 		"package:win-archive": "bun scripts/generate-build-info.ts && bun scripts/generate-changelog.ts && vite build && bun run build:cli && electrobun build --env=canary",
 		"test:native-parity-e2e": "bun src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts",
+		"test:ownership-e2e": "bun src/bun/terminal-process-ownership/__tests__/ownership.bun-e2e.ts",
 		"test:terminal-state-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/terminal-state/__tests__",
 		"benchmark:terminal-state-spike": "bun src/bun/prototypes/terminal-state/benchmark.ts",
 		"test:stream-resync-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/stream-resync/__tests__",

--- a/src/bun/terminal-process-ownership/README.md
+++ b/src/bun/terminal-process-ownership/README.md
@@ -1,0 +1,60 @@
+# Terminal process & port ownership (seq 1293)
+
+One backend-neutral answer to *"which processes does this terminal session own,
+how much do they cost, and which ports do they listen on?"* — for tmux sessions
+and native sessions alike.
+
+This is the safety/observability gate that must exist **before** the native
+backend becomes a normal product backend: today's resource and port accounting is
+written against tmux pane PIDs, so a native session would simply be invisible to
+it.
+
+## Shape
+
+```
+claim (per backend)                 →   snapshot (backend-neutral)
+────────────────────────────────────    ─────────────────────────────────────
+tmux-source.ts   pane PIDs from the      collector.ts  roots + descendants,
+                 live tmux server                      aggregated cost,
+native-source.ts host/shell PIDs from                  listening ports,
+                 the session record                    measured coverage
+                 + ownership verdict
+```
+
+* `contract.ts` — pure vocabulary: `TerminalOwnershipClaim`, `TerminalOwnership`,
+  proof helpers. No spawns, no clock, no tmux, no registry.
+* `collector.ts` — the adapter over the app's **existing** scanners
+  (`collectProcessInfo` for the shared `ps` snapshot, `aggregateResources`,
+  `getLsofOutput` + `parseLsofOutput`). There is no second monitoring subsystem:
+  this module only decides *which* PIDs those scanners may attribute.
+* `tmux-source.ts` — the only file here that speaks tmux, via the existing
+  pane-PID helpers (typed tmux client singleton; no raw spawn, no `-F` format).
+* `native-source.ts` — translates the native session record + ownership verdict.
+  Standalone by contract: it declares plain input types instead of importing the
+  native session store, whose isolation test forbids outside references.
+
+## Ownership is proved, never assumed
+
+A claim carries a proof. Anything short of a proof becomes an explicit state with
+a reason, and **nothing** is attributed:
+
+| state         | when                                                            |
+| ------------- | --------------------------------------------------------------- |
+| `owned`       | tmux reported the pane, or the record's PIDs verified as `owned` |
+| `stale`       | the recorded host/shell process has exited (`dead` verdict)      |
+| `reused`      | a recorded PID is alive but is no longer our process             |
+| `unavailable` | no record, no verdict, foreign record, or no usable PID          |
+
+An unproved claim short-circuits `collectOwnershipSnapshot` — no `ps`, no `lsof`,
+and on the native path never a tmux call.
+
+`coverage` reports what could actually be measured. On Windows both scanners are
+absent (they shell out to `ps` / `lsof`), so `descendants`/`resources`/`ports` are
+`false` while ownership itself still verifies through Job Object membership — the
+snapshot says "not measured", never "nothing there".
+
+## Scope
+
+Read-only accounting. No launch/attach/resize/stop, no backend selection or
+fallback, no process signalling, no UI or RPC, and no changes to the existing
+tmux pollers — this task owns the adapter and its tests only.

--- a/src/bun/terminal-process-ownership/__tests__/collector.test.ts
+++ b/src/bun/terminal-process-ownership/__tests__/collector.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildOwnershipSnapshot,
+	collectOwnershipSnapshot,
+	type TerminalOwnershipEvidence,
+	type TerminalOwnershipScanners,
+} from "../collector";
+import { nativeOwnershipClaim } from "../native-source";
+import { verifiedClaim } from "../contract";
+import { tmuxOwnershipClaimFromPanePids } from "../tmux-source";
+
+/** shell 4101 → nested child 4200 → grandchild 4300 (the listener). */
+const tree = new Map<number, number[]>([
+	[4100, [4101]],
+	[4101, [4200]],
+	[4200, [4300]],
+	// An unrelated process tree that must never be attributed.
+	[9000, [9001]],
+]);
+
+const resources = new Map<number, { rss: number; cpu: number }>([
+	[4100, { rss: 1_000, cpu: 1 }],
+	[4101, { rss: 2_000, cpu: 2 }],
+	[4200, { rss: 4_000, cpu: 4 }],
+	[4300, { rss: 8_000, cpu: 8 }],
+	[9001, { rss: 999_000, cpu: 99 }],
+]);
+
+/** `lsof -F pcn`: the owned grandchild plus an unrelated sentinel listener. */
+const lsofOutput = ["p4300", "cbun", "n127.0.0.1:4321", "p9001", "csentinel", "n*:5999", ""].join("\n");
+
+const evidence: TerminalOwnershipEvidence = { tree, resources, lsofOutput };
+
+const ownedNative = nativeOwnershipClaim({
+	sessionId: "sess-1",
+	record: { sessionId: "sess-1", host: { pid: 4100 }, shell: { pid: 4101 } },
+	verdict: "owned",
+});
+
+const throwingScanners: TerminalOwnershipScanners = {
+	processInfo: async () => {
+		throw new Error("processInfo must not run for an unproved claim");
+	},
+	lsof: async () => {
+		throw new Error("lsof must not run for an unproved claim");
+	},
+};
+
+describe("ownership snapshot", () => {
+	it("attributes nested descendants and their listening ports", () => {
+		const snapshot = buildOwnershipSnapshot(ownedNative, evidence);
+		expect(snapshot.backend).toBe("native");
+		expect(snapshot.sessionId).toBe("sess-1");
+		if (snapshot.ownership.state !== "owned") throw new Error("expected owned ownership");
+		expect(snapshot.ownership.processes).toEqual([
+			{ pid: 4100, role: "host" },
+			{ pid: 4101, role: "shell" },
+			{ pid: 4200, role: "descendant" },
+			{ pid: 4300, role: "descendant" },
+		]);
+		expect(snapshot.ports).toEqual([{ port: 4321, pid: 4300, processName: "bun" }]);
+		expect(snapshot.resources).toEqual({ rss: 15_000, cpu: 15 });
+		expect(snapshot.coverage).toEqual({ descendants: true, resources: true, ports: true });
+	});
+
+	it("never attributes an unrelated process, its cost, or its port", () => {
+		const snapshot = buildOwnershipSnapshot(ownedNative, evidence);
+		if (snapshot.ownership.state !== "owned") throw new Error("expected owned ownership");
+		const pids = snapshot.ownership.processes.map((process) => process.pid);
+		expect(pids).not.toContain(9000);
+		expect(pids).not.toContain(9001);
+		expect(snapshot.ports.map((port) => port.port)).not.toContain(5999);
+		expect(snapshot.resources?.rss).toBeLessThan(999_000);
+	});
+
+	it("counts nothing for an exited (stale) session", () => {
+		const claim = nativeOwnershipClaim({
+			sessionId: "sess-1",
+			record: { sessionId: "sess-1", host: { pid: 4100 }, shell: { pid: 4101 } },
+			verdict: "dead",
+		});
+		const snapshot = buildOwnershipSnapshot(claim, evidence);
+		expect(snapshot.ownership).toEqual({
+			state: "stale",
+			reason: "the recorded native host or shell process has exited",
+		});
+		expect(snapshot.resources).toBeNull();
+		expect(snapshot.ports).toEqual([]);
+		expect(snapshot.coverage).toEqual({ descendants: false, resources: false, ports: false });
+	});
+
+	it("counts nothing for a reused PID even though the PID is alive and busy", () => {
+		const claim = nativeOwnershipClaim({
+			sessionId: "sess-1",
+			// 9001 is alive in the evidence and holds a port — but it is not ours.
+			record: { sessionId: "sess-1", host: { pid: 9000 }, shell: { pid: 9001 } },
+			verdict: "reused",
+		});
+		const snapshot = buildOwnershipSnapshot(claim, evidence);
+		expect(snapshot.ownership).toMatchObject({ state: "reused" });
+		expect(snapshot.resources).toBeNull();
+		expect(snapshot.ports).toEqual([]);
+	});
+
+	it("reports absent scanners as unmeasured coverage, not as an empty result", () => {
+		const snapshot = buildOwnershipSnapshot(ownedNative, { tree: null, resources: null, lsofOutput: null });
+		if (snapshot.ownership.state !== "owned") throw new Error("expected owned ownership");
+		expect(snapshot.ownership.processes.map((process) => process.pid)).toEqual([4100, 4101]);
+		expect(snapshot.resources).toBeNull();
+		expect(snapshot.ports).toEqual([]);
+		expect(snapshot.coverage).toEqual({ descendants: false, resources: false, ports: false });
+	});
+
+	it("keeps tmux pane roots and their descendants distinct per role", () => {
+		const snapshot = buildOwnershipSnapshot(tmuxOwnershipClaimFromPanePids("dev3-task-abc", [4101]), evidence);
+		if (snapshot.ownership.state !== "owned") throw new Error("expected owned ownership");
+		expect(snapshot.backend).toBe("tmux");
+		expect(snapshot.ownership.processes).toEqual([
+			{ pid: 4101, role: "pane" },
+			{ pid: 4200, role: "descendant" },
+			{ pid: 4300, role: "descendant" },
+		]);
+	});
+
+	it("does not list a shared PID twice when roots overlap", () => {
+		const snapshot = buildOwnershipSnapshot(verifiedClaim("tmux", "dev3-task-abc", [
+			{ pid: 4101, role: "pane" },
+			{ pid: 4200, role: "pane" },
+		]), evidence);
+		if (snapshot.ownership.state !== "owned") throw new Error("expected owned ownership");
+		expect(snapshot.ownership.processes.map((process) => process.pid)).toEqual([4101, 4200, 4300]);
+	});
+});
+
+describe("collectOwnershipSnapshot", () => {
+	it("runs no scanner at all for an unproved claim", async () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record: null });
+		const snapshot = await collectOwnershipSnapshot(claim, throwingScanners);
+		expect(snapshot.ownership).toMatchObject({ state: "unavailable" });
+		expect(snapshot.coverage).toEqual({ descendants: false, resources: false, ports: false });
+	});
+
+	it("pulls evidence from the injected scanners exactly once for a proved claim", async () => {
+		const processInfo = vi.fn(async () => ({ tree, resources }));
+		const lsof = vi.fn(async () => lsofOutput);
+		const snapshot = await collectOwnershipSnapshot(ownedNative, { processInfo, lsof });
+		expect(processInfo).toHaveBeenCalledTimes(1);
+		expect(lsof).toHaveBeenCalledTimes(1);
+		expect(snapshot.ports).toEqual([{ port: 4321, pid: 4300, processName: "bun" }]);
+	});
+
+	it("survives scanners that report nothing measurable", async () => {
+		const snapshot = await collectOwnershipSnapshot(ownedNative, {
+			processInfo: async () => null,
+			lsof: async () => null,
+		});
+		expect(snapshot.coverage).toEqual({ descendants: false, resources: false, ports: false });
+		expect(snapshot.ownership).toMatchObject({ state: "owned" });
+	});
+});

--- a/src/bun/terminal-process-ownership/__tests__/contract.test.ts
+++ b/src/bun/terminal-process-ownership/__tests__/contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isOwnablePid, unprovedClaim, verifiedClaim } from "../contract";
+
+describe("ownership claim construction", () => {
+	it("accepts only positive integer PIDs as ownable", () => {
+		expect(isOwnablePid(1)).toBe(true);
+		expect(isOwnablePid(0)).toBe(false);
+		expect(isOwnablePid(-5)).toBe(false);
+		expect(isOwnablePid(12.5)).toBe(false);
+		expect(isOwnablePid("300")).toBe(false);
+		expect(isOwnablePid(undefined)).toBe(false);
+	});
+
+	it("keeps proved roots, dropping duplicates and unusable PIDs", () => {
+		const claim = verifiedClaim("tmux", "dev3-task-abc", [
+			{ pid: 100, role: "pane" },
+			{ pid: 100, role: "pane" },
+			{ pid: 0, role: "pane" },
+			{ pid: 200, role: "pane" },
+		]);
+		expect(claim.proof.verified).toBe(true);
+		expect(claim.roots).toEqual([
+			{ pid: 100, role: "pane" },
+			{ pid: 200, role: "pane" },
+		]);
+	});
+
+	it("degrades a root-less verified claim to unavailable instead of empty-owned", () => {
+		const claim = verifiedClaim("native", "sess-1", [{ pid: -1, role: "host" }]);
+		expect(claim.proof).toEqual({
+			verified: false,
+			state: "unavailable",
+			reason: "no usable root process was proved for this session",
+		});
+		expect(claim.roots).toEqual([]);
+	});
+
+	it("carries the unproved state and reason verbatim", () => {
+		const claim = unprovedClaim("native", "sess-1", "reused", "pid 42 is not ours");
+		expect(claim).toEqual({
+			backend: "native",
+			sessionId: "sess-1",
+			roots: [],
+			proof: { verified: false, state: "reused", reason: "pid 42 is not ours" },
+		});
+	});
+});

--- a/src/bun/terminal-process-ownership/__tests__/isolation.test.ts
+++ b/src/bun/terminal-process-ownership/__tests__/isolation.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Isolation guards for the ownership accounting module (seq 1293):
+ *  - No production source imports it yet — this task builds the accounting seam,
+ *    not its rollout (no UI, no RPC, no poller rewiring).
+ *  - tmux stays confined to `tmux-source.ts`; the native path can never reach it.
+ *  - The module is read-only: nothing here signals or kills a process.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve(fileURLToPath(new URL("../../../", import.meta.url))); // repo/src
+const moduleRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+function sourceFiles(directory: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...sourceFiles(path));
+		else if (/\.(?:ts|tsx)$/.test(entry.name)) files.push(path);
+	}
+	return files;
+}
+
+const moduleFiles = sourceFiles(moduleRoot);
+const moduleFilesNoTests = moduleFiles.filter((path) => !path.includes("__tests__"));
+const relative = (path: string): string => path.slice(moduleRoot.length + 1);
+
+describe("terminal process ownership isolation", () => {
+	it("has no product callers (absent from the production import graph)", () => {
+		const importsModule = /(?:from|require\s*\()\s*['"][^'"]*terminal-process-ownership(?:\/[^'"]*)?['"]/;
+		const importers = sourceFiles(sourceRoot)
+			.filter((path) => !path.startsWith(moduleRoot))
+			.filter((path) => importsModule.test(readFileSync(path, "utf8")));
+		expect(importers).toEqual([]);
+	});
+
+	it("keeps tmux confined to the tmux source", () => {
+		// An import of the tmux MODULE (`../tmux`) — not this module's own files.
+		const usesTmux = /(?:from|require\s*\()\s*['"][^'"]*\/tmux(?:\/[^'"]*)?['"]/;
+		const offenders = moduleFilesNoTests.filter((path) => usesTmux.test(readFileSync(path, "utf8"))).map(relative);
+		expect(offenders).toEqual(["tmux-source.ts"]);
+	});
+
+	it("never lets the native path reach tmux", () => {
+		// Flag real usage — a tmux import path or a "tmux" command literal — not the
+		// word appearing in prose that documents the boundary.
+		const usesTmux = /(?:from|require\s*\()\s*['"][^'"]*tmux|['"`]tmux(?:\.exe|\.cmd)?['"`]/i;
+		expect(usesTmux.test(readFileSync(join(moduleRoot, "native-source.ts"), "utf8"))).toBe(false);
+	});
+
+	it("signals no process (read-only accounting)", () => {
+		const mutates = /process\.kill|SIGKILL|SIGTERM|killPane|killSession|terminateJob/;
+		const offenders = moduleFilesNoTests.filter((path) => mutates.test(readFileSync(path, "utf8"))).map(relative);
+		expect(offenders).toEqual([]);
+	});
+
+	it("exports nothing backend-internal from the barrel", () => {
+		const barrel = readFileSync(join(moduleRoot, "index.ts"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+		expect(barrel).not.toMatch(/TmuxOwnershipPort|tmuxOwnershipPort|TmuxClient|PANE_/);
+	});
+});

--- a/src/bun/terminal-process-ownership/__tests__/native-source.test.ts
+++ b/src/bun/terminal-process-ownership/__tests__/native-source.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { nativeOwnershipClaim } from "../native-source";
+
+const record = { sessionId: "sess-1", host: { pid: 4100 }, shell: { pid: 4101 } };
+
+describe("native ownership claim", () => {
+	it("proves host and shell roots for an owned session", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record, verdict: "owned" });
+		expect(claim.backend).toBe("native");
+		expect(claim.proof.verified).toBe(true);
+		expect(claim.roots).toEqual([
+			{ pid: 4100, role: "host" },
+			{ pid: 4101, role: "shell" },
+		]);
+	});
+
+	it("reports an exited session as stale, never as owned", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record, verdict: "dead" });
+		expect(claim.proof).toEqual({
+			verified: false,
+			state: "stale",
+			reason: "the recorded native host or shell process has exited",
+		});
+		expect(claim.roots).toEqual([]);
+	});
+
+	it("reports a reused PID as reused, never as owned", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record, verdict: "reused" });
+		expect(claim.proof.verified).toBe(false);
+		expect(claim.proof).toMatchObject({ state: "reused" });
+		expect(claim.roots).toEqual([]);
+	});
+
+	it("is unavailable when no record exists (missing host data)", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record: null, verdict: "owned" });
+		expect(claim.proof).toEqual({
+			verified: false,
+			state: "unavailable",
+			reason: "no native session record was found for this session",
+		});
+	});
+
+	it("is unavailable when ownership was never verified", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-1", record });
+		expect(claim.proof).toMatchObject({ state: "unavailable", reason: "native session ownership was not verified" });
+	});
+
+	it("refuses a record that belongs to another session id", () => {
+		const claim = nativeOwnershipClaim({ sessionId: "sess-2", record, verdict: "owned" });
+		expect(claim.proof).toMatchObject({
+			state: "unavailable",
+			reason: "the native session record belongs to a different session id",
+		});
+	});
+
+	it("is unavailable when the record carries no usable PID", () => {
+		const claim = nativeOwnershipClaim({
+			sessionId: "sess-1",
+			record: { sessionId: "sess-1", host: { pid: 0 }, shell: {} },
+			verdict: "owned",
+		});
+		expect(claim.proof).toMatchObject({
+			state: "unavailable",
+			reason: "the native session record carried no usable host or shell PID",
+		});
+	});
+});

--- a/src/bun/terminal-process-ownership/__tests__/ownership.bun-e2e.ts
+++ b/src/bun/terminal-process-ownership/__tests__/ownership.bun-e2e.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+/**
+ * Real-process proof for the ownership snapshot (seq 1293).
+ *
+ * The vitest unit tests prove the attribution RULES against injected evidence;
+ * this script proves the same rules against the REAL scanners (`ps` + `lsof`) and
+ * real processes — under `bun`, because vitest stubs `Bun.spawn`.
+ *
+ * Checks: a nested grandchild listener is attributed to its root, an unrelated
+ * sentinel listener never is, and an exited tree owns nothing.
+ *
+ * Run: bun run test:ownership-e2e   (POSIX only — the scanners shell out)
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearProcessInfoCache, getDescendantPids, getLsofOutput } from "../../port-scanner";
+import { spawn } from "../../spawn";
+import { collectOwnershipSnapshot } from "../collector";
+import { verifiedClaim } from "../contract";
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+const LISTENER = `
+const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+console.log("PORT " + server.port);
+setInterval(() => {}, 1000);
+`;
+
+type Listener = { pid: number; port: number };
+
+const roots: number[] = [];
+
+/** Read stdout until the listener announces its ephemeral port. */
+async function readPort(stdout: ReadableStream<Uint8Array>, timeoutMs = 15_000): Promise<number> {
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	const deadline = Date.now() + timeoutMs;
+	let buffered = "";
+	try {
+		while (Date.now() < deadline) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffered += decoder.decode(value, { stream: true });
+			const match = buffered.match(/PORT (\d+)/);
+			if (match) return Number(match[1]);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return 0;
+}
+
+/**
+ * Start `sh → sh → bun listener`; the outer sh is the claimed root. The trailing
+ * `; :` and the `& wait` stop each shell from `exec`ing its single command away,
+ * which is what keeps the listener a genuine GRANDCHILD.
+ */
+async function startNestedListener(scriptPath: string): Promise<Listener> {
+	const proc = spawn(["sh", "-c", 'sh -c "$BUN $SCRIPT & wait"; :'], {
+		stdout: "pipe",
+		stderr: "ignore",
+		env: { BUN: process.execPath, SCRIPT: scriptPath },
+	});
+	roots.push(proc.pid);
+	return { pid: proc.pid, port: proc.stdout ? await readPort(proc.stdout) : 0 };
+}
+
+/** A listener that is nobody's descendant — the negative control. */
+async function startSentinelListener(scriptPath: string): Promise<Listener> {
+	const proc = spawn([process.execPath, scriptPath], { stdout: "pipe", stderr: "ignore" });
+	roots.push(proc.pid);
+	return { pid: proc.pid, port: proc.stdout ? await readPort(proc.stdout) : 0 };
+}
+
+async function killTree(pid: number): Promise<void> {
+	clearProcessInfoCache();
+	for (const target of [...(await getDescendantPids(pid)), pid]) {
+		try {
+			process.kill(target, "SIGKILL");
+		} catch {
+			// already gone
+		}
+	}
+}
+
+async function run(): Promise<void> {
+	if (process.platform === "win32") {
+		console.log("SKIPPED — POSIX only (`ps` / `lsof` scanners)");
+		return;
+	}
+	if ((await getLsofOutput()).length === 0) {
+		console.error("`lsof` produced no output — cannot observe port attribution on this machine");
+		failures++;
+		return;
+	}
+
+	const workDir = mkdtempSync(join(tmpdir(), "dev3-ownership-"));
+	const scriptPath = join(workDir, "listener.js");
+	writeFileSync(scriptPath, LISTENER);
+
+	try {
+		console.log("\nnested listener + unrelated sentinel");
+		const owned = await startNestedListener(scriptPath);
+		const sentinel = await startSentinelListener(scriptPath);
+		check(owned.port > 0, `nested listener came up on port ${owned.port}`);
+		check(sentinel.port > 0, `sentinel listener came up on port ${sentinel.port}`);
+
+		clearProcessInfoCache();
+		const claim = verifiedClaim("native", "live-session", [{ pid: owned.pid, role: "host" }]);
+		const snapshot = await collectOwnershipSnapshot(claim);
+		const processes = snapshot.ownership.state === "owned" ? snapshot.ownership.processes : [];
+		const ports = snapshot.ports.map((port) => port.port);
+
+		check(snapshot.ownership.state === "owned", "ownership verified from the proved root");
+		check(
+			snapshot.coverage.descendants && snapshot.coverage.resources && snapshot.coverage.ports,
+			"all three scanners reported coverage",
+		);
+		check(
+			processes.filter((process) => process.role === "descendant").length >= 2,
+			"the nested shell and the listener are attributed as descendants",
+		);
+		check(ports.includes(owned.port), "the nested listener's port is in the snapshot");
+		check(!ports.includes(sentinel.port), "the unrelated sentinel's port is NOT in the snapshot");
+		check(!processes.some((process) => process.pid === sentinel.pid), "the sentinel process is NOT attributed");
+		check((snapshot.resources?.rss ?? 0) > 0, "resource cost aggregated for the owned tree");
+
+		console.log("\nexited tree");
+		await killTree(owned.pid);
+		clearProcessInfoCache();
+		const afterExit = await collectOwnershipSnapshot(claim);
+		const exitedPorts = afterExit.ports.map((port) => port.port);
+		check(!exitedPorts.includes(owned.port), "the dead tree's port is gone from the snapshot");
+		check(afterExit.resources?.rss === 0, "the dead tree costs nothing");
+	} finally {
+		for (const pid of roots) await killTree(pid);
+		rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+run()
+	.then(() => {
+		if (failures > 0) {
+			console.error(`\n${failures} check(s) FAILED`);
+			process.exit(1);
+		}
+		console.log("\nALL CHECKS PASSED");
+		process.exit(0);
+	})
+	.catch((error) => {
+		console.error("\nERROR:", error);
+		process.exit(1);
+	});

--- a/src/bun/terminal-process-ownership/__tests__/tmux-source.test.ts
+++ b/src/bun/terminal-process-ownership/__tests__/tmux-source.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { tmuxOwnershipClaim, tmuxOwnershipClaimFromPanePids, type TmuxOwnershipPort } from "../tmux-source";
+
+function fakePort(panes: Record<string, number[]>): TmuxOwnershipPort {
+	return { panePids: async (sessionName) => panes[sessionName] ?? [] };
+}
+
+describe("tmux ownership claim", () => {
+	it("treats every reported pane PID as a proved root", () => {
+		const claim = tmuxOwnershipClaimFromPanePids("dev3-task-abc", [11, 12]);
+		expect(claim.backend).toBe("tmux");
+		expect(claim.proof.verified).toBe(true);
+		expect(claim.roots).toEqual([
+			{ pid: 11, role: "pane" },
+			{ pid: 12, role: "pane" },
+		]);
+	});
+
+	it("is unavailable when tmux reports no panes for the session", () => {
+		const claim = tmuxOwnershipClaimFromPanePids("dev3-task-abc", []);
+		expect(claim.proof).toEqual({
+			verified: false,
+			state: "unavailable",
+			reason: "tmux reported no panes for this session",
+		});
+	});
+
+	it("folds sibling sessions into one accounting unit", async () => {
+		const claim = await tmuxOwnershipClaim(
+			"dev3-task-abc",
+			["dev3-task-abc", "dev3-dev-abc"],
+			fakePort({ "dev3-task-abc": [11], "dev3-dev-abc": [21, 22] }),
+		);
+		expect(claim.roots.map((root) => root.pid)).toEqual([11, 21, 22]);
+	});
+
+	it("asks tmux only for the sessions it was given", async () => {
+		const panePids = vi.fn(async () => [11]);
+		await tmuxOwnershipClaim("dev3-task-abc", ["dev3-task-abc"], { panePids });
+		expect(panePids.mock.calls).toEqual([["dev3-task-abc"]]);
+	});
+});

--- a/src/bun/terminal-process-ownership/collector.ts
+++ b/src/bun/terminal-process-ownership/collector.ts
@@ -1,0 +1,162 @@
+/**
+ * The adapter that turns a {@link TerminalOwnershipClaim} into a snapshot using
+ * the app's EXISTING resource and listening-port scanners (seq 1293).
+ *
+ * There is deliberately no second monitoring subsystem here: descendants come
+ * from the shared `ps` snapshot (`collectProcessInfo`, TTL-cached and already
+ * shared by both pollers), per-PID cost from `aggregateResources`, and listening
+ * ports from one `lsof` run parsed by `parseLsofOutput`. This module only decides
+ * WHICH pids those scanners may attribute to a session.
+ *
+ * Two entry points:
+ *  - {@link buildOwnershipSnapshot} — pure: claim + already-collected evidence.
+ *  - {@link collectOwnershipSnapshot} — async: pulls the evidence from the shared
+ *    scanners, and runs NO scanner at all when the claim is unproved.
+ */
+
+import type { PortInfo, ResourceUsage } from "../../shared/types";
+import { collectDescendants, collectProcessInfo, getLsofOutput, parseLsofOutput } from "../port-scanner";
+import { aggregateResources } from "../resource-monitor";
+import {
+	TERMINAL_OWNERSHIP_SCHEMA,
+	TERMINAL_OWNERSHIP_VERSION,
+	type OwnedProcess,
+	type TerminalOwnership,
+	type TerminalOwnershipClaim,
+	type TerminalOwnershipCoverage,
+} from "./contract";
+import type { TerminalBackendIdentity } from "../../shared/terminal-backend-identity";
+
+export interface TerminalOwnershipSnapshot {
+	readonly schema: typeof TERMINAL_OWNERSHIP_SCHEMA;
+	readonly version: typeof TERMINAL_OWNERSHIP_VERSION;
+	readonly backend: TerminalBackendIdentity;
+	readonly sessionId: string;
+	readonly ownership: TerminalOwnership;
+	/** Aggregated cost of the owned processes; null when ownership is unproved. */
+	readonly resources: ResourceUsage | null;
+	/** Listening TCP ports held by the owned processes; empty unless proved. */
+	readonly ports: readonly PortInfo[];
+	readonly coverage: TerminalOwnershipCoverage;
+}
+
+/**
+ * Facts gathered from the shared scanners. A `null` field means the scanner
+ * could not run on this platform — reported through `coverage`, never silently
+ * flattened into "no children" / "no ports".
+ */
+export interface TerminalOwnershipEvidence {
+	/** Parent PID → child PIDs, from the shared `ps` snapshot. */
+	readonly tree: Map<number, number[]> | null;
+	/** PID → { rss, cpu }, from the same `ps` snapshot. */
+	readonly resources: Map<number, { rss: number; cpu: number }> | null;
+	/** Raw `lsof -F pcn` output for LISTENing sockets. */
+	readonly lsofOutput: string | null;
+}
+
+/** The scanners the collector is allowed to touch; faked in tests. */
+export interface TerminalOwnershipScanners {
+	processInfo: () => Promise<{
+		tree: Map<number, number[]>;
+		resources: Map<number, { rss: number; cpu: number }>;
+	} | null>;
+	lsof: () => Promise<string | null>;
+}
+
+/**
+ * Process enumeration is POSIX-only: both scanners shell out to `ps` / `lsof`.
+ * On Windows the native session's ownership proof is Job Object membership, which
+ * proves identity but cannot enumerate a tree — so the evidence is reported
+ * absent instead of guessed.
+ */
+const posixOnly = (): boolean => process.platform !== "win32";
+
+export const defaultOwnershipScanners: TerminalOwnershipScanners = {
+	processInfo: async () => (posixOnly() ? await collectProcessInfo() : null),
+	// The scanners return "" when the tool is missing or failed — that is "not
+	// measured", not "no listening ports".
+	lsof: async () => (posixOnly() ? emptyToNull(await getLsofOutput()) : null),
+};
+
+function emptyToNull(output: string | null): string | null {
+	return output !== null && output.length > 0 ? output : null;
+}
+
+function unprovedSnapshot(claim: TerminalOwnershipClaim, ownership: TerminalOwnership): TerminalOwnershipSnapshot {
+	return {
+		schema: TERMINAL_OWNERSHIP_SCHEMA,
+		version: TERMINAL_OWNERSHIP_VERSION,
+		backend: claim.backend,
+		sessionId: claim.sessionId,
+		ownership,
+		resources: null,
+		ports: [],
+		coverage: { descendants: false, resources: false, ports: false },
+	};
+}
+
+/**
+ * Expand a claim into a snapshot from already-collected evidence. Pure and
+ * synchronous — no spawns, no clock.
+ */
+export function buildOwnershipSnapshot(
+	claim: TerminalOwnershipClaim,
+	evidence: TerminalOwnershipEvidence,
+): TerminalOwnershipSnapshot {
+	if (!claim.proof.verified) {
+		return unprovedSnapshot(claim, { state: claim.proof.state, reason: claim.proof.reason });
+	}
+
+	const processes: OwnedProcess[] = [];
+	const pids = new Set<number>();
+	for (const root of claim.roots) {
+		if (pids.has(root.pid)) continue;
+		pids.add(root.pid);
+		processes.push({ pid: root.pid, role: root.role });
+	}
+	if (evidence.tree) {
+		for (const root of claim.roots) {
+			for (const pid of collectDescendants(root.pid, evidence.tree)) {
+				if (pids.has(pid)) continue;
+				pids.add(pid);
+				processes.push({ pid, role: "descendant" });
+			}
+		}
+	}
+
+	const lsofOutput = emptyToNull(evidence.lsofOutput);
+	return {
+		schema: TERMINAL_OWNERSHIP_SCHEMA,
+		version: TERMINAL_OWNERSHIP_VERSION,
+		backend: claim.backend,
+		sessionId: claim.sessionId,
+		ownership: { state: "owned", processes },
+		resources: evidence.resources ? aggregateResources(pids, evidence.resources) : null,
+		ports: lsofOutput ? parseLsofOutput(lsofOutput, pids) : [],
+		coverage: {
+			descendants: evidence.tree !== null,
+			resources: evidence.resources !== null,
+			ports: lsofOutput !== null,
+		},
+	};
+}
+
+/**
+ * Collect the evidence from the shared scanners and expand the claim. An
+ * unproved claim short-circuits: no `ps`, no `lsof`, nothing attributed.
+ */
+export async function collectOwnershipSnapshot(
+	claim: TerminalOwnershipClaim,
+	scanners: TerminalOwnershipScanners = defaultOwnershipScanners,
+): Promise<TerminalOwnershipSnapshot> {
+	if (!claim.proof.verified) {
+		return unprovedSnapshot(claim, { state: claim.proof.state, reason: claim.proof.reason });
+	}
+	const info = await scanners.processInfo();
+	const lsofOutput = await scanners.lsof();
+	return buildOwnershipSnapshot(claim, {
+		tree: info?.tree ?? null,
+		resources: info?.resources ?? null,
+		lsofOutput,
+	});
+}

--- a/src/bun/terminal-process-ownership/contract.ts
+++ b/src/bun/terminal-process-ownership/contract.ts
@@ -1,0 +1,123 @@
+/**
+ * Backend-neutral process ownership vocabulary for one terminal session
+ * (tmux-removal roadmap seq 1293).
+ *
+ * ONE contract answers "which processes does this terminal session own, and was
+ * that ownership actually PROVED?" for both backends. A backend produces a
+ * {@link TerminalOwnershipClaim} — verified root processes plus the proof that
+ * backs them — and `collector.ts` expands it into a
+ * {@link TerminalOwnershipSnapshot} using the app's existing `ps`/`lsof`
+ * scanners.
+ *
+ * Hard boundaries of this seam:
+ *  - Ownership is never inferred from a task id or a bare PID. A claim carries a
+ *    proof, and an unproved claim becomes an explicit
+ *    `unavailable` / `stale` / `reused` snapshot with a reason — never an empty
+ *    "owned" set that silently reads as "this session costs nothing".
+ *  - This slice is READ-ONLY accounting: nothing here signals, kills, launches,
+ *    attaches to, or selects a backend.
+ *  - This file is pure vocabulary: no spawns, no clock, no tmux, no registry.
+ */
+
+import type { TerminalBackendIdentity } from "../../shared/terminal-backend-identity";
+
+export const TERMINAL_OWNERSHIP_SCHEMA = "dev3-terminal-process-ownership" as const;
+export const TERMINAL_OWNERSHIP_VERSION = 1 as const;
+
+/** Why a root process belongs to the session — for logs and diagnostics. */
+export type TerminalOwnershipRootRole = "host" | "shell" | "pane";
+
+/** A process the backend PROVED it owns, before descendants are expanded. */
+export interface TerminalOwnershipRoot {
+	readonly pid: number;
+	readonly role: TerminalOwnershipRootRole;
+}
+
+/** A process attributed to the session: a proved root or one of its children. */
+export interface OwnedProcess {
+	readonly pid: number;
+	readonly role: TerminalOwnershipRootRole | "descendant";
+}
+
+/**
+ * Why a claim carries no proof:
+ *  - `unavailable` — ownership could not be determined at all (no session state,
+ *    no usable host data, no verdict). Nothing is attributed and no scanner runs.
+ *  - `stale` — the recorded processes are gone; the session's cost is zero and
+ *    must not be attributed to whatever holds those PIDs now.
+ *  - `reused` — a recorded PID is alive but is no longer the process we started.
+ */
+export type TerminalOwnershipUnprovedState = "unavailable" | "stale" | "reused";
+
+export type TerminalOwnershipProof =
+	| { readonly verified: true }
+	| { readonly verified: false; readonly state: TerminalOwnershipUnprovedState; readonly reason: string };
+
+/** What a backend claims to own for one session, plus the proof behind it. */
+export interface TerminalOwnershipClaim {
+	readonly backend: TerminalBackendIdentity;
+	/** The product's session id (tmux session name / native session id). */
+	readonly sessionId: string;
+	/** Proved roots; meaningful only when `proof.verified` is true. */
+	readonly roots: readonly TerminalOwnershipRoot[];
+	readonly proof: TerminalOwnershipProof;
+}
+
+export type TerminalOwnership =
+	| { readonly state: "owned"; readonly processes: readonly OwnedProcess[] }
+	| { readonly state: TerminalOwnershipUnprovedState; readonly reason: string };
+
+/**
+ * What the snapshot could actually measure. A `false` flag means the fact was
+ * not observable (no process table on this platform, no `lsof`), NOT that the
+ * session has no children / no ports.
+ */
+export interface TerminalOwnershipCoverage {
+	readonly descendants: boolean;
+	readonly resources: boolean;
+	readonly ports: boolean;
+}
+
+export function isOwnablePid(pid: unknown): pid is number {
+	return typeof pid === "number" && Number.isInteger(pid) && pid > 0;
+}
+
+export function verifiedProof(): TerminalOwnershipProof {
+	return { verified: true };
+}
+
+export function unprovedProof(state: TerminalOwnershipUnprovedState, reason: string): TerminalOwnershipProof {
+	return { verified: false, state, reason };
+}
+
+export function unprovedClaim(
+	backend: TerminalBackendIdentity,
+	sessionId: string,
+	state: TerminalOwnershipUnprovedState,
+	reason: string,
+): TerminalOwnershipClaim {
+	return { backend, sessionId, roots: [], proof: unprovedProof(state, reason) };
+}
+
+/**
+ * Build a verified claim from proved roots. Unusable PIDs are dropped, and a
+ * claim left with no root degrades to `unavailable` — a verified-but-empty claim
+ * would be indistinguishable from a session that genuinely costs nothing.
+ */
+export function verifiedClaim(
+	backend: TerminalBackendIdentity,
+	sessionId: string,
+	roots: readonly TerminalOwnershipRoot[],
+): TerminalOwnershipClaim {
+	const seen = new Set<number>();
+	const usable: TerminalOwnershipRoot[] = [];
+	for (const root of roots) {
+		if (!isOwnablePid(root.pid) || seen.has(root.pid)) continue;
+		seen.add(root.pid);
+		usable.push({ pid: root.pid, role: root.role });
+	}
+	if (usable.length === 0) {
+		return unprovedClaim(backend, sessionId, "unavailable", "no usable root process was proved for this session");
+	}
+	return { backend, sessionId, roots: usable, proof: verifiedProof() };
+}

--- a/src/bun/terminal-process-ownership/index.ts
+++ b/src/bun/terminal-process-ownership/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Backend-neutral terminal process/port ownership accounting (seq 1293).
+ *
+ * Read-only: one claim → one snapshot of the processes a terminal session owns
+ * and the ports they listen on, for both tmux and native sessions. See
+ * contract.ts for the vocabulary and its boundaries.
+ *
+ * The tmux port type stays private (it is a backend-internal seam for tests);
+ * nothing tmux-shaped is re-exported here.
+ */
+
+export {
+	TERMINAL_OWNERSHIP_SCHEMA,
+	TERMINAL_OWNERSHIP_VERSION,
+	isOwnablePid,
+	unprovedClaim,
+	unprovedProof,
+	verifiedClaim,
+	verifiedProof,
+	type OwnedProcess,
+	type TerminalOwnership,
+	type TerminalOwnershipClaim,
+	type TerminalOwnershipCoverage,
+	type TerminalOwnershipProof,
+	type TerminalOwnershipRoot,
+	type TerminalOwnershipRootRole,
+	type TerminalOwnershipUnprovedState,
+} from "./contract";
+export {
+	buildOwnershipSnapshot,
+	collectOwnershipSnapshot,
+	defaultOwnershipScanners,
+	type TerminalOwnershipEvidence,
+	type TerminalOwnershipScanners,
+	type TerminalOwnershipSnapshot,
+} from "./collector";
+export {
+	nativeOwnershipClaim,
+	type NativeOwnershipInput,
+	type NativeOwnershipRecordInput,
+	type NativeOwnershipVerdict,
+} from "./native-source";
+export { tmuxOwnershipClaim, tmuxOwnershipClaimFromPanePids } from "./tmux-source";

--- a/src/bun/terminal-process-ownership/native-source.ts
+++ b/src/bun/terminal-process-ownership/native-source.ts
@@ -1,0 +1,85 @@
+/**
+ * The native side of the ownership contract (seq 1293).
+ *
+ * A native session's ownership evidence already exists: the persisted session
+ * record pins the host + shell PIDs, and the session store's ownership check
+ * classifies them as `owned` / `dead` / `reused` (POSIX start signature, or
+ * Windows Job Object membership). This module ONLY translates that verdict into
+ * a {@link TerminalOwnershipClaim} — it never re-derives identity, never signals
+ * a PID, and never falls back to tmux.
+ *
+ * STANDALONE BY CONTRACT. It imports nothing from the native session store: the
+ * input types below are plain data, deliberately shaped to be structurally
+ * compatible with that store's public read APIs (`readRecord` → record,
+ * `classifyOwnership` → verdict), so a caller passes those values straight
+ * through without this file referencing that module (whose isolation test
+ * forbids exactly that).
+ *
+ * A verdict of anything but `owned` — or missing host data — yields an explicit
+ * unproved claim, so a stale or reused PID is never counted as session cost.
+ */
+
+import {
+	isOwnablePid,
+	unprovedClaim,
+	verifiedClaim,
+	type TerminalOwnershipClaim,
+	type TerminalOwnershipRoot,
+} from "./contract";
+
+/** Structurally matches the native session store's `OwnershipVerdict`. */
+export type NativeOwnershipVerdict = "owned" | "dead" | "reused";
+
+/**
+ * The record facts this module reads. Field names mirror the persisted native
+ * session record so a caller can pass one directly; everything is optional
+ * because a lookup may find no record at all.
+ */
+export interface NativeOwnershipRecordInput {
+	sessionId?: string;
+	host?: { pid?: number };
+	shell?: { pid?: number };
+}
+
+export interface NativeOwnershipInput {
+	/** The session id being accounted for. */
+	sessionId: string;
+	/** The persisted record, or null/undefined when nothing was found on disk. */
+	record?: NativeOwnershipRecordInput | null;
+	/** The store's ownership verdict; absent means ownership was never checked. */
+	verdict?: NativeOwnershipVerdict | null;
+}
+
+/**
+ * Translate a native record + verdict into a claim.
+ *
+ * `dead` → `stale`, `reused` → `reused`, and every "we cannot tell" case
+ * (no record, no verdict, foreign record, unusable PIDs) → `unavailable`.
+ */
+export function nativeOwnershipClaim(input: NativeOwnershipInput): TerminalOwnershipClaim {
+	const unproved = (state: "unavailable" | "stale" | "reused", reason: string): TerminalOwnershipClaim =>
+		unprovedClaim("native", input.sessionId, state, reason);
+
+	const record = input.record ?? null;
+	if (!record) return unproved("unavailable", "no native session record was found for this session");
+	if (typeof record.sessionId === "string" && record.sessionId !== input.sessionId) {
+		return unproved("unavailable", "the native session record belongs to a different session id");
+	}
+
+	const verdict = input.verdict ?? null;
+	if (verdict === "dead") return unproved("stale", "the recorded native host or shell process has exited");
+	if (verdict === "reused") return unproved("reused", "a recorded native PID is alive but is no longer our process");
+	if (verdict !== "owned") return unproved("unavailable", "native session ownership was not verified");
+
+	const hostPid = record.host?.pid;
+	const shellPid = record.shell?.pid;
+	if (!isOwnablePid(hostPid) || !isOwnablePid(shellPid)) {
+		return unproved("unavailable", "the native session record carried no usable host or shell PID");
+	}
+
+	const roots: TerminalOwnershipRoot[] = [
+		{ pid: hostPid, role: "host" },
+		{ pid: shellPid, role: "shell" },
+	];
+	return verifiedClaim("native", input.sessionId, roots);
+}

--- a/src/bun/terminal-process-ownership/tmux-source.ts
+++ b/src/bun/terminal-process-ownership/tmux-source.ts
@@ -1,0 +1,60 @@
+/**
+ * The tmux side of the ownership contract, and the ONLY file in this module that
+ * speaks tmux (seq 1293).
+ *
+ * tmux itself is the ownership evidence: `#{pane_pid}` is reported by the live
+ * server for a pane it created, so a pane PID is proved, not guessed. The pane
+ * PIDs come from the existing `getSessionPanePids` / `getAllSessionPanePids`
+ * helpers, which go through the typed tmux client singleton — nothing here
+ * spawns tmux, recomputes a session name, or declares a `-F` format.
+ *
+ * A session the server reports no panes for is `unavailable`: it is not running
+ * on this server, so nothing may be attributed to it.
+ */
+
+import { DEFAULT_TMUX_SOCKET } from "../tmux";
+import { getSessionPanePids } from "../port-scanner";
+import { unprovedClaim, verifiedClaim, type TerminalOwnershipClaim, type TerminalOwnershipRoot } from "./contract";
+
+/** Every tmux capability this source consumes. */
+export interface TmuxOwnershipPort {
+	panePids(sessionName: string): Promise<readonly number[]>;
+}
+
+/** The production port over the existing pane-PID helper. */
+export function tmuxOwnershipPort(socket: string = DEFAULT_TMUX_SOCKET): TmuxOwnershipPort {
+	return { panePids: (sessionName) => getSessionPanePids(socket, sessionName) };
+}
+
+/**
+ * Build a claim from pane PIDs a caller already has — e.g. a poller holding one
+ * server-wide `getAllSessionPanePids` map, which must not pay for a second tmux
+ * call per session. Pure.
+ */
+export function tmuxOwnershipClaimFromPanePids(
+	sessionId: string,
+	panePids: readonly number[],
+): TerminalOwnershipClaim {
+	if (panePids.length === 0) {
+		return unprovedClaim("tmux", sessionId, "unavailable", "tmux reported no panes for this session");
+	}
+	const roots: TerminalOwnershipRoot[] = panePids.map((pid) => ({ pid, role: "pane" }));
+	return verifiedClaim("tmux", sessionId, roots);
+}
+
+/**
+ * Ask tmux which panes a session owns and build the claim. `sessions` lets a
+ * caller fold sibling tmux sessions (e.g. a task's dev-server session) into one
+ * accounting unit without this module knowing dev3's naming rules.
+ */
+export async function tmuxOwnershipClaim(
+	sessionId: string,
+	sessions: readonly string[] = [sessionId],
+	port: TmuxOwnershipPort = tmuxOwnershipPort(),
+): Promise<TerminalOwnershipClaim> {
+	const panePids: number[] = [];
+	for (const sessionName of sessions) {
+		panePids.push(...(await port.panePids(sessionName)));
+	}
+	return tmuxOwnershipClaimFromPanePids(sessionId, panePids);
+}


### PR DESCRIPTION
Seq 1293 on the tmux-removal roadmap. Resource/port accounting is written against tmux pane PIDs, so a native terminal session is invisible to it — this adds the read-only accounting seam that must exist before native becomes a normal backend.

New module `src/bun/terminal-process-ownership/` (claim → snapshot):

- `contract.ts` — pure vocabulary. A backend produces a `TerminalOwnershipClaim`: proved roots plus a **proof**. No proof means an explicit `unavailable` / `stale` / `reused` snapshot with a reason; ownership is never inferred from a task id or a bare PID, and a verified-but-root-less claim degrades to `unavailable` instead of reading as a free session.
- `collector.ts` — adapter over the **existing** scanners (`collectProcessInfo`, `collectDescendants`, `aggregateResources`, `getLsofOutput` + `parseLsofOutput`). No second monitoring subsystem; it only decides which PIDs those scanners may attribute. An unproved claim runs no scanner at all.
- `tmux-source.ts` — the only file that speaks tmux, via the existing pane-PID helpers over the typed client singleton.
- `native-source.ts` — translates the native session record + its ownership verdict (POSIX start signature / Windows Job membership). Standalone by contract: plain, structurally-compatible input types instead of importing the session store, whose isolation test forbids outside references.

`coverage: {descendants, resources, ports}` reports what could actually be measured — on Windows `ps`/`lsof` are absent, so ownership still verifies through Job membership while the counters say "not measured" rather than implying zero.

Existing tmux pollers are untouched, so tmux behavior is unchanged. No launch/attach/stop, no backend selection, no signalling, no UI or RPC — an isolation test guards all of that plus "no product callers yet".

Tests: unit coverage for nested children, exited processes, PID reuse, and an unrelated sentinel, plus a real-process/real-scanner proof at `bun run test:ownership-e2e` (vitest here stubs `Bun.spawn`, so live processes must run under bun). Rationale in `decisions/171-terminal-process-ownership-accounting.md`.