### PR TITLE
Add native multi-pane terminal session coordinator

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -16,6 +16,7 @@ on:
       - "src/shared/native-terminal-runtime.ts"
       - "src/bun/prototypes/detached-pty/**"
       - "src/bun/native-terminal-registry/**"
+      - "src/bun/native-terminal-multipane/**"
       - "src/bun/native-terminal-adapter/**"
       - "src/bun/terminal-parity/**"
   workflow_dispatch:
@@ -80,6 +81,15 @@ jobs:
       - name: Native single-view adapter parity E2E
         timeout-minutes: 5
         run: bun run test:native-parity-e2e
+
+      # Seq 1283 native multi-pane coordinator. Runs the previously deferred
+      # multi-view scenarios with REAL panes (2 then 6, PowerShell on Windows):
+      # independent shells, non-crossing output, client-local focus/zoom,
+      # writer-vs-observer resize, fresh-process reconnect to the same pids,
+      # single-pane close, and full owned-tree cleanup.
+      - name: Native multi-pane coordinator E2E
+        timeout-minutes: 6
+        run: bun run test:native-multipane-e2e
 
       - name: Explicit Windows shell launch matrix
         if: runner.os == 'Windows'

--- a/change-logs/2026/07/25/feature-90-native-multipane-coordinator.md
+++ b/change-logs/2026/07/25/feature-90-native-multipane-coordinator.md
@@ -1,0 +1,3 @@
+Short: Native multi-pane terminal coordinator
+
+Added a native multi-pane terminal session coordinator that composes one persistent PTY host per logical pane, with a shared split layout, client-local focus and zoom, writer-owned resize, and recovery of the same panes and processes after an app restart. Internal groundwork for running terminals without tmux — no product surface changes, tmux remains the default.

--- a/decisions/169-one-host-per-pane-multipane-coordinator.md
+++ b/decisions/169-one-host-per-pane-multipane-coordinator.md
@@ -1,0 +1,62 @@
+# 169 — One registry-owned host per logical pane, not a multi-PTY daemon
+
+## Context
+
+Seq 1283 (LAY-003/004/005) needed a native multi-pane terminal session: N panes,
+splits, directional focus, zoom, writer-owned resize, and restart recovery —
+without tmux. The persistent native-session registry (seq 1214) already gives a
+detached host that owns exactly one PTY, publishes a versioned record, and can be
+rediscovered from disk by a fresh controller. The open question was whether to
+generalize protocol v1 into a multi-PTY daemon or to compose N single-PTY hosts.
+
+## Investigation
+
+Protocol v1 hard-codes one PTY per connection: `hello`/`welcome` carry a single
+`sessionId`, `status` returns one `paneId`/`shellPid`/`cols`/`rows`, and writer
+ownership (`WriterOwnership`) arbitrates one PTY per host. Making it multiplexed
+would mean a pane id on every frame, per-pane writer leases, per-pane ownership
+evidence in one record, and a partial-failure story for "3 of 5 panes died" — all
+inside the one component whose single-PTY crash/restart/reattach behavior is
+already proved by four e2e suites. Composition needs none of that: pane teardown
+is process teardown, ownership evidence stays per process, and a dead pane is
+just a session that no longer classifies as `owned`.
+
+## Decision
+
+One logical pane === one registry session, named deterministically
+`<coordinatorId>-<paneId>` (`paths.paneSessionId`). `NativeMultipaneCoordinator`
+(`src/bun/native-terminal-multipane/coordinator.ts`) owns only the shared
+`SplitTree` and the pane→session binding, persisted as a minimal versioned record
+in a new additive namespace `~/.dev3.0/native-multipane/` — atomic tmp+rename
+writes, removal guarded by a compare-and-swap on the record `epoch`. Host pid,
+shell pid, endpoint, ownership evidence, and PTY size are never copied here; they
+are read from each pane's own registry record. Protocol v1 is untouched.
+
+Three layers stay deliberately distinct: pane membership and geometry are shared
+(`SplitTree`, normalized by `focus-mapping.normalizeSharedLayout` so its
+single-renderer `activePaneId`/`zoomedPaneId` never become shared state); focus
+and zoom are client-local (`CoordinatorClientView` over
+`shared/native-terminal-client-layout`); cols/rows belong to whichever client the
+host made writer, and an observer attachment is refused with
+`ObserverMutationError` instead of silently ignored.
+
+## Risks
+
+Six panes mean six host processes rather than one, so per-pane memory and boot
+latency add up (measured well under the registry's 15s boot budget in the
+harness). A coordinator record can also drift from reality if a pane host dies
+while no controller is attached; `recover()` handles this by reconciling dead
+panes out of the layout deterministically and returning `null` (plus dropping the
+record) when none survive.
+
+## Alternatives considered
+
+- **Generalize protocol v1 to multi-PTY.** Rejected: re-litigates crash,
+  restart, ownership, and backpressure semantics that are already proved, with no
+  behavior the composition cannot deliver.
+- **A supervisor process owning N PTYs.** Rejected: reintroduces the exact
+  single-point-of-failure and attach/reattach complexity that killing tmux was
+  meant to remove.
+- **Store host/shell pids in the coordinator record.** Rejected: two sources of
+  truth for liveness; the registry record is already authoritative and
+  ownership-verified.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"test:native-crash-e2e": "bun src/bun/native-terminal-registry/__tests__/crash-recovery.bun-e2e.ts",
 		"test:native-multi-client-e2e": "bun src/bun/native-terminal-registry/__tests__/multi-client.bun-e2e.ts",
 		"test:native-app-restart-e2e": "bun src/bun/native-terminal-registry/__tests__/app-restart.bun-e2e.ts",
+		"test:native-multipane-e2e": "bun src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts",
 		"test:native-shell-launch": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/__tests__/shell-launch.test.ts src/bun/native-terminal-registry/__tests__/shell-probe.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-runner.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-evidence.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-matrix-support.test.ts src/bun/native-terminal-registry/__tests__/host-config.test.ts src/bun/native-terminal-registry/__tests__/protocol.test.ts src/bun/native-terminal-registry/__tests__/registry.test.ts src/bun/native-terminal-registry/__tests__/client.test.ts src/bun/native-terminal-registry/__tests__/isolation.test.ts",
 		"test:native-live-parser-e2e": "bun src/bun/native-terminal-registry/__tests__/live-parser.bun-e2e.ts",
 		"test:native-host-images-e2e": "bun src/bun/native-terminal-registry/host-images/__tests__/lifecycle.bun-e2e.ts",

--- a/src/bun/native-terminal-multipane/README.md
+++ b/src/bun/native-terminal-multipane/README.md
@@ -1,0 +1,92 @@
+# Native multi-pane terminal session coordinator (seq 1283)
+
+The native runtime slice of LAY-003 / LAY-004 / LAY-005: it composes the existing
+persistent single-pane hosts (`../native-terminal-registry`) into one logical
+multi-pane terminal session, with no tmux anywhere in the path.
+
+**Not wired into any product surface.** No RPC handler, CLI command, or renderer
+imports this module — an isolation test enforces that. tmux stays the production
+default.
+
+## Model
+
+| Layer | Owner | Where it lives |
+|---|---|---|
+| Pane membership + geometry | shared | `SplitTree`, persisted in the coordinator record |
+| Focus + zoom | each client | `CoordinatorClientView`, never persisted |
+| PTY cols/rows, input | the host's writer | per-pane registry session |
+
+One logical pane === one registry-owned host === one shell process. The pane's
+registry session id is `<coordinatorId>-<paneId>`, so a fresh controller can
+rediscover every host from the layout alone. Protocol v1 stays a single-PTY
+contract — see [decision 169](../../../decisions/169-one-host-per-pane-multipane-coordinator.md).
+
+`SplitTree` carries `activePaneId`/`zoomedPaneId` because it was written for a
+single renderer. `focus-mapping.normalizeSharedLayout` strips both before the
+tree becomes shared state, and `directionalFocusTarget` borrows the tree's
+geometry with a client's own focus temporarily installed — so directional focus
+works without ever writing a client's focus back into shared state.
+
+## On-disk state
+
+Additive namespace `~/.dev3.0/native-multipane/<coordinatorId>/coordinator.json`
+(override with `DEV3_NATIVE_MULTIPANE_DIR`). It is a sibling of — never inside —
+the registry's `native-sessions/` root, and it never touches legacy tmux records.
+
+The record is deliberately minimal: schema version, coordinator id, epoch,
+`updatedAt`, the serialized `SplitTree`, and the pane→session bindings. Host pid,
+shell pid, endpoint, ownership evidence, and PTY size are read from each pane's
+own registry record instead of being duplicated.
+
+Writes are tmp-write + rename. Removal is a compare-and-swap on `epoch`, so a
+stale controller can never erase a coordinator that was torn down and recreated
+under the same id. A record whose bindings disagree with its own layout, or whose
+schema version is not this build's, is unreadable rather than half-adopted.
+
+## Lifecycle
+
+```ts
+const coordinator = await NativeMultipaneCoordinator.create("demo", spec);
+const paneId = await coordinator.split("pane-1", "horizontal", spec);
+await coordinator.resizePane(paneId, 120, 40);   // writer-owned; observers are refused
+await coordinator.closePane(paneId);             // kills only that pane's owned tree
+await coordinator.cleanup();                     // idempotent full teardown
+```
+
+`recover(id)` is the fresh-controller path after an app-process restart: it never
+spawns and never double-attaches. Panes whose host no longer verifies as ours are
+reconciled out of the layout deterministically; when none survive it drops the
+record and returns `null`. Closing the last pane tears the logical session down.
+
+Two controllers may observe the same pane set. The host grants writer to the
+first live attachment; a second controller attaches as observer, and
+`resizePane`/`writePane` throw `ObserverMutationError` instead of silently
+no-oping.
+
+## Harness
+
+`cli.ts` is a dev-only driver. Every command runs in a fresh process, so anything
+after `create` exercises real recovery from disk:
+
+```bash
+bun src/bun/native-terminal-multipane/cli.ts create demo --panes 6
+bun src/bun/native-terminal-multipane/cli.ts list demo          # same ids, same pids
+bun src/bun/native-terminal-multipane/cli.ts split demo pane-3 --vertical
+bun src/bun/native-terminal-multipane/cli.ts focus demo pane-1 right
+bun src/bun/native-terminal-multipane/cli.ts zoom demo pane-2
+bun src/bun/native-terminal-multipane/cli.ts resize demo pane-1 120 40
+bun src/bun/native-terminal-multipane/cli.ts close demo pane-3
+bun src/bun/native-terminal-multipane/cli.ts cleanup demo
+```
+
+## Tests
+
+```bash
+bunx vitest run --config vitest.config.bun.ts native-terminal-multipane
+bun run test:native-multipane-e2e     # 2 and 6 REAL panes, detach/reconnect, cleanup
+```
+
+The e2e run proves independent shells (each echoes its own env marker and pid),
+non-crossing output streams, client-local focus/zoom, writer-vs-observer resize,
+fresh-process recovery of identical host/shell pids, single-pane close, full
+teardown, and that tmux is never invoked (PATH shim sentinel).

--- a/src/bun/native-terminal-multipane/__tests__/coordinator.test.ts
+++ b/src/bun/native-terminal-multipane/__tests__/coordinator.test.ts
@@ -5,7 +5,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { listPaneIds } from "../../../shared/split-tree";
 import { defineShellLaunchSpec } from "../../native-terminal-registry/shell-launch";
 import { NativeMultipaneCoordinator, type PaneLaunchSpec } from "../coordinator";
-import { CoordinatorExistsError, CoordinatorGoneError, ObserverMutationError, PaneNotFoundError } from "../errors";
+import {
+	CoordinatorExistsError,
+	CoordinatorGoneError,
+	ObserverMutationError,
+	PaneNotFoundError,
+	PaneResizeNotAppliedError,
+} from "../errors";
 import { NATIVE_MULTIPANE_DIR_ENV, coordinatorRecordFile } from "../paths";
 import { readMultipaneRecord, writeMultipaneRecordAtomic } from "../record";
 import { createFakeRegistry, type FakeRegistry } from "./fake-panes";
@@ -175,6 +181,34 @@ describe("native multipane writer ownership", () => {
 		await expect(observer.writePane("pane-1", "echo hi")).rejects.toBeInstanceOf(ObserverMutationError);
 		expect(deps.panes.get("mp-pane-1")?.resizes).toEqual([{ cols: 120, rows: 40 }]);
 		expect(deps.panes.get("mp-pane-1")?.inputs).toEqual([]);
+	});
+
+	it("waits for the host to republish the new size before resolving", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		const pane = deps.panes.get("mp-pane-1")!;
+		const applyLater = { ...deps, async connectPane(record: Parameters<typeof deps.connectPane>[0], token: string) {
+			const connection = await deps.connectPane(record, token);
+			return { ...connection, resize: (cols: number, rows: number) => {
+				setTimeout(() => { pane.record.cols = cols; pane.record.rows = rows; }, 60);
+			} };
+		} };
+		const delayed = (await NativeMultipaneCoordinator.recover(ID, applyLater))!;
+		await delayed.resizePane("pane-1", 200, 60);
+		expect(deps.readPaneRecord("mp-pane-1")).toMatchObject({ cols: 200, rows: 60 });
+		coordinator.detach();
+	});
+
+	it("reports a resize the host never applied instead of claiming success", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		const neverApplies = { ...deps, async connectPane(record: Parameters<typeof deps.connectPane>[0], token: string) {
+			const connection = await deps.connectPane(record, token);
+			return { ...connection, resize: () => undefined };
+		} };
+		const stuck = (await NativeMultipaneCoordinator.recover(ID, neverApplies))!;
+		await expect(stuck.resizePane("pane-1", 200, 60, { timeoutMs: 100 })).rejects.toBeInstanceOf(
+			PaneResizeNotAppliedError,
+		);
+		coordinator.detach();
 	});
 
 	it("keeps two clients' focus and zoom independent over one pane set", async () => {

--- a/src/bun/native-terminal-multipane/__tests__/coordinator.test.ts
+++ b/src/bun/native-terminal-multipane/__tests__/coordinator.test.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { listPaneIds } from "../../../shared/split-tree";
+import { defineShellLaunchSpec } from "../../native-terminal-registry/shell-launch";
+import { NativeMultipaneCoordinator, type PaneLaunchSpec } from "../coordinator";
+import { CoordinatorExistsError, CoordinatorGoneError, ObserverMutationError, PaneNotFoundError } from "../errors";
+import { NATIVE_MULTIPANE_DIR_ENV, coordinatorRecordFile } from "../paths";
+import { readMultipaneRecord, writeMultipaneRecordAtomic } from "../record";
+import { createFakeRegistry, type FakeRegistry } from "./fake-panes";
+
+const ID = "mp";
+
+function launchFor(paneId: string): PaneLaunchSpec {
+	return {
+		launch: defineShellLaunchSpec({
+			executable: "/bin/bash",
+			argv: ["--norc", "--noprofile"],
+			cwd: `/tmp/${paneId}`,
+			env: { DEV3_NATIVE_PANE_ID: paneId },
+		}),
+		cols: 100,
+		rows: 30,
+	};
+}
+
+async function createWithPanes(deps: FakeRegistry, count: number): Promise<NativeMultipaneCoordinator> {
+	const coordinator = await NativeMultipaneCoordinator.create(ID, launchFor("pane-1"), deps);
+	let last = coordinator.paneIds()[0]!;
+	for (let index = 1; index < count; index++) {
+		last = await coordinator.split(last, index % 2 === 1 ? "horizontal" : "vertical", launchFor(`pane-${index + 1}`));
+	}
+	return coordinator;
+}
+
+describe("native multipane coordinator", () => {
+	let root: string;
+	let deps: FakeRegistry;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "dev3-multipane-"));
+		process.env[NATIVE_MULTIPANE_DIR_ENV] = root;
+		deps = createFakeRegistry();
+	});
+
+	afterEach(() => {
+		delete process.env[NATIVE_MULTIPANE_DIR_ENV];
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("creates one logical session bound to one registry-owned host", async () => {
+		const coordinator = await NativeMultipaneCoordinator.create(ID, launchFor("pane-1"), deps);
+		expect(coordinator.paneIds()).toEqual(["pane-1"]);
+		expect(deps.startCalls).toEqual(["mp-pane-1"]);
+		expect(readMultipaneRecord(ID)?.panes).toEqual([{ paneId: "pane-1", sessionId: "mp-pane-1" }]);
+	});
+
+	it("grows to six panes with a stable id and an independent shell each", async () => {
+		const coordinator = await createWithPanes(deps, 6);
+		expect(coordinator.paneIds()).toHaveLength(6);
+		expect(new Set(deps.startCalls).size).toBe(6);
+		const cwds = [...deps.panes.values()].map((pane) => pane.launch.cwd);
+		expect(new Set(cwds).size).toBe(6);
+		const shellPids = (await coordinator.listPanes()).map((pane) => pane.shellPid);
+		expect(new Set(shellPids).size).toBe(6);
+	});
+
+	it("refuses to create a second coordinator over a live pane set", async () => {
+		await createWithPanes(deps, 2);
+		const before = deps.startCalls.length;
+		await expect(NativeMultipaneCoordinator.create(ID, launchFor("pane-1"), deps)).rejects.toBeInstanceOf(
+			CoordinatorExistsError,
+		);
+		expect(deps.startCalls).toHaveLength(before);
+	});
+
+	it("recovers the same panes, layout, and pids without respawning", async () => {
+		const first = await createWithPanes(deps, 6);
+		const expected = await first.listPanes();
+		first.detach();
+
+		const startsBefore = deps.startCalls.length;
+		const recovered = await NativeMultipaneCoordinator.recover(ID, deps);
+		expect(recovered).not.toBeNull();
+		expect(recovered!.paneIds()).toEqual(first.paneIds());
+		expect(await recovered!.listPanes()).toEqual(expected);
+		expect(recovered!.layout).toEqual(first.layout);
+		expect(deps.startCalls).toHaveLength(startsBefore);
+	});
+
+	it("reconciles a host that died while the controller was gone", async () => {
+		const coordinator = await createWithPanes(deps, 3);
+		const [, second] = coordinator.paneIds();
+		deps.kill(`mp-${second}`);
+
+		const recovered = await NativeMultipaneCoordinator.recover(ID, deps);
+		expect(recovered!.paneIds()).not.toContain(second);
+		expect(recovered!.paneIds()).toHaveLength(2);
+		expect(listPaneIds(recovered!.layout)).toEqual(readMultipaneRecord(ID)?.panes.map((pane) => pane.paneId));
+	});
+
+	it("reports no coordinator and drops the record when every host is gone", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		for (const paneId of coordinator.paneIds()) deps.kill(`mp-${paneId}`);
+		expect(await NativeMultipaneCoordinator.recover(ID, deps)).toBeNull();
+		expect(existsSync(coordinatorRecordFile(ID))).toBe(false);
+	});
+
+	it("closes only the requested pane's process tree", async () => {
+		const coordinator = await createWithPanes(deps, 3);
+		const target = coordinator.paneIds()[1]!;
+		const result = await coordinator.closePane(target);
+		expect(result.sessionTornDown).toBe(false);
+		expect(deps.stopCalls).toEqual([`mp-${target}`]);
+		expect(coordinator.paneIds()).toEqual(result.remainingPaneIds);
+		expect(deps.panes.size).toBe(2);
+	});
+
+	it("tears the logical session down when the final pane closes", async () => {
+		const coordinator = await NativeMultipaneCoordinator.create(ID, launchFor("pane-1"), deps);
+		const result = await coordinator.closePane("pane-1");
+		expect(result.sessionTornDown).toBe(true);
+		expect(deps.panes.size).toBe(0);
+		expect(readMultipaneRecord(ID)).toBeNull();
+	});
+
+	it("is safe to clean up repeatedly", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		await coordinator.cleanup();
+		const stopsAfterFirst = deps.stopCalls.length;
+		await coordinator.cleanup();
+		await coordinator.cleanup();
+		expect(deps.stopCalls).toHaveLength(stopsAfterFirst);
+		expect(readMultipaneRecord(ID)).toBeNull();
+	});
+
+	it("rejects an unknown logical pane", async () => {
+		const coordinator = await NativeMultipaneCoordinator.create(ID, launchFor("pane-1"), deps);
+		await expect(coordinator.closePane("pane-99")).rejects.toBeInstanceOf(PaneNotFoundError);
+	});
+
+	it("refuses layout mutations once another epoch owns the record", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		const record = readMultipaneRecord(ID)!;
+		writeMultipaneRecordAtomic({ ...record, epoch: "someone-else" });
+		await expect(coordinator.split("pane-1", "horizontal", launchFor("pane-3"))).rejects.toBeInstanceOf(
+			CoordinatorGoneError,
+		);
+	});
+});
+
+describe("native multipane writer ownership", () => {
+	let root: string;
+	let deps: FakeRegistry;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "dev3-multipane-writer-"));
+		process.env[NATIVE_MULTIPANE_DIR_ENV] = root;
+		deps = createFakeRegistry();
+	});
+
+	afterEach(() => {
+		delete process.env[NATIVE_MULTIPANE_DIR_ENV];
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("lets the writer resize and refuses the observer", async () => {
+		const writer = await createWithPanes(deps, 2);
+		await writer.resizePane("pane-1", 120, 40);
+		expect(deps.panes.get("mp-pane-1")?.resizes).toEqual([{ cols: 120, rows: 40 }]);
+
+		const observer = (await NativeMultipaneCoordinator.recover(ID, deps))!;
+		await expect(observer.resizePane("pane-1", 10, 10)).rejects.toBeInstanceOf(ObserverMutationError);
+		await expect(observer.writePane("pane-1", "echo hi")).rejects.toBeInstanceOf(ObserverMutationError);
+		expect(deps.panes.get("mp-pane-1")?.resizes).toEqual([{ cols: 120, rows: 40 }]);
+		expect(deps.panes.get("mp-pane-1")?.inputs).toEqual([]);
+	});
+
+	it("keeps two clients' focus and zoom independent over one pane set", async () => {
+		const coordinator = await createWithPanes(deps, 4);
+		const [first, , third] = coordinator.paneIds();
+		const viewA = coordinator.attachClient("a");
+		const viewB = coordinator.attachClient("b");
+
+		viewA.focus(third!);
+		viewA.zoom(third!);
+		expect(viewB.focusedPaneId).toBe(first);
+		expect(viewB.zoomedPaneId).toBeNull();
+		expect(coordinator.layout.zoomedPaneId).toBeNull();
+		expect(coordinator.layout.activePaneId).toBe(first);
+	});
+
+	it("moves client focus through the shared geometry without writing to it", async () => {
+		const coordinator = await createWithPanes(deps, 2);
+		const before = coordinator.layout;
+		const view = coordinator.attachClient("a");
+		view.focus("pane-1");
+		view.focusDirection(coordinator.layout, "right");
+		expect(view.focusedPaneId).toBe("pane-2");
+		expect(coordinator.layout).toEqual(before);
+	});
+});

--- a/src/bun/native-terminal-multipane/__tests__/fake-panes.ts
+++ b/src/bun/native-terminal-multipane/__tests__/fake-panes.ts
@@ -1,0 +1,130 @@
+/**
+ * In-memory stand-in for the registry so coordinator behaviour is provable
+ * without spawning real hosts. Real-process coverage lives in the bun-e2e
+ * harness; these fakes only model ownership, liveness, and writer roles.
+ */
+
+import type { OwnershipVerdict } from "../../native-terminal-registry/ownership";
+import type { NativeSessionRecord } from "../../native-terminal-registry/record";
+import type { StartOptions, StartResult } from "../../native-terminal-registry/registry";
+import type { ClientRole } from "../../native-terminal-registry/writer-ownership";
+import type { CoordinatorDeps, PaneConnection } from "../coordinator";
+
+export interface FakePane {
+	record: NativeSessionRecord;
+	token: string;
+	alive: boolean;
+	launch: StartOptions["launch"];
+	writerTaken: boolean;
+	resizes: Array<{ cols: number; rows: number }>;
+	inputs: string[];
+}
+
+export interface FakeRegistry extends CoordinatorDeps {
+	panes: Map<string, FakePane>;
+	startCalls: string[];
+	stopCalls: string[];
+	kill(sessionId: string): void;
+}
+
+let nextPid = 1000;
+
+function fakeRecord(sessionId: string, opts: StartOptions): NativeSessionRecord {
+	const hostPid = ++nextPid;
+	const shellPid = ++nextPid;
+	return {
+		schemaVersion: 1,
+		sessionId,
+		paneId: sessionId,
+		protocolVersion: 1,
+		hostArtifactVersion: "1",
+		runtimeVersion: "test",
+		platform: process.platform,
+		host: { pid: hostPid, executable: "bun", startSignature: `host-${hostPid}` },
+		shell: {
+			pid: shellPid,
+			command: [opts.launch.executable, ...opts.launch.argv],
+			startSignature: `shell-${shellPid}`,
+		},
+		endpoint: { transport: "ws", address: "127.0.0.1", port: 40000 + shellPid },
+		ownership: { evidenceKind: "posix-start-signature" },
+		cols: opts.cols ?? 80,
+		rows: opts.rows ?? 24,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function createFakeRegistry(): FakeRegistry {
+	const panes = new Map<string, FakePane>();
+	const startCalls: string[] = [];
+	const stopCalls: string[] = [];
+
+	const registry: FakeRegistry = {
+		panes,
+		startCalls,
+		stopCalls,
+		kill(sessionId) {
+			const pane = panes.get(sessionId);
+			if (pane) pane.alive = false;
+		},
+		async startPane(sessionId, opts): Promise<StartResult> {
+			startCalls.push(sessionId);
+			const existing = panes.get(sessionId);
+			if (existing?.alive) return { status: "already-running", record: existing.record };
+			const record = fakeRecord(sessionId, opts);
+			panes.set(sessionId, {
+				record,
+				token: `token-${sessionId}-${record.host.pid}`,
+				alive: true,
+				launch: opts.launch,
+				writerTaken: false,
+				resizes: [],
+				inputs: [],
+			});
+			return { status: "started", record };
+		},
+		async stopPane(sessionId): Promise<boolean> {
+			stopCalls.push(sessionId);
+			panes.delete(sessionId);
+			return true;
+		},
+		readPaneRecord(sessionId): NativeSessionRecord | null {
+			return panes.get(sessionId)?.record ?? null;
+		},
+		readPaneToken(sessionId): string | null {
+			return panes.get(sessionId)?.token ?? null;
+		},
+		async classifyPane(record, token): Promise<OwnershipVerdict> {
+			const pane = panes.get(record.sessionId);
+			if (!pane || !pane.alive) return "dead";
+			return pane.token === token ? "owned" : "reused";
+		},
+		async connectPane(record): Promise<PaneConnection> {
+			const pane = panes.get(record.sessionId);
+			if (!pane) throw new Error(`no fake pane ${record.sessionId}`);
+			// Mirror the host rule: the first live attachment is writer, the rest observe.
+			const role: ClientRole = pane.writerTaken ? "observer" : "writer";
+			pane.writerTaken = true;
+			let closed = false;
+			return {
+				role: () => role,
+				onOutput: () => () => undefined,
+				input(data) {
+					pane.inputs.push(typeof data === "string" ? data : new TextDecoder().decode(data));
+				},
+				resize(cols, rows) {
+					pane.resizes.push({ cols, rows });
+					pane.record.cols = cols;
+					pane.record.rows = rows;
+				},
+				close() {
+					if (closed) return;
+					closed = true;
+					if (role === "writer") pane.writerTaken = false;
+				},
+			};
+		},
+	};
+	return registry;
+}

--- a/src/bun/native-terminal-multipane/__tests__/focus-mapping.test.ts
+++ b/src/bun/native-terminal-multipane/__tests__/focus-mapping.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { createSplitTree, listPaneIds, splitPane, zoomPane, type SplitTree } from "../../../shared/split-tree";
+import { CoordinatorClientView } from "../client-view";
+import { directionalFocusTarget, normalizeSharedLayout } from "../focus-mapping";
+
+function grid(count: number): SplitTree {
+	let tree = createSplitTree();
+	let last = "pane-1";
+	for (let index = 1; index < count; index++) {
+		tree = splitPane(tree, last, index % 2 === 1 ? "horizontal" : "vertical");
+		last = tree.activePaneId;
+	}
+	return normalizeSharedLayout(tree);
+}
+
+describe("shared layout normalization", () => {
+	it("parks focus on the first pane and clears zoom", () => {
+		const zoomed = zoomPane(splitPane(createSplitTree(), "pane-1", "horizontal"), "pane-2");
+		const shared = normalizeSharedLayout(zoomed);
+		expect(shared.activePaneId).toBe("pane-1");
+		expect(shared.zoomedPaneId).toBeNull();
+		expect(listPaneIds(shared)).toEqual(["pane-1", "pane-2"]);
+	});
+
+	it("returns the same reference when already normalized", () => {
+		const shared = grid(4);
+		expect(normalizeSharedLayout(shared)).toBe(shared);
+	});
+});
+
+describe("directional focus mapping", () => {
+	it("moves right and back left across a horizontal split", () => {
+		const tree = grid(2);
+		expect(directionalFocusTarget(tree, "pane-1", "right")).toBe("pane-2");
+		expect(directionalFocusTarget(tree, "pane-2", "left")).toBe("pane-1");
+	});
+
+	it("stays put when there is no pane that way", () => {
+		const tree = grid(2);
+		expect(directionalFocusTarget(tree, "pane-1", "left")).toBe("pane-1");
+		expect(directionalFocusTarget(tree, "pane-1", "up")).toBe("pane-1");
+	});
+
+	it("never mutates the shared tree, even across six panes", () => {
+		const tree = grid(6);
+		const snapshot = structuredClone(tree);
+		for (const paneId of listPaneIds(tree)) {
+			for (const direction of ["left", "right", "up", "down"] as const) {
+				expect(listPaneIds(tree)).toContain(directionalFocusTarget(tree, paneId, direction));
+			}
+		}
+		expect(tree).toEqual(snapshot);
+	});
+
+	it("falls back to the first pane for an unknown origin", () => {
+		expect(directionalFocusTarget(grid(3), "pane-99", "down")).toBe("pane-1");
+	});
+});
+
+describe("coordinator client views", () => {
+	it("keeps focus and zoom local to each view", () => {
+		const tree = grid(4);
+		const paneIds = listPaneIds(tree);
+		const viewA = new CoordinatorClientView("a", paneIds);
+		const viewB = new CoordinatorClientView("b", paneIds);
+
+		viewA.focusDirection(tree, "right");
+		viewA.toggleZoom();
+		expect(viewB.focusedPaneId).toBe(paneIds[0]);
+		expect(viewB.zoomedPaneId).toBeNull();
+		expect(viewA.zoomedPaneId).toBe(viewA.focusedPaneId);
+	});
+
+	it("reconciles a removed pane per view without touching the other", () => {
+		const tree = grid(3);
+		const paneIds = listPaneIds(tree);
+		const viewA = new CoordinatorClientView("a", paneIds);
+		const viewB = new CoordinatorClientView("b", paneIds);
+		viewA.focus(paneIds[2]!);
+		viewA.zoom(paneIds[2]!);
+
+		const remaining = paneIds.filter((id) => id !== paneIds[2]);
+		viewA.observe(remaining);
+		expect(viewA.zoomedPaneId).toBeNull();
+		expect(remaining).toContain(viewA.focusedPaneId);
+		expect(viewB.layout.paneIds).toEqual(paneIds);
+	});
+});

--- a/src/bun/native-terminal-multipane/__tests__/isolation.test.ts
+++ b/src/bun/native-terminal-multipane/__tests__/isolation.test.ts
@@ -1,0 +1,47 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve(fileURLToPath(new URL("../../../", import.meta.url))); // repo/src
+const moduleRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+function sourceFiles(directory: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...sourceFiles(path));
+		else if (/\.(?:ts|tsx)$/.test(entry.name)) files.push(path);
+	}
+	return files;
+}
+
+const moduleFiles = sourceFiles(moduleRoot);
+const moduleFilesNoTests = moduleFiles.filter((path) => !path.includes("__tests__"));
+
+describe("native multipane coordinator isolation", () => {
+	it("has no product callers — nothing outside the module imports it", () => {
+		// Sibling isolation tests may NAME this module in their allowlists; only a
+		// real import from product source would put it into the app graph.
+		const importsMultipane = /(?:from|import|require\s*\()\s*['"][^'"]*native-terminal-multipane/;
+		const importers = sourceFiles(sourceRoot)
+			.filter((path) => !path.startsWith(moduleRoot))
+			.filter((path) => importsMultipane.test(readFileSync(path, "utf8")));
+		expect(importers).toEqual([]);
+	});
+
+	it("never imports or spawns tmux (static sentinel over the module source)", () => {
+		const usesTmux = /(?:from|require\s*\()\s*['"][^'"]*tmux|['"`]tmux(?:\.exe|\.cmd)?['"`]/i;
+		expect(moduleFilesNoTests.filter((path) => usesTmux.test(readFileSync(path, "utf8")))).toEqual([]);
+	});
+
+	it("never touches the legacy tmux task records or the registry's own namespace root", () => {
+		const legacy = /tasks\.json|projects\.json|DEV3_NATIVE_SESSIONS_DIR/;
+		expect(moduleFilesNoTests.filter((path) => legacy.test(readFileSync(path, "utf8")))).toEqual([]);
+	});
+
+	it("keeps the client-local layout model free of PTY dimensions", () => {
+		const source = readFileSync(join(moduleRoot, "client-view.ts"), "utf8");
+		expect(/\bcols\b|\brows\b|resize/.test(source)).toBe(false);
+	});
+});

--- a/src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts
+++ b/src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env bun
+/**
+ * Real-runtime multi-pane coordinator proof (seq 1283).
+ *
+ * Creates 2 and then 6 REAL panes — each its own registry-owned host and shell —
+ * exercises split / directional focus / client-local zoom / writer-owned resize /
+ * close, detaches, reconnects from a genuinely FRESH controller process, and
+ * tears everything down. Never touches tmux (proved by a PATH shim sentinel).
+ */
+
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { listPaneIds } from "../../../shared/split-tree";
+import { isProcessAlive } from "../../native-terminal-registry/process-identity";
+import { readRecord } from "../../native-terminal-registry/record";
+import { defineShellLaunchSpec, type ShellLaunchSpec } from "../../native-terminal-registry/shell-launch";
+import { spawn } from "../../spawn";
+import { NativeMultipaneCoordinator, type PaneConnection, type PaneLaunchSpec } from "../coordinator";
+import { ObserverMutationError } from "../errors";
+import { directionalFocusTarget } from "../focus-mapping";
+import { NATIVE_MULTIPANE_DIR_ENV, coordinatorRecordFile, paneSessionId } from "../paths";
+import { readMultipaneRecord } from "../record";
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+const isWindows = process.platform === "win32";
+const lineEnd = isWindows ? "\r" : "\n";
+const COORDINATOR_ID = "mpe2e";
+
+function makeSink(connection: PaneConnection): { text: () => string; waitFor: (needle: string) => Promise<boolean> } {
+	let output = "";
+	const waiters: Array<{ needle: string; resolve: (matched: boolean) => void }> = [];
+	const decoder = new TextDecoder();
+	connection.onOutput((bytes) => {
+		output += decoder.decode(bytes, { stream: true });
+		for (let index = waiters.length - 1; index >= 0; index--) {
+			const waiter = waiters[index]!;
+			if (!output.includes(waiter.needle)) continue;
+			waiters.splice(index, 1);
+			waiter.resolve(true);
+		}
+	});
+	return {
+		text: () => output,
+		waitFor(needle) {
+			if (output.includes(needle)) return Promise.resolve(true);
+			return new Promise((resolve) => waiters.push({ needle, resolve }));
+		},
+	};
+}
+
+/** Poll `probe` until it yields a value, or give up and return null. */
+async function waitFor<T>(probe: () => T | null, timeoutMs = 5000): Promise<T | null> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const value = probe();
+		if (value !== null) return value;
+		if (Date.now() >= deadline) return null;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+}
+
+/** Echo the pane's own env marker plus the shell's real pid — proof of independence. */
+function identityCommand(): string {
+	if (isWindows) return 'Write-Output ("PANE-" + $env:DEV3_NATIVE_PANE_ID + "-" + $PID)';
+	return 'printf "PANE-%s-%s\\n" "$DEV3_NATIVE_PANE_ID" "$$"';
+}
+
+function launchSpec(root: string, paneId: string): PaneLaunchSpec {
+	const base: ShellLaunchSpec = isWindows
+		? { executable: "powershell.exe", argv: ["-NoLogo", "-NoProfile", "-NoExit"], cwd: root, env: {} }
+		: { executable: "/bin/bash", argv: ["--norc", "--noprofile"], cwd: root, env: {} };
+	return {
+		launch: defineShellLaunchSpec({ ...base, env: { ...base.env, DEV3_NATIVE_PANE_ID: paneId } }),
+		cols: 80,
+		rows: 24,
+		timeoutMs: 20_000,
+	};
+}
+
+async function growTo(
+	coordinator: NativeMultipaneCoordinator,
+	root: string,
+	target: number,
+): Promise<void> {
+	let last = coordinator.paneIds()[coordinator.paneIds().length - 1]!;
+	while (coordinator.paneIds().length < target) {
+		const index = coordinator.paneIds().length;
+		last = await coordinator.split(
+			last,
+			index % 2 === 1 ? "horizontal" : "vertical",
+			launchSpec(root, `pane-${index + 1}`),
+		);
+	}
+}
+
+function cliEntry(): string {
+	return fileURLToPath(new URL("../cli.ts", import.meta.url));
+}
+
+/** A genuinely fresh controller: a separate process that only reads disk state. */
+async function freshControllerList(): Promise<string> {
+	const proc = spawn([process.execPath, cliEntry(), "list", COORDINATOR_ID], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	await proc.exited;
+	if (proc.exitCode !== 0) throw new Error(`fresh controller failed: ${stderr || stdout}`);
+	return stdout;
+}
+
+async function run(): Promise<void> {
+	const root = mkdtempSync(join(tmpdir(), "dev3-multipane-e2e-"));
+	const shimDir = join(root, "shim");
+	const sentinel = join(root, "tmux-was-invoked");
+	mkdirSync(shimDir, { recursive: true });
+	const shim = join(shimDir, isWindows ? "tmux.cmd" : "tmux");
+	writeFileSync(
+		shim,
+		isWindows
+			? `@echo off\r\necho called>>"${sentinel}"\r\nexit /b 0\r\n`
+			: `#!/bin/sh\necho called >> "${sentinel}"\nexit 0\n`,
+	);
+	if (!isWindows) chmodSync(shim, 0o755);
+
+	process.env.DEV3_NATIVE_SESSIONS_DIR = join(root, "sessions");
+	process.env[NATIVE_MULTIPANE_DIR_ENV] = join(root, "multipane");
+	process.env.PATH = `${shimDir}${delimiter}${process.env.PATH ?? ""}`;
+
+	let coordinator: NativeMultipaneCoordinator | null = null;
+	try {
+		console.log("\n# two real panes");
+		coordinator = await NativeMultipaneCoordinator.create(COORDINATOR_ID, launchSpec(root, "pane-1"));
+		await growTo(coordinator, root, 2);
+		const twoPanes = await coordinator.listPanes();
+		check(twoPanes.length === 2, "two logical panes exist");
+		check(
+			new Set(twoPanes.map((pane) => pane.hostPid)).size === 2 &&
+				new Set(twoPanes.map((pane) => pane.shellPid)).size === 2,
+			"each logical pane owns its own host process and shell process",
+		);
+		check(
+			twoPanes.every((pane) => pane.state === "running" && isProcessAlive(pane.shellPid)),
+			"both pane shells are live and ownership-verified",
+		);
+		for (const pane of twoPanes) {
+			console.log(`  pane ${pane.paneId} session=${pane.sessionId} hostPid=${pane.hostPid} shellPid=${pane.shellPid}`);
+		}
+
+		const sinks = new Map<string, ReturnType<typeof makeSink>>();
+		for (const pane of twoPanes) {
+			const connection = await coordinator.connect(pane.paneId);
+			sinks.set(pane.paneId, makeSink(connection));
+			await coordinator.writePane(pane.paneId, `${identityCommand()}${lineEnd}`);
+		}
+		for (const pane of twoPanes) {
+			await sinks.get(pane.paneId)!.waitFor(`PANE-${pane.paneId}-`);
+		}
+		check(
+			twoPanes.every((pane) => sinks.get(pane.paneId)!.text().includes(`PANE-${pane.paneId}-${pane.shellPid}`)),
+			"each pane's shell reports its own env marker and its own pid",
+		);
+		check(
+			!sinks.get("pane-1")!.text().includes("PANE-pane-2-") && !sinks.get("pane-2")!.text().includes("PANE-pane-1-"),
+			"pane output streams never cross",
+		);
+
+		console.log("\n# client-local focus and zoom");
+		const viewA = coordinator.attachClient("view-a");
+		const viewB = coordinator.attachClient("view-b");
+		viewA.focus("pane-1");
+		viewA.focusDirection(coordinator.layout, "right");
+		viewA.toggleZoom();
+		check(viewA.focusedPaneId === "pane-2", "directional focus follows the shared geometry");
+		check(
+			viewB.focusedPaneId === "pane-1" && viewB.zoomedPaneId === null,
+			"the second client keeps its own focus and stays unzoomed",
+		);
+		check(
+			coordinator.layout.zoomedPaneId === null && coordinator.layout.activePaneId === "pane-1",
+			"client focus and zoom never leak into the shared layout",
+		);
+
+		console.log("\n# writer-owned resize vs observer");
+		await coordinator.resizePane("pane-1", 111, 41);
+		// The host republishes its record after applying the resize, so poll rather
+		// than assume the write already landed.
+		const resized = await waitFor(() => {
+			const record = readRecord(paneSessionId(COORDINATOR_ID, "pane-1"));
+			return record?.cols === 111 && record?.rows === 41 ? record : null;
+		});
+		check(resized !== null, "the writer resizes its pane's PTY");
+
+		const observerController = await NativeMultipaneCoordinator.recover(COORDINATOR_ID);
+		check(observerController !== null, "a second controller observes the same live pane set");
+		let observerRejected = false;
+		try {
+			await observerController!.resizePane("pane-1", 20, 5);
+		} catch (error) {
+			observerRejected = error instanceof ObserverMutationError;
+		}
+		const afterObserver = readRecord(paneSessionId(COORDINATOR_ID, "pane-1"));
+		check(observerRejected, "an observer attachment refuses to resize the PTY");
+		check(afterObserver?.cols === 111 && afterObserver?.rows === 41, "the observer left the PTY dimensions untouched");
+		check(
+			observerController!.paneIds().join(",") === coordinator.paneIds().join(","),
+			"both controllers observe the same shared pane membership",
+		);
+		observerController!.detach();
+
+		console.log("\n# detach and reconnect from a fresh controller process");
+		coordinator.detach();
+		const listing = await freshControllerList();
+		console.log(listing.trimEnd().split("\n").map((line) => `    ${line}`).join("\n"));
+		check(
+			twoPanes.every((pane) => listing.includes(`hostPid=${pane.hostPid}`) && listing.includes(`shellPid=${pane.shellPid}`)),
+			"a fresh controller process recovers the same host and shell pids",
+		);
+		check(
+			twoPanes.every((pane) => listing.includes(`${pane.paneId}\tsession=${pane.sessionId}`)),
+			"a fresh controller process recovers the same logical pane ids and bindings",
+		);
+		const afterReconnect = await coordinator.listPanes();
+		check(
+			JSON.stringify(afterReconnect) === JSON.stringify(twoPanes.map((p) => (p.paneId === "pane-1" ? { ...p, cols: 111, rows: 41 } : p))),
+			"reconnecting spawned nothing: identical panes, only the writer's resize applied",
+		);
+
+		console.log("\n# six real panes");
+		await growTo(coordinator, root, 6);
+		const sixPanes = await coordinator.listPanes();
+		check(sixPanes.length === 6, "six logical panes exist");
+		check(new Set(sixPanes.map((pane) => pane.shellPid)).size === 6, "all six panes own distinct shells");
+		check(
+			listPaneIds(coordinator.layout).join(",") === readMultipaneRecord(COORDINATOR_ID)?.panes.map((p) => p.paneId).join(","),
+			"the persisted record agrees with the in-memory layout",
+		);
+		const gridTargets = listPaneIds(coordinator.layout).map((paneId) => directionalFocusTarget(coordinator!.layout, paneId, "up"));
+		check(
+			gridTargets.every((target) => listPaneIds(coordinator!.layout).includes(target)),
+			"directional focus resolves inside the six-pane geometry",
+		);
+
+		console.log("\n# closing one pane");
+		const victim = sixPanes[2]!;
+		const survivors = sixPanes.filter((pane) => pane.paneId !== victim.paneId);
+		const closed = await coordinator.closePane(victim.paneId);
+		check(!closed.sessionTornDown && closed.remainingPaneIds.length === 5, "closing a pane leaves the session alive");
+		check(!isProcessAlive(victim.shellPid) && !isProcessAlive(victim.hostPid), "the closed pane's owned process tree is gone");
+		check(
+			survivors.every((pane) => isProcessAlive(pane.shellPid)),
+			"every other pane's process tree survives untouched",
+		);
+		check(
+			readMultipaneRecord(COORDINATOR_ID)?.panes.every((pane) => pane.paneId !== victim.paneId) === true,
+			"the persisted layout reconciles the closed pane away",
+		);
+
+		console.log("\n# cleanup");
+		const remaining = await coordinator.listPanes();
+		await coordinator.cleanup();
+		await coordinator.cleanup();
+		const deadline = Date.now() + 5000;
+		while (Date.now() < deadline && remaining.some((pane) => isProcessAlive(pane.shellPid))) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		check(
+			remaining.every((pane) => !isProcessAlive(pane.shellPid) && !isProcessAlive(pane.hostPid)),
+			"cleanup tears down every owned pane process tree",
+		);
+		check(!existsSync(coordinatorRecordFile(COORDINATOR_ID)), "cleanup removes the coordinator record");
+		check((await NativeMultipaneCoordinator.recover(COORDINATOR_ID)) === null, "repeated cleanup and recovery are safe");
+		check(!existsSync(sentinel), "the complete multi-pane lifecycle NEVER invokes tmux");
+	} finally {
+		try {
+			await coordinator?.cleanup();
+		} catch {
+			// best-effort cleanup
+		}
+		try {
+			rmSync(root, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+}
+
+run()
+	.then(() => {
+		if (failures > 0) {
+			console.error(`\n${failures} check(s) FAILED`);
+			process.exit(1);
+		}
+		console.log("\nALL CHECKS PASSED");
+		process.exit(0);
+	})
+	.catch((error) => {
+		console.error("\nERROR:", error);
+		process.exit(1);
+	});

--- a/src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts
+++ b/src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts
@@ -58,16 +58,6 @@ function makeSink(connection: PaneConnection): { text: () => string; waitFor: (n
 	};
 }
 
-/** Poll `probe` until it yields a value, or give up and return null. */
-async function waitFor<T>(probe: () => T | null, timeoutMs = 5000): Promise<T | null> {
-	const deadline = Date.now() + timeoutMs;
-	for (;;) {
-		const value = probe();
-		if (value !== null) return value;
-		if (Date.now() >= deadline) return null;
-		await new Promise((resolve) => setTimeout(resolve, 50));
-	}
-}
 
 /** Echo the pane's own env marker plus the shell's real pid — proof of independence. */
 function identityCommand(): string {
@@ -193,13 +183,11 @@ async function run(): Promise<void> {
 
 		console.log("\n# writer-owned resize vs observer");
 		await coordinator.resizePane("pane-1", 111, 41);
-		// The host republishes its record after applying the resize, so poll rather
-		// than assume the write already landed.
-		const resized = await waitFor(() => {
-			const record = readRecord(paneSessionId(COORDINATOR_ID, "pane-1"));
-			return record?.cols === 111 && record?.rows === 41 ? record : null;
-		});
-		check(resized !== null, "the writer resizes its pane's PTY");
+		const resized = readRecord(paneSessionId(COORDINATOR_ID, "pane-1"));
+		check(
+			resized?.cols === 111 && resized?.rows === 41,
+			"resizePane resolves only once the pane's record reports the new size",
+		);
 
 		const observerController = await NativeMultipaneCoordinator.recover(COORDINATOR_ID);
 		check(observerController !== null, "a second controller observes the same live pane set");

--- a/src/bun/native-terminal-multipane/__tests__/record.test.ts
+++ b/src/bun/native-terminal-multipane/__tests__/record.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createSplitTree, serializeSplitTree, splitPane } from "../../../shared/split-tree";
+import { isValidCoordinatorId, NATIVE_MULTIPANE_DIR_ENV, coordinatorRecordFile, paneSessionId } from "../paths";
+import {
+	listCoordinatorIds,
+	NATIVE_MULTIPANE_SCHEMA_VERSION,
+	parseMultipaneRecord,
+	readMultipaneRecord,
+	removeMultipaneRecord,
+	serializeMultipaneRecord,
+	writeMultipaneRecordAtomic,
+	type NativeMultipaneRecord,
+} from "../record";
+
+function twoPaneRecord(coordinatorId = "mp"): NativeMultipaneRecord {
+	const tree = splitPane(createSplitTree(), "pane-1", "horizontal");
+	return {
+		schemaVersion: NATIVE_MULTIPANE_SCHEMA_VERSION,
+		coordinatorId,
+		epoch: "2026-07-25T00:00:00.000Z",
+		updatedAt: "2026-07-25T00:00:01.000Z",
+		layout: serializeSplitTree({ ...tree, activePaneId: "pane-1", zoomedPaneId: null }),
+		panes: [
+			{ paneId: "pane-1", sessionId: paneSessionId(coordinatorId, "pane-1") },
+			{ paneId: "pane-2", sessionId: paneSessionId(coordinatorId, "pane-2") },
+		],
+	};
+}
+
+describe("native multipane coordinator ids", () => {
+	it("accepts short safe ids and rejects traversal or oversized ones", () => {
+		expect(isValidCoordinatorId("mp-demo_1.a")).toBe(true);
+		expect(isValidCoordinatorId("..")).toBe(false);
+		expect(isValidCoordinatorId("a/b")).toBe(false);
+		expect(isValidCoordinatorId("x".repeat(33))).toBe(false);
+	});
+
+	it("derives a valid registry session id per logical pane", () => {
+		expect(paneSessionId("mp", "pane-7")).toBe("mp-pane-7");
+	});
+});
+
+describe("native multipane record", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "dev3-multipane-record-"));
+		process.env[NATIVE_MULTIPANE_DIR_ENV] = root;
+	});
+
+	afterEach(() => {
+		delete process.env[NATIVE_MULTIPANE_DIR_ENV];
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("round-trips a valid record", () => {
+		const record = twoPaneRecord();
+		expect(parseMultipaneRecord(serializeMultipaneRecord(record))).toEqual(record);
+	});
+
+	it("rejects a record whose bindings disagree with its layout", () => {
+		const record = twoPaneRecord();
+		const mismatched = { ...record, panes: [record.panes[0]!] };
+		expect(parseMultipaneRecord(serializeMultipaneRecord(mismatched))).toBeNull();
+	});
+
+	it("rejects a foreign schema version instead of migrating it", () => {
+		const record = { ...twoPaneRecord(), schemaVersion: 2 };
+		expect(parseMultipaneRecord(JSON.stringify(record))).toBeNull();
+	});
+
+	it("rejects duplicate pane sessions and malformed json", () => {
+		const record = twoPaneRecord();
+		const duplicated = { ...record, panes: [record.panes[0]!, record.panes[0]!] };
+		expect(parseMultipaneRecord(JSON.stringify(duplicated))).toBeNull();
+		expect(parseMultipaneRecord("{oops")).toBeNull();
+	});
+
+	it("publishes atomically and leaves no temp file behind", () => {
+		const record = twoPaneRecord();
+		writeMultipaneRecordAtomic(record);
+		expect(readMultipaneRecord("mp")).toEqual(record);
+		expect(readFileSync(coordinatorRecordFile("mp"), "utf8")).toBe(serializeMultipaneRecord(record));
+		expect(existsSync(`${coordinatorRecordFile("mp")}.${process.pid}.tmp`)).toBe(false);
+	});
+
+	it("removes state only when the epoch still matches", () => {
+		const record = twoPaneRecord();
+		writeMultipaneRecordAtomic(record);
+		expect(removeMultipaneRecord("mp", "stale-epoch")).toBe(false);
+		expect(readMultipaneRecord("mp")).toEqual(record);
+		expect(removeMultipaneRecord("mp", record.epoch)).toBe(true);
+		expect(readMultipaneRecord("mp")).toBeNull();
+	});
+
+	it("treats removal of already-absent state as success", () => {
+		expect(removeMultipaneRecord("mp", "any")).toBe(true);
+		expect(removeMultipaneRecord("mp", "any")).toBe(true);
+	});
+
+	it("lists discoverable coordinator ids", () => {
+		writeMultipaneRecordAtomic(twoPaneRecord("beta"));
+		writeMultipaneRecordAtomic(twoPaneRecord("alpha"));
+		expect(listCoordinatorIds()).toEqual(["alpha", "beta"]);
+	});
+});

--- a/src/bun/native-terminal-multipane/cli.ts
+++ b/src/bun/native-terminal-multipane/cli.ts
@@ -1,0 +1,236 @@
+#!/usr/bin/env bun
+/**
+ * Manual driver for the native multi-pane coordinator (seq 1283).
+ * NOT wired into the production `dev3` CLI (src/cli/main.ts) — a dev-only harness.
+ *
+ * Every command runs in a FRESH process, so `list`/`split`/`close` after a
+ * `create` exercise the real fresh-controller recovery path: they rediscover the
+ * same logical session, pane ordering, host pids, and shell pids from disk
+ * without spawning or attaching twice.
+ *
+ *   bun src/bun/native-terminal-multipane/cli.ts create <id> [--panes N] [--cols N] [--rows N]
+ *   bun src/bun/native-terminal-multipane/cli.ts list <id>                       # reconnect + print
+ *   bun src/bun/native-terminal-multipane/cli.ts split <id> <paneId> [--vertical]
+ *   bun src/bun/native-terminal-multipane/cli.ts focus <id> <paneId> <left|right|up|down>
+ *   bun src/bun/native-terminal-multipane/cli.ts zoom <id> <paneId>
+ *   bun src/bun/native-terminal-multipane/cli.ts resize <id> <paneId> <cols> <rows>
+ *   bun src/bun/native-terminal-multipane/cli.ts write <id> <paneId> <text>
+ *   bun src/bun/native-terminal-multipane/cli.ts close <id> <paneId>
+ *   bun src/bun/native-terminal-multipane/cli.ts cleanup <id>
+ */
+
+import { getPaneRects, type SplitDirection, type SplitNode, type SplitOrientation, type SplitTree } from "../../shared/split-tree";
+import {
+	decodeShellLaunchSpec,
+	defaultNativeShellLaunchSpec,
+	defineShellLaunchSpec,
+	NATIVE_SESSION_LAUNCH_ENV,
+} from "../native-terminal-registry/shell-launch";
+import { NativeMultipaneCoordinator, type PaneLaunchSpec } from "./coordinator";
+
+function positionalArgs(): string[] {
+	return process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+}
+
+function hasFlag(flag: string): boolean {
+	return process.argv.includes(flag);
+}
+
+function flagValue(flag: string, fallback: number): number {
+	const index = process.argv.indexOf(flag);
+	if (index < 0) return fallback;
+	const parsed = Number(process.argv[index + 1]);
+	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function requireArg(index: number, name: string): string {
+	const value = positionalArgs()[index];
+	if (!value) {
+		process.stderr.write(`usage: cli.ts <command> <${name}>\n`);
+		process.exit(2);
+	}
+	return value;
+}
+
+/** A genuinely independent shell per pane: explicit executable/argv/cwd/env. */
+function paneLaunchSpec(paneId: string): PaneLaunchSpec {
+	const explicit = process.env[NATIVE_SESSION_LAUNCH_ENV];
+	const base = explicit
+		? decodeShellLaunchSpec(explicit)
+		: defaultNativeShellLaunchSpec({ platform: process.platform, cwd: process.cwd(), env: process.env });
+	return {
+		launch: defineShellLaunchSpec({ ...base, env: { ...base.env, DEV3_NATIVE_PANE_ID: paneId } }),
+		cols: flagValue("--cols", 80),
+		rows: flagValue("--rows", 24),
+	};
+}
+
+function renderNode(node: SplitNode, depth: number, out: string[]): void {
+	const indent = "  ".repeat(depth + 1);
+	if (node.type === "pane") {
+		out.push(`${indent}${node.id}`);
+		return;
+	}
+	out.push(`${indent}${node.id} ${node.orientation} ratio=${node.ratio.toFixed(2)}`);
+	renderNode(node.first, depth + 1, out);
+	renderNode(node.second, depth + 1, out);
+}
+
+function renderLayout(tree: SplitTree): string {
+	const out: string[] = ["layout:"];
+	renderNode(tree.root, 0, out);
+	const rects = getPaneRects(tree);
+	for (const [paneId, rect] of rects) {
+		out.push(
+			`  rect ${paneId}\tx=${rect.x.toFixed(3)}\ty=${rect.y.toFixed(3)}\tw=${rect.width.toFixed(3)}\th=${rect.height.toFixed(3)}`,
+		);
+	}
+	return `${out.join("\n")}\n`;
+}
+
+async function printCoordinator(coordinator: NativeMultipaneCoordinator): Promise<void> {
+	const panes = await coordinator.listPanes();
+	process.stdout.write(`coordinator=${coordinator.coordinatorId} panes=${panes.length} epoch=${coordinator.epoch}\n`);
+	for (const pane of panes) {
+		process.stdout.write(
+			`  ${pane.paneId}\tsession=${pane.sessionId}\thostPid=${pane.hostPid}\tshellPid=${pane.shellPid}\tsize=${pane.cols}x${pane.rows}\tstate=${pane.state}\n`,
+		);
+	}
+	process.stdout.write(renderLayout(coordinator.layout));
+}
+
+/** Fresh-controller recovery; every non-create command starts here. */
+async function requireCoordinator(coordinatorId: string): Promise<NativeMultipaneCoordinator> {
+	const coordinator = await NativeMultipaneCoordinator.recover(coordinatorId);
+	if (!coordinator) {
+		process.stderr.write(`no live native multipane coordinator ${coordinatorId} (run \`create ${coordinatorId}\` first)\n`);
+		process.exit(1);
+	}
+	return coordinator;
+}
+
+function orientation(): SplitOrientation {
+	return hasFlag("--vertical") ? "vertical" : "horizontal";
+}
+
+async function create(coordinatorId: string): Promise<void> {
+	const target = flagValue("--panes", 1);
+	const coordinator = await NativeMultipaneCoordinator.create(coordinatorId, paneLaunchSpec("pane-1"));
+	let lastPaneId = coordinator.paneIds()[0]!;
+	for (let index = 1; index < target; index++) {
+		// Alternate orientation off the newest pane: deterministic, and it produces
+		// a genuinely 2-dimensional layout for directional-focus checks.
+		const nextOrientation: SplitOrientation = index % 2 === 1 ? "horizontal" : "vertical";
+		lastPaneId = await coordinator.split(lastPaneId, nextOrientation, paneLaunchSpec(`pane-${index + 1}`));
+	}
+	await printCoordinator(coordinator);
+	coordinator.detach();
+}
+
+async function main(): Promise<void> {
+	const [command] = positionalArgs();
+	switch (command) {
+		case "create": {
+			await create(requireArg(1, "coordinatorId"));
+			process.exit(0);
+			break;
+		}
+		case "list": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			await printCoordinator(coordinator);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "split": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const paneId = requireArg(2, "paneId");
+			const created = await coordinator.split(paneId, orientation(), paneLaunchSpec("split"));
+			process.stdout.write(`split ${paneId} ${orientation()} -> ${created}\n`);
+			await printCoordinator(coordinator);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "focus": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const from = requireArg(2, "paneId");
+			const direction = requireArg(3, "direction") as SplitDirection;
+			// Focus is client-local: two views over the same shared layout stay independent.
+			const viewA = coordinator.attachClient("view-a");
+			const viewB = coordinator.attachClient("view-b");
+			viewA.focus(from);
+			viewA.focusDirection(coordinator.layout, direction);
+			process.stdout.write(
+				`view-a focus=${viewA.focusedPaneId} zoom=${viewA.zoomedPaneId}\nview-b focus=${viewB.focusedPaneId} zoom=${viewB.zoomedPaneId}\n`,
+			);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "zoom": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const paneId = requireArg(2, "paneId");
+			const viewA = coordinator.attachClient("view-a");
+			const viewB = coordinator.attachClient("view-b");
+			viewA.toggleZoom(paneId);
+			process.stdout.write(
+				`view-a zoom=${viewA.zoomedPaneId}\nview-b zoom=${viewB.zoomedPaneId}\nsharedZoom=${coordinator.layout.zoomedPaneId}\n`,
+			);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "resize": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const paneId = requireArg(2, "paneId");
+			await coordinator.resizePane(paneId, Number(requireArg(3, "cols")), Number(requireArg(4, "rows")));
+			await printCoordinator(coordinator);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "write": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const paneId = requireArg(2, "paneId");
+			await coordinator.writePane(paneId, `${requireArg(3, "text")}${process.platform === "win32" ? "\r" : "\n"}`);
+			process.stdout.write(`wrote to ${paneId}\n`);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "close": {
+			const coordinator = await requireCoordinator(requireArg(1, "coordinatorId"));
+			const result = await coordinator.closePane(requireArg(2, "paneId"));
+			process.stdout.write(
+				`closed ${result.closedPaneId} remaining=${result.remainingPaneIds.join(",") || "none"} sessionTornDown=${result.sessionTornDown}\n`,
+			);
+			if (!result.sessionTornDown) await printCoordinator(coordinator);
+			coordinator.detach();
+			process.exit(0);
+			break;
+		}
+		case "cleanup": {
+			const coordinatorId = requireArg(1, "coordinatorId");
+			const coordinator = await NativeMultipaneCoordinator.recover(coordinatorId);
+			if (!coordinator) {
+				process.stdout.write(`nothing to clean up for ${coordinatorId}\n`);
+				process.exit(0);
+			}
+			await coordinator.cleanup();
+			process.stdout.write(`cleaned up ${coordinatorId}\n`);
+			process.exit(0);
+			break;
+		}
+		default:
+			process.stdout.write(
+				"usage: cli.ts create|list|split|focus|zoom|resize|write|close|cleanup <coordinatorId> [...]\n",
+			);
+			process.exit(2);
+	}
+}
+
+void main().catch((err) => {
+	process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+	process.exit(1);
+});

--- a/src/bun/native-terminal-multipane/client-view.ts
+++ b/src/bun/native-terminal-multipane/client-view.ts
@@ -1,0 +1,75 @@
+/**
+ * One client's view of a coordinator (seq 1283).
+ *
+ * Holds the client-local overlays — focus and zoom — over the coordinator's
+ * shared pane set. Two views of the same coordinator stay independent: nothing
+ * here touches the shared layout, another view, or a PTY. Resizing a PTY is the
+ * writer's job and lives on the coordinator, deliberately not here.
+ */
+
+import {
+	createClientPaneLayout,
+	focusPane,
+	reconcileClientPaneLayout,
+	toggleZoom,
+	unzoomPane,
+	zoomPane,
+	type ClientPaneLayout,
+} from "../../shared/native-terminal-client-layout";
+import { directionalFocusTarget } from "./focus-mapping";
+import type { SplitDirection, SplitTree } from "../../shared/split-tree";
+
+export class CoordinatorClientView {
+	private state: ClientPaneLayout;
+
+	constructor(
+		readonly viewId: string,
+		sharedPaneIds: readonly string[],
+	) {
+		this.state = createClientPaneLayout(sharedPaneIds);
+	}
+
+	get layout(): ClientPaneLayout {
+		return this.state;
+	}
+
+	get focusedPaneId(): string | null {
+		return this.state.focusedPaneId;
+	}
+
+	get zoomedPaneId(): string | null {
+		return this.state.zoomedPaneId;
+	}
+
+	/** Fold a fresh observation of the shared pane set into this view. */
+	observe(sharedPaneIds: readonly string[]): ClientPaneLayout {
+		this.state = reconcileClientPaneLayout(this.state, sharedPaneIds);
+		return this.state;
+	}
+
+	focus(paneId: string): ClientPaneLayout {
+		this.state = focusPane(this.state, paneId);
+		return this.state;
+	}
+
+	/** Move focus through the shared geometry without writing back to it. */
+	focusDirection(tree: SplitTree, direction: SplitDirection): ClientPaneLayout {
+		if (this.state.focusedPaneId === null) return this.state;
+		return this.focus(directionalFocusTarget(tree, this.state.focusedPaneId, direction));
+	}
+
+	zoom(paneId: string | null = this.state.focusedPaneId): ClientPaneLayout {
+		this.state = zoomPane(this.state, paneId);
+		return this.state;
+	}
+
+	unzoom(): ClientPaneLayout {
+		this.state = unzoomPane(this.state);
+		return this.state;
+	}
+
+	toggleZoom(paneId: string | null = this.state.focusedPaneId): ClientPaneLayout {
+		this.state = toggleZoom(this.state, paneId);
+		return this.state;
+	}
+}

--- a/src/bun/native-terminal-multipane/coordinator.ts
+++ b/src/bun/native-terminal-multipane/coordinator.ts
@@ -26,7 +26,13 @@ import { readRecord, readToken, type NativeSessionRecord } from "../native-termi
 import { start, stop, type StartOptions, type StartResult } from "../native-terminal-registry/registry";
 import type { ShellLaunchSpec } from "../native-terminal-registry/shell-launch";
 import { CoordinatorClientView } from "./client-view";
-import { CoordinatorExistsError, CoordinatorGoneError, ObserverMutationError, PaneNotFoundError } from "./errors";
+import {
+	CoordinatorExistsError,
+	CoordinatorGoneError,
+	ObserverMutationError,
+	PaneNotFoundError,
+	PaneResizeNotAppliedError,
+} from "./errors";
 import { normalizeSharedLayout } from "./focus-mapping";
 import { coordinatorRecordFile, paneSessionId } from "./paths";
 import {
@@ -40,6 +46,7 @@ import {
 } from "./record";
 
 const RECORD_LOCK_TIMEOUT_MS = 30_000;
+const RESIZE_APPLY_TIMEOUT_MS = 5000;
 
 /** Everything a genuinely independent pane shell needs — no implicit inheritance. */
 export interface PaneLaunchSpec {
@@ -342,11 +349,25 @@ export class NativeMultipaneCoordinator {
 		return connection;
 	}
 
-	/** Writer-owned: an observer attachment is refused rather than silently ignored. */
-	async resizePane(paneId: string, cols: number, rows: number): Promise<void> {
+	/**
+	 * Writer-owned: an observer attachment is refused rather than silently
+	 * ignored. Resolves only once the pane's host has republished the new size,
+	 * so a caller that reads the record right after never sees the stale one.
+	 */
+	async resizePane(paneId: string, cols: number, rows: number, opts: { timeoutMs?: number } = {}): Promise<void> {
 		const connection = await this.connect(paneId);
 		if (connection.role() !== "writer") throw new ObserverMutationError(paneId, "resize");
 		connection.resize(cols, rows);
+		const sessionId = paneSessionId(this.coordinatorId, paneId);
+		const deadline = Date.now() + (opts.timeoutMs ?? RESIZE_APPLY_TIMEOUT_MS);
+		for (;;) {
+			const record = this.deps.readPaneRecord(sessionId);
+			if (record?.cols === cols && record.rows === rows) return;
+			if (Date.now() >= deadline) {
+				throw new PaneResizeNotAppliedError(paneId, cols, rows, record?.cols ?? -1, record?.rows ?? -1);
+			}
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
 	}
 
 	/** Writer-owned: observers may watch a pane but never type into it. */

--- a/src/bun/native-terminal-multipane/coordinator.ts
+++ b/src/bun/native-terminal-multipane/coordinator.ts
@@ -1,0 +1,411 @@
+/**
+ * The native multi-pane terminal session coordinator (seq 1283, LAY-003/004/005).
+ *
+ * COMPOSITION, NOT A NEW DAEMON: one logical pane === one existing
+ * registry-owned PTY host. The coordinator binds stable logical pane ids to
+ * those hosts, owns the shared `SplitTree`, and persists a minimal versioned
+ * record, so a fresh controller after an app-process restart rediscovers the
+ * same panes, hosts, and shells without spawning or attaching twice. Protocol v1
+ * stays a single-PTY contract (decision 169).
+ *
+ * THREE DISTINCT LAYERS, kept apart on purpose:
+ *  • shared    — pane membership + geometry (`SplitTree`), persisted here;
+ *  • per client— focus and zoom (`CoordinatorClientView`), never persisted;
+ *  • per PTY   — cols/rows, owned by whichever client the host made writer.
+ *
+ * Never inspects, attaches to, migrates, stops, or modifies a tmux session, and
+ * has no product caller: it is composed by its own harness and tests only.
+ */
+
+import { listPaneIds, restoreSplitTree, serializeSplitTree, splitPane, closePane as closeTreePane, createSplitTree, type SplitOrientation, type SplitTree } from "../../shared/split-tree";
+import { withFileLock } from "../file-lock";
+import { NativeSessionClient } from "../native-terminal-registry/client";
+import { classifyOwnership, type OwnershipVerdict } from "../native-terminal-registry/ownership";
+import type { ClientRole } from "../native-terminal-registry/writer-ownership";
+import { readRecord, readToken, type NativeSessionRecord } from "../native-terminal-registry/record";
+import { start, stop, type StartOptions, type StartResult } from "../native-terminal-registry/registry";
+import type { ShellLaunchSpec } from "../native-terminal-registry/shell-launch";
+import { CoordinatorClientView } from "./client-view";
+import { CoordinatorExistsError, CoordinatorGoneError, ObserverMutationError, PaneNotFoundError } from "./errors";
+import { normalizeSharedLayout } from "./focus-mapping";
+import { coordinatorRecordFile, paneSessionId } from "./paths";
+import {
+	NATIVE_MULTIPANE_SCHEMA_VERSION,
+	pruneCoordinatorDir,
+	readMultipaneRecord,
+	removeMultipaneRecord,
+	writeMultipaneRecordAtomic,
+	type MultipanePaneEntry,
+	type NativeMultipaneRecord,
+} from "./record";
+
+const RECORD_LOCK_TIMEOUT_MS = 30_000;
+
+/** Everything a genuinely independent pane shell needs — no implicit inheritance. */
+export interface PaneLaunchSpec {
+	launch: ShellLaunchSpec;
+	cols?: number;
+	rows?: number;
+	timeoutMs?: number;
+}
+
+export interface PaneSnapshot {
+	paneId: string;
+	sessionId: string;
+	hostPid: number;
+	shellPid: number;
+	cols: number;
+	rows: number;
+	state: "running" | "reused" | "dead";
+}
+
+export interface CloseResult {
+	closedPaneId: string;
+	remainingPaneIds: string[];
+	/** True when the closed pane was the last one and the logical session ended. */
+	sessionTornDown: boolean;
+}
+
+/** A live attachment to one pane's host, narrowed to what the coordinator needs. */
+export interface PaneConnection {
+	role(): ClientRole | null;
+	onOutput(cb: (bytes: Uint8Array) => void): () => void;
+	input(data: string | Uint8Array): void;
+	resize(cols: number, rows: number): void;
+	close(): void;
+}
+
+/** Injected effects, so the coordinator is unit-testable without real processes. */
+export interface CoordinatorDeps {
+	startPane(sessionId: string, opts: StartOptions): Promise<StartResult>;
+	stopPane(sessionId: string, opts?: { timeoutMs?: number }): Promise<boolean>;
+	readPaneRecord(sessionId: string): NativeSessionRecord | null;
+	readPaneToken(sessionId: string): string | null;
+	classifyPane(record: NativeSessionRecord, token: string | null): Promise<OwnershipVerdict>;
+	connectPane(record: NativeSessionRecord, token: string): Promise<PaneConnection>;
+}
+
+export const defaultCoordinatorDeps: CoordinatorDeps = {
+	startPane: (sessionId, opts) => start(sessionId, opts),
+	stopPane: (sessionId, opts) => stop(sessionId, opts ?? {}),
+	readPaneRecord: readRecord,
+	readPaneToken: readToken,
+	classifyPane: classifyOwnership,
+	async connectPane(record, token) {
+		const client = new NativeSessionClient();
+		await client.connect(record, token, { timeoutMs: 5000 });
+		return {
+			role: () => client.getRole(),
+			onOutput: (cb) => client.onOutput(cb),
+			input: (data) => client.input(data),
+			resize: (cols, rows) => client.resize(cols, rows),
+			close: () => client.close(),
+		};
+	},
+};
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function buildRecord(
+	coordinatorId: string,
+	epoch: string,
+	tree: SplitTree,
+	panes: MultipanePaneEntry[],
+): NativeMultipaneRecord {
+	return {
+		schemaVersion: NATIVE_MULTIPANE_SCHEMA_VERSION,
+		coordinatorId,
+		epoch,
+		updatedAt: nowIso(),
+		layout: serializeSplitTree(tree),
+		panes,
+	};
+}
+
+/** Bindings in shared layout order, so the record is self-consistent by construction. */
+function bindPanes(coordinatorId: string, tree: SplitTree): MultipanePaneEntry[] {
+	return listPaneIds(tree).map((paneId) => ({ paneId, sessionId: paneSessionId(coordinatorId, paneId) }));
+}
+
+export class NativeMultipaneCoordinator {
+	private tree: SplitTree;
+	private readonly connections = new Map<string, PaneConnection>();
+	private torndown = false;
+
+	private constructor(
+		readonly coordinatorId: string,
+		readonly epoch: string,
+		tree: SplitTree,
+		private readonly deps: CoordinatorDeps,
+	) {
+		this.tree = tree;
+	}
+
+	/**
+	 * Create a brand-new logical session with one pane. Refuses when a live
+	 * coordinator already holds the id, so a second controller can never
+	 * double-spawn over an existing pane set.
+	 */
+	static async create(
+		coordinatorId: string,
+		spec: PaneLaunchSpec,
+		deps: CoordinatorDeps = defaultCoordinatorDeps,
+	): Promise<NativeMultipaneCoordinator> {
+		return withFileLock(
+			coordinatorRecordFile(coordinatorId),
+			async () => {
+				const existing = readMultipaneRecord(coordinatorId);
+				if (existing) {
+					if (await hasLivePane(existing, deps)) throw new CoordinatorExistsError(coordinatorId);
+					await dropPanes(existing.panes, deps);
+					removeMultipaneRecord(coordinatorId, existing.epoch);
+				}
+				const tree = normalizeSharedLayout(createSplitTree());
+				const panes = bindPanes(coordinatorId, tree);
+				await deps.startPane(panes[0]!.sessionId, {
+					launch: spec.launch,
+					cols: spec.cols,
+					rows: spec.rows,
+					timeoutMs: spec.timeoutMs,
+				});
+				const epoch = nowIso();
+				writeMultipaneRecordAtomic(buildRecord(coordinatorId, epoch, tree, panes));
+				return new NativeMultipaneCoordinator(coordinatorId, epoch, tree, deps);
+			},
+			{ timeout: RECORD_LOCK_TIMEOUT_MS, staleThreshold: RECORD_LOCK_TIMEOUT_MS * 2 },
+		);
+	}
+
+	/**
+	 * Rediscover an existing logical session from disk — the fresh-controller
+	 * path after an app-process restart. Never spawns a shell. Panes whose host
+	 * no longer verifies as ours are reconciled out of the layout deterministically;
+	 * when none survive the coordinator is gone and null is returned.
+	 */
+	static async recover(
+		coordinatorId: string,
+		deps: CoordinatorDeps = defaultCoordinatorDeps,
+	): Promise<NativeMultipaneCoordinator | null> {
+		return withFileLock(
+			coordinatorRecordFile(coordinatorId),
+			async () => {
+				const record = readMultipaneRecord(coordinatorId);
+				if (!record) return null;
+				const tree = restoreSplitTree(record.layout);
+				if (!tree) return null;
+
+				const dead: MultipanePaneEntry[] = [];
+				for (const pane of record.panes) {
+					if (!(await isPaneOwned(pane.sessionId, deps))) dead.push(pane);
+				}
+				if (dead.length === 0) {
+					return new NativeMultipaneCoordinator(coordinatorId, record.epoch, tree, deps);
+				}
+				if (dead.length === record.panes.length) {
+					await dropPanes(record.panes, deps);
+					removeMultipaneRecord(coordinatorId, record.epoch);
+					return null;
+				}
+				let reconciled = tree;
+				for (const pane of dead) reconciled = closeTreePane(reconciled, pane.paneId);
+				reconciled = normalizeSharedLayout(reconciled);
+				await dropPanes(dead, deps);
+				writeMultipaneRecordAtomic(
+					buildRecord(coordinatorId, record.epoch, reconciled, bindPanes(coordinatorId, reconciled)),
+				);
+				return new NativeMultipaneCoordinator(coordinatorId, record.epoch, reconciled, deps);
+			},
+			{ timeout: RECORD_LOCK_TIMEOUT_MS, staleThreshold: RECORD_LOCK_TIMEOUT_MS * 2 },
+		);
+	}
+
+	/** The shared layout: membership + geometry, with no client overlay applied. */
+	get layout(): SplitTree {
+		return this.tree;
+	}
+
+	paneIds(): string[] {
+		return listPaneIds(this.tree);
+	}
+
+	sessionIdFor(paneId: string): string {
+		this.assertPane(paneId);
+		return paneSessionId(this.coordinatorId, paneId);
+	}
+
+	/** Per-pane host/shell identity, read from each pane's own registry record. */
+	async listPanes(): Promise<PaneSnapshot[]> {
+		const out: PaneSnapshot[] = [];
+		for (const paneId of this.paneIds()) {
+			const sessionId = paneSessionId(this.coordinatorId, paneId);
+			const record = this.deps.readPaneRecord(sessionId);
+			if (!record) {
+				out.push({ paneId, sessionId, hostPid: -1, shellPid: -1, cols: 0, rows: 0, state: "dead" });
+				continue;
+			}
+			const verdict = await this.deps.classifyPane(record, this.deps.readPaneToken(sessionId));
+			out.push({
+				paneId,
+				sessionId,
+				hostPid: record.host.pid,
+				shellPid: record.shell.pid,
+				cols: record.cols,
+				rows: record.rows,
+				state: verdict === "owned" ? "running" : verdict,
+			});
+		}
+		return out;
+	}
+
+	/**
+	 * Split a pane, spawning a genuinely independent shell with its own explicit
+	 * executable/argv/cwd/env behind a fresh stable logical pane id. The layout is
+	 * published only after the new host reports readiness, so a failed spawn
+	 * leaves the previous pane set intact.
+	 */
+	async split(paneId: string, orientation: SplitOrientation, spec: PaneLaunchSpec): Promise<string> {
+		this.assertPane(paneId);
+		return this.withOwnedRecord(async () => {
+			const nextTree = normalizeSharedLayout(splitPane(this.tree, paneId, orientation));
+			const created = listPaneIds(nextTree).find((id) => !listPaneIds(this.tree).includes(id));
+			if (!created) throw new PaneNotFoundError(paneId);
+			await this.deps.startPane(paneSessionId(this.coordinatorId, created), {
+				launch: spec.launch,
+				cols: spec.cols,
+				rows: spec.rows,
+				timeoutMs: spec.timeoutMs,
+			});
+			this.publish(nextTree);
+			return created;
+		});
+	}
+
+	/**
+	 * Close one pane: stop only its owned process tree, then reconcile the layout.
+	 * Closing the final pane tears the logical session down instead.
+	 */
+	async closePane(paneId: string): Promise<CloseResult> {
+		this.assertPane(paneId);
+		if (this.paneIds().length === 1) {
+			await this.cleanup();
+			return { closedPaneId: paneId, remainingPaneIds: [], sessionTornDown: true };
+		}
+		return this.withOwnedRecord(async () => {
+			this.dropConnection(paneId);
+			await this.deps.stopPane(paneSessionId(this.coordinatorId, paneId));
+			this.publish(normalizeSharedLayout(closeTreePane(this.tree, paneId)));
+			return { closedPaneId: paneId, remainingPaneIds: this.paneIds(), sessionTornDown: false };
+		});
+	}
+
+	/** Stop every owned pane tree and drop the record. Safe to call repeatedly. */
+	async cleanup(): Promise<void> {
+		if (this.torndown) return;
+		this.torndown = true;
+		for (const paneId of this.paneIds()) this.dropConnection(paneId);
+		for (const paneId of this.paneIds()) {
+			await this.deps.stopPane(paneSessionId(this.coordinatorId, paneId));
+		}
+		await withFileLock(
+			coordinatorRecordFile(this.coordinatorId),
+			async () => {
+				removeMultipaneRecord(this.coordinatorId, this.epoch);
+			},
+			{ timeout: RECORD_LOCK_TIMEOUT_MS, staleThreshold: RECORD_LOCK_TIMEOUT_MS * 2 },
+		);
+		pruneCoordinatorDir(this.coordinatorId); // only possible once the lock dir is gone
+	}
+
+	/** Detach this controller's attachments; every pane process keeps running. */
+	detach(): void {
+		for (const paneId of [...this.connections.keys()]) this.dropConnection(paneId);
+	}
+
+	/** A new client view over the current shared pane set (focus/zoom stay local). */
+	attachClient(viewId: string): CoordinatorClientView {
+		return new CoordinatorClientView(viewId, this.paneIds());
+	}
+
+	/** Attach to one pane's host, reusing this controller's existing attachment. */
+	async connect(paneId: string): Promise<PaneConnection> {
+		this.assertPane(paneId);
+		const cached = this.connections.get(paneId);
+		if (cached) return cached;
+		const sessionId = paneSessionId(this.coordinatorId, paneId);
+		const record = this.deps.readPaneRecord(sessionId);
+		const token = this.deps.readPaneToken(sessionId);
+		if (!record || !token) throw new PaneNotFoundError(paneId);
+		const connection = await this.deps.connectPane(record, token);
+		this.connections.set(paneId, connection);
+		return connection;
+	}
+
+	/** Writer-owned: an observer attachment is refused rather than silently ignored. */
+	async resizePane(paneId: string, cols: number, rows: number): Promise<void> {
+		const connection = await this.connect(paneId);
+		if (connection.role() !== "writer") throw new ObserverMutationError(paneId, "resize");
+		connection.resize(cols, rows);
+	}
+
+	/** Writer-owned: observers may watch a pane but never type into it. */
+	async writePane(paneId: string, data: string | Uint8Array): Promise<void> {
+		const connection = await this.connect(paneId);
+		if (connection.role() !== "writer") throw new ObserverMutationError(paneId, "input");
+		connection.input(data);
+	}
+
+	private assertPane(paneId: string): void {
+		if (!this.paneIds().includes(paneId)) throw new PaneNotFoundError(paneId);
+	}
+
+	private dropConnection(paneId: string): void {
+		const connection = this.connections.get(paneId);
+		if (!connection) return;
+		this.connections.delete(paneId);
+		try {
+			connection.close();
+		} catch {
+			// already closed — detaching must never fail a lifecycle operation
+		}
+	}
+
+	/** Serialise a layout mutation and verify we still own the record epoch. */
+	private async withOwnedRecord<T>(mutate: () => Promise<T>): Promise<T> {
+		return withFileLock(
+			coordinatorRecordFile(this.coordinatorId),
+			async () => {
+				const current = readMultipaneRecord(this.coordinatorId);
+				if (!current || current.epoch !== this.epoch) throw new CoordinatorGoneError(this.coordinatorId);
+				return mutate();
+			},
+			{ timeout: RECORD_LOCK_TIMEOUT_MS, staleThreshold: RECORD_LOCK_TIMEOUT_MS * 2 },
+		);
+	}
+
+	private publish(tree: SplitTree): void {
+		this.tree = tree;
+		writeMultipaneRecordAtomic(
+			buildRecord(this.coordinatorId, this.epoch, tree, bindPanes(this.coordinatorId, tree)),
+		);
+	}
+}
+
+async function isPaneOwned(sessionId: string, deps: CoordinatorDeps): Promise<boolean> {
+	const record = deps.readPaneRecord(sessionId);
+	if (!record) return false;
+	return (await deps.classifyPane(record, deps.readPaneToken(sessionId))) === "owned";
+}
+
+async function hasLivePane(record: NativeMultipaneRecord, deps: CoordinatorDeps): Promise<boolean> {
+	for (const pane of record.panes) {
+		if (await isPaneOwned(pane.sessionId, deps)) return true;
+	}
+	return false;
+}
+
+/** Release each pane's registry state through the registry's own ownership guard. */
+async function dropPanes(panes: readonly MultipanePaneEntry[], deps: CoordinatorDeps): Promise<void> {
+	for (const pane of panes) await deps.stopPane(pane.sessionId);
+}

--- a/src/bun/native-terminal-multipane/errors.ts
+++ b/src/bun/native-terminal-multipane/errors.ts
@@ -25,6 +25,21 @@ export class PaneNotFoundError extends Error {
 	}
 }
 
+/** The writer's resize never showed up in the pane's republished record. */
+export class PaneResizeNotAppliedError extends Error {
+	readonly code = "pane-resize-not-applied";
+	constructor(
+		readonly paneId: string,
+		requestedCols: number,
+		requestedRows: number,
+		actualCols: number,
+		actualRows: number,
+	) {
+		super(`pane ${paneId} still reports ${actualCols}x${actualRows} after resizing to ${requestedCols}x${requestedRows}`);
+		this.name = "PaneResizeNotAppliedError";
+	}
+}
+
 /** An observer client tried to write to or resize a PTY it does not own. */
 export class ObserverMutationError extends Error {
 	readonly code = "observer-mutation";

--- a/src/bun/native-terminal-multipane/errors.ts
+++ b/src/bun/native-terminal-multipane/errors.ts
@@ -1,0 +1,38 @@
+/** Typed failures of the native multi-pane coordinator (seq 1283). */
+
+export class CoordinatorExistsError extends Error {
+	readonly code = "coordinator-exists";
+	constructor(readonly coordinatorId: string) {
+		super(`native multipane coordinator ${coordinatorId} is already live — recover it instead of creating a second one`);
+		this.name = "CoordinatorExistsError";
+	}
+}
+
+/** The on-disk record was replaced (or removed) by another coordinator epoch. */
+export class CoordinatorGoneError extends Error {
+	readonly code = "coordinator-gone";
+	constructor(readonly coordinatorId: string) {
+		super(`native multipane coordinator ${coordinatorId} no longer owns its record`);
+		this.name = "CoordinatorGoneError";
+	}
+}
+
+export class PaneNotFoundError extends Error {
+	readonly code = "pane-not-found";
+	constructor(readonly paneId: string) {
+		super(`unknown logical pane ${paneId}`);
+		this.name = "PaneNotFoundError";
+	}
+}
+
+/** An observer client tried to write to or resize a PTY it does not own. */
+export class ObserverMutationError extends Error {
+	readonly code = "observer-mutation";
+	constructor(
+		readonly paneId: string,
+		readonly action: "input" | "resize",
+	) {
+		super(`pane ${paneId} is attached as observer — ${action} is writer-owned`);
+		this.name = "ObserverMutationError";
+	}
+}

--- a/src/bun/native-terminal-multipane/focus-mapping.ts
+++ b/src/bun/native-terminal-multipane/focus-mapping.ts
@@ -1,0 +1,50 @@
+/**
+ * The deliberate mapping between `SplitTree` focus semantics and the
+ * client-local focus/zoom model (seq 1283).
+ *
+ * `SplitTree` carries `activePaneId`/`zoomedPaneId` because it was written for a
+ * single renderer. In a multi-client coordinator those two fields are NOT shared
+ * state: focus and zoom belong to each client (see
+ * `shared/native-terminal-client-layout`). So the coordinator persists a
+ * NORMALIZED tree — membership, orientation, and ratios only — and asks the tree
+ * for directional focus by borrowing its geometry with the caller's own focus
+ * temporarily installed. Nothing here writes a client's focus back into the
+ * shared layout, and no function here carries a PTY dimension.
+ *
+ * Pure module: shared layout types only, no fs, no process, no PTY.
+ */
+
+import {
+	activatePane,
+	focusPane,
+	listPaneIds,
+	type SplitDirection,
+	type SplitTree,
+} from "../../shared/split-tree";
+
+/**
+ * Strip the client-local overlays from a tree before it becomes shared state:
+ * focus parks on the first pane (a `SplitTree` must always name one) and zoom
+ * clears. Two clients therefore load byte-identical shared layout.
+ */
+export function normalizeSharedLayout(tree: SplitTree): SplitTree {
+	const first = listPaneIds(tree)[0];
+	if (first === undefined) return tree;
+	if (tree.activePaneId === first && tree.zoomedPaneId === null) return tree;
+	return { ...tree, activePaneId: first, zoomedPaneId: null };
+}
+
+/**
+ * Where a client focused on `fromPaneId` lands when it moves `direction`,
+ * computed from the shared geometry. Returns `fromPaneId` when there is no pane
+ * that way. The input tree is never mutated.
+ */
+export function directionalFocusTarget(
+	tree: SplitTree,
+	fromPaneId: string,
+	direction: SplitDirection,
+): string {
+	const paneIds = listPaneIds(tree);
+	if (!paneIds.includes(fromPaneId)) return paneIds[0] ?? fromPaneId;
+	return focusPane(activatePane(tree, fromPaneId), direction).activePaneId;
+}

--- a/src/bun/native-terminal-multipane/index.ts
+++ b/src/bun/native-terminal-multipane/index.ts
@@ -21,6 +21,7 @@ export {
 	CoordinatorGoneError,
 	ObserverMutationError,
 	PaneNotFoundError,
+	PaneResizeNotAppliedError,
 } from "./errors";
 export { directionalFocusTarget, normalizeSharedLayout } from "./focus-mapping";
 export {

--- a/src/bun/native-terminal-multipane/index.ts
+++ b/src/bun/native-terminal-multipane/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Native multi-pane terminal session coordinator (seq 1283).
+ *
+ * Composes the existing persistent single-pane hosts into one logical
+ * multi-pane session. No product caller, no native opt-in — tmux remains the
+ * production default. See README.md and decision 169.
+ */
+
+export {
+	defaultCoordinatorDeps,
+	NativeMultipaneCoordinator,
+	type CloseResult,
+	type CoordinatorDeps,
+	type PaneConnection,
+	type PaneLaunchSpec,
+	type PaneSnapshot,
+} from "./coordinator";
+export { CoordinatorClientView } from "./client-view";
+export {
+	CoordinatorExistsError,
+	CoordinatorGoneError,
+	ObserverMutationError,
+	PaneNotFoundError,
+} from "./errors";
+export { directionalFocusTarget, normalizeSharedLayout } from "./focus-mapping";
+export {
+	assertValidCoordinatorId,
+	coordinatorDir,
+	coordinatorRecordFile,
+	isValidCoordinatorId,
+	multipaneRootDir,
+	NATIVE_MULTIPANE_DIR_ENV,
+	paneSessionId,
+} from "./paths";
+export {
+	listCoordinatorIds,
+	NATIVE_MULTIPANE_SCHEMA_VERSION,
+	parseMultipaneRecord,
+	readMultipaneRecord,
+	recordLayout,
+	removeMultipaneRecord,
+	serializeMultipaneRecord,
+	writeMultipaneRecordAtomic,
+	type MultipanePaneEntry,
+	type NativeMultipaneRecord,
+} from "./record";

--- a/src/bun/native-terminal-multipane/paths.ts
+++ b/src/bun/native-terminal-multipane/paths.ts
@@ -1,0 +1,64 @@
+/**
+ * On-disk namespace for the native multi-pane coordinator (seq 1283).
+ *
+ * ISOLATION: an ADDITIVE root `~/.dev3.0/native-multipane/`, overridable via
+ * DEV3_NATIVE_MULTIPANE_DIR. It is a sibling of — never inside — the registry's
+ * `native-sessions/` root, so a coordinator record can never be mistaken for a
+ * session record and neither namespace renames or deletes the other. Legacy
+ * tmux records are untouched (AGENTS.md on-disk invariants).
+ *
+ * Dependency-light on purpose: only node:path plus the registry's pure session
+ * id validator, so the path logic stays unit-testable under vitest.
+ */
+
+import { join } from "node:path";
+import { isValidSessionId } from "../native-terminal-registry/paths";
+
+export const NATIVE_MULTIPANE_DIR_ENV = "DEV3_NATIVE_MULTIPANE_DIR";
+
+/** Root of the coordinator namespace: env override, else `~/.dev3.0/native-multipane/`. */
+export function multipaneRootDir(): string {
+	const explicit = process.env[NATIVE_MULTIPANE_DIR_ENV];
+	if (explicit) return explicit;
+	const dev3Home =
+		process.env.DEV3_HOME || `${process.env.HOME || process.env.USERPROFILE || "/tmp"}/.dev3.0`;
+	return join(dev3Home, "native-multipane");
+}
+
+// Shorter than a session id: every derived pane session id is
+// `<coordinatorId>-<paneId>` and must still fit the registry's 64-char limit.
+const COORDINATOR_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/;
+
+export function isValidCoordinatorId(id: string): boolean {
+	return typeof id === "string" && COORDINATOR_ID_PATTERN.test(id) && !id.includes("..");
+}
+
+export function assertValidCoordinatorId(id: string): void {
+	if (!isValidCoordinatorId(id)) {
+		throw new Error(
+			`invalid native multipane coordinator id ${JSON.stringify(id)} — allowed: ${COORDINATOR_ID_PATTERN.source} and no "..".`,
+		);
+	}
+}
+
+export function coordinatorDir(id: string): string {
+	assertValidCoordinatorId(id);
+	return join(multipaneRootDir(), id);
+}
+
+export function coordinatorRecordFile(id: string): string {
+	return join(coordinatorDir(id), "coordinator.json");
+}
+
+/**
+ * The registry session id that backs one logical pane. Deterministic so a fresh
+ * controller can rediscover the same host from the layout alone.
+ */
+export function paneSessionId(coordinatorId: string, paneId: string): string {
+	assertValidCoordinatorId(coordinatorId);
+	const sessionId = `${coordinatorId}-${paneId}`;
+	if (!isValidSessionId(sessionId)) {
+		throw new Error(`pane ${JSON.stringify(paneId)} does not map to a valid native session id`);
+	}
+	return sessionId;
+}

--- a/src/bun/native-terminal-multipane/record.ts
+++ b/src/bun/native-terminal-multipane/record.ts
@@ -1,0 +1,171 @@
+/**
+ * Versioned coordinator/layout record for the native multi-pane coordinator
+ * (seq 1283).
+ *
+ * MINIMAL BY DESIGN: the record holds only what a fresh controller cannot
+ * rediscover on its own — the coordinator id, its epoch, the serialized shared
+ * `SplitTree`, and the logical-pane → registry-session binding. Everything else
+ * (host pid, shell pid, endpoint, ownership evidence, PTY size) already lives in
+ * the per-pane registry record and is read from there, never duplicated here.
+ *
+ * OWNERSHIP-SAFE WRITES: publication is tmp-write + rename, so a reader never
+ * sees a torn file, and removal is a compare-and-swap on `epoch` — a stale
+ * controller can never erase a coordinator that was torn down and recreated
+ * under the same id.
+ *
+ * COMPATIBILITY: parse returns null for anything whose schemaVersion is not
+ * exactly this build's — a newer record is unreadable-and-not-ours, never
+ * migrated in place.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { listPaneIds, restoreSplitTree, type SplitTree } from "../../shared/split-tree";
+import { isValidSessionId } from "../native-terminal-registry/paths";
+import { coordinatorDir, coordinatorRecordFile, isValidCoordinatorId, multipaneRootDir } from "./paths";
+
+export const NATIVE_MULTIPANE_SCHEMA_VERSION = 1 as const;
+
+/** One logical pane bound to exactly one registry-owned PTY host. */
+export interface MultipanePaneEntry {
+	paneId: string;
+	sessionId: string;
+}
+
+export interface NativeMultipaneRecord {
+	schemaVersion: typeof NATIVE_MULTIPANE_SCHEMA_VERSION;
+	coordinatorId: string;
+	/** Creation stamp; doubles as the compare-and-swap guard for writes/removal. */
+	epoch: string;
+	updatedAt: string;
+	/** Serialized shared SplitTree — membership and geometry, no client overlays. */
+	layout: string;
+	panes: MultipanePaneEntry[];
+}
+
+export function serializeMultipaneRecord(record: NativeMultipaneRecord): string {
+	return `${JSON.stringify(record, null, 2)}\n`;
+}
+
+function parsePanes(value: unknown): MultipanePaneEntry[] | null {
+	if (!Array.isArray(value) || value.length === 0) return null;
+	const panes: MultipanePaneEntry[] = [];
+	const sessionIds = new Set<string>();
+	for (const entry of value) {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+		const { paneId, sessionId } = entry as Record<string, unknown>;
+		if (typeof paneId !== "string" || paneId.length === 0) return null;
+		if (typeof sessionId !== "string" || !isValidSessionId(sessionId)) return null;
+		if (sessionIds.has(sessionId)) return null;
+		sessionIds.add(sessionId);
+		panes.push({ paneId, sessionId });
+	}
+	return panes;
+}
+
+/**
+ * Parse + strictly validate a record. The layout must restore to a valid
+ * SplitTree whose pane set is exactly the bound pane set, in the same order —
+ * a record that disagrees with itself is unreadable rather than half-adopted.
+ */
+export function parseMultipaneRecord(text: string): NativeMultipaneRecord | null {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+	const r = raw as Record<string, unknown>;
+	if (r.schemaVersion !== NATIVE_MULTIPANE_SCHEMA_VERSION) return null;
+	if (
+		typeof r.coordinatorId !== "string" ||
+		!isValidCoordinatorId(r.coordinatorId) ||
+		typeof r.epoch !== "string" ||
+		r.epoch.length === 0 ||
+		typeof r.updatedAt !== "string" ||
+		typeof r.layout !== "string"
+	) {
+		return null;
+	}
+	const tree = restoreSplitTree(r.layout);
+	if (!tree) return null;
+	const panes = parsePanes(r.panes);
+	if (!panes) return null;
+	const layoutPaneIds = listPaneIds(tree);
+	if (layoutPaneIds.length !== panes.length) return null;
+	if (layoutPaneIds.some((paneId, index) => panes[index]?.paneId !== paneId)) return null;
+	return {
+		schemaVersion: NATIVE_MULTIPANE_SCHEMA_VERSION,
+		coordinatorId: r.coordinatorId,
+		epoch: r.epoch,
+		updatedAt: r.updatedAt,
+		layout: r.layout,
+		panes,
+	};
+}
+
+export function readMultipaneRecord(coordinatorId: string): NativeMultipaneRecord | null {
+	try {
+		return parseMultipaneRecord(readFileSync(coordinatorRecordFile(coordinatorId), "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+/** The restored shared layout of a record; null when it is not this schema. */
+export function recordLayout(record: NativeMultipaneRecord): SplitTree | null {
+	return restoreSplitTree(record.layout);
+}
+
+/** Atomically publish a coordinator record (tmp write + rename). */
+export function writeMultipaneRecordAtomic(record: NativeMultipaneRecord): void {
+	const dir = coordinatorDir(record.coordinatorId);
+	mkdirSync(dir, { recursive: true, mode: 0o700 });
+	const target = coordinatorRecordFile(record.coordinatorId);
+	const tmp = `${target}.${process.pid}.tmp`;
+	writeFileSync(tmp, serializeMultipaneRecord(record), { mode: 0o600 });
+	renameSync(tmp, target);
+}
+
+/**
+ * Remove a coordinator record, but ONLY when its on-disk epoch still matches
+ * `expectedEpoch`. Returns false when the guard rejects the removal (the record
+ * belongs to a newer coordinator) and true when the state is gone — including
+ * when it was already gone, so repeated cleanup is safe.
+ */
+export function removeMultipaneRecord(coordinatorId: string, expectedEpoch: string): boolean {
+	const current = readMultipaneRecord(coordinatorId);
+	if (!current) {
+		pruneCoordinatorDir(coordinatorId);
+		return true;
+	}
+	if (current.epoch !== expectedEpoch) return false;
+	try {
+		unlinkSync(coordinatorRecordFile(coordinatorId));
+	} catch {
+		// concurrent removal — the post-condition (record gone) still holds
+	}
+	pruneCoordinatorDir(coordinatorId);
+	return !existsSync(coordinatorRecordFile(coordinatorId));
+}
+
+/** Drop the coordinator directory once it holds nothing (no-op while locked). */
+export function pruneCoordinatorDir(coordinatorId: string): void {
+	try {
+		rmdirSync(coordinatorDir(coordinatorId));
+	} catch {
+		// dir not empty (unknown siblings) or already gone — leave it
+	}
+}
+
+/** Every discoverable coordinator id, sorted; unreadable entries are skipped. */
+export function listCoordinatorIds(): string[] {
+	try {
+		return readdirSync(multipaneRootDir(), { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && isValidCoordinatorId(entry.name))
+			.map((entry) => entry.name)
+			.sort((a, b) => a.localeCompare(b));
+	} catch {
+		return [];
+	}
+}

--- a/src/bun/native-terminal-registry/__tests__/isolation.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/isolation.test.ts
@@ -25,11 +25,17 @@ const moduleFilesNoTests = moduleFiles.filter((path) => !path.includes("__tests_
 // registry into the app/CLI graph.
 const adapterRoot = resolve(sourceRoot, "bun/native-terminal-adapter");
 
+// The native multi-pane coordinator (seq 1283) is the second SANCTIONED
+// non-production consumer: it composes one registry-owned host per logical pane
+// and proves in its own isolation test that nothing imports it either.
+const multipaneRoot = resolve(sourceRoot, "bun/native-terminal-multipane");
+
 describe("native-session registry isolation", () => {
 	it("is absent from the production source import graph", () => {
 		const importers = sourceFiles(sourceRoot)
 			.filter((path) => !path.startsWith(moduleRoot))
 			.filter((path) => !path.startsWith(adapterRoot))
+			.filter((path) => !path.startsWith(multipaneRoot))
 			.filter((path) => readFileSync(path, "utf8").includes("native-terminal-registry"));
 		expect(importers).toEqual([]);
 	});


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

The native runtime slice of LAY-003 / LAY-004 / LAY-005 (seq 1283): a native multi-pane terminal session coordinator that composes the existing persistent single-pane hosts instead of turning protocol v1 into a multi-PTY daemon. One logical pane === one registry-owned host === one shell, addressed as `<coordinatorId>-<paneId>`.

Three layers stay deliberately distinct: pane membership and geometry are shared (`SplitTree`, normalized so its single-renderer `activePaneId`/`zoomedPaneId` never become shared state), focus and zoom are client-local (`CoordinatorClientView`), and cols/rows belong to the host's writer — an observer attachment is refused with `ObserverMutationError`.

State lives in a new additive namespace `~/.dev3.0/native-multipane/`, a sibling of the registry root; legacy tmux records are untouched. The record is minimal (schema version, id, epoch, serialized layout, pane-to-session bindings) with tmp+rename writes and compare-and-swap removal on `epoch`. Host/shell pids, endpoint, ownership evidence, and PTY size are read from each pane's own registry record rather than duplicated.

`recover()` is the fresh-controller path after an app-process restart: it never spawns and never double-attaches, reconciles dead panes out of the layout deterministically, and drops the record when none survive. Closing the last pane tears the logical session down; cleanup is idempotent. `resizePane()` resolves only once the pane host has republished the new size, so a caller that reads host state right after never sees the stale one.

Rationale in `decisions/169-one-host-per-pane-multipane-coordinator.md`. No product caller and no native opt-in — tmux remains the production default, enforced by an isolation test.

Validated with a real-process harness (`bun run test:native-multipane-e2e`, also wired into the native-Windows CI job): 2 and 6 real panes, independent shells, non-crossing output, client-local focus/zoom, writer-vs-observer resize, fresh-process reconnect to the same pids, single-pane close, full teardown, and a PATH shim sentinel proving tmux is never invoked. Passed on macOS and on native Windows with real PowerShell panes.