### PR TITLE
Open agent accounts settings from rate limit indicator

### DIFF
--- a/change-logs/2026/07/26/fix-rate-limit-accounts-settings.md
+++ b/change-logs/2026/07/26/fix-rate-limit-accounts-settings.md
@@ -1,0 +1,3 @@
+Short: Open accounts from usage
+
+Clicking the header agent rate-limit usage indicator now opens Global Settings → Accounts instead of only dismissing its usage tooltip.

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../rpc";
+import { OPEN_SETTINGS_SECTION_EVENT } from "../state";
 import { useT } from "../i18n";
 import Tooltip from "./Tooltip";
 import type { AgentRateLimitsReport } from "../../shared/rate-limits";
@@ -21,7 +22,7 @@ const MAX_PILL_BARS = 4;
 
 /**
  * Ambient agent rate-limit indicator (global header, stateful-indicators zone).
- * Passive "battery gauge" for the account-wide Claude/Codex limit windows so a
+ * "Battery gauge" for the account-wide Claude/Codex limit windows so a
  * dev running many parallel agents is never blindsided by hitting a limit.
  * Hidden until usable data exists; shows the most constrained window for the
  * most recently active account and treats unlimited credits as 0% used.
@@ -80,6 +81,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const ariaLabel = unlimited
 		? `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source} ${t("rateLimits.unlimited")}`
 		: `${t("rateLimits.tooltipTitle")}: ${SOURCE_NAMES[latestSnapshot.source] ?? latestSnapshot.source}${latestLabel ? ` ${latestLabel}` : ""} ${t("rateLimits.percentUsed", { percent })}${latestReset ? `, ${t("rateLimits.resetsIn", { time: latestReset })}` : ""}`;
+	const interactiveAriaLabel = `${ariaLabel}. ${t("rateLimits.openAccounts")}`;
 
 	const pillSnapshots = report.snapshots.slice(0, MAX_PILL_BARS);
 
@@ -88,6 +90,10 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 		: warn
 			? "text-warning bg-warning/15 border-warning/30"
 			: "text-fg-3 border-transparent";
+
+	const openAccountsSettings = () => {
+		window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_SECTION_EVENT, { detail: "accounts" }));
+	};
 
 	return (
 		<Tooltip
@@ -106,11 +112,11 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 				</div>
 			}
 		>
-			<div
-				role="status"
-				tabIndex={0}
-				aria-label={ariaLabel}
+			<button
+				type="button"
+				aria-label={interactiveAriaLabel}
 				data-help-id="header.rateLimits"
+				onClick={openAccountsSettings}
 				className={`header-anim flex cursor-pointer select-none items-center gap-1.5 px-1.5 py-1 rounded-lg border transition-colors ${colorClasses}`}
 			>
 				{/* One mini bar per recently active account, top-to-bottom in the
@@ -146,7 +152,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 						)}
 					</span>
 				)}
-			</div>
+			</button>
 		</Tooltip>
 	);
 }

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
+import { OPEN_SETTINGS_SECTION_EVENT } from "../../state";
 import RateLimitIndicator from "../RateLimitIndicator";
 import type { AgentRateLimitsReport } from "../../../shared/rate-limits";
 import type { AgentAccountsState } from "../../../shared/agent-accounts";
@@ -54,6 +55,10 @@ function renderIndicator() {
 	);
 }
 
+function getIndicator() {
+	return screen.getByRole("button", { name: /Agent rate limits/ });
+}
+
 beforeEach(() => {
 	mockedGet.mockReset();
 	mockedAccounts.mockReset();
@@ -65,7 +70,7 @@ describe("RateLimitIndicator", () => {
 		mockedGet.mockResolvedValue({ generatedAt: Date.now(), snapshots: [] });
 		const { container } = renderIndicator();
 		await act(async () => {});
-		expect(container.querySelector("[role='status']")).toBeNull();
+		expect(container.querySelector("button")).toBeNull();
 	});
 
 	it("shows the worst window percentage from the latest active account", async () => {
@@ -73,7 +78,7 @@ describe("RateLimitIndicator", () => {
 		renderIndicator();
 		await act(async () => {});
 		expect(screen.getByText("42%")).toBeTruthy();
-		expect(screen.getByRole("status").className).toContain("text-fg-3");
+		expect(getIndicator().className).toContain("text-fg-3");
 	});
 
 	it("compact mode keeps the mini bars but drops the percent text", async () => {
@@ -84,7 +89,7 @@ describe("RateLimitIndicator", () => {
 			</I18nProvider>,
 		);
 		await act(async () => {});
-		const pill = screen.getByRole("status");
+		const pill = getIndicator();
 		expect(pill.querySelector("[aria-hidden='true']")).toBeTruthy();
 		expect(screen.queryByText("42%")).toBeNull();
 	});
@@ -121,7 +126,7 @@ describe("RateLimitIndicator", () => {
 
 		expect(screen.getByText("29%")).toBeTruthy();
 		expect(screen.queryByText("100%")).toBeNull();
-		expect(screen.getByRole("status").className).toContain("text-fg-3");
+		expect(getIndicator().className).toContain("text-fg-3");
 	});
 
 	it("shows unlimited latest accounts as 0% used", async () => {
@@ -154,8 +159,8 @@ describe("RateLimitIndicator", () => {
 
 		expect(screen.getByText("∞ unlimited")).toBeTruthy();
 		expect(screen.queryByText("0%")).toBeNull();
-		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("Codex ∞ unlimited");
-		expect(screen.getByRole("status").className).toContain("text-fg-3");
+		expect(getIndicator().getAttribute("aria-label")).toContain("Codex ∞ unlimited");
+		expect(getIndicator().className).toContain("text-fg-3");
 	});
 
 	it("labels the header percentage as used so it is not ambiguous", async () => {
@@ -165,7 +170,23 @@ describe("RateLimitIndicator", () => {
 		// The number and the "used" qualifier sit in the same badge.
 		expect(screen.getByText("42%")).toBeTruthy();
 		expect(screen.getByText("used")).toBeTruthy();
-		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("42% used");
+		expect(getIndicator().getAttribute("aria-label")).toContain("42% used");
+	});
+
+	it("opens agent accounts settings when the usage indicator is clicked", async () => {
+		mockedGet.mockResolvedValue(report(42));
+		const onOpenSettings = vi.fn();
+		window.addEventListener(OPEN_SETTINGS_SECTION_EVENT, onOpenSettings);
+		try {
+			renderIndicator();
+			await act(async () => {});
+			await userEvent.click(getIndicator());
+
+			expect(onOpenSettings).toHaveBeenCalledTimes(1);
+			expect((onOpenSettings.mock.calls[0]?.[0] as CustomEvent).detail).toBe("accounts");
+		} finally {
+			window.removeEventListener(OPEN_SETTINGS_SECTION_EVENT, onOpenSettings);
+		}
 	});
 
 	it("spells out '<n>% used' on each Claude window row in the tooltip", async () => {
@@ -220,7 +241,7 @@ describe("RateLimitIndicator", () => {
 		mockedGet.mockResolvedValue(report(42));
 		renderIndicator();
 		await act(async () => {});
-		const pill = screen.getByRole("status");
+		const pill = getIndicator();
 		const fill = pill.querySelector('span[aria-hidden="true"] > span > span');
 		expect(fill).toBeTruthy();
 		expect((fill as HTMLElement).style.width).toBe("42%");
@@ -277,7 +298,7 @@ describe("RateLimitIndicator", () => {
 		});
 		renderIndicator();
 		await act(async () => {});
-		const pill = screen.getByRole("status");
+		const pill = getIndicator();
 		const fills = pill.querySelectorAll('span[aria-hidden="true"] > span > span');
 		expect(fills.length).toBe(3);
 		expect((fills[0] as HTMLElement).style.width).toBe("42%");
@@ -323,7 +344,7 @@ describe("RateLimitIndicator", () => {
 		});
 		renderIndicator();
 		await act(async () => {});
-		const pill = screen.getByRole("status");
+		const pill = getIndicator();
 		const fills = pill.querySelectorAll('span[aria-hidden="true"] > span > span');
 		expect(fills.length).toBe(4);
 		expect((fills[0] as HTMLElement).style.width).toBe("100%");
@@ -334,14 +355,14 @@ describe("RateLimitIndicator", () => {
 		mockedGet.mockResolvedValue(report(83));
 		renderIndicator();
 		await act(async () => {});
-		expect(screen.getByRole("status").className).toContain("text-warning");
+		expect(getIndicator().className).toContain("text-warning");
 	});
 
 	it("escalates to the danger token at ≥95%", async () => {
 		mockedGet.mockResolvedValue(report(97));
 		renderIndicator();
 		await act(async () => {});
-		expect(screen.getByRole("status").className).toContain("text-danger");
+		expect(getIndicator().className).toContain("text-danger");
 	});
 
 	it("updates from an agentRateLimitsUpdated push event", async () => {
@@ -358,7 +379,7 @@ describe("RateLimitIndicator", () => {
 		mockedGet.mockRejectedValue(new Error("no backend"));
 		const { container } = renderIndicator();
 		await act(async () => {});
-		expect(container.querySelector("[role='status']")).toBeNull();
+		expect(container.querySelector("button")).toBeNull();
 	});
 
 	it("shows a monthly-only Codex limit and its detailed credit usage", async () => {
@@ -379,7 +400,7 @@ describe("RateLimitIndicator", () => {
 		await act(async () => {});
 
 		expect(screen.getByText("97%")).toBeTruthy();
-		expect(screen.getByRole("status").getAttribute("aria-label")).toContain("monthly credits");
+		expect(getIndicator().getAttribute("aria-label")).toContain("monthly credits");
 		await userEvent.tab();
 		expect(await screen.findByText(/329.53 \/ 8,824/)).toBeTruthy();
 	});

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -106,6 +106,7 @@ const dashboard = {
 
 	// Ambient agent rate-limit indicator
 	"rateLimits.tooltipTitle": "Agent rate limits",
+	"rateLimits.openAccounts": "Open agent accounts settings",
 	"rateLimits.used": "used",
 	"rateLimits.percentUsed": "{percent}% used",
 	"rateLimits.resetsIn": "resets in {time}",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -106,6 +106,7 @@ const dashboard = {
 
 	// Ambient agent rate-limit indicator
 	"rateLimits.tooltipTitle": "Límites de agentes",
+	"rateLimits.openAccounts": "Abrir la configuración de cuentas de agentes",
 	"rateLimits.used": "usado",
 	"rateLimits.percentUsed": "{percent}% usado",
 	"rateLimits.resetsIn": "se restablece en {time}",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -114,6 +114,7 @@ const dashboard = {
 
 	// Ambient agent rate-limit indicator
 	"rateLimits.tooltipTitle": "Лимиты агентов",
+	"rateLimits.openAccounts": "Открыть настройки аккаунтов агентов",
 	"rateLimits.used": "использовано",
 	"rateLimits.percentUsed": "{percent}% использовано",
 	"rateLimits.resetsIn": "сброс через {time}",


### PR DESCRIPTION
## Summary

- Make the header rate-limit usage indicator a semantic button.
- Open Global Settings → Accounts when the indicator is clicked.
- Preserve the hover/focus usage details and add a localized accessible action label.

## Root cause

The indicator was a passive status element. The tooltip hid itself on mouse down, so clicking the usage control only dismissed the panel and offered no path to account management.

## Validation

- `bunx vitest run src/mainview/components/__tests__/RateLimitIndicator.test.tsx`
- `bunx vitest run src/mainview/components/__tests__/RateLimitIndicator.test.tsx src/mainview/__tests__/App.test.tsx`
- `bun run lint`
- Browser QA in streamer mode confirmed the click opens Global Settings → Accounts.