### PR TITLE
Fix tmux version skew blocking terminal launches

### DIFF
--- a/change-logs/2026/07/26/fix-tmux-version-skew-recovery.md
+++ b/change-logs/2026/07/26/fix-tmux-version-skew-recovery.md
@@ -1,0 +1,3 @@
+Short: Fix blocked terminal launches
+
+A tmux client/server version mismatch after an app update could block every new task and project terminal from starting until all tmux sessions were killed. dev3 now detects the mismatch at startup, reuses a compatible client found later in PATH when available, and gives the exact tmux Sessions → Kill All recovery when it is not.

--- a/decisions/172-probe-tmux-server-version.md
+++ b/decisions/172-probe-tmux-server-version.md
@@ -1,0 +1,23 @@
+# 172 — Probe the running tmux server version
+
+## Context
+
+After an app update, a tmux server can remain alive with sessions created by an older binary while dev3 selects the newly bundled client. In that state task launches can fail with `open terminal failed: not a terminal`, although non-interactive tmux commands still work.
+This supersedes the live-server probe assumption in decisions 105 and 137, while retaining their binary pinning and fallback strategy.
+
+## Investigation
+
+The incident log contained four launches whose PTY emitted exactly 38 bytes before exiting, matching `open terminal failed: not a terminal\r\n`.
+tmux issue #4356 documents that protocol version skew can preserve commands such as `list-sessions` while losing the terminal file descriptor required by an attached `new-session`; killing every session works because it also stops the old server.
+
+## Decision
+
+`selectTmuxBinary` compares the live server's `display-message -p '#{version}'` result with each candidate's `tmux -V`, instead of treating a successful `list-sessions` as compatibility. Startup scans every tmux candidate on `PATH`, including binaries after the dev3 shim, and falls back to an exact-version client when possible; otherwise task launch reports the existing tmux Sessions → Kill All recovery.
+
+## Risks
+
+Exact version matching is intentionally conservative: two different versions that happen to interoperate will not be mixed. If the server version cannot be read, the generic launch diagnostic remains the fallback rather than claiming a confirmed version mismatch.
+
+## Alternatives considered
+
+Automatically killing the server would destroy every live terminal and is not acceptable. Retrying `new-session`, raising the wait timeout, or probing only `list-sessions` cannot restore the missing terminal file descriptor and would hide the actual recovery.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5958,18 +5958,24 @@ describe("handlers.checkSystemRequirements", () => {
 	});
 
 	it("dereferences the PATH shim in fallback candidates (ELOOP regression)", async () => {
-		// Without the tmux@3.6 keg, whichSync returns our own ~/.dev3.0/bin/tmux
-		// shim (that dir is first in PATH) — it must never survive as a fallback
+		// Without the tmux@3.6 keg, PATH starts with our own ~/.dev3.0/bin/tmux
+		// shim — it must never survive as a fallback
 		// candidate, or the shim ends up symlinked onto itself.
+		const originalPath = process.env.PATH;
 		const SHIM = "/mock/dev3-home/bin/tmux";
+		process.env.PATH = "/mock/dev3-home/bin:/usr/bin";
 		mockSpawnSync.mockReturnValue({ exitCode: 0, stdout: new TextEncoder().encode(SHIM) });
 		vi.mocked(existsSync).mockImplementation((p) => String(p) === SHIM); // valid shim; vendored keg not installed
 
-		await handlers.checkSystemRequirements();
-		expect(tmux.dereferenceShim).toHaveBeenCalledWith(SHIM);
-		const fallbacks = vi.mocked(tmux.selectBinary).mock.calls[0][1] as string[];
-		expect(fallbacks).toContain("/opt/homebrew/bin/tmux");
-		expect(fallbacks).not.toContain(SHIM);
+		try {
+			await handlers.checkSystemRequirements();
+			expect(tmux.dereferenceShim).toHaveBeenCalledWith(SHIM);
+			const fallbacks = vi.mocked(tmux.selectBinary).mock.calls[0][1] as string[];
+			expect(fallbacks).toContain("/opt/homebrew/bin/tmux");
+			expect(fallbacks).not.toContain(SHIM);
+		} finally {
+			process.env.PATH = originalPath;
+		}
 	});
 
 	it("rejects a PATH tmux shim that resolves to a directory", async () => {
@@ -6059,6 +6065,36 @@ describe("resolveTmuxBinaryAtStartup", () => {
 		const chosen = await resolveTmuxBinaryAtStartup();
 		expect(chosen).toBe("/opt/homebrew/opt/tmux@3.6/bin/tmux");
 		expect(tmux.selectBinary).toHaveBeenCalled();
+	});
+
+	it("keeps tmux binaries after the dev3 PATH shim as live-server fallbacks", async () => {
+		const originalPath = process.env.PATH;
+		const shim = "/mock/dev3-home/bin/tmux";
+		const preferred = "/opt/homebrew/opt/tmux@3.6/bin/tmux";
+		const legacyPathTmux = "/opt/homebrew/bin/tmux";
+		const dereferenceMock = vi.mocked(tmux.dereferenceShim);
+		const originalDereference = dereferenceMock.getMockImplementation();
+		process.env.PATH = "/mock/dev3-home/bin:/opt/homebrew/bin:/usr/bin";
+		mockSpawnSync.mockReturnValue({ exitCode: 0, stdout: new TextEncoder().encode(`${shim}\n`) });
+		vi.mocked(existsSync).mockImplementation((path) => [shim, preferred, legacyPathTmux].includes(String(path)));
+		dereferenceMock.mockImplementation((path) => {
+			if (path === shim) return preferred;
+			if (path === preferred || path === legacyPathTmux) return path;
+			return undefined;
+		});
+
+		try {
+			const { resolveTmuxBinaryAtStartup } = await import("../rpc-handlers/settings-config");
+			await resolveTmuxBinaryAtStartup();
+
+			expect(tmux.selectBinary).toHaveBeenCalledWith(
+				preferred,
+				expect.arrayContaining([legacyPathTmux]),
+			);
+		} finally {
+			process.env.PATH = originalPath;
+			if (originalDereference) dereferenceMock.mockImplementation(originalDereference);
+		}
 	});
 
 	it("ignores a saved home-directory path instead of recreating the shim to it", async () => {
@@ -8487,6 +8523,31 @@ describe("launchTaskPty", () => {
 			await rejection;
 			expect(pty.tmuxSessionExists).toHaveBeenCalledTimes(10);
 		} finally {
+			vi.useRealTimers();
+			vi.mocked(pty.tmuxSessionExists).mockResolvedValue(true);
+		}
+	});
+
+	it("explains how to recover when the selected tmux cannot attach to the running server", async () => {
+		vi.useFakeTimers();
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(pty.tmuxSessionExists).mockResolvedValue(false);
+		const mismatchSpy = vi.spyOn(tmux, "serverVersionMismatch").mockReturnValue({
+			clientVersion: "3.6a",
+			serverVersion: "3.7a",
+		});
+
+		try {
+			const launch = launchTaskPty(project, task, "/tmp/wt", "builtin-claude", "claude-default");
+			const rejection = expect(launch).rejects.toThrow(
+				"tmux 3.6a cannot attach to the running tmux 3.7a server",
+			);
+			await vi.runAllTimersAsync();
+			await rejection;
+			await expect(launch).rejects.toThrow("choose Kill All, then retry");
+		} finally {
+			mismatchSpy.mockRestore();
 			vi.useRealTimers();
 			vi.mocked(pty.tmuxSessionExists).mockResolvedValue(true);
 		}

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -18,8 +18,7 @@ import { isFreshStartMode } from "../fresh-start";
 import { spawn } from "../spawn";
 import { setCurrentUiTheme } from "../theme-state";
 import { extractConfigFromParams, getPushMessage, getSystemRequirements, log, resolveBinaryPath, setFocusMode } from "./shared";
-import { hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
-import { whichSync } from "../which";
+import { binaryCandidatesOnPath, hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
 import { isExecutableFile } from "../executable";
 
 // `resolveOperationalProjectConfig` moved to ../repo-config (it depends only on
@@ -242,16 +241,13 @@ async function getAppVersion(): Promise<{ version: string; channel: string; buil
  * the server restarts.
  */
 async function commitTmuxBinary(preferred: string): Promise<string | undefined> {
-	let pathTmux: string | null = null;
-	try {
-		pathTmux = whichSync("tmux");
-	} catch {
-		log.debug("which tmux failed while building fallback candidates");
-	}
-	// whichSync may hand us our own PATH shim (~/.dev3.0/bin is first in
-	// PATH) — dereference it so we never probe or commit the shim itself.
-	const pathTmuxReal = pathTmux ? tmux.dereferenceShim(pathTmux) : undefined;
-	const fallbacks = [pathTmuxReal ?? "", ...tmuxSearchPaths()].filter(Boolean);
+	// The app's shim is first in PATH, but a compatible client for a server
+	// left by an older release may still exist later (for example Homebrew).
+	// Keep every executable candidate so version selection can find that client.
+	const pathCandidates = binaryCandidatesOnPath("tmux")
+		.map((candidate) => tmux.dereferenceShim(candidate))
+		.filter((candidate): candidate is string => Boolean(candidate));
+	const fallbacks = [...pathCandidates, ...tmuxSearchPaths()];
 	return tmux.selectBinary(preferred, fallbacks);
 }
 

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -10,7 +10,7 @@ import { createLogger } from "../logger";
 import { DEV3_HOME } from "../paths";
 import { broadcastToOtherInstances } from "../instance-broadcast";
 import { realpathSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { whichSync } from "../which";
 import { isExecutableFile } from "../executable";
 
@@ -163,6 +163,14 @@ function realExecDir(): string | undefined {
  */
 export function tmuxSearchPaths(): string[] {
 	return [...bundledTmuxCandidates(process.platform, realExecDir()), ...VENDORED_TMUX_PATHS];
+}
+
+export function binaryCandidatesOnPath(binaryName: string, path = process.env.PATH ?? ""): string[] {
+	const directories = path
+		.split(delimiter)
+		.map((directory) => directory.trim().replace(/^"|"$/g, ""))
+		.filter(Boolean);
+	return Array.from(new Set(directories.map((directory) => join(directory, binaryName))));
 }
 
 export function resolveBinaryPath(

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -58,6 +58,14 @@ async function waitForTaskTmuxSession(taskId: string, socket: string): Promise<v
 			await new Promise((resolve) => setTimeout(resolve, MAIN_AGENT_PANE_CAPTURE_INTERVAL_MS));
 		}
 	}
+	const mismatch = tmux.serverVersionMismatch();
+	if (mismatch) {
+		throw new Error(
+			`tmux ${mismatch.clientVersion} cannot attach to the running tmux ${mismatch.serverVersion} server, ` +
+			`so ${taskSessionName(taskId)} was not created. Open the tmux Sessions menu in the header, ` +
+			"choose Kill All, then retry.",
+		);
+	}
 	throw new Error(
 		`tmux started but did not create session ${taskSessionName(taskId)}. ` +
 			"Run `dev3 doctor` to verify the selected tmux binary, then retry.",

--- a/src/bun/tmux/__tests__/binary.test.ts
+++ b/src/bun/tmux/__tests__/binary.test.ts
@@ -52,6 +52,7 @@ import {
 	probeTmuxVersion,
 	TMUX_SHIM_PATH,
 	getTmuxBinary,
+	getTmuxServerVersionMismatch,
 	setTmuxBinary,
 } from "../binary";
 
@@ -110,7 +111,7 @@ describe("selectTmuxBinary", () => {
 		expect(chosen).toBe(PREFERRED);
 		expect(getTmuxBinary()).toBe(PREFERRED);
 		// One probe only — no fallback scanning when there is no server at all.
-		const probes = mockSpawn.mock.calls.filter((c) => (c[0] as string[]).includes("list-sessions"));
+		const probes = mockSpawn.mock.calls.filter((c) => (c[0] as string[]).includes("display-message"));
 		expect(probes).toHaveLength(1);
 	});
 
@@ -133,18 +134,60 @@ describe("selectTmuxBinary", () => {
 		expect(getTmuxBinary()).toBe(PATH_TMUX);
 	});
 
+	it("detects version skew when non-interactive server commands still succeed", async () => {
+		mockSpawn.mockImplementation(((args: string[]) => {
+			if (args[1] === "-V") {
+				return {
+					exited: Promise.resolve(0),
+					stderr: "",
+					stdout: args[0] === PREFERRED ? "tmux 3.6a\n" : "tmux 3.7a\n",
+				};
+			}
+			if (args.includes("display-message")) {
+				return { exited: Promise.resolve(0), stderr: "", stdout: "3.7a\n" };
+			}
+			// tmux/tmux#4356: list-sessions can still succeed across the protocol
+			// skew even though an attached client loses its terminal file descriptor.
+			return { exited: Promise.resolve(0), stderr: "", stdout: "" };
+		}) as any);
+
+		const chosen = await selectTmuxBinary(PREFERRED, [PATH_TMUX]);
+
+		expect(chosen).toBe(PATH_TMUX);
+		expect(getTmuxBinary()).toBe(PATH_TMUX);
+		expect(getTmuxServerVersionMismatch()).toBeNull();
+	});
+
+	it("records the server version when no compatible client remains", async () => {
+		mockSpawn.mockImplementation(((args: string[]) => {
+			if (args[1] === "-V") {
+				return { exited: Promise.resolve(0), stderr: "", stdout: "tmux 3.6a\n" };
+			}
+			return { exited: Promise.resolve(0), stderr: "", stdout: "3.7a\n" };
+		}) as any);
+
+		const chosen = await selectTmuxBinary(PREFERRED);
+
+		expect(chosen).toBe(PREFERRED);
+		expect(getTmuxServerVersionMismatch()).toEqual({
+			clientVersion: "3.6a",
+			serverVersion: "3.7a",
+		});
+	});
+
 	it("keeps the preferred binary when every candidate is incompatible", async () => {
 		mockVersionAndServer(1, "server exited unexpectedly");
 		const chosen = await selectTmuxBinary(PREFERRED, [PATH_TMUX, "/usr/local/bin/tmux"]);
 		expect(chosen).toBe(PREFERRED);
 		expect(getTmuxBinary()).toBe(PREFERRED);
+		expect(getTmuxServerVersionMismatch()).toBeNull();
 	});
 
 	it("skips fallback candidates that do not exist on disk", async () => {
 		mockVersionAndServer(1, "server exited unexpectedly");
 		mockExistsSync.mockImplementation((path) => path === PREFERRED);
 		await selectTmuxBinary(PREFERRED, [PATH_TMUX]);
-		const probes = mockSpawn.mock.calls.filter((c) => (c[0] as string[]).includes("list-sessions"));
+		const probes = mockSpawn.mock.calls.filter((c) => (c[0] as string[]).includes("display-message"));
 		expect(probes).toHaveLength(1); // only the preferred binary was probed
 	});
 

--- a/src/bun/tmux/binary.ts
+++ b/src/bun/tmux/binary.ts
@@ -31,24 +31,53 @@ export function getTmuxBinary(): string {
 	return tmuxBinary;
 }
 
-type TmuxServerProbe = "compatible" | "no-server" | "mismatch";
+type TmuxServerProbe = {
+	status: "compatible" | "no-server" | "mismatch";
+	serverVersion?: string;
+};
+
+export interface TmuxServerVersionMismatch {
+	clientVersion: string;
+	serverVersion: string;
+}
+
+let serverVersionMismatch: TmuxServerVersionMismatch | null = null;
+
+export function getTmuxServerVersionMismatch(): TmuxServerVersionMismatch | null {
+	return serverVersionMismatch;
+}
+
+function normalizeTmuxVersion(version: string): string {
+	return version.trim().replace(/^tmux\s+/, "");
+}
 
 /**
- * Check whether `binary` can talk to a server already running on `socket`.
- * tmux clients hard-fail against a server built from a different version
- * ("server exited unexpectedly"), so a cheap `list-sessions` distinguishes
- * three states: works, no server at all, or a version-mismatched server.
+ * Check whether `binary` matches a server already running on `socket`.
+ * Non-interactive commands may succeed across version skew while attached
+ * clients lose their terminal fd (tmux/tmux#4356), so compare the running
+ * server's `#{version}` with this binary instead of trusting list-sessions.
  */
-async function probeTmuxServer(binary: string, socket: string): Promise<TmuxServerProbe> {
+async function probeTmuxServer(binary: string, binaryVersion: string, socket: string): Promise<TmuxServerProbe> {
 	try {
-		const proc = spawn([binary, "-L", socket, "list-sessions"], { stdout: "pipe", stderr: "pipe" });
-		const stderr = await new Response(proc.stderr).text();
-		const exitCode = await proc.exited;
-		if (exitCode === 0) return "compatible";
-		if (stderr.includes("no server running") || stderr.includes("error connecting")) return "no-server";
-		return "mismatch";
+		const proc = spawn([binary, "-L", socket, "display-message", "-p", "#{version}"], { stdout: "pipe", stderr: "pipe" });
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		if (exitCode === 0) {
+			const serverVersion = normalizeTmuxVersion(stdout);
+			return {
+				status: serverVersion === normalizeTmuxVersion(binaryVersion) ? "compatible" : "mismatch",
+				...(serverVersion ? { serverVersion } : {}),
+			};
+		}
+		if (stderr.includes("no server running") || stderr.includes("error connecting")) {
+			return { status: "no-server" };
+		}
+		return { status: "mismatch" };
 	} catch {
-		return "mismatch";
+		return { status: "mismatch" };
 	}
 }
 
@@ -173,6 +202,7 @@ function isSymlink(path: string): boolean {
  * reboot, when no incompatible server is left running.
  */
 export async function selectTmuxBinary(preferred: string, fallbackCandidates: string[] = []): Promise<string | undefined> {
+	serverVersionMismatch = null;
 	// Never commit the PATH shim itself — dereference it to its real target
 	// (whichSync returns the shim because ~/.dev3.0/bin is first in PATH).
 	const preferredReal = dereferenceTmuxShim(preferred);
@@ -180,12 +210,13 @@ export async function selectTmuxBinary(preferred: string, fallbackCandidates: st
 		preferredReal,
 		...fallbackCandidates.filter((candidate) => candidate !== TMUX_SHIM_PATH),
 	].filter((candidate): candidate is string => Boolean(candidate))));
-	const validCandidates: string[] = [];
+	const validCandidates: Array<{ path: string; version: string }> = [];
 	for (const candidate of candidates) {
 		if (candidate.startsWith("/") && !isExecutableFile(candidate)) continue;
-		if (await probeTmuxVersion(candidate)) validCandidates.push(candidate);
+		const version = await probeTmuxVersion(candidate);
+		if (version) validCandidates.push({ path: candidate, version });
 	}
-	if (preferred === TMUX_SHIM_PATH && preferredReal && !validCandidates.includes(preferredReal) && isSymlink(TMUX_SHIM_PATH)) {
+	if (preferred === TMUX_SHIM_PATH && preferredReal && !validCandidates.some((candidate) => candidate.path === preferredReal) && isSymlink(TMUX_SHIM_PATH)) {
 		log.warn("tmux shim points to an executable that is not tmux — removing it", { shim: TMUX_SHIM_PATH, target: preferredReal });
 		try {
 			unlinkSync(TMUX_SHIM_PATH);
@@ -198,29 +229,39 @@ export async function selectTmuxBinary(preferred: string, fallbackCandidates: st
 		log.error("no executable tmux binary found", { preferred, fallbacks: fallbackCandidates });
 		return undefined;
 	}
-	const probe = await probeTmuxServer(chosen, DEFAULT_TMUX_SOCKET);
-	if (probe === "mismatch") {
+	const preferredProbe = await probeTmuxServer(chosen.path, chosen.version, DEFAULT_TMUX_SOCKET);
+	if (preferredProbe.status === "mismatch") {
 		for (const candidate of validCandidates) {
-			if (candidate === chosen) continue;
-			if ((await probeTmuxServer(candidate, DEFAULT_TMUX_SOCKET)) === "compatible") {
+			if (candidate.path === chosen.path) continue;
+			const candidateProbe = await probeTmuxServer(candidate.path, candidate.version, DEFAULT_TMUX_SOCKET);
+			if (candidateProbe.status === "compatible") {
 				log.warn("preferred tmux binary can't talk to the running dev3 server — falling back until the server restarts", {
-					preferred: chosen,
-					fallback: candidate,
+					preferred: chosen.path,
+					preferredVersion: normalizeTmuxVersion(chosen.version),
+					serverVersion: preferredProbe.serverVersion,
+					fallback: candidate.path,
+					fallbackVersion: normalizeTmuxVersion(candidate.version),
 				});
 				chosen = candidate;
 				break;
 			}
 		}
-		if (chosen === validCandidates[0]) {
+		if (chosen.path === validCandidates[0].path && preferredProbe.serverVersion) {
+			serverVersionMismatch = {
+				clientVersion: normalizeTmuxVersion(chosen.version),
+				serverVersion: preferredProbe.serverVersion,
+			};
 			log.warn("running dev3 tmux server is incompatible with every known tmux binary — a one-time `tmux -L dev3 kill-server` is required", {
-				preferred: chosen,
+				preferred: chosen.path,
+				clientVersion: serverVersionMismatch.clientVersion,
+				serverVersion: serverVersionMismatch.serverVersion,
 			});
 		}
 	}
-	setTmuxBinary(chosen);
-	updateTmuxShim(chosen);
-	await warnIfKnownBadTmux(chosen);
-	return chosen;
+	setTmuxBinary(chosen.path);
+	updateTmuxShim(chosen.path);
+	await warnIfKnownBadTmux(chosen.path);
+	return chosen.path;
 }
 
 // tmux 3.7 clients busy-spin on a congested server socket (10-35s UI freezes

--- a/src/bun/tmux/client.ts
+++ b/src/bun/tmux/client.ts
@@ -18,6 +18,7 @@ import { spawn as defaultSpawn } from "../spawn";
 import {
 	dereferenceTmuxShim,
 	getTmuxBinary,
+	getTmuxServerVersionMismatch,
 	probeTmuxVersion,
 	selectTmuxBinary,
 } from "./binary";
@@ -95,6 +96,11 @@ export class TmuxClient {
 	/** Resolve a candidate path that may be the dev3 PATH shim (see ./binary). */
 	dereferenceShim(binaryPath: string): string | undefined {
 		return dereferenceTmuxShim(binaryPath);
+	}
+
+	/** Version skew detected against the live server, when no compatible client was found. */
+	serverVersionMismatch(): { clientVersion: string; serverVersion: string } | null {
+		return getTmuxServerVersionMismatch();
 	}
 
 	// ── Core runner (private — no raw-args escape hatch) ──────────────


### PR DESCRIPTION
## Summary

- Prevent a stale tmux server from blocking every new task and project terminal after an app update changes the selected tmux client version.
- Compare the live server `#{version}` with each client `tmux -V` instead of treating a successful `list-sessions` call as protocol compatibility.
- Search the complete PATH, including binaries after the dev3 shim, for an exact-version fallback.
- When no compatible client remains, report both versions and direct the user to tmux Sessions → Kill All before retrying.

## Root cause

The incident produced four attached-client exits with a 38-byte first PTY chunk, matching `open terminal failed: not a terminal`. tmux protocol version skew can still allow non-interactive commands such as `list-sessions`, so the previous compatibility probe returned a false positive. Kill All worked because removing the final session stopped the stale server and allowed the selected client to start a matching replacement.

Upstream reference: https://github.com/tmux/tmux/issues/4356

## Verification

- `bun run lint`
- `bunx vitest run --config vitest.config.bun.ts src/bun/tmux/__tests__/binary.test.ts` — 29 passed
- `bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/rpc-handlers.test.ts` — 589 passed
- Isolated live tmux and non-excluded git timeout rerun — 9 passed
- `bun scripts/generate-changelog.ts`
