### PR TITLE
Fix clickable notification toasts swallowed by the swipe gesture

### DIFF
--- a/change-logs/2026/07/26/fix-clickable-toast-navigation.md
+++ b/change-logs/2026/07/26/fix-clickable-toast-navigation.md
@@ -1,0 +1,3 @@
+Short: Clickable toasts open their task again
+
+Clicking anywhere on a notification toast (shared image, shared artifact, agent notify) except its dismiss button opens the owning task and closes the toast — the swipe gesture no longer swallows the click. Pressing a toast also no longer leaves a stray blue focus ring around it.

--- a/decisions/172-toast-lazy-pointer-capture.md
+++ b/decisions/172-toast-lazy-pointer-capture.md
@@ -1,0 +1,44 @@
+# 172 — Capture the toast swipe pointer only after a drag starts
+
+## Context
+
+Clickable toasts (`toast.info(msg, { onClick })` — shared images, shared artifacts, agent
+notifications) stopped navigating anywhere: clicking the context line or the message did
+nothing, and the toast stayed on screen. The swipe-to-dismiss gesture (#1033) had taken
+pointer capture on `pointerdown` for the whole card.
+
+## Investigation
+
+Reproduced in headless Chromium against the dev-server build: a real mousedown/mouseup on
+the toast's inner button left the toast mounted and `onClick` unfired, while
+`document.activeElement` had become that button. An active pointer capture retargets the
+compatibility mouse events — and therefore the synthesized `click` — to the capturing
+element, so the click landed on the card `div` (no handler) instead of the nested button.
+The stray focus, a side effect of the retargeted mousedown, is what painted the blue
+`:focus-visible` ring the user saw around the toast body in WebKit.
+
+## Decision
+
+`ToastCard.updateSwipe` (`src/mainview/toast.tsx`) now calls `setPointerCapture` on the
+first pointer move past `SWIPE_DECIDE_PX` instead of on `pointerdown`. A tap therefore never
+captures and its click reaches the button normally; a real drag still captures and keeps
+tracking outside the card. Both toast buttons also `preventDefault()` on `mousedown` so a
+pointer press never focuses them — the keyboard focus ring stays reserved for Tab.
+
+The clickable target is the whole card, not just the text: the content is plain markup and
+the action lives in an `absolute inset-[3px]` overlay button (accessible name = the toast
+message) that sits under the dismiss button (`relative`, later in DOM order). The 3px inset
+keeps the focus ring inside the card's `overflow-hidden` box instead of clipping it.
+
+## Risks
+
+Between `pointerdown` and the threshold crossing the pointer is uncaptured, so a very fast
+fling that leaves the card before the first `pointermove` would lose the gesture. In
+practice the first move arrives within a few pixels. `releasePointerCapture` is now called
+for gestures that never captured — already inside a `try/catch`.
+
+## Alternatives considered
+
+Keeping capture and moving the click action to `pointerup` on the card: works, but duplicates
+activation logic and loses the button's native keyboard semantics. Suppressing the focus ring
+with a CSS override scoped to toasts: hides the symptom and breaks keyboard focus visibility.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -863,7 +863,7 @@ describe("App keyboard shortcuts", () => {
 			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "");
 
 			dispatchShowImage();
-			await userEvent.click(await screen.findByText("Agent shared an image"));
+			await userEvent.click(await screen.findByRole("button", { name: "Agent shared an image" }));
 
 			const view = screen.getByTestId("project-screen");
 			expect(view).toHaveAttribute("data-project-id", "p1");
@@ -880,7 +880,7 @@ describe("App keyboard shortcuts", () => {
 
 			await renderApp();
 			dispatchShowImage();
-			await userEvent.click(await screen.findByText("Agent shared an image"));
+			await userEvent.click(await screen.findByRole("button", { name: "Agent shared an image" }));
 
 			expect(await screen.findByTestId("task-screen")).toBeInTheDocument();
 			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -191,6 +191,52 @@ describe("toast service", () => {
 		expect(screen.getByText("Open task")).toBeInTheDocument();
 	});
 
+	it("captures the pointer only once a drag starts (a tap must stay clickable)", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Tap me", { onClick: vi.fn(), durationMs: 60_000 });
+		});
+
+		const card = toastCard() as HTMLElement;
+		const setPointerCapture = vi.fn();
+		Object.defineProperty(card, "setPointerCapture", { configurable: true, value: setPointerCapture });
+
+		act(() => {
+			fireEvent.pointerDown(card, { pointerId: 1, clientX: 0 });
+			fireEvent.pointerMove(card, { pointerId: 1, clientX: 4 });
+		});
+		expect(setPointerCapture).not.toHaveBeenCalled();
+
+		act(() => {
+			fireEvent.pointerMove(card, { pointerId: 1, clientX: 40 });
+		});
+		expect(setPointerCapture).toHaveBeenCalledOnce();
+	});
+
+	it("spreads a clickable toast's hit area over the whole card except the dismiss button", () => {
+		render(<ToastHost />);
+		act(() => {
+			toast.info("Whole box", { onClick: vi.fn(), durationMs: 60_000 });
+		});
+
+		const card = toastCard() as HTMLElement;
+		const overlay = within(card).getByRole("button", { name: "Whole box" });
+		expect(overlay.className).toContain("absolute");
+		expect(overlay.className).toContain("inset-[3px]");
+		expect(overlay.contains(within(card).getByRole("button", { name: "Dismiss" }))).toBe(false);
+	});
+
+	it("does not focus a clickable toast on pointer press (no stray focus ring)", async () => {
+		const user = userEvent.setup();
+		render(<ToastHost />);
+		act(() => {
+			toast.info("No ring", { onClick: vi.fn(), durationMs: 60_000 });
+		});
+		const button = within(screen.getByRole("alert")).getByRole("button", { name: "No ring" });
+		await user.pointer({ target: button, keys: "[MouseLeft>]" });
+		expect(document.activeElement).not.toBe(button);
+	});
+
 	it("still runs a clickable toast's action on a plain click (no drag)", async () => {
 		const user = userEvent.setup();
 		const onClick = vi.fn();

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -347,17 +347,22 @@ function ToastCard({ entry, paused, onDismiss, onInteraction }: ToastCardProps) 
 		draggedRef.current = false;
 		dragXRef.current = 0;
 		setDragging(true);
-		try {
-			e.currentTarget.setPointerCapture(e.pointerId);
-		} catch {
-			// Pointer capture is a best-effort enhancement (absent in happy-dom).
-		}
 	}
 
 	function updateSwipe(e: React.PointerEvent) {
 		if (pointerIdRef.current !== e.pointerId) return;
 		const dx = e.clientX - startXRef.current;
-		if (Math.abs(dx) > SWIPE_DECIDE_PX) draggedRef.current = true;
+		if (Math.abs(dx) > SWIPE_DECIDE_PX && !draggedRef.current) {
+			draggedRef.current = true;
+			// Capture only once a real drag starts: an active pointer capture retargets
+			// the follow-up `click` to the capturing card, so capturing on pointerdown
+			// killed every clickable toast's own button (decision 172).
+			try {
+				e.currentTarget.setPointerCapture(e.pointerId);
+			} catch {
+				// Best-effort enhancement (absent in happy-dom).
+			}
+		}
 		const next = dx > 0 ? dx : 0; // right-anchored toast: only follow rightward
 		dragXRef.current = next;
 		setDragX(next);
@@ -421,7 +426,7 @@ function ToastCard({ entry, paused, onDismiss, onInteraction }: ToastCardProps) 
 			<div
 				data-toast-card
 				data-dragging={dragging ? "true" : "false"}
-				className={`toast-swipe relative overflow-hidden bg-overlay border ${v.border} rounded-xl shadow-2xl w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3 p-4`}
+				className={`toast-swipe group relative overflow-hidden bg-overlay border ${v.border} rounded-xl shadow-2xl w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3 p-4`}
 				style={{ transform: `translateX(${dragX}px)`, opacity }}
 				onPointerDown={beginSwipe}
 				onPointerMove={updateSwipe}
@@ -434,46 +439,47 @@ function ToastCard({ entry, paused, onDismiss, onInteraction }: ToastCardProps) 
 				>
 					{v.icon}
 				</span>
-				{entry.onClick ? (
+				<div className="flex-1 min-w-0 pr-1">
+					{entry.context && (
+						<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
+							{entry.context}
+						</div>
+					)}
+					<div
+						className={`text-fg text-sm leading-relaxed break-words ${entry.onClick ? "group-hover:underline" : ""}`}
+					>
+						{entry.message}
+					</div>
+				</div>
+				{/* Whole-card hit area for a clickable toast, laid over the content so
+				    every pixel except the dismiss button activates it. Inset by 3px so
+				    the keyboard focus ring (2px outline, 2px offset) stays inside the
+				    card's `overflow-hidden` box instead of being clipped away. */}
+				{entry.onClick && (
 					<button
 						type="button"
+						// Pointer press must not focus the toast: WebKit then paints the
+						// keyboard focus ring around a toast nobody tabbed to.
+						onMouseDown={(event) => event.preventDefault()}
 						onClick={() => {
 							if (suppressIfDragged()) return;
 							entry.onClick?.();
 							onDismiss(entry.id);
 						}}
-						className="flex-1 min-w-0 text-left pr-1 cursor-pointer group"
-					>
-						{entry.context && (
-							<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-								{entry.context}
-							</div>
-						)}
-						<div className="text-fg text-sm leading-relaxed break-words group-hover:underline">
-							{entry.message}
-						</div>
-					</button>
-				) : (
-					<div className="flex-1 min-w-0 pr-1">
-						{entry.context && (
-							<div className="text-[0.6875rem] font-mono text-fg-muted truncate mb-0.5">
-								{entry.context}
-							</div>
-						)}
-						<div className="text-fg text-sm leading-relaxed break-words">
-							{entry.message}
-						</div>
-					</div>
+						aria-label={entry.message}
+						className="absolute inset-[3px] cursor-pointer rounded-[0.625rem]"
+					/>
 				)}
 				<button
 					type="button"
 					onPointerDown={(event) => event.stopPropagation()}
+					onMouseDown={(event) => event.preventDefault()}
 					onClick={() => {
 						if (suppressIfDragged()) return;
 						onDismiss(entry.id);
 					}}
 					aria-label="Dismiss"
-					className="text-fg-muted hover:text-fg transition-colors flex-shrink-0"
+					className="relative text-fg-muted hover:text-fg transition-colors flex-shrink-0"
 				>
 					<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
Clickable toasts (shared image, shared artifact, agent `notify`) did nothing when clicked: the swipe-to-dismiss gesture took pointer capture on `pointerdown`, and an active pointer capture retargets the follow-up `click` to the capturing card — so it never reached the nested action button. The stray focus from that retargeted `mousedown` is also what painted a blue `:focus-visible` ring around a toast nobody tabbed to.

- Capture the pointer lazily, on the first move past the 8px swipe threshold, so a tap stays a real click while a drag still tracks outside the card.
- Make the whole card the hit area: the content is plain markup and the action lives in an `absolute inset-[3px]` overlay button (accessible name = the toast message), with the dismiss button stacked above it. The 3px inset keeps the keyboard focus ring inside the card's `overflow-hidden` box.
- Both toast buttons `preventDefault()` on `mousedown`, so a pointer press never focuses them — the focus ring is reserved for Tab.

Verified in a real browser: clicking any empty part of the card (icon area, corners, padding) navigates and dismisses, the X only dismisses, a rightward drag still dismisses without navigating, and no ring appears after a mouse press. Details in `decisions/172-toast-lazy-pointer-capture.md`.