### PR TITLE
Make project breadcrumb look clickable

### DIFF
--- a/change-logs/2026/07/26/fix-project-name-link-color.md
+++ b/change-logs/2026/07/26/fix-project-name-link-color.md
@@ -1,0 +1,1 @@
+Make the clickable project breadcrumb use the existing accent link colors so its navigation affordance is visually clear without adding an underline.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -426,7 +426,7 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 								{seg.onClick ? (
 									<button
 										onClick={seg.onClick}
-										className="text-fg-3 hover:text-fg transition-colors truncate"
+										className="text-accent hover:text-accent-hover transition-colors truncate"
 									>
 										{seg.label}
 									</button>

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -211,6 +211,20 @@ describe("GlobalHeader — project switcher dropdown", () => {
 		});
 	});
 
+	it("styles the clickable project name as an accent link", () => {
+		const navigate = vi.fn();
+		renderHeader(
+			{ screen: "project", projectId: "p1", activeTaskId: "t1" },
+			[project1, project2],
+			navigate,
+			[{ id: "t1", seq: 1, title: "Task 1", status: "in-progress" } as Task],
+		);
+
+		const projectName = screen.getByRole("button", { name: "Project Alpha" });
+		expect(projectName).toHaveClass("text-accent", "hover:text-accent-hover");
+		expect(projectName).not.toHaveClass("text-fg-3");
+	});
+
 	it("project name is clickable in activity/task view with no task selected", async () => {
 		const user = userEvent.setup();
 		const navigate = vi.fn();


### PR DESCRIPTION
## Summary

- Style the clickable project breadcrumb with the existing accent link tokens.
- Keep the current-project breadcrumb neutral on its own Kanban board.
- Add regression coverage and a changelog entry.

## Validation

- `bunx vitest run src/mainview/components/__tests__/GlobalHeader.test.tsx` — 68 passed
- `bun run test` — mainview 3027 passed, Bun 3723 passed (1 skipped), CLI 616 passed
- `bun run lint`
- Browser QA in streamer mode confirmed the blue breadcrumb and navigation back to the project board; no page errors.