### PR TITLE
Rate-limit SGR mouse reports emitted by terminal scrolling

### DIFF
--- a/change-logs/2026/07/26/fix-wheel-mouse-report-flood.md
+++ b/change-logs/2026/07/26/fix-wheel-mouse-report-flood.md
@@ -1,0 +1,3 @@
+Short: No more scroll garbage in the prompt
+
+Scrolling fast through a long agent session no longer pastes fragments of mouse escape sequences (`<64;69;44M`) into the input box. Wheel reports are now rate-limited so a momentum flick cannot overrun the PTY's read window, and drag motion is reported once per cell instead of once per pixel.

--- a/decisions/175-pace-sgr-mouse-reports.md
+++ b/decisions/175-pace-sgr-mouse-reports.md
@@ -1,0 +1,60 @@
+# 175 — Pace SGR mouse reports so a fast scroll cannot overrun the PTY read window
+
+## Context
+
+Scrolling fast through a long Claude Code session periodically pasted garbage
+into its input box: `5;68;43M`, `<64;69;44M<64;69;44M`, `;25M` — fragments of
+SGR mouse reports, some whole, some missing their leading `ESC [ <`.
+
+`TerminalView`'s wheel handler emits one report (`\x1b[<65;col;row M`, ~12
+bytes) per accumulated scroll line, with no cap: a single momentum flick could
+produce dozens per event, several KB/s in total. Claude Code enables mouse
+tracking (`mouse_any_flag`/`mouse_all_flag`/`mouse_sgr_flag` all set on the
+pane), so tmux forwards the whole stream straight into its PTY instead of
+handling the wheel itself.
+
+## Investigation
+
+A raw-stdin chunk spy running inside tmux, fed bursts of 50/100/200/400 reports
+via `tmux send-keys -H`, showed the macOS PTY hands a reader **at most 1022
+bytes per read**. Bursts under that arrived intact; anything larger was sliced
+at an arbitrary byte offset, and the following chunks began mid-sequence —
+`5;10;18M<ESC>[…`, `10;13M<ESC>[…`, `;17M<ESC>[…` — byte-for-byte the shape of
+the reported garbage. Separate writes were *not* coalesced while the reader kept
+up; the slicing only appears once bytes pile up in the PTY buffer because the
+app is busy rendering.
+
+So the split itself is legitimate stream behaviour, and the literal-text paste
+is Claude Code failing to carry an unterminated escape prefix across stdin
+chunks. What dev3 controls is the volume that makes the split likely at all.
+
+## Decision
+
+`src/mainview/wheel-pacer.ts` — a token bucket (150 reports/s sustained, burst
+16) gates the wheel handler in `TerminalView.setupMouseTracking`. Excess lines
+are **dropped, not queued**, so an over-fast flick stops where the finger
+stopped instead of coasting. A flush is emitted as one `term.input()` write of
+repeated sequences (≤ ~192 bytes), and drag motion reports are deduplicated per
+cell rather than per pixel.
+
+At 1.8 KB/s the app would have to stop reading stdin for ~570 ms before 1022
+bytes accumulate, versus ~200 ms before.
+
+## Risks
+
+The cap is below the peak rate a trackpad flick could previously reach, so an
+extreme flick scrolls somewhat less far. 150 reports/s is still far faster than
+anything readable. The fix reduces the probability of the slice, it cannot
+eliminate it — an app that stalls long enough will still see a split chunk, and
+handling that correctly remains the TUI's job.
+
+## Alternatives considered
+
+- **Batch a whole flick into one write** — makes it worse: a single >1 KB write
+  is guaranteed to be sliced, while paced smaller writes usually are not.
+- **Throttle in `pty-server` instead** — the backend cannot see how far behind
+  the reader is either, and it would also delay unrelated keystrokes.
+- **Handle the wheel in tmux copy-mode instead of forwarding it** — breaks
+  scrolling inside every mouse-owning TUI (vim, less, htop, Claude Code).
+- **Leave it to Claude Code** — correct in principle, out of our control, and
+  the flood is worth trimming regardless.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -10,6 +10,7 @@ import type { TerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
 import { installTerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
 import { getEffectiveZoom, ZOOM_CHANGED_EVENT } from "./zoom";
 import { getScrollThreshold } from "./scroll-speed";
+import { createWheelPacer } from "./wheel-pacer";
 import { TERMINAL_KEYMAPS, getKeymapPreset, KEYMAP_CHANGED_EVENT } from "./terminal-keymaps";
 import { uploadDroppedFile } from "./utils/uploadDroppedFile";
 import { writeClipboardText } from "./utils/clipboard-write";
@@ -827,6 +828,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			let trackedButton = -1;
 			let mouseDownX = 0;
 			let mouseDownY = 0;
+			let lastDragCell = "";
 
 			function cellCoords(e: MouseEvent): [number, number] {
 				const rect = canvas.getBoundingClientRect();
@@ -858,9 +860,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 				col: number,
 				row: number,
 				press: boolean,
+				repeat = 1,
 			) {
 				term.input(
-					`\x1b[<${btn};${col};${row}${press ? "M" : "m"}`,
+					`\x1b[<${btn};${col};${row}${press ? "M" : "m"}`.repeat(repeat),
 					true,
 				);
 			}
@@ -886,6 +889,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 					mouseDownY = e.clientY;
 					mouseGestureDraggedRef.current = false;
 					const [col, row] = cellCoords(e);
+					lastDragCell = `${col};${row}`;
 					sgrMouse(e.button | altBit(e), col, row, true);
 					e.preventDefault();
 					e.stopPropagation();
@@ -918,7 +922,13 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 						mouseGestureDraggedRef.current = true;
 					}
 					const [col, row] = cellCoords(e);
-					sgrMouse((trackedButton | altBit(e)) + 32, col, row, true);
+					// One report per cell, not per pixel — a drag across the pane
+					// otherwise pumps ~100 redundant sequences/s into the PTY.
+					const cell = `${col};${row}`;
+					if (cell !== lastDragCell) {
+						lastDragCell = cell;
+						sgrMouse((trackedButton | altBit(e)) + 32, col, row, true);
+					}
 					e.stopPropagation();
 				} catch { /* disposed */ }
 			}
@@ -993,6 +1003,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			document.addEventListener("mouseup", onMouseUp);
 
 			let scrollAccumulator = 0;
+			const wheelPacer = createWheelPacer();
 
 			term.attachCustomWheelEventHandler((e: WheelEvent) => {
 				if (disposed) return false;
@@ -1009,10 +1020,14 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 						scrollAccumulator -= lines * threshold;
 						if (lines < 0) tmuxCopyModeMayBeActiveRef.current = true;
 						const code = lines < 0 ? 64 : 65;
-						const count = Math.abs(lines);
-						for (let i = 0; i < count; i++) {
-							sgrMouse(code, col, row, true);
-						}
+						// Paced and sent as one write — an unpaced flick overruns the
+						// PTY's 1022-byte read window and TUIs paste the sliced tail
+						// into their prompt (decision 175).
+						const allowed = wheelPacer.take(
+							Math.abs(lines),
+							performance.now(),
+						);
+						if (allowed > 0) sgrMouse(code, col, row, true, allowed);
 					}
 					return true;
 				} catch { return false; /* disposed */ }

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -791,6 +791,83 @@ describe("TerminalView – tmux copy-mode focus recovery", () => {
 	});
 });
 
+// ── Mouse-report flood control (decision 175) ─────────────────────────────────
+
+describe("TerminalView – mouse report pacing", () => {
+	afterEach(() => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(false);
+	});
+
+	const countReports = () =>
+		mockInput.mock.calls.reduce(
+			(sum, [data]) => sum + (String(data).match(/\x1b\[</g)?.length ?? 0),
+			0,
+		);
+
+	it("caps a single violent flick and keeps every write far below 1 KB", async () => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+		await renderAndSetup();
+		const wheelHandler = mockTermInstance.attachCustomWheelEventHandler.mock.calls[0]?.[0] as
+			| ((event: WheelEvent) => boolean)
+			| undefined;
+
+		mockInput.mockClear();
+		act(() => {
+			wheelHandler?.({ deltaY: 100_000, clientX: 20, clientY: 20 } as WheelEvent);
+		});
+
+		expect(countReports()).toBeLessThanOrEqual(16);
+		for (const [data] of mockInput.mock.calls) {
+			expect(String(data).length).toBeLessThan(1022);
+		}
+	});
+
+	it("drops sustained excess instead of queueing it", async () => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+		await renderAndSetup();
+		const wheelHandler = mockTermInstance.attachCustomWheelEventHandler.mock.calls[0]?.[0] as
+			| ((event: WheelEvent) => boolean)
+			| undefined;
+
+		mockInput.mockClear();
+		act(() => {
+			for (let i = 0; i < 50; i++) {
+				wheelHandler?.({ deltaY: 5_000, clientX: 20, clientY: 20 } as WheelEvent);
+			}
+		});
+
+		// 50 events × 5000px would be thousands of reports unpaced; the bucket
+		// only refills with elapsed time, and these all land in the same tick.
+		expect(countReports()).toBeLessThanOrEqual(20);
+	});
+
+	it("reports a drag once per cell, not once per pixel", async () => {
+		mockTermInstance.hasMouseTracking.mockReturnValue(true);
+		await renderAndSetup();
+		const canvasListeners = mockTermInstance.renderer.getCanvas().addEventListener.mock.calls;
+		const mouseDown = canvasListeners.find((call: unknown[]) => call[0] === "mousedown")?.[1] as (event: MouseEvent) => void;
+		const mouseMove = canvasListeners.find((call: unknown[]) => call[0] === "mousemove")?.[1] as (event: MouseEvent) => void;
+		const event = (x: number, y: number) => ({
+			button: 0,
+			clientX: x,
+			clientY: y,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		}) as unknown as MouseEvent;
+
+		act(() => {
+			mouseDown(event(20, 20));
+		});
+		mockInput.mockClear();
+		act(() => {
+			// charWidth is 8, so x 16–23 is one cell: only the jump to 33 counts.
+			for (const x of [17, 18, 19, 20, 21, 22, 23, 33]) mouseMove(event(x, 20));
+		});
+
+		expect(countReports()).toBe(1);
+	});
+});
+
 // ── Terminal disposal safety ──────────────────────────────────────────────────
 
 describe("TerminalView – disposal safety (no 'Terminal has been disposed' errors)", () => {

--- a/src/mainview/__tests__/wheel-pacer.test.ts
+++ b/src/mainview/__tests__/wheel-pacer.test.ts
@@ -1,0 +1,58 @@
+// Wheel-report pacer — keeps a fast flick from overrunning the PTY's
+// 1022-byte read window (decision 175).
+import { describe, expect, it } from "vitest";
+import {
+	createWheelPacer,
+	WHEEL_REPORT_BURST,
+	WHEEL_REPORTS_PER_SECOND,
+} from "../wheel-pacer";
+
+describe("createWheelPacer", () => {
+	it("passes a small scroll through untouched", () => {
+		const pacer = createWheelPacer();
+		expect(pacer.take(3, 0)).toBe(3);
+	});
+
+	it("caps a single flush at the burst size", () => {
+		const pacer = createWheelPacer();
+		expect(pacer.take(500, 0)).toBe(WHEEL_REPORT_BURST);
+	});
+
+	it("drops the excess instead of queueing it", () => {
+		const pacer = createWheelPacer();
+		pacer.take(500, 0);
+		// Same instant, bucket empty — nothing coasts on afterwards.
+		expect(pacer.take(500, 0)).toBe(0);
+	});
+
+	it("refills at the configured rate", () => {
+		const pacer = createWheelPacer(100, 16);
+		pacer.take(16, 0);
+		expect(pacer.take(16, 50)).toBe(5);
+		expect(pacer.take(16, 150)).toBe(10);
+	});
+
+	it("never refills beyond the burst ceiling", () => {
+		const pacer = createWheelPacer(100, 16);
+		pacer.take(16, 0);
+		expect(pacer.take(500, 10_000)).toBe(16);
+	});
+
+	it("keeps a one-second flood under the PTY read window", () => {
+		const pacer = createWheelPacer();
+		let sent = 0;
+		// 120 Hz trackpad flick asking for far more than it can get.
+		for (let ms = 0; ms <= 1000; ms += 8) sent += pacer.take(40, ms);
+		expect(sent).toBeLessThanOrEqual(WHEEL_REPORTS_PER_SECOND + WHEEL_REPORT_BURST);
+		// ~14 bytes per SGR report must stay well below 1022 bytes per read.
+		expect(sent * 14).toBeLessThan(3000);
+	});
+
+	it("ignores non-positive requests and time going backwards", () => {
+		const pacer = createWheelPacer();
+		expect(pacer.take(0, 100)).toBe(0);
+		expect(pacer.take(-5, 100)).toBe(0);
+		pacer.take(WHEEL_REPORT_BURST, 100);
+		expect(pacer.take(5, 50)).toBe(0);
+	});
+});

--- a/src/mainview/wheel-pacer.ts
+++ b/src/mainview/wheel-pacer.ts
@@ -1,0 +1,45 @@
+// ── Wheel-report pacer ──
+// A fast flick can accumulate dozens of scroll lines per wheel event, and the
+// wheel handler turns every line into its own SGR mouse report (~12 bytes).
+// Unpaced, that is several KB/s of escape sequences pushed into the pane's PTY.
+//
+// macOS hands a PTY reader at most 1022 bytes per read (measured). Once a
+// busy TUI lets that much pile up, the next read lands mid-sequence, and an
+// app that does not carry the unterminated prefix across chunks — Claude Code
+// among them — prints the orphaned tail into its input box as literal text.
+// See decision 175.
+//
+// A token bucket keeps the stream far below that ceiling. Excess lines are
+// dropped rather than queued: a scroll the app cannot keep up with should end
+// where the finger stopped, not keep coasting.
+
+/** Sustained reports per second (~1.8 KB/s of SGR mouse sequences). */
+export const WHEEL_REPORTS_PER_SECOND = 150;
+/** Ceiling on a single flush (~192 bytes) so one write never approaches 1 KB. */
+export const WHEEL_REPORT_BURST = 16;
+
+export interface WheelPacer {
+	/** How many of `requested` reports may be sent now; the rest are dropped. */
+	take(requested: number, now: number): number;
+}
+
+export function createWheelPacer(
+	ratePerSecond: number = WHEEL_REPORTS_PER_SECOND,
+	burst: number = WHEEL_REPORT_BURST,
+): WheelPacer {
+	let tokens = burst;
+	let lastRefill: number | null = null;
+
+	return {
+		take(requested, now) {
+			if (requested <= 0) return 0;
+			if (lastRefill !== null && now > lastRefill) {
+				tokens = Math.min(burst, tokens + ((now - lastRefill) / 1000) * ratePerSecond);
+			}
+			lastRefill = now;
+			const allowed = Math.min(requested, burst, Math.floor(tokens));
+			tokens -= allowed;
+			return allowed;
+		},
+	};
+}


### PR DESCRIPTION
Scrolling fast through a long Claude Code session periodically pasted fragments of SGR mouse reports into its input box — `5;68;43M`, `<64;69;44M<64;69;44M`, `;25M`.

**Root cause.** The wheel handler emitted one SGR report (~12 bytes) per accumulated scroll line with no cap, so a momentum flick pushed several KB/s into the pane's PTY. Claude Code enables mouse tracking (`mouse_any_flag`/`mouse_all_flag`/`mouse_sgr_flag` all set), so tmux forwards that stream straight through instead of handling the wheel itself. A raw-stdin chunk spy inside tmux, fed bursts of 50/100/200/400 reports, showed macOS hands a PTY reader at most 1022 bytes per read: bursts under that arrive intact, larger ones get sliced at an arbitrary offset and the next chunk starts mid-sequence (`5;10;18M<ESC>[…`, `10;13M<ESC>[…`) — byte-for-byte the reported garbage. Claude Code does not carry the unterminated prefix across stdin chunks, so the orphaned tail lands in its prompt as literal text.

**Fix.** A token bucket (`src/mainview/wheel-pacer.ts`, 150 reports/s sustained, burst 16) gates the wheel handler. Excess lines are dropped rather than queued, a flush goes out as one write of at most ~192 bytes, and drag motion is reported once per cell instead of once per pixel. Measured live in the running app: 20 wheel events of 5000px — ~4000 reports (≈44 KB) before — now produce 1 write, 16 reports, 176 bytes. Normal-speed scrolling passes through unchanged.

This lowers the probability of the slice; an app that stalls long enough will still see a split chunk, and handling that remains the TUI's job. Details in `decisions/175-pace-sgr-mouse-reports.md`.