### PR TITLE
Wrap cross-task agent messages in a dev3-ai-message envelope

### DIFF
--- a/change-logs/2026/07/26/feature-cross-task-message-envelope.md
+++ b/change-logs/2026/07/26/feature-cross-task-message-envelope.md
@@ -1,0 +1,3 @@
+Short: Cross-task agent messages are labeled
+
+`dev3 message --task seq:N` sent from inside another task's worktree now arrives wrapped in a `<dev3-ai-message>` envelope carrying the sender's seq, title and the exact reply command, so the receiving agent immediately knows the text came from another agent and where to answer. Scheduled messages keep their plain text in the queue and get wrapped at delivery.

--- a/decisions/177-cross-task-agent-message-envelope.md
+++ b/decisions/177-cross-task-agent-message-envelope.md
@@ -1,0 +1,46 @@
+# 177 — Cross-task agent messages carry a pseudo-XML envelope
+
+## Context
+
+`dev3 message --task seq:N "..."` types text straight into another task's agent
+pane. The receiver could not tell an agent-authored message from something the
+human typed, and had no address to answer at — replies went nowhere.
+
+## Decision
+
+When `dev3 message` runs inside a worktree, the CLI attaches its own task id as
+`sourceTaskId` (`src/cli/commands/message.ts`). The app resolves both ends
+(`resolveAgentMessageSource` in `src/bun/cli-socket-server.ts`); if the sender
+exists and differs from the target, delivery wraps the text via
+`wrapAgentMessage` (`src/shared/agent-message-envelope.ts`):
+
+```
+<dev3-ai-message>
+<from-task>seq:1310</from-task>
+<from-title>…</from-title>
+<reply-with>dev3 message --task seq:1310 "your reply"</reply-with>
+<message>
+…verbatim body…
+</message>
+</dev3-ai-message>
+```
+
+Wrapping happens at **delivery** time (`deliverToTarget` /
+`sendMessageImmediately` in `src/bun/scheduled-message-scheduler.ts`), so a
+scheduled message stores the plain text (`ScheduledMessage.source` holds the
+sender) and the card chip preview stays readable. Length validation also runs on
+the raw text, so the envelope cannot push a message over the cap.
+
+## Risks
+
+- A human running `dev3 message --task other` from inside a task terminal is
+  attributed to that task's agent — acceptable; the human sends from the UI.
+- The body is verbatim: a message containing `</message>` can confuse the
+  receiver. Only metadata tags are escaped; agents read prose, not a parser.
+
+## Alternatives considered
+
+- Wrap in the CLI: simplest, but the stored scheduled text and its UI preview
+  would show markup.
+- Wrap in the app without CLI help: the app cannot know which task the sending
+  process lives in — worktree context is a CLI-side fact.

--- a/src/bun/__tests__/agent-message-envelope.test.ts
+++ b/src/bun/__tests__/agent-message-envelope.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { wrapAgentMessage } from "../../shared/agent-message-envelope";
+
+describe("wrapAgentMessage", () => {
+	it("wraps the text with the sender seq and a reply command", () => {
+		const out = wrapAgentMessage("do the thing", { taskId: "t-1", seq: 1310, title: "Fix the parser" });
+		expect(out).toBe(
+			[
+				"<dev3-ai-message>",
+				"<from-task>seq:1310</from-task>",
+				"<from-title>Fix the parser</from-title>",
+				'<reply-with>dev3 message --task seq:1310 "your reply"</reply-with>',
+				"<message>",
+				"do the thing",
+				"</message>",
+				"</dev3-ai-message>",
+			].join("\n"),
+		);
+	});
+
+	it("keeps a multi-line body verbatim", () => {
+		const out = wrapAgentMessage("line 1\n\nline <2>", { taskId: "t-1", seq: 7 });
+		expect(out).toContain("<message>\nline 1\n\nline <2>\n</message>");
+		expect(out).not.toContain("<from-title>");
+	});
+
+	it("escapes markup in the sender title", () => {
+		const out = wrapAgentMessage("hi", { taskId: "t-1", seq: 9, title: "Fix <div> & span" });
+		expect(out).toContain("<from-title>Fix &lt;div&gt; &amp; span</from-title>");
+	});
+});

--- a/src/bun/__tests__/scheduled-message-scheduler.test.ts
+++ b/src/bun/__tests__/scheduled-message-scheduler.test.ts
@@ -245,6 +245,25 @@ describe("cancel / send-now / immediate", () => {
 		expect(sendPromptToAgentPane).toHaveBeenCalledWith("dev3-task-123", "dev3", "hello now", task.sessionState.panes);
 	});
 
+	it("sendMessageImmediately wraps a cross-task message in the envelope", async () => {
+		const task = makeTask();
+		await sendMessageImmediately(task as never, "hello now", null, { taskId: "other", seq: 7, title: "Sender" });
+		const text = vi.mocked(sendPromptToAgentPane).mock.calls[0]![2];
+		expect(text).toContain("<dev3-ai-message>");
+		expect(text).toContain("<from-task>seq:7</from-task>");
+		expect(text).toContain("hello now");
+	});
+
+	it("fireScheduledMessage wraps a queued cross-task message but stores it plain", async () => {
+		const message = makeMessage({ source: { taskId: "other", seq: 7 } });
+		const task = makeTask({ scheduledMessages: [message] });
+		mockUpdateTaskWith(task);
+		await fireScheduledMessage(project, task as never, message as never, { late: false });
+		const text = vi.mocked(sendPromptToAgentPane).mock.calls[0]![2];
+		expect(text).toContain("<from-task>seq:7</from-task>");
+		expect(message.text).toBe("check CI and continue");
+	});
+
 	it("sendMessageImmediately throws when nothing is live to deliver to", async () => {
 		vi.mocked(sendPromptToAgentPane).mockResolvedValue(false);
 		const task = makeTask();

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
-import type { CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
+import type { AgentMessageSource, CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
 import { isValidNotificationDurationMs, NOTIFICATION_MAX_DURATION_MS, NOTIFICATION_MIN_DURATION_MS } from "../shared/duration";
 import { socketMetaPathFor } from "../shared/socket-meta";
 import { isCliEndpointHandle } from "../shared/cli-endpoint";
@@ -173,6 +173,27 @@ async function resolveTaskFromParams(params: Record<string, unknown>): Promise<{
 	const found = await resolveTaskAcrossProjects(taskId);
 	if (!found) throw taskNotFoundError(taskId);
 	return found;
+}
+
+/**
+ * Turn the CLI's `sourceTaskId` (set when `dev3 message` ran inside a worktree)
+ * into the envelope metadata. Returns null for human-sent messages, an unknown
+ * sender, or a task messaging itself — those stay verbatim.
+ */
+async function resolveAgentMessageSource(
+	params: Record<string, unknown>,
+	targetTaskId: string,
+): Promise<AgentMessageSource | null> {
+	const sourceTaskId = typeof params.sourceTaskId === "string" ? params.sourceTaskId.trim() : "";
+	if (!sourceTaskId) return null;
+	let found: { project: Project; task: Task } | null = null;
+	try {
+		found = await resolveTaskAcrossProjects(sourceTaskId);
+	} catch {
+		return null; // ambiguous/broken sender ref — deliver the raw text instead
+	}
+	if (!found || found.task.id === targetTaskId) return null;
+	return { taskId: found.task.id, seq: found.task.seq, title: getTaskTitle(found.task) };
 }
 
 type Handler = (params: Record<string, unknown>) => Promise<unknown>;
@@ -1076,7 +1097,8 @@ const handlers: Record<string, Handler> = {
 	"message.send": async (params) => {
 		const { project, task } = await resolveTaskFromParams(params);
 		const text = ((params.text as string) ?? "").toString();
-		await sendMessageImmediately(task, text);
+		const source = await resolveAgentMessageSource(params, task.id);
+		await sendMessageImmediately(task, text, null, source);
 		return { delivered: true, taskId: task.id, projectId: project.id };
 	},
 
@@ -1086,7 +1108,8 @@ const handlers: Record<string, Handler> = {
 		const { project, task } = await resolveTaskFromParams(params);
 		const text = ((params.text as string) ?? "").toString();
 		const at = (params.at as string) ?? "";
-		const updated = await scheduleMessageCore(project, task, { text, at });
+		const source = await resolveAgentMessageSource(params, task.id);
+		const updated = await scheduleMessageCore(project, task, { text, at, source });
 		return { taskId: task.id, projectId: project.id, at, pending: (updated.scheduledMessages ?? []).length };
 	},
 

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -1,4 +1,5 @@
 import {
+	type AgentMessageSource,
 	type Project,
 	type Task,
 	type TaskStatus,
@@ -11,6 +12,7 @@ import {
 import * as data from "./data";
 import { DEFAULT_TMUX_SOCKET, taskSessionName } from "./tmux";
 import { sendPromptToAgentPane, sendPromptToPane } from "./agent-prompt";
+import { wrapAgentMessage } from "../shared/agent-message-envelope";
 // Import push via the barrel (not ./rpc-handlers/shared) so tests that mock
 // `../rpc-handlers` — e.g. the cli-socket lost-update race suites, which reach
 // this module through cli-socket-server — don't load the real Electrobun-backed
@@ -58,10 +60,13 @@ function messagePreview(text: string): string {
 async function deliverToTarget(task: Task, message: ScheduledMessage): Promise<boolean> {
 	const tmuxSession = taskSessionName(task.id);
 	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
+	// Agent-to-agent traffic is wrapped at delivery time, so the queue (and the
+	// card chip that previews it) keeps the plain text the sender wrote.
+	const text = message.source ? wrapAgentMessage(message.text, message.source) : message.text;
 	if (message.target.kind === "pane") {
-		return sendPromptToPane(tmuxSession, socket, message.target.paneId, message.text);
+		return sendPromptToPane(tmuxSession, socket, message.target.paneId, text);
 	}
-	return sendPromptToAgentPane(tmuxSession, socket, message.text, task.sessionState?.panes);
+	return sendPromptToAgentPane(tmuxSession, socket, text, task.sessionState?.panes);
 }
 
 /** Toast + attention for a late-fire or drop. Silent path never calls this. */
@@ -149,7 +154,7 @@ function validateText(text: string): string {
 export async function scheduleMessage(
 	project: Project,
 	task: Task,
-	input: { text: string; at: string; target?: ScheduledMessageTarget | null },
+	input: { text: string; at: string; target?: ScheduledMessageTarget | null; source?: AgentMessageSource | null },
 ): Promise<Task> {
 	const text = validateText(input.text);
 	if (isTerminal(task.status)) {
@@ -164,6 +169,7 @@ export async function scheduleMessage(
 		text,
 		at: at.toISOString(),
 		target: normalizeTarget(input.target),
+		...(input.source ? { source: input.source } : {}),
 	};
 	const { task: updated } = await data.updateTaskWith<void>(project, task.id, (current) => {
 		const queue = current.scheduledMessages ?? [];
@@ -201,6 +207,7 @@ export async function sendMessageImmediately(
 	task: Task,
 	text: string,
 	target?: ScheduledMessageTarget | null,
+	source?: AgentMessageSource | null,
 ): Promise<void> {
 	const trimmed = validateText(text);
 	if (isTerminal(task.status)) {
@@ -211,6 +218,7 @@ export async function sendMessageImmediately(
 		text: trimmed,
 		at: "",
 		target: normalizeTarget(target),
+		...(source ? { source } : {}),
 	});
 	if (!delivered) {
 		throw new Error("Could not deliver the message — the task has no live agent session.");

--- a/src/cli/__tests__/message.test.ts
+++ b/src/cli/__tests__/message.test.ts
@@ -65,8 +65,24 @@ describe("message — immediate (bare form)", () => {
 			taskId: CTX.taskId,
 			text: "continue please",
 			projectId: CTX.projectId,
+			sourceTaskId: CTX.taskId,
 		});
 		expect(stdoutOutput).toContain("Message sent");
+	});
+
+	it("attaches the worktree task as the sender when messaging another task", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, taskId: "other", projectId: CTX.projectId }));
+		await handleMessage(args(["ping"], { task: "seq:42" }), SOCKET, CTX);
+		const [, , params] = mockSend.mock.calls[0]!;
+		expect(params!.taskId).toBe("seq:42");
+		expect(params!.sourceTaskId).toBe(CTX.taskId);
+	});
+
+	it("omits the sender when there is no worktree context", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, taskId: "other", projectId: "p" }));
+		await handleMessage(args(["ping"], { task: "seq:42" }), SOCKET, null);
+		const [, , params] = mockSend.mock.calls[0]!;
+		expect(params).not.toHaveProperty("sourceTaskId");
 	});
 
 	it("reports a delivery failure as a command error", async () => {

--- a/src/cli/commands/message.ts
+++ b/src/cli/commands/message.ts
@@ -43,6 +43,10 @@ export async function handleMessage(
 	const params: Record<string, unknown> = { taskId: expandShortId(rawTaskId, context), text };
 	const projectId = resolveProjectId(args.flags.project, context);
 	if (projectId) params.projectId = projectId;
+	// Running inside a worktree means an agent is the author: hand the app our own
+	// task id so it can wrap the text in the cross-task envelope (it resolves both
+	// ends and skips wrapping when a task messages itself).
+	if (context?.taskId) params.sourceTaskId = context.taskId;
 
 	// Bare form → send immediately.
 	if (!hasIn && !hasAt) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -379,6 +379,8 @@ const COMMANDS: CommandHelp[] = [
 			"--at <hh:mm>  Schedule at the next occurrence of a local time (today or tomorrow).",
 			"Text can be a positional arg, --message, or @file. An agent may schedule its own wake-up.",
 			"Targets the current worktree's task; override with --task <id>.",
+			"Messaging ANOTHER task from a worktree wraps the text in a <dev3-ai-message> envelope",
+			"carrying your seq + the reply command, so the receiving agent knows who wrote it.",
 		],
 	},
 	{

--- a/src/shared/agent-message-envelope.ts
+++ b/src/shared/agent-message-envelope.ts
@@ -1,0 +1,27 @@
+import type { AgentMessageSource } from "./types";
+
+/**
+ * Wrap a cross-task agent message in a pseudo-XML envelope so the receiving
+ * agent immediately sees the text came from another task's agent (not from the
+ * human) and knows the exact command to answer with.
+ */
+export function wrapAgentMessage(text: string, source: AgentMessageSource): string {
+	const lines = [
+		"<dev3-ai-message>",
+		`<from-task>seq:${source.seq}</from-task>`,
+	];
+	if (source.title) lines.push(`<from-title>${escapeXmlText(source.title)}</from-title>`);
+	lines.push(
+		`<reply-with>dev3 message --task seq:${source.seq} "your reply"</reply-with>`,
+		"<message>",
+		text,
+		"</message>",
+		"</dev3-ai-message>",
+	);
+	return lines.join("\n");
+}
+
+/** Minimal escaping for the single-line metadata tags (the body stays verbatim). */
+function escapeXmlText(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1550,6 +1550,23 @@ export interface ScheduledMessage {
 	at: string;
 	/** Delivery target; `{ kind: "agent" }` by default. */
 	target: ScheduledMessageTarget;
+	/** Set when another task's agent sent it — wraps the text at fire time. */
+	source?: AgentMessageSource;
+}
+
+/**
+ * The task whose agent authored a cross-task message. Present only for
+ * agent-to-agent traffic (`dev3 message` run inside another task's worktree);
+ * absent for anything the human sends. Drives the pseudo-XML envelope in
+ * `wrapAgentMessage` so the receiver knows who wrote it and how to reply.
+ */
+export interface AgentMessageSource {
+	/** Sender task id (used to skip wrapping when a task messages itself). */
+	taskId: string;
+	/** Sender's stable `seq` — the reply address (`--task seq:<N>`). */
+	seq: number;
+	/** Sender's title, for human-readable context in the envelope. */
+	title?: string;
 }
 
 /** Per-task cap on pending scheduled messages; scheduling past this is rejected. */


### PR DESCRIPTION
`dev3 message --task seq:N "..."` sent from inside another task's worktree now arrives wrapped in a pseudo-XML envelope, so the receiving agent can tell agent-authored text from human input and knows the exact command to reply with:

```
<dev3-ai-message>
<from-task>seq:1310</from-task>
<from-title>…</from-title>
<reply-with>dev3 message --task seq:1310 "your reply"</reply-with>
<message>
…verbatim body…
</message>
</dev3-ai-message>
```

- The CLI attaches its own worktree task as `sourceTaskId`; the app resolves both ends and skips wrapping when a task messages itself, when the sender is unknown, or for anything sent from the UI.
- Wrapping happens at delivery time, so a "Send later" item keeps the plain text in the queue (and in the card chip preview) and gets the envelope only when it fires; `ScheduledMessage.source` carries the sender (additive optional field).
- Length validation runs on the raw text, so the envelope can't push a message past the 10k cap. Only metadata tags are escaped; the body stays verbatim.
- New shared helper `wrapAgentMessage`, unit tests for the envelope, scheduler wrapping and the CLI param, plus `decisions/177-cross-task-agent-message-envelope.md` and a changelog entry.