### PR TITLE
Fail the desktop launch safely when WebView2 never produces a renderer

### DIFF
--- a/change-logs/2026/07/26/fix-windows-webview2-startup-failure.md
+++ b/change-logs/2026/07/26/fix-windows-webview2-startup-failure.md
@@ -1,3 +1,3 @@
-Short: Clean failure when the window has no renderer
+Short: No more crash when WebView2 fails
 
-A Windows desktop launch with no interactive desktop or a broken WebView2 runtime used to keep running without any UI — the native window is created but its WebView2 controller fails afterwards, so the app logged "ready", served remote RPC and could not even be shut down, because the quit gate waits for a renderer that never existed. The launch now waits for the first dom-ready and, if none arrives, prints what to install or run instead and exits with the new code 8.
+A Windows launch with no interactive desktop or a broken WebView2 runtime used to create a window whose webview never came up, and the first-paint resize nudge then segfaulted the app seconds later — or it kept running with no UI at all and could not even be shut down, because the quit gate waits for a renderer that never existed. The nudge now waits for the renderer, and a launch that never gets one prints what to install or run instead and exits with the new code 8.

--- a/change-logs/2026/07/26/fix-windows-webview2-startup-failure.md
+++ b/change-logs/2026/07/26/fix-windows-webview2-startup-failure.md
@@ -1,0 +1,3 @@
+Short: Clean failure when the window has no renderer
+
+A Windows desktop launch with no interactive desktop or a broken WebView2 runtime used to keep running without any UI — the native window is created but its WebView2 controller fails afterwards, so the app logged "ready", served remote RPC and could not even be shut down, because the quit gate waits for a renderer that never existed. The launch now waits for the first dom-ready and, if none arrives, prints what to install or run instead and exits with the new code 8.

--- a/decisions/177-renderer-readiness-desktop-launch.md
+++ b/decisions/177-renderer-readiness-desktop-launch.md
@@ -25,16 +25,31 @@ no event, and no falsy return — the bun side cannot see it at all.
   `DOM ready` **366 ms** after `Window created` (`NavigationCompleted fired for
   webview 1`, no HRESULT). The packaged Windows launch proof measured 1511 ms.
   So a healthy renderer is ~3 orders of magnitude faster than any sane budget.
-- Electrobun's webview transport (`BrowserView.createTransport`) sends over the
-  encrypted renderer socket, and when no socket ever connected it falls back to an
-  FFI `evaluateJavaScriptWithNoCompletion(webviewPtr, …)`. It early-returns only on
-  a null `ptr`, which a controller failure does not produce — so every
-  `broadcastToAllWindows()` from the 10 s pollers is an FFI call into a webview
-  with no live controller. This is the leading candidate for the delayed native
-  crash, but it is NOT proven: an idle SSH launch survived 17.5 minutes with those
-  pollers ticking. The Seq 1295 run had real projects and an attempted `createTask`;
-  the idle one had none. The delayed crash is therefore treated as *evidence*, not
-  as the thing being fixed — the fix removes the window in which it can happen.
+- **The crash is the first-paint resize nudge.** `createAppWindow` fired a 200 ms
+  `setTimeout` that called `win.getSize()` + `win.setSize()` unconditionally. With a
+  dead WebView2 controller that reaches an invalid native wrapper and Bun panics:
+
+  ```
+  [22:21] ERROR: Failed to create WebView2 controller, HRESULT: 0x80070578
+  panic(thread 26360): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
+  bun.report/1.3.14/…libNativeWrapper.dll…   → exit code 9
+  Elapsed: 4176ms
+  ```
+
+  Controlled A/B on the same machine, same SSH session, same checkout: nudge
+  unconditional → segfault 4176 ms after start, exit 9. Nudge moved behind
+  `dom-ready` → no crash, process alive until the watchdog ended it. That also
+  explains the Seq 1295 "4–15 minutes" spread and why an idle run survived 17.5
+  minutes: it is a **race** between the 200 ms timer and the asynchronous controller
+  failure, not a timer we could ever out-wait. A readiness watchdog alone would
+  never have caught it — the offending call has to be removed from the pre-renderer
+  window, which is why the nudge now waits for `dom-ready` (where it belongs
+  anyway: it exists to fix the FIRST PAINT).
+- Electrobun's webview transport falls back from the renderer socket to an FFI
+  `evaluateJavaScriptWithNoCompletion(webviewPtr, …)` and only early-returns on a
+  null `ptr`, which a controller failure does not produce — so poller broadcasts
+  are also FFI calls into a controller-less webview. Not observed to crash on its
+  own (17.5 minutes of 10 s ticks), but it is why the launch must not linger.
 - Shutdown was independently broken: the `before-quit` gate cancels the quit and
   asks the renderer to confirm. With a renderer, Ctrl+C works (observed:
   `Quit intercepted` → `quitApp (confirmed by renderer)` → cleanup). Without one,
@@ -62,9 +77,20 @@ no event, and no falsy return — the bun side cannot see it at all.
   `markQuitConfirmed()` so the quit gate cannot wait for a renderer, runs the
   normal `runGlobalQuitCleanup()`, and leaves via `hardExit()` with the new
   `CLI_EXIT_CODE_RENDERER_UNAVAILABLE = 8`.
-- `src/bun/hard-exit.ts` prefers `process.reallyExit` and falls back to
-  `process.exit`. It skips buffered flushes, so the diagnostic is written with a
-  synchronous `writeSync(2, …)` first.
+- `src/bun/hard-exit.ts` owns leaving the process, and every layer of that had to
+  be measured on Windows rather than assumed:
+  - `process.exit(8)` exits **0** — electrobun replaces `process.exit` and its
+    `quit()` always ends in `forceExit(0)`.
+  - `process.reallyExit(8)` exits 8 in a plain Bun process but does **not end an
+    electrobun app**: the app logged its full cleanup and then stayed alive for
+    4.5 minutes with the native runtime holding the process.
+  - `ExitProcess(8)` via `bun:ffi` does end it, but the process died with
+    `0xC0000409` (fail-fast) because loader/CRT teardown ran while electrobun's
+    native threads were live.
+  - `TerminateProcess(GetCurrentProcess(), 8)` yields exactly 8. That is the
+    primary path; `reallyExit` and `process.exit` remain ordered fallbacks for a
+    platform where the FFI lookup fails. All of them skip buffered flushes, so the
+    diagnostic is written with a synchronous `writeSync(2, …)` first.
 - `writeAppReadyMarker()` moved from "window created" to "renderer ready". The
   marker is the packaged-launch proof's readiness signal and used to be written
   while there was no UI at all — a half-started app reporting success.
@@ -80,11 +106,16 @@ no event, and no falsy return — the bun side cannot see it at all.
 - A healthy launch that is slower than 45 s to first paint would now be killed.
   Observed healthy startups are 0.37–1.5 s, and the budget is win32-only, so the
   margin is large — but a pathologically slow machine is the failure mode to watch.
-- The delayed `libNativeWrapper` crash is bounded out, not root-caused. If it ever
-  appears within the readiness budget, this fix will not catch it.
-- `reallyExit` bypasses exit handlers. Everything this process owns is torn down
-  explicitly before the call; anything added to `runGlobalQuitCleanup()` later
-  inherits that requirement.
+- The nudge was the crash we could reproduce; the pre-renderer window still
+  contains other native calls (poller broadcasts into a controller-less webview).
+  Nothing was observed to crash there in 17.5 minutes, but the class is not
+  eliminated — only shortened to 45 s.
+- `TerminateProcess` bypasses every exit handler and flush. Everything this process
+  owns is torn down explicitly before the call; anything added to
+  `runGlobalQuitCleanup()` later inherits that requirement.
+- The launcher chain does not forward the code: with `bun run dev` the console saw
+  `9` while the app process itself exited `8`. The app's own exit code is the
+  contract; `bin/launcher.exe`'s translation of it is an electrobun detail.
 
 ## Alternatives considered
 

--- a/decisions/177-renderer-readiness-desktop-launch.md
+++ b/decisions/177-renderer-readiness-desktop-launch.md
@@ -1,0 +1,104 @@
+# 177 — A created window is not a renderer: the desktop launch readiness contract
+
+## Context
+
+On a real Windows x64 machine over SSH (no interactive desktop) dev3 booted, logged
+`=== dev-3.0 ready ===`, served remote RPC, and — in the Seq 1295 observation — died
+~906 s later inside `libNativeWrapper.dll` with exit code 9. Reproduced live in Seq
+1302 from an isolated checkout; the log order is the whole finding:
+
+```
+21:07:23.650 INFO  [window-manager] Window created {"id":1,"total":1}
+21:07:23.650 INFO  [main] Main window created
+21:07:23.662 INFO  [main] === dev-3.0 ready ===
+[Sun Jul 26 21:07:23 2026] ERROR: Failed to create WebView2 controller, HRESULT: 0x80070578
+```
+
+`new BrowserWindow()` **succeeds**. Electrobun only throws when the native window
+pointer is null; here the window is created and the WebView2 controller fails
+*afterwards*, asynchronously, inside the native wrapper. There is no JS exception,
+no event, and no falsy return — the bun side cannot see it at all.
+
+## Investigation
+
+- The same isolated checkout on the machine's own interactive desktop reaches
+  `DOM ready` **366 ms** after `Window created` (`NavigationCompleted fired for
+  webview 1`, no HRESULT). The packaged Windows launch proof measured 1511 ms.
+  So a healthy renderer is ~3 orders of magnitude faster than any sane budget.
+- Electrobun's webview transport (`BrowserView.createTransport`) sends over the
+  encrypted renderer socket, and when no socket ever connected it falls back to an
+  FFI `evaluateJavaScriptWithNoCompletion(webviewPtr, …)`. It early-returns only on
+  a null `ptr`, which a controller failure does not produce — so every
+  `broadcastToAllWindows()` from the 10 s pollers is an FFI call into a webview
+  with no live controller. This is the leading candidate for the delayed native
+  crash, but it is NOT proven: an idle SSH launch survived 17.5 minutes with those
+  pollers ticking. The Seq 1295 run had real projects and an attempted `createTask`;
+  the idle one had none. The delayed crash is therefore treated as *evidence*, not
+  as the thing being fixed — the fix removes the window in which it can happen.
+- Shutdown was independently broken: the `before-quit` gate cancels the quit and
+  asks the renderer to confirm. With a renderer, Ctrl+C works (observed:
+  `Quit intercepted` → `quitApp (confirmed by renderer)` → cleanup). Without one,
+  nobody answers and the app never exits.
+- Electrobun **replaces `process.exit`**: the first call routes into its `quit()`,
+  which always ends in `forceExit(0)`. A desktop-side `process.exit(8)` exits 0.
+  `process.reallyExit` is not patched (verified on Windows, Bun 1.3.14).
+
+## Decision
+
+- `src/bun/renderer-readiness.ts` owns the contract. The first webview `dom-ready`
+  is the only proof a renderer exists, so `index.ts` arms a watchdog right after
+  `openMainWindow()` and disarms it in `onDomReady`. Budget: 45 s
+  (`RENDERER_READY_TIMEOUT_MS`), ~30x the slowest observed healthy startup.
+- `resolveRendererReadyTimeoutMs()` watches **win32 only** by default; macOS and
+  Linux get `null` (no timer at all), so their startup is byte-identical. The
+  `DEV3_RENDERER_READY_TIMEOUT_MS` env is the seam: an explicit value applies on
+  every platform, `0` disables the watchdog, and garbage falls back to the
+  platform default rather than silently disarming a safety net.
+- On timeout `failDesktopLaunch()` writes an actionable diagnostic (the
+  `DEV3_DESKTOP_RENDERER_UNAVAILABLE` marker, the 0x80070578 explanation, the
+  WebView2 `winget` command, and `dev3 remote` as the headless answer) — console +
+  log file only, no native dialog and no `window.alert`, because the renderer that
+  would host in-app UI is precisely what is missing. It then calls
+  `markQuitConfirmed()` so the quit gate cannot wait for a renderer, runs the
+  normal `runGlobalQuitCleanup()`, and leaves via `hardExit()` with the new
+  `CLI_EXIT_CODE_RENDERER_UNAVAILABLE = 8`.
+- `src/bun/hard-exit.ts` prefers `process.reallyExit` and falls back to
+  `process.exit`. It skips buffered flushes, so the diagnostic is written with a
+  synchronous `writeSync(2, …)` first.
+- `writeAppReadyMarker()` moved from "window created" to "renderer ready". The
+  marker is the packaged-launch proof's readiness signal and used to be written
+  while there was no UI at all — a half-started app reporting success.
+- Headless mode is left alone by construction: it never imports the window layer.
+  A new guard in `cli-startup-graph.test.ts` walks `headless-entry.ts`'s static
+  import graph and fails if `window-manager` or `electrobun/*` becomes reachable,
+  and `test:headless-soak` (opt-in, 16 min default, not in `bun run test`) proves
+  remote mode serves past the observed 906 s window with the watchdog pinned to
+  1 ms.
+
+## Risks
+
+- A healthy launch that is slower than 45 s to first paint would now be killed.
+  Observed healthy startups are 0.37–1.5 s, and the budget is win32-only, so the
+  margin is large — but a pathologically slow machine is the failure mode to watch.
+- The delayed `libNativeWrapper` crash is bounded out, not root-caused. If it ever
+  appears within the readiness budget, this fix will not catch it.
+- `reallyExit` bypasses exit handlers. Everything this process owns is torn down
+  explicitly before the call; anything added to `runGlobalQuitCleanup()` later
+  inherits that requirement.
+
+## Alternatives considered
+
+- **Poll for the WebView2 runtime / interactive desktop before creating a window.**
+  Rejected: it answers a different question (is a runtime installed) than the one
+  that matters (did *this* controller come up), and it would need a second
+  platform-specific probe to maintain.
+- **Fall back to headless/remote mode automatically.** Rejected by scope and by
+  UX: a user who launched a desktop app silently getting a background web server
+  is worse than a clear failure, and it would mask a broken install forever.
+- **Arm the watchdog on every platform.** Rejected for now: the failure is only
+  observed on Windows, and the cost of a false positive is killing a working app
+  on the user's own machine. The env override makes the other platforms one
+  variable away when evidence appears.
+- **Make the pollers renderer-aware instead of exiting.** Rejected: it leaves a
+  UI-less process running forever and multiplies the number of places that must
+  remember the contract, instead of ending the launch that cannot succeed.

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -12,6 +12,7 @@ Public `dev3` CLI exit codes are defined in `src/shared/cli-exit-codes.ts`.
 | `5` | `CLI_EXIT_CODE_GUI_DEPS_MISSING` | `dev3 gui` cannot launch because system libraries (GTK, WebKit, etc.) are missing. The CLI prints the install command for the detected distro and exits with this code so wrappers can detect it. |
 | `6` | `CLI_EXIT_CODE_COMPLETION_DECLINED` | `dev3 task move --status completed` asked the user for approval and the user declined. The task keeps its current status and the session stays alive. |
 | `7` | `CLI_EXIT_CODE_DOCTOR_PROBLEMS` | `dev3 doctor` found at least one problem (a check with status "fail"). Warnings alone still exit 0. |
+| `8` | `CLI_EXIT_CODE_RENDERER_UNAVAILABLE` | The desktop launch created a window but no renderer ever reported dom-ready within the readiness budget — a missing or broken WebView2 runtime, or no interactive desktop (SSH / session 0). The process prints an actionable diagnostic and leaves instead of running without a UI. |
 
 `--tolerate-app-offline` turns code `2` into code `0` for a single invocation: the
 "app not running" notice is still written to stderr, but the process exits

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"test:native-parity-e2e": "bun src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts",
 		"test:ownership-e2e": "bun src/bun/terminal-process-ownership/__tests__/ownership.bun-e2e.ts",
 		"test:cli-loopback-e2e": "bun src/bun/__tests__/cli-loopback-transport.bun-e2e.ts",
+		"test:headless-soak": "bun src/bun/__tests__/headless-remote-soak.bun-e2e.ts",
 		"test:cli-packaged-e2e": "bun src/cli/__tests__/cli-packaged-loopback.bun-e2e.ts",
 		"test:terminal-state-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/terminal-state/__tests__",
 		"benchmark:terminal-state-spike": "bun src/bun/prototypes/terminal-state/benchmark.ts",

--- a/src/bun/__tests__/headless-remote-soak.bun-e2e.ts
+++ b/src/bun/__tests__/headless-remote-soak.bun-e2e.ts
@@ -1,0 +1,130 @@
+/**
+ * Opt-in duration + fault regression for headless (`dev3 remote`) mode.
+ *
+ * Windows over SSH produced a desktop process that lived ~906 s with a dead
+ * WebView2 controller and then died inside libNativeWrapper. `dev3 remote` is the
+ * documented answer for a machine with no interactive desktop, so it must never
+ * be able to inherit that failure: it must serve for longer than that window
+ * without ever constructing a BrowserWindow, and it must ignore the desktop
+ * renderer-readiness watchdog entirely (here it is pinned to 1 ms — a value that
+ * would kill any desktop launch instantly).
+ *
+ * Deliberately NOT part of `bun run test`: it runs for 16 minutes by default.
+ *
+ *   bun run test:headless-soak                    # 16 min (covers the 906 s window)
+ *   DEV3_SOAK_MS=60000 bun run test:headless-soak # quick smoke
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
+const SOAK_MS = Number(process.env.DEV3_SOAK_MS ?? 16 * 60 * 1000);
+const PROBE_INTERVAL_MS = 15_000;
+const START_TIMEOUT_MS = 120_000;
+
+const failures: string[] = [];
+function check(label: string, ok: boolean, detail = ""): void {
+	if (ok) {
+		console.log(`  ok   ${label}`);
+		return;
+	}
+	failures.push(`${label}${detail ? ` — ${detail}` : ""}`);
+	console.log(`  FAIL ${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+const home = mkdtempSync(resolve(tmpdir(), "dev3-headless-soak-"));
+
+const child = spawn(
+	process.execPath,
+	["src/cli/main.ts", "remote", "start", "--no-detach", "--no-tunnel"],
+	{
+		cwd: REPO_ROOT,
+		env: {
+			...process.env,
+			HOME: home,
+			// 0 = pick a free port, so concurrent runs never collide.
+			DEV3_REMOTE_PORT: "0",
+			// Would abort any desktop launch immediately; headless must not care.
+			DEV3_RENDERER_READY_TIMEOUT_MS: "1",
+		},
+		stdio: ["ignore", "pipe", "pipe"],
+	},
+);
+
+let output = "";
+let exitCode: number | null = null;
+let exitSignal: NodeJS.Signals | null = null;
+child.stdout?.on("data", (chunk) => { output += String(chunk); });
+child.stderr?.on("data", (chunk) => { output += String(chunk); });
+child.on("exit", (code, signal) => { exitCode = code; exitSignal = signal; });
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** The banner prints `http://<host>:<port>/`; that URL is the health probe. */
+function accessUrl(): string | null {
+	return output.match(/http:\/\/[\d.]+:(\d+)\//)?.[0] ?? null;
+}
+
+async function main(): Promise<void> {
+	console.log(`[soak] headless remote, ${Math.round(SOAK_MS / 1000)}s, isolated home ${home}`);
+
+	const startDeadline = Date.now() + START_TIMEOUT_MS;
+	while (Date.now() < startDeadline && accessUrl() === null && exitCode === null) {
+		await sleep(500);
+	}
+	const url = accessUrl();
+	check("headless server started and printed an access URL", url !== null, output.slice(-600));
+	if (url === null) return;
+
+	check("did not exit during startup", exitCode === null, `exit=${exitCode}`);
+
+	const soakDeadline = Date.now() + SOAK_MS;
+	let probes = 0;
+	let served = 0;
+	while (Date.now() < soakDeadline) {
+		await sleep(PROBE_INTERVAL_MS);
+		probes++;
+		if (exitCode !== null) break;
+		try {
+			const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+			// Any HTTP answer proves the listener is alive; auth may redirect.
+			if (res.status > 0) served++;
+			await res.arrayBuffer();
+		} catch { /* counted as a miss below */ }
+		if (probes % 8 === 0) {
+			console.log(`  … ${Math.round((Date.now() - (soakDeadline - SOAK_MS)) / 1000)}s, ${served}/${probes} probes served`);
+		}
+	}
+
+	check(`survived the whole soak (${Math.round(SOAK_MS / 1000)}s)`, exitCode === null, `exit=${exitCode} signal=${exitSignal}`);
+	check("answered every health probe", served === probes, `${served}/${probes}`);
+	check("never created a desktop window", !/window-manager|Window created/.test(output));
+	check(
+		"never took the desktop renderer-unavailable exit",
+		!output.includes("DEV3_DESKTOP_RENDERER_UNAVAILABLE"),
+	);
+
+	child.kill("SIGTERM");
+	const stopDeadline = Date.now() + 30_000;
+	while (Date.now() < stopDeadline && exitCode === null && exitSignal === null) await sleep(250);
+	check("shut down on SIGTERM without waiting for a renderer", exitCode !== null || exitSignal !== null);
+}
+
+try {
+	await main();
+} finally {
+	if (exitCode === null) child.kill("SIGKILL");
+	try {
+		console.log(`[soak] remote log tail:\n${readFileSync(resolve(home, ".dev3.0/remote/remote.log"), "utf8").split("\n").slice(-5).join("\n")}`);
+	} catch { /* no log written — the checks above already say so */ }
+	rmSync(home, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+	console.error(`\n[soak] FAILED (${failures.length}):\n  - ${failures.join("\n  - ")}`);
+	process.exit(1);
+}
+console.log("\n[soak] PASS");

--- a/src/bun/__tests__/renderer-readiness.test.ts
+++ b/src/bun/__tests__/renderer-readiness.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	RENDERER_READY_TIMEOUT_MS,
+	RENDERER_UNAVAILABLE_MARKER,
+	buildRendererUnavailableDiagnostic,
+	createRendererReadinessWatchdog,
+	resolveRendererReadyTimeoutMs,
+} from "../renderer-readiness";
+import { hardExit } from "../hard-exit";
+import { CLI_EXIT_CODE_RENDERER_UNAVAILABLE } from "../../shared/cli-exit-codes";
+
+/** Deterministic stand-in for setTimeout: nothing fires until `run()`. */
+function fakeTimers() {
+	const pending = new Map<number, () => void>();
+	let nextId = 1;
+	let clock = 0;
+	return {
+		setTimer: (fn: () => void) => {
+			const id = nextId++;
+			pending.set(id, fn);
+			return id;
+		},
+		clearTimer: (handle: unknown) => {
+			pending.delete(handle as number);
+		},
+		now: () => clock,
+		advance: (ms: number) => {
+			clock += ms;
+		},
+		fire: () => {
+			for (const fn of [...pending.values()]) fn();
+		},
+		pendingCount: () => pending.size,
+	};
+}
+
+function watchdogWith(timeoutMs: number | null) {
+	const timers = fakeTimers();
+	const onTimeout = vi.fn();
+	const onReady = vi.fn();
+	const onArmed = vi.fn();
+	const watchdog = createRendererReadinessWatchdog({
+		timeoutMs,
+		onTimeout,
+		onReady,
+		onArmed,
+		setTimer: timers.setTimer,
+		clearTimer: timers.clearTimer,
+		now: timers.now,
+	});
+	return { watchdog, timers, onTimeout, onReady, onArmed };
+}
+
+describe("resolveRendererReadyTimeoutMs", () => {
+	it("watches win32 by default and leaves macOS/Linux untouched", () => {
+		expect(resolveRendererReadyTimeoutMs({}, "win32")).toBe(RENDERER_READY_TIMEOUT_MS);
+		expect(resolveRendererReadyTimeoutMs({}, "darwin")).toBeNull();
+		expect(resolveRendererReadyTimeoutMs({}, "linux")).toBeNull();
+	});
+
+	it("honours an explicit budget on every platform", () => {
+		expect(resolveRendererReadyTimeoutMs({ DEV3_RENDERER_READY_TIMEOUT_MS: "2500" }, "darwin")).toBe(2500);
+		expect(resolveRendererReadyTimeoutMs({ DEV3_RENDERER_READY_TIMEOUT_MS: " 900 " }, "win32")).toBe(900);
+	});
+
+	it("treats 0 as 'disable the watchdog'", () => {
+		expect(resolveRendererReadyTimeoutMs({ DEV3_RENDERER_READY_TIMEOUT_MS: "0" }, "win32")).toBeNull();
+	});
+
+	it("falls back to the platform default rather than disabling on garbage", () => {
+		for (const raw of ["", "  ", "abc", "-5", "NaN", "Infinity"]) {
+			expect(resolveRendererReadyTimeoutMs({ DEV3_RENDERER_READY_TIMEOUT_MS: raw }, "win32")).toBe(
+				RENDERER_READY_TIMEOUT_MS,
+			);
+		}
+	});
+});
+
+describe("renderer readiness watchdog", () => {
+	it("fires the failure path exactly once when no renderer reports", () => {
+		const { watchdog, timers, onTimeout, onArmed } = watchdogWith(1_000);
+		watchdog.arm();
+
+		expect(onArmed).toHaveBeenCalledWith(1_000);
+		expect(watchdog.state()).toBe("armed");
+
+		timers.fire();
+
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+		expect(onTimeout).toHaveBeenCalledWith(1_000);
+		expect(watchdog.state()).toBe("failed");
+
+		// A late dom-ready after the failure must not resurrect the launch.
+		expect(watchdog.markReady("dom-ready")).toBe(false);
+		expect(watchdog.state()).toBe("failed");
+	});
+
+	it("disarms on the first dom-ready and reports the elapsed time", () => {
+		const { watchdog, timers, onTimeout, onReady } = watchdogWith(1_000);
+		watchdog.arm();
+		timers.advance(366);
+
+		expect(watchdog.markReady("dom-ready")).toBe(true);
+		expect(watchdog.state()).toBe("ready");
+		expect(onReady).toHaveBeenCalledWith("dom-ready", 366);
+		expect(timers.pendingCount()).toBe(0);
+
+		// Nothing is left to fire, and a second window is not a second chance.
+		timers.fire();
+		expect(onTimeout).not.toHaveBeenCalled();
+		expect(watchdog.markReady("dom-ready")).toBe(false);
+	});
+
+	it("arms only once, so extra windows never restart the budget", () => {
+		const { watchdog, timers, onArmed } = watchdogWith(1_000);
+		watchdog.arm();
+		watchdog.arm();
+		expect(onArmed).toHaveBeenCalledTimes(1);
+		expect(timers.pendingCount()).toBe(1);
+	});
+
+	it("never arms a timer when disabled, but still gates first-ready work", () => {
+		const { watchdog, timers, onTimeout, onReady } = watchdogWith(null);
+		expect(watchdog.state()).toBe("disabled");
+
+		watchdog.arm();
+		expect(timers.pendingCount()).toBe(0);
+		timers.fire();
+		expect(onTimeout).not.toHaveBeenCalled();
+
+		expect(watchdog.markReady("dom-ready")).toBe(true);
+		expect(watchdog.markReady("dom-ready")).toBe(false);
+		expect(onReady).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("renderer-unavailable diagnostic", () => {
+	it("carries the grep marker, the budget and the documented exit code", () => {
+		const text = buildRendererUnavailableDiagnostic(45_000, "win32");
+		expect(text).toContain(RENDERER_UNAVAILABLE_MARKER);
+		expect(text).toContain("45000ms");
+		expect(text).toContain(`code ${CLI_EXIT_CODE_RENDERER_UNAVAILABLE}`);
+	});
+
+	it("names the two real Windows causes with runnable next steps", () => {
+		const text = buildRendererUnavailableDiagnostic(45_000, "win32");
+		expect(text).toContain("0x80070578");
+		expect(text).toContain("winget install --id Microsoft.EdgeWebView2Runtime -e");
+		expect(text).toContain("dev3 remote");
+	});
+
+	it("stays useful off Windows without inventing Windows advice", () => {
+		const text = buildRendererUnavailableDiagnostic(1_000, "darwin");
+		expect(text).toContain(RENDERER_UNAVAILABLE_MARKER);
+		expect(text).not.toContain("0x80070578");
+		expect(text).toContain("dev3 remote");
+	});
+});
+
+describe("hardExit", () => {
+	it("prefers reallyExit, which electrobun does not replace", () => {
+		const reallyExit = vi.fn();
+		const exit = vi.fn();
+		hardExit(8, { exit: exit as never, reallyExit });
+		expect(reallyExit).toHaveBeenCalledWith(8);
+		expect(exit).not.toHaveBeenCalled();
+	});
+
+	it("falls back to process.exit when reallyExit is absent", () => {
+		const exit = vi.fn();
+		hardExit(8, { exit: exit as never });
+		expect(exit).toHaveBeenCalledWith(8);
+	});
+});

--- a/src/bun/__tests__/renderer-readiness.test.ts
+++ b/src/bun/__tests__/renderer-readiness.test.ts
@@ -158,17 +158,32 @@ describe("renderer-unavailable diagnostic", () => {
 });
 
 describe("hardExit", () => {
-	it("prefers reallyExit, which electrobun does not replace", () => {
-		const reallyExit = vi.fn();
-		const exit = vi.fn();
-		hardExit(8, { exit: exit as never, reallyExit });
-		expect(reallyExit).toHaveBeenCalledWith(8);
-		expect(exit).not.toHaveBeenCalled();
+	function fakeProc(platform: NodeJS.Platform = "win32", withReallyExit = true) {
+		return {
+			platform,
+			exit: vi.fn() as never,
+			...(withReallyExit ? { reallyExit: vi.fn() } : {}),
+		};
+	}
+
+	it("exits through the OS primitive first — electrobun survives reallyExit", async () => {
+		const osExit = vi.fn();
+		const proc = fakeProc();
+		await hardExit(8, { proc, osExit });
+		expect(osExit).toHaveBeenCalledWith(8, "win32");
 	});
 
-	it("falls back to process.exit when reallyExit is absent", () => {
-		const exit = vi.fn();
-		hardExit(8, { exit: exit as never });
-		expect(exit).toHaveBeenCalledWith(8);
+	it("falls back to reallyExit and then process.exit when the OS exit fails", async () => {
+		const osExit = vi.fn(() => { throw new Error("dlopen failed"); });
+		const proc = fakeProc();
+		await hardExit(8, { proc, osExit });
+		expect(proc.reallyExit).toHaveBeenCalledWith(8);
+		expect(proc.exit).toHaveBeenCalledWith(8);
+	});
+
+	it("still exits when the process has no reallyExit at all", async () => {
+		const proc = fakeProc("linux", false);
+		await hardExit(8, { proc, osExit: () => { throw new Error("no libc"); } });
+		expect(proc.exit).toHaveBeenCalledWith(8);
 	});
 });

--- a/src/bun/__tests__/window-manager-fresh.test.ts
+++ b/src/bun/__tests__/window-manager-fresh.test.ts
@@ -102,13 +102,23 @@ function spawn() {
 	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {} });
 }
 
+/** Fire every registered dom-ready listener, then let their timers run. */
+function reportDomReady(win: FakeWindow): void {
+	for (const [event, handler] of win.webview.on.mock.calls) {
+		if (event === "dom-ready") (handler as () => void)();
+	}
+	vi.advanceTimersByTime(500);
+}
+
 describe("window-manager fresh-start mode", () => {
 	it("restores the saved geometry when fresh-start is off", () => {
 		delete process.env.DEV3_FRESH_START;
 		spawn();
 		expect(createdWindows[0].frame).toEqual(SAVED_FRAME);
-		// Fullscreen restore is wired on dom-ready.
-		expect(createdWindows[0].webview.on).toHaveBeenCalledWith("dom-ready", expect.any(Function));
+		// Fullscreen restore happens on dom-ready, and replaces the resize nudge.
+		reportDomReady(createdWindows[0]);
+		expect(createdWindows[0].setFullScreen).toHaveBeenCalledWith(true);
+		expect(createdWindows[0].setSize).not.toHaveBeenCalled();
 		// Geometry persistence listeners are attached.
 		expect(createdWindows[0].handlers.move).toBeTypeOf("function");
 		expect(createdWindows[0].handlers.resize).toBeTypeOf("function");
@@ -119,10 +129,33 @@ describe("window-manager fresh-start mode", () => {
 		spawn();
 		// 95% of 1920×1080, centered → 1824×1026 at (48, 27) — NOT the saved frame.
 		expect(createdWindows[0].frame).toEqual({ x: 48, y: 27, width: 1824, height: 1026 });
-		// No fullscreen restore.
-		expect(createdWindows[0].webview.on).not.toHaveBeenCalledWith("dom-ready", expect.any(Function));
+		// No fullscreen restore — the first-paint resize nudge runs instead.
+		reportDomReady(createdWindows[0]);
+		expect(createdWindows[0].setFullScreen).not.toHaveBeenCalled();
+		expect(createdWindows[0].setSize).toHaveBeenCalled();
 		// No geometry persistence listeners — dev must not clobber shared state.
 		expect(createdWindows[0].handlers.move).toBeUndefined();
 		expect(createdWindows[0].handlers.resize).toBeUndefined();
+	});
+
+	// Regression guard for the Windows segfault (decision 177): resizing a window
+	// whose webview never initialized reaches an invalid native wrapper and kills
+	// the process, so NOTHING may size the window before the renderer reports in.
+	it("never touches window size before the renderer reports dom-ready", () => {
+		delete process.env.DEV3_FRESH_START;
+		spawn();
+		vi.advanceTimersByTime(60_000);
+		expect(createdWindows[0].getSize).not.toHaveBeenCalled();
+		expect(createdWindows[0].setSize).not.toHaveBeenCalled();
+		expect(createdWindows[0].setFullScreen).not.toHaveBeenCalled();
+	});
+
+	it("nudges the first paint only once, even if dom-ready fires again", () => {
+		process.env.DEV3_FRESH_START = "1";
+		spawn();
+		reportDomReady(createdWindows[0]);
+		const afterFirst = createdWindows[0].setSize.mock.calls.length;
+		reportDomReady(createdWindows[0]);
+		expect(createdWindows[0].setSize.mock.calls.length).toBe(afterFirst);
 	});
 });

--- a/src/bun/hard-exit.ts
+++ b/src/bun/hard-exit.ts
@@ -1,26 +1,70 @@
 /**
- * Leave the desktop process with a real exit code.
+ * Leave the desktop process with a real exit code — for real.
  *
- * Electrobun REPLACES `process.exit`: the first call routes into its own
- * `quit()`, which emits `before-quit` (our gate can cancel it) and then always
- * ends in `forceExit(0)` — so a desktop-side `process.exit(8)` exits 0. It does
- * not patch `process.reallyExit`, which is the Node-compat primitive underneath
- * (verified on Windows with Bun 1.3.14: `bun -e "process.reallyExit(8)"` exits 8).
+ * Two layers of the runtime fight this:
  *
- * `reallyExit` skips exit handlers and any buffered stream flush, so callers must
- * have written their diagnostic synchronously (`writeSync`) before calling this.
+ * 1. Electrobun REPLACES `process.exit`. The first call routes into its own
+ *    `quit()`, which emits `before-quit` (our gate can cancel it) and always ends
+ *    in `forceExit(0)` — so a desktop-side `process.exit(8)` exits 0.
+ * 2. `process.reallyExit` is not patched and works in a plain Bun process
+ *    (`bun -e "process.reallyExit(8)"` exits 8), but it does NOT end an electrobun
+ *    app: measured on Windows, the app logged its cleanup and then stayed alive
+ *    for minutes with the native runtime still holding the process (decision 177).
+ *
+ * So the primary exit is the OS primitive — `ExitProcess` / `_exit` — which
+ * terminates every thread of the process with the code we ask for, native runtime
+ * included. `bun:ffi` is imported dynamically: this module is also loaded by tests
+ * running under Node, and the import only happens on the failure path.
+ *
+ * All of these skip exit handlers and buffered stream flushes, so callers must
+ * have written their diagnostic synchronously (`writeSync`) beforehand.
  */
 
 export interface ExitCapableProcess {
 	exit: (code?: number) => never;
 	reallyExit?: (code: number) => void;
+	platform: NodeJS.Platform;
 }
 
-export function hardExit(code: number, proc: ExitCapableProcess = process): void {
-	const reallyExit = proc.reallyExit;
-	if (typeof reallyExit === "function") {
-		reallyExit.call(proc, code);
-		return;
+export interface HardExitDeps {
+	proc?: ExitCapableProcess;
+	/** Injected in tests; the default goes through `bun:ffi`. */
+	osExit?: (code: number, platform: NodeJS.Platform) => void | Promise<void>;
+}
+
+/** libc / kernel32 entry point that ends the process, per platform. */
+function osExitTarget(platform: NodeJS.Platform): { library: string; symbol: string } {
+	if (platform === "win32") return { library: "kernel32.dll", symbol: "ExitProcess" };
+	if (platform === "darwin") return { library: "libSystem.B.dylib", symbol: "_exit" };
+	return { library: "libc.so.6", symbol: "_exit" };
+}
+
+async function ffiOsExit(code: number, platform: NodeJS.Platform): Promise<void> {
+	const { library, symbol } = osExitTarget(platform);
+	const { dlopen, FFIType } = await import("bun:ffi");
+	const lib = dlopen(library, {
+		[symbol]: { args: [FFIType.u32], returns: FFIType.void },
+	});
+	(lib.symbols as Record<string, (value: number) => void>)[symbol](code);
+}
+
+/**
+ * Never returns in practice. Ordered attempts: OS primitive → `reallyExit` →
+ * electrobun's `process.exit`, so a platform where the FFI lookup fails still
+ * gets the best available exit instead of a process that refuses to die.
+ */
+export async function hardExit(code: number, deps: HardExitDeps = {}): Promise<void> {
+	const proc = deps.proc ?? (process as unknown as ExitCapableProcess);
+	const osExit = deps.osExit ?? ffiOsExit;
+	try {
+		await osExit(code, proc.platform);
+	} catch {
+		// dlopen or the symbol lookup failed — fall through to the JS exits.
+	}
+	try {
+		proc.reallyExit?.(code);
+	} catch {
+		// ignore — the last resort below is electrobun's own exit
 	}
 	proc.exit(code);
 }

--- a/src/bun/hard-exit.ts
+++ b/src/bun/hard-exit.ts
@@ -32,20 +32,26 @@ export interface HardExitDeps {
 	osExit?: (code: number, platform: NodeJS.Platform) => void | Promise<void>;
 }
 
-/** libc / kernel32 entry point that ends the process, per platform. */
-function osExitTarget(platform: NodeJS.Platform): { library: string; symbol: string } {
-	if (platform === "win32") return { library: "kernel32.dll", symbol: "ExitProcess" };
-	if (platform === "darwin") return { library: "libSystem.B.dylib", symbol: "_exit" };
-	return { library: "libc.so.6", symbol: "_exit" };
-}
-
 async function ffiOsExit(code: number, platform: NodeJS.Platform): Promise<void> {
-	const { library, symbol } = osExitTarget(platform);
 	const { dlopen, FFIType } = await import("bun:ffi");
+	if (platform === "win32") {
+		// TerminateProcess, not ExitProcess: `ExitProcess(8)` runs loader/CRT
+		// teardown while electrobun's native threads are live, and Bun fail-fasts
+		// on the way out — the process died with 0xC0000409 instead of 8 (measured).
+		// TerminateProcess kills every thread immediately with the code we pass,
+		// which is safe here because our own cleanup already ran.
+		const lib = dlopen("kernel32.dll", {
+			GetCurrentProcess: { args: [], returns: FFIType.ptr },
+			TerminateProcess: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.i32 },
+		});
+		lib.symbols.TerminateProcess(lib.symbols.GetCurrentProcess(), code);
+		return;
+	}
+	const library = platform === "darwin" ? "libSystem.B.dylib" : "libc.so.6";
 	const lib = dlopen(library, {
-		[symbol]: { args: [FFIType.u32], returns: FFIType.void },
+		_exit: { args: [FFIType.u32], returns: FFIType.void },
 	});
-	(lib.symbols as Record<string, (value: number) => void>)[symbol](code);
+	lib.symbols._exit(code);
 }
 
 /**

--- a/src/bun/hard-exit.ts
+++ b/src/bun/hard-exit.ts
@@ -1,0 +1,26 @@
+/**
+ * Leave the desktop process with a real exit code.
+ *
+ * Electrobun REPLACES `process.exit`: the first call routes into its own
+ * `quit()`, which emits `before-quit` (our gate can cancel it) and then always
+ * ends in `forceExit(0)` — so a desktop-side `process.exit(8)` exits 0. It does
+ * not patch `process.reallyExit`, which is the Node-compat primitive underneath
+ * (verified on Windows with Bun 1.3.14: `bun -e "process.reallyExit(8)"` exits 8).
+ *
+ * `reallyExit` skips exit handlers and any buffered stream flush, so callers must
+ * have written their diagnostic synchronously (`writeSync`) before calling this.
+ */
+
+export interface ExitCapableProcess {
+	exit: (code?: number) => never;
+	reallyExit?: (code: number) => void;
+}
+
+export function hardExit(code: number, proc: ExitCapableProcess = process): void {
+	const reallyExit = proc.reallyExit;
+	if (typeof reallyExit === "function") {
+		reallyExit.call(proc, code);
+		return;
+	}
+	proc.exit(code);
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -13,11 +13,18 @@ import {
 	isUpdateAlreadyReady,
 } from "./updater";
 import { loadSettings, loadSettingsSync } from "./settings";
-import { installSignalQuitConfirmation, isQuitConfirmed, markQuitDialogPending } from "./quit-manager";
+import { installSignalQuitConfirmation, isQuitConfirmed, markQuitConfirmed, markQuitDialogPending } from "./quit-manager";
 import { initNativeNotifications } from "./native-notifications";
 import { markPendingNotificationNav } from "./notification-nav";
 import { createLogger, getLogPath } from "./logger";
 import { writeAppReadyMarker } from "./app-ready-marker";
+import {
+	buildRendererUnavailableDiagnostic,
+	createRendererReadinessWatchdog,
+	resolveRendererReadyTimeoutMs,
+} from "./renderer-readiness";
+import { hardExit } from "./hard-exit";
+import { CLI_EXIT_CODE_RENDERER_UNAVAILABLE } from "../shared/cli-exit-codes";
 import { DEV3_HOME } from "./paths";
 import { resolveUserHome } from "../shared/user-home";
 import { normalizeEnvPath } from "../shared/env-path";
@@ -35,7 +42,7 @@ import { startLoopMonitor } from "./loop-monitor";
 import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
 import electrobunConfig, { cliBinaryName } from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
-import { existsSync } from "node:fs";
+import { existsSync, writeSync } from "node:fs";
 import { homedir } from "node:os";
 import { rehydrateTaskLifecycles } from "./lifecycle/rehydrate";
 
@@ -345,6 +352,36 @@ onMenuContextChange((ctx) => {
 
 // --- Main Window ---
 
+// A created window is not a renderer: on Windows the WebView2 controller can
+// fail AFTER the window exists (HRESULT 0x80070578 with no interactive desktop)
+// with no JS error and a non-null window pointer. Everything below that needs a
+// live webview hangs off the first `dom-ready`; silence for the whole budget
+// means this launch has no UI and must leave. See renderer-readiness.ts.
+const readiness = createRendererReadinessWatchdog({
+	timeoutMs: resolveRendererReadyTimeoutMs(),
+	onArmed: (timeoutMs) => log.info("Waiting for the renderer to report dom-ready", { timeoutMs }),
+	onReady: (source, elapsedMs) => log.info("Renderer ready", { source, elapsedMs }),
+	onTimeout: (timeoutMs) => failDesktopLaunch(timeoutMs),
+});
+
+/**
+ * The desktop launch produced no renderer. Print the diagnostic, tear down
+ * everything this process owns, and leave with the documented code.
+ *
+ * `markQuitConfirmed()` first: the `before-quit` gate below asks the renderer to
+ * confirm, and there is no renderer to answer — without this the app would sit
+ * alive forever (proven on Windows, decision 174).
+ */
+function failDesktopLaunch(timeoutMs: number): void {
+	const diagnostic = buildRendererUnavailableDiagnostic(timeoutMs);
+	log.error("Desktop launch failed: no renderer", { timeoutMs, exitCode: CLI_EXIT_CODE_RENDERER_UNAVAILABLE });
+	// Synchronous, because hardExit() below skips any buffered flush.
+	try { writeSync(2, `${diagnostic}\n`); } catch { /* stderr is closed — the log file still has it */ }
+	markQuitConfirmed();
+	try { runGlobalQuitCleanup(); } catch (err) { log.warn("Cleanup during failed launch failed", { error: String(err) }); }
+	hardExit(CLI_EXIT_CODE_RENDERER_UNAVAILABLE);
+}
+
 async function openMainWindow() {
 	const buildChannel = await Updater.localInfo.channel();
 	return createAppWindow({
@@ -352,6 +389,14 @@ async function openMainWindow() {
 		url,
 		handlers: handlers as unknown as Record<string, (...args: unknown[]) => unknown>,
 		onDomReady: async (win) => {
+			// dom-ready is the readiness contract: it only fires once a webview
+			// actually rendered, so it is the one signal that proves a renderer.
+			if (readiness.markReady("dom-ready")) {
+				// Window, RPC, push transport AND a live renderer — only now is the
+				// app genuinely usable, so this is where the automated packaged-build
+				// proof gets its marker. No-op without DEV3_READY_MARKER_FILE.
+				writeAppReadyMarker(APP_VERSION);
+			}
 			if (buildChannel === "dev") {
 				win.webview.openDevTools();
 			}
@@ -379,6 +424,7 @@ setOpenNewWindow(() => {
 
 await openMainWindow();
 log.info("Main window created");
+readiness.arm();
 
 // Wire push messages: every open renderer window + any connected browser clients.
 setPushMessage((name, payload) => {
@@ -386,10 +432,6 @@ setPushMessage((name, payload) => {
 	broadcastToAllWindows(name, payload);
 	pushToBrowserClients(name, payload);
 });
-
-// Window + RPC + push transport are live, so the app is usable: report it for
-// automated packaged-build proofs. No-op without DEV3_READY_MARKER_FILE.
-writeAppReadyMarker(APP_VERSION);
 
 // Initialize the backend gate before background pollers and CLI requests can
 // raise agent notifications. Queued entries flush when Focus Mode is disabled.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -379,7 +379,9 @@ function failDesktopLaunch(timeoutMs: number): void {
 	try { writeSync(2, `${diagnostic}\n`); } catch { /* stderr is closed — the log file still has it */ }
 	markQuitConfirmed();
 	try { runGlobalQuitCleanup(); } catch (err) { log.warn("Cleanup during failed launch failed", { error: String(err) }); }
-	hardExit(CLI_EXIT_CODE_RENDERER_UNAVAILABLE);
+	// Async only because the OS-level exit needs a dynamic bun:ffi import; it
+	// never returns, so there is nothing to await.
+	void hardExit(CLI_EXIT_CODE_RENDERER_UNAVAILABLE);
 }
 
 async function openMainWindow() {

--- a/src/bun/renderer-readiness.ts
+++ b/src/bun/renderer-readiness.ts
@@ -1,0 +1,163 @@
+/**
+ * The desktop launch's renderer readiness contract.
+ *
+ * A window handle is NOT a renderer. On Windows the native side creates the
+ * window synchronously and *then* fails to create the WebView2 controller —
+ * `HRESULT 0x80070578` (`ERROR_INVALID_WINDOW_HANDLE`) when there is no
+ * interactive desktop, e.g. over SSH. That failure is asynchronous, inside
+ * libNativeWrapper: no JS exception, no event, and a non-null window pointer,
+ * so `new BrowserWindow()` returns success and the app logs "ready" with zero
+ * renderers. It then keeps pushing to a webview that has no live controller —
+ * electrobun's transport falls back to an FFI `evaluateJavaScriptWithNoCompletion`
+ * when no renderer socket ever connected — and the quit gate can never finish,
+ * because it asks the renderer to confirm and nobody answers.
+ *
+ * The first webview `dom-ready` is the only signal that a renderer exists, so
+ * the launch arms a watchdog on it: ready inside the budget → proceed; silence →
+ * the launch has failed and the caller must leave instead of half-running.
+ * Measured healthy startups reach dom-ready in 366 ms (Windows, interactive) and
+ * 1511 ms (packaged launch proof), so the budget is ~30x the observed cost.
+ */
+
+import { CLI_EXIT_CODE_RENDERER_UNAVAILABLE } from "../shared/cli-exit-codes";
+
+/** Budget from window creation to the first `dom-ready`. */
+export const RENDERER_READY_TIMEOUT_MS = 45_000;
+
+/** Grepped by the Windows launch proof; keep it stable. */
+export const RENDERER_UNAVAILABLE_MARKER = "DEV3_DESKTOP_RENDERER_UNAVAILABLE";
+
+export const RENDERER_READY_TIMEOUT_ENV = "DEV3_RENDERER_READY_TIMEOUT_MS";
+
+/**
+ * How long this platform waits for a renderer, or `null` for "do not watch".
+ *
+ * Only win32 is watched by default: the failure is a WebView2/interactive-desktop
+ * one, and killing a launch is severe enough that macOS and Linux keep their
+ * existing behaviour until the same failure is observed there. The env override
+ * is the seam for tests and for the opt-in duration regression; `0` disables the
+ * watchdog outright, and an unparsable value falls back to the platform default
+ * rather than silently disabling a safety net.
+ */
+export function resolveRendererReadyTimeoutMs(
+	env: Record<string, string | undefined> = process.env,
+	platform: NodeJS.Platform = process.platform,
+): number | null {
+	const platformDefault = platform === "win32" ? RENDERER_READY_TIMEOUT_MS : null;
+	const raw = env[RENDERER_READY_TIMEOUT_ENV]?.trim();
+	if (!raw) return platformDefault;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) return platformDefault;
+	return parsed === 0 ? null : parsed;
+}
+
+/**
+ * The actionable diagnostic. No native dialog and no `window.alert`: the renderer
+ * that would host in-app UI is exactly what is missing, so the console and the
+ * log file are the only channels that exist here.
+ */
+export function buildRendererUnavailableDiagnostic(
+	timeoutMs: number,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	const lines = [
+		`${RENDERER_UNAVAILABLE_MARKER}: the desktop window never produced a renderer within ${timeoutMs}ms.`,
+		"The native window was created but its webview never reported dom-ready, so this process has no UI.",
+	];
+	if (platform === "win32") {
+		lines.push(
+			"On Windows this is almost always one of:",
+			"  1. No interactive desktop — an SSH / service / session-0 launch. WebView2 fails with",
+			"     HRESULT 0x80070578 (ERROR_INVALID_WINDOW_HANDLE). Log in to the machine's own desktop,",
+			"     or run the headless server instead: dev3 remote",
+			"  2. The WebView2 runtime is missing or broken. Install it with:",
+			"     winget install --id Microsoft.EdgeWebView2Runtime -e",
+		);
+	} else {
+		lines.push(
+			"Check that this process has access to a graphical session, or run the headless server: dev3 remote",
+		);
+	}
+	lines.push(
+		`Exiting with code ${CLI_EXIT_CODE_RENDERER_UNAVAILABLE} instead of running without a UI.`,
+	);
+	return lines.join("\n");
+}
+
+export type RendererReadinessState = "disabled" | "idle" | "armed" | "ready" | "failed";
+
+type TimerHandle = unknown;
+
+export interface RendererReadinessOptions {
+	/** `null` disables the watchdog: `arm()` and `markReady()` become no-ops. */
+	timeoutMs: number | null;
+	/** Called once, when the budget expires without a renderer. */
+	onTimeout: (timeoutMs: number) => void;
+	onArmed?: (timeoutMs: number) => void;
+	onReady?: (source: string, elapsedMs: number) => void;
+	setTimer?: (fn: () => void, ms: number) => TimerHandle;
+	clearTimer?: (handle: TimerHandle) => void;
+	now?: () => number;
+}
+
+export interface RendererReadinessWatchdog {
+	/** Start the budget. Idempotent — extra windows do not restart it. */
+	arm(): void;
+	/** Report a renderer. Returns true only for the first report. */
+	markReady(source: string): boolean;
+	state(): RendererReadinessState;
+}
+
+export function createRendererReadinessWatchdog(
+	opts: RendererReadinessOptions,
+): RendererReadinessWatchdog {
+	const setTimer = opts.setTimer ?? ((fn, ms) => {
+		const handle = setTimeout(fn, ms);
+		// The watchdog must never be the reason a process stays alive.
+		(handle as { unref?: () => void }).unref?.();
+		return handle;
+	});
+	const clearTimer = opts.clearTimer ?? ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+	const now = opts.now ?? (() => Date.now());
+
+	let state: RendererReadinessState = opts.timeoutMs === null ? "disabled" : "idle";
+	let timer: TimerHandle | null = null;
+	let armedAt = 0;
+
+	return {
+		arm(): void {
+			if (state !== "idle") return;
+			const timeoutMs = opts.timeoutMs as number;
+			state = "armed";
+			armedAt = now();
+			timer = setTimer(() => {
+				if (state !== "armed") return;
+				state = "failed";
+				timer = null;
+				opts.onTimeout(timeoutMs);
+			}, timeoutMs);
+			opts.onArmed?.(timeoutMs);
+		},
+		markReady(source: string): boolean {
+			if (state === "ready" || state === "failed") return false;
+			const wasArmed = state === "armed";
+			if (state === "disabled") {
+				// Nothing to disarm, but the caller still needs "first renderer"
+				// semantics so it can gate one-shot work on it.
+				state = "ready";
+				opts.onReady?.(source, 0);
+				return true;
+			}
+			state = "ready";
+			if (timer !== null) {
+				clearTimer(timer);
+				timer = null;
+			}
+			opts.onReady?.(source, wasArmed ? now() - armedAt : 0);
+			return true;
+		},
+		state(): RendererReadinessState {
+			return state;
+		},
+	};
+}

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -176,17 +176,27 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		// versions. A quick resize nudge forces the viewport into the post-resize
 		// layout immediately so the app's pb-8 padding stays reliable. Skipped when
 		// restoring fullscreen (setSize would fight the fullscreen transition).
-		setTimeout(() => {
-			try {
-				const size = win.getSize();
-				win.setSize(size.width, size.height - 1);
-				setTimeout(() => {
-					try { win.setSize(size.width, size.height); } catch { /* ignore */ }
-				}, 50);
-			} catch (err) {
-				log.warn("Resize nudge failed", { error: String(err) });
-			}
-		}, 200);
+		//
+		// It waits for dom-ready because resizing a window whose webview never came
+		// up is fatal, not cosmetic: on Windows a failed WebView2 controller plus
+		// this nudge segfaults the native wrapper (decision 177). dom-ready is also
+		// when the nudge is meant to happen — it exists to fix the FIRST PAINT.
+		let nudged = false;
+		win.webview.on("dom-ready", () => {
+			if (nudged) return; // a reload re-fires dom-ready; one nudge per window
+			nudged = true;
+			setTimeout(() => {
+				try {
+					const size = win.getSize();
+					win.setSize(size.width, size.height - 1);
+					setTimeout(() => {
+						try { win.setSize(size.width, size.height); } catch { /* ignore */ }
+					}, 50);
+				} catch (err) {
+					log.warn("Resize nudge failed", { error: String(err) });
+				}
+			}, 200);
+		});
 	}
 
 	if (opts.onDomReady) {

--- a/src/cli/__tests__/cli-startup-graph.test.ts
+++ b/src/cli/__tests__/cli-startup-graph.test.ts
@@ -112,3 +112,32 @@ describe("CLI startup import graph stays light", () => {
 		expect(electrobunDeps, `unexpected static electrobun import(s): ${electrobunDeps.join(", ")}`).toEqual([]);
 	});
 });
+
+/**
+ * The headless server must be window-free BY DESIGN, not by luck. `dev3 remote`
+ * is the documented answer for a machine with no interactive desktop — the exact
+ * situation where creating a BrowserWindow yields a window with no WebView2
+ * controller and no renderer (see renderer-readiness.ts). If the window layer
+ * ever becomes statically reachable from headless-entry, remote mode inherits
+ * that failure mode; this goes red first.
+ */
+describe("headless server never reaches the desktop window layer", () => {
+	const HEADLESS_ENTRY = resolve(REPO_ROOT, "src/bun/headless-entry.ts");
+	const { files, bare } = walkStaticGraph(HEADLESS_ENTRY);
+
+	it("walks a non-trivial graph that includes the remote access server", () => {
+		expect(files.size).toBeGreaterThan(10);
+		expect(files.has(resolve(REPO_ROOT, "src/bun/remote-access-server.ts"))).toBe(true);
+	});
+
+	it("never statically imports the window manager", () => {
+		const windowManager = resolve(REPO_ROOT, "src/bun/window-manager.ts");
+		expect(existsSync(windowManager)).toBe(true);
+		expect(files.has(windowManager), "headless mode must never reach window-manager").toBe(false);
+	});
+
+	it("never statically imports electrobun's native GUI layer", () => {
+		const electrobunDeps = [...bare].filter((d) => d === "electrobun" || d.startsWith("electrobun/"));
+		expect(electrobunDeps, `unexpected static electrobun import(s): ${electrobunDeps.join(", ")}`).toEqual([]);
+	});
+});

--- a/src/shared/cli-exit-codes.ts
+++ b/src/shared/cli-exit-codes.ts
@@ -6,6 +6,7 @@ export const CLI_EXIT_CODE_INTERNAL_ERROR = 4;
 export const CLI_EXIT_CODE_GUI_DEPS_MISSING = 5;
 export const CLI_EXIT_CODE_COMPLETION_DECLINED = 6;
 export const CLI_EXIT_CODE_DOCTOR_PROBLEMS = 7;
+export const CLI_EXIT_CODE_RENDERER_UNAVAILABLE = 8;
 
 export const CLI_EXIT_CODE_DEFINITIONS = [
 	{
@@ -50,5 +51,11 @@ export const CLI_EXIT_CODE_DEFINITIONS = [
 		code: CLI_EXIT_CODE_DOCTOR_PROBLEMS,
 		description:
 			'`dev3 doctor` found at least one problem (a check with status "fail"). Warnings alone still exit 0.',
+	},
+	{
+		constant: "CLI_EXIT_CODE_RENDERER_UNAVAILABLE",
+		code: CLI_EXIT_CODE_RENDERER_UNAVAILABLE,
+		description:
+			"The desktop launch created a window but no renderer ever reported dom-ready within the readiness budget (missing/broken WebView2 runtime, or no interactive desktop). The process prints an actionable diagnostic and leaves instead of running without a UI.",
 	},
 ] as const;


### PR DESCRIPTION
## Summary

On Windows a desktop launch with no interactive desktop (SSH / session 0) or a broken WebView2 runtime created a window whose webview never came up — `new BrowserWindow()` succeeds, and the WebView2 controller then fails asynchronously inside `libNativeWrapper` with `HRESULT 0x80070578`, invisible to JS. Two independent failures followed, both reproduced live on a real Windows x64 machine over SSH:

1. **A segfault.** The 200 ms first-paint resize nudge called `getSize()`/`setSize()` unconditionally, reaching an invalid native wrapper: `panic: Segmentation fault at address 0xFFFFFFFFFFFFFFFF`, crash token naming `libNativeWrapper.dll`, exit code 9 — 4176 ms after start. Controlled A/B on the same machine and checkout: nudge unconditional → crash; nudge behind `dom-ready` → no crash. That also explains the previously observed "4–15 minutes" spread: it is a race with the async controller failure, not a timer.
2. **A UI-less zombie.** With the crash avoided, the app logged `=== dev-3.0 ready ===`, wrote the readiness marker, served remote RPC, and could not be shut down at all — the `before-quit` gate asks the renderer to confirm and there was no renderer.

## What changed

- The first-paint resize nudge now waits for `dom-ready`, which is where a first-paint workaround belongs anyway.
- `renderer-readiness.ts`: the first webview `dom-ready` is the readiness contract. A watchdog is armed after the window is created (45 s, win32 only by default, `DEV3_RENDERER_READY_TIMEOUT_MS` as the seam, `0` disables). Healthy startups measured 366 ms and 1511 ms.
- On timeout: an actionable diagnostic (grep marker, the `0x80070578` explanation, the WebView2 `winget` command, `dev3 remote` as the headless answer) — console and log only, no native dialog. Then `markQuitConfirmed()` so nothing waits for a renderer, the normal cleanup, and exit with the new `CLI_EXIT_CODE_RENDERER_UNAVAILABLE = 8`.
- `hard-exit.ts`: getting a real exit code out needed all three layers measured — `process.exit` is replaced by electrobun (exits 0), `reallyExit` does not end an electrobun app at all, `ExitProcess` fail-fasts with `0xC0000409`. `TerminateProcess(GetCurrentProcess(), code)` yields exactly 8, with the others as ordered fallbacks.
- The packaged-launch readiness marker moved from "window created" to "renderer ready" — it used to report success with no UI.
- Headless/remote mode is untouched by construction: a new static-import-graph guard fails if `window-manager` or `electrobun/*` ever becomes reachable from `headless-entry.ts`, plus an opt-in 16-minute soak (`test:headless-soak`, not in `bun run test`) that serves past the observed 906 s window with the watchdog pinned to 1 ms.

Details and every measurement: `decisions/177-renderer-readiness-desktop-launch.md`.

## Real Windows evidence (SSH, no interactive desktop)

```
22:27:14.009 INFO  [window-manager] Window created {"id":1,"total":1}
22:27:14.010 INFO  [main] Waiting for the renderer to report dom-ready {"timeoutMs":45000}
22:27:14      ERROR: Failed to create WebView2 controller, HRESULT: 0x80070578
22:27:59.021 ERROR [main] Desktop launch failed: no renderer {"timeoutMs":45000,"exitCode":8}
DEV3_DESKTOP_RENDERER_UNAVAILABLE: the desktop window never produced a renderer within 45000ms.
Exiting with code 8 instead of running without a UI.
22:27:59.021 INFO  [main] App is quitting, running global cleanup
22:27:59.022 INFO  [cli-socket] CLI socket removed
```

`APP_EXIT=8` after 45.45 s; no panic, no exit 9; surviving `bun`/`launcher` processes: 0; listeners on the run's ports: 0; leftover socket endpoint files: 0.

Healthy interactive Windows startup on the same machine reached `DOM ready` 366 ms after `Window created` and quit cleanly on Ctrl+C. That baseline was captured before this branch, so re-verification of the healthy interactive window **with** this change is still an owner-run step.