### PR TITLE
Route native task terminals through the existing remote PTY bridge

### DIFF
--- a/change-logs/2026/07/26/feature-70-native-terminal-remote-viewers.md
+++ b/change-logs/2026/07/26/feature-70-native-terminal-remote-viewers.md
@@ -1,0 +1,3 @@
+Short: Native terminals work in remote mode
+
+A task terminal explicitly running on the native backend is now fully usable through `dev3 remote` in a browser: a viewer that attaches mid-session rebuilds the screen from a bounded journal instead of starting blank, a reconnect resumes from its own watermark with no missing or duplicated output, and exactly one viewer types while the rest are read-only until they take control. Tmux terminals are unchanged.

--- a/decisions/172-native-terminal-remote-viewer-bridge.md
+++ b/decisions/172-native-terminal-remote-viewer-bridge.md
@@ -1,0 +1,55 @@
+# 172 — Native terminal viewers over the existing PTY WebSocket
+
+## Context
+
+A task terminal on the native backend (seq 1292) streams through `pty-server`'s
+WebSocket bridge, which remote mode already proxies at `/pty?session=…`. Two
+things tmux gave that bridge for free are missing natively: tmux repaints its
+pane for any newly attached client, and tmux arbitrates several attached clients
+itself. So a browser tab attaching to a live native session showed a blank
+screen, and every viewer could type into the one PTY at once.
+
+## Investigation
+
+The native host already replays its bounded journal to a newly attached client,
+but the app holds ONE client per session and multiplexes every viewer through it
+— so that replay only reaches viewers connected at that instant. `capturePane`
+returns null for native, and the tmux redraw jiggle in `applyClientSizes` only
+resizes a live shell without repainting a plain one.
+
+## Decision
+
+Mirror both missing pieces at the bridge, native-only
+(`src/bun/native-terminal-bridge.ts`, wired in `src/bun/pty-server.ts`):
+
+- `NativeBridgeJournal` — a byte-capped ring of the batches already broadcast,
+  recorded even with zero viewers. `attachNativeClient` flushes pending output,
+  then replays either the delta after the viewer's `since` watermark or the whole
+  tail with an explicit reset, BEFORE the viewer joins the broadcast set.
+- `NativeClientLease` — one writer among the viewers; observers' input is
+  refused with an explicit `role` frame, and `applyClientSizes` sizes the PTY
+  from the writer alone so a phone in portrait cannot shrink the writer's shell.
+
+Framing is in-band on the same wire (`src/shared/native-terminal-stream.ts`):
+one APC-wrapped JSON header per message, followed by raw terminal bytes. Remote
+forwards the `since` param through its existing `/pty` proxy; no second server,
+listener, or auth path is introduced.
+
+## Risks
+
+The journal is bounded (256 KB, matching the host's), so a viewer offline long
+enough gets a rebuilt screen rather than full scrollback — reported as
+`reset: "pressure"`, never as a silent gap. Framing costs one small JSON parse
+per output batch (not per byte); the payload is never escaped.
+
+## Alternatives considered
+
+- **A second WebSocket/daemon speaking the host protocol straight to the
+  browser.** Rejected: duplicates the authenticated remote transport and would
+  put a second writer against the host.
+- **A JSON envelope around the payload.** Rejected: escaping every output byte
+  on the hot path, for no gain over an in-band header.
+- **Reusing the host's parser-state snapshot as the attach screen.** Rejected
+  here: the live parser is opt-in and semantic, while the bridge needs the raw
+  bytes every viewer already renders. It remains the right source if native
+  terminals later need a semantic capture surface.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -10,6 +10,12 @@ git history, PRs, and `decisions/NNN-*.md`. Newest first.
 - **Why:** Post-boot the app read as frozen — `BootstrapScreen` only covers launch, so a dropped socket left a stale board and silently queued actions for the 120s RPC timeout. A header dot/banner was rejected (permanent chrome + layout shift on phones), a toast too (transient signal for a persisting condition). Bible §5.5 + §10.
 - **Status:** Observed. Evidence: `StatusDock.tsx`, `ConnectionStatusPill.tsx`, `ProjectView.tsx`, `KanbanBoardSkeleton.tsx`, `BoardLoadFailed.tsx`.
 
+## 2026-07-25 — A read-only terminal viewer says so, in an earned strip above the canvas
+
+- **Rule:** A native task terminal shared by several viewers (desktop window + remote tabs) gives exactly one of them the write lease; an observer gets a slim NON-overlapping strip directly above the canvas naming the read-only state plus a `Take control` button (secondary, bordered), and that strip flashes `danger` for ~1.6s when the server refuses a keystroke. Writers — and every tmux terminal — get zero chrome.
+- **Why:** A silently read-only terminal is indistinguishable from a hung one. An absolute overlay badge (PaneZoomBadge's pattern) was rejected because it collides with the narrow pane-dots strip; a toast per refused keystroke was rejected as spam for an expected, persisting condition. Follows the existing slim-strip pattern (window switcher/pane dots), so wide and narrow are identical. Bible §5 terminal surfaces.
+- **Status:** Observed. Evidence: `NativeViewerBar.tsx`, `TaskTerminal.tsx`, `decisions/172-native-terminal-remote-viewer-bridge.md`.
+
 ## 2026-07-24 — Inspector bars adapt to the PANEL's width, not the viewport's
 
 - **Rule:** A toolbar that shares the viewport with another surface gates its label/fold behaviour on its own container width (`useContainerWidth`, ResizeObserver), not on `useCompact`/`useNarrowViewport`; and every bar is boxed (`min-w-0 overflow-hidden`) so it can never paint over a neighbour or the pinned chrome. Inspector tiers: `tight` <1280 (label strip → `+k`, branch clamp, tmux/Runtime icon-only), `veryTight` <900 (drop label strip + include-tests).

--- a/src/bun/__tests__/native-terminal-bridge.test.ts
+++ b/src/bun/__tests__/native-terminal-bridge.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The native terminal's per-viewer bridge state (seq 1300).
+ *
+ * Two invariants the remote path depends on: a viewer either resumes exactly
+ * where it stopped or is told the screen was replaced (never a silent gap), and
+ * exactly one viewer holds the write lease at any moment while viewers remain.
+ */
+import { describe, it, expect } from "vitest";
+import { NativeBridgeJournal, NativeClientLease } from "../native-terminal-bridge";
+
+describe("NativeBridgeJournal", () => {
+	it("numbers frames from 1 and reports the watermark", () => {
+		const journal = new NativeBridgeJournal();
+
+		expect(journal.push("a")).toBe(1);
+		expect(journal.push("b")).toBe(2);
+		expect(journal.tailSeq).toBe(2);
+		expect(journal.headSeq).toBe(1);
+	});
+
+	it("ignores an empty frame instead of burning a sequence number", () => {
+		const journal = new NativeBridgeJournal();
+		journal.push("a");
+
+		expect(journal.push("")).toBe(1);
+		expect(journal.tailSeq).toBe(1);
+	});
+
+	it("hands a first-time viewer the whole tail and flags it as a rebuild", () => {
+		const journal = new NativeBridgeJournal();
+		journal.push("one");
+		journal.push("two");
+
+		const replay = journal.replayFrom(null);
+
+		expect(replay).toEqual({ seq: 2, data: "onetwo", resumed: false, reset: "fresh" });
+	});
+
+	it("resumes a reconnecting viewer with only the frames it missed", () => {
+		const journal = new NativeBridgeJournal();
+		journal.push("one");
+		journal.push("two");
+		journal.push("three");
+
+		expect(journal.replayFrom(1)).toEqual({ seq: 3, data: "twothree", resumed: true });
+	});
+
+	it("sends nothing to a viewer that is already level — no duplicated bytes", () => {
+		const journal = new NativeBridgeJournal();
+		journal.push("one");
+
+		expect(journal.replayFrom(1)).toEqual({ seq: 1, data: "", resumed: true });
+		// A watermark ahead of us (stale reconnect ordering) must never rewind either.
+		expect(journal.replayFrom(9)).toEqual({ seq: 1, data: "", resumed: true });
+	});
+
+	it("attaches to a session that has produced nothing yet", () => {
+		const journal = new NativeBridgeJournal();
+
+		expect(journal.replayFrom(null)).toEqual({ seq: 0, data: "", resumed: false, reset: "fresh" });
+	});
+
+	it("still resumes a viewer whose whole missing range survived the cap", () => {
+		const journal = new NativeBridgeJournal(8);
+		journal.push("aaaa");
+		journal.push("bbbb");
+		journal.push("cccc"); // evicts "aaaa"
+
+		// Eviction alone is not a gap: frames 2 and 3 are exactly what seq 1 missed.
+		expect(journal.headSeq).toBe(2);
+		expect(journal.replayFrom(1)).toEqual({ seq: 3, data: "bbbbcccc", resumed: true });
+		expect(journal.resyncCount).toBe(0);
+	});
+
+	it("stays bounded and answers an evicted watermark with an explicit resync", () => {
+		const journal = new NativeBridgeJournal(8);
+		journal.push("aaaa");
+		journal.push("bbbb");
+		journal.push("cccc");
+		journal.push("dddd"); // frames 1 and 2 are gone
+
+		expect(journal.headSeq).toBe(3);
+		const replay = journal.replayFrom(1);
+
+		expect(replay).toEqual({ seq: 4, data: "ccccdddd", resumed: false, reset: "pressure" });
+		expect(journal.resyncCount).toBe(1);
+	});
+
+	it("keeps the newest frame even when it alone exceeds the cap", () => {
+		const journal = new NativeBridgeJournal(4);
+		journal.push("aaaa");
+		journal.push("bbbbbbbbbb");
+
+		expect(journal.replayFrom(1)).toMatchObject({ data: "bbbbbbbbbb", resumed: true });
+	});
+});
+
+describe("NativeClientLease", () => {
+	it("makes the first viewer the writer and every later one an observer", () => {
+		const lease = new NativeClientLease<string>();
+
+		expect(lease.attach("desktop")).toBe("writer");
+		expect(lease.attach("browser")).toBe("observer");
+		expect(lease.canWrite("desktop")).toBe(true);
+		expect(lease.canWrite("browser")).toBe(false);
+	});
+
+	it("moves the lease atomically on takeover", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+		lease.attach("browser");
+
+		expect(lease.claim("browser")).toEqual({ writer: "browser", previous: "desktop" });
+		expect(lease.roleOf("desktop")).toBe("observer");
+		expect(lease.roleOf("browser")).toBe("writer");
+		// Re-claiming is a no-op, not a second transfer.
+		expect(lease.claim("browser")).toBeNull();
+	});
+
+	it("refuses a claim from a viewer that never attached", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+
+		expect(lease.claim("stranger")).toBeNull();
+		expect(lease.writer).toBe("desktop");
+	});
+
+	it("promotes a remaining viewer when the writer disconnects", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+		lease.attach("browser");
+
+		expect(lease.detach("desktop")).toEqual({ writer: "browser", previous: "desktop" });
+		expect(lease.canWrite("browser")).toBe(true);
+	});
+
+	it("says nothing when an observer disconnects", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+		lease.attach("browser");
+
+		expect(lease.detach("browser")).toBeNull();
+		expect(lease.writer).toBe("desktop");
+	});
+
+	it("leaves no writer once the last viewer is gone, and re-seeds on the next attach", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+
+		expect(lease.detach("desktop")).toEqual({ writer: null, previous: "desktop" });
+		expect(lease.size).toBe(0);
+		expect(lease.attach("browser")).toBe("writer");
+	});
+
+	it("hands the lease to the next viewer on an explicit release", () => {
+		const lease = new NativeClientLease<string>();
+		lease.attach("desktop");
+		lease.attach("browser");
+
+		expect(lease.release("desktop")).toEqual({ writer: "browser", previous: "desktop" });
+		expect(lease.release("desktop")).toBeNull();
+	});
+});

--- a/src/bun/__tests__/native-terminal-stream.test.ts
+++ b/src/bun/__tests__/native-terminal-stream.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The native terminal's in-band bridge framing (seq 1300).
+ *
+ * The same wire carries tmux's bare terminal text and the native backend's
+ * framed messages, so the decoder's most important property is that it says
+ * "not mine" for anything it does not fully understand — a truncated, foreign
+ * version, or plain-text frame must fall through to the terminal untouched
+ * rather than throw or half-parse.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	attachMessage,
+	claimMessage,
+	decodeNativeStreamMessage,
+	encodeNativeStreamMessage,
+	isNativeStreamMessage,
+	outputMessage,
+	parseSinceParam,
+	ptyUrlWithSince,
+	releaseMessage,
+	roleMessage,
+	NATIVE_STREAM_PROTOCOL_VERSION,
+} from "../../shared/native-terminal-stream";
+
+const ATTACH = {
+	seq: 7,
+	role: "writer" as const,
+	sessionId: "dev3-task-abc",
+	paneId: "dev3-task-abc:0",
+	hostPid: 100,
+	shellPid: 101,
+	resumed: true,
+};
+
+describe("native stream framing", () => {
+	it("round-trips an attach with its replay payload", () => {
+		const decoded = decodeNativeStreamMessage(attachMessage(ATTACH, "hello\r\n"));
+
+		expect(decoded?.header).toEqual({ t: "attach", v: NATIVE_STREAM_PROTOCOL_VERSION, ...ATTACH });
+		expect(decoded?.payload).toBe("hello\r\n");
+	});
+
+	it("carries a reset reason only when the screen is being replaced", () => {
+		const rebuilt = decodeNativeStreamMessage(
+			attachMessage({ ...ATTACH, resumed: false, reset: "pressure" }, "screen"),
+		);
+
+		expect(rebuilt?.header).toMatchObject({ resumed: false, reset: "pressure" });
+		expect(decodeNativeStreamMessage(attachMessage(ATTACH, ""))?.header).not.toHaveProperty("reset");
+	});
+
+	it("round-trips output, role, and ownership frames", () => {
+		expect(decodeNativeStreamMessage(outputMessage(42, "data"))).toEqual({
+			header: { t: "o", v: NATIVE_STREAM_PROTOCOL_VERSION, seq: 42 },
+			payload: "data",
+		});
+		expect(decodeNativeStreamMessage(roleMessage("observer", true))?.header).toMatchObject({
+			t: "role",
+			role: "observer",
+			refused: true,
+		});
+		expect(decodeNativeStreamMessage(claimMessage())?.header.t).toBe("claim");
+		expect(decodeNativeStreamMessage(releaseMessage())?.header.t).toBe("release");
+	});
+
+	it("keeps a payload containing the frame marker intact", () => {
+		// Terminal output can legitimately contain escape sequences; only the FIRST
+		// header is consumed, everything after it is opaque bytes.
+		const payload = `tail ${outputMessage(1, "inner")}`;
+		const decoded = decodeNativeStreamMessage(outputMessage(9, payload));
+
+		expect(decoded?.header).toMatchObject({ seq: 9 });
+		expect(decoded?.payload).toBe(payload);
+	});
+
+	it("treats plain terminal text as not-a-frame", () => {
+		expect(isNativeStreamMessage("$ ls -la\r\n")).toBe(false);
+		expect(decodeNativeStreamMessage("$ ls -la\r\n")).toBeNull();
+		expect(decodeNativeStreamMessage("\x1b[31mred\x1b[0m")).toBeNull();
+	});
+
+	it("refuses a truncated, malformed, or foreign-version frame", () => {
+		expect(decodeNativeStreamMessage("\x1b_dev3nt;{\"t\":\"o\",\"v\":1,\"seq\":1}")).toBeNull();
+		expect(decodeNativeStreamMessage("\x1b_dev3nt;not json\x1b\\payload")).toBeNull();
+		expect(decodeNativeStreamMessage(encodeNativeStreamMessage({ t: "o", v: 99, seq: 1 }))).toBeNull();
+		expect(decodeNativeStreamMessage(encodeNativeStreamMessage({ t: "o", v: 1 } as never))).toBeNull();
+	});
+});
+
+describe("resume addressing", () => {
+	it("leaves a URL untouched when there is no watermark (the tmux path)", () => {
+		expect(ptyUrlWithSince("ws://host/pty?session=t1", null)).toBe("ws://host/pty?session=t1");
+		expect(ptyUrlWithSince("ws://host/pty?session=t1", -1)).toBe("ws://host/pty?session=t1");
+	});
+
+	it("appends the watermark with the right separator", () => {
+		expect(ptyUrlWithSince("ws://host/pty?session=t1", 12)).toBe("ws://host/pty?session=t1&since=12");
+		expect(ptyUrlWithSince("ws://host/pty", 0)).toBe("ws://host/pty?since=0");
+	});
+
+	it("reads back only a sane watermark", () => {
+		expect(parseSinceParam("12")).toBe(12);
+		expect(parseSinceParam("0")).toBe(0);
+		expect(parseSinceParam(null)).toBeNull();
+		expect(parseSinceParam("")).toBeNull();
+		expect(parseSinceParam("-3")).toBeNull();
+		expect(parseSinceParam("1.5")).toBeNull();
+		expect(parseSinceParam("nope")).toBeNull();
+	});
+});

--- a/src/bun/__tests__/pty-server-native-bridge.test.ts
+++ b/src/bun/__tests__/pty-server-native-bridge.test.ts
@@ -1,0 +1,419 @@
+/**
+ * The native terminal's viewer bridge over the PTY WebSocket (seq 1300).
+ *
+ * This is the exact channel remote mode proxies to a browser, so the tests drive
+ * the server's real WebSocket handlers (captured from `Bun.serve`) with fake
+ * clients instead of asserting on the pure units alone. What must hold: a viewer
+ * rebuilds the screen on attach, resumes after a drop without missing or
+ * duplicated bytes, and is read-only until it explicitly takes over — while the
+ * shell, its siblings, and tmux are never touched.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		accessSync: vi.fn(),
+		existsSync: vi.fn(() => true),
+		writeFileSync: vi.fn(),
+		mkdirSync: vi.fn(),
+		lstatSync: vi.fn(() => { throw new Error("ENOENT"); }),
+		statSync: vi.fn(() => ({ isFile: () => true })),
+		readlinkSync: vi.fn(() => { throw new Error("EINVAL"); }),
+		realpathSync: vi.fn((p: string) => p),
+		unlinkSync: vi.fn(),
+		symlinkSync: vi.fn(),
+	};
+});
+
+vi.mock("../spawn", () => ({ spawn: vi.fn(), spawnSync: vi.fn() }));
+
+vi.mock("../native-task-terminal", () => ({
+	startNativeTaskTerminal: vi.fn(),
+	attachNativeTaskTerminal: vi.fn(async () => null),
+	nativeTaskTerminalAlive: vi.fn(async () => true),
+	stopNativeTaskTerminal: vi.fn(async () => undefined),
+}));
+
+import {
+	claimMessage,
+	decodeNativeStreamMessage,
+	releaseMessage,
+	type NativeStreamAttachHeader,
+	type NativeStreamHeader,
+} from "../../shared/native-terminal-stream";
+import { encodeResizeSequence } from "../../shared/resize-protocol";
+import { startNativeTaskTerminal } from "../native-task-terminal";
+import { tmux } from "../tmux";
+
+// The PTY server's WebSocket handlers are the unit under test; `Bun.serve` is a
+// stub in this suite, so intercept the config it is handed at module load.
+interface WsHandlers {
+	open(ws: unknown): void;
+	message(ws: unknown, message: string | Uint8Array): void;
+	close(ws: unknown): void;
+}
+let handlers: WsHandlers;
+const bun = globalThis as unknown as { Bun: { serve: (config: unknown) => unknown } };
+const stubServe = bun.Bun.serve;
+bun.Bun.serve = (config: unknown) => {
+	const websocket = (config as { websocket?: WsHandlers }).websocket;
+	if (websocket) handlers = websocket;
+	return stubServe(config);
+};
+
+const pty = await import("../pty-server");
+
+const TASK_ID = "aabbccdd-1111-2222-3333-444444444444";
+const SESSION_ID = `dev3-task-${TASK_ID}`;
+const LAUNCH = { executable: "/bin/zsh", argv: ["/tmp/dev3/run.sh"] };
+/** Longer than the 16ms output batch window, so a flush has definitely landed. */
+const FLUSH_MS = 40;
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** ES2020 target: no Array.prototype.at. */
+function lastCall<T>(items: T[]): T | undefined {
+	return items.length === 0 ? undefined : items[items.length - 1];
+}
+
+/** A viewer of the session: what the server sent it, in order. */
+class Viewer {
+	readonly frames: Array<{ header: NativeStreamHeader; payload: string }> = [];
+	readonly raw: string[] = [];
+	readonly data: { url: URL };
+	closed = false;
+
+	constructor(since?: number) {
+		const query = `session=${TASK_ID}${since === undefined ? "" : `&since=${since}`}`;
+		this.data = { url: new URL(`http://localhost/?${query}`) };
+	}
+
+	sendText(text: string): void {
+		if (this.closed) throw new Error("dead client");
+		this.raw.push(text);
+		const frame = decodeNativeStreamMessage(text);
+		if (frame) this.frames.push(frame);
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+
+	get attach(): NativeStreamAttachHeader {
+		const frame = this.frames.find((f) => f.header.t === "attach");
+		if (!frame) throw new Error("no attach frame received");
+		return frame.header as NativeStreamAttachHeader;
+	}
+
+	/** Everything this viewer would have written into its terminal, in order. */
+	screen(): string {
+		return this.frames.map((f) => f.payload).join("");
+	}
+
+	roles(): Array<{ role: string; refused: boolean }> {
+		return this.frames
+			.filter((f) => f.header.t === "role")
+			.map((f) => {
+				const header = f.header as { role: string; refused?: boolean };
+				return { role: header.role, refused: header.refused === true };
+			});
+	}
+
+	get lastRole(): { role: string; refused: boolean } | undefined {
+		return lastCall(this.roles());
+	}
+
+	get watermark(): number {
+		for (let i = this.frames.length - 1; i >= 0; i--) {
+			const header = this.frames[i].header as { seq?: number };
+			if (typeof header.seq === "number") return header.seq;
+		}
+		throw new Error("no watermark received");
+	}
+}
+
+interface FakeShell {
+	write: ReturnType<typeof vi.fn>;
+	resize: ReturnType<typeof vi.fn>;
+	detach: ReturnType<typeof vi.fn>;
+	emit: (data: string) => void;
+}
+
+function fakeShell(): FakeShell {
+	let emit: (data: string) => void = () => {};
+	const shell: FakeShell = {
+		write: vi.fn(),
+		resize: vi.fn(),
+		detach: vi.fn(),
+		emit: (data) => emit(data),
+	};
+	vi.mocked(startNativeTaskTerminal).mockImplementation(async (spec) => {
+		emit = (data) => spec.onOutput(new TextEncoder().encode(data));
+		return {
+			sessionId: SESSION_ID,
+			paneId: `${SESSION_ID}:0`,
+			hostPid: 4242,
+			shellPid: 4243,
+			write: shell.write,
+			resize: shell.resize,
+			detach: shell.detach,
+		} as unknown as Awaited<ReturnType<typeof startNativeTaskTerminal>>;
+	});
+	return shell;
+}
+
+let shell: FakeShell;
+const attached: Viewer[] = [];
+
+/** Connect a viewer through the real open handler. */
+function connect(since?: number): Viewer {
+	const viewer = new Viewer(since);
+	handlers.open(viewer);
+	attached.push(viewer);
+	return viewer;
+}
+
+function disconnect(viewer: Viewer): void {
+	handlers.close(viewer);
+	viewer.close();
+}
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	shell = fakeShell();
+	await pty.createNativeTaskSession(TASK_ID, "proj-1", "/tmp/wt", LAUNCH);
+});
+
+afterEach(async () => {
+	for (const viewer of attached.splice(0)) if (!viewer.closed) disconnect(viewer);
+	await pty.destroySessionAwaited(TASK_ID);
+});
+
+describe("attaching a native viewer", () => {
+	it("rebuilds the screen from the journal and reports the session identity", async () => {
+		shell.emit("hello from the shell\r\n");
+		await delay(FLUSH_MS);
+
+		const desktop = connect();
+
+		expect(desktop.attach).toMatchObject({
+			role: "writer",
+			resumed: false,
+			reset: "fresh",
+			sessionId: SESSION_ID,
+			paneId: `${SESSION_ID}:0`,
+			hostPid: 4242,
+			shellPid: 4243,
+		});
+		expect(desktop.screen()).toBe("hello from the shell\r\n");
+	});
+
+	it("replays even output produced with no viewer attached at all", async () => {
+		// Remote-only use: the desktop window is closed, the shell keeps working.
+		shell.emit("headless output\r\n");
+		await delay(FLUSH_MS);
+
+		expect(connect().screen()).toBe("headless output\r\n");
+	});
+
+	it("gives a second viewer the same screen and identity, as an observer", async () => {
+		shell.emit("shared screen\r\n");
+		await delay(FLUSH_MS);
+		const desktop = connect();
+
+		const browser = connect();
+
+		expect(browser.attach.role).toBe("observer");
+		expect(browser.attach.sessionId).toBe(desktop.attach.sessionId);
+		expect(browser.attach.paneId).toBe(desktop.attach.paneId);
+		expect(browser.attach.hostPid).toBe(desktop.attach.hostPid);
+		expect(browser.attach.shellPid).toBe(desktop.attach.shellPid);
+		expect(browser.screen()).toBe(desktop.screen());
+	});
+
+	it("attaches to a silent session without claiming to have replayed anything", () => {
+		const desktop = connect();
+
+		expect(desktop.attach).toMatchObject({ seq: 0, resumed: false, reset: "fresh" });
+		expect(desktop.screen()).toBe("");
+	});
+
+	it("streams live output to every viewer with a monotonic watermark", async () => {
+		const desktop = connect();
+		const browser = connect();
+
+		shell.emit("first\r\n");
+		await delay(FLUSH_MS);
+		shell.emit("second\r\n");
+		await delay(FLUSH_MS);
+
+		expect(desktop.screen()).toBe("first\r\nsecond\r\n");
+		expect(browser.screen()).toBe("first\r\nsecond\r\n");
+		const seqs = desktop.frames.map((f) => (f.header as { seq: number }).seq);
+		expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+		expect(desktop.watermark).toBe(browser.watermark);
+	});
+});
+
+describe("reconnecting a native viewer", () => {
+	it("resumes from its watermark with exactly the frames it missed", async () => {
+		const first = connect();
+		shell.emit("before-drop\r\n");
+		await delay(FLUSH_MS);
+		const watermark = first.watermark;
+
+		disconnect(first);
+		shell.emit("after-drop\r\n");
+		await delay(FLUSH_MS);
+
+		const resumed = connect(watermark);
+
+		expect(resumed.attach).toMatchObject({ resumed: true });
+		expect(resumed.screen()).toBe("after-drop\r\n");
+	});
+
+	it("sends nothing at all to a viewer that never fell behind", async () => {
+		const desktop = connect();
+		shell.emit("caught up\r\n");
+		await delay(FLUSH_MS);
+		const watermark = desktop.watermark;
+		disconnect(desktop);
+
+		const resumed = connect(watermark);
+
+		expect(resumed.attach).toMatchObject({ resumed: true, seq: watermark });
+		expect(resumed.screen()).toBe("");
+	});
+
+	it("keeps the same host, shell, session, and pane identity across the drop", async () => {
+		const first = connect();
+		shell.emit("x\r\n");
+		await delay(FLUSH_MS);
+		disconnect(first);
+
+		const second = connect(first.watermark);
+
+		expect(second.attach.sessionId).toBe(first.attach.sessionId);
+		expect(second.attach.paneId).toBe(first.attach.paneId);
+		expect(second.attach.hostPid).toBe(first.attach.hostPid);
+		expect(second.attach.shellPid).toBe(first.attach.shellPid);
+		expect(startNativeTaskTerminal).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("writer and observer", () => {
+	it("passes the writer's keystrokes to the shell", () => {
+		const desktop = connect();
+
+		handlers.message(desktop, "ls\r");
+
+		expect(shell.write).toHaveBeenCalledWith("ls\r");
+	});
+
+	it("refuses an observer's keystrokes and says so", () => {
+		connect();
+		const browser = connect();
+
+		handlers.message(browser, "rm -rf /\r");
+
+		expect(shell.write).not.toHaveBeenCalled();
+		expect(browser.lastRole).toEqual({ role: "observer", refused: true });
+	});
+
+	it("sizes the PTY from the writer alone, so an observer's viewport cannot shrink it", () => {
+		const desktop = connect();
+		const browser = connect();
+
+		handlers.message(desktop, encodeResizeSequence(200, 50));
+		handlers.message(browser, encodeResizeSequence(40, 12));
+
+		expect(shell.resize.mock.calls).toEqual([[200, 50]]);
+	});
+
+	it("moves the lease atomically on an explicit takeover", () => {
+		const desktop = connect();
+		const browser = connect();
+
+		handlers.message(browser, claimMessage());
+
+		expect(browser.lastRole).toEqual({ role: "writer", refused: false });
+		expect(desktop.lastRole).toEqual({ role: "observer", refused: false });
+
+		handlers.message(browser, "now mine\r");
+		expect(shell.write).toHaveBeenCalledWith("now mine\r");
+		handlers.message(desktop, "not any more\r");
+		expect(shell.write).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-sizes the PTY to the new writer's viewport after a takeover", () => {
+		const desktop = connect();
+		const browser = connect();
+		handlers.message(desktop, encodeResizeSequence(200, 50));
+		handlers.message(browser, encodeResizeSequence(80, 24));
+
+		handlers.message(browser, claimMessage());
+
+		expect(lastCall(shell.resize.mock.calls)).toEqual([80, 24]);
+	});
+
+	it("hands the lease back on an explicit release", () => {
+		const desktop = connect();
+		const browser = connect();
+		handlers.message(browser, claimMessage());
+
+		handlers.message(browser, releaseMessage());
+
+		expect(desktop.lastRole).toEqual({ role: "writer", refused: false });
+		expect(browser.lastRole).toEqual({ role: "observer", refused: false });
+	});
+
+	it("promotes a remaining viewer when the writer disconnects, and leaves the shell alive", () => {
+		const desktop = connect();
+		const browser = connect();
+
+		disconnect(desktop);
+
+		expect(shell.detach).not.toHaveBeenCalled();
+		expect(browser.lastRole).toEqual({ role: "writer", refused: false });
+		handlers.message(browser, "still here\r");
+		expect(shell.write).toHaveBeenCalledWith("still here\r");
+	});
+
+	it("keeps the shell running when every viewer disconnects", async () => {
+		disconnect(connect());
+
+		expect(shell.detach).not.toHaveBeenCalled();
+		shell.emit("still alive\r\n");
+		await delay(FLUSH_MS);
+
+		expect(connect().screen()).toBe("still alive\r\n");
+	});
+});
+
+describe("isolation from tmux", () => {
+	it("never reaches for tmux across the whole viewer lifecycle", async () => {
+		const killSession = vi.spyOn(tmux, "killSession").mockResolvedValue("" as never);
+		const capturePane = vi.spyOn(tmux, "capturePane").mockResolvedValue("" as never);
+
+		const desktop = connect();
+		const browser = connect();
+		shell.emit("work\r\n");
+		await delay(FLUSH_MS);
+		handlers.message(browser, claimMessage());
+		handlers.message(browser, "input\r");
+		handlers.message(browser, encodeResizeSequence(120, 40));
+		disconnect(desktop);
+
+		expect(killSession).not.toHaveBeenCalled();
+		expect(capturePane).not.toHaveBeenCalled();
+		expect(await pty.capturePane(TASK_ID)).toBeNull();
+		killSession.mockRestore();
+		capturePane.mockRestore();
+	});
+});

--- a/src/bun/native-task-terminal.ts
+++ b/src/bun/native-task-terminal.ts
@@ -47,6 +47,8 @@ export interface NativeTaskTerminalSpec extends NativeTaskTerminalHooks {
 /** The app's live write/resize/read binding to one native task terminal. */
 export interface NativeTaskTerminal {
 	readonly sessionId: string;
+	/** The host's pane identity — the same string every viewer of this shell sees. */
+	readonly paneId: string;
 	readonly hostPid: number;
 	readonly shellPid: number;
 	write(data: string): void;
@@ -98,6 +100,7 @@ function bind(
 	client.onDisconnect(close);
 	return {
 		sessionId,
+		paneId: record?.paneId ?? `${sessionId}:0`,
 		hostPid: record?.host.pid ?? -1,
 		shellPid: record?.shell.pid ?? -1,
 		write(data) {

--- a/src/bun/native-terminal-bridge.ts
+++ b/src/bun/native-terminal-bridge.ts
@@ -1,0 +1,186 @@
+/**
+ * App-side bridge state for a NATIVE task terminal's viewers (seq 1300).
+ *
+ * The app holds one writer client against the native host; every viewer —
+ * desktop window, remote browser tab — multiplexes through it over the PTY
+ * WebSocket. That multiplexing needs two things the tmux path gets for free
+ * from tmux itself:
+ *
+ *  • {@link NativeBridgeJournal} — a bounded mirror of the output the app has
+ *    already broadcast, so a viewer that attaches mid-session (or reconnects
+ *    after a tunnel drop) is handed the screen instead of a blank terminal.
+ *    Bounded means a viewer can fall off it; that is reported as an explicit
+ *    reset, never as unbounded buffering or a silently corrupt screen.
+ *  • {@link NativeClientLease} — exactly one WRITER among the viewers. tmux lets
+ *    every attached client type; a native session has one PTY and no client
+ *    arbitration of its own, so two viewers typing (or two viewports resizing)
+ *    would fight over one shell. Observers are read-only until they explicitly
+ *    take over.
+ *
+ * Both are pure in-memory structures over opaque client handles, so they are
+ * unit-testable without a WebSocket, and neither knows anything about tmux.
+ */
+
+import type { NativeStreamResetReason, NativeStreamRole } from "../shared/native-terminal-stream";
+
+/** Matches the host's own journal cap — the app mirrors, it does not extend. */
+export const DEFAULT_BRIDGE_JOURNAL_MAX_BYTES = 256 * 1024;
+
+export interface BridgeReplay {
+	/** Watermark after applying `data`; the client resumes from here. */
+	seq: number;
+	data: string;
+	/** True when `data` continues the client's stream; false when it replaces the screen. */
+	resumed: boolean;
+	/** Why the screen was replaced. Absent when `resumed`. */
+	reset?: NativeStreamResetReason;
+}
+
+/**
+ * Byte-capped ring of the frames already broadcast for one native session.
+ *
+ * Sequence numbers are 1-based and strictly increasing for the life of the
+ * session, so a client's watermark stays meaningful across reconnects. Frames
+ * are evicted oldest-first once the cap is exceeded; a client whose watermark
+ * was evicted gets the whole retained tail and an explicit `pressure` reset.
+ */
+export class NativeBridgeJournal {
+	private frames: Array<{ seq: number; data: string }> = [];
+	private bytes = 0;
+	private tail = 0;
+	private evicted = false;
+	private resets = 0;
+
+	constructor(private readonly maxBytes: number = DEFAULT_BRIDGE_JOURNAL_MAX_BYTES) {}
+
+	/** Seq of the newest retained frame; 0 before any output. */
+	get tailSeq(): number {
+		return this.tail;
+	}
+
+	/** Seq of the oldest retained frame; 0 when empty. */
+	get headSeq(): number {
+		return this.frames[0]?.seq ?? 0;
+	}
+
+	/** How many attaches had to replace the screen because the watermark was gone. */
+	get resyncCount(): number {
+		return this.resets;
+	}
+
+	/** Record one broadcast frame and return its sequence number. */
+	push(data: string): number {
+		if (!data) return this.tail;
+		const seq = ++this.tail;
+		this.frames.push({ seq, data });
+		this.bytes += data.length;
+		while (this.frames.length > 1 && this.bytes > this.maxBytes) {
+			this.bytes -= this.frames.shift()!.data.length;
+			this.evicted = true;
+		}
+		return seq;
+	}
+
+	/**
+	 * What to send a client attaching with watermark `since` (`null` = never had
+	 * one). Ahead-or-level clients get nothing, which is what makes a reconnect
+	 * free of duplicated bytes; a reachable watermark gets the delta after it.
+	 */
+	replayFrom(since: number | null): BridgeReplay {
+		if (since === null) {
+			this.resets++;
+			return { seq: this.tail, data: this.joinAll(), resumed: false, reset: "fresh" };
+		}
+		if (since >= this.tail) return { seq: this.tail, data: "", resumed: true };
+		const head = this.headSeq;
+		if (head === 0 || since < head - 1) {
+			this.resets++;
+			const reason: NativeStreamResetReason = this.evicted ? "pressure" : "gap";
+			return { seq: this.tail, data: this.joinAll(), resumed: false, reset: reason };
+		}
+		let data = "";
+		for (const frame of this.frames) {
+			if (frame.seq > since) data += frame.data;
+		}
+		return { seq: this.tail, data, resumed: true };
+	}
+
+	private joinAll(): string {
+		let data = "";
+		for (const frame of this.frames) data += frame.data;
+		return data;
+	}
+}
+
+export interface LeaseChange<C> {
+	writer: C | null;
+	/** The client that held the lease before this change, if any. */
+	previous: C | null;
+}
+
+/**
+ * Single-writer lease over a native session's viewers.
+ *
+ * The first viewer to attach becomes the writer; later ones observe. A takeover
+ * is one atomic step — the lease moves, and both the old and new writer learn
+ * their new role — so there is never a moment with two writers or none while
+ * viewers remain.
+ */
+export class NativeClientLease<C> {
+	/** Insertion-ordered, so promotion after a writer leaves is deterministic. */
+	private readonly clients = new Set<C>();
+	private current: C | null = null;
+
+	get writer(): C | null {
+		return this.current;
+	}
+
+	get size(): number {
+		return this.clients.size;
+	}
+
+	roleOf(client: C): NativeStreamRole {
+		return this.current === client ? "writer" : "observer";
+	}
+
+	canWrite(client: C): boolean {
+		return this.current === client;
+	}
+
+	attach(client: C): NativeStreamRole {
+		this.clients.add(client);
+		if (this.current === null) this.current = client;
+		return this.roleOf(client);
+	}
+
+	/** Take the lease. Returns `null` when this client already held it. */
+	claim(client: C): LeaseChange<C> | null {
+		if (!this.clients.has(client) || this.current === client) return null;
+		const previous = this.current;
+		this.current = client;
+		return { writer: client, previous };
+	}
+
+	/** Hand the lease back. Returns `null` unless this client held it. */
+	release(client: C): LeaseChange<C> | null {
+		if (this.current !== client) return null;
+		this.current = this.nextAfter(client);
+		return { writer: this.current, previous: client };
+	}
+
+	/** Drop a disconnected viewer. Returns the promotion when the writer left. */
+	detach(client: C): LeaseChange<C> | null {
+		const wasWriter = this.current === client;
+		this.clients.delete(client);
+		if (!wasWriter) return null;
+		this.current = this.nextAfter(client);
+		return { writer: this.current, previous: client };
+	}
+
+	private nextAfter(client: C): C | null {
+		for (const candidate of this.clients) {
+			if (candidate !== client) return candidate;
+		}
+		return null;
+	}
+}

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -3,6 +3,15 @@ import type { TmuxLayout, TmuxWindowInfo, TmuxPaneInfo } from "../shared/types";
 import { ENV_UNSET } from "../shared/agent-accounts";
 import type { TerminalBackendIdentity } from "../shared/terminal-backend-identity";
 import { isResizeSequence, parseResizeSequence, smallestClientSize } from "../shared/resize-protocol";
+import {
+	attachMessage,
+	decodeNativeStreamMessage,
+	outputMessage,
+	parseSinceParam,
+	roleMessage,
+	NATIVE_STREAM_SINCE_PARAM,
+} from "../shared/native-terminal-stream";
+import { NativeBridgeJournal, NativeClientLease } from "./native-terminal-bridge";
 import { createLogger } from "./logger";
 import { spawn } from "./spawn";
 import { getUserShell } from "./shell-env";
@@ -13,7 +22,7 @@ import {
 	type NativeTaskTerminal,
 } from "./native-task-terminal";
 import { PTY_WS_CLOSE } from "../shared/pty-ws-close-codes";
-import type { TerminalLaunchSpec } from "./task-terminal-backend";
+import { nativeTaskSessionId, type TerminalLaunchSpec } from "./task-terminal-backend";
 import {
 	tmux,
 	DEFAULT_TMUX_SOCKET,
@@ -116,6 +125,10 @@ interface PtySession {
 	native: NativeTaskTerminal | null;
 	/** Guards against two concurrent reattach attempts for one native session. */
 	nativeAttaching: boolean;
+	/** Bounded mirror of broadcast output, so a late/reconnecting viewer sees the screen. */
+	nativeStream: NativeBridgeJournal | null;
+	/** Which viewer may type into the shell. Native only — tmux arbitrates its own clients. */
+	nativeLease: NativeClientLease<any> | null;
 	/** All currently connected WebSocket clients. PTY output is broadcast to all. */
 	clients: Set<any>;
 	tmuxSocket: string;
@@ -200,6 +213,8 @@ export function createSession(
 		proc: null,
 		native: null,
 		nativeAttaching: false,
+		nativeStream: null,
+		nativeLease: null,
 		clients: new Set(),
 		tmuxSocket,
 		tmuxSessionName,
@@ -232,7 +247,11 @@ function ingestPtyOutput(session: PtySession, data: string | Uint8Array): void {
 	session.idleNotified = false;
 	const cleaned = handleOsc52(str, session);
 	checkForBell(cleaned, session.taskId);
-	if (cleaned && session.clients.size > 0) enqueuePtyData(session, cleaned);
+	if (!cleaned) return;
+	// A native session always enqueues: the batch lands in its bounded journal even
+	// with no viewer attached, which is what lets a remote tab attach to a running
+	// shell and see the screen. tmux replays its own pane, so it stays as it was.
+	if (session.backend === "native" || session.clients.size > 0) enqueuePtyData(session, cleaned);
 }
 
 /** One death path for both create and reattach, so their bookkeeping cannot drift. */
@@ -287,6 +306,8 @@ export async function createNativeTaskSession(
 		proc: null,
 		native: null,
 		nativeAttaching: false,
+		nativeStream: new NativeBridgeJournal(),
+		nativeLease: new NativeClientLease(),
 		clients: new Set(),
 		// A native session has no tmux socket or session name; the empty strings
 		// exist so a stray tmux call fails loudly instead of hitting a real session.
@@ -352,6 +373,8 @@ export async function reattachNativeTaskSession(taskId: string, projectId: strin
 		proc: null,
 		native: null,
 		nativeAttaching: false,
+		nativeStream: new NativeBridgeJournal(),
+		nativeLease: new NativeClientLease(),
 		clients: new Set(),
 		tmuxSocket: "",
 		tmuxSessionName: "",
@@ -876,16 +899,97 @@ function sessionShell(session: PtySession): { write(data: string): void; resize(
 	return term ?? null;
 }
 
+function sendToClient(client: any, text: string): void {
+	try {
+		client.sendText(text);
+	} catch {
+		// dead client — dropped on its close event
+	}
+}
+
+/**
+ * Hand a newly connected viewer its role and the screen, before it joins the
+ * live broadcast. `since` is the watermark it last applied (null on a first
+ * attach), so a reconnect replays only the missing tail; a watermark that fell
+ * off the bounded journal is answered with the whole tail and an explicit reset
+ * rather than a silently corrupt screen.
+ */
+function attachNativeClient(session: PtySession, ws: any, since: number | null): void {
+	const journal = session.nativeStream;
+	const lease = session.nativeLease;
+	if (!journal || !lease) return;
+	settleNativeStream(session);
+	const role = lease.attach(ws);
+	const replay = journal.replayFrom(since);
+	const sessionId = nativeTaskSessionId(session.taskId);
+	sendToClient(
+		ws,
+		attachMessage(
+			{
+				seq: replay.seq,
+				role,
+				sessionId,
+				paneId: session.native?.paneId ?? `${sessionId}:0`,
+				hostPid: session.native?.hostPid ?? -1,
+				shellPid: session.native?.shellPid ?? -1,
+				resumed: replay.resumed,
+				...(replay.reset ? { reset: replay.reset } : {}),
+			},
+			replay.data,
+		),
+	);
+	log.info("Native viewer attached", {
+		taskId: shortId(session.taskId),
+		role,
+		since,
+		seq: replay.seq,
+		resumed: replay.resumed,
+		reset: replay.reset ?? "none",
+		viewers: lease.size,
+	});
+}
+
+/** Move the writer lease between viewers and tell both sides, in one step. */
+function handleNativeOwnership(session: PtySession, ws: any, action: "claim" | "release"): void {
+	const lease = session.nativeLease;
+	if (!lease) return;
+	const change = action === "claim" ? lease.claim(ws) : lease.release(ws);
+	if (!change) return;
+	if (change.previous) sendToClient(change.previous, roleMessage(lease.roleOf(change.previous)));
+	if (change.writer) sendToClient(change.writer, roleMessage("writer"));
+	if (action === "release") sendToClient(ws, roleMessage(lease.roleOf(ws)));
+	// The new writer's viewport now owns the PTY geometry.
+	applyClientSizes(session);
+	log.info("Native writer lease moved", { taskId: shortId(session.taskId), action, viewers: lease.size });
+}
+
+/** The native writer's last reported viewport, or null while it has not sent one. */
+function writerClientSize(session: PtySession): { cols: number; rows: number } | null {
+	const writer = session.nativeLease?.writer as { ptyCols?: number; ptyRows?: number } | null | undefined;
+	if (!writer?.ptyCols || !writer.ptyRows) return null;
+	return { cols: writer.ptyCols, rows: writer.ptyRows };
+}
+
 function applyClientSizes(session: PtySession): void {
 	const term = sessionShell(session);
 	if (!term) return;
-	const target = smallestClientSize(
-		Array.from(session.clients, (c) => ({ cols: (c as any).ptyCols, rows: (c as any).ptyRows })),
-	);
+	// Native: the WRITER alone sizes the PTY. A native host has no client-size
+	// negotiation of its own, so clamping to the smallest viewer would let any
+	// remote tab (a phone in portrait, say) shrink the writer's shell out from
+	// under it. Observers letterbox instead — their zoom stays client-local.
+	const target = session.backend === "native"
+		? writerClientSize(session)
+		: smallestClientSize(
+			Array.from(session.clients, (c) => ({ cols: (c as any).ptyCols, rows: (c as any).ptyRows })),
+		);
 	if (!target) return;
 	const { cols: minCols, rows: minRows } = target;
 
 	if (session.appliedCols === minCols && session.appliedRows === minRows) {
+		// A native viewer is repainted from the journal on attach, so it never needs
+		// the redraw jiggle below — and jiggling would resize a live shell for a
+		// client that merely reconnected.
+		if (session.backend === "native") return;
 		// Target size is unchanged — typically a new, equal-or-larger viewer just
 		// connected. tmux does NOT emit a SIGWINCH / redraw for a same-size
 		// resize, so that viewer's freshly-mounted blank terminal would never get
@@ -911,15 +1015,49 @@ function applyClientSizes(session: PtySession): void {
 	}
 }
 
-/** Flush accumulated PTY data to all connected WebSocket clients in one batch. */
+/**
+ * Flush accumulated PTY data to all connected WebSocket clients in one batch.
+ *
+ * A native session records the batch into its bounded journal first and tags the
+ * message with the resulting watermark, so a viewer that drops can resume from
+ * exactly where it stopped. tmux sessions send the bare text they always have.
+ */
 function flushPendingData(session: PtySession): void {
 	session.batchTimer = null;
-	if (!session.pendingData || session.clients.size === 0) return;
+	if (!session.pendingData) return;
+	if (session.backend !== "native") {
+		if (session.clients.size === 0) return;
+		const data = session.pendingData;
+		session.pendingData = "";
+		for (const client of session.clients) {
+			try { client.sendText(data); } catch { /* dead client */ }
+		}
+		return;
+	}
 	const data = session.pendingData;
 	session.pendingData = "";
+	// Journal FIRST and unconditionally: with no viewer attached (remote-only use,
+	// or every tab closed) this tail is the entire screen the next one will get.
+	const seq = session.nativeStream?.push(data) ?? 0;
+	if (session.clients.size === 0) return;
+	const framed = outputMessage(seq, data);
 	for (const client of session.clients) {
-		try { client.sendText(data); } catch { /* dead client */ }
+		try { client.sendText(framed); } catch { /* dead client */ }
 	}
+}
+
+/**
+ * Bring the journal level with everything already broadcast, so a client
+ * attaching right now replays a tail that ends exactly where the live stream
+ * resumes. Called before an attach — the ordering guarantee, not an optimisation.
+ */
+function settleNativeStream(session: PtySession): void {
+	if (session.backend !== "native" || !session.pendingData) return;
+	if (session.batchTimer) {
+		clearTimeout(session.batchTimer);
+		session.batchTimer = null;
+	}
+	flushPendingData(session);
 }
 
 /**
@@ -1290,9 +1428,17 @@ const ptyServer = Bun.serve({
 					cwd: session.cwd,
 				});
 
+				(ws as any).sessionId = sessionId;
+
+				// Native attaches BEFORE joining the broadcast set: the replay tail must
+				// end exactly where this client's live stream begins, or the screen it
+				// rebuilds is missing (or double-printing) the frames in between.
+				if (session.backend === "native") {
+					attachNativeClient(session, ws, parseSinceParam(url?.searchParams.get(NATIVE_STREAM_SINCE_PARAM)));
+				}
+
 				// Add this client to the session's broadcast set
 				session.clients.add(ws as any);
-				(ws as any).sessionId = sessionId;
 
 				const cols = 80;
 				const rows = 24;
@@ -1345,6 +1491,34 @@ const ptyServer = Bun.serve({
 						? message
 						: new TextDecoder().decode(message);
 
+				if (session.backend === "native") {
+					const control = decodeNativeStreamMessage(data);
+					if (control) {
+						if (control.header.t === "claim" || control.header.t === "release") {
+							handleNativeOwnership(session, ws, control.header.t);
+						}
+						return;
+					}
+					// Every viewer reports its own viewport; only the writer's reaches the
+					// PTY (see applyClientSizes), so an observer's zoom stays client-local.
+					if (isResizeSequence(data)) {
+						const size = parseResizeSequence(data);
+						if (size) {
+							(ws as any).ptyCols = size.cols;
+							(ws as any).ptyRows = size.rows;
+							applyClientSizes(session);
+						}
+						return;
+					}
+					if (!session.nativeLease?.canWrite(ws)) {
+						// Say so explicitly — silently swallowed keystrokes read as a hung shell.
+						sendToClient(ws, roleMessage("observer", true));
+						return;
+					}
+					shell.write(data);
+					return;
+				}
+
 				// Handle resize messages. Record this client's requested size and
 				// resize the shared PTY to the smallest across all clients, so
 				// multiple windows on the same task don't fight over the geometry.
@@ -1375,8 +1549,12 @@ const ptyServer = Bun.serve({
 
 				const session = sessions.get(sessionId);
 				if (session) {
-					// Remove this client — don't kill the PTY
+					// Remove this client — don't kill the PTY. For native that also means
+					// the host, shell, and every sibling viewer keep running; a browser tab
+					// closing only releases its own lease.
+					const promoted = session.nativeLease?.detach(ws as any) ?? null;
 					session.clients.delete(ws as any);
+					if (promoted?.writer) sendToClient(promoted.writer, roleMessage("writer"));
 					// A viewer left: the smallest-size constraint may have relaxed,
 					// so grow the PTY back to the smallest of the remaining clients.
 					applyClientSizes(session);

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -17,6 +17,7 @@ import { isAbsolute, join, extname, relative, resolve } from "node:path";
 import { networkInterfaces } from "node:os";
 import QRCode from "qrcode";
 import type { RemoteNetInterface } from "../shared/types";
+import { NATIVE_STREAM_SINCE_PARAM, parseSinceParam } from "../shared/native-terminal-stream";
 import { PATHS } from "./electrobun-platform";
 import { createLogger } from "./logger";
 import { initSecret, createQrToken, createSessionToken, exchangeQrForSession, refreshSession, verifySessionToken, SESSION_TOKEN_TTL_S } from "./jwt";
@@ -344,14 +345,18 @@ let ptyPortGetter: (() => number) | null = null;
  * Proxy a WebSocket connection to the internal PTY server.
  * Browser connects to us at /pty?session=xxx, we forward to localhost:ptyPort.
  */
-function proxyToPty(clientWs: any, sessionId: string): void {
+function proxyToPty(clientWs: any, sessionId: string, sinceSeq: number | null): void {
 	const ptyPort = ptyPortGetter?.() ?? 0;
 	if (!ptyPort) {
 		clientWs.close(4002, "PTY server not available");
 		return;
 	}
 
-	const targetUrl = `ws://localhost:${ptyPort}?session=${sessionId}`;
+	// `since` is the native viewer's resume watermark; it has to survive this hop
+	// or every browser reconnect would rebuild the whole screen. Absent for tmux.
+	const targetUrl = `ws://localhost:${ptyPort}?session=${sessionId}${
+		sinceSeq === null ? "" : `&${NATIVE_STREAM_SINCE_PARAM}=${sinceSeq}`
+	}`;
 	const upstream = new WebSocket(targetUrl);
 
 	upstream.addEventListener("open", () => {
@@ -451,6 +456,8 @@ async function handleRpcMessage(ws: any, raw: string | ArrayBuffer): Promise<voi
 interface WsData {
 	type: "rpc" | "pty" | "shared-proxy";
 	sessionId?: string;
+	/** Native viewer's resume watermark, forwarded to the PTY server. */
+	sinceSeq?: number | null;
 	/** For `shared-proxy`: the upstream `ws://localhost:<port>/<path>` URL to dial. */
 	proxyUpstreamUrl?: string;
 }
@@ -645,7 +652,8 @@ export async function startRemoteAccessServer(options: StartOptions): Promise<vo
 				const sessionId = url.searchParams.get("session");
 				if (!sessionId) return new Response("Missing session param", { status: 400 });
 				log.info("PTY WS upgrade: authorized", { ip: clientIp, session: sessionId.slice(0, 8) });
-				if (server.upgrade(req, { data: { type: "pty", sessionId } as WsData })) return;
+				const sinceSeq = parseSinceParam(url.searchParams.get(NATIVE_STREAM_SINCE_PARAM));
+				if (server.upgrade(req, { data: { type: "pty", sessionId, sinceSeq } as WsData })) return;
 				return new Response("WebSocket upgrade failed", { status: 400 });
 			}
 
@@ -698,12 +706,12 @@ export async function startRemoteAccessServer(options: StartOptions): Promise<vo
 		},
 		websocket: {
 			open(ws) {
-				const wsData = (ws as any).data as { type: string; sessionId?: string; proxyUpstreamUrl?: string };
+				const wsData = (ws as any).data as { type: string; sessionId?: string; sinceSeq?: number | null; proxyUpstreamUrl?: string };
 				if (wsData.type === "rpc") {
 					rpcClients.add(ws);
 					log.info("Remote RPC client connected", { total: rpcClients.size });
 				} else if (wsData.type === "pty") {
-					proxyToPty(ws, wsData.sessionId!);
+					proxyToPty(ws, wsData.sessionId!, wsData.sinceSeq ?? null);
 				} else if (wsData.type === "shared-proxy") {
 					proxyToSharedUpstream(ws, wsData.proxyUpstreamUrl!);
 				}

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -5,6 +5,13 @@ import { toast } from "./toast";
 import { api, isElectrobun } from "./rpc";
 import { getShiftKeySequence } from "./shift-key-sequences";
 import { encodeResizeSequence } from "../shared/resize-protocol";
+import {
+	claimMessage,
+	decodeNativeStreamMessage,
+	ptyUrlWithSince,
+	type NativeStreamHeader,
+	type NativeStreamRole,
+} from "../shared/native-terminal-stream";
 // TEMP DIAGNOSTIC: remove these imports after the terminal copy bug is fixed.
 import type { TerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
 import { installTerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
@@ -204,6 +211,8 @@ export interface TerminalHandle {
 	submit: (data: string) => void;
 	focus: () => void;
 	blur: () => void;
+	/** Native backend only: take the writer lease from whoever holds it. No-op on tmux. */
+	claimWriter: () => void;
 }
 
 /** Set once the user has seen the one-time "select text to copy" hint toast. */
@@ -215,6 +224,11 @@ interface TerminalViewProps {
 	projectId: string;
 	onReady?: (handle: TerminalHandle) => void;
 	/**
+	 * Native backend only: this viewer's write role, and whether the server just
+	 * refused something it typed. Never fires for a tmux session.
+	 */
+	onNativeStatus?: (status: { role: NativeStreamRole; refused: boolean }) => void;
+	/**
 	 * Touch compose mode (mobile/tablet in browser mode): the terminal must NOT
 	 * summon the on-screen keyboard — taps neither focus the hidden textarea nor
 	 * forward touch→mouse to the canvas. Text entry goes through TerminalComposer;
@@ -223,7 +237,7 @@ interface TerminalViewProps {
 	touchComposeMode?: boolean;
 }
 
-function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: TerminalViewProps) {
+function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, touchComposeMode }: TerminalViewProps) {
 	const t = useT();
 	// Mirror t in a ref so the long-lived terminal-setup effect's closures
 	// (e.g. the select-to-copy hint) always read the latest translator.
@@ -245,6 +259,12 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 	const touchComposeModeRef = useRef(touchComposeMode ?? false);
 	touchComposeModeRef.current = touchComposeMode ?? false;
 	const copyDiagnosticsRef = useRef<TerminalCopyDiagnostics | null>(null);
+	// Native backend only. The watermark is what a reconnect resumes from, so it
+	// must survive the socket — a tmux session never sets either of these.
+	const nativeSeqRef = useRef<number | null>(null);
+	const nativeRoleRef = useRef<NativeStreamRole | null>(null);
+	const onNativeStatusRef = useRef(onNativeStatus);
+	onNativeStatusRef.current = onNativeStatus;
 	// Mouse-copy keeps tmux copy mode alive so the scrollback viewport does not
 	// jump to live output. Remember when that mode may be active so the next
 	// plain click can return to live input without requiring Escape.
@@ -778,6 +798,11 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 
 							// Expose terminal handle for external input (ExtraKeyBar, TerminalComposer)
 							onReady?.({
+								claimWriter: () => {
+									if (wsRef.current?.readyState === WebSocket.OPEN) {
+										wsRef.current.send(claimMessage());
+									}
+								},
 								sendInput: (data: string) => {
 									if (wsRef.current?.readyState === WebSocket.OPEN) {
 										wsRef.current.send(data);
@@ -1150,6 +1175,39 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			}
 		}
 
+		/** Publish the writer/observer role, and whether the server just refused input. */
+		function reportNativeRole(role: NativeStreamRole, refused: boolean): void {
+			nativeRoleRef.current = role;
+			onNativeStatusRef.current?.({ role, refused });
+		}
+
+		/**
+		 * Apply one native-stream frame. `attach` either continues this viewer's
+		 * stream (resumed — write the delta straight on) or replaces the screen, in
+		 * which case the terminal is reset FIRST so a rebuilt screen can never be
+		 * printed underneath the stale one.
+		 */
+		function handleNativeFrame(header: NativeStreamHeader, payload: string): void {
+			if (header.t === "role") {
+				reportNativeRole(header.role, header.refused === true);
+				return;
+			}
+			let reset = "";
+			if (header.t === "attach") {
+				nativeSeqRef.current = header.seq;
+				reportNativeRole(header.role, false);
+				// RIS in the SAME batch as the replay, so the screen is replaced in one
+				// write instead of briefly showing an empty terminal.
+				if (!header.resumed) reset = "\x1bc";
+			} else if (header.t === "o") {
+				nativeSeqRef.current = header.seq;
+			} else {
+				return;
+			}
+			const cleaned = payload.replace(OSC52_RE, "");
+			if (reset || cleaned) enqueueTermWrite(reset + cleaned);
+		}
+
 		function connectPty(term: Terminal, fit: FitAddon) {
 			if (disposed || ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
 			if (reconnectTimer !== null) {
@@ -1161,7 +1219,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 			console.log("[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
 			let socket: WebSocket;
 			try {
-				socket = new WebSocket(ptyUrl);
+				socket = new WebSocket(ptyUrlWithSince(ptyUrl, nativeSeqRef.current));
 			} catch (err) {
 				console.error("[TerminalView] WebSocket constructor FAILED:", err);
 				console.error("[TerminalView] URL was:", diagnosticPtyUrl);
@@ -1197,6 +1255,13 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, touchComposeMode }: 
 				if (disposed) return;
 				try {
 					if (typeof event.data === "string") {
+						// A native session frames every message with a watermark header; a
+						// tmux session sends bare terminal text and never enters this branch.
+						const native = decodeNativeStreamMessage(event.data);
+						if (native) {
+							handleNativeFrame(native.header, native.payload);
+							return;
+						}
 						const cleaned = event.data.replace(OSC52_RE, "");
 						if (cleaned) enqueueTermWrite(cleaned);
 					} else {

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,8 +1,9 @@
 import { render, act, fireEvent, waitFor } from "@testing-library/react";
-import TerminalView, { buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
+import TerminalView, { type TerminalHandle, buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
 import { KEYMAP_LS_KEY } from "../terminal-keymaps";
+import type { NativeStreamRole } from "../../shared/native-terminal-stream";
 
 // ── Hoisted mocks (must be before vi.mock factories) ─────────────────────────
 
@@ -151,7 +152,10 @@ class MockWebSocket {
 	onclose: ((e: CloseEvent) => void) | null = null;
 	onerror: ((e: Event) => void) | null = null;
 
-	constructor() {
+	readonly url: string;
+
+	constructor(url = "") {
+		this.url = url;
 		lastWebSocket = this;
 		webSockets.push(this);
 	}
@@ -1359,5 +1363,165 @@ describe("clearStaleSelectionOnWrite", () => {
 			},
 		};
 		expect(() => clearStaleSelectionOnWrite(throwing)).not.toThrow();
+	});
+});
+
+/**
+ * Native backend: the PTY socket carries framed messages with a watermark, so a
+ * reconnect resumes instead of rebuilding, and the writer/observer role reaches
+ * the UI. A tmux session must be completely unaffected by all of it.
+ */
+describe("TerminalView – native stream framing", () => {
+	const PTY_URL = "ws://localhost:1234/pty?session=t1";
+
+	async function renderNative(onNativeStatus?: (status: { role: NativeStreamRole; refused: boolean }) => void) {
+		await act(async () => {
+			render(
+				<I18nProvider>
+					<TerminalView ptyUrl={PTY_URL} taskId="t1" projectId="p1" onNativeStatus={onNativeStatus} />
+				</I18nProvider>,
+			);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		await act(async () => {
+			fireResize?.();
+		});
+	}
+
+	function deliver(text: string) {
+		act(() => {
+			lastWebSocket?.onmessage?.({ data: text } as MessageEvent);
+		});
+	}
+
+	function frame(header: Record<string, unknown>, payload = ""): string {
+		return `\x1b_dev3nt;${JSON.stringify({ v: 1, ...header })}\x1b\\${payload}`;
+	}
+
+	it("connects without a watermark and resumes from one after a drop", async () => {
+		const onNativeStatus = vi.fn();
+		await renderNative(onNativeStatus);
+		expect(webSockets[0].url).toBe(PTY_URL);
+
+		deliver(frame({
+			t: "attach",
+			seq: 4,
+			role: "writer",
+			sessionId: "dev3-task-t1",
+			paneId: "dev3-task-t1:0",
+			hostPid: 1,
+			shellPid: 2,
+			resumed: false,
+			reset: "fresh",
+		}, "screen"));
+		deliver(frame({ t: "o", seq: 9 }, "live"));
+
+		await act(async () => {
+			webSockets[0].readyState = WebSocket.CLOSED;
+			webSockets[0].onclose?.({ code: 1006, reason: "network gone", wasClean: false } as CloseEvent);
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+
+		expect(webSockets).toHaveLength(2);
+		expect(webSockets[1].url).toBe(`${PTY_URL}&since=9`);
+	});
+
+	it("replaces the screen in one write when the server rebuilt it", async () => {
+		await renderNative();
+		mockTermInstance.write.mockClear();
+
+		deliver(frame({
+			t: "attach",
+			seq: 2,
+			role: "writer",
+			sessionId: "s",
+			paneId: "s:0",
+			hostPid: 1,
+			shellPid: 2,
+			resumed: false,
+			reset: "pressure",
+		}, "rebuilt"));
+
+		expect(mockTermInstance.write).toHaveBeenCalledWith("\x1bcrebuilt");
+	});
+
+	it("appends a resumed delta without resetting the screen", async () => {
+		await renderNative();
+		mockTermInstance.write.mockClear();
+
+		deliver(frame({
+			t: "attach",
+			seq: 3,
+			role: "writer",
+			sessionId: "s",
+			paneId: "s:0",
+			hostPid: 1,
+			shellPid: 2,
+			resumed: true,
+		}, "delta"));
+
+		expect(mockTermInstance.write).toHaveBeenCalledWith("delta");
+	});
+
+	it("reports the role, and a refusal, to the surrounding UI", async () => {
+		const onNativeStatus = vi.fn();
+		await renderNative(onNativeStatus);
+
+		deliver(frame({
+			t: "attach",
+			seq: 0,
+			role: "observer",
+			sessionId: "s",
+			paneId: "s:0",
+			hostPid: 1,
+			shellPid: 2,
+			resumed: true,
+		}));
+		expect(onNativeStatus).toHaveBeenCalledWith({ role: "observer", refused: false });
+
+		deliver(frame({ t: "role", role: "observer", refused: true }));
+		expect(onNativeStatus).toHaveBeenLastCalledWith({ role: "observer", refused: true });
+
+		deliver(frame({ t: "role", role: "writer" }));
+		expect(onNativeStatus).toHaveBeenLastCalledWith({ role: "writer", refused: false });
+	});
+
+	it("sends a claim through the handle so a viewer can take over", async () => {
+		let handle: TerminalHandle | null = null;
+		await act(async () => {
+			render(
+				<I18nProvider>
+					<TerminalView ptyUrl={PTY_URL} taskId="t1" projectId="p1" onReady={(h) => { handle = h; }} />
+				</I18nProvider>,
+			);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		await act(async () => {
+			fireResize?.();
+		});
+
+		handle!.claimWriter();
+
+		expect(lastWebSocket?.send).toHaveBeenCalledWith(`\x1b_dev3nt;${JSON.stringify({ t: "claim", v: 1 })}\x1b\\`);
+	});
+
+	it("leaves a tmux session's plain text and reconnect URL untouched", async () => {
+		const onNativeStatus = vi.fn();
+		await renderNative(onNativeStatus);
+		mockTermInstance.write.mockClear();
+
+		deliver("$ ls -la\r\n");
+
+		expect(mockTermInstance.write).toHaveBeenCalledWith("$ ls -la\r\n");
+		expect(onNativeStatus).not.toHaveBeenCalled();
+
+		await act(async () => {
+			webSockets[0].readyState = WebSocket.CLOSED;
+			webSockets[0].onclose?.({ code: 1006, reason: "gone", wasClean: false } as CloseEvent);
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+		expect(webSockets[1].url).toBe(PTY_URL);
 	});
 });

--- a/src/mainview/components/NativeViewerBar.tsx
+++ b/src/mainview/components/NativeViewerBar.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { useT } from "../i18n";
+import Tooltip from "./Tooltip";
+import type { NativeStreamRole } from "../../shared/native-terminal-stream";
+
+/**
+ * Earned read-only strip for a NATIVE task terminal (seq 1300).
+ *
+ * A native session has one PTY and no client arbitration of its own, so exactly
+ * one viewer — desktop window or remote browser tab — may type; the rest watch
+ * until they explicitly take over. This strip exists because a silently
+ * read-only terminal is indistinguishable from a hung one.
+ *
+ * Placement follows the terminal's existing slim-strip pattern (window switcher,
+ * pane dots): a NON-overlapping row directly above the canvas, identical on
+ * desktop and narrow viewports, rendered only for an observer. A writer — and
+ * every tmux terminal — sees no chrome at all.
+ */
+const REFUSED_FLASH_MS = 1600;
+
+interface NativeViewerBarProps {
+	role: NativeStreamRole;
+	/** Bumped each time the server refused this viewer's input, to flash the strip. */
+	refusedAt: number;
+	onTakeControl: () => void;
+}
+
+function NativeViewerBar({ role, refusedAt, onTakeControl }: NativeViewerBarProps) {
+	const t = useT();
+	const [flashing, setFlashing] = useState(false);
+
+	useEffect(() => {
+		if (!refusedAt) return;
+		setFlashing(true);
+		const timer = setTimeout(() => setFlashing(false), REFUSED_FLASH_MS);
+		return () => clearTimeout(timer);
+	}, [refusedAt]);
+
+	// The normal case is a writer, and the normal case gets zero chrome.
+	if (role !== "observer") return null;
+
+	return (
+		<div
+			role="status"
+			className={`flex shrink-0 items-center justify-between gap-2 border-b px-3 py-1 text-xs transition-colors ${
+				flashing ? "border-danger/40 bg-danger/15 text-danger" : "border-edge bg-raised text-fg-3"
+			}`}
+		>
+			<span className="truncate">{t(flashing ? "nativeViewer.refused" : "nativeViewer.readOnly")}</span>
+			<Tooltip content={t("nativeViewer.takeControlHint")} placement="bottom">
+				<button
+					type="button"
+					onClick={onTakeControl}
+					className="shrink-0 rounded border border-edge bg-elevated px-2 py-0.5 font-medium text-fg-2 transition-colors hover:border-edge-active hover:bg-elevated-hover hover:text-fg"
+				>
+					{t("nativeViewer.takeControl")}
+				</button>
+			</Tooltip>
+		</div>
+	);
+}
+
+export default NativeViewerBar;

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type Dispatch } from "react";
+import { useCallback, useEffect, useRef, useState, type Dispatch } from "react";
 import type { Task, Project, TaskSessionState } from "../../shared/types";
 import { getTaskOpenMode, taskClosedHomeRoute, type AppAction, type Route } from "../state";
 import { api } from "../rpc";
@@ -15,6 +15,8 @@ import MobilePaneCarousel from "./MobilePaneCarousel";
 import MobileWindowCarousel from "./MobileWindowCarousel";
 import PaneZoomBadge from "./PaneZoomBadge";
 import ClosePanePicker from "./ClosePanePicker";
+import NativeViewerBar from "./NativeViewerBar";
+import type { NativeStreamRole } from "../../shared/native-terminal-stream";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { isElectrobun } from "../rpc";
@@ -53,6 +55,14 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	// (instead of waiting up to one poll interval).
 	const [windowEpoch, setWindowEpoch] = useState(0);
 	const [ptyUrl, setPtyUrl] = useState<string | null>(null);
+	// Native backend only: this viewer's write role plus a bump each time the
+	// server refused its input. Never set for a tmux terminal.
+	const [nativeRole, setNativeRole] = useState<NativeStreamRole>("writer");
+	const [refusedAt, setRefusedAt] = useState(0);
+	const handleNativeStatus = useCallback(({ role, refused }: { role: NativeStreamRole; refused: boolean }) => {
+		setNativeRole(role);
+		if (refused) setRefusedAt(Date.now());
+	}, []);
 	const [termHandle, setTermHandle] = useState<TerminalHandle | null>(null);
 	const [error, setError] = useState<{ kind: ErrorKind; path: string } | null>(null);
 	const [recoverable, setRecoverable] = useState<TaskSessionState | null>(null);
@@ -330,6 +340,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			taskId={taskId}
 			projectId={projectId}
 			onReady={setTermHandle}
+			onNativeStatus={handleNativeStatus}
 			touchComposeMode={touchInput && !rawMode}
 		/>
 	) : (
@@ -347,6 +358,13 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 				<div className="contents" data-collapse-on-compose>
 					<TaskInfoPanel task={task} project={project} dispatch={dispatch} navigate={navigate} isFullPage />
 				</div>
+			)}
+			{ptyUrl && (
+				<NativeViewerBar
+					role={nativeRole}
+					refusedAt={refusedAt}
+					onTakeControl={() => termHandle?.claimWriter()}
+				/>
 			)}
 			{narrow && ptyUrl ? (
 				// Narrow: a window switcher (outer) wraps the pane carousel (inner).

--- a/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
+++ b/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
@@ -23,6 +23,7 @@ function makeHandle(): TerminalHandle {
 		submit: vi.fn(),
 		focus: vi.fn(),
 		blur: vi.fn(),
+	claimWriter: vi.fn(),
 	};
 }
 

--- a/src/mainview/components/__tests__/NativeViewerBar.test.tsx
+++ b/src/mainview/components/__tests__/NativeViewerBar.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * The native terminal's read-only strip (seq 1300).
+ *
+ * The point of the strip is that a read-only terminal must never be mistakable
+ * for a hung one — so it renders for an observer, offers the takeover, reacts to
+ * a refused keystroke, and disappears entirely for the writer (and therefore for
+ * every tmux terminal, which never reports a role at all).
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NativeViewerBar from "../NativeViewerBar";
+import { I18nProvider } from "../../i18n";
+
+afterEach(cleanup);
+
+function renderBar(props: Partial<React.ComponentProps<typeof NativeViewerBar>> = {}) {
+	const onTakeControl = vi.fn();
+	const result = render(
+		<I18nProvider>
+			<NativeViewerBar role="observer" refusedAt={0} onTakeControl={onTakeControl} {...props} />
+		</I18nProvider>,
+	);
+	return { ...result, onTakeControl };
+}
+
+describe("NativeViewerBar", () => {
+	it("renders nothing for the writer — the normal case gets no chrome", () => {
+		const { container } = renderBar({ role: "writer" });
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("tells an observer the terminal is read-only", () => {
+		renderBar();
+
+		expect(screen.getByRole("status")).toHaveTextContent(/read-only/i);
+		expect(screen.getByRole("button", { name: /take control/i })).toBeInTheDocument();
+	});
+
+	it("asks for the writer lease when the user takes control", async () => {
+		const { onTakeControl } = renderBar();
+
+		await userEvent.click(screen.getByRole("button", { name: /take control/i }));
+
+		expect(onTakeControl).toHaveBeenCalledTimes(1);
+	});
+
+	it("flashes a refusal, then settles back to the plain read-only notice", () => {
+		vi.useFakeTimers();
+		try {
+			const { rerender, onTakeControl } = renderBar();
+			rerender(
+				<I18nProvider>
+					<NativeViewerBar role="observer" refusedAt={1234} onTakeControl={onTakeControl} />
+				</I18nProvider>,
+			);
+
+			expect(screen.getByRole("status")).toHaveTextContent(/take control to type/i);
+
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			expect(screen.getByRole("status")).toHaveTextContent(/another viewer is typing/i);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/src/mainview/components/__tests__/TerminalComposer.test.tsx
+++ b/src/mainview/components/__tests__/TerminalComposer.test.tsx
@@ -51,6 +51,7 @@ function makeHandle(): TerminalHandle {
 		submit: vi.fn(),
 		focus: vi.fn(),
 		blur: vi.fn(),
+	claimWriter: vi.fn(),
 	};
 }
 

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -56,6 +56,12 @@ const terminal = {
 	"paneZoom.badge": "Zoomed",
 	"paneZoom.restore": "Show all panes",
 
+	// Native terminal: one viewer types, the rest watch until they take over
+	"nativeViewer.readOnly": "Read-only — another viewer is typing",
+	"nativeViewer.refused": "Read-only — take control to type here",
+	"nativeViewer.takeControl": "Take control",
+	"nativeViewer.takeControlHint": "Type in this terminal; the other viewer becomes read-only",
+
 	// Tmux hotkey hints
 	"tmux.hSplit": "h-split",
 	"tmux.vSplit": "v-split",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -56,6 +56,12 @@ const terminal = {
 	"paneZoom.badge": "Zoom",
 	"paneZoom.restore": "Mostrar todos los paneles",
 
+	// Native terminal: one viewer types, the rest watch until they take over
+	"nativeViewer.readOnly": "Solo lectura — otro cliente está escribiendo",
+	"nativeViewer.refused": "Solo lectura — toma el control para escribir aquí",
+	"nativeViewer.takeControl": "Tomar el control",
+	"nativeViewer.takeControlHint": "Escribirás tú; el otro cliente pasará a solo lectura",
+
 	// Tmux hotkey hints
 	"tmux.hSplit": "h-div",
 	"tmux.vSplit": "v-div",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -58,6 +58,12 @@ const terminal = {
 	"paneZoom.badge": "Зум",
 	"paneZoom.restore": "Показать все панели",
 
+	// Native terminal: one viewer types, the rest watch until they take over
+	"nativeViewer.readOnly": "Только чтение — печатает другой клиент",
+	"nativeViewer.refused": "Только чтение — возьмите управление, чтобы печатать",
+	"nativeViewer.takeControl": "Взять управление",
+	"nativeViewer.takeControlHint": "Печатать будете вы, другой клиент перейдёт в режим чтения",
+
 	// Tmux hotkey hints
 	"tmux.hSplit": "гориз.",
 	"tmux.vSplit": "верт.",

--- a/src/shared/native-terminal-stream.ts
+++ b/src/shared/native-terminal-stream.ts
@@ -1,0 +1,196 @@
+/**
+ * In-band control framing for the NATIVE terminal's browser/desktop bridge
+ * (seq 1300).
+ *
+ * The PTY WebSocket (`/pty?session=…`, proxied verbatim by remote mode) carries
+ * raw terminal text in both directions. The native backend needs a little more
+ * than raw text — a sequence watermark to resume from, an explicit reset when a
+ * reconnecting client fell off the bounded journal, and the writer/observer role
+ * — so a native session prefixes each message with ONE APC-framed JSON header:
+ *
+ *   ESC _ dev3nt; {"t":"o","v":1,"seq":42} ESC \  <raw terminal bytes…>
+ *
+ * Why in-band instead of a JSON envelope around the payload: terminal output is
+ * the hot path (thousands of frames/sec), and JSON-escaping every byte of it
+ * costs far more than one `indexOf` plus a ~40-byte parse. Why APC: it is the
+ * same trick the resize protocol already uses, and a terminal emulator that ever
+ * saw a stray frame would ignore it rather than render garbage.
+ *
+ * Tmux sessions never see any of this — they keep sending bare text, byte for
+ * byte as before.
+ *
+ * Pure module: no runtime deps, shared by the bun bridge and the renderer.
+ */
+
+export const NATIVE_STREAM_PROTOCOL_VERSION = 1;
+
+const PREFIX = "\x1b_dev3nt;";
+const SUFFIX = "\x1b\\";
+
+/** Who may write to the shell: exactly one client per session at a time. */
+export type NativeStreamRole = "writer" | "observer";
+
+/** Why the server rebuilt the screen instead of sending the next delta. */
+export type NativeStreamResetReason = "fresh" | "gap" | "pressure";
+
+/** First message on every native attach; the payload is the replayed tail. */
+export interface NativeStreamAttachHeader {
+	t: "attach";
+	v: number;
+	/** Sequence of the last replayed frame; resume from here after a drop. */
+	seq: number;
+	role: NativeStreamRole;
+	sessionId: string;
+	paneId: string;
+	hostPid: number;
+	shellPid: number;
+	/** False when the client's `since` was out of range and the screen was rebuilt. */
+	resumed: boolean;
+	/** Set only when `resumed` is false, so the client can clear before writing. */
+	reset?: NativeStreamResetReason;
+}
+
+/** One batch of live output; the payload is the raw terminal bytes. */
+export interface NativeStreamOutputHeader {
+	t: "o";
+	v: number;
+	seq: number;
+}
+
+/** The client's role changed (takeover, or promotion after the writer left). */
+export interface NativeStreamRoleHeader {
+	t: "role";
+	v: number;
+	role: NativeStreamRole;
+	/** Set when the server refused this client's input or resize. */
+	refused?: boolean;
+}
+
+export type NativeStreamServerHeader =
+	| NativeStreamAttachHeader
+	| NativeStreamOutputHeader
+	| NativeStreamRoleHeader;
+
+/** Client → server: take the writer lease, or hand it back. */
+export interface NativeStreamOwnershipHeader {
+	t: "claim" | "release";
+	v: number;
+}
+
+export type NativeStreamClientHeader = NativeStreamOwnershipHeader;
+
+export type NativeStreamHeader = NativeStreamServerHeader | NativeStreamClientHeader;
+
+export interface NativeStreamMessage<H extends NativeStreamHeader = NativeStreamHeader> {
+	header: H;
+	/** Raw terminal bytes that follow the header; empty for control-only frames. */
+	payload: string;
+}
+
+/** True when a WebSocket text frame is a native-stream message rather than terminal data. */
+export function isNativeStreamMessage(text: string): boolean {
+	return text.startsWith(PREFIX);
+}
+
+export function encodeNativeStreamMessage(header: NativeStreamHeader, payload = ""): string {
+	return `${PREFIX}${JSON.stringify(header)}${SUFFIX}${payload}`;
+}
+
+function isValidHeader(value: unknown): value is NativeStreamHeader {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as Record<string, unknown>;
+	if (obj.v !== NATIVE_STREAM_PROTOCOL_VERSION) return false;
+	switch (obj.t) {
+		case "attach":
+			return (
+				typeof obj.seq === "number" &&
+				(obj.role === "writer" || obj.role === "observer") &&
+				typeof obj.sessionId === "string" &&
+				typeof obj.paneId === "string" &&
+				typeof obj.hostPid === "number" &&
+				typeof obj.shellPid === "number" &&
+				typeof obj.resumed === "boolean"
+			);
+		case "o":
+			return typeof obj.seq === "number";
+		case "role":
+			return obj.role === "writer" || obj.role === "observer";
+		case "claim":
+		case "release":
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Split a native-stream message into its header and raw payload, or `null` when
+ * the text is not one (a truncated or foreign-version frame reads as `null`, so
+ * the caller treats it as terminal data and never throws).
+ */
+export function decodeNativeStreamMessage(text: string): NativeStreamMessage | null {
+	if (!isNativeStreamMessage(text)) return null;
+	const end = text.indexOf(SUFFIX, PREFIX.length);
+	if (end === -1) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text.slice(PREFIX.length, end));
+	} catch {
+		return null;
+	}
+	if (!isValidHeader(parsed)) return null;
+	return { header: parsed, payload: text.slice(end + SUFFIX.length) };
+}
+
+// ── Builders ──────────────────────────────────────────────────────────
+
+export function attachMessage(
+	fields: Omit<NativeStreamAttachHeader, "t" | "v">,
+	payload: string,
+): string {
+	return encodeNativeStreamMessage({ t: "attach", v: NATIVE_STREAM_PROTOCOL_VERSION, ...fields }, payload);
+}
+
+export function outputMessage(seq: number, payload: string): string {
+	return encodeNativeStreamMessage({ t: "o", v: NATIVE_STREAM_PROTOCOL_VERSION, seq }, payload);
+}
+
+export function roleMessage(role: NativeStreamRole, refused = false): string {
+	return encodeNativeStreamMessage({
+		t: "role",
+		v: NATIVE_STREAM_PROTOCOL_VERSION,
+		role,
+		...(refused ? { refused: true } : {}),
+	});
+}
+
+export function claimMessage(): string {
+	return encodeNativeStreamMessage({ t: "claim", v: NATIVE_STREAM_PROTOCOL_VERSION });
+}
+
+export function releaseMessage(): string {
+	return encodeNativeStreamMessage({ t: "release", v: NATIVE_STREAM_PROTOCOL_VERSION });
+}
+
+// ── Resume addressing ─────────────────────────────────────────────────
+
+/** Query parameter a reconnecting client uses to resume from its watermark. */
+export const NATIVE_STREAM_SINCE_PARAM = "since";
+
+/**
+ * Point a PTY URL at the client's watermark. A client that has never received a
+ * frame (or is on tmux) passes `null` and gets the URL back untouched, so the
+ * tmux path stays byte-identical.
+ */
+export function ptyUrlWithSince(url: string, sinceSeq: number | null): string {
+	if (sinceSeq === null || !Number.isInteger(sinceSeq) || sinceSeq < 0) return url;
+	const separator = url.includes("?") ? "&" : "?";
+	return `${url}${separator}${NATIVE_STREAM_SINCE_PARAM}=${sinceSeq}`;
+}
+
+/** Read a client's resume watermark from a PTY upgrade URL; `null` when absent or bogus. */
+export function parseSinceParam(raw: string | null | undefined): number | null {
+	if (raw === null || raw === undefined || raw === "") return null;
+	const value = Number(raw);
+	return Number.isInteger(value) && value >= 0 ? value : null;
+}


### PR DESCRIPTION
Makes an explicitly native Task Terminal fully usable through `dev3 remote` in a browser, reusing the existing authenticated remote transport. No second WebSocket server, daemon, listener, authentication system, or remote protocol is introduced — the native stream rides the `/pty` bridge that remote mode already proxies.

## What this adds

- **`src/shared/native-terminal-stream.ts`** — a native-only in-band APC sub-protocol (`\x1b_dev3nt;{json}\x1b\\` + raw bytes) on the existing pty wire, carrying `attach` / `o` / `role` / `claim` / `release` frames plus `since`-watermark helpers. Framing in-band avoids escaping every output byte on the hot path; precedent is `src/shared/resize-protocol.ts`.
- **`src/bun/native-terminal-bridge.ts`** — `NativeBridgeJournal`, a bounded (256 KB) output ring with 1-based sequence numbers whose `replayFrom` either resumes a viewer with exactly the frames it missed or replaces its screen with an explicit `fresh` / `gap` / `pressure` reset — never a silent gap, never a resync loop. Plus `NativeClientLease`, which keeps exactly one writer while any viewer remains, transfers the lease atomically on takeover, and promotes a survivor when the writer disconnects.
- **`src/bun/pty-server.ts`** — native sessions journal output even with zero viewers, so a browser-only attach has a screen to rebuild; attach replays before live with a settle-flush so the tail ends exactly where the live stream begins; input and PTY resize are honoured only from the current writer, while observer sizes are recorded but never applied, so one client's viewport cannot shrink the shared PTY; a disconnect releases only that client's lease state.
- **`src/bun/remote-access-server.ts`** — forwards only the `since` parameter to the internal PTY server.
- **UI** — a `NativeViewerBar` read-only strip with a `Take control` action, rendered only for an observer, as a non-overlapping row above the canvas, identical on desktop and narrow viewports. A writer, and every tmux terminal, sees no chrome at all. Planned with `/ux-principal`; one entry in `docs/ux/UX_DECISIONS.md`.
- **`src/bun/native-task-terminal.ts`** — exposes `paneId` on `NativeTaskTerminal` so the attach frame can report the shared pane identity.

## tmux is untouched

The tmux branches of `flushPendingData` and `applyClientSizes` are unchanged, and `ptyUrlWithSince` is a no-op for a null watermark, so tmux `/pty` URLs stay bare. Negative tests spy on `tmux.killSession` / `tmux.capturePane` and fail if the native path ever calls tmux.

## Out of scope, deliberately

Native is not the default, there is no fallback, no live-session migration, and no tmux removal.

## Notes

Rationale and rejected alternatives are recorded in `decisions/172-native-terminal-remote-viewer-bridge.md`.

Verified live against a real native host with two isolated browser viewers: the second viewer rebuilt the identical screen from the journal, an observer keystroke was refused without reaching the shell, `Take control` swapped roles atomically in both directions with live echo on both viewers, a forced reconnect resumed at `?since=8` with no missing or duplicated bytes and the same host/shell PIDs, an observer at 390x844 left the writer's PTY at 114x40, closing the writer promoted the survivor with the shell alive, and cancelling the task tore down host and shell without touching tmux. The tmux remote path was re-checked at 1440x900 and 390x844.