### PR TITLE
Stream git patch-id pipelines without a shell

### DIFF
--- a/change-logs/2026/07/26/fix-shell-free-merge-detection-pipeline.md
+++ b/change-logs/2026/07/26/fix-shell-free-merge-detection-pipeline.md
@@ -1,0 +1,3 @@
+Short: Merge detection works without bash
+
+Squash and rebase merge detection no longer shells out to `bash -c` for its `git patch-id` pipelines — the two git processes are now streamed into each other directly, so tasks merged on Windows are detected instead of silently reported as unmerged.

--- a/decisions/178-shell-free-git-patch-id-pipeline.md
+++ b/decisions/178-shell-free-git-patch-id-pipeline.md
@@ -1,0 +1,50 @@
+# 178 — Shell-free git → git patch-id streaming pipeline
+
+## Context
+
+`isContentMergedInto()` (`src/bun/git.ts`) detected squash/rebase merges by piping
+`git diff` / `git log -p` into `git patch-id --stable` through three
+`bash -c "… | …"` calls. Windows has no native `bash`: PATH resolves it to WSL
+bash, whose filesystem view does not match the native worktree cwd, so every
+pipeline exited 128 and merge detection silently reported "not merged" (found
+during Seq 1295 real-Windows validation).
+
+## Investigation
+
+The failure is the shell, not git: the same `git` invocations succeed when spawned
+directly with the native cwd. Only Strategy 2 (patch-id) was affected; Strategy 1
+(merge-tree) and Strategy 3 (GitHub PR) already spawn git/gh as plain argv.
+
+## Decision
+
+Added `runGitPipe(producerCmd, consumerCmd, cwd, { prefix })` in `src/bun/git.ts`.
+It spawns both sides via the `src/bun/spawn.ts` wrapper (`stdin: "pipe"` on the
+consumer), copies producer stdout into the consumer's `FileSink` chunk by chunk,
+awaiting `flush()` between chunks for backpressure, and drains all three remaining
+pipes before awaiting exits. Optional `prefix` bytes replace the shell-`echo`
+synthetic `commit <zero sha>` header. Failure is deterministic: either non-zero
+exit, a spawn error, or a broken pipe yields `ok: false` with both stderrs joined,
+and the surviving child is killed so nothing is orphaned. All three call sites in
+`isContentMergedInto()` now use it; no shell is involved anywhere in the function.
+
+Side effect: the pipeline now goes through `withGitFilenameEncoding`, so patch
+headers use `core.quotepath=false`. Both sides of every comparison are produced the
+same way and patch-ids are never persisted, so results are unchanged.
+
+## Risks
+
+The consumer's stdin is Bun's `FileSink`; the backend test spawn mock had to grow a
+Node-writable adapter (`nodeStdinAsFileSink` in `src/bun/__tests__/git-test-helpers.ts`)
+to model `write`/`flush`/`end`, so mocked flush timing is an approximation of Bun's.
+A per-chunk `flush()` costs a microtask per chunk versus letting the kernel pipe
+handle it, which is negligible next to git's own work.
+
+## Alternatives considered
+
+- Pass `producer.stdout` straight as the consumer's `stdin` (Bun accepts a
+  ReadableStream). Less explicit control over broken-pipe and error ordering, and
+  no place to inject the synthetic commit header.
+- Buffer the patch in JS and feed it as a Blob — reintroduces the multi-MB memory
+  cost the original bash pipeline existed to avoid.
+- PowerShell pipelines on Windows — text-oriented, would corrupt binary patch bytes.
+- Reimplement patch-id in JavaScript — must match git's hashing exactly, forever.

--- a/src/bun/__tests__/git-merge-detection.test.ts
+++ b/src/bun/__tests__/git-merge-detection.test.ts
@@ -22,8 +22,11 @@ vi.mock("../spawn", async () => {
 	return createSpawnMock(() => ghPrListResponse);
 });
 
-import { isBranchMergedViaGitHubPR, isContentMergedInto } from "../git";
-import { createTestRepo, cleanup, makeTaskCommits, g, type TestRepo } from "./git-test-helpers";
+import { isBranchMergedViaGitHubPR, isContentMergedInto, runGitPipe } from "../git";
+import { createTestRepo, cleanup, makeTaskCommits, g, spawnedCommands, type TestRepo } from "./git-test-helpers";
+
+// Anything that would put a shell (or WSL) between us and git.
+const SHELLS = /^(bash|sh|zsh|dash|cmd|cmd\.exe|powershell|powershell\.exe|pwsh|wsl|wsl\.exe)$/i;
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -33,6 +36,7 @@ describe("isContentMergedInto", () => {
 	beforeEach(() => {
 		repo = createTestRepo();
 		ghPrListResponse = "[]";
+		spawnedCommands.length = 0;
 	});
 
 	afterEach(() => {
@@ -253,6 +257,206 @@ describe("isContentMergedInto", () => {
 
 		const result = await isContentMergedInto(repo.local, "origin/main");
 		expect(result).toBe(false);
+	});
+
+	// ── Shell-free streaming pipeline (Windows regression) ───────────────────
+	//
+	// A `bash -c "git … | git patch-id"` pipeline exits 128 on Windows because
+	// PATH resolves bash to WSL bash, which cannot see the native worktree cwd.
+
+	it("detects a squash merge without spawning any shell", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		g("git checkout main", repo.local);
+		g("git merge --squash task-branch", repo.local);
+		g('git commit -m "squash: task (#1)"', repo.local);
+		// Diverge on the same file afterwards so merge-tree conflicts and the
+		// patch-id pipeline is what actually answers.
+		writeFileSync(
+			join(repo.local, "feature.ts"),
+			"export const add = (a: number, b: number) => a + b;\n" +
+				"export const sub = (a: number, b: number) => a - b;\n" +
+				"export const mul = (a: number, b: number) => a * b;\n",
+		);
+		g("git add feature.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+
+		expect(spawnedCommands.filter((cmd) => SHELLS.test(cmd[0]))).toEqual([]);
+		// No rendered pipeline string smuggled into argv either.
+		expect(spawnedCommands.filter((cmd) => cmd.some((arg) => arg.includes("|")))).toEqual([]);
+		expect(spawnedCommands.some((cmd) => cmd.includes("patch-id"))).toBe(true);
+	});
+
+	it("detects a squash merge from a linked worktree (separate gitdir pointer)", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		g("git checkout main", repo.local);
+		g("git merge --squash task-branch", repo.local);
+		g('git commit -m "squash: task (#1)"', repo.local);
+		writeFileSync(
+			join(repo.local, "feature.ts"),
+			"export const add = (a: number, b: number) => a + b;\n" +
+				"export const sub = (a: number, b: number) => a - b;\n" +
+				"export const mul = (a: number, b: number) => a * b;\n",
+		);
+		g("git add feature.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+
+		const linked = join(repo.dir, "linked-worktree");
+		g(`git worktree add "${linked}" task-branch`, repo.local);
+
+		expect(await isContentMergedInto(linked, "origin/main")).toBe(true);
+		expect(spawnedCommands.filter((cmd) => SHELLS.test(cmd[0]))).toEqual([]);
+	});
+
+	it("detects a squash merge whose patch contains binary, renamed and deleted files", async () => {
+		g("git checkout -b task-branch", repo.local);
+		writeFileSync(join(repo.local, "logo.bin"), Buffer.from([0, 1, 2, 0, 255, 0, 7]));
+		g("git mv app.ts renamed.ts", repo.local);
+		g("git add logo.bin", repo.local);
+		g('git commit -m "task: binary + rename"', repo.local);
+		writeFileSync(join(repo.local, "doomed.ts"), "export const gone = true;\n");
+		g("git add doomed.ts", repo.local);
+		g('git commit -m "task: add doomed"', repo.local);
+		g("git rm doomed.ts", repo.local);
+		g('git commit -m "task: delete doomed"', repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		g("git checkout main", repo.local);
+		g("git merge --squash task-branch", repo.local);
+		g('git commit -m "squash: task (#1)"', repo.local);
+		writeFileSync(join(repo.local, "renamed.ts"), "const a = 1;\nconst b = 2;\nconst c = 4;\n");
+		g("git add renamed.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+	});
+
+	it("returns true when the branch carries no changes at all (empty diff)", async () => {
+		g("git checkout -b task-branch", repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+	});
+
+	it("returns true after cherry-picking every task commit onto main", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push -u origin task-branch", repo.local);
+		const shas = g("git log --format=%H main..task-branch", repo.local).trim().split("\n").reverse();
+
+		g("git checkout main", repo.local);
+		for (const sha of shas) g(`git cherry-pick ${sha}`, repo.local);
+		writeFileSync(join(repo.local, "unrelated.ts"), "export const x = 1;\n");
+		g("git add unrelated.ts", repo.local);
+		g('git commit -m "unrelated PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+	});
+
+	it("returns false when main changed the same file differently", async () => {
+		g("git checkout -b task-branch", repo.local);
+		writeFileSync(join(repo.local, "app.ts"), "const a = 'task';\nconst b = 2;\nconst c = 3;\n");
+		g("git add app.ts", repo.local);
+		g('git commit -m "task: change a"', repo.local);
+		g("git push -u origin task-branch", repo.local);
+
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "app.ts"), "const a = 'other';\nconst b = 2;\nconst c = 3;\n");
+		g("git add app.ts", repo.local);
+		g('git commit -m "other PR"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
+	});
+});
+
+describe("runGitPipe", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+		spawnedCommands.length = 0;
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	const PATCH_ID = ["git", "patch-id", "--stable"];
+
+	it("streams a prefix followed by the producer's bytes into the consumer", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+
+		const prefix = new TextEncoder().encode(`commit ${"0".repeat(40)}\n\n`);
+		const piped = await runGitPipe(["git", "diff", "main", "HEAD"], PATCH_ID, repo.local, { prefix });
+
+		expect(piped.ok).toBe(true);
+		// patch-id echoes the commit id it was given after the patch id.
+		expect(piped.stdout).toMatch(/^[0-9a-f]{40} 0{40}$/);
+		expect(spawnedCommands.filter((cmd) => SHELLS.test(cmd[0]))).toEqual([]);
+	});
+
+	it("produces identical patch-ids for identical patches across invocations", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+
+		const cmd = ["git", "log", "-p", "--no-merges", "main..HEAD"];
+		const first = await runGitPipe(cmd, PATCH_ID, repo.local);
+		const second = await runGitPipe(cmd, PATCH_ID, repo.local);
+
+		expect(first.ok).toBe(true);
+		expect(first.stdout.split("\n")).toHaveLength(2);
+		expect(second.stdout).toBe(first.stdout);
+	});
+
+	it("streams patches larger than the OS pipe buffer without deadlocking", async () => {
+		g("git checkout -b task-branch", repo.local);
+		writeFileSync(join(repo.local, "big.txt"), "x".repeat(64) + "\n".repeat(1) + Array.from({ length: 40_000 }, (_, i) => `line ${i}`).join("\n"));
+		g("git add big.txt", repo.local);
+		g('git commit -m "task: big file"', repo.local);
+
+		const piped = await runGitPipe(["git", "log", "-p", "main..HEAD"], PATCH_ID, repo.local);
+		expect(piped.ok).toBe(true);
+		expect(piped.stdout).toMatch(/^[0-9a-f]{40} /);
+	});
+
+	it("fails when the producer fails", async () => {
+		const piped = await runGitPipe(["git", "log", "-p", "no-such-ref-xyz"], PATCH_ID, repo.local);
+		expect(piped.ok).toBe(false);
+		expect(piped.stderr).not.toBe("");
+	});
+
+	it("fails when the consumer fails", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+
+		const piped = await runGitPipe(
+			["git", "log", "-p", "main..HEAD"],
+			["git", "patch-id", "--definitely-not-a-flag"],
+			repo.local,
+		);
+		expect(piped.ok).toBe(false);
+	});
+
+	it("fails when a side cannot be spawned at all", async () => {
+		const piped = await runGitPipe(["dev3-no-such-binary"], PATCH_ID, repo.local);
+		expect(piped.ok).toBe(false);
 	});
 });
 

--- a/src/bun/__tests__/git-test-helpers.ts
+++ b/src/bun/__tests__/git-test-helpers.ts
@@ -6,7 +6,7 @@
  * See git-merge-detection.test.ts for the reference pattern.
  */
 import { execSync } from "child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { spawn as cpSpawn } from "child_process";
@@ -70,7 +70,9 @@ function getTemplateDir(): string {
 export function createTestRepo(): TestRepo {
 	const template = getTemplateDir();
 	const dir = mkdtempSync(join(tmpdir(), "dev3-git-test-"));
-	execSync(`cp -R "${template}/origin.git" "${template}/local" "${dir}/"`, { stdio: "pipe" });
+	// cpSync, not `cp -R`: these tests also run on Windows, where cmd.exe has no cp.
+	cpSync(join(template, "origin.git"), join(dir, "origin.git"), { recursive: true });
+	cpSync(join(template, "local"), join(dir, "local"), { recursive: true });
 	const local = join(dir, "local");
 	g(`git remote set-url origin "${join(dir, "origin.git")}"`, local);
 	return { dir, local };
@@ -153,12 +155,41 @@ function fakeProc(stdout: string, exitCode: number) {
 }
 
 /**
+ * Every command the spawn mock was asked to run, in order. Lets a test assert
+ * *how* something was executed (e.g. that no shell was involved).
+ */
+export const spawnedCommands: string[][] = [];
+
+/** Node writable dressed up as Bun's FileSink, for `stdin: "pipe"` callers. */
+function nodeStdinAsFileSink(stdin: NodeJS.WritableStream | null) {
+	stdin?.on("error", () => { /* EPIPE when the child exits before we finish writing */ });
+	return {
+		write(chunk: Uint8Array) {
+			stdin?.write(Buffer.from(chunk));
+			return chunk.byteLength;
+		},
+		// Bun resolves flush() once the child drained the chunk; Node's write
+		// callback fires at the same point, so an empty write is a fence.
+		flush() {
+			return new Promise<number>((resolve) => {
+				if (!stdin || (stdin as NodeJS.WritableStream & { destroyed?: boolean }).destroyed) return resolve(0);
+				stdin.write(Buffer.alloc(0), () => resolve(0));
+			});
+		},
+		end() {
+			stdin?.end();
+		},
+	};
+}
+
+/**
  * Creates a spawn mock that replaces Bun.spawn with Node.js child_process.
  * Optionally intercepts `gh` CLI calls with a custom response getter.
  */
 export function createSpawnMock(getGhResponse?: () => string) {
 	return {
 		spawn: (cmd: string[], opts?: Record<string, unknown>) => {
+			spawnedCommands.push([...cmd]);
 			if (cmd[0] === "gh" && getGhResponse) {
 				return fakeProc(getGhResponse(), 0);
 			}
@@ -170,7 +201,10 @@ export function createSpawnMock(getGhResponse?: () => string) {
 				stdio: ["pipe", "pipe", "pipe"],
 			});
 
-			if (opts?.stdin instanceof Blob) {
+			let sink: ReturnType<typeof nodeStdinAsFileSink> | undefined;
+			if (opts?.stdin === "pipe") {
+				sink = nodeStdinAsFileSink(child.stdin);
+			} else if (opts?.stdin instanceof Blob) {
 				(opts.stdin as Blob).arrayBuffer().then((buf) => {
 					child.stdin?.write(Buffer.from(buf));
 					child.stdin?.end();
@@ -191,8 +225,10 @@ export function createSpawnMock(getGhResponse?: () => string) {
 
 			return {
 				exited,
+				stdin: sink,
 				stdout: child.stdout ? toWebStream(child.stdout) : emptyStream(),
 				stderr: child.stderr ? toWebStream(child.stderr) : emptyStream(),
+				kill: (signal?: number) => child.kill(signal as NodeJS.Signals | number | undefined),
 			};
 		},
 	};

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -308,6 +308,102 @@ async function runGitStdinBinary(
 	return { code: await proc.exited, stdout: new Uint8Array(stdoutBuffer) };
 }
 
+type PipeSink = {
+	write(chunk: Uint8Array): number;
+	flush(): Promise<number> | number;
+	end(): void;
+};
+
+/**
+ * Streams one git process's stdout straight into another git process's stdin,
+ * with no shell involved.
+ *
+ * A `bash -c "git … | git …"` pipeline is unusable on Windows: PATH there
+ * resolves `bash` to WSL bash, whose filesystem view mangles the native
+ * worktree cwd, so the whole pipeline exits 128. See decision 178.
+ *
+ * Bytes are copied verbatim (patches are binary-safe) and each chunk is flushed
+ * before the next read, so memory stays bounded no matter how large the patch.
+ */
+export async function runGitPipe(
+	producerCmd: string[],
+	consumerCmd: string[],
+	cwd: string,
+	opts?: { prefix?: Uint8Array },
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+	const producerFinal = withGitFilenameEncoding(producerCmd);
+	const consumerFinal = withGitFilenameEncoding(consumerCmd);
+	log.debug("Executing git pipeline", { cwd, producer: producerFinal, consumer: consumerFinal });
+
+	let producer: ReturnType<typeof spawn> | undefined;
+	let consumer: ReturnType<typeof spawn> | undefined;
+	try {
+		producer = spawn(producerFinal, { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+		consumer = spawn(consumerFinal, { cwd, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+	} catch (err) {
+		// One side never started — never leave the other running.
+		try { producer?.kill(); } catch { /* already gone */ }
+		try { consumer?.kill(); } catch { /* already gone */ }
+		const stderr = `git pipeline spawn failed: ${String(err)}`;
+		log.warn("Git pipeline spawn failed", { producer: producerFinal, consumer: consumerFinal, error: String(err) });
+		return { ok: false, stdout: "", stderr };
+	}
+
+	// Drain every pipe before awaiting exit, or a >64KB write blocks forever.
+	const consumerStdoutPromise = new Response(consumer.stdout as unknown as ReadableStream<Uint8Array>).text().catch(() => "");
+	const consumerStderrPromise = new Response(consumer.stderr as unknown as ReadableStream<Uint8Array>).text().catch(() => "");
+	const producerStderrPromise = new Response(producer.stderr as unknown as ReadableStream<Uint8Array>).text().catch(() => "");
+
+	const sink = consumer.stdin as unknown as PipeSink;
+	const reader = (producer.stdout as unknown as ReadableStream<Uint8Array>).getReader();
+	let pipeError: string | null = null;
+	try {
+		if (opts?.prefix) {
+			sink.write(opts.prefix);
+			await sink.flush();
+		}
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value?.byteLength) continue;
+			sink.write(value);
+			await sink.flush();
+		}
+	} catch (err) {
+		// Consumer died early (broken pipe) or the producer stream errored.
+		pipeError = String(err);
+	} finally {
+		try { reader.releaseLock(); } catch { /* already released */ }
+		try { sink.end(); } catch { /* consumer already gone */ }
+		if (pipeError) {
+			try { producer.kill(); } catch { /* already gone */ }
+		}
+	}
+
+	const [producerCode, consumerCode] = await Promise.all([
+		producer.exited.catch(() => 1),
+		consumer.exited.catch(() => 1),
+	]);
+	const [stdout, producerStderr, consumerStderr] = await Promise.all([
+		consumerStdoutPromise,
+		producerStderrPromise,
+		consumerStderrPromise,
+	]);
+
+	const ok = producerCode === 0 && consumerCode === 0 && !pipeError;
+	const stderr = [pipeError, producerStderr.trim(), consumerStderr.trim()].filter(Boolean).join("\n");
+	if (!ok) {
+		log.warn("Git pipeline failed", {
+			producer: producerFinal,
+			consumer: consumerFinal,
+			producerCode,
+			consumerCode,
+			stderr,
+		});
+	}
+	return { ok, stdout: stdout.trim(), stderr };
+}
+
 const BATCH_HEADER_RE = /^[0-9a-f]{40,64} blob (\d+)$/;
 
 function indexOfNewline(bytes: Uint8Array, from: number): number {
@@ -1619,6 +1715,11 @@ export async function getBranchDiffStats(
 	};
 }
 
+const PATCH_ID_CMD = ["git", "patch-id", "--stable"];
+// git patch-id keys each patch by the commit line preceding it; a raw `git diff`
+// has none, so we synthesise a zero SHA header.
+const FAKE_COMMIT_HEADER = new TextEncoder().encode(`commit ${"0".repeat(40)}\n\n`);
+
 export async function isContentMergedInto(
 	worktreePath: string,
 	ref: string,
@@ -1645,8 +1746,8 @@ export async function isContentMergedInto(
 	// same files AFTER the squash merge (add/add conflicts). In that case,
 	// fall back to patch-id matching which handles post-merge divergence well.
 	//
-	// IMPORTANT: We pipe git log -p directly into git patch-id via Bun
-	// subprocess piping to avoid reading multi-MB patch output into JS memory.
+	// IMPORTANT: We stream git log -p directly into git patch-id via runGitPipe
+	// (no shell) to avoid reading multi-MB patch output into JS memory.
 	const mergeBaseResult = await run(["git", "merge-base", ref, "HEAD"], worktreePath);
 	if (!mergeBaseResult.ok) return false;
 	const mergeBase = mergeBaseResult.stdout;
@@ -1655,27 +1756,28 @@ export async function isContentMergedInto(
 	const taskStatResult = await run(["git", "diff", "--shortstat", mergeBase, "HEAD"], worktreePath);
 	if (!taskStatResult.ok || !taskStatResult.stdout) return true; // no task changes
 
-	// Validate refs before use — mergeBase is a SHA from git merge-base,
-	// ref is origin/<baseBranch> from project config. Guard against injection
-	// for the one bash -c call below.
+	// Validate refs before use — mergeBase is a SHA from git merge-base, ref is
+	// origin/<baseBranch> from project config. Nothing below goes through a
+	// shell, but a ref starting with "-" would still be read as a git option.
 	assertSafeRef(mergeBase, "mergeBase");
 	assertSafeRef(ref, "ref");
 
 	const [combinedPatchIdResult, taskPatchIdsResult, mainPatchIdsResult] = await Promise.all([
 		// Combined diff as a single patch-id (for squash merge detection).
 		// We prepend a fake commit header so git patch-id can parse it.
-		run(
-			["bash", "-c", `{ echo "commit ${"0".repeat(40)}"; echo; git diff "${mergeBase}" HEAD; } | git patch-id --stable`],
-			worktreePath,
-		),
+		runGitPipe(["git", "diff", mergeBase, "HEAD"], PATCH_ID_CMD, worktreePath, {
+			prefix: FAKE_COMMIT_HEADER,
+		}),
 		// Per-commit patch-ids from the task branch (capped to prevent unbounded memory)
-		run(
-			["bash", "-c", `git log -p --no-merges --max-count=500 "${mergeBase}..HEAD" | git patch-id --stable`],
+		runGitPipe(
+			["git", "log", "-p", "--no-merges", "--max-count=500", `${mergeBase}..HEAD`],
+			PATCH_ID_CMD,
 			worktreePath,
 		),
 		// Per-commit patch-ids from the base branch (capped to prevent unbounded memory)
-		run(
-			["bash", "-c", `git log -p --no-merges --max-count=500 "${mergeBase}..${ref}" | git patch-id --stable`],
+		runGitPipe(
+			["git", "log", "-p", "--no-merges", "--max-count=500", `${mergeBase}..${ref}`],
+			PATCH_ID_CMD,
 			worktreePath,
 		),
 	]);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

`isContentMergedInto()` detected squash/rebase merges through three `bash -c "git … | git patch-id --stable"` pipelines. Windows has no native bash: PATH resolves it to WSL bash, which joins a linked worktree's drive-qualified `gitdir:` pointer onto its own `/mnt/d/...` view, so every pipeline exited 128 and merged tasks were silently reported as unmerged.

Replaced the shell with `runGitPipe(producerCmd, consumerCmd, cwd, { prefix })`: both git processes are spawned as plain argv through the `src/bun/spawn.ts` wrapper, and the producer's stdout is copied into the consumer's stdin chunk by chunk with a `flush()` between chunks — bounded memory, real backpressure, byte-preserving for binary patches. The synthetic `commit <zero sha>` header that used to come from a shell `echo` is now an optional `prefix` argument. Spawn failures, non-zero exits, and broken pipes all resolve deterministically to `ok: false` and kill the surviving child.

Also made the backend git test helper's repo cloning `cpSync`-based so the suite runs on Windows (cmd.exe has no `cp`), and taught its spawn mock about `stdin: "pipe"` plus argv recording, which is what the new no-shell regression asserts against.

Verified on a real Windows machine (drive-qualified `D:\` linked worktree): the old bash pipeline reproduces `fatal: not a git repository … exit 128`, the new path returns `ok: true`, and a `Win32_ProcessStartTrace` capture over 15 runs of the product path shows only `git.exe` and `bun.exe` — no bash/sh/cmd/powershell/wsl. Git stays a required dev3 system dependency; bash no longer is.

Rationale and rejected alternatives: `decisions/178-shell-free-git-patch-id-pipeline.md`.