### PR TITLE
Complete teardown when git no longer registers the worktree

### DIFF
--- a/change-logs/2026/07/28/fix-unregistered-worktree-teardown.md
+++ b/change-logs/2026/07/28/fix-unregistered-worktree-teardown.md
@@ -1,0 +1,5 @@
+Short: Tasks complete despite orphan worktrees
+
+Completing a task no longer fails with "Failed to remove worktree … is not a working tree". When git has no metadata for the worktree path there is nothing left to remove, so dev3 now reclaims the orphan directory, prunes git metadata and finishes the move to Completed; genuinely refused removals (for example a locked worktree) still surface an error.
+
+Reported by Evgeny Alterman.

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -123,6 +123,26 @@ describe("removeWorktree", () => {
 		expect(existsSync(wtPath)).toBe(true);
 	});
 
+	it("swallows the failure when git no longer knows the path is a worktree", async () => {
+		// Real user report: `.git/worktrees/<name>` metadata vanished, so every
+		// completion attempt died on "is not a working tree" and the task could
+		// never leave review. Teardown must succeed and reclaim the orphan dir.
+		const project = makeProject(repo.local);
+		const task = makeTask({
+			id: "77777777-8888-9999-aaaa-bbbbbbbbbbbb",
+			branchName: "dev3/task-77777777",
+		});
+		const wtPath = join(taskDir(project, task), "worktree");
+		mkdirSync(taskDir(project, task), { recursive: true });
+		g(`git worktree add -b dev3/task-77777777 "${wtPath}" main`, repo.local);
+		rmSync(join(repo.local, ".git", "worktrees"), { recursive: true, force: true });
+
+		await removeWorktree(project, { ...task, worktreePath: wtPath });
+
+		expect(existsSync(wtPath)).toBe(false);
+		expect(g("git branch", repo.local)).not.toContain("dev3/task-77777777");
+	});
+
 	it("removes worktree and deletes RENAMED branch correctly", async () => {
 		const wtPath = join(repo.dir, "worktree");
 		g(`git worktree add -b dev3/task-aaaaaaaa "${wtPath}" main`, repo.local);

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -2287,6 +2287,14 @@ export async function applySparseCheckout(
 	log.info("Sparse checkout applied", { worktreePath, pathCount: paths.length });
 }
 
+/**
+ * `git worktree remove` failures that mean "git never knew about this path"
+ * (metadata pruned, repo re-cloned, admin dir wiped) — not "removal refused".
+ */
+function isUnregisteredWorktreeError(stderr: string): boolean {
+	return /is not a working tree|is not a worktree|not a valid path/i.test(stderr);
+}
+
 export async function removeWorktree(
 	project: Project,
 	task: Task,
@@ -2318,12 +2326,27 @@ export async function removeWorktree(
 		);
 		if (!removeResult.ok) {
 			const detail = removeResult.stderr.trim() || "git worktree remove exited unsuccessfully";
-			log.error("Failed to remove worktree", {
-				path: targetPath,
-				taskId: task.id,
-				stderr: removeResult.stderr,
-			});
-			throw new Error(`Failed to remove worktree at ${targetPath}: ${detail}`);
+			if (isUnregisteredWorktreeError(removeResult.stderr)) {
+				// Git has no metadata for this path, so there is no worktree left to
+				// remove — only an orphan directory. Blocking teardown here strands the
+				// task forever (nothing can ever make git recognize the path again).
+				log.warn("Worktree is not registered with git, treating as already removed", {
+					path: targetPath,
+					taskId: task.id,
+					stderr: removeResult.stderr,
+				});
+				if (isManagedTaskWorktreePath(project, targetPath)) {
+					rmSync(targetPath, { recursive: true, force: true });
+				}
+				await run(["git", "worktree", "prune"], project.path);
+			} else {
+				log.error("Failed to remove worktree", {
+					path: targetPath,
+					taskId: task.id,
+					stderr: removeResult.stderr,
+				});
+				throw new Error(`Failed to remove worktree at ${targetPath}: ${detail}`);
+			}
 		}
 	} else {
 		log.info("Worktree directory already missing, pruning git metadata", {


### PR DESCRIPTION
Completing a task could fail permanently with `Failed to move task: Error: Failed to remove worktree at …: fatal: '…' is not a working tree`, leaving the task stuck in review forever. It happens when the `.git/worktrees/<name>` admin dir is gone while the worktree directory is still on disk: `git worktree remove` exits 128, the lifecycle aborts teardown, and no retry can ever succeed (nothing can make git recognize that path again). The reporter's manual workaround — deleting the worktree folder by hand — worked only because that hits `removeWorktree`'s already-missing branch, which just prunes metadata.

`removeWorktree` now classifies the failure: stderr matching `is not a working tree` / `is not a worktree` / `not a valid path` means git has no metadata and there is nothing left to remove, so dev3 logs a warning, deletes the orphan directory (only when the path is a dev3-managed task worktree), prunes git metadata and continues to branch deletion and the terminal status write. Genuinely refused removals — a locked worktree, for example — still throw and block teardown on purpose, since user work may be at stake there.

Reported by Evgeny Alterman.