### PR TITLE
Per-project environment variables for agent terminals

### DIFF
--- a/change-logs/2026/07/31/feature-per-project-env-vars.md
+++ b/change-logs/2026/07/31/feature-per-project-env-vars.md
@@ -1,0 +1,3 @@
+Short: Per-project env vars for agents
+
+Project Settings now has an Environment Variables editor, also configurable in .dev3/config.json and .dev3/config.local.json with per-key merging. The variables are exported into the project terminal, every agent terminal, setup/dev/cleanup script, and column agent of the project's tasks. This field is not for secrets; the editor identifies whether its storage is local-only or committed.

--- a/decisions/179-per-key-env-config-merge.md
+++ b/decisions/179-per-key-env-config-merge.md
@@ -1,0 +1,38 @@
+# 179. Per-key merge for the `env` config field
+
+## Context
+
+Per-project environment variables must reach the standalone project terminal,
+every task-scoped agent terminal, setup/dev/cleanup script, column agent, and
+spawned agent pane. They can be set in Project Settings (`projects.json`),
+`.dev3/config.json` (shared), and `.dev3/config.local.json` (machine-local), but
+this field is not for secrets.
+
+## Decision
+
+`env` is the one field that merges PER KEY across all cascade layers (worktree
+local > worktree repo > main local > main repo > projects.json). Implemented as
+an explicit special case after the uniform loop in `applyConfigCascade`;
+launch-time consumers use `resolveProjectEnv()`, which re-reads the files so
+config edits apply on the next launch. Injection order in task sessions:
+project env first, so `DEV3_*` lifecycle vars and per-agent-config `envVars`
+always override it. The UI identifies whether the active storage is local-only
+or committed, and warns that saving worktree repo config commits immediately.
+
+## Risks
+
+Provenance surfaces (`dev3 config show`, UI source badges) attribute `env` to
+its highest-priority source even when the effective map mixes layers. Accepted:
+per-key provenance would complicate three surfaces for marginal value. Values
+remain plaintext in existing config storage, so the product must not present
+this field as secret storage.
+
+## Alternatives considered
+
+Whole-field resolution like every other key: rejected — a repo config defining
+one var would silently erase all UI-configured vars, defeating the "shared file
++ machine-local overrides + UI" use case. A separate dotenv file or `envFile`
+pointer was left out of v1 because it duplicates the existing config cascade
+and gitignore machinery. Keychain/encryption and a variable-name denylist were
+also left out: storage remains unchanged, and cloning a repository already
+trusts its committed configuration.

--- a/src/bun/__tests__/agent-accounts.test.ts
+++ b/src/bun/__tests__/agent-accounts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -326,7 +326,7 @@ describe("setActiveClaudeAccount / getActiveClaudeConfigDir", () => {
 		mkdirSync(join(paths.claudeHome, "output-styles"), { recursive: true });
 		const account = await importCurrentClaudeAccount(paths);
 		const dir = claudeAccountDir(account.id, paths);
-		rmSync(join(dir, "output-styles")); // simulate the pre-fix on-disk state
+		unlinkSync(join(dir, "output-styles")); // simulate the pre-fix on-disk state
 
 		expect(await getActiveClaudeConfigDir(account.id, paths)).toBe(dir);
 		expect(lstatSync(join(dir, "output-styles")).isSymbolicLink()).toBe(true);

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -326,6 +326,12 @@ describe("dev3-project-config skill content", () => {
 			"If `portCount > 0`, also smoke-test the mapping:",
 		);
 	});
+
+	it("documents project environment variables and their secret-storage boundary", () => {
+		const skill = getProjectConfigSkillContent();
+		expect(skill).toContain("| `env` | Record<string, string> |");
+		expect(skill).toContain("This field is not for secrets; `.dev3/config.json` is committed.");
+	});
 });
 
 describe("dev3 Bug Hunter skill content", () => {

--- a/src/bun/__tests__/data-projects.test.ts
+++ b/src/bun/__tests__/data-projects.test.ts
@@ -3,14 +3,15 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Project } from "../../shared/types";
 
 const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/data-projects`);
+const log = vi.hoisted(() => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
 
 vi.mock("../logger", () => ({
-	createLogger: () => ({
-		debug: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-	}),
+	createLogger: () => log,
 }));
 
 vi.mock("../paths", () => ({
@@ -28,6 +29,7 @@ vi.mock("../file-lock", () => ({
 beforeEach(() => {
 	rmSync(TEST_HOME, { recursive: true, force: true });
 	mkdirSync(TEST_HOME, { recursive: true });
+	log.info.mockClear();
 });
 
 import { addProject, loadProjects, updateProject } from "../data";
@@ -104,6 +106,19 @@ describe("updateProject", () => {
 
 		const all = await loadProjects();
 		expect(all[0].autoReviewEnabled).toBe(true);
+	});
+
+	it("logs env key names without logging their values", async () => {
+		const project = await addProject("/tmp/env-repo", "Env Repo");
+
+		await updateProject(project.id, { env: { SECRET_TOKEN: "sensitive-value" } });
+
+		const updateLog = log.info.mock.calls.find(([message]) => message === "Updating project");
+		expect(updateLog).toEqual([
+			"Updating project",
+			{ projectId: project.id, updates: {}, envKeys: ["SECRET_TOKEN"] },
+		]);
+		expect(JSON.stringify(log.info.mock.calls)).not.toContain("sensitive-value");
 	});
 });
 

--- a/src/bun/__tests__/env-text.test.ts
+++ b/src/bun/__tests__/env-text.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { parseEnvText, serializeEnvText, sanitizeEnvMap, validateEnvMap } from "../../shared/env-text";
+
+describe("parseEnvText", () => {
+	it("parses KEY=value lines", () => {
+		expect(parseEnvText("FOO=bar\nBAZ=qux").env).toEqual({ FOO: "bar", BAZ: "qux" });
+	});
+
+	it("keeps everything after the first = verbatim, including = and spaces", () => {
+		expect(parseEnvText("URL=https://x.dev/?a=1&b=2").env).toEqual({ URL: "https://x.dev/?a=1&b=2" });
+		expect(parseEnvText("MSG= hello world ").env).toEqual({ MSG: " hello world " });
+	});
+
+	it("parses CRLF line endings", () => {
+		expect(parseEnvText("FOO=bar\r\nBAZ=qux\r\n")).toEqual({
+			env: { FOO: "bar", BAZ: "qux" },
+			errors: [],
+		});
+	});
+
+	it("allows empty values", () => {
+		expect(parseEnvText("EMPTY=").env).toEqual({ EMPTY: "" });
+	});
+
+	it("skips blank lines and # comments", () => {
+		const { env, errors } = parseEnvText("# comment\n\n  \nFOO=1\n  # indented comment");
+		expect(env).toEqual({ FOO: "1" });
+		expect(errors).toEqual([]);
+	});
+
+	it("reports invalid lines with 1-based line numbers", () => {
+		const { env, errors } = parseEnvText("FOO=1\nnot a var\n2BAD=x");
+		expect(env).toEqual({ FOO: "1" });
+		expect(errors).toEqual([
+			{ line: 2, text: "not a var" },
+			{ line: 3, text: "2BAD=x" },
+		]);
+	});
+
+	it("last duplicate key wins", () => {
+		expect(parseEnvText("A=1\nA=2").env).toEqual({ A: "2" });
+	});
+});
+
+describe("serializeEnvText", () => {
+	it("round-trips with parseEnvText", () => {
+		const env = { FOO: "bar", URL: "https://x.dev/?a=1", EMPTY: "" };
+		expect(parseEnvText(serializeEnvText(env)).env).toEqual(env);
+	});
+
+	it("returns empty string for empty map", () => {
+		expect(serializeEnvText({})).toBe("");
+	});
+});
+
+describe("sanitizeEnvMap", () => {
+	it("returns {} for non-objects", () => {
+		expect(sanitizeEnvMap(null)).toEqual({});
+		expect(sanitizeEnvMap("FOO=1")).toEqual({});
+		expect(sanitizeEnvMap([1, 2])).toEqual({});
+	});
+
+	it("returns {} silently for undefined (not configured)", () => {
+		const warnings: string[] = [];
+		expect(sanitizeEnvMap(undefined, (m) => warnings.push(m))).toEqual({});
+		expect(warnings).toEqual([]);
+	});
+
+	it("drops non-string values and invalid keys, keeps the rest, warns per drop", () => {
+		const warnings: string[] = [];
+		const out = sanitizeEnvMap({ GOOD: "1", BAD_NUM: 2, "2BAD": "x" }, (m) => warnings.push(m));
+		expect(out).toEqual({ GOOD: "1" });
+		expect(warnings.length).toBe(2);
+	});
+});
+
+describe("validateEnvMap", () => {
+	it("accepts a valid map and undefined", () => {
+		expect(validateEnvMap({ FOO: "bar" })).toEqual([]);
+		expect(validateEnvMap(undefined)).toEqual([]);
+	});
+
+	it("rejects non-object, invalid keys, non-string values", () => {
+		expect(validateEnvMap("x").length).toBe(1);
+		expect(validateEnvMap({ "2BAD": "x" }).length).toBe(1);
+		expect(validateEnvMap({ FOO: 3 }).length).toBe(1);
+	});
+
+	it("rejects line breaks in values", () => {
+		expect(validateEnvMap({ LF: "a\nb", CR: "a\rb" })).toEqual([
+			"env var LF must not contain line breaks",
+			"env var CR must not contain line breaks",
+		]);
+	});
+});

--- a/src/bun/__tests__/repo-config.test.ts
+++ b/src/bun/__tests__/repo-config.test.ts
@@ -27,6 +27,7 @@ import {
 	resolveProjectConfig,
 	resolveOperationalProjectConfig,
 	migrateProjectConfig,
+	resolveProjectEnv,
 	hasRepoConfig,
 	hasLocalConfig,
 } from "../repo-config";
@@ -407,6 +408,7 @@ describe("migrateProjectConfig", () => {
 			setupScript: "bun install",
 			cleanupScript: "rm -rf dist",
 			defaultBaseBranch: "develop",
+			env: { PERSONAL_VALUE: "local" },
 		});
 
 		await migrateProjectConfig(project);
@@ -417,6 +419,7 @@ describe("migrateProjectConfig", () => {
 		expect(written.setupScript).toBe("bun install");
 		expect(written.cleanupScript).toBe("rm -rf dist");
 		expect(written.defaultBaseBranch).toBe("develop");
+		expect(written.env).toBeUndefined();
 	});
 
 	it("skips if config.json already exists", async () => {
@@ -451,6 +454,22 @@ describe("migrateProjectConfig", () => {
 			clonePaths: [],
 			defaultBaseBranch: "main",
 			peerReviewEnabled: true,
+		});
+
+		await migrateProjectConfig(project);
+
+		expect(existsSync(join(TEST_DIR, ".dev3", "config.json"))).toBe(false);
+	});
+
+	it("does not create config.json when env is the only non-default setting", async () => {
+		const project = makeProject({
+			setupScript: "",
+			devScript: "",
+			cleanupScript: "",
+			clonePaths: [],
+			defaultBaseBranch: "main",
+			peerReviewEnabled: true,
+			env: { PERSONAL_VALUE: "local" },
 		});
 
 		await migrateProjectConfig(project);
@@ -887,5 +906,63 @@ describe("resolveOperationalProjectConfig — worktree + main cascade", () => {
 		const resolved = await resolveOperationalProjectConfig(makeProject({ defaultCompareRef: undefined }), WT_DIR);
 		expect(resolved.defaultCompareRef).toBe("origin/main");
 		expect(detectDefaultCompareRef).toHaveBeenCalledWith(WT_DIR, "main");
+	});
+});
+
+describe("env config cascade (per-key merge)", () => {
+	const WT_DIR = join(tmpdir(), `dev3-env-wt-${process.pid}`);
+
+	function writeConfig(dir: string, file: string, content: object) {
+		mkdirSync(join(dir, ".dev3"), { recursive: true });
+		writeFileSync(join(dir, ".dev3", file), JSON.stringify(content));
+	}
+
+	beforeEach(() => { mkdirSync(WT_DIR, { recursive: true }); });
+	afterEach(() => { rmSync(WT_DIR, { recursive: true, force: true }); });
+
+	it("merges env per key across layers instead of whole-field", async () => {
+		const project = makeProject({ env: { A: "project", B: "project" } });
+		writeConfig(TEST_DIR, "config.json", { env: { B: "repo", C: "repo" } });
+		writeConfig(TEST_DIR, "config.local.json", { env: { C: "local" } });
+
+		const resolved = await resolveProjectConfig(project);
+		expect(resolved.env).toEqual({ A: "project", B: "repo", C: "local" });
+	});
+
+	it("worktree layers outrank main-checkout layers per key", async () => {
+		const project = makeProject();
+		writeConfig(TEST_DIR, "config.json", { env: { X: "main", Y: "main" } });
+		writeConfig(WT_DIR, "config.json", { env: { X: "wt" } });
+
+		const resolved = await resolveOperationalProjectConfig(project, WT_DIR);
+		expect(resolved.env).toEqual({ X: "wt", Y: "main" });
+	});
+
+	it("drops malformed env entries from files without failing resolution", async () => {
+		const project = makeProject();
+		writeConfig(TEST_DIR, "config.json", {
+			setupScript: "bun install",
+			env: { GOOD: "1", BAD: 42, "2BAD": "x" },
+		});
+
+		const resolved = await resolveProjectConfig(project);
+		expect(resolved.env).toEqual({ GOOD: "1" });
+		expect(resolved.setupScript).toBe("bun install");
+	});
+
+	it("leaves env undefined when nothing sets it", async () => {
+		const resolved = await resolveProjectConfig(makeProject());
+		expect(resolved.env).toBeUndefined();
+	});
+
+	it("resolveProjectEnv returns {} for a project with no env", async () => {
+		expect(await resolveProjectEnv(makeProject())).toEqual({});
+	});
+
+	it("resolveProjectEnv returns the merged map for a worktree", async () => {
+		const project = makeProject({ env: { A: "project" } });
+		writeConfig(WT_DIR, "config.local.json", { env: { B: "wt-local" } });
+
+		expect(await resolveProjectEnv(project, WT_DIR)).toEqual({ A: "project", B: "wt-local" });
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -197,6 +197,7 @@ vi.mock("../repo-config", () => {
 		getConfigSources: vi.fn(() => []),
 		hasRepoConfig: vi.fn(() => false),
 		hasLocalConfig: vi.fn(() => false),
+		resolveProjectEnv: vi.fn(async (project: any) => project.env ?? {}),
 	};
 });
 
@@ -8085,7 +8086,10 @@ describe("handlers.getProjectPtyUrl", () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	it("creates a project PTY session and returns ws URL", async () => {
-		const project = makeProject({ path: "/tmp/test-project" });
+		const project = makeProject({
+			path: "/tmp/test-project",
+			env: { API_URLS: "https://api.example.com,http://api.example.com" },
+		});
 		(data.getProject as any).mockResolvedValue(project);
 		vi.mocked(pty.hasSession).mockReturnValue(false);
 		vi.mocked(pty.hasDeadSession).mockReturnValue(false);
@@ -8093,12 +8097,13 @@ describe("handlers.getProjectPtyUrl", () => {
 
 		const url = await handlers.getProjectPtyUrl({ projectId: project.id });
 
+		expect(repoConfig.resolveProjectEnv).toHaveBeenCalledWith(project, project.path);
 		expect(pty.createSession).toHaveBeenCalledWith(
 			`project-${project.id}`,
 			project.id,
 			"/tmp/test-project",
 			process.env.SHELL || "/bin/zsh",
-			{},
+			{ API_URLS: "https://api.example.com,http://api.example.com" },
 			"dev3",
 			"project",
 		);

--- a/src/bun/__tests__/tmux-pty-devserver-selfhost.test.ts
+++ b/src/bun/__tests__/tmux-pty-devserver-selfhost.test.ts
@@ -101,7 +101,7 @@ vi.mock("../tmux", () => {
 });
 
 vi.mock("../agents", () => ({}));
-vi.mock("../repo-config", () => ({}));
+vi.mock("../repo-config", () => ({ resolveProjectEnv: vi.fn(async () => ({})) }));
 
 vi.mock("../port-pool", () => ({
 	getPortAssignments: vi.fn(() => []),

--- a/src/bun/__tests__/tmux-pty-native-launch.test.ts
+++ b/src/bun/__tests__/tmux-pty-native-launch.test.ts
@@ -122,7 +122,7 @@ vi.mock("../temp-paths", () => ({
 	dev3TaskTempPath: vi.fn((taskId: string, name?: string) => (name ? `/tmp/dev3/${taskId}/${name}` : `/tmp/dev3/${taskId}`)),
 }));
 
-vi.mock("../repo-config", () => ({}));
+vi.mock("../repo-config", () => ({ resolveProjectEnv: vi.fn(async () => ({})) }));
 
 vi.mock("../port-pool", () => ({
 	getPortAssignments: vi.fn(() => []),

--- a/src/bun/__tests__/tmux-pty-search.test.ts
+++ b/src/bun/__tests__/tmux-pty-search.test.ts
@@ -73,7 +73,7 @@ vi.mock("../tmux", () => {
 });
 
 vi.mock("../agents", () => ({}));
-vi.mock("../repo-config", () => ({}));
+vi.mock("../repo-config", () => ({ resolveProjectEnv: vi.fn(async () => ({})) }));
 vi.mock("../port-pool", () => ({}));
 vi.mock("../port-scanner", () => ({
 	clearPortDataForTask: vi.fn(),

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -229,6 +229,7 @@ EOF
 | \`sparseCheckoutEnabled\` | boolean | Enable sparse checkout for worktrees (default: \`false\`) |
 | \`sparseCheckoutPaths\` | string[] | Paths to include in sparse checkout |
 | \`portCount\` | number | Ports to allocate per task (injected as \`DEV3_PORT0\`..N env vars). Default: \`0\`. **You must map these to the project's own port env vars in \`devScript\` — see step 3a.** |
+| \`env\` | Record<string, string> | Environment variables exported into task sessions. This field is not for secrets; \`.dev3/config.json\` is committed. |
 
 **Only include these fields.** Unknown keys are silently ignored. Do NOT include project metadata (id, name, path).
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -26,7 +26,7 @@ const PROJECTS_BACKUP_FILE_PATTERN = /^projects-\d{4}-\d{2}-\d{2}\.json\.bak$/;
 const TASK_BACKUPS_DIR = "tasks-backups";
 const TASK_BACKUP_RETENTION_HOURS = 72;
 const TASK_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
-type ProjectUpdates = Partial<Pick<Project, "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels">>;
+type ProjectUpdates = Partial<Pick<Project, "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels" | "env">>;
 
 export class DataFileReadError extends Error {
 	override name = "DataFileReadError";
@@ -533,9 +533,15 @@ export async function updateProject(
 	projectId: string,
 	updates: ProjectUpdates,
 ): Promise<Project> {
+	const { env, ...loggedUpdates } = updates;
+	const logFields = {
+		projectId,
+		updates: loggedUpdates,
+		envKeys: Object.keys(env ?? {}),
+	};
 	if (await isVirtualProjectId(projectId)) {
 		return withFileLock(VIRTUAL_PROJECTS_FILE, async () => {
-			log.info("Updating virtual project", { projectId, updates });
+			log.info("Updating virtual project", logFields);
 			const projects = await rawLoadAllVirtualProjects({ strict: true });
 			const idx = projects.findIndex((p) => p.id === projectId);
 			if (idx === -1) throw new Error(`Project not found: ${projectId}`);
@@ -545,7 +551,7 @@ export async function updateProject(
 		});
 	}
 	return withFileLock(PROJECTS_FILE, async () => {
-		log.info("Updating project", { projectId, updates });
+		log.info("Updating project", logFields);
 		const projects = await rawLoadAllProjects({ strict: true, persistMigrations: true });
 		const idx = projects.findIndex((p) => p.id === projectId);
 		if (idx === -1) throw new Error(`Project not found: ${projectId}`);

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -346,7 +346,10 @@ export async function runCleanupScript(
 	const script = resolved.cleanupScript?.trim() || 'echo "Task finished"';
 	const dialect = launchDialect();
 	const scriptPath = dev3TaskTempPath(task.id, `cleanup${dialect.scriptExtension}`);
-	const cleanupEnv = buildCleanupScriptEnv(task, project, transition);
+	const cleanupEnv = {
+		...(resolved.env ?? {}),
+		...buildCleanupScriptEnv(task, project, transition),
+	};
 	await Bun.write(scriptPath, `${[...dialect.header(), script].join("\n")}\n`);
 	// The cleanup script is shown in a throwaway tmux session — POSIX-only.
 	assertPosixLaunchDialect("the cleanup-script tmux session");

--- a/src/bun/repo-config.ts
+++ b/src/bun/repo-config.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import type { Project, Dev3RepoConfig, ConfigSourceEntry, ResolvedConfigSource } from "../shared/types";
 import { DEV3_REPO_CONFIG_KEYS } from "../shared/types";
+import { sanitizeEnvMap } from "../shared/env-text";
 import { createLogger } from "./logger";
 import * as git from "./git";
 
@@ -219,6 +220,14 @@ async function applyConfigCascade(
 		if (val !== undefined) (resolved as any)[key] = val;
 	}
 
+	// `env` merges PER KEY across layers, unlike every other field: a repo file
+	// that sets one var must not erase UI- or local-configured vars (decision 179).
+	const envMerged = sanitizeEnvMap(project.env, (m) => log.warn(m));
+	for (let i = layers.length - 1; i >= 0; i--) {
+		Object.assign(envMerged, sanitizeEnvMap(layers[i]?.env, (m) => log.warn(m)));
+	}
+	resolved.env = Object.keys(envMerged).length > 0 ? envMerged : undefined;
+
 	// defaultCompareRef: explicit value wins; else derive from mode + base branch;
 	// else auto-detect from git (resilient to a missing/broken folder). Merge raw
 	// layer values low→high so the highest-priority layer wins, matching the cascade.
@@ -297,6 +306,13 @@ export async function resolveOperationalProjectConfig(project: Project, worktree
 	return applyConfigCascade(project, layers, worktreePath);
 }
 
+/** Per-key-merged project env for a terminal or task session, re-read at launch
+ *  time so config-file edits apply on the next launch. Never throws. */
+export async function resolveProjectEnv(project: Project, worktreePath?: string | null): Promise<Record<string, string>> {
+	const resolved = await resolveOperationalProjectConfig(project, worktreePath ?? undefined);
+	return resolved.env ?? {};
+}
+
 /**
  * One-time migration: if no .dev3/config.json exists, create it from
  * settings stored in projects.json. Runs automatically on project load.
@@ -318,6 +334,7 @@ export async function migrateProjectConfig(project: Project, configPath?: string
 	const config: Dev3RepoConfig = {};
 	let hasSettings = false;
 	for (const key of DEV3_REPO_CONFIG_KEYS) {
+		if (key === "env") continue;
 		const val = (project as any)[key];
 		if (val !== undefined && val !== DEFAULTS[key]) {
 			// For arrays, check if non-empty

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -20,6 +20,14 @@ import { setCurrentUiTheme } from "../theme-state";
 import { extractConfigFromParams, getPushMessage, getSystemRequirements, log, resolveBinaryPath, setFocusMode } from "./shared";
 import { binaryCandidatesOnPath, hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
 import { isExecutableFile } from "../executable";
+import { validateEnvMap } from "../../shared/env-text";
+
+/** Reject malformed env maps at the RPC boundary — the UI validates too, but
+ *  saves must not depend on the client being well-behaved. */
+function assertValidEnvParam(env: unknown): void {
+	const problems = validateEnvMap(env);
+	if (problems.length > 0) throw new Error(`Invalid env config: ${problems.join("; ")}`);
+}
 
 // `resolveOperationalProjectConfig` moved to ../repo-config (it depends only on
 // resolveProjectConfig, so it belongs next to the config resolver and stays
@@ -55,6 +63,7 @@ async function getProjectConfigFiles(params: { projectId: string }): Promise<{ h
 
 async function updateProjectSettings(params: { projectId: string } & ProjectSettingsUpdate): Promise<Project> {
 	log.info("→ updateProjectSettings", { projectId: params.projectId });
+	assertValidEnvParam(params.env);
 	const updates = {
 		...extractConfigFromParams(params),
 		...(params.githubAuthHost !== undefined ? { githubAuthHost: params.githubAuthHost } : {}),
@@ -68,6 +77,7 @@ async function updateProjectSettings(params: { projectId: string } & ProjectSett
 
 async function saveRepoConfig(params: { projectId: string; worktreePath?: string; autoCommit?: boolean } & Dev3RepoConfig): Promise<void> {
 	log.info("→ saveRepoConfig", { projectId: params.projectId, worktreePath: params.worktreePath, autoCommit: params.autoCommit });
+	assertValidEnvParam(params.env);
 	const project = await data.getProject(params.projectId);
 	const configPath = params.worktreePath || project.path;
 	const config = extractConfigFromParams(params) as Dev3RepoConfig;
@@ -90,6 +100,7 @@ async function saveRepoConfig(params: { projectId: string; worktreePath?: string
 
 async function saveLocalConfig(params: { projectId: string; worktreePath?: string } & Dev3RepoConfig): Promise<void> {
 	log.info("→ saveLocalConfig", { projectId: params.projectId, worktreePath: params.worktreePath });
+	assertValidEnvParam(params.env);
 	const project = await data.getProject(params.projectId);
 	const configPath = params.worktreePath || project.path;
 	const config = extractConfigFromParams(params) as Dev3RepoConfig;

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -617,7 +617,11 @@ export async function launchTaskPty(
 	// below: a git-ignored hook (e.g. installed by the b44 CLI into
 	// .dev3/config.local.json) only exists at the project root, so the script
 	// command must be resolvable as "$DEV3_PROJECT_PATH/.dev3/<hook>.sh".
+	// Project env (Project Settings / .dev3 config) first — overridable by
+	// lifecycle DEV3_* vars and per-agent-config env.
+	const projectEnv = await repoConfig.resolveProjectEnv(project, worktreePath);
 	const env = {
+		...projectEnv,
 		...buildTaskLifecycleEnv(project, task, worktreePath, opts?.branchName),
 		...buildAgentEnv(extraEnv, task.id),
 		...artifactTemplateEnv,
@@ -859,6 +863,7 @@ export async function launchColumnAgent(
 	});
 
 	const env = {
+		...(await repoConfig.resolveProjectEnv(project, worktreePath)),
 		...buildAgentEnv(extraEnv, task.id),
 		...ensureArtifactTemplateEnv(project, task, worktreePath),
 	};
@@ -974,12 +979,16 @@ export async function runDevServer(params: { taskId: string; projectId: string }
 		const portExports = devPorts.length > 0
 			? buildEnvExports(portPool.buildPortEnv(devPorts)).join("\n") + "\n"
 			: "";
+		const projectEnvExports = Object.keys(resolved.env ?? {}).length > 0
+			? buildEnvExports(resolved.env ?? {}).join("\n") + "\n"
+			: "";
 		// Same workspace env the setup/cleanup hooks get, so a devScript can
 		// reference root-resolved hooks ("$DEV3_PROJECT_PATH/...") too.
 		const lifecycleExports = buildEnvExports(buildTaskLifecycleEnv(project, task, task.worktreePath)).join("\n") + "\n";
 
 		const wrappedScript = [
 			`#!/bin/bash`,
+			...(projectEnvExports ? [projectEnvExports] : []),
 			lifecycleExports,
 			...(portExports ? [portExports] : []),
 			`set -x`,
@@ -1570,7 +1579,8 @@ async function getProjectPtyUrl(params: { projectId: string }): Promise<string> 
 		if (!existsSync(project.path)) {
 			throw new Error(`Project path does not exist: ${project.path}`);
 		}
-		pty.createSession(sessionKey, params.projectId, project.path, getUserShell(), {}, DEFAULT_TMUX_SOCKET, "project");
+		const env = await repoConfig.resolveProjectEnv(project, project.path);
+		pty.createSession(sessionKey, params.projectId, project.path, getUserShell(), env, DEFAULT_TMUX_SOCKET, "project");
 	}
 
 	const url = `ws://localhost:${pty.getPtyPort()}?session=${sessionKey}`;
@@ -2343,6 +2353,7 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 	});
 
 	const env: Record<string, string> = {
+		...(await repoConfig.resolveProjectEnv(project, task.worktreePath)),
 		...buildAgentEnv(extraEnv, task.id),
 		...ensureArtifactTemplateEnv(project, task, task.worktreePath),
 	};
@@ -2507,6 +2518,7 @@ async function spawnSingleBugHunterPane(opts: {
 	});
 
 	const env: Record<string, string> = {
+		...(await repoConfig.resolveProjectEnv(opts.project, opts.worktreePath)),
 		...buildAgentEnv(extraEnv, opts.task.id),
 		...ensureArtifactTemplateEnv(opts.project, opts.task, opts.worktreePath),
 	};

--- a/src/cli/__tests__/socket-client-loopback.test.ts
+++ b/src/cli/__tests__/socket-client-loopback.test.ts
@@ -23,6 +23,14 @@ function tempDir(): string {
 	return dir;
 }
 
+function socketTempDir(): string {
+	// Unix-domain socket paths are capped around 104 bytes on macOS.
+	const root = process.platform === "win32" ? process.env.DEV3_TEST_ROOT as string : "/tmp";
+	const dir = mkdtempSync(join(root, "dev3-cli-socket-"));
+	dirs.push(dir);
+	return dir;
+}
+
 /**
  * A loopback server that answers with whatever `reply` builds. `node:net` is the
  * same client `socket-client` uses, so this exercises the real TCP path end to
@@ -93,7 +101,7 @@ describe("sendRequest over a loopback endpoint record", () => {
 	});
 
 	it("never attaches a token when the handle is a Unix socket path", async () => {
-		const dir = tempDir();
+		const dir = socketTempDir();
 		const socketPath = join(dir, "unix.sock");
 		const received: CliRequest[] = [];
 		await new Promise<void>((resolve) => {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -16,6 +16,10 @@ function formatConfigValue(field: string, value: unknown): string {
 	if (typeof value === "string") return value || "(empty)";
 	if (value !== null && typeof value === "object") {
 		const keys = Object.keys(value as Record<string, unknown>);
+		// Env values may be secrets — print key names only.
+		if (field === "env") {
+			return keys.length > 0 ? `${keys.join(", ")} (${keys.length} ${keys.length === 1 ? "var" : "vars"})` : "(empty)";
+		}
 		if (field === "builtinColumnAgents") {
 			return keys.length === 1 ? "1 column" : `${keys.length} columns`;
 		}

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -3,6 +3,7 @@ import { toast } from "../toast";
 import { confirm } from "../confirm";
 import type { CodingAgent, ColumnAgentConfig, CustomColumn, Dev3RepoConfig, GitHubAccount, GitHubCliStatus, Label, Project, SetupScriptLaunchMode, Task } from "../../shared/types";
 import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
+import { hasEnvLineBreak, parseEnvText, serializeEnvText } from "../../shared/env-text";
 import { CUSTOM_COLUMN_INSTRUCTION_MAX_CHARS, DEFAULT_REVIEW_PROMPT } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
@@ -442,6 +443,133 @@ function CustomColumnRow({ column, saving, onUpdate, onDelete, availableAgents }
 	);
 }
 
+// ---- Env vars editor (dotenv-style textarea backed by config.env) ----
+
+type EnvStorageScope = "project" | "repo" | "local";
+
+function envWithoutLineBreaks(env: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(Object.entries(env).filter(([, value]) => !hasEnvLineBreak(value)));
+}
+
+function EnvVarsEditor({ env, storageScope, onChange, onErrorChange }: {
+	env: Record<string, string> | undefined;
+	storageScope: EnvStorageScope;
+	onChange: (env: Record<string, string> | undefined) => void;
+	onErrorChange?: (hasError: boolean) => void;
+}) {
+	const t = useT();
+	const lineBreakEntries = Object.entries(env ?? {}).filter(([, value]) => hasEnvLineBreak(value));
+	const [text, setText] = useState(() => serializeEnvText(envWithoutLineBreaks(env ?? {})));
+	const [errorLines, setErrorLines] = useState<number[]>([]);
+	// Tracks the env value this editor last emitted (or was initialized from);
+	// an external change (tab switch, async config load) reinitializes the text.
+	const emittedRef = useRef(JSON.stringify(env ?? {}));
+
+	useEffect(() => {
+		const incoming = JSON.stringify(env ?? {});
+		if (incoming !== emittedRef.current) {
+			emittedRef.current = incoming;
+			setText(serializeEnvText(envWithoutLineBreaks(env ?? {})));
+			setErrorLines([]);
+		}
+	}, [env]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// The cleanup clears the parent's gate on unmount (config-layer switch): child
+	// effects run before parent ones, so a parent-side reset would overwrite the
+	// value this editor just reported for the layer it mounted with.
+	useEffect(() => {
+		onErrorChange?.(errorLines.length > 0 || lineBreakEntries.length > 0);
+		return () => onErrorChange?.(false);
+	}, [errorLines.length, lineBreakEntries.length, onErrorChange]);
+
+	function handleChange(next: string) {
+		setText(next);
+		const { env: parsed, errors } = parseEnvText(next);
+		setErrorLines(errors.map((e) => e.line));
+		if (errors.length === 0) {
+			// Always emit an object (never undefined): the save handlers skip
+			// undefined params, which would make a cleared env impossible to persist.
+			const preserved = Object.fromEntries(lineBreakEntries);
+			const updated = { ...preserved, ...parsed };
+			emittedRef.current = JSON.stringify(updated);
+			onChange(updated);
+		}
+	}
+
+	function removeLineBreakEntry(key: string) {
+		const updated = { ...(env ?? {}) };
+		delete updated[key];
+		emittedRef.current = JSON.stringify(updated);
+		onChange(updated);
+	}
+
+	return (
+		<div>
+			<label className="block text-fg text-sm font-semibold mb-2">
+				{t("projectSettings.envVars")}
+			</label>
+			<p className="text-fg-3 text-sm mb-3">
+				{t("projectSettings.envVarsDesc")}
+			</p>
+			{storageScope === "repo" ? (
+				<div role="note" className="mb-3 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2.5 text-danger-strong">
+					<span aria-hidden="true" className="shrink-0 text-sm leading-5">&#9888;</span>
+					<p className="text-xs leading-5">{t("projectSettings.envVarsRepoWarning")}</p>
+				</div>
+			) : (
+				<p className="mb-3 text-xs leading-5 text-fg-3">
+					{t(storageScope === "project"
+						? "projectSettings.envVarsProjectNotice"
+						: "projectSettings.envVarsLocalNotice")}
+				</p>
+			)}
+			<textarea
+				value={text}
+				onChange={(e) => handleChange(e.target.value)}
+				rows={4}
+				placeholder={t("projectSettings.envVarsPlaceholder")}
+				aria-label={t("projectSettings.envVars")}
+				autoCapitalize="off"
+				autoCorrect="off"
+				spellCheck={false}
+				className={`w-full px-4 py-3 bg-raised border rounded-xl text-fg text-sm font-mono placeholder-fg-muted outline-none transition-colors resize-y ${
+					errorLines.length > 0 ? "border-danger/60 focus:border-danger" : "border-edge focus:border-accent/40"
+				}`}
+			/>
+			{lineBreakEntries.length > 0 && (
+				<div role="note" className="mt-2 rounded-lg border border-edge bg-elevated/50 px-3 py-2.5">
+					<p className="text-xs font-medium text-fg-2">
+						{t("projectSettings.envVarsLineBreakTitle")}
+					</p>
+					<p className="mt-1 text-xs leading-5 text-fg-3">
+						{t("projectSettings.envVarsLineBreakDesc")}
+					</p>
+					<div className="mt-2 divide-y divide-edge/60">
+						{lineBreakEntries.map(([key]) => (
+							<div key={key} className="flex min-w-0 items-center justify-between gap-3 py-1.5">
+								<code className="min-w-0 break-all text-xs text-fg-2">{key}</code>
+								<button
+									type="button"
+									onClick={() => removeLineBreakEntry(key)}
+									aria-label={t("projectSettings.envVarsRemoveLineBreakAria", { key })}
+									className="shrink-0 rounded px-2 py-1 text-xs font-medium text-danger transition-colors hover:bg-danger/10"
+								>
+									{t("projectSettings.envVarsRemoveLineBreak")}
+								</button>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+			{errorLines.length > 0 && (
+				<p className="text-danger text-sm mt-2">
+					{t("projectSettings.envVarsInvalidLines", { lines: errorLines.join(", ") })}
+				</p>
+			)}
+		</div>
+	);
+}
+
 // ---- Config form (shared between Repo and Local tabs) ----
 
 interface ConfigFormProps {
@@ -453,6 +581,10 @@ interface ConfigFormProps {
 	projectId: string;
 	/** Project path for "Open in Finder" on sparse checkout */
 	projectPath?: string;
+	/** Destination that owns env values, used for storage-specific safety copy. */
+	envStorageScope: EnvStorageScope;
+	/** Reports whether the env textarea currently holds unparseable lines. */
+	onEnvErrorChange?: (hasError: boolean) => void;
 }
 
 interface BranchInfo {
@@ -643,7 +775,7 @@ function normalizeLocalConfig(config: Dev3RepoConfig, inherited: Dev3RepoConfig)
 		: { ...config, defaultCompareRef };
 }
 
-function ConfigForm({ config, onChange, inherited, projectId, projectPath }: ConfigFormProps) {
+function ConfigForm({ config, onChange, inherited, projectId, projectPath, envStorageScope, onEnvErrorChange }: ConfigFormProps) {
 	const t = useT();
 	const [detecting, setDetecting] = useState(false);
 	const [detectFeedback, setDetectFeedback] = useState<string | null>(null);
@@ -782,6 +914,14 @@ function ConfigForm({ config, onChange, inherited, projectId, projectPath }: Con
 					className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors resize-y"
 				/>
 			</Field>
+
+			{/* Environment Variables */}
+			<EnvVarsEditor
+				env={config.env}
+				storageScope={envStorageScope}
+				onChange={(env) => update("env", env)}
+				onErrorChange={onEnvErrorChange}
+			/>
 			</SettingsSection>
 
 			<SettingsSection
@@ -1059,6 +1199,7 @@ function ProjectSettings({
 		peerReviewEnabled: p.peerReviewEnabled,
 		sparseCheckoutEnabled: p.sparseCheckoutEnabled,
 		sparseCheckoutPaths: p.sparseCheckoutPaths,
+		env: p.env,
 	}), []);
 	const [projectConfig, setProjectConfig] = useState<ProjectConfigValues>(() => project ? projectConfigFromProject(project) : {});
 	const [savingProject, setSavingProject] = useState(false);
@@ -1086,6 +1227,11 @@ function ProjectSettings({
 	const [draggedLabelId, setDraggedLabelId] = useState<string | null>(null);
 	const [labelDropTarget, setLabelDropTarget] = useState<{ labelId: string; side: "before" | "after" } | null>(null);
 	const [githubStatus, setGitHubStatus] = useState<GitHubCliStatus | null>(null);
+
+	// A visible env textarea holding unparseable lines blocks saving that tab. The
+	// editor owns this flag for its own lifetime — it reports on mount and clears
+	// on unmount, so switching tabs or config layers needs no reset here.
+	const [envTextError, setEnvTextError] = useState(false);
 
 	// ---- Config file presence (for override warning on Project Config tab) ----
 	const [configFileOverride, setConfigFileOverride] = useState<string | null>(null);
@@ -1201,6 +1347,7 @@ function ProjectSettings({
 		const bcaB = JSON.stringify(b.builtinColumnAgents ?? {});
 		if (bcaA !== bcaB) return false;
 		if ((a.portCount ?? 0) !== (b.portCount ?? 0)) return false;
+		if (JSON.stringify(a.env ?? {}) !== JSON.stringify(b.env ?? {})) return false;
 		return true;
 	}, []);
 
@@ -1479,6 +1626,7 @@ function ProjectSettings({
 
 	// Keep the ref in sync for the navigation guard
 	handleSaveRef.current = async () => {
+		if (envTextError) return;
 		if (activeTab === "project") await handleSaveProjectConfig();
 		else if (activeTab === "worktree") {
 			if (worktreeSubTab === "repo") await handleSaveWtRepo();
@@ -1672,6 +1820,8 @@ function ProjectSettings({
 								onChange={setProjectConfig}
 								projectId={projectId}
 								projectPath={project.path}
+								envStorageScope="project"
+								onEnvErrorChange={setEnvTextError}
 							/>
 
 							<SettingsSection
@@ -1860,18 +2010,24 @@ function ProjectSettings({
 
 									{worktreeSubTab === "repo" ? (
 										<ConfigForm
+											key={worktreeSubTab}
 											config={wtRepoConfig}
 											onChange={setWtRepoConfig}
 											projectId={projectId}
 											projectPath={selectedTask?.worktreePath ?? project.path}
+											envStorageScope="repo"
+											onEnvErrorChange={setEnvTextError}
 										/>
 									) : (
 										<ConfigForm
+											key={worktreeSubTab}
 											config={wtLocalConfig}
 											onChange={setWtLocalConfig}
 											inherited={wtRepoConfig}
 											projectId={projectId}
 											projectPath={selectedTask?.worktreePath ?? project.path}
+											envStorageScope="local"
+											onEnvErrorChange={setEnvTextError}
 										/>
 									)}
 								</>
@@ -1896,7 +2052,7 @@ function ProjectSettings({
 							<button
 								type="button"
 								onClick={() => handleSaveRef.current()}
-								disabled={saving}
+								disabled={saving || envTextError}
 								className="px-5 py-2.5 bg-accent text-white text-sm font-semibold rounded-xl outline-none hover:bg-accent-hover focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-base disabled:opacity-50 shadow-lg shadow-accent/20 transition-[background-color,opacity,transform] duration-150 ease-out active:scale-[0.96]"
 							>
 								{saving ? t("projectSettings.saving") : t("unsavedChanges.save")}

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -836,3 +836,122 @@ describe("ProjectSettings", () => {
 		});
 	});
 });
+
+describe("environment variables editor", () => {
+	it("explains where each environment variable configuration is stored", async () => {
+		(api.request.getProjectConfigs as ReturnType<typeof vi.fn>).mockResolvedValue({ repo: {}, local: {} });
+		const user = userEvent.setup();
+		await renderProjectSettings(mockProject, {}, [mockTaskWithWorktree]);
+
+		await goToProjectTab();
+		expect(screen.getByText(
+			"Stored in dev3's local project settings. These values are never written to the repository.",
+		)).toBeInTheDocument();
+
+		await user.click(screen.getByText("Worktree Config"));
+		expect(await screen.findByText(
+			"Do not store secrets here. Save writes these values to .dev3/config.json and commits the file immediately to this branch.",
+		)).toHaveClass("text-xs");
+
+		await user.click(screen.getByText("Local Overrides"));
+		expect(screen.getByText(
+			"Stored in .dev3/config.local.json. This gitignored file is never committed to the repository.",
+		)).toBeInTheDocument();
+	});
+
+	it("clears invalid editor text when switching worktree config layers", async () => {
+		(api.request.getProjectConfigs as ReturnType<typeof vi.fn>).mockResolvedValue({ repo: {}, local: {} });
+		const user = userEvent.setup();
+		await renderProjectSettings(mockProject, {}, [mockTaskWithWorktree]);
+
+		await user.click(screen.getByText("Worktree Config"));
+		const repoEditor = await screen.findByLabelText("Environment Variables");
+		await user.type(repoEditor, "not a var");
+		expect(screen.getByText("Invalid lines: 1")).toBeInTheDocument();
+
+		await user.click(screen.getByText("Local Overrides"));
+		expect(screen.getByLabelText("Environment Variables")).toHaveValue("");
+		expect(screen.queryByText("Invalid lines: 1")).not.toBeInTheDocument();
+	});
+
+	it("renders line-break values read-only and lets the user remove them", async () => {
+		const mockSave = api.request.updateProjectSettings as ReturnType<typeof vi.fn>;
+		mockSave.mockClear();
+		const user = userEvent.setup();
+		await renderProjectSettings(mockProject, { env: { GOOD: "ok", MULTI: "a\nb" } });
+		await goToProjectTab();
+
+		expect(screen.getByLabelText("Environment Variables")).toHaveValue("GOOD=ok");
+		expect(screen.getByText("Values with line breaks cannot be edited here.")).toBeInTheDocument();
+		expect(screen.getByText("MULTI")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Remove MULTI" }));
+		const save = screen.getByText("Save");
+		expect(save).toBeEnabled();
+		await user.click(save);
+
+		await vi.waitFor(() => {
+			expect(mockSave).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: "proj-1", env: { GOOD: "ok" } }),
+			);
+		});
+	});
+
+	it("shows the env editor and round-trips text into config.env on save", async () => {
+		const { api } = await import("../../rpc");
+		const mockSave = api.request.updateProjectSettings as ReturnType<typeof vi.fn>;
+		mockSave.mockClear();
+
+		const user = userEvent.setup();
+		await renderProjectSettings();
+		await goToProjectTab();
+
+		const textarea = screen.getByLabelText("Environment Variables");
+		await user.type(textarea, "FOO=bar{Enter}BAZ=qux");
+		await user.click(screen.getByText("Save"));
+
+		await vi.waitFor(() => {
+			expect(mockSave).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: "proj-1", env: { FOO: "bar", BAZ: "qux" } }),
+			);
+		});
+	});
+
+	it("shows an inline error and disables Save for an invalid line", async () => {
+		const { api } = await import("../../rpc");
+		const mockSave = api.request.updateProjectSettings as ReturnType<typeof vi.fn>;
+		mockSave.mockClear();
+
+		const user = userEvent.setup();
+		await renderProjectSettings();
+		await goToProjectTab();
+
+		const textarea = screen.getByLabelText("Environment Variables");
+		await user.type(textarea, "FOO=bar{Enter}not a var");
+
+		expect(screen.getByText(/Invalid lines: 2/)).toBeInTheDocument();
+		expect(screen.getByText("Save")).toBeDisabled();
+		expect(mockSave).not.toHaveBeenCalled();
+	});
+
+	it("clearing the textarea saves an empty env object (removal persists)", async () => {
+		const { api } = await import("../../rpc");
+		const mockSave = api.request.updateProjectSettings as ReturnType<typeof vi.fn>;
+		mockSave.mockClear();
+
+		const user = userEvent.setup();
+		await renderProjectSettings(mockProject, { env: { FOO: "bar" } });
+		await goToProjectTab();
+
+		const textarea = screen.getByLabelText("Environment Variables");
+		expect(textarea).toHaveValue("FOO=bar");
+		await user.clear(textarea);
+		await user.click(screen.getByText("Save"));
+
+		await vi.waitFor(() => {
+			expect(mockSave).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: "proj-1", env: {} }),
+			);
+		});
+	});
+});

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -225,6 +225,22 @@ const settings = {
 	"projectSettings.cleanupScript": "Cleanup Script",
 	"projectSettings.cleanupScriptDesc":
 		"Runs before the worktree is removed — when a task is marked Completed or Cancelled, an active task is deleted, or its preparation is cancelled",
+	"projectSettings.envVars": "Environment Variables",
+	"projectSettings.envVarsDesc":
+		"KEY=value per line, # for comments. Exported into every agent terminal, setup/dev/cleanup script, and column agent for this project's tasks. Applies on next launch.",
+	"projectSettings.envVarsPlaceholder": "API_URL=https://api.example.com\n# FEATURE_FLAG=enabled",
+	"projectSettings.envVarsProjectNotice":
+		"Stored in dev3's local project settings. These values are never written to the repository.",
+	"projectSettings.envVarsRepoWarning":
+		"Do not store secrets here. Save writes these values to .dev3/config.json and commits the file immediately to this branch.",
+	"projectSettings.envVarsLocalNotice":
+		"Stored in .dev3/config.local.json. This gitignored file is never committed to the repository.",
+	"projectSettings.envVarsInvalidLines": "Invalid lines: {lines}",
+	"projectSettings.envVarsLineBreakTitle": "Values with line breaks cannot be edited here.",
+	"projectSettings.envVarsLineBreakDesc":
+		"Remove each listed key to continue saving, or edit its JSON source directly.",
+	"projectSettings.envVarsRemoveLineBreak": "Remove",
+	"projectSettings.envVarsRemoveLineBreakAria": "Remove {key}",
 	"projectSettings.clonePaths": "Clone Paths (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Directories and files to clone from the root project into each worktree using Copy-on-Write (instant, no disk space duplication on APFS/btrfs). Falls back to regular copy on unsupported filesystems.",
 	"projectSettings.addClonePath": "Add Path",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -225,6 +225,22 @@ const settings = {
 	"projectSettings.cleanupScript": "Script de limpieza",
 	"projectSettings.cleanupScriptDesc":
 		"Se ejecuta antes de eliminar el worktree — cuando una tarea se marca como Completed o Cancelled, se elimina una tarea activa o se cancela su preparación",
+	"projectSettings.envVars": "Variables de entorno",
+	"projectSettings.envVarsDesc":
+		"KEY=value por línea, # para comentarios. Se exportan a cada terminal de agente, scripts de setup/dev/cleanup y agentes de columna de las tareas de este proyecto. Se aplican en el próximo lanzamiento.",
+	"projectSettings.envVarsPlaceholder": "API_URL=https://api.example.com\n# FEATURE_FLAG=enabled",
+	"projectSettings.envVarsProjectNotice":
+		"Se guardan en la configuración local del proyecto de dev3. Estos valores nunca se escriben en el repositorio.",
+	"projectSettings.envVarsRepoWarning":
+		"No guardes secretos aquí. Guardar escribe estos valores en .dev3/config.json y confirma el archivo inmediatamente en esta rama.",
+	"projectSettings.envVarsLocalNotice":
+		"Se guardan en .dev3/config.local.json. Este archivo ignorado por git nunca se confirma en el repositorio.",
+	"projectSettings.envVarsInvalidLines": "Líneas inválidas: {lines}",
+	"projectSettings.envVarsLineBreakTitle": "Los valores con saltos de línea no se pueden editar aquí.",
+	"projectSettings.envVarsLineBreakDesc":
+		"Elimina cada clave de la lista para poder guardar o edita directamente su origen JSON.",
+	"projectSettings.envVarsRemoveLineBreak": "Eliminar",
+	"projectSettings.envVarsRemoveLineBreakAria": "Eliminar {key}",
 	"projectSettings.clonePaths": "Rutas de clonación (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Directorios y archivos que se clonan del proyecto raíz a cada worktree usando Copy-on-Write (instantáneo, sin duplicar espacio en APFS/btrfs). En sistemas de archivos no compatibles se hace una copia normal.",
 	"projectSettings.addClonePath": "Agregar ruta",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -225,6 +225,22 @@ const settings = {
 	"projectSettings.cleanupScript": "Скрипт очистки",
 	"projectSettings.cleanupScriptDesc":
 		"Запускается перед удалением worktree — когда задача помечена как Completed или Cancelled, активная задача удалена или её подготовка отменена",
+	"projectSettings.envVars": "Переменные окружения",
+	"projectSettings.envVarsDesc":
+		"KEY=value на строку, # — комментарий. Экспортируются в каждый терминал агента, setup/dev/cleanup-скрипты и колоночных агентов задач этого проекта. Применяются при следующем запуске.",
+	"projectSettings.envVarsPlaceholder": "API_URL=https://api.example.com\n# FEATURE_FLAG=enabled",
+	"projectSettings.envVarsProjectNotice":
+		"Хранятся в локальных настройках проекта dev3. Эти значения никогда не записываются в репозиторий.",
+	"projectSettings.envVarsRepoWarning":
+		"Не храните здесь секреты. При сохранении значения записываются в .dev3/config.json, а файл сразу коммитится в эту ветку.",
+	"projectSettings.envVarsLocalNotice":
+		"Хранятся в .dev3/config.local.json. Этот игнорируемый git файл никогда не коммитится в репозиторий.",
+	"projectSettings.envVarsInvalidLines": "Некорректные строки: {lines}",
+	"projectSettings.envVarsLineBreakTitle": "Значения с переносами строк нельзя редактировать здесь.",
+	"projectSettings.envVarsLineBreakDesc":
+		"Удалите каждую указанную переменную, чтобы продолжить сохранение, или отредактируйте её JSON-источник напрямую.",
+	"projectSettings.envVarsRemoveLineBreak": "Удалить",
+	"projectSettings.envVarsRemoveLineBreakAria": "Удалить {key}",
 	"projectSettings.clonePaths": "Clone-пути (Copy-on-Write)",
 	"projectSettings.clonePathsDesc": "Директории и файлы, которые клонируются из корневого проекта в каждый worktree через Copy-on-Write (мгновенно, без дублирования на APFS/btrfs). На неподдерживаемых ФС делается обычная копия.",
 	"projectSettings.addClonePath": "Добавить путь",

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -68,6 +68,7 @@ html {
 	--accent-hover: 28 119 241;    /* accent fills: deeper, keeps white ink readable */
 	--accent-emphasis: 137 190 255; /* accent text/icons on hover: lifts on dark */
 	--danger: 255 137 135;
+	--danger-strong: 255 137 135; /* danger ink on a danger-tinted fill */
 	--success: 63 223 126;
 	--success-hover: 4 190 88;
 	--warning: 240 210 78;
@@ -161,6 +162,7 @@ html {
 	--accent-hover: 8 93 199;
 	--accent-emphasis: 5 84 181;
 	--danger: 214 17 51;
+	--danger-strong: 159 18 57; /* --danger on a danger/10 fill is only 4.28:1 */
 	--success: 14 138 71;
 	--success-hover: 10 114 57;
 	--warning: 145 118 13;

--- a/src/shared/env-text.ts
+++ b/src/shared/env-text.ts
@@ -1,0 +1,75 @@
+/** Dotenv-style text <-> env map for per-project env vars. Values are taken
+ *  verbatim after the first `=` — no quoting rules, no interpolation (v1). */
+
+export const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const LINE_RE = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+export function hasEnvLineBreak(value: string): boolean {
+	return value.includes("\n") || value.includes("\r");
+}
+
+export interface EnvParseError {
+	line: number;
+	text: string;
+}
+
+export function parseEnvText(text: string): { env: Record<string, string>; errors: EnvParseError[] } {
+	const env: Record<string, string> = {};
+	const errors: EnvParseError[] = [];
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const raw = lines[i].endsWith("\r") ? lines[i].slice(0, -1) : lines[i];
+		if (raw.trim() === "" || raw.trim().startsWith("#")) continue;
+		const match = LINE_RE.exec(raw);
+		if (!match) {
+			errors.push({ line: i + 1, text: raw });
+			continue;
+		}
+		env[match[1]] = match[2];
+	}
+	return { env, errors };
+}
+
+export function serializeEnvText(env: Record<string, string>): string {
+	return Object.entries(env)
+		.map(([key, value]) => `${key}=${value}`)
+		.join("\n");
+}
+
+/** Best-effort cleanup for env maps read from JSON config files on disk:
+ *  never throws, drops anything malformed, optionally reports each drop. */
+export function sanitizeEnvMap(val: unknown, warn?: (msg: string) => void): Record<string, string> {
+	if (val === null || typeof val !== "object" || Array.isArray(val)) {
+		if (val !== undefined && val !== null) warn?.("Ignoring env config: not an object");
+		return {};
+	}
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(val as Record<string, unknown>)) {
+		if (!ENV_KEY_RE.test(key)) {
+			warn?.(`Ignoring env var with invalid name: ${key}`);
+			continue;
+		}
+		if (typeof value !== "string") {
+			warn?.(`Ignoring env var with non-string value: ${key}`);
+			continue;
+		}
+		out[key] = value;
+	}
+	return out;
+}
+
+/** Strict validation for env maps arriving via RPC save handlers. */
+export function validateEnvMap(val: unknown): string[] {
+	if (val === undefined) return [];
+	if (val === null || typeof val !== "object" || Array.isArray(val)) {
+		return ["env must be an object of string values"];
+	}
+	const problems: string[] = [];
+	for (const [key, value] of Object.entries(val as Record<string, unknown>)) {
+		if (!ENV_KEY_RE.test(key)) problems.push(`invalid env var name: ${key}`);
+		else if (typeof value !== "string") problems.push(`env var ${key} must be a string`);
+		else if (hasEnvLineBreak(value)) problems.push(`env var ${key} must not contain line breaks`);
+	}
+	return problems;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -998,6 +998,9 @@ export interface Dev3RepoConfig {
 	builtinColumnAgents?: Record<string, ColumnAgentConfig>;
 	/** Number of ports to allocate per task/worktree (injected as DEV3_PORT0..N). Default: 0. */
 	portCount?: number;
+	/** Env vars exported into every task session (agent terminals, setup/dev/cleanup
+	 *  scripts, column agents). Merged PER KEY across config layers (decision 179). */
+	env?: Record<string, string>;
 }
 
 /** Keys of Dev3RepoConfig â used for merge logic. */
@@ -1016,6 +1019,7 @@ export const DEV3_REPO_CONFIG_KEYS: (keyof Dev3RepoConfig)[] = [
 	"sparseCheckoutPaths",
 	"builtinColumnAgents",
 	"portCount",
+	"env",
 ];
 
 export type ConfigSource = "repo" | "local";
@@ -1058,6 +1062,7 @@ export interface Project {
 	githubAuthHost?: string | null;
 	githubAuthLogin?: string | null;
 	clonePaths?: string[];
+	env?: Record<string, string>;
 	createdAt: string;
 	deleted?: boolean;
 	labels?: Label[];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,7 @@ export default {
 					emphasis: "rgb(var(--accent-emphasis) / <alpha-value>)",
 				},
 				danger: "rgb(var(--danger) / <alpha-value>)",
+				"danger-strong": "rgb(var(--danger-strong) / <alpha-value>)",
 				warning: "rgb(var(--warning) / <alpha-value>)",
 				favorite: "rgb(var(--favorite) / <alpha-value>)",
 				awake: {


### PR DESCRIPTION
## What

Adds a per-project environment-variables map that is exported into every task-scoped session: agent terminals, setup/dev/cleanup scripts, column agents, and spawned agent panes (both tmux and native backends).

## How

- New `env: Record<string,string>` field on `Dev3RepoConfig`/`Project`, riding the existing config cascade — editable in Project Settings, shareable via `.dev3/config.json`, and overridable in the gitignored `.dev3/config.local.json` for secrets.
- Unlike other config fields, `env` merges **per key** across cascade layers (worktree local > worktree repo > main local > main repo > projects.json), so a repo file setting one var can't erase UI/local vars. See `decisions/179-per-key-env-config-merge.md`.
- `resolveProjectEnv()` re-reads config at launch time; injected at the lowest precedence so `DEV3_*` lifecycle vars and per-agent-config `envVars` always win.
- Project Settings gains an "Environment Variables" dotenv-style textarea (KEY=value, `#` comments) with inline validation that blocks saving on invalid lines; server-side validation guards the three save handlers. `dev3 config show` prints env key names only (values may be secrets).

## Testing

- Unit: dotenv parse/serialize/sanitize/validate round-trips; per-key cascade merge with real config files; editor save/clear/error-state renderer tests.
- Full suite green (`bun run test`) + `bun run lint`; manual browser QA of the editor on the Project Config and Worktree Config tabs, including error state, save-to-file, and clearing a previously saved value.