### PR TITLE
Fix diff comment caret jumps

### DIFF
--- a/change-logs/2026/07/28/fix-diff-comment-caret.md
+++ b/change-logs/2026/07/28/fix-diff-comment-caret.md
@@ -1,0 +1,5 @@
+Short: Stable diff comment editing
+
+Fixed inline diff comment editing so typing in the middle of existing text no longer moves the caret to the end after the first character.
+
+Suggested by @yakirn (h0x91b/dev-3.0#1152)

--- a/decisions/172-local-diff-comment-editor-state.md
+++ b/decisions/172-local-diff-comment-editor-state.md
@@ -1,0 +1,21 @@
+# 172 — Keep inline diff comment drafts inside the slot
+
+## Context
+
+Inline diff comments render through `@git-diff-view/react` extended-line slots. The editor previously lifted its controlled draft into `TaskDiffViewer`, above that slot boundary.
+
+## Investigation
+
+The library publishes a changed `renderExtendLine` callback through an effect-backed external store. Every keystroke therefore caused a delayed controlled-value write after the browser inserted the first character, which collapsed the selection to the end.
+
+## Decision
+
+`InlineCommentThreadView` owns the active draft while `TaskDiffViewer` retains only the globally active comment ID. The diff-view mock mirrors the library's effect-delayed slot update so the caret regression test exercises this timing boundary.
+
+## Risks
+
+Each mounted thread can retain an inactive local draft until it unmounts. Entering edit mode always initializes that draft from the latest saved comment body, so stale hidden state cannot reach Save.
+
+## Alternatives considered
+
+Capturing and restoring the selection after every controlled update was rejected because it is fragile around IME composition and browser selection timing. Stabilizing the slot callback through shared context was rejected because it expands the state boundary and still couples text input to the library's external renderer.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -224,9 +224,7 @@ interface TaskDiffFileSectionProps {
 		body: string;
 	}) => void;
 	editingCommentId: string | null;
-	editingCommentDraft: string;
-	onEditDraftChange: (value: string) => void;
-	onStartEditComment: (commentId: string, body: string) => void;
+	onStartEditComment: (commentId: string) => void;
 	onCancelEditComment: () => void;
 	onSaveEditComment: (commentId: string, body: string) => void;
 	onDeleteComment: (commentId: string) => void;
@@ -604,8 +602,6 @@ function InlineCommentThreadView({
 	lineNumber,
 	registerCommentRef,
 	editingCommentId,
-	editingCommentDraft,
-	onEditDraftChange,
 	onStartEdit,
 	onCancelEdit,
 	onSaveEdit,
@@ -616,9 +612,7 @@ function InlineCommentThreadView({
 	lineNumber: number;
 	registerCommentRef: (commentId: string, element: HTMLDivElement | null) => void;
 	editingCommentId: string | null;
-	editingCommentDraft: string;
-	onEditDraftChange: (value: string) => void;
-	onStartEdit: (commentId: string, body: string) => void;
+	onStartEdit: (commentId: string) => void;
 	onCancelEdit: () => void;
 	onSaveEdit: (commentId: string, body: string) => void;
 	onDeleteComment: (commentId: string) => void;
@@ -626,6 +620,7 @@ function InlineCommentThreadView({
 	const t = useT();
 	const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const focusedEditCommentIdRef = useRef<string | null>(null);
+	const [editingCommentDraft, setEditingCommentDraft] = useState("");
 
 	useEffect(() => {
 		if (!editingCommentId) {
@@ -670,7 +665,7 @@ function InlineCommentThreadView({
 							<textarea
 								ref={editTextareaRef}
 								value={editingCommentDraft}
-								onChange={(event) => onEditDraftChange(event.target.value)}
+								onChange={(event) => setEditingCommentDraft(event.target.value)}
 								rows={3}
 								className="dev3-inline-comment__textarea w-full resize-y rounded-lg border border-edge bg-base px-3 py-2 text-sm text-fg outline-none transition-colors placeholder:text-fg-muted focus:border-edge-active focus:bg-elevated"
 							/>
@@ -701,7 +696,10 @@ function InlineCommentThreadView({
 							<div className="flex shrink-0 items-center gap-1">
 								<button
 									type="button"
-									onClick={() => onStartEdit(comment.id, comment.body)}
+									onClick={() => {
+										setEditingCommentDraft(comment.body);
+										onStartEdit(comment.id);
+									}}
 									aria-label={t("infoPanel.diffReviewEdit")}
 									className="inline-flex h-7 items-center justify-center rounded-md border border-edge bg-base px-2 text-[0.6875rem] font-semibold text-fg-2 transition-colors hover:bg-elevated-hover"
 								>
@@ -1154,8 +1152,6 @@ function TaskDiffFileSection({
 	isRead,
 	onAddComment,
 	editingCommentId,
-	editingCommentDraft,
-	onEditDraftChange,
 	onStartEditComment,
 	onCancelEditComment,
 	onSaveEditComment,
@@ -1696,8 +1692,6 @@ function TaskDiffFileSection({
 										lineNumber={lineNumber}
 										registerCommentRef={registerCommentRef}
 										editingCommentId={editingCommentId}
-										editingCommentDraft={editingCommentDraft}
-										onEditDraftChange={onEditDraftChange}
 										onStartEdit={onStartEditComment}
 										onCancelEdit={onCancelEditComment}
 										onSaveEdit={onSaveEditComment}
@@ -1774,7 +1768,6 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 	const [copiedReviewXml, setCopiedReviewXml] = useState(false);
 	const [reviewSendState, setReviewSendState] = useState<"sending" | "sent" | undefined>();
 	const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
-	const [editingCommentDraft, setEditingCommentDraft] = useState("");
 	// GitHub PR review layer (read-only). Fetched once per diff open when the
 	// task carries a sticky PR; the refresh button re-fetches with force. The
 	// export selection and send states are deliberately session-local — unlike
@@ -2149,7 +2142,6 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 			setActiveFileId(null);
 			setInlineComments({});
 			setEditingCommentId(null);
-			setEditingCommentDraft("");
 			return;
 		}
 
@@ -2173,7 +2165,6 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		// must survive diff reloads (e.g. a refresh after the agent edits files).
 		setInlineComments(readStoredReview(task.id));
 		setEditingCommentId(null);
-		setEditingCommentDraft("");
 	}, [currentRequest.focusFile, payload, task.id]);
 
 	// Scroll spy: as the user scrolls the diff, highlight the file whose section is currently
@@ -2359,7 +2350,6 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 				}
 				setInlineComments({});
 				setEditingCommentId(null);
-				setEditingCommentDraft("");
 			})
 			.catch(() => {});
 	}
@@ -2653,15 +2643,13 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		activateSearchMatch(activeSearchIndex + direction);
 	}
 
-	function startEditingComment(commentId: string, body: string) {
+	function startEditingComment(commentId: string) {
 		setEditingCommentId(commentId);
-		setEditingCommentDraft(body);
 		setCopiedReviewXml(false);
 	}
 
 	function cancelEditingComment() {
 		setEditingCommentId(null);
-		setEditingCommentDraft("");
 	}
 
 	function updateInlineComment(commentId: string, body: string) {
@@ -3791,8 +3779,6 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 								isRead={readFiles[file.id] ?? false}
 								onAddComment={addInlineComment}
 								editingCommentId={editingCommentId}
-								editingCommentDraft={editingCommentDraft}
-								onEditDraftChange={setEditingCommentDraft}
 								onStartEditComment={startEditingComment}
 								onCancelEditComment={cancelEditingComment}
 								onSaveEditComment={updateInlineComment}

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -57,6 +57,16 @@ vi.mock("@git-diff-view/react", async () => {
 		}) => {
 			const [widget, setWidget] = React.useState<{ lineNumber: number; side: number } | null>(null);
 			const [nextWidgetLineNumber, setNextWidgetLineNumber] = React.useState(1);
+			const [storedRenderExtendLine, setStoredRenderExtendLine] = React.useState<typeof renderExtendLine>(
+				() => renderExtendLine,
+			);
+
+			// The real library publishes a new slot renderer from an effect. Keeping
+			// that delay here catches controlled inputs whose caret gets reset when
+			// the external slot store applies the next value.
+			React.useEffect(() => {
+				setStoredRenderExtendLine(() => renderExtendLine);
+			}, [renderExtendLine]);
 
 			// Mirror the library's onCreateUseWidgetHook so production code can open
 			// the composer programmatically (used by drag-to-select range commenting).
@@ -146,7 +156,7 @@ vi.mock("@git-diff-view/react", async () => {
 						{threadEntries.map((entry) => (
 							<React.Fragment key={entry.key}>
 								<div data-testid="mock-extend">
-									{renderExtendLine?.({
+									{storedRenderExtendLine?.({
 										diffFile: {},
 										side: entry.side,
 										lineNumber: entry.lineNumber,
@@ -156,7 +166,7 @@ vi.mock("@git-diff-view/react", async () => {
 								</div>
 								{diffViewMode === 3 && (
 									<div data-testid="mock-empty-extend-counterpart">
-										{renderExtendLine?.({
+										{storedRenderExtendLine?.({
 											diffFile: {},
 											side: entry.side === SplitSide.old ? SplitSide.new : SplitSide.old,
 											lineNumber: entry.lineNumber,


### PR DESCRIPTION
## Summary

- keep each inline diff comment draft inside its extended-line editor while the viewer retains only the active comment ID
- model `@git-diff-view/react`'s effect-delayed slot renderer in the regression test
- document the state-boundary decision and credit the original issue reporter in the changelog

## Root cause

`@git-diff-view/react` publishes a changed `renderExtendLine` callback through an effect-backed external store. Lifting the controlled textarea value above that boundary caused a delayed value write after the browser inserted the first character, which moved the caret to the end. The timing is renderer-dependent rather than Linux-specific.

## User impact

Typing in the middle of an existing inline diff comment now preserves both the insertion point and the expected text order.

## Validation

- `bunx vitest run src/mainview/components/__tests__/TaskDiffViewer.test.tsx` — 80 tests passed
- `bun run lint` — no TypeScript errors
- manual Chromium QA against the packaged dev build and real diff library: inserting `XY` at offset 3 changed `abcdef` to `abcXYdef` and left the caret at offset 5

Fixes #1152
