### PR TITLE
Show human approval on Kanban task cards

### DIFF
--- a/change-logs/2026/07/27/feature-approved-review-badge.md
+++ b/change-logs/2026/07/27/feature-approved-review-badge.md
@@ -1,0 +1,3 @@
+Short: Human approval badge
+
+Show a compact green person-check badge on Kanban task cards when a pull request has a human approval, independently of mergeability.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -489,8 +489,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			</TaskPrStatusPopover>
 		);
 	})() : null;
-	const REVIEW_BADGE: Record<NonNullable<TaskPRBadgeInfo["reviewState"]>, { glyph: string; cls: string; key: TranslationKey }> = {
-		approved: { glyph: "", cls: "text-success bg-success/10 hover:bg-success/20", key: "task.review.approved" },
+	const REVIEW_BADGE: Record<NonNullable<TaskPRBadgeInfo["reviewState"]>, { glyph: string | null; square?: boolean; cls: string; key: TranslationKey }> = {
+		approved: { glyph: null, square: true, cls: "text-success bg-success/10 hover:bg-success/20", key: "task.review.approved" },
 		changes_requested: { glyph: "", cls: "text-danger bg-danger/10 hover:bg-danger/20", key: "task.review.changesRequested" },
 		commented: { glyph: "", cls: "text-warning bg-warning/10 hover:bg-warning/20", key: "task.review.commented" },
 	};
@@ -503,10 +503,27 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					e.stopPropagation();
 					window.open(prInfo!.url, "_blank");
 				}}
-				className={`inline-flex h-5 flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[0.625rem] font-semibold leading-none transition-colors ${reviewMeta.cls}`}
+				className={`inline-flex flex-shrink-0 items-center rounded font-mono text-[0.625rem] font-semibold leading-none transition-colors ${reviewMeta.square ? "h-5 w-5 justify-center p-0" : "h-5 gap-1 px-1.5 py-0.5"} ${reviewMeta.cls}`}
 				aria-label={t(reviewMeta.key)}
 			>
-				<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{reviewMeta.glyph}</span>
+				{reviewMeta.glyph === null ? (
+					<svg
+						className="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<circle cx="8.5" cy="7.5" r="3" />
+						<path d="M3.5 19c.4-3.2 2.1-5 5-5s4.6 1.8 5 5" />
+						<path d="m15 17 2 2 4-5" />
+					</svg>
+				) : (
+					<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{reviewMeta.glyph}</span>
+				)}
 			</button>
 		</TaskPrStatusPopover>
 	) : null;

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -1601,7 +1601,23 @@ describe("TaskCard", () => {
 			renderCard(reviewTask(), {
 				prInfo: { number: 12, url: "https://example/pr/12", ciStatus: null, reviewState: "approved" },
 			});
+			const badge = screen.getByLabelText(/PR approved/);
+			expect(badge).toHaveClass("h-5", "w-5", "justify-center", "p-0");
+			expect(badge.querySelector("svg")).toBeInTheDocument();
+		});
+
+		it("keeps the approval badge visible when the PR is not mergeable", () => {
+			renderCard(reviewTask(), {
+				prInfo: {
+					number: 12,
+					url: "https://example/pr/12",
+					ciStatus: null,
+					reviewState: "approved",
+					mergeState: { mergeable: "CONFLICTING", status: "DIRTY" },
+				},
+			});
 			expect(screen.getByLabelText(/PR approved/)).toBeInTheDocument();
+			expect(screen.getByLabelText(/not mergeable/i)).toBeInTheDocument();
 		});
 
 		it("clicking a badge opens the pull request", async () => {


### PR DESCRIPTION
## Summary

- Replace the approved review badge glyph with a compact green person-check icon.
- Keep human approval independent from PR mergeability, so both approved and not-mergeable states can appear together.
- Add component coverage for the icon shape and the approved-plus-conflicts case.

## Verification

- `bun run lint`
- `bun run test`
- Browser QA in streamer mode: Kanban loaded without console errors.