### PR TITLE
Make task relaunch tolerate a surviving worktree and branch

### DIFF
--- a/change-logs/2026/07/29/fix-relaunch-task-on-existing-branch.md
+++ b/change-logs/2026/07/29/fix-relaunch-task-on-existing-branch.md
@@ -1,0 +1,3 @@
+Short: Re-run tasks on an existing branch
+
+Fixed a task launched on an existing or remote branch (for example a code-review task on `origin/<branch>`) becoming impossible to start again after it was moved back to To Do: the leftover worktree directory made `git worktree add` fail and the retry died with "a branch named X already exists". The worktree path is now reclaimed on every launch path, and a surviving local or variant branch is checked out instead of recreated, so its commits are kept.

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -432,6 +432,53 @@ describe("createWorktree", () => {
 		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
 	});
 
+	it("re-runs a task on a remote branch whose worktree and local branch survived", async () => {
+		// Regression: a task launched on origin/<branch> that is moved back to To Do
+		// keeps its worktree and local branch. Re-running it hit "'<path>' already
+		// exists", retried with `--track -b`, and died on "a branch named X already
+		// exists" — the task could never be launched again.
+		g("git checkout -b verif/evidence", repo.local);
+		makeTaskCommits(repo.local);
+		g("git push origin verif/evidence", repo.local);
+		g("git checkout main", repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const first = await createWorktree(project, task, "origin/verif/evidence");
+		expect(first.branchName).toBe("verif/evidence");
+
+		// Move back to To Do leaves the worktree and the branch behind, so the
+		// second launch starts from exactly that state.
+		const second = await createWorktree(project, task, "origin/verif/evidence");
+
+		expect(existsSync(second.worktreePath)).toBe(true);
+		expect(second.branchName).toBe("verif/evidence");
+		expect(second.worktreePath).toBe(first.worktreePath);
+
+		g(`git worktree remove --force "${second.worktreePath}"`, repo.local);
+	});
+
+	it("re-runs a variant task whose worktree and variant branch survived", async () => {
+		g("git checkout -b feature/base", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+
+		const project = makeProject(repo.local);
+		const task = makeTask();
+
+		const first = await createWorktree(project, task, "feature/base", "feature/base-v1");
+		expect(first.branchName).toBe("feature/base-v1");
+
+		const second = await createWorktree(project, task, "feature/base", "feature/base-v1");
+
+		expect(existsSync(second.worktreePath)).toBe(true);
+		expect(second.branchName).toBe("feature/base-v1");
+
+		g(`git worktree remove --force "${second.worktreePath}"`, repo.local);
+		g("git branch -D feature/base-v1", repo.local);
+	});
+
 	it("creates default task branch when no existing branch specified", async () => {
 		const project = makeProject(repo.local);
 		const task = makeTask();

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -941,6 +941,26 @@ function branchName(task: Task): string {
 	return `dev3/task-${shortId(task.id)}`;
 }
 
+async function localBranchExists(projectPath: string, branch: string): Promise<boolean> {
+	return (await run(["git", "rev-parse", "--verify", `refs/heads/${branch}`], projectPath)).ok;
+}
+
+/**
+ * Free the task's own worktree directory before `git worktree add`. The path is
+ * derived from task.id, so dev3 owns it: a leftover means a prior failed cleanup
+ * or a re-run after the task was moved back to To Do. Stderr-driven retries do
+ * not work here — a failed add still creates the directory as a side effect.
+ */
+async function reclaimStaleWorktreeDir(project: Project, wtPath: string): Promise<void> {
+	if (!existsSync(wtPath)) return;
+	log.warn("Reclaiming leftover worktree directory", { wtPath, projectPath: project.path });
+	await run(["git", "worktree", "remove", "--force", wtPath], project.path);
+	if (existsSync(wtPath)) {
+		rmSync(wtPath, { recursive: true, force: true });
+	}
+	await run(["git", "worktree", "prune"], project.path);
+}
+
 export async function createWorktree(
 	project: Project,
 	task: Task,
@@ -958,18 +978,22 @@ export async function createWorktree(
 
 	if (existingBranch && variantBranchName) {
 		// Multi-variant mode: create a new branch from the existing branch's HEAD
-		const resolvedBase = existingBranch.startsWith("origin/") ? existingBranch : existingBranch;
+		const resolvedBase = existingBranch;
 		log.info("Creating variant worktree from existing branch", {
 			wtPath, variantBranchName, base: resolvedBase, taskId: task.id,
 		});
 
+		await reclaimStaleWorktreeDir(project, wtPath);
+		// A leftover variant branch (re-run of a task that kept its branch) is
+		// checked out instead of recreated, so its commits survive the re-run.
+		const variantAddArgs = await localBranchExists(project.path, variantBranchName)
+			? ["git", "worktree", "add", wtPath, variantBranchName]
+			: ["git", "worktree", "add", "-b", variantBranchName, wtPath, resolvedBase];
+
 		const result = await measureGitStep(
 			"createWorktree.variant.worktreeAdd",
 			{ taskId: task.id.slice(0, 8), wtPath, variantBranchName, base: resolvedBase },
-			() => run(
-				["git", "worktree", "add", "-b", variantBranchName, wtPath, resolvedBase],
-				project.path,
-			),
+			() => run(variantAddArgs, project.path),
 		);
 
 		if (!result.ok) {
@@ -1001,6 +1025,8 @@ export async function createWorktree(
 			wtPath, existingBranch, resolvedBranch, isRemoteRef, taskId: task.id,
 		});
 
+		await reclaimStaleWorktreeDir(project, wtPath);
+
 		const result = await measureGitStep(
 			"createWorktree.existing.worktreeAdd",
 			{ taskId: task.id.slice(0, 8), wtPath, resolvedBranch, isRemoteRef },
@@ -1012,8 +1038,13 @@ export async function createWorktree(
 
 		if (!result.ok) {
 			const isAlreadyCheckedOut = result.stderr.includes("already checked out") || result.stderr.includes("already used by worktree");
+			// `--track -b` only helps when the local branch is still missing. With the
+			// branch already on disk it fails with a misleading "a branch named X
+			// already exists" that hides the real reason the first add failed.
+			const localBranchMissing = isRemoteRef
+				&& !(await localBranchExists(project.path, resolvedBranch));
 
-			if (isRemoteRef && !isAlreadyCheckedOut) {
+			if (isRemoteRef && localBranchMissing && !isAlreadyCheckedOut) {
 				// Remote branch without a local tracking branch yet — create one
 				log.info("Retrying with tracking branch creation", { existingBranch });
 				const trackResult = await measureGitStep(
@@ -1127,41 +1158,13 @@ export async function createWorktree(
 
 	log.info("Creating worktree", { wtPath, branch, baseBranch, resolvedBase, taskId: task.id, taskDir: tDir });
 
-	// Proactively reclaim stale leftovers from a prior failed cleanup before
-	// invoking `git worktree add`. Stderr-driven retries don't work here: the
-	// first attempt creates the worktree directory as a side effect even when
-	// it fails on the branch check, so a second attempt then trips on
-	// "directory already exists". The branch and the worktree path are both
-	// owned by dev3 (derived from task.id), so reclaiming them is safe.
-	const dirExistsBeforeAdd = existsSync(wtPath);
-	const branchExistsBeforeAdd = (await run(
-		["git", "rev-parse", "--verify", `refs/heads/${branch}`],
-		project.path,
-	)).ok;
-
-	if (dirExistsBeforeAdd || branchExistsBeforeAdd) {
-		log.warn("Found stale leftovers from prior failed cleanup, reclaiming", {
-			taskId: task.id.slice(0, 8),
-			wtPath,
-			branch,
-			dirExists: dirExistsBeforeAdd,
-			branchExists: branchExistsBeforeAdd,
-		});
-
-		if (dirExistsBeforeAdd) {
-			// Try `git worktree remove` first (handles the case where the path
-			// is still registered as a worktree); fall back to plain rmSync if
-			// the directory remains.
-			await run(["git", "worktree", "remove", "--force", wtPath], project.path);
-			if (existsSync(wtPath)) {
-				rmSync(wtPath, { recursive: true, force: true });
-			}
-			await run(["git", "worktree", "prune"], project.path);
-		}
-
-		if (branchExistsBeforeAdd) {
-			await run(["git", "branch", "-D", branch], project.path);
-		}
+	// Reclaim stale leftovers from a prior failed cleanup before `git worktree
+	// add`. Both the path and the `dev3/task-*` branch are derived from task.id,
+	// so dev3 owns them and recreating them from the base branch is safe.
+	await reclaimStaleWorktreeDir(project, wtPath);
+	if (await localBranchExists(project.path, branch)) {
+		log.warn("Reclaiming leftover task branch", { taskId: task.id.slice(0, 8), branch });
+		await run(["git", "branch", "-D", branch], project.path);
 	}
 
 	const result = await measureGitStep(


### PR DESCRIPTION
A task launched on an existing or remote branch (e.g. a code-review task on `origin/<branch>`) could never be started again once it was moved back to To Do.

Moving an active task to To Do is a plain column change — no teardown — so the worktree directory and the local branch survive on purpose. The relaunch then failed in `createWorktree`: the `existingBranch` and variant paths had none of the stale-leftover reclaim the default `dev3/task-*` path already did, so `git worktree add` died on `'<path>' already exists`. The remote-ref retry ran `git worktree add --track -b <branch>` unconditionally and reported `a branch named X already exists`, hiding the real cause.

- Reclaim the task's own worktree directory on all three `createWorktree` paths (the path is derived from `task.id`, so dev3 owns it).
- Only retry with `--track -b` when `refs/heads/<branch>` is genuinely missing.
- Check out a surviving local or variant branch instead of recreating it, so its commits are kept; a branch dev3 did not create is still never deleted.

Two regression tests reproduce the original failure verbatim without the fix.