### PR TITLE
Fix artifact theme defaults and browser switching

### DIFF
--- a/change-logs/2026/07/28/fix-artifact-browser-theme-default.md
+++ b/change-logs/2026/07/28/fix-artifact-browser-theme-default.md
@@ -1,0 +1,1 @@
+HTML artifacts now open with the currently selected dev3 light or dark theme in desktop and browser mode. The artifact theme control still cycles through the opposite theme, host-following mode, and the selected theme.

--- a/src/mainview/components/TaskArtifactViewer.tsx
+++ b/src/mainview/components/TaskArtifactViewer.tsx
@@ -76,7 +76,7 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, onClose, t
 	const [error, setError] = useState(false);
 	const [fullscreen, setFullscreen] = useState(false);
 	const [downloading, setDownloading] = useState(false);
-	const [themeMode, setThemeMode] = useState<ArtifactThemeMode>("follow");
+	const [themeMode, setThemeMode] = useState<ArtifactThemeMode>(() => currentTheme());
 	const frameRef = useRef<HTMLIFrameElement>(null);
 	const viewerRef = useRef<HTMLElement>(null);
 	const assetsRef = useRef<ArtifactAsset[]>([]);
@@ -177,7 +177,10 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, onClose, t
 		? t("artifactViewer.themeFollow")
 		: themeMode === "light" ? t("artifactViewer.themeLight") : t("artifactViewer.themeDark");
 	const themeLabel = t("artifactViewer.themeMode", { mode: themeName });
-	const cycleTheme = () => setThemeMode((mode) => mode === "follow" ? "light" : mode === "light" ? "dark" : "follow");
+	const cycleTheme = () => setThemeMode((mode) => {
+		if (mode === "follow") return currentTheme();
+		return mode === currentTheme() ? (mode === "light" ? "dark" : "light") : "follow";
+	});
 	const themeIcon = themeMode === "follow" ? "◐" : themeMode === "light" ? "" : "";
 
 	return (

--- a/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
@@ -70,20 +70,29 @@ describe("TaskArtifactViewer", () => {
 		expect(onClose).toHaveBeenCalledOnce();
 	});
 
-	it("cycles artifact theme from dev3-following to light and dark overrides", async () => {
-		render(<I18nProvider><TaskArtifactViewer artifacts={[artifact("a")]} initialIndex={0} onClose={vi.fn()} /></I18nProvider>);
-		const frame = await screen.findByTitle("Artifact a") as HTMLIFrameElement;
-		const postMessage = vi.spyOn(frame.contentWindow!, "postMessage");
-		const theme = screen.getByTestId("artifact-viewer-theme");
-		expect(theme).toHaveAccessibleName("Artifact theme: Follow dev3");
-		await userEvent.click(theme);
-		expect(theme).toHaveAccessibleName("Artifact theme: Light");
-		await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ type: "dev3-artifact-theme", theme: "light" }, "*"));
-		await userEvent.click(theme);
-		expect(theme).toHaveAccessibleName("Artifact theme: Dark");
-		await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ type: "dev3-artifact-theme", theme: "dark" }, "*"));
-		await userEvent.click(theme);
-		expect(theme).toHaveAccessibleName("Artifact theme: Follow dev3");
+	it.each(["light", "dark"] as const)("starts in the current dev3 %s theme and keeps the override cycle", async (hostTheme) => {
+		const previousTheme = document.documentElement.dataset.theme;
+		document.documentElement.dataset.theme = hostTheme;
+		try {
+			render(<I18nProvider><TaskArtifactViewer artifacts={[artifact("a")]} initialIndex={0} onClose={vi.fn()} /></I18nProvider>);
+			const frame = await screen.findByTitle("Artifact a") as HTMLIFrameElement;
+			const postMessage = vi.spyOn(frame.contentWindow!, "postMessage");
+			const theme = screen.getByTestId("artifact-viewer-theme");
+			const nextTheme = hostTheme === "light" ? "dark" : "light";
+			expect(theme).toHaveAccessibleName(`Artifact theme: ${hostTheme === "light" ? "Light" : "Dark"}`);
+			fireEvent.load(frame);
+			await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ type: "dev3-artifact-theme", theme: hostTheme }, "*"));
+			await userEvent.click(theme);
+			expect(theme).toHaveAccessibleName(`Artifact theme: ${nextTheme === "light" ? "Light" : "Dark"}`);
+			await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ type: "dev3-artifact-theme", theme: nextTheme }, "*"));
+			await userEvent.click(theme);
+			expect(theme).toHaveAccessibleName("Artifact theme: Follow dev3");
+			await userEvent.click(theme);
+			expect(theme).toHaveAccessibleName(`Artifact theme: ${hostTheme === "light" ? "Light" : "Dark"}`);
+		} finally {
+			if (previousTheme) document.documentElement.dataset.theme = previousTheme;
+			else delete document.documentElement.dataset.theme;
+		}
 	});
 
 	it("does not consume terminal shortcuts until focus enters the viewer", async () => {


### PR DESCRIPTION
## Summary

- Initialize the artifact viewer theme from the current dev3 light or dark theme when an HTML artifact opens.
- Keep the artifact theme control responsive with an adaptive Light/Dark/Follow cycle.
- Add regression coverage for both host themes and update the changelog.

## Verification

- bunx vitest run src/mainview/components/__tests__/TaskArtifactViewer.test.tsx src/mainview/components/__tests__/TaskWorkspaceView.test.tsx src/mainview/utils/__tests__/artifactDocument.test.ts (20 tests passed)
- bun run lint
- Browser QA verified fresh light and dark artifact opens plus theme switching.