### PR TITLE
Symlink ~/.claude/output-styles into per-agent Claude config dirs

### DIFF
--- a/change-logs/2026/07/29/fix-symlink-output-styles-agent-accounts.md
+++ b/change-logs/2026/07/29/fix-symlink-output-styles-agent-accounts.md
@@ -1,0 +1,3 @@
+Short: Custom output styles work per account
+
+Per-agent Claude config dirs now symlink `~/.claude/output-styles`, so a custom `outputStyle` named in the shared `settings.json` actually resolves instead of silently falling back to the default style. Existing accounts are backfilled on the next launch, and a named-but-unresolvable output style is logged as a warning.

--- a/src/bun/__tests__/agent-accounts.test.ts
+++ b/src/bun/__tests__/agent-accounts.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	addClaudeApiProfile,
 	claudeAccountDir,
+	CLAUDE_SHARED_ENTRIES,
 	codexAccountDir,
 	completeClaudeLogin,
 	completeCodexLogin,
@@ -124,6 +125,19 @@ describe("importCurrentClaudeAccount", () => {
 		expect(lstatSync(join(dir, "settings.json")).isSymbolicLink()).toBe(true);
 	});
 
+	it("symlinks every shared entry, incl. output-styles, so settings.json names resolve", async () => {
+		seedClaudeLogin();
+		mkdirSync(join(paths.claudeHome, "output-styles"), { recursive: true });
+		writeFileSync(join(paths.claudeHome, "output-styles", "custom.md"), "# custom");
+		const account = await importCurrentClaudeAccount(paths);
+		const dir = claudeAccountDir(account.id, paths);
+
+		for (const entry of CLAUDE_SHARED_ENTRIES) {
+			expect(lstatSync(join(dir, entry)).isSymbolicLink()).toBe(true);
+		}
+		expect(existsSync(join(dir, "output-styles", "custom.md"))).toBe(true);
+	});
+
 	it("does not auto-activate the imported account (system login stays active)", async () => {
 		seedClaudeLogin();
 		await importCurrentClaudeAccount(paths);
@@ -240,6 +254,17 @@ describe("setActiveClaudeAccount / getActiveClaudeConfigDir", () => {
 
 	it("rejects unknown account ids", async () => {
 		await expect(setActiveClaudeAccount("nope", paths)).rejects.toThrow(/Unknown Claude account/);
+	});
+
+	it("backfills a shared entry missing from an account created by an older version", async () => {
+		seedClaudeLogin();
+		mkdirSync(join(paths.claudeHome, "output-styles"), { recursive: true });
+		const account = await importCurrentClaudeAccount(paths);
+		const dir = claudeAccountDir(account.id, paths);
+		rmSync(join(dir, "output-styles")); // simulate the pre-fix on-disk state
+
+		expect(await getActiveClaudeConfigDir(account.id, paths)).toBe(dir);
+		expect(lstatSync(join(dir, "output-styles")).isSymbolicLink()).toBe(true);
 	});
 
 	it("per-launch accountId override selects an account regardless of the registry default", async () => {

--- a/src/bun/agent-accounts.ts
+++ b/src/bun/agent-accounts.ts
@@ -25,6 +25,7 @@ import {
 	existsSync,
 	lstatSync,
 	mkdirSync,
+	readdirSync,
 	readFileSync,
 	renameSync,
 	rmSync,
@@ -82,8 +83,12 @@ export function defaultAccountPaths(): AccountPaths {
 }
 
 /** Entries of ~/.claude shared across accounts via symlinks: user customization
- *  (settings/skills/agents/commands/plugins/memory) plus transcripts+todos so
- *  session resume and usage tracking keep working after an account switch.
+ *  (settings/skills/agents/commands/plugins/output-styles/memory) plus
+ *  transcripts+todos so session resume and usage tracking keep working after an
+ *  account switch. Anything Claude Code resolves *by name* out of its config dir
+ *  MUST be listed here — settings.json is shared, so a name it references
+ *  (`outputStyle`) that has no matching directory in the account dir silently
+ *  falls back to the default with no warning anywhere.
  *  Credentials and .claude.json stay per-account by design. */
 export const CLAUDE_SHARED_ENTRIES = [
 	"settings.json",
@@ -92,6 +97,7 @@ export const CLAUDE_SHARED_ENTRIES = [
 	"agents",
 	"commands",
 	"plugins",
+	"output-styles",
 	"projects",
 	"todos",
 ];
@@ -497,7 +503,9 @@ export async function getActiveClaudeConfigDir(
 	const id = resolveAccountIdOverride(registry.claude.activeId, accountIdOverride);
 	if (!id || !registry.claude.accounts.some((e) => e.id === id)) return null;
 	const dir = claudeAccountDir(id, paths);
-	return existsSync(join(dir, ".claude.json")) ? dir : null;
+	if (!existsSync(join(dir, ".claude.json"))) return null;
+	scaffoldClaudeAccountDir(dir, paths); // backfill entries added since this account was created
+	return dir;
 }
 
 /** Fan the profile's model overrides into the four Claude alias slots
@@ -608,7 +616,10 @@ export async function getActiveCodexSessionEnv(
 	return { CODEX_HOME: ensureCodexAccountHome(id, paths) };
 }
 
-/** Create the per-account config dir with symlinks into ~/.claude for shared state. */
+/** Create the per-account config dir with symlinks into ~/.claude for shared
+ *  state. Idempotent and re-run on every account resolution, so an account
+ *  created before an entry joined CLAUDE_SHARED_ENTRIES is backfilled instead of
+ *  staying silently half-linked. */
 function scaffoldClaudeAccountDir(dir: string, paths: AccountPaths): void {
 	mkdirSync(dir, { recursive: true });
 	for (const entry of CLAUDE_SHARED_ENTRIES) {
@@ -624,6 +635,30 @@ function scaffoldClaudeAccountDir(dir: string, paths: AccountPaths): void {
 		} catch (err) {
 			log.warn("Failed to symlink shared claude entry", { entry, error: String(err) });
 		}
+	}
+	warnOnUnresolvableOutputStyle(dir);
+}
+
+/** Output styles Claude Code ships in-binary — they need no config-dir file. */
+const BUILTIN_OUTPUT_STYLES = new Set(["default", "explanatory", "learning"]);
+
+/** A settings.json `outputStyle` naming a style with no file in the account dir
+ *  is always a plumbing bug: Claude Code falls back to the default style without
+ *  a single log line, so the setting looks correct while doing nothing. */
+function warnOnUnresolvableOutputStyle(dir: string): void {
+	const name = (safeReadJson(join(dir, "settings.json")) as { outputStyle?: unknown } | null)?.outputStyle;
+	if (typeof name !== "string" || !name.trim() || BUILTIN_OUTPUT_STYLES.has(name.trim().toLowerCase())) return;
+	let styleFiles: string[] = [];
+	try {
+		styleFiles = readdirSync(join(dir, "output-styles")).filter((f) => f.endsWith(".md"));
+	} catch {
+		// unreadable or missing — reported below
+	}
+	if (styleFiles.length === 0) {
+		log.warn("settings.json names an outputStyle but the account dir has no output-styles files", {
+			outputStyle: name,
+			dir,
+		});
 	}
 }
 


### PR DESCRIPTION
Per-agent Claude config dirs (`~/.dev3.0/agent-accounts/claude/<id>/`) symlinked everything from `~/.claude` that agents rely on — except `output-styles`. Since `settings.json` *is* shared, an `"outputStyle": "<custom>"` looked correctly configured while Claude Code could not resolve the style by name inside the account dir and silently fell back to the default. No warning, no log line, nothing in the UI.

## Changes

- **`output-styles` added to `CLAUDE_SHARED_ENTRIES`** (`src/bun/agent-accounts.ts`), next to `skills`/`commands`, with a comment recording the invariant: anything Claude Code resolves *by name* out of its config dir must be listed there, or the shared `settings.json` points at nothing.
- **Backfill for existing accounts.** `scaffoldClaudeAccountDir` is now also called from `getActiveClaudeConfigDir` — idempotent (one `lstat` per entry), so accounts created before an entry joined the list get the missing symlink on the next agent launch instead of staying silently half-linked.
- **Warning on an unresolvable style.** `warnOnUnresolvableOutputStyle` logs when `settings.json` names a non-builtin `outputStyle` and the account dir has no `output-styles/*.md`. A named-but-missing style is always a configuration bug, never an intentional state.

`settings.local.json` is deliberately left unshared: Claude Code writes accumulated permissions into it, and a symlink would mutate the user's real `~/.claude`, breaking this module's "never mutate `~/.claude` beyond trust writes" invariant.

## Tests

Three cases in `src/bun/__tests__/agent-accounts.test.ts`: every shared entry is a symlink, a custom style file is visible through the `output-styles` link, and a deleted entry is backfilled on the next `getActiveClaudeConfigDir` call.