### PR TITLE
Heal a stale resume session id instead of killing the pane

### DIFF
--- a/change-logs/2026/08/01/fix-resume-stale-session-id.md
+++ b/change-logs/2026/08/01/fix-resume-stale-session-id.md
@@ -1,0 +1,3 @@
+Short: Resume survives a stale session id
+
+Resuming a task no longer dies with "No conversation found with session ID" when the stored agent session id has no transcript on disk. dev3 now checks the id against the agent's transcript store first and reopens the newest surviving conversation for that worktree instead, repairing the stored pointer so later resumes are clean.

--- a/decisions/189-verify-resume-session-id-against-transcripts.md
+++ b/decisions/189-verify-resume-session-id-against-transcripts.md
@@ -1,0 +1,65 @@
+# 189 — Verify a resume session id against the agent's transcripts
+
+## Context
+
+A long-running task could not be resumed after a machine restart: the agent pane
+launched `claude --resume 125a4c8c-…`, printed `No conversation found with
+session ID: 125a4c8c-…`, and exited 1. The pane died next to dev3's virtual
+shell, so the task looked destroyed — while the conversation itself was intact on
+disk under a *different* file name.
+
+dev3 mints a UUID on fresh launch, passes it as `--session-id`, and persists it
+as the task's resume pointer (`sessionState.panes[].sessionId`). That pointer is
+written optimistically, before the agent has materialized a transcript for it.
+
+## Investigation
+
+The surviving transcript was `~/.claude/projects/<encoded-cwd>/1160218f-….jsonl`,
+covering the task's whole life. Two id fields inside it disagreed: every line's
+`sessionId` was `1160218f` (the file's own id), while 934 lines carried
+`session_id` = `125a4c8c` — the *live process* id dev3 assigned. So the process
+really ran under our id but appended to an earlier conversation's file (a
+`~/.claude/session-env/125a4c8c-…/` dir existed; a transcript never did).
+
+The task's hourly backups pinned the moment it broke: the stored pointer was
+`1160218f` at `2026-07-26T20Z` and `125a4c8c` at `21Z`. Every resume after that
+was doomed. A sweep of all boards found 3 of 58 pointers stale the same way.
+
+## Decision
+
+Check the stored id against what is actually on disk before spending it on
+`--resume`. `src/bun/agent-transcripts.ts` (`resolveResumableSessionId`) returns
+the stored id when its transcript exists, the **newest transcript for that
+worktree** when it does not, and null (→ the agent's own `--continue`) when the
+store is empty. `resumeTask` in `src/bun/rpc-handlers/tmux-pty.ts` routes both
+the main pane and every extra pane through it, and `launchTaskPty`'s existing
+`sessionState` write persists the healed id — so a stale pointer repairs itself
+on first use.
+
+Transcript layout is adapter knowledge: `AgentAdapter.transcriptStore` returns
+`{ dir, ext }` (pure, no fs) and only Claude implements it, because only Claude's
+store is filename-keyed by the resumable id.
+
+## Risks
+
+- **Wrong conversation on substitution.** If several transcripts exist for one
+  worktree we pick the newest by mtime, which may not be the one the user meant.
+  Accepted: the alternative is a dead pane, and mtime order matches "what I was
+  last working on" in practice.
+- **Unverifiable stores stay unverified.** Codex and Gemini key transcripts on a
+  cwd header *inside* the file, so their ids pass through untouched. Deliberate:
+  the resolver never downgrades a resume it cannot check.
+- **Optimistic persist remains.** A fresh launch still records the id before a
+  transcript exists, so dead pointers can still be written — they now heal on
+  read instead of failing.
+
+## Alternatives considered
+
+- **Persist the id from the transcript filename instead of the runtime id** —
+  correct at the source, but requires watching the store after launch (the file
+  does not exist until the first message) for no additional coverage: healing on
+  resume already handles every way the pointer can rot.
+- **Always `--continue`, never `--resume <id>`** — loses targeted resume, which
+  variant isolation and multi-pane tasks depend on.
+- **Surface the failure in the UI and let the user pick** — a modal for a
+  question dev3 can answer itself; the substitution is logged instead.

--- a/src/bun/__tests__/agent-transcripts.test.ts
+++ b/src/bun/__tests__/agent-transcripts.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listResumableSessionIds, resolveResumableSessionId } from "../agent-transcripts";
+import { claudeEncodePath } from "../../shared/conversation-search-core";
+
+const WORKTREE = "/Users/dev/.dev3.0/ops/operations/7d8312c0/work";
+
+let home: string;
+
+function transcriptDir(): string {
+	return join(home, ".claude", "projects", claudeEncodePath(WORKTREE));
+}
+
+/** Seed a claude transcript; `ageSeconds` back-dates it so ordering is explicit. */
+function seedTranscript(sessionId: string, ageSeconds: number): void {
+	const dir = transcriptDir();
+	mkdirSync(dir, { recursive: true });
+	const file = join(dir, `${sessionId}.jsonl`);
+	writeFileSync(file, `${JSON.stringify({ type: "assistant", sessionId })}\n`);
+	const when = new Date(Date.UTC(2026, 6, 27) - ageSeconds * 1000);
+	utimesSync(file, when, when);
+}
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), "agent-transcripts-"));
+});
+
+afterEach(() => {
+	rmSync(home, { recursive: true, force: true });
+});
+
+describe("resolveResumableSessionId", () => {
+	it("keeps a stored id that still has a transcript", () => {
+		seedTranscript("1160218f-85f5-4a45-8032-ced3af5a532b", 0);
+
+		expect(resolveResumableSessionId("claude", WORKTREE, "1160218f-85f5-4a45-8032-ced3af5a532b", home)).toEqual({
+			sessionId: "1160218f-85f5-4a45-8032-ced3af5a532b",
+			substituted: false,
+		});
+	});
+
+	it("substitutes the newest transcript when the stored id has none", () => {
+		// The real failure: dev3 persisted the live runtime id, but the agent kept
+		// appending to the conversation it was resumed from.
+		seedTranscript("1160218f-85f5-4a45-8032-ced3af5a532b", 0);
+		seedTranscript("aefa0626-853c-49c9-97bf-bd0e88ed89e7", 3600);
+
+		expect(resolveResumableSessionId("claude", WORKTREE, "125a4c8c-b567-4d24-991b-8732e82878c8", home)).toEqual({
+			sessionId: "1160218f-85f5-4a45-8032-ced3af5a532b",
+			substituted: true,
+		});
+	});
+
+	it("drops a dead id to agent-latest when the store holds no transcripts", () => {
+		mkdirSync(transcriptDir(), { recursive: true });
+
+		expect(resolveResumableSessionId("claude", WORKTREE, "125a4c8c-b567-4d24-991b-8732e82878c8", home)).toEqual({
+			sessionId: null,
+			substituted: true,
+		});
+	});
+
+	it("passes the stored id through untouched when the store dir does not exist", () => {
+		// Unverifiable — a missing dir must never downgrade a resume that would work.
+		expect(resolveResumableSessionId("claude", WORKTREE, "125a4c8c-b567-4d24-991b-8732e82878c8", home)).toEqual({
+			sessionId: "125a4c8c-b567-4d24-991b-8732e82878c8",
+			substituted: false,
+		});
+	});
+
+	it("passes the stored id through for agents with no filename-keyed store", () => {
+		seedTranscript("1160218f-85f5-4a45-8032-ced3af5a532b", 0);
+
+		expect(resolveResumableSessionId("codex", WORKTREE, "some-codex-session", home)).toEqual({
+			sessionId: "some-codex-session",
+			substituted: false,
+		});
+	});
+
+	it("leaves a null stored id alone so the agent picks its own latest", () => {
+		seedTranscript("1160218f-85f5-4a45-8032-ced3af5a532b", 0);
+
+		expect(resolveResumableSessionId("claude", WORKTREE, null, home)).toEqual({
+			sessionId: null,
+			substituted: false,
+		});
+	});
+});
+
+describe("listResumableSessionIds", () => {
+	it("returns session ids newest first and ignores non-transcript files", () => {
+		seedTranscript("aaaaaaaa-0000-0000-0000-000000000001", 7200);
+		seedTranscript("bbbbbbbb-0000-0000-0000-000000000002", 60);
+		seedTranscript("cccccccc-0000-0000-0000-000000000003", 3600);
+		writeFileSync(join(transcriptDir(), "notes.txt"), "ignore me");
+		writeFileSync(join(transcriptDir(), ".jsonl"), "no id");
+
+		expect(listResumableSessionIds("claude", WORKTREE, home)).toEqual([
+			"bbbbbbbb-0000-0000-0000-000000000002",
+			"cccccccc-0000-0000-0000-000000000003",
+			"aaaaaaaa-0000-0000-0000-000000000001",
+		]);
+	});
+
+	it("returns nothing for an agent without a filename-keyed store", () => {
+		seedTranscript("aaaaaaaa-0000-0000-0000-000000000001", 0);
+
+		expect(listResumableSessionIds("codex", WORKTREE, home)).toEqual([]);
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -293,6 +293,7 @@ import * as repoConfig from "../repo-config";
 import * as cowClone from "../cow-clone";
 import { Utils } from "electrobun/bun";
 import { accessSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { claudeEncodePath } from "../../shared/conversation-search-core";
 import {
 	createTaskPreparation,
 	finishTaskPreparation,
@@ -8595,6 +8596,99 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		await expect(
 			handlers.spawnBugHuntersInTask({ taskId: "task-1", projectId: "proj-1", agentId: null, configId: null, count: 3 }),
 		).rejects.toThrow("no worktree");
+	});
+});
+
+describe("resumeTask session-id healing", () => {
+	const WORKTREE = "/tmp/resume-wt";
+	const LIVE = "1160218f-85f5-4a45-8032-ced3af5a532b";
+	const DEAD = "125a4c8c-b567-4d24-991b-8732e82878c8";
+	const STORE = `${process.env.HOME}/.claude/projects/${claudeEncodePath(WORKTREE)}`;
+
+	/** Transcript files the claude store holds for this worktree. */
+	function seedStore(files: string[], storeExists = true): void {
+		(readdirSync as any).mockImplementation((dir: string) => (String(dir) === STORE ? files : []));
+		(existsSync as any).mockImplementation((path: string) => (String(path) === STORE ? storeExists : true));
+	}
+
+	function arrangeTask(storedSessionId: string): void {
+		const project = makeProject();
+		const task = makeTask({
+			worktreePath: WORKTREE,
+			sessionState: {
+				panes: [{ agentCmd: "claude", sessionId: storedSessionId, agentId: "builtin-claude", configId: "claude-default" }],
+			},
+		});
+		(data.loadProjects as any).mockResolvedValue([project]);
+		(data.loadVirtualProjects as any).mockResolvedValue([]);
+		(data.getTask as any).mockResolvedValue(task);
+		(pty.hasSession as any).mockReturnValue(false);
+		(pty.getPtyPort as any).mockReturnValue(9999);
+	}
+
+	function resumeOptions(): any {
+		return (agents.resolveCommandForAgent as any).mock.calls[0][3];
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		(readdirSync as any).mockImplementation(() => []);
+		(existsSync as any).mockImplementation(() => true);
+	});
+
+	it("resumes the surviving transcript when the stored session id is dead", async () => {
+		seedStore([`${LIVE}.jsonl`]);
+		arrangeTask(DEAD);
+
+		await handlers.resumeTask({ taskId: "task-1" });
+
+		expect(resumeOptions()).toMatchObject({ resume: true, sessionId: LIVE });
+	});
+
+	it("repairs the persisted pointer so the next resume is clean", async () => {
+		seedStore([`${LIVE}.jsonl`]);
+		arrangeTask(DEAD);
+
+		await handlers.resumeTask({ taskId: "task-1" });
+
+		expect(data.updateTask).toHaveBeenCalledWith(
+			expect.anything(),
+			"task-1",
+			expect.objectContaining({
+				sessionState: { panes: [expect.objectContaining({ sessionId: LIVE })] },
+			}),
+		);
+	});
+
+	it("keeps a stored session id that still has its transcript", async () => {
+		seedStore([`${LIVE}.jsonl`, `${DEAD}.jsonl`]);
+		arrangeTask(DEAD);
+
+		await handlers.resumeTask({ taskId: "task-1" });
+
+		expect(resumeOptions()).toMatchObject({ resume: true, sessionId: DEAD });
+	});
+
+	it("falls back to agent-latest when the store holds no transcript", async () => {
+		seedStore([]);
+		arrangeTask(DEAD);
+
+		await handlers.resumeTask({ taskId: "task-1" });
+
+		expect(resumeOptions()).toMatchObject({ resume: true });
+		expect(resumeOptions().sessionId).toBeUndefined();
+	});
+
+	it("passes a stored id through untouched when the store is absent (unverifiable)", async () => {
+		seedStore([], false);
+		arrangeTask(DEAD);
+
+		await handlers.resumeTask({ taskId: "task-1" });
+
+		expect(resumeOptions()).toMatchObject({ resume: true, sessionId: DEAD });
 	});
 });
 

--- a/src/bun/agent-transcripts.ts
+++ b/src/bun/agent-transcripts.ts
@@ -1,0 +1,78 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { resolveUserHome } from "../shared/user-home";
+import { getAgentAdapter } from "../shared/agent-adapters/registry";
+
+/**
+ * Verifies a stored agent session id against the transcripts actually on disk
+ * before dev3 spends it on `--resume`.
+ *
+ * dev3 mints a session id at fresh launch and persists it as the task's resume
+ * pointer. That pointer can go stale while the conversation itself survives:
+ * the agent process owns the id we assigned, but its transcript may end up in a
+ * different file (e.g. the user resumes another conversation from inside the
+ * session). Resuming a dead id is a hard failure — the agent exits non-zero and
+ * the pane dies — even though a perfectly good transcript sits next to it. See
+ * decision 180.
+ */
+
+/** Resume pointer to actually use, after checking it against the store. */
+export interface ResumeTarget {
+	/** Id for `--resume`, or null to let the agent pick its own latest session. */
+	sessionId: string | null;
+	/** The stored id had no transcript, so this replaces it (worth logging). */
+	substituted: boolean;
+}
+
+/** Session ids that have a transcript for this worktree, newest first. */
+export function listResumableSessionIds(
+	agentCmd: string,
+	worktreePath: string,
+	home: string = resolveUserHome(),
+): string[] {
+	const store = getAgentAdapter(agentCmd).transcriptStore?.(worktreePath, home) ?? null;
+	if (!store) return [];
+	return sessionIdsNewestFirst(store.dir, store.ext);
+}
+
+/**
+ * Pick the session id to resume. Falls back to the newest transcript when the
+ * stored id is dead, and to the agent's own "latest" when the store is empty.
+ * Passes the stored id through untouched whenever it cannot be verified, so an
+ * unknown store never makes resume worse than not checking at all.
+ */
+export function resolveResumableSessionId(
+	agentCmd: string,
+	worktreePath: string,
+	storedSessionId: string | null | undefined,
+	home: string = resolveUserHome(),
+): ResumeTarget {
+	const stored = storedSessionId ?? null;
+	const store = getAgentAdapter(agentCmd).transcriptStore?.(worktreePath, home) ?? null;
+	if (!store || !existsSync(store.dir)) return { sessionId: stored, substituted: false };
+	if (!stored) return { sessionId: null, substituted: false };
+
+	const ids = sessionIdsNewestFirst(store.dir, store.ext);
+	if (ids.includes(stored)) return { sessionId: stored, substituted: false };
+	return { sessionId: ids[0] ?? null, substituted: true };
+}
+
+function sessionIdsNewestFirst(dir: string, ext: string): string[] {
+	let names: string[];
+	try {
+		names = readdirSync(dir).filter((f) => f.endsWith(ext) && f.length > ext.length);
+	} catch {
+		return [];
+	}
+	return names
+		.map((name) => ({ id: name.slice(0, -ext.length), mtimeMs: mtimeMsOf(`${dir}/${name}`) }))
+		.sort((a, b) => b.mtimeMs - a.mtimeMs)
+		.map((entry) => entry.id);
+}
+
+function mtimeMsOf(path: string): number {
+	try {
+		return statSync(path).mtimeMs;
+	} catch {
+		return 0;
+	}
+}

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from "node:fs";
-import type { ColumnAgentConfig, DevServerStatus, PermissionMode, PortInfo, Project, Task, TmuxLayout, TmuxSessionInfo } from "../../shared/types";
+import type { ColumnAgentConfig, DevServerStatus, PaneSessionEntry, PermissionMode, PortInfo, Project, Task, TmuxLayout, TmuxSessionInfo } from "../../shared/types";
 import { getTaskTitle } from "../../shared/types";
 import * as data from "../data";
 import * as pty from "../pty-server";
@@ -14,6 +14,7 @@ import { loadSettings, recordFavoriteUsages } from "../settings";
 import { getUserShell } from "../shell-env";
 import { spawn } from "../spawn";
 import { setupAgentHooks } from "../agent-hooks";
+import { resolveResumableSessionId } from "../agent-transcripts";
 import { ensureArtifactTemplateEnv } from "../artifact-template";
 import {
 	tmux,
@@ -1407,6 +1408,25 @@ async function wakeIfHibernated(project: Project, task: Task): Promise<void> {
 	await dispatchLifecycleEvent(project.id, task.id, { type: "wakeRequested" }, { project, task });
 }
 
+/**
+ * Resume pointer for one pane, healed against the transcripts on disk. A stored
+ * id whose transcript is gone would kill the pane on `--resume`; the newest
+ * surviving conversation for that worktree is the right thing to reopen instead
+ * (decision 189). Returns null to let the agent pick its own latest session.
+ */
+function resolveResumeTarget(task: Task, pane: PaneSessionEntry, label: string): string | null {
+	const target = resolveResumableSessionId(pane.agentCmd, task.worktreePath ?? "", pane.sessionId);
+	if (target.substituted) {
+		log.warn("Stored session id has no transcript — resuming the newest conversation instead", {
+			taskId: task.id.slice(0, 8),
+			pane: label,
+			stored: pane.sessionId,
+			using: target.sessionId ?? "agent-latest",
+		});
+	}
+	return target.sessionId;
+}
+
 async function resumeTask(params: { taskId: string }): Promise<string> {
 	log.info("→ resumeTask", { taskId: params.taskId.slice(0, 8) });
 	const { task, project } = await findTaskAcrossProjects(params.taskId);
@@ -1426,6 +1446,7 @@ async function resumeTask(params: { taskId: string }): Promise<string> {
 
 	// Launch main pane (panes[0]) with resume
 	const main = panes[0];
+	const mainResume = resolveResumeTarget(task, main, "main");
 	const resolvedProject = project.kind === "virtual"
 		? project
 		: await repoConfig.resolveProjectConfig(project, task.worktreePath);
@@ -1437,7 +1458,7 @@ async function resumeTask(params: { taskId: string }): Promise<string> {
 		main.configId,
 		false,
 		true,
-		main.sessionId ? { sessionId: main.sessionId } : undefined,
+		mainResume ? { sessionId: mainResume } : undefined,
 	);
 
 	// Resume extra panes (panes[1..]) via split-window.
@@ -1465,8 +1486,9 @@ async function resumeTask(params: { taskId: string }): Promise<string> {
 			for (let i = 1; i < panes.length; i++) {
 				const pane = panes[i];
 				try {
+					const paneResume = resolveResumeTarget(task, pane, `pane ${i}`);
 					const cmdOpts: agents.CommandOptions = { resume: true, accountId: pane.accountId };
-					if (pane.sessionId) cmdOpts.sessionId = pane.sessionId;
+					if (paneResume) cmdOpts.sessionId = paneResume;
 					let resumeCmd: string;
 					let resumeBaseCmd = pane.agentCmd;
 					let extraEnv: Record<string, string> = {};
@@ -1476,7 +1498,7 @@ async function resumeTask(params: { taskId: string }): Promise<string> {
 						extraEnv = resolved.extraEnv;
 						resumeBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || pane.agentCmd;
 					} else {
-						resumeCmd = agents.buildResumeCommand(pane.agentCmd, pane.sessionId ?? undefined) ?? pane.agentCmd;
+						resumeCmd = agents.buildResumeCommand(pane.agentCmd, paneResume ?? undefined) ?? pane.agentCmd;
 					}
 					await ensureAgentTrust(task.worktreePath, project.path, resumeBaseCmd, pane.accountId);
 					resumeCmd = await applyAgentHooksToCommand(task.worktreePath, resumeBaseCmd, resumeCmd, {

--- a/src/shared/agent-adapters/claude.ts
+++ b/src/shared/agent-adapters/claude.ts
@@ -1,5 +1,6 @@
 /** Claude Code adapter. */
 import { CLAUDE_SKILL_BODY } from "../agent-skill-content";
+import { claudeEncodePath } from "../conversation-search-core";
 import { modelArgs, providerArgs } from "./common";
 import { shellEscape, quoteIfUnsafe } from "./shell";
 import { buildTaskPrompt } from "./template";
@@ -74,6 +75,10 @@ export const claudeAdapter: AgentAdapter = {
 
 	buildResumeCommand(baseCmd, sessionId) {
 		return sessionId ? `${baseCmd} --resume ${sessionId}` : `${baseCmd} --continue`;
+	},
+
+	transcriptStore(worktreePath, home) {
+		return { dir: `${home}/.claude/projects/${claudeEncodePath(worktreePath)}`, ext: ".jsonl" };
 	},
 
 	hooksSpec(options) {

--- a/src/shared/agent-adapters/types.ts
+++ b/src/shared/agent-adapters/types.ts
@@ -91,6 +91,15 @@ export interface AgentAdapter {
 	 */
 	buildResumeCommand(baseCmd: string, sessionId?: string): string | null;
 
+	/**
+	 * Where this agent keeps one worktree's transcripts, when the resumable
+	 * session id IS the file's basename — which lets dev3 verify a stored id
+	 * before spending it on `--resume`. Pure: returns paths, never touches fs.
+	 * Omitted by agents whose store is not filename-keyed (codex/gemini key on a
+	 * cwd header inside the file), leaving their stored ids unverifiable.
+	 */
+	transcriptStore?(worktreePath: string, home: string): { dir: string; ext: string };
+
 	/** Agent-native lifecycle hooks to install, or null when the agent has none. */
 	hooksSpec(options?: { stopTarget?: TaskStatus; permissionMode?: PermissionMode }): HooksSpec | null;
 }


### PR DESCRIPTION
## The bug

Resuming a task can die with `No conversation found with session ID: …` and leave a dead agent pane next to dev3's virtual shell — while the conversation is fully intact on disk under a different file name.

dev3 mints a UUID at fresh launch, passes it as `--session-id`, and persists it as the task's resume pointer. That pointer is written optimistically, before the agent has materialized a transcript for it, so it can rot.

**Found in the wild** on a task that had run Jul 21–27: the surviving transcript was `1160218f-….jsonl`, but the stored pointer was `125a4c8c-…`. Inside that file every line's `sessionId` was `1160218f` (the file's id) while 934 lines carried `session_id` = `125a4c8c` (the live process id dev3 assigned) — the process ran under our id but appended to an earlier conversation's file. The task's hourly backups pin the flip exactly: `1160218f` at `2026-07-26T20Z`, `125a4c8c` at `21Z`. A sweep of all boards found 3 of 58 pointers stale the same way.

## The fix

Verify the stored id against what is actually on disk before spending it on `--resume` (`src/bun/agent-transcripts.ts`):

| stored id | result |
|---|---|
| transcript exists | kept as-is |
| transcript gone | newest transcript for that worktree, `substituted: true` |
| store empty | `null` → the agent's own `--continue` |
| store unverifiable (missing dir, or a non-filename-keyed agent) | passed through untouched |

`resumeTask` routes the main pane **and** every extra pane through it, and `launchTaskPty`'s existing `sessionState` write persists the healed id — so a stale pointer repairs itself on first use, including the ones already on disk.

Transcript layout is adapter knowledge: `AgentAdapter.transcriptStore` returns `{ dir, ext }` (pure, no fs). Only Claude implements it, because only Claude's store is filename-keyed by the resumable id; Codex/Gemini key on a cwd header inside the file, so their ids keep passing through unverified. The resolver never downgrades a resume it cannot check.

Rationale, risks and alternatives: `decisions/189-verify-resume-session-id-against-transcripts.md`.

## Verification

- `bun run lint` clean; `bun run test` green (3074 renderer + 4013 bun + 664 cli).
- 8 unit tests for the resolver (real temp fs) + 5 `resumeTask` wiring tests. **3 of the 5 wiring tests fail without the fix** — confirmed by stubbing the resolver out and re-running.
- Run against the real reported break: stored `125a4c8c-…` → resumes `1160218f-…` (`substituted=true`); the healthy sibling task's pointer is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
