### PR TITLE
Save unfinished tasks as drafts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ Public `dev3` CLI exit codes are a documented contract:
 - **Runtime** — the actor-owned execution phase (`idle`, `preparing`, `running`, or `tearing-down`), independent of the column. `Task.runtimeState` is only a persisted recovery hint and must be verified against tmux/worktree reality at boot.
 - **Activity** — a watcher declared by lifecycle state, such as `mergeWatch` or `prWatch`. Activities deliver findings back through the task mailbox; they never write task status directly.
 - **Actor/mailbox** — the per-task FIFO that serializes lifecycle events while allowing different tasks to run in parallel. RPC callers await their own mailbox event and its synchronous effects.
+- **Draft** — a task the user explicitly marked unfinished ("Save as draft"). A property of the task (`Task.draft`), not a column and not a runtime phase: it lives in To Do, `idle`, with no worktree. No activation path may start it — the lifecycle machine rejects the move, so the UI affordances are only mirrors. The opposite of a *scratch* task (no prompt, launched immediately). Promotion to an ordinary task is one-way; see [decision 180](decisions/180-draft-tasks-lifecycle-enforced-one-way.md).
 - **Compensating event** — the explicit event dispatched when an `abort` effect fails. The transition table declares the recovery path; the executor must not hide it in ad-hoc catch logic.
 
 Two-process model:

--- a/change-logs/2026/07/29/feature-30-save-task-as-draft.md
+++ b/change-logs/2026/07/29/feature-30-save-task-as-draft.md
@@ -1,0 +1,5 @@
+Short: Park unfinished tasks as drafts
+
+The New Task popup gained a fourth exit, "Save as draft": it parks an unfinished task in To Do with a dashed card and a Draft badge, and nothing can start it — not Run, not a drag, not a scheduled launch, not an automation, not an agent over the CLI. Clicking a draft card reopens the popup prefilled with everything you had entered, so you can keep writing across several sittings and then Save (or Save & Start) once the description is finally there.
+
+Suggested by @yakirn (h0x91b/dev-3.0#1158)

--- a/change-logs/2026/07/29/feature-30-save-task-as-draft.md
+++ b/change-logs/2026/07/29/feature-30-save-task-as-draft.md
@@ -1,5 +1,5 @@
 Short: Park unfinished tasks as drafts
 
-The New Task popup gained a fourth exit, "Save as draft": it parks an unfinished task in To Do with a dashed card and a Draft badge, and nothing can start it — not Run, not a drag, not a scheduled launch, not an automation, not an agent over the CLI. Clicking a draft card reopens the popup prefilled with everything you had entered, so you can keep writing across several sittings and then Save (or Save & Start) once the description is finally there.
+The New Task popup gained a fourth exit, "Save as draft": it parks an unfinished task in To Do with a dashed card and a Draft badge, and nothing can start it — not Run, not a drag, not a scheduled launch, not an automation, not an agent over the CLI. Clicking a draft card reopens the popup prefilled with everything you had entered, so you can keep writing across several sittings and then Save (or Save & Start) once the description is finally there. Closing the popup with unsaved text now offers the same escape hatch: the confirmation asks whether to park the changes as a draft instead of only "keep typing or lose it".
 
 Suggested by @yakirn (h0x91b/dev-3.0#1158)

--- a/decisions/180-draft-tasks-lifecycle-enforced-one-way.md
+++ b/decisions/180-draft-tasks-lifecycle-enforced-one-way.md
@@ -1,0 +1,48 @@
+# 180 — Draft tasks: enforced in the lifecycle machine, and one-way
+
+## Context
+
+"Save as draft" (issue #1158) parks an unfinished task in To Do with a guarantee
+that **nothing** can start it: not the Run button, not a board drag, not a
+scheduled launch, not an automation, not `dev3 task move` from an agent. Two
+choices in that design will look arbitrary later, so they are recorded here.
+
+## Decision
+
+**1. The block lives in the lifecycle machine, not in the UI.** `Task.draft` is
+derived into `LifecycleFacts.draft` (`src/bun/lifecycle/state.ts`), and
+`moveTransition` (`src/bun/lifecycle/machine.ts`) rejects the move the moment
+`needsActivation && facts.draft`. Every activation path in the app funnels
+through that one `moveRequested` event, so one guard covers all of them —
+including paths added later, which get the rule for free. The hidden Run button,
+the non-droppable card and the CLI's dedicated exit code are cosmetic mirrors of
+a rule that already holds server-side. `scheduleTaskLaunch` repeats the refusal
+because it persists a *future* activation rather than dispatching one, so it does
+not pass through the machine.
+
+**2. draft → ready is one-way.** `editTask` refuses `draft: true` on a task that
+is not already a draft, and there is no demote affordance in the UI, RPC or CLI.
+A task the user has already started reasoning about (possibly launched, possibly
+with notes and an overview) must not be able to slide back into "not ready" —
+that would make "is this runnable?" a question with a moving answer, and every
+consumer (scheduler, automations, agents) would have to re-check it.
+
+## Risks
+
+- The single choke point is only as good as the funnel: a future feature that
+  activates a task *without* dispatching `moveRequested` would bypass the rule.
+  That funnel is already the project's central invariant (see the task lifecycle
+  glossary in `AGENTS.md`), so the risk is accepted rather than mitigated.
+- `DRAFT_TASK_ACTIVATION_ERROR` (`src/shared/types.ts`) is matched as a string by
+  the CLI to pick exit code 9. It is therefore a contract, not log text — hence
+  the shared constant instead of an inline message.
+
+## Alternatives considered
+
+- **Guard in each caller** (Run button, drag handler, scheduler, CLI): rejected —
+  five places to keep in sync, and the sixth one added next year is the bug.
+- **A separate `draft` status/column**: rejected — it would change how the To Do
+  column is composed, and every consumer of `TaskStatus` would need a new case.
+  A draft is a *property* of a To Do task, not a lifecycle phase.
+- **Allow demotion, guarded by "only while never launched"**: rejected as a rule
+  whose precondition ("never launched") is itself derived state that drifts.

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -13,6 +13,7 @@ Public `dev3` CLI exit codes are defined in `src/shared/cli-exit-codes.ts`.
 | `6` | `CLI_EXIT_CODE_COMPLETION_DECLINED` | `dev3 task move --status completed` asked the user for approval and the user declined. The task keeps its current status and the session stays alive. |
 | `7` | `CLI_EXIT_CODE_DOCTOR_PROBLEMS` | `dev3 doctor` found at least one problem (a check with status "fail"). Warnings alone still exit 0. |
 | `8` | `CLI_EXIT_CODE_RENDERER_UNAVAILABLE` | The desktop launch created a window but no renderer ever reported dom-ready within the readiness budget — a missing or broken WebView2 runtime, or no interactive desktop (SSH / session 0). The process prints an actionable diagnostic and leaves instead of running without a UI. |
+| `9` | `CLI_EXIT_CODE_TASK_IS_DRAFT` | `dev3 task move` was asked to start a task the user saved as a draft. A draft is deliberately unfinished, so no launch path may start it — the human must finish its description and save it as a normal task first. |
 
 `--tolerate-app-offline` turns code `2` into code `0` for a single invocation: the
 "app not running" notice is still written to stderr, but the process exits

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -44,6 +44,7 @@ vi.mock("../data", () => ({
 	loadTasks: vi.fn(),
 	updateTask: vi.fn(),
 	setTaskPriority: vi.fn(),
+	deriveTaskBaseBranch: vi.fn((project: any, branch?: string | null) => branch || project.defaultBaseBranch),
 	addTask: vi.fn(),
 	addProject: vi.fn(),
 	reorderProjects: vi.fn(),
@@ -2988,6 +2989,156 @@ describe("handlers.editTask", () => {
 		await expect(
 			handlers.editTask({ taskId: "task-1", projectId: "proj-1", description: "Edit" }),
 		).rejects.toThrow("Can only edit tasks in todo status");
+	});
+
+	it("touches only the fields it was given", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", description: "Keep me", customTitle: "Keep title" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+
+		await handlers.editTask({ taskId: "task-1", projectId: "proj-1", priority: "P0" });
+
+		expect(data.updateTask).toHaveBeenCalledTimes(1);
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { priority: "P0" });
+	});
+
+	it("saves a whole draft in a single write", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", draft: true, description: "" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, draft: true, description: "Half a thought" });
+
+		await handlers.editTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			description: "Half a thought",
+			customTitle: "My draft",
+			priority: "P1",
+			labelIds: ["l1"],
+			existingBranch: "feature/x",
+			draft: true,
+		});
+
+		expect(data.updateTask).toHaveBeenCalledTimes(1);
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", expect.objectContaining({
+			description: "Half a thought",
+			customTitle: "My draft",
+			titleEditedByUser: true,
+			priority: "P1",
+			labelIds: ["l1"],
+			existingBranch: "feature/x",
+			draft: true,
+		}));
+	});
+
+	it("keeps the placeholder title of a draft that still has no description", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", draft: true, description: "", title: "Draft — 09:12" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue(task);
+
+		await handlers.editTask({ taskId: "task-1", projectId: "proj-1", description: "", draft: true });
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", expect.objectContaining({
+			title: "Draft — 09:12",
+		}));
+	});
+
+	it("promotes a draft into a runnable task", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", draft: true, description: "" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, draft: false, description: "Now it is written" });
+
+		const result = await handlers.editTask({
+			taskId: "task-1",
+			projectId: "proj-1",
+			description: "Now it is written",
+			draft: false,
+		});
+
+		expect(result.draft).toBe(false);
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", expect.objectContaining({
+			draft: false,
+			description: "Now it is written",
+		}));
+	});
+
+	it("refuses to promote a draft that still has no description", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", draft: true, description: "" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+
+		await expect(
+			handlers.editTask({ taskId: "task-1", projectId: "proj-1", description: "   ", draft: false }),
+		).rejects.toThrow(/needs a description/i);
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("refuses to turn a runnable task back into a draft", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "todo", description: "Already runnable" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+
+		await expect(
+			handlers.editTask({ taskId: "task-1", projectId: "proj-1", draft: true }),
+		).rejects.toThrow(/cannot be turned back into a draft/i);
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+});
+
+// ================================================================
+// Draft tasks — creation and scheduling guards
+// ================================================================
+
+describe("draft tasks", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("creates a blank draft with a readable placeholder title", async () => {
+		const project = makeProject();
+		const created = makeTask({ status: "todo", draft: true, description: "", title: "Draft — 09:12" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.addTask).mockResolvedValue(created);
+
+		const result = await handlers.createTask({ projectId: "proj-1", description: "", draft: true });
+
+		expect(result).toEqual(created);
+		expect(data.addTask).toHaveBeenCalledWith(project, "", "todo", expect.objectContaining({
+			draft: true,
+			title: expect.stringMatching(/^Draft — \d{2}:\d{2}$/),
+		}));
+	});
+
+	it("refuses to create a draft straight into a running column", async () => {
+		vi.mocked(data.getProject).mockResolvedValue(makeProject());
+
+		await expect(
+			handlers.createTask({ projectId: "proj-1", description: "x", draft: true, status: "in-progress" }),
+		).rejects.toThrow(/cannot be created into an active status/i);
+	});
+
+	it("refuses to schedule a deferred launch on a draft", async () => {
+		const project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(makeTask({ status: "todo", draft: true }));
+
+		await expect(
+			handlers.scheduleTaskLaunch({
+				taskId: "task-1",
+				projectId: "proj-1",
+				at: new Date(Date.now() + 60_000).toISOString(),
+				targetStatus: "in-progress",
+				variants: [{ agentId: "builtin-claude", configId: "claude-auto" }],
+			}),
+		).rejects.toThrow(/draft/i);
+		expect(data.updateTask).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -53,7 +53,7 @@ function tasksBackupFileName(now: Date = new Date()): string {
 	return `${now.toISOString().slice(0, 13)}Z.json`;
 }
 
-function deriveTaskBaseBranch(project: Project, existingBranch?: string | null): string {
+export function deriveTaskBaseBranch(project: Project, existingBranch?: string | null): string {
 	const normalizedExistingBranch = existingBranch?.trim()
 		.replace(/^refs\/remotes\//, "")
 		.replace(/^origin\//, "");
@@ -819,6 +819,8 @@ export async function addTask(
 		configId?: string | null;
 		accountId?: string | null;
 		seq?: number;
+		/** Overrides the title derived from the description (blank-description drafts). */
+		title?: string;
 		existingBranch?: string;
 		preparing?: boolean;
 		preparingStage?: Task["preparingStage"];
@@ -827,6 +829,7 @@ export async function addTask(
 		runtimeState?: Task["runtimeState"];
 		watched?: boolean;
 		scratch?: boolean;
+		draft?: boolean;
 		customTitle?: string | null;
 		titleEditedByUser?: boolean;
 		labelIds?: string[];
@@ -841,7 +844,7 @@ export async function addTask(
 ): Promise<Task> {
 	const file = tasksFile(project);
 	return withFileLock(file, async () => {
-		const title = titleFromDescription(description);
+		const title = extras?.title?.trim() || titleFromDescription(description);
 		log.info("Creating task", { projectId: project.id, title, status });
 		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const now = new Date().toISOString();
@@ -890,6 +893,7 @@ export async function addTask(
 			...(extras?.runtimeState ? { runtimeState: extras.runtimeState } : {}),
 			...(extras?.watched ? { watched: true } : {}),
 			...(extras?.scratch ? { scratch: true } : {}),
+			...(extras?.draft ? { draft: true } : {}),
 			...(extras?.customTitle ? { customTitle: extras.customTitle } : {}),
 			...(extras?.titleEditedByUser ? { titleEditedByUser: true } : {}),
 			...(extras?.opsWorkDir ? { opsWorkDir: extras.opsWorkDir } : {}),

--- a/src/bun/lifecycle/__tests__/machine.test.ts
+++ b/src/bun/lifecycle/__tests__/machine.test.ts
@@ -831,3 +831,72 @@ describe("boot runtime reconciliation", () => {
 		});
 	});
 });
+
+// A draft is a task the user explicitly marked unfinished. The rule lives here,
+// in the pure transition, because every activation path (Run button, board drag,
+// variant spawn, scheduled launch, automation, CLI) funnels through it.
+describe("draft tasks cannot be activated", () => {
+	const draft = () => state("todo", {
+		facts: {
+			hasWorktree: false,
+			projectKind: "git",
+			hasPrIdentity: false,
+			peerReviewEnabled: true,
+			draft: true,
+		},
+	});
+
+	for (const target of ["in-progress", "user-questions", "review-by-ai", "review-by-user", "review-by-colleague"] as const) {
+		it(`refuses a move to ${target}`, () => {
+			const result = transition(draft(), {
+				type: "moveRequested",
+				target: { status: target, customColumnId: null },
+			});
+
+			expect(result.next.column.status).toBe("todo");
+			expect(result.next.runtime.phase).toBe("idle");
+			expect(result.effects).toHaveLength(1);
+			expect(result.effects[0]).toMatchObject({
+				type: "reject",
+				message: expect.stringContaining("draft"),
+			});
+		});
+	}
+
+	it("refuses a launch that carries preparation instructions", () => {
+		const result = transition(draft(), {
+			type: "moveRequested",
+			target: { status: "in-progress", customColumnId: null },
+			runId: "run-1",
+			preparation: {
+				launch: { label: "variant", agentId: "builtin-claude", configId: "claude-auto" },
+				awaitCompletion: false,
+				publishColumn: true,
+			},
+		});
+
+		expect(result.next.column.status).toBe("todo");
+		expect(result.effects.map((e) => e.type)).toEqual(["reject"]);
+	});
+
+	it("still allows a draft to move inside To Do and to be deleted", () => {
+		const toCustomColumn = transition(draft(), {
+			type: "moveRequested",
+			target: { customColumnId: "col-1" },
+		});
+		const deleted = transition(draft(), { type: "deleteRequested" });
+
+		expect(toCustomColumn.effects.some((e) => e.type === "reject")).toBe(false);
+		expect(deleted.effects.some((e) => e.type === "reject")).toBe(false);
+	});
+
+	it("leaves an ordinary To Do task activatable", () => {
+		const result = transition(state("todo"), {
+			type: "moveRequested",
+			target: { status: "in-progress", customColumnId: null },
+		});
+
+		expect(result.next.column.status).toBe("in-progress");
+		expect(result.effects.some((e) => e.type === "prepareTask")).toBe(true);
+	});
+});

--- a/src/bun/lifecycle/events.ts
+++ b/src/bun/lifecycle/events.ts
@@ -24,6 +24,8 @@ export interface LifecycleFacts {
 	hasWorktree: boolean;
 	projectKind: "git" | "virtual";
 	hasPrIdentity: boolean;
+	/** The task is an unfinished draft: no activation path may start it. */
+	draft?: boolean;
 	peerReviewEnabled: boolean;
 	manualCompletion?: boolean;
 	mergeCompletionPrompt?: Task["mergeCompletionPrompt"];

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -1,5 +1,6 @@
 import {
 	ACTIVE_STATUSES as ACTIVE_TASK_STATUSES,
+	DRAFT_TASK_ACTIVATION_ERROR,
 	getAllowedTransitions,
 	isStatusGuardBlocked,
 	MERGE_COMPLETE_ELIGIBLE_STATUSES,
@@ -194,6 +195,16 @@ function moveTransition(
 		};
 	}
 	const needsActivation = !ACTIVE_STATUSES.has(oldStatus) && ACTIVE_STATUSES.has(target.status);
+
+	// A draft is refused here, at the single choke point every activation path
+	// funnels through (Run button, board drag, variant spawn, scheduled launch,
+	// automations, CLI) — UI affordances only mirror this rule.
+	if (needsActivation && state.facts.draft === true) {
+		return {
+			next: state,
+			effects: [effect({ type: "reject", message: DRAFT_TASK_ACTIVATION_ERROR }, "abort")],
+		};
+	}
 
 	if (needsActivation) {
 		const runId = event.runId ?? "pending-run";

--- a/src/bun/lifecycle/state.ts
+++ b/src/bun/lifecycle/state.ts
@@ -64,6 +64,7 @@ export function lifecycleStateFromTask(project: Project, task: Task): LifecycleS
 			hasWorktree: !!task.worktreePath,
 			projectKind: project.kind === "virtual" ? "virtual" : "git",
 			hasPrIdentity: task.prNumber != null,
+			draft: task.draft === true,
 			peerReviewEnabled: project.peerReviewEnabled !== false,
 			manualCompletion: task.manualCompletion === true,
 			mergeCompletionPrompt: task.mergeCompletionPrompt,

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1,5 +1,5 @@
 import type { LaunchVariant, Project, Task, TaskPriority, TaskStatus } from "../../shared/types";
-import { ACTIVE_STATUSES, titleFromDescription } from "../../shared/types";
+import { ACTIVE_STATUSES, DRAFT_TASK_ACTIVATION_ERROR, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import { resolveCompletionRequest } from "../completion-requests";
 import { loadSettings, recordFavoriteUsages } from "../settings";
@@ -15,6 +15,18 @@ function scratchPlaceholder(now: Date = new Date()): string {
 
 function isScratchPlaceholderDescription(description: string): boolean {
 	return /^Scratch — \d{2}:\d{2}$/.test(description.trim());
+}
+
+/**
+ * Title for a draft parked before anything was typed into the description — the
+ * card has to stay recognisable on the board. Unlike the scratch placeholder
+ * this never enters `description`: a draft's description must stay empty so
+ * "Save" remains unavailable until the user actually writes the prompt.
+ */
+function draftPlaceholderTitle(now: Date = new Date()): string {
+	const hh = String(now.getHours()).padStart(2, "0");
+	const mm = String(now.getMinutes()).padStart(2, "0");
+	return `Draft — ${hh}:${mm}`;
 }
 
 export async function handleBellAutoStatus(taskId: string): Promise<void> {
@@ -77,11 +89,12 @@ async function getAllProjectTasks(): Promise<{ projectId: string; tasks: Task[] 
 	return results;
 }
 
-async function createTask(params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string; scratch?: boolean; opsWorkDir?: string; priority?: TaskPriority }): Promise<Task> {
+async function createTask(params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string; scratch?: boolean; draft?: boolean; opsWorkDir?: string; priority?: TaskPriority }): Promise<Task> {
 	log.info("→ createTask", {
 		projectId: params.projectId,
 		requestedStatus: params.status ?? "todo",
 		scratch: params.scratch === true,
+		draft: params.draft === true,
 		descriptionLength: params.description.length,
 		hasExistingBranch: Boolean(params.existingBranch),
 		hasOpsWorkDir: Boolean(params.opsWorkDir),
@@ -89,6 +102,13 @@ async function createTask(params: { projectId: string; description: string; stat
 	});
 	const project = await data.getProject(params.projectId);
 	const isScratch = params.scratch === true;
+	const isDraft = params.draft === true;
+	// A draft is the exact opposite of a scratch task (unfinished vs launch-now)
+	// and can never be created straight into a running column.
+	if (isDraft && isScratch) throw new Error("A task cannot be both a draft and a scratch task");
+	if (isDraft && isActive(params.status ?? "todo")) {
+		throw new Error("A draft task cannot be created into an active status");
+	}
 	// Scratch tasks always start in "todo" with a placeholder title so the
 	// Launch Variants modal can open and let the user pick the agent before
 	// anything is actually spawned. The `scratch: true` flag is persisted so
@@ -99,6 +119,8 @@ async function createTask(params: { projectId: string; description: string; stat
 	const extras: Parameters<typeof data.addTask>[3] = {
 		...(params.existingBranch ? { existingBranch: params.existingBranch } : {}),
 		...(isScratch ? { scratch: true } : {}),
+		...(isDraft ? { draft: true } : {}),
+		...(isDraft && !params.description.trim() ? { title: draftPlaceholderTitle() } : {}),
 		...(params.opsWorkDir ? { opsWorkDir: params.opsWorkDir } : {}),
 		...(params.priority ? { priority: params.priority } : {}),
 	};
@@ -518,26 +540,78 @@ async function addAttempts(params: {
 	return [updatedSource, ...launched];
 }
 
-async function editTask(params: { taskId: string; projectId: string; description: string }): Promise<Task> {
-	log.info("→ editTask", { taskId: params.taskId });
+/**
+ * Single optional-field update for a To Do task: every supplied field is
+ * written, everything else is left untouched. Saving a draft is therefore one
+ * call and one persisted write instead of a create plus best-effort title/label
+ * follow-ups. `draft: false` promotes a draft into an ordinary task and demands
+ * a non-empty description; the reverse direction is refused outright.
+ */
+async function editTask(params: {
+	taskId: string;
+	projectId: string;
+	description?: string;
+	customTitle?: string | null;
+	priority?: TaskPriority;
+	labelIds?: string[];
+	existingBranch?: string | null;
+	draft?: boolean;
+}): Promise<Task> {
+	log.info("→ editTask", { taskId: params.taskId, draft: params.draft });
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
 	if (task.status !== "todo") {
 		throw new Error(`Can only edit tasks in todo status (got ${task.status})`);
 	}
-	const updates: Partial<Task> = { description: params.description };
-	if (
-		task.scratch === true
-		&& params.description.trim()
-		&& !isScratchPlaceholderDescription(params.description)
-	) {
-		updates.scratch = false;
+	if (params.draft === true && task.draft !== true) {
+		throw new Error("A task that is already runnable cannot be turned back into a draft");
 	}
-	if (!task.customTitle) {
-		updates.title = titleFromDescription(params.description);
+
+	const description = params.description ?? task.description;
+	const customTitle = params.customTitle !== undefined
+		? (params.customTitle?.trim() || null)
+		: (task.customTitle ?? null);
+
+	if (params.draft === false && !description.trim()) {
+		throw new Error("A draft needs a description before it can become a runnable task");
 	}
+
+	const updates: Partial<Task> = {};
+	if (params.description !== undefined) {
+		updates.description = params.description;
+		if (
+			task.scratch === true
+			&& params.description.trim()
+			&& !isScratchPlaceholderDescription(params.description)
+		) {
+			updates.scratch = false;
+		}
+	}
+	if (params.customTitle !== undefined) {
+		updates.customTitle = customTitle;
+		// Only the UI reaches this RPC, so a typed title is a real user edit and
+		// must lock the title against future agent renames (issue #583).
+		updates.titleEditedByUser = customTitle !== null;
+		if (task.scratch === true && customTitle !== null) updates.scratch = false;
+	}
+	if (!customTitle && (params.description !== undefined || params.customTitle !== undefined)) {
+		// A draft parked with no description keeps the placeholder title it was
+		// created with, so its card stays recognisable on the board.
+		updates.title = titleFromDescription(description) || task.title || draftPlaceholderTitle();
+	}
+	// Priority is a whole-group property, but a draft is never part of a variant
+	// group (nothing can launch it), so the plain per-task write is correct here.
+	if (params.priority !== undefined) updates.priority = params.priority;
+	if (params.labelIds !== undefined) updates.labelIds = params.labelIds;
+	if (params.existingBranch !== undefined) {
+		updates.existingBranch = params.existingBranch;
+		updates.baseBranch = data.deriveTaskBaseBranch(project, params.existingBranch);
+	}
+	if (params.draft !== undefined) updates.draft = params.draft;
+
 	const updated = await data.updateTask(project, task.id, updates);
-	log.info("← editTask done", { taskId: task.id });
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	log.info("← editTask done", { taskId: task.id, draft: updated.draft === true });
 	return updated;
 }
 
@@ -720,6 +794,9 @@ async function scheduleTaskLaunch(params: {
 	if (task.status !== "todo") {
 		throw new Error(`Task must be in todo status to schedule a launch (got ${task.status})`);
 	}
+	// Refused here as well as in the lifecycle machine: a draft must never carry a
+	// pending scheduledLaunch that would fire while the user is away.
+	if (task.draft === true) throw new Error(DRAFT_TASK_ACTIVATION_ERROR);
 	if (params.variants.length === 0) {
 		throw new Error("Scheduled launch needs at least one variant");
 	}

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -3,6 +3,8 @@ import { handleTask } from "../commands/task";
 import type { CliContext } from "../context";
 import type { ParsedArgs } from "../args";
 import type { Task, CliResponse } from "../../shared/types";
+import { DRAFT_TASK_ACTIVATION_ERROR } from "../../shared/types";
+import { CLI_EXIT_CODE_TASK_IS_DRAFT } from "../../shared/cli-exit-codes";
 
 vi.mock("../stdin", () => ({
 	readStdin: vi.fn(),
@@ -146,6 +148,22 @@ describe("task show", () => {
 	it("exits with usage error when no ID and no context", async () => {
 		await expect(handleTask("show", args(), SOCKET, null)).rejects.toThrow("EXIT_3");
 		expect(stderrOutput).toContain("Usage:");
+	});
+
+	it("marks a draft task so an agent does not start on a half-written prompt", async () => {
+		mockSend.mockResolvedValue(okResp({ ...FAKE_TASK, status: "todo", draft: true }));
+
+		await handleTask("show", args(["aaaaaaaa"]), SOCKET, null);
+
+		expect(stdoutOutput).toMatch(/Draft:\s+yes/);
+	});
+
+	it("does not mention drafts for an ordinary task", async () => {
+		mockSend.mockResolvedValue(okResp(FAKE_TASK));
+
+		await handleTask("show", args(["aaaaaaaa"]), SOCKET, null);
+
+		expect(stdoutOutput).not.toContain("Draft:");
 	});
 
 	it("exits with error on server failure", async () => {
@@ -633,6 +651,15 @@ describe("task move", () => {
 			handleTask("move", args(["aaaaaaaa"], { status: "todo" }), SOCKET, null),
 		).rejects.toThrow("EXIT_1");
 		expect(stderrOutput).toContain("Invalid status transition");
+	});
+
+	it("exits with the draft exit code when the task is a draft", async () => {
+		mockSend.mockResolvedValue(errResp(DRAFT_TASK_ACTIVATION_ERROR));
+
+		await expect(
+			handleTask("move", args(["aaaaaaaa"], { status: "in-progress" }), SOCKET, null),
+		).rejects.toThrow(`EXIT_${CLI_EXIT_CODE_TASK_IS_DRAFT}`);
+		expect(stderrOutput).toContain("draft");
 	});
 
 	it("prints arrow notation with status label", async () => {

--- a/src/cli/__tests__/tasks.test.ts
+++ b/src/cli/__tests__/tasks.test.ts
@@ -105,6 +105,14 @@ describe("tasks list", () => {
 		expect(stdoutOutput).toContain("Agent is Working");
 	});
 
+	it("marks draft tasks in the status column", async () => {
+		mockSend.mockResolvedValue(okResp([{ ...TASKS[0], draft: true }]));
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001" } }, SOCKET, null);
+
+		expect(stdoutOutput).toContain("To Do (draft)");
+	});
+
 	it("auto-detects projectId from context", async () => {
 		mockSend.mockResolvedValue(okResp(TASKS));
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1,6 +1,6 @@
 import type { CliResponse, Task, TaskStatus, TaskHistoryEntry, TaskNote } from "../../shared/types";
-import { STATUS_LABELS, ALL_STATUSES, DEFAULT_PRIORITY, getTaskTitle, getTaskOverview, normalizePriority } from "../../shared/types";
-import { CLI_EXIT_CODE_COMPLETION_DECLINED } from "../../shared/cli-exit-codes";
+import { STATUS_LABELS, ALL_STATUSES, DEFAULT_PRIORITY, DRAFT_TASK_ACTIVATION_ERROR, getTaskTitle, getTaskOverview, normalizePriority } from "../../shared/types";
+import { CLI_EXIT_CODE_COMPLETION_DECLINED, CLI_EXIT_CODE_TASK_IS_DRAFT } from "../../shared/cli-exit-codes";
 import { CODEX_STOP_HOOK_FLAG, CODEX_STOP_HOOK_SUCCESS_JSON, TOLERATE_APP_OFFLINE_FLAG } from "../../shared/agent-hooks";
 import { sendRequest } from "../socket-client";
 import { printDetail, exitError, exitUsage } from "../output";
@@ -88,6 +88,10 @@ function printTask(task: Task, opts: ShowTaskOptions = {}): void {
 		["Status:", STATUS_LABELS[task.status] || task.status],
 		["Priority:", task.priority ?? DEFAULT_PRIORITY],
 	];
+
+	// Drafts are deliberately unfinished — say so before an agent reads the
+	// half-written description and starts guessing.
+	if (task.draft === true) fields.push(["Draft:", "yes — cannot be started until the user finishes it"]);
 
 	if (task.branchName) fields.push(["Branch:", task.branchName]);
 	if (task.worktreePath) fields.push(["Worktree:", task.worktreePath]);
@@ -332,7 +336,18 @@ async function moveTask(args: ParsedArgs, socketPath: string, context: CliContex
 	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "task.move", params);
-	if (!resp.ok) exitError(resp.error || "Failed to move task");
+	if (!resp.ok) {
+		// A draft was deliberately parked by the human — give it its own exit code
+		// so an agent can tell "not ready yet" apart from a real failure.
+		if (resp.error?.includes(DRAFT_TASK_ACTIVATION_ERROR)) {
+			exitError(
+				resp.error,
+				"Ask the user to finish the draft's description and save it as a normal task before starting work.",
+				CLI_EXIT_CODE_TASK_IS_DRAFT,
+			);
+		}
+		exitError(resp.error || "Failed to move task");
+	}
 
 	const task = resp.data as Task;
 	if (codexStopHook) {

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -82,7 +82,9 @@ export async function handleTasks(
 				return [
 					String(t.seq),
 					t.id.slice(0, 8),
-					STATUS_LABELS[t.status] || t.status,
+					// Drafts share the To Do column but are not runnable — mark them
+					// here so a listing never reads as "ready to pick up".
+					`${STATUS_LABELS[t.status] || t.status}${t.draft === true ? " (draft)" : ""}`,
 					title.length > 60 ? title.slice(0, 57) + "..." : title,
 				];
 			}),

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -22,6 +22,9 @@ import { useFocusTrap } from "../utils/useFocusTrap";
 import HelpSpot from "./HelpSpot";
 import Select from "./Select";
 
+/** "draft" parks the task as an unfinished draft; the rest are the launch exits. */
+type SubmitMode = "save" | "run" | "scratch" | "draft";
+
 interface ProjectCurrentBranchInfo {
 	branch: string | null;
 	isBaseBranch: boolean;
@@ -35,9 +38,19 @@ interface CreateTaskModalProps {
 	onClose: () => void;
 	onCreateAndRun?: (task: Task, project: Project) => void;
 	onOpenAutomations?: (project: Project) => void;
+	/**
+	 * Reopens this popup on an existing draft instead of creating a task: every
+	 * field is prefilled from the draft and the exits become Save as draft /
+	 * Save / Save and Run.
+	 */
+	draftTask?: Task;
 }
 
-function CreateTaskModal({ project: initialProject, projects, dispatch, onClose, onCreateAndRun, onOpenAutomations }: CreateTaskModalProps) {
+function sameLabelIds(left: string[], right: string[]): boolean {
+	return left.length === right.length && left.every((id) => right.includes(id));
+}
+
+function CreateTaskModal({ project: initialProject, projects, dispatch, onClose, onCreateAndRun, onOpenAutomations, draftTask }: CreateTaskModalProps) {
 	const t = useT();
 	const trapRef = useFocusTrap<HTMLDivElement>();
 	const availableProjects = useMemo(() => {
@@ -47,22 +60,28 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		}
 		return orderProjectsForDisplay(visibleProjects);
 	}, [initialProject, projects]);
+	// Editing an existing draft: the task already belongs to a board, so the
+	// project is fixed and every field starts from what the user had saved.
+	const isDraftEdit = !!draftTask;
 	const [selectedProjectId, setSelectedProjectId] = useState(initialProject.id);
 	const selectedProject = availableProjects.find((candidate) => candidate.id === selectedProjectId) ?? initialProject;
 	const project = selectedProject;
-	const [description, setDescription] = useState("");
+	const [description, setDescription] = useState(draftTask?.description ?? "");
 	const [creating, setCreating] = useState(false);
-	const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
-	const [priority, setPriority] = useState<TaskPriority>(DEFAULT_PRIORITY);
+	const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>(draftTask?.labelIds ?? []);
+	const [priority, setPriority] = useState<TaskPriority>(draftTask?.priority ?? DEFAULT_PRIORITY);
 	const [labelPickerOpen, setLabelPickerOpen] = useState(false);
 	const [confirmDiscard, setConfirmDiscard] = useState(false);
-	const [customTitle, setCustomTitle] = useState<string | null>(null);
+	const [customTitle, setCustomTitle] = useState<string | null>(draftTask?.customTitle ?? null);
 	const [editingTitle, setEditingTitle] = useState(false);
-	const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
+	const [selectedBranch, setSelectedBranch] = useState<string | null>(draftTask?.existingBranch ?? null);
+	// Whether the user actually touched the branch picker. The initial auto-fill of
+	// the project's current branch must not count as "the form has content".
+	const [branchTouched, setBranchTouched] = useState(false);
 	const [projectCurrentBranch, setProjectCurrentBranch] = useState<ProjectCurrentBranchInfo | null>(null);
 	const [checkedProjectCurrentBranch, setCheckedProjectCurrentBranch] = useState(false);
 	const [pendingBranchChoice, setPendingBranchChoice] = useState<string | null>(null);
-	const [pendingSubmitMode, setPendingSubmitMode] = useState<"save" | "run" | "scratch" | null>(null);
+	const [pendingSubmitMode, setPendingSubmitMode] = useState<SubmitMode | null>(null);
 	const [reviewMode, setReviewMode] = useState(false);
 	const [dismissedPrUrl, setDismissedPrUrl] = useState<string | null>(null);
 	const [prApplying, setPrApplying] = useState(false);
@@ -84,7 +103,9 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		try {
 			const result = await api.request.getProjectCurrentBranch({ projectId: project.id });
 			if (requestId !== projectBranchRequestRef.current) return null;
-			if (!result.isBaseBranch && result.branch) {
+			// An existing draft already carries the branch the user chose (including a
+			// deliberate "base branch" = null), so never auto-fill over it.
+			if (!isDraftEdit && !result.isBaseBranch && result.branch) {
 				setSelectedBranch((prev) => prev ?? result.branch);
 			}
 			setProjectCurrentBranch(result);
@@ -98,7 +119,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 				setCheckedProjectCurrentBranch(true);
 			}
 		}
-	}, [project.id]);
+	}, [project.id, isDraftEdit]);
 
 	function handleProjectChange(projectId: string) {
 		if (creating || projectId === selectedProjectId) return;
@@ -255,13 +276,29 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		}
 	}
 
+	// "Save as draft" needs at least one filled field, so the board never fills up
+	// with empty ghost cards.
+	const hasAnyInput = !!description.trim()
+		|| !!customTitle
+		|| selectedLabelIds.length > 0
+		|| priority !== DEFAULT_PRIORITY
+		|| branchTouched;
+
+	const draftDirty = !!draftTask && (
+		description !== (draftTask.description ?? "")
+		|| (customTitle ?? null) !== (draftTask.customTitle ?? null)
+		|| priority !== (draftTask.priority ?? DEFAULT_PRIORITY)
+		|| !sameLabelIds(selectedLabelIds, draftTask.labelIds ?? [])
+		|| (selectedBranch ?? null) !== (draftTask.existingBranch ?? null)
+	);
+
 	function handleRequestClose() {
 		if (pendingBranchChoice) {
 			setPendingBranchChoice(null);
 			setPendingSubmitMode(null);
 			return;
 		}
-		if (description.trim()) {
+		if (isDraftEdit ? draftDirty : !!description.trim()) {
 			setConfirmDiscard(true);
 		} else {
 			onClose();
@@ -289,9 +326,43 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		}
 	});
 
-	async function createTaskWithBranch(branch: string | null, mode: "save" | "run" | "scratch") {
+	// Saving an existing draft is ONE editTask call — one atomic write for the
+	// description, title, priority, labels, branch and the draft flag itself.
+	async function saveExistingDraft(branch: string | null, mode: SubmitMode) {
+		if (!draftTask) return;
 		const trimmed = description.trim();
-		if (mode !== "scratch" && !trimmed) return;
+		const keepDraft = mode === "draft";
+		if (!keepDraft && !trimmed) return;
+		if (creating) return;
+		setCreating(true);
+		try {
+			const updated = await api.request.editTask({
+				taskId: draftTask.id,
+				projectId: draftTask.projectId,
+				description: trimmed,
+				customTitle,
+				priority,
+				labelIds: selectedLabelIds,
+				existingBranch: branch,
+				draft: keepDraft,
+			});
+			dispatch({ type: "updateTask", task: updated });
+			trackEvent("task_edited", { project_id: project.id, source: keepDraft ? "draft_save" : "draft_promote" });
+			if (mode === "run" && onCreateAndRun) {
+				onCreateAndRun(updated, project);
+			} else {
+				onClose();
+			}
+		} catch (err) {
+			toast.error(t("createTask.draftSaveFailed", { error: String(err) }));
+			setCreating(false);
+		}
+	}
+
+	async function createTaskWithBranch(branch: string | null, mode: SubmitMode) {
+		const trimmed = description.trim();
+		if (mode !== "scratch" && mode !== "draft" && !trimmed) return;
+		if (mode === "draft" && !hasAnyInput) return;
 		if (creating) return;
 		setCreating(true);
 		try {
@@ -301,6 +372,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 				// we still send an empty string here to match the RPC shape.
 				description: mode === "scratch" ? "" : trimmed,
 				...(mode === "scratch" ? { scratch: true } : {}),
+				...(mode === "draft" ? { draft: true } : {}),
 				...(branch ? { existingBranch: branch } : {}),
 				...(isVirtual && opsFolder ? { opsWorkDir: opsFolder } : {}),
 				...(priority !== DEFAULT_PRIORITY ? { priority } : {}),
@@ -346,6 +418,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 				project_id: project.id,
 				...(mode === "run" ? { source: "create_and_run" } : {}),
 				...(mode === "scratch" ? { source: "scratch" } : {}),
+				...(mode === "draft" ? { source: "draft" } : {}),
 			});
 			if ((mode === "run" || mode === "scratch") && onCreateAndRun) {
 				onCreateAndRun(task, project);
@@ -358,16 +431,32 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		}
 	}
 
-	async function handleSubmit(mode: "save" | "run" | "scratch") {
+	async function commit(branch: string | null, mode: SubmitMode) {
+		if (isDraftEdit) {
+			await saveExistingDraft(branch, mode);
+			return;
+		}
+		await createTaskWithBranch(branch, mode);
+	}
+
+	async function handleSubmit(mode: SubmitMode) {
 		const trimmed = description.trim();
 		if (creating) return;
-		if (mode !== "scratch" && !trimmed) return;
+		if (mode !== "scratch" && mode !== "draft" && !trimmed) return;
+		if (mode === "draft" && !(isDraftEdit ? true : hasAnyInput)) return;
 		if (mode === "run" && !onCreateAndRun) return;
 		if (mode === "scratch" && !onCreateAndRun) return;
 
-		// Virtual ops have no git branch — create directly with no branch choice.
+		// Virtual ops have no git branch — commit directly with no branch choice.
 		if (isVirtual) {
-			await createTaskWithBranch(null, mode);
+			await commit(null, mode);
+			return;
+		}
+
+		// Parking a draft launches nothing, so the "which branch?" question is
+		// deferred to the moment the draft is actually promoted.
+		if (mode === "draft") {
+			await commit(selectedBranch, mode);
 			return;
 		}
 
@@ -396,7 +485,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 			return;
 		}
 
-		await createTaskWithBranch(effectiveBranch, mode);
+		await commit(effectiveBranch, mode);
 	}
 
 	async function handleCreate() {
@@ -411,6 +500,10 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		await handleSubmit("scratch");
 	}
 
+	async function handleSaveAsDraft() {
+		await handleSubmit("draft");
+	}
+
 	function dismissBranchChoice() {
 		setPendingBranchChoice(null);
 		setPendingSubmitMode(null);
@@ -420,7 +513,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 		const mode = pendingSubmitMode;
 		dismissBranchChoice();
 		if (!mode) return;
-		void createTaskWithBranch(branch, mode);
+		void commit(branch, mode);
 	}
 
 	function toggleLabelId(labelId: string) {
@@ -440,7 +533,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 				<div className="flex items-center justify-between">
 					<div className="flex items-center gap-1.5">
 						<h2 className="text-fg text-lg font-semibold">
-							{t("createTask.title")}
+							{isDraftEdit ? t("createTask.editDraftTitle") : t("createTask.title")}
 						</h2>
 						<HelpSpot topicId="modal.create-task" />
 					</div>
@@ -457,18 +550,26 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 
 				{/* Project context — defaults to the board that opened this modal. */}
 				<div className="space-y-1.5">
-					<label htmlFor="create-task-project" className="text-fg-2 text-sm font-medium">
+					<label htmlFor={isDraftEdit ? undefined : "create-task-project"} className="text-fg-2 text-sm font-medium">
 						{t("createTask.projectLabel")}
 					</label>
-					<Select
-						id="create-task-project"
-						value={project.id}
-						options={availableProjects.map((candidate) => ({
-							value: candidate.id,
-							label: isBuiltinOpsProject(candidate) ? t("ops.boardName") : candidate.name,
-						}))}
-						onChange={handleProjectChange}
-					/>
+					{isDraftEdit ? (
+						/* The draft already lives on a board — moving it between projects is
+						   the card's own action, not a field of this popup. */
+						<div className="px-3 py-2 bg-raised border border-edge rounded-xl text-fg-2 text-sm truncate">
+							{isBuiltinOpsProject(project) ? t("ops.boardName") : project.name}
+						</div>
+					) : (
+						<Select
+							id="create-task-project"
+							value={project.id}
+							options={availableProjects.map((candidate) => ({
+								value: candidate.id,
+								label: isBuiltinOpsProject(candidate) ? t("ops.boardName") : candidate.name,
+							}))}
+							onChange={handleProjectChange}
+						/>
+					)}
 				</div>
 
 				{/* Description textarea + drop zone */}
@@ -565,7 +666,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 						<span className="text-[0.6875rem] text-accent animate-pulse">{t(pasteKind === "text" ? "paste.savingText" : "images.pasting")}</span>
 					)}
 					<ImageAttachmentsStrip text={description} onRemovePath={handleRemovePath} />
-					{generatedTitle && (
+					{(generatedTitle || customTitle) && (
 						<div className="text-xs">
 							{editingTitle ? (
 								<div className="flex items-center gap-1.5">
@@ -750,6 +851,7 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 						selectedBranch={selectedBranch}
 						onSelectBranch={(branch) => {
 							setSelectedBranch(branch);
+							setBranchTouched(true);
 							// Turn off review mode when branch is deselected
 							if (!branch && reviewMode) {
 								handleReviewModeChange(false);
@@ -784,7 +886,9 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 					) : (
 						<>
 							<div className="flex flex-wrap items-center justify-end gap-2">
-								{onCreateAndRun && (
+								{/* Scratch is the opposite of a draft (launch now, no prompt) and
+								    makes no sense on a task that already exists. */}
+								{onCreateAndRun && !isDraftEdit && (
 									<div className="mr-auto flex flex-col items-start gap-0.5">
 										<button
 											onClick={handleCreateScratch}
@@ -805,6 +909,18 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 										</span>
 									</div>
 								)}
+								{/* Quietest of the group — parking a draft must never look like the
+								    primary action. Available with an empty description so a chosen
+								    branch, priority or label set is not lost. */}
+								<button
+									onClick={handleSaveAsDraft}
+									disabled={creating || !(isDraftEdit || hasAnyInput)}
+									title={t("createTask.saveAsDraftHint")}
+									data-testid="create-task-save-draft"
+									className={`px-3 py-1.5 text-fg-3 text-xs font-medium rounded-lg border border-dashed border-edge-active hover:text-fg hover:bg-fg/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${isDraftEdit ? "mr-auto" : ""}`}
+								>
+									{t("createTask.saveAsDraft")}
+								</button>
 								{onCreateAndRun && (
 									<button
 										onClick={handleCreateAndRun}

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -865,15 +865,25 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, onClose,
 			{/* Actions */}
 				<div className="space-y-2.5 pt-1">
 					{confirmDiscard ? (
-						<div className="flex items-center justify-between gap-2 bg-danger/10 border border-danger/30 rounded-xl px-3 py-2.5">
+						<div className="flex flex-wrap items-center justify-between gap-2 bg-danger/10 border border-danger/30 rounded-xl px-3 py-2.5">
 							<span className="text-fg-2 text-sm">{t("createTask.discardConfirm")}</span>
-							<div className="flex gap-2 shrink-0">
+							<div className="flex flex-wrap gap-2 shrink-0">
 								<button
 									ref={keepEditingRef}
 									onClick={() => setConfirmDiscard(false)}
 									className="px-3 py-1 text-fg-3 text-sm hover:text-fg transition-colors rounded-lg focus:outline-none focus:ring-2 focus:ring-edge-active focus:text-fg"
 								>
 									{t("createTask.keepEditing")}
+								</button>
+								{/* The one moment work actually gets lost — parking the draft is the
+								    likely intent here, so it leads over the destructive exit. */}
+								<button
+									onClick={handleSaveAsDraft}
+									disabled={creating || !(isDraftEdit || hasAnyInput)}
+									data-testid="discard-save-draft"
+									className="px-3 py-1 bg-accent text-white text-sm font-medium rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+								>
+									{t("createTask.saveAsDraft")}
 								</button>
 								<button
 									onClick={onClose}

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -12,6 +12,7 @@ import { useT, statusKey, statusDescKey } from "../i18n";
 import { api } from "../rpc";
 import KanbanColumn from "./KanbanColumn";
 import LaunchVariantsModal from "./LaunchVariantsModal";
+import CreateTaskModal from "./CreateTaskModal";
 import { sortTasksForColumn } from "./sortTasks";
 import LabelFilterBar from "./LabelFilterBar";
 import { matchesTaskQuery } from "../utils/taskSearch";
@@ -118,6 +119,9 @@ function KanbanBoard({
 	});
 	const [launchModal, setLaunchModal] = useState<{ task: Task; targetStatus: TaskStatus; mode?: "spawn" | "addAttempts" } | null>(null);
 	const [dragFromStatus, setDragFromStatus] = useState<TaskStatus | null>(null);
+	// Draft being edited: reopens the New Task popup prefilled from the card.
+	const [editDraftTaskId, setEditDraftTaskId] = useState<string | null>(null);
+	const [dragFromDraft, setDragFromDraft] = useState(false);
 	const [dragFromCustomColumnId, setDragFromCustomColumnId] = useState<string | null>(null);
 	const [moveOrderMap, setMoveOrderMap] = useState<Map<string, number>>(new Map());
 	const [searchQuery, setSearchQuery] = useState("");
@@ -249,6 +253,7 @@ function KanbanBoard({
 		function handleDragEnd() {
 			setDragFromStatus(null);
 			setDragFromCustomColumnId(null);
+			setDragFromDraft(false);
 			setDraggedTaskId(null);
 		}
 		window.addEventListener("dragend", handleDragEnd);
@@ -262,6 +267,7 @@ function KanbanBoard({
 		if (task) {
 			setDragFromStatus(task.status);
 			setDragFromCustomColumnId(task.customColumnId ?? null);
+			setDragFromDraft(task.draft === true);
 			setDraggedTaskId(taskId);
 		}
 	}
@@ -269,8 +275,16 @@ function KanbanBoard({
 	async function handleTaskDrop(taskId: string, targetStatus: TaskStatus) {
 		setDragFromStatus(null);
 		setDragFromCustomColumnId(null);
+		setDragFromDraft(false);
 		const task = tasks.find((t) => t.id === taskId);
 		if (!task) return;
+
+		// Columns already refuse a draft as a drop target; this is the last-resort
+		// guard for a drop that still reaches the board (keyboard DnD, stale state).
+		if (task.draft === true && targetStatus !== "todo") {
+			toast.error(t("kanban.draftNotDroppable"), { taskId: task.id });
+			return;
+		}
 
 		// If already in target status and no custom column, nothing to do
 		if (task.status === targetStatus && !task.customColumnId) return;
@@ -301,8 +315,13 @@ function KanbanBoard({
 	async function handleTaskDropToCustomColumn(taskId: string, customColumnId: string) {
 		setDragFromStatus(null);
 		setDragFromCustomColumnId(null);
+		setDragFromDraft(false);
 		const task = tasks.find((t) => t.id === taskId);
 		if (!task || task.customColumnId === customColumnId) return;
+		if (task.draft === true) {
+			toast.error(t("kanban.draftNotDroppable"), { taskId: task.id });
+			return;
+		}
 
 		// Optimistic update
 		const optimisticTask = { ...task, customColumnId };
@@ -569,6 +588,12 @@ function KanbanBoard({
 		return null;
 	}, [currentTip, displayTasks, collapseState]);
 
+	// Resolved from the live task list, so the popup closes by itself if the draft
+	// is promoted or deleted from somewhere else.
+	const editDraftTask = editDraftTaskId
+		? tasks.find((task) => task.id === editDraftTaskId && task.draft === true) ?? null
+		: null;
+
 	const orderedColumns = getOrderedColumns();
 	const handleTipChanged = applyTipState;
 
@@ -603,6 +628,8 @@ function KanbanBoard({
 		onReorderTask: handleReorderTask,
 		dragFromStatus,
 		dragFromCustomColumnId,
+		dragFromDraft,
+		onEditDraft: (task: Task) => setEditDraftTaskId(task.id),
 		onDragStart: handleDragStart,
 		onTaskMoved: recordMove,
 		bellCounts,
@@ -724,6 +751,18 @@ function KanbanBoard({
 				</div>
 			)}
 
+			{editDraftTask && (
+				<CreateTaskModal
+					project={project}
+					dispatch={dispatch}
+					draftTask={editDraftTask}
+					onClose={() => setEditDraftTaskId(null)}
+					onCreateAndRun={(task) => {
+						setEditDraftTaskId(null);
+						setLaunchModal({ task, targetStatus: "in-progress" });
+					}}
+				/>
+			)}
 			{launchModal && (
 				<LaunchVariantsModal
 					task={launchModal.task}

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -39,6 +39,8 @@ interface KanbanColumnProps {
 	onReorderTask: (taskId: string, targetIndex: number) => void;
 	dragFromStatus: TaskStatus | null;
 	dragFromCustomColumnId?: string | null;
+	/** The card being dragged is an unfinished draft: only To Do may accept it. */
+	dragFromDraft?: boolean;
 	onDragStart: (taskId: string) => void;
 	onTaskMoved: (taskId: string) => void;
 	bellCounts: Map<string, number>;
@@ -62,6 +64,8 @@ interface KanbanColumnProps {
 	// PR numbers for task cards
 	taskPrMap?: Map<string, TaskPRBadgeInfo>;
 	onOpenUnresolvedComments?: (task: Task) => void;
+	/** Reopens the New Task popup on a draft card. */
+	onEditDraft?: (task: Task) => void;
 	// Feature discovery tip
 	tip?: Tip | null;
 	tipState?: TipState;
@@ -97,6 +101,7 @@ function KanbanColumn({
 	onReorderTask,
 	dragFromStatus,
 	dragFromCustomColumnId,
+	dragFromDraft = false,
 	onDragStart,
 	onTaskMoved,
 	bellCounts,
@@ -110,6 +115,7 @@ function KanbanColumn({
 	siblingMap,
 	taskPrMap,
 	onOpenUnresolvedComments,
+	onEditDraft,
 	isCustomColumn,
 	customColumnId,
 	colorOverride,
@@ -230,12 +236,16 @@ function KanbanColumn({
 		? customColumnId !== undefined && dragFromCustomColumnId === customColumnId
 		: dragFromStatus === status && (dragFromCustomColumnId === null || dragFromCustomColumnId === undefined);
 
+	// A draft may be reordered inside To Do but never dragged out of it — the
+	// mouse must not become a loophole around the non-runnable guarantee.
+	const draftBlocksDrop = dragFromDraft && !(!isCustomColumn && status === "todo");
+
 	// Can this column accept a cross-column drop?
-	const isCrossColumnTarget = isCustomColumn
+	const isCrossColumnTarget = !draftBlocksDrop && (isCustomColumn
 		// Custom columns accept drops from any column except themselves
 		? (dragFromStatus !== null || dragFromCustomColumnId !== null) && dragFromCustomColumnId !== customColumnId
 		// Built-in columns use transition logic; also accept from custom columns (underlying status governs)
-		: dragFromStatus !== null && getAllowedTransitions(dragFromStatus).includes(status);
+		: dragFromStatus !== null && getAllowedTransitions(dragFromStatus).includes(status));
 
 	// Clear dropIndex when drag ends globally
 	useEffect(() => {
@@ -609,6 +619,7 @@ function KanbanColumn({
 							siblingMap={siblingMap}
 							prInfo={taskPrMap?.get(task.id)}
 							onOpenUnresolvedComments={onOpenUnresolvedComments}
+							onEditDraft={onEditDraft}
 						/>
 					</div>
 				))}

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -68,9 +68,11 @@ interface TaskCardProps {
 	prInfo?: TaskPRBadgeInfo;
 	/** Opens the selected task's diff at its first unresolved review thread. */
 	onOpenUnresolvedComments?: (task: Task) => void;
+	/** Reopens the New Task popup on a draft card instead of the detail modal. */
+	onEditDraft?: (task: Task) => void;
 }
 
-function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, bellReasons, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo, onOpenUnresolvedComments }: TaskCardProps) {
+function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants, onAddAttempts, onDragStart: onDragStartProp, onTaskMoved, resourceUsage, bellCount = 0, bellReasons, ports, isActiveInSplit = false, isMoving: isMovingProp = false, onSetMoving, siblingMap, prInfo, onOpenUnresolvedComments, onEditDraft }: TaskCardProps) {
 	const t = useT();
 	const statusColors = useStatusColors();
 	const narrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
@@ -111,6 +113,8 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const isShuttingDown = task.shuttingDown === true;
 	const isDisabled = moving || isMovingProp || isPreparing || cancellingPreparation || isShuttingDown;
 	const isTodo = task.status === "todo";
+	// An unfinished draft: not runnable, and a click reopens the New Task popup.
+	const isDraft = task.draft === true;
 	const isCancelled = task.status === "cancelled";
 	const isActive = ACTIVE_STATUSES.includes(task.status);
 	const isCompleting = (moving || isMovingProp) && (task.status === "completed" || task.status === "cancelled");
@@ -282,6 +286,12 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		// Intercept: todo → active status opens the LaunchVariantsModal
 		if (task.status === "todo" && ACTIVE_STATUSES.includes(newStatus)) {
 			setMenuOpen(false);
+			// A draft would be refused by the lifecycle machine at the end of the
+			// launch flow — say so now instead of walking the user through it.
+			if (isDraft) {
+				toast.error(t("kanban.draftNotDroppable"), { taskId: task.id });
+				return;
+			}
 			onLaunchVariants(task, newStatus);
 			return;
 		}
@@ -394,6 +404,10 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		// the previously-active task's terminal on screen.
 		if (isDisabled && !isPreparing) return;
 		if (cancellingPreparation) return;
+		if (isDraft && onEditDraft && !menuOpen) {
+			onEditDraft(task);
+			return;
+		}
 		if (isActive && !menuOpen) {
 			preview.close();
 			const openMode = getTaskOpenMode();
@@ -446,6 +460,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	}
 
 	function handleTitleClick(e: React.MouseEvent) {
+		if (isDraft && onEditDraft) {
+			e.stopPropagation();
+			onEditDraft(task);
+			return;
+		}
 		if (isTodo) {
 			e.stopPropagation();
 			setDetailOpen(true);
@@ -597,7 +616,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			onContextMenu={handleContextMenu}
 			onMouseEnter={handleCardMouseEnter}
 			onMouseLeave={handleCardMouseLeave}
-			className={`group relative p-3.5 glass-card rounded-xl transition-all border border-l-[3px] ${isActiveInSplit ? "border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/20" : "border-transparent"} ${
+			className={`group relative p-3.5 glass-card rounded-xl transition-all border border-l-[3px] ${isDraft ? "border-dashed" : ""} ${isActiveInSplit ? "border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/20" : isDraft ? "border-edge-active" : "border-transparent"} ${
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25"
@@ -726,6 +745,15 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				<div className="mb-1 flex items-center gap-1.5">
 					<PriorityBadge priority={task.priority} onChange={handleSetPriority} />
 					<span className="text-[0.625rem] text-fg-muted font-mono">#{task.seq}</span>
+					{isDraft && (
+						<span
+							data-testid="task-card-draft-badge"
+							title={t("task.draftHint")}
+							className="inline-flex items-center rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-3"
+						>
+							{t("task.draftBadge")}
+						</span>
+					)}
 				</div>
 			)}
 
@@ -1073,8 +1101,9 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					</span>
 				)}
 
-				{/* Run button for TODO cards — right-aligned */}
-				{isTodo && (
+				{/* Run button for TODO cards — right-aligned. A draft has nothing to run
+				    yet; the lifecycle machine would refuse the launch anyway. */}
+				{isTodo && !isDraft && (
 					<>
 						<div className="flex-1" />
 						<Tooltip content={t("task.run")} detail={t("ttip.task.run")}>

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../../rpc", () => ({
 	request: {
 			createTask: vi.fn(),
 			renameTask: vi.fn(),
+			editTask: vi.fn(),
 			listBranches: vi.fn(),
 			fetchBranches: vi.fn(),
 			setTaskLabels: vi.fn(),
@@ -81,6 +82,7 @@ function renderModal(props: {
 	onCreateAndRun?: (task: Task) => void;
 	project?: Project;
 	projects?: Project[];
+	draftTask?: Task;
 } = {}) {
 	return render(
 		<I18nProvider>
@@ -90,6 +92,7 @@ function renderModal(props: {
 				dispatch={props.dispatch ?? vi.fn()}
 				onClose={props.onClose ?? vi.fn()}
 				onCreateAndRun={props.onCreateAndRun}
+				draftTask={props.draftTask}
 			/>
 		</I18nProvider>,
 	);
@@ -1490,5 +1493,172 @@ describe("CreateTaskModal — virtual (Operations) project", () => {
 		await waitFor(() => {
 			expect(mockedApi.request.createTask).toHaveBeenCalledWith({ projectId: "p1", description: "Backup prod" });
 		});
+	});
+});
+
+// ============================================================================
+// Save as draft — the fourth exit of the New Task popup, and the draft-edit mode
+// it reopens into.
+// ============================================================================
+
+const draftTask: Task = {
+	...mockTask,
+	id: "draft-1",
+	title: "Draft — 09:12",
+	description: "",
+	draft: true,
+	priority: "P1",
+	labelIds: ["l1"],
+	customTitle: "Half an idea",
+	existingBranch: "feature/x",
+};
+
+describe("CreateTaskModal — Save as draft (create mode)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getProjectCurrentBranch.mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false, behindOrigin: 0 });
+	});
+
+	it("refuses to save an untouched popup, and enables once any field is filled", async () => {
+		renderModal();
+		const button = screen.getByTestId("create-task-save-draft");
+		expect(button).toBeDisabled();
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "half a thought");
+
+		expect(button).toBeEnabled();
+	});
+
+	it("is available with an empty description once a priority was picked", async () => {
+		renderModal();
+		expect(screen.getByTestId("create-task-save-draft")).toBeDisabled();
+
+		await userEvent.click(screen.getByLabelText(/^Priority P3/));
+		await userEvent.click(screen.getByRole("menuitemradio", { name: /^P0/ }));
+
+		expect(screen.getByTestId("create-task-save-draft")).toBeEnabled();
+	});
+
+	it("creates the task as a draft and closes without launching", async () => {
+		const onClose = vi.fn();
+		const onCreateAndRun = vi.fn();
+		mockedApi.request.createTask.mockResolvedValue({ ...mockTask, draft: true, description: "half a thought" });
+		renderModal({ onClose, onCreateAndRun });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "half a thought");
+		await userEvent.click(screen.getByTestId("create-task-save-draft"));
+
+		await waitFor(() => {
+			expect(mockedApi.request.createTask).toHaveBeenCalledWith(expect.objectContaining({
+				description: "half a thought",
+				draft: true,
+			}));
+		});
+		expect(onCreateAndRun).not.toHaveBeenCalled();
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
+	});
+});
+
+describe("CreateTaskModal — draft-edit mode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getProjectCurrentBranch.mockResolvedValue({ branch: "other", isBaseBranch: false, isDirty: false, behindOrigin: 0 });
+	});
+
+	it("prefills every field the user had entered", async () => {
+		renderModal({ draftTask, onCreateAndRun: vi.fn() });
+
+		expect(screen.getByText("Edit Draft")).toBeTruthy();
+		expect(screen.getByText("Half an idea")).toBeTruthy();
+		expect(screen.getByText("P1")).toBeTruthy();
+		// The draft's own branch must survive — never overwritten by the project's
+		// current branch auto-fill.
+		await waitFor(() => expect(screen.getByText("feature/x")).toBeTruthy());
+	});
+
+	it("offers Save as draft / Save / Save & Start and hides Scratch", () => {
+		renderModal({ draftTask, onCreateAndRun: vi.fn() });
+
+		expect(screen.getByTestId("create-task-save-draft")).toBeEnabled();
+		expect(screen.queryByRole("button", { name: /Scratch Task/i })).toBeNull();
+		// Empty description → nothing may make it runnable yet.
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: /Save & Start/i })).toBeDisabled();
+	});
+
+	it("enables Save once the description is non-empty", async () => {
+		renderModal({ draftTask, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "Now it is written");
+
+		expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+	});
+
+	it("saves the whole draft in one editTask call and keeps it a draft", async () => {
+		const dispatch = vi.fn();
+		mockedApi.request.editTask.mockResolvedValue({ ...draftTask, description: "more words" });
+		renderModal({ draftTask, dispatch, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "more words");
+		await userEvent.click(screen.getByTestId("create-task-save-draft"));
+
+		await waitFor(() => {
+			expect(mockedApi.request.editTask).toHaveBeenCalledTimes(1);
+			expect(mockedApi.request.editTask).toHaveBeenCalledWith({
+				taskId: "draft-1",
+				projectId: "p1",
+				description: "more words",
+				customTitle: "Half an idea",
+				priority: "P1",
+				labelIds: ["l1"],
+				existingBranch: "feature/x",
+				draft: true,
+			});
+		});
+		expect(dispatch).toHaveBeenCalledWith({ type: "updateTask", task: expect.objectContaining({ draft: true }) });
+	});
+
+	it("promotes the draft on Save", async () => {
+		mockedApi.request.editTask.mockResolvedValue({ ...draftTask, draft: false, description: "written" });
+		renderModal({ draftTask, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "written");
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(mockedApi.request.editTask).toHaveBeenCalledWith(expect.objectContaining({ draft: false }));
+		});
+	});
+
+	it("hands the promoted task to the launch flow on Save & Start", async () => {
+		const onCreateAndRun = vi.fn();
+		const promoted = { ...draftTask, draft: false, description: "written" };
+		mockedApi.request.editTask.mockResolvedValue(promoted);
+		renderModal({ draftTask, onCreateAndRun });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "written");
+		await userEvent.click(screen.getByRole("button", { name: /Save & Start/i }));
+
+		await waitFor(() => expect(onCreateAndRun).toHaveBeenCalledWith(promoted, mockProject));
+	});
+
+	it("asks before discarding unsaved edits to the draft", async () => {
+		const onClose = vi.fn();
+		renderModal({ draftTask, onClose, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "unsaved");
+		await userEvent.click(screen.getByLabelText("Close"));
+
+		expect(screen.getByText(/Discard changes/i)).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it("closes straight away when nothing was edited", async () => {
+		const onClose = vi.fn();
+		renderModal({ draftTask, onClose, onCreateAndRun: vi.fn() });
+
+		await userEvent.click(screen.getByLabelText("Close"));
+
+		expect(onClose).toHaveBeenCalled();
 	});
 });

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -1649,7 +1649,7 @@ describe("CreateTaskModal — draft-edit mode", () => {
 		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "unsaved");
 		await userEvent.click(screen.getByLabelText("Close"));
 
-		expect(screen.getByText(/Discard changes/i)).toBeTruthy();
+		expect(screen.getByText(/Unsaved changes/i)).toBeTruthy();
 		expect(onClose).not.toHaveBeenCalled();
 	});
 
@@ -1660,5 +1660,60 @@ describe("CreateTaskModal — draft-edit mode", () => {
 		await userEvent.click(screen.getByLabelText("Close"));
 
 		expect(onClose).toHaveBeenCalled();
+	});
+});
+
+// The discard bar is the one moment work actually gets lost, so it offers the
+// draft as a way out instead of only "lose it or keep typing".
+describe("CreateTaskModal — Save as draft from the discard confirmation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedApi.request.getProjectCurrentBranch.mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false, behindOrigin: 0 });
+	});
+
+	it("offers all three exits when closing a half-written new task", async () => {
+		renderModal({ onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "half a thought");
+		await userEvent.click(screen.getByLabelText("Close"));
+
+		expect(screen.getByRole("button", { name: /Keep editing/i })).toBeTruthy();
+		expect(screen.getByTestId("discard-save-draft")).toBeEnabled();
+		expect(screen.getByRole("button", { name: /^Discard$/i })).toBeTruthy();
+	});
+
+	it("parks the new task as a draft instead of losing it", async () => {
+		const onClose = vi.fn();
+		mockedApi.request.createTask.mockResolvedValue({ ...mockTask, draft: true, description: "half a thought" });
+		renderModal({ onClose, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "half a thought");
+		await userEvent.click(screen.getByLabelText("Close"));
+		await userEvent.click(screen.getByTestId("discard-save-draft"));
+
+		await waitFor(() => {
+			expect(mockedApi.request.createTask).toHaveBeenCalledWith(expect.objectContaining({
+				description: "half a thought",
+				draft: true,
+			}));
+		});
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
+	});
+
+	it("keeps a reopened draft's edits when the user was about to discard them", async () => {
+		mockedApi.request.editTask.mockResolvedValue({ ...draftTask, description: "second sitting" });
+		renderModal({ draftTask, onCreateAndRun: vi.fn() });
+
+		await userEvent.type(screen.getByPlaceholderText(/Describe what needs to be done/i), "second sitting");
+		await userEvent.click(screen.getByLabelText("Close"));
+		await userEvent.click(screen.getByTestId("discard-save-draft"));
+
+		await waitFor(() => {
+			expect(mockedApi.request.editTask).toHaveBeenCalledWith(expect.objectContaining({
+				taskId: "draft-1",
+				description: "second sitting",
+				draft: true,
+			}));
+		});
 	});
 });

--- a/src/mainview/components/__tests__/KanbanColumn.test.tsx
+++ b/src/mainview/components/__tests__/KanbanColumn.test.tsx
@@ -157,6 +157,9 @@ function renderBuiltinColumn(overrides: {
 	tasks?: Task[];
 	isCustomColumn?: boolean;
 	customColumnId?: string;
+	dragFromStatus?: Task["status"] | null;
+	dragFromDraft?: boolean;
+	onTaskDrop?: (taskId: string, targetStatus: Task["status"]) => void;
 } = {}) {
 	return render(
 		<I18nProvider>
@@ -171,10 +174,11 @@ function renderBuiltinColumn(overrides: {
 				agents={[]}
 				onLaunchVariants={vi.fn()}
 				onAddAttempts={vi.fn()}
-				onTaskDrop={vi.fn()}
+				onTaskDrop={overrides.onTaskDrop ?? vi.fn()}
 				onReorderTask={vi.fn()}
-				dragFromStatus={null}
+				dragFromStatus={overrides.dragFromStatus ?? null}
 				dragFromCustomColumnId={null}
+				dragFromDraft={overrides.dragFromDraft}
 				onDragStart={vi.fn()}
 				onTaskMoved={vi.fn()}
 				bellCounts={new Map()}
@@ -770,5 +774,31 @@ describe("custom column inline rename (issue #222)", () => {
 		await userEvent.clear(input);
 		await userEvent.type(input, "Beta{Enter}");
 		expect(onRenameColumn).toHaveBeenCalledWith("Beta");
+	});
+});
+
+// The mouse must not become a loophole around the draft rule: only To Do may
+// accept a draft card as a drop target.
+describe("KanbanColumn — draft drop targets", () => {
+	function columnFor(label: string) {
+		return screen.getByText(label).closest("[class*='glass-column']") as HTMLElement;
+	}
+
+	it("refuses a dragged draft on an active column", () => {
+		renderBuiltinColumn({ status: "in-progress", label: "Agent is Working", dragFromStatus: "todo", dragFromDraft: true });
+
+		expect(dispatch(columnFor("Agent is Working"), "dragover")).toBe(false);
+	});
+
+	it("refuses a dragged draft on a custom column", () => {
+		renderBuiltinColumn({ label: "On hold", isCustomColumn: true, customColumnId: "col-1", dragFromStatus: "todo", dragFromDraft: true });
+
+		expect(dispatch(columnFor("On hold"), "dragover")).toBe(false);
+	});
+
+	it("accepts a non-draft To Do card on an active column", () => {
+		renderBuiltinColumn({ status: "in-progress", label: "Agent is Working", dragFromStatus: "todo" });
+
+		expect(dispatch(columnFor("Agent is Working"), "dragover")).toBe(true);
 	});
 });

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -162,6 +162,7 @@ function renderCard(
 		prInfo?: TaskPRBadgeInfo;
 		onOpenUnresolvedComments?: (task: Task) => void;
 		siblingMap?: Map<string, Task[]>;
+		onEditDraft?: (task: Task) => void;
 	},
 ) {
 	return render(
@@ -182,6 +183,7 @@ function renderCard(
 				prInfo={opts?.prInfo}
 				onOpenUnresolvedComments={opts?.onOpenUnresolvedComments}
 				siblingMap={opts?.siblingMap}
+				onEditDraft={opts?.onEditDraft}
 			/>
 		</I18nProvider>,
 	);
@@ -1995,5 +1997,56 @@ describe("TaskCard", () => {
 				expect(screen.queryByTestId("pr-status-sheet")).not.toBeInTheDocument();
 			});
 		});
+	});
+});
+
+// A draft card must read as "not ready" at a glance and route clicks to the
+// New Task popup instead of the read-only detail modal.
+describe("TaskCard — drafts", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("shows a Draft badge and a dashed border", () => {
+		const { container } = renderCard(makeTask({ draft: true }), { onEditDraft: vi.fn() });
+
+		expect(screen.getByTestId("task-card-draft-badge")).toHaveTextContent("Draft");
+		expect(container.querySelector("[data-task-id='t1']")?.className).toContain("border-dashed");
+	});
+
+	it("offers no Run button", () => {
+		renderCard(makeTask({ draft: true }), { onEditDraft: vi.fn() });
+
+		expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
+	});
+
+	it("reopens the New Task popup instead of the detail modal", async () => {
+		const onEditDraft = vi.fn();
+		const task = makeTask({ draft: true });
+		renderCard(task, { onEditDraft });
+
+		await userEvent.click(screen.getByText("My task"));
+
+		expect(onEditDraft).toHaveBeenCalledWith(task);
+		expect(screen.queryByTestId("task-detail-modal")).toBeNull();
+	});
+
+	it("refuses the status menu's active targets instead of opening the launch flow", async () => {
+		const onLaunchVariants = vi.fn();
+		renderCard(makeTask({ draft: true }), { onEditDraft: vi.fn(), onLaunchVariants });
+
+		await userEvent.click(screen.getAllByText("To Do")[0]);
+		await userEvent.click(screen.getByText("Agent is Working"));
+
+		expect(onLaunchVariants).not.toHaveBeenCalled();
+		expect(vi.mocked(toast.error)).toHaveBeenCalled();
+	});
+
+	it("leaves an ordinary To Do card opening the detail modal", async () => {
+		const onEditDraft = vi.fn();
+		renderCard(makeTask(), { onEditDraft });
+
+		await userEvent.click(screen.getByText("My task"));
+
+		expect(onEditDraft).not.toHaveBeenCalled();
+		expect(screen.getByTestId("task-detail-modal")).toBeTruthy();
 	});
 });

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -35,7 +35,7 @@ const kanban = {
 	"createTask.saveAsDraftHint": "Park this task as an unfinished draft. It stays in To Do and nothing can start it until you finish the description.",
 	"createTask.editDraftTitle": "Edit Draft",
 	"createTask.draftSaveFailed": "Failed to save draft: {error}",
-	"createTask.discardConfirm": "Discard changes? Your description will be lost.",
+	"createTask.discardConfirm": "Unsaved changes — park them as a draft, or discard?",
 	"createTask.keepEditing": "Keep editing",
 	"createTask.discard": "Discard",
 	"createTask.branchLabel": "Branch",

--- a/src/mainview/i18n/translations/en/kanban.ts
+++ b/src/mainview/i18n/translations/en/kanban.ts
@@ -14,6 +14,7 @@ const kanban = {
 	"kanban.showLess": "Show less",
 	"kanban.collapseColumn": "Unpin column",
 	"kanban.renameColumn": "Rename column",
+	"kanban.draftNotDroppable": "This is a draft — finish its description and save it as a task before starting it.",
 
 	// CreateTaskModal
 	"createTask.title": "New Task",
@@ -30,6 +31,10 @@ const kanban = {
 	"createTask.scratch": "Scratch Task",
 	"createTask.scratchSubtitle": "No prompt — agent will ask",
 	"createTask.scratchHint": "Open a terminal + agent with no prompt. The agent will name the task itself once you tell it what to do.",
+	"createTask.saveAsDraft": "Save as draft",
+	"createTask.saveAsDraftHint": "Park this task as an unfinished draft. It stays in To Do and nothing can start it until you finish the description.",
+	"createTask.editDraftTitle": "Edit Draft",
+	"createTask.draftSaveFailed": "Failed to save draft: {error}",
 	"createTask.discardConfirm": "Discard changes? Your description will be lost.",
 	"createTask.keepEditing": "Keep editing",
 	"createTask.discard": "Discard",
@@ -63,6 +68,8 @@ const kanban = {
 
 	// TaskCard
 	"task.moveTo": "Move to",
+	"task.draftBadge": "Draft",
+	"task.draftHint": "Unfinished draft — click to keep writing. Nothing can start it yet.",
 	"task.delete": "Delete",
 	"task.confirmDelete": "Delete task \"{title}\"?",
 	"task.failedMove": "Failed to move task: {error}",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -35,7 +35,7 @@ const kanban = {
 	"createTask.saveAsDraftHint": "Aparca esta tarea como un borrador sin terminar. Permanece en To Do y nada puede iniciarla hasta que completes la descripción.",
 	"createTask.editDraftTitle": "Editar borrador",
 	"createTask.draftSaveFailed": "No se pudo guardar el borrador: {error}",
-	"createTask.discardConfirm": "¿Descartar cambios? Se perderá la descripción introducida.",
+	"createTask.discardConfirm": "Cambios sin guardar: ¿guardarlos como borrador o descartarlos?",
 	"createTask.keepEditing": "Seguir editando",
 	"createTask.discard": "Descartar",
 	"createTask.branchLabel": "Rama",

--- a/src/mainview/i18n/translations/es/kanban.ts
+++ b/src/mainview/i18n/translations/es/kanban.ts
@@ -14,6 +14,7 @@ const kanban = {
 	"kanban.showLess": "Mostrar menos",
 	"kanban.collapseColumn": "Desanclar columna",
 	"kanban.renameColumn": "Renombrar columna",
+	"kanban.draftNotDroppable": "Esto es un borrador: completa su descripción y guárdalo como tarea antes de iniciarlo.",
 
 	// CreateTaskModal
 	"createTask.title": "Nueva tarea",
@@ -30,6 +31,10 @@ const kanban = {
 	"createTask.scratch": "Tarea rápida",
 	"createTask.scratchSubtitle": "Sin prompt — el agente preguntará",
 	"createTask.scratchHint": "Abre un terminal con un agente sin prompt. El agente nombrará la tarea por sí mismo cuando le digas qué hacer.",
+	"createTask.saveAsDraft": "Guardar como borrador",
+	"createTask.saveAsDraftHint": "Aparca esta tarea como un borrador sin terminar. Permanece en To Do y nada puede iniciarla hasta que completes la descripción.",
+	"createTask.editDraftTitle": "Editar borrador",
+	"createTask.draftSaveFailed": "No se pudo guardar el borrador: {error}",
 	"createTask.discardConfirm": "¿Descartar cambios? Se perderá la descripción introducida.",
 	"createTask.keepEditing": "Seguir editando",
 	"createTask.discard": "Descartar",
@@ -63,6 +68,8 @@ const kanban = {
 
 	// TaskCard
 	"task.moveTo": "Mover a",
+	"task.draftBadge": "Borrador",
+	"task.draftHint": "Borrador sin terminar: haz clic para seguir escribiendo. Todavía nada puede iniciarlo.",
 	"task.delete": "Eliminar",
 	"task.confirmDelete": "¿Eliminar tarea \"{title}\"?",
 	"task.failedMove": "Error al mover tarea: {error}",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -35,7 +35,7 @@ const kanban = {
 	"createTask.saveAsDraftHint": "Отложить задачу как незаконченный черновик. Она остаётся в To Do, и запустить её нельзя, пока вы не допишете описание.",
 	"createTask.editDraftTitle": "Черновик",
 	"createTask.draftSaveFailed": "Не удалось сохранить черновик: {error}",
-	"createTask.discardConfirm": "Отменить? Введённое описание будет потеряно.",
+	"createTask.discardConfirm": "Есть несохранённые изменения — отложить черновиком или выбросить?",
 	"createTask.keepEditing": "Продолжить редактирование",
 	"createTask.discard": "Отменить",
 	"createTask.branchLabel": "Ветка",

--- a/src/mainview/i18n/translations/ru/kanban.ts
+++ b/src/mainview/i18n/translations/ru/kanban.ts
@@ -14,6 +14,7 @@ const kanban = {
 	"kanban.showLess": "Свернуть",
 	"kanban.collapseColumn": "Открепить колонку",
 	"kanban.renameColumn": "Переименовать колонку",
+	"kanban.draftNotDroppable": "Это черновик — допишите описание и сохраните как задачу, прежде чем запускать.",
 
 	// CreateTaskModal
 	"createTask.title": "Новая задача",
@@ -30,6 +31,10 @@ const kanban = {
 	"createTask.scratch": "Черновик",
 	"createTask.scratchSubtitle": "Без промпта — агент спросит",
 	"createTask.scratchHint": "Открыть терминал с агентом без промпта. Агент сам назовёт таску, когда ты объяснишь, что нужно.",
+	"createTask.saveAsDraft": "Сохранить черновик",
+	"createTask.saveAsDraftHint": "Отложить задачу как незаконченный черновик. Она остаётся в To Do, и запустить её нельзя, пока вы не допишете описание.",
+	"createTask.editDraftTitle": "Черновик",
+	"createTask.draftSaveFailed": "Не удалось сохранить черновик: {error}",
 	"createTask.discardConfirm": "Отменить? Введённое описание будет потеряно.",
 	"createTask.keepEditing": "Продолжить редактирование",
 	"createTask.discard": "Отменить",
@@ -63,6 +68,8 @@ const kanban = {
 
 	// TaskCard
 	"task.moveTo": "Переместить в",
+	"task.draftBadge": "Черновик",
+	"task.draftHint": "Незаконченный черновик — нажмите, чтобы продолжить писать. Запустить его пока нельзя.",
 	"task.delete": "Удалить",
 	"task.confirmDelete": "Удалить задачу «{title}»?",
 	"task.failedMove": "Не удалось переместить задачу: {error}",

--- a/src/shared/cli-exit-codes.ts
+++ b/src/shared/cli-exit-codes.ts
@@ -7,6 +7,7 @@ export const CLI_EXIT_CODE_GUI_DEPS_MISSING = 5;
 export const CLI_EXIT_CODE_COMPLETION_DECLINED = 6;
 export const CLI_EXIT_CODE_DOCTOR_PROBLEMS = 7;
 export const CLI_EXIT_CODE_RENDERER_UNAVAILABLE = 8;
+export const CLI_EXIT_CODE_TASK_IS_DRAFT = 9;
 
 export const CLI_EXIT_CODE_DEFINITIONS = [
 	{
@@ -57,5 +58,11 @@ export const CLI_EXIT_CODE_DEFINITIONS = [
 		code: CLI_EXIT_CODE_RENDERER_UNAVAILABLE,
 		description:
 			"The desktop launch created a window but no renderer ever reported dom-ready within the readiness budget (missing/broken WebView2 runtime, or no interactive desktop). The process prints an actionable diagnostic and leaves instead of running without a UI.",
+	},
+	{
+		constant: "CLI_EXIT_CODE_TASK_IS_DRAFT",
+		code: CLI_EXIT_CODE_TASK_IS_DRAFT,
+		description:
+			"`dev3 task move` was asked to start a task the user saved as a draft. A draft is deliberately unfinished, so no launch path may start it — the human must finish its description and save it as a normal task first.",
 	},
 ] as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,14 @@ export const ACTIVE_STATUSES: TaskStatus[] = [
 	"review-by-ai",
 ];
 
+/**
+ * Rejection message every activation path produces for a draft task. The CLI
+ * compares against it to translate the lifecycle rejection into its dedicated
+ * exit code, so the string is a contract — not free-form log text.
+ */
+export const DRAFT_TASK_ACTIVATION_ERROR =
+	"Task is a draft — finish its description and save it as a normal task before starting it.";
+
 export const MERGE_COMPLETE_ELIGIBLE_STATUSES: TaskStatus[] = [
 	"user-questions",
 	"review-by-user",
@@ -1331,6 +1339,16 @@ export interface Task {
 	 * description or title converts it into a normal task and clears this flag.
 	 */
 	scratch?: boolean;
+	/**
+	 * True while the task is an unfinished draft parked in To Do by "Save as
+	 * draft". A draft is explicitly not ready: every activation path refuses it
+	 * (the lifecycle machine rejects the move, see {@link DRAFT_TASK_ACTIVATION_ERROR}),
+	 * and clicking its card reopens the New Task popup prefilled. Cleared only by
+	 * an explicit save with a non-empty description; the transition is one-way.
+	 * Absent/false on every pre-existing task, so older app versions reading the
+	 * same `tasks.json` simply see an ordinary To Do task.
+	 */
+	draft?: boolean;
 	/**
 	 * For tasks in a virtual ("Operations") project only: the user-chosen fixed
 	 * working folder picked at creation (e.g. `~/Downloads`). When absent, the
@@ -2839,7 +2857,7 @@ export type AppRPCSchema = {
 				response: ConversationMatch[];
 			};
 			createTask: {
-				params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string; scratch?: boolean; opsWorkDir?: string; priority?: TaskPriority };
+				params: { projectId: string; description: string; status?: TaskStatus; existingBranch?: string; scratch?: boolean; draft?: boolean; opsWorkDir?: string; priority?: TaskPriority };
 				response: Task;
 			};
 			setTaskPriority: {
@@ -2878,7 +2896,22 @@ export type AppRPCSchema = {
 				response: Task;
 			};
 			editTask: {
-				params: { taskId: string; projectId: string; description: string };
+				// One optional-field update for a To Do task: whatever is present is
+				// written, everything else is left alone. Saving a draft is a single
+				// call (and therefore a single persisted write) rather than a create
+				// followed by best-effort title/label follow-ups.
+				// `draft: false` promotes a draft into an ordinary task and requires a
+				// non-empty description; there is no way back to `draft: true`.
+				params: {
+					taskId: string;
+					projectId: string;
+					description?: string;
+					customTitle?: string | null;
+					priority?: TaskPriority;
+					labelIds?: string[];
+					existingBranch?: string | null;
+					draft?: boolean;
+				};
 				response: Task;
 			};
 			renameTask: {


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that implemented this branch) — writing up what landed here.

Adds a fourth exit to the New Task popup: **Save as draft**. A draft is a To Do task the user explicitly marked unfinished — it cannot be started by anything or anybody until the description is written and the draft is saved as a normal task.

## What changed

**Enforcement lives in the lifecycle machine, not the UI.** `Task.draft` is derived into `LifecycleFacts.draft`, and `moveTransition` rejects the move as soon as `needsActivation && facts.draft`. Every activation path funnels through that one `moveRequested` event — Run button, board drag, variant spawn, scheduled launch, automations, `dev3 task move` — so one guard covers all of them, including paths added later. `scheduleTaskLaunch` repeats the refusal because it persists a *future* activation rather than dispatching one. The hidden Run button, the non-droppable card and the CLI exit code are mirrors of a rule that already holds server-side.

**`editTask` is now a single optional-field update** (description, custom title, priority, label ids, branch, draft flag), so saving a draft is one call and one persisted write instead of a create plus best-effort title/label follow-ups. Promotion (`draft: false`) demands a non-empty description; the reverse direction is refused outright — draft → ready is one-way.

**The popup has two modes.** Create mode gains Save as draft (available with an empty description, as long as *some* field was filled, so a chosen branch/priority/label set is never lost). Draft-edit mode reopens on an existing draft with every field prefilled: Save as draft / Save / Save & Start, with the last two enabled only for a non-empty description, and Scratch hidden.

**The unsaved-changes confirmation offers the same escape hatch.** Closing the popup with unsaved text used to be "keep typing or lose it"; it now leads with parking the work as a draft over the destructive exit, and its wording asks the question the three buttons answer.

**Card and CLI.** A draft card renders a dashed border plus a Draft badge, routes clicks to the popup, hides Run, and is refused as a drag source outside To Do (the status menu short-circuits too, instead of walking the user into the launch flow). `dev3 task show` / `task list` report the flag, and `dev3 task move` to an active status exits with the new dedicated code `9`.

Everything else stays uniform: column counters, search, task switcher, statistics and deletion treat a draft as an ordinary task. `Task.draft` is optional, so pre-existing tasks and older app versions reading the same `tasks.json` see today's behaviour — no migration, no path changes.

## Notes

Two choices that will look arbitrary later are recorded in `decisions/180-draft-tasks-lifecycle-enforced-one-way.md`: enforcing the block in the lifecycle machine rather than in each caller, and making draft → ready one-way. `AGENTS.md` gains the **Draft** glossary term.

Suggested by @yakirn (#1158).