### PR TITLE
Route task pane controls through a backend-neutral API

### DIFF
--- a/change-logs/2026/07/29/refactor-native-multipane-neutral-pane-rpc.md
+++ b/change-logs/2026/07/29/refactor-native-multipane-neutral-pane-rpc.md
@@ -1,1 +1,0 @@
-Replace four tmux-specific RPCs (tmuxAction, tmuxPaneCount, tmuxKillPane, tmuxPaneNavigate) with three backend-neutral ones (taskPaneState, taskPaneAction, tmuxNewWindow) so the same pane controls work on both tmux and native backends. All renderer callers (TerminalView, TaskTmuxControls, MobilePaneCarousel, ClosePanePicker, PaneZoomBadge, menuRouter) are migrated to the new API.

--- a/change-logs/2026/07/29/refactor-native-multipane-neutral-pane-rpc.md
+++ b/change-logs/2026/07/29/refactor-native-multipane-neutral-pane-rpc.md
@@ -1,0 +1,1 @@
+Replace four tmux-specific RPCs (tmuxAction, tmuxPaneCount, tmuxKillPane, tmuxPaneNavigate) with three backend-neutral ones (taskPaneState, taskPaneAction, tmuxNewWindow) so the same pane controls work on both tmux and native backends. All renderer callers (TerminalView, TaskTmuxControls, MobilePaneCarousel, ClosePanePicker, PaneZoomBadge, menuRouter) are migrated to the new API.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -342,6 +342,12 @@ const {
 	runCleanupScript,
 	portableReadKey,
 } = await import("../rpc-handlers");
+const {
+	tmuxAction,
+	tmuxKillPane,
+	tmuxPaneCount,
+	tmuxPaneNavigate,
+} = await import("../rpc-handlers/tmux-pty");
 const { _resetLifecycleActorsForTest } = await import("../lifecycle/service");
 
 beforeEach(async () => {
@@ -7096,7 +7102,7 @@ describe("handlers.pushTask", () => {
 // handlers.runDevServer
 // ================================================================
 
-describe("handlers.tmuxKillPane", () => {
+describe("tmuxKillPane", () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	function killPaneCall() {
@@ -7108,7 +7114,7 @@ describe("handlers.tmuxKillPane", () => {
 			.mockReturnValueOnce({ stdout: "%1\n%2\n", stderr: new Response(""), exited: Promise.resolve(0) }) // count
 			.mockReturnValue({ stdout: "", stderr: new Response(""), exited: Promise.resolve(0) }); // kill-pane
 
-		const res = await handlers.tmuxKillPane({ taskId: "task-1", paneId: "%2" });
+		const res = await tmuxKillPane({ taskId: "task-1", paneId: "%2" });
 
 		expect(res).toEqual({ killed: true });
 		const kill = killPaneCall();
@@ -7119,7 +7125,7 @@ describe("handlers.tmuxKillPane", () => {
 	it("refuses to kill the last pane without force", async () => {
 		mockSpawn.mockReturnValueOnce({ stdout: "%1\n", stderr: new Response(""), exited: Promise.resolve(0) }); // count → 1
 
-		const res = await handlers.tmuxKillPane({ taskId: "task-1", paneId: "%1" });
+		const res = await tmuxKillPane({ taskId: "task-1", paneId: "%1" });
 
 		expect(res).toEqual({ killed: false });
 		expect(killPaneCall()).toBeUndefined();
@@ -7128,7 +7134,7 @@ describe("handlers.tmuxKillPane", () => {
 	it("force-kills the last pane (bypasses the count guard)", async () => {
 		mockSpawn.mockReturnValue({ stdout: "", stderr: new Response(""), exited: Promise.resolve(0) });
 
-		const res = await handlers.tmuxKillPane({ taskId: "task-1", paneId: "%1", force: true });
+		const res = await tmuxKillPane({ taskId: "task-1", paneId: "%1", force: true });
 
 		expect(res).toEqual({ killed: true });
 		expect(killPaneCall()).toBeDefined();
@@ -7137,7 +7143,7 @@ describe("handlers.tmuxKillPane", () => {
 	});
 
 	it("rejects a malformed pane id without spawning tmux", async () => {
-		const res = await handlers.tmuxKillPane({ taskId: "task-1", paneId: "; rm -rf /" });
+		const res = await tmuxKillPane({ taskId: "task-1", paneId: "; rm -rf /" });
 
 		expect(res).toEqual({ killed: false });
 		expect(mockSpawn).not.toHaveBeenCalled();
@@ -7715,10 +7721,10 @@ describe("handlers.listTmuxSessions", () => {
 });
 
 // ================================================================
-// handlers.tmuxAction
+// tmuxAction
 // ================================================================
 
-describe("handlers.tmuxAction", () => {
+describe("tmuxAction", () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	it("sends split-window -v for splitH action", async () => {
@@ -7728,7 +7734,7 @@ describe("handlers.tmuxAction", () => {
 			exited: Promise.resolve(0),
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "splitH" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "splitH" });
 		// -c must carry a session_path fallback: tmux 3.7 on macOS sometimes
 		// reports an empty pane_current_path (unreadable foreground cwd), and a
 		// bare #{pane_current_path} then expands to "" — tmux falls back to the
@@ -7746,7 +7752,7 @@ describe("handlers.tmuxAction", () => {
 			exited: Promise.resolve(0),
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "splitV" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "splitV" });
 		expect(mockSpawn).toHaveBeenCalledWith(
 			["tmux", "-L", "dev3", "split-window", "-h", "-t", "dev3-abcd1234", "-c", "#{?pane_current_path,#{pane_current_path},#{session_path}}"],
 			expect.any(Object),
@@ -7760,7 +7766,7 @@ describe("handlers.tmuxAction", () => {
 			exited: Promise.resolve(0),
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenH" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenH" });
 		expect(mockSpawn).toHaveBeenCalledWith(
 			["tmux", "-L", "dev3", "select-layout", "-t", "dev3-abcd1234", "even-vertical"],
 			expect.any(Object),
@@ -7774,7 +7780,7 @@ describe("handlers.tmuxAction", () => {
 			exited: Promise.resolve(0),
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenV" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "layoutEvenV" });
 		expect(mockSpawn).toHaveBeenCalledWith(
 			["tmux", "-L", "dev3", "select-layout", "-t", "dev3-abcd1234", "even-horizontal"],
 			expect.any(Object),
@@ -7788,7 +7794,7 @@ describe("handlers.tmuxAction", () => {
 			exited: Promise.resolve(0),
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "zoom" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "zoom" });
 		expect(mockSpawn).toHaveBeenCalledWith(
 			["tmux", "-L", "dev3", "resize-pane", "-Z", "-t", "dev3-abcd1234"],
 			expect.any(Object),
@@ -7803,7 +7809,7 @@ describe("handlers.tmuxAction", () => {
 		});
 
 		await expect(
-			handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "zoom" }),
+			tmuxAction({ taskId: "abcd1234-full-id", action: "zoom" }),
 		).rejects.toThrow("tmux zoom failed");
 	});
 
@@ -7824,7 +7830,7 @@ describe("handlers.tmuxAction", () => {
 			};
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
 
 		const spawnCalls = mockSpawn.mock.calls.map((c) => c[0] as string[]);
 		expect(spawnCalls.some((a) => a.includes("kill-pane"))).toBe(false);
@@ -7853,7 +7859,7 @@ describe("handlers.tmuxAction", () => {
 			};
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "killPane" });
 
 		expect(mockSpawn).toHaveBeenCalledWith(
 			["tmux", "-L", "dev3", "kill-pane", "-t", "dev3-abcd1234"],
@@ -7877,7 +7883,7 @@ describe("handlers.tmuxAction", () => {
 			};
 		});
 
-		await handlers.tmuxAction({ taskId: "abcd1234-full-id", action: "killPane", force: true });
+		await tmuxAction({ taskId: "abcd1234-full-id", action: "killPane", force: true });
 
 		const spawnCalls = mockSpawn.mock.calls.map((c) => c[0] as string[]);
 		expect(spawnCalls.some((a) => a.includes("list-panes"))).toBe(false);
@@ -7886,10 +7892,10 @@ describe("handlers.tmuxAction", () => {
 });
 
 // ================================================================
-// handlers.tmuxPaneCount
+// tmuxPaneCount
 // ================================================================
 
-describe("handlers.tmuxPaneCount", () => {
+describe("tmuxPaneCount", () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	it("returns the number of panes reported by list-panes", async () => {
@@ -7908,7 +7914,7 @@ describe("handlers.tmuxPaneCount", () => {
 			};
 		});
 
-		const result = await handlers.tmuxPaneCount({ taskId: "abcd1234-full-id" });
+		const result = await tmuxPaneCount({ taskId: "abcd1234-full-id" });
 		expect(result).toEqual({ count: 3 });
 	});
 
@@ -7928,7 +7934,7 @@ describe("handlers.tmuxPaneCount", () => {
 			};
 		});
 
-		const result = await handlers.tmuxPaneCount({ taskId: "abcd1234-full-id" });
+		const result = await tmuxPaneCount({ taskId: "abcd1234-full-id" });
 		expect(result).toEqual({ count: 1 });
 	});
 
@@ -7939,7 +7945,7 @@ describe("handlers.tmuxPaneCount", () => {
 			exited: Promise.resolve(1),
 		}));
 
-		const result = await handlers.tmuxPaneCount({ taskId: "abcd1234-full-id" });
+		const result = await tmuxPaneCount({ taskId: "abcd1234-full-id" });
 		expect(result).toEqual({ count: 0 });
 	});
 });
@@ -11785,9 +11791,9 @@ describe("handlers.getProjectPtyUrl — virtual board guard", () => {
 
 
 // ----------------------------------------------------------------------------
-// handlers.tmuxPaneNavigate (narrow-viewport pane carousel)
+// tmuxPaneNavigate (narrow-viewport pane carousel)
 // ----------------------------------------------------------------------------
-describe("handlers.tmuxPaneNavigate", () => {
+describe("tmuxPaneNavigate", () => {
 	const TASK_ID = "abcd1234-0000-0000-0000-000000000000";
 	const SESSION = "dev3-abcd1234";
 	const SEP = "\t";
@@ -11819,7 +11825,7 @@ describe("handlers.tmuxPaneNavigate", () => {
 
 	it("zoom-on-entry: zooms a multi-pane window that is not yet zoomed", async () => {
 		mockLayouts([lay(row("%1", "1", "0", "claude"), row("%2", "0", "0", "bash"), row("%3", "0", "0", "zsh"))]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
 		expect(res).toEqual({ count: 3, activeIndex: 0, zoomed: true, labels: ["claude", "bash", "zsh"] });
 		expect(called("resize-pane -Z")).toBe(true);
 		expect(called("select-pane")).toBe(false);
@@ -11827,7 +11833,7 @@ describe("handlers.tmuxPaneNavigate", () => {
 
 	it("labels prefer an explicitly-set pane title over the command", async () => {
 		mockLayouts([lay(row("%1", "1", "0", "node", "Agent"), row("%2", "0", "0", "node", "Dev Server"))]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
 		expect(res.labels).toEqual(["Agent", "Dev Server"]);
 	});
 
@@ -11836,7 +11842,7 @@ describe("handlers.tmuxPaneNavigate", () => {
 			lay(row("%1", "1", "0", "claude"), row("%2", "0", "0", "bash"), row("%3", "0", "0", "zsh")), // before
 			lay(row("%1", "0", "0", "claude"), row("%2", "1", "0", "bash"), row("%3", "0", "0", "zsh")), // after select (active moved, auto-unzoomed)
 		]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, step: "next", zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, step: "next", zoom: true });
 		expect(res).toEqual({ count: 3, activeIndex: 1, zoomed: true, labels: ["claude", "bash", "zsh"] });
 		expect(called(`select-pane -t ${SESSION}:.+`)).toBe(true);
 		expect(called("resize-pane -Z")).toBe(true);
@@ -11847,14 +11853,14 @@ describe("handlers.tmuxPaneNavigate", () => {
 			lay(row("%1", "1", "0", "claude"), row("%2", "0", "0", "bash"), row("%3", "0", "0", "zsh")),
 			lay(row("%1", "0", "0", "claude"), row("%2", "0", "0", "bash"), row("%3", "1", "0", "zsh")),
 		]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, index: 2, zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, index: 2, zoom: true });
 		expect(res.activeIndex).toBe(2);
 		expect(called("select-pane -t %3")).toBe(true);
 	});
 
 	it("single pane: no navigation, no zoom, hides nothing to switch", async () => {
 		mockLayouts([lay(row("%1", "1", "0", "claude"))]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, step: "next", zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, step: "next", zoom: true });
 		expect(res).toEqual({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
 		expect(called("select-pane")).toBe(false);
 		expect(called("resize-pane")).toBe(false);
@@ -11862,14 +11868,14 @@ describe("handlers.tmuxPaneNavigate", () => {
 
 	it("idempotent zoom: already zoomed + zoom:true is a no-op", async () => {
 		mockLayouts([lay(row("%1", "1", "1", "claude"), row("%2", "0", "1", "bash"), row("%3", "0", "1", "zsh"))]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, zoom: true });
 		expect(res).toEqual({ count: 3, activeIndex: 0, zoomed: true, labels: ["claude", "bash", "zsh"] });
 		expect(called("resize-pane")).toBe(false);
 	});
 
 	it("zoom:false unzooms a zoomed window (pager unmount / restore split)", async () => {
 		mockLayouts([lay(row("%1", "1", "1", "claude"), row("%2", "0", "1", "bash"))]);
-		const res = await handlers.tmuxPaneNavigate({ taskId: TASK_ID, zoom: false });
+		const res = await tmuxPaneNavigate({ taskId: TASK_ID, zoom: false });
 		expect(res).toEqual({ count: 2, activeIndex: 0, zoomed: false, labels: ["claude", "bash"] });
 		expect(called("resize-pane -Z")).toBe(true);
 	});

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -78,6 +78,7 @@ import { automationsHandlers } from "./rpc-handlers/automations";
 import { pxpipeProxyHandlers } from "./rpc-handlers/pxpipe-proxy";
 import { agentAccountHandlers } from "./rpc-handlers/agent-accounts";
 import { prCommentsHandlers } from "./rpc-handlers/pr-comments";
+import { taskPanesHandlers } from "./rpc-handlers/task-panes";
 
 export const handlers = {
 	...appHandlers,
@@ -96,4 +97,5 @@ export const handlers = {
 	...pxpipeProxyHandlers,
 	...agentAccountHandlers,
 	...prCommentsHandlers,
+	...taskPanesHandlers,
 };

--- a/src/bun/rpc-handlers/__tests__/task-panes.test.ts
+++ b/src/bun/rpc-handlers/__tests__/task-panes.test.ts
@@ -1,0 +1,673 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NativeTaskPanesState } from "../../native-task-panes";
+import { createSplitTree, serializeSplitTree } from "../../../shared/split-tree";
+import { applySplitLayout } from "../../../shared/split-tree-layouts";
+
+// ── Mocks (hoisted so vi.mock factories can reference them) ──────────────────
+
+const mocks = vi.hoisted(() => ({
+	// data
+	loadProjects: vi.fn(),
+	loadVirtualProjects: vi.fn(),
+	getTask: vi.fn(),
+	// pty-server
+	getSessionSocket: vi.fn(),
+	getSessionTmuxName: vi.fn(),
+	getTmuxLayout: vi.fn(),
+	// tmux singleton methods
+	tmuxSelectPane: vi.fn(),
+	tmuxSelectPaneDirection: vi.fn(),
+	tmuxToggleZoom: vi.fn(),
+	tmuxSelectLayout: vi.fn(),
+	tmuxNextLayout: vi.fn(),
+	tmuxResizePaneDirection: vi.fn(),
+	tmuxNewWindow: vi.fn(),
+	tmuxSplitWindow: vi.fn(),
+	tmuxKillPane: vi.fn(),
+	// task-terminal-backend
+	taskTerminalBackendIdentity: vi.fn(),
+	// native-task-panes
+	nativeTaskPanesState: vi.fn(),
+	splitNativeTaskPane: vi.fn(),
+	closeNativeTaskPane: vi.fn(),
+	focusNativeTaskPane: vi.fn(),
+	setNativeTaskPaneLayout: vi.fn(),
+	// tmux-pty helpers
+	readPaneLayout: vi.fn(),
+	tmuxActionHelper: vi.fn(),
+	tmuxKillPaneHelper: vi.fn(),
+	handlePaneExited: vi.fn(),
+}));
+
+vi.mock("../../data", () => ({
+	loadProjects: mocks.loadProjects,
+	loadVirtualProjects: mocks.loadVirtualProjects,
+	getTask: mocks.getTask,
+}));
+
+vi.mock("../../pty-server", () => ({
+	getSessionSocket: mocks.getSessionSocket,
+	getSessionTmuxName: mocks.getSessionTmuxName,
+	getTmuxLayout: mocks.getTmuxLayout,
+}));
+
+vi.mock("../../tmux", () => ({
+	PANE_CWD_FORMAT: "#{pane_current_path}",
+	TmuxError: class TmuxError extends Error {
+		exitCode: number;
+		stderr: string;
+		constructor(msg: string, exitCode = 1, stderr = "") {
+			super(msg);
+			this.exitCode = exitCode;
+			this.stderr = stderr;
+		}
+	},
+	tmux: {
+		selectPane: mocks.tmuxSelectPane,
+		selectPaneDirection: mocks.tmuxSelectPaneDirection,
+		toggleZoom: mocks.tmuxToggleZoom,
+		selectLayout: mocks.tmuxSelectLayout,
+		nextLayout: mocks.tmuxNextLayout,
+		resizePaneDirection: mocks.tmuxResizePaneDirection,
+		newWindow: mocks.tmuxNewWindow,
+		splitWindow: mocks.tmuxSplitWindow,
+		killPane: mocks.tmuxKillPane,
+	},
+}));
+
+vi.mock("../../task-terminal-backend", () => ({
+	taskTerminalBackendIdentity: mocks.taskTerminalBackendIdentity,
+}));
+
+vi.mock("../../native-task-panes", () => ({
+	nativeTaskPanesState: mocks.nativeTaskPanesState,
+	splitNativeTaskPane: mocks.splitNativeTaskPane,
+	closeNativeTaskPane: mocks.closeNativeTaskPane,
+	focusNativeTaskPane: mocks.focusNativeTaskPane,
+	setNativeTaskPaneLayout: mocks.setNativeTaskPaneLayout,
+}));
+
+vi.mock("../tmux-pty", () => ({
+	readPaneLayout: mocks.readPaneLayout,
+	tmuxAction: mocks.tmuxActionHelper,
+	tmuxKillPane: mocks.tmuxKillPaneHelper,
+	handlePaneExited: mocks.handlePaneExited,
+}));
+
+import { taskPanesHandlers } from "../task-panes";
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+const TASK_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const tmuxTask = { id: TASK_ID, terminalBackend: undefined } as any;
+const nativeTask = { id: TASK_ID, terminalBackend: "native" } as any;
+
+/** Minimal TmuxLayout for two panes in one 100×40-cell window. */
+const twoPane80TmuxLayout = {
+	sessionName: "dev3-aaaaaaaa",
+	exists: true,
+	windows: [{ index: 0, name: "main", active: true, panes: 2, zoomed: false }],
+	panes: [
+		{ windowIndex: 0, paneId: "%1", active: true,  left: 0,  top: 0, width: 50, height: 40, command: "claude", title: "Agent" },
+		{ windowIndex: 0, paneId: "%2", active: false, left: 50, top: 0, width: 50, height: 40, command: "bash",   title: ""      },
+	],
+};
+
+/** readPaneLayout response for the above two-pane window. */
+const twoPane80PaneLayout = {
+	count: 2,
+	activeIndex: 0,
+	zoomed: false,
+	paneIds: ["%1", "%2"],
+	labels: ["Agent", ""],
+};
+
+/** A single-pane native state with a fresh SplitTree. */
+function makeSingleNativeState(): NativeTaskPanesState {
+	const tree = createSplitTree();
+	return {
+		taskId: TASK_ID,
+		panes: [{ paneId: "pane-1", sessionId: "sess-1", hostPid: 100, shellPid: 101, cols: 80, rows: 24, alive: true }],
+		layout: serializeSplitTree(tree),
+		activePaneId: "pane-1",
+	};
+}
+
+/** A two-pane native state (pane-1 left, pane-2 right). */
+function makeTwoPaneNativeState(): NativeTaskPanesState {
+	let tree = createSplitTree();
+	tree = { ...tree, root: {
+		type: "split", id: "split-1", orientation: "horizontal", ratio: 0.5,
+		first: { type: "pane", id: "pane-1" },
+		second: { type: "pane", id: "pane-2" },
+	}, nextSplitOrdinal: 2, nextPaneOrdinal: 3 };
+	return {
+		taskId: TASK_ID,
+		panes: [
+			{ paneId: "pane-1", sessionId: "sess-1", hostPid: 100, shellPid: 101, cols: 80, rows: 24, alive: true },
+			{ paneId: "pane-2", sessionId: "sess-2", hostPid: 102, shellPid: 103, cols: 80, rows: 24, alive: true },
+		],
+		layout: serializeSplitTree(tree),
+		activePaneId: "pane-1",
+	};
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// Default: both paths find the task
+	mocks.loadProjects.mockResolvedValue([{ id: "proj-1" }]);
+	mocks.loadVirtualProjects.mockResolvedValue([]);
+	mocks.getTask.mockImplementation((_proj: any, taskId: string) => {
+		if (taskId === TASK_ID) return Promise.resolve(tmuxTask);
+		throw new Error("not found");
+	});
+	mocks.taskTerminalBackendIdentity.mockReturnValue("tmux");
+	mocks.getSessionSocket.mockReturnValue("dev3-sock");
+	mocks.getSessionTmuxName.mockReturnValue("dev3-aaaaaaaa");
+	mocks.getTmuxLayout.mockResolvedValue(twoPane80TmuxLayout);
+	mocks.readPaneLayout.mockResolvedValue(twoPane80PaneLayout);
+	mocks.tmuxActionHelper.mockResolvedValue(undefined);
+	mocks.tmuxKillPaneHelper.mockResolvedValue({ killed: true });
+	mocks.handlePaneExited.mockResolvedValue(undefined);
+	mocks.tmuxSelectPane.mockResolvedValue(undefined);
+	mocks.tmuxSelectPaneDirection.mockResolvedValue(undefined);
+	mocks.tmuxToggleZoom.mockResolvedValue(undefined);
+	mocks.tmuxSelectLayout.mockResolvedValue(undefined);
+	mocks.tmuxNextLayout.mockResolvedValue(undefined);
+	mocks.tmuxResizePaneDirection.mockResolvedValue(undefined);
+	mocks.tmuxNewWindow.mockResolvedValue(undefined);
+	mocks.nativeTaskPanesState.mockResolvedValue(makeTwoPaneNativeState());
+	mocks.splitNativeTaskPane.mockImplementation(async () => {
+		const state = makeTwoPaneNativeState();
+		return { paneId: "pane-2", state };
+	});
+	mocks.focusNativeTaskPane.mockImplementation(async (_taskId: string, paneId: string) => {
+		const s = makeTwoPaneNativeState();
+		return { ...s, activePaneId: paneId };
+	});
+	mocks.closeNativeTaskPane.mockResolvedValue({ sessionTornDown: false, state: makeTwoPaneNativeState() });
+	mocks.setNativeTaskPaneLayout.mockImplementation(async (_taskId: string, tree: any) => {
+		return { ...makeTwoPaneNativeState(), layout: serializeSplitTree(tree) };
+	});
+});
+
+// ── taskPaneState ─────────────────────────────────────────────────────────────
+
+describe("taskPaneState", () => {
+	it("returns tmux backend state with normalized rects and labels", async () => {
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+
+		expect(state.backend).toBe("tmux");
+		expect(state.panes).toHaveLength(2);
+
+		// Rect normalization: each pane is 50 of 100 cells wide, full height
+		const p0 = state.panes[0];
+		expect(p0.paneId).toBe("%1");
+		expect(p0.active).toBe(true);
+		expect(p0.label).toBe("Agent");
+		expect(p0.rect.x).toBeCloseTo(0);
+		expect(p0.rect.y).toBeCloseTo(0);
+		expect(p0.rect.width).toBeCloseTo(0.5);
+		expect(p0.rect.height).toBeCloseTo(1.0);
+
+		const p1 = state.panes[1];
+		expect(p1.paneId).toBe("%2");
+		expect(p1.active).toBe(false);
+		expect(p1.rect.x).toBeCloseTo(0.5);
+		expect(p1.rect.width).toBeCloseTo(0.5);
+
+		// Zoom flag preserved
+		expect(state.zoomedPaneId).toBeNull();
+	});
+
+	it("preserves zoom flag from pane layout", async () => {
+		mocks.readPaneLayout.mockResolvedValue({ ...twoPane80PaneLayout, zoomed: true, activeIndex: 1 });
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+		expect(state.zoomedPaneId).toBe("%2");
+	});
+
+	it("reports tmux capabilities including newWindow", async () => {
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+		expect(state.capabilities).toContain("split");
+		expect(state.capabilities).toContain("newWindow");
+		expect(state.capabilities).toContain("focus");
+		expect(state.capabilities).toContain("close");
+	});
+
+	it("returns native backend state with rects from SplitTree", async () => {
+		mocks.taskTerminalBackendIdentity.mockReturnValue("native");
+		mocks.getTask.mockResolvedValue(nativeTask);
+		const twoPane = makeTwoPaneNativeState();
+		mocks.nativeTaskPanesState.mockResolvedValue(twoPane);
+
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+
+		expect(state.backend).toBe("native");
+		expect(state.panes).toHaveLength(2);
+		// horizontal split ratio 0.5 → left pane x=0 width=0.5, right pane x=0.5 width=0.5
+		expect(state.panes[0].rect.x).toBeCloseTo(0);
+		expect(state.panes[0].rect.width).toBeCloseTo(0.5);
+		expect(state.panes[1].rect.x).toBeCloseTo(0.5);
+		expect(state.panes[1].rect.width).toBeCloseTo(0.5);
+	});
+
+	it("native capabilities do NOT include newWindow", async () => {
+		mocks.taskTerminalBackendIdentity.mockReturnValue("native");
+		mocks.getTask.mockResolvedValue(nativeTask);
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+		expect(state.capabilities).not.toContain("newWindow");
+		expect(state.capabilities).toContain("split");
+		expect(state.capabilities).toContain("focus");
+	});
+
+	it("throws for an unusable persisted backend identity", async () => {
+		mocks.taskTerminalBackendIdentity.mockImplementation(() => {
+			throw new Error("unusable backend: gibberish");
+		});
+		await expect(taskPanesHandlers.taskPaneState({ taskId: TASK_ID })).rejects.toThrow("unusable backend");
+	});
+});
+
+// ── taskPaneAction — tmux path ────────────────────────────────────────────────
+
+describe("taskPaneAction (tmux)", () => {
+	it("splitH delegates to tmuxAction with splitH", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitH" } });
+		expect(mocks.tmuxActionHelper).toHaveBeenCalledWith(expect.objectContaining({ action: "splitH" }));
+	});
+
+	it("splitV delegates to tmuxAction with splitV", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitV" } });
+		expect(mocks.tmuxActionHelper).toHaveBeenCalledWith(expect.objectContaining({ action: "splitV" }));
+	});
+
+	it("focus selects the specified pane", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focus", paneId: "%2" } });
+		expect(mocks.tmuxSelectPane).toHaveBeenCalledWith("%2", expect.anything());
+	});
+
+	it("focusStep:next selects .+ target", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusStep", step: "next" } });
+		expect(mocks.tmuxSelectPane).toHaveBeenCalledWith(expect.stringContaining(".+"), expect.anything());
+	});
+
+	it("focusStep:prev selects .- target", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusStep", step: "prev" } });
+		expect(mocks.tmuxSelectPane).toHaveBeenCalledWith(expect.stringContaining(".-"), expect.anything());
+	});
+
+	it("focusDirection calls selectPaneDirection", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusDirection", direction: "right" } });
+		expect(mocks.tmuxSelectPaneDirection).toHaveBeenCalledWith("dev3-aaaaaaaa", "right", expect.anything());
+	});
+
+	it("zoom (toggle) calls toggleZoom", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom" } });
+		expect(mocks.tmuxToggleZoom).toHaveBeenCalled();
+	});
+
+	it("zoom:on does not toggle if already zoomed", async () => {
+		mocks.readPaneLayout.mockResolvedValue({ ...twoPane80PaneLayout, zoomed: true });
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom", mode: "on" } });
+		expect(mocks.tmuxToggleZoom).not.toHaveBeenCalled();
+	});
+
+	it("zoom:off toggles when currently zoomed", async () => {
+		mocks.readPaneLayout.mockResolvedValue({ ...twoPane80PaneLayout, zoomed: true });
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom", mode: "off" } });
+		expect(mocks.tmuxToggleZoom).toHaveBeenCalled();
+	});
+
+	it("close with paneId delegates to tmuxKillPane helper", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close", paneId: "%2" } });
+		expect(mocks.tmuxKillPaneHelper).toHaveBeenCalledWith(
+			expect.objectContaining({ taskId: TASK_ID, paneId: "%2" }),
+		);
+	});
+
+	it("close without paneId delegates to tmuxAction killPane", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close" } });
+		expect(mocks.tmuxActionHelper).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "killPane" }),
+		);
+	});
+
+	it("close delegates to tmuxKillPane which runs handlePaneExited", async () => {
+		// tmuxKillPane internally calls handlePaneExited. Verify delegation occurs.
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close", paneId: "%2" } });
+		// tmuxKillPane was called — that function (when not mocked in real code) calls handlePaneExited
+		expect(mocks.tmuxKillPaneHelper).toHaveBeenCalledWith(
+			expect.objectContaining({ taskId: TASK_ID, paneId: "%2" }),
+		);
+	});
+
+	it("close force:true passes force through to tmuxKillPane", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close", paneId: "%1", force: true } });
+		expect(mocks.tmuxKillPaneHelper).toHaveBeenCalledWith(
+			expect.objectContaining({ force: true }),
+		);
+	});
+
+	it("close force:false (default) does NOT pass force=true to tmuxKillPane", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close", paneId: "%1" } });
+		expect(mocks.tmuxKillPaneHelper).toHaveBeenCalledWith(
+			expect.objectContaining({ force: undefined }),
+		);
+	});
+
+	it("resize calls resizePaneDirection", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "resize", direction: "right", amount: 10 } });
+		expect(mocks.tmuxResizePaneDirection).toHaveBeenCalledWith("dev3-aaaaaaaa", "right", 10, expect.anything());
+	});
+
+	it("resize uses default amount 5 when omitted", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "resize", direction: "down" } });
+		expect(mocks.tmuxResizePaneDirection).toHaveBeenCalledWith("dev3-aaaaaaaa", "down", 5, expect.anything());
+	});
+
+	it("layoutPreset calls selectLayout with the geometric name", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "layoutPreset", preset: "evenH" } });
+		// evenH → even-vertical
+		expect(mocks.tmuxSelectLayout).toHaveBeenCalledWith("dev3-aaaaaaaa", "even-vertical", expect.anything());
+	});
+
+	it("layoutPreset:evenV uses even-horizontal", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "layoutPreset", preset: "evenV" } });
+		expect(mocks.tmuxSelectLayout).toHaveBeenCalledWith("dev3-aaaaaaaa", "even-horizontal", expect.anything());
+	});
+
+	it("layoutPreset:mainH uses main-horizontal", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "layoutPreset", preset: "mainH" } });
+		expect(mocks.tmuxSelectLayout).toHaveBeenCalledWith("dev3-aaaaaaaa", "main-horizontal", expect.anything());
+	});
+
+	it("layoutCycle calls nextLayout and reports layoutPreset: null", async () => {
+		const state = await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "layoutCycle" } });
+		expect(mocks.tmuxNextLayout).toHaveBeenCalled();
+		// After nextLayout tmux cycles freely — we cannot name the preset
+		expect(state.layoutPreset).toBeNull();
+	});
+
+	it("returns fresh tmux state after every action", async () => {
+		const state = await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom" } });
+		expect(state.backend).toBe("tmux");
+		expect(state.panes).toHaveLength(2);
+	});
+});
+
+// ── taskPaneAction — native path ──────────────────────────────────────────────
+
+describe("taskPaneAction (native)", () => {
+	beforeEach(() => {
+		mocks.taskTerminalBackendIdentity.mockReturnValue("native");
+		mocks.getTask.mockResolvedValue(nativeTask);
+	});
+
+	it("splitH calls splitNativeTaskPane with orientation 'vertical'", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitH" } });
+		expect(mocks.splitNativeTaskPane).toHaveBeenCalledWith(
+			TASK_ID,
+			"pane-1", // active pane id from makeTwoPaneNativeState
+			"vertical",
+		);
+	});
+
+	it("splitV calls splitNativeTaskPane with orientation 'horizontal'", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitV" } });
+		expect(mocks.splitNativeTaskPane).toHaveBeenCalledWith(TASK_ID, expect.any(String), "horizontal");
+	});
+
+	it("focus calls focusNativeTaskPane", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focus", paneId: "pane-2" } });
+		expect(mocks.focusNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-2");
+	});
+
+	it("focusStep:next wraps to next pane by layout order", async () => {
+		const state = makeTwoPaneNativeState(); // activePaneId = pane-1
+		mocks.nativeTaskPanesState.mockResolvedValue(state);
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusStep", step: "next" } });
+		expect(mocks.focusNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-2");
+	});
+
+	it("focusStep:prev wraps from first pane to last", async () => {
+		const state = makeTwoPaneNativeState();
+		mocks.nativeTaskPanesState.mockResolvedValue(state);
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusStep", step: "prev" } });
+		// pane-1 is index 0; prev wraps to index 1 (pane-2)
+		expect(mocks.focusNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-2");
+	});
+
+	it("focusDirection calls setNativeTaskPaneLayout when direction finds a different pane", async () => {
+		// Two panes side by side — direction "right" from pane-1 should focus pane-2
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focusDirection", direction: "right" } });
+		expect(mocks.focusNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-2");
+	});
+
+	it("zoom:toggle updates layout via setNativeTaskPaneLayout", async () => {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom" } });
+		expect(mocks.setNativeTaskPaneLayout).toHaveBeenCalled();
+	});
+
+	it("zoom:on sets zoomedPaneId", async () => {
+		await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "zoom", mode: "on", paneId: "pane-2" },
+		});
+		// After zoomPane, the tree should have zoomedPaneId set; setNativeTaskPaneLayout was called with that tree
+		const calledTree = mocks.setNativeTaskPaneLayout.mock.calls[0][1];
+		expect(calledTree.zoomedPaneId).toBe("pane-2");
+	});
+
+	it("zoom:off clears zoomedPaneId", async () => {
+		// Pre-zoom the tree
+		const preZoomedState = makeTwoPaneNativeState();
+		const { restoreSplitTree: restore, zoomPane } = await import("../../../shared/split-tree");
+		const baseTree = restore(preZoomedState.layout)!;
+		const zoomedTree = zoomPane(baseTree, "pane-1");
+		mocks.nativeTaskPanesState.mockResolvedValue({
+			...preZoomedState,
+			layout: serializeSplitTree(zoomedTree),
+		});
+
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom", mode: "off" } });
+		const calledTree = mocks.setNativeTaskPaneLayout.mock.calls[0][1];
+		expect(calledTree.zoomedPaneId).toBeNull();
+	});
+
+	it("close with 1 pane and no force returns unchanged state (refuses)", async () => {
+		mocks.nativeTaskPanesState.mockResolvedValue(makeSingleNativeState());
+		const state = await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "close", force: false },
+		});
+		expect(mocks.closeNativeTaskPane).not.toHaveBeenCalled();
+		expect(state.panes).toHaveLength(1); // unchanged
+	});
+
+	it("close with 1 pane and force:true tears down session", async () => {
+		mocks.nativeTaskPanesState.mockResolvedValue(makeSingleNativeState());
+		mocks.closeNativeTaskPane.mockResolvedValue({ sessionTornDown: true, state: null });
+
+		const state = await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "close", force: true },
+		});
+		expect(mocks.closeNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-1");
+		// Session torn down → empty state returned
+		expect(state.panes).toHaveLength(0);
+	});
+
+	it("close with 2 panes and no force succeeds without confirm", async () => {
+		// Two panes: closing one should proceed without force
+		mocks.closeNativeTaskPane.mockResolvedValue({ sessionTornDown: false, state: makeSingleNativeState() });
+		const state = await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "close", paneId: "pane-2" },
+		});
+		expect(mocks.closeNativeTaskPane).toHaveBeenCalledWith(TASK_ID, "pane-2");
+		expect(state.panes).toHaveLength(1);
+	});
+
+	it("layoutPreset applies the correct geometric preset to the tree", async () => {
+		await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "layoutPreset", preset: "evenH" },
+		});
+		expect(mocks.setNativeTaskPaneLayout).toHaveBeenCalled();
+		// The tree passed should be the evenH layout (even-vertical in SplitTree)
+		const calledTree = mocks.setNativeTaskPaneLayout.mock.calls[0][1];
+		// applySplitLayout with even-vertical produces two equal-height panes
+		expect(calledTree.root.type).toBe("split");
+	});
+
+	it("layoutCycle computes nextPreset honestly from current geometry", async () => {
+		// Set up a tree that matches evenH (even-vertical preset)
+		const twoPane = makeTwoPaneNativeState();
+		const { restoreSplitTree: restore } = await import("../../../shared/split-tree");
+		const baseTree = restore(twoPane.layout)!;
+		const evenVTree = applySplitLayout(baseTree, "even-vertical");
+		mocks.nativeTaskPanesState.mockResolvedValue({
+			...twoPane,
+			layout: serializeSplitTree(evenVTree),
+		});
+
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "layoutCycle" } });
+		expect(mocks.setNativeTaskPaneLayout).toHaveBeenCalled();
+	});
+
+	it("resize adjusts the split ratio via setNativeTaskPaneLayout", async () => {
+		await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "resize", direction: "right", amount: 10 },
+		});
+		expect(mocks.setNativeTaskPaneLayout).toHaveBeenCalled();
+	});
+
+	it("native path issues NO tmux call — ever", async () => {
+		// Exercise the most common native actions and verify the tmux singleton is untouched
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitH" } });
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "zoom" } });
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "focus", paneId: "pane-2" } });
+
+		expect(mocks.tmuxSelectPane).not.toHaveBeenCalled();
+		expect(mocks.tmuxSelectPaneDirection).not.toHaveBeenCalled();
+		expect(mocks.tmuxToggleZoom).not.toHaveBeenCalled();
+		expect(mocks.tmuxSelectLayout).not.toHaveBeenCalled();
+		expect(mocks.tmuxNextLayout).not.toHaveBeenCalled();
+		expect(mocks.tmuxResizePaneDirection).not.toHaveBeenCalled();
+		expect(mocks.tmuxActionHelper).not.toHaveBeenCalled();
+		expect(mocks.tmuxKillPaneHelper).not.toHaveBeenCalled();
+	});
+});
+
+// ── native layoutPreset detection ────────────────────────────────────────────
+
+/**
+ * Three-pane native state: pane-1 | pane-2 on top, pane-3 on bottom (initial
+ * tiled-ish). Used for preset detection tests where 3 panes are needed to
+ * distinguish main-* from even-* (2-pane trees collapse to identical rects).
+ */
+function makeThreePaneNativeState(): NativeTaskPanesState {
+	// Build pane-1, pane-2, pane-3 in a vertical split
+	let tree = createSplitTree(); // pane-1
+	// Split pane-1 → pane-1 + pane-2 (horizontal)
+	tree = { ...tree, root: {
+		type: "split", id: "split-1", orientation: "horizontal", ratio: 0.5,
+		first: { type: "pane", id: "pane-1" },
+		second: { type: "pane", id: "pane-2" },
+	}, nextSplitOrdinal: 2, nextPaneOrdinal: 3 };
+	// Split pane-2 → pane-2 + pane-3 (vertical — stacked)
+	tree = { ...tree, root: {
+		type: "split", id: "split-2", orientation: "vertical", ratio: 0.5,
+		first: tree.root,
+		second: { type: "pane", id: "pane-3" },
+	}, nextSplitOrdinal: 3, nextPaneOrdinal: 4 };
+	return {
+		taskId: TASK_ID,
+		panes: [
+			{ paneId: "pane-1", sessionId: "sess-1", hostPid: 100, shellPid: 101, cols: 80, rows: 24, alive: true },
+			{ paneId: "pane-2", sessionId: "sess-2", hostPid: 102, shellPid: 103, cols: 80, rows: 24, alive: true },
+			{ paneId: "pane-3", sessionId: "sess-3", hostPid: 104, shellPid: 105, cols: 80, rows: 24, alive: true },
+		],
+		layout: serializeSplitTree(tree),
+		activePaneId: "pane-1",
+	};
+}
+
+describe("native layoutPreset detection", () => {
+	beforeEach(() => {
+		mocks.taskTerminalBackendIdentity.mockReturnValue("native");
+		mocks.getTask.mockResolvedValue(nativeTask);
+	});
+
+	async function stateForPreset(
+		base: NativeTaskPanesState,
+		preset: "even-horizontal" | "even-vertical" | "main-horizontal" | "main-vertical" | "tiled",
+	) {
+		const { restoreSplitTree: restore } = await import("../../../shared/split-tree");
+		const baseTree = restore(base.layout)!;
+		const presetTree = applySplitLayout(baseTree, preset);
+		mocks.nativeTaskPanesState.mockResolvedValue({ ...base, layout: serializeSplitTree(presetTree) });
+		return taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+	}
+
+	it("detects evenH after applying even-vertical (2 panes)", async () => {
+		const state = await stateForPreset(makeTwoPaneNativeState(), "even-vertical");
+		expect(state.layoutPreset).toBe("evenH");
+	});
+
+	it("detects evenV after applying even-horizontal (2 panes)", async () => {
+		const state = await stateForPreset(makeTwoPaneNativeState(), "even-horizontal");
+		expect(state.layoutPreset).toBe("evenV");
+	});
+
+	// For 3+ panes, main-* and even-* produce distinct geometries and are distinguishable.
+	it("detects mainH after applying main-horizontal (3 panes)", async () => {
+		const state = await stateForPreset(makeThreePaneNativeState(), "main-horizontal");
+		expect(state.layoutPreset).toBe("mainH");
+	});
+
+	it("detects mainV after applying main-vertical (3 panes)", async () => {
+		const state = await stateForPreset(makeThreePaneNativeState(), "main-vertical");
+		expect(state.layoutPreset).toBe("mainV");
+	});
+
+	it("detects tiled after applying tiled (3 panes)", async () => {
+		const state = await stateForPreset(makeThreePaneNativeState(), "tiled");
+		expect(state.layoutPreset).toBe("tiled");
+	});
+
+	it("reports null for a hand-built geometry that matches no preset", async () => {
+		// A custom 70/30 ratio matches no standard preset
+		const base = makeTwoPaneNativeState();
+		const { restoreSplitTree: restore } = await import("../../../shared/split-tree");
+		const baseTree = restore(base.layout)!;
+		const customTree = { ...baseTree, root: {
+			type: "split" as const, id: "split-1", orientation: "horizontal" as const, ratio: 0.7,
+			first: { type: "pane" as const, id: "pane-1" },
+			second: { type: "pane" as const, id: "pane-2" },
+		}, nextSplitOrdinal: 2, nextPaneOrdinal: 3 };
+		mocks.nativeTaskPanesState.mockResolvedValue({ ...base, layout: serializeSplitTree(customTree) });
+
+		const state = await taskPanesHandlers.taskPaneState({ taskId: TASK_ID });
+		expect(state.layoutPreset).toBeNull();
+	});
+});
+
+// ── tmuxNewWindow ─────────────────────────────────────────────────────────────
+
+describe("tmuxNewWindow", () => {
+	it("opens a new tmux window for a tmux task", async () => {
+		await taskPanesHandlers.tmuxNewWindow({ taskId: TASK_ID });
+		expect(mocks.tmuxNewWindow).toHaveBeenCalled();
+	});
+
+	it("is a no-op for a native task", async () => {
+		mocks.getTask.mockResolvedValue(nativeTask);
+		mocks.taskTerminalBackendIdentity.mockReturnValue("native");
+		await taskPanesHandlers.tmuxNewWindow({ taskId: TASK_ID });
+		expect(mocks.tmuxNewWindow).not.toHaveBeenCalled();
+	});
+});

--- a/src/bun/rpc-handlers/task-panes.ts
+++ b/src/bun/rpc-handlers/task-panes.ts
@@ -1,0 +1,501 @@
+/**
+ * Backend-neutral pane RPC handlers (seq 1311, PR2).
+ *
+ * `taskPaneState`  — read current pane geometry for any backend.
+ * `taskPaneAction` — execute a split/focus/zoom/close/layout/resize action.
+ * `tmuxNewWindow`  — tmux-only: open a new window in the task session.
+ *
+ * All tmux internals are delegated to the exported helpers from tmux-pty.ts.
+ * All native internals go through native-task-panes.ts.
+ */
+import * as pty from "../pty-server";
+import * as data from "../data";
+import {
+	tmux,
+	PANE_CWD_FORMAT,
+	TmuxError,
+} from "../tmux";
+import { taskTerminalBackendIdentity } from "../task-terminal-backend";
+import {
+	nativeTaskPanesState,
+	splitNativeTaskPane,
+	closeNativeTaskPane,
+	focusNativeTaskPane,
+	setNativeTaskPaneLayout,
+} from "../native-task-panes";
+import {
+	readPaneLayout,
+	tmuxAction,
+	tmuxKillPane,
+} from "./tmux-pty";
+import {
+	paneActionToSplitOrientation,
+	paneLayoutPresetToSplitPreset,
+	splitPresetToPaneLayoutPreset,
+} from "../../shared/pane-action-mapping";
+import {
+	focusPane,
+	getPaneRects,
+	listPaneIds,
+	restoreSplitTree,
+	resizeSplit,
+	toggleZoom,
+	unzoomPane,
+	zoomPane,
+	type SplitBranchNode,
+	type SplitNode,
+	type SplitOrientation,
+	type SplitPaneRect,
+	type SplitTree,
+} from "../../shared/split-tree";
+import { applySplitLayout, SPLIT_LAYOUT_PRESETS } from "../../shared/split-tree-layouts";
+import {
+	nextTaskPaneLayoutPreset,
+	type TaskPaneAction,
+	type TaskPaneCapability,
+	type TaskPaneInfo,
+	type TaskPaneLayoutPreset,
+	type TaskPaneState,
+} from "../../shared/task-panes";
+import { createLogger } from "../logger";
+
+const log = createLogger("task-panes");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Find a task by ID across all projects (git AND virtual/Operations boards). */
+async function findTaskAcrossProjects(taskId: string): Promise<{ task: import("../../shared/types").Task | null; project: import("../../shared/types").Project | null }> {
+	try {
+		const projects = [...await data.loadProjects(), ...await data.loadVirtualProjects()];
+		for (const project of projects) {
+			try {
+				const task = await data.getTask(project, taskId);
+				return { task, project };
+			} catch {
+				// task not in this project
+			}
+		}
+	} catch (err) {
+		log.error("Failed to load projects during task search", { taskId: taskId.slice(0, 8), error: String(err) });
+	}
+	return { task: null, project: null };
+}
+
+/** Build TaskPaneState from the live tmux layout for a task session. */
+async function tmuxTaskPaneState(taskId: string): Promise<TaskPaneState> {
+	const socket = pty.getSessionSocket(taskId);
+	const tmuxSession = pty.getSessionTmuxName(taskId);
+
+	const [paneLayout, tmuxLayout] = await Promise.all([
+		readPaneLayout(socket, tmuxSession),
+		pty.getTmuxLayout(taskId, socket),
+	]);
+
+	const activeWindow = tmuxLayout.windows.find((w) => w.active) ?? tmuxLayout.windows[0];
+	const winPanes = activeWindow
+		? tmuxLayout.panes.filter((p) => p.windowIndex === activeWindow.index)
+		: [];
+
+	const winW = winPanes.length > 0 ? Math.max(1, ...winPanes.map((p) => p.left + p.width)) : 1;
+	const winH = winPanes.length > 0 ? Math.max(1, ...winPanes.map((p) => p.top + p.height)) : 1;
+
+	const panes: TaskPaneInfo[] = paneLayout.paneIds.map((paneId, i) => {
+		const geom = winPanes.find((p) => p.paneId === paneId);
+		return {
+			paneId,
+			index: i,
+			label: paneLayout.labels[i] ?? "",
+			active: i === paneLayout.activeIndex,
+			zoomed: paneLayout.zoomed && i === paneLayout.activeIndex,
+			rect: geom
+				? {
+					x: geom.left / winW,
+					y: geom.top / winH,
+					width: geom.width / winW,
+					height: geom.height / winH,
+				}
+				: { x: 0, y: 0, width: 1, height: 1 },
+		};
+	});
+
+	const count = panes.length;
+	const capabilities: TaskPaneCapability[] = [
+		"split",
+		"zoom",
+		"newWindow",
+	];
+	if (count > 1) {
+		capabilities.push("focus", "focusDirection", "close", "closePick", "layoutPreset", "layoutCycle");
+	} else if (count === 1) {
+		capabilities.push("close");
+	}
+
+	return {
+		backend: "tmux",
+		panes,
+		activePaneId: panes[paneLayout.activeIndex]?.paneId ?? null,
+		zoomedPaneId: paneLayout.zoomed ? (panes[paneLayout.activeIndex]?.paneId ?? null) : null,
+		layout: null,
+		layoutPreset: null,
+		capabilities,
+	};
+}
+
+const RECT_EPS = 0.001;
+
+function rectsMatch(
+	a: Map<string, SplitPaneRect>,
+	b: Map<string, SplitPaneRect>,
+	ids: string[],
+): boolean {
+	for (const id of ids) {
+		const ra = a.get(id);
+		const rb = b.get(id);
+		if (!ra || !rb) return false;
+		if (
+			Math.abs(ra.x - rb.x) > RECT_EPS ||
+			Math.abs(ra.y - rb.y) > RECT_EPS ||
+			Math.abs(ra.width - rb.width) > RECT_EPS ||
+			Math.abs(ra.height - rb.height) > RECT_EPS
+		) return false;
+	}
+	return true;
+}
+
+function detectLayoutPreset(tree: SplitTree): TaskPaneLayoutPreset | null {
+	const ids = listPaneIds(tree);
+	if (ids.length < 2) return null;
+	const currentRects = getPaneRects(tree);
+	for (const preset of SPLIT_LAYOUT_PRESETS) {
+		const testTree = applySplitLayout(tree, preset);
+		const testRects = getPaneRects(testTree);
+		if (rectsMatch(currentRects, testRects, ids)) {
+			return splitPresetToPaneLayoutPreset(preset);
+		}
+	}
+	return null;
+}
+
+/** Build TaskPaneState from a NativeTaskPanesState. */
+function nativeStateToTaskPaneState(
+	nativeState: import("../native-task-panes").NativeTaskPanesState,
+	tree: SplitTree | null,
+): TaskPaneState {
+	const rects = tree ? getPaneRects(tree) : new Map<string, SplitPaneRect>();
+	const zoomedPaneId = tree?.zoomedPaneId ?? null;
+	const activePaneId = nativeState.activePaneId || null;
+	const layoutPreset = tree ? detectLayoutPreset(tree) : null;
+
+	const panes: TaskPaneInfo[] = nativeState.panes.map((p, i) => ({
+		paneId: p.paneId,
+		index: i,
+		label: "",
+		active: p.paneId === activePaneId,
+		zoomed: p.paneId === zoomedPaneId,
+		rect: rects.get(p.paneId) ?? { x: 0, y: 0, width: 1, height: 1 },
+		sessionKey: p.sessionId,
+		hostPid: p.hostPid,
+		shellPid: p.shellPid,
+		alive: p.alive,
+	}));
+
+	const count = panes.length;
+	const capabilities: TaskPaneCapability[] = ["split", "zoom", "resize"];
+	if (count > 1) {
+		capabilities.push("focus", "focusDirection", "close", "closePick", "layoutPreset", "layoutCycle");
+	} else if (count === 1) {
+		capabilities.push("close");
+	}
+
+	return {
+		backend: "native",
+		panes,
+		activePaneId,
+		zoomedPaneId,
+		layout: nativeState.layout,
+		layoutPreset,
+		capabilities,
+	};
+}
+
+/** Walk the tree to find the closest ancestor split of the given orientation containing paneId. */
+function findSplitForResize(root: SplitNode, paneId: string, orientation: SplitOrientation): string | null {
+	function walk(node: SplitNode): { found: boolean; splitId: string | null } {
+		if (node.type === "pane") return { found: node.id === paneId, splitId: null };
+		const first = walk(node.first);
+		const second = walk(node.second);
+		if (!first.found && !second.found) return { found: false, splitId: null };
+		if (first.found && first.splitId) return { found: true, splitId: first.splitId };
+		if (second.found && second.splitId) return { found: true, splitId: second.splitId };
+		if ((node as SplitBranchNode).orientation === orientation) return { found: true, splitId: node.id };
+		return { found: true, splitId: null };
+	}
+	return walk(root).splitId;
+}
+
+// ── Handler: taskPaneState ────────────────────────────────────────────────────
+
+async function taskPaneState(params: { taskId: string }): Promise<TaskPaneState> {
+	const { task } = await findTaskAcrossProjects(params.taskId);
+	if (!task) {
+		// Fallback: assume tmux (legacy task not found)
+		return tmuxTaskPaneState(params.taskId);
+	}
+
+	const identity = taskTerminalBackendIdentity(task);
+
+	if (identity === "native") {
+		const nativeState = await nativeTaskPanesState(params.taskId);
+		if (!nativeState) {
+			return {
+				backend: "native",
+				panes: [],
+				activePaneId: null,
+				zoomedPaneId: null,
+				layout: null,
+				layoutPreset: null,
+				capabilities: ["split"],
+			};
+		}
+		const tree = nativeState.layout ? restoreSplitTree(nativeState.layout) : null;
+		return nativeStateToTaskPaneState(nativeState, tree);
+	}
+
+	return tmuxTaskPaneState(params.taskId);
+}
+
+// ── Handler: taskPaneAction ───────────────────────────────────────────────────
+
+async function taskPaneAction(params: { taskId: string; action: TaskPaneAction }): Promise<TaskPaneState> {
+	const { action, taskId } = params;
+
+	const { task } = await findTaskAcrossProjects(taskId);
+	if (!task) throw new Error(`Task ${taskId.slice(0, 8)} not found`);
+
+	const identity = taskTerminalBackendIdentity(task);
+
+	if (identity === "native") {
+		return nativePaneAction(taskId, action);
+	}
+	return tmuxPaneAction(taskId, action);
+}
+
+// ── tmux pane action dispatch ─────────────────────────────────────────────────
+
+async function tmuxPaneAction(taskId: string, action: TaskPaneAction): Promise<TaskPaneState> {
+	const socket = pty.getSessionSocket(taskId);
+	const tmuxSession = pty.getSessionTmuxName(taskId);
+
+	switch (action.kind) {
+		case "splitH":
+		case "splitV": {
+			await tmuxAction({ taskId, action: action.kind });
+			break;
+		}
+		case "focus": {
+			try {
+				await tmux.selectPane(action.paneId, { socket });
+			} catch (err) {
+				if (!(err instanceof TmuxError)) throw err;
+			}
+			break;
+		}
+		case "focusStep": {
+			const target = action.step === "next"
+				? `${tmuxSession}:.+`
+				: `${tmuxSession}:.-`;
+			await tmux.selectPane(target, { socket, bestEffort: true });
+			break;
+		}
+		case "focusDirection": {
+			await tmux.selectPaneDirection(tmuxSession, action.direction, { socket, bestEffort: true });
+			break;
+		}
+		case "zoom": {
+			if (!action.mode || action.mode === "toggle") {
+				await tmux.toggleZoom(tmuxSession, { socket });
+			} else {
+				// on/off: read current zoom, toggle only on mismatch
+				const paneLayout = await readPaneLayout(socket, tmuxSession);
+				const wantZoomed = action.mode === "on";
+				if (paneLayout.zoomed !== wantZoomed) {
+					await tmux.toggleZoom(tmuxSession, { socket });
+				}
+			}
+			break;
+		}
+		case "close": {
+			if (action.paneId) {
+				await tmuxKillPane({ taskId, paneId: action.paneId, force: action.force });
+			} else {
+				await tmuxAction({ taskId, action: "killPane", force: action.force });
+			}
+			break;
+		}
+		case "resize": {
+			await tmux.resizePaneDirection(tmuxSession, action.direction, action.amount ?? 5, { socket });
+			break;
+		}
+		case "layoutPreset": {
+			const layout = paneLayoutPresetToSplitPreset(action.preset);
+			// paneLayoutPresetToSplitPreset returns the SplitTree name which is also the tmux name
+			await tmux.selectLayout(tmuxSession, layout, { socket });
+			break;
+		}
+		case "layoutCycle": {
+			await tmux.nextLayout(tmuxSession, { socket });
+			break;
+		}
+	}
+
+	return tmuxTaskPaneState(taskId);
+}
+
+// ── native pane action dispatch ───────────────────────────────────────────────
+
+async function nativePaneAction(taskId: string, action: TaskPaneAction): Promise<TaskPaneState> {
+	// Read current state first — most actions need the active pane id or tree
+	const nativeState = await nativeTaskPanesState(taskId);
+	if (!nativeState) throw new Error(`No native pane set for task ${taskId.slice(0, 8)}`);
+
+	const tree = nativeState.layout ? restoreSplitTree(nativeState.layout) : null;
+	let updatedState = nativeState;
+
+	switch (action.kind) {
+		case "splitH":
+		case "splitV": {
+			const orientation = paneActionToSplitOrientation(action.kind);
+			const fromPaneId = action.paneId ?? nativeState.activePaneId;
+			if (!fromPaneId) throw new Error("No active pane to split from");
+			const { state } = await splitNativeTaskPane(taskId, fromPaneId, orientation);
+			updatedState = state;
+			break;
+		}
+		case "focus": {
+			updatedState = await focusNativeTaskPane(taskId, action.paneId);
+			break;
+		}
+		case "focusStep": {
+			if (!tree) break;
+			const ids = listPaneIds(tree);
+			if (ids.length < 2) break;
+			const activeIdx = ids.indexOf(nativeState.activePaneId);
+			let nextIdx: number;
+			if (action.step === "next") {
+				nextIdx = (activeIdx + 1) % ids.length;
+			} else {
+				nextIdx = (activeIdx - 1 + ids.length) % ids.length;
+			}
+			updatedState = await focusNativeTaskPane(taskId, ids[nextIdx]);
+			break;
+		}
+		case "focusDirection": {
+			if (!tree) break;
+			const focused = focusPane(tree, action.direction);
+			if (focused.activePaneId !== tree.activePaneId) {
+				updatedState = await focusNativeTaskPane(taskId, focused.activePaneId);
+			}
+			break;
+		}
+		case "zoom": {
+			if (!tree) break;
+			let newTree: SplitTree;
+			if (!action.mode || action.mode === "toggle") {
+				newTree = toggleZoom(tree, action.paneId ?? tree.activePaneId);
+			} else if (action.mode === "on") {
+				newTree = zoomPane(tree, action.paneId ?? tree.activePaneId);
+			} else {
+				newTree = unzoomPane(tree);
+			}
+			updatedState = await setNativeTaskPaneLayout(taskId, newTree);
+			break;
+		}
+		case "close": {
+			const paneId = action.paneId ?? nativeState.activePaneId;
+			if (!paneId) throw new Error("No pane to close");
+
+			const paneCount = nativeState.panes.length;
+			if (paneCount <= 1 && !action.force) {
+				// Refuse to close last pane without force — return unchanged state
+				const currentTree = tree;
+				return nativeStateToTaskPaneState(nativeState, currentTree);
+			}
+
+			const { state } = await closeNativeTaskPane(taskId, paneId);
+			if (!state) {
+				// Session torn down — return empty state
+				return {
+					backend: "native",
+					panes: [],
+					activePaneId: null,
+					zoomedPaneId: null,
+					layout: null,
+					layoutPreset: null,
+					capabilities: ["split"],
+				};
+			}
+			updatedState = state;
+			break;
+		}
+		case "resize": {
+			if (!tree) break;
+			// left/right → horizontal split axis; up/down → vertical split axis
+			const orientation: SplitOrientation =
+				action.direction === "left" || action.direction === "right" ? "horizontal" : "vertical";
+			const activePaneId = action.paneId ?? nativeState.activePaneId;
+			const splitId = findSplitForResize(tree.root, activePaneId, orientation);
+			if (!splitId) break;
+			const delta =
+				action.direction === "right" || action.direction === "down"
+					? (action.amount ?? 5) / 100
+					: -(action.amount ?? 5) / 100;
+			const newTree = resizeSplit(tree, splitId, delta);
+			updatedState = await setNativeTaskPaneLayout(taskId, newTree);
+			break;
+		}
+		case "layoutPreset": {
+			if (!tree) break;
+			const splitPreset = paneLayoutPresetToSplitPreset(action.preset);
+			const newTree = applySplitLayout(tree, splitPreset);
+			updatedState = await setNativeTaskPaneLayout(taskId, newTree);
+			break;
+		}
+		case "layoutCycle": {
+			if (!tree) break;
+			const currentPreset = detectLayoutPreset(tree);
+			const nextPreset = nextTaskPaneLayoutPreset(currentPreset);
+			const splitPreset = paneLayoutPresetToSplitPreset(nextPreset);
+			const newTree = applySplitLayout(tree, splitPreset);
+			updatedState = await setNativeTaskPaneLayout(taskId, newTree);
+			break;
+		}
+	}
+
+	const updatedTree = updatedState.layout ? restoreSplitTree(updatedState.layout) : null;
+	return nativeStateToTaskPaneState(updatedState, updatedTree);
+}
+
+// ── Handler: tmuxNewWindow ────────────────────────────────────────────────────
+
+async function tmuxNewWindow(params: { taskId: string }): Promise<void> {
+	const { task } = await findTaskAcrossProjects(params.taskId);
+	// No-op for native tasks — newWindow is tmux-only
+	if (task && taskTerminalBackendIdentity(task) === "native") return;
+
+	const socket = pty.getSessionSocket(params.taskId);
+	const tmuxSession = pty.getSessionTmuxName(params.taskId);
+	try {
+		await tmux.newWindow({ target: tmuxSession, cwd: PANE_CWD_FORMAT, socket });
+	} catch (err) {
+		if (!(err instanceof TmuxError)) throw err;
+		throw new Error(`tmux new-window failed: ${err.stderr || "unknown error"}`);
+	}
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+export const taskPanesHandlers = {
+	taskPaneState,
+	taskPaneAction,
+	tmuxNewWindow,
+};

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1785,7 +1785,7 @@ async function killTmuxSession(params: { sessionName: string }): Promise<void> {
 	log.info("← killTmuxSession done", { sessionName: params.sessionName });
 }
 
-async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV"; force?: boolean }): Promise<void> {
+export async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV"; force?: boolean }): Promise<void> {
 	log.info("→ tmuxAction", { taskId: params.taskId.slice(0, 8), action: params.action, force: params.force === true });
 	const socket = pty.getSessionSocket(params.taskId);
 	const tmuxSession = pty.getSessionTmuxName(params.taskId);
@@ -1870,7 +1870,7 @@ async function tmuxAction(params: { taskId: string; action: "splitH" | "splitV" 
 	log.info("← tmuxAction done", { taskId: params.taskId.slice(0, 8), action: params.action });
 }
 
-async function tmuxPaneCount(params: { taskId: string }): Promise<{ count: number }> {
+export async function tmuxPaneCount(params: { taskId: string }): Promise<{ count: number }> {
 	const socket = pty.getSessionSocket(params.taskId);
 	const tmuxSession = pty.getSessionTmuxName(params.taskId);
 	try {
@@ -1892,7 +1892,7 @@ async function tmuxPaneCount(params: { taskId: string }): Promise<{ count: numbe
  * own session), and clean up sessionState via handlePaneExited (kill-pane does
  * not fire tmux's pane-exited hook).
  */
-async function tmuxKillPane(params: { taskId: string; paneId: string; force?: boolean }): Promise<{ killed: boolean }> {
+export async function tmuxKillPane(params: { taskId: string; paneId: string; force?: boolean }): Promise<{ killed: boolean }> {
 	log.info("→ tmuxKillPane", { taskId: params.taskId.slice(0, 8), paneId: params.paneId, force: params.force === true });
 	// The pane id always originates from our own tmuxLayout (`%N`); validate the
 	// shape defensively before it reaches a spawn arg.
@@ -1931,7 +1931,7 @@ async function tmuxKillPane(params: { taskId: string; paneId: string; force?: bo
 	return { killed: true };
 }
 
-interface PaneLayoutInfo {
+export interface PaneLayoutInfo {
 	count: number;
 	activeIndex: number;
 	zoomed: boolean;
@@ -1950,7 +1950,7 @@ interface PaneLayoutInfo {
  * equal to host_short is treated as unset — else the running command, else "".
  * The frontend localises the empty fallback to "Pane N".
  */
-async function readPaneLayout(socket: string, tmuxSession: string): Promise<PaneLayoutInfo> {
+export async function readPaneLayout(socket: string, tmuxSession: string): Promise<PaneLayoutInfo> {
 	try {
 		const rows = await tmux.listPanes(PANE_SWITCHER_FORMAT, { target: tmuxSession, socket });
 		const paneIds: string[] = [];
@@ -1983,7 +1983,7 @@ async function readPaneLayout(socket: string, tmuxSession: string): Promise<Pane
  * (read the flag, toggle only on a mismatch) so a doubled call — React Strict
  * Mode, a retry, a poll racing a tap — never flips zoom the wrong way.
  */
-async function tmuxPaneNavigate(params: {
+export async function tmuxPaneNavigate(params: {
 	taskId: string;
 	step?: "next" | "prev";
 	index?: number;
@@ -2752,10 +2752,6 @@ export const tmuxPtyHandlers = {
 	getPortAllocations,
 	listTmuxSessions,
 	killTmuxSession,
-	tmuxAction,
-	tmuxPaneCount,
-	tmuxKillPane,
-	tmuxPaneNavigate,
 	tmuxLayout,
 	tmuxWindowNavigate,
 	tmuxAltClickMoveCursor,

--- a/src/bun/tmux/client.ts
+++ b/src/bun/tmux/client.ts
@@ -388,6 +388,18 @@ export class TmuxClient {
 		return this.runCommand(opts?.socket, ["resize-pane", "-Z", "-t", target], opts);
 	}
 
+	/** `select-pane -L/-R/-U/-D -t` — move focus by direction. */
+	selectPaneDirection(target: string, direction: "left" | "right" | "up" | "down", opts?: CommandOpts): Promise<void> {
+		const flag = { left: "-L", right: "-R", up: "-U", down: "-D" }[direction];
+		return this.runCommand(opts?.socket, ["select-pane", flag, "-t", target], opts);
+	}
+
+	/** `resize-pane -L/-R/-U/-D -t <target> <amount>`. */
+	resizePaneDirection(target: string, direction: "left" | "right" | "up" | "down", amount: number, opts?: CommandOpts): Promise<void> {
+		const flag = { left: "-L", right: "-R", up: "-U", down: "-D" }[direction];
+		return this.runCommand(opts?.socket, ["resize-pane", flag, "-t", target, String(amount)], opts);
+	}
+
 	/**
 	 * `send-keys -t <target> <keys…>` — each entry is one tmux key argument.
 	 * `literal` adds `-l` so the entries are sent as raw text (control bytes

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1507,7 +1507,19 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, touc
 
 			e.preventDefault();
 			e.stopPropagation();
-			api.request.tmuxAction({ taskId, action: binding.action }).catch(() => {});
+			const a = binding.action;
+			if (a === "newWindow") {
+				api.request.tmuxNewWindow({ taskId }).catch(() => {});
+			} else if (a === "close") {
+				api.request.taskPaneAction({ taskId, action: { kind: "close" } }).catch(() => {});
+			} else if (a === "focusStep:next") {
+				api.request.taskPaneAction({ taskId, action: { kind: "focusStep", step: "next" } }).catch(() => {});
+			} else if (a === "focusStep:prev") {
+				api.request.taskPaneAction({ taskId, action: { kind: "focusStep", step: "prev" } }).catch(() => {});
+			} else {
+				// splitH, splitV, zoom
+				api.request.taskPaneAction({ taskId, action: { kind: a } }).catch(() => {});
+			}
 		}
 		window.addEventListener("keydown", handleKeydown, { capture: true });
 		return () => window.removeEventListener("keydown", handleKeydown, { capture: true });

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -104,7 +104,8 @@ vi.mock("../rpc", () => ({
 		request: {
 			uploadFileBase64: vi.fn(),
 			pasteClipboardImage: vi.fn(),
-			tmuxAction: vi.fn(),
+			taskPaneAction: vi.fn(),
+			tmuxNewWindow: vi.fn(),
 			tmuxAltClickMoveCursor: vi.fn().mockResolvedValue({ moved: true }),
 			exitCopyModeAllPanes: vi.fn().mockResolvedValue({ panesExited: 1 }),
 			logRendererEvent: vi.fn().mockResolvedValue(undefined),
@@ -469,7 +470,7 @@ describe("TerminalView – focus-on-type", () => {
 
 // ── Terminal keymap shortcuts ─────────────────────────────────────────────────
 
-const mockedTmuxAction = vi.mocked(api.request.tmuxAction);
+const mockedTaskPaneAction = vi.mocked(api.request.taskPaneAction);
 const mockedUploadFileBase64 = vi.mocked(api.request.uploadFileBase64);
 const mockedCopyTerminalSelection = vi.mocked(api.request.copyTerminalSelection);
 const mockedExitCopyModeAllPanes = vi.mocked(api.request.exitCopyModeAllPanes);
@@ -507,13 +508,13 @@ function dispatchDrop(target: Element, files: File[]) {
 describe("TerminalView – keymap shortcuts", () => {
 	beforeEach(() => {
 		localStorage.clear();
-		mockedTmuxAction.mockClear();
-		mockedTmuxAction.mockResolvedValue(undefined as any);
+		mockedTaskPaneAction.mockClear();
+		mockedTaskPaneAction.mockResolvedValue(undefined as any);
 		mockedUploadFileBase64.mockReset();
 		lastWebSocket = null;
 	});
 
-	it("iterm2 mode: Cmd+W calls tmuxAction with killPane", async () => {
+	it("iterm2 mode: Cmd+W calls taskPaneAction with close", async () => {
 		localStorage.setItem(KEYMAP_LS_KEY, "iterm2");
 		await renderAndSetup();
 		const target = focusInsideTerminal();
@@ -522,7 +523,7 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).toHaveBeenCalledWith({ taskId: "t1", action: "killPane" });
+		expect(mockedTaskPaneAction).toHaveBeenCalledWith({ taskId: "t1", action: { kind: "close" } });
 		target.remove();
 	});
 
@@ -535,7 +536,7 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyD", metaKey: true, shiftKey: false, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).toHaveBeenCalledWith({ taskId: "t1", action: "splitV" });
+		expect(mockedTaskPaneAction).toHaveBeenCalledWith({ taskId: "t1", action: { kind: "splitV" } });
 		target.remove();
 	});
 
@@ -548,11 +549,11 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyD", metaKey: true, shiftKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).toHaveBeenCalledWith({ taskId: "t1", action: "splitH" });
+		expect(mockedTaskPaneAction).toHaveBeenCalledWith({ taskId: "t1", action: { kind: "splitH" } });
 		target.remove();
 	});
 
-	it("default preset (nothing stored): Cmd+W calls tmuxAction (iTerm2 is the default)", async () => {
+	it("default preset (nothing stored): Cmd+W calls taskPaneAction (iTerm2 is the default)", async () => {
 		// No localStorage entry — iTerm2 hotkeys ship on by default.
 		await renderAndSetup();
 		const target = focusInsideTerminal();
@@ -561,11 +562,11 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).toHaveBeenCalledWith({ taskId: "t1", action: "killPane" });
+		expect(mockedTaskPaneAction).toHaveBeenCalledWith({ taskId: "t1", action: { kind: "close" } });
 		target.remove();
 	});
 
-	it("default mode (explicit opt-out): Cmd+W does NOT call tmuxAction", async () => {
+	it("default mode (explicit opt-out): Cmd+W does NOT call taskPaneAction", async () => {
 		localStorage.setItem(KEYMAP_LS_KEY, "default");
 		await renderAndSetup();
 		const target = focusInsideTerminal();
@@ -574,11 +575,11 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).not.toHaveBeenCalled();
+		expect(mockedTaskPaneAction).not.toHaveBeenCalled();
 		target.remove();
 	});
 
-	it("tmux-native mode: Cmd+W does NOT call tmuxAction", async () => {
+	it("tmux-native mode: Cmd+W does NOT call taskPaneAction", async () => {
 		localStorage.setItem(KEYMAP_LS_KEY, "tmux-native");
 		await renderAndSetup();
 		const target = focusInsideTerminal();
@@ -587,7 +588,7 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).not.toHaveBeenCalled();
+		expect(mockedTaskPaneAction).not.toHaveBeenCalled();
 		target.remove();
 	});
 
@@ -600,7 +601,7 @@ describe("TerminalView – keymap shortcuts", () => {
 			window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW", metaKey: true, bubbles: true }));
 		});
 
-		expect(mockedTmuxAction).not.toHaveBeenCalled();
+		expect(mockedTaskPaneAction).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/mainview/__tests__/terminal-keymaps.test.ts
+++ b/src/mainview/__tests__/terminal-keymaps.test.ts
@@ -74,8 +74,8 @@ describe("TERMINAL_KEYMAPS", () => {
 		}
 	});
 
-	it("Cmd+W maps to killPane", () => {
-		const binding = TERMINAL_KEYMAPS["iterm2"].find((b) => b.action === "killPane");
+	it("Cmd+W maps to close", () => {
+		const binding = TERMINAL_KEYMAPS["iterm2"].find((b) => b.action === "close");
 		expect(binding).toBeDefined();
 		expect(binding!.code).toBe("KeyW");
 		expect(binding!.meta).toBe(true);

--- a/src/mainview/components/ClosePanePicker.tsx
+++ b/src/mainview/components/ClosePanePicker.tsx
@@ -163,7 +163,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 			}
 			setBusy(true);
 			try {
-				await api.request.tmuxKillPane({ taskId, paneId: box.paneId, force: true });
+				await api.request.taskPaneAction({ taskId, action: { kind: "close", paneId: box.paneId, force: true } });
 			} catch {
 				toast.error(t("tmux.pickPaneError"), { taskId });
 			}
@@ -172,7 +172,7 @@ export default function ClosePanePicker({ taskId }: ClosePanePickerProps) {
 		}
 		setBusy(true);
 		try {
-			await api.request.tmuxKillPane({ taskId, paneId: box.paneId });
+			await api.request.taskPaneAction({ taskId, action: { kind: "close", paneId: box.paneId } });
 		} catch {
 			toast.error(t("tmux.pickPaneError"), { taskId });
 		}

--- a/src/mainview/components/MobilePaneCarousel.tsx
+++ b/src/mainview/components/MobilePaneCarousel.tsx
@@ -6,7 +6,7 @@ import BottomSheet from "./BottomSheet";
 import PaneMapSheet from "./PaneMapSheet";
 import { ClosePaneIcon, ManagePanesIcon, NewWindowIcon, SplitHIcon, SplitVIcon } from "./TmuxIcons";
 
-type ManageAction = "splitH" | "splitV" | "newWindow" | "killPane";
+type ManageAction = "splitH" | "splitV" | "newWindow" | "close";
 
 /**
  * Narrow-viewport terminal pane switcher. The tmux window is kept zoomed to one
@@ -32,6 +32,7 @@ interface PaneInfo {
 	activeIndex: number;
 	zoomed: boolean;
 	labels: string[];
+	paneIds: string[];
 }
 
 function prefersReducedMotion(): boolean {
@@ -40,7 +41,7 @@ function prefersReducedMotion(): boolean {
 
 function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; refreshKey?: number; children: ReactNode }) {
 	const t = useT();
-	const [info, setInfo] = useState<PaneInfo>({ count: 0, activeIndex: 0, zoomed: false, labels: [] });
+	const [info, setInfo] = useState<PaneInfo>({ count: 0, activeIndex: 0, zoomed: false, labels: [], paneIds: [] });
 	const [dragDx, setDragDx] = useState(0);
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [mapOpen, setMapOpen] = useState(false);
@@ -55,12 +56,47 @@ function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; 
 	const countRef = useRef(0);
 	countRef.current = info.count;
 
+	/** Read current pane info and update state; optionally navigate and/or enforce zoom. */
 	const navigate = useCallback(
 		async (opts?: { step?: "next" | "prev"; index?: number; paneId?: string; zoom?: boolean }): Promise<PaneInfo | null> => {
 			if (busyRef.current) return null;
 			busyRef.current = true;
 			try {
-				const res = await api.request.tmuxPaneNavigate({ taskId, ...opts });
+				if (opts?.step) {
+					await api.request.taskPaneAction({
+						taskId,
+						action: { kind: "focusStep", step: opts.step },
+					});
+				} else if (typeof opts?.index === "number") {
+					// Resolve index to paneId from current info (best-effort)
+					const targetPaneId = info.paneIds[opts.index];
+					if (targetPaneId) {
+						await api.request.taskPaneAction({
+							taskId,
+							action: { kind: "focus", paneId: targetPaneId },
+						});
+					}
+				} else if (opts?.paneId) {
+					await api.request.taskPaneAction({
+						taskId,
+						action: { kind: "focus", paneId: opts.paneId },
+					});
+				}
+				if (typeof opts?.zoom === "boolean") {
+					await api.request.taskPaneAction({
+						taskId,
+						action: { kind: "zoom", mode: opts.zoom ? "on" : "off" },
+					});
+				}
+				const state = await api.request.taskPaneState({ taskId });
+				const activeIdx = state.panes.findIndex((p) => p.active);
+				const res: PaneInfo = {
+					count: state.panes.length,
+					activeIndex: activeIdx < 0 ? 0 : activeIdx,
+					zoomed: !!state.zoomedPaneId,
+					labels: state.panes.map((p) => p.label),
+					paneIds: state.panes.map((p) => p.paneId),
+				};
 				setInfo(res);
 				return res;
 			} catch {
@@ -69,7 +105,7 @@ function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; 
 				busyRef.current = false;
 			}
 		},
-		[taskId],
+		[taskId, info.paneIds],
 	);
 
 	// Create / close panes and windows from the sheet. The ⌃B prefix is the only
@@ -80,12 +116,14 @@ function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; 
 	const runManageAction = useCallback(
 		async (action: ManageAction) => {
 			setSheetOpen(false);
-			if (action === "killPane") {
-				// Closing the only pane in the session tears down tmux (and the agent).
-				// Count session-wide (matches the backend's last-pane guard) and confirm.
+			if (action === "newWindow") {
+				await api.request.tmuxNewWindow({ taskId }).catch(() => {});
+			} else if (action === "close") {
+				// Closing the only pane tears down the session — confirm first.
 				let count = 0;
 				try {
-					count = (await api.request.tmuxPaneCount({ taskId })).count;
+					const state = await api.request.taskPaneState({ taskId });
+					count = state.panes.length;
 				} catch {
 					count = 0;
 				}
@@ -101,12 +139,12 @@ function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; 
 						confirmed = false;
 					}
 					if (!confirmed) return;
-					await api.request.tmuxAction({ taskId, action, force: true }).catch(() => {});
+					await api.request.taskPaneAction({ taskId, action: { kind: "close", force: true } }).catch(() => {});
 				} else {
-					await api.request.tmuxAction({ taskId, action }).catch(() => {});
+					await api.request.taskPaneAction({ taskId, action: { kind: "close" } }).catch(() => {});
 				}
 			} else {
-				await api.request.tmuxAction({ taskId, action }).catch(() => {});
+				await api.request.taskPaneAction({ taskId, action: { kind: action } }).catch(() => {});
 			}
 			await navigate({ zoom: true });
 		},
@@ -443,7 +481,7 @@ function MobilePaneCarousel({ taskId, refreshKey, children }: { taskId: string; 
 
 					<button
 						type="button"
-						onClick={() => void runManageAction("killPane")}
+						onClick={() => void runManageAction("close")}
 						className="tmux-anim w-full flex items-center gap-3 min-h-[44px] px-3 rounded-xl text-left text-sm text-danger hover:bg-danger/10 transition-colors"
 					>
 						<span>

--- a/src/mainview/components/PaneMapSheet.tsx
+++ b/src/mainview/components/PaneMapSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { TmuxLayout, TmuxPaneInfo, TmuxWindowInfo } from "../../shared/types";
+import type { TaskPaneState } from "../../shared/task-panes";
 import { api } from "../rpc";
 import { useT } from "../i18n";
 import BottomSheet from "./BottomSheet";
@@ -8,34 +8,31 @@ interface PaneMapSheetProps {
 	taskId: string;
 	open: boolean;
 	onClose: () => void;
-	/** Jump to a pane by its tmux pane id (e.g. "%5") and zoom it. */
+	/** Jump to a pane by its backend-stable pane id and zoom it. */
 	onJump: (paneId: string) => void | Promise<void>;
 }
 
 /**
- * Narrow-viewport "zoom-out" overview: a spatial mini-map of the active tmux
- * window's panes, positioned by their real geometry (pane_left/top/width/height)
- * — the same picture `dev3 ui state` prints as ASCII boxes. Tap a box to jump to
- * (and zoom) that pane. When the session has more than one window, a read-only
- * window list is shown below as the foundation for a future windows switcher.
+ * Narrow-viewport "zoom-out" overview: a spatial mini-map of the active pane
+ * set, positioned by each pane's normalized 0..1 rect. Works for both tmux
+ * and native backends. Tap a box to jump to (and zoom) that pane.
  */
 export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapSheetProps) {
 	const t = useT();
-	const [layout, setLayout] = useState<TmuxLayout | null>(null);
+	const [state, setState] = useState<TaskPaneState | null>(null);
 	const [loading, setLoading] = useState(false);
 
-	// Re-fetch the layout each time the sheet opens (panes/windows change outside
-	// React — extra agents, dev server, manual splits).
+	// Re-fetch the layout each time the sheet opens.
 	useEffect(() => {
 		if (!open) return;
 		let cancelled = false;
 		setLoading(true);
 		(async () => {
 			try {
-				const res = await api.request.tmuxLayout({ taskId });
-				if (!cancelled) setLayout(res);
+				const res = await api.request.taskPaneState({ taskId });
+				if (!cancelled) setState(res);
 			} catch {
-				if (!cancelled) setLayout(null);
+				if (!cancelled) setState(null);
 			} finally {
 				if (!cancelled) setLoading(false);
 			}
@@ -45,19 +42,13 @@ export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapS
 		};
 	}, [open, taskId]);
 
-	const activeWindow: TmuxWindowInfo | undefined = layout?.windows.find((w) => w.active) ?? layout?.windows[0];
-	const panes: TmuxPaneInfo[] = activeWindow
-		? (layout?.panes ?? []).filter((p) => p.windowIndex === activeWindow.index)
-		: [];
-	// Window extent in character cells. `... || 1` guards an empty/degenerate read.
-	const winW = Math.max(1, ...panes.map((p) => p.left + p.width));
-	const winH = Math.max(1, ...panes.map((p) => p.top + p.height));
-	// Terminal cells are ~2× taller than wide; halving the height contribution
-	// makes the map's shape match what's on screen. Clamp so a tall/wide split
-	// never produces an extreme box on a phone.
-	const aspect = Math.min(2.4, Math.max(1.1, winW / (winH * 2)));
+	const panes = state?.panes ?? [];
+	// Standard landscape terminal aspect ratio (width/height) — cell ratio not
+	// available in the neutral state, so we use a fixed 1.6 approximation.
+	const aspect = 1.6;
 
-	const paneLabel = (p: TmuxPaneInfo, i: number) => p.command?.trim() || t("panePager.pane", { index: String(i + 1) });
+	const paneLabel = (label: string, i: number) =>
+		label.trim() || t("panePager.pane", { index: String(i + 1) });
 
 	async function handleJump(paneId: string) {
 		onClose();
@@ -66,7 +57,7 @@ export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapS
 
 	return (
 		<BottomSheet open={open} onClose={onClose} title={t("paneMap.title")} testId="pane-map-sheet">
-			{loading && !layout ? (
+			{loading && !state ? (
 				<div className="py-8 text-center text-fg-3 text-sm">{t("paneMap.loading")}</div>
 			) : panes.length === 0 ? (
 				<div className="py-8 text-center text-fg-3 text-sm">{t("paneMap.empty")}</div>
@@ -80,7 +71,7 @@ export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapS
 						aria-label={t("paneMap.title")}
 					>
 						{panes.map((p, i) => {
-							const label = paneLabel(p, i);
+							const label = paneLabel(p.label, i);
 							return (
 								<button
 									key={p.paneId}
@@ -94,10 +85,10 @@ export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapS
 											: "border-edge-active bg-elevated text-fg-2 hover:border-accent/50 hover:bg-elevated-hover"
 									}`}
 									style={{
-										left: `${(p.left / winW) * 100}%`,
-										top: `${(p.top / winH) * 100}%`,
-										width: `${(p.width / winW) * 100}%`,
-										height: `${(p.height / winH) * 100}%`,
+										left: `${p.rect.x * 100}%`,
+										top: `${p.rect.y * 100}%`,
+										width: `${p.rect.width * 100}%`,
+										height: `${p.rect.height * 100}%`,
 									}}
 								>
 									<span className="max-w-full truncate text-[0.7rem] font-medium leading-tight">{label}</span>
@@ -106,26 +97,6 @@ export default function PaneMapSheet({ taskId, open, onClose, onJump }: PaneMapS
 							);
 						})}
 					</div>
-
-					{layout && layout.windows.length > 1 && (
-						<div className="mt-3 border-t border-edge/60 pt-3">
-							<p className="mb-1.5 text-fg-muted text-xs">{t("paneMap.windows")}</p>
-							<ul className="space-y-1">
-								{layout.windows.map((w) => (
-									<li
-										key={w.index}
-										className={`flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs ${
-											w.active ? "bg-accent/10 text-accent" : "text-fg-3"
-										}`}
-									>
-										<span className="w-4 flex-shrink-0 tabular-nums text-fg-muted">{w.index}</span>
-										<span className="flex-1 truncate">{w.name || t("paneMap.untitledWindow")}</span>
-										<span className="flex-shrink-0 text-fg-muted">{t.plural("paneMap.paneCount", w.panes)}</span>
-									</li>
-								))}
-							</ul>
-						</div>
-					)}
 				</>
 			)}
 		</BottomSheet>

--- a/src/mainview/components/PaneZoomBadge.tsx
+++ b/src/mainview/components/PaneZoomBadge.tsx
@@ -30,9 +30,15 @@ function PaneZoomBadge({ taskId }: { taskId: string }) {
 			if (busyRef.current) return;
 			busyRef.current = true;
 			try {
-				const res = await api.request.tmuxPaneNavigate(zoom === undefined ? { taskId } : { taskId, zoom });
-				setZoomed(res.zoomed);
-				setMulti(res.count > 1);
+				if (typeof zoom === "boolean") {
+					await api.request.taskPaneAction({
+						taskId,
+						action: { kind: "zoom", mode: zoom ? "on" : "off" },
+					});
+				}
+				const state = await api.request.taskPaneState({ taskId });
+				setZoomed(!!state.zoomedPaneId);
+				setMulti(state.panes.length > 1);
 			} catch {
 				// Transient (session not ready / restarting) — the next poll retries.
 			} finally {

--- a/src/mainview/components/PaneZoomBadge.tsx
+++ b/src/mainview/components/PaneZoomBadge.tsx
@@ -12,7 +12,7 @@ import Tooltip from "./Tooltip";
  * leaves no obvious way back. This badge surfaces the zoomed state and offers a
  * one-tap un-zoom.
  *
- * It only ever READS zoom (a read-only `tmuxPaneNavigate` poll) — it never
+ * It only ever READS zoom (a read-only `taskPaneState` poll) — it never
  * mutates the shared view unless the user taps it. We deliberately do NOT
  * auto-un-zoom on entry: that would fight a deliberate desktop `⌃B z` and break
  * a phone client attached to the same session (see decision 091).

--- a/src/mainview/components/ScheduleMessageModal.tsx
+++ b/src/mainview/components/ScheduleMessageModal.tsx
@@ -76,15 +76,17 @@ function ScheduleMessageModal({ task, project, dispatch, onClose, initialText }:
 	const { handlePaste, isPasting, pasteKind } = useClipboardPaste(project.id, insertPathAtCursor);
 	const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop, isDragging } = useFileDrop(project.id, insertPathAtCursor, task.id);
 
-	// Load the task's live panes for the (optional) concrete-pane target. Failure
-	// is non-fatal — the default agent target always works.
+	// Load live tmux panes for the (optional) concrete-pane target selector.
+	// tmuxLayout is tmux-only — skip entirely for native tasks so we never fire
+	// a session query against a backend that has no tmux session.
 	useEffect(() => {
+		if (task.terminalBackend === "native") return;
 		let cancelled = false;
 		api.request.tmuxLayout({ taskId: task.id })
 			.then((layout) => { if (!cancelled) setPanes(layout.panes ?? []); })
 			.catch(() => {});
 		return () => { cancelled = true; };
-	}, [task.id]);
+	}, [task.id, task.terminalBackend]);
 
 	// Focus the message field on open so the user can type immediately.
 	useEffect(() => {

--- a/src/mainview/components/TerminalSearchBar.tsx
+++ b/src/mainview/components/TerminalSearchBar.tsx
@@ -9,7 +9,7 @@ export interface TerminalSearchBarHandle {
 }
 
 interface TerminalSearchBarProps {
-	/** PTY session key — a task id or `project-<id>` (same key tmuxAction uses). */
+	/** PTY session key — a task id or `project-<id>`. */
 	taskId: string;
 	onClose: () => void;
 	/**

--- a/src/mainview/components/__tests__/ClosePanePicker.test.tsx
+++ b/src/mainview/components/__tests__/ClosePanePicker.test.tsx
@@ -10,7 +10,7 @@ import { toast } from "../../toast";
 import { startClosePanePicker } from "../../close-pane-picker";
 
 vi.mock("../../rpc", () => ({
-	api: { request: { tmuxLayout: vi.fn(), tmuxKillPane: vi.fn() } },
+	api: { request: { tmuxLayout: vi.fn(), taskPaneAction: vi.fn() } },
 }));
 vi.mock("../../confirm", () => ({ confirm: vi.fn() }));
 vi.mock("../../toast", () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
@@ -67,7 +67,15 @@ function renderPicker(taskId = "task-1") {
 describe("ClosePanePicker", () => {
 	beforeEach(() => {
 		vi.mocked(api.request.tmuxLayout).mockReset();
-		vi.mocked(api.request.tmuxKillPane).mockReset().mockResolvedValue({ killed: true });
+		vi.mocked(api.request.taskPaneAction).mockReset().mockResolvedValue({
+			backend: "tmux",
+			panes: [],
+			activePaneId: null,
+			zoomedPaneId: null,
+			layout: null,
+			layoutPreset: null,
+			capabilities: [],
+		});
 		vi.mocked(confirm).mockReset();
 		vi.mocked(toast.error).mockReset();
 	});
@@ -132,7 +140,10 @@ describe("ClosePanePicker", () => {
 		act(() => startClosePanePicker("task-1"));
 		await userEvent.click(await screen.findByLabelText("Close zsh"));
 
-		expect(api.request.tmuxKillPane).toHaveBeenCalledWith({ taskId: "task-1", paneId: "%2" });
+		expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "close", paneId: "%2" },
+		});
 		expect(confirm).not.toHaveBeenCalled();
 	});
 
@@ -145,7 +156,10 @@ describe("ClosePanePicker", () => {
 		await userEvent.click(await screen.findByLabelText("Close claude"));
 
 		expect(confirm).toHaveBeenCalled();
-		expect(api.request.tmuxKillPane).toHaveBeenCalledWith({ taskId: "task-1", paneId: "%1", force: true });
+		expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "close", paneId: "%1", force: true },
+		});
 	});
 
 	it("does not kill the last pane when the confirm is declined", async () => {
@@ -157,7 +171,7 @@ describe("ClosePanePicker", () => {
 		await userEvent.click(await screen.findByLabelText("Close claude"));
 
 		expect(confirm).toHaveBeenCalled();
-		expect(api.request.tmuxKillPane).not.toHaveBeenCalled();
+		expect(api.request.taskPaneAction).not.toHaveBeenCalled();
 	});
 
 	it("draws a single full-cover hit-box for a zoomed window", async () => {
@@ -191,6 +205,6 @@ describe("ClosePanePicker", () => {
 		await userEvent.keyboard("{Escape}");
 
 		await waitFor(() => expect(screen.queryByLabelText("Close claude")).toBeNull());
-		expect(api.request.tmuxKillPane).not.toHaveBeenCalled();
+		expect(api.request.taskPaneAction).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/components/__tests__/MobilePaneCarousel.test.tsx
+++ b/src/mainview/components/__tests__/MobilePaneCarousel.test.tsx
@@ -4,14 +4,15 @@ import MobilePaneCarousel from "../MobilePaneCarousel";
 import { I18nProvider } from "../../i18n";
 import { api } from "../../rpc";
 import { confirm } from "../../confirm";
+import type { TaskPaneState } from "../../../shared/task-panes";
 
 vi.mock("../../rpc", () => ({
 	api: {
 		request: {
-			tmuxPaneNavigate: vi.fn(),
+			taskPaneState: vi.fn(),
+			taskPaneAction: vi.fn(),
+			tmuxNewWindow: vi.fn(),
 			tmuxLayout: vi.fn(),
-			tmuxAction: vi.fn(),
-			tmuxPaneCount: vi.fn(),
 		},
 	},
 }));
@@ -20,7 +21,25 @@ vi.mock("../../confirm", () => ({
 	confirm: vi.fn(),
 }));
 
-const THREE_PANES = { count: 3, activeIndex: 0, zoomed: true, labels: ["claude", "bash", "zsh"] };
+function makeState(count: number, activeIndex = 0, zoomed = false, labels?: string[]): TaskPaneState {
+	const paneLabels = labels ?? Array.from({ length: count }, (_, i) => ["claude", "bash", "zsh"][i] ?? `pane-${i + 1}`);
+	return {
+		backend: "tmux",
+		panes: Array.from({ length: count }, (_, i) => ({
+			paneId: `%${i + 1}`,
+			index: i,
+			label: paneLabels[i] ?? "",
+			active: i === activeIndex,
+			zoomed: zoomed && i === activeIndex,
+			rect: { x: 0, y: 0, width: 1, height: 1 },
+		})),
+		activePaneId: count > 0 ? `%${activeIndex + 1}` : null,
+		zoomedPaneId: zoomed && count > 0 ? `%${activeIndex + 1}` : null,
+		layout: null,
+		layoutPreset: null,
+		capabilities: ["split"],
+	};
+}
 
 const LAYOUT = {
 	sessionName: "dev3-task1",
@@ -53,45 +72,46 @@ function touch(el: Element, type: string, x: number, y: number) {
 
 describe("MobilePaneCarousel", () => {
 	beforeEach(() => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockReset();
+		vi.mocked(api.request.taskPaneState).mockReset();
+		vi.mocked(api.request.taskPaneAction).mockReset();
+		vi.mocked(api.request.tmuxNewWindow).mockReset();
 		vi.mocked(api.request.tmuxLayout).mockReset();
-		vi.mocked(api.request.tmuxAction).mockReset();
-		vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
-		vi.mocked(api.request.tmuxPaneCount).mockReset();
-		vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 2 });
+		vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(2, 0, true));
+		vi.mocked(api.request.tmuxNewWindow).mockResolvedValue(undefined);
 		vi.mocked(confirm).mockReset();
 		vi.mocked(confirm).mockResolvedValue(true);
 	});
 
 	it("always renders the terminal children", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
 		expect(screen.getByTestId("terminal-body")).toBeInTheDocument();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 	});
 
 	it("shows no switcher for a single-pane session", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 		expect(screen.queryByLabelText("Switch pane")).toBeNull();
 		expect(screen.queryByLabelText("Next pane")).toBeNull();
 	});
 
 	it("auto-zooms on mount and shows chevrons + the named dropdown for a multi-pane session", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Switch pane")).toBeInTheDocument());
 		expect(screen.getByLabelText("Previous pane")).toBeInTheDocument();
 		expect(screen.getByLabelText("Next pane")).toBeInTheDocument();
-		// Trigger shows the active pane's name.
-		expect(screen.getByLabelText("Switch pane")).toHaveTextContent("1. claude");
-		// First call is the mount auto-zoom: pure zoom intent, no navigation.
-		expect(vi.mocked(api.request.tmuxPaneNavigate).mock.calls[0][0]).toEqual({ taskId: "task-1", zoom: true });
+		// First call is the mount auto-zoom.
+		expect(vi.mocked(api.request.taskPaneAction).mock.calls[0][0]).toMatchObject({
+			taskId: "task-1",
+			action: { kind: "zoom", mode: "on" },
+		});
 	});
 
 	it("the dropdown lists named panes and jumps to one by index", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Switch pane")).toBeInTheDocument());
 
@@ -101,11 +121,14 @@ describe("MobilePaneCarousel", () => {
 		expect(options[1]).toHaveTextContent("bash");
 
 		await userEvent.click(screen.getByRole("option", { name: /zsh/ }));
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", index: 2, zoom: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "focus", paneId: "%3" },
+		})));
 	});
 
 	it("the pane overview button opens a spatial map that jumps by pane id", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(2, 0, true));
 		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Pane overview")).toBeInTheDocument());
@@ -114,105 +137,119 @@ describe("MobilePaneCarousel", () => {
 		await waitFor(() => expect(api.request.tmuxLayout).toHaveBeenCalledWith({ taskId: "task-1" }));
 
 		await userEvent.click(await screen.findByLabelText("Go to zsh"));
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", paneId: "%2", zoom: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "focus", paneId: "%2" },
+		})));
 	});
 
 	it("no pane overview button for a single-pane session", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 		expect(screen.queryByLabelText("Pane overview")).toBeNull();
 	});
 
 	it("chevron buttons move between panes with keep-zoom", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Next pane")).toBeInTheDocument());
 		await userEvent.click(screen.getByLabelText("Next pane"));
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", step: "next", zoom: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "focusStep", step: "next" },
+		})));
 		await userEvent.click(screen.getByLabelText("Previous pane"));
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", step: "prev", zoom: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "focusStep", step: "prev" },
+		})));
 	});
 
 	it("Arrow keys move between panes with keep-zoom", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Switch pane")).toBeInTheDocument());
 		const group = screen.getByRole("group");
 		group.focus();
 		await userEvent.keyboard("{ArrowRight}");
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", step: "next", zoom: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "focusStep", step: "next" },
+		})));
 	});
 
 	it("a left swipe over the terminal advances to the next pane", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Switch pane")).toBeInTheDocument());
 		const surface = screen.getByTestId("pane-carousel-surface");
-		vi.mocked(api.request.tmuxPaneNavigate).mockClear();
+		vi.mocked(api.request.taskPaneAction).mockClear();
 
 		touch(surface, "touchstart", 240, 200);
-		touch(surface, "touchmove", 150, 205); // clearly horizontal
-		touch(surface, "touchmove", 120, 205); // past commit threshold
+		touch(surface, "touchmove", 150, 205);
+		touch(surface, "touchmove", 120, 205);
 		touch(surface, "touchend", 120, 205);
 
 		await waitFor(() =>
-			expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", step: "next", zoom: true }),
+			expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+				taskId: "task-1",
+				action: { kind: "focusStep", step: "next" },
+			})),
 		);
 	});
 
-	it("a vertical drag does not change panes (left to the terminal)", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+	it("a vertical drag does not change panes", async () => {
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Switch pane")).toBeInTheDocument());
 		const surface = screen.getByTestId("pane-carousel-surface");
-		vi.mocked(api.request.tmuxPaneNavigate).mockClear();
+		vi.mocked(api.request.taskPaneAction).mockClear();
 
 		touch(surface, "touchstart", 200, 100);
-		touch(surface, "touchmove", 205, 220); // clearly vertical
+		touch(surface, "touchmove", 205, 220);
 		touch(surface, "touchend", 205, 220);
 
 		await Promise.resolve();
-		expect(api.request.tmuxPaneNavigate).not.toHaveBeenCalled();
+		expect(vi.mocked(api.request.taskPaneAction).mock.calls.filter(
+			(c) => c[0].action.kind === "focusStep",
+		)).toHaveLength(0);
 	});
 
 	it("exposes the Panes & windows button even on a single-pane session", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Panes & windows")).toBeInTheDocument());
-		// Switcher chrome stays hidden — only the manage entry point is shown.
 		expect(screen.queryByLabelText("Switch pane")).toBeNull();
 	});
 
 	it("the sheet splits the pane and immediately refreshes the layout", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Panes & windows")).toBeInTheDocument());
 
 		await userEvent.click(screen.getByLabelText("Panes & windows"));
 		await userEvent.click(screen.getByRole("button", { name: "Split vertically" }));
 
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "splitV" });
-		// A refresh+zoom is issued right after, not left to the 3s poll.
-		await waitFor(() =>
-			expect(api.request.tmuxPaneNavigate).toHaveBeenLastCalledWith({ taskId: "task-1", zoom: true }),
-		);
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "splitV" },
+		})));
 	});
 
 	it("the sheet opens a new tmux window", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Panes & windows")).toBeInTheDocument());
 
 		await userEvent.click(screen.getByLabelText("Panes & windows"));
 		await userEvent.click(screen.getByRole("button", { name: "New window" }));
 
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "newWindow" });
+		await waitFor(() => expect(api.request.tmuxNewWindow).toHaveBeenCalledWith({ taskId: "task-1" }));
 	});
 
-	it("closing the only pane confirms first, then force-kills", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
-		vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 1 });
+	it("closing the only pane confirms first, then force-closes", async () => {
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		vi.mocked(confirm).mockResolvedValue(true);
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Panes & windows")).toBeInTheDocument());
@@ -221,12 +258,14 @@ describe("MobilePaneCarousel", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Close pane" }));
 
 		await waitFor(() => expect(confirm).toHaveBeenCalled());
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "killPane", force: true });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+			taskId: "task-1",
+			action: { kind: "close", force: true },
+		})));
 	});
 
-	it("declining the last-pane confirm does not kill the pane", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: false, labels: ["claude"] });
-		vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 1 });
+	it("declining the last-pane confirm does not close the pane", async () => {
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 		vi.mocked(confirm).mockResolvedValue(false);
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Panes & windows")).toBeInTheDocument());
@@ -235,11 +274,14 @@ describe("MobilePaneCarousel", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Close pane" }));
 
 		await waitFor(() => expect(confirm).toHaveBeenCalled());
-		expect(api.request.tmuxAction).not.toHaveBeenCalled();
+		const closeCalls = vi.mocked(api.request.taskPaneAction).mock.calls.filter(
+			(c) => c[0].action.kind === "close",
+		);
+		expect(closeCalls).toHaveLength(0);
 	});
 
 	it("a changed refreshKey re-reads + re-zooms the new window's panes", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue(THREE_PANES);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3, 0, true));
 		const { rerender } = render(
 			<I18nProvider>
 				<MobilePaneCarousel taskId="task-1" refreshKey={0}>
@@ -247,10 +289,9 @@ describe("MobilePaneCarousel", () => {
 				</MobilePaneCarousel>
 			</I18nProvider>,
 		);
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
-		vi.mocked(api.request.tmuxPaneNavigate).mockClear();
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
+		vi.mocked(api.request.taskPaneAction).mockClear();
 
-		// Simulate a window switch: TaskTerminal bumps refreshKey.
 		rerender(
 			<I18nProvider>
 				<MobilePaneCarousel taskId="task-1" refreshKey={1}>
@@ -259,7 +300,10 @@ describe("MobilePaneCarousel", () => {
 			</I18nProvider>,
 		);
 		await waitFor(() =>
-			expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", zoom: true }),
+			expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
+				taskId: "task-1",
+				action: { kind: "zoom", mode: "on" },
+			})),
 		);
 	});
 });

--- a/src/mainview/components/__tests__/MobilePaneCarousel.test.tsx
+++ b/src/mainview/components/__tests__/MobilePaneCarousel.test.tsx
@@ -41,15 +41,6 @@ function makeState(count: number, activeIndex = 0, zoomed = false, labels?: stri
 	};
 }
 
-const LAYOUT = {
-	sessionName: "dev3-task1",
-	exists: true,
-	windows: [{ index: 0, name: "main", active: true, panes: 2, zoomed: false }],
-	panes: [
-		{ windowIndex: 0, paneId: "%1", active: true, left: 0, top: 0, width: 99, height: 50, command: "claude", title: "Agent" },
-		{ windowIndex: 0, paneId: "%2", active: false, left: 100, top: 0, width: 100, height: 50, command: "zsh", title: "Shell" },
-	],
-};
 
 function renderCarousel(taskId = "task-1") {
 	return render(
@@ -128,15 +119,15 @@ describe("MobilePaneCarousel", () => {
 	});
 
 	it("the pane overview button opens a spatial map that jumps by pane id", async () => {
-		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(2, 0, true));
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
+		// PaneMapSheet now calls taskPaneState (not tmuxLayout)
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(2, 0, true, ["claude", "bash"]));
 		renderCarousel();
 		await waitFor(() => expect(screen.getByLabelText("Pane overview")).toBeInTheDocument());
 
 		await userEvent.click(screen.getByLabelText("Pane overview"));
-		await waitFor(() => expect(api.request.tmuxLayout).toHaveBeenCalledWith({ taskId: "task-1" }));
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalledWith({ taskId: "task-1" }));
 
-		await userEvent.click(await screen.findByLabelText("Go to zsh"));
+		await userEvent.click(await screen.findByLabelText("Go to bash"));
 		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith(expect.objectContaining({
 			taskId: "task-1",
 			action: { kind: "focus", paneId: "%2" },

--- a/src/mainview/components/__tests__/PaneMapSheet.test.tsx
+++ b/src/mainview/components/__tests__/PaneMapSheet.test.tsx
@@ -1,30 +1,39 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { TmuxLayout } from "../../../shared/types";
+import type { TaskPaneState } from "../../../shared/task-panes";
 import PaneMapSheet from "../PaneMapSheet";
 import { I18nProvider } from "../../i18n";
 import { api } from "../../rpc";
 
 vi.mock("../../rpc", () => ({
-	api: { request: { tmuxLayout: vi.fn() } },
+	api: { request: { taskPaneState: vi.fn() } },
 }));
 
-// Two side-by-side panes in window 0; a second (background) window exists.
-const LAYOUT: TmuxLayout = {
-	sessionName: "dev3-task1",
-	exists: true,
-	windows: [
-		{ index: 0, name: "main", active: true, panes: 2, zoomed: false },
-		{ index: 1, name: "logs", active: false, panes: 1, zoomed: false },
-	],
-	panes: [
-		{ windowIndex: 0, paneId: "%1", active: true, left: 0, top: 0, width: 99, height: 50, command: "claude", title: "Agent" },
-		{ windowIndex: 0, paneId: "%2", active: false, left: 100, top: 0, width: 100, height: 50, command: "zsh", title: "Shell" },
-		// A pane in the non-active window — must NOT appear on the map.
-		{ windowIndex: 1, paneId: "%3", active: true, left: 0, top: 0, width: 200, height: 50, command: "tail", title: "Logs" },
-	],
-};
+function makeState(panes: Array<{ paneId: string; label: string; active: boolean; x: number; y: number; width: number; height: number }>): TaskPaneState {
+	return {
+		backend: "tmux",
+		panes: panes.map((p, i) => ({
+			paneId: p.paneId,
+			index: i,
+			label: p.label,
+			active: p.active,
+			zoomed: false,
+			rect: { x: p.x, y: p.y, width: p.width, height: p.height },
+		})),
+		activePaneId: panes.find((p) => p.active)?.paneId ?? null,
+		zoomedPaneId: null,
+		layout: null,
+		layoutPreset: null,
+		capabilities: ["split", "focus"],
+	};
+}
+
+// Two side-by-side panes: left takes 49.5%, right takes 50%.
+const TWO_PANE_STATE = makeState([
+	{ paneId: "%1", label: "claude", active: true, x: 0,     y: 0, width: 0.495, height: 1.0 },
+	{ paneId: "%2", label: "zsh",    active: false, x: 0.5,  y: 0, width: 0.5,   height: 1.0 },
+]);
 
 function renderSheet(props: Partial<React.ComponentProps<typeof PaneMapSheet>> = {}) {
 	const onClose = props.onClose ?? vi.fn();
@@ -39,43 +48,41 @@ function renderSheet(props: Partial<React.ComponentProps<typeof PaneMapSheet>> =
 
 describe("PaneMapSheet", () => {
 	beforeEach(() => {
-		vi.mocked(api.request.tmuxLayout).mockReset();
+		vi.mocked(api.request.taskPaneState).mockReset();
 	});
 
 	it("fetches the layout when opened", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(TWO_PANE_STATE);
 		renderSheet();
-		await waitFor(() => expect(api.request.tmuxLayout).toHaveBeenCalledWith({ taskId: "task-1" }));
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalledWith({ taskId: "task-1" }));
 	});
 
 	it("does not fetch while closed", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(TWO_PANE_STATE);
 		renderSheet({ open: false });
 		await Promise.resolve();
-		expect(api.request.tmuxLayout).not.toHaveBeenCalled();
+		expect(api.request.taskPaneState).not.toHaveBeenCalled();
 	});
 
-	it("renders one box per pane of the active window, positioned by geometry", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
+	it("renders one box per pane, positioned by normalized rect", async () => {
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(TWO_PANE_STATE);
 		renderSheet();
 
 		const active = await screen.findByLabelText("Go to claude");
 		const other = screen.getByLabelText("Go to zsh");
-		// Only the active window's two panes — the %3 pane (window 1) is excluded.
-		expect(screen.queryByLabelText("Go to tail")).toBeNull();
 
-		// Geometry → CSS percentages (winW = 200, winH = 50).
+		// Geometry from 0..1 rects → CSS percentages
 		expect(active.style.left).toBe("0%");
 		expect(active.style.width).toBe("49.5%");
 		expect(other.style.left).toBe("50%");
 		expect(other.style.width).toBe("50%");
-		// The active pane is flagged for assistive tech.
+
 		expect(active).toHaveAttribute("aria-current", "true");
 		expect(other).not.toHaveAttribute("aria-current");
 	});
 
 	it("jumps to the tapped pane by id and closes", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(TWO_PANE_STATE);
 		const { onClose, onJump } = renderSheet();
 
 		await userEvent.click(await screen.findByLabelText("Go to zsh"));
@@ -83,35 +90,24 @@ describe("PaneMapSheet", () => {
 		expect(onClose).toHaveBeenCalled();
 	});
 
-	it("lists windows when the session has more than one", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue(LAYOUT);
-		renderSheet();
-		await screen.findByLabelText("Go to claude");
-		expect(screen.getByText("Windows")).toBeInTheDocument();
-		expect(screen.getByText("logs")).toBeInTheDocument();
-		expect(screen.getByText("1 pane")).toBeInTheDocument();
-		expect(screen.getByText("2 panes")).toBeInTheDocument();
-	});
-
-	it("hides the window list for a single-window session", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue({
-			...LAYOUT,
-			windows: [LAYOUT.windows[0]],
-			panes: LAYOUT.panes.filter((p) => p.windowIndex === 0),
-		});
-		renderSheet();
-		await screen.findByLabelText("Go to claude");
-		expect(screen.queryByText("Windows")).toBeNull();
-	});
-
 	it("shows an empty state when there are no panes", async () => {
-		vi.mocked(api.request.tmuxLayout).mockResolvedValue({
-			sessionName: "dev3-task1",
-			exists: false,
-			windows: [],
+		vi.mocked(api.request.taskPaneState).mockResolvedValue({
+			backend: "tmux",
 			panes: [],
+			activePaneId: null,
+			zoomedPaneId: null,
+			layout: null,
+			layoutPreset: null,
+			capabilities: [],
 		});
 		renderSheet();
 		expect(await screen.findByText("No panes to show.")).toBeInTheDocument();
+	});
+
+	it("does not show a window list (tmux-only concept removed from neutral view)", async () => {
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(TWO_PANE_STATE);
+		renderSheet();
+		await screen.findByLabelText("Go to claude");
+		expect(screen.queryByText("Windows")).toBeNull();
 	});
 });

--- a/src/mainview/components/__tests__/PaneZoomBadge.test.tsx
+++ b/src/mainview/components/__tests__/PaneZoomBadge.test.tsx
@@ -4,10 +4,28 @@ import PaneZoomBadge from "../PaneZoomBadge";
 import { I18nProvider } from "../../i18n";
 import { api } from "../../rpc";
 
+const makeState = (zoomed: boolean, count: number) => ({
+	backend: "tmux" as const,
+	panes: Array.from({ length: count }, (_, i) => ({
+		paneId: `%${i + 1}`,
+		index: i,
+		label: "",
+		active: i === 0,
+		zoomed: zoomed && i === 0,
+		rect: { x: 0, y: 0, width: 1, height: 1 },
+	})),
+	activePaneId: "%1",
+	zoomedPaneId: zoomed ? "%1" : null,
+	layout: null,
+	layoutPreset: null,
+	capabilities: ["split" as const],
+});
+
 vi.mock("../../rpc", () => ({
 	api: {
 		request: {
-			tmuxPaneNavigate: vi.fn(),
+			taskPaneState: vi.fn(),
+			taskPaneAction: vi.fn(),
 		},
 	},
 }));
@@ -22,43 +40,47 @@ function renderBadge(taskId = "task-1") {
 
 describe("PaneZoomBadge", () => {
 	beforeEach(() => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockReset();
+		vi.mocked(api.request.taskPaneState).mockReset();
+		vi.mocked(api.request.taskPaneAction).mockReset();
 	});
 
 	it("polls zoom state read-only on mount (no zoom mutation)", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 2, activeIndex: 0, zoomed: false, labels: ["claude", "bash"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(false, 2));
 		renderBadge();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
-		// First call carries no zoom intent — it must not toggle the shared view.
-		expect(vi.mocked(api.request.tmuxPaneNavigate).mock.calls[0][0]).toEqual({ taskId: "task-1" });
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
+		expect(vi.mocked(api.request.taskPaneAction)).not.toHaveBeenCalled();
 	});
 
 	it("shows no badge when the window is not zoomed", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 2, activeIndex: 0, zoomed: false, labels: ["claude", "bash"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(false, 2));
 		renderBadge();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 		expect(screen.queryByLabelText("Show all panes")).toBeNull();
 	});
 
 	it("shows no badge for a single-pane session even if flagged zoomed", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 1, activeIndex: 0, zoomed: true, labels: ["claude"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(true, 1));
 		renderBadge();
-		await waitFor(() => expect(api.request.tmuxPaneNavigate).toHaveBeenCalled());
+		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 		expect(screen.queryByLabelText("Show all panes")).toBeNull();
 	});
 
 	it("shows the badge when a multi-pane window is zoomed", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 3, activeIndex: 1, zoomed: true, labels: ["claude", "bash", "zsh"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(true, 3));
 		renderBadge();
 		await waitFor(() => expect(screen.getByLabelText("Show all panes")).toBeInTheDocument());
 		expect(screen.getByLabelText("Show all panes")).toHaveTextContent("Zoomed");
 	});
 
 	it("un-zooms when the badge is tapped", async () => {
-		vi.mocked(api.request.tmuxPaneNavigate).mockResolvedValue({ count: 3, activeIndex: 1, zoomed: true, labels: ["claude", "bash", "zsh"] });
+		vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(true, 3));
+		vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(false, 3));
 		renderBadge();
 		await waitFor(() => expect(screen.getByLabelText("Show all panes")).toBeInTheDocument());
 		await userEvent.click(screen.getByLabelText("Show all panes"));
-		expect(api.request.tmuxPaneNavigate).toHaveBeenCalledWith({ taskId: "task-1", zoom: false });
+		expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "zoom", mode: "off" },
+		});
 	});
 });

--- a/src/mainview/components/__tests__/TaskTmuxControls.test.tsx
+++ b/src/mainview/components/__tests__/TaskTmuxControls.test.tsx
@@ -6,11 +6,29 @@ import { api } from "../../rpc";
 import { confirm } from "../../confirm";
 import { CLOSE_PANE_PICKER_EVENT } from "../../close-pane-picker";
 
+const makeState = (count: number) => ({
+	backend: "tmux" as const,
+	panes: Array.from({ length: count }, (_, i) => ({
+		paneId: `%${i + 1}`,
+		index: i,
+		label: "",
+		active: i === 0,
+		zoomed: false,
+		rect: { x: 0, y: 0, width: 1, height: 1 },
+	})),
+	activePaneId: count > 0 ? "%1" : null,
+	zoomedPaneId: null,
+	layout: null,
+	layoutPreset: null,
+	capabilities: ["split" as const],
+});
+
 vi.mock("../../rpc", () => ({
 	api: {
 		request: {
-			tmuxAction: vi.fn(),
-			tmuxPaneCount: vi.fn(),
+			taskPaneAction: vi.fn(),
+			taskPaneState: vi.fn(),
+			tmuxNewWindow: vi.fn(),
 		},
 	},
 }));
@@ -31,8 +49,9 @@ describe("TaskTmuxControls", () => {
 	beforeEach(() => {
 		localStorage.clear();
 		mockNarrow = false;
-		vi.mocked(api.request.tmuxAction).mockReset();
-		vi.mocked(api.request.tmuxPaneCount).mockReset();
+		vi.mocked(api.request.taskPaneAction).mockReset();
+		vi.mocked(api.request.taskPaneState).mockReset();
+		vi.mocked(api.request.tmuxNewWindow).mockReset();
 		vi.mocked(confirm).mockReset();
 	});
 
@@ -65,9 +84,9 @@ describe("TaskTmuxControls", () => {
 
 		expect(onPicker).toHaveBeenCalledTimes(1);
 		expect((onPicker.mock.calls[0][0] as CustomEvent).detail).toEqual({ taskId: "task-1" });
-		// The picker owns the kill now — the button never touches tmux directly here.
-		expect(api.request.tmuxAction).not.toHaveBeenCalled();
-		expect(api.request.tmuxPaneCount).not.toHaveBeenCalled();
+		// The picker owns the kill now — the button never touches pane API directly here.
+		expect(api.request.taskPaneAction).not.toHaveBeenCalled();
+		expect(api.request.taskPaneState).not.toHaveBeenCalled();
 		expect(confirm).not.toHaveBeenCalled();
 
 		window.removeEventListener(CLOSE_PANE_PICKER_EVENT, onPicker);
@@ -80,8 +99,8 @@ describe("TaskTmuxControls", () => {
 
 		it("kills the pane without confirmation when more than one pane exists", async () => {
 			const user = userEvent.setup();
-			vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 3 });
-			vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(3));
+			vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(2));
 
 			render(
 				<I18nProvider>
@@ -91,15 +110,18 @@ describe("TaskTmuxControls", () => {
 
 			await user.click(screen.getByLabelText("Close pane"));
 
-			await waitFor(() => expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "killPane" }));
+			await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+				taskId: "task-1",
+				action: { kind: "close" },
+			}));
 			expect(confirm).not.toHaveBeenCalled();
 		});
 
 		it("asks for confirmation only when the active pane is the last one, and forces the kill on accept", async () => {
 			const user = userEvent.setup();
-			vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 1 });
+			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 			vi.mocked(confirm).mockResolvedValue(true);
-			vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+			vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(0));
 
 			render(
 				<I18nProvider>
@@ -114,12 +136,15 @@ describe("TaskTmuxControls", () => {
 				message: expect.stringContaining("only remaining pane"),
 				danger: true,
 			});
-			await waitFor(() => expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "killPane", force: true }));
+			await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+				taskId: "task-1",
+				action: { kind: "close", force: true },
+			}));
 		});
 
 		it("does not kill the last pane when the confirmation is dismissed", async () => {
 			const user = userEvent.setup();
-			vi.mocked(api.request.tmuxPaneCount).mockResolvedValue({ count: 1 });
+			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
 			vi.mocked(confirm).mockResolvedValue(false);
 
 			render(
@@ -131,13 +156,13 @@ describe("TaskTmuxControls", () => {
 			await user.click(screen.getByLabelText("Close pane"));
 
 			expect(confirm).toHaveBeenCalled();
-			expect(api.request.tmuxAction).not.toHaveBeenCalled();
+			expect(api.request.taskPaneAction).not.toHaveBeenCalled();
 		});
 	});
 
 	it("does not prompt for confirmation for non-destructive actions", async () => {
 		const user = userEvent.setup();
-		vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+		vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(1));
 
 		render(
 			<I18nProvider>
@@ -148,13 +173,16 @@ describe("TaskTmuxControls", () => {
 		await user.click(screen.getByLabelText("Split horizontally"));
 
 		expect(confirm).not.toHaveBeenCalled();
-		expect(api.request.tmuxPaneCount).not.toHaveBeenCalled();
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "splitH" });
+		expect(api.request.taskPaneState).not.toHaveBeenCalled();
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "splitH" },
+		}));
 	});
 
 	it("opens a new tmux window from the green new-window button", async () => {
 		const user = userEvent.setup();
-		vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+		vi.mocked(api.request.tmuxNewWindow).mockResolvedValue(undefined);
 
 		render(
 			<I18nProvider>
@@ -165,12 +193,12 @@ describe("TaskTmuxControls", () => {
 		await user.click(screen.getByLabelText("New window"));
 
 		expect(confirm).not.toHaveBeenCalled();
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "newWindow" });
+		await waitFor(() => expect(api.request.tmuxNewWindow).toHaveBeenCalledWith({ taskId: "task-1" }));
 	});
 
-	it("cycles tmux layouts from the split-button primary action", async () => {
+	it("cycles layouts from the split-button primary action", async () => {
 		const user = userEvent.setup();
-		vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+		vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(2));
 
 		render(
 			<I18nProvider>
@@ -180,12 +208,15 @@ describe("TaskTmuxControls", () => {
 
 		await user.click(screen.getByLabelText("Cycle layouts"));
 
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "nextLayout" });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "layoutCycle" },
+		}));
 	});
 
-	it("opens the tmux layout menu and applies the chosen preset", async () => {
+	it("opens the layout menu and applies the chosen preset", async () => {
 		const user = userEvent.setup();
-		vi.mocked(api.request.tmuxAction).mockResolvedValue(undefined);
+		vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(2));
 
 		render(
 			<I18nProvider>
@@ -201,6 +232,9 @@ describe("TaskTmuxControls", () => {
 		const tiled = await screen.findByText("Tiled (grid)");
 		await user.click(tiled);
 
-		expect(api.request.tmuxAction).toHaveBeenCalledWith({ taskId: "task-1", action: "layoutTiled" });
+		await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
+			taskId: "task-1",
+			action: { kind: "layoutPreset", preset: "tiled" },
+		}));
 	});
 });

--- a/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
+++ b/src/mainview/components/task-info-panel/TaskTmuxControls.tsx
@@ -36,7 +36,7 @@ type TmuxAction =
 	| "newWindow"
 	| "zoom"
 	| "nextLayout"
-	| "killPane"
+	| "close"
 	| "layoutTiled"
 	| "layoutEvenH"
 	| "layoutEvenV"
@@ -207,16 +207,20 @@ export default function TaskTmuxControls({ taskId, compact = false }: TaskTmuxCo
 
 	const handleTmuxAction = (action: TmuxAction) => async (event: ReactMouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
-		if (action === "killPane") {
+		if (action === "newWindow") {
+			api.request.tmuxNewWindow({ taskId }).catch(() => {});
+			return;
+		}
+		if (action === "close") {
 			let count = 0;
 			try {
-				const result = await api.request.tmuxPaneCount({ taskId });
-				count = result.count;
+				const state = await api.request.taskPaneState({ taskId });
+				count = state.panes.length;
 			} catch {
 				count = 0;
 			}
 			if (count <= 1) {
-				// Closing the last pane tears down the whole tmux session — confirm first.
+				// Closing the last pane tears down the whole session — confirm first.
 				let confirmed = false;
 				try {
 					confirmed = await confirm({
@@ -228,21 +232,37 @@ export default function TaskTmuxControls({ taskId, compact = false }: TaskTmuxCo
 					confirmed = false;
 				}
 				if (!confirmed) return;
-				api.request.tmuxAction({ taskId, action, force: true }).catch(() => {});
+				api.request.taskPaneAction({ taskId, action: { kind: "close", force: true } }).catch(() => {});
 				return;
 			}
+			api.request.taskPaneAction({ taskId, action: { kind: "close" } }).catch(() => {});
+			return;
 		}
-		api.request.tmuxAction({ taskId, action }).catch(() => {});
+		const actionMap: Record<string, import("../../../shared/task-panes").TaskPaneAction> = {
+			splitH: { kind: "splitH" },
+			splitV: { kind: "splitV" },
+			zoom: { kind: "zoom", mode: "toggle" },
+			nextLayout: { kind: "layoutCycle" },
+			layoutTiled: { kind: "layoutPreset", preset: "tiled" },
+			layoutEvenH: { kind: "layoutPreset", preset: "evenH" },
+			layoutEvenV: { kind: "layoutPreset", preset: "evenV" },
+			layoutMainH: { kind: "layoutPreset", preset: "mainH" },
+			layoutMainV: { kind: "layoutPreset", preset: "mainV" },
+		};
+		const paneAction = actionMap[action];
+		if (paneAction) {
+			api.request.taskPaneAction({ taskId, action: paneAction }).catch(() => {});
+		}
 	};
 
 	// The red Close Pane button. On a real desktop split it opens the two-step
 	// picker (an overlay over the terminal in TaskTerminal); on narrow viewports it
 	// falls back to the direct kill of the visible pane (reusing the last-pane
-	// teardown confirm baked into handleTmuxAction("killPane")).
+	// teardown confirm baked into handleTmuxAction("close")).
 	const handleClosePane = (event: ReactMouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
 		if (narrow) {
-			void handleTmuxAction("killPane")(event);
+			void handleTmuxAction("close")(event);
 			return;
 		}
 		startClosePanePicker(taskId);
@@ -303,7 +323,7 @@ export default function TaskTmuxControls({ taskId, compact = false }: TaskTmuxCo
 					</button>
 				</Tooltip>
 				<Tooltip content={t("tmux.newWindowDesc")}>
-					<button className={tmuxNewWindowBtnClass} onClick={handleTmuxAction("newWindow")} aria-label={t("tmux.newWindowDesc")}>
+					<button className={tmuxNewWindowBtnClass} onClick={(e) => { e.stopPropagation(); api.request.tmuxNewWindow({ taskId }).catch(() => {}); }} aria-label={t("tmux.newWindowDesc")}>
 						<NewWindowIcon className={tmuxSvgClass} />
 					</button>
 				</Tooltip>

--- a/src/mainview/menuRouter.ts
+++ b/src/mainview/menuRouter.ts
@@ -305,7 +305,7 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 			return;
 		}
 
-		// ── Terminal: pane ops piggy-back on tmuxAction (taskId required) ──
+		// ── Terminal: pane ops via taskPaneAction (taskId required) ──
 		case "term-close-pane": {
 			// Close Pane opens the two-step visual picker (overlay in TaskTerminal),
 			// matching the toolbar button. Desktop-only menu → no narrow fallback.
@@ -325,11 +325,11 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 		case "term-layout-cycle": {
 			const taskId = currentTaskId(state);
 			if (!taskId) return;
-			const tmuxAction = TMUX_ACTION_MAP[action];
+			const paneAction = PANE_ACTION_MAP[action];
 			try {
-				await api.request.tmuxAction({ taskId, action: tmuxAction });
+				await api.request.taskPaneAction({ taskId, action: paneAction });
 			} catch (err) {
-				console.error(`[menu] tmuxAction(${tmuxAction}) failed`, err);
+				console.error(`[menu] taskPaneAction(${action}) failed`, err);
 			}
 			return;
 		}
@@ -408,14 +408,16 @@ export const BROWSER_HANDLED_ACTIONS: ReadonlySet<string> = new Set<string>([
 	"help-keyboard-shortcuts", "help-explain-screen", "help-documentation", "help-github", "help-report-bug",
 ]);
 
-const TMUX_ACTION_MAP = {
-	"term-split-h": "splitH",
-	"term-split-v": "splitV",
-	"term-zoom-pane": "zoom",
-	"term-layout-tiled": "layoutTiled",
-	"term-layout-even-h": "layoutEvenH",
-	"term-layout-even-v": "layoutEvenV",
-	"term-layout-main-h": "layoutMainH",
-	"term-layout-main-v": "layoutMainV",
-	"term-layout-cycle": "nextLayout",
-} as const satisfies Record<string, "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV">;
+import type { TaskPaneAction } from "../shared/task-panes";
+
+const PANE_ACTION_MAP: Record<string, TaskPaneAction> = {
+	"term-split-h": { kind: "splitH" },
+	"term-split-v": { kind: "splitV" },
+	"term-zoom-pane": { kind: "zoom", mode: "toggle" },
+	"term-layout-tiled": { kind: "layoutPreset", preset: "tiled" },
+	"term-layout-even-h": { kind: "layoutPreset", preset: "evenH" },
+	"term-layout-even-v": { kind: "layoutPreset", preset: "evenV" },
+	"term-layout-main-h": { kind: "layoutPreset", preset: "mainH" },
+	"term-layout-main-v": { kind: "layoutPreset", preset: "mainV" },
+	"term-layout-cycle": { kind: "layoutCycle" },
+};

--- a/src/mainview/terminal-keymaps.ts
+++ b/src/mainview/terminal-keymaps.ts
@@ -1,6 +1,14 @@
 import type { TerminalKeymapPreset } from "../shared/types";
 
-export type TmuxAction = "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow";
+/**
+ * Keyboard binding actions dispatched from the terminal keymap.
+ * These map to TaskPaneAction kinds (close, splitH, splitV, zoom, focusStep)
+ * or to tmuxNewWindow for "newWindow".
+ */
+export type PaneKeyAction = "splitH" | "splitV" | "zoom" | "close" | "focusStep:next" | "focusStep:prev" | "newWindow";
+
+/** @deprecated Use PaneKeyAction. */
+export type TmuxAction = PaneKeyAction;
 
 export interface KeyBinding {
 	/**
@@ -12,7 +20,7 @@ export interface KeyBinding {
 	meta?: boolean;
 	ctrl?: boolean;
 	shift?: boolean;
-	action: TmuxAction;
+	action: PaneKeyAction;
 }
 
 export const TERMINAL_KEYMAPS: Record<TerminalKeymapPreset, KeyBinding[]> = {
@@ -21,12 +29,12 @@ export const TERMINAL_KEYMAPS: Record<TerminalKeymapPreset, KeyBinding[]> = {
 
 	// Mirrors iTerm2's standard pane & tab shortcuts, layered on top of native tmux.
 	"iterm2": [
-		{ code: "KeyW", meta: true, action: "killPane" },
+		{ code: "KeyW", meta: true, action: "close" },
 		{ code: "KeyD", meta: true, shift: false, action: "splitV" },
 		{ code: "KeyD", meta: true, shift: true, action: "splitH" },
 		{ code: "KeyT", meta: true, action: "newWindow" },
-		{ code: "BracketRight", meta: true, action: "nextPane" },
-		{ code: "BracketLeft", meta: true, action: "prevPane" },
+		{ code: "BracketRight", meta: true, action: "focusStep:next" },
+		{ code: "BracketLeft", meta: true, action: "focusStep:prev" },
 	],
 };
 

--- a/src/shared/__tests__/pane-action-mapping.test.ts
+++ b/src/shared/__tests__/pane-action-mapping.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+	paneActionToSplitOrientation,
+	paneLayoutPresetToSplitPreset,
+	splitPresetToPaneLayoutPreset,
+} from "../pane-action-mapping";
+import { SPLIT_LAYOUT_PRESETS } from "../split-tree-layouts";
+import { TASK_PANE_LAYOUT_PRESETS } from "../task-panes";
+
+describe("paneActionToSplitOrientation", () => {
+	it("splitH → vertical (new pane below)", () => {
+		expect(paneActionToSplitOrientation("splitH")).toBe("vertical");
+	});
+	it("splitV → horizontal (new pane right)", () => {
+		expect(paneActionToSplitOrientation("splitV")).toBe("horizontal");
+	});
+});
+
+describe("paneLayoutPresetToSplitPreset", () => {
+	it("tiled → tiled", () => expect(paneLayoutPresetToSplitPreset("tiled")).toBe("tiled"));
+	it("evenH → even-vertical", () => expect(paneLayoutPresetToSplitPreset("evenH")).toBe("even-vertical"));
+	it("evenV → even-horizontal", () => expect(paneLayoutPresetToSplitPreset("evenV")).toBe("even-horizontal"));
+	it("mainH → main-horizontal", () => expect(paneLayoutPresetToSplitPreset("mainH")).toBe("main-horizontal"));
+	it("mainV → main-vertical", () => expect(paneLayoutPresetToSplitPreset("mainV")).toBe("main-vertical"));
+
+	it("covers every TaskPaneLayoutPreset", () => {
+		for (const preset of TASK_PANE_LAYOUT_PRESETS) {
+			expect(SPLIT_LAYOUT_PRESETS).toContain(paneLayoutPresetToSplitPreset(preset));
+		}
+	});
+});
+
+describe("splitPresetToPaneLayoutPreset", () => {
+	it("tiled → tiled", () => expect(splitPresetToPaneLayoutPreset("tiled")).toBe("tiled"));
+	it("even-vertical → evenH", () => expect(splitPresetToPaneLayoutPreset("even-vertical")).toBe("evenH"));
+	it("even-horizontal → evenV", () => expect(splitPresetToPaneLayoutPreset("even-horizontal")).toBe("evenV"));
+	it("main-horizontal → mainH", () => expect(splitPresetToPaneLayoutPreset("main-horizontal")).toBe("mainH"));
+	it("main-vertical → mainV", () => expect(splitPresetToPaneLayoutPreset("main-vertical")).toBe("mainV"));
+
+	it("round-trips with paneLayoutPresetToSplitPreset", () => {
+		for (const preset of TASK_PANE_LAYOUT_PRESETS) {
+			const split = paneLayoutPresetToSplitPreset(preset);
+			const back = splitPresetToPaneLayoutPreset(split);
+			expect(back).toBe(preset);
+		}
+	});
+});

--- a/src/shared/pane-action-mapping.ts
+++ b/src/shared/pane-action-mapping.ts
@@ -1,0 +1,39 @@
+/**
+ * Single source of truth for the product↔tmux/SplitTree name mapping.
+ * The product names the DIVIDER; tmux/SplitTree name the split AXIS.
+ *
+ * splitH → horizontal divider → new pane BELOW → tmux -v → SplitTree "vertical"
+ * splitV → vertical divider   → new pane RIGHT → tmux -h → SplitTree "horizontal"
+ */
+import type { SplitOrientation } from "./split-tree";
+import type { SplitLayoutPreset } from "./split-tree-layouts";
+import type { TaskPaneLayoutPreset } from "./task-panes";
+
+/** Product splitH/splitV → SplitTree/tmux orientation. */
+export function paneActionToSplitOrientation(action: "splitH" | "splitV"): SplitOrientation {
+	return action === "splitH" ? "vertical" : "horizontal";
+}
+
+/** Product layout preset → SplitTree geometric preset. */
+export function paneLayoutPresetToSplitPreset(preset: TaskPaneLayoutPreset): SplitLayoutPreset {
+	const map: Record<TaskPaneLayoutPreset, SplitLayoutPreset> = {
+		tiled: "tiled",
+		evenH: "even-vertical",
+		evenV: "even-horizontal",
+		mainH: "main-horizontal",
+		mainV: "main-vertical",
+	};
+	return map[preset];
+}
+
+/** SplitTree geometric preset → product layout preset. */
+export function splitPresetToPaneLayoutPreset(preset: SplitLayoutPreset): TaskPaneLayoutPreset {
+	const map: Record<SplitLayoutPreset, TaskPaneLayoutPreset> = {
+		tiled: "tiled",
+		"even-vertical": "evenH",
+		"even-horizontal": "evenV",
+		"main-horizontal": "mainH",
+		"main-vertical": "mainV",
+	};
+	return map[preset];
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,7 @@ import type { ConversationMatch } from "./conversation-search-core";
 import type { AgentRateLimitsReport } from "./rate-limits";
 import type { AgentAccount, AgentAccountKind, AgentAccountsState, ClaudeSlotModels } from "./agent-accounts";
 import type { TerminalBackendIdentity } from "./terminal-backend-identity";
+import type { TaskPaneState, TaskPaneAction } from "./task-panes";
 
 // ---- Changelog ----
 
@@ -3524,21 +3525,17 @@ export type AppRPCSchema = {
 				params: { taskId: string; projectId: string; noteId: string };
 				response: Task;
 			};
-			tmuxAction: {
-				params: { taskId: string; action: "splitH" | "splitV" | "zoom" | "killPane" | "nextPane" | "prevPane" | "newWindow" | "nextLayout" | "layoutTiled" | "layoutEvenH" | "layoutEvenV" | "layoutMainH" | "layoutMainV"; force?: boolean };
-				response: void;
-			};
-			tmuxPaneCount: {
+			taskPaneState: {
 				params: { taskId: string };
-				response: { count: number };
+				response: TaskPaneState;
 			};
-			tmuxKillPane: {
-				params: { taskId: string; paneId: string; force?: boolean };
-				response: { killed: boolean };
+			taskPaneAction: {
+				params: { taskId: string; action: TaskPaneAction };
+				response: TaskPaneState;
 			};
-			tmuxPaneNavigate: {
-				params: { taskId: string; step?: "next" | "prev"; index?: number; paneId?: string; zoom?: boolean };
-				response: { count: number; activeIndex: number; zoomed: boolean; labels: string[] };
+			tmuxNewWindow: {
+				params: { taskId: string };
+				response: void;
 			};
 			tmuxLayout: {
 				params: { taskId: string };


### PR DESCRIPTION
Second of three PRs for the native multi-pane Task Terminal task. Stacked on #1184 — review that first. Plumbing only: no control moves, no restyle, no new copy, and the Task Terminal still renders a single terminal view.

- New `taskPaneState` / `taskPaneAction` RPCs speak pane count, split, focus, resize, zoom, close and named layouts without any tmux vocabulary, and report a `capabilities` list so a control can tell what its backend actually supports. `tmuxAction`, `tmuxPaneCount`, `tmuxKillPane` and `tmuxPaneNavigate` are gone; every caller moved.
- `src/bun/rpc-handlers/task-panes.ts` dispatches on the task's persisted backend identity through the existing single selection point. The tmux path reuses the existing tmux code paths unchanged, including the last-pane refusal, the pre-kill active-pane capture and the pane-exited cleanup. The native path drives the pane-set runtime and the shared SplitTree, and cannot reach tmux at all.
- `src/shared/pane-action-mapping.ts` holds the one place that translates the product's divider-named splits and layout presets into SplitTree geometry — dev3 names the divider, tmux names the axis, so this mapping is easy to get backwards.
- Layout presets have honest native equivalents; `newWindow` does not, so it stays an explicitly tmux-only RPC and is not offered on a native task.
- The window switcher, alt-click and terminal-search pane framing remain tmux concepts and are gated so they cannot fire on a native task.

The changelog entry for the whole task lives in #1184.