### PR TITLE
Highlight unread task images and artifacts

### DIFF
--- a/change-logs/2026/07/30/feature-unread-shared-content.md
+++ b/change-logs/2026/07/30/feature-unread-shared-content.md
@@ -1,0 +1,3 @@
+Short: Unread artifact alerts
+
+New task images and HTML artifacts now highlight their toolbar buttons in green and animate their icons until the user opens the corresponding viewer. Existing shared items remain read, and reduced-motion preferences disable the attention animation.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -6494,6 +6494,59 @@ describe("handlers.setTaskLabels", () => {
 	});
 });
 
+describe("handlers.markTaskSharedItemsRead", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("marks only the requested images as read and leaves legacy items read", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			sharedImages: [
+				{ id: "new", isUnread: true },
+				{ id: "other", isUnread: true },
+				{ id: "legacy" },
+			] as Task["sharedImages"],
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.updateTaskWith).mockImplementation(async (_project, _taskId, mutator) => {
+			const { updates, result } = await mutator(task);
+			return { task: { ...task, ...updates }, result };
+		});
+
+		const result = await handlers.markTaskSharedItemsRead({
+			taskId: "task-1",
+			projectId: "proj-1",
+			kind: "images",
+			itemIds: ["new", "legacy"],
+		});
+
+		expect(result.sharedImages?.map((image) => image.isUnread)).toEqual([false, true, undefined]);
+	});
+
+	it("marks only the requested artifacts as read", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			sharedArtifacts: [
+				{ id: "seen", isUnread: true },
+				{ id: "later", isUnread: true },
+			] as Task["sharedArtifacts"],
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.updateTaskWith).mockImplementation(async (_project, _taskId, mutator) => {
+			const { updates, result } = await mutator(task);
+			return { task: { ...task, ...updates }, result };
+		});
+
+		const result = await handlers.markTaskSharedItemsRead({
+			taskId: "task-1",
+			projectId: "proj-1",
+			kind: "artifacts",
+			itemIds: ["seen"],
+		});
+
+		expect(result.sharedArtifacts?.map((artifact) => artifact.isUnread)).toEqual([false, true]);
+	});
+});
+
 // ================================================================
 // handlers.addTaskNote / updateTaskNote / deleteTaskNote
 // ================================================================

--- a/src/bun/__tests__/shared-artifacts.test.ts
+++ b/src/bun/__tests__/shared-artifacts.test.ts
@@ -64,6 +64,7 @@ describe("saveSharedArtifact", () => {
 		const saved = saveSharedArtifact("/my/project", html, [image], "Quarterly report");
 
 		expect(saved.title).toBe("Quarterly report");
+		expect(saved.isUnread).toBe(true);
 		expect(saved.name).toBe("report.html");
 		expect(saved.assets.map((item) => item.name)).toEqual(["chart.png"]);
 		expect(dirname(saved.assets[0].storedPath)).toBe(dirname(saved.storedPath));

--- a/src/bun/__tests__/shared-images.test.ts
+++ b/src/bun/__tests__/shared-images.test.ts
@@ -95,6 +95,7 @@ describe("saveSharedImage", () => {
 		expect(rec.mime).toBe("image/png");
 		expect(rec.originalPath).toBe(src);
 		expect(rec.bytes).toBe(Buffer.byteLength("PNGDATA"));
+		expect(rec.isUnread).toBe(true);
 		expect(existsSync(rec.storedPath)).toBe(true);
 		expect(readFileSync(rec.storedPath, "utf8")).toBe("PNGDATA");
 	});

--- a/src/bun/rpc-handlers/notes-labels.ts
+++ b/src/bun/rpc-handlers/notes-labels.ts
@@ -224,6 +224,38 @@ async function setTaskLabels(params: { taskId: string; projectId: string; labelI
 	return task;
 }
 
+async function markTaskSharedItemsRead(params: {
+	taskId: string;
+	projectId: string;
+	kind: "images" | "artifacts";
+	itemIds: string[];
+}): Promise<Task> {
+	const project = await data.getProject(params.projectId);
+	const itemIds = new Set(params.itemIds);
+	const { task } = await data.updateTaskWith(project, params.taskId, (current) => {
+		if (params.kind === "images") {
+			return {
+				updates: {
+					sharedImages: (current.sharedImages ?? []).map((image) =>
+						itemIds.has(image.id) && image.isUnread ? { ...image, isUnread: false } : image,
+					),
+				},
+				result: undefined,
+			};
+		}
+		return {
+			updates: {
+				sharedArtifacts: (current.sharedArtifacts ?? []).map((artifact) =>
+					itemIds.has(artifact.id) && artifact.isUnread ? { ...artifact, isUnread: false } : artifact,
+				),
+			},
+			result: undefined,
+		};
+	});
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task });
+	return task;
+}
+
 async function addTaskNote(params: { taskId: string; projectId: string; content: string; source?: NoteSource }): Promise<Task> {
 	log.info("→ addTaskNote", { taskId: params.taskId });
 	const project = await data.getProject(params.projectId);
@@ -287,6 +319,7 @@ export const notesLabelsHandlers = {
 	reorderColumns,
 	reorderLabels,
 	setTaskLabels,
+	markTaskSharedItemsRead,
 	addTaskNote,
 	updateTaskNote,
 	deleteTaskNote,

--- a/src/bun/shared-artifacts.ts
+++ b/src/bun/shared-artifacts.ts
@@ -130,6 +130,7 @@ export function saveSharedArtifact(
 		const baseTitle = htmlName.replace(/\.html$/i, "");
 		const record: SharedArtifact = {
 			id,
+			isUnread: true,
 			kind: "html",
 			title: title?.trim() || baseTitle,
 			name: htmlName,

--- a/src/bun/shared-images.ts
+++ b/src/bun/shared-images.ts
@@ -83,6 +83,7 @@ export function saveSharedImage(projectPath: string, sourcePath: string, caption
 	const trimmedCaption = caption?.trim();
 	return {
 		id: crypto.randomUUID(),
+		isUnread: true,
 		storedPath,
 		originalPath: sourcePath,
 		name: name || `image.${ext}`,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -340,6 +340,18 @@ function App() {
 	// Lightbox for images an agent surfaced via `dev3 show-image`, bound to a task.
 	const [imageViewer, setImageViewer] = useState<{ taskId: string; images: SharedImage[]; index: number } | null>(null);
 	const [artifactViewer, setArtifactViewer] = useState<{ taskId: string; artifacts: SharedArtifact[]; index: number } | null>(null);
+	const markSharedItemsRead = useCallback((
+		projectId: string,
+		taskId: string,
+		kind: "images" | "artifacts",
+		items: Array<{ id: string; isUnread?: boolean }>,
+	) => {
+		const itemIds = items.filter((item) => item.isUnread).map((item) => item.id);
+		if (itemIds.length === 0) return;
+		void api.request.markTaskSharedItemsRead({ projectId, taskId, kind, itemIds })
+			.then((task) => dispatch({ type: "updateTask", task }))
+			.catch((error) => console.error("Failed to mark shared items read:", error));
+	}, [dispatch]);
 	const closeArtifactViewer = useCallback(() => {
 		setArtifactViewer(null);
 		requestAnimationFrame(() => {
@@ -1299,6 +1311,7 @@ function App() {
 			const alreadyOpenForTask = imageViewerRef.current?.taskId === taskId;
 
 			if (alreadyOpenForTask || (viewingThisTask && autoOpen && foreground)) {
+				markSharedItemsRead(projectId, taskId, "images", images);
 				setImageViewer({ taskId, images, index: images.length - 1 });
 				return;
 			}
@@ -1312,28 +1325,31 @@ function App() {
 				context,
 				onClick: () => {
 					openTaskFromNotification(taskId, projectId);
+					markSharedItemsRead(projectId, taskId, "images", images);
 					setImageViewer({ taskId, images, index: images.length - 1 });
 				},
 			});
 		}
 		window.addEventListener("rpc:cliShowImage", onCliShowImage);
 		return () => window.removeEventListener("rpc:cliShowImage", onCliShowImage);
-	}, [dispatch, openTaskFromNotification, t, state.route]);
+	}, [dispatch, markSharedItemsRead, openTaskFromNotification, t, state.route]);
 
 	// Reopen the image viewer from a task-scoped trigger (the inspector image badge).
 	useEffect(() => {
 		function onOpenViewer(e: Event) {
-			const { taskId, images, index } = (e as CustomEvent).detail as {
+			const { taskId, projectId, images, index } = (e as CustomEvent).detail as {
 				taskId: string;
+				projectId: string;
 				images: SharedImage[];
 				index?: number;
 			};
-			if (!taskId || !images?.length) return;
+			if (!taskId || !projectId || !images?.length) return;
+			markSharedItemsRead(projectId, taskId, "images", images);
 			setImageViewer({ taskId, images, index: index ?? images.length - 1 });
 		}
 		window.addEventListener("dev3:openImageViewer", onOpenViewer);
 		return () => window.removeEventListener("dev3:openImageViewer", onOpenViewer);
-	}, []);
+	}, [markSharedItemsRead]);
 
 	useEffect(() => {
 		function onCliShowArtifact(e: Event) {
@@ -1354,6 +1370,7 @@ function App() {
 			const foreground = typeof document === "undefined" || (document.visibilityState === "visible" && document.hasFocus());
 			const alreadyOpenForTask = artifactViewerRef.current?.taskId === taskId;
 			if (alreadyOpenForTask || (viewingThisTask && foreground)) {
+				markSharedItemsRead(projectId, taskId, "artifacts", artifacts);
 				setArtifactViewer({ taskId, artifacts, index: artifacts.length - 1 });
 				return;
 			}
@@ -1364,27 +1381,30 @@ function App() {
 				context,
 				onClick: () => {
 					openTaskFromNotification(taskId, projectId);
+					markSharedItemsRead(projectId, taskId, "artifacts", artifacts);
 					setArtifactViewer({ taskId, artifacts, index: artifacts.length - 1 });
 				},
 			});
 		}
 		window.addEventListener("rpc:cliShowArtifact", onCliShowArtifact);
 		return () => window.removeEventListener("rpc:cliShowArtifact", onCliShowArtifact);
-	}, [dispatch, openTaskFromNotification, state.route, t]);
+	}, [dispatch, markSharedItemsRead, openTaskFromNotification, state.route, t]);
 
 	useEffect(() => {
 		function onOpenArtifactViewer(e: Event) {
-			const { taskId, artifacts, index } = (e as CustomEvent).detail as {
+			const { taskId, projectId, artifacts, index } = (e as CustomEvent).detail as {
 				taskId: string;
+				projectId: string;
 				artifacts: SharedArtifact[];
 				index?: number;
 			};
-			if (!taskId || !artifacts?.length) return;
+			if (!taskId || !projectId || !artifacts?.length) return;
+			markSharedItemsRead(projectId, taskId, "artifacts", artifacts);
 			setArtifactViewer({ taskId, artifacts, index: index ?? artifacts.length - 1 });
 		}
 		window.addEventListener("dev3:openArtifactViewer", onOpenArtifactViewer);
 		return () => window.removeEventListener("dev3:openArtifactViewer", onOpenArtifactViewer);
-	}, []);
+	}, [markSharedItemsRead]);
 
 	// Browser Web Notifications (remote mode). The desktop WKWebView already shows
 	// the native banner, so it ignores this push; only browsers act on it, falling

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -47,6 +47,7 @@ vi.mock("../rpc", () => ({
 			openQuickShell: vi.fn().mockResolvedValue({ id: "op-task-1", projectId: "ops-proj" }),
 			dismissMergeCompletionPrompt: vi.fn().mockResolvedValue(undefined),
 			setTaskManualCompletion: vi.fn().mockResolvedValue(undefined),
+			markTaskSharedItemsRead: vi.fn().mockResolvedValue({ id: "updated-task" }),
 			listAgentSkills: vi.fn().mockResolvedValue([]),
 			respondToAgentCompletionRequest: vi.fn().mockResolvedValue(undefined),
 			getRemoteAccessQR: vi.fn().mockResolvedValue({
@@ -822,6 +823,7 @@ describe("App keyboard shortcuts", () => {
 		];
 		const sharedImage = {
 			id: "img1",
+			isUnread: true,
 			storedPath: "/a/shared-images/img1.png",
 			originalPath: "/tmp/img1.png",
 			name: "img1.png",
@@ -869,6 +871,12 @@ describe("App keyboard shortcuts", () => {
 			expect(view).toHaveAttribute("data-project-id", "p1");
 			expect(view).toHaveAttribute("data-active-task-id", "t-img");
 			expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+			expect(api.request.markTaskSharedItemsRead).toHaveBeenCalledWith({
+				projectId: "p1",
+				taskId: "t-img",
+				kind: "images",
+				itemIds: ["img1"],
+			});
 		});
 
 		it("fullscreen open-mode: clicking the toast opens the full-page task view", async () => {
@@ -893,6 +901,7 @@ describe("App keyboard shortcuts", () => {
 		];
 		const artifact = (id: string) => ({
 			id,
+			isUnread: true,
 			kind: "html",
 			title: `Artifact ${id}`,
 			name: `${id}.html`,
@@ -910,10 +919,16 @@ describe("App keyboard shortcuts", () => {
 			await renderApp();
 			act(() => {
 				window.dispatchEvent(new CustomEvent("dev3:openArtifactViewer", {
-					detail: { taskId: "t-artifact", artifacts: [artifact("a"), artifact("b")], index: 1 },
+					detail: { taskId: "t-artifact", projectId: "p1", artifacts: [artifact("a"), artifact("b")], index: 1 },
 				}));
 			});
 			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-artifact-title", "Artifact b"));
+			expect(api.request.markTaskSharedItemsRead).toHaveBeenCalledWith({
+				projectId: "p1",
+				taskId: "t-artifact",
+				kind: "artifacts",
+				itemIds: ["a", "b"],
+			});
 
 			const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(false);
 			try {

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -1386,8 +1386,8 @@ function TaskInfoPanel({
 								</>
 							)}
 							<TaskExposedPorts task={task} compact={tight} />
-							<TaskSharedImages task={task} compact={tight} />
-							<TaskArtifacts task={task} compact={tight} />
+							<TaskSharedImages task={task} projectId={project.id} compact={tight} />
+							<TaskArtifacts task={task} projectId={project.id} compact={tight} />
 						</div>
 					</div>
 				</div>
@@ -1472,8 +1472,8 @@ function TaskInfoPanel({
 									</>
 								)}
 								<TaskExposedPorts task={task} compact={tight} />
-								<TaskSharedImages task={task} compact={tight} />
-								<TaskArtifacts task={task} compact={tight} />
+								<TaskSharedImages task={task} projectId={project.id} compact={tight} />
+								<TaskArtifacts task={task} projectId={project.id} compact={tight} />
 							</div>
 						</div>
 					</div>

--- a/src/mainview/components/task-info-panel/TaskArtifacts.tsx
+++ b/src/mainview/components/task-info-panel/TaskArtifacts.tsx
@@ -3,25 +3,30 @@ import { useT } from "../../i18n";
 import { ArtifactsIcon } from "../TaskIcons";
 import Tooltip from "../Tooltip";
 
-export default function TaskArtifacts({ task, compact = false }: { task: Task; compact?: boolean }) {
+export default function TaskArtifacts({ task, projectId, compact = false }: { task: Task; projectId: string; compact?: boolean }) {
 	const t = useT();
 	const count = task.sharedArtifacts?.length ?? 0;
 	if (count === 0) return null;
-	const label = t.plural("infoPanel.artifactsBadge", count);
+	const isUnread = task.sharedArtifacts?.some((artifact) => artifact.isUnread) ?? false;
+	const baseLabel = t.plural("infoPanel.artifactsBadge", count);
+	const label = isUnread ? `${baseLabel}. ${t("infoPanel.sharedItemsUnread")}` : baseLabel;
 	return (
 		<Tooltip content={label} detail={t("ttip.sharedArtifacts")}>
 			<button
 				type="button"
 				onClick={() => window.dispatchEvent(new CustomEvent("dev3:openArtifactViewer", {
-					detail: { taskId: task.id, artifacts: task.sharedArtifacts, index: count - 1 },
+					detail: { taskId: task.id, projectId, artifacts: task.sharedArtifacts, index: count - 1 },
 				}))}
-				className="task-anim flex items-center gap-1 px-2 py-1 rounded-lg transition-colors flex-shrink-0 text-fg-2 hover:text-fg hover:bg-elevated-hover border border-edge"
+				className={`task-anim flex items-center gap-1 px-2 py-1 rounded-lg transition-colors flex-shrink-0 border ${isUnread
+					? "text-success bg-success/15 border-success/40 hover:bg-success/25"
+					: "text-fg-2 hover:text-fg hover:bg-elevated-hover border-edge"
+				}`}
 				aria-label={label}
 				data-testid="shared-artifacts-badge"
 			>
-				<ArtifactsIcon className="w-[1.125rem] h-[1.125rem]" />
+				<ArtifactsIcon className={`w-[1.125rem] h-[1.125rem]${isUnread ? " task-shared-unread-icon" : ""}`} />
 				{!compact && <span className="text-[0.6875rem] font-semibold">{t("infoPanel.artifactsLabel")}</span>}
-				<span className="text-[0.6875rem] font-semibold text-accent tabular-nums">{count}</span>
+				<span className={`text-[0.6875rem] font-semibold tabular-nums ${isUnread ? "text-success" : "text-accent"}`}>{count}</span>
 			</button>
 		</Tooltip>
 	);

--- a/src/mainview/components/task-info-panel/TaskSharedImages.tsx
+++ b/src/mainview/components/task-info-panel/TaskSharedImages.tsx
@@ -5,6 +5,7 @@ import { ImagesIcon } from "../TaskIcons";
 
 interface TaskSharedImagesProps {
 	task: Task;
+	projectId: string;
 	/** Icon-only rendering (count kept) for a bar that is short on width. */
 	compact?: boolean;
 }
@@ -17,26 +18,31 @@ interface TaskSharedImagesProps {
  * App-level lightbox at the newest image via the same `dev3:openImageViewer`
  * event the inspector badge used, so the viewer stays a single App-mounted host.
  */
-export default function TaskSharedImages({ task, compact = false }: TaskSharedImagesProps) {
+export default function TaskSharedImages({ task, projectId, compact = false }: TaskSharedImagesProps) {
 	const t = useT();
 	const count = task.sharedImages?.length ?? 0;
 	if (count === 0) return null;
 
-	const label = t("infoPanel.imagesBadge", { count: String(count) });
+	const isUnread = task.sharedImages?.some((image) => image.isUnread) ?? false;
+	const baseLabel = t("infoPanel.imagesBadge", { count: String(count) });
+	const label = isUnread ? `${baseLabel}. ${t("infoPanel.sharedItemsUnread")}` : baseLabel;
 	return (
 		<Tooltip content={label} detail={t("ttip.sharedImages")}>
 			<button
 				type="button"
 				onClick={() => window.dispatchEvent(new CustomEvent("dev3:openImageViewer", {
-					detail: { taskId: task.id, images: task.sharedImages, index: count - 1 },
+					detail: { taskId: task.id, projectId, images: task.sharedImages, index: count - 1 },
 				}))}
-				className="task-anim flex items-center gap-1 px-2 py-1 rounded-lg transition-colors flex-shrink-0 text-fg-2 hover:text-fg hover:bg-elevated-hover border border-edge"
+				className={`task-anim flex items-center gap-1 px-2 py-1 rounded-lg transition-colors flex-shrink-0 border ${isUnread
+					? "text-success bg-success/15 border-success/40 hover:bg-success/25"
+					: "text-fg-2 hover:text-fg hover:bg-elevated-hover border-edge"
+				}`}
 				aria-label={label}
 				data-testid="shared-images-badge"
 			>
-				<ImagesIcon className="w-[1.125rem] h-[1.125rem]" />
+				<ImagesIcon className={`w-[1.125rem] h-[1.125rem]${isUnread ? " task-shared-unread-icon" : ""}`} />
 				{!compact && <span className="text-[0.6875rem] font-semibold">{t("infoPanel.imagesLabel")}</span>}
-				<span className="text-[0.6875rem] font-semibold text-accent tabular-nums">{count}</span>
+				<span className={`text-[0.6875rem] font-semibold tabular-nums ${isUnread ? "text-success" : "text-accent"}`}>{count}</span>
 			</button>
 		</Tooltip>
 	);

--- a/src/mainview/components/task-info-panel/__tests__/TaskArtifacts.test.tsx
+++ b/src/mainview/components/task-info-panel/__tests__/TaskArtifacts.test.tsx
@@ -19,7 +19,7 @@ function artifact(id: string): SharedArtifact {
 }
 
 function renderButton(artifacts?: SharedArtifact[]) {
-	return render(<I18nProvider><TaskArtifacts task={{ id: "task-1", sharedArtifacts: artifacts } as Task} /></I18nProvider>);
+	return render(<I18nProvider><TaskArtifacts task={{ id: "task-1", sharedArtifacts: artifacts } as Task} projectId="project-1" /></I18nProvider>);
 }
 
 describe("TaskArtifacts", () => {
@@ -37,7 +37,19 @@ describe("TaskArtifacts", () => {
 		await userEvent.click(screen.getByTestId("shared-artifacts-badge"));
 		window.removeEventListener("dev3:openArtifactViewer", spy);
 		const detail = (spy.mock.calls[0][0] as CustomEvent).detail;
-		expect(detail).toMatchObject({ taskId: "task-1", index: 1 });
+		expect(detail).toMatchObject({ taskId: "task-1", projectId: "project-1", index: 1 });
 		expect(detail.artifacts).toHaveLength(2);
+	});
+
+	it("highlights and animates unread artifacts while legacy artifacts remain read", () => {
+		renderButton([{ ...artifact("new"), isUnread: true }]);
+		const unreadButton = screen.getByTestId("shared-artifacts-badge");
+		expect(unreadButton.className).toContain("text-success");
+		expect(unreadButton.querySelector(".task-shared-unread-icon")).not.toBeNull();
+
+		renderButton([artifact("legacy")]);
+		const buttons = screen.getAllByTestId("shared-artifacts-badge");
+		expect(buttons[1].className).not.toContain("text-success");
+		expect(buttons[1].querySelector(".task-shared-unread-icon")).toBeNull();
 	});
 });

--- a/src/mainview/components/task-info-panel/__tests__/TaskSharedImages.test.tsx
+++ b/src/mainview/components/task-info-panel/__tests__/TaskSharedImages.test.tsx
@@ -23,7 +23,7 @@ function makeTask(images?: SharedImage[]): Task {
 function renderBtn(task: Task) {
 	return render(
 		<I18nProvider>
-			<TaskSharedImages task={task} />
+			<TaskSharedImages task={task} projectId="project-1" />
 		</I18nProvider>,
 	);
 }
@@ -42,6 +42,18 @@ describe("TaskSharedImages", () => {
 		expect(btn).toHaveAttribute("aria-label", expect.stringContaining("3"));
 	});
 
+	it("highlights and animates the button only when an image is unread", () => {
+		const unread = { ...sharedImage("new"), isUnread: true };
+		const { rerender } = renderBtn(makeTask([unread]));
+		const button = screen.getByTestId("shared-images-badge");
+		expect(button.className).toContain("text-success");
+		expect(button.querySelector(".task-shared-unread-icon")).not.toBeNull();
+
+		rerender(<I18nProvider><TaskSharedImages task={makeTask([sharedImage("old")])} projectId="project-1" /></I18nProvider>);
+		expect(button.className).not.toContain("text-success");
+		expect(button.querySelector(".task-shared-unread-icon")).toBeNull();
+	});
+
 	it("dispatches dev3:openImageViewer at the newest image when clicked", async () => {
 		const task = makeTask([sharedImage("a"), sharedImage("b")]);
 		const spy = vi.fn();
@@ -51,7 +63,7 @@ describe("TaskSharedImages", () => {
 		window.removeEventListener("dev3:openImageViewer", spy);
 		expect(spy).toHaveBeenCalledTimes(1);
 		const detail = (spy.mock.calls[0][0] as CustomEvent).detail;
-		expect(detail).toMatchObject({ taskId: "task-1", index: 1 });
+		expect(detail).toMatchObject({ taskId: "task-1", projectId: "project-1", index: 1 });
 		expect(detail.images).toHaveLength(2);
 	});
 });

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -224,6 +224,7 @@ const infoPanel = {
 	"infoPanel.artifactsBadge_one": "View {count} shared artifact",
 	"infoPanel.artifactsBadge_other": "View {count} shared artifacts",
 	"infoPanel.artifactsLabel": "Artifacts",
+	"infoPanel.sharedItemsUnread": "New items not viewed yet",
 } as const;
 
 export default infoPanel;

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -224,6 +224,7 @@ const infoPanel = {
 	"infoPanel.artifactsBadge_one": "Ver {count} artefacto compartido",
 	"infoPanel.artifactsBadge_other": "Ver {count} artefactos compartidos",
 	"infoPanel.artifactsLabel": "Artefactos",
+	"infoPanel.sharedItemsUnread": "Hay elementos nuevos sin ver",
 };
 
 export default infoPanel;

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -240,6 +240,7 @@ const infoPanel = {
 	"infoPanel.artifactsBadge_many": "Открыть {count} присланных артефактов",
 	"infoPanel.artifactsBadge_other": "Открыть {count} присланных артефактов",
 	"infoPanel.artifactsLabel": "Артефакты",
+	"infoPanel.sharedItemsUnread": "Есть новые непросмотренные элементы",
 };
 
 export default infoPanel;

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -1422,9 +1422,23 @@ svg .th-draw { stroke-dasharray: 1; stroke-dashoffset: 0; }
 .task-anim:hover .th-col-up { animation: th-col-up 2.4s ease-in-out infinite; }
 .task-anim:hover .th-col-up-ghost { animation: th-col-up-ghost 2.4s ease-in-out infinite; }
 
+/* Fresh task-bound images/artifacts keep gently nudging until their viewer opens. */
+@keyframes task-shared-unread-nudge {
+	0%, 55%, 100% { transform: translateY(0) rotate(0deg) scale(1); }
+	64% { transform: translateY(-1.5px) rotate(-7deg) scale(1.06); }
+	73% { transform: translateY(0) rotate(6deg) scale(1.06); }
+	82% { transform: translateY(-.5px) rotate(-3deg) scale(1.02); }
+	91% { transform: translateY(0) rotate(0deg) scale(1); }
+}
+.task-shared-unread-icon {
+	transform-origin: center;
+	animation: task-shared-unread-nudge 1.8s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.task-anim:hover [class^="th-"],
-	.task-anim:hover [class*=" th-"] {
+	.task-anim:hover [class*=" th-"],
+	.task-shared-unread-icon {
 		animation: none;
 	}
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1956,6 +1956,8 @@ export interface TaskNote {
  */
 export interface SharedImage {
 	id: string;
+	/** True until the user opens a viewer containing this image. Absent means read for legacy records. */
+	isUnread?: boolean;
 	/** Absolute path of the copied file under ~/.dev3.0/worktrees/<slug>/shared-images/. */
 	storedPath: string;
 	/** The path the agent originally passed (kept for provenance / tooltip). */
@@ -1989,6 +1991,8 @@ export interface SharedArtifactAsset {
  */
 export interface SharedArtifact {
 	id: string;
+	/** True until the user opens a viewer containing this artifact. Absent means read for legacy records. */
+	isUnread?: boolean;
 	kind: "html";
 	title: string;
 	name: string;
@@ -3190,6 +3194,10 @@ export type AppRPCSchema = {
 			};
 			setTaskLabels: {
 				params: { taskId: string; projectId: string; labelIds: string[] };
+				response: Task;
+			};
+			markTaskSharedItemsRead: {
+				params: { taskId: string; projectId: string; kind: "images" | "artifacts"; itemIds: string[] };
 				response: Task;
 			};
 			toggleTaskWatch: {


### PR DESCRIPTION
## Summary

- mark newly shared task images and HTML artifacts as unread while treating legacy records as already viewed
- highlight unread toolbar controls with success styling and an attention animation that respects reduced-motion preferences
- clear unread state only for the exact items opened in the viewer, preserving concurrently arriving content
- localize the unread announcement for English, Russian, and Spanish

## Test plan

- `bun run lint`
- targeted renderer tests for the Images and Artifacts controls and App viewer flows
- targeted Bun tests for shared-content creation and read-state persistence
- browser QA covering unread styling, per-viewer clearing, and legacy read state