### PR TITLE
Never hide a board column that holds tasks

### DIFF
--- a/change-logs/2026/07/30/fix-board-never-hides-occupied-columns.md
+++ b/change-logs/2026/07/30/fix-board-never-hides-occupied-columns.md
@@ -1,0 +1,3 @@
+Short: Board never hides a column holding tasks
+
+The board no longer hides a review column that still holds cards: turning peer review off, or converting a board to Operations, used to take those tasks off the board entirely while they stayed in tasks.json and visible to the CLI, and a restart did not bring them back. A task whose status matches no column now lands in To Do instead of vanishing, and the tasks.json read cache keys on the file's inode so a same-size rewrite can never be served stale.

--- a/decisions/181-board-never-hides-occupied-columns.md
+++ b/decisions/181-board-never-hides-occupied-columns.md
@@ -1,0 +1,45 @@
+# 181 — Occupancy outranks config in board column visibility
+
+## Context
+
+`getBoardColumns` (`src/shared/types.ts`) hid the PR Review column whenever
+`peerReviewEnabled === false`, and hid both AI Review and PR Review on virtual
+("Operations") boards — unconditionally. AI Review already had an escape hatch
+(`aiReviewHasItems`), PR Review had none.
+
+A hidden column still receives tasks: the lifecycle machine, the CLI, and task
+moves all write those statuses regardless of column visibility. The card then
+renders nowhere while remaining in `tasks.json` and answering to
+`dev3 task show` — and a restart does not bring it back, which reads as data
+loss. This surfaced while investigating issue #1170 (a task visible to the CLI
+but never on the board); it is not confirmed as that reporter's cause.
+
+## Decision
+
+Column visibility now takes occupancy as an override: `getBoardColumns` accepts
+`opts.occupiedStatuses` (the built-in statuses currently holding at least one
+card) and `shouldHide` returns false for any status in that set. The old
+`opts.aiReviewHasItems` boolean is gone — replaced, not deprecated. `KanbanBoard`
+computes the set from the **unfiltered** task list, so the board's search filter
+cannot hide a column out from under its cards.
+
+Companion fix in the same change: `partitionTasksByStatus`
+(`src/mainview/components/partitionTasks.ts`) routes a task with an unrecognized
+status into To Do rather than letting an optional-chained `Map.get(...)?.push`
+drop it silently.
+
+## Risks
+
+A user who turns peer review off, or converts a board to Operations, keeps
+seeing the review column until it empties out — mildly surprising, but the
+alternative loses cards. No data or on-disk format is touched.
+
+## Alternatives considered
+
+- **Auto-move occupied cards to a visible status** when a column hides — mutates
+  user data as a side effect of a settings toggle; rejected.
+- **Refuse the settings change while the column is occupied** — blocks a
+  legitimate config change on unrelated task state; rejected.
+- **Badge the orphaned cards** in a dedicated "unknown status" tray — new UI
+  surface for a state that should not occur; To Do is already the correct
+  fallback.

--- a/src/bun/__tests__/data-cache.test.ts
+++ b/src/bun/__tests__/data-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { mkdirSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import type { Project, Task } from "../../shared/types";
 
 const { logDebug, testHome } = vi.hoisted(() => ({
@@ -154,6 +154,35 @@ describe("tasks read cache", () => {
 
 		const reloaded = await loadTasks(project);
 		expect(reloaded).toHaveLength(3);
+	});
+
+	// Every write in data.ts lands via atomicWriteFile's rename(), so a replaced
+	// file always has a new inode. That makes the cache safe even when the new
+	// payload has the identical byte length AND the timestamps are forced back —
+	// the case that would otherwise serve a stale board (missing task) forever.
+	it("re-reads a same-size, same-mtime replacement (inode differs)", async () => {
+		const project = makeProject();
+		const file = `${HOME}/data/${SLUG}/tasks.json`;
+		const frozen = new Date("2026-05-05T05:05:05.000Z");
+
+		writeTasksFile([makeTask({ id: "aaaaa" })]);
+		utimesSync(file, frozen, frozen);
+		expect((await loadTasks(project))[0].id).toBe("aaaaa");
+		expect(loadingTasksLogCount()).toBe(1);
+		const before = statSync(file, { bigint: true });
+
+		writeFileSync(`${file}.swap`, JSON.stringify([makeTask({ id: "bbbbb" })], null, 2));
+		renameSync(`${file}.swap`, file);
+		utimesSync(file, frozen, frozen);
+
+		// Only the inode may differ — size and mtime are byte-for-byte identical.
+		const after = statSync(file, { bigint: true });
+		expect(after.size).toBe(before.size);
+		expect(after.mtimeNs).toBe(before.mtimeNs);
+
+		const reloaded = await loadTasks(project);
+		expect(reloaded[0].id).toBe("bbbbb");
+		expect(loadingTasksLogCount()).toBe(2);
 	});
 
 	it("still returns empty list when tasks file is missing", async () => {

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -88,7 +88,7 @@ export async function atomicWriteFile(filePath: string, content: string): Promis
 	}
 }
 
-// ---- Read cache (mtime/size keyed) ----
+// ---- Read cache (inode/mtime/size keyed) ----
 //
 // Background pollers re-read projects.json/tasks.json multiple times per second.
 // Caching the parsed result and validating it with a cheap stat() avoids re-reading
@@ -96,10 +96,19 @@ export async function atomicWriteFile(filePath: string, content: string): Promis
 // BEFORE readFile so a concurrent write can only over-invalidate, never serve stale.
 // Cache hits return shallow copies; mutators bypass the cache and saves invalidate it,
 // so callers of the public load APIs must treat results as read-only snapshots.
+//
+// The identity includes the inode and nanosecond mtime, not just millisecond mtime
+// and size: every write here lands via atomicWriteFile's rename(), which always
+// produces a NEW inode, so a same-size rewrite can never be mistaken for the cached
+// file — including a rewrite by another app instance within the same millisecond.
 
-interface FileCacheEntry<T> {
-	mtimeMs: number;
-	size: number;
+interface FileIdentity {
+	mtimeNs: bigint;
+	size: bigint;
+	ino: bigint;
+}
+
+interface FileCacheEntry<T> extends FileIdentity {
 	value: T[];
 }
 
@@ -107,19 +116,23 @@ const projectsCache = new Map<string, FileCacheEntry<Project>>();
 const virtualProjectsCache = new Map<string, FileCacheEntry<Project>>();
 const tasksCache = new Map<string, FileCacheEntry<Task>>();
 
+function sameFileIdentity(a: FileIdentity, b: FileIdentity): boolean {
+	return a.ino === b.ino && a.mtimeNs === b.mtimeNs && a.size === b.size;
+}
+
 async function cacheLookup<T>(
 	cache: Map<string, FileCacheEntry<T>>,
 	file: string,
-): Promise<{ hit: T[] | null; stat: { mtimeMs: number; size: number } | null }> {
-	let fileStat: { mtimeMs: number; size: number } | null = null;
+): Promise<{ hit: T[] | null; stat: FileIdentity | null }> {
+	let fileStat: FileIdentity;
 	try {
-		const st = await stat(file);
-		fileStat = { mtimeMs: st.mtimeMs, size: st.size };
+		const st = await stat(file, { bigint: true });
+		fileStat = { mtimeNs: st.mtimeNs, size: st.size, ino: st.ino };
 	} catch {
 		return { hit: null, stat: null };
 	}
 	const entry = cache.get(file);
-	if (entry && entry.mtimeMs === fileStat.mtimeMs && entry.size === fileStat.size) {
+	if (entry && sameFileIdentity(entry, fileStat)) {
 		return { hit: entry.value.map((item) => ({ ...item })), stat: fileStat };
 	}
 	return { hit: null, stat: fileStat };
@@ -151,7 +164,7 @@ function toDataFileReadError(
 async function rawLoadAllProjects(options?: { strict?: boolean; persistMigrations?: boolean }): Promise<Project[]> {
 	// Mutators (strict/persistMigrations) always read fresh from disk.
 	const useCache = !options?.strict && !options?.persistMigrations;
-	let preReadStat: { mtimeMs: number; size: number } | null = null;
+	let preReadStat: FileIdentity | null = null;
 	if (useCache) {
 		const { hit, stat: st } = await cacheLookup(projectsCache, PROJECTS_FILE);
 		if (hit) return hit;
@@ -276,7 +289,7 @@ export async function saveProjects(projects: Project[]): Promise<void> {
 
 async function rawLoadAllVirtualProjects(options?: { strict?: boolean }): Promise<Project[]> {
 	const useCache = !options?.strict;
-	let preReadStat: { mtimeMs: number; size: number } | null = null;
+	let preReadStat: FileIdentity | null = null;
 	if (useCache) {
 		const { hit, stat: st } = await cacheLookup(virtualProjectsCache, VIRTUAL_PROJECTS_FILE);
 		if (hit) return hit;
@@ -599,7 +612,7 @@ async function rawLoadTasks(project: Project, options?: { strict?: boolean; pers
 	const file = tasksFile(project);
 	// Mutators (strict/persistMigrations) always read fresh from disk.
 	const useCache = !options?.strict && !options?.persistMigrations;
-	let preReadStat: { mtimeMs: number; size: number } | null = null;
+	let preReadStat: FileIdentity | null = null;
 	if (useCache) {
 		const { hit, stat: st } = await cacheLookup(tasksCache, file);
 		if (hit) return hit;

--- a/src/mainview/__tests__/getBoardColumns.test.ts
+++ b/src/mainview/__tests__/getBoardColumns.test.ts
@@ -58,8 +58,56 @@ describe("getBoardColumns", () => {
 	});
 
 	it("AI Review stays visible (even when disabled) if it currently has items", () => {
-		const result = tokens(getBoardColumns(project({ builtinColumnAgents: {} }), { aiReviewHasItems: true }));
+		const result = tokens(
+			getBoardColumns(project({ builtinColumnAgents: {} }), { occupiedStatuses: new Set(["review-by-ai"] as const) }),
+		);
 		expect(result).toContain("review-by-ai");
+	});
+
+	// An occupied column that hides takes its cards off the board for good: they
+	// stay in tasks.json and stay visible to the CLI, and a restart does not bring
+	// them back. Never hide a column that holds tasks.
+	it("PR Review stays visible with peer review off if it currently has items", () => {
+		const result = tokens(
+			getBoardColumns(project({ peerReviewEnabled: false }), {
+				occupiedStatuses: new Set(["review-by-colleague"] as const),
+			}),
+		);
+		expect(result).toContain("review-by-colleague");
+	});
+
+	it("virtual board keeps an occupied AI Review / PR Review column", () => {
+		const result = tokens(
+			getBoardColumns(project({ kind: "virtual" }), {
+				occupiedStatuses: new Set(["review-by-ai", "review-by-colleague"] as const),
+			}),
+		);
+		expect(result).toContain("review-by-ai");
+		expect(result).toContain("review-by-colleague");
+	});
+
+	it("occupancy of an unrelated column does not resurrect a hidden one", () => {
+		const result = tokens(
+			getBoardColumns(project({ peerReviewEnabled: false }), { occupiedStatuses: new Set(["todo"] as const) }),
+		);
+		expect(result).not.toContain("review-by-colleague");
+	});
+
+	it("a hidden column stays hidden when it is listed in a stored columnOrder", () => {
+		const result = tokens(
+			getBoardColumns(project({ peerReviewEnabled: false, columnOrder: ["todo", "review-by-colleague", "completed"] })),
+		);
+		expect(result).not.toContain("review-by-colleague");
+	});
+
+	it("an occupied column listed in a stored columnOrder keeps its stored position", () => {
+		const result = tokens(
+			getBoardColumns(
+				project({ peerReviewEnabled: false, columnOrder: ["todo", "review-by-colleague", "completed"] }),
+				{ occupiedStatuses: new Set(["review-by-colleague"] as const) },
+			),
+		);
+		expect(result.slice(0, 3)).toEqual(["todo", "review-by-colleague", "completed"]);
 	});
 
 	it("virtual (Operations) board hides both AI Review and PR Review", () => {

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -14,6 +14,7 @@ import KanbanColumn from "./KanbanColumn";
 import LaunchVariantsModal from "./LaunchVariantsModal";
 import CreateTaskModal from "./CreateTaskModal";
 import { sortTasksForColumn } from "./sortTasks";
+import { partitionTasksByStatus } from "./partitionTasks";
 import LabelFilterBar from "./LabelFilterBar";
 import { matchesTaskQuery } from "../utils/taskSearch";
 import { buildFilterGroups, taskQueryContext, isAttentionTask, type FacetResolver, type FilterFunnelOption } from "../utils/taskFacets";
@@ -495,16 +496,9 @@ function KanbanBoard({
 	}
 
 	// Built-in column tasks (exclude tasks in an existing custom column; tasks
-	// with a dangling customColumnId fall back here into their status column).
-	const tasksByStatus = new Map<TaskStatus, Task[]>();
-	for (const status of ALL_STATUSES) {
-		tasksByStatus.set(status, []);
-	}
-	for (const task of displayTasks) {
-		if (!isInCustomColumn(task)) {
-			tasksByStatus.get(task.status)?.push(task);
-		}
-	}
+	// with a dangling customColumnId fall back here into their status column,
+	// and an unrecognized status falls back to To Do — see partitionTasksByStatus).
+	const tasksByStatus = partitionTasksByStatus(displayTasks, isInCustomColumn);
 
 	// Sort tasks within each built-in column for variant grouping
 	for (const status of ALL_STATUSES) {
@@ -515,12 +509,17 @@ function KanbanBoard({
 	}
 
 	// Returns all columns in their effective display order (delegates to the
-	// shared getBoardColumns). "Your Review" stays even on virtual boards: a
-	// finished ops task is handed
-	// back via review-by-user, so hiding it would drop the task off the board.
+	// shared getBoardColumns). Occupancy is computed from the FULL task list, not
+	// the filtered one: a search filter must never hide a column out from under
+	// the cards it holds. "Your Review" stays even on virtual boards: a finished
+	// ops task is handed back via review-by-user, so hiding it would drop the
+	// task off the board.
 	function getOrderedColumns(): ColumnSlot[] {
-		const aiReviewHasItems = tasks.some((t) => t.status === "review-by-ai" && !isInCustomColumn(t));
-		return getBoardColumns(project, { aiReviewHasItems });
+		const occupiedStatuses = new Set<TaskStatus>();
+		for (const task of tasks) {
+			if (!isInCustomColumn(task)) occupiedStatuses.add(task.status);
+		}
+		return getBoardColumns(project, { occupiedStatuses });
 	}
 
 	function handleColumnDragStart(colId: string) {

--- a/src/mainview/components/__tests__/partitionTasks.test.ts
+++ b/src/mainview/components/__tests__/partitionTasks.test.ts
@@ -1,0 +1,51 @@
+import { partitionTasksByStatus } from "../partitionTasks";
+import { ALL_STATUSES, type Task, type TaskStatus } from "../../../shared/types";
+
+function task(id: string, status: string, customColumnId: string | null = null): Task {
+	return { id, status, customColumnId } as unknown as Task;
+}
+
+const noCustomColumns = () => false;
+
+describe("partitionTasksByStatus", () => {
+	it("creates a bucket for every built-in status, even when empty", () => {
+		const byStatus = partitionTasksByStatus([], noCustomColumns);
+		expect([...byStatus.keys()]).toEqual(ALL_STATUSES);
+		expect([...byStatus.values()].every((tasks) => tasks.length === 0)).toBe(true);
+	});
+
+	it("buckets tasks by their own status, preserving input order", () => {
+		const byStatus = partitionTasksByStatus(
+			[task("a", "todo"), task("b", "completed"), task("c", "todo")],
+			noCustomColumns,
+		);
+		expect(byStatus.get("todo")!.map((t) => t.id)).toEqual(["a", "c"]);
+		expect(byStatus.get("completed")!.map((t) => t.id)).toEqual(["b"]);
+	});
+
+	it("skips tasks that live in a custom column", () => {
+		const byStatus = partitionTasksByStatus(
+			[task("a", "todo"), task("b", "todo", "deploy")],
+			(t) => t.customColumnId === "deploy",
+		);
+		expect(byStatus.get("todo")!.map((t) => t.id)).toEqual(["a"]);
+	});
+
+	// A dropped card is invisible on the board while still sitting in tasks.json and
+	// answering to the CLI — and a restart does not bring it back. Land it in To Do
+	// instead, where the user can at least see and move it.
+	it("puts a task with an unrecognized status into To Do instead of dropping it", () => {
+		const byStatus = partitionTasksByStatus([task("ghost", "archived-by-future-version")], noCustomColumns);
+		expect(byStatus.get("todo")!.map((t) => t.id)).toEqual(["ghost"]);
+	});
+
+	it("loses no task, whatever the status", () => {
+		const tasks = [
+			...ALL_STATUSES.map((s: TaskStatus, i) => task(`ok-${i}`, s)),
+			task("weird", ""),
+			task("weirder", "not-a-status"),
+		];
+		const total = [...partitionTasksByStatus(tasks, noCustomColumns).values()].reduce((n, list) => n + list.length, 0);
+		expect(total).toBe(tasks.length);
+	});
+});

--- a/src/mainview/components/partitionTasks.ts
+++ b/src/mainview/components/partitionTasks.ts
@@ -1,0 +1,29 @@
+import { ALL_STATUSES, type Task, type TaskStatus } from "../../shared/types";
+
+/**
+ * Column a task falls back to when its own `status` matches no built-in column
+ * (a hand-edited tasks.json, or a status written by a newer app version).
+ */
+export const UNKNOWN_STATUS_FALLBACK: TaskStatus = "todo";
+
+/**
+ * Buckets board tasks into their built-in status columns.
+ *
+ * Every task that is not in a custom column ends up in exactly one bucket: an
+ * unrecognized status lands in To Do instead of being dropped. A dropped card is
+ * invisible on the board yet still present in tasks.json and to the CLI, and it
+ * survives a restart — indistinguishable from data loss for the user.
+ */
+export function partitionTasksByStatus(
+	tasks: Task[],
+	isInCustomColumn: (task: Task) => boolean,
+): Map<TaskStatus, Task[]> {
+	const byStatus = new Map<TaskStatus, Task[]>();
+	for (const status of ALL_STATUSES) byStatus.set(status, []);
+	const fallback = byStatus.get(UNKNOWN_STATUS_FALLBACK)!;
+	for (const task of tasks) {
+		if (isInCustomColumn(task)) continue;
+		(byStatus.get(task.status) ?? fallback).push(task);
+	}
+	return byStatus;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1095,27 +1095,34 @@ export type BoardColumnSlot =
  * Returns every column a project's board renders, in effective display order,
  * respecting `columnOrder` and hiding columns that don't apply (virtual boards
  * have no AI/PR review; `peerReviewEnabled === false` hides PR review; AI review
- * hides when disabled and empty). Single source of truth for the board's column
- * layout — see [[KanbanBoard]].
+ * hides when disabled). Single source of truth for the board's column layout —
+ * see [[KanbanBoard]].
  *
- * Pure function of the project plus `opts.aiReviewHasItems` (the renderer passes
- * whether the AI-review column currently holds tasks).
+ * Pure function of the project plus `opts.occupiedStatuses` — the built-in
+ * statuses that currently hold at least one card. **A column holding tasks is
+ * never hidden**, whatever the project config says: hiding it would drop those
+ * cards off the board with no way to reach them (and it survives a restart,
+ * which reads as data loss). Turning peer review off, or converting a board to
+ * Operations, therefore leaves an occupied review column standing until it
+ * empties out.
  */
 export function getBoardColumns(
 	project: Pick<Project, "customColumns" | "columnOrder" | "peerReviewEnabled" | "builtinColumnAgents" | "kind">,
-	opts: { aiReviewHasItems?: boolean } = {},
+	opts: { occupiedStatuses?: ReadonlySet<TaskStatus> } = {},
 ): BoardColumnSlot[] {
 	const cols = project.customColumns ?? [];
 	const peerReviewEnabled = project.peerReviewEnabled !== false;
 	// AI Review shows by default (on when builtinColumnAgents is unset or has a review-by-ai config).
 	const aiReviewEnabled = project.builtinColumnAgents === undefined || !!project.builtinColumnAgents?.["review-by-ai"];
-	const aiReviewHasItems = opts.aiReviewHasItems ?? false;
+	const occupied = opts.occupiedStatuses;
 	// Virtual ("Operations") boards have no diff/PR, so AI Review and PR Review are hidden.
 	const isVirtual = project.kind === "virtual";
 	const shouldHide = (s: TaskStatus) =>
-		(isVirtual && (s === "review-by-ai" || s === "review-by-colleague")) ||
-		(s === "review-by-colleague" && !peerReviewEnabled) ||
-		(s === "review-by-ai" && !aiReviewEnabled && !aiReviewHasItems);
+		!occupied?.has(s) && (
+			(isVirtual && (s === "review-by-ai" || s === "review-by-colleague")) ||
+			(s === "review-by-colleague" && !peerReviewEnabled) ||
+			(s === "review-by-ai" && !aiReviewEnabled)
+		);
 	const filterBuiltin = (statuses: TaskStatus[]) => statuses.filter((s) => !shouldHide(s));
 
 	if (!project.columnOrder || project.columnOrder.length === 0) {


### PR DESCRIPTION
Hardening found while investigating #1170 (a CLI-created task visible to the CLI but never on the board). None of these is confirmed to be that reporter's cause — the repro is still not established — but each one loses cards on its own, so they are worth closing regardless.

**1. A hidden column could still hold tasks.** `getBoardColumns` hid PR Review whenever `peerReviewEnabled === false`, and hid both review columns on virtual ("Operations") boards, unconditionally. Nothing stops the lifecycle machine or the CLI from putting a task into a hidden status, and the card then renders nowhere while staying in `tasks.json` and answering to `dev3 task show` — across restarts. AI Review already had an `aiReviewHasItems` escape hatch; PR Review had none.

`getBoardColumns` now takes `occupiedStatuses` and never hides a built-in column that holds cards. The old `aiReviewHasItems` option is replaced, not deprecated. `KanbanBoard` computes occupancy from the **unfiltered** task list, so the board's search filter cannot hide a column out from under its cards. Rationale and rejected alternatives in `decisions/181`.

**2. An unrecognized status dropped the card.** The board's partition loop did `tasksByStatus.get(task.status)?.push(task)` — the optional chain silently swallowed any status without a bucket. Extracted into `partitionTasksByStatus`, which routes such a task into To Do.

**3. Read cache could serve a stale task list.** The `projects.json` / `tasks.json` cache validated on millisecond mtime + size, so a same-size rewrite within one millisecond could be mistaken for the cached file. Every write here lands via `atomicWriteFile`'s `rename()`, which always yields a new inode, so the cache identity is now inode + nanosecond mtime + size.

Refs #1170.