### PR TITLE
Restore Active Tasks Kanban toggle navigation

### DIFF
--- a/change-logs/2026/07/30/feature-active-task-kanban-toggle.md
+++ b/change-logs/2026/07/30/feature-active-task-kanban-toggle.md
@@ -1,0 +1,3 @@
+Short: Return to Kanban on repeat click
+
+Clicking the currently open task in Active Tasks now returns to its project's Kanban board, while clicks on other tasks still open the selected task. Credit: Bar Volovsky.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -396,11 +396,12 @@ function ActiveTasksSidebar({
 
 	function handleTaskClick(task: Task) {
 		if (task.shuttingDown) return;
+		preview.close();
 		const targetProjectId = task.projectId || project.id;
 		if (task.id === activeTaskId && targetProjectId === project.id) {
+			navigate({ screen: "project", projectId: project.id });
 			return;
 		}
-		preview.close();
 		navigate({
 			screen: "project",
 			projectId: targetProjectId,

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -126,7 +126,7 @@ function makeTask(overrides?: Partial<Task>): Task {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
-	it("keeps the focused task open when clicked again", async () => {
+	it("returns to the Kanban board when the focused task is clicked again", async () => {
 		const user = userEvent.setup();
 		const navigate = vi.fn();
 		render(
@@ -145,8 +145,8 @@ function makeTask(overrides?: Partial<Task>): Task {
 		);
 
 		await user.click(screen.getByText("Привет! как сам?"));
-		expect(navigate).not.toHaveBeenCalled();
-		expect(terminalPreview.close).not.toHaveBeenCalled();
+		expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+		expect(terminalPreview.close).toHaveBeenCalledTimes(1);
 	});
 
 	it("shows agent-first identity with compact config and variant dots", () => {


### PR DESCRIPTION
## Summary

- Restore the Active Tasks toggle: clicking the currently open task returns to its project's Kanban board.
- Keep navigation to another active task unchanged.
- Add regression coverage and changelog credit for Bar Volovsky.

## Tests

- bun run lint
- bun run test
- Manual browser QA covered both navigation paths.