### PR TITLE
Prevent artifact resize overlay from freezing the UI

### DIFF
--- a/change-logs/2026/07/30/fix-artifact-resize-cleanup.md
+++ b/change-logs/2026/07/30/fix-artifact-resize-cleanup.md
@@ -1,0 +1,3 @@
+Short: Artifact resizing stays responsive
+
+Artifact panel resizing now exits cleanly when pointer release is lost, the window loses focus, or the page is hidden, preventing the resize overlay from blocking the task UI.

--- a/src/mainview/components/TaskWorkspacePane.tsx
+++ b/src/mainview/components/TaskWorkspacePane.tsx
@@ -135,6 +135,28 @@ function TaskWorkspacePane({
 		});
 	}, [clampArtifactWidth]);
 
+	useEffect(() => {
+		if (!artifactResizing) return;
+		const finishForPointer = (event: PointerEvent) => {
+			if (resizeSessionRef.current?.pointerId !== event.pointerId) return;
+			finishArtifactResize(true);
+		};
+		const finishForBlur = () => finishArtifactResize(true);
+		const finishWhenHidden = () => {
+			if (document.visibilityState === "hidden") finishArtifactResize(true);
+		};
+		window.addEventListener("pointerup", finishForPointer, true);
+		window.addEventListener("pointercancel", finishForPointer, true);
+		window.addEventListener("blur", finishForBlur);
+		document.addEventListener("visibilitychange", finishWhenHidden);
+		return () => {
+			window.removeEventListener("pointerup", finishForPointer, true);
+			window.removeEventListener("pointercancel", finishForPointer, true);
+			window.removeEventListener("blur", finishForBlur);
+			document.removeEventListener("visibilitychange", finishWhenHidden);
+		};
+	}, [artifactResizing, finishArtifactResize]);
+
 	const resizeArtifactBy = useCallback((delta: number) => {
 		setArtifactWidth((width) => clampArtifactWidth(width + delta));
 	}, [clampArtifactWidth]);

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -99,7 +99,43 @@ const task: Task = {
 	updatedAt: "2025-06-15T12:00:00Z",
 };
 
+const artifact: SharedArtifact = {
+	id: "artifact-1",
+	kind: "html",
+	title: "Metrics",
+	name: "metrics.html",
+	storedPath: "/tmp/shared-artifacts/artifact-1/metrics.html",
+	originalPath: "/tmp/metrics.html",
+	bytes: 10,
+	createdAt: 1,
+	assets: [],
+};
+
 const renderWorkspace = (element: ReactElement) => render(element, { wrapper: I18nProvider });
+
+function startArtifactResize() {
+	renderWorkspace(
+		<TaskWorkspaceView
+			projectId="p1"
+			taskId="t1"
+			tasks={[task]}
+			projects={[project]}
+			navigate={vi.fn()}
+			dispatch={vi.fn()}
+			artifactViewer={{ taskId: "t1", artifacts: [artifact], index: 0 }}
+		/>,
+	);
+
+	const separator = screen.getByRole("separator", { name: "Resize artifact panel" });
+	const releasePointerCapture = vi.fn();
+	Object.defineProperties(separator, {
+		setPointerCapture: { value: vi.fn() },
+		releasePointerCapture: { value: releasePointerCapture },
+		hasPointerCapture: { value: () => true },
+	});
+	fireEvent.pointerDown(separator, { pointerId: 7, clientX: 900 });
+	return { releasePointerCapture, separator };
+}
 
 describe("TaskWorkspaceView", () => {
 	beforeEach(() => {
@@ -225,17 +261,6 @@ describe("TaskWorkspaceView", () => {
 
 	it("shows a task artifact beside the terminal and closes it independently", async () => {
 		const onClose = vi.fn();
-		const artifact: SharedArtifact = {
-			id: "artifact-1",
-			kind: "html",
-			title: "Metrics",
-			name: "metrics.html",
-			storedPath: "/tmp/shared-artifacts/artifact-1/metrics.html",
-			originalPath: "/tmp/metrics.html",
-			bytes: 10,
-			createdAt: 1,
-			assets: [],
-		};
 		renderWorkspace(
 			<TaskWorkspaceView
 				projectId="p1"
@@ -279,6 +304,40 @@ describe("TaskWorkspaceView", () => {
 		expect(document.body.style.userSelect).toBe("");
 		await userEvent.click(screen.getByText("Close Artifact"));
 		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it("finishes artifact resizing when pointer release misses the separator", () => {
+		const { releasePointerCapture, separator } = startArtifactResize();
+		fireEvent.pointerMove(separator, { pointerId: 7, clientX: 850 });
+		fireEvent.pointerUp(window, { pointerId: 7, clientX: 850 });
+
+		expect(releasePointerCapture).toHaveBeenCalledWith(7);
+		expect(separator).toHaveAttribute("aria-valuenow", "610");
+		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
+		expect(document.body.style.cursor).toBe("");
+		expect(document.body.style.userSelect).toBe("");
+	});
+
+	it("finishes artifact resizing when the window loses focus", () => {
+		const { releasePointerCapture } = startArtifactResize();
+		fireEvent.blur(window);
+
+		expect(releasePointerCapture).toHaveBeenCalledWith(7);
+		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
+		expect(document.body.style.cursor).toBe("");
+		expect(document.body.style.userSelect).toBe("");
+	});
+
+	it("finishes artifact resizing when the document becomes hidden", () => {
+		const visibilityState = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+		const { releasePointerCapture } = startArtifactResize();
+		fireEvent(document, new Event("visibilitychange"));
+
+		expect(releasePointerCapture).toHaveBeenCalledWith(7);
+		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
+		expect(document.body.style.cursor).toBe("");
+		expect(document.body.style.userSelect).toBe("");
+		visibilityState.mockRestore();
 	});
 
 	// Regression test for the `key={taskId}` prop on TaskTerminal in

--- a/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
+++ b/src/mainview/components/__tests__/TaskWorkspaceView.test.tsx
@@ -113,6 +113,29 @@ const artifact: SharedArtifact = {
 
 const renderWorkspace = (element: ReactElement) => render(element, { wrapper: I18nProvider });
 
+function mockPointerCapture(separator: HTMLElement) {
+	const setPointerCapture = vi.fn();
+	const releasePointerCapture = vi.fn();
+	Object.defineProperties(separator, {
+		setPointerCapture: { value: setPointerCapture },
+		releasePointerCapture: { value: releasePointerCapture },
+		hasPointerCapture: { value: () => true },
+	});
+	return { releasePointerCapture, setPointerCapture };
+}
+
+function expectArtifactResizeFinished(
+	separator: HTMLElement,
+	releasePointerCapture: ReturnType<typeof vi.fn>,
+	expectedWidth: string,
+) {
+	expect(releasePointerCapture).toHaveBeenCalledWith(7);
+	expect(separator).toHaveAttribute("aria-valuenow", expectedWidth);
+	expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
+	expect(document.body.style.cursor).toBe("");
+	expect(document.body.style.userSelect).toBe("");
+}
+
 function startArtifactResize() {
 	renderWorkspace(
 		<TaskWorkspaceView
@@ -127,12 +150,7 @@ function startArtifactResize() {
 	);
 
 	const separator = screen.getByRole("separator", { name: "Resize artifact panel" });
-	const releasePointerCapture = vi.fn();
-	Object.defineProperties(separator, {
-		setPointerCapture: { value: vi.fn() },
-		releasePointerCapture: { value: releasePointerCapture },
-		hasPointerCapture: { value: () => true },
-	});
+	const { releasePointerCapture } = mockPointerCapture(separator);
 	fireEvent.pointerDown(separator, { pointerId: 7, clientX: 900 });
 	return { releasePointerCapture, separator };
 }
@@ -282,13 +300,7 @@ describe("TaskWorkspaceView", () => {
 		separator.focus();
 		await userEvent.keyboard("{ArrowLeft}");
 		expect(separator).toHaveAttribute("aria-valuenow", "584");
-		const setPointerCapture = vi.fn();
-		const releasePointerCapture = vi.fn();
-		Object.defineProperties(separator, {
-			setPointerCapture: { value: setPointerCapture },
-			releasePointerCapture: { value: releasePointerCapture },
-			hasPointerCapture: { value: () => true },
-		});
+		const { releasePointerCapture, setPointerCapture } = mockPointerCapture(separator);
 		fireEvent.pointerDown(separator, { pointerId: 7, clientX: 900 });
 		expect(setPointerCapture).toHaveBeenCalledWith(7);
 		expect(screen.getByTestId("artifact-resize-shield")).toBeInTheDocument();
@@ -297,11 +309,7 @@ describe("TaskWorkspaceView", () => {
 		expect(screen.getByTestId("artifact-resize-ghost")).toBeInTheDocument();
 		expect(separator).toHaveAttribute("aria-valuenow", "584");
 		fireEvent.pointerUp(separator, { pointerId: 7, clientX: 850 });
-		expect(releasePointerCapture).toHaveBeenCalledWith(7);
-		expect(separator).toHaveAttribute("aria-valuenow", "634");
-		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
-		expect(document.body.style.cursor).toBe("");
-		expect(document.body.style.userSelect).toBe("");
+		expectArtifactResizeFinished(separator, releasePointerCapture, "634");
 		await userEvent.click(screen.getByText("Close Artifact"));
 		expect(onClose).toHaveBeenCalledOnce();
 	});
@@ -311,33 +319,36 @@ describe("TaskWorkspaceView", () => {
 		fireEvent.pointerMove(separator, { pointerId: 7, clientX: 850 });
 		fireEvent.pointerUp(window, { pointerId: 7, clientX: 850 });
 
-		expect(releasePointerCapture).toHaveBeenCalledWith(7);
-		expect(separator).toHaveAttribute("aria-valuenow", "610");
-		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
-		expect(document.body.style.cursor).toBe("");
-		expect(document.body.style.userSelect).toBe("");
+		expectArtifactResizeFinished(separator, releasePointerCapture, "610");
+	});
+
+	it("finishes artifact resizing when pointer cancellation misses the separator", () => {
+		const { releasePointerCapture, separator } = startArtifactResize();
+		fireEvent.pointerMove(separator, { pointerId: 7, clientX: 850 });
+		fireEvent.pointerCancel(window, { pointerId: 7, clientX: 850 });
+
+		expectArtifactResizeFinished(separator, releasePointerCapture, "610");
 	});
 
 	it("finishes artifact resizing when the window loses focus", () => {
-		const { releasePointerCapture } = startArtifactResize();
+		const { releasePointerCapture, separator } = startArtifactResize();
+		fireEvent.pointerMove(separator, { pointerId: 7, clientX: 850 });
 		fireEvent.blur(window);
 
-		expect(releasePointerCapture).toHaveBeenCalledWith(7);
-		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
-		expect(document.body.style.cursor).toBe("");
-		expect(document.body.style.userSelect).toBe("");
+		expectArtifactResizeFinished(separator, releasePointerCapture, "610");
 	});
 
 	it("finishes artifact resizing when the document becomes hidden", () => {
 		const visibilityState = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
-		const { releasePointerCapture } = startArtifactResize();
-		fireEvent(document, new Event("visibilitychange"));
+		try {
+			const { releasePointerCapture, separator } = startArtifactResize();
+			fireEvent.pointerMove(separator, { pointerId: 7, clientX: 850 });
+			fireEvent(document, new Event("visibilitychange"));
 
-		expect(releasePointerCapture).toHaveBeenCalledWith(7);
-		expect(screen.queryByTestId("artifact-resize-shield")).not.toBeInTheDocument();
-		expect(document.body.style.cursor).toBe("");
-		expect(document.body.style.userSelect).toBe("");
-		visibilityState.mockRestore();
+			expectArtifactResizeFinished(separator, releasePointerCapture, "610");
+		} finally {
+			visibilityState.mockRestore();
+		}
 	});
 
 	// Regression test for the `key={taskId}` prop on TaskTerminal in


### PR DESCRIPTION
## Summary

- finish artifact panel resizing when pointer release or cancellation reaches the window instead of the separator
- clean up active resize sessions when the window loses focus or the document becomes hidden
- preserve deferred resizing while committing the last ghost width and restoring body interaction styles
- add public `TaskWorkspaceView` regression coverage and a user-visible changelog entry

## Root cause

The artifact separator mounts a transparent full-workspace shield while dragging. Cleanup previously depended on pointer events reaching the separator, so a lost WebKit release could leave the shield mounted and make the app appear completely frozen even though its processes remained alive.

## User impact

Interrupted artifact resizes no longer strand an input-blocking overlay. The panel keeps the last previewed width and the rest of the task UI remains interactive.

## Validation

- `bun run lint`
- `bunx vitest run src/mainview/components/__tests__/TaskWorkspaceView.test.tsx` — 11 tests passed
- `bun run test` — 7,791 tests passed
- task-local Chromium QA for external pointer release and window blur; no console errors
