### PR TITLE
Play task sounds through Web Audio so macOS media keys stay put

### DIFF
--- a/change-logs/2026/07/30/fix-macos-media-keys-task-sound.md
+++ b/change-logs/2026/07/30/fix-macos-media-keys-task-sound.md
@@ -1,0 +1,5 @@
+Short: Media keys stay with your music
+
+Task completion and cancellation sounds now play through the Web Audio API instead of an `<audio>` element. On macOS, WebKit made any `<audio>` longer than 0.95s the system "Now Playing" session, so the 1.3-1.5s chimes hijacked the hardware Play/Pause keys — pressing Play replayed the chime instead of resuming Spotify or Music. Web Audio mixes as ambient sound, so the keys stay with whatever was really playing.
+
+Suggested by @Paveltarno (h0x91b/dev-3.0#1176)

--- a/decisions/181-task-sounds-web-audio-not-media-element.md
+++ b/decisions/181-task-sounds-web-audio-not-media-element.md
@@ -1,0 +1,62 @@
+# 181 — Task sounds play through Web Audio, never an `<audio>` element
+
+## Context
+Issue #1176: on macOS, after dev3 played the task-completion chime, the hardware
+media keys stopped controlling the user's audio app (Spotify). Pressing
+Play/Pause replayed the dev3 chime instead of resuming the music.
+
+## Investigation
+WebKit promotes an `<audio>` element to the system "Now Playing" session — the
+media-key target — once its duration passes 0.95s
+(`isElementLongEnoughForMainContent` in `MediaElementSession.cpp`, the threshold
+added for WebKit bug 263750 "Slack.com audible notifications steal NowPlaying
+status"). Our chimes are 1.512s and 1.320s, so they sat just above the exemption.
+Pausing or resetting the element does not help: the NowPlaying eligibility check
+never looks at whether the element is currently playing.
+
+Verified with a two-`WKWebView` probe (a long-playing reference player plus the
+chime page) driving a synthesized `NX_KEYTYPE_PLAY` event:
+- `<audio>` chime → the key replayed the chime, the reference player was ignored.
+- Web Audio chime → the key paused the reference player, the chime did not replay.
+
+An `AudioContext` is only NowPlaying eligible when the page sets
+`navigator.audioSession.type = "playback"` (`AudioContext::isNowPlayingEligible`),
+which we never do — and it activates the audio session as ambient sound, so it
+also stops interrupting other players. Chrome behaves the same way (WebAudio is
+`kAmbient`), so remote browser mode gets the same guarantee.
+
+## Decision
+`src/mainview/task-sounds.ts` decodes both chimes once into `AudioBuffer`s and
+plays them through a lazily created, long-lived `AudioContext`
+(`AudioBufferSourceNode` → `GainNode` for the per-sound volume, graph
+disconnected on `ended`). No `HTMLAudioElement` is ever constructed. The context
+is created on the first gesture or first sound rather than at import, so Chrome
+does not log its "AudioContext was not allowed to start" warning.
+
+This replaces the element-priming mechanism of decision 147: an unlocked
+`AudioContext` stays unlocked, so the delayed, push-driven plays that priming
+existed for (remote desktop Chrome, sound arriving seconds after the click) work
+without a per-element user-activation trick. The gesture-unlock queue survives in
+a simpler form: a sound that arrives while the context is suspended is queued and
+flushed when a gesture resumes it.
+
+## Risks
+Sounds are silent until `decodeAudioData` finishes (a few ms for a 36 KB MP3,
+pre-warmed on the first gesture) instead of streaming from the element. Web Audio
+is required — there is no `<audio>` fallback, by design, since a fallback would
+reintroduce the bug on exactly the platform that has it. A browser without
+`AudioContext` plays nothing and logs a warning.
+
+## Alternatives considered
+- Trim the MP3s below the 0.95s exemption: fragile — the exemption is bypassed
+  whenever the app already registered as the NowPlaying application
+  (`registeredAsNowPlayingApplication` in `canShowControlsManager`), and it would
+  not stop the chime from interrupting other players.
+- Tear the element down after `ended` (`pause` + `removeAttribute("src")` +
+  `load()`): does release the session (WebKit's own layout test asserts it), but
+  it leaves a window where dev3 owns the keys and fights the priming design.
+- `navigator.mediaSession.playbackState = "none"`: no effect in WebKit, and on
+  desktop Chrome touching `playbackState` makes even a short blip a media-key
+  target.
+- Play the sound in the bun process (`afplay`): rejected for the same reasons as
+  decision 030 — macOS-only and no sound for remote browser clients.

--- a/src/mainview/__tests__/task-sounds.test.ts
+++ b/src/mainview/__tests__/task-sounds.test.ts
@@ -1,22 +1,107 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	SOUND_DEFS,
-	playTaskCompletionSound,
-	playTaskSoundFromPush,
-	setTaskCompletionSoundEnabled,
-} from "../task-sounds";
 
-// Regression guard for the `views://` range-request bug: task sounds must be
-// inlined as base64 `data:` URLs (via the `?inline` import suffix), never served
-// as separate files through the Electrobun `views://` scheme. WKWebView's media
-// loader fetches <audio> sources with a Range request that the scheme handler
-// does not satisfy, so a file URL silently fails with `NotSupportedError`.
-describe("task sound assets", () => {
-	for (const [status, def] of Object.entries(SOUND_DEFS)) {
-		it(`serves "${status}" as an inlined data: URL`, () => {
-			expect(def.url.startsWith("data:audio/")).toBe(true);
-		});
+// happy-dom has no Web Audio implementation, so every test installs this fake
+// AudioContext on `window` and asserts against the graph the module builds.
+type FakeNode = { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> };
+type FakeSource = FakeNode & {
+	buffer: unknown;
+	start: ReturnType<typeof vi.fn>;
+	onended: (() => void) | null;
+};
+type FakeGain = FakeNode & { gain: { value: number } };
+
+class FakeAudioContext {
+	static instances: FakeAudioContext[] = [];
+	state: AudioContextState = "running";
+	destination = { name: "destination" } as unknown as AudioDestinationNode;
+	sources: FakeSource[] = [];
+	gains: FakeGain[] = [];
+	decodeCalls: ArrayBuffer[] = [];
+	resumeCalls = 0;
+
+	constructor() {
+		FakeAudioContext.instances.push(this);
 	}
+
+	resume = vi.fn(async () => {
+		this.resumeCalls++;
+		this.state = "running";
+	});
+
+	decodeAudioData = vi.fn((bytes: ArrayBuffer) => {
+		this.decodeCalls.push(bytes);
+		return Promise.resolve({ duration: 1.5, byteLength: bytes.byteLength } as unknown as AudioBuffer);
+	});
+
+	createBufferSource = vi.fn(() => {
+		const source: FakeSource = {
+			buffer: null,
+			onended: null,
+			start: vi.fn(),
+			connect: vi.fn(),
+			disconnect: vi.fn(),
+		};
+		this.sources.push(source);
+		return source as unknown as AudioBufferSourceNode;
+	});
+
+	createGain = vi.fn(() => {
+		const gain: FakeGain = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+		this.gains.push(gain);
+		return gain as unknown as GainNode;
+	});
+}
+
+type SoundsModule = typeof import("../task-sounds");
+
+// Every test gets a fresh module instance: unlock state, the decoded-buffer cache
+// and the pending queue are all module-level globals.
+async function loadModule(): Promise<SoundsModule> {
+	vi.resetModules();
+	return await import("../task-sounds");
+}
+
+function latestContext(): FakeAudioContext {
+	const ctx = FakeAudioContext.instances[FakeAudioContext.instances.length - 1];
+	if (!ctx) throw new Error("no AudioContext was constructed");
+	return ctx;
+}
+
+// Playback is async (decode → resume → start) and the fire-and-forget callers
+// (`playTaskCompletionSound`, the push handler, the queue flush) are not
+// awaitable, so drain enough microtasks for the whole chain to land.
+async function settle(): Promise<void> {
+	for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+let audioElementPlay: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	FakeAudioContext.instances = [];
+	(window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+	// The whole point of the fix: nothing may reach an <audio> element.
+	audioElementPlay = vi
+		.spyOn(window.HTMLMediaElement.prototype, "play")
+		.mockResolvedValue(undefined as unknown as void);
+});
+
+afterEach(() => {
+	audioElementPlay.mockRestore();
+	delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+});
+
+// Regression guard for the `views://` range-request bug (decision 057): task
+// sounds must be inlined as base64 `data:` URLs (via the `?inline` import
+// suffix), never served as separate files through the Electrobun `views://`
+// scheme — and Web Audio decoding now reads those base64 bytes directly.
+describe("task sound assets", () => {
+	it("serves every sound as an inlined base64 data: URL", async () => {
+		const mod = await loadModule();
+		for (const def of Object.values(mod.SOUND_DEFS)) {
+			expect(def.url.startsWith("data:audio/")).toBe(true);
+			expect(def.url).toContain(";base64,");
+		}
+	});
 });
 
 // The sound plays in exactly one place per move: UI-initiated moves play it
@@ -26,90 +111,133 @@ describe("task sound assets", () => {
 // this is what prevents the double-play in remote mode (desktop window + browser
 // on the same machine both receiving a broadcast push).
 describe("completion sound playback", () => {
-	let playSpy: ReturnType<typeof vi.spyOn>;
-
-	beforeEach(() => {
-		setTaskCompletionSoundEnabled(true);
-		playSpy = vi
-			.spyOn(window.HTMLMediaElement.prototype, "play")
-			.mockResolvedValue(undefined as unknown as void);
+	it("plays locally and reports the UI owns the sound when enabled", async () => {
+		const mod = await loadModule();
+		mod.setTaskCompletionSoundEnabled(true);
+		expect(mod.playTaskCompletionSound("completed")).toBe(true);
+		await settle();
+		expect(latestContext().sources).toHaveLength(1);
+		expect(latestContext().sources[0]?.start).toHaveBeenCalledTimes(1);
 	});
 
-	afterEach(() => {
-		playSpy.mockRestore();
+	it("does not play and reports false when the setting is disabled", async () => {
+		const mod = await loadModule();
+		mod.setTaskCompletionSoundEnabled(false);
+		expect(mod.playTaskCompletionSound("completed")).toBe(false);
+		await settle();
+		expect(FakeAudioContext.instances).toHaveLength(0);
 	});
 
-	it("plays locally and reports the UI owns the sound when enabled", () => {
-		const played = playTaskCompletionSound("completed");
-		expect(played).toBe(true);
-		expect(playSpy).toHaveBeenCalledTimes(1);
+	it("plays the backend push (CLI / branch-merge / agent approval)", async () => {
+		const mod = await loadModule();
+		mod.playTaskSoundFromPush("completed");
+		await settle();
+		expect(latestContext().sources).toHaveLength(1);
 	});
 
-	it("does not play and reports false when the setting is disabled", () => {
-		setTaskCompletionSoundEnabled(false);
-		const played = playTaskCompletionSound("completed");
-		expect(played).toBe(false);
-		expect(playSpy).not.toHaveBeenCalled();
+	it("rings for two different tasks completing back-to-back", async () => {
+		const mod = await loadModule();
+		mod.setTaskCompletionSoundEnabled(true);
+		expect(mod.playTaskCompletionSound("completed")).toBe(true);
+		expect(mod.playTaskCompletionSound("cancelled")).toBe(true);
+		await settle();
+		expect(latestContext().sources).toHaveLength(2);
 	});
 
-	it("plays the backend push (CLI / branch-merge / agent approval)", () => {
-		playTaskSoundFromPush("completed");
-		expect(playSpy).toHaveBeenCalledTimes(1);
+	it("applies the per-sound volume through a gain node", async () => {
+		const mod = await loadModule();
+		await mod.playTaskSound("cancelled");
+		await settle();
+		expect(latestContext().gains[0]?.gain.value).toBe(mod.SOUND_DEFS.cancelled.volume);
 	});
 
-	it("rings for two different tasks completing back-to-back", () => {
-		expect(playTaskCompletionSound("completed")).toBe(true);
-		expect(playTaskCompletionSound("cancelled")).toBe(true);
-		expect(playSpy).toHaveBeenCalledTimes(2);
+	it("decodes each sound once and reuses the buffer", async () => {
+		const mod = await loadModule();
+		await mod.playTaskSound("completed");
+		await mod.playTaskSound("completed");
+		await settle();
+		const ctx = latestContext();
+		expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+		expect(ctx.sources).toHaveLength(2);
 	});
 });
 
-// Desktop Chrome rejects a delayed, programmatic `.play()` on a never-activated
-// <audio> element — and the remote `taskSound` push lands seconds after the
-// user's "Approve" click. Priming each element inside the first user gesture
-// (play/pause) marks it user-activated so the later push-driven play is honored.
-// Fresh module instances (resetModules + dynamic import) isolate this global
-// unlock/prime state from the shared-state tests above.
-describe("audio unlock priming (remote desktop browsers)", () => {
-	it("primes both sound templates on the first user gesture", async () => {
-		vi.resetModules();
-		const playSpy = vi
-			.spyOn(window.HTMLMediaElement.prototype, "play")
-			.mockResolvedValue(undefined as unknown as void);
-		const pauseSpy = vi
-			.spyOn(window.HTMLMediaElement.prototype, "pause")
-			.mockImplementation(() => {});
-		try {
-			const mod = await import("../task-sounds");
-			mod.initTaskSoundPlayback();
-			expect(playSpy).not.toHaveBeenCalled();
-
-			window.dispatchEvent(new Event("pointerdown"));
-
-			// `>=` (not exact): `window` is shared across the static import above and
-			// this fresh dynamic instance, so a leaked unlock listener may also fire.
-			expect(playSpy.mock.calls.length).toBeGreaterThanOrEqual(Object.keys(mod.SOUND_DEFS).length);
-			await Promise.resolve();
-			expect(pauseSpy).toHaveBeenCalled();
-		} finally {
-			playSpy.mockRestore();
-			pauseSpy.mockRestore();
-		}
+// Issue #1176: on macOS, WebKit promotes any <audio> element longer than 0.95s to
+// the system "Now Playing" session, so our 1.3-1.5s chimes stole the hardware
+// media keys from Spotify/Music — Play/Pause replayed the chime. Web Audio never
+// creates a media element and never becomes a Now Playing candidate, so these
+// two assertions are the actual regression guard for the reported bug.
+describe("macOS media-key ownership", () => {
+	it("never plays through an <audio> element", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await mod.playTaskSound("completed");
+		window.dispatchEvent(new Event("pointerdown"));
+		await settle();
+		expect(audioElementPlay).not.toHaveBeenCalled();
+		expect(document.querySelector("audio")).toBeNull();
 	});
 
-	it("reuses one <audio> element per status instead of cloning", async () => {
-		vi.resetModules();
-		const playSpy = vi
-			.spyOn(window.HTMLMediaElement.prototype, "play")
-			.mockResolvedValue(undefined as unknown as void);
-		try {
-			const mod = await import("../task-sounds");
-			mod.playTaskSoundFromPush("completed");
-			mod.playTaskSoundFromPush("completed");
-			expect(playSpy).toHaveBeenCalledTimes(2);
-			expect(playSpy.mock.instances[0]).toBe(playSpy.mock.instances[1]);
-		} finally {
-			playSpy.mockRestore();
-		}
+	it("releases the audio graph when the sound ends", async () => {
+		const mod = await loadModule();
+		await mod.playTaskSound("completed");
+		await settle();
+		const ctx = latestContext();
+		const source = ctx.sources[0];
+		const gain = ctx.gains[0];
+		expect(source?.onended).toBeTypeOf("function");
+		source?.onended?.();
+		expect(source?.disconnect).toHaveBeenCalledTimes(1);
+		expect(gain?.disconnect).toHaveBeenCalledTimes(1);
+	});
+});
+
+// Autoplay policy: a context created before any user gesture starts suspended
+// (desktop Chrome in remote mode — the `taskSound` push lands seconds after the
+// user's "Approve" click, long after its transient activation expired). The sound
+// is queued and flushed once a gesture resumes the context.
+describe("autoplay unlock (remote desktop browsers)", () => {
+	class SuspendedAudioContext extends FakeAudioContext {
+		state: AudioContextState = "suspended";
+		gestureSeen = false;
+
+		resume = vi.fn(async () => {
+			this.resumeCalls++;
+			if (this.gestureSeen) this.state = "running";
+		});
+	}
+
+	it("queues a sound while suspended and plays it on the next gesture", async () => {
+		(window as unknown as { AudioContext: unknown }).AudioContext = SuspendedAudioContext;
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+
+		await mod.playTaskSound("completed");
+		await settle();
+		const ctx = latestContext() as SuspendedAudioContext;
+		expect(ctx.sources).toHaveLength(0);
+
+		ctx.gestureSeen = true;
+		window.dispatchEvent(new Event("pointerdown"));
+		await settle();
+		expect(ctx.state).toBe("running");
+		expect(ctx.sources).toHaveLength(1);
+	});
+
+	it("does not construct a context before the first gesture or sound", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		expect(FakeAudioContext.instances).toHaveLength(0);
+
+		window.dispatchEvent(new Event("pointerdown"));
+		await settle();
+		expect(FakeAudioContext.instances).toHaveLength(1);
+	});
+
+	it("stays silent without crashing when Web Audio is unavailable", async () => {
+		delete (window as unknown as { AudioContext?: unknown }).AudioContext;
+		const mod = await loadModule();
+		await expect(mod.playTaskSound("completed")).resolves.toBeUndefined();
+		expect(audioElementPlay).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -1,9 +1,8 @@
 // `?inline` forces Vite to emit these as base64 `data:` URLs instead of files
-// served via the `views://` scheme. WKWebView's media loader (AppleCoreMedia)
-// fetches <audio> sources with a Range request (`bytes=0-1`), which the
-// Electrobun `views://` scheme handler does not satisfy — the request returns no
-// body and playback fails with `NotSupportedError`. A data: URL sidesteps the
-// scheme handler entirely, so playback works in packaged builds on every OS.
+// served via the `views://` scheme, which cannot satisfy the Range requests
+// WKWebView's media loader issues (decision 057). Web Audio fetches nothing —
+// the bytes are decoded straight out of the base64 payload — but keeping the
+// imports inlined avoids reintroducing a `views://` asset for audio.
 import completedSoundUrl from "../assets/sounds/task-completed.mp3?inline";
 import cancelledSoundUrl from "../assets/sounds/task-cancelled.mp3?inline";
 
@@ -14,9 +13,22 @@ export const SOUND_DEFS: Record<TaskSoundStatus, { url: string; volume: number }
 	cancelled: { url: cancelledSoundUrl, volume: 0.7 },
 };
 
+// Task sounds MUST go through Web Audio, never an <audio> element. On macOS,
+// WebKit makes any <audio> longer than 0.95s the system "Now Playing" session
+// (`MediaElementSession::isElementLongEnoughForMainContent`), so our 1.3-1.5s
+// chimes hijacked the hardware media keys from Spotify/Music: Play/Pause
+// replayed the chime instead of resuming the real player (issue #1176). An
+// AudioContext is only Now Playing eligible when the page opts into
+// `navigator.audioSession.type = "playback"`, which we never do — so it can
+// neither steal the keys nor interrupt other audio (it mixes as ambient sound).
+// Chrome behaves the same way: WebAudio is ambient, an <audio> element is not.
 const SOUND_UNLOCK_EVENTS: Array<keyof WindowEventMap> = ["pointerdown", "keydown", "touchstart"];
 const pendingQueue: TaskSoundStatus[] = [];
-const templates = new Map<TaskSoundStatus, HTMLAudioElement>();
+const buffers = new Map<TaskSoundStatus, AudioBuffer>();
+const decoding = new Map<TaskSoundStatus, Promise<AudioBuffer | null>>();
+
+let context: AudioContext | null = null;
+let unlockHandlersInstalled = false;
 
 // The completion/cancel sound is played in exactly one place per move:
 //
@@ -62,69 +74,104 @@ export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 	void playTaskSound(status);
 }
 
-let unlockHandlersInstalled = false;
-let playbackUnlocked = false;
-let templatesPrimed = false;
-
-function canPlayImmediately(): boolean {
-	if (playbackUnlocked) return true;
-	if (typeof navigator === "undefined" || !("userActivation" in navigator)) return true;
-	return navigator.userActivation?.hasBeenActive === true;
+function audioContextCtor(): typeof AudioContext | undefined {
+	if (typeof window === "undefined") return undefined;
+	const scoped = window as typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+	return scoped.AudioContext ?? scoped.webkitAudioContext;
 }
 
-function getAudioTemplate(status: TaskSoundStatus): HTMLAudioElement {
-	const existing = templates.get(status);
-	if (existing) return existing;
-
-	const audio = new Audio(SOUND_DEFS[status].url);
-	audio.preload = "auto";
-	audio.load();
-	templates.set(status, audio);
-	return audio;
-}
-
-// Chrome on desktop rejects a delayed, programmatic `.play()` on an <audio>
-// element that was never activated by a user gesture. In remote mode the sound
-// arrives via the backend `taskSound` push, which lands SECONDS after the user's
-// "Approve" click (the backend tears the worktree down first), so the click's
-// transient activation has long expired by the time `.play()` runs. Priming each
-// element — a muted play/pause performed SYNCHRONOUSLY inside the first user
-// gesture — marks it as user-activated, so every later push-driven play is
-// honored. Mobile Chrome unlocks media stickily after a single gesture and never
-// needed this, which is why the bug only showed on desktop browsers.
-function primeTemplates(): void {
-	if (templatesPrimed) return;
-	templatesPrimed = true;
-
-	for (const status of Object.keys(SOUND_DEFS) as TaskSoundStatus[]) {
-		const audio = getAudioTemplate(status);
-		audio.muted = true;
-
-		let started: Promise<void> | undefined;
-		try {
-			started = audio.play() as Promise<void> | undefined;
-		} catch {
-			templatesPrimed = false;
-		}
-
-		Promise.resolve(started)
-			.then(() => {
-				audio.pause();
-				audio.currentTime = 0;
-			})
-			.catch(() => {
-				templatesPrimed = false;
-			})
-			.finally(() => {
-				audio.muted = false;
-			});
+// Created lazily, never closed: a long-lived context stays unlocked, so later
+// push-driven sounds (which arrive seconds after any user gesture) can start
+// without another gesture. Constructing it on demand rather than at import also
+// keeps Chrome from logging its "AudioContext was not allowed to start" warning
+// on a page the user has not interacted with yet.
+function ensureContext(): AudioContext | null {
+	if (context) return context;
+	const Ctor = audioContextCtor();
+	if (!Ctor) return null;
+	try {
+		context = new Ctor();
+	} catch (err) {
+		console.warn("[task-sounds] no audio context", { error: String(err) });
+		return null;
 	}
+	return context;
+}
+
+function decodeBytes(url: string): ArrayBuffer {
+	const marker = ";base64,";
+	const at = url.indexOf(marker);
+	if (!url.startsWith("data:") || at === -1) {
+		throw new Error("task sound must be an inlined base64 data: URL");
+	}
+	const binary = atob(url.slice(at + marker.length));
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return bytes.buffer;
+}
+
+// Safari/WKWebView only gained promise-based `decodeAudioData` in 14.1 and still
+// supports the callback form; accept whichever the engine hands back.
+function decodeAudioData(ctx: AudioContext, bytes: ArrayBuffer): Promise<AudioBuffer> {
+	return new Promise((resolve, reject) => {
+		const returned = ctx.decodeAudioData(bytes, resolve, reject) as Promise<AudioBuffer> | undefined;
+		if (returned && typeof returned.then === "function") returned.then(resolve, reject);
+	});
+}
+
+function loadBuffer(ctx: AudioContext, status: TaskSoundStatus): Promise<AudioBuffer | null> {
+	const ready = buffers.get(status);
+	if (ready) return Promise.resolve(ready);
+
+	const inFlight = decoding.get(status);
+	if (inFlight) return inFlight;
+
+	const pending = Promise.resolve()
+		.then(() => decodeAudioData(ctx, decodeBytes(SOUND_DEFS[status].url)))
+		.then((buffer) => {
+			buffers.set(status, buffer);
+			return buffer;
+		})
+		.catch((err) => {
+			console.warn("[task-sounds] decode failed", { status, error: String(err) });
+			return null;
+		})
+		.finally(() => {
+			decoding.delete(status);
+		});
+
+	decoding.set(status, pending);
+	return pending;
+}
+
+async function resume(ctx: AudioContext): Promise<boolean> {
+	if (ctx.state === "running") return true;
+	try {
+		await ctx.resume();
+	} catch {
+		// Autoplay policy: the context stays suspended until a user gesture.
+	}
+	// Cast: TS keeps `state` narrowed from the early return above, but `resume()`
+	// is exactly what changes it.
+	return (ctx.state as AudioContextState) === "running";
+}
+
+function startSound(ctx: AudioContext, status: TaskSoundStatus, buffer: AudioBuffer): void {
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.value = SOUND_DEFS[status].volume;
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	// Tear the graph down when the chime finishes so nothing outlives playback.
+	source.onended = () => {
+		source.disconnect();
+		gain.disconnect();
+	};
+	source.start();
 }
 
 function flushPendingQueue(): void {
-	if (!canPlayImmediately()) return;
-	playbackUnlocked = true;
-
 	while (pendingQueue.length > 0) {
 		const status = pendingQueue.shift();
 		if (!status) continue;
@@ -137,16 +184,20 @@ function installUnlockHandlers(): void {
 	unlockHandlersInstalled = true;
 
 	const unlock = () => {
-		// Prime inside the gesture even when nothing is queued yet — the pending
-		// completion push almost always arrives *after* the last user gesture.
-		primeTemplates();
-		flushPendingQueue();
-		if (templatesPrimed && pendingQueue.length === 0) {
+		const ctx = ensureContext();
+		if (!ctx) return;
+		// Decode inside the gesture too, so the first sound needs no round-trip.
+		for (const status of Object.keys(SOUND_DEFS) as TaskSoundStatus[]) {
+			void loadBuffer(ctx, status);
+		}
+		void resume(ctx).then((running) => {
+			if (!running) return;
+			flushPendingQueue();
 			for (const eventName of SOUND_UNLOCK_EVENTS) {
 				window.removeEventListener(eventName, unlock);
 			}
 			unlockHandlersInstalled = false;
-		}
+		});
 	};
 
 	for (const eventName of SOUND_UNLOCK_EVENTS) {
@@ -155,42 +206,25 @@ function installUnlockHandlers(): void {
 }
 
 export function initTaskSoundPlayback(): void {
-	for (const status of Object.keys(SOUND_DEFS) as TaskSoundStatus[]) {
-		getAudioTemplate(status);
-	}
 	installUnlockHandlers();
 }
 
 export async function playTaskSound(status: TaskSoundStatus): Promise<void> {
-	initTaskSoundPlayback();
+	const ctx = ensureContext();
+	if (!ctx) return;
+	installUnlockHandlers();
 
-	if (!canPlayImmediately()) {
+	const buffer = await loadBuffer(ctx, status);
+	if (!buffer) return;
+
+	if (!(await resume(ctx))) {
 		pendingQueue.push(status);
 		return;
 	}
 
-	playbackUnlocked = true;
-
-	// Reuse the primed template rather than a fresh clone: only the primed element
-	// carries the user-activation that lets a delayed play through on desktop
-	// Chrome. A clone would be un-activated and rejected. Completion sounds never
-	// realistically overlap, so restarting `currentTime` is fine.
-	const audio = getAudioTemplate(status);
-	audio.muted = false;
-	audio.volume = SOUND_DEFS[status].volume;
 	try {
-		audio.currentTime = 0;
-	} catch {
-		// Some engines throw on currentTime before metadata loads — harmless here.
-	}
-
-	try {
-		await audio.play();
+		startSound(ctx, status, buffer);
 	} catch (err) {
 		console.warn("[task-sounds] playback failed", { status, error: String(err) });
-		pendingQueue.push(status);
-		playbackUnlocked = false;
-		templatesPrimed = false;
-		installUnlockHandlers();
 	}
 }


### PR DESCRIPTION
Fixes #1176. Reported by @Paveltarno.

## Root cause

Not the missing element cleanup the issue suspected. WebKit promotes **any `<audio>` element whose sound is longer than 0.95s** to the system "Now Playing" session — the hardware media-key target (`isElementLongEnoughForMainContent` in `MediaElementSession.cpp`, the threshold added for WebKit bug 263750, "Slack notifications steal NowPlaying status"). The chimes are **1.512s** and **1.320s**, just over the line.

Cleanup would not have helped: the eligibility check never looks at whether the element is currently playing, so a paused, `src`-reset element keeps the keys.

## Fix

`src/mainview/task-sounds.ts` decodes both chimes once into `AudioBuffer`s and plays them through one lazily created, long-lived `AudioContext` (`AudioBufferSourceNode` → `GainNode` for the per-sound volume, graph disconnected on `ended`). No `HTMLAudioElement` is ever constructed.

An `AudioContext` is only Now Playing eligible when the page sets `navigator.audioSession.type = "playback"` (`AudioContext::isNowPlayingEligible`), which we never do — and it activates the audio session as ambient sound, so it also stops interrupting other players. Chrome treats Web Audio the same way (`kAmbient`), so remote browser mode gets the same guarantee.

This replaces the element-priming unlock of decision 147: an unlocked context stays unlocked, so delayed push-driven plays (remote desktop Chrome, sound arriving seconds after the click) no longer need a per-element user-activation trick. A sound arriving while the context is suspended is still queued and flushed on the next gesture.

## Verification

Built a throwaway `WKWebView` host with two webviews — a long-playing reference player plus the chime page — and posted a real `NX_KEYTYPE_PLAY` event:

| chime path | media key after the chime |
|---|---|
| `<audio>` (old) | replayed the chime, reference player ignored |
| Web Audio (new) | paused the reference player, chime did not replay |

The old path reproducing the bug is also the positive control that the synthesized key is really delivered.

In the app in remote browser mode: one `AudioContext`, both chimes started (decoded durations 1.48s / 1.28s), **zero** `HTMLMediaElement.play` calls, no console errors. `bun run lint` clean, full suite green after rebase (3112 + 4027 + 668).

Rationale and the four rejected alternatives (trim the MP3s under 0.95s, tear the element down on `ended`, `mediaSession.playbackState`, `afplay` in bun): `decisions/181-task-sounds-web-audio-not-media-element.md`.