### PR TITLE
Fix Ctrl+O being stolen from the terminal on macOS

### DIFF
--- a/change-logs/2026/07/30/fix-ctrl-o-mac-terminal.md
+++ b/change-logs/2026/07/30/fix-ctrl-o-mac-terminal.md
@@ -1,0 +1,3 @@
+Short: Ctrl+O reaches the terminal on macOS
+
+On macOS the "Open in…" picker fired on Ctrl+O as well as ⌘O, and its capture-phase handler swallowed the keystroke before the focused terminal saw it — so Ctrl+O-bound features of the CLI running in the pane (Claude Code's transcript/expand toggle, for one) were unreachable. The shortcut now matches the keymap exactly: ⌘O on macOS, Ctrl+O elsewhere.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -8,7 +8,7 @@ import { trackPageView, trackEvent, registerAgents } from "./analytics";
 import type { CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskDialogSubject, TaskStatus, UpdateChangelog } from "../shared/types";
 import { orderProjectsForDisplay, taskSeqLabel } from "../shared/types";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
-import { isRemote } from "./utils/platform";
+import { hasAppModifier, isRemote } from "./utils/platform";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
 import { useMobileDenseZoom } from "./hooks/useMobileDenseZoom";
@@ -807,10 +807,11 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				api.request.hideApp().catch(() => {});
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "o") {
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "o") {
 				// Cmd/Ctrl+O — open the current project/worktree in the selected app,
 				// or the "Open in..." picker when nothing is chosen yet. In remote mode
 				// Cmd+O is the browser's Open-File dialog, so yield to it (scope: desktop).
+				// Platform-exact modifier: ⌃O belongs to the terminal on macOS.
 				if (remote) return;
 				e.preventDefault();
 				e.stopPropagation();

--- a/src/mainview/utils/__tests__/platform.test.ts
+++ b/src/mainview/utils/__tests__/platform.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { hasAppModifier } from "../platform";
+
+const originalNavigator = globalThis.navigator;
+
+function setPlatform(platform: string, userAgent: string) {
+	Object.defineProperty(globalThis, "navigator", {
+		value: { platform, userAgent },
+		writable: true,
+		configurable: true,
+	});
+}
+
+function keyEvent(key: string, mods: { metaKey?: boolean; ctrlKey?: boolean }): KeyboardEvent {
+	return new KeyboardEvent("keydown", { key, ...mods });
+}
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "navigator", {
+		value: originalNavigator,
+		writable: true,
+		configurable: true,
+	});
+});
+
+describe("hasAppModifier", () => {
+	it("accepts only Cmd on macOS, so Ctrl+<key> stays with the terminal", () => {
+		setPlatform("MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+		expect(hasAppModifier(keyEvent("o", { metaKey: true }))).toBe(true);
+		expect(hasAppModifier(keyEvent("o", { ctrlKey: true }))).toBe(false);
+	});
+
+	it("accepts only Ctrl off macOS", () => {
+		setPlatform("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)");
+		expect(hasAppModifier(keyEvent("o", { ctrlKey: true }))).toBe(true);
+		expect(hasAppModifier(keyEvent("o", { metaKey: true }))).toBe(false);
+	});
+
+	it("is false with no modifier on either platform", () => {
+		setPlatform("MacIntel", "Mozilla/5.0 (Macintosh)");
+		expect(hasAppModifier(keyEvent("o", {}))).toBe(false);
+		setPlatform("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)");
+		expect(hasAppModifier(keyEvent("o", {}))).toBe(false);
+	});
+});

--- a/src/mainview/utils/platform.ts
+++ b/src/mainview/utils/platform.ts
@@ -11,6 +11,16 @@ export function isMac(): boolean {
 }
 
 /**
+ * Whether an event carries the platform's app-shortcut modifier, as declared in
+ * `keymap.ts` (`⌘X` on macOS, `Ctrl+X` elsewhere). Accepting either modifier on
+ * both platforms would steal `Ctrl`-prefixed keys from the focused terminal on
+ * macOS, where they belong to the shell and the agent CLI running in it.
+ */
+export function hasAppModifier(e: KeyboardEvent): boolean {
+	return isMac() ? e.metaKey : e.ctrlKey;
+}
+
+/**
  * Whether the renderer is running in browser remote mode (`dev3 remote`) rather
  * than the Electrobun desktop shell. Electrobun injects `__electrobunWebviewId`
  * onto `window` inside the WKWebView; its absence means a plain browser tab over


### PR DESCRIPTION
## Problem

On macOS the "Open in…" picker fires on **Ctrl+O** as well as ⌘O, and because its handler is capture-phase it swallows the keystroke before the focused terminal sees it. Any CLI running in a dev3 pane loses Ctrl+O — for example Claude Code binds it to the transcript / expand-tool-output toggle (moved there from Ctrl+R in its v1.0.113, 2025-09-13), which is simply unreachable from inside dev3 on macOS.

The handler and the registry disagree. `src/mainview/keymap.ts` declares:

```js
{ id: "open-in", keys: { mac: "⌘O", other: "Ctrl+O" }, ... scope: "desktop" }
```

…so on macOS the intended key is ⌘O only. But `src/mainview/App.tsx` gated the branch on `(e.metaKey || e.ctrlKey)`, which accepts either modifier on every platform. Introduced in #1090 (v1.39.1) and carried through the #1106 rework.

## Fix

Add `hasAppModifier(e)` to `src/mainview/utils/platform.ts` — `isMac() ? e.metaKey : e.ctrlKey` — and use it for the `open-in` branch, so the runtime check matches what `keymap.ts` advertises. ⌘O still opens the picker on macOS; Ctrl+O now passes through to the terminal. Non-mac behaviour is unchanged (Ctrl+O still opens the picker), as is the existing `remote` early-return that yields ⌘O to the browser's native Open-File dialog.

`platform.ts` is the established home for OS-dependent keybinding branching (its module docstring already describes exactly this role), so the helper is reusable.

## Scope note

The same `metaKey || ctrlKey` pattern appears on ~24 branches of that handler chain, so other Ctrl-prefixed keys (⌃P, ⌃K, ⌃N, ⌃[, ⌃]) are candidates for the same shadowing on macOS. I deliberately did **not** sweep them: I only verified the Ctrl+O case, and some entries declare extra modifiers off-mac (`zoom-out` is `⌘-` / `Ctrl+Alt+-`), so a blanket substitution needs per-branch judgment. Happy to follow up with a broader pass if you want it — `hasAppModifier` is there to build on.

## Tests

- New `src/mainview/utils/__tests__/platform.test.ts` — `hasAppModifier` accepts only ⌘ on macOS and only Ctrl elsewhere, and is false with no modifier.
- `bun run lint` — clean.
- `src/mainview/__tests__/{keymap,App,TerminalView,help}` — 189 + 17 tests pass.

## Test instructions

1. On macOS, open a task with a terminal pane running Claude Code. Press **Ctrl+O** — expect Claude Code's transcript/expand view to toggle, and **no** "Open in…" picker.
2. Same pane, press **⌘O** — expect the "Open in…" picker modal to open on the task's worktree.
3. Press **⌘O** on the Kanban board with no task open — expect the picker on the current project.
4. On Linux, press **Ctrl+O** — expect the picker (unchanged behaviour).
5. In remote/browser mode on macOS, press **⌘O** — expect the browser's own Open-File dialog, not the picker.
