### PR TITLE
Fix fork PR review task diffs

### DIFF
--- a/change-logs/2026/07/30/fix-review-task-fork-diffs.md
+++ b/change-logs/2026/07/30/fix-review-task-fork-diffs.md
@@ -1,0 +1,3 @@
+Short: Review task diffs restored
+
+PR review tasks created from fork branches now compare against the project base, restoring changed-file counts, line stats, branch diffs, and recent-commit diffs.

--- a/decisions/140-pr-review-diff-base-fallback.md
+++ b/decisions/140-pr-review-diff-base-fallback.md
@@ -3,11 +3,10 @@
 ## Context
 A task created from a GitHub PR (or any "existing branch" task) checks out the PR
 head branch. `deriveTaskBaseBranch` (`src/bun/data.ts`) normalizes the task's
-`existingBranch` and stores it as `baseBranch`, so for these tasks
-`baseBranch === branchName`. Every comparison consumer then compared the branch
-against itself: the branch-mode diff ran `<branch>...HEAD` (empty), ahead/behind
-was `0/0`, and rebase/merge targeted the branch itself. Users saw "No changes to
-show" when clicking Diff on a PR-review task (issue reported for base44 PR #16484).
+`existingBranch` and stores it as `baseBranch`. Same-repo tasks commonly have
+`baseBranch === branchName`; fork tasks instead keep `<owner>/<head>` as their
+base while the local branch is `<head>`. Both shapes compare the PR head against
+itself, producing an empty diff, zero line stats, and zero recent commits.
 
 ## Investigation
 Confirmed against on-disk task data: `baseBranch === branchName ===
@@ -15,13 +14,16 @@ codex/remote-verification-retry-safety`, `existingBranch =
 origin/codex/...`, `prNumber = 16484`. The merge-completion poller already had an
 inline workaround for exactly this (`git-operations.ts`, ~line 399) — it falls back
 to the project base branch when `baseBranch === live branch` — but the diff/status
-paths did not.
+paths did not. A later fork-PR report exposed the second shape: `baseBranch` and
+`existingBranch` were owner-qualified while `branchName` was not.
 
 ## Decision
 Added a shared pure helper `resolveTaskCompareBaseBranch(task, project)` in
 `src/shared/types.ts`: returns `task.baseBranch`, except when it collapses onto
-`task.branchName`, in which case it returns `project.defaultBaseBranch` (default
-`main`). Routed the diff/status/rebase/merge base derivation through it in
+`task.branchName`, including when a fork-qualified `existingBranch` resolves to
+that local branch, in which case it returns `project.defaultBaseBranch` (default
+`main`). A variant branch keeps its distinct source `existingBranch` as the base.
+Routed the diff/status/rebase/merge base derivation through it in
 `src/bun/rpc-handlers/git-operations.ts` (`getTaskDiff`, `getBranchStatusImpl`,
 `rebaseTask`, `rebaseTaskViaAgent`, `mergeTask`) and in the renderer
 `useTaskBranchStatus.ts` (so `compareRef`, `displayRef`, and the compare-ref

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -4794,6 +4794,26 @@ describe("resolveTaskCompareBaseBranch", () => {
 		).toBe("main");
 	});
 
+	it("falls back to the project base for a fork-qualified existing branch", () => {
+		const task = makeTask({
+			baseBranch: "contributor/fix/ctrl-o",
+			branchName: "fix/ctrl-o",
+			existingBranch: "contributor/fix/ctrl-o",
+		});
+
+		expect(resolveTaskCompareBaseBranch(task, { defaultBaseBranch: "main" })).toBe("main");
+	});
+
+	it("keeps the existing branch as the base for a variant branch", () => {
+		const task = makeTask({
+			baseBranch: "feature/source",
+			branchName: "feature/source-v2",
+			existingBranch: "feature/source",
+		});
+
+		expect(resolveTaskCompareBaseBranch(task, { defaultBaseBranch: "main" })).toBe("feature/source");
+	});
+
 	it("defaults the project base to main when unset", () => {
 		expect(
 			resolveTaskCompareBaseBranch(
@@ -4839,6 +4859,57 @@ describe("handlers.getTaskDiff base branch resolution", () => {
 			"/tmp/wt",
 			"branch",
 			expect.objectContaining({ baseBranch: "main" }),
+		);
+	});
+
+	it("resolves a fork PR-review task's diff base to the project base", async () => {
+		const project = makeProject({ defaultBaseBranch: "main" });
+		const task = makeTask({
+			worktreePath: "/tmp/wt",
+			branchName: "fix/ctrl-o",
+			baseBranch: "contributor/fix/ctrl-o",
+			existingBranch: "contributor/fix/ctrl-o",
+			prNumber: 1193,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getTaskDiff).mockResolvedValue(branchDiffResponse);
+
+		await handlers.getTaskDiff({ taskId: task.id, projectId: project.id, mode: "branch" });
+
+		expect(git.getTaskDiff).toHaveBeenCalledWith(
+			"/tmp/wt",
+			"branch",
+			expect.objectContaining({ baseBranch: "main" }),
+		);
+	});
+
+	it("resolves a fork PR-review task's recent-commit base to the project base", async () => {
+		const project = makeProject({ defaultBaseBranch: "main" });
+		const task = makeTask({
+			worktreePath: "/tmp/wt",
+			branchName: "fix/ctrl-o",
+			baseBranch: "contributor/fix/ctrl-o",
+			existingBranch: "contributor/fix/ctrl-o",
+			prNumber: 1193,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.getTaskDiff).mockResolvedValue({
+			...branchDiffResponse,
+			mode: "recent",
+			compareRef: "HEAD~1",
+			compareLabel: "HEAD~1",
+			recentCount: 1,
+		});
+
+		await handlers.getTaskDiff({ taskId: task.id, projectId: project.id, mode: "recent", count: 1 });
+
+		expect(git.getTaskDiff).toHaveBeenCalledWith(
+			"/tmp/wt",
+			"recent",
+			expect.objectContaining({ baseBranch: "main", count: 1 }),
 		);
 	});
 
@@ -5002,22 +5073,18 @@ describe("handlers.getBranchStatus", () => {
 		});
 	});
 
-	it("compares a PR-review task (baseBranch === branchName) against the project base, not itself", async () => {
-		// PR-review / existing-branch tasks check out the PR head branch and
-		// deriveTaskBaseBranch stores that same branch as baseBranch. Comparing
-		// origin/<branch> against HEAD is trivially empty (the "No changes to show"
-		// diff bug + a false "Branch Merged" prompt) — it must fall back to the base.
+	it("compares a fork PR-review task against the project base, not its remote-qualified head", async () => {
 		const project = makeProject({ defaultBaseBranch: "main" });
 		const task = makeTask({
 			worktreePath: "/tmp/wt",
-			branchName: "codex/pr-head",
-			baseBranch: "codex/pr-head",
-			existingBranch: "origin/codex/pr-head",
-			prNumber: 16484,
+			branchName: "fix/ctrl-o",
+			baseBranch: "contributor/fix/ctrl-o",
+			existingBranch: "contributor/fix/ctrl-o",
+			prNumber: 1193,
 		});
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
-		vi.mocked(git.getCurrentBranch).mockResolvedValue("codex/pr-head");
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("fix/ctrl-o");
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 5, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
@@ -5027,7 +5094,6 @@ describe("handlers.getBranchStatus", () => {
 
 		await handlers.getBranchStatus({ taskId: task.id, projectId: project.id });
 
-		// The comparison ref must be the project base, never the branch against itself.
 		expect(git.getBranchStatus).toHaveBeenCalledWith("/tmp/wt", "origin/main");
 		expect(git.getBranchDiffStats).toHaveBeenCalledWith("/tmp/wt", "origin/main");
 	});

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -568,7 +568,7 @@ function TaskInfoPanel({
 		? () => onOpenInlineDiff({
 			mode: "branch",
 			compareRef: branchMeta?.compareRef,
-			compareLabel: branchMeta?.compareLabel ?? `origin/${task.baseBranch || project.defaultBaseBranch || "main"}`,
+			compareLabel: branchMeta?.compareLabel ?? `origin/${resolveTaskCompareBaseBranch(task, project)}`,
 			focusFirstUnresolvedThread: true,
 		})
 		: undefined;

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1583,6 +1583,31 @@ describe("TaskInfoPanel", () => {
 			});
 		});
 
+		it("opens a fork PR-review diff against the project base", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const onOpenInlineDiff = vi.fn();
+			const task = makeTask({
+				status: "review-by-colleague",
+				branchName: "fix/ctrl-o",
+				baseBranch: "contributor/fix/ctrl-o",
+				existingBranch: "contributor/fix/ctrl-o",
+				prNumber: 1193,
+			});
+
+			await act(async () => {
+				renderPanel(task, { onOpenInlineDiff });
+			});
+
+			const diffButtons = screen.getAllByRole("button", { name: "Show Diff" });
+			const enabledButton = diffButtons.find((button) => !button.hasAttribute("disabled"));
+			await user.click(enabledButton!);
+
+			expect(onOpenInlineDiff).toHaveBeenCalledWith({
+				mode: "branch",
+				compareLabel: "origin/main",
+			});
+		});
+
 		it("keeps Show Diff active while branch status is still loading", async () => {
 			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 			const onOpenInlineDiff = vi.fn();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1824,23 +1824,36 @@ export function buildTaskDialogSubject(task: Task, project: Project): TaskDialog
  * branch diff, ahead/behind status, and rebase/merge targets.
  *
  * Normally this is `task.baseBranch` (falling back to the project's default
- * base). PR-review and other "existing branch" tasks are the exception: they
- * check out an existing remote branch and `deriveTaskBaseBranch` (see
- * `src/bun/data.ts`) stores that same branch as `baseBranch`, so
- * `baseBranch === branchName`. Comparing a branch against itself is trivially
- * empty — the "No changes to show" branch-diff bug, and a false "Branch Merged"
- * prompt. When the stored base collapses onto the task's own branch, fall back
- * to the project's real base branch so comparisons show the branch's actual
- * changes. Mirrors the merge-completion poller's inline fallback in
- * `src/bun/rpc-handlers/git-operations.ts`.
+ * base). PR-review and other "existing branch" tasks are the exception:
+ * `deriveTaskBaseBranch` stores their checkout ref as `baseBranch`. The local
+ * branch may have the same name, or a fork-qualified checkout ref such as
+ * `contributor/feature` may become local branch `feature`. Comparing either
+ * checkout shape against HEAD is trivially empty. Fall back to the project's
+ * real base branch so diff, commit count, and branch status show the task's
+ * actual changes. A variant branch intentionally differs from its source
+ * `existingBranch`, so it keeps that source as its comparison base.
  */
 export function resolveTaskCompareBaseBranch(
-	task: Pick<Task, "baseBranch" | "branchName">,
+	task: Pick<Task, "baseBranch" | "branchName" | "existingBranch">,
 	project: Pick<Project, "defaultBaseBranch">,
 ): string {
 	const projectBase = project.defaultBaseBranch || "main";
 	const stored = task.baseBranch || projectBase;
-	if (task.branchName && stored === task.branchName) {
+	const existingBranch = task.existingBranch?.trim()
+		.replace(/^refs\/remotes\//, "")
+		.replace(/^origin\//, "");
+	const existingBranchResolvesToTaskBranch = Boolean(
+		task.branchName
+		&& existingBranch
+		&& (
+			existingBranch === task.branchName
+			|| existingBranch.endsWith(`/${task.branchName}`)
+		),
+	);
+	if (
+		(task.branchName && stored === task.branchName)
+		|| (existingBranchResolvesToTaskBranch && stored === existingBranch)
+	) {
 		return projectBase;
 	}
 	return stored;


### PR DESCRIPTION
## Summary

- compare fork PR review tasks against the project base instead of their own remote-qualified head
- restore changed-file counts, line statistics, branch diffs, and recent-commit diffs
- preserve the source branch as the comparison base for multi-variant tasks
- use the resolved comparison base when opening unresolved review threads

## Root cause

Fork PR review tasks store an owner-qualified baseBranch and existingBranch, while the checked-out local branchName omits the remote owner. The comparison resolver did not recognize those refs as the same PR head, so Git compared the branch against itself and returned an empty diff.

## Validation

- bun run lint
- bun run test: 7,816 passing, 1 skipped
- browser QA on the reported review task: Branch and Last commit both show 4 files and +61/-2 lines
- regression coverage for fork-qualified refs and multi-variant source branches