### PR TITLE
Stop seven app shortcuts from stealing Ctrl+keys from the terminal on macOS

### DIFF
--- a/change-logs/2026/07/30/fix-ctrl-shortcuts-mac-terminal.md
+++ b/change-logs/2026/07/30/fix-ctrl-shortcuts-mac-terminal.md
@@ -1,0 +1,3 @@
+Short: Ctrl+Q/H/N/P/K/G/[ reach the terminal on macOS
+
+Following the Ctrl+O fix, seven more app shortcuts claimed their Ctrl form on macOS and swallowed the keystroke before the focused terminal saw it — Ctrl+Q (unfreeze output), Ctrl+H (backspace), Ctrl+N/Ctrl+P (shell history), Ctrl+K (kill to end of line), Ctrl+G (abort input) and Ctrl+[ (escape). They now match the keymap exactly: ⌘ on macOS, Ctrl elsewhere, with a regression test over the whole set.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -793,16 +793,18 @@ function App() {
 			// native behavior; aliased ones (⌘1–9 → `G then 1–9`, ⌘N → `C`) fall back
 			// to their bare-key path. Source of truth: `keymap.ts` scope/remoteKeys.
 			const remote = isRemote();
-			if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "q") {
+			if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "q") {
 				if (remote) return; // ⌘Q quits the browser — leave it to the browser.
 				// WKWebView swallows the native menu Cmd+Q accelerator while a
 				// terminal has focus, so we catch it here (capture phase) and ask
 				// the main process to start the quit. The `before-quit` gate then
 				// pushes `showQuitDialog` back, or quits if the user opted out.
+				// Platform-exact modifier: ⌃Q is XON, it unfreezes terminal output.
 				e.preventDefault();
 				e.stopPropagation();
 				api.request.requestQuit().catch(() => {});
-			} else if ((e.metaKey || e.ctrlKey) && e.key === "h") {
+			} else if (hasAppModifier(e) && e.key === "h") {
+				// Platform-exact modifier: ⌃H is backspace in readline.
 				if (remote) return; // ⌘H hides the browser — leave it to the browser.
 				e.preventDefault();
 				e.stopPropagation();
@@ -824,23 +826,26 @@ function App() {
 				e.preventDefault();
 				e.stopPropagation();
 				api.request.openNewWindow().catch(() => {});
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "n") {
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "n") {
 				// ⌘N opens a new browser window in remote (not cancelable) — fall back
 				// to the bare `C` shortcut there. See keymap.ts `new-task` remoteKeys.
+				// Platform-exact modifier: ⌃N is next-history in the shell.
 				if (remote) return;
 				if (createTaskProjectId || showAddProjectModal || showQuitDialog) return;
 				if (!openCreateTaskModal()) return;
 				e.preventDefault();
 				e.stopPropagation();
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
+				// Cmd/Ctrl+P — Add Project. Platform-exact modifier: ⌃P is previous-history.
 				e.preventDefault();
 				e.stopPropagation();
 				if (showQuitDialog) return;
 				openAddProject();
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
 				// Cmd/Ctrl+K — open the project quick-switch palette (Slack/Linear/VSCode
 				// "go to anything" convention). Not Cmd+T: that's the universal new-tab key
 				// and the live terminal underneath (ghostty/tmux) intercepts it.
+				// Platform-exact modifier: ⌃K is kill-to-end-of-line in the shell.
 				e.preventDefault();
 				e.stopPropagation();
 				if (showQuitDialog || createTaskProjectId || showAddProjectModal) return;
@@ -923,8 +928,9 @@ function App() {
 				if (!cycleVariant(1)) return;
 				e.preventDefault();
 				e.stopPropagation();
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "[") {
-				// Cmd+[ — navigate back through route history
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.key === "[") {
+				// Cmd+[ — navigate back through route history. Platform-exact modifier:
+				// ⌃[ is Escape in a terminal; the Ctrl+- alias above covers mac Ctrl users.
 				e.preventDefault();
 				e.stopPropagation();
 				dispatch({ type: "goBack" });
@@ -1006,8 +1012,9 @@ function App() {
 					e.stopPropagation();
 					navigateToProject(available[idx].id);
 				}
-			} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.code === "KeyG") {
+			} else if (hasAppModifier(e) && !e.shiftKey && !e.altKey && e.code === "KeyG") {
 				// Cmd/Ctrl+G — Mac-friendly chord alias for the bare-`f` hint mode.
+				// Platform-exact modifier: ⌃G aborts the current shell input.
 				if (isTypingContext()) return;
 				if (!document.querySelector("[data-hint-id]")) return;
 				e.preventDefault();

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -205,6 +205,21 @@ class FakeWebNotification {
 	}
 }
 
+const realNavigator = globalThis.navigator;
+
+/**
+ * Fake the platform `isMac()` reads. The shortcut chain is platform-exact for
+ * the combos the terminal owns (⌘Q/⌘H/⌘N/⌘P/⌘K/⌘[/⌘G), so a test asserting a
+ * ⌘ or a Ctrl combo has to state which OS it is on.
+ */
+function fakePlatform(os: "mac" | "linux") {
+	const value =
+		os === "mac"
+			? { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" }
+			: { platform: "Linux x86_64", userAgent: "Mozilla/5.0 (X11; Linux x86_64)" };
+	Object.defineProperty(globalThis, "navigator", { value, writable: true, configurable: true });
+}
+
 describe("App keyboard shortcuts", () => {
 	beforeEach(() => {
 		// These assert the DESKTOP keymap (⌘Q, ⌘N, zoom, ⌘1–9). happy-dom looks like
@@ -212,11 +227,17 @@ describe("App keyboard shortcuts", () => {
 		// the Electrobun webview flag. Safe here because rpc is mocked (above).
 		(window as Window & { __electrobunWebviewId?: number }).__electrobunWebviewId = 1;
 		rpcTransport.isElectrobun = true;
+		// The ⌘ combos below are the macOS keymap — happy-dom is not a Mac.
+		fakePlatform("mac");
 		vi.clearAllMocks();
 		vi.mocked(api.request.checkSystemRequirements).mockResolvedValue([]);
 		vi.mocked(api.request.getProjects).mockResolvedValue([]);
 		vi.mocked(api.request.getLastRoute).mockResolvedValue({ route: null });
 		vi.mocked(api.request.listTmuxSessions).mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		Object.defineProperty(globalThis, "navigator", { value: realNavigator, writable: true, configurable: true });
 	});
 
 	it("opens the native pane layout lab from the debug menu action", async () => {
@@ -264,11 +285,19 @@ describe("App keyboard shortcuts", () => {
 			expect(api.request.requestQuit).toHaveBeenCalled();
 		});
 
-		it("Ctrl+Q forwards to bun via requestQuit", async () => {
+		it("Ctrl+Q forwards to bun via requestQuit off macOS", async () => {
+			fakePlatform("linux");
 			vi.mocked(api.request.requestQuit).mockResolvedValue(undefined);
 			await renderApp();
 			await userEvent.keyboard("{Control>}q{/Control}");
 			expect(api.request.requestQuit).toHaveBeenCalled();
+		});
+
+		it("Ctrl+Q on macOS is XON for the terminal, not a quit", async () => {
+			vi.mocked(api.request.requestQuit).mockResolvedValue(undefined);
+			await renderApp();
+			await userEvent.keyboard("{Control>}q{/Control}");
+			expect(api.request.requestQuit).not.toHaveBeenCalled();
 		});
 
 		it("Escape closes the quit dialog", async () => {
@@ -304,10 +333,53 @@ describe("App keyboard shortcuts", () => {
 			expect(api.request.hideApp).toHaveBeenCalled();
 		});
 
-		it("Ctrl+H calls hideApp", async () => {
+		it("Ctrl+H calls hideApp off macOS", async () => {
+			fakePlatform("linux");
 			await renderApp();
 			await userEvent.keyboard("{Control>}h{/Control}");
 			expect(api.request.hideApp).toHaveBeenCalled();
+		});
+
+		it("Ctrl+H on macOS is backspace for the terminal, not a hide", async () => {
+			await renderApp();
+			await userEvent.keyboard("{Control>}h{/Control}");
+			expect(api.request.hideApp).not.toHaveBeenCalled();
+		});
+	});
+
+	// Regression guard for the ⌃O bug (PR #1193) and its siblings: the chain runs
+	// in capture phase and calls preventDefault + stopPropagation, so any combo it
+	// claims never reaches the focused terminal. On macOS these belong to the shell.
+	describe("Ctrl+<key> stays with the terminal on macOS", () => {
+		const stolen: Array<{ combo: string; init: KeyboardEventInit }> = [
+			{ combo: "Ctrl+Q (XON)", init: { key: "q", code: "KeyQ" } },
+			{ combo: "Ctrl+H (backspace)", init: { key: "h", code: "KeyH" } },
+			{ combo: "Ctrl+N (next history)", init: { key: "n", code: "KeyN" } },
+			{ combo: "Ctrl+P (previous history)", init: { key: "p", code: "KeyP" } },
+			{ combo: "Ctrl+K (kill to end of line)", init: { key: "k", code: "KeyK" } },
+			{ combo: "Ctrl+G (abort input)", init: { key: "g", code: "KeyG" } },
+			{ combo: "Ctrl+[ (escape)", init: { key: "[", code: "BracketLeft" } },
+			{ combo: "Ctrl+O (open file)", init: { key: "o", code: "KeyO" } },
+		];
+
+		it.each(stolen)("leaves $combo alone", async ({ init }) => {
+			await renderApp();
+			const event = new KeyboardEvent("keydown", { ...init, ctrlKey: true, bubbles: true, cancelable: true });
+			act(() => window.dispatchEvent(event));
+			expect(event.defaultPrevented).toBe(false);
+			expect(api.request.requestQuit).not.toHaveBeenCalled();
+			expect(api.request.hideApp).not.toHaveBeenCalled();
+			expect(screen.getByTestId("dashboard-screen")).toBeInTheDocument();
+			expect(screen.queryByTestId("add-project-modal")).not.toBeInTheDocument();
+			expect(screen.queryByText("New Task")).not.toBeInTheDocument();
+		});
+
+		it("still claims the same keys with Ctrl off macOS", async () => {
+			fakePlatform("linux");
+			await renderApp();
+			const event = new KeyboardEvent("keydown", { key: "k", code: "KeyK", ctrlKey: true, bubbles: true, cancelable: true });
+			act(() => window.dispatchEvent(event));
+			expect(event.defaultPrevented).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
Follow-up to #1193, which fixed only the `Ctrl+O` branch of the global shortcut chain in `src/mainview/App.tsx`.

The chain runs in capture phase with `preventDefault()` + `stopPropagation()`, so every branch gating on `(e.metaKey || e.ctrlKey)` also claims `Ctrl+<key>` on macOS — and the focused terminal never sees the keystroke. Seven of those combos belong to the shell:

| Combo | What the shell wanted it for | What the app did instead |
|---|---|---|
| `Ctrl+Q` | XON, unfreeze terminal output | started the quit flow |
| `Ctrl+H` | backspace (readline) | hid the whole app |
| `Ctrl+N` | next history entry | opened Create Task |
| `Ctrl+P` | previous history entry | opened Add Project |
| `Ctrl+K` | kill-to-end-of-line | opened the project switch palette |
| `Ctrl+G` | abort current input | entered task hint mode |
| `Ctrl+[` | identical to Escape | navigated back |

All seven now use `hasAppModifier(e)` (`src/mainview/utils/platform.ts`, added in #1193): Cmd on macOS, Ctrl elsewhere. Each branch was checked against its own `keymap.ts` entry first — all seven declare `⌘<key>` on mac and `Ctrl+<key>` only off-mac, so `keymap.ts` needed no change. The separate `Ctrl+-` back alias (declared on mac) is untouched. The remaining 16 `(e.metaKey || e.ctrlKey)` sites are left as-is; 9 of them additionally require Shift.

The condition that shipped the `Ctrl+O` bug had no test coverage at all. Added a regression describe in `App.test.tsx` covering all eight combos (the seven plus `Ctrl+O`): a capture-phase `keydown` with `ctrlKey` against a faked-macOS navigator must leave `defaultPrevented === false` and fire no side effect, plus one off-mac case asserting `Ctrl+K` still works. The `App keyboard shortcuts` describe now fakes a macOS navigator, since its `⌘` assertions only hold when `isMac()` is true.

Verified: `bun run lint` clean, full `bun run test` green (mainview 3138, bun 4031, cli 668). The guard was confirmed to bite by reverting one branch by hand.