### PR TITLE
Dim inactive tmux panes

### DIFF
--- a/change-logs/2026/07/30/feature-30-dim-inactive-tmux-panes.md
+++ b/change-logs/2026/07/30/feature-30-dim-inactive-tmux-panes.md
@@ -1,0 +1,3 @@
+Short: Dim inactive terminal splits
+
+Inactive tmux panes now render on a darker background with greyed default text, while the focused pane keeps the full theme colors, so it is obvious which split you are typing into.

--- a/src/bun/tmux/themes.ts
+++ b/src/bun/tmux/themes.ts
@@ -136,12 +136,13 @@ set -gF message-command-style "fg=#{@thm_teal},bg=#{@thm_overlay_0},align=centre
 # Menu
 set -gF menu-selected-style "#{E:@catppuccin_menu_selected_style}"
 
-# Pane background — match theme bg so no white gaps around borders
-set -gF window-style "bg=#{@thm_bg}"
-set -gF window-active-style "bg=#{@thm_bg}"
+# Pane background — active pane keeps the theme bg; inactive panes get a darker
+# bg and greyed default fg so the focused split is obvious at a glance.
+set -gF window-style "bg=#{@thm_mantle},fg=#{@thm_overlay_1}"
+set -gF window-active-style "bg=#{@thm_bg},fg=#{@thm_fg}"
 
-# Pane borders — include bg so border area also matches
-set -gF pane-border-style "fg=#{@thm_overlay_0},bg=#{@thm_bg}"
+# Pane borders — include bg so border area also matches its pane
+set -gF pane-border-style "fg=#{@thm_surface_1},bg=#{@thm_mantle}"
 set -gF pane-active-border-style "fg=#{@thm_lavender},bg=#{@thm_bg}"
 
 # Popups


### PR DESCRIPTION
Inactive tmux panes now render on a darker background (`@thm_mantle`) with greyed default text (`@thm_overlay_1`), while the focused pane keeps the full theme colors. The inactive pane border is toned down to `@thm_surface_1`; the active border stays lavender.

Makes it obvious which split you are typing into when a task terminal has more than one pane.

Both flavors resolve correctly:

| | dark (mocha) | light (latte) |
|---|---|---|
| inactive pane bg / fg | `#181825` / `#7f849c` | `#e6e9ef` / `#8c8fa1` |
| active pane bg / fg | `#1e1e2e` / `#cdd6f4` | `#eff1f5` / `#4c4f69` |

Note: `window-style` only recolors text drawn in the terminal's default color, so TUIs that set explicit colors (agents, neovim) keep their palette — the pane background still shifts, so the focused split remains clearly distinguishable.

Changed file: `src/bun/tmux/themes.ts`.