### PR TITLE
Package the native terminal host on macOS and Linux

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -10,7 +10,9 @@ on:
       - "scripts/fixtures/windows-conpty-package/**"
       - "scripts/build-cli.ts"
       - "scripts/build-native.ts"
-      - "scripts/build-windows-terminal-host.ts"
+      - "scripts/build-terminal-host.ts"
+      - "scripts/package-native-host.ts"
+      - "scripts/package-posix-native-host.ts"
       - "scripts/verify-packaged-windows-conpty.ts"
       - "scripts/verify-windows-app-launch.ts"
       - "scripts/verify-windows-conpty-update-archive.ts"
@@ -217,3 +219,44 @@ jobs:
             artifacts/windows-app-layout.json
             artifacts/windows-app-launch-proof.json
             artifacts/*-update.json
+
+  # The REAL dev3 macOS and Linux packages. Synthesized bundle trees in vitest
+  # cannot prove a package ships a launchable host, so this builds the actual
+  # package, lets postBuild assemble + stage + drive the detached host with no
+  # Bun on PATH, and then proves a bundled resolver (no source checkout, no env
+  # override) reaches that image from the packaged runtime.
+  posix-app-package:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup build Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # postBuild → scripts/package-posix-native-host.ts: assemble the versioned
+      # image into the bundle, stage it outside the install root, then version /
+      # start / reattach / stop the detached host from the staged copy.
+      - name: Build the real dev3 package
+        run: bun run build
+
+      - name: Resolve the packaged host image from the packaged runtime
+        run: bun scripts/verify-packaged-host-resolution.ts
+
+      - name: Upload package proof
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: posix-native-host-package-proof-${{ matrix.os }}
+          path: |
+            build/*/native-host-package-proof.json
+            build/*/native-host-resolution-proof.json

--- a/change-logs/2026/07/30/fix-cross-platform-native-host-package.md
+++ b/change-logs/2026/07/30/fix-cross-platform-native-host-package.md
@@ -1,0 +1,3 @@
+Short: Native terminal host now ships on macOS and Linux
+
+The experimental native terminal backend could not start from a packaged macOS or Linux build: the host bundle was only built on Windows and no package outside Windows carried a native host image. Both are now produced and verified on every platform, and a packaged app resolves and stages its own image without any environment override. Terminal backend defaults are unchanged — tmux still owns every task that has not explicitly opted in.

--- a/decisions/182-macos-native-host-image-under-contents.md
+++ b/decisions/182-macos-native-host-image-under-contents.md
@@ -1,0 +1,68 @@
+# 182 — The macOS native host image lives at `<bundle>.app/Contents/native-host-image/`
+
+## Context
+
+The packaged native terminal host (decision 169) only ever shipped on Windows:
+`scripts/build-windows-terminal-host.ts` exited outside win32 and the Electrobun
+`postBuild` proof did the same. A packaged macOS build therefore carried no
+`native-host-image/`, so `resolveNativeHostRuntime()` fell through to the
+source-checkout branch — unreachable from a bundled app — and an explicitly
+native task sat in Preparing behind an honest `NativeHostRuntimeError` (seq 1311).
+
+Making the image ship on macOS needs one decision the other platforms did not:
+*where*. Electrobun emits `<bundle>.app/Contents/MacOS/bun` for the runtime and
+`<bundle>.app/Contents/Resources/app/` for everything in `build.copy`, while
+Linux and Windows put the runtime at `<bundle>/bin/bun[.exe]` with copies under
+`<bundle>/Resources/app/`.
+
+## Investigation
+
+`packagedHostImageRoots()` probes exactly two directories: the packaged runtime's
+own directory and its parent. On Linux and Windows those are `<bundle>/bin` and
+`<bundle>`, which is why `<bundle>/native-host-image/` already worked. On macOS
+they are `Contents/MacOS` and `Contents` — so `Resources/app/native-host-image/`,
+the "obvious" home next to the other copied assets, is **not reachable** without
+a darwin-specific third probe.
+
+`Resources/app` is also the directory Electrobun packs into `app.asar` when
+`useAsar` is enabled, deleting the original tree. An image inside an archive
+cannot be executed.
+
+## Decision
+
+Assemble the macOS image into `<bundle>.app/Contents/native-host-image/<tag>/`.
+`nativeHostPackageLayout()` in
+`src/bun/native-terminal-registry/host-images/package-layout.ts` owns the per-OS
+split and is held to the "runtime directory or its parent" invariant by its own
+test, so `resolveNativeHostRuntime()` needed no change at all.
+
+The runtime carrier inside the image is `dev3-terminal-host` on POSIX and stays
+`dev3-terminal-host.exe` on Windows (`packagedHostRuntimeCarrier()`), because the
+Windows proof asserts that name as the detached host's Task Manager image name.
+
+## Risks
+
+`Contents/native-host-image/` is not one of Apple's standard bundle directories.
+`electrobun.config.ts` currently sets `codesign: false` and `notarize: false`, so
+nothing validates the layout today — but if macOS signing is ever enabled, a
+non-standard directory at the `Contents/` level is the kind of thing `codesign
+--deep` and Gatekeeper complain about, and the ~60 MB Bun carrier inside it would
+have to be signed as a nested executable. Whoever turns signing on must revisit
+this placement rather than assume it survives.
+
+Second risk: the image duplicates the packaged Bun runtime, so every macOS and
+Linux package grows by roughly the size of Bun. That is the same cost Windows
+already pays and is inherent to an immutable image that must survive an in-app
+update swapping the install directory.
+
+## Alternatives considered
+
+* **`Contents/Resources/app/native-host-image/`** — sits with the other copied
+  assets and is codesign-friendly, but needs a darwin-only third probe root in
+  `packagedHostImageRoots()` and would be swallowed by asar packing.
+* **Ship the image via the `dist/native` copy rule** — no `postBuild` hook at
+  all, but the carrier has to be the Bun runtime Electrobun copies into the
+  bundle, which does not exist until after the copy step runs.
+* **Symlink the carrier at the packaged `bun`** — halves the package size, but a
+  live host would follow the link into an install directory an update replaces,
+  which is the exact failure the immutable image exists to prevent.

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -81,10 +81,10 @@ export default {
 		},
 	},
 	scripts: {
-		// Windows only (both no-op elsewhere): postBuild assembles the versioned
-		// native host image into the bundle so it ships inside the update archive,
-		// postPackage re-verifies that image from the FINAL archive.
-		postBuild: "./scripts/verify-packaged-windows-conpty.ts",
+		// postBuild assembles the versioned native host image into the bundle on
+		// every platform, so it ships inside the update archive; postPackage
+		// re-verifies the Windows image from the FINAL archive (no-op elsewhere).
+		postBuild: "./scripts/package-native-host.ts",
 		postPackage: "./scripts/verify-windows-conpty-update-archive.ts",
 	},
 } satisfies ElectrobunConfig;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"test:native-host-image": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/host-images/__tests__/artifact-manifest.test.ts src/bun/native-terminal-registry/host-images/__tests__/artifact-manifest-cli.test.ts src/bun/native-terminal-registry/host-images/__tests__/packaged-image-manifest.test.ts src/bun/native-terminal-registry/host-images/__tests__/packaged-image.test.ts",
 		"package:win-archive": "bun scripts/generate-build-info.ts && bun scripts/generate-changelog.ts && vite build && bun run build:cli && electrobun build --env=canary",
 		"verify:win-app-launch": "bun scripts/verify-windows-app-launch.ts",
+		"verify:packaged-host": "bun scripts/verify-packaged-host-resolution.ts",
 		"test:native-parity-e2e": "bun src/bun/native-terminal-adapter/__tests__/parity-corpus.native-e2e.ts",
 		"test:ownership-e2e": "bun src/bun/terminal-process-ownership/__tests__/ownership.bun-e2e.ts",
 		"test:cli-loopback-e2e": "bun src/bun/__tests__/cli-loopback-transport.bun-e2e.ts",

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -3,8 +3,8 @@
  * the `build:native` package script.
  *
  * The macOS notification shim is still built by its `.sh` script; Windows only
- * needs the `dist/native` copy source to exist. The terminal host bundler is a
- * TypeScript script on every platform and no-ops outside Windows itself.
+ * needs the `dist/native` copy source to exist. The terminal host bundler runs
+ * on every platform — a package without it has no native terminal to launch.
  */
 
 import { mkdirSync } from "node:fs";
@@ -38,7 +38,7 @@ function main(): void {
 	for (const script of plan.shellSteps) runOrExit(["bash", script], script);
 	// Always present so the electrobun `dist/native` copy rule has a source.
 	mkdirSync(resolve(import.meta.dir, "../dist/native"), { recursive: true });
-	runOrExit([process.execPath, "scripts/build-windows-terminal-host.ts"], "Windows terminal host bundle");
+	runOrExit([process.execPath, "scripts/build-terminal-host.ts"], "native terminal host bundle");
 }
 
 if (import.meta.main) main();

--- a/scripts/build-terminal-host.ts
+++ b/scripts/build-terminal-host.ts
@@ -1,14 +1,23 @@
+/**
+ * Bundle the native terminal host into `dist/native/dev3-terminal-host.js` on
+ * every platform.
+ *
+ * Electrobun copies `dist/native` into the package, and the packaging hook then
+ * assembles that bundle plus the packaged Bun runtime into an immutable
+ * `native-host-image/<tag>/`. This step used to no-op outside Windows, which is
+ * exactly why a packaged macOS build had no host to launch (seq 1311).
+ *
+ * The ConPTY runtime floor belongs to the Bun that EXECUTES the host — the one
+ * Electrobun copies into the package — and the packaging hook asserts it there.
+ * Whatever Bun bundles this script is not bound by it, so CI jobs that only
+ * type-check a build are free to run an older toolchain.
+ */
+
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { assertPackagedConptyRuntime } from "../src/shared/native-terminal-runtime";
 
-if (process.platform !== "win32") {
-	console.log("[native-terminal-host] Windows host build skipped outside Windows");
-	process.exit(0);
-}
-
-const compilerVersion = assertPackagedConptyRuntime(Bun.version);
+const compilerVersion = Bun.version;
 const entrypoint = resolve(import.meta.dir, "../src/bun/native-terminal-host/main.ts");
 const outputDir = resolve(import.meta.dir, "../dist/native");
 const output = resolve(outputDir, "dev3-terminal-host.js");
@@ -20,16 +29,16 @@ const build = spawnSync(
 	{ cwd: resolve(import.meta.dir, ".."), env: process.env, encoding: "utf8" },
 );
 if (build.status !== 0) {
-	throw new Error(`Failed to bundle the Windows terminal host with Bun ${compilerVersion}.\n${build.stdout}\n${build.stderr}`);
+	throw new Error(`Failed to bundle the terminal host with Bun ${compilerVersion}.\n${build.stdout}\n${build.stderr}`);
 }
 
 const version = spawnSync(process.execPath, [output, "version"], { encoding: "utf8", env: process.env });
 if (version.status !== 0) throw new Error(`Bundled terminal host version probe failed: ${version.stderr}`);
 const reported = JSON.parse(version.stdout.trim());
-if (assertPackagedConptyRuntime(reported.bunVersion) !== compilerVersion) {
+if (reported.bunVersion !== compilerVersion) {
 	throw new Error(`Bundled terminal host reports Bun ${reported.bunVersion}; expected build Bun ${compilerVersion}.`);
 }
 console.log(
 	`[native-terminal-host] bundled ${output} with build Bun ${reported.bunVersion}; ` +
-		"the Electrobun postBuild proof will execute it with the copied package runtime",
+		"the Electrobun postBuild hook will execute it with the copied package runtime",
 );

--- a/scripts/native-host-resolution-probe.ts
+++ b/scripts/native-host-resolution-probe.ts
@@ -1,0 +1,14 @@
+/**
+ * Prints how `resolveNativeHostRuntime()` resolves in the process that runs it.
+ *
+ * Only ever executed as a `bun build --target=bun` BUNDLE, by
+ * `scripts/verify-packaged-host-resolution.ts`. Bundling is the point: it puts
+ * the resolver's `import.meta.url` inside `$bunfs`, so the source-checkout
+ * branch cannot fire and a `packaged-image` verdict can only have come from an
+ * image that really ships inside the package.
+ */
+
+import { resolveNativeHostRuntime } from "../src/bun/native-host-runtime";
+
+const runtime = resolveNativeHostRuntime();
+process.stdout.write(`DEV3_RESOLUTION_PROBE ${JSON.stringify({ execPath: process.execPath, ...runtime })}\n`);

--- a/scripts/package-native-host.ts
+++ b/scripts/package-native-host.ts
@@ -1,0 +1,14 @@
+/**
+ * Electrobun `postBuild` hook: assemble and prove this package's native terminal
+ * host image. Lifecycle hooks accept a single script path, so the platform split
+ * lives here rather than in the config.
+ *
+ * Windows keeps its richer ConPTY proof (tasklist image names, PowerShell child,
+ * update-archive re-verification in `postPackage`); macOS and Linux get the
+ * equivalent assemble + stage + detached-lifecycle proof.
+ */
+
+if (process.platform === "win32") await import("./verify-packaged-windows-conpty");
+else await import("./package-posix-native-host");
+
+export {};

--- a/scripts/package-posix-native-host.ts
+++ b/scripts/package-posix-native-host.ts
@@ -1,0 +1,308 @@
+/**
+ * macOS + Linux packaged-host proof, the sibling of the Windows one.
+ *
+ * Runs as Electrobun `postBuild` and does the same two jobs the Windows script
+ * does for its own package:
+ *
+ *   1. ASSEMBLE the versioned native host image into the app bundle, so it ships
+ *      inside the final update archive.
+ *   2. PROVE it: version identity from the packaged runtime with no Bun on PATH,
+ *      additive staging outside the replaceable install directory, and a full
+ *      detached host start / reattach / stop cycle from the staged image.
+ *
+ * Before this existed, `bun run build:native` no-opped outside Windows and no
+ * package carried an image, so an explicitly-native task on macOS sat in
+ * Preparing behind an honest NativeHostRuntimeError (seq 1311).
+ *
+ * Everything it asserts lands in `native-host-package-proof.json` beside the
+ * build. No-ops on Windows, which has its own richer proof.
+ */
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, relative, resolve } from "node:path";
+import {
+	NATIVE_TERMINAL_HOST_READY_MARKER,
+	assertPackagedConptyRuntime,
+	sameNativeTerminalPath,
+	type NativeTerminalHostIdentity,
+	type NativeTerminalHostProofState,
+} from "../src/shared/native-terminal-runtime";
+import { NATIVE_SESSION_PROTOCOL_VERSION } from "../src/bun/native-terminal-registry/protocol";
+import {
+	assemblePackagedImage,
+	discoverPackagedImage,
+	fingerprintPackagedImage,
+	isInsideDirectory,
+	stagePackagedImage,
+	PACKAGED_HOST_IMAGE_PARENT,
+} from "../src/bun/native-terminal-registry/host-images/packaged-image";
+import {
+	manifestArchForElectrobunArch,
+	manifestOsForElectrobunOs,
+	nativeHostPackageLayout,
+	packagedRuntimePathIn,
+} from "../src/bun/native-terminal-registry/host-images/package-layout";
+
+if (process.platform === "win32") {
+	console.log("[native-terminal-runtime] POSIX packaged-host proof skipped on Windows");
+	process.exit(0);
+}
+
+/** No Bun, no Homebrew — the packaged runtime has to carry the host on its own. */
+const CLEAN_PATH = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(delimiter);
+
+function run(executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv, timeout = 25_000): string {
+	const result = spawnSync(executable, args, { cwd, env, encoding: "utf8", timeout });
+	if (result.status !== 0 || result.error) {
+		throw new Error(
+			`${executable} ${args.join(" ")} failed (exit ${result.status ?? "none"}` +
+				`${result.error ? `, ${result.error.message}` : ""}).\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+		);
+	}
+	return (result.stdout ?? "").trim();
+}
+
+function parseLastJson<T>(output: string, description: string): T {
+	const line = output.trim().split(/\r?\n/).at(-1);
+	if (!line) throw new Error(`${description} returned no JSON output.`);
+	try {
+		return JSON.parse(line) as T;
+	} catch (cause) {
+		throw new Error(`${description} returned invalid JSON: ${line}`, { cause });
+	}
+}
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const buildDir = process.env.ELECTROBUN_BUILD_DIR;
+if (!buildDir || !existsSync(buildDir)) {
+	throw new Error(`Electrobun did not provide a valid ELECTROBUN_BUILD_DIR (${buildDir ?? "missing"}).`);
+}
+const appVersion = process.env.ELECTROBUN_APP_VERSION;
+if (!appVersion) throw new Error("Packaged host image assembly requires ELECTROBUN_APP_VERSION from the Electrobun hook.");
+
+const targetOs = manifestOsForElectrobunOs(process.env.ELECTROBUN_OS);
+const targetArch = manifestArchForElectrobunArch(process.env.ELECTROBUN_ARCH);
+
+const bundleRuntimes = readdirSync(buildDir, { withFileTypes: true })
+	.filter((entry) => entry.isDirectory())
+	.map((entry) => packagedRuntimePathIn(targetOs, join(buildDir, entry.name)))
+	.filter((path): path is string => path !== null);
+if (bundleRuntimes.length !== 1) {
+	throw new Error(
+		`Expected exactly one Electrobun app bundle carrying a packaged Bun runtime under ${buildDir}; found ${bundleRuntimes.length}.`,
+	);
+}
+
+const layout = nativeHostPackageLayout(targetOs, bundleRuntimes[0]);
+if (!existsSync(layout.entrypointPath)) {
+	throw new Error(
+		`This package ships no native terminal host at ${layout.entrypointPath}. ` +
+			"Run `bun run build:native` before Electrobun packaging.",
+	);
+}
+
+const cleanDir = mkdtempSync(join(tmpdir(), "dev3-packaged-native-host-"));
+const sessionDir = join(cleanDir, "session");
+const stagingRoot = join(cleanDir, "native-host-images");
+const cleanEnv: NodeJS.ProcessEnv = {
+	PATH: CLEAN_PATH,
+	HOME: process.env.HOME,
+	TMPDIR: process.env.TMPDIR ?? tmpdir(),
+	TERM: "xterm-256color",
+};
+const keepProofFiles = process.env.DEV3_KEEP_CONPTY_PROOF_FILES === "1";
+
+let hostStopped = false;
+let stagedEntrypointForCleanup: { runtime: string; entrypoint: string } | null = null;
+try {
+	const appRuntimeVersion = assertPackagedConptyRuntime(run(layout.runtimePath, ["--version"], cleanDir, cleanEnv));
+
+	const packagedVersion = parseLastJson<NativeTerminalHostIdentity>(
+		run(layout.runtimePath, [layout.entrypointPath, "version"], cleanDir, cleanEnv),
+		"Packaged terminal host version probe",
+	);
+	if (
+		assertPackagedConptyRuntime(packagedVersion.bunVersion) !== appRuntimeVersion ||
+		packagedVersion.carrier !== "bun-runtime-script" ||
+		!sameNativeTerminalPath(packagedVersion.executable, layout.runtimePath) ||
+		!sameNativeTerminalPath(packagedVersion.entrypoint, layout.entrypointPath)
+	) {
+		throw new Error(`Packaged terminal host identity mismatch: ${JSON.stringify(packagedVersion)}`);
+	}
+
+	const expectations = {
+		os: targetOs,
+		arch: targetArch,
+		bunVersion: appRuntimeVersion,
+		protocolVersion: NATIVE_SESSION_PROTOCOL_VERSION,
+		archiveParent: PACKAGED_HOST_IMAGE_PARENT,
+	};
+	const assembled = assemblePackagedImage({
+		packageRoot: layout.hostImagePackageRoot,
+		runtimeSourcePath: layout.runtimePath,
+		entrypointSourcePath: layout.entrypointPath,
+		hostVersion: appVersion,
+		protocolVersion: NATIVE_SESSION_PROTOCOL_VERSION,
+		bunVersion: appRuntimeVersion,
+		runtimeFloor: appRuntimeVersion,
+		os: targetOs,
+		arch: targetArch,
+	});
+	const discovered = discoverPackagedImage(layout.hostImagePackageRoot, expectations);
+	if (discovered.status !== "ok" || discovered.tag !== assembled.tag) {
+		throw new Error(`Assembled native host image did not validate inside the bundle: ${JSON.stringify(discovered)}`);
+	}
+
+	// Additive staging OUTSIDE the replaceable installation directory: an update
+	// swaps the bundle out from under a live host, the staged copy survives it.
+	const staged = stagePackagedImage({ sourceImageDir: discovered.imageDir, stagingRoot, expectations });
+	if (staged.status !== "staged") throw new Error(`Staging the packaged host image failed: ${JSON.stringify(staged)}`);
+	if (isInsideDirectory(layout.appBundleRoot, staged.imageDir)) {
+		throw new Error(`Host image staging must be outside the replaceable bundle ${layout.appBundleRoot}.`);
+	}
+	if (sha256(staged.runtimeCarrierPath) !== sha256(layout.runtimePath) || sha256(staged.entrypointPath) !== sha256(layout.entrypointPath)) {
+		throw new Error("Staged host image files differ from the packaged runtime and entrypoint.");
+	}
+	if ((statSync(staged.runtimeCarrierPath).mode & 0o111) === 0) {
+		throw new Error(`Staged runtime carrier ${staged.runtimeCarrierPath} lost its executable bit.`);
+	}
+	const stagedFingerprint = fingerprintPackagedImage(staged.imageDir);
+	const restaged = stagePackagedImage({ sourceImageDir: discovered.imageDir, stagingRoot, expectations });
+	if (restaged.status !== "already-staged" || fingerprintPackagedImage(staged.imageDir) !== stagedFingerprint) {
+		throw new Error(`Re-staging an existing host image must be a no-op: ${JSON.stringify(restaged)}`);
+	}
+
+	const hostEnv: NodeJS.ProcessEnv = {
+		...cleanEnv,
+		DEV3_EXPECT_HOST_EXECUTABLE: staged.runtimeCarrierPath,
+		DEV3_TERMINAL_HOST_ENTRYPOINT: staged.entrypointPath,
+		DEV3_TERMINAL_HOST_PROOF_DIR: sessionDir,
+	};
+	stagedEntrypointForCleanup = { runtime: staged.runtimeCarrierPath, entrypoint: staged.entrypointPath };
+
+	const stagedVersion = parseLastJson<NativeTerminalHostIdentity>(
+		run(staged.runtimeCarrierPath, [staged.entrypointPath, "version"], cleanDir, hostEnv),
+		"Staged terminal host version probe",
+	);
+	if (
+		stagedVersion.bunVersion !== appRuntimeVersion ||
+		stagedVersion.carrier !== "bun-runtime-script" ||
+		!sameNativeTerminalPath(stagedVersion.executable, staged.runtimeCarrierPath) ||
+		!sameNativeTerminalPath(stagedVersion.entrypoint, staged.entrypointPath)
+	) {
+		throw new Error(`Staged terminal host identity mismatch: ${JSON.stringify(stagedVersion)}`);
+	}
+
+	const state = parseLastJson<NativeTerminalHostProofState>(
+		run(staged.runtimeCarrierPath, [staged.entrypointPath, "start"], cleanDir, hostEnv),
+		"Detached packaged terminal host re-entry",
+	);
+	if (
+		state.marker !== NATIVE_TERMINAL_HOST_READY_MARKER ||
+		state.bunVersion !== appRuntimeVersion ||
+		state.hostPid <= 0 ||
+		state.shellPid <= 0 ||
+		state.hostPid === state.shellPid ||
+		!sameNativeTerminalPath(state.executable, staged.runtimeCarrierPath) ||
+		!sameNativeTerminalPath(state.entrypoint, staged.entrypointPath)
+	) {
+		throw new Error(`Detached packaged terminal host returned invalid state: ${JSON.stringify(state)}`);
+	}
+	const hostLogRedirected = existsSync(join(sessionDir, "host.log"));
+
+	const reattached = parseLastJson<NativeTerminalHostProofState>(
+		run(staged.runtimeCarrierPath, [staged.entrypointPath, "reattach"], cleanDir, hostEnv, 15_000),
+		"Detached packaged terminal host reattach",
+	);
+	const reattachSamePids = reattached.hostPid === state.hostPid && reattached.shellPid === state.shellPid;
+	if (!reattachSamePids || reattached.marker !== state.marker || reattached.bunVersion !== state.bunVersion) {
+		throw new Error(
+			`Detached terminal host reattach changed process identity: started ${JSON.stringify(state)}, reattached ${JSON.stringify(reattached)}.`,
+		);
+	}
+
+	const stopped = parseLastJson<{ stopped: boolean; hostPid: number; shellPid: number }>(
+		run(staged.runtimeCarrierPath, [staged.entrypointPath, "stop"], cleanDir, hostEnv, 15_000),
+		"Detached packaged terminal host stop",
+	);
+	if (!stopped.stopped || stopped.hostPid !== state.hostPid || stopped.shellPid !== state.shellPid) {
+		throw new Error(`Detached terminal host returned invalid stop state: ${JSON.stringify(stopped)}`);
+	}
+	hostStopped = true;
+	if (isProcessAlive(state.hostPid) || isProcessAlive(state.shellPid)) {
+		throw new Error(`Detached terminal processes survived stop (host ${state.hostPid}, shell ${state.shellPid}).`);
+	}
+
+	const proof = {
+		marker: state.marker,
+		platform: targetOs,
+		arch: targetArch,
+		appBundleRoot: layout.appBundleRoot,
+		hostImagePackageRoot: layout.hostImagePackageRoot,
+		systemBunOnPath: false,
+		packagedRuntimePath: layout.runtimePath,
+		packagedEntrypointPath: layout.entrypointPath,
+		packagedRuntimeSha256: sha256(layout.runtimePath),
+		packagedEntrypointSha256: sha256(layout.entrypointPath),
+		electrobunAppBunVersion: appRuntimeVersion,
+		terminalHostBunVersion: state.bunVersion,
+		hostImageReusedExisting: assembled.reused,
+		hostImageTag: assembled.tag,
+		hostImageDir: assembled.imageDir,
+		hostImageArchivePath: relative(resolve(layout.appBundleRoot), resolve(assembled.imageDir)),
+		hostImageDeclaredArchiveRoot: assembled.manifest.archiveRoot,
+		hostImageRuntimeCarrier: assembled.manifest.runtimeCarrier,
+		hostImageProtocolVersion: assembled.manifest.artifact.protocolVersion,
+		hostImageRuntimeFloor: assembled.manifest.runtimeFloor,
+		hostImageFiles: assembled.manifest.artifact.files,
+		hostImageFingerprint: stagedFingerprint,
+		stagedImageDir: staged.imageDir,
+		stagedOutsideInstallationDirectory: true,
+		restagingExistingImageWasNoOp: true,
+		detachedHostLogRedirected: hostLogRedirected,
+		hostPid: state.hostPid,
+		shellPid: state.shellPid,
+		reattachSamePids,
+		hostStopped: true,
+		ffiModuleAvailable: state.ffiModuleAvailable,
+	};
+	writeFileSync(join(buildDir, "native-host-package-proof.json"), `${JSON.stringify(proof, null, 2)}\n`);
+	console.log(
+		`[native-terminal-runtime] verified the ${targetOs} host image ${assembled.tag} at ${proof.hostImageArchivePath}: ` +
+			"staged outside the install root, detached re-entry with no Bun on PATH",
+	);
+} finally {
+	if (!hostStopped && stagedEntrypointForCleanup && existsSync(join(sessionDir, "state.json"))) {
+		const cleanup = spawnSync(
+			stagedEntrypointForCleanup.runtime,
+			[stagedEntrypointForCleanup.entrypoint, "stop"],
+			{ cwd: cleanDir, env: { ...cleanEnv, DEV3_TERMINAL_HOST_PROOF_DIR: sessionDir }, encoding: "utf8", timeout: 15_000 },
+		);
+		if (cleanup.status !== 0) console.error(`[native-terminal-runtime] cleanup failed: ${cleanup.stderr || cleanup.stdout}`);
+	}
+	if (keepProofFiles) console.log(`[native-terminal-runtime] retained manual proof files under ${cleanDir}`);
+	else rmSync(cleanDir, { recursive: true, force: true });
+}

--- a/scripts/verify-packaged-host-resolution.ts
+++ b/scripts/verify-packaged-host-resolution.ts
@@ -1,0 +1,138 @@
+/**
+ * Prove an already-built package resolves its OWN native host image — the exact
+ * thing seq 1311 could not do on macOS.
+ *
+ * Run after `bun run build` (or against any build directory):
+ *
+ *   bun scripts/verify-packaged-host-resolution.ts [buildDir]
+ *
+ * It bundles the resolution probe with `bun build --target=bun` so the resolver
+ * cannot fall back to a source checkout, then runs that bundle under the
+ * PACKAGED Bun runtime with a sanitized environment: no `DEV3_NATIVE_HOST_ENTRYPOINT`,
+ * no Bun on PATH, and a throwaway staging root. A `packaged-image` verdict is
+ * therefore only reachable through the image the package actually ships.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { discoverPackagedImage } from "../src/bun/native-terminal-registry/host-images/packaged-image";
+import {
+	nativeHostPackageLayout,
+	packagedRuntimePathIn,
+} from "../src/bun/native-terminal-registry/host-images/package-layout";
+import type { ManifestOs } from "../src/bun/native-terminal-registry/host-images/artifact-manifest";
+
+const PROBE_MARKER = "DEV3_RESOLUTION_PROBE ";
+
+interface ResolvedRuntimeReport {
+	execPath: string;
+	kind: string;
+	runtimePath: string;
+	entrypointPath: string;
+	imageTag?: string;
+	origin: string;
+}
+
+function currentManifestOs(): ManifestOs {
+	if (process.platform === "win32" || process.platform === "darwin" || process.platform === "linux") return process.platform;
+	throw new Error(`No packaged host image is defined for ${process.platform}.`);
+}
+
+function singleBundleRuntime(buildDir: string, os: ManifestOs): string {
+	const runtimes = readdirSync(buildDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => packagedRuntimePathIn(os, join(buildDir, entry.name)))
+		.filter((path): path is string => path !== null);
+	if (runtimes.length !== 1) {
+		throw new Error(`Expected exactly one built app bundle under ${buildDir}; found ${runtimes.length}.`);
+	}
+	return runtimes[0];
+}
+
+function defaultBuildDir(): string {
+	const buildRoot = resolve(import.meta.dir, "../build");
+	if (!existsSync(buildRoot)) throw new Error(`No build directory at ${buildRoot}; run \`bun run build\` first.`);
+	const candidates = readdirSync(buildRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+	if (candidates.length !== 1) {
+		throw new Error(`${buildRoot} holds ${candidates.length} build directories; pass the one to verify as an argument.`);
+	}
+	return join(buildRoot, candidates[0].name);
+}
+
+const buildDir = resolve(process.argv[2] ?? defaultBuildDir());
+const os = currentManifestOs();
+const layout = nativeHostPackageLayout(os, singleBundleRuntime(buildDir, os));
+
+const shipped = discoverPackagedImage(layout.hostImagePackageRoot);
+if (shipped.status !== "ok") {
+	throw new Error(`This package ships no usable native host image: ${JSON.stringify(shipped)}`);
+}
+
+const workspace = mkdtempSync(join(tmpdir(), "dev3-host-resolution-"));
+try {
+	const probeBundle = join(workspace, "resolution-probe.js");
+	const build = spawnSync(
+		process.execPath,
+		["build", resolve(import.meta.dir, "native-host-resolution-probe.ts"), "--target=bun", "--outfile", probeBundle],
+		{ cwd: resolve(import.meta.dir, ".."), env: process.env, encoding: "utf8" },
+	);
+	if (build.status !== 0) throw new Error(`Failed to bundle the resolution probe.\n${build.stdout}\n${build.stderr}`);
+
+	const stagingRoot = join(workspace, "native-host-images");
+	const probe = spawnSync(layout.runtimePath, [probeBundle], {
+		cwd: workspace,
+		encoding: "utf8",
+		timeout: 60_000,
+		env: {
+			PATH: process.platform === "win32" ? (process.env.PATH ?? "") : ["/usr/bin", "/bin"].join(delimiter),
+			HOME: process.env.HOME,
+			USERPROFILE: process.env.USERPROFILE,
+			SystemRoot: process.env.SystemRoot,
+			TMPDIR: process.env.TMPDIR ?? tmpdir(),
+			DEV3_NATIVE_HOST_IMAGES_DIR: stagingRoot,
+		},
+	});
+	const reportLine = (probe.stdout ?? "")
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.startsWith(PROBE_MARKER));
+	if (!reportLine) {
+		throw new Error(
+			`The packaged runtime could not resolve a native host (exit ${probe.status ?? "none"}).\n` +
+				`stdout: ${probe.stdout}\nstderr: ${probe.stderr}`,
+		);
+	}
+	const resolved = JSON.parse(reportLine.slice(PROBE_MARKER.length)) as ResolvedRuntimeReport;
+
+	if (resolved.kind !== "packaged-image") {
+		throw new Error(`Packaged app resolved a ${resolved.kind} host, not its own packaged image: ${JSON.stringify(resolved)}`);
+	}
+	if (resolved.imageTag !== shipped.tag) {
+		throw new Error(`Packaged app launched image ${resolved.imageTag}, but this package ships ${shipped.tag}.`);
+	}
+	if (!resolved.entrypointPath.startsWith(stagingRoot)) {
+		throw new Error(`Resolved host must run from the staged copy under ${stagingRoot}, not ${resolved.entrypointPath}.`);
+	}
+
+	const proof = {
+		platform: os,
+		buildDir,
+		appBundleRoot: layout.appBundleRoot,
+		shippedImageTag: shipped.tag,
+		shippedImageDir: shipped.imageDir,
+		resolvedKind: resolved.kind,
+		resolvedImageTag: resolved.imageTag,
+		resolvedRuntimePath: resolved.runtimePath,
+		resolvedEntrypointPath: resolved.entrypointPath,
+		resolvedFromStagedCopy: true,
+		probeWasBundled: true,
+		environmentOverrideUsed: false,
+		packagedRuntimeExecPath: resolved.execPath,
+	};
+	writeFileSync(join(buildDir, "native-host-resolution-proof.json"), `${JSON.stringify(proof, null, 2)}\n`);
+	console.log(`[native-terminal-runtime] packaged ${os} app resolved its own host image ${shipped.tag} from ${resolved.entrypointPath}`);
+} finally {
+	rmSync(workspace, { recursive: true, force: true });
+}

--- a/src/bun/__tests__/electrobun-config.test.ts
+++ b/src/bun/__tests__/electrobun-config.test.ts
@@ -21,11 +21,11 @@ describe("electrobun bundled resources", () => {
 });
 
 describe("electrobun packaged Bun runtime", () => {
-	it("pins the global app runtime at or above the ConPTY floor and verifies the packaged Windows host", () => {
+	it("pins the global app runtime at or above the ConPTY floor and packages a native host on every platform", () => {
 		expect(config.build).toHaveProperty("bunVersion");
 		expect(assertPackagedConptyRuntime(config.build.bunVersion)).toBe(config.build.bunVersion);
 		expect(config.scripts).not.toHaveProperty("preBuild");
-		expect(config.scripts.postBuild).toBe("./scripts/verify-packaged-windows-conpty.ts");
+		expect(config.scripts.postBuild).toBe("./scripts/package-native-host.ts");
 		expect(config.build.copy["dist/native"]).toBe("native");
 	});
 

--- a/src/bun/__tests__/native-host-runtime.test.ts
+++ b/src/bun/__tests__/native-host-runtime.test.ts
@@ -18,6 +18,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("../native-terminal-registry/host-images/packaged-image", () => ({
 	PACKAGED_HOST_IMAGE_PARENT: "native-host-image",
+	PACKAGED_HOST_ENTRYPOINT: "dev3-terminal-host.js",
 	discoverPackagedImage: vi.fn(() => ({ status: "absent", reason: "no native-host-image/ in this test package" })),
 	stagePackagedImage: vi.fn(() => ({ status: "failed", tag: null, reason: "not reached" })),
 }));
@@ -42,6 +43,7 @@ import {
 	resolveNativeHostRuntime,
 } from "../native-host-runtime";
 import { discoverPackagedImage } from "../native-terminal-registry/host-images/packaged-image";
+import { nativeHostPackageLayout } from "../native-terminal-registry/host-images/package-layout";
 import { encodeShellLaunchSpec, NATIVE_SESSION_LAUNCH_ENV } from "../native-terminal-registry/shell-launch";
 
 const TEST_ROOT = join(process.env.DEV3_TEST_ROOT ?? "/tmp", "native-host-runtime");
@@ -141,6 +143,15 @@ describe("packaged image lookup", () => {
 		const roots = packagedHostImageRoots();
 		expect(roots.length).toBe(2);
 		expect(join(roots[0], "..")).toBe(roots[1]);
+	});
+
+	it("covers where every platform's packaging hook writes the image", () => {
+		const roots = packagedHostImageRoots();
+
+		// macOS assembles under <bundle>.app/Contents, one level above MacOS/bun.
+		expect(nativeHostPackageLayout("darwin", join(roots[0], "bun")).hostImagePackageRoot).toBe(roots[1]);
+		// Linux and Windows assemble at the bundle root, one level above bin/bun.
+		expect(nativeHostPackageLayout("linux", join(roots[0], "bun")).hostImagePackageRoot).toBe(roots[1]);
 	});
 
 	it("finds an image the Windows package wrote above the runtime's bin/ directory", () => {

--- a/src/bun/native-terminal-host/main.ts
+++ b/src/bun/native-terminal-host/main.ts
@@ -20,7 +20,7 @@ import {
 	type NativeTerminalHostProofState,
 } from "../../shared/native-terminal-runtime";
 import { resolveHostConfig, runHost as runRegistrySessionHost } from "../native-terminal-registry/host";
-import { powerShellInteractiveArgs } from "./pty-proof";
+import { proofShellCommand } from "./pty-proof";
 import { computeTerminalHostReentryArgs, requireLiveTerminalHostState } from "./reentry";
 import { resolvesWithin } from "./wait-with-timeout";
 
@@ -103,10 +103,10 @@ async function runHost(): Promise<void> {
 		// Containment may still use a signed helper; the proof reports this capability.
 	}
 
-	const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
-	if (!systemRoot) throw new Error("Packaged terminal host cannot resolve SystemRoot.");
-	const powershell = join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-	if (!existsSync(powershell)) throw new Error(`Packaged terminal host cannot find PowerShell at ${powershell}.`);
+	const shell = proofShellCommand(process.platform, process.env);
+	if (!existsSync(shell.executable)) {
+		throw new Error(`Packaged terminal host cannot find its proof shell at ${shell.executable}.`);
+	}
 
 	let output = "";
 	let captureStartup = true;
@@ -117,7 +117,7 @@ async function runHost(): Promise<void> {
 	const decoder = new TextDecoder();
 	const proc = (() => {
 		try {
-			return spawn([powershell, ...powerShellInteractiveArgs()], {
+			return spawn([shell.executable, ...shell.args], {
 				cwd: process.cwd(),
 				env: { ...process.env, TERM: "xterm-256color" },
 				terminal: {
@@ -134,7 +134,7 @@ async function runHost(): Promise<void> {
 			throw nativeTerminalSpawnError({
 				platform: process.platform,
 				bunVersion: Bun.version,
-				command: powershell,
+				command: shell.executable,
 				cause,
 			});
 		}
@@ -148,18 +148,18 @@ async function runHost(): Promise<void> {
 		throw nativeTerminalSpawnError({
 			platform: process.platform,
 			bunVersion: Bun.version,
-			command: powershell,
+			command: shell.executable,
 			cause: new Error("Bun.spawn returned without a terminal handle"),
 		});
 	}
 
 	const startup = await resolvesWithin(ptyOutputSeen, 10_000);
-	const powershellPid = proc.pid;
+	const shellPid = proc.pid;
 	captureStartup = false;
 	if (!startup) {
 		proc.kill();
 		throw new Error(
-			`Packaged Bun ${Bun.version} started PowerShell ${proc.pid} but received no Bun.Terminal output. ` +
+			`Packaged Bun ${Bun.version} started ${shell.executable} ${proc.pid} but received no Bun.Terminal output. ` +
 				`Transcript: ${JSON.stringify(output.slice(-2000))}`,
 		);
 	}
@@ -168,14 +168,14 @@ async function runHost(): Promise<void> {
 		marker: NATIVE_TERMINAL_HOST_READY_MARKER,
 		bunVersion: Bun.version,
 		hostPid: process.pid,
-		shellPid: powershellPid,
+		shellPid,
 		executable: process.execPath,
 		entrypoint: process.argv[1],
 		ffiModuleAvailable,
 	});
 
 	while (!existsSync(stopFile())) {
-		if (!isProcessAlive(proc.pid)) throw new Error("PowerShell exited before the detached host stop request.");
+		if (!isProcessAlive(proc.pid)) throw new Error(`${shell.executable} exited before the detached host stop request.`);
 		await delay(50);
 	}
 

--- a/src/bun/native-terminal-host/pty-proof.ts
+++ b/src/bun/native-terminal-host/pty-proof.ts
@@ -1,3 +1,27 @@
+/**
+ * The interactive shell the packaging pty tracer (`__host`) drives. It exists
+ * only to prove a staged packaged image can open a real pty from the packaged
+ * runtime; a product session never comes through here.
+ */
+
+import { join } from "node:path";
+
+export interface ProofShellCommand {
+	executable: string;
+	args: string[];
+}
+
 export function powerShellInteractiveArgs(): string[] {
 	return ["-NoLogo", "-NoProfile"];
+}
+
+/** Windows drives PowerShell from SystemRoot; macOS and Linux get a plain interactive `sh`. */
+export function proofShellCommand(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): ProofShellCommand {
+	if (platform !== "win32") return { executable: "/bin/sh", args: ["-i"] };
+	const systemRoot = env.SystemRoot ?? env.WINDIR;
+	if (!systemRoot) throw new Error("Packaged terminal host cannot resolve SystemRoot.");
+	return {
+		executable: join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+		args: powerShellInteractiveArgs(),
+	};
 }

--- a/src/bun/native-terminal-registry/host-images/PACKAGED-IMAGE.md
+++ b/src/bun/native-terminal-registry/host-images/PACKAGED-IMAGE.md
@@ -53,15 +53,37 @@ The staging root is `hostImagesRootDir()` (`../paths.ts`): an additive
 
 ## Build + verification path
 
-1. `bun run build:native` bundles `dist/native/dev3-terminal-host.js`.
-2. Electrobun `postBuild` → `scripts/verify-packaged-windows-conpty.ts` assembles
-   the image into the bundle, so it ships in the archive, and validates it.
+1. `bun run build:native` bundles `dist/native/dev3-terminal-host.js` — on every
+   platform. Electrobun's `dist/native` copy rule carries it into the package.
+2. Electrobun `postBuild` → `scripts/package-native-host.ts` dispatches by
+   platform. Both branches assemble the image into the bundle so it ships in the
+   archive, then stage it outside the install root and drive a detached host
+   start / reattach / stop with no Bun on PATH.
+   * Windows → `scripts/verify-packaged-windows-conpty.ts`, which additionally
+     asserts the ConPTY process image names and the rollback-beside behaviour.
+   * macOS + Linux → `scripts/package-posix-native-host.ts`.
 3. Electrobun `postPackage` → `scripts/verify-windows-conpty-update-archive.ts`
-   re-enters the same script against the **final `.tar.zst`**: discover, validate
+   re-enters the Windows script against the **final `.tar.zst`**: discover, validate
    archive paths, stage outside the install root, start detached / reattach / stop
    with no Bun on PATH, then stage a second image beside the live one and prove
    the old image is byte-identical and still selectable for rollback.
-4. Everything asserted lands in `windows-conpty-package-proof.json`.
+4. Everything asserted lands in `windows-conpty-package-proof.json`, or in
+   `native-host-package-proof.json` on macOS and Linux.
+
+### Where the image sits, per platform
+
+`package-layout.ts` owns this. The image root must be the packaged runtime's own
+directory or its parent — those are the only two roots `packagedHostImageRoots()`
+probes at launch.
+
+| OS | Packaged runtime | Image root |
+|---|---|---|
+| macOS | `<bundle>.app/Contents/MacOS/bun` | `<bundle>.app/Contents/` |
+| Linux | `<bundle>/bin/bun` | `<bundle>/` |
+| Windows | `<bundle>\bin\bun.exe` | `<bundle>\` |
+
+The runtime carrier inside the image is `dev3-terminal-host.exe` on Windows and
+`dev3-terminal-host` everywhere else.
 
 ## Artifact-manifest CLI
 

--- a/src/bun/native-terminal-registry/host-images/__tests__/package-layout.test.ts
+++ b/src/bun/native-terminal-registry/host-images/__tests__/package-layout.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the packaged host image lands per platform, and the invariant that ties
+ * it to runtime discovery: the image root must be the packaged runtime's own
+ * directory or its parent, because those are the only two roots
+ * `packagedHostImageRoots()` probes.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	manifestArchForElectrobunArch,
+	manifestOsForElectrobunOs,
+	nativeHostPackageLayout,
+	packagedRuntimePathIn,
+	packagedRuntimeFileName,
+} from "../package-layout";
+
+let workspace: string;
+
+beforeEach(() => {
+	workspace = mkdtempSync(join(tmpdir(), "dev3-package-layout-"));
+});
+
+afterEach(() => {
+	rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("Electrobun target tokens", () => {
+	test("maps every supported OS token onto a manifest OS", () => {
+		expect(manifestOsForElectrobunOs("macos")).toBe("darwin");
+		expect(manifestOsForElectrobunOs("linux")).toBe("linux");
+		expect(manifestOsForElectrobunOs("win")).toBe("win32");
+	});
+
+	test("refuses an unknown or missing OS token instead of guessing", () => {
+		expect(() => manifestOsForElectrobunOs(undefined)).toThrow(/Unsupported ELECTROBUN_OS/);
+		expect(() => manifestOsForElectrobunOs("darwin")).toThrow(/Unsupported ELECTROBUN_OS/);
+	});
+
+	test("treats anything that is not arm64 as x64", () => {
+		expect(manifestArchForElectrobunArch("arm64")).toBe("arm64");
+		expect(manifestArchForElectrobunArch("x64")).toBe("x64");
+		expect(manifestArchForElectrobunArch(undefined)).toBe("x64");
+	});
+});
+
+describe("nativeHostPackageLayout", () => {
+	test("puts the macOS image under Contents/, beside MacOS/ and Resources/", () => {
+		const layout = nativeHostPackageLayout("darwin", "/b/dev-3.0.app/Contents/MacOS/bun");
+
+		expect(layout.appBundleRoot).toBe("/b/dev-3.0.app");
+		expect(layout.hostImagePackageRoot).toBe("/b/dev-3.0.app/Contents");
+		expect(layout.entrypointPath).toBe("/b/dev-3.0.app/Contents/Resources/app/native/dev3-terminal-host.js");
+	});
+
+	test.each([
+		["linux", "/b/dev-3.0/bin/bun"],
+		["win32", "/b/dev-3.0/bin/bun.exe"],
+	] as const)("puts the %s image at the bundle root, one level above bin/", (os, runtimePath) => {
+		const layout = nativeHostPackageLayout(os, runtimePath);
+
+		expect(layout.appBundleRoot).toBe("/b/dev-3.0");
+		expect(layout.hostImagePackageRoot).toBe("/b/dev-3.0");
+		expect(layout.entrypointPath).toBe("/b/dev-3.0/Resources/app/native/dev3-terminal-host.js");
+	});
+
+	test.each([
+		["darwin", "/b/dev-3.0.app/Contents/MacOS/bun"],
+		["linux", "/b/dev-3.0/bin/bun"],
+		["win32", "/b/dev-3.0/bin/bun.exe"],
+	] as const)("keeps the %s image root reachable from the runtime's directory or its parent", (os, runtimePath) => {
+		const layout = nativeHostPackageLayout(os, runtimePath);
+		const runtimeDir = dirname(runtimePath);
+
+		// Mirrors packagedHostImageRoots(): beside the runtime, then one level up.
+		expect([runtimeDir, dirname(runtimeDir)]).toContain(layout.hostImagePackageRoot);
+	});
+});
+
+describe("packagedRuntimePathIn", () => {
+	function bundleWithRuntime(name: string, relativeRuntime: string): string {
+		const bundleRoot = join(workspace, name);
+		const runtimePath = join(bundleRoot, relativeRuntime);
+		mkdirSync(dirname(runtimePath), { recursive: true });
+		writeFileSync(runtimePath, "bun");
+		return bundleRoot;
+	}
+
+	test("finds the macOS runtime inside Contents/MacOS", () => {
+		const bundleRoot = bundleWithRuntime("dev-3.0.app", join("Contents", "MacOS", "bun"));
+		expect(packagedRuntimePathIn("darwin", bundleRoot)).toBe(join(bundleRoot, "Contents", "MacOS", "bun"));
+	});
+
+	test("finds the Linux runtime inside bin/", () => {
+		const bundleRoot = bundleWithRuntime("dev-3.0", join("bin", "bun"));
+		expect(packagedRuntimePathIn("linux", bundleRoot)).toBe(join(bundleRoot, "bin", "bun"));
+	});
+
+	test("reports a miss instead of searching a second location", () => {
+		const bundleRoot = bundleWithRuntime("dev-3.0", join("bin", "bun"));
+		expect(packagedRuntimePathIn("darwin", bundleRoot)).toBeNull();
+	});
+
+	test("names the runtime binary the way each platform ships it", () => {
+		expect(packagedRuntimeFileName("win32")).toBe("bun.exe");
+		expect(packagedRuntimeFileName("darwin")).toBe("bun");
+		expect(packagedRuntimeFileName("linux")).toBe("bun");
+	});
+});

--- a/src/bun/native-terminal-registry/host-images/__tests__/package-runtime.test.ts
+++ b/src/bun/native-terminal-registry/host-images/__tests__/package-runtime.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The whole packaging path over a synthesized Electrobun bundle, per platform:
+ * find the packaged runtime → derive the layout → assemble the image into the
+ * bundle → discover it the way an installed app does → stage it outside the
+ * install root.
+ *
+ * macOS is also covered for real by `scripts/package-posix-native-host.ts` on
+ * every build. Linux and Windows have no build machine here, so this is where
+ * their bundle shape is held to the same contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import type { ManifestArch, ManifestOs } from "../artifact-manifest";
+import {
+	discoverPackagedImage,
+	assemblePackagedImage,
+	isInsideDirectory,
+	stagePackagedImage,
+	packagedHostRuntimeCarrier,
+	PACKAGED_HOST_ENTRYPOINT,
+	PACKAGED_HOST_IMAGE_PARENT,
+} from "../packaged-image";
+import { nativeHostPackageLayout, packagedRuntimePathIn, packagedRuntimeFileName } from "../package-layout";
+
+const BUN_VERSION = "1.3.14";
+const PROTOCOL_VERSION = 1;
+
+let workspace: string;
+
+beforeEach(() => {
+	workspace = mkdtempSync(join(tmpdir(), "dev3-package-runtime-"));
+});
+
+afterEach(() => {
+	rmSync(workspace, { recursive: true, force: true });
+});
+
+interface BundleShape {
+	os: ManifestOs;
+	arch: ManifestArch;
+	bundleName: string;
+	runtimeRelativePath: string;
+	entrypointRelativePath: string;
+	expectedImageArchivePath: string;
+}
+
+const SHAPES: BundleShape[] = [
+	{
+		os: "darwin",
+		arch: "arm64",
+		bundleName: "dev-3.0.app",
+		runtimeRelativePath: join("Contents", "MacOS", "bun"),
+		entrypointRelativePath: join("Contents", "Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
+		expectedImageArchivePath: join("Contents", PACKAGED_HOST_IMAGE_PARENT),
+	},
+	{
+		os: "linux",
+		arch: "x64",
+		bundleName: "dev-3.0",
+		runtimeRelativePath: join("bin", "bun"),
+		entrypointRelativePath: join("Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
+		expectedImageArchivePath: PACKAGED_HOST_IMAGE_PARENT,
+	},
+	{
+		os: "win32",
+		arch: "x64",
+		bundleName: "dev-3.0",
+		runtimeRelativePath: join("bin", "bun.exe"),
+		entrypointRelativePath: join("Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
+		expectedImageArchivePath: PACKAGED_HOST_IMAGE_PARENT,
+	},
+];
+
+/** A build directory holding one bundle, shaped exactly the way Electrobun emits it. */
+function buildBundle(shape: BundleShape): { buildDir: string; bundleRoot: string } {
+	const buildDir = join(workspace, `build-${shape.os}`);
+	const bundleRoot = join(buildDir, shape.bundleName);
+	for (const [relativePath, contents, mode] of [
+		[shape.runtimeRelativePath, `bun-${shape.os}-${shape.arch}`, 0o755],
+		[shape.entrypointRelativePath, "console.log('host');\n", 0o644],
+	] as const) {
+		const path = join(bundleRoot, relativePath);
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, contents, { mode });
+	}
+	return { buildDir, bundleRoot };
+}
+
+describe.each(SHAPES)("$os package", (shape) => {
+	test("assembles, discovers, and stages the image the installed app will launch", () => {
+		const { bundleRoot } = buildBundle(shape);
+
+		const runtimePath = packagedRuntimePathIn(shape.os, bundleRoot);
+		expect(runtimePath).toBe(join(bundleRoot, shape.runtimeRelativePath));
+		const layout = nativeHostPackageLayout(shape.os, runtimePath!);
+		expect(layout.appBundleRoot).toBe(bundleRoot);
+		expect(layout.entrypointPath).toBe(join(bundleRoot, shape.entrypointRelativePath));
+
+		const assembled = assemblePackagedImage({
+			packageRoot: layout.hostImagePackageRoot,
+			runtimeSourcePath: layout.runtimePath,
+			entrypointSourcePath: layout.entrypointPath,
+			hostVersion: "1.41.0",
+			protocolVersion: PROTOCOL_VERSION,
+			bunVersion: BUN_VERSION,
+			runtimeFloor: BUN_VERSION,
+			os: shape.os,
+			arch: shape.arch,
+		});
+		expect(relative(bundleRoot, dirname(assembled.imageDir))).toBe(shape.expectedImageArchivePath);
+		expect(assembled.manifest.runtimeCarrier).toBe(packagedHostRuntimeCarrier(shape.os));
+		expect(assembled.manifest.archiveRoot).toBe(`${PACKAGED_HOST_IMAGE_PARENT}/${assembled.tag}`);
+
+		// The installed app looks in exactly this root; anything else is unreachable.
+		const expectations = { os: shape.os, arch: shape.arch, bunVersion: BUN_VERSION, protocolVersion: PROTOCOL_VERSION, archiveParent: PACKAGED_HOST_IMAGE_PARENT };
+		const discovered = discoverPackagedImage(layout.hostImagePackageRoot, expectations);
+		expect(discovered.status).toBe("ok");
+		if (discovered.status !== "ok") return;
+
+		const stagingRoot = join(workspace, `staging-${shape.os}`);
+		const staged = stagePackagedImage({ sourceImageDir: discovered.imageDir, stagingRoot, expectations });
+		expect(staged.status).toBe("staged");
+		if (staged.status !== "staged") return;
+		expect(isInsideDirectory(layout.appBundleRoot, staged.imageDir)).toBe(false);
+		expect(readFileSync(staged.runtimeCarrierPath, "utf8")).toBe(`bun-${shape.os}-${shape.arch}`);
+		expect(statSync(staged.runtimeCarrierPath).mode & 0o111).not.toBe(0);
+	});
+
+	test("names the runtime and its carrier the way this platform can execute them", () => {
+		expect(packagedRuntimeFileName(shape.os)).toBe(shape.os === "win32" ? "bun.exe" : "bun");
+		expect(packagedHostRuntimeCarrier(shape.os)).toBe(shape.os === "win32" ? "dev3-terminal-host.exe" : "dev3-terminal-host");
+	});
+
+	test("a bundle built without `bun run build:native` has no host to package", () => {
+		const { bundleRoot } = buildBundle(shape);
+		rmSync(join(bundleRoot, shape.entrypointRelativePath));
+
+		const layout = nativeHostPackageLayout(shape.os, packagedRuntimePathIn(shape.os, bundleRoot)!);
+		expect(() =>
+			assemblePackagedImage({
+				packageRoot: layout.hostImagePackageRoot,
+				runtimeSourcePath: layout.runtimePath,
+				entrypointSourcePath: layout.entrypointPath,
+				hostVersion: "1.41.0",
+				protocolVersion: PROTOCOL_VERSION,
+				bunVersion: BUN_VERSION,
+				runtimeFloor: BUN_VERSION,
+				os: shape.os,
+				arch: shape.arch,
+			}),
+		).toThrow();
+		expect(discoverPackagedImage(layout.hostImagePackageRoot, {}).status).not.toBe("ok");
+	});
+});

--- a/src/bun/native-terminal-registry/host-images/__tests__/packaged-image.test.ts
+++ b/src/bun/native-terminal-registry/host-images/__tests__/packaged-image.test.ts
@@ -17,7 +17,7 @@ import {
 	listPackagedImages,
 	PACKAGED_HOST_ENTRYPOINT,
 	PACKAGED_HOST_IMAGE_PARENT,
-	PACKAGED_HOST_RUNTIME_CARRIER,
+	packagedHostRuntimeCarrier,
 	readPackagedImage,
 	selectPackagedImage,
 	stagePackagedImage,
@@ -79,12 +79,12 @@ describe("assemblePackagedImage", () => {
 		expect(image.reused).toBe(false);
 		expect(image.tag.startsWith("1.3.14-p1-")).toBe(true);
 		expect(image.manifest.archiveRoot).toBe(`${PACKAGED_HOST_IMAGE_PARENT}/${image.tag}`);
-		expect(image.manifest.runtimeCarrier).toBe(PACKAGED_HOST_RUNTIME_CARRIER);
+		expect(image.manifest.runtimeCarrier).toBe("dev3-terminal-host.exe");
 		expect(image.manifest.artifact.entrypoint).toBe(PACKAGED_HOST_ENTRYPOINT);
 		expect(existsSync(image.entrypointPath)).toBe(true);
 		expect(existsSync(image.runtimeCarrierPath)).toBe(true);
 		expect(image.manifest.artifact.files.map((entry) => entry.path).sort()).toEqual(
-			[PACKAGED_HOST_ENTRYPOINT, PACKAGED_HOST_RUNTIME_CARRIER].sort(),
+			[PACKAGED_HOST_ENTRYPOINT, "dev3-terminal-host.exe"].sort(),
 		);
 	});
 
@@ -322,5 +322,47 @@ describe("selectPackagedImage", () => {
 		const selection = selectPackagedImage(stagingRoot, { protocolVersion: 1 });
 		expect(selection.status).toBe("ambiguous");
 		if (selection.status === "ambiguous") expect(selection.tags).toHaveLength(2);
+	});
+});
+
+describe("cross-platform images", () => {
+	test("the runtime carrier is extensionless everywhere except Windows", () => {
+		expect(packagedHostRuntimeCarrier("win32")).toBe("dev3-terminal-host.exe");
+		expect(packagedHostRuntimeCarrier("darwin")).toBe("dev3-terminal-host");
+		expect(packagedHostRuntimeCarrier("linux")).toBe("dev3-terminal-host");
+	});
+
+	test.each([
+		["darwin", "arm64"],
+		["linux", "x64"],
+	] as const)("assembles and discovers a %s/%s image", (os, arch) => {
+		const packageRoot = newPackageRoot(`${os}-${arch}`);
+		const image = assemblePackagedImage(assembleInput(packageRoot, writeSources(`${os}-${arch}`), { os, arch }));
+
+		expect(image.manifest.runtimeCarrier).toBe("dev3-terminal-host");
+		expect(image.manifest.artifact.os).toBe(os);
+		expect(image.manifest.artifact.files.map((entry) => entry.path).sort()).toEqual(
+			[PACKAGED_HOST_ENTRYPOINT, "dev3-terminal-host"].sort(),
+		);
+
+		const discovered = discoverPackagedImage(packageRoot, { os, arch, archiveParent: PACKAGED_HOST_IMAGE_PARENT });
+		expect(discovered.status).toBe("ok");
+		if (discovered.status === "ok") expect(discovered.tag).toBe(image.tag);
+	});
+
+	test("an image built for another OS is rejected rather than adapted", () => {
+		const packageRoot = newPackageRoot("wrong-os");
+		assemblePackagedImage(assembleInput(packageRoot, writeSources("wrong-os"), { os: "darwin", arch: "arm64" }));
+
+		const discovered = discoverPackagedImage(packageRoot, { os: "linux", arch: "arm64" });
+		expect(discovered.status).toBe("partial");
+		if (discovered.status === "partial") expect(discovered.reason).toMatch(/os is darwin, expected linux/);
+	});
+
+	test("the same bytes on two platforms are two different images", () => {
+		const sources = writeSources("shared-bytes");
+		const mac = assemblePackagedImage(assembleInput(newPackageRoot("m"), sources, { os: "darwin", arch: "arm64" }));
+		const win = assemblePackagedImage(assembleInput(newPackageRoot("w"), sources, { os: "win32", arch: "arm64" }));
+		expect(mac.tag).not.toBe(win.tag);
 	});
 });

--- a/src/bun/native-terminal-registry/host-images/package-layout.ts
+++ b/src/bun/native-terminal-registry/host-images/package-layout.ts
@@ -1,0 +1,97 @@
+/**
+ * Where a packaged native host image lives inside an Electrobun bundle, per OS.
+ *
+ * Electrobun emits three different shapes, and the packaged-image contract has
+ * exactly one hard constraint: the directory the image is written under must be
+ * one of the roots {@link packagedHostImageRoots} probes at runtime — the
+ * directory holding the packaged Bun runtime, or its parent.
+ *
+ *   macOS    <bundle>.app/Contents/MacOS/bun      → image root <bundle>.app/Contents
+ *   Linux    <bundle>/bin/bun                     → image root <bundle>
+ *   Windows  <bundle>\bin\bun.exe                 → image root <bundle>
+ *
+ * On macOS that deliberately puts `native-host-image/` beside `MacOS/` and
+ * `Resources/` rather than inside `Resources/app/`: the app directory is what
+ * Electrobun would pack into an asar, and an image inside an archive cannot be
+ * executed. `Contents/` is also the only place the runtime resolver can reach
+ * without a darwin-specific probe.
+ *
+ * `appBundleRoot` is the single top-level entry Electrobun puts into the
+ * `.tar.zst` update archive; on macOS it is NOT the image root, which is why the
+ * two are separate fields.
+ *
+ * Pure node:path except for one small `existsSync` probe, so it unit-tests
+ * without a build.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { ManifestArch, ManifestOs } from "./artifact-manifest";
+import { PACKAGED_HOST_ENTRYPOINT } from "./packaged-image";
+
+/** Electrobun's own OS token (`ELECTROBUN_OS`) → the manifest's `ManifestOs`. */
+export function manifestOsForElectrobunOs(electrobunOs: string | undefined): ManifestOs {
+	if (electrobunOs === "macos") return "darwin";
+	if (electrobunOs === "linux") return "linux";
+	if (electrobunOs === "win") return "win32";
+	throw new Error(`Unsupported ELECTROBUN_OS ${JSON.stringify(electrobunOs ?? "")}; expected macos, linux, or win.`);
+}
+
+/** `ELECTROBUN_ARCH` → the manifest's `ManifestArch`; anything unknown is x64. */
+export function manifestArchForElectrobunArch(electrobunArch: string | undefined): ManifestArch {
+	return electrobunArch === "arm64" ? "arm64" : "x64";
+}
+
+/** Filename of the Bun runtime Electrobun copies into the bundle. */
+export function packagedRuntimeFileName(os: ManifestOs): string {
+	return os === "win32" ? "bun.exe" : "bun";
+}
+
+export interface NativeHostPackageLayout {
+	/** Top-level directory Electrobun puts into the update archive. */
+	appBundleRoot: string;
+	/** Directory whose `native-host-image/` the image is assembled into. */
+	hostImagePackageRoot: string;
+	/** Packaged Bun runtime, copied into the image as its runtime carrier. */
+	runtimePath: string;
+	/** Bundled host entrypoint, copied from `dist/native/` by the Electrobun copy rules. */
+	entrypointPath: string;
+}
+
+/**
+ * Derive the whole layout from the packaged runtime's own path. Everything else
+ * in the bundle is at a fixed offset from it, so there is nothing to search for
+ * and nothing to guess.
+ */
+export function nativeHostPackageLayout(os: ManifestOs, runtimePath: string): NativeHostPackageLayout {
+	const runtime = resolve(runtimePath);
+	const runtimeDir = dirname(runtime);
+	if (os === "darwin") {
+		const contentsDir = dirname(runtimeDir); // <bundle>.app/Contents
+		return {
+			appBundleRoot: dirname(contentsDir),
+			hostImagePackageRoot: contentsDir,
+			runtimePath: runtime,
+			entrypointPath: join(contentsDir, "Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
+		};
+	}
+	const bundleRoot = dirname(runtimeDir); // <bundle>/bin → <bundle>
+	return {
+		appBundleRoot: bundleRoot,
+		hostImagePackageRoot: bundleRoot,
+		runtimePath: runtime,
+		entrypointPath: join(bundleRoot, "Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
+	};
+}
+
+/**
+ * The packaged runtime inside `bundleRoot`, or `null` when this build shape does
+ * not carry one. Callers report the miss; guessing a second location is how the
+ * Windows image ended up unreachable once already.
+ */
+export function packagedRuntimePathIn(os: ManifestOs, bundleRoot: string): string | null {
+	const relativePath =
+		os === "darwin" ? join("Contents", "MacOS", packagedRuntimeFileName(os)) : join("bin", packagedRuntimeFileName(os));
+	const candidate = join(resolve(bundleRoot), relativePath);
+	return existsSync(candidate) ? candidate : null;
+}

--- a/src/bun/native-terminal-registry/host-images/packaged-image.ts
+++ b/src/bun/native-terminal-registry/host-images/packaged-image.ts
@@ -48,8 +48,14 @@ import {
 
 /** Directory, inside the package/archive, that holds every packaged host image. */
 export const PACKAGED_HOST_IMAGE_PARENT = "native-host-image";
-/** Bun runtime carrier filename inside an image — also the detached host's process image name. */
-export const PACKAGED_HOST_RUNTIME_CARRIER = "dev3-terminal-host.exe";
+/**
+ * Bun runtime carrier filename inside an image — also the detached host's
+ * process image name. Windows refuses to execute an extensionless binary and
+ * reports this name in Task Manager; macOS and Linux want no extension.
+ */
+export function packagedHostRuntimeCarrier(os: ManifestOs): string {
+	return os === "win32" ? "dev3-terminal-host.exe" : "dev3-terminal-host";
+}
 /** Bundled host entrypoint filename inside an image. */
 export const PACKAGED_HOST_ENTRYPOINT = "dev3-terminal-host.js";
 
@@ -103,14 +109,15 @@ export function assemblePackagedImage(input: AssemblePackagedImageInput): Assemb
 	const parentDir = join(input.packageRoot, PACKAGED_HOST_IMAGE_PARENT);
 	mkdirSync(parentDir, { recursive: true });
 	const scratchDir = mkdtempSync(join(parentDir, ".assemble-"));
+	const runtimeCarrier = packagedHostRuntimeCarrier(input.os);
 	try {
-		copyFileSync(input.runtimeSourcePath, join(scratchDir, PACKAGED_HOST_RUNTIME_CARRIER));
+		copyFileSync(input.runtimeSourcePath, join(scratchDir, runtimeCarrier));
 		copyFileSync(input.entrypointSourcePath, join(scratchDir, PACKAGED_HOST_ENTRYPOINT));
 		const manifest = buildPackagedHostImageManifest({
 			imageRoot: scratchDir,
 			entrypoint: PACKAGED_HOST_ENTRYPOINT,
-			runtimeCarrier: PACKAGED_HOST_RUNTIME_CARRIER,
-			files: [PACKAGED_HOST_RUNTIME_CARRIER, PACKAGED_HOST_ENTRYPOINT],
+			runtimeCarrier,
+			files: [runtimeCarrier, PACKAGED_HOST_ENTRYPOINT],
 			metadata: {
 				hostVersion: input.hostVersion,
 				protocolVersion: input.protocolVersion,


### PR DESCRIPTION
## Summary

The experimental native terminal backend could not start from a packaged macOS or Linux build. `scripts/build-windows-terminal-host.ts` exited outside win32, so no `dist/native/dev3-terminal-host.js` was ever bundled, and the Electrobun `postBuild` hook that assembles `native-host-image/` was Windows-only. `resolveNativeHostRuntime()` therefore had nothing to find and an explicitly-native task sat in Preparing behind an honest `NativeHostRuntimeError` (seq 1311).

This makes the immutable host image ship and resolve on macOS and Linux while leaving the Windows artifact contract byte-for-byte alone.

- `build-terminal-host.ts` (renamed) bundles the host on every platform.
- `host-images/package-layout.ts` derives the per-OS image root from the packaged runtime's own path: macOS `<bundle>.app/Contents/`, Linux and Windows `<bundle>/`. Both are already probed by `packagedHostImageRoots()`, so `resolveNativeHostRuntime()` needed no change. Recorded in `decisions/182`, including the future codesigning risk of the `Contents/` placement.
- `packagedHostRuntimeCarrier(os)` replaces the hardcoded carrier name: `dev3-terminal-host.exe` on Windows (the Task Manager image-name contract), extensionless elsewhere.
- `postBuild` now points at `scripts/package-native-host.ts`, which dispatches to the unchanged Windows ConPTY proof or to the new `package-posix-native-host.ts`. The POSIX side assembles the image, stages it outside the install root, and drives a detached start / reattach / stop with no Bun on PATH.
- The `__host` packaging tracer drives PowerShell on Windows and `/bin/sh -i` elsewhere. The product `session-host` path is untouched.
- `scripts/verify-packaged-host-resolution.ts` runs a `bun build --target=bun` probe under the packaged runtime, so a `packaged-image` verdict cannot come from a source checkout or an env override. CI gains a `posix-app-package` job that builds the real macOS and Linux packages and runs it.

Terminal backend defaults, task stamping, live-session ownership, fallback rules, and tmux behaviour are unchanged. Native stays explicitly opt-in; a missing or invalid image still fails loudly and never touches tmux.

## Verification

- `bun run lint` and the full `bun run test` green after rebase (7 879 tests).
- Real macOS build: `postBuild` assembled image `1.3.14-p1-141635a7683d` at `Contents/native-host-image/`, staged it outside the bundle, and completed the detached lifecycle with `PATH=/usr/bin:/bin`.
- `bun scripts/verify-packaged-host-resolution.ts`: the packaged app resolved its own image, `kind=packaged-image`, from the staged copy.
- The product native task-terminal E2E run under the packaged runtime (`Contents/MacOS/bun`) passed end to end with `runtime: "packaged-image"` — real task terminals launched from the staged image.
- Windows was not re-run locally; its script, fixture, archive proof, and `.exe` carrier name are unchanged and covered by the existing CI jobs plus a test asserting the carrier name per OS.