### PR TITLE
fix: always default diff comparison to origin/<base> when it exists

### DIFF
--- a/change-logs/2026/07/30/fix-default-compare-ref-remote.md
+++ b/change-logs/2026/07/30/fix-default-compare-ref-remote.md
@@ -1,0 +1,3 @@
+Short: Diff defaults to origin/main again
+
+New projects with a single committer no longer default their diff comparison to the local base branch — when `origin/<base>` exists it always wins, so freshly cloned repos compare against `origin/main` instead of a local `main` that dev3 never fast-forwards.

--- a/decisions/067-background-polling-read-caches.md
+++ b/decisions/067-background-polling-read-caches.md
@@ -10,7 +10,7 @@ Four independent caches, all in the bun process:
 
 1. **`src/bun/data.ts`** — mtime+size stat-validated cache for `loadProjects()`/`loadTasks()`. `stat()` is taken *before* `readFile` so a concurrent write can only over-invalidate, never serve stale. Cache hits return shallow copies (`{...item}`); mutator paths (`strict`/`persistMigrations`) bypass the cache; saves invalidate it.
 2. **`src/bun/git.ts` `fetchOrigin`** — exponential failure backoff (2 min base, doubling, 30 min cap) per `projectPath:branch` key, cleared on success.
-3. **`src/bun/git.ts` `detectDefaultCompareRef`** — 10 min TTL promise cache keyed on `projectPath\0baseBranch` (it runs `git shortlog` over 2 weeks of history on every `resolveProjectConfig`).
+3. **`src/bun/git.ts` `detectDefaultCompareRef`** — 10 min TTL promise cache keyed on `projectPath\0baseBranch` (it spawns several git commands on every `resolveProjectConfig`; the 2-week `git shortlog` scan it originally ran was dropped in decision 183).
 4. **`src/bun/github.ts`** — `gh auth status` cached 60s (only the `authenticated` result, so a fresh `gh auth login` is visible immediately) and `gh auth token` cached 5 min per host+login.
 
 ## Risks

--- a/decisions/183-default-compare-ref-always-remote.md
+++ b/decisions/183-default-compare-ref-always-remote.md
@@ -1,0 +1,26 @@
+# 183 — Default compare ref is always `origin/<base>` when the remote ref exists
+
+## Context
+
+`detectDefaultCompareRef` (`src/bun/git.ts`) picks the diff/rebase/branch-status comparison target for a project when nothing configures it explicitly. Since #338 it ran `git shortlog -sne --since="2 weeks ago"` and, if the base branch had **one or fewer distinct committer emails**, returned the *local* base branch instead of `origin/<base>` — the assumption being that a solo repo's local `main` is as good as the remote one.
+
+That assumption is wrong in dev3. dev3 fetches `origin` but never fast-forwards the main clone's local base branch, so local `main` drifts behind after the first merged PR and every diff/"N commits ahead" readout silently compares against stale history. A freshly cloned solo repo hits this immediately: comparison default resolves to `main`, not `origin/main` (reported for a project cloned over SSH).
+
+## Investigation
+
+The heuristic also mis-fires on committer identity: `parseRecentCommitters` dedupes by lowercased email, so `Arseniy Pavlenko <h0x91b@gmail.com>` + `h0x91B <h0x91b@gmail.com>` collapses to one committer even when the repo has real history. Reproduced on the reporter's repo — shortlog printed two author lines, one email, so the "solo" branch was taken.
+
+## Decision
+
+Removed the committer heuristic and `parseRecentCommitters` entirely. `detectDefaultCompareRef` now resolves in order: `origin/<base>` if it exists → `origin/main` / `origin/master` if an `origin` remote has them → the local base branch as last resort. The existing side effect that points the local base branch's upstream at `origin/<base>` (for `main`/`master`) is unchanged. Users who want local comparison still set `defaultCompareRef` / `defaultCompareRefMode: "local"` explicitly.
+
+## Risks
+
+- Repos with an `origin` that is never fetched (offline/archived remotes) now compare against a stale remote ref instead of a live local branch. Acceptable: dev3 fetches origin on its own poll cycle, and the explicit config escape hatch exists.
+- Existing projects that already persisted the auto-detected `main` into `projects.json` or `.dev3/config.json` keep it — the change only affects unset projects, by design (an on-disk value is a user choice).
+
+## Alternatives considered
+
+- Keep the heuristic but fix the email dedupe (count commits, not identities): still leaves solo repos comparing against a branch dev3 never updates.
+- Auto fast-forward the main clone's local base branch on fetch: touches the user's checkout behind their back; rejected.
+- Default `defaultCompareRefMode: "remote"` in `DEFAULTS` and drop detection: loses the `origin/main` fallback for a repo whose configured base branch has no remote counterpart.

--- a/src/bun/__tests__/git-branch-ops.test.ts
+++ b/src/bun/__tests__/git-branch-ops.test.ts
@@ -656,40 +656,52 @@ describe("listBranches", () => {
 // ─── detectDefaultCompareRef ────────────────────────────────────────────────
 
 describe("detectDefaultCompareRef", () => {
-	it("prefers local main when the last two weeks have one committer", async () => {
+	it("prefers origin/main even when a single committer owns the repo", async () => {
 		queueResponse(0, "origin\n"); // remotes
 		queueResponse(0, "abc123\n"); // rev-parse --verify origin/main
 		queueResponse(0, "abc123\n"); // rev-parse --verify main
 		queueResponse(0, ""); // branch --set-upstream-to origin/main main
-		queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n    2 h0x91B <H0X91B@gmail.com>\n"); // shortlog
-
-		const ref = await detectDefaultCompareRef("/repo", "main");
-
-		expect(ref).toBe("main");
-	});
-
-	it("prefers origin/main when there are multiple recent committers and a remote main exists", async () => {
-		queueResponse(0, "origin\n"); // remotes
-		queueResponse(0, "abc123\n"); // rev-parse --verify origin/main
-		queueResponse(0, "def456\n"); // rev-parse --verify main
-		queueResponse(0, ""); // branch --set-upstream-to origin/main main
-		queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n    3 roi <roir@wix.com>\n"); // shortlog
 
 		const ref = await detectDefaultCompareRef("/repo", "main");
 
 		expect(ref).toBe("origin/main");
 	});
 
-	it("uses origin/master when master is the collaborative base branch", async () => {
+	it("tracks the local base branch against origin when it does not exist yet", async () => {
+		queueResponse(0, "origin\n"); // remotes
+		queueResponse(0, "abc123\n"); // rev-parse --verify origin/main
+		queueResponse(128, "", "fatal: ambiguous argument 'main'"); // rev-parse --verify main
+		queueResponse(0, ""); // branch --track main origin/main
+
+		expect(await detectDefaultCompareRef("/repo", "main")).toBe("origin/main");
+		expect(spawnResponses).toHaveLength(0);
+	});
+
+	it("uses origin/master when master is the base branch", async () => {
 		queueResponse(0, "origin\n"); // remotes
 		queueResponse(0, "abc123\n"); // rev-parse --verify origin/master
 		queueResponse(128, "", "fatal: ambiguous argument 'master'"); // rev-parse --verify master
 		queueResponse(0, ""); // branch --track master origin/master
-		queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n    3 roi <roir@wix.com>\n"); // shortlog
 
 		const ref = await detectDefaultCompareRef("/repo", "master");
 
 		expect(ref).toBe("origin/master");
+	});
+
+	it("falls back to the local base branch when there is no origin remote", async () => {
+		queueResponse(0, "\n"); // remotes — none
+		queueResponse(0, "abc123\n"); // rev-parse --verify main
+
+		expect(await detectDefaultCompareRef("/repo", "main")).toBe("main");
+	});
+
+	it("falls back to origin/main when the configured base branch has no remote ref", async () => {
+		queueResponse(0, "origin\n"); // remotes
+		queueResponse(128, "", "fatal"); // rev-parse --verify origin/develop
+		queueResponse(0, "abc123\n"); // rev-parse --verify develop
+		queueResponse(0, "abc123\n"); // rev-parse --verify origin/main
+
+		expect(await detectDefaultCompareRef("/repo", "develop")).toBe("origin/main");
 	});
 
 	it("caches the result for repeated calls (no extra git spawns)", async () => {
@@ -697,23 +709,19 @@ describe("detectDefaultCompareRef", () => {
 		queueResponse(0, "abc123\n"); // rev-parse --verify origin/main
 		queueResponse(0, "abc123\n"); // rev-parse --verify main
 		queueResponse(0, ""); // branch --set-upstream-to origin/main main
-		queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n"); // shortlog
 
 		const first = await detectDefaultCompareRef("/repo", "main");
-		expect(first).toBe("main");
+		expect(first).toBe("origin/main");
 		expect(spawnResponses).toHaveLength(0);
 
 		// Second call hits the cache — nothing queued, no spawn attempted
 		const second = await detectDefaultCompareRef("/repo", "main");
-		expect(second).toBe("main");
+		expect(second).toBe("origin/main");
 	});
 
 	it("caches per projectPath+baseBranch key", async () => {
-		queueResponse(0, "origin\n");
+		queueResponse(0, "\n");
 		queueResponse(0, "abc123\n");
-		queueResponse(0, "abc123\n");
-		queueResponse(0, "");
-		queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n");
 		expect(await detectDefaultCompareRef("/repo", "main")).toBe("main");
 
 		// Different repo: full detection runs again
@@ -721,7 +729,6 @@ describe("detectDefaultCompareRef", () => {
 		queueResponse(0, "abc123\n");
 		queueResponse(0, "def456\n");
 		queueResponse(0, "");
-		queueResponse(0, "   10 a <a@x.com>\n    3 b <b@x.com>\n");
 		expect(await detectDefaultCompareRef("/other-repo", "main")).toBe("origin/main");
 		expect(spawnResponses).toHaveLength(0);
 	});
@@ -729,11 +736,8 @@ describe("detectDefaultCompareRef", () => {
 	it("expires the cache after the TTL", async () => {
 		vi.useFakeTimers({ toFake: ["Date"] });
 		try {
-			queueResponse(0, "origin\n");
+			queueResponse(0, "\n");
 			queueResponse(0, "abc123\n");
-			queueResponse(0, "abc123\n");
-			queueResponse(0, "");
-			queueResponse(0, "   10 Arseniy Pavlenko <h0x91b@gmail.com>\n");
 			expect(await detectDefaultCompareRef("/repo", "main")).toBe("main");
 
 			vi.setSystemTime(Date.now() + 11 * 60_000);
@@ -742,7 +746,6 @@ describe("detectDefaultCompareRef", () => {
 			queueResponse(0, "abc123\n");
 			queueResponse(0, "def456\n");
 			queueResponse(0, "");
-			queueResponse(0, "   10 a <a@x.com>\n    3 b <b@x.com>\n");
 			expect(await detectDefaultCompareRef("/repo", "main")).toBe("origin/main");
 			expect(spawnResponses).toHaveLength(0);
 		} finally {

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1225,22 +1225,10 @@ async function refExists(projectPath: string, ref: string): Promise<boolean> {
 	return result.ok;
 }
 
-function parseRecentCommitters(shortlogOutput: string): Set<string> {
-	const emails = new Set<string>();
-
-	for (const line of shortlogOutput.split("\n")) {
-		const match = line.match(/<([^>]+)>/);
-		if (!match) continue;
-		emails.add(match[1].trim().toLowerCase());
-	}
-
-	return emails;
-}
-
-// detectDefaultCompareRef runs `git shortlog` over two weeks of history — expensive
-// on large repos. It is invoked by resolveProjectConfig, which the renderer polls
-// every few seconds, so the result is cached with a TTL. The in-flight promise is
-// cached too, coalescing concurrent callers.
+// detectDefaultCompareRef spawns several git commands (and sets up base-branch
+// tracking). It is invoked by resolveProjectConfig, which the renderer polls every
+// few seconds, so the result is cached with a TTL. The in-flight promise is cached
+// too, coalescing concurrent callers.
 const compareRefCache = new Map<string, { at: number; promise: Promise<string> }>();
 const COMPARE_REF_CACHE_TTL_MS = 10 * 60_000;
 
@@ -1275,36 +1263,20 @@ async function detectDefaultCompareRefUncached(
 		.includes("origin");
 	const remoteBaseRef = `origin/${baseBranch}`;
 	const remoteBaseExists = hasOriginRemote && await refExists(projectPath, remoteBaseRef);
-	let localBaseExists = await refExists(projectPath, baseBranch);
+	const localBaseExists = await refExists(projectPath, baseBranch);
 	if (baseBranch === "main" || baseBranch === "master") {
 		if (remoteBaseExists) {
 			if (localBaseExists) {
 				await run(["git", "branch", "--set-upstream-to", remoteBaseRef, baseBranch], projectPath);
 			} else {
 				await run(["git", "branch", "--track", baseBranch, remoteBaseRef], projectPath);
-				localBaseExists = true;
 			}
 		}
 	}
-	const historyRef = remoteBaseExists ? remoteBaseRef : baseBranch;
 
-	const shortlogResult = await run(
-		["git", "shortlog", "-sne", "--since=2 weeks ago", historyRef],
-		projectPath,
-	);
-	const recentCommitters = shortlogResult.ok
-		? parseRecentCommitters(shortlogResult.stdout)
-		: new Set<string>();
-
-	if (recentCommitters.size <= 1) {
-		if (localBaseExists) return baseBranch;
-		if (remoteBaseExists) return remoteBaseRef;
-		return baseBranch;
-	}
-
-	if (remoteBaseExists) {
-		return remoteBaseRef;
-	}
+	// The remote ref always wins: dev3 fetches origin but never fast-forwards the
+	// main clone's local base branch, so the local one goes stale and diffs lie.
+	if (remoteBaseExists) return remoteBaseRef;
 
 	if (hasOriginRemote) {
 		for (const branchName of ["main", "master"]) {
@@ -1313,7 +1285,6 @@ async function detectDefaultCompareRefUncached(
 		}
 	}
 
-	if (localBaseExists) return baseBranch;
 	return baseBranch;
 }
 


### PR DESCRIPTION
## Summary

A freshly cloned project defaulted its diff comparison to the **local** base branch (`main`) instead of `origin/main`.

Cause: `detectDefaultCompareRef` (`src/bun/git.ts`) ran `git shortlog -sne --since="2 weeks ago"` and returned the local base branch whenever the base had **one or fewer distinct committer emails** — the assumption being that a solo repo's local `main` is as good as the remote one. That assumption does not hold in dev3: it fetches `origin` but never fast-forwards the main clone's local base branch, so local `main` drifts behind after the first merged PR and every diff / "N commits ahead" / rebase readout silently compares against stale history.

The heuristic also mis-fired on committer identity — `parseRecentCommitters` dedupes by lowercased email, so `Arseniy Pavlenko <h0x91b@gmail.com>` + `h0x91B <h0x91b@gmail.com>` collapsed to a single committer even on a repo with real history. Reproduced on the reporting repo.

## Changes

- Removed the committer heuristic and `parseRecentCommitters` entirely. Resolution order is now `origin/<base>` if it exists → `origin/main` / `origin/master` when an `origin` remote has them → the local base branch as a last resort. The existing side effect that points the local base branch's upstream at `origin/<base>` is unchanged.
- Explicit configuration still wins: `defaultCompareRef` / `defaultCompareRefMode: "local"` and any value already persisted in `projects.json` or `.dev3/config.json` are untouched.
- Rewrote the `detectDefaultCompareRef` unit tests for the new behaviour and added coverage for "no `origin` remote" and "configured base branch has no remote counterpart".
- New decision record `183-default-compare-ref-always-remote.md`; corrected the now-stale `shortlog` mention in decision 067.

## Verification

- Real-git check: bare remote + fresh single-committer clone resolves to `origin/main` (previously `main`).
- `bun run lint` clean; `bun run test` green apart from known load-flaky files (`TaskDiffViewer`, `artifactTemplateFileProtocol`, `AgentAccountsSection`, `cli-socket-codex-capture`), all of which pass in isolation.