### PR TITLE
Align CI Bun pins, and resolve the packaged host image from the bundled CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Restore node_modules cache
         id: cache-deps
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Restore node_modules cache
         id: cache-deps
@@ -315,7 +315,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Restore node_modules cache
         id: cache-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Preview update popover changelog
         # Surface the exact "what's new" payload that gets embedded into
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Restore node_modules cache
         id: cache-deps
@@ -311,7 +311,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Restore node_modules cache
         id: cache-deps
@@ -523,7 +523,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Install Linux dependencies
         run: |
@@ -619,7 +619,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Install Linux dependencies
         run: |
@@ -721,7 +721,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/windows-conpty-package.yml"
+      # A Bun pin change in these is a packaged-runtime change: they install the
+      # Bun that builds and ships the app, so the package proof has to re-run.
+      - ".github/workflows/build.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/native-terminal-soak.yml"
       - "electrobun.config.ts"
       - "package.json"
       - "scripts/fixtures/windows-conpty-package/**"

--- a/change-logs/2026/07/30/chore-align-ci-bun-pins.md
+++ b/change-logs/2026/07/30/chore-align-ci-bun-pins.md
@@ -1,0 +1,1 @@
+Every CI and release job now installs the same Bun the app packages (1.3.14) instead of the stale 1.3.10 pinned in the build and release workflows, and a test fails the build if a workflow pin ever drifts away from that baseline again.

--- a/change-logs/2026/07/30/fix-packaged-cli-native-host-resolution.md
+++ b/change-logs/2026/07/30/fix-packaged-cli-native-host-resolution.md
@@ -1,0 +1,3 @@
+Short: Remote mode can start native terminals
+
+Running dev3 in remote or headless mode from an installed app could not start an experimental native terminal: the bundled CLI looked for the packaged host image next to itself instead of at the package root, so the task failed the availability check even though the image was there. The desktop app was unaffected, and no task ever silently fell back to tmux.

--- a/scripts/verify-packaged-host-resolution.ts
+++ b/scripts/verify-packaged-host-resolution.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { discoverPackagedImage } from "../src/bun/native-terminal-registry/host-images/packaged-image";
 import {
+	hostImageRootForPackagedCli,
 	nativeHostPackageLayout,
 	packagedRuntimePathIn,
 } from "../src/bun/native-terminal-registry/host-images/package-layout";
@@ -71,55 +72,90 @@ if (shipped.status !== "ok") {
 }
 
 const workspace = mkdtempSync(join(tmpdir(), "dev3-host-resolution-"));
-try {
-	const probeBundle = join(workspace, "resolution-probe.js");
-	const build = spawnSync(
-		process.execPath,
-		["build", resolve(import.meta.dir, "native-host-resolution-probe.ts"), "--target=bun", "--outfile", probeBundle],
-		{ cwd: resolve(import.meta.dir, ".."), env: process.env, encoding: "utf8" },
-	);
-	if (build.status !== 0) throw new Error(`Failed to bundle the resolution probe.\n${build.stdout}\n${build.stderr}`);
+const probeSource = resolve(import.meta.dir, "native-host-resolution-probe.ts");
+/** The bundled `dev3` CLI's directory — what `dev3 remote` / headless mode runs from. */
+const bundledCliDir = join(layout.hostImagePackageRoot, "Resources", "app", "cli");
 
-	const stagingRoot = join(workspace, "native-host-images");
-	const probe = spawnSync(layout.runtimePath, [probeBundle], {
-		cwd: workspace,
-		encoding: "utf8",
-		timeout: 60_000,
-		env: {
-			PATH: process.platform === "win32" ? (process.env.PATH ?? "") : ["/usr/bin", "/bin"].join(delimiter),
-			HOME: process.env.HOME,
-			USERPROFILE: process.env.USERPROFILE,
-			SystemRoot: process.env.SystemRoot,
-			TMPDIR: process.env.TMPDIR ?? tmpdir(),
-			DEV3_NATIVE_HOST_IMAGES_DIR: stagingRoot,
-		},
-	});
+function probeEnv(stagingRoot: string): NodeJS.ProcessEnv {
+	return {
+		PATH: process.platform === "win32" ? (process.env.PATH ?? "") : ["/usr/bin", "/bin"].join(delimiter),
+		HOME: process.env.HOME,
+		USERPROFILE: process.env.USERPROFILE,
+		SystemRoot: process.env.SystemRoot,
+		TMPDIR: process.env.TMPDIR ?? tmpdir(),
+		DEV3_NATIVE_HOST_IMAGES_DIR: stagingRoot,
+	};
+}
+
+/** Run one probe process and hold its verdict to the packaged-image contract. */
+function checkResolution(label: string, executable: string, args: string[], stagingRoot: string): ResolvedRuntimeReport {
+	const probe = spawnSync(executable, args, { cwd: workspace, encoding: "utf8", timeout: 120_000, env: probeEnv(stagingRoot) });
 	const reportLine = (probe.stdout ?? "")
 		.split(/\r?\n/)
 		.map((line) => line.trim())
 		.find((line) => line.startsWith(PROBE_MARKER));
 	if (!reportLine) {
 		throw new Error(
-			`The packaged runtime could not resolve a native host (exit ${probe.status ?? "none"}).\n` +
+			`${label} could not resolve a native host (exit ${probe.status ?? "none"}).\n` +
 				`stdout: ${probe.stdout}\nstderr: ${probe.stderr}`,
 		);
 	}
 	const resolved = JSON.parse(reportLine.slice(PROBE_MARKER.length)) as ResolvedRuntimeReport;
-
 	if (resolved.kind !== "packaged-image") {
-		throw new Error(`Packaged app resolved a ${resolved.kind} host, not its own packaged image: ${JSON.stringify(resolved)}`);
+		throw new Error(`${label} resolved a ${resolved.kind} host, not the packaged image: ${JSON.stringify(resolved)}`);
 	}
 	if (resolved.imageTag !== shipped.tag) {
-		throw new Error(`Packaged app launched image ${resolved.imageTag}, but this package ships ${shipped.tag}.`);
+		throw new Error(`${label} launched image ${resolved.imageTag}, but this package ships ${shipped.tag}.`);
 	}
 	if (!resolved.entrypointPath.startsWith(stagingRoot)) {
-		throw new Error(`Resolved host must run from the staged copy under ${stagingRoot}, not ${resolved.entrypointPath}.`);
+		throw new Error(`${label} must run from the staged copy under ${stagingRoot}, not ${resolved.entrypointPath}.`);
+	}
+	return resolved;
+}
+
+try {
+	// 1. Desktop app: the packaged Bun runs a bundled script.
+	const probeBundle = join(workspace, "resolution-probe.js");
+	const build = spawnSync(
+		process.execPath,
+		["build", probeSource, "--target=bun", "--outfile", probeBundle],
+		{ cwd: resolve(import.meta.dir, ".."), env: process.env, encoding: "utf8" },
+	);
+	if (build.status !== 0) throw new Error(`Failed to bundle the resolution probe.\n${build.stdout}\n${build.stderr}`);
+
+	const desktopStagingRoot = join(workspace, "native-host-images-desktop");
+	const resolved = checkResolution("The packaged desktop runtime", layout.runtimePath, [probeBundle], desktopStagingRoot);
+
+	// 2. Bundled CLI: `dev3 remote` / headless mode, several levels deeper. A
+	// compiled binary dropped into the real cli/ directory reproduces its
+	// process.execPath exactly; nothing else in the bundle is touched.
+	if (!existsSync(bundledCliDir)) throw new Error(`This package ships no bundled CLI directory at ${bundledCliDir}.`);
+	if (hostImageRootForPackagedCli(bundledCliDir) !== layout.hostImagePackageRoot) {
+		throw new Error(
+			`The bundled CLI at ${bundledCliDir} derives image root ` +
+				`${hostImageRootForPackagedCli(bundledCliDir)}, but the image was assembled into ${layout.hostImagePackageRoot}.`,
+		);
+	}
+	const cliProbePath = join(bundledCliDir, process.platform === "win32" ? "dev3-host-probe.exe" : "dev3-host-probe");
+	const cliStagingRoot = join(workspace, "native-host-images-cli");
+	let cliResolved: ResolvedRuntimeReport;
+	try {
+		const compile = spawnSync(
+			process.execPath,
+			["build", probeSource, "--compile", "--outfile", cliProbePath],
+			{ cwd: resolve(import.meta.dir, ".."), env: process.env, encoding: "utf8" },
+		);
+		if (compile.status !== 0) throw new Error(`Failed to compile the CLI-layout probe.\n${compile.stdout}\n${compile.stderr}`);
+		cliResolved = checkResolution("The bundled dev3 CLI", cliProbePath, [], cliStagingRoot);
+	} finally {
+		rmSync(cliProbePath, { force: true });
 	}
 
 	const proof = {
 		platform: os,
 		buildDir,
 		appBundleRoot: layout.appBundleRoot,
+		hostImagePackageRoot: layout.hostImagePackageRoot,
 		shippedImageTag: shipped.tag,
 		shippedImageDir: shipped.imageDir,
 		resolvedKind: resolved.kind,
@@ -130,9 +166,17 @@ try {
 		probeWasBundled: true,
 		environmentOverrideUsed: false,
 		packagedRuntimeExecPath: resolved.execPath,
+		bundledCliDir,
+		bundledCliResolvedKind: cliResolved.kind,
+		bundledCliResolvedImageTag: cliResolved.imageTag,
+		bundledCliResolvedEntrypointPath: cliResolved.entrypointPath,
+		bundledCliExecPath: cliResolved.execPath,
 	};
 	writeFileSync(join(buildDir, "native-host-resolution-proof.json"), `${JSON.stringify(proof, null, 2)}\n`);
-	console.log(`[native-terminal-runtime] packaged ${os} app resolved its own host image ${shipped.tag} from ${resolved.entrypointPath}`);
+	console.log(
+		`[native-terminal-runtime] packaged ${os} app resolved host image ${shipped.tag} from both the desktop runtime ` +
+			`and the bundled CLI layout (${bundledCliDir})`,
+	);
 } finally {
 	rmSync(workspace, { recursive: true, force: true });
 }

--- a/src/bun/__tests__/native-host-runtime.test.ts
+++ b/src/bun/__tests__/native-host-runtime.test.ts
@@ -27,10 +27,10 @@ vi.mock("../native-terminal-registry/host-images/packaged-image", () => ({
 // registry CLI on disk, and one case needs a build that does not.
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
-	return { ...actual, default: actual, existsSync: vi.fn(actual.existsSync) };
+	return { ...actual, default: actual, existsSync: vi.fn(actual.existsSync), realpathSync: vi.fn(actual.realpathSync) };
 });
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { spawn } from "node:child_process";
 const realFs = await vi.importActual<typeof import("node:fs")>("node:fs");
 import {
@@ -58,6 +58,7 @@ function launchSpec() {
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(existsSync).mockImplementation(realFs.existsSync);
+	vi.mocked(realpathSync).mockImplementation(realFs.realpathSync as never);
 	mkdirSync(TEST_ROOT, { recursive: true });
 	writeFileSync(ENTRYPOINT, "// built host bundle\n");
 	delete process.env[NATIVE_HOST_ENTRYPOINT_ENV];
@@ -152,6 +153,26 @@ describe("packaged image lookup", () => {
 		expect(nativeHostPackageLayout("darwin", join(roots[0], "bun")).hostImagePackageRoot).toBe(roots[1]);
 		// Linux and Windows assemble at the bundle root, one level above bin/bun.
 		expect(nativeHostPackageLayout("linux", join(roots[0], "bun")).hostImagePackageRoot).toBe(roots[1]);
+	});
+
+	it("reaches the image from the bundled dev3 CLI that `dev3 remote` runs", () => {
+		// Seq 1352: headless mode's execPath is <bundle>.app/Contents/Resources/app/cli/dev3,
+		// and neither directory around it holds the image.
+		const cliPath = "/Apps/dev-3.0.app/Contents/Resources/app/cli/dev3";
+		vi.mocked(realpathSync).mockImplementation(((path: string) => (path === process.execPath ? cliPath : path)) as never);
+
+		const roots = packagedHostImageRoots();
+
+		expect(roots).toEqual([
+			"/Apps/dev-3.0.app/Contents/Resources/app/cli",
+			"/Apps/dev-3.0.app/Contents/Resources/app",
+			"/Apps/dev-3.0.app/Contents",
+		]);
+		expect(roots[roots.length - 1]).toBe(nativeHostPackageLayout("darwin", "/Apps/dev-3.0.app/Contents/MacOS/bun").hostImagePackageRoot);
+	});
+
+	it("adds nothing extra for a desktop runtime that is not the bundled CLI", () => {
+		expect(packagedHostImageRoots()).toHaveLength(2);
 	});
 
 	it("finds an image the Windows package wrote above the runtime's bin/ directory", () => {

--- a/src/bun/__tests__/workflow-bun-pins.test.ts
+++ b/src/bun/__tests__/workflow-bun-pins.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Every CI/release job must install the SAME Bun the app packages.
+ *
+ * They drifted once and it cost a red build: `build.yml` pinned Bun 1.3.10
+ * while `electrobun.config.ts` packaged 1.3.14, so the first job to build the
+ * native terminal host outside Windows tripped the ConPTY floor. A stale pin is
+ * silent until some build step finally cares about the version, which is exactly
+ * why it needs a guard rather than review discipline.
+ *
+ * `MINIMUM_WINDOWS_CONPTY_BUN_VERSION` is the single baseline: it feeds
+ * `electrobun.config.ts` `build.bunVersion`, so pinning workflows to it keeps
+ * the build toolchain and the packaged runtime identical by construction.
+ *
+ * If a future job genuinely needs a different Bun — proving behaviour on an
+ * older runtime, say — add it to an explicit exception list here with the
+ * reason. Do not loosen the equality.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { MINIMUM_WINDOWS_CONPTY_BUN_VERSION } from "../../shared/native-terminal-runtime";
+
+const WORKFLOWS_DIR = fileURLToPath(new URL("../../../.github/workflows", import.meta.url));
+
+interface BunPin {
+	workflow: string;
+	line: number;
+	version: string;
+}
+
+function bunPins(): BunPin[] {
+	const pins: BunPin[] = [];
+	for (const entry of readdirSync(WORKFLOWS_DIR, { withFileTypes: true })) {
+		if (!entry.isFile() || !/\.ya?ml$/.test(entry.name)) continue;
+		readFileSync(join(WORKFLOWS_DIR, entry.name), "utf8")
+			.split(/\r?\n/)
+			.forEach((text, index) => {
+				const match = /^\s*bun-version:\s*["']?([^"'\s#]+)/.exec(text);
+				if (match) pins.push({ workflow: entry.name, line: index + 1, version: match[1] });
+			});
+	}
+	return pins;
+}
+
+function setupBunSteps(): number {
+	return readdirSync(WORKFLOWS_DIR, { withFileTypes: true })
+		.filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+		.reduce((total, entry) => total + (readFileSync(join(WORKFLOWS_DIR, entry.name), "utf8").match(/oven-sh\/setup-bun/g)?.length ?? 0), 0);
+}
+
+describe("workflow Bun pins", () => {
+	it("finds a pin to check", () => {
+		expect(bunPins().length).toBeGreaterThan(0);
+	});
+
+	it("pins every workflow to the Bun the app packages", () => {
+		const drifted = bunPins()
+			.filter((pin) => pin.version !== MINIMUM_WINDOWS_CONPTY_BUN_VERSION)
+			.map((pin) => `${pin.workflow}:${pin.line} pins Bun ${pin.version}`);
+
+		expect(
+			drifted,
+			`These jobs would build with a Bun the app does not package (${MINIMUM_WINDOWS_CONPTY_BUN_VERSION}):\n${drifted.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("leaves no setup-bun step without a pin, where `latest` could drift silently", () => {
+		expect(bunPins()).toHaveLength(setupBunSteps());
+	});
+
+	it("keeps the baseline a plain release version, never a range or tag", () => {
+		expect(MINIMUM_WINDOWS_CONPTY_BUN_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+});

--- a/src/bun/__tests__/workflow-bun-pins.test.ts
+++ b/src/bun/__tests__/workflow-bun-pins.test.ts
@@ -70,6 +70,24 @@ describe("workflow Bun pins", () => {
 		expect(bunPins()).toHaveLength(setupBunSteps());
 	});
 
+	// A pin change IS a packaged-runtime change, so the job that proves the
+	// package must re-run on it. Without this, a pure pin edit ships unproven.
+	it("makes every Bun-pinning workflow trigger the packaged-runtime proof", () => {
+		const packageWorkflow = "windows-conpty-package.yml";
+		const triggerPaths = readFileSync(join(WORKFLOWS_DIR, packageWorkflow), "utf8")
+			.split(/\r?\n/)
+			.map((line) => /^\s*-\s*["']([^"']+)["']/.exec(line)?.[1])
+			.filter((path): path is string => path !== undefined);
+		const pinningWorkflows = [...new Set(bunPins().map((pin) => pin.workflow))];
+
+		const untriggered = pinningWorkflows.filter((workflow) => !triggerPaths.includes(`.github/workflows/${workflow}`));
+
+		expect(
+			untriggered,
+			`These workflows pin Bun but do not re-run ${packageWorkflow}, so a pin change would ship unproven:\n${untriggered.join("\n")}`,
+		).toEqual([]);
+	});
+
 	it("keeps the baseline a plain release version, never a range or tag", () => {
 		expect(MINIMUM_WINDOWS_CONPTY_BUN_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
 	});

--- a/src/bun/native-host-runtime.ts
+++ b/src/bun/native-host-runtime.ts
@@ -32,6 +32,7 @@ import {
 	stagePackagedImage,
 	PACKAGED_HOST_IMAGE_PARENT,
 } from "./native-terminal-registry/host-images/packaged-image";
+import { hostImageRootForPackagedCli } from "./native-terminal-registry/host-images/package-layout";
 import type { PackagedHostImageExpectations } from "./native-terminal-registry/host-images/packaged-image-manifest";
 import type { HostLaunch, HostLauncher, HostSpawnOptions } from "./native-terminal-registry/registry";
 import { encodeShellLaunchSpec, NATIVE_SESSION_LAUNCH_ENV } from "./native-terminal-registry/shell-launch";
@@ -85,17 +86,27 @@ function realExecDir(): string | null {
  * Where a packaged image can sit, nearest first.
  *
  * The packaging hook assembles `<packageRoot>/native-host-image/<tag>/`, and
- * `<packageRoot>` is not always the runtime's own directory: the Windows package
- * puts the runtime in `<packageRoot>\bin\bun.exe`, so looking only beside the
- * executable missed the image the same build had just written one level up
- * (observed on a real Windows machine — the launch failed with "this dev3
- * package has no native-host-image/ directory").
+ * `<packageRoot>` is not always the runtime's own directory:
+ *
+ *  • The desktop app runs the packaged Bun from `<packageRoot>\bin\bun.exe`
+ *    (Windows, Linux) or `<bundle>.app/Contents/MacOS/bun` (macOS), so the image
+ *    is one level up. Looking only beside the executable missed the image the
+ *    same build had just written (observed on a real Windows machine — the
+ *    launch failed with "this dev3 package has no native-host-image/ directory").
+ *  • `dev3 remote` / headless mode runs the BUNDLED CLI, several levels deeper at
+ *    `<packageRoot>/Resources/app/cli/dev3`. Neither directory around it holds
+ *    the image, so packaged remote mode could not launch a native task at all
+ *    (seq 1352). That root comes from Electrobun's own named copy path rather
+ *    than from walking up until something matches.
  */
 export function packagedHostImageRoots(): string[] {
 	const execDir = realExecDir();
 	if (!execDir) return [];
 	const parent = dirname(execDir);
-	return parent && parent !== execDir ? [execDir, parent] : [execDir];
+	const roots = parent && parent !== execDir ? [execDir, parent] : [execDir];
+	const bundledCliRoot = hostImageRootForPackagedCli(execDir);
+	if (bundledCliRoot && !roots.includes(bundledCliRoot)) roots.push(bundledCliRoot);
+	return roots;
 }
 
 function developmentRuntime(): NativeHostRuntime | null {

--- a/src/bun/native-terminal-registry/host-images/PACKAGED-IMAGE.md
+++ b/src/bun/native-terminal-registry/host-images/PACKAGED-IMAGE.md
@@ -85,6 +85,16 @@ probes at launch.
 The runtime carrier inside the image is `dev3-terminal-host.exe` on Windows and
 `dev3-terminal-host` everywhere else.
 
+Two different executables have to reach that root at runtime:
+
+| Process | `process.execPath` | How it finds the image root |
+|---|---|---|
+| Desktop app | `<package>/bin/bun[.exe]`, or `<bundle>.app/Contents/MacOS/bun` | Its own directory, then one level up |
+| `dev3 remote` / headless | `<package>/Resources/app/cli/dev3[.exe]` | `hostImageRootForPackagedCli()` strips the three named `Resources/app/cli` segments |
+
+The CLI root is derived from Electrobun's own copy path, never by walking up
+until a `native-host-image/` turns up.
+
 ## Artifact-manifest CLI
 
 The standalone generator still exists for describing an arbitrary artifact

--- a/src/bun/native-terminal-registry/host-images/__tests__/package-layout.test.ts
+++ b/src/bun/native-terminal-registry/host-images/__tests__/package-layout.test.ts
@@ -15,6 +15,7 @@ import {
 	nativeHostPackageLayout,
 	packagedRuntimePathIn,
 	packagedRuntimeFileName,
+	hostImageRootForPackagedCli,
 } from "../package-layout";
 
 let workspace: string;
@@ -107,5 +108,37 @@ describe("packagedRuntimePathIn", () => {
 		expect(packagedRuntimeFileName("win32")).toBe("bun.exe");
 		expect(packagedRuntimeFileName("darwin")).toBe("bun");
 		expect(packagedRuntimeFileName("linux")).toBe("bun");
+	});
+});
+
+describe("hostImageRootForPackagedCli", () => {
+	// Every row is a REAL Electrobun output path. `hostImagePackageRoot` in the
+	// same bundle must come out identical, or `dev3 remote` looks in the wrong
+	// place while the desktop app looks in the right one.
+	test.each([
+		["darwin", "/b/dev-3.0.app/Contents/MacOS/bun", "/b/dev-3.0.app/Contents/Resources/app/cli"],
+		["linux", "/b/dev-3.0/bin/bun", "/b/dev-3.0/Resources/app/cli"],
+		["win32", "/b/dev-3.0/bin/bun.exe", "/b/dev-3.0/Resources/app/cli"],
+	] as const)("on %s the bundled CLI resolves the same image root as the desktop app", (os, runtimePath, cliDir) => {
+		expect(hostImageRootForPackagedCli(cliDir)).toBe(nativeHostPackageLayout(os, runtimePath).hostImagePackageRoot);
+	});
+
+	test("rejects any directory that is not Electrobun's Resources/app/cli", () => {
+		for (const wrong of [
+			"/b/dev-3.0.app/Contents/MacOS", // desktop runtime dir
+			"/b/dev-3.0.app/Contents/Resources/app", // one segment short
+			"/b/dev-3.0.app/Contents/Resources/app/cli/extra", // one segment too deep
+			"/b/dev-3.0/Resources/cli", // missing app/
+			"/usr/local/bin", // a CLI installed outside any package
+			"/",
+		]) {
+			expect(hostImageRootForPackagedCli(wrong)).toBeNull();
+		}
+	});
+
+	test("does not walk up looking for a match", () => {
+		// A `cli` directory nested under an unrelated tree must not resolve to
+		// some ancestor that happens to exist.
+		expect(hostImageRootForPackagedCli("/home/me/projects/cli")).toBeNull();
 	});
 });

--- a/src/bun/native-terminal-registry/host-images/package-layout.ts
+++ b/src/bun/native-terminal-registry/host-images/package-layout.ts
@@ -25,7 +25,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { ManifestArch, ManifestOs } from "./artifact-manifest";
 import { PACKAGED_HOST_ENTRYPOINT } from "./packaged-image";
 
@@ -82,6 +82,39 @@ export function nativeHostPackageLayout(os: ManifestOs, runtimePath: string): Na
 		runtimePath: runtime,
 		entrypointPath: join(bundleRoot, "Resources", "app", "native", PACKAGED_HOST_ENTRYPOINT),
 	};
+}
+
+/**
+ * Path segments Electrobun's copy rules put between the package root and the
+ * bundled `dev3` CLI (`cliCopyEntry()` in electrobun.config.ts writes
+ * `cli/dev3`, and every copy lands under `Resources/app/`).
+ */
+const PACKAGED_CLI_SEGMENTS = ["Resources", "app", "cli"] as const;
+
+/**
+ * The host-image root for a process running as the BUNDLED `dev3` CLI —
+ * `dev3 remote` / headless mode, where `process.execPath` is the packaged CLI
+ * binary rather than the desktop app's Bun.
+ *
+ * Seq 1352 found this the hard way: from `Contents/Resources/app/cli/dev3` the
+ * two roots beside and above the executable are `.../app/cli` and `.../app`,
+ * while the image sits at `Contents/native-host-image`. The gate failed
+ * honestly and never touched tmux, but packaged remote mode could not run a
+ * native task at all.
+ *
+ * Anchored on the three NAMED segments, so it matches the one layout Electrobun
+ * actually emits and nothing else — no walking up until something is found.
+ * Stripping them lands on `Contents/` on macOS (`Resources` sits inside it) and
+ * on the bundle root on Linux and Windows, which are exactly the image roots
+ * {@link nativeHostPackageLayout} assembles into.
+ */
+export function hostImageRootForPackagedCli(executableDir: string): string | null {
+	let candidate = resolve(executableDir);
+	for (const segment of [...PACKAGED_CLI_SEGMENTS].reverse()) {
+		if (basename(candidate) !== segment) return null;
+		candidate = dirname(candidate);
+	}
+	return candidate;
 }
 
 /**


### PR DESCRIPTION
Draft. Two independent fixes for the native-terminal rollout, kept in one branch because the second was assigned into this follow-up. Say the word and I will split them.

---

## Fix 1 — every CI and release job now installs the Bun the app packages

`electrobun.config.ts` packages Bun **1.3.14** (via `MINIMUM_WINDOWS_CONPTY_BUN_VERSION`), but `build.yml` and `release.yml` still installed **1.3.10**. Nothing noticed until a build step finally cared: the first job to bundle the native terminal host outside Windows tripped the ConPTY floor and `build-check` went red.

- **Nine pins moved 1.3.10 → 1.3.14:** `build.yml` 19 / 59 / 318, `release.yml` 51 / 101 / 314 / 526 / 622 / 724. `windows-conpty-package.yml` (×3) and `native-terminal-soak.yml` (×1) were already correct — 13 `setup-bun` steps, all now identical.
- **New guard** `src/bun/__tests__/workflow-bun-pins.test.ts` derives the expected pin from the same constant that feeds `build.bunVersion`, so the baseline has one source. It names the offending `file:line` on drift and fails an unpinned `setup-bun` step, where `latest` would drift silently.

### Version pins deliberately left alone

| Pin | Why it stays |
|---|---|
| `h0x91b/dev3/tmux@3.6`, `TMUX_VERSION="3.6a"` | Deliberate pin from decision 105 (tmux 3.7 client busy-spin regression). Unrelated to the Bun toolchain. |
| Action refs (`actions/checkout@v5`, `oven-sh/setup-bun@v2`, …) | Floating major-version tags, not runtime pins. |
| `MINIMUM_WINDOWS_CONPTY_BUN_VERSION = "1.3.14"` | This *is* the baseline everything now derives from. |

The repo has no `.tool-versions`, `.nvmrc`, `.bun-version`, Dockerfile, `engines`, or `packageManager`, so no other place hides a toolchain version.

---

## Fix 2 — `dev3 remote` could not find the host image it ships with

`packagedHostImageRoots()` probed only the executable's directory and its parent. That covers the desktop app, whose Bun sits one level under the package root. It does not cover `dev3 remote` / headless mode, which runs `<package>/Resources/app/cli/dev3` — three levels deeper. A packaged macOS canary (seq 1352) proved remote mode could not launch a native task at all: the two probed roots were `.../app/cli/native-host-image` and `.../app/native-host-image`, while the image sits at `Contents/native-host-image`. The gate failed honestly and never touched tmux.

`hostImageRootForPackagedCli()` strips Electrobun's three **named** `Resources/app/cli` segments, landing on `Contents/` on macOS and the bundle root on Linux and Windows — exactly the roots the packaging hook assembles into. No ancestor scanning, no relaxed manifest validation; the candidate list stays bounded at three.

`verify-packaged-host-resolution.ts` now drives **both** layouts: a bundled script under the packaged runtime, and a compiled probe dropped into the real `cli/` directory so its `execPath` matches the shipped CLI exactly. It runs on macOS and Linux in the existing `posix-app-package` job.

## Verification

- **The fix is load-bearing:** with `native-host-runtime.ts` stashed, the CLI probe reproduces the seq 1352 failure verbatim — `no native-host-image/ directory (looked in .../app/cli/native-host-image)`. Restored, both layouts resolve `packaged-image` from the staged copy.
- Real macOS build: image `1.3.14-p1-bc4b32fe5ec2` assembled, staged outside the bundle, detached lifecycle with no Bun on PATH; packaged runtime confirmed 1.3.14 in `build.json` and `bun --version`.
- `build-check` path reproduced locally on Bun 1.3.14; the pin guard proven to fail on drift (`build.yml:19 pins Bun 1.3.10`) and then restored.
- `bun run lint` green; full `bun run test` green (7 892 tests).

No backend defaults, tmux behaviour, task stamping, or Seq 1311 pane work touched. Windows untouched — no physical access used.