### PR TITLE
Show the task context line on agent-driven info toasts

### DIFF
--- a/change-logs/2026/07/31/fix-info-toast-task-context.md
+++ b/change-logs/2026/07/31/fix-info-toast-task-context.md
@@ -1,0 +1,3 @@
+Short: Agent info toasts show their task
+
+The blue "agent turned off/on completion prompts" toast now shows the same task context line as other notifications (`#seq · project · task title`), so it is clear which task it came from.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1489,6 +1489,9 @@ describe("task.update", () => {
 			taskId: task.id,
 			projectId: project.id,
 			manualCompletion: true,
+			taskSeq: task.seq,
+			taskTitle: "Test task",
+			projectName: project.name,
 		});
 	});
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -469,6 +469,9 @@ const handlers: Record<string, Handler> = {
 					taskId: updated.id,
 					projectId: project.id,
 					manualCompletion,
+					taskSeq: updated.seq,
+					taskTitle: getTaskTitle(updated),
+					projectName: project.name,
 				});
 			}
 		}

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -32,7 +32,7 @@ import GaugeDemo from "./components/gauges/GaugeDemo";
 import ProductivityStatsView from "./components/ProductivityStatsView";
 import ViewportLab from "./components/ViewportLab";
 import NativePaneLayoutLab from "./labs/native-pane/NativePaneLayoutLab";
-import { setToastSuppressed, ToastHost, toast, type ToastEntry } from "./toast";
+import { setToastSuppressed, taskToastContext, ToastHost, toast, type ToastEntry } from "./toast";
 import StuckPreparationPopover from "./components/StuckPreparationPopover";
 import FolderPickerHost from "./components/FolderPickerModal";
 import KeyboardShortcutsModal, { type ShortcutsTab } from "./components/KeyboardShortcutsModal";
@@ -1276,10 +1276,7 @@ function App() {
 				taskId && projectId
 					? () => openTaskFromNotification(taskId, projectId)
 					: undefined;
-			// Compact source line, e.g. "#804 · dev-3.0 · Task title".
-			const context = taskSeq !== undefined
-				? [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ")
-				: undefined;
+			const context = taskToastContext(taskSeq, projectName, taskTitle);
 			toast[level](message, { durationMs, onClick, context, taskId: taskId ?? undefined });
 		}
 		window.addEventListener("rpc:cliToast", onCliToast);
@@ -1326,9 +1323,7 @@ function App() {
 
 			// Elsewhere: don't steal focus automatically — a clickable toast both
 			// navigates to the owning task and opens the viewer (honoring open-mode).
-			const context = taskSeq !== undefined
-				? [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ")
-				: undefined;
+			const context = taskToastContext(taskSeq, projectName, taskTitle);
 			toast.info(t.plural("showImage.toast", newCount ?? 1), {
 				context,
 				onClick: () => {
@@ -1382,9 +1377,7 @@ function App() {
 				setArtifactViewer({ taskId, artifacts, index: artifacts.length - 1 });
 				return;
 			}
-			const context = taskSeq !== undefined
-				? [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ")
-				: undefined;
+			const context = taskToastContext(taskSeq, projectName, taskTitle);
 			toast.info(t.plural("showArtifact.toast", newCount ?? 1), {
 				context,
 				onClick: () => {
@@ -1520,14 +1513,21 @@ function App() {
 	// future merge events behave; user toggles in the inspector stay silent.
 	useEffect(() => {
 		function onManualCompletionChanged(e: Event) {
-			const { taskId, projectId, manualCompletion } = (e as CustomEvent).detail as {
+			const { taskId, projectId, manualCompletion, taskSeq, taskTitle, projectName } = (e as CustomEvent).detail as {
 				taskId: string;
 				projectId: string;
 				manualCompletion: boolean;
+				taskSeq?: number;
+				taskTitle?: string;
+				projectName?: string;
 			};
 			toast.info(
 				t(manualCompletion ? "app.manualCompletionAgentEnabled" : "app.manualCompletionAgentDisabled"),
-				{ taskId, onClick: () => openTaskFromNotification(taskId, projectId) },
+				{
+					taskId,
+					context: taskToastContext(taskSeq, projectName, taskTitle),
+					onClick: () => openTaskFromNotification(taskId, projectId),
+				},
 			);
 		}
 		window.addEventListener("rpc:manualCompletionChanged", onManualCompletionChanged);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -2093,11 +2093,19 @@ describe("App keyboard shortcuts", () => {
 			await renderApp();
 			await act(async () => {
 				window.dispatchEvent(new CustomEvent("rpc:manualCompletionChanged", {
-					detail: { taskId: "t1", projectId: "p1", manualCompletion: true },
+					detail: {
+						taskId: "t1",
+						projectId: "p1",
+						manualCompletion: true,
+						taskSeq: 42,
+						taskTitle: "Some task",
+						projectName: "Alpha",
+					},
 				}));
 			});
 
 			expect(await screen.findByText("Agent turned off completion prompts for this task.")).toBeInTheDocument();
+			expect(await screen.findByText("#42 · Alpha · Some task")).toBeInTheDocument();
 		});
 
 		it("does not navigate when user is on a different task's screen", async () => {

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -26,6 +26,16 @@ export interface ToastOpts {
 	context?: string;
 }
 
+/** Compact source line for a task-scoped toast, e.g. "#804 · dev-3.0 · Task title". */
+export function taskToastContext(
+	taskSeq: number | undefined,
+	projectName: string | undefined,
+	taskTitle: string | undefined,
+): string | undefined {
+	if (taskSeq === undefined) return undefined;
+	return [`#${taskSeq}`, projectName, taskTitle].filter(Boolean).join(" · ");
+}
+
 export interface ToastHostProps {
 	/** Receives only task-scoped entries evicted by the visible toast capacity limit. */
 	onTaskOverflow?: (entry: ToastEntry) => void;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3677,7 +3677,7 @@ export type AppRPCSchema = {
 			 */
 			updateAvailable: { version: string; changelog?: UpdateChangelog; reminder?: boolean };
 			branchMerged: { taskId: string; projectId: string; taskTitle: string; branchName: string; fingerprint: string | null; subject: TaskDialogSubject; shouldPrompt?: boolean; shouldNotify?: boolean };
-			manualCompletionChanged: { taskId: string; projectId: string; manualCompletion: boolean };
+			manualCompletionChanged: { taskId: string; projectId: string; manualCompletion: boolean; taskSeq?: number; taskTitle?: string; projectName?: string };
 			/**
 			 * A branch-merged completion prompt was resolved by declining it
 			 * (`dismissMergeCompletionPrompt`). Lets other connected clients — a


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that made this change).

The blue info toast raised when an agent flips the merge-completion policy (`dev3 task update --manual-completion on|off`) had no task context header, unlike the success/info toasts from `dev3 notify`, `show-image` and `show-artifact`. The push payload simply never carried the task identity.

- `manualCompletionChanged` now pushes `taskSeq`, `taskTitle` and `projectName` (schema updated in `src/shared/types.ts`).
- The renderer renders the usual `#seq · project · task title` line for that toast.
- The context line is now built by one shared helper `taskToastContext()` in `toast.tsx`, replacing three inline copies in `App.tsx`.

Verified with `bun run lint`, the full test suite, and a headless-browser screenshot of the rendered toast.