### PR TITLE
Fix productivity gauge grid overlap

### DIFF
--- a/change-logs/2026/07/31/fix-hero-gauge-grid-wrap.md
+++ b/change-logs/2026/07/31/fix-hero-gauge-grid-wrap.md
@@ -1,0 +1,1 @@
+The Productivity Stats hero gauges now use three columns on wide screens, keeping the six speedometers in two rows so their bezels and cards no longer overlap.

--- a/src/mainview/components/ProductivityStatsView.tsx
+++ b/src/mainview/components/ProductivityStatsView.tsx
@@ -316,7 +316,7 @@ function ProductivityStatsView({ navigate, goBack, canGoBack }: ProductivityStat
 								)}
 							</div>
 						) : (
-						<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+						<div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
 							<StatGauge
 								value={data.hero.tasksShipped.value}
 								max={data.hero.tasksShipped.max}


### PR DESCRIPTION
## Summary

- Change the Productivity Stats hero gauge grid from six columns to three columns, rendering the six speedometers in two rows.
- Prevent fixed-size speedometer bezels from overlapping inside the cockpit's max-width layout.
- Keep the compact mobile stats layout unchanged.

## Validation

- `ProductivityStatsView.test.tsx`: 11 tests passed.
- `bun run lint`: passed with no TypeScript errors.
- Browser QA at 1440×900: two rows render without overlap, with no console errors.
- Browser QA at 390×844: the compact mobile grid remains active.
- The full local suite also exposed unrelated existing timeouts in `TaskDiffViewer` and the artifact file-protocol Chromium test; the changed-area tests pass.
