### PR TITLE
Deliver agent prompts to native-backend tasks

### DIFF
--- a/change-logs/2026/08/02/fix-native-dev3-message-delivery.md
+++ b/change-logs/2026/08/02/fix-native-dev3-message-delivery.md
@@ -1,0 +1,9 @@
+Short: Messages reach native-terminal agents
+
+`dev3 message`, scheduled "Send later" messages, and the Create-PR / commit /
+rebase-conflict hand-offs now reach agents running on the native terminal
+backend instead of always failing with "the task has no live agent session".
+Delivery routes through one backend-neutral seam that finds the task's real agent
+pane — never a shell split — and, when another app instance holds that pane's
+write lease, hands the whole delivery to it so the text lands exactly once. tmux
+behavior is unchanged, and a task with no live agent still fails honestly.

--- a/decisions/190-native-agent-prompt-delivery.md
+++ b/decisions/190-native-agent-prompt-delivery.md
@@ -1,0 +1,92 @@
+# 190 — Native agent-prompt delivery: `pane-1` is the agent, and the delivery goes to whoever holds the pen
+
+## Context
+
+`dev3 message`, scheduled "Send later" messages, and the Create-PR / commit /
+rebase-conflict hand-offs all typed their text into a task's agent through
+`sendPromptToAgentPane` — pure tmux: list the session's panes, cross-reference
+`sessionState.panes`, `send-keys`. A task running on the native terminal backend
+has no tmux session, so pane resolution returned `null` and every send failed
+with `Could not deliver the message — the task has no live agent session.` while
+the agent was demonstrably alive (seq 1371; reproduced against a live three-pane
+native task).
+
+## Investigation
+
+The live coordinator record of the failing task (`~/.dev3.0/native-multipane/
+dev3-task-<id>/coordinator.json`) plus the three pane records showed the shape
+the fix has to rely on:
+
+- `pane-1`'s shell is `zsh /tmp/dev3-<taskId>-run.sh` — the agent wrapper.
+- `pane-2` / `pane-3` are bare `zsh` splits.
+- `activePaneId` was `pane-2`, i.e. a **shell**, so any focus-following
+  heuristic would have typed the prompt into a shell prompt.
+- `sessionState.panes[0]` exists but carries no `paneId` (that field is a tmux
+  pane id and is never populated on the native path).
+
+## Decision
+
+Three invariants, encoded in `src/bun/agent-prompt-native.ts`:
+
+1. **Discovery is structural, not heuristic.** The agent runs in the
+   coordinator's first pane: `startNativeTaskPanes` launches the agent wrapper
+   there, and every split created by `nativePaneAction` is a plain shell (it
+   never passes a launch spec). `createSplitTree` names that pane `pane-1`
+   deterministically, and `NativeMultipaneCoordinator.recover()` reconciles dead
+   panes out of the tree. So *"`pane-1` is in the pane set and alive"* is exactly
+   *"the agent is running"* — `NATIVE_AGENT_PANE_ID` plus a liveness check, no
+   focus tracking and no `pane_current_command` sniffing. Discovery reads the
+   coordinator from disk, so every app process answers the same.
+2. **Ownership is resolved from the host, never assumed.** A binding is not
+   permission to write (decision 191): the host grants the writer lease to one
+   client across all dev3 processes and silently drops an observer's input.
+   Delivery binds the pane on demand (`reattachNativeTaskSession` for the agent
+   pane, `ensureNativePanePtySession` for the rest — neither spawns), then asks
+   `resolvePaneOwner`. `local` writes here; `vacant` claims the lease first;
+   `unknown` and `gone` are reported as undelivered rather than guessed at.
+3. **The delivery travels, not the bytes — and the owner side is a dead end.**
+   A `peer` owner receives the WHOLE delivery over the internal CLI-socket method
+   `_native.deliverPrompt` and performs it once; the forwarding process writes
+   nothing itself. The owner-side entry point `deliverNativePromptAsOwner`
+   resolves no owner and forwards nothing, so a stale answer can never bounce one
+   message between two processes. That pair — forward-whole-delivery plus a
+   non-forwarding owner side — is what makes it exactly once.
+
+Routing lives in `src/bun/agent-prompt-delivery.ts` (`deliverAgentPrompt`) — the
+single seam now used by immediate sends, scheduled fires, and all three git
+hand-offs. A native task never falls back to tmux, and a task with an unreadable
+`terminalBackend` marker throws rather than guessing.
+
+Proven end to end by `bun run test:native-message-e2e`: two real app processes
+over one isolated dev3 home, message entering the non-owner, landing exactly once
+in `pane-1`, host and shell pids unchanged, one registry session, and a tmux
+sentinel untouched.
+
+## Risks
+
+- If a future feature launches an agent into a native **split**, that agent is
+  invisible to discovery. The mitigating fact is that the split path is
+  shell-only by construction today; a change there must extend this rule (record
+  which panes are agent panes) in the same commit.
+- A forward that times out (`forwardToOwner`, 10 s) is reported as undelivered
+  while the owner may still have performed it. At-most-once is preserved on the
+  sender side, but a caller must not retry blindly on a timeout.
+- `\r` is assumed to be the submit keypress for every agent CLI on a native PTY.
+  That matches what tmux's `Enter` sends; a TUI wanting something else would
+  need a per-agent submit key.
+
+## Alternatives considered
+
+- **Route native writes through `TerminalBackend.attachView().write()`.** The
+  clean-looking option, and wrong: a second client attaches as an observer and
+  the host discards the keystrokes with no error the caller can see.
+- **Claim the lease whenever we want to type.** Rejected: it steals the pane out
+  from under whoever is actually typing in it. Claiming is limited to a lease the
+  host reports as vacant.
+- **Forward the bytes instead of the delivery.** Would split one submit across
+  two processes and make exactly-once depend on timing.
+- **Reuse the tmux focus heuristic over native panes.** Rejected by the live
+  data above — the active pane was a shell.
+- **Make `sessionState.panes[].paneId` hold native pane ids.** Would mean two
+  meanings for one field plus a write path on every pane change, to reproduce
+  information that is already deterministic.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"test:native-app-restart-e2e": "bun src/bun/native-terminal-registry/__tests__/app-restart.bun-e2e.ts",
 		"test:native-multipane-e2e": "bun src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts",
 		"test:native-task-terminal-e2e": "bun src/bun/__tests__/native-task-terminal.bun-e2e.ts",
+		"test:native-message-e2e": "bun src/bun/__tests__/native-message-owner-routing.bun-e2e.ts",
 		"test:native-shell-launch": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/__tests__/shell-launch.test.ts src/bun/native-terminal-registry/__tests__/shell-probe.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-runner.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-evidence.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-matrix-support.test.ts src/bun/native-terminal-registry/__tests__/host-config.test.ts src/bun/native-terminal-registry/__tests__/protocol.test.ts src/bun/native-terminal-registry/__tests__/registry.test.ts src/bun/native-terminal-registry/__tests__/recovery.test.ts src/bun/native-terminal-registry/__tests__/client.test.ts src/bun/native-terminal-registry/__tests__/isolation.test.ts",
 		"test:native-live-parser-e2e": "bun src/bun/native-terminal-registry/__tests__/live-parser.bun-e2e.ts",
 		"test:native-host-images-e2e": "bun src/bun/native-terminal-registry/host-images/__tests__/lifecycle.bun-e2e.ts",

--- a/src/bun/__tests__/agent-prompt-delivery.test.ts
+++ b/src/bun/__tests__/agent-prompt-delivery.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The routing seam: which backend's delivery path a task's persisted
+// `terminalBackend` marker selects. Both adapters are mocked so the assertions
+// are purely about routing — and about the two paths NEVER crossing.
+vi.mock("../agent-prompt", () => ({
+	sendPromptToAgentPane: vi.fn(async () => true),
+	sendPromptToPane: vi.fn(async () => true),
+}));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => true),
+	sendPromptToNativePane: vi.fn(async () => true),
+}));
+vi.mock("../tmux", () => ({
+	DEFAULT_TMUX_SOCKET: "dev3",
+	taskSessionName: (taskId: string) => `dev3-task-${taskId}`,
+}));
+
+import { sendPromptToAgentPane, sendPromptToPane } from "../agent-prompt";
+import { sendPromptToNativeAgentPane, sendPromptToNativePane } from "../agent-prompt-native";
+import { deliverAgentPrompt } from "../agent-prompt-delivery";
+import type { PaneSessionEntry, Task } from "../../shared/types";
+
+const TASK_ID = "task-1234";
+const PANES: PaneSessionEntry[] = [
+	{ paneId: "%1", agentCmd: "claude", sessionId: null, agentId: null, configId: null },
+];
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: TASK_ID,
+		projectId: "project-1",
+		worktreePath: "/tmp/worktree",
+		sessionState: { panes: PANES },
+		...overrides,
+	} as Task;
+}
+
+beforeEach(() => {
+	vi.mocked(sendPromptToAgentPane).mockResolvedValue(true);
+	vi.mocked(sendPromptToPane).mockResolvedValue(true);
+	vi.mocked(sendPromptToNativeAgentPane).mockResolvedValue(true);
+	vi.mocked(sendPromptToNativePane).mockResolvedValue(true);
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("deliverAgentPrompt — tmux tasks (regression)", () => {
+	it("routes an unmarked legacy task through the tmux path with the exact old arguments", async () => {
+		await expect(deliverAgentPrompt(task(), "check CI")).resolves.toBe(true);
+		expect(sendPromptToAgentPane).toHaveBeenCalledWith(`dev3-task-${TASK_ID}`, "dev3", "check CI", PANES);
+		expect(sendPromptToNativeAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("routes an explicitly tmux-marked task through the tmux path", async () => {
+		await deliverAgentPrompt(task({ terminalBackend: "tmux" } as Partial<Task>), "check CI");
+		expect(sendPromptToAgentPane).toHaveBeenCalledTimes(1);
+		expect(sendPromptToNativeAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("honours the task's own tmux socket", async () => {
+		await deliverAgentPrompt(task({ tmuxSocket: "custom" } as Partial<Task>), "check CI");
+		expect(sendPromptToAgentPane).toHaveBeenCalledWith(`dev3-task-${TASK_ID}`, "custom", "check CI", PANES);
+	});
+
+	it("routes a concrete tmux pane target to the pane path", async () => {
+		await deliverAgentPrompt(task(), "check CI", { kind: "pane", paneId: "%4" });
+		expect(sendPromptToPane).toHaveBeenCalledWith(`dev3-task-${TASK_ID}`, "dev3", "%4", "check CI");
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("propagates a tmux failure as false", async () => {
+		vi.mocked(sendPromptToAgentPane).mockResolvedValue(false);
+		await expect(deliverAgentPrompt(task(), "check CI")).resolves.toBe(false);
+	});
+});
+
+describe("deliverAgentPrompt — native tasks", () => {
+	const nativeTask = (extra: Partial<Task> = {}) =>
+		task({ terminalBackend: "native", ...extra } as Partial<Task>);
+
+	it("routes an agent target to the native agent pane", async () => {
+		await expect(deliverAgentPrompt(nativeTask(), "check CI")).resolves.toBe(true);
+		expect(sendPromptToNativeAgentPane).toHaveBeenCalledWith(expect.objectContaining({ id: TASK_ID }), "check CI");
+	});
+
+	it("routes a concrete pane target to the native pane path", async () => {
+		await deliverAgentPrompt(nativeTask(), "ls", { kind: "pane", paneId: "pane-2" });
+		expect(sendPromptToNativePane).toHaveBeenCalledWith(
+			expect.objectContaining({ id: TASK_ID }),
+			"pane-2",
+			"ls",
+		);
+	});
+
+	it("NEVER falls back to tmux when native delivery fails", async () => {
+		vi.mocked(sendPromptToNativeAgentPane).mockResolvedValue(false);
+		await expect(deliverAgentPrompt(nativeTask(), "check CI")).resolves.toBe(false);
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+		expect(sendPromptToPane).not.toHaveBeenCalled();
+	});
+
+	it("ignores stale tmux session state left on a native task", async () => {
+		await deliverAgentPrompt(nativeTask({ sessionState: { panes: PANES } }), "check CI");
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+});
+
+describe("deliverAgentPrompt — unusable backend marker", () => {
+	it("throws instead of guessing a backend", async () => {
+		await expect(
+			deliverAgentPrompt(task({ terminalBackend: "screen" } as unknown as Partial<Task>), "check CI"),
+		).rejects.toThrow(/terminalBackend/);
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+		expect(sendPromptToNativeAgentPane).not.toHaveBeenCalled();
+	});
+});

--- a/src/bun/__tests__/agent-prompt-native.test.ts
+++ b/src/bun/__tests__/agent-prompt-native.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Native prompt delivery against mocked pane-set, PTY-binding and owner-routing
+// seams. ../tmux is mocked too — not because this path uses it, but so a stray
+// tmux call would be visible instead of silently working (rule: never fall back).
+vi.mock("../tmux", () => ({
+	tmux: {
+		activePaneId: vi.fn(),
+		listPanes: vi.fn(),
+		sendKeys: vi.fn(),
+		showOption: vi.fn(),
+		setPaneOption: vi.fn(),
+	},
+	PANE_ID_FORMAT: { sentinel: "pane-id-format" },
+	TMUX_AGENT_PANE_OPTION: "@dev3_agent",
+	TMUX_LAST_AGENT_PANE_OPTION: "@dev3_last_agent_pane",
+}));
+vi.mock("../native-task-panes", () => ({ nativeTaskPanesState: vi.fn() }));
+vi.mock("../pty-server", () => ({
+	nativePaneTerminal: vi.fn(),
+	reattachNativeTaskSession: vi.fn(),
+	ensureNativePanePtySession: vi.fn(),
+}));
+vi.mock("../native-pane-owner", () => ({
+	resolvePaneOwner: vi.fn(),
+	forwardToOwner: vi.fn(),
+}));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import type { NativeTaskPane, NativeTaskPanesState } from "../native-task-panes";
+import { nativeTaskPanesState } from "../native-task-panes";
+import { ensureNativePanePtySession, nativePaneTerminal, reattachNativeTaskSession } from "../pty-server";
+import { forwardToOwner, resolvePaneOwner } from "../native-pane-owner";
+import type { NativeTaskTerminal } from "../native-task-terminal";
+import { tmux } from "../tmux";
+import { AGENT_PROMPT_ENTER_DELAY_MS } from "../agent-prompt";
+import {
+	NATIVE_AGENT_PANE_ID,
+	NATIVE_PROMPT_DELIVERY_METHOD,
+	deliverNativePromptAsOwner,
+	resolveNativeAgentPane,
+	sendPromptToNativeAgentPane,
+	sendPromptToNativePane,
+} from "../agent-prompt-native";
+import type { Task } from "../../shared/types";
+
+const TASK_ID = "3fbe0929-25b3-4fbe-9218-7ceb490a43c3";
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: TASK_ID,
+		projectId: "project-1",
+		worktreePath: "/tmp/worktree",
+		...overrides,
+	} as Task;
+}
+
+function pane(paneId: string, alive = true): NativeTaskPane {
+	return { paneId, sessionId: `dev3-task-${TASK_ID}-${paneId}`, hostPid: 10, shellPid: 11, cols: 80, rows: 24, alive };
+}
+
+function panesState(panes: NativeTaskPane[]): NativeTaskPanesState {
+	return { taskId: TASK_ID, panes, layout: "", activePaneId: panes[0]?.paneId ?? "" };
+}
+
+/** A fake binding whose host role is scriptable, tracking every byte written. */
+function fakeTerminal(role: "writer" | "observer" = "writer") {
+	const writes: string[] = [];
+	const terminal = {
+		sessionId: `dev3-task-${TASK_ID}-pane-1`,
+		paneId: NATIVE_AGENT_PANE_ID,
+		hostPid: 10,
+		shellPid: 11,
+		write: vi.fn((data: string) => void writes.push(data)),
+		resize: vi.fn(),
+		hostRole: vi.fn(() => role),
+		hostWriterAttached: vi.fn(() => true),
+		claimHostWriter: vi.fn(async () => role),
+		writerPid: vi.fn(async () => 1),
+		detach: vi.fn(),
+	} as unknown as NativeTaskTerminal & { claimHostWriter: ReturnType<typeof vi.fn> };
+	return { terminal, writes };
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.mocked(nativePaneTerminal).mockReturnValue(null);
+	vi.mocked(reattachNativeTaskSession).mockResolvedValue(false);
+	vi.mocked(ensureNativePanePtySession).mockResolvedValue(undefined);
+	vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "local" });
+	vi.mocked(forwardToOwner).mockResolvedValue({ delivered: true });
+	vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane(NATIVE_AGENT_PANE_ID)]));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.clearAllMocks();
+});
+
+describe("resolveNativeAgentPane — discovery", () => {
+	it("finds the agent pane in a single-pane task", async () => {
+		await expect(resolveNativeAgentPane(TASK_ID)).resolves.toBe(NATIVE_AGENT_PANE_ID);
+	});
+
+	it("picks the agent pane, not a shell split, in a multi-pane task", async () => {
+		// pane-2 is a plain shell AND the active pane — discovery must still land on
+		// the agent rather than following focus (the live seq 1371 repro).
+		const state = panesState([pane("pane-2"), pane(NATIVE_AGENT_PANE_ID)]);
+		vi.mocked(nativeTaskPanesState).mockResolvedValue({ ...state, activePaneId: "pane-2" });
+		await expect(resolveNativeAgentPane(TASK_ID)).resolves.toBe(NATIVE_AGENT_PANE_ID);
+	});
+
+	it("returns null when only shell panes survive the agent", async () => {
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane("pane-2"), pane("pane-3")]));
+		await expect(resolveNativeAgentPane(TASK_ID)).resolves.toBeNull();
+	});
+
+	it("returns null when the agent pane is present but dead", async () => {
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane(NATIVE_AGENT_PANE_ID, false)]));
+		await expect(resolveNativeAgentPane(TASK_ID)).resolves.toBeNull();
+	});
+
+	it("returns null for a stopped task with no pane set at all", async () => {
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(null);
+		await expect(resolveNativeAgentPane(TASK_ID)).resolves.toBeNull();
+	});
+});
+
+describe("sendPromptToNativeAgentPane — this process owns the lease", () => {
+	it("writes the text, then submits exactly one carriage return after the delay", async () => {
+		const { terminal, writes } = fakeTerminal("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(true);
+		expect(writes).toEqual(["check CI"]);
+
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
+		expect(writes).toEqual(["check CI", "\r"]);
+
+		// Nothing fires later — one submit per delivery, never retried.
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS * 5);
+		expect(writes).toEqual(["check CI", "\r"]);
+		expect(forwardToOwner).not.toHaveBeenCalled();
+	});
+
+	it("never writes and never schedules a submit when no agent pane is live", async () => {
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane("pane-2")]));
+		const { terminal, writes } = fakeTerminal("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(false);
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS * 2);
+		expect(writes).toEqual([]);
+	});
+
+	it("never touches tmux, whatever the outcome", async () => {
+		const { terminal } = fakeTerminal("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		await sendPromptToNativeAgentPane(task(), "check CI");
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
+
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(null);
+		await sendPromptToNativeAgentPane(task(), "check CI");
+
+		expect(tmux.sendKeys).not.toHaveBeenCalled();
+		expect(tmux.listPanes).not.toHaveBeenCalled();
+		expect(tmux.activePaneId).not.toHaveBeenCalled();
+	});
+});
+
+describe("sendPromptToNativeAgentPane — another app process owns the lease", () => {
+	it("forwards the whole delivery to the owner and writes nothing locally", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "peer", pid: 4242, endpoint: "/sock/4242.sock" });
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(true);
+
+		expect(forwardToOwner).toHaveBeenCalledTimes(1);
+		expect(forwardToOwner).toHaveBeenCalledWith(
+			{ kind: "peer", pid: 4242, endpoint: "/sock/4242.sock" },
+			NATIVE_PROMPT_DELIVERY_METHOD,
+			{ taskId: TASK_ID, paneId: NATIVE_AGENT_PANE_ID, text: "check CI" },
+		);
+
+		// Exactly once: no local paste, and no local Enter after the delay either.
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS * 3);
+		expect(writes).toEqual([]);
+		expect(forwardToOwner).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports false when the owner says it did not deliver", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "peer", pid: 4242, endpoint: "/sock/4242.sock" });
+		vi.mocked(forwardToOwner).mockResolvedValue({ delivered: false });
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(false);
+		expect(writes).toEqual([]);
+	});
+
+	it("reports false — and still writes nothing locally — when the forward fails", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "peer", pid: 4242, endpoint: "/sock/4242.sock" });
+		vi.mocked(forwardToOwner).mockRejectedValue(new Error("owner 4242 closed before answering"));
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(false);
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS * 2);
+		expect(writes).toEqual([]);
+	});
+});
+
+describe("sendPromptToNativeAgentPane — vacant / unprovable lease", () => {
+	it("claims a vacant lease and then delivers", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(terminal.claimHostWriter).mockResolvedValue("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "vacant" });
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(true);
+		expect(terminal.claimHostWriter).toHaveBeenCalledTimes(1);
+		expect(writes).toEqual(["check CI"]);
+	});
+
+	it("gives up when the vacant lease is taken before the claim lands", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(terminal.claimHostWriter).mockResolvedValue("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind: "vacant" });
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(false);
+		expect(writes).toEqual([]);
+	});
+
+	it.each(["unknown", "gone"] as const)("refuses to guess when the owner is %s", async (kind) => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+		vi.mocked(resolvePaneOwner).mockResolvedValue({ kind });
+
+		await expect(sendPromptToNativeAgentPane(task(), "check CI")).resolves.toBe(false);
+		expect(writes).toEqual([]);
+		expect(forwardToOwner).not.toHaveBeenCalled();
+	});
+});
+
+describe("sendPromptToNativePane — binding on demand", () => {
+	it("rebinds the agent pane when this process holds no binding yet", async () => {
+		const { terminal, writes } = fakeTerminal("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValueOnce(null).mockReturnValue(terminal);
+		vi.mocked(reattachNativeTaskSession).mockResolvedValue(true);
+
+		await expect(sendPromptToNativeAgentPane(task(), "resume please")).resolves.toBe(true);
+		expect(reattachNativeTaskSession).toHaveBeenCalledWith(TASK_ID, "project-1", "/tmp/worktree");
+		expect(writes).toEqual(["resume please"]);
+	});
+
+	it("fails honestly when the rebind cannot produce a binding", async () => {
+		await expect(sendPromptToNativeAgentPane(task(), "hello")).resolves.toBe(false);
+		expect(resolvePaneOwner).not.toHaveBeenCalled();
+	});
+
+	it("does not attempt a rebind for a task with no worktree on record", async () => {
+		await expect(sendPromptToNativeAgentPane(task({ worktreePath: null }), "hello")).resolves.toBe(false);
+		expect(reattachNativeTaskSession).not.toHaveBeenCalled();
+	});
+
+	it("survives a throwing rebind and still reports the honest failure", async () => {
+		vi.mocked(reattachNativeTaskSession).mockRejectedValue(new Error("host image missing"));
+		await expect(sendPromptToNativeAgentPane(task(), "hello")).resolves.toBe(false);
+	});
+
+	it("registers a non-agent pane through its own PTY session, not the task reattach", async () => {
+		const { terminal, writes } = fakeTerminal("writer");
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane(NATIVE_AGENT_PANE_ID), pane("pane-2")]));
+		vi.mocked(nativePaneTerminal).mockReturnValueOnce(null).mockReturnValue(terminal);
+
+		await expect(sendPromptToNativePane(task(), "pane-2", "ls")).resolves.toBe(true);
+		expect(ensureNativePanePtySession).toHaveBeenCalledWith(
+			TASK_ID,
+			"pane-2",
+			`dev3-task-${TASK_ID}-pane-2`,
+			"project-1",
+			"/tmp/worktree",
+		);
+		expect(reattachNativeTaskSession).not.toHaveBeenCalled();
+		expect(writes).toEqual(["ls"]);
+	});
+
+	it("does not register a non-agent pane that is not alive", async () => {
+		vi.mocked(nativeTaskPanesState).mockResolvedValue(panesState([pane("pane-2", false)]));
+		await expect(sendPromptToNativePane(task(), "pane-2", "ls")).resolves.toBe(false);
+		expect(ensureNativePanePtySession).not.toHaveBeenCalled();
+	});
+});
+
+describe("deliverNativePromptAsOwner — the owner-side dead end", () => {
+	const params = { taskId: TASK_ID, paneId: NATIVE_AGENT_PANE_ID, text: "check CI" };
+
+	it("writes and submits once, and never forwards onward", async () => {
+		const { terminal, writes } = fakeTerminal("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+
+		await expect(deliverNativePromptAsOwner(params)).resolves.toBe(true);
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
+		expect(writes).toEqual(["check CI", "\r"]);
+		// The hop guard: the owner side resolves no owner and forwards nothing, so
+		// a stale answer cannot bounce one message between two processes.
+		expect(resolvePaneOwner).not.toHaveBeenCalled();
+		expect(forwardToOwner).not.toHaveBeenCalled();
+	});
+
+	it("claims the lease when it fell vacant between resolution and arrival", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(terminal.claimHostWriter).mockResolvedValue("writer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+
+		await expect(deliverNativePromptAsOwner(params)).resolves.toBe(true);
+		expect(writes).toEqual(["check CI"]);
+	});
+
+	it("refuses when the lease is no longer ours", async () => {
+		const { terminal, writes } = fakeTerminal("observer");
+		vi.mocked(terminal.claimHostWriter).mockResolvedValue("observer");
+		vi.mocked(nativePaneTerminal).mockReturnValue(terminal);
+
+		await expect(deliverNativePromptAsOwner(params)).resolves.toBe(false);
+		expect(writes).toEqual([]);
+	});
+
+	it("refuses when this process has no binding for the pane", async () => {
+		await expect(deliverNativePromptAsOwner(params)).resolves.toBe(false);
+	});
+});

--- a/src/bun/__tests__/native-message-owner-routing.bun-e2e.ts
+++ b/src/bun/__tests__/native-message-owner-routing.bun-e2e.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env bun
+/**
+ * PRODUCT end-to-end proof that a message entering a dev3 app process that does
+ * NOT own a native pane's writer lease is still delivered — exactly once, by the
+ * process that does own it (seq 1377). Run: `bun run test:native-message-e2e`.
+ *
+ * Two REAL processes share one isolated `$HOME`:
+ *
+ *   • **app A** — a child process (`--role=owner`). It creates the task's native
+ *     pane set through `pty.createNativeTaskSession`, therefore holds the pane's
+ *     writer lease, and runs the REAL `startSocketServer()`, so the production
+ *     `_native.deliverPrompt` handler is what answers the forwarded delivery.
+ *   • **app B** — this parent process. The message enters here. It binds the same
+ *     pane (an OBSERVER, because A holds the lease) and calls the production seam
+ *     `deliverAgentPrompt(task, text)`.
+ *
+ * What it asserts: the lease really lives in A; `deliverAgentPrompt` reports true
+ * in B; the token lands in native pane-1 with its submit CR; it occurs EXACTLY
+ * once and is still exactly once well past the submit delay; the bytes were
+ * written by A and never by B; host/shell pids are unchanged; no second native
+ * session or host was spawned; and no tmux session was created or mutated.
+ *
+ * Isolation: `$HOME` is a tmpdir — set BEFORE the first `src/` import, because
+ * `DEV3_HOME` (and `native-pane-owner`'s sockets dir) are module-load constants.
+ * Hence static imports of node builtins only, everything else via `await import`.
+ * Registry/host-image/multipane/log dirs are redirected the same way the sibling
+ * `native-task-terminal.bun-e2e.ts` does. Test-only: no production file changes.
+ *
+ * The pane's shell is `stty -echo; exec cat`, so every delivered line comes back
+ * on the stream exactly once and an occurrence count is meaningful evidence.
+ *
+ * Both halves own listeners and timers, so each ends in an explicit process.exit.
+ */
+
+import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ENTRY = fileURLToPath(import.meta.url);
+const IS_OWNER = process.argv.includes("--role=owner");
+
+// Fixed ids keep the pane session id deterministic in both processes.
+const TASK_ID = "00000000-0000-4000-8000-0000000e2e91";
+const PROJECT_ID = "e2e-owner-routing";
+const PANE_ID = "pane-1";
+const PANE_SESSION_ID = `dev3-task-${TASK_ID}-${PANE_ID}`;
+
+const READY_PREFIX = "__OWNER_READY__";
+const WRITE_PREFIX = "__OWNER_WRITE__";
+const WORK_ENV = "DEV3_MESSAGE_E2E_WORK";
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+function occurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+/** A shell that never echoes, so one written line produces exactly one output line. */
+function catShellLaunch(): { executable: string; argv: string[] } {
+	return { executable: "/bin/bash", argv: ["--norc", "--noprofile", "-lc", "stty -echo; exec cat"] };
+}
+
+// ── app A: the process that owns the pane and answers `_native.deliverPrompt` ──
+
+async function runOwner(): Promise<never> {
+	const work = process.env[WORK_ENV] ?? process.cwd();
+	const pty = await import("../pty-server");
+	const { NativeSessionClient } = await import("../native-terminal-registry/client");
+	const { readRecord } = await import("../native-terminal-registry/record");
+	const { startSocketServer } = await import("../cli-socket-server");
+
+	await pty.createNativeTaskSession(TASK_ID, PROJECT_ID, work, catShellLaunch(), {}, { cols: 120, rows: 40 });
+	const terminal = pty.nativePaneTerminal(TASK_ID, PANE_ID);
+	if (!terminal) {
+		console.log(`${READY_PREFIX}${JSON.stringify({ error: "the created pane produced no terminal" })}`);
+		process.exit(1);
+	}
+
+	// Wait until `stty -echo` has taken effect and `cat` is reading: only then is
+	// an occurrence count honest evidence rather than a race with shell warm-up.
+	const probe = await NativeSessionClient.discover(PANE_SESSION_ID);
+	const decoder = new TextDecoder();
+	let seen = "";
+	probe.onOutput((bytes) => {
+		seen += decoder.decode(bytes, { stream: true });
+	});
+	let echoOff = false;
+	for (let attempt = 0; attempt < 30 && !echoOff; attempt++) {
+		const warmup = `ECHOPROBE-${attempt}-${process.pid}`;
+		seen = "";
+		terminal.write(`${warmup}\r`);
+		const deadline = Date.now() + 500;
+		while (Date.now() < deadline && occurrences(seen, warmup) === 0) await delay(25);
+		await delay(150); // let a second (echoed) copy arrive before believing there is one
+		echoOff = occurrences(seen, warmup) === 1;
+	}
+	probe.close();
+
+	// From here every byte this process puts into the pane is reported on stdout —
+	// the owner-side evidence that the forwarded delivery ran HERE, exactly once.
+	const passthrough = terminal.write.bind(terminal);
+	(terminal as { write: (data: string) => void }).write = (data) => {
+		console.log(`${WRITE_PREFIX}${JSON.stringify(data)}`);
+		passthrough(data);
+	};
+
+	const endpoint = startSocketServer();
+	const record = readRecord(PANE_SESSION_ID);
+	console.log(
+		READY_PREFIX +
+			JSON.stringify({
+				pid: process.pid,
+				hostPid: record?.host.pid ?? -1,
+				shellPid: record?.shell.pid ?? -1,
+				role: terminal.hostRole(),
+				echoOff,
+				endpoint,
+			}),
+	);
+
+	await new Promise(() => {}); // stay alive until the parent kills us
+	process.exit(0);
+}
+
+// ── app B: the process the message enters ──
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+interface OwnerReady {
+	pid: number;
+	hostPid: number;
+	shellPid: number;
+	role: string;
+	echoOff: boolean;
+	endpoint: string;
+	error?: string;
+}
+
+/** The child's stdout, split into lines as they arrive. */
+function collectLines(stream: ReadableStream<Uint8Array>, lines: string[]): void {
+	void (async () => {
+		const decoder = new TextDecoder();
+		let buffer = "";
+		for await (const chunk of stream) {
+			buffer += decoder.decode(chunk, { stream: true });
+			let newline = buffer.indexOf("\n");
+			while (newline !== -1) {
+				lines.push(buffer.slice(0, newline));
+				buffer = buffer.slice(newline + 1);
+				newline = buffer.indexOf("\n");
+			}
+		}
+	})();
+}
+
+async function waitForLine(lines: string[], prefix: string, timeoutMs: number): Promise<string | null> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const found = lines.find((line) => line.startsWith(prefix));
+		if (found) return found;
+		await delay(50);
+	}
+	return null;
+}
+
+async function runSender(): Promise<void> {
+	const root = mkdtempSync(join(tmpdir(), "dev3-native-message-e2e-"));
+	const work = join(root, "work");
+	mkdirSync(work, { recursive: true });
+	mkdirSync(join(root, "native-sessions"), { recursive: true });
+	mkdirSync(join(root, "native-multipane"), { recursive: true });
+
+	// $HOME first: DEV3_HOME and the sockets dir both freeze at module load.
+	process.env.HOME = root;
+	process.env[WORK_ENV] = work;
+	process.env.DEV3_NATIVE_SESSIONS_DIR = join(root, "native-sessions");
+	process.env.DEV3_NATIVE_HOST_IMAGES_DIR = join(root, "host-images");
+	process.env.DEV3_LOG_DIR = join(root, "logs");
+
+	const { NATIVE_MULTIPANE_DIR_ENV } = await import("../native-terminal-multipane/paths");
+	process.env[NATIVE_MULTIPANE_DIR_ENV] = join(root, "native-multipane");
+
+	const { spawn } = await import("../spawn");
+	const { deliverAgentPrompt } = await import("../agent-prompt-delivery");
+	const { AGENT_PROMPT_ENTER_DELAY_MS } = await import("../agent-prompt");
+	const { resolvePaneOwner } = await import("../native-pane-owner");
+	const { NativeSessionClient } = await import("../native-terminal-registry/client");
+	const { readRecord } = await import("../native-terminal-registry/record");
+	const { sessionsRootDir } = await import("../native-terminal-registry/paths");
+	const { isProcessAlive } = await import("../native-terminal-registry/process-identity");
+	const { tmux, taskSessionName } = await import("../tmux");
+	const { SESSION_OVERVIEW_FORMAT } = await import("../tmux/formats");
+	const pty = await import("../pty-server");
+	type Task = import("../../shared/types").Task;
+
+	const listSessions = async (socket?: string): Promise<string> => {
+		try {
+			const rows = await tmux.listSessions(SESSION_OVERVIEW_FORMAT, socket ? { socket } : undefined);
+			return rows.map((row) => row.name).sort().join(",");
+		} catch {
+			return ""; // no tmux server on that socket — an empty list is the honest answer
+		}
+	};
+
+	const token = `NMORT-${process.pid}-${Date.now()}`;
+	console.log(`  info - platform=${process.platform} bun=${Bun.version} pane=${PANE_SESSION_ID}`);
+
+	const sentinelSocket = `dev3-native-message-e2e-${process.pid}`;
+	const sentinelSession = "dev3-native-message-e2e-sentinel";
+	let sentinelAlive = false;
+	let sentinelSocketSessionsBefore = "";
+	let child: ReturnType<typeof spawn> | null = null;
+	let observer: Awaited<ReturnType<typeof NativeSessionClient.discover>> | null = null;
+
+	try {
+		try {
+			await tmux.newSessionDetached({
+				sessionName: sentinelSession,
+				cwd: work,
+				socket: sentinelSocket,
+				command: "sleep 600",
+			});
+			sentinelAlive = await tmux.hasSession(sentinelSession, { socket: sentinelSocket });
+			sentinelSocketSessionsBefore = await listSessions(sentinelSocket);
+		} catch (err) {
+			console.log(`  SKIP - tmux sentinel unavailable (${err instanceof Error ? err.message : String(err)})`);
+		}
+
+		// ── app A comes up: it owns the pane and serves `_native.deliverPrompt` ──
+		child = spawn([process.execPath, ENTRY, "--role=owner"], { stdout: "pipe", stderr: "pipe" });
+		const childLines: string[] = [];
+		const childErrors: string[] = [];
+		collectLines(child.stdout as unknown as ReadableStream<Uint8Array>, childLines);
+		collectLines(child.stderr as unknown as ReadableStream<Uint8Array>, childErrors);
+		const readyLine = await waitForLine(childLines, READY_PREFIX, 90_000);
+		if (!readyLine) {
+			console.error(childErrors.slice(-10).join("\n"));
+			throw new Error("app A never reported readiness");
+		}
+		const ready = JSON.parse(readyLine.slice(READY_PREFIX.length)) as OwnerReady;
+		if (ready.error) throw new Error(`app A failed to start its pane: ${ready.error}`);
+		console.log(`  info - app A pid=${ready.pid} host=${ready.hostPid} shell=${ready.shellPid}`);
+		check(ready.role === "writer" && ready.echoOff, "app A holds the writer lease and its pane shell stopped echoing");
+
+		// ── app B binds the same pane ──
+		const reattached = await pty.reattachNativeTaskSession(TASK_ID, PROJECT_ID, work);
+		const terminal = reattached ? pty.nativePaneTerminal(TASK_ID, PANE_ID) : null;
+		if (!terminal) throw new Error("app B could not bind the pane app A created");
+		let localWrites = 0;
+		const passthrough = terminal.write.bind(terminal);
+		(terminal as { write: (data: string) => void }).write = (data) => {
+			localWrites++;
+			passthrough(data);
+		};
+
+		// An independent raw client is the pane's byte witness: it observes what the
+		// SHELL emitted, with no dependency on either app's own bookkeeping.
+		observer = await NativeSessionClient.discover(PANE_SESSION_ID);
+		const decoder = new TextDecoder();
+		let paneOutput = "";
+		observer.onOutput((bytes) => {
+			paneOutput += decoder.decode(bytes, { stream: true });
+		});
+
+		// ── 1. the lease lives in app A, not here ──
+		const owner = await resolvePaneOwner(terminal);
+		check(terminal.hostRole() === "observer", "app B is an OBSERVER on the pane — its own writes would be dropped");
+		check(
+			owner.kind === "peer" && owner.pid === ready.pid,
+			`app B resolves the pane owner as peer pid ${ready.pid} (got ${owner.kind === "peer" ? owner.pid : owner.kind})`,
+		);
+
+		const before = readRecord(PANE_SESSION_ID);
+
+		// ── 2. the production seam, called in the process that owns nothing ──
+		const task = {
+			id: TASK_ID,
+			projectId: PROJECT_ID,
+			worktreePath: work,
+			terminalBackend: "native",
+		} as unknown as Task;
+		const delivered = await deliverAgentPrompt(task, token);
+		check(delivered === true, "deliverAgentPrompt resolved TRUE in the non-owning process");
+
+		// ── 3. the token reached the pane's shell, submit CR and all ──
+		const lineDeadline = Date.now() + 15_000;
+		while (Date.now() < lineDeadline && !paneOutput.includes(token)) await delay(50);
+		check(
+			new RegExp(`(^|[\\r\\n])${token}[\\r\\n]`).test(paneOutput),
+			"the token came back from native pane-1 on a line of its own — the submit CR arrived",
+		);
+
+		// ── 4. exactly once, and still exactly once after the submit delay ──
+		const firstCount = occurrences(paneOutput, token);
+		check(firstCount === 1, `the token occurs exactly once in the pane output (got ${firstCount})`);
+		await delay(AGENT_PROMPT_ENTER_DELAY_MS + 4000);
+		const settledCount = occurrences(paneOutput, token);
+		check(settledCount === 1, `no late duplicate after the submit delay + margin (got ${settledCount})`);
+
+		// ── 5. app A wrote it; app B never wrote locally ──
+		const ownerWrites = childLines
+			.filter((line) => line.startsWith(WRITE_PREFIX))
+			.map((line) => JSON.parse(line.slice(WRITE_PREFIX.length)) as string);
+		check(
+			ownerWrites.filter((data) => data.includes(token)).length === 1,
+			`the owning process performed the delivery exactly once (${ownerWrites.length} owner write(s) total)`,
+		);
+		check(ownerWrites.filter((data) => data === "\r").length === 1, "the owning process sent exactly one submit CR");
+		check(localWrites === 0, "the forwarding process never wrote a byte into the pane itself");
+
+		// ── 6. the delivery changed no process identity ──
+		const after = readRecord(PANE_SESSION_ID);
+		check(
+			before?.host.pid === ready.hostPid && after?.host.pid === ready.hostPid,
+			"the pane's host pid is unchanged before vs after the delivery",
+		);
+		check(
+			before?.shell.pid === ready.shellPid && after?.shell.pid === ready.shellPid,
+			"the pane's shell pid is unchanged before vs after the delivery",
+		);
+
+		// ── 7. nothing was respawned ──
+		const sessionDirs = readdirSync(sessionsRootDir(), { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+		const taskDirs = sessionDirs.filter((name) => name.startsWith(`dev3-task-${TASK_ID}`));
+		const liveHostPids = new Set(
+			sessionDirs
+				.map((name) => readRecord(name)?.host.pid ?? -1)
+				.filter((pid) => pid > 0 && isProcessAlive(pid)),
+		);
+		check(taskDirs.length === 1, `exactly ONE registry session directory exists for this task (got ${taskDirs.length})`);
+		check(
+			liveHostPids.size === 1 && liveHostPids.has(ready.hostPid),
+			"exactly one live native host exists, and it is app A's original one",
+		);
+
+		// ── 8. tmux was never touched ──
+		// The DEFAULT socket is the developer's live one, so its full session list is
+		// not ours to compare — only the absence of this task's session name is
+		// attributable to us. The throwaway socket IS ours, so there the whole list
+		// must be byte-identical before and after.
+		if (sentinelAlive) {
+			check(
+				await tmux.hasSession(sentinelSession, { socket: sentinelSocket }),
+				"the pre-existing tmux sentinel session is still alive after the delivery",
+			);
+			check(
+				(await listSessions(sentinelSocket)) === sentinelSocketSessionsBefore,
+				"the throwaway socket's session list is unchanged — nothing was created or mutated there",
+			);
+			check(
+				!(await tmux.hasSession(taskSessionName(TASK_ID), { socket: sentinelSocket })),
+				"no tmux session named for this task exists on that socket",
+			);
+		} else {
+			console.log("  SKIP - tmux sentinel checks (tmux unavailable on this machine)");
+		}
+		check(
+			!(await tmux.hasSession(taskSessionName(TASK_ID))),
+			"no tmux session named for this task exists on the default socket either",
+		);
+	} finally {
+		try {
+			observer?.close();
+		} catch {
+			// best-effort
+		}
+		try {
+			child?.kill("SIGKILL");
+		} catch {
+			// best-effort
+		}
+		try {
+			await pty.destroyNativeTaskSession(TASK_ID);
+		} catch {
+			// best-effort
+		}
+		if (sentinelAlive) {
+			try {
+				await tmux.killSession(sentinelSession, { socket: sentinelSocket });
+			} catch {
+				// best-effort
+			}
+		}
+		try {
+			rmSync(root, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	}
+}
+
+const run = IS_OWNER ? runOwner : runSender;
+
+run()
+	.then(() => {
+		if (failures > 0) {
+			console.error(`\n${failures} check(s) FAILED`);
+			process.exit(1);
+		}
+		console.log("\nALL CHECKS PASSED");
+		process.exit(0);
+	})
+	.catch((err) => {
+		console.error("\nERROR:", err);
+		process.exit(1);
+	});

--- a/src/bun/__tests__/scheduled-message-scheduler.test.ts
+++ b/src/bun/__tests__/scheduled-message-scheduler.test.ts
@@ -13,6 +13,10 @@ vi.mock("../agent-prompt", () => ({
 	sendPromptToAgentPane: vi.fn(async () => true),
 	sendPromptToPane: vi.fn(async () => true),
 }));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => true),
+	sendPromptToNativePane: vi.fn(async () => true),
+}));
 vi.mock("../pty-server", () => ({ DEFAULT_TMUX_SOCKET: "dev3" }));
 const pushFn = vi.fn();
 vi.mock("../rpc-handlers", () => ({
@@ -26,6 +30,7 @@ vi.mock("../logger", () => ({
 
 import * as data from "../data";
 import { sendPromptToAgentPane, sendPromptToPane } from "../agent-prompt";
+import { sendPromptToNativeAgentPane, sendPromptToNativePane } from "../agent-prompt-native";
 import {
 	startScheduledMessageScheduler,
 	stopScheduledMessageScheduler,
@@ -84,6 +89,8 @@ beforeEach(() => {
 	pushFn.mockClear();
 	vi.mocked(sendPromptToAgentPane).mockResolvedValue(true);
 	vi.mocked(sendPromptToPane).mockResolvedValue(true);
+	vi.mocked(sendPromptToNativeAgentPane).mockResolvedValue(true);
+	vi.mocked(sendPromptToNativePane).mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -268,5 +275,57 @@ describe("cancel / send-now / immediate", () => {
 		vi.mocked(sendPromptToAgentPane).mockResolvedValue(false);
 		const task = makeTask();
 		await expect(sendMessageImmediately(task as never, "hello")).rejects.toThrow(/no live agent/i);
+	});
+});
+
+// Both entry points — the immediate `dev3 message` send and the queued
+// "Send later" fire — go through ONE seam (deliverToTarget → deliverAgentPrompt),
+// so a native task must reach the native adapter from either of them.
+describe("scheduled-message scheduler — native-backend tasks", () => {
+	const nativeTask = (overrides: Record<string, unknown> = {}) =>
+		makeTask({ terminalBackend: "native", worktreePath: "/tmp/worktree", ...overrides });
+
+	it("sendMessageImmediately delivers through the native adapter, not tmux", async () => {
+		const task = nativeTask();
+		await sendMessageImmediately(task as never, "hello now");
+		expect(sendPromptToNativeAgentPane).toHaveBeenCalledWith(
+			expect.objectContaining({ id: task.id }),
+			"hello now",
+		);
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("sendMessageImmediately still fails honestly when no native agent is live", async () => {
+		vi.mocked(sendPromptToNativeAgentPane).mockResolvedValue(false);
+		await expect(sendMessageImmediately(nativeTask() as never, "hello")).rejects.toThrow(/no live agent/i);
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("a due queued message fires through the native adapter and leaves the queue", async () => {
+		const task = nativeTask();
+		mockUpdateTaskWith(task);
+		vi.mocked(data.loadTasks).mockResolvedValue([task] as never);
+		startScheduledMessageScheduler();
+		await flush();
+		expect(sendPromptToNativeAgentPane).toHaveBeenCalledTimes(1);
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("an undeliverable queued message drops with the no-live-agent notice", async () => {
+		vi.mocked(sendPromptToNativeAgentPane).mockResolvedValue(false);
+		const message = makeMessage();
+		const task = nativeTask({ scheduledMessages: [message] });
+		mockUpdateTaskWith(task);
+		const { delivered } = await fireScheduledMessage(project, task as never, message as never, { late: false });
+		expect(delivered).toBe(false);
+		expect(pushFn).toHaveBeenCalledWith("cliToast", expect.objectContaining({ level: "error" }));
+	});
+
+	it("wraps a cross-task message in the envelope on the native path too", async () => {
+		const task = nativeTask();
+		await sendMessageImmediately(task as never, "hello now", null, { taskId: "other", seq: 7, title: "Sender" });
+		const text = vi.mocked(sendPromptToNativeAgentPane).mock.calls[0]![1];
+		expect(text).toContain("<from-task>seq:7</from-task>");
+		expect(text).toContain("hello now");
 	});
 });

--- a/src/bun/agent-prompt-delivery.ts
+++ b/src/bun/agent-prompt-delivery.ts
@@ -1,0 +1,47 @@
+/**
+ * The ONE backend-neutral entry point for typing a prompt into a task's agent.
+ *
+ * Everything that hands a task's agent some text goes through here: `dev3 message`
+ * (immediate), scheduled-message delivery, the Create-PR / auto-merge / commit
+ * hand-offs, and the rebase-conflict hand-off. Before this seam existed each of
+ * them called the tmux helpers directly, so a task running on the native backend
+ * had no pane to find and every send failed with "no live agent session" while the
+ * agent was plainly alive (seq 1371).
+ *
+ * Rules, all load-bearing:
+ *  - The task's persisted backend identity decides the path, and a task whose
+ *    marker cannot be read throws instead of guessing (`taskTerminalBackendIdentity`).
+ *  - A native task NEVER falls back to tmux. If its agent pane cannot be resolved
+ *    or written to, the answer is false — the caller's honest "no live agent
+ *    session" — not a tmux send that would type into nothing.
+ *  - The tmux path is the pre-existing code, unchanged, called with the same
+ *    arguments it was called with before.
+ */
+
+import type { ScheduledMessageTarget, Task } from "../shared/types";
+import { sendPromptToAgentPane, sendPromptToPane } from "./agent-prompt";
+import { sendPromptToNativeAgentPane, sendPromptToNativePane } from "./agent-prompt-native";
+import { taskTerminalBackendIdentity } from "./task-terminal-backend";
+import { DEFAULT_TMUX_SOCKET, taskSessionName } from "./tmux";
+
+/**
+ * Type `prompt` into `task`'s agent (or into one concrete pane) and submit it.
+ * Returns false when nothing usable is live, so callers keep their existing
+ * drop-with-notice / throw behavior.
+ */
+export async function deliverAgentPrompt(
+	task: Task,
+	prompt: string,
+	target: ScheduledMessageTarget = { kind: "agent" },
+): Promise<boolean> {
+	if (taskTerminalBackendIdentity(task) === "native") {
+		return target.kind === "pane"
+			? sendPromptToNativePane(task, target.paneId, prompt)
+			: sendPromptToNativeAgentPane(task, prompt);
+	}
+	const tmuxSession = taskSessionName(task.id);
+	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
+	return target.kind === "pane"
+		? sendPromptToPane(tmuxSession, socket, target.paneId, prompt)
+		: sendPromptToAgentPane(tmuxSession, socket, prompt, task.sessionState?.panes);
+}

--- a/src/bun/agent-prompt-native.ts
+++ b/src/bun/agent-prompt-native.ts
@@ -1,0 +1,203 @@
+/**
+ * Agent-pane discovery and prompt delivery for the NATIVE terminal backend —
+ * the counterpart of the tmux logic in {@link ./agent-prompt}.
+ *
+ * Three things make this different from tmux, and they are the whole reason the
+ * module exists:
+ *
+ *  - **Discovery is structural, not heuristic.** The agent always runs in the
+ *    coordinator's first pane: `startNativeTaskPanes` launches the agent wrapper
+ *    there, and every later split is a plain shell (`nativePaneAction` never
+ *    passes a launch spec). `createSplitTree` names that pane deterministically
+ *    and `recover()` drops dead panes out of the tree, so "`pane-1` is in the
+ *    pane set and alive" IS "the agent is running". No focus tracking, no
+ *    command sniffing.
+ *  - **A binding is not permission to write.** The host grants the writer lease
+ *    to ONE client across all dev3 app processes and silently drops an
+ *    observer's input, so ownership is resolved from the host itself
+ *    (`resolvePaneOwner`, decision 191) before anything is typed.
+ *  - **The delivery travels, not the bytes.** When another app process owns the
+ *    lease, the whole delivery is forwarded to it over the socket the CLI
+ *    already speaks and performed there exactly once. The forwarding process
+ *    never also writes, and the owner-side entry point never forwards again, so
+ *    there is no hop loop and no double submit.
+ *
+ * Never touches tmux, and never falls back to it: an unresolvable or unproven
+ * target is an honest "no live agent session".
+ */
+
+import type { Task } from "../shared/types";
+import { scheduleAgentPromptSubmit } from "./agent-prompt";
+import { createLogger } from "./logger";
+import { forwardToOwner, resolvePaneOwner } from "./native-pane-owner";
+import type { NativeTaskTerminal } from "./native-task-terminal";
+import { nativeTaskPanesState } from "./native-task-panes";
+import { ensureNativePanePtySession, nativePaneTerminal, reattachNativeTaskSession } from "./pty-server";
+
+const log = createLogger("agent-prompt-native");
+
+/** The coordinator pane the task's agent runs in (see the module header). */
+export const NATIVE_AGENT_PANE_ID = "pane-1";
+
+/** Carriage return — what a native PTY needs as the discrete "submit" keypress. */
+const SUBMIT_KEY = "\r";
+
+/**
+ * Internal CLI-socket method that performs one prompt delivery inside the app
+ * process holding the pane's writer lease. Owner-side only: its handler calls
+ * {@link deliverNativePromptAsOwner}, which never forwards, so a delivery can
+ * never bounce between two processes.
+ */
+export const NATIVE_PROMPT_DELIVERY_METHOD = "_native.deliverPrompt";
+
+/** Params of {@link NATIVE_PROMPT_DELIVERY_METHOD} — a whole delivery, already resolved. */
+export interface NativePromptDeliveryParams {
+	taskId: string;
+	paneId: string;
+	/** Final text, envelope-wrapping already applied by the sender. */
+	text: string;
+}
+
+/**
+ * The task's live agent pane id, or null when no agent is running. Extra
+ * shell-only splits never qualify, and a pane set that outlived its agent pane
+ * (shells still open, `pane-1` gone) correctly resolves to null. Reads the
+ * coordinator from disk, so it answers the same in every app process.
+ */
+export async function resolveNativeAgentPane(taskId: string): Promise<string | null> {
+	const state = await nativeTaskPanesState(taskId);
+	if (!state) return null;
+	const agentPane = state.panes.find((pane) => pane.paneId === NATIVE_AGENT_PANE_ID);
+	return agentPane?.alive ? agentPane.paneId : null;
+}
+
+/** Type the prompt, then submit it after the shared delay. One paste, one CR. */
+function typeThenSubmit(terminal: NativeTaskTerminal, paneId: string, prompt: string): void {
+	terminal.write(prompt);
+	scheduleAgentPromptSubmit(() => terminal.write(SUBMIT_KEY), { paneId });
+}
+
+/**
+ * This process's binding for `paneId`, binding it on demand when there is none —
+ * the app restarted, or this is simply not the process that launched the task.
+ * Never spawns: both helpers only rediscover an already-running host.
+ */
+async function bindPane(task: Task, paneId: string): Promise<NativeTaskTerminal | null> {
+	const existing = nativePaneTerminal(task.id, paneId);
+	if (existing) return existing;
+	if (!task.worktreePath) return null;
+
+	try {
+		if (paneId === NATIVE_AGENT_PANE_ID) {
+			await reattachNativeTaskSession(task.id, task.projectId, task.worktreePath);
+		} else {
+			const state = await nativeTaskPanesState(task.id);
+			const pane = state?.panes.find((p) => p.paneId === paneId && p.alive);
+			if (!pane) return null;
+			await ensureNativePanePtySession(task.id, paneId, pane.sessionId, task.projectId, task.worktreePath);
+		}
+	} catch (err) {
+		log.warn("Binding the native pane before prompt delivery failed", {
+			taskId: task.id.slice(0, 8),
+			paneId,
+			error: String(err),
+		});
+		return null;
+	}
+	return nativePaneTerminal(task.id, paneId);
+}
+
+/**
+ * Perform a delivery in THIS process, which must hold the writer lease.
+ *
+ * The owner-side half of the forwarding hop, and deliberately a dead end: it
+ * resolves no owner and forwards nothing, so a stale answer can never make two
+ * processes bounce one message back and forth. Returns false when the lease is
+ * not (or no longer) ours — the sender then reports an undelivered message
+ * rather than a phantom success.
+ */
+export async function deliverNativePromptAsOwner(params: NativePromptDeliveryParams): Promise<boolean> {
+	const terminal = nativePaneTerminal(params.taskId, params.paneId);
+	if (!terminal) return false;
+	if (terminal.hostRole() !== "writer") {
+		// The lease may have fallen vacant between the sender resolving us and this
+		// call landing; claiming is safe because the host refuses while it is held.
+		if ((await terminal.claimHostWriter()) !== "writer") {
+			log.warn("Owner-routed delivery arrived without the writer lease", {
+				taskId: params.taskId.slice(0, 8),
+				paneId: params.paneId,
+			});
+			return false;
+		}
+	}
+	typeThenSubmit(terminal, params.paneId, params.text);
+	return true;
+}
+
+/**
+ * Type `prompt` into one native pane, wherever its writer lease lives.
+ * Returns false when nothing was (provably) delivered.
+ */
+export async function sendPromptToNativePane(task: Task, paneId: string, prompt: string): Promise<boolean> {
+	const terminal = await bindPane(task, paneId);
+	if (!terminal) return false;
+
+	const owner = await resolvePaneOwner(terminal);
+	const context = { taskId: task.id.slice(0, 8), paneId, owner: owner.kind };
+
+	switch (owner.kind) {
+		case "local":
+			typeThenSubmit(terminal, paneId, prompt);
+			return true;
+
+		case "vacant": {
+			// Nobody is typing — take the lease and deliver here.
+			if ((await terminal.claimHostWriter()) === "writer") {
+				typeThenSubmit(terminal, paneId, prompt);
+				return true;
+			}
+			log.info("Writer lease was taken while claiming it; not delivering", context);
+			return false;
+		}
+
+		case "peer": {
+			// Forward the WHOLE delivery, never the bytes, and never write locally
+			// as well — that is what keeps it exactly once.
+			const params: NativePromptDeliveryParams = { taskId: task.id, paneId, text: prompt };
+			try {
+				const delivered = await forwardToOwner<{ delivered: boolean }>(
+					owner,
+					NATIVE_PROMPT_DELIVERY_METHOD,
+					params as unknown as Record<string, unknown>,
+				);
+				log.info("Prompt delivery routed to the owning app process", { ...context, ownerPid: owner.pid });
+				return delivered?.delivered === true;
+			} catch (err) {
+				log.warn("Forwarding the prompt to the owning app process failed", {
+					...context,
+					ownerPid: owner.pid,
+					error: String(err),
+				});
+				return false;
+			}
+		}
+
+		case "unknown":
+		case "gone":
+		default:
+			// The host cannot name an owner, so a write here would be dropped
+			// silently. Report it as undelivered rather than guess.
+			log.info("No provable writer for this native pane", context);
+			return false;
+	}
+}
+
+/** Deliver `prompt` to the task's live native agent pane; false when none is running. */
+export async function sendPromptToNativeAgentPane(task: Task, prompt: string): Promise<boolean> {
+	const paneId = await resolveNativeAgentPane(task.id);
+	if (!paneId) {
+		log.info("No live native agent pane for this task", { taskId: task.id.slice(0, 8) });
+		return false;
+	}
+	return sendPromptToNativePane(task, paneId, prompt);
+}

--- a/src/bun/agent-prompt.ts
+++ b/src/bun/agent-prompt.ts
@@ -121,6 +121,27 @@ export async function resolveAgentPromptTargetPane(
 	return activePane;
 }
 
+/**
+ * Schedule the single submit keypress that ends a prompt delivery. Exactly one
+ * per delivery: callers invoke it only from the success path of the paste, and
+ * it never retries — a re-sent Enter would submit whatever the agent's input
+ * box holds at that moment.
+ */
+export function scheduleAgentPromptSubmit(send: () => void | Promise<void>, context: Record<string, string>): void {
+	setTimeout(() => {
+		// `send` runs synchronously inside the timer — a `.then(send)` hop would
+		// defer it by a microtask, which is a real behavior change for callers that
+		// drive the clock (and for how promptly the agent sees the submit).
+		try {
+			void Promise.resolve(send()).catch((err) =>
+				log.warn("agent prompt submit failed", { ...context, error: String(err) }),
+			);
+		} catch (err) {
+			log.warn("agent prompt submit threw", { ...context, error: String(err) });
+		}
+	}, AGENT_PROMPT_ENTER_DELAY_MS);
+}
+
 /** Type `text` into `pane`, then send Enter as a discrete keypress after a short delay. */
 async function pasteThenEnter(socket: string, pane: string, text: string): Promise<boolean> {
 	try {
@@ -132,11 +153,7 @@ async function pasteThenEnter(socket: string, pane: string, text: string): Promi
 		log.warn("send-keys paste failed", { paneId: pane, error: String(err) });
 		return false;
 	}
-	setTimeout(() => {
-		tmux.sendKeys(pane, ["Enter"], { socket, bestEffort: true }).catch((err) => {
-			log.warn("send-keys Enter failed", { paneId: pane, error: String(err) });
-		});
-	}, AGENT_PROMPT_ENTER_DELAY_MS);
+	scheduleAgentPromptSubmit(() => tmux.sendKeys(pane, ["Enter"], { socket, bestEffort: true }), { paneId: pane });
 	return true;
 }
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -15,6 +15,7 @@ import { createScratchTask, deleteTask, getPushMessage, getPushMessageLocal, lau
 import { getDevServerStatus, runDevServer, stopDevServer, restartDevServer } from "./rpc-handlers/tmux-pty";
 import { getTmuxLayout } from "./pty-server";
 import { scheduleMessage as scheduleMessageCore, sendMessageImmediately } from "./scheduled-message-scheduler";
+import { NATIVE_PROMPT_DELIVERY_METHOD, deliverNativePromptAsOwner } from "./agent-prompt-native";
 import { getUserIdleSeconds } from "./user-activity";
 import * as repoConfig from "./repo-config";
 import { loadSettings } from "./settings";
@@ -1175,6 +1176,19 @@ const handlers: Record<string, Handler> = {
 		const source = await resolveAgentMessageSource(params, task.id);
 		await sendMessageImmediately(task, text, null, source);
 		return { delivered: true, taskId: task.id, projectId: project.id };
+	},
+
+	// Owner-routed half of native prompt delivery: another dev-3.0 instance
+	// resolved US as the holder of this pane's writer lease and handed over the
+	// whole delivery. Performs it here, exactly once, and never forwards again
+	// (see agent-prompt-native.ts) — a stale owner answer cannot start a hop loop.
+	[NATIVE_PROMPT_DELIVERY_METHOD]: async (params) => {
+		const delivered = await deliverNativePromptAsOwner({
+			taskId: (params.taskId as string) ?? "",
+			paneId: (params.paneId as string) ?? "",
+			text: ((params.text as string) ?? "").toString(),
+		});
+		return { delivered };
 	},
 
 	// `dev3 message --in <dur> | --at <hh:mm> "text"`: queue a scheduled message on

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -14,7 +14,7 @@ import * as git from "../git";
 import * as github from "../github";
 import { tmux, DEFAULT_TMUX_SOCKET, TmuxError, taskSessionName, PANE_ID_FORMAT, PANE_START_COMMAND_FORMAT } from "../tmux";
 import { dev3TaskTempPath } from "../temp-paths";
-import { sendPromptToAgentPane } from "../agent-prompt";
+import { deliverAgentPrompt } from "../agent-prompt-delivery";
 import {
 	scheduleMessage as scheduleMessageCore,
 	cancelScheduledMessage as cancelScheduledMessageCore,
@@ -548,11 +548,8 @@ async function createPullRequest(params: { taskId: string; projectId: string; au
 
 	assertGitTask(project, task);
 
-	const tmuxSession = taskSessionName(task.id);
-	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
-
 	const prompt = params.autoMerge ? CREATE_PR_AUTO_MERGE_AGENT_PROMPT : CREATE_PR_AGENT_PROMPT;
-	const handedOff = await sendPromptToAgentPane(tmuxSession, socket, prompt, task.sessionState?.panes);
+	const handedOff = await deliverAgentPrompt(task, prompt);
 	if (!handedOff) {
 		log.info("← createPullRequest skipped — no active pane", { taskId: task.id.slice(0, 8) });
 		return;
@@ -577,10 +574,7 @@ async function rebaseTaskViaAgent(params: { taskId: string; projectId: string; c
 
 	const baseBranch = resolveTaskCompareBaseBranch(task, project);
 	const rebaseTarget = params.compareRef || `origin/${baseBranch}`;
-	const tmuxSession = taskSessionName(task.id);
-	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
-
-	const handedOff = await sendPromptToAgentPane(tmuxSession, socket, rebaseConflictAgentPrompt(rebaseTarget), task.sessionState?.panes);
+	const handedOff = await deliverAgentPrompt(task, rebaseConflictAgentPrompt(rebaseTarget));
 	log.info("← rebaseTaskViaAgent", { taskId: task.id.slice(0, 8), handedOff });
 	return { handedOff };
 }
@@ -598,10 +592,7 @@ async function commitTaskViaAgent(params: { taskId: string; projectId: string })
 
 	assertGitTask(project, task);
 
-	const tmuxSession = taskSessionName(task.id);
-	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
-
-	const handedOff = await sendPromptToAgentPane(tmuxSession, socket, COMMIT_AGENT_PROMPT, task.sessionState?.panes);
+	const handedOff = await deliverAgentPrompt(task, COMMIT_AGENT_PROMPT);
 	log.info("← commitTaskViaAgent", { taskId: task.id.slice(0, 8), handedOff });
 	return { handedOff };
 }

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -10,8 +10,7 @@ import {
 	MAX_SCHEDULED_MESSAGE_LENGTH,
 } from "../shared/types";
 import * as data from "./data";
-import { DEFAULT_TMUX_SOCKET, taskSessionName } from "./tmux";
-import { sendPromptToAgentPane, sendPromptToPane } from "./agent-prompt";
+import { deliverAgentPrompt } from "./agent-prompt-delivery";
 import { wrapAgentMessage } from "../shared/agent-message-envelope";
 // Import push via the barrel (not ./rpc-handlers/shared) so tests that mock
 // `../rpc-handlers` — e.g. the cli-socket lost-update race suites, which reach
@@ -52,21 +51,20 @@ function messagePreview(text: string): string {
 }
 
 /**
- * Resolve the delivery target and type the text (send-keys paste + delayed
- * Enter) into it. `agent` resolves the live agent pane dynamically; `pane`
- * targets a concrete live pane. Returns false when nothing usable is live —
- * the caller then takes the drop-with-notice path.
+ * Resolve the delivery target and type the text into it, then submit it.
+ * `agent` resolves the live agent pane dynamically; `pane` targets a concrete
+ * live pane. Backend-neutral — the tmux/native split lives behind
+ * {@link deliverAgentPrompt}. Returns false when nothing usable is live: the
+ * caller then takes the drop-with-notice path.
+ *
+ * The ONE seam shared by immediate `dev3 message` sends and queued
+ * "Send later" fires, so the two can never drift apart again.
  */
 async function deliverToTarget(task: Task, message: ScheduledMessage): Promise<boolean> {
-	const tmuxSession = taskSessionName(task.id);
-	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
 	// Agent-to-agent traffic is wrapped at delivery time, so the queue (and the
 	// card chip that previews it) keeps the plain text the sender wrote.
 	const text = message.source ? wrapAgentMessage(message.text, message.source) : message.text;
-	if (message.target.kind === "pane") {
-		return sendPromptToPane(tmuxSession, socket, message.target.paneId, text);
-	}
-	return sendPromptToAgentPane(tmuxSession, socket, text, task.sessionState?.panes);
+	return deliverAgentPrompt(task, text, message.target);
 }
 
 /** Toast + attention for a late-fire or drop. Silent path never calls this. */


### PR DESCRIPTION
`dev3 message`, scheduled "Send later" messages, and the Create-PR / commit / rebase-conflict hand-offs all typed into a task's agent through the tmux-only `sendPromptToAgentPane`. A task on the native terminal backend has no tmux session, so pane resolution returned `null` and every send failed with `Could not deliver the message — the task has no live agent session.` while the agent was alive (reproduced on a live three-pane native task, seq 1371).

**What changed**

- New `src/bun/agent-prompt-delivery.ts` — one backend-neutral seam (`deliverAgentPrompt`) shared by immediate sends, scheduled fires, and all three git hand-offs. The persisted `terminalBackend` marker picks the path; an unreadable marker throws instead of guessing, and a native task never falls back to tmux.
- New `src/bun/agent-prompt-native.ts` — native agent discovery and delivery. Discovery is structural: the agent runs in the coordinator's `pane-1` (splits are shell-only by construction), so "`pane-1` present and alive" is "the agent is running". No focus following — the live repro had a *shell* as the active pane.
- `pty-server.findNativePaneBinding` / `writeToNativePane` — delivery reuses the app's existing writer binding, because the host grants one writer per pane and silently drops an observer's input. The bound pane id is verified, and a process holding no binding (app restarted) reattaches first.
- tmux delivery is byte-for-byte the same code, called with the same arguments.

Invariants recorded in `decisions/190-native-agent-prompt-delivery.md`.

**Coverage** — native single-pane, multi-pane with a focused shell split, shell-only survivors, dead agent pane, stopped task, restart/reattach discovery, exactly-once submit, and tmux regressions across both entry points. One pre-existing failure remains in `native-host-runtime.test.ts` (`omits the opt-in proof flags…`), verified failing at clean `HEAD` before this branch.