### PR TITLE
Fix launch picker overlay stacking

### DIFF
--- a/change-logs/2026/08/01/fix-account-picker-layer.md
+++ b/change-logs/2026/08/01/fix-account-picker-layer.md
@@ -1,0 +1,3 @@
+Short: Keep picker menus visible
+
+Raise the launch picker’s portalled favorites menu above modal surfaces so account and preset selection stays visible and usable.

--- a/src/mainview/components/FavoritesMenu.tsx
+++ b/src/mainview/components/FavoritesMenu.tsx
@@ -129,7 +129,7 @@ function FavoritesMenu({
 			ref={menuRef}
 			role="menu"
 			aria-label={t("launch.favorites")}
-			className={`fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active overflow-hidden py-1 max-w-[calc(100vw-1rem)] origin-top ${
+			className={`fixed z-[10000] bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active overflow-hidden py-1 max-w-[calc(100vw-1rem)] origin-top ${
 				reducedMotion ? "" : "transition-[opacity,transform] duration-150"
 			} ${entered ? "opacity-100 scale-100" : "opacity-0 scale-[0.98]"}`}
 			style={{ top: pos.top, left: pos.left, width: 360 }}

--- a/src/mainview/components/__tests__/AgentConfigPicker.favorites.test.tsx
+++ b/src/mainview/components/__tests__/AgentConfigPicker.favorites.test.tsx
@@ -161,6 +161,14 @@ describe("AgentConfigPicker — favorites", () => {
 		expect(menu()).toHaveStyle({ width: "360px" });
 	});
 
+	it("keeps the favorites menu above its surrounding modal", async () => {
+		const user = userEvent.setup();
+		({ container } = render(<Harness initial={{ agentId: "builtin-claude", configId: "fable-auto-medium" }} />));
+
+		await user.click(trigger()!);
+		expect(menu()).toHaveClass("z-[10000]");
+	});
+
 	it("clicking a menu item selects that combo (does not launch) and closes the menu", async () => {
 		const user = userEvent.setup();
 		const onChange = vi.fn();


### PR DESCRIPTION
## Summary

- Raise the portalled launch-picker favorites menu above modal surfaces.
- Add a regression test for the overlay layer and document the user-visible fix.

## Root cause

`FavoritesMenu` used `z-50`, while the launch modal uses `z-[60]`. Because the menu is portalled to `document.body`, it was rendered behind the modal instead of above it.

## Validation

- `bun run lint`
- `env -u DEV3_NATIVE_SESSION_COLS -u DEV3_NATIVE_SESSION_ROWS -u DEV3_NATIVE_SESSION_LIVE_PARSER -u DEV3_NATIVE_SESSION_STATE_TAP bun run test`
- Streamer-mode browser QA: menu visible above the launch modal; no browser errors.