### PR TITLE
Run the dev3 tmux server only on the bundled config

### DIFF
--- a/change-logs/2026/08/02/fix-isolate-tmux-config.md
+++ b/change-logs/2026/08/02/fix-isolate-tmux-config.md
@@ -1,0 +1,3 @@
+Short: tmux panes ignore your personal tmux.conf
+
+The dev3 tmux server now runs exclusively on the bundled config and no longer sources `/etc/tmux.conf`, `~/.tmux.conf` or `~/.config/tmux/tmux.conf`. Personal prefix keys, plugin managers and status-line overrides can no longer change how dev3 terminals behave; detached sessions also pass `-f` now, so the config is identical no matter which session starts the server. Your own tmux on the default socket is unaffected.

--- a/decisions/197-isolate-tmux-config.md
+++ b/decisions/197-isolate-tmux-config.md
@@ -1,0 +1,43 @@
+# 197 — Isolate the dev3 tmux server from the user's tmux config
+
+## Context
+
+Since the theme-switching change (change-logs/2026/03/18), the generated dev3 tmux
+config ended with three `if-shell … source-file` lines pulling in `/etc/tmux.conf`,
+`~/.tmux.conf` and `~/.config/tmux/tmux.conf`. The intent was to preserve personal
+keybindings inside dev3 panes. In practice it makes every dev3 terminal depend on
+state we do not control: a user `set -g prefix`, `status` override, plugin manager
+(`run-shell '~/.tmux/plugins/tpm/tpm'`), `mouse off`, or a smaller `history-limit`
+silently changes or breaks dev3 behavior, and bug reports become unreproducible.
+
+## Investigation
+
+`-f` is only honored when it starts the server, and only `new-session` starts one.
+`spawnAttachedSession` already passed `-f`; `newSessionDetached` (native terminal
+backend, dev-server sessions) did not — so whichever of the two started the dev3
+server decided whether `~/.tmux.conf` got loaded. That is a race, not a policy.
+
+## Decision
+
+The dev3 tmux server runs **exclusively** on the generated config.
+
+- `TMUX_CONFIG_FUNCTIONAL` (`src/bun/tmux/config.ts`) no longer sources the system
+  or user configs — the three `if-shell` lines are deleted, not made optional.
+- `TmuxClient.newSessionDetached` (`src/bun/tmux/client.ts`) now prepends
+  `-f activeTmuxConfigPath()`, so every server-starting path passes `-f` and tmux
+  never falls back to its default config search.
+
+## Risks
+
+Users with personal tmux settings lose them inside dev3 panes (prefix key, plugins,
+status line). That is the intended trade-off: dev3 panes are app surface, not the
+user's tmux. Their own `tmux` on the default socket is untouched — dev3 has always
+run on the `-L dev3` socket.
+
+## Alternatives considered
+
+- **Keep sourcing, add a setting.** Ships the same non-reproducible behavior with a
+  switch; nobody would find it before filing the bug report.
+- **`-f /dev/null` plus `source-file` of ours.** Same result, one more indirection.
+- **Add `-f` everywhere in `argv()`.** tmux ignores it on a live server, so it would
+  only add noise to every command's argv and to every test asserting argv.

--- a/src/bun/tmux/__tests__/client.test.ts
+++ b/src/bun/tmux/__tests__/client.test.ts
@@ -13,6 +13,7 @@ import {
 	WINDOW_SWITCHER_FORMAT,
 	STATUS_GEOMETRY_FORMAT,
 } from "../formats";
+import { activeTmuxConfigPath } from "../config";
 import { DEV3_HOME } from "../../paths";
 
 // The client is constructed with an INJECTED fake spawn — the only seam its
@@ -235,7 +236,7 @@ describe("splitWindow / newWindow", () => {
 });
 
 describe("newSessionDetached", () => {
-	it("starts detached with env flags and pins the client cwd to DEV3_HOME", async () => {
+	it("starts detached with -f, env flags, and pins the client cwd to DEV3_HOME", async () => {
 		const { client, spawnFn } = makeClient({ stderr: "" });
 		const { stderr } = await client.newSessionDetached({
 			sessionName: "dev3-dev-abc",
@@ -245,7 +246,7 @@ describe("newSessionDetached", () => {
 		});
 		expect(stderr).toBe("");
 		expect(argvOf(spawnFn)).toEqual([
-			"tmux", "-L", "dev3", "new-session", "-d",
+			"tmux", "-L", "dev3", "-f", activeTmuxConfigPath(), "new-session", "-d",
 			"-e", "DEV3_TASK_ID=t1",
 			"-s", "dev3-dev-abc", "-c", "/wt", "bash dev.sh",
 		]);

--- a/src/bun/tmux/__tests__/config.test.ts
+++ b/src/bun/tmux/__tests__/config.test.ts
@@ -72,6 +72,15 @@ describe("buildThemeConfig", () => {
 		);
 	});
 
+	it("never sources the system or user tmux configs", () => {
+		for (const flavor of ["mocha", "latte"] as const) {
+			const config = buildThemeConfig(flavor);
+			expect(config).not.toContain("/etc/tmux.conf");
+			expect(config).not.toContain("~/.tmux.conf");
+			expect(config).not.toContain("~/.config/tmux/tmux.conf");
+		}
+	});
+
 	it("selects the requested Catppuccin flavor", () => {
 		expect(buildThemeConfig("mocha")).toContain('@catppuccin_flavor "mocha"');
 		expect(buildThemeConfig("latte")).toContain('@catppuccin_flavor "latte"');

--- a/src/bun/tmux/client.ts
+++ b/src/bun/tmux/client.ts
@@ -23,7 +23,7 @@ import {
 	selectTmuxBinary,
 } from "./binary";
 import { DEFAULT_TMUX_SOCKET } from "./constants";
-import { tmuxClientCwd } from "./config";
+import { activeTmuxConfigPath, tmuxClientCwd } from "./config";
 import { TmuxError, TmuxSpawnError } from "./errors";
 import type { TmuxFormat } from "./formats";
 import { PANE_ID_FORMAT } from "./formats";
@@ -173,7 +173,10 @@ export class TmuxClient {
 		env?: Record<string, string>;
 		command?: string;
 	} & SocketOpt): Promise<{ stderr: string }> {
-		const args = ["new-session", "-d"];
+		// `-f` on every server-starting command: without it tmux falls back to
+		// /etc/tmux.conf + ~/.tmux.conf and the user's personal settings leak
+		// into the dev3 server (decisions/197-isolate-tmux-config.md).
+		const args = ["-f", activeTmuxConfigPath(), "new-session", "-d"];
 		for (const [key, value] of Object.entries(opts.env ?? {})) {
 			args.push("-e", `${key}=${value}`);
 		}

--- a/src/bun/tmux/config.ts
+++ b/src/bun/tmux/config.ts
@@ -76,11 +76,8 @@ export function setActiveTmuxTheme(theme: "dark" | "light"): string {
 
 // Shared functional settings (not theme-related)
 const TMUX_CONFIG_FUNCTIONAL = String.raw`
-# Source system and user tmux configs first, so personal keybindings
-# and preferences are preserved. Our settings below override as needed.
-if-shell "test -f /etc/tmux.conf" "source-file /etc/tmux.conf"
-if-shell "test -f ~/.tmux.conf" "source-file ~/.tmux.conf"
-if-shell "test -f ~/.config/tmux/tmux.conf" "source-file ~/.config/tmux/tmux.conf"
+# System and user tmux configs are deliberately NOT sourced: the dev3 server
+# runs exclusively on this config. See decisions/197-isolate-tmux-config.md.
 
 # Mouse support
 setw -g mouse on


### PR DESCRIPTION
The dev3 tmux server no longer sources the system or user tmux configs (`/etc/tmux.conf`, `~/.tmux.conf`, `~/.config/tmux/tmux.conf`). Personal prefix keys, plugin managers, status-line overrides and a smaller `history-limit` can no longer change how dev3 terminals behave, and bug reports stop depending on state we do not control.

Second half of the fix: `-f` was only passed by `spawnAttachedSession`, not by `newSessionDetached` (native terminal backend, dev-server sessions). Since `-f` is only honored by whichever command starts the server, that made the effective config a race. Both server-starting paths now pass `-f`.

The user's own tmux on the default socket is untouched — dev3 has always run on the `-L dev3` socket.

Rationale and alternatives: `decisions/197-isolate-tmux-config.md`.