### PR TITLE
Clear the inline diff review automatically after a successful send

### DIFF
--- a/change-logs/2026/08/03/feature-auto-clear-review-after-send.md
+++ b/change-logs/2026/08/03/feature-auto-clear-review-after-send.md
@@ -1,0 +1,3 @@
+Short: Review clears itself after sending
+
+Sending an inline diff review to the agent now clears the comments automatically, so "Reset review" and its confirmation are no longer part of every review cycle. A failed send keeps the comments intact for a retry, and the manual Reset button stays for dropping comments without sending.

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -2330,6 +2330,10 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 		api.request.sendAgentMessageNow({ taskId: task.id, projectId: project.id, text: snapshot })
 			.then(() => {
 				setReviewSendState("sent");
+				// Delivered comments are dead weight: clear them here so the reviewer
+				// never has to run the destructive "Reset review" as a routine step.
+				setInlineComments({});
+				setEditingCommentId(null);
 				toast.success(t("infoPanel.diffReviewExportSendSuccess"));
 			})
 			.catch((err) => {

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -1807,16 +1807,6 @@ describe("TaskDiffViewer", () => {
 		expect(screen.getByRole("button", { name: "Copy to Clipboard" })).toHaveClass("w-full");
 		expect(screen.getByRole("button", { name: "Send to Agent" })).toBeEnabled();
 
-		await user.click(screen.getByRole("button", { name: "Send to Agent" }));
-		await waitFor(() => {
-			expect(api.request.sendAgentMessageNow).toHaveBeenCalledWith({
-				taskId: "t1",
-				projectId: "p1",
-				text: expect.stringContaining(`<comment>${longComment}</comment>`),
-			});
-		});
-		expect(screen.getByRole("button", { name: "Sent" })).toBeInTheDocument();
-
 		await user.click(screen.getByRole("button", { name: "Comment 1" }));
 		await waitFor(() => {
 			expect(scrollIntoViewMock).toHaveBeenCalled();
@@ -2473,6 +2463,56 @@ describe("TaskDiffViewer", () => {
 		await waitFor(() => {
 			expect(screen.queryAllByText("kill me")).toHaveLength(0);
 		});
+		expect(screen.queryByTestId("review-reset-button")).not.toBeInTheDocument();
+		expect(localStorage.getItem(reviewKey)).toBeNull();
+	});
+
+	it("clears the review after a successful send, and keeps it when the send fails", async () => {
+		const user = userEvent.setup();
+		const reviewKey = "dev3-inline-diff-review-v1:t1";
+		const showConfirm = vi.mocked(confirm);
+		vi.mocked(api.request.sendAgentMessageNow).mockRejectedValueOnce(new Error("no agent"));
+
+		render(
+			<I18nProvider>
+				<TaskDiffViewer
+					task={task}
+					project={project}
+					request={{ mode: "branch", compareRef: "origin/main", compareLabel: "origin/main" }}
+					onBack={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+
+		const diffs = await screen.findAllByTestId("mock-diff");
+		await user.click(within(diffs[0]).getByRole("button", { name: "Open inline comment composer" }));
+		await user.type(screen.getByPlaceholderText("Leave a comment on this line..."), "send me");
+		await user.click(screen.getByRole("button", { name: "Add comment" }));
+
+		await waitFor(() => {
+			expect(localStorage.getItem(reviewKey)).toContain("send me");
+		});
+
+		// Failed send: the comments must survive so the reviewer can retry.
+		await user.click(screen.getByTestId("review-send-button"));
+		await waitFor(() => {
+			expect(api.request.sendAgentMessageNow).toHaveBeenCalledWith({
+				taskId: "t1",
+				projectId: "p1",
+				text: expect.stringContaining("<comment>send me</comment>"),
+			});
+		});
+		expect(screen.getAllByText("send me").length).toBeGreaterThan(0);
+		expect(localStorage.getItem(reviewKey)).toContain("send me");
+
+		// Successful send: comments are delivered, so they clear without a confirm.
+		vi.mocked(api.request.sendAgentMessageNow).mockResolvedValueOnce(undefined as never);
+		await user.click(screen.getByTestId("review-send-button"));
+
+		await waitFor(() => {
+			expect(screen.queryAllByText("send me")).toHaveLength(0);
+		});
+		expect(showConfirm).not.toHaveBeenCalled();
 		expect(screen.queryByTestId("review-reset-button")).not.toBeInTheDocument();
 		expect(localStorage.getItem(reviewKey)).toBeNull();
 	});

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -176,7 +176,7 @@ const infoPanel = {
 	"infoPanel.diffReviewExportSend": "Send to Agent",
 	"infoPanel.diffReviewExportSendSending": "Sending\u2026",
 	"infoPanel.diffReviewExportSendSent": "Sent",
-	"infoPanel.diffReviewExportSendSuccess": "Review sent to the agent",
+	"infoPanel.diffReviewExportSendSuccess": "Review sent to the agent — comments cleared",
 	"infoPanel.diffReviewExportSendFailed": "Could not send the review to the agent: {error}",
 	"infoPanel.diffReviewExportCopyTooltipTitle": "Copy review as a prompt",
 	"infoPanel.diffReviewExportCopyTooltip": "Copy the review as an XML prompt to your clipboard — paste it into any agent yourself.",

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -176,7 +176,7 @@ const infoPanel = {
 	"infoPanel.diffReviewExportSend": "Enviar al agente",
 	"infoPanel.diffReviewExportSendSending": "Enviando\u2026",
 	"infoPanel.diffReviewExportSendSent": "Enviado",
-	"infoPanel.diffReviewExportSendSuccess": "Review enviado al agente",
+	"infoPanel.diffReviewExportSendSuccess": "Review enviado al agente — comentarios borrados",
 	"infoPanel.diffReviewExportSendFailed": "No se pudo enviar el review al agente: {error}",
 	"infoPanel.diffReviewExportCopyTooltipTitle": "Copiar el review como prompt",
 	"infoPanel.diffReviewExportCopyTooltip": "Copia el review como prompt XML al portapapeles — pégalo tú mismo en cualquier agente.",

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -186,7 +186,7 @@ const infoPanel = {
 	"infoPanel.diffReviewExportSend": "Отправить агенту",
 	"infoPanel.diffReviewExportSendSending": "Отправка\u2026",
 	"infoPanel.diffReviewExportSendSent": "Отправлено",
-	"infoPanel.diffReviewExportSendSuccess": "Ревью отправлено агенту",
+	"infoPanel.diffReviewExportSendSuccess": "Ревью отправлено агенту — комментарии очищены",
 	"infoPanel.diffReviewExportSendFailed": "Не удалось отправить ревью агенту: {error}",
 	"infoPanel.diffReviewExportCopyTooltipTitle": "Скопировать ревью как промпт",
 	"infoPanel.diffReviewExportCopyTooltip": "Скопировать ревью как XML-промпт в буфер обмена — вставите в любого агента сами.",


### PR DESCRIPTION
Feedback from Alexander Kiselyov: the review cycle was always four steps — write comments, "Send to Agent", "Reset review", confirm a destructive dialog. After a successful send the comments are already delivered, so the reset and its confirmation were pure friction.

- A successful send now clears the inline review comments (and their persisted entry) automatically — no extra click, no confirmation dialog.
- A failed send changes nothing: the comments survive so the reviewer can retry.
- The manual "Reset review" button keeps its confirmation for the "changed my mind, drop the comments without sending" case.
- The success toast now says the review was sent *and* cleared, so the disappearance is not a surprise (en/ru/es).