### PR TITLE
Spawn extra task agents through the backend-neutral pane seam

### DIFF
--- a/change-logs/2026/08/02/fix-native-extra-agent-spawn.md
+++ b/change-logs/2026/08/02/fix-native-extra-agent-spawn.md
@@ -1,0 +1,3 @@
+Short: Spawn extra agents on native tasks
+
+The "+ Agent" action now opens its pane through the shared backend-neutral pane seam, so a task running the native terminal gets a real extra agent pane instead of a failed tmux split. Native launches no longer write a phantom tmux pane entry, a failed launch reports why instead of leaving a half-started agent, and tmux tasks keep their existing split and pane bookkeeping.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -8416,6 +8416,145 @@ describe("handlers.spawnAgentInTask", () => {
 		// 3rd arg is the per-launch accountId (undefined here → registry default).
 		expect(agents.ensureClaudeTrust).toHaveBeenCalledWith("/tmp/wt", project.path, undefined);
 	});
+
+	// The tmux pane registry is what recovery reconciles against live tmux panes,
+	// so the tmux path must keep appending to it (the native path must not).
+	it("appends the new pane to sessionState on a tmux task", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/wt" });
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockResolvedValue(task);
+		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
+		mockSpawn.mockReturnValue({ stderr: new Response(""), stdout: "%7\n", exited: Promise.resolve(0) });
+
+		await handlers.spawnAgentInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default" });
+
+		const write = (data.updateTask as any).mock.calls.find((c: any[]) => c[2]?.sessionState);
+		expect(write).toBeDefined();
+		expect(write[2].sessionState.panes).toHaveLength(1);
+		expect(write[2].sessionState.panes[0]).toMatchObject({ paneId: "%7", agentId: "builtin-claude", configId: "claude-default" });
+	});
+});
+
+// ================================================================
+// handlers.spawnAgentInTask on a NATIVE task (seq 1397)
+//
+// Same "+ Agent" entry point the Spawn Agent dialog calls, on a task whose
+// terminal is native rather than tmux. It used to split `dev3-<id>` blindly,
+// so on a native task there was no such session and the launch died.
+// ================================================================
+
+describe("handlers.spawnAgentInTask on a native task", () => {
+	const TASK_ID = "abcd1234-full-id";
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(globalThis as any).Bun.write = vi.fn().mockResolvedValue(undefined);
+		mockNativePanes.focusNativeTaskPane.mockResolvedValue(null as any);
+	});
+
+	/** A live native pane set (the agent's own pane) backed by a real SplitTree. */
+	function arrangeNativePaneSet(opts: { splitFails?: boolean } = {}) {
+		let tree = createSplitTree();
+		const state = () => ({
+			taskId: TASK_ID,
+			panes: listPaneIds(tree).map((paneId) => ({ paneId, sessionId: `${paneId}-s`, hostPid: 1, shellPid: 2, cols: 80, rows: 24, alive: true })),
+			layout: serializeSplitTree(tree),
+			activePaneId: tree.activePaneId,
+		});
+		mockNativePanes.nativeTaskPanesState.mockImplementation(async () => state() as any);
+		mockNativePanes.splitNativeTaskPane.mockImplementation(async (_taskId: string, fromPaneId: string, orientation: SplitOrientation) => {
+			if (opts.splitFails) throw new Error("host would not start");
+			const paneId = `pane-${tree.nextPaneOrdinal}`;
+			tree = splitPane(tree, fromPaneId, orientation);
+			return { paneId, state: state() } as any;
+		});
+		return { paneIds: () => listPaneIds(tree), activePaneId: () => tree.activePaneId };
+	}
+
+	function arrangeNativeTask() {
+		const project = makeProject();
+		const task = makeTask({ id: TASK_ID, worktreePath: "/tmp/wt", terminalBackend: "native" } as any);
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockResolvedValue(task);
+		(data.updateTask as any).mockResolvedValue(task);
+		(agents.resolveCommandForAgent as any).mockResolvedValue({
+			command: "claude",
+			extraEnv: {},
+			agent: { id: "builtin-claude", baseCommand: "claude" },
+			config: { id: "claude-default" },
+		});
+		return { project, task };
+	}
+
+	function spawn() {
+		return handlers.spawnAgentInTask({ taskId: TASK_ID, projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default" });
+	}
+
+	it("opens one real native pane to the right and never calls tmux", async () => {
+		arrangeNativeTask();
+		const set = arrangeNativePaneSet();
+
+		await spawn();
+
+		expect(mockNativePanes.splitNativeTaskPane).toHaveBeenCalledTimes(1);
+		const [, anchor, orientation, launchOpts] = mockNativePanes.splitNativeTaskPane.mock.calls[0] as any[];
+		expect([anchor, orientation]).toEqual(["pane-1", "horizontal"]);
+		expect(launchOpts.launch.executable).toBe("/bin/bash");
+		expect(launchOpts.launch.argv).toEqual([expect.stringContaining("spawn-")]);
+		expect(launchOpts.cwd).toBe("/tmp/wt");
+		expect(launchOpts.env).toMatchObject({ DEV3_TASK_ID: TASK_ID, DEV3_WORKTREE_ROOT: "/tmp/wt" });
+		expect(set.paneIds()).toEqual(["pane-1", "pane-2"]);
+		// Zero tmux process spawns — no split-window, and no probe of the default socket.
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	// tmux's own split-window leaves the new pane active; the native path must not
+	// hand focus back, or "+ Agent" would land the user in the wrong pane.
+	it("leaves the new agent pane focused, like the tmux path", async () => {
+		arrangeNativeTask();
+		const set = arrangeNativePaneSet();
+
+		await spawn();
+
+		expect(set.activePaneId()).toBe("pane-2");
+		expect(mockNativePanes.focusNativeTaskPane).not.toHaveBeenCalled();
+	});
+
+	// sessionState.panes is reconciled against live TMUX panes, so a native entry
+	// there would be a phantom no pane can ever match.
+	it("records the launched agent without writing a phantom tmux pane", async () => {
+		arrangeNativeTask();
+		arrangeNativePaneSet();
+
+		await spawn();
+
+		const writes = (data.updateTask as any).mock.calls;
+		expect(writes).toHaveLength(1);
+		expect(writes[0][2]).toEqual({ agentId: "builtin-claude", configId: "claude-default" });
+		expect(writes[0][2].sessionState).toBeUndefined();
+	});
+
+	it("reports honestly when the native terminal is not running", async () => {
+		arrangeNativeTask();
+		mockNativePanes.nativeTaskPanesState.mockResolvedValue(null as any);
+
+		await expect(spawn()).rejects.toThrow("the task terminal is not running");
+		expect(mockNativePanes.splitNativeTaskPane).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a failed native split as an actionable error and leaves no pane behind", async () => {
+		arrangeNativeTask();
+		const set = arrangeNativePaneSet({ splitFails: true });
+
+		await expect(spawn()).rejects.toThrow("Failed to spawn agent: host would not start");
+
+		expect(set.paneIds()).toEqual(["pane-1"]);
+		expect(data.updateTask).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
 });
 
 // ================================================================

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -61,6 +61,7 @@ import {
 	nativeAuxPaneShellPid,
 	openAuxPane,
 	splitTaskPane,
+	AuxPaneUnavailableError,
 	type AuxPaneHandle,
 	type AuxPanePlacement,
 } from "../task-aux-panes";
@@ -2476,27 +2477,41 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 	await writeLaunchScript(scriptPath, buildCmdScript(tmuxCmd, env));
 
 	const socket = pty.getSessionSocket(params.taskId);
-	const tmuxSession = taskSessionName(params.taskId);
-	let newPaneId: string | null;
+
+	// One extra pane in the task's own terminal, on whichever backend it runs. The
+	// tmux split is the same one this path always did (right half, no -l); the
+	// native path opens a real coordinator pane and never touches tmux.
+	//
+	// The bare primitive, NOT an auxiliary purpose: "+ Agent" is the user asking for
+	// one more agent beside whatever is already there, so several of these panes
+	// coexist by design, while a purpose owns at most one pane and replaces it.
+	let handle: AuxPaneHandle;
 	try {
-		({ paneId: newPaneId } = await tmux.splitWindow({
-			target: tmuxSession,
-			orientation: "horizontal",
-			printPaneId: true,
-			env: { DEV3_TASK_ID: task.id, DEV3_WORKTREE_ROOT: task.worktreePath },
+		handle = await splitTaskPane({
+			task,
+			placement: "right",
+			size: "",
 			cwd: task.worktreePath,
-			command: `bash "${scriptPath}"`,
+			env: { DEV3_TASK_ID: task.id, DEV3_WORKTREE_ROOT: task.worktreePath },
 			socket,
-		}));
+			tmuxCommand: `bash "${scriptPath}"`,
+			nativeLaunch: { executable: "/bin/bash", argv: [scriptPath] },
+		});
 	} catch (err) {
-		if (!(err instanceof TmuxError)) throw err;
-		log.error("spawnAgentInTask failed", { exitCode: err.exitCode, stderr: err.stderr });
-		throw new Error(`Failed to spawn agent: ${err.stderr || "unknown error"}`);
+		log.error("spawnAgentInTask failed", { taskId: params.taskId.slice(0, 8), error: String(err) });
+		throw new Error(
+			err instanceof AuxPaneUnavailableError
+				? "Failed to spawn agent: the task terminal is not running, so there is no pane to split — start the task first."
+				: `Failed to spawn agent: ${err instanceof Error ? err.message : String(err)}`,
+		);
 	}
 
-	if (newPaneId) void markAgentPane(socket, newPaneId);
+	const newPaneId = handle.paneId || null;
+	if (handle.backend === "tmux" && newPaneId) void markAgentPane(socket, newPaneId);
 
-	// Append this pane to sessionState for recovery
+	// sessionState.panes is the tmux pane registry — recovery and `handlePaneExited`
+	// reconcile it against live tmux panes. A native pane is owned by the coordinator
+	// record instead, so writing it here would leave a phantom entry forever.
 	const paneEntry = {
 		paneId: newPaneId,
 		agentCmd: resolvedBaseCmd,
@@ -2510,10 +2525,14 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 		const updated = await data.updateTask(project, task.id, {
 			agentId: launchedAgentId,
 			configId: launchedConfigId,
-			sessionState: { panes: [...existingPanes, paneEntry] },
+			...(handle.backend === "tmux" ? { sessionState: { panes: [...existingPanes, paneEntry] } } : {}),
 		});
 		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
-		log.info("Appended pane to sessionState", { taskId: params.taskId.slice(0, 8), paneCount: existingPanes.length + 1 });
+		log.info("Recorded the spawned agent", {
+			taskId: params.taskId.slice(0, 8),
+			backend: handle.backend,
+			paneCount: handle.backend === "tmux" ? existingPanes.length + 1 : existingPanes.length,
+		});
 	} catch (err) {
 		log.error("Failed to append pane to sessionState (non-fatal)", { error: String(err) });
 	}


### PR DESCRIPTION
The "+ Agent" action was the third launch path still splitting `dev3-<taskId>` unconditionally: `spawnAgentInTask` called `tmux.splitWindow` directly, so on a native-backed task there was no such session and the launch failed the same way Find bugs (#1228) and AI Review (#1229) did.

It now goes through `splitTaskPane` — the bare primitive, not an auxiliary purpose, because "+ Agent" deliberately allows several coexisting agent panes while a purpose owns at most one.

- Native: a real coordinator pane, no tmux call and no probe of the default tmux socket.
- Native: no `sessionState.panes` entry, which is the tmux pane registry `handlePaneExited` reconciles against live tmux panes — a native pane id there would be a permanent phantom. The `agentId`/`configId` write is unchanged on both backends.
- tmux: the same `split-window -h` with the same `-c`/`-t`/`-e` and the same pane-registry append; the only delta is the seam's `DEV3_TASK_SEQ` env var, which every other extra pane already carries.
- A dead terminal now reports "the task terminal is not running, so there is no pane to split — start the task first." instead of a tmux socket error, and a failed split leaves no pane and no task write.

Verified live on a native task (extra pane opens beside the agent, both halves equal, second Claude process running, zero tmux sessions for the task, no phantom pane record) plus new regression cases through the real RPC entry point.