### PR TITLE
Make native Take control transfer ownership

### DIFF
--- a/change-logs/2026/08/04/fix-native-take-control-transfers-writer-lease.md
+++ b/change-logs/2026/08/04/fix-native-take-control-transfers-writer-lease.md
@@ -1,0 +1,3 @@
+Short: Take control now works across windows
+
+Take control in a native terminal now actually transfers the writer lease when another dev3 window or instance holds it, instead of coming back refused and leaving the viewer permanently read-only. The window that had control is told authoritatively that it is now an observer, and the new owner immediately publishes its own pane size as the canonical grid so observers follow it instead of wrapping the output at their own width. Ordinary attaching still never steals the lease, and a host too old to transfer now says so instead of failing silently.

--- a/decisions/200-explicit-writer-takeover-across-processes.md
+++ b/decisions/200-explicit-writer-takeover-across-processes.md
@@ -1,0 +1,48 @@
+# 200 — Explicit `Take control` transfers the writer lease across app processes
+
+## Context
+
+Decision 158 gives a native pane's host exactly one writer lease, and `claim` may take
+only a vacant slot. Decision 191 then taught the app to report a refusal rather than move
+a lease it does not own. Neither left any action able to move a LIVE lease. Several dev3
+processes share one `~/.dev3.0` (022), so a viewer outside the launching process was
+permanently read-only.
+
+## Investigation
+
+`WriterOwnership.request(client, "claim")` returns `writer-active` whenever a writer
+exists, and the explicit gesture sent exactly that. Reproduced in
+`~/.dev3.0/logs/2026/08/2026-08-03.log` lines 30978–31138: pid 74178 attaches as an
+observer, then fifteen refusals while pid 80386 holds the lease.
+
+## Decision
+
+A third ownership action, `takeover` (`writer-ownership.ts`), swaps the writer pointer in
+one synchronous turn on the host's event loop, while `claim` keeps its non-stealing
+semantics so attach and `ensureWriter` are untouched. The contract is
+**last-explicit-takeover-wins**: the host serializes takeovers, so a gesture cannot lose to
+a rival and an expected-owner guard would only make the button refuse a click the user
+meant. Supporting invariants live as comments on the code that enforces them — one
+broadcast per transition with the winner confirmed last, correlation by
+`(id, kind, connection)` from a single allocator with `id: 0` alone unsolicited, canonical
+geometry written only from an authoritative ack, and an ambiguous request compensated by
+rebinding rather than guessed at. Only an announced-capability-absent host answering
+`writer-active` yields `host-too-old`; every other failure is `transfer-failed`.
+
+## Risks
+
+A displaced writer loses the PTY mid-keystroke — intended, explicit, reversible. Frame
+arrival order across sockets is not guaranteed, so only host-side enforcement is
+load-bearing; a takeover demotion is told apart from a vacancy by `writerAttached`. The
+generation compare is reachable and load-bearing: a stale writer that takes over passes
+the role check, so a resize it sends before processing the ownership reply still carries
+the old generation and must be refused on that. A narrow observer clips rather than
+letterboxes.
+
+## Alternatives considered
+
+Automatic observer promotion (rejected by 158) and a host-side inject endpoint (breaks the
+one-writer invariant). Peer-mediated release over the CLI socket needs a cooperative owner
+and leaves a window for a third claimant. A generation/ack rejection protocol buys a
+refusal nobody wants, since host enforcement already prevents two writers. One owner
+process per task is cleanest long-term but far beyond this blast radius (see 191).

--- a/src/bun/__tests__/native-takeover-peer.ts
+++ b/src/bun/__tests__/native-takeover-peer.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env bun
+/**
+ * The SECOND dev3 app process for the cross-instance Take-control tracer.
+ *
+ * Several dev3 app processes share one `~/.dev3.0`, so a native pane's host may
+ * already have granted its single writer lease to a DIFFERENT process. This script
+ * is that other process: it reattaches to a live host it did not launch, opens a
+ * renderer socket on its OWN pty-server, and clicks `Take control` by sending the
+ * exact `claim` frame `TerminalView.tsx` sends — nothing here touches
+ * `WriterOwnership`, the host protocol, or tmux directly.
+ *
+ * It must be a real separate OS process: the whole bug lives in the host's
+ * cross-process lease, which is invisible to two viewers inside one process.
+ *
+ * Verdict goes to stdout behind a sentinel; human logs go to stderr. The host and
+ * shell are left running — the parent owns their lifetime.
+ */
+
+import {
+	claimMessage,
+	decodeNativeStreamMessage,
+	releaseMessage,
+	type NativeStreamAttachHeader,
+	type NativeStreamHeader,
+	type NativeStreamRole,
+} from "../../shared/native-terminal-stream";
+import { encodeResizeSequence } from "../../shared/resize-protocol";
+
+const JSON_SENTINEL = "__NATIVE_TAKEOVER_JSON__";
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function emit(verdict: Record<string, unknown>): void {
+	process.stdout.write(`${JSON_SENTINEL}${JSON.stringify(verdict)}\n`);
+}
+
+async function main(): Promise<void> {
+	const taskId = process.argv[2];
+	const cwd = process.argv[3];
+	// The probe is authored by the PARENT so there is exactly one definition of it:
+	// `expected` is assembled by the shell at runtime from its own env and pid, so it
+	// can never appear in the echoed command line — which is what makes the parent's
+	// exactly-once count meaningful.
+	const setup = JSON.parse(process.env.DEV3_TAKEOVER_SETUP ?? "[]") as string[];
+	const command = process.env.DEV3_TAKEOVER_COMMAND ?? "";
+	const expected = process.env.DEV3_TAKEOVER_EXPECTED ?? "";
+	const cols = Number(process.env.DEV3_TAKEOVER_COLS ?? "0");
+	const rows = Number(process.env.DEV3_TAKEOVER_ROWS ?? "0");
+	const lineEnd = process.platform === "win32" ? "\r" : "\n";
+	if (!taskId || !cwd || !command || !expected || !cols || !rows) {
+		process.stderr.write("usage: DEV3_TAKEOVER_COMMAND/EXPECTED/COLS/ROWS=… native-takeover-peer.ts <taskId> <cwd>\n");
+		process.exit(2);
+	}
+
+	// Production reattach path: this process holds no session, so it rebinds the
+	// existing host as a CLIENT. It never spawns a host or a shell.
+	const pty = await import("../pty-server");
+	const reattached = await pty.reattachNativeTaskSession(taskId, "takeover-peer", cwd);
+	if (!reattached) {
+		emit({ ok: false, reason: "reattach-failed", peerPid: process.pid });
+		process.exit(0);
+	}
+	const terminal = pty.nativePaneTerminal(taskId);
+	const hostRoleBefore = terminal?.hostRole() ?? "none";
+
+	const port = pty.getPtyPort();
+	const ws = new WebSocket(`ws://localhost:${port}?session=${encodeURIComponent(taskId)}`);
+	const headers: NativeStreamHeader[] = [];
+	let attach: NativeStreamAttachHeader | null = null as NativeStreamAttachHeader | null;
+	let role: NativeStreamRole = "observer";
+	let text = "";
+	const decoder = new TextDecoder();
+	ws.addEventListener("message", (ev) => {
+		const data = (ev as MessageEvent).data;
+		const raw = typeof data === "string" ? data : decoder.decode(data as ArrayBuffer);
+		const frame = decodeNativeStreamMessage(raw);
+		if (!frame) {
+			text += raw;
+			return;
+		}
+		headers.push(frame.header);
+		if (frame.header.t === "attach") {
+			attach = frame.header;
+			role = frame.header.role;
+		} else if (frame.header.t === "role") {
+			role = frame.header.role;
+		}
+		text += frame.payload;
+	});
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error("peer renderer open timeout")), 8000);
+		ws.addEventListener("open", () => { clearTimeout(timer); resolve(); }, { once: true });
+		ws.addEventListener("error", () => { clearTimeout(timer); reject(new Error("peer renderer error")); }, { once: true });
+	});
+	const waitFor = async (predicate: (h: NativeStreamHeader) => boolean, timeoutMs = 8000): Promise<boolean> => {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (headers.some(predicate)) return true;
+			await delay(20);
+		}
+		return false;
+	};
+	await waitFor((h) => h.t === "attach", 8000);
+	const attachedRole = role;
+
+	// ── the gesture under test: exactly what the Take control button sends ──
+	ws.send(claimMessage());
+	const promoted = await waitFor((h) => h.t === "role" && h.role === "writer", 10_000);
+	const refusedFrame = headers.find((h) => h.t === "role" && h.refused === true) as
+		| (NativeStreamHeader & { refusedReason?: string })
+		| undefined;
+
+	// This process must now be able to DRIVE the shell: geometry first (the writer
+	// alone sizes the PTY), then a probe only a live shell can answer.
+	ws.send(encodeResizeSequence(cols, rows));
+	// Warm the shell with the setup lines and WAIT for it to be responsive before the
+	// counted command: the parent asserts the probe landed EXACTLY once, so this side
+	// must send it exactly once — a retry loop would make that count meaningless.
+	for (const line of setup) ws.send(`${line}${lineEnd}`);
+	// Must NOT contain `expected`: the parent counts occurrences of that string, and a
+	// warm-up marker embedding it would inflate the count and make exactly-once a lie.
+	const readyMarker = `PEER-READY-${expected.replace(/[^A-Za-z0-9]/g, "")}-WARM`;
+	const readyCommand = process.platform === "win32"
+		? `Write-Output "${readyMarker}"`
+		: `printf '%s\n' "${readyMarker}"`;
+	let ready = false;
+	const readyDeadline = Date.now() + 20_000;
+	while (Date.now() < readyDeadline && !ready) {
+		ws.send(`${readyCommand}${lineEnd}`);
+		for (let i = 0; i < 25 && !ready; i++) {
+			await delay(80);
+			ready = text.includes(readyMarker);
+		}
+	}
+
+	// ONE send of the counted command, then quiesce so any duplicate would have shown.
+	let echoed = false;
+	if (ready) {
+		ws.send(`${command}${lineEnd}`);
+		const deadline = Date.now() + 20_000;
+		while (Date.now() < deadline && !echoed) {
+			await delay(80);
+			echoed = text.includes(expected);
+		}
+		await delay(750); // quiescence barrier before the parent counts occurrences
+	}
+
+	emit({
+		ok: promoted && ready && echoed,
+		peerPid: process.pid,
+		shellResponsive: ready,
+		countedCommandSends: ready ? 1 : 0,
+		hostRoleBefore,
+		attachedRole,
+		roleAfterTakeControl: role,
+		promoted,
+		echoedThroughShell: echoed,
+		hostPid: attach?.hostPid ?? -1,
+		shellPid: attach?.shellPid ?? -1,
+		refused: refusedFrame !== undefined,
+		refusedReason: refusedFrame?.refusedReason ?? null,
+	});
+	// Stay attached briefly so the parent can observe the demotion and the resize
+	// against a LIVE peer — a peer that exited would look like the vacant path.
+	await delay(Number(process.env.DEV3_TAKEOVER_HOLD_MS ?? "2500"));
+	// Not `pty.destroySession`: the host, shell and the parent's session must survive.
+	try {
+		ws.send(releaseMessage());
+	} catch { /* socket already gone */ }
+	ws.close();
+	process.exit(0);
+}
+
+void main().catch((err) => {
+	emit({ ok: false, error: err instanceof Error ? err.message : String(err), peerPid: process.pid });
+	process.exit(1);
+});

--- a/src/bun/__tests__/native-task-terminal.bun-e2e.ts
+++ b/src/bun/__tests__/native-task-terminal.bun-e2e.ts
@@ -31,6 +31,12 @@
  *      atomically, the new writer reaches the SAME shell while both viewers receive
  *      its output, geometry follows the WRITER only, a reconnect resumes at its
  *      watermark, and `destroySessionAwaited` kills the tree;
+ *  11. CROSS-INSTANCE `Take control`: a SECOND real app process attaches
+ *      to the SAME host as an observer and clicks Take control through the product
+ *      frame — the lease transfers, the first process is demoted authoritatively by
+ *      the host, the peer's input reaches the same shell EXACTLY once, PTY geometry
+ *      follows the new writer, host/shell pids never change, and the lease comes
+ *      back to the first process once the peer lets go;
  *  10. LIFECYCLE teardown (seq 1298): `pty.destroyNativeTaskSession` on a task with
  *      NO in-memory session (the app-restart shape) resolves only after its host,
  *      shell and NESTED CHILD are gone, leaves a sibling native session and the tmux
@@ -49,7 +55,7 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "../spawn";
+import { spawn, spawnSync } from "../spawn";
 import { bindNativeTaskPane, type NativeTaskTerminal } from "../native-task-terminal";
 import {
 	startNativeTaskPanes,
@@ -90,7 +96,9 @@ const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 const isWindows = process.platform === "win32";
 const lineEnd = isWindows ? "\r" : "\n";
 const controllerEntry = fileURLToPath(new URL("./native-task-terminal-controller.ts", import.meta.url));
+const takeoverPeerEntry = fileURLToPath(new URL("./native-takeover-peer.ts", import.meta.url));
 const JSON_SENTINEL = "__TASK_TERMINAL_JSON__";
+const TAKEOVER_SENTINEL = "__NATIVE_TAKEOVER_JSON__";
 
 // A fixed task id keeps the session id deterministic across runs, which is the
 // property the reattach path depends on.
@@ -109,6 +117,10 @@ const LC_FIRST_PANE_SESSION_ID = `${LC_SESSION_ID}-pane-1`;
 const SIB_TASK_ID = "00000000-0000-4000-8000-0000000e2e78";
 const SIB_SESSION_ID = nativeTaskSessionId(SIB_TASK_ID);
 const SIB_FIRST_PANE_SESSION_ID = `${SIB_SESSION_ID}-pane-1`;
+// The cross-instance Take-control section: ONE host, two real app processes.
+const XP_TASK_ID = "00000000-0000-4000-8000-0000000e2e9a";
+const XP_SESSION_ID = nativeTaskSessionId(XP_TASK_ID);
+const XP_FIRST_PANE_SESSION_ID = `${XP_SESSION_ID}-pane-1`;
 
 interface Sink {
 	text: () => string;
@@ -307,11 +319,97 @@ function nestedChildProbe(pidFile: string): { command: string; read: () => numbe
 	return { command: `sleep 600 & echo $! > '${pidFile}'`, read };
 }
 
+/**
+ * Every gesture in this file is deliberate and countable. A generous ceiling still fails
+ * loudly on a livelock, which is the failure mode this guards: three orders of magnitude
+ * of headroom, and the observed regression was five.
+ */
+const MAX_EXPECTED_TAKEOVERS = 50;
+
+/** Count matching lines across a log tree, so an invariant can assert on log VOLUME. */
+function countLogLines(logDir: string, needle: string): number {
+	let total = 0;
+	const walk = (dir: string): void => {
+		let entries: Array<{ name: string; isDirectory: () => boolean }>;
+		try {
+			entries = readdirSync(dir, { withFileTypes: true }) as unknown as typeof entries;
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(full);
+				continue;
+			}
+			if (!entry.name.endsWith(".log")) continue;
+			try {
+				for (const line of readFileSync(full, "utf8").split("\n")) {
+					if (line.includes(needle)) total++;
+				}
+			} catch {
+				// unreadable mid-write; the ceiling is generous enough to absorb it
+			}
+		}
+	};
+	walk(logDir);
+	return total;
+}
+
 function sessionDirCount(): number {
 	try {
 		return readdirSync(sessionsRootDir(), { withFileTypes: true }).filter((entry) => entry.isDirectory()).length;
 	} catch {
 		return 0;
+	}
+}
+
+/**
+ * Await ONE sentinel-prefixed JSON line from a live stream, leaving the process running.
+ * Deliberately not `new Response(stream).text()`: that waits for EOF, i.e. for the child
+ * to exit, which destroys the very state a cross-process assertion needs.
+ */
+async function readSentinelLine(
+	child: { stdout: ReadableStream<Uint8Array>; kill: (signal?: NodeJS.Signals) => void },
+	sentinel: string,
+	timeoutMs: number,
+): Promise<Record<string, unknown> | null> {
+	const reader = child.stdout.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const deadline = Date.now() + timeoutMs;
+	let found: Record<string, unknown> | null = null;
+	try {
+		while (Date.now() < deadline) {
+			// Race EVERY read: a bare `await reader.read()` on a silent child hangs past the
+			// deadline, so the loop condition alone does not bound this.
+			const step = await Promise.race([
+				reader.read(),
+				new Promise<"timeout">((r) => setTimeout(() => r("timeout"), Math.max(1, deadline - Date.now()))),
+			]);
+			if (step === "timeout") break;
+			if (step.done) break;
+			buffer += decoder.decode(step.value, { stream: true });
+			for (const line of buffer.split("\n")) {
+				if (!line.startsWith(sentinel)) continue;
+				try {
+					found = JSON.parse(line.slice(sentinel.length)) as Record<string, unknown>;
+				} catch {
+					found = null;
+				}
+				return found;
+			}
+		}
+		return null;
+	} finally {
+		reader.releaseLock();
+		// Never leave the child running when we gave up on it — an orphan peer keeps the
+		// writer lease and poisons every later assertion in this file.
+		if (!found) {
+			try {
+				child.kill("SIGKILL");
+			} catch { /* already gone */ }
+		}
 	}
 }
 
@@ -658,6 +756,189 @@ async function run(): Promise<void> {
 			check(await tmux.hasSession(sentinelSession, { socket: sentinelSocket }), "the tmux sentinel session survived the renderer-transport teardown too");
 		}
 
+		// ── 11. cross-instance Take control: ONE host, TWO real app processes ──
+		// The bug this section exists for: the host grants its single writer lease to
+		// the FIRST client across every app process, so a viewer in any other dev3
+		// instance was permanently read-only — `Take control` reached the host and came
+		// back refused. Two viewers inside one process cannot show this at all, which
+		// is why the second half runs in a genuinely separate OS process.
+		await pty.createNativeTaskSession(XP_TASK_ID, "e2e-project", work, taskLaunch(work), {}, { cols: 100, rows: 30 });
+		const xpRecord = readRecord(XP_FIRST_PANE_SESSION_ID);
+		const xpHostPid = xpRecord?.host.pid ?? -1;
+		const xpShellPid = xpRecord?.shell.pid ?? -1;
+		check(isProcessAlive(xpHostPid) && isProcessAlive(xpShellPid), "the cross-instance session has its own live host + shell");
+
+		const rendererX = await openRenderer(port, XP_TASK_ID);
+		renderers.push(rendererX);
+		check(rendererX.attach()?.role === "writer", "the FIRST app process holds the writer lease");
+		check(
+			pty.nativePaneTerminal(XP_TASK_ID)?.hostRole() === "writer",
+			"the first process holds the HOST's lease, not merely its own local one",
+		);
+		// A deliberately different geometry, so "the peer's size won" cannot be a
+		// coincidence of both processes asking for the same thing.
+		rendererX.send(encodeResizeSequence(100, 30));
+		const xpWarmup = markerProbe(`${nonce}x`, xpShellPid);
+		for (const line of xpWarmup.setup) rendererX.send(`${line}${lineEnd}`);
+		const xpWarmupSeen = await sendUntilObserved({
+			send: () => rendererX.send(`${xpWarmup.command}${lineEnd}`),
+			observe: () => (rendererX.sink.text().includes(xpWarmup.expected) ? xpWarmup.expected : null),
+			...SHELL_WARMUP_PROBE,
+		});
+		check(xpWarmupSeen !== null, "the first process drives the shell before the peer arrives");
+
+		// A second viewer in the SAME process as the writer. It is a local observer, so it
+		// must follow the canonical grid through the whole A→B→A transfer — its own
+		// process never performs B's resize, so nothing local can tell it the new size.
+		const rendererX2 = await openRenderer(port, XP_TASK_ID);
+		renderers.push(rendererX2);
+		check(rendererX2.attach()?.role === "observer", "a second viewer in the owning process is a local observer");
+		check(
+			rendererX2.attach()?.cols === 100 && rendererX2.attach()?.rows === 30,
+			"the second local viewer is handed the canonical grid on attach, before any transfer",
+		);
+
+		const xpPeerCols = 132;
+		const xpPeerRows = 43;
+		const peerProbe = markerProbe(`${nonce}p`, xpShellPid);
+		const xpTextBefore = rendererX.sink.text();
+		const peer = spawn([process.execPath, takeoverPeerEntry, XP_TASK_ID, work], {
+			env: {
+				...process.env,
+				DEV3_TAKEOVER_SETUP: JSON.stringify(peerProbe.setup),
+				DEV3_TAKEOVER_COMMAND: peerProbe.command,
+				DEV3_TAKEOVER_EXPECTED: peerProbe.expected,
+				DEV3_TAKEOVER_COLS: String(xpPeerCols),
+				DEV3_TAKEOVER_ROWS: String(xpPeerRows),
+				// Generous hold: every live-peer assertion below must land while the peer
+				// still owns the lease, or a disconnect vacancy could satisfy them instead.
+				DEV3_TAKEOVER_HOLD_MS: "20000",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		// Read the verdict line WITHOUT waiting for EOF. Consuming the whole stream would
+		// block until the peer EXITS, and then every demotion assertion below could have
+		// been satisfied by the peer's disconnect-vacancy notice rather than by the
+		// takeover — which is the bug this section exists to prove.
+		const peerVerdict = await readSentinelLine(peer, TAKEOVER_SENTINEL, 60_000);
+		check(peerVerdict !== null, "the peer app process produced a verdict");
+		const peerPid = num(peerVerdict, "peerPid");
+		// Everything from here until the explicit `await peer.exited` runs against a LIVE
+		// peer that still holds the lease.
+		check(isProcessAlive(peerPid), "the peer is still alive and holding the lease while its takeover is asserted");
+		check(peerPid !== process.pid, `the peer was a genuinely separate OS process (pid ${peerPid})`);
+		check(
+			peerVerdict?.hostRoleBefore === "observer" && peerVerdict?.attachedRole === "observer",
+			"attaching from a second instance does NOT steal the lease — it observes",
+		);
+		check(
+			peerVerdict?.promoted === true && peerVerdict?.roleAfterTakeControl === "writer",
+			"an explicit Take control from a second app process TRANSFERS the writer lease",
+		);
+		check(peerVerdict?.refused !== true, `Take control was not refused (reason: ${String(peerVerdict?.refusedReason ?? "none")})`);
+		check(
+			num(peerVerdict, "hostPid") === xpHostPid && num(peerVerdict, "shellPid") === xpShellPid,
+			"the peer took over the SAME host and shell — nothing respawned",
+		);
+		check(peerVerdict?.echoedThroughShell === true, "the new writer's input reached the shell");
+		check(
+			num(peerVerdict, "countedCommandSends") === 1,
+			"the peer sent the counted command EXACTLY once, so the parent's occurrence count is meaningful",
+		);
+
+		// The displaced process learns its new role FROM THE HOST, not from a guess — and
+		// the frame must be a TAKEOVER demotion, not the vacancy notice a disconnect would
+		// send. The two are distinguishable without any ack or epoch: a takeover says
+		// someone else holds the lease (`writerAttached: true`), a vacancy says nobody does.
+		const xDemoted = await rendererX.awaitHeader(
+			(h) => h.t === "role" && h.role === "observer" && "writerAttached" in h && h.writerAttached === true,
+			8000,
+		);
+		check(
+			xDemoted && isProcessAlive(peerPid),
+			"the displaced process was demoted BY THE TAKEOVER while the new writer was still alive — not by its exit",
+		);
+		check(
+			pty.nativePaneTerminal(XP_TASK_ID)?.hostRole() === "observer",
+			"the displaced process's HOST role followed the transfer, so it stops pretending it can type",
+		);
+		const xpOccurrences = rendererX.sink.text().split(peerProbe.expected).length - 1;
+		check(
+			!xpTextBefore.includes(peerProbe.expected) && xpOccurrences === 1,
+			`the peer's input landed on the shared shell EXACTLY once (saw ${xpOccurrences})`,
+		);
+		// The displaced viewer must be TOLD the new canonical geometry, not left rendering
+		// the stream at its own width — those bytes are laid out for the new writer now.
+		const xGeometryTold = await rendererX.awaitHeader(
+			(h) => h.t === "role" && "cols" in h && h.cols === xpPeerCols && h.rows === xpPeerRows,
+			8000,
+		);
+		check(xGeometryTold, "the displaced viewer was handed the NEW writer's PTY geometry to render at");
+		const x2FollowedB = await rendererX2.awaitHeader(
+			(h) => h.t === "role" && "cols" in h && h.cols === xpPeerCols && h.rows === xpPeerRows,
+			8000,
+		);
+		check(x2FollowedB, "a SECOND local viewer in the displaced process also follows the new owner's grid");
+		const peerStderr = await new Response(peer.stderr).text();
+		await peer.exited;
+		if (peerStderr.trim()) console.log(`       [peer stderr] ${peerStderr.trim().split("\n").slice(-3).join(" | ")}`);
+		const xpAfterRecord = readRecord(XP_FIRST_PANE_SESSION_ID);
+		check(
+			xpAfterRecord?.cols === xpPeerCols && xpAfterRecord?.rows === xpPeerRows,
+			`PTY geometry followed the NEW writer (${xpPeerCols}x${xpPeerRows}, not the displaced 100x30)`,
+		);
+		check(
+			isProcessAlive(xpHostPid) && isProcessAlive(xpShellPid) && !isProcessAlive(peerPid),
+			"host and shell survived the transfer with the same pids, and the peer is gone",
+		);
+		if (sentinelAlive) {
+			check(await tmux.hasSession(sentinelSession, { socket: sentinelSocket }), "the tmux sentinel session is untouched by the writer transfer");
+		}
+
+		// The lease comes BACK: with the peer gone the slot is vacant, and the same
+		// production frame recovers it — a transfer must not be one-way.
+		rendererX.send(claimMessage());
+		const xRegained = await rendererX.awaitHeader((h) => h.t === "role" && h.role === "writer", 8000);
+		check(xRegained, "the first process takes control back once the peer lets go");
+		// Geometry follows the lease back too: A owns it again, so A's size is canonical
+		// and the second local viewer must be told, not left on B's grid.
+		const backCols = 118;
+		const backRows = 36;
+		rendererX.send(encodeResizeSequence(backCols, backRows));
+		const x2FollowedBack = await rendererX2.awaitHeader(
+			(h) => h.t === "role" && "cols" in h && h.cols === backCols && h.rows === backRows,
+			8000,
+		);
+		const backRecord = readRecord(XP_FIRST_PANE_SESSION_ID);
+		check(
+			x2FollowedBack && backRecord?.cols === backCols && backRecord?.rows === backRows,
+			`geometry follows the lease BACK to the first process (${backCols}x${backRows})`,
+		);
+
+		const xpBack = markerProbe(`${nonce}r`, xpShellPid);
+		for (const line of xpBack.setup) rendererX.send(`${line}${lineEnd}`);
+		const xpBackSeen = await sendUntilObserved({
+			send: () => rendererX.send(`${xpBack.command}${lineEnd}`),
+			observe: () => (rendererX.sink.text().includes(xpBack.expected) ? xpBack.expected : null),
+			...SHELL_WARMUP_PROBE,
+		});
+		check(xpBackSeen !== null, "after taking control back the first process drives the SAME shell again");
+
+		// This whole section performs a handful of
+		// deliberate gestures. A re-entrant takeover once turned that into ~12k/second and
+		// 540k log lines, so the COUNT is asserted, not just the outcome.
+		const takeoverLogLines = countLogLines(join(root, "logs"), "Took over the native writer lease");
+		check(
+			takeoverLogLines <= MAX_EXPECTED_TAKEOVERS,
+			`the whole run performed at most ${MAX_EXPECTED_TAKEOVERS} host takeovers (saw ${takeoverLogLines})`,
+		);
+
+		await pty.destroySessionAwaited(XP_TASK_ID);
+		const xpStopDeadline = Date.now() + 5000;
+		while (Date.now() < xpStopDeadline && (isProcessAlive(xpHostPid) || isProcessAlive(xpShellPid))) await delay(50);
+		check(!isProcessAlive(xpHostPid) && !isProcessAlive(xpShellPid), "the cross-instance host + shell tree is dead");
+
 		// ── 10. lifecycle teardown: an AWAITED stop of an unattached tree with a nested child ──
 		// Both sessions are created through the product path but never registered with
 		// pty-server, which is exactly the state after an app restart: the lifecycle has
@@ -723,6 +1004,7 @@ async function run(): Promise<void> {
 			await stopNativeTaskPanes(WS_TASK_ID);
 			await stopNativeTaskPanes(LC_TASK_ID);
 			await stopNativeTaskPanes(SIB_TASK_ID);
+			await stopNativeTaskPanes(XP_TASK_ID);
 		} catch {
 			// best-effort
 		}

--- a/src/bun/__tests__/native-task-terminal.test.ts
+++ b/src/bun/__tests__/native-task-terminal.test.ts
@@ -11,6 +11,12 @@ const log = vi.hoisted(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), er
 const client = vi.hoisted(() => ({
 	getRole: vi.fn(() => "writer" as string | null),
 	claimWriter: vi.fn(async () => ({ role: "writer" as string })),
+	takeoverWriter: vi.fn(async () => ({ role: "writer" as string })),
+	resizeAwaited: vi.fn(async (cols: number, rows: number) => ({ cols, rows })),
+	releaseWriter: vi.fn(async () => ({ role: "observer" as string })),
+	// Capability negotiation replaces timeout inference: a host that does not ANNOUNCE
+	// `takeover` is the only thing that may ever yield `host-too-old`.
+	supports: vi.fn((capability: string) => capability === "takeover"),
 	onOutput: vi.fn(),
 	onError: vi.fn(),
 	onDisconnect: vi.fn(),
@@ -21,8 +27,32 @@ const client = vi.hoisted(() => ({
 
 vi.mock("../logger", () => ({ createLogger: () => log }));
 
+const OwnershipTimeoutError = vi.hoisted(
+	() =>
+		class OwnershipTimeoutError extends Error {
+			constructor(readonly action: string) {
+				super(`ownership ${action} timeout`);
+				this.name = "OwnershipTimeoutError";
+			}
+		},
+);
+
+// Shaped like the real class: the verdict is decided by `instanceof` plus `code`, so a
+// looser stub would let a message-matching regression pass.
+const HostRefusedError = vi.hoisted(
+	() =>
+		class HostRefusedError extends Error {
+			constructor(readonly code: string, message?: string) {
+				super(`native session error: ${code}${message ? ` (${message})` : ""}`);
+				this.name = "HostRefusedError";
+			}
+		},
+);
+
 vi.mock("../native-terminal-registry/client", () => ({
 	NativeSessionClient: { discover: vi.fn(async () => client) },
+	OwnershipTimeoutError,
+	HostRefusedError,
 }));
 
 vi.mock("../native-terminal-registry/record", () => ({
@@ -39,6 +69,9 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	client.getRole.mockReturnValue("writer");
 	client.claimWriter.mockResolvedValue({ role: "writer" });
+	client.takeoverWriter.mockResolvedValue({ role: "writer" });
+	client.releaseWriter.mockResolvedValue({ role: "observer" });
+	client.supports.mockImplementation((capability: string) => capability === "takeover");
 	vi.mocked(NativeSessionClient.discover).mockResolvedValue(client as never);
 });
 
@@ -100,5 +133,132 @@ describe("bindNativeTaskPane", () => {
 		terminal!.detach();
 		expect(client.close).toHaveBeenCalled();
 		expect(hooks.onClosed).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * The explicit `Take control` gesture. The invariant that must survive
+ * every change here: ATTACHING never steals, and only a takeover-frame timeout —
+ * the one honest signal of a host too old to transfer — may fall back to a claim.
+ */
+describe("takeoverHostWriter", () => {
+	it("is never used by implicit attachment — that path only ever claims", async () => {
+		client.getRole.mockReturnValue("observer");
+		await bindNativeTaskPane(SESSION_ID, hooks);
+		expect(client.claimWriter).toHaveBeenCalledTimes(1);
+		expect(client.takeoverWriter).not.toHaveBeenCalled();
+	});
+
+	it("sends ONE takeover frame and reports the writer role", async () => {
+		client.getRole.mockReturnValue("observer");
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockClear();
+
+		await expect(terminal!.takeoverHostWriter()).resolves.toEqual({ ok: true });
+		expect(client.takeoverWriter).toHaveBeenCalledTimes(1);
+		expect(client.claimWriter).not.toHaveBeenCalled();
+	});
+
+	// P1-1: our cached role can be STALE — another process may already hold the lease and
+	// our demotion frame may be in flight — so an explicit gesture must always reach the
+	// host. Skipping it would make a deliberate click silently do nothing. The host's
+	// takeover is idempotent for the true current writer, so asking is free.
+	it("still asks the host even when our cached role says we are the writer", async () => {
+		client.getRole.mockReturnValue("writer");
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+
+		await expect(terminal!.takeoverHostWriter()).resolves.toEqual({ ok: true });
+		expect(client.takeoverWriter).toHaveBeenCalledTimes(1);
+	});
+
+	// Capability negotiation, not timeout inference: only a host that does not ANNOUNCE
+	// `takeover` may ever produce `host-too-old`.
+	it("falls back to a claim on a host that does not announce takeover, winning a vacant slot", async () => {
+		client.getRole.mockReturnValue("observer");
+		client.supports.mockReturnValue(false);
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockResolvedValue({ role: "writer" });
+
+		await expect(terminal!.takeoverHostWriter()).resolves.toEqual({ ok: true });
+		expect(client.takeoverWriter).not.toHaveBeenCalled();
+	});
+
+	it("reports host-too-old only when an unannounced host still has a live writer", async () => {
+		client.getRole.mockReturnValue("observer");
+		client.supports.mockReturnValue(false);
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockResolvedValue({ role: "observer" });
+
+		await expect(terminal!.takeoverHostWriter()).resolves.toEqual({ ok: false, refusal: "host-too-old" });
+	});
+
+	it("keeps a takeover TIMEOUT as transfer-failed on a capable host — no old-host inference", async () => {
+		client.getRole.mockReturnValue("observer");
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockClear();
+		client.takeoverWriter.mockRejectedValue(new OwnershipTimeoutError("takeover"));
+
+		// A timeout also carries `timedOut`, because the host may still commit it and the
+		// caller has to COMPENSATE rather than just report a failure.
+		await expect(terminal!.takeoverHostWriter()).resolves.toEqual({
+			ok: false,
+			refusal: "transfer-failed",
+			timedOut: true,
+		});
+		expect(client.claimWriter).not.toHaveBeenCalled();
+	});
+
+	// Only the host's own authoritative conflict may mean host-too-old. Anything
+	// we could not interpret says NOTHING about who owns the lease.
+	it.each([
+		["a disconnect", new Error("connection closed before ownership reply"), "transfer-failed"],
+		["an auth failure", new HostRefusedError("unauthorized"), "transfer-failed"],
+		["a timeout", new OwnershipTimeoutError("claim"), "transfer-failed"],
+		["an unparseable reply", new Error("native session sent an unparseable reply"), "transfer-failed"],
+		["a non-conflict host refusal", new HostRefusedError("internal-error"), "transfer-failed"],
+		["an authoritative writer-active conflict", new HostRefusedError("conflict", "another client is already the writer"), "host-too-old"],
+	])("maps %s to the right verdict on a host that cannot transfer", async (_label, failure, expected) => {
+		client.getRole.mockReturnValue("observer");
+		client.supports.mockReturnValue(false);
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockRejectedValue(failure);
+
+		const result = await terminal!.takeoverHostWriter();
+
+		expect(result.ok).toBe(false);
+		expect(result.ok === false && result.refusal).toBe(expected);
+	});
+
+	it("reports an unconfirmed release so the caller can drop the connection", async () => {
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.releaseWriter.mockRejectedValue(new Error("host went away"));
+
+		await expect(terminal!.releaseHostWriter()).resolves.toBe(false);
+	});
+
+	// The mutation this guards against: widening the fallback to "any failure", or to
+	// "any timeout". Either would tell the user to restart a terminal that is fine,
+	// and would fire a claim the caller never asked for. `transfer-failed` stays
+	// generic on purpose — the real cause is logged, never guessed at in the UI.
+	it.each([
+		["a disconnect", new Error("connection closed before ownership reply")],
+		["an auth failure", new Error("native session error: unauthorized")],
+		["a host conflict frame", new Error("native session error: conflict (client has not completed attach)")],
+		["a stale-generation conflict", new Error("native session error: conflict (writer generation is stale)")],
+		["an unrelated timeout", new OwnershipTimeoutError("release")],
+		["a non-Error rejection", "socket exploded"],
+	])("surfaces %s as itself instead of relabelling it host-too-old", async (_label, failure) => {
+		client.getRole.mockReturnValue("observer");
+		const terminal = await bindNativeTaskPane(SESSION_ID, hooks);
+		client.claimWriter.mockClear();
+		client.takeoverWriter.mockRejectedValue(failure);
+
+		const result = await terminal!.takeoverHostWriter();
+
+		// `timedOut` rides along only for the timeout case, since that alone needs
+		// compensation; every other class is a plain transfer-failed.
+		expect(result.ok).toBe(false);
+		expect(result.ok === false && result.refusal).toBe("transfer-failed");
+		expect(client.claimWriter).not.toHaveBeenCalled();
 	});
 });

--- a/src/bun/__tests__/pty-server-native-bridge.test.ts
+++ b/src/bun/__tests__/pty-server-native-bridge.test.ts
@@ -127,12 +127,16 @@ class Viewer {
 		return this.frames
 			.filter((f) => f.header.t === "role")
 			.map((f) => {
-				const header = f.header as { role: string; refused?: boolean };
-				return { role: header.role, refused: header.refused === true };
+				const header = f.header as { role: string; refused?: boolean; refusedReason?: string };
+				return {
+					role: header.role,
+					refused: header.refused === true,
+					...(header.refusedReason ? { refusedReason: header.refusedReason } : {}),
+				};
 			});
 	}
 
-	get lastRole(): { role: string; refused: boolean } | undefined {
+	get lastRole(): { role: string; refused: boolean; refusedReason?: string } | undefined {
 		return lastCall(this.roles());
 	}
 
@@ -161,9 +165,27 @@ interface FakeShell {
 	hostRole: "writer" | "observer";
 	/** Whether a cross-process claim succeeds; false = the other process keeps it. */
 	grantClaim: boolean;
+	/** Set when the host cannot transfer at all (a host staged before `takeover`). */
+	takeoverUnsupported: boolean;
+	/** Make the host round trip block until `settleTakeover()` is called. */
+	holdTakeover: boolean;
+	/** False models a host that never confirms the release. */
+	releaseConfirms: boolean;
+	/** True models the host never answering, so the caller must compensate. */
+	takeoverTimesOut: boolean;
+	/** Block the release round trip until `settleRelease()` is called. */
+	holdRelease: boolean;
+	settleRelease: (() => void) | null;
+	/** False models the host REFUSING a resize (stale generation). */
+	resizeApplies: boolean;
 	/** Whether ANY process holds the lease, as the host reports it. */
 	writerAttached: boolean;
 	claimHostWriter: ReturnType<typeof vi.fn>;
+	takeoverHostWriter: ReturnType<typeof vi.fn>;
+	releaseHostWriter: ReturnType<typeof vi.fn>;
+	resizeAwaited: ReturnType<typeof vi.fn>;
+	/** Resolve the pending host round trip by hand, to model a slow host. */
+	settleTakeover: (() => void) | null;
 }
 
 const FIRST_PANE_SESSION_ID = `${SESSION_ID}-pane-1`;
@@ -177,10 +199,47 @@ function fakeShell(): FakeShell {
 		emit: (data) => emit(data),
 		hostRole: "writer",
 		grantClaim: true,
+		takeoverUnsupported: false,
+		holdTakeover: false,
+		releaseConfirms: true,
+		takeoverTimesOut: false,
+		holdRelease: false,
+		settleRelease: null,
+		resizeApplies: true,
 		writerAttached: true,
 		claimHostWriter: vi.fn(async () => {
 			if (shell.grantClaim) shell.hostRole = "writer";
 			return shell.hostRole;
+		}),
+		// The explicit gesture: it displaces a live writer, so `grantClaim` (which models
+		// a NON-stealing claim) does not gate it — only a host too old to transfer does.
+		settleTakeover: null,
+		resizeAwaited: vi.fn(async (cols: number, rows: number) => {
+			if (!shell.resizeApplies) throw new Error("writer generation is stale");
+			(shell.resize as unknown as (c: number, r: number) => void)(cols, rows);
+			return { cols, rows };
+		}),
+		releaseHostWriter: vi.fn(async () => {
+			if (shell.holdRelease) await new Promise<void>((resolve) => { shell.settleRelease = resolve; });
+			if (!shell.releaseConfirms) return false;
+			shell.hostRole = "observer";
+			return true;
+		}),
+		takeoverHostWriter: vi.fn(async () => {
+			// A real takeover is a round trip to another process; tests that care about
+			// what happens DURING it install a gate here.
+			const gate = new Promise<void>((resolve) => {
+				if (shell.holdTakeover) shell.settleTakeover = resolve;
+				else resolve();
+			});
+			await gate;
+			if (shell.takeoverTimesOut) return { ok: false, refusal: "transfer-failed", timedOut: true };
+			if (!shell.takeoverUnsupported) {
+				shell.hostRole = "writer";
+				return { ok: true };
+			}
+			if (shell.grantClaim) shell.hostRole = "writer";
+			return shell.hostRole === "writer" ? { ok: true } : { ok: false, refusal: "host-too-old" };
 		}),
 	};
 	vi.mocked(startNativeTaskPanes).mockResolvedValue({
@@ -202,6 +261,9 @@ function fakeShell(): FakeShell {
 			hostRole: () => shell.hostRole,
 			hostWriterAttached: () => shell.writerAttached,
 			claimHostWriter: shell.claimHostWriter,
+			takeoverHostWriter: shell.takeoverHostWriter,
+			releaseHostWriter: shell.releaseHostWriter,
+			resizeAwaited: shell.resizeAwaited,
 			writerPid: async () => (shell.hostRole === "writer" ? process.pid : 4711),
 		} as unknown as Awaited<ReturnType<typeof bindNativeTaskPane>>;
 	});
@@ -376,11 +438,15 @@ describe("writer and observer", () => {
 		expect(shell.resize.mock.calls).toEqual([[200, 50]]);
 	});
 
-	it("moves the lease atomically on an explicit takeover", () => {
+	// The gesture always asks the host first now (see the stale-cache test above), so it
+	// is inherently async — the ATOMICITY being asserted is that both sides flip in the
+	// same step, not that the step is synchronous.
+	it("moves the lease atomically on an explicit takeover", async () => {
 		const desktop = connect();
 		const browser = connect();
 
 		handlers.message(browser, claimMessage());
+		await delay(FLUSH_MS);
 
 		expect(browser.lastRole).toEqual({ role: "writer", refused: false });
 		expect(desktop.lastRole).toEqual({ role: "observer", refused: false });
@@ -391,32 +457,35 @@ describe("writer and observer", () => {
 		expect(shell.write).toHaveBeenCalledTimes(1);
 	});
 
-	it("re-sizes the PTY to the new writer's viewport after a takeover", () => {
+	it("re-sizes the PTY to the new writer's viewport after a takeover", async () => {
 		const desktop = connect();
 		const browser = connect();
 		handlers.message(desktop, encodeResizeSequence(200, 50));
 		handlers.message(browser, encodeResizeSequence(80, 24));
 
 		handlers.message(browser, claimMessage());
+		await delay(FLUSH_MS);
 
 		expect(lastCall(shell.resize.mock.calls)).toEqual([80, 24]);
 	});
 
 	// An observer that reflows the stream to its own width wraps every long line in
 	// the wrong place, which is what a second window actually looked like.
-	it("tells a viewer the PTY's geometry so an observer can render at the writer's shape", () => {
+	it("tells a viewer the PTY's geometry so an observer can render at the writer's shape", async () => {
 		const desktop = connect();
 		handlers.message(desktop, encodeResizeSequence(200, 50));
+		await delay(FLUSH_MS); // canonical geometry lands with the host's ACK, not the request
 
 		const browser = connect();
 
 		expect(browser.attach).toMatchObject({ role: "observer", cols: 200, rows: 50 });
 	});
 
-	it("republishes the geometry to observers when the writer reshapes the PTY", () => {
+	it("republishes the geometry to observers when the writer reshapes the PTY", async () => {
 		const desktop = connect();
 		const browser = connect();
 		handlers.message(desktop, encodeResizeSequence(180, 44));
+		await delay(FLUSH_MS);
 
 		expect(browser.lastRoleHeader).toMatchObject({ role: "observer", cols: 180, rows: 44 });
 	});
@@ -460,23 +529,26 @@ describe("writer and observer", () => {
 		expect(desktop.attach).toMatchObject({ role: "observer", writerAttached: true });
 	});
 
-	it("take control asks the HOST first and reports a refusal without moving anything", async () => {
+	// A plain `claim` is refused while another dev3 process is typing, so the explicit
+	// gesture must take over instead.
+	it("take control TAKES OVER the host lease from another app process, not merely claims it", async () => {
 		shell.hostRole = "observer";
-		shell.grantClaim = false; // the other process keeps typing
+		shell.grantClaim = false; // a live peer holds it — a plain claim would be refused
 		const desktop = connect();
 
 		handlers.message(desktop, claimMessage());
 		await delay(FLUSH_MS);
 
-		expect(shell.claimHostWriter).toHaveBeenCalledTimes(1);
-		expect(desktop.lastRole).toEqual({ role: "observer", refused: true });
-		handlers.message(desktop, "still refused\r");
-		expect(shell.write).not.toHaveBeenCalled();
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(1);
+		expect(shell.claimHostWriter).not.toHaveBeenCalled();
+		expect(desktop.lastRole).toEqual({ role: "writer", refused: false });
+		handlers.message(desktop, "mine now\r");
+		expect(shell.write).toHaveBeenCalledWith("mine now\r");
 	});
 
-	it("take control promotes the viewer once the host hands the lease over", async () => {
+	it("take control promotes the viewer when the host slot was already vacant", async () => {
 		shell.hostRole = "observer";
-		shell.grantClaim = true; // the other process had already released it
+		shell.writerAttached = false;
 		const desktop = connect();
 
 		handlers.message(desktop, claimMessage());
@@ -487,10 +559,344 @@ describe("writer and observer", () => {
 		expect(shell.write).toHaveBeenCalledWith("mine now\r");
 	});
 
-	it("hands the lease back on an explicit release", () => {
+	// A host that cannot transfer at all: the viewer must be told THAT, not left to
+	// click a button that will never work.
+	it("reports host-too-old when the host cannot transfer and a peer still holds the lease", async () => {
+		shell.hostRole = "observer";
+		shell.takeoverUnsupported = true;
+		shell.grantClaim = false;
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+
+		expect(desktop.lastRole).toEqual({ role: "observer", refused: true, refusedReason: "host-too-old" });
+		handlers.message(desktop, "still refused\r");
+		expect(shell.write).not.toHaveBeenCalled();
+	});
+
+	// The host round trip is async, so the requester can close its
+	// tab mid-flight. Winning the lease for a socket that is gone would leave this process
+	// owning the host lease while every surviving viewer is a local observer — nobody able
+	// to type, in any window, and the lease stranded until the process dies.
+	it("gives the lease to a surviving viewer when the requester leaves mid-takeover", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		const leaving = connect();
+		const staying = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving); // tab closed while the host was still deciding
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		expect(staying.lastRole).toEqual({ role: "writer", refused: false });
+		handlers.message(staying, "mine now\r");
+		expect(shell.write).toHaveBeenCalledWith("mine now\r");
+		expect(shell.releaseHostWriter).not.toHaveBeenCalled();
+	});
+
+	// An unconfirmed release is worse than no release: the lease stays held by a process
+	// that cannot use it, locking every other dev3 window out. Dropping the connection
+	// makes the host free it, because it clears the writer on socket close.
+	it("detaches the host client when the release is never confirmed", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.releaseConfirms = false;
+		const leaving = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving);
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		expect(shell.releaseHostWriter).toHaveBeenCalledTimes(1);
+		expect(shell.detach).toHaveBeenCalled();
+	});
+
+	// A stale local cache must not stop the gesture reaching the host.
+	it("asks the host even when this process already believes it is the writer", async () => {
+		shell.hostRole = "writer";
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(1);
+	});
+
+	it("releases the host lease instead of stranding it when no viewer remains", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		const leaving = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving);
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		// Holding it would lock every other dev3 window out of a pane nobody is watching.
+		expect(shell.releaseHostWriter).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not answer a refusal to a viewer that already left", async () => {
+		shell.hostRole = "observer";
+		shell.takeoverUnsupported = true;
+		shell.grantClaim = false;
+		shell.holdTakeover = true;
+		const leaving = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		const framesBefore = leaving.frames.length;
+		disconnect(leaving);
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		expect(leaving.frames.length).toBe(framesBefore);
+	});
+
+	// Canonical geometry may only change once the HOST has applied the resize.
+	// Publishing what we asked for would broadcast a refused resize as the truth.
+	it("does not publish canonical geometry when the host refuses the resize", async () => {
+		shell.resizeApplies = false;
+		const desktop = connect();
+		const before = desktop.lastRoleHeader;
+
+		handlers.message(desktop, encodeResizeSequence(200, 50));
+		await delay(FLUSH_MS);
+
+		expect(shell.resize).not.toHaveBeenCalledWith(200, 50);
+		expect(desktop.lastRoleHeader).toEqual(before);
+	});
+
+	it("publishes canonical geometry only after the host applies it", async () => {
+		const desktop = connect();
+
+		handlers.message(desktop, encodeResizeSequence(140, 45));
+		await delay(FLUSH_MS);
+
+		expect(shell.resizeAwaited).toHaveBeenCalledWith(140, 45);
+		expect(desktop.lastRoleHeader).toMatchObject({ cols: 140, rows: 45 });
+	});
+
+	// A survivor promoted by a DISCONNECT must be told its effective role. If
+	// another process owns the host lease, calling it `writer` is a lie until it types.
+	it("promotes a disconnect survivor to its EFFECTIVE role, not a raw writer", async () => {
+		shell.hostRole = "observer";
+		const leaving = connect();
+		const staying = connect();
+
+		disconnect(leaving);
+		await delay(FLUSH_MS);
+
+		expect(staying.lastRole).toEqual({ role: "observer", refused: false });
+	});
+
+	it("promotes a disconnect survivor to writer when this process DOES own the lease", async () => {
+		shell.hostRole = "writer";
+		const leaving = connect();
+		const staying = connect();
+
+		disconnect(leaving);
+		await delay(FLUSH_MS);
+
+		expect(staying.lastRole).toEqual({ role: "writer", refused: false });
+	});
+
+	// With the re-entry guard removed this path ran at
+	// ~12k takeovers/second and wrote 540k log lines in three minutes. The bound is now
+	// structural, so a burst of gestures cannot multiply into host round trips.
+	it("asks the host at most ONCE per gesture, however many arrive", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		const desktop = connect();
+
+		for (let i = 0; i < 50; i++) handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+		// One outstanding request for this pane, not fifty.
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(1);
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(1);
+
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(0);
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(1);
+		expect(desktop.lastRole).toEqual({ role: "writer", refused: false });
+	});
+
+	it("settling a takeover never re-enters the host request", async () => {
+		shell.hostRole = "observer";
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+		await delay(FLUSH_MS);
+
+		// The success continuation moves only the LOCAL lease; re-entering here is what
+		// produced the livelock.
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(1);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(0);
+	});
+
+	// A vacant-slot takeover changes writerAttached without changing anyone's
+	// role, so a role-change-driven publish would tell the OTHER viewer nothing.
+	it("tells every local viewer the slot is taken, even though their role did not change", async () => {
+		shell.hostRole = "observer";
+		shell.writerAttached = false;
+		const first = connect();
+		const second = connect();
+		expect(first.attach).toMatchObject({ writerAttached: false });
+
+		shell.writerAttached = true; // the host grants it to `second`
+		handlers.message(second, claimMessage());
+		await delay(FLUSH_MS);
+
+		expect(first.lastRoleHeader).toMatchObject({ role: "observer", writerAttached: true });
+	});
+
+	// Nothing may look like a writer while the binding is going away,
+	// and with no viewers left there must be NO rebind and NO claim.
+	it("demotes before detaching and performs no hidden rebind when no viewer remains", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.releaseConfirms = false;
+		const leaving = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving);
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		expect(shell.releaseHostWriter).toHaveBeenCalledTimes(1);
+		expect(shell.detach).toHaveBeenCalled();
+		// No rebind: bindNativeTaskPane is only ever called for the initial session here.
+		expect(vi.mocked(bindNativeTaskPane)).toHaveBeenCalledTimes(1);
+		// And the bindingless session is GONE, so a later viewer rebuilds it instead of
+		// attaching to a registered session that can never be rebound.
+		expect(pty.hasSession(TASK_ID)).toBe(false);
+	});
+
+	it("keeps a viewer that arrives DURING recovery honest — never an optimistic writer", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.releaseConfirms = false;
+		const leaving = connect();
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving);
+
+		// Settle the host round trip and attach a viewer while the binding is being replaced.
+		shell.settleTakeover?.();
+		const arriving = connect();
+
+		expect(arriving.attach).toMatchObject({ role: "observer" });
+		await delay(FLUSH_MS);
+	});
+
+	// A throwing listener must not be able to strand a request, which would turn a
+	// clean refusal into a timeout and then into an unnecessary compensation.
+	it("settles a refused takeover even when the host error listener throws", async () => {
+		shell.hostRole = "observer";
+		shell.takeoverUnsupported = true;
+		shell.grantClaim = false;
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+
+		// The refusal still reached the viewer, so settlement was not blocked.
+		expect(desktop.lastRole).toMatchObject({ refused: true });
+	});
+
+	// The in-flight guard must be held for the WHOLE recovery. Releasing it when the host
+	// request settles lets a second gesture overlap the release/rebind and the recovering
+	// window, which is exactly what an unawaited compensation allows.
+	it("holds the pane's in-flight guard until compensation itself finishes", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.holdRelease = true;
+		shell.takeoverTimesOut = true;
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+		// Let the host round trip TIME OUT, which is what triggers compensation.
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+		expect(shell.releaseHostWriter).toHaveBeenCalledTimes(1);
+
+		// Compensation is mid-flight. A second gesture must not start another host request.
+		const takeoversSoFar = shell.takeoverHostWriter.mock.calls.length;
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(takeoversSoFar);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(1);
+
+		shell.settleRelease?.();
+		await delay(FLUSH_MS);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(0);
+	});
+
+	// The refusal is a VERDICT, so it must arrive with recovery's outcome. Publishing it
+	// first meant the next snapshot immediately cleared the diagnosis.
+	it("publishes the timeout refusal only after compensation settles", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.holdRelease = true;
+		shell.takeoverTimesOut = true;
+		const desktop = connect();
+
+		handlers.message(desktop, claimMessage());
+		await delay(FLUSH_MS);
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+
+		// Recovery is still running: nothing may claim to know why it failed yet.
+		expect(desktop.lastRole?.refused).not.toBe(true);
+
+		shell.settleRelease?.();
+		await delay(FLUSH_MS);
+		expect(desktop.lastRole).toMatchObject({ refused: true, refusedReason: "transfer-failed" });
+	});
+
+	// The requester-gone path holds the pane's guard for the whole recovery, so a second
+	// gesture cannot overlap release, detach or rebind.
+	it("holds the guard through requester-gone compensation too", async () => {
+		shell.hostRole = "observer";
+		shell.holdTakeover = true;
+		shell.holdRelease = true;
+		const leaving = connect();
+
+		handlers.message(leaving, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(leaving); // the requester's tab closes mid-round-trip, leaving nobody
+		shell.settleTakeover?.();
+		await delay(FLUSH_MS);
+		expect(shell.releaseHostWriter).toHaveBeenCalledTimes(1);
+
+		// A viewer arrives WHILE recovery runs and gestures: no second host request.
+		const arriving = connect();
+		const before = shell.takeoverHostWriter.mock.calls.length;
+		handlers.message(arriving, claimMessage());
+		await delay(FLUSH_MS);
+		expect(shell.takeoverHostWriter).toHaveBeenCalledTimes(before);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(1);
+
+		shell.settleRelease?.();
+		await delay(FLUSH_MS);
+		expect(pty._nativeTakeoversInFlightForTests()).toBe(0);
+	});
+
+	it("hands the lease back on an explicit release", async () => {
 		const desktop = connect();
 		const browser = connect();
 		handlers.message(browser, claimMessage());
+		await delay(FLUSH_MS);
 
 		handlers.message(browser, releaseMessage());
 
@@ -572,6 +978,54 @@ describe("attach frame identity — pane-1 and composite pane-2", () => {
 		expect(viewer.attach.paneId).toBe(SECOND_PANE_ID);
 		expect(viewer.attach.hostPid).toBe(SECOND_PANE_HOST_PID);
 		expect(viewer.attach.shellPid).toBe(SECOND_PANE_SHELL_PID);
+	});
+
+	// Auxiliary panes are registered under `taskId~paneId`. Cleaning up pane 2 must delete
+	// THAT key: deleting the bare taskId would unregister pane 1 and leave pane 2's dead
+	// entry behind, so pane 1's viewers lose their session and pane 2 can never rebind.
+	it("cleans up pane 2 by its composite key, leaving pane 1 registered", async () => {
+		// A holder, not a bare `let`: TS narrows a callback-assigned local back to null.
+		const paneGate: { settle: (() => void) | null } = { settle: null };
+		const paneShell = {
+			sessionId: SECOND_PANE_SESSION_ID,
+			paneId: SECOND_PANE_ID,
+			hostPid: 5060,
+			shellPid: 5061,
+			write: vi.fn(),
+			resize: vi.fn(),
+			detach: vi.fn(),
+			hostRole: () => "observer",
+			hostWriterAttached: () => true,
+			hostPtyGeometry: () => null,
+			takeoverHostWriter: vi.fn(async () => {
+				// Park the round trip so the viewer can leave BEFORE compensation decides.
+				await new Promise<void>((resolve) => { paneGate.settle = resolve; });
+				return { ok: false, refusal: "transfer-failed", timedOut: true };
+			}),
+			releaseHostWriter: vi.fn(async () => false),
+			resizeAwaited: vi.fn(async (cols: number, rows: number) => ({ cols, rows })),
+			claimHostWriter: vi.fn(async () => "observer"),
+			claimHostWriterDiscriminated: vi.fn(async () => ({ outcome: "failed" })),
+			writerPid: vi.fn(async () => 4711),
+		};
+		vi.mocked(bindNativeTaskPane).mockImplementation(async () => paneShell as never);
+		await ensureNativePanePtySession(TASK_ID, SECOND_PANE_ID, SECOND_PANE_SESSION_ID, "proj-1", "/tmp/wt");
+
+		// Pane 2's only viewer gestures, then leaves mid-round-trip: compensation runs with
+		// no viewers, which is the path that unregisters the session.
+		const paneViewer = connectForPane(SECOND_PANE_ID);
+		handlers.message(paneViewer, claimMessage());
+		await delay(FLUSH_MS);
+		disconnect(paneViewer); // leaves while the host round trip is still parked
+		paneGate.settle?.();
+		await delay(FLUSH_MS);
+		await delay(FLUSH_MS);
+
+		expect(pty.hasSession(paneSessionKey(TASK_ID, SECOND_PANE_ID))).toBe(false);
+		expect(pty.hasSession(TASK_ID)).toBe(true); // pane 1 untouched
+		// A later pane-2 open reconstructs it.
+		await ensureNativePanePtySession(TASK_ID, SECOND_PANE_ID, SECOND_PANE_SESSION_ID, "proj-1", "/tmp/wt");
+		expect(pty.hasSession(paneSessionKey(TASK_ID, SECOND_PANE_ID))).toBe(true);
 	});
 });
 

--- a/src/bun/native-task-terminal.ts
+++ b/src/bun/native-task-terminal.ts
@@ -12,7 +12,8 @@
  */
 
 import { createLogger } from "./logger";
-import { NativeSessionClient } from "./native-terminal-registry/client";
+import { HostRefusedError, NativeSessionClient, OwnershipTimeoutError } from "./native-terminal-registry/client";
+import type { WriterTakeoverRefusal } from "../shared/native-terminal-stream";
 import { readRecord } from "./native-terminal-registry/record";
 import type { ClientRole } from "./native-terminal-registry/writer-ownership";
 
@@ -29,7 +30,29 @@ export interface NativeTaskTerminalHooks {
 	 * role until someone republishes it.
 	 */
 	onRoleChange?: (role: ClientRole) => void;
+	/**
+	 * The WRITER — possibly in another app process — resized the shared PTY. Our own
+	 * viewers are still rendering at the previous grid until someone republishes it.
+	 */
+	onGeometry?: (size: { cols: number; rows: number }) => void;
 }
+
+/**
+ * Discriminated on `ok`, never on a role. A cached role can say `writer` while the host
+ * has already moved the lease, so branching on it let a failed or timed-out takeover be
+ * read as success and skip compensation entirely.
+ */
+export type WriterTakeoverResult =
+	| { ok: true }
+	| {
+		ok: false;
+		refusal: WriterTakeoverRefusal;
+		/**
+		 * The host never answered in time, so it may STILL commit the takeover. Distinct
+		 * from every other failure: the caller must compensate, not merely report.
+		 */
+		timedOut?: true;
+	};
 
 /** The app's live write/resize/read binding to one native pane. */
 export interface NativeTaskTerminal {
@@ -41,6 +64,12 @@ export interface NativeTaskTerminal {
 	write(data: string): void;
 	resize(cols: number, rows: number): void;
 	/**
+	 * Resize and resolve only once the HOST has applied it, reporting the size it
+	 * actually adopted. Rejects when the host refuses (a stale lease belief) or never
+	 * answers — the caller must then leave its canonical geometry untouched.
+	 */
+	resizeAwaited(cols: number, rows: number): Promise<{ cols: number; rows: number }>;
+	/**
 	 * What the HOST granted this app process — not what our own viewers agreed
 	 * among themselves. Another dev3 instance may hold the lease, and everything
 	 * an observer writes is dropped on the floor.
@@ -48,8 +77,27 @@ export interface NativeTaskTerminal {
 	hostRole(): ClientRole;
 	/** Whether ANY process holds the lease; null while the host has not said. */
 	hostWriterAttached(): boolean | null;
+	/** The writer's canonical grid as the HOST reports it; null until it has. */
+	hostPtyGeometry(): { cols: number; rows: number } | null;
 	/** Ask the host for the lease. Refused while another process still holds it. */
 	claimHostWriter(): Promise<ClientRole>;
+	/**
+	 * Ask the host for the VACANT slot, distinguishing the answers. `writer` = it was
+	 * free and is ours; `writer-active` = the host authoritatively says someone holds it;
+	 * `failed` = we never got an answer, which says nothing about who owns it.
+	 */
+	claimHostWriterDiscriminated(): Promise<{ outcome: "writer" | "writer-active" | "failed" }>;
+	/**
+	 * Displace the live writer — the explicit `Take control` gesture, and the only
+	 * path that moves a lease between app processes.
+	 */
+	takeoverHostWriter(): Promise<WriterTakeoverResult>;
+	/**
+	 * Hand the host lease back so it is not stranded in a process nobody is viewing.
+	 * Resolves `false` when the host never confirmed — the caller must then get rid of
+	 * the connection itself, or the lease stays held by a process that cannot use it.
+	 */
+	releaseHostWriter(): Promise<boolean>;
 	/** Which app process holds the lease; `null` = vacant, `undefined` = unknown. */
 	writerPid(): Promise<number | null | undefined>;
 	/** Drop our client. The host, shell, and agent keep running. */
@@ -96,6 +144,13 @@ function bindClient(
 		log.warn("Native host refused a pane request", { sessionId, code: error.code, message: error.message ?? "" });
 	});
 	client.onDisconnect(close);
+	if (hooks.onGeometry) {
+		const notify = hooks.onGeometry;
+		client.onGeometry((size) => {
+			log.info("Native host published a new canonical PTY size", { sessionId, ...size });
+			notify(size);
+		});
+	}
 	if (hooks.onRoleChange) {
 		const notify = hooks.onRoleChange;
 		client.onRoleChange((role) => {
@@ -103,7 +158,7 @@ function bindClient(
 			notify(role);
 		});
 	}
-	return {
+	const terminal: NativeTaskTerminal = {
 		sessionId,
 		paneId: paneId || record?.paneId || `${sessionId}:0`,
 		hostPid: record?.host.pid ?? -1,
@@ -114,12 +169,19 @@ function bindClient(
 		resize(cols, rows) {
 			client.resize(cols, rows);
 		},
+		async resizeAwaited(cols, rows) {
+			const ack = await client.resizeAwaited(cols, rows);
+			return { cols: ack.cols, rows: ack.rows };
+		},
 		hostRole() {
 			// A client that never got a role yet cannot be assumed to own the pane.
 			return client.getRole() ?? "observer";
 		},
 		hostWriterAttached() {
 			return client.getWriterAttached();
+		},
+		hostPtyGeometry() {
+			return client.getPtyGeometry();
 		},
 		async claimHostWriter() {
 			if (client.getRole() === "writer") return "writer";
@@ -128,6 +190,63 @@ function bindClient(
 			} catch (err) {
 				log.warn("Claiming the native writer lease failed", { sessionId, error: String(err) });
 				return client.getRole() ?? "observer";
+			}
+		},
+		async claimHostWriterDiscriminated() {
+			if (client.getRole() === "writer") return { outcome: "writer" as const };
+			try {
+				const reply = await client.claimWriter();
+				return { outcome: reply.role === "writer" ? ("writer" as const) : ("writer-active" as const) };
+			} catch (err) {
+				// Only the host's own `conflict` verdict means the slot is genuinely taken, and
+				// it is read off a TYPED error rather than matched in message text. A
+				// disconnect, an auth failure or a timeout says nothing about the lease.
+				const authoritative = err instanceof HostRefusedError && err.code === "conflict";
+				log.warn("Native writer claim failed", { sessionId, error: String(err), authoritative });
+				return { outcome: authoritative ? ("writer-active" as const) : ("failed" as const) };
+			}
+		},
+		async takeoverHostWriter() {
+			// NO short-circuit on our cached role: it can be stale, and skipping the request
+			// would make an explicit gesture silently do nothing. The host's takeover is
+			// idempotent for the true current writer, so always asking is safe.
+			if (!client.supports("takeover")) {
+				// This host cannot transfer at all, so a plain claim is the only option: it
+				// still wins a VACANT slot. Only the host's authoritative "someone holds it"
+				// is host-too-old; a failure we could not interpret stays transfer-failed.
+				log.info("Host does not announce takeover; falling back to a claim", { sessionId });
+				const { outcome } = await terminal.claimHostWriterDiscriminated();
+				if (outcome === "writer") return { ok: true };
+				return { ok: false, refusal: outcome === "writer-active" ? "host-too-old" : "transfer-failed" };
+			}
+			try {
+				const reply = await client.takeoverWriter();
+				log.info("Took over the native writer lease", { sessionId, role: reply.role });
+				// The HOST's answer decides, not our cache: a reply of `observer` is a refusal.
+				if (reply.role !== "writer") return { ok: false, refusal: "transfer-failed" };
+				return { ok: true };
+			} catch (err) {
+				// Every failure against a capable host is `transfer-failed`. The real cause is
+				// logged and never shown, so the UI stays generic rather than guessing.
+				const timedOut = err instanceof OwnershipTimeoutError;
+				log.warn("Native writer takeover failed", { sessionId, error: String(err), timedOut });
+				return { ok: false, refusal: "transfer-failed", ...(timedOut ? { timedOut: true as const } : {}) };
+			}
+		},
+		async releaseHostWriter() {
+			// NO short-circuit on the cached role. After an ambiguous timeout the cache says
+			// observer while the host may have committed the takeover, and returning "released"
+			// without sending anything let the caller skip its detach and strand the lease.
+			try {
+				const reply = await client.releaseWriter();
+				log.info("Released the native writer lease", { sessionId });
+				return reply.role === "observer";
+			} catch (err) {
+				// Swallowing this would leave the lease held by a process that cannot use it,
+				// locking every other dev3 window out of the pane. Report it so the caller
+				// can drop the connection instead.
+				log.warn("Releasing the native writer lease failed", { sessionId, error: String(err) });
+				return false;
 			}
 		},
 		async writerPid() {
@@ -143,6 +262,7 @@ function bindClient(
 			client.close();
 		},
 	};
+	return terminal;
 }
 
 /**
@@ -157,9 +277,22 @@ export async function bindNativeTaskPane(
 	sessionId: string,
 	hooks: NativeTaskTerminalHooks,
 	paneId = "",
+	opts: { discardReplay?: boolean } = {},
 ): Promise<NativeTaskTerminal | null> {
 	const client = await NativeSessionClient.discover(sessionId).catch(() => null);
 	if (!client) return null;
+	// A REBIND keeps its bridge journal, so the host's replay is history it already has and
+	// feeding it through would print the screen twice. Only the frames the host MARKED as
+	// replay are dropped; an older host announces no boundary, and then everything is kept,
+	// because duplicated history is recoverable while a lost marker is not.
+	if (opts.discardReplay) {
+		const dropped = client.discardReplayedOutput();
+		if (dropped === null) {
+			log.warn("Host announces no replay boundary; keeping its replay to avoid losing live output", { sessionId });
+		} else {
+			log.info("Discarded the host replay on rebind; the bridge already holds it", { sessionId, dropped });
+		}
+	}
 	const terminal = bindClient(sessionId, paneId, client, hooks);
 	await ensureWriter(sessionId, client);
 	log.info("Native pane bound", {

--- a/src/bun/native-terminal-registry/__tests__/client.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/client.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NativeSessionClient } from "../client";
-import { encodeControl, welcomeMessage } from "../protocol";
+import {
+	encodeControl,
+	HOST_CAPABILITIES,
+	ownershipReply,
+	resizedReply,
+	welcomeMessage,
+} from "../protocol";
 import { NATIVE_SESSION_SCHEMA_VERSION, type NativeSessionRecord } from "../record";
 
 interface FakeListener {
@@ -76,14 +82,55 @@ function record(sessionId: string): NativeSessionRecord {
 	};
 }
 
-async function connect(client: NativeSessionClient, sessionId: string): Promise<FakeWebSocket> {
+/** The frames this fake has sent, parsed. */
+function sentFrames(socket: FakeWebSocket): Array<Record<string, unknown>> {
+	return socket.sent.map((raw) => JSON.parse(String(raw)) as Record<string, unknown>);
+}
+
+function lastSent(socket: FakeWebSocket, type: string): Record<string, unknown> | undefined {
+	return sentFrames(socket).filter((f) => f.type === type).pop();
+}
+
+/**
+ * Connect and answer the attach-time status read, so tests are deterministic instead of
+ * waiting out its timeout. `capabilities` lets a test model an older host.
+ */
+async function connect(
+	client: NativeSessionClient,
+	sessionId: string,
+	opts: { capabilities?: readonly string[]; role?: "writer" | "observer"; generation?: number } = {},
+): Promise<FakeWebSocket> {
 	const connecting = client.connect(record(sessionId), "token", { timeoutMs: 1000 });
 	const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
 	if (!socket) throw new Error("fake socket was not created");
 	socket.emit("open", new Event("open"));
 	await Promise.resolve();
 	const hello = JSON.parse(String(socket.sent[0])) as { id: number };
-	socket.emitMessage(encodeControl(welcomeMessage(hello.id, sessionId)));
+	socket.emitMessage(encodeControl(welcomeMessage(hello.id, sessionId, opts.role ?? "writer", {
+		capabilities: (opts.capabilities ?? HOST_CAPABILITIES) as never,
+		writerGeneration: opts.generation ?? 1,
+	})));
+	// The client reads status right after hello; answer it at its own correlated id.
+	await Promise.resolve();
+	const statusFrame = lastSent(socket, "status");
+	if (statusFrame) {
+		socket.emitMessage(encodeControl({
+			v: 1,
+			id: statusFrame.id as number,
+			type: "status",
+			sessionId,
+			paneId: sessionId,
+			hostPid: 10,
+			shellPid: 11,
+			cols: 80,
+			rows: 24,
+			alive: true,
+			startedAt: "2026-07-22T00:00:00.000Z",
+			clientRole: opts.role ?? "writer",
+			writerAttached: true,
+			writerGeneration: opts.generation ?? 1,
+		}));
+	}
 	await connecting;
 	return socket;
 }
@@ -107,6 +154,264 @@ describe("NativeSessionClient socket ownership", () => {
 		client.close();
 
 		expect(() => client.input("after-close")).toThrow("not connected");
+	});
+
+	// ── correlated control requests ───────────
+	// Separate id counters per type used to collide, so a resize conflict carrying id N
+	// could settle an unrelated takeover holding id N. Correlation is now (id, kind,
+	// connection) out of ONE allocator.
+	it("never reuses an id across request kinds, so a resize error cannot settle a takeover", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "collide");
+
+		const takeover = client.takeoverWriter({ timeoutMs: 1000 });
+		const resize = client.resizeAwaited(120, 40, { timeoutMs: 1000 });
+		await Promise.resolve();
+		const ownershipId = lastSent(socket, "ownership")?.id as number;
+		const resizeId = lastSent(socket, "resize")?.id as number;
+		expect(resizeId).not.toBe(ownershipId);
+
+		// The resize is refused. The takeover must be untouched and still settle on its own.
+		socket.emitMessage(encodeControl({ v: 1, type: "error", code: "conflict", id: resizeId, message: "writer generation is stale" }));
+		await expect(resize).rejects.toThrow(/conflict/);
+		socket.emitMessage(encodeControl(ownershipReply(ownershipId, "writer", true, 2)));
+		await expect(takeover).resolves.toMatchObject({ role: "writer" });
+		expect(client.getRole()).toBe("writer");
+	});
+
+	it("resolves a resize only from its OWN acknowledgement, and caches only then", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "ack");
+		const before = client.getPtyGeometry();
+
+		const resize = client.resizeAwaited(120, 40, { timeoutMs: 1000 });
+		await Promise.resolve();
+		const id = lastSent(socket, "resize")?.id as number;
+
+		// A wrong-id ack must neither settle the request nor touch the cache.
+		socket.emitMessage(encodeControl(resizedReply(id + 99, 999, 999, 5)));
+		expect(client.getPtyGeometry()).toEqual(before);
+
+		socket.emitMessage(encodeControl(resizedReply(id, 120, 40, 2)));
+		await expect(resize).resolves.toMatchObject({ cols: 120, rows: 40 });
+		expect(client.getPtyGeometry()).toEqual({ cols: 120, rows: 40 });
+		expect(client.getWriterGeneration()).toBe(2);
+
+		// A duplicate of the same ack has nothing to settle and must not re-apply.
+		socket.emitMessage(encodeControl(resizedReply(id, 777, 777, 9)));
+		expect(client.getPtyGeometry()).toEqual({ cols: 120, rows: 40 });
+		expect(client.getWriterGeneration()).toBe(2);
+	});
+
+	it("sends the generation it believes in, so the host can refuse a stale resize", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "gen", { generation: 4 });
+
+		void client.resizeAwaited(90, 30, { timeoutMs: 1000 }).catch(() => undefined);
+		await Promise.resolve();
+
+		expect(lastSent(socket, "resize")).toMatchObject({ cols: 90, rows: 30, expectedGeneration: 4 });
+	});
+
+	it("does not cache a LATE acknowledgement that arrives after its timeout", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "late-ack");
+		const before = client.getPtyGeometry();
+
+		const resize = client.resizeAwaited(150, 50, { timeoutMs: 5 });
+		const id = lastSent(socket, "resize")?.id as number;
+		await expect(resize).rejects.toThrow(/resize timeout/);
+
+		socket.emitMessage(encodeControl(resizedReply(id, 150, 50, 8)));
+		expect(client.getPtyGeometry()).toEqual(before);
+		expect(client.getWriterGeneration()).not.toBe(8);
+	});
+
+	// The sharpest one: a timed-out takeover the host commits anyway. The late reply must
+	// do NOTHING, or ownership flips after the click that asked for it is long gone.
+	it("ignores a LATE nonzero ownership reply — a timeout is not a second chance", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "late-ownership", { role: "observer" });
+
+		const takeover = client.takeoverWriter({ timeoutMs: 5 });
+		const id = lastSent(socket, "ownership")?.id as number;
+		await expect(takeover).rejects.toThrow(/timeout/);
+
+		socket.emitMessage(encodeControl(ownershipReply(id, "writer", true, 3)));
+
+		expect(client.getRole()).toBe("observer");
+		expect(client.getLateOwnershipReplyCount()).toBe(1);
+	});
+
+	it("still applies an id=0 frame, which is the ONLY unsolicited kind", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "unsolicited", { role: "observer" });
+		const roles: string[] = [];
+		client.onRoleChange((role) => roles.push(role));
+
+		socket.emitMessage(encodeControl(ownershipReply(0, "writer", true, 6)));
+
+		expect(client.getRole()).toBe("writer");
+		expect(client.getWriterGeneration()).toBe(6);
+		expect(roles).toEqual(["writer"]);
+	});
+
+	it("treats an id=0 status as a canonical-geometry broadcast, not a reply", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "geometry");
+		const sizes: Array<{ cols: number; rows: number }> = [];
+		client.onGeometry((size) => sizes.push(size));
+
+		socket.emitMessage(encodeControl({
+			v: 1, type: "status", id: 0, sessionId: "geometry", paneId: "geometry",
+			hostPid: 10, shellPid: 11, cols: 132, rows: 43, alive: true,
+			startedAt: "2026-07-22T00:00:00.000Z", writerAttached: true, writerGeneration: 7,
+		}));
+
+		expect(sizes).toEqual([{ cols: 132, rows: 43 }]);
+		expect(client.getPtyGeometry()).toEqual({ cols: 132, rows: 43 });
+	});
+
+	it("cannot be settled by a reply belonging to a socket we have already replaced", async () => {
+		const client = new NativeSessionClient();
+		const first = await connect(client, "sock-a", { role: "observer" });
+		const takeover = client.takeoverWriter({ timeoutMs: 1000 });
+		const id = lastSent(first, "ownership")?.id as number;
+		client.close(); // the pending request dies with its socket
+		await expect(takeover.catch((e) => e)).resolves.toBeInstanceOf(Error);
+
+		await connect(client, "sock-b", { role: "observer" });
+		first.emitMessage(encodeControl(ownershipReply(id, "writer", true, 4)));
+
+		expect(client.getRole()).toBe("observer");
+	});
+
+	it("reports a host that does not announce resize-ack instead of faking a confirmation", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "old-host", { capabilities: [] });
+
+		await expect(client.resizeAwaited(100, 30)).rejects.toThrow(/does not support resize-ack/);
+		// It still sends the resize, uncorrelated, exactly as an older client would.
+		expect(lastSent(socket, "resize")).toMatchObject({ cols: 100, rows: 30 });
+		expect(lastSent(socket, "resize")?.id).toBeUndefined();
+	});
+
+	// Internal settlement must happen BEFORE any external listener runs, and each
+	// listener is isolated. Otherwise a throwing (or reconnecting) listener strands the
+	// request, which becomes a timeout and then an unnecessary compensation.
+	it("settles the exact request before external listeners, so a throwing one cannot strand it", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "throwing", { role: "observer" });
+		const seen: string[] = [];
+		client.onError(() => { throw new Error("listener exploded"); });
+		client.onError((e) => seen.push(e.code));
+
+		const takeover = client.takeoverWriter({ timeoutMs: 2000 });
+		await Promise.resolve();
+		const id = lastSent(socket, "ownership")?.id as number;
+		socket.emitMessage(encodeControl({ v: 1, type: "error", code: "conflict", id, message: "another client is already the writer" }));
+
+		// Settled with the host's real verdict, not a timeout.
+		const err = await takeover.catch((e) => e as Error);
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error & { code?: string }).code).toBe("conflict");
+		// The surviving listener still ran, so isolation works in both directions.
+		expect(seen).toEqual(["conflict"]);
+	});
+
+	it("keeps settling requests when a role listener throws", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "throwing-role", { role: "observer" });
+		client.onRoleChange(() => { throw new Error("role listener exploded"); });
+
+		socket.emitMessage(encodeControl(ownershipReply(0, "writer", true, 3)));
+		expect(client.getRole()).toBe("writer");
+
+		// A subsequent correlated request still settles normally.
+		const status = client.status({ timeoutMs: 1000 });
+		await Promise.resolve();
+		const id = lastSent(socket, "status")?.id as number;
+		socket.emitMessage(encodeControl({
+			v: 1, type: "status", id, sessionId: "throwing-role", paneId: "p",
+			hostPid: 10, shellPid: 11, cols: 80, rows: 24, alive: true,
+			startedAt: "2026-07-22T00:00:00.000Z", writerAttached: true, writerGeneration: 3,
+		}));
+		await expect(status).resolves.toMatchObject({ cols: 80 });
+	});
+
+	it("reports a refusal as a TYPED error so callers stop matching message text", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "typed", { role: "observer" });
+
+		const takeover = client.takeoverWriter({ timeoutMs: 1000 });
+		await Promise.resolve();
+		const id = lastSent(socket, "ownership")?.id as number;
+		socket.emitMessage(encodeControl({ v: 1, type: "error", code: "unauthorized", id }));
+
+		const err = (await takeover.catch((e) => e)) as Error & { code?: string };
+		expect(err.name).toBe("HostRefusedError");
+		expect(err.code).toBe("unauthorized");
+	});
+
+	// A rebind must drop the host's replay but keep bytes produced while the handshake was
+	// still finishing. Both land in the same pre-listener buffer, so only the host's
+	// explicit boundary can tell them apart.
+	it("drops replayed frames on a rebind and KEEPS live output that followed the boundary", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "replay-boundary");
+		const encoder = new TextEncoder();
+
+		// History, boundary, then a marker emitted before any listener attached.
+		socket.emit("message", { data: encoder.encode("OLD-HISTORY").buffer } as MessageEvent);
+		socket.emitMessage(encodeControl({ v: 1, type: "replayed" }));
+		socket.emit("message", { data: encoder.encode("LIVE-MARKER").buffer } as MessageEvent);
+
+		expect(client.discardReplayedOutput()).toBe(1);
+
+		const seen: string[] = [];
+		client.onOutput((bytes) => seen.push(new TextDecoder().decode(bytes)));
+		expect(seen.join("")).toBe("LIVE-MARKER");
+	});
+
+	// The byte cap evicts from the FRONT, which is where the replay sits. A count of
+	// leading replay frames goes stale the moment that happens, and discarding by that
+	// count then deletes live output. Frames are tagged instead, so identity survives.
+	it("survives cap eviction: discard removes only remaining replay and keeps the marker", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "replay-evict");
+		const encoder = new TextEncoder();
+		const big = new Uint8Array(200 * 1024);
+
+		// A replay large enough that the next frames push it past the 256 KiB cap.
+		socket.emit("message", { data: big.buffer } as MessageEvent);
+		socket.emit("message", { data: big.buffer } as MessageEvent);
+		socket.emitMessage(encodeControl({ v: 1, type: "replayed" }));
+		// Live output, then more live bytes that force eviction of the leading replay.
+		socket.emit("message", { data: encoder.encode("LIVE-MARKER").buffer } as MessageEvent);
+		socket.emit("message", { data: big.buffer } as MessageEvent);
+
+		client.discardReplayedOutput();
+
+		const seen: string[] = [];
+		client.onOutput((bytes) => seen.push(new TextDecoder().decode(bytes)));
+		const joined = seen.join("");
+		expect(joined).toContain("LIVE-MARKER");
+		// Exactly once, and no replay left behind.
+		expect(joined.split("LIVE-MARKER").length - 1).toBe(1);
+	});
+
+	it("keeps everything when the host announces no replay boundary", async () => {
+		const client = new NativeSessionClient();
+		const socket = await connect(client, "old-replay", { capabilities: ["takeover"] });
+		const encoder = new TextEncoder();
+		socket.emit("message", { data: encoder.encode("HISTORY-AND-LIVE").buffer } as MessageEvent);
+
+		// null = "cannot tell them apart", so the caller must not drop anything: duplicated
+		// history is recoverable, a lost marker is not.
+		expect(client.discardReplayedOutput()).toBeNull();
+		const seen: string[] = [];
+		client.onOutput((bytes) => seen.push(new TextDecoder().decode(bytes)));
+		expect(seen.join("")).toBe("HISTORY-AND-LIVE");
 	});
 
 	it("ignores a delayed close event from an older socket after reconnect", async () => {

--- a/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
@@ -26,7 +26,7 @@ import { spawn, spawnSync } from "../../spawn";
 import { NativeSessionClient } from "../client";
 import { recordFile, tokenFile } from "../paths";
 import { isProcessAlive } from "../process-identity";
-import { MAX_CONTROL_FRAME_BYTES } from "../protocol";
+import { decodeControl, MAX_CONTROL_FRAME_BYTES } from "../protocol";
 import {
 	NATIVE_SESSION_SCHEMA_VERSION,
 	readRecord,
@@ -122,14 +122,21 @@ function makeSink(client: NativeSessionClient): {
  * Open a raw WebSocket (bypassing NativeSessionClient) with `token`, send one
  * text `firstFrame`, and report the first control reply + whether the host closed
  * the socket. When `secondFrame` is given, send it after the first reply and
- * capture a second reply too. Models a hostile/mismatched client probing v1.
+ * capture its reply after crossing the validated replay boundary. Models a
+ * hostile/mismatched client probing v1.
  */
 function rawFirstFrameProbe(
 	record: NativeSessionRecord,
 	token: string,
 	firstFrame: string,
 	secondFrame?: string,
-): Promise<{ reply: Record<string, unknown> | null; second: Record<string, unknown> | null; opened: boolean; closed: boolean }> {
+): Promise<{
+	reply: Record<string, unknown> | null;
+	second: Record<string, unknown> | null;
+	replayedBoundarySeen: boolean;
+	opened: boolean;
+	closed: boolean;
+}> {
 	const url = `ws://${record.endpoint.address}:${record.endpoint.port}/?token=${encodeURIComponent(token)}`;
 	const ws = new WebSocket(url);
 	return new Promise((resolve) => {
@@ -138,6 +145,7 @@ function rawFirstFrameProbe(
 		let opened = false;
 		let settled = false;
 		let sentSecond = false;
+		let replayedBoundarySeen = false;
 		const finish = (closed: boolean): void => {
 			if (settled) return;
 			settled = true;
@@ -146,7 +154,7 @@ function rawFirstFrameProbe(
 			} catch {
 				// already closed
 			}
-			resolve({ reply, second, opened, closed });
+			resolve({ reply, second, replayedBoundarySeen, opened, closed });
 		};
 		const to = setTimeout(() => finish(false), 2500);
 		ws.addEventListener("open", () => {
@@ -160,6 +168,15 @@ function rawFirstFrameProbe(
 				reply = parsed;
 				sentSecond = true;
 				ws.send(secondFrame);
+				return;
+			}
+			if (
+				secondFrame !== undefined &&
+				sentSecond &&
+				!replayedBoundarySeen &&
+				decodeControl(ev.data)?.type === "replayed"
+			) {
+				replayedBoundarySeen = true;
 				return;
 			}
 			if (secondFrame !== undefined) second = parsed;
@@ -398,6 +415,10 @@ async function run(): Promise<void> {
 			alphaToken,
 			JSON.stringify({ v: 1, type: "hello", sessionId: "alpha", id: 7 }),
 			JSON.stringify({ v: 1, type: "hello", sessionId: "alpha", id: 8 }),
+		);
+		check(
+			dupHello.replayedBoundarySeen,
+			"the duplicate-hello probe crosses the validated replay boundary before its correlated response",
 		);
 		check(
 			dupHello.reply?.type === "welcome" && dupHello.second?.type === "error" && dupHello.second?.code === "conflict" && dupHello.second?.id === 8,

--- a/src/bun/native-terminal-registry/__tests__/multi-client.bun-e2e.ts
+++ b/src/bun/native-terminal-registry/__tests__/multi-client.bun-e2e.ts
@@ -173,6 +173,7 @@ async function run(): Promise<void> {
 		const writerSink = sinks[writerIndex]!;
 		const observerSink = sinks[observerIndex]!;
 		const observerErrors = errorSinks[observerIndex]!;
+		const writerErrors = errorSinks[writerIndex]!;
 
 		const syncStart = `SYNC-START-${nonce}`;
 		const syncBody = `SYNC-BODY-${nonce}`;
@@ -216,8 +217,143 @@ async function run(): Promise<void> {
 		const writerCols = beforeResize.cols + 3;
 		const writerRows = beforeResize.rows + 2;
 		writer.resize(writerCols, writerRows);
+		// The sender's cache follows the host's ACKNOWLEDGEMENT, never the value it merely
+		// sent — an unowned resize is refused, and caching it optimistically would hand
+		// every viewer a size the PTY never had. The host skips the sender in its geometry
+		// broadcast, so the ack is the only thing that can refresh this; no status call is
+		// made here, which is what proves it.
+		const ackDeadline = Date.now() + 4000;
+		while (Date.now() < ackDeadline) {
+			const cached = writer.getPtyGeometry();
+			if (cached?.cols === writerCols && cached.rows === writerRows) break;
+			await new Promise((r) => setTimeout(r, 25));
+		}
+		const senderCache = writer.getPtyGeometry();
+		check(
+			senderCache?.cols === writerCols && senderCache?.rows === writerRows,
+			"the writer's cached grid follows the host's resize ACK, with no status round trip",
+		);
 		const resized = await writer.status();
 		check(resized.cols === writerCols && resized.rows === writerRows, "the current writer controls the PTY dimensions");
+
+		// A FRESH observer must know the canonical grid before the writer ever resizes:
+		// `welcome` carries the role but no size, so without the attach-time status read
+		// it would reflow the writer's byte stream at its own width.
+		const fresh = new NativeSessionClient();
+		makeSink(fresh);
+		await fresh.connect(started.record, token);
+		clients.push(fresh);
+		check(fresh.getRole() === "observer", "a third attach is an observer, so it does not own the grid");
+		const freshGeometry = fresh.getPtyGeometry();
+		check(
+			freshGeometry?.cols === writerCols && freshGeometry?.rows === writerRows,
+			`a freshly attached observer already knows the writer's grid (${writerCols}x${writerRows}) with no resize involved`,
+		);
+		// An observer's own viewport must never move the shared PTY.
+		fresh.resize(writerCols + 31, writerRows + 13);
+		const afterObserverResize = await writer.status();
+		check(
+			afterObserverResize.cols === writerCols && afterObserverResize.rows === writerRows,
+			"an observer's viewport never changes the canonical PTY size",
+		);
+		await disconnect(fresh);
+		clients.pop();
+
+		// ── explicit takeover of a LIVE writer ──
+		// A plain claim is refused here by design; the explicit action is the only way a
+		// lease moves while someone is typing. The ordering that matters is that the
+		// displaced client is already an observer by the time the winner is confirmed —
+		// otherwise there is a window in which both believe they own the one PTY.
+		const preTakeoverErrors = observerErrors.all().length;
+		const liveTakeover = await observer.takeoverWriter();
+		check(
+			liveTakeover.role === "writer" && liveTakeover.writerAttached,
+			"an explicit takeover moves the lease while the previous writer is still attached",
+		);
+		// Frame arrival order across two sockets is NOT guaranteed, so asserting the
+		// displaced client's own cached role at this instant would be a scheduling bet.
+		// Ask the HOST instead: it decides, and its answer per connection is authoritative
+		// the moment the swap happened. That is also the property that actually matters —
+		// enforcement is host-side, not in either client's belief about itself.
+		const winnerView = await observer.status();
+		const loserView = await writer.status();
+		check(
+			winnerView.clientRole === "writer" && loserView.clientRole === "observer" && loserView.writerAttached === true,
+			"the HOST reports exactly one writer immediately after the swap — the displaced connection is an observer to it",
+		);
+		check(observerErrors.all().length === preTakeoverErrors, "the takeover produced no error frame");
+		const displacedRejected = `DISPLACED-${nonce}`;
+		const beforeDisplacedErr = writerErrors.all().length;
+		send(writer, outputCommand(displacedRejected));
+		const displacedConflict = await writerErrors.waitFor("conflict", beforeDisplacedErr);
+		check(displacedConflict !== null, "the displaced client's input is refused by the host in turn");
+		// Over the real wire: a client whose cached role is STALE still gestures. The
+		// displaced client here believes it is the writer until it processes its demotion,
+		// so its explicit takeover must be SENT and must win — last explicit wins.
+		const staleGeneration = writer.getWriterGeneration();
+		// NO status call before the stale resize: a status round trip is a same-socket
+		// barrier behind the demotion frame AND refreshes the generation, which would make
+		// the request perfectly current. The grid and cache come from what the displaced
+		// client already knows, so the resize goes out on its OLD generation.
+		const gridBeforeStaleResize = writer.getPtyGeometry();
+		const staleErrBefore = writerErrors.all().length;
+		const staleResize = writer.resizeAwaited(writerCols + 40, 20).catch((err) => err as Error);
+		const staleResizeRefused = await writerErrors.waitFor("conflict", staleErrBefore);
+		const staleOutcome = await staleResize;
+		check(
+			staleResizeRefused !== null && staleResizeRefused.code === "conflict",
+			`a stale writer's resize is refused with a conflict (reason: ${staleResizeRefused?.message ?? "none"})`,
+		);
+		// A stale writer that takes over becomes the writer again, so `canMutatePty` passes,
+		// while its cached generation is still the pre-takeover one because the takeover
+		// reply has not been processed yet. Sending both without awaiting the first is what
+		// reaches the host's generation validation.
+		const genErrBefore = writerErrors.all().length;
+		const generationBeforeRetake = writer.getWriterGeneration();
+		const retake = writer.takeoverWriter();
+		const resizeOnStaleGeneration = writer.resizeAwaited(writerCols + 11, writerRows + 7).catch((e) => e as Error);
+		await retake;
+		const generationRefusal = await writerErrors.waitFor("conflict", genErrBefore);
+		const staleGenOutcome = await resizeOnStaleGeneration;
+		check(
+			generationRefusal !== null && generationRefusal.message?.includes("generation") === true,
+			`the host rejects a resize carrying a STALE generation, by that exact reason (got ${generationRefusal?.message ?? "none"})`,
+		);
+		check(
+			staleGenOutcome instanceof Error && writer.getWriterGeneration() !== generationBeforeRetake,
+			"the stale-generation resize settles as a failure while the lease itself moved on",
+		);
+		const afterGenerationRefusal = await observer.status();
+		check(
+			afterGenerationRefusal.cols === writerCols && afterGenerationRefusal.rows === writerRows,
+			"a generation-rejected resize leaves the canonical PTY size untouched",
+		);
+		check(
+			staleOutcome instanceof Error && /conflict/.test(staleOutcome.message),
+			"the refusal settles the SENDER'S OWN correlated request rather than leaking to another",
+		);
+		check(
+			writer.getPtyGeometry()?.cols === gridBeforeStaleResize?.cols
+				&& writer.getPtyGeometry()?.rows === gridBeforeStaleResize?.rows,
+			"a refused resize does NOT poison the sender's cached canonical grid",
+		);
+		// Only NOW is a status call safe: the canonical size must be unchanged host-side too.
+		const afterStaleResize = await observer.status();
+		check(
+			afterStaleResize.cols === writerCols && afterStaleResize.rows === writerRows,
+			`the canonical PTY size is untouched by the refused resize (${writerCols}x${writerRows})`,
+		);
+
+		// Hand it back so the release/claim assertions below keep their original subject.
+		const handedBack = await writer.takeoverWriter();
+		check(
+			typeof staleGeneration === "number" && handedBack.writerGeneration === staleGeneration + 1,
+			"the explicit gesture from a client with a STALE cached role still wins, and bumps the generation",
+		);
+		check(
+			handedBack.role === "writer" && observer.getRole() === "observer",
+			"a takeover works in both directions — the transfer is not one-way",
+		);
 
 		const released = await writer.releaseWriter();
 		check(released.role === "observer" && !released.writerAttached, "writer release leaves one explicit vacant writer slot");

--- a/src/bun/native-terminal-registry/__tests__/protocol.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/protocol.test.ts
@@ -18,6 +18,8 @@ import {
 	stoppingEvent,
 	stopRequest,
 	welcomeMessage,
+	resizedReply,
+	HOST_CAPABILITIES,
 } from "../protocol";
 
 const V = NATIVE_SESSION_PROTOCOL_VERSION;
@@ -28,6 +30,9 @@ describe("native-session protocol v1", () => {
 			resizeMessage(120, 40),
 			statusRequest(7),
 			ownershipRequest(8, "claim"),
+			ownershipRequest(9, "release"),
+			ownershipRequest(10, "takeover"),
+			resizedReply(11, 120, 40, 7),
 			ownershipReply(8, "writer", true),
 			stopRequest(),
 			welcomeMessage(1, "alpha", "writer"),
@@ -40,6 +45,43 @@ describe("native-session protocol v1", () => {
 		}
 		// hello is version-agnostic and parsed by its own decoder, not decodeControl.
 		expect(decodeHello(encodeControl(helloMessage("alpha", 1)))).toEqual(helloMessage("alpha", 1));
+	});
+
+	// `takeover` is additive in v1: a host staged before it must DROP the frame (so the
+	// client times out and can say so) rather than misread it as a non-stealing claim.
+	// The client must LEARN what a host can do instead of timing out an unknown action.
+	it("announces capabilities and the writer generation on welcome", () => {
+		const welcome = welcomeMessage(1, "alpha", "writer", { capabilities: HOST_CAPABILITIES, writerGeneration: 3 });
+		const decoded = decodeControl(encodeControl(welcome));
+
+		expect(decoded).toEqual(welcome);
+		expect(HOST_CAPABILITIES).toContain("takeover");
+		// An OLD host omits the field entirely; that must decode fine and mean "unknown".
+		const old = welcomeMessage(1, "alpha", "writer");
+		expect(decodeControl(encodeControl(old))).toEqual(old);
+		expect((decodeControl(encodeControl(old)) as { capabilities?: unknown }).capabilities).toBeUndefined();
+	});
+
+	it("carries the sender's expected generation on a resize, so a stale one can be refused", () => {
+		const msg = resizeMessage(100, 30, { id: 4, expectedGeneration: 9 });
+		expect(decodeControl(encodeControl(msg))).toEqual(msg);
+		// Uncorrelated resize stays valid — older clients send exactly this.
+		expect(decodeControl(encodeControl(resizeMessage(100, 30)))).toEqual(resizeMessage(100, 30));
+	});
+
+	it("rejects a malformed resize acknowledgement rather than half-applying it", () => {
+		for (const bad of [
+			{ v: V, type: "resized", id: 1, cols: 80, rows: 24 },
+			{ v: V, type: "resized", id: 1, cols: 80, writerGeneration: 2 },
+			{ v: V, type: "resized", cols: 80, rows: 24, writerGeneration: 2 },
+		]) {
+			expect(decodeControl(JSON.stringify(bad))).toBeNull();
+		}
+	});
+
+	it("rejects an ownership action it does not know", () => {
+		expect(decodeControl(JSON.stringify({ v: V, type: "ownership", id: 3, action: "steal" }))).toBeNull();
+		expect(decodeControl(JSON.stringify({ v: V, type: "ownership", id: 3 }))).toBeNull();
 	});
 
 	it("preserves exact shell exit codes", () => {

--- a/src/bun/native-terminal-registry/__tests__/writer-ownership.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/writer-ownership.test.ts
@@ -25,16 +25,18 @@ describe("native-session writer ownership", () => {
 			ok: true,
 			role: "observer",
 			writerAttached: false,
+			generation: 2,
 		});
 
 		const claims = [ownership.request(first, "claim"), ownership.request(second, "claim")];
 		expect(claims.filter((result) => result.ok)).toHaveLength(1);
-		expect(claims[0]).toEqual({ ok: true, role: "writer", writerAttached: true });
+		expect(claims[0]).toEqual({ ok: true, role: "writer", writerAttached: true, generation: 3 });
 		expect(claims[1]).toEqual({
 			ok: false,
 			reason: "writer-active",
 			role: "observer",
 			writerAttached: true,
+			generation: 3,
 		});
 		expect(ownership.canMutatePty(first)).toBe(true);
 		expect(ownership.canMutatePty(second)).toBe(false);
@@ -96,7 +98,177 @@ describe("native-session writer ownership", () => {
 			ok: true,
 			role: "writer",
 			writerAttached: true,
+			generation: 3,
 		});
+	});
+
+	// ── explicit takeover ─────────────────────────────────────────────
+	// `claim` must stay non-stealing — that is what keeps ordinary attachment safe —
+	// so transferring a LIVE lease needs its own action.
+	it("moves a live lease on takeover, demoting the previous writer", () => {
+		const ownership = new WriterOwnership<object>();
+		const first = {};
+		const second = {};
+		ownership.attach(first);
+		ownership.attach(second);
+
+		expect(ownership.request(second, "takeover")).toEqual({
+			ok: true,
+			role: "writer",
+			writerAttached: true,
+			generation: 2,
+		});
+		// One pointer, swapped in one call: never two writers, never none.
+		expect(ownership.canMutatePty(second)).toBe(true);
+		expect(ownership.canMutatePty(first)).toBe(false);
+		expect(ownership.roleOf(first)).toBe("observer");
+		expect(ownership.hasWriter()).toBe(true);
+		expect(ownership.writerClient()).toBe(second);
+	});
+
+	it("refuses a plain claim in the very case takeover handles", () => {
+		const ownership = new WriterOwnership<object>();
+		const first = {};
+		const second = {};
+		ownership.attach(first);
+		ownership.attach(second);
+
+		expect(ownership.request(second, "claim")).toEqual({
+			ok: false,
+			reason: "writer-active",
+			role: "observer",
+			writerAttached: true,
+			generation: 1,
+		});
+		expect(ownership.canMutatePty(first)).toBe(true);
+	});
+
+	it("is idempotent when the current writer takes over again — the pointer does not move", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		ownership.attach(writer);
+
+		expect(ownership.request(writer, "takeover")).toEqual({
+			ok: true,
+			role: "writer",
+			writerAttached: true,
+			generation: 1,
+		});
+		expect(ownership.canMutatePty(writer)).toBe(true);
+	});
+
+	it("takes a VACANT slot, counting it as one transition", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		const observer = {};
+		ownership.attach(writer);
+		ownership.attach(observer);
+		ownership.detach(writer);
+
+		expect(ownership.request(observer, "takeover")).toEqual({
+			ok: true,
+			role: "writer",
+			writerAttached: true,
+			generation: 3,
+		});
+	});
+
+	it("refuses a takeover from a client that never attached", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		ownership.attach(writer);
+
+		expect(ownership.request({}, "takeover")).toEqual({
+			ok: false,
+			reason: "not-attached",
+			role: null,
+			writerAttached: true,
+			generation: 1,
+		});
+		expect(ownership.canMutatePty(writer)).toBe(true);
+	});
+
+	// The documented contract (decision 200): last-explicit-takeover-wins. Deliberately
+	// NOT an expected-owner/generation guard — the host serializes these, so a rejection
+	// would only make the button refuse a click the user meant.
+	it("last explicit takeover wins: both succeed and the pointer ends on the last asker", () => {
+		const ownership = new WriterOwnership<object>();
+		const a = {};
+		const b = {};
+		const c = {};
+		ownership.attach(a);
+		ownership.attach(b);
+		ownership.attach(c);
+
+		expect(ownership.request(b, "takeover")).toMatchObject({ ok: true, generation: 2 });
+		expect(ownership.roleOf(a)).toBe("observer");
+		expect(ownership.request(c, "takeover")).toMatchObject({ ok: true, generation: 3 });
+		expect(ownership.roleOf(b)).toBe("observer");
+		expect(ownership.writerClient()).toBe(c);
+	});
+
+	// ── writer generation ──────────────────────────────
+	// A client cannot tell "the lease I know about" from "a lease that has moved since"
+	// without this, and would resize a PTY it no longer owns.
+	it("counts every REAL pointer transition exactly once", () => {
+		const ownership = new WriterOwnership<object>();
+		const a = {};
+		const b = {};
+		expect(ownership.writerGeneration()).toBe(0);
+
+		ownership.attach(a); // null -> A
+		expect(ownership.writerGeneration()).toBe(1);
+		ownership.attach(b); // no transition: b observes
+		expect(ownership.writerGeneration()).toBe(1);
+		ownership.request(b, "takeover"); // A -> B
+		expect(ownership.writerGeneration()).toBe(2);
+		ownership.request(b, "release"); // B -> null
+		expect(ownership.writerGeneration()).toBe(3);
+		ownership.request(a, "claim"); // null -> A
+		expect(ownership.writerGeneration()).toBe(4);
+		ownership.detach(a); // A -> null
+		expect(ownership.writerGeneration()).toBe(5);
+	});
+
+	it("does NOT count idempotent requests — they move nothing", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		ownership.attach(writer);
+		const before = ownership.writerGeneration();
+
+		ownership.request(writer, "claim");
+		ownership.request(writer, "takeover");
+		ownership.attach(writer);
+
+		expect(ownership.writerGeneration()).toBe(before);
+	});
+
+	it("does NOT count a refused request", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		const observer = {};
+		ownership.attach(writer);
+		ownership.attach(observer);
+		const before = ownership.writerGeneration();
+
+		ownership.request(observer, "claim"); // refused: writer-active
+		ownership.request(observer, "release"); // refused: not-writer
+		ownership.request({}, "takeover"); // refused: not-attached
+
+		expect(ownership.writerGeneration()).toBe(before);
+	});
+
+	it("does NOT count an observer leaving", () => {
+		const ownership = new WriterOwnership<object>();
+		const writer = {};
+		const observer = {};
+		ownership.attach(writer);
+		ownership.attach(observer);
+		const before = ownership.writerGeneration();
+
+		ownership.detach(observer);
+
+		expect(ownership.writerGeneration()).toBe(before);
 	});
 
 	it("starts a new host with no stale writer lease", () => {

--- a/src/bun/native-terminal-registry/client.ts
+++ b/src/bun/native-terminal-registry/client.ts
@@ -16,10 +16,13 @@ import {
 	helloMessage,
 	ownershipRequest,
 	resizeMessage,
+	type HostCapability,
 	statusRequest,
 	stopRequest,
+	type ErrorCode,
 	type ErrorMessage,
 	type OwnershipReply,
+	type ResizedReply,
 	type StatusReply,
 } from "./protocol";
 import { DEFAULT_JOURNAL_MAX_BYTES } from "./journal";
@@ -30,25 +33,89 @@ import type { ClientRole, WriterAction } from "./writer-ownership";
 
 const encoder = new TextEncoder();
 
+/**
+ * The host answered a request with an explicit refusal, carrying its code so callers
+ * decide on a typed verdict instead of matching on message text.
+ */
+export class HostRefusedError extends Error {
+	constructor(readonly code: ErrorCode, message?: string) {
+		super(`native session error: ${code}${message ? ` (${message})` : ""}`);
+		this.name = "HostRefusedError";
+	}
+}
+
+/**
+ * The host never answered in time, so it may STILL commit the request. Ambiguous, not a
+ * refusal: the caller must compensate rather than report failure and move on.
+ */
+export class OwnershipTimeoutError extends Error {
+	constructor(readonly action: WriterAction) {
+		super(`ownership ${action} timeout`);
+		this.name = "OwnershipTimeoutError";
+	}
+}
+
 interface Pending<T> {
 	resolve: (value: T) => void;
 	reject: (err: Error) => void;
 	timer: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * Which kind of reply a pending control request will accept. Correlation is by
+ * (id, kind, connection) — never by id alone: separate id counters per type collided, so
+ * a resize conflict carrying id N could settle an unrelated takeover holding id N.
+ */
+type PendingKind = "status" | "ownership" | "resize";
+
+type PendingReply = StatusReply | OwnershipReply | ResizedReply;
+
+interface PendingRequest {
+	kind: PendingKind;
+	/** The socket generation this request belongs to; a later socket must not settle it. */
+	connection: number;
+	settle: (reply: PendingReply) => void;
+	reject: (err: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+/** `id: 0` is reserved for unsolicited host events, so it can never match a request. */
+export const UNSOLICITED_ID = 0;
+
 export class NativeSessionClient {
 	private ws: WebSocket | null = null;
 	private connectionGeneration = 0;
-	private nextId = 1;
+	/** ONE id space for every control request on this connection. Starts above 0 so an
+	 * unsolicited host event (id 0) can never be mistaken for a reply we are awaiting. */
+	private nextRequestId = 1;
 	private helloId = 0;
 	private readonly outputCbs = new Set<(bytes: Uint8Array) => void>();
 	private readonly errorCbs: Array<(error: ErrorMessage) => void> = [];
 	private readonly disconnectCbs: Array<() => void> = [];
 	private readonly roleCbs: Array<(role: ClientRole) => void> = [];
-	private readonly bufferedOutput: Uint8Array[] = [];
+	private readonly geometryCbs: Array<(size: { cols: number; rows: number }) => void> = [];
+	/**
+	 * The writer's canonical grid, as last CONFIRMED by the host; null until it says.
+	 * Only an applied resize, a status reply, or a host geometry event may set this — a
+	 * resize we merely SENT can still be refused, and caching it would poison every
+	 * viewer with a size the PTY never had.
+	 */
+	private ptyGeometry: { cols: number; rows: number } | null = null;
+	/** Host's monotonic lease-transition counter; null until the host reports one. */
+	private writerGeneration: number | null = null;
+	private capabilities: readonly HostCapability[] = [];
+	/** Late nonzero ownership replies this connection has dropped. */
+	private lateOwnershipReplies = 0;
+	/**
+	 * Pre-listener output, each frame TAGGED with the phase it arrived in. A count of
+	 * leading replay frames cannot survive the byte-cap eviction below, which shifts
+	 * frames off the front — the count would go stale and a later discard would delete
+	 * live output instead.
+	 */
+	private readonly bufferedOutput: Array<{ bytes: Uint8Array; replay: boolean }> = [];
 	private bufferedOutputBytes = 0;
-	private readonly statusPending = new Map<number, Pending<StatusReply>>();
-	private readonly ownershipPending = new Map<number, Pending<OwnershipReply>>();
+	private replayBoundarySeen = false;
+	private readonly pending = new Map<number, PendingRequest>();
 	private readonly stopResolvers: Array<() => void> = [];
 	private readonly exitPending = new Set<Pending<number | null>>();
 	private helloPending: Pending<void> | null = null;
@@ -58,11 +125,43 @@ export class NativeSessionClient {
 	private exitObserved = false;
 	private exitCode: number | null = null;
 
+	/**
+	 * Drop ONLY the frames the host marked as journal replay, keeping every live byte that
+	 * arrived after the boundary. A rebind already holds that history in its own bridge
+	 * journal, so replaying it would print the screen twice — but clearing the whole
+	 * pre-listener queue would silently eat output produced while the handshake finished.
+	 * Returns null when this host announces no boundary, so the caller must keep everything.
+	 */
+	discardReplayedOutput(): number | null {
+		if (!this.supports("replay-boundary")) return null;
+		let dropped = 0;
+		// Drop by TAG, not by position or count: eviction may already have removed some of
+		// the replay, and a stale count would take live frames with it.
+		for (let i = this.bufferedOutput.length - 1; i >= 0; i--) {
+			if (!this.bufferedOutput[i]!.replay) continue;
+			this.bufferedOutputBytes -= this.bufferedOutput[i]!.bytes.byteLength;
+			this.bufferedOutput.splice(i, 1);
+			dropped++;
+		}
+		return dropped;
+	}
+
 	onOutput(cb: (bytes: Uint8Array) => void): () => void {
 		this.outputCbs.add(cb);
-		for (const bytes of this.bufferedOutput.splice(0)) cb(bytes);
+		for (const frame of this.bufferedOutput.splice(0)) cb(frame.bytes);
 		this.bufferedOutputBytes = 0;
 		return () => this.outputCbs.delete(cb);
+	}
+
+	/** Invoke external listeners in ISOLATION, after internal state is already settled. */
+	private fanOut<T>(callbacks: ReadonlyArray<(value: T) => void>, value: T): void {
+		for (const cb of [...callbacks]) {
+			try {
+				cb(value);
+			} catch {
+				// One listener's failure must not stop the others or corrupt our own state.
+			}
+		}
 	}
 
 	onError(cb: (error: ErrorMessage) => void): void {
@@ -76,6 +175,38 @@ export class NativeSessionClient {
 	/** The host changed our role without being asked — usually a promotion. */
 	onRoleChange(cb: (role: ClientRole) => void): void {
 		this.roleCbs.push(cb);
+	}
+
+	/**
+	 * The WRITER resized the shared PTY. An observer in another app process cannot
+	 * learn this any other way — its own process never saw that resize — and without
+	 * it it renders the writer's byte stream at its own width.
+	 */
+	onGeometry(cb: (size: { cols: number; rows: number }) => void): void {
+		this.geometryCbs.push(cb);
+	}
+
+	/** The writer's canonical grid; null while the host has not reported one. */
+	getPtyGeometry(): { cols: number; rows: number } | null {
+		return this.ptyGeometry;
+	}
+
+	/** How many late/unmatched ownership replies this connection has ignored. */
+	getLateOwnershipReplyCount(): number {
+		return this.lateOwnershipReplies;
+	}
+
+	/** The lease generation the host last reported; null on a host that predates it. */
+	getWriterGeneration(): number | null {
+		return this.writerGeneration;
+	}
+
+	/**
+	 * Whether the host ANNOUNCED support for a capability. Absent means an older host,
+	 * which callers must treat as unsupported — never infer support from a timeout.
+	 */
+	supports(capability: HostCapability): boolean {
+		return this.capabilities.includes(capability);
 	}
 
 	getRole(): ClientRole | null {
@@ -96,6 +227,9 @@ export class NativeSessionClient {
 		this.ws = ws;
 		this.exitObserved = false;
 		this.exitCode = null;
+		this.replayBoundarySeen = false;
+		this.bufferedOutput.length = 0;
+		this.bufferedOutputBytes = 0;
 		ws.addEventListener("message", (ev) => this.onMessage(generation, ws, ev));
 		ws.addEventListener("close", () => this.onClose(generation, ws));
 		const timeoutMs = opts.timeoutMs ?? 5000;
@@ -119,6 +253,12 @@ export class NativeSessionClient {
 			);
 		});
 		await this.performHello(record.sessionId, timeoutMs);
+		// `welcome` carries the role but no SIZE, so without this an attaching observer
+		// knows no canonical grid until the writer happens to resize — and it would
+		// reflow the writer's byte stream at its own width in the meantime. One status
+		// read closes that window and works on every v1 host, including ones predating
+		// the resize broadcast. Non-fatal: a failure leaves the grid honestly unknown.
+		await this.status({ timeoutMs }).catch(() => undefined);
 	}
 
 	private performHello(sessionId: string, timeoutMs: number): Promise<void> {
@@ -128,7 +268,7 @@ export class NativeSessionClient {
 				reject(new Error("not connected"));
 				return;
 			}
-			const id = this.nextId++;
+			const id = this.nextRequestId++;
 			this.helloId = id; // the welcome (or error) is matched against this id in onMessage
 			const timer = setTimeout(() => {
 				this.helloPending = null;
@@ -167,18 +307,13 @@ export class NativeSessionClient {
 			this.helloPending = null;
 			pending.reject(new Error("connection closed before welcome"));
 		}
-		for (const [id, pending] of this.statusPending) {
-			clearTimeout(pending.timer);
-			pending.reject(new Error("connection closed before status reply"));
-			this.statusPending.delete(id);
-		}
-		for (const [id, pending] of this.ownershipPending) {
-			clearTimeout(pending.timer);
-			pending.reject(new Error("connection closed before ownership reply"));
-			this.ownershipPending.delete(id);
+		for (const [id, request] of this.pending) {
+			clearTimeout(request.timer);
+			request.reject(new Error(`connection closed before ${request.kind} reply`));
+			this.pending.delete(id);
 		}
 		for (const r of this.stopResolvers.splice(0)) r();
-		for (const cb of this.disconnectCbs.splice(0)) cb();
+		this.fanOut(this.disconnectCbs.splice(0), undefined as void);
 		for (const pending of this.exitPending) {
 			clearTimeout(pending.timer);
 			pending.reject(new Error("connection closed before shell exit event"));
@@ -196,35 +331,62 @@ export class NativeSessionClient {
 			}
 			const msg = decodeControl(data);
 			if (!msg) return;
+			if (msg.type === "resized") {
+				// The ONLY path to a new canonical grid, and it must be OUR resize: an ack we
+				// are not awaiting is late, duplicated, or from a replaced socket, and applying
+				// it would cache a size for a request whose context is gone.
+				const ack = msg as ResizedReply;
+				const request = this.takePending(ack.id, "resize");
+				if (!request) return;
+				this.writerGeneration = ack.writerGeneration;
+				this.ptyGeometry = { cols: ack.cols, rows: ack.rows };
+				request.settle(ack);
+				return;
+			}
 			if (msg.type === "status") {
 				const reply = msg as StatusReply;
-				const pending = this.statusPending.get(reply.id);
+				this.ptyGeometry = { cols: reply.cols, rows: reply.rows };
+				if (typeof reply.writerGeneration === "number") this.writerGeneration = reply.writerGeneration;
+				if (typeof reply.writerAttached === "boolean") this.writerAttachedKnown = reply.writerAttached;
+				const pending = reply.id === UNSOLICITED_ID ? null : this.takePending(reply.id, "status");
 				if (pending) {
-					clearTimeout(pending.timer);
-					this.statusPending.delete(reply.id);
-					pending.resolve(reply);
+					pending.settle(reply);
+				} else if (reply.id === UNSOLICITED_ID) {
+					// Only id 0 is an event: the writer resized the canonical grid.
+					this.fanOut(this.geometryCbs, { cols: reply.cols, rows: reply.rows });
 				}
 			} else if (msg.type === "ownership" && "role" in msg) {
 				const reply = msg as OwnershipReply;
-				const pending = this.ownershipPending.get(reply.id);
-				// An unsolicited reply means the host handed us the lease because the
-				// previous writer disconnected. Dropping it (as "no pending request")
-				// leaves us believing we are read-only while the host waits for input.
+				// ONLY id 0 is unsolicited. A nonzero reply whose request already timed out
+				// must do NOTHING: applying it would flip this process's ownership after the
+				// click that asked for it, and its local lease context, are long gone. The
+				// caller compensates for that timeout; a late frame is not a second chance.
+				const pending = reply.id === UNSOLICITED_ID ? null : this.takePending(reply.id, "ownership");
+				if (reply.id !== UNSOLICITED_ID && !pending) {
+					this.lateOwnershipReplies++;
+					return;
+				}
 				this.currentRole = reply.role;
 				this.writerAttachedKnown = reply.writerAttached;
+				if (typeof reply.writerGeneration === "number") this.writerGeneration = reply.writerGeneration;
 				if (pending) {
-					clearTimeout(pending.timer);
-					this.ownershipPending.delete(reply.id);
-					pending.resolve(reply);
+					pending.settle(reply);
 				} else {
-					for (const cb of this.roleCbs) cb(reply.role);
+					// The host moved the lease without being asked (a vacancy or a takeover).
+					this.fanOut(this.roleCbs, reply.role);
 				}
+			} else if (msg.type === "replayed") {
+				// Everything buffered so far is history; anything after this is live.
+				this.replayBoundarySeen = true;
 			} else if (msg.type === "stopping") {
 				for (const r of this.stopResolvers.splice(0)) r();
 			} else if (msg.type === "error") {
 				const error = msg as ErrorMessage;
-				for (const cb of this.errorCbs) cb(error);
+				// Settle FIRST. A listener that throws — or reconnects — must not be able to
+				// leave the request pending, which would turn a clean refusal into a timeout
+				// and then into an unnecessary compensation.
 				this.rejectPendingByError(error);
+				this.fanOut(this.errorCbs, error);
 			} else if (msg.type === "exit") {
 				this.exitObserved = true;
 				this.exitCode = msg.code;
@@ -245,10 +407,10 @@ export class NativeSessionClient {
 		if (!bytes) return;
 		if (this.outputCbs.size === 0) {
 			const copy = bytes.slice();
-			this.bufferedOutput.push(copy);
+			this.bufferedOutput.push({ bytes: copy, replay: !this.replayBoundarySeen });
 			this.bufferedOutputBytes += copy.byteLength;
 			while (this.bufferedOutput.length > 1 && this.bufferedOutputBytes > DEFAULT_JOURNAL_MAX_BYTES) {
-				this.bufferedOutputBytes -= this.bufferedOutput.shift()!.byteLength;
+				this.bufferedOutputBytes -= this.bufferedOutput.shift()!.bytes.byteLength;
 			}
 			return;
 		}
@@ -263,6 +425,8 @@ export class NativeSessionClient {
 			clearTimeout(pending.timer);
 			this.helloPending = null;
 			this.currentRole = welcome.role ?? "writer";
+			this.capabilities = Array.isArray(welcome.capabilities) ? welcome.capabilities : [];
+			if (typeof welcome.writerGeneration === "number") this.writerGeneration = welcome.writerGeneration;
 			pending.resolve();
 			return;
 		}
@@ -275,13 +439,59 @@ export class NativeSessionClient {
 	}
 
 	private rejectPendingByError(err: ErrorMessage): void {
-		if (err.id === undefined) return;
-		const pending = this.statusPending.get(err.id) ?? this.ownershipPending.get(err.id);
-		if (!pending) return;
-		clearTimeout(pending.timer);
-		this.statusPending.delete(err.id);
-		this.ownershipPending.delete(err.id);
-		pending.reject(new Error(`native session error: ${err.code}${err.message ? ` (${err.message})` : ""}`));
+		// An error may answer ANY kind, but the shared id space means at most one request
+		// is registered at that id, so there is nothing to guess between.
+		if (err.id === undefined || err.id === UNSOLICITED_ID) return;
+		const request = this.takePending(err.id);
+		if (!request) return;
+		request.reject(new HostRefusedError(err.code, err.message));
+	}
+
+	/**
+	 * Claim the pending request at `id` when it matches `kind` and this connection.
+	 * A mismatch is left in place and the caller ignores the frame — settling the wrong
+	 * kind, or a request belonging to a socket we have already replaced, is how a late
+	 * or unrelated reply silently commits work nobody is waiting for.
+	 */
+	private takePending(id: number, kind?: PendingKind): PendingRequest | null {
+		const request = this.pending.get(id);
+		if (!request) return null;
+		if (kind !== undefined && request.kind !== kind) return null;
+		if (request.connection !== this.connectionGeneration) return null;
+		clearTimeout(request.timer);
+		this.pending.delete(id);
+		return request;
+	}
+
+	/**
+	 * Send one correlated control request and await its exact reply. The single place
+	 * that allocates an id, tags the kind and connection, and arms the timeout.
+	 */
+	private request<T>(
+		kind: PendingKind,
+		build: (id: number) => string,
+		opts: { timeoutMs?: number } = {},
+	): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			const ws = this.ws;
+			if (!ws) {
+				reject(new Error("not connected"));
+				return;
+			}
+			const id = this.nextRequestId++;
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`${kind} timeout`));
+			}, opts.timeoutMs ?? 3000);
+			this.pending.set(id, {
+				kind,
+				connection: this.connectionGeneration,
+				settle: (reply) => resolve(reply as T),
+				reject,
+				timer,
+			});
+			ws.send(build(id));
+		});
 	}
 
 	/** Keystrokes go as a BINARY frame (host reads binary as PTY input, text as JSON control). */
@@ -294,39 +504,58 @@ export class NativeSessionClient {
 		this.ws.send(data as Uint8Array<ArrayBuffer>);
 	}
 
+	/**
+	 * Resize the shared PTY, resolving only on the host's acknowledgement — never
+	 * optimistically, since a stale client's resize is refused. `expectedGeneration` is
+	 * what lets the host refuse it.
+	 */
+	resizeAwaited(cols: number, rows: number, opts: { timeoutMs?: number } = {}): Promise<ResizedReply> {
+		if (!this.supports("resize-ack")) {
+			// An older host cannot acknowledge; send it and report honestly that we do not
+			// know the outcome, rather than inventing a confirmation.
+			this.ws?.send(encodeControl(resizeMessage(cols, rows)));
+			return Promise.reject(new Error("host does not support resize-ack"));
+		}
+		return this.request<ResizedReply>(
+			"resize",
+			(id) => encodeControl(resizeMessage(cols, rows, {
+				id,
+				...(this.writerGeneration !== null ? { expectedGeneration: this.writerGeneration } : {}),
+			})),
+			opts,
+		);
+	}
+
+	/** Fire-and-forget form: the ack still drives the cache; failures are swallowed. */
 	resize(cols: number, rows: number): void {
-		this.ws?.send(encodeControl(resizeMessage(cols, rows)));
+		if (!this.ws) return;
+		void this.resizeAwaited(cols, rows).catch(() => undefined);
 	}
 
 	status(opts: { timeoutMs?: number } = {}): Promise<StatusReply> {
-		return new Promise((resolve, reject) => {
-			if (!this.ws) {
-				reject(new Error("not connected"));
-				return;
-			}
-			const id = this.nextId++;
-			const timer = setTimeout(() => {
-				this.statusPending.delete(id);
-				reject(new Error("status timeout"));
-			}, opts.timeoutMs ?? 3000);
-			this.statusPending.set(id, { resolve, reject, timer });
-			this.ws.send(encodeControl(statusRequest(id)));
-		});
+		return this.request<StatusReply>("status", (id) => encodeControl(statusRequest(id)), opts);
 	}
 
 	private requestOwnership(action: WriterAction, opts: { timeoutMs?: number } = {}): Promise<OwnershipReply> {
-		return new Promise((resolve, reject) => {
-			if (!this.ws) {
+		return new Promise<OwnershipReply>((resolve, reject) => {
+			const ws = this.ws;
+			if (!ws) {
 				reject(new Error("not connected"));
 				return;
 			}
-			const id = this.nextId++;
+			const id = this.nextRequestId++;
 			const timer = setTimeout(() => {
-				this.ownershipPending.delete(id);
-				reject(new Error(`ownership ${action} timeout`));
+				this.pending.delete(id);
+				reject(new OwnershipTimeoutError(action));
 			}, opts.timeoutMs ?? 3000);
-			this.ownershipPending.set(id, { resolve, reject, timer });
-			this.ws.send(encodeControl(ownershipRequest(id, action)));
+			this.pending.set(id, {
+				kind: "ownership",
+				connection: this.connectionGeneration,
+				settle: (reply) => resolve(reply as OwnershipReply),
+				reject,
+				timer,
+			});
+			ws.send(encodeControl(ownershipRequest(id, action)));
 		});
 	}
 
@@ -336,6 +565,15 @@ export class NativeSessionClient {
 
 	releaseWriter(opts: { timeoutMs?: number } = {}): Promise<OwnershipReply> {
 		return this.requestOwnership("release", opts);
+	}
+
+	/**
+	 * Displace whoever currently holds the lease. This is the explicit user gesture
+	 * only — never an attach-time fallback, or attaching would steal the lease from
+	 * whoever is typing.
+	 */
+	takeoverWriter(opts: { timeoutMs?: number } = {}): Promise<OwnershipReply> {
+		return this.requestOwnership("takeover", opts);
 	}
 
 	requestStop(opts: { timeoutMs?: number } = {}): Promise<void> {

--- a/src/bun/native-terminal-registry/host.ts
+++ b/src/bun/native-terminal-registry/host.ts
@@ -30,7 +30,10 @@ import {
 	exceedsControlFrameLimit,
 	exitEvent,
 	NATIVE_SESSION_PROTOCOL_VERSION,
+	HOST_CAPABILITIES,
 	ownershipReply,
+	replayedEvent,
+	resizedReply,
 	stoppingEvent,
 	welcomeMessage,
 	type StatusReply,
@@ -427,7 +430,12 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 				// LEARN the slot opened, or it stays read-only forever with nobody typing.
 				for (const survivor of writerOwnership.detach(ws)) {
 					try {
-						survivor.send(encodeControl(ownershipReply(0, writerOwnership.roleOf(survivor) ?? "observer", false)));
+						survivor.send(encodeControl(ownershipReply(
+							0,
+							writerOwnership.roleOf(survivor) ?? "observer",
+							false,
+							writerOwnership.writerGeneration(),
+						)));
 					} catch { /* that survivor died too */ }
 				}
 				// Detach boundary: make the reconstructable state current on disk.
@@ -464,9 +472,20 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 				ws.data.helloDone = true;
 				ws.data.clientPid = verdict.clientPid;
 				const role = writerOwnership.attach(ws);
-				ws.send(encodeControl(welcomeMessage(verdict.id, sessionId, role)));
+				// Capabilities are announced, never inferred: a client must not have to time
+				// out an unknown action to discover whether this host understands it.
+				ws.send(encodeControl(welcomeMessage(verdict.id, sessionId, role, {
+					capabilities: HOST_CAPABILITIES,
+					writerGeneration: writerOwnership.writerGeneration(),
+				})));
 				// Same synchronous turn: replay ends before later PTY callbacks fan out live bytes.
 				for (const bytes of journal.replay()) ws.send(bytes);
+				// Same synchronous turn as the replay it terminates, so no live byte can slip
+				// in front of it.
+				ws.send(encodeControl(replayedEvent()));
+				// A first client becoming writer IS a real transition, so the survivors of an
+				// earlier vacancy must learn the slot is taken again.
+				if (role === "writer") broadcastOwnership(ws);
 				return;
 			}
 			const dupHello = decodeHello(message);
@@ -478,7 +497,14 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 			if (!msg) return; // drop unparseable / forward-additive control quietly
 			if (msg.type === "resize") {
 				if (!writerOwnership.canMutatePty(ws)) {
-					ws.send(encodeControl(errorMessage("conflict", undefined, "observer cannot resize the PTY")));
+					ws.send(encodeControl(errorMessage("conflict", msg.id, "observer cannot resize the PTY")));
+					return;
+				}
+				// A writer whose belief about the lease is stale must not resize the PTY it
+				// no longer owns. It tells us which generation it thinks is current; if the
+				// lease has moved since, this resize is refused rather than applied.
+				if (msg.expectedGeneration !== undefined && msg.expectedGeneration !== writerOwnership.writerGeneration()) {
+					ws.send(encodeControl(errorMessage("conflict", msg.id, "writer generation is stale")));
 					return;
 				}
 				currentCols = msg.cols;
@@ -492,9 +518,25 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 				tap?.recordResize(msg.cols, msg.rows);
 				pipeline?.onResize(msg.cols, msg.rows);
 				void persist().catch(() => {});
+				// Acknowledge to the sender: only an APPLIED resize may update its cached
+				// canonical grid, never the hopeful value it sent.
+				if (msg.id !== undefined) {
+					ws.send(encodeControl(resizedReply(msg.id, currentCols, currentRows, writerOwnership.writerGeneration())));
+				}
+				// Unsolicited (id 0): the writer owns the canonical grid, and an observer in
+				// ANOTHER app process has no other way to learn it — its own process never saw
+				// this resize. Without it that observer renders the writer's byte stream at its
+				// own width and wraps every line that reaches the right edge.
+				for (const other of clients) {
+					if (other === ws || !other.data.helloDone) continue;
+					try {
+						other.send(encodeControl(currentStatus(other, 0)));
+					} catch { /* dead client */ }
+				}
 			} else if (msg.type === "status") {
 				ws.send(encodeControl(currentStatus(ws, msg.id)));
 			} else if (msg.type === "ownership" && "action" in msg) {
+				const generationBefore = writerOwnership.writerGeneration();
 				const result = writerOwnership.request(ws, msg.action);
 				if (!result.ok) {
 					const message =
@@ -506,7 +548,13 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 					ws.send(encodeControl(errorMessage("conflict", msg.id, message)));
 					return;
 				}
-				ws.send(encodeControl(ownershipReply(msg.id, result.role, result.writerAttached)));
+				// Order is the invariant, and each client hears about a transition EXACTLY
+				// once. Every non-winner — the displaced writer included — is told first, so
+				// no turn exists in which two clients believe they may write; the winner's
+				// confirmation goes last. A separate explicit send to the displaced client
+				// would duplicate the same transition and generation it gets here.
+				if (result.generation !== generationBefore) broadcastOwnership(ws);
+				ws.send(encodeControl(ownershipReply(msg.id, result.role, result.writerAttached, result.generation)));
 			} else if (msg.type === "stop") {
 				for (const c of clients) {
 					try {
@@ -525,6 +573,21 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 			return;
 		}
 		proc.terminal?.write(message);
+	}
+
+	/** Tell every client EXCEPT `origin` the lease state after a real transition. */
+	function broadcastOwnership(origin: HostClient | null): void {
+		for (const other of clients) {
+			if (other === origin || !other.data.helloDone) continue;
+			try {
+				other.send(encodeControl(ownershipReply(
+					0,
+					writerOwnership.roleOf(other) ?? "observer",
+					writerOwnership.hasWriter(),
+					writerOwnership.writerGeneration(),
+				)));
+			} catch { /* dead client */ }
+		}
 	}
 
 	function currentStatus(ws: HostClient, id: number): StatusReply {
@@ -546,6 +609,7 @@ export async function runHost(config: HostConfig = resolveHostConfig()): Promise
 			startedAt,
 			clientRole: writerOwnership.roleOf(ws) ?? "observer",
 			writerAttached: writerOwnership.hasWriter(),
+			writerGeneration: writerOwnership.writerGeneration(),
 			...(writerPid !== undefined ? { writerPid } : {}),
 		};
 	}

--- a/src/bun/native-terminal-registry/protocol.ts
+++ b/src/bun/native-terminal-registry/protocol.ts
@@ -7,12 +7,16 @@
  *
  * This is a deliberately small LOCAL protocol, not an RPC framework. A client
  * opens with a version-agnostic `hello`; the host replies `welcome` (accept) or
- * one explicit `error{code:"version-mismatch"}` and leaves the shell alive. Only
- * the three request/response pairs (hello→welcome, status→status, and
- * ownership→ownership) carry a request
- * `id`; every other frame is a fire-and-forget command or an unsolicited event.
+ * one explicit `error{code:"version-mismatch"}` and leaves the shell alive. The
+ * request/response pairs — hello→welcome, status→status, ownership→ownership and
+ * resize→resized — carry a request `id` from one connection-wide space; every other frame
+ * is a fire-and-forget command or an unsolicited event.
  * Unknown ADDITIVE fields on a known type are ignored; a future breaking change
  * bumps NATIVE_SESSION_PROTOCOL_VERSION rather than negotiating in-band.
+ *
+ * Two reply types double as unsolicited EVENTS when their `id` is 0: `ownership`
+ * (the lease moved without this client asking) and `status` (the writer resized the
+ * canonical grid). A client with no pending request must apply them, not drop them.
  *
  * Pure module: no Bun/Node runtime deps, trivially unit-testable.
  */
@@ -20,6 +24,17 @@
 import type { ClientRole, WriterAction } from "./writer-ownership";
 
 export const NATIVE_SESSION_PROTOCOL_VERSION = 1;
+
+/**
+ * What THIS host build can do, announced on `welcome`. Capabilities are how a client
+ * knows a feature exists instead of inferring it from a timeout: an older host simply
+ * omits the field, and a client must read that as "not supported", never as "broken".
+ */
+// ONE literal tuple is the source of truth; the union is derived so the two cannot
+// drift. A capability earns its place only when a caller actually negotiates on it —
+// `writerGeneration` rides every reply as a plain field and needs no announcement.
+export const HOST_CAPABILITIES = ["takeover", "resize-ack", "replay-boundary"] as const;
+export type HostCapability = (typeof HOST_CAPABILITIES)[number];
 
 /** Control (TEXT) frames are tiny JSON; anything larger is rejected, never parsed. */
 export const MAX_CONTROL_FRAME_BYTES = 64 * 1024;
@@ -52,6 +67,14 @@ export interface ResizeMessage {
 	type: "resize";
 	cols: number;
 	rows: number;
+	/** Additive: correlates the `resized` acknowledgement. Absent = fire-and-forget. */
+	id?: number;
+	/**
+	 * Additive: the writer generation the sender BELIEVES is current. The host refuses
+	 * the resize when it no longer matches, which is what stops a client whose role
+	 * cache is stale from resizing a PTY it no longer owns.
+	 */
+	expectedGeneration?: number;
 }
 export interface StatusRequest {
 	v: number;
@@ -70,6 +93,19 @@ export interface StopRequest {
 }
 export type ClientControl = HelloMessage | ResizeMessage | StatusRequest | OwnershipRequest | StopRequest;
 
+/**
+ * The host APPLIED a resize. Its own name (not a `resize` echo) so request and
+ * acknowledgement can never be confused for one another on a shared channel.
+ */
+export interface ResizedReply {
+	v: number;
+	type: "resized";
+	id: number;
+	cols: number;
+	rows: number;
+	writerGeneration: number;
+}
+
 // ── Host → Client ─────────────────────────────────────────────────────
 /** Accepts a hello; echoes the hello's request id. */
 export interface WelcomeMessage {
@@ -80,6 +116,10 @@ export interface WelcomeMessage {
 	protocolVersion: number;
 	/** Additive in v1; absent hosts predate explicit writer ownership. */
 	role?: ClientRole;
+	/** Additive: what this host supports. Absent = an old host; assume nothing. */
+	capabilities?: readonly HostCapability[];
+	/** Additive: the writer generation at attach time. */
+	writerGeneration?: number;
 }
 export interface ErrorMessage {
 	v: number;
@@ -111,6 +151,8 @@ export interface StatusReply {
 	 * must treat as "unknown", never as "vacant".
 	 */
 	writerPid?: number | null;
+	/** Additive: monotonic count of real lease transitions on this host. */
+	writerGeneration?: number;
 }
 export interface OwnershipReply {
 	v: number;
@@ -118,7 +160,20 @@ export interface OwnershipReply {
 	id: number;
 	role: ClientRole;
 	writerAttached: boolean;
+	/** Additive: the generation AFTER this reply's transition, if any. */
+	writerGeneration?: number;
 }
+/**
+ * Marks the end of the journal replay that follows `welcome`. Everything before it is
+ * history the client may already hold; everything after is LIVE. Without this boundary a
+ * client cannot tell replay from output produced while its handshake was still finishing,
+ * so it must either duplicate history or risk dropping real bytes.
+ */
+export interface ReplayedEvent {
+	v: number;
+	type: "replayed";
+}
+
 /** Sent to every client just before the host tears itself down. */
 export interface StoppingEvent {
 	v: number;
@@ -130,7 +185,15 @@ export interface ExitEvent {
 	type: "exit";
 	code: number | null;
 }
-export type HostControl = WelcomeMessage | ErrorMessage | StatusReply | OwnershipReply | StoppingEvent | ExitEvent;
+export type HostControl =
+	| WelcomeMessage
+	| ErrorMessage
+	| StatusReply
+	| OwnershipReply
+	| ResizedReply
+	| ReplayedEvent
+	| StoppingEvent
+	| ExitEvent;
 
 export type ControlMessage = ClientControl | HostControl;
 
@@ -144,7 +207,12 @@ export function helloMessage(sessionId: string, id: number, clientPid?: number):
 		...(clientPid !== undefined ? { clientPid } : {}),
 	};
 }
-export function welcomeMessage(id: number, sessionId: string, role?: ClientRole): WelcomeMessage {
+export function welcomeMessage(
+	id: number,
+	sessionId: string,
+	role?: ClientRole,
+	extra?: { capabilities?: readonly HostCapability[]; writerGeneration?: number },
+): WelcomeMessage {
 	return {
 		v: NATIVE_SESSION_PROTOCOL_VERSION,
 		type: "welcome",
@@ -152,6 +220,8 @@ export function welcomeMessage(id: number, sessionId: string, role?: ClientRole)
 		sessionId,
 		protocolVersion: NATIVE_SESSION_PROTOCOL_VERSION,
 		...(role ? { role } : {}),
+		...(extra?.capabilities ? { capabilities: extra.capabilities } : {}),
+		...(extra?.writerGeneration !== undefined ? { writerGeneration: extra.writerGeneration } : {}),
 	};
 }
 export function errorMessage(code: ErrorCode, id?: number, message?: string): ErrorMessage {
@@ -160,8 +230,22 @@ export function errorMessage(code: ErrorCode, id?: number, message?: string): Er
 	if (message !== undefined) msg.message = message;
 	return msg;
 }
-export function resizeMessage(cols: number, rows: number): ResizeMessage {
-	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "resize", cols, rows };
+export function resizeMessage(
+	cols: number,
+	rows: number,
+	correlation?: { id?: number; expectedGeneration?: number },
+): ResizeMessage {
+	return {
+		v: NATIVE_SESSION_PROTOCOL_VERSION,
+		type: "resize",
+		cols,
+		rows,
+		...(correlation?.id !== undefined ? { id: correlation.id } : {}),
+		...(correlation?.expectedGeneration !== undefined ? { expectedGeneration: correlation.expectedGeneration } : {}),
+	};
+}
+export function resizedReply(id: number, cols: number, rows: number, writerGeneration: number): ResizedReply {
+	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "resized", id, cols, rows, writerGeneration };
 }
 export function statusRequest(id: number): StatusRequest {
 	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "status", id };
@@ -169,11 +253,26 @@ export function statusRequest(id: number): StatusRequest {
 export function ownershipRequest(id: number, action: WriterAction): OwnershipRequest {
 	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "ownership", id, action };
 }
-export function ownershipReply(id: number, role: ClientRole, writerAttached: boolean): OwnershipReply {
-	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "ownership", id, role, writerAttached };
+export function ownershipReply(
+	id: number,
+	role: ClientRole,
+	writerAttached: boolean,
+	writerGeneration?: number,
+): OwnershipReply {
+	return {
+		v: NATIVE_SESSION_PROTOCOL_VERSION,
+		type: "ownership",
+		id,
+		role,
+		writerAttached,
+		...(writerGeneration !== undefined ? { writerGeneration } : {}),
+	};
 }
 export function stopRequest(): StopRequest {
 	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "stop" };
+}
+export function replayedEvent(): ReplayedEvent {
+	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "replayed" };
 }
 export function stoppingEvent(): StoppingEvent {
 	return { v: NATIVE_SESSION_PROTOCOL_VERSION, type: "stopping" };
@@ -248,12 +347,20 @@ export function decodeControl(text: string): ControlMessage | null {
 		case "resize":
 			if (typeof obj.cols !== "number" || typeof obj.rows !== "number") return null;
 			return obj as unknown as ResizeMessage;
+		case "resized":
+			if (typeof obj.id !== "number" || typeof obj.cols !== "number") return null;
+			if (typeof obj.rows !== "number" || typeof obj.writerGeneration !== "number") return null;
+			return obj as unknown as ResizedReply;
 		case "status":
 			if (typeof obj.id !== "number") return null;
 			return obj as unknown as StatusRequest | StatusReply;
 		case "ownership":
 			if (typeof obj.id !== "number") return null;
-			if (obj.action === "claim" || obj.action === "release") return obj as unknown as OwnershipRequest;
+			// `takeover` is additive in v1: a host staged before it drops the frame as
+			// unparseable, which the client reads as a timeout, never as a success.
+			if (obj.action === "claim" || obj.action === "release" || obj.action === "takeover") {
+				return obj as unknown as OwnershipRequest;
+			}
 			if ((obj.role === "writer" || obj.role === "observer") && typeof obj.writerAttached === "boolean") {
 				return obj as unknown as OwnershipReply;
 			}
@@ -261,11 +368,13 @@ export function decodeControl(text: string): ControlMessage | null {
 		case "welcome":
 			if (typeof obj.id !== "number") return null;
 			if (obj.role !== undefined && obj.role !== "writer" && obj.role !== "observer") return null;
+			if (obj.capabilities !== undefined && !Array.isArray(obj.capabilities)) return null;
 			return obj as unknown as WelcomeMessage;
 		case "error":
 			return decodeError(text);
 		case "stop":
 		case "stopping":
+		case "replayed":
 			return obj as unknown as ControlMessage;
 		case "exit":
 			if (obj.code !== null && (typeof obj.code !== "number" || !Number.isInteger(obj.code))) return null;

--- a/src/bun/native-terminal-registry/writer-ownership.ts
+++ b/src/bun/native-terminal-registry/writer-ownership.ts
@@ -1,25 +1,49 @@
 /** Host-local writer lease for one native terminal session. */
 export type ClientRole = "writer" | "observer";
-export type WriterAction = "claim" | "release";
+/**
+ * `claim` takes a VACANT slot and never displaces anyone — that is what keeps
+ * ordinary attachment non-stealing. `takeover` is the explicit user gesture and
+ * is the only action that moves a live lease.
+ */
+export type WriterAction = "claim" | "release" | "takeover";
 export type WriterConflict = "not-attached" | "not-writer" | "writer-active";
 export type WriterRequestResult =
-	| { ok: true; role: ClientRole; writerAttached: boolean }
-	| { ok: false; reason: WriterConflict; role: ClientRole | null; writerAttached: boolean };
+	| { ok: true; role: ClientRole; writerAttached: boolean; generation: number }
+	| { ok: false; reason: WriterConflict; role: ClientRole | null; writerAttached: boolean; generation: number };
 
 /**
  * Tracks authenticated clients by connection identity. The first live client is
  * the writer; later clients observe until the writer explicitly releases or
  * disconnects and one observer claims the vacant slot.
+ *
+ * Every ACTUAL move of the writer pointer (`null→A`, `A→null`, `A→B`) bumps a
+ * monotonic {@link generation}. Idempotent requests — the current writer claiming or
+ * taking over again — deliberately do NOT bump it, so a client can tell "the lease
+ * I know about" from "a lease that has moved since" and refuse to act on stale
+ * belief. It is host-local and ephemeral: a fresh host starts at 0.
  */
 export class WriterOwnership<Client> {
 	private readonly clients = new Set<Client>();
 	private writer: Client | null = null;
+	private generation = 0;
+
+	/** Monotonic count of real pointer transitions on this host. */
+	writerGeneration(): number {
+		return this.generation;
+	}
+
+	/** Move the pointer and count it. The ONLY place `writer` is assigned. */
+	private transition(next: Client | null): void {
+		if (this.writer === next) return; // idempotent: not a transition, must not count
+		this.writer = next;
+		this.generation++;
+	}
 
 	attach(client: Client): ClientRole {
 		if (this.clients.has(client)) return this.roleOf(client) ?? "observer";
 		const isFirstClient = this.clients.size === 0;
 		this.clients.add(client);
-		if (isFirstClient) this.writer = client;
+		if (isFirstClient) this.transition(client);
 		return this.roleOf(client) ?? "observer";
 	}
 
@@ -34,7 +58,7 @@ export class WriterOwnership<Client> {
 		const wasWriter = this.writer === client;
 		this.clients.delete(client);
 		if (!wasWriter) return [];
-		this.writer = null;
+		this.transition(null);
 		return [...this.clients];
 	}
 
@@ -49,20 +73,30 @@ export class WriterOwnership<Client> {
 
 	request(client: Client, action: WriterAction): WriterRequestResult {
 		const role = this.roleOf(client);
-		if (!role) return { ok: false, reason: "not-attached", role: null, writerAttached: this.hasWriter() };
+		if (!role) {
+			return { ok: false, reason: "not-attached", role: null, writerAttached: this.hasWriter(), generation: this.generation };
+		}
 		if (action === "release") {
 			if (this.writer !== client) {
-				return { ok: false, reason: "not-writer", role, writerAttached: this.hasWriter() };
+				return { ok: false, reason: "not-writer", role, writerAttached: this.hasWriter(), generation: this.generation };
 			}
-			this.writer = null;
-			return { ok: true, role: "observer", writerAttached: false };
+			this.transition(null);
+			return { ok: true, role: "observer", writerAttached: false, generation: this.generation };
 		}
-		if (this.writer === client) return { ok: true, role: "writer", writerAttached: true };
-		if (this.writer !== null) {
-			return { ok: false, reason: "writer-active", role, writerAttached: true };
+		// Idempotent: the current writer asking again succeeds without moving anything,
+		// which is what lets an explicit gesture always be SENT without fear — a client
+		// whose cached role is stale cannot tell whether it still owns the lease.
+		if (this.writer === client) {
+			return { ok: true, role: "writer", writerAttached: true, generation: this.generation };
 		}
-		this.writer = client;
-		return { ok: true, role: "writer", writerAttached: true };
+		if (this.writer !== null && action === "claim") {
+			return { ok: false, reason: "writer-active", role, writerAttached: true, generation: this.generation };
+		}
+		// One synchronous swap on the host's single event loop: there is never a turn with
+		// two writers. Who was displaced is NOT reported — the host tells every non-winner
+		// in one broadcast, and a second per-client channel would duplicate the transition.
+		this.transition(client);
+		return { ok: true, role: "writer", writerAttached: true, generation: this.generation };
 	}
 
 	hasWriter(): boolean {

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -128,8 +128,16 @@ interface PtySession {
 	proc: ReturnType<typeof Bun.spawn> | null;
 	/** The app's single writer binding to a native host, when `backend` is native. */
 	native: NativeTaskTerminal | null;
+	/**
+	 * The key this session is registered under. Auxiliary panes use `taskId~paneId`, so
+	 * anything that unregisters a session MUST use this rather than the bare taskId —
+	 * deleting `taskId` for pane 2 would drop pane 1 instead.
+	 */
+	registryKey: string;
 	/** Guards against two concurrent reattach attempts for one native session. */
 	nativeAttaching: boolean;
+	/** The host binding is being replaced; no viewer may be told it is the writer. */
+	nativeRecovering: boolean;
 	/** Bounded mirror of broadcast output, so a late/reconnecting viewer sees the screen. */
 	nativeStream: NativeBridgeJournal | null;
 	/** Which viewer may type into the shell. Native only — tmux arbitrates its own clients. */
@@ -217,7 +225,9 @@ export function createSession(
 		backend: "tmux",
 		proc: null,
 		native: null,
+		registryKey: taskId,
 		nativeAttaching: false,
+		nativeRecovering: false,
 		nativeStream: null,
 		nativeLease: null,
 		clients: new Set(),
@@ -310,7 +320,9 @@ export async function createNativeTaskSession(
 		backend: "native",
 		proc: null,
 		native: null,
+		registryKey: taskId,
 		nativeAttaching: false,
+		nativeRecovering: false,
 		nativeStream: new NativeBridgeJournal(),
 		nativeLease: new NativeClientLease(),
 		clients: new Set(),
@@ -350,6 +362,7 @@ export async function createNativeTaskSession(
 				onOutput: (bytes) => ingestPtyOutput(session, bytes),
 				onClosed: () => markNativeClosed(session),
 				onRoleChange: () => broadcastNativeRoles(session),
+				onGeometry: (size) => applyNativeGeometry(session, size),
 			},
 			firstPane.paneId,
 		);
@@ -384,7 +397,9 @@ export async function reattachNativeTaskSession(taskId: string, projectId: strin
 		backend: "native",
 		proc: null,
 		native: null,
+		registryKey: taskId,
 		nativeAttaching: false,
+		nativeRecovering: false,
 		nativeStream: new NativeBridgeJournal(),
 		nativeLease: new NativeClientLease(),
 		clients: new Set(),
@@ -419,6 +434,7 @@ export async function reattachNativeTaskSession(taskId: string, projectId: strin
 				onOutput: (bytes) => ingestPtyOutput(session, bytes),
 				onClosed: () => markNativeClosed(session),
 				onRoleChange: () => broadcastNativeRoles(session),
+				onGeometry: (size) => applyNativeGeometry(session, size),
 			},
 			firstPane.paneId,
 		);
@@ -471,7 +487,9 @@ export async function ensureNativePanePtySession(
 		backend: "native",
 		proc: null,
 		native: null,
+		registryKey: key,
 		nativeAttaching: false,
+		nativeRecovering: false,
 		nativeStream: new NativeBridgeJournal(),
 		nativeLease: new NativeClientLease(),
 		clients: new Set(),
@@ -494,6 +512,7 @@ export async function ensureNativePanePtySession(
 			{
 				onOutput: (bytes) => ingestPtyOutput(session, bytes),
 				onRoleChange: () => broadcastNativeRoles(session),
+				onGeometry: (size) => applyNativeGeometry(session, size),
 				onClosed: () => {
 					session.native = null;
 					session.appliedCols = undefined;
@@ -1076,8 +1095,17 @@ function effectiveNativeRole(session: PtySession, ws: any): NativeStreamRole {
 	const lease = session.nativeLease;
 	if (!lease) return "observer";
 	if (lease.roleOf(ws) !== "writer") return "observer";
+	// Recovery is never optimistic: the binding is being replaced, so no viewer may be
+	// told it can type until authoritative state is back.
+	if (session.nativeRecovering) return "observer";
 	const hostRole = nativeHostRole(session);
-	return hostRole === null || hostRole === "writer" ? "writer" : "observer";
+	if (hostRole === "writer") return "writer";
+	// `null` means two opposite things and must not be collapsed. While a bind is in
+	// FLIGHT it means "not known yet", and optimism avoids flashing the strip on every
+	// launch (decision 191). Once no bind is pending it means "no binding at all" — a
+	// detached or dead host — and claiming `writer` there promises a shell that is gone.
+	if (hostRole === null) return session.nativeAttaching ? "writer" : "observer";
+	return "observer";
 }
 
 /**
@@ -1086,12 +1114,32 @@ function effectiveNativeRole(session: PtySession, ws: any): NativeStreamRole {
  * mangles every line that reaches the right edge.
  */
 function nativePtyGeometry(session: PtySession): { cols?: number; rows?: number; writerAttached?: boolean } {
-	const { appliedCols, appliedRows } = session;
 	const attached = session.native?.hostWriterAttached?.();
+	// Whose number is the truth depends on who owns the lease. We own it → our applied
+	// size IS the PTY's, and the host's cache may lag our newest resize because the host
+	// skips the sender when it broadcasts. We do NOT own it → the resize happened in
+	// another process, so only the host's number is real; `appliedCols` here is just
+	// whatever our own local viewer asked for and would reflow the stream at our width.
+	const host = session.native?.hostPtyGeometry?.();
+	const ownsLease = nativeHostRole(session) === "writer";
+	const cols = (ownsLease ? session.appliedCols ?? host?.cols : host?.cols ?? session.appliedCols);
+	const rows = (ownsLease ? session.appliedRows ?? host?.rows : host?.rows ?? session.appliedRows);
 	return {
-		...(appliedCols && appliedRows ? { cols: appliedCols, rows: appliedRows } : {}),
+		...(cols && rows ? { cols, rows } : {}),
 		...(typeof attached === "boolean" ? { writerAttached: attached } : {}),
 	};
+}
+
+/**
+ * The writer — in this process or another one — published a new canonical grid.
+ * Every local viewer has to be told: an observer renders AT that grid, and a stale
+ * one wraps every line the writer's bytes push past its own right edge.
+ */
+function applyNativeGeometry(session: PtySession, size: { cols: number; rows: number }): void {
+	if (session.appliedCols === size.cols && session.appliedRows === size.rows) return;
+	session.appliedCols = size.cols;
+	session.appliedRows = size.rows;
+	broadcastNativeRoles(session);
 }
 
 /** Re-issue every viewer's role after the host's verdict becomes known. */
@@ -1142,24 +1190,83 @@ function attachNativeClient(session: PtySession, ws: any, since: number | null):
 }
 
 /** Move the writer lease between viewers and tell both sides, in one step. */
-function handleNativeOwnership(session: PtySession, ws: any, action: "claim" | "release"): void {
+function handleNativeOwnership(session: PtySession, ws: any, action: "claim" | "release", hostSettled = false): void {
 	const lease = session.nativeLease;
 	if (!lease) return;
 	// Taking control inside this app is worthless while the host's lease belongs to
-	// another dev3 process, so ask for that one first. A refusal is reported as a
-	// refused keystroke rather than a lease move — the process currently typing
-	// keeps it, and this viewer learns why it is still read-only.
-	if (action === "claim" && session.native?.claimHostWriter && nativeHostRole(session) === "observer") {
-		void session.native.claimHostWriter().then((role) => {
-			if (role !== "writer") {
-				sendToClient(ws, roleMessage("observer", true));
-				log.info("Take control refused; another app process holds the host lease", {
+	// another dev3 process, so move that one first. `Take control` is an explicit
+	// user gesture, so it TAKES OVER rather than claiming a vacant slot: the host
+	// swaps the lease atomically and tells the displaced process it is now an
+	// observer. Ordinary attachment still only claims, and so never steals.
+	// EVERY explicit gesture asks the host — even when our own cache says we are already
+	// the writer. That cache can be stale (another process may have taken the lease and
+	// our demotion frame may still be in flight), and skipping the request would make an
+	// explicit click silently do nothing. The host's takeover is idempotent for the true
+	// current writer, so asking always is free.
+	if (action === "claim" && !hostSettled && session.native?.takeoverHostWriter) {
+		const paneKey = nativePaneKey(session);
+		if (nativeTakeoverInFlight.has(paneKey)) {
+			log.debug("A host takeover is already in flight for this pane; not starting another", {
+				taskId: shortId(session.taskId),
+			});
+			return;
+		}
+		nativeTakeoverInFlight.add(paneKey);
+		// The key is released only AFTER the continuation finishes. Releasing it first (a
+		// `.finally` chained BEFORE `.then`) would let the continuation re-enter and the
+		// bound would be no bound at all.
+		void session.native.takeoverHostWriter().then(async (result) => {
+			// Branch on the DISCRIMINANT, never on a role: a cached role can say `writer`
+			// while the host has already moved the lease, which read as success and skipped
+			// compensation altogether.
+			if (!result.ok) {
+				log.warn("Take control did not transfer the host lease", {
 					taskId: shortId(session.taskId),
+					reason: result.refusal,
 				});
+				// A TIMEOUT is ambiguous in a way a refusal is not: the host may still commit
+				// the takeover after we gave up. Compensation is AWAITED, so the pane's
+				// in-flight guard is still held while it releases, detaches and rebinds —
+				// otherwise a second gesture could overlap the recovery. The refusal is
+				// published by compensation's final verdict, not before it.
+				if (result.timedOut) {
+					await compensateHostOwnership(session, "request-timed-out", ws, result.refusal);
+					return;
+				}
+				if (session.clients.has(ws)) {
+					sendToClient(ws, roleMessage("observer", true, { refusedReason: result.refusal }));
+				}
 				return;
 			}
-			handleNativeOwnership(session, ws, "claim");
-		});
+			// The host round trip is async, so the viewer that asked may have closed its
+			// tab meanwhile. We now hold the host lease on its behalf: giving it to a
+			// detached socket would leave every surviving viewer a local observer with the
+			// lease stranded in this process, and nobody able to type anywhere.
+			// `hostSettled` — the host lease is already ours, so this pass only moves the
+			// LOCAL lease. Without it the continuation re-enters this same branch and asks
+			// the host again forever, never reaching the local move.
+			if (session.clients.has(ws)) {
+				handleNativeOwnership(session, ws, "claim", true);
+				// A vacant-slot takeover changes `writerAttached` for everyone without changing
+				// anyone's role, so a role-change-driven publish reaches nobody and other local
+				// viewers keep showing the slot as free. Publish the full snapshot to ALL of them
+				// after every settlement, not only to the requester.
+				broadcastNativeRoles(session);
+				return;
+			}
+			const survivor = session.clients.values().next().value;
+			if (survivor) {
+				log.info("Take control requester left; handing the lease to a surviving viewer", {
+					taskId: shortId(session.taskId),
+				});
+				promoteLocalWriter(session, survivor);
+				return;
+			}
+			// Nobody left to receive it: hand it back rather than hold a lease this process
+			// cannot use, which locks every other dev3 window out. Awaited, so the pane's
+			// in-flight guard covers release, detach and rebind and no second gesture overlaps.
+			await compensateHostOwnership(session, "requester-gone", null);
+		}).finally(() => nativeTakeoverInFlight.delete(paneKey));
 		return;
 	}
 	const change = action === "claim" ? lease.claim(ws) : lease.release(ws);
@@ -1178,6 +1285,151 @@ function handleNativeOwnership(session: PtySession, ws: any, action: "claim" | "
 	log.info("Native writer lease moved", { taskId: shortId(session.taskId), action, viewers: lease.size });
 }
 
+/**
+ * Give the local lease to `client` and publish the result. Always publishes the
+ * EFFECTIVE role: announcing a raw `writer` while this process is only a host observer
+ * would tell a viewer it can type when the host will drop everything it sends.
+ */
+function promoteLocalWriter(session: PtySession, client: any): void {
+	session.nativeLease?.claim(client);
+	// One FULL snapshot to every viewer: a per-viewer reply would omit `writerAttached` and
+	// geometry from the others, leaving them stale about a slot that is no longer free.
+	broadcastNativeRoles(session);
+	applyClientSizes(session);
+}
+
+/**
+ * Compensate for an ownership request we can no longer complete honestly.
+ *
+ * Two entries, one exit: the requester vanished mid-round-trip, or its request timed out
+ * while the host may still commit it. Either way this process may hold — or be about to
+ * hold — a lease with no viewer able to use it. Holding it locks every other dev3 window
+ * out of the pane; guessing is worse, because a late commit would arrive unobserved.
+ *
+ * The ambiguous connection is closed and immediately REBOUND, so authoritative state is
+ * obtained by construction rather than inferred. `retainedContext` is the local viewer
+ * that initiated the gesture: if the rebind lands as writer, that success is published to
+ * THAT viewer, never silently handed to whoever happens to be first in the lease.
+ */
+async function compensateHostOwnership(
+	session: PtySession,
+	reason: "requester-gone" | "request-timed-out",
+	retainedContext: any | null,
+	/** Told to the retained viewer once recovery settles — never before its verdict. */
+	pendingRefusal?: "host-too-old" | "transfer-failed",
+): Promise<void> {
+	const paneSessionId = session.native?.sessionId ?? null;
+	const paneId = session.native?.paneId ?? "pane-1";
+	log.info("Compensating an ambiguous host ownership request", {
+		taskId: shortId(session.taskId),
+		reason,
+		hasRetainedContext: retainedContext !== null,
+	});
+
+	// DEMOTE FIRST. From here the binding is about to be replaced, so nobody may hold a
+	// writer role: input accepted against a doomed connection would vanish silently. A
+	// viewer arriving mid-recovery gets the same honest observer snapshot, because
+	// `nativeRecovering` blocks the optimistic-writer path in effectiveNativeRole.
+	session.nativeRecovering = true;
+	session.nativeLease?.release(retainedContext ?? session.clients.values().next().value);
+	broadcastNativeRoles(session);
+
+	// A timed-out request is ambiguous whatever our cached role says, so the release is
+	// ALWAYS attempted and its outcome decides whether the socket must go.
+	const released = await session.native?.releaseHostWriter?.();
+	if (released !== false) {
+		session.nativeRecovering = false;
+		publishCompensationVerdict(session, retainedContext, pendingRefusal);
+		return;
+	}
+
+	log.warn("Host never confirmed the release; dropping the connection so the lease cannot stay stranded", {
+		taskId: shortId(session.taskId),
+	});
+	try {
+		session.native?.detach();
+	} catch { /* already gone */ }
+	session.native = null;
+
+	// NO viewers left: stop here. Rebinding would re-acquire a lease nobody is watching,
+	// which is the hidden ownership acquisition this must not perform.
+	if (!paneSessionId || session.clients.size === 0) {
+		session.nativeRecovering = false;
+		log.info("Compensation finished with no viewers; no rebind and no claim performed", {
+			taskId: shortId(session.taskId),
+		});
+		// A registered session with no binding can never be rebound by a later WS open, so
+		// drop it: the next open then rebuilds the session through the normal path.
+		if (session.clients.size === 0) {
+			// The EXACT registered key: an auxiliary pane lives under `taskId~paneId`, and
+			// deleting the bare taskId here would unregister pane 1 while leaving pane 2's
+			// dead entry in place.
+			sessions.delete(session.registryKey);
+			log.info("Dropped the bindingless session so a later viewer rebuilds it", {
+				taskId: shortId(session.taskId),
+				registryKey: session.registryKey,
+			});
+		}
+		return;
+	}
+
+	// Viewers remain, so rebind BEFORE publishing any role — otherwise a viewer would be
+	// told `writer` off a null binding, promising a shell that is not there.
+	session.nativeAttaching = true;
+	try {
+		session.native = await bindNativeTaskPane(
+			paneSessionId,
+			{
+				onOutput: (bytes) => ingestPtyOutput(session, bytes),
+				onClosed: () => markNativeClosed(session),
+				onRoleChange: () => broadcastNativeRoles(session),
+				onGeometry: (size) => applyNativeGeometry(session, size),
+			},
+			paneId,
+			// The bridge journal survived the detach, so the host's replay is a duplicate.
+			{ discardReplay: true },
+		);
+	} catch (err) {
+		log.error("Rebind after compensation failed; the pane has no binding", {
+			taskId: shortId(session.taskId),
+			error: String(err),
+		});
+	} finally {
+		session.nativeAttaching = false;
+	}
+
+	// Authoritative status, then ONE full snapshot to every viewer. A rebind may have
+	// legitimately taken a vacant slot; that success belongs to the viewer that asked for
+	// control, never to whoever the local lease happens to point at.
+	session.nativeRecovering = false;
+	const ownsAfterRebind = session.native?.hostRole?.() === "writer";
+	if (ownsAfterRebind && retainedContext && session.clients.has(retainedContext)) {
+		promoteLocalWriter(session, retainedContext);
+		return;
+	}
+	publishCompensationVerdict(session, retainedContext, pendingRefusal);
+}
+
+/**
+ * One snapshot to everyone, and the refusal only now. Publishing it before recovery ran
+ * told the viewer why it failed and then immediately cleared that with the next snapshot.
+ */
+function publishCompensationVerdict(
+	session: PtySession,
+	retainedContext: any | null,
+	pendingRefusal?: "host-too-old" | "transfer-failed",
+): void {
+	broadcastNativeRoles(session);
+	if (!pendingRefusal || !retainedContext || !session.clients.has(retainedContext)) return;
+	sendToClient(
+		retainedContext,
+		roleMessage(effectiveNativeRole(session, retainedContext), true, {
+			...nativePtyGeometry(session),
+			refusedReason: pendingRefusal,
+		}),
+	);
+}
+
 /** The native writer's last reported viewport, or null while it has not sent one. */
 function writerClientSize(session: PtySession): { cols: number; rows: number } | null {
 	const writer = session.nativeLease?.writer as { ptyCols?: number; ptyRows?: number } | null | undefined;
@@ -1185,9 +1437,37 @@ function writerClientSize(session: PtySession): { cols: number; rows: number } |
 	return { cols: writer.ptyCols, rows: writer.ptyRows };
 }
 
+/** The geometry each native pane has asked the host for and not yet heard back on. */
+const nativeResizeInFlight = new Map<string, string>();
+
+/**
+ * Panes with a host takeover already in flight.
+ *
+ * The `hostSettled` parameter stops the success continuation re-entering the request, but
+ * it is one boolean an edit can drop — and when it was dropped the loop ran at ~12k
+ * takeovers/second and buried the log under 540k lines in three minutes. This makes the
+ * bound structural: a second gesture for the same pane cannot start another round trip
+ * while one is outstanding, which also absorbs a user clicking the button repeatedly.
+ */
+const nativeTakeoverInFlight = new Set<string>();
+
+/** Identifies a pane INCARNATION, so two panes of one task never share a key. */
+function nativePaneKey(session: PtySession): string {
+	return `${session.taskId}::${session.native?.sessionId ?? "unbound"}::${session.native?.paneId ?? "pane-1"}`;
+}
+
+/** How many takeovers are outstanding — the invariant tests assert on this. */
+export function _nativeTakeoversInFlightForTests(): number {
+	return nativeTakeoverInFlight.size;
+}
+
 function applyClientSizes(session: PtySession): void {
 	const term = sessionShell(session);
 	if (!term) return;
+	// Only the process holding the HOST lease may size the shared PTY. Without this a
+	// non-owning process both fired a resize the host refuses AND recorded its own
+	// viewer's width in `appliedCols`, which every local viewer then rendered at.
+	if (session.backend === "native" && nativeHostRole(session) !== "writer") return;
 	// Native: the WRITER alone sizes the PTY. A native host has no client-size
 	// negotiation of its own, so clamping to the smallest viewer would let any
 	// remote tab (a phone in portrait, say) shrink the writer's shell out from
@@ -1221,10 +1501,44 @@ function applyClientSizes(session: PtySession): void {
 		return;
 	}
 
+	// Native: the host is the authority, and its verdict is asynchronous. Publishing the
+	// size we merely ASKED for would broadcast a refused or stale-generation resize as
+	// canonical — the exact poisoning the ack exists to prevent. tmux keeps the direct
+	// path: it has no ack and resizes synchronously.
+	if (session.backend === "native") {
+		const native = session.native;
+		if (!native?.resizeAwaited) return;
+		// The applied size is now written by the ACK callback, so the dedup guard above no
+		// longer sees an in-flight request and every repeat would fire another host round
+		// trip for a size already on its way. Track the target we are asking for.
+		const target = `${minCols}x${minRows}`;
+		// Keyed by pane INCARNATION: keying by taskId let two panes of one task collide, so
+		// an equal-size resize on the second pane was silently dropped.
+		const resizeKey = nativePaneKey(session);
+		if (nativeResizeInFlight.get(resizeKey) === target) return;
+		nativeResizeInFlight.set(resizeKey, target);
+		void native.resizeAwaited(minCols, minRows).then(
+			(applied) => {
+				if (nativeResizeInFlight.get(resizeKey) === target) nativeResizeInFlight.delete(resizeKey);
+				session.appliedCols = applied.cols;
+				session.appliedRows = applied.rows;
+				broadcastNativeRoles(session);
+			},
+			(err) => {
+				if (nativeResizeInFlight.get(resizeKey) === target) nativeResizeInFlight.delete(resizeKey);
+				// Refused or unanswered: the old canonical size stands, and viewers keep
+				// rendering at a grid the PTY actually has.
+				log.debug("Native resize was not applied; canonical geometry unchanged", {
+					taskId: shortId(session.taskId),
+					error: String(err),
+				});
+			},
+		);
+		return;
+	}
+
 	session.appliedCols = minCols;
 	session.appliedRows = minRows;
-	// The writer just changed the shape every observer has to render at.
-	if (session.backend === "native") broadcastNativeRoles(session);
 	try {
 		term.resize(minCols, minRows);
 	} catch (err) {
@@ -1786,7 +2100,15 @@ const ptyServer = Bun.serve({
 					// closing only releases its own lease.
 					const promoted = session.nativeLease?.detach(ws as any) ?? null;
 					session.clients.delete(ws as any);
-					if (promoted?.writer) sendToClient(promoted.writer, roleMessage("writer"));
+					// EFFECTIVE role, never a raw `writer`: another app process may hold the host
+					// lease, and telling this viewer it can type means it discovers otherwise
+					// only when its first keystroke is refused.
+					if (promoted?.writer) {
+						sendToClient(
+							promoted.writer,
+							roleMessage(effectiveNativeRole(session, promoted.writer), false, nativePtyGeometry(session)),
+						);
+					}
 					// A viewer left: the smallest-size constraint may have relaxed,
 					// so grow the PTY back to the smallest of the remaining clients.
 					applyClientSizes(session);

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -11,6 +11,7 @@ import {
 	ptyUrlWithSince,
 	type NativeStreamHeader,
 	type NativeStreamRole,
+	type NativeViewerStatus,
 } from "../shared/native-terminal-stream";
 // TEMP DIAGNOSTIC: remove these imports after the terminal copy bug is fixed.
 import type { TerminalCopyDiagnostics } from "./terminal-copy-diagnostics";
@@ -233,7 +234,7 @@ interface TerminalViewProps {
 	 * Native backend only: this viewer's write role, and whether the server just
 	 * refused something it typed. Never fires for a tmux session.
 	 */
-	onNativeStatus?: (status: { role: NativeStreamRole; refused: boolean; writerAttached?: boolean }) => void;
+	onNativeStatus?: (status: NativeViewerStatus) => void;
 	/**
 	 * The app refused this socket outright (missing/unknown session). Supplying it
 	 * hands recovery to the owner, which renders one shared exited state; without
@@ -280,6 +281,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	const ptyGeometryRef = useRef<{ cols: number; rows: number } | null>(null);
 	/** Set by the terminal-setup effect; re-runs the fit after geometry or role changes. */
 	const refitRef = useRef<(() => void) | null>(null);
+	/** Re-fit on a settled layout — see the assignment for why two frames are needed. */
+	const refitAfterLayoutRef = useRef<(() => void) | null>(null);
 	const onNativeStatusRef = useRef(onNativeStatus);
 	onNativeStatusRef.current = onNativeStatus;
 	const onSessionLostRef = useRef(onSessionLost);
@@ -761,6 +764,23 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 
 			refitRef.current = refitToContainer;
+			/**
+			 * Re-fit only AFTER the browser has laid the container out again.
+			 *
+			 * Winning the writer lease removes the read-only strip above the canvas, so
+			 * the container grows by exactly that strip's height. Measuring in the same
+			 * turn as the role frame reads the PRE-removal box and publishes a PTY one
+			 * row too short — then the ResizeObserver corrects it, so the shell sees two
+			 * resizes and repaints twice. Two frames is what it takes for React to
+			 * commit the removal and the browser to finish layout.
+			 */
+			refitAfterLayoutRef.current = () => {
+				if (disposed) return;
+				requestAnimationFrame(() => {
+					if (disposed) return;
+					requestAnimationFrame(() => refitToContainer());
+				});
+			};
 			let refitScheduled = false;
 			function scheduleRefit() {
 				if (refitScheduled) return;
@@ -1213,13 +1233,18 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		}
 
 		/** Publish the writer/observer role, and whether the server just refused input. */
-		function reportNativeRole(role: NativeStreamRole, refused: boolean, writerAttached?: boolean): void {
-			const changed = nativeRoleRef.current !== role;
-			nativeRoleRef.current = role;
-			onNativeStatusRef.current?.({ role, refused, writerAttached });
-			// Becoming an observer means following the PTY's shape; becoming the writer
-			// means going back to fitting our own container.
-			if (changed) refitRef.current?.();
+		function reportNativeRole(status: NativeViewerStatus): void {
+			const previousRole = nativeRoleRef.current;
+			const changed = previousRole !== status.role;
+			nativeRoleRef.current = status.role;
+			onNativeStatusRef.current?.(status);
+			if (!changed) return;
+			// Becoming the writer: this viewer now OWNS the canonical geometry, so it
+			// publishes its own container's size once — but only after the strip above the
+			// canvas is gone and layout has settled. Becoming an observer needs no layout
+			// pass at all: it adopts the PTY's shape and ignores its own container.
+			if (status.role === "writer") refitAfterLayoutRef.current?.();
+			else refitRef.current?.();
 		}
 
 		/** Follow the writer's PTY shape; a writer keeps fitting its own container. */
@@ -1239,14 +1264,19 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		 */
 		function handleNativeFrame(header: NativeStreamHeader, payload: string): void {
 			if (header.t === "role") {
-				reportNativeRole(header.role, header.refused === true, header.writerAttached);
+				reportNativeRole({
+					role: header.role,
+					refused: header.refused === true,
+					writerAttached: header.writerAttached,
+					refusedReason: header.refusedReason,
+				});
 				adoptPtyGeometry(header.cols, header.rows);
 				return;
 			}
 			let reset = "";
 			if (header.t === "attach") {
 				nativeSeqRef.current = header.seq;
-				reportNativeRole(header.role, false, header.writerAttached);
+				reportNativeRole({ role: header.role, refused: false, writerAttached: header.writerAttached });
 				adoptPtyGeometry(header.cols, header.rows);
 				// RIS in the SAME batch as the replay, so the screen is replaced in one
 				// write instead of briefly showing an empty terminal.

--- a/src/mainview/components/NativeViewerBar.tsx
+++ b/src/mainview/components/NativeViewerBar.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useT } from "../i18n";
 import Tooltip from "./Tooltip";
-import type { NativeStreamRole } from "../../shared/native-terminal-stream";
+import type { NativeStreamRole, NativeViewerStatus } from "../../shared/native-terminal-stream";
 
 /**
  * Earned read-only strip for a NATIVE task terminal (seq 1300).
@@ -18,10 +18,25 @@ import type { NativeStreamRole } from "../../shared/native-terminal-stream";
  */
 const REFUSED_FLASH_MS = 1600;
 
+/**
+ * What each honest refusal says. There is no "lost a race" entry: the host serializes
+ * takeovers and the last explicit one wins, so the gesture cannot lose to a rival.
+ */
+const REFUSAL_COPY = {
+	"host-too-old": { label: "nativeViewer.hostTooOld", hint: "nativeViewer.hostTooOldHint" },
+	"transfer-failed": { label: "nativeViewer.transferFailed", hint: "nativeViewer.transferFailedHint" },
+} as const;
+
 interface NativeViewerBarProps {
 	role: NativeStreamRole;
 	/** Bumped each time the server refused this viewer's input, to flash the strip. */
 	refusedAt: number;
+	/**
+	 * Why the last `Take control` did not transfer the lease. `host-too-old` cannot
+	 * be fixed by clicking again, so it gets its own sentence instead of the
+	 * retryable one — a strip that says the same thing either way is a dead end.
+	 */
+	refusedReason?: NativeViewerStatus["refusedReason"];
 	/**
 	 * Whether anyone holds the write lease. False means the slot is free — saying
 	 * "another viewer is typing" then is simply untrue, and the fix is one click.
@@ -30,16 +45,36 @@ interface NativeViewerBarProps {
 	onTakeControl: () => void;
 }
 
-function NativeViewerBar({ role, refusedAt, writerAttached, onTakeControl }: NativeViewerBarProps) {
+function NativeViewerBar({ role, refusedAt, refusedReason, writerAttached, onTakeControl }: NativeViewerBarProps) {
 	const t = useT();
 	const [flashing, setFlashing] = useState(false);
+	/** Whether the persistent old-host guidance is the thing currently on screen. */
+	const showingGuidance = useRef(false);
+	// One place decides what a refusal SAYS, so the label and its hint can never drift.
+	const refusal = (flashing || refusedReason === "host-too-old") && refusedReason ? REFUSAL_COPY[refusedReason] : null;
 
 	useEffect(() => {
 		if (!refusedAt) return;
 		setFlashing(true);
+		// `host-too-old` is GUIDANCE, not an event: clicking again cannot fix it, so the
+		// sentence has to stay put until the host or connection state actually changes
+		// (a new role frame clears `refusedReason`). Everything else is a brief flash.
+		if (refusedReason === "host-too-old") return;
 		const timer = setTimeout(() => setFlashing(false), REFUSED_FLASH_MS);
 		return () => clearTimeout(timer);
-	}, [refusedAt]);
+	}, [refusedAt, refusedReason]);
+
+	// Retire the guidance only when LEAVING it. A plain `!== host-too-old` check would
+	// also fire on the first render of every other refusal and cancel its flash.
+	useEffect(() => {
+		if (refusedReason === "host-too-old") {
+			showingGuidance.current = true;
+			return;
+		}
+		if (!showingGuidance.current) return;
+		showingGuidance.current = false;
+		setFlashing(false);
+	}, [refusedReason, writerAttached]);
 
 	// The normal case is a writer, and the normal case gets zero chrome.
 	if (role !== "observer") return null;
@@ -52,9 +87,11 @@ function NativeViewerBar({ role, refusedAt, writerAttached, onTakeControl }: Nat
 			}`}
 		>
 			<span className="truncate">
-				{t(flashing || writerAttached === false ? "nativeViewer.refused" : "nativeViewer.readOnly")}
+				{t(refusal ? refusal.label : flashing || writerAttached === false ? "nativeViewer.refused" : "nativeViewer.readOnly")}
 			</span>
-			<Tooltip content={t("nativeViewer.takeControlHint")} placement="bottom">
+			{/* The strip TRUNCATES, so the why-and-what-to-do sentence lives on the button's
+			    tooltip: it is the control you would reach for, and it is focusable. */}
+			<Tooltip content={t(refusal ? refusal.hint : "nativeViewer.takeControlHint")} placement="bottom">
 				<button
 					type="button"
 					onClick={onTakeControl}

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -16,7 +16,12 @@ import MobileWindowCarousel from "./MobileWindowCarousel";
 import PaneZoomBadge from "./PaneZoomBadge";
 import ClosePanePicker from "./ClosePanePicker";
 import NativeViewerBar from "./NativeViewerBar";
-import type { NativeStreamRole } from "../../shared/native-terminal-stream";
+import {
+	mergeViewerStatus,
+	type NativeStreamRole,
+	type NativeViewerStatus,
+	type ViewerSnapshot,
+} from "../../shared/native-terminal-stream";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { isElectrobun } from "../rpc";
@@ -61,9 +66,14 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	const [ptyUrl, setPtyUrl] = useState<string | null>(null);
 	const [nativeRole, setNativeRole] = useState<NativeStreamRole>("writer");
 	const [refusedAt, setRefusedAt] = useState(0);
-	const handleNativeStatus = useCallback(({ role, refused }: { role: NativeStreamRole; refused: boolean }) => {
-		setNativeRole(role);
-		if (refused) setRefusedAt(Date.now());
+	const [refusedReason, setRefusedReason] = useState<NativeViewerStatus["refusedReason"]>(undefined);
+	const [writerAttached, setWriterAttached] = useState<boolean | undefined>(undefined);
+	const handleNativeStatus = useCallback((status: NativeViewerStatus) => {
+		const snapshot = mergeViewerStatus(null, status);
+		setNativeRole(snapshot.role);
+		setWriterAttached(snapshot.writerAttached);
+		setRefusedAt(snapshot.refusedAt);
+		setRefusedReason(snapshot.refusedReason);
 	}, []);
 	const [termHandle, setTermHandle] = useState<TerminalHandle | null>(null);
 	const [error, setError] = useState<{ kind: ErrorKind; path: string } | null>(null);
@@ -86,9 +96,13 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	const [clientFocusPaneId, setClientFocusPaneId] = useState<string | null>(null);
 	// Per-pane handles and roles for NativeViewerBar.
 	const paneHandlesRef = useRef<Map<string, TerminalHandle>>(new Map());
-	const paneRolesRef = useRef<Map<string, { role: NativeStreamRole; refusedAt: number }>>(new Map());
+	// Every MOUNTED pane's full snapshot, not just the focused one: a pane keeps producing
+	// role/writerAttached frames while another pane has focus, and recording only the
+	// focused one made a focus switch restore defaults or stale state.
+	const paneRolesRef = useRef<Map<string, ViewerSnapshot>>(new Map());
 	const [focusedPaneRole, setFocusedPaneRole] = useState<NativeStreamRole>("writer");
 	const [focusedPaneRefusedAt, setFocusedPaneRefusedAt] = useState(0);
+	const [focusedPaneRefusedReason, setFocusedPaneRefusedReason] = useState<NativeViewerStatus["refusedReason"]>(undefined);
 	/** Whether ANY process holds the lease; undefined until the host reports it. */
 	const [focusedPaneWriterAttached, setFocusedPaneWriterAttached] = useState<boolean | undefined>(undefined);
 
@@ -437,22 +451,30 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		const focusPaneId = clientFocusPaneId ?? nativePaneState?.activePaneId ?? panes[0]?.paneId ?? null;
 
 		function makePaneNativeStatusHandler(paneId: string) {
-			return ({ role, refused, writerAttached }: { role: NativeStreamRole; refused: boolean; writerAttached?: boolean }) => {
-				paneRolesRef.current.set(paneId, { role, refusedAt: refused ? Date.now() : (paneRolesRef.current.get(paneId)?.refusedAt ?? 0) });
-				if (paneId === focusPaneId) {
-					setFocusedPaneRole(role);
-					setFocusedPaneWriterAttached(writerAttached);
-					if (refused) setFocusedPaneRefusedAt(Date.now());
-				}
+			return (status: NativeViewerStatus) => {
+				// Recorded for EVERY mounted pane. Focus decides what is displayed, never
+				// whether ownership truth is written down.
+				const snapshot = mergeViewerStatus(paneRolesRef.current.get(paneId) ?? null, status);
+				paneRolesRef.current.set(paneId, snapshot);
+				if (paneId !== focusPaneId) return;
+				// One atomic replacement, so a non-refused authoritative frame clears the
+				// diagnosis instead of leaving stale guidance on screen.
+				setFocusedPaneRole(snapshot.role);
+				setFocusedPaneWriterAttached(snapshot.writerAttached);
+				setFocusedPaneRefusedAt(snapshot.refusedAt);
+				setFocusedPaneRefusedReason(snapshot.refusedReason);
 			};
 		}
 
 		function handleFocusPane(paneId: string) {
 			setClientFocusPaneId(paneId);
 			publishNativePaneFocus(taskId, paneId);
+			// Restored from the pane's own recorded snapshot — no extra frame required.
 			const stored = paneRolesRef.current.get(paneId);
 			setFocusedPaneRole(stored?.role ?? "writer");
 			setFocusedPaneRefusedAt(stored?.refusedAt ?? 0);
+			setFocusedPaneRefusedReason(stored?.refusedReason);
+			setFocusedPaneWriterAttached(stored?.writerAttached);
 		}
 
 		// A drag commits once, on release. Paint the new ratio locally first so the
@@ -509,7 +531,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 								// Use focused pane's handle for touch composer.
 								if (isFocused) setTermHandle(handle);
 							}}
-							onNativeStatus={isFocused ? makePaneNativeStatusHandler(paneId) : undefined}
+							onNativeStatus={makePaneNativeStatusHandler(paneId)}
 							onSessionLost={() => markPaneGone(paneId)}
 							touchComposeMode={touchInput && !rawMode}
 						/>
@@ -564,6 +586,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 						<NativeViewerBar
 							role={focusedPaneRole}
 							refusedAt={focusedPaneRefusedAt}
+							refusedReason={focusedPaneRefusedReason}
 							writerAttached={focusedPaneWriterAttached}
 							onTakeControl={() => paneHandlesRef.current.get(focusPaneId)?.claimWriter()}
 						/>
@@ -606,6 +629,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 					<NativeViewerBar
 						role={focusedPaneRole}
 						refusedAt={focusedPaneRefusedAt}
+							refusedReason={focusedPaneRefusedReason}
 						writerAttached={focusedPaneWriterAttached}
 						onTakeControl={() => paneHandlesRef.current.get(focusPaneId)?.claimWriter()}
 					/>
@@ -728,6 +752,8 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 				<NativeViewerBar
 					role={nativeRole}
 					refusedAt={refusedAt}
+					refusedReason={refusedReason}
+					writerAttached={writerAttached}
 					onTakeControl={() => termHandle?.claimWriter()}
 				/>
 			)}

--- a/src/mainview/components/__tests__/NativeViewerBar.test.tsx
+++ b/src/mainview/components/__tests__/NativeViewerBar.test.tsx
@@ -66,4 +66,54 @@ describe("NativeViewerBar", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	// Once Take control can actually transfer a lease between dev3 processes,
+	// the only refusal left is one clicking cannot fix — so it must not read like the
+	// retryable one, and the strip must say what to do instead.
+	it("distinguishes a host that cannot transfer from a retryable refusal", () => {
+		vi.useFakeTimers();
+		try {
+			const { onTakeControl } = renderBar({ refusedAt: 99, refusedReason: "host-too-old" });
+
+			const status = screen.getByRole("status");
+			expect(status).toHaveTextContent(/too old/i);
+			expect(status).not.toHaveTextContent(/take control to type/i);
+			// The strip truncates, so the actionable sentence rides the button's tooltip.
+			expect(screen.getByRole("button", { name: /take control/i })).toBeInTheDocument();
+
+			// GUIDANCE, not an event: clicking again cannot fix an old host, so the sentence
+			// must NOT time out into the generic read-only line the way a flash does.
+			act(() => {
+				vi.advanceTimersByTime(10_000);
+			});
+			expect(screen.getByRole("status")).toHaveTextContent(/too old/i);
+			// The slot can still free up when the other window leaves, so the gesture stays
+			// available — disabling it would strand the one recovery path that does work.
+			expect(screen.getByRole("button", { name: /take control/i })).toBeEnabled();
+			expect(onTakeControl).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("retires the old-host guidance once the host verdict changes", () => {
+		const { rerender, onTakeControl } = renderBar({ refusedAt: 99, refusedReason: "host-too-old" });
+		expect(screen.getByRole("status")).toHaveTextContent(/too old/i);
+
+		rerender(
+			<I18nProvider>
+				<NativeViewerBar role="observer" refusedAt={99} writerAttached={false} onTakeControl={onTakeControl} />
+			</I18nProvider>,
+		);
+
+		expect(screen.getByRole("status")).not.toHaveTextContent(/too old/i);
+	});
+
+	it("says the host never answered, without guessing why", () => {
+		renderBar({ refusedAt: 99, refusedReason: "transfer-failed" });
+
+		const status = screen.getByRole("status");
+		expect(status).toHaveTextContent(/no answer from the terminal/i);
+		expect(status).not.toHaveTextContent(/too old/i);
+	});
 });

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -64,6 +64,10 @@ const terminal = {
 	// Native terminal: one viewer types, the rest watch until they take over
 	"nativeViewer.readOnly": "Read-only — another viewer is typing",
 	"nativeViewer.refused": "Read-only — take control to type here",
+	"nativeViewer.hostTooOld": "Can't take control — terminal host too old",
+	"nativeViewer.hostTooOldHint": "This pane's terminal host predates control transfer. Restart the terminal, or wait for the other window to release it.",
+	"nativeViewer.transferFailed": "Couldn't take control — no answer from the terminal",
+	"nativeViewer.transferFailedHint": "The terminal host did not confirm the transfer. Check the terminal is still alive, then try again.",
 	"nativeViewer.takeControl": "Take control",
 	"nativeViewer.takeControlHint": "Type in this terminal; the other viewer becomes read-only",
 

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -64,6 +64,10 @@ const terminal = {
 	// Native terminal: one viewer types, the rest watch until they take over
 	"nativeViewer.readOnly": "Solo lectura — otro cliente está escribiendo",
 	"nativeViewer.refused": "Solo lectura — toma el control para escribir aquí",
+	"nativeViewer.hostTooOld": "No se puede tomar el control — host antiguo",
+	"nativeViewer.hostTooOldHint": "El host de terminal de este panel es anterior a la transferencia de control. Reinicia la terminal o espera a que la otra ventana lo libere.",
+	"nativeViewer.transferFailed": "No se pudo tomar el control — la terminal no respondió",
+	"nativeViewer.transferFailedHint": "El host de terminal no confirmó la transferencia. Comprueba que la terminal sigue viva e inténtalo de nuevo.",
 	"nativeViewer.takeControl": "Tomar el control",
 	"nativeViewer.takeControlHint": "Escribirás tú; el otro cliente pasará a solo lectura",
 

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -66,6 +66,10 @@ const terminal = {
 	// Native terminal: one viewer types, the rest watch until they take over
 	"nativeViewer.readOnly": "Только чтение — печатает другой клиент",
 	"nativeViewer.refused": "Только чтение — возьмите управление, чтобы печатать",
+	"nativeViewer.hostTooOld": "Управление не передать — старый хост",
+	"nativeViewer.hostTooOldHint": "Хост терминала этой панели не умеет передавать управление. Перезапустите терминал или дождитесь, пока другое окно его освободит.",
+	"nativeViewer.transferFailed": "Не удалось взять управление — терминал не ответил",
+	"nativeViewer.transferFailedHint": "Хост терминала не подтвердил передачу управления. Проверьте, жив ли терминал, и попробуйте снова.",
 	"nativeViewer.takeControl": "Взять управление",
 	"nativeViewer.takeControlHint": "Печатать будете вы, другой клиент перейдёт в режим чтения",
 

--- a/src/shared/native-terminal-stream.ts
+++ b/src/shared/native-terminal-stream.ts
@@ -66,6 +66,14 @@ export interface NativeStreamOutputHeader {
 	seq: number;
 }
 
+/**
+ * Why an explicit `Take control` did not transfer the lease. Two honest outcomes only:
+ * the host cannot transfer at all, or it never confirmed. There is no "lost a race" — the
+ * host serializes takeovers and the last explicit one wins. Defined here because both the
+ * backend result type and the viewer wire frame carry it.
+ */
+export type WriterTakeoverRefusal = "host-too-old" | "transfer-failed";
+
 /** The client's role changed (takeover, or promotion after the writer left). */
 export interface NativeStreamRoleHeader {
 	t: "role";
@@ -73,6 +81,8 @@ export interface NativeStreamRoleHeader {
 	role: NativeStreamRole;
 	/** Set when the server refused this client's input or resize. */
 	refused?: boolean;
+	/** Why an explicit `Take control` did not transfer the lease. */
+	refusedReason?: WriterTakeoverRefusal;
 	/** The PTY's size, so an observer keeps following the writer's geometry. */
 	cols?: number;
 	rows?: number;
@@ -82,6 +92,57 @@ export interface NativeStreamRoleHeader {
 	 * else is typing" and must not be shown as the same one.
 	 */
 	writerAttached?: boolean;
+}
+
+/**
+ * What a native viewer publishes upward after every role frame: the role itself,
+ * whether this frame was a refusal, and — for a refused `Take control` — why, so
+ * the strip can distinguish "try again" from "this host cannot transfer at all".
+ */
+export interface NativeViewerStatus {
+	role: NativeStreamRole;
+	refused: boolean;
+	writerAttached?: boolean;
+	refusedReason?: NativeStreamRoleHeader["refusedReason"];
+}
+
+/**
+ * A viewer's FULL ownership snapshot. Every frame is normalized into one of these at a
+ * single boundary ({@link mergeViewerStatus}), so no consumer merges fields itself — that
+ * is how the stored and displayed values came to disagree, and how a stale refusal
+ * diagnosis outlived the condition that caused it.
+ */
+export interface ViewerSnapshot {
+	role: NativeStreamRole;
+	/** 0 = never refused. Bumped only by a refusal, so it can drive a flash. */
+	refusedAt: number;
+	refusedReason?: NativeStreamRoleHeader["refusedReason"];
+	writerAttached?: boolean;
+}
+
+/**
+ * Fold one frame into the previous snapshot.
+ *
+ * A refusal records its reason. Any NON-refused frame is an authoritative verdict about
+ * the current state and CLEARS the diagnosis — success, vacancy and a new host all arrive
+ * this way, and preserving the old reason across them is what left dead guidance on
+ * screen. `writerAttached` is the one genuinely partial field: the protocol omits it when
+ * the host has not said, so a known value survives a frame that does not mention it.
+ */
+export function mergeViewerStatus(previous: ViewerSnapshot | null, status: NativeViewerStatus): ViewerSnapshot {
+	if (!status.refused) {
+		return {
+			role: status.role,
+			refusedAt: 0,
+			writerAttached: status.writerAttached ?? previous?.writerAttached,
+		};
+	}
+	return {
+		role: status.role,
+		refusedAt: Date.now(),
+		refusedReason: status.refusedReason,
+		writerAttached: status.writerAttached ?? previous?.writerAttached,
+	};
 }
 
 export type NativeStreamServerHeader =
@@ -176,13 +237,19 @@ export function outputMessage(seq: number, payload: string): string {
 export function roleMessage(
 	role: NativeStreamRole,
 	refused = false,
-	extra?: { cols?: number; rows?: number; writerAttached?: boolean } | null,
+	extra?: {
+		cols?: number;
+		rows?: number;
+		writerAttached?: boolean;
+		refusedReason?: NativeStreamRoleHeader["refusedReason"];
+	} | null,
 ): string {
 	return encodeNativeStreamMessage({
 		t: "role",
 		v: NATIVE_STREAM_PROTOCOL_VERSION,
 		role,
 		...(refused ? { refused: true } : {}),
+		...(extra?.refusedReason ? { refusedReason: extra.refusedReason } : {}),
 		...(extra?.cols && extra.rows ? { cols: extra.cols, rows: extra.rows } : {}),
 		...(typeof extra?.writerAttached === "boolean" ? { writerAttached: extra.writerAttached } : {}),
 	});


### PR DESCRIPTION
Hi — Claude here, the AI assistant that wrote this branch. Description below is mine.

## Summary

An explicit `Take control` in a native terminal could never transfer the writer lease when another dev3 window or app process held it — it reached the host, came back refused, and left the viewer permanently read-only.

One branch caused it, not a race. The host grants a single writer lease to the first client **across every app process** (several dev3 processes share one `~/.dev3.0`), and `WriterOwnership.request(client, "claim")` returns `writer-active` whenever the slot is taken. No action existed that could move a *live* lease, so the button was architecturally incapable of working. Reproduced deterministically in `~/.dev3.0/logs/2026/08/2026-08-03.log` lines 30978–31138: pid 74178 attaches to host 73645 as an observer, its attach-time claim is refused with `another client is already the writer`, then fifteen `Take control refused` lines follow while pid 80386 holds the lease.

## What changed

A third ownership action, `takeover`, alongside `claim`/`release`:

- **`writer-ownership.ts`** — `takeover` swaps the single writer pointer in one synchronous turn on the host's event loop and **returns the displaced client**. `claim` keeps its exact non-stealing semantics, so ordinary attachment, `ensureWriter` and `agent-prompt-native` are unchanged.
- **`host.ts`** — sends the displaced client the unsolicited id-0 observer frame (the channel decision 191 built for the vacancy notice) **before** confirming the winner, so no turn exists in which two clients believe they own the PTY.
- **`pty-server.ts`** — only the explicit gesture uses `takeover`.
- **Old hosts fail closed.** The action is additive, so a host staged before it drops the frame unparsed and the request *times out*. Only `OwnershipTimeoutError` with `action === "takeover"` falls back to a plain claim (which still wins a vacant slot there); a disconnect, auth failure or host error frame is surfaced as itself, never relabelled. A claim refused on such a host becomes an actionable `host-too-old` state on the read-only strip.

Two further bugs surfaced while verifying, fixed here:

- **Displaced viewers rendered at the wrong grid.** A cross-process resize happens in the *other* process, so the displaced process's `appliedCols/Rows` was stale and it kept telling its own viewers the old size — the writer's bytes would wrap at the wrong width. The host now broadcasts the canonical grid to the other clients on each writer resize, and `nativePtyGeometry` prefers the host's number over the local one. Geometry is owner-driven; attach and focus still never resize.
- **Promotion published a PTY one row short.** Winning the lease removes the strip above the canvas, so re-fitting inside the role frame's turn measured the pre-removal box and the ResizeObserver then corrected it — two resizes, two repaints. `TerminalView` now re-fits once, after layout settles.

The strip truncates, so the short label stays in the bar and the why-and-what-to-do sentence rides the `Take control` button's tooltip (focusable, unlike a span). The button stays clickable in `host-too-old` on purpose — the slot can still free up when the other window leaves, and disabling it would strand the one recovery path that works. Copy in en/ru/es. Rationale, rejected alternatives and risks: `decisions/198-explicit-writer-takeover-across-processes.md`.

## Evidence this fix is real

`src/bun/__tests__/native-takeover-peer.ts` is a second **real OS process** that reattaches via `reattachNativeTaskSession`, stands up its own pty-server and renderer socket, and sends the identical `claimMessage()` frame `TerminalView.tsx` sends — never `WriterOwnership` or the host protocol directly, and no tmux path. Against unmodified `HEAD` it fails on seven targeted checks (lease not transferred, refusal reported, input never reached the shell, displaced process never told, host role not followed, exactly-once count `0`, geometry still `100x30`) and passes with this change. The guardrails stay green on `HEAD` as well, so they are load-bearing rather than tautological: attaching from a second instance still observes, the same host/shell are reused, pids are unchanged, the tmux sentinel survives.

## Known gaps

- **No browser QA.** Driving two real app instances meant two full dev3 processes against the shared `~/.dev3.0`, which exposed every real task — it surfaced another agent's completion-approval dialog inside the QA browser, one click from completing someone else's task. Aborted deliberately; nothing leaked. The three strip states and the button-to-frame path are covered in jsdom and the cross-process behaviour by the two-process e2e, but no human has yet watched it in a real window.
- An observer narrower than the canonical grid still **clips** rather than letterboxing. The dotted-filler renderer is deliberately out of scope.
