### PR TITLE
Rebuild the Kanban task card around five zones and a lifecycle rail

### DIFF
--- a/change-logs/2026/08/03/feature-02-kanban-card-lifecycle-rail.md
+++ b/change-logs/2026/08/03/feature-02-kanban-card-lifecycle-rail.md
@@ -1,3 +1,0 @@
-Short: Task cards get a status rail
-
-Rebuilt the Kanban task card around five zones: a 3px status strip on the top edge, a full-width identity header that finally fits the agent and config string, a vertical lifecycle rail on the left that is the status control (pipeline ring, short upright column name, attention count, quick-complete), and a segmented bottom bar where read-only signals are grouped git / run / time above a reserved action strip. Clicking anywhere on the rail opens Move to, and the action strip can no longer be squeezed out by badges.

--- a/change-logs/2026/08/03/feature-02-kanban-card-lifecycle-rail.md
+++ b/change-logs/2026/08/03/feature-02-kanban-card-lifecycle-rail.md
@@ -1,0 +1,3 @@
+Short: Task cards get a status rail
+
+Rebuilt the Kanban task card around five zones: a 3px status strip on the top edge, a full-width identity header that finally fits the agent and config string, a vertical lifecycle rail on the left that is the status control (pipeline ring, short upright column name, attention count, quick-complete), and a segmented bottom bar where read-only signals are grouped git / run / time above a reserved action strip. Clicking anywhere on the rail opens Move to, and the action strip can no longer be squeezed out by badges.

--- a/change-logs/2026/08/04/feature-02-kanban-card-lifecycle-rail.md
+++ b/change-logs/2026/08/04/feature-02-kanban-card-lifecycle-rail.md
@@ -1,0 +1,3 @@
+Short: Task cards get a status rail
+
+Rebuilt the Kanban task card around five zones: a 3px status strip on the top edge, a full-width identity header that finally fits the agent and config string, a vertical lifecycle rail on the left that is the status control (pipeline ring, short upright column name, attention count, quick-complete), and a segmented bottom bar where read-only signals are grouped git / run / time above a reserved action strip. Clicking anywhere on the rail opens Move to, and the action strip can no longer be squeezed out by badges. Board columns grew to 304px, and a variant task now shows a compact `2/3` next to its number instead of a spelled-out "Variant 2" — and nothing at all when it is the only variant.

--- a/decisions/199-task-card-five-zone-layout.md
+++ b/decisions/199-task-card-five-zone-layout.md
@@ -1,0 +1,71 @@
+# 199 — Task card: five zones and a vertical lifecycle rail
+
+## Context
+
+`TaskCard.tsx` had grown to ~17 element classes with no zoning: identity, content,
+lifecycle state, read-only signals and actions all stacked in one vertical flow at the
+same visual weight, across up to three separate badge rows. Card height swung 192–266 px,
+so a column never lined up. The status control — the single most important button on the
+card — rendered as a plain text row wedged between badges, and the variant config string
+(`Auto (Opus 5, Medium) · claude-opus-5[1m]`) burned two wrapped lines. Every new feature
+had been adding a row, which does not scale: the card shows roughly half of what `Task`
+and `TaskPRBadgeInfo` already know.
+
+## Investigation
+
+Eight layouts were prototyped as a standalone HTML artifact and reviewed with the user
+(disposable, deliberately not committed — see the artifact rule in the global agent
+instructions). The winner was "V8": a full-width identity header, a left lifecycle rail,
+and a segmented bottom bar. The measured trade-offs that decided it:
+
+- Full-width identity buys the header **+62 px** (182 → 244 px, +34% rel.). Not enough for
+  the longest config string, which needs 138 px while the rest of the header eats 196 —
+  shortening the config label is the follow-up, not more layout.
+- A right-hand indicator rail (rejected) kept card height constant regardless of signal
+  count, but a bare counter hides severity, and a board exists to show alarms.
+- Hiding signals behind hover (rejected) broke risk scanning outright.
+
+## Decision
+
+Five zones with one admission rule each, recorded in
+`docs/ux/ux-architecture.yaml` → `surfaces.task_card.zone_model`:
+
+1. **Lifecycle** — the 3 px top strip plus `TaskCardRail.tsx`. The rail is the status
+   control: `PipelineRing`, the attention-bell count, the short upright column name, and
+   quick-complete. Two stacked buttons, not one — a `✓` nested inside the status button
+   would be invalid markup and unreachable by keyboard.
+2. **Identity** — one full-width header row above the rail.
+3. **Content** — title (3-line clamp) and labels; the show-description affordance is an
+   icon on the label row, never its own row.
+4. **Signals** — the bottom bar's wrapping strip, grouped `git` / `run` / `time` with 1 px
+   dividers.
+5. **Actions** — a reserved strip at the bar's foot, `min-h-9`, so badges can never
+   squeeze actions out.
+
+The rail label is a short uppercase form capped at 8 upright letters (`status.rail.*` in
+en/ru/es; custom columns clipped). Upright means
+`writing-mode: vertical-rl; text-orientation: upright` — never rotated 90°, on explicit
+user instruction. The full column label lives in the rail's accessible name and tooltip.
+
+`mt-auto` on the bottom bar is load-bearing: the rail is usually the taller of the two
+columns, and without it the bar floats and leaves a dead gap above the card's edge.
+
+## Risks
+
+- The rail prints an abbreviation, so tests must find the status control by its accessible
+  name or `data-testid="task-card-rail"`, never by the full label text.
+- Quick-complete moved into the rail and is no longer desktop-only; on narrow viewports the
+  rail widens so both halves clear the 44 px touch minimum.
+- `task-card-footer` is gone. Signals live under `task-card-signals`, the git group keeps
+  `task-card-status-badges`, and actions keep `task-card-action-row`.
+- A custom column whose name exceeds 8 characters is clipped in the rail. Two different
+  label lengths in one column would otherwise stack to different heights.
+
+## Alternatives considered
+
+Seven other layouts, all prototyped: three-band zoning without a rail; a two-line density
+mode; a hover tray; a fixed right meta-rail with positional slots; a telemetry cockpit with
+a status stepper; a wide rail absorbing the alarms; and V8 without the top strip. V7 (no
+strip) was rejected because the rail no longer reaches the top corner, leaving a ~31 px gap
+of nothing at the top of every card during a column scan — the 3 px strip is the cheapest
+fix at no layout cost.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -489,6 +489,12 @@ bar make red decorative). Evidence: `decisions/184-*.md`, `TaskCard.tsx`, `TaskI
 - **Why:** The menu enumerates every action; DOM surfaces are intentionally partial to control density.
 - **Status:** Observed. Evidence: `src/shared/application-menu.ts`.
 
+## 2026-08-03 — Task card is governed by five zones, and the left rail owns lifecycle
+
+- **Rule:** The board card is a 3px status strip + a full-width identity header + a 38px vertical lifecycle rail (status control) + a body whose segmented bottom bar carries grouped signals above a reserved action strip; each zone has one admission rule (`surfaces.task_card.zone_model`).
+- **Why:** Nothing was zoned, so every feature added a badge row and the status control — the most important button on the card — read as a text label; the rejected alternative was a right-hand indicator rail (constant height, but a bare counter hides severity).
+- **Status:** Implemented. Evidence: `src/mainview/components/TaskCard.tsx`, `src/mainview/components/TaskCardRail.tsx`.
+
 ## 2026-05-29 — Button variants documented as role → token, not as a prop
 
 - **Rule:** Button semantics are documented as semantic role mapped to Tailwind token classes (`bg-accent` = primary, `text-danger`/`bg-danger` = destructive, ghost = hover surface) — there is no `<Button variant>` API.

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -213,6 +213,15 @@ ux_architecture:
       purpose: "Compact object summary on the board with the most relevant per-task affordances."
       allowed: ["status_dot", "label_chip", "variant_dots", "open_action", "context_menu", "git_status_badge", "deferred_timer_chip", "native_backend_mark"]
       forbidden: ["full_settings", "global_destination"]
+      zone_model:
+        rationale: "The card had no zoning: identity, content, state, signals and actions stacked at one visual weight across up to three badge rows, and every feature added a row. Five zones, each with one admission rule, give a new feature a home instead of a new row."
+        order: ["lifecycle", "identity", "content", "signals", "actions"]
+        lifecycle: "The 3px top status strip plus the vertical left rail (TaskCardRail.tsx). Owns ONLY things that change or report which column the task is in: pipeline ring, short upright status name, attention-bell count, quick-complete. Clicking the rail opens Move-to. Nothing informational may enter it."
+        identity: "One full-width header row above the rail: priority (frozen PriorityBadge), #seq, attempt, agent + config, variant dots, scratch/automation/native marks, dismiss. Full width is deliberate — the agent config string had 182px next to a rail and now has 244px. Never grows past one line; overflow goes to the tooltip."
+        content: "Epic (future), title (3-line clamp), label chips. The only zone allowed to be the card's visual focus. The show-description affordance is an icon on the label row, never its own row."
+        signals: "Read-only facts in the segmented bottom bar, sub-grouped git / run / time with 1px dividers between groups. This is where new badges land."
+        actions: "A reserved strip at the very bottom of the bar (min-height 36px) so signals can never squeeze actions out. Max 4 visible, rest to the context menu."
+      rail_label: "Short uppercase status form, max 8 upright letters (status.rail.* keys per locale; custom columns clipped to 8 chars). Upright means writing-mode: vertical-rl + text-orientation: upright — never rotated 90deg. The full column label lives in the rail's accessible name and tooltip."
       deferred_timer_chip: "One shared countdown-chip slot (popover with cancel / run-now, 30s re-render) for deferred agent interactions. Content depends on state and the two NEVER coexist: scheduledLaunch on a `todo` card, scheduledMessages on a live-agent card. Do not add a second timer badge class."
       variant_dots: "Max 3 status dots (self — ring-highlighted — + lowest-variantIndex siblings; NO +N counter), always a clickable button opening SiblingPopover — the group overview: per-variant title, agent/config, status, current-variant marker; dead variants greyed, non-navigable. Same pattern on sidebar cards; do not fork the mechanic per surface."
       visible_budget:

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -469,7 +469,7 @@ function KanbanColumn({
 		<>
 		<div
 			className={`group/col relative flex flex-col flex-shrink-0 glass-column column-glow rounded-2xl border transition-[background-color,border-color,box-shadow,opacity,width] duration-150 ease-out ${
-				fullWidth ? "w-full" : isCompactNarrow ? "w-[6.125rem]" : "w-[17.5rem]"
+				fullWidth ? "w-full" : isCompactNarrow ? "w-[6.125rem]" : "w-[19rem]"
 			} ${
 				showDropHighlight
 					? "border-accent bg-accent/5 shadow-lg shadow-accent/10"

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -10,7 +10,6 @@ import { useT } from "../i18n";
 import type { TranslationKey } from "../i18n";
 import { formatBytes } from "../utils/formatBytes";
 import { formatCountdown } from "../../shared/duration";
-import { getStatusLabel } from "../utils/statusLabel";
 import { trackEvent, agentNameFromId } from "../analytics";
 import { useStatusColors } from "../hooks/useStatusColors";
 import { useTerminalPreview } from "../hooks/useTerminalPreview";
@@ -23,8 +22,8 @@ import OpenInMenu from "./OpenInMenu";
 import TerminalPreviewPopover from "./TerminalPreviewPopover";
 import { moveTaskToStatus } from "../utils/moveTaskToStatus";
 import TaskDetailModal from "./TaskDetailModal";
-import PipelineRing, { CompleteCheckIcon } from "./PipelineRing";
 import PipelineDropdown, { PipelineMenuAction } from "./PipelineDropdown";
+import TaskCardRail from "./TaskCardRail";
 import BottomSheet from "./BottomSheet";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
@@ -609,6 +608,190 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 
 	const showDismissButton = isTodo || isCancelled;
 
+	// ---- LIFECYCLE zone inputs ----------------------------------------------
+	const activeCol = task.customColumnId
+		? (project.customColumns ?? []).find((c) => c.id === task.customColumnId)
+		: null;
+	// The rail's ✓ is now a 44px touch target on narrow, so it no longer has to be
+	// desktop-only. Deliberately NOT gated on `isHibernated`: finishing a parked
+	// task must not require waking it first.
+	const canQuickComplete = !isDisabled && getAllowedTransitions(task.status).includes("completed");
+	const railColor = isCompleting || isShuttingDown ? "#888" : activeCol ? activeCol.color : color;
+
+	// ---- IDENTITY zone inputs -----------------------------------------------
+	const agent = task.agentId ? agents.find((a) => a.id === task.agentId) : null;
+	const agentConfig = agent && task.configId
+		? agent.configurations.find((c) => c.id === task.configId)
+		: agent?.configurations.find((c) => c.id === agent.defaultConfigId) ?? agent?.configurations[0];
+	const configLabel = agentConfig
+		? (agentConfig.model ? `${agentConfig.name} · ${agentConfig.model}` : agentConfig.name)
+		: agent?.name ?? "";
+	const seqLabel = task.variantIndex !== null
+		? `#${task.seq} · ${t("task.attempt", { n: String(task.variantIndex) })}`
+		: `#${task.seq}`;
+	const hasLauncherIcon = agent ? resolveAgentLauncherIcon(agent) !== null : false;
+
+	// ---- SIGNALS zone: read-only facts, grouped git / run / time -------------
+	const gitSignals = [prBadge, mergeBadge, reviewBadge, commentBadge].filter(Boolean);
+	const runSignals: React.ReactNode[] = [];
+	if (isActive && ports && ports.length > 0) {
+		runSignals.push(
+			<Tooltip key="ports" content={t.plural("ports.count", ports.length)} detail={t("ttip.task.ports")}>
+				<button
+					ref={portsAnchorRef}
+					onClick={(e) => {
+						e.stopPropagation();
+						if (!portsPopoverOpen && portsAnchorRef.current) {
+							const rect = portsAnchorRef.current.getBoundingClientRect();
+							setPortsPopoverPos({ top: rect.bottom + 6, left: rect.left });
+							setPortsPopoverVisible(false);
+						}
+						setPortsPopoverOpen(!portsPopoverOpen);
+					}}
+					className="inline-flex h-5 flex-shrink-0 items-center gap-1 rounded bg-accent/10 px-1.5 font-mono text-[0.625rem] text-accent transition-colors hover:bg-accent/20"
+					aria-label={t.plural("ports.count", ports.length)}
+				>
+					<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{""}</span>
+					{ports.length}
+				</button>
+			</Tooltip>,
+		);
+	}
+	if (isActive && resourceUsage) {
+		runSignals.push(
+			<span
+				key="res"
+				className={`inline-flex h-5 flex-shrink-0 items-center gap-1 rounded px-1.5 font-mono text-[0.625rem] ${
+					resourceUsage.rss > 4 * 1024 * 1024 * 1024
+						? "text-red-400 bg-red-500/10"
+						: resourceUsage.rss > 2 * 1024 * 1024 * 1024
+							? "text-yellow-400 bg-yellow-500/10"
+							: "text-fg-3 bg-fg/5"
+				}`}
+				title={t("resources.details", { cpu: resourceUsage.cpu.toFixed(1), memory: formatBytes(resourceUsage.rss) })}
+			>
+				<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+					{"\u{F035B}"}
+				</span>
+				{formatBytes(resourceUsage.rss)}
+				{resourceUsage.cpu >= 1 && (
+					<>
+						<span className="text-fg-muted">·</span>
+						{resourceUsage.cpu.toFixed(0)}%
+					</>
+				)}
+			</span>,
+		);
+	}
+	const timeSignals: React.ReactNode[] = [];
+	if (sched) {
+		timeSignals.push(
+			<div key="sched" className="relative flex-shrink-0">
+				<Tooltip content={t("task.scheduledTooltip")}>
+					<button
+						data-testid="task-card-scheduled-badge"
+						onClick={(e) => { e.stopPropagation(); setSchedPopoverOpen(!schedPopoverOpen); }}
+						className="flex h-5 items-center gap-1 rounded px-1.5 text-[0.6875rem] text-accent transition-colors hover:bg-fg/5"
+					>
+						<ClockIcon className="w-3 h-3" />
+						{formatCountdown(new Date(sched.at).getTime() - Date.now())}
+					</button>
+				</Tooltip>
+				{schedPopoverOpen && (
+					<div
+						className="absolute bottom-full left-0 mb-1 z-30 min-w-[10rem] rounded-lg border border-edge bg-elevated shadow-lg py-1"
+						onClick={(e) => e.stopPropagation()}
+					>
+						<button
+							onClick={handleStartScheduledNow}
+							className="w-full text-left px-3 py-1.5 text-xs text-fg hover:bg-fg/5 transition-colors"
+						>
+							{t("task.startNow")}
+						</button>
+						<button
+							onClick={handleCancelSchedule}
+							className="w-full text-left px-3 py-1.5 text-xs text-danger hover:bg-fg/5 transition-colors"
+						>
+							{t("task.cancelSchedule")}
+						</button>
+					</div>
+				)}
+			</div>,
+		);
+	}
+	if (!isTodo) {
+		timeSignals.push(
+			<ScheduledMessagesChip key="msgs" task={task} project={project} dispatch={dispatch} placement="up" />,
+		);
+	}
+	const variantDots = (
+		<VariantDots
+			groupMembers={groupMembers}
+			currentTaskId={task.id}
+			statusColors={statusColors}
+			agents={agents}
+			navigate={navigate}
+			projectId={project.id}
+			onOpen={preview.close}
+			testId={`variant-indicator-${task.id}`}
+		/>
+	);
+
+	// A group separator, so compartments read apart without extra colour.
+	const groupDivider = <span aria-hidden="true" className="h-4 w-px flex-shrink-0 bg-edge" />;
+	const signalGroups: React.ReactNode[] = [];
+	if (gitSignals.length) {
+		signalGroups.push(
+			<div key="git" data-testid="task-card-status-badges" className="flex min-w-0 flex-wrap items-center gap-1">
+				{gitSignals}
+			</div>,
+		);
+	}
+	if (runSignals.length) {
+		signalGroups.push(
+			<div key="run" data-testid="task-card-run-signals" className="flex min-w-0 flex-wrap items-center gap-1">
+				{runSignals}
+			</div>,
+		);
+	}
+	if (timeSignals.length) {
+		signalGroups.push(
+			<div key="time" data-testid="task-card-time-signals" className="flex min-w-0 flex-wrap items-center gap-1">
+				{timeSignals}
+			</div>,
+		);
+	}
+
+	const watchButton = (
+		<Tooltip content={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")} detail={t("ttip.task.watch")}>
+			<button
+				onClick={async (e) => {
+					e.stopPropagation();
+					try {
+						const updated = await api.request.toggleTaskWatch({
+							taskId: task.id,
+							projectId: project.id,
+							watched: !task.watched,
+						});
+						dispatch({ type: "updateTask", task: updated });
+					} catch {
+						// Toggle failed silently — secondary action
+					}
+				}}
+				className={`flex flex-shrink-0 items-center gap-1 rounded-lg px-1.5 py-1 text-xs transition-[opacity,color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-fg/5 ${
+					task.watched ? "text-accent font-medium" : "text-fg-3 hover:text-fg"
+				}`}
+				aria-label={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")}
+				disabled={isDisabled}
+			>
+				<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+					{task.watched ? "\u{F009A}" : "\u{F0F1C}"}
+				</span>
+				<span className="text-[0.6875rem]">{task.watched ? t("task.watching") : t("task.watch")}</span>
+			</button>
+		</Tooltip>
+	);
+
 	return (
 		<div
 			ref={cardRef}
@@ -620,12 +803,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			onContextMenu={handleContextMenu}
 			onMouseEnter={handleCardMouseEnter}
 			onMouseLeave={handleCardMouseLeave}
-			className={`group relative p-3.5 glass-card rounded-xl transition-[transform,box-shadow,background-color,border-color,opacity,filter] duration-150 ease-out border border-l-[3px] ${isDraft ? "border-dashed" : ""} ${isActiveInSplit ? "border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/20" : isDraft ? "border-edge-active" : "border-transparent"} ${
+			className={`group relative flex flex-col overflow-hidden glass-card rounded-xl transition-[transform,box-shadow,background-color,border-color,opacity,filter] duration-150 ease-out border ${isDraft ? "border-dashed border-edge-active" : isActiveInSplit ? "border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/20" : "border-transparent"} ${
 				isActive || isCompleted || isCancelled
 					? "cursor-pointer hover:-translate-y-0.5 hover:shadow-card-hover"
 					: "cursor-grab active:cursor-grabbing hover:-translate-y-0.5 hover:shadow-card-hover"
 			} ${isCompleting || isShuttingDown ? "grayscale opacity-40 pointer-events-none" : isPreparing ? "opacity-60" : isDisabled ? "opacity-50 pointer-events-none" : isHibernated ? "grayscale opacity-60" : ""}`}
-			style={{ borderLeftColor: isCompleting || isShuttingDown ? "#888" : color }}
 			onClick={handleClick}
 		>
 			{/* Moving spinner overlay */}
@@ -690,99 +872,46 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			{/* Shared teardown feedback used by the active-task surfaces too. */}
 			{isShuttingDown && <TaskShutdownOverlay />}
 
-			{/* Dismiss button — top-right, visible on hover */}
-			{showDismissButton && (
-				<Tooltip content={isCancelled ? t("task.delete") : t("task.cancel")} detail={isCancelled ? t("ttip.task.delete") : t("ttip.task.cancel")}>
-					<button
-						onClick={handleDismiss}
-						className="absolute top-2.5 right-2.5 opacity-0 group-hover:opacity-100 w-5 h-5 flex items-center justify-center rounded-md bg-fg/5 text-fg-3 hover:bg-danger/15 hover:text-danger transition-[opacity,color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96]"
-						aria-label={isCancelled ? t("task.delete") : t("task.cancel")}
-						disabled={isDisabled}
-					>
-						<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-							<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-						</svg>
-					</button>
-				</Tooltip>
-			)}
-
-			{/* Bell badge — macOS Dock style, peeking outside the card */}
-			{bellCount > 0 && (
-				<div
-					className="absolute -top-1.5 -right-1.5 z-10 min-w-[1.25rem] h-5 flex items-center justify-center px-1.5 rounded-full bg-red-500 shadow-lg shadow-red-500/40"
-				>
-					<span className="text-[0.6875rem] font-bold text-white leading-none">
-						{bellCount > 9 ? "9+" : bellCount}
-					</span>
-				</div>
-			)}
-
-			{/* Seq + variant badge */}
-			{task.variantIndex !== null ? (() => {
-				const agent = task.agentId ? agents.find((a) => a.id === task.agentId) : null;
-				const config = agent && task.configId
-					? agent.configurations.find((c) => c.id === task.configId)
-					: agent?.configurations.find((c) => c.id === agent.defaultConfigId) ?? agent?.configurations[0];
-				const configLabel = config
-					? (config.model ? `${config.name} · ${config.model}` : config.name)
-					: "";
-				const prefixLabel = `#${task.seq} · ${t("task.attempt", { n: String(task.variantIndex) })}`;
-				const hasLauncherIcon = agent ? resolveAgentLauncherIcon(agent) !== null : false;
-				const topLabel = agent && !hasLauncherIcon ? `${prefixLabel} · ${agent.name}` : prefixLabel;
-				return (
-					<div className="text-xs text-accent font-semibold mb-1.5 flex flex-col items-start gap-0.5">
-						<span className="inline-flex items-center gap-1.5">
-							<PriorityBadge priority={task.priority} onChange={handleSetPriority} />
-							<span className="bg-accent/15 px-2 py-0.5 rounded-md inline-flex min-h-6 items-center gap-1.5">
-								{agent && hasLauncherIcon && <AgentLauncherBadge agent={agent} />}
-								<span>{topLabel}</span>
-							</span>
-						</span>
-						{configLabel && (
-							<span className="pl-1 text-[0.6875rem] font-medium leading-tight text-accent/80">
-								{configLabel}
-							</span>
-						)}
-					</div>
-				);
-			})() : (
-				<div className="mb-1 flex items-center gap-1.5">
-					<PriorityBadge priority={task.priority} onChange={handleSetPriority} />
-					<span className="text-[0.625rem] text-fg-muted font-mono">#{task.seq}</span>
-					{isDraft && (
-						<span
-							data-testid="task-card-draft-badge"
-							title={t("task.draftHint")}
-							className="inline-flex items-center rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-3"
-						>
-							{t("task.draftBadge")}
-						</span>
-					)}
-				</div>
-			)}
-
-			{/* Hibernated label — greyness alone must not have to carry the meaning. */}
-			{isHibernated && (
-				<div className="mb-1.5 flex items-center gap-1.5">
-					<span
-						data-testid="task-card-hibernated-badge"
-						title={t("task.hibernatedHint")}
-						className="inline-flex items-center rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-muted"
-					>
-						{t("task.hibernatedBadge")}
-					</span>
-				</div>
-			)}
-
-			{/* Title + description expand */}
+			{/* LIFECYCLE — a 3px status strip on the top edge. The rail below no longer
+			    reaches the top corner, and without this the card's column stops being
+			    readable while scanning a column from the top. */}
 			<div
-				className={`text-fg text-sm leading-relaxed break-words font-medium pr-5 ${isTodo ? "cursor-pointer hover:text-fg-2" : ""}`}
-				onClick={handleTitleClick}
-				title={isTodo && hasLongDescription ? task.description : undefined}
+				data-testid="task-card-status-strip"
+				aria-hidden="true"
+				className="h-[3px] w-full flex-shrink-0"
+				style={{ background: railColor }}
+			/>
+
+			{/* IDENTITY — one line, full card width: which task is this and who runs it.
+			    Full width is the point: the rail starts a row lower so the agent and
+			    config string get the whole card instead of 182px next to a rail. */}
+			<div
+				data-testid="task-card-identity"
+				className="flex min-w-0 items-center gap-1.5 border-b border-edge px-2.5 py-1.5"
 			>
+				<PriorityBadge priority={task.priority} onChange={handleSetPriority} />
+				<span className="flex-shrink-0 font-mono text-[0.6875rem] font-semibold text-accent">{seqLabel}</span>
+				{agent && hasLauncherIcon && <AgentLauncherBadge agent={agent} />}
+				{/* No launcher icon means the agent is unidentifiable from the glyph
+				    alone, so its name has to be spelled out. */}
+				{agent && !hasLauncherIcon && (
+					<span className="flex-shrink-0 font-mono text-[0.625rem] font-medium text-accent/80">{agent.name}</span>
+				)}
+				{configLabel && (
+					<span
+						className="min-w-[3rem] flex-1 truncate font-mono text-[0.625rem] font-medium text-accent/80"
+						title={configLabel}
+					>
+						{configLabel}
+					</span>
+				)}
+				{variantDots}
+				{/* Only when there is no config to absorb the slack — otherwise a spacer
+				    would starve the string this full-width header exists for. */}
+				{!configLabel && <div className="flex-1" />}
 				{task.scratch && (
 					<span
-						className="text-fg-3 mr-1.5"
+						className="flex-shrink-0 text-fg-3"
 						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 						title={t("task.scratchSession")}
 					>
@@ -791,47 +920,270 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				)}
 				{task.automationId && (
 					<span
-						className="text-fg-3 mr-1.5"
+						className="flex-shrink-0 text-fg-3"
 						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 						title={t("task.automationRun")}
 					>
 						{"\u{F0150}"}
 					</span>
 				)}
-				<NativeBackendMark task={task} className="w-3.5 h-3.5 mr-1.5" testId="task-card-native-backend" />
-				{displayTitle}
-			</div>
-			{hasLongDescription && !isTodo && (
-				<Tooltip content={t("task.showDescription")} detail={t("ttip.task.showDescription")}>
-					<button
-						onClick={handleShowDescription}
-						className="mt-1 text-[0.6875rem] text-fg-muted hover:text-accent transition-colors flex items-center gap-1"
-					>
-						<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-							<path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h10" />
-						</svg>
-						{t("task.showDescription")}
-					</button>
-				</Tooltip>
-			)}
-			{isTodo && task.preparationError && (
-				<div
-					role="alert"
-					className="mt-2 flex items-start gap-1.5 rounded-lg border border-danger/30 bg-danger/10 px-2 py-1.5 text-xs text-danger"
-				>
+				<NativeBackendMark task={task} className="w-3.5 h-3.5 flex-shrink-0" testId="task-card-native-backend" />
+				{isDraft && (
 					<span
-						className="mt-0.5 flex-shrink-0 leading-none"
-						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+						data-testid="task-card-draft-badge"
+						title={t("task.draftHint")}
+						className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-3"
 					>
-						{"\uf071"}
+						{t("task.draftBadge")}
 					</span>
-					<span className="line-clamp-2 break-words">
-						{t("task.launchFailed", { error: task.preparationError })}
+				)}
+				{isHibernated && (
+					<span
+						data-testid="task-card-hibernated-badge"
+						title={t("task.hibernatedHint")}
+						className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-muted"
+					>
+						{t("task.hibernatedBadge")}
 					</span>
-				</div>
-			)}
+				)}
+				{showDismissButton && (
+					<Tooltip content={isCancelled ? t("task.delete") : t("task.cancel")} detail={isCancelled ? t("ttip.task.delete") : t("ttip.task.cancel")}>
+						<button
+							onClick={handleDismiss}
+							className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-fg/5 text-fg-3 opacity-0 transition-[opacity,color,background-color,transform] duration-150 ease-out group-hover:opacity-100 hover:bg-danger/15 hover:text-danger motion-safe:active:scale-[0.96]"
+							aria-label={isCancelled ? t("task.delete") : t("task.cancel")}
+							disabled={isDisabled}
+						>
+							<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+								<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</Tooltip>
+				)}
+			</div>
 
-			{/* Task detail modal — portal to body so it's not clipped by card */}
+			{/* Rail + body */}
+			<div className="flex min-w-0 items-stretch">
+				<TaskCardRail
+					status={task.status}
+					project={project}
+					customColumn={activeCol ? { name: activeCol.name, color: activeCol.color } : null}
+					color={railColor}
+					bellCount={bellCount}
+					disabled={isDisabled || isHibernated}
+					canComplete={canQuickComplete}
+					completing={quickCompleting}
+					onOpenMenu={toggleMenu}
+					onComplete={handleQuickComplete}
+					menuTriggerRef={triggerRef}
+					touch={narrow}
+				/>
+
+				<div className="flex min-w-0 flex-1 flex-col px-3 pt-2.5">
+					{/* CONTENT */}
+					<div>
+						<div
+							className={`break-words text-sm font-medium leading-relaxed text-fg line-clamp-3 ${isTodo ? "cursor-pointer hover:text-fg-2" : ""}`}
+							onClick={handleTitleClick}
+							title={isTodo && hasLongDescription ? task.description : undefined}
+						>
+							{displayTitle}
+						</div>
+						{isTodo && task.preparationError && (
+							<div
+								role="alert"
+								className="mt-2 flex items-start gap-1.5 rounded-lg border border-danger/30 bg-danger/10 px-2 py-1.5 text-xs text-danger"
+							>
+								<span
+									className="mt-0.5 flex-shrink-0 leading-none"
+									style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+								>
+									{""}
+								</span>
+								<span className="line-clamp-2 break-words">
+									{t("task.launchFailed", { error: task.preparationError })}
+								</span>
+							</div>
+						)}
+
+						{/* Label chips — always rendered so "+" stays discoverable on hover */}
+						{(() => {
+							const projectLabels = project.labels ?? [];
+							const taskLabelIds = task.labelIds ?? [];
+							const assignedLabels = taskLabelIds
+								.map((id) => projectLabels.find((l) => l.id === id))
+								.filter(Boolean) as typeof projectLabels;
+
+							async function removeLabel(labelId: string) {
+								try {
+									const updated = await api.request.setTaskLabels({
+										taskId: task.id,
+										projectId: project.id,
+										labelIds: taskLabelIds.filter((id) => id !== labelId),
+									});
+									dispatch({ type: "updateTask", task: updated });
+								} catch {
+									// ignore
+								}
+							}
+
+							async function toggleLabel(labelId: string) {
+								const newIds = taskLabelIds.includes(labelId)
+									? taskLabelIds.filter((id) => id !== labelId)
+									: [...taskLabelIds, labelId];
+								try {
+									const updated = await api.request.setTaskLabels({
+										taskId: task.id,
+										projectId: project.id,
+										labelIds: newIds,
+									});
+									dispatch({ type: "updateTask", task: updated });
+								} catch {
+									// ignore
+								}
+							}
+
+							return (
+								<div className="mt-2 flex min-h-[1.125rem] items-start gap-2">
+								<div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+									{assignedLabels.map((label) => (
+										<LabelChip
+											key={label.id}
+											label={label}
+											size="xs"
+											onClick={(e) => {
+												e.stopPropagation();
+												setPickerOpen(true);
+											}}
+											onRemove={(e) => {
+												e.stopPropagation();
+												removeLabel(label.id);
+											}}
+										/>
+									))}
+									<button
+										ref={pickerAnchorRef}
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											setPickerOpen(true);
+										}}
+										className="flex flex-shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-fg-3 opacity-0 transition-[opacity,color,background-color,transform] duration-150 ease-out group-hover:opacity-70 hover:!opacity-100 hover:bg-fg/8 hover:text-fg motion-safe:active:scale-[0.96]"
+									>
+										<svg className="w-2.5 h-2.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+											<path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+										</svg>
+										<span className="text-[0.625rem] font-medium leading-none">Add label</span>
+									</button>
+									{pickerOpen && pickerAnchorRef.current && (
+										<LabelPicker
+											project={project}
+											dispatch={dispatch}
+											taskId={task.id}
+											onClose={() => setPickerOpen(false)}
+											anchorEl={pickerAnchorRef.current}
+											selectedIds={taskLabelIds}
+											onToggle={toggleLabel}
+										/>
+									)}
+								</div>
+								{/* The description affordance rides the label row instead of
+								    claiming a row of its own — it was ~20px on most cards. */}
+								{hasLongDescription && !isTodo && (
+									<Tooltip content={t("task.showDescription")} detail={t("ttip.task.showDescription")}>
+										<button
+											onClick={handleShowDescription}
+											aria-label={t("task.showDescription")}
+											className="flex h-[1.125rem] w-[1.125rem] flex-shrink-0 items-center justify-center rounded text-fg-muted transition-colors hover:bg-fg/8 hover:text-accent"
+										>
+											<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+												<path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h10" />
+											</svg>
+										</button>
+									</Tooltip>
+								)}
+								</div>
+							);
+						})()}
+					</div>
+
+					{/* SIGNALS + ACTIONS — one segmented bar welded to the bottom edge.
+					    mt-auto is what keeps it there when the rail is the taller column. */}
+					<div className="-mx-3 mt-auto border-t border-edge bg-black/20">
+						{signalGroups.length > 0 && (
+							<div
+								data-testid="task-card-signals"
+								className="flex min-w-0 flex-wrap items-center gap-1.5 px-2.5 py-1.5"
+							>
+								{signalGroups.flatMap((group, i) => (i === 0 ? [group] : [<span key={`d${i}`}>{groupDivider}</span>, group]))}
+							</div>
+						)}
+						{/* Actions get a reserved strip, so signals can never squeeze them
+						    out. min-h-9 is what the 22px buttons plus their hover fill need. */}
+						<div
+							data-testid="task-card-action-row"
+							className={`flex min-h-9 min-w-0 items-center gap-1 px-2 py-1.5 ${signalGroups.length > 0 ? "border-t border-edge" : ""}`}
+						>
+							{isActive && task.worktreePath && (
+								<Tooltip content={t("openIn.menuTitle")} detail={t("ttip.openIn.menu")}>
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											const rect = (e.target as HTMLElement).getBoundingClientRect();
+											setCtxMenuPos({ top: rect.bottom + 4, left: rect.left });
+											setCtxMenuOpen(true);
+										}}
+										className="flex flex-shrink-0 items-center gap-1 rounded-lg px-1.5 py-1 text-accent transition-[color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-accent/15"
+										aria-label={t("openIn.menuTitle")}
+									>
+										<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0379}"}</span>
+									</button>
+								</Tooltip>
+							)}
+							{watchButton}
+							<div className="flex-1" />
+							{isActive && (
+								<Tooltip content={t("task.addVariant")} detail={t("ttip.task.addVariant")}>
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											preview.close();
+											onAddAttempts(task);
+										}}
+										className="flex flex-shrink-0 items-center rounded-lg px-2 py-1 text-xs font-medium text-accent transition-[color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-accent/15"
+										disabled={isDisabled}
+									>
+										{t("task.addVariant")}
+									</button>
+								</Tooltip>
+							)}
+							{/* A draft has nothing to run yet; the lifecycle machine would
+							    refuse the launch anyway. */}
+							{isTodo && !isDraft && (
+								<Tooltip content={t("task.run")} detail={t("ttip.task.run")}>
+									<button
+										onClick={(e) => {
+											e.stopPropagation();
+											onLaunchVariants(task, "in-progress");
+										}}
+										className="flex flex-shrink-0 items-center gap-1.5 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm shadow-green-900/30 transition-[background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-green-500"
+										disabled={isDisabled}
+									>
+										{/* Play triangle centred on the viewBox — the usual 8→19 path
+										    sits 1.5px right of centre and opens a gap before the label. */}
+										<svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+											<path d="M6 4.5v15l12-7.5z" />
+										</svg>
+										{t("task.run")}
+									</button>
+								</Tooltip>
+							)}
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* Task detail modal — portal to body so it's not clipped by the card */}
 			{detailOpen && createPortal(
 				<TaskDetailModal
 					task={task}
@@ -842,389 +1194,6 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					onLaunchVariants={onLaunchVariants}
 				/>,
 				document.body
-			)}
-
-			{/* Label chips row — always rendered so "+" is discoverable on hover */}
-			{(() => {
-				const projectLabels = project.labels ?? [];
-				const taskLabelIds = task.labelIds ?? [];
-				const assignedLabels = taskLabelIds
-					.map((id) => projectLabels.find((l) => l.id === id))
-					.filter(Boolean) as typeof projectLabels;
-
-				async function removeLabel(labelId: string) {
-					try {
-						const updated = await api.request.setTaskLabels({
-							taskId: task.id,
-							projectId: project.id,
-							labelIds: taskLabelIds.filter((id) => id !== labelId),
-						});
-						dispatch({ type: "updateTask", task: updated });
-					} catch {
-						// ignore
-					}
-				}
-
-				async function toggleLabel(labelId: string) {
-					const newIds = taskLabelIds.includes(labelId)
-						? taskLabelIds.filter((id) => id !== labelId)
-						: [...taskLabelIds, labelId];
-					try {
-						const updated = await api.request.setTaskLabels({
-							taskId: task.id,
-							projectId: project.id,
-							labelIds: newIds,
-						});
-						dispatch({ type: "updateTask", task: updated });
-					} catch {
-						// ignore
-					}
-				}
-
-				return (
-					<div className="flex items-start mt-2 min-h-[1.125rem] gap-2">
-					<div className="flex items-center flex-wrap gap-1 min-w-0 flex-1">
-						{assignedLabels.map((label) => (
-							<LabelChip
-								key={label.id}
-								label={label}
-								size="xs"
-								onClick={(e) => {
-									e.stopPropagation();
-									setPickerOpen(true);
-								}}
-								onRemove={(e) => {
-									e.stopPropagation();
-									removeLabel(label.id);
-								}}
-							/>
-						))}
-						<button
-							ref={pickerAnchorRef}
-							type="button"
-							onClick={(e) => {
-								e.stopPropagation();
-								setPickerOpen(true);
-							}}
-							className="opacity-0 group-hover:opacity-70 hover:!opacity-100 flex items-center gap-1 px-1.5 py-0.5 rounded-md text-fg-3 hover:text-fg hover:bg-fg/8 transition-[opacity,color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] flex-shrink-0"
-						>
-							<svg className="w-2.5 h-2.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-								<path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-							</svg>
-							<span className="text-[0.625rem] font-medium leading-none">Add label</span>
-						</button>
-						{pickerOpen && pickerAnchorRef.current && (
-							<LabelPicker
-								project={project}
-								dispatch={dispatch}
-								taskId={task.id}
-								onClose={() => setPickerOpen(false)}
-								anchorEl={pickerAnchorRef.current}
-								selectedIds={taskLabelIds}
-								onToggle={toggleLabel}
-							/>
-						)}
-					</div>
-					{!isActive && (
-						<Tooltip content={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")} detail={t("ttip.task.watch")}>
-							<button
-								onClick={async (e) => {
-									e.stopPropagation();
-									try {
-										const updated = await api.request.toggleTaskWatch({
-											taskId: task.id,
-											projectId: project.id,
-											watched: !task.watched,
-										});
-										dispatch({ type: "updateTask", task: updated });
-									} catch {
-										// Toggle failed silently — secondary action
-									}
-								}}
-								className={`flex-shrink-0 flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-xs transition-[opacity,color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-fg/5 ${
-									task.watched
-										? "text-accent"
-										: "opacity-0 group-hover:opacity-70 text-fg-3 hover:!opacity-100"
-								}`}
-								aria-label={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")}
-								disabled={isDisabled}
-							>
-								<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-									{task.watched ? "\u{F009A}" : "\u{F0F1C}"}
-								</span>
-								<span className="text-[0.6875rem]">{task.watched ? t("task.watching") : t("task.watch")}</span>
-							</button>
-						</Tooltip>
-					)}
-				</div>
-				);
-			})()}
-
-			{/* Bottom row — pipeline + badges */}
-			<div data-testid="task-card-footer" className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5">
-				{/* Status control: pipeline ring + label opens "Move to"; the ✓ half is
-				    the same lifecycle control, not a second card action. Desktop only —
-				    on narrow the sheet's promoted Completed row is the ≥44px touch path. */}
-				{(() => {
-					const activeCol = task.customColumnId
-						? (project.customColumns ?? []).find((c) => c.id === task.customColumnId)
-						: null;
-					// Deliberately NOT gated on `isHibernated`: finishing a parked task
-					// must not require waking it first.
-					const canQuickComplete = !narrow && !isDisabled && getAllowedTransitions(task.status).includes("completed");
-					return (
-						<div className="flex min-w-0 items-center rounded-lg transition-colors hover:bg-fg/5">
-							<button
-								ref={triggerRef}
-								onClick={toggleMenu}
-								className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1"
-								disabled={isDisabled || isHibernated}
-							>
-								{activeCol ? (
-									<div
-										className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-										style={{ background: activeCol.color, boxShadow: `0 0 6px ${activeCol.color}60` }}
-									/>
-								) : (
-									<PipelineRing status={task.status} />
-								)}
-								<span className="min-w-0 truncate text-xs text-fg-2">
-									{activeCol ? activeCol.name : getStatusLabel(task.status, t, project)}
-								</span>
-							</button>
-							{canQuickComplete && (
-								<Tooltip content={t("pipeline.completeTooltip")} disabled={quickCompleting}>
-									<button
-										data-testid="task-card-quick-complete"
-										onClick={handleQuickComplete}
-										disabled={quickCompleting}
-										aria-label={t("pipeline.completeTooltip")}
-										className={`mr-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md text-success transition-[opacity,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] ${
-											quickCompleting
-												? "bg-success/25 opacity-100"
-												: "opacity-50 hover:bg-success/20 hover:opacity-100 group-hover:opacity-80"
-										}`}
-									>
-										{/* Both glyphs stay mounted and cross-fade — a hard swap on a
-										    5px-wide target reads as a flicker. */}
-										<span className="relative flex h-3 w-3 items-center justify-center">
-											<span className={`absolute inset-0 h-3 w-3 animate-spin rounded-full border-2 border-success/30 border-t-success transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${quickCompleting ? "opacity-100 scale-100 blur-0" : "opacity-0 scale-[0.25] blur-[4px]"}`} />
-											<CompleteCheckIcon className={`absolute inset-0 h-3 w-3 transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${quickCompleting ? "opacity-0 scale-[0.25] blur-[4px]" : "opacity-100 scale-100 blur-0"}`} />
-										</span>
-									</button>
-								</Tooltip>
-							)}
-						</div>
-					);
-				})()}
-
-				{/* Deferred-launch countdown badge (todo cards with a pending "Start in…") */}
-				{sched && (
-					<div className="relative flex-shrink-0">
-						<Tooltip content={t("task.scheduledTooltip")}>
-							<button
-								data-testid="task-card-scheduled-badge"
-								onClick={(e) => { e.stopPropagation(); setSchedPopoverOpen(!schedPopoverOpen); }}
-								className="flex items-center gap-1 rounded-lg px-1.5 py-1 text-xs text-accent transition-colors hover:bg-fg/5"
-							>
-								<ClockIcon className="w-3 h-3" />
-								{formatCountdown(new Date(sched.at).getTime() - Date.now())}
-							</button>
-						</Tooltip>
-						{schedPopoverOpen && (
-							<div
-								className="absolute bottom-full left-0 mb-1 z-30 min-w-[10rem] rounded-lg border border-edge bg-elevated shadow-lg py-1"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<button
-									onClick={handleStartScheduledNow}
-									className="w-full text-left px-3 py-1.5 text-xs text-fg hover:bg-fg/5 transition-colors"
-								>
-									{t("task.startNow")}
-								</button>
-								<button
-									onClick={handleCancelSchedule}
-									className="w-full text-left px-3 py-1.5 text-xs text-danger hover:bg-fg/5 transition-colors"
-								>
-									{t("task.cancelSchedule")}
-								</button>
-							</div>
-						)}
-					</div>
-				)}
-
-				{/* Scheduled-message countdown chip (live-agent cards with a pending "Send later") */}
-				{!isTodo && <ScheduledMessagesChip task={task} project={project} dispatch={dispatch} placement="up" />}
-
-				{/* PR + merge/review badges for non-active cards */}
-				{!isActive && prBadge}
-				{!isActive && mergeBadge}
-				{!isActive && reviewBadge}
-				{!isActive && commentBadge}
-
-				{/* Sibling variant dots */}
-				<VariantDots
-					groupMembers={groupMembers}
-					currentTaskId={task.id}
-					statusColors={statusColors}
-					agents={agents}
-					navigate={navigate}
-					projectId={project.id}
-					onOpen={preview.close}
-					testId={`variant-indicator-${task.id}`}
-				/>
-
-				{/* Port indicator for active tasks */}
-				{isActive && ports && ports.length > 0 && (
-					<Tooltip content={t.plural("ports.count", ports.length)} detail={t("ttip.task.ports")}>
-						<button
-							ref={portsAnchorRef}
-							onClick={(e) => {
-								e.stopPropagation();
-								if (!portsPopoverOpen && portsAnchorRef.current) {
-									const rect = portsAnchorRef.current.getBoundingClientRect();
-									setPortsPopoverPos({ top: rect.bottom + 6, left: rect.left });
-									setPortsPopoverVisible(false);
-								}
-								setPortsPopoverOpen(!portsPopoverOpen);
-							}}
-							className="inline-flex flex-shrink-0 items-center gap-1 rounded bg-accent/10 px-1.5 py-0.5 font-mono text-[0.625rem] text-accent transition-colors hover:bg-accent/20"
-							aria-label={t.plural("ports.count", ports.length)}
-						>
-							<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF0AC"}</span>
-							{ports.length}
-						</button>
-					</Tooltip>
-				)}
-
-				{/* Resource usage badge */}
-				{isActive && resourceUsage && (
-					<span
-						className={`inline-flex flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[0.625rem] ${
-							resourceUsage.rss > 4 * 1024 * 1024 * 1024
-								? "text-red-400 bg-red-500/10"
-								: resourceUsage.rss > 2 * 1024 * 1024 * 1024
-									? "text-yellow-400 bg-yellow-500/10"
-									: "text-fg-3 bg-fg/5"
-						}`}
-						title={t("resources.details", { cpu: resourceUsage.cpu.toFixed(1), memory: formatBytes(resourceUsage.rss) })}
-					>
-						<span className="text-[0.6875rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-							{"\u{F035B}"}
-						</span>
-						{formatBytes(resourceUsage.rss)}
-						{resourceUsage.cpu >= 1 && (
-							<>
-								<span className="text-fg-muted">·</span>
-								{resourceUsage.cpu.toFixed(0)}%
-							</>
-						)}
-					</span>
-				)}
-
-				{/* Run button for TODO cards — right-aligned. A draft has nothing to run
-				    yet; the lifecycle machine would refuse the launch anyway. */}
-				{isTodo && !isDraft && (
-					<>
-						<div className="flex-1" />
-						<Tooltip content={t("task.run")} detail={t("ttip.task.run")}>
-							<button
-								onClick={(e) => {
-									e.stopPropagation();
-									onLaunchVariants(task, "in-progress");
-								}}
-								className="flex flex-shrink-0 items-center gap-1.5 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm shadow-green-900/30 transition-[background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-green-500"
-								disabled={isDisabled}
-							>
-								{/* Play triangle centred on the viewBox — the usual 8→19 path sits
-								    1.5px right of centre and opens a gap before the label. */}
-								<svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-									<path d="M6 4.5v15l12-7.5z" />
-								</svg>
-								{t("task.run")}
-							</button>
-						</Tooltip>
-					</>
-				)}
-			</div>
-
-			{/* PR / CI / review status badges — their own row so they don't crowd the
-			    action row's Watch / + Variant controls (which previously squeezed them
-			    onto one overflowing line). */}
-			{isActive && (prBadge || mergeBadge || reviewBadge || commentBadge) && (
-				<div data-testid="task-card-status-badges" className="mt-1 flex min-w-0 flex-wrap items-center gap-1">
-					{prBadge}
-					{mergeBadge}
-					{reviewBadge}
-					{commentBadge}
-				</div>
-			)}
-
-			{/* Action row for active tasks — Open in... | Watch | + Variant */}
-			{isActive && (
-				<div data-testid="task-card-action-row" className="mt-1 grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
-					<div className="flex min-w-0 items-center gap-1">
-						{task.worktreePath && (
-							<Tooltip content={t("openIn.menuTitle")} detail={t("ttip.openIn.menu")}>
-								<button
-									onClick={(e) => {
-										e.stopPropagation();
-										const rect = (e.target as HTMLElement).getBoundingClientRect();
-										setCtxMenuPos({ top: rect.bottom + 4, left: rect.left });
-										setCtxMenuOpen(true);
-									}}
-									className="flex flex-shrink-0 items-center gap-1 rounded-lg px-1.5 py-1 text-accent transition-[color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-accent/15"
-									aria-label={t("openIn.menuTitle")}
-								>
-									<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0379}"}</span>
-								</button>
-							</Tooltip>
-						)}
-						<Tooltip content={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")} detail={t("ttip.task.watch")}>
-							<button
-								onClick={async (e) => {
-									e.stopPropagation();
-									try {
-										const updated = await api.request.toggleTaskWatch({
-											taskId: task.id,
-											projectId: project.id,
-											watched: !task.watched,
-										});
-										dispatch({ type: "updateTask", task: updated });
-									} catch {
-										// Toggle failed silently — secondary action
-									}
-								}}
-								className={`flex flex-shrink-0 items-center gap-1 rounded-lg px-1.5 py-1 text-xs transition-[opacity,color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-fg/5 ${
-									task.watched
-										? "text-accent font-medium"
-										: "opacity-0 group-hover:opacity-70 text-fg-3 hover:!opacity-100"
-								}`}
-								aria-label={task.watched ? t("task.unwatchTooltip") : t("task.watchTooltip")}
-								disabled={isDisabled}
-							>
-								<span className="text-[0.75rem] leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-									{task.watched ? "\u{F009A}" : "\u{F0F1C}"}
-								</span>
-								<span className="text-[0.6875rem]">{task.watched ? t("task.watching") : t("task.watch")}</span>
-							</button>
-						</Tooltip>
-					</div>
-					<div className="min-w-0" />
-					<Tooltip content={t("task.addVariant")} detail={t("ttip.task.addVariant")}>
-						<button
-							onClick={(e) => {
-								e.stopPropagation();
-								preview.close();
-								onAddAttempts(task);
-							}}
-							className="flex flex-shrink-0 justify-self-end items-center rounded-lg px-2 py-1 text-xs font-medium text-accent transition-[color,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] hover:bg-accent/15"
-							disabled={isDisabled}
-						>
-							{t("task.addVariant")}
-						</button>
-					</Tooltip>
-				</div>
 			)}
 
 

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -626,9 +626,11 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const configLabel = agentConfig
 		? (agentConfig.model ? `${agentConfig.name} · ${agentConfig.model}` : agentConfig.name)
 		: agent?.name ?? "";
-	const seqLabel = task.variantIndex !== null
-		? `#${task.seq} · ${t("task.attempt", { n: String(task.variantIndex) })}`
-		: `#${task.seq}`;
+	// A lone variant is not a variant — `1/1` says nothing, and the spelled-out
+	// "Variant 1" ate the header room the config string exists for.
+	const variantFraction = task.variantIndex !== null && groupMembers.length > 1
+		? `${task.variantIndex}/${groupMembers.length}`
+		: null;
 	const hasLauncherIcon = agent ? resolveAgentLauncherIcon(agent) !== null : false;
 
 	// ---- SIGNALS zone: read-only facts, grouped git / run / time -------------
@@ -887,10 +889,17 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 			    config string get the whole card instead of 182px next to a rail. */}
 			<div
 				data-testid="task-card-identity"
-				className="flex min-w-0 items-center gap-1.5 border-b border-edge px-2.5 py-1.5"
+				className="flex min-w-0 items-center gap-1.5 border-b border-edge py-1.5 pl-1.5 pr-2.5"
 			>
 				<PriorityBadge priority={task.priority} onChange={handleSetPriority} />
-				<span className="flex-shrink-0 font-mono text-[0.6875rem] font-semibold text-accent">{seqLabel}</span>
+				<span className="flex-shrink-0 font-mono text-[0.6875rem] font-semibold text-accent">
+					#{task.seq}
+					{variantFraction && (
+						<span className="ml-0.5 font-normal text-accent/60" title={t("task.attempt", { n: String(task.variantIndex) })}>
+							{variantFraction}
+						</span>
+					)}
+				</span>
 				{agent && hasLauncherIcon && <AgentLauncherBadge agent={agent} />}
 				{/* No launcher icon means the agent is unidentifiable from the glyph
 				    alone, so its name has to be spelled out. */}

--- a/src/mainview/components/TaskCardRail.tsx
+++ b/src/mainview/components/TaskCardRail.tsx
@@ -1,0 +1,155 @@
+import type { Ref } from "react";
+import type { Project, TaskStatus } from "../../shared/types";
+import { useT, type TranslationKey } from "../i18n";
+import { getStatusLabel } from "../utils/statusLabel";
+import { PIPELINE_STAGES, getPipelineIndex } from "./StatusPipeline";
+import PipelineRing, { CompleteCheckIcon } from "./PipelineRing";
+import Tooltip from "./Tooltip";
+
+/**
+ * How many upright letters a rail can stack before it out-grows a short card.
+ * An upright letter is ~11px tall, and the shortest card body is ~110px once the
+ * ring, the bell slot and the ✓ have taken their share.
+ */
+export const RAIL_LABEL_MAX = 8;
+
+/** Short, uppercase rail forms of the built-in statuses. The full label stays in
+ *  the rail's accessible name and tooltip, and in the Move-to menu. */
+const RAIL_LABEL_KEY: Record<TaskStatus, TranslationKey> = {
+	todo: "status.rail.todo",
+	"in-progress": "status.rail.inProgress",
+	"user-questions": "status.rail.userQuestions",
+	"review-by-ai": "status.rail.reviewByAi",
+	"review-by-user": "status.rail.reviewByUser",
+	"review-by-colleague": "status.rail.reviewByColleague",
+	completed: "status.rail.completed",
+	cancelled: "status.rail.cancelled",
+};
+
+/** A custom column has no short form of its own — clip its name and shout it. */
+export function shortenForRail(name: string): string {
+	return name.slice(0, RAIL_LABEL_MAX).trim().toUpperCase();
+}
+
+interface TaskCardRailProps {
+	status: TaskStatus;
+	project: Project;
+	/** Set when the task sits in a custom column: its own name and dot colour win. */
+	customColumn?: { name: string; color: string } | null;
+	/** STATUS_COLORS[status], or the custom column's colour. Inline-styled — the
+	 *  documented per-status hex exception, same as PipelineRing itself. */
+	color: string;
+	/** Accumulated `dev3 attention` count. Lives here because attention is a
+	 *  lifecycle fact, and a card-corner badge overlapped the ring. */
+	bellCount?: number;
+	/** Rail is inert while the task is preparing, moving, hibernated or tearing down. */
+	disabled?: boolean;
+	canComplete: boolean;
+	completing: boolean;
+	onOpenMenu: (e: React.MouseEvent) => void;
+	onComplete: (e: React.MouseEvent) => void;
+	menuTriggerRef: Ref<HTMLButtonElement>;
+	/** Narrow viewport: widen so both halves clear the 44px touch minimum. */
+	touch?: boolean;
+}
+
+/**
+ * The card's LIFECYCLE zone: everything that changes or reports which column the
+ * task is in, and nothing else. Two stacked buttons rather than one — a ✓ nested
+ * inside the status button would be invalid markup and unreachable by keyboard.
+ */
+export default function TaskCardRail({
+	status,
+	project,
+	customColumn,
+	color,
+	bellCount = 0,
+	disabled = false,
+	canComplete,
+	completing,
+	onOpenMenu,
+	onComplete,
+	menuTriggerRef,
+	touch = false,
+}: TaskCardRailProps) {
+	const t = useT();
+	const stage = getPipelineIndex(status) + 1;
+	const total = PIPELINE_STAGES.length;
+	const fullLabel = customColumn ? customColumn.name : getStatusLabel(status, t, project);
+	const railLabel = customColumn ? shortenForRail(customColumn.name) : t(RAIL_LABEL_KEY[status]);
+	const stageLabel = t("pipeline.stageOf", { current: String(stage), total: String(total) });
+
+	return (
+		<div
+			data-testid="task-card-rail"
+			className={`flex flex-shrink-0 flex-col items-stretch self-stretch rounded-bl-[0.6875rem] ${touch ? "w-12" : "w-[2.375rem]"}`}
+			style={{ background: `${color}22` }}
+		>
+			<Tooltip content={fullLabel} detail={`${stageLabel} · ${t("task.moveTo")}`}>
+				<button
+					ref={menuTriggerRef}
+					type="button"
+					onClick={onOpenMenu}
+					disabled={disabled}
+					aria-label={`${fullLabel} — ${stageLabel}. ${t("task.moveTo")}`}
+					className="flex w-full flex-1 flex-col items-center gap-1.5 rounded-tl-none rounded-bl-none pt-2 pb-1.5 transition-[filter] duration-150 ease-out hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:active:scale-[0.97]"
+				>
+					{customColumn ? (
+						<span
+							className="h-[0.9375rem] w-[0.9375rem] flex-shrink-0 rounded-full"
+							style={{ background: color, boxShadow: `0 0 6px ${color}60` }}
+						/>
+					) : (
+						<PipelineRing status={status} tooltip={false} />
+					)}
+
+					{bellCount > 0 && (
+						<span
+							data-testid="task-card-rail-bell"
+							className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-red-500 px-1 text-[0.625rem] font-bold leading-none text-white shadow-[0_2px_6px_rgb(239_68_68_/_0.45)]"
+						>
+							{bellCount > 9 ? "9+" : bellCount}
+						</span>
+					)}
+
+					{/* Upright stacked letters — read straight down, never rotated. The
+					    accessible name above carries the full label, so the visual
+					    abbreviation is hidden from assistive tech. */}
+					<span
+						aria-hidden="true"
+						className="max-h-32 overflow-hidden font-mono text-[0.625rem] font-extrabold uppercase leading-none tracking-[0.14em] [text-orientation:upright] [writing-mode:vertical-rl]"
+						style={{ color }}
+					>
+						{railLabel}
+					</span>
+				</button>
+			</Tooltip>
+
+			{canComplete && (
+				<Tooltip content={t("pipeline.completeTooltip")} disabled={completing}>
+					<button
+						data-testid="task-card-quick-complete"
+						type="button"
+						onClick={onComplete}
+						disabled={completing}
+						aria-label={t("pipeline.completeTooltip")}
+						className={`flex w-full flex-shrink-0 items-center justify-center rounded-bl-[0.6875rem] text-success transition-[opacity,background-color,transform] duration-150 ease-out motion-safe:active:scale-[0.96] ${touch ? "h-11" : "h-7"} ${
+							completing ? "bg-success/25 opacity-100" : "opacity-70 hover:bg-success/20 hover:opacity-100"
+						}`}
+					>
+						{/* Both glyphs stay mounted and cross-fade — a hard swap on a
+						    12px target reads as a flicker. */}
+						<span className="relative flex h-3.5 w-3.5 items-center justify-center">
+							<span
+								className={`absolute inset-0 h-3.5 w-3.5 animate-spin rounded-full border-2 border-success/30 border-t-success transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${completing ? "opacity-100 scale-100 blur-0" : "opacity-0 scale-[0.25] blur-[4px]"}`}
+							/>
+							<CompleteCheckIcon
+								className={`absolute inset-0 h-3.5 w-3.5 transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${completing ? "opacity-0 scale-[0.25] blur-[4px]" : "opacity-100 scale-100 blur-0"}`}
+							/>
+						</span>
+					</button>
+				</Tooltip>
+			)}
+		</div>
+	);
+}

--- a/src/mainview/components/__tests__/KanbanColumn.test.tsx
+++ b/src/mainview/components/__tests__/KanbanColumn.test.tsx
@@ -593,7 +593,7 @@ describe("KanbanColumn — compact empty column on narrow viewport", () => {
 		const { container } = renderBuiltinColumn({ status: "in-progress", label: "In Progress" });
 		const column = container.querySelector(".glass-column") as HTMLElement;
 		expect(column.className).toMatch(/w-\[6\.125rem\]/);
-		expect(column.className).not.toMatch(/w-\[17\.5rem\]/);
+		expect(column.className).not.toMatch(/w-\[19rem\]/);
 		// "No tasks" placeholder is hidden in compact mode
 		expect(screen.queryByText("No tasks")).toBeNull();
 	});
@@ -602,14 +602,14 @@ describe("KanbanColumn — compact empty column on narrow viewport", () => {
 		setViewport(1200);
 		const { container } = renderBuiltinColumn({ status: "todo", label: "To Do" });
 		const column = container.querySelector(".glass-column") as HTMLElement;
-		expect(column.className).toMatch(/w-\[17\.5rem\]/);
+		expect(column.className).toMatch(/w-\[19rem\]/);
 	});
 
 	it("stays full width when viewport is wide, even if the column is empty", () => {
 		setViewport(1920);
 		const { container } = renderBuiltinColumn({ status: "in-progress", label: "In Progress" });
 		const column = container.querySelector(".glass-column") as HTMLElement;
-		expect(column.className).toMatch(/w-\[17\.5rem\]/);
+		expect(column.className).toMatch(/w-\[19rem\]/);
 		expect(screen.getByText("No tasks")).toBeInTheDocument();
 	});
 
@@ -623,7 +623,7 @@ describe("KanbanColumn — compact empty column on narrow viewport", () => {
 		};
 		const { container } = renderBuiltinColumn({ status: "in-progress", label: "In Progress", tasks: [task] });
 		const column = container.querySelector(".glass-column") as HTMLElement;
-		expect(column.className).toMatch(/w-\[17\.5rem\]/);
+		expect(column.className).toMatch(/w-\[19rem\]/);
 	});
 });
 

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -292,6 +292,24 @@ describe("TaskCard", () => {
 			expect(screen.getByText("#7")).toBeInTheDocument();
 		});
 
+		it("shows a compact N/M fraction when the group really has siblings", () => {
+			const task = makeTask({ seq: 5, variantIndex: 2, groupId: "g1" });
+			renderCard(task, {
+				siblingMap: new Map([[
+					"g1",
+					[task, makeTask({ id: "t2", seq: 5, variantIndex: 1, groupId: "g1" }), makeTask({ id: "t3", seq: 5, variantIndex: 3, groupId: "g1" })],
+				]]),
+			});
+			expect(screen.getByText("2/3")).toBeInTheDocument();
+		});
+
+		it("hides the fraction for a lone variant — 1/1 says nothing", () => {
+			const task = makeTask({ seq: 5, variantIndex: 1, groupId: "g1" });
+			renderCard(task, { siblingMap: new Map([["g1", [task]]]) });
+			expect(screen.queryByText("1/1")).not.toBeInTheDocument();
+			expect(screen.getByText("#5")).toBeInTheDocument();
+		});
+
 		it("shows badge with seq, attempt, agent name and config for variant task", () => {
 			renderCard(makeTask({
 				seq: 5,
@@ -303,7 +321,7 @@ describe("TaskCard", () => {
 				configId: "claude-default",
 				groupId: "g1",
 			}));
-			expect(screen.getByText("#5 · Variant 1")).toBeInTheDocument();
+			expect(screen.getByText("#5")).toBeInTheDocument();
 			expect(screen.getByRole("img", { name: "Claude" })).toBeInTheDocument();
 			expect(screen.getByText("Default · sonnet")).toBeInTheDocument();
 		});
@@ -319,7 +337,7 @@ describe("TaskCard", () => {
 				configId: "codex-default",
 				groupId: "g1",
 			}));
-			expect(screen.getByText("#5 · Variant 2")).toBeInTheDocument();
+			expect(screen.getByText("#5")).toBeInTheDocument();
 			expect(screen.getByRole("img", { name: "Codex" })).toBeInTheDocument();
 			expect(screen.getByText("Default")).toBeInTheDocument();
 		});
@@ -335,7 +353,7 @@ describe("TaskCard", () => {
 				configId: "whatever",
 				groupId: "g1",
 			}));
-			expect(screen.getByText("#5 · Variant 3")).toBeInTheDocument();
+			expect(screen.getByText("#5")).toBeInTheDocument();
 		});
 
 		it("shows agent name without config when configId does not match", () => {
@@ -349,7 +367,7 @@ describe("TaskCard", () => {
 				configId: "nonexistent-config",
 				groupId: "g1",
 			}));
-			expect(screen.getByText("#5 · Variant 1")).toBeInTheDocument();
+			expect(screen.getByText("#5")).toBeInTheDocument();
 			expect(screen.getByRole("img", { name: "Claude" })).toBeInTheDocument();
 		});
 
@@ -386,7 +404,7 @@ describe("TaskCard", () => {
 				</I18nProvider>,
 			);
 			// Seq+attempt and the agent config are separate nodes in the identity header.
-			expect(screen.getByText("#2 · Variant 1")).toBeInTheDocument();
+			expect(screen.getByText("#2")).toBeInTheDocument();
 			expect(screen.getByText("Custom")).toBeInTheDocument();
 			expect(screen.getByText("First · fast")).toBeInTheDocument();
 		});

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -6,6 +6,15 @@ import type { CodingAgent, Label, Project, Task, TaskPRBadgeInfo, TaskStatus } f
 import { getPreparingStageProgress } from "../../../shared/types";
 import type { AppAction, Route } from "../../state";
 
+/**
+ * The lifecycle rail is the status control. Its first button carries the full
+ * column label as its accessible name; the rail only *prints* a short uppercase
+ * form, so tests must not look the trigger up by the full label text.
+ */
+function statusTrigger(): HTMLElement {
+	return within(screen.getByTestId("task-card-rail")).getAllByRole("button")[0];
+}
+
 vi.mock("../../rpc", () => ({
 	api: {
 		request: {
@@ -376,7 +385,9 @@ describe("TaskCard", () => {
 					/>
 				</I18nProvider>,
 			);
-			expect(screen.getByText("#2 · Variant 1 · Custom")).toBeInTheDocument();
+			// Seq+attempt and the agent config are separate nodes in the identity header.
+			expect(screen.getByText("#2 · Variant 1")).toBeInTheDocument();
+			expect(screen.getByText("Custom")).toBeInTheDocument();
 			expect(screen.getByText("First · fast")).toBeInTheDocument();
 		});
 	});
@@ -387,7 +398,9 @@ describe("TaskCard", () => {
 
 			expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
 			expect(screen.getByText("Run")).toBeInTheDocument();
-			expect(screen.getByText("To Do")).toBeInTheDocument();
+			// The rail prints the short form; the full column label is its a11y name.
+			expect(screen.getByText("TODO")).toBeInTheDocument();
+			expect(statusTrigger()).toHaveAccessibleName(/To Do/);
 		});
 
 		it("Run button triggers onLaunchVariants with in-progress", async () => {
@@ -513,7 +526,7 @@ describe("TaskCard", () => {
 			const user = userEvent.setup();
 			renderCard(makeTask({ status: "todo" }));
 
-			await user.click(screen.getByText("To Do"));
+			await user.click(statusTrigger());
 
 			expect(screen.getByText("Agent is Working")).toBeInTheDocument();
 			expect(screen.getByText("Cancelled")).toBeInTheDocument();
@@ -525,7 +538,7 @@ describe("TaskCard", () => {
 			const task = makeTask({ status: "todo" });
 			renderCard(task, { onLaunchVariants });
 
-			await user.click(screen.getByText("To Do"));
+			await user.click(statusTrigger());
 			await user.click(screen.getByText("Agent is Working"));
 
 			expect(onLaunchVariants).toHaveBeenCalledWith(task, "in-progress");
@@ -570,7 +583,7 @@ describe("TaskCard", () => {
 			const user = userEvent.setup();
 			renderCard(makeTask({ status: "cancelled" }));
 
-			await user.click(screen.getByText("Cancelled"));
+			await user.click(statusTrigger());
 
 			expect(screen.getByText("Delete")).toBeInTheDocument();
 		});
@@ -581,7 +594,7 @@ describe("TaskCard", () => {
 			const user = userEvent.setup();
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }));
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 
 			expect(screen.getByText("To Do")).toBeInTheDocument();
 			expect(screen.getByText("Completed")).toBeInTheDocument();
@@ -600,11 +613,11 @@ describe("TaskCard", () => {
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }));
 
 			// Click the status trigger button (first match — the card's status button)
-			await user.click(screen.getAllByText("Agent is Working")[0]);
+			await user.click(statusTrigger());
 			expect(screen.getByText("Move to")).toBeInTheDocument();
 
 			// Click the trigger again to close — it's still the first match
-			await user.click(screen.getAllByText("Agent is Working")[0]);
+			await user.click(statusTrigger());
 			expect(screen.queryByText("Move to")).not.toBeInTheDocument();
 		});
 	});
@@ -639,7 +652,7 @@ describe("TaskCard", () => {
 			const user = userEvent.setup();
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }));
 
-			await user.click(screen.getAllByText("Agent is Working")[0]);
+			await user.click(statusTrigger());
 
 			const sheet = screen.getByTestId("task-status-sheet");
 			expect(within(sheet).getByText("Move to")).toBeInTheDocument();
@@ -654,7 +667,7 @@ describe("TaskCard", () => {
 			mockedApi.request.moveTask.mockResolvedValue({ ...task, status: "user-questions" });
 			renderCard(task, { navigate });
 
-			await user.click(screen.getAllByText("Agent is Working")[0]);
+			await user.click(statusTrigger());
 			await user.click(within(screen.getByTestId("task-status-sheet")).getByText("Has Questions"));
 
 			await waitFor(() => {
@@ -847,7 +860,7 @@ describe("TaskCard", () => {
 				description: "This is a much longer description that differs from title",
 			}));
 
-			expect(screen.getByText("Show full description")).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Show full description" })).toBeInTheDocument();
 		});
 
 		it("does not show description button when title equals description", () => {
@@ -859,7 +872,7 @@ describe("TaskCard", () => {
 				description: "Same",
 			}));
 
-			expect(screen.queryByText("Show full description")).not.toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: "Show full description" })).not.toBeInTheDocument();
 		});
 
 		it("does not show description button for todo tasks even with long description", () => {
@@ -869,7 +882,7 @@ describe("TaskCard", () => {
 				description: "This is a much longer description that differs from title",
 			}));
 
-			expect(screen.queryByText("Show full description")).not.toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: "Show full description" })).not.toBeInTheDocument();
 		});
 
 		it("clicking description button opens detail modal", async () => {
@@ -882,7 +895,7 @@ describe("TaskCard", () => {
 				description: "Long description different from title",
 			}));
 
-			await user.click(screen.getByText("Show full description"));
+			await user.click(screen.getByRole("button", { name: "Show full description" }));
 
 			expect(screen.getByTestId("task-detail-modal")).toBeInTheDocument();
 		});
@@ -896,7 +909,7 @@ describe("TaskCard", () => {
 				description: "This is a much longer description that differs from title",
 			}));
 
-			await user.click(screen.getByText("Show full description"));
+			await user.click(screen.getByRole("button", { name: "Show full description" }));
 
 			expect(screen.getByTestId("task-detail-modal")).toBeInTheDocument();
 		});
@@ -914,7 +927,7 @@ describe("TaskCard", () => {
 			const runButton = screen.getByRole("button", { name: "Run" });
 			expect(runButton).toBeDisabled();
 
-			await user.click(screen.getByText("Show full description"));
+			await user.click(screen.getByRole("button", { name: "Show full description" }));
 
 			expect(onLaunchVariants).not.toHaveBeenCalled();
 		});
@@ -1107,7 +1120,7 @@ describe("TaskCard", () => {
 
 			renderCard(task, { dispatch, onTaskMoved });
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 			await user.click(screen.getByText("Completed"));
 
 			await waitFor(() => {
@@ -1142,7 +1155,7 @@ describe("TaskCard", () => {
 
 			renderCard(task, { dispatch });
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 			await user.click(screen.getByText("Cancelled"));
 
 			await waitFor(() => {
@@ -1166,7 +1179,7 @@ describe("TaskCard", () => {
 
 			renderCard(task, { dispatch, onTaskMoved });
 
-			await user.click(screen.getByText("Has Questions"));
+			await user.click(statusTrigger());
 			await user.click(screen.getByText("Agent is Working"));
 
 			await waitFor(() => {
@@ -1200,7 +1213,7 @@ describe("TaskCard", () => {
 
 			renderCard(task);
 
-			await user.click(screen.getByText("Has Questions"));
+			await user.click(statusTrigger());
 			await user.click(screen.getByText("Agent is Working"));
 
 			await waitFor(() => {
@@ -1357,7 +1370,7 @@ describe("TaskCard", () => {
 			const user = userEvent.setup();
 			renderCard(makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/test" }));
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 			expect(screen.getByText("Move to")).toBeInTheDocument();
 
 			// Click outside the menu
@@ -1380,7 +1393,7 @@ describe("TaskCard", () => {
 			renderCard(task, { dispatch });
 
 			// Open status dropdown
-			await user.click(screen.getByText("Cancelled"));
+			await user.click(statusTrigger());
 
 			// Click "Delete" in the dropdown — it's the button with danger text styling
 			const allDeleteBtns = screen.getAllByText("Delete");
@@ -1465,7 +1478,7 @@ describe("TaskCard", () => {
 				{ projectOverride: projectWithCustomColumns },
 			);
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 
 			await waitFor(() => {
 				expect(screen.getByText("On Hold")).toBeInTheDocument();
@@ -1484,7 +1497,7 @@ describe("TaskCard", () => {
 				{ projectOverride: projectWithCustomColumns, dispatch },
 			);
 
-			await user.click(screen.getByText("Agent is Working"));
+			await user.click(statusTrigger());
 
 			await waitFor(() => {
 				expect(screen.getByText("On Hold")).toBeInTheDocument();
@@ -1509,7 +1522,7 @@ describe("TaskCard", () => {
 			);
 
 			// Card status button now shows custom column name instead of built-in status
-			await user.click(screen.getByText("On Hold"));
+			await user.click(statusTrigger());
 
 			await waitFor(() => {
 				expect(screen.getByText("Blocked")).toBeInTheDocument();
@@ -1526,7 +1539,7 @@ describe("TaskCard", () => {
 	});
 
 	describe("PR badge", () => {
-		it("wraps crowded completed-card footer badges instead of overlapping them", () => {
+		it("wraps crowded completed-card signal badges instead of overlapping them", () => {
 			renderCard(makeTask({ status: "completed" }), {
 				prInfo: {
 					number: 42,
@@ -1537,7 +1550,7 @@ describe("TaskCard", () => {
 				},
 			});
 
-			expect(screen.getByTestId("task-card-footer")).toHaveClass("flex-wrap");
+			expect(screen.getByTestId("task-card-signals")).toHaveClass("flex-wrap");
 		});
 
 		it("renders the PR badge in its own status-badge row for active tasks", () => {
@@ -1546,11 +1559,11 @@ describe("TaskCard", () => {
 			});
 
 			const badge = screen.getByText("#42").closest("button");
-			// Badge lives in the dedicated status-badge row, not crammed into the
-			// action row (Watch / + Variant) or the footer.
+			// The badge belongs to the git compartment of the signal strip, never to
+			// the reserved action strip (Open in / Watch / + Variant).
 			expect(screen.getByTestId("task-card-status-badges")).toContainElement(badge);
+			expect(screen.getByTestId("task-card-signals")).toContainElement(badge);
 			expect(screen.getByTestId("task-card-action-row")).not.toContainElement(badge);
-			expect(screen.getByTestId("task-card-footer")).not.toContainElement(badge);
 		});
 
 		it("shows PR badge when prInfo is provided", () => {
@@ -2033,7 +2046,8 @@ describe("TaskCard — drafts", () => {
 		const onLaunchVariants = vi.fn();
 		renderCard(makeTask({ draft: true }), { onEditDraft: vi.fn(), onLaunchVariants });
 
-		await userEvent.click(screen.getAllByText("To Do")[0]);
+		await userEvent.click(statusTrigger());
+		// The second click is on the menu's "Agent is Working" row, not the rail.
 		await userEvent.click(screen.getByText("Agent is Working"));
 
 		expect(onLaunchVariants).not.toHaveBeenCalled();
@@ -2084,7 +2098,7 @@ describe("hibernated card", () => {
 
 	it("refuses to open the status menu, so the column cannot be changed", () => {
 		const { container } = renderCard(hibernated());
-		const trigger = container.querySelector("[data-testid='task-card-footer'] button");
+		const trigger = container.querySelector("[data-testid='task-card-rail'] button");
 
 		expect(trigger).toBeDisabled();
 	});

--- a/src/mainview/components/__tests__/TaskCardSeq.test.tsx
+++ b/src/mainview/components/__tests__/TaskCardSeq.test.tsx
@@ -81,7 +81,7 @@ describe("TaskCard — seq display", () => {
 		expect(screen.getByText("#7")).toBeInTheDocument();
 	});
 
-	it("variant task shows #N · Variant M · Agent format", () => {
+	it("variant task with no sibling data shows the bare #N", () => {
 		renderCard(makeTask({
 			seq: 3,
 			status: "in-progress",
@@ -92,7 +92,7 @@ describe("TaskCard — seq display", () => {
 			configId: "claude-default",
 			groupId: "g1",
 		}));
-		expect(screen.getByText("#3 · Variant 2")).toBeInTheDocument();
+		expect(screen.getByText("#3")).toBeInTheDocument();
 		expect(screen.getByRole("img", { name: "Claude" })).toBeInTheDocument();
 		expect(screen.getByText("Default · sonnet")).toBeInTheDocument();
 	});

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -68,6 +68,17 @@ const common = {
 	"status.completed": "Completed",
 	"status.cancelled": "Cancelled",
 
+	// Short uppercase forms for the task card's vertical lifecycle rail. Max 8
+	// upright letters — the full label stays in the rail's accessible name.
+	"status.rail.todo": "TODO",
+	"status.rail.inProgress": "WORKING",
+	"status.rail.userQuestions": "ASKING",
+	"status.rail.reviewByAi": "AI",
+	"status.rail.reviewByUser": "REVIEW",
+	"status.rail.reviewByColleague": "PR",
+	"status.rail.completed": "DONE",
+	"status.rail.cancelled": "CANCEL",
+
 	// Status descriptions (info tooltips for column headers)
 	"status.todo.desc": "Tasks waiting to be picked up by an agent.",
 	"status.inProgress.desc": "An AI agent is actively working on this task.",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -68,6 +68,17 @@ const common = {
 	"status.completed": "Completado",
 	"status.cancelled": "Cancelado",
 
+	// Formas cortas para el riel vertical de la tarjeta. Máximo 8 letras —
+	// el nombre completo permanece en el nombre accesible del riel.
+	"status.rail.todo": "TODO",
+	"status.rail.inProgress": "TRABAJA",
+	"status.rail.userQuestions": "PREGUNTA",
+	"status.rail.reviewByAi": "IA",
+	"status.rail.reviewByUser": "REVISIÓN",
+	"status.rail.reviewByColleague": "PR",
+	"status.rail.completed": "LISTO",
+	"status.rail.cancelled": "CANCELA",
+
 	// Status descriptions (info tooltips for column headers)
 	"status.todo.desc": "Tareas esperando ser asignadas a un agente.",
 	"status.inProgress.desc": "Un agente de IA está trabajando activamente en esta tarea.",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -68,6 +68,17 @@ const common = {
 	"status.completed": "Завершено",
 	"status.cancelled": "Отменено",
 
+	// Короткие формы для вертикального рельса карточки. Максимум 8 букв —
+	// полное название остаётся в доступном имени рельса.
+	"status.rail.todo": "ТУДУ",
+	"status.rail.inProgress": "РАБОТА",
+	"status.rail.userQuestions": "ВОПРОС",
+	"status.rail.reviewByAi": "ИИ",
+	"status.rail.reviewByUser": "РЕВЬЮ",
+	"status.rail.reviewByColleague": "PR",
+	"status.rail.completed": "ГОТОВО",
+	"status.rail.cancelled": "ОТМЕНА",
+
 	// Status descriptions (info tooltips for column headers)
 	"status.todo.desc": "Задачи, ожидающие назначения агенту.",
 	"status.inProgress.desc": "ИИ-агент активно работает над задачей.",


### PR DESCRIPTION
The task card had grown a badge for every feature and no rule about where anything belongs. This rebuilds it around an explicit five-zone contract, each zone with one admission rule.

**LIFECYCLE** — a new `TaskCardRail` on the left edge, tinted with the column colour: the pipeline ring, the attention count, the column name as upright stacked letters (never rotated), and quick-complete at the bottom. Clicking anywhere on it opens Move to. Two stacked buttons rather than one, so the check stays reachable by keyboard.

**IDENTITY** — a full-width header row above the rail, so the agent and config string get the whole card instead of 182px beside a rail. Priority badge unchanged, sitting closer to the card edge.

**CONTENT** — title and labels, with the full-description affordance moved onto the label row.

**SIGNALS** — read-only facts in one wrapping strip, sub-grouped git / run / time with hairline dividers.

**ACTIONS** — a reserved strip welded to the card's bottom edge, so badges can no longer squeeze the buttons out.

Also: a variant task shows a compact `2/3` next to its number instead of a spelled-out "Variant 2", and nothing at all when it is its own only variant; board columns grow from 280px to 304px.

Short rail labels are added to all three locales. Zone model recorded in `docs/ux/ux-architecture.yaml` and `decisions/199-task-card-five-zone-layout.md`.