### PR TITLE
Cut two redundant whole-file reads per task save (I/O only — does not fix freezes or per-mutation blocking)

### DIFF
--- a/change-logs/2026/08/04/fix-task-store-burst-io.md
+++ b/change-logs/2026/08/04/fix-task-store-burst-io.md
@@ -1,0 +1,7 @@
+Short: Fewer whole-file reads per task save
+
+The hourly task-store backup now checks with a stat() whether this hour is already
+snapshotted, instead of reading both the board and the existing backup in full before every
+save. On a 1509-task project a burst of ten saves moves 74 MB instead of 221 MB, with the
+same once-per-hour snapshot; a save that crosses an hour boundary is now filed under the hour
+it started in, and expired backups are pruned when the next snapshot is written.

--- a/decisions/204-task-store-burst-read-reduction.md
+++ b/decisions/204-task-store-burst-read-reduction.md
@@ -1,0 +1,21 @@
+# 204 — Decide the hourly tasks backup with stat(), not two full reads
+
+## Context
+
+The hourly backup read the store, then the existing backup. Once this hour's snapshot exists both are redundant; only the hour's first save needs that content.
+
+## Investigation
+
+The `perf:task-store` harness saw no stall above 16 ms, so the freezes reported were **not reproduced here**. Of the 221 MB ten mutations moved, ~148 MB was those two reads; 74 MB of mutator reads stays, blocking unchanged.
+
+## Decision
+
+`writeHourlyTasksBackup` answers "is this hour covered" with `stat()`, reads the store only when about to snapshot, and prunes only when it wrote one. The hour is captured before that read, so a boundary-spanning read stays in its start hour.
+
+## Risks
+
+Expired backups stay until the next snapshot is written, and a save crossing an hour boundary buckets an hour earlier. Every mutation still parses, stringifies and publishes the store; no cache or write path is touched.
+
+## Alternatives considered
+
+Serving mutators from cache was built twice and dropped: a cached value may only reach a writer if parsed from the published bytes, reinstating the parse and worsening the stall tail (see the task notes). Removing the per-mutation stringify and publish needs coalescing and a durability design.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"test:full": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && concurrently --group --names mainview,bun,cli \"$VT vitest run\" \"$VT vitest run --config vitest.config.bun.ts\" \"$VT vitest run --config vitest.config.cli.ts\"",
 		"test:bun": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.bun.ts",
 		"test:cli": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.cli.ts",
+		"perf:task-store": "bun src/bun/__tests__/task-store-burst.bun-perf.ts",
 		"test:pane-e2e": "bun --preload ./src/bun/__tests__/pane-exit-e2e-preload.ts src/bun/__tests__/pane-exit-e2e.ts",
 		"test:proto-e2e": "bun src/bun/prototypes/detached-pty/__tests__/lifecycle.bun-e2e.ts",
 		"test:native-registry-e2e": "bun src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts",

--- a/src/bun/__tests__/data-hourly-backup-io.test.ts
+++ b/src/bun/__tests__/data-hourly-backup-io.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import type { Task } from "../../shared/types";
+import { buildFixtureTasks, fixtureProject, FIXTURE_PROJECT_SLUG } from "./task-store-fixture";
+
+/**
+ * The hourly tasks backup answers "is this hour covered" with stat(), not by reading
+ * two whole files. Counts, not timings, so it holds in CI; cadence, content and the
+ * hour the snapshot is filed under are asserted so the saving cannot cost a snapshot.
+ */
+
+const { testHome } = vi.hoisted(() => ({ testHome: `${process.env.DEV3_TEST_ROOT}/data-hourly-backup-io` }));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../paths", () => ({ DEV3_HOME: testHome, OPS_DIR: `${testHome}/ops` }));
+vi.mock("../cow-clone", () => ({ detectClonePaths: vi.fn(() => Promise.resolve([])) }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+
+import { readFile } from "node:fs/promises";
+import { _resetDataCaches, loadTasks, updateTask } from "../data";
+
+const DATA_DIR = `${testHome}/data/${FIXTURE_PROJECT_SLUG}`;
+const TASKS_FILE = `${DATA_DIR}/tasks.json`;
+const BACKUP_DIR = `${DATA_DIR}/tasks-backups`;
+const TASK_COUNT = 60;
+const BURST = 10;
+
+const project = fixtureProject();
+const fixture = buildFixtureTasks(TASK_COUNT);
+
+const readPaths = () =>
+	vi.mocked(readFile).mock.calls.map((call) => String(call[0]));
+const backups = () => readdirSync(BACKUP_DIR).filter((name) => name.endsWith(".json")).sort();
+
+beforeEach(() => {
+	rmSync(testHome, { recursive: true, force: true });
+	mkdirSync(DATA_DIR, { recursive: true });
+	writeFileSync(TASKS_FILE, JSON.stringify(fixture, null, 2));
+	writeFileSync(`${testHome}/projects.json`, JSON.stringify([project], null, 2));
+	_resetDataCaches();
+	vi.mocked(readFile).mockClear();
+});
+
+describe("hourly tasks backup I/O", () => {
+	it("never reads an existing backup file to decide whether this hour is covered", async () => {
+		await updateTask(project, fixture[0].id, { overview: "first" });
+		expect(backups()).toHaveLength(1);
+		vi.mocked(readFile).mockClear();
+
+		for (let i = 1; i < BURST; i++) {
+			await updateTask(project, fixture[i].id, { overview: `burst-${i}` });
+		}
+
+		// Zero reads of anything under tasks-backups/, and the store is read once per
+		// mutation for the mutator load — never a second time to feed the backup.
+		expect(readPaths().filter((path) => path.includes("tasks-backups"))).toEqual([]);
+		expect(readPaths().filter((path) => path === TASKS_FILE)).toHaveLength(BURST - 1);
+	});
+
+	it("still snapshots once per hour, from the state before that hour's first save", async () => {
+		const beforeAnySave = readFileSync(TASKS_FILE, "utf8");
+
+		await updateTask(project, fixture[0].id, { overview: "first" });
+		await updateTask(project, fixture[1].id, { overview: "second" });
+
+		const files = backups();
+		expect(files).toHaveLength(1);
+		expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/);
+		expect(readFileSync(`${BACKUP_DIR}/${files[0]}`, "utf8")).toBe(beforeAnySave);
+	});
+
+	it("keeps a snapshot already taken this hour untouched", async () => {
+		await updateTask(project, fixture[0].id, { overview: "first" });
+		const [name] = backups();
+		const snapshot = readFileSync(`${BACKUP_DIR}/${name}`, "utf8");
+
+		await updateTask(project, fixture[2].id, { overview: "third" });
+
+		expect(backups()).toEqual([name]);
+		expect(readFileSync(`${BACKUP_DIR}/${name}`, "utf8")).toBe(snapshot);
+	});
+
+	it("files the snapshot under the hour that was current when the backup began", async () => {
+		// The hour is now chosen before the snapshot's own read of the store, so a read
+		// spanning the boundary lands in the hour the backup entered. The old code chose
+		// it after that read and would have filed the same save an hour later.
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-08-04T10:59:59.900Z"));
+			let storeReads = 0;
+			vi.mocked(readFile).mockImplementation(async (path, options) => {
+				// Read 1 is the mutator load, read 2 is the snapshot's own read.
+				if (String(path) === TASKS_FILE && ++storeReads === 2) {
+					vi.setSystemTime(new Date("2026-08-04T11:00:00.100Z"));
+				}
+				const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+				return actual.readFile(path as never, options as never);
+			});
+
+			await updateTask(project, fixture[0].id, { overview: "boundary" });
+
+			expect(storeReads).toBe(2);
+			expect(backups()).toEqual(["2026-08-04T10Z.json"]);
+		} finally {
+			vi.useRealTimers();
+			vi.mocked(readFile).mockRestore();
+		}
+	});
+
+	it("loses no mutation and keeps the store's on-disk format", async () => {
+		const target = fixture[4];
+		for (let i = 1; i <= BURST; i++) {
+			const current = (await loadTasks(project)).find((t) => t.id === target.id);
+			await updateTask(project, target.id, { overview: `${current?.overview ?? ""}|${i}` });
+		}
+
+		const content = readFileSync(TASKS_FILE, "utf8");
+		const persisted = JSON.parse(content) as Task[];
+		expect(persisted).toHaveLength(TASK_COUNT);
+		expect(persisted.find((t) => t.id === target.id)?.overview).toBe(`${target.overview}|1|2|3|4|5|6|7|8|9|10`);
+		expect(content.startsWith("[\n  {\n")).toBe(true);
+		expect(content).toBe(JSON.stringify(persisted, null, 2));
+	});
+});

--- a/src/bun/__tests__/task-store-burst.bun-perf.ts
+++ b/src/bun/__tests__/task-store-burst.bun-perf.ts
@@ -1,0 +1,387 @@
+/**
+ * Burst profiler for the real task-store seam (`bun run perf:task-store`). Private
+ * HOME, seeded fixture, never touches the real store; there is no fsync on this path,
+ * so nothing here speaks to crash durability. See the closing note for scope.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { tmpdir } from "node:os";
+
+// require, not a static import: a static `node:fs` binding materialises the builtin
+// namespace and the instrumentation below would never be seen by the app modules.
+const { mkdirSync, rmSync, writeFileSync, statSync } = require("node:fs");
+import { buildFixtureTasks, fixtureProject, FIXTURE_PROJECT_SLUG } from "./task-store-fixture";
+
+const TASK_COUNT = Number(process.env.PERF_TASK_COUNT ?? 1509);
+const BURST_SIZE = Number(process.env.PERF_BURST_SIZE ?? 10);
+const BURST_SPREAD_MS = Number(process.env.PERF_BURST_SPREAD_MS ?? 600);
+const ROUNDS = Number(process.env.PERF_ROUNDS ?? 3);
+
+// ---- private HOME (must be set before ./paths is ever imported) ----
+
+const home = `${tmpdir()}/dev3-task-store-perf-${process.pid}`;
+rmSync(home, { recursive: true, force: true });
+process.env.HOME = home;
+process.env.DEV3_LOG_LEVEL ??= "error";
+const dataDir = `${home}/.dev3.0/data/${FIXTURE_PROJECT_SLUG}`;
+mkdirSync(dataDir, { recursive: true });
+
+const project = fixtureProject();
+const tasks = buildFixtureTasks(TASK_COUNT);
+const tasksFile = `${dataDir}/tasks.json`;
+const fixtureJson = JSON.stringify(tasks, null, 2);
+writeFileSync(tasksFile, fixtureJson);
+writeFileSync(`${home}/.dev3.0/projects.json`, JSON.stringify([project], null, 2));
+
+// ---- instrumentation ----
+
+interface JsonStats {
+	parseCalls: number;
+	parseMs: number;
+	parseBytes: number;
+	stringifyCalls: number;
+	stringifyMs: number;
+	stringifyBytes: number;
+}
+
+const json: JsonStats = {
+	parseCalls: 0, parseMs: 0, parseBytes: 0,
+	stringifyCalls: 0, stringifyMs: 0, stringifyBytes: 0,
+};
+
+/** Only count whole-store work; small log/config payloads are noise. */
+const BIG = 100_000;
+const origParse = JSON.parse;
+const origStringify = JSON.stringify;
+JSON.parse = ((text: string, ...rest: unknown[]) => {
+	const big = typeof text === "string" && text.length >= BIG;
+	if (!big) return (origParse as any)(text, ...rest);
+	const t0 = Bun.nanoseconds();
+	const out = (origParse as any)(text, ...rest);
+	json.parseCalls++;
+	json.parseMs += (Bun.nanoseconds() - t0) / 1e6;
+	json.parseBytes += text.length;
+	return out;
+}) as typeof JSON.parse;
+JSON.stringify = ((value: unknown, ...rest: unknown[]) => {
+	const t0 = Bun.nanoseconds();
+	const out = (origStringify as any)(value, ...rest);
+	if (typeof out === "string" && out.length >= BIG) {
+		json.stringifyCalls++;
+		json.stringifyMs += (Bun.nanoseconds() - t0) / 1e6;
+		json.stringifyBytes += out.length;
+	}
+	return out;
+}) as typeof JSON.stringify;
+
+function resetJson(): void {
+	json.parseCalls = 0; json.parseMs = 0; json.parseBytes = 0;
+	json.stringifyCalls = 0; json.stringifyMs = 0; json.stringifyBytes = 0;
+}
+
+/** Disk volume moved, plus how long publishing took: writeFile + rename, no fsync. */
+interface IoStats {
+	reads: number;
+	readBytes: number;
+	writes: number;
+	writeBytes: number;
+	/** writeFile + rename per save, in ms. Excludes stat and cache priming. */
+	writeMs: number[];
+}
+
+const io: IoStats = { reads: 0, readBytes: 0, writes: 0, writeBytes: 0, writeMs: [] };
+
+function resetIo(): void {
+	io.reads = 0; io.readBytes = 0; io.writes = 0; io.writeBytes = 0; io.writeMs = [];
+}
+
+{
+	const fsp = require("node:fs/promises");
+	const origRead = fsp.readFile;
+	const origWrite = fsp.writeFile;
+	fsp.readFile = async (path: any, ...rest: any[]) => {
+		const out = await origRead(path, ...rest);
+		if (String(path).includes("/data/")) {
+			io.reads++;
+			io.readBytes += typeof out === "string" ? out.length : out.byteLength;
+		}
+		return out;
+	};
+	const origRename = fsp.rename;
+	fsp.writeFile = async (path: any, content: any, ...rest: any[]) => {
+		const track = String(path).includes("/data/");
+		if (!track) return origWrite(path, content, ...rest);
+		io.writes++;
+		io.writeBytes += typeof content === "string" ? content.length : content.byteLength;
+		const t0 = Bun.nanoseconds();
+		const out = await origWrite(path, content, ...rest);
+		pendingWriteMs = (Bun.nanoseconds() - t0) / 1e6;
+		return out;
+	};
+	fsp.rename = async (from: any, to: any) => {
+		const track = String(to).includes("/data/");
+		const t0 = Bun.nanoseconds();
+		const out = await origRename(from, to);
+		if (track) {
+			io.writeMs.push(pendingWriteMs + (Bun.nanoseconds() - t0) / 1e6);
+			pendingWriteMs = 0;
+		}
+		return out;
+	};
+}
+
+let pendingWriteMs = 0;
+
+/**
+ * File-lock cost, split into the two things it actually charges: sync time inside
+ * the mkdir/rmdir syscalls, and the queueing wait each caller spent from its first
+ * EEXIST to acquiring the lock (tracked per mutation through AsyncLocalStorage).
+ */
+interface LockStats {
+	acquires: number;
+	collisions: number;
+	syncMs: number;
+	waitMs: number[];
+}
+
+const lock: LockStats = { acquires: 0, collisions: 0, syncMs: 0, waitMs: [] };
+const lockCtx = new AsyncLocalStorage<{ firstFail: number }>();
+
+function resetLock(): void {
+	lock.acquires = 0; lock.collisions = 0; lock.syncMs = 0; lock.waitMs = [];
+}
+
+{
+	const fsSync = require("node:fs");
+	const origMkdir = fsSync.mkdirSync;
+	const origRmdir = fsSync.rmdirSync;
+	fsSync.mkdirSync = (p: any, ...rest: any[]) => {
+		if (!String(p).endsWith(".lock")) return origMkdir(p, ...rest);
+		const ctx = lockCtx.getStore();
+		const t0 = Bun.nanoseconds();
+		try {
+			const out = origMkdir(p, ...rest);
+			lock.acquires++;
+			if (ctx) lock.waitMs.push(ctx.firstFail ? (Bun.nanoseconds() - ctx.firstFail) / 1e6 : 0);
+			return out;
+		} catch (err: any) {
+			if (err?.code === "EEXIST") {
+				lock.collisions++;
+				if (ctx && !ctx.firstFail) ctx.firstFail = Bun.nanoseconds();
+			}
+			throw err;
+		} finally {
+			lock.syncMs += (Bun.nanoseconds() - t0) / 1e6;
+		}
+	};
+	fsSync.rmdirSync = (p: any, ...rest: any[]) => {
+		if (!String(p).endsWith(".lock")) return origRmdir(p, ...rest);
+		const t0 = Bun.nanoseconds();
+		try {
+			return origRmdir(p, ...rest);
+		} finally {
+			lock.syncMs += (Bun.nanoseconds() - t0) / 1e6;
+		}
+	};
+}
+
+/** Event-loop delay sampler: how long a 2 ms timer was actually starved. */
+class LoopSampler {
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private last = 0;
+	readonly samples: number[] = [];
+	start(): void {
+		this.samples.length = 0;
+		this.last = Bun.nanoseconds();
+		this.timer = setInterval(() => {
+			const now = Bun.nanoseconds();
+			this.samples.push((now - this.last) / 1e6 - 2);
+			this.last = now;
+		}, 2);
+	}
+	stop(): void {
+		if (this.timer) clearInterval(this.timer);
+		this.timer = null;
+	}
+	stats() {
+		const s = [...this.samples].sort((a, b) => a - b);
+		const at = (q: number) => (s.length ? s[Math.min(s.length - 1, Math.floor(s.length * q))] : 0);
+		return {
+			count: s.length,
+			p50: at(0.5),
+			p99: at(0.99),
+			max: s.length ? s[s.length - 1] : 0,
+			over16: s.filter((v) => v > 16).length,
+			over50: s.filter((v) => v > 50).length,
+			blockedMs: s.filter((v) => v > 2).reduce((a, b) => a + b, 0),
+		};
+	}
+}
+
+function pct(values: number[], q: number): number {
+	if (!values.length) return 0;
+	const s = [...values].sort((a, b) => a - b);
+	return s[Math.min(s.length - 1, Math.floor(s.length * q))];
+}
+
+const fmt = (n: number) => n.toFixed(2);
+
+// ---- the harness ----
+
+const data = await import("../data");
+
+function restoreFixture(): void {
+	writeFileSync(tasksFile, fixtureJson);
+	data._resetDataCaches();
+}
+
+interface RoundResult {
+	label: string;
+	burstMs: number;
+	mutationMs: number[];
+	loop: ReturnType<LoopSampler["stats"]>;
+	json: JsonStats;
+	io: IoStats;
+	lock: LockStats;
+	fileBytes: number;
+}
+
+async function runRound(label: string, drive: () => Promise<void>): Promise<RoundResult> {
+	restoreFixture();
+	resetJson();
+	resetIo();
+	resetLock();
+	const sampler = new LoopSampler();
+	sampler.start();
+	const t0 = Bun.nanoseconds();
+	await drive();
+	const burstMs = (Bun.nanoseconds() - t0) / 1e6;
+	sampler.stop();
+	return {
+		label,
+		burstMs,
+		mutationMs: [...mutationMs],
+		loop: sampler.stats(),
+		json: { ...json },
+		io: { ...io, writeMs: [...io.writeMs] },
+		lock: { ...lock, waitMs: [...lock.waitMs] },
+		fileBytes: statSync(tasksFile).size,
+	};
+}
+
+let mutationMs: number[] = [];
+
+/** Sequential burst on ONE task — the ordering/lossless correctness scenario. */
+async function sequentialBurst(): Promise<void> {
+	mutationMs = [];
+	const target = tasks[Math.floor(tasks.length / 2)];
+	for (let i = 1; i <= BURST_SIZE; i++) {
+		const t0 = Bun.nanoseconds();
+		const current = await data.getTask(project, target.id);
+		await lockCtx.run({ firstFail: 0 }, () =>
+			data.updateTask(project, target.id, { overview: `${current.overview ?? ""}|${i}` }),
+		);
+		mutationMs.push((Bun.nanoseconds() - t0) / 1e6);
+	}
+}
+
+/** Distinct, evenly-spread targets so a burst touches the whole store. */
+function burstTargetIndex(i: number): number {
+	return Math.floor((i * TASK_COUNT) / BURST_SIZE);
+}
+
+/** Concurrent burst spread over BURST_SPREAD_MS — the live latency scenario. */
+async function concurrentBurst(): Promise<void> {
+	mutationMs = [];
+	const step = BURST_SPREAD_MS / BURST_SIZE;
+	const inflight: Promise<void>[] = [];
+	for (let i = 0; i < BURST_SIZE; i++) {
+		const target = tasks[burstTargetIndex(i)];
+		inflight.push(
+			(async () => {
+				await Bun.sleep(i * step);
+				const t0 = Bun.nanoseconds();
+				await lockCtx.run({ firstFail: 0 }, () => data.updateTask(project, target.id, { overview: `burst-${i}` }));
+				mutationMs.push((Bun.nanoseconds() - t0) / 1e6);
+			})(),
+		);
+	}
+	await Promise.all(inflight);
+}
+
+const COLUMNS: Array<{ head: string; pick: (r: RoundResult) => number }> = [
+	{ head: "burst ms", pick: (r) => r.burstMs },
+	{ head: "mut p50", pick: (r) => pct(r.mutationMs, 0.5) },
+	{ head: "mut max", pick: (r) => Math.max(...r.mutationMs) },
+	{ head: "loop p99", pick: (r) => r.loop.p99 },
+	{ head: "loop max", pick: (r) => r.loop.max },
+	{ head: ">16ms", pick: (r) => r.loop.over16 },
+	{ head: ">50ms", pick: (r) => r.loop.over50 },
+	{ head: "blocked ms", pick: (r) => r.loop.blockedMs },
+	{ head: "parses", pick: (r) => r.json.parseCalls },
+	{ head: "parse ms", pick: (r) => r.json.parseMs },
+	{ head: "serials", pick: (r) => r.json.stringifyCalls },
+	{ head: "serial ms", pick: (r) => r.json.stringifyMs },
+	{ head: "lock hits", pick: (r) => r.lock.collisions },
+	{ head: "lock sync", pick: (r) => r.lock.syncMs },
+	{ head: "lockwait p50", pick: (r) => pct(r.lock.waitMs, 0.5) },
+	{ head: "lockwait max", pick: (r) => (r.lock.waitMs.length ? Math.max(...r.lock.waitMs) : 0) },
+	{ head: "publish p50", pick: (r) => pct(r.io.writeMs, 0.5) },
+	{ head: "publish max", pick: (r) => (r.io.writeMs.length ? Math.max(...r.io.writeMs) : 0) },
+	{ head: "read MB", pick: (r) => r.io.readBytes / 1048576 },
+	{ head: "write MB", pick: (r) => r.io.writeBytes / 1048576 },
+];
+
+function report(rounds: RoundResult[]): void {
+	console.log(
+		`\n=== ${rounds[0].label} (${rounds.length} rounds, burst=${BURST_SIZE}, tasks=${TASK_COUNT}, ` +
+		`file=${(rounds[0].fileBytes / 1048576).toFixed(2)} MB) ===`,
+	);
+	const cell = (v: string, head: string) => v.padStart(Math.max(head.length, 7));
+	console.log(["round", ...COLUMNS.map((c) => c.head.padStart(Math.max(c.head.length, 7)))].join(" | "));
+	for (const [i, r] of rounds.entries()) {
+		console.log([String(i + 1).padStart(5), ...COLUMNS.map((c) => cell(fmt(c.pick(r)), c.head))].join(" | "));
+	}
+	const avg = (pick: (r: RoundResult) => number) => rounds.reduce((a, r) => a + pick(r), 0) / rounds.length;
+	console.log(["  avg", ...COLUMNS.map((c) => cell(fmt(avg(c.pick)), c.head))].join(" | "));
+}
+
+// ---- correctness + timing ----
+
+const sequential: RoundResult[] = [];
+for (let r = 0; r < ROUNDS; r++) sequential.push(await runRound("sequential burst (one task, ordering)", sequentialBurst));
+report(sequential);
+
+{
+	const target = tasks[Math.floor(tasks.length / 2)];
+	const persisted = await data.getTask(project, target.id);
+	const expected = `${target.overview}${Array.from({ length: BURST_SIZE }, (_, i) => `|${i + 1}`).join("")}`;
+	const ok = persisted.overview === expected;
+	console.log(`ordering: ${ok ? "OK" : "FAIL"} — ${BURST_SIZE} mutations, persisted tail ${JSON.stringify(String(persisted.overview).slice(-30))}`);
+	if (!ok) process.exitCode = 1;
+}
+
+const concurrent: RoundResult[] = [];
+for (let r = 0; r < ROUNDS; r++) concurrent.push(await runRound(`concurrent burst (${BURST_SIZE} tasks / ${BURST_SPREAD_MS} ms)`, concurrentBurst));
+report(concurrent);
+
+{
+	const all = await data.loadTasks(project);
+	const byId = new Map(all.map((t) => [t.id, t]));
+	const missing: number[] = [];
+	for (let i = 0; i < BURST_SIZE; i++) {
+		if (byId.get(tasks[burstTargetIndex(i)].id)?.overview !== `burst-${i}`) missing.push(i);
+	}
+	console.log(`lossless: ${missing.length === 0 ? "OK" : `FAIL — lost ${missing.join(",")}`} (${BURST_SIZE} concurrent mutations)`);
+	if (missing.length) process.exitCode = 1;
+	console.log(`store integrity: ${all.length} tasks persisted (expected ${TASK_COUNT})`);
+	if (all.length !== TASK_COUNT) process.exitCode = 1;
+}
+
+console.log(
+	"\nScope: only redundant whole-file reads were removed. Every mutation still parses the store, stringifies it, " +
+	"and publishes it (writeFile + rename, no fsync), and measured main-loop blocking is unchanged. " +
+	"Builds are compared by running this file against each separately, never side by side.",
+);
+
+rmSync(home, { recursive: true, force: true });

--- a/src/bun/__tests__/task-store-fixture.ts
+++ b/src/bun/__tests__/task-store-fixture.ts
@@ -1,0 +1,169 @@
+import type { Project, Task, TaskHistoryEntry, TaskStatus } from "../../shared/types";
+
+/**
+ * Deterministic task-store fixture shaped like the live dev-3.0 board: 1509 tasks
+ * in 7.4 MB, per-task p50 ~2 KB / p99 ~27 KB / max ~246 KB. The long tail is the
+ * point — uniformly average tasks under-report parse and serialize cost.
+ */
+
+const SEED = 0x5eed1509;
+
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) >>> 0;
+		let t = a;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** Size buckets (compact bytes, share of tasks) reproducing the live quantiles. */
+const SIZE_BUCKETS: Array<{ bytes: number; share: number }> = [
+	{ bytes: 1_000, share: 0.25 },
+	{ bytes: 1_700, share: 0.25 },
+	{ bytes: 2_700, share: 0.25 },
+	{ bytes: 5_400, share: 0.15 },
+	{ bytes: 12_500, share: 0.07 },
+	{ bytes: 30_000, share: 0.023 },
+	{ bytes: 90_000, share: 0.006 },
+	{ bytes: 246_000, share: 0.001 },
+];
+
+const WORDS = [
+	"lifecycle", "worktree", "tmux", "mutation", "burst", "persist", "kanban", "renderer",
+	"handler", "column", "variant", "review", "socket", "backend", "harness", "fixture",
+	"latency", "parse", "serialize", "atomic", "lock", "cache", "stall", "profile",
+];
+
+function filler(rand: () => number, bytes: number): string {
+	const out: string[] = [];
+	let size = 0;
+	while (size < bytes) {
+		const word = WORDS[Math.floor(rand() * WORDS.length)];
+		out.push(word);
+		size += word.length + 1;
+	}
+	return out.join(" ");
+}
+
+/**
+ * Bucket by position, not by dice: a golden-ratio sweep hits every quantile at any
+ * task count, so the heavy tail is present in exactly its real proportion instead
+ * of depending on how the rolls fell.
+ */
+function pickBudget(index: number): number {
+	const quantile = (index * 0.6180339887498949) % 1;
+	let acc = 0;
+	for (const bucket of SIZE_BUCKETS) {
+		acc += bucket.share;
+		if (quantile <= acc) return bucket.bytes;
+	}
+	return SIZE_BUCKETS[SIZE_BUCKETS.length - 1].bytes;
+}
+
+const FIXTURE_PROJECT_PATH = "/tmp/dev3-task-store-perf";
+
+/** The frozen projectSlug() of the fixture project path — never recompute it inline. */
+export const FIXTURE_PROJECT_SLUG = "tmp-dev3-task-store-perf";
+
+export function fixtureProject(): Project {
+	return {
+		id: "perf-project",
+		name: "task-store-perf",
+		path: FIXTURE_PROJECT_PATH,
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		labels: [],
+		customColumns: [],
+	} satisfies Project;
+}
+
+interface TaskShape {
+	seq: number;
+	descBytes: number;
+	noteBytes: number;
+	historyBytes: number;
+	noteCount: number;
+	historyCount: number;
+}
+
+function makeTask(shape: TaskShape, rand: () => number): Task {
+	const { seq, descBytes, noteBytes, historyBytes, noteCount, historyCount } = shape;
+	const createdAt = new Date(Date.UTC(2026, 0, 1, 0, 0, 0) + seq * 60_000).toISOString();
+	const status: TaskStatus = seq % 7 === 0 ? "completed" : seq % 3 === 0 ? "in-progress" : "todo";
+	return {
+		id: `task-${String(seq).padStart(5, "0")}-0000-4000-8000-000000000000`,
+		seq,
+		projectId: "perf-project",
+		title: `Task ${seq} — ${filler(rand, 40)}`,
+		description: filler(rand, descBytes),
+		status,
+		priority: "P3",
+		baseBranch: "main",
+		worktreePath: seq % 3 === 0 ? `/tmp/wt/${seq}/worktree` : null,
+		branchName: seq % 3 === 0 ? `feat/dev3-task-${seq}` : null,
+		groupId: null,
+		variantIndex: null,
+		agentId: "builtin-claude",
+		configId: "claude-bypass-sonnet",
+		createdAt,
+		updatedAt: createdAt,
+		statusEnteredAt: createdAt,
+		movedAt: createdAt,
+		tmuxSocket: "dev3",
+		labelIds: [],
+		relations: [],
+		customTitle: null,
+		titleEditedByUser: false,
+		customColumnId: null,
+		overview: filler(rand, 120),
+		userOverview: null,
+		notes: Array.from({ length: noteCount }, (_, n) => ({
+			id: `note-${seq}-${n}`,
+			content: filler(rand, Math.floor(noteBytes / noteCount)),
+			source: "ai",
+			createdAt,
+			updatedAt: createdAt,
+		})),
+		history: Array.from({ length: historyCount }, (_, h): TaskHistoryEntry => ({
+			at: createdAt,
+			title: `Task ${seq}`,
+			overview: filler(rand, Math.floor(historyBytes / historyCount)),
+			changed: h === 0 ? "created" : "overview",
+		})),
+	} satisfies Task;
+}
+
+/** Same seed → byte-identical output, so every consumer measures the same store. */
+export function buildFixtureTasks(count: number): Task[] {
+	const rand = mulberry32(SEED);
+	// Fixed field overhead, so a bucket value is the final serialized size.
+	const overhead = JSON.stringify(
+		makeTask({ seq: 1, descBytes: 0, noteBytes: 0, historyBytes: 0, noteCount: 1, historyCount: 3 }, () => 0),
+	).length;
+	const tasks: Task[] = [];
+	for (let i = 0; i < count; i++) {
+		const budget = pickBudget(i);
+		// Floor keeps even the smallest task carrying real text in every field.
+		const free = Math.max(240, budget - overhead);
+		tasks.push(
+			makeTask(
+				{
+					seq: i + 1,
+					descBytes: Math.floor(free * 0.35),
+					noteBytes: Math.floor(free * 0.45),
+					historyBytes: Math.floor(free * 0.2),
+					noteCount: budget > 20_000 ? 4 : budget > 4_000 ? 2 : 1,
+					historyCount: budget > 20_000 ? 6 : 3,
+				},
+				rand,
+			),
+		);
+	}
+	return tasks;
+}

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -755,7 +755,22 @@ async function rawSaveTasks(
 	log.info(`Saved ${tasks.length} task(s)`, { projectId: project.id });
 }
 
+/**
+ * At most one pre-save snapshot per entry hour, decided with stat() rather than by
+ * reading two whole files. The hour is captured before reading, so a boundary-spanning
+ * read stays in its start hour. See decision 204.
+ */
 async function writeHourlyTasksBackup(project: Project, filePath: string): Promise<void> {
+	const backupDir = tasksBackupDir(project);
+	const backupFile = `${backupDir}/${tasksBackupFileName()}`;
+
+	try {
+		await stat(backupFile);
+		return; // This hour is already snapshotted.
+	} catch (err: any) {
+		if (err.code !== "ENOENT") throw err;
+	}
+
 	let currentContent: string;
 	try {
 		currentContent = await readFile(filePath, "utf8");
@@ -766,19 +781,8 @@ async function writeHourlyTasksBackup(project: Project, filePath: string): Promi
 		throw err;
 	}
 
-	const backupDir = tasksBackupDir(project);
-	const backupFile = `${backupDir}/${tasksBackupFileName()}`;
-
 	await mkdir(backupDir, { recursive: true });
-
-	try {
-		await readFile(backupFile, "utf8");
-	} catch (err: any) {
-		if (err.code !== "ENOENT") {
-			throw err;
-		}
-		await writeFile(backupFile, currentContent);
-	}
+	await writeFile(backupFile, currentContent);
 
 	const backupFiles = (await readdir(backupDir))
 		.filter((entry) => TASK_BACKUP_FILE_PATTERN.test(entry))


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that did this work) — flagging up front what this **is not**, because the honest scope matters more than the headline.

## What this changes

Before every task save, `writeHourlyTasksBackup` read the whole `tasks.json` and then the whole existing hourly backup, purely to learn whether the current hour was already snapshotted. Once that snapshot exists, both reads are redundant — only the hour's first save needs the content. It now answers with `stat()` and reads the store only when it is about to write a snapshot.

On the live ~1509-task / ~7.4 MB board, ten mutations moved **221 MB**; about **148 MB** of that was those two reads. What remains is the retained mutator reads at **74 MB**.

## What this does NOT fix

- **Not the multi-second freezes.** A deterministic harness over a production-shaped fixture recorded no event-loop stall above 16 ms at bursts of 1/8/10, so that symptom was never reproduced at this seam. It stays open.
- **Not per-mutation main-loop blocking.** Measured blocking is unchanged (89–99 ms per 10-mutation burst against 96 ms before — inside run-to-run spread). Every mutation still parses the store, stringifies it, and publishes it atomically.

Serving mutators from the in-memory cache was implemented twice to remove that blocking and dropped both times: a cached value may only reach a writer if it was parsed from the published bytes, which reinstates the parse it was meant to avoid and makes the stall tail worse. Removing the remaining stringify + publish needs write coalescing plus its own durability and ordering design — deliberately not attempted here.

## Behaviour changes worth reviewing

1. Pruning of expired backups now runs only when a snapshot was created, so a stale file can outlive its retention until the next snapshot is written.
2. The hour is captured before the snapshot's own read, so a read spanning an hour boundary is filed under the hour it started in; the old code filed it an hour later. Covered by a deterministic regression.

## Coverage

`src/bun/__tests__/data-hourly-backup-io.test.ts` is count-based, not timing-based: zero reads under `tasks-backups/`, one store read per mutation, snapshot cadence and byte-identical content, the hour-boundary rule, and lossless ordering with the on-disk format preserved. It is red on `main` on two counts (nine backup-file reads for a nine-mutation burst, and the boundary bucketing).

`bun run perf:task-store` is an isolated deterministic harness (private HOME, seeded fixture) kept for the durability-design follow-up. Rationale and the dropped-cache measurements: `decisions/204-task-store-burst-read-reduction.md`.