### PR TITLE
Reveal the clipped card config in the styled tooltip

### DIFF
--- a/change-logs/2026/08/04/fix-card-config-styled-tooltip.md
+++ b/change-logs/2026/08/04/fix-card-config-styled-tooltip.md
@@ -1,0 +1,3 @@
+Short: Card header tooltips are styled now
+
+The task card's agent-config string keeps its ellipsis but now reveals the full value in the app's own tooltip instead of the slow, unstyled native one — and only when the text is actually clipped. The scratch, automation, draft and hibernated markers in the same header row moved to the styled tooltip too.

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -13,6 +13,7 @@ import { formatCountdown } from "../../shared/duration";
 import { trackEvent, agentNameFromId } from "../analytics";
 import { useStatusColors } from "../hooks/useStatusColors";
 import { useTerminalPreview } from "../hooks/useTerminalPreview";
+import { useIsTruncated } from "../hooks/useIsTruncated";
 import LabelChip from "./LabelChip";
 import LabelPicker from "./LabelPicker";
 import PriorityBadge from "./PriorityBadge";
@@ -632,6 +633,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 		? `${task.variantIndex}/${groupMembers.length}`
 		: null;
 	const hasLauncherIcon = agent ? resolveAgentLauncherIcon(agent) !== null : false;
+	const [configRef, configTruncated] = useIsTruncated<HTMLSpanElement>(configLabel);
 
 	// ---- SIGNALS zone: read-only facts, grouped git / run / time -------------
 	const gitSignals = [prBadge, mergeBadge, reviewBadge, commentBadge].filter(Boolean);
@@ -895,9 +897,9 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 				<span className="flex-shrink-0 font-mono text-[0.6875rem] font-semibold text-accent">
 					#{task.seq}
 					{variantFraction && (
-						<span className="ml-0.5 font-normal text-accent/60" title={t("task.attempt", { n: String(task.variantIndex) })}>
-							{variantFraction}
-						</span>
+						<Tooltip content={t("task.attempt", { n: String(task.variantIndex) })} detail={t("ttip.task.siblings")}>
+							<span className="ml-0.5 font-normal text-accent/60">{variantFraction}</span>
+						</Tooltip>
 					)}
 				</span>
 				{agent && hasLauncherIcon && <AgentLauncherBadge agent={agent} />}
@@ -907,53 +909,57 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					<span className="flex-shrink-0 font-mono text-[0.625rem] font-medium text-accent/80">{agent.name}</span>
 				)}
 				{configLabel && (
-					<span
-						className="min-w-[3rem] flex-1 truncate font-mono text-[0.625rem] font-medium text-accent/80"
-						title={configLabel}
-					>
-						{configLabel}
-					</span>
+					// The config string is the one header item allowed to clip, so it is
+					// also the one that needs the full value back on hover — but only
+					// when it is actually clipped.
+					<Tooltip content={configLabel} disabled={!configTruncated}>
+						<span
+							ref={configRef}
+							data-testid="task-card-config"
+							className="min-w-[3rem] flex-1 truncate font-mono text-[0.625rem] font-medium text-accent/80"
+						>
+							{configLabel}
+						</span>
+					</Tooltip>
 				)}
 				{variantDots}
 				{/* Only when there is no config to absorb the slack — otherwise a spacer
 				    would starve the string this full-width header exists for. */}
 				{!configLabel && <div className="flex-1" />}
 				{task.scratch && (
-					<span
-						className="flex-shrink-0 text-fg-3"
-						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						title={t("task.scratchSession")}
-					>
-						{"\u{F018D}"}
-					</span>
+					<Tooltip content={t("task.scratchSession")}>
+						<span className="flex-shrink-0 text-fg-3" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+							{"\u{F018D}"}
+						</span>
+					</Tooltip>
 				)}
 				{task.automationId && (
-					<span
-						className="flex-shrink-0 text-fg-3"
-						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-						title={t("task.automationRun")}
-					>
-						{"\u{F0150}"}
-					</span>
+					<Tooltip content={t("task.automationRun")}>
+						<span className="flex-shrink-0 text-fg-3" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+							{"\u{F0150}"}
+						</span>
+					</Tooltip>
 				)}
 				<NativeBackendMark task={task} className="w-3.5 h-3.5 flex-shrink-0" testId="task-card-native-backend" />
 				{isDraft && (
-					<span
-						data-testid="task-card-draft-badge"
-						title={t("task.draftHint")}
-						className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-3"
-					>
-						{t("task.draftBadge")}
-					</span>
+					<Tooltip content={t("task.draftBadge")} detail={t("task.draftHint")}>
+						<span
+							data-testid="task-card-draft-badge"
+							className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-3"
+						>
+							{t("task.draftBadge")}
+						</span>
+					</Tooltip>
 				)}
 				{isHibernated && (
-					<span
-						data-testid="task-card-hibernated-badge"
-						title={t("task.hibernatedHint")}
-						className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-muted"
-					>
-						{t("task.hibernatedBadge")}
-					</span>
+					<Tooltip content={t("task.hibernatedBadge")} detail={t("task.hibernatedHint")}>
+						<span
+							data-testid="task-card-hibernated-badge"
+							className="flex-shrink-0 rounded border border-dashed border-edge-active px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.06em] text-fg-muted"
+						>
+							{t("task.hibernatedBadge")}
+						</span>
+					</Tooltip>
 				)}
 				{showDismissButton && (
 					<Tooltip content={isCancelled ? t("task.delete") : t("task.cancel")} detail={isCancelled ? t("ttip.task.delete") : t("ttip.task.cancel")}>

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -276,13 +276,14 @@ describe("TaskCard", () => {
 	describe("scratch session indicator", () => {
 		it("renders a non-empty glyph for scratch tasks (regression: was an empty placeholder)", () => {
 			renderCard(makeTask({ scratch: true, customTitle: "Quick shell", title: "Quick shell" }));
-			const icon = screen.getByTitle("Live shell session");
-			expect(icon.textContent).toBe("\u{F018D}");
+			// The label moved from a native title= to the styled Tooltip, so the
+			// glyph itself is what identifies the indicator now.
+			expect(screen.getByText("\u{F018D}")).toBeInTheDocument();
 		});
 
 		it("shows no scratch indicator for a normal task", () => {
 			renderCard(makeTask({ scratch: false }));
-			expect(screen.queryByTitle("Live shell session")).not.toBeInTheDocument();
+			expect(screen.queryByText("\u{F018D}")).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/mainview/hooks/__tests__/useIsTruncated.test.tsx
+++ b/src/mainview/hooks/__tests__/useIsTruncated.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useIsTruncated } from "../useIsTruncated";
+
+/**
+ * happy-dom reports 0 for every layout box, so the widths are stubbed per
+ * element via the `data-*` attributes the getters below read back.
+ */
+beforeAll(() => {
+	Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+		configurable: true,
+		get(this: HTMLElement) {
+			return Number(this.dataset.scroll ?? 0);
+		},
+	});
+	Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+		configurable: true,
+		get(this: HTMLElement) {
+			return Number(this.dataset.client ?? 0);
+		},
+	});
+});
+
+function Probe({ scroll, client }: { scroll: number; client: number }) {
+	const [ref, truncated] = useIsTruncated<HTMLSpanElement>("text");
+	return (
+		<span ref={ref} data-scroll={scroll} data-client={client} data-testid="probe">
+			{truncated ? "clipped" : "fits"}
+		</span>
+	);
+}
+
+describe("useIsTruncated", () => {
+	it("reports clipped when the content is wider than the box", () => {
+		render(<Probe scroll={200} client={80} />);
+		expect(screen.getByTestId("probe")).toHaveTextContent("clipped");
+	});
+
+	it("reports fitting when the content is not wider", () => {
+		render(<Probe scroll={80} client={80} />);
+		expect(screen.getByTestId("probe")).toHaveTextContent("fits");
+	});
+
+	it("tolerates a 1px sub-pixel rounding overflow", () => {
+		render(<Probe scroll={81} client={80} />);
+		expect(screen.getByTestId("probe")).toHaveTextContent("fits");
+	});
+});

--- a/src/mainview/hooks/useIsTruncated.ts
+++ b/src/mainview/hooks/useIsTruncated.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Tracks whether a single-line element is actually clipped by `truncate`.
+ *
+ * Exists so a tooltip can reveal the full string only when it is hidden — a
+ * tooltip that repeats text already fully on screen is noise. Re-measures on
+ * element resize, so it follows column-width and viewport changes.
+ *
+ *   const [ref, truncated] = useIsTruncated<HTMLSpanElement>(label);
+ *   <Tooltip content={label} disabled={!truncated}><span ref={ref} …/></Tooltip>
+ */
+export function useIsTruncated<T extends HTMLElement>(
+	/** Re-measure when the rendered text changes, not just its box. */
+	text?: string,
+): [(node: T | null) => void, boolean] {
+	const [truncated, setTruncated] = useState(false);
+	const nodeRef = useRef<T | null>(null);
+
+	const measure = useCallback(() => {
+		const el = nodeRef.current;
+		// +1px: sub-pixel layout rounding otherwise reports a 1px overflow on
+		// strings that visually fit.
+		setTruncated(!!el && el.scrollWidth > el.clientWidth + 1);
+	}, []);
+
+	const ref = useCallback(
+		(node: T | null) => {
+			nodeRef.current = node;
+			measure();
+		},
+		[measure],
+	);
+
+	useEffect(() => {
+		measure();
+		const el = nodeRef.current;
+		if (!el || typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver(measure);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [measure, text]);
+
+	return [ref, truncated];
+}


### PR DESCRIPTION
The agent-config string in the task card's identity row is the one header item allowed to clip, so it is also the one that has to give the full value back on hover. It was leaning on a native `title=`, which carries an OS-controlled ~1.5s delay and cannot be themed.

It now uses the app's own `Tooltip` primitive, shown **only when the text is actually clipped** — a tooltip that repeats a label already fully on screen is noise. The new `useIsTruncated` hook measures `scrollWidth` against `clientWidth` and re-measures through a `ResizeObserver`, so it follows column-width and viewport changes.

The scratch, automation, draft and hibernated markers in the same row moved off `title=` as well; draft and hibernated gain a two-tier tooltip (badge text as the headline, the existing hint as the detail).