### PR TITLE
Halve the width of the task card status rail

### DIFF
--- a/change-logs/2026/08/04/fix-narrow-card-status-rail.md
+++ b/change-logs/2026/08/04/fix-narrow-card-status-rail.md
@@ -1,0 +1,3 @@
+Short: Card status rail is half as wide
+
+The task card's vertical status rail shrank from 38px to 20px on the desktop board, giving the title and labels the space back. The pipeline ring, custom-column dot and attention count shrank with it; on narrow viewports the rail stays 44px so both of its buttons keep a full-size touch target.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -491,7 +491,7 @@ bar make red decorative). Evidence: `decisions/184-*.md`, `TaskCard.tsx`, `TaskI
 
 ## 2026-08-03 — Task card is governed by five zones, and the left rail owns lifecycle
 
-- **Rule:** The board card is a 3px status strip + a full-width identity header + a 38px vertical lifecycle rail (status control) + a body whose segmented bottom bar carries grouped signals above a reserved action strip; each zone has one admission rule (`surfaces.task_card.zone_model`).
+- **Rule:** The board card is a 3px status strip + a full-width identity header + a 20px vertical lifecycle rail (44px on touch) (status control) + a body whose segmented bottom bar carries grouped signals above a reserved action strip; each zone has one admission rule (`surfaces.task_card.zone_model`).
 - **Why:** Nothing was zoned, so every feature added a badge row and the status control — the most important button on the card — read as a text label; the rejected alternative was a right-hand indicator rail (constant height, but a bare counter hides severity).
 - **Status:** Implemented. Evidence: `src/mainview/components/TaskCard.tsx`, `src/mainview/components/TaskCardRail.tsx`.
 

--- a/src/mainview/components/PipelineRing.tsx
+++ b/src/mainview/components/PipelineRing.tsx
@@ -15,13 +15,15 @@ export function CompleteCheckIcon({ className }: { className?: string }) {
 
 interface PipelineRingProps {
 	status: TaskStatus;
-	/** "touch" bumps the ring to a legible size inside ≥44px rows. */
-	size?: "default" | "touch";
+	/** "touch" bumps the ring to a legible size inside ≥44px rows; "compact"
+	 *  shrinks it for the narrow card rail, where 18px would leave no margin. */
+	size?: "compact" | "default" | "touch";
 	/** Off where the stage position is already spelled out next to the ring. */
 	tooltip?: boolean;
 }
 
-const RING_PX = { default: 18, touch: 22 } as const;
+const RING_PX = { compact: 14, default: 18, touch: 22 } as const;
+const DIGIT_PX = { compact: 8, default: 9, touch: 11 } as const;
 
 /**
  * Compact conic progress ring replacing the seven-dot mini pipeline: the arc is
@@ -39,7 +41,8 @@ export default function PipelineRing({ status, size = "default", tooltip = true 
 	const sideBranch = isSideBranch(status);
 	const color = statusColors[status];
 	const px = RING_PX[size];
-	const hole = px / 2 - 2.6;
+	// A thinner ring at 14px: the default 2.6px stroke would swallow the digit.
+	const hole = px / 2 - (size === "compact" ? 2.1 : 2.6);
 	const label = t("pipeline.stageOf", { current: String(stage), total: String(total) });
 
 	return (
@@ -61,7 +64,7 @@ export default function PipelineRing({ status, size = "default", tooltip = true 
 			/>
 			<span
 				className="relative font-bold tabular-nums leading-none text-fg"
-				style={{ fontSize: size === "touch" ? 11 : 9 }}
+				style={{ fontSize: DIGIT_PX[size] }}
 			>
 				{sideBranch ? "×" : stage}
 			</span>

--- a/src/mainview/components/TaskCardRail.tsx
+++ b/src/mainview/components/TaskCardRail.tsx
@@ -82,7 +82,7 @@ export default function TaskCardRail({
 	return (
 		<div
 			data-testid="task-card-rail"
-			className={`flex flex-shrink-0 flex-col items-stretch self-stretch rounded-bl-[0.6875rem] ${touch ? "w-12" : "w-[2.375rem]"}`}
+			className={`flex flex-shrink-0 flex-col items-stretch self-stretch rounded-bl-[0.6875rem] ${touch ? "w-11" : "w-5"}`}
 			style={{ background: `${color}22` }}
 		>
 			<Tooltip content={fullLabel} detail={`${stageLabel} · ${t("task.moveTo")}`}>
@@ -92,21 +92,21 @@ export default function TaskCardRail({
 					onClick={onOpenMenu}
 					disabled={disabled}
 					aria-label={`${fullLabel} — ${stageLabel}. ${t("task.moveTo")}`}
-					className="flex w-full flex-1 flex-col items-center gap-1.5 rounded-tl-none rounded-bl-none pt-2 pb-1.5 transition-[filter] duration-150 ease-out hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:active:scale-[0.97]"
+					className={`flex w-full flex-1 flex-col items-center rounded-tl-none rounded-bl-none pb-1.5 transition-[filter] duration-150 ease-out hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:active:scale-[0.97] ${touch ? "gap-1.5 pt-2" : "gap-1 pt-1.5"}`}
 				>
 					{customColumn ? (
 						<span
-							className="h-[0.9375rem] w-[0.9375rem] flex-shrink-0 rounded-full"
+							className={`flex-shrink-0 rounded-full ${touch ? "h-[0.9375rem] w-[0.9375rem]" : "h-2.5 w-2.5"}`}
 							style={{ background: color, boxShadow: `0 0 6px ${color}60` }}
 						/>
 					) : (
-						<PipelineRing status={status} tooltip={false} />
+						<PipelineRing status={status} size={touch ? "default" : "compact"} tooltip={false} />
 					)}
 
 					{bellCount > 0 && (
 						<span
 							data-testid="task-card-rail-bell"
-							className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-red-500 px-1 text-[0.625rem] font-bold leading-none text-white shadow-[0_2px_6px_rgb(239_68_68_/_0.45)]"
+							className={`flex flex-shrink-0 items-center justify-center rounded-full bg-red-500 font-bold leading-none text-white shadow-[0_2px_6px_rgb(239_68_68_/_0.45)] ${touch ? "h-4 min-w-4 px-1 text-[0.625rem]" : "h-3.5 min-w-3.5 px-0.5 text-[0.5625rem]"}`}
 						>
 							{bellCount > 9 ? "9+" : bellCount}
 						</span>


### PR DESCRIPTION
The card's vertical lifecycle rail was eating more of the board column than it earns. It drops from 38px to 20px on desktop, handing the space back to the title and label rows.

Width alone was not enough: an 18px ring inside a 20px rail leaves 1px of margin and reads as glued to the edges. `PipelineRing` therefore gains a third size, `compact` — 14px, an 8px digit, and a thinner 2.1px stroke so the arc does not swallow the number. The custom-column dot (15px → 10px) and the attention badge (16px → 14px) shrink to match. Other callers of the ring are untouched.

Narrow viewports deliberately keep a 44px rail: there it is two thumb targets, and 44px is the accessibility floor. Measured on a 430px viewport — status button 44×96, quick-complete 44×44.