### PR TITLE
Bound the cleanup-script wait so teardown cannot wedge on a stale tmux client

### DIFF
--- a/change-logs/2026/08/05/fix-cleanup-script-teardown-wedge.md
+++ b/change-logs/2026/08/05/fix-cleanup-script-teardown-wedge.md
@@ -1,0 +1,5 @@
+Short: Stuck "Shutting down" cards fixed
+
+Task teardown no longer hangs forever when the cleanup script's tmux client refuses to exit: an orphaned client is detected and killed within seconds, a genuinely long script gives up at a 10-minute cap, and worktree removal plus the final status write always run. The cleanup step now logs its spawn, exit code and duration.
+
+Suggested by @DolevEpshtein (h0x91b/dev-3.0#1251)

--- a/decisions/205-cleanup-script-orphaned-tmux-client-watchdog.md
+++ b/decisions/205-cleanup-script-orphaned-tmux-client-watchdog.md
@@ -1,0 +1,58 @@
+# 205 — Cleanup-script teardown watchdog: orphaned tmux client, then a hard cap
+
+## Context
+
+`runCleanupScript` spawned the project cleanup script in an attached `dev3-cl-<short>` tmux
+session and awaited `proc.exited` with no bound. That await sits in the middle of the teardown
+effect chain, before `captureCompletedDiffStats`, `removeWorktree` and `persistTerminalTask`, so
+a client that never exits strands the task in `tearing-down` forever: the card keeps the
+`shuttingDown` overlay (greyed, `pointer-events: none`) and the worktree is never removed.
+
+Reported in [issue #1251](https://github.com/h0x91b/dev-3.0/issues/1251) with an exact
+correlation: 43 live `dev3-cl-*` clients ↔ 43 tasks persisted as `tearing-down`, 391 leaked
+worktrees / 142 GB in one project. The scripts themselves had completed; the tmux **client**
+process stayed alive (`Ss+`) for days after its session was already gone from
+`list-sessions`.
+
+## Investigation
+
+The lifecycle actor is a strictly serial FIFO mailbox per task (`src/bun/lifecycle/actor.ts`),
+so the reporter's suggestion of a periodic reconciler for stale `tearing-down` tasks cannot
+work: a sweep event would queue behind the wedged effect chain and never run. Only bounding the
+await itself unwedges the task. That is why this fix lives at the source and no watchdog sweep
+was added.
+
+A flat timeout is the obvious bound but has to choose between cutting off a legitimately slow
+cleanup script and leaving the card stuck for minutes. The reported failure has a much sharper
+signature — session gone, client alive — which distinguishes the two cases directly.
+
+## Decision
+
+`awaitCleanupSession` in `src/bun/lifecycle/executor.ts` polls every
+`CLEANUP_SESSION_POLL_MS` (5 s) while racing `proc.exited`:
+
+- Two consecutive `has-session` misses ⇒ orphaned client: warn, best-effort
+  `kill-session`, `kill(9)` the client, continue teardown (~10 s to recover).
+- `CLEANUP_SCRIPT_HARD_TIMEOUT_MS` (10 min) ⇒ same abandonment path, for a script that is
+  genuinely still running.
+- A throwing `has-session` (unreadable socket) counts as alive — inconclusive is not proof of
+  death, and the hard cap still applies.
+
+Spawn, exit code and duration are now logged; the previously silent gap between
+`Killed dev server session` and `Removing worktree` was what made this hard to localize.
+
+## Risks
+
+A cleanup script legitimately running longer than 10 minutes is killed and teardown proceeds —
+accepted: a leaked worktree and an unclickable card are worse. The liveness probe adds one
+`tmux has-session` spawn per 5 s per teardown, bounded by one teardown at a time per task.
+
+## Alternatives considered
+
+- **Flat 60 s timeout** — simplest, but either kills legitimate slow cleanups or leaves the card
+  stuck for the full window; it also ignores the diagnostic signal already available.
+- **Run the cleanup script without tmux** (plain piped `spawn`) — removes the failing component
+  entirely, but drops the TTY that scripts rely on for colored/interactive output and is a
+  larger behavioral change than the bug warrants.
+- **Periodic reconciliation of stale `tearing-down` tasks** — impossible through the mailbox, as
+  above; would require a path around the actor.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -689,6 +689,71 @@ describe("runCleanupScript", () => {
 
 		expect(mockSpawn).not.toHaveBeenCalled();
 	});
+
+	// Issue #1251: an attached cleanup client that never exits used to block the
+	// whole teardown chain — no worktree removal, no terminal status write, card
+	// stuck on "Shutting down…" until the app restarted.
+	describe("wedged tmux client", () => {
+		const wedgedClient = { pid: 4242, exited: new Promise<number>(() => {}), kill: vi.fn() };
+
+		function mockCleanupSpawn(sessionAlive: boolean) {
+			mockSpawn.mockImplementation((argv: string[]) => {
+				if (argv.includes("new-session") && !argv.includes("-d")) return wedgedClient;
+				return {
+					stdout: new Response(""),
+					stderr: new Response(""),
+					exited: Promise.resolve(argv.includes("has-session") && !sessionAlive ? 1 : 0),
+				};
+			});
+		}
+
+		function cleanupTask() {
+			return makeTask({ id: "task-wedged-1234", worktreePath: "/tmp/test-worktree", status: "in-progress" });
+		}
+
+		beforeEach(() => {
+			wedgedClient.kill.mockClear();
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("kills the client and returns once its session is gone", async () => {
+			mockCleanupSpawn(false);
+			const project = makeProject({ path: "/tmp/project-root", cleanupScript: "echo cleanup" });
+
+			const pending = runCleanupScript(cleanupTask(), project, {
+				fromStatus: "in-progress",
+				toStatus: "completed",
+			});
+			await vi.advanceTimersByTimeAsync(30_000);
+			await expect(pending).resolves.toBeUndefined();
+
+			expect(wedgedClient.kill).toHaveBeenCalledWith(9);
+			const killSession = mockSpawn.mock.calls
+				.map(([argv]) => argv as string[])
+				.find((argv) => argv.includes("kill-session"));
+			expect(killSession).toContain("dev3-cl-task-wed");
+		});
+
+		it("waits out a live session and gives up only at the hard cap", async () => {
+			mockCleanupSpawn(true);
+			const project = makeProject({ path: "/tmp/project-root", cleanupScript: "echo cleanup" });
+
+			const pending = runCleanupScript(cleanupTask(), project, {
+				fromStatus: "in-progress",
+				toStatus: "completed",
+			});
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(wedgedClient.kill).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(10 * 60_000);
+			await expect(pending).resolves.toBeUndefined();
+			expect(wedgedClient.kill).toHaveBeenCalledWith(9);
+		});
+	});
 });
 
 describe("uploadFileBase64", () => {

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -339,6 +339,87 @@ function buildCleanupScriptEnv(
 	};
 }
 
+/**
+ * A cleanup script sits in the middle of the teardown effect chain, before
+ * worktree removal and the terminal status write. Its attached tmux client has
+ * been observed staying alive forever after its session was already gone, which
+ * stranded the task in `tearing-down` with a permanently greyed-out card and
+ * leaked the worktree (issue #1251, decision 205). Nothing about a cleanup
+ * script may block teardown, so the wait is bounded twice: an orphaned client
+ * (session gone, client alive) is killed within seconds, and even a script that
+ * is genuinely still running gives up at the hard cap.
+ */
+export const CLEANUP_SESSION_POLL_MS = 5_000;
+export const CLEANUP_SCRIPT_HARD_TIMEOUT_MS = 10 * 60_000;
+/** Consecutive missing-session polls before the client is declared orphaned. */
+const CLEANUP_ORPHAN_POLLS = 2;
+
+type CleanupProcess = { exited: Promise<number>; kill: (signal?: number) => void };
+
+async function abandonCleanupSession(
+	proc: CleanupProcess,
+	socket: string,
+	sessionName: string,
+	reason: "orphaned-client" | "hard-timeout",
+	fields: Record<string, unknown>,
+): Promise<void> {
+	log.warn("Cleanup script abandoned — continuing teardown without it", { ...fields, reason });
+	try {
+		await tmux.killSession(sessionName, { socket, bestEffort: true });
+	} catch {
+		// Killing the session is best-effort; teardown continues either way.
+	}
+	try {
+		proc.kill(9);
+	} catch {
+		// The client may have exited between the last poll and the kill.
+	}
+}
+
+/** An unreadable socket is inconclusive, not proof of death — only the hard cap acts on it. */
+async function cleanupSessionAlive(socket: string, sessionName: string): Promise<boolean> {
+	try {
+		return await tmux.hasSession(sessionName, { socket });
+	} catch {
+		return true;
+	}
+}
+
+async function awaitCleanupSession(
+	proc: CleanupProcess,
+	socket: string,
+	sessionName: string,
+	taskId: string,
+): Promise<void> {
+	const startedAt = Date.now();
+	const fields = { taskId, session: sessionName };
+	let missingSessionPolls = 0;
+	for (;;) {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const settled = await Promise.race([
+			proc.exited.then((exitCode) => ({ exitCode })),
+			new Promise<null>((resolve) => {
+				timer = setTimeout(() => resolve(null), CLEANUP_SESSION_POLL_MS);
+			}),
+		]);
+		clearTimeout(timer);
+		const elapsedMs = Date.now() - startedAt;
+		if (settled) {
+			log.info("Cleanup script finished", { ...fields, exitCode: settled.exitCode, elapsedMs });
+			return;
+		}
+		if (elapsedMs >= CLEANUP_SCRIPT_HARD_TIMEOUT_MS) {
+			await abandonCleanupSession(proc, socket, sessionName, "hard-timeout", { ...fields, elapsedMs });
+			return;
+		}
+		missingSessionPolls = (await cleanupSessionAlive(socket, sessionName)) ? 0 : missingSessionPolls + 1;
+		if (missingSessionPolls >= CLEANUP_ORPHAN_POLLS) {
+			await abandonCleanupSession(proc, socket, sessionName, "orphaned-client", { ...fields, elapsedMs });
+			return;
+		}
+	}
+}
+
 export async function runCleanupScript(
 	task: Task,
 	project: Project,
@@ -356,17 +437,21 @@ export async function runCleanupScript(
 	await Bun.write(scriptPath, `${[...dialect.header(), script].join("\n")}\n`);
 	// The cleanup script is shown in a throwaway tmux session — POSIX-only.
 	assertPosixLaunchDialect("the cleanup-script tmux session");
+	const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
+	const sessionName = cleanupSessionName(task.id);
+	const taskId = task.id.slice(0, 8);
+	log.info("Running cleanup script", { taskId, session: sessionName });
 	const proc = tmux.spawnAttachedSession({
-		socket: task.tmuxSocket ?? DEFAULT_TMUX_SOCKET,
+		socket,
 		configFile: activeTmuxConfigPath(),
-		sessionName: cleanupSessionName(task.id),
+		sessionName,
 		cwd: task.worktreePath,
 		envFlags: cleanupEnv,
 		command: buildScriptRunnerCommand(scriptPath, { shellPath: getUserShell() }),
 		terminal: { cols: 220, rows: 50, data: () => {} },
 		processEnv: cleanupEnv,
 	});
-	await proc.exited;
+	await awaitCleanupSession(proc, socket, sessionName, taskId);
 }
 
 export async function captureCompletedDiffStats(


### PR DESCRIPTION
Fixes #1251.

`runCleanupScript` awaited its attached `dev3-cl-<short>` tmux client with no bound. That await sits mid-teardown, before `captureCompletedDiffStats`, `removeWorktree` and `persistTerminalTask` — a client that never exits stranded the task in `tearing-down` forever (card greyed out under the `shuttingDown` overlay, worktree never removed). The reporter measured an exact 43↔43 correlation between live `dev3-cl-*` clients and tasks persisted as `tearing-down`, plus 391 leaked worktrees / 142 GB in one project.

The wait is now bounded twice in `awaitCleanupSession`:

- **Orphaned client** (session gone, client alive — the reported signature): two consecutive `has-session` misses, 5 s apart, then best-effort `kill-session` + `kill(9)` and teardown continues. Live check on a real socket: a healthy client exits ~1 ms after its session is killed, so the ~10 s heuristic has a large margin.
- **Hard cap** at 10 minutes for a script that is genuinely still running.
- A throwing `has-session` counts as alive — inconclusive is not proof of death; only the hard cap acts on it.

Spawn, exit code and duration are now logged; the silent gap between `Killed dev server session` and `Removing worktree` was what made this hard to localize.

The issue's fourth suggestion — periodically reconciling tasks stuck in `tearing-down` — is deliberately not implemented: the lifecycle actor is a strictly serial FIFO mailbox per task, so a sweep event would queue behind the wedged effect chain and never run. Rationale and alternatives in `decisions/205-cleanup-script-orphaned-tmux-client-watchdog.md`.