### PR TITLE
Size the renderer ready budget off the measured launch distribution

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -22,6 +22,7 @@ on:
       - "scripts/verify-windows-app-launch.ts"
       - "scripts/verify-windows-conpty-update-archive.ts"
       - "src/bun/app-ready-marker.ts"
+      - "src/bun/renderer-readiness.ts"
       - "src/bun/index.ts"
       - "scripts/native-terminal-host-manifest/**"
       - "src/bun/native-terminal-host/**"

--- a/change-logs/2026/08/06/fix-windows-renderer-ready-budget.md
+++ b/change-logs/2026/08/06/fix-windows-renderer-ready-budget.md
@@ -1,0 +1,3 @@
+Short: Windows launch no longer gives up early
+
+The Windows desktop launch waited only 45 seconds for its renderer, which measurement showed was barely longer than the slowest healthy packaged startup — so a slow or loaded machine could be told it had no UI when it simply had not painted yet. The budget is now sized off 40 measured launches, and every packaged-launch proof records how long the renderer actually took so it stays that way.

--- a/decisions/177-renderer-readiness-desktop-launch.md
+++ b/decisions/177-renderer-readiness-desktop-launch.md
@@ -62,8 +62,11 @@ no event, and no falsy return — the bun side cannot see it at all.
 
 - `src/bun/renderer-readiness.ts` owns the contract. The first webview `dom-ready`
   is the only proof a renderer exists, so `index.ts` arms a watchdog right after
-  `openMainWindow()` and disarms it in `onDomReady`. Budget: 45 s
-  (`RENDERER_READY_TIMEOUT_MS`), ~30x the slowest observed healthy startup.
+  `openMainWindow()` and disarms it in `onDomReady`. Budget:
+  `RENDERER_READY_TIMEOUT_MS`, set here to 45 s on the belief it was ~30x the
+  slowest healthy startup. Measurement later showed it was ~1.1x, and the budget
+  was re-sized off the real distribution — see
+  [decision 207](207-renderer-ready-budget-from-measured-distribution.md).
 - `resolveRendererReadyTimeoutMs()` watches **win32 only** by default; macOS and
   Linux get `null` (no timer at all), so their startup is byte-identical. The
   `DEV3_RENDERER_READY_TIMEOUT_MS` env is the seam: an explicit value applies on
@@ -103,13 +106,13 @@ no event, and no falsy return — the bun side cannot see it at all.
 
 ## Risks
 
-- A healthy launch that is slower than 45 s to first paint would now be killed.
-  Observed healthy startups are 0.37–1.5 s, and the budget is win32-only, so the
-  margin is large — but a pathologically slow machine is the failure mode to watch.
+- A healthy launch that is slower than the budget to first paint would now be
+  killed. This risk **materialised** at 45 s: packaged launches on a shared CI
+  runner measured 4–40.5 s, and one crossed the line (decision 207).
 - The nudge was the crash we could reproduce; the pre-renderer window still
   contains other native calls (poller broadcasts into a controller-less webview).
   Nothing was observed to crash there in 17.5 minutes, but the class is not
-  eliminated — only shortened to 45 s.
+  eliminated — only shortened to the readiness budget.
 - `TerminateProcess` bypasses every exit handler and flush. Everything this process
   owns is torn down explicitly before the call; anything added to
   `runGlobalQuitCleanup()` later inherits that requirement.

--- a/decisions/207-renderer-ready-budget-from-measured-distribution.md
+++ b/decisions/207-renderer-ready-budget-from-measured-distribution.md
@@ -1,0 +1,84 @@
+# 207 — The renderer ready budget is sized off a measured distribution, not a sample
+
+## Context
+
+`windows-app-archive` (`.github/workflows/windows-conpty-package.yml`) went red on
+run 31049142202: the packaged app started, logged `=== dev-3.0 ready ===`, then
+its own readiness watchdog fired 45 s later and the app exited 8
+(`DEV3_DESKTOP_RENDERER_UNAVAILABLE`). The 45 s came from decision 177, justified
+as "~30x the observed cost" against two samples — 366 ms on an interactive
+desktop and 1511 ms in the packaged proof.
+
+## Investigation
+
+The proof already records `readyAfterMs` (spawn → dom-ready) and CI uploads it,
+so the distribution existed and had never been read. 40 green
+`windows-app-archive` proofs on GitHub-hosted `windows-latest`:
+
+| min | median | p90 | p95 | max |
+|---|---|---|---|---|
+| 4 036 ms | 11 128 ms | 18 702 ms | 24 825 ms | 40 534 ms |
+
+The slowest healthy launch is **40.5 s** against a 45 s budget — about 10%
+headroom, not 30x. The 1511 ms sample was a fast run, and the packaged launch on
+a shared runner is an order of magnitude slower and ten times as wide. The
+failing run's log shows the runner crawling (`spawnSync` of `which` at 1881 ms,
+a 3304 ms event-loop stall).
+
+Two things this investigation refuted rather than confirmed:
+
+- **The three other red runs in the last 25 are unrelated.** Their
+  `windows-app-archive` jobs all passed; they failed in `package-runtime` on
+  different E2E steps. This failure has one occurrence, not four.
+- **Extending the budget by measured event-loop stall time would not have
+  helped.** The failing run stalled for 3.3 s inside a 45 s window, so a
+  "45 s of healthy wall clock" budget would still have fired.
+
+What remains unproven is whether that run was an extreme tail (>52 s spawn →
+dom-ready) or a genuine no-renderer condition. Both are handled: the marker now
+carries the measurement, so a tail shows up as a large `rendererReadyMs` in a
+green proof, and a genuine no-renderer still fails, 180 s later.
+
+## Decision
+
+- `RENDERER_READY_TIMEOUT_MS` 45 s → **180 s** (`src/bun/renderer-readiness.ts`),
+  ~4.4x the slowest measured healthy launch and still bounded.
+- The watchdog reports `elapsedMs` as `null` when it was never armed
+  (macOS/Linux) instead of a fake `0`, and `writeAppReadyMarker` records it as
+  `rendererReadyMs` in the ready marker. `index.ts` writes the marker from the
+  watchdog's `onReady`, where the measurement lives.
+- `scripts/verify-windows-app-launch.ts` requires `rendererReadyMs` to be a
+  non-negative number for a marker to count, surfaces it in
+  `windows-app-launch-proof.json`, and derives its own poll budget as
+  `RENDERER_READY_TIMEOUT_MS + 60 s` so a rendererless launch always surfaces
+  the app's actionable diagnostic rather than the script's generic timeout.
+
+## Risks
+
+- **This is a trade, not a pure win: the slow case was made to work by making
+  the broken case fail slower.** A user whose WebView2 is broken, or who launched
+  with no interactive desktop, now waits 3 minutes instead of 45 s — and during
+  that wait there is **no signal at all**. The native window is created and stays
+  blank (that is the whole failure: the renderer that would draw anything is
+  exactly what is missing); there is no splash, no progress indicator, no
+  notification. The diagnostic goes to stdout and to
+  `~/.dev3.0/logs/<yyyy>/<mm>/<date>.log`, and a double-clicked Windows launch has
+  no console — so what that user actually sees is a blank window for 180 s and
+  then nothing. Accepted deliberately: a false "you have no UI" on a working
+  machine is worse than a slow true one. A visible signal during the wait is real
+  missing work, reported separately rather than bolted onto this change.
+- 180 s is itself an estimate. It is falsifiable: `rendererReadyMs` is now in
+  every uploaded proof, so the next re-tune reads the distribution.
+
+## Alternatives considered
+
+- **A bounded retry of the launch in the verify script** — rejected. A retry
+  turns a 50%-reproducible real regression green, which is exactly the failure
+  this job exists to catch.
+- **A workflow-level `retry` on the job** — rejected for the same reason, and it
+  would mask every unrelated failure in the same job.
+- **Charging the budget only for non-stalled time** — refuted by the data above.
+- **A CI-only env override (`DEV3_RENDERER_READY_TIMEOUT_MS`)** — rejected: the
+  45 s number is wrong for real slow or loaded Windows machines too, not only
+  for CI. Hiding that behind a CI variable would leave a false
+  "no renderer" exit in shipped builds.

--- a/scripts/verify-windows-app-launch.ts
+++ b/scripts/verify-windows-app-launch.ts
@@ -35,9 +35,17 @@ import {
 	PACKAGED_HOST_IMAGE_PARENT,
 } from "../src/bun/native-terminal-registry/host-images/packaged-image";
 import type { AppReadyMarker } from "../src/bun/app-ready-marker";
+import { RENDERER_READY_TIMEOUT_MS } from "../src/bun/renderer-readiness";
 import { cliBinaryName } from "../electrobun.config";
 
-const READY_TIMEOUT_MS = Number(process.env.DEV3_READY_TIMEOUT_MS ?? 180_000);
+/**
+ * Strictly longer than the app's own renderer budget, so a launch with no
+ * renderer surfaces the app's actionable `DEV3_DESKTOP_RENDERER_UNAVAILABLE`
+ * diagnostic instead of this script's generic "no marker" timeout.
+ */
+const READY_TIMEOUT_MS = Number(
+	process.env.DEV3_READY_TIMEOUT_MS ?? RENDERER_READY_TIMEOUT_MS + 60_000,
+);
 const GRACEFUL_SHUTDOWN_MS = 10_000;
 const FORCED_SHUTDOWN_MS = 20_000;
 
@@ -140,7 +148,11 @@ export function isUsableReadyMarker(value: unknown, expectedVersion: string): va
 		marker.platform === "win32" &&
 		marker.version === expectedVersion &&
 		typeof marker.startedAt === "string" &&
-		marker.startedAt.length > 0
+		marker.startedAt.length > 0 &&
+		// Windows always arms the readiness watchdog, so a marker without a
+		// measured window→dom-ready cost did not come from a watched launch.
+		typeof marker.rendererReadyMs === "number" &&
+		marker.rendererReadyMs >= 0
 	);
 }
 
@@ -474,6 +486,10 @@ async function main(): Promise<void> {
 			readyMarker: marker,
 			readyAfterMs,
 			readyTimeoutMs: READY_TIMEOUT_MS,
+			// The two halves of readyAfterMs, kept apart because only the second one
+			// is what the app's renderer budget is set against.
+			rendererReadyMs: marker.rendererReadyMs,
+			rendererReadyBudgetMs: RENDERER_READY_TIMEOUT_MS,
 			ownedProcessesBeforeShutdown,
 			shutdownMethod,
 			shutdownAfterMs,
@@ -485,7 +501,8 @@ async function main(): Promise<void> {
 		console.log(`[windows-app-launch] ${JSON.stringify(proof)}`);
 		console.log(
 			`[windows-app-launch] ${desktopExecutableRelativePath} (rejected ${desktopSelection.rejected.length} other executables) ` +
-				`shipped with cli/${expectedCliName} and host image ${discovered.tag}, reached ready in ${readyAfterMs}ms, ` +
+				`shipped with cli/${expectedCliName} and host image ${discovered.tag}, reached ready in ${readyAfterMs}ms ` +
+				`(renderer ${marker.rendererReadyMs}ms of a ${RENDERER_READY_TIMEOUT_MS}ms budget), ` +
 				`shut down via ${shutdownMethod} with no owned processes left`,
 		);
 	} finally {

--- a/src/bun/__tests__/renderer-readiness.test.ts
+++ b/src/bun/__tests__/renderer-readiness.test.ts
@@ -51,6 +51,24 @@ function watchdogWith(timeoutMs: number | null) {
 	return { watchdog, timers, onTimeout, onReady, onArmed };
 }
 
+describe("the renderer ready budget", () => {
+	/**
+	 * Slowest healthy packaged launch ever measured: spawn → dom-ready across 40
+	 * green `windows-app-archive` proofs (min 4.0 s, median 11.1 s, p95 24.8 s).
+	 * It brackets the watched window from above, so headroom against it is a
+	 * lower bound on the real headroom.
+	 */
+	const SLOWEST_MEASURED_HEALTHY_LAUNCH_MS = 40_534;
+
+	it("keeps at least 3x headroom over the slowest measured healthy launch", () => {
+		expect(RENDERER_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(SLOWEST_MEASURED_HEALTHY_LAUNCH_MS * 3);
+	});
+
+	it("stays bounded, so a machine that never produces a renderer still fails", () => {
+		expect(RENDERER_READY_TIMEOUT_MS).toBeLessThanOrEqual(300_000);
+	});
+});
+
 describe("resolveRendererReadyTimeoutMs", () => {
 	it("watches win32 by default and leaves macOS/Linux untouched", () => {
 		expect(resolveRendererReadyTimeoutMs({}, "win32")).toBe(RENDERER_READY_TIMEOUT_MS);
@@ -131,6 +149,8 @@ describe("renderer readiness watchdog", () => {
 		expect(watchdog.markReady("dom-ready")).toBe(true);
 		expect(watchdog.markReady("dom-ready")).toBe(false);
 		expect(onReady).toHaveBeenCalledTimes(1);
+		// Nothing timed this launch, so it reports null instead of a fake 0 ms.
+		expect(onReady).toHaveBeenCalledWith("dom-ready", null);
 	});
 });
 

--- a/src/bun/__tests__/windows-build-orchestration.test.ts
+++ b/src/bun/__tests__/windows-build-orchestration.test.ts
@@ -47,21 +47,26 @@ describe("build plans", () => {
 
 describe("app ready marker", () => {
 	it("describes the running process", () => {
-		const marker = buildAppReadyMarker("9.9.9", new Date("2026-07-25T10:00:00.000Z"));
+		const marker = buildAppReadyMarker("9.9.9", 1234, new Date("2026-07-25T10:00:00.000Z"));
 		expect(marker).toEqual({
 			ready: true,
 			pid: process.pid,
 			version: "9.9.9",
 			platform: process.platform,
 			startedAt: "2026-07-25T10:00:00.000Z",
+			rendererReadyMs: 1234,
 		});
+	});
+
+	it("records an unmeasured renderer as null rather than a fake zero", () => {
+		expect(buildAppReadyMarker("9.9.9", null).rendererReadyMs).toBeNull();
 	});
 
 	it("writes atomically and leaves no temp file behind", () => {
 		const dir = mkdtempSync(join(tmpdir(), "dev3-ready-marker-"));
 		try {
 			const markerPath = join(dir, "nested", "app-ready.json");
-			const written = writeAppReadyMarker("1.2.3", markerPath);
+			const written = writeAppReadyMarker("1.2.3", 900, markerPath);
 			expect(written?.version).toBe("1.2.3");
 			expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual(written);
 			expect(readdirSync(join(dir, "nested"))).toEqual(["app-ready.json"]);
@@ -71,13 +76,20 @@ describe("app ready marker", () => {
 	});
 
 	it("is a no-op without a marker path and never throws on a bad one", () => {
-		expect(writeAppReadyMarker("1.2.3", undefined)).toBeNull();
-		expect(writeAppReadyMarker("1.2.3", "")).toBeNull();
-		expect(writeAppReadyMarker("1.2.3", join(tmpdir(), "dev3-missing\0path", "marker.json"))).toBeNull();
+		expect(writeAppReadyMarker("1.2.3", 900, undefined)).toBeNull();
+		expect(writeAppReadyMarker("1.2.3", 900, "")).toBeNull();
+		expect(writeAppReadyMarker("1.2.3", 900, join(tmpdir(), "dev3-missing\0path", "marker.json"))).toBeNull();
 	});
 
 	it("accepts only a complete Windows marker for the expected version", () => {
-		const good = { ready: true, pid: 42, version: "1.2.3", platform: "win32", startedAt: "now" };
+		const good = {
+			ready: true,
+			pid: 42,
+			version: "1.2.3",
+			platform: "win32",
+			startedAt: "now",
+			rendererReadyMs: 1500,
+		};
 		expect(isUsableReadyMarker(good, "1.2.3")).toBe(true);
 		expect(isUsableReadyMarker(good, "1.2.4")).toBe(false);
 		expect(isUsableReadyMarker({ ...good, ready: false }, "1.2.3")).toBe(false);
@@ -85,6 +97,10 @@ describe("app ready marker", () => {
 		expect(isUsableReadyMarker({ ...good, platform: "darwin" }, "1.2.3")).toBe(false);
 		expect(isUsableReadyMarker({ ...good, startedAt: "" }, "1.2.3")).toBe(false);
 		expect(isUsableReadyMarker(null, "1.2.3")).toBe(false);
+		// A Windows launch always measures the renderer; a marker that did not is
+		// not proof of a watched launch.
+		expect(isUsableReadyMarker({ ...good, rendererReadyMs: null }, "1.2.3")).toBe(false);
+		expect(isUsableReadyMarker({ ...good, rendererReadyMs: -1 }, "1.2.3")).toBe(false);
 	});
 });
 

--- a/src/bun/app-ready-marker.ts
+++ b/src/bun/app-ready-marker.ts
@@ -16,15 +16,27 @@ export interface AppReadyMarker {
 	version: string;
 	platform: NodeJS.Platform;
 	startedAt: string;
+	/**
+	 * Window creation → first `dom-ready`, in ms: the exact quantity the renderer
+	 * readiness budget is set against. Recorded on every proof run so the budget
+	 * stays sized off a measured distribution instead of one sample. `null` where
+	 * the readiness watchdog is off (macOS/Linux) — nothing measured it there.
+	 */
+	rendererReadyMs: number | null;
 }
 
-export function buildAppReadyMarker(version: string, now: Date = new Date()): AppReadyMarker {
+export function buildAppReadyMarker(
+	version: string,
+	rendererReadyMs: number | null,
+	now: Date = new Date(),
+): AppReadyMarker {
 	return {
 		ready: true,
 		pid: process.pid,
 		version,
 		platform: process.platform,
 		startedAt: now.toISOString(),
+		rendererReadyMs,
 	};
 }
 
@@ -35,12 +47,13 @@ export function buildAppReadyMarker(version: string, now: Date = new Date()): Ap
  */
 export function writeAppReadyMarker(
 	version: string,
+	rendererReadyMs: number | null,
 	markerPath: string | undefined = process.env.DEV3_READY_MARKER_FILE,
 ): AppReadyMarker | null {
 	if (!markerPath) return null;
 	try {
 		mkdirSync(dirname(markerPath), { recursive: true });
-		const marker = buildAppReadyMarker(version);
+		const marker = buildAppReadyMarker(version, rendererReadyMs);
 		const tempPath = `${markerPath}.${process.pid}.tmp`;
 		writeFileSync(tempPath, `${JSON.stringify(marker, null, 2)}\n`);
 		renameSync(tempPath, markerPath);

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -363,7 +363,14 @@ onMenuContextChange((ctx) => {
 const readiness = createRendererReadinessWatchdog({
 	timeoutMs: resolveRendererReadyTimeoutMs(),
 	onArmed: (timeoutMs) => log.info("Waiting for the renderer to report dom-ready", { timeoutMs }),
-	onReady: (source, elapsedMs) => log.info("Renderer ready", { source, elapsedMs }),
+	onReady: (source, elapsedMs) => {
+		log.info("Renderer ready", { source, elapsedMs });
+		// Window, RPC, push transport AND a live renderer — only now is the app
+		// genuinely usable, so this is where the automated packaged-build proof
+		// gets its marker, carrying the measurement the budget is set against.
+		// No-op without DEV3_READY_MARKER_FILE.
+		writeAppReadyMarker(APP_VERSION, elapsedMs);
+	},
 	onTimeout: (timeoutMs) => failDesktopLaunch(timeoutMs),
 });
 
@@ -396,12 +403,8 @@ async function openMainWindow() {
 		onDomReady: async (win) => {
 			// dom-ready is the readiness contract: it only fires once a webview
 			// actually rendered, so it is the one signal that proves a renderer.
-			if (readiness.markReady("dom-ready")) {
-				// Window, RPC, push transport AND a live renderer — only now is the
-				// app genuinely usable, so this is where the automated packaged-build
-				// proof gets its marker. No-op without DEV3_READY_MARKER_FILE.
-				writeAppReadyMarker(APP_VERSION);
-			}
+			// The first report writes the proof marker (see the watchdog's onReady).
+			readiness.markReady("dom-ready");
 			if (buildChannel === "dev") {
 				win.webview.openDevTools();
 			}

--- a/src/bun/renderer-readiness.ts
+++ b/src/bun/renderer-readiness.ts
@@ -15,14 +15,23 @@
  * The first webview `dom-ready` is the only signal that a renderer exists, so
  * the launch arms a watchdog on it: ready inside the budget → proceed; silence →
  * the launch has failed and the caller must leave instead of half-running.
- * Measured healthy startups reach dom-ready in 366 ms (Windows, interactive) and
- * 1511 ms (packaged launch proof), so the budget is ~30x the observed cost.
  */
 
 import { CLI_EXIT_CODE_RENDERER_UNAVAILABLE } from "../shared/cli-exit-codes";
 
-/** Budget from window creation to the first `dom-ready`. */
-export const RENDERER_READY_TIMEOUT_MS = 45_000;
+/**
+ * Budget from window creation to the first `dom-ready`.
+ *
+ * Sized off the measured packaged-launch distribution, not off a dev machine.
+ * 40 green `windows-app-archive` proofs (spawn → dom-ready, which brackets this
+ * window from above): min 4.0 s, median 11.1 s, p90 18.7 s, p95 24.8 s, max
+ * 40.5 s — a 10x spread driven by shared-runner speed, not by the app. The
+ * original 45 s came from a 1.5 s single sample and left the slowest healthy
+ * launch only ~10% of headroom, which is what made the CI job flaky. 180 s is
+ * ~4.4x the slowest healthy launch ever observed and still bounded: a machine
+ * with no renderer at all fails with the same diagnostic, just later.
+ */
+export const RENDERER_READY_TIMEOUT_MS = 180_000;
 
 /** Grepped by the Windows launch proof; keep it stable. */
 export const RENDERER_UNAVAILABLE_MARKER = "DEV3_DESKTOP_RENDERER_UNAVAILABLE";
@@ -94,7 +103,8 @@ export interface RendererReadinessOptions {
 	/** Called once, when the budget expires without a renderer. */
 	onTimeout: (timeoutMs: number) => void;
 	onArmed?: (timeoutMs: number) => void;
-	onReady?: (source: string, elapsedMs: number) => void;
+	/** `elapsedMs` is null when the watchdog was never armed — nothing measured it. */
+	onReady?: (source: string, elapsedMs: number | null) => void;
 	setTimer?: (fn: () => void, ms: number) => TimerHandle;
 	clearTimer?: (handle: TimerHandle) => void;
 	now?: () => number;
@@ -145,7 +155,7 @@ export function createRendererReadinessWatchdog(
 				// Nothing to disarm, but the caller still needs "first renderer"
 				// semantics so it can gate one-shot work on it.
 				state = "ready";
-				opts.onReady?.(source, 0);
+				opts.onReady?.(source, null);
 				return true;
 			}
 			state = "ready";
@@ -153,7 +163,7 @@ export function createRendererReadinessWatchdog(
 				clearTimer(timer);
 				timer = null;
 			}
-			opts.onReady?.(source, wasArmed ? now() - armedAt : 0);
+			opts.onReady?.(source, wasArmed ? now() - armedAt : null);
 			return true;
 		},
 		state(): RendererReadinessState {


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that made this change).

## What was wrong

`windows-app-archive` went red on run 31049142202: the packaged app started, logged `=== dev-3.0 ready ===`, then its own readiness watchdog fired 45 s later and the app exited 8 with `DEV3_DESKTOP_RENDERER_UNAVAILABLE`. The 45 s came from decision 177, justified as "~30x the observed cost" against two samples (366 ms interactive, 1511 ms packaged).

## The measurement

The proof script has always recorded `readyAfterMs` (spawn → dom-ready) into `windows-app-launch-proof.json` and CI uploads it on every run. Nobody had read it. Pulled from every available run — **40 green samples**, all GitHub-hosted `windows-latest`:

| n | min | median | p90 | p95 | max |
|---|---|---|---|---|---|
| 40 | 4 036 ms | 11 128 ms | 18 702 ms | 24 825 ms | **40 534 ms** |

The slowest healthy launch sits ~10% under the 45 s budget, not 30x under it. So this is not only a CI flake — a slow or loaded **real** Windows machine can be told it has no UI.

Two things the investigation refuted rather than confirmed:

- The three other red runs in the last 25 are unrelated: their `windows-app-archive` jobs passed, they failed in `package-runtime` on different E2E steps.
- Charging the budget only for non-stalled time would not have helped: the failing run stalled 3 304 ms inside a 45 000 ms window.

What is **not** proven is whether that one run was an extreme tail (>52 s) or a genuine no-renderer condition. Decision 207 says so plainly; the change is falsifiable either way.

## What changed

- `RENDERER_READY_TIMEOUT_MS` 45 s → **180 s**, ~4.4x the slowest measured healthy launch, with the distribution in the comment.
- The watchdog reports elapsed as `null` where it was never armed (macOS/Linux) instead of a fake `0`; `writeAppReadyMarker` records it as `rendererReadyMs`; `index.ts` writes the marker from `onReady`, where the measurement lives.
- `scripts/verify-windows-app-launch.ts` rejects a marker without a non-negative `rendererReadyMs`, surfaces `rendererReadyMs` + `rendererReadyBudgetMs` in the proof, and derives its own poll budget as watchdog + 60 s so the app's actionable diagnostic always wins the race.
- Decision 207 added; decision 177 corrected in place; one `paths` entry added so `src/bun/renderer-readiness.ts` gates the job it controls.

## A real failure still fails loudly

Nothing was made lenient, only longer. A machine with no interactive desktop or broken WebView2 still never fires dom-ready, the watchdog still fires, the app still exits 8 with the same diagnostic — at 180 s instead of 45 s. Two gates were **added**: a marker without a measured `rendererReadyMs` no longer counts as proof, and a test keeps the budget bounded at ≤ 300 s. **No retry at any level** — a retry would turn a 50%-reproducible regression green, and a job-level retry would mask unrelated failures in the same job.

## The trade, stated plainly

This is a trade, not a pure win: the slow case was made to work by making the broken case fail slower. A user whose WebView2 is broken, or who launched with no interactive desktop, now waits 3 minutes instead of 45 s — and during that wait there is **no signal at all**. The native window is created and stays blank (that is the whole failure: the renderer that would draw anything is exactly what is missing); there is no splash, no progress indicator, no notification. The diagnostic goes to stdout and to `~/.dev3.0/logs/<yyyy>/<mm>/<date>.log`, and a double-clicked Windows launch has no console — so what that user actually sees is a blank window for 180 s, then the window vanishes, and the only trace is a log file they have no reason to know exists.

Accepted deliberately: a false "you have no UI" on a working machine is worse than a slow true one. A visible signal during the wait is real missing work and is being tracked separately, deliberately not bolted onto this change.