### PR TITLE
Park promptless scratch tasks in Has Questions on launch

### DIFF
--- a/change-logs/2026/08/06/feature-scratch-task-parks-in-has-questions.md
+++ b/change-logs/2026/08/06/feature-scratch-task-parks-in-has-questions.md
@@ -1,0 +1,3 @@
+Short: Scratch tasks wait in Has Questions
+
+A Scratch task now launches into Has Questions instead of In Progress — it has no prompt, so nothing is happening until you type, and the board says so. The first message you send flips it to In Progress as usual. Codex agents no longer flip a parked task to In Progress just by starting their session.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -365,6 +365,18 @@ describe("getCodexHookTargetStatus", () => {
 		expect(getCodexHookTargetStatus("PreToolUse", "review-by-ai", true)).toBeNull();
 	});
 
+	// A scratch task launches parked in user-questions with no prompt. Codex
+	// fires SessionStart at startup, which must not claim the task is working —
+	// only a real prompt may.
+	it("leaves a task parked in user-questions when the session starts", () => {
+		expect(getCodexHookTargetStatus("SessionStart", "user-questions", false)).toBeNull();
+	});
+
+	it("resumes the remembered status when the session starts after an approval", () => {
+		expect(getCodexHookTargetStatus("SessionStart", "user-questions", false, "in-progress"))
+			.toBe("in-progress");
+	});
+
 	it.each(["todo", "user-questions", "review-by-user"] as const)(
 		"does not overwrite %s when a turn stops",
 		(status) => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -3539,6 +3539,36 @@ describe("handlers.spawnVariants", () => {
 		expect(data.addTask).not.toHaveBeenCalled();
 	});
 
+	// A scratch task launches with no prompt — "Agent is Working" would be a lie.
+	// It parks in Has Questions until the user types; the agent's UserPromptSubmit
+	// hook moves it to in-progress from there.
+	it("parks a scratch task in user-questions instead of in-progress", async () => {
+		const project = makeProject();
+		const sourceTask = makeTask({
+			status: "todo",
+			seq: 5,
+			scratch: true,
+			description: "Scratch — 14:32",
+			worktreePath: null,
+			branchName: null,
+		});
+
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(sourceTask);
+		mockTransformSource(sourceTask);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/vwt", branchName: "dev3/task-task-1" });
+		vi.mocked(data.updateTask).mockResolvedValue(makeTask({ status: "user-questions", worktreePath: "/tmp/vwt" }));
+
+		const result = await handlers.spawnVariants({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			variants: [{ agentId: "agent-1", configId: null }],
+		});
+
+		expect(result[0].status).toBe("user-questions");
+	});
+
 	it("keeps the source task id as variant #1 and creates only variants 2..N when launching multiple variants", async () => {
 		const project = makeProject();
 		const sourceTask = makeTask({ status: "todo", seq: 5, worktreePath: null, branchName: null });

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -370,6 +370,15 @@ async function spawnVariants(params: {
 	const srcBranch = getSourceTaskBranch(sourceTask, project);
 	const isMultiVariant = params.variants.length > 1;
 	const needsWorktree = isActive(params.targetStatus);
+	// A scratch task still carrying its placeholder launches with a blank prompt
+	// (see taskWithLaunchDescription in the executor), so "Agent is Working"
+	// would be a lie — it parks in Has Questions until the user types, and the
+	// agent's UserPromptSubmit hook moves it to in-progress from there.
+	const launchesWithoutPrompt = sourceTask.scratch === true
+		&& isScratchPlaceholderDescription(sourceTask.description);
+	const targetStatus: TaskStatus = launchesWithoutPrompt && needsWorktree
+		? "user-questions"
+		: params.targetStatus;
 
 	const firstVariant = params.variants[0];
 	if (!firstVariant) throw new Error("At least one variant is required");
@@ -377,7 +386,7 @@ async function spawnVariants(params: {
 	const launchedSource = await dispatchLifecycleEvent(project.id, sourceTask.id, {
 		type: "moveRequested",
 		runId: sourceRunId,
-		target: { status: params.targetStatus, customColumnId: null },
+		target: { status: targetStatus, customColumnId: null },
 		taskPatch: {
 			groupId,
 			variantIndex: 1,
@@ -470,7 +479,7 @@ async function spawnVariants(params: {
 			: undefined;
 		resultTasks.push(await dispatchLifecycleEvent(project.id, pendingTask.id, {
 			type: "moveRequested",
-			target: { status: params.targetStatus, customColumnId: null },
+			target: { status: targetStatus, customColumnId: null },
 			taskPatch: {
 				groupId,
 				variantIndex: i + 1,

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -36,7 +36,11 @@ export function getCodexHookTargetStatus(
 	if (currentStatus === "completed" || currentStatus === "cancelled") return null;
 
 	switch (event) {
+		// Starting a session is not working: a scratch task launches parked in
+		// user-questions with no prompt, and only a real prompt may claim it.
 		case "SessionStart":
+			if (currentStatus === "user-questions") return resumeStatus ?? null;
+			return currentStatus === "review-by-ai" ? null : "in-progress";
 		case "UserPromptSubmit":
 		case "PreToolUse":
 		case "PostToolUse":

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -212,7 +212,7 @@ For the full command reference (rename / swap / move windows, resize, capture ou
 const SKILL_SCRATCH_TASK = `
 ## Scratch tasks
 
-If your task title starts with \`Scratch — \` (e.g. \`Scratch — 14:32\`), the user clicked "Scratch Task" — there is no initial instruction and the \`description\` is just the placeholder title. Greet the user in one short line and ask what they want to do. As soon as they answer, treat that message as the task description: set a real title, overview, and labels (session-start checklist) and proceed as normal.
+If your task title starts with \`Scratch — \` (e.g. \`Scratch — 14:32\`), the user clicked "Scratch Task" — there is no initial instruction and the \`description\` is just the placeholder title. The task launches parked in **Has Questions** on purpose — nothing is expected of you until someone writes, and you must not move it out of that column yourself. Greet the user in one short line and ask what they want to do. As soon as they answer, treat that message as the task description: set a real title, overview, and labels (session-start checklist) and proceed as normal.
 
 If instead a peer **agent** started you, your first message says so and names the task that asked — report progress and results back to it with the \`dev3 message --task seq:<N>\` command in that message, and treat its instructions as your task description.
 `;


### PR DESCRIPTION
## Summary

A Scratch task launches with no prompt, so parking it in **In Progress** claimed the agent was working when nothing was happening. It now lands in **Has Questions** until someone writes to it; the agent's `UserPromptSubmit` hook moves it to In Progress on the first message.

- `spawnVariants` (`src/bun/rpc-handlers/task-lifecycle.ts`) overrides the target column to `user-questions` when the task is scratch **and** its description is still the `Scratch — HH:MM` placeholder — the same predicate the executor uses to blank the launch prompt. A scratch task whose description was edited into a real prompt still goes to In Progress.
- The override lives in the backend rather than the renderer, so the Scratch Task button, a deferred "Start in…" launch, and every other UI entry point get it for free.
- Codex fires a `SessionStart` hook at startup which used to map `user-questions → in-progress` and would have undone the park immediately. `getCodexHookTargetStatus` now returns `null` for that case (or the remembered approval resume status). Claude has no `SessionStart` hook and was unaffected.
- Agent skill text tells the agent the Has Questions column is deliberate and not to move the task itself.

Left unchanged on purpose: a scratch task launched by a **peer agent** (`task.createScratchAndRun`) still targets In Progress — it is waiting on the requesting agent, not on the user, and that path also runs with `enforceAllowedTransition: true`, where `todo → user-questions` is not an allowed transition.