### PR TITLE
Roll back a bug hunter launch when the prompt provably never landed

### DIFF
--- a/change-logs/2026/08/06/fix-hunter-launch-rolls-back-on-unproven-prompt.md
+++ b/change-logs/2026/08/06/fix-hunter-launch-rolls-back-on-unproven-prompt.md
@@ -1,0 +1,5 @@
+Short: Find bugs no longer leaves silent hunter panes
+
+Launching bug hunters on a tmux task now waits for each hunt prompt to actually reach its pane instead of firing it blind. If a pane provably never got its prompt, the whole launch is undone and you get an error naming that pane, rather than a hunter sitting at an empty prompt you would have to notice and close by hand. A delivery whose fate cannot be proven keeps its pane. The visible trade-off: the Find bugs action now takes about five seconds before it finishes, the way it already did on the native terminal backend.
+
+Declared ride-along, unrelated to the fix above: `decisions/209-required-checks-wait-for-windows-packaging.md` stated the new Windows gate's cost as about +4 minutes, which the gate's first live run measured at +4m45 — corrected here with the run id and the reason the first estimate was low, because the estimate came from per-job durations and the scope job runs serially in front of the packaging jobs.

--- a/decisions/209-required-checks-wait-for-windows-packaging.md
+++ b/decisions/209-required-checks-wait-for-windows-packaging.md
@@ -109,13 +109,20 @@ so the proof is not skippable forever.
 
 Other risks:
 
-- **Wall-clock: the required `test` context goes from roughly 1 m 10 s to roughly 5 m 10 s on in-scope
-  PRs, and is unchanged on out-of-scope ones — about +4 minutes.** Today's critical path is the test
-  shards at ~1 m 07 s (measured on run 31082720488, where the live terminal e2e legs at 1 m 01 s and 41 s
-  sat under it and cost nothing). The packaging jobs do not sit under it: `package-runtime (windows-latest)`
-  and `windows-app-archive` are ~305 s p50 each, p90 ~350 s, worst observed 462 s. So unlike the terminal
-  gate, this one does move the critical path, by design. These are per-job durations excluding runner
-  queueing, so treat them as a floor. Accepted deliberately — a cost, not a rounding error.
+- **Wall-clock: the required `test` context goes from roughly 1 m 10 s to 6 m 00 s on in-scope PRs, and
+  is unchanged on out-of-scope ones — about +4 m 45 s.** Measured on run 31083965892, the gate's first
+  live run: `test` green at +359 s against a +72 s baseline (slowest shard 67 s plus a 5 s aggregator),
+  so +287 s. This line first said +4 minutes and was 47–49 s optimistic, because that estimate was
+  derived from per-job durations. `windows-app-archive` ran 5 m 31 s of *duration* yet completed at
+  +348 s, because the called workflow does not dispatch until `windows_scope` reports and the scope job
+  is serial in front of the packaging jobs by design. **So the added wall-clock is scope job + dispatch
+  latency + slowest packaging job, minus whatever the old critical path already covered — never
+  `max(packaging durations)`, which underestimates by roughly the scope job.** The critical path without
+  the gate is the test shards at ~1 m 07 s (run 31082720488, where the live terminal e2e legs at 1 m 01 s
+  and 41 s sat under it and cost nothing). The packaging jobs do not sit under it: `package-runtime
+  (windows-latest)` and `windows-app-archive` are ~305 s p50 each, p90 ~350 s, worst observed 462 s. So
+  unlike the terminal gate, this one does move the critical path, by design. Per-job durations exclude
+  runner queueing, so treat them as a floor. Accepted deliberately — a cost, not a rounding error.
 - **`strict=false` is untouched and this change does not improve it.** PRs need not be up to date with
   `main`, so the Windows proof can be green against a stale base and merge onto a moved one. Worse, the
   scope decision is computed from the PR's own diff, so a file that becomes Windows-relevant on `main`

--- a/decisions/210-hunter-prompt-verdict-decides-the-launch.md
+++ b/decisions/210-hunter-prompt-verdict-decides-the-launch.md
@@ -1,0 +1,72 @@
+# 210 — A bug hunter launch lives or dies by its prompt's verdict, on both backends
+
+## Context
+
+`spawnBugHuntersInTask` opens N panes and types the hunt prompt into each. The native
+arm already undid the whole launch when a prompt did not land; the tmux arm fired two
+`send-keys` calls per pane from nested `setTimeout`s with `bestEffort: true`, and a
+comment stated that tmux cannot prove a delivery. `201-backend-neutral-pane-input` made
+that false: the
+guarded seam pins a pane to one tmux server generation and answers with a named verdict.
+A hunter pane that never got its prompt is a zombie the user has to spot and close.
+
+## Investigation
+
+Measured live against a real tmux server on a throwaway socket, driving
+`deliverAgentPrompt` itself rather than a mock:
+
+| Case | Verdict |
+|---|---|
+| live shell pane | `delivered`, and `capture-pane` shows the command ran |
+| pane killed, server alive | `not-delivered` / `pane-absent` — `no pane %1 on this tmux server` |
+| pane id that never existed | `not-delivered` / `pane-absent` |
+| whole server killed | `not-delivered` / `backend-failure` — `listing panes failed … no server running` |
+
+"The pane is gone" and "tmux could not answer" stay distinct, so the message the user
+gets names which one happened.
+
+## Decision
+
+Both backends now go through `deliverAgentPrompt` (`src/bun/rpc-handlers/tmux-pty.ts`,
+`deliverHunterPrompt` + the delivery loop in `spawnBugHuntersInTask`) and act on the
+`AgentPromptDelivery` vocabulary from seq 1421 — no second vocabulary. Only a proven
+`not-delivered` undoes the launch; `unconfirmed` keeps the pane and logs. Rollback is
+now backend-neutral (`rollBackHunterLaunch`), and a rolled-back tmux pane is retired
+from `sessionState` by hand, because `kill-pane` fires no `pane-exited` hook. The false
+comment went with the behaviour, in this commit, not before it.
+
+Two deliberate divergences from the native arm as it stood, rather than quiet ones:
+
+1. A **throw** from delivery no longer rolls back. It carries no verdict, so killing the
+   pane would collapse "cannot say" into failure — the exact move
+   `201-backend-neutral-pane-input` exists to prevent. It is reported as `unconfirmed`.
+2. The native arm's check was `if (!(await sendPromptToNativePane(...)))`. Seq 1421
+   (`4232a0211`) widened that function's return from a boolean to an `AgentPromptDelivery`
+   object, and every return path is a non-null object, so the test became always-false.
+   The caller was never touched; only the callee's type moved. Scope, precisely: the
+   `catch` arm and the split / layout failures earlier in the function still rolled back —
+   what died is the delivery **verdict** path, which is the realistic one, because
+   `sendPromptToNativePane` was written to turn every provable failure into a returned
+   `not-delivered` rather than a throw. Neither safety net could see it: `!someObject` is
+   legal TypeScript, and the suite's negative case drove the mock with
+   `mockResolvedValueOnce(false)` — a value the real function can no longer produce, so
+   it was green because it asserted a path production could not reach. One broken call
+   site in `src/`; every other consumer discriminates on `.status`. Routing through the
+   seam restores it, and the mocks now return real delivery objects.
+
+## Risks
+
+The tmux launch now awaits the prompt (~5 s boot plus ~0.8 s per hunter) instead of
+returning immediately, so the Find bugs action takes that long before the dialog closes —
+native already behaved this way. Where the whole tmux server is gone the rollback cannot
+close anything, so the error names the panes as "still open" even though the server took
+them with it; the headline still reports the real failure. The seam routes on
+`task.tmuxSocket`, while the surrounding launch uses `pty.getSessionSocket`; these agree
+in production, and `201-backend-neutral-pane-input` makes the task the authority.
+
+## Alternatives considered
+
+Keeping tmux fire-and-forget and reporting the zombie panes afterwards (nothing reads
+that report — the user does). Rolling back on `unconfirmed` too (kills panes that may
+already be hunting). Rolling back only the pane that failed (the user asked for N hunters;
+a silently smaller set is the outcome the native arm already refuses to produce).

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -171,7 +171,8 @@ const mockNativePanes = {
 };
 vi.mock("../native-task-panes", () => mockNativePanes);
 
-const mockSendPromptToNativePane = vi.fn(async () => true);
+/** The native arm of the seam: its best answer is `unconfirmed`, never `delivered`. */
+const mockSendPromptToNativePane = vi.fn(async () => ({ status: "unconfirmed", reason: "unacknowledged" }) as any);
 vi.mock("../agent-prompt-native", () => ({
 	sendPromptToNativePane: (...args: any[]) => mockSendPromptToNativePane(...(args as [])),
 	sendPromptToNativeAgentPane: vi.fn(async () => true),
@@ -5563,6 +5564,7 @@ describe("handlers.resolvePrUrl", () => {
 describe("handlers.getTaskDiff", () => {
 	beforeEach(() => vi.clearAllMocks());
 
+
 	it("throws when task has no worktree", async () => {
 		const project = makeProject();
 		const task = makeTask({ worktreePath: null });
@@ -8721,17 +8723,116 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		vi.useRealTimers();
 	});
 
-	function makeSplitMock(paneIds: string[]) {
+	/**
+	 * A fake tmux SERVER, not a fake seam: it answers the split, the pane sighting the
+	 * guarded seam pins against, the guarded send itself, and kill-pane. Delivery runs
+	 * through that seam now (`201-backend-neutral-pane-input`), so a test can name WHY a delivery failed —
+	 * an unlisted pane, a guard that refused, a command that exited non-zero — instead
+	 * of only seeing that the launch threw.
+	 */
+	const HUNTER_TOKEN = "srv-hunter-1";
+	const HUNTER_SESSION = "dev3-abcd1234";
+
+	interface GuardedSend {
+		pane: string;
+		/** The literal text this send puts into the pane, decoded from its `-H` hex. */
+		text: string;
+		/** The key names this send presses. */
+		keys: string[];
+		exitCode: number;
+	}
+
+	function parseGuardedCommands(commandList: string): { text: string; keys: string[] } {
+		let text = "";
+		const keys: string[] = [];
+		for (const command of commandList.split(" ; ")) {
+			const hex = command.split(" -H ")[1];
+			if (hex !== undefined) {
+				text += Buffer.from(hex.split(" ").join(""), "hex").toString("utf8");
+				continue;
+			}
+			const parts = command.split(" ");
+			if (parts[0] === "send-keys") keys.push(...parts.slice(3));
+		}
+		return { text, keys };
+	}
+
+	function makeSplitMock(
+		paneIds: string[],
+		opts: {
+			/** Panes the server will not list when the seam pins them. */
+			unlistedPanes?: string[];
+			/** Panes whose guard refuses, so nothing is sent. */
+			guardRefuses?: string[];
+			/** Panes whose guarded send exits non-zero — fate unknown. */
+			sendFails?: string[];
+			/** kill-pane fails, the way a pane that will not go looks. */
+			killFails?: boolean;
+			/** The server cannot answer at all — measured live as `no server running`. */
+			listPanesFails?: boolean;
+		} = {},
+	) {
 		let i = 0;
 		const enc = new TextEncoder();
-		mockSpawn.mockImplementation((args: string[]) => {
-			const isSplit = args.includes("split-window");
-			if (isSplit) {
-				const pane = paneIds[i++] ?? `%99`;
-				return { stderr: enc.encode(""), stdout: enc.encode(pane), exited: Promise.resolve(0) };
-			}
-			return { stderr: enc.encode(""), stdout: enc.encode(""), exited: Promise.resolve(0) };
+		const opened: string[] = [];
+		const killed: string[] = [];
+		const sends: GuardedSend[] = [];
+		const reply = (stdout: string, exitCode = 0) => ({
+			stderr: enc.encode(""),
+			stdout: enc.encode(stdout),
+			exited: Promise.resolve(exitCode),
 		});
+		mockSpawn.mockImplementation((args: string[]) => {
+			if (args.includes("split-window")) {
+				const pane = paneIds[i++] ?? `%99`;
+				opened.push(pane);
+				return reply(pane);
+			}
+			// The pane sighting: pane id, dead flag, server token, session name.
+			if (args.includes("list-panes") && args.some((arg) => arg.includes("@dev3_server_token"))) {
+				if (opts.listPanesFails) return reply("", 1);
+				const rows = opened
+					.filter((pane) => !killed.includes(pane) && !(opts.unlistedPanes ?? []).includes(pane))
+					.map((pane) => `${pane}\t0\t${HUNTER_TOKEN}\t${HUNTER_SESSION}`);
+				return reply(rows.join("\n"));
+			}
+			const guardIndex = args.indexOf("if-shell");
+			if (guardIndex >= 0) {
+				const pane = args[guardIndex + 2];
+				const exitCode = (opts.sendFails ?? []).includes(pane) ? 1 : 0;
+				sends.push({ pane, ...parseGuardedCommands(args[guardIndex + 5] ?? ""), exitCode });
+				if (exitCode !== 0) return reply("", exitCode);
+				// No marker on stdout is how tmux reports "the guard was false".
+				return reply((opts.guardRefuses ?? []).includes(pane) ? "" : "dev3-pane-input-sent\n");
+			}
+			if (args.includes("kill-pane")) {
+				const pane = args[args.indexOf("-t") + 1];
+				if (opts.killFails) return reply("no such pane", 1);
+				killed.push(pane);
+				return reply("");
+			}
+			return reply("");
+		});
+		return {
+			sends,
+			sendsTo: (pane: string) => sends.filter((send) => send.pane === pane),
+			killed: () => killed,
+		};
+	}
+
+	/**
+	 * Launch and let the boot delay plus every pane's inter-stage delay elapse. The
+	 * prompt is awaited on tmux now, so the launch cannot settle before its timers do.
+	 */
+	function runLaunch<T>(started: Promise<T>, panes: number): Promise<T> {
+		const settled = started.catch(() => undefined);
+		return vi
+			.advanceTimersByTimeAsync(5000)
+			.then(async () => {
+				for (let pane = 0; pane < panes; pane++) await vi.advanceTimersByTimeAsync(800);
+			})
+			.then(() => settled)
+			.then(() => started);
 	}
 
 	it("creates N panes: first horizontal 50% off the session, rest vertical off the previous right pane", async () => {
@@ -8740,9 +8841,12 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		(data.getProject as any).mockResolvedValue(project);
 		(data.getTask as any).mockResolvedValue(task);
 		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
-		makeSplitMock(["%10", "%11", "%12"]);
+		const server = makeSplitMock(["%10", "%11", "%12"]);
 
-		const result = await handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 3 });
+		const result = await runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 3 }),
+			3,
+		);
 
 		expect(result).toEqual({ spawned: 3 });
 
@@ -8768,19 +8872,15 @@ describe("handlers.spawnBugHuntersInTask", () => {
 			expect(script).toContain("export DEV3_ARTIFACT_TEMPLATE_DIR='/tmp/test-dev3/artifact-template-v1'");
 		}
 
-		// After 5s the auto-paste of /dev3-bug-hunter happens. The prompt MUST
-		// lock the hunter to changes in this branch only — otherwise hunters
-		// would roam the whole codebase, which is not the intent in the local
-		// lightbox path. Prompt and Enter are sent as TWO separate send-keys
-		// calls (paste, then Enter after a delay) so Claude does not treat the
-		// trailing Enter as a newline inside a bracketed paste.
-		vi.advanceTimersByTime(5100);
-		const pasteCalls = mockSpawn.mock.calls
-			.map((c) => c[0] as string[])
-			.filter((args) => args.includes("send-keys") && !args.includes("Enter"));
+		// After the boot delay each hunter gets the /dev3-bug-hunter prompt. The prompt
+		// MUST lock the hunter to changes in this branch only — otherwise hunters would
+		// roam the whole codebase, which is not the intent in the local lightbox path.
+		// Text and Enter are TWO guarded sends per pane (`201-backend-neutral-pane-input`), so Claude does
+		// not read the trailing Enter as a newline inside a bracketed paste.
+		expect(server.sends.map((send) => send.pane)).toEqual(["%10", "%10", "%11", "%11", "%12", "%12"]);
+		const pasteCalls = server.sends.filter((send) => send.text !== "");
 		expect(pasteCalls).toHaveLength(3);
-		for (const args of pasteCalls) {
-			const prompt = args[args.length - 1];
+		for (const { text: prompt } of pasteCalls) {
 			expect(prompt).toContain("/dev3-bug-hunter");
 			expect(prompt).toContain("read-only helper inside a task owned by the main agent");
 			expect(prompt).toContain("Do NOT run the dev3 session-start checklist");
@@ -8801,16 +8901,11 @@ describe("handlers.spawnBugHuntersInTask", () => {
 			expect(prompt).toContain("do NOT create any");
 		}
 
-		// Enter not pressed yet.
-		const enterCallsBeforeDelay = mockSpawn.mock.calls.map((c) => c[0] as string[]).filter((args) => args.includes("send-keys") && args.includes("Enter"));
-		expect(enterCallsBeforeDelay).toHaveLength(0);
-
-		// After another 800ms the Enter goes in as a discrete keypress.
-		vi.advanceTimersByTime(900);
-		const enterCalls = mockSpawn.mock.calls.map((c) => c[0] as string[]).filter((args) => args.includes("send-keys") && args.includes("Enter"));
+		// The submit is its own guarded send, one per pane, carrying no text.
+		const enterCalls = server.sends.filter((send) => send.text === "");
 		expect(enterCalls).toHaveLength(3);
-		for (const args of enterCalls) {
-			expect(args[args.length - 1]).toBe("Enter");
+		for (const { keys } of enterCalls) {
+			expect(keys).toEqual(["Enter"]);
 		}
 	});
 
@@ -8836,13 +8931,16 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		});
 		makeSplitMock(["%10"]);
 
-		await handlers.spawnBugHuntersInTask({
-			taskId: persistedTask.id,
-			projectId: project.id,
-			agentId: "hunter-agent",
-			configId: "hunter-config",
-			count: 1,
-		});
+		await runLaunch(
+			handlers.spawnBugHuntersInTask({
+				taskId: persistedTask.id,
+				projectId: project.id,
+				agentId: "hunter-agent",
+				configId: "hunter-config",
+				count: 1,
+			}),
+			1,
+		);
 
 		expect(persistedTask).toMatchObject({
 			agentId: "primary-agent",
@@ -8865,17 +8963,16 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		(data.getProject as any).mockResolvedValue(project);
 		(data.getTask as any).mockResolvedValue(task);
 		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "codex", extraEnv: {}, agent: { baseCommand: "codex" } });
-		makeSplitMock(["%10", "%11"]);
+		const server = makeSplitMock(["%10", "%11"]);
 
-		await handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-codex", configId: "codex-default", count: 2 });
+		await runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-codex", configId: "codex-default", count: 2 }),
+			2,
+		);
 
-		vi.advanceTimersByTime(5100);
-		const pasteCalls = mockSpawn.mock.calls
-			.map((c) => c[0] as string[])
-			.filter((args) => args.includes("send-keys") && !args.includes("Enter"));
+		const pasteCalls = server.sends.filter((send) => send.text !== "");
 		expect(pasteCalls).toHaveLength(2);
-		for (const args of pasteCalls) {
-			const prompt = args[args.length - 1];
+		for (const { text: prompt } of pasteCalls) {
 			expect(prompt).toContain("$dev3-bug-hunter");
 			expect(prompt).not.toContain("/dev3-bug-hunter");
 		}
@@ -8887,16 +8984,16 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		(data.getProject as any).mockResolvedValue(project);
 		(data.getTask as any).mockResolvedValue(task);
 		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
-		makeSplitMock(["%10"]);
+		const server = makeSplitMock(["%10"]);
 
-		await handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 1 });
+		await runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 1 }),
+			1,
+		);
 
-		vi.advanceTimersByTime(5100);
-		const pasteCalls = mockSpawn.mock.calls
-			.map((c) => c[0] as string[])
-			.filter((args) => args.includes("send-keys") && !args.includes("Enter"));
+		const pasteCalls = server.sends.filter((send) => send.text !== "");
 		expect(pasteCalls).toHaveLength(1);
-		const prompt = pasteCalls[0][pasteCalls[0].length - 1];
+		const prompt = pasteCalls[0].text;
 		expect(prompt).toContain("git merge-base upstream/release HEAD");
 		expect(prompt).not.toContain("origin/main");
 	});
@@ -8907,15 +9004,14 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		(data.getProject as any).mockResolvedValue(project);
 		(data.getTask as any).mockResolvedValue(task);
 		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
-		makeSplitMock(["%10"]);
+		const server = makeSplitMock(["%10"]);
 
-		await handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 1 });
+		await runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count: 1 }),
+			1,
+		);
 
-		vi.advanceTimersByTime(5100);
-		const pasteCalls = mockSpawn.mock.calls
-			.map((c) => c[0] as string[])
-			.filter((args) => args.includes("send-keys") && !args.includes("Enter"));
-		const prompt = pasteCalls[0][pasteCalls[0].length - 1];
+		const prompt = server.sends.filter((send) => send.text !== "")[0].text;
 		expect(prompt).toContain("git merge-base main HEAD");
 		expect(prompt).not.toContain("origin/main");
 	});
@@ -8926,13 +9022,123 @@ describe("handlers.spawnBugHuntersInTask", () => {
 		(data.getProject as any).mockResolvedValue(project);
 		(data.getTask as any).mockResolvedValue(task);
 		(agents.resolveCommandForProject as any).mockResolvedValue({ command: "claude", extraEnv: {} });
-		makeSplitMock(["%a", "%b", "%c", "%d", "%e", "%f", "%g"]);
+		makeSplitMock(["%1", "%2", "%3", "%4", "%5", "%6", "%7"]);
 
-		const result = await handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: null, configId: null, count: 99 });
+		const result = await runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: null, configId: null, count: 99 }),
+			6,
+		);
 
 		expect(result.spawned).toBe(6);
 		const splitCalls = mockSpawn.mock.calls.map((c) => c[0] as string[]).filter((args) => args.includes("split-window"));
 		expect(splitCalls).toHaveLength(6);
+	});
+
+	// ── The prompt decides the launch (seq 1430) ────────────────────────────
+	//
+	// Every case below asserts the CAUSE — how many guarded sends each pane got,
+	// and which panes were killed — never just "the launch threw". A launch that
+	// failed for an unrelated reason produces the same rejection, so counting the
+	// executions is the only assertion a wrong cause cannot fake.
+
+	function arrangeTmuxHunterTask() {
+		const project = makeProject();
+		const task = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/wt" });
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockResolvedValue(task);
+		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
+	}
+
+	function launchTmuxHunters(count: number): Promise<{ spawned: number }> {
+		return runLaunch(
+			handlers.spawnBugHuntersInTask({ taskId: "abcd1234-full-id", projectId: "proj-1", agentId: "builtin-claude", configId: "claude-default", count }),
+			count,
+		);
+	}
+
+	it("rolls the tmux launch back when the guard refuses one pane's prompt", async () => {
+		arrangeTmuxHunterTask();
+		const server = makeSplitMock(["%10", "%11"], { guardRefuses: ["%11"] });
+
+		await expect(launchTmuxHunters(2)).rejects.toThrow(
+			"All 2 hunter panes opened, but the hunt prompt never reached %11 (incarnation-changed); launch rolled back.",
+		);
+
+		// The cause: %11 was pinned and its FIRST stage was refused, so exactly one
+		// guarded send ran against it — a pin that had failed would have run zero.
+		expect(server.sendsTo("%11")).toHaveLength(1);
+		expect(server.sendsTo("%10")).toHaveLength(2);
+		expect(server.killed()).toEqual(["%10", "%11"]);
+	});
+
+	it("rolls the tmux launch back when a hunter pane is not on the server any more", async () => {
+		arrangeTmuxHunterTask();
+		const server = makeSplitMock(["%10", "%11"], { unlistedPanes: ["%10"] });
+
+		await expect(launchTmuxHunters(2)).rejects.toThrow(/never reached %10 \(pane-absent\)/);
+
+		// An absent pane is refused by the pin, so NOTHING was sent to it — that is
+		// what tells this apart from the guard refusing a pane that does exist.
+		expect(server.sendsTo("%10")).toHaveLength(0);
+		expect(server.sendsTo("%11")).toHaveLength(2);
+		expect(server.killed()).toEqual(["%10", "%11"]);
+	});
+
+	it("keeps the tmux launch when a send's fate is unknown, instead of killing a pane that may be hunting", async () => {
+		arrangeTmuxHunterTask();
+		const server = makeSplitMock(["%10", "%11"], { sendFails: ["%10"] });
+
+		const result = await launchTmuxHunters(2);
+
+		expect(result).toEqual({ spawned: 2 });
+		// A send that exited non-zero may have applied a prefix of its stage, so the
+		// verdict is "cannot say" and the pane stays. Cause: it was attempted once.
+		expect(server.sendsTo("%10")).toHaveLength(1);
+		expect(server.sendsTo("%11")).toHaveLength(2);
+		expect(server.killed()).toEqual([]);
+	});
+
+	// Measured live against a real tmux server: killing the pane answers pane-absent,
+	// killing the whole SERVER answers backend-failure with "no server running". Two
+	// different facts about the world, and the message must not merge them.
+	it("says the server could not answer, rather than that the pane is gone", async () => {
+		arrangeTmuxHunterTask();
+		const server = makeSplitMock(["%10"], { listPanesFails: true });
+
+		await expect(launchTmuxHunters(1)).rejects.toThrow(/never reached %10 \(backend-failure\)/);
+
+		// Nothing was sent: the pin could not be taken, so no guarded send ever ran.
+		expect(server.sendsTo("%10")).toHaveLength(0);
+	});
+
+	it("names the tmux panes the rollback could not close", async () => {
+		arrangeTmuxHunterTask();
+		const server = makeSplitMock(["%10", "%11"], { guardRefuses: ["%10", "%11"], killFails: true });
+
+		await expect(launchTmuxHunters(2)).rejects.toThrow(
+			/the rollback could not close %10, %11 — those panes are still open, close them by hand\./,
+		);
+
+		expect(server.killed()).toEqual([]);
+	});
+
+	it("retires a rolled-back tmux pane from sessionState", async () => {
+		const project = makeProject();
+		let persistedTask = makeTask({ id: "abcd1234-full-id", worktreePath: "/tmp/wt" });
+		(data.getProject as any).mockResolvedValue(project);
+		(data.getTask as any).mockImplementation(async () => persistedTask);
+		(data.updateTask as any).mockImplementation(async (_project: Project, _taskId: string, patch: Partial<Task>) => {
+			persistedTask = { ...persistedTask, ...patch };
+			return persistedTask;
+		});
+		(agents.resolveCommandForAgent as any).mockResolvedValue({ command: "claude", extraEnv: {} });
+		makeSplitMock(["%10"], { guardRefuses: ["%10"] });
+
+		await expect(launchTmuxHunters(1)).rejects.toThrow(/never reached %10/);
+
+		// kill-pane fires no pane-exited hook, so the entry this launch appended has to
+		// be gone by hand — otherwise the next prompt can be aimed at a dead pane.
+		expect(persistedTask.sessionState?.panes ?? []).toEqual([]);
 	});
 
 	it("throws when task has no worktree", async () => {
@@ -8961,7 +9167,7 @@ describe("handlers.spawnBugHuntersInTask on a native task", () => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
 		(globalThis as any).Bun.write = vi.fn().mockResolvedValue(undefined);
-		mockSendPromptToNativePane.mockResolvedValue(true);
+		mockSendPromptToNativePane.mockResolvedValue({ status: "unconfirmed", reason: "unacknowledged" } as any);
 		mockNativePanes.focusNativeTaskPane.mockResolvedValue(null as any);
 		mockNativePanes.closeNativeTaskPane.mockResolvedValue({ sessionTornDown: false, state: null } as any);
 	});
@@ -9128,26 +9334,30 @@ describe("handlers.spawnBugHuntersInTask on a native task", () => {
 	it("fails the launch when a prompt is reported undelivered", async () => {
 		arrangeNativeTask();
 		const set = arrangeNativePaneSet();
-		mockSendPromptToNativePane.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		mockSendPromptToNativePane
+			.mockResolvedValueOnce({ status: "unconfirmed", reason: "unacknowledged" } as any)
+			.mockResolvedValueOnce({ status: "not-delivered", reason: "owner-unknown" } as any);
 
 		// Not "only 2 of 2 could be started" — the panes DID open, the prompt did not land.
 		await expect(launchHunters(2)).rejects.toThrow(
-			"All 2 hunter panes opened, but the hunt prompt never reached pane-3; launch rolled back.",
+			"All 2 hunter panes opened, but the hunt prompt never reached pane-3 (owner-unknown); launch rolled back.",
 		);
 
 		expect(set.paneIds()).toEqual(["pane-1"]);
 		expect(set.activePaneId()).toBe("pane-1");
 	});
 
-	it("fails the launch when a prompt delivery throws", async () => {
+	// A throw carries no verdict, so it cannot join the proven failures: killing a
+	// pane whose prompt MAY have landed is the collapse `201-backend-neutral-pane-input` forbids.
+	it("keeps the panes when a prompt delivery throws, because nothing can say whether it landed", async () => {
 		arrangeNativeTask();
 		const set = arrangeNativePaneSet();
 		mockSendPromptToNativePane.mockRejectedValue(new Error("writer lease is gone"));
 
-		await expect(launchHunters(2)).rejects.toThrow(/writer lease is gone/);
+		await expect(launchHunters(2)).resolves.toEqual({ spawned: 2 });
 
-		expect(set.paneIds()).toEqual(["pane-1"]);
-		expect(set.activePaneId()).toBe("pane-1");
+		expect(mockSendPromptToNativePane).toHaveBeenCalledTimes(2);
+		expect(set.paneIds()).toEqual(["pane-1", "pane-2", "pane-3"]);
 	});
 
 	it("rolls the whole launch back when a later split fails, instead of leaving a partial set", async () => {

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -51,7 +51,8 @@ import {
 	setNativeTaskPaneLayout,
 } from "../native-task-panes";
 import { setSplitRatio, splitCreatedBySplitting } from "../../shared/split-tree";
-import { sendPromptToNativePane } from "../agent-prompt-native";
+import { deliverAgentPrompt } from "../agent-prompt-delivery";
+import { agentPromptMayHaveLanded, type AgentPromptDelivery } from "../../shared/agent-prompt-delivery";
 import {
 	auxPaneAlive,
 	auxPaneTitle,
@@ -2564,8 +2565,8 @@ async function spawnAgentInTask(params: { taskId: string; projectId: string; age
 	log.info("← spawnAgentInTask done", { taskId: params.taskId.slice(0, 8) });
 }
 
+/** How long the hunter agents get to boot before their prompt is typed in. */
 const BUG_HUNTER_AUTOTYPE_DELAY_MS = 5000;
-const BUG_HUNTER_ENTER_DELAY_MS = 800;
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -2758,13 +2759,14 @@ async function equalizeNativeHunterColumn(taskId: string, anchors: string[]): Pr
 }
 
 /**
- * Undo a native launch that went wrong, and build the error the user sees.
- * `headline` says what actually failed; this adds what the cleanup achieved.
+ * Undo a hunter launch that went wrong, on whichever backend it ran, and build the
+ * error the user sees. `headline` says what actually failed; this adds what the
+ * cleanup achieved.
  *
  * A close that fails is NAMED — claiming the launch was rolled back while panes
  * are still on screen is the one outcome this must never produce.
  */
-async function rollBackNativeHunters(
+async function rollBackHunterLaunch(
 	task: Task,
 	handles: AuxPaneHandle[],
 	socket: string,
@@ -2782,6 +2784,14 @@ async function rollBackNativeHunters(
 				paneId: handle.paneId,
 				error: String(err),
 			});
+			continue;
+		}
+		// kill-pane does not fire tmux's pane-exited hook, so the pane this launch
+		// appended to sessionState has to be retired here or it outlives the rollback.
+		if (handle.backend === "tmux") {
+			await handlePaneExited(task.id, handle.paneId).catch((err) =>
+				log.warn("Could not retire a rolled-back hunter pane from sessionState", { paneId: handle.paneId, error: String(err) }),
+			);
 		}
 	}
 	if (focusedBefore) await focusNativeTaskPane(task.id, focusedBefore).catch(() => {});
@@ -2793,6 +2803,20 @@ async function rollBackNativeHunters(
 		);
 	}
 	return new Error(`${headline}; launch rolled back.`);
+}
+
+/**
+ * One hunter's prompt, as a verdict rather than an exception. A throw carries no
+ * verdict — nothing can then say whether the text landed — so it becomes
+ * `unconfirmed` and keeps the pane, instead of joining the proven failures that
+ * undo the launch.
+ */
+async function deliverHunterPrompt(task: Task, paneId: string, prompt: string): Promise<AgentPromptDelivery> {
+	try {
+		return await deliverAgentPrompt(task, prompt, { kind: "pane", paneId });
+	} catch (err) {
+		return { status: "unconfirmed", reason: "backend-failure", detail: String(err) };
+	}
 }
 
 async function spawnBugHuntersInTask(params: { taskId: string; projectId: string; agentId: string | null; configId: string | null; count: number; accountId?: string | null }): Promise<{ spawned: number }> {
@@ -2875,7 +2899,7 @@ async function spawnBugHuntersInTask(params: { taskId: string; projectId: string
 				opened: handles.length,
 				error: String(err),
 			});
-			throw await rollBackNativeHunters(
+			throw await rollBackHunterLaunch(
 				task,
 				handles,
 				socket,
@@ -2897,7 +2921,7 @@ async function spawnBugHuntersInTask(params: { taskId: string; projectId: string
 				taskId: params.taskId.slice(0, 8),
 				error: String(err),
 			});
-			throw await rollBackNativeHunters(
+			throw await rollBackHunterLaunch(
 				task,
 				handles,
 				socket,
@@ -2923,50 +2947,43 @@ async function spawnBugHuntersInTask(params: { taskId: string; projectId: string
 		);
 	}
 
-	if (native) {
-		// A native delivery can be PROVEN — sendPromptToNativePane resolves the pane's
-		// writer lease and reports whether the text landed. So its verdict decides the
-		// launch: a hunter sitting at an empty prompt is not a hunter.
-		await sleep(BUG_HUNTER_AUTOTYPE_DELAY_MS);
-		const undelivered: string[] = [];
-		for (const handle of handles) {
-			try {
-				if (!(await sendPromptToNativePane(task, handle.paneId, prompt))) undelivered.push(handle.paneId);
-			} catch (err) {
-				undelivered.push(`${handle.paneId} (${String(err)})`);
-			}
+	// The prompt decides the launch on BOTH backends. Delivery runs through the guarded
+	// seam (`201-backend-neutral-pane-input`): the pane is pinned to one backend generation, and the answer
+	// is one of three — landed, cannot say, or provably nothing sent. Only the last one
+	// undoes the launch, because a hunter that never got its prompt is a pane the user
+	// has to notice and close by hand, while a pane that may have got it must not be
+	// killed on a guess.
+	await sleep(BUG_HUNTER_AUTOTYPE_DELAY_MS);
+	const undelivered: string[] = [];
+	for (const handle of handles) {
+		const delivery = await deliverHunterPrompt(task, handle.paneId, prompt);
+		if (!agentPromptMayHaveLanded(delivery)) {
+			undelivered.push(`${handle.paneId} (${delivery.reason ?? "no reason given"})`);
+			continue;
 		}
-		if (undelivered.length > 0) {
-			log.error("Bug hunter prompt was not delivered — rolling the launch back", {
+		if (delivery.status === "unconfirmed") {
+			log.warn("Bug hunter prompt could not be confirmed — keeping the pane", {
 				taskId: params.taskId.slice(0, 8),
-				undelivered,
+				paneId: handle.paneId,
+				reason: delivery.reason,
+				detail: delivery.detail,
 			});
-			throw await rollBackNativeHunters(
-				task,
-				handles,
-				socket,
-				focusedBefore,
-				`All ${handles.length} hunter ${handles.length === 1 ? "pane" : "panes"} opened, ` +
-					`but the hunt prompt never reached ${undelivered.join(", ")}`,
-			);
 		}
-	} else {
-		// tmux cannot prove a delivery, so it stays fire-and-forget on the original
-		// timers. Paste and Enter are two send-keys calls: Claude Code's input layer
-		// reads a fast "prompt Enter" as one paste, newline included, and never submits.
-		for (const handle of handles) {
-			const paneId = handle.paneId;
-			setTimeout(() => {
-				tmux.sendKeys(paneId, [prompt], { socket, bestEffort: true }).catch((err) => {
-					log.warn("send-keys paste for bug hunter pane failed", { paneId, error: String(err) });
-				});
-				setTimeout(() => {
-					tmux.sendKeys(paneId, ["Enter"], { socket, bestEffort: true }).catch((err) => {
-						log.warn("send-keys Enter for bug hunter pane failed", { paneId, error: String(err) });
-					});
-				}, BUG_HUNTER_ENTER_DELAY_MS);
-			}, BUG_HUNTER_AUTOTYPE_DELAY_MS);
-		}
+	}
+	if (undelivered.length > 0) {
+		log.error("Bug hunter prompt was not delivered — rolling the launch back", {
+			taskId: params.taskId.slice(0, 8),
+			native,
+			undelivered,
+		});
+		throw await rollBackHunterLaunch(
+			task,
+			handles,
+			socket,
+			focusedBefore,
+			`All ${handles.length} hunter ${handles.length === 1 ? "pane" : "panes"} opened, ` +
+				`but the hunt prompt never reached ${undelivered.join(", ")}`,
+		);
 	}
 
 	// Bump favorite usage — one per hunter actually spawned (all share the combo). Best-effort.


### PR DESCRIPTION
Launching bug hunters on a tmux task fired the hunt prompt into each pane from a pair of nested `setTimeout`s with `bestEffort: true`, and never learned whether it arrived. A pane whose agent never got its prompt is a zombie the user has to spot and close by hand. The native arm immediately above it already undid the launch in that case; a comment claimed tmux could not prove a delivery, which the guarded pane-input seam (`201-backend-neutral-pane-input`) had already made false.

Both backends now deliver through `deliverAgentPrompt` and act on the `AgentPromptDelivery` verdict from #1263 — no second vocabulary. Only a proven `not-delivered` undoes the launch; `unconfirmed` keeps the pane and logs, because killing a pane whose prompt may have landed is the collapse the seam exists to prevent. Rollback is backend-neutral now, and a rolled-back tmux pane is retired from `sessionState` by hand since `kill-pane` fires no `pane-exited` hook. The false comment goes in the same commit as the behaviour, deliberately not before it.

It also restores native rollback, which had been dead since #1263: that PR widened `sendPromptToNativePane` from a boolean to an `AgentPromptDelivery` object while the call site kept reading `if (!(await sendPromptToNativePane(...)))`, always false against an object. Scope precisely: the `catch` arm and the split/layout failures still rolled back — what died is the delivery verdict path, the realistic one, since that function converts every provable failure into a returned `not-delivered` rather than a throw. Neither safety net could see it (`!someObject` is legal TypeScript, and the negative test drove its mock with `mockResolvedValueOnce(false)`, a value the real function can no longer produce).

**User-visible:** a tmux "Find bugs" launch now takes about five seconds before it finishes, the way it already did on the native backend, and it can fail with a rollback where it previously always reported success.

Verified live against a real tmux server on a throwaway socket, driving `deliverAgentPrompt` itself rather than a mock: a live pane answers `delivered` and `capture-pane` shows the command actually ran; a killed pane and a pane id that never existed both answer `not-delivered` / `pane-absent`; a killed server answers `not-delivered` / `backend-failure` with `no server running`. The tests drive a fake tmux **server** and decode the `-H` hex to read what the pane will really receive, asserting execution counts (1 for a guard-refused pane, 0 for an absent one, 2 for a healthy one) so a failed pin cannot fake a pass. Four mutations of the shipped code were checked and all are caught.

Reasoning recorded in `decisions/210-hunter-prompt-verdict-decides-the-launch.md`.

**Declared ride-along, unrelated to the fix:** `decisions/209-required-checks-wait-for-windows-packaging.md` stated the new Windows gate's cost as about +4 minutes; its first live run measured +4m45. Corrected here with the run id and the reason the estimate was low — it came from per-job durations, but the scope job runs serially in front of the packaging jobs, so the cost is scope + dispatch + slowest packaging job, never `max(packaging durations)`.

---

Hey, Claude here — the AI assistant that wrote this branch in a dev3 task. Happy to adjust anything in it.
