### PR TITLE
Play the task completion chime before teardown, not after

### DIFF
--- a/change-logs/2026/08/06/fix-task-completion-sound-timing.md
+++ b/change-logs/2026/08/06/fix-task-completion-sound-timing.md
@@ -1,0 +1,3 @@
+Short: Completion chime plays immediately
+
+The completion and cancellation chime now fires as the first thing a terminal move does, instead of after the terminal session, cleanup script and worktree were torn down — so it no longer arrives seconds late, and it is no longer lost when teardown fails. Accepting the "branch merged — complete the task?" prompt plays it locally like every board surface does, Task → Move to Status → Mark Completed / Mark Cancelled now actually work (behind the usual confirmation) instead of doing nothing, and View → Debug gained three probes that play the chime through the exact client and backend paths the real moves use.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2435,7 +2435,10 @@ describe("handlers.moveTask", () => {
 		}
 	});
 
-	it("in-progress → completed: emits renderer sound after teardown finishes", async () => {
+	// The chime belongs to the move, not to the cleanup: teardown takes seconds
+	// and aborts the effect chain when it fails, so a sound emitted at the end
+	// lands long after the card left the column — or never.
+	it("in-progress → completed: emits the renderer sound before teardown starts", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
 		const updatedTask = makeTask({ status: "completed", worktreePath: null, branchName: null });
@@ -2452,7 +2455,7 @@ describe("handlers.moveTask", () => {
 
 		const soundIndex = push.mock.calls.findIndex((call) => call[0] === "taskSound");
 		expect(soundIndex).toBeGreaterThanOrEqual(0);
-		expect(push.mock.invocationCallOrder[soundIndex]).toBeGreaterThan(
+		expect(push.mock.invocationCallOrder[soundIndex]).toBeLessThan(
 			vi.mocked(git.removeWorktree).mock.invocationCallOrder[0],
 		);
 		expect(push).toHaveBeenCalledWith("taskSound", { status: "completed", taskId: task.id });

--- a/src/bun/lifecycle/__tests__/machine.test.ts
+++ b/src/bun/lifecycle/__tests__/machine.test.ts
@@ -370,6 +370,9 @@ describe("task lifecycle transition table", () => {
 			runId: "teardown-run",
 		});
 		expect(result.effects.map((effect) => effect.type)).toEqual([
+			// The chime leads: teardown takes seconds and aborts the chain when it
+			// fails, so a sound at the tail arrives late or never.
+			"emitTaskSound",
 			"clearTaskRuntime",
 			"releasePorts",
 			"persistRuntime",
@@ -382,9 +385,8 @@ describe("task lifecycle transition table", () => {
 			"persistTerminalTask",
 			"push",
 			"notifyStatusChange",
-			"emitTaskSound",
 		]);
-		expect(result.effects[3]).toMatchObject({
+		expect(result.effects[4]).toMatchObject({
 			type: "push",
 			message: "taskUpdated",
 			view: "shuttingDown",

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -294,6 +294,12 @@ function moveTransition(
 			runId,
 		};
 		const effects: LifecycleEffect[] = [
+			// First, before any teardown. Killing the terminal, running the cleanup
+			// script and removing the worktree take seconds, and they abort the
+			// effect chain when they fail — a sound emitted at the end arrives long
+			// after the card left the column, or never (issue: silent completions
+			// from the CLI / agent approval / branch-merge auto-complete).
+			...(event.clientPlayedSound ? [] : [effect({ type: "emitTaskSound", status: terminalStatus })]),
 			effect({ type: "clearTaskRuntime" }),
 			...(state.runtime.phase === "preparing"
 				? [effect({ type: "cancelPreparationProcesses" })]
@@ -325,9 +331,6 @@ function moveTransition(
 			effect({ type: "push", message: "taskUpdated", view: "current" }),
 			effect({ type: "notifyStatusChange", from: oldStatus, to: terminalStatus }),
 		);
-		if (!event.clientPlayedSound) {
-			effects.push(effect({ type: "emitTaskSound", status: terminalStatus }));
-		}
 		return {
 			next: { ...state, column: target, runtime },
 			effects,

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -3,7 +3,8 @@ import type { TerminalBackendIdentity } from "../../shared/terminal-backend-iden
 import { ACTIVE_STATUSES, DRAFT_TASK_ACTIVATION_ERROR, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import { resolveAgentRequest, type AgentLaunchChoice } from "../agent-requests";
-import { loadSettings, recordFavoriteUsages } from "../settings";
+import { loadSettings, loadSettingsSync, recordFavoriteUsages } from "../settings";
+import { emitTaskSound } from "../lifecycle/executor";
 import { getPushMessage, isActive, log } from "./shared";
 import { dispatchLifecycleEvent, removeLifecycleActor } from "../lifecycle/service";
 import { clearMergeNotification } from "../lifecycle/activities";
@@ -219,6 +220,18 @@ export async function moveTask(params: {
 		clientPlayedSound: params.clientPlayedSound,
 		enforceAllowedTransition: params.enforceAllowedTransition,
 	});
+}
+
+/**
+ * View → Debug probe. Pushes `taskSound` through the same `emitTaskSound` a
+ * CLI-driven or merge-driven completion uses, so a silent chime can be pinned on
+ * the backend push or on the renderer's audio pipeline.
+ */
+async function debugEmitTaskSound(params: { status: "completed" | "cancelled" }): Promise<{ pushed: boolean }> {
+	const pushed = loadSettingsSync().playSoundOnTaskComplete !== false;
+	log.info("→ debugEmitTaskSound", { status: params.status, pushed });
+	emitTaskSound(params.status, "debug-probe");
+	return { pushed };
 }
 
 /**
@@ -1028,6 +1041,7 @@ export const taskLifecycleHandlers = {
 	openQuickShell,
 	createTask,
 	moveTask,
+	debugEmitTaskSound,
 	cancelTaskPreparation,
 	reorderTask,
 	setTaskPriority,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -53,7 +53,7 @@ import AboutModal from "./components/AboutModal";
 import FilePreviewModal from "./components/FilePreviewModal";
 import { OPEN_FILE_PREVIEW_EVENT, type OpenFilePreviewDetail } from "./terminal-path-open";
 import RosettaWarningModal from "./components/RosettaWarningModal";
-import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "./task-sounds";
+import { initTaskSoundPlayback, playTaskCompletionSound, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "./task-sounds";
 import { offerMergeCompletion } from "./utils/offerMergeCompletion";
 import { taskDialogInfoFromSubject } from "./utils/taskDialogInfo";
 import { getRecentProjectIds, orderByRecency, recordProjectJump } from "./utils/recentProjects";
@@ -183,7 +183,7 @@ function App() {
 		function onMenuAction(e: Event) {
 			const detail = (e as CustomEvent).detail;
 			if (!detail?.action) return;
-			handleMenuAction(detail.action, { state, dispatch, setLocale }).catch((err) => {
+			handleMenuAction(detail.action, { state, dispatch, setLocale, t }).catch((err) => {
 				console.error("[App] handleMenuAction failed", err);
 			});
 		}
@@ -802,7 +802,7 @@ function App() {
 	const runCommand = useCallback(
 		(actionId: string) => {
 			setShowCommandPalette(false);
-			handleMenuAction(actionId, { state, dispatch, setLocale }).catch((err) => {
+			handleMenuAction(actionId, { state, dispatch, setLocale, t }).catch((err) => {
 				console.error("[App] runCommand failed", err);
 			});
 		},
@@ -813,7 +813,7 @@ function App() {
 	// the native menu and the command palette.
 	const handleMenuBarAction = useCallback(
 		(actionId: string) => {
-			handleMenuAction(actionId, { state, dispatch, setLocale }).catch((err) => {
+			handleMenuAction(actionId, { state, dispatch, setLocale, t }).catch((err) => {
 				console.error("[App] menu bar action failed", err);
 			});
 		},
@@ -1496,6 +1496,10 @@ function App() {
 				shouldNotify,
 				onOpenTask: () => openTaskFromNotification(taskId, projectId),
 				onComplete: () => {
+					// Sound first, exactly like `moveTaskToStatus` does for the board
+					// surfaces — this handler is a hand-rolled move and used to leave the
+					// chime to the backend push, which lands after the whole teardown.
+					const playedLocally = playTaskCompletionSound("completed");
 					// If the user is currently inside this task's view, leave it BEFORE
 					// the worktree is destroyed (otherwise TaskTerminal reacts to
 					// ptyDied / missing worktree and shows the "session ended / restart
@@ -1524,12 +1528,14 @@ function App() {
 						taskId,
 						projectId,
 						newStatus: "completed",
+						clientPlayedSound: playedLocally,
 					}).catch(() => {
 						api.request.moveTask({
 							taskId,
 							projectId,
 							newStatus: "completed",
 							force: true,
+							clientPlayedSound: playedLocally,
 						}).catch((err) => console.error("moveTask (branch-merged) failed:", err));
 					});
 				},

--- a/src/mainview/__tests__/menuRouter.browser.test.ts
+++ b/src/mainview/__tests__/menuRouter.browser.test.ts
@@ -15,6 +15,7 @@ function makeCtx() {
 		state: { route: { screen: "dashboard" } } as unknown as AppState,
 		dispatch: vi.fn(),
 		setLocale: vi.fn(),
+		t: ((key: string) => key) as never,
 	};
 }
 
@@ -25,13 +26,13 @@ beforeEach(() => {
 
 describe("BROWSER_HANDLED_ACTIONS", () => {
 	it("contains actions the router executes in the browser", () => {
-		for (const a of ["open-new-task", "task-move-todo", "term-split-h", "about", "help-github", "gauge-demo", "native-pane-layout-lab", "view-dashboard"]) {
+		for (const a of ["open-new-task", "task-move-todo", "term-split-h", "about", "help-github", "gauge-demo", "native-pane-layout-lab", "view-dashboard", "task-mark-completed", "task-mark-cancelled"]) {
 			expect(BROWSER_HANDLED_ACTIONS.has(a)).toBe(true);
 		}
 	});
 
 	it("excludes bun-only / unhandled actions", () => {
-		for (const a of ["new-window", "check-for-updates", "toggle-devtools", "zoom-in", "open-logs-directory", "show-remote-qr", "task-rename", "task-mark-completed"]) {
+		for (const a of ["new-window", "check-for-updates", "toggle-devtools", "zoom-in", "open-logs-directory", "show-remote-qr", "task-rename"]) {
 			expect(BROWSER_HANDLED_ACTIONS.has(a)).toBe(false);
 		}
 	});

--- a/src/mainview/__tests__/menuRouter.test.ts
+++ b/src/mainview/__tests__/menuRouter.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import { handleMenuAction } from "../menuRouter";
 import type { AppState } from "../state";
 
+const { moveTaskToStatus } = vi.hoisted(() => ({ moveTaskToStatus: vi.fn((_opts: unknown) => Promise.resolve(true)) }));
+vi.mock("../utils/moveTaskToStatus", () => ({ moveTaskToStatus }));
+
 // These palette actions only dispatch a window CustomEvent (App.tsx opens the
 // palette) — they never touch state, dispatch, or locale, so a bare ctx is fine.
 const ctx = {
 	state: { route: { screen: "dashboard" } } as unknown as AppState,
 	dispatch: vi.fn(),
 	setLocale: vi.fn(),
+	t: ((key: string) => key) as never,
 };
 
 describe("handleMenuAction — palette openers", () => {
@@ -46,6 +50,7 @@ describe("handleMenuAction — term-close-pane", () => {
 		state: { route: { screen: "task", projectId: "p1", taskId: "task-42" } } as unknown as AppState,
 		dispatch: vi.fn(),
 		setLocale: vi.fn(),
+		t: ((key: string) => key) as never,
 	};
 
 	it("opens the two-step pane picker for the current task", async () => {
@@ -63,5 +68,46 @@ describe("handleMenuAction — term-close-pane", () => {
 		await handleMenuAction("term-close-pane", ctx);
 		window.removeEventListener("dev3:closePanePicker", listener);
 		expect(listener).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleMenuAction — task-sound probes", () => {
+	it("plays the client sound through the same call the board moves use", async () => {
+		const sounds = await import("../task-sounds");
+		const spy = vi.spyOn(sounds, "playTaskCompletionSound").mockReturnValue(true);
+		await handleMenuAction("debug-play-sound-completed", ctx);
+		await handleMenuAction("debug-play-sound-cancelled", ctx);
+		expect(spy.mock.calls).toEqual([["completed"], ["cancelled"]]);
+		spy.mockRestore();
+	});
+
+});
+
+describe("handleMenuAction — terminal moves from the menu", () => {
+	const task = { id: "task-9", projectId: "p1", status: "in-progress" };
+	const terminalCtx = {
+		state: {
+			route: { screen: "task", projectId: "p1", taskId: "task-9" },
+			projects: [{ id: "p1", name: "demo" }],
+			currentProjectTasks: [task],
+		} as unknown as AppState,
+		dispatch: vi.fn(),
+		setLocale: vi.fn(),
+		t: ((key: string) => key) as never,
+	};
+
+	it("routes Mark Completed / Mark Cancelled through the shared move helper, always confirming", async () => {
+		moveTaskToStatus.mockClear();
+		await handleMenuAction("task-mark-completed", terminalCtx);
+		await handleMenuAction("task-mark-cancelled", terminalCtx);
+		expect(moveTaskToStatus).toHaveBeenCalledTimes(2);
+		expect(moveTaskToStatus.mock.calls[0][0]).toMatchObject({ newStatus: "completed", alwaysConfirm: true });
+		expect(moveTaskToStatus.mock.calls[1][0]).toMatchObject({ newStatus: "cancelled", alwaysConfirm: true });
+	});
+
+	it("is a no-op when no task is focused", async () => {
+		moveTaskToStatus.mockClear();
+		await handleMenuAction("task-mark-completed", ctx);
+		expect(moveTaskToStatus).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/__tests__/menuRouterSoundPush.test.ts
+++ b/src/mainview/__tests__/menuRouterSoundPush.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleMenuAction } from "../menuRouter";
+import type { AppState } from "../state";
+
+// Own file because the whole `../rpc` module is mocked: the other menuRouter
+// tests run against the real Electrobun proxy.
+const { debugEmitTaskSound } = vi.hoisted(() => ({
+	debugEmitTaskSound: vi.fn(() => Promise.resolve({ pushed: true })),
+}));
+
+vi.mock("../rpc", () => ({
+	api: { request: { debugEmitTaskSound } },
+}));
+
+const ctx = {
+	state: { route: { screen: "dashboard" } } as unknown as AppState,
+	dispatch: vi.fn(),
+	setLocale: vi.fn(),
+	t: ((key: string) => key) as never,
+};
+
+describe("handleMenuAction — backend task-sound probe", () => {
+	it("asks bun for a real taskSound push", async () => {
+		await handleMenuAction("debug-push-sound-completed", ctx);
+		expect(debugEmitTaskSound).toHaveBeenCalledWith({ status: "completed" });
+	});
+});

--- a/src/mainview/menuRouter.ts
+++ b/src/mainview/menuRouter.ts
@@ -1,6 +1,10 @@
 import { api } from "./rpc";
 import { startClosePanePicker } from "./close-pane-picker";
 import { toggleStreamerMode } from "./streamer-mode";
+import { toast } from "./toast";
+import { playTaskCompletionSound, taskSoundDiagnostics } from "./task-sounds";
+import { moveTaskToStatus } from "./utils/moveTaskToStatus";
+import type { TFunction } from "./i18n";
 import type { AppState, AppAction, Route } from "./state";
 import type { Locale } from "./i18n/types";
 import type { TaskStatus } from "../shared/types";
@@ -21,6 +25,8 @@ interface RouterCtx {
 	state: AppState;
 	dispatch: (action: AppAction) => void;
 	setLocale: (locale: Locale) => void;
+	/** Needed by the shared move helper for its confirmation copy and toasts. */
+	t: TFunction;
 }
 
 function navigate(ctx: RouterCtx, route: Route): void {
@@ -111,6 +117,31 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 		case "native-pane-layout-lab":
 			navigate(ctx, { screen: "native-pane-layout-lab" });
 			return;
+
+		// ── Debug: task-sound probes ──
+		// Deliberately the same calls the real flows make, so a silent chime here
+		// means the pipeline is broken, not the trigger. The toast is raw
+		// diagnostics (like terminal output), not localized product copy.
+		case "debug-play-sound-completed":
+		case "debug-play-sound-cancelled": {
+			const status = action === "debug-play-sound-completed" ? "completed" : "cancelled";
+			const played = playTaskCompletionSound(status);
+			// Decoding is async on the first play, so a same-tick snapshot would
+			// always report zero buffers.
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			const probe = taskSoundDiagnostics();
+			const line = `sound ${status}: ${played ? "play requested" : "skipped — setting off"} · context ${probe.context} · buffers ${probe.buffers} · queued ${probe.queued}`;
+			console.info("[menu][sound-probe]", line);
+			toast.info(line);
+			return;
+		}
+		case "debug-push-sound-completed": {
+			const { pushed } = await api.request.debugEmitTaskSound({ status: "completed" });
+			const line = `backend taskSound push: ${pushed ? "sent" : "suppressed — setting off"}`;
+			console.info("[menu][sound-probe]", line);
+			toast.info(line);
+			return;
+		}
 
 		// ── Help: external links (bun uses Utils.openExternal; browser uses window.open) ──
 		case "help-documentation":
@@ -258,8 +289,28 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 			return;
 		}
 
-		// ── Task: lifecycle moves (safe statuses only; destructive
-		// complete/cancel are intentionally not palette/menu quick-actions) ──
+		// ── Task: terminal moves. Routed through the same helper the board uses,
+		// so the chime, the optimistic update and the unpushed-work confirmation
+		// are identical. `alwaysConfirm` because a menu or palette entry is as easy
+		// to mis-hit as the card's one-click ✓, and this destroys the worktree. ──
+		case "task-mark-completed":
+		case "task-mark-cancelled": {
+			const task = currentTask(state);
+			if (!task) return;
+			const project = state.projects?.find((p) => p.id === currentProjectId(state));
+			if (!project) return;
+			await moveTaskToStatus({
+				task,
+				project,
+				newStatus: action === "task-mark-completed" ? "completed" : "cancelled",
+				dispatch: ctx.dispatch,
+				t: ctx.t,
+				alwaysConfirm: true,
+			});
+			return;
+		}
+
+		// ── Task: lifecycle moves (non-terminal) ──
 		case "task-move-todo":
 		case "task-move-in-progress":
 		case "task-move-user-questions":
@@ -393,6 +444,7 @@ export const BROWSER_HANDLED_ACTIONS: ReadonlySet<string> = new Set<string>([
 	// View / navigation
 	"view-dashboard", "view-kanban", "view-changelog", "view-stats", "open-settings",
 	"go-back", "go-forward", "gauge-demo", "viewport-lab", "native-pane-layout-lab", "update-popover-preview",
+	"debug-play-sound-completed", "debug-play-sound-cancelled", "debug-push-sound-completed",
 	"open-new-task", "open-add-project", "open-project-switch", "open-command-palette",
 	// Project
 	"project-settings", "project-pull-main", "project-create-pr",
@@ -400,6 +452,8 @@ export const BROWSER_HANDLED_ACTIONS: ReadonlySet<string> = new Set<string>([
 	// Task (safe, non-destructive)
 	"task-toggle-watch", "task-run-script", "task-open-in-finder", "task-copy-worktree-path",
 	"task-move-todo", "task-move-in-progress", "task-move-user-questions", "task-move-review-ai", "task-move-review-user",
+	// Destructive, but always behind the terminal-move confirmation.
+	"task-mark-completed", "task-mark-cancelled",
 	// Terminal
 	"term-split-h", "term-split-v", "term-zoom-pane", "term-close-pane",
 	"term-layout-tiled", "term-layout-even-h", "term-layout-even-v", "term-layout-main-h", "term-layout-main-v", "term-layout-cycle",

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -74,6 +74,19 @@ export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 	void playTaskSound(status);
 }
 
+/**
+ * State of the audio pipeline, for the View → Debug sound probes. Never creates
+ * the context — an untouched app must report `none`, not be primed by looking.
+ */
+export function taskSoundDiagnostics(): { context: string; buffers: number; queued: number; enabled: boolean } {
+	return {
+		context: context?.state ?? "none",
+		buffers: buffers.size,
+		queued: pendingQueue.length,
+		enabled: completionSoundEnabled,
+	};
+}
+
 function audioContextCtor(): typeof AudioContext | undefined {
 	if (typeof window === "undefined") return undefined;
 	const scoped = window as typeof globalThis & { webkitAudioContext?: typeof AudioContext };

--- a/src/shared/application-menu.ts
+++ b/src/shared/application-menu.ts
@@ -89,6 +89,9 @@ export const MENU_ACTIONS = {
 	viewportLab: "viewport-lab",
 	nativePaneLayoutLab: "native-pane-layout-lab",
 	updatePopoverPreview: "update-popover-preview",
+	debugPlaySoundCompleted: "debug-play-sound-completed",
+	debugPlaySoundCancelled: "debug-play-sound-cancelled",
+	debugPushSoundCompleted: "debug-push-sound-completed",
 
 	// ── Terminal — pane ──
 	termSplitH: "term-split-h",
@@ -665,6 +668,13 @@ function viewMenu(): ApplicationMenuItemConfig {
 					item({ label: "Viewport Lab", action: MENU_ACTIONS.viewportLab }),
 					item({ label: "Native Pane Layout Lab", action: MENU_ACTIONS.nativePaneLayoutLab }),
 					item({ label: "Update Popover Preview", action: MENU_ACTIONS.updatePopoverPreview }),
+					SEP,
+					// Task-sound probes. The two "client" items call the exact function
+					// every board/panel/toolbar move calls; the "backend push" item goes
+					// through the same `emitTaskSound` the CLI and merge auto-complete use.
+					item({ label: "Play Completed Sound (client)", action: MENU_ACTIONS.debugPlaySoundCompleted }),
+					item({ label: "Play Cancelled Sound (client)", action: MENU_ACTIONS.debugPlaySoundCancelled }),
+					item({ label: "Push Completed Sound (backend)", action: MENU_ACTIONS.debugPushSoundCompleted }),
 				],
 			},
 		],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3241,6 +3241,13 @@ export type AppRPCSchema = {
 				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean; clientPlayedSound?: boolean };
 				response: Task;
 			};
+			// View → Debug probe: fires the same `taskSound` push a real CLI /
+			// merge-driven completion fires, with no task involved. `pushed` is false
+			// when the completion-sound setting is off (the real push is gated too).
+			debugEmitTaskSound: {
+				params: { status: "completed" | "cancelled" };
+				response: { pushed: boolean };
+			};
 			cancelTaskPreparation: {
 				params: { taskId: string; projectId: string };
 				response: Task;


### PR DESCRIPTION
The completion / cancellation chime was silent or seconds late on every path that does not start from a board surface.

Two causes:

1. **The chime was the last lifecycle effect.** In the terminal branch of `src/bun/lifecycle/machine.ts`, `emitTaskSound` sat behind `destroyTaskPty`, `runCleanupScript` and `removeWorktree` — all `onError: "abort"`. A CLI move, an approved agent completion request or a merge-driven auto-complete therefore chimed seconds after the card had already left the column, and not at all when teardown failed. It is now the **first** effect of the branch.
2. **The branch-merged completion handler played nothing.** `src/mainview/App.tsx` hand-rolls its own optimistic move for the "branch merged — complete the task?" prompt instead of going through `utils/moveTaskToStatus`, and never called `playTaskCompletionSound`. It now plays locally like every board surface and passes `clientPlayedSound` so the backend push stays suppressed.

Also in here, found during the audit of every complete/cancel entry point:

- **`Task → Move to Status → Mark Completed` / `Mark Cancelled` did nothing.** Both were declared in `MENU_ACTIONS` and rendered enabled, but neither side routed them. They now go through `moveTaskToStatus` with `alwaysConfirm: true` — a menu or palette entry is as easy to mis-hit as the card's one-click ✓, and the move destroys the worktree.
- **Three sound probes under `View → Debug`** — play the completed / cancelled chime through the exact client call the board makes, or ask bun for a real `taskSound` push. Each reports audio-context state, decoded buffers and queue length in a toast.

Two existing tests encoded the old ordering (`emits renderer sound after teardown finishes` in `rpc-handlers.test.ts`, and the effect-order assertion in `machine.test.ts`); both were deliberately flipped. That ordering came from the lifecycle state-machine rewrite in #1043 and was a snapshot of the previous behaviour, not a documented decision.