### PR TITLE
Park the task in Has Questions when an API error kills a Claude turn

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -44,7 +44,7 @@ Last updated: 2026-07-13
 | **LLM provider (backend)** | Anthropic / Amazon Bedrock (per-agent toggle) | — | — | — | — |
 | **Agent selection** | — | — | — | — | `--agent` |
 | **Auto-trust worktree** | Yes (`ensureClaudeTrust`) | — | Yes (`ensureCodexTrust`) | Yes (`ensureGeminiTrust`) | — |
-| **Status hooks (automatic)** | Yes (4 hooks) | — | Yes (6 worktree-local hooks, automatically trusted) | — | — |
+| **Status hooks (automatic)** | Yes (6 hooks) | — | Yes (6 worktree-local hooks, automatically trusted) | — | — |
 | **Status management** | Automatic via hooks | Manual (SKILL.md) | Automatic via hooks with `user-questions`/legacy-session fallback | Manual (SKILL.md) | Manual (SKILL.md) |
 | **Rate-limit tracking** | Yes (statusLine wrapper injected via `--settings`, `dev3 statusline`) | — | Yes (rollout files + cached live monthly credits via `codex app-server`) | — | — |
 | **dev3 artifact starter** | Yes (`DEV3_ARTIFACT_TEMPLATE_DIR`) | Yes | Yes | Yes | Yes |
@@ -61,8 +61,12 @@ Injected into `.claude/settings.local.json`.
 |------------|------------------|---------|
 | `UserPromptSubmit` | → `in-progress` | User sent a message, agent starts working |
 | `PreToolUse` | → `in-progress` | Agent is about to call a tool (also catches post-permission resume) |
+| `PostToolUse` | → `in-progress` | A tool finished, including answers submitted to `AskUserQuestion` |
 | `PermissionRequest` | → `user-questions` | Agent needs user approval for a tool call |
 | `Stop` | → `review-by-user` | Agent finished its turn |
+| `StopFailure` | → `user-questions` | An API error (usage limit, auth, billing, server) ended the turn. Fires **instead of** `Stop`, so without it the task would keep claiming the agent is working. Routed through `dev3 hook claude-stop-failure`, which also raises the attention badge and a desktop notification naming the reset time |
+
+Codex has no equivalent event — a Codex session that runs out of quota is still only visible in the rate-limit indicator.
 
 ### Codex
 

--- a/change-logs/2026/08/06/feature-01-claude-limit-parks-task.md
+++ b/change-logs/2026/08/06/feature-01-claude-limit-parks-task.md
@@ -1,0 +1,3 @@
+Short: Usage limits park the task, not hide
+
+When a Claude turn dies on an API error — a hit usage limit, an expired login, a billing block — the task now moves itself to Has Questions with a red attention badge and a desktop notification naming the reset time, instead of sitting in Agent is Working for hours. Claude Code fires its `StopFailure` hook instead of `Stop` in that case, which dev3 previously ignored.

--- a/decisions/212-stopfailure-parks-the-task.md
+++ b/decisions/212-stopfailure-parks-the-task.md
@@ -1,0 +1,73 @@
+# 212 — StopFailure parks the task in Has Questions
+
+## Context
+
+A Claude session that hits its subscription usage limit mid-task prints
+`You've hit your session limit · resets 3:40pm (Asia/Jerusalem)`, drops the turn,
+and returns to its prompt. The board kept showing **Agent is Working** — for
+hours, until the user happened to look into the pane. Same for an expired login
+or a billing block: the agent is idle and needs a human, and nothing said so.
+
+## Investigation
+
+The cause is not a missing pattern match, it is a missing event. Claude Code's
+`StopFailure` fires **instead of** `Stop` when an API error ends the turn, and
+dev3 only listened to `Stop`. Verified against the shipped
+`@anthropic-ai/claude-code` 2.1.112 bundle:
+
+- Hook registry contains `StopFailure`; its own description reads *"Fires instead
+  of Stop when an API error (rate limit, auth failure, etc.) ended the turn.
+  Fire-and-forget — hook output and exit codes are ignored."*
+- Payload schema: `hook_event_name`, `error`, optional `error_details`, optional
+  `last_assistant_message`. The matcher matches on `error`.
+- `error` enum: `authentication_failed`, `billing_error`, `rate_limit`,
+  `invalid_request`, `server_error`, `unknown`, `max_output_tokens`. The HTTP 429
+  path — which is where the subscription-limit sentence is produced — sets
+  `rate_limit`.
+- No reset timestamp anywhere in the payload. It exists only as text inside the
+  limit sentence, which arrives as `last_assistant_message`.
+
+The published hooks docs describe the payload as `stop_reason` / `error_message`
+instead. The two disagree, so the parser accepts both spellings.
+
+## Decision
+
+`buildClaudeHooks` (`src/shared/agent-hooks.ts`) registers `StopFailure` with
+**no matcher** — every one of those errors leaves the agent idle — pointing at a
+new internal adapter `dev3 hook claude-stop-failure`
+(`src/cli/commands/claude-stop-failure.ts`). It forwards to the
+`task.claudeStopFailure` socket handler (`src/bun/cli-socket-server.ts`), which
+moves the task to `user-questions`, raises the attention badge, and posts a
+desktop notification. The badge reason comes from
+`describeClaudeStopFailure` (`src/shared/agent-stop-failure.ts`): Claude's own
+limit sentence when the last message is one (it carries the reset time),
+otherwise a short per-error line.
+
+An adapter rather than another `dev3 task move` hook, because the badge and the
+notification need the error and the reset text, which a status move cannot carry.
+
+## Risks
+
+- **Wording drift.** The reset time is scraped from Claude's sentence via a
+  prefix list (`You've hit your`, `You've used`, …). If Anthropic rewords it, the
+  task still parks correctly and the badge falls back to our generic line — the
+  failure mode is a vaguer reason, never a missed event.
+- **Older Claude Code.** A build without `StopFailure` sees an unknown key in
+  `hooks`. Nothing else in the file is affected, and the behaviour is exactly
+  today's: the task keeps sitting in Agent is Working.
+- **Codex is not covered.** No equivalent hook exists; a Codex quota exhaustion
+  is still only visible in the rate-limit indicator.
+
+## Alternatives considered
+
+- **Scan the pane output for the limit sentence.** Works for Claude and Codex
+  alike, but it is a regex over a live PTY stream, breaks on rewording, and can
+  fire on the agent merely *quoting* the sentence. Rejected while a real event
+  exists.
+- **Trigger off the rate-limit monitor at 100%.** Data is already there
+  (`rate-limit-monitor.ts`), but it is per *account*, not per task: with several
+  tasks on one account it cannot tell which one actually died, and its 30 s poll
+  is blind to auth and billing failures entirely.
+- **A `matcher` limited to `rate_limit|billing_error`.** Would leave a task whose
+  turn died on `authentication_failed` stuck in Agent is Working — the exact bug
+  being fixed, one error value over.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -162,25 +162,39 @@ describe("buildClaudeHooks", () => {
 		for (const groups of Object.values(hooks)) {
 			for (const group of groups) {
 				for (const entry of group.hooks) {
-					// Command should be "dev3 task move --status X", no UUID
-					expect(entry.command).toMatch(/task move --status/);
+					// Either "dev3 task move --status X" or a "dev3 hook <name>" adapter
+					// that reads the event from stdin — never a UUID either way.
+					expect(entry.command).toMatch(/task move --status|hook claude-stop-failure/);
 					expect(entry.command).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/);
 				}
 			}
 		}
 	});
 
-	it("every Claude hook tolerates app-offline (exit 2) without blocking the agent", () => {
+	it("StopFailure parks the task through the dev3 hook adapter, with no matcher", () => {
+		const hooks = buildClaudeHooks();
+
+		// StopFailure fires INSTEAD of Stop when an API error killed the turn, so
+		// without it a rate-limited task stays in "Agent is Working" forever.
+		expect(hooks.StopFailure).toHaveLength(1);
+		expect(hooks.StopFailure[0].matcher).toBeUndefined();
+		expect(hooks.StopFailure[0].hooks[0].command).toContain("hook claude-stop-failure");
+	});
+
+	it("every status-move Claude hook tolerates app-offline (exit 2) without blocking the agent", () => {
 		// Claude Code treats a hook exit code of 2 as a *blocking* error
 		// (PreToolUse blocks the tool, UserPromptSubmit erases the prompt, Stop
 		// blocks stoppage). CLI_EXIT_CODE_APP_NOT_RUNNING is also 2, so when the
 		// desktop app is closed the hook must swallow exactly that code — and
 		// nothing else — into success. (issue: closed app wedged Edit/Bash.)
+		// `dev3 hook <name>` adapters are exempt: they own the offline case inside
+		// the CLI and always exit 0.
 		const hooks = buildClaudeHooks({ stopTarget: "review-by-ai" });
 
 		for (const groups of Object.values(hooks)) {
 			for (const group of groups) {
 				for (const entry of group.hooks) {
+					if (!entry.command.includes("task move")) continue;
 					expect(entry.command).toContain("|| [ $? -eq 2 ]");
 					// Never the blunt `|| true`, which would also hide real failures.
 					expect(entry.command).not.toContain("|| true");

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -545,6 +545,82 @@ describe("task.agentHook", () => {
 	});
 });
 
+describe("task.claudeStopFailure", () => {
+	const LIMIT_MESSAGE = "You've hit your session limit · resets 3:40pm (Asia/Jerusalem)";
+
+	function stub(project: Project, task: Task): void {
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+	}
+
+	it("parks a rate-limited turn in user-questions and names the reset time", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress" });
+		stub(project, task);
+
+		const response = await handleRequest(makeRequest("task.claudeStopFailure", {
+			taskId: task.id,
+			projectId: project.id,
+			error: "rate_limit",
+			lastAssistantMessage: LIMIT_MESSAGE,
+		}));
+
+		expect((response.data as { task: Task }).task.status).toBe("user-questions");
+		expect(pushCliAttention).not.toHaveBeenCalled(); // not suppressed → pushed live
+		expect(notifyFromCliDesktop).toHaveBeenCalledWith(expect.objectContaining({ body: LIMIT_MESSAGE }));
+	});
+
+	it("still badges when the task is already in user-questions", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "user-questions" });
+		stub(project, task);
+
+		await handleRequest(makeRequest("task.claudeStopFailure", {
+			taskId: task.id,
+			projectId: project.id,
+			error: "server_error",
+		}));
+
+		expect(moveTask).not.toHaveBeenCalled();
+		expect(notifyFromCliDesktop).toHaveBeenCalled();
+	});
+
+	it("leaves a finished task alone", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "completed" });
+		stub(project, task);
+
+		const response = await handleRequest(makeRequest("task.claudeStopFailure", {
+			taskId: task.id,
+			projectId: project.id,
+			error: "rate_limit",
+		}));
+
+		expect((response.data as { moved: boolean }).moved).toBe(false);
+		expect(moveTask).not.toHaveBeenCalled();
+		expect(notifyFromCliDesktop).not.toHaveBeenCalled();
+	});
+
+	it("queues the badge under focus mode instead of dropping it", async () => {
+		vi.mocked(isNotificationSuppressed).mockReturnValue(true);
+		const project = makeProject();
+		const task = makeTask({ status: "in-progress" });
+		stub(project, task);
+
+		await handleRequest(makeRequest("task.claudeStopFailure", {
+			taskId: task.id,
+			projectId: project.id,
+			error: "rate_limit",
+		}));
+
+		expect(pushCliAttention).toHaveBeenCalledWith({
+			taskId: task.id,
+			projectId: task.projectId,
+			reason: "Usage limit reached — the agent stopped mid-task",
+		});
+	});
+});
+
 describe("projects.list", () => {
 	it("returns all projects", async () => {
 		const projects = [makeProject({ id: "p1" }), makeProject({ id: "p2" })];

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -5,6 +5,7 @@ import { socketMetaPathFor } from "../shared/socket-meta";
 import { isCliEndpointHandle } from "../shared/cli-endpoint";
 import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, MAX_SHARED_IMAGES_PER_TASK, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, titleFromDescription } from "../shared/types";
 import { CODEX_STATUS_HOOK_EVENTS, getCodexHookTargetStatus, type CodexStatusHookEvent } from "../shared/agent-hooks";
+import { CLAUDE_STOP_FAILURE_ERRORS, describeClaudeStopFailure, type ClaudeStopFailureError } from "../shared/agent-stop-failure";
 import { SharedImageError, deleteSharedImageFiles, pruneSharedImages, saveSharedImage } from "./shared-images";
 import { SharedArtifactError, saveSharedArtifact } from "./shared-artifacts";
 import { addAutomation, deleteAutomation, loadAutomations, updateAutomation } from "./automations-data";
@@ -1009,6 +1010,48 @@ const handlers: Record<string, Handler> = {
 		}
 
 		return updated;
+	},
+
+	// Claude Code's StopFailure hook: an API error ended the turn, so the agent is
+	// parked at its prompt with nothing to show for it. Park the task in front of
+	// the user too — the board would otherwise keep claiming the agent is working.
+	"task.claudeStopFailure": async (params) => {
+		const { project, task } = await resolveTaskFromParams(params);
+		const rawError = params.error;
+		const error: ClaudeStopFailureError = CLAUDE_STOP_FAILURE_ERRORS.includes(rawError as ClaudeStopFailureError)
+			? rawError as ClaudeStopFailureError
+			: "unknown";
+		const reason = describeClaudeStopFailure({
+			error,
+			...(typeof params.errorDetails === "string" ? { errorDetails: params.errorDetails } : {}),
+			...(typeof params.lastAssistantMessage === "string" ? { lastAssistantMessage: params.lastAssistantMessage } : {}),
+		});
+
+		if (task.status === "completed" || task.status === "cancelled") {
+			return { task, moved: false, reason };
+		}
+
+		let updated = task;
+		if (task.status !== "user-questions" || task.customColumnId != null) {
+			updated = await moveTask({
+				taskId: task.id,
+				projectId: project.id,
+				newStatus: "user-questions",
+				ifStatus: task.status,
+			});
+		}
+
+		if ((await loadSettings()).focusMode) setFocusMode(true);
+		if (isNotificationSuppressed()) {
+			pushCliAttention({ taskId: task.id, projectId: task.projectId, reason });
+		} else {
+			getPushMessage()?.("cliAttention", { taskId: task.id, reason });
+		}
+		// A dead turn is precisely the case where the user has walked away, so this
+		// goes to the OS rather than an in-app toast nobody is looking at.
+		notifyFromCliDesktop({ task: updated, body: reason, projectName: project.name });
+
+		return { task: updated, moved: updated.status === "user-questions", reason };
 	},
 
 	"task.move": async (params) => {

--- a/src/cli/__tests__/claude-stop-failure.test.ts
+++ b/src/cli/__tests__/claude-stop-failure.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliContext } from "../context";
+
+vi.mock("../socket-client", () => ({
+	sendRequest: vi.fn(),
+}));
+
+import { sendRequest } from "../socket-client";
+import { handleClaudeStopFailure } from "../commands/claude-stop-failure";
+import { describeClaudeStopFailure, parseClaudeStopFailurePayload } from "../../shared/agent-stop-failure";
+
+const mockSend = vi.mocked(sendRequest);
+const SOCKET = "/tmp/test.sock";
+const CONTEXT: CliContext = {
+	projectId: "project-1",
+	taskId: "task-1",
+	socketPath: SOCKET,
+};
+
+const LIMIT_MESSAGE = "You've hit your session limit · resets 3:40pm (Asia/Jerusalem)\n/usage-credits to request more usage from your admin.";
+
+let stdout = "";
+let stderr = "";
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stdout = "";
+	stderr = "";
+	stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stdout += String(chunk);
+		return true;
+	});
+	stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stderr += String(chunk);
+		return true;
+	});
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+	stderrSpy.mockRestore();
+});
+
+describe("parseClaudeStopFailurePayload", () => {
+	it("reads the shipped schema's error/error_details pair", () => {
+		expect(parseClaudeStopFailurePayload(JSON.stringify({
+			hook_event_name: "StopFailure",
+			error: "rate_limit",
+			error_details: "429",
+			last_assistant_message: LIMIT_MESSAGE,
+		}))).toEqual({
+			error: "rate_limit",
+			errorDetails: "429",
+			lastAssistantMessage: LIMIT_MESSAGE,
+		});
+	});
+
+	// The docs print stop_reason/error_message while the shipped zod schema uses
+	// error/error_details. Betting on one spelling would drop every event.
+	it("also reads the documented stop_reason/error_message pair", () => {
+		expect(parseClaudeStopFailurePayload(JSON.stringify({
+			hook_event_name: "StopFailure",
+			stop_reason: "billing_error",
+			error_message: "payment required",
+		}))).toEqual({ error: "billing_error", errorDetails: "payment required" });
+	});
+
+	it("degrades an unrecognized error to unknown instead of dropping the event", () => {
+		expect(parseClaudeStopFailurePayload(JSON.stringify({
+			hook_event_name: "StopFailure",
+			error: "some_future_error",
+		}))).toEqual({ error: "unknown" });
+	});
+
+	it("ignores other events and malformed input", () => {
+		expect(parseClaudeStopFailurePayload(JSON.stringify({ hook_event_name: "Stop" }))).toBeNull();
+		expect(parseClaudeStopFailurePayload("not-json")).toBeNull();
+	});
+});
+
+describe("describeClaudeStopFailure", () => {
+	it("prefers Claude's own limit sentence — it is the only place the reset time appears", () => {
+		expect(describeClaudeStopFailure({ error: "rate_limit", lastAssistantMessage: LIMIT_MESSAGE }))
+			.toBe("You've hit your session limit · resets 3:40pm (Asia/Jerusalem)");
+	});
+
+	it("falls back to a per-error line when the last message is an ordinary reply", () => {
+		expect(describeClaudeStopFailure({ error: "rate_limit", lastAssistantMessage: "Done, tests are green." }))
+			.toBe("Usage limit reached — the agent stopped mid-task");
+		expect(describeClaudeStopFailure({ error: "authentication_failed" }))
+			.toBe("The agent must sign in again");
+	});
+
+	it("keeps the reason short enough for a task card", () => {
+		const reason = describeClaudeStopFailure({
+			error: "rate_limit",
+			lastAssistantMessage: `You've hit your ${"very ".repeat(60)}long limit`,
+		});
+		expect(reason.length).toBeLessThanOrEqual(120);
+		expect(reason.endsWith("…")).toBe(true);
+	});
+});
+
+describe("handleClaudeStopFailure", () => {
+	it("forwards the failure to one socket handler", async () => {
+		mockSend.mockResolvedValue({ id: "1", ok: true, data: {} });
+
+		await handleClaudeStopFailure(
+			JSON.stringify({ hook_event_name: "StopFailure", error: "rate_limit", last_assistant_message: LIMIT_MESSAGE }),
+			SOCKET,
+			CONTEXT,
+		);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.claudeStopFailure", {
+			taskId: "task-1",
+			projectId: "project-1",
+			error: "rate_limit",
+			lastAssistantMessage: LIMIT_MESSAGE,
+		}, { timeoutMs: 3_000, connectAttempts: 2, retryDelayMs: 50 });
+		expect(stdout).toBe("");
+		expect(stderr).toBe("");
+	});
+
+	it("is a silent no-op outside a task, with no socket, and on junk input", async () => {
+		await handleClaudeStopFailure(JSON.stringify({ hook_event_name: "StopFailure", error: "rate_limit" }), SOCKET, null);
+		await handleClaudeStopFailure(JSON.stringify({ hook_event_name: "StopFailure", error: "rate_limit" }), null, CONTEXT);
+		await handleClaudeStopFailure("not-json", SOCKET, CONTEXT);
+
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(stdout).toBe("");
+		expect(stderr).toBe("");
+	});
+
+	it("reports a socket failure on stderr without throwing", async () => {
+		mockSend.mockRejectedValue(new Error("socket closed"));
+
+		await handleClaudeStopFailure(
+			JSON.stringify({ hook_event_name: "StopFailure", error: "server_error" }),
+			SOCKET,
+			CONTEXT,
+		);
+
+		expect(stderr).toContain("socket closed");
+	});
+});

--- a/src/cli/commands/claude-stop-failure.ts
+++ b/src/cli/commands/claude-stop-failure.ts
@@ -1,0 +1,34 @@
+import { parseClaudeStopFailurePayload } from "../../shared/agent-stop-failure";
+import type { CliContext } from "../context";
+import { sendRequest } from "../socket-client";
+
+/**
+ * Internal adapter for Claude Code's `StopFailure` hook. Claude ignores this
+ * hook's exit code and output, and a board update must never look like a failure
+ * to the agent either, so every path here ends quietly with exit 0.
+ */
+export async function handleClaudeStopFailure(
+	rawInput: string,
+	socketPath: string | null,
+	context: CliContext | null,
+): Promise<void> {
+	const payload = parseClaudeStopFailurePayload(rawInput);
+	if (!payload || !socketPath || !context?.taskId) return;
+
+	try {
+		const response = await sendRequest(socketPath, "task.claudeStopFailure", {
+			taskId: context.taskId,
+			projectId: context.projectId,
+			error: payload.error,
+			...(payload.errorDetails ? { errorDetails: payload.errorDetails } : {}),
+			...(payload.lastAssistantMessage ? { lastAssistantMessage: payload.lastAssistantMessage } : {}),
+		}, { timeoutMs: 3_000, connectAttempts: 2, retryDelayMs: 50 });
+		if (!response.ok) {
+			process.stderr.write(`dev3 Claude StopFailure hook: ${response.error || "status update failed"}\n`);
+		}
+	} catch (error) {
+		process.stderr.write(
+			`dev3 Claude StopFailure hook: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
+	}
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,6 +24,7 @@ import { handleShowImage } from "./commands/show-image";
 import { handleShowArtifact } from "./commands/show-artifact";
 import { handleStatusLine } from "./commands/statusline";
 import { handleCodexHook } from "./commands/codex-hook";
+import { handleClaudeStopFailure } from "./commands/claude-stop-failure";
 import { handleDoctor } from "./commands/doctor";
 import { TOLERATE_APP_OFFLINE_FLAG } from "../shared/agent-hooks";
 import { BUILD_TIME, BUILD_COMMIT, BUILD_VERSION } from "../shared/build-info.generated";
@@ -166,6 +167,15 @@ async function main(): Promise<void> {
 		// Internal lifecycle adapter. It intentionally remains successful when
 		// the app is offline so a status-sync failure can never block Codex.
 		return await handleCodexHook(
+			await Bun.stdin.text(),
+			socketPath || context?.socketPath || null,
+			context,
+		);
+	}
+	if (command === "hook" && subcommand === "claude-stop-failure") {
+		// Internal: Claude Code fires StopFailure instead of Stop when an API error
+		// ended the turn. Stays silent and successful whatever happens.
+		return await handleClaudeStopFailure(
 			await Bun.stdin.text(),
 			socketPath || context?.socketPath || null,
 			context,

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -17,6 +17,7 @@ export const CODEX_STOP_HOOK_FLAG = "--codex-stop-hook";
 export const TOLERATE_APP_OFFLINE_FLAG = "--tolerate-app-offline";
 export const CODEX_STOP_HOOK_SUCCESS_JSON = "{}";
 export const CODEX_DEV3_HOOK_COMMAND = `${DEV3_CLI} hook codex`;
+export const CLAUDE_STOP_FAILURE_HOOK_SUBCOMMAND = "hook claude-stop-failure";
 export const CODEX_STATUS_HOOK_EVENTS = [
 	"SessionStart",
 	"UserPromptSubmit",
@@ -74,6 +75,7 @@ export interface HookEntry {
  * - UserPromptSubmit/PreToolUse/PostToolUse: → in-progress (skipped when in review-by-ai)
  * - PermissionRequest: → user-questions
  * - Stop: primary agent → stopTarget; review agent → review-by-user
+ * - StopFailure: → user-questions (fires INSTEAD of Stop on an API error)
  */
 export interface MatcherGroup {
 	matcher?: string;
@@ -182,6 +184,13 @@ export function buildClaudeHooks(
 			{ hooks: [{ type: "command", command: move("user-questions") }] },
 		],
 		Stop: buildStopGroups(stopTarget, dialect),
+		// No matcher: every API error that killed the turn leaves the agent idle at
+		// its prompt, so all of them belong in front of the user. The handler owns
+		// the app-offline case and always exits 0 — Claude ignores its exit code
+		// anyway, StopFailure being fire-and-forget.
+		StopFailure: [
+			{ hooks: [{ type: "command", command: `${dialect.cli} ${CLAUDE_STOP_FAILURE_HOOK_SUBCOMMAND}`, timeout: 5 }] },
+		],
 	};
 }
 

--- a/src/shared/agent-stop-failure.ts
+++ b/src/shared/agent-stop-failure.ts
@@ -1,0 +1,110 @@
+/**
+ * Claude Code's `StopFailure` hook — the turn ended on an API error.
+ *
+ * It fires INSTEAD of `Stop`, so without handling it a task whose turn died on a
+ * usage limit (or an auth/billing failure) keeps sitting in "Agent is Working"
+ * forever: the agent is idle at its prompt and nothing on the board says so.
+ * dev3 turns every such event into a Has Questions move plus an attention badge.
+ */
+
+/** The `error` values Claude Code can put in a StopFailure payload. */
+export const CLAUDE_STOP_FAILURE_ERRORS = [
+	"rate_limit",
+	"authentication_failed",
+	"billing_error",
+	"invalid_request",
+	"server_error",
+	"max_output_tokens",
+	"unknown",
+] as const;
+
+export type ClaudeStopFailureError = typeof CLAUDE_STOP_FAILURE_ERRORS[number];
+
+export interface ClaudeStopFailurePayload {
+	error: ClaudeStopFailureError;
+	errorDetails?: string;
+	lastAssistantMessage?: string;
+}
+
+/** Longest reason we put on a badge — it has to stay readable on a task card. */
+export const STOP_FAILURE_REASON_MAX_LEN = 120;
+
+const REASON_BY_ERROR: Record<ClaudeStopFailureError, string> = {
+	rate_limit: "Usage limit reached — the agent stopped mid-task",
+	authentication_failed: "The agent must sign in again",
+	billing_error: "Billing blocked the request",
+	invalid_request: "The API rejected the request",
+	server_error: "The API is failing — the turn was dropped",
+	max_output_tokens: "The reply hit the output cap",
+	unknown: "The turn ended on an API error",
+};
+
+/**
+ * Claude's own limit sentences, e.g. "You've hit your session limit · resets
+ * 3:40pm (Asia/Jerusalem)". They carry the reset time, which no payload field
+ * does, so they beat any wording of ours — but only when the last message really
+ * is one of them and not an ordinary reply.
+ */
+const LIMIT_SENTENCE_PREFIXES = [
+	"You've hit your",
+	"You've used",
+	"You're out of",
+	"You're close to",
+	"You're now using extra usage",
+];
+
+function firstLine(text: string): string {
+	return text.split("\n")[0]?.trim() ?? "";
+}
+
+function truncate(text: string): string {
+	if (text.length <= STOP_FAILURE_REASON_MAX_LEN) return text;
+	return `${text.slice(0, STOP_FAILURE_REASON_MAX_LEN - 1).trimEnd()}…`;
+}
+
+/**
+ * One short line for the attention badge and the notification body. Prefers
+ * Claude's own limit sentence (it names the reset time) over our generic text.
+ */
+export function describeClaudeStopFailure(payload: ClaudeStopFailurePayload): string {
+	const line = firstLine(payload.lastAssistantMessage ?? "");
+	if (line && LIMIT_SENTENCE_PREFIXES.some((prefix) => line.startsWith(prefix))) {
+		return truncate(line);
+	}
+	return truncate(REASON_BY_ERROR[payload.error] ?? REASON_BY_ERROR.unknown);
+}
+
+function asError(value: unknown): ClaudeStopFailureError {
+	return CLAUDE_STOP_FAILURE_ERRORS.includes(value as ClaudeStopFailureError)
+		? value as ClaudeStopFailureError
+		: "unknown";
+}
+
+function asText(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+/**
+ * Parse the hook's stdin JSON. Returns null only when this is not a StopFailure
+ * event at all; an unrecognized `error` degrades to "unknown" so a newly added
+ * Claude error value still parks the task instead of being dropped.
+ *
+ * Accepts the field pair from the shipped schema (`error` / `error_details`) and
+ * the one the docs print (`stop_reason` / `error_message`) — they disagree, and
+ * guessing wrong would silently swallow every event.
+ */
+export function parseClaudeStopFailurePayload(rawInput: string): ClaudeStopFailurePayload | null {
+	try {
+		const parsed = JSON.parse(rawInput) as Record<string, unknown>;
+		if (parsed.hook_event_name !== "StopFailure") return null;
+		const errorDetails = asText(parsed.error_details ?? parsed.error_message);
+		const lastAssistantMessage = asText(parsed.last_assistant_message);
+		return {
+			error: asError(parsed.error ?? parsed.stop_reason),
+			...(errorDetails ? { errorDetails } : {}),
+			...(lastAssistantMessage ? { lastAssistantMessage } : {}),
+		};
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

A Claude session that hits its subscription usage limit mid-task prints `You've hit your session limit · resets 3:40pm (…)`, drops the turn and returns to its prompt — while the board kept showing **Agent is Working** for hours.

The cause is a missing event, not a missing pattern match: Claude Code fires **`StopFailure` instead of `Stop`** when an API error ends the turn, and dev3 only listened to `Stop`.

`buildClaudeHooks` now registers `StopFailure` with no matcher — every one of its error values leaves the agent idle at its prompt — pointing at a new internal adapter `dev3 hook claude-stop-failure`. It forwards to the `task.claudeStopFailure` socket handler, which moves the task to `user-questions`, raises the attention badge and posts a desktop notification.

The badge reason prefers Claude's own limit sentence, because that is the only place the reset time appears — no payload field carries it. Otherwise it falls back to a short per-error line (`The agent must sign in again`, …).

Verified against the shipped `@anthropic-ai/claude-code` 2.1.112 bundle rather than the docs: the hook's own description reads *"Fires instead of Stop when an API error (rate limit, auth failure, etc.) ended the turn. Fire-and-forget — hook output and exit codes are ignored."*, its payload is `error` / `error_details?` / `last_assistant_message?`, and the HTTP 429 path that produces the subscription-limit sentence sets `error: "rate_limit"`. The published docs describe the payload as `stop_reason` / `error_message` instead, so the parser accepts both spellings — betting on one would silently drop every event.

Codex has no equivalent hook; its quota exhaustion remains visible only in the rate-limit indicator.

Details and rejected alternatives (pane-output scraping, triggering off the per-account rate-limit monitor, a matcher narrowed to `rate_limit|billing_error`) are in `decisions/212-stopfailure-parks-the-task.md`.