### PR TITLE
Retry the Windows launch proof's process query and poll liveness without WMI

### DIFF
--- a/change-logs/2026/08/06/fix-windows-launch-proof-process-query.md
+++ b/change-logs/2026/08/06/fix-windows-launch-proof-process-query.md
@@ -1,0 +1,8 @@
+Short: Windows build survives a stalled process query
+
+A single 60s stall of the Windows launch proof's PowerShell process query withheld the
+downloadable Windows build from a launch that had actually succeeded (run 31098005022
+attempt 1). The two queries that need parent pids now retry a bounded number of times at
+unchanged budgets and record how long every attempt took, and the shutdown liveness polls
+moved off PowerShell and WMI onto tasklist.exe, which cuts the number of stall-prone calls
+per run from roughly fifteen to two.

--- a/decisions/215-windows-launch-proof-process-query-dialects.md
+++ b/decisions/215-windows-launch-proof-process-query-dialects.md
@@ -1,0 +1,79 @@
+# 215 — The Windows launch proof retries its process query instead of widening its budget, and polls liveness without WMI
+
+## Context
+
+`windows-proof-main` run 31098005022 **attempt 1** (`b88543d7c`) failed with
+`Process snapshot failed (exit none, spawnSync …powershell.exe ETIMEDOUT)` at the first
+`processSnapshot()` in `scripts/verify-windows-app-launch.ts`. The app itself had already
+launched and written its readiness marker; only the query that inspects the process table
+stalled. The upload step deliberately carries no `if:`
+(`213-downloadable-windows-build-is-the-launched-tree.md`), so the downloadable Windows
+build — the whole point of that change — was withheld from a launch that had succeeded.
+
+Cite the run **with its attempt number**: a rerun overwrites the run-level conclusion, so
+a bare `31098005022` now reads as green and argues for the opposite of this record.
+
+## Investigation
+
+- Bun honours `spawnSync`'s `timeout` to the millisecond (measured: 2002 ms for a 2000 ms
+  budget), so the 60 s in the log is real and not a mis-measure.
+- Nothing in `#1272` reaches the stalled call. Ruled out by reading: the retained unpack
+  directory only changes where `tar.exe` extracts (the query enumerates processes, not
+  files); the path change moves ~400 MB off `C:\…\Temp` onto the workspace disk, i.e.
+  *less* pressure where it was before; no extra process is spawned; the pre-extraction
+  `rmSync` is a no-op on a fresh runner.
+- The red is **not stationary**: the same commit passed on attempt 2 (44.5 s total,
+  ready 22.3 s, shutdown 20.4 s). Sample of two on a two-run workflow history — that is
+  one observed stall and one clean rerun, **not a rate**, and no duration distribution
+  exists at all.
+- The proof issues far more of these queries than it looks: `alivePids()` ran a full
+  PowerShell + WMI snapshot on every 500 ms poll of a 10 s graceful and a 20 s forced
+  shutdown window — inferred ~15 PowerShell cold starts per run from `shutdownAfterMs`,
+  against 2 that genuinely need parent pids.
+- **The snapshot is not a diagnostic.** It underwrites the ready marker's pid being the
+  launcher or one of its descendants, and "no owned process survived shutdown". Making its
+  absence non-fatal would have weakened the proof while looking like a fix.
+
+## Decision
+
+1. **Attempts, not a bigger number.** `runProcessQuery()` retries a bounded number of
+   times (3) at unchanged per-attempt budgets, and throws with a message naming the cause
+   (the runner's query, not the app) and the fix. Raising the budget was refused: there is
+   no distribution to size one from, and a budget picked to make one run pass is not a
+   budget.
+2. **The runs now produce that distribution.** Every attempt is timed into
+   `processQueryStats` in `windows-app-launch-proof.json` and echoed in the summary line,
+   so the next budget argument can be read off measurements.
+3. **Liveness leaves WMI.** `alivePids()` uses `tasklist.exe /FO CSV /NH` — a native exe
+   with neither a PowerShell start-up nor a WMI round-trip — because liveness needs pids
+   only. `/FO CSV /NH` is chosen for locale-independence: tasklist translates its headers
+   and unit strings, and `livePidSet()` throws rather than let an unparseable list read as
+   an empty machine (that would report every owned process dead and pass a shutdown that
+   never happened).
+
+Seq 1450 independently dropped `Get-CimInstance Win32_Process` as its primary query in
+favour of `Get-Process` for cost reasons. Two arrivals at the same conclusion; note the
+limit of the shared evidence, though — the ETIMEDOUT wraps the PowerShell start-up **and**
+the WMI round-trip, so this failure cannot by itself prove the WMI half is the expensive
+one.
+
+## Risks
+
+- Three attempts at a 60 s budget means a genuinely dead query costs 180 s per tree walk
+  instead of 60 s, inside a 35-minute job. Acceptable while there are two such walks.
+- A stall that is not transient now takes 3× as long to be reported. The recorded
+  durations are the mitigation: they say whether attempts helped or only postponed.
+- `tasklist.exe` is not proven immune to the same stall class, only cheaper and free of
+  WMI. It therefore gets the same bounded retry rather than a claim of immunity.
+
+## Alternatives considered
+
+- **Let the snapshot fail without failing the proof.** Rejected: it is an assertion, not a
+  diagnostic (see Investigation). This would have shipped a build whose shutdown was never
+  verified.
+- **Raise the 60 s budget.** Rejected on principle stated above; also indistinguishable
+  from doing nothing if the stall has no upper bound.
+- **Upload the build on failure (`if: always()`).** Rejected — that is the guard from
+  decision 213 working on its first real test, not a bug.
+- **Replace the tree walk with `Get-Process` too.** It cannot report parent pids, and the
+  two walks exist precisely to establish parentage.

--- a/scripts/verify-windows-app-launch.ts
+++ b/scripts/verify-windows-app-launch.ts
@@ -49,6 +49,17 @@ const READY_TIMEOUT_MS = Number(
 const GRACEFUL_SHUTDOWN_MS = 10_000;
 const FORCED_SHUTDOWN_MS = 20_000;
 
+/**
+ * Attempts, not a bigger single budget. Run 31098005022 lost the downloadable Windows
+ * build to one 60s stall of the process query, and the same commit passed on re-run, so
+ * the stall is transient rather than a deterministic break. No duration distribution
+ * exists to size a bigger budget from, so the budgets below are unchanged and every
+ * attempt is timed into the proof instead — the next runs produce that distribution.
+ */
+const PROCESS_QUERY_ATTEMPTS = 3;
+const TREE_WALK_TIMEOUT_MS = 60_000;
+const LIVENESS_QUERY_TIMEOUT_MS = 30_000;
+
 export interface ProcessEntry {
 	pid: number;
 	parentPid: number;
@@ -199,6 +210,85 @@ function requireSuccess(result: CommandResult, description: string): string {
 	return result.stdout.trim();
 }
 
+/** What the Windows process queries cost this run, so a budget can be set from measurements. */
+export interface ProcessQueryStats {
+	calls: number;
+	attempts: number;
+	maxMs: number;
+	totalMs: number;
+}
+
+export function newProcessQueryStats(): ProcessQueryStats {
+	return { calls: 0, attempts: 0, maxMs: 0, totalMs: 0 };
+}
+
+/**
+ * A Windows process query, retried a bounded number of times and timed into `stats`.
+ *
+ * Every attempt is measured whether it succeeds or not: the point of the numbers is to
+ * answer "is the budget too small" with data instead of with a guess.
+ */
+export function runProcessQuery(
+	description: string,
+	stats: ProcessQueryStats,
+	attempts: number,
+	execute: () => CommandResult,
+	now: () => number = Date.now,
+): string {
+	stats.calls += 1;
+	let last: CommandResult | undefined;
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		const startedAt = now();
+		const result = execute();
+		const elapsedMs = now() - startedAt;
+		stats.attempts += 1;
+		stats.totalMs += elapsedMs;
+		stats.maxMs = Math.max(stats.maxMs, elapsedMs);
+		if (result.status === 0 && !result.error) return result.stdout.trim();
+		last = result;
+	}
+	throw new Error(
+		`${description} failed on all ${attempts} attempts (exit ${last?.status ?? "none"}${last?.error ? `, ${last.error.message}` : ""}).\n` +
+			"CAUSE: the runner's own process query stalled or died. This says nothing about the launched app — " +
+			"one such stall already withheld a Windows build from a green launch (run 31098005022 attempt 1).\n" +
+			"FIX: read processQueryStats in windows-app-launch-proof.json for the durations this run measured. " +
+			"If they sit near the per-attempt budget, move the query off this dialect — the liveness path already " +
+			"uses tasklist.exe, which needs neither PowerShell nor WMI — rather than raising the budget.\n" +
+			`stdout: ${last?.stdout ?? ""}\nstderr: ${last?.stderr ?? ""}`,
+	);
+}
+
+/**
+ * Pids out of `tasklist.exe /FO CSV /NH`. That spelling is deliberate: tasklist
+ * translates its column headers on a localized Windows, so a parser reading the English
+ * header form matches nothing on a German or Russian machine — and "matched nothing"
+ * here would read as "no process is alive".
+ */
+export function parseTasklistPids(output: string): number[] {
+	const pids: number[] = [];
+	for (const line of output.split(/\r?\n/)) {
+		const match = /^"[^"]*","(\d+)"/.exec(line.trim());
+		if (match) pids.push(Number(match[1]));
+	}
+	return pids;
+}
+
+/** The live pids, refusing to read an unparseable process list as an empty machine. */
+export function livePidSet(output: string): Set<number> {
+	const pids = parseTasklistPids(output);
+	if (pids.length === 0) {
+		throw new Error(
+			"tasklist.exe /FO CSV /NH returned no parseable process rows.\n" +
+				'CAUSE: its output no longer matches "image","pid",… — the row shape changed. Windows always lists its own ' +
+				"system processes, so an empty parse cannot mean an empty machine.\n" +
+				"FIX: update parseTasklistPids for the new shape. Never let an unparseable list read as an empty one: " +
+				"that reports every owned process as dead and passes a shutdown that never happened.\n" +
+				`stdout: ${output}`,
+		);
+	}
+	return new Set(pids);
+}
+
 function sha256(path: string): string {
 	return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
@@ -239,22 +329,29 @@ async function main(): Promise<void> {
 	const system32 = join(systemRoot, "System32");
 	const powershell = join(system32, "WindowsPowerShell", "v1.0", "powershell.exe");
 	const taskkill = join(system32, "taskkill.exe");
+	const tasklist = join(system32, "tasklist.exe");
+	const treeWalkStats = newProcessQueryStats();
+	const livenessStats = newProcessQueryStats();
 
+	/** Only the two tree walks need parent pids, and only WMI reports them. */
 	function processSnapshot(): ProcessEntry[] {
-		const output = requireSuccess(
-			run(
-				powershell,
-				[
-					"-NoProfile",
-					"-NonInteractive",
-					"-Command",
-					"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name | ConvertTo-Json -Compress -Depth 3",
-				],
-				repoRoot,
-				process.env,
-				60_000,
-			),
-			"Process snapshot",
+		const output = runProcessQuery(
+			"Windows process tree snapshot (powershell Get-CimInstance Win32_Process)",
+			treeWalkStats,
+			PROCESS_QUERY_ATTEMPTS,
+			() =>
+				run(
+					powershell,
+					[
+						"-NoProfile",
+						"-NonInteractive",
+						"-Command",
+						"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name | ConvertTo-Json -Compress -Depth 3",
+					],
+					repoRoot,
+					process.env,
+					TREE_WALK_TIMEOUT_MS,
+				),
 		);
 		const parsed = JSON.parse(output) as unknown;
 		const rows = Array.isArray(parsed) ? parsed : [parsed];
@@ -264,9 +361,21 @@ async function main(): Promise<void> {
 		});
 	}
 
+	/**
+	 * Liveness needs pids only, never parents, so it goes through tasklist.exe: a native
+	 * exe with no PowerShell start-up and no WMI round-trip. The shutdown poll loops call
+	 * this every 500ms, so this is where nearly every process query of a run lives — it is
+	 * the difference between one stall-prone call per run and roughly fifteen.
+	 */
 	function alivePids(pids: number[]): number[] {
 		if (pids.length === 0) return [];
-		const live = new Set(processSnapshot().map((entry) => entry.pid));
+		const output = runProcessQuery(
+			"Windows live process list (tasklist.exe)",
+			livenessStats,
+			PROCESS_QUERY_ATTEMPTS,
+			() => run(tasklist, ["/FO", "CSV", "/NH"], repoRoot, process.env, LIVENESS_QUERY_TIMEOUT_MS),
+		);
+		const live = livePidSet(output);
 		return pids.filter((pid) => live.has(pid));
 	}
 
@@ -504,6 +613,10 @@ async function main(): Promise<void> {
 			rendererReadyMs: marker.rendererReadyMs,
 			rendererReadyBudgetMs: RENDERER_READY_TIMEOUT_MS,
 			ownedProcessesBeforeShutdown,
+			// Published so a future budget can be read off measurements instead of picked.
+			// `treeWalks` is the WMI dialect that stalled for 60s in run 31098005022 attempt 1;
+			// `liveness` is tasklist.exe, which replaced it everywhere parents are not needed.
+			processQueryStats: { treeWalks: treeWalkStats, liveness: livenessStats },
 			shutdownMethod,
 			shutdownAfterMs,
 			survivingOwnedProcesses: [] as number[],
@@ -516,7 +629,9 @@ async function main(): Promise<void> {
 			`[windows-app-launch] ${desktopExecutableRelativePath} (rejected ${desktopSelection.rejected.length} other executables) ` +
 				`shipped with cli/${expectedCliName} and host image ${discovered.tag}, reached ready in ${readyAfterMs}ms ` +
 				`(renderer ${marker.rendererReadyMs}ms of a ${RENDERER_READY_TIMEOUT_MS}ms budget), ` +
-				`shut down via ${shutdownMethod} with no owned processes left`,
+				`shut down via ${shutdownMethod} with no owned processes left; ` +
+				`process queries: ${treeWalkStats.calls} WMI tree walks (slowest ${treeWalkStats.maxMs}ms of a ${TREE_WALK_TIMEOUT_MS}ms budget), ` +
+				`${livenessStats.calls} tasklist liveness checks (slowest ${livenessStats.maxMs}ms of a ${LIVENESS_QUERY_TIMEOUT_MS}ms budget)`,
 		);
 	} finally {
 		if (launcherPid !== null) {

--- a/src/bun/__tests__/windows-build-orchestration.test.ts
+++ b/src/bun/__tests__/windows-build-orchestration.test.ts
@@ -8,6 +8,10 @@ import { nativeBuildPlan } from "../../../scripts/build-native";
 import {
 	descendantPids,
 	isUsableReadyMarker,
+	livePidSet,
+	newProcessQueryStats,
+	parseTasklistPids,
+	runProcessQuery,
 	selectDesktopExecutable,
 	selectWindowsArchive,
 } from "../../../scripts/verify-windows-app-launch";
@@ -199,3 +203,65 @@ describe("owned process tree", () => {
 		expect(descendantPids([{ pid: 7, parentPid: 7, name: "weird.exe" }], 7)).toEqual([]);
 	});
 });
+
+describe("windows process queries", () => {
+	const TASKLIST_CSV = [
+		'"System Idle Process","0","Services","0","8 K"',
+		'"launcher.exe","7652","Console","2","12,340 K"',
+		'"msedgewebview2.exe","6928","Console","2","210,004 K"',
+	].join("\r\n");
+
+	it("reads pids out of tasklist CSV rows regardless of the machine's language", () => {
+		expect(parseTasklistPids(TASKLIST_CSV)).toEqual([0, 7652, 6928]);
+		// A localized Windows translates the memory unit and the session name; only the
+		// quoted image/pid pair is depended on.
+		expect(parseTasklistPids('"launcher.exe","4242","Консоль","2","57 400 КБ"')).toEqual([4242]);
+		expect(parseTasklistPids('INFO: No tasks are running which match the specified criteria.')).toEqual([]);
+	});
+
+	it("refuses to read an unparseable process list as an empty machine", () => {
+		expect([...livePidSet(TASKLIST_CSV)]).toEqual([0, 7652, 6928]);
+		expect(() => livePidSet("PID | NAME\n7652 | launcher.exe")).toThrow(
+			/no parseable process rows[\s\S]*CAUSE[\s\S]*row shape changed[\s\S]*FIX[\s\S]*passes a shutdown that never happened/,
+		);
+	});
+
+	it("times a first-attempt success and does not retry it", () => {
+		const stats = newProcessQueryStats();
+		let calls = 0;
+		const clock = fakeClock([0, 900]);
+		const output = runProcessQuery("tree walk", stats, 3, () => {
+			calls += 1;
+			return { status: 0, stdout: " [] \n", stderr: "" };
+		}, clock);
+		expect(output).toBe("[]");
+		expect(calls).toBe(1);
+		expect(stats).toEqual({ calls: 1, attempts: 1, maxMs: 900, totalMs: 900 });
+	});
+
+	it("survives a stalled attempt and times the stall it survived", () => {
+		const stats = newProcessQueryStats();
+		const results = [timedOut(), timedOut(), { status: 0, stdout: "ok", stderr: "" }];
+		const clock = fakeClock([0, 60_000, 60_000, 61_200, 61_200, 61_800]);
+		expect(runProcessQuery("tree walk", stats, 3, () => results.shift()!, clock)).toBe("ok");
+		expect(stats).toEqual({ calls: 1, attempts: 3, maxMs: 60_000, totalMs: 61_800 });
+	});
+
+	it("blames the runner's process query, not the app, once the attempts are spent", () => {
+		const stats = newProcessQueryStats();
+		expect(() => runProcessQuery("Windows process tree snapshot", stats, 3, timedOut, fakeClock([]))).toThrow(
+			/failed on all 3 attempts[\s\S]*ETIMEDOUT[\s\S]*CAUSE: the runner's own process query[\s\S]*FIX[\s\S]*rather than raising the budget/,
+		);
+		expect(stats.attempts).toBe(3);
+	});
+});
+
+function timedOut(): { status: null; stdout: string; stderr: string; error: Error } {
+	return { status: null, stdout: "", stderr: "", error: new Error("spawnSync powershell.exe ETIMEDOUT") };
+}
+
+/** Reads the listed instants in order, then holds the last one. */
+function fakeClock(instants: number[]): () => number {
+	let index = 0;
+	return () => instants[Math.min(index++, instants.length - 1)] ?? 0;
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that did this work) — writing this description myself.

`windows-proof-main` run `31098005022` **attempt 1** (`b88543d7c`) failed with `Process snapshot failed (exit none, spawnSync …powershell.exe ETIMEDOUT)` at the first `processSnapshot()`. The app had already launched and written its readiness marker; only the PowerShell/WMI query that inspects the process table stalled for its full 60s budget. Because the upload step deliberately carries no `if:` (decision 213), the downloadable Windows build was withheld from a launch that had succeeded.

Cite that failure **with its attempt number**: attempt 2 of the same run passed on the same sha, so a bare run id now reads as green.

**Verdict: a transient stall, not a regression.** Every part of #1272 was ruled out by reading — the retained tree and the changed path cannot reach a query that enumerates processes rather than files (and the path change moved ~400 MB of write pressure *off* the disk it used to sit on), the diff spawns no extra process, and the new pre-extraction `rmSync` is a no-op on a fresh runner. Bun honours `spawnSync`'s timeout to the millisecond, so the 60s is real.

The snapshot is **not** a diagnostic: it underwrites the ready marker's pid being the launcher or one of its descendants, and "no owned process survived shutdown". Making its absence non-fatal would have weakened the proof while looking like a fix.

What this changes:

- `runProcessQuery()` retries the two tree walks a bounded number of times (3) at **unchanged** per-attempt budgets, and throws naming the cause (the runner's query, not the app) and the fix.
- The 60s budget is deliberately not raised: no duration distribution exists to size one from. Instead every attempt is timed into `processQueryStats` in `windows-app-launch-proof.json` and echoed in the summary line, so the next budget argument can be read off measurements.
- Shutdown liveness polls leave WMI for `tasklist.exe /FO CSV /NH` — a native exe with neither a PowerShell start-up nor a WMI round-trip — which cuts stall-prone calls per run from roughly fifteen to two. `/FO CSV /NH` is chosen for locale-independence, and an unparseable list throws rather than read as an empty machine, which would report every owned process dead and pass a shutdown that never happened.

Reasoning and rejected alternatives: `decisions/215-windows-launch-proof-process-query-dialects.md`.