### PR TITLE
Say in the build log that the electrobun icon warnings are already repaired

### DIFF
--- a/decisions/214-vendor-rcedit-for-windows-icons.md
+++ b/decisions/214-vendor-rcedit-for-windows-icons.md
@@ -74,9 +74,53 @@ artifact an icon would make it read as finished. A user who eventually runs the
 installer still gets an icon'd app — it extracts the tree we fixed. Only the
 installer's own file icon stays blank.
 
-**So every Windows build log keeps exactly one `Failed to embed icon` warning,
-forever.** That surviving line is this decision, not a leftover. Do not "finish the
-job".
+## What the build log actually looks like, and why that matters
+
+An earlier draft of this record claimed the `launcher.exe` and `bun.exe` warnings "go
+away" after this fix. **They do not**, and that error cost the repo owner his trust in
+the fix on the first Windows run: he saw the warnings, concluded the icons were broken,
+and stopped reading twelve lines short of the success.
+
+Electrobun attempts the embed **before** `postBuild` and warns on the way past. This
+hook then repairs two of the three. So a **working** Windows build prints:
+
+```
+Warning: Failed to embed icon into launcher.exe: ... Cannot find module '...rcedit/package.json'
+Warning: Failed to embed icon into bun.exe: ...
+Running postBuild script: ./scripts/package-native-host.ts
+[windows-icons] the two ... warnings above are EXPECTED and already repaired — ...
+[windows-icons] app icon embedded and verified in bin/launcher.exe, bin/bun.exe. ...
+Warning: Failed to embed icon into Windows installer: ...
+```
+
+All three warnings survive forever. The first two are **repaired twelve lines later**;
+the installer one is never repaired, per the section above. The hook's success line
+therefore states that the earlier warnings are superseded rather than merely announcing
+itself — **a log that reads as broken while being correct is a defect, not cosmetics.**
+
+## What this does NOT fix: the running app's window and taskbar icon
+
+An icon resource in a PE governs the file's icon in Explorer, on a shortcut, and in the
+Start menu. It does **not** by itself give a running window an icon.
+
+Read out of electrobun's `package/src/native/win/nativeWrapper.cpp`: the main window
+class `BasicWindowClass` is registered as `WNDCLASSW wc = {0}` with `lpfnWndProc` and
+`hCursor` set and **`hIcon` never assigned**; its `hInstance` is the native wrapper
+*DLL* rather than the executable; and the repository contains no `WM_SETICON`,
+`LoadIconW` or `SetClassLongPtr` call for an app window anywhere. (The only `hIcon`
+assignments in that file are for the tray `NOTIFYICONDATA`. GitHub code search was
+control-checked against the same repo before trusting the zero results.)
+
+So whatever Windows shows for the window and its taskbar button is a system fallback,
+not an icon anyone loaded. **This change is correct and incomplete**: closing that
+surface means electrobun setting a window icon — upstream work, or a separate decision
+here. `rcedit` cannot reach it.
+
+**Do not "confirm" this fix by looking at the taskbar.**
+
+⚠️ Explorer caches per-file icons. An `.exe` whose icon resource changed **at the same
+path** can keep showing the old or default icon until that cache is invalidated, so a
+stale thumbnail is not evidence of a failed embed.
 
 ## How the two-line `bun.lock` diff was produced
 

--- a/scripts/embed-windows-icons.ts
+++ b/scripts/embed-windows-icons.ts
@@ -76,8 +76,18 @@ async function run(): Promise<void> {
 		},
 	});
 
+	// Electrobun's own icon attempt runs BEFORE this hook and warns twice on the
+	// way past. A build that worked therefore prints two alarming lines and then
+	// succeeds a dozen lines later, and a human believes the warnings. So say out
+	// loud that they are superseded rather than only announcing success.
 	console.log(
-		`[windows-icons] embedded and verified the app icon in ${targets.map((target) => target.relativePath).join(", ")}`,
+		"[windows-icons] the two 'Failed to embed icon into launcher.exe/bun.exe' warnings above are EXPECTED and already repaired — " +
+			"electrobun cannot resolve its own rcedit (decisions/214-vendor-rcedit-for-windows-icons.md), so we embed it here instead.",
+	);
+	console.log(
+		`[windows-icons] app icon embedded and verified in ${targets.map((target) => target.relativePath).join(", ")}. ` +
+			"A third warning, for the Windows installer, survives on purpose and is not repaired (decision 213). " +
+			"This governs the icon in Explorer, on shortcuts and in the Start menu — NOT the running app's taskbar icon.",
 	);
 }
 

--- a/src/bun/windows-icons/embed-windows-icons.ts
+++ b/src/bun/windows-icons/embed-windows-icons.ts
@@ -22,9 +22,14 @@ import { hasEmbeddedIcon } from "./pe-icon-resources";
  * artifact an icon would make it read as vetted.
  *
  * Consequence to expect in every Windows build log, permanently: electrobun emits
- * THREE `Failed to embed icon` warnings and this hook removes two of them. The
- * surviving installer warning is the decision above, not a leftover — do not
- * "finish the job" by reaching into the zip electrobun just wrote.
+ * THREE `Failed to embed icon` warnings, and this hook removes NONE of them —
+ * electrobun tries first and warns on the way past, and we repair two of the three
+ * afterwards. A build that worked still prints all three. That is why the hook's
+ * success line says the earlier warnings are superseded instead of only announcing
+ * itself; a log that reads as broken while being correct is a defect.
+ *
+ * The third, for the installer, is the decision above — do not "finish the job" by
+ * reaching into the zip electrobun just wrote.
  */
 export const WINDOWS_ICON_TARGETS = ["bin/launcher.exe", "bin/bun.exe"] as const;
 


### PR DESCRIPTION
Follow-up to #1273. No behaviour change to the icon embedding — this repairs the build log and a false claim in the decision record.

## The defect

#1273 embeds the Windows app icon and verifies it by reading the resource back out of the PE. It works. But electrobun attempts the embed **before** our `postBuild` hook and warns on the way past, so a **correct** Windows build prints:

```
Warning: Failed to embed icon into launcher.exe: ... Cannot find module '...rcedit/package.json'
Warning: Failed to embed icon into bun.exe: ...
Running postBuild script: ./scripts/package-native-host.ts
[windows-icons] embedded and verified the app icon in bin/launcher.exe, bin/bun.exe
```

The first thing a human does is believe the warnings. That is what happened on the first real Windows run of #1273: the build was correct and was read as broken, twelve lines short of the success line.

A log that reads as broken while being correct is a defect, not cosmetics.

## What changed

- The success line now **supersedes** the earlier warnings instead of only announcing itself: it names them as expected and already repaired, names the third (installer) warning as surviving on purpose per decision 213, and states that this governs the icon in Explorer, on shortcuts and in the Start menu — **not** the running app's taskbar icon.
- `decisions/214-vendor-rcedit-for-windows-icons.md` gains two sections and drops a false sentence. The earlier draft claimed the launcher and bun warnings "go away" after the fix; they do not, and the record now carries the real log transcript.
- A new section records what this fix does **not** cover. Read out of electrobun's `package/src/native/win/nativeWrapper.cpp`: the main window class `BasicWindowClass` is registered with `hIcon` never assigned, its `hInstance` is the native wrapper DLL rather than the executable, and there is no `WM_SETICON` / `LoadIconW` / `SetClassLongPtr` call for an app window anywhere. The window and taskbar icon is therefore a system fallback that a PE resource cannot reach. Tracked separately; not attempted here.
- Notes that Explorer caches per-file icons, so a stale thumbnail is not evidence of a failed embed.

## Verification

Both log lines proved to print on **both** build paths — the soft `dev` path and the hard packaging path — by running the real hook against a fake bundle whose executables already carry an icon resource, with only the `rcedit` spawn stubbed (a Windows `.exe` cannot run on the macOS agent). The failure side was exercised in the same run: a broken bundle warns and exits 0 on `dev`, throws and exits 1 on `canary`.

Lint clean. 9 718 tests green across the three configs (backend 5 316, CLI 718, renderer 3 684).