### PR TITLE
Give the keyboard to the pane + Agent just opened

### DIFF
--- a/change-logs/2026/08/06/fix-spawned-agent-takes-the-keyboard.md
+++ b/change-logs/2026/08/06/fix-spawned-agent-takes-the-keyboard.md
@@ -1,0 +1,3 @@
+Short: Typing goes to the new agent
+
+"+ Agent" now leaves the keyboard in the pane it just opened, so the first thing you type is the new agent's prompt instead of being swallowed by the button that opened the dialog. On a native task the viewer also follows the freshly spawned pane; an auxiliary pane such as a dev server still hands focus back to the agent.

--- a/decisions/212-spawned-pane-takes-the-keyboard.md
+++ b/decisions/212-spawned-pane-takes-the-keyboard.md
@@ -1,0 +1,56 @@
+# 212 — A spawned agent pane takes the keyboard, and the viewer follows it
+
+## Context
+
+"+ Agent" opened a pane and left the user with nothing focused: the dialog's focus
+trap restores focus to its trigger button on unmount, so the next keystroke went to
+the "+ Agent" button instead of the agent. `TerminalView`'s type-to-focus fallback
+did not help — it only fires when `document.activeElement` is `<body>`.
+
+On a native task there was a second half to it: pane focus is client-local
+(decision 179), and the viewer keeps its current pane across pane-state frames, so
+even after the split the keyboard belonged to the *old* agent.
+
+## Investigation
+
+The tmux path was already correct server-side (`split-window` makes the new pane
+active); only DOM focus was missing. The native path deliberately makes the new pane
+the coordinator's active pane on split, and `openAuxPane` passes `restoreFocus: true`
+precisely because an auxiliary pane (dev server, viewer) must NOT steal the agent's
+keyboard — `spawnAgentInTask` does not, so its pane stays active.
+
+## Decision
+
+Three pieces, all in the renderer:
+
+1. `useFocusTrap({ shouldRestoreFocus })` — a callback, not a flag, because the
+   dialog decides in its click handler and unmounts in that same commit, so it never
+   re-renders to publish a new value. `SpawnAgentModal` returns `false` after a
+   successful spawn.
+2. `src/mainview/terminal-focus-request.ts` — a request is a wish: the surface that
+   started the agent asks, and `TaskTerminal` (the only component that knows which
+   pane is focused and whether its canvas attached) answers when it can, or lets the
+   wish expire after 15 s.
+3. `TaskTerminal` adopts a pane that is BOTH brand new and the server's active one,
+   and on native holds the pending wish until such a pane arrives. Serving it with
+   the pane already on screen would type the new agent's prompt into the old agent,
+   so a spawn that produces no pane focuses nothing at all.
+
+## Risks
+
+A viewer that polls between the native split and `openAuxPane`'s focus restore could
+briefly see the aux pane as active and adopt it. The window is one RPC round trip
+against a 2.5 s poll, and the consequence is a moved highlight, not lost input.
+
+A second window spawning an agent moves this window's pane focus too — both viewers
+see the same fresh active pane. Treated as correct: the pane was opened for the user,
+not for one window.
+
+## Alternatives considered
+
+- Widen `TerminalView`'s type-to-focus fallback to fire while a button has focus —
+  space and Enter would then activate the button and type at the same time.
+- Drop the focus restore from `useFocusTrap` entirely — every other dialog needs it,
+  and cancelling "+ Agent" must still return to the button.
+- Have the server tell the client which pane to focus — contradicts decision 179;
+  the pane set plus `activePaneId` already carries everything needed.

--- a/src/mainview/components/SpawnAgentModal.tsx
+++ b/src/mainview/components/SpawnAgentModal.tsx
@@ -11,6 +11,7 @@ import AgentConfigPicker from "./AgentConfigPicker";
 import AgentPickerSkeleton from "./AgentPickerSkeleton";
 import MemoryPressureBanner from "./MemoryPressureBanner";
 import { useFocusTrap } from "../utils/useFocusTrap";
+import { requestTaskTerminalFocus } from "../terminal-focus-request";
 import { useReducedMotion } from "../utils/useReducedMotion";
 
 const NOT_INSTALLED_ID = "spawn-agent-not-installed";
@@ -23,7 +24,10 @@ interface SpawnAgentModalProps {
 
 function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 	const t = useT();
-	const trapRef = useFocusTrap<HTMLDivElement>();
+	// A spawned agent owns the keyboard from here on, so the trap must not pull
+	// focus back to the "+ Agent" button — that is the extra click this removes.
+	const spawnedRef = useRef(false);
+	const trapRef = useFocusTrap<HTMLDivElement>({ shouldRestoreFocus: () => !spawnedRef.current });
 	const reducedMotion = useReducedMotion();
 	const errorRef = useRef<HTMLDivElement>(null);
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
@@ -107,6 +111,10 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 			});
 			trackEvent("spawn_extra_agent", { project_id: project.id, agent_id: agentId ?? "default" });
 			trackAgentLaunched(agents, agentId, configId);
+			spawnedRef.current = true;
+			// The terminal holds this until the new pane is attachable, then types
+			// straight into it — the user's next keystroke is the agent's prompt.
+			requestTaskTerminalFocus(task.id);
 			onClose();
 		} catch (err) {
 			setError(String(err));

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -30,6 +30,7 @@ import { getPaneRects, restoreSplitTree, serializeSplitTree, setSplitRatio } fro
 import NativePaneDividers from "./NativePaneDividers";
 import { publishNativePaneFocus } from "../native-pane-focus";
 import { fetchPaneState, runPaneAction, subscribePaneState } from "../pane-state-bus";
+import { subscribeTaskTerminalFocus } from "../terminal-focus-request";
 
 interface TaskTerminalProps {
 	projectId: string;
@@ -43,6 +44,8 @@ interface TaskTerminalProps {
 
 const PTY_CONNECT_TIMEOUT_MS = 10_000;
 const NATIVE_PANE_POLL_MS = 2500;
+/** How long a "give the terminal the keyboard" wish waits for a pane to attach. */
+const FOCUS_REQUEST_TTL_MS = 15_000;
 
 type ErrorKind = "worktree-gone" | "session-ended";
 
@@ -105,6 +108,33 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	const [focusedPaneRefusedReason, setFocusedPaneRefusedReason] = useState<NativeViewerStatus["refusedReason"]>(undefined);
 	/** Whether ANY process holds the lease; undefined until the host reports it. */
 	const [focusedPaneWriterAttached, setFocusedPaneWriterAttached] = useState<boolean | undefined>(undefined);
+
+	// Pane ids seen in the previous pane-state frame, so the next one can tell a
+	// pane that JUST opened from one that was already there.
+	const knownPaneIdsRef = useRef<Set<string>>(new Set());
+
+	// ── Pending keyboard focus ────────────────────────────────────────────────
+	// A surface that just started an agent ("+ Agent") asks for the keyboard. On
+	// native the pane it means does not exist yet, so the wish waits for the pane
+	// the server just made active — focusing whatever is on screen right now would
+	// put the user's first keystroke in the WRONG agent. It expires rather than
+	// firing minutes later, and on tmux there is nothing to wait for: one canvas,
+	// and tmux already made the new pane active.
+	const pendingFocusRef = useRef<{ until: number; awaitFreshPane: boolean } | null>(null);
+	const [focusRequestSeq, setFocusRequestSeq] = useState(0);
+
+	/** Hand the keyboard over if it was asked for and this handle can take it. */
+	function consumePendingFocus(handle: TerminalHandle | null | undefined) {
+		const pending = pendingFocusRef.current;
+		if (!pending) return;
+		if (Date.now() > pending.until) {
+			pendingFocusRef.current = null;
+			return;
+		}
+		if (pending.awaitFreshPane || !handle) return;
+		pendingFocusRef.current = null;
+		handle.focus();
+	}
 
 	// A host that is gone never comes back, so a pane stays marked until it leaves
 	// the pane set — re-asking every poll would just hammer a dead session.
@@ -179,9 +209,23 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 				for (const paneId of stale) next.delete(paneId);
 				return next;
 			});
+			// A pane that is BOTH brand new and the server's active one was opened for
+			// the user to work in ("+ Agent"), so this viewer follows it. An auxiliary
+			// pane (dev server, viewer) hands focus back on split, so it never matches
+			// and never steals the agent's keyboard.
+			const known = knownPaneIdsRef.current;
+			const fresh = state.activePaneId && known.size > 0 && !known.has(state.activePaneId)
+				? state.activePaneId
+				: null;
+			knownPaneIdsRef.current = live;
+			// The pane a pending focus request was waiting for has arrived.
+			if (fresh && pendingFocusRef.current?.awaitFreshPane) {
+				pendingFocusRef.current = { ...pendingFocusRef.current, awaitFreshPane: false };
+				setFocusRequestSeq((n) => n + 1);
+			}
 			setClientFocusPaneId((prev) => {
 				const kept = prev && live.has(prev) ? prev : null;
-				const next = kept ?? state.activePaneId ?? (state.panes[0]?.paneId ?? null);
+				const next = fresh ?? kept ?? state.activePaneId ?? (state.panes[0]?.paneId ?? null);
 				if (next) publishNativePaneFocus(taskId, next);
 				return next;
 			});
@@ -227,6 +271,31 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			}
 		}
 	}, [nativePaneState?.panes.map((p) => p.paneId).join(",")]);
+
+	// Which native pane this viewer types into. Computed here, above the native
+	// branch, because the focus effects below need it too.
+	const nativeFocusPaneId = clientFocusPaneId
+		?? nativePaneState?.activePaneId
+		?? nativePaneState?.panes[0]?.paneId
+		?? null;
+
+	// ── Someone asked for the keyboard ────────────────────────────────────────
+	useEffect(() => {
+		return subscribeTaskTerminalFocus(taskId, () => {
+			pendingFocusRef.current = { until: Date.now() + FOCUS_REQUEST_TTL_MS, awaitFreshPane: isNative };
+			setFocusRequestSeq((n) => n + 1);
+			// Do not wait out the poll interval for a pane that already exists on the
+			// server — ask now so the keystrokes have somewhere to land.
+			if (isNative) void fetchPaneState(taskId).catch(() => {});
+		});
+	}, [taskId, isNative]);
+
+	// A handle that registers later consumes the request from onReady; this covers
+	// the pane that was already attached when the request arrived.
+	useEffect(() => {
+		if (!pendingFocusRef.current) return;
+		consumePendingFocus(isNative ? paneHandlesRef.current.get(nativeFocusPaneId ?? "") : termHandle);
+	}, [focusRequestSeq, isNative, nativeFocusPaneId, termHandle]);
 
 	// Hibernating a task whose terminal is already open must not leave a dead
 	// socket reconnecting forever: drop straight to the wake screen the moment the
@@ -459,7 +528,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		const panes = nativePaneState?.panes ?? [];
 
 		// Focused pane: clicking a pane updates client-local focus.
-		const focusPaneId = clientFocusPaneId ?? nativePaneState?.activePaneId ?? panes[0]?.paneId ?? null;
+		const focusPaneId = nativeFocusPaneId;
 
 		function makePaneNativeStatusHandler(paneId: string) {
 			return (status: NativeViewerStatus) => {
@@ -541,6 +610,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 								paneHandlesRef.current.set(paneId, handle);
 								// Use focused pane's handle for touch composer.
 								if (isFocused) setTermHandle(handle);
+								if (isFocused) consumePendingFocus(handle);
 							}}
 							onNativeStatus={makePaneNativeStatusHandler(paneId)}
 							onSessionLost={() => markPaneGone(paneId)}
@@ -572,6 +642,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 					onReady={(handle) => {
 						if (focusPaneId) paneHandlesRef.current.set(focusPaneId, handle);
 						setTermHandle(handle);
+						consumePendingFocus(handle);
 					}}
 					onNativeStatus={focusPaneId ? makePaneNativeStatusHandler(focusPaneId) : undefined}
 					onSessionLost={focusPaneId ? () => markPaneGone(focusPaneId) : undefined}
@@ -739,7 +810,10 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			ptyUrl={ptyUrl}
 			taskId={taskId}
 			projectId={projectId}
-			onReady={setTermHandle}
+			onReady={(handle) => {
+				setTermHandle(handle);
+				consumePendingFocus(handle);
+			}}
 			onNativeStatus={handleNativeStatus}
 			touchComposeMode={touchInput && !rawMode}
 		/>

--- a/src/mainview/components/__tests__/SpawnAgentModal.test.tsx
+++ b/src/mainview/components/__tests__/SpawnAgentModal.test.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SpawnAgentModal from "../SpawnAgentModal";
 import { I18nProvider } from "../../i18n";
+import { subscribeTaskTerminalFocus } from "../../terminal-focus-request";
 import type { CodingAgent, GlobalSettings, Project, Task } from "../../../shared/types";
 
 const claudeAgent: CodingAgent = {
@@ -364,6 +366,72 @@ describe("SpawnAgentModal", () => {
 				expect(document.activeElement).not.toBe(outside);
 			}
 			document.body.removeChild(outside);
+		});
+	});
+
+	// The whole point of "+ Agent": the keystroke after it is the agent's prompt,
+	// so the keyboard has to end up in the terminal and not back on the trigger.
+	describe("handing the keyboard to the spawned agent", () => {
+		beforeEach(() => {
+			// Earlier cases leave implementations behind (clearAllMocks keeps them):
+			// a rejecting spawn and an uninstalled agent both block the success path.
+			mockedApi.request.spawnAgentInTask.mockResolvedValue(undefined);
+			mockedApi.request.checkAgentAvailability.mockResolvedValue([
+				{ agentId: "builtin-claude", name: "Claude", baseCommand: "claude", installed: true, resolvedPath: "/usr/local/bin/claude" },
+			]);
+		});
+
+		/** Opens the dialog by CLICKING the trigger, so it is the element focus would return to. */
+		async function openFromTrigger(user: ReturnType<typeof userEvent.setup>) {
+			function Harness() {
+				const [open, setOpen] = useState(false);
+				return (
+					<>
+						<button data-testid="trigger" onClick={() => setOpen(true)}>+ Agent</button>
+						{open && <SpawnAgentModal task={baseTask} project={baseProject} onClose={() => setOpen(false)} />}
+					</>
+				);
+			}
+			render(<I18nProvider><Harness /></I18nProvider>);
+			const trigger = screen.getByTestId("trigger");
+			await user.click(trigger);
+			return trigger;
+		}
+
+		it("asks the task terminal for the keyboard after a successful spawn", async () => {
+			const user = userEvent.setup();
+			const seen: string[] = [];
+			const stop = subscribeTaskTerminalFocus("t1", () => seen.push("t1"));
+			renderModal();
+
+			await vi.waitFor(() => expect(screen.getByTestId("spawn-agent-submit")).toBeEnabled());
+			await user.click(screen.getByTestId("spawn-agent-submit"));
+
+			await vi.waitFor(() => expect(seen).toEqual(["t1"]));
+			stop();
+		});
+
+		it("does not pull focus back to the + Agent button", async () => {
+			const user = userEvent.setup();
+			const trigger = await openFromTrigger(user);
+
+			await vi.waitFor(() => expect(screen.getByTestId("spawn-agent-submit")).toBeEnabled());
+			await user.click(screen.getByTestId("spawn-agent-submit"));
+
+			await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+			expect(trigger).not.toHaveFocus();
+		});
+
+		it("still returns focus to the trigger when the dialog is cancelled", async () => {
+			const user = userEvent.setup();
+			const trigger = await openFromTrigger(user);
+
+			await vi.waitFor(() => expect(screen.getByTestId("spawn-agent-submit")).toBeEnabled());
+			await user.keyboard("{Escape}");
+
+			await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+			expect(trigger).toHaveFocus();
+			expect(mockedApi.request.spawnAgentInTask).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/mainview/components/__tests__/TaskTerminalSpawnFocus.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminalSpawnFocus.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * "+ Agent" must leave the keyboard in the pane it just opened: the user's next
+ * keystroke is the new agent's prompt, with no click in between.
+ *
+ * Two halves are asserted here — the viewer FOLLOWS a pane that is both brand new
+ * and the server's active one, and it hands DOM focus to that pane's canvas once
+ * it attaches (the pane does not exist yet when the dialog asks).
+ */
+
+import { useEffect } from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Task, Project } from "../../../shared/types";
+import type { TaskPaneState } from "../../../shared/task-panes";
+import { createSplitTree, serializeSplitTree, splitPane } from "../../../shared/split-tree";
+import { I18nProvider } from "../../i18n";
+import { api } from "../../rpc";
+import { _resetPaneStateBus, fetchPaneState } from "../../pane-state-bus";
+import { _resetNativePaneFocus } from "../../native-pane-focus";
+import { requestTaskTerminalFocus } from "../../terminal-focus-request";
+
+vi.mock("../../rpc", () => ({
+	api: {
+		request: {
+			getPtyUrl: vi.fn(),
+			getPanePtyUrl: vi.fn(),
+			taskPaneState: vi.fn(),
+			taskPaneAction: vi.fn(),
+			checkWorktreeExists: vi.fn(),
+		},
+	},
+	isElectrobun: false,
+}));
+
+/** Records a focus() spy per pane, keyed by the pane id embedded in its PTY URL. */
+const focusCalls: string[] = [];
+
+// onReady must fire ONCE per mount, from an effect: the real TerminalView reports
+// its handle after the canvas attaches, and calling it during render would loop.
+vi.mock("../../TerminalView", () => ({
+	default: ({ ptyUrl, onReady }: { ptyUrl: string; onReady?: (h: unknown) => void }) => {
+		const paneId = ptyUrl.split("~")[1] ?? "";
+		useEffect(() => {
+			onReady?.({ focus: () => focusCalls.push(paneId), blur: () => {}, paste: () => {}, claimWriter: () => {} });
+		}, [ptyUrl]);
+		return <div data-testid="terminal-view" data-pty-url={ptyUrl} />;
+	},
+}));
+vi.mock("../TaskInfoPanel", () => ({ default: () => null }));
+vi.mock("../NativeViewerBar", () => ({ default: () => null }));
+vi.mock("../MobilePaneCarousel", () => ({
+	default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../MobileWindowCarousel", () => ({
+	default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../PaneZoomBadge", () => ({ default: () => null }));
+vi.mock("../ClosePanePicker", () => ({ default: () => null }));
+vi.mock("../TaskPreparingView", () => ({ default: () => null }));
+vi.mock("../ExtraKeyBar", () => ({ default: () => null }));
+vi.mock("../TerminalComposer", () => ({ default: () => null }));
+vi.mock("../../hooks/useNarrowViewport", () => ({ useNarrowViewport: () => false }));
+
+const TASK_ID = "task-spawn-focus";
+const PROJECT_ID = "proj-1";
+const AGENT_PANE = "pane-1";
+const SPAWNED_PANE = "pane-2";
+
+const NATIVE_TASK = {
+	id: TASK_ID,
+	projectId: PROJECT_ID,
+	title: "Native task",
+	status: "in-progress",
+	worktreePath: "/tmp/wt",
+	createdAt: 0,
+	terminalBackend: "native",
+} as unknown as Task;
+
+const PROJECT = { id: PROJECT_ID, name: "P", path: "/tmp/proj" } as unknown as Project;
+
+function paneState(paneIds: string[], activePaneId: string): TaskPaneState {
+	let tree = createSplitTree();
+	for (let i = 1; i < paneIds.length; i++) tree = splitPane(tree, paneIds[i - 1], "horizontal");
+	return {
+		backend: "native",
+		panes: paneIds.map((paneId, i) => ({
+			paneId,
+			index: i,
+			label: "",
+			active: paneId === activePaneId,
+			zoomed: false,
+			alive: true,
+			rect: { x: i / paneIds.length, y: 0, width: 1 / paneIds.length, height: 1 },
+		})),
+		activePaneId,
+		zoomedPaneId: null,
+		layout: serializeSplitTree(tree),
+		layoutPreset: null,
+		capabilities: ["split", "zoom", "close", "focus"],
+	};
+}
+
+import TaskTerminal from "../TaskTerminal";
+
+let currentPanes: string[] = [AGENT_PANE];
+let currentActive = AGENT_PANE;
+
+beforeEach(() => {
+	currentPanes = [AGENT_PANE];
+	currentActive = AGENT_PANE;
+	focusCalls.length = 0;
+	_resetPaneStateBus();
+	_resetNativePaneFocus();
+	for (const fn of Object.values(api.request)) vi.mocked(fn as (...a: unknown[]) => unknown).mockReset();
+	vi.mocked(api.request.taskPaneState).mockImplementation(() => Promise.resolve(paneState(currentPanes, currentActive)));
+	vi.mocked(api.request.taskPaneAction).mockImplementation(() => Promise.resolve(paneState(currentPanes, currentActive)));
+	vi.mocked(api.request.getPanePtyUrl).mockImplementation(({ paneId }: { paneId: string }) =>
+		Promise.resolve({ url: `ws://localhost:9999?session=${TASK_ID}~${paneId}` }),
+	);
+	vi.mocked(api.request.checkWorktreeExists).mockResolvedValue(true as never);
+});
+
+function mountTerminal() {
+	return render(
+		<I18nProvider>
+			<TaskTerminal
+				projectId={PROJECT_ID}
+				taskId={TASK_ID}
+				tasks={[NATIVE_TASK]}
+				projects={[PROJECT]}
+				navigate={vi.fn()}
+				dispatch={vi.fn()}
+			/>
+		</I18nProvider>,
+	);
+}
+
+async function deliverPanes(paneIds: string[], activePaneId: string) {
+	currentPanes = paneIds;
+	currentActive = activePaneId;
+	await act(async () => {
+		await fetchPaneState(TASK_ID);
+	});
+}
+
+function focusedPaneIds(): string[] {
+	return [...document.querySelectorAll('[data-pane-id][data-focused="true"]')].map(
+		(el) => el.getAttribute("data-pane-id") ?? "",
+	);
+}
+
+describe("focus after spawning an agent into a native task", () => {
+	it("follows a pane that is both new and the server's active one", async () => {
+		mountTerminal();
+		await deliverPanes([AGENT_PANE], AGENT_PANE);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(1));
+
+		await deliverPanes([AGENT_PANE, SPAWNED_PANE], SPAWNED_PANE);
+
+		await waitFor(() => expect(focusedPaneIds()).toEqual([SPAWNED_PANE]));
+	});
+
+	it("gives the keyboard to the spawned pane once it attaches", async () => {
+		mountTerminal();
+		await deliverPanes([AGENT_PANE], AGENT_PANE);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(1));
+		focusCalls.length = 0;
+
+		// The dialog asks BEFORE the pane exists — this is the whole ordering problem.
+		await act(async () => { requestTaskTerminalFocus(TASK_ID); });
+		await deliverPanes([AGENT_PANE, SPAWNED_PANE], SPAWNED_PANE);
+
+		await waitFor(() => expect(focusCalls).toContain(SPAWNED_PANE));
+		expect(focusCalls).not.toContain(AGENT_PANE);
+	});
+
+	it("leaves focus alone for an auxiliary pane that hands focus back", async () => {
+		mountTerminal();
+		await deliverPanes([AGENT_PANE], AGENT_PANE);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(1));
+
+		// A dev-server pane: new, but the coordinator kept the agent pane active.
+		await deliverPanes([AGENT_PANE, SPAWNED_PANE], AGENT_PANE);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(2));
+
+		expect(focusedPaneIds()).toEqual([AGENT_PANE]);
+	});
+
+	it("never serves the request with the pane the user is already in", async () => {
+		mountTerminal();
+		await deliverPanes([AGENT_PANE], AGENT_PANE);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(1));
+		focusCalls.length = 0;
+
+		// The spawn failed to produce a pane. Grabbing focus for the pane already on
+		// screen would type the new agent's prompt into the OLD agent.
+		await act(async () => { requestTaskTerminalFocus(TASK_ID); });
+		await deliverPanes([AGENT_PANE], AGENT_PANE);
+
+		expect(focusCalls).toEqual([]);
+	});
+});
+
+describe("focus after spawning an agent into a tmux task", () => {
+	const TMUX_TASK = { ...NATIVE_TASK, id: TASK_ID, terminalBackend: "tmux" } as unknown as Task;
+
+	it("focuses the one canvas straight away — tmux itself activated the new pane", async () => {
+		vi.mocked(api.request.getPtyUrl).mockResolvedValue({ url: `ws://localhost:9999?session=${TASK_ID}~tmux` } as never);
+		render(
+			<I18nProvider>
+				<TaskTerminal
+					projectId={PROJECT_ID}
+					taskId={TASK_ID}
+					tasks={[TMUX_TASK]}
+					projects={[PROJECT]}
+					navigate={vi.fn()}
+					dispatch={vi.fn()}
+				/>
+			</I18nProvider>,
+		);
+		await waitFor(() => expect(screen.queryAllByTestId("terminal-view")).toHaveLength(1));
+		focusCalls.length = 0;
+
+		await act(async () => { requestTaskTerminalFocus(TASK_ID); });
+
+		await waitFor(() => expect(focusCalls).toEqual(["tmux"]));
+	});
+});

--- a/src/mainview/terminal-focus-request.ts
+++ b/src/mainview/terminal-focus-request.ts
@@ -1,0 +1,25 @@
+/**
+ * "Put the keyboard in this task's terminal" — asked for by a surface that just
+ * started something the user is about to type into (the "+ Agent" dialog), and
+ * answered by the task terminal, which is the only component that knows which
+ * pane is focused and whether its canvas is attached yet.
+ *
+ * A request is a WISH, not a command: the terminal keeps it pending until a
+ * focusable pane exists (a freshly spawned native pane needs a poll plus a PTY
+ * URL first), then consumes it. Nothing here focuses anything itself.
+ */
+
+const EVENT = "dev3:requestTerminalFocus";
+
+export function requestTaskTerminalFocus(taskId: string): void {
+	window.dispatchEvent(new CustomEvent(EVENT, { detail: { taskId } }));
+}
+
+export function subscribeTaskTerminalFocus(taskId: string, onRequest: () => void): () => void {
+	const listener = (event: Event) => {
+		const detail = (event as CustomEvent<{ taskId: string }>).detail;
+		if (detail?.taskId === taskId) onRequest();
+	};
+	window.addEventListener(EVENT, listener);
+	return () => window.removeEventListener(EVENT, listener);
+}

--- a/src/mainview/utils/useFocusTrap.ts
+++ b/src/mainview/utils/useFocusTrap.ts
@@ -64,10 +64,20 @@ function getFocusable(container: HTMLElement): HTMLElement[] {
  * be focusable itself (`tabIndex={-1}`) so step 1 has a target even when the
  * dialog has no focusable children yet.
  *
+ * `shouldRestoreFocus` opts step 3 out: a dialog that hands the keyboard to
+ * something else on success (a terminal it just spawned an agent into) must not
+ * have focus yanked back to its own trigger button on unmount. It is a callback,
+ * not a flag, because the decision is made in the click handler — the dialog
+ * unmounts in that same commit and never re-renders to publish a new value.
+ *
  * Works identically in the Electrobun desktop shell and the browser remote mode.
  */
-export function useFocusTrap<T extends HTMLElement = HTMLElement>(): RefObject<T | null> {
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+	options?: { shouldRestoreFocus?: () => boolean },
+): RefObject<T | null> {
 	const ref = useRef<T>(null);
+	const shouldRestore = useRef(options?.shouldRestoreFocus);
+	shouldRestore.current = options?.shouldRestoreFocus;
 
 	// Capture the trigger element at first render — before the dialog mounts and
 	// before any `autoFocus` child runs — so focus can be restored on close.
@@ -139,6 +149,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(): RefObject<T
 		return () => {
 			document.removeEventListener("keydown", onKeyDown, true);
 			// Return focus to where the user was before the dialog opened.
+			if (shouldRestore.current?.() === false) return;
 			(previouslyFocused.current as HTMLElement | null)?.focus?.();
 		};
 	}, []);


### PR DESCRIPTION
Clicking **+ Agent** left the user with nothing focused: the spawn dialog's focus trap returns focus to the button that opened it, so the first keystroke after spawning went into that button instead of the new agent. `TerminalView`'s type-to-focus fallback did not catch it either — it only fires when `document.activeElement` is `<body>`.

On a native task there was a second half: pane focus is client-local (decision 179), so the viewer kept its current pane across pane-state frames and the keyboard still belonged to the *old* agent even after the split.

## What changed

- `useFocusTrap({ shouldRestoreFocus })` — a callback, not a flag: the dialog decides in its click handler and unmounts in that same commit, so a new prop value would never reach the cleanup.
- `src/mainview/terminal-focus-request.ts` — a request is a wish; the task terminal is the only component that knows which pane is focused and whether its canvas attached, so it answers when it can, or lets the wish expire after 15 s.
- `TaskTerminal` adopts a pane that is **both** brand new and the server's active one. An auxiliary pane (dev server, viewer) hands focus back on split via `openAuxPane`'s `restoreFocus`, so it never matches and never steals the agent's keyboard. A spawn that produces no pane focuses nothing — serving the request with the pane already on screen would type the new agent's prompt into the old agent.

Reasoning and rejected alternatives: `decisions/212-spawned-pane-takes-the-keyboard.md`.

## Verified

- tmux path driven live in headless Chromium: **+ Agent → Spawn**, no click on the terminal, keys `f o c u s` landed in the freshly spawned Claude's prompt (checked with `tmux capture-pane`); `document.activeElement` was the terminal input, not the button.
- Native path covered by unit tests (adopt the new active pane, focus it once it attaches, aux pane leaves focus alone, no-new-pane focuses nothing) plus the tmux case.
- `bun run lint` and the full `bun run test` green after rebasing on `main`.