### PR TITLE
Free the Windows dev build folder before Electrobun wipes it

### DIFF
--- a/change-logs/2026/08/06/fix-windows-dev-build-ebusy.md
+++ b/change-logs/2026/08/06/fix-windows-dev-build-ebusy.md
@@ -1,0 +1,3 @@
+Short: Windows dev build no longer dies on EBUSY
+
+`bun run dev` on Windows failed before it could start, because Electrobun wipes its build folder with an un-retried delete and Windows refuses to remove a folder a running process sits in. Detached terminal hosts no longer inherit the app's bundle directory as their working directory, and a new pre-build step clears the folder first — terminating only this build's own app processes, never a `dev3` CLI that might be serving another task. macOS and Linux are untouched.

--- a/decisions/217-windows-build-folder-freed-before-electrobun-wipes-it.md
+++ b/decisions/217-windows-build-folder-freed-before-electrobun-wipes-it.md
@@ -1,0 +1,161 @@
+# 217 — Windows: free the build folder before Electrobun wipes it
+
+Cite this record as `217-windows-build-folder-freed-before-electrobun-wipes-it`
+— decision numbers in this repo are not unique, slugs are.
+
+## Context
+
+`bun run dev` cannot start on Windows. Every build dies in Electrobun's own
+preamble:
+
+```
+EBUSY: resource busy or locked, rm 'D:\src\dev-3.0\build\dev-win-x64'
+at runBuild (electrobun)
+```
+
+Everything before it succeeds — vite bundle, `dist/dev3.exe`, the native host
+image. This blocks every other Windows fix, because none of them can be built.
+
+## Investigation
+
+Electrobun 1.18.1 `src/cli/index.ts` opens `runBuild` with
+`if (existsSync(buildFolder)) rmSync(buildFolder, { recursive: true })` — no
+`force`, no `maxRetries` — immediately after `runHook("preBuild")`. `bun run dev`
+reaches it twice: once via `electrobun build` (`scripts/dev.ts` → `devPlan`) and
+again inside `electrobun dev`. A clean tree skips the wipe, so the failure is
+"something from the previous run is still alive", not structural.
+
+Who holds the folder on Windows (macOS unlinks a running image happily, which is
+why this is a one-platform defect):
+
+- **The app itself.** `runApp` spawns `launcher.exe` with
+  `cwd: build\<prefix>\<app>\bin`, and a live process's current directory cannot
+  be deleted on Windows. Its image lives there too.
+- **The packaged CLI.** `resolveDev3CliPath` (`src/shared/dev3-cli-path.ts`) makes
+  Windows agent hooks invoke `<execDir>\cli\dev3.exe` — inside the build folder.
+  A hook from **another worktree** therefore pins it, and some of those calls block
+  for up to ten minutes waiting for user approval.
+- **Detached native terminal hosts.** `nativeHostLauncher` used `node:child_process`
+  `spawn` with no `cwd`, so every host inherited the app's bundle cwd — and hosts
+  are deliberately detached to survive app restarts (decision
+  `169-packaged-windows-native-host-image`). This was the load-bearing holder: with
+  any task terminal alive, no amount of killing would have freed the folder.
+- **Not a holder:** the host's *image* — it runs from the staged copy in
+  `~/.dev3.0/native-host-images/<tag>/`, never from the install directory.
+
+`process.chdir()` at app startup was rejected outright, and not on suspicion:
+`src/bun/index.ts` already records that Electrobun resolves `views://` relative to
+`process.cwd()`, so moving the process blanks the desktop window with "Resource not
+found". It was tried before and the reason is written down.
+
+That leaves the host cwd, and the rule for it already exists: decision
+`110-no-chdir-pin-child-cwd` pins every cwd-less child to `DEV3_HOME` in
+`spawn.ts` for exactly this hazard class (a bundle deleted from under a running
+instance). The detached host launchers were the ONE HOLE in it — they call
+`node:child_process.spawn` directly because they need `argv0`, so the wrapper never
+saw them. This change closes that gap rather than inventing a policy.
+
+`spawn.ts` and `src/bun/index.ts` both cited that rule as "decision 109", which is
+three unrelated records; both now cite the slug. Numbers in this repo are reused —
+cite slugs.
+
+## Decision
+
+Two parts, neither of which can be verified by an agent — no agent runs Windows.
+
+1. **`detachedHostCwd()`** (`src/bun/native-terminal-registry/paths.ts`) returns
+   `~/.dev3.0`, and both detached host launchers (`nativeHostLauncher` in
+   `src/bun/native-host-runtime.ts`, `defaultHostLauncher` in
+   `native-terminal-registry/registry.ts`) pass it as `cwd`. It is outside any app
+   bundle, lives as long as dev3 has data, and the on-disk invariants in AGENTS.md
+   forbid moving or deleting it. This removes the condition rather than cleaning up
+   after it, and it kills nothing.
+2. **`scripts/free-build-folder.ts`**, wired as Electrobun's `preBuild` hook. On
+   any non-Windows host it returns before touching anything, so the macOS dev loop
+   is byte-identical. On Windows it **attempts the delete first** — a machine holding
+   nothing never runs a process query at all — and only after that fails does it
+   enumerate, terminate the processes whose **own image** lives inside the build
+   folder, and retry the delete.
+
+Deliberate limits inside the hook:
+
+- **The packaged `cli/dev3.exe` is never killed.** It may be serving a different
+  task; the hook names it (best-effort `CommandLine` for attribution) and fails with
+  a message that leaves the decision to the user.
+- **No `taskkill /T`.** A detached host still records the app as its parent, so `/T`
+  would take out live agent terminals. Every process worth killing matches by image
+  path individually, so the tree flag buys nothing.
+- **`tasklist.exe /FO CSV /NH` for the listing.** A native executable: no WMI
+  service, no PowerShell cold start. A sibling task observed a Windows process
+  enumeration stall for tens of seconds on a CI runner, and its evidence (n=1, one
+  60 s budget) **cannot separate a stalled WMI round-trip from a stalled
+  `powershell.exe` start**, and a later clean run consumed no retries at all, so it
+  did not settle the question either — this avoids both halves rather than claiming
+  immunity from one. `/NH` removes the localized header from the parse.
+- **Bounded ATTEMPTS, not a longer timeout,** and every query logs the milliseconds
+  it cost, so the next stall arrives with evidence. The bounds are `2 × 5 s`
+  (listing) and `2 × 10 s` (paths).
+
+  Sized against the only figures anyone has: on a Windows GitHub runner a WMI
+  process-tree walk measured ~1965 ms mean / 3316 ms worst, and a `tasklist`
+  liveness call 349 ms worst — about 6× cheaper per call (post-merge run
+  `31100808763`, attempt 1). So the 5 s listing bound carries ~14× headroom over
+  measured worst, and the 10 s path bound ~3× over the WMI worst. Two honest caveats:
+  these are **ONE run's figures, not a distribution**, and the path query here is
+  `Get-Process`, not WMI — no measurement of it exists, so the WMI worst is only the
+  closest available proxy.
+- **The retry path is unit-proven and field-unproven.** That run consumed zero
+  retries in production, so nothing here has been exercised by a real stall — and the
+  same run cannot separate a stalled WMI round-trip from a stalled `powershell.exe`
+  start either. That discrimination stays open.
+- **A zero-row parse is a failure, never "nothing is running".** Concluding the
+  latter would report every owned process dead and clear nothing while claiming to.
+- **The narrow path query is the only thing that authorizes a kill.** `tasklist`
+  gives names, not paths, so names only select *candidates* (matched against the
+  `.exe` files this build folder actually contains) and a single `Get-Process -Id
+  <pids>` call confirms the real image path. A single-pid CIM call is used only to
+  attribute a refused CLI to a task, and may fail silently.
+
+**The app process keeps its own cwd inside the build folder, on purpose.** Nothing
+here moves it (see above), so after this change the folder is still pinned while the
+dev app runs — by the app itself, whose image also lives there. That is class one:
+the hook terminates it and prints what it terminated, and the user is rebuilding it
+anyway. What the fix removes is the pin held by processes we must NOT kill.
+
+## Risks
+
+- Nothing here is verified on Windows. macOS proves only the no-op branch and the
+  pure selection logic (17 mutations, red/green each).
+- Terminating the previous dev app is silent-by-intent but printed: the user is
+  rebuilding it anyway.
+- Hosts started **before** this change still carry the old bundle cwd, so the first
+  build after upgrading can still refuse once until those tasks are restarted.
+- A holder that owns a handle without running from the folder (a shell or Explorer
+  window sitting in it, an antivirus scan) cannot be enumerated at all; the hook
+  fails with a message naming that as the cause.
+
+## Alternatives considered
+
+- **Retry the delete without killing** — a live app never releases the folder, so
+  it only fails slower. Kept as the retry loop *after* killing.
+- **Build into a per-run folder** (`build/dev-win-x64-<n>`) — rejected: the layout
+  is assumed by the packaging scripts, the verify proofs, CI artifacts and the
+  updater, and orphan folders would accumulate.
+- **Patch or vendor Electrobun's `rmSync`** (`force` + `maxRetries`) — rejected: a
+  fork to maintain, and it still cannot free a folder a live app is sitting in.
+- **Kill by process name** (`bun.exe`, `dev-3.0.exe`) — rejected outright: that
+  reaches every agent's Bun on the machine. Image path is the only trustworthy
+  ownership signal.
+- **`process.chdir()` at startup** — rejected, see Investigation.
+
+## Related, established but NOT fixed here
+
+The same Windows rule makes a worktree undeletable while any live process sits in
+it, and `git worktree remove --force` runs on task completion. The teardown order
+already guards it: `destroyTaskPty` awaits `destroyNativeTaskSession` (which waits
+for the host tree to be gone) and `killDevServer` runs before `removeWorktree` —
+deliberately, with a comment saying why. What remains is a race (handles released
+just after exit) and any process with a cwd in the worktree outside the host's job
+object; neither is established as occurring, and a failure surfaces loudly as
+`Failed to remove worktree at …` rather than a silent leftover. Reported to the
+coordinator instead of widened into this task.

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -86,6 +86,9 @@ export default {
 		},
 	},
 	scripts: {
+		// preBuild clears the build folder before electrobun's own un-forced,
+		// un-retried rmSync of it, which throws EBUSY on Windows. No-op elsewhere.
+		preBuild: "./scripts/free-build-folder.ts",
 		// postBuild assembles the versioned native host image into the bundle on
 		// every platform, so it ships inside the update archive; postPackage
 		// re-verifies the Windows image from the FINAL archive (no-op elsewhere).

--- a/scripts/free-build-folder.ts
+++ b/scripts/free-build-folder.ts
@@ -1,0 +1,392 @@
+/**
+ * Electrobun `preBuild` hook: make sure the build folder can actually be deleted.
+ *
+ * Electrobun opens every build with `rmSync(buildFolder, { recursive: true })`
+ * (electrobun 1.18.1 `src/cli/index.ts`, immediately after `runHook("preBuild")`)
+ * — no `force`, no retries. On Windows that throws `EBUSY` whenever anything still
+ * holds the folder, and something usually does: `runApp` launches the dev app with
+ * `cwd` set to `build/<prefix>/<app>/bin`, and a live process's current directory
+ * is undeletable on Windows. macOS unlinks a running image happily, so the whole
+ * problem is Windows-only and every other host returns immediately.
+ *
+ * Order of work matters as much as the process query: the delete is attempted
+ * FIRST, so a machine holding nothing never runs a process query at all.
+ * Enumeration happens only after the delete failed and we need to name the holder.
+ * See decisions/217-windows-build-folder-freed-before-electrobun-wipes-it.md.
+ *
+ * What it deliberately does NOT kill: the packaged `cli/dev3.exe` sitting in the
+ * same folder. Agent hooks in OTHER worktrees invoke the CLI by that absolute path
+ * (`resolveDev3CliPath`), and some of those calls block for up to ten minutes
+ * waiting for the user to approve something — killing one turns into an
+ * unexplainable failure in an unrelated task. Those are named and the build stops
+ * so the user decides. Same reason `taskkill /T` is not used: a detached native
+ * terminal host still records the app as its parent, and `/T` would take out live
+ * agent terminals. Every process worth killing is matched by image PATH, never by
+ * process name.
+ */
+
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { win32 } from "node:path";
+
+export interface ProcessRow {
+	pid: number;
+	name: string;
+	/** Full image path, or null when the query could not tell us. */
+	executablePath: string | null;
+}
+
+/** How a process inside the build folder relates to us. */
+export type BuildFolderRole = "app-runtime" | "packaged-cli";
+
+export interface BuildFolderRelease {
+	/** This build's own app image — safe to terminate. */
+	kill: ProcessRow[];
+	/** The packaged CLI: may be serving another task, so the user decides. */
+	refuse: ProcessRow[];
+}
+
+/** Only Windows locks a running image or a live cwd; every other host no-ops. */
+export function shouldFreeBuildFolder(platform: NodeJS.Platform): boolean {
+	return platform === "win32";
+}
+
+/** Lowercased, `/`-normalized, trailing-separator-free — Windows path comparison. */
+function normalizeWindowsPath(path: string): string {
+	const unified = path.replaceAll("/", "\\").toLowerCase();
+	return unified.length > 3 && unified.endsWith("\\") ? unified.slice(0, -1) : unified;
+}
+
+/**
+ * Is `candidate` the directory `parent` or something below it?
+ *
+ * The separator check is what keeps `build\dev-win-x64-old` from matching
+ * `build\dev-win-x64` — a bare prefix test would reach into an unrelated tree.
+ */
+export function isInsideDirectory(parent: string, candidate: string): boolean {
+	const root = normalizeWindowsPath(parent);
+	const path = normalizeWindowsPath(candidate);
+	if (!root || !path) return false;
+	return path === root || path.startsWith(`${root}\\`);
+}
+
+/**
+ * `tasklist /FO CSV /NH` rows → `{ name, pid }`.
+ *
+ * `/NH` is what makes this locale-safe: no column headers to translate, and the
+ * first two fields are the image name and the pid on every Windows build. A row
+ * that is not a quoted name followed by a numeric pid is dropped.
+ */
+export function parseTasklistCsv(stdout: string): ProcessRow[] {
+	const rows: ProcessRow[] = [];
+	for (const line of stdout.split(/\r?\n/)) {
+		const match = /^"([^"]*)","(\d+)"/.exec(line.trim());
+		if (!match) continue;
+		const pid = Number(match[2]);
+		if (!Number.isInteger(pid) || pid <= 0) continue;
+		rows.push({ pid, name: match[1] ?? "", executablePath: null });
+	}
+	return rows;
+}
+
+/** `Get-Process | Select-Object Id,ProcessName,Path | ConvertTo-Json` — one row is not an array. */
+export function parseProcessPaths(json: string): ProcessRow[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return [];
+	}
+	const rows = Array.isArray(parsed) ? parsed : [parsed];
+	const result: ProcessRow[] = [];
+	for (const row of rows) {
+		const entry = row as { Id?: unknown; ProcessName?: unknown; Path?: unknown };
+		const pid = Number(entry.Id);
+		if (!Number.isInteger(pid) || pid <= 0) continue;
+		result.push({
+			pid,
+			name: typeof entry.ProcessName === "string" ? entry.ProcessName : "",
+			executablePath: typeof entry.Path === "string" && entry.Path ? entry.Path : null,
+		});
+	}
+	return result;
+}
+
+/**
+ * Every `.exe` this build folder actually contains, lowercased.
+ *
+ * Derived from our own folder instead of a hardcoded list, so a bundle that starts
+ * shipping another executable is covered without editing this hook.
+ */
+export function bundleExecutableNames(root: string, listDir: (path: string) => string[] = defaultListDir): Set<string> {
+	const names = new Set<string>();
+	const walk = (dir: string, depth: number): void => {
+		if (depth > 8) return;
+		for (const entry of listDir(dir)) {
+			if (entry.toLowerCase().endsWith(".exe")) names.add(entry.toLowerCase());
+			else walk(win32.join(dir, entry), depth + 1);
+		}
+	};
+	walk(root, 0);
+	return names;
+}
+
+function defaultListDir(dir: string): string[] {
+	try {
+		return readdirSync(dir);
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Which running processes are worth asking about, so the expensive path query stays
+ * narrow. A name match NEVER authorizes a kill — `bun.exe` matches half the machine.
+ */
+export function candidateHolders(rows: ProcessRow[], bundleNames: Set<string>, selfPid: number): ProcessRow[] {
+	return rows.filter((row) => {
+		if (row.pid === selfPid || !row.name) return false;
+		const name = row.name.toLowerCase();
+		return bundleNames.has(name.endsWith(".exe") ? name : `${name}.exe`);
+	});
+}
+
+/** The packaged CLI is the one image in the bundle that can be serving someone else. */
+export function buildFolderRole(executablePath: string): BuildFolderRole {
+	return win32.basename(executablePath).toLowerCase() === "dev3.exe" ? "packaged-cli" : "app-runtime";
+}
+
+/**
+ * Split confirmed image paths into ours and not-ours.
+ *
+ * Image path is the only ownership signal worth trusting: a `bun.exe` on PATH
+ * belongs to some agent's session, while `build\…\bin\bun.exe` is this repo's own
+ * dev build.
+ *
+ * `selfPid` is excluded so the hook can never terminate itself, and a process whose
+ * path the query withheld (another user, or it exited meanwhile) is left alone.
+ */
+export function planBuildFolderRelease(rows: ProcessRow[], buildDir: string, selfPid: number): BuildFolderRelease {
+	const release: BuildFolderRelease = { kill: [], refuse: [] };
+	for (const row of rows) {
+		if (row.pid === selfPid || row.executablePath === null) continue;
+		if (!isInsideDirectory(buildDir, row.executablePath)) continue;
+		if (buildFolderRole(row.executablePath) === "packaged-cli") release.refuse.push(row);
+		else release.kill.push(row);
+	}
+	return release;
+}
+
+export interface ProcessListing {
+	rows: ProcessRow[];
+	failure: string | null;
+}
+
+/**
+ * A query that answered but parsed to ZERO processes is a broken query, never
+ * "nothing is running" — treating it as the latter would silently report every
+ * owned process dead and clear nothing while claiming success.
+ */
+export function interpretProcessRows(label: string, rows: ProcessRow[]): ProcessListing {
+	if (rows.length === 0) return { rows: [], failure: `${label} produced output that parsed to zero processes` };
+	return { rows, failure: null };
+}
+
+export function describeHolder(row: ProcessRow, commandLine?: string | null): string {
+	const suffix = commandLine ? ` — command: ${commandLine}` : "";
+	return `${row.name || "?"} (pid ${row.pid}) — ${row.executablePath ?? "unknown path"}${suffix}`;
+}
+
+/**
+ * Refusal message for the packaged CLI. Names the CAUSE (another task's in-flight
+ * `dev3` call lives in this folder) and the FIX (let it finish, or end it), because
+ * killing it is the user's call and not ours.
+ */
+export function refusedPackagedCliMessage(buildDir: string, refused: string[]): string {
+	return [
+		`Refusing to clear the build folder ${buildDir}: a packaged dev3 CLI is running out of it, and it may be serving a DIFFERENT task.`,
+		"Agent hooks in other worktrees invoke this exact path, and some of those calls block for up to ten minutes waiting for your approval in the app — terminating one would fail that task with no visible reason.",
+		`Still running: ${refused.join("; ")}`,
+		"Fix: let that command finish (or approve/cancel whatever it is waiting for, or stop it yourself), then run `bun run dev` again. If you are sure it belongs to nothing you care about, end it in Task Manager and re-run.",
+	].join("\n");
+}
+
+/**
+ * Give-up message after the delete still failed. The cause the user cannot see is a
+ * handle no process list shows — a shell or Explorer window sitting in the folder, a
+ * scanner — so name it, and name the QUERY as the culprit when that is what failed,
+ * pointing at the OS process list rather than at the app.
+ */
+export function stuckBuildFolderMessage(buildDir: string, killed: string[], queryFailure: string | null): string {
+	const context = queryFailure
+		? `The Windows process query did not answer, so no holder could be named and nothing was terminated — that is this machine's OS process list, not the app: ${queryFailure}.`
+		: killed.length
+			? `Terminated this build's own processes first: ${killed.join("; ")}.`
+			: "No process is running an executable from inside that folder, so the handle belongs to something else.";
+	return [
+		`Cannot clear the build folder ${buildDir}: Windows refuses to delete it because a process still holds a file or its current directory inside it.`,
+		context,
+		`Fix: close every dev-3.0 window left over from an earlier run, close any terminal or Explorer window whose current folder is inside ${buildDir}, let an antivirus scan finish, then run \`bun run dev\` again. If it still fails, delete ${buildDir} by hand once and re-run.`,
+	].join("\n");
+}
+
+const SYSTEM_ROOT = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? process.env.WINDIR;
+
+/**
+ * Bounded ATTEMPTS, not one long wait. A sibling task observed a Windows process
+ * enumeration stall for tens of seconds on a CI runner, and its evidence cannot
+ * separate a stalled WMI round-trip from a stalled `powershell.exe` start — so this
+ * hook must never turn EBUSY into a silent hang, and every query records how long it
+ * took so the next stall arrives with evidence. Sized against one measured Windows
+ * runner (tasklist 349ms worst, a WMI tree walk 3316ms worst) — one run, not a
+ * distribution; see the decision record.
+ */
+const QUERY_ATTEMPTS = 2;
+const TASKLIST_TIMEOUT_MS = 5_000;
+const PATH_QUERY_TIMEOUT_MS = 10_000;
+
+function system32(...segments: string[]): string {
+	return SYSTEM_ROOT ? win32.join(SYSTEM_ROOT, "System32", ...segments) : segments[segments.length - 1]!;
+}
+
+interface QueryOutcome {
+	stdout: string | null;
+	/** Why it produced nothing usable, ready to embed in an error message. */
+	failure: string | null;
+}
+
+/** Run a query with bounded attempts, always reporting what each attempt cost. */
+function query(label: string, command: string[], timeoutMs: number): QueryOutcome {
+	const failures: string[] = [];
+	for (let attempt = 1; attempt <= QUERY_ATTEMPTS; attempt++) {
+		const startedAt = Date.now();
+		const result = Bun.spawnSync(command, { stdout: "pipe", stderr: "ignore", env: process.env, timeout: timeoutMs });
+		const elapsedMs = Date.now() - startedAt;
+		const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
+		console.log(`[free-build-folder] ${label} attempt ${attempt}: ${elapsedMs}ms, exit ${result.exitCode ?? "timed out"}`);
+		if (result.exitCode === 0 && stdout.trim()) return { stdout, failure: null };
+		failures.push(
+			result.exitCode === null
+				? `${label} attempt ${attempt} timed out after ${elapsedMs}ms`
+				: `${label} attempt ${attempt} exited ${result.exitCode} after ${elapsedMs}ms`,
+		);
+	}
+	return { stdout: null, failure: failures.join("; ") };
+}
+
+/**
+ * `tasklist` rather than PowerShell: a native executable, no WMI service, no
+ * PowerShell cold start — the two halves of the observed stall that nobody could
+ * separate.
+ */
+function runningProcesses(): ProcessListing {
+	const outcome = query("tasklist", [system32("tasklist.exe"), "/FO", "CSV", "/NH"], TASKLIST_TIMEOUT_MS);
+	if (outcome.stdout === null) return { rows: [], failure: outcome.failure };
+	return interpretProcessRows("tasklist", parseTasklistCsv(outcome.stdout));
+}
+
+/** Confirm real image paths for a narrow pid list — the only thing that authorizes a kill. */
+function imagePathsOf(pids: number[]): ProcessListing {
+	const outcome = query(
+		"image paths",
+		[
+			system32("WindowsPowerShell", "v1.0", "powershell.exe"),
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			`Get-Process -Id ${pids.join(",")} -ErrorAction SilentlyContinue | Select-Object Id,ProcessName,Path | ConvertTo-Json -Compress -Depth 3`,
+		],
+		PATH_QUERY_TIMEOUT_MS,
+	);
+	if (outcome.stdout === null) return { rows: [], failure: outcome.failure };
+	return interpretProcessRows("the image-path query", parseProcessPaths(outcome.stdout));
+}
+
+/** Best-effort attribution of a refused CLI to a task; failure is fine. */
+function commandLineOf(pid: number): string | null {
+	const outcome = query(
+		`command line of ${pid}`,
+		[
+			system32("WindowsPowerShell", "v1.0", "powershell.exe"),
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			`(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction SilentlyContinue).CommandLine`,
+		],
+		PATH_QUERY_TIMEOUT_MS,
+	);
+	const line = outcome.stdout?.trim();
+	return line ? line.slice(0, 300) : null;
+}
+
+function terminate(pid: number): void {
+	Bun.spawnSync([system32("taskkill.exe"), "/PID", String(pid), "/F"], {
+		stdout: "ignore",
+		stderr: "ignore",
+		env: process.env,
+	});
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((done) => setTimeout(done, ms));
+}
+
+/** True when the folder is gone. The retries absorb a handle closing a moment late. */
+function tryRemove(buildDir: string): boolean {
+	try {
+		rmSync(buildDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function main(): Promise<void> {
+	if (!shouldFreeBuildFolder(process.platform)) return;
+
+	const buildDir = process.env.ELECTROBUN_BUILD_DIR;
+	if (!buildDir) {
+		console.warn("[free-build-folder] ELECTROBUN_BUILD_DIR is unset — leaving the build folder to electrobun");
+		return;
+	}
+	if (!existsSync(buildDir)) return;
+
+	// Delete first: on a machine holding nothing, no process query runs at all.
+	if (tryRemove(buildDir)) {
+		console.log(`[free-build-folder] cleared ${buildDir}`);
+		return;
+	}
+
+	const listing = runningProcesses();
+	const candidates = candidateHolders(listing.rows, bundleExecutableNames(buildDir), process.pid);
+	const confirmed = candidates.length ? imagePathsOf(candidates.map((row) => row.pid)) : { rows: [], failure: null };
+	const queryFailure = listing.failure ?? confirmed.failure;
+	const release = planBuildFolderRelease(confirmed.rows, buildDir, process.pid);
+
+	if (release.refuse.length) {
+		throw new Error(
+			refusedPackagedCliMessage(
+				buildDir,
+				release.refuse.map((row) => describeHolder(row, commandLineOf(row.pid))),
+			),
+		);
+	}
+
+	const killed = release.kill.map((row) => describeHolder(row));
+	for (const holder of release.kill) {
+		console.log(`[free-build-folder] terminating ${describeHolder(holder)}`);
+		terminate(holder.pid);
+	}
+	// `/F` returns before the kernel has torn the process down; without this the
+	// delete races the closing handles.
+	if (release.kill.length) await sleep(500);
+
+	if (!tryRemove(buildDir)) throw new Error(stuckBuildFolderMessage(buildDir, killed, queryFailure));
+	console.log(`[free-build-folder] cleared ${buildDir}`);
+}
+
+if (import.meta.main) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/scripts/free-build-folder.ts
+++ b/scripts/free-build-folder.ts
@@ -75,6 +75,13 @@ export function isInsideDirectory(parent: string, candidate: string): boolean {
  * `/NH` is what makes this locale-safe: no column headers to translate, and the
  * first two fields are the image name and the pid on every Windows build. A row
  * that is not a quoted name followed by a numeric pid is dropped.
+ *
+ * `scripts/verify-windows-app-launch.ts` (`parseTasklistPids`) parses the same output
+ * separately, and the split is DELIBERATE: same lesson (locale-safe CSV, and a
+ * zero-row parse is a failure, never an empty machine), different contracts (it wants
+ * pids only and keeps pid 0; this wants name+pid pairs and drops pid 0) and different
+ * blast radius (a CI proof of a packaged app there; this developer-machine hook here).
+ * Do not merge them into one helper with a flag.
  */
 export function parseTasklistCsv(stdout: string): ProcessRow[] {
 	const rows: ProcessRow[] = [];

--- a/scripts/verify-windows-app-launch.ts
+++ b/scripts/verify-windows-app-launch.ts
@@ -263,6 +263,14 @@ export function runProcessQuery(
  * translates its column headers on a localized Windows, so a parser reading the English
  * header form matches nothing on a German or Russian machine — and "matched nothing"
  * here would read as "no process is alive".
+ *
+ * `scripts/free-build-folder.ts` parses the same output with its own regex, and that
+ * is DELIBERATE, not an oversight to tidy away: same lesson (locale-safe CSV, throw
+ * rather than read zero rows as an empty machine), different contracts (pids only and
+ * pid 0 kept here; name+pid pairs and pid 0 dropped there) and different blast radius
+ * (a CI proof of a packaged app here; a developer's pre-build hook there). A shared
+ * helper would need a flag to serve both, and a change made for one would break the
+ * other on a Windows surface nobody can watch.
  */
 export function parseTasklistPids(output: string): number[] {
 	const pids: number[] = [];

--- a/src/bun/__tests__/electrobun-config.test.ts
+++ b/src/bun/__tests__/electrobun-config.test.ts
@@ -24,7 +24,12 @@ describe("electrobun packaged Bun runtime", () => {
 	it("pins the global app runtime at or above the ConPTY floor and packages a native host on every platform", () => {
 		expect(config.build).toHaveProperty("bunVersion");
 		expect(assertPackagedConptyRuntime(config.build.bunVersion)).toBe(config.build.bunVersion);
-		expect(config.scripts).not.toHaveProperty("preBuild");
+		// This used to assert preBuild was ABSENT. The invariant it protected is that
+		// host packaging and its proof stay in postBuild/postPackage — so preBuild is
+		// pinned to the one thing it may do: clearing the build folder before
+		// electrobun's own un-retried wipe of it (Windows EBUSY, decision
+		// 217-windows-build-folder-freed-before-electrobun-wipes-it).
+		expect(config.scripts.preBuild).toBe("./scripts/free-build-folder.ts");
 		expect(config.scripts.postBuild).toBe("./scripts/package-native-host.ts");
 		expect(config.build.copy["dist/native"]).toBe("native");
 	});

--- a/src/bun/__tests__/windows-build-orchestration.test.ts
+++ b/src/bun/__tests__/windows-build-orchestration.test.ts
@@ -15,6 +15,18 @@ import {
 	selectDesktopExecutable,
 	selectWindowsArchive,
 } from "../../../scripts/verify-windows-app-launch";
+import {
+	bundleExecutableNames,
+	candidateHolders,
+	interpretProcessRows,
+	isInsideDirectory,
+	parseProcessPaths,
+	parseTasklistCsv,
+	planBuildFolderRelease,
+	refusedPackagedCliMessage,
+	shouldFreeBuildFolder,
+	stuckBuildFolderMessage,
+} from "../../../scripts/free-build-folder";
 import { buildAppReadyMarker, writeAppReadyMarker } from "../app-ready-marker";
 
 describe("packaged CLI binary naming", () => {
@@ -265,3 +277,116 @@ function fakeClock(instants: number[]): () => number {
 	let index = 0;
 	return () => instants[Math.min(index++, instants.length - 1)] ?? 0;
 }
+
+describe("freeing the build folder before electrobun wipes it", () => {
+	const BUILD_DIR = "D:\\src\\dev-3.0\\build\\dev-win-x64";
+
+	it("runs on Windows only — every other host leaves electrobun's own wipe alone", () => {
+		expect(shouldFreeBuildFolder("win32")).toBe(true);
+		expect(shouldFreeBuildFolder("darwin")).toBe(false);
+		expect(shouldFreeBuildFolder("linux")).toBe(false);
+	});
+
+	it("matches the folder and its contents, case- and separator-insensitively", () => {
+		expect(isInsideDirectory(BUILD_DIR, BUILD_DIR)).toBe(true);
+		expect(isInsideDirectory(BUILD_DIR, `${BUILD_DIR}\\dev-3.0\\bin\\launcher.exe`)).toBe(true);
+		expect(isInsideDirectory(BUILD_DIR, "d:/src/dev-3.0/build/dev-win-x64/dev-3.0/bin/bun.exe")).toBe(true);
+		expect(isInsideDirectory(`${BUILD_DIR}\\`, `${BUILD_DIR}\\bin\\bun.exe`)).toBe(true);
+	});
+
+	it("does not reach into a neighbouring folder that merely shares the prefix", () => {
+		expect(isInsideDirectory(BUILD_DIR, `${BUILD_DIR}-old\\bin\\launcher.exe`)).toBe(false);
+		expect(isInsideDirectory(BUILD_DIR, "D:\\src\\dev-3.0\\build\\dev-win-arm64\\bin\\bun.exe")).toBe(false);
+		expect(isInsideDirectory("", "D:\\anything")).toBe(false);
+	});
+
+	it("reads tasklist CSV without depending on a localized header", () => {
+		expect(parseTasklistCsv('"launcher.exe","1234","Console","1","52,000 K"\r\n"bun.exe","5678","Console","1","9 K"\r\n')).toEqual([
+			{ pid: 1234, name: "launcher.exe", executablePath: null },
+			{ pid: 5678, name: "bun.exe", executablePath: null },
+		]);
+		expect(parseTasklistCsv("INFO: No tasks are running which match the specified criteria.")).toEqual([]);
+		// Real tasklist output opens with pid 0, which is not a killable process.
+		expect(parseTasklistCsv('"System Idle Process","0","Services","0","8 K"')).toEqual([]);
+		// Only a row that STARTS with the name/pid pair counts — a quoted pair inside
+		// any other text (a window title, a translated notice) is not a process.
+		expect(parseTasklistCsv('NOTE: nothing here "evil.exe","666" still nothing')).toEqual([]);
+	});
+
+	it("reads the narrow image-path query, including the single-row object form", () => {
+		expect(
+			parseProcessPaths('[{"Id":100,"ProcessName":"launcher","Path":"C:\\\\a\\\\launcher.exe"},{"Id":0,"ProcessName":"idle","Path":null}]'),
+		).toEqual([{ pid: 100, name: "launcher", executablePath: "C:\\a\\launcher.exe" }]);
+		expect(parseProcessPaths('{"Id":7,"ProcessName":"bun","Path":null}')).toEqual([
+			{ pid: 7, name: "bun", executablePath: null },
+		]);
+		expect(parseProcessPaths("not json")).toEqual([]);
+	});
+
+	it("treats a zero-row parse as a broken query, not as an empty machine", () => {
+		const empty = interpretProcessRows("tasklist", []);
+		expect(empty.rows).toEqual([]);
+		expect(empty.failure).toBe("tasklist produced output that parsed to zero processes");
+		expect(interpretProcessRows("tasklist", [{ pid: 1, name: "a.exe", executablePath: null }]).failure).toBeNull();
+	});
+
+	it("derives the candidate names from the bundle on disk, not a hardcoded list", () => {
+		const tree: Record<string, string[]> = {
+			[BUILD_DIR]: ["dev-3.0"],
+			[`${BUILD_DIR}\\dev-3.0`]: ["bin", "Resources"],
+			[`${BUILD_DIR}\\dev-3.0\\bin`]: ["launcher.exe", "bun.exe", "build.json"],
+			[`${BUILD_DIR}\\dev-3.0\\Resources`]: ["dev3.exe"],
+		};
+		expect(bundleExecutableNames(BUILD_DIR, (dir) => tree[dir] ?? [])).toEqual(
+			new Set(["launcher.exe", "bun.exe", "dev3.exe"]),
+		);
+	});
+
+	it("asks the expensive path query only about names the bundle ships, and never about itself", () => {
+		const rows = parseTasklistCsv(
+			'"launcher.exe","100","Console","1","1 K"\r\n"chrome.exe","200","Console","1","1 K"\r\n"bun.exe","300","Console","1","1 K"',
+		);
+		expect(candidateHolders(rows, new Set(["launcher.exe", "bun.exe"]), 300).map((row) => row.pid)).toEqual([100]);
+	});
+
+	it("kills this build's own app image and refuses the packaged CLI another task may be using", () => {
+		const rows = [
+			{ pid: 100, name: "launcher", executablePath: `${BUILD_DIR}\\dev-3.0\\bin\\launcher.exe` },
+			{ pid: 200, name: "bun", executablePath: `${BUILD_DIR}\\dev-3.0\\bin\\bun.exe` },
+			{ pid: 300, name: "dev3", executablePath: `${BUILD_DIR}\\dev-3.0\\Resources\\app\\cli\\dev3.exe` },
+			{ pid: 400, name: "bun", executablePath: "C:\\Users\\dev\\.bun\\bin\\bun.exe" },
+			{ pid: 500, name: "System", executablePath: null },
+			{ pid: 600, name: "self", executablePath: `${BUILD_DIR}\\dev-3.0\\bin\\bun.exe` },
+		];
+		const release = planBuildFolderRelease(rows, BUILD_DIR, 600);
+		expect(release.kill.map((row) => row.pid)).toEqual([100, 200]);
+		expect(release.refuse.map((row) => row.pid)).toEqual([300]);
+	});
+
+	it("names the other task's CLI as the cause and leaves the decision to the user", () => {
+		const message = refusedPackagedCliMessage(BUILD_DIR, ["dev3 (pid 300) — command: dev3 task move"]);
+		expect(message).toContain(BUILD_DIR);
+		expect(message).toContain("DIFFERENT task");
+		expect(message).toContain("ten minutes");
+		expect(message).toContain("pid 300");
+		expect(message).toContain("Fix:");
+	});
+
+	it("names an invisible handle as the cause and the windows to close as the fix", () => {
+		const killed = stuckBuildFolderMessage(BUILD_DIR, ["launcher (pid 100) — path"], null);
+		expect(killed).toContain("Terminated this build's own processes first");
+		expect(killed).toContain("Fix: close every dev-3.0 window");
+
+		const nothingFound = stuckBuildFolderMessage(BUILD_DIR, [], null);
+		expect(nothingFound).toContain("the handle belongs to something else");
+
+		const blind = stuckBuildFolderMessage(BUILD_DIR, [], "tasklist attempt 2 timed out after 5001ms");
+		expect(blind).toContain("this machine's OS process list, not the app");
+		expect(blind).toContain("nothing was terminated");
+		expect(blind).toContain("timed out after 5001ms");
+		for (const message of [killed, nothingFound, blind]) {
+			expect(message).toContain("Windows refuses to delete it");
+			expect(message).toContain("Fix:");
+		}
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -103,7 +103,7 @@ log.info("Log files", { dir: getLogPath() });
 // The brew-upgrade/in-app-update ENOENT hazard it was meant to fix — a child
 // inheriting a since-deleted bundle cwd — is instead handled in spawn.ts, which
 // pins cwd-less children to DEV3_HOME without ever moving the process. See
-// decision 109.
+// decisions/110-no-chdir-pin-child-cwd.md.
 
 // ── CLI binary + agent skills + shell PATH (FIRST — before any async work) ──
 // These must run before resolveShellEnv() because existing tmux sessions

--- a/src/bun/native-host-runtime.ts
+++ b/src/bun/native-host-runtime.ts
@@ -27,7 +27,7 @@ import { fileURLToPath } from "node:url";
 import { spawn as spawnChild } from "node:child_process";
 import { createLogger } from "./logger";
 import { NATIVE_SESSION_PROTOCOL_VERSION } from "./native-terminal-registry/protocol";
-import { hostImagesRootDir } from "./native-terminal-registry/paths";
+import { detachedHostCwd, hostImagesRootDir } from "./native-terminal-registry/paths";
 import {
 	discoverPackagedImage,
 	stagePackagedImage,
@@ -237,6 +237,10 @@ export function nativeHostLauncher(runtime: NativeHostRuntime): HostLauncher {
 				argv0: nativeHostProcessName(sessionId, opts.launch.env),
 				stdio: ["ignore", logFd, logFd],
 				detached: true,
+				// Never inherit the app's cwd: this child outlives it, and on Windows a
+				// live cwd is undeletable — which is what made `bun run dev` fail to wipe
+				// its own build folder. See detachedHostCwd().
+				cwd: detachedHostCwd(),
 				env: {
 					...process.env,
 					DEV3_NATIVE_SESSION_ID: sessionId,

--- a/src/bun/native-terminal-registry/__tests__/host-launcher-naming.test.ts
+++ b/src/bun/native-terminal-registry/__tests__/host-launcher-naming.test.ts
@@ -24,6 +24,7 @@ const { defaultHostLauncher } = await import("../registry");
 const { nativeHostLauncher } = await import("../../native-host-runtime");
 const { TASK_SEQ_ENV } = await import("../process-naming");
 const { defineShellLaunchSpec } = await import("../shell-launch");
+const { detachedHostCwd } = await import("../paths");
 
 const SESSION_ID = "dev3-task-11111111-2222-3333-4444-555555555555-pane-2";
 
@@ -79,6 +80,21 @@ describe("host launcher process naming", () => {
 		expect(options.detached).toBe(true);
 		expect(options.env.DEV3_NATIVE_SESSION_ID).toBe(SESSION_ID);
 		expect(options.env.DEV3_NATIVE_SESSION_COLS).toBe("100");
+	});
+
+	/**
+	 * A detached host outlives the app, so inheriting the app's cwd pins that
+	 * directory: on Windows that made `bun run dev` unable to wipe its own build
+	 * folder, and the app's cwd IS inside that folder.
+	 */
+	it("never inherits the app's cwd — both launchers pin the host outside any bundle", () => {
+		nativeHostLauncher(RUNTIME)(SESSION_ID, { launch: launchSpec({}) }, 1);
+		defaultHostLauncher(SESSION_ID, { launch: launchSpec({}) }, 1);
+		expect(spawnCalls).toHaveLength(2);
+		for (const call of spawnCalls) {
+			expect(call.options.cwd).toBe(detachedHostCwd());
+			expect(String(call.options.cwd)).not.toContain("/build/");
+		}
 	});
 
 	it("falls back to the session id when the task number is absent", () => {

--- a/src/bun/native-terminal-registry/paths.ts
+++ b/src/bun/native-terminal-registry/paths.ts
@@ -63,6 +63,26 @@ export function hostImagesRootDir(): string {
 	return join(dev3HomeDir(), "native-host-images");
 }
 
+/**
+ * Working directory for a detached host process.
+ *
+ * A detached host outlives the app that spawned it (that is the point — decision
+ * 169), so it must not inherit the app's cwd: on Windows a live process's current
+ * directory cannot be deleted, and the app's cwd is inside its own bundle, which
+ * `bun run dev` wipes on every build. `~/.dev3.0` satisfies all three
+ * requirements — outside any app bundle, alive as long as dev3 has data at all,
+ * and protected from being moved or deleted underneath us by the on-disk
+ * invariants in AGENTS.md. Same destination `spawn.ts` already pins cwd-less
+ * children to (decision `110-no-chdir-pin-child-cwd`); this is the one spawn that
+ * bypasses that wrapper, because it needs `argv0`.
+ *
+ * No mkdir: the registry has already written this session's own directory under
+ * `~/.dev3.0` before any launcher runs.
+ */
+export function detachedHostCwd(): string {
+	return dev3HomeDir();
+}
+
 // Stable session ids are chosen by launchers, so they must map to a safe single
 // directory segment — no path separators, no traversal, no leading dot.
 const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;

--- a/src/bun/native-terminal-registry/registry.ts
+++ b/src/bun/native-terminal-registry/registry.ts
@@ -30,7 +30,7 @@ import { withFileLock } from "../file-lock";
 import { whichSync } from "../which";
 import { NativeSessionClient } from "./client";
 import { classifyOwnership, type OwnershipVerdict } from "./ownership";
-import { isValidSessionId, logFile, recordFile, sessionDir, sessionsRootDir } from "./paths";
+import { detachedHostCwd, isValidSessionId, logFile, recordFile, sessionDir, sessionsRootDir } from "./paths";
 import { isProcessAlive } from "./process-identity";
 import { nativeHostProcessName } from "./process-naming";
 import { inspectRecordFile, readRecord, readToken, removeSessionState, type NativeSessionRecord } from "./record";
@@ -162,6 +162,9 @@ export function defaultHostLauncher(sessionId: string, opts: HostSpawnOptions, l
 		argv0: nativeHostProcessName(sessionId, opts.launch.env),
 		stdio: ["ignore", logFd, logFd],
 		detached: true,
+		// Never inherit the app's cwd: this child outlives it, and on Windows a live
+		// cwd is undeletable. See detachedHostCwd().
+		cwd: detachedHostCwd(),
 		env: {
 			...process.env,
 			DEV3_NATIVE_SESSION_ID: sessionId,

--- a/src/bun/spawn.ts
+++ b/src/bun/spawn.ts
@@ -17,7 +17,8 @@
  * dir from under a running instance, after which any child that inherits our
  * bundle cwd dies with ENOENT (posix_spawn resolves the child cwd from ours).
  * Pinning cwd-less children to DEV3_HOME — which lives as long as our data does —
- * sidesteps that without ever moving the process. See decision 109.
+ * sidesteps that without ever moving the process.
+ * See decisions/110-no-chdir-pin-child-cwd.md.
  *
  * RULE: Never use Bun.spawn / Bun.spawnSync directly — always use these.
  */


### PR DESCRIPTION
`bun run dev` could not start on Windows: Electrobun opens every build with an un-forced, un-retried `rmSync` of its build folder, and Windows refuses to delete a directory that holds a running image or is some live process's current directory.

Two changes:

- **Detached native terminal hosts no longer inherit the app's cwd.** New `detachedHostCwd()` (`~/.dev3.0`) is passed by both host launchers. They are detached on purpose so they outlive the app, and the app's cwd is inside the bundle `bun run dev` wipes — so every live task terminal was pinning the build folder from a process we must not kill. This closes the one hole in `decisions/110-no-chdir-pin-child-cwd.md`, which already pins cwd-less children to `DEV3_HOME` in `spawn.ts`; the host launchers bypass that wrapper because they need `argv0`.
- **`scripts/free-build-folder.ts`, wired as Electrobun's `preBuild` hook.** No-op on every non-Windows host. On Windows it attempts the delete first — a machine holding nothing runs no process query at all — and only on failure enumerates (`tasklist /FO CSV /NH`, then one narrow `Get-Process` for real image paths), terminates only processes whose own image lives inside the build folder, and retries. It never kills the packaged `cli/dev3.exe`: that may be serving another task, so it is named and the build stops for the user to decide. No `taskkill /T`, because a detached host still records the app as its parent.

Also corrected two stale decision references I did not create (`spawn.ts`, `src/bun/index.ts` cited "decision 109", which is three unrelated records) — the rule being miscited is the one this change extends. Cited by slug so a renumber cannot break it again.

**Not verified on Windows** — no agent has a Windows machine, and this defect only exists there. What is verified on macOS: the no-op branch, 17 red/green mutations on the hook's pure logic, one per launcher `cwd`, one on the config wiring, and a real `electrobun build` proving the hook runs and the macOS dev loop is unregressed.

Record: `decisions/217-windows-build-folder-freed-before-electrobun-wipes-it.md`.