### PR TITLE
Fix clipboard image paste on Windows

### DIFF
--- a/change-logs/2026/08/06/fix-windows-clipboard-image-paste.md
+++ b/change-logs/2026/08/06/fix-windows-clipboard-image-paste.md
@@ -1,0 +1,3 @@
+Short: Pasting an image works on Windows
+
+Pasting an image now takes the picture from the paste event itself instead of re-reading the host clipboard, which on Windows returned raw bitmap bytes that were saved as a broken `.png`; the host-clipboard fallback converts those bytes to real PNG. Image thumbnails, "open image", "open folder", and `dev3 show-image` also stop rejecting Windows paths like `C:/Users/...`. A paste that still fails now shows an error instead of doing nothing. On macOS the paste path changed too — the pasted image is uploaded from the event rather than through the clipboard RPC.

--- a/decisions/216-clipboard-image-dib-to-png.md
+++ b/decisions/216-clipboard-image-dib-to-png.md
@@ -1,0 +1,38 @@
+# 216 — Convert Windows clipboard DIB bytes to PNG ourselves
+
+## Context
+
+Pasting a screenshot on Windows produced nothing usable. Two independent causes sat behind one symptom, both inside "read the host clipboard from the bun process":
+
+- `electrobun 1.18.1`, `package/src/native/win/nativeWrapper.cpp` → `clipboardReadImage()` returns **raw CF_DIB bytes** and carries the comment `TODO: Implement proper PNG conversion using GDI+ or similar`. macOS (`nativeWrapper.mm`) returns real PNG via `NSPasteboard`. We wrote those DIB bytes into a file named `.png` — a corrupt file.
+- The same version calls `OpenClipboard(nullptr)` with no retry loop (upstream `main` has one), so a clipboard held open by another process yields no formats and `pasteClipboardImage` returns `null` with no user-visible trace.
+
+## Investigation
+
+Verified against the pinned version, not upstream `main`: `raw.githubusercontent.com/blackboardsh/electrobun/v1.18.1/package/src/native/win/nativeWrapper.cpp`. No agent can run Windows, so the fix had to be provable by tests on macOS.
+
+Also established what consumes the pasted path: the agent on the other end of the prompt. The Claude API accepts only JPEG, PNG, GIF, and WebP (`platform.claude.com/docs/en/build-with-claude/vision` → "Supported formats"). So wrapping the DIB in a 14-byte `BITMAPFILEHEADER` and saving `.bmp` was rejected — it would produce a file that exists, opens in a viewer, and is unreadable exactly where it is used.
+
+## Decision
+
+Two layers, in this order:
+
+1. **Prefer the paste event's own files.** `imageFilesFromClipboard` (`src/mainview/utils/clipboardImageFiles.ts`) reads `clipboardData.files`, falling back to `items[i].getAsFile()`. The webview has already decoded the clipboard bitmap into real PNG bytes, and in remote mode it is the user's own device rather than the app host. `TerminalView`'s paste interceptor now uses this first; `useClipboardPaste` already did something similar.
+2. **Convert what the host clipboard gives us.** `clipboardImageToPng` (`src/bun/clipboard-image.ts`) passes PNG through, strips a `BITMAPFILEHEADER` off a whole BMP, and converts a 24/32-bit uncompressed DIB to PNG (BGR→RGB, bottom-up un-flip, `deflateSync` + hand-written IHDR/IDAT/IEND and CRC32). Anything else is refused rather than saved as a broken `.png`. `pasteClipboardImage` calls it before `saveUploadedFile`.
+
+A failed paste now raises `toast.error(t("imagePaste.failed"))` instead of only `console.error`.
+
+**Deletion condition:** layer 2 exists solely because of that upstream TODO. When electrobun's Windows `clipboardReadImage` returns PNG (and its `openClipboardWithRetry` reaches a release we depend on), delete `src/bun/clipboard-image.ts` and its test, and let the bytes go straight to `saveUploadedFile`. Layer 1 stays regardless — it is the correct source on every platform.
+
+## Risks
+
+- The converter covers 24/32-bit `BI_RGB`/`BI_BITFIELDS` only. A palette (≤8-bit) or RLE-compressed DIB is refused with a toast, not converted. Screenshots are 32-bit, so this is the tail.
+- 32-bit `BI_RGB` leaves the 4th byte undefined; we force alpha opaque unless a V4/V5 header declares a non-zero alpha mask. A source that writes meaningful alpha into a 40-byte header would lose it — the alternative (trusting the byte) produces a fully transparent image, which is worse.
+- **Not verified on Windows by any agent.** All assertions are mutation-proved on macOS (22 mutations, all caught); the Windows behaviour is reasoned from the pinned upstream source.
+- The PNG encoder is hand-written, so its output was decoded by three implementations that share no code with it: Chromium's decoder via `canvas.getImageData` (returned the four expected pixel colours), Apple ImageIO via `sips` (2x2, 8-bit, 4 samples per pixel), and Python `zlib` (chunk CRCs + inflated scanlines). The test suite keeps the CRC half of that permanently: `decodePng` in the test checks every chunk against `crc32` from `node:zlib` rather than our own table.
+
+## Alternatives considered
+
+- **Wrap the DIB as BMP and save `.bmp`** — valid file, unreadable by the consumer (see Investigation). Rejected.
+- **Only prefer the paste event's files, leave the RPC alone** — leaves a fallback that still writes corrupt `.png` files whenever it is reached. Rejected.
+- **Patch electrobun / bump the dependency** — the fix is not in a release we can pin, and a bump drags unrelated native changes into a Windows port that is still stabilising.

--- a/src/bun/__tests__/absolute-path.test.ts
+++ b/src/bun/__tests__/absolute-path.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { isFullyQualifiedPath } from "../../shared/absolute-path";
+
+// The guard is a shape check, not a sandbox: it decides whether a caller handed
+// us a fully-qualified path. Its value lives in what it REFUSES, so the
+// rejection cases carry the same weight as the acceptances.
+describe("isFullyQualifiedPath", () => {
+	it("accepts a POSIX absolute path on macOS/Linux", () => {
+		expect(
+			isFullyQualifiedPath("/Users/me/.dev3.0/worktrees/p/uploads/a.png", "darwin"),
+			"cause: POSIX absolute paths rejected on darwin. fix: keep the leading-slash branch in isFullyQualifiedPath",
+		).toBe(true);
+	});
+
+	it("accepts a drive-qualified Windows path with either separator", () => {
+		// The whole reason this helper exists: an uploaded path on Windows is
+		// "C:/Users/...", which a POSIX-only startsWith("/") check rejected, so the
+		// New Task thumbnail rendered "Load failed".
+		expect(
+			isFullyQualifiedPath("C:/Users/user/.dev3.0/uploads/a.png", "win32"),
+			"cause: forward-slash Windows path rejected. fix: accept /^[A-Za-z]:[\\\\/]/ in isFullyQualifiedPath",
+		).toBe(true);
+		expect(
+			isFullyQualifiedPath("C:\\Users\\user\\uploads\\a.png", "win32"),
+			"cause: backslash Windows path rejected. fix: accept /^[A-Za-z]:[\\\\/]/ in isFullyQualifiedPath",
+		).toBe(true);
+	});
+
+	it("accepts a UNC share path on Windows", () => {
+		expect(
+			isFullyQualifiedPath("\\\\fileserver\\share\\a.png", "win32"),
+			"cause: UNC path rejected. fix: accept /^\\\\\\\\[^\\\\/]/ in isFullyQualifiedPath",
+		).toBe(true);
+	});
+
+	it("rejects a drive-RELATIVE Windows path that only looks absolute", () => {
+		// "C:foo" resolves against the process's per-drive cwd — fully qualified it
+		// is not, and it is the one Windows shape that fools a naive check.
+		expect(
+			isFullyQualifiedPath("C:foo\\a.png", "win32"),
+			"cause: drive-relative C:foo accepted as fully qualified. fix: require a separator after the colon",
+		).toBe(false);
+		expect(
+			isFullyQualifiedPath("C:", "win32"),
+			"cause: bare drive letter accepted. fix: require a separator after the colon",
+		).toBe(false);
+	});
+
+	it("rejects Windows shapes when the platform is not win32", () => {
+		expect(
+			isFullyQualifiedPath("C:/Users/me/a.png", "darwin"),
+			"cause: Windows path accepted on darwin, where it is a relative name. fix: gate the Windows branches on platform === win32",
+		).toBe(false);
+	});
+
+	it("rejects relative paths, empty input, and anything containing ..", () => {
+		expect(
+			isFullyQualifiedPath("uploads/a.png", "darwin"),
+			"cause: relative path accepted. fix: return false unless the path is rooted",
+		).toBe(false);
+		expect(
+			isFullyQualifiedPath("", "darwin"),
+			"cause: empty path accepted. fix: guard the empty string first",
+		).toBe(false);
+		expect(
+			isFullyQualifiedPath("/Users/me/../../etc/passwd", "darwin"),
+			'cause: ".." traversal accepted. fix: keep the path.includes("..") rejection',
+		).toBe(false);
+		expect(
+			isFullyQualifiedPath("C:\\Users\\me\\..\\..\\Windows\\x", "win32"),
+			'cause: ".." traversal accepted on Windows. fix: check for ".." before the platform branches',
+		).toBe(false);
+		expect(
+			isFullyQualifiedPath("\\Users\\me\\a.png", "win32"),
+			"cause: root-relative \\path accepted; on Windows it is drive-relative. fix: do not treat a single leading backslash as qualified",
+		).toBe(false);
+	});
+});

--- a/src/bun/__tests__/clipboard-image.test.ts
+++ b/src/bun/__tests__/clipboard-image.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { crc32, inflateSync } from "node:zlib";
+import { clipboardImageToPng } from "../clipboard-image";
+
+/**
+ * A DIB exactly as Windows puts one on the clipboard: BITMAPINFOHEADER, then
+ * 4-byte-aligned BGR(A) rows, bottom-up unless the height is negative.
+ */
+function buildDib(opts: {
+	width: number;
+	height: number; // negative = top-down
+	bitCount: 24 | 32 | 8;
+	rows: number[][]; // file order, raw bytes per row (before padding)
+	headerSize?: number;
+	alphaMask?: number;
+	truncate?: number; // drop this many bytes off the end
+}): Uint8Array {
+	const headerSize = opts.headerSize ?? 40;
+	const bytesPerPixel = opts.bitCount / 8;
+	const stride = (opts.width * bytesPerPixel + 3) & ~3;
+	const rowCount = Math.abs(opts.height);
+	// A <=8-bit DIB carries a full colour table between header and pixels; include
+	// it so such a DIB is refused for its bit depth, not for being too short.
+	const paletteBytes = opts.bitCount <= 8 ? 256 * 4 : 0;
+	const buf = new Uint8Array(headerSize + paletteBytes + stride * rowCount);
+	const view = new DataView(buf.buffer);
+	view.setUint32(0, headerSize, true);
+	view.setInt32(4, opts.width, true);
+	view.setInt32(8, opts.height, true);
+	view.setUint16(12, 1, true); // planes
+	view.setUint16(14, opts.bitCount, true);
+	view.setUint32(16, 0, true); // BI_RGB
+	if (opts.alphaMask !== undefined) view.setUint32(52, opts.alphaMask, true);
+	opts.rows.forEach((row, i) => buf.set(row, headerSize + paletteBytes + i * stride));
+	return opts.truncate ? buf.subarray(0, buf.length - opts.truncate) : buf;
+}
+
+/** Minimal PNG reader — enough to assert dimensions and actual pixels. */
+function decodePng(png: Uint8Array): { width: number; height: number; colorType: number; pixels: number[][] } {
+	const magic = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	expect(
+		Array.from(png.subarray(0, 8)),
+		"cause: output is not a PNG file. fix: encodePng must emit the 8-byte PNG signature first",
+	).toEqual(magic);
+
+	const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+	let at = 8;
+	let width = 0;
+	let height = 0;
+	let colorType = 0;
+	const idat: Uint8Array[] = [];
+	while (at < png.length) {
+		const len = view.getUint32(at);
+		const type = String.fromCharCode(...png.subarray(at + 4, at + 8));
+		const data = png.subarray(at + 8, at + 8 + len);
+		if (type === "IHDR") {
+			const d = new DataView(data.buffer, data.byteOffset, data.byteLength);
+			width = d.getUint32(0);
+			height = d.getUint32(4);
+			expect(data[8], "cause: PNG bit depth is not 8. fix: write 8 into IHDR byte 8").toBe(8);
+			colorType = data[9]!;
+		}
+		if (type === "IDAT") idat.push(data);
+		// zlib's own CRC32, not our hand-rolled table — a writer and a checker that
+		// share one implementation would agree on a wrong value.
+		expect(
+			view.getUint32(at + 8 + len) >>> 0,
+			`cause: the ${type} chunk CRC does not match zlib's crc32, so strict decoders will reject the PNG. fix: CRC32 must cover type+data and be finalised with ^0xffffffff`,
+		).toBe(crc32(Buffer.from(png.subarray(at + 4, at + 8 + len))) >>> 0);
+		at += 12 + len;
+	}
+	const merged = Buffer.concat(idat.map((c) => Buffer.from(c)));
+	const raw = new Uint8Array(inflateSync(merged));
+	const pixels: number[][] = [];
+	for (let y = 0; y < height; y++) {
+		const rowStart = y * (1 + width * 4);
+		expect(
+			raw[rowStart],
+			"cause: scanline filter byte is not 0 (None). fix: prefix every scanline with a 0 filter byte",
+		).toBe(0);
+		for (let x = 0; x < width; x++) {
+			const p = rowStart + 1 + x * 4;
+			pixels.push([raw[p]!, raw[p + 1]!, raw[p + 2]!, raw[p + 3]!]);
+		}
+	}
+	return { width, height, colorType, pixels };
+}
+
+const RED = [0x00, 0x00, 0xff]; // BGR
+const GREEN = [0x00, 0xff, 0x00];
+const BLUE = [0xff, 0x00, 0x00];
+const WHITE = [0xff, 0xff, 0xff];
+
+describe("clipboardImageToPng", () => {
+	it("passes real PNG bytes through untouched (the macOS path)", () => {
+		const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+		const result = clipboardImageToPng(png);
+		expect(result.ok, "cause: PNG input rejected. fix: detect the PNG signature and pass the bytes through").toBe(true);
+		if (!result.ok) return;
+		expect(
+			result.png,
+			"cause: PNG input was re-encoded instead of passed through. fix: return the same buffer for PNG input",
+		).toBe(png);
+	});
+
+	it("converts a bottom-up 24-bit DIB, un-flipping the rows", () => {
+		// File order is bottom row first, so the image's TOP-LEFT pixel is red.
+		const dib = buildDib({
+			width: 2,
+			height: 2,
+			bitCount: 24,
+			rows: [[...BLUE, ...WHITE], [...RED, ...GREEN]],
+		});
+		const result = clipboardImageToPng(dib);
+		expect(result.ok, "cause: a plain 24-bit CF_DIB was refused. fix: accept biSize=40 / biBitCount=24 in dibToPng").toBe(true);
+		if (!result.ok) return;
+		const { width, height, colorType, pixels } = decodePng(result.png);
+		expect(width, "cause: wrong PNG width. fix: copy biWidth from DIB header offset 4").toBe(2);
+		expect(height, "cause: wrong PNG height. fix: use abs(biHeight) from DIB header offset 8").toBe(2);
+		expect(colorType, "cause: PNG color type is not 6 (RGBA). fix: write 6 into IHDR byte 9").toBe(6);
+		expect(
+			pixels,
+			"cause: bottom-up DIB rows were not flipped, or BGR was not swapped to RGB. fix: read source row (height-1-y) and emit R=byte[2], G=byte[1], B=byte[0]",
+		).toEqual([
+			[255, 0, 0, 255],
+			[0, 255, 0, 255],
+			[0, 0, 255, 255],
+			[255, 255, 255, 255],
+		]);
+	});
+
+	it("keeps row order for a top-down DIB (negative biHeight)", () => {
+		const dib = buildDib({
+			width: 2,
+			height: -2,
+			bitCount: 24,
+			rows: [[...RED, ...GREEN], [...BLUE, ...WHITE]],
+		});
+		const result = clipboardImageToPng(dib);
+		expect(result.ok, "cause: top-down DIB refused. fix: treat a negative biHeight as top-down, not invalid").toBe(true);
+		if (!result.ok) return;
+		expect(
+			decodePng(result.png).pixels[0],
+			"cause: a top-down DIB was flipped anyway, so the image is upside down. fix: when biHeight < 0 read source row y directly",
+		).toEqual([255, 0, 0, 255]);
+	});
+
+	it("forces alpha opaque for 32-bit BI_RGB, where the 4th byte is undefined", () => {
+		// Windows screenshots are commonly 32-bit with a zero 4th byte. Trusting it
+		// yields a fully transparent PNG that looks like nothing was pasted.
+		const dib = buildDib({
+			width: 1,
+			height: 1,
+			bitCount: 32,
+			rows: [[...RED, 0x00]],
+		});
+		const result = clipboardImageToPng(dib);
+		expect(result.ok, "cause: 32-bit DIB refused. fix: accept biBitCount=32 in dibToPng").toBe(true);
+		if (!result.ok) return;
+		expect(
+			decodePng(result.png).pixels[0],
+			"cause: the undefined 4th byte of 32-bit BI_RGB was used as alpha, producing a transparent image. fix: force alpha 255 unless a V4/V5 header declares a non-zero alpha mask",
+		).toEqual([255, 0, 0, 255]);
+	});
+
+	it("honours a declared alpha mask on a V5 header", () => {
+		const dib = buildDib({
+			width: 1,
+			height: 1,
+			bitCount: 32,
+			headerSize: 124,
+			alphaMask: 0xff000000,
+			rows: [[...RED, 0x80]],
+		});
+		const result = clipboardImageToPng(dib);
+		expect(result.ok, "cause: BITMAPV5HEADER refused. fix: allow biSize 108 and 124 in dibToPng").toBe(true);
+		if (!result.ok) return;
+		expect(
+			decodePng(result.png).pixels[0]?.[3],
+			"cause: a declared alpha mask was ignored. fix: read the alpha mask at header offset 52 when biSize >= 108 and use the source alpha byte",
+		).toBe(0x80);
+	});
+
+	it("strips the 14-byte BITMAPFILEHEADER of a whole BMP file", () => {
+		const dib = buildDib({ width: 1, height: 1, bitCount: 24, rows: [[...GREEN]] });
+		const bmp = new Uint8Array(14 + dib.length);
+		bmp[0] = 0x42; // 'B'
+		bmp[1] = 0x4d; // 'M'
+		bmp.set(dib, 14);
+		const result = clipboardImageToPng(bmp);
+		expect(result.ok, "cause: a full BMP file was refused. fix: detect the 'BM' magic and skip 14 bytes").toBe(true);
+		if (!result.ok) return;
+		expect(
+			decodePng(result.png).pixels[0],
+			"cause: the BITMAPFILEHEADER was parsed as a DIB header, so pixels are garbage. fix: subarray(14) before dibToPng",
+		).toEqual([0, 255, 0, 255]);
+	});
+
+	it("reports empty clipboard bytes instead of writing a zero-byte file", () => {
+		const result = clipboardImageToPng(new Uint8Array(0));
+		expect(result.ok, "cause: empty input accepted. fix: return not-ok for a zero-length buffer").toBe(false);
+		if (result.ok) return;
+		expect(
+			result.reason,
+			'cause: empty input is not distinguishable from an unsupported format. fix: return reason "empty" for zero-length input',
+		).toBe("empty");
+	});
+
+	it("refuses a palette DIB rather than emitting garbage pixels", () => {
+		const dib = buildDib({ width: 2, height: 1, bitCount: 8, rows: [[0, 1]] });
+		const result = clipboardImageToPng(dib);
+		expect(
+			result.ok,
+			"cause: an 8-bit palette DIB was converted as if it were BGR, producing garbage. fix: accept only biBitCount 24 and 32",
+		).toBe(false);
+	});
+
+	it("refuses a DIB whose pixel data is shorter than the header claims", () => {
+		const dib = buildDib({ width: 4, height: 4, bitCount: 24, rows: [], truncate: 20 });
+		const result = clipboardImageToPng(dib);
+		expect(
+			result.ok,
+			"cause: a truncated DIB was converted, reading past the buffer. fix: check pixelStart + stride*height against the buffer length",
+		).toBe(false);
+	});
+
+	it("refuses bytes that are neither PNG nor a plausible DIB", () => {
+		const result = clipboardImageToPng(new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3, 4]));
+		expect(
+			result.ok,
+			"cause: arbitrary bytes were accepted as a DIB. fix: validate biSize against the known header sizes",
+		).toBe(false);
+	});
+});

--- a/src/bun/clipboard-image.ts
+++ b/src/bun/clipboard-image.ts
@@ -1,0 +1,142 @@
+import { deflateSync } from "node:zlib";
+
+/**
+ * Turn whatever the host clipboard handed us into PNG bytes.
+ *
+ * macOS returns real PNG (NSPasteboard converts). Windows returns raw CF_DIB
+ * bytes — electrobun 1.18.1 has a "TODO: implement proper PNG conversion" there
+ * — so a DIB saved as `.png` is a corrupt file. PNG is the required output
+ * because the consumer of the pasted path is an agent, and the Claude API
+ * accepts only JPEG/PNG/GIF/WebP; a BMP would exist, open in a viewer, and be
+ * unreadable exactly where it is used.
+ *
+ * Delete this module once electrobun's Windows `clipboardReadImage` returns PNG.
+ * See decisions/216-clipboard-image-dib-to-png.md.
+ */
+export type ClipboardImageResult =
+	| { ok: true; png: Uint8Array }
+	| { ok: false; reason: "empty" | "unsupported" };
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+export function clipboardImageToPng(bytes: Uint8Array): ClipboardImageResult {
+	if (bytes.length === 0) return { ok: false, reason: "empty" };
+
+	if (PNG_MAGIC.every((b, i) => bytes[i] === b)) {
+		return { ok: true, png: bytes };
+	}
+
+	// BMP file: 14-byte BITMAPFILEHEADER, then the DIB we know how to read.
+	if (bytes[0] === 0x42 && bytes[1] === 0x4d && bytes.length > 14) {
+		return dibToPng(bytes.subarray(14));
+	}
+
+	return dibToPng(bytes);
+}
+
+const BI_RGB = 0;
+const BI_BITFIELDS = 3;
+
+function dibToPng(dib: Uint8Array): ClipboardImageResult {
+	if (dib.length < 40) return { ok: false, reason: "unsupported" };
+	const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength);
+
+	const headerSize = view.getUint32(0, true);
+	// 40 = BITMAPINFOHEADER, 52/56 = +masks, 108 = V4, 124 = V5.
+	if (![40, 52, 56, 108, 124].includes(headerSize)) return { ok: false, reason: "unsupported" };
+
+	const width = view.getInt32(4, true);
+	const rawHeight = view.getInt32(8, true);
+	const bitCount = view.getUint16(14, true);
+	const compression = view.getUint32(16, true);
+	const clrUsed = view.getUint32(32, true);
+
+	if (width <= 0 || rawHeight === 0) return { ok: false, reason: "unsupported" };
+	if (bitCount !== 24 && bitCount !== 32) return { ok: false, reason: "unsupported" };
+	if (compression !== BI_RGB && compression !== BI_BITFIELDS) return { ok: false, reason: "unsupported" };
+
+	// A 40-byte header with BI_BITFIELDS carries its three masks right after it.
+	const trailingMasks = compression === BI_BITFIELDS && headerSize === 40 ? 12 : 0;
+	const paletteBytes = bitCount <= 8 ? (clrUsed || 1 << bitCount) * 4 : clrUsed * 4;
+	const pixelStart = headerSize + trailingMasks + paletteBytes;
+
+	const topDown = rawHeight < 0;
+	const height = Math.abs(rawHeight);
+	const bytesPerPixel = bitCount / 8;
+	const stride = ((width * bytesPerPixel + 3) & ~3) >>> 0;
+	if (pixelStart + stride * height > dib.length) return { ok: false, reason: "unsupported" };
+
+	// 32-bit BI_RGB leaves the 4th byte undefined, so alpha is only trusted when
+	// a V4/V5 header declares a non-zero alpha mask.
+	const alphaMask = bitCount === 32 && headerSize >= 108 ? view.getUint32(52, true) : 0;
+	const useAlpha = alphaMask !== 0;
+
+	// One filter byte (0 = none) plus RGBA per pixel, per PNG scanline.
+	const raw = new Uint8Array((1 + width * 4) * height);
+	for (let y = 0; y < height; y++) {
+		const srcRow = topDown ? y : height - 1 - y;
+		let src = pixelStart + srcRow * stride;
+		let dst = y * (1 + width * 4) + 1;
+		for (let x = 0; x < width; x++) {
+			raw[dst] = dib[src + 2]!; // DIB pixels are BGR(A)
+			raw[dst + 1] = dib[src + 1]!;
+			raw[dst + 2] = dib[src]!;
+			raw[dst + 3] = useAlpha ? dib[src + 3]! : 0xff;
+			src += bytesPerPixel;
+			dst += 4;
+		}
+	}
+
+	return { ok: true, png: encodePng(width, height, raw) };
+}
+
+function encodePng(width: number, height: number, rawScanlines: Uint8Array): Uint8Array {
+	const ihdr = new Uint8Array(13);
+	const ihdrView = new DataView(ihdr.buffer);
+	ihdrView.setUint32(0, width);
+	ihdrView.setUint32(4, height);
+	ihdr[8] = 8; // bit depth
+	ihdr[9] = 6; // color type: RGBA
+	// [10] compression, [11] filter, [12] interlace — all 0.
+
+	const chunks = [
+		new Uint8Array(PNG_MAGIC),
+		pngChunk("IHDR", ihdr),
+		pngChunk("IDAT", new Uint8Array(deflateSync(rawScanlines))),
+		pngChunk("IEND", new Uint8Array(0)),
+	];
+	const total = chunks.reduce((n, c) => n + c.length, 0);
+	const out = new Uint8Array(total);
+	let at = 0;
+	for (const c of chunks) {
+		out.set(c, at);
+		at += c.length;
+	}
+	return out;
+}
+
+function pngChunk(type: string, data: Uint8Array): Uint8Array {
+	const chunk = new Uint8Array(12 + data.length);
+	const view = new DataView(chunk.buffer);
+	view.setUint32(0, data.length);
+	for (let i = 0; i < 4; i++) chunk[4 + i] = type.charCodeAt(i);
+	chunk.set(data, 8);
+	view.setUint32(8 + data.length, crc32(chunk.subarray(4, 8 + data.length)));
+	return chunk;
+}
+
+const CRC_TABLE = (() => {
+	const table = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		table[n] = c >>> 0;
+	}
+	return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+	let c = 0xffffffff;
+	for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]!) & 0xff]! ^ (c >>> 8);
+	return (c ^ 0xffffffff) >>> 0;
+}

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -25,6 +25,8 @@ import { writeSystemClipboard } from "../system-clipboard";
 import { getPushMessage, getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererDiagnostic, setActiveContext, setAppForeground, setStreamerPrivacy, setTerminalFocus } from "./shared";
 import { applyMenuContext, type MenuContext } from "../../shared/application-menu";
 import { loadSharedArtifactContent, loadSharedArtifactDownload } from "../shared-artifacts";
+import { isFullyQualifiedPath } from "../../shared/absolute-path";
+import { clipboardImageToPng } from "../clipboard-image";
 
 async function updateMenuContext(params: MenuContext): Promise<void> {
 	applyMenuContext({
@@ -763,12 +765,22 @@ async function pasteClipboardImage(params: { projectId: string }): Promise<{ pat
 		log.info("← pasteClipboardImage: no image in clipboard");
 		return null;
 	}
-	const pngData = Utils.clipboardReadImage();
-	if (!pngData || pngData.length === 0) {
+	const clipboardData = Utils.clipboardReadImage();
+	if (!clipboardData || clipboardData.length === 0) {
 		log.warn("← pasteClipboardImage: clipboardReadImage returned empty");
 		return null;
 	}
-	return saveUploadedFile(params.projectId, pngData, { mimeType: "image/png" });
+	// Windows hands back raw CF_DIB bytes, not PNG — convert before saving.
+	const converted = clipboardImageToPng(clipboardData);
+	if (!converted.ok) {
+		log.warn("← pasteClipboardImage: clipboard bytes are not a usable image", {
+			reason: converted.reason,
+			len: clipboardData.length,
+			head: Array.from(clipboardData.subarray(0, 8)),
+		});
+		return null;
+	}
+	return saveUploadedFile(params.projectId, converted.png, { mimeType: "image/png" });
 }
 
 async function uploadImageBase64(params: { projectId: string; base64: string; filename?: string; mimeType?: string }): Promise<{ path: string } | null> {
@@ -799,7 +811,7 @@ async function uploadFileBase64(params: { projectId: string; base64: string; fil
 
 async function readImageBase64(params: { path: string }): Promise<{ dataUrl: string } | null> {
 	log.info("→ readImageBase64", { path: params.path });
-	if (!params.path.startsWith("/") || params.path.includes("..")) {
+	if (!isFullyQualifiedPath(params.path, process.platform)) {
 		log.warn("← readImageBase64: invalid path, rejected");
 		return null;
 	}
@@ -834,7 +846,7 @@ async function readArtifactDownload(params: { artifact: SharedArtifact }) {
 
 async function openImageFile(params: { path: string }): Promise<void> {
 	log.info("→ openImageFile", { path: params.path });
-	if (!params.path.startsWith("/") || params.path.includes("..")) {
+	if (!isFullyQualifiedPath(params.path, process.platform)) {
 		throw new Error("Invalid file path");
 	}
 	Utils.openPath(params.path);
@@ -842,7 +854,7 @@ async function openImageFile(params: { path: string }): Promise<void> {
 
 async function openFolder(params: { path: string }): Promise<void> {
 	log.info("→ openFolder", { path: params.path });
-	if (!params.path.startsWith("/") || params.path.includes("..")) {
+	if (!isFullyQualifiedPath(params.path, process.platform)) {
 		throw new Error("Invalid folder path");
 	}
 	Utils.openPath(params.path);
@@ -902,7 +914,7 @@ function resolveZedCli(): string | null {
 
 async function openInApp(params: { appName: string; path: string }): Promise<void> {
 	log.info("→ openInApp", { appName: params.appName, path: params.path });
-	if (!params.path.startsWith("/") || params.path.includes("..")) {
+	if (!isFullyQualifiedPath(params.path, process.platform)) {
 		throw new Error("Invalid path");
 	}
 	if (!params.appName || params.appName.includes("/")) {

--- a/src/bun/shared-images.ts
+++ b/src/bun/shared-images.ts
@@ -5,6 +5,7 @@ import { MAX_SHARED_IMAGE_BYTES, SHARED_IMAGE_EXTS } from "../shared/types";
 import { DEV3_HOME } from "./paths";
 import { projectStorageKey } from "../shared/project-storage-key";
 import { createLogger } from "./logger";
+import { isFullyQualifiedPath } from "../shared/absolute-path";
 
 const log = createLogger("shared-images");
 
@@ -55,7 +56,7 @@ export class SharedImageError extends Error {}
  * per-image `caption` is the agent's note about what to look at in this shot.
  */
 export function saveSharedImage(projectPath: string, sourcePath: string, caption?: string): SharedImage {
-	if (!sourcePath.startsWith("/") || sourcePath.includes("..")) {
+	if (!isFullyQualifiedPath(sourcePath, process.platform)) {
 		throw new SharedImageError(`Path must be absolute and free of "..": ${sourcePath}`);
 	}
 	if (!existsSync(sourcePath)) {

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -29,6 +29,7 @@ import { matchesShortcut } from "./keymap";
 import { uploadDroppedFile } from "./utils/uploadDroppedFile";
 import { writeClipboardText } from "./utils/clipboard-write";
 import { isLargeTextPaste, uploadPastedText } from "./utils/uploadPastedText";
+import { imageFilesFromClipboard } from "./utils/clipboardImageFiles";
 import { createAnsiThemeFilter } from "./utils/ansi-theme-adapt";
 import { submitPastedText } from "./terminal-submit";
 import { createFilePathLinkProvider, type FilePathLinkProvider } from "./terminal-file-links";
@@ -1822,6 +1823,27 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 			// Attachments (images / large text) need a project to upload into.
 			if (projectId) {
+				// The paste event's own files are the reliable source: the webview hands
+				// over real PNG bytes for a clipboard bitmap. The host-clipboard RPC below
+				// is the fallback — on Windows it returns raw DIB bytes, and in remote mode
+				// it reads the app host's clipboard rather than the user's device.
+				const pastedImages = imageFilesFromClipboard(clip);
+				if (pastedImages.length > 0) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					void Promise.all(pastedImages.map((f) => uploadDroppedFile(projectId, f)))
+						.then((paths) => {
+							const line = paths.filter((p): p is string => Boolean(p)).map((p) => p.replace(/ /g, "\\ ")).join(" ");
+							if (line) sendPathToPty(line);
+							else toast.error(t("imagePaste.failed"), { taskId });
+						})
+						.catch((err) => {
+							console.error("[TerminalView] Image paste upload failed:", err);
+							toast.error(t("fileDrop.uploadFailed", { error: String(err instanceof Error ? err.message : err) }), { taskId });
+						});
+					return;
+				}
+
 				let hasImage = false;
 				const items = clip?.items;
 				if (items) {
@@ -1838,8 +1860,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					e.stopImmediatePropagation();
 					api.request.pasteClipboardImage({ projectId }).then((result) => {
 						if (result) sendPathToPty(result.path);
+						else toast.error(t("imagePaste.failed"), { taskId });
 					}).catch((err) => {
 						console.error("[TerminalView] Image paste failed:", err);
+						toast.error(t("imagePaste.failed"), { taskId });
 					});
 					return;
 				}
@@ -1883,7 +1907,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 		container.addEventListener("paste", onPaste, { capture: true });
 		return () => container.removeEventListener("paste", onPaste, { capture: true });
-	}, [projectId]);
+	}, [projectId, taskId, t]);
 
 	function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
 		e.preventDefault();

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -995,12 +995,14 @@ function dispatchPaste(
 	target: Element,
 	text: string,
 	items: Array<{ type: string }> = [],
+	files: File[] = [],
 ) {
 	const event = new Event("paste", { bubbles: true, cancelable: true });
 	Object.defineProperty(event, "clipboardData", {
 		value: {
 			getData: (type: string) => (type === "text/plain" ? text : ""),
 			items,
+			files,
 		},
 	});
 	const preventDefault = vi.spyOn(event, "preventDefault");
@@ -1085,6 +1087,26 @@ describe("TerminalView – paste routing", () => {
 		expect(preventDefault).not.toHaveBeenCalled();
 	});
 
+	it("tells the user when the host clipboard yields no usable image, instead of failing silently", async () => {
+		// This is the Windows symptom: electrobun's clipboardReadImage returns nothing
+		// usable, the handler returned null, and absolutely nothing appeared on screen.
+		const { toast } = await import("../toast");
+		const errorToast = vi.mocked(toast.error);
+		errorToast.mockClear();
+		mockedPasteClipboardImage.mockResolvedValue(null);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+
+		dispatchPaste(terminal, "", [{ type: "image/png" }]);
+
+		await waitFor(() => {
+			expect(
+				errorToast,
+				"cause: a failed image paste produced no user-visible feedback. fix: toast.error(t(\"imagePaste.failed\")) when pasteClipboardImage resolves null or rejects",
+			).toHaveBeenCalled();
+		});
+	});
+
 	it("still diverts image pastes to the attachment uploader (not term.paste)", async () => {
 		mockedPasteClipboardImage.mockResolvedValue({ path: "/tmp/uploads/pic.png" } as any);
 		const { container } = await renderAndSetup();
@@ -1096,6 +1118,44 @@ describe("TerminalView – paste routing", () => {
 			expect(mockedPasteClipboardImage).toHaveBeenCalledWith({ projectId: "p1" });
 		});
 		expect(mockPaste).not.toHaveBeenCalled();
+	});
+
+	it("uploads an image carried by the paste event itself, without reading the host clipboard", async () => {
+		// The webview already decoded the clipboard bitmap into real PNG bytes. Going
+		// through the host clipboard instead is what breaks on Windows, where
+		// electrobun returns raw CF_DIB bytes (or nothing at all).
+		mockedUploadFileBase64.mockResolvedValue({ path: "/tmp/uploads/image.png" } as any);
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+		const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "image.png", { type: "image/png" });
+
+		dispatchPaste(terminal, "", [{ type: "image/png" }], [file]);
+
+		await waitFor(() => {
+			expect(mockedUploadFileBase64).toHaveBeenCalled();
+		});
+		expect(
+			mockedPasteClipboardImage,
+			"cause: the paste went through the host-clipboard RPC even though the event carried the image. fix: check imageFilesFromClipboard before the pasteClipboardImage fallback",
+		).not.toHaveBeenCalled();
+		expect(
+			mockPaste,
+			"cause: an image paste was also typed into the terminal as text. fix: preventDefault and return after the upload branch",
+		).not.toHaveBeenCalled();
+	});
+
+	it("leaves ordinary text pastes on the bracketed path when a non-image file is attached", async () => {
+		const { container } = await renderAndSetup();
+		const terminal = container.querySelector('[data-terminal="true"]')!;
+		const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+
+		dispatchPaste(terminal, "hello world", [], [file]);
+
+		expect(
+			mockPaste,
+			'cause: a text paste was diverted to the uploader because a non-image file was attached. fix: filter clipboard files on type.startsWith("image/")',
+		).toHaveBeenCalledWith("hello world");
+		expect(mockedUploadFileBase64).not.toHaveBeenCalled();
 	});
 
 	it("still diverts large text pastes to the .txt uploader (not term.paste)", async () => {

--- a/src/mainview/hooks/useClipboardPaste.ts
+++ b/src/mainview/hooks/useClipboardPaste.ts
@@ -2,6 +2,9 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { api } from "../rpc";
 import { isLargeTextPaste, uploadPastedText } from "../utils/uploadPastedText";
 import { useAttachUpload } from "./useAttachUpload";
+import { imageFilesFromClipboard } from "../utils/clipboardImageFiles";
+import { toast } from "../toast";
+import { useT } from "../i18n";
 
 type PasteKind = "image" | "text" | null;
 
@@ -9,6 +12,7 @@ export function useClipboardPaste(
 	projectId: string,
 	onPathPasted: (path: string) => void,
 ): { handlePaste: (e: React.ClipboardEvent) => void; isPasting: boolean; pasteKind: PasteKind } {
+	const t = useT();
 	const [isPasting, setIsPasting] = useState(false);
 	const [pasteKind, setPasteKind] = useState<PasteKind>(null);
 	const mountedRef = useRef(true);
@@ -25,7 +29,8 @@ export function useClipboardPaste(
 			// mode) — upload them directly. The RPC fallback below reads the app
 			// host's clipboard, which in remote/browser mode is NOT the device the
 			// user pasted from.
-			const files = Array.from(e.clipboardData?.files ?? []);
+			const files = imageFilesFromClipboard(e.clipboardData);
+			if (files.length === 0) files.push(...Array.from(e.clipboardData?.files ?? []));
 			if (files.length > 0 && projectId) {
 				e.preventDefault();
 				setPasteKind("image");
@@ -55,13 +60,15 @@ export function useClipboardPaste(
 
 				api.request.pasteClipboardImage({ projectId }).then((result) => {
 					if (!mountedRef.current) return;
-					if (result) {
-						onPathPasted(result.path);
-					}
+					if (result) onPathPasted(result.path);
+					// A null result means the host clipboard had nothing usable — say so
+					// instead of leaving the user with an unchanged field.
+					else toast.error(t("imagePaste.failed"));
 					setIsPasting(false);
 					setPasteKind(null);
 				}).catch(() => {
 					if (!mountedRef.current) return;
+					toast.error(t("imagePaste.failed"));
 					setIsPasting(false);
 					setPasteKind(null);
 				});
@@ -89,7 +96,7 @@ export function useClipboardPaste(
 				setPasteKind(null);
 			});
 		},
-		[projectId, onPathPasted, attach],
+		[projectId, onPathPasted, attach, t],
 	);
 
 	return { handlePaste, isPasting: isPasting || isUploadingFiles, pasteKind };

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -215,6 +215,7 @@ const terminal = {
 	"quickShell.open": "Quick Shell",
 	"quickShell.tooltipWithShortcut": "Quick Shell \u2014 new scratch in Operations (\u2318\u21e7`)",
 	"fileDrop.uploadFailed": "File upload failed: {error}",
+	"imagePaste.failed": "Couldn't paste the image from the clipboard. Save it as a file and drag it in instead.",
 
 	// Touch composer (mobile input mode)
 	"terminal.composerPlaceholder": "Type prompt…",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -215,6 +215,7 @@ const terminal = {
 	"quickShell.open": "Shell rápido",
 	"quickShell.tooltipWithShortcut": "Shell rápido — nuevo scratch en Operations (⌘⇧`)",
 	"fileDrop.uploadFailed": "Error al subir el archivo: {error}",
+	"imagePaste.failed": "No se pudo pegar la imagen del portapapeles. Guárdala como archivo y arrástrala aquí.",
 
 	// Touch composer (mobile input mode)
 	"terminal.composerPlaceholder": "Escribe un prompt…",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -223,6 +223,7 @@ const terminal = {
 	"quickShell.open": "Быстрая консоль",
 	"quickShell.tooltipWithShortcut": "Быстрая консоль — новый scratch в Operations (⌘⇧`)",
 	"fileDrop.uploadFailed": "Ошибка загрузки файла: {error}",
+	"imagePaste.failed": "Не удалось вставить картинку из буфера. Сохраните её в файл и перетащите сюда.",
 
 	// Touch composer (mobile input mode)
 	"terminal.composerPlaceholder": "Введите промпт…",

--- a/src/mainview/utils/__tests__/clipboardImageFiles.test.ts
+++ b/src/mainview/utils/__tests__/clipboardImageFiles.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { imageFilesFromClipboard } from "../clipboardImageFiles";
+
+function pngFile(name: string): File {
+	return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: "image/png" });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asClipboard = (v: unknown) => v as any;
+
+describe("imageFilesFromClipboard", () => {
+	it("takes image files straight off the event", () => {
+		const file = pngFile("image.png");
+		expect(
+			imageFilesFromClipboard(asClipboard({ files: [file] })),
+			"cause: the paste event's own image file was ignored, so the paste falls back to reading the host clipboard. fix: return clipboardData.files entries whose type starts with image/",
+		).toEqual([file]);
+	});
+
+	it("ignores non-image files on the event", () => {
+		expect(
+			imageFilesFromClipboard(asClipboard({ files: [new File(["x"], "a.txt", { type: "text/plain" })] })),
+			"cause: a pasted text file was treated as an image. fix: filter on type.startsWith(\"image/\")",
+		).toEqual([]);
+	});
+
+	it("falls back to items.getAsFile() when the files list is empty", () => {
+		const file = pngFile("clip.png");
+		const items = [{ kind: "file", type: "image/png", getAsFile: () => file }];
+		expect(
+			imageFilesFromClipboard(asClipboard({ files: [], items })),
+			"cause: a webview that exposes the image only through clipboardData.items is not handled. fix: fall back to items[i].getAsFile()",
+		).toEqual([file]);
+	});
+
+	it("does not take the same image from both files and items", () => {
+		// Chromium populates both for one pasted bitmap; using both attaches it twice.
+		const file = pngFile("image.png");
+		const getAsFile = vi.fn(() => file);
+		const result = imageFilesFromClipboard(
+			asClipboard({ files: [file], items: [{ kind: "file", type: "image/png", getAsFile }] }),
+		);
+		expect(
+			result.length,
+			"cause: one pasted image produced two uploads. fix: only consult items when the files list yielded nothing",
+		).toBe(1);
+		expect(
+			getAsFile,
+			"cause: items were read even though files already had the image. fix: return early after the files branch",
+		).not.toHaveBeenCalled();
+	});
+
+	it("survives a clipboard with items that have no getAsFile", () => {
+		const items = [{ kind: "file", type: "image/png" }];
+		expect(
+			() => imageFilesFromClipboard(asClipboard({ items })),
+			"cause: an item without getAsFile threw instead of being skipped. fix: check typeof item.getAsFile === \"function\"",
+		).not.toThrow();
+	});
+
+	it("returns nothing for a missing clipboard", () => {
+		expect(
+			imageFilesFromClipboard(null),
+			"cause: a null clipboardData threw or produced files. fix: return [] when clip is falsy",
+		).toEqual([]);
+	});
+});

--- a/src/mainview/utils/clipboardImageFiles.ts
+++ b/src/mainview/utils/clipboardImageFiles.ts
@@ -1,0 +1,30 @@
+/**
+ * Image files carried by a paste event itself.
+ *
+ * Prefer these over reading the host clipboard through the bun process: the
+ * webview already decoded the clipboard bitmap into real PNG bytes, it is the
+ * user's own device in remote mode, and it needs no platform-specific handling.
+ *
+ * `files` is checked first and `items` only as a fallback, because a webview
+ * that populates both describes the SAME image twice — uploading from both
+ * would attach it twice.
+ */
+export function imageFilesFromClipboard(clip: DataTransfer | null | undefined): File[] {
+	if (!clip) return [];
+
+	const fromFiles = Array.from(clip.files ?? []).filter((f) => f.type.startsWith("image/"));
+	if (fromFiles.length > 0) return fromFiles;
+
+	const items = clip.items;
+	if (!items) return [];
+	const fromItems: File[] = [];
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		// A synthetic paste event (and some webviews) expose items without getAsFile.
+		if (!item || item.kind !== "file" || !item.type.startsWith("image/")) continue;
+		if (typeof item.getAsFile !== "function") continue;
+		const file = item.getAsFile();
+		if (file) fromItems.push(file);
+	}
+	return fromItems;
+}

--- a/src/shared/absolute-path.ts
+++ b/src/shared/absolute-path.ts
@@ -1,0 +1,24 @@
+/**
+ * Shape check for a path an agent, the CLI, or the renderer handed us.
+ *
+ * This is NOT a security boundary — every fully-qualified path on the machine
+ * passes, so widening it opens no hole. It only answers "did the caller give me
+ * a fully-qualified path, or a fragment I would resolve against an arbitrary
+ * cwd?", and rejects `..` so a handed-in path cannot walk upwards. Sandboxing a
+ * path to a directory is a separate job the callers do not ask for.
+ *
+ * Windows matters here: an uploaded path looks like `C:/Users/me/.dev3.0/...`,
+ * which a POSIX-only `startsWith("/")` check rejects outright.
+ */
+export function isFullyQualifiedPath(path: string, platform: string): boolean {
+	// Conservative on purpose: a literal ".." anywhere is refused, even inside a
+	// filename like "a..b.png". Callers never need such names.
+	if (!path || path.includes("..")) return false;
+	// POSIX root. Also accepted on Windows — Bun and Node resolve "/x" there.
+	if (path.startsWith("/")) return true;
+	if (platform !== "win32") return false;
+	// UNC share: \\server\share\...
+	if (/^\\\\[^\\/]/.test(path)) return true;
+	// Drive-qualified: C:\... or C:/... — "C:foo" is drive-RELATIVE and refused.
+	return /^[A-Za-z]:[\\/]/.test(path);
+}


### PR DESCRIPTION
Hi, Claude here — the AI assistant that worked on this branch.

Pasting an image with Ctrl+V did nothing on Windows. Three independent defects sat behind one symptom.

**The picture is now taken from the paste event itself.** `imageFilesFromClipboard` (`src/mainview/utils/clipboardImageFiles.ts`) reads `clipboardData.files`, falling back to `items[i].getAsFile()`; `TerminalView`'s paste interceptor uses it before the host-clipboard RPC. The webview has already decoded the clipboard bitmap into real PNG bytes, and in remote mode that is the user's own device rather than the app host. **This changes the macOS path too** — a pasted image is now uploaded from the event instead of through `pasteClipboardImage`.

**The host-clipboard fallback no longer writes corrupt files.** electrobun 1.18.1's Windows `clipboardReadImage` returns raw CF_DIB bytes (its own comment: `TODO: Implement proper PNG conversion using GDI+ or similar`), while macOS returns real PNG — we saved those bytes as `.png`. `clipboardImageToPng` (`src/bun/clipboard-image.ts`) passes PNG through, strips a `BITMAPFILEHEADER` off a whole BMP, and converts a 24/32-bit uncompressed DIB to PNG; palette, RLE and truncated DIBs are refused rather than saved. PNG is the required output because the consumer of the pasted path is an agent, and the Claude API accepts only JPEG/PNG/GIF/WebP — a `.bmp` would exist, open in a viewer, and be unreadable exactly where it is used. Rationale and the deletion condition: `decisions/216-clipboard-image-dib-to-png.md`.

**A POSIX-only path guard is gone.** `if (!path.startsWith("/") || path.includes(".."))` was copy-pasted in five places and rejected `C:/Users/...` outright, so on Windows the image thumbnail rendered "Load failed" and `openImageFile` / `openFolder` / `openInApp` / `dev3 show-image` all refused valid paths. Replaced by `isFullyQualifiedPath` (`src/shared/absolute-path.ts`), which takes the platform as an argument — a shape check, explicitly not a security boundary — and still refuses relative paths, `..`, drive-relative `C:foo`, and a bare `C:`.

**Failures are visible.** A paste that cannot produce a file raises `toast.error(t("imagePaste.failed"))` instead of only a `console.error`. New key in en/ru/es.

### Verification

- 22 mutations applied to the new code, all caught; baseline and restore green. One assertion was initially passing for the wrong reason (a palette DIB refused for length, not bit depth) and was fixed.
- The hand-written PNG encoder's output was decoded by three implementations sharing no code with it: Chromium via `canvas.getImageData` (returned the four expected pixel colours), Apple ImageIO via `sips`, and Python `zlib`. The test suite keeps the CRC half permanently — chunk CRCs are checked against `crc32` from `node:zlib`, not our own table.
- Browser QA on macOS: pasting a real PNG into New Task inserts the uploads path and the thumbnail renders — the exact surface that showed "Load failed" on Windows.

### Not verified

**The Windows behaviour is unverified.** No agent on this project can run Windows; the fix is reasoned from electrobun's pinned source and proved by tests on macOS. Arseny has a per-step recipe to run on his machine.

Unrelated to this change: `sendPathToPty` escapes spaces as `\ `, which is meaningless in PowerShell and cmd. Tracked separately.
