### PR TITLE
Record the measured Windows process-query costs and why the 60s budget must not grow

### DIFF
--- a/decisions/215-windows-launch-proof-process-query-dialects.md
+++ b/decisions/215-windows-launch-proof-process-query-dialects.md
@@ -57,6 +57,39 @@ limit of the shared evidence, though — the ETIMEDOUT wraps the PowerShell star
 the WMI round-trip, so this failure cannot by itself prove the WMI half is the expensive
 one.
 
+## What the queries actually cost — and why 60 s must not be raised
+
+First measurement, from the post-merge run of this change: `windows-proof-main` run
+`31100808763` **attempt 1** on merge commit `45a1d68b3` (cite the attempt; a rerun
+overwrites the run-level conclusion). The PR side never sees these numbers by design —
+`#1271` moved the packaged proof post-merge after measuring +4m47 on every in-scope PR — so
+the first Windows execution of a change like this is always its own merge commit.
+
+| Dialect | Calls | Slowest | Mean | Budget |
+|---|---|---|---|---|
+| WMI tree walk (`powershell` + `Get-CimInstance`) | 2 | 3 316 ms | ~1 965 ms | 60 000 ms |
+| Liveness (`tasklist.exe`) | 15 | 349 ms | ~327 ms | 30 000 ms |
+
+What follows from it, and it is the durable part of this record:
+
+- **Raising the 60 s budget is now the harder position, not the easier one.** 60 s is ~18×
+  the slowest *normal* call ever measured, so the stall that started all this was ~18× past
+  worst-normal. A bigger number has to explain a tail that far out.
+- **17 process queries per run**, of which 15 used to be PowerShell + WMI and now are not.
+  Cost inside process queries dropped from ~33 s to ~8.9 s per run; `tasklist` is ~6×
+  cheaper per call.
+- **The estimate in this record's Investigation was wrong and too low**: ~1 s per snapshot
+  was inferred, ~1 965 ms measured. The call count inferred there (~15) was exact.
+- **Zero retries were consumed.** The retry path is unit-proven and field-unproven; nobody
+  may describe it otherwise until a real stall exercises it.
+
+The change also leaves **two** PowerShell cold starts where there were ~15 while removing
+almost all WMI exposure, so a *next* stall discriminates what one observation could not:
+on a remaining tree walk it convicts the **PowerShell spawn**; on the `tasklist` path it
+convicts **neither** and points at the runner's process subsystem, which would mean
+`Get-Process` does not save the Windows preBuild work built on the same mechanism either.
+Nothing was learned on that question here — the run was green.
+
 ## Risks
 
 - Three attempts at a 60 s budget means a genuinely dead query costs 180 s per tree walk


### PR DESCRIPTION
Hey, Claude here — the AI that wrote #1276, closing the loop on it.

#1276 fixed a 60s stall of the Windows launch proof's process query that withheld the downloadable Windows build from a launch that had actually succeeded (run 31098005022 **attempt 1** — cite the attempt, a rerun overwrites the run-level conclusion). It refused to raise the timeout on the grounds that no duration distribution existed to size one from, and instead started recording every attempt.

The first post-merge run has now produced that data — run 31100808763 **attempt 1**, merge commit 45a1d68b3:

| Dialect | Calls | Slowest | Mean | Budget |
|---|---|---|---|---|
| WMI tree walk (`powershell` + `Get-CimInstance`) | 2 | 3 316 ms | ~1 965 ms | 60 000 ms |
| Liveness (`tasklist.exe`) | 15 | 349 ms | ~327 ms | 30 000 ms |

Why that is worth writing down rather than leaving in a run log:

- **60s is ~18x the slowest normal call ever measured**, so the stall was ~18x past worst-normal. Raising the budget is now the harder position, not the easier one — a bigger number has to explain a tail that far out. Without this on record, the next person to see a stall re-derives it or, worse, just raises the timeout.
- 17 process queries per run, 15 of which used to be PowerShell + WMI; cost inside process queries fell from ~33s to ~8.9s per run.
- Two corrections against the record's own earlier reasoning: its ~1s-per-snapshot estimate was too low (~1 965 ms measured), while its ~15-cold-starts count was exact.
- **Zero retries were consumed**, so the retry path is unit-proven and field-unproven. Nobody should describe it otherwise until a real stall exercises it.
- Which half stalls — the PowerShell spawn or the WMI round-trip — is still open, and the closing paragraph names what a next stall on each dialect would convict, so the question gets answered for free rather than needing a new experiment.

Docs only: one section appended to `decisions/215-windows-launch-proof-process-query-dialects.md`. Note that a decisions-only change is out of Windows CI scope by design, so the packaging job will skip and this run will report success having proved nothing about Windows — correct behaviour, but this run must not be cited as a proof.