### PR TITLE
Say the machine is loaded instead of quoting megabytes at launch

### DIFF
--- a/change-logs/2026/08/06/fix-launch-memory-banner-plain-language.md
+++ b/change-logs/2026/08/06/fix-launch-memory-banner-plain-language.md
@@ -1,0 +1,3 @@
+Short: Memory warning in plain words
+
+The memory notice in the launch dialogs no longer quotes megabytes; it now says in one short line that the machine is loaded and that another task will be a squeeze, taking half the vertical space it used to. The variant number and remove button in the launch dialog are also centred against the pickers instead of riding their top edge.

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -336,7 +336,7 @@ function LaunchVariantsModal({
 
 				{/* Memory notice, outside the scrolling variant list so it cannot be
 				    scrolled out of sight. The forecast scales with the variant count. */}
-				<div className="px-6 pt-4 empty:hidden">
+				<div className="px-6 pt-3 empty:hidden">
 					<MemoryPressureBanner launchCount={variants.length} />
 				</div>
 
@@ -372,8 +372,12 @@ function LaunchVariantsModal({
 								aria-label={t("launch.variantGroup", { n: String(index + 1) })}
 								className="grid grid-cols-[1.75rem_minmax(0,1fr)_1.5rem] items-start gap-3 p-3 bg-raised rounded-[1.25rem] border border-edge"
 							>
-								{/* Variant number */}
-								<span className="text-accent font-bold text-sm">#{index + 1}</span>
+								{/* Variant number. A control-height box, so the index reads as
+								    centred against the fields beside it instead of riding
+								    their top edge. */}
+								<span className="flex h-[34px] items-center text-accent font-bold text-sm">
+									#{index + 1}
+								</span>
 
 								{/* Provider → Model → Mode (stacks in a narrow dialog) */}
 								<AgentConfigPicker
@@ -397,7 +401,7 @@ function LaunchVariantsModal({
 								{variants.length > 1 && (
 									<button
 										onClick={() => removeVariant(index)}
-										className={`text-fg-muted hover:text-danger p-1 ${pressClass}`}
+										className={`flex h-[34px] w-6 items-center justify-center text-fg-muted hover:text-danger ${pressClass}`}
 										title={t("launch.removeVariant")}
 									>
 										<svg

--- a/src/mainview/components/MemoryPressureBanner.tsx
+++ b/src/mainview/components/MemoryPressureBanner.tsx
@@ -2,15 +2,19 @@ import { useEffect, useState } from "react";
 import type { SystemMemorySnapshot } from "../../shared/types";
 import { api } from "../rpc";
 import { useT } from "../i18n";
-import { formatBytes } from "../utils/formatBytes";
 
 /**
  * Launch-time memory notice for the create-task and launch-variants modals.
  *
  * A passive header widget will not stop anyone from starting a twentieth task, so
- * the same numbers appear at the moment the decision is actually made. It
- * INFORMS: it never blocks, never gates behind a confirmation, and never disables
- * the launch button. The user keeps authority over their own machine.
+ * a verdict appears at the moment the decision is actually made. It INFORMS: it
+ * never blocks, never gates behind a confirmation, and never disables the launch
+ * button. The user keeps authority over their own machine.
+ *
+ * One plain-language line, no byte counts: at launch time "139 MB per task" is
+ * arithmetic the user has to do themselves, and it cost this notice as much
+ * vertical space as the variant picker it sits above. The exact figures stay one
+ * hover away in the header's memory readout.
  *
  * It appears only when the machine is genuinely tight — otherwise it becomes
  * wallpaper the user stops reading.
@@ -59,30 +63,41 @@ export default function MemoryPressureBanner({ launchCount }: MemoryPressureBann
 	// The forecast overrunning what is left is the sharper signal, and should not
 	// look identical to the merely-tight case.
 	const severe = wontFit || snapshot.pressure === "critical";
-	const surfaceClass = severe ? "border-danger/30 bg-danger/10" : "border-accent/30 bg-accent/10";
-	const headlineClass = severe ? "text-danger" : "text-accent";
+	const surfaceClass = severe
+		? "border-danger/30 bg-danger/10 text-danger"
+		: "border-accent/30 bg-accent/10 text-accent";
+
+	const count = Math.max(1, launchCount);
+	const verdict =
+		forecast === null
+			? t("memory.bannerTight")
+			: t.plural(severe ? "memory.bannerOutOfRoom" : "memory.bannerLoaded", count);
 
 	return (
 		<div
 			role="status"
 			aria-live="polite"
 			data-testid="memory-pressure-banner"
-			className={`flex flex-col gap-1 rounded-xl border px-3 py-2.5 ${surfaceClass}`}
+			className={`flex items-start gap-2 rounded-lg border px-3 py-1.5 text-xs ${surfaceClass}`}
 		>
-			<p className={`text-sm font-medium ${headlineClass}`}>
-				{t("memory.bannerHeadline", { free: formatBytes(snapshot.headroom) })}
-			</p>
-			<p className="text-xs leading-relaxed text-fg-2">
-				{snapshot.swapping && `${t("memory.bannerSwapping")} `}
-				{forecast === null
-					? t("memory.bannerNoForecast")
-					: t("memory.bannerForecast", {
-							median: formatBytes(snapshot.medianTaskRss!),
-							count: String(Math.max(1, launchCount)),
-							needed: formatBytes(forecast),
-						})}
-				{wontFit && ` ${t("memory.bannerWontFit")}`}
-			</p>
+			{/* mt-px keeps the glyph on the first line's optical centre when the
+			    sentence wraps in a narrow dialog. */}
+			<svg
+				className="w-3.5 h-3.5 mt-px flex-shrink-0"
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				aria-hidden="true"
+			>
+				<circle cx="8" cy="8" r="6.25" />
+				<path d="M8 4.75v3.75M8 11.1h.01" />
+			</svg>
+			<span className="min-w-0">
+				{verdict}
+				{snapshot.swapping && ` ${t("memory.bannerSwapping")}`}
+			</span>
 		</div>
 	);
 }

--- a/src/mainview/components/SpawnAgentModal.tsx
+++ b/src/mainview/components/SpawnAgentModal.tsx
@@ -156,7 +156,7 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 				</div>
 
 				{/* Memory notice — this dialog starts exactly one more agent. */}
-				<div className="px-6 pt-4 empty:hidden">
+				<div className="px-6 pt-3 empty:hidden">
 					<MemoryPressureBanner launchCount={1} />
 				</div>
 

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -1761,22 +1761,21 @@ describe("CreateTaskModal — memory notice", () => {
 		expect(screen.queryByTestId("memory-pressure-banner")).toBeNull();
 	});
 
-	it("states free memory and whether the machine is swapping", async () => {
+	it("says the machine is loaded and whether it is swapping, without byte counts", async () => {
 		mockedApi.request.getSystemMemory.mockResolvedValue(memory({ swapping: true }));
 		renderModal();
 
 		const banner = await screen.findByTestId("memory-pressure-banner");
-		expect(banner).toHaveTextContent("3.0 GB");
+		expect(banner).toHaveTextContent(/already loaded/i);
 		expect(banner).toHaveTextContent(/already swapping/i);
+		expect(banner).not.toHaveTextContent(/\d+(\.\d+)?\s?(MB|GB)/);
 	});
 
-	it("forecasts one task, because this modal creates one", async () => {
+	it("speaks of one task, because this modal creates one", async () => {
 		mockedApi.request.getSystemMemory.mockResolvedValue(memory());
 		renderModal();
 
-		expect(await screen.findByTestId("memory-pressure-banner")).toHaveTextContent(
-			/1 more would need roughly 2\.0 GB/,
-		);
+		expect(await screen.findByTestId("memory-pressure-banner")).toHaveTextContent(/one more task/i);
 	});
 
 	it("never disables the create exits while the notice is showing", async () => {

--- a/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
+++ b/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
@@ -832,50 +832,49 @@ describe("LaunchVariantsModal — memory notice", () => {
 		expect(screen.queryByTestId("memory-pressure-banner")).toBeNull();
 	});
 
-	it("appears when the machine is under pressure", async () => {
+	it("appears when the machine is under pressure, in plain words and no byte counts", async () => {
 		mockedApi.request.getSystemMemory.mockResolvedValue(memory());
 		renderModal(makeProject());
 
-		expect(await screen.findByTestId("memory-pressure-banner")).toHaveTextContent("4.0 GB");
+		const banner = await screen.findByTestId("memory-pressure-banner");
+		expect(banner).toHaveTextContent(/already loaded/i);
+		expect(banner).not.toHaveTextContent(/\d+(\.\d+)?\s?(MB|GB)/);
 	});
 
-	it("scales the forecast by the number of variants", async () => {
+	it("counts the variants it is about to launch", async () => {
 		const user = userEvent.setup();
 		mockedApi.request.getSystemMemory.mockResolvedValue(memory({ headroom: 20 * GIB, pressure: "warn" }));
 		renderModal(makeProject());
 
 		const banner = await screen.findByTestId("memory-pressure-banner");
-		// One variant at a 3 GB median.
-		expect(banner).toHaveTextContent(/1 more would need roughly 3\.0 GB/);
+		expect(banner).toHaveTextContent(/one more task/i);
 
 		await user.click(screen.getByRole("button", { name: /Add Variant/i }));
 		await user.click(screen.getByRole("button", { name: /Add Variant/i }));
 
-		expect(await screen.findByTestId("memory-pressure-banner")).toHaveTextContent(
-			/3 more would need roughly 9\.0 GB/,
-		);
+		expect(await screen.findByTestId("memory-pressure-banner")).toHaveTextContent(/3 more tasks/i);
 	});
 
-	it("warns when the forecast does not fit, even at normal pressure", async () => {
+	it("hardens the wording when the forecast does not fit, even at normal pressure", async () => {
 		mockedApi.request.getSystemMemory.mockResolvedValue(
 			memory({ pressure: "normal", headroom: 1 * GIB, medianTaskRss: 3 * GIB }),
 		);
 		renderModal(makeProject());
 
 		const banner = await screen.findByTestId("memory-pressure-banner");
-		expect(banner).toHaveTextContent(/does not fit/i);
+		expect(banner).toHaveTextContent(/out of memory/i);
 		expect(banner.className).toContain("border-danger/30");
 	});
 
-	it("omits the forecast when there are no active tasks to learn from", async () => {
+	it("drops the task-count claim when there are no active tasks to learn from", async () => {
 		mockedApi.request.getSystemMemory.mockResolvedValue(
 			memory({ activeTaskCount: 0, tasksRssApprox: 0, medianTaskRss: null }),
 		);
 		renderModal(makeProject());
 
 		const banner = await screen.findByTestId("memory-pressure-banner");
-		expect(banner).toHaveTextContent(/nothing to base a forecast on/i);
-		expect(banner).not.toHaveTextContent(/would need roughly/);
+		expect(banner).toHaveTextContent(/already tight on memory/i);
+		expect(banner).not.toHaveTextContent(/more task/i);
 	});
 
 	it("never blocks the launch — the button stays enabled and still spawns", async () => {

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -190,11 +190,12 @@ const dashboard = {
 	"memory.activeTasks_one": "{count} active task",
 	"memory.activeTasks_other": "{count} active tasks",
 	"memory.approxNote": "Approximate: shared pages are counted once per process, so this overstates.",
-	"memory.bannerHeadline": "{free} of memory left",
-	"memory.bannerSwapping": "The machine is already swapping.",
-	"memory.bannerForecast": "Your active tasks use about {median} each, so {count} more would need roughly {needed}.",
-	"memory.bannerNoForecast": "No tasks are running yet, so there is nothing to base a forecast on.",
-	"memory.bannerWontFit": "That does not fit in what is left.",
+	"memory.bannerSwapping": "It is already swapping to disk.",
+	"memory.bannerTight": "This machine is already tight on memory.",
+	"memory.bannerLoaded_one": "This machine is already loaded — one more task is a lot to ask of it.",
+	"memory.bannerLoaded_other": "This machine is already loaded — {count} more tasks are a lot to ask of it.",
+	"memory.bannerOutOfRoom_one": "This machine is out of memory — one more task will likely make it crawl.",
+	"memory.bannerOutOfRoom_other": "This machine is out of memory — {count} more tasks will likely make it crawl.",
 } as const;
 
 export default dashboard;

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -188,11 +188,12 @@ const dashboard = {
 	"memory.activeTasks_one": "{count} tarea activa",
 	"memory.activeTasks_other": "{count} tareas activas",
 	"memory.approxNote": "Aproximado: las páginas compartidas se cuentan una vez por proceso, así que esto sobreestima.",
-	"memory.bannerHeadline": "Quedan {free} de memoria",
-	"memory.bannerSwapping": "La máquina ya está intercambiando.",
-	"memory.bannerForecast": "Tus tareas activas usan unos {median} cada una, así que {count} más necesitarían aproximadamente {needed}.",
-	"memory.bannerNoForecast": "Aún no hay tareas en ejecución, así que no hay base para un pronóstico.",
-	"memory.bannerWontFit": "Eso no cabe en lo que queda.",
+	"memory.bannerSwapping": "Ya está usando la memoria de intercambio.",
+	"memory.bannerTight": "Esta máquina ya va justa de memoria.",
+	"memory.bannerLoaded_one": "Esta máquina ya está cargada: una tarea más le costará.",
+	"memory.bannerLoaded_other": "Esta máquina ya está cargada: {count} tareas más le costarán.",
+	"memory.bannerOutOfRoom_one": "Esta máquina se ha quedado sin memoria: una tarea más la ralentizará.",
+	"memory.bannerOutOfRoom_other": "Esta máquina se ha quedado sin memoria: {count} tareas más la ralentizarán.",
 };
 
 export default dashboard;

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -208,11 +208,16 @@ const dashboard = {
 	"memory.activeTasks_many": "{count} активных задач",
 	"memory.activeTasks_other": "{count} активных задач",
 	"memory.approxNote": "Приблизительно: общие страницы считаются в каждом процессе, поэтому сумма завышена.",
-	"memory.bannerHeadline": "Свободно {free} памяти",
-	"memory.bannerSwapping": "Машина уже свопит.",
-	"memory.bannerForecast": "Твои активные задачи занимают примерно по {median}, поэтому ещё {count} потребуют около {needed}.",
-	"memory.bannerNoForecast": "Активных задач пока нет, поэтому прогнозировать не от чего.",
-	"memory.bannerWontFit": "В остаток это не влезет.",
+	"memory.bannerSwapping": "Она уже свопит на диск.",
+	"memory.bannerTight": "Машине уже тесно по памяти.",
+	"memory.bannerLoaded_one": "Машина уже нагружена — ещё одну задачу ей будет тяжеловато потянуть.",
+	"memory.bannerLoaded_few": "Машина уже нагружена — ещё {count} задачи ей будет тяжеловато потянуть.",
+	"memory.bannerLoaded_many": "Машина уже нагружена — ещё {count} задач ей будет тяжеловато потянуть.",
+	"memory.bannerLoaded_other": "Машина уже нагружена — ещё {count} задач ей будет тяжеловато потянуть.",
+	"memory.bannerOutOfRoom_one": "Памяти в обрез — ещё одну задачу машина, скорее всего, не потянет.",
+	"memory.bannerOutOfRoom_few": "Памяти в обрез — ещё {count} задачи машина, скорее всего, не потянет.",
+	"memory.bannerOutOfRoom_many": "Памяти в обрез — ещё {count} задач машина, скорее всего, не потянет.",
+	"memory.bannerOutOfRoom_other": "Памяти в обрез — ещё {count} задач машина, скорее всего, не потянет.",
 };
 
 export default dashboard;


### PR DESCRIPTION
The launch-time memory notice (New Task / Launch Variants / Spawn Agent) used to lead with a byte count and a per-task forecast: *"4.1 GB of memory left — your active tasks use about 139 MB each, so 1 more would need roughly 139 MB."* At the moment of deciding whether to start a task, that is arithmetic the user has to do themselves, and it cost the notice two lines — nearly as much vertical space as the variant picker below it.

It now states a verdict in one plain sentence and no byte counts:

- loaded: *"This machine is already loaded — one more task is a lot to ask of it."*
- out of room / critical: *"This machine is out of memory — 3 more tasks will likely make it crawl."*
- no active tasks to learn from: *"This machine is already tight on memory."*
- swapping appends *"It is already swapping to disk."*

The exact figures are unchanged and still one hover away in the header's memory readout. The banner keeps its severity colouring, still never blocks or disables a launch, and shrinks from 62 px to 30 px.

Also in `LaunchVariantsModal`: the `#N` index and the remove `x` now sit in a control-height box, so they read as centred against the pickers instead of riding their top edge.

Verified in headless Chromium by injecting warn / out-of-room memory snapshots into both dialogs; `#N`, the favourites star and the Provider select measure identical top and height. Full suite green.