### PR TITLE
Stop re-offering completion when a merged task is reopened

### DIFF
--- a/change-logs/2026/08/07/fix-no-merge-prompt-after-reopening-a-task.md
+++ b/change-logs/2026/08/07/fix-no-merge-prompt-after-reopening-a-task.md
@@ -1,0 +1,3 @@
+Short: No merge prompt after reopening
+
+Pulling a task back out of Completed no longer greets you with "the branch is already merged — complete the task?" seconds later. The head the task comes back on counts as already answered; work merged after the reopen still offers completion as usual.

--- a/decisions/2026/08/06/reopen-answers-the-merge-prompt-for-its-head.md
+++ b/decisions/2026/08/06/reopen-answers-the-merge-prompt-for-its-head.md
@@ -1,0 +1,45 @@
+# Reopening a task answers the merge prompt for the head it comes back on
+
+## Context
+
+Pulling a task back out of Completed (or Cancelled) recreates its worktree on the
+same branch — which is usually already merged into the base. Both merge surfaces
+then fired within seconds: the 60s merge poller (`checkMergedBranches`) and the
+info panel's 15s branch-status poll, each offering "The branch is in the base
+branch — is the task complete too?". Accepting the prompt earlier does not record
+a dismissal (only "Not now" does), and a task completed by hand records nothing at
+all, so the existing suppression in `shouldSuppressMergePrompt` had nothing to
+match against.
+
+## Decision
+
+`preparationSucceeded` now emits a `dismissMergePromptForCurrentHead` effect when
+the preparation's origin column was terminal and the project is a git project
+(`src/bun/lifecycle/machine.ts`). The executor resolves the fingerprint from git
+HEAD and writes `mergeCompletionPrompt` with `dismissedAt` set, plus an actor
+reservation so the notice-only toast is muted too
+(`src/bun/lifecycle/executor.ts`). `getMergeCompletionFingerprint` moved to
+`src/bun/lifecycle/merge-fingerprint.ts` so the executor can use it without
+importing the poller module.
+
+Scope is deliberately one head: work committed and merged after the reopen has a
+new fingerprint and prompts normally. Setting `manualCompletion` instead would
+silence the task forever, which is a different (user-owned) decision.
+
+## Risks
+
+If HEAD cannot be read the fingerprint falls back to `fallback:<branch>`, which
+suppresses for one hour instead of permanently — the prompt can reappear on a
+reopened task whose worktree git call failed. Reopening a task whose branch is
+*not* merged now also records a dismissal for that head; harmless, because the
+poller only prompts once a merge is detected, and by then the head that merged is
+usually a later one.
+
+## Alternatives considered
+
+- Auto-set `manualCompletion` on reopen — sticky, hides a legitimate prompt after
+  the next real merge, and silently flips a flag the user reads in `task show`.
+- Skip merge detection for N minutes after a reopen — a timer hides the symptom
+  and still prompts once it expires.
+- Suppress prompts on the client after a reopen — leaves the CLI/poller path and
+  a second window prompting anyway.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2389,6 +2389,35 @@ describe("handlers.moveTask", () => {
 		expect(git.createWorktree).toHaveBeenCalled();
 	});
 
+	it("completed → in-progress (reopen): marks the merged head as already answered", async () => {
+		const project = makeProject();
+		const task = makeTask({ status: "completed", worktreePath: null });
+		const updatedTask = makeTask({ status: "in-progress", worktreePath: "/tmp/wt", branchName: "dev3/t" });
+
+		// Writes accumulate so the preparing runId survives into the
+		// preparation-succeeded follow-up — the transition that owns the dismissal.
+		let current = task;
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockImplementation(async () => current);
+		vi.mocked(git.createWorktree).mockResolvedValue({ worktreePath: "/tmp/wt", branchName: "dev3/t" });
+		vi.mocked(git.getHeadSha).mockResolvedValue("abc123");
+		vi.mocked(data.updateTask).mockImplementation(async (_project, taskId, patch) => {
+			current = { ...updatedTask, ...current, ...patch, id: taskId } as Task;
+			return current;
+		});
+
+		await handlers.moveTask({ taskId: "task-1", projectId: "proj-1", newStatus: "in-progress" });
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			mergeCompletionPrompt: {
+				fingerprint: "v1:dev3/t:abc123",
+				promptedAt: expect.any(String),
+				dismissedAt: expect.any(String),
+				precise: true,
+			},
+		});
+	});
+
 	it("in-progress → completed: destroys PTY, runs cleanup, removes worktree", async () => {
 		const project = makeProject();
 		const task = makeTask({ status: "in-progress", worktreePath: "/tmp/wt" });
@@ -10731,6 +10760,71 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 			shouldNotify,
 		}));
 		expect(data.updateTask).not.toHaveBeenCalled();
+	});
+
+	it("stays quiet for a task the user pulled back out of Completed on the same merged head", async () => {
+		const project = makeProject();
+		const dismissedAt = new Date().toISOString();
+		const task = makeTask({
+			status: "review-by-user",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+			// What the reopen writes: this head was already answered.
+			mergeCompletionPrompt: {
+				fingerprint: "v1:dev3/task-test:abc123",
+				promptedAt: dismissedAt,
+				dismissedAt,
+				precise: true,
+			},
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).not.toHaveBeenCalledWith("branchMerged", expect.anything());
+	});
+
+	it("offers completion again once the reopened task merges new work", async () => {
+		const project = makeProject();
+		const dismissedAt = new Date().toISOString();
+		const task = makeTask({
+			status: "review-by-user",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+			// Dismissed for the head the task was reopened on; HEAD has moved since.
+			mergeCompletionPrompt: {
+				fingerprint: "v1:dev3/task-test:oldhead",
+				promptedAt: dismissedAt,
+				dismissedAt,
+				precise: true,
+			},
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).toHaveBeenCalledWith("branchMerged", expect.objectContaining({
+			taskId: task.id,
+			fingerprint: "v1:dev3/task-test:abc123",
+		}));
 	});
 
 	it("compares PR-review tasks against the project base branch, not the reviewed branch itself", async () => {

--- a/src/bun/lifecycle/__tests__/machine.test.ts
+++ b/src/bun/lifecycle/__tests__/machine.test.ts
@@ -343,6 +343,78 @@ describe("task lifecycle transition table", () => {
 		});
 	});
 
+	it("silences the merge prompt for the head a reopened task comes back on", () => {
+		const preparing = state("review-by-user", {
+			runtime: {
+				phase: "preparing",
+				stage: "creating-worktree",
+				runId: "reopen-run",
+				origin: { status: "completed", customColumnId: null },
+			},
+		});
+		const prepared = transition(preparing, {
+			type: "preparationSucceeded",
+			runId: "reopen-run",
+			worktreePath: "/tmp/reopened",
+			branchName: "fix/thing",
+			origin: { status: "completed", customColumnId: null },
+			target: { status: "review-by-user", customColumnId: null },
+			mode: "activation",
+		});
+
+		expect(prepared.effects.some((effect) => effect.type === "dismissMergePromptForCurrentHead")).toBe(true);
+	});
+
+	it("leaves the merge prompt alone when a To Do task is started for the first time", () => {
+		const preparing = state("in-progress", {
+			runtime: {
+				phase: "preparing",
+				stage: "creating-worktree",
+				runId: "first-run",
+				origin: { status: "todo", customColumnId: null },
+			},
+		});
+		const prepared = transition(preparing, {
+			type: "preparationSucceeded",
+			runId: "first-run",
+			worktreePath: "/tmp/fresh",
+			branchName: "feat/thing",
+			origin: { status: "todo", customColumnId: null },
+			target: { status: "in-progress", customColumnId: null },
+			mode: "activation",
+		});
+
+		expect(prepared.effects.some((effect) => effect.type === "dismissMergePromptForCurrentHead")).toBe(false);
+	});
+
+	it("skips the reopen dismissal for a virtual project with no branch to merge", () => {
+		const preparing = state("review-by-user", {
+			runtime: {
+				phase: "preparing",
+				stage: "creating-worktree",
+				runId: "reopen-run",
+				origin: { status: "completed", customColumnId: null },
+			},
+			facts: {
+				hasWorktree: true,
+				projectKind: "virtual",
+				hasPrIdentity: false,
+				peerReviewEnabled: true,
+			},
+		});
+		const prepared = transition(preparing, {
+			type: "preparationSucceeded",
+			runId: "reopen-run",
+			worktreePath: "/tmp/ops",
+			branchName: null,
+			origin: { status: "completed", customColumnId: null },
+			target: { status: "review-by-user", customColumnId: null },
+			mode: "activation",
+		});
+
+		expect(prepared.effects.some((effect) => effect.type === "dismissMergePromptForCurrentHead")).toBe(false);
+	});
+
 	it("clears a deleted custom column without launching the underlying built-in agent", () => {
 		const current = state("review-by-ai", {
 			column: { status: "review-by-ai", customColumnId: "obsolete-column" },

--- a/src/bun/lifecycle/activities.ts
+++ b/src/bun/lifecycle/activities.ts
@@ -27,10 +27,10 @@ import {
 	wasAsleep,
 } from "../rpc-handlers/git-poll-throttle";
 import {
-	type MergeCompletionFingerprint,
 	MERGE_PROMPT_RETRY_SUPPRESS_MS,
 	shouldSuppressMergePrompt,
 } from "./merge-prompt";
+import { getMergeCompletionFingerprint } from "./merge-fingerprint";
 import {
 	computeSignalKey,
 	countUnresolvedReviewThreads,
@@ -73,23 +73,6 @@ function isPromptReserved(taskId: string, fingerprint: string, nowMs: number): b
 		return false;
 	}
 	return true;
-}
-
-export async function getMergeCompletionFingerprint(task: Pick<Task, "id" | "worktreePath" | "branchName">, branchName: string | null): Promise<MergeCompletionFingerprint> {
-	const resolvedBranchName = branchName || task.branchName || task.id;
-	if (task.worktreePath) {
-		const headSha = await git.getHeadSha(task.worktreePath);
-		if (headSha) {
-			return {
-				fingerprint: `v1:${resolvedBranchName}:${headSha}`,
-				precise: true,
-			};
-		}
-	}
-	return {
-		fingerprint: `fallback:${resolvedBranchName}`,
-		precise: false,
-	};
 }
 
 export async function prepareMergeCompletionPrompt(params: { taskId: string; projectId: string; fingerprint?: string | null; force?: boolean }): Promise<{ shouldPrompt: boolean; fingerprint: string | null; shouldNotify?: boolean }> {

--- a/src/bun/lifecycle/effects.ts
+++ b/src/bun/lifecycle/effects.ts
@@ -107,6 +107,9 @@ export type LifecycleEffect =
 	| ({ type: "persistPreparationFailure"; error: string | null } & EffectPolicy)
 	| ({ type: "persistMergePrompt"; fingerprint: string; precise: boolean; promptedAt?: string } & EffectPolicy)
 	| ({ type: "persistMergeDismissal"; fingerprint: string; precise: boolean; dismissedAt: string } & EffectPolicy)
+	// Same dismissal, but for the head only the executor can fingerprint because
+	// it has to read git HEAD in the worktree.
+	| ({ type: "dismissMergePromptForCurrentHead" } & EffectPolicy)
 	| ({ type: "persistPrStatus"; payload: unknown } & EffectPolicy)
 	| ({ type: "launchColumnAgent"; column: LifecycleColumn } & EffectPolicy)
 	| ({ type: "notifyStatusChange"; from: TaskStatus; to: TaskStatus } & EffectPolicy)

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -62,6 +62,7 @@ import {
 } from "../rpc-handlers/shared";
 import { assertPosixLaunchDialect, launchDialect } from "../../shared/platform-launch";
 import type { LifecycleEffect } from "./effects";
+import { getMergeCompletionFingerprint } from "./merge-fingerprint";
 import type {
 	LifecycleColumn,
 	LifecycleEvent,
@@ -1062,6 +1063,20 @@ export async function executeLifecycleEffect(
 				},
 			});
 			ctx.stateTask = ctx.task;
+			return {};
+		}
+		case "dismissMergePromptForCurrentHead": {
+			const { fingerprint, precise } = await getMergeCompletionFingerprint(ctx.task, ctx.task.branchName);
+			const dismissedAt = new Date().toISOString();
+			const updates: Partial<Task> = {
+				mergeCompletionPrompt: { fingerprint, promptedAt: dismissedAt, dismissedAt, precise },
+			};
+			const persisted = await data.updateTask(ctx.project, ctx.task.id, updates);
+			ctx.task = taskAfterPersistedUpdate(ctx.task, persisted, updates);
+			ctx.stateTask = ctx.task;
+			// The persisted dismissal covers the prompt; the reservation also mutes the
+			// passive "branch merged" toast the notice-only path would still raise.
+			ctx.hooks.reserveMergePrompt(ctx.task.id, fingerprint, Date.parse(dismissedAt));
 			return {};
 		}
 		case "persistPrStatus": {

--- a/src/bun/lifecycle/machine.ts
+++ b/src/bun/lifecycle/machine.ts
@@ -569,6 +569,13 @@ export function transition(state: LifecycleState, event: LifecycleEvent): Transi
 						origin: event.origin,
 						target: event.target,
 					}),
+					// Pulling a task back out of Completed is an explicit "I want to do more
+					// here" — the branch is still merged, so without this the merge poller
+					// re-offers completion seconds later (issue: prompt on reopen). Only
+					// this head is silenced: work merged after the reopen prompts again.
+					...(TERMINAL_STATUSES.has(event.origin.status) && state.facts.projectKind === "git"
+						? [effect({ type: "dismissMergePromptForCurrentHead" })]
+						: []),
 					effect({ type: "push", message: "taskUpdated", view: "current" }),
 					...(!event.columnReserved
 						? [effect({ type: "notifyStatusChange", from: event.origin.status, to: state.column.status })]

--- a/src/bun/lifecycle/merge-fingerprint.ts
+++ b/src/bun/lifecycle/merge-fingerprint.ts
@@ -1,0 +1,28 @@
+import type { Task } from "../../shared/types";
+import * as git from "../git";
+import type { MergeCompletionFingerprint } from "./merge-prompt";
+
+/**
+ * Identity of "this exact merged head", used to decide whether a merge-completion
+ * prompt for it was already answered. Lives apart from the pollers so the
+ * lifecycle executor can reuse it without importing the activity module.
+ */
+export async function getMergeCompletionFingerprint(
+	task: Pick<Task, "id" | "worktreePath" | "branchName">,
+	branchName: string | null,
+): Promise<MergeCompletionFingerprint> {
+	const resolvedBranchName = branchName || task.branchName || task.id;
+	if (task.worktreePath) {
+		const headSha = await git.getHeadSha(task.worktreePath);
+		if (headSha) {
+			return {
+				fingerprint: `v1:${resolvedBranchName}:${headSha}`,
+				precise: true,
+			};
+		}
+	}
+	return {
+		fingerprint: `fallback:${resolvedBranchName}`,
+		precise: false,
+	};
+}

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -30,12 +30,12 @@ import { lifecycleActorRuntime } from "../lifecycle/service";
 import {
 	PR_DETECTION_TIMEOUT_MS,
 	dismissMergeCompletionPrompt,
-	getMergeCompletionFingerprint,
 	persistProjectPrIdentities,
 	persistTaskPrIdentity,
 	prepareMergeCompletionPrompt,
 	refreshTaskPrStatus,
 } from "../lifecycle/activities";
+import { getMergeCompletionFingerprint } from "../lifecycle/merge-fingerprint";
 
 /**
  * Reject git-only RPCs for virtual (Operations) tasks. They have a working dir


### PR DESCRIPTION
Pulling a task back out of Completed (or Cancelled) recreates its worktree on the same, usually already-merged branch — so both merge surfaces (the 60s merge poller and the info panel's 15s branch-status poll) offered "The branch is in the base branch — is the task complete too?" within seconds. Reopening is an explicit "I want to do more here", so the prompt is pure noise there.

The existing suppression keys on a recorded dismissal for that exact head, and nothing recorded one: accepting the prompt does not (only "Not now" does), and a task completed by hand records nothing at all.

`preparationSucceeded` now emits a `dismissMergePromptForCurrentHead` effect when the preparation's origin column was terminal and the project is a git project. The executor resolves the fingerprint from git HEAD, writes `mergeCompletionPrompt` with `dismissedAt`, and reserves it so the notice-only toast is muted too. `getMergeCompletionFingerprint` moved to `src/bun/lifecycle/merge-fingerprint.ts` so the executor can use it without importing the poller module.

Scope is deliberately one head: work committed and merged after the reopen has a new fingerprint and prompts as usual. Setting `manualCompletion` instead would silence the task forever, which is a different, user-owned decision. Rationale and alternatives in the `reopen-answers-the-merge-prompt-for-its-head` decision record.

**Gate.** Full suite green on f20797c8d: lint clean, mainview 3713/0, backend 5354/0 (3 skipped), cli 764/0 — one `bun run test` after rebasing onto 7d6f66c65 and `bun install --frozen-lockfile`.

Context for earlier, noisier runs on older shas, none of which is offered in place of that green: this machine was running a dozen worktrees' suites in parallel, load average measured between 30 and 162 against 16 cores, and the failures it produced were confined to the git temp-repo suites with timeout signatures (11s durations, no assertion messages) and a floating count on identical bytes (1, then 0, then 39). One earlier backend run had a single unidentified failure plus a second suite that failed with no test-level failure — the hook/timeout signature rather than an assertion; the run's log is a single-line JSON reporter dump truncated at 1 MiB, so neither can be named.