### PR TITLE
Publish the unstable channel hourly and enable the channel control

### DIFF
--- a/.github/workflows/release-build-linux.yml
+++ b/.github/workflows/release-build-linux.yml
@@ -110,7 +110,7 @@ jobs:
           bun scripts/generate-changelog.ts
           bunx vite build
           bun run build:cli
-          bunx electrobun build --env=stable || echo "::warning::electrobun build exited with $? (recovering artifacts)"
+          bunx electrobun build --env=${{ inputs.channel }} || echo "::warning::electrobun build exited with $? (recovering artifacts)"
 
       - name: Debug build output
         if: always()

--- a/.github/workflows/release-build-macos.yml
+++ b/.github/workflows/release-build-macos.yml
@@ -151,7 +151,7 @@ jobs:
           bun scripts/generate-changelog.ts
           bunx vite build
           bun run build:cli
-          bunx electrobun build --env=stable || echo "::warning::electrobun build exited with $? (recovering artifacts)"
+          bunx electrobun build --env=${{ inputs.channel }} || echo "::warning::electrobun build exited with $? (recovering artifacts)"
 
       - name: Debug build output
         if: always()

--- a/.github/workflows/unstable-publish.yml
+++ b/.github/workflows/unstable-publish.yml
@@ -1,0 +1,148 @@
+name: Unstable publish
+
+# The unstable channel's feed. No tag: versioning belongs to the human, so this publishes
+# whatever `main` is at, ordered by the monotonic `buildOrder` in the manifest rather than
+# by the version string. See decisions/2026/08/06/stable-unstable-update-channels.md.
+#
+# HOURLY-IF-MAIN-MOVED, NOT PER MERGE. Merges land in batches of four or five back to back,
+# so per-push meant four wasted sign-and-notarize cycles for one meaningful artifact. A cron
+# that compares a sha has no burst to collapse, which is also why there is no
+# `cancel-in-progress` here.
+#
+# Scheduled workflows are BEST EFFORT and can fire late. A missed tick is harmless: the next
+# one still sees the sha mismatch and builds, so no commit is ever permanently unpublished.
+on:
+  schedule:
+    # Offset off the hour: the top of the hour is the busiest slot on shared runners.
+    - cron: "23 * * * *"
+  # Safe to press on an unchanged `main`: every platform skips, and a republish of the same
+  # commit reproduces the same `buildOrder` so clients would not reinstall anyway.
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Publish every platform without comparing the feed (seeds a channel that has never published)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────────
+  # Has main moved since the last publish, per platform?
+  # ──────────────────────────────────────────────────
+  decide:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      macos-arm64: ${{ steps.probe.outputs.macos-arm64 }}
+      macos-x64: ${{ steps.probe.outputs.macos-x64 }}
+      linux-x64: ${{ steps.probe.outputs.linux-x64 }}
+      linux-arm64: ${{ steps.probe.outputs.linux-arm64 }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      # No `bun install`: the script imports only src/shared, so this job stays seconds long
+      # in front of four sign-and-notarize cycles.
+      #
+      # THE SAME CREDENTIALS THE BUILDS PUBLISH WITH, and the reason is not convenience. The
+      # bucket grants no anonymous `s3:ListBucket`, so an unauthenticated GET answers 403 for
+      # a key that does not exist — indistinguishable from a policy failure, which this
+      # workflow (correctly) refuses to build on. Probing anonymously therefore made the first
+      # publish unreachable: 403 → refuse → no manifest → 403 again, every hour, forever.
+      - name: Probe the published unstable feed
+        id: probe
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: eu-west-1
+          FORCE_PUBLISH: ${{ inputs.force }}
+        run: bun scripts/decide-unstable-publish.ts
+
+  # ──────────────────────────────────────────────────
+  # The packaged Windows proof gates every publisher
+  # ──────────────────────────────────────────────────
+  # `workflow-windows-proof.test.ts` asserts that every job syncing the feed depends on this,
+  # and that assertion is enumerated across the whole workflow directory precisely so a NEW
+  # publisher like this one cannot skip it. A Windows failure must not land a partial ship.
+  # See decisions/2026/08/06/windows-proof-post-merge-not-pull-request.md.
+  #
+  # NOT SCOPED BY CHANGED PATHS, unlike the post-merge proof — there is no pushed range here.
+  # Scoped instead by whether anything publishes at all: on a quiet hour every platform skips,
+  # so a full Windows packaging run would gate nothing. The condition must name EVERY output
+  # `decide` emits; a platform missing from it silently loses its gate, which is why
+  # unstable-publish.test.ts derives the list from UNSTABLE_PLATFORMS rather than trusting it.
+  windows-proof:
+    needs: decide
+    if: >-
+      needs.decide.outputs.macos-arm64 == 'true' ||
+      needs.decide.outputs.macos-x64 == 'true' ||
+      needs.decide.outputs.linux-x64 == 'true' ||
+      needs.decide.outputs.linux-arm64 == 'true'
+    uses: ./.github/workflows/windows-conpty-package.yml
+
+  # ──────────────────────────────────────────────────
+  # Per-platform builds — each one skipped independently
+  # ──────────────────────────────────────────────────
+  # `tag` is the SHORT SHA, not a version. There is no tag on this path, and passing a
+  # constant like "unstable" would overwrite one archive prefix forever; the short sha makes a
+  # specific unstable build fetchable after the root feed has moved on. The versioned prefix
+  # therefore grows per commit and has NO retention policy today — named rather than implied.
+  #
+  # `publish: true` is a literal here, unlike release.yml's dry-run comparison: this workflow
+  # exists only to publish, and it has no dry-run path. `workflow_dispatch` on an unchanged
+  # main is made safe by the skip above, not by withholding the upload.
+  build-macos-arm64:
+    needs: [decide, windows-proof]
+    if: needs.decide.outputs.macos-arm64 == 'true'
+    uses: ./.github/workflows/release-build-macos.yml
+    secrets: inherit
+    with:
+      arch: arm64
+      runsOn: macos-15
+      channel: unstable
+      tag: ${{ github.sha }}
+      publish: true
+
+  build-macos-x64:
+    needs: [decide, windows-proof]
+    if: needs.decide.outputs.macos-x64 == 'true'
+    uses: ./.github/workflows/release-build-macos.yml
+    secrets: inherit
+    with:
+      arch: x64
+      runsOn: macos-15-intel
+      channel: unstable
+      tag: ${{ github.sha }}
+      publish: true
+
+  build-linux-x64:
+    needs: [decide, windows-proof]
+    if: needs.decide.outputs.linux-x64 == 'true'
+    uses: ./.github/workflows/release-build-linux.yml
+    secrets: inherit
+    with:
+      arch: x64
+      runsOn: ubuntu-22.04
+      channel: unstable
+      tag: ${{ github.sha }}
+      publish: true
+      bestEffort: false
+
+  build-linux-arm64:
+    needs: [decide, windows-proof]
+    if: needs.decide.outputs.linux-arm64 == 'true'
+    uses: ./.github/workflows/release-build-linux.yml
+    secrets: inherit
+    with:
+      arch: arm64
+      runsOn: ubuntu-22.04-arm
+      channel: unstable
+      tag: ${{ github.sha }}
+      publish: true
+      bestEffort: true

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
@@ -1424,7 +1427,7 @@
 
     "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
 
-    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
@@ -1790,7 +1793,6 @@
 
     "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
-
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1927,13 +1929,13 @@
 
     "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
-    "png-to-ico/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "qrcode/pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 

--- a/change-logs/2026/08/08/feature-02-stable-unstable-update-channels.md
+++ b/change-logs/2026/08/08/feature-02-stable-unstable-update-channels.md
@@ -1,0 +1,3 @@
+Short: Choose stable or unstable updates
+
+Settings → System now lets you pick which builds you get. Stable ships only when a release is tagged, which is what everyone was already on; unstable publishes from main roughly hourly, so you see features the day they land. Switching either way keeps your board, your tasks and your settings — and switching back to stable while it is behind installs the older build, which the confirmation says out loud before you commit to it.

--- a/decisions/2026/08/06/stable-unstable-update-channels.md
+++ b/decisions/2026/08/06/stable-unstable-update-channels.md
@@ -108,6 +108,112 @@ stable version — expected, and `doctor` already says so. An explicit
 `brew upgrade --cask dev3` pulls an unstable user back to stable; that is acceptable because it is
 explicit, and the in-app setting still says unstable, so the next check offers the switch again.
 
+**How the bundle learns it is unstable: a one-line vendored patch, not a fork.** electrobun's CLI
+gates `--env` on `["dev","canary","stable"].includes(envArg) ? envArg : "dev"` (`src/cli/index.ts`)
+— so the obvious `--env=unstable` does not fail, it **silently produces a dev build**. That
+mechanism is the useful part: a future agent will otherwise try the obvious flag and ship a dev
+bundle wearing an unstable name.
+
+Everything below that check is already channel-generic — `getAppFileName`, `getPlatformPrefix`, the
+DMG volume name, the patch naming — and electrobun's own type is
+`BuildEnvironment = "stable" | "canary" | "dev" | (string & {})`, which **explicitly admits arbitrary
+strings**. So `patches/electrobun@1.18.1.patch` does not extend electrobun; it removes a check that
+contradicts electrobun's own type. This is the repo's first patched dependency.
+
+*Why not patch `version.json` after the build instead?* Because there is nothing left to patch:
+electrobun computes the bundle hash, writes `version.json`, tars the bundle, and then **deletes the
+bundle folder** on every non-dev build. The outer self-extracting wrapper carries its own
+`metadata.json` with a `channel` field and is code-signed and notarized. So "just patch the file"
+means untar, patch, re-tar, re-compress, patch the wrapper, re-sign and **re-notarize** — putting
+Apple's notary service on the hot path of an hourly job. Worth recording separately, because it took
+reading to establish: **the hash is computed BEFORE `version.json` is written, so `version.json` is
+not part of the hash** and editing it can never invalidate a bundle.
+
+*Why not publish unstable under the existing `canary` prefix?* It would need no patch at all, and it
+was rejected: it resurrects the name this change deletes, in the bucket **and** inside the bundle,
+and every future reader has to learn that canary means unstable. A stored lie costs more than a
+maintained patch — the patch is visible in `package.json`, the lie is visible only to whoever
+already knows it.
+
+**A lapsed patch must be RED, not silent**, because the failure mode is a dev build published under
+an unstable name: it polls the wrong feed and never updates, and nothing logs it. Three guards:
+
+| Guard | Catches |
+|---|---|
+| `electrobun-channel-patch.test.ts` reads the INSTALLED dependency | patch not declared for the pinned version · declared but not applied · list replaced rather than extended |
+| `create-release-artifacts.sh` compares `version.json`'s channel with its channel argument | a build that succeeded on the wrong channel |
+| the same script's early check for `./build/dev-*` next to a missing `./build/<channel>-*` | names the degradation instead of surfacing later as "build failed before tarring" |
+
+**EXPIRY: this patch dies when electrobun accepts arbitrary channel strings in the CLI**, matching
+its own `BuildEnvironment` type. It touches exactly one place — the `--env` allowlist in
+`src/cli/index.ts` — so that is where an upgrade should look.
+
+**Reported upstream: blackboardsh/electrobun#517.** Searched first — the closest existing issues are
+#261 (reading env inside `electrobun.config.ts`) and #432 (detecting dev vs packaged at runtime), and
+neither covers the `--env` allowlist. The report carries the four facts above plus the ask that
+matters more than accepting custom channels: **fail loudly on an unknown `--env` instead of degrading
+to `dev`.** If either lands, this patch deletes itself.
+
+**The publisher: hourly if `main` moved, decided PER PLATFORM.** `unstable-publish.yml` probes the
+already-published `unstable-{os}-{arch}-update.json` and compares its `sha` with `main`. Per platform
+on purpose: a run that publishes three of four self-heals on the next tick, where one shared decision
+would skip the fourth forever because `main` had not moved. `tag` is the **short sha** — there is no
+tag on this path, and a constant would overwrite one archive prefix forever; the versioned prefix
+therefore grows per commit with **no retention policy today**, stated rather than implied.
+
+**ABSENT means build, UNDECIDABLE means fail** — and the probe, not the decision, is what has to
+tell them apart. Mapping an unproven absence to "absent" turns one bucket-policy change into a full
+sign-and-notarize cycle every hour, forever; mapping it to "present" stops publishing forever. Both
+are silent, so the decision refuses and quotes what the probe actually saw.
+
+**The first version of that probe could never bootstrap, and the live bucket is what proved it.**
+The probe was an anonymous GET, on the belief that a missing key answers 404. It does not here.
+`h0x91b-releases` grants no anonymous `s3:ListBucket`, so a missing key answers **403 AccessDenied**
+— measured, with a deliberately invented key as the control, while `stable-macos-arm64-update.json`
+answered 200 from the same caller. The consequence is a closed loop, not a risk: 403 → refuse to
+build → no manifest is ever written → 403 again, every hour, forever, red every time. It would have
+merged green: the unit tests all passed, because they tested the *rule* and the rule was right.
+
+The fix is to probe **with the publishing credentials** (`aws s3 cp` through the CLI), where a
+missing key answers a clean 404 and `absent` is a fact rather than a guess. That fixes the class
+rather than the instance — a one-off seeding, by hand or by a `force` flag, would have left "no key"
+and "no access" looking identical forever, and the next new platform would hit the same wall without
+this conversation in anyone's memory. `FeedProbe` is therefore a union (`absent` / `present` /
+`undecidable`) rather than an HTTP status: the type no longer lets a caller pass a status it cannot
+interpret.
+
+A `force` input on `workflow_dispatch` survives as the escape hatch — the only way out if the probe
+itself cannot run — and a forced run emits `::warning::FORCED` naming that nothing was compared, so
+it cannot be mistaken in the log for a normal publish. Four assertions pin all of this: the probe is
+authenticated, no `fetch(` returns to it, the credentials reach the step, and the escape exists and
+is wired. All four were mutation-proved.
+
+**AN INVARIANT OVER A DIRECTORY COVERS CODE NOBODY HAS WRITTEN YET.** This publisher is the
+proof rather than the theory: the assertion that every feed publisher is gated by the packaged
+Windows proof is enumerated across the whole workflow directory, so it applied to
+`unstable-publish.yml` the moment the file existed — and it was verified by mutation, removing
+`windows-proof` from one caller's `needs`, which turned it red naming the job. A single-file
+assertion would have been **silent** here, because this file did not exist when the assertion was
+written. That is what buys the small noise a directory-scoped check adds to every unrelated
+workflow edit.
+
+**Cost accepted, but only on hours that publish.** The packaged Windows proof gates this publisher
+too, as it gates every job that syncs the feed. So an hour in which `main` moved pays for the proof
+as well as four builds — the guardrail working as designed, and not free.
+
+It first shipped **unconditional**, on the reasoning that unlike the post-merge proof there is no
+pushed range to scope against. True, and beside the point: the thing to scope against is not a
+changed-path set but *whether anything publishes at all*. `main` is quiet most hours, and on a quiet
+hour every platform skips, so the proof gated nothing and still packaged Windows — roughly 24 runs a
+day, all of them gating an empty set. It now carries `if:` over the four `decide` outputs.
+
+The failure mode of that condition is silent in both directions, so it is pinned by two assertions
+in `unstable-publish.test.ts`: one that the `if:` exists at all, and one that derives the platform
+list from `UNSTABLE_PLATFORMS` rather than re-typing it. A fifth platform added to `decide` but not
+to the condition would leave the proof skipped on its hour — and GitHub skips a job whose `needs`
+was skipped, so that platform's build would skip too and it would stop publishing entirely, with
+nothing red anywhere. Both mutations were run and both fail naming the platform.
+
 **In-place switching is macOS-only, and says so.** `Updater.appDataFolder()` is
 `{appData}/{identifier}/{channel}`. On macOS that folder is only download scratch and the swap
 targets `process.execPath`, so retargeting the cached `localInfo` is coherent. On Linux and

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
 		"typescript": "6.0.3",
 		"vite": "8.0.13",
 		"vitest": "4.1.6"
+	},
+	"patchedDependencies": {
+		"electrobun@1.18.1": "patches/electrobun@1.18.1.patch"
 	}
 }

--- a/patches/electrobun@1.18.1.patch
+++ b/patches/electrobun@1.18.1.patch
@@ -1,0 +1,15 @@
+diff --git a/src/cli/index.ts b/src/cli/index.ts
+index 88cf526df431ba65071c5d0fb82b6855c5e0b186..9c97a7b7b315d5c505349334aaea0c10ce0c2c74 100644
+--- a/src/cli/index.ts
++++ b/src/cli/index.ts
+@@ -2078,7 +2078,9 @@ ${utiDecls}
+ 		// Get environment
+ 		const envArg =
+ 			process.argv.find((arg) => arg.startsWith("--env="))?.split("=")[1] || "";
+-		const buildEnvironment = ["dev", "canary", "stable"].includes(envArg)
++		const buildEnvironment = ["dev", "canary", "stable", "unstable"].includes(
++			envArg,
++		)
+ 			? envArg
+ 			: "dev";
+ 

--- a/scripts/create-release-artifacts.sh
+++ b/scripts/create-release-artifacts.sh
@@ -55,6 +55,18 @@ BUILD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_ORDER=$(git rev-list --count HEAD 2>/dev/null || echo "0")
 echo "Manifest identity: sha=${BUILD_SHA} buildOrder=${BUILD_ORDER}"
 
+# THE CHEAP HALF OF THE CHANNEL CHECK, and it runs on every path.
+# electrobun names its build folder after the channel, so `./build/dev-*` existing while
+# `./build/unstable-*` does not is the exact fingerprint of a SILENT degradation: electrobun
+# gates `--env` on an allowlist and falls back to "dev" outside it, and "unstable" is
+# admitted only by a vendored one-line patch. Without this, a lapsed patch surfaces later as
+# "build failed before tarring", which sends the operator to debug the wrong thing.
+if [ ! -d "$BUILD_DIR" ] && [ -d "./build/dev-${OS}-${ARCH}" ]; then
+  echo "::error::expected ${BUILD_DIR} but found ./build/dev-${OS}-${ARCH} — electrobun REJECTED --env=${CHANNEL} and silently fell back to a dev build."
+  echo "::error::Likely cause: the vendored electrobun patch (patches/electrobun@*.patch — the --env allowlist in src/cli/index.ts) stopped applying, usually after an upgrade. Fix: re-apply it, or delete it if electrobun now accepts arbitrary channel strings."
+  exit 1
+fi
+
 # Platform-specific settings
 if [ "$OS" = "macos" ]; then
   APP_BUNDLE="${APP_FILE_NAME}.app"
@@ -232,6 +244,19 @@ VERSION_JSON=$(find_version_json "$RECOVER_DIR")
 HASH=$(bun -e "const j=await Bun.file('${VERSION_JSON}').json();console.log(j.hash)")
 VERSION=$(bun -e "const j=await Bun.file('${VERSION_JSON}').json();console.log(j.version)")
 echo "Bundle hash: $HASH, version: $VERSION"
+
+# THE BUILT ARTIFACT MUST AGREE WITH THE CHANNEL WE ARE PUBLISHING IT AS.
+# electrobun gates `--env` on an allowlist and falls back to "dev" SILENTLY outside it;
+# "unstable" is admitted by a vendored one-line patch. If that patch ever stops applying —
+# an upgrade is the likely cause — the build still succeeds, produces a DEV bundle, and
+# without this check it would be published under unstable-* names: it would poll the wrong
+# feed and never update again, with nothing in any log saying so.
+BUNDLE_CHANNEL=$(bun -e "const j=await Bun.file('${VERSION_JSON}').json();console.log(j.channel)")
+if [ "$BUNDLE_CHANNEL" != "$CHANNEL" ]; then
+  echo "::error::bundle was built for channel '${BUNDLE_CHANNEL}' but is being published as '${CHANNEL}'"
+  echo "::error::'${BUNDLE_CHANNEL}' = 'dev' means electrobun REJECTED --env=${CHANNEL} and silently degraded. Likely cause: the vendored patch (patches/electrobun@*.patch — the --env allowlist in src/cli/index.ts) stopped applying after an upgrade. Fix: re-apply it, or delete it if electrobun now accepts arbitrary channel strings."
+  exit 1
+fi
 
 # Create update.json
 echo "{\"version\":\"${VERSION}\",\"hash\":\"${HASH}\",\"os\":\"${OS}\",\"arch\":\"${ARCH}\",\"sha\":\"${BUILD_SHA}\",\"buildOrder\":${BUILD_ORDER},\"changelog\":${CHANGELOG_JSON}}" \

--- a/scripts/decide-unstable-publish.ts
+++ b/scripts/decide-unstable-publish.ts
@@ -1,0 +1,82 @@
+/**
+ * Probes the published unstable feed and writes one GitHub output per platform.
+ *
+ * Thin on purpose: every rule lives in `src/shared/unstable-publish.ts` where it is unit
+ * tested, and this file only does the I/O — read the object, print, write outputs, set the
+ * exit code.
+ *
+ * THE READ IS AUTHENTICATED, and that is not an implementation detail. `h0x91b-releases`
+ * grants no anonymous `s3:ListBucket`, so an anonymous GET for a key that does not exist
+ * answers **403 AccessDenied**, exactly like a key hidden behind a broken policy — measured
+ * against the live bucket, including a deliberately invented key. Probing that way made the
+ * bootstrap unreachable: 403 is (correctly) refused, no build runs, no manifest appears, and
+ * the next hour reads 403 again, forever. Reading with the publishing credentials makes a
+ * missing key answer 404, so "absent" is a fact rather than a guess.
+ */
+
+import { appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { decidePlatformPublish, UNSTABLE_PLATFORMS, type FeedProbe } from "../src/shared/unstable-publish";
+
+const BUCKET_PREFIX = "s3://h0x91b-releases/dev-3.0";
+
+const headSha = process.env.GITHUB_SHA ?? "";
+if (!headSha) {
+	console.error("::error::GITHUB_SHA is unset, so there is nothing to compare the feed against");
+	process.exit(1);
+}
+
+/**
+ * Bootstrap escape, used when the feed genuinely has nothing yet and a human says so.
+ * Deliberately NOT a code path that can decide on its own: it is a `workflow_dispatch`
+ * input, so pressing it is an act, and the run says loudly that nothing was compared.
+ */
+const forced = process.env.FORCE_PUBLISH === "true";
+
+/** One authenticated read. Absent is claimed only on an explicit 404 / NoSuchKey. */
+function probe(os: string, arch: string): FeedProbe {
+	const result = spawnSync(
+		"aws",
+		["s3", "cp", `${BUCKET_PREFIX}/unstable-${os}-${arch}-update.json`, "-"],
+		{ encoding: "utf8" },
+	);
+	if (result.error) {
+		return { kind: "undecidable", detail: `the aws CLI could not be run: ${result.error.message}` };
+	}
+	if (result.status === 0) return { kind: "present", body: result.stdout };
+
+	const stderr = (result.stderr || "").trim();
+	if (/\b404\b|NoSuchKey|Not Found|does not exist/i.test(stderr)) return { kind: "absent" };
+	return { kind: "undecidable", detail: stderr || `aws exited ${result.status} without saying why` };
+}
+
+const outputPath = process.env.GITHUB_OUTPUT;
+let failures = 0;
+let builds = 0;
+
+for (const { os, arch } of UNSTABLE_PLATFORMS) {
+	const key = `${os}-${arch}`;
+	const decision = forced
+		? ({ build: true, reason: "forced by workflow_dispatch — the feed was NOT compared" } as const)
+		: decidePlatformPublish(probe(os, arch), headSha);
+
+	if ("error" in decision) {
+		console.error(`::error::${key}: ${decision.error}`);
+		failures++;
+		continue;
+	}
+	console.log(`${key}: ${decision.build ? "BUILD" : "skip"} — ${decision.reason}`);
+	if (decision.build) builds++;
+	if (outputPath) appendFileSync(outputPath, `${key}=${decision.build}\n`);
+}
+
+if (forced) {
+	console.log("::warning::FORCED publish — every platform builds and nothing was compared against the feed. Use this only to seed a channel that has never published.");
+}
+if (failures > 0) {
+	console.error(`::error::${failures} of ${UNSTABLE_PLATFORMS.length} platforms could not be decided — refusing to publish a partial guess`);
+	process.exit(1);
+}
+if (!forced && builds === 0) {
+	console.log("::notice::main has not moved since the last unstable publish on any platform — nothing to build");
+}

--- a/src/bun/__tests__/create-release-artifacts.test.ts
+++ b/src/bun/__tests__/create-release-artifacts.test.ts
@@ -138,7 +138,7 @@ describe("create-release-artifacts.sh", () => {
 		mkdirSync(join(buildDir, "payload", "Contents", "Resources"), { recursive: true });
 		writeFileSync(
 			join(buildDir, "payload", "Contents", "Resources", "version.json"),
-			JSON.stringify({ version: "9.9.9", hash: "deadbeef" }),
+			JSON.stringify({ version: "9.9.9", hash: "deadbeef", channel: "stable" }),
 		);
 		// A REAL tar (the script untars it to recover version.json) and deliberately no .zst.
 		spawnSync("tar", ["-cf", join(buildDir, "dev-3.0.app.tar"), "-C", buildDir, "payload"], { encoding: "utf8" });
@@ -185,12 +185,12 @@ describe("create-release-artifacts.sh", () => {
 			existsSync(join(tempDir, "artifacts-macos-arm64", "stable-macos-arm64-dev-3.0.app.tar.zst")),
 			"the compressed tarball must be staged from a build that only produced the uncompressed tar.",
 		).toBe(true);
-		// Staging happens BEFORE the script's remaining work, so asserting the artifact exists
-		// is NOT the same as asserting the script succeeded — and that gap is how the
-		// version.json fallback stayed broken while this test passed.
+		// The staging copy happens BEFORE the last checks in the script, so asserting the
+		// artifact exists is not the same as asserting the script succeeded. It has to be
+		// both, or a script that stages and then fails reads as a pass.
 		expect(
 			result.status,
-			"the whole recovery path must EXIT 0, not merely produce the tarball. A non-zero exit means something after the staging copy rejected the build; read the output above rather than trusting the artifact's existence.",
+			"the whole recovery path must EXIT 0, not merely produce the tarball. Staging happens before the script's final checks, so a non-zero exit here means something after the copy rejected the build — read the stderr above rather than trusting the artifact's existence.",
 		).toBe(0);
 	});
 

--- a/src/bun/__tests__/electrobun-channel-patch.test.ts
+++ b/src/bun/__tests__/electrobun-channel-patch.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The vendor patch that lets `electrobun build --env=unstable` mean what it says.
+ *
+ * WHY A PATCH AT ALL. electrobun's CLI gates `--env` on a three-element allowlist and
+ * SILENTLY falls back to `dev` on anything else, while every layer below it is already
+ * channel-generic (`getAppFileName`, `getPlatformPrefix`, the DMG volume name, the patch
+ * naming) and its own type is `BuildEnvironment = "stable" | "canary" | "dev" | (string & {})`
+ * — it explicitly admits arbitrary strings. So this is not extending electrobun; it is
+ * removing a check that contradicts electrobun's own type.
+ *
+ * WHY THIS TEST EXISTS. The failure mode of a lapsed patch is invisible: `--env=unstable`
+ * hits the allowlist, degrades to `dev`, and the release publishes a DEV build wearing an
+ * unstable name — polling the wrong feed, with nothing in any log saying so. So a lapse must
+ * be RED here rather than discovered by a user who stops receiving updates.
+ *
+ * This is one of TWO assertions, deliberately. This one proves the patch is applied to the
+ * installed dependency; the release workflow separately proves the BUILT ARTIFACT's
+ * version.json says `unstable`, because this can pass while that fails for an unrelated
+ * reason. See decisions/2026/08/06/stable-unstable-update-channels.md.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const CLI_SOURCE = resolve(repoRoot, "node_modules/electrobun/src/cli/index.ts");
+const PACKAGE_JSON = resolve(repoRoot, "package.json");
+
+/** The `--env` allowlist, read out of the INSTALLED dependency rather than the patch file. */
+function installedChannelAllowlist(): string[] {
+	const source = readFileSync(CLI_SOURCE, "utf8");
+	const match = source.match(/const buildEnvironment = \[([^\]]*)\]\s*\.?includes/s);
+	if (!match) return [];
+	return [...match[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+}
+
+describe("the electrobun --env allowlist patch", () => {
+	it("is declared in package.json for the exact installed version", () => {
+		const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			patchedDependencies?: Record<string, string>;
+		};
+		const version = pkg.devDependencies?.electrobun ?? pkg.dependencies?.electrobun;
+		const patched = pkg.patchedDependencies ?? {};
+		expect(
+			patched[`electrobun@${version}`],
+			`package.json pins electrobun@${version} but declares no patch for that exact version. An electrobun UPGRADE is the likely cause: bun silently stops applying a patch keyed to the old version, --env=unstable degrades to a dev build, and the unstable feed publishes a dev bundle that polls the wrong channel. Fix: re-create the patch against the new version (bun patch electrobun, add "unstable" to the --env allowlist in src/cli/index.ts, bun patch --commit node_modules/electrobun), or delete this patch entirely if electrobun now accepts arbitrary channel strings.`,
+		).toBeTruthy();
+		expect(existsSync(resolve(repoRoot, patched[`electrobun@${version}`] ?? "")))
+			.toBe(true);
+	});
+
+	it("is actually applied to the installed dependency, not merely declared", () => {
+		const allowlist = installedChannelAllowlist();
+		expect(
+			allowlist,
+			`could not find the --env allowlist in ${CLI_SOURCE}. electrobun restructured that code, so this guard is now vacuous and the patch may be silently unapplied. Fix: re-read src/cli/index.ts, point this parser at the new shape, and re-verify the patch.`,
+		).not.toHaveLength(0);
+		expect(
+			allowlist,
+			`the installed electrobun does NOT accept --env=unstable; it will silently fall back to "dev". That publishes a DEV build under an unstable name: it polls the wrong feed and no log says so. Likely cause: an electrobun upgrade dropped the patch. Fix: re-apply it (bun patch electrobun → add "unstable" → bun patch --commit).`,
+		).toContain("unstable");
+	});
+
+	it("still admits the channels electrobun shipped, so the patch only ADDS", () => {
+		// A patch that replaced the list instead of extending it would break stable releases,
+		// and stable is the channel almost everyone is on.
+		expect(installedChannelAllowlist()).toEqual(expect.arrayContaining(["dev", "canary", "stable"]));
+	});
+});

--- a/src/bun/__tests__/unstable-publish.test.ts
+++ b/src/bun/__tests__/unstable-publish.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The hourly publisher's skip decision. Every branch here is a way to waste a full
+ * sign-and-notarize cycle, or to stop publishing entirely, without anything going red.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { decidePlatformPublish, UNSTABLE_PLATFORMS } from "../../shared/unstable-publish";
+
+const HEAD = "35c68a90fbf37fde8c9288976e30d7a8d5b329e5";
+
+const WORKFLOW = readFileSync(
+	fileURLToPath(new URL("../../../.github/workflows/unstable-publish.yml", import.meta.url)),
+	"utf8",
+);
+
+describe("deciding whether a platform needs an unstable build", () => {
+	it("builds when no manifest has ever been published", () => {
+		expect(decidePlatformPublish({ kind: "absent" }, HEAD)).toEqual({
+			build: true,
+			reason: "no unstable manifest has ever been published for this platform",
+		});
+	});
+
+	it("skips when the published manifest is already at this commit", () => {
+		const decision = decidePlatformPublish({ kind: "present", body: JSON.stringify({ sha: HEAD }) }, HEAD);
+		expect(
+			decision,
+			"an unchanged main must SKIP. If this builds, the cron signs and notarizes a full release every hour for no change.",
+		).toMatchObject({ build: false });
+	});
+
+	it("builds when the published manifest is at an older commit", () => {
+		expect(decidePlatformPublish({ kind: "present", body: JSON.stringify({ sha: "cafe1234deadbeef" }) }, HEAD))
+			.toMatchObject({ build: true });
+	});
+
+	// THE TRAP, and it is why `absent` is a separate kind rather than an HTTP status. On this
+	// bucket a GET for a nonexistent key answers 403 AccessDenied, because anonymous callers
+	// have no s3:ListBucket — measured against the live bucket, invented key included.
+	// Mapping that to "absent" would rebuild everything hourly forever after a policy change;
+	// mapping it to "present" would stop publishing forever. Only a probe that can PROVE
+	// absence may say so.
+	it("FAILS on an undecidable read rather than treating it as never-published", () => {
+		const decision = decidePlatformPublish({ kind: "undecidable", detail: "403 AccessDenied" }, HEAD);
+		expect(
+			decision,
+			"an undecidable read must be an ERROR, never a build. A missing key on this bucket answers 403 to an anonymous caller, so treating an unproven absence as absent turns one bucket-policy change into a full sign-and-notarize cycle every hour, forever.",
+		).toMatchObject({ error: expect.stringContaining("403 AccessDenied") });
+	});
+
+	it("FAILS on a server error rather than guessing", () => {
+		expect(decidePlatformPublish({ kind: "undecidable", detail: "503 Slow Down" }, HEAD)).toMatchObject({
+			error: expect.stringContaining("503"),
+		});
+	});
+
+	it("quotes what it actually saw, so absent and unreachable stay distinguishable afterwards", () => {
+		const decision = decidePlatformPublish({ kind: "undecidable", detail: "500 Internal Error" }, HEAD);
+		expect(
+			"error" in decision && decision.error,
+			"the failure must quote the probe's own words. Without them the operator cannot tell a transient outage from a permissions change, which are the two causes and have different fixes.",
+		).toContain("500 Internal Error");
+	});
+
+	it("names s3:ListBucket in the failure, because that is the fix for the likely cause", () => {
+		const decision = decidePlatformPublish({ kind: "undecidable", detail: "403 AccessDenied" }, HEAD);
+		expect(
+			"error" in decision && decision.error,
+			"the undecidable failure must name the permission that makes absence provable. Without it the operator reads 'could not be read', checks that the bucket is up, finds it is, and has nowhere to go next.",
+		).toContain("s3:ListBucket");
+	});
+
+	it("FAILS on a manifest that is not JSON, because a truncated manifest means a broken publish", () => {
+		expect(decidePlatformPublish({ kind: "present", body: "<?xml version" }, HEAD)).toMatchObject({
+			error: expect.stringContaining("not valid JSON"),
+		});
+	});
+
+	it("builds when the published manifest predates the sha field", () => {
+		// Cannot be compared, so it cannot be trusted as current. Builds exactly once,
+		// after which the field is present.
+		expect(decidePlatformPublish({ kind: "present", body: JSON.stringify({ version: "1.42.0" }) }, HEAD))
+			.toMatchObject({ build: true });
+	});
+
+	it("covers every platform the workflow publishes", () => {
+		expect(
+			UNSTABLE_PLATFORMS.map((p) => `${p.os}-${p.arch}`),
+			"the platform list must match the four caller jobs in unstable-publish.yml. A platform present in the workflow but missing here is never probed, so it publishes every hour regardless of whether main moved.",
+		).toEqual(["macos-arm64", "macos-x64", "linux-x64", "linux-arm64"]);
+	});
+});
+
+/**
+ * THE BOOTSTRAP LOOP, found by probing the live bucket rather than by reading the code.
+ *
+ * A missing key on h0x91b-releases answers 403 AccessDenied to an anonymous caller — proven
+ * against the real bucket, invented key included — and this workflow refuses to build on an
+ * unproven absence. Probed anonymously it therefore deadlocks on its own first run: 403 →
+ * refuse → no manifest is ever written → 403 again, every hour, forever, red every time.
+ * Two things break the loop, and both are pinned here.
+ */
+describe("the publisher can reach its own first publish", () => {
+	const SCRIPT = readFileSync(
+		fileURLToPath(new URL("../../../scripts/decide-unstable-publish.ts", import.meta.url)),
+		"utf8",
+	);
+
+	it("probes the feed with credentials, not anonymously", () => {
+		expect(
+			SCRIPT,
+			"the probe went back to an unauthenticated fetch of the feed URL. On this bucket a MISSING key answers 403, not 404, so absence can never be proven and the first publish is unreachable — the cron then fails every hour forever. Fix: read the object through the aws CLI with the publishing credentials.",
+		).toMatch(/aws/);
+		expect(
+			/fetch\(/.test(SCRIPT),
+			"an anonymous fetch is back in the probe. It cannot distinguish a missing key from a denied one on this bucket. Fix: use the authenticated read.",
+		).toBe(false);
+	});
+
+	it("carries the credentials into the probing step", () => {
+		const decide = /^ {2}decide:$[\s\S]*?^ {2}[a-z-]+:$/m.exec(WORKFLOW)?.[0] ?? WORKFLOW;
+		expect(
+			decide,
+			"the decide job no longer passes AWS credentials, so the authenticated probe falls back to an anonymous read and every platform reports undecidable. Fix: keep AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY on the probe step.",
+		).toMatch(/AWS_ACCESS_KEY_ID/);
+	});
+
+	it("keeps a human-pressed escape for a channel that has never published", () => {
+		expect(
+			WORKFLOW,
+			"the `force` dispatch input is gone. It is the only way to seed a channel whose feed is empty when the probe itself cannot run — without it a permissions problem has no manual way out. Fix: restore the workflow_dispatch input and FORCE_PUBLISH.",
+		).toMatch(/force:/);
+		expect(
+			SCRIPT,
+			"the script no longer reads FORCE_PUBLISH, so the dispatch input is decoration and pressing it does nothing.",
+		).toMatch(/FORCE_PUBLISH/);
+	});
+
+	it("says loudly that a forced run compared nothing", () => {
+		expect(
+			SCRIPT,
+			"a forced run must announce that the feed was NOT compared. Silently publishing four platforms on a human's say-so looks identical in the log to a normal publish, and the next reader will believe the feed said so.",
+		).toMatch(/::warning::FORCED/);
+	});
+});
+
+/**
+ * The Windows proof gates every publish, so it must run whenever ANY platform publishes —
+ * and only then. Getting the condition wrong is invisible in both directions: too narrow and
+ * a platform publishes ungated, too broad and a quiet hour pays for a full Windows packaging
+ * run that gates nothing (~24 of them a day, since main is quiet most hours).
+ */
+describe("the Windows proof is scoped to hours that actually publish", () => {
+	const gate = /^ {2}windows-proof:$[\s\S]*?^ {4}uses:/m.exec(WORKFLOW)?.[0] ?? "";
+
+	it("is conditional at all, rather than running on every quiet hour", () => {
+		expect(
+			gate,
+			"the windows-proof job in unstable-publish.yml has no `if:`, so it packages Windows every hour whether or not anything publishes. Fix: gate it on the decide outputs — see the comment above the job.",
+		).toMatch(/^ {4}if:/m);
+	});
+
+	it("names every platform decide emits, so none loses its gate silently", () => {
+		const missing = UNSTABLE_PLATFORMS.map((p) => `${p.os}-${p.arch}`).filter(
+			(key) => !gate.includes(`needs.decide.outputs.${key} == 'true'`),
+		);
+		expect(
+			missing,
+			`the windows-proof condition does not mention ${missing.join(", ")}. A platform absent from it publishes on an hour when the proof was skipped — GitHub skips a job whose \`needs\` was skipped, so the build would be skipped too and that platform would stop publishing entirely. Fix: add the missing term to the \`if:\` in unstable-publish.yml.`,
+		).toEqual([]);
+	});
+});

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -4,7 +4,7 @@ import GlobalSettings from "../GlobalSettings";
 import { I18nProvider } from "../../i18n";
 import type { CodingAgent, GlobalSettings as GlobalSettingsType } from "../../../shared/types";
 import type { SettingsSectionId } from "../../state";
-import { UNSTABLE_FEED_AVAILABLE } from "../../../shared/update-channel";
+import * as confirmService from "../../confirm";
 
 vi.mock("../../zoom", () => ({
 	getZoom: vi.fn(() => 1.0),
@@ -16,6 +16,8 @@ vi.mock("../../zoom", () => ({
 	MAX_ZOOM: 2.0,
 	ZOOM_CHANGED_EVENT: "zoom-changed",
 }));
+
+vi.mock("../../confirm", () => ({ confirm: vi.fn() }));
 
 vi.mock("../../rpc", () => ({
 	isElectrobun: false,
@@ -116,6 +118,8 @@ async function waitForLoad() {
 		expect(mockedApi.request.getGlobalSettings).toHaveBeenCalled();
 	});
 }
+
+const mockedConfirm = vi.mocked(confirmService.confirm);
 
 /** Open a custom Select trigger (by element id) and click the option labeled `label`. */
 async function pickFromSelect(user: ReturnType<typeof userEvent.setup>, triggerId: string, label: string) {
@@ -422,30 +426,52 @@ describe("GlobalSettings", () => {
 			expect(select).toBeInTheDocument();
 		});
 
-		// The control shipped `disabled` while no unstable feed existed; enabling it is the
-		// point of the channels work. It must NOT be silently disabled again — that state
-		// looks identical to "feature present" on a screenshot.
-		// The control stays unusable until the unstable feed publishes. Enabling it earlier
-		// is the 403-forever trap: the updater fetches a missing manifest, reports "no
-		// update", and the UI renders that as "you are up to date" — permanently, silently.
-		it("stays disabled while no unstable feed is published", async () => {
+		// The control shipped `disabled` for as long as no unstable feed existed — picking a
+		// channel with no manifest in the bucket gets a 403, which the UI renders as "you are
+		// up to date", forever and silently. The feed exists now, so the gate is gone.
+		// Re-disabling it would look identical to "feature present" on a screenshot.
+		it("is enabled, so the channel is actually choosable", async () => {
 			setupMocks();
 			renderGlobalSettings("system");
 			await waitForLoad();
 
 			expect(
 				screen.getByDisplayValue("Stable"),
-				"the update-channel select must stay disabled while UNSTABLE_FEED_AVAILABLE is false. Fix: flip that constant in src/shared/update-channel.ts in the SAME change that lands the publishing workflow — not before, or a user who picks Unstable silently stops receiving updates forever.",
-			).toBeDisabled();
+				"the update-channel select must be enabled. It was `disabled` while no unstable feed was published; re-disabling it silently removes the feature while leaving the UI looking complete.",
+			).not.toBeDisabled();
 		});
 
-		it("keeps the constant and the control in lockstep", () => {
-			// If someone flips the constant without shipping the feed, the test above starts
-			// failing and names the reason. This asserts the coupling exists at all.
+		it("persists the switch only after the user confirms the consequence", async () => {
+			setupMocks();
+			mockedConfirm.mockResolvedValue(true);
+			const user = userEvent.setup();
+			renderGlobalSettings("system");
+			await waitForLoad();
+
+			await user.selectOptions(screen.getByDisplayValue("Stable"), "unstable");
+
 			expect(
-				UNSTABLE_FEED_AVAILABLE,
-				"UNSTABLE_FEED_AVAILABLE must be DELETED, not flipped to true, in the change that lands the publishing workflow — a permanently-true constant is a dead branch and this guard test then asserts nothing. Fix: remove the constant, its `disabled` guard, and both guard tests, and restore the enabled-control assertions instead.",
-			).toBe(false);
+				mockedConfirm,
+				"switching channels must go through confirm(): unstable is main as it lands, and switching back installs an OLDER build that then reads state a newer one wrote.",
+			).toHaveBeenCalled();
+			expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalledWith(
+				expect.objectContaining({ updateChannel: "unstable" }),
+			);
+		});
+
+		it("writes nothing when the user cancels the confirmation", async () => {
+			setupMocks();
+			mockedConfirm.mockResolvedValue(false);
+			const user = userEvent.setup();
+			renderGlobalSettings("system");
+			await waitForLoad();
+
+			await user.selectOptions(screen.getByDisplayValue("Stable"), "unstable");
+
+			expect(
+				mockedApi.request.saveGlobalSettings,
+				"a cancelled confirmation must leave the setting untouched. Persisting first and confirming after would put the user on unstable the moment the dialog appeared.",
+			).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/mainview/components/global-settings/SystemSettingsSection.tsx
+++ b/src/mainview/components/global-settings/SystemSettingsSection.tsx
@@ -1,5 +1,5 @@
 import type { GlobalSettings } from "../../../shared/types";
-import { UNSTABLE_FEED_AVAILABLE, type UpdateChannel } from "../../../shared/update-channel";
+import type { UpdateChannel } from "../../../shared/update-channel";
 import type { TFunction } from "../../i18n";
 import BrowserNotificationsSetting from "./BrowserNotificationsSetting";
 import SettingsEntry from "./SettingsEntry";
@@ -34,12 +34,7 @@ export default function SystemSettingsSection({
 					<select
 						value={globalSettings.updateChannel}
 						onChange={(event) => onUpdateChannelChange(event.target.value as UpdateChannel)}
-						// Choosable only once the unstable feed publishes — otherwise picking it
-						// silently stops all updates (403 reads as "up to date").
-						disabled={!UNSTABLE_FEED_AVAILABLE}
-						className={`w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm outline-none appearance-none${
-							UNSTABLE_FEED_AVAILABLE ? "" : " cursor-not-allowed opacity-50"
-						}`}
+						className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm outline-none appearance-none"
 					>
 						<option value="stable">{t("settings.updateChannelStable")}</option>
 						<option value="unstable">{t("settings.updateChannelUnstable")}</option>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -771,7 +771,7 @@ export const DEFAULT_EXTERNAL_APPS: ExternalApp[] = [
  * (agentId, configId) preset, surfaced as a quick-pick chip on the launch
  * picker. Carries no config overrides of its own (custom tweaks live in the
  * agent editor); `uses`/`lastUsedAt` drive chip ordering and eviction. See
- * `src/shared/favorites.ts` and decisions/125-agent-favorites.md.
+ * `src/shared/favorites.ts` and decisions/2026/07/11/agent-favorites.md.
  */
 export interface FavoriteAgentConfig {
 	agentId: string;
@@ -1439,7 +1439,7 @@ export interface Task {
 	 * switcher). Absent → the registry default (the preselect); `null` →
 	 * explicitly the system login (~/.claude / ~/.codex); a string → that managed
 	 * account. Persisted so Retry and session recovery re-launch on the same
-	 * account. See decisions/125-per-launch-agent-account-selection.md.
+	 * account. See decisions/2026/07/12/per-launch-agent-account-selection.md.
 	 */
 	accountId?: string | null;
 	createdAt: string;

--- a/src/shared/unstable-publish.ts
+++ b/src/shared/unstable-publish.ts
@@ -1,0 +1,80 @@
+/**
+ * Whether the hourly unstable publisher has anything to build.
+ *
+ * The decision is made PER PLATFORM off the manifest already published for that platform,
+ * not once for the whole run. A run that publishes three of four platforms then self-heals
+ * on the next tick; a single shared decision would skip the fourth forever, because `main`
+ * would not have moved.
+ *
+ * See decisions/2026/08/06/stable-unstable-update-channels.md.
+ */
+
+/** Every platform the unstable channel publishes, in the order the workflow declares them. */
+export const UNSTABLE_PLATFORMS = [
+	{ os: "macos", arch: "arm64" },
+	{ os: "macos", arch: "x64" },
+	{ os: "linux", arch: "x64" },
+	{ os: "linux", arch: "arm64" },
+] as const;
+
+/**
+ * What one look at `s3://.../unstable-{os}-{arch}-update.json` established.
+ *
+ * ABSENT IS A CLAIM, NOT A GUESS, and it is why this is a union rather than an HTTP status.
+ * An ANONYMOUS GET cannot make that claim about this bucket: it grants no `s3:ListBucket`,
+ * so a key that does not exist answers **403 AccessDenied**, byte-identical to a key that
+ * exists behind a broken policy. The publisher is therefore probed with the same credentials
+ * it publishes with, where a missing key answers a clean 404 and `absent` means absent.
+ */
+export type FeedProbe =
+	/** Proven missing by an authenticated read. The only input that may bootstrap a platform. */
+	| { kind: "absent" }
+	/** Read back in full. `body` is the raw manifest. */
+	| { kind: "present"; body: string }
+	/** Neither proven — a permissions problem, an outage, anything. Never treated as absent. */
+	| { kind: "undecidable"; detail: string };
+
+export type PublishDecision =
+	| { build: true; reason: string }
+	| { build: false; reason: string }
+	| { error: string };
+
+/**
+ * ABSENT means build. UNDECIDABLE means FAIL — and the whole point is that the probe, not
+ * this function, is responsible for telling them apart honestly.
+ *
+ * Mapping an undecidable read to "absent" would sign and notarize a full release every hour
+ * forever the moment bucket permissions changed; mapping it to "present" would stop
+ * publishing forever. Both are silent. So it fails, naming what it actually saw.
+ */
+export function decidePlatformPublish(probe: FeedProbe, headSha: string): PublishDecision {
+	if (probe.kind === "absent") {
+		return { build: true, reason: "no unstable manifest has ever been published for this platform" };
+	}
+	if (probe.kind === "undecidable") {
+		return {
+			error:
+				`the published manifest could not be read, and its absence could NOT be established: ${probe.detail}. This is deliberately NOT treated as "never published" — building on an unproven absence would sign and notarize a full release every hour for as long as the condition lasts. Fix: read the error above; if it is an access failure, the publishing credentials need s3:ListBucket on h0x91b-releases so a missing key answers 404 instead of 403.`,
+		};
+	}
+
+	let published: { sha?: unknown };
+	try {
+		published = JSON.parse(probe.body) as { sha?: unknown };
+	} catch {
+		return {
+			error: `the published manifest was read but is not valid JSON, so the last published commit cannot be determined. Fix: inspect the object in the bucket — a truncated manifest means a previous publish died mid-upload.`,
+		};
+	}
+
+	if (typeof published.sha !== "string" || !published.sha) {
+		// Written before the `sha` field existed, or by something that is not our script.
+		// Cannot be compared, so it cannot be trusted as current — build once, after which
+		// the field is there.
+		return { build: true, reason: "the published manifest carries no sha, so it cannot be compared" };
+	}
+	if (published.sha === headSha) {
+		return { build: false, reason: `already published at ${headSha.slice(0, 9)}` };
+	}
+	return { build: true, reason: `published ${published.sha.slice(0, 9)}, main is at ${headSha.slice(0, 9)}` };
+}

--- a/src/shared/update-channel.ts
+++ b/src/shared/update-channel.ts
@@ -15,27 +15,6 @@
 /** The channel a user has selected. Persisted in settings.json. */
 export type UpdateChannel = "stable" | "unstable";
 
-/**
- * Whether the unstable feed actually exists in the release bucket yet.
- *
- * SHIP-ORDERING GATE, and it is deliberately a constant rather than a promise in a review
- * comment. The Settings control must not become usable before the feed publishes: with no
- * `unstable-*-update.json` in the bucket the updater fetches a 403, reports "no update",
- * and the UI renders that as "you are up to date" — forever. The user has silently opted
- * out of all updates and nothing tells them.
- *
- * DELETE THIS CONSTANT in the change that lands the publishing workflow — do NOT flip it
- * to `true`. A constant that is permanently true is a dead branch and a test that asserts
- * nothing, which this project bans outright. That change removes this export, removes the
- * `disabled` guard in `SystemSettingsSection.tsx`, removes the two guard tests in
- * `GlobalSettings.test.tsx`, and replaces them with the enabled-control assertions
- * (enabled / persists only after confirm / writes nothing on cancel).
- *
- * Until then `GlobalSettings.test.tsx` asserts the control is disabled while this is
- * `false`, so the constant and the control cannot drift apart.
- */
-export const UNSTABLE_FEED_AVAILABLE = false;
-
 /** New installs and every unrecognised value land here. Nobody opts in by accident. */
 export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = "stable";
 

--- a/src/shared/windows-ci-scope.ts
+++ b/src/shared/windows-ci-scope.ts
@@ -33,6 +33,9 @@ export const WINDOWS_SCOPE_PATHS = [
 	// in this list — it pins Bun, a pin change is a packaged-runtime change, and a
 	// workflow outside the list cannot dispatch the proof for its own edits.
 	".github/workflows/windows-proof-main.yml",
+	// The hourly unstable publisher. In under BOTH criteria: it dispatches the proof (same
+	// rule as the line above) and it pins Bun for the builds it calls.
+	".github/workflows/unstable-publish.yml",
 	// (2) these carry the Bun pin that builds and ships the app, so a pin change here is
 	// a packaged-runtime change and the proof has to re-run. release.yml still pins Bun in
 	// its `prepare` and `release` jobs after the per-platform builds moved out; the two


### PR DESCRIPTION
Hi, Claude here — the AI assistant that wrote this branch.

**Stacked on #1284**, which is stacked on #1283. Merge order: #1283 → the manifest-ordering fix → #1284 → this. I rebase each onto `main` as its parent lands.

The last piece: the unstable feed actually publishes, so the Settings control stops being decoration. **This is the PR that makes the feature reachable by a user.**

## Getting `channel: unstable` into the bundle — a one-line vendored patch

`electrobun build --env=unstable` does **not** fail. It hits `["dev","canary","stable"].includes(envArg) ? envArg : "dev"` (`src/cli/index.ts`) and **silently produces a dev build** — which would then publish under unstable names, poll the wrong feed, and never update, with nothing logged.

Everything below that check is already channel-generic (`getAppFileName`, `getPlatformPrefix`, DMG volume name, patch naming), and electrobun's own type is `BuildEnvironment = "stable" | "canary" | "dev" | (string & {})` — it **explicitly admits arbitrary strings**. So `patches/electrobun@1.18.1.patch` is not a fork: it removes a check that contradicts electrobun's own type.

**Why not patch `version.json` after the build?** Because nothing is left to patch — electrobun tars the bundle and then **deletes** it, and the signed, notarized wrapper carries its own `channel` field. That route means untar → patch → re-tar → re-compress → patch wrapper → re-sign → **re-notarize**, i.e. Apple's notary service on the hot path of an hourly job. (Established while reading: the bundle hash is computed **before** `version.json` is written, so editing that file can never invalidate a bundle.)

**Why not publish unstable under the existing `canary` prefix?** No patch needed — and rejected: it resurrects the name this work deletes, in the bucket *and* inside the bundle, and every future reader would have to learn that canary means unstable. A stored lie costs more than a maintained patch.

### A lapsed patch is silent, so three guards make it red

| Guard | Catches |
|---|---|
`electrobun-channel-patch.test.ts` — reads the **installed dependency**, not the patch file | not declared for the pinned version · declared but not applied · list **replaced** instead of extended (that one would break stable, which is where almost everyone is) |
`create-release-artifacts.sh` compares `version.json`'s channel with its channel argument | a build that succeeded on the wrong channel |
same script: `./build/dev-*` present while `./build/<channel>-*` is missing | names the degradation instead of surfacing later as "build failed before tarring" |

All mutation-proved. **Expiry:** this patch dies when electrobun accepts arbitrary channel strings in the CLI; it touches exactly one place, so that is where an upgrade should look. Reported upstream as [blackboardsh/electrobun#517](https://github.com/blackboardsh/electrobun/issues/517) (searched first — #261 and #432 are adjacent but do not cover the allowlist). The ask that matters most there is not "accept custom channels" but **fail loudly on an unknown `--env` instead of degrading to `dev`**. If either lands, this patch deletes itself.

## Infrastructure cost, declared not absorbed

**This is the repo's first patched dependency** — there was no `patchedDependencies` and no `patches/` before. Every electrobun upgrade must re-check it, and guard 1 above makes a lapse a **red build** rather than a silent wrong publish.

## The publisher

Hourly cron **if `main` moved**, plus `workflow_dispatch`. Not per merge: merges land in batches of four or five, so per-push meant four wasted sign-and-notarize cycles for one meaningful artifact — and a sha comparison has no burst to collapse, which is why there is no `cancel-in-progress`.

- **Per-platform skip**, read from the already-published `unstable-{os}-{arch}-update.json`. A run that publishes three of four **self-heals on the next tick**; one shared decision would skip the fourth forever, because `main` had not moved.
- **ABSENT means build, UNDECIDABLE means fail** — and the *probe*, not the rule, is what has to tell them apart. See the section below: the first version of this got the rule right and the probe wrong, and everything stayed green.
- **`tag` is the short sha.** No tag exists here, and a constant would overwrite one archive prefix forever. Consequence stated rather than implied: the versioned prefix grows per commit with **no retention policy today**.
- **The packaged Windows proof gates it**, like every job that syncs the feed. Verified by mutation, not assumed: removing `windows-proof` from one caller's `needs` turns the directory-wide assertion red. That assertion is enumerated over the whole workflow directory, so it covered this file **the moment it existed** — a single-file assertion would have been silent, because this workflow did not exist when the assertion was written. **Cost accepted:** an hour in which `main` moved pays for the proof as well as four builds.

## The bootstrap loop — found by probing the live bucket, not by reading the code

The probe was an anonymous `GET` of the feed, on the belief that a missing key answers 404. **It does not on this bucket.** `h0x91b-releases` grants no anonymous `s3:ListBucket`, so a key that does not exist answers **403 AccessDenied** — measured, with a deliberately invented key as the control, while `stable-macos-arm64-update.json` answered 200 from the same caller.

That closes a loop rather than risking one:

```
cron ticks -> 403 on all four platforms -> job fails (correctly: an unproven
absence must never build) -> no manifest is ever written -> 403 again, next
hour, forever, red every time
```

> **It would have merged green.** Every unit test passed, because they tested the **rule** — and the rule was right. What was wrong was the way the *input* to that rule was obtained. A test that asserts a decision knows nothing about a decision fed from a bad source: the whole construction reads green from end to end while the function cannot work at all.

**Fixed by probing with the publishing credentials** (`aws s3 cp`), where a missing key answers a clean 404 and `absent` is a fact rather than a guess. `FeedProbe` became a union — `absent` / `present` / `undecidable` — instead of an HTTP status, so a caller can no longer hand up a status it is unable to interpret. The ambiguity is dead structurally, not by a check.

Rejected: seeding the first manifest by hand, or a one-off skip. Both fix *this* instance and leave "no key" and "no access" identical forever, so the next new platform hits the same wall with nobody around who remembers why.

A `force` input on `workflow_dispatch` survives as the escape hatch — the only way out if the probe itself cannot run — and a forced run prints `::warning::FORCED` saying **nothing was compared**, so it is not mistakable in the log for a normal publish. Four assertions pin it (authenticated probe · no `fetch(` returning · credentials reach the step · escape exists and is wired), all mutation-proved.

⚠️ **The first real cron tick is the measurement.** That the credentials reach the step is asserted; that the authenticated probe works against the live bucket is **not yet observed**, because no tick has happened. Until it does, the publisher is unverified on live — and the dangerous outcome to watch for is a **green run with no manifest in the bucket**, which looks exactly like success. Check for the key, not the colour.

## Enabling the control

`UNSTABLE_FEED_AVAILABLE` is **deleted**, not flipped to `true` — a permanently-true constant is a dead branch whose guard test asserts nothing. Its two guard tests go with it, replaced by the three they were holding the place for: enabled · persists only after confirmation · **cancel writes nothing**.

## Browser QA — driven, not assumed

Screenshots below, streamer mode on. Every state was verified against `~/.dev3.0/settings.json`, not just against the rendered UI:

- control **enabled**, both options present, no dimming.
- switching **to** unstable → confirmation names the consequence, and **Cancel left `updateChannel: stable` on disk.** That is the negative case and the one that actually breaks in practice: a dialog that writes before the user confirms would have put them on unstable the moment it appeared.
- confirming → `updateChannel: unstable` on disk, select shows Unstable.
- switching **back** → the dialog says it installs an **older** build that will read state a newer one wrote, and the button reads **"Install stable"**, never "Update". The direction wording survived from design into the shipped UI, which is what stops a user thinking they are moving forward while moving back.
- no console errors, and **the setting was restored to `stable` afterwards** — not politeness: `~/.dev3.0/` is shared with every installed version on the machine, so a QA pass that left the developer's own app on unstable would be a real defect introduced by testing.

## Verification

`bun run lint` clean. Full `bun run test` green: renderer **3711**, backend **5441**, CLI **764**, zero failures, `exit 0`.

Disclosed rather than smoothed over: an earlier run on this branch came back red with 13 failures at a one-minute load average of **149.60**, and a later one with 7 at **~72**. Twelve of those were `STACK_TRACE_ERROR` with no failed assertion. The one real assertion — `cli-socket-label-delete-race.test.ts:175` — was attributed, not dismissed: its neighbour at `:136` dies first under load and `:175` then inherits its leftover state. Same file, same order, observed on two branches and three shas, absent from a paired clean-`main` baseline, and **not reproducible in isolation** (six green isolated runs). It is a repository flake with a known mechanism, recorded in a dev3 task note, and owned by a separate task.

CI on `8247313cd`: **11 of 11 success** — `lint`, `build-check`, `trivy-scan`, both `terminal e2e` legs, all five `test` shards and the aggregate `test`. These are this branch's **first** real checks: while it targeted another branch, `build.yml` (`pull_request: branches: [main]`) fired nothing, so the empty list was *unrun*, never green.
