### PR TITLE
Stop task git numbers from trusting a stale comparison base

### DIFF
--- a/change-logs/2026/08/07/fix-stale-task-comparison-base.md
+++ b/change-logs/2026/08/07/fix-stale-task-comparison-base.md
@@ -1,0 +1,3 @@
+Short: Task git numbers stop trusting a dead base
+
+A task's ahead/behind counts, diff chip, PR badge and Rebase (AI) target could stay pinned to an already-merged review branch after the task's own branch was renamed, so every number described someone else's branch. The comparison base now survives a rename, retires itself once that branch is merged or gone, is fetched from the remote that actually owns it, and a stored pull request only counts while it belongs to the task's own branch.

--- a/decisions/2026/08/06/comparison-base-survives-rename-and-retires-when-dead.md
+++ b/decisions/2026/08/06/comparison-base-survives-rename-and-retires-when-dead.md
@@ -1,0 +1,86 @@
+# The comparison base survives a rename and retires when it dies
+
+## Context
+
+A task's git numbers — ahead/behind, the diff chip, the rebase target — are all
+computed against `resolveTaskCompareBaseBranch(task, project)`. For a PR-review
+task `deriveTaskBaseBranch` stores the reviewed branch itself as `baseBranch`,
+and the function recognises that self-referential shape by `baseBranch` matching
+`task.branchName`. A variant task deliberately keeps its source branch as the
+base, and that is the *same* stored shape with a different `branchName` — the
+two cases are told apart only by the branch name.
+
+Observed on task Seq 1427: the agent renamed its branch, `syncTaskBranchName`
+persisted the new name, the name-based guard stopped matching, and a foreign,
+already-merged review branch became the comparison base. The header read
+`21 ahead · 3 behind vs arditti/feat/dev3-terminal-file-path-open` with a
+`213 files +15671 -792` chip. Every number was arithmetically correct against
+that ref — a correct answer to the wrong question. "Rebase (AI)" instructed the
+agent to rebase onto the dead branch; it refused only because it checked.
+
+## Investigation
+
+Three independent defects, each verified read-only against the live task:
+
+1. The guard keys on `task.branchName`, which `syncTaskBranchName` rewrites.
+   Any rename silently drops the protection.
+2. Nothing ever retires the base. `mergeWatch` knows the branch merged and only
+   offers task completion; `baseBranch` keeps naming the merged branch forever.
+3. `fetchOrigin` could only fetch from `origin`, so a fork-qualified base
+   (`arditti/feat/…`, resolving to `refs/remotes/arditti/feat/…`) was fetched as
+   `git fetch origin arditti/feat/…` → `couldn't find remote ref`. The tracking
+   ref stayed frozen at `42c01aaca` while the fork was at `49ebf7d5`.
+
+Plus a latent one: with `ahead === 0`, `mergedByContent` was proved by
+`task.prNumber` — here a *foreign* merged PR (#1255) — and the green PR badge
+came from the same rot, falling back to the persisted number without checking
+its state or its head branch.
+
+## Decision
+
+Four changes, each at the point where the information is lost.
+
+- **Freeze the base across a rename.** `compareBasePin` in
+  `src/bun/task-branch-sync.ts` resolves the base before and after the rename;
+  if the rename would move it, the pre-rename answer is persisted into
+  `baseBranch` — but only when it survives being stored, so renaming *onto* the
+  base name is a no-op. Chosen over a new "checkout branch" field because the
+  rename is the only event that destroys the signal, and healing there also
+  repairs the stored data instead of re-deriving the truth on every read.
+- **Retire a dead base.** `healDeadCompareBase` in
+  `src/bun/rpc-handlers/git-operations.ts` falls a task back to the project base
+  and persists it when the stored base is merged into `origin/<project base>` or
+  no longer resolves. Only ever fires when the task's base differs from the
+  project's own, so a project-wide `develop` base is untouched.
+- **Fetch from the remote that owns the ref.** `git.fetchCompareRef` routes a
+  `<remote>/<branch>` base to that remote (explicit refspec, so the tracking ref
+  actually moves) and everything else to `origin`. Used by branch status, task
+  diff, and the merge watcher.
+- **Prove PR ownership.** `github.getPullRequestSnapshot` returns state *and*
+  `headRefName`; `isPullRequestMerged` now takes the branch that must own the PR.
+  The badge fallback and `pollTaskPrStatus`'s sticky-number lookup both drop a PR
+  whose head is a different branch. A PR GitHub cannot answer for at all
+  (offline, non-GitHub remote) keeps the stored badge rather than blinking out.
+
+## Risks
+
+- Retiring the base is a write on a 15s poll path; it is idempotent and guarded
+  by `task.baseBranch !== resolved`, so it fires once. If a user deliberately
+  compares against a merged branch, the `vs … ▾` dropdown still overrides it —
+  that override lives in renderer state, not in `task.baseBranch`.
+- The badge check costs one extra `gh pr view` for tasks with a stored PR and no
+  open PR. It is cached per `(worktree, PR)` with a terminal-state fast path.
+- `fetchCompareRef` spends one `git remote` per slashed base branch. Local, and
+  skipped entirely for unslashed names.
+
+## Alternatives considered
+
+- **A persisted `checkoutBranch` field** to make the self-compare guard immune
+  to renames. More robust in principle, but it adds a field that old tasks lack
+  (so the heuristic stays anyway) and does nothing for the merged/deleted-base
+  half of the bug.
+- **Resetting `existingBranch` on merge.** It is provenance, and other flows read
+  it; clearing it loses the record of what the task grew out of. Only the base is
+  retired.
+- **Blanking the PR badge whenever GitHub cannot confirm ownership.** Rejected:
+  a transient network failure would flicker the badge off on every poll.

--- a/src/bun/__tests__/git-fetch-snapshot.test.ts
+++ b/src/bun/__tests__/git-fetch-snapshot.test.ts
@@ -31,6 +31,7 @@ type SpawnResponse = {
 
 let spawnResponses: SpawnResponse[] = [];
 let lastSpawnOptions: { env?: Record<string, string> } | undefined;
+let spawnCommands: string[][] = [];
 let killedProcesses = 0;
 
 function queueResponse(exitCode: number, stdout: string, stderr = "") {
@@ -38,8 +39,9 @@ function queueResponse(exitCode: number, stdout: string, stderr = "") {
 }
 
 vi.mock("../spawn", () => ({
-	spawn: (_cmd: string[], opts?: { env?: Record<string, string> }) => {
+	spawn: (cmd: string[], opts?: { env?: Record<string, string> }) => {
 		lastSpawnOptions = opts;
+		spawnCommands.push(cmd);
 		const response = spawnResponses.shift() ?? { exitCode: 1, stdout: "", stderr: "no response queued" };
 		const encoder = new TextEncoder();
 		let resolveExit!: (code: number) => void;
@@ -71,6 +73,7 @@ vi.mock("../spawn", () => ({
 }));
 
 import {
+	fetchCompareRef,
 	fetchOrigin,
 	_resetFetchState,
 	saveDiffSnapshot,
@@ -80,6 +83,7 @@ import {
 beforeEach(() => {
 	lastSpawnOptions = undefined;
 	spawnResponses = [];
+	spawnCommands = [];
 	killedProcesses = 0;
 	_resetFetchState();
 });
@@ -230,6 +234,54 @@ describe("fetchOrigin", () => {
 		expect(ok1).toBe(true);
 		expect(ok2).toBe(true);
 		expect(spawnResponses).toHaveLength(0); // both consumed
+	});
+});
+
+// ─── fetchCompareRef ─────────────────────────────────────────────────────────
+
+describe("fetchCompareRef", () => {
+	/** Spawned fetches, minus the `-c core.quotepath=false` every git call carries. */
+	function fetchCommands(): string[][] {
+		return spawnCommands
+			.map((cmd) => cmd.filter((arg) => arg !== "-c" && arg !== "core.quotepath=false"))
+			.filter((cmd) => cmd[1] === "fetch");
+	}
+
+	it("fetches a fork-qualified base from the remote that owns it", async () => {
+		queueResponse(0, "origin\narditti\n"); // git remote
+		queueResponse(0, ""); // git fetch
+
+		expect(await fetchCompareRef("/repo", "arditti/feat/file-path-open")).toBe(true);
+		expect(fetchCommands()).toEqual([[
+			"git", "fetch", "arditti",
+			"+refs/heads/feat/file-path-open:refs/remotes/arditti/feat/file-path-open",
+			"--quiet",
+		]]);
+	});
+
+	it("treats a slashed branch name as an origin branch when no such remote exists", async () => {
+		queueResponse(0, "origin\n"); // git remote
+		queueResponse(0, ""); // git fetch
+
+		expect(await fetchCompareRef("/repo", "feat/file-path-open")).toBe(true);
+		expect(fetchCommands()).toEqual([["git", "fetch", "origin", "feat/file-path-open", "--quiet"]]);
+	});
+
+	it("does not consult remotes for an unslashed branch", async () => {
+		queueResponse(0, ""); // git fetch
+
+		expect(await fetchCompareRef("/repo", "main")).toBe(true);
+		expect(spawnCommands.some((cmd) => cmd[cmd.length - 1] === "remote")).toBe(false);
+	});
+
+	it("keeps the origin and fork fetches of the same branch on separate cooldowns", async () => {
+		queueResponse(0, "origin\narditti\n");
+		queueResponse(0, "");
+		expect(await fetchCompareRef("/repo", "arditti/feat/x")).toBe(true);
+
+		queueResponse(0, "");
+		expect(await fetchOrigin("/repo", "arditti/feat/x")).toBe(true);
+		expect(fetchCommands()).toHaveLength(2);
 	});
 });
 

--- a/src/bun/__tests__/github.test.ts
+++ b/src/bun/__tests__/github.test.ts
@@ -527,7 +527,7 @@ describe("github", () => {
 	describe("isPullRequestMerged", () => {
 		const PROJECT = { githubAuthHost: "github.com", githubAuthLogin: "h0x91b" };
 
-		function mockGhPrView(state: string | null, ok = true) {
+		function mockGhPrView(state: string | null, ok = true, headRefName = "feat/mine") {
 			whichMock.mockResolvedValue("/opt/homebrew/bin/gh");
 			spawnMock.mockImplementation((cmd: string[]) => {
 				if (cmd.join(" ") === "gh auth status --json hosts") {
@@ -537,35 +537,59 @@ describe("github", () => {
 				}
 				if (cmd[1] === "auth" && cmd[2] === "token") return fakeProc("secret-token\n");
 				if (!ok) return fakeProc("", "no such PR", 1);
-				return fakeProc(JSON.stringify({ state }));
+				return fakeProc(JSON.stringify({ state, headRefName }));
 			});
 		}
 
-		it("returns true for a merged PR", async () => {
+		it("returns true for a merged PR on this branch", async () => {
 			mockGhPrView("MERGED");
 			const { isPullRequestMerged } = await import("../github");
-			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077)).resolves.toBe(true);
+			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077, "feat/mine")).resolves.toBe(true);
 		});
 
 		it("returns false for an open PR", async () => {
 			mockGhPrView("OPEN");
 			const { isPullRequestMerged } = await import("../github");
-			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077)).resolves.toBe(false);
+			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077, "feat/mine")).resolves.toBe(false);
 		});
 
 		it("returns false when the gh command fails (offline / unauthenticated)", async () => {
 			mockGhPrView(null, false);
 			const { isPullRequestMerged } = await import("../github");
-			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077)).resolves.toBe(false);
+			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1077, "feat/mine")).resolves.toBe(false);
+		});
+
+		it("refuses a merged PR that belongs to another branch", async () => {
+			mockGhPrView("MERGED", true, "contributor/their-feature");
+			const { isPullRequestMerged, _resetPullRequestMergedCache } = await import("../github");
+			_resetPullRequestMergedCache();
+			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1255, "fix/mine")).resolves.toBe(false);
+		});
+
+		it("accepts a merged PR without an ownership check when no branch is known", async () => {
+			mockGhPrView("MERGED", true, "contributor/their-feature");
+			const { isPullRequestMerged, _resetPullRequestMergedCache } = await import("../github");
+			_resetPullRequestMergedCache();
+			await expect(isPullRequestMerged(PROJECT, "/tmp/wt", 1255, null)).resolves.toBe(true);
+		});
+
+		it("reports state and head branch via getPullRequestSnapshot", async () => {
+			mockGhPrView("MERGED", true, "contributor/their-feature");
+			const { getPullRequestSnapshot, _resetPullRequestMergedCache } = await import("../github");
+			_resetPullRequestMergedCache();
+			await expect(getPullRequestSnapshot(PROJECT, "/tmp/wt", 1255)).resolves.toEqual({
+				state: "MERGED",
+				headRefName: "contributor/their-feature",
+			});
 		});
 
 		it("caches a merged answer instead of re-asking gh", async () => {
 			mockGhPrView("MERGED");
 			const { isPullRequestMerged, _resetPullRequestMergedCache } = await import("../github");
 			_resetPullRequestMergedCache();
-			await isPullRequestMerged(PROJECT, "/tmp/wt", 1077);
+			await isPullRequestMerged(PROJECT, "/tmp/wt", 1077, "feat/mine");
 			const callsAfterFirst = spawnMock.mock.calls.length;
-			await isPullRequestMerged(PROJECT, "/tmp/wt", 1077);
+			await isPullRequestMerged(PROJECT, "/tmp/wt", 1077, "feat/mine");
 			expect(spawnMock.mock.calls.length).toBe(callsAfterFirst);
 		});
 	});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -79,7 +79,11 @@ vi.mock("../git", () => ({
 	isGitRepo: vi.fn(),
 	getDefaultBranch: vi.fn(),
 	fetchOrigin: vi.fn().mockResolvedValue(true),
+	fetchCompareRef: vi.fn().mockResolvedValue(true),
 	fetchFork: vi.fn().mockResolvedValue(true),
+	listRemotes: vi.fn().mockResolvedValue(["origin"]),
+	refExists: vi.fn().mockResolvedValue(true),
+	isRefMergedInto: vi.fn().mockResolvedValue(false),
 	getBranchStatus: vi.fn(),
 	getTaskDiff: vi.fn(),
 	getUncommittedChanges: vi.fn(),
@@ -106,6 +110,7 @@ vi.mock("../git", () => ({
 vi.mock("../github", () => ({
 	runGitHub: vi.fn(),
 	isPullRequestMerged: vi.fn(),
+	getPullRequestSnapshot: vi.fn().mockResolvedValue(null),
 	getGitHubShellExports: vi.fn().mockResolvedValue([]),
 	getGitHubCliStatus: vi.fn(),
 }));
@@ -5043,7 +5048,7 @@ describe("handlers.getTaskDiff base branch resolution", () => {
 		await handlers.getTaskDiff({ taskId: task.id, projectId: project.id, mode: "branch" });
 
 		// Fetch and diff against the real base — never the branch compared to itself.
-		expect(git.fetchOrigin).toHaveBeenCalledWith(project.path, "main");
+		expect(git.fetchCompareRef).toHaveBeenCalledWith(project.path, "main");
 		expect(git.getTaskDiff).toHaveBeenCalledWith(
 			"/tmp/wt",
 			"branch",
@@ -5202,7 +5207,7 @@ describe("handlers.getBranchStatus", () => {
 			const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 
 			expect(result.mergedByContent).toBe(true);
-			expect(github.isPullRequestMerged).toHaveBeenCalledWith(project, "/tmp/wt", 1077);
+			expect(github.isPullRequestMerged).toHaveBeenCalledWith(project, "/tmp/wt", 1077, "dev3/t");
 			// Content strategies are pointless here — nothing of the branch is left.
 			expect(git.isContentMergedInto).not.toHaveBeenCalled();
 		});
@@ -5259,6 +5264,143 @@ describe("handlers.getBranchStatus", () => {
 			expect(result.mergedByContent).toBe(true);
 			expect(git.isContentMergedInto).toHaveBeenCalled();
 			expect(github.isPullRequestMerged).not.toHaveBeenCalled();
+		});
+	});
+
+	// A task's stored PR number survives a branch rename, and a task grown out of
+	// a review task inherits the reviewed PR's number — so it can name a PR that
+	// belongs to somebody else's branch entirely.
+	describe("getBranchStatus with a stored PR from another branch", () => {
+		function mockClean() {
+			vi.mocked(git.getCurrentBranch).mockResolvedValue("fix/mine");
+			vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 3 });
+			vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
+			vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
+			vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", exitCode: 0 } as any);
+		}
+
+		it("hides the badge and refuses the merge proof when the PR's head is a foreign branch", async () => {
+			const project = makeProject();
+			const task = makeTask({
+				worktreePath: "/tmp/wt", branchName: "fix/mine", prNumber: 1255, prUrl: "https://gh/pr/1255",
+			});
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			vi.mocked(data.getTask).mockResolvedValue(task);
+			mockClean();
+			vi.mocked(github.getPullRequestSnapshot).mockResolvedValue({
+				state: "MERGED", headRefName: "arditti/feat/file-path-open",
+			});
+
+			const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(result.prNumber).toBeNull();
+			expect(result.mergedByContent).toBe(false);
+			expect(github.isPullRequestMerged).not.toHaveBeenCalled();
+		});
+
+		it("keeps the badge when the stored PR is this branch's own merged PR", async () => {
+			const project = makeProject();
+			const task = makeTask({
+				worktreePath: "/tmp/wt", branchName: "fix/mine", prNumber: 1300, prUrl: "https://gh/pr/1300",
+			});
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			vi.mocked(data.getTask).mockResolvedValue(task);
+			mockClean();
+			vi.mocked(github.getPullRequestSnapshot).mockResolvedValue({ state: "MERGED", headRefName: "fix/mine" });
+			vi.mocked(github.isPullRequestMerged).mockResolvedValue(true);
+
+			const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(result.prNumber).toBe(1300);
+			expect(result.mergedByContent).toBe(true);
+		});
+
+		it("keeps the stored badge when GitHub cannot answer at all (offline)", async () => {
+			const project = makeProject();
+			const task = makeTask({
+				worktreePath: "/tmp/wt", branchName: "fix/mine", prNumber: 1300, prUrl: "https://gh/pr/1300",
+			});
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			vi.mocked(data.getTask).mockResolvedValue(task);
+			mockClean();
+			vi.mocked(github.getPullRequestSnapshot).mockResolvedValue(null);
+
+			const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(result.prNumber).toBe(1300);
+		});
+	});
+
+	// A review-branch or variant-source base stops being a base once that branch
+	// merges or disappears; every number computed against it then answers a
+	// question nobody is asking.
+	describe("getBranchStatus retires a dead comparison base", () => {
+		function mockVariantTask() {
+			const project = makeProject();
+			const task = makeTask({
+				worktreePath: "/tmp/wt",
+				branchName: "feature/source-v2",
+				baseBranch: "feature/source",
+				existingBranch: "feature/source",
+			});
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			vi.mocked(data.getTask).mockResolvedValue(task);
+			vi.mocked(data.updateTask).mockImplementation(async (_p, _id, updates) => ({ ...task, ...updates }) as any);
+			vi.mocked(git.getCurrentBranch).mockResolvedValue("feature/source-v2");
+			vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 2, behind: 0 });
+			vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
+			vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
+			vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
+			vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", exitCode: 0 } as any);
+			return { project, task };
+		}
+
+		it("falls back to the project base once the base branch is merged into it", async () => {
+			const { project } = mockVariantTask();
+			vi.mocked(git.refExists).mockResolvedValue(true);
+			vi.mocked(git.isRefMergedInto).mockResolvedValue(true);
+
+			await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(git.isRefMergedInto).toHaveBeenCalledWith(project.path, "feature/source", "origin/main");
+			expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { baseBranch: "main" });
+			expect(git.getBranchStatus).toHaveBeenCalledWith("/tmp/wt", "origin/main");
+		});
+
+		it("falls back to the project base when the base ref no longer resolves", async () => {
+			const { project } = mockVariantTask();
+			vi.mocked(git.refExists).mockResolvedValue(false);
+
+			await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { baseBranch: "main" });
+			expect(git.isRefMergedInto).not.toHaveBeenCalled();
+		});
+
+		it("keeps a live base branch that has not landed yet", async () => {
+			mockVariantTask();
+			vi.mocked(git.refExists).mockResolvedValue(true);
+			vi.mocked(git.isRefMergedInto).mockResolvedValue(false);
+
+			await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(data.updateTask).not.toHaveBeenCalled();
+			expect(git.getBranchStatus).toHaveBeenCalledWith("/tmp/wt", "origin/feature/source");
+		});
+
+		it("does not probe anything for a task on the project base", async () => {
+			mockVariantTask();
+			vi.mocked(data.getTask).mockResolvedValue(makeTask({
+				worktreePath: "/tmp/wt", branchName: "dev3/t", baseBranch: "main",
+			}));
+			vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
+
+			await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(git.refExists).not.toHaveBeenCalled();
+			expect(git.isRefMergedInto).not.toHaveBeenCalled();
 		});
 	});
 
@@ -5634,7 +5776,7 @@ describe("handlers.getTaskDiff", () => {
 			compareLabel: "origin/main",
 		});
 
-		expect(git.fetchOrigin).toHaveBeenCalledWith(project.path, "main");
+		expect(git.fetchCompareRef).toHaveBeenCalledWith(project.path, "main");
 		expect(git.getTaskDiff).toHaveBeenCalledWith("/tmp/wt", "branch", {
 			baseBranch: "main",
 			compareRef: "origin/main",

--- a/src/bun/__tests__/task-branch-sync.test.ts
+++ b/src/bun/__tests__/task-branch-sync.test.ts
@@ -132,6 +132,57 @@ describe("syncTaskBranchName", () => {
 		expect(git.getCurrentBranch).not.toHaveBeenCalled();
 	});
 
+	it("pins the comparison base when a review task's branch is renamed", async () => {
+		// PR-review task: baseBranch is the reviewed branch, and the guard in
+		// resolveTaskCompareBaseBranch recognised it only while branchName matched.
+		// After the rename the review branch would leak through as the base.
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("fix/dev3-underline-flicker");
+
+		const project = makeProject();
+		const task = makeTask({
+			baseBranch: "arditti/feat/dev3-file-path-open",
+			existingBranch: "arditti/feat/dev3-file-path-open",
+			branchName: "feat/dev3-file-path-open",
+		});
+
+		await syncTaskBranchName(project, task);
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", {
+			branchName: "fix/dev3-underline-flicker",
+			baseBranch: "main",
+		});
+	});
+
+	it("leaves a variant's source branch as its base across a rename", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("feature/source-v3");
+
+		const project = makeProject();
+		const task = makeTask({
+			baseBranch: "feature/source",
+			existingBranch: "feature/source",
+			branchName: "feature/source-v2",
+		});
+
+		await syncTaskBranchName(project, task);
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { branchName: "feature/source-v3" });
+	});
+
+	it("does not pin anything when the branch is renamed onto the stored base", async () => {
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("feature/source");
+
+		const project = makeProject();
+		const task = makeTask({
+			baseBranch: "feature/source",
+			existingBranch: "feature/source",
+			branchName: "feature/source-v2",
+		});
+
+		await syncTaskBranchName(project, task);
+
+		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { branchName: "feature/source" });
+	});
+
 	it("returns the original task when persisting fails", async () => {
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("chore/dev3-example");
 		vi.mocked(data.updateTask).mockRejectedValue(new Error("disk full"));

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1220,7 +1220,7 @@ export async function listBranches(projectPath: string): Promise<BranchInfo[]> {
 	return branches;
 }
 
-async function refExists(projectPath: string, ref: string): Promise<boolean> {
+export async function refExists(projectPath: string, ref: string): Promise<boolean> {
 	const result = await run(["git", "rev-parse", "--verify", ref], projectPath);
 	return result.ok;
 }
@@ -1256,11 +1256,7 @@ async function detectDefaultCompareRefUncached(
 	projectPath: string,
 	baseBranch: string,
 ): Promise<string> {
-	const remoteResult = await run(["git", "remote"], projectPath);
-	const hasOriginRemote = remoteResult.ok && remoteResult.stdout
-		.split("\n")
-		.map((remote) => remote.trim())
-		.includes("origin");
+	const hasOriginRemote = (await listRemotes(projectPath)).includes("origin");
 	const remoteBaseRef = `origin/${baseBranch}`;
 	const remoteBaseExists = hasOriginRemote && await refExists(projectPath, remoteBaseRef);
 	const localBaseExists = await refExists(projectPath, baseBranch);
@@ -1341,10 +1337,19 @@ export async function fetchOrigin(
 	branch?: string,
 	timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<boolean> {
+	return fetchFromRemote(projectPath, "origin", branch, timeoutMs);
+}
+
+async function fetchFromRemote(
+	projectPath: string,
+	remote: string,
+	branch?: string,
+	timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<boolean> {
 	await reportCurrentPreparationStage("fetching-origin");
 	const now = Date.now();
-	// Cache key is scoped to the specific branch when provided, or "*" for a full fetch.
-	const cacheKey = branch ? `${projectPath}:${branch}` : `${projectPath}:*`;
+	// Cache key is scoped to the specific remote+branch, or "*" for a full fetch.
+	const cacheKey = branch ? `${projectPath}:${remote}/${branch}` : `${projectPath}:${remote}:*`;
 	const lastSuccess = fetchLastSuccess.get(cacheKey) ?? 0;
 
 	// Skip if a successful fetch completed recently
@@ -1387,10 +1392,15 @@ export async function fetchOrigin(
 		}
 
 		const startedAt = performance.now();
+		// A non-origin remote needs an explicit refspec, otherwise `git fetch <fork>
+		// <branch>` lands in FETCH_HEAD only and refs/remotes/<fork>/<branch> —
+		// the ref every comparison resolves — stays frozen at its old commit.
 		const cmd = branch
-			? ["git", "fetch", "origin", branch, "--quiet"]
-			: ["git", "fetch", "origin", "--quiet"];
-		log.debug("Fetching origin", { projectPath, branch });
+			? remote === "origin"
+				? ["git", "fetch", "origin", branch, "--quiet"]
+				: ["git", "fetch", remote, `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`, "--quiet"]
+			: ["git", "fetch", remote, "--quiet"];
+		log.debug("Fetching remote", { projectPath, remote, branch });
 		const result = await run(cmd, projectPath, {
 			timeoutMs,
 			env: {
@@ -1429,6 +1439,41 @@ export async function fetchOrigin(
 	} finally {
 		fetchInFlight.delete(cacheKey);
 	}
+}
+
+/** Configured remote names, e.g. `["origin", "arditti"]`. Empty when git fails. */
+export async function listRemotes(projectPath: string): Promise<string[]> {
+	const result = await run(["git", "remote"], projectPath);
+	if (!result.ok) return [];
+	return result.stdout.split("\n").map((remote) => remote.trim()).filter(Boolean);
+}
+
+/**
+ * Fetch the branch a task actually compares against. A fork-review base is
+ * stored remote-qualified (`arditti/feat/x`) and resolves to
+ * `refs/remotes/arditti/feat/x`, so fetching it from `origin` fails with
+ * "couldn't find remote ref" and the comparison keeps using a frozen ref.
+ * Route it to the remote that owns it; anything else is an origin branch.
+ */
+export async function fetchCompareRef(
+	projectPath: string,
+	branch: string,
+	timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<boolean> {
+	const slash = branch.indexOf("/");
+	if (slash > 0) {
+		const remote = branch.slice(0, slash);
+		if (remote !== "origin" && (await listRemotes(projectPath)).includes(remote)) {
+			return fetchFromRemote(projectPath, remote, branch.slice(slash + 1), timeoutMs);
+		}
+	}
+	return fetchFromRemote(projectPath, "origin", branch, timeoutMs);
+}
+
+/** Is `ref` fully contained in `targetRef`? False when either ref is unresolvable. */
+export async function isRefMergedInto(projectPath: string, ref: string, targetRef: string): Promise<boolean> {
+	const result = await run(["git", "merge-base", "--is-ancestor", ref, targetRef], projectPath);
+	return result.ok;
 }
 
 // `git pull --ff-only` intermittently dies with "fatal: Cannot fast-forward to

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -383,48 +383,84 @@ export async function runGitHub(
 	return runGh(args, { cwd, env, timeoutMs: options?.timeoutMs });
 }
 
-// A merged PR never un-merges, so positive answers are cached for the process
-// lifetime; negatives expire so the 15s branch-status poll re-asks without
-// hammering the API.
-const PR_MERGED_NEGATIVE_TTL_MS = 60_000;
+// A merged PR never un-merges, so a terminal answer is cached for the process
+// lifetime; everything else expires so the 15s branch-status poll re-asks
+// without hammering the API.
+const PR_SNAPSHOT_TTL_MS = 60_000;
 const PR_MERGED_TIMEOUT_MS = 10_000;
-const prMergedCache = new Map<string, { at: number; merged: boolean }>();
+const prSnapshotCache = new Map<string, { at: number; snapshot: PullRequestSnapshot | null }>();
 
-/** Test-only: clear the merged-PR cache. */
+/** Identity of one PR, as far as a task needs to trust it. */
+export interface PullRequestSnapshot {
+	/** `OPEN` / `MERGED` / `CLOSED`, uppercased. */
+	state: string;
+	/** The PR's head branch, so a caller can prove the PR is about its own work. */
+	headRefName: string;
+}
+
+/** Test-only: clear the PR snapshot cache. */
 export function _resetPullRequestMergedCache(): void {
-	prMergedCache.clear();
+	prSnapshotCache.clear();
 }
 
 /**
- * Is this exact PR merged? Task-scoped by design: the caller passes the PR
- * number recorded for its own task, so a reused branch name cannot make
- * somebody else's merged PR look like this task's work.
+ * State + head branch of one PR by number. Null when GitHub cannot answer
+ * (offline, unauthenticated, non-GitHub remote, PR gone).
+ */
+export async function getPullRequestSnapshot(
+	project: ProjectGitHubSelection,
+	cwd: string,
+	prNumber: number,
+): Promise<PullRequestSnapshot | null> {
+	const key = `${cwd}#${prNumber}`;
+	const cached = prSnapshotCache.get(key);
+	if (cached && (cached.snapshot?.state === "MERGED" || Date.now() - cached.at < PR_SNAPSHOT_TTL_MS)) {
+		return cached.snapshot;
+	}
+
+	let snapshot: PullRequestSnapshot | null = null;
+	try {
+		const result = await runGitHub(project, cwd, ["pr", "view", String(prNumber), "--json", "state,headRefName"], {
+			timeoutMs: PR_MERGED_TIMEOUT_MS,
+		});
+		if (result.ok && result.stdout) {
+			const parsed = JSON.parse(result.stdout);
+			if (typeof parsed?.state === "string") {
+				snapshot = {
+					state: parsed.state.toUpperCase(),
+					headRefName: typeof parsed.headRefName === "string" ? parsed.headRefName : "",
+				};
+			}
+		}
+	} catch (err) {
+		log.warn("getPullRequestSnapshot failed", { prNumber, error: String(err) });
+	}
+	prSnapshotCache.set(key, { at: Date.now(), snapshot });
+	return snapshot;
+}
+
+/**
+ * Is this exact PR merged *and* about this branch's work? A task's stored PR
+ * number outlives the branch it was opened from: rename the branch, or inherit
+ * the number from a review task, and the number points at somebody else's PR.
+ * `headBranch` is that ownership proof — pass null only where no branch is known.
  */
 export async function isPullRequestMerged(
 	project: ProjectGitHubSelection,
 	cwd: string,
 	prNumber: number,
+	headBranch: string | null,
 ): Promise<boolean> {
-	const key = `${cwd}#${prNumber}`;
-	const cached = prMergedCache.get(key);
-	if (cached && (cached.merged || Date.now() - cached.at < PR_MERGED_NEGATIVE_TTL_MS)) {
-		return cached.merged;
-	}
-
-	let merged = false;
-	try {
-		const result = await runGitHub(project, cwd, ["pr", "view", String(prNumber), "--json", "state"], {
-			timeoutMs: PR_MERGED_TIMEOUT_MS,
-		});
-		if (result.ok && result.stdout) {
-			merged = JSON.parse(result.stdout)?.state === "MERGED";
-		}
-	} catch (err) {
-		// Offline, unauthenticated, non-GitHub remote — degrade to "not merged".
-		log.warn("isPullRequestMerged failed", { prNumber, error: String(err) });
-	}
-	prMergedCache.set(key, { at: Date.now(), merged });
-	log.info("isPullRequestMerged", { prNumber, merged });
+	const snapshot = await getPullRequestSnapshot(project, cwd, prNumber);
+	const merged = snapshot?.state === "MERGED"
+		&& (headBranch === null || snapshot.headRefName === headBranch);
+	log.info("isPullRequestMerged", {
+		prNumber,
+		merged,
+		state: snapshot?.state ?? null,
+		headRefName: snapshot?.headRefName ?? null,
+		headBranch,
+	});
 	return merged;
 }
 

--- a/src/bun/lifecycle/activities.ts
+++ b/src/bun/lifecycle/activities.ts
@@ -204,7 +204,7 @@ async function checkMergedBranches(): Promise<void> {
 			...dueTasks.map((t) => t.baseBranch || project.defaultBaseBranch || "main"),
 		])];
 		try {
-			await Promise.all(uniqueBaseBranches.map((b) => git.fetchOrigin(project.path, b)));
+			await Promise.all(uniqueBaseBranches.map((b) => git.fetchCompareRef(project.path, b)));
 		} catch {
 			continue;
 		}
@@ -255,7 +255,7 @@ async function checkMergedBranches(): Promise<void> {
 					merged = await git.isBranchMergedViaGitHubPR(task.worktreePath!, project)
 						|| (task.prNumber != null
 							&& (await git.getBranchStatus(task.worktreePath!, ref)).ahead === 0
-							&& await github.isPullRequestMerged(project, task.worktreePath!, task.prNumber));
+							&& await github.isPullRequestMerged(project, task.worktreePath!, task.prNumber, branchName));
 				} else {
 					merged = await git.isContentMergedInto(task.worktreePath!, ref, project);
 				}
@@ -343,9 +343,10 @@ interface GitHubPullRequestSummary {
 	mergeStateStatus?: unknown;
 	statusCheckRollup?: unknown;
 	reviewDecision?: unknown;
+	headRefName?: unknown;
 }
 
-const PR_STATUS_JSON_FIELDS = "number,isDraft,autoMergeRequest,url,statusCheckRollup,reviewDecision,mergeable,mergeStateStatus,state,title";
+const PR_STATUS_JSON_FIELDS = "number,isDraft,autoMergeRequest,url,statusCheckRollup,reviewDecision,mergeable,mergeStateStatus,state,title,headRefName";
 
 interface PolledPRStatus {
 	found: boolean;
@@ -517,7 +518,17 @@ async function pollTaskPrStatus(project: Project, task: Task, suggestCompletion:
 			try {
 				const parsed = JSON.parse(knownPrResult.stdout);
 				if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-					pr = parsed as GitHubPullRequestSummary;
+					const known = parsed as GitHubPullRequestSummary;
+					// The stored number survives a branch rename, and a task grown out
+					// of a review task inherits the reviewed PR's number. Either way it
+					// can name somebody else's PR — take it only if its head is us.
+					if (typeof known.headRefName === "string" && known.headRefName !== branchName) {
+						log.info("Ignoring stored PR from a different branch", {
+							taskId: task.id.slice(0, 8), pr: task.prNumber, prHead: known.headRefName, branch: branchName,
+						});
+						return { found: false, ciStatus: null };
+					}
+					pr = known;
 					isOpenPr = typeof pr.state === "string" && pr.state.toUpperCase() === "OPEN";
 				}
 			} catch {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -125,6 +125,36 @@ function monitorGitPane(paneId: string | null, task: Task, projectId: string, op
 	}
 }
 
+/**
+ * Retire a comparison base that has stopped being a base. A review-branch or
+ * variant-source base is a moment in time: once that branch is merged into the
+ * project base — or deleted outright — every number computed against it answers
+ * a question nobody is asking, and "Rebase (AI)" points the agent at a dead
+ * branch. Fall the task back to the project base and persist it, so the fix
+ * outlives this poll. The user's `vs … ▾` override is unaffected: it lives in
+ * renderer state, not in `task.baseBranch`.
+ */
+async function healDeadCompareBase(project: Project, task: Task, baseBranch: string): Promise<string> {
+	const projectBase = project.defaultBaseBranch || "main";
+	if (baseBranch === projectBase || task.baseBranch !== baseBranch) return baseBranch;
+
+	const reason = !await git.refExists(project.path, baseBranch)
+		? "gone"
+		: await git.isRefMergedInto(project.path, baseBranch, `origin/${projectBase}`)
+			? "merged"
+			: null;
+	if (!reason) return baseBranch;
+
+	log.info("Retiring stale comparison base", { taskId: task.id.slice(0, 8), baseBranch, projectBase, reason });
+	try {
+		const updated = await data.updateTask(project, task.id, { baseBranch: projectBase });
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	} catch (err) {
+		log.warn("Failed to retire stale comparison base", { taskId: task.id.slice(0, 8), error: String(err) });
+	}
+	return projectBase;
+}
+
 async function getBranchStatusImpl(params: { taskId: string; projectId: string; compareRef?: string }): Promise<BranchStatus> {
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
@@ -136,7 +166,7 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 		return { ahead: 0, behind: 0, canRebase: false, insertions: 0, deletions: 0, unpushed: 0, mergedByContent: false, diffFiles: 0, diffInsertions: 0, diffDeletions: 0, diffFileStats: [], prNumber: null, prUrl: null, mergeCompletionFingerprint: null };
 	}
 
-	const baseBranch = resolveTaskCompareBaseBranch(task, project);
+	const resolvedBase = resolveTaskCompareBaseBranch(task, project);
 	const liveBranch = await git.getCurrentBranch(task.worktreePath);
 	const branchForPush = liveBranch ?? task.branchName ?? "";
 
@@ -144,12 +174,13 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 		await syncTaskBranchName(project, task);
 	}
 
-	log.debug("getBranchStatus: fetching origin", { worktreePath: task.worktreePath, baseBranch, branchName: branchForPush });
-	await git.fetchOrigin(project.path, baseBranch);
+	log.debug("getBranchStatus: fetching origin", { worktreePath: task.worktreePath, baseBranch: resolvedBase, branchName: branchForPush });
+	await git.fetchCompareRef(project.path, resolvedBase);
+	const baseBranch = await healDeadCompareBase(project, task, resolvedBase);
 	const ref = params.compareRef || `origin/${baseBranch}`;
 	const compareRefBranch = params.compareRef?.startsWith("origin/") ? params.compareRef.slice("origin/".length) : null;
 	if (compareRefBranch && compareRefBranch !== baseBranch) {
-		await git.fetchOrigin(project.path, compareRefBranch);
+		await git.fetchCompareRef(project.path, compareRefBranch);
 	}
 	// Also refresh origin/<task-branch> so getUnpushedCount reflects out-of-band remote pushes.
 	if (branchForPush && branchForPush !== baseBranch && branchForPush !== compareRefBranch) {
@@ -184,9 +215,22 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 		git.getBranchDiffStats(task.worktreePath, ref),
 		prDetection,
 	]);
-	const prInfo = detectedPr ?? (task.prNumber != null && task.prUrl
-		? { number: task.prNumber, url: task.prUrl }
-		: null);
+	let prInfo = detectedPr;
+	if (!prInfo && task.prNumber != null && task.prUrl) {
+		// The sticky number outlives the branch it was opened from: rename the
+		// branch, or inherit the number from the review task this one grew out of,
+		// and it points at a stranger's PR. Show it only while GitHub says the PR
+		// is about this branch. No answer at all (offline, non-GitHub remote) keeps
+		// the stored pair — better a stale badge than one that blinks out.
+		const snapshot = await github.getPullRequestSnapshot(project, task.worktreePath, task.prNumber);
+		if (!snapshot || !branchForPush || snapshot.headRefName === branchForPush) {
+			prInfo = { number: task.prNumber, url: task.prUrl };
+		} else {
+			log.info("Ignoring stored PR from a different branch", {
+				taskId: task.id.slice(0, 8), pr: task.prNumber, prHead: snapshot.headRefName, branch: branchForPush,
+			});
+		}
+	}
 	const prNumber = prInfo?.number ?? null;
 	const prUrl = prInfo?.url ?? null;
 	log.debug("getBranchStatus: raw results", { status, uncommitted, unpushed, branchDiff, prNumber, prUrl, ref });
@@ -196,11 +240,11 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 	// Git alone cannot tell "merged, then rebased away" from "brand-new branch,
 	// nothing committed yet" — only this task's own merged PR proves work landed.
 	// No PR (or no GitHub / offline) ⇒ not merged, never a false positive.
-	const prNumberForMergeProof = detectedPr?.number ?? task.prNumber ?? null;
+	const prNumberForMergeProof = prInfo?.number ?? null;
 	const mergedByContent = status.ahead > 0
 		? await git.isContentMergedInto(task.worktreePath, ref, project) === true
 		: prNumberForMergeProof != null
-			&& await github.isPullRequestMerged(project, task.worktreePath, prNumberForMergeProof) === true;
+			&& await github.isPullRequestMerged(project, task.worktreePath, prNumberForMergeProof, branchForPush || null) === true;
 	const mergeCompletionFingerprint = mergedByContent
 		? (await getMergeCompletionFingerprint(task, branchForPush)).fingerprint
 		: null;
@@ -286,10 +330,10 @@ async function getTaskDiff(params: {
 	// `HEAD~N..HEAD` and clamps against the already on-disk `origin/<base>`
 	// merge-base — so neither pays for a network fetch.
 	if (params.mode !== "uncommitted" && params.mode !== "recent") {
-		await git.fetchOrigin(project.path, baseBranch);
+		await git.fetchCompareRef(project.path, baseBranch);
 		const compareRefBranch = params.compareRef?.startsWith("origin/") ? params.compareRef.slice("origin/".length) : null;
 		if (compareRefBranch && compareRefBranch !== baseBranch) {
-			await git.fetchOrigin(project.path, compareRefBranch);
+			await git.fetchCompareRef(project.path, compareRefBranch);
 		}
 	}
 

--- a/src/bun/task-branch-sync.ts
+++ b/src/bun/task-branch-sync.ts
@@ -1,11 +1,29 @@
 import { existsSync } from "node:fs";
-import type { Project, Task } from "../shared/types";
+import { type Project, type Task, resolveTaskCompareBaseBranch } from "../shared/types";
 import * as data from "./data";
 import * as git from "./git";
 import { getPushMessage } from "./rpc-handlers/shared-pure";
 import { createLogger } from "./logger";
 
 const log = createLogger("task-branch-sync");
+
+/**
+ * A rename must not move the branch the task is compared against.
+ * `resolveTaskCompareBaseBranch` recognises a review task's checkout ref by it
+ * matching `branchName`; once the branch is renamed that match is gone and the
+ * review branch leaks through as the comparison base, so every ahead/behind
+ * number, the diff chip, and the rebase target start describing a foreign
+ * branch. Freeze the pre-rename answer into `baseBranch` — but only when it
+ * survives being stored, so renaming *onto* the base name changes nothing.
+ */
+function compareBasePin(project: Project, task: Task, liveBranch: string): { baseBranch?: string } {
+	const before = resolveTaskCompareBaseBranch(task, project);
+	const renamed = { ...task, branchName: liveBranch };
+	if (resolveTaskCompareBaseBranch(renamed, project) === before) return {};
+	if (resolveTaskCompareBaseBranch({ ...renamed, baseBranch: before }, project) !== before) return {};
+	log.info("Branch renamed, pinning comparison base", { taskId: task.id.slice(0, 8), baseBranch: before });
+	return { baseBranch: before };
+}
 
 /**
  * Reconcile `task.branchName` with the branch actually checked out in the
@@ -21,7 +39,8 @@ export async function syncTaskBranchName(project: Project, task: Task): Promise<
 	if (!liveBranch || liveBranch === task.branchName) return task;
 
 	try {
-		const updated = await data.updateTask(project, task.id, { branchName: liveBranch });
+		const updates: Partial<Task> = { branchName: liveBranch, ...compareBasePin(project, task, liveBranch) };
+		const updated = await data.updateTask(project, task.id, updates);
 		// Persisting alone leaves the renderer's in-memory task stale (it only
 		// refreshes on a taskUpdated push), so broadcast the new name too.
 		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });


### PR DESCRIPTION
A task's git numbers — ahead/behind, the diff chip, the PR badge and the "Rebase (AI)" target — are all computed against `resolveTaskCompareBaseBranch`. For a PR-review task that base is the reviewed branch itself, recognised by matching `task.branchName`. Rename the branch and the match is gone, so a foreign, already-merged review branch silently becomes the comparison base.

Observed on task Seq 1427: `21 ahead · 3 behind vs arditti/feat/dev3-terminal-file-path-open` with a `213 files +15671 -792` chip and a green badge for a PR merged hours earlier from somebody else's branch. Every number was arithmetically correct against that ref — a correct answer to the wrong question. "Rebase (AI)" pointed the agent at the dead branch; it refused only because it checked.

Four fixes, each at the point where the information is lost:

- **The base survives a rename.** `compareBasePin` (`src/bun/task-branch-sync.ts`) freezes the pre-rename base into `baseBranch`, but only when it survives being stored — so renaming *onto* the base name stays a no-op. A renamed review task and a variant task are byte-identical on disk, so no pure function can tell them apart after the fact.
- **A dead base retires itself.** `healDeadCompareBase` (`src/bun/rpc-handlers/git-operations.ts`) falls the task back to the project base and persists it once the stored base is merged into `origin/<project base>` or no longer resolves. Only fires when the task's base differs from the project's own, so a project-wide `develop` base is untouched.
- **Fork-qualified bases are fetched from their own remote.** `git.fetchCompareRef` routes `arditti/feat/x` to the `arditti` remote with an explicit refspec, so the remote-tracking ref actually moves. Previously `git fetch origin arditti/feat/x` failed with `couldn't find remote ref` and the ref stayed frozen.
- **A stored PR must own the branch.** `github.getPullRequestSnapshot` returns state *and* `headRefName`; `isPullRequestMerged` now takes the branch that must own the PR. The badge fallback and `pollTaskPrStatus`'s sticky-number lookup both drop a PR whose head is a different branch. A PR GitHub cannot answer for at all (offline, non-GitHub remote) keeps the stored badge rather than blinking out.

The user's `vs … ▾` override is unaffected — it lives in renderer state, not in `task.baseBranch`.

Rationale, risks and rejected alternatives: `decisions/222-comparison-base-survives-rename-and-retires-when-dead.md`.

17 new tests cover the renamed review task, the renamed variant, base retirement (merged / unresolvable / still live / project-base no-op), PR ownership, and remote-aware fetching.
