### PR TITLE
Split the native journal proof into durability and isolation

### DIFF
--- a/change-logs/2026/08/07/fix-native-journal-proof-durability-vs-isolation.md
+++ b/change-logs/2026/08/07/fix-native-journal-proof-durability-vs-isolation.md
@@ -1,0 +1,8 @@
+Short: Native journal proof says what broke
+
+The native-session registry's Windows lifecycle proof reported journal isolation as one
+boolean over two unrelated properties, so a red run could name neither: a session's own
+output is now awaited to a ceiling instead of a fixed 400 ms sleep, cross-session leakage is
+re-checked on every observation so waiting can never hide it, and a failure names the cause,
+the fix and the journal contents it saw. Whether this also removes the intermittent Windows
+red is unproven — only recurrence will tell, and the log will then say which half broke.

--- a/decisions/2026/08/06/journal-proof-splits-durability-from-isolation.md
+++ b/decisions/2026/08/06/journal-proof-splits-durability-from-isolation.md
@@ -1,0 +1,61 @@
+# The journal proof splits durability from isolation
+
+_Cite this record by slug — `journal-proof-splits-durability-from-isolation` — never by number or path._
+
+## Context
+
+`test:native-registry-e2e` went red once on Windows (run 31100808763, attempt 1, commit
+45a1d68b3) on the single line `FAIL - bravo journal holds only bravo's output`. The check
+was one boolean over two unrelated properties — the session's own marker being present AND
+the other session's marker being absent — and printed nothing else, so the log could not say
+whether the registry had leaked one session's output into another's journal (a correctness
+defect on the only platform with no tmux) or the marker simply had not been flushed yet.
+
+## Investigation
+
+The host records a chunk into the `JournalWriter` **before** it fans the same bytes out to
+clients (`host.ts`, the `terminal.data` callback). The test observed `BRAVOMARK` on the live
+stream first, so those bytes were in the writer's memory by construction — the failure could
+only be memory→disk→read, or a real leak. The test then slept a fixed 400 ms against a 150 ms
+debounce timer on a loaded 2-core runner, and read through `readJournalTail`, which reports
+"unreadable" and "nothing persisted" as the same empty tail. The commit under test touched no
+registry file, and a strict descendant (ab86cf4ff, run 31102170635 attempt 1) ran the same
+proof green 19 minutes later.
+
+## Decision
+
+`lifecycle.bun-e2e.ts` now treats the two properties differently. **Durability** ("a session's
+own output reaches its journal") is eventual, so it is polled to a `JOURNAL_DURABILITY_BUDGET_MS`
+ceiling instead of slept at. **Isolation** ("a journal never holds the other session's output")
+is a safety property: it is re-evaluated on every poll and ends the loop on the first violation,
+so waiting can never sit on top of a leak and wait it out of sight. `check()` gained an
+explain-on-failure callback; the journal failure names which of the four causes fired
+(leak / marker never produced live / journal unreadable / never flushed) and quotes the chunk
+count, file size, read error and journal tail.
+
+## What this change does and does not claim
+
+The mechanism behind the red was never named, so **this change does not claim to remove the
+flake.** Polling durability instead of asserting it once may well be the cause on Windows —
+that is a hypothesis, not a repair. What it does claim: the check could not distinguish two
+different failures and now can, and the next occurrence is diagnosable from the CI log alone
+(which half broke, plus the journal evidence behind it). If it recurs after this lands, the
+log will finally say which half.
+
+## Risks
+
+The budget is a ceiling, not a delay, so a green run costs nothing — but a genuine durability
+regression now takes up to 10 s to report instead of failing at 400 ms. Accepted: the proof
+already runs minutes of packaging around it, and a fixed sleep is what produced an
+uninvestigable red in the first place.
+
+An isolation check cannot pass over zero observations: "no foreign marker" is vacuously true
+on an empty or missing journal, so it is conjoined with the session's OWN marker being present.
+An empty journal fails the check, and both cases are mutation-proved.
+
+## Alternatives considered
+
+- **Raise the fixed sleep.** Same defect at a different threshold, and still one bit of output.
+- **Split into two checks without polling.** Fixes the diagnosis, keeps the timing flake.
+- **Retry the read inside `readJournalTail`.** A production change with no evidence behind it
+  yet; the new failure message will say whether a Windows sharing violation is really happening.

--- a/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
+++ b/src/bun/native-terminal-registry/__tests__/lifecycle.bun-e2e.ts
@@ -24,7 +24,7 @@ import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn, spawnSync } from "../../spawn";
 import { NativeSessionClient } from "../client";
-import { recordFile, tokenFile } from "../paths";
+import { journalFile, recordFile, tokenFile } from "../paths";
 import { isProcessAlive } from "../process-identity";
 import { decodeControl, MAX_CONTROL_FRAME_BYTES } from "../protocol";
 import {
@@ -74,11 +74,17 @@ function liveProcessCommandLine(pid: number): string {
 }
 
 let failures = 0;
-function check(condition: boolean, msg: string): void {
+/**
+ * `explain` runs ONLY on failure and must name the CAUSE and the FIX: this proof's
+ * whole output on CI is these lines, so a bare `FAIL - x` costs a Windows-only
+ * investigation that cannot be reproduced anywhere else.
+ */
+function check(condition: boolean, msg: string, explain?: () => string): void {
 	if (condition) console.log(`  ok   - ${msg}`);
 	else {
 		failures++;
 		console.error(`  FAIL - ${msg}`);
+		for (const line of (explain?.() ?? "").split("\n")) if (line) console.error(`         ${line}`);
 	}
 }
 
@@ -193,6 +199,112 @@ function rawFirstFrameProbe(
 			finish(true);
 		});
 	});
+}
+
+/**
+ * Ceiling for a session's own output to become durable on disk, NOT a delay: the
+ * journal writer flushes on a 150 ms debounce, and a loaded 2-core CI runner can
+ * starve that timer well past the fixed 400 ms sleep this replaced. Only the
+ * durability half is allowed to wait — isolation is asserted on every observation.
+ */
+const JOURNAL_DURABILITY_BUDGET_MS = 10_000;
+
+/**
+ * One observation of a session's persisted journal, taken through the PRODUCT read
+ * path (`replayJournal`) and the raw file at once. The product path answers
+ * "unreadable" and "nothing persisted" with the same empty tail, so the file size
+ * and the read error are carried alongside — otherwise a Windows sharing violation
+ * during the writer's atomic rename is indistinguishable from a lost marker.
+ */
+interface JournalObservation {
+	own: boolean;
+	foreign: boolean;
+	chunks: number;
+	fileBytes: number;
+	readError: string;
+	tail: string;
+}
+
+/** Printable, single-line excerpt — a journal holds raw PTY bytes, escapes included. */
+function excerpt(text: string, max = 240): string {
+	let out = "";
+	for (const ch of text.slice(-max)) {
+		const code = ch.codePointAt(0) ?? 0;
+		out += code < 0x20 || code === 0x7f ? `\\x${code.toString(16).padStart(2, "0")}` : ch;
+	}
+	return out;
+}
+
+function observeJournal(sessionId: string, ownMark: string, foreignMark: string): JournalObservation {
+	const chunks = NativeSessionClient.replayJournal(sessionId);
+	const text = chunks.map((bytes) => new TextDecoder().decode(bytes)).join("");
+	let fileBytes = -1;
+	let readError = "";
+	try {
+		// The raw read is the point: `readJournalTail` catches every failure and answers
+		// with an empty tail, so this is the only place the actual error survives.
+		fileBytes = Buffer.byteLength(readFileSync(journalFile(sessionId), "utf8"), "utf8");
+	} catch (err) {
+		readError = String(err);
+	}
+	return {
+		own: text.includes(ownMark),
+		foreign: text.includes(foreignMark),
+		chunks: chunks.length,
+		fileBytes,
+		readError,
+		tail: excerpt(text),
+	};
+}
+
+/** Names the CAUSE and the FIX for whichever of the two journal properties broke. */
+function explainJournal(
+	sessionId: string,
+	other: string,
+	obs: JournalObservation,
+	waitedMs: number,
+	liveMarkSeen: boolean,
+): string {
+	const evidence = `evidence: chunks=${obs.chunks} fileBytes=${obs.fileBytes}${obs.readError ? ` readError=${obs.readError}` : ""} tail="${obs.tail}"`;
+	if (obs.foreign) {
+		return [
+			`CAUSE: ${sessionId}'s journal contains ${other}'s marker — cross-session leakage in the registry,`,
+			"       not a timing problem (a journal is per-session state; waiting cannot remove a foreign byte).",
+			`FIX: the registry's journal path or output fan-out (paths.journalFile / host.ts data callback). Never this assertion.`,
+			evidence,
+		].join("\n");
+	}
+	if (!liveMarkSeen) {
+		return [
+			`CAUSE: ${sessionId}'s shell never produced its marker on the LIVE stream, so nothing was there to persist —`,
+			"       a lost or unexecuted command, not a journal defect (the check above is the primary failure).",
+			"FIX: the shell round-trip for this session, e.g. a warm-up budget as in command-roundtrip.ts.",
+			evidence,
+		].join("\n");
+	}
+	if (obs.readError.includes("ENOENT")) {
+		return [
+			`CAUSE: ${sessionId} has no journal file at all after ${waitedMs}ms — nothing was ever published for it,`,
+			"       so this is not a slow flush: the writer never reached disk, or it wrote somewhere else.",
+			"FIX: JournalWriter.flush (its failures print to host.log) and paths.journalFile for this session.",
+			evidence,
+		].join("\n");
+	}
+	if (obs.readError) {
+		return [
+			`CAUSE: ${sessionId}'s journal file exists but could not be read after ${waitedMs}ms — on Windows this is normally a`,
+			"       sharing violation racing the writer's atomic rename, which readJournalTail reports as an empty tail.",
+			"FIX: the read path (journal-read.ts) must survive a transient read failure instead of reporting no journal.",
+			evidence,
+		].join("\n");
+	}
+	return [
+		`CAUSE: ${sessionId}'s marker reached its live client but never reached disk within ${waitedMs}ms.`,
+		"       Its bytes were recorded in the writer BEFORE the client saw them (host.ts records, then fans out),",
+		"       so the loss is memory→disk: a failed flush (see host.log), a starved 150ms flush timer, or cap eviction.",
+		"FIX: the JournalWriter flush path — raise DEFAULT_JOURNAL_MAX_BYTES only if fileBytes is at the cap.",
+		evidence,
+	].join("\n");
 }
 
 const cliEntry = fileURLToPath(new URL("../cli.ts", import.meta.url));
@@ -335,21 +447,48 @@ async function run(): Promise<void> {
 		await cB.connect(recBravo!, readFileSync(tokenFile("bravo"), "utf8").trim());
 		const sB = makeSink(cB);
 		send(cB, isWindows ? `Write-Output "BRAVOMARK:${nonce}"` : `echo "BRAVOMARK:${nonce}"`);
-		await sB.waitFor(`BRAVOMARK:${nonce}`);
+		// Asserted, never discarded: the host records a chunk into the journal BEFORE it fans the
+		// same bytes out to clients, so a marker the client saw is already in the writer. Without
+		// this check a lost command masquerades as a journal defect below.
+		const bravoMarkLive = await sB.waitFor(`BRAVOMARK:${nonce}`);
+		check(bravoMarkLive, "bravo client receives its own live shell output", () =>
+			[
+				"CAUSE: bravo's shell produced no BRAVOMARK on the live stream within the wait budget.",
+				"FIX: the shell round-trip for the CLI-started session (command-roundtrip.ts warm-up budget).",
+			].join("\n"),
+		);
 		await cB.disconnect({ timeoutMs: 3000 });
 
 		// ── 4. disconnect survival + INDEPENDENT journals ──
-		await delay(400); // let the journal debounce flush
 		check(isProcessAlive(alpha.record.host.pid) && isProcessAlive(alpha.record.shell.pid), "alpha host + shell survive client disconnect");
 		check(isProcessAlive(bravo.hostPid) && isProcessAlive(bravo.shellPid), "bravo host + shell survive client disconnect");
-		const decodeJournal = (sessionId: string): string =>
-			NativeSessionClient.replayJournal(sessionId)
-				.map((bytes) => new TextDecoder().decode(bytes))
-				.join("");
-		const alphaJournal = decodeJournal("alpha");
-		const bravoJournal = decodeJournal("bravo");
-		check(alphaJournal.includes(`ALPHAMARK:${nonce}`) && !alphaJournal.includes(`BRAVOMARK:${nonce}`), "alpha journal holds only alpha's output");
-		check(bravoJournal.includes(`BRAVOMARK:${nonce}`) && !bravoJournal.includes(`ALPHAMARK:${nonce}`), "bravo journal holds only bravo's output");
+		// TWO different properties, deliberately not one boolean:
+		//   durability — a session's own output REACHES its journal. Eventual (the writer flushes on
+		//     a debounce), so it is polled to a ceiling instead of slept at for a fixed 400ms.
+		//   isolation  — a journal NEVER holds the other session's output. A safety property:
+		//     re-observed on every poll and terminal on the first violation, so the durability wait
+		//     can never sit on top of a leak and wait it out of sight.
+		// The two are CONJOINED, never asserted alone: "holds no foreign marker" is vacuously true
+		// of an empty or missing journal, so an isolation check over zero observations would pass
+		// while proving nothing. Requiring the session's own marker is what forbids that.
+		const alphaMark = `ALPHAMARK:${nonce}`;
+		const bravoMark = `BRAVOMARK:${nonce}`;
+		const journalStart = Date.now();
+		let obsAlpha = observeJournal("alpha", alphaMark, bravoMark);
+		let obsBravo = observeJournal("bravo", bravoMark, alphaMark);
+		while (!obsAlpha.foreign && !obsBravo.foreign && !(obsAlpha.own && obsBravo.own)) {
+			if (Date.now() - journalStart > JOURNAL_DURABILITY_BUDGET_MS) break;
+			await delay(50);
+			obsAlpha = observeJournal("alpha", alphaMark, bravoMark);
+			obsBravo = observeJournal("bravo", bravoMark, alphaMark);
+		}
+		const journalWaitedMs = Date.now() - journalStart;
+		check(obsAlpha.own && !obsAlpha.foreign, "alpha journal holds only alpha's output", () =>
+			explainJournal("alpha", "bravo", obsAlpha, journalWaitedMs, true),
+		);
+		check(obsBravo.own && !obsBravo.foreign, "bravo journal holds only bravo's output", () =>
+			explainJournal("bravo", "alpha", obsBravo, journalWaitedMs, bravoMarkLive),
+		);
 
 		// ── 5. fresh client rediscovers alpha and proves PID + state preserved ──
 		const c2 = await NativeSessionClient.discover("alpha");


### PR DESCRIPTION
Hey — Claude here, the AI assistant that did this work on Arseny's machine.

`test:native-registry-e2e` went red once on Windows (run 31100808763, **attempt 1**, commit 45a1d68b3) on a single line: `FAIL - bravo journal holds only bravo's output`. That check was one boolean over two unrelated properties — the session's own marker being present AND the other session's marker being absent — and it printed nothing else, so the log could not say whether the registry had leaked one session's output into another's journal or the marker simply had not been flushed yet.

**The honest headline: the check could not distinguish two different failures and now can. Whether that also removes the intermittent Windows red is unproven — only recurrence will tell, and the log will then say which half broke.**

### Verdict on the original red

Non-deterministic, and not a regression from 45a1d68b3:

- that commit touched **zero** files under `src/bun/native-terminal-registry/` (only `scripts/verify-windows-app-launch.ts` and its test);
- a strict descendant, ab86cf4ff, ran the same proof green (run 31102170635, attempt 1);
- re-running the **same commit** as attempt 2 passed the step (job 92646008091).

The mechanism could not be named from the evidence that exists, and that is the defect this PR fixes.

### What changed

- **Durability** ("a session's own output reaches its journal") is eventual, so it is polled to a ceiling instead of slept at for a fixed 400 ms.
- **Isolation** ("a journal never holds the other session's output") is a safety property: re-evaluated on every observation and terminal on the first violation, so waiting can never sit on top of a leak.
- The two are **conjoined**, never asserted alone — "holds no foreign marker" is vacuously true of an empty or missing journal, so requiring the session's own marker is what makes zero observations a failure.
- The live-stream wait is asserted instead of discarded, so a lost command can no longer masquerade as a journal defect.
- Failures name the CAUSE and the FIX and quote the chunk count, file size, read error and journal tail.

Five mutations, red per mutation and green in between: real cross-session leakage (fires immediately, no wait), the marker dropped at publish time, and the three shapes of absence — journal missing (`ENOENT`), present but empty (`fileBytes=0`), and unreadable (`EACCES`). All three arrive as `chunks=0` and all three fail.

Decision record: `journal-proof-splits-durability-from-isolation` (cite by slug).


---

### CI note — run 31119234650, attempt 1 died in a GitHub Actions outage

Attempt 1 was **not** a test failure: GitHub Actions was in a partial system outage (major outage on the Actions component), and four jobs died before running a single step — `trivy-scan`, `terminal e2e (ubuntu-latest)`, `test (4/5)` with `##[error]Failed to resolve action download info. Error: Service Unavailable / The HTTP request timed out after 00:01:40`, and `terminal e2e (macos-latest)` cancelled with an Azure `BlobNotFound`. No test code executed in any of them. `lint`, `test (2/5)` and `test (3/5)` went green before the outage bit.

A later green attempt on this PR is therefore an infrastructure retry, not a flaky test going green on a second try.
