### PR TITLE
Give the Windows app window and taskbar an icon at runtime

### DIFF
--- a/change-logs/2026/08/08/fix-windows-window-taskbar-icon.md
+++ b/change-logs/2026/08/08/fix-windows-window-taskbar-icon.md
@@ -1,0 +1,3 @@
+Short: Windows window and taskbar icon
+
+The dev-3.0 window on Windows now shows the app icon in its title bar and in the taskbar instead of the generic system default. Electrobun never assigns an icon to its window class, so the app sets one itself at startup from the icon already embedded in its own executables.

--- a/decisions/2026/08/06/runtime-window-icon-via-win32-ffi.md
+++ b/decisions/2026/08/06/runtime-window-icon-via-win32-ffi.md
@@ -1,0 +1,164 @@
+# We set the Windows window/taskbar icon ourselves, from Bun, at runtime
+
+## Context
+
+The decision record `vendor-rcedit-for-windows-icons` gave the Windows executables an icon
+resource and closed with the half it could not reach: the **running window and its
+taskbar button** stayed on the system default. A PE icon resource governs Explorer,
+shortcuts and the Start menu. It does not decorate a window.
+
+The taskbar is where a user looks to know the app is theirs, so an unbranded window
+is the most visible way a desktop build reads as unfinished — on the one platform we
+are asking people to try for the first time.
+
+## Investigation
+
+Read out of `package/src/native/win/nativeWrapper.cpp` in electrobun, fetched at the
+exact tag we ship (`v1.18.1`, `package.json` pins `"electrobun": "1.18.1"`):
+
+- `createWindowWithFrameAndStyleFromWorker` is declared
+  **`ELECTROBUN_EXPORT HWND`**. The pointer it returns — surfaced in JS as
+  `BrowserWindow.ptr` and passed straight back into every window FFI call — **is the
+  raw `HWND`** on Windows. That is the whole enabling fact: the window handle is
+  already in our hands, in Bun, with no patching.
+- `BasicWindowClass` is registered as `WNDCLASSA wc = {0}` with only `lpfnWndProc`,
+  `hInstance` and `lpszClassName` assigned. **`hIcon` is never set**, and the file
+  contains no `WM_SETICON`, `LoadIconW` or `SetClassLongPtr` for an app window. The
+  only `hIcon` writes are the tray `NOTIFYICONDATA`.
+- Electrobun exports `setWindowIcon(void* window, const char* iconPath)` and its
+  Windows body is an **explicit no-op** carrying `// TODO: Implement using
+  SetWindowIcon/LoadImage APIs`. It works on Linux. So the gap is known upstream and
+  unstaffed, not accidental.
+
+**Two corrections to the `vendor-rcedit-for-windows-icons` record**, which read the same file less closely:
+
+| That record says | Actually |
+|---|---|
+| `WNDCLASSW wc = {0}` with `hCursor` set | `WNDCLASSA wc = {0}`, no `hCursor` (that is `ContainerViewClass`) |
+| `hInstance` is the native wrapper **DLL** | `hInstance = GetModuleHandle(NULL)` — the **executable** that loaded the DLL |
+
+Neither changes that record's conclusion (`hIcon` is zero, so the icon is a system
+fallback), but the second one matters here: the module the window class belongs to
+is `bun.exe`, the very file that record embedded the icon into.
+
+## Decision
+
+**Set the icon at runtime from Bun, through `bun:ffi`, out of our own executable.**
+
+1. `src/bun/windows-icons/win32-icon-surface.ts` — `ExtractIconExW` (shell32) reads
+   icon index 0 out of a PE file by **path**, then `SendMessageW(hwnd, WM_SETICON,
+   ICON_BIG|ICON_SMALL, hIcon)` (user32) hands it to the window. Both DLLs are part
+   of Windows, so this vendors nothing and assumes no binary on `PATH` — the rule
+   this repo was burned by in `pin-tmux-3.6-vendored-keg`.
+2. The icon source is our own executables: `process.execPath` first, then
+   `bin/bun.exe` and `bin/launcher.exe` under the bundle root. That is the icon
+   the `vendor-rcedit-for-windows-icons` record already embedded, so this ships **no new asset**, needs **no copy
+   rule** in `electrobun.config.ts`, and never guesses at the resource ID rcedit
+   happened to write — `ExtractIconExW` addresses it by index, not by name.
+3. `src/bun/windows-icons/window-icon.ts` holds all the decision logic behind an
+   injected `Win32IconSurface`, so it is unit-tested on macOS. Every assertion in it
+   fails on an empty list rather than looping zero times: an empty source list, an
+   empty handle list, and a "no executable carried an icon" miss are all errors,
+   because a step that decorates nothing is visually identical to one that worked.
+4. `src/bun/windows-icons/apply-window-icon.ts` is the call site glue in
+   `src/bun/window-manager.ts`, right after `new BrowserWindow`. It is a no-op off
+   Windows and **never fatal** — an app that refuses to open a window because it
+   could not decorate it is strictly worse than the default icon.
+5. Icon handles are extracted once, cached per executable path, shared by every
+   window and deliberately never passed to `DestroyIcon`: one pair of handles for
+   the life of the process.
+
+## The two failures that look exactly like success
+
+Both are the reason this module has assertions at all, and each is a named guard in
+`window-icon.ts` with its own mutation proof:
+
+| The trap | Guard | What it says |
+|---|---|---|
+| **No executable carries an icon.** A plain local build may never have run the embed step, `ExtractIconExW` returns zero, and nothing is set. | the throw at the end of `loadAppIcon` | names `embed-windows-icons.ts` — so this half's failure cannot be mistaken for the other half's |
+| **An icon came back, but the handle is Win32 `NULL`.** `WM_SETICON` with a null handle **REMOVES** the icon rather than setting one, so the app would actively un-decorate its own window while every call reported success. | the null-handle check inside `loadAppIcon`'s loop | names which executable returned it and what `WM_SETICON` would have done |
+
+Six guards, each broken on purpose and confirmed red, then green again: empty
+candidate list, empty source list, **null icon handle**, **no executable carries an
+icon**, empty window-handle list, handle rejected by `IsWindow`.
+
+## This change is OUT of Windows CI scope, and that is not an oversight
+
+None of the files here appear in `WINDOWS_SCOPE_PATHS`
+(`src/shared/windows-ci-scope.ts`); checked by running the repo's own
+`windowsScopeHits()` over this commit's file list, which returns `[]`. So the
+packaged Windows jobs are **deliberately not dispatched** for this change, and a
+green CI run says **nothing** about Windows here.
+
+The list is not extended on purpose: it is held in an open PR by another task, and a
+separate task owns auditing it. Widening it from here would collide with both.
+
+## What is verified, and what is not
+
+Agents run on macOS; this defect is visible only on a Windows desktop. **Do not read
+this record as "fixed".**
+
+| | What | How far it was checked |
+|---|---|---|
+| 🟢 | `BrowserWindow.ptr` is the `HWND` | read from electrobun's own source at the pinned tag |
+| 🟢 | The decision logic and every assertion | 36 unit tests; all six guards mutation-proved red/green |
+| 🟢 | Type-check and the full suite | `bun run lint`, `bun run test` |
+| 🔴 | The icon actually appearing in the taskbar | **never observed** — needs a Windows desktop |
+| 🔴 | `ExtractIconExW`/`SendMessageW` through `bun:ffi` on Windows | never executed anywhere |
+
+## How to read what a Windows machine shows you
+
+Look at three surfaces — the window's title-bar corner, the taskbar button, and the
+Alt-Tab switcher. Explorer is not one of them: it caches an icon per file path and
+will show a stale one long after the bytes changed.
+
+| What you see | What it means | What to do |
+|---|---|---|
+| The app icon | The mechanism works | Nothing |
+| No icon — the generic default | Read the single `[window-icon]` line in the log | If it names `embed-windows-icons.ts`, the icon never reached the executable and the fault is in the embed step, not here |
+| The icon **disappears** | **The premise of the null-handle guard is wrong.** A null handle cannot reach `WM_SETICON` — that guard throws first — so vanishing means `ExtractIconExW` returned handles that are non-null and still **invalid** | Stop. The fix is a *validity* check on the handles, not a null check. There is no guard for this case |
+
+The third row is the dangerous one and is why the three are written down: a guard
+whose premise is false is worse than a missing guard, because it reports success
+while proving nothing. **Do not change code before recording which of the three you
+saw** — the difference between them is the whole diagnosis, and it is destroyed the
+moment the code moves underneath the observation.
+
+## Risks
+
+- **The FFI path has never run.** A wrong `FFIType` or a `dlopen` failure surfaces as
+  one warning line and the default icon, not a crash — but it also means the first
+  real evidence comes from a Windows machine.
+- **`ExtractIconExW` needs the embed from the `vendor-rcedit-for-windows-icons` record to have worked.** If it did
+  not, the loop finds no icon and throws a message naming
+  `embed-windows-icons.ts`. The two halves are chained on purpose.
+- **A future electrobun release may implement `setWindowIcon` on Windows.** Then both
+  set the same icon — idempotent and harmless. Delete this module at that point
+  rather than keeping two paths (no-deprecation rule).
+- **`BrowserWindow.ptr` is an undocumented contract.** If upstream ever returns
+  something other than an `HWND`, `IsWindow` rejects it and the assertion names
+  `nativeWrapper.cpp` instead of failing silently.
+
+## Alternatives considered
+
+- **Patch or contribute upstream.** Correct in principle and the right long-term home
+  — the upstream `TODO` is sitting right there. Rejected as *the* fix because our
+  users would wait on someone else's release cycle for an unknown number of months
+  for a defect we can close today, and because electrobun's CLI ships as a compiled
+  binary we do not build (`vendor-rcedit-for-windows-icons`), so we could not even test a patch locally. Worth
+  filing upstream separately; nothing here has to wait on it.
+- **Vendor a native shim of our own.** A tiny DLL that does the same three Win32
+  calls. Rejected: it adds a binary to build, sign and ship for a job `bun:ffi` does
+  with two `dlopen`s against DLLs Windows guarantees, and it would re-create exactly
+  the "assume a binary exists" exposure the tmux incident taught us to avoid.
+- **Set the icon on the window CLASS** (`SetClassLongPtrW`, `GCLP_HICON`) so windows
+  we never see inherit it. Rejected as unnecessary: every dev-3.0 window is created
+  through `window-manager.ts`, and a per-window `WM_SETICON` is what the taskbar
+  reads. Class-level state shared with electrobun's own internals buys nothing here.
+- **Ship an `.ico` next to the app and `LoadImageW` it.** Rejected: a second copy of
+  the icon to ship and keep in sync, plus a copy rule in `electrobun.config.ts` —
+  which is contended build-config territory — to gain nothing over reading the
+  resource already inside our own executable.
+- **Accept the default icon and document it.** Rejected. It is the single most
+  visible way the Windows build reads as unfinished, and the fix costs three Win32
+  calls.

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -3,6 +3,7 @@ import type { AppRPCSchema } from "../shared/types";
 import { createLogger } from "./logger";
 import { loadWindowState, saveWindowState, resolveRestoreFrame, displayContaining, type Rect } from "./window-state";
 import { isFreshStartMode } from "./fresh-start";
+import { applyWindowsWindowIcon } from "./windows-icons/apply-window-icon";
 
 const log = createLogger("window-manager");
 
@@ -130,6 +131,12 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		rpc,
 		frame,
 	});
+
+	// Windows draws a system-fallback icon in the window and the taskbar because
+	// electrobun never assigns one to its window class; we set it ourselves from
+	// the icon already embedded in our executables. No-op off Windows, where the
+	// bundle's own icon already reaches the dock and the launcher.
+	applyWindowsWindowIcon(win.ptr as unknown as number);
 
 	const id = ++seq;
 	const entry: WindowEntry = { window: win, id };

--- a/src/bun/windows-icons/__tests__/window-icon.test.ts
+++ b/src/bun/windows-icons/__tests__/window-icon.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import {
+	applyIconToWindows,
+	loadAppIcon,
+	resolveIconSources,
+	setWindowIcon,
+	type IconPair,
+	type Win32IconSurface,
+} from "../window-icon";
+
+const ICONS: IconPair = { big: 4242n, small: 4243n };
+const BUNDLE_ROOT = join("C:", "Users", "a", "AppData", "Local", "dev-3.0");
+const EXEC_PATH = join(BUNDLE_ROOT, "bin", "bun.exe");
+
+/** A Windows where `iconBearing` files carry an icon and `liveWindows` exist. */
+function fakeWin32(options: { iconBearing?: string[]; liveWindows?: number[] } = {}) {
+	const iconBearing = new Set(options.iconBearing ?? []);
+	const liveWindows = new Set(options.liveWindows ?? []);
+	const applied: Array<{ hwnd: number; icons: IconPair }> = [];
+	const inspected: string[] = [];
+	const surface: Win32IconSurface = {
+		extractIcons: (exePath) => {
+			inspected.push(exePath);
+			return iconBearing.has(exePath) ? ICONS : null;
+		},
+		applyToWindow: (hwnd, icons) => {
+			if (!liveWindows.has(hwnd)) return false;
+			applied.push({ hwnd, icons });
+			return true;
+		},
+	};
+	return { surface, applied, inspected };
+}
+
+describe("resolveIconSources", () => {
+	it("tries the running executable first, then the bundle's two executables", () => {
+		expect(resolveIconSources(EXEC_PATH, BUNDLE_ROOT, join)).toEqual([
+			EXEC_PATH,
+			join(BUNDLE_ROOT, "bin", "bun.exe"),
+			join(BUNDLE_ROOT, "bin", "launcher.exe"),
+		].filter((path, index, all) => all.indexOf(path) === index));
+	});
+
+	it("keeps no duplicate when the running executable IS the bundle's bun.exe", () => {
+		const sources = resolveIconSources(EXEC_PATH, BUNDLE_ROOT, join);
+		expect(new Set(sources).size).toBe(sources.length);
+		expect(sources).toContain(join(BUNDLE_ROOT, "bin", "launcher.exe"));
+	});
+
+	it("fails naming the caller when every candidate is empty, instead of searching nothing", () => {
+		expect(() => resolveIconSources("", "", () => "")).toThrowError(/src\/bun\/window-manager\.ts/);
+	});
+});
+
+describe("loadAppIcon", () => {
+	it("returns the icon from the first executable that carries one", () => {
+		const win32 = fakeWin32({ iconBearing: [EXEC_PATH] });
+		expect(loadAppIcon([EXEC_PATH, "other.exe"], win32.surface)).toEqual(ICONS);
+		expect(win32.inspected).toEqual([EXEC_PATH]);
+	});
+
+	it("falls through to a later executable when the first carries no icon", () => {
+		const launcher = join(BUNDLE_ROOT, "bin", "launcher.exe");
+		const win32 = fakeWin32({ iconBearing: [launcher] });
+		expect(loadAppIcon([EXEC_PATH, launcher], win32.surface)).toEqual(ICONS);
+		expect(win32.inspected).toEqual([EXEC_PATH, launcher]);
+	});
+
+	it("fails naming the build step when no executable carries an icon", () => {
+		const win32 = fakeWin32();
+		expect(() => loadAppIcon([EXEC_PATH], win32.surface)).toThrowError(/embed-windows-icons\.ts/);
+	});
+
+	it("rejects a null icon handle instead of handing WM_SETICON a value that REMOVES the icon", () => {
+		const surface: Win32IconSurface = {
+			extractIcons: () => ({ big: 0n, small: 0n }),
+			applyToWindow: () => true,
+		};
+		expect(() => loadAppIcon([EXEC_PATH], surface)).toThrowError(/null icon handle/);
+	});
+
+	it("rejects a pair where only the small icon is null", () => {
+		const surface: Win32IconSurface = {
+			extractIcons: () => ({ big: 4242n, small: 0n }),
+			applyToWindow: () => true,
+		};
+		expect(() => loadAppIcon([EXEC_PATH], surface)).toThrowError(/REMOVES the window's icon/);
+	});
+
+	it("fails on an empty list rather than looping zero times and reporting success", () => {
+		const win32 = fakeWin32({ iconBearing: [EXEC_PATH] });
+		expect(() => loadAppIcon([], win32.surface)).toThrowError(/zero times/);
+	});
+});
+
+describe("applyIconToWindows", () => {
+	it("hands the icon to every window handle", () => {
+		const win32 = fakeWin32({ liveWindows: [11, 22] });
+		applyIconToWindows([11, 22], ICONS, win32.surface);
+		expect(win32.applied).toEqual([
+			{ hwnd: 11, icons: ICONS },
+			{ hwnd: 22, icons: ICONS },
+		]);
+	});
+
+	it("fails on an empty handle list rather than decorating nothing and reporting success", () => {
+		const win32 = fakeWin32({ liveWindows: [11] });
+		expect(() => applyIconToWindows([], ICONS, win32.surface)).toThrowError(/no window handles/);
+		expect(win32.applied).toEqual([]);
+	});
+
+	it("fails naming electrobun's HWND contract when a handle is not a live window", () => {
+		const win32 = fakeWin32({ liveWindows: [11] });
+		expect(() => applyIconToWindows([11, 99], ICONS, win32.surface)).toThrowError(/nativeWrapper\.cpp/);
+	});
+});
+
+describe("setWindowIcon", () => {
+	it("resolves the icon and applies it to the window", () => {
+		const win32 = fakeWin32({ iconBearing: [EXEC_PATH], liveWindows: [7] });
+		setWindowIcon(7, { execPath: EXEC_PATH, bundleRoot: BUNDLE_ROOT, joinPath: join }, win32.surface);
+		expect(win32.applied).toEqual([{ hwnd: 7, icons: ICONS }]);
+	});
+
+	it("does not touch the window when no executable carries an icon", () => {
+		const win32 = fakeWin32({ liveWindows: [7] });
+		expect(() => setWindowIcon(7, { execPath: EXEC_PATH, bundleRoot: BUNDLE_ROOT, joinPath: join }, win32.surface)).toThrow();
+		expect(win32.applied).toEqual([]);
+	});
+});

--- a/src/bun/windows-icons/apply-window-icon.ts
+++ b/src/bun/windows-icons/apply-window-icon.ts
@@ -1,0 +1,30 @@
+/**
+ * Glue between `window-manager.ts` and the Win32 calls: no-op everywhere except
+ * Windows, and never fatal. An app that refuses to open a window because it could
+ * not decorate it would be strictly worse than the default icon we already ship.
+ */
+import { join } from "node:path";
+import { createLogger } from "../logger";
+import { setWindowIcon } from "./window-icon";
+import { loadWin32IconSurface } from "./win32-icon-surface";
+
+const log = createLogger("window-icon");
+
+/** Fire-and-forget: gives one freshly created window its taskbar icon on Windows. */
+export function applyWindowsWindowIcon(handle: number | null | undefined): void {
+	if (process.platform !== "win32") return;
+	if (typeof handle !== "number" || handle === 0) {
+		log.warn("No window handle to set an icon on; the window keeps the default Windows icon", { handle: String(handle) });
+		return;
+	}
+
+	void (async () => {
+		try {
+			const surface = await loadWin32IconSurface();
+			setWindowIcon(handle, { execPath: process.execPath, bundleRoot: process.cwd(), joinPath: join }, surface);
+			log.info("Window and taskbar icon applied");
+		} catch (error) {
+			log.warn("Window icon not applied; the window keeps the default Windows icon", { error: String(error) });
+		}
+	})();
+}

--- a/src/bun/windows-icons/win32-icon-surface.ts
+++ b/src/bun/windows-icons/win32-icon-surface.ts
@@ -1,0 +1,68 @@
+/**
+ * The Win32 half of the runtime window icon: `ExtractIconExW` to read the icon
+ * out of one of our own executables, `SendMessageW(WM_SETICON)` to hand it to a
+ * live window. Decision logic lives in `window-icon.ts`; this file is only the
+ * calls, and is imported dynamically so nothing outside Windows loads it.
+ *
+ * `user32.dll` and `shell32.dll` are part of Windows itself, so this adds no
+ * vendored binary and makes no PATH assumption — the standing rule from the
+ * `tmux@3.6` incident (the decision record `pin-tmux-3.6-vendored-keg`).
+ */
+import type { IconPair, Win32IconSurface } from "./window-icon";
+
+const WM_SETICON = 0x0080;
+const ICON_SMALL = 0n;
+const ICON_BIG = 1n;
+
+function wide(value: string): Uint16Array {
+	const out = new Uint16Array(value.length + 1);
+	for (let i = 0; i < value.length; i++) out[i] = value.charCodeAt(i);
+	return out;
+}
+
+/**
+ * The extracted handles are kept for the life of the process and shared by every
+ * window, so they are deliberately never passed to `DestroyIcon`: one pair of
+ * handles per process, released when the process exits.
+ */
+export async function loadWin32IconSurface(): Promise<Win32IconSurface> {
+	const { dlopen, FFIType } = await import("bun:ffi");
+	const { i32, ptr, u32, u64 } = FFIType;
+
+	const shell32 = dlopen("shell32.dll", {
+		ExtractIconExW: { args: [ptr, i32, ptr, ptr, u32], returns: u32 },
+	} as const);
+	const user32 = dlopen("user32.dll", {
+		SendMessageW: { args: [u64, u32, u64, u64], returns: u64 },
+		IsWindow: { args: [u64], returns: i32 },
+	} as const);
+
+	const cache = new Map<string, IconPair | null>();
+
+	return {
+		extractIcons(exePath: string): IconPair | null {
+			const cached = cache.get(exePath);
+			if (cached !== undefined) return cached;
+
+			const big = new BigUint64Array(1);
+			const small = new BigUint64Array(1);
+			const extracted = shell32.symbols.ExtractIconExW(wide(exePath), 0, big, small, 1);
+			// A file with no icon resource returns zero icons and leaves both handles
+			// null — the same shape as a path that does not exist at all.
+			const icons = extracted > 0 && big[0] !== 0n && small[0] !== 0n ? { big: big[0], small: small[0] } : null;
+			cache.set(exePath, icons);
+			return icons;
+		},
+
+		applyToWindow(hwnd: number, icons: IconPair): boolean {
+			const handle = BigInt(hwnd);
+			// SendMessageW returns the PREVIOUS icon, which is legitimately zero on
+			// the first call, so it cannot be the success test. The window handle
+			// being live is the only thing worth checking.
+			if (user32.symbols.IsWindow(handle) === 0) return false;
+			user32.symbols.SendMessageW(handle, WM_SETICON, ICON_BIG, icons.big);
+			user32.symbols.SendMessageW(handle, WM_SETICON, ICON_SMALL, icons.small);
+			return true;
+		},
+	};
+}

--- a/src/bun/windows-icons/window-icon.ts
+++ b/src/bun/windows-icons/window-icon.ts
@@ -1,0 +1,128 @@
+/**
+ * Gives the RUNNING app's window — and therefore its taskbar button — an icon on
+ * Windows. This is a different surface from the icon resource embedded into the
+ * executables by `embed-windows-icons.ts`, which only governs Explorer, shortcuts
+ * and the Start menu.
+ *
+ * Electrobun registers its `BasicWindowClass` with `hIcon` left at zero and never
+ * calls `WM_SETICON`, `LoadIconW` or `SetClassLongPtr` for an app window, so what
+ * Windows draws is the system fallback rather than anything anyone loaded. Its own
+ * `setWindowIcon` export is an explicit no-op on Windows. See
+ * the decision record `runtime-window-icon-via-win32-ffi`.
+ *
+ * Everything here is platform-agnostic decision logic driven through an injected
+ * `Win32IconSurface`, so it is exercised on the machines we actually develop on.
+ * The Win32 calls themselves live in `win32-icon-surface.ts`.
+ */
+
+/** Big + small icon handles, as returned by `ExtractIconExW`. */
+export interface IconPair {
+	big: bigint;
+	small: bigint;
+}
+
+export interface Win32IconSurface {
+	/**
+	 * Pulls icon index 0 out of a PE file. Returns `null` when the file carries no
+	 * icon resource — which is exactly what an executable looks like when the
+	 * embedding step in `embed-windows-icons.ts` did not run.
+	 */
+	extractIcons(exePath: string): IconPair | null;
+	/** `true` only if the handle is a live window that accepted both icons. */
+	applyToWindow(hwnd: number, icons: IconPair): boolean;
+}
+
+/**
+ * Where the icon comes from: our own executables, which already carry the icon
+ * resource. Reusing them means no extra file to ship, no copy rule to keep in
+ * sync, and no guessing at the resource ID rcedit happened to write.
+ *
+ * `execPath` is the running `bun.exe` and is tried first because it is the one
+ * path that cannot be wrong. The bundle-relative entries are the fallback for a
+ * layout where the process is started through something else.
+ */
+export function resolveIconSources(execPath: string, bundleRoot: string, joinPath: (...parts: string[]) => string): string[] {
+	const candidates = [execPath, joinPath(bundleRoot, "bin", "bun.exe"), joinPath(bundleRoot, "bin", "launcher.exe")];
+	const sources = candidates.filter((path, index) => path.length > 0 && candidates.indexOf(path) === index);
+	if (sources.length === 0) {
+		throw new Error(
+			"No candidate executable to read the window icon from. " +
+				"Cause: both process.execPath and the bundle root resolved to empty strings, so the search would have inspected nothing. " +
+				"Fix: check the caller in src/bun/window-manager.ts — it must pass process.execPath and process.cwd().",
+		);
+	}
+	return sources;
+}
+
+/**
+ * Loads the icon from the first source that carries one. Throws rather than
+ * returning `null`, because a silent miss here is indistinguishable from success:
+ * the window keeps the same default icon either way.
+ */
+export function loadAppIcon(sources: string[], surface: Win32IconSurface): IconPair {
+	if (sources.length === 0) {
+		throw new Error(
+			"Window icon lookup was handed an empty list of executables. " +
+				"Cause: the candidate list was filtered away, so the loop would have run zero times and reported success. " +
+				"Fix: pass the full list from resolveIconSources().",
+		);
+	}
+
+	for (const source of sources) {
+		const icons = surface.extractIcons(source);
+		if (!icons) continue;
+		// A zero handle is Win32's null. Handing it to WM_SETICON REMOVES the icon,
+		// so "an IconPair came back" is not the same as "an icon came back" — the two
+		// must be separated here or a no-op reports success.
+		if (icons.big === 0n || icons.small === 0n) {
+			throw new Error(
+				`${source} returned a null icon handle (big=${icons.big}, small=${icons.small}). ` +
+					"Cause: ExtractIconExW reported an icon but handed back Win32 NULL; passing that to WM_SETICON REMOVES the window's icon instead of setting one. " +
+					"Fix: check the icon resource in that executable — src/bun/windows-icons/embed-windows-icons.ts writes it.",
+			);
+		}
+		return icons;
+	}
+
+	throw new Error(
+		`None of ${sources.join(", ")} carries an icon resource. ` +
+			"Cause: the build did not embed the app icon into the Windows executables, so there is nothing to hand the window. " +
+			"Fix: check the [windows-icons] lines in the build log and src/bun/windows-icons/embed-windows-icons.ts.",
+	);
+}
+
+/**
+ * Applies the icon to every window handle. An empty list is a failure, not a
+ * no-op: this whole module exists because a step that touches nothing currently
+ * looks exactly like a step that worked.
+ */
+export function applyIconToWindows(handles: number[], icons: IconPair, surface: Win32IconSurface): void {
+	if (handles.length === 0) {
+		throw new Error(
+			"Window icon application was handed no window handles. " +
+				"Cause: BrowserWindow.ptr was missing or zero, so no window was given an icon while the call reported success. " +
+				"Fix: check that electrobun still returns the HWND from createWindow (src/bun/window-manager.ts passes window.ptr).",
+		);
+	}
+
+	const rejected = handles.filter((handle) => !surface.applyToWindow(handle, icons));
+	if (rejected.length > 0) {
+		throw new Error(
+			`WM_SETICON was rejected for window handle(s) ${rejected.join(", ")}. ` +
+				"Cause: the handle is not a live window — electrobun's createWindow no longer returns an HWND, or the window was already destroyed. " +
+				"Fix: re-check that createWindowWithFrameAndStyleFromWorker still returns HWND in electrobun's native/win/nativeWrapper.cpp.",
+		);
+	}
+}
+
+export interface WindowIconEnvironment {
+	execPath: string;
+	bundleRoot: string;
+	joinPath(...parts: string[]): string;
+}
+
+/** Resolve the icon and put it on one window. */
+export function setWindowIcon(handle: number, env: WindowIconEnvironment, surface: Win32IconSurface): void {
+	const icons = loadAppIcon(resolveIconSources(env.execPath, env.bundleRoot, env.joinPath), surface);
+	applyIconToWindows([handle], icons, surface);
+}


### PR DESCRIPTION
Hi — this is Claude, the AI assistant that wrote this branch.

## The window and taskbar icon is UNVERIFIED, and no check on this PR can verify it

**None of the four required checks exercises Windows.** These files sit outside `WINDOWS_SCOPE_PATHS`, so the packaged Windows proof is deliberately not dispatched for this change — verified by running the repo's own `windowsScopeHits()` over this commit's file list, which returns `[]`. A fully green PR here is not weak evidence about the Windows icon; it is **zero** evidence. The only verification that exists is a human looking at a Windows build.

## What this does

Electrobun registers its window class with `hIcon` never assigned and never calls `WM_SETICON`, so the running app's window and taskbar button show a Windows system fallback. Its own exported `setWindowIcon` is an explicit no-op on Windows with a `TODO`. The PR before this one (#1273) embedded an icon resource into the executables, which governs Explorer, shortcuts and the Start menu — but a PE resource does not decorate a window.

This sets the icon at runtime from Bun via `bun:ffi`: `ExtractIconExW` (shell32) reads icon index 0 out of our own `bun.exe` — the icon #1273 already embedded — and `SendMessageW(WM_SETICON)` (user32) hands it to each window as it is created. Both DLLs ship with Windows, so nothing is vendored and no binary is assumed on `PATH`. No-op off Windows, and never fatal.

The enabling fact, read from electrobun's own source at the pinned tag: `createWindowWithFrameAndStyleFromWorker` is declared `ELECTROBUN_EXPORT HWND`, so `BrowserWindow.ptr` **is** the raw `HWND`.

Decision record: `decisions/2026/08/06/runtime-window-icon-via-win32-ffi.md`. It also corrects two factual errors about `nativeWrapper.cpp` in the `vendor-rcedit-for-windows-icons` record.

## The guard worth reviewing, out of six

`ExtractIconExW` can report success and hand back a **null handle**. `WM_SETICON` with a null handle does not set an icon — it **removes** one. Without that guard the app would strip its own window icon while every call returned success. All six guards are mutation-proved red/green.

## This PR does NOT have a green local test suite

Being explicit rather than letting the CI badge speak:

- Two full runs on `b52092b45` came back red. First started at load 9.95 and hit 143; second started at **7.25 / 14.38** after an eight-minute monotonic drain and was at 95 by 45 seconds in.
- A **paired baseline on clean `origin/main` (2e29a4249)** in a separate worktree, under comparable load (13 before, **79 during**), is **also red** — with different failures. That is why the red is attributed to the machine rather than to this diff.
- Across both runs on this sha: 22 timeouts / `STACK_TRACE_ERROR` and **one real assertion**. The failure set reshuffled between runs on frozen code.

### The one unexplained failure — one observation, not absent

`src/bun/__tests__/cli-socket-label-delete-race.test.ts:175` — *"deletes the label from project and all tasks (no concurrency)"* — `AssertionError: expected [ 'label-kept-2222', ...(1) ] to deeply equal [ 'label-kept-2222' ]`.

It is **not** explained by the baseline, and I am not claiming it is:

- The baseline **did** cover it. Proved by collection, not by absence in a log: `vitest list` with the baseline's exact config and excludes collects **5371** tests including all four `label-delete-race` entries by name, and the run reported 5369 passed + 2 failed = **5371** exactly. Collected set = executed set.
- That file alone: **5/5 green at load 69** on this branch, **4/4 green at load 23.6** on clean `main`. Both siblings run in those passes, so whatever produces it needs the whole concurrent suite.
- Unproven hypothesis: its concurrent sibling died with `STACK_TRACE_ERROR` in the same run, and this is the no-concurrency case seeing residue.

### A known defect in my own baseline method

The baseline's CLI side is **invalid** and I am not citing it. A fresh worktree lacks `src/shared/build-info.generated.ts`, which is generated by `bun run lint` and not tracked, so `doctor.test.ts` and `doctor-worktrees.test.ts` failed to import and four CLI suites never loaded — 24 collected instead of 764. A collection error yields a *smaller pass count*, not a red, so the broken side looks like a healthy run. The **bun** config, where the assertion lives, is exactly paired.

### Also reproduced on clean main

`App.test.tsx` → *"refuses Cmd+2 into the sensitive project"* failed on clean `2e29a4249` with `Unable to find an element by: [data-testid="project-screen"]`. First sighting of that flake on code this branch did not touch.

## How to read a Windows build

Look at the **title-bar corner**, the **taskbar button** and **Alt-Tab**. Ignore Explorer — it caches icons per path and will show a stale one.

| What you see | What it means |
|---|---|
| The app icon | Works |
| No icon | Read the single `[window-icon]` log line; if it names `embed-windows-icons.ts`, the icon never reached the executable and the fault is the embed step |
| The icon **disappears** | **Stop, do not patch.** A null handle cannot reach `WM_SETICON` — that guard throws first — so vanishing means the guard's premise is wrong and the fix is a *validity* check on the handles |
