### PR TITLE
Render a phone-shaped Kanban loading skeleton on narrow viewports

### DIFF
--- a/change-logs/2026/08/08/fix-mobile-kanban-loading-skeleton.md
+++ b/change-logs/2026/08/08/fix-mobile-kanban-loading-skeleton.md
@@ -1,0 +1,3 @@
+Short: Phone-shaped Kanban loading skeleton
+
+The Kanban loading placeholder now matches the phone layout it precedes: below 768px it shows a single full-width column under a pager row instead of five squeezed vertical rails, so the board reads as loading rather than as an empty grid.

--- a/src/mainview/components/KanbanBoardSkeleton.tsx
+++ b/src/mainview/components/KanbanBoardSkeleton.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useState } from "react";
 import { useT } from "../i18n";
+import { useNarrowViewport } from "../hooks/useNarrowViewport";
+import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 
 /** Placeholder card counts per column — uneven so the board reads as content. */
 const COLUMN_CARDS = [3, 2, 4, 2, 3];
+
+/** Enough cards to fill a phone screen; the column clips the overflow. */
+const PHONE_CARDS = 12;
 
 /** Local fetches resolve in a few ms; don't flash a skeleton at them. */
 const DEFAULT_APPEAR_AFTER_MS = 200;
@@ -19,6 +24,7 @@ export default function KanbanBoardSkeleton({
 	appearAfterMs?: number;
 }) {
 	const t = useT();
+	const isCarousel = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	const [visible, setVisible] = useState(appearAfterMs === 0);
 
 	useEffect(() => {
@@ -28,6 +34,39 @@ export default function KanbanBoardSkeleton({
 	}, [appearAfterMs]);
 
 	if (!visible) return <div className="flex-1 min-h-0" />;
+
+	// Phones get the carousel shell — one full-width column under a pager row.
+	// Five columns squeezed into a phone read as empty vertical rails, not as a
+	// board that is loading.
+	if (isCarousel) {
+		return (
+			<div
+				className="flex-1 min-h-0 flex flex-col"
+				role="status"
+				aria-label={t("kanban.loadingTasks")}
+				data-testid="kanban-skeleton"
+			>
+				<div className="flex items-center gap-2 px-2 py-2 border-b border-edge flex-shrink-0 animate-pulse">
+					<div className="w-9 h-9 rounded-lg bg-elevated" />
+					<div className="flex-1 flex justify-center">
+						<div className="h-3 w-12 rounded-full bg-elevated" />
+					</div>
+					<div className="w-9 h-9 rounded-lg bg-elevated" />
+				</div>
+				<div className="flex-1 min-h-0 flex px-3 pb-3 pt-2">
+					<div
+						className="flex-1 min-w-0 flex flex-col gap-3 overflow-hidden rounded-2xl border border-edge bg-raised/40 p-3 animate-pulse"
+						data-testid="kanban-skeleton-column"
+					>
+						<div className="h-3 w-24 flex-shrink-0 rounded-full bg-elevated" />
+						{Array.from({ length: PHONE_CARDS }, (_, cardIndex) => (
+							<div key={cardIndex} className="h-20 flex-shrink-0 rounded-xl bg-elevated" />
+						))}
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div
@@ -40,6 +79,7 @@ export default function KanbanBoardSkeleton({
 				<div
 					key={columnIndex}
 					className="flex-1 min-w-0 flex flex-col gap-3 rounded-2xl border border-edge bg-raised/40 p-3 animate-pulse"
+					data-testid="kanban-skeleton-column"
 				>
 					<div className="h-3 w-24 rounded-full bg-elevated" />
 					{Array.from({ length: cards }, (_, cardIndex) => (

--- a/src/mainview/components/__tests__/KanbanBoardSkeleton.test.tsx
+++ b/src/mainview/components/__tests__/KanbanBoardSkeleton.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import KanbanBoardSkeleton from "../KanbanBoardSkeleton";
+import { I18nProvider } from "../../i18n";
+
+function mockViewport(narrow: boolean) {
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: (query: string) => ({
+			matches: narrow,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}),
+	});
+}
+
+function renderSkeleton() {
+	return render(
+		<I18nProvider>
+			<KanbanBoardSkeleton appearAfterMs={0} />
+		</I18nProvider>,
+	);
+}
+
+describe("KanbanBoardSkeleton", () => {
+	it("renders five columns on a wide viewport", () => {
+		mockViewport(false);
+		renderSkeleton();
+		expect(screen.getAllByTestId("kanban-skeleton-column")).toHaveLength(5);
+	});
+
+	it("renders a single full-width column on a phone viewport", () => {
+		mockViewport(true);
+		renderSkeleton();
+		expect(screen.getAllByTestId("kanban-skeleton-column")).toHaveLength(1);
+		expect(screen.getByTestId("kanban-skeleton")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
The Kanban loading placeholder always drew five columns, with no responsive handling at all. Below 768px the real board switches to a one-column carousel (`MobileBoardCarousel`), so on a phone the skeleton showed a layout that never appears once tasks load — five squeezed vertical rails reading as an empty grid rather than a loading board.

The skeleton now mirrors that layout: below `CAROUSEL_MAX_WIDTH` it renders a pager row plus a single full-width column whose cards fill the screen height (the column clips the overflow). The wide-viewport branch is unchanged.

Also adds `data-testid="kanban-skeleton-column"` and a unit test covering both viewport shapes.