### PR TITLE
Scale a phone per screen: dense inside a task, 25% roomier to browse

### DIFF
--- a/change-logs/2026/08/08/fix-mobile-per-screen-density.md
+++ b/change-logs/2026/08/08/fix-mobile-per-screen-density.md
@@ -1,0 +1,3 @@
+Short: Board and dashboard 25% bigger on phone
+
+The phone used one scale everywhere, tuned for working inside a task, which left the Kanban board and the dashboard reading as a thumbnail of a desktop board. Screens you only browse — board, dashboard, settings, stats, changelog — are now 25% larger, while a task's terminal, diff and inspector keep the dense scale. Bottom sheets such as the header's More menu and Task actions come up at the larger size too, even when opened on top of a task, and the icon buttons inside them no longer sit against the left edge of their tap target.

--- a/decisions/2026/08/06/touch-target-floor-is-24px-and-never-overrides.md
+++ b/decisions/2026/08/06/touch-target-floor-is-24px-and-never-overrides.md
@@ -51,6 +51,30 @@ pixel; measured heights via `getBoundingClientRect` before and after.
   `@media (hover: none)` and the right padding goes back to symmetric; tapping
   the chip opens the label picker, which is how a phone removes a label.
 
+## Follow-up: the sheet floor repeated both faults (2026-08-08)
+
+`.touch-actions :is(button, …)` — the 44px floor inside a bottom sheet — made
+the same two mistakes at a smaller scale, visible only inside sheets:
+
+1. At 0-2-0 it outweighed `.touch-inline` (0-1-0), so a label chip in the
+   task-actions sheet header came back as a 44px square. Fixed in the selector:
+   `…:not(.touch-inline)`.
+2. It inflated icon-only buttons to 44×44 without centring them, so the glyph
+   sat 2px from the left edge of a square it never asked for — the prevent-sleep
+   toggle in the header's More sheet, the note-delete buttons, the edit-title
+   pencil. Fixed with a default in `@layer components`: `display: inline-flex`
+   plus `justify-content`/`align-items: center`. `inline-flex` and not
+   `text-align`, because Tailwind's preflight makes every `svg` a block, so text
+   alignment is inert on exactly the buttons that need it. The components layer
+   is what keeps it a *default*: `flex`, `justify-between` and `text-left` are
+   utilities, emitted after it, so an author's stated layout still wins.
+
+Verified in headless Chromium at 390px by walking every button in five sheets
+and comparing the left and right gap between each button's box and its content:
+eight offenders before, zero after, and the full-width rows kept `text-left`.
+Guarded by `src/mainview/__tests__/touch-target-floor.test.ts` — happy-dom does
+not run the real cascade, so no component test can catch either fault.
+
 ## Risks
 
 Any control that relied on the old blanket 44px and sets no size of its own now

--- a/decisions/2026/08/08/phone-density-is-per-screen-not-global.md
+++ b/decisions/2026/08/08/phone-density-is-per-screen-not-global.md
@@ -1,0 +1,73 @@
+# Phone density is per screen, not one global factor
+
+## Context
+
+`MOBILE_DENSE_FACTOR = 0.67` shipped as a single multiplier on the root
+font-size for every screen on a phone (`src/mainview/zoom.ts`). It was tuned
+against a task: the terminal, the diff and the inspector all want to show as
+much as a ~400px viewport can hold. Applied to the Kanban board and the
+dashboard, the same factor put a card title at 9.4px and made a column read as
+a thumbnail of a desktop board.
+
+## Investigation
+
+Measured on a 390px viewport: at 0.67 a card title renders 9.38px; the user
+asked for +25% on the board while explicitly keeping the task view as it is.
+One global number cannot satisfy both, and raising it to 0.84 everywhere would
+undo the task-view density that was the point of the factor.
+
+## Decision
+
+Two densities, chosen by route. `MOBILE_ROOMY_FACTOR = 0.84` (dense + 25%) for
+screens the user browses — board, dashboard, settings, stats, changelog — and
+`MOBILE_DENSE_FACTOR = 0.67` for the working set: `task`, `project-terminal`,
+and `project` with an active task. The mapping is `mobileDensityForRoute()` in
+`src/mainview/zoom.ts`; `App.tsx` calls `setMobileDensity()` from an effect on
+`state.route`. Density is a module-level variable, not state: the root
+font-size is a document-level property, and the terminal already listens to
+`ZOOM_CHANGED_EVENT` to refit its canvas, which a density switch reuses.
+
+The default is `roomy` because `bootstrapZoom()` runs before React and the
+first route is the dashboard — defaulting to dense would re-scale the whole app
+on first paint.
+
+A `BottomSheet` is browsed and tapped, never worked in, so it renders roomy
+even on top of a dense task screen. It does this with a local CSS `zoom` —
+`overlayScaleUp()` returns `roomy / dense` = 1.25 — and not by moving the root
+font-size: the sheet covers a live terminal, and re-scaling the root would
+reflow the pty and send a `SIGWINCH` to the agent's shell because a menu
+opened. Measured on a 390px viewport: panel still spans 0..390 flush to the
+bottom edge, no horizontal overflow, rows 44px → 55px.
+
+## Risks
+
+The two px-pinned type rungs (`nano: 9px`, `dense: 10px`) do not scale with the
+root font-size, so on a roomy screen they sit relatively smaller against their
+rem-based neighbours than they did at 0.67. Measured on the board this reads
+fine (a 10px label chip beside an 11.8px card title), but any future rung
+pinned in px will drift further apart between the two densities.
+
+A route that shows a terminal outside the four dense cases would get the roomy
+factor and refit its canvas on entry. Today there is no such route.
+
+CSS `zoom` is standardised but young outside Chromium; a browser that ignores
+it degrades to the old, too-small sheet rather than breaking layout, and one
+that mis-resolves percentages inside it would make the panel over-wide. Both
+were checked in Chromium at 390px, not in WebKit.
+
+## Alternatives considered
+
+- **Raise the global factor to 0.84.** Rejected: the user is happy with the
+  task view, and this makes the terminal and diff show a third less.
+- **A user-facing "board density" setting.** Rejected: a preference for
+  something the app can decide from the route, and it would need a home in
+  Settings for one number.
+- **Per-component `text-*` overrides on the board.** Rejected: it is the whole
+  screen that is undersized, not a handful of labels, and it would fight every
+  future component added to the board.
+- **Flipping the root to roomy while a sheet is open.** Rejected: the sheet
+  covers a live terminal, and the pty would resize under the agent.
+- **Pinning the sheet's type in px instead of zooming it.** Rejected: its rows
+  carry explicit rem-based `text-sm`/`text-xs` classes, so this is the same
+  specificity fight as the `:is()` touch-target rule in
+  `touch-target-floor-is-24px-and-never-overrides.md`, repeated per component.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -10,6 +10,12 @@ git history, PRs, and the records in `decisions/`. Newest first.
 - **Why:** the 2026-07-30 rule argued the readout matters most where screen is scarce — in practice a phone header has room for a breadcrumb and one kebab, and a number the user does not act on at a glance is exactly what should give that room back. The desktop half of the rule is unchanged: capacity is still permanent chrome at roomy widths, still capped at one.
 - **Status:** Implemented. Evidence: `GlobalHeader.tsx`, `MemoryHeadroomIndicator.tsx`, seq 1463.
 
+## 2026-08-08 — A phone scales per screen: dense to work in, roomy to browse
+
+- **Rule:** the phone's root font-size factor is chosen by route, not fixed. Working surfaces — a task's terminal, diff and inspector, and the project terminal — keep `MOBILE_DENSE_FACTOR` 0.67, where the point is to fit as much as a ~400px viewport holds. Everything the user only browses and taps — Kanban board, dashboard, settings, stats, changelog — gets `MOBILE_ROOMY_FACTOR` 0.84 (+25%). Mapping in `mobileDensityForRoute()`. A `BottomSheet` is a browse-and-tap surface wherever it opens, so it scales itself up to roomy with a local CSS `zoom` (`overlayScaleUp()`) instead of moving the root — the root would reflow the terminal underneath it.
+- **Why:** 0.67 was tuned against a task and then applied everywhere; on the board it put a card title at 9.4px and turned a column into a thumbnail of a desktop board. Rejected: raising the global factor (costs the task view a third of its content); a user-facing density setting (a preference for something the route already answers); per-component overrides on the board (the whole screen is undersized, not a handful of labels).
+- **Status:** Decided. Evidence: `zoom.ts`, `decisions/2026/08/08/phone-density-is-per-screen-not-global.md`, seq 1459.
+
 ## 2026-08-07 — A narrow control row sheds; it never stacks
 
 - **Rule:** every narrow control row is `flex-nowrap` with a written priority order and drops from the bottom of it as width runs out — the inspector summary bar sheds diff badge → artifacts → images, then takes the status pill icon-only; the diff viewer's four mutually exclusive modes collapse to one trigger + `BottomSheet`. Anything shed must already have a sheet path, and the last survivors truncate rather than clip. Thresholds are container queries on the row, not viewport breakpoints. Bible §12.6 + §12.3 (Diff viewer).

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -18,7 +18,7 @@ import { isTypingContext } from "./utils/typing-context";
 import { matchesShortcut } from "./keymap";
 import { setShortcutOverrides } from "./keymap-store";
 import { syncTerminalBidiFromGlobalSettings } from "./terminal-bidi/flag";
-import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
+import { adjustZoom, applyZoom, mobileDensityForRoute, setMobileDensity, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { useViewport } from "./hooks/useViewport";
 import { useMobile } from "./hooks/useMobile";
 import { useAndroidBackGuard } from "./hooks/useAndroidBackGuard";
@@ -153,6 +153,11 @@ function App() {
 		};
 	}, []);
 	useViewport(state.route);
+	// A phone scales differently per screen: dense inside a task, roomy on the
+	// screens the user only browses. No-op on a desktop-width viewport.
+	useEffect(() => {
+		setMobileDensity(mobileDensityForRoute(state.route));
+	}, [state.route]);
 	// Android hardware/gesture Back drives in-app navigation in mobile remote
 	// mode: close the topmost layer → route back → double-back-to-exit toast.
 	// Reads history depth through a ref so the popstate handler stays stable.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -78,6 +78,8 @@ vi.mock("../zoom", () => ({
 	DEFAULT_ZOOM: 1.0,
 	getZoom: vi.fn().mockReturnValue(1.0),
 	bootstrapZoom: vi.fn(),
+	setMobileDensity: vi.fn(),
+	mobileDensityForRoute: vi.fn().mockReturnValue("roomy"),
 	ZOOM_CHANGED_EVENT: "zoom-changed",
 	MIN_ZOOM: 0.5,
 	MAX_ZOOM: 2.0,

--- a/src/mainview/__tests__/touch-target-floor.test.ts
+++ b/src/mainview/__tests__/touch-target-floor.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Two cascade invariants behind the mobile touch floor. Both were shipped
+ * broken once, both are invisible in a component test because happy-dom does
+ * not run the real stylesheet — so they are asserted against the source.
+ *
+ * See decisions/2026/08/06/touch-target-floor-is-24px-and-never-overrides.md
+ * and decisions/2026/08/08/phone-density-is-per-screen-not-global.md.
+ */
+const CSS = readFileSync(path.resolve(__dirname, "..", "index.css"), "utf8");
+
+/** The rule body that follows a selector, up to its closing brace. */
+function bodyAfter(selectorFragment: string): string {
+	const at = CSS.indexOf(selectorFragment);
+	expect(at, `selector not found: ${selectorFragment}`).toBeGreaterThan(-1);
+	return CSS.slice(at, CSS.indexOf("}", at));
+}
+
+describe("touch target floor", () => {
+	it("keeps the global coarse-pointer floor at 24px and at specificity 0", () => {
+		const body = bodyAfter(':where(button, a[role="button"], [role="menuitem"]');
+		expect(body).toContain("min-height: 24px");
+		expect(body).toContain("min-width: 24px");
+		// `:is()` would inherit [role="menuitem"]'s weight and beat an author's
+		// deliberate size; a floor must always lose to one.
+		expect(CSS).not.toContain(':is(button, a[role="button"], [role="menuitem"], [role="option"]');
+	});
+
+	it("lets inline chips opt out of the 44px sheet floor", () => {
+		// Without the :not(), this rule (0-2-0) outweighs `.touch-inline` (0-1-0)
+		// and blows a label pill up into a 44px square inside a sheet.
+		expect(CSS).toContain('.touch-actions :is(button, a[role="button"], [role="menuitem"]):not(.touch-inline)');
+	});
+
+	it("centres whatever the sheet floor inflates, without outranking a utility", () => {
+		const at = CSS.indexOf(".touch-actions :where(");
+		expect(at).toBeGreaterThan(-1);
+		const body = CSS.slice(at, CSS.indexOf("}", at));
+		expect(body).toContain("display: inline-flex"); // Tailwind makes every svg a block
+		expect(body).toContain("justify-content: center");
+		expect(body).toContain("align-items: center");
+		// In the components layer, so `flex` / `justify-between` / `text-left`
+		// on the element itself still win — utilities are emitted after it.
+		expect(CSS.slice(0, at)).toMatch(/@layer components \{\s*$/m);
+	});
+});

--- a/src/mainview/__tests__/zoom.test.ts
+++ b/src/mainview/__tests__/zoom.test.ts
@@ -20,6 +20,10 @@ import {
 	bootstrapZoom,
 	DEFAULT_ZOOM,
 	MOBILE_DENSE_FACTOR,
+	MOBILE_ROOMY_FACTOR,
+	mobileDensityForRoute,
+	setMobileDensity,
+	overlayScaleUp,
 	MIN_ZOOM,
 	MAX_ZOOM,
 	ZOOM_STEP,
@@ -36,6 +40,7 @@ function setScreenWidth(width: number) {
 describe("zoom", () => {
 	beforeEach(() => {
 		setScreenWidth(DESKTOP_SCREEN_WIDTH);
+		setMobileDensity("dense"); // module state leaks between tests
 		storage.clear();
 		localStorageMock.getItem.mockClear();
 		localStorageMock.setItem.mockClear();
@@ -160,6 +165,7 @@ describe("zoom", () => {
 		it("has expected default values", () => {
 			expect(DEFAULT_ZOOM).toBe(1.0);
 			expect(MOBILE_DENSE_FACTOR).toBe(0.67);
+			expect(MOBILE_ROOMY_FACTOR).toBe(0.84); // dense + 25%
 			expect(MIN_ZOOM).toBe(0.5);
 			expect(MAX_ZOOM).toBe(2.0);
 			expect(ZOOM_STEP).toBe(0.1);
@@ -167,8 +173,64 @@ describe("zoom", () => {
 		});
 	});
 
+	describe("phone density per screen", () => {
+		it("keeps a task dense and everything the user browses roomy", () => {
+			expect(mobileDensityForRoute({ screen: "task", projectId: "p", taskId: "t" })).toBe("dense");
+			expect(mobileDensityForRoute({ screen: "project-terminal", projectId: "p" })).toBe("dense");
+			expect(mobileDensityForRoute({ screen: "project", projectId: "p", taskView: true })).toBe("dense");
+			expect(mobileDensityForRoute({ screen: "project", projectId: "p", activeTaskId: "t" })).toBe("dense");
+			expect(mobileDensityForRoute({ screen: "project", projectId: "p" })).toBe("roomy"); // the board
+			expect(mobileDensityForRoute({ screen: "dashboard" })).toBe("roomy");
+			expect(mobileDensityForRoute({ screen: "settings" })).toBe("roomy");
+		});
+
+		it("re-scales the root font-size when the route switches density", () => {
+			setScreenWidth(MOBILE_SCREEN_WIDTH);
+			applyZoom(DEFAULT_ZOOM);
+			expect(document.documentElement.style.fontSize).toBe(`${16 * MOBILE_DENSE_FACTOR}px`);
+			setMobileDensity("roomy");
+			expect(getEffectiveZoom()).toBe(MOBILE_ROOMY_FACTOR);
+			expect(document.documentElement.style.fontSize).toBe(`${16 * MOBILE_ROOMY_FACTOR}px`);
+		});
+
+		it("tells the terminal about a density change, so its canvas refits", () => {
+			setScreenWidth(MOBILE_SCREEN_WIDTH);
+			applyZoom(DEFAULT_ZOOM);
+			const handler = vi.fn();
+			window.addEventListener(ZOOM_CHANGED_EVENT, handler);
+			setMobileDensity("roomy");
+			expect(handler).toHaveBeenCalledTimes(1);
+			expect((handler.mock.calls[0][0] as CustomEvent).detail).toBe(MOBILE_ROOMY_FACTOR);
+			setMobileDensity("roomy"); // same density → nothing to re-scale
+			expect(handler).toHaveBeenCalledTimes(1);
+			window.removeEventListener(ZOOM_CHANGED_EVENT, handler);
+		});
+
+		it("tells a browse-and-tap overlay how far to scale itself back up", () => {
+			setScreenWidth(MOBILE_SCREEN_WIDTH);
+			expect(overlayScaleUp()).toBe(1.25); // dense screen: the sheet makes up the gap
+			setMobileDensity("roomy");
+			expect(overlayScaleUp()).toBe(1); // already roomy — no second helping
+			setScreenWidth(DESKTOP_SCREEN_WIDTH);
+			setMobileDensity("dense");
+			expect(overlayScaleUp()).toBe(1); // desktop is never scaled at all
+		});
+
+		it("does not touch a desktop viewport, where both densities are 1", () => {
+			setScreenWidth(DESKTOP_SCREEN_WIDTH);
+			applyZoom(DEFAULT_ZOOM);
+			const handler = vi.fn();
+			window.addEventListener(ZOOM_CHANGED_EVENT, handler);
+			setMobileDensity("roomy");
+			expect(getEffectiveZoom()).toBe(DEFAULT_ZOOM);
+			expect(document.documentElement.style.fontSize).toBe("16px");
+			expect(handler).not.toHaveBeenCalled();
+			window.removeEventListener(ZOOM_CHANGED_EVENT, handler);
+		});
+	});
+
 	describe("phone factor", () => {
-		it("scales every screen on a phone, not just the terminal", () => {
+		it("scales a task screen on a phone, not just the terminal", () => {
 			setScreenWidth(MOBILE_SCREEN_WIDTH);
 			applyZoom(DEFAULT_ZOOM);
 			expect(getEffectiveZoom()).toBe(MOBILE_DENSE_FACTOR);

--- a/src/mainview/components/BottomSheet.tsx
+++ b/src/mainview/components/BottomSheet.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { useT } from "../i18n";
 import { useFocusTrap } from "../utils/useFocusTrap";
 import { useBackLayer } from "../hooks/useBackLayer";
+import { overlayScaleUp } from "../zoom";
 
 interface BottomSheetProps {
 	open: boolean;
@@ -41,6 +42,10 @@ function Sheet({ onClose, title, ariaLabel, children, testId }: BottomSheetProps
 	const trapRef = useFocusTrap<HTMLDivElement>();
 	const [dragY, setDragY] = useState(0);
 	const startY = useRef<number | null>(null);
+	// A sheet is browsed and tapped, never worked in, so it renders at the roomy
+	// phone size even on top of a dense task screen. Read once at mount — the
+	// sheet unmounts on close, so it can never go stale.
+	const scaleUp = useRef(overlayScaleUp()).current;
 
 	// Android hardware Back closes the sheet (mobile remote mode).
 	useBackLayer(onClose);
@@ -87,7 +92,11 @@ function Sheet({ onClose, title, ariaLabel, children, testId }: BottomSheetProps
 				tabIndex={-1}
 				data-bottom-sheet
 				className="bottom-sheet-panel w-full max-w-[40rem] bg-overlay border-t border-edge rounded-t-2xl shadow-2xl max-h-[85dvh] overflow-y-auto outline-none"
-				style={dragY ? { transform: `translateY(${dragY}px)` } : undefined}
+				style={{
+					...(scaleUp !== 1 ? { zoom: scaleUp } : null),
+					// dragY is viewport px; inside a zoomed panel a transform scales too.
+					...(dragY ? { transform: `translateY(${dragY / scaleUp}px)` } : null),
+				}}
 			>
 				{/* Grabber + header: also the swipe-down dismiss surface. */}
 				<div
@@ -113,7 +122,7 @@ function Sheet({ onClose, title, ariaLabel, children, testId }: BottomSheetProps
 				</div>
 				{/* `touch-actions`: 44px rows are the sheet default, not opt-in per
 				    sheet — the global coarse-pointer floor is only 24px (WCAG 2.5.8),
-				    and the 0.67× phone factor would shrink these rows further. */}
+				    and the phone factor would shrink these rows further. */}
 				<div
 					className="touch-actions px-4 py-3"
 					style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom))" }}

--- a/src/mainview/components/__tests__/BottomSheet.test.tsx
+++ b/src/mainview/components/__tests__/BottomSheet.test.tsx
@@ -4,9 +4,14 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import BottomSheet from "../BottomSheet";
 import { I18nProvider } from "../../i18n";
 import { closeTopBackLayer, __resetBackLayersForTests } from "../../back-navigation";
+import { overlayScaleUp } from "../../zoom";
+
+vi.mock("../../zoom", () => ({ overlayScaleUp: vi.fn(() => 1) }));
+const mockedScaleUp = vi.mocked(overlayScaleUp);
 
 beforeEach(() => {
 	__resetBackLayersForTests();
+	mockedScaleUp.mockReturnValue(1);
 });
 
 function renderSheet(props: Partial<React.ComponentProps<typeof BottomSheet>> = {}) {
@@ -68,6 +73,17 @@ describe("BottomSheet", () => {
 			expect(closeTopBackLayer()).toBe(true);
 		});
 		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("scales itself up to the roomy size on top of a dense phone screen", () => {
+		mockedScaleUp.mockReturnValue(1.25);
+		renderSheet();
+		expect(screen.getByRole("dialog")).toHaveStyle({ zoom: "1.25" });
+	});
+
+	it("leaves its own scale alone when the screen underneath is already roomy", () => {
+		renderSheet();
+		expect(screen.getByRole("dialog").style.zoom).toBe("");
 	});
 
 	it("does not register a back layer when closed", () => {

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -562,10 +562,39 @@ button {
    Sizing is absolute px, NOT rem: the mobile task screen scales the root
    font-size to 0.67× on a phone (see zoom.ts MOBILE_DENSE_FACTOR),
    which is meant to pack content-heavy terminal/diff surfaces — a touch action
-   sheet must keep true 44px targets and not shrink with it. */
-.touch-actions :is(button, a[role="button"], [role="menuitem"]) {
+   sheet must keep true 44px targets and not shrink with it.
+
+   `:not(.touch-inline)`: a sheet is not only action rows — it also carries a
+   task title, its label chips and a worktree path. Those chips already opt out
+   of the global floor, and without the exclusion this rule (0-2-0) outweighed
+   `.touch-inline` (0-1-0) and blew a 4px label pill up into a 44px square
+   inside the sheet only. */
+.touch-actions :is(button, a[role="button"], [role="menuitem"]):not(.touch-inline) {
 	min-height: 44px;
 	min-width: 44px;
+}
+
+/* Whatever the floor above inflates, centres its content by default. A control
+   drawn at ~28px in a desktop toolbar becomes a 44px box here; without this its
+   glyph sits against the left edge of a square it never asked for — which is
+   what happened to the prevent-sleep toggle in the header's More sheet and to
+   every icon-only button in the task-actions sheet.
+
+   `inline-flex` and not `text-align`, because Tailwind's preflight makes every
+   `svg` a block: an icon-only button is centred by the flex box or not at all.
+   Inline-level, so a button sitting in running text keeps its line.
+
+   Authored in `@layer components` on purpose: a button that wants another
+   layout states it with a Tailwind utility (`flex`, `block`, `justify-between`,
+   `text-left`), and utilities come after components, so the author always wins
+   over this default — every full-width action row already carries `text-left`
+   and its own `flex`. */
+@layer components {
+	.touch-actions :where(button, a[role="button"], [role="menuitem"]) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 /* ---- Close-pane picker: marching-ants selection marquee -------------------

--- a/src/mainview/zoom.ts
+++ b/src/mainview/zoom.ts
@@ -4,6 +4,7 @@
 // the new size — no bitmap scaling, so text stays crisp in WKWebView.
 // Terminal canvases handle zoom separately (see TerminalView).
 
+import type { Route } from "./state";
 import { detectMobile } from "./hooks/useMobile";
 
 const ZOOM_KEY = "dev3-zoom";
@@ -12,21 +13,67 @@ export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 2.0;
 export const ZOOM_STEP = 0.1;
 export const ZOOM_CHANGED_EVENT = "zoom-changed" as const;
-// A phone gets ~2/3 scale (1.5× denser) on EVERY screen: at 1.0 the board, cards
-// and modals are sized for a desktop pointer and read as oversized on a ~400px
-// viewport. Applied as a multiplier on top of the user's zoom; the saved setting
-// is untouched, so ⌘+/⌘− still work from there. Terminal/diff screens asked for
-// this same factor before it became the phone default — they keep it, not a
-// second helping of it (see mobileFactor).
+// A phone gets ~2/3 scale (1.5× denser) inside a task: at 1.0 the terminal,
+// diff and inspector are sized for a desktop pointer and read as oversized on a
+// ~400px viewport. Applied as a multiplier on top of the user's zoom; the saved
+// setting is untouched, so ⌘+/⌘− still work from there. Terminal/diff screens
+// asked for this factor before it became the phone default — they keep it, not
+// a second helping of it (see mobileFactor).
 export const MOBILE_DENSE_FACTOR = 0.67;
+// Browsing screens get +25% over the dense factor. Dense is tuned for a
+// working surface — a task's terminal, diff and inspector, where the point is
+// to see as much at once as the phone allows. The board and the dashboard are
+// read at arm's length and tapped, not worked in: at 0.67 a card title lands
+// around 9px and the whole column reads as a thumbnail of a desktop board.
+export const MOBILE_ROOMY_FACTOR = 0.84;
 
 const BASE_FONT_SIZE = 16; // browser default root font-size in px
 
+export type MobileDensity = "dense" | "roomy";
+
 /** In-memory cache — avoids localStorage reads on every call. */
 let currentZoom = DEFAULT_ZOOM;
+// Set from the route; ignored entirely on a desktop-width viewport. Starts
+// roomy because bootstrapZoom() runs before React and the first route is the
+// dashboard — starting dense would re-scale the whole app on first paint.
+let mobileDensity: MobileDensity = "roomy";
 
 function mobileFactor(): number {
-	return detectMobile() ? MOBILE_DENSE_FACTOR : 1;
+	if (!detectMobile()) return 1;
+	return mobileDensity === "roomy" ? MOBILE_ROOMY_FACTOR : MOBILE_DENSE_FACTOR;
+}
+
+/**
+ * Which density a screen wants. Dense is the working set: a task (terminal,
+ * diff, inspector) and the project terminal. Everything the user only browses
+ * — board, dashboard, settings, stats, changelog — is roomy.
+ */
+export function mobileDensityForRoute(route: Route): MobileDensity {
+	if (route.screen === "task" || route.screen === "project-terminal") return "dense";
+	if (route.screen === "project" && (route.activeTaskId || route.taskView)) return "dense";
+	return "roomy";
+}
+
+/** Re-scales the root font-size when the route moves between the two densities. */
+export function setMobileDensity(next: MobileDensity) {
+	if (next === mobileDensity) return;
+	const before = getEffectiveZoom();
+	mobileDensity = next;
+	if (getEffectiveZoom() === before) return; // desktop: both densities are 1
+	syncRootFontSize();
+	window.dispatchEvent(new CustomEvent(ZOOM_CHANGED_EVENT, { detail: getEffectiveZoom() }));
+}
+
+/**
+ * How much a browse-and-tap overlay must scale itself up to reach the roomy
+ * size while the screen underneath stays dense — 1 when there is nothing to
+ * make up for. Applied as a local CSS `zoom`, never by moving the root
+ * font-size: re-scaling the root would reflow the terminal behind the overlay
+ * and resize the agent's shell just because a menu opened.
+ */
+export function overlayScaleUp(): number {
+	if (!detectMobile() || mobileDensity !== "dense") return 1;
+	return Math.round((MOBILE_ROOMY_FACTOR / MOBILE_DENSE_FACTOR) * 100) / 100;
 }
 
 /** User zoom × phone factor — what the root font-size and terminal font actually use. */


### PR DESCRIPTION
The phone used one root font-size factor everywhere — `MOBILE_DENSE_FACTOR` 0.67, tuned against a task, where the terminal, diff and inspector want to hold as much as a ~400px viewport allows. Applied to the Kanban board it put a card title at 9.4px and made a column read as a thumbnail of a desktop board.

**Density is now chosen by route.** `MOBILE_ROOMY_FACTOR` 0.84 (+25%) for the screens the user browses and taps — board, dashboard, settings, stats, changelog; 0.67 stays for the working set — `task`, `project-terminal`, and `project` with an active task. Mapping is `mobileDensityForRoute()`; `App.tsx` applies it from an effect on `state.route`. A desktop-width viewport is untouched: both densities resolve to 1.

**A bottom sheet scales itself.** It is browsed and tapped wherever it opens, so it renders roomy even on top of a dense task screen — a local CSS `zoom` of `roomy / dense` = 1.25, never a move of the root font-size: the sheet covers a live terminal, and re-scaling the root would reflow the pty and send a `SIGWINCH` to the agent's shell because a menu opened.

**The 44px sheet touch floor repeated two old faults**, both only visible inside sheets:

- At 0-2-0 it outweighed `.touch-inline` (0-1-0), so a label chip in the task-actions sheet came back as a 44px square — the exact specificity trap from `decisions/2026/08/06/touch-target-floor-is-24px-and-never-overrides.md`. Fixed in the selector with `:not(.touch-inline)`.
- It inflated icon-only buttons to 44×44 without centring them, so the glyph sat 2px from the left edge of a square it never asked for (prevent-sleep toggle, note-delete buttons, edit-title pencil). Fixed with a default in `@layer components`: `display: inline-flex` + centring. `inline-flex` and not `text-align`, because Tailwind's preflight makes every `svg` a block, so text alignment is inert on exactly those buttons. The components layer keeps it a default — `flex`, `justify-between` and `text-left` are utilities, emitted after it, so an author's stated layout still wins.

Measured in headless Chromium at 390px: card title 9.38px → 11.76px; root flips 13.44 ↔ 10.72 in both directions on navigation; sheet panel still spans 0..390 flush to the bottom edge with no horizontal overflow, rows 44 → 55px; a sheet opened on the board stays at zoom 1. Walked every button in five sheets comparing the left and right gap to its content — eight off-centre before, zero after, and full-width rows kept `text-left`.

Full `bun run test` green after the rebase: 3720 renderer, 5421 backend, 764 CLI, 0 failed.

Records: `decisions/2026/08/08/phone-density-is-per-screen-not-global.md`, a follow-up section in the 2026-08-06 touch-floor record, and `docs/ux/UX_DECISIONS.md`. New guard `src/mainview/__tests__/touch-target-floor.test.ts` asserts both cascade invariants against `index.css` — happy-dom does not run the real cascade, so no component test can catch them.