### PR TITLE
Take the sidebar rail's upright word out of flow so short rows shrink back

### DIFF
--- a/change-logs/2026/08/08/fix-sidebar-rail-label-latched-height.md
+++ b/change-logs/2026/08/08/fix-sidebar-rail-label-latched-height.md
@@ -1,0 +1,3 @@
+Short: Sidebar rows stop staying tall
+
+The Active Tasks sidebar showed its upright status word only on rows tall enough for it, but the word itself propped up the row: once a task had been focused with an overview, its row kept both the word and the extra height after focus moved away. The word is now painted out of flow, so a row that loses its overview shrinks straight back.

--- a/decisions/2026/08/07/sidebar-rail-short-labels.md
+++ b/decisions/2026/08/07/sidebar-rail-short-labels.md
@@ -23,9 +23,10 @@ that had room for it.
 `TaskCardRail` gained `autoLabel`. The sidebar sets it, the card does not (a card
 is always tall enough). With it on, the rail measures itself through a
 `ResizeObserver` and renders the upright word only when its height clears
-`58 + letters * 14.4`. Showing the word only when it already fits cannot grow the
-rail, so the measurement settles in one pass with no oscillation. Verified live:
-88px rows show ring + ✓ only, `PR` appears at 104px, `ON HOLD` at 273px.
+`58 + letters * 14.4`. Verified live: 88px rows show ring + ✓ only, `PR` appears
+at 104px, `ON HOLD` at 273px. This record also claimed that showing the word only
+when it already fits cannot grow the rail — it can, and the fix is in
+`decisions/2026/08/08/rail-label-out-of-flow.md`.
 
 ## Risks
 

--- a/decisions/2026/08/08/rail-label-out-of-flow.md
+++ b/decisions/2026/08/08/rail-label-out-of-flow.md
@@ -1,0 +1,44 @@
+# The rail's upright word is painted out of flow, so it cannot measure itself
+
+## Context
+
+`decisions/2026/08/07/sidebar-rail-short-labels.md` gave `TaskCardRail` an
+`autoLabel` mode: the sidebar rail measures its own height through a
+`ResizeObserver` and prints the upright status word only above
+`58 + letters * 14.4`. It claimed "showing the word only when it already fits
+cannot grow the rail". That claim is wrong.
+
+## Investigation
+
+The rail is `self-stretch` in a row whose height comes from its own content, so
+the rail's intrinsic height competes with the content column. `WORKING` in flow
+needs ~159px against an 88px baseline row — so the word that had just been shown
+on a 257px row (task focused, overview rendered) became the tallest thing in the
+row the moment the overview left. The measurement then read its own word's
+height, stayed above the threshold, and the row never shrank: reported live as
+short sidebar rows stuck at ~257px with a word and empty space under the title.
+
+## Decision
+
+With `autoLabel` on, the word renders inside a `relative flex min-h-0 w-full
+flex-1 overflow-hidden` slot as an `absolute` child (`TaskCardRail.tsx`), so it
+contributes nothing to the rail's intrinsic height and the observed height only
+ever describes the row's real content. The card path (no `autoLabel`) keeps the
+word in flow — a card is always tall enough, and clipping it there would be a
+regression. Verified live in the browser: switching the focused task from a row
+with an overview drops it from 257px + `WORKING` back to 88px with no word.
+
+## Risks
+
+The word is now clipped rather than height-forcing if a row is somehow shorter
+than the threshold predicts — acceptable, the full status stays in the rail
+button's `aria-label` and tooltip. `ResizeObserver` is still absent in happy-dom,
+so tests must inject one (`__tests__/TaskCardRail.test.tsx`).
+
+## Alternatives considered
+
+Measure a sibling outside the rail (the row's content column) — needs a ref
+threaded from `ActiveTaskRow` into `TaskCardRail` and couples the two. Cap the
+row height in CSS — hides the symptom, leaves the word deciding its own fate.
+Drop the word from the sidebar entirely — already rejected in the 2026-08-07
+record.

--- a/src/mainview/components/TaskCardRail.tsx
+++ b/src/mainview/components/TaskCardRail.tsx
@@ -13,6 +13,9 @@ import Tooltip from "./Tooltip";
  */
 export const RAIL_LABEL_MAX = 8;
 
+const RAIL_LABEL_CLASS =
+	"max-h-32 overflow-hidden font-mono text-dense font-extrabold uppercase leading-none tracking-[0.14em] [text-orientation:upright] [writing-mode:vertical-rl]";
+
 /** Short, uppercase rail forms of the built-in statuses. The full label stays in
  *  the rail's accessible name and tooltip, and in the Move-to menu. */
 const RAIL_LABEL_KEY: Record<TaskStatus, TranslationKey> = {
@@ -98,8 +101,9 @@ export default function TaskCardRail({
 	const [labelFits, setLabelFits] = useState(!autoLabel);
 
 	// Measured: an upright letter is ~14.4px, and the ring, the ✓ and the rail's
-	// own padding claim ~58px before the word starts. Showing the word only when
-	// it already fits cannot grow the rail, so this settles in one pass.
+	// own padding claim ~58px before the word starts. With `autoLabel` the word is
+	// taken out of flow (see below), so the height it measures never includes the
+	// word itself — otherwise the first fit would latch and the row could not shrink.
 	const neededForLabel = 58 + railLabel.length * 14.4;
 	useLayoutEffect(() => {
 		if (!autoLabel) return;
@@ -149,15 +153,20 @@ export default function TaskCardRail({
 					{/* Upright stacked letters — read straight down, never rotated. The
 					    accessible name above carries the full label, so the visual
 					    abbreviation is hidden from assistive tech. */}
-					{labelFits && (
-						<span
-							aria-hidden="true"
-							className="max-h-32 overflow-hidden font-mono text-dense font-extrabold uppercase leading-none tracking-[0.14em] [text-orientation:upright] [writing-mode:vertical-rl]"
-							style={{ color }}
-						>
-							{railLabel}
-						</span>
-					)}
+					{labelFits &&
+						(autoLabel ? (
+							// Out of flow: the word must never add to the height that decides
+							// whether it fits, or a row that once had room keeps it forever.
+							<span className="relative flex min-h-0 w-full flex-1 justify-center overflow-hidden">
+								<span aria-hidden="true" className={`absolute top-0 ${RAIL_LABEL_CLASS}`} style={{ color }}>
+									{railLabel}
+								</span>
+							</span>
+						) : (
+							<span aria-hidden="true" className={RAIL_LABEL_CLASS} style={{ color }}>
+								{railLabel}
+							</span>
+						))}
 				</button>
 			</Tooltip>
 

--- a/src/mainview/components/__tests__/TaskCardRail.test.tsx
+++ b/src/mainview/components/__tests__/TaskCardRail.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, act } from "@testing-library/react";
+import TaskCardRail from "../TaskCardRail";
+import { I18nProvider } from "../../i18n";
+import type { Project } from "../../../shared/types";
+
+const project: Project = {
+	id: "p1",
+	name: "Test",
+	path: "/tmp/test",
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: "2025-01-01T00:00:00Z",
+};
+
+/** Drives the rail's own ResizeObserver, which happy-dom does not provide. */
+function installResizeObserver(): { fire: () => void } {
+	const callbacks: Array<() => void> = [];
+	vi.stubGlobal(
+		"ResizeObserver",
+		class {
+			constructor(cb: () => void) {
+				callbacks.push(cb);
+			}
+			observe() {}
+			disconnect() {}
+		},
+	);
+	return { fire: () => callbacks.forEach((cb) => cb()) };
+}
+
+function railHeight(px: number) {
+	vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+		() => ({ height: px, width: 20, top: 0, left: 0, right: 20, bottom: px, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect,
+	);
+}
+
+function renderRail() {
+	render(
+		<I18nProvider>
+			<TaskCardRail
+				status="in-progress"
+				project={project}
+				color="#afbaff"
+				canComplete={false}
+				completing={false}
+				onOpenMenu={vi.fn()}
+				onComplete={vi.fn()}
+				menuTriggerRef={{ current: null }}
+				autoLabel
+			/>
+		</I18nProvider>,
+	);
+}
+
+function label(): HTMLElement | null {
+	return screen.getByTestId("task-card-rail").querySelector("[class*=vertical-rl]");
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("TaskCardRail autoLabel", () => {
+	it("drops the upright word again when the row shrinks back", () => {
+		const observer = installResizeObserver();
+		railHeight(273); // a sidebar row carrying an overview
+		renderRail();
+		expect(label()).not.toBeNull();
+
+		// The overview goes away with the task losing focus: the row is short again,
+		// so the word must go with it instead of holding the height it needs.
+		railHeight(88);
+		act(() => observer.fire());
+		expect(label()).toBeNull();
+	});
+
+	it("keeps the word out of flow so it never props up the height that measures it", () => {
+		const observer = installResizeObserver();
+		railHeight(273);
+		renderRail();
+		observer.fire();
+
+		expect(label()!.className).toContain("absolute");
+	});
+
+	it("hides the word on a short row from the first paint", () => {
+		installResizeObserver();
+		railHeight(88);
+		renderRail();
+
+		expect(label()).toBeNull();
+	});
+});


### PR DESCRIPTION
The Active Tasks sidebar rail prints its upright status word (`WORKING`, `ON HOLD`) only when the row is tall enough for it — but the word was in flow, and the rail is `self-stretch`, so the word became the row's own content: ~159px for `WORKING` against an 88px baseline row. Once a task had been focused with an overview (257–276px rows), its `ResizeObserver` measurement kept reading the height of its own word, so the fit latched and the row never shrank back — leaving tall, mostly empty rows with a word on them.

With `autoLabel` on, the word now renders as an `absolute` child inside a `flex-1 min-h-0 overflow-hidden` slot, so it contributes nothing to the height that decides whether it fits. The card path (no `autoLabel`) keeps the word in flow — a card is always tall enough, and clipping it there would be a regression.

Verified in a real browser: switching the focused task drops the previous row from 257px + `WORKING` back to 88px with no word, and the new focused row picks it up.

Decision record: `decisions/2026/08/08/rail-label-out-of-flow.md` (it also corrects the wrong claim in the 2026-08-07 record that showing the word could not grow the rail).