### PR TITLE
Wait for the session record instead of assuming a resize ack persisted it

### DIFF
--- a/change-logs/2026/08/08/fix-native-e2e-record-geometry-wait.md
+++ b/change-logs/2026/08/08/fix-native-e2e-record-geometry-wait.md
@@ -1,0 +1,1 @@
+The native task-terminal E2E no longer assumes that a resize acknowledgement means the session record is already on disk — the host persists it fire-and-forget after answering, so the record lagged and the Windows release gate failed intermittently. The three geometry reads in that test now wait for the record and print what it actually held when they fail.

--- a/decisions/2026/08/08/resize-ack-does-not-imply-persisted-record.md
+++ b/decisions/2026/08/08/resize-ack-does-not-imply-persisted-record.md
@@ -1,0 +1,81 @@
+# A resize ack does not imply the session record is on disk
+
+## Context
+
+The Windows release gate `Product native task-terminal E2E` failed on tag v1.42.1
+(sha `d91e5d2dd`, run `31248826195` attempt 1, job `93081796448`) with a single check:
+
+```
+FAIL - geometry follows the lease BACK to the first process (118x36)
+```
+
+Its siblings passed: handing the writer lease to a peer process, taking it back, and the
+shell surviving both. A parallel run on the same sha two seconds later was green, so no diff
+was implicated.
+
+## Investigation
+
+The check is a conjunction: a local viewer must be told the new grid, **and** the session
+record on disk must already carry it. Which conjunct failed is decidable from the job log:
+
+```
+08:42:18.3228  ok   - the first process takes control back once the peer lets go
+08:42:18.3547  FAIL - geometry follows the lease BACK to the first process (118x36)
+```
+
+32 ms apart. `awaitHeader` (the test's own helper) can only return `false` by exhausting its
+timeout, which is 8000 ms here — so the viewer half was **true**. Geometry did follow the
+lease back. The record on disk was the failing half.
+
+`host.ts`'s resize branch applies the resize, fires `void persist().catch(...)` — fire and
+forget, through `publishOwned` → `withOwnedSessionState` (a cross-process lock) → mkdir +
+write temp + rename — and sends the ack **first**. So every in-band event outruns the file.
+
+Measured with a probe booting a real host and client, `resizeAwaited` then `readRecord`
+immediately, on an idle Mac:
+
+| Writes queued ahead | Stale right after the ack | Catch-up lag |
+|---|---|---|
+| 0 | 20 / 20 | 1.3 – 2.9 ms |
+| 1 | 20 / 20 | 2.5 – 6.5 ms, one outlier **47.3 ms** |
+| 3 | 20 / 20 | 4.8 – 7.5 ms |
+
+60 of 60 samples stale: the property the check assumed is false **100 % of the time, on every
+platform**. It passed only because `awaitHeader` polls every 20 ms and accidentally donated
+~20 ms of slack. A loaded Windows runner eats that slack.
+
+The product does **not** share the assumption: `MultiPaneCoordinator.resizePane`
+(`src/bun/native-terminal-multipane/coordinator.ts`) polls the record with a 5 s deadline and
+its docblock says why. Every other record reader wants pids, ports, command or liveness — all
+facts `registry.start()` already waits for.
+
+## Decision
+
+Fix the test, not the product. `awaitRecord()` in
+`src/bun/__tests__/native-task-terminal.bun-e2e.ts` waits for the record to satisfy a
+predicate and returns the last record seen, so a failure prints what the file actually held.
+Applied at all **three** reads of record geometry in that file — the failing one and two that
+were only luckier (separated by a shell round trip and by 20 s) — because one false
+assumption in three places is one defect, and a half-migration would bring the next Windows
+run back for the survivors.
+
+Not chosen: awaiting `persist()` before the ack. It would put a locked file write on the
+critical path of every resize, so dragging a window would serialize on the filesystem — a
+real cost for a property nothing consumes.
+
+## Risks
+
+The check now tolerates a persistence lag of up to 5 s. What it stops asserting is
+"persistence is synchronous with the ack", which was never true. Both halves were mutation
+tested against product-side breakage:
+
+| Mutation (product code) | Result |
+|---|---|
+| `broadcastNativeRoles` dropped from the resize-ack continuation in `pty-server.ts` | `FAIL - … (second viewer told: false, record: 118x36)` |
+| host acks the resize but never adopts or persists it | `FAIL - … (second viewer told: false, record: 132x43)` |
+
+## Alternatives considered
+
+- **Await `persist()` before the ack** — see above.
+- **A "record settled" signal in the host protocol** — a permanent protocol surface added for
+  a test's benefit.

--- a/src/bun/__tests__/native-task-terminal.bun-e2e.ts
+++ b/src/bun/__tests__/native-task-terminal.bun-e2e.ts
@@ -75,7 +75,7 @@ import {
 	type NativeStreamRole,
 } from "../../shared/native-terminal-stream";
 import { NativeSessionClient } from "../native-terminal-registry/client";
-import { readRecord } from "../native-terminal-registry/record";
+import { readRecord, type NativeSessionRecord } from "../native-terminal-registry/record";
 import { sessionsRootDir } from "../native-terminal-registry/paths";
 import { isProcessAlive } from "../native-terminal-registry/process-identity";
 import { defaultNativeShellLaunchSpec } from "../native-terminal-registry/shell-launch";
@@ -93,6 +93,33 @@ function check(condition: boolean, message: string): void {
 }
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * The session record, waited for rather than assumed.
+ *
+ * A resize ACK does NOT mean the record is on disk. The host applies the resize, fires
+ * `persist()` FIRE-AND-FORGET through a cross-process lock, and answers the ack first
+ * (`native-terminal-registry/host.ts`, resize branch), so every in-band event — ack, role
+ * frame, output byte — outruns the file. Measured on an idle Mac: stale in 60 of 60
+ * samples right after the ack, catching up 1.3–47 ms later. The product's own reader polls
+ * for exactly this reason (`MultiPaneCoordinator.resizePane`). Returns the last record seen,
+ * so a failing check can report what the file actually held.
+ */
+async function awaitRecord(
+	sessionId: string,
+	predicate: (record: NativeSessionRecord) => boolean,
+	timeoutMs = 5000,
+): Promise<NativeSessionRecord | null> {
+	const deadline = Date.now() + timeoutMs;
+	let last = readRecord(sessionId);
+	for (;;) {
+		last = readRecord(sessionId);
+		if (last && predicate(last)) return last;
+		if (Date.now() >= deadline) return last;
+		await delay(20);
+	}
+}
+
 const isWindows = process.platform === "win32";
 const lineEnd = isWindows ? "\r" : "\n";
 const controllerEntry = fileURLToPath(new URL("./native-task-terminal-controller.ts", import.meta.url));
@@ -546,8 +573,11 @@ async function run(): Promise<void> {
 			...SHELL_WARMUP_PROBE,
 		});
 		check(geoSeen !== null, `the shell observed the resized geometry (${cols}x${rows})`);
-		const resized = readRecord(FIRST_PANE_SESSION_ID);
-		check(resized?.cols === cols && resized?.rows === rows, "the host persisted the new geometry in the session record");
+		const resized = await awaitRecord(FIRST_PANE_SESSION_ID, (r) => r.cols === cols && r.rows === rows);
+		check(
+			resized?.cols === cols && resized?.rows === rows,
+			`the host persisted the new geometry in the session record (record: ${resized?.cols ?? "?"}x${resized?.rows ?? "?"})`,
+		);
 
 		// ── 4. detach: the app-side client goes, the terminal does not ──
 		terminal.detach();
@@ -883,10 +913,10 @@ async function run(): Promise<void> {
 		const peerStderr = await new Response(peer.stderr).text();
 		await peer.exited;
 		if (peerStderr.trim()) console.log(`       [peer stderr] ${peerStderr.trim().split("\n").slice(-3).join(" | ")}`);
-		const xpAfterRecord = readRecord(XP_FIRST_PANE_SESSION_ID);
+		const xpAfterRecord = await awaitRecord(XP_FIRST_PANE_SESSION_ID, (r) => r.cols === xpPeerCols && r.rows === xpPeerRows);
 		check(
 			xpAfterRecord?.cols === xpPeerCols && xpAfterRecord?.rows === xpPeerRows,
-			`PTY geometry followed the NEW writer (${xpPeerCols}x${xpPeerRows}, not the displaced 100x30)`,
+			`PTY geometry followed the NEW writer (${xpPeerCols}x${xpPeerRows}, not the displaced 100x30; record: ${xpAfterRecord?.cols ?? "?"}x${xpAfterRecord?.rows ?? "?"})`,
 		);
 		check(
 			isProcessAlive(xpHostPid) && isProcessAlive(xpShellPid) && !isProcessAlive(peerPid),
@@ -910,10 +940,10 @@ async function run(): Promise<void> {
 			(h) => h.t === "role" && "cols" in h && h.cols === backCols && h.rows === backRows,
 			8000,
 		);
-		const backRecord = readRecord(XP_FIRST_PANE_SESSION_ID);
+		const backRecord = await awaitRecord(XP_FIRST_PANE_SESSION_ID, (r) => r.cols === backCols && r.rows === backRows);
 		check(
 			x2FollowedBack && backRecord?.cols === backCols && backRecord?.rows === backRows,
-			`geometry follows the lease BACK to the first process (${backCols}x${backRows})`,
+			`geometry follows the lease BACK to the first process (${backCols}x${backRows}; second viewer told: ${x2FollowedBack}, record: ${backRecord?.cols ?? "?"}x${backRecord?.rows ?? "?"})`,
 		);
 
 		const xpBack = markerProbe(`${nonce}r`, xpShellPid);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that did this investigation) — writing this one up myself.

The Windows release gate `Product native task-terminal E2E` failed on tag v1.42.1 (sha `d91e5d2dd`, run 31248826195 attempt 1, job 93081796448) with one check:

```
FAIL - geometry follows the lease BACK to the first process (118x36)
```

**This is a test fix. It adds no product behaviour whatsoever, and there was no geometry race.** The check asserted something the product never promised.

## What actually happened

The check is a conjunction: a local viewer must be told the new grid, **and** the session record on disk must already carry it. Which half failed is decidable from the job log:

```
08:42:18.3228  ok   - the first process takes control back once the peer lets go
08:42:18.3547  FAIL - geometry follows the lease BACK to the first process (118x36)
```

32 ms apart. `awaitHeader` can only return `false` by exhausting its timeout, which is 8000 ms here — so the viewer half was **true**. Geometry did follow the lease back. The record on disk was the failing half.

`host.ts`'s resize branch applies the resize, fires `void persist().catch(...)` — fire and forget, through a cross-process lock plus write and rename — and sends the ack **first**. So every in-band event outruns the file. Measured with a probe booting a real host and client, `resizeAwaited` then `readRecord` immediately, idle Mac:

| Writes queued ahead | Stale right after the ack | Catch-up lag |
|---|---|---|
| 0 | 20 / 20 | 1.3 – 2.9 ms |
| 1 | 20 / 20 | 2.5 – 6.5 ms, one outlier **47.3 ms** |
| 3 | 20 / 20 | 4.8 – 7.5 ms |

60 of 60 stale: the assumption is false **100 % of the time, on every platform**. The test passed only because `awaitHeader` polls every 20 ms and accidentally donated ~20 ms of slack; a loaded Windows runner eats that slack. The product does not share the assumption — `MultiPaneCoordinator.resizePane` polls the record with a deadline and its docblock says why.

## The change

`awaitRecord()` waits for the record to satisfy a predicate and returns the last record seen, so a failure prints what the file actually held. Applied at **all three** reads of record geometry in that file — the failing one and two that were only luckier (separated by a shell round trip, and by 20 s). One false assumption in three places, not three bugs; a half-migration would bring the next Windows run back for the survivors.

Not chosen: awaiting `persist()` before the ack. That puts a locked file write on the critical path of every resize, so dragging a window would serialize on the filesystem — for a property no consumer uses.

## Mutation testing (product code broken on purpose, not the new wait)

| Mutation | Result |
|---|---|
| `broadcastNativeRoles` dropped from the resize-ack continuation in `pty-server.ts` | `FAIL - … (second viewer told: false, record: 118x36)` |
| host acks the resize but never adopts or persists it | `FAIL - … (second viewer told: false, record: 132x43)` |
| clean tree | `ALL CHECKS PASSED`, twice |

The gate still catches broken geometry propagation, and now fails with a diagnosis instead of a bare FAIL.

## Test runs — the full suite came back RED, and that is not smoothed over

The gate itself is green on the rebased sha: `bun run test:native-task-terminal-e2e` → `ALL CHECKS PASSED`.

The full `bun run test`, run twice, was **red both times** — two failures, named:

- mainview `__tests__/App.test.tsx` › `refuses Cmd+2 into the sensitive project and keeps the current board` — `Unable to find an element by [data-testid="project-screen"]`. Isolated on this sha: 122/122 green.
- bun `__tests__/git-diff-recent.test.ts` › `N=1 shows only the last commit` — `Test timed out in 5000ms`. Isolated on this sha: 6/6 green.

**Zero failed assertions** among them: one is a timeout, one is a lookup that found no node.

Three independent reasons this diff cannot reach them:

1. **A paired baseline on clean `52441b09c`** (separate worktree, `bun run lint` run inside it first so `build-info.generated.ts` exists, `node_modules` symlinked) was **also red — with a different test**: `git-diff-recent` › `N=3 shows the last three commits` instead of `N=1`, and mainview green. The composition of red reshuffles on code this branch never touched.
2. Collected-file counts are identical across every run (245 / 314 / 43) and `collected == passed + failed + skipped` in each config, so no suite silently vanished; cli reported its full 764, not the amputated 24.
3. The only edited source is `src/bun/__tests__/native-task-terminal.bun-e2e.ts`. `vitest.config.bun.ts` sets no `include`, so the default `**/*.{test,spec}.*` never collects a `*.bun-e2e.ts` file — it did not execute in those runs at all.

Full reasoning, measurements and the rejected alternatives: `decisions/2026/08/08/resize-ack-does-not-imply-persisted-record.md`.
