### PR TITLE
Hide the update-channel picker until the second channel has a feed

### DIFF
--- a/.github/workflows/unstable-publish.yml
+++ b/.github/workflows/unstable-publish.yml
@@ -12,9 +12,29 @@ name: Unstable publish
 # Scheduled workflows are BEST EFFORT and can fire late. A missed tick is harmless: the next
 # one still sees the sha mismatch and builds, so no commit is ever permanently unpublished.
 on:
-  schedule:
-    # Offset off the hour: the top of the hour is the busiest slot on shared runners.
-    - cron: "23 * * * *"
+  # THE SCHEDULE IS OFF, AND THIS IS NOT A PAUSE FOR CONVENIENCE.
+  #
+  # `electrobun build --env=unstable` cannot produce an unstable build today. The CLI that
+  # actually runs is a COMPILED BINARY that `node_modules/electrobun/bin/electrobun.cjs`
+  # downloads from the vendor's releases (`ensureCliBinary()`); `patches/electrobun@*.patch`
+  # edits `src/cli/index.ts`, which that path never executes. So `--env=unstable` hits the
+  # vendor's own allowlist and degrades to `dev` — caught on run 31251014417 by the built-
+  # folder check in create-release-artifacts.sh (`expected ./build/unstable-linux-x64 but
+  # found ./build/dev-linux-x64`), which is the one guard that asserts a RESULT.
+  #
+  # Left on the schedule, this fails all four builds every hour, forever. An hourly red
+  # nobody can fix is worse than no workflow: it is ignored within a day, and by the same
+  # people who would have to notice the next real failure.
+  #
+  # RE-ENABLE ONLY TOGETHER WITH A BUILD PATH PROVEN TO EMIT `unstable-*` — proven by a check
+  # on the RESULT, not by asserting a patch is applied to a file nobody executes, which is
+  # exactly what stayed green while this was broken. `unstable-publish.test.ts` guards it;
+  # delete that guard in the same change.
+  #   schedule:
+  #     - cron: "23 * * * *"
+  #
+  # Still dispatchable by hand, deliberately: whoever fixes the build path needs to run this
+  # end to end, and a manual run is a person watching it rather than a red left on a wall.
   # Safe to press on an unchanged `main`: every platform skips, and a republish of the same
   # commit reproduces the same `buildOrder` so clients would not reinstall anyway.
   workflow_dispatch:

--- a/change-logs/2026/08/08/fix-hide-update-channel-until-feed-exists.md
+++ b/change-logs/2026/08/08/fix-hide-update-channel-until-feed-exists.md
@@ -1,0 +1,3 @@
+Short: Update channel hidden until it works
+
+The update-channel picker went out live in 1.42.1, but nothing is published on the second channel yet — choosing it left the app showing a bare HTTP 403 instead of an update. The picker is disabled again and a channel already saved is read back as stable, so anyone who switched is returned to working updates without touching their settings file. The hourly publishing job is off for the same reason, rather than failing every hour.

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -156,7 +156,12 @@ describe("saveSettings", () => {
 			defaultAgentId: "builtin-codex",
 			defaultConfigId: "codex-default",
 			taskDropPosition: "bottom",
-			updateChannel: "unstable",
+			// "stable" and not "unstable" ON PURPOSE, and it costs this guard something: while
+			// UNSTABLE_FEED_AVAILABLE is false, coerceUpdateChannel collapses every value to
+			// "stable", so this field can no longer distinguish "preserved" from "reset to the
+			// default" here. The collapse itself is asserted in update-channel.test.ts. Put
+			// "unstable" back when the flag is deleted, so the drift guard regains its teeth.
+			updateChannel: "stable",
 			terminalPathOpenMode: "reveal",
 			theme: "light",
 			resolvedTheme: "light",

--- a/src/bun/__tests__/unstable-publish.test.ts
+++ b/src/bun/__tests__/unstable-publish.test.ts
@@ -94,6 +94,25 @@ describe("deciding whether a platform needs an unstable build", () => {
 });
 
 /**
+ * THE SCHEDULE IS OFF ON PURPOSE, and this guard is what stops that fact from being quietly
+ * undone. `electrobun build --env=unstable` cannot produce an unstable build: the CLI that
+ * runs is a compiled binary the vendor's `bin/electrobun.cjs` downloads, while the patch
+ * edits `src/cli/index.ts`, which that path never executes — so `--env` degrades to `dev`.
+ * Left on the cron, all four builds fail every hour forever, and an hourly red is ignored
+ * within a day by exactly the people who must notice the next real one.
+ */
+describe("the hourly schedule stays off until the build path is proven", () => {
+	it("has no active cron while --env=unstable cannot produce an unstable build", () => {
+		const triggers = WORKFLOW.slice(WORKFLOW.indexOf("\non:"), WORKFLOW.indexOf("\njobs:"));
+		const activeCron = triggers.split("\n").filter((l) => /^\s*-?\s*(schedule:|cron:)/.test(l));
+		expect(
+			activeCron,
+			`the cron is live again. It may only be re-enabled together with a build path PROVEN to emit unstable-* artifacts — proven by a check on the RESULT, like the built-folder comparison in create-release-artifacts.sh, not by asserting that a patch is applied to a source file nobody executes (that is exactly what passed while the feature was broken). Delete this test in the same change that re-enables the schedule.`,
+		).toEqual([]);
+	});
+});
+
+/**
  * THE BOOTSTRAP LOOP, found by probing the live bucket rather than by reading the code.
  *
  * A missing key on h0x91b-releases answers 403 AccessDenied to an anonymous caller — proven

--- a/src/bun/__tests__/update-channel.test.ts
+++ b/src/bun/__tests__/update-channel.test.ts
@@ -42,8 +42,15 @@ describe("the persisted channel value", () => {
 		}
 	});
 
-	it("accepts exactly the one opt-in spelling", () => {
-		expect(coerceUpdateChannel("unstable")).toBe("unstable");
+	// While UNSTABLE_FEED_AVAILABLE is false the opt-in spelling collapses too — that is the
+	// half of the patch that reaches a user who ALREADY switched on v1.42.1, since the update
+	// check reads this persisted value rather than the (now disabled) Settings control.
+	// Restore the accepts-the-opt-in-spelling assertion in the change that deletes the flag.
+	it("collapses even the opt-in spelling while the second channel has no feed", () => {
+		expect(
+			coerceUpdateChannel("unstable"),
+			"a value persisted by v1.42.1 must collapse to stable while the feed is unavailable, in memory and without rewriting settings.json. Fix: keep the UNSTABLE_FEED_AVAILABLE guard at the top of coerceUpdateChannel until the channel has a proven build path.",
+		).toBe("stable");
 	});
 });
 

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -4,7 +4,7 @@ import GlobalSettings from "../GlobalSettings";
 import { I18nProvider } from "../../i18n";
 import type { CodingAgent, GlobalSettings as GlobalSettingsType } from "../../../shared/types";
 import type { SettingsSectionId } from "../../state";
-import * as confirmService from "../../confirm";
+import { coerceUpdateChannel } from "../../../shared/update-channel";
 
 vi.mock("../../zoom", () => ({
 	getZoom: vi.fn(() => 1.0),
@@ -118,8 +118,6 @@ async function waitForLoad() {
 		expect(mockedApi.request.getGlobalSettings).toHaveBeenCalled();
 	});
 }
-
-const mockedConfirm = vi.mocked(confirmService.confirm);
 
 /** Open a custom Select trigger (by element id) and click the option labeled `label`. */
 async function pickFromSelect(user: ReturnType<typeof userEvent.setup>, triggerId: string, label: string) {
@@ -426,53 +424,36 @@ describe("GlobalSettings", () => {
 			expect(select).toBeInTheDocument();
 		});
 
-		// The control shipped `disabled` for as long as no unstable feed existed — picking a
-		// channel with no manifest in the bucket gets a 403, which the UI renders as "you are
-		// up to date", forever and silently. The feed exists now, so the gate is gone.
-		// Re-disabling it would look identical to "feature present" on a screenshot.
-		it("is enabled, so the channel is actually choosable", async () => {
+		// The control is `disabled` again, because nothing is published under `unstable-*` and
+		// the build path cannot produce it. v1.42.1 shipped it live: picking the channel gets a
+		// bare `HTTP 403 fetching update.json` on macOS, and the user stays in it. Enabling this
+		// again without a PROVEN build path re-ships that.
+		it("is disabled while the second channel has no feed", async () => {
 			setupMocks();
 			renderGlobalSettings("system");
 			await waitForLoad();
 
 			expect(
 				screen.getByDisplayValue("Stable"),
-				"the update-channel select must be enabled. It was `disabled` while no unstable feed was published; re-disabling it silently removes the feature while leaving the UI looking complete.",
-			).not.toBeDisabled();
+				"the update-channel select must stay disabled while UNSTABLE_FEED_AVAILABLE is false. Fix: DELETE that constant — do not flip it — in the same change that lands a build path proven to emit the channel's artifacts, and restore the enabled-control assertions with it.",
+			).toBeDisabled();
 		});
 
-		it("persists the switch only after the user confirms the consequence", async () => {
-			setupMocks();
-			mockedConfirm.mockResolvedValue(true);
-			const user = userEvent.setup();
-			renderGlobalSettings("system");
-			await waitForLoad();
-
-			await user.selectOptions(screen.getByDisplayValue("Stable"), "unstable");
-
+		// The disabled control protects whoever has NOT switched. This is the half that helps
+		// whoever ALREADY did: the update check reads the persisted setting, not the select.
+		it("collapses a persisted unstable choice back to stable", () => {
 			expect(
-				mockedConfirm,
-				"switching channels must go through confirm(): unstable is main as it lands, and switching back installs an OLDER build that then reads state a newer one wrote.",
-			).toHaveBeenCalled();
-			expect(mockedApi.request.saveGlobalSettings).toHaveBeenCalledWith(
-				expect.objectContaining({ updateChannel: "unstable" }),
-			);
+				coerceUpdateChannel("unstable"),
+				"a channel already saved by v1.42.1 must collapse to stable while the feed is unavailable. Without this the patch disables a control the affected user never touches again and leaves them on the broken channel — a fix that looks complete and helps nobody.",
+			).toBe("stable");
 		});
 
-		it("writes nothing when the user cancels the confirmation", async () => {
-			setupMocks();
-			mockedConfirm.mockResolvedValue(false);
-			const user = userEvent.setup();
-			renderGlobalSettings("system");
-			await waitForLoad();
-
-			await user.selectOptions(screen.getByDisplayValue("Stable"), "unstable");
-
-			expect(
-				mockedApi.request.saveGlobalSettings,
-				"a cancelled confirmation must leave the setting untouched. Persisting first and confirming after would put the user on unstable the moment the dialog appeared.",
-			).not.toHaveBeenCalled();
-		});
+		// The confirmation-flow tests (switch persists only after confirm; cancel writes
+		// nothing; switching back names the direction) drove the select with userEvent, which
+		// cannot operate a disabled control. They are removed rather than weakened, and they
+		// come back with the control itself — restore them in the same change that deletes
+		// UNSTABLE_FEED_AVAILABLE. The confirm() handler they covered is untouched by this
+		// patch; nothing can reach it while the select is disabled.
 	});
 
 	describe("default agent selection", () => {

--- a/src/mainview/components/global-settings/SystemSettingsSection.tsx
+++ b/src/mainview/components/global-settings/SystemSettingsSection.tsx
@@ -1,5 +1,5 @@
 import type { GlobalSettings } from "../../../shared/types";
-import type { UpdateChannel } from "../../../shared/update-channel";
+import { UNSTABLE_FEED_AVAILABLE, type UpdateChannel } from "../../../shared/update-channel";
 import type { TFunction } from "../../i18n";
 import BrowserNotificationsSetting from "./BrowserNotificationsSetting";
 import SettingsEntry from "./SettingsEntry";
@@ -34,7 +34,10 @@ export default function SystemSettingsSection({
 					<select
 						value={globalSettings.updateChannel}
 						onChange={(event) => onUpdateChannelChange(event.target.value as UpdateChannel)}
-						className="w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm outline-none appearance-none"
+						disabled={!UNSTABLE_FEED_AVAILABLE}
+						className={`w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm outline-none appearance-none${
+							UNSTABLE_FEED_AVAILABLE ? "" : " cursor-not-allowed opacity-50"
+						}`}
 					>
 						<option value="stable">{t("settings.updateChannelStable")}</option>
 						<option value="unstable">{t("settings.updateChannelUnstable")}</option>

--- a/src/shared/update-channel.ts
+++ b/src/shared/update-channel.ts
@@ -19,6 +19,32 @@ export type UpdateChannel = "stable" | "unstable";
 export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = "stable";
 
 /**
+ * FALSE, because nothing is published under `unstable-*` and nothing can be yet.
+ *
+ * `electrobun build --env=unstable` cannot produce an unstable build: the CLI that actually
+ * runs is a compiled binary the vendor's `bin/electrobun.cjs` downloads (`ensureCliBinary()`),
+ * while `patches/electrobun@*.patch` edits `src/cli/index.ts`, which that path never
+ * executes — so `--env` hits the vendor's allowlist and degrades to `dev`. v1.42.1 shipped
+ * the control live regardless, so a macOS user who picks Unstable gets a bare
+ * `HTTP 403 fetching update.json` and stays in it until they switch back.
+ *
+ * TWO THINGS HANG OFF THIS FLAG, and the second is the one that is easy to omit:
+ *  1. the Settings control is disabled — that protects whoever has NOT switched yet;
+ *  2. {@link coerceUpdateChannel} collapses to stable — the ONLY thing that helps whoever
+ *     ALREADY switched. The control is UI, but the update check reads the persisted
+ *     setting directly, so disabling the select alone would ship a fix that does nothing
+ *     for the single person it exists for.
+ *
+ * The collapse happens in memory, on load. Nothing under `~/.dev3.0/` is rewritten, so an
+ * older installed build reading the same file still finds the value it wrote.
+ *
+ * DELETE THIS CONSTANT — do not flip it to `true` — in the change that gives the second
+ * channel a build path PROVEN to emit its artifacts. A permanently-true constant is a dead
+ * branch whose guard tests then assert nothing.
+ */
+export const UNSTABLE_FEED_AVAILABLE = false;
+
+/**
  * Read a persisted channel value. Anything that is not exactly `"unstable"` becomes
  * `"stable"`.
  *
@@ -31,6 +57,10 @@ export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = "stable";
  * as a compatibility alias.
  */
 export function coerceUpdateChannel(value: unknown): UpdateChannel {
+	// While the second channel has no feed, a value already persisted by v1.42.1 must
+	// collapse too — see {@link UNSTABLE_FEED_AVAILABLE}. Disabling the control alone
+	// leaves the one user who already switched exactly where they were.
+	if (!UNSTABLE_FEED_AVAILABLE) return DEFAULT_UPDATE_CHANNEL;
 	return value === "unstable" ? "unstable" : DEFAULT_UPDATE_CHANNEL;
 }
 


### PR DESCRIPTION
Hi, Claude here — the AI assistant that wrote this branch.

**This is NOT a fix for the unstable channel.** It returns the app to the state #1284 shipped: the mechanism exists, the channel does not. Please do not read a green tick here as "channels work now".

## What went wrong

`electrobun build --env=unstable` **cannot produce an unstable build**, and never could. The CLI that actually runs is a **compiled binary** that the vendor's `bin/electrobun.cjs` downloads from their releases (`ensureCliBinary()`, checking `bin/electrobun` then `.cache/electrobun` before fetching). `patches/electrobun@1.18.1.patch` edits `src/cli/index.ts` — a file that path **never executes**. So `--env=unstable` hits the vendor's own allowlist and degrades to `dev`.

Caught on the first scheduled run (`31251014417`) by the built-folder comparison in `create-release-artifacts.sh`:

```
expected ./build/unstable-linux-x64 but found ./build/dev-linux-x64
```

That check asserts a **result**. The three guards that assert the *patch* — declared for the pinned version, applied to `node_modules`, only adds to the list — were green throughout, because they describe a file nobody runs. Same shape as the bootstrap bug this stack already hit, one level deeper: there a correct rule was fed from a bad source, here a correct assertion names a non-executable artifact.

## Why it is user-visible, not just CI-red

`v1.42.1` (`d91e5d2dd`) contains #1288, so the **picker shipped live**. On macOS, choosing it produces a bare `HTTP 403 fetching update.json` from `updater.ts`'s `if (!resp.ok)` branch, and the user stays there. Linux and Windows refuse cross-channel switching earlier with a readable message, so the bare 403 is mainly a macOS problem.

## What this does

| | Protects |
|---|---|
| `UNSTABLE_FEED_AVAILABLE = false` restored, picker `disabled` | whoever has **not** switched |
| `coerceUpdateChannel` collapses every value to `stable` while the flag is false | whoever **already** switched — the update check reads the persisted setting, not the control, so disabling the select alone would ship a fix that helps nobody |
| Cron schedule commented out, `workflow_dispatch` kept | stops four failed builds every hour, forever; an hourly red is ignored within a day by the people who must notice the next real one |

The collapse is **in memory, on load**. Nothing under `~/.dev3.0/` is rewritten, so an older installed build still reads the value it wrote.

The constant must be **deleted, not flipped**, in the change that gives the channel a proven build path. Mutation-proved: flipping it to `true` fails **two** tests, dropping the collapse line fails the one that says *"a fix that looks complete and helps nobody"*.

## Two costs, stated plainly

**Three confirmation-flow tests were deleted, not weakened** — `userEvent` cannot drive a disabled control, and a weakened test stays green while lying, whereas a deleted one is visible in the diff. The comment left in their place says to restore them together with the control.

**The settings drift guard lost its teeth on exactly one field.** `updateChannel` now carries `"stable"` in the round-trip fixture, which equals the default, so that field can no longer distinguish "preserved" from "reset to default". **The guard is not weakened anywhere else**: it asserts each field separately, the other 25 still carry non-default values, and its completeness mechanism is `Required<GlobalSettings>` — a type, not a value — so a new field added without handling still fails to compile. The collapse itself is asserted in `update-channel.test.ts`.

## This needs a release to reach anyone

Merging changes nothing for users: they are on `1.42.1` with the live picker. Without `1.42.2` this patch helps no one.

## Next, separately

Rename the second channel to `canary`, which electrobun supports natively — the patch, its three empty tests, `patchedDependencies` and the now-false "the vendored patch stopped applying" hint in `create-release-artifacts.sh` all go in that same change. Nothing is published under `unstable-*`, so the rename needs no migration and `coerceUpdateChannel` already collapses the old value.