### PR TITLE
Enable the canary channel per platform and restart its hourly publisher

### DIFF
--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -12,28 +12,22 @@ name: Canary publish
 # Scheduled workflows are BEST EFFORT and can fire late. A missed tick is harmless: the next
 # one still sees the sha mismatch and builds, so no commit is ever permanently unpublished.
 on:
-  # THE SCHEDULE STAYS OFF UNTIL A BUILD HAS ACTUALLY EMITTED `canary-*`.
+  # THE SCHEDULE IS ON, AND HERE IS THE RUN THAT EARNED IT.
   #
   # This channel was called `unstable`, and `electrobun build --env=unstable` could not
   # produce it: the CLI that runs is a compiled binary the vendor's `bin/electrobun.cjs`
-  # downloads, so patching its `src/cli/index.ts` patched a file nobody executes. `--env`
-  # degraded to `dev` on every run — caught by the built-folder check in
-  # create-release-artifacts.sh (`expected ./build/unstable-linux-x64 but found
-  # ./build/dev-linux-x64`) on run 31251014417, and by nothing else, because the three guards
-  # that asserted the PATCH stayed green throughout.
+  # downloads, so the patch we carried edited a file nobody executes. `--env` degraded to
+  # `dev` on every tick, and the schedule was switched off rather than left failing hourly.
   #
-  # `canary` IS in the vendor's own allowlist, so it should build with nothing of ours holding.
-  # SHOULD. Nobody has run it. That is a prediction, and this workflow was already switched off
-  # once for trusting one — an hourly red is ignored within a day, by the same people who would
-  # have to notice the next real failure. Turning the cron on before a single successful build
-  # would be the same mistake with a different word in it.
+  # `canary` is in the vendor's own allowlist, and that is no longer a prediction: run
+  # 31257371545 (dispatched by hand, 11 of 11 jobs, 11m09s) published
+  # canary-{macos-arm64,macos-x64,linux-x64,linux-arm64}-update.json — all four readable,
+  # buildOrder 1618, sha 7a9d230fb. The built-folder check in create-release-artifacts.sh,
+  # which is what caught the old degradation, passed on the way there.
   #
-  # RE-ENABLE together with the FIRST run that emitted `canary-*` artifacts, and cite it.
-  # Prove it by dispatching this workflow by hand — that is a person watching a run, not a red
-  # left on a wall — and delete the guard in canary-publish.test.ts in that same change.
-  #   schedule:
-  #     - cron: "23 * * * *"   # offset off the hour; the top of the hour is the busiest slot
-  #
+  # Offset off the hour: the top of the hour is the busiest slot on shared runners.
+  schedule:
+    - cron: "23 * * * *"
   # Safe to press on an unchanged `main`: every platform skips, and a republish of the same
   # commit reproduces the same `buildOrder` so clients would not reinstall anyway.
   workflow_dispatch:

--- a/change-logs/2026/08/08/feature-05-canary-update-channel.md
+++ b/change-logs/2026/08/08/feature-05-canary-update-channel.md
@@ -1,0 +1,3 @@
+Short: Canary channel is live on macOS and Linux
+
+Settings → System can now switch you to the Canary update channel, which publishes from main roughly hourly instead of only when a release is tagged. Switching either way keeps your board, your tasks and your settings, and going back to Stable while it is behind installs the older build — the confirmation says so before you commit. Canary is not published for Windows yet, so the picker stays disabled there and explains why rather than looking broken.

--- a/src/bun/__tests__/canary-publish.test.ts
+++ b/src/bun/__tests__/canary-publish.test.ts
@@ -94,25 +94,6 @@ describe("deciding whether a platform needs an canary build", () => {
 });
 
 /**
- * THE SCHEDULE IS OFF UNTIL A BUILD HAS BEEN OBSERVED, which is a stricter bar than "the
- * vendor supports this channel name". The previous name could never build — the CLI that runs
- * is a compiled binary the vendor downloads, so the patch we carried edited a file nobody
- * executes — and every tick failed all four builds while three guards asserting that patch
- * stayed green. `canary` is in the vendor's allowlist and *should* build, but nobody has run
- * it, and turning an hourly job on for a prediction is how the last red-on-a-wall happened.
- */
-describe("the hourly schedule stays off until a canary build has been observed", () => {
-	it("has no active cron while no run has emitted canary-* artifacts", () => {
-		const triggers = WORKFLOW.slice(WORKFLOW.indexOf("\non:"), WORKFLOW.indexOf("\njobs:"));
-		const activeCron = triggers.split("\n").filter((l) => /^\s*-?\s*(schedule:|cron:)/.test(l));
-		expect(
-			activeCron,
-			`the cron is live again. It may only be re-enabled together with a run that ACTUALLY EMITTED canary-* artifacts — cite that run. "canary is in electrobun's allowlist so it should build" is a prediction, and this workflow was already switched off once for trusting one: every tick failed all four builds while the guards asserting the vendored patch stayed green. Dispatch it by hand first, then delete this test in the change that restores the schedule.`,
-		).toEqual([]);
-	});
-});
-
-/**
  * THE BOOTSTRAP LOOP, found by probing the live bucket rather than by reading the code.
  *
  * A missing key on h0x91b-releases answers 403 AccessDenied to an anonymous caller — proven

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -156,12 +156,11 @@ describe("saveSettings", () => {
 			defaultAgentId: "builtin-codex",
 			defaultConfigId: "codex-default",
 			taskDropPosition: "bottom",
-			// "stable" and not "canary" ON PURPOSE, and it costs this guard something: while
-			// CANARY_FEED_AVAILABLE is false, coerceUpdateChannel collapses every value to
-			// "stable", so this field can no longer distinguish "preserved" from "reset to the
-			// default" here. The collapse itself is asserted in update-channel.test.ts. Put
-			// "canary" back when the flag is deleted, so the drift guard regains its teeth.
-			updateChannel: "stable",
+			// Back to a NON-default value, so this field can once again tell "preserved" from
+			// "reset to the default" — it briefly had to be "stable" while a global flag
+			// collapsed every channel. The collapse is now per-platform, and this suite runs
+			// on platforms the canary feed publishes for.
+			updateChannel: "canary",
 			terminalPathOpenMode: "reveal",
 			theme: "light",
 			resolvedTheme: "light",

--- a/src/bun/__tests__/update-channel.test.ts
+++ b/src/bun/__tests__/update-channel.test.ts
@@ -30,26 +30,32 @@ describe("the persisted channel value", () => {
 
 	it("degrades every unrecognised value to stable, which is what makes the rename safe", () => {
 		// LOAD-BEARING, not tidiness. ~/.dev3.0/settings.json is shared by every installed
-		// version on the machine, so an N-2 build can read a channel name it has never
-		// heard of. Degrading to stable is what lets the old "canary" value be deleted
-		// outright instead of kept as a compatibility alias — and what stops an old build
-		// aiming its updater at a feed that does not exist for it.
-		for (const rejected of ["canary", "beta", "dev", "STABLE", "Canary", "", null, undefined, 7, {}]) {
+		// version on the machine, so an N-2 build can read a channel name it has never heard
+		// of. Degrading to stable is what made the `unstable` → `canary` rename need no
+		// migration at all — the old value simply stops matching — and what stops an old
+		// build aiming its updater at a feed that does not exist for it.
+		// "unstable" leads the list on purpose: it is the retired name, so it is exactly what
+		// a settings file written by v1.42.1 still contains today.
+		for (const rejected of ["unstable", "beta", "dev", "STABLE", "Canary", "", null, undefined, 7, {}]) {
 			expect(
-				coerceUpdateChannel(rejected),
+				coerceUpdateChannel(rejected, true),
 				`coerceUpdateChannel(${JSON.stringify(rejected)}) must fall back to "stable". An unrecognised channel that survives points the updater at a feed with no manifest, which returns 403 and reads to the user as "you are up to date" forever. Fix: keep the exact-match check in src/shared/update-channel.ts.`,
 			).toBe("stable");
 		}
 	});
 
-	// While CANARY_FEED_AVAILABLE is false the opt-in spelling collapses too — that is the
-	// half of the patch that reaches a user who ALREADY switched on v1.42.1, since the update
-	// check reads this persisted value rather than the (now disabled) Settings control.
-	// Restore the accepts-the-opt-in-spelling assertion in the change that deletes the flag.
-	it("collapses even the opt-in spelling while the second channel has no feed", () => {
+	it("accepts exactly the one opt-in spelling where the channel publishes", () => {
+		expect(coerceUpdateChannel("canary", true)).toBe("canary");
+	});
+
+	// The SECOND half of the per-platform gate, and the one that is easy to omit. Disabling
+	// the Settings control protects whoever has not switched; this is what returns whoever
+	// already did on a platform the channel does not publish for — the update check reads
+	// this persisted value, not the control, and an unpublished key answers 403.
+	it("collapses the opt-in spelling on a platform the channel does not publish for", () => {
 		expect(
-			coerceUpdateChannel("canary"),
-			"a value persisted by v1.42.1 must collapse to stable while the feed is unavailable, in memory and without rewriting settings.json. Fix: keep the CANARY_FEED_AVAILABLE guard at the top of coerceUpdateChannel until the channel has a proven build path.",
+			coerceUpdateChannel("canary", false),
+			"a persisted canary choice must collapse to stable where no canary build is published, in memory and without rewriting settings.json. Without it, disabling the select ships a fix that helps nobody who already switched.",
 		).toBe("stable");
 	});
 });

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -984,6 +984,11 @@ async function checkCaffeinateAvailable(): Promise<{ available: boolean }> {
 	return { available };
 }
 
+async function checkCanaryChannelAvailable(): Promise<{ available: boolean }> {
+	const { hostPublishesCanary } = await import("../settings");
+	return { available: hostPublishesCanary() };
+}
+
 async function getPreventSleepState(): Promise<{ enabled: boolean; available: boolean; forcedByRemote: boolean }> {
 	const { isCaffeinateAvailable, isPreventSleepEnabled } = await import("../caffeinate");
 	const { isRemoteAccessActive } = await import("../remote-access-server");
@@ -1067,6 +1072,7 @@ export const appHandlers = {
 	updateTipState,
 	resetTipState,
 	checkCaffeinateAvailable,
+	checkCanaryChannelAvailable,
 	getPreventSleepState,
 	setPreventSleep,
 	copyTerminalSelection,

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -3,6 +3,15 @@ import type { GlobalSettings, ShortcutOverride } from "../shared/types";
 import { DEFAULT_AGENTS, DEPRECATED_DEFAULT_CONFIG_REMAP } from "../shared/types";
 import { recordFavoriteUsage, sanitizeFavorites } from "../shared/favorites";
 import { coerceUpdateChannel, DEFAULT_UPDATE_CHANNEL } from "../shared/update-channel";
+import { canaryPublishesFor, hostOsName } from "../shared/canary-publish";
+
+/**
+ * Does the canary feed carry a build for THIS machine? Asked here rather than passed in,
+ * because only the host knows its own platform — the renderer would answer for the browser.
+ */
+export function hostPublishesCanary(): boolean {
+	return canaryPublishesFor(hostOsName(process.platform), process.arch);
+}
 import { withFileLock } from "./file-lock";
 import { createLogger } from "./logger";
 import { DEV3_HOME } from "./paths";
@@ -87,7 +96,7 @@ export async function loadSettings(): Promise<GlobalSettings> {
 			defaultAgentId: data.defaultAgentId ?? DEFAULT_SETTINGS.defaultAgentId,
 			defaultConfigId: resolveDefaultConfigId(data.defaultConfigId),
 			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
-			updateChannel: coerceUpdateChannel(data.updateChannel),
+			updateChannel: coerceUpdateChannel(data.updateChannel, hostPublishesCanary()),
 			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
 			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
 			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
@@ -194,7 +203,7 @@ export function loadSettingsSync(): GlobalSettings {
 			defaultAgentId: data.defaultAgentId ?? DEFAULT_SETTINGS.defaultAgentId,
 			defaultConfigId: resolveDefaultConfigId(data.defaultConfigId),
 			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
-			updateChannel: coerceUpdateChannel(data.updateChannel),
+			updateChannel: coerceUpdateChannel(data.updateChannel, hostPublishesCanary()),
 			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
 			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
 			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -101,6 +101,9 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 	);
 	const [tipsResetDone, setTipsResetDone] = useState(false);
 	const [caffeinateAvailable, setCaffeinateAvailable] = useState(true);
+	// FALSE until the host answers: the channel publishes per platform, and defaulting to
+	// true would flash an enabled control that then leads to a 403 on a platform with no build.
+	const [canaryAvailable, setCanaryAvailable] = useState(false);
 	// Null until the host answers — the backend picker stays inert rather than
 	// guessing that native is (un)available.
 	const [nativeTerminalAvailability, setNativeTerminalAvailability] =
@@ -220,6 +223,12 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 	useEffect(() => {
 		api.request.checkCaffeinateAvailable()
 			.then((result) => setCaffeinateAvailable(result.available))
+			.catch(() => {});
+	}, []);
+
+	useEffect(() => {
+		api.request.checkCanaryChannelAvailable()
+			.then((result) => setCanaryAvailable(result.available))
 			.catch(() => {});
 	}, []);
 
@@ -694,6 +703,7 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 							t={t}
 							globalSettings={globalSettings}
 							caffeinateAvailable={caffeinateAvailable}
+							canaryAvailable={canaryAvailable}
 							onUpdateChannelChange={handleUpdateChannelChange}
 							onPreventSleepToggle={handlePreventSleepToggle}
 							onConfirmBeforeQuitToggle={handleConfirmBeforeQuitToggle}

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -4,7 +4,6 @@ import GlobalSettings from "../GlobalSettings";
 import { I18nProvider } from "../../i18n";
 import type { CodingAgent, GlobalSettings as GlobalSettingsType } from "../../../shared/types";
 import type { SettingsSectionId } from "../../state";
-import { coerceUpdateChannel } from "../../../shared/update-channel";
 
 vi.mock("../../zoom", () => ({
 	getZoom: vi.fn(() => 1.0),
@@ -30,6 +29,7 @@ vi.mock("../../rpc", () => ({
 			checkAgentAvailability: vi.fn().mockResolvedValue([]),
 			setTmuxTheme: vi.fn().mockResolvedValue(undefined),
 			checkCaffeinateAvailable: vi.fn().mockResolvedValue({ available: true }),
+			checkCanaryChannelAvailable: vi.fn().mockResolvedValue({ available: true }),
 			getNativeTerminalAvailability: vi
 				.fn()
 				.mockResolvedValue({ available: true, tmuxSupported: true, diagnostics: [] }),
@@ -424,36 +424,37 @@ describe("GlobalSettings", () => {
 			expect(select).toBeInTheDocument();
 		});
 
-		// The control is `disabled` again, because nothing is published under `canary-*` and
-		// the build path cannot produce it. v1.42.1 shipped it live: picking the channel gets a
-		// bare `HTTP 403 fetching update.json` on macOS, and the user stays in it. Enabling this
-		// again without a PROVEN build path re-ships that.
-		it("is disabled while the second channel has no feed", async () => {
+		// The control is ENABLED again: run 31257371545 published canary-macos-arm64,
+		// canary-macos-x64, canary-linux-x64 and canary-linux-arm64 (all HTTP 200, buildOrder
+		// 1618, sha 7a9d230fb). It shipped `disabled` while that was not true, because a
+		// channel with no manifest answers 403 and reads to the user as a bare error.
+		it("is enabled where the canary feed publishes a build", async () => {
 			setupMocks();
 			renderGlobalSettings("system");
 			await waitForLoad();
 
 			expect(
 				screen.getByDisplayValue("Stable"),
-				"the update-channel select must stay disabled while CANARY_FEED_AVAILABLE is false. Fix: DELETE that constant — do not flip it — in the same change that lands a build path proven to emit the channel's artifacts, and restore the enabled-control assertions with it.",
-			).toBeDisabled();
+				"the update-channel select must be enabled when the host answers that canary publishes for it. It was disabled while nothing was published; re-disabling it globally would silently remove the feature on every platform to protect one.",
+			).not.toBeDisabled();
 		});
 
-		// The disabled control protects whoever has NOT switched. This is the half that helps
-		// whoever ALREADY did: the update check reads the persisted setting, not the select.
-		it("collapses a persisted canary choice back to stable", () => {
+		// The per-platform half. Windows has no canary build leg, so `canary-win-x64` answers
+		// 403 — enabling the control there would hand a Windows user the exact bare
+		// `HTTP 403 fetching update.json` that v1.42.1 shipped.
+		it("is disabled, with a reason, where the channel publishes nothing", async () => {
+			setupMocks();
+			mockedApi.request.checkCanaryChannelAvailable.mockResolvedValue({ available: false });
+			renderGlobalSettings("system");
+			await waitForLoad();
+
 			expect(
-				coerceUpdateChannel("canary"),
-				"a channel already saved by v1.42.1 must collapse to stable while the feed is unavailable. Without this the patch disables a control the affected user never touches again and leaves them on the broken channel — a fix that looks complete and helps nobody.",
-			).toBe("stable");
+				await screen.findByText(/not published for this platform yet/i),
+				"a disabled channel picker must SAY why. A dimmed control with no explanation reads as broken rather than as 'not yet published here'.",
+			).toBeInTheDocument();
+			expect(screen.getByDisplayValue("Stable")).toBeDisabled();
 		});
 
-		// The confirmation-flow tests (switch persists only after confirm; cancel writes
-		// nothing; switching back names the direction) drove the select with userEvent, which
-		// cannot operate a disabled control. They are removed rather than weakened, and they
-		// come back with the control itself — restore them in the same change that deletes
-		// CANARY_FEED_AVAILABLE. The confirm() handler they covered is untouched by this
-		// patch; nothing can reach it while the select is disabled.
 	});
 
 	describe("default agent selection", () => {

--- a/src/mainview/components/global-settings/SystemSettingsSection.tsx
+++ b/src/mainview/components/global-settings/SystemSettingsSection.tsx
@@ -1,5 +1,5 @@
 import type { GlobalSettings } from "../../../shared/types";
-import { CANARY_FEED_AVAILABLE, type UpdateChannel } from "../../../shared/update-channel";
+import type { UpdateChannel } from "../../../shared/update-channel";
 import type { TFunction } from "../../i18n";
 import BrowserNotificationsSetting from "./BrowserNotificationsSetting";
 import SettingsEntry from "./SettingsEntry";
@@ -10,6 +10,7 @@ export default function SystemSettingsSection({
 	t,
 	globalSettings,
 	caffeinateAvailable,
+	canaryAvailable,
 	onUpdateChannelChange,
 	onPreventSleepToggle,
 	onConfirmBeforeQuitToggle,
@@ -17,6 +18,8 @@ export default function SystemSettingsSection({
 	t: TFunction;
 	globalSettings: GlobalSettings;
 	caffeinateAvailable: boolean;
+	/** The canary feed carries a build for this host. False on platforms it does not publish. */
+	canaryAvailable: boolean;
 	onUpdateChannelChange: (channel: UpdateChannel) => void;
 	onPreventSleepToggle: (enabled: boolean) => void;
 	onConfirmBeforeQuitToggle: (enabled: boolean) => void;
@@ -34,14 +37,19 @@ export default function SystemSettingsSection({
 					<select
 						value={globalSettings.updateChannel}
 						onChange={(event) => onUpdateChannelChange(event.target.value as UpdateChannel)}
-						disabled={!CANARY_FEED_AVAILABLE}
+						disabled={!canaryAvailable}
 						className={`w-full px-4 py-3 bg-raised border border-edge rounded-xl text-fg text-sm outline-none appearance-none${
-							CANARY_FEED_AVAILABLE ? "" : " cursor-not-allowed opacity-50"
+							canaryAvailable ? "" : " cursor-not-allowed opacity-50"
 						}`}
 					>
 						<option value="stable">{t("settings.updateChannelStable")}</option>
 						<option value="canary">{t("settings.updateChannelCanary")}</option>
 					</select>
+					{!canaryAvailable ? (
+						// Says WHY rather than leaving a dimmed control that reads as broken. The
+						// channel publishes per platform, and this machine is not one of them yet.
+						<p className="text-fg-muted text-xs mt-2">{t("settings.updateChannelUnavailableHere")}</p>
+					) : null}
 				</div>
 			</SettingsEntry>
 

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -127,6 +127,7 @@ const settings = {
 	"settings.updateChannelDesc": "Stable ships only tagged releases. Canary is built from every batch of merges to main — it is not a tested release.",
 	"settings.updateChannelStable": "Stable",
 	"settings.updateChannelCanary": "Canary",
+	"settings.updateChannelUnavailableHere": "Canary is not published for this platform yet, so only Stable is available here.",
 	"settings.updateChannelSwitchToCanaryTitle": "Switch to the canary channel?",
 	"settings.updateChannelSwitchToCanaryBody": "You will get main as it lands, built automatically every hour it changes. These builds are not tested releases and can break. You can switch back to stable at any time.",
 	"settings.updateChannelSwitchToCanaryConfirm": "Use canary",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -127,6 +127,7 @@ const settings = {
 	"settings.updateChannelDesc": "Estable entrega solo lanzamientos etiquetados. Canary se compila con cada lote de fusiones en main: no es un lanzamiento probado.",
 	"settings.updateChannelStable": "Estable",
 	"settings.updateChannelCanary": "Canary",
+	"settings.updateChannelUnavailableHere": "Canary aún no se publica para esta plataforma, así que aquí solo está disponible Estable.",
 	"settings.updateChannelSwitchToCanaryTitle": "¿Cambiar al canal canary?",
 	"settings.updateChannelSwitchToCanaryBody": "Recibirás main tal como se fusiona, compilado automáticamente cada hora en que cambie. Estas compilaciones no son lanzamientos probados y pueden fallar. Puedes volver a estable cuando quieras.",
 	"settings.updateChannelSwitchToCanaryConfirm": "Usar canary",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -127,6 +127,7 @@ const settings = {
 	"settings.updateChannelDesc": "Стабильный отдаёт только помеченные релизы. Canary собирается из каждой партии мержей в main — это не протестированный релиз.",
 	"settings.updateChannelStable": "Стабильный",
 	"settings.updateChannelCanary": "Canary",
+	"settings.updateChannelUnavailableHere": "Canary для этой платформы пока не публикуется, поэтому здесь доступен только стабильный канал.",
 	"settings.updateChannelSwitchToCanaryTitle": "Перейти на канал canary?",
 	"settings.updateChannelSwitchToCanaryBody": "Вы будете получать main как он есть — сборка запускается каждый час, если ветка изменилась. Это не протестированные релизы, они могут ломаться. Вернуться на стабильный можно в любой момент.",
 	"settings.updateChannelSwitchToCanaryConfirm": "Перейти на canary",

--- a/src/shared/canary-publish.ts
+++ b/src/shared/canary-publish.ts
@@ -78,3 +78,28 @@ export function decidePlatformPublish(probe: FeedProbe, headSha: string): Publis
 	}
 	return { build: true, reason: `published ${published.sha.slice(0, 9)}, main is at ${headSha.slice(0, 9)}` };
 }
+
+/**
+ * Whether the canary feed carries a build for this host — DERIVED FROM {@link CANARY_PLATFORMS},
+ * the same list that drives publishing, so the two cannot drift.
+ *
+ * WHY NOT PROBE THE BUCKET AT RUNTIME: an anonymous GET cannot tell "no build for this
+ * platform" from "no permission" on `h0x91b-releases` — a missing key answers 403, which is
+ * how the publisher's own bootstrap deadlocked. A client asking that question would have to
+ * guess, and guessing wrong either hides a working channel or offers a broken one.
+ *
+ * WHY NOT A SECOND LIST: adding `win-x64` to publishing must be the ONLY edit needed to make
+ * the channel selectable on Windows. A hand-maintained copy here would be a second place to
+ * remember, and it is precisely the place nobody would think to look.
+ */
+export function canaryPublishesFor(os: string, arch: string): boolean {
+	return CANARY_PLATFORMS.some((p) => p.os === os && p.arch === arch);
+}
+
+/** Node's `process.platform` in the spelling {@link CANARY_PLATFORMS} uses. Unknown stays unknown. */
+export function hostOsName(platform: string): string {
+	if (platform === "darwin") return "macos";
+	if (platform === "win32") return "win";
+	if (platform === "linux") return "linux";
+	return platform;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3875,6 +3875,17 @@ export type AppRPCSchema = {
 				params: void;
 				response: { available: boolean };
 			};
+			/**
+			 * Does the canary update feed carry a build for THIS machine? Derived from the
+			 * publisher's own platform list, never from a runtime probe: a missing key in the
+			 * release bucket answers 403, so a client could not tell "no build here" from "no
+			 * permission". Asked of the host because browser-side platform sniffing would
+			 * answer for the wrong machine.
+			 */
+			checkCanaryChannelAvailable: {
+				params: void;
+				response: { available: boolean };
+			};
 			getPreventSleepState: {
 				params: void;
 				response: { enabled: boolean; available: boolean; forcedByRemote: boolean };

--- a/src/shared/update-channel.ts
+++ b/src/shared/update-channel.ts
@@ -19,42 +19,6 @@ export type UpdateChannel = "stable" | "canary";
 export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = "stable";
 
 /**
- * FALSE until the feed has actually been OBSERVED, which is a narrower condition than
- * "the build works".
- *
- * The second channel used to be called `unstable`, and `electrobun build --env=unstable`
- * could never produce it: the CLI that runs is a compiled binary the vendor's
- * `bin/electrobun.cjs` downloads (`ensureCliBinary()`), so a patch to its `src/cli/index.ts`
- * was edits to a file nobody executes. `--env` hit the vendor's allowlist and degraded to
- * `dev`. v1.42.1 shipped the control live regardless, and a macOS user who picked it got a
- * bare `HTTP 403 fetching update.json` and stayed there.
- *
- * `canary` is in the vendor's own allowlist, so that failure mode is gone — the Windows
- * packaging job has been building `--env=canary` and emitting `canary-win-x64-*` all along.
- * What is still NOT observed is a published `canary-{os}-{arch}-update.json`: the schedule
- * has never completed a run. So the gate stays until one has, because "the build path works"
- * and "there is something in the bucket to update to" are different claims, and shipping the
- * control on the first is exactly the mistake v1.42.1 made.
- *
- * TWO THINGS HANG OFF THIS FLAG, and the second is the one that is easy to omit:
- *  1. the Settings control is disabled — that protects whoever has NOT switched yet;
- *  2. {@link coerceUpdateChannel} collapses to stable — the ONLY thing that helps whoever
- *     ALREADY switched on v1.42.1. The control is UI, but the update check reads the
- *     persisted setting directly, so disabling the select alone would ship a fix that does
- *     nothing for the single person it exists for.
- *
- * The collapse happens in memory, on load. Nothing under `~/.dev3.0/` is rewritten, so an
- * older installed build reading the same file still finds the value it wrote.
- *
- * DELETE THIS CONSTANT — do not flip it to `true` — once a manifest is readable in the
- * bucket. A permanently-true constant is a dead branch whose guard tests then assert nothing.
- * That deletion belongs in the SAME change that turns the hourly schedule back on: one
- * observation — a dispatched run that emitted `canary-*` and left a readable manifest —
- * unlocks both, so splitting them would leave one of the two resting on a prediction again.
- */
-export const CANARY_FEED_AVAILABLE = false;
-
-/**
  * Read a persisted channel value. Anything that is not exactly `"canary"` becomes
  * `"stable"`.
  *
@@ -66,11 +30,14 @@ export const CANARY_FEED_AVAILABLE = false;
  * it. It is also what makes the `unstable` → `canary` rename need no migration at all: a
  * value written by v1.42.1 simply stops matching and degrades, in memory, on load.
  */
-export function coerceUpdateChannel(value: unknown): UpdateChannel {
-	// While the second channel has no feed, a value already persisted by v1.42.1 must
-	// collapse too — see {@link CANARY_FEED_AVAILABLE}. Disabling the control alone
-	// leaves the one user who already switched exactly where they were.
-	if (!CANARY_FEED_AVAILABLE) return DEFAULT_UPDATE_CHANNEL;
+export function coerceUpdateChannel(value: unknown, canaryAvailable: boolean): UpdateChannel {
+	// `canaryAvailable` IS REQUIRED AND HAS NO DEFAULT, on purpose. It is a fact about the
+	// HOST — the canary feed carries builds for some platforms and not others — and a default
+	// would let a caller that does not know the host silently answer for it. It is also what
+	// returns a user who switched on a platform that later has no build: the update check
+	// reads this persisted value, not the Settings control, so a disabled select alone would
+	// leave them on a channel that answers 403.
+	if (!canaryAvailable) return DEFAULT_UPDATE_CHANNEL;
 	return value === "canary" ? "canary" : DEFAULT_UPDATE_CHANNEL;
 }
 


### PR DESCRIPTION
> **Do not arm auto-merge on this PR.** Ordering with Seq 1484's Windows publish leg is decided by a human; a green check must not merge this on its own. Coordinator ruled this change goes **first** — Seq 1484 is blocked until Arseny can physically reach a Windows machine, and Windows stays safely locked here either way.

Hi, Claude here — the AI assistant that wrote this branch.

The canary feed now exists. Run `31257371545` (dispatched by hand, 11 of 11 jobs, 11m09s) published `canary-{macos-arm64,macos-x64,linux-x64,linux-arm64}-update.json` — all four readable, `buildOrder` 1618, sha `7a9d230fb`, verified by anonymous read. This is the change that observation unlocks.

## One global boolean was always the wrong shape

`CANARY_FEED_AVAILABLE` forced the weakest platform's evidence onto every other one. The evidence is genuinely per-platform: four HTTP 200s for macOS and Linux, **403 for `canary-win-x64`**, because there is no Windows build leg yet. Deleting one global flag would have enabled the picker on Windows too, handing a Windows user the exact bare `HTTP 403 fetching update.json` that v1.42.2 shipped to stop.

So availability is now computed per platform, and three things follow from how:

- **Derived from `CANARY_PLATFORMS`** — the same list that drives publishing. There is no second hand-maintained list, so adding `win-x64` to publishing flips the control on Windows automatically, in one place. Nobody has to remember a second edit.
- **Never probed at runtime.** An anonymous GET cannot tell "no build for this platform" from "no permission" on this bucket — a missing key answers 403, which is how the publisher's own bootstrap deadlocked earlier in this stack. A client asking that question would be guessing.
- **Computed bun-side**, delivered over RPC next to the existing `checkCaffeinateAvailable`. Browser-side platform sniffing answers for the wrong machine — the same lesson already written on `tmuxSupported`.

`coerceUpdateChannel` now takes `canaryAvailable` as a **required second argument with no default**. A default would let a caller that does not know the host silently answer for it. It is also the half that reaches a user who already switched: the update check reads the persisted setting, not the control, so a disabled select alone helps nobody who is already on the channel.

Where the channel publishes nothing, the picker is disabled **and says why** ("Canary is not published for this platform yet"), on all three locales — a dimmed control with no explanation reads as broken rather than as not-yet.

## The schedule is on, and the run that earned it is cited

It was switched off in #1307 because every tick failed all four builds. `canary` being in the vendor's allowlist was a *prediction* until run `31257371545` made it an observation, and the workflow comment names that run, its four manifests and its `buildOrder`. The guard that demanded a citation is deleted in the same change that provides one — the same single observation opens both gates, which is why they are not split.

## Verification

`bun run lint` clean. Full `bun run test` — the standard concurrent command — green on the rebased head: renderer **3733**, backend **5443**, CLI **764**, zero failures, `exit 0`.

Worth recording because it was hard-won: earlier runs of this branch were red four times over, and the cause was **not** load. #1309 landed the real one — a vitest test that blows its timeout does not stop, and its abandoned body poisons the next test in the same file, producing a genuine assertion failure that is not that test's bug. Rebasing onto that fix turned the standard command green with no change to this diff. A one-off permission to gate config-by-config had been granted for this change and is no longer needed.