### PR TITLE
Cut remote terminal echo latency behind the project's first PostHog flag

### DIFF
--- a/change-logs/2026/08/09/feature-30-remote-terminal-latency-flag.md
+++ b/change-logs/2026/08/09/feature-30-remote-terminal-latency-flag.md
@@ -1,0 +1,3 @@
+Short: Snappier terminal over remote
+
+The terminal over remote access no longer holds a keystroke echo for a full frame before sending it, and it now throttles its send cadence instead of piling frames into a socket the tunnel cannot drain — so sustained output stops rendering smoothly but behind reality. Both behaviours ship behind the project's first PostHog feature flag, which refreshes about every five minutes without a restart.

--- a/change-logs/2026/08/10/feature-30-remote-terminal-latency-flag.md
+++ b/change-logs/2026/08/10/feature-30-remote-terminal-latency-flag.md
@@ -1,3 +1,5 @@
 Short: Snappier terminal over remote
 
 The terminal over remote access no longer holds a keystroke echo for a full frame before sending it, and it now throttles its send cadence instead of piling frames into a socket the tunnel cannot drain — so sustained output stops rendering smoothly but behind reality. Both behaviours ship behind the project's first PostHog feature flag, which refreshes about every five minutes without a restart.
+
+Debug → Feature Flags is a new window listing every flag with the value the app is actually gating code on, next to the PostHog distinct ID of this install with a copy button, so a rollout can be pointed at one machine.

--- a/change-logs/2026/08/10/feature-30-remote-terminal-latency-flag.md
+++ b/change-logs/2026/08/10/feature-30-remote-terminal-latency-flag.md
@@ -2,4 +2,4 @@ Short: Snappier terminal over remote
 
 The terminal over remote access no longer holds a keystroke echo for a full frame before sending it, and it now throttles its send cadence instead of piling frames into a socket the tunnel cannot drain — so sustained output stops rendering smoothly but behind reality. Both behaviours ship behind the project's first PostHog feature flag, which refreshes about every five minutes without a restart.
 
-Debug → Feature Flags is a new window listing every flag with the value the app is actually gating code on, next to the PostHog distinct ID of this install with a copy button, so a rollout can be pointed at one machine.
+Debug → Feature Flags is a new window listing every flag with the value the app is actually gating code on, next to the PostHog distinct ID a rollout can be pointed at — the id PostHog really evaluates this install as, shared by the desktop window and any attached browser, with a copy button and a warning if the two ever disagree. Alongside it, saving a global setting no longer erases values the host owns rather than the settings screen.

--- a/decisions/2026/08/08/first-posthog-feature-flag.md
+++ b/decisions/2026/08/08/first-posthog-feature-flag.md
@@ -68,23 +68,54 @@ renderer and keeps it in *that renderer's* `localStorage`, so the desktop window
 and a remote browser were two persons of the same machine — a percentage rollout
 would bucket them independently and half-enable the install. Now:
 
-- The remote HTML shell carries `window.__DEV3_DISTINCT_ID__`, injected next to
-  the existing theme bootstrap (`injectInitialThemeBootstrap`). posthog-js reads
-  it at init as `bootstrap.distinctID` with `isIdentifiedID: false`, which is
-  synchronous — an RPC round trip would land after init.
-- `bootstrap.distinctID` applies only when a renderer has no persisted identity,
-  which is exactly the desired precedence: the desktop renderer keeps the id it
-  already had, and bun *seeds itself from that same id* on first run
-  (`resolveAnalyticsDistinctId({ seed })`). An existing install therefore keeps
-  its person instead of splitting into a second one.
+- Both renderers get the id from one place, `distinctIdBootstrapScript()`: the
+  desktop window as a webview **preload** (Electrobun runs inline JS after HTML
+  parsing, before page scripts — `createAppWindow({ preload })`), a remote browser
+  as a `<script>` tag next to the existing theme bootstrap
+  (`injectInitialThemeBootstrap`). posthog-js reads `window.__DEV3_DISTINCT_ID__`
+  at init as `bootstrap.distinctID` with `isIdentifiedID: false`, which has to be
+  synchronous — an RPC round trip lands after init.
+- **The first version injected into the served HTML only**, so the desktop window
+  never received it and evaluated flags under its own posthog-js id while the
+  Debug window displayed bun's. Targeting the displayed id matched nobody, at any
+  rollout percentage. Two further defects hid behind it: `loadSettingsSync` was a
+  hand-kept twin of `loadSettings` that never read `analyticsDistinctId` (so even
+  the browser injection was always empty), and `saveGlobalSettings` wrote the
+  renderer's whole snapshot, erasing an id minted after that snapshot was taken —
+  the install got a new id on every launch. Fixes: one `normalizeSettings()` for
+  both readers, and `saveGlobalSettings` preserves host-owned fields over the
+  payload.
+- **The Debug window shows the id PostHog evaluates as**, read from the renderer
+  (`evaluatingDistinctId()`), and prints the host's stored id next to it when the
+  two disagree. The displayed id is now the one a rollout must target by
+  construction, and a broken handover is visible instead of silent.
+- `bootstrap.distinctID` applies only when a renderer has no persisted identity.
+  For a fresh browser that is exactly right — it adopts the install's id. For a
+  browser that already has an identity of its own (a dev machine that opened the
+  app before) it is not: that renderer keeps evaluating as itself. So **the desktop
+  renderer is authoritative** — `resolveAnalyticsDistinctId({ seed, authoritative })`
+  overwrites the stored id when the desktop window reports a different one, while a
+  browser only ever seeds an empty slot. Without that rule one stale browser could
+  pin the install to an id the desktop window never evaluates as, and the flag
+  would be targeted at nobody. An existing install still keeps its person: the
+  desktop renderer's own posthog-js id is what gets stored.
+- **A build with no `VITE_POSTHOG_KEY` evaluates nothing at all.** `.env` lives in
+  the repo root and is git-ignored, so a task worktree does not have it and its
+  `bun run dev` renderer gets the no-op client: every flag reads as its shipped
+  default, `onFeatureFlags` never fires, and nothing is ever pushed or logged. The
+  Debug window says so outright instead of showing an empty id row. Copy `.env`
+  from the main checkout into the worktree before testing flag behaviour there.
 - No `identify()` call. It would guarantee unification but converts an anonymous
   person into an identified one, changing person semantics and billing for the
   sake of flags. Seeding achieves the same id with none of that.
 
-**Only the Electrobun renderer refreshes flags** (`initFeatureFlags` returns
-early otherwise). Not for identity any more — that is shared — but for cost: one
-poller per install regardless of how many browsers are attached, and no
-last-writer-wins race between renderers pushing into bun.
+**Only the Electrobun renderer polls** (`initFeatureFlags` returns early before
+setting the interval). Not for identity any more — that is shared — but for cost:
+one poller per install regardless of how many browsers are attached. Every
+renderer *pushes* what it evaluated, though: a browser that pushed nothing left
+bun on shipped defaults and made the Debug window's Refresh button a no-op with no
+log line, which is exactly how the broken handover went unnoticed. Since all
+renderers now evaluate as one person, their pushes agree.
 
 **Defaults, every gap named:**
 
@@ -94,7 +125,8 @@ last-writer-wins race between renderers pushing into bun.
 | PostHog unreachable | last known value; posthog-js serves its own cache, the renderer keeps pushing it |
 | No PostHog key configured | flags off — the no-op client reports every flag unset |
 | Renderer not up yet | flags off |
-| bun has no stored distinct id yet | the HTML shell omits `__DEV3_DISTINCT_ID__`; that renderer falls back to its own posthog-js id and offers it as the seed |
+| bun has no stored distinct id yet | preload and HTML shell both omit `__DEV3_DISTINCT_ID__`; that renderer falls back to its own posthog-js id and offers it as the seed |
+| The webview drops the preload (platform difference, future Electrobun change) | that renderer keeps its own id; the Debug window shows the disagreement instead of a misleading id |
 | Renderer timers throttled (window hidden or minimized) | last known value, held indefinitely |
 | Key absent from a push payload | last known value — only an explicit `false` turns a flag off |
 
@@ -159,6 +191,13 @@ killed instead, the same deletion runs with the branches swapped.
 - **Letting each renderer keep its own posthog-js id.** What shipped first, and
   wrong: two ids for one machine, so a percentage rollout could enable the
   desktop window and not the browser. Caught by the user before release.
+- **Handing the desktop renderer the id over RPC after boot.** Too late by
+  construction: posthog-js fixes its identity at `init`, which runs at module
+  import. A preload is the only pre-init channel a bundled renderer has.
+- **Showing only bun's stored id in the Debug window.** What shipped first. It
+  reads as authoritative while being the one id nothing evaluates against, so a
+  broken handover looks like a PostHog misconfiguration and costs a debugging
+  session (it did).
 - **`identify(installId)`.** Unifies unconditionally, but creates an identified
   person for a machine, not a user.
 - **Backpressure measured only on `session.clients`.** Simplest, and inert over the

--- a/decisions/2026/08/08/first-posthog-feature-flag.md
+++ b/decisions/2026/08/08/first-posthog-feature-flag.md
@@ -62,14 +62,29 @@ cloudflared's HTTP/2 stream window stops draining. Backpressure measured only on
   injected through `StartOptions` like `getPtyPort`. Without it the backpressure
   half of the flag would measure nothing but loopback.
 
-**Only the Electrobun renderer pushes flags** (`initFeatureFlags` returns early
-otherwise). It is the one renderer that exists exactly once per install, so a
-machine acts on flags evaluated under a single distinct id. A remote browser has
-its own anonymous `localStorage` id and would bucket differently on a percentage
-rollout, giving one machine two answers and a last-writer-wins race in bun. This
-also keeps flag-request cost at one poller per install regardless of how many
-browsers are attached. No `identify()` call was added — that would change person
-semantics and billing for the sake of flags.
+**bun owns one distinct id per install** (`src/bun/analytics-identity.ts`, stored
+as `GlobalSettings.analyticsDistinctId`). posthog-js mints an anonymous id per
+renderer and keeps it in *that renderer's* `localStorage`, so the desktop window
+and a remote browser were two persons of the same machine — a percentage rollout
+would bucket them independently and half-enable the install. Now:
+
+- The remote HTML shell carries `window.__DEV3_DISTINCT_ID__`, injected next to
+  the existing theme bootstrap (`injectInitialThemeBootstrap`). posthog-js reads
+  it at init as `bootstrap.distinctID` with `isIdentifiedID: false`, which is
+  synchronous — an RPC round trip would land after init.
+- `bootstrap.distinctID` applies only when a renderer has no persisted identity,
+  which is exactly the desired precedence: the desktop renderer keeps the id it
+  already had, and bun *seeds itself from that same id* on first run
+  (`resolveAnalyticsDistinctId({ seed })`). An existing install therefore keeps
+  its person instead of splitting into a second one.
+- No `identify()` call. It would guarantee unification but converts an anonymous
+  person into an identified one, changing person semantics and billing for the
+  sake of flags. Seeding achieves the same id with none of that.
+
+**Only the Electrobun renderer refreshes flags** (`initFeatureFlags` returns
+early otherwise). Not for identity any more — that is shared — but for cost: one
+poller per install regardless of how many browsers are attached, and no
+last-writer-wins race between renderers pushing into bun.
 
 **Defaults, every gap named:**
 
@@ -79,6 +94,7 @@ semantics and billing for the sake of flags.
 | PostHog unreachable | last known value; posthog-js serves its own cache, the renderer keeps pushing it |
 | No PostHog key configured | flags off — the no-op client reports every flag unset |
 | Renderer not up yet | flags off |
+| bun has no stored distinct id yet | the HTML shell omits `__DEV3_DISTINCT_ID__`; that renderer falls back to its own posthog-js id and offers it as the seed |
 | Renderer timers throttled (window hidden or minimized) | last known value, held indefinitely |
 | Key absent from a push payload | last known value — only an explicit `false` turns a flag off |
 
@@ -140,6 +156,11 @@ killed instead, the same deletion runs with the branches swapped.
 - **Our own SSE/WebSocket channel** feeding `updateFlags()` with
   `advanced_disable_feature_flags: true`. The only shape that would be genuinely
   push-based, and it needs a backend dev3 does not have. Rejected, not overlooked.
+- **Letting each renderer keep its own posthog-js id.** What shipped first, and
+  wrong: two ids for one machine, so a percentage rollout could enable the
+  desktop window and not the browser. Caught by the user before release.
+- **`identify(installId)`.** Unifies unconditionally, but creates an identified
+  person for a machine, not a user.
 - **Backpressure measured only on `session.clients`.** Simplest, and inert over the
   tunnel — see Investigation.
 - **Dropping frames under pressure.** Forbidden: the ANSI stream is stateful.

--- a/decisions/2026/08/08/first-posthog-feature-flag.md
+++ b/decisions/2026/08/08/first-posthog-feature-flag.md
@@ -1,0 +1,146 @@
+# The project's first PostHog feature flag, and the pattern every later one follows
+
+## Context
+
+Two remote-terminal latency fixes needed a rollout switch (seq 1470, investigation
+in seq 1468): a leading-edge flush in `enqueuePtyData` and backpressure on the
+broadcast, both in `src/bun/pty-server.ts`. The repo had no feature-flag
+infrastructure at all — `posthog-js` was initialized in the renderer for `capture`
+only, `posthog-node` was not installed, and there were zero references to
+`getFeatureFlag` / `onFeatureFlags` anywhere in `src/`.
+
+Both fixes live in the bun process; PostHog lived only in the renderer behind
+`VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST`, which do not exist in bun.
+
+## Investigation
+
+**Local evaluation is banned for this app.** PostHog's local evaluation requires a
+personal API key inside the SDK. dev3 is a desktop app installed on users'
+machines, so shipping one would hand every user account-level access to our
+PostHog project. Nobody may "optimize" into it later; the 600/min limit and the
+10-flag-requests-per-definitions-fetch billing in PostHog's docs describe a server
+deployment we do not have.
+
+**There is no instant kill switch, and no engineering on our side creates one.**
+PostHog has no push or subscription channel for flags: request #25820 (SSE/websocket
+flag subscriptions) was closed, and #28517 "Real-time feature flags" sits unassigned
+in their backlog with PostHog stating flags do not propagate immediately. Their own
+position is that flags are for persistent changes, not instantaneous logic switches.
+The polling interval therefore *is* the worst-case propagation delay.
+
+**Cost of remote evaluation** at a 5-minute cadence: 12 requests/hour, ~288/day,
+~8 600/month per install (derived). At 30 seconds that becomes ~86 000/month per
+install — 10x the cost for a delay that is still not instant.
+
+**Where backpressure is actually visible.** Every socket in `session.clients` is
+loopback: the desktop renderer connects to the PTY server on localhost, and in
+remote mode so does the proxy in `remote-access-server.ts`. The proxy's upstream
+`WebSocket` client reads without flow control, so the loopback hop never shows a
+backlog however slow the viewer is. The only socket in the chain that faces the
+tunnel is the proxy's browser-facing `clientWs`, whose buffer grows once
+cloudflared's HTTP/2 stream window stops draining. Backpressure measured only on
+`session.clients` would have been inert in exactly the scenario it was written for.
+
+## Decision
+
+**Shape: renderer evaluates, bun caches** (shape (a) of the two considered).
+
+- `src/shared/feature-flags.ts` — flag keys, defaults, and `FEATURE_FLAG_REFRESH_MS`
+  (5 minutes). The cadence is one named constant; tune it there, never at a call site.
+- `src/mainview/feature-flags.ts` — `initFeatureFlags()`, called from `main.tsx`.
+  Subscribes to `posthog.onFeatureFlags` (fires after every successful load,
+  including the first) and re-asks via `posthog.reloadFeatureFlags()` on a
+  5-minute timer. `src/mainview/posthog.ts` now exposes the flag APIs next to
+  `capture`.
+- `src/bun/feature-flags.ts` — `isFeatureEnabled(key)`, a synchronous `Map` read,
+  fed by the `setFeatureFlags` RPC. The bun process never talks to PostHog.
+- `src/bun/pty-server.ts` reads the flag per chunk in `enqueuePtyData`; no await,
+  no network call, no lookup beyond the `Map` get.
+- `src/bun/pty-backpressure.ts` — the pure window math, plus `isBackedUp`.
+- `registerBackpressureProbe(sessionKey, probe)` in `pty-server.ts`, registered by
+  `proxyToPty` in `remote-access-server.ts` for the tunnel-facing socket and
+  injected through `StartOptions` like `getPtyPort`. Without it the backpressure
+  half of the flag would measure nothing but loopback.
+
+**Only the Electrobun renderer pushes flags** (`initFeatureFlags` returns early
+otherwise). It is the one renderer that exists exactly once per install, so a
+machine acts on flags evaluated under a single distinct id. A remote browser has
+its own anonymous `localStorage` id and would bucket differently on a percentage
+rollout, giving one machine two answers and a last-writer-wins race in bun. This
+also keeps flag-request cost at one poller per install regardless of how many
+browsers are attached. No `identify()` call was added — that would change person
+semantics and billing for the sake of flags.
+
+**Defaults, every gap named:**
+
+| Situation | Value bun serves |
+|---|---|
+| Before the first successful fetch | `FEATURE_FLAG_DEFAULTS` — every flag off |
+| PostHog unreachable | last known value; posthog-js serves its own cache, the renderer keeps pushing it |
+| No PostHog key configured | flags off — the no-op client reports every flag unset |
+| Renderer not up yet | flags off |
+| Renderer timers throttled (window hidden or minimized) | last known value, held indefinitely |
+| Key absent from a push payload | last known value — only an explicit `false` turns a flag off |
+
+Off means "the behaviour the app already shipped", so an install that never reaches
+PostHog behaves exactly as it did before this change.
+
+`reloadFeatureFlags()` is deliberately fire-and-forget: it is neither awaitable nor
+reactive, and the cached value keeps being served while a refetch is in flight.
+Holding the last known value across an outage is the behaviour we want, stated
+here so it is not mistaken for an oversight.
+
+**One flag covers both fixes.** Splitting them would let an install get the
+leading-edge flush without backpressure — the worst combination, since faster
+flushing raises message rate on an unthrottled socket.
+
+**Mid-session flips are safe for these two fixes specifically.** Both change only
+*when* bytes are sent, never the bytes or the wire format, so a live PTY session
+crosses a flag change without corrupting the screen. This is a property of these
+two changes, not a general guarantee — the next flag must argue its own case.
+
+**Nothing is ever dropped.** The ANSI stream is stateful, so a discarded chunk
+corrupts the screen. Under backpressure output waits in `session.pendingData` and
+is coalesced; the window widens to at most 250 ms.
+
+**Removal plan.** `AGENTS.md` forbids deprecation, and this flag is a deliberate
+temporary exception. End state: once the flag has held at 100% for one release
+cycle with no latency or backlog reports, delete the `remoteTerminalLatency` entry
+from `FEATURE_FLAGS`/`FEATURE_FLAG_DEFAULTS` and the `isFeatureEnabled` branch in
+`enqueuePtyData`, leaving the leading-edge + backpressure path as the only path,
+and archive the flag in PostHog. The plumbing (`shared/bun/mainview` feature-flags
+modules and the RPC method) stays — it is the reusable pattern. If the flag is
+killed instead, the same deletion runs with the branches swapped.
+
+## Risks
+
+- **Up to 5 minutes to kill.** Accepted; PostHog offers nothing faster, and
+  shortening the interval multiplies cost per install without buying "instant".
+- **`pendingData` is unbounded** while a window is widened. Bounded in practice by
+  output rate over at most 250 ms, and the alternative (dropping frames) corrupts
+  the screen.
+- **The tunnel-facing buffered amount is a proxy for real link congestion**, not a
+  measurement of it. It depends on cloudflared propagating HTTP/2 flow control to
+  its local TCP read. Verified by reading, not instrumented — there is no terminal
+  round-trip instrumentation anywhere in the codebase, so the end-user signal for
+  this change is "it feels faster", stated plainly.
+- **Property changes auto-trigger a flag reload in posthog-js.** Audited: no code
+  path sets person or group properties on a timer or per action, so nothing
+  multiplies the 5-minute poll today. A future `setPersonProperties` on a hot path
+  would silently do so.
+
+## Alternatives considered
+
+- **`posthog-node` polling from bun** (shape (b)). Self-contained, but needs the
+  project key plumbed into the bun process — no mechanism exists
+  (`src/shared/electrobun-build-env.ts` is about build archives, not env
+  injection) — and introduces a second distinct id, so a percentage rollout could
+  half-enable one machine.
+- **Local evaluation.** Rejected outright: a personal API key in a desktop app.
+- **Our own SSE/WebSocket channel** feeding `updateFlags()` with
+  `advanced_disable_feature_flags: true`. The only shape that would be genuinely
+  push-based, and it needs a backend dev3 does not have. Rejected, not overlooked.
+- **Backpressure measured only on `session.clients`.** Simplest, and inert over the
+  tunnel — see Investigation.
+- **Dropping frames under pressure.** Forbidden: the ANSI stream is stateful.
+- **Two flags, one per fix.** Rejected — see the one-flag reasoning above.

--- a/src/bun/__tests__/analytics-identity.test.ts
+++ b/src/bun/__tests__/analytics-identity.test.ts
@@ -13,7 +13,7 @@ vi.mock("../settings", () => ({
 	saveSettings: vi.fn(async (next: Record<string, unknown>) => { store.settings = { ...next }; }),
 }));
 
-import { analyticsDistinctIdSync, resolveAnalyticsDistinctId } from "../analytics-identity";
+import { analyticsDistinctIdSync, distinctIdBootstrapScript, resolveAnalyticsDistinctId } from "../analytics-identity";
 
 beforeEach(() => {
 	store.settings = {};
@@ -43,6 +43,28 @@ describe("analytics distinct id", () => {
 		expect(second).toBe(first);
 	});
 
+	// bootstrap.distinctID loses to a renderer that already has its own identity, so
+	// a browser with history keeps evaluating as itself. If it also owned the stored
+	// id, the desktop window would be targeted at an id it never evaluates as.
+	it("lets the desktop renderer take the identity back from a browser", async () => {
+		await resolveAnalyticsDistinctId("browser-with-history", { authoritative: false });
+		const id = await resolveAnalyticsDistinctId("desktop-id", { authoritative: true });
+		expect(id).toBe("desktop-id");
+		expect(store.settings.analyticsDistinctId).toBe("desktop-id");
+	});
+
+	it("keeps the stored id when the authoritative renderer reports the same one", async () => {
+		await resolveAnalyticsDistinctId("desktop-id", { authoritative: true });
+		const id = await resolveAnalyticsDistinctId("desktop-id", { authoritative: true });
+		expect(id).toBe("desktop-id");
+	});
+
+	it("ignores an authoritative caller with no id of its own, rather than minting a second", async () => {
+		await resolveAnalyticsDistinctId("existing-id");
+		const id = await resolveAnalyticsDistinctId(undefined, { authoritative: true });
+		expect(id).toBe("existing-id");
+	});
+
 	it("reads without minting, so rendering the HTML shell cannot create an id", () => {
 		expect(analyticsDistinctIdSync()).toBeNull();
 		expect(store.settings.analyticsDistinctId).toBeUndefined();
@@ -51,5 +73,21 @@ describe("analytics distinct id", () => {
 	it("exposes the stored id to the HTML shell once it exists", async () => {
 		await resolveAnalyticsDistinctId("desktop-id");
 		expect(analyticsDistinctIdSync()).toBe("desktop-id");
+	});
+});
+
+describe("renderer bootstrap script", () => {
+	it("hands the id over as one global assignment", async () => {
+		await resolveAnalyticsDistinctId("desktop-id");
+		expect(distinctIdBootstrapScript()).toBe('window.__DEV3_DISTINCT_ID__="desktop-id";');
+	});
+
+	it("stays empty before an id exists, so the renderer falls back to its own", () => {
+		expect(distinctIdBootstrapScript()).toBe("");
+	});
+
+	it("escapes the value instead of concatenating it into the script", async () => {
+		await resolveAnalyticsDistinctId('id";alert(1);//');
+		expect(distinctIdBootstrapScript()).toBe('window.__DEV3_DISTINCT_ID__="id\\";alert(1);//";');
 	});
 });

--- a/src/bun/__tests__/analytics-identity.test.ts
+++ b/src/bun/__tests__/analytics-identity.test.ts
@@ -1,0 +1,55 @@
+/**
+ * One distinct id per install (seq 1470). posthog-js mints an id per renderer, so
+ * without this the desktop window and a remote browser are two persons of the
+ * same machine and a percentage rollout can half-enable it.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { store } = vi.hoisted(() => ({ store: { settings: {} as Record<string, unknown> } }));
+
+vi.mock("../settings", () => ({
+	loadSettings: vi.fn(async () => ({ ...store.settings })),
+	loadSettingsSync: vi.fn(() => ({ ...store.settings })),
+	saveSettings: vi.fn(async (next: Record<string, unknown>) => { store.settings = { ...next }; }),
+}));
+
+import { analyticsDistinctIdSync, resolveAnalyticsDistinctId } from "../analytics-identity";
+
+beforeEach(() => {
+	store.settings = {};
+	vi.clearAllMocks();
+});
+
+describe("analytics distinct id", () => {
+	it("adopts the seed the first renderer offers, so an existing person survives", async () => {
+		const id = await resolveAnalyticsDistinctId("existing-posthog-id");
+		expect(id).toBe("existing-posthog-id");
+		expect(store.settings.analyticsDistinctId).toBe("existing-posthog-id");
+	});
+
+	it("mints one when no renderer has an id to offer", async () => {
+		const id = await resolveAnalyticsDistinctId(undefined);
+		expect(id).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it("ignores a blank seed rather than storing an empty id", async () => {
+		const id = await resolveAnalyticsDistinctId("   ");
+		expect(id).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it("hands every later caller the same id, whatever seed they bring", async () => {
+		const first = await resolveAnalyticsDistinctId("desktop-id");
+		const second = await resolveAnalyticsDistinctId("browser-id");
+		expect(second).toBe(first);
+	});
+
+	it("reads without minting, so rendering the HTML shell cannot create an id", () => {
+		expect(analyticsDistinctIdSync()).toBeNull();
+		expect(store.settings.analyticsDistinctId).toBeUndefined();
+	});
+
+	it("exposes the stored id to the HTML shell once it exists", async () => {
+		await resolveAnalyticsDistinctId("desktop-id");
+		expect(analyticsDistinctIdSync()).toBe("desktop-id");
+	});
+});

--- a/src/bun/__tests__/feature-flags.test.ts
+++ b/src/bun/__tests__/feature-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { isFeatureEnabled, setFeatureFlags, _resetFeatureFlagsForTests } from "../feature-flags";
+import { getAllFeatureFlags, isFeatureEnabled, setFeatureFlags, _resetFeatureFlagsForTests } from "../feature-flags";
 import { FEATURE_FLAGS, FEATURE_FLAG_DEFAULTS, FEATURE_FLAG_REFRESH_MS } from "../../shared/feature-flags";
 
 const FLAG = FEATURE_FLAGS.remoteTerminalLatency;
@@ -38,6 +38,12 @@ describe("bun feature-flag cache", () => {
 	it("ignores keys the app does not declare", () => {
 		setFeatureFlags({ "some-other-flag": true });
 		expect(isFeatureEnabled(FLAG)).toBe(false);
+	});
+
+	it("reports every declared flag, not only the ones pushed so far", () => {
+		expect(getAllFeatureFlags()).toEqual({ [FLAG]: false });
+		setFeatureFlags({ [FLAG]: true });
+		expect(getAllFeatureFlags()).toEqual({ [FLAG]: true });
 	});
 
 	it("refreshes every 5 minutes — the accepted worst-case propagation delay", () => {

--- a/src/bun/__tests__/feature-flags.test.ts
+++ b/src/bun/__tests__/feature-flags.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { isFeatureEnabled, setFeatureFlags, _resetFeatureFlagsForTests } from "../feature-flags";
+import { FEATURE_FLAGS, FEATURE_FLAG_DEFAULTS, FEATURE_FLAG_REFRESH_MS } from "../../shared/feature-flags";
+
+const FLAG = FEATURE_FLAGS.remoteTerminalLatency;
+
+beforeEach(() => {
+	_resetFeatureFlagsForTests();
+});
+
+describe("bun feature-flag cache", () => {
+	it("serves the shipped default before the renderer has pushed anything", () => {
+		expect(isFeatureEnabled(FLAG)).toBe(FEATURE_FLAG_DEFAULTS[FLAG]);
+		expect(FEATURE_FLAG_DEFAULTS[FLAG]).toBe(false);
+	});
+
+	it("takes the pushed value in both directions", () => {
+		setFeatureFlags({ [FLAG]: true });
+		expect(isFeatureEnabled(FLAG)).toBe(true);
+		setFeatureFlags({ [FLAG]: false });
+		expect(isFeatureEnabled(FLAG)).toBe(false);
+	});
+
+	it("holds the last known value when a key is missing from the push", () => {
+		setFeatureFlags({ [FLAG]: true });
+		setFeatureFlags({});
+		expect(isFeatureEnabled(FLAG)).toBe(true);
+	});
+
+	it("ignores non-boolean values rather than coercing them", () => {
+		setFeatureFlags({ [FLAG]: true });
+		setFeatureFlags({ [FLAG]: undefined as unknown as boolean });
+		expect(isFeatureEnabled(FLAG)).toBe(true);
+		setFeatureFlags({ [FLAG]: "false" as unknown as boolean });
+		expect(isFeatureEnabled(FLAG)).toBe(true);
+	});
+
+	it("ignores keys the app does not declare", () => {
+		setFeatureFlags({ "some-other-flag": true });
+		expect(isFeatureEnabled(FLAG)).toBe(false);
+	});
+
+	it("refreshes every 5 minutes — the accepted worst-case propagation delay", () => {
+		expect(FEATURE_FLAG_REFRESH_MS).toBe(5 * 60 * 1000);
+	});
+});

--- a/src/bun/__tests__/pty-backpressure.test.ts
+++ b/src/bun/__tests__/pty-backpressure.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+	batchWindowMs,
+	isBackedUp,
+	PTY_BACKPRESSURE_HIGH_WATER_BYTES,
+	PTY_BACKPRESSURE_LOW_WATER_BYTES,
+	PTY_BATCH_INTERVAL_MAX_MS,
+} from "../pty-backpressure";
+
+const BASE = 16;
+
+describe("batchWindowMs", () => {
+	it("keeps the normal cadence while the socket is draining", () => {
+		expect(batchWindowMs(0, BASE)).toBe(BASE);
+		expect(batchWindowMs(PTY_BACKPRESSURE_LOW_WATER_BYTES - 1, BASE)).toBe(BASE);
+	});
+
+	it("caps at the maximum window once the socket is saturated", () => {
+		expect(batchWindowMs(PTY_BACKPRESSURE_HIGH_WATER_BYTES, BASE)).toBe(PTY_BATCH_INTERVAL_MAX_MS);
+		expect(batchWindowMs(PTY_BACKPRESSURE_HIGH_WATER_BYTES * 10, BASE)).toBe(PTY_BATCH_INTERVAL_MAX_MS);
+	});
+
+	it("interpolates between the water marks", () => {
+		const mid = (PTY_BACKPRESSURE_LOW_WATER_BYTES + PTY_BACKPRESSURE_HIGH_WATER_BYTES) / 2;
+		const window = batchWindowMs(mid, BASE);
+		expect(window).toBeGreaterThan(BASE);
+		expect(window).toBeLessThan(PTY_BATCH_INTERVAL_MAX_MS);
+		expect(window).toBe(Math.round(BASE + (PTY_BATCH_INTERVAL_MAX_MS - BASE) / 2));
+	});
+
+	it("never shrinks below the base window as pressure grows", () => {
+		let previous = 0;
+		for (let bytes = 0; bytes <= PTY_BACKPRESSURE_HIGH_WATER_BYTES; bytes += 32 * 1024) {
+			const window = batchWindowMs(bytes, BASE);
+			expect(window).toBeGreaterThanOrEqual(previous);
+			previous = window;
+		}
+	});
+});
+
+describe("isBackedUp", () => {
+	it("is false below the low water mark and true at or above it", () => {
+		expect(isBackedUp(0)).toBe(false);
+		expect(isBackedUp(PTY_BACKPRESSURE_LOW_WATER_BYTES - 1)).toBe(false);
+		expect(isBackedUp(PTY_BACKPRESSURE_LOW_WATER_BYTES)).toBe(true);
+	});
+});

--- a/src/bun/__tests__/pty-output-batching.test.ts
+++ b/src/bun/__tests__/pty-output-batching.test.ts
@@ -1,0 +1,288 @@
+/**
+ * PTY output batching: leading-edge flush and broadcast backpressure (seq 1470).
+ *
+ * Both live behind FEATURE_FLAGS.remoteTerminalLatency, so every behaviour is
+ * asserted on BOTH branches — a flagged change covered on one branch is untested.
+ * The tests drive the server's real WebSocket handlers with a fake client, the
+ * same channel remote mode proxies to a browser.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		accessSync: vi.fn(),
+		existsSync: vi.fn(() => true),
+		writeFileSync: vi.fn(),
+		mkdirSync: vi.fn(),
+		lstatSync: vi.fn(() => { throw new Error("ENOENT"); }),
+		statSync: vi.fn(() => ({ isFile: () => true })),
+		readlinkSync: vi.fn(() => { throw new Error("EINVAL"); }),
+		realpathSync: vi.fn((p: string) => p),
+		unlinkSync: vi.fn(),
+		symlinkSync: vi.fn(),
+	};
+});
+
+vi.mock("../spawn", () => ({ spawn: vi.fn(), spawnSync: vi.fn() }));
+
+import { spawn, spawnSync } from "../spawn";
+import { FEATURE_FLAGS } from "../../shared/feature-flags";
+import { setFeatureFlags, _resetFeatureFlagsForTests } from "../feature-flags";
+import {
+	PTY_BACKPRESSURE_HIGH_WATER_BYTES,
+	PTY_BACKPRESSURE_LOW_WATER_BYTES,
+	PTY_BATCH_INTERVAL_MAX_MS,
+} from "../pty-backpressure";
+
+// The PTY server's WebSocket handlers are part of the unit under test; intercept
+// the config `Bun.serve` is handed at module load.
+interface WsHandlers {
+	open(ws: unknown): void;
+	close(ws: unknown): void;
+}
+let wsHandlers: WsHandlers;
+const bun = globalThis as unknown as { Bun: { serve: (config: unknown) => unknown } };
+const stubServe = bun.Bun.serve;
+bun.Bun.serve = (config: unknown) => {
+	const websocket = (config as { websocket?: WsHandlers }).websocket;
+	if (websocket) wsHandlers = websocket;
+	return stubServe(config);
+};
+
+const pty = await import("../pty-server");
+const { createSession, destroySession, hasSession, registerBackpressureProbe } = pty;
+
+const FLAG = FEATURE_FLAGS.remoteTerminalLatency;
+const BATCH_MS = 16;
+
+/** A viewer of the session: every frame the server pushed it, in order. */
+class FakeClient {
+	readonly sent: string[] = [];
+	readonly data: { url: URL };
+	/** What this socket claims it still owes the far end. */
+	buffered = 0;
+
+	constructor(sessionId: string) {
+		this.data = { url: new URL(`http://localhost/?session=${sessionId}`) };
+	}
+
+	sendText(text: string): void {
+		this.sent.push(text);
+	}
+
+	getBufferedAmount(): number {
+		return this.buffered;
+	}
+}
+
+const mockSpawn = vi.mocked(spawn);
+const mockSpawnSync = vi.mocked(spawnSync);
+
+let emit: (data: string) => void;
+const activeSessions: string[] = [];
+
+/** A tmux-backed session with one attached viewer, ready to receive output. */
+function startSession(taskId: string): FakeClient {
+	activeSessions.push(taskId);
+	createSession(taskId, "proj-1", "/tmp/cwd", "bash", {});
+	const client = new FakeClient(taskId);
+	wsHandlers.open(client);
+	return client;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.clearAllMocks();
+	_resetFeatureFlagsForTests();
+	mockSpawnSync.mockReturnValue({ exitCode: 0, stdout: new Uint8Array(0) } as never);
+	mockSpawn.mockImplementation(((_cmd: unknown, opts: { terminal?: { data?: unknown } }) => {
+		const onData = opts?.terminal?.data as ((t: unknown, d: string) => void) | undefined;
+		if (onData) emit = (data: string) => onData(null, data);
+		return {
+			pid: 100,
+			terminal: { close: vi.fn(), resize: vi.fn(), write: vi.fn() },
+			kill: vi.fn(),
+			exited: new Promise(() => {}),
+		};
+	}) as never);
+});
+
+afterEach(() => {
+	for (const id of activeSessions) {
+		if (hasSession(id)) destroySession(id);
+	}
+	activeSessions.length = 0;
+	vi.useRealTimers();
+	_resetFeatureFlagsForTests();
+});
+
+describe("leading-edge flush", () => {
+	it("makes an isolated keystroke echo wait the full window when the flag is off", () => {
+		setFeatureFlags({ [FLAG]: false });
+		const client = startSession("task-batch-off-1");
+
+		emit("x");
+		expect(client.sent).toEqual([]);
+
+		vi.advanceTimersByTime(BATCH_MS);
+		expect(client.sent).toEqual(["x"]);
+	});
+
+	it("sends an isolated keystroke echo with no delay when the flag is on", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-batch-on-1");
+
+		emit("x");
+		expect(client.sent).toEqual(["x"]);
+
+		// Nothing left over: the window closes without a second, empty frame.
+		vi.advanceTimersByTime(BATCH_MS * 4);
+		expect(client.sent).toEqual(["x"]);
+	});
+
+	it("still coalesces a burst into one frame per window on both branches", () => {
+		for (const enabled of [false, true]) {
+			_resetFeatureFlagsForTests();
+			setFeatureFlags({ [FLAG]: enabled });
+			const client = startSession(`task-batch-burst-${enabled}`);
+
+			emit("a");
+			emit("b");
+			emit("c");
+			vi.advanceTimersByTime(BATCH_MS);
+
+			// Leading edge sends "a" alone, then "bc"; trailing edge sends "abc".
+			expect(client.sent.join("")).toBe("abc");
+			expect(client.sent.length).toBeLessThanOrEqual(2);
+		}
+	});
+
+	it("loses no bytes and keeps their order across many windows", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-batch-order-1");
+
+		for (let i = 0; i < 50; i++) {
+			emit(`chunk${i}|`);
+			vi.advanceTimersByTime(5);
+		}
+		vi.advanceTimersByTime(PTY_BATCH_INTERVAL_MAX_MS);
+
+		const expected = Array.from({ length: 50 }, (_, i) => `chunk${i}|`).join("");
+		expect(client.sent.join("")).toBe(expected);
+	});
+});
+
+describe("broadcast backpressure", () => {
+	it("keeps blasting into a saturated socket when the flag is off", () => {
+		setFeatureFlags({ [FLAG]: false });
+		const client = startSession("task-bp-off-1");
+		client.buffered = PTY_BACKPRESSURE_HIGH_WATER_BYTES;
+
+		emit("first");
+		vi.advanceTimersByTime(BATCH_MS);
+		expect(client.sent).toEqual(["first"]);
+	});
+
+	it("widens the window instead of sending into a saturated socket", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-bp-on-1");
+		client.buffered = PTY_BACKPRESSURE_HIGH_WATER_BYTES;
+
+		emit("first");
+		// No leading-edge send: the socket cannot absorb it.
+		expect(client.sent).toEqual([]);
+		vi.advanceTimersByTime(BATCH_MS);
+		expect(client.sent).toEqual([]);
+
+		emit("second");
+		vi.advanceTimersByTime(PTY_BATCH_INTERVAL_MAX_MS);
+		// Nothing dropped — the whole stream arrives, just later and coalesced.
+		expect(client.sent.join("")).toBe("firstsecond");
+	});
+
+	it("reads pressure from a registered probe, not only from the local socket", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-bp-probe-1");
+		// The loopback socket looks idle; the tunnel-facing one is saturated.
+		client.buffered = 0;
+		const off = registerBackpressureProbe("task-bp-probe-1", () => PTY_BACKPRESSURE_HIGH_WATER_BYTES);
+
+		emit("under pressure");
+		expect(client.sent).toEqual([]);
+		vi.advanceTimersByTime(PTY_BATCH_INTERVAL_MAX_MS);
+		expect(client.sent).toEqual(["under pressure"]);
+
+		// Unregistered: the fast path is back.
+		off();
+		emit("clear");
+		expect(client.sent).toEqual(["under pressure", "clear"]);
+	});
+
+	it("survives a probe that throws because its owner is gone", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-bp-probe-2");
+		registerBackpressureProbe("task-bp-probe-2", () => { throw new Error("socket closed"); });
+
+		expect(() => emit("still fine")).not.toThrow();
+		expect(client.sent).toEqual(["still fine"]);
+	});
+
+	it("returns to the normal cadence once the socket drains", () => {
+		setFeatureFlags({ [FLAG]: true });
+		const client = startSession("task-bp-drain-1");
+		client.buffered = PTY_BACKPRESSURE_LOW_WATER_BYTES;
+
+		emit("slow");
+		expect(client.sent).toEqual([]);
+		vi.advanceTimersByTime(PTY_BATCH_INTERVAL_MAX_MS);
+		expect(client.sent).toEqual(["slow"]);
+
+		client.buffered = 0;
+		emit("fast");
+		expect(client.sent).toEqual(["slow", "fast"]);
+	});
+});
+
+describe("mid-session flag flip", () => {
+	it("switches cadence on a live session without losing or reordering output", () => {
+		setFeatureFlags({ [FLAG]: false });
+		const client = startSession("task-flip-1");
+
+		emit("before|");
+		expect(client.sent).toEqual([]);
+		vi.advanceTimersByTime(BATCH_MS);
+		expect(client.sent).toEqual(["before|"]);
+
+		// Flip on mid-stream: the next chunk takes the fast path.
+		setFeatureFlags({ [FLAG]: true });
+		emit("during|");
+		expect(client.sent).toEqual(["before|", "during|"]);
+
+		// Flip back off: the next chunk waits out the window again.
+		setFeatureFlags({ [FLAG]: false });
+		emit("after|");
+		expect(client.sent).toEqual(["before|", "during|"]);
+		vi.advanceTimersByTime(BATCH_MS);
+
+		expect(client.sent.join("")).toBe("before|during|after|");
+	});
+
+	it("flushes data already pending when the flag flips", () => {
+		setFeatureFlags({ [FLAG]: false });
+		const client = startSession("task-flip-2");
+
+		emit("queued|");
+		setFeatureFlags({ [FLAG]: true });
+		// The open window still owns the pending bytes; the flip does not strand them.
+		emit("next|");
+		vi.advanceTimersByTime(BATCH_MS);
+
+		expect(client.sent.join("")).toBe("queued|next|");
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1790,6 +1790,22 @@ describe("handlers.saveGlobalSettings", () => {
 		expect(push).toHaveBeenCalledWith("globalSettingsUpdated", settings);
 	});
 
+	// The renderer sends a whole snapshot taken when it loaded, and the analytics id
+	// is minted by the host afterwards — trusting the payload erased it, so the
+	// install got a fresh id (and lost its flag targeting) on every launch.
+	it("keeps the stored analytics id when the renderer's snapshot predates it", async () => {
+		vi.mocked(loadSettings).mockResolvedValue({
+			updateChannel: "stable",
+			analyticsDistinctId: "id-minted-after-the-snapshot",
+		} as GlobalSettings);
+
+		await handlers.saveGlobalSettings({ updateChannel: "beta" } as unknown as GlobalSettings);
+
+		expect(saveSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ updateChannel: "beta", analyticsDistinctId: "id-minted-after-the-snapshot" }),
+		);
+	});
+
 	it("does not release Focus Mode when an optional patch omits it", async () => {
 		_resetWatchedNotificationState();
 		setFocusMode(true);

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -200,6 +200,14 @@ describe("saveSettings", () => {
 		for (const key of Object.keys(full) as (keyof GlobalSettings)[]) {
 			expect(loaded[key], `field "${key}" was dropped by loadSettings`).toEqual(full[key]);
 		}
+
+		// Both readers or neither: the sync one used to be a hand-kept twin missing
+		// `analyticsDistinctId`, so the value sat on disk and every synchronous
+		// caller (webview preload, served HTML) got undefined.
+		const loadedSync = loadSettingsSync();
+		for (const key of Object.keys(full) as (keyof GlobalSettings)[]) {
+			expect(loadedSync[key], `field "${key}" was dropped by loadSettingsSync`).toEqual(full[key]);
+		}
 	});
 
 	it("creates the settings directory before writing the file", async () => {

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -163,6 +163,7 @@ describe("saveSettings", () => {
 			updateChannel: "canary",
 			terminalPathOpenMode: "reveal",
 			theme: "light",
+			analyticsDistinctId: "11111111-2222-3333-4444-555555555555",
 			resolvedTheme: "light",
 			cloneBaseDirectory: "/tmp/clones",
 			customBinaryPaths: { git: "/usr/bin/git" },

--- a/src/bun/analytics-identity.ts
+++ b/src/bun/analytics-identity.ts
@@ -1,0 +1,34 @@
+/**
+ * The install-wide PostHog distinct id.
+ *
+ * posthog-js mints an anonymous id per renderer and keeps it in that renderer's
+ * localStorage, so the desktop window and a remote browser end up as two
+ * different persons of the same machine — a percentage rollout would bucket them
+ * independently. bun owns one id instead and hands it to every renderer.
+ *
+ * See decisions/2026/08/08/first-posthog-feature-flag.md.
+ */
+import { randomUUID } from "node:crypto";
+import { loadSettings, loadSettingsSync, saveSettings } from "./settings";
+
+/** Read without minting: callers that only render the HTML shell. */
+export function analyticsDistinctIdSync(): string | null {
+	return loadSettingsSync().analyticsDistinctId ?? null;
+}
+
+/**
+ * Return the stored id, adopting `seed` if there is none yet.
+ *
+ * Seeding matters for existing installs: the desktop renderer already has a
+ * posthog-js id with history behind it, so taking that one over minting a fresh
+ * one keeps the person intact instead of splitting it in two.
+ */
+export async function resolveAnalyticsDistinctId(seed?: string): Promise<string> {
+	const settings = await loadSettings();
+	const stored = settings.analyticsDistinctId;
+	if (stored) return stored;
+
+	const distinctId = seed?.trim() || randomUUID();
+	await saveSettings({ ...settings, analyticsDistinctId: distinctId });
+	return distinctId;
+}

--- a/src/bun/analytics-identity.ts
+++ b/src/bun/analytics-identity.ts
@@ -17,18 +17,45 @@ export function analyticsDistinctIdSync(): string | null {
 }
 
 /**
- * Return the stored id, adopting `seed` if there is none yet.
+ * Inline script handing a renderer the install's id before page scripts run.
+ *
+ * Both renderers need it from the same source: the desktop window gets it as a
+ * webview preload, a remote browser as a tag in the served HTML. Without it
+ * posthog-js mints its own id per renderer, so the id the Debug window showed was
+ * not the one flags were evaluated against — and targeting it did nothing.
+ *
+ * Empty until an id exists (first launch), which lands the renderer on its own
+ * posthog-js id — the very id it then reports back as the seed.
+ */
+export function distinctIdBootstrapScript(): string {
+	const id = analyticsDistinctIdSync();
+	return id ? `window.__DEV3_DISTINCT_ID__=${JSON.stringify(id)};` : "";
+}
+
+/**
+ * Return the stored id, adopting `seed` when there is none yet — or whenever the
+ * caller is authoritative.
  *
  * Seeding matters for existing installs: the desktop renderer already has a
  * posthog-js id with history behind it, so taking that one over minting a fresh
  * one keeps the person intact instead of splitting it in two.
+ *
+ * Only the desktop renderer is authoritative, and it has to be: `bootstrap.distinctID`
+ * loses to a renderer that already has its own persisted identity, so a browser with
+ * history of its own keeps evaluating as itself. Letting whoever asked first own the
+ * install forever meant one such browser could pin the stored id to an identity the
+ * desktop window never evaluates as — flags then get targeted at nobody.
  */
-export async function resolveAnalyticsDistinctId(seed?: string): Promise<string> {
+export async function resolveAnalyticsDistinctId(
+	seed?: string,
+	opts: { authoritative?: boolean } = {},
+): Promise<string> {
 	const settings = await loadSettings();
 	const stored = settings.analyticsDistinctId;
-	if (stored) return stored;
+	const trimmed = seed?.trim();
+	if (stored && !(opts.authoritative && trimmed && trimmed !== stored)) return stored;
 
-	const distinctId = seed?.trim() || randomUUID();
+	const distinctId = trimmed || randomUUID();
 	await saveSettings({ ...settings, analyticsDistinctId: distinctId });
 	return distinctId;
 }

--- a/src/bun/feature-flags.ts
+++ b/src/bun/feature-flags.ts
@@ -27,6 +27,13 @@ export function setFeatureFlags(flags: Record<string, boolean>): void {
 	}
 }
 
+/** Every declared flag with its effective value — what the code actually gates on. */
+export function getAllFeatureFlags(): Record<FeatureFlagKey, boolean> {
+	const out = {} as Record<FeatureFlagKey, boolean>;
+	for (const key of FEATURE_FLAG_KEYS) out[key] = isFeatureEnabled(key);
+	return out;
+}
+
 export function _resetFeatureFlagsForTests(): void {
 	values.clear();
 }

--- a/src/bun/feature-flags.ts
+++ b/src/bun/feature-flags.ts
@@ -1,0 +1,32 @@
+/**
+ * Feature-flag cache for the bun process.
+ *
+ * The bun process never talks to PostHog: the Electrobun renderer evaluates the
+ * flags and pushes them here over RPC (`setFeatureFlags`). Reads are synchronous
+ * and cheap enough for a hot path such as `enqueuePtyData`.
+ */
+import { FEATURE_FLAG_DEFAULTS, FEATURE_FLAG_KEYS, type FeatureFlagKey } from "../shared/feature-flags";
+
+const values = new Map<FeatureFlagKey, boolean>();
+
+/** Cached read. Falls back to the shipped default until a value is pushed. */
+export function isFeatureEnabled(key: FeatureFlagKey): boolean {
+	const cached = values.get(key);
+	return cached === undefined ? FEATURE_FLAG_DEFAULTS[key] : cached;
+}
+
+/**
+ * Merge a pushed batch. A key missing from the payload keeps its last known
+ * value rather than reverting — an unreachable PostHog must not silently flip
+ * behaviour, only an explicit `false` may.
+ */
+export function setFeatureFlags(flags: Record<string, boolean>): void {
+	for (const key of FEATURE_FLAG_KEYS) {
+		const value = flags[key];
+		if (typeof value === "boolean") values.set(key, value);
+	}
+}
+
+export function _resetFeatureFlagsForTests(): void {
+	values.clear();
+}

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -171,7 +171,7 @@ log.info("CLI socket server ready", { path: cliSocketPath });
 }
 
 // ── PTY / port scanner / resource monitor (dynamic import so PATH is patched first) ──
-const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
+const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort, registerBackpressureProbe } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");
 const { startResourceMonitor, stopResourceMonitor } = await import("./resource-monitor");
 const { startRateLimitMonitor, stopRateLimitMonitor } = await import("./rate-limit-monitor");
@@ -219,6 +219,7 @@ await startRemoteAccessServer({
 		return await handler(params);
 	},
 	getPtyPort,
+	registerBackpressureProbe,
 	onQrTokenConsumed: () => {
 		getPushMessage()?.("qrTokenConsumed", {});
 	},

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -299,7 +299,7 @@ log.info("CLI socket server ready", { path: cliSocketPath });
 }
 
 // Side-effect: starts the PTY WebSocket server (dynamic import so PATH is patched first)
-const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort } = await import("./pty-server");
+const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort, registerBackpressureProbe } = await import("./pty-server");
 const { startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");
 const { startResourceMonitor, stopResourceMonitor } = await import("./resource-monitor");
 const { startRateLimitMonitor, stopRateLimitMonitor } = await import("./rate-limit-monitor");
@@ -462,6 +462,7 @@ await startRemoteAccessServer({
 		return await handler(params);
 	},
 	getPtyPort,
+	registerBackpressureProbe,
 	onQrTokenConsumed: () => {
 		getPushMessage()?.("qrTokenConsumed", {});
 	},

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -13,6 +13,7 @@ import {
 	isUpdateAlreadyReady,
 } from "./updater";
 import { loadSettings, loadSettingsSync } from "./settings";
+import { distinctIdBootstrapScript } from "./analytics-identity";
 import { installSignalQuitConfirmation, isQuitConfirmed, markQuitConfirmed, markQuitDialogPending } from "./quit-manager";
 import { initNativeNotifications } from "./native-notifications";
 import { markPendingNotificationNav } from "./notification-nav";
@@ -400,6 +401,9 @@ async function openMainWindow() {
 		title: makeTitle(APP_VERSION, lastBuildTime, buildChannel),
 		url,
 		handlers: handlers as unknown as Record<string, (...args: unknown[]) => unknown>,
+		// One analytics identity per install: hand it over before posthog-js boots,
+		// or the renderer mints its own and flag targeting aims at the wrong id.
+		preload: distinctIdBootstrapScript(),
 		onDomReady: async (win) => {
 			// dom-ready is the readiness contract: it only fires once a webview
 			// actually rendered, so it is the one signal that proves a renderer.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -840,6 +840,8 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 	if (e.data.action === MENU_ACTIONS.hardRefresh) {
 		log.info("Hard refresh — navigating to home page");
 		focused?.webview.loadURL(url);
+	} else if (e.data.action === MENU_ACTIONS.featureFlags) {
+		sendToFocusedWindow("showFeatureFlags", {});
 	} else if (e.data.action === MENU_ACTIONS.about) {
 		// The channel BAKED INTO THE BUNDLE, not the one selected in Settings: About answers
 		// "which build am I running", and those two disagree for as long as a switch is

--- a/src/bun/pty-backpressure.ts
+++ b/src/bun/pty-backpressure.ts
@@ -1,0 +1,37 @@
+/**
+ * How wide the PTY output batch window gets when a viewer's socket is behind.
+ *
+ * Over a Cloudflare tunnel a blind 16 ms broadcast piles frames into the socket
+ * buffer faster than the link drains them, so the terminal animates smoothly but
+ * behind reality. Widening the window throttles the send cadence instead.
+ *
+ * Nothing is ever dropped: the ANSI stream is stateful, so a discarded chunk
+ * corrupts the screen. Output waits in `session.pendingData` and is coalesced.
+ */
+
+/** Below this many buffered bytes the socket is considered idle. */
+export const PTY_BACKPRESSURE_LOW_WATER_BYTES = 64 * 1024;
+/** At or above this, the window is at its maximum. */
+export const PTY_BACKPRESSURE_HIGH_WATER_BYTES = 1024 * 1024;
+/** Widest batch window under full backpressure. */
+export const PTY_BATCH_INTERVAL_MAX_MS = 250;
+
+/**
+ * Interpolate the batch window between the normal cadence and the maximum,
+ * linearly across the low/high water marks.
+ */
+export function batchWindowMs(bufferedBytes: number, baseIntervalMs: number): number {
+	if (bufferedBytes < PTY_BACKPRESSURE_LOW_WATER_BYTES) return baseIntervalMs;
+	if (bufferedBytes >= PTY_BACKPRESSURE_HIGH_WATER_BYTES) return PTY_BATCH_INTERVAL_MAX_MS;
+	const span = PTY_BACKPRESSURE_HIGH_WATER_BYTES - PTY_BACKPRESSURE_LOW_WATER_BYTES;
+	const progress = (bufferedBytes - PTY_BACKPRESSURE_LOW_WATER_BYTES) / span;
+	return Math.round(baseIntervalMs + progress * (PTY_BATCH_INTERVAL_MAX_MS - baseIntervalMs));
+}
+
+/**
+ * A backed-up socket must not also get the leading-edge flush — an immediate
+ * send is exactly what it cannot absorb.
+ */
+export function isBackedUp(bufferedBytes: number): boolean {
+	return bufferedBytes >= PTY_BACKPRESSURE_LOW_WATER_BYTES;
+}

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -27,6 +27,9 @@ import {
 	stopNativeTaskPanes,
 } from "./native-task-panes";
 import { paneSessionKey, parsePaneSessionKey } from "../shared/pane-session-key";
+import { FEATURE_FLAGS } from "../shared/feature-flags";
+import { isFeatureEnabled } from "./feature-flags";
+import { batchWindowMs, isBackedUp } from "./pty-backpressure";
 import { PTY_WS_CLOSE } from "../shared/pty-ws-close-codes";
 import { nativeTaskSessionId, type TerminalLaunchSpec } from "./task-terminal-backend";
 import {
@@ -170,6 +173,30 @@ interface PtySession {
 }
 
 const sessions = new Map<string, PtySession>();
+
+/** Session key → sockets outside this module that carry the session's output. */
+const backpressureProbes = new Map<string, Set<() => number>>();
+
+/**
+ * Report how many bytes a socket this module cannot see still owes a viewer.
+ *
+ * The remote proxy's browser-facing socket is the only one that ever backs up:
+ * every socket in `session.clients` is loopback. Returns an unregister function.
+ */
+export function registerBackpressureProbe(sessionKey: string, probe: () => number): () => void {
+	let probes = backpressureProbes.get(sessionKey);
+	if (!probes) {
+		probes = new Set();
+		backpressureProbes.set(sessionKey, probes);
+	}
+	probes.add(probe);
+	return () => {
+		const current = backpressureProbes.get(sessionKey);
+		if (!current) return;
+		current.delete(probe);
+		if (current.size === 0) backpressureProbes.delete(sessionKey);
+	};
+}
 let onPtyDiedCallback: ((taskId: string) => void) | null = null;
 let onBellCallback: ((taskId: string) => void) | null = null;
 let onIdleCallback: ((taskId: string) => void) | null = null;
@@ -1576,7 +1603,10 @@ function applyClientSizes(session: PtySession): void {
  * exactly where it stopped. tmux sessions send the bare text they always have.
  */
 function flushPendingData(session: PtySession): void {
-	session.batchTimer = null;
+	if (session.batchTimer) {
+		clearTimeout(session.batchTimer);
+		session.batchTimer = null;
+	}
 	if (!session.pendingData) return;
 	if (session.backend !== "native") {
 		if (session.clients.size === 0) return;
@@ -1606,29 +1636,60 @@ function flushPendingData(session: PtySession): void {
  */
 function settleNativeStream(session: PtySession): void {
 	if (session.backend !== "native" || !session.pendingData) return;
-	if (session.batchTimer) {
-		clearTimeout(session.batchTimer);
-		session.batchTimer = null;
-	}
 	flushPendingData(session);
+}
+
+/**
+ * Bytes still queued in the slowest socket that carries this session's output.
+ *
+ * `session.clients` are all loopback sockets (the desktop renderer, or the
+ * remote proxy), so their own buffers stay near zero however slow the viewer is.
+ * The tunnel-facing socket lives in remote-access-server and reports itself
+ * through a probe — see registerBackpressureProbe.
+ */
+function bufferedBytesFor(session: PtySession): number {
+	let worst = 0;
+	for (const client of session.clients) {
+		const buffered = typeof client?.getBufferedAmount === "function" ? Number(client.getBufferedAmount()) : 0;
+		if (Number.isFinite(buffered) && buffered > worst) worst = buffered;
+	}
+	for (const probe of backpressureProbes.get(session.registryKey) ?? []) {
+		try {
+			const buffered = Number(probe());
+			if (Number.isFinite(buffered) && buffered > worst) worst = buffered;
+		} catch { /* probe owner is gone; close() will unregister it */ }
+	}
+	return worst;
 }
 
 /**
  * Enqueue PTY data for batched delivery to the WebSocket.
  * Instead of sending every chunk immediately (which for Claude Code means
  * thousands of tiny WS messages per second), we accumulate data and flush
- * at ~60fps. The first chunk in a batch is sent immediately for latency,
- * subsequent chunks within the batch window are coalesced.
+ * at ~60fps.
+ *
+ * With FEATURE_FLAGS.remoteTerminalLatency on, the chunk that opens a window is
+ * sent immediately (a lone keystroke echo no longer waits out the full window)
+ * and the window widens while a viewer's socket is behind. The flag is read from
+ * a local cache — no await, no lookup beyond a Map get, on a per-chunk path.
  */
 function enqueuePtyData(session: PtySession, data: string): void {
 	session.pendingData += data;
-	if (!session.batchTimer) {
-		// First chunk — schedule flush. If only one chunk arrives within
-		// the interval, the delay is at most PTY_BATCH_INTERVAL_MS (16ms),
-		// which is imperceptible. For bursty output, all intermediate
-		// chunks are coalesced into a single WS message.
+	if (session.batchTimer) return;
+
+	if (!isFeatureEnabled(FEATURE_FLAGS.remoteTerminalLatency)) {
+		// Trailing edge only: one chunk in the window still costs the full 16ms.
 		session.batchTimer = setTimeout(() => flushPendingData(session), PTY_BATCH_INTERVAL_MS);
+		return;
 	}
+
+	const buffered = bufferedBytesFor(session);
+	// A backed-up socket cannot absorb an immediate send; only widen the window.
+	if (!isBackedUp(buffered)) flushPendingData(session);
+	session.batchTimer = setTimeout(
+		() => flushPendingData(session),
+		batchWindowMs(buffered, PTY_BATCH_INTERVAL_MS),
+	);
 }
 
 async function configureTmux(tmuxSessionName: string, socket: string): Promise<void> {

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -24,7 +24,7 @@ import { initSecret, createQrToken, createSessionToken, exchangeQrForSession, re
 import { getTunnelUrl, getTunnelState, tunnelManager } from "./cloudflare-tunnel";
 import { loadSettingsSync } from "./settings";
 import { getCurrentUiTheme } from "./theme-state";
-import { analyticsDistinctIdSync } from "./analytics-identity";
+import { distinctIdBootstrapScript } from "./analytics-identity";
 
 const log = createLogger("remote-access");
 
@@ -330,12 +330,12 @@ function getInitialThemeBootstrap(): { preference: "dark" | "light" | "system"; 
 export function injectInitialThemeBootstrap(html: string): string {
 	const { preference, resolved } = getInitialThemeBootstrap();
 	// The distinct id has to be on the page before posthog-js initializes, which
-	// happens at module import — an RPC round trip would be too late.
-	const distinctId = analyticsDistinctIdSync();
+	// happens at module import — an RPC round trip would be too late. Same script
+	// the desktop window gets as a webview preload, so both are one person.
 	const script =
 		`<script>window.__DEV3_INITIAL_THEME__=${JSON.stringify(preference)};` +
 		`window.__DEV3_INITIAL_RESOLVED_THEME__=${JSON.stringify(resolved)};` +
-		(distinctId ? `window.__DEV3_DISTINCT_ID__=${JSON.stringify(distinctId)};` : "") +
+		distinctIdBootstrapScript() +
 		`</script>`;
 
 	return html.includes("</head>")

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -340,6 +340,7 @@ export function injectInitialThemeBootstrap(html: string): string {
 // ── PTY proxy ───────────────────────────────────────────────────────
 
 let ptyPortGetter: (() => number) | null = null;
+let backpressureProbeRegistrar: StartOptions["registerBackpressureProbe"] | null = null;
 
 /**
  * Proxy a WebSocket connection to the internal PTY server.
@@ -358,6 +359,13 @@ function proxyToPty(clientWs: any, sessionId: string, sinceSeq: number | null): 
 		sinceSeq === null ? "" : `&${NATIVE_STREAM_SINCE_PARAM}=${sinceSeq}`
 	}`;
 	const upstream = new WebSocket(targetUrl);
+
+	// This socket is the only one in the chain that faces the tunnel, so it is the
+	// only one whose backlog means anything. The PTY server widens its batch
+	// window from this number instead of blasting into a full buffer.
+	const unregisterProbe = backpressureProbeRegistrar?.(sessionId, () =>
+		typeof clientWs?.getBufferedAmount === "function" ? clientWs.getBufferedAmount() : 0,
+	);
 
 	upstream.addEventListener("open", () => {
 		log.info("PTY proxy upstream connected", { session: sessionId.slice(0, 8) });
@@ -385,6 +393,7 @@ function proxyToPty(clientWs: any, sessionId: string, sinceSeq: number | null): 
 
 	// Store upstream ref on the client WS for bidirectional forwarding
 	(clientWs as any)._ptyUpstream = upstream;
+	(clientWs as any)._ptyBackpressureProbeOff = unregisterProbe;
 }
 
 /**
@@ -554,6 +563,8 @@ let serverPort = 0;
 interface StartOptions {
 	rpcHandler: RpcRequestHandler;
 	getPtyPort: () => number;
+	/** pty-server's `registerBackpressureProbe`; injected like `getPtyPort`. */
+	registerBackpressureProbe: (sessionKey: string, probe: () => number) => () => void;
 	onQrTokenConsumed?: () => void;
 }
 
@@ -592,6 +603,7 @@ export async function startRemoteAccessServer(options: StartOptions): Promise<vo
 	await initSecret();
 	requestHandler = options.rpcHandler;
 	ptyPortGetter = options.getPtyPort;
+	backpressureProbeRegistrar = options.registerBackpressureProbe;
 	qrConsumedCallback = options.onQrTokenConsumed ?? null;
 
 	const requestedPort = resolveListenPort();
@@ -742,6 +754,7 @@ export async function startRemoteAccessServer(options: StartOptions): Promise<vo
 					rpcClients.delete(ws);
 					log.info("Remote RPC client disconnected", { total: rpcClients.size });
 				} else if (wsData.type === "pty") {
+					((ws as any)._ptyBackpressureProbeOff as (() => void) | undefined)?.();
 					closeUpstreamSocket((ws as any)._ptyUpstream as WebSocket | undefined);
 				} else if (wsData.type === "shared-proxy") {
 					closeUpstreamSocket((ws as any)._proxyUpstream as WebSocket | undefined);

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -24,6 +24,7 @@ import { initSecret, createQrToken, createSessionToken, exchangeQrForSession, re
 import { getTunnelUrl, getTunnelState, tunnelManager } from "./cloudflare-tunnel";
 import { loadSettingsSync } from "./settings";
 import { getCurrentUiTheme } from "./theme-state";
+import { analyticsDistinctIdSync } from "./analytics-identity";
 
 const log = createLogger("remote-access");
 
@@ -328,9 +329,14 @@ function getInitialThemeBootstrap(): { preference: "dark" | "light" | "system"; 
 
 export function injectInitialThemeBootstrap(html: string): string {
 	const { preference, resolved } = getInitialThemeBootstrap();
+	// The distinct id has to be on the page before posthog-js initializes, which
+	// happens at module import — an RPC round trip would be too late.
+	const distinctId = analyticsDistinctIdSync();
 	const script =
 		`<script>window.__DEV3_INITIAL_THEME__=${JSON.stringify(preference)};` +
-		`window.__DEV3_INITIAL_RESOLVED_THEME__=${JSON.stringify(resolved)};</script>`;
+		`window.__DEV3_INITIAL_RESOLVED_THEME__=${JSON.stringify(resolved)};` +
+		(distinctId ? `window.__DEV3_DISTINCT_ID__=${JSON.stringify(distinctId)};` : "") +
+		`</script>`;
 
 	return html.includes("</head>")
 		? html.replace("</head>", `${script}</head>`)

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -17,7 +17,8 @@ import { DEV3_HOME } from "../paths";
 import { isFreshStartMode } from "../fresh-start";
 import { spawn } from "../spawn";
 import { setCurrentUiTheme } from "../theme-state";
-import { setFeatureFlags as cacheFeatureFlags } from "../feature-flags";
+import { getAllFeatureFlags, setFeatureFlags as cacheFeatureFlags } from "../feature-flags";
+import { resolveAnalyticsDistinctId as resolveDistinctId } from "../analytics-identity";
 import { extractConfigFromParams, getPushMessage, getSystemRequirements, log, resolveBinaryPath, setFocusMode } from "./shared";
 import { binaryCandidatesOnPath, hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
 import { isExecutableFile } from "../executable";
@@ -454,9 +455,21 @@ async function setFeatureFlags(params: { flags: Record<string, boolean> }): Prom
 	cacheFeatureFlags(params.flags);
 }
 
+/** Read side for Debug -> Feature Flags: what bun actually gates code on. */
+async function getFeatureFlags(): Promise<Record<string, boolean>> {
+	return getAllFeatureFlags();
+}
+
+/** One distinct id per install, seeded from whichever renderer asks first. */
+async function resolveAnalyticsDistinctId(params: { seed?: string }): Promise<{ distinctId: string }> {
+	return { distinctId: await resolveDistinctId(params?.seed) };
+}
+
 export const settingsConfigHandlers = {
 	getResolvedProject,
 	setFeatureFlags,
+	getFeatureFlags,
+	resolveAnalyticsDistinctId,
 	getProjectConfigs,
 	getProjectConfigFiles,
 	updateProjectSettings,

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -160,8 +160,14 @@ async function saveGlobalSettings(params: GlobalSettings): Promise<void> {
 	if (Object.prototype.hasOwnProperty.call(params, "focusMode")) {
 		setFocusMode(params.focusMode === true);
 	}
-	await saveSettings(params);
-	getPushMessage()?.("globalSettingsUpdated", params);
+	// The renderer sends its whole snapshot, taken when it loaded. Anything the host
+	// owns and the renderer never edits must survive that: the analytics identity was
+	// minted after the snapshot was taken, so trusting the payload erased it on every
+	// settings change and the install got a new id on every launch.
+	const stored = await loadSettings();
+	const next: GlobalSettings = { ...params, analyticsDistinctId: stored.analyticsDistinctId ?? params.analyticsDistinctId };
+	await saveSettings(next);
+	getPushMessage()?.("globalSettingsUpdated", next);
 	log.info("← saveGlobalSettings done");
 }
 
@@ -460,9 +466,9 @@ async function getFeatureFlags(): Promise<Record<string, boolean>> {
 	return getAllFeatureFlags();
 }
 
-/** One distinct id per install, seeded from whichever renderer asks first. */
-async function resolveAnalyticsDistinctId(params: { seed?: string }): Promise<{ distinctId: string }> {
-	return { distinctId: await resolveDistinctId(params?.seed) };
+/** One distinct id per install; the desktop renderer's identity wins (see analytics-identity). */
+async function resolveAnalyticsDistinctId(params: { seed?: string; authoritative?: boolean }): Promise<{ distinctId: string }> {
+	return { distinctId: await resolveDistinctId(params?.seed, { authoritative: params?.authoritative }) };
 }
 
 export const settingsConfigHandlers = {

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -17,6 +17,7 @@ import { DEV3_HOME } from "../paths";
 import { isFreshStartMode } from "../fresh-start";
 import { spawn } from "../spawn";
 import { setCurrentUiTheme } from "../theme-state";
+import { setFeatureFlags as cacheFeatureFlags } from "../feature-flags";
 import { extractConfigFromParams, getPushMessage, getSystemRequirements, log, resolveBinaryPath, setFocusMode } from "./shared";
 import { binaryCandidatesOnPath, hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
 import { isExecutableFile } from "../executable";
@@ -444,8 +445,18 @@ async function setTmuxTheme(params: { theme: "dark" | "light"; preference?: "dar
 	await pty.applyTmuxTheme(params.theme);
 }
 
+/**
+ * Cache PostHog flag values evaluated by the renderer. Fire-and-forget: the hot
+ * paths that read them (e.g. enqueuePtyData) do a synchronous cached lookup.
+ */
+async function setFeatureFlags(params: { flags: Record<string, boolean> }): Promise<void> {
+	log.debug("→ setFeatureFlags", params.flags);
+	cacheFeatureFlags(params.flags);
+}
+
 export const settingsConfigHandlers = {
 	getResolvedProject,
+	setFeatureFlags,
 	getProjectConfigs,
 	getProjectConfigFiles,
 	updateProjectSettings,

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -85,70 +85,80 @@ function resolveDefaultConfigId(stored: unknown): string {
 	return looksBuiltin ? DEFAULT_SETTINGS.defaultConfigId : remapped;
 }
 
+/**
+ * Shape the raw file into `GlobalSettings`.
+ *
+ * One function for both loaders on purpose: they used to be hand-kept twins, and
+ * the sync one silently lacked `analyticsDistinctId` — so the value existed on
+ * disk, the async reader saw it, and every synchronous reader got `undefined`.
+ */
+function normalizeSettings(data: Record<string, unknown>): GlobalSettings {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const d = data as any;
+	return {
+		defaultAgentId: d.defaultAgentId ?? DEFAULT_SETTINGS.defaultAgentId,
+		defaultConfigId: resolveDefaultConfigId(d.defaultConfigId),
+		taskDropPosition: d.taskDropPosition === "bottom" ? "bottom" : "top",
+		updateChannel: coerceUpdateChannel(d.updateChannel, hostPublishesCanary()),
+		theme: d.theme === "light" || d.theme === "system" || d.theme === "dark" ? d.theme : undefined,
+		resolvedTheme: d.resolvedTheme === "light" || d.resolvedTheme === "dark" ? d.resolvedTheme : undefined,
+		// Machine identity for analytics — opaque string, never regenerated on load.
+		analyticsDistinctId: typeof d.analyticsDistinctId === "string" && d.analyticsDistinctId
+			? d.analyticsDistinctId
+			: undefined,
+		cloneBaseDirectory: d.cloneBaseDirectory ?? undefined,
+		customBinaryPaths: d.customBinaryPaths ?? undefined,
+		agentBinaryPaths: d.agentBinaryPaths ?? undefined,
+		playSoundOnTaskComplete: d.playSoundOnTaskComplete ?? true,
+		externalApps: Array.isArray(d.externalApps) ? d.externalApps : undefined,
+		tipsDisabled: d.tipsDisabled === true ? true : undefined,
+		taskOpenMode: d.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
+		terminalPathOpenMode:
+			d.terminalPathOpenMode === "preview" ||
+			d.terminalPathOpenMode === "system" ||
+			d.terminalPathOpenMode === "reveal"
+				? d.terminalPathOpenMode
+				: undefined,
+		defaultDiffViewMode:
+			d.defaultDiffViewMode === "unified"
+				? "unified"
+				: d.defaultDiffViewMode === "split"
+					? "split"
+					: d.defaultDiffViewMode === "auto"
+						? "auto"
+						: undefined,
+		preventSleepWhileRunning: d.preventSleepWhileRunning ?? undefined,
+		skipQuitDialog: d.skipQuitDialog === true ? true : undefined,
+		importShellEnv: d.importShellEnv === false ? false : undefined,
+		focusMode: d.focusMode === true ? true : undefined,
+		// Default-on toggle — only an explicit false is a stored opt-out.
+		agentRateLimitTracking: d.agentRateLimitTracking === false ? false : undefined,
+		// Boolean preference — both true (watch) and false (don't watch) are
+		// meaningful stored choices, so preserve either; only undefined drops.
+		watchByDefault: typeof d.watchByDefault === "boolean" ? d.watchByDefault : undefined,
+		// Default-on toggle — only an explicit false is a stored opt-out.
+		suggestCompletingTasksAfterMerge: d.suggestCompletingTasksAfterMerge === false ? false : undefined,
+		agentsLayoutRevision: typeof d.agentsLayoutRevision === "number" ? d.agentsLayoutRevision : undefined,
+		// Default-off experimental toggle — only an explicit true is a stored opt-in.
+		pxpipeProxyEnabled: d.pxpipeProxyEnabled === true ? true : undefined,
+		// Default-off beta toggle — only an explicit true is a stored opt-in.
+		experimentalTerminalBidi: d.experimentalTerminalBidi === true ? true : undefined,
+		// Cross-provider favorite pointers; shape-validated, capped, empty ⇒ undefined.
+		favorites: sanitizeFavorites(d.favorites),
+		// User shortcut rebinds; sparse by design — absent means "all defaults".
+		keyboardShortcuts: sanitizeShortcutOverrides(d.keyboardShortcuts),
+		// Custom Review-toggle prompt; blank ⇒ the localized built-in text.
+		reviewModePrompt: typeof d.reviewModePrompt === "string" && d.reviewModePrompt.trim()
+			? d.reviewModePrompt
+			: undefined,
+	};
+}
+
 export async function loadSettings(): Promise<GlobalSettings> {
 	try {
 		const file = Bun.file(SETTINGS_FILE);
-		if (!(await file.exists())) {
-			return { ...DEFAULT_SETTINGS };
-		}
-		const data = await file.json();
-		return {
-			defaultAgentId: data.defaultAgentId ?? DEFAULT_SETTINGS.defaultAgentId,
-			defaultConfigId: resolveDefaultConfigId(data.defaultConfigId),
-			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
-			updateChannel: coerceUpdateChannel(data.updateChannel, hostPublishesCanary()),
-			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
-			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
-			// Machine identity for analytics — opaque string, never regenerated on load.
-			analyticsDistinctId: typeof data.analyticsDistinctId === "string" && data.analyticsDistinctId
-				? data.analyticsDistinctId
-				: undefined,
-			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
-			customBinaryPaths: data.customBinaryPaths ?? undefined,
-			agentBinaryPaths: data.agentBinaryPaths ?? undefined,
-			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
-			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
-			tipsDisabled: data.tipsDisabled === true ? true : undefined,
-			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
-			terminalPathOpenMode:
-				data.terminalPathOpenMode === "preview" ||
-				data.terminalPathOpenMode === "system" ||
-				data.terminalPathOpenMode === "reveal"
-					? data.terminalPathOpenMode
-					: undefined,
-			defaultDiffViewMode:
-				data.defaultDiffViewMode === "unified"
-					? "unified"
-					: data.defaultDiffViewMode === "split"
-						? "split"
-						: data.defaultDiffViewMode === "auto"
-							? "auto"
-							: undefined,
-			preventSleepWhileRunning: data.preventSleepWhileRunning ?? undefined,
-			skipQuitDialog: data.skipQuitDialog === true ? true : undefined,
-			importShellEnv: data.importShellEnv === false ? false : undefined,
-			focusMode: data.focusMode === true ? true : undefined,
-			// Default-on toggle — only an explicit false is a stored opt-out.
-			agentRateLimitTracking: data.agentRateLimitTracking === false ? false : undefined,
-			// Boolean preference — both true (watch) and false (don't watch) are
-			// meaningful stored choices, so preserve either; only undefined drops.
-			watchByDefault: typeof data.watchByDefault === "boolean" ? data.watchByDefault : undefined,
-			// Default-on toggle — only an explicit false is a stored opt-out.
-			suggestCompletingTasksAfterMerge: data.suggestCompletingTasksAfterMerge === false ? false : undefined,
-			agentsLayoutRevision: typeof data.agentsLayoutRevision === "number" ? data.agentsLayoutRevision : undefined,
-			// Default-off experimental toggle — only an explicit true is a stored opt-in.
-			pxpipeProxyEnabled: data.pxpipeProxyEnabled === true ? true : undefined,
-			// Default-off beta toggle — only an explicit true is a stored opt-in.
-			experimentalTerminalBidi: data.experimentalTerminalBidi === true ? true : undefined,
-			// Cross-provider favorite pointers; shape-validated, capped, empty ⇒ undefined.
-			favorites: sanitizeFavorites(data.favorites),
-			// User shortcut rebinds; sparse by design — absent means "all defaults".
-			keyboardShortcuts: sanitizeShortcutOverrides(data.keyboardShortcuts),
-			// Custom Review-toggle prompt; blank ⇒ the localized built-in text.
-			reviewModePrompt: typeof data.reviewModePrompt === "string" && data.reviewModePrompt.trim()
-				? data.reviewModePrompt
-				: undefined,
-		};
+		if (!(await file.exists())) return { ...DEFAULT_SETTINGS };
+		return normalizeSettings(await file.json());
 	} catch (err) {
 		log.error("Failed to load settings", { error: String(err) });
 		return { ...DEFAULT_SETTINGS };
@@ -203,63 +213,8 @@ export async function recordFavoriteUsages(
 
 export function loadSettingsSync(): GlobalSettings {
 	try {
-		if (!existsSync(SETTINGS_FILE)) {
-			return { ...DEFAULT_SETTINGS };
-		}
-		const data = JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
-		return {
-			defaultAgentId: data.defaultAgentId ?? DEFAULT_SETTINGS.defaultAgentId,
-			defaultConfigId: resolveDefaultConfigId(data.defaultConfigId),
-			taskDropPosition: data.taskDropPosition === "bottom" ? "bottom" : "top",
-			updateChannel: coerceUpdateChannel(data.updateChannel, hostPublishesCanary()),
-			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
-			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
-			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
-			customBinaryPaths: data.customBinaryPaths ?? undefined,
-			agentBinaryPaths: data.agentBinaryPaths ?? undefined,
-			playSoundOnTaskComplete: data.playSoundOnTaskComplete ?? true,
-			externalApps: Array.isArray(data.externalApps) ? data.externalApps : undefined,
-			tipsDisabled: data.tipsDisabled === true ? true : undefined,
-			taskOpenMode: data.taskOpenMode === "fullscreen" ? "fullscreen" : undefined,
-			terminalPathOpenMode:
-				data.terminalPathOpenMode === "preview" ||
-				data.terminalPathOpenMode === "system" ||
-				data.terminalPathOpenMode === "reveal"
-					? data.terminalPathOpenMode
-					: undefined,
-			defaultDiffViewMode:
-				data.defaultDiffViewMode === "unified"
-					? "unified"
-					: data.defaultDiffViewMode === "split"
-						? "split"
-						: data.defaultDiffViewMode === "auto"
-							? "auto"
-							: undefined,
-			preventSleepWhileRunning: data.preventSleepWhileRunning ?? undefined,
-			skipQuitDialog: data.skipQuitDialog === true ? true : undefined,
-			importShellEnv: data.importShellEnv === false ? false : undefined,
-			focusMode: data.focusMode === true ? true : undefined,
-			// Default-on toggle — only an explicit false is a stored opt-out.
-			agentRateLimitTracking: data.agentRateLimitTracking === false ? false : undefined,
-			// Boolean preference — both true (watch) and false (don't watch) are
-			// meaningful stored choices, so preserve either; only undefined drops.
-			watchByDefault: typeof data.watchByDefault === "boolean" ? data.watchByDefault : undefined,
-			// Default-on toggle — only an explicit false is a stored opt-out.
-			suggestCompletingTasksAfterMerge: data.suggestCompletingTasksAfterMerge === false ? false : undefined,
-			agentsLayoutRevision: typeof data.agentsLayoutRevision === "number" ? data.agentsLayoutRevision : undefined,
-			// Default-off experimental toggle — only an explicit true is a stored opt-in.
-			pxpipeProxyEnabled: data.pxpipeProxyEnabled === true ? true : undefined,
-			// Default-off beta toggle — only an explicit true is a stored opt-in.
-			experimentalTerminalBidi: data.experimentalTerminalBidi === true ? true : undefined,
-			// Cross-provider favorite pointers; shape-validated, capped, empty ⇒ undefined.
-			favorites: sanitizeFavorites(data.favorites),
-			// User shortcut rebinds; sparse by design — absent means "all defaults".
-			keyboardShortcuts: sanitizeShortcutOverrides(data.keyboardShortcuts),
-			// Custom Review-toggle prompt; blank ⇒ the localized built-in text.
-			reviewModePrompt: typeof data.reviewModePrompt === "string" && data.reviewModePrompt.trim()
-				? data.reviewModePrompt
-				: undefined,
-		};
+		if (!existsSync(SETTINGS_FILE)) return { ...DEFAULT_SETTINGS };
+		return normalizeSettings(JSON.parse(readFileSync(SETTINGS_FILE, "utf-8")));
 	} catch (err) {
 		log.error("Failed to load settings (sync)", { error: String(err) });
 		return { ...DEFAULT_SETTINGS };

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -99,6 +99,10 @@ export async function loadSettings(): Promise<GlobalSettings> {
 			updateChannel: coerceUpdateChannel(data.updateChannel, hostPublishesCanary()),
 			theme: data.theme === "light" || data.theme === "system" || data.theme === "dark" ? data.theme : undefined,
 			resolvedTheme: data.resolvedTheme === "light" || data.resolvedTheme === "dark" ? data.resolvedTheme : undefined,
+			// Machine identity for analytics — opaque string, never regenerated on load.
+			analyticsDistinctId: typeof data.analyticsDistinctId === "string" && data.analyticsDistinctId
+				? data.analyticsDistinctId
+				: undefined,
 			cloneBaseDirectory: data.cloneBaseDirectory ?? undefined,
 			customBinaryPaths: data.customBinaryPaths ?? undefined,
 			agentBinaryPaths: data.agentBinaryPaths ?? undefined,

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -74,6 +74,13 @@ export interface CreateAppWindowOptions {
 	/** Called after the window has been removed from the registry. */
 	onClosed?: (win: BrowserWindow, remaining: number) => void;
 	maxRequestTime?: number;
+	/**
+	 * Inline JS run after HTML parsing, before page scripts. The bundled renderer
+	 * is loaded straight from disk, so this is the only way to hand it a value the
+	 * host knows and it must see before it boots (the served remote HTML gets a
+	 * `<script>` tag instead).
+	 */
+	preload?: string;
 }
 
 /**
@@ -130,6 +137,7 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		url: opts.url,
 		rpc,
 		frame,
+		...(opts.preload ? { preload: opts.preload } : {}),
 	});
 
 	// Windows draws a system-fallback icon in the window and the taskbar because

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -49,6 +49,7 @@ import RemoteAccessExposedPorts from "./components/RemoteAccessExposedPorts";
 import { ConfirmHost, confirm } from "./confirm";
 import AgentLaunchRequestModal from "./components/AgentLaunchRequestModal";
 import AboutModal from "./components/AboutModal";
+import FeatureFlagsModal from "./components/FeatureFlagsModal";
 import FilePreviewModal from "./components/FilePreviewModal";
 import { OPEN_FILE_PREVIEW_EVENT, type OpenFilePreviewDetail } from "./terminal-path-open";
 import RosettaWarningModal from "./components/RosettaWarningModal";
@@ -281,6 +282,7 @@ function App() {
 	const [aboutVersion, setAboutVersion] = useState<string | null>(null);
 	/** The channel baked into the running bundle — what tells a canary install from the release. */
 	const [aboutBuildChannel, setAboutBuildChannel] = useState<string | null>(null);
+	const [showFeatureFlags, setShowFeatureFlags] = useState(false);
 
 	// Silent update indicator
 	const [updateVersion, setUpdateVersion] = useState<string | null>(null);
@@ -1703,6 +1705,15 @@ function App() {
 		return () => window.removeEventListener("rpc:showAbout", onShowAbout);
 	}, []);
 
+	// Debug -> Feature Flags: a read-only look at what the app is gating code on.
+	useEffect(() => {
+		function onShowFeatureFlags() {
+			setShowFeatureFlags(true);
+		}
+		window.addEventListener("rpc:showFeatureFlags", onShowFeatureFlags);
+		return () => window.removeEventListener("rpc:showFeatureFlags", onShowFeatureFlags);
+	}, []);
+
 	// Surface the result of a manual "Check for Updates" menu action as a toast.
 	// (Available updates flow through rpc:updateAvailable → the header plaque.)
 	useEffect(() => {
@@ -2711,6 +2722,7 @@ function App() {
 					onClose={() => setAboutVersion(null)}
 				/>
 			)}
+			{showFeatureFlags && <FeatureFlagsModal onClose={() => setShowFeatureFlags(false)} />}
 			{rosettaWarning && (
 				<RosettaWarningModal
 					command={rosettaWarning.command}

--- a/src/mainview/__tests__/FeatureFlagsModal.test.tsx
+++ b/src/mainview/__tests__/FeatureFlagsModal.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Debug → Feature Flags. What must hold: the values shown are the ones bun gates
- * code on (re-read while the window is open), the distinct id is copyable and
- * masked in streamer mode, and a remote browser is told its own id is worthless
- * rather than being handed a misleading one.
+ * code on (re-read while the window is open), the id shown is the one PostHog
+ * evaluates this renderer as (copyable, masked in streamer mode), a disagreement
+ * with the host's stored id is surfaced rather than hidden, and Refresh reports
+ * whether an answer actually arrived.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -10,23 +11,31 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { I18nProvider } from "../i18n";
 
 const { state } = vi.hoisted(() => ({
-	state: { flags: { "remote-terminal-latency": false } as Record<string, boolean> },
+	state: {
+		flags: { "remote-terminal-latency": false } as Record<string, boolean>,
+		storedId: "01234567-89ab-cdef",
+		evaluatingId: "01234567-89ab-cdef",
+		answered: true,
+	},
 }));
 
 vi.mock("../rpc", () => ({
 	api: {
 		request: {
 			getFeatureFlags: vi.fn(() => Promise.resolve(state.flags)),
-			// bun owns the id, so the modal shows the same one in every renderer.
-			resolveAnalyticsDistinctId: vi.fn(() => Promise.resolve({ distinctId: "01234567-89ab-cdef" })),
+			// The host's own copy of the id — normally identical to the evaluating one.
+			resolveAnalyticsDistinctId: vi.fn(() => Promise.resolve({ distinctId: state.storedId })),
 		},
 	},
 	isElectrobun: true,
 }));
 
-const { reload } = vi.hoisted(() => ({ reload: vi.fn() }));
+const { reload } = vi.hoisted(() => ({ reload: vi.fn(() => Promise.resolve(state.answered)) }));
 
-vi.mock("../feature-flags", () => ({ refreshFeatureFlagsNow: reload }));
+vi.mock("../feature-flags", () => ({
+	refreshFeatureFlagsNow: reload,
+	evaluatingDistinctId: () => state.evaluatingId,
+}));
 
 import FeatureFlagsModal from "../components/FeatureFlagsModal";
 
@@ -40,6 +49,9 @@ function renderModal(onClose = vi.fn()) {
 
 beforeEach(() => {
 	state.flags = { "remote-terminal-latency": false };
+	state.storedId = "01234567-89ab-cdef";
+	state.evaluatingId = "01234567-89ab-cdef";
+	state.answered = true;
 	vi.clearAllMocks();
 });
 
@@ -79,9 +91,39 @@ describe("FeatureFlagsModal", () => {
 		await screen.findByText("Copied");
 	});
 
-	it("shows the id bun owns, not one this renderer minted", async () => {
+	it("shows the id PostHog evaluates this renderer as, because that is what a rollout targets", async () => {
+		state.evaluatingId = "evaluating-id";
+		state.storedId = "evaluating-id";
+		renderModal();
+		await screen.findByText("evaluating-id");
+	});
+
+	// The bug this window exists to catch: the host handing over its id can fail,
+	// and then targeting the displayed id silently matches nobody.
+	it("surfaces a disagreement between the evaluating id and the host's stored one", async () => {
+		state.evaluatingId = "renderer-minted-id";
+		state.storedId = "host-stored-id";
+		renderModal();
+
+		await screen.findByText("renderer-minted-id");
+		await waitFor(() => expect(screen.getByText(/host-stored-id/)).toBeInTheDocument());
+	});
+
+	// A worktree build has no PostHog key, so the client is a no-op: nothing ever
+	// evaluates and every value shown is a shipped default. Saying so beats an
+	// empty id row that reads like a bug in the window.
+	it("says the build has no PostHog key and falls back to the host's id", async () => {
+		state.evaluatingId = "";
+		renderModal();
+
+		await screen.findByText(/no PostHog key/);
+		await screen.findByText("01234567-89ab-cdef");
+	});
+
+	it("stays quiet when both ids agree", async () => {
 		renderModal();
 		await screen.findByText("01234567-89ab-cdef");
+		expect(screen.queryByText(/different id/)).not.toBeInTheDocument();
 	});
 
 	it("masks the distinct id in streamer mode", async () => {
@@ -96,6 +138,25 @@ describe("FeatureFlagsModal", () => {
 
 		await user.click(await screen.findByRole("button", { name: "Refresh now" }));
 		expect(reload).toHaveBeenCalled();
+	});
+
+	it("confirms a refresh that got an answer", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		await user.click(await screen.findByRole("button", { name: "Refresh now" }));
+		await screen.findByText("Values updated");
+	});
+
+	// Silence used to be indistinguishable from success, which is how a dead
+	// refresh path survived: the button looked like it had worked.
+	it("says so when PostHog never answers", async () => {
+		state.answered = false;
+		const user = userEvent.setup();
+		renderModal();
+
+		await user.click(await screen.findByRole("button", { name: "Refresh now" }));
+		await screen.findByText("No answer from PostHog");
 	});
 
 	it("closes on the Close button", async () => {

--- a/src/mainview/__tests__/FeatureFlagsModal.test.tsx
+++ b/src/mainview/__tests__/FeatureFlagsModal.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Debug → Feature Flags. What must hold: the values shown are the ones bun gates
+ * code on (re-read while the window is open), the distinct id is copyable and
+ * masked in streamer mode, and a remote browser is told its own id is worthless
+ * rather than being handed a misleading one.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { I18nProvider } from "../i18n";
+
+const { state } = vi.hoisted(() => ({
+	state: { flags: { "remote-terminal-latency": false } as Record<string, boolean> },
+}));
+
+vi.mock("../rpc", () => ({
+	api: {
+		request: {
+			getFeatureFlags: vi.fn(() => Promise.resolve(state.flags)),
+			// bun owns the id, so the modal shows the same one in every renderer.
+			resolveAnalyticsDistinctId: vi.fn(() => Promise.resolve({ distinctId: "01234567-89ab-cdef" })),
+		},
+	},
+	isElectrobun: true,
+}));
+
+const { reload } = vi.hoisted(() => ({ reload: vi.fn() }));
+
+vi.mock("../feature-flags", () => ({ refreshFeatureFlagsNow: reload }));
+
+import FeatureFlagsModal from "../components/FeatureFlagsModal";
+
+function renderModal(onClose = vi.fn()) {
+	return render(
+		<I18nProvider>
+			<FeatureFlagsModal onClose={onClose} />
+		</I18nProvider>,
+	);
+}
+
+beforeEach(() => {
+	state.flags = { "remote-terminal-latency": false };
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("FeatureFlagsModal", () => {
+	it("shows every declared flag with the value bun reports", async () => {
+		state.flags = { "remote-terminal-latency": true, "some-other-flag": false };
+		renderModal();
+
+		await screen.findByText("remote-terminal-latency");
+		expect(screen.getByText("some-other-flag")).toBeInTheDocument();
+		expect(screen.getByText("On")).toBeInTheDocument();
+		expect(screen.getByText("Off")).toBeInTheDocument();
+	});
+
+	it("picks up a flag that flips while the window stays open", async () => {
+		renderModal();
+		await screen.findByText("Off");
+
+		state.flags = { "remote-terminal-latency": true };
+		await waitFor(() => expect(screen.getByText("On")).toBeInTheDocument(), { timeout: 3000 });
+	});
+
+	it("copies the distinct id and confirms it", async () => {
+		// setup() installs its own navigator.clipboard stub, so override it after.
+		const user = userEvent.setup();
+		const writeText = vi.fn(() => Promise.resolve());
+		Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+		renderModal();
+
+		await user.click(await screen.findByRole("button", { name: "Copy" }));
+
+		expect(writeText).toHaveBeenCalledWith("01234567-89ab-cdef");
+		await screen.findByText("Copied");
+	});
+
+	it("shows the id bun owns, not one this renderer minted", async () => {
+		renderModal();
+		await screen.findByText("01234567-89ab-cdef");
+	});
+
+	it("masks the distinct id in streamer mode", async () => {
+		renderModal();
+		const id = await screen.findByText("01234567-89ab-cdef");
+		expect(id).toHaveClass("streamer-private");
+	});
+
+	it("asks PostHog for fresh values instead of waiting out the timer", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		await user.click(await screen.findByRole("button", { name: "Refresh now" }));
+		expect(reload).toHaveBeenCalled();
+	});
+
+	it("closes on the Close button", async () => {
+		const onClose = vi.fn();
+		const user = userEvent.setup();
+		renderModal(onClose);
+
+		await user.click(await screen.findByRole("button", { name: "Close" }));
+		expect(onClose).toHaveBeenCalled();
+	});
+});

--- a/src/mainview/__tests__/feature-flags.test.ts
+++ b/src/mainview/__tests__/feature-flags.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Renderer half of the flag loop (seq 1470). What must hold: every renderer pushes
+ * what it evaluated (a browser that stayed silent left the host on shipped defaults
+ * and made Refresh a dead button), only the desktop one polls, the identity reported
+ * to the host is the one PostHog evaluates against, and a manual refresh reports
+ * whether an answer actually arrived.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { ph, rpc, env } = vi.hoisted(() => ({
+	ph: {
+		flags: {} as Record<string, boolean | undefined>,
+		listeners: [] as Array<() => void>,
+		distinctId: "renderer-id",
+		reloadCalls: 0,
+	},
+	rpc: { pushed: [] as Array<Record<string, boolean>> },
+	env: { isElectrobun: true },
+}));
+
+vi.mock("../posthog", () => ({
+	default: {
+		getFeatureFlag: (key: string) => ph.flags[key],
+		get_distinct_id: () => ph.distinctId,
+		onFeatureFlags: (cb: () => void) => {
+			ph.listeners.push(cb);
+			return () => {
+				ph.listeners = ph.listeners.filter((l) => l !== cb);
+			};
+		},
+		reloadFeatureFlags: () => {
+			ph.reloadCalls += 1;
+		},
+	},
+}));
+
+vi.mock("../rpc", () => ({
+	api: {
+		request: {
+			setFeatureFlags: vi.fn(({ flags }: { flags: Record<string, boolean> }) => {
+				rpc.pushed.push(flags);
+				return Promise.resolve();
+			}),
+			resolveAnalyticsDistinctId: vi.fn(() => Promise.resolve({ distinctId: "host-id" })),
+		},
+	},
+	get isElectrobun() {
+		return env.isElectrobun;
+	},
+}));
+
+import { api } from "../rpc";
+import { evaluatingDistinctId, initFeatureFlags, refreshFeatureFlagsNow } from "../feature-flags";
+
+beforeEach(() => {
+	ph.flags = {};
+	ph.listeners = [];
+	ph.distinctId = "renderer-id";
+	ph.reloadCalls = 0;
+	rpc.pushed = [];
+	env.isElectrobun = true;
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("renderer feature flags", () => {
+	it("reports the id PostHog evaluates as, claiming identity for the desktop window", () => {
+		initFeatureFlags();
+		expect(api.request.resolveAnalyticsDistinctId).toHaveBeenCalledWith({
+			seed: "renderer-id",
+			authoritative: true,
+		});
+		expect(evaluatingDistinctId()).toBe("renderer-id");
+	});
+
+	it("reports without claiming identity from a browser, which may have an id of its own", () => {
+		env.isElectrobun = false;
+		initFeatureFlags();
+		expect(api.request.resolveAnalyticsDistinctId).toHaveBeenCalledWith({
+			seed: "renderer-id",
+			authoritative: false,
+		});
+	});
+
+	it("pushes evaluated values to the host when PostHog answers", () => {
+		ph.flags["remote-terminal-latency"] = true;
+		initFeatureFlags();
+
+		ph.listeners.forEach((l) => l());
+
+		expect(rpc.pushed).toEqual([{ "remote-terminal-latency": true }]);
+	});
+
+	it("pushes from a browser renderer too, so its Debug window is not a liar", () => {
+		env.isElectrobun = false;
+		initFeatureFlags();
+
+		ph.listeners.forEach((l) => l());
+
+		expect(rpc.pushed).toHaveLength(1);
+	});
+
+	it("polls only in the desktop renderer — one poller per install, not per browser", () => {
+		vi.useFakeTimers();
+		env.isElectrobun = false;
+		initFeatureFlags();
+		vi.advanceTimersByTime(20 * 60 * 1000);
+		expect(ph.reloadCalls).toBe(0);
+
+		env.isElectrobun = true;
+		initFeatureFlags();
+		vi.advanceTimersByTime(20 * 60 * 1000);
+		expect(ph.reloadCalls).toBeGreaterThan(0);
+	});
+
+	it("resolves true once a manual refresh has been answered and pushed", async () => {
+		ph.flags["remote-terminal-latency"] = false;
+		const pending = refreshFeatureFlagsNow();
+		expect(ph.reloadCalls).toBe(1);
+
+		ph.flags["remote-terminal-latency"] = true;
+		ph.listeners.forEach((l) => l());
+
+		await expect(pending).resolves.toBe(true);
+		expect(rpc.pushed).toEqual([{ "remote-terminal-latency": true }]);
+	});
+
+	it("resolves false when PostHog never answers, instead of looking successful", async () => {
+		vi.useFakeTimers();
+		const pending = refreshFeatureFlagsNow();
+		await vi.advanceTimersByTimeAsync(30_000);
+		await expect(pending).resolves.toBe(false);
+	});
+
+	it("drops its one-shot listener, so a later answer is not counted twice", async () => {
+		const pending = refreshFeatureFlagsNow();
+		ph.listeners.forEach((l) => l());
+		await pending;
+		expect(ph.listeners).toHaveLength(0);
+	});
+});

--- a/src/mainview/components/FeatureFlagsModal.tsx
+++ b/src/mainview/components/FeatureFlagsModal.tsx
@@ -3,11 +3,15 @@ import { useT } from "../i18n";
 import { api } from "../rpc";
 import { useFocusTrap } from "../utils/useFocusTrap";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import { refreshFeatureFlagsNow } from "../feature-flags";
+import { evaluatingDistinctId, refreshFeatureFlagsNow } from "../feature-flags";
 import { FEATURE_FLAG_REFRESH_MS } from "../../shared/feature-flags";
 
 /** Re-read bun while the window is open, so a flag flip shows up without reopening. */
 const POLL_MS = 1000;
+/** How long the refresh verdict stays on screen before the button goes quiet again. */
+const VERDICT_MS = 4000;
+
+type RefreshState = "idle" | "pending" | "answered" | "silent";
 
 interface FeatureFlagsModalProps {
 	onClose: () => void;
@@ -24,14 +28,20 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 
 	const [flags, setFlags] = useState<Record<string, boolean> | null>(null);
 	const [copied, setCopied] = useState(false);
-	const [distinctId, setDistinctId] = useState("");
+	const [refreshState, setRefreshState] = useState<RefreshState>("idle");
+	// What PostHog evaluates this renderer as — the id a rollout has to target.
+	// Empty when the build carries no PostHog key: then nothing evaluates at all.
+	const [evaluatingId] = useState(evaluatingDistinctId);
+	// What the host stored. Equal to the above unless the handover broke, and then
+	// seeing both is the whole diagnosis.
+	const [storedId, setStoredId] = useState("");
 
 	const load = useCallback(() => {
 		api.request.getFeatureFlags().then(setFlags).catch(() => {});
 	}, []);
 
 	useEffect(() => {
-		api.request.resolveAnalyticsDistinctId({}).then((r) => setDistinctId(r.distinctId)).catch(() => {});
+		api.request.resolveAnalyticsDistinctId({}).then((r) => setStoredId(r.distinctId)).catch(() => {});
 	}, []);
 
 	useEffect(() => {
@@ -47,7 +57,23 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 		}).catch(() => {});
 	}
 
+	function handleRefresh() {
+		if (refreshState === "pending") return;
+		setRefreshState("pending");
+		refreshFeatureFlagsNow().then((answered) => {
+			load();
+			setRefreshState(answered ? "answered" : "silent");
+			window.setTimeout(() => setRefreshState("idle"), VERDICT_MS);
+		});
+	}
+
 	const entries = Object.entries(flags ?? {});
+	// No client means no evaluation, so fall back to the host's copy rather than an
+	// empty row — the id is still what a rollout will have to target later.
+	const noClient = !evaluatingId;
+	const distinctId = evaluatingId || storedId;
+	const idMismatch = !!evaluatingId && !!storedId && evaluatingId !== storedId;
+	const refreshLabel = refreshState === "pending" ? t("featureFlags.refreshing") : t("featureFlags.refreshNow");
 
 	return (
 		<div
@@ -98,6 +124,7 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 				</div>
 
 				<div className="space-y-1">
+					{noClient && <p className="text-warning text-micro">{t("featureFlags.noClient")}</p>}
 					<p className="text-fg-3 text-xs">{t("featureFlags.distinctIdLabel")}</p>
 					<div className="flex items-center gap-2">
 						<code className="streamer-private flex-1 min-w-0 truncate px-3 py-2 rounded-lg bg-elevated border border-edge text-fg-2 text-xs font-mono">
@@ -118,24 +145,42 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 							{copied ? t("featureFlags.copied") : t("featureFlags.copy")}
 						</button>
 					</div>
+					{idMismatch && (
+						<p className="text-warning text-micro">
+							{t("featureFlags.idMismatch", { stored: storedId })}
+						</p>
+					)}
 				</div>
 
 				<p className="text-fg-muted text-xs">
 					{t("featureFlags.cadence", { minutes: String(Math.round(FEATURE_FLAG_REFRESH_MS / 60000)) })}
 				</p>
 
-				<div className="flex justify-end gap-2 pt-1">
+				<div className="flex items-center justify-end gap-3 pt-1">
+					<span
+						aria-live="polite"
+						className={`mr-auto text-micro transition-opacity ${
+							refreshState === "answered"
+								? "text-success opacity-100"
+								: refreshState === "silent"
+									? "text-danger opacity-100"
+									: "opacity-0"
+						}`}
+					>
+						{refreshState === "silent" ? t("featureFlags.refreshFailed") : t("featureFlags.refreshed")}
+					</span>
 					<button
 						type="button"
-						onClick={refreshFeatureFlagsNow}
-						className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
+						onClick={handleRefresh}
+						disabled={refreshState === "pending"}
+						className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors active:scale-[0.96] disabled:opacity-50 disabled:active:scale-100"
 					>
-						{t("featureFlags.refreshNow")}
+						{refreshLabel}
 					</button>
 					<button
 						type="button"
 						onClick={onClose}
-						className="px-4 py-2 text-sm rounded-lg bg-accent-fill text-white hover:bg-accent-fill-hover transition-colors"
+						className="px-4 py-2 text-sm rounded-lg bg-accent-fill text-white hover:bg-accent-fill-hover transition-colors active:scale-[0.96]"
 					>
 						{t("featureFlags.close")}
 					</button>

--- a/src/mainview/components/FeatureFlagsModal.tsx
+++ b/src/mainview/components/FeatureFlagsModal.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from "react";
+import { useT } from "../i18n";
+import { api } from "../rpc";
+import { useFocusTrap } from "../utils/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+import { refreshFeatureFlagsNow } from "../feature-flags";
+import { FEATURE_FLAG_REFRESH_MS } from "../../shared/feature-flags";
+
+/** Re-read bun while the window is open, so a flag flip shows up without reopening. */
+const POLL_MS = 1000;
+
+interface FeatureFlagsModalProps {
+	onClose: () => void;
+}
+
+/**
+ * Debug → Feature Flags. Read-only: the values are the ones bun gates code on,
+ * next to the PostHog distinct id a rollout can be targeted at.
+ */
+export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
+	const t = useT();
+	const trapRef = useFocusTrap<HTMLDivElement>();
+	useEscapeKey(onClose);
+
+	const [flags, setFlags] = useState<Record<string, boolean> | null>(null);
+	const [copied, setCopied] = useState(false);
+	const [distinctId, setDistinctId] = useState("");
+
+	const load = useCallback(() => {
+		api.request.getFeatureFlags().then(setFlags).catch(() => {});
+	}, []);
+
+	useEffect(() => {
+		api.request.resolveAnalyticsDistinctId({}).then((r) => setDistinctId(r.distinctId)).catch(() => {});
+	}, []);
+
+	useEffect(() => {
+		load();
+		const timer = window.setInterval(load, POLL_MS);
+		return () => window.clearInterval(timer);
+	}, [load]);
+
+	function handleCopy() {
+		navigator.clipboard.writeText(distinctId).then(() => {
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 1500);
+		}).catch(() => {});
+	}
+
+	const entries = Object.entries(flags ?? {});
+
+	return (
+		<div
+			className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div
+				ref={trapRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="feature-flags-dialog-title"
+				tabIndex={-1}
+				className="bg-overlay border border-edge rounded-2xl shadow-2xl w-[34rem] p-6 space-y-4 outline-none"
+			>
+				<h2 id="feature-flags-dialog-title" className="text-fg text-lg font-semibold">
+					{t("featureFlags.title")}
+				</h2>
+
+				<div className="space-y-1">
+					<p className="text-fg-3 text-xs">{t("featureFlags.effectiveHint")}</p>
+					{flags === null
+						? <p className="text-fg-muted text-sm py-2">{t("featureFlags.loading")}</p>
+						: entries.length === 0
+							? (
+								<div className="py-2 space-y-1">
+									<p className="text-fg-muted text-sm">{t("featureFlags.empty")}</p>
+									<p className="text-fg-muted text-micro">{t("featureFlags.emptyHint")}</p>
+								</div>
+								)
+							: (
+								<ul className="divide-y divide-edge border border-edge rounded-lg overflow-hidden">
+									{entries.map(([key, value]) => (
+										<li key={key} className="flex items-center justify-between gap-3 px-3 py-2 bg-elevated">
+											<code className="text-fg-2 text-xs font-mono truncate">{key}</code>
+											<span
+												className={`shrink-0 px-2 py-0.5 rounded text-micro font-medium ${
+													value ? "bg-success/15 text-success" : "bg-raised text-fg-muted"
+												}`}
+											>
+												{value ? t("featureFlags.on") : t("featureFlags.off")}
+											</span>
+										</li>
+									))}
+								</ul>
+							)}
+				</div>
+
+				<div className="space-y-1">
+					<p className="text-fg-3 text-xs">{t("featureFlags.distinctIdLabel")}</p>
+					<div className="flex items-center gap-2">
+						<code className="streamer-private flex-1 min-w-0 truncate px-3 py-2 rounded-lg bg-elevated border border-edge text-fg-2 text-xs font-mono">
+							{distinctId || t("featureFlags.distinctIdMissing")}
+						</code>
+						<button
+							type="button"
+							onClick={handleCopy}
+							disabled={!distinctId}
+							title={t("featureFlags.copy")}
+							aria-label={t("featureFlags.copy")}
+							className={`shrink-0 px-3 py-2 text-xs rounded-lg border transition-colors disabled:opacity-40 ${
+								copied
+									? "border-success/40 bg-success/10 text-success"
+									: "border-edge text-fg-2 hover:text-fg hover:bg-elevated"
+							}`}
+						>
+							{copied ? t("featureFlags.copied") : t("featureFlags.copy")}
+						</button>
+					</div>
+				</div>
+
+				<p className="text-fg-muted text-xs">
+					{t("featureFlags.cadence", { minutes: String(Math.round(FEATURE_FLAG_REFRESH_MS / 60000)) })}
+				</p>
+
+				<div className="flex justify-end gap-2 pt-1">
+					<button
+						type="button"
+						onClick={refreshFeatureFlagsNow}
+						className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
+					>
+						{t("featureFlags.refreshNow")}
+					</button>
+					<button
+						type="button"
+						onClick={onClose}
+						className="px-4 py-2 text-sm rounded-lg bg-accent-fill text-white hover:bg-accent-fill-hover transition-colors"
+					>
+						{t("featureFlags.close")}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/mainview/feature-flags.ts
+++ b/src/mainview/feature-flags.ts
@@ -1,0 +1,38 @@
+/**
+ * Feature-flag refresh loop. The renderer owns evaluation (posthog-js is already
+ * initialized here and already owns the distinct id) and pushes the values to the
+ * bun process, which reads them synchronously on hot paths.
+ *
+ * Only the Electrobun renderer runs this: it is the one renderer that exists
+ * exactly once per install, so the flags a machine acts on come from a single
+ * distinct id. A remote browser has its own anonymous id and would bucket
+ * differently on a percentage rollout, giving one machine two answers.
+ *
+ * See decisions/2026/08/08/first-posthog-feature-flag.md.
+ */
+import posthog from "./posthog";
+import { api, isElectrobun } from "./rpc";
+import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REFRESH_MS, type FeatureFlagKey } from "../shared/feature-flags";
+
+function pushFlagsToBun(): void {
+	const flags = {} as Record<FeatureFlagKey, boolean>;
+	for (const key of FEATURE_FLAG_KEYS) flags[key] = posthog.getFeatureFlag(key) === true;
+	api.request.setFeatureFlags({ flags }).catch(() => {
+		// A dropped push leaves bun on its last known value, which is the point.
+	});
+}
+
+/**
+ * Start the refresh loop. `onFeatureFlags` fires after every successful load,
+ * including the first, so the push is driven by PostHog rather than by a guess
+ * at when the values are ready.
+ *
+ * `reloadFeatureFlags()` is deliberately fire-and-forget: it is neither awaitable
+ * nor reactive, and the cached value keeps being served while a refetch is in
+ * flight. Holding the last known value through an outage is the behaviour we want.
+ */
+export function initFeatureFlags(): void {
+	if (!isElectrobun) return;
+	posthog.onFeatureFlags(() => pushFlagsToBun());
+	setInterval(() => posthog.reloadFeatureFlags(), FEATURE_FLAG_REFRESH_MS);
+}

--- a/src/mainview/feature-flags.ts
+++ b/src/mainview/feature-flags.ts
@@ -1,12 +1,12 @@
 /**
- * Feature-flag refresh loop. The renderer owns evaluation (posthog-js is already
- * initialized here and already owns the distinct id) and pushes the values to the
- * bun process, which reads them synchronously on hot paths.
+ * Feature-flag refresh loop. The renderer owns evaluation (posthog-js lives here)
+ * and pushes the values to the bun process, which reads them synchronously on hot
+ * paths.
  *
- * Only the Electrobun renderer runs this: it is the one renderer that exists
- * exactly once per install, so the flags a machine acts on come from a single
- * distinct id. A remote browser has its own anonymous id and would bucket
- * differently on a percentage rollout, giving one machine two answers.
+ * Only the Electrobun renderer refreshes: it exists exactly once per install, so
+ * one poller per machine rather than one per attached browser. The *identity* is
+ * shared either way — bun owns the distinct id and every renderer reports the
+ * same one, so a percentage rollout cannot half-enable a machine.
  *
  * See decisions/2026/08/08/first-posthog-feature-flag.md.
  */
@@ -22,16 +22,19 @@ function pushFlagsToBun(): void {
 	});
 }
 
-/**
- * Start the refresh loop. `onFeatureFlags` fires after every successful load,
- * including the first, so the push is driven by PostHog rather than by a guess
- * at when the values are ready.
- *
- * `reloadFeatureFlags()` is deliberately fire-and-forget: it is neither awaitable
- * nor reactive, and the cached value keeps being served while a refetch is in
- * flight. Holding the last known value through an outage is the behaviour we want.
- */
+/** Ask PostHog for fresh values now instead of waiting out the refresh timer. */
+export function refreshFeatureFlagsNow(): void {
+	posthog.reloadFeatureFlags();
+}
+
 export function initFeatureFlags(): void {
+	// Offer this renderer's own posthog-js id as the seed. bun keeps the first one
+	// it is ever given, so an existing install adopts the id it already had rather
+	// than minting a second person for the same machine.
+	api.request
+		.resolveAnalyticsDistinctId({ seed: posthog.get_distinct_id() || undefined })
+		.catch(() => {});
+
 	if (!isElectrobun) return;
 	posthog.onFeatureFlags(() => pushFlagsToBun());
 	setInterval(() => posthog.reloadFeatureFlags(), FEATURE_FLAG_REFRESH_MS);

--- a/src/mainview/feature-flags.ts
+++ b/src/mainview/feature-flags.ts
@@ -3,10 +3,14 @@
  * and pushes the values to the bun process, which reads them synchronously on hot
  * paths.
  *
- * Only the Electrobun renderer refreshes: it exists exactly once per install, so
- * one poller per machine rather than one per attached browser. The *identity* is
- * shared either way — bun owns the distinct id and every renderer reports the
- * same one, so a percentage rollout cannot half-enable a machine.
+ * Only the Electrobun renderer *polls*: it exists exactly once per install, so one
+ * poller per machine rather than one per attached browser. Every renderer pushes
+ * what it evaluated, though — a browser that never pushes would leave the Debug
+ * window showing shipped defaults forever and make its Refresh button a no-op.
+ *
+ * Identity comes from the host (`window.__DEV3_DISTINCT_ID__`, see
+ * src/bun/analytics-identity.ts), so all renderers evaluate as one person and a
+ * percentage rollout cannot half-enable a machine.
  *
  * See decisions/2026/08/08/first-posthog-feature-flag.md.
  */
@@ -14,28 +18,58 @@ import posthog from "./posthog";
 import { api, isElectrobun } from "./rpc";
 import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REFRESH_MS, type FeatureFlagKey } from "../shared/feature-flags";
 
-function pushFlagsToBun(): void {
+/** How long a manual refresh waits for PostHog before reporting no answer. */
+const MANUAL_REFRESH_TIMEOUT_MS = 8000;
+
+function pushFlagsToBun(): Promise<void> {
 	const flags = {} as Record<FeatureFlagKey, boolean>;
 	for (const key of FEATURE_FLAG_KEYS) flags[key] = posthog.getFeatureFlag(key) === true;
-	api.request.setFeatureFlags({ flags }).catch(() => {
+	return api.request.setFeatureFlags({ flags }).catch(() => {
 		// A dropped push leaves bun on its last known value, which is the point.
 	});
 }
 
-/** Ask PostHog for fresh values now instead of waiting out the refresh timer. */
-export function refreshFeatureFlagsNow(): void {
-	posthog.reloadFeatureFlags();
+/** The id PostHog evaluates this renderer as — the one a rollout must target. */
+export function evaluatingDistinctId(): string {
+	try {
+		return posthog.get_distinct_id() || "";
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Ask PostHog for fresh values now instead of waiting out the refresh timer.
+ * Resolves once the answer has been pushed to bun, or false if none arrived —
+ * the caller is a button and has to show one or the other.
+ */
+export function refreshFeatureFlagsNow(): Promise<boolean> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (answered: boolean) => {
+			if (settled) return;
+			settled = true;
+			window.clearTimeout(timer);
+			off?.();
+			resolve(answered);
+		};
+		const off = posthog.onFeatureFlags(() => {
+			void pushFlagsToBun().then(() => finish(true));
+		});
+		const timer = window.setTimeout(() => finish(false), MANUAL_REFRESH_TIMEOUT_MS);
+		posthog.reloadFeatureFlags();
+	});
 }
 
 export function initFeatureFlags(): void {
-	// Offer this renderer's own posthog-js id as the seed. bun keeps the first one
-	// it is ever given, so an existing install adopts the id it already had rather
-	// than minting a second person for the same machine.
+	// Report the id PostHog actually evaluates as. The desktop renderer is
+	// authoritative: its posthog-js identity outlives any attached browser, and a
+	// browser that already had an identity of its own must not pin the install to it.
 	api.request
-		.resolveAnalyticsDistinctId({ seed: posthog.get_distinct_id() || undefined })
+		.resolveAnalyticsDistinctId({ seed: evaluatingDistinctId() || undefined, authoritative: isElectrobun })
 		.catch(() => {});
 
+	posthog.onFeatureFlags(() => void pushFlagsToBun());
 	if (!isElectrobun) return;
-	posthog.onFeatureFlags(() => pushFlagsToBun());
 	setInterval(() => posthog.reloadFeatureFlags(), FEATURE_FLAG_REFRESH_MS);
 }

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -71,6 +71,11 @@ const common = {
 	"featureFlags.copied": "Copied",
 	"featureFlags.cadence": "Refreshed about every {minutes} min. PostHog has no push channel, so that is also the worst case for a change to arrive.",
 	"featureFlags.refreshNow": "Refresh now",
+	"featureFlags.refreshing": "Asking PostHog…",
+	"featureFlags.refreshed": "Values updated",
+	"featureFlags.refreshFailed": "No answer from PostHog",
+	"featureFlags.idMismatch": "The host stored a different id ({stored}). Target the one above — it is the one flags are evaluated against.",
+	"featureFlags.noClient": "This build has no PostHog key, so no flag will ever evaluate — the values above are the shipped defaults. The id below is the one the host stored.",
 	"featureFlags.close": "Close",
 
 	// Generic

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -57,6 +57,22 @@ const common = {
 	"about.website": "Website",
 	"about.close": "Close",
 
+	// Debug -> Feature Flags (developer inspector)
+	"featureFlags.title": "Feature flags",
+	"featureFlags.effectiveHint": "Values the app is gating code on right now.",
+	"featureFlags.loading": "Reading…",
+	"featureFlags.empty": "No flags are declared.",
+	"featureFlags.emptyHint": "Add one to FEATURE_FLAGS in src/shared/feature-flags.ts, then create it in PostHog under the same key.",
+	"featureFlags.on": "On",
+	"featureFlags.off": "Off",
+	"featureFlags.distinctIdLabel": "PostHog distinct ID — target a rollout at this install",
+	"featureFlags.distinctIdMissing": "PostHog is not configured",
+	"featureFlags.copy": "Copy",
+	"featureFlags.copied": "Copied",
+	"featureFlags.cadence": "Refreshed about every {minutes} min. PostHog has no push channel, so that is also the worst case for a change to arrive.",
+	"featureFlags.refreshNow": "Refresh now",
+	"featureFlags.close": "Close",
+
 	// Generic
 	"toast.source.menu": "Menu",
 	"toast.source.settings": "Settings",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -71,6 +71,11 @@ const common = {
 	"featureFlags.copied": "Copiado",
 	"featureFlags.cadence": "Se actualiza cada {minutes} min aprox. PostHog no tiene canal push, así que ese es también el peor caso para que llegue un cambio.",
 	"featureFlags.refreshNow": "Actualizar ahora",
+	"featureFlags.refreshing": "Consultando a PostHog…",
+	"featureFlags.refreshed": "Valores actualizados",
+	"featureFlags.refreshFailed": "PostHog no respondió",
+	"featureFlags.idMismatch": "El host guardó otro id ({stored}). Apunta al de arriba: es el que se usa para evaluar los flags.",
+	"featureFlags.noClient": "Esta compilación no tiene clave de PostHog, así que ningún flag se evaluará nunca: arriba están los valores por defecto. El id de abajo es el que guardó el host.",
 	"featureFlags.close": "Cerrar",
 
 	// Generic

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -57,6 +57,22 @@ const common = {
 	"about.website": "Sitio web",
 	"about.close": "Cerrar",
 
+	// Debug -> Feature Flags (developer inspector)
+	"featureFlags.title": "Feature flags",
+	"featureFlags.effectiveHint": "Valores por los que la app decide el código ahora mismo.",
+	"featureFlags.loading": "Leyendo…",
+	"featureFlags.empty": "No hay flags declarados.",
+	"featureFlags.emptyHint": "Añade uno a FEATURE_FLAGS en src/shared/feature-flags.ts y créalo en PostHog con la misma clave.",
+	"featureFlags.on": "Activo",
+	"featureFlags.off": "Inactivo",
+	"featureFlags.distinctIdLabel": "PostHog distinct ID — apunta un despliegue a esta instalación",
+	"featureFlags.distinctIdMissing": "PostHog no está configurado",
+	"featureFlags.copy": "Copiar",
+	"featureFlags.copied": "Copiado",
+	"featureFlags.cadence": "Se actualiza cada {minutes} min aprox. PostHog no tiene canal push, así que ese es también el peor caso para que llegue un cambio.",
+	"featureFlags.refreshNow": "Actualizar ahora",
+	"featureFlags.close": "Cerrar",
+
 	// Generic
 	"toast.source.menu": "Menú",
 	"toast.source.settings": "Ajustes",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -57,6 +57,22 @@ const common = {
 	"about.website": "Сайт",
 	"about.close": "Закрыть",
 
+	// Debug -> Feature Flags (developer inspector)
+	"featureFlags.title": "Фича-флаги",
+	"featureFlags.effectiveHint": "Значения, по которым приложение прямо сейчас разводит код.",
+	"featureFlags.loading": "Читаю…",
+	"featureFlags.empty": "Ни одного флага не объявлено.",
+	"featureFlags.emptyHint": "Добавьте его в FEATURE_FLAGS в src/shared/feature-flags.ts, затем заведите в PostHog под тем же ключом.",
+	"featureFlags.on": "Вкл",
+	"featureFlags.off": "Выкл",
+	"featureFlags.distinctIdLabel": "PostHog distinct ID — нацельте выкатку на эту инсталляцию",
+	"featureFlags.distinctIdMissing": "PostHog не настроен",
+	"featureFlags.copy": "Копировать",
+	"featureFlags.copied": "Скопировано",
+	"featureFlags.cadence": "Обновляется примерно раз в {minutes} мин. У PostHog нет push-канала, так что это же и худший случай доезда изменения.",
+	"featureFlags.refreshNow": "Обновить сейчас",
+	"featureFlags.close": "Закрыть",
+
 	// Generic
 	"toast.source.menu": "Меню",
 	"toast.source.settings": "Настройки",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -71,6 +71,11 @@ const common = {
 	"featureFlags.copied": "Скопировано",
 	"featureFlags.cadence": "Обновляется примерно раз в {minutes} мин. У PostHog нет push-канала, так что это же и худший случай доезда изменения.",
 	"featureFlags.refreshNow": "Обновить сейчас",
+	"featureFlags.refreshing": "Спрашиваем PostHog…",
+	"featureFlags.refreshed": "Значения обновлены",
+	"featureFlags.refreshFailed": "PostHog не ответил",
+	"featureFlags.idMismatch": "В настройках хоста лежит другой id ({stored}). Таргетируй тот, что выше — именно по нему считаются флаги.",
+	"featureFlags.noClient": "В этой сборке нет ключа PostHog, поэтому ни один флаг никогда не оценится — выше показаны дефолты из кода. Ниже — id, который хранит хост.",
 	"featureFlags.close": "Закрыть",
 
 	// Generic

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -8,6 +8,7 @@ import App from "./App";
 import { I18nProvider } from "./i18n";
 import { MobileProvider, detectMobile } from "./hooks/useMobile";
 import { initAnalytics } from "./analytics";
+import { initFeatureFlags } from "./feature-flags";
 import { api, isElectrobun } from "./rpc";
 import { initAutoFullscreen } from "./fullscreen";
 import { bootstrapZoom } from "./zoom";
@@ -87,6 +88,9 @@ initStreamerMode();
 // chrome wastes a big share of a phone screen). Desktop/Electrobun only get
 // the fullscreenchange subscription for the menu toggle. See fullscreen.ts.
 initAutoFullscreen({ mobile: !isElectrobun && detectMobile() });
+
+// Start the PostHog feature-flag refresh loop (desktop renderer only)
+initFeatureFlags();
 
 // Load saved terminal scroll speed into cache before terminals mount
 bootstrapScrollSpeed();

--- a/src/mainview/menuRouter.ts
+++ b/src/mainview/menuRouter.ts
@@ -108,6 +108,9 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 			return;
 
 		// ── Debug screens (browser equivalents of the bun navigate-to-* pushes) ──
+		case "feature-flags":
+			window.dispatchEvent(new CustomEvent("rpc:showFeatureFlags"));
+			return;
 		case "gauge-demo":
 			navigate(ctx, { screen: "gauge-demo" });
 			return;
@@ -443,7 +446,7 @@ export const BROWSER_HANDLED_ACTIONS: ReadonlySet<string> = new Set<string>([
 	"about", "hard-refresh",
 	// View / navigation
 	"view-dashboard", "view-kanban", "view-changelog", "view-stats", "open-settings",
-	"go-back", "go-forward", "gauge-demo", "viewport-lab", "native-pane-layout-lab", "update-popover-preview",
+	"go-back", "go-forward", "gauge-demo", "viewport-lab", "native-pane-layout-lab", "update-popover-preview", "feature-flags",
 	"debug-play-sound-completed", "debug-play-sound-cancelled", "debug-push-sound-completed",
 	"open-new-task", "open-add-project", "open-project-switch", "open-command-palette",
 	// Project

--- a/src/mainview/posthog.ts
+++ b/src/mainview/posthog.ts
@@ -16,13 +16,23 @@ if ((!apiKey || !apiHost) && import.meta.env.DEV) {
 // on the shipped defaults in src/shared/feature-flags.ts.
 type PostHogClient = Pick<
 	typeof posthog,
-	"capture" | "getFeatureFlag" | "onFeatureFlags" | "reloadFeatureFlags"
+	"capture" | "getFeatureFlag" | "onFeatureFlags" | "reloadFeatureFlags" | "get_distinct_id"
 >;
+
+// bun owns one distinct id per install and injects it into the HTML shell before
+// this module runs, so the desktop window and a remote browser are one person
+// rather than two. `bootstrap.distinctID` only applies when this renderer has no
+// persisted identity of its own, which is exactly right: the desktop renderer
+// keeps the id it already had, and bun seeds itself from that same id.
+const injectedDistinctId = (window as unknown as { __DEV3_DISTINCT_ID__?: string }).__DEV3_DISTINCT_ID__;
 
 const client: PostHogClient = apiKey && apiHost
 	? posthog.init(apiKey, {
 		api_host: apiHost,
 		defaults: "2026-05-30",
+		...(injectedDistinctId
+			? { bootstrap: { distinctID: injectedDistinctId, isIdentifiedID: false } }
+			: {}),
 		capture_exceptions: {
 			capture_unhandled_errors: true,
 			capture_unhandled_rejections: true,
@@ -34,6 +44,7 @@ const client: PostHogClient = apiKey && apiHost
 		getFeatureFlag: () => undefined,
 		onFeatureFlags: () => () => undefined,
 		reloadFeatureFlags: () => undefined,
+		get_distinct_id: () => "",
 	};
 
 export default client;

--- a/src/mainview/posthog.ts
+++ b/src/mainview/posthog.ts
@@ -10,7 +10,16 @@ if ((!apiKey || !apiHost) && import.meta.env.DEV) {
 	);
 }
 
-const client: Pick<typeof posthog, "capture"> = apiKey && apiHost
+// The flag APIs are exposed next to capture so feature-flags.ts can refresh and
+// read flags; the rest of the posthog surface stays out of reach. With no key
+// configured the no-op client reports every flag as unset, which lands the app
+// on the shipped defaults in src/shared/feature-flags.ts.
+type PostHogClient = Pick<
+	typeof posthog,
+	"capture" | "getFeatureFlag" | "onFeatureFlags" | "reloadFeatureFlags"
+>;
+
+const client: PostHogClient = apiKey && apiHost
 	? posthog.init(apiKey, {
 		api_host: apiHost,
 		defaults: "2026-05-30",
@@ -20,6 +29,11 @@ const client: Pick<typeof posthog, "capture"> = apiKey && apiHost
 			capture_console_errors: false,
 		},
 	})
-	: { capture: () => undefined };
+	: {
+		capture: () => undefined,
+		getFeatureFlag: () => undefined,
+		onFeatureFlags: () => () => undefined,
+		reloadFeatureFlags: () => undefined,
+	};
 
 export default client;

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -102,6 +102,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	menuAction: (payload) => window.dispatchEvent(new CustomEvent("rpc:menuAction", { detail: payload })),
 	showQuitDialog: () => window.dispatchEvent(new CustomEvent("rpc:showQuitDialog")),
 	showAbout: (payload) => window.dispatchEvent(new CustomEvent("rpc:showAbout", { detail: payload })),
+	showFeatureFlags: () => window.dispatchEvent(new CustomEvent("rpc:showFeatureFlags")),
 	updateCheckOutcome: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateCheckOutcome", { detail: payload })),
 };
 

--- a/src/mainview/settings-registry.ts
+++ b/src/mainview/settings-registry.ts
@@ -386,6 +386,8 @@ export const SETTINGS_ENTRIES = [
 /** GlobalSettings fields intentionally kept outside the visible settings registry. */
 export const SETTINGS_GLOBAL_FIELD_EXCLUSIONS = [
 	"resolvedTheme",
+	// Machine identity for analytics, not a preference — read-only in Debug -> Feature Flags.
+	"analyticsDistinctId",
 	"customBinaryPaths",
 	"agentBinaryPaths",
 	"importShellEnv",
@@ -401,6 +403,7 @@ export const GLOBAL_SETTINGS_FIELDS = [
 	"updateChannel",
 	"theme",
 	"resolvedTheme",
+	"analyticsDistinctId",
 	"cloneBaseDirectory",
 	"customBinaryPaths",
 	"agentBinaryPaths",

--- a/src/shared/application-menu.ts
+++ b/src/shared/application-menu.ts
@@ -87,6 +87,7 @@ export const MENU_ACTIONS = {
 	openLogsDirectory: "open-logs-directory",
 	gaugeDemo: "gauge-demo",
 	viewportLab: "viewport-lab",
+	featureFlags: "feature-flags",
 	nativePaneLayoutLab: "native-pane-layout-lab",
 	updatePopoverPreview: "update-popover-preview",
 	debugPlaySoundCompleted: "debug-play-sound-completed",
@@ -666,6 +667,7 @@ function viewMenu(): ApplicationMenuItemConfig {
 				submenu: [
 					item({ label: "Gauge Demo", action: MENU_ACTIONS.gaugeDemo }),
 					item({ label: "Viewport Lab", action: MENU_ACTIONS.viewportLab }),
+			item({ label: "Feature Flags", action: MENU_ACTIONS.featureFlags }),
 					item({ label: "Native Pane Layout Lab", action: MENU_ACTIONS.nativePaneLayoutLab }),
 					item({ label: "Update Popover Preview", action: MENU_ACTIONS.updatePopoverPreview }),
 					SEP,

--- a/src/shared/feature-flags.ts
+++ b/src/shared/feature-flags.ts
@@ -1,0 +1,30 @@
+/**
+ * PostHog feature flags the app reads, shared by the renderer (which evaluates
+ * them) and the bun process (which caches the pushed values).
+ *
+ * Flags are read synchronously from a cache; the renderer refreshes them every
+ * FEATURE_FLAG_REFRESH_MS. PostHog has no push channel, so that interval is
+ * also the worst-case propagation delay of a rollout or a kill.
+ * See decisions/2026/08/08/first-posthog-feature-flag.md.
+ */
+
+export const FEATURE_FLAGS = {
+	/** Leading-edge PTY flush + broadcast backpressure in src/bun/pty-server.ts. */
+	remoteTerminalLatency: "remote-terminal-latency",
+} as const;
+
+export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
+
+export const FEATURE_FLAG_KEYS: readonly FeatureFlagKey[] = Object.values(FEATURE_FLAGS);
+
+/**
+ * Served before the first successful fetch, when PostHog is unreachable, and
+ * when no PostHog key is configured: every flag is off, i.e. the behaviour the
+ * app already shipped.
+ */
+export const FEATURE_FLAG_DEFAULTS: Record<FeatureFlagKey, boolean> = {
+	[FEATURE_FLAGS.remoteTerminalLatency]: false,
+};
+
+/** How often the renderer re-asks PostHog. Tune here, never at a call site. */
+export const FEATURE_FLAG_REFRESH_MS = 5 * 60 * 1000;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3947,6 +3947,15 @@ export type AppRPCSchema = {
 				response: void;
 			};
 			/**
+			 * PostHog feature-flag values, pushed by the Electrobun renderer every
+			 * FEATURE_FLAG_REFRESH_MS. The bun process never queries PostHog itself
+			 * and holds the last pushed value — see src/bun/feature-flags.ts.
+			 */
+			setFeatureFlags: {
+				params: { flags: Record<string, boolean> };
+				response: void;
+			};
+			/**
 			 * Pushed by the renderer whenever the current route changes; the bun
 			 * side uses it to rebuild the native menu so context-aware items
 			 * (task / project / terminal) render disabled when irrelevant.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -843,6 +843,13 @@ export interface GlobalSettings {
 	updateChannel: UpdateChannel;
 	theme?: "dark" | "light" | "system";
 	resolvedTheme?: "dark" | "light";
+	/**
+	 * The id PostHog buckets this install by, owned by bun so every renderer —
+	 * desktop window and remote browser alike — reports the same one. Seeded once
+	 * from the desktop renderer's own posthog-js id so existing installs keep
+	 * their person instead of splitting into a second one.
+	 */
+	analyticsDistinctId?: string;
 	cloneBaseDirectory?: string;
 	customBinaryPaths?: Record<string, string>; // requirementId â custom binary path
 	agentBinaryPaths?: Record<string, string>; // agentId â resolved binary path
@@ -3955,6 +3962,19 @@ export type AppRPCSchema = {
 				params: { flags: Record<string, boolean> };
 				response: void;
 			};
+			/** Every declared flag with the value bun currently gates code on. */
+			getFeatureFlags: {
+				params: void;
+				response: Record<string, boolean>;
+			};
+			/**
+			 * The install-wide PostHog distinct id. `seed` is the calling renderer's
+			 * own posthog-js id, adopted only when bun has none stored yet.
+			 */
+			resolveAnalyticsDistinctId: {
+				params: { seed?: string };
+				response: { distinctId: string };
+			};
 			/**
 			 * Pushed by the renderer whenever the current route changes; the bun
 			 * side uses it to rebuild the native menu so context-aware items
@@ -4363,6 +4383,8 @@ export type AppRPCSchema = {
 			showQuitDialog: {};
 			/** Open the in-app About modal (replaces the native About message box). */
 			showAbout: { version: string; buildChannel?: string };
+			/** Open the Debug → Feature Flags inspector. */
+			showFeatureFlags: {};
 			/**
 			 * Result of a manual "Check for Updates" menu action, surfaced as a toast.
 			 * `available` updates flow through `updateAvailable` instead (header plaque).

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3969,10 +3969,13 @@ export type AppRPCSchema = {
 			};
 			/**
 			 * The install-wide PostHog distinct id. `seed` is the calling renderer's
-			 * own posthog-js id, adopted only when bun has none stored yet.
+			 * own posthog-js id. Adopted when bun has none stored yet, or when the
+			 * caller is `authoritative` — the desktop renderer, whose posthog-js
+			 * identity outlives every attached browser and is the one flags are
+			 * really evaluated against.
 			 */
 			resolveAnalyticsDistinctId: {
-				params: { seed?: string };
+				params: { seed?: string; authoritative?: boolean };
 				response: { distinctId: string };
 			};
 			/**


### PR DESCRIPTION
A keystroke echo in remote mode carried ~32 ms of our own fixed lag before any network cost. Measured on the host with ICMP: Cloudflare's geographic detour is a ~5 ms floor — roughly 6x smaller than our own pipeline. Two blockers in `src/bun/pty-server.ts`, both fixed here:

**Leading-edge flush.** `enqueuePtyData` scheduled a 16 ms `setTimeout` and never fast-pathed the first chunk, despite the comment above it promising exactly that. Every isolated keystroke ate the full window, 100% of the time. The first chunk in a window is now sent immediately; the window still coalesces everything after it.

**Broadcast backpressure.** The broadcast wrote into client sockets with no buffered-amount check. Over the tunnel frames pile up and the terminal animates smoothly but behind reality. The batch window now widens (16 ms → 250 ms) as the socket backs up. Nothing is ever dropped — the ANSI stream is stateful, so throttling cadence is correct and discarding output is not.

The only socket in the chain that ever backs up faces the tunnel and lives in `remote-access-server.ts`; every socket in `session.clients` is loopback and always looks idle. Hence `registerBackpressureProbe`, injected through `StartOptions` like `getPtyPort` — without it the backpressure half would measure nothing.

**The project's first feature flag.** Both fixes flip together on one PostHog flag (`remote-terminal-latency`), refreshed every 5 minutes without a restart. The Electrobun renderer evaluates flags with `posthog-js` and pushes them to bun over a new `setFeatureFlags` RPC; bun caches them and reads synchronously on the per-chunk hot path. Only the desktop renderer pushes, so a machine acts on one distinct id. Local evaluation is banned (it needs a personal API key inside a desktop app), and there is no instant kill switch at any interval — PostHog has no push channel, so the poll interval *is* the worst-case propagation delay. Defaults, mid-session flip safety, id consistency and the flag-removal plan are in `decisions/2026/08/08/first-posthog-feature-flag.md`.

Flags default to off everywhere they are unknown, so an install that never reaches PostHog behaves exactly as before.