### PR TITLE
Keep the full shared-image history per task

### DIFF
--- a/change-logs/2026/08/10/fix-uncap-task-shared-images.md
+++ b/change-logs/2026/08/10/fix-uncap-task-shared-images.md
@@ -1,0 +1,3 @@
+Short: Task image history is no longer capped
+
+Images an agent shares with `dev3 show-image` are no longer capped at 50 per task — the 51st image used to silently drop and delete the oldest one. The whole history is kept now, exactly like shared artifacts, and the stored files still die with the worktree.

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -479,7 +479,7 @@ ux_architecture:
         store: "~/.dev3.0/worktrees/{slug}/shared-images/ — copied by bun (src/bun/shared-images.ts), sibling of the DnD uploads/ dir (decision 036), in the worktree tree (shares its lifecycle). Model: Task.sharedImages: SharedImage[] in tasks.json (atomic write)."
         rationale: "Worktree location per the user's call (not data/). ADDITIVE — no rename/move/delete of existing on-disk state (frozen ~/.dev3.0/ layout invariants). Works in remote/browser because bun reads the file and returns base64; the renderer never reads a local path."
         bytes_to_webview: "Reuses the existing readImageBase64(path) -> { dataUrl } RPC (base64), works on both transports. Follow-up: custom protocol / dev-server static route if base64 is heavy."
-        retention: "Bounded — last 50 images/task, drop+delete oldest at write time (pruneSharedImages, app-managed content cleanup; NOT a load-time user-state migration)."
+        retention: "Unbounded — every image a task shares is kept, matching shared artifacts; the stored files live in the worktree and are removed with it."
       arrival_policy:
         always: "copy+persist images, mark unseen, raise attention badge (cliAttention/addBell path) + toast (cliToast path with custom onClick -> open viewer)."
         focused_on_this_task: "auto-open the viewer at the newest image (you are already here — it 'pops')."

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
-import { getAllowedTransitions, type Project, type Task, type CliRequest, type TaskNote, type SharedArtifact } from "../../shared/types";
+import { getAllowedTransitions, type Project, type Task, type CliRequest, type TaskNote, type SharedArtifact, type SharedImage } from "../../shared/types";
 
 // ---- Mocks ----
 
@@ -35,11 +35,6 @@ vi.mock("../shared-images", () => ({
 		createdAt: 1,
 		...(caption ? { caption } : {}),
 	})),
-	pruneSharedImages: vi.fn((existing: unknown[] | undefined, incoming: unknown[]) => ({
-		kept: [...(existing ?? []), ...incoming],
-		dropped: [],
-	})),
-	deleteSharedImageFiles: vi.fn(),
 }));
 
 vi.mock("../shared-artifacts", () => ({
@@ -1199,6 +1194,35 @@ describe("ui.show-image", () => {
 				expect.objectContaining({ originalPath: "/tmp/b.png", caption: "after" }),
 			]),
 		);
+	});
+
+	it("retains image history beyond the previous per-task cap", async () => {
+		const project = makeProject();
+		const existing: SharedImage[] = Array.from({ length: 50 }, (_, index) => ({
+			id: `old-${index}`,
+			storedPath: `/wt/shared-images/old-${index}.png`,
+			originalPath: `/tmp/old-${index}.png`,
+			name: `old-${index}.png`,
+			mime: "image/png",
+			bytes: 10,
+			createdAt: index,
+		}));
+		const task = makeTask({ sharedImages: existing });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		let persisted: Task | undefined;
+		vi.mocked(data.updateTaskWith).mockImplementation(async (_project, _taskId, mutator) => {
+			const { updates, result } = await (mutator as (t: Task) => { updates: Partial<Task>; result: unknown })(task);
+			persisted = { ...task, ...updates };
+			return { task: persisted, result } as never;
+		});
+
+		await handleRequest(makeRequest("ui.show-image", { taskId: task.id, projectId: project.id, paths: ["/tmp/new.png"] }));
+
+		expect(persisted?.sharedImages?.map((image) => image.id)).toEqual([
+			...existing.map((image) => image.id),
+			"img-/tmp/new.png",
+		]);
 	});
 
 	it("errors when no paths are given", async () => {

--- a/src/bun/__tests__/shared-images.test.ts
+++ b/src/bun/__tests__/shared-images.test.ts
@@ -2,7 +2,6 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SharedImage } from "../../shared/types";
 
 const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/shared-images`);
 
@@ -11,15 +10,7 @@ vi.mock("../paths", () => ({
 	OPS_DIR: `${TEST_HOME}/ops`,
 }));
 
-import {
-	SharedImageError,
-	deleteSharedImageFiles,
-	imageExt,
-	isSupportedImage,
-	pruneSharedImages,
-	saveSharedImage,
-	sharedImagesDir,
-} from "../shared-images";
+import { SharedImageError, imageExt, isSupportedImage, saveSharedImage, sharedImagesDir } from "../shared-images";
 
 const SRC_DIR = mkdtempSync(join(tmpdir(), "dev3-shared-src-"));
 
@@ -27,18 +18,6 @@ afterAll(() => {
 	rmSync(TEST_HOME, { recursive: true, force: true });
 	rmSync(SRC_DIR, { recursive: true, force: true });
 });
-
-function makeImage(id: string, createdAt: number): SharedImage {
-	return {
-		id,
-		storedPath: `${TEST_HOME}/x/${id}.png`,
-		originalPath: `/src/${id}.png`,
-		name: `${id}.png`,
-		mime: "image/png",
-		bytes: 10,
-		createdAt,
-	};
-}
 
 describe("imageExt / isSupportedImage", () => {
 	it("normalizes the extension to lowercase without the dot", () => {
@@ -52,30 +31,6 @@ describe("imageExt / isSupportedImage", () => {
 		expect(isSupportedImage("/a.webp")).toBe(true);
 		expect(isSupportedImage("/a.svg")).toBe(false);
 		expect(isSupportedImage("/a.txt")).toBe(false);
-	});
-});
-
-describe("pruneSharedImages", () => {
-	it("keeps everything when under the cap", () => {
-		const existing = [makeImage("a", 1), makeImage("b", 2)];
-		const incoming = [makeImage("c", 3)];
-		const { kept, dropped } = pruneSharedImages(existing, incoming, 50);
-		expect(kept.map((i) => i.id)).toEqual(["a", "b", "c"]);
-		expect(dropped).toEqual([]);
-	});
-
-	it("drops the oldest when over the cap, keeping newest in order", () => {
-		const existing = [makeImage("a", 1), makeImage("b", 2), makeImage("c", 3)];
-		const incoming = [makeImage("d", 4)];
-		const { kept, dropped } = pruneSharedImages(existing, incoming, 2);
-		expect(kept.map((i) => i.id)).toEqual(["c", "d"]);
-		expect(dropped.map((i) => i.id)).toEqual(["a", "b"]);
-	});
-
-	it("treats undefined existing as empty", () => {
-		const { kept, dropped } = pruneSharedImages(undefined, [makeImage("a", 1)], 50);
-		expect(kept.map((i) => i.id)).toEqual(["a"]);
-		expect(dropped).toEqual([]);
 	});
 });
 
@@ -124,16 +79,5 @@ describe("saveSharedImage", () => {
 		const src = join(SRC_DIR, "notes.txt");
 		writeFileSync(src, "hi");
 		expect(() => saveSharedImage("/my/project", src)).toThrow(/Unsupported image type/);
-	});
-});
-
-describe("deleteSharedImageFiles", () => {
-	it("removes the stored files and never throws on a missing one", () => {
-		const src = join(SRC_DIR, "todelete.png");
-		writeFileSync(src, "X");
-		const rec = saveSharedImage("/my/project", src);
-		expect(existsSync(rec.storedPath)).toBe(true);
-		deleteSharedImageFiles([rec, makeImage("ghost", 1)]);
-		expect(existsSync(rec.storedPath)).toBe(false);
 	});
 });

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -3,10 +3,10 @@ import type { AgentMessageSource, CliRequest, CliResponse, CustomColumn, Label, 
 import { isValidNotificationDurationMs, NOTIFICATION_MAX_DURATION_MS, NOTIFICATION_MIN_DURATION_MS } from "../shared/duration";
 import { socketMetaPathFor } from "../shared/socket-meta";
 import { isCliEndpointHandle } from "../shared/cli-endpoint";
-import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, MAX_SHARED_IMAGES_PER_TASK, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, titleFromDescription } from "../shared/types";
+import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, titleFromDescription } from "../shared/types";
 import { CODEX_STATUS_HOOK_EVENTS, getCodexHookTargetStatus, type CodexStatusHookEvent } from "../shared/agent-hooks";
 import { CLAUDE_STOP_FAILURE_ERRORS, describeClaudeStopFailure, type ClaudeStopFailureError } from "../shared/agent-stop-failure";
-import { SharedImageError, deleteSharedImageFiles, pruneSharedImages, saveSharedImage } from "./shared-images";
+import { SharedImageError, saveSharedImage } from "./shared-images";
 import { SharedArtifactError, saveSharedArtifact } from "./shared-artifacts";
 import { addAutomation, deleteAutomation, loadAutomations, updateAutomation } from "./automations-data";
 import { createAgentRequest, type AgentLaunchChoice } from "./agent-requests";
@@ -1320,12 +1320,11 @@ const handlers: Record<string, Handler> = {
 			throw new Error(`Failed to store image: ${err instanceof Error ? err.message : String(err)}`);
 		}
 
-		// Append + enforce the per-task cap inside the file lock; delete pruned files.
-		const { task: updated, result: dropped } = await data.updateTaskWith<SharedImage[]>(project, task.id, (current) => {
-			const { kept, dropped } = pruneSharedImages(current.sharedImages, incoming, MAX_SHARED_IMAGES_PER_TASK);
-			return { updates: { sharedImages: kept }, result: dropped };
+		// Append inside the file lock. The history is uncapped — the stored files
+		// live in the worktree and die with it.
+		const { task: updated } = await data.updateTaskWith<void>(project, task.id, (current) => {
+			return { updates: { sharedImages: [...(current.sharedImages ?? []), ...incoming] }, result: undefined };
 		});
-		if (dropped.length > 0) deleteSharedImageFiles(dropped);
 
 		// Persist to state everywhere (badge + history) regardless of focus mode.
 		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });

--- a/src/bun/shared-images.ts
+++ b/src/bun/shared-images.ts
@@ -1,13 +1,10 @@
-import { copyFileSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { basename, extname } from "node:path";
 import type { SharedImage } from "../shared/types";
 import { MAX_SHARED_IMAGE_BYTES, SHARED_IMAGE_EXTS } from "../shared/types";
 import { DEV3_HOME } from "./paths";
 import { projectStorageKey } from "../shared/project-storage-key";
-import { createLogger } from "./logger";
 import { isFullyQualifiedPath } from "../shared/absolute-path";
-
-const log = createLogger("shared-images");
 
 const SUPPORTED_EXTS = new Set(SHARED_IMAGE_EXTS);
 
@@ -95,30 +92,3 @@ export function saveSharedImage(projectPath: string, sourcePath: string, caption
 	};
 }
 
-/**
- * Merge new images onto the existing history and enforce the per-task cap by
- * dropping the oldest. Returns the kept list plus the dropped records (whose
- * files the caller should delete). Pure — no I/O.
- */
-export function pruneSharedImages(
-	existing: SharedImage[] | undefined,
-	incoming: SharedImage[],
-	cap: number,
-): { kept: SharedImage[]; dropped: SharedImage[] } {
-	const all = [...(existing ?? []), ...incoming];
-	if (all.length <= cap) return { kept: all, dropped: [] };
-	const dropped = all.slice(0, all.length - cap);
-	const kept = all.slice(all.length - cap);
-	return { kept, dropped };
-}
-
-/** Best-effort delete of pruned image files. Never throws. */
-export function deleteSharedImageFiles(images: SharedImage[]): void {
-	for (const img of images) {
-		try {
-			rmSync(img.storedPath, { force: true });
-		} catch (err) {
-			log.debug("Failed to delete pruned shared image", { path: img.storedPath, error: String(err) });
-		}
-	}
-}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1562,9 +1562,9 @@ export interface Task {
 	completedDiffStats?: CompletedDiffStats | null;
 	/**
 	 * Images the agent surfaced to the human via `dev3 show-image`, oldest→newest.
-	 * Displayed in the TaskImageViewer lightbox. Capped at
-	 * {@link MAX_SHARED_IMAGES_PER_TASK}; the copied files live in the project
-	 * worktree `shared-images/` dir. See {@link SharedImage}.
+	 * Displayed in the TaskImageViewer lightbox. Uncapped — every image the task
+	 * shared is kept; the copied files live in the project worktree
+	 * `shared-images/` dir and die with the worktree. See {@link SharedImage}.
 	 */
 	sharedImages?: SharedImage[];
 	/**
@@ -1792,9 +1792,6 @@ export const MAX_SCHEDULED_MESSAGE_LENGTH = 10_000;
  * real ceiling a large review hits (decision 198).
  */
 export const AGENT_MESSAGE_SPILL_THRESHOLD = 8_000;
-
-/** Per-task cap on retained shared images; oldest are pruned (files deleted) past this. */
-export const MAX_SHARED_IMAGES_PER_TASK = 50;
 
 /** Raster image extensions accepted by `dev3 show-image` (lowercase, no dot).
  * SVG is excluded on purpose — an inline data-URI SVG in the webview is an XSS


### PR DESCRIPTION
Images shared with `dev3 show-image` were capped at 50 per task: the 51st image silently dropped the oldest record **and deleted its file from disk**, so the history was destroyed rather than just trimmed in the UI.

The cap is gone. `ui.show-image` now appends to `Task.sharedImages` exactly like `ui.show-artifact` appends to `Task.sharedArtifacts` (artifacts lost their equivalent cap earlier). Stored files still live in the project worktree's `shared-images/` dir and are removed with the worktree, so growth stays bounded by task lifetime.

- Removed `MAX_SHARED_IMAGES_PER_TASK`, `pruneSharedImages`, and `deleteSharedImageFiles` (no deprecation shims).
- Per-call limits are unchanged: still 20 images per `dev3 show-image` invocation and 25 MB per file.
- Updated the retention note in `docs/ux/ux-architecture.yaml` and added `retains image history beyond the previous per-task cap` to the handler suite.