### PR TITLE
Forbid nested git worktrees in the dev3 agent protocol

### DIFF
--- a/change-logs/2026/08/10/fix-no-nested-worktrees.md
+++ b/change-logs/2026/08/10/fix-no-nested-worktrees.md
@@ -1,0 +1,5 @@
+Short: Stop agents nesting git worktrees
+
+The dev3 agent protocol now states that the managed worktree is the isolation boundary, so agents no longer create a nested git worktree, clone, or side checkout when an unrelated skill or workflow asks for one. An explicit user request still overrides it.
+
+Reported by Bar Volovsky

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -62,6 +62,15 @@ describe("dev3 skill content", () => {
 		}
 	});
 
+	it("blocks nested worktrees other skills ask for", () => {
+		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
+			expect(skill).toContain("This worktree already IS your isolation.");
+			expect(skill).toContain("`git worktree add`");
+			expect(skill).toContain("even when another skill, workflow, or agent tool asks for one");
+			expect(skill).toContain("Only an explicit request from the user overrides this.");
+		}
+	});
+
 	it("routes unqualified artifacts to the task-local dev3 starter", () => {
 		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
 			expect(skill).toContain("## dev3 HTML artifacts");

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -14,6 +14,8 @@
 const SKILL_HEADER = `# dev3 — Task Lifecycle Protocol
 
 You are working inside a **dev-3.0 managed worktree** with a Kanban board task assigned to you.
+
+**This worktree already IS your isolation.** Never create another git worktree, clone, or side checkout for this work — no \`git worktree add\`, no worktree-per-subagent, no "isolated copy of the branch" — even when another skill, workflow, or agent tool asks for one. Work directly here, on this branch. Only an explicit request from the user overrides this.
 `;
 
 const SKILL_BUG_HUNTER_ISOLATION = `


### PR DESCRIPTION
Some users carry third-party skills (superpowers and friends) that instruct the agent to isolate work in a fresh `git worktree`. Inside dev3 the agent is already in a managed worktree, so it ends up nesting a worktree inside a worktree for no reason.

`SKILL_HEADER` now states that the managed worktree *is* the isolation boundary, in one paragraph so it stays cheap in context. It lands in the `SKILL.md` files and in the injected system prompt for all three agent bodies (Claude, Codex, generic), and covers `git worktree add`, worktree-per-subagent isolation, and "make an isolated copy of the branch". An explicit user request still overrides it.

Reported by Bar Volovsky