### PR TITLE
Save project settings into the config layer that wins the cascade

### DIFF
--- a/.dev3/config.json
+++ b/.dev3/config.json
@@ -6,12 +6,5 @@
     "node_modules",
     "build",
     "dist"
-  ],
-  "builtinColumnAgents": {
-    "review-by-ai": {
-      "agentId": "builtin-claude",
-      "configId": "claude-bypass-sonnet",
-      "prompt": ""
-    }
-  }
+  ]
 }

--- a/change-logs/2026/08/10/fix-ai-review-config-reset.md
+++ b/change-logs/2026/08/10/fix-ai-review-config-reset.md
@@ -1,0 +1,3 @@
+Short: AI Review settings stop resetting
+
+Project Settings saves no longer get silently reverted when a .dev3 config file already owns the field — the value is written back into that file instead of projects.json, and the Project tab now shows the config that will actually run. The AI Review column also defaults to Claude Opus 5 (X-High) and rewrites the removed `claude-bypass-sonnet` preset instead of falling back to whatever preset happens to sit first in the list.

--- a/decisions/2026/08/10/project-settings-save-into-winning-config-layer.md
+++ b/decisions/2026/08/10/project-settings-save-into-winning-config-layer.md
@@ -1,0 +1,43 @@
+# Project Settings saves go into the config layer that wins the cascade
+
+## Context
+
+`resolveProjectConfig` ranks `.dev3/config.local.json` > `.dev3/config.json` > the `Project`
+object in `projects.json` > `DEFAULTS`. The Project Settings tab always saved through
+`updateProjectSettings`, which writes the `Project` object — the lowest file-independent layer.
+For any field a `.dev3` file already declared, the save looked successful (the handler echoed the
+raw record back and the UI dispatched it) and then reverted on the next `getProjects`, which
+resolves the cascade. This repo's own `.dev3/config.json` pinned `builtinColumnAgents`, so the AI
+Review preset was unchangeable from the UI.
+
+## Investigation
+
+`src/bun/rpc-handlers/app-handlers.ts:164` resolves every project on read, while
+`updateProjectSettings` returned the unresolved record — the only reason the change appeared to
+stick until a reload. Separately, `findConfig` (`src/bun/agents.ts`) fell back to
+`configurations[0]` for an unknown preset id, so the long-dead `claude-bypass-sonnet` stored in
+every project silently launched the first preset in the list rather than a Sonnet one.
+
+## Decision
+
+`repoConfig.saveConfigToWinningLayer` (`src/bun/repo-config.ts`) routes each incoming key to the
+highest `.dev3` layer that already defines it and returns the rest for `projects.json`;
+`updateProjectSettings` uses it and returns the resolved project. `env` is excluded — it merges per
+key (decision 179) and may hold personal secrets that must not land in a committed file. Unknown
+preset ids now route through `DEPRECATED_DEFAULT_CONFIG_REMAP` before falling back to the agent's
+`defaultConfigId`, and `remapColumnAgents` (`src/shared/types.ts`) rewrites stored column agents on
+both read paths.
+
+## Risks
+
+Saving from the Project tab can now modify a git-tracked `.dev3/config.json`, which shows up as a
+working-tree change. That is the intended trade: the alternative is a save that provably does
+nothing. No file is ever created by this path — only keys already present in an existing file are
+redirected.
+
+## Alternatives considered
+
+Dropping `builtinColumnAgents` from `DEV3_REPO_CONFIG_KEYS` would fix the AI Review case alone and
+break sharing the review preset through the repo, leaving every other field equally broken.
+Disabling the inputs when a file override exists is honest but leaves the user editing JSON by hand
+for a setting the UI already renders.

--- a/src/bun/__tests__/repo-config.test.ts
+++ b/src/bun/__tests__/repo-config.test.ts
@@ -30,6 +30,7 @@ import {
 	resolveProjectEnv,
 	hasRepoConfig,
 	hasLocalConfig,
+	saveConfigToWinningLayer,
 } from "../repo-config";
 import type { Project, Dev3RepoConfig } from "../../shared/types";
 
@@ -964,5 +965,66 @@ describe("env config cascade (per-key merge)", () => {
 		writeConfig(WT_DIR, "config.local.json", { env: { B: "wt-local" } });
 
 		expect(await resolveProjectEnv(project, WT_DIR)).toEqual({ A: "project", B: "wt-local" });
+	});
+});
+
+describe("saveConfigToWinningLayer", () => {
+	const REVIEW = { "review-by-ai": { agentId: "builtin-claude", configId: "claude-auto-opus5-xhigh", prompt: "" } };
+
+	function writeConfig(file: string, content: object) {
+		mkdirSync(join(TEST_DIR, ".dev3"), { recursive: true });
+		writeFileSync(join(TEST_DIR, ".dev3", file), JSON.stringify(content));
+	}
+	function readConfig(file: string): Dev3RepoConfig {
+		return JSON.parse(readFileSync(join(TEST_DIR, ".dev3", file), "utf-8"));
+	}
+
+	it("returns every key for the project object when no config file exists", async () => {
+		const leftover = await saveConfigToWinningLayer(TEST_DIR, { setupScript: "bun install" });
+		expect(leftover).toEqual({ setupScript: "bun install" });
+		expect(existsSync(join(TEST_DIR, ".dev3", "config.json"))).toBe(false);
+	});
+
+	it("writes a key the repo config already owns back into that file", async () => {
+		writeConfig("config.json", { builtinColumnAgents: { "review-by-ai": { agentId: "builtin-claude", configId: "claude-bypass-sonnet", prompt: "" } }, setupScript: "old" });
+
+		const leftover = await saveConfigToWinningLayer(TEST_DIR, { builtinColumnAgents: REVIEW });
+
+		expect(leftover).toEqual({});
+		expect(readConfig("config.json").builtinColumnAgents).toEqual(REVIEW);
+		expect(readConfig("config.json").setupScript).toBe("old");
+	});
+
+	it("prefers the local config when both files own the key", async () => {
+		writeConfig("config.json", { builtinColumnAgents: {} as any, devScript: "repo" });
+		writeConfig("config.local.json", { devScript: "local" });
+
+		const leftover = await saveConfigToWinningLayer(TEST_DIR, { devScript: "next" });
+
+		expect(leftover).toEqual({});
+		expect(readConfig("config.local.json").devScript).toBe("next");
+		expect(readConfig("config.json").devScript).toBe("repo");
+	});
+
+	it("never redirects env — it merges per key and may hold secrets", async () => {
+		writeConfig("config.json", { env: { A: "repo" } });
+
+		const leftover = await saveConfigToWinningLayer(TEST_DIR, { env: { B: "ui" } });
+
+		expect(leftover).toEqual({ env: { B: "ui" } });
+		expect(readConfig("config.json").env).toEqual({ A: "repo" });
+	});
+});
+
+describe("resolveProjectConfig — removed column-agent presets", () => {
+	it("rewrites the stamped legacy review default to the current default", async () => {
+		mkdirSync(join(TEST_DIR, ".dev3"), { recursive: true });
+		writeFileSync(join(TEST_DIR, ".dev3", "config.json"), JSON.stringify({
+			builtinColumnAgents: { "review-by-ai": { agentId: "builtin-claude", configId: "claude-bypass-sonnet", prompt: "" } },
+		}));
+
+		const resolved = await resolveProjectConfig(makeProject());
+
+		expect(resolved.builtinColumnAgents?.["review-by-ai"].configId).toBe("claude-auto-opus5-xhigh");
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -12110,7 +12110,7 @@ describe("triggerColumnAgentIfNeeded", () => {
 
 		expect(agents.resolveCommandForAgent).toHaveBeenCalledWith(
 			"builtin-claude",
-			"claude-bypass-sonnet",
+			"claude-auto-opus5-xhigh",
 			expect.objectContaining({
 				taskDescription: expect.stringContaining("Review all changes on this branch"),
 			}),
@@ -12183,7 +12183,7 @@ describe("triggerColumnAgentIfNeeded", () => {
 
 		expect(agents.resolveCommandForAgent).toHaveBeenCalledWith(
 			"builtin-claude",
-			"claude-bypass-sonnet",
+			"claude-auto-opus5-xhigh",
 			expect.anything(),
 			expect.anything(),
 		);

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -3,7 +3,7 @@ import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AgentConfiguration, CodingAgent, LlmProvider, Project } from "../shared/types";
-import { DEFAULT_AGENTS } from "../shared/types";
+import { DEFAULT_AGENTS, DEPRECATED_DEFAULT_CONFIG_REMAP } from "../shared/types";
 export { skillInvocationPrefix } from "../shared/types";
 import { buildProviderEnv, getProviderDefinition, providerOmitsModelFlag, providerPinnedModel } from "../shared/llm-provider";
 import { createLogger } from "./logger";
@@ -477,17 +477,17 @@ export function findConfig(
 	agent: CodingAgent,
 	configId: string | null | undefined,
 ): AgentConfiguration | undefined {
-	if (!configId) {
-		// Fall back to agent's defaultConfigId, then first config
-		return (
-			agent.configurations.find((c) => c.id === agent.defaultConfigId) ||
-			agent.configurations[0]
-		);
-	}
-	return (
-		agent.configurations.find((c) => c.id === configId) ||
-		agent.configurations[0]
-	);
+	// Fall back to the agent's defaultConfigId, then the first config
+	const fallback = () =>
+		agent.configurations.find((c) => c.id === agent.defaultConfigId) ||
+		agent.configurations[0];
+	if (!configId) return fallback();
+	const exact = agent.configurations.find((c) => c.id === configId);
+	if (exact) return exact;
+	// A removed preset id (e.g. "claude-bypass-sonnet") must land on its documented
+	// successor, never on whatever happens to sit first in the list.
+	const remapped = DEPRECATED_DEFAULT_CONFIG_REMAP[configId];
+	return (remapped && agent.configurations.find((c) => c.id === remapped)) || fallback();
 }
 
 /** Default env vars injected for Claude-based agents. */

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import type { Project, Task, TaskHistoryChange, TaskHistoryEntry, TaskPriority, TaskStatus, TipState } from "../shared/types";
-import { comparePriority, compareTaskSortRank, DEFAULT_PRIORITY, getTaskOverview, getTaskTitle, isStatusGuardBlocked, titleFromDescription } from "../shared/types";
+import { comparePriority, compareTaskSortRank, DEFAULT_PRIORITY, DEFAULT_REVIEW_AGENT_ID, DEFAULT_REVIEW_CONFIG_ID, getTaskOverview, getTaskTitle, isStatusGuardBlocked, remapColumnAgents, titleFromDescription } from "../shared/types";
 import {
 	decodeTerminalBackend,
 	isTerminalBackendIdentity,
@@ -194,13 +194,20 @@ async function rawLoadAllProjects(options?: { strict?: boolean; persistMigration
 				if (legacy.enabled !== false) {
 					project.builtinColumnAgents = {
 						"review-by-ai": {
-							agentId: legacy.agentId ?? "builtin-claude",
-							configId: legacy.configId ?? "claude-bypass-sonnet",
+							agentId: legacy.agentId ?? DEFAULT_REVIEW_AGENT_ID,
+							configId: legacy.configId ?? DEFAULT_REVIEW_CONFIG_ID,
 							prompt: legacy.reviewPrompt ?? "",
 						},
 					};
 				}
 				delete (project as any).aiReview;
+				needsSave = true;
+			}
+			// Rewrite column-agent presets whose id no longer exists (e.g. the removed
+			// "claude-bypass-sonnet"), which would otherwise resolve to a random preset.
+			const remapped = remapColumnAgents(project.builtinColumnAgents);
+			if (remapped !== project.builtinColumnAgents) {
+				project.builtinColumnAgents = remapped;
 				needsSave = true;
 			}
 		}

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -15,6 +15,8 @@ import type {
 } from "../../shared/types";
 import {
 	buildTaskDialogSubject,
+	DEFAULT_REVIEW_AGENT_ID,
+	DEFAULT_REVIEW_CONFIG_ID,
 	DEFAULT_REVIEW_PROMPT,
 	getPreparingStageProgress,
 	getTaskTitle,
@@ -497,8 +499,8 @@ async function columnAgentConfig(
 		const configured = resolved.builtinColumnAgents?.["review-by-ai"];
 		return {
 			config: {
-				agentId: configured?.agentId || "builtin-claude",
-				configId: configured?.configId || "claude-bypass-sonnet",
+				agentId: configured?.agentId || DEFAULT_REVIEW_AGENT_ID,
+				configId: configured?.configId || DEFAULT_REVIEW_CONFIG_ID,
 				prompt: configured?.prompt || DEFAULT_REVIEW_PROMPT,
 			},
 			paneTitle: "AI Review",

--- a/src/bun/repo-config.ts
+++ b/src/bun/repo-config.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import type { Project, Dev3RepoConfig, ConfigSourceEntry, ResolvedConfigSource } from "../shared/types";
-import { DEV3_REPO_CONFIG_KEYS } from "../shared/types";
+import { DEV3_REPO_CONFIG_KEYS, remapColumnAgents } from "../shared/types";
 import { sanitizeEnvMap } from "../shared/env-text";
 import { createLogger } from "./logger";
 import * as git from "./git";
@@ -219,6 +219,8 @@ async function applyConfigCascade(
 		val = val ?? (project as any)[key] ?? DEFAULTS[key];
 		if (val !== undefined) (resolved as any)[key] = val;
 	}
+	// A config file may still name a preset that was removed from DEFAULT_AGENTS.
+	resolved.builtinColumnAgents = remapColumnAgents(resolved.builtinColumnAgents);
 
 	// `env` merges PER KEY across layers, unlike every other field: a repo file
 	// that sets one var must not erase UI- or local-configured vars (decision 179).
@@ -353,6 +355,45 @@ export async function migrateProjectConfig(project: Project, configPath?: string
 		fields: Object.keys(config),
 	});
 	await saveRepoConfig(basePath, config);
+}
+
+/**
+ * Route a Project Settings save to the layer that actually wins the cascade.
+ *
+ * Without this, saving a field that a .dev3 file already defines writes to
+ * projects.json, where the file immediately shadows it again — the value looks
+ * saved until the next read and then "resets" (the AI Review preset bug).
+ *
+ * Only keys ALREADY present in an existing file are redirected, so no file is
+ * created and no key silently migrates into git. `env` is never redirected: it
+ * merges per key across layers (decision 179) and may hold personal secrets.
+ *
+ * Returns the keys that still belong on the Project object.
+ */
+export async function saveConfigToWinningLayer(
+	basePath: string,
+	config: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const local = readJsonFile<Dev3RepoConfig>(`${basePath}/${LOCAL_CONFIG_FILE}`);
+	const repo = readJsonFile<Dev3RepoConfig>(`${basePath}/${CONFIG_FILE}`);
+	const localPatch: Record<string, unknown> = {};
+	const repoPatch: Record<string, unknown> = {};
+	const leftover: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(config)) {
+		const field = key as keyof Dev3RepoConfig;
+		if (field !== "env" && local && effective(local[field]) !== undefined) localPatch[key] = value;
+		else if (field !== "env" && repo && effective(repo[field]) !== undefined) repoPatch[key] = value;
+		else leftover[key] = value;
+	}
+	if (Object.keys(localPatch).length > 0) {
+		writeFileSync(`${basePath}/${LOCAL_CONFIG_FILE}`, JSON.stringify({ ...local, ...localPatch }, null, 2) + "\n");
+		log.info("Saved settings into overriding local config", { path: basePath, fields: Object.keys(localPatch) });
+	}
+	if (Object.keys(repoPatch).length > 0) {
+		writeFileSync(`${basePath}/${CONFIG_FILE}`, JSON.stringify({ ...repo, ...repoPatch }, null, 2) + "\n");
+		log.info("Saved settings into overriding repo config", { path: basePath, fields: Object.keys(repoPatch) });
+	}
+	return leftover;
 }
 
 /** Check if a .dev3/config.json file exists in the project. */

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -64,8 +64,14 @@ async function getProjectConfigFiles(params: { projectId: string }): Promise<{ h
 async function updateProjectSettings(params: { projectId: string } & ProjectSettingsUpdate): Promise<Project> {
 	log.info("→ updateProjectSettings", { projectId: params.projectId });
 	assertValidEnvParam(params.env);
+	const project = await data.getProject(params.projectId);
+	// Fields a .dev3 file already owns are written back to that file — writing them
+	// to projects.json would leave the file shadowing them on the very next read.
+	const configUpdates = project.kind === "virtual"
+		? extractConfigFromParams(params)
+		: await repoConfig.saveConfigToWinningLayer(project.path, extractConfigFromParams(params));
 	const updates = {
-		...extractConfigFromParams(params),
+		...configUpdates,
 		...(params.githubAuthHost !== undefined ? { githubAuthHost: params.githubAuthHost } : {}),
 		...(params.githubAuthLogin !== undefined ? { githubAuthLogin: params.githubAuthLogin } : {}),
 		...(params.sensitive !== undefined ? { sensitive: params.sensitive } : {}),
@@ -75,7 +81,10 @@ async function updateProjectSettings(params: { projectId: string } & ProjectSett
 			? { reviewModePrompt: params.reviewModePrompt.trim() ? params.reviewModePrompt : undefined }
 			: {}),
 	};
-	const updated = await data.updateProject(params.projectId, updates);
+	const saved = await data.updateProject(params.projectId, updates);
+	// Return the RESOLVED project: the caller renders what will actually run,
+	// not a raw record a config file may override.
+	const updated = saved.kind === "virtual" ? saved : await repoConfig.resolveProjectConfig(saved);
 	getPushMessage()?.("projectUpdated", { project: updated });
 	log.info("← updateProjectSettings done");
 	return updated;

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -699,8 +699,18 @@ describe("findConfig", () => {
 		expect(findConfig(agent, undefined)!.name).toBe("Second");
 	});
 
-	it("falls back to first config when configId is invalid", () => {
-		expect(findConfig(agent, "nonexistent")!.name).toBe("First");
+	it("falls back to defaultConfigId when configId is invalid", () => {
+		expect(findConfig(agent, "nonexistent")!.name).toBe("Second");
+	});
+
+	it("falls back to first config when configId is invalid and there is no default", () => {
+		const noDefault: CodingAgent = { ...agent, defaultConfigId: undefined };
+		expect(findConfig(noDefault, "nonexistent")!.name).toBe("First");
+	});
+
+	it("maps a removed preset id to its documented successor", () => {
+		const claude = DEFAULT_AGENTS.find((a) => a.id === "builtin-claude")!;
+		expect(findConfig(claude, "claude-bypass-sonnet")!.id).toBe("claude-bypass-sonnet5-xhigh");
 	});
 
 	it("falls back to first config when no defaultConfigId and no configId", () => {

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -4,7 +4,7 @@ import { confirm } from "../confirm";
 import type { CodingAgent, ColumnAgentConfig, CustomColumn, Dev3RepoConfig, GitHubAccount, GitHubCliStatus, Label, Project, SetupScriptLaunchMode, Task } from "../../shared/types";
 import { ACTIVE_STATUSES, getTaskTitle } from "../../shared/types";
 import { hasEnvLineBreak, parseEnvText, serializeEnvText } from "../../shared/env-text";
-import { CUSTOM_COLUMN_INSTRUCTION_MAX_CHARS, DEFAULT_REVIEW_PROMPT, resolveReviewModePrompt } from "../../shared/types";
+import { CUSTOM_COLUMN_INSTRUCTION_MAX_CHARS, DEFAULT_REVIEW_AGENT_ID, DEFAULT_REVIEW_CONFIG_ID, DEFAULT_REVIEW_PROMPT, resolveReviewModePrompt } from "../../shared/types";
 import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
@@ -16,8 +16,6 @@ import SettingsSection from "./global-settings/SettingsSection";
 import { matchesBranchQuery } from "./BranchSelector";
 import type { NavigationGuard } from "../navigation-guard";
 
-const DEFAULT_REVIEW_AGENT_ID = "builtin-claude";
-const DEFAULT_REVIEW_CONFIG_ID = "claude-bypass-sonnet";
 const CONFIG_BOOLEAN_DEFAULTS = {
 	autoReviewEnabled: false,
 	peerReviewEnabled: true,
@@ -1374,6 +1372,23 @@ function ProjectSettings({
 		const init = initialAiReviewRef.current;
 		return aiReviewAgentId !== init.agentId || aiReviewConfigId !== init.configId || aiReviewPrompt !== init.prompt;
 	}, [aiReviewAgentId, aiReviewConfigId, aiReviewPrompt]);
+
+	// The form is seeded by useState, which only runs on mount — re-sync when the
+	// project's effective review config changes (initial load, save, push update).
+	// Unsaved edits win: never clobber what the user is in the middle of typing.
+	const reviewConfigKey = JSON.stringify(reviewConfig ?? null);
+	useEffect(() => {
+		if (isAiReviewDirty()) return;
+		const next = {
+			agentId: reviewConfig?.agentId ?? DEFAULT_REVIEW_AGENT_ID,
+			configId: reviewConfig?.configId ?? DEFAULT_REVIEW_CONFIG_ID,
+			prompt: reviewConfig?.prompt || DEFAULT_REVIEW_PROMPT,
+		};
+		setAiReviewAgentId(next.agentId);
+		setAiReviewConfigId(next.configId);
+		setAiReviewPrompt(next.prompt);
+		initialAiReviewRef.current = next;
+	}, [reviewConfigKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const isDirty = useCallback(() => {
 		if (activeTab === "project") {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -313,9 +313,13 @@ export interface TaskRelation {
 
 export interface ColumnAgentConfig {
 	agentId: string; // e.g. "builtin-claude"
-	configId: string; // e.g. "claude-bypass-sonnet"
+	configId: string; // e.g. "claude-auto-opus5-xhigh"
 	prompt: string; // prompt sent to the agent
 }
+
+/** Agent + preset the "AI Review" column runs when a project never configured one. */
+export const DEFAULT_REVIEW_AGENT_ID = "builtin-claude";
+export const DEFAULT_REVIEW_CONFIG_ID = "claude-auto-opus5-xhigh";
 
 export const DEFAULT_REVIEW_PROMPT = `Review all changes on this branch (use git diff against {baseBranch}).
 Focus on: bugs, logic errors, runtime failures, duplicated code, security issues.
@@ -741,6 +745,30 @@ export const DEPRECATED_DEFAULT_CONFIG_REMAP: Record<string, string> = {
 	// the Bypass Medium tier (its closest surviving behavioral + effort equivalent).
 	"claude-fable5-cost-trick": "claude-fable5-cost-trick-bypass-medium",
 };
+
+/**
+ * Rewrite column-agent presets whose id was removed from DEFAULT_AGENTS. Without
+ * this a stored `claude-bypass-sonnet` matches no option (the select renders
+ * blank) and findConfig silently falls back to the FIRST preset in the list, so
+ * the column runs a model nobody chose. Applied wherever column agents are read.
+ */
+export function remapColumnAgents(
+	agents: Record<string, ColumnAgentConfig> | undefined,
+): Record<string, ColumnAgentConfig> | undefined {
+	if (!agents) return agents;
+	let changed = false;
+	const out: Record<string, ColumnAgentConfig> = {};
+	for (const [column, config] of Object.entries(agents)) {
+		// "claude-bypass-sonnet" was the hardcoded review default the UI stamped onto
+		// every save, so it marks "never chosen" rather than a preference — it follows
+		// the current default instead of the generic successor mapping.
+		const wasStampedDefault = config.agentId === DEFAULT_REVIEW_AGENT_ID && config.configId === "claude-bypass-sonnet";
+		const mapped = wasStampedDefault ? DEFAULT_REVIEW_CONFIG_ID : DEPRECATED_DEFAULT_CONFIG_REMAP[config.configId];
+		if (mapped) changed = true;
+		out[column] = mapped ? { ...config, configId: mapped } : config;
+	}
+	return changed ? out : agents;
+}
 
 // ---- External Apps ("Open in...") ----
 


### PR DESCRIPTION
Project Settings wrote every field to `projects.json`, the lowest layer of the config cascade, so any field a `.dev3/config.json` (or `config.local.json`) already declared was shadowed again on the very next read. The save looked successful — the handler echoed the raw record back and the UI dispatched it — and then reverted on the next `getProjects`, which resolves the cascade. Since this repo's own `.dev3/config.json` pinned `builtinColumnAgents`, the AI Review preset was simply unchangeable from the UI, and the same held for `setupScript`, `devScript`, `portCount` and `clonePaths`.

Two more defects sat behind the same symptom:

- `findConfig` fell back to `configurations[0]` for an unknown preset id, so the long-removed `claude-bypass-sonnet` stored in every project silently launched whatever preset happened to sit first in the list — and rendered blank in the picker.
- The AI Review form was seeded by `useState`, which only runs on mount, so it never re-synced with the project and could stamp its defaults over a real value.

## Changes

- `saveConfigToWinningLayer` (`src/bun/repo-config.ts`) routes each incoming key to the highest `.dev3` layer that already defines it and returns the rest for `projects.json`. No file is created — only keys already present in an existing file are redirected. `env` is never redirected: it merges per key (decision 179) and may hold personal secrets.
- `updateProjectSettings` uses it and returns the resolved project, so the UI renders what will actually run.
- Unknown preset ids route through `DEPRECATED_DEFAULT_CONFIG_REMAP` before falling back to the agent's `defaultConfigId`; `remapColumnAgents` rewrites stored column agents on both read paths.
- The AI Review column now defaults to `claude-auto-opus5-xhigh` (Claude Opus 5, X-High). The stamped legacy default `claude-bypass-sonnet` is treated as "never chosen" and follows the current default.
- The AI Review form re-syncs with the project's effective config; unsaved edits are never clobbered.
- Dropped the redundant `builtinColumnAgents` block from this repo's `.dev3/config.json`.

Decision record: `decisions/2026/08/10/project-settings-save-into-winning-config-layer.md`.