### PR TITLE
Render repo-relative images in the diff markdown preview

### DIFF
--- a/change-logs/2026/08/10/fix-diff-markdown-images.md
+++ b/change-logs/2026/08/10/fix-diff-markdown-images.md
@@ -1,0 +1,3 @@
+Short: Markdown preview shows repo images
+
+The Markdown preview and rich diff in the diff viewer now render images the document references from the repo (`![](docs/shot.png)`) instead of showing a broken box — the file is read off disk and inlined. Missing files show a labelled placeholder, remote URLs are untouched.

--- a/decisions/2026/08/10/markdown-preview-disk-images.md
+++ b/decisions/2026/08/10/markdown-preview-disk-images.md
@@ -1,0 +1,44 @@
+# Repo-relative images in the markdown preview are swapped in the HTML, not in the DOM
+
+## Context
+
+The diff viewer's markdown preview (`MarkdownDocument`, `MarkdownRichDiff`) rendered
+`![alt](docs/shot.png)` as a broken image: the webview's base URL is the app bundle
+(or the remote server), never the checkout, so a repo-relative src cannot resolve.
+
+## Investigation
+
+The first implementation resolved the images by mutating the rendered `<img>` nodes in a
+`useEffect` (remove `src`, read the file, set a data URL). Unit tests passed and it worked
+after a manual re-mount, but on first open of the diff it silently did nothing. Browser
+instrumentation showed the effect ran once with the right base dir and found all five
+images, yet every node reported `isConnected === false` by the time the read resolved:
+React had rebuilt that subtree from `dangerouslySetInnerHTML` and the effect did not
+re-run, because its dependency (the HTML string) had not changed.
+
+## Decision
+
+`useDiskMarkdownImages` (`src/mainview/components/pr-review/markdown-images.ts`) takes the
+rendered HTML, collects disk-backed `<img src>` values, resolves each to an absolute path
+against the document's directory (root-relative ones against the worktree), reads it via
+the existing `readFilePreview` RPC, and returns **new HTML** with the src replaced by a
+data URL plus a `data-dev3-md-image` state marker. Resolution state lives in React state,
+so every re-render keeps the resolved images. `MarkdownRichDiff` joins its blocks with a
+NUL separator for one resolve pass and splits them back.
+
+`readFilePreview` is reused deliberately: it already caps image size, maps the MIME type,
+and gates the path to the home dir plus registered project roots — the same exposure class
+as the terminal path preview, and it works identically in desktop and remote/browser mode.
+
+## Risks
+
+Data URLs are large; the module-level cache is capped at 24 entries and 40 images per
+document. A file larger than the `readFilePreview` image cap renders as a missing
+placeholder rather than an image.
+
+## Alternatives considered
+
+- Serving worktree files over a URL (custom `views://` protocol handler plus a remote HTTP
+  route) — two transports to implement and secure for a preview-only feature.
+- Keeping the DOM-mutation approach and forcing a re-run on every render — fights React for
+  ownership of a subtree it rebuilds at will; that is the bug above.

--- a/src/mainview/components/FilePreviewModal.tsx
+++ b/src/mainview/components/FilePreviewModal.tsx
@@ -111,7 +111,11 @@ export default function FilePreviewModal({ path, line, taskId, onClose }: FilePr
 				return (
 					<div className="min-h-0 flex-1 overflow-auto p-4">
 						{isMarkdown && !showRaw ? (
-							<MarkdownDocument body={preview.content} className="max-w-[70ch] mx-auto" />
+							<MarkdownDocument
+								body={preview.content}
+								className="max-w-[70ch] mx-auto"
+								imageBaseDir={dirName || null}
+							/>
 						) : (
 							renderCode(preview.content)
 						)}

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -224,6 +224,18 @@
 	max-width: 100%;
 	border-radius: 0.375rem;
 }
+/* A repo-relative image while it is read off disk, or when the file is gone:
+   no src, so the box shows its alt text instead of a broken-image icon. */
+.dev3-pr-md img[data-dev3-md-image="loading"],
+.dev3-pr-md img[data-dev3-md-image="missing"] {
+	display: inline-block;
+	min-width: 8rem;
+	padding: 0.75rem 1rem;
+	border: 1px dashed rgb(var(--border-default));
+	color: rgb(var(--text-tertiary));
+	font-size: 0.75rem;
+	font-style: italic;
+}
 .dev3-pr-md hr {
 	border: none;
 	border-top: 1px solid rgb(var(--border-default));

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1539,6 +1539,9 @@ function TaskDiffFileSection({
 	// removed blocks red); pure adds/deletes have nothing to compare against.
 	const mdRichDiffBlocks = useMarkdownDiffBlocks(file.oldContent, file.newContent);
 	const mdDiffBlocks = isMarkdownRichDiffFile(file) ? mdRichDiffBlocks : null;
+	// Images the document references live next to it in the worktree; without a
+	// worktree (project diff) there is nothing on disk to point at.
+	const mdImageBaseDir = worktreePath ? copiedFilePath.slice(0, copiedFilePath.lastIndexOf("/")) : null;
 
 	// The built diff instance is the only honest source of "is this line on
 	// screen" (the backend ships hunks: null — the library computes the diff
@@ -1723,8 +1726,8 @@ function TaskDiffFileSection({
 					<div className="px-4 py-4" data-testid="diff-md-preview">
 						{mdPreviewSource.trim()
 							? mdDiffBlocks
-								? <MarkdownRichDiff blocks={mdDiffBlocks} />
-								: <MarkdownDocument body={mdPreviewSource} />
+								? <MarkdownRichDiff blocks={mdDiffBlocks} imageBaseDir={mdImageBaseDir} imageRootDir={worktreePath} />
+								: <MarkdownDocument body={mdPreviewSource} imageBaseDir={mdImageBaseDir} imageRootDir={worktreePath} />
 							: <div className="text-sm text-fg-muted">{t("infoPanel.diffMdPreviewEmpty")}</div>}
 					</div>
 				) : buildError ? (

--- a/src/mainview/components/pr-review/__tests__/markdown-images.test.tsx
+++ b/src/mainview/components/pr-review/__tests__/markdown-images.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { FilePreviewResult } from "../../../../shared/types";
+import { isDiskImageSrc, resolveDiskImagePath } from "../markdown-images";
+import { MarkdownDocument, renderMarkdownDocument } from "../markdown";
+import { MarkdownRichDiff, buildMarkdownDiffBlocks } from "../markdown-diff";
+
+const readFilePreview = vi.fn<(params: { path: string }) => Promise<FilePreviewResult>>();
+
+vi.mock("../../../rpc", () => ({
+	isElectrobun: false,
+	api: {
+		request: {
+			get readFilePreview() {
+				return readFilePreview;
+			},
+		},
+	},
+}));
+
+const PNG_DATA_URL = "data:image/png;base64,AAAA";
+
+beforeEach(() => {
+	readFilePreview.mockReset();
+	readFilePreview.mockImplementation(async () => ({ kind: "image", dataUrl: PNG_DATA_URL, size: 3 }));
+});
+
+describe("isDiskImageSrc", () => {
+	it.each([
+		["docs/shot.png", true],
+		["./shot.png", true],
+		["../assets/shot.png", true],
+		["/docs/shot.png", true],
+		["https://example.com/a.png", false],
+		["http://example.com/a.png", false],
+		["data:image/png;base64,AAAA", false],
+		["//example.com/a.png", false],
+		["", false],
+	])("classifies %s as disk-backed: %s", (src, expected) => {
+		expect(isDiskImageSrc(src)).toBe(expected);
+	});
+});
+
+describe("resolveDiskImagePath", () => {
+	it("resolves against the document directory", () => {
+		expect(resolveDiskImagePath("screenshots/board.png", "/wt/docs")).toBe("/wt/docs/screenshots/board.png");
+	});
+
+	it("collapses . and .. segments", () => {
+		expect(resolveDiskImagePath("./a/../b/shot.png", "/wt/docs")).toBe("/wt/docs/b/shot.png");
+		expect(resolveDiskImagePath("../assets/shot.png", "/wt/docs")).toBe("/wt/assets/shot.png");
+	});
+
+	it("never escapes above the filesystem root", () => {
+		expect(resolveDiskImagePath("../../../../etc/passwd", "/wt")).toBe("/etc/passwd");
+	});
+
+	it("resolves a root-relative src against the checkout root", () => {
+		expect(resolveDiskImagePath("/docs/shot.png", "/wt/docs/deep", "/wt")).toBe("/wt/docs/shot.png");
+	});
+
+	it("gives up on a root-relative src with no root", () => {
+		expect(resolveDiskImagePath("/docs/shot.png", "/wt/docs")).toBeNull();
+	});
+
+	it("strips a query or fragment and decodes percent escapes", () => {
+		expect(resolveDiskImagePath("my%20shot.png?v=2", "/wt/docs")).toBe("/wt/docs/my shot.png");
+		expect(resolveDiskImagePath("shot.png#frag", "/wt/docs")).toBe("/wt/docs/shot.png");
+	});
+});
+
+describe("markdown image sanitization", () => {
+	it("keeps a repo-relative img src through the sanitizer", () => {
+		expect(renderMarkdownDocument("![board](docs/screenshots/board.png)")).toContain('src="docs/screenshots/board.png"');
+	});
+});
+
+describe("MarkdownDocument images", () => {
+	it("swaps a repo-relative image for the data URL read off disk", async () => {
+		render(<MarkdownDocument body={"![board](screenshots/board.png)"} imageBaseDir="/wt/docs" />);
+		await waitFor(() => expect(screen.getByAltText("board")).toHaveAttribute("src", PNG_DATA_URL));
+		expect(readFilePreview).toHaveBeenCalledWith({ path: "/wt/docs/screenshots/board.png" });
+		expect(screen.getByAltText("board").dataset.dev3MdImage).toBe("loaded");
+	});
+
+	// The swap lives in the HTML, not in the rendered <img> nodes: React rebuilds
+	// that subtree on re-render, which would silently discard a DOM-level edit.
+	it("keeps the resolved image across a re-render", async () => {
+		const { rerender } = render(<MarkdownDocument body={"![board](screenshots/board.png)"} imageBaseDir="/wt/docs" />);
+		await waitFor(() => expect(screen.getByAltText("board")).toHaveAttribute("src", PNG_DATA_URL));
+		rerender(<MarkdownDocument body={"![board](screenshots/board.png)"} imageBaseDir="/wt/docs" className="mx-auto" />);
+		expect(screen.getByAltText("board")).toHaveAttribute("src", PNG_DATA_URL);
+	});
+
+	it("marks the image missing when the file is not on disk", async () => {
+		readFilePreview.mockResolvedValue({ kind: "not-found" });
+		render(<MarkdownDocument body={"![gone](gone.png)"} imageBaseDir="/wt/docs" />);
+		await waitFor(() => expect(screen.getByAltText("gone").dataset.dev3MdImage).toBe("missing"));
+		expect(screen.getByAltText("gone")).not.toHaveAttribute("src");
+	});
+
+	it("leaves remote images untouched and reads nothing off disk", async () => {
+		render(<MarkdownDocument body={"![remote](https://example.com/a.png)"} imageBaseDir="/wt/docs" />);
+		expect(screen.getByAltText("remote")).toHaveAttribute("src", "https://example.com/a.png");
+		expect(readFilePreview).not.toHaveBeenCalled();
+	});
+
+	it("does nothing without a base directory", async () => {
+		render(<MarkdownDocument body={"![board](screenshots/board.png)"} />);
+		expect(screen.getByAltText("board")).toHaveAttribute("src", "screenshots/board.png");
+		expect(readFilePreview).not.toHaveBeenCalled();
+	});
+});
+
+describe("MarkdownRichDiff images", () => {
+	it("resolves images inside diff blocks", async () => {
+		const blocks = buildMarkdownDiffBlocks("# Title\n\nintro", "# Title\n\n![new](shots/new.png)");
+		expect(blocks).not.toBeNull();
+		render(<MarkdownRichDiff blocks={blocks!} imageBaseDir="/wt/docs" imageRootDir="/wt" />);
+		await waitFor(() => expect(screen.getByAltText("new")).toHaveAttribute("src", PNG_DATA_URL));
+		expect(readFilePreview).toHaveBeenCalledWith({ path: "/wt/docs/shots/new.png" });
+	});
+});

--- a/src/mainview/components/pr-review/markdown-diff.tsx
+++ b/src/mainview/components/pr-review/markdown-diff.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { marked } from "marked";
 import { renderMarkdownDocument } from "./markdown";
+import { useDiskMarkdownImages } from "./markdown-images";
 
 export type MarkdownDiffKind = "context" | "added" | "removed";
 
@@ -9,6 +10,9 @@ export type MarkdownDiffBlock = { kind: MarkdownDiffKind; html: string };
 /** One diffable unit of a markdown document: a top-level block, or a single
  * item of a list (so adding one bullet does not repaint the whole list). */
 type Chunk = { raw: string; listItem: boolean };
+
+/** Joins block HTML for the one-pass image resolve; sanitized HTML has no NULs. */
+const BLOCK_SEPARATOR = "\u0000";
 
 // LCS is O(old × new); a pathological pair of huge documents would freeze the
 // webview, so past this many cells the renderer falls back to a plain preview.
@@ -115,7 +119,18 @@ export function buildMarkdownDiffBlocks(oldSource: string, newSource: string): M
 	return groupOps(ops).map(({ kind, source }) => ({ kind, html: renderMarkdownDocument(source) }));
 }
 
-export function MarkdownRichDiff({ blocks }: { blocks: MarkdownDiffBlock[] }) {
+export function MarkdownRichDiff({ blocks, imageBaseDir, imageRootDir }: {
+	blocks: MarkdownDiffBlock[];
+	/** Directory of the document, so repo-relative images can be read off disk. */
+	imageBaseDir?: string | null;
+	/** Checkout root, for root-relative image paths (`/docs/shot.png`). */
+	imageRootDir?: string | null;
+}) {
+	// One resolve pass for the whole diff: the blocks travel as a single string
+	// joined by a separator no HTML can contain, then split back apart.
+	const joined = useMemo(() => blocks.map((block) => block.html).join(BLOCK_SEPARATOR), [blocks]);
+	const resolvedHtml = useDiskMarkdownImages(joined, imageBaseDir, imageRootDir);
+	const htmls = useMemo(() => resolvedHtml.split(BLOCK_SEPARATOR), [resolvedHtml]);
 	return (
 		<div
 			className="dev3-pr-md dev3-md-doc dev3-md-diff min-w-0 text-sm leading-relaxed text-fg"
@@ -127,7 +142,7 @@ export function MarkdownRichDiff({ blocks }: { blocks: MarkdownDiffBlock[] }) {
 					className={`dev3-md-diff-block dev3-md-diff-${block.kind}`}
 					data-diff-kind={block.kind}
 					// eslint-disable-next-line react/no-danger -- sanitized in renderMarkdownDocument
-					dangerouslySetInnerHTML={{ __html: block.html }}
+					dangerouslySetInnerHTML={{ __html: htmls[index] ?? block.html }}
 				/>
 			))}
 		</div>

--- a/src/mainview/components/pr-review/markdown-images.ts
+++ b/src/mainview/components/pr-review/markdown-images.ts
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../rpc";
+
+/**
+ * Repo-relative images in a rendered markdown document (`![](docs/shot.png)`).
+ * The webview has no base URL pointing at the checkout, so such a src can never
+ * load as a plain URL — it is read off disk through `readFilePreview` and swapped
+ * in as a data URL. Same handler the terminal path preview uses, so the path is
+ * gated to the home dir plus registered project roots on the bun side.
+ *
+ * The swap happens in the HTML *before* React inserts it, not by mutating the
+ * rendered `<img>` nodes: React owns that subtree and rebuilds it whenever the
+ * document re-renders, which silently discards any DOM edit made in an effect.
+ */
+
+const MAX_IMAGES_PER_DOCUMENT = 40;
+/** Data URLs are heavy (up to 4 MB each), so the cache stays deliberately small. */
+const MAX_CACHED_IMAGES = 24;
+
+/** Absolute path → data URL, or null for "read failed / not an image". */
+const cache = new Map<string, string | null>();
+const inflight = new Map<string, Promise<string | null>>();
+
+/** True for a markdown image src that must be read off disk rather than fetched. */
+export function isDiskImageSrc(src: string): boolean {
+	return Boolean(src) && !src.startsWith("//") && !/^[a-z][a-z0-9+.-]*:/i.test(src);
+}
+
+/**
+ * Resolve a markdown image src to an absolute path. `baseDir` is the directory
+ * of the document; a root-relative src (`/docs/shot.png`) resolves against
+ * `rootDir` instead, which is how such links are meant inside a repo.
+ */
+export function resolveDiskImagePath(src: string, baseDir: string, rootDir?: string | null): string | null {
+	const withoutSuffix = src.replace(/[?#].*$/, "");
+	let target: string;
+	try {
+		target = decodeURIComponent(withoutSuffix);
+	} catch {
+		target = withoutSuffix;
+	}
+	if (!target || target.includes("\0")) return null;
+	const rootRelative = target.startsWith("/");
+	const base = rootRelative ? rootDir : baseDir;
+	if (!base) return null;
+	const segments = base.split("/").filter((part, index) => part || index === 0);
+	for (const part of target.split("/")) {
+		if (!part || part === ".") continue;
+		if (part === "..") {
+			if (segments.length > 1) segments.pop();
+			continue;
+		}
+		segments.push(part);
+	}
+	const abs = segments.join("/");
+	return abs.startsWith("/") ? abs : null;
+}
+
+function readImage(absPath: string): Promise<string | null> {
+	const cached = cache.get(absPath);
+	if (cached !== undefined) return Promise.resolve(cached);
+	const pending = inflight.get(absPath);
+	if (pending) return pending;
+	const request = api.request
+		.readFilePreview({ path: absPath })
+		.then((result) => (result.kind === "image" ? result.dataUrl : null))
+		.catch(() => null)
+		.then((dataUrl) => {
+			if (cache.size >= MAX_CACHED_IMAGES) {
+				const oldest = cache.keys().next().value;
+				if (oldest !== undefined) cache.delete(oldest);
+			}
+			cache.set(absPath, dataUrl);
+			inflight.delete(absPath);
+			return dataUrl;
+		});
+	inflight.set(absPath, request);
+	return request;
+}
+
+const IMG_TAG = /<img\b[^>]*>/gi;
+const SRC_ATTR = /\ssrc="([^"]*)"/i;
+
+/** Disk-backed image sources of a rendered document, in document order, deduped. */
+function collectDiskImageSrcs(html: string): string[] {
+	const found: string[] = [];
+	for (const tag of html.match(IMG_TAG) ?? []) {
+		const src = SRC_ATTR.exec(tag)?.[1];
+		if (!src || !isDiskImageSrc(src) || found.includes(src)) continue;
+		found.push(src);
+		if (found.length >= MAX_IMAGES_PER_DOCUMENT) break;
+	}
+	return found;
+}
+
+/**
+ * Replace every disk-backed `<img src>` with what `resolved` knows about it:
+ * a data URL once read, otherwise no src at all plus a state marker, so the
+ * webview shows the alt text instead of a broken-image icon.
+ */
+function applyDiskImages(
+	html: string,
+	baseDir: string,
+	rootDir: string | null | undefined,
+	resolved: Record<string, string | null>,
+): string {
+	return html.replace(IMG_TAG, (tag) => {
+		const match = SRC_ATTR.exec(tag);
+		if (!match || !isDiskImageSrc(match[1])) return tag;
+		const absPath = resolveDiskImagePath(match[1], baseDir, rootDir);
+		const dataUrl = absPath ? resolved[absPath] : null;
+		const state = dataUrl ? "loaded" : absPath && !(absPath in resolved) ? "loading" : "missing";
+		const src = dataUrl ? ` src="${dataUrl}"` : "";
+		return `${tag.slice(0, match.index)}${src} data-dev3-md-image="${state}" title="${match[1]}"${tag.slice(match.index + match[0].length)}`;
+	});
+}
+
+/**
+ * Rendered markdown HTML with repo-relative images swapped for data URLs read
+ * off disk. Returns the HTML unchanged when there is no directory to resolve
+ * against (no worktree) or the document has no disk-backed images.
+ */
+export function useDiskMarkdownImages(html: string, baseDir?: string | null, rootDir?: string | null): string {
+	const srcs = useMemo(() => (baseDir ? collectDiskImageSrcs(html) : []), [html, baseDir]);
+	const [resolved, setResolved] = useState<Record<string, string | null>>({});
+
+	useEffect(() => {
+		if (!baseDir || !srcs.length) return;
+		let stale = false;
+		for (const src of srcs) {
+			const absPath = resolveDiskImagePath(src, baseDir, rootDir);
+			if (!absPath) continue;
+			void readImage(absPath).then((dataUrl) => {
+				if (stale) return;
+				setResolved((prev) => (absPath in prev && prev[absPath] === dataUrl ? prev : { ...prev, [absPath]: dataUrl }));
+			});
+		}
+		return () => {
+			stale = true;
+		};
+	}, [srcs, baseDir, rootDir]);
+
+	return useMemo(
+		() => (baseDir && srcs.length ? applyDiskImages(html, baseDir, rootDir, resolved) : html),
+		[html, baseDir, rootDir, srcs, resolved],
+	);
+}

--- a/src/mainview/components/pr-review/markdown.tsx
+++ b/src/mainview/components/pr-review/markdown.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
+import { useDiskMarkdownImages } from "./markdown-images";
 
 // PR comments are arbitrary third-party content, so the pipeline must be
 // XSS-safe by construction: marked renders GFM to HTML, sanitize-html strips
@@ -49,8 +50,16 @@ export function renderMarkdownDocument(body: string): string {
 	return sanitizeHtml(html, SANITIZE_OPTIONS);
 }
 
-export function MarkdownDocument({ body, className }: { body: string; className?: string }) {
-	const html = useMemo(() => renderMarkdownDocument(body), [body]);
+export function MarkdownDocument({ body, className, imageBaseDir, imageRootDir }: {
+	body: string;
+	className?: string;
+	/** Directory of the document, so repo-relative images can be read off disk. */
+	imageBaseDir?: string | null;
+	/** Checkout root, for root-relative image paths (`/docs/shot.png`). */
+	imageRootDir?: string | null;
+}) {
+	const rendered = useMemo(() => renderMarkdownDocument(body), [body]);
+	const html = useDiskMarkdownImages(rendered, imageBaseDir, imageRootDir);
 	return (
 		<div
 			className={`dev3-pr-md dev3-md-doc min-w-0 text-sm leading-relaxed text-fg${className ? ` ${className}` : ""}`}


### PR DESCRIPTION
The Markdown preview and rich diff in the diff viewer rendered `![alt](docs/shot.png)` as a broken box: the webview's base URL is the app bundle (or the remote server), never the checkout, so a repo-relative `src` can never resolve.

`useDiskMarkdownImages` now collects disk-backed `<img src>` values from the rendered HTML, resolves each against the document's directory (root-relative ones against the worktree), reads the file through the existing `readFilePreview` RPC, and returns new HTML with a data URL inlined. Relative paths, `..` segments and percent escapes are handled; remote URLs are untouched; a file that is not on disk renders as a labelled dashed placeholder instead of a broken-image icon. Same fix applies to the Markdown mode of the terminal file preview modal.

The swap deliberately happens in the HTML string rather than by mutating the rendered `<img>` nodes: React rebuilds that subtree from `dangerouslySetInnerHTML` and discards DOM-level edits without re-running the effect. Details in `decisions/2026/08/10/markdown-preview-disk-images.md`.

Reusing `readFilePreview` keeps the size cap, MIME mapping and path gating (home dir plus registered project roots) already in place, and works identically in desktop and remote/browser mode.