### PR TITLE
Hide the terminal cursor while input goes elsewhere

### DIFF
--- a/change-logs/2026/08/10/fix-terminal-cursor-hidden-when-unfocused.md
+++ b/change-logs/2026/08/10/fix-terminal-cursor-hidden-when-unfocused.md
@@ -1,0 +1,3 @@
+Short: Terminal cursor hides when unfocused
+
+The terminal cursor no longer blinks while your input goes somewhere else — it disappears when focus moves to the artifact panel, another pane, or another app, and comes back the moment the terminal is focused again. Dictating into a terminal that only looked ready to receive it is what this ends.

--- a/decisions/2026/08/10/hide-terminal-cursor-when-unfocused.md
+++ b/decisions/2026/08/10/hide-terminal-cursor-when-unfocused.md
@@ -1,0 +1,51 @@
+# Hide the terminal cursor while input goes elsewhere
+
+## Context
+
+ghostty-web blinks the cursor forever, regardless of focus. Reading an artifact and
+then dictating a prompt, the user watched a blinking cursor, assumed the terminal was
+listening, and lost the whole dictation to the artifact iframe. A blinking cursor is
+the strongest "type here" signal a terminal has, so it must be true.
+
+## Investigation
+
+`CanvasRenderer` exposes `setCursorStyle`/`setCursorBlink` but no unfocused-cursor
+concept, and `cursorVisible` is private. Two vendor facts decided the shape:
+
+- The cursor is drawn only when `buffer.getCursor().visible && this.cursorVisible`.
+- While `cursorBlink` is on, the cursor's row is repainted on **every** frame of the
+  rAF loop (`if (cursorMoved || this.cursorBlink)`), then the cursor is drawn on top.
+
+So disabling blink would freeze the last painted cursor on screen — the opposite of
+the goal — while lying about `visible` drops it within one frame, no forced repaint.
+Theme swapping was rejected too: ghostty warns and ignores `options.theme` after
+`open()`.
+
+## Decision
+
+`src/mainview/terminal-cursor-focus.ts` wraps `renderer.render` and, while gated,
+hands it a Proxy of the buffer whose `getCursor().visible` is `false`. `TerminalView`
+installs it **before** the bidi wrapper (`uninstallBidiRender` restores whatever
+render it wrapped, so a gate on top would be silently removed by the bidi settings
+toggle) and drives it from `inputReachesTerminal()`: window focused **and**
+`activeElement` inside the terminal container. `focusout` re-reads on the next frame,
+because it fires before the next element takes focus. Touch compose mode is exempt —
+there the composer owns the keyboard and the terminal never holds focus.
+
+## Risks
+
+- Focus on `<body>` (right after clicking a kanban card) hides the cursor even though
+  the printable-key handler would forward the keystroke to the terminal. Accepted: the
+  first keystroke restores focus and the cursor, and the opposite error is the bug
+  being fixed.
+- The wrapper depends on undocumented vendor internals; a ghostty-web upgrade that
+  stops repainting the cursor row per frame would leave a stale cursor behind.
+  `src/mainview/__tests__/terminal-cursor-focus.test.ts` drives the real
+  `CanvasRenderer` and asserts no cursor rect is painted, so that would fail loudly.
+
+## Alternatives considered
+
+- **Dim/grey cursor instead of hiding** — user chose hiding; a dim cursor still reads
+  as an input affordance at a glance.
+- **Hollow cursor (xterm.js style)** — requires a vendor renderer change.
+- **CSS on the terminal element** — the cursor is canvas pixels, unreachable from CSS.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -22,6 +22,7 @@ import {
 	TERMINAL_BIDI_CHANGED_EVENT,
 } from "./terminal-bidi/flag";
 import { installBidiRender, uninstallBidiRender } from "./terminal-bidi/proxy";
+import { installCursorVisibilityGate, type CursorVisibilityGate } from "./terminal-cursor-focus";
 import { getScrollThreshold } from "./scroll-speed";
 import { createWheelPacer } from "./wheel-pacer";
 import type { TaskPaneAction } from "../shared/task-panes";
@@ -283,6 +284,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	const touchComposeModeRef = useRef(touchComposeMode ?? false);
 	touchComposeModeRef.current = touchComposeMode ?? false;
 	const copyDiagnosticsRef = useRef<TerminalCopyDiagnostics | null>(null);
+	/** Hides the cursor while input would not reach this terminal. */
+	const cursorGateRef = useRef<CursorVisibilityGate | null>(null);
 	// Native backend only. The watermark is what a reconnect resumes from, so it
 	// must survive the socket — a tmux session never sets either of these.
 	const nativeSeqRef = useRef<number | null>(null);
@@ -307,6 +310,23 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	);
 	const resolvedThemeRef = useRef(resolvedTheme);
 	resolvedThemeRef.current = resolvedTheme;
+	// Window focus is tracked separately from DOM focus: activeElement stays put
+	// when the app goes to the background, so only this tells the two apart.
+	const windowFocusedRef = useRef(document.hasFocus());
+
+	/**
+	 * Would a keystroke right now reach this terminal? Touch compose mode is
+	 * exempt — there the composer owns the keyboard by design and the terminal
+	 * never holds focus, so gating on focus would hide the cursor forever.
+	 */
+	function inputReachesTerminal() {
+		if (touchComposeModeRef.current) return true;
+		if (!windowFocusedRef.current) return false;
+		const container = containerRef.current;
+		const active = document.activeElement;
+		if (!container || !active) return false;
+		return active === container || container.contains(active);
+	}
 
 	/**
 	 * Narrow renderer→backend diagnostic (decision 199). Same-bridge limitation
@@ -514,6 +534,16 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 			// Beta: paint right-to-left rows in visual order (Settings → System →
 			// Advanced Experience). The renderer exists only after term.open().
+			// A blinking cursor in a terminal nothing is typing into reads as "your
+			// keystrokes land here" — they land in the artifact iframe, the kanban
+			// board, or another app. Hide it while that is the case. Installed BEFORE
+			// the bidi wrapper so the bidi settings toggle, which restores whatever
+			// render it wrapped, cannot uninstall this gate along the way.
+			if (term.renderer) {
+				cursorGateRef.current = installCursorVisibilityGate(term.renderer);
+				cursorGateRef.current.setCursorVisible(inputReachesTerminal());
+			}
+
 			if (getTerminalBidiEnabled() && term.renderer) {
 				installBidiRender(term.renderer);
 			}
@@ -1533,6 +1563,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 			copyDiagnosticsRef.current?.dispose();
 			copyDiagnosticsRef.current = null;
+			cursorGateRef.current?.dispose();
+			cursorGateRef.current = null;
 			pendingWrite = "";
 			layoutObserver?.disconnect();
 			mouseCleanup?.();
@@ -1602,6 +1634,44 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 		} catch { /* disposed */ }
 	}, [resolvedTheme]);
+
+	// Keep the cursor in sync with where input actually goes: focus moving to the
+	// artifact iframe, another pane, or another app must take the cursor with it.
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const sync = () => cursorGateRef.current?.setCursorVisible(inputReachesTerminal());
+		// focusout fires BEFORE the next element takes focus, and hopping between
+		// the container and its own hidden textarea fires it too — so re-read
+		// activeElement a frame later, once focus has settled.
+		let frame = 0;
+		const syncNextFrame = () => {
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(sync);
+		};
+		const onWindowFocus = () => {
+			windowFocusedRef.current = true;
+			sync();
+		};
+		const onWindowBlur = () => {
+			windowFocusedRef.current = false;
+			sync();
+		};
+
+		sync();
+		container.addEventListener("focusin", sync);
+		container.addEventListener("focusout", syncNextFrame);
+		window.addEventListener("focus", onWindowFocus);
+		window.addEventListener("blur", onWindowBlur);
+		return () => {
+			cancelAnimationFrame(frame);
+			container.removeEventListener("focusin", sync);
+			container.removeEventListener("focusout", syncNextFrame);
+			window.removeEventListener("focus", onWindowFocus);
+			window.removeEventListener("blur", onWindowBlur);
+		};
+	}, [touchComposeMode]);
 
 	// When the user starts typing printable characters but nothing has focus
 	// (activeElement === body), steal focus to the terminal and forward the key.

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -20,6 +20,7 @@ const {
 	mockOnDataDispose,
 	mockOnResizeDispose,
 	mockOnSelectionChangeDispose,
+	mockVendorRender,
 	fitAddonHolder,
 } = vi.hoisted(() => {
 	const mockFocus = vi.fn();
@@ -28,6 +29,9 @@ const {
 	const mockOnDataDispose = vi.fn();
 	const mockOnResizeDispose = vi.fn();
 	const mockOnSelectionChangeDispose = vi.fn();
+	// The renderer's own paint. Held separately because TerminalView wraps
+	// `renderer.render` (cursor-visibility gate, bidi view) at mount.
+	const mockVendorRender = vi.fn();
 	// Holds the last-constructed FitAddon so tests can drive proposeDimensions.
 	const fitAddonHolder: { current: null | { proposeDimensions: ReturnType<typeof vi.fn> } } = { current: null };
 	// Plain object — avoids document.createElement at hoist time
@@ -62,7 +66,7 @@ const {
 			charWidth: 8,
 			charHeight: 16,
 			remeasureFont: vi.fn(),
-			render: vi.fn(),
+			render: mockVendorRender,
 		},
 		wasmTerm: {},
 		viewportY: 0,
@@ -85,6 +89,7 @@ const {
 		mockOnDataDispose,
 		mockOnResizeDispose,
 		mockOnSelectionChangeDispose,
+		mockVendorRender,
 		fitAddonHolder,
 	};
 });
@@ -1645,8 +1650,8 @@ describe("TerminalView – right-to-left reordering (beta flag)", () => {
 
 	it("installs and removes it live, repainting every row each time", async () => {
 		await renderAndSetup();
-		// Installing replaces the property, so hold on to the vendor's own spy.
-		const vendorRender = mockTermInstance.renderer.render;
+		// Installing replaces the property, so use the vendor's own spy.
+		const vendorRender = mockVendorRender;
 		vendorRender.mockClear();
 
 		await act(async () => {
@@ -1657,15 +1662,18 @@ describe("TerminalView – right-to-left reordering (beta flag)", () => {
 		// opacity 0 keeps the scrollbar from flashing on a forced frame.
 		expect(vendorRender).toHaveBeenCalledTimes(1);
 		expect(vendorRender.mock.calls[0].slice(1)).toEqual([true, 0, expect.anything(), 0]);
-		// What it received is the visual-order view, not the raw terminal.
-		expect(vendorRender.mock.calls[0][0]).not.toBe(mockTermInstance.wasmTerm);
+		// What it received is the visual-order view: `beginFrame` is the bidi view's
+		// own marker. Plain identity against wasmTerm no longer separates the two —
+		// the cursor-visibility gate also hands the vendor a pass-through view while
+		// the terminal is unfocused, which it is in a test with no real focus.
+		expect(vendorRender.mock.calls[0][0]).toHaveProperty("beginFrame");
 
 		await act(async () => {
 			syncTerminalBidiFromGlobalSettings({ experimentalTerminalBidi: false });
 		});
 		expect(isBidiRenderInstalled(mockTermInstance.renderer)).toBe(false);
 		expect(vendorRender).toHaveBeenCalledTimes(2);
-		expect(vendorRender.mock.calls[1][0]).toBe(mockTermInstance.wasmTerm);
+		expect(vendorRender.mock.calls[1][0]).not.toHaveProperty("beginFrame");
 	});
 });
 

--- a/src/mainview/__tests__/terminal-cursor-focus.test.ts
+++ b/src/mainview/__tests__/terminal-cursor-focus.test.ts
@@ -1,0 +1,123 @@
+// Drives ghostty-web's REAL CanvasRenderer through the gate with a recording 2D
+// context, so "the cursor is hidden" is asserted as pixels not painted rather
+// than as our own flag. Bar cursor at cell width 10 is a 2px-wide fillRect,
+// which nothing else in a frame produces — that is the marker used below.
+import { CanvasRenderer } from "ghostty-web";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installBidiRender, uninstallBidiRender } from "../terminal-bidi/proxy";
+import { fakeRenderable, padded, recordingCtx, row } from "../terminal-bidi/__tests__/fixtures";
+import { installCursorVisibilityGate, isCursorVisibilityGateInstalled } from "../terminal-cursor-focus";
+
+const CELL_WIDTH = 10;
+const CELL_HEIGHT = 17;
+const CURSOR_COLOR = "#ff00ff";
+
+let ops: ReturnType<typeof recordingCtx>["ops"];
+let getContextSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	const recorder = recordingCtx();
+	ops = recorder.ops;
+	getContextSpy = vi
+		.spyOn(HTMLCanvasElement.prototype, "getContext")
+		.mockImplementation(() => recorder.ctx as unknown as CanvasRenderingContext2D);
+});
+
+afterEach(() => {
+	getContextSpy.mockRestore();
+});
+
+function newRenderer() {
+	return new CanvasRenderer(document.createElement("canvas"), {
+		fontSize: 15,
+		fontFamily: "monospace",
+		cursorBlink: false,
+		cursorStyle: "bar",
+		devicePixelRatio: 1,
+		theme: { cursor: CURSOR_COLOR },
+	});
+}
+
+/** Every bar-cursor rect painted this frame, as {x, y} cell coordinates. */
+function cursorRects(): { x: number; y: number }[] {
+	return ops
+		.filter((op) => op.op === "fillRect" && op.args[2] === 2 && op.fillStyle === CURSOR_COLOR)
+		.map((op) => ({
+			x: Number(op.args[0]) / CELL_WIDTH,
+			y: Number(op.args[1]) / CELL_HEIGHT,
+		}));
+}
+
+function grid() {
+	return fakeRenderable([padded(row("ok"), 4)], 4, { x: 2, y: 0, visible: true });
+}
+
+describe("terminal cursor visibility gate", () => {
+	it("paints the cursor while the terminal has input", () => {
+		const renderer = newRenderer();
+		const gate = installCursorVisibilityGate(renderer);
+		gate.setCursorVisible(true);
+
+		renderer.render(grid(), true, 0);
+
+		expect(cursorRects()).toEqual([{ x: 2, y: 0 }]);
+	});
+
+	it("paints no cursor once input goes elsewhere", () => {
+		const renderer = newRenderer();
+		const gate = installCursorVisibilityGate(renderer);
+		gate.setCursorVisible(false);
+
+		renderer.render(grid(), true, 0);
+
+		expect(cursorRects()).toEqual([]);
+	});
+
+	it("keeps painting the row's text with the cursor hidden", () => {
+		const renderer = newRenderer();
+		installCursorVisibilityGate(renderer).setCursorVisible(false);
+
+		renderer.render(grid(), true, 0);
+
+		const glyphs = ops.filter((op) => op.op === "fillText").map((op) => String(op.args[0]));
+		expect(glyphs.join("")).toContain("ok");
+	});
+
+	it("restores the vendor cursor on dispose", () => {
+		const renderer = newRenderer();
+		const gate = installCursorVisibilityGate(renderer);
+		gate.setCursorVisible(false);
+		gate.dispose();
+
+		renderer.render(grid(), true, 0);
+
+		expect(isCursorVisibilityGateInstalled(renderer)).toBe(false);
+		expect(cursorRects()).toEqual([{ x: 2, y: 0 }]);
+	});
+
+	// The bidi settings toggle restores whatever render it wrapped, so a gate
+	// installed on top of bidi would be silently removed by turning bidi off.
+	it("survives the bidi render toggle", () => {
+		const renderer = newRenderer();
+		const gate = installCursorVisibilityGate(renderer);
+		gate.setCursorVisible(false);
+		installBidiRender(renderer);
+		uninstallBidiRender(renderer);
+
+		renderer.render(grid(), true, 0);
+
+		expect(isCursorVisibilityGateInstalled(renderer)).toBe(true);
+		expect(cursorRects()).toEqual([]);
+	});
+
+	it("hides the cursor with bidi installed on top", () => {
+		const renderer = newRenderer();
+		const gate = installCursorVisibilityGate(renderer);
+		installBidiRender(renderer);
+		gate.setCursorVisible(false);
+
+		renderer.render(grid(), true, 0);
+
+		expect(cursorRects()).toEqual([]);
+	});
+});

--- a/src/mainview/terminal-cursor-focus.ts
+++ b/src/mainview/terminal-cursor-focus.ts
@@ -1,0 +1,112 @@
+/**
+ * Hide the terminal cursor while the terminal is not the thing receiving input.
+ *
+ * ghostty-web has no public "unfocused cursor" concept: the renderer draws the
+ * cursor whenever the buffer reports `visible` and its own blink phase is on.
+ * So the gate lies to the renderer about one field — it hands `render()` a view
+ * of the buffer whose `getCursor().visible` is false — instead of touching the
+ * renderer's private cursor state.
+ *
+ * Why the cursor disappears within one frame, with no forced repaint: while
+ * `cursorBlink` is enabled the renderer repaints the cursor's row on EVERY frame
+ * of its rAF loop (`if (cursorMoved || this.cursorBlink)`), then draws the cursor
+ * on top. Flipping the flag therefore drops the cursor on the next frame — which
+ * is also why the caller must NOT disable blinking to "stop" the cursor: that
+ * kills the per-frame row repaint and leaves the last cursor pixels burned in.
+ */
+
+/** The buffer field the gate rewrites; everything else is forwarded untouched. */
+interface CursorReporter {
+	getCursor(): { x: number; y: number; visible: boolean };
+}
+
+/** The renderer surface we wrap — structurally compatible with `CanvasRenderer`. */
+interface GateableRenderer {
+	render(
+		buffer: CursorReporter,
+		forceAll?: boolean,
+		viewportY?: number,
+		scrollbackProvider?: unknown,
+		scrollbarOpacity?: number,
+	): void;
+}
+
+const ORIGINAL_RENDER = Symbol.for("dev3.terminalCursorFocus.originalRender");
+
+type WrappedRenderer = GateableRenderer & {
+	[ORIGINAL_RENDER]?: GateableRenderer["render"];
+};
+
+export interface CursorVisibilityGate {
+	/** `false` hides the cursor, `true` restores the terminal's own cursor. */
+	setCursorVisible(visible: boolean): void;
+	/** Restore the vendor's own render. Safe to call twice. */
+	dispose(): void;
+}
+
+/**
+ * A pass-through view of the buffer that reports the cursor as hidden.
+ *
+ * A Proxy rather than explicit forwarding: the buffer is ghostty's WASM terminal
+ * and the renderer calls a growing set of optional methods on it, so enumerating
+ * them here would silently drop whatever the next version adds. Methods are bound
+ * to the target because it carries private fields.
+ */
+function hiddenCursorView<T extends CursorReporter>(inner: T): T {
+	return new Proxy(inner, {
+		get(target, prop, receiver) {
+			if (prop === "getCursor") {
+				return () => ({ ...target.getCursor(), visible: false });
+			}
+			const value = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
+export function installCursorVisibilityGate(renderer: GateableRenderer): CursorVisibilityGate {
+	const target = renderer as WrappedRenderer;
+	let cursorVisible = true;
+	let innerBuffer: CursorReporter | null = null;
+	let hiddenView: CursorReporter | null = null;
+
+	if (!target[ORIGINAL_RENDER] && typeof renderer.render === "function") {
+		const original = renderer.render;
+		target[ORIGINAL_RENDER] = original;
+		target.render = function gatedRender(
+			buffer: CursorReporter,
+			forceAll?: boolean,
+			viewportY?: number,
+			scrollbackProvider?: unknown,
+			scrollbarOpacity?: number,
+		) {
+			let effective = buffer;
+			if (!cursorVisible) {
+				// The renderer is handed the same buffer object every frame; the view
+				// is memoized so a repaint does not allocate a Proxy per frame.
+				if (innerBuffer !== buffer) {
+					innerBuffer = buffer;
+					hiddenView = hiddenCursorView(buffer);
+				}
+				effective = hiddenView ?? buffer;
+			}
+			original.call(this, effective, forceAll, viewportY, scrollbackProvider, scrollbarOpacity);
+		};
+	}
+
+	return {
+		setCursorVisible(visible: boolean) {
+			cursorVisible = visible;
+		},
+		dispose() {
+			const original = target[ORIGINAL_RENDER];
+			if (!original) return;
+			target.render = original;
+			delete target[ORIGINAL_RENDER];
+		},
+	};
+}
+
+export function isCursorVisibilityGateInstalled(renderer: GateableRenderer): boolean {
+	return (renderer as WrappedRenderer)[ORIGINAL_RENDER] !== undefined;
+}


### PR DESCRIPTION
The terminal cursor blinked forever, regardless of focus. Reading an artifact and then dictating a prompt, the user watched a blinking cursor, assumed the terminal was listening, and lost the dictation to the artifact iframe.

The cursor is now hidden whenever input would not reach that terminal: the app window is unfocused, or `document.activeElement` sits outside the terminal container (artifact iframe, another pane, a button, another task). Clicking back into the terminal restores it.

## How it works

`src/mainview/terminal-cursor-focus.ts` wraps `renderer.render` and, while gated, hands the vendor a Proxy of the buffer whose `getCursor().visible` is `false`.

Two ghostty-web internals decided that shape:

- The cursor is drawn only when `buffer.getCursor().visible && this.cursorVisible`, and `cursorVisible` is private.
- While `cursorBlink` is on, the cursor's row is repainted on **every** frame of the rAF loop. So disabling blink — the obvious fix — freezes the last painted cursor on the canvas forever, while lying about `visible` drops it within one frame and needs no forced repaint. `options.theme` is also out: ghostty warns and ignores it after `open()`.

The gate is installed **before** the bidi wrapper, because `uninstallBidiRender` restores whatever render it wrapped and would otherwise remove the gate when the RTL beta is toggled off. Touch compose mode is exempt — there the composer owns the keyboard and the terminal never holds focus.

Full rationale, risks and rejected alternatives: `decisions/2026/08/10/hide-terminal-cursor-when-unfocused.md`.

## Verification

`src/mainview/__tests__/terminal-cursor-focus.test.ts` drives the real `CanvasRenderer` with a recording 2D context and asserts on painted rects, not on our own flags — including the bidi-toggle composition case.

Driven in a browser against the running app by hooking `ctx.fillRect` and counting cursor paints over 900 ms: 44–62 while the terminal was focused, 0 with focus on a button, 0 after `window blur`, 43 after `window focus`.

One known trade-off: focus on `<body>` (right after clicking a kanban card) hides the cursor even though the printable-key handler would forward the keystroke. The first keystroke restores focus and the cursor, and the opposite error is the bug being fixed.