### PR TITLE
Fit block, box-drawing and powerline glyphs onto the terminal cell box

### DIFF
--- a/change-logs/2026/08/10/fix-web-terminal-glyph-cell-alignment.md
+++ b/change-logs/2026/08/10/fix-web-terminal-glyph-cell-alignment.md
@@ -1,0 +1,5 @@
+Short: Powerline prompts line up in the terminal
+
+Block, box-drawing and powerline glyphs in the web terminal are now painted on the same cell box as the cell background, so powerline caps sit flush against the segment they join instead of 2px above it, and bars drawn out of block characters come out solid instead of striped with 1px seams.
+
+Reported by Vitaly Pavlenko.

--- a/decisions/2026/08/10/web-terminal-glyph-cell-fit.md
+++ b/decisions/2026/08/10/web-terminal-glyph-cell-fit.md
@@ -1,0 +1,59 @@
+# Fit cell-edge glyphs onto the cell box instead of trusting ghostty-web's metrics
+
+## Context
+
+Powerline caps in the web terminal sat ~2px above the coloured segment they were
+supposed to join, and bars drawn out of `U+2588` came out striped with 1px
+vertical seams. Native Ghostty 1.3.1 renders the same script in the same font
+pixel-perfect, and the font files say the glyphs are 100–101% of the line box, so
+neither the font nor the user's config could explain it.
+
+## Investigation
+
+`measureFont` in `node_modules/ghostty-web/dist/ghostty-web.js` derives the cell
+from the **ink box of a capital "M"** — `Math.ceil(ascent + descent) + 2` tall,
+`Math.ceil(advance)` wide — while `renderCellText` draws every glyph into the
+font's own line box at the font's own advance. At 14px JetBrains Mono that is a
+16px cell against an 18px line box (the glyph starts 2px above the cell) and a
+9px cell against an 8.4px advance (0.6px of bare cell per column). On device
+pixels: the block glyph's extent was 5 device px above the background rect, with
+one dead column per cell; a `U+E0B0` separator even bled into the neighbouring
+cell's column.
+
+## Decision
+
+`src/mainview/terminal-glyph-cell-fit.ts` patches `renderCellText` per renderer
+instance (same idiom as `installGlyphCellFit`'s neighbours
+`installCursorVisibilityGate` and `installBidiRender`), clips to the exact cell
+box, and maps the glyph's source box onto it — for box-drawing, block and
+powerline codepoints only. Glyphs whose ink covers the whole design box (`U+2588`,
+`U+E0B0`–`U+E0BF`) are fitted by their **ink box**; partial glyphs (half blocks,
+box corners, shades) by the **font's line box**, so they keep their proportions.
+Installed in `TerminalView.tsx` next to the cursor gate.
+
+Full-cell glyphs are grown **one device pixel past every edge** and cut back by
+the clip. Landing the measured ink exactly on the cell edge leaves the outermost
+device row only ~76% covered at font size 20 — a hairline between vertically
+stacked blocks. With the overshoot, a solid block area measures 1.000 coverage at
+sizes 13/14/15/16/18/20; it also fixes a 0.958 seam the vendor itself had at 14.
+
+## Risks
+
+Box-drawing lines lose ~10–19% of their ink (measured), because a 1px line
+stretched by `cellWidth / advance` ≈ 1.05 antialiases — they are slightly softer
+in exchange for actually joining across rows. Relies on three private members of
+`CanvasRenderer` (`renderCellText`, `fontSize`, `fontFamily`), so a vendor bump
+must be re-checked; the fit degrades to the vendor's own path if any measurement
+is missing. The cell is still 2px shorter than the font's line box, so descenders
+still overflow into the row below — invisible only because a black background is
+skipped rather than painted.
+
+## Alternatives considered
+
+Correcting the cell metrics to the real line box (13→18px at size 14) fixes
+alignment and descender clipping but costs every user ~38% of their rows; parked
+as a separate decision. A procedural sprite table for the ~40 block and powerline
+glyphs (what native Ghostty does) is exact but would have to duplicate the
+vendor's selection/inverse/faint colour logic to pick a fill colour; the
+overshoot-and-clip reaches the same pixels without it. Upstreaming to
+`coder/ghostty-web` was declined for now.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -23,6 +23,7 @@ import {
 } from "./terminal-bidi/flag";
 import { installBidiRender, uninstallBidiRender } from "./terminal-bidi/proxy";
 import { installCursorVisibilityGate, type CursorVisibilityGate } from "./terminal-cursor-focus";
+import { installGlyphCellFit, type GlyphCellFit } from "./terminal-glyph-cell-fit";
 import { getScrollThreshold } from "./scroll-speed";
 import { createWheelPacer } from "./wheel-pacer";
 import type { TaskPaneAction } from "../shared/task-panes";
@@ -286,6 +287,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	const copyDiagnosticsRef = useRef<TerminalCopyDiagnostics | null>(null);
 	/** Hides the cursor while input would not reach this terminal. */
 	const cursorGateRef = useRef<CursorVisibilityGate | null>(null);
+	/** Keeps block, box-drawing and powerline glyphs on the cell background's box. */
+	const glyphFitRef = useRef<GlyphCellFit | null>(null);
 	// Native backend only. The watermark is what a reconnect resumes from, so it
 	// must survive the socket — a tmux session never sets either of these.
 	const nativeSeqRef = useRef<number | null>(null);
@@ -542,6 +545,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			if (term.renderer) {
 				cursorGateRef.current = installCursorVisibilityGate(term.renderer);
 				cursorGateRef.current.setCursorVisible(inputReachesTerminal());
+				// Powerline prompts and block-drawn bars are only flush if the glyph
+				// shares the background's cell box; the vendor's own metrics do not.
+				glyphFitRef.current = installGlyphCellFit(term.renderer);
 			}
 
 			if (getTerminalBidiEnabled() && term.renderer) {
@@ -1565,6 +1571,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			copyDiagnosticsRef.current = null;
 			cursorGateRef.current?.dispose();
 			cursorGateRef.current = null;
+			glyphFitRef.current?.dispose();
+			glyphFitRef.current = null;
 			pendingWrite = "";
 			layoutObserver?.disconnect();
 			mouseCleanup?.();

--- a/src/mainview/__tests__/terminal-glyph-cell-fit.test.ts
+++ b/src/mainview/__tests__/terminal-glyph-cell-fit.test.ts
@@ -1,0 +1,146 @@
+// Drives ghostty-web's REAL CanvasRenderer, so the assertions are about the
+// geometry a glyph actually lands on rather than about our own abstractions.
+//
+// The stub font in `recordingCtx` reproduces both halves of the vendor's bug:
+// an "M" whose ink is 12 + 3 = 15 tall inside a line box of 14 + 4 = 18, and an
+// advance of 9.5 under a cell width of ceil(9.5) = 10. The vendor's own formulas
+// therefore give a 10 x 17 cell with the baseline at 13.
+import { CanvasRenderer, type GhosttyCell } from "ghostty-web";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cell, fakeRenderable, padded, recordingCtx } from "../terminal-bidi/__tests__/fixtures";
+import {
+	clearGlyphCellFitCache,
+	installGlyphCellFit,
+	isGlyphCellFitInstalled,
+} from "../terminal-glyph-cell-fit";
+
+const CELL_WIDTH = 10;
+const CELL_HEIGHT = 17;
+const BASELINE = 13;
+const ADVANCE = 9.5;
+const INK_HEIGHT = 15;
+const LINE_BOX_HEIGHT = 18;
+
+let ops: ReturnType<typeof recordingCtx>["ops"];
+let getContextSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	clearGlyphCellFitCache();
+	const recorder = recordingCtx();
+	ops = recorder.ops;
+	getContextSpy = vi
+		.spyOn(HTMLCanvasElement.prototype, "getContext")
+		.mockImplementation(() => recorder.ctx as unknown as CanvasRenderingContext2D);
+});
+
+afterEach(() => {
+	getContextSpy.mockRestore();
+});
+
+/** Paint one row containing `cells`, with the fit installed unless told otherwise. */
+function paint(cells: GhosttyCell[], { fit = true } = {}) {
+	const renderer = new CanvasRenderer(document.createElement("canvas"), {
+		fontSize: 15,
+		fontFamily: "monospace",
+		cursorBlink: false,
+		devicePixelRatio: 1,
+	});
+	if (fit) installGlyphCellFit(renderer);
+	const buffer = fakeRenderable([padded(cells, cells.length)], cells.length);
+	// Frame 1 resizes the canvas and forces a full redraw; assert on frame 2.
+	renderer.render(buffer, true, 0, undefined, 0);
+	ops.length = 0;
+	renderer.render(buffer, true, 0, undefined, 0);
+	return renderer;
+}
+
+/** The op names between the glyph's `save` and its `restore`, plus their args. */
+function glyphOps() {
+	const drawn = ops.map((op) => ({ op: op.op, args: op.args as number[] }));
+	const start = drawn.findIndex((op) => op.op === "save");
+	if (start < 0) return drawn.filter((op) => op.op === "fillText");
+	const end = drawn.findIndex((op, index) => index > start && op.op === "restore");
+	return drawn.slice(start, end + 1);
+}
+
+function argsOf(name: string): number[] {
+	const found = ops.find((op) => op.op === name);
+	if (!found) throw new Error(`no ${name} recorded`);
+	return found.args as number[];
+}
+
+describe("glyph-cell fit", () => {
+	it("leaves ordinary text on the vendor's path", () => {
+		paint([cell("A")]);
+		expect(ops.some((op) => op.op === "clip")).toBe(false);
+		expect(argsOf("fillText").slice(1)).toEqual([0, BASELINE]);
+	});
+
+	it("clips a full block to the cell box and grows its ink one device pixel past it", () => {
+		paint([cell("█")]);
+		const sequence = glyphOps().map((op) => op.op);
+		expect(sequence).toEqual([
+			"save",
+			"rect",
+			"clip",
+			"translate",
+			"scale",
+			"translate",
+			"fillText",
+			"restore",
+		]);
+		// The clip is exactly the box `renderCellBackground` fills.
+		expect(argsOf("rect")).toEqual([0, 0, CELL_WIDTH, CELL_HEIGHT]);
+		// One device pixel of overshoot per edge, cut back by the clip: landing the
+		// measured ink exactly on the edge leaves the last device row part-covered.
+		expect(argsOf("scale")).toEqual([(CELL_WIDTH + 2) / ADVANCE, (CELL_HEIGHT + 2) / INK_HEIGHT]);
+	});
+
+	it("scales the overshoot with the device pixel ratio", () => {
+		const recorder = recordingCtx();
+		recorder.ctx.getTransform = () => ({ a: 2, d: 2 });
+		getContextSpy.mockImplementation(() => recorder.ctx as unknown as CanvasRenderingContext2D);
+		ops = recorder.ops;
+		paint([cell("█")]);
+		// A device pixel is half a CSS pixel at dpr 2, so the overshoot halves.
+		expect(argsOf("scale")).toEqual([(CELL_WIDTH + 1) / ADVANCE, (CELL_HEIGHT + 1) / INK_HEIGHT]);
+	});
+
+	it("fits partial glyphs by the line box, with no overshoot to distort them", () => {
+		paint([cell("│")]);
+		expect(argsOf("scale")).toEqual([CELL_WIDTH / ADVANCE, CELL_HEIGHT / LINE_BOX_HEIGHT]);
+		expect(argsOf("translate")[0]).toBe(0);
+	});
+
+	it("puts the glyph's top edge on the cell's top edge", () => {
+		paint([cell("│")]);
+		// The vendor draws at y = baseline; after the fit that maps to the top of the
+		// cell, because the source box's own top is what got scaled onto it.
+		const scaleY = CELL_HEIGHT / LINE_BOX_HEIGHT;
+		const lineBoxAscent = 14;
+		const [, offsetY] = argsOf("translate");
+		expect(offsetY).toBeCloseTo((lineBoxAscent - BASELINE) * scaleY, 6);
+		// Composed, the vendor's own y = BASELINE lands the box top on the cell top.
+		expect(offsetY + BASELINE * scaleY - lineBoxAscent * scaleY).toBeCloseTo(0, 6);
+	});
+
+	it("does not touch a wide cell or a multi-codepoint grapheme", () => {
+		paint([cell("█", { width: 2 }), cell("", { codepoint: 0, width: 0 })]);
+		expect(ops.some((op) => op.op === "clip")).toBe(false);
+		paint([cell("█", { grapheme_len: 1 })]);
+		expect(ops.some((op) => op.op === "clip")).toBe(false);
+	});
+
+	it("installs once and restores the vendor's painting on dispose", () => {
+		const renderer = paint([cell("█")]);
+		expect(isGlyphCellFitInstalled(renderer)).toBe(true);
+		const second = installGlyphCellFit(renderer);
+		second.dispose();
+		expect(isGlyphCellFitInstalled(renderer)).toBe(false);
+
+		const buffer = fakeRenderable([[cell("█")]], 1);
+		ops.length = 0;
+		renderer.render(buffer, true, 0, undefined, 0);
+		expect(ops.some((op) => op.op === "clip")).toBe(false);
+	});
+});

--- a/src/mainview/terminal-bidi/__tests__/fixtures.ts
+++ b/src/mainview/terminal-bidi/__tests__/fixtures.ts
@@ -195,12 +195,17 @@ export function recordingCtx(): {
 		globalAlpha: 1,
 		textBaseline: "alphabetic",
 		textAlign: "left",
+		// A fractional advance under a whole-pixel cell, and a line box taller than
+		// the ink of an "M": both halves of the gap the glyph-cell fit closes.
 		measureText: () => ({
-			width: 10,
+			width: 9.5,
 			actualBoundingBoxAscent: 12,
 			actualBoundingBoxDescent: 3,
+			fontBoundingBoxAscent: 14,
+			fontBoundingBoxDescent: 4,
 		}),
-		scale: () => {},
+		// The renderer scales by its devicePixelRatio once; the suites build it at 1.
+		getTransform: () => ({ a: 1, d: 1 }),
 		beginPath: () => {},
 		moveTo: () => {},
 		lineTo: () => {},
@@ -218,6 +223,14 @@ export function recordingCtx(): {
 	}
 	ctx.fillRect = record("fillRect");
 	ctx.fillText = record("fillText");
+	// Recorded, not stubbed away: the glyph-cell fit's whole behaviour is the
+	// clip + transform it wraps a glyph in.
+	ctx.save = record("save");
+	ctx.restore = record("restore");
+	ctx.translate = record("translate");
+	ctx.scale = record("scale");
+	ctx.rect = record("rect");
+	ctx.clip = record("clip");
 	return { ctx, ops };
 }
 

--- a/src/mainview/terminal-glyph-cell-fit.ts
+++ b/src/mainview/terminal-glyph-cell-fit.ts
@@ -1,0 +1,202 @@
+/**
+ * Put box-drawing, block and powerline glyphs on the same integer cell box the
+ * cell background is painted on.
+ *
+ * ghostty-web derives the cell from the INK box of a capital "M" — `measureFont`
+ * is `Math.ceil(ascent + descent) + 2` tall and `Math.ceil(advance)` wide — but
+ * draws every glyph into the font's own line box at the font's own advance. The
+ * two boxes disagree on both axes: at 14px JetBrains Mono the cell is 16px tall
+ * against an 18px line box, and 9px wide against an 8.4px advance. So a
+ * powerline cap lands 2.5px above the background segment it is supposed to join,
+ * and each full block leaves a 0.6px seam against its neighbour.
+ *
+ * Native Ghostty avoids this by constraining these glyphs to the cell. This does
+ * the same, for exactly the codepoints that are meant to touch the cell edges,
+ * and clips to the cell so nothing bleeds into the row above. Ordinary text is
+ * left on the vendor's own path.
+ */
+
+/** The cell fields the fit reads; everything else is forwarded to the vendor. */
+interface FitCell {
+	codepoint: number;
+	width: number;
+	grapheme_len: number;
+}
+
+interface CellMetrics {
+	width: number;
+	height: number;
+	baseline: number;
+}
+
+/**
+ * The renderer surface, reached by cast rather than by type: `renderCellText`,
+ * `fontSize` and `fontFamily` are `private` on `CanvasRenderer`, so a structural
+ * interface would not accept it.
+ */
+interface FittableRenderer {
+	renderCellText(cell: FitCell, col: number, row: number): void;
+	getMetrics(): CellMetrics;
+	getCanvas(): HTMLCanvasElement;
+	fontSize?: number;
+	fontFamily?: string;
+}
+
+const ORIGINAL_RENDER_CELL_TEXT = Symbol.for("dev3.terminalGlyphCellFit.originalRenderCellText");
+
+type WrappedRenderer = FittableRenderer & {
+	[ORIGINAL_RENDER_CELL_TEXT]?: FittableRenderer["renderCellText"];
+};
+
+export interface GlyphCellFit {
+	/** Restore the vendor's own glyph painting. Safe to call twice. */
+	dispose(): void;
+}
+
+/**
+ * How a glyph's source box is chosen:
+ * - `ink` — the glyph's ink covers the whole design box by definition (a full
+ *   block, a powerline separator), so fitting the ink box lands it exactly on
+ *   the cell.
+ * - `line-box` — the glyph only covers part of the cell (upper half block, box
+ *   corner, shade), so the font's line box is fitted instead and the glyph keeps
+ *   its proportions inside the cell.
+ */
+type FitKind = "ink" | "line-box";
+
+function fitKindFor(codepoint: number): FitKind | null {
+	if (codepoint === 0x2588) return "ink";
+	if (codepoint >= 0xe0b0 && codepoint <= 0xe0bf) return "ink";
+	// Box drawing + block elements, then the Nerd Fonts powerline-extra shapes.
+	if (codepoint >= 0x2500 && codepoint <= 0x259f) return "line-box";
+	if (codepoint >= 0xe0c0 && codepoint <= 0xe0d7) return "line-box";
+	return null;
+}
+
+/** The box the glyph is drawn into today, measured from the baseline. */
+interface SourceBox {
+	/** Distance from the baseline up to the top of the box. */
+	top: number;
+	height: number;
+	advance: number;
+}
+
+const sourceBoxes = new Map<string, SourceBox | null>();
+let measuringCtx: CanvasRenderingContext2D | null | undefined;
+
+function measureSourceBox(font: string, glyph: string, kind: FitKind): SourceBox | null {
+	// The line box is the same for every glyph in the font, so it is cached per
+	// font; an ink box has to be cached per glyph.
+	const key = kind === "ink" ? `${font} ${glyph}` : font;
+	const cached = sourceBoxes.get(key);
+	if (cached !== undefined) return cached;
+
+	if (measuringCtx === undefined) measuringCtx = document.createElement("canvas").getContext("2d");
+	const box = measuringCtx ? readSourceBox(measuringCtx, font, glyph, kind) : null;
+	sourceBoxes.set(key, box);
+	return box;
+}
+
+function readSourceBox(
+	ctx: CanvasRenderingContext2D,
+	font: string,
+	glyph: string,
+	kind: FitKind,
+): SourceBox | null {
+	ctx.font = font;
+	// "M" for the line box, because that is the character the vendor measured the
+	// cell from — its advance is the one `Math.ceil`'d into cellWidth.
+	const metrics = ctx.measureText(kind === "ink" ? glyph : "M");
+	const top = kind === "ink" ? metrics.actualBoundingBoxAscent : metrics.fontBoundingBoxAscent;
+	const bottom = kind === "ink" ? metrics.actualBoundingBoxDescent : metrics.fontBoundingBoxDescent;
+	const height = top + bottom;
+	const advance = metrics.width;
+	// A missing or degenerate measurement would scale the glyph to NaN.
+	if (!Number.isFinite(top) || !(height > 0) || !(advance > 0)) return null;
+	return { top, height, advance };
+}
+
+/**
+ * One device pixel, in the CSS pixels the renderer draws in. The renderer applies
+ * `ctx.scale(dpr, dpr)` once, so the live transform carries it.
+ */
+function devicePixel(ctx: CanvasRenderingContext2D): [number, number] {
+	const transform = typeof ctx.getTransform === "function" ? ctx.getTransform() : null;
+	const scaleX = transform && transform.a > 0 ? transform.a : 1;
+	const scaleY = transform && transform.d > 0 ? transform.d : 1;
+	return [1 / scaleX, 1 / scaleY];
+}
+
+/** Drops every cached measurement. Exported for tests; fonts are immutable at runtime. */
+export function clearGlyphCellFitCache(): void {
+	sourceBoxes.clear();
+	measuringCtx = undefined;
+}
+
+export function installGlyphCellFit(renderer: object): GlyphCellFit {
+	const target = renderer as WrappedRenderer;
+	let canvasCtx: CanvasRenderingContext2D | null | undefined;
+
+	if (!target[ORIGINAL_RENDER_CELL_TEXT] && typeof target.renderCellText === "function") {
+		const original = target.renderCellText;
+		target[ORIGINAL_RENDER_CELL_TEXT] = original;
+		target.renderCellText = function fittedRenderCellText(
+			this: FittableRenderer,
+			cell: FitCell,
+			col: number,
+			row: number,
+		) {
+			// Wide cells and multi-codepoint graphemes are none of these glyphs, and
+			// fitting one would distort it.
+			const kind = cell && cell.grapheme_len === 0 && cell.width === 1 ? fitKindFor(cell.codepoint) : null;
+			if (!kind) {
+				original.call(this, cell, col, row);
+				return;
+			}
+			if (canvasCtx === undefined) canvasCtx = this.getCanvas().getContext("2d");
+			const box = canvasCtx
+				? measureSourceBox(`${this.fontSize}px ${this.fontFamily}`, String.fromCodePoint(cell.codepoint), kind)
+				: null;
+			if (!canvasCtx || !box) {
+				original.call(this, cell, col, row);
+				return;
+			}
+
+			const metrics = this.getMetrics();
+			const x = col * metrics.width;
+			const y = row * metrics.height;
+			// A full-cell glyph is grown by one device pixel past every edge and cut
+			// back by the clip. Landing the measured ink exactly on the cell edge
+			// instead leaves the outermost device row only ~76% covered at font size
+			// 20 — a hairline between vertically stacked blocks. Partial glyphs get no
+			// padding: growing an upper-half block would just make it the wrong size.
+			const [padX, padY] = kind === "ink" ? devicePixel(canvasCtx) : [0, 0];
+			const scaleX = (metrics.width + 2 * padX) / box.advance;
+			const scaleY = (metrics.height + 2 * padY) / box.height;
+			canvasCtx.save();
+			canvasCtx.beginPath();
+			canvasCtx.rect(x, y, metrics.width, metrics.height);
+			canvasCtx.clip();
+			// The vendor draws at (x, y + baseline); these three steps map the box it
+			// draws into onto the cell box, anchored at the cell's own origin.
+			canvasCtx.translate(x - padX, y - padY + (box.top - metrics.baseline) * scaleY);
+			canvasCtx.scale(scaleX, scaleY);
+			canvasCtx.translate(-x, -y);
+			original.call(this, cell, col, row);
+			canvasCtx.restore();
+		};
+	}
+
+	return {
+		dispose() {
+			const original = target[ORIGINAL_RENDER_CELL_TEXT];
+			if (!original) return;
+			target.renderCellText = original;
+			delete target[ORIGINAL_RENDER_CELL_TEXT];
+		},
+	};
+}
+
+export function isGlyphCellFitInstalled(renderer: object): boolean {
+	return (renderer as WrappedRenderer)[ORIGINAL_RENDER_CELL_TEXT] !== undefined;
+}


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

In the web terminal, powerline caps sat ~2px above the coloured segment they were supposed to join, and bars drawn out of `U+2588` came out striped with 1px vertical seams. Native Ghostty renders the same script in the same font pixel-perfect, and the font files say the glyphs are 100–101% of the line box — so neither the font nor the user's config was to blame.

`ghostty-web`'s `measureFont` sizes the cell from the **ink box of a capital `M`** (`ceil(ascent + descent) + 2` tall, `ceil(advance)` wide), but `renderCellText` draws every glyph into the font's own line box at the font's own advance. At 14px JetBrains Mono that is a 16px cell against an 18px line box, and a 9px cell against an 8.4px advance — one error per axis.

`src/mainview/terminal-glyph-cell-fit.ts` patches `renderCellText` per renderer instance (same idiom as `installCursorVisibilityGate` / `installBidiRender`), clips to the cell box and maps the glyph's source box onto it, for box-drawing, block and powerline codepoints only. Glyphs whose ink covers the whole design box (`U+2588`, `U+E0B0`–`U+E0BF`) are fitted by their ink box and grown one device pixel past every edge so a solid block area reaches full coverage; partial glyphs (half blocks, corners, shades) are fitted by the font's line box and keep their proportions. Ordinary text stays on the vendor's path.

Measured on device pixels with the real `CanvasRenderer` and the real font: every fitted glyph now starts and ends exactly on the background rect (before: 5–8 device px above it), the horizontal seams go 12 → 0, and the row-to-row boundary of stacked blocks measures 1.000 coverage at sizes 13/14/15/16/18/20 — it also fixes a 0.958 seam the vendor itself had at size 14. Known cost, measured: box-drawing lines lose 10–19% of their ink (a 1px line stretched by ~1.05 antialiases) in exchange for actually joining across rows.

Rationale, risks and the rejected alternatives (correcting the cell metrics globally; a procedural sprite table) are in `decisions/2026/08/10/web-terminal-glyph-cell-fit.md`.

Reported by Vitaly Pavlenko.