### PR TITLE
Hide the LAN QR in Remote Access while the Cloudflare tunnel is starting

### DIFF
--- a/change-logs/2026/08/11/fix-remote-qr-waits-for-tunnel.md
+++ b/change-logs/2026/08/11/fix-remote-qr-waits-for-tunnel.md
@@ -1,0 +1,3 @@
+Short: QR waits for the public link
+
+Remote Access no longer flashes a scannable LAN QR code while the Cloudflare tunnel is still starting: with "Accessible from anywhere" on, the QR, the URL and Copy URL are replaced by a loader until the public hostname lands. With the tunnel off, the interface picker and the local QR appear immediately as before.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2246,6 +2246,13 @@ function App() {
 	const createTaskProject = createTaskProjectId
 		? state.projects.find((project) => project.id === createTaskProjectId) ?? null
 		: null;
+	// While the public tunnel is still coming up, the QR and the URL still point at
+	// the LAN address. Scanned from another network that link just fails, so publish
+	// nothing until the tunnel hostname lands.
+	const tunnelUrlPending = remoteQR !== null
+		&& tunnelWanted
+		&& remoteQR.cloudflaredInstalled
+		&& (tunnelStarting || remoteQR.tunnelState === "starting");
 	const remoteCopyLabel = qrConsumed
 		? "remote.copyUrl"
 		: remoteUrlCopyState === "copying"
@@ -2468,8 +2475,22 @@ function App() {
 						<h2 className="text-fg text-lg font-semibold">{t("remote.title")}</h2>
 						<p className="text-fg-2 text-sm">{t("remote.subtitle")}</p>
 						<div className="flex justify-center relative">
-							<img src={remoteQR.qrDataUrl} alt="QR Code" className={`w-56 h-56 rounded-lg transition-[opacity,filter] duration-500 streamer-private-media ${qrConsumed ? "opacity-20 grayscale" : ""}`} />
-							{qrConsumed && (
+							{tunnelUrlPending ? (
+								<div
+									data-testid="remote-qr-pending"
+									className="w-56 h-56 rounded-lg bg-base border border-edge flex flex-col items-center justify-center gap-3 px-4"
+								>
+									<svg className="w-7 h-7 animate-spin text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+										<circle cx="12" cy="12" r="9" strokeWidth="3" opacity="0.25" />
+										<path d="M21 12a9 9 0 0 1-9 9" strokeWidth="3" strokeLinecap="round" />
+									</svg>
+									<span className="text-fg-2 text-sm">{t("remote.qrWaitingTunnel")}</span>
+									<span className="text-fg-muted text-xs leading-snug">{t("remote.qrWaitingTunnelHint")}</span>
+								</div>
+							) : (
+								<img src={remoteQR.qrDataUrl} alt="QR Code" className={`w-56 h-56 rounded-lg transition-[opacity,filter] duration-500 streamer-private-media ${qrConsumed ? "opacity-20 grayscale" : ""}`} />
+							)}
+							{qrConsumed && !tunnelUrlPending && (
 								<div className="absolute inset-0 flex items-center justify-center">
 									<div className="bg-base/90 rounded-lg px-4 py-2">
 										<span className="text-accent text-sm font-medium">{t("remote.connected")}</span>
@@ -2477,7 +2498,7 @@ function App() {
 								</div>
 							)}
 						</div>
-						{!qrConsumed && (
+						{!qrConsumed && !tunnelUrlPending && (
 							<div className="flex items-center justify-center gap-2 text-fg-muted text-xs">
 								<div className="w-4 h-4 relative">
 									<svg className="w-4 h-4 -rotate-90" viewBox="0 0 20 20">
@@ -2518,9 +2539,11 @@ function App() {
 								</select>
 							</div>
 						)}
-						<div className={`bg-base rounded-lg p-3 ${qrConsumed ? "opacity-40" : ""}`}>
-							<code className={`text-xs break-all streamer-private ${qrConsumed ? "text-fg-3" : "text-fg select-all"}`}>{remoteQR.accessUrl}</code>
-						</div>
+						{!tunnelUrlPending && (
+							<div className={`bg-base rounded-lg p-3 ${qrConsumed ? "opacity-40" : ""}`}>
+								<code className={`text-xs break-all streamer-private ${qrConsumed ? "text-fg-3" : "text-fg select-all"}`}>{remoteQR.accessUrl}</code>
+							</div>
+						)}
 
 						{/* Tunnel toggle */}
 						<div className="bg-base rounded-lg p-3 text-left space-y-2">
@@ -2633,7 +2656,7 @@ function App() {
 							<button
 								type="button"
 								onClick={async () => {
-									if (qrConsumed || remoteUrlCopyState === "copying") return;
+									if (qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying") return;
 									setRemoteUrlCopyState("copying");
 									try {
 										await navigator.clipboard.writeText(remoteQR.accessUrl);
@@ -2643,9 +2666,9 @@ function App() {
 										setRemoteUrlCopyState("idle");
 									}
 								}}
-								disabled={qrConsumed || remoteUrlCopyState === "copying"}
+								disabled={qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying"}
 								aria-label={t(remoteCopyLabel)}
-								className={`inline-flex min-w-[7.25rem] items-center justify-center gap-1.5 px-4 py-2 text-sm rounded-lg transition-[background-color,color,transform] active:scale-[0.98] ${qrConsumed ? "bg-elevated text-fg-3 cursor-not-allowed" : remoteUrlCopyState === "copying" ? "bg-accent/80 text-white cursor-wait" : remoteUrlCopyState === "copied" ? "bg-success-fill text-white hover:bg-success-fill-hover" : "bg-accent-fill text-white hover:bg-accent-fill-hover"}`}
+								className={`inline-flex min-w-[7.25rem] items-center justify-center gap-1.5 px-4 py-2 text-sm rounded-lg transition-[background-color,color,transform] active:scale-[0.98] ${qrConsumed || tunnelUrlPending ? "bg-elevated text-fg-3 cursor-not-allowed" : remoteUrlCopyState === "copying" ? "bg-accent/80 text-white cursor-wait" : remoteUrlCopyState === "copied" ? "bg-success-fill text-white hover:bg-success-fill-hover" : "bg-accent-fill text-white hover:bg-accent-fill-hover"}`}
 							>
 								{remoteUrlCopyState === "copying" && (
 									<svg

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1949,6 +1949,69 @@ describe("App keyboard shortcuts", () => {
 			).toContain("remote-access-active");
 		});
 
+		it("hides the LAN QR and URL until the tunnel hostname lands", async () => {
+			await renderApp();
+			vi.mocked(api.request.getRemoteAccessQR).mockClear();
+			let resolveTunnel!: (value: Awaited<ReturnType<typeof api.request.getRemoteAccessQR>>) => void;
+			vi.mocked(api.request.getRemoteAccessQR).mockImplementation(
+				() => new Promise((resolve) => { resolveTunnel = resolve; }),
+			);
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,local",
+					accessUrl: "http://192.168.0.1:1234/?token=l",
+					tunnelState: "idle",
+					cloudflaredInstalled: true,
+					interfaces: [],
+					selectedHost: "192.168.0.1",
+					autoStartTunnel: true,
+				},
+			}));
+
+			await waitFor(() => expect(screen.getByTestId("remote-qr-pending")).toBeInTheDocument());
+			expect(screen.queryByAltText("QR Code")).not.toBeInTheDocument();
+			expect(screen.queryByText("http://192.168.0.1:1234/?token=l")).not.toBeInTheDocument();
+			expect(screen.getByText("Copy URL")).toBeDisabled();
+
+			await act(async () => {
+				resolveTunnel({
+					qrDataUrl: "data:image/png;base64,tunnel",
+					accessUrl: "https://public.trycloudflare.com/?token=t",
+					tunnelState: "connected",
+					cloudflaredInstalled: true,
+					interfaces: [],
+					selectedHost: "",
+				});
+			});
+
+			await waitFor(() => expect(screen.getByAltText("QR Code")).toBeInTheDocument());
+			expect(screen.queryByTestId("remote-qr-pending")).not.toBeInTheDocument();
+			expect(screen.getByText("https://public.trycloudflare.com/?token=t")).toBeInTheDocument();
+			expect(screen.getByText("Copy URL")).not.toBeDisabled();
+		});
+
+		it("keeps the local QR visible when the tunnel is wanted but cloudflared is missing", async () => {
+			await renderApp();
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,local",
+					accessUrl: "http://192.168.0.1:1234/?token=l",
+					tunnelState: "idle",
+					cloudflaredInstalled: false,
+					interfaces: [],
+					selectedHost: "192.168.0.1",
+				},
+			}));
+			await waitFor(() => expect(screen.getByAltText("QR Code")).toBeInTheDocument());
+
+			await userEvent.click(screen.getByLabelText("Accessible from anywhere (Cloudflare Tunnel)"));
+
+			await waitFor(() => expect(screen.getByText("cloudflared is not installed")).toBeInTheDocument());
+			expect(screen.getByAltText("QR Code")).toBeInTheDocument();
+			expect(screen.queryByTestId("remote-qr-pending")).not.toBeInTheDocument();
+		});
+
 		it("does not restart the tunnel when opened while already connected", async () => {
 			await renderApp();
 			vi.mocked(api.request.getRemoteAccessQR).mockClear();

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -138,6 +138,8 @@ const dashboard = {
 	"remote.title": "Remote Access",
 	"remote.subtitle": "Scan this QR code to open the UI on your phone or another device",
 	"remote.refreshIn": "Refreshes in {seconds}s",
+	"remote.qrWaitingTunnel": "Preparing the public link…",
+	"remote.qrWaitingTunnelHint": "Nothing to scan yet — the QR appears once Cloudflare hands over the address.",
 	"remote.addressLabel": "Reachable at",
 	"remote.localhostLabel": "Localhost",
 	"remote.anywhereToggle": "Accessible from anywhere (Cloudflare Tunnel)",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -138,6 +138,8 @@ const dashboard = {
 	"remote.title": "Acceso remoto",
 	"remote.subtitle": "Escanea este código QR para abrir la interfaz en tu teléfono u otro dispositivo",
 	"remote.refreshIn": "Se actualiza en {seconds}s",
+	"remote.qrWaitingTunnel": "Preparando el enlace público…",
+	"remote.qrWaitingTunnelHint": "Todavía no hay nada que escanear: el QR aparece cuando Cloudflare entrega la dirección.",
 	"remote.addressLabel": "Accesible en",
 	"remote.localhostLabel": "Localhost",
 	"remote.anywhereToggle": "Accesible desde cualquier lugar (Cloudflare Tunnel)",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -154,6 +154,8 @@ const dashboard = {
 	"remote.title": "Удалённый доступ",
 	"remote.subtitle": "Отсканируйте QR-код, чтобы открыть интерфейс на телефоне или другом устройстве",
 	"remote.refreshIn": "Обновится через {seconds}с",
+	"remote.qrWaitingTunnel": "Готовим публичную ссылку…",
+	"remote.qrWaitingTunnelHint": "Сканировать пока нечего — QR появится, когда Cloudflare выдаст адрес.",
 	"remote.addressLabel": "Доступен по адресу",
 	"remote.localhostLabel": "Localhost",
 	"remote.anywhereToggle": "Доступ откуда угодно (Cloudflare Tunnel)",


### PR DESCRIPTION
Opening Remote Access with "Accessible from anywhere" on used to show the LAN QR code and URL immediately, while the Cloudflare tunnel was still coming up. That link is scannable and looks final, but it only works on the same network — on a segmented corporate network (VLANs blocking the traffic) the user scans it and gets a dead page, which reads as a broken feature.

Now, while the tunnel is starting, the QR, the URL block and the `Copy URL` button are replaced by a loader ("Preparing the public link…"); they appear together once the public hostname lands. With the tunnel checkbox off nothing changes — the interface picker and the local QR show up immediately, as before.

Deliberately unchanged: if `cloudflared` is missing, or the tunnel state is `failed`, the local QR stays visible next to the corresponding message instead of leaving an endless spinner. The pending condition is tied to the same state that drives the existing "Starting tunnel..." indicator, so the loader cannot outlive it.