### PR TITLE
Open the setup-script pane below the agent pane

### DIFF
--- a/change-logs/2026/08/11/fix-setup-pane-below-agent.md
+++ b/change-logs/2026/08/11/fix-setup-pane-below-agent.md
@@ -1,0 +1,3 @@
+Short: Setup log pane now sits below
+
+When a project has a setup script, its log pane now opens below the agent pane instead of above it, so the agent keeps the top slot it occupies on tasks without a setup script.

--- a/src/bun/__tests__/platform-launch-posix-golden.test.ts
+++ b/src/bun/__tests__/platform-launch-posix-golden.test.ts
@@ -98,7 +98,7 @@ const STARTUP_WRAPPER_NATIVE = [
 
 const STARTUP_WRAPPER_TMUX_PARALLEL = [
 	"#!/bin/bash",
-	"tmux split-window -v -c \"/w/t\" \"'/bin/zsh' '/tmp/dev3-T-cmd.sh'\"",
+	"tmux split-window -v -b -c \"/w/t\" \"'/bin/zsh' '/tmp/dev3-T-cmd.sh'\"",
 	"'/bin/zsh' -x '/tmp/dev3-T-setup.sh'",
 	"S=$?",
 	"if [ $S -ne 0 ]; then",
@@ -119,7 +119,7 @@ const STARTUP_WRAPPER_TMUX_BLOCKING = [
 	"  printf '\\033[1;31m✗ Setup failed (exit %s)\\033[0m\\n' \"$S\"",
 	"  exec '/bin/zsh'",
 	"fi",
-	"tmux split-window -v -c \"/w/t\" \"'/bin/zsh' '/tmp/dev3-T-cmd.sh'\"",
+	"tmux split-window -v -b -c \"/w/t\" \"'/bin/zsh' '/tmp/dev3-T-cmd.sh'\"",
 	"printf '\\033[1;32m✓ Setup done\\033[0m\\n'",
 	"printf '\\033[2mClosing in 15s — press any key to close now\\033[0m\\n'",
 	"if [ -n \"$ZSH_VERSION\" ]; then read -t 15 -k 1 -s; else read -t 15 -n 1 -s; fi",

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -9809,7 +9809,7 @@ describe("launchTaskPty", () => {
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
 			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '${process.env.DEV3_TEST_ROOT}/dev3-task-1-setup.sh'`);
-			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
+			const splitIndex = script.indexOf(`tmux split-window -v -b -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
 
 			expect(setupIndex).toBeGreaterThanOrEqual(0);
 			expect(splitIndex).toBeGreaterThanOrEqual(0);
@@ -9833,7 +9833,7 @@ describe("launchTaskPty", () => {
 
 			const startupCall = writeSpy.mock.calls.find(([path]) => String(path).endsWith("-startup.sh"));
 			const script = String(startupCall?.[1] ?? "");
-			const splitIndex = script.indexOf(`tmux split-window -v -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
+			const splitIndex = script.indexOf(`tmux split-window -v -b -c "/tmp/wt" "'${process.env.SHELL}' '${process.env.DEV3_TEST_ROOT}/dev3-task-1-cmd.sh'"`);
 			const setupIndex = script.indexOf(`'${process.env.SHELL}' -x '${process.env.DEV3_TEST_ROOT}/dev3-task-1-setup.sh'`);
 
 			expect(splitIndex).toBeGreaterThanOrEqual(0);

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -160,8 +160,9 @@ export function buildAgentRetryWrapper(opts: {
  * The setup/startup wrapper: run the project's setup script, then hand the view
  * to the agent wrapper.
  *
- * The tmux flavour puts the agent in a SECOND pane via `tmux split-window`,
- * which only works because the wrapper runs inside a dev3 tmux pane. A native
+ * The tmux flavour puts the agent in a SECOND pane via `tmux split-window -b`
+ * (agent on top, setup log below), which only works because the wrapper runs
+ * inside a dev3 tmux pane. A native
  * session has one view and no $TMUX, so there the setup script runs first and
  * then EXECs the agent in the same view — never a bare `tmux` shell-out, which
  * outside tmux would target the user's own default socket.
@@ -191,7 +192,9 @@ export function buildSetupStartupWrapper(opts: {
 		return [...d.header(), ...runSetup, setupDone, d.execReplacing(cmdRunner)].join("\n") + "\n";
 	}
 	assertPosixLaunchDialect("the tmux setup/startup wrapper");
-	const splitCmd = `tmux split-window -v -c "${escapeForDoubleQuotes(opts.worktreePath)}" "${escapeForDoubleQuotes(cmdRunner)}"`;
+	// `-b` puts the agent ABOVE the wrapper's own pane, so the setup log sits at
+	// the bottom and the agent keeps the top slot it has without a setup script.
+	const splitCmd = `tmux split-window -v -b -c "${escapeForDoubleQuotes(opts.worktreePath)}" "${escapeForDoubleQuotes(cmdRunner)}"`;
 	return [
 		...d.header(),
 		...(opts.launchMode === "parallel" ? [splitCmd] : []),


### PR DESCRIPTION
When a project has a setup script, the launch wrapper ran the setup in the task's original tmux pane and split the agent into a new one. `tmux split-window -v` places that new pane *below*, so the agent ended up at the bottom and the setup log took the top slot — the opposite of the layout a task without a setup script gets.

Adding `-b` to the split puts the agent above the wrapper's own pane, so the setup log sits at the bottom and closes itself 15s after it finishes, while the agent keeps its usual top slot and focus. Applies to both launch modes (`parallel` and `blocking`); the native backend has a single view and no split, so it is untouched.

Verified `-b` semantics against a real tmux server (new pane `pane_top=0` and active, the original pane pushed down).