### PR TITLE
Space artifact panels, pad bare cards, fix chart label contrast

### DIFF
--- a/change-logs/2026/08/11/fix-artifact-template-spacing-and-chart-labels.md
+++ b/change-logs/2026/08/11/fix-artifact-template-spacing-and-chart-labels.md
@@ -1,0 +1,3 @@
+Short: Artifact panels, padding and chart labels
+
+The dev3 artifact starter no longer stacks panels flush against each other: `main.app` spaces its children, and a bare `.card` carries its own padding, so a report looks right whatever order panels are written in. Chart value labels also stopped rendering as dark grey text inside a white halo on the dark theme — charts now declare the card surface they sit on, so ECharts picks readable label colors in both themes.

--- a/decisions/2026/08/11/artifact-chart-background-drives-label-contrast.md
+++ b/decisions/2026/08/11/artifact-chart-background-drives-label-contrast.md
@@ -1,0 +1,21 @@
+# Artifact charts declare their card surface as `backgroundColor`
+
+## Context
+
+Value labels in dev3 artifact charts rendered as dark grey glyphs wrapped in a fat white halo. On the light theme nobody noticed — the halo is invisible on a white card. On the dark theme every number on a bar chart looked broken. The artifact shell had deliberately set `backgroundColor: "transparent"` in the registered `dev3` ECharts theme so the card surface would show through.
+
+## Investigation
+
+Reproduced with the pristine starter plus one horizontal bar chart with `label: { position: "right" }`, then read the emitted SVG in a headless browser. Labels came out `fill="#333" stroke="rgb(255,255,255)" stroke-width="2" paint-order="stroke"`. Re-initializing the same chart with `backgroundColor` set to `--dev3-surface-raised` flipped them to `fill="#ccc" stroke="rgb(14,18,30)"`. ECharts resolves its automatic label fill and outside stroke against `option.backgroundColor` and assumes white paper when that is transparent; the stroke is not configurable per label position without hand-coloring every series.
+
+## Decision
+
+`chartShellOption` in `src/assets/artifact-template/app.js` now declares `backgroundColor: tokenColor("--dev3-surface-raised")` as a default that report options can still override. The painted rectangle is the exact color of the `.card` the chart already sits in, so nothing changes visually, while every ECharts auto-contrast heuristic gets a truthful background in both themes. `AUTHORING.md` tells report authors not to touch it unless a chart sits on another surface.
+
+## Risks
+
+A chart hosted on a surface other than `--dev3-surface-raised` (`surface-base`, `surface-elevated`, a gradient) now paints a mismatched rectangle behind itself. Every `.chart-host` in the starter lives inside a `.card`, and the override is one option key away.
+
+## Alternatives considered
+
+Injecting per-series label defaults (`color` plus `textBorderWidth: 0`) instead: it fixes outside labels but throws away ECharts' inside-label contrast logic, and has to be re-applied for `emphasis`, per-datum labels, and every series type. Leaving the halo and asking report authors to color labels by hand: the same bug returns in every artifact nobody remembered to patch.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -26,6 +26,12 @@ For most reports, edit only `index.html` and `report.js`.
 
 Do not read or edit `app.css` or `app.js` unless the artifact format itself must change. This keeps formatting out of the authoring context and makes normal artifact work a targeted change. Delete irrelevant HTML sections and their matching `report.js` blocks freely; the reusable shell has no dependency on demo data or panels.
 
+## Panels, spacing, and padding
+
+`main.app` spaces its direct children for you, so stacked panels never touch. Add sections as top-level siblings of `.app` and do not hand-add vertical margins between them. Nest a group of panels inside `<div class="stack">` when they belong together; use `.grid`, `.dashboard-grid`, or `.evidence-book` for column layouts.
+
+`.card` already carries its own padding, so a bare `<section class="card">` looks right with plain content inside it. `.section` and `.kpi` set a roomier padding, and `.table-card` intentionally drops it so a table can run edge to edge. Never re-pad a card from report markup.
+
 ## Preview and share
 
 Pass every local dependency explicitly after `--assets`:
@@ -53,6 +59,8 @@ The starter already pins ECharts 6.1.0, Choices.js 11.2.3, and noUiSlider 15.8.1
 `index.html` loads Apache ECharts 6.1.0 through a versioned cdnjs tag. Keep that tag intact when the report has charts. Offline, chart hosts show a notice while the rest of the report remains usable.
 
 The stable bridge lives in `app.js` and exposes `window.dev3Artifact.chart()`, `.color()`, `.enhance()`, `.setControl()`, and `.toast()`. Keep chart options, values, labels, filters, and interactions in `report.js`; use the exposed helpers there without editing the shell. The chart helper applies dev3 tokens, uses the SVG renderer for crisp print/PDF output, adds aria descriptions, re-renders on theme changes, and resizes with its container.
+
+The shell declares the card surface as each chart's `backgroundColor`, because ECharts derives value-label contrast from it — without that, every label renders dark grey inside a white halo, which is illegible on the dark theme. Keep report code out of that decision: do not set `backgroundColor` or hand-color value labels unless the chart sits on a surface other than `--dev3-surface-raised`.
 
 Use `.remount()` when switching a chart view so ECharts redraws its geometry from left to right; use `.update()` when live data should morph in place. The shell keeps ECharts' native timing and disables motion when the user prefers reduced motion.
 

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -22,9 +22,11 @@
       white-space: nowrap;
       border: 0;
     }
-    .app { max-width: 1180px; margin: auto; }
+    /* Stacked top-level blocks are spaced by the container, so any panel order
+       an author writes keeps the same rhythm without per-panel margins. */
+    .app { display: flex; max-width: 1180px; flex-direction: column; gap: 14px; margin: auto; }
     .topbar, .brand, .actions, .segmented, .inline, .table-tools { display: flex; align-items: center; }
-    .topbar { justify-content: space-between; gap: 20px; margin-bottom: 20px; }
+    .topbar { justify-content: space-between; gap: 20px; margin-bottom: 6px; }
     .brand { gap: 13px; }
     .brand img {
       width: 48px;
@@ -42,7 +44,7 @@
       top: 0;
       display: flex;
       gap: 4px;
-      margin: 0 0 14px;
+      margin: 0;
       padding: 5px;
       overflow-x: auto;
       border: 1px solid rgb(var(--dev3-border));
@@ -120,8 +122,10 @@
       color: rgb(var(--dev3-accent));
     }
     .grid { display: grid; gap: 14px; }
-    .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); margin-bottom: 14px; }
+    .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .stack { display: grid; gap: 14px; }
     .card {
+      padding: 16px;
       border: 1px solid rgb(var(--dev3-border));
       border-radius: 16px;
       background: rgb(var(--dev3-surface-raised));
@@ -144,7 +148,6 @@
       display: grid;
       grid-template-columns: repeat(12, minmax(0, 1fr));
       gap: 14px;
-      margin-bottom: 14px;
     }
     .dashboard-grid > * { min-width: 0; }
     .velocity-panel { grid-column: span 8; }
@@ -160,7 +163,6 @@
       gap: 12px;
       margin-bottom: 16px;
     }
-    .gallery-panel { margin-bottom: 14px; }
     .section-title { margin: 0; font-size: 15px; font-weight: 700; }
     .section-copy { margin-top: 2px; color: rgb(var(--dev3-text-secondary)); font-size: 12px; }
     .segmented {
@@ -367,7 +369,7 @@
       background: rgb(var(--dev3-accent) / .18);
       color: rgb(var(--dev3-text-primary));
     }
-    .table-card { overflow: hidden; }
+    .table-card { padding: 0; overflow: hidden; }
     .table-head { padding: 16px 18px 12px; }
     .table-tools { gap: 8px; }
     .table-tools input, .table-tools select {
@@ -492,8 +494,8 @@
         color: rgb(var(--dev3-text-primary)) !important;
       }
       body { padding: 0; font-size: 10px; }
-      .app { max-width: none; }
-      .topbar { margin-bottom: 8px; }
+      .app { max-width: none; gap: 8px; }
+      .topbar { margin-bottom: 0; }
       .brand { gap: 9px; }
       .brand img { width: 34px; height: 34px; border-radius: 10px; box-shadow: none; }
       h1 { font-size: 17px; }
@@ -501,12 +503,14 @@
       .muted, .section-copy { font-size: 9px; }
       .actions, .scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }
       .print-only { display: block !important; }
-      .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; }
+      .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+      .card { padding: 10px; }
+      .table-card { padding: 0; }
       .kpi { padding: 9px 10px; }
       .kpi-top { font-size: 8px; }
       .kpi-value { margin: 3px 0 1px; font-size: 20px; }
       .trend { font-size: 8px; }
-      .dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; }
+      .dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
       .velocity-panel { grid-column: 1 / -1; }
       .pie-panel, .radar-panel { grid-column: auto; }
       .card, tr { break-inside: avoid; box-shadow: none; }

--- a/src/assets/artifact-template/app.js
+++ b/src/assets/artifact-template/app.js
@@ -212,6 +212,11 @@
 
   function chartShellOption(option) {
     return {
+      // ECharts derives label contrast from the canvas background. Left
+      // transparent it assumes white paper and paints every value label dark
+      // grey inside a 2px white halo — illegible on the dark theme. Naming the
+      // card surface it actually sits on keeps labels readable in both themes.
+      backgroundColor: tokenColor("--dev3-surface-raised"),
       ...option,
       animation: prefersReducedMotion() ? false : option.animation ?? true,
       aria: { enabled: true, ...(option.aria || {}) },

--- a/src/assets/artifact-template/index.html
+++ b/src/assets/artifact-template/index.html
@@ -76,7 +76,7 @@
       </article>
     </section>
 
-    <section class="card section gallery-panel section-anchor" id="gallery">
+    <section class="card section section-anchor" id="gallery">
       <div class="section-head">
         <div><h2 class="section-title">Chart gallery</h2><div class="section-copy">More ECharts types through the same bridge — keep what fits your report, delete the rest</div></div>
         <div class="segmented" id="galleryTabs">


### PR DESCRIPTION
Three visual defects in the dev3 artifact starter, all reproduced in a headless browser against the pristine template.

**Panels stacked flush.** Vertical rhythm lived on individual classes (`.kpis`, `.dashboard-grid`, `.gallery-panel`), so a plain top-level `<section class="card">` got no spacing at all — two sibling panels measured a `0px` gap. `main.app` is now a flex column with a `14px` gap, the per-class margins are gone, and a new `.stack` helper groups panels inside a section. Print keeps an `8px` gap.

**A bare `.card` had no padding.** Padding only existed on `.section` and `.kpi`, so content in a plain card sat flush against its border. `.card` now carries its own `16px` (`10px` in print), `.table-card` explicitly drops it so tables still run edge to edge, and `.section` / `.kpi` keep their roomier values.

**Chart value labels rendered as dark grey text inside a 2px white halo** — invisible on the light theme, illegible on the dark one. The registered theme set `backgroundColor: "transparent"`, and ECharts resolves automatic label fill and outside stroke against that value, assuming white paper when it is missing. The emitted SVG carried `fill="#333" stroke="rgb(255,255,255)"`. `chartShellOption` now declares the card surface (`--dev3-surface-raised`) as an overridable default, which turns the same labels into `fill="#ccc"` with a stroke that matches the background. The painted rectangle is the exact color already behind every `.chart-host`, so nothing changes visually. Recorded in `decisions/2026/08/11/artifact-chart-background-drives-label-contrast.md`.

`AUTHORING.md` documents both rules so report code stops re-adding margins, padding, and hand-colored labels.

Verified in a headless browser: dark and light themes on the full demo page, a print PDF diffed against one built from `origin/main` (identical), and a 390px viewport. `bun run lint` clean; full `bun run test` green apart from the known `App.test.tsx` "refuses Cmd+2" load flake, which passes 124/124 in isolation and shares no code with this diff.