### PR TITLE
Load global settings when the app boots

### DIFF
--- a/change-logs/2026/08/12/fix-global-settings-stale-at-boot.md
+++ b/change-logs/2026/08/12/fix-global-settings-stale-at-boot.md
@@ -1,0 +1,5 @@
+Short: Sound setting honored right after launch
+
+The task-complete sound played on every UI-driven completion after a restart even when the setting was off, because the app never read global settings at boot — it held hardcoded defaults until the Settings screen was opened. Custom keyboard rebinds and the experimental terminal BiDi flag were stale the same way.
+
+Suggested by @giladra-wix (h0x91b/dev-3.0#1337)

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -400,6 +400,18 @@ function App() {
 		initTaskSoundPlayback();
 	}, []);
 
+	// Load the settings this component mirrors into module state (completion
+	// sound, shortcut rebinds, terminal BiDi). Without it they stay at the
+	// hardcoded defaults until the user opens Settings — which re-enabled the
+	// completion sound on every launch for users who had turned it off (#1337).
+	useEffect(() => {
+		let alive = true;
+		api.request.getGlobalSettings()
+			.then((next) => { if (alive) setGlobalSettings(next); })
+			.catch(() => {});
+		return () => { alive = false; };
+	}, []);
+
 	// Mirror the completion-sound setting into the task-sounds module so the UI
 	// can gate its instant client-side playback without a round-trip.
 	useEffect(() => {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -163,7 +163,7 @@ vi.mock("../confirm", () => ({
 	confirm: vi.fn().mockResolvedValue(false),
 	ConfirmHost: () => null,
 }));
-import { initTaskSoundPlayback, playTaskSoundFromPush } from "../task-sounds";
+import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "../task-sounds";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
 import { setStreamerMode } from "../streamer-mode";
 
@@ -1332,6 +1332,22 @@ describe("App keyboard shortcuts", () => {
 		it("initializes task sound playback on mount", async () => {
 			await renderApp();
 			expect(initTaskSoundPlayback).toHaveBeenCalled();
+		});
+
+		// #1337: without a settings load at boot the mirror kept its default and
+		// the chime played on every UI-driven completion despite the setting.
+		it("mirrors the stored completion-sound setting on mount", async () => {
+			vi.mocked(api.request.getGlobalSettings).mockResolvedValue({
+				defaultAgentId: "builtin-claude",
+				defaultConfigId: "claude-default",
+				taskSortOrder: "oldest-first",
+				updateChannel: "stable",
+				playSoundOnTaskComplete: false,
+			});
+
+			await renderApp();
+
+			await waitFor(() => expect(setTaskCompletionSoundEnabled).toHaveBeenCalledWith(false));
 		});
 
 		it("opens when rpc:openAddProjectModal fires", async () => {


### PR DESCRIPTION
Fixes #1337.

`App.tsx` initialized its `globalSettings` state with a hardcoded object and only ever replaced it when the Settings screen loaded, a `globalSettingsUpdated` push arrived, or the create-task modal lazily fetched them. Until one of those happened, every module mirror fed from that state held a default instead of the stored value.

For the completion sound that meant `playSoundOnTaskComplete` read as `undefined` (`undefined !== false` → enabled), so a UI-driven completion played the chime locally and told the backend to skip its own `taskSound` push — bypassing the backend gate, which reads the settings file correctly. The Settings screen still showed `Off` because it loads its own copy. Toggling the switch pushed the real value into `App.tsx` and "fixed" it until the next restart.

Two more mirrors were stale the same way: user keyboard rebinds (`setShortcutOverrides`) and the experimental terminal BiDi flag (`syncTerminalBidiFromGlobalSettings`).

## Change

- `src/mainview/App.tsx` — load global settings once on mount, same shape as `useTaskSortOrder`.
- `src/mainview/__tests__/App.test.tsx` — regression test: the stored `playSoundOnTaskComplete: false` reaches the task-sounds mirror on mount. Verified red against the pre-fix `App.tsx`, green with it.
- Changelog entry, crediting the reporter.

## Verification

- `bun run lint` — clean.
- `bun run test` — 3795 renderer + 5549 backend + 764 CLI passed, 0 failed.
- Browser QA (headless Chromium, streamer mode): app boots, no console errors from the new mount-time RPC.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c8f7346d-4a62-4c2a-b2ac-f81b24e6b4f7) · `dev3://task/c8f7346d-4a62-4c2a-b2ac-f81b24e6b4f7`
