### PR TITLE
Make the PR origin-task link optional and fix its markdown block

### DIFF
--- a/change-logs/2026/08/13/feature-pr-deeplink-opt-out.md
+++ b/change-logs/2026/08/13/feature-pr-deeplink-opt-out.md
@@ -1,0 +1,5 @@
+Short: Turn the PR task link on or off
+
+The deep link dev3 appends to pull requests is now a setting (Settings → Tasks, on by default), so a public PR need not advertise which tool opened it, and the footer itself says where to switch it off. The footer also stopped swallowing the auto-merge instruction, starts on its own line so Markdown renders a rule instead of a heading, and the https open page now resolves new-task links correctly.
+
+Builds on the origin-task deep link contributed by @BnayaZil (h0x91b/dev-3.0#1339).

--- a/decisions/2026/08/13/pr-deep-link-opt-out-and-block-ordering.md
+++ b/decisions/2026/08/13/pr-deep-link-opt-out-and-block-ordering.md
@@ -1,0 +1,46 @@
+# PR deep-link opt-out, block ordering, and symmetric id encoding
+
+## Context
+
+The origin-task deep link (#1339, `pr-origin-task-deep-link.md`) shipped always-on
+and assembled the handoff prompt as `base + deepLink + merge`. Review of the merged
+branch (h0x91b/dev-3.0#1340) found three things worth fixing and one policy gap: a
+public PR advertises dev3 to everyone who reads it, with no way to opt out.
+
+## Investigation
+
+Observed in a live task pane: with `autoMerge: true` the auto-merge sentence landed
+on the same line as the block's last element, inside the markdown the agent was told
+to copy verbatim. Separately, `buildTaskWebLink` percent-encoded the task id while
+`buildTaskDeepLink` did not, so the two links in one footer could resolve differently.
+
+## Decision
+
+- `GlobalSettings.prOriginTaskLink` (default on, `?? true` style — only an explicit
+  `false` is stored) gates the block; `createPullRequest` reads it and passes an empty
+  section when off. Surfaced in Settings → Tasks, and the footer names that path so a
+  reader of the PR knows where it comes from.
+- The block is assembled LAST (`base + merge + deepLink`) and opens with a blank line,
+  because `---` under a text line is setext syntax and would render an `<h2>`.
+- `buildTaskDeepLink` / `buildProjectDeepLink` now percent-encode the id and
+  `parseDeepLink` decodes it, so the scheme link and the web link agree.
+- `docs/open.html` resolves `new-task` before `task`/`project`, since it is the only
+  intent that also carries `project`. `src/bun/__tests__/open-page-grammar.test.ts`
+  pins the page's literals to the module so the third copy cannot drift silently.
+
+## Risks
+
+- Decoding in `parseDeepLink` changes how a link containing a literal `%` parses.
+  Ids are UUIDs, so no existing link is affected, and a malformed sequence falls back
+  to the raw string instead of throwing.
+- The opt-out is global, not per project. If someone wants the link on internal repos
+  and off on public ones, this does not cover it — deliberately, until asked for.
+
+## Alternatives considered
+
+- **Keep the block first and the merge sentence last.** Rejected: the block ends the
+  prompt naturally and anything trailing it reads as part of the quoted markdown.
+- **Per-project setting.** More precise, more surface; the global switch answers the
+  actual complaint (do not advertise dev3) with one control.
+- **Drop the raw `dev3://` line to shorten the footer.** Rejected: it is the fallback
+  when the https page is unreachable, which already happened once.

--- a/docs/open.html
+++ b/docs/open.html
@@ -113,7 +113,7 @@ code {
   <div id="ok">
     <h1>Opening in dev-3.0…</h1>
     <p class="muted">Your browser should hand off to the dev-3.0 app. If nothing happens, use the button below.</p>
-    <a class="btn" id="open-btn" href="#">Open in dev-3.0</a>
+    <a class="btn" id="open-btn" href="/">Open in dev-3.0</a>
     <div class="raw">
       <p class="muted">Or paste this into Spotlight or your browser's address bar:</p>
       <div class="raw-link">
@@ -137,16 +137,18 @@ code {
   (function () {
     var p = new URLSearchParams(location.search);
     var deepLink = null;
-    if (p.get("task")) {
-      deepLink = "dev3://task/" + encodeURIComponent(p.get("task"));
-    } else if (p.get("project")) {
-      deepLink = "dev3://project/" + encodeURIComponent(p.get("project"));
-    } else if (p.has("new-task") || p.get("text")) {
+    // new-task first: it is the only intent that also carries `project`, so any
+    // later branch would swallow it and open the project instead.
+    if (p.has("new-task") || p.get("text")) {
       var q = new URLSearchParams();
       if (p.get("project")) q.set("project", p.get("project"));
       if (p.get("text")) q.set("text", p.get("text"));
       var qs = q.toString();
       deepLink = "dev3://new-task" + (qs ? "?" + qs : "");
+    } else if (p.get("task")) {
+      deepLink = "dev3://task/" + encodeURIComponent(p.get("task"));
+    } else if (p.get("project")) {
+      deepLink = "dev3://project/" + encodeURIComponent(p.get("project"));
     }
 
     if (!deepLink) {
@@ -163,6 +165,10 @@ code {
       navigator.clipboard.writeText(deepLink).then(function () {
         btn.textContent = "Copied";
         setTimeout(function () { btn.textContent = "Copy"; }, 1200);
+      }, function () {
+        // Denied or unavailable — say so instead of leaving the button mute.
+        btn.textContent = "Copy failed";
+        setTimeout(function () { btn.textContent = "Copy"; }, 1600);
       });
     });
 

--- a/src/bun/__tests__/deep-link.test.ts
+++ b/src/bun/__tests__/deep-link.test.ts
@@ -95,6 +95,14 @@ describe("build* + round-trip", () => {
 	it("omits absent params", () => {
 		expect(buildNewTaskDeepLink()).toBe("dev3://new-task");
 	});
+
+	it("round-trips an id that needs escaping, like the web link does", () => {
+		expect(parseDeepLink(buildTaskDeepLink("a/b c"))).toEqual({ kind: "task", taskId: "a/b c" });
+	});
+
+	it("keeps an unescaped legacy link readable", () => {
+		expect(parseDeepLink("dev3://task/plain-id")).toEqual({ kind: "task", taskId: "plain-id" });
+	});
 });
 
 describe("buildTaskWebLink", () => {
@@ -114,12 +122,16 @@ describe("buildTaskPrDeepLinkSection", () => {
 		expect(section).toContain(buildTaskDeepLink("abc-123"));
 	});
 
-	it("opens with a markdown horizontal rule so it reads as a footer", () => {
-		expect(buildTaskPrDeepLinkSection("t1").startsWith("---\n")).toBe(true);
+	it("puts a blank line before the rule so it cannot turn a text line into a heading", () => {
+		expect(buildTaskPrDeepLinkSection("t1").startsWith("\n---\n")).toBe(true);
 	});
 
 	it("wraps the raw scheme link in a code span for copy-paste", () => {
 		expect(buildTaskPrDeepLinkSection("t1")).toContain("`dev3://task/t1`");
+	});
+
+	it("tells the reader the footer can be turned off", () => {
+		expect(buildTaskPrDeepLinkSection("t1")).toContain("Settings → Tasks");
 	});
 });
 

--- a/src/bun/__tests__/open-page-grammar.test.ts
+++ b/src/bun/__tests__/open-page-grammar.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	buildTaskDeepLink,
+	buildProjectDeepLink,
+	buildNewTaskDeepLink,
+	buildTaskWebLink,
+	DEEP_LINK_WEB_BASE,
+} from "../../shared/deep-link";
+
+/**
+ * `docs/open.html` is a third copy of the dev3:// grammar — a plain <script> the
+ * landing site serves, which cannot import the TypeScript module. Nothing else
+ * would notice if the two drifted, so this pins the page's literals to what
+ * `shared/deep-link.ts` actually builds today.
+ */
+const page = readFileSync(join(import.meta.dirname, "../../../docs/open.html"), "utf8");
+
+describe("docs/open.html mirrors the deep-link grammar", () => {
+	it("builds the same prefix for every link kind", () => {
+		expect(page).toContain('"dev3://task/"');
+		expect(page).toContain('"dev3://project/"');
+		expect(page).toContain('"dev3://new-task"');
+	});
+
+	it("uses the same prefixes the module produces", () => {
+		expect(buildTaskDeepLink("x")).toBe("dev3://task/x");
+		expect(buildProjectDeepLink("x")).toBe("dev3://project/x");
+		expect(buildNewTaskDeepLink()).toBe("dev3://new-task");
+	});
+
+	it("lives at the path the web link points to", () => {
+		expect(buildTaskWebLink("x")).toBe(`${DEEP_LINK_WEB_BASE}/open.html?task=x`);
+	});
+
+	it("reads every query param the grammar defines", () => {
+		for (const param of ["task", "project", "text", "new-task"]) {
+			expect(page).toContain(`"${param}"`);
+		}
+	});
+
+	it("resolves new-task before the branches that also read project", () => {
+		expect(page.indexOf('p.has("new-task")')).toBeLessThan(page.indexOf('p.get("task")'));
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -12930,6 +12930,35 @@ describe("handlers.createPullRequest", () => {
 		expect(sends[1]?.join(" ")).toContain("send-keys -t %3 Enter");
 	});
 
+	it("keeps the deep-link block last so nothing is appended inside it", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		tmuxWithLivePanes();
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id, autoMerge: true });
+
+		const prompt = typedText(guardedSends()[0]);
+		expect(prompt.indexOf("gh pr merge --auto")).toBeLessThan(prompt.indexOf("dev3://task/task-1"));
+		expect(prompt.trimEnd().endsWith("Settings → Tasks.)_")).toBe(true);
+	});
+
+	it("omits the deep link when the user turned the setting off", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(loadSettings).mockResolvedValueOnce({ prOriginTaskLink: false } as never);
+		tmuxWithLivePanes();
+
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const prompt = typedText(guardedSends()[0]);
+		expect(prompt).not.toContain("dev3://task/task-1");
+		expect(prompt).toContain("gh pr create");
+	});
+
 	it("tells the agent to append a deep link back to the origin task", async () => {
 		const project = makeProject();
 		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -183,6 +183,7 @@ describe("saveSettings", () => {
 			agentRateLimitTracking: false,
 			watchByDefault: true,
 			suggestCompletingTasksAfterMerge: false,
+			prOriginTaskLink: false,
 			agentsLayoutRevision: 1,
 			pxpipeProxyEnabled: true,
 			favorites: [{ agentId: "builtin-codex", configId: "codex-default", uses: 3, lastUsedAt: 123 }],

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -17,6 +17,7 @@ import { dev3TaskTempPath } from "../temp-paths";
 import { deliverAgentPrompt } from "../agent-prompt-delivery";
 import type { AgentPromptDelivery } from "../../shared/agent-prompt-delivery";
 import { buildTaskPrDeepLinkSection } from "../../shared/deep-link";
+import { loadSettings } from "../settings";
 import { auxPaneAlive, auxPaneTitle, openAuxPane } from "../task-aux-panes";
 import {
 	scheduleMessage as scheduleMessageCore,
@@ -538,16 +539,23 @@ async function pushTask(params: { taskId: string; projectId: string }): Promise<
 /**
  * PR handoff prompt. `deepLinkSection` is the markdown block the agent must
  * append verbatim so the PR carries a deep link back to the originating task
- * (built from the task id, one source of truth in `shared/deep-link.ts`).
+ * (built from the task id, one source of truth in `shared/deep-link.ts`), or
+ * empty when the user opted out.
+ *
+ * The block goes LAST, after the auto-merge sentence: it ends the prompt, and
+ * anything appended behind it would read as part of the markdown the agent was
+ * told to copy verbatim.
  */
 function createPrAgentPrompt(deepLinkSection: string, autoMerge: boolean): string {
 	const base =
 		"Please push this branch and open a pull request for it using the gh CLI (first run git push, then gh pr create). Choose an appropriate title and description based on the work in this conversation.";
-	const deepLink = ` At the very end of the PR description, append this markdown block exactly as written so reviewers can jump straight back to the originating dev3 task:\n\n${deepLinkSection}`;
 	const merge = autoMerge
 		? " Finally, enable auto-merge on the PR with gh pr merge --auto so it merges automatically once checks pass."
 		: "";
-	return base + deepLink + merge;
+	const deepLink = deepLinkSection
+		? ` At the very end of the PR description, after a blank line, append this markdown block exactly as written so reviewers can jump straight back to the originating dev3 task:\n${deepLinkSection}`
+		: "";
+	return base + merge + deepLink;
 }
 
 const COMMIT_AGENT_PROMPT =
@@ -570,7 +578,11 @@ async function createPullRequest(params: { taskId: string; projectId: string; au
 
 	assertGitTask(project, task);
 
-	const prompt = createPrAgentPrompt(buildTaskPrDeepLinkSection(task.id), params.autoMerge ?? false);
+	const linkOptOut = (await loadSettings()).prOriginTaskLink === false;
+	const prompt = createPrAgentPrompt(
+		linkOptOut ? "" : buildTaskPrDeepLinkSection(task.id),
+		params.autoMerge ?? false,
+	);
 	const delivery = await deliverAgentPrompt(task, prompt);
 	log.info("← createPullRequest", { taskId: task.id.slice(0, 8), status: delivery.status, reason: delivery.reason });
 	return { delivery };

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -138,6 +138,8 @@ function normalizeSettings(data: Record<string, unknown>): GlobalSettings {
 		watchByDefault: typeof d.watchByDefault === "boolean" ? d.watchByDefault : undefined,
 		// Default-on toggle — only an explicit false is a stored opt-out.
 		suggestCompletingTasksAfterMerge: d.suggestCompletingTasksAfterMerge === false ? false : undefined,
+		// Default-on toggle — only an explicit false is a stored opt-out.
+		prOriginTaskLink: d.prOriginTaskLink === false ? false : undefined,
 		agentsLayoutRevision: typeof d.agentsLayoutRevision === "number" ? d.agentsLayoutRevision : undefined,
 		// Default-off experimental toggle — only an explicit true is a stored opt-in.
 		pxpipeProxyEnabled: d.pxpipeProxyEnabled === true ? true : undefined,

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -335,6 +335,13 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 		[persistSettingChange],
 	);
 
+	const handlePrOriginTaskLinkToggle = useCallback(
+		(enabled: boolean) => {
+			persistSettingChange({ prOriginTaskLink: enabled });
+		},
+		[persistSettingChange],
+	);
+
 	const handleTipsDisabledToggle = useCallback(
 		(disabled: boolean) => {
 			persistSettingChange({ tipsDisabled: disabled });
@@ -641,6 +648,7 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 						onSoundToggle={handleSoundToggle}
 						onWatchByDefaultToggle={handleWatchByDefaultToggle}
 						onSuggestCompletingTasksAfterMergeToggle={handleSuggestCompletingTasksAfterMergeToggle}
+						onPrOriginTaskLinkToggle={handlePrOriginTaskLinkToggle}
 						onFocusModeToggle={handleFocusModeToggle}
 						onTaskSortOrderChange={handleTaskSortOrderChange}
 						onTaskOpenModeChange={handleTaskOpenModeChange}

--- a/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
+++ b/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
@@ -15,6 +15,7 @@ interface BehaviorSettingsSectionProps {
 	onSoundToggle: (enabled: boolean) => void;
 	onWatchByDefaultToggle: (enabled: boolean) => void;
 	onSuggestCompletingTasksAfterMergeToggle: (enabled: boolean) => void;
+	onPrOriginTaskLinkToggle: (enabled: boolean) => void;
 	onFocusModeToggle: (enabled: boolean) => void;
 	onTaskSortOrderChange: (order: GlobalSettings["taskSortOrder"]) => void;
 	onTaskOpenModeChange: (mode: "split" | "fullscreen") => void;
@@ -32,6 +33,7 @@ export default function BehaviorSettingsSection({
 	onSoundToggle,
 	onWatchByDefaultToggle,
 	onSuggestCompletingTasksAfterMergeToggle,
+	onPrOriginTaskLinkToggle,
 	onFocusModeToggle,
 	onTaskSortOrderChange,
 	onTaskOpenModeChange,
@@ -171,6 +173,26 @@ export default function BehaviorSettingsSection({
 					offLabel={t("settings.off")}
 					onToggle={() =>
 						onSuggestCompletingTasksAfterMergeToggle(globalSettings.suggestCompletingTasksAfterMerge === false)
+					}
+				/>
+			</div>
+			</SettingsEntry>
+
+			<SettingsEntry anchor="pr-origin-task-link">
+			<div>
+				<p className="block text-fg text-sm font-semibold mb-2">
+					{t("settings.prOriginTaskLink")}
+				</p>
+				<p className="text-fg-3 text-sm mb-3">
+					{t("settings.prOriginTaskLinkDesc")}
+				</p>
+				<SettingsToggle
+					checked={globalSettings.prOriginTaskLink !== false}
+					ariaLabel={t("settings.prOriginTaskLink")}
+					onLabel={t("settings.on")}
+					offLabel={t("settings.off")}
+					onToggle={() =>
+						onPrOriginTaskLinkToggle(globalSettings.prOriginTaskLink === false)
 					}
 				/>
 			</div>

--- a/src/mainview/components/global-settings/__tests__/BehaviorSettingsSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/BehaviorSettingsSection.test.tsx
@@ -23,6 +23,7 @@ function renderSection(settings: Partial<GlobalSettings> = {}) {
 				onSoundToggle={vi.fn()}
 				onWatchByDefaultToggle={vi.fn()}
 				onSuggestCompletingTasksAfterMergeToggle={vi.fn()}
+				onPrOriginTaskLinkToggle={vi.fn()}
 				onFocusModeToggle={vi.fn()}
 				onTaskSortOrderChange={vi.fn()}
 				onTaskOpenModeChange={vi.fn()}

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -208,6 +208,8 @@ const settings = {
 	"settings.watchByDefaultDesc": "Preselect Watch when launching a task. You can override it for each task.",
 	"settings.suggestCompletingTasksAfterMerge": "Suggest completing tasks after merge",
 	"settings.suggestCompletingTasksAfterMergeDesc": "When off, a merged branch shows an informational toast instead of asking to complete the task.",
+	"settings.prOriginTaskLink": "Link pull requests back to the task",
+	"settings.prOriginTaskLinkDesc": "When on, pull requests dev3 opens end with a deep link back to the originating task. Turn it off to keep dev3 out of public PR descriptions.",
 	"settings.taskOpenMode": "Task open mode",
 	"settings.taskOpenModeDesc": "How active tasks open when you click on them. Also affects Cmd+1..9: Split keeps the task view, Full screen switches to the board.",
 	"settings.taskOpenModeSplit": "Split view (sidebar + terminal)",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -208,6 +208,8 @@ const settings = {
 	"settings.watchByDefaultDesc": "Preselecciona Observar al iniciar una tarea. Puedes cambiarlo para cada tarea.",
 	"settings.suggestCompletingTasksAfterMerge": "Sugerir completar tareas tras un merge",
 	"settings.suggestCompletingTasksAfterMergeDesc": "Desactivado, una rama fusionada muestra un aviso informativo en lugar de preguntar si se completa la tarea.",
+	"settings.prOriginTaskLink": "Enlazar los pull requests con la tarea",
+	"settings.prOriginTaskLinkDesc": "Activado, los pull requests que abre dev3 terminan con un enlace directo a la tarea de origen. Desactívalo para no mencionar dev3 en descripciones públicas de PR.",
 	"settings.taskOpenMode": "Modo de apertura de tarea",
 	"settings.taskOpenModeDesc": "Cómo se abren las tareas activas al hacer clic en ellas. También afecta a Cmd+1..9: Vista dividida mantiene la vista de tarea, Pantalla completa cambia al tablero.",
 	"settings.taskOpenModeSplit": "Vista dividida (barra lateral + terminal)",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -210,6 +210,8 @@ const settings = {
 	"settings.watchByDefaultDesc": "Предварительно включает «Следить» при запуске задачи. Для каждой задачи это можно изменить отдельно.",
 	"settings.suggestCompletingTasksAfterMerge": "Предлагать завершить задачу после merge",
 	"settings.suggestCompletingTasksAfterMergeDesc": "Если выключено, после merge показывается информационное уведомление вместо вопроса о завершении задачи.",
+	"settings.prOriginTaskLink": "Ссылка из pull request на задачу",
+	"settings.prOriginTaskLinkDesc": "Если включено, pull request'ы, которые открывает dev3, заканчиваются ссылкой на исходную задачу. Выключите, чтобы не упоминать dev3 в публичных описаниях PR.",
 	"settings.taskOpenMode": "Режим открытия задачи",
 	"settings.taskOpenModeDesc": "Как открываются активные задачи при нажатии на них. Также влияет на Cmd+1..9: «Разделённый вид» сохраняет вид задачи, «Полный экран» переключает на доску.",
 	"settings.taskOpenModeSplit": "Разделённый вид (боковая панель + терминал)",

--- a/src/mainview/settings-registry.ts
+++ b/src/mainview/settings-registry.ts
@@ -174,6 +174,15 @@ export const SETTINGS_ENTRIES = [
 		storage: "global",
 	},
 	{
+		id: "pr-origin-task-link",
+		category: "tasks",
+		titleKey: "settings.prOriginTaskLink",
+		descriptionKey: "settings.prOriginTaskLinkDesc",
+		anchor: "pr-origin-task-link",
+		globalField: "prOriginTaskLink",
+		storage: "global",
+	},
+	{
 		id: "task-complete-sound",
 		category: "tasks",
 		titleKey: "settings.taskCompleteSound",
@@ -421,6 +430,7 @@ export const GLOBAL_SETTINGS_FIELDS = [
 	"agentRateLimitTracking",
 	"watchByDefault",
 	"suggestCompletingTasksAfterMerge",
+	"prOriginTaskLink",
 	"agentsLayoutRevision",
 	"pxpipeProxyEnabled",
 	"favorites",

--- a/src/shared/deep-link.ts
+++ b/src/shared/deep-link.ts
@@ -39,6 +39,15 @@ export type DeepLinkNav =
 
 const stripSlashes = (s: string) => s.replace(/^\/+/, "").replace(/\/+$/, "");
 
+/** Ids travel percent-encoded in both the path and the query, so both sides decode. */
+const decodeId = (s: string) => {
+	try {
+		return decodeURIComponent(s);
+	} catch {
+		return s;
+	}
+};
+
 /**
  * Parse a `dev3://…` URL into a target, or `null` when it is malformed or of an
  * unknown kind. Tolerant of case in the host and of trailing slashes; ids and
@@ -56,11 +65,11 @@ export function parseDeepLink(raw: string): DeepLinkTarget | null {
 	const kind = url.hostname.toLowerCase();
 	switch (kind) {
 		case "task": {
-			const taskId = stripSlashes(url.pathname);
+			const taskId = decodeId(stripSlashes(url.pathname));
 			return taskId ? { kind: "task", taskId } : null;
 		}
 		case "project": {
-			const projectId = stripSlashes(url.pathname);
+			const projectId = decodeId(stripSlashes(url.pathname));
 			return projectId ? { kind: "project", projectId } : null;
 		}
 		case "new-task": {
@@ -75,12 +84,12 @@ export function parseDeepLink(raw: string): DeepLinkTarget | null {
 
 /** `dev3://task/<taskId>` */
 export function buildTaskDeepLink(taskId: string): string {
-	return `${DEEP_LINK_SCHEME}://task/${taskId}`;
+	return `${DEEP_LINK_SCHEME}://task/${encodeURIComponent(taskId)}`;
 }
 
 /** `dev3://project/<projectId>` */
 export function buildProjectDeepLink(projectId: string): string {
-	return `${DEEP_LINK_SCHEME}://project/${projectId}`;
+	return `${DEEP_LINK_SCHEME}://project/${encodeURIComponent(projectId)}`;
 }
 
 /** `dev3://new-task?project=…&text=…` — both params optional. */
@@ -108,5 +117,14 @@ export function buildTaskWebLink(taskId: string): string {
  * truth for the PR handoff prompt and its tests.
  */
 export function buildTaskPrDeepLinkSection(taskId: string): string {
-	return `---\n\n🔗 **Origin task in dev3:** [open in dev3](${buildTaskWebLink(taskId)}) · \`${buildTaskDeepLink(taskId)}\``;
+	// The leading blank line is load-bearing: `---` directly under a line of text is
+	// setext syntax, which turns that line into an <h2> and draws no rule at all.
+	return [
+		"",
+		"---",
+		"",
+		`🔗 **Origin task in dev3:** [open in dev3](${buildTaskWebLink(taskId)}) · \`${buildTaskDeepLink(taskId)}\``,
+		"",
+		"_(dev3 added this footer — turn it off in Settings → Tasks.)_",
+	].join("\n");
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -914,6 +914,12 @@ export interface GlobalSettings {
 	/** When false, merged branches show a notice instead of a completion prompt. */
 	suggestCompletingTasksAfterMerge?: boolean;
 	/**
+	 * When false, the Create-PR handoff stops asking the agent to append the
+	 * deep link back to the originating task. Default on; the opt-out exists
+	 * because a public PR would otherwise advertise that dev3 produced it.
+	 */
+	prOriginTaskLink?: boolean;
+	/**
 	 * One-time migration marker: when this is behind the app's current
 	 * revision, built-in agent presets get their configuration order
 	 * resynced to match the declared order in DEFAULT_AGENTS once, then


### PR DESCRIPTION
Follow-ups to #1339 (thanks @BnayaZil for the original feature — this only sands the edges found while reviewing it), closing the items in #1340.

- **Opt-out setting.** `GlobalSettings.prOriginTaskLink`, default on, surfaced in Settings → Tasks & Board. When off, the Create-PR handoff sends the plain prompt and no link is added, so a public PR need not advertise which tool opened it. The footer itself now names where to switch it off.
- **The block goes last.** The prompt was assembled `base + deepLink + merge`, so with auto-merge on, "Finally, enable auto-merge…" landed inside the markdown the agent was told to copy verbatim. Now `base + merge + deepLink`.
- **No accidental heading.** The block opens with a blank line — `---` directly under a text line is setext syntax and renders an `<h2>` instead of a rule.
- **Symmetric id encoding.** `buildTaskDeepLink`/`buildProjectDeepLink` percent-encode the id and `parseDeepLink` decodes it, so the scheme link and the https link in one footer can no longer resolve differently.
- **open.html:** `new-task` is resolved before `task`/`project` (it is the only intent that also carries `project`), the Copy button reports a denied clipboard instead of going mute, and the Open button starts with a real href.
- **Drift guard.** `open-page-grammar.test.ts` pins the static page's literals to `shared/deep-link.ts`, which had no test covering that third copy of the grammar.

Decision record: `decisions/2026/08/13/pr-deep-link-opt-out-and-block-ordering.md`.

Closes #1340