### PR TITLE
Fix mobile bottom sheets rendering taller than the viewport

### DIFF
--- a/change-logs/2026/08/14/fix-mobile-bottom-sheet-unclosable.md
+++ b/change-logs/2026/08/14/fix-mobile-bottom-sheet-unclosable.md
@@ -1,0 +1,3 @@
+Short: Mobile sheets close again
+
+Fixed the mobile bottom sheets (task actions, status, move to, PR status, pane map) rendering taller than the screen inside a task, which pushed their header — grabber, title and close button — above the top edge and left no backdrop to tap, so the only way out was picking an action. Backdrop dismissal now listens for a pointer tap, which iOS delivers reliably.

--- a/decisions/2026/08/14/bottom-sheet-max-height-divided-by-zoom.md
+++ b/decisions/2026/08/14/bottom-sheet-max-height-divided-by-zoom.md
@@ -1,0 +1,38 @@
+# Bottom sheet max-height is divided by its own CSS zoom
+
+## Context
+
+`BottomSheet` scales itself up with CSS `zoom` (`overlayScaleUp()`, 1.25) so a browse-and-tap
+sheet reaches the roomy phone size while the task screen underneath stays dense. Its height cap
+was the Tailwind class `max-h-[85dvh]`.
+
+## Investigation
+
+Measured in headless Chromium at a 393×660 phone viewport, task actions sheet open:
+computed `max-height: 561px` (85% of 660) but `getBoundingClientRect()` returned
+`height 701.25`, `top -41.25`. `dvh` resolves against the viewport *before* `zoom` scales the
+rendered box, so 85dvh renders as 85·1.25 = 106dvh. The flex container aligns to `items-end`,
+so the overflow goes off the *top*: the sticky header — grabber, title, close button, and the
+only swipe-to-dismiss surface — sat above the viewport, and the panel covered the full width,
+leaving no backdrop to tap. On a phone (no Esc, no Android Back on iOS) the sheet could only be
+left by picking an action.
+
+## Decision
+
+`src/mainview/components/BottomSheet.tsx` sets `maxHeight: calc(85dvh / scaleUp)` inline instead
+of the class, so the *rendered* panel is 85dvh at any scale. The backdrop dismiss handler moved
+from `onMouseDown` to `onPointerDown` — iOS does not reliably synthesize mouse events for a tap
+on a plain non-interactive div.
+
+## Risks
+
+`calc()` with a runtime-interpolated divisor is not type-checked; `scaleUp` is a finite number
+from `overlayScaleUp()` and never 0. At `scaleUp === 1` the value is `calc(85dvh / 1)`, identical
+to the old cap.
+
+## Alternatives considered
+
+Scaling the sheet through the root font-size instead of `zoom` — rejected for the reason already
+in the code: it would reflow the terminal behind the overlay and resize the agent's shell just
+because a menu opened. Making the whole panel swipe-dismissable would hide the symptom without
+fixing the clipped header or the unreachable backdrop.

--- a/src/mainview/components/BottomSheet.tsx
+++ b/src/mainview/components/BottomSheet.tsx
@@ -79,7 +79,9 @@ function Sheet({ onClose, title, ariaLabel, children, testId }: BottomSheetProps
 	return createPortal(
 		<div
 			className="fixed inset-0 z-[70] flex items-end justify-center bg-black/50"
-			onMouseDown={(e) => {
+			// Pointer, not mouse: iOS does not reliably synthesize mouse events for a
+			// tap on a plain non-interactive div, so a backdrop tap gets swallowed.
+			onPointerDown={(e) => {
 				if (e.target === e.currentTarget) onClose();
 			}}
 			data-testid={testId}
@@ -91,8 +93,13 @@ function Sheet({ onClose, title, ariaLabel, children, testId }: BottomSheetProps
 				aria-label={ariaLabel ?? title}
 				tabIndex={-1}
 				data-bottom-sheet
-				className="bottom-sheet-panel w-full max-w-[40rem] bg-overlay border-t border-edge rounded-t-2xl shadow-2xl max-h-[85dvh] overflow-y-auto outline-none"
+				className="bottom-sheet-panel w-full max-w-[40rem] bg-overlay border-t border-edge rounded-t-2xl shadow-2xl overflow-y-auto outline-none"
 				style={{
+					// `dvh` resolves against the viewport before `zoom` scales the box,
+					// so a flat 85dvh renders as 85·scaleUp — taller than the screen,
+					// pushing the header (grabber, title, close) above the top edge and
+					// leaving no backdrop to tap. Divide it back out.
+					maxHeight: `calc(85dvh / ${scaleUp})`,
 					...(scaleUp !== 1 ? { zoom: scaleUp } : null),
 					// dragY is viewport px; inside a zoomed panel a transform scales too.
 					...(dragY ? { transform: `translateY(${dragY / scaleUp}px)` } : null),

--- a/src/mainview/components/__tests__/BottomSheet.test.tsx
+++ b/src/mainview/components/__tests__/BottomSheet.test.tsx
@@ -81,6 +81,12 @@ describe("BottomSheet", () => {
 		expect(screen.getByRole("dialog")).toHaveStyle({ zoom: "1.25" });
 	});
 
+	it("divides its max height by the scale so the zoomed panel still fits the viewport", () => {
+		mockedScaleUp.mockReturnValue(1.25);
+		renderSheet();
+		expect(screen.getByRole("dialog").style.maxHeight).toBe("calc(85dvh / 1.25)");
+	});
+
 	it("leaves its own scale alone when the screen underneath is already roomy", () => {
 		renderSheet();
 		expect(screen.getByRole("dialog").style.zoom).toBe("");

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -2017,7 +2017,7 @@ describe("TaskCard", () => {
 			});
 			await user.click(screen.getByLabelText("Open PR #12"));
 			const sheet = await screen.findByTestId("pr-status-sheet");
-			fireEvent.mouseDown(sheet);
+			fireEvent.pointerDown(sheet);
 			await waitFor(() => {
 				expect(screen.queryByTestId("pr-status-sheet")).not.toBeInTheDocument();
 			});


### PR DESCRIPTION
On a phone the task actions sheet could not be dismissed without picking an action.

`BottomSheet` scales itself with CSS `zoom` (×1.25) to reach the roomy size on top of a dense task screen, and capped its height with `max-h-[85dvh]`. `dvh` resolves against the viewport *before* `zoom` scales the box, so the panel rendered at 85·1.25 = 106dvh. Measured at 393×660: computed `max-height: 561px`, actual `height 701.25`, `top -41.25`. The flex container aligns to `items-end`, so the overflow goes off the top — the sticky header (grabber, title, close button, and the only swipe-to-dismiss surface) sat above the viewport, and the full-width panel left no backdrop to tap. No Esc on a phone, no hardware Back on iOS.

- `maxHeight: calc(85dvh / scaleUp)` inline instead of the class, so the *rendered* panel is 85dvh at any scale.
- Backdrop dismissal moved from `onMouseDown` to `onPointerDown` — iOS does not reliably synthesize mouse events for a tap on a plain non-interactive div.

The fix is in the primitive, so it covers every sheet: task actions, status, "Move to", PR status, pane map, and the diff sheets.

Verified in headless Chromium at iPhone 14 Pro emulation: header and close button back on screen (`top 99`, height 561 of 660), backdrop tap closes the sheet, internal scrolling and the sticky header still work. Decision record: `decisions/2026/08/14/bottom-sheet-max-height-divided-by-zoom.md`.