### PR TITLE
Repeat mobile Backspace and arrow keys while held

### DIFF
--- a/change-logs/2026/08/14/feature-mobile-key-repeat.md
+++ b/change-logs/2026/08/14/feature-mobile-key-repeat.md
@@ -1,0 +1,3 @@
+Short: Hold mobile keys to repeat
+
+On mobile, holding the Backspace or arrow keys in the terminal key bar now repeats them after a short delay, like a physical keyboard, instead of requiring one tap per character.

--- a/src/mainview/components/ExtraKeyBar.tsx
+++ b/src/mainview/components/ExtraKeyBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { TerminalHandle } from "../TerminalView";
 import { useT } from "../i18n";
 import { useAttachUpload } from "../hooks/useAttachUpload";
@@ -17,6 +17,10 @@ interface ExtraKeyBarProps {
 	onAttachPaths?: (paths: string[]) => void;
 }
 
+/** Hold-to-repeat timings, matching a typical OS key-repeat feel. */
+const REPEAT_DELAY_MS = 400;
+const REPEAT_INTERVAL_MS = 60;
+
 /**
  * Extra key bar for mobile terminal access — provides keys
  * that are missing or hard to reach on mobile keyboards:
@@ -25,6 +29,7 @@ interface ExtraKeyBarProps {
  * The leading ⌨ button (when the host wires onToggleRaw) switches between
  * compose mode (default — TerminalComposer owns text entry) and raw mode
  * (direct typing into the terminal).
+ * Backspace and the arrows repeat while held, like a physical keyboard.
  *
  * Sizing uses `vw` units so buttons scale to actual screen width
  * regardless of the CSS viewport used in browser mode.
@@ -69,6 +74,30 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 		handle.sendInput(data);
 		refocus();
 	}, [handle, ctrlActive, refocus]);
+
+	// Hold-to-repeat: the tap itself is handled by onClick, so the timer only
+	// emits the *extra* presses once the finger stays down past the delay.
+	const repeat = useRef<{ delay?: ReturnType<typeof setTimeout>; tick?: ReturnType<typeof setInterval> }>({});
+
+	const stopRepeat = useCallback(() => {
+		if (repeat.current.delay) clearTimeout(repeat.current.delay);
+		if (repeat.current.tick) clearInterval(repeat.current.tick);
+		repeat.current = {};
+	}, []);
+
+	useEffect(() => stopRepeat, [stopRepeat]);
+
+	const holdProps = useCallback((data: string) => ({
+		onPointerDown: () => {
+			stopRepeat();
+			repeat.current.delay = setTimeout(() => {
+				repeat.current.tick = setInterval(() => send(data), REPEAT_INTERVAL_MS);
+			}, REPEAT_DELAY_MS);
+		},
+		onPointerUp: stopRepeat,
+		onPointerLeave: stopRepeat,
+		onPointerCancel: stopRepeat,
+	}), [send, stopRepeat]);
 
 	const toggleCtrl = useCallback(() => {
 		setCtrlActive((prev) => !prev);
@@ -138,6 +167,7 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 				className={btnNormal}
 				onMouseDown={(e) => e.preventDefault()}
 				onClick={() => send("\x7f")}
+				{...holdProps("\x7f")}
 				aria-label={t("terminal.backspace")}
 				title={t("terminal.backspace")}
 				data-testid="extra-key-backspace"
@@ -147,10 +177,10 @@ function ExtraKeyBar({ handle, rawMode, onToggleRaw, attachProjectId, attachTask
 
 			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
 
-			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[A")}>{"▲"}</button>
-			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[B")}>{"▼"}</button>
-			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[D")}>{"◀"}</button>
-			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[C")}>{"▶"}</button>
+			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[A")} {...holdProps("\x1b[A")}>{"▲"}</button>
+			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[B")} {...holdProps("\x1b[B")}>{"▼"}</button>
+			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[D")} {...holdProps("\x1b[D")}>{"◀"}</button>
+			<button className={btnArrow} onMouseDown={(e) => e.preventDefault()} onClick={() => send("\x1b[C")} {...holdProps("\x1b[C")}>{"▶"}</button>
 
 			<div className="w-[0.25vw] h-[7vw] bg-edge mx-[0.5vw]" />
 

--- a/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
+++ b/src/mainview/components/__tests__/ExtraKeyBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ExtraKeyBar from "../ExtraKeyBar";
 import type { TerminalHandle } from "../../TerminalView";
@@ -74,6 +74,50 @@ describe("ExtraKeyBar", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Backspace" }));
 		expect(handle.sendInput).toHaveBeenCalledWith("\x7f");
+	});
+
+	it("repeats Backspace while held, and stops on release", () => {
+		vi.useFakeTimers();
+		try {
+			const handle = makeHandle();
+			renderBar(handle);
+			const key = screen.getByTestId("extra-key-backspace");
+
+			fireEvent.pointerDown(key);
+			vi.advanceTimersByTime(300);
+			// Before the delay the tap alone rules — no auto-repeat yet.
+			expect(handle.sendInput).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(100 + 60 * 3);
+			expect(handle.sendInput).toHaveBeenCalledTimes(3);
+			expect(handle.sendInput).toHaveBeenCalledWith("\x7f");
+
+			fireEvent.pointerUp(key);
+			vi.advanceTimersByTime(1000);
+			expect(handle.sendInput).toHaveBeenCalledTimes(3);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("stops the repeat when the finger slides off the key", () => {
+		vi.useFakeTimers();
+		try {
+			const handle = makeHandle();
+			renderBar(handle);
+			const key = screen.getByRole("button", { name: "◀" });
+
+			fireEvent.pointerDown(key);
+			vi.advanceTimersByTime(400 + 60 * 2);
+			expect(handle.sendInput).toHaveBeenCalledWith("\x1b[D");
+			const emitted = vi.mocked(handle.sendInput).mock.calls.length;
+
+			fireEvent.pointerLeave(key);
+			vi.advanceTimersByTime(1000);
+			expect(vi.mocked(handle.sendInput).mock.calls.length).toBe(emitted);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("puts common controls before rarely used modifiers", () => {


### PR DESCRIPTION
On mobile, the terminal key bar (`ExtraKeyBar`) required one tap per deleted character. Holding `⌫` — and the four arrow keys — now auto-repeats like a physical keyboard: a 400 ms delay, then one press every 60 ms.

The tap itself is still handled by `onClick`; the timer only emits the *extra* presses, so a quick tap sends exactly one key. The repeat is cancelled on `pointerup`, `pointerleave`, `pointercancel` and unmount.

Verified in headless Chromium on a mobile viewport against a live terminal by counting the outgoing PTY frames: a ~1.2 s hold sent 14 `DEL`s, a single tap sent 1. Two unit tests cover the repeat-after-delay and the stop-on-release / stop-on-slide-off paths.