### PR TITLE
Rotate the remote-access QR token once a minute

### DIFF
--- a/change-logs/2026/08/14/chore-slower-qr-token-rotation.md
+++ b/change-logs/2026/08/14/chore-slower-qr-token-rotation.md
@@ -1,0 +1,1 @@
+The remote-access QR code and its share link now rotate once a minute instead of every 25 seconds (the signed URL's lifetime grew from 30 to 65 seconds to match), so a link you just handed to a phone stays valid noticeably longer.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -16,8 +16,8 @@ That's the whole thing. It prints an ASCII QR code, a public URL, and an SSH-for
 
 ## How the connection works
 
-The access URL is signed with a short-lived JWT — **30 seconds, single use** — and the QR
-auto-refreshes every 25 seconds. Once you scan it, the browser keeps a trusted session for 8
+The access URL is signed with a short-lived JWT — **65 seconds, single use** — and the QR
+auto-refreshes every 60 seconds. Once you scan it, the browser keeps a trusted session for 8
 hours and reconnects on reload without rescanning.
 
 Three ways in, printed on every start:

--- a/src/bun/__tests__/jwt.test.ts
+++ b/src/bun/__tests__/jwt.test.ts
@@ -91,13 +91,13 @@ describe("createQrToken", () => {
 		}
 	});
 
-	it("creates tokens with type 'qr' and ~30s expiry", async () => {
+	it("creates tokens with type 'qr' and ~65s expiry", async () => {
 		const token = await createQrToken();
 		// Decode the payload (middle part) to inspect
 		const payloadB64 = token.split(".")[1];
 		const payload = JSON.parse(atob(payloadB64.replace(/-/g, "+").replace(/_/g, "/")));
 		expect(payload.type).toBe("qr");
-		expect(payload.exp - payload.iat).toBe(30);
+		expect(payload.exp - payload.iat).toBe(65);
 		expect(payload.jti).toBeTruthy();
 	});
 
@@ -141,7 +141,7 @@ describe("exchangeQrForSession", () => {
 		const qrToken = await createQrToken();
 		// Manually create an expired token by modifying Date.now
 		const originalNow = Date.now;
-		Date.now = () => originalNow() + 31_000; // 31 seconds later
+		Date.now = () => originalNow() + 66_000; // 66 seconds later
 		const result = await exchangeQrForSession(qrToken);
 		Date.now = originalNow;
 		expect(result).toBeNull();

--- a/src/bun/jwt.ts
+++ b/src/bun/jwt.ts
@@ -2,7 +2,7 @@
  * Zero-dependency JWT module using Bun's Web Crypto API (HMAC-SHA256).
  *
  * Two token types:
- * - "qr"      — short-lived (30s), embedded in QR code URLs, single-use
+ * - "qr"      — short-lived (65s), embedded in QR code URLs, single-use
  * - "session" — long-lived (24h rolling), carried in an HttpOnly cookie,
  *   refreshable
  */
@@ -13,7 +13,7 @@ import { DEV3_HOME } from "./paths";
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const QR_TOKEN_TTL_S = 30;
+const QR_TOKEN_TTL_S = 65;
 // 24 hours — long enough that a "trusted device" (your own phone/laptop)
 // survives overnight idle without rescanning the QR. The session rides an
 // HttpOnly cookie refreshed on load + every 15 min while open, so an active

--- a/src/bun/remote-console.ts
+++ b/src/bun/remote-console.ts
@@ -3,7 +3,7 @@
  *
  * Prints an ASCII QR code (via `qrcode` lib) with the access URL and user-facing
  * tips (SSH port-forward template, tunnel hint). Re-generates the QR every
- * 25s to stay within the 30s JWT TTL — same schedule as the GUI modal in
+ * 60s to stay within the 65s JWT TTL — same schedule as the GUI modal in
  * `src/mainview/App.tsx:443-462`.
  *
  * The refresh halts as soon as a client successfully redeems the QR token
@@ -17,7 +17,7 @@ import { tunnelManager } from "./cloudflare-tunnel";
 
 const log = createLogger("remote-console");
 
-const REFRESH_INTERVAL_MS = 25_000; // QR TTL is 30s; refresh with 5s headroom
+const REFRESH_INTERVAL_MS = 60_000; // QR TTL is 65s; refresh with 5s headroom
 
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 let qrConsumed = false;
@@ -68,7 +68,7 @@ export async function renderHeadlessBanner(opts: BannerOptions): Promise<void> {
 	if (staticCode) {
 		console.log("  URL (static code — no rotation, dev only):");
 	} else {
-		console.log("  URL (includes one-time QR token, regenerated every 25s):");
+		console.log("  URL (includes one-time QR token, regenerated every 60s):");
 	}
 	console.log(`  ${accessUrl}`);
 	if (staticCode) {
@@ -82,9 +82,9 @@ export async function renderHeadlessBanner(opts: BannerOptions): Promise<void> {
 }
 
 /**
- * Start the auto-refresh timer that regenerates the QR every 25s and reprints
+ * Start the auto-refresh timer that regenerates the QR every 60s and reprints
  * just the URL line (we do NOT reprint the QR — it would clobber scrollback).
- * The QR image itself stays valid for 30s from when it was last printed;
+ * The QR image itself stays valid for 65s from when it was last printed;
  * users who want a fresh visual QR can rerun the command.
  *
  * The timer stops automatically when `markQrConsumed()` is called.

--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -36,8 +36,8 @@ Usage:
 What it does:
   Starts a Bun-only dev-3.0 server (no GUI window) and serves the full web UI
   to any browser over HTTP + WebSocket. Prints an ASCII QR code and an access
-  URL signed with a short-lived (30s, single-use) JWT token — the QR is
-  auto-refreshed every 25 seconds, matching the GUI modal's behavior.
+  URL signed with a short-lived (65s, single-use) JWT token — the QR is
+  auto-refreshed every 60 seconds, matching the GUI modal's behavior.
 
   By default a Cloudflare quick tunnel (trycloudflare.com) is started and its
   public URL is included in the QR, so you can connect from any device without

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -81,6 +81,9 @@ import { isTaskTerminalRoute } from "./utils/terminalFullscreen";
 /** Command shown when cloudflared is missing (Cloudflare Tunnel remote access). */
 const CLOUDFLARED_INSTALL_CMD = "brew install cloudflared";
 
+/** QR token rotation period; the token's own TTL (`QR_TOKEN_TTL_S`) adds 5s headroom. */
+const QR_REFRESH_SECONDS = 60;
+
 type RemoteAccessQRData = {
 	qrDataUrl: string;
 	accessUrl: string;
@@ -2024,7 +2027,7 @@ function App() {
 
 	// QR token consumed — someone connected via the QR code
 	const [qrConsumed, setQrConsumed] = useState(false);
-	const [qrCountdown, setQrCountdown] = useState(25);
+	const [qrCountdown, setQrCountdown] = useState(QR_REFRESH_SECONDS);
 
 	useEffect(() => {
 		function onQrConsumed() {
@@ -2074,7 +2077,7 @@ function App() {
 		return () => window.removeEventListener("rpc:showRemoteAccessQR", onShowRemoteQR);
 	}, [applyRemoteQR, startRemoteTunnel]);
 
-	// Auto-refresh QR code every 25 seconds while modal is open (JWT tokens expire in 30s)
+	// Auto-refresh QR code every 60 seconds while modal is open (JWT tokens expire in 65s)
 	// After a QR is consumed, keep polling without visually rotating the token:
 	// a recovered Quick Tunnel gets a new hostname, and the open modal must
 	// reactivate with that new URL instead of staying green on a dead domain.
@@ -2085,19 +2088,19 @@ function App() {
 	qrConsumedRef.current = qrConsumed;
 	const remoteQRRef = useRef(remoteQR);
 	remoteQRRef.current = remoteQR;
-	// Preserve the chosen interface/IP across the 25s token refresh — without
+	// Preserve the chosen interface/IP across the 60s token refresh — without
 	// this, picking a host would snap back to the auto-pick on the next tick.
 	const selectedHostRef = useRef<string | undefined>(undefined);
 	selectedHostRef.current = remoteQR?.selectedHost;
 	useEffect(() => {
 		if (!qrModalOpen) return;
-		setQrCountdown(25);
-		let counter = 25;
+		setQrCountdown(QR_REFRESH_SECONDS);
+		let counter = QR_REFRESH_SECONDS;
 		let refreshInFlight = false;
 		const tick = setInterval(() => {
 			counter -= 1;
 			if (counter <= 0) {
-				counter = 25;
+				counter = QR_REFRESH_SECONDS;
 				const host = tunnelWantedRef.current ? undefined : selectedHostRef.current;
 				if (!refreshInFlight) {
 					refreshInFlight = true;
@@ -2515,7 +2518,7 @@ function App() {
 									<svg className="w-4 h-4 -rotate-90" viewBox="0 0 20 20">
 										<circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" strokeWidth="2" opacity="0.2" />
 										<circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" strokeWidth="2"
-											strokeDasharray={`${(qrCountdown / 25) * 50.3} 50.3`}
+											strokeDasharray={`${(qrCountdown / QR_REFRESH_SECONDS) * 50.3} 50.3`}
 											strokeLinecap="round"
 											className="transition-[stroke-dasharray] duration-1000 ease-linear"
 										/>

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1920,7 +1920,7 @@ describe("App keyboard shortcuts", () => {
 				});
 
 				await act(async () => {
-					await vi.advanceTimersByTimeAsync(25_000);
+					await vi.advanceTimersByTimeAsync(60_000);
 				});
 
 				expect(api.request.getRemoteAccessQR).toHaveBeenCalledWith({ tunnel: true, host: undefined });


### PR DESCRIPTION
Rotate the remote-access QR code and its share link once a minute instead of every 25 seconds, so a link handed to a phone stays usable noticeably longer.

- `QR_REFRESH_SECONDS` (GUI modal, `src/mainview/App.tsx`) and the headless `dev3 remote` refresher (`src/bun/remote-console.ts`) both go 25s → 60s; the countdown ring and label read off the same constant.
- `QR_TOKEN_TTL_S` (`src/bun/jwt.ts`) goes 30s → 65s to keep the same 5s headroom — without it the token would die 35s before the next rotation minted a replacement.
- No other behavior change: the token stays single-use with `jti` replay prevention, and a rotated-out link is not accepted afterwards.
- Docs, `dev3 remote --help` text and comments updated to the new numbers; jwt/App tests updated to the new TTL and timer.

Verified with `bun run lint`, the jwt / remote-access / CLI remote / App suites, and a live browser pass: the modal counts down to 1s and wraps to 60s, no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b2310c6d-9255-40ea-a571-4634d85f5565) · `dev3://task/b2310c6d-9255-40ea-a571-4634d85f5565` _(dev3 added this footer — turn it off in Settings → Tasks.)_