### PR TITLE
Publish the Windows build through the canary update channel

### DIFF
--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -52,6 +52,7 @@ jobs:
       macos-x64: ${{ steps.probe.outputs.macos-x64 }}
       linux-x64: ${{ steps.probe.outputs.linux-x64 }}
       linux-arm64: ${{ steps.probe.outputs.linux-arm64 }}
+      win-x64: ${{ steps.probe.outputs.win-x64 }}
     steps:
       - uses: actions/checkout@v5
 
@@ -96,7 +97,8 @@ jobs:
       needs.decide.outputs.macos-arm64 == 'true' ||
       needs.decide.outputs.macos-x64 == 'true' ||
       needs.decide.outputs.linux-x64 == 'true' ||
-      needs.decide.outputs.linux-arm64 == 'true'
+      needs.decide.outputs.linux-arm64 == 'true' ||
+      needs.decide.outputs.win-x64 == 'true'
     uses: ./.github/workflows/windows-conpty-package.yml
 
   # ──────────────────────────────────────────────────
@@ -159,3 +161,23 @@ jobs:
       tag: ${{ github.sha }}
       publish: true
       bestEffort: true
+
+  # THE ONLY CHANNEL WINDOWS PUBLISHES TO. There is deliberately no Windows caller in
+  # release.yml: the stable feed is what an ordinary user's app polls, and the Windows build
+  # is UNSIGNED — SmartScreen greets its first launch — so it goes where the stakes are low
+  # first. See decisions/2026/08/08/windows-ships-through-canary-first.md.
+  #
+  # `bestEffort: false`: unlike linux-arm64, this platform is proven. The same commit is
+  # packaged, launched and shut down cleanly by the `windows-proof` gate above before this job
+  # starts, so a failure here is a real failure of the publish, not an unproven target.
+  build-win-x64:
+    needs: [decide, windows-proof]
+    if: needs.decide.outputs.win-x64 == 'true'
+    uses: ./.github/workflows/release-build-windows.yml
+    secrets: inherit
+    with:
+      arch: x64
+      runsOn: windows-latest
+      channel: canary
+      tag: ${{ github.sha }}
+      publish: true

--- a/.github/workflows/release-build-windows.yml
+++ b/.github/workflows/release-build-windows.yml
@@ -1,0 +1,182 @@
+name: Release build (Windows)
+
+# The Windows leg of the publishing path, shaped like release-build-macos.yml and
+# release-build-linux.yml so one reader can hold all three. Today it has exactly ONE caller —
+# canary-publish.yml. That is deliberate: the build is UNSIGNED and will never be signed (no
+# certificate, by decision), so its first launch on any machine shows Windows' SmartScreen
+# warning. That belongs on the channel whose users opted into surprises.
+# See decisions/2026/08/08/windows-ships-through-canary-first.md.
+#
+# TWO FILES ARE PUBLISHED, and they are not interchangeable:
+#   `<channel>-win-<arch>-<app>.tar.zst`  the in-app updater's download. Windows tar.exe cannot
+#                                        read zstd, so a human cannot open it.
+#   `<channel>-win-<arch>-<app>.zip`      the first install. The tree the launch proof below
+#                                        actually spawned, zipped, so Explorer extracts it with
+#                                        nothing installed.
+#
+# NO CLI TARBALL. create-cli-tarball.sh has a macos branch and a linux branch and no Windows
+# one; `dev3.exe` ships INSIDE the bundle (`Resources/app/cli/dev3.exe`, asserted by the launch
+# proof), so there is nothing missing here — adding a Windows branch to that script is its own
+# change, with `dev3 self-install` on Windows to think about.
+#
+# EVERY INPUT IS REQUIRED, NO DEFAULTS. A default publishes the wrong channel, or publishes at
+# all from a dry run, with every test still green.
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: "x64 — feeds cache keys, script args and artifact paths (no arm64 Windows target today)"
+        required: true
+        type: string
+      runsOn:
+        description: "Runner label (windows-latest)"
+        required: true
+        type: string
+      channel:
+        description: "stable or canary — prefixes every artifact name and the update manifest"
+        required: true
+        type: string
+      tag:
+        description: "Tag or ref being built, used for the versioned S3 prefix"
+        required: true
+        type: string
+      publish:
+        # THE MOST DANGEROUS INPUT IN THIS FILE, for the reason spelled out at length in
+        # release-build-linux.yml: a reusable workflow cannot read its caller's `needs`, and a
+        # job output is a STRING, so a raw `false` arrives truthy and every dry run becomes a
+        # live publish to the feed real users poll, while the run stays green.
+        description: "Whether to upload to S3. Pass an explicit boolean comparison, never a raw output string."
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runsOn }}
+    # The packaging half of this job is measured at ~3 minutes on windows-latest (run
+    # 31257371545); the rest of the budget is the launch proof's 4-minute readiness window plus
+    # zipping and uploading ~400 MB. Same 35 as the proof job it mirrors.
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history + tags: build-update-changelog.ts resolves the previous release tag and
+          # diffs the changelog window. The shallow default left the update popover empty
+          # (decision 152).
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      # `bun install` costs ~255s on Windows — the one platform where it is worth caching, and
+      # the same key the Windows proof job uses on purpose: same lockfile, same runner, one
+      # entry serves both.
+      - name: Restore node_modules cache
+        id: cache-deps
+        uses: actions/cache/restore@v5
+        with:
+          path: ./node_modules
+          key: bun-deps-windows-x64-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Save node_modules cache
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ./node_modules
+          key: bun-deps-windows-x64-${{ hashFiles('bun.lock') }}
+
+      - name: Clean build directory
+        shell: bash
+        run: rm -rf ./build ./artifacts
+
+      # The same command list as `package:win-archive`, with the channel as an input instead of
+      # hardcoded `canary`. electrobun's own postBuild/postPackage hooks assemble and re-verify
+      # the native terminal host image out of the final archive from here.
+      - name: Build release
+        env:
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
+        run: |
+          bun scripts/generate-build-info.ts
+          bun scripts/generate-changelog.ts
+          bunx vite build
+          bun run build:cli
+          bunx electrobun build --env=${{ inputs.channel }}
+
+      - name: Debug build output
+        if: always()
+        shell: bash
+        run: |
+          echo "=== ./build/ ==="
+          find ./build -maxdepth 3 -type f 2>/dev/null || echo "(empty)"
+          echo "=== ./artifacts/ ==="
+          ls -lhR ./artifacts/ 2>/dev/null || echo "(empty)"
+
+      # THE STEP THAT MAKES THIS PUBLISHABLE AT ALL, and it has no `continue-on-error`.
+      # It extracts the very archive published below, launches the desktop executable, waits for
+      # the ready marker and proves the whole process tree dies. A Windows build that never
+      # reached a window must not reach a user, and this is the only thing standing between
+      # those two facts.
+      - name: Launch the packaged Windows app and prove clean shutdown
+        timeout-minutes: 10
+        env:
+          DEV3_REQUIRE_WINDOWS_PROOF: "1"
+          # Durable, not a temp workspace the script deletes: the zip staged in the next step is
+          # built out of THIS directory, so the bytes a human downloads are the bytes that ran.
+          DEV3_WINDOWS_APP_UNPACK_DIR: ${{ github.workspace }}\windows-app-unpacked
+        run: bun run verify:win-app-launch
+
+      - name: Upload Windows launch proof
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: windows-launch-proof-${{ inputs.channel }}-${{ inputs.arch }}
+          path: |
+            artifacts/windows-app-launch-proof.json
+            artifacts/windows-app-layout.json
+            artifacts/windows-conpty-package-proof.json
+
+      # BEFORE create-release-artifacts.sh, which deletes ./artifacts and with it the proof this
+      # reads. Reads `retainedUnpackDir` out of the launch proof, so it cannot zip a tree
+      # nothing launched.
+      - name: Stage the launched tree as the downloadable zip
+        env:
+          DEV3_RELEASE_CHANNEL: ${{ inputs.channel }}
+          DEV3_RELEASE_ARCH: ${{ inputs.arch }}
+        run: bun scripts/package-windows-launched-tree.ts
+
+      - name: Create release artifacts
+        shell: bash
+        run: bash ./scripts/create-release-artifacts.sh win ${{ inputs.arch }} ${{ inputs.channel }}
+
+      - name: Upload artifacts to S3
+        if: inputs.publish
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: eu-west-1
+        run: |
+          TAG="${{ inputs.tag }}"
+          aws s3 sync "./artifacts-win-${{ inputs.arch }}/" "s3://h0x91b-releases/dev-3.0/$TAG/"
+          # THE MANIFEST GOES LAST, AND IT IS THE ONLY FILE CLIENTS DISCOVER BUILDS THROUGH.
+          # Measured on run 31091740061: one sync of the whole directory uploaded
+          # `*-update.json` FIRST on 4 of 4 platforms, advertising a tarball not yet at the root
+          # path for 2.25-2.99s. Splitting the root sync in two closes that window; a client
+          # polling between the two syncs reads the PREVIOUS manifest, which is correct.
+          aws s3 sync "./artifacts-win-${{ inputs.arch }}/" "s3://h0x91b-releases/dev-3.0/" \
+            --exclude "*-update.json"
+          aws s3 cp "./artifacts-win-${{ inputs.arch }}/${{ inputs.channel }}-win-${{ inputs.arch }}-update.json" \
+            "s3://h0x91b-releases/dev-3.0/"
+
+      - name: Upload artifacts for release job
+        uses: actions/upload-artifact@v5
+        with:
+          name: artifacts-win-${{ inputs.arch }}
+          path: ./artifacts-win-${{ inputs.arch }}/

--- a/change-logs/2026/08/14/feature-windows-canary-channel.md
+++ b/change-logs/2026/08/14/feature-windows-canary-channel.md
@@ -1,0 +1,3 @@
+Short: Windows builds now reach the canary channel
+
+Windows (win-x64) now publishes to the canary update channel: the update manifest plus a downloadable .zip of the exact app tree CI launched and shut down cleanly, so a Windows user can install dev-3.0 for the first time instead of digging a build out of a workflow run. The build is not code-signed, so Windows shows a SmartScreen warning on first launch; the download instructions say so plainly. Tagged stable releases still ship no Windows build.

--- a/decisions/2026/08/08/windows-ships-through-canary-first.md
+++ b/decisions/2026/08/08/windows-ships-through-canary-first.md
@@ -1,0 +1,187 @@
+# Windows ships through the canary channel only, unsigned, and the first install is the launched tree
+
+## Context
+
+Windows has been packaged on every in-scope merge to `main` since
+`windows-proof-post-merge-not-pull-request.md`, and the packaged app provably reaches a window
+and dies cleanly. None of it reached a human. The output was a 30-day CI artifact behind a
+GitHub login: not attached to a release, not in the update bucket, not installable by anyone who
+was not looking at a workflow run. Arseny asked why Windows builds for minutes and appears
+nowhere. It appeared nowhere.
+
+Two facts set the shape of the answer, and both are his:
+
+1. **Canary first, deliberately** — every Windows-specific surprise should surface where the
+   stakes are low.
+2. **There is no Windows code-signing certificate and there will not be one.** An unsigned build
+   is the target, not a stopgap. Nothing here may be designed around buying one.
+
+## Investigation
+
+The gap was narrower than it looked. `getPlatformPrefix()` in `src/bun/updater.ts` already
+returns `win` for `process.platform === "win32"`, and `electrobun build --env=canary` on Windows
+already emits `canary-win-x64-update.json` plus `canary-win-x64-dev-3.0-canary.tar.zst`. What was
+missing was a publisher: `CANARY_PLATFORMS` listed four platforms, `canary-publish.yml` had four
+caller jobs, `create-release-artifacts.sh` branched on `macos` and `linux`, and no
+`release-build-windows.yml` existed.
+
+The launch log of the Windows job on run 31257371545 also produced the finding that ordered the
+work. The packaged canary build's **runtime** channel was `stable` — `getAppVersion` returned
+`{"channel":"stable","buildChannel":"canary"}` — because the then-global `CANARY_FEED_AVAILABLE
+= false` collapsed any canary preference, so it fetched `stable-win-x64-update.json` and logged
+`HTTP 403`.
+
+That constant is **gone**: #1310 (Seq 1443) replaced it with `canaryPublishesFor(os, arch)`,
+derived from `CANARY_PLATFORMS` itself so publishing and availability cannot drift. **That makes
+the `win-x64` entry added here the single switch that unlocks the channel on Windows** — which is
+the intended design, and also the reason the ordering below is written down rather than left to
+whoever merges next.
+
+Two candidate first-install files exist, and they are not equal:
+
+| Candidate | Openable on a stock Windows box | Ever launched by anything |
+|---|---|---|
+| `canary-win-x64-dev-3.0-canary.tar.zst` | **no** — `tar.exe` has no zstd; the bundle ships `zig-zstd.exe` for exactly this reason | yes, extracted then launched |
+| `dev-3.0-Setup-canary.zip` (self-extracting `.exe`) | yes | **no — no job has ever run it** |
+| the extracted tree, zipped | yes | yes, this is the tree that reached a window |
+
+## Decision
+
+**Windows publishes to canary and only canary, and the human-installable file is the tree the
+launch proof spawned.**
+
+- `CANARY_PLATFORMS` gains `{ os: "win", arch: "x64" }` (`src/shared/canary-publish.ts`). The
+  token is `win`, not `windows`: it names electrobun's build folder, its artifact prefix, and the
+  manifest key `getPlatformPrefix()` fetches, so one string has to serve all three.
+- New `.github/workflows/release-build-windows.yml`, shaped like its macOS and Linux siblings,
+  with one caller: `build-win-x64` in `canary-publish.yml`, gated on `windows-proof` like every
+  other publisher. **`release.yml` gets no Windows caller** — an unsigned build does not belong
+  in the feed ordinary users poll.
+- `scripts/create-release-artifacts.sh` grows a `win` branch **and an OS allowlist**. The
+  allowlist is the load-bearing half: `windows` is the word every runner label and filename uses,
+  it previously fell through to the linux branch, and it would have published a flawless
+  `canary-windows-x64-update.json` that no client ever fetches.
+- `scripts/package-windows-launched-tree.ts` reads `retainedUnpackDir` out of
+  `windows-app-launch-proof.json` and zips **that** directory, after checking the launcher the
+  proof named is still inside it. It structurally cannot zip a re-extraction, which is the
+  property `downloadable-windows-build-is-the-launched-tree.md` exists to keep — the same rule,
+  now applied to a file in the bucket instead of a CI artifact.
+
+  **The Windows build is not byte-reproducible, which turns that rule from tidy into load-bearing.**
+  Three runs built sha `068ea95df` and produced three artifacts of the same name at 130 056 815,
+  130 056 817 and 130 056 830 bytes — a 15-byte spread, measured through the artifacts API filtered
+  by name. So "extract the same archive again" does not even yield the same bytes as another run's
+  tree, and *which* run a `.zip` came from is not recoverable from its name. Only the same run's
+  retained directory qualifies, and only the run id identifies it.
+- The run summary carries the unsigned-launch warning as prose next to the download link. Hiding
+  it turns a SmartScreen dialog into a malware verdict.
+
+## What the unsigned warning actually does — measured, not predicted
+
+Artifact `windows-app-068ea95df…` from run **31781800859** (v1.44.0), downloaded in a browser onto
+a real x64 Windows machine, extracted to `D:\tmp\dev-3.0-canary`, launched via `bin\launcher.exe`
+(583 KB in Explorer = the 596 992 bytes the launch proof recorded for that executable):
+
+| | Observed |
+|---|---|
+| First launch | a full-screen blue SmartScreen warning |
+| Clicks to get past it | **two** — «Подробнее», then «Всё равно запустить» (ru-RU machine; the en-US strings are *More info* / *Run anyway*, inferred from the standard pair, not read) |
+| Title / body text | **not captured.** It is localised, and the operator reported it is awkward to screenshot |
+| After clicking through | the app runs. Title bar `[CANARY] dev-3.0 v1.44.0`, board renders, a task was created and a Claude Code agent ran in a Windows worktree over PowerShell |
+| Browser warning while downloading | **not reported.** Unknown, not "absent" |
+
+So the cost of shipping unsigned is two extra clicks, once per build, and a scary full-screen
+dialog that a first-time user will read as a malware verdict unless something tells them otherwise.
+That is why the download instructions in `package-windows-launched-tree.ts` name the click path
+explicitly and say the warning means *unrecognised publisher*, not *virus found*. The title line is
+deliberately not quoted there — quoting the English one on a machine that shows Russian, or the
+reverse, would be worse than describing it.
+
+## "Launched on Windows" is meaningless without naming which bytes
+
+Because the build is not reproducible, there are three different claims here and they are easy to
+collapse into one sentence that sounds stronger than any of them:
+
+| Claim | Proven by | Names the bytes as |
+|---|---|---|
+| the published zip's bytes reached a window and shut down cleanly | `verify:win-app-launch` in the publishing run | that run's id |
+| a build of this code runs on real hardware, and the OS warning says *X* | a human launching a CI artifact | that artifact's run id |
+| **the published bytes reached a window on a human's machine** | a human launching the zip **from the bucket** | the bucket key |
+
+Only the third is acceptance, and it cannot exist before the publish — so **it must never gate the
+PR or the merge**, or the task deadlocks on a file that does not exist yet. It is a short second
+pass taken immediately after the first publish.
+
+Never write "launched on Windows" unqualified in a report. Say which byte set, named by run id or
+bucket key. A green first pass followed by a failing second pass is the most valuable outcome this
+sequence can produce, not an embarrassment: it would mean the publishing path corrupts something
+the proof does not look at.
+
+## Never bootstrap a platform by dispatching `canary-publish.yml` from a branch
+
+It is the obvious move — the branch has the platform in `CANARY_PLATFORMS` and the build job,
+`main` has neither, so a `--ref <branch>` dispatch looks like a way to observe the new manifest
+before merging anything. It was proposed twice while this task ran. **It publishes the other four
+platforms from unmerged code, and it corrupts canary ordering for them.**
+
+`decidePlatformPublish` compares the published `sha` against `GITHUB_SHA`, which on a branch
+dispatch is the branch head. Measured at the time of writing:
+
+| | sha | buildOrder |
+|---|---|---|
+| published canary manifests (all four) | `7a9d230fb` | 1618 |
+| `main` | `7a9d230fb` | 1618 |
+| this branch | `9169b4e9d` | 1619 |
+
+So every platform reports BUILD, and `publish: true` is a literal on this path. macOS and Linux
+canary users are then offered 1619 — greater than their 1618, so they install it — from a commit
+that is not on `main`. Then the squash merge of that same PR lands on `main` at **1619 as well**,
+because `git rev-list --count` moves by one per squashed PR. Remote 1619 is not greater than local
+1619, so those users are never offered the merged build and sit on an off-`main` bundle until an
+unrelated merge reaches 1620.
+
+The safe bootstrap is instead: **merge, then dispatch on `main` as the very next action**, read
+the new manifest anonymously, and cite the 200.
+
+Between those two moments Windows is selectable with nothing in the bucket to select — the window
+`canaryPublishesFor()` necessarily creates, measured at 15–20 minutes off run 31257371545 and
+**unbounded if the never-before-executed Windows build job fails on its first run**. It is
+survivable for one reason, and it is not the length: **no Windows user can be running a build
+from that commit at all**, because Windows has no distribution channel until this leg publishes —
+which is the entire premise of this change. The only possible holders are people who pull CI
+artifacts or run from source, and they are the ones equipped to read a run summary.
+
+That safety is temporary and specific to the first Windows publish. Once Windows is distributed,
+the same window would be a real 403 for real users, so a second platform must not be bootstrapped
+this way without re-deriving the argument.
+
+## Risks
+
+- **Windows is packaged twice per canary run**: once by the `windows-proof` gate, once by this
+  publisher. Measured ~3 minutes for the packaging half, so it is paid knowingly. Folding the
+  upload into `windows-conpty-package.yml` would have removed it, but that workflow is also
+  `release.yml`'s gate, and editing it reaches the stable release path.
+- **No Windows CLI tarball.** `create-cli-tarball.sh` has no Windows branch; `dev3.exe` ships
+  inside the bundle (asserted by the launch proof), so nothing is missing from the app — but a
+  Windows user cannot install the CLI standalone the way a macOS or Linux user can.
+- **The self-extracting installer is still unpublished and still unproven.** Anyone finding
+  `dev-3.0-Setup-canary.zip` in the build output must not assume it was vetted. Closing that gap
+  means growing the launch proof a second target (install, launch from there, uninstall).
+- **`stable-win-x64-update.json` does not exist**, so a Windows build's update check 403s
+  forever until stable also publishes Windows. Out of scope here, and named rather than left to
+  be rediscovered.
+- **Windows canary has no arm64 leg.** A Windows-on-ARM machine runs the x64 build under
+  emulation, untested by anything.
+
+## Alternatives considered
+
+- **Publish the Setup installer as the first install.** It is the shape a real Windows release
+  would ship, which is exactly why handing it out unproven is worse than not handing it out:
+  the unvetted thing would be the one with a future. Deferred, not rejected.
+- **Add the S3 upload to `windows-conpty-package.yml`** and reuse the build the proof already
+  makes. Saves the duplicate packaging, but that file is `release.yml`'s gate, so it drags the
+  stable path into a canary change.
+- **Ship Windows in tagged stable releases at the same time.** Rejected by Arseny's own
+  instruction, and correct on its own merits: the first unsigned Windows build meeting real
+  users should meet the ones who opted into surprises.
+- **Buy a code-signing certificate.** Ruled out by the user, and not revisited here.

--- a/scripts/create-release-artifacts.sh
+++ b/scripts/create-release-artifacts.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Creates release artifacts for a given OS, architecture and update channel.
 # Usage: ./scripts/create-release-artifacts.sh <os> <arch> <channel>
-#   os:      macos or linux
+#   os:      macos, linux or win
 #   arch:    arm64 or x64
 #   channel: stable or canary (must match the `electrobun build --env=` used)
 # Outputs artifacts to ./artifacts-<os>-<arch>/
@@ -18,8 +18,17 @@ set -euo pipefail
 # and `buildOrder` fields the channel logic needs. A second writer would let the feed
 # disagree with itself.
 
-OS="${1:?Usage: $0 <os> <arch> <channel> (os: macos|linux, arch: arm64|x64, channel: stable|canary)}"
-ARCH="${2:?Usage: $0 <os> <arch> <channel> (os: macos|linux, arch: arm64|x64, channel: stable|canary)}"
+OS="${1:?Usage: $0 <os> <arch> <channel> (os: macos|linux|win, arch: arm64|x64, channel: stable|canary)}"
+ARCH="${2:?Usage: $0 <os> <arch> <channel> (os: macos|linux|win, arch: arm64|x64, channel: stable|canary)}"
+# OS IS VALIDATED, and `win` is the whole reason. It is the token getPlatformPrefix() in
+# src/bun/updater.ts builds the feed URL from, so `windows` — the obvious thing to type, and
+# what every runner label and workflow filename says — would produce a perfectly well-formed
+# `canary-windows-x64-update.json` that no client ever asks for, with the run green and the
+# bucket looking populated. Before this guard the unknown OS just fell into the linux branch.
+if [ "$OS" != "macos" ] && [ "$OS" != "linux" ] && [ "$OS" != "win" ]; then
+  echo "::error::unknown os '${OS}' (expected macos|linux|win). This token names electrobun's build folder AND the published manifest key the in-app updater fetches (getPlatformPrefix in src/bun/updater.ts) — Windows is 'win', never 'windows'."
+  exit 1
+fi
 # CHANNEL is REQUIRED and deliberately NOT defaulted. A default would let a future
 # caller publish canary artifacts into the stable feed — every filename here is
 # prefixed with it — and nothing would go red, because a missing argument would read
@@ -43,6 +52,9 @@ BUILD_DIR="./build/${CHANNEL}-${OS}-${ARCH}"
 PLATFORM_PREFIX="${CHANNEL}-${OS}-${ARCH}"
 OUTPUT_DIR="./artifacts-${OS}-${ARCH}"
 ZSTD="./node_modules/electrobun/dist-${OS}-${ARCH}/zig-zstd"
+if [ "$OS" = "win" ]; then
+  ZSTD="${ZSTD}.exe"
+fi
 
 # Identity and ordering for the manifest. `sha` says WHICH COMMIT (the hourly canary
 # workflow compares it against main to decide whether to build at all); `buildOrder`
@@ -104,6 +116,13 @@ if [ "$OS" = "macos" ]; then
   APP_BUNDLE="${APP_FILE_NAME}.app"
   TAR_NAME="${APP_FILE_NAME}.app.tar"
   VERSION_JSON_SUBPATH="${APP_BUNDLE}/Contents/Resources/version.json"
+elif [ "$OS" = "win" ]; then
+  # Same flat bundle shape as Linux, but capital-R `Resources` — measured off the tree the
+  # launch proof extracted on run 31257371545 (`dev-3.0-canary/bin/launcher.exe`,
+  # `dev-3.0-canary/Resources/app/...`). find_version_json's fallback covers a layout change.
+  APP_BUNDLE="${APP_FILE_NAME}"
+  TAR_NAME="${APP_FILE_NAME}.tar"
+  VERSION_JSON_SUBPATH="${APP_BUNDLE}/Resources/version.json"
 else
   APP_BUNDLE="${APP_FILE_NAME}"
   TAR_NAME="${APP_FILE_NAME}.tar"

--- a/scripts/package-windows-launched-tree.ts
+++ b/scripts/package-windows-launched-tree.ts
@@ -1,0 +1,141 @@
+/**
+ * Turns the tree the launch proof actually spawned into the ONE file a Windows human can
+ * open, and stages it beside the update tarball for publication.
+ *
+ * WHY A SECOND FILE AT ALL. `canary-win-x64-dev-3.0-canary.tar.zst` is what the in-app
+ * updater downloads, and Windows `tar.exe` cannot read zstd — the bundle ships electrobun's
+ * `zig-zstd.exe` precisely because of that. So the archive that serves updates is unopenable
+ * to somebody who does not have the app yet, and a channel with no first install is a channel
+ * nobody can join. A `.zip` is the one container Explorer extracts with nothing installed.
+ *
+ * WHY IT IS BUILT FROM THE PROOF AND NOT FROM THE ARCHIVE. The rule this file exists to keep
+ * is decisions/2026/08/06/downloadable-windows-build-is-the-launched-tree.md: the bytes handed
+ * to a human must be bytes something actually launched. Re-extracting the same `.tar.zst`
+ * would produce an equal-looking tree that nothing ever started, and would read identically
+ * in the log. So the source directory is read OUT of `windows-app-launch-proof.json`
+ * (`retainedUnpackDir`), and the launcher named there must exist inside it before anything is
+ * compressed. This script structurally cannot zip a tree no proof ran.
+ *
+ * The self-extracting `dev-3.0-Setup-canary.exe` the build also produces is NOT published
+ * here. Nothing has ever launched it — a known gap, not a rejected idea; see the same record.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const BUCKET_BASE = "https://h0x91b-releases.s3.eu-west-1.amazonaws.com/dev-3.0";
+
+type LaunchProof = {
+	retainedUnpackDir?: unknown;
+	bundleRoot?: unknown;
+	desktopExecutableRelativePath?: unknown;
+};
+
+function fail(message: string): never {
+	console.error(`::error::${message}`);
+	process.exit(1);
+}
+
+function requireString(proof: LaunchProof, field: keyof LaunchProof, why: string): string {
+	const value = proof[field];
+	if (typeof value !== "string" || !value) {
+		fail(`the Windows launch proof carries no \`${field}\`, so ${why}. Fix: run \`bun run verify:win-app-launch\` with DEV3_WINDOWS_APP_UNPACK_DIR set before this step — without that variable the proof extracts into a temp workspace it deletes, and there is no launched tree left to publish.`);
+	}
+	return value;
+}
+
+/**
+ * `ZipFile.CreateFromDirectory`, not `Compress-Archive`: the tree is ~400 MB across thousands
+ * of files and the cmdlet takes minutes on it, inside a job with a 35-minute budget.
+ * `includeBaseDirectory: false` keeps the bundle root (`dev-3.0-canary/`) as the zip's single
+ * top-level entry, because that root is already the unpack dir's only child — so extracting
+ * gives one folder, not a hundred loose files in Downloads.
+ */
+function zipDirectory(sourceDir: string, destinationZip: string): void {
+	const script = [
+		"Add-Type -AssemblyName System.IO.Compression.FileSystem;",
+		"[System.IO.Compression.ZipFile]::CreateFromDirectory(",
+		`  '${sourceDir.replaceAll("'", "''")}',`,
+		`  '${destinationZip.replaceAll("'", "''")}',`,
+		"  [System.IO.Compression.CompressionLevel]::Optimal,",
+		"  $false)",
+	].join("\n");
+
+	const result = spawnSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], {
+		encoding: "utf8",
+	});
+	if (result.error) fail(`powershell could not be run to build the zip: ${result.error.message}`);
+	if (result.status !== 0) {
+		fail(`zipping the launched tree failed (powershell exited ${result.status}): ${(result.stderr || result.stdout || "").trim()}`);
+	}
+}
+
+const channel = process.env.DEV3_RELEASE_CHANNEL;
+const arch = process.env.DEV3_RELEASE_ARCH;
+if (channel !== "stable" && channel !== "canary") {
+	fail(`DEV3_RELEASE_CHANNEL must be stable or canary, got '${channel ?? ""}'. It prefixes the published file name, so guessing it would publish one channel's build under the other channel's name.`);
+}
+if (!arch) fail("DEV3_RELEASE_ARCH is unset, so the published file name would be missing its architecture");
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const proofPath = resolve(process.env.DEV3_WINDOWS_LAUNCH_PROOF ?? join(repoRoot, "artifacts", "windows-app-launch-proof.json"));
+if (!existsSync(proofPath)) {
+	fail(`no Windows launch proof at ${proofPath}. This step must run AFTER \`bun run verify:win-app-launch\` and BEFORE create-release-artifacts.sh, which deletes ./artifacts.`);
+}
+
+let proof: LaunchProof;
+try {
+	proof = JSON.parse(readFileSync(proofPath, "utf8")) as LaunchProof;
+} catch (error) {
+	fail(`the Windows launch proof at ${proofPath} is not valid JSON (${String(error)}), so the launched tree cannot be identified`);
+}
+
+const unpackDir = resolve(requireString(proof, "retainedUnpackDir", "the directory the proof launched from is unknown"));
+const bundleRoot = requireString(proof, "bundleRoot", "the bundle folder inside it is unknown");
+const launcherRelative = requireString(proof, "desktopExecutableRelativePath", "the executable it started is unknown");
+
+const launcherPath = join(unpackDir, bundleRoot, ...launcherRelative.split("/"));
+if (!existsSync(launcherPath)) {
+	fail(`the launch proof names ${launcherRelative} inside ${bundleRoot}, but ${launcherPath} does not exist. The retained tree was moved or cleaned between the proof and this step, so what would be published is not what launched. Fix: keep DEV3_WINDOWS_APP_UNPACK_DIR untouched between the two steps.`);
+}
+
+const outputDir = resolve(join(repoRoot, `artifacts-win-${arch}`));
+mkdirSync(outputDir, { recursive: true });
+// Named off `bundleRoot` rather than recomputed from the channel: the name then cannot
+// disagree with the bytes, and it lines up with electrobun's own
+// `canary-win-x64-dev-3.0-canary.tar.zst` without a second copy of the suffix rule.
+const zipName = `${channel}-win-${arch}-${bundleRoot}.zip`;
+const zipPath = join(outputDir, zipName);
+
+console.log(`Zipping the launched tree: ${unpackDir} -> ${zipPath}`);
+zipDirectory(unpackDir, zipPath);
+const zipBytes = statSync(zipPath).size;
+console.log(`Staged ${zipName} (${(zipBytes / 1024 / 1024).toFixed(1)} MB)`);
+
+// The download instructions live with the artifact, not in a wiki. The SmartScreen paragraph
+// is not decoration: a canary user who meets an unexplained "Windows protected your PC"
+// dialog concludes the app is malware, and there is no certificate coming.
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+	appendFileSync(
+		summaryPath,
+		[
+			"",
+			"## Windows canary build",
+			"",
+			`**Download:** ${BUCKET_BASE}/${zipName} (${(zipBytes / 1024 / 1024).toFixed(1)} MB)`,
+			"",
+			`1. Download the \`.zip\`, right-click it → **Extract All**. No other tool is needed.`,
+			`2. Open the extracted \`${bundleRoot}\` folder and double-click \`${launcherRelative}\`.`,
+			// MEASURED, not predicted, on a real ru-RU Windows machine: the buttons were
+			// «Подробнее» then «Всё равно запустить» — two clicks, and the app ran normally
+			// afterwards. The title line is deliberately NOT quoted here: it is localised, and
+			// nobody has read the en-US one.
+			`3. **This build is not code-signed, and it never will be.** Windows blanks the screen with a blue SmartScreen warning the first time you run it. Getting past it is two clicks: **More info**, then **Run anyway**. This is Windows telling you it does not recognise the publisher — not a virus report.`,
+			"",
+			`These are the exact bytes the launch proof spawned in this run — bundle root \`${bundleRoot}\`, entry point \`${launcherRelative}\`.`,
+			"",
+		].join("\n"),
+	);
+}

--- a/src/bun/__tests__/canary-publish.test.ts
+++ b/src/bun/__tests__/canary-publish.test.ts
@@ -88,8 +88,40 @@ describe("deciding whether a platform needs an canary build", () => {
 	it("covers every platform the workflow publishes", () => {
 		expect(
 			CANARY_PLATFORMS.map((p) => `${p.os}-${p.arch}`),
-			"the platform list must match the four caller jobs in canary-publish.yml. A platform present in the workflow but missing here is never probed, so it publishes every hour regardless of whether main moved.",
-		).toEqual(["macos-arm64", "macos-x64", "linux-x64", "linux-arm64"]);
+			"the platform list must match the caller jobs in canary-publish.yml. A platform present in the workflow but missing here is never probed, so it publishes every hour regardless of whether main moved.",
+		).toEqual(["macos-arm64", "macos-x64", "linux-x64", "linux-arm64", "win-x64"]);
+	});
+
+	// The token, not the platform. `windows` is what every runner label, workflow filename and
+	// English sentence says, and it would build a perfectly well-formed
+	// `canary-windows-x64-update.json` that no client ever fetches — green run, populated
+	// bucket, zero Windows users updated, nothing anywhere saying why.
+	it("spells Windows the way the updater spells it, not the way the runner does", () => {
+		const updater = readFileSync(
+			fileURLToPath(new URL("../updater.ts", import.meta.url)),
+			"utf8",
+		);
+		expect(
+			updater,
+			"getPlatformPrefix no longer maps win32 to 'win'. The published manifest key and the key the app asks for are built from two different files, and this is the only thing tying them together. Fix: whichever side changed, change the other in the same commit.",
+		).toMatch(/"win32"\s*\?\s*"win"/);
+		expect(
+			CANARY_PLATFORMS.map((p) => p.os),
+			"a platform is declared as 'windows'. The in-app updater fetches `{channel}-win-{arch}-update.json`, so publishing under 'windows' writes a manifest nobody reads.",
+		).not.toContain("windows");
+	});
+
+	// A platform can be probed and never built, which is the quieter half of the same bug: the
+	// decide job reports BUILD, nothing consumes the output, and the run is green with that
+	// platform silently absent from the feed forever.
+	it("gives every probed platform a caller job that actually builds it", () => {
+		const missing = CANARY_PLATFORMS.map((p) => `${p.os}-${p.arch}`).filter(
+			(key) => !new RegExp(`^ {2}build-${key}:$`, "m").test(WORKFLOW),
+		);
+		expect(
+			missing,
+			`${missing.join(", ")} is probed by the decide job but has no \`build-<platform>\` caller job in canary-publish.yml. The probe would report BUILD, nothing would consume it, and that platform would never appear in the feed — with the run green every hour. Fix: add the caller job.`,
+		).toEqual([]);
 	});
 });
 

--- a/src/bun/__tests__/create-release-artifacts.test.ts
+++ b/src/bun/__tests__/create-release-artifacts.test.ts
@@ -263,6 +263,84 @@ describe("create-release-artifacts.sh", () => {
 		).toBe("1.42.3");
 	});
 
+	// `windows` is the word every runner label, workflow filename and English sentence uses,
+	// and it is the wrong one: the in-app updater fetches `{channel}-win-{arch}-update.json`
+	// (getPlatformPrefix, src/bun/updater.ts). Before the guard, an unknown OS fell through to
+	// the linux branch and produced a flawless `canary-windows-x64-update.json` that no client
+	// ever asks for — green run, files in the bucket, nobody updated.
+	it("rejects 'windows' rather than publishing a manifest key nobody fetches", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dev3-release-artifacts-"));
+		tempDirs.push(tempDir);
+
+		const result = spawnSync("bash", [SCRIPT_PATH, "windows", "x64", "canary"], { cwd: tempDir, encoding: "utf8" });
+
+		expect(
+			result.status,
+			"an unknown os must fail. Falling through to the linux branch names every artifact `canary-windows-x64-*`, which is well-formed, published, and invisible to every client.",
+		).not.toBe(0);
+		expect(`${result.stdout}${result.stderr}`).toMatch(/unknown os 'windows'/);
+	});
+
+	// The whole Windows branch in one pass: the build-folder name electrobun uses
+	// (`build/canary-win-x64`), the `.exe` suffix on zig-zstd, the capital-R `Resources`
+	// version.json path measured off run 31257371545, and the `win` token landing in the
+	// manifest the updater keys on. Runs on any host: nothing here is a Windows binary.
+	it("stages the Windows tarball and writes a manifest keyed 'win'", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dev3-release-artifacts-"));
+		tempDirs.push(tempDir);
+
+		const buildDir = join(tempDir, "build", "canary-win-x64");
+		mkdirSync(join(buildDir, "dev-3.0-canary", "Resources"), { recursive: true });
+		writeFileSync(
+			join(buildDir, "dev-3.0-canary", "Resources", "version.json"),
+			JSON.stringify({ version: "1.42.2", hash: "3r8kx81pg91jh", channel: "canary" }),
+		);
+		// A real tar and deliberately no .zst, so the compress branch runs and its `.exe` path
+		// is exercised rather than assumed.
+		spawnSync("tar", ["-cf", join(buildDir, "dev-3.0-canary.tar"), "-C", buildDir, "dev-3.0-canary"], {
+			encoding: "utf8",
+		});
+		const zstdDir = join(tempDir, "node_modules", "electrobun", "dist-win-x64");
+		mkdirSync(zstdDir, { recursive: true });
+		writeFileSync(
+			join(zstdDir, "zig-zstd.exe"),
+			['#!/bin/sh', '[ "$1" = "compress" ] || { echo "error: InvalidArgs"; exit 1; }', 'shift', 'IN=""; OUT=""',
+				'while [ $# -gt 0 ]; do', '  case "$1" in', '    -i) IN="$2"; shift 2 ;;', '    -o) OUT="$2"; shift 2 ;;',
+				'    --*) shift ;;', '    *) echo "error: InvalidArgs"; exit 1 ;;', "  esac", "done",
+				'cp "$IN" "$OUT"'].join("\n"),
+			{ mode: 0o755 },
+		);
+
+		const result = spawnSync("bash", [SCRIPT_PATH, "win", "x64", "canary"], { cwd: tempDir, encoding: "utf8" });
+		const output = `${result.stdout}${result.stderr}`;
+
+		expect(
+			output,
+			"zig-zstd on Windows is `zig-zstd.exe`. A missing suffix makes this branch die with 'No such file or directory' only when electrobun crashes between tarring and compressing — the one path nobody exercises.",
+		).not.toMatch(/No such file or directory|InvalidArgs/);
+		expect(
+			output,
+			"version.json must be found at the EXPECTED Windows path. The `find` fallback notice means the bundle layout moved, which the log has to show rather than silently absorb.",
+		).not.toMatch(/version\.json found at unexpected path/);
+		expect(
+			existsSync(join(tempDir, "artifacts-win-x64", "canary-win-x64-dev-3.0-canary.tar.zst")),
+			"the staged tarball must carry electrobun's own Windows name, or the manifest advertises a download that is not in the bucket under that key.",
+		).toBe(true);
+
+		const manifest = JSON.parse(
+			readFileSync(join(tempDir, "artifacts-win-x64", "canary-win-x64-update.json"), "utf8"),
+		) as { os: string; arch: string };
+		expect(
+			manifest.os,
+			"the manifest's os field must be 'win', matching getPlatformPrefix in src/bun/updater.ts. 'windows' here means the file the app fetches disagrees with the file this script wrote.",
+		).toBe("win");
+		expect(manifest.arch).toBe("x64");
+		expect(
+			result.status,
+			"the whole Windows path must EXIT 0. Staging happens before the channel check, so an existing tarball is not proof the script accepted the build.",
+		).toBe(0);
+	});
+
 	// Both fields land in the manifest this script is the single writer of. They answer
 	// different questions: sha says WHICH COMMIT (the hourly workflow's skip check),
 	// buildOrder says WHICH BUILD IS NEWER (canary clients' ordering).

--- a/src/bun/__tests__/package-windows-launched-tree.test.ts
+++ b/src/bun/__tests__/package-windows-launched-tree.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The zip a Windows human downloads must be the tree something launched.
+ *
+ * These assertions are all REFUSALS, and that is not a gap in coverage — it is where the whole
+ * risk lives. Zipping works or it does not, loudly. The failure this file guards is the quiet
+ * one: a zip built from an equal-looking re-extraction of the same archive, which nothing ever
+ * started, and which reads identically in the log to the real thing. Every branch below is a
+ * way that could happen.
+ *
+ * The compression itself is not asserted here: it goes through PowerShell's
+ * System.IO.Compression, which does not exist on the host running this suite. It is covered by
+ * the Windows job, where the produced zip is the published artifact.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../../../scripts/package-windows-launched-tree.ts",
+);
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function run(proof: unknown | null, env: Record<string, string> = {}) {
+	const tempDir = mkdtempSync(join(tmpdir(), "dev3-win-tree-"));
+	tempDirs.push(tempDir);
+	const proofPath = join(tempDir, "launch-proof.json");
+	if (proof !== null) writeFileSync(proofPath, JSON.stringify(proof));
+
+	const result = spawnSync("bun", [SCRIPT_PATH], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			DEV3_RELEASE_CHANNEL: "canary",
+			DEV3_RELEASE_ARCH: "x64",
+			DEV3_WINDOWS_LAUNCH_PROOF: proofPath,
+			...env,
+		},
+	});
+	return { ...result, output: `${result.stdout}${result.stderr}`, tempDir };
+}
+
+describe("packaging the launched Windows tree", () => {
+	it("refuses a proof with no retained unpack dir, instead of re-extracting the archive", () => {
+		const result = run({ bundleRoot: "dev-3.0-canary", desktopExecutableRelativePath: "bin/launcher.exe" });
+
+		expect(result.status, "a proof without `retainedUnpackDir` means the launch happened in a temp workspace that is already deleted. There is no launched tree left, and the only way to produce a zip anyway is to re-extract the archive — a look-alike nothing ran.").not.toBe(0);
+		expect(result.output).toMatch(/retainedUnpackDir/);
+		expect(
+			result.output,
+			"the failure must name the fix, because the cause is one missing environment variable two steps earlier and nothing else points at it.",
+		).toMatch(/DEV3_WINDOWS_APP_UNPACK_DIR/);
+	});
+
+	it("refuses when the tree no longer holds the executable the proof launched", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dev3-win-unpack-"));
+		tempDirs.push(tempDir);
+		// The bundle root exists, so the directory looks entirely plausible — it just does not
+		// contain the launcher any more, which is what a cleanup step between the two jobs
+		// leaves behind.
+		mkdirSync(join(tempDir, "dev-3.0-canary", "bin"), { recursive: true });
+
+		const result = run({
+			retainedUnpackDir: tempDir,
+			bundleRoot: "dev-3.0-canary",
+			desktopExecutableRelativePath: "bin/launcher.exe",
+		});
+
+		expect(result.status, "the tree must be verified against the proof, not trusted because the directory exists. A tree missing its launcher zips into a download that cannot start.").not.toBe(0);
+		expect(result.output).toMatch(/bin\/launcher\.exe/);
+	});
+
+	it("refuses a missing proof by naming the step ordering that causes it", () => {
+		const result = run(null);
+
+		expect(result.status).not.toBe(0);
+		expect(
+			result.output,
+			"the ordering IS the bug: create-release-artifacts.sh deletes ./artifacts, so running this after it finds no proof. The error has to say so or the next reader debugs the proof instead of the order.",
+		).toMatch(/create-release-artifacts\.sh/);
+	});
+
+	it("refuses to guess the channel it is publishing under", () => {
+		const result = run(
+			{ retainedUnpackDir: "/nope", bundleRoot: "dev-3.0-canary", desktopExecutableRelativePath: "bin/launcher.exe" },
+			{ DEV3_RELEASE_CHANNEL: "" },
+		);
+
+		expect(result.status, "the channel prefixes the published file name. Defaulting it would publish a canary build under the stable name, where ordinary users' apps would find it.").not.toBe(0);
+		expect(result.output).toMatch(/DEV3_RELEASE_CHANNEL/);
+	});
+
+	it("rejects a channel it does not publish, the same way the artifact script does", () => {
+		const result = run(
+			{ retainedUnpackDir: "/nope", bundleRoot: "dev-3.0-canary", desktopExecutableRelativePath: "bin/launcher.exe" },
+			{ DEV3_RELEASE_CHANNEL: "unstable" },
+		);
+
+		expect(result.status, "`unstable` is this channel's PREVIOUS name, so it is exactly what a stale caller passes. It must fail here as loudly as it does in create-release-artifacts.sh.").not.toBe(0);
+	});
+});

--- a/src/shared/canary-publish.ts
+++ b/src/shared/canary-publish.ts
@@ -9,12 +9,19 @@
  * See decisions/2026/08/06/stable-canary-update-channels.md.
  */
 
-/** Every platform the canary channel publishes, in the order the workflow declares them. */
+/**
+ * Every platform the canary channel publishes, in the order the workflow declares them.
+ *
+ * The `os` token is the one `getPlatformPrefix()` in src/bun/updater.ts builds its feed URL
+ * from, so Windows is `win`, never `windows`. The same token names electrobun's build folder
+ * (`build/canary-win-x64`) and its artifact prefix, which is why one string serves all three.
+ */
 export const CANARY_PLATFORMS = [
 	{ os: "macos", arch: "arm64" },
 	{ os: "macos", arch: "x64" },
 	{ os: "linux", arch: "x64" },
 	{ os: "linux", arch: "arm64" },
+	{ os: "win", arch: "x64" },
 ] as const;
 
 /**

--- a/src/shared/windows-ci-scope.ts
+++ b/src/shared/windows-ci-scope.ts
@@ -46,6 +46,10 @@ export const WINDOWS_SCOPE_PATHS = [
 	".github/workflows/release.yml",
 	".github/workflows/release-build-macos.yml",
 	".github/workflows/release-build-linux.yml",
+	// The Windows leg, and unlike its two siblings above it is in under BOTH criteria: it pins
+	// Bun AND it is the only workflow that packages the app a Windows user installs. An edit
+	// here changes the shipped Windows build directly, so it must re-run the proof.
+	".github/workflows/release-build-windows.yml",
 	".github/workflows/native-terminal-soak.yml",
 	"electrobun.config.ts",
 	"package.json",
@@ -55,6 +59,7 @@ export const WINDOWS_SCOPE_PATHS = [
 	"scripts/build-terminal-host.ts",
 	"scripts/package-native-host.ts",
 	"scripts/package-posix-native-host.ts",
+	"scripts/package-windows-launched-tree.ts",
 	"scripts/verify-packaged-windows-conpty.ts",
 	"scripts/verify-windows-app-launch.ts",
 	"scripts/verify-windows-conpty-update-archive.ts",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

Windows has been packaged and launch-proven on every in-scope merge for a while, and none of it reached a human: the output was a 30-day CI artifact behind a GitHub login. This adds the missing publisher.

- `win-x64` joins `CANARY_PLATFORMS`. The token is `win`, not `windows`, because that is what `getPlatformPrefix()` builds the feed URL from and what names electrobun's build folder.
- New reusable `release-build-windows.yml` with exactly one caller: `build-win-x64` in `canary-publish.yml`, gated on `windows-proof` like every other publisher. **`release.yml` gets no Windows caller** — the build is unsigned and will not be signed, so it goes where the stakes are low. The release-page leg is a separate task.
- `create-release-artifacts.sh` gains a `win` branch **and an OS allowlist**. The allowlist is the load-bearing half: `windows` previously fell through to the linux branch and would have published a well-formed `canary-windows-x64-update.json` that no client ever fetches.
- `package-windows-launched-tree.ts` publishes the human-installable `.zip` built from `retainedUnpackDir` in the launch proof, so it structurally cannot zip a tree nothing launched. This matters more than it reads: the build is **not byte-reproducible** — three runs on sha `068ea95df` produced artifacts 15 bytes apart — so re-extracting the archive would not even yield another run's bytes.

Two files are published per run and they are not interchangeable: the `.tar.zst` the updater downloads (Windows `tar.exe` cannot read zstd, so a human cannot open it), and the `.zip` a human extracts with nothing installed.

**Unsigned, measured on real hardware rather than predicted.** Artifact `windows-app-068ea95df…` (run 31781800859, v1.44.0) on an x64 Windows box: first launch shows a full-screen blue SmartScreen warning, two clicks to pass it (`Подробнее` → `Всё равно запустить` on a ru-RU machine), and the app then runs normally — title bar `[CANARY] dev-3.0 v1.44.0`, board renders, a task ran a Claude Code agent over PowerShell. The dialog's title text was not captured and is not quoted anywhere, because it is localised. The download instructions in the run summary name the click path and say the warning means *unrecognised publisher*, not *virus found*.

Rationale, risks and the two ordering traps found on the way are in `decisions/2026/08/08/windows-ships-through-canary-first.md`.

**Do not enable auto-merge on this PR.** `canary-publish` must be dispatched on `main` immediately after the merge: adding `win-x64` to the list is what unlocks the channel on Windows via `canaryPublishesFor()`, and no `canary-win-x64-update.json` exists until a run publishes one.