### PR TITLE
Widen artifact reports and make their tables read like data grids

### DIFF
--- a/change-logs/2026/08/14/feature-03-artifact-template-wide-tables.md
+++ b/change-logs/2026/08/14/feature-03-artifact-template-wide-tables.md
@@ -1,0 +1,3 @@
+Short: Wider artifact reports, readable tables
+
+The dev3 artifact starter now grows with the viewport up to 1840px instead of parking a fixed 1180px column on a wide monitor, and every table reads like a data grid: alternating row tint, a full-row hover highlight, vertical rules between cells, tabular figures, a header that stays pinned while the rows scroll, and a caret showing the sorted column and direction. Dense evidence ledgers keep their first column pinned so a row never becomes an anonymous strip of digits.

--- a/decisions/2026/08/14/artifact-table-sticky-header-scrollports.md
+++ b/decisions/2026/08/14/artifact-table-sticky-header-scrollports.md
@@ -1,0 +1,36 @@
+# Sticky artifact table headers depend on which box is the scrollport
+
+## Context
+
+The artifact starter's tables gained a header that stays visible while rows scroll
+(`src/assets/artifact-template/app.css`, `thead th`). `position: sticky` resolves its
+offset against the nearest scrollport, which made two existing rules silently hostile.
+
+## Investigation
+
+1. `.table-card` used `overflow: hidden` to clip the table to the card radius. That makes
+   the card a scroll container, so the header pinned to the card — which never scrolls —
+   and never moved. `overflow: clip` clips identically without creating a scrollport.
+2. `.evidence-table-scroll` sets `overflow-x: auto`, so its block axis computes to `auto`
+   too and it *is* a scrollport. With the page offset applied, the evidence header rendered
+   56px down inside the ledger, painted over the first rows. Verified in headless Chromium
+   before and after the fix.
+
+## Decision
+
+`.table-card` uses `overflow: clip`. The page offset lives in `--dev3-table-head-top`, set
+by `trackStickyOffset()` in `app.js` from the measured `.section-nav` height (0 when a
+report has no nav), and `.evidence-table thead th` resets it to `top: 0`. Print resets
+`position: static` so `thead` repeats per page instead of pinning.
+
+## Risks
+
+`overflow: clip` needs Chromium/Safari 16+; older engines lose corner clipping but keep the
+layout. A report that hand-builds its own sticky chrome above the nav can overlap the header —
+it must feed its own height into `--dev3-table-head-top`.
+
+## Alternatives considered
+
+Hard-coding `top: 56px` (breaks reports without a nav, and any nav that wraps);
+`JavaScript`-driven header cloning (heavier, breaks print and text selection);
+leaving headers unpinned (the original problem — a 200-row ledger loses its column names).

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -32,6 +32,8 @@ Do not read or edit `app.css` or `app.js` unless the artifact format itself must
 
 `.card` already carries its own padding, so a bare `<section class="card">` looks right with plain content inside it. `.section` and `.kpi` set a roomier padding, and `.table-card` intentionally drops it so a table can run edge to edge. Never re-pad a card from report markup.
 
+The container grows with the viewport up to 1840px, so dense tables and dashboards use a wide monitor instead of leaving it empty. Because the panels are wide, put running prose in `<p class="prose">` (or any `.prose` block) to hold a readable line length; short `.muted` and `.section-copy` lines are capped for you. `.kpis` fits as many cards per row as the width allows, so a report may ship three or six KPI cards without a layout override.
+
 ## Preview and share
 
 Pass every local dependency explicitly after `--assets`:
@@ -84,11 +86,17 @@ Keep form markup native and opt into the polished CDN controls with one attribut
 Use native checkbox, radio, and switch markup from `index.html`; `app.css` supplies the shared skin without report JavaScript.
 When report code changes an enhanced select or range, call `dev3Artifact.setControl(element, value)` so the native value, visual control, events, and output stay synchronized.
 
+## Tables
+
+Every table gets its reading aids from the shell: alternating row tint, a full-row hover highlight, a vertical rule between cells, tabular figures, and a header that stays visible while the rows scroll. Do not re-implement any of it in report code, and do not add per-row background styles.
+
+Mark a sortable heading with `data-sort` plus `tabindex="0"`; the shell maintains `aria-sort` and renders the ascending/descending caret, so report code only has to sort the data. A heading without `data-sort` renders as a plain label with no pointer cursor.
+
 ## Dense evidence tables
 
 Keep decision summaries and charts first, then preserve exhaustive source rows in a visible evidence ledger. Large mechanically produced datasets may live in an additional classic JavaScript asset such as `evidence-data.js`; list it in `--assets`, load it before `report.js`, and keep only rendering logic in `report.js`.
 
-Wrap wide tables in `.evidence-table-scroll` and add `.evidence-table` to the table. The shell keeps every column reachable with horizontal scrolling on narrow screens and lays all columns out for print. Reuse the semantic source markers `.good`, `.bad`, `.sig`, `.flat`, `.dim`, `.sep`, `.regime`, and `.total`; the shell maps them to dev3 tokens, quiet typographic significance emphasis, column separators, rollout boundaries, and total rows.
+Wrap wide tables in `.evidence-table-scroll` and add `.evidence-table` to the table. The shell keeps every column reachable with horizontal scrolling on narrow screens and lays all columns out for print. The first column is pinned while the numbers scroll past it, so put the row's identity there — a day, a cohort, a file — and never a value that only makes sense next to its neighbours. Reuse the semantic source markers `.good`, `.bad`, `.sig`, `.flat`, `.dim`, `.sep`, `.regime`, and `.total`; the shell maps them to dev3 tokens, quiet typographic significance emphasis, column separators, rollout boundaries, and total rows.
 
 ## Print and PDF
 

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -24,7 +24,11 @@
     }
     /* Stacked top-level blocks are spaced by the container, so any panel order
        an author writes keeps the same rhythm without per-panel margins. */
-    .app { display: flex; max-width: 1180px; flex-direction: column; gap: 14px; margin: auto; }
+    /* Wide monitors get the room instead of a 1000px empty gutter; prose keeps a
+       readable measure through .prose instead of the container. */
+    .app { display: flex; width: min(100%, clamp(1180px, 88vw, 1840px)); flex-direction: column; gap: 14px; margin: auto; }
+    .prose { max-width: 72ch; }
+    .muted, .section-copy { max-width: 90ch; }
     .topbar, .brand, .actions, .segmented, .inline, .table-tools { display: flex; align-items: center; }
     .topbar { justify-content: space-between; gap: 20px; margin-bottom: 6px; }
     .brand { gap: 13px; }
@@ -122,7 +126,7 @@
       color: rgb(var(--dev3-accent));
     }
     .grid { display: grid; gap: 14px; }
-    .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .kpis { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
     .stack { display: grid; gap: 14px; }
     .card {
       padding: 16px;
@@ -369,7 +373,8 @@
       background: rgb(var(--dev3-accent) / .18);
       color: rgb(var(--dev3-text-primary));
     }
-    .table-card { padding: 0; overflow: hidden; }
+    /* clip, not hidden: hidden makes the card a scrollport and unpins the header. */
+    .table-card { padding: 0; overflow: clip; }
     .table-head { padding: 16px 18px 12px; }
     .table-tools { gap: 8px; }
     .table-tools input, .table-tools select {
@@ -381,16 +386,31 @@
       outline: none;
     }
     .table-tools input { width: 190px; }
-    table { width: 100%; border-collapse: collapse; }
+    table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
     th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); text-align: left; font-size: 12px; }
+    /* A vertical rule keeps the eye inside one column across a wide row; every
+       cell owns its trailing edge so a pinned column can strengthen its own. */
+    th:not(:last-child), td:not(:last-child) { border-inline-end: 1px solid rgb(var(--dev3-border) / .5); }
     th {
       color: rgb(var(--dev3-text-muted));
       font-weight: 600;
       letter-spacing: .05em;
       text-transform: uppercase;
-      cursor: pointer;
     }
-    tbody tr:hover { background: rgb(var(--dev3-accent) / .04); }
+    /* border-collapse drops borders on sticky cells, so paint them inset. */
+    thead th { position: sticky; z-index: 5; top: var(--dev3-table-head-top, 0px); background: rgb(var(--dev3-surface-raised)); box-shadow: inset 0 -1px 0 rgb(var(--dev3-border)); }
+    th[data-sort] { cursor: pointer; }
+    th[data-sort]:hover { color: rgb(var(--dev3-text-secondary)); }
+    th[data-sort]::after { margin-inline-start: 6px; content: "↕"; font-size: 10px; opacity: .3; }
+    th[data-sort]:hover::after { opacity: .65; }
+    th[aria-sort]::after { color: rgb(var(--dev3-accent)); opacity: 1; }
+    th[aria-sort="ascending"]::after { content: "↑"; }
+    th[aria-sort="descending"]::after { content: "↓"; }
+    /* The tint travels as a variable so a pinned cell can composite the same
+       zebra/hover state over its own opaque base. */
+    tbody tr { background: var(--dev3-row-tint, transparent); transition: background-color .12s ease; }
+    tbody tr:nth-child(even) { --dev3-row-tint: rgb(var(--dev3-text-primary) / .045); }
+    tbody tr:hover { --dev3-row-tint: rgb(var(--dev3-accent) / .1); }
     .evidence-book { display: grid; gap: 16px; }
     .evidence-toolbar, .evidence-legend { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
     .evidence-toolbar { justify-content: space-between; }
@@ -412,7 +432,13 @@
     .evidence-table { width: max-content; min-width: 100%; font-variant-numeric: tabular-nums; }
     .evidence-table th, .evidence-table td { padding: 6px 9px; white-space: nowrap; text-align: right; font-size: 10.5px; }
     .evidence-table th { background: rgb(var(--dev3-surface-raised)); cursor: default; font-size: 9.5px; }
-    .evidence-table th:first-child, .evidence-table td:first-child { text-align: left; }
+    /* Its own scroller is the scrollport, so the page offset would push the
+       header onto the rows instead of pinning it. */
+    .evidence-table thead th { top: 0; }
+    /* The label column stays put while the numbers scroll past it. */
+    .evidence-table th:first-child, .evidence-table td:first-child { position: sticky; inset-inline-start: 0; border-inline-end-color: rgb(var(--dev3-border)); text-align: left; }
+    .evidence-table thead th:first-child { z-index: 6; }
+    .evidence-table tbody td:first-child { z-index: 1; background-color: rgb(var(--dev3-surface-raised)); background-image: linear-gradient(var(--dev3-row-tint, transparent), var(--dev3-row-tint, transparent)); }
     .evidence-table th.grp { border-left: 1px solid rgb(var(--dev3-border)); text-align: center; color: rgb(var(--dev3-text-secondary)); }
     .evidence-table .sep { border-left: 1px solid rgb(var(--dev3-border)); }
     .evidence-table .day { color: rgb(var(--dev3-text-primary)); font-weight: 650; }
@@ -462,6 +488,10 @@
     .dev3-footer a:hover { text-decoration: underline; }
 
 
+    /* A chart growing sideways needs height, or a wide panel reads as a strip. */
+    @media (min-width: 1500px) {
+      .chart-host { height: 330px; }
+    }
     @media (max-width: 900px) {
       .kpis { grid-template-columns: repeat(2, 1fr); }
       .dashboard-grid { grid-template-columns: 1fr; }
@@ -494,7 +524,7 @@
         color: rgb(var(--dev3-text-primary)) !important;
       }
       body { padding: 0; font-size: 10px; }
-      .app { max-width: none; gap: 8px; }
+      .app { width: auto; gap: 8px; }
       .topbar { margin-bottom: 0; }
       .brand { gap: 9px; }
       .brand img { width: 34px; height: 34px; border-radius: 10px; box-shadow: none; }
@@ -525,6 +555,9 @@
       .table-head { padding: 8px 10px 6px; }
       th, td { padding: 5px 10px; font-size: 8px; }
       thead { display: table-header-group; }
+      /* Repeat the header on every page instead of pinning it to a scrollport. */
+      thead th, .evidence-table th:first-child, .evidence-table td:first-child { position: static; box-shadow: none; }
+      th[data-sort]:not([aria-sort])::after { content: ""; margin: 0; }
       .evidence-book { gap: 8px; }
       .evidence-toolbar, .evidence-legend { display: none !important; }
       .evidence-group { overflow: visible; border-radius: 8px; break-inside: auto; }

--- a/src/assets/artifact-template/app.js
+++ b/src/assets/artifact-template/app.js
@@ -79,6 +79,38 @@
     });
   }
 
+  // A sticky table header must land below the sticky section nav, and sit at the
+  // very top when a report has no nav at all.
+  function trackStickyOffset() {
+    const nav = document.querySelector(".section-nav");
+    const apply = () => {
+      const offset = nav ? Math.round(nav.getBoundingClientRect().height) : 0;
+      document.documentElement.style.setProperty("--dev3-table-head-top", `${offset}px`);
+    };
+    apply();
+    window.addEventListener("resize", apply);
+  }
+
+  // Report code owns sorting; the shell owns only the visible sort state, so
+  // every artifact shows which column is sorted and in which direction.
+  function initializeSortIndicators() {
+    document.querySelectorAll("thead").forEach((head) => {
+      const headings = [...head.querySelectorAll("th[data-sort]")];
+      if (!headings.length) return;
+      const mark = (heading) => {
+        const next = heading.getAttribute("aria-sort") === "ascending" ? "descending" : "ascending";
+        headings.forEach((item) => item.removeAttribute("aria-sort"));
+        heading.setAttribute("aria-sort", next);
+      };
+      headings.forEach((heading) => {
+        heading.addEventListener("click", () => mark(heading));
+        heading.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") mark(heading);
+        });
+      });
+    });
+  }
+
   const selectControls = new Map();
   const sliderControls = new Map();
 
@@ -295,6 +327,8 @@
 
   registerDev3ChartTheme();
   initializeNavigation();
+  trackStickyOffset();
+  initializeSortIndicators();
   enhanceControls();
 
   // ---- generic shell controls -----------------------------------------------

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -259,6 +259,49 @@ describe("bundled artifact starter contract", () => {
 		expect(html).not.toContain("crossorigin=");
 	});
 
+	it("uses the full width of a wide monitor while prose keeps a measure", () => {
+		const css = readFileSync(cssPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+
+		expect(css).toContain("width: min(100%, clamp(1180px, 88vw, 1840px))");
+		expect(css).toContain(".prose { max-width: 72ch; }");
+		expect(css).toContain(".kpis { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }");
+		expect(css).toContain("@media (min-width: 1500px)");
+		expect(guide).toContain("`.prose`");
+	});
+
+	it("gives every table zebra rows, row hover, column rules, and a pinned header", () => {
+		const css = readFileSync(cssPath, "utf8");
+		const app = readFileSync(appPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+
+		expect(css).toContain("th:not(:last-child), td:not(:last-child) { border-inline-end:");
+		expect(css).toContain("tbody tr:nth-child(even) { --dev3-row-tint:");
+		expect(css).toContain("tbody tr:hover { --dev3-row-tint:");
+		expect(css).toContain("top: var(--dev3-table-head-top, 0px)");
+		// hidden would turn the card into a scrollport and unpin the header.
+		expect(css).toContain(".table-card { padding: 0; overflow: clip; }");
+		// The evidence scroller is its own scrollport, so the page offset must not apply.
+		expect(css).toContain(".evidence-table thead th { top: 0; }");
+		expect(css).toContain('th[aria-sort="descending"]::after');
+		expect(app).toContain("function trackStickyOffset");
+		expect(app).toContain("--dev3-table-head-top");
+		expect(app).toContain("function initializeSortIndicators");
+		expect(app).toContain('setAttribute("aria-sort", next)');
+		expect(guide).toContain("## Tables");
+	});
+
+	it("keeps the pinned evidence label column readable while the numbers scroll", () => {
+		const css = readFileSync(cssPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+		const printBlock = css.slice(css.indexOf("@media print"));
+
+		expect(css).toContain("inset-inline-start: 0");
+		expect(css).toContain("background-image: linear-gradient(var(--dev3-row-tint, transparent)");
+		expect(printBlock).toContain(".evidence-table th:first-child, .evidence-table td:first-child { position: static;");
+		expect(guide).toContain("The first column is pinned");
+	});
+
 	it("keeps dense-table significance markers typographic", () => {
 		const css = readFileSync(cssPath, "utf8");
 		const significanceRule = css.match(/\.evidence-table \.sig\s*\{([^}]*)\}/)?.[1] || "";
@@ -335,7 +378,9 @@ describe("bundled artifact starter contract", () => {
 		// makes artifact HTML unreadable for agents (the reason we load from CDN).
 		expect(statSync(htmlPath).size).toBeLessThan(120_000);
 		expect(statSync(htmlPath).size).toBeLessThan(MAX_SHARED_ARTIFACT_HTML_BYTES);
-		expect(statSync(cssPath).size).toBeLessThan(30_000);
+		// The shell stylesheet is not part of the authoring surface, so its budget
+		// only has to stay far below an inlined library.
+		expect(statSync(cssPath).size).toBeLessThan(34_000);
 		expect(statSync(appPath).size).toBeLessThan(30_000);
 		expect(statSync(reportPath).size).toBeLessThan(15_000);
 	});


### PR DESCRIPTION
## Summary

The artifact starter parked a fixed 1180px column on any monitor and rendered its tables as flat, undifferentiated rows, so a wide report scrolled sideways while a thousand pixels of gutter sat empty.

**Layout** — `.app` is now `min(100%, clamp(1180px, 88vw, 1840px))`, `.kpis` uses `auto-fit` so a report can ship three or six KPI cards without a layout override, and chart hosts grow to 330px above 1500px. Running prose gets `.prose` (72ch) so the wider panels do not stretch a paragraph into a 200-character line; short `.muted` / `.section-copy` lines are capped for authors.

**Tables** — alternating row tint, a full-row hover highlight, a vertical rule between cells, tabular figures, and a header pinned while the rows scroll. The tint travels as `--dev3-row-tint` so a pinned cell can composite the same zebra/hover state over its own opaque base. Sortable headings get a caret and `aria-sort` maintained by the shell (`initializeSortIndicators`), so report code keeps owning only the data; a heading without `data-sort` no longer fakes a pointer cursor. Dense evidence ledgers pin their first column, so scrolling the numbers never leaves an anonymous strip of digits.

**Two sticky traps fixed along the way** — `.table-card` used `overflow: hidden`, which made the card its own scrollport and pinned the header to a box that never scrolls (`overflow: clip` clips identically without one). `.evidence-table-scroll` sets `overflow-x: auto`, so its block axis is a scrollport too, and the page-level offset painted the ledger header 56px down over the first rows; it resets to `top: 0`. The page offset itself lives in `--dev3-table-head-top`, measured from the `.section-nav` height in `app.js` (0 when a report has no nav). Recorded in `decisions/2026/08/14/artifact-table-sticky-header-scrollports.md`.

`AUTHORING.md` documents the new width behaviour, `.prose`, the table aids, and the pinned label column. Three new contract tests cover the width, the table aids, and the pinned column, including a guard against reverting `overflow: clip` back to `hidden`.

## Verification

Driven in headless Chromium (`agent-browser`) at 2100 / 1900 / 1400 / 420px, both themes: container measures 1840px on a wide viewport with no horizontal overflow at 420px; the three row states are distinct (`transparent` / `text-primary 4.5%` / `accent 10%`); the pinned header lands exactly at the nav's bottom edge; the sort caret matches the report's actual order; the evidence label column holds at `scrollLeft` 469 of 484. Print checked as a real PDF — header repeats per page, all 16 ledger columns lay out, resting carets disappear, no sticky artifacts.

`bun run lint` clean; `artifact-template.test.ts` 18/18 and the two renderer artifact-template suites green. In the full local run two unrelated bun files (`git-diff-recent`, `create-release-artifacts`) failed with `STACK_TRACE_ERROR` under a load average of ~59 and both pass 17/17 in isolation on this commit; the renderer shard's verdict was lost to a truncated log, and this change contains no renderer code.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=28035f03-c56b-43e9-b6ef-352945d6622f) · `dev3://task/28035f03-c56b-43e9-b6ef-352945d6622f` _(dev3 added this footer — turn it off in Settings → Tasks.)_
