### PR TITLE
Clear the inherited terminal screen on attach and blur it until remote output lands

### DIFF
--- a/change-logs/2026/08/14/fix-remote-terminal-stale-screen.md
+++ b/change-logs/2026/08/14/fix-remote-terminal-stale-screen.md
@@ -1,0 +1,3 @@
+Short: No stale screen on task switch
+
+Opening a task in remote mode no longer shows the previous task's terminal output: a fresh ghostty terminal inherited the screen the previous one held, and over a tunnel that leftover stayed on display for as long as the redraw took. The canvas is now cleared on attach, and in remote mode it sits behind a blur labelled "Syncing terminal..." until the session's own output arrives.

--- a/decisions/2026/08/14/clear-inherited-ghostty-screen-and-gate-remote-attach.md
+++ b/decisions/2026/08/14/clear-inherited-ghostty-screen-and-gate-remote-attach.md
@@ -1,0 +1,57 @@
+# Clear the inherited ghostty screen on attach, and gate it behind a blur in remote mode
+
+## Context
+
+In remote mode (`dev3 remote`, browser transport) entering a task showed the *previous*
+task's terminal output for as long as the new session's redraw took to cross the tunnel —
+hundreds of milliseconds to seconds, read by the user as the new task's own output.
+
+## Investigation
+
+Driven in a real browser (`agent-browser`) against a dev-server build, with PTY frames
+held back 4 s by a `window.WebSocket` wrapper so the attach window could be inspected:
+
+- The new `TerminalView` is a fresh mount (`key={taskId}` in `TaskWorkspacePane`), with a new
+  `Terminal`, a new container and a new canvas node — the previous canvas was already gone
+  from the DOM (`isConnected === false`).
+- Yet with no PTY byte delivered, the fresh canvas rendered a full screen of the leaving
+  task's output (`canvas.toDataURL().length` ≈ 217–274 KB against ≈ 27 KB for an empty one).
+  So the leftover lives inside ghostty-web across `Terminal` instances, not in stale pixels
+  of an orphaned node.
+- `term.reset()` right after `term.open()` did not help: nothing repaints the canvas until
+  something is written, so the inherited image stayed on screen.
+
+## Decision
+
+`src/mainview/TerminalView.tsx`:
+
+1. **Clear through the write path.** `connectPty()` enqueues RIS (`\x1bc`) via
+   `enqueueTermWrite`, the same batched path that repaints. Skipped when
+   `nativeSeqRef.current !== null` — a native resume gets a delta that expects the screen it
+   left behind.
+2. **Sync gate, remote only.** `isRemote()` mounts a blurred overlay (`terminal.syncing`)
+   over the canvas until the socket's own output lands, re-armed per socket so a mobile tab
+   resume is covered too. It lifts on the first socket-delivered batch, on a final close, or
+   after `TERMINAL_SYNC_GATE_TIMEOUT_MS` (2.5 s) so a silent session is never stuck blurred.
+   Desktop never arms it: locally the redraw is one frame away and a flash of overlay is worse
+   than none.
+3. **`writeScheduled` flag** next to `writeRafId`: a `requestAnimationFrame` callback that
+   runs before the call returns (the test stub does) left the id set forever, so every later
+   batch queued unwritten. Scheduling is now guarded by the boolean, the id only cancels.
+
+Only the socket's own bytes lift the gate (`pendingFromSocket`), so our own clear cannot.
+
+## Risks
+
+- The gate flashes for ~100 ms on a local browser session, where the redraw is fast. Accepted:
+  the alternative (delaying the overlay) re-exposes the stale screen for exactly that window.
+- RIS on every fresh attach discards a tmux pane's client-side scrollback view; tmux redraws
+  the pane immediately after, and the scrollback lives in tmux, not in the canvas.
+
+## Alternatives considered
+
+- **Blur only, no clear** — the stale text stays readable through a 6 px blur, and blurred-but-
+  legible output of another task is the same bug with extra steps.
+- **`term.reset()` at open** — verified not to repaint (see Investigation).
+- **Server-side clear or `capture-pane` replay on attach** — races tmux's own redraw; rejected
+  before, see `decisions/2026/04/24/defer-initial-capture-pane-on-reconnect.md`.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -37,7 +37,7 @@ import { submitPastedText } from "./terminal-submit";
 import { createFilePathLinkProvider, type FilePathLinkProvider } from "./terminal-file-links";
 import { installFilePathUnderlines, type FilePathUnderlinesHandle } from "./terminal-link-underlines";
 import { activateTerminalPath } from "./terminal-path-open";
-import { isMac } from "./utils/platform";
+import { isMac, isRemote } from "./utils/platform";
 import { paneHighlightRect, type PaneRectPct } from "./utils/paneHighlight";
 import TerminalSearchBar, { type TerminalSearchBarHandle } from "./components/TerminalSearchBar";
 import { isFinalPtyCloseCode } from "../shared/pty-ws-close-codes";
@@ -95,6 +95,13 @@ const TERMINAL_BASE_FONT_SIZE = 14;
  * already three dropped frames — worth a line, while staying quiet in normal use.
  */
 const TERMINAL_DISPOSE_BUDGET_MS = 50;
+
+/**
+ * How long the sync gate waits for the first repaint before lifting itself.
+ * A session that emits nothing after attach (idle shell, refused socket) must
+ * not stay blurred forever, so the gate is a hint with a deadline — not a lock.
+ */
+export const TERMINAL_SYNC_GATE_TIMEOUT_MS = 2_500;
 
 // ghostty-web 0.4.0 FitAddon reserves 15px on width for a native scrollbar
 // that never appears — ghostty draws its scrollbar overlaid on the canvas.
@@ -317,6 +324,40 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	// when the app goes to the background, so only this tells the two apart.
 	const windowFocusedRef = useRef(document.hasFocus());
 
+	// ── Sync gate (remote mode only) ──────────────────────────────────────────
+	// Over a tunnel the redraw that fills this canvas arrives hundreds of ms after
+	// the attach, so whatever the canvas held until then reads as live output —
+	// either the screen this same viewer had before a resume, or nothing at all.
+	// Blur it and say "syncing" until the first batch lands. Desktop never arms it:
+	// locally the redraw is one frame away and a flash of overlay is the worse bug.
+	const [syncing, setSyncing] = useState(() => isRemote());
+	const syncingRef = useRef(syncing);
+	const syncGateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	function clearSyncGateTimer() {
+		if (syncGateTimerRef.current === null) return;
+		clearTimeout(syncGateTimerRef.current);
+		syncGateTimerRef.current = null;
+	}
+
+	/** Raise the gate for a socket that is about to (re)fill the canvas. */
+	function armSyncGate() {
+		if (!isRemote()) return;
+		clearSyncGateTimer();
+		syncGateTimerRef.current = setTimeout(releaseSyncGate, TERMINAL_SYNC_GATE_TIMEOUT_MS);
+		if (syncingRef.current) return;
+		syncingRef.current = true;
+		setSyncing(true);
+	}
+
+	/** The canvas now shows this session's own output — or the wait timed out. */
+	function releaseSyncGate() {
+		clearSyncGateTimer();
+		if (!syncingRef.current) return;
+		syncingRef.current = false;
+		setSyncing(false);
+	}
+
 	/**
 	 * Would a keystroke right now reach this terminal? Touch compose mode is
 	 * exempt — there the composer owns the keyboard by design and the terminal
@@ -534,6 +575,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 			console.log("[TerminalView] Terminal opened in DOM successfully");
 			termRef.current = term;
+
 
 			// Beta: paint right-to-left rows in visual order (Settings → System →
 			// Advanced Experience). The renderer exists only after term.open().
@@ -1290,6 +1332,12 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		// a single term.write() call per animation frame (~60fps).
 		let pendingWrite = "";
 		let writeRafId: number | null = null;
+		// Guards scheduling separately from the frame id: a callback that runs before
+		// requestAnimationFrame returns would otherwise leave the id set forever and
+		// every later batch would sit in the queue unwritten.
+		let writeScheduled = false;
+		/** Whether the pending batch carries bytes from the PTY, not our own clear. */
+		let pendingFromSocket = false;
 		// Reference to the terminal for batched writes (set by connectPty)
 		let batchTerm: Terminal | null = null;
 		// Rewrites SGR colors unreadable on the current background: pale/dim
@@ -1298,15 +1346,22 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 		function enqueueTermWrite(data: string) {
 			pendingWrite += data;
-			if (writeRafId === null) {
+			if (!writeScheduled) {
+				writeScheduled = true;
 				writeRafId = requestAnimationFrame(() => {
+					writeScheduled = false;
 					writeRafId = null;
 					if (disposed || !pendingWrite || !batchTerm) return;
 					const batch = themeFilter(pendingWrite, resolvedThemeRef.current);
 					pendingWrite = "";
 					if (!batch) return;
+					const fromSocket = pendingFromSocket;
+					pendingFromSocket = false;
 					try {
 						batchTerm.write(batch);
+						// Only the socket's own output proves the canvas is current; the
+						// clear we enqueue ourselves must leave the gate up.
+						if (fromSocket) releaseSyncGate();
 						// Drop any stale selection left floating over the
 						// just-repainted cells when the app owns the screen
 						// (alt-screen or primary+mouse-tracking); ghostty-web
@@ -1366,6 +1421,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			let reset = "";
 			if (header.t === "attach") {
 				nativeSeqRef.current = header.seq;
+				// A resumed attach can carry an empty delta — the screen is already
+				// correct, so the gate has to lift here rather than wait for output.
+				if (header.resumed && !payload) releaseSyncGate();
 				reportNativeRole({ role: header.role, refused: false, writerAttached: header.writerAttached });
 				adoptPtyGeometry(header.cols, header.rows);
 				// RIS in the SAME batch as the replay, so the screen is replaced in one
@@ -1377,7 +1435,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				return;
 			}
 			const cleaned = payload.replace(OSC52_RE, "");
-			if (reset || cleaned) enqueueTermWrite(reset + cleaned);
+			if (reset || cleaned) {
+				pendingFromSocket = true;
+				enqueueTermWrite(reset + cleaned);
+			}
 		}
 
 		function connectPty(term: Terminal, fit: FitAddon) {
@@ -1387,6 +1448,15 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				reconnectTimer = null;
 			}
 			batchTerm = term;
+			// Every socket refills the canvas, so every socket gets its own gate: a
+			// resume after backgrounding reattaches to the screen it left behind.
+			armSyncGate();
+			// A freshly constructed ghostty-web terminal paints the screen the PREVIOUS
+			// one held — new Terminal, new canvas node, same leftover pixels — so task B
+			// showed task A's output until B's own redraw landed. RIS through the batched
+			// write path, which is what actually repaints. Skipped on a native resume:
+			// there the server sends a delta that expects the screen it left behind.
+			if (nativeSeqRef.current === null) enqueueTermWrite("\x1bc");
 			const diagnosticPtyUrl = ptyUrl.replace(/([?&]token=)[^&]+/, "$1***");
 			console.log("[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
 			let socket: WebSocket;
@@ -1435,11 +1505,11 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 							return;
 						}
 						const cleaned = event.data.replace(OSC52_RE, "");
-						if (cleaned) enqueueTermWrite(cleaned);
+						if (cleaned) { pendingFromSocket = true; enqueueTermWrite(cleaned); }
 					} else {
 						// Binary data — decode and batch with text data
 						const str = new TextDecoder().decode(new Uint8Array(event.data));
-						if (str) enqueueTermWrite(str);
+						if (str) { pendingFromSocket = true; enqueueTermWrite(str); }
 					}
 				} catch {
 					// Swallow ghostty-web rendering errors to avoid flooding
@@ -1457,6 +1527,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					wasClean: event.wasClean,
 				});
 				if (disposed) return;
+				// A socket that will never deliver a redraw must not leave the canvas
+				// blurred behind a "syncing" label that can no longer come true.
+				if (event.code === 1000 || isFinalPtyCloseCode(event.code)) releaseSyncGate();
 				if (event.code === 1000 && event.wasClean) {
 					try { term.writeln("\r\n\x1b[2m[session ended]\x1b[0m"); } catch { /* disposed */ }
 					return;
@@ -1563,6 +1636,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			if (reconnectTimer !== null) clearTimeout(reconnectTimer);
 			if (refitTimer !== null) clearTimeout(refitTimer);
 			// Cancel pending write batch to prevent writing to disposed terminal
+			writeScheduled = false;
 			if (writeRafId !== null) {
 				cancelAnimationFrame(writeRafId);
 				writeRafId = null;
@@ -2028,6 +2102,15 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		? LIGHT_TERMINAL_THEME.background
 		: DARK_TERMINAL_THEME.background;
 
+	// The gate starts raised in remote mode, before any socket exists, so its
+	// deadline starts with the mount: a setup that never reaches connectPty must
+	// not leave the canvas blurred forever.
+	useEffect(() => {
+		armSyncGate();
+		return clearSyncGateTimer;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	function handleTerminalClick(event: React.MouseEvent<HTMLDivElement>) {
 		try { termRef.current?.focus(); } catch { /* disposed */ }
 		if (touchComposeModeRef.current) return;
@@ -2059,6 +2142,20 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				onDragOver={handleDragOver}
 				onDrop={handleDrop}
 			/>
+			{syncing && (
+				<div
+					data-testid="terminal-sync-gate"
+					role="status"
+					aria-live="polite"
+					aria-busy="true"
+					// Never blocks input: typing goes to the container underneath, and a
+					// click while syncing still focuses the terminal it is covering.
+					className="pointer-events-none absolute inset-0 z-[15] flex items-center justify-center gap-3 bg-base/60 backdrop-blur-[6px]"
+				>
+					<div className="w-2 h-2 rounded-full bg-accent animate-pulse" />
+					<span className="text-fg-3 text-sm">{t("terminal.syncing")}</span>
+				</div>
+			)}
 			{searchOpen && searchPaneRect && (
 				<div
 					className="pointer-events-none absolute z-20 rounded-sm border-2 border-accent bg-accent/5"

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, fireEvent, waitFor } from "@testing-library/react";
-import TerminalView, { type TerminalHandle, buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
+import TerminalView, { type TerminalHandle, TERMINAL_SYNC_GATE_TIMEOUT_MS, buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
 import type { NativeStreamRole } from "../../shared/native-terminal-stream";
@@ -1728,5 +1728,85 @@ describe("TerminalView – diagnostics must never break cleanup", () => {
 		// term.dispose() is the LAST statement in the cleanup, so reaching it proves
 		// every disposer between the throwing marker and the end still ran.
 		expect(mockTermInstance.dispose).toHaveBeenCalled();
+	});
+});
+
+// The gate that hides a not-yet-repainted canvas in remote mode. Tests run with
+// no `__electrobunWebviewId`, so `isRemote()` is true unless a test sets one.
+describe("TerminalView – remote sync gate", () => {
+	afterEach(() => {
+		delete (window as unknown as Record<string, unknown>).__electrobunWebviewId;
+	});
+
+	it("clears the screen the previous terminal instance left behind", async () => {
+		await renderAndSetup();
+		// ghostty-web hands a new Terminal the old one's screen, so the reset has to
+		// land at open — before any socket output can be written on top of it.
+		// RIS is the first thing written, before any PTY byte can land on top of it.
+		expect(mockTermInstance.write.mock.calls[0][0]).toBe("\x1bc");
+	});
+
+	it("covers the canvas until the socket delivers output", async () => {
+		const view = await renderAndSetup();
+		expect(view.queryByTestId("terminal-sync-gate")).not.toBeNull();
+
+		await act(async () => {
+			lastWebSocket?.onmessage?.({ data: "fresh output" } as MessageEvent);
+		});
+
+		expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
+	});
+
+	it("never arms on the desktop shell, where the redraw is one frame away", async () => {
+		(window as unknown as Record<string, unknown>).__electrobunWebviewId = 1;
+		const view = await renderAndSetup();
+		expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
+	});
+
+	it("lifts itself when nothing ever repaints", async () => {
+		// Fake timers before the render: the gate's deadline is scheduled during
+		// mount, so a timer installed afterwards would never own it.
+		vi.useFakeTimers();
+		try {
+			const view = await renderAndSetup();
+			expect(view.queryByTestId("terminal-sync-gate")).not.toBeNull();
+
+			// The PTY connect itself is deferred by a timer, and that socket re-arms the
+			// gate — so the deadline only starts once this advance has run the connect.
+			await act(async () => { await vi.advanceTimersByTimeAsync(TERMINAL_SYNC_GATE_TIMEOUT_MS); });
+			await act(async () => { await vi.advanceTimersByTimeAsync(TERMINAL_SYNC_GATE_TIMEOUT_MS); });
+
+			expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("re-arms for the socket that replaces a backgrounded one", async () => {
+		const view = await renderAndSetup();
+		await act(async () => {
+			lastWebSocket?.onmessage?.({ data: "fresh output" } as MessageEvent);
+		});
+		expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
+
+		// Returning to a suspended mobile tab reattaches to the screen it left, so
+		// the stale-screen window opens again.
+		await act(async () => {
+			Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+			document.dispatchEvent(new Event("visibilitychange"));
+			Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+
+		expect(view.queryByTestId("terminal-sync-gate")).not.toBeNull();
+	});
+
+	it("lifts when the app refuses the session instead of blurring a dead canvas", async () => {
+		const view = await renderAndSetup();
+		await act(async () => {
+			webSockets[0].readyState = WebSocket.CLOSED;
+			webSockets[0].onclose?.({ code: 4001, reason: "Unknown session", wasClean: false } as CloseEvent);
+		});
+		expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
 	});
 });

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -1,6 +1,7 @@
 const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Connecting...",
+	"terminal.syncing": "Syncing terminal...",
 	"terminal.envError": "Task environment error",
 	"terminal.worktreeNotFound": "The task's working directory no longer exists. This can happen when the worktree is removed externally.",
 	"terminal.errorPath": "Worktree not found:",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -1,6 +1,7 @@
 const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Conectando...",
+	"terminal.syncing": "Sincronizando terminal...",
 	"terminal.envError": "Error del entorno de la tarea",
 	"terminal.worktreeNotFound": "El directorio de trabajo de la tarea ya no existe. Esto puede ocurrir cuando el worktree se elimina externamente.",
 	"terminal.errorPath": "Worktree no encontrado:",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -1,6 +1,7 @@
 const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Подключение...",
+	"terminal.syncing": "Синхронизация терминала...",
 	"terminal.envError": "Ошибка окружения задачи",
 	"terminal.worktreeNotFound": "Рабочая директория задачи больше не существует. Это может произойти, если worktree был удалён извне.",
 	"terminal.errorPath": "Worktree не найден:",


### PR DESCRIPTION
Hi — this is Claude (the AI assistant that did the work on this branch).

In remote mode (`dev3 remote`, browser transport) entering a task showed the **previous** task's terminal output until the new session's redraw crossed the tunnel — hundreds of milliseconds to seconds, read as the new task's own output.

## The actual cause

The lag only made it visible. A freshly mounted `TerminalView` — new `Terminal`, new container, new canvas node, previous canvas already out of the DOM — renders the screen the *previous* ghostty-web terminal held, until something is written into it.

Verified in a real browser with PTY frames held back 4 s: with zero bytes delivered, `canvas.toDataURL().length` was 217–274 KB (a full screen of the leaving task's output) against ≈27 KB for an empty canvas. `term.reset()` right after `term.open()` does **not** fix it — nothing repaints the canvas until a write happens.

## Changes (`src/mainview/TerminalView.tsx`)

- **Clear through the write path.** `connectPty()` enqueues RIS (`\x1bc`) via the batched `enqueueTermWrite`, which is what actually repaints. Skipped when `nativeSeqRef.current !== null`: a native resume receives a delta that expects the screen it left behind.
- **Sync gate, remote only.** A blurred overlay (`terminal.syncing`, en/ru/es) covers the canvas until the socket's own output lands. Re-armed per socket, so a mobile tab resume is covered too; lifted on the first socket-delivered batch, on a final close, or after `TERMINAL_SYNC_GATE_TIMEOUT_MS` (2.5 s) so a silent session is never stuck blurred. `isRemote()` gates it — the desktop shell repaints a frame later, where a flash of overlay would be the worse bug.
- **Latent batching bug fixed.** `writeRafId` was both the "already scheduled" guard and the frame id, so a `requestAnimationFrame` callback that ran before the call returned left the id permanently set and every later batch queued unwritten. Scheduling now uses a separate `writeScheduled` flag; the id is only kept for cancellation.

Decision record: `decisions/2026/08/14/clear-inherited-ghostty-screen-and-gate-remote-attach.md`.

## Verification

- 6 new `TerminalView` tests (gate raised/released/re-armed/timed out, desktop never arms, RIS written first); `TerminalView.test.tsx` 90 green, plus TaskTerminal / TaskTerminalNative / ProjectTerminal / TaskWorkspaceView.
- `bun run lint` clean.
- Browser QA in streamer mode: with frames delayed, the canvas is empty (~27 KB) behind the gate and the gate lifts on its deadline; without the delay, content paints correctly and the gate flashes ~100 ms locally, no console errors.
- Full local `bun run test`: 6 failures, all in `terminal-bidi/reorder-fuzz` (`STACK_TRACE_ERROR`, no assertion) and one `App.test.tsx` streamer-mode case — both known load flakes on this machine (load average was 99 from parallel agents). Both files are green in isolation and neither touches this diff; CI is the honest gate here.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=e4909d57-a939-432c-abdf-e0bd5628c04e) · `dev3://task/e4909d57-a939-432c-abdf-e0bd5628c04e` _(dev3 added this footer — turn it off in Settings → Tasks.)_
