### PR TITLE
Order dev3 task list by live work before backlog and archive

### DIFF
--- a/change-logs/2026/08/14/fix-task-list-status-order.md
+++ b/change-logs/2026/08/14/fix-task-list-status-order.md
@@ -1,0 +1,3 @@
+Short: task list shows live work first
+
+`dev3 task list` (and `dev3 tasks list`) now groups by column before paging: live work (in-progress, questions, every review column, custom columns) first, then To Do, then completed, then cancelled — newest first inside each group. A default page is no longer filled with archived tasks while something is still running.

--- a/src/cli/__tests__/tasks.test.ts
+++ b/src/cli/__tests__/tasks.test.ts
@@ -371,6 +371,105 @@ describe("tasks list default limit", () => {
 	});
 });
 
+// ─── tasks list: status grouping ─────────────────────────────────────────────
+
+describe("tasks list status grouping", () => {
+	function withStatus(seq: number, status: Task["status"], extra: Partial<Task> = {}): Task {
+		return {
+			...TASKS[0],
+			id: `s${String(seq).padStart(8, "0")}-1111-2222-3333-444444444444`,
+			seq,
+			title: `task ${status} ${seq}`,
+			status,
+			...extra,
+		};
+	}
+
+	function order(output: string, ...titles: string[]): number[] {
+		return titles.map((title) => output.indexOf(title));
+	}
+
+	it("puts live work first, then To Do, then completed, then cancelled", async () => {
+		mockSend.mockResolvedValue(
+			okResp([
+				withStatus(1, "cancelled"),
+				withStatus(2, "completed"),
+				withStatus(3, "todo"),
+				withStatus(4, "in-progress"),
+			]),
+		);
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001" } }, SOCKET, null);
+
+		const [live, todo, done, cancelled] = order(
+			stdoutOutput,
+			"task in-progress 4",
+			"task todo 3",
+			"task completed 2",
+			"task cancelled 1",
+		);
+		expect(live).toBeGreaterThan(-1);
+		expect(live).toBeLessThan(todo);
+		expect(todo).toBeLessThan(done);
+		expect(done).toBeLessThan(cancelled);
+	});
+
+	it("treats every review/question column as live work", async () => {
+		mockSend.mockResolvedValue(
+			okResp([
+				withStatus(10, "todo"),
+				withStatus(1, "user-questions"),
+				withStatus(2, "review-by-ai"),
+				withStatus(3, "review-by-user"),
+				withStatus(4, "review-by-colleague"),
+			]),
+		);
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001" } }, SOCKET, null);
+
+		const todoIdx = stdoutOutput.indexOf("task todo 10");
+		for (const title of [
+			"task user-questions 1",
+			"task review-by-ai 2",
+			"task review-by-user 3",
+			"task review-by-colleague 4",
+		]) {
+			expect(stdoutOutput.indexOf(title)).toBeLessThan(todoIdx);
+		}
+	});
+
+	it("ranks a custom-column task as live work", async () => {
+		mockSend.mockResolvedValue(
+			okResp([withStatus(9, "todo"), withStatus(1, "todo", { customColumnId: "3d339f70" })]),
+		);
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001" } }, SOCKET, null);
+
+		expect(stdoutOutput.indexOf("task todo 1")).toBeLessThan(stdoutOutput.indexOf("task todo 9"));
+	});
+
+	it("keeps newest-first inside a group", async () => {
+		mockSend.mockResolvedValue(okResp([withStatus(5, "in-progress"), withStatus(7, "in-progress")]));
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001" } }, SOCKET, null);
+
+		expect(stdoutOutput.indexOf("task in-progress 7")).toBeLessThan(
+			stdoutOutput.indexOf("task in-progress 5"),
+		);
+	});
+
+	it("fills a small --limit with live work before completed tasks", async () => {
+		mockSend.mockResolvedValue(
+			okResp([withStatus(50, "completed"), withStatus(49, "completed"), withStatus(2, "in-progress")]),
+		);
+
+		await handleTasks("list", { positional: [], flags: { project: "proj-001", limit: "1" } }, SOCKET, null);
+
+		expect(stdoutOutput).toContain("task in-progress 2");
+		expect(stdoutOutput).not.toContain("task completed 50");
+	});
+});
+
 describe("tasks list --offset paging", () => {
 	it("skips the first N tasks (after newest-first sort)", async () => {
 		mockSend.mockResolvedValue(okResp(TASKS));

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -1,4 +1,4 @@
-import type { Task } from "../../shared/types";
+import type { Task, TaskStatus } from "../../shared/types";
 import { STATUS_LABELS, ALL_STATUSES, getTaskTitle } from "../../shared/types";
 import { sendRequest } from "../socket-client";
 import { printTable, exitError, exitUsage } from "../output";
@@ -8,6 +8,26 @@ import { resolveProjectId, type CliContext } from "../context";
 // Default page size for `tasks list` when --limit is omitted. Keeps large
 // boards (hundreds of tasks) from flooding the terminal; page with --offset.
 const DEFAULT_LIST_LIMIT = 50;
+
+// Listing order: live work first, then the backlog, then the archive. A default
+// page must never be filled with completed tasks while something is running.
+const STATUS_GROUP_RANK: Record<TaskStatus, number> = {
+	"in-progress": 0,
+	"user-questions": 0,
+	"review-by-ai": 0,
+	"review-by-user": 0,
+	"review-by-colleague": 0,
+	todo: 1,
+	completed: 2,
+	cancelled: 3,
+};
+
+// Custom-column tasks are live work too — they left To Do and never reached
+// completed/cancelled, so they rank with the active group.
+function groupRank(task: Task): number {
+	if (task.customColumnId) return 0;
+	return STATUS_GROUP_RANK[task.status] ?? 1;
+}
 
 export async function handleTasks(
 	subcommand: string | undefined,
@@ -57,9 +77,10 @@ export async function handleTasks(
 			tasks = tasks.filter((t) => t.labelIds?.some((id) => id === labelId || id.startsWith(labelId)));
 		}
 
-		// Newest first — sort by seq descending so the most recent tasks lead.
-		// Done before paging so --offset/--limit walk from the newest task.
-		tasks = [...tasks].sort((a, b) => b.seq - a.seq);
+		// Live work first, then To Do, then completed, then cancelled; newest
+		// (highest seq) first inside each group. Done before paging so
+		// --offset/--limit walk the same order the board reads in.
+		tasks = [...tasks].sort((a, b) => groupRank(a) - groupRank(b) || b.seq - a.seq);
 
 		// Client-side paging (server returns all tasks matching status filter).
 		// Defaults to the newest DEFAULT_LIST_LIMIT so large boards don't flood.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -119,8 +119,9 @@ const COMMANDS: CommandHelp[] = [
 			{
 				name: "list",
 				usage: "dev3 tasks list [--status <s>] [--label <id>] [--limit <n>] [--offset <n>]",
-				summary: "List tasks newest-first (default 50 per page).",
+				summary: "List tasks: live work, then To Do, then completed, then cancelled (default 50 per page).",
 				details: [
+					"Newest first (highest seq) inside each group.",
 					"--status <s>   Filter by status.",
 					"--label <id>   Filter by label id (8-char prefix works).",
 					"--limit <n>    Page size (default 50).",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

`dev3 task list` / `dev3 tasks list` sorted purely by `seq` descending, so on a board with 1600+ tasks a default page could be filled with completed and cancelled work while several tasks were actively running.

Listing now groups by column before paging:

1. Live work — `in-progress`, `user-questions`, every review column, and any custom column
2. `todo`
3. `completed`
4. `cancelled`

Newest first (highest `seq`) inside each group, exactly as before. Sorting still happens before paging, so `--offset`/`--limit` walk the same order the board reads in. A task sitting in a user-defined custom column ranks as live work: it left To Do and never reached the archive.

Also updated the `tasks list` help summary, which still claimed plain "newest-first", and added five CLI tests covering the group order, the review columns, custom columns, intra-group ordering, and a small `--limit` filling with live work instead of completed tasks.

Verified: `bun run lint` clean, `bun run test:cli` 769 passed. The full suite showed 7 renderer failures (`reorder-fuzz`, `App.test` streamer Cmd+2, `TaskDiffViewer`) on a machine at load ~87; all of them pass in isolation and this branch touches no renderer code.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=29ae3bf9-60dd-41f4-b395-1b05e6129cb3) · `dev3://task/29ae3bf9-60dd-41f4-b395-1b05e6129cb3` _(dev3 added this footer — turn it off in Settings → Tasks.)_
