### PR TITLE
Fix transient task-metadata write failures (per-call temp names + bounded retries)

### DIFF
--- a/change-logs/2026/08/14/fix-atomic-write-race-and-lock-retry.md
+++ b/change-logs/2026/08/14/fix-atomic-write-race-and-lock-retry.md
@@ -1,0 +1,3 @@
+Short: No more transient task write failures
+
+Task metadata writes no longer fail on transient filesystem hiccups: each atomic write now uses its own temp file (two concurrent writes inside one process used to collide and fail with ENOENT), retries a transient rename a few times, and a timed-out file-lock acquisition is retried with a short deadline instead of failing the whole operation.

--- a/decisions/2026/08/14/atomic-write-per-call-temp-and-lock-retry.md
+++ b/decisions/2026/08/14/atomic-write-per-call-temp-and-lock-retry.md
@@ -1,0 +1,45 @@
+# Per-call temp names for atomic writes, plus a bounded file-lock retry
+
+## Context
+
+Two vents reported the same shape of failure: a single write to task metadata broke a task-lifecycle
+operation, and an immediate manual retry succeeded. One was an `ENOENT` on the atomic rename during a
+status transition; the other was `FileLockTimeoutError` from `dev3 note add` after the 5s lock deadline,
+during concurrent dev-server shutdown and checks.
+
+## Investigation
+
+`atomicWriteFile` (`src/bun/data.ts`) named its temp file `${filePath}.tmp-${process.pid}` — keyed on the
+PROCESS, not the call. Two concurrent writes to one file inside one process therefore shared a temp path:
+whoever renamed first won, the loser's `rename` hit `ENOENT`, and the loser's error-path `unlink` could
+delete the winner's temp file mid-flight. Neither path had any retry. `withFileLock` threw
+`FileLockTimeoutError` at the deadline and no caller caught it (`note.add` in `cli-socket-server.ts` lets it
+reach the CLI). For `tasks.json` the race window was narrow — mutators hold the lock — but it was not closed
+by construction, and unsynchronised `rawSaveTasks` paths exist.
+
+## Decision
+
+1. `atomicWriteFile` derives the temp name per CALL: `${filePath}.tmp-${pid}-${counter++}`. Concurrent
+   in-process writes can no longer share a temp file or clobber each other's cleanup.
+2. `atomicWriteFile` retries the write+rename pair 3 extra times (10/30/90 ms) on `ENOENT`, `EPERM`,
+   `EACCES`, `EBUSY`, logging a warning per retry. Any other error surfaces immediately.
+3. `withFileLock` (`src/bun/file-lock.ts`) retries a timed-out acquisition `retries` times (default 2), each
+   attempt with the unchanged short deadline, warning per attempt; the final error names the attempt count.
+
+Retrying was chosen over raising the 5s deadline: the per-attempt deadline stays short, each failed attempt
+is visible in the log, and a genuinely stuck holder still fails without a long silent stall.
+
+## Risks
+
+A hard failure now takes up to 3× longer to surface (15s worst case for a lock, ~130 ms for a write). Callers
+that deliberately used a short timeout to fail fast must pass `retries: 0`. Stale-lock breaking is unchanged,
+so a crashed holder is still broken at 10s rather than waited out.
+
+## Alternatives considered
+
+- Raise `DEFAULT_TIMEOUT` to 15s: same total wait, but hides contention — no per-attempt signal, and a stuck
+  lock stalls silently for the whole window.
+- Catch `FileLockTimeoutError` at each call site (e.g. only `note.add`): ~40 call sites, and it fixes the
+  symptom in one place while leaving every other metadata mutator exposed.
+- Serialize all writes to a path through an in-process queue: closes the in-process race but not the
+  cross-process one, and duplicates what the file lock already does.

--- a/src/bun/__tests__/data-atomic-write-race.test.ts
+++ b/src/bun/__tests__/data-atomic-write-race.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+
+// The temp-path and rename behaviour of atomicWriteFile is what the two vents
+// about transient task-metadata failures come down to, so the fs layer is
+// mocked only to (a) observe every temp path it picks and (b) inject a single
+// transient rename failure. Everything else runs against the real filesystem.
+const writtenTempPaths: string[] = [];
+let renameFailures: Array<string | null> = [];
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return {
+		...actual,
+		writeFile: vi.fn(async (path: any, data: any, opts?: any) => {
+			writtenTempPaths.push(String(path));
+			return actual.writeFile(path, data, opts);
+		}),
+		rename: vi.fn(async (from: any, to: any) => {
+			const code = renameFailures.shift();
+			if (code) {
+				const err: NodeJS.ErrnoException = new Error(`simulated ${code}`);
+				err.code = code;
+				throw err;
+			}
+			return actual.rename(from, to);
+		}),
+	};
+});
+
+const tempDir = mkdtempSync(join(tmpdir(), "dev3-atomic-race-"));
+const targetFile = join(tempDir, "tasks.json");
+
+function tempSiblings(): string[] {
+	return readdirSync(tempDir).filter((f) => f.includes(".tmp"));
+}
+
+describe("atomicWriteFile — concurrency and transient failures", () => {
+	beforeEach(() => {
+		writtenTempPaths.length = 0;
+		renameFailures = [];
+		rmSync(tempDir, { recursive: true, force: true });
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		renameFailures = [];
+	});
+
+	afterAll(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("gives every call its own temp path", async () => {
+		const { atomicWriteFile } = await import("../data");
+
+		await atomicWriteFile(targetFile, "one");
+		await atomicWriteFile(targetFile, "two");
+
+		expect(writtenTempPaths).toHaveLength(2);
+		expect(new Set(writtenTempPaths).size).toBe(2);
+		for (const p of writtenTempPaths) expect(p.startsWith(`${targetFile}.tmp-`)).toBe(true);
+	});
+
+	it("survives concurrent writes to the same file inside one process", async () => {
+		const { atomicWriteFile } = await import("../data");
+
+		const payloads = ["a", "bb", "ccc", "dddd", "eeeee"];
+		// Before the per-call temp suffix, the losers of this race hit ENOENT on
+		// rename (their temp file was renamed away by the winner) and rejected.
+		await Promise.all(payloads.map((p) => atomicWriteFile(targetFile, p)));
+
+		expect(payloads).toContain(readFileSync(targetFile, "utf8"));
+		expect(tempSiblings()).toHaveLength(0);
+	});
+
+	it("retries a transient rename failure and then lands the write", async () => {
+		const { atomicWriteFile } = await import("../data");
+
+		renameFailures = ["EPERM", "EBUSY"];
+		await atomicWriteFile(targetFile, "landed");
+
+		expect(readFileSync(targetFile, "utf8")).toBe("landed");
+		expect(writtenTempPaths).toHaveLength(3);
+		expect(tempSiblings()).toHaveLength(0);
+	});
+
+	it("surfaces a non-transient error immediately instead of retrying", async () => {
+		const { atomicWriteFile } = await import("../data");
+
+		renameFailures = ["EXDEV"];
+		await expect(atomicWriteFile(targetFile, "nope")).rejects.toThrow("simulated EXDEV");
+
+		expect(writtenTempPaths).toHaveLength(1);
+		expect(tempSiblings()).toHaveLength(0);
+	});
+
+	it("gives up after the bounded retry budget", async () => {
+		const { atomicWriteFile } = await import("../data");
+
+		renameFailures = ["EBUSY", "EBUSY", "EBUSY", "EBUSY", "EBUSY"];
+		await expect(atomicWriteFile(targetFile, "nope")).rejects.toThrow("simulated EBUSY");
+
+		expect(writtenTempPaths).toHaveLength(4);
+		expect(tempSiblings()).toHaveLength(0);
+	});
+});

--- a/src/bun/__tests__/file-lock-retry.test.ts
+++ b/src/bun/__tests__/file-lock-retry.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync, rmdirSync } from "node:fs";
+import { withFileLock, FileLockTimeoutError } from "../file-lock";
+
+// A lost 5-second acquisition window under real contention used to fail the
+// whole operation (e.g. `dev3 note add`). withFileLock now retries a timed-out
+// acquisition a bounded number of times, keeping the per-attempt deadline short.
+const tempDir = mkdtempSync(join(tmpdir(), "dev3-lock-retry-"));
+const filePath = join(tempDir, "tasks.json");
+const lockDir = `${filePath}.lock`;
+
+describe("withFileLock — bounded acquisition retry", () => {
+	beforeEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterAll(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("acquires the lock on a later attempt when the holder releases late", async () => {
+		mkdirSync(lockDir);
+		setTimeout(() => rmdirSync(lockDir), 120);
+
+		const result = await withFileLock(filePath, async () => "acquired", {
+			timeout: 50,
+			staleThreshold: 60000,
+		});
+
+		expect(result).toBe("acquired");
+	});
+
+	it("reports the attempt count once every attempt times out", async () => {
+		mkdirSync(lockDir);
+
+		await expect(
+			withFileLock(filePath, async () => "never", { timeout: 30, staleThreshold: 60000 }),
+		).rejects.toThrow(/\(3 attempts\)/);
+	});
+
+	it("fails on the first timeout when retries are disabled", async () => {
+		mkdirSync(lockDir);
+
+		const started = Date.now();
+		const err = await withFileLock(filePath, async () => "never", {
+			timeout: 30,
+			staleThreshold: 60000,
+			retries: 0,
+		}).catch((e) => e);
+
+		expect(err).toBeInstanceOf(FileLockTimeoutError);
+		expect(String(err.message)).not.toContain("attempts");
+		expect(Date.now() - started).toBeLessThan(300);
+	});
+});

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -66,11 +66,23 @@ async function ensureDir(filePath: string): Promise<void> {
 	await mkdir(dir, { recursive: true });
 }
 
+// Per-call counter: the temp name must be unique per CALL, not per process.
+// Two concurrent atomicWriteFile calls to the same file inside one process used
+// to share `<file>.tmp-<pid>`, so the loser's rename() hit ENOENT and its
+// cleanup unlink() could delete the winner's temp file mid-flight.
+let atomicWriteSeq = 0;
+
+// Backoff for a transient failure of the write/rename pair (a Windows indexer
+// or antivirus holding the file, a momentary EACCES). Bounded on purpose — a
+// real permission or disk problem must still surface.
+const ATOMIC_WRITE_RETRY_DELAYS_MS = [10, 30, 90];
+const TRANSIENT_WRITE_ERROR_CODES = new Set(["ENOENT", "EPERM", "EACCES", "EBUSY"]);
+
 /**
  * Crash-safe write: write `content` to a sibling temp file in the SAME
  * directory, then rename() it over `filePath`. rename() within one filesystem
  * is atomic on POSIX, so a crash/power-loss can only ever leave the temp file
- * truncated — never the live file. The temp name (`<file>.tmp-<pid>`) never
+ * truncated — never the live file. The temp name (`<file>.tmp-<pid>-<n>`) never
  * matches the exact filenames or backup patterns older versions read, so a
  * leftover is harmless; we still clean it up on failure. The final path and
  * byte content are identical to the old in-place writeFile, so older app
@@ -79,13 +91,20 @@ async function ensureDir(filePath: string): Promise<void> {
  * Exported for sibling data modules (automations-data.ts) — same guarantees.
  */
 export async function atomicWriteFile(filePath: string, content: string): Promise<void> {
-	const tmpPath = `${filePath}.tmp-${process.pid}`;
-	try {
-		await writeFile(tmpPath, content);
-		await rename(tmpPath, filePath);
-	} catch (err) {
-		await unlink(tmpPath).catch(() => {});
-		throw err;
+	for (let attempt = 0; ; attempt++) {
+		const tmpPath = `${filePath}.tmp-${process.pid}-${atomicWriteSeq++}`;
+		try {
+			await writeFile(tmpPath, content);
+			await rename(tmpPath, filePath);
+			return;
+		} catch (err: any) {
+			await unlink(tmpPath).catch(() => {});
+			const retryable = TRANSIENT_WRITE_ERROR_CODES.has(err?.code);
+			if (!retryable || attempt >= ATOMIC_WRITE_RETRY_DELAYS_MS.length) throw err;
+			const delay = ATOMIC_WRITE_RETRY_DELAYS_MS[attempt];
+			log.warn("Atomic write failed, retrying", { filePath, code: err.code, attempt: attempt + 1, delay });
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
 	}
 }
 

--- a/src/bun/file-lock.ts
+++ b/src/bun/file-lock.ts
@@ -8,10 +8,18 @@ const DEFAULT_TIMEOUT = 5000;
 const DEFAULT_STALE_THRESHOLD = 10000;
 const INITIAL_RETRY_DELAY = 5;
 const MAX_RETRY_DELAY = 50;
+// Extra acquisition attempts after a timeout. Under real contention (several
+// agents, pollers and CLI mutators on one tasks.json) a single 5s window is
+// occasionally lost, and the caller sees a hard failure for a purely transient
+// queue. Retrying keeps the per-attempt deadline short, so a genuinely stuck
+// holder still fails fast-ish and is visible as a warning per attempt — which
+// simply raising the timeout would hide.
+const DEFAULT_RETRIES = 2;
 
 export class FileLockTimeoutError extends Error {
-	constructor(lockPath: string, timeout: number) {
-		super(`Failed to acquire file lock "${lockPath}" within ${timeout}ms`);
+	constructor(lockPath: string, timeout: number, attempts = 1) {
+		const suffix = attempts > 1 ? ` (${attempts} attempts)` : "";
+		super(`Failed to acquire file lock "${lockPath}" within ${timeout}ms${suffix}`);
 		this.name = "FileLockTimeoutError";
 	}
 }
@@ -19,6 +27,8 @@ export class FileLockTimeoutError extends Error {
 export interface FileLockOptions {
 	timeout?: number;
 	staleThreshold?: number;
+	/** Extra acquisition attempts after a timed-out one (default 2). */
+	retries?: number;
 }
 
 /**
@@ -41,9 +51,23 @@ export async function withFileLock<T>(
 ): Promise<T> {
 	const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
 	const staleThreshold = options?.staleThreshold ?? DEFAULT_STALE_THRESHOLD;
+	const retries = Math.max(0, options?.retries ?? DEFAULT_RETRIES);
 	const lockDir = filePath + ".lock";
 
-	await acquireLock(lockDir, timeout, staleThreshold);
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await acquireLock(lockDir, timeout, staleThreshold);
+			break;
+		} catch (err) {
+			if (!(err instanceof FileLockTimeoutError) || attempt >= retries) {
+				if (err instanceof FileLockTimeoutError && attempt > 0) {
+					throw new FileLockTimeoutError(lockDir, timeout, attempt + 1);
+				}
+				throw err;
+			}
+			log.warn("Lock acquisition timed out, retrying", { lockDir, timeout, attempt: attempt + 1 });
+		}
+	}
 	try {
 		return await fn();
 	} finally {


### PR DESCRIPTION
Two vents reported the same shape of failure: a single write to task metadata broke a task-lifecycle operation, and an immediate manual retry succeeded (one `ENOENT` on the atomic rename during a status transition, one `FileLockTimeoutError` from `dev3 note add`). Neither path had any retry.

`atomicWriteFile` named its temp file `${filePath}.tmp-${process.pid}` — keyed on the process, not the call. Two concurrent writes to one file inside a single process therefore shared a temp path: the loser's `rename` hit `ENOENT`, and its error-path `unlink` could delete the winner's temp file mid-flight.

What changed:

- `atomicWriteFile` derives the temp name per call (`<file>.tmp-<pid>-<n>`), so concurrent in-process writes can no longer collide or clobber each other's cleanup.
- `atomicWriteFile` retries the write+rename pair 3 extra times (10/30/90 ms) on `ENOENT`/`EPERM`/`EACCES`/`EBUSY`, logging a warning per retry; any other error surfaces immediately.
- `withFileLock` retries a timed-out acquisition (`retries`, default 2) with the unchanged short per-attempt deadline, warning per attempt, and the final error names the attempt count. Retrying was chosen over raising the 5s deadline so contention stays visible in the log and a genuinely stuck holder still fails without a long silent stall.

Stale-lock breaking and the post-create read-back are untouched — neither caused these failures.

The new race test is a real reproduction, not a fit: run against the pre-fix implementation it fails 4 of 5 cases; the concurrent-write case fails deterministically.

Decision record: `decisions/2026/08/14/atomic-write-per-call-temp-and-lock-retry.md`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=eec54125-8536-462b-96cc-b2ed4e3ba18b) · `dev3://task/eec54125-8536-462b-96cc-b2ed4e3ba18b` _(dev3 added this footer — turn it off in Settings → Tasks.)_
