### PR TITLE
Correct the Windows download size in comments and install docs

### DIFF
--- a/.github/workflows/release-build-windows.yml
+++ b/.github/workflows/release-build-windows.yml
@@ -74,7 +74,10 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     # The packaging half of this job is measured at ~3 minutes on windows-latest (run
     # 31257371545); the rest of the budget is the launch proof's 4-minute readiness window plus
-    # zipping and uploading ~400 MB. Same 35 as the proof job it mirrors.
+    # compressing a ~400 MB tree down to a 121 MB zip and uploading that. Both numbers are
+    # measured on windows-latest (run 31799430704: `Staged stable-win-x64-dev-3.0.zip (121.0 MB)`,
+    # 15s of zipping) — do not quote 400 MB for anything downloaded, only for the tree on disk.
+    # Same 35 as the proof job it mirrors.
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -279,9 +279,14 @@ jobs:
             artifacts/*-update.json
 
       # The downloadable build, deliberately NOT folded into the proof artifact above:
-      # that one is JSON for CI and gets opened constantly, this one is ~400 MB for a
-      # human and gets opened rarely. Merging them would make every proof download drag
-      # the payload behind it.
+      # that one is JSON for CI and gets opened constantly, this one is the whole app for a
+      # human and gets opened rarely. Merging them would make every proof download drag the
+      # payload behind it.
+      #
+      # SIZES, MEASURED, because ~400 MB was quoted here for a long time and is only true of
+      # the tree on disk: GitHub compresses an artifact, so this one downloads at ~124 MB
+      # (windows-app-e4b5fcbf5…, 130 055 428 bytes) and the release zip built from the same
+      # tree is 121.0 MB (run 31799430704, on windows-latest).
       #
       # The EXTRACTED tree, not the `.tar.zst`: Windows tar.exe cannot read zstd (this
       # job ships electrobun's zig-zstd.exe precisely because of that), so the archive is

--- a/change-logs/2026/08/14/feature-01-windows-release-asset.md
+++ b/change-logs/2026/08/14/feature-01-windows-release-asset.md
@@ -1,3 +1,3 @@
 Short: Windows build on the release page
 
-Tagged releases now carry a Windows build: `stable-win-x64-dev-3.0.zip`, the exact tree CI extracted and launched on a Windows runner, attached next to the macOS disk images. It is unsigned and always will be, so the release notes and the install docs spell out the first-launch SmartScreen warning and the two clicks past it (**More info** → **Run anyway**) — extract the zip, run `bin\launcher.exe`, no installer needed.
+Tagged releases now carry a Windows build: `stable-win-x64-dev-3.0.zip` (121 MB, ~400 MB extracted), the exact tree CI extracted and launched on a Windows runner, attached next to the macOS disk images. It is unsigned and always will be, so the release notes and the install docs spell out the first-launch SmartScreen warning and the two clicks past it (**More info** → **Run anyway**) — extract the zip, run `bin\launcher.exe`, no installer needed.

--- a/decisions/2026/08/14/windows-zip-on-the-release-page.md
+++ b/decisions/2026/08/14/windows-zip-on-the-release-page.md
@@ -100,8 +100,11 @@ users they reach.
   is loud (warning + run summary), the *cause* is one job page away. Tightening it would mean
   distinguishing "did not build" from "built and failed to upload", which is more machinery than
   the difference buys today.
-- **The zip is ~400 MB** as a release asset, per release, forever. GitHub's per-asset limit is 2 GB
-  and storage on a public repo is free, so this is a listing-clutter cost, not a bill.
+- **The zip is 121.0 MB** as a release asset, per release, forever — measured on windows-latest in
+  the first stable-channel build (run 31799430704), not the ~400 MB every older comment quoted;
+  that figure is the extracted tree, and it had been repeated for the download for months. GitHub's
+  per-asset limit is 2 GB and storage on a public repo is free, so this is a listing-clutter cost,
+  not a bill.
 - **Unsigned means SmartScreen every time.** Two clicks, measured once on one machine, in one
   locale. A browser-side download warning was never reported — unknown, not absent.
 - **"Launched on Windows" is not a property of a commit.** Windows trees are not byte-reproducible:

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,8 +46,8 @@ Apple Silicon and Intel are both supported. For Windows, see the next section.
 one zip you extract and run:
 
 1. Download [**`stable-win-x64-dev-3.0.zip`**](https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip)
-   (~400 MB). It is attached to every release built after 2026-08-14 — if the latest release
-   predates that, the link 404s and there is no Windows build for it.
+   (~121 MB, ~400 MB once extracted). It is attached to every release built after 2026-08-14 —
+   if the latest release predates that, the link 404s and there is no Windows build for it.
 2. Right-click the zip → **Extract All**. Nothing else is needed; the app carries its own runtime.
 3. Open the extracted `dev-3.0` folder and double-click `bin\launcher.exe`.
 4. **The first launch shows a full-screen blue SmartScreen warning.** This build is not

--- a/scripts/package-windows-launched-tree.ts
+++ b/scripts/package-windows-launched-tree.ts
@@ -47,8 +47,10 @@ function requireString(proof: LaunchProof, field: keyof LaunchProof, why: string
 }
 
 /**
- * `ZipFile.CreateFromDirectory`, not `Compress-Archive`: the tree is ~400 MB across thousands
- * of files and the cmdlet takes minutes on it, inside a job with a 35-minute budget.
+ * `ZipFile.CreateFromDirectory`, not `Compress-Archive`: the INPUT tree is ~400 MB across
+ * thousands of files and the cmdlet takes minutes on it, inside a job with a 35-minute budget.
+ * (~400 MB is the tree on disk only. The zip it produces is 121.0 MB, measured on
+ * windows-latest in run 31799430704 — 15 seconds of compression.)
  * `includeBaseDirectory: false` keeps the bundle root (`dev-3.0-canary/`) as the zip's single
  * top-level entry, because that root is already the unpack dir's only child — so extracting
  * gives one folder, not a hundred loose files in Downloads.

--- a/src/bun/__tests__/windows-release-notes.test.ts
+++ b/src/bun/__tests__/windows-release-notes.test.ts
@@ -63,7 +63,9 @@ describe("the release-notes fragment", () => {
 			WINDOWS_UNSIGNED_WARNING,
 		);
 		expect(notes).toContain(FACTS.zipUrl);
-		expect(notes, "a size lets the reader decide before starting a ~400 MB download").toMatch(/397\.7 MB/);
+		// The real one is 121.0 MB (run 31799430704, windows-latest); the fixture is deliberately a
+		// different number so a hardcoded size in the renderer would show up here.
+		expect(notes, "a size lets the reader decide before starting a nine-figure download").toMatch(/397\.7 MB/);
 	});
 
 	it("writes the entry point the way Windows shows it", () => {

--- a/src/bun/__tests__/workflow-windows-proof.test.ts
+++ b/src/bun/__tests__/workflow-windows-proof.test.ts
@@ -164,7 +164,7 @@ describe("the packaged Windows app is downloadable", () => {
 	it("keeps the JSON proof and the payload in separate artifacts", () => {
 		expect(
 			/\.tar\.zst|\.zip|unpacked/.test(proofUpload),
-			"the proof artifact picked up a packaged payload. It is JSON downloaded constantly by CI; folding a ~400 MB build into it makes every proof download drag the payload behind it. Fix: leave the build in its own artifact.",
+			"the proof artifact picked up a packaged payload. It is JSON downloaded constantly by CI; folding a ~124 MB build into it (130 055 428 bytes measured on windows-app-e4b5fcbf5…; ~400 MB is the extracted tree, not the download) makes every proof download drag the payload behind it. Fix: leave the build in its own artifact.",
 		).toBe(false);
 	});
 


### PR DESCRIPTION
Hey — Claude here, the AI assistant that wrote this branch. **Comments and documentation only; no behaviour changes.**

`~400 MB` had propagated to six places as the size of the Windows *download*. It is the size of the extracted tree. Measured on `windows-latest` in the first stable-channel Windows build ([run 31799430704](https://github.com/h0x91b/dev-3.0/actions/runs/31799430704), `Staged stable-win-x64-dev-3.0.zip (121.0 MB)`), three quantities were being conflated:

| Quantity | Size |
|---|---|
| Extracted tree on disk | ~400 MB |
| Release zip a human downloads | **121.0 MB** |
| `windows-app-<sha>` CI artifact download | ~124 MB (130 055 428 bytes) |

Corrected in `docs/install.md` (the line someone reads before clicking), the timeout-budget comment in `release-build-windows.yml`, the artifact comment in `windows-conpty-package.yml`, the zip-helper comment in `package-windows-launched-tree.ts`, a risk bullet in `decisions/2026/08/14/windows-zip-on-the-release-page.md`, and a stale failure message in `workflow-windows-proof.test.ts`. Each now names the number it means and where it was measured.

No second changelog entry: the size is folded into this task's existing `feature-01-windows-release-asset.md`, one entry per task.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=97d2c908-c73c-4088-9d46-11beb2558220) · `dev3://task/97d2c908-c73c-4088-9d46-11beb2558220`