### PR TITLE
Publish canary builds as one rolling GitHub pre-release

### DIFF
--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -184,3 +184,64 @@ jobs:
       tag: ${{ github.sha }}
       publish: true
       bestEffort: false
+
+  # ──────────────────────────────────────────────────
+  # The page a human can click — one rolling pre-release
+  # ──────────────────────────────────────────────────
+  # A DOWNLOAD SURFACE, NOT A SECOND FEED. Clients discover builds through the manifests the
+  # jobs above sync to S3, ordered by `buildOrder`; nothing in the app reads a GitHub release.
+  # This job exists because the only way to obtain a canary build was a raw bucket URL handed
+  # over by hand — and on Windows that is the ONLY bootstrap there is, because the in-app
+  # channel switch refuses on every non-macOS platform and its error text sends the user to
+  # "the releases page". See decisions/2026/08/14/canary-rolling-github-prerelease.md.
+  #
+  # ONE ROLLING ENTRY, tag `canary`, assets replaced in place. Measured over 145 runs of this
+  # workflow: 4.2 publishes a day, peak 9 — a release per publish is ~30 entries a week and
+  # buries every stable release, which is the opposite of what was asked for.
+  #
+  # `always()` because a partial run is the normal case: each platform skips on its own feed,
+  # so this must refresh whatever DID build. It cannot run on a quiet hour, because every
+  # build job is then skipped and no `result` is 'success'; and it cannot run behind a failed
+  # `decide`, for the same reason.
+  release-page:
+    needs: [decide, build-macos-arm64, build-macos-x64, build-linux-x64, build-linux-arm64, build-win-x64]
+    if: >-
+      always() && (
+      needs.build-macos-arm64.result == 'success' ||
+      needs.build-macos-x64.result == 'success' ||
+      needs.build-linux-x64.result == 'success' ||
+      needs.build-linux-arm64.result == 'success' ||
+      needs.build-win-x64.result == 'success' )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The ONLY job here that writes to the repository, and the tag move is why. Workflow-level
+    # permissions stay `contents: read` so a build job can never edit a release or a ref.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      # `pattern:` IS LOAD-BEARING, not tidiness. This run also carries the Windows proof's
+      # artifacts, including the ~400 MB unpacked launch tree; an unfiltered download would
+      # flatten every loose .exe and .dll of it into the same directory the publisher uploads
+      # from, and attach them to the release one by one.
+      - name: Collect the built artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: artifacts-*
+          path: all-artifacts
+          merge-multiple: true
+
+      - name: List collected artifacts
+        run: ls -lhR all-artifacts/
+
+      # No `bun install`: the script imports only src/shared, like the decide job above.
+      - name: Refresh the rolling canary pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/publish-canary-release.ts

--- a/change-logs/2026/08/14/feature-40-canary-releases-page.md
+++ b/change-logs/2026/08/14/feature-40-canary-releases-page.md
@@ -1,0 +1,3 @@
+Short: Canary builds on the releases page
+
+Canary builds are now downloadable from the GitHub releases page: one rolling pre-release tagged `canary`, refreshed on every publish, carrying the macOS DMGs, the Linux tarballs, the CLI tarballs and the launched Windows zip. It is always a pre-release and never "Latest", so the stable release keeps the badge and every `/releases/latest` link keeps resolving to it. Each file's row names the run that produced those exact bytes, and the in-app updater still reads the S3 feed — nothing about updates changed.

--- a/decisions/2026/08/14/canary-rolling-github-prerelease.md
+++ b/decisions/2026/08/14/canary-rolling-github-prerelease.md
@@ -1,0 +1,52 @@
+# One rolling `canary` pre-release, not one release per publish
+
+## Context
+
+Canary builds existed only as keys in the S3 update bucket. A person who wanted to shake out a
+canary build had no page to visit and had to be handed a raw bucket URL by hand. On Windows that
+is the *only* bootstrap there is: `src/bun/updater.ts` refuses a cross-channel switch on every
+non-macOS platform (the running app **is** the channel folder there, so an in-place switch would
+install where the launcher never starts), and its error text tells the user to "install the other
+channel's build once from the releases page" — a page that had no canary build on it.
+
+## Investigation
+
+The cadence had to be measured before the shape could be chosen, because the hourly publisher's
+`decide` job skips every platform when `main` has not moved. Over the 145 most recent runs of
+`canary-publish.yml`, publishes per day were 3, 9, 5, 1, 3 (Aug 9–13) — **4.2 a day, peak 9**, not
+the 24 an hourly cron suggests; 91 of 145 ticks built nothing. `main` itself took 152 commits in
+14 days, so several merges collapse into one tick. A release per publish is therefore ~30 entries
+a week, which buries every stable release — the opposite of what was asked for.
+
+## Decision
+
+`canary-publish.yml` gained a `release-page` job that refreshes **one** pre-release tagged
+`canary`: it moves the tag to the published commit, rewrites the body, and re-uploads the assets
+with `--clobber`. Rules live in `src/shared/canary-release.ts`; the I/O is
+`scripts/publish-canary-release.ts`. It is always `--prerelease --latest=false`, on both the
+create and the refresh path, because `/releases/latest` is resolved by `src/bun/rosetta.ts` and by
+every download button on `docs/index.html`.
+
+Two things are attached as **copies, never bucket links**: the canary keys at the bucket root are
+overwritten in place, so a link would silently change bytes under whoever downloads it. And each
+row of the body names the **run**, not just the commit — Windows trees are not byte-reproducible
+(one sha, three runs, a 15-byte spread), so the sha alone does not identify a file. That
+provenance lives in a small `canary-assets.json` asset and is merged per file, because a run
+rebuilds only the platforms whose own feed is behind.
+
+## Risks
+
+The page orders by date, so the rolling entry sits permanently **above** every stable release
+rather than between them; Arseny picked that shape with the consequence stated. Canary history is
+not kept on the page — older builds remain in the bucket's per-sha prefix. The versioned canary
+prefix still has no retention policy. And the tag `canary` must never fall inside `release.yml`'s
+`v*` / `test-*` filters, or every canary publish would start a full stable release including the
+Homebrew cask edit; `canary-release.test.ts` pins that against the filters read out of
+`release.yml` itself.
+
+## Alternatives considered
+
+**One release per publish** — ~30 entries a week, buries stable, needs a pruning job.
+**One per day (`canary-YYYY-MM-DD`)** — the documented fallback if the history is ever wanted:
+~7 entries a week genuinely interleaved with stable ones, at ~400 MiB of assets a day.
+**Linking the bucket instead of attaching copies** — rejected: root keys are overwritten in place.

--- a/scripts/publish-canary-release.ts
+++ b/scripts/publish-canary-release.ts
@@ -1,0 +1,192 @@
+/**
+ * Refreshes the rolling `canary` GitHub pre-release from the artifacts of one canary run.
+ *
+ * Thin on purpose, like decide-canary-publish.ts: every rule lives in
+ * `src/shared/canary-release.ts` where it is unit tested, and this file only does the I/O —
+ * read the downloaded artifacts, move the tag, create-or-edit the release, upload the files.
+ *
+ * PRERELEASE AND NOT-LATEST ARE ASSERTED ON BOTH PATHS, create and edit. GitHub keeps
+ * `/releases/latest` off prereleases, and that URL is load-bearing in two places outside CI:
+ * `src/bun/rosetta.ts` hands it to a user on the wrong architecture, and the landing page's
+ * download buttons point at it. A canary release that ever became Latest would send every
+ * casual visitor an unsigned build of whatever main was at.
+ *
+ * PARTIAL RUNS ARE NORMAL. Each platform is skipped independently, so a run may carry only a
+ * Windows zip; the ledger merge keeps the other platforms' rows and their real provenance
+ * instead of letting the body claim they came from this run.
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import {
+	CANARY_LEDGER_ASSET,
+	CANARY_RELEASE_TAG,
+	classifyCanaryArtifact,
+	mergeCanaryLedger,
+	parseCanaryLedger,
+	platformOfArtifact,
+	renderCanaryReleaseBody,
+	type CanaryAssetEntry,
+} from "../src/shared/canary-release";
+
+const artifactDir = process.env.DEV3_CANARY_ARTIFACT_DIR ?? "all-artifacts";
+const repo = process.env.GITHUB_REPOSITORY ?? "";
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const runId = process.env.GITHUB_RUN_ID ?? "";
+const sha = process.env.GITHUB_SHA ?? "";
+
+for (const [name, value] of Object.entries({ GITHUB_REPOSITORY: repo, GITHUB_RUN_ID: runId, GITHUB_SHA: sha })) {
+	if (!value) {
+		console.error(`::error::${name} is unset, so the release cannot say which run produced these bytes`);
+		process.exit(1);
+	}
+}
+
+const repoUrl = `${serverUrl}/${repo}`;
+
+/** One `gh` invocation. Never throws on a non-zero exit — callers decide what a failure means. */
+function gh(args: string[], stdin?: string) {
+	const result = spawnSync("gh", args, { encoding: "utf8", input: stdin });
+	return {
+		ok: result.status === 0,
+		stdout: (result.stdout ?? "").trim(),
+		stderr: (result.stderr ?? "").trim() || `gh exited ${result.status}`,
+	};
+}
+
+function ghOrDie(args: string[], what: string) {
+	const result = gh(args);
+	if (!result.ok) {
+		console.error(`::error::${what} failed: ${result.stderr}`);
+		process.exit(1);
+	}
+	return result.stdout;
+}
+
+// ── What this run actually built ────────────────────────────────────────────
+let names: string[];
+try {
+	names = readdirSync(artifactDir).filter((name) => statSync(join(artifactDir, name)).isFile());
+} catch (err) {
+	console.error(`::error::${artifactDir} could not be read (${String(err)}). The job downloads the build artifacts into it, so an empty run should have been skipped by the job's \`if:\` rather than reaching this script.`);
+	process.exit(1);
+}
+
+const uploads: string[] = [];
+for (const name of names.sort()) {
+	const verdict = classifyCanaryArtifact(name);
+	if (verdict.upload) uploads.push(name);
+	else console.log(`skip ${name} — ${verdict.reason}`);
+}
+
+if (uploads.length === 0) {
+	console.error("::error::this run produced no downloadable artifact, so refreshing the release would only rewrite its body. Fix: check the build jobs — the release job is gated on at least one of them succeeding.");
+	process.exit(1);
+}
+
+/**
+ * The version comes out of THIS run's own manifest rather than package.json: the manifest is
+ * what the publisher wrote (`1.44.0+canary.<sha>`), so the title cannot drift from the build.
+ */
+const manifest = names.find((name) => name.endsWith("-update.json"));
+if (!manifest) {
+	console.error("::error::no *-update.json among the artifacts, so the canary version cannot be read. Fix: create-release-artifacts.sh writes one per platform — check the build job's artifact upload.");
+	process.exit(1);
+}
+const version = (JSON.parse(readFileSync(join(artifactDir, manifest), "utf8")) as { version?: string }).version;
+if (!version) {
+	console.error(`::error::${manifest} carries no version field, which means a previous publish wrote a broken manifest`);
+	process.exit(1);
+}
+
+// ── Does the rolling release exist yet? ─────────────────────────────────────
+const releaseExists = gh(["release", "view", CANARY_RELEASE_TAG, "--repo", repo, "--json", "tagName"]).ok;
+
+/**
+ * The ledger already on the release, if any. A missing or unreadable one is NOT fatal: it
+ * degrades to "this run's assets only", which is honest — every row it prints still names the
+ * run that produced that file.
+ */
+let previous = null;
+if (releaseExists) {
+	const download = gh([
+		"release", "download", CANARY_RELEASE_TAG, "--repo", repo,
+		"--pattern", CANARY_LEDGER_ASSET, "--output", "-",
+	]);
+	if (download.ok) previous = parseCanaryLedger(download.stdout);
+	if (!previous) {
+		console.log(`::warning::no readable ${CANARY_LEDGER_ASSET} on the existing release, so rows for platforms this run did not build are dropped rather than guessed`);
+	}
+}
+
+const builtAt = new Date().toISOString();
+const fresh: CanaryAssetEntry[] = uploads.map((asset) => ({
+	asset,
+	platform: platformOfArtifact(asset),
+	sha,
+	runId,
+	builtAt,
+}));
+
+const ledger = mergeCanaryLedger(previous, fresh);
+const ledgerPath = join(artifactDir, CANARY_LEDGER_ASSET);
+writeFileSync(ledgerPath, `${JSON.stringify(ledger, null, "\t")}\n`);
+
+const notesPath = join(artifactDir, "canary-release-notes.md");
+writeFileSync(notesPath, renderCanaryReleaseBody({ ledger, version, repoUrl, generatedAt: builtAt }));
+console.log("=== Release body ===");
+console.log(readFileSync(notesPath, "utf8"));
+
+// ── Point the tag at this commit ────────────────────────────────────────────
+// `gh release create --target` only creates a tag that does not exist yet; an existing tag
+// would keep the release pinned to whatever commit it was first cut from, so the page would
+// show an ever-staler source commit while the assets moved on.
+if (gh(["api", `repos/${repo}/git/ref/tags/${CANARY_RELEASE_TAG}`]).ok) {
+	ghOrDie(
+		["api", "-X", "PATCH", `repos/${repo}/git/refs/tags/${CANARY_RELEASE_TAG}`, "-f", `sha=${sha}`, "-F", "force=true"],
+		`moving the ${CANARY_RELEASE_TAG} tag to ${sha.slice(0, 9)}`,
+	);
+	console.log(`Moved tag ${CANARY_RELEASE_TAG} → ${sha.slice(0, 9)}`);
+}
+
+// ── Create or refresh the release ───────────────────────────────────────────
+if (releaseExists) {
+	ghOrDie(
+		[
+			"release", "edit", CANARY_RELEASE_TAG, "--repo", repo,
+			"--title", `Canary ${version}`,
+			"--notes-file", notesPath,
+			// Re-asserted every run: if anything ever flips these by hand, the next publish puts
+			// them back rather than leaving an unsigned build wearing the Latest badge.
+			"--prerelease",
+			"--latest=false",
+		],
+		`updating the ${CANARY_RELEASE_TAG} release`,
+	);
+} else {
+	ghOrDie(
+		[
+			"release", "create", CANARY_RELEASE_TAG, "--repo", repo,
+			"--target", sha,
+			"--title", `Canary ${version}`,
+			"--notes-file", notesPath,
+			"--prerelease",
+			"--latest=false",
+		],
+		`creating the ${CANARY_RELEASE_TAG} release`,
+	);
+}
+
+// ── Attach the files ────────────────────────────────────────────────────────
+// `--clobber` because the names are stable by design: one link in the app's own refusal
+// message, one link in a bug report, and they keep resolving to the current canary.
+for (const asset of [...uploads, CANARY_LEDGER_ASSET]) {
+	ghOrDie(
+		["release", "upload", CANARY_RELEASE_TAG, join(artifactDir, asset), "--repo", repo, "--clobber"],
+		`uploading ${asset}`,
+	);
+	console.log(`Uploaded ${asset}`);
+}
+
+console.log(`::notice::Canary ${version} is on ${repoUrl}/releases/tag/${CANARY_RELEASE_TAG} (pre-release, not Latest) with ${uploads.length} downloadable files`);

--- a/src/bun/__tests__/canary-release.test.ts
+++ b/src/bun/__tests__/canary-release.test.ts
@@ -1,0 +1,349 @@
+/**
+ * The rolling `canary` GitHub pre-release: what it may hand out, what it must never become,
+ * and what the release body has to say.
+ *
+ * TWO FAILURES ARE SILENT AND EXPENSIVE, and everything here exists for one of them:
+ *   1. The canary release becoming "Latest". `/releases/latest` is fetched by
+ *      src/bun/rosetta.ts and linked by every download button on docs/index.html, so a canary
+ *      wearing that badge sends unsigned builds of whatever main was at to casual visitors —
+ *      with nothing red anywhere.
+ *   2. The tag matching release.yml's filters. That workflow fires on `v*` and `test-*`; a
+ *      canary tag inside either glob would start a full stable release on every publish,
+ *      including the Homebrew cask edit.
+ *
+ * Scope follows the property: the pure rules are asserted against the module, the shell
+ * decisions against the script that makes them, and the job wiring against the workflow.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { CANARY_PLATFORMS } from "../../shared/canary-publish";
+import {
+	CANARY_LEDGER_ASSET,
+	CANARY_RELEASE_TAG,
+	classifyCanaryArtifact,
+	mergeCanaryLedger,
+	parseCanaryLedger,
+	platformOfArtifact,
+	renderCanaryReleaseBody,
+	type CanaryAssetEntry,
+} from "../../shared/canary-release";
+
+const read = (path: string) => readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf8");
+
+const CANARY_WORKFLOW = read("../../../.github/workflows/canary-publish.yml");
+const RELEASE_WORKFLOW = read("../../../.github/workflows/release.yml");
+const SCRIPT = read("../../../scripts/publish-canary-release.ts");
+
+const entry = (over: Partial<CanaryAssetEntry> = {}): CanaryAssetEntry => ({
+	asset: "canary-win-x64-dev-3.0-canary.zip",
+	platform: "win-x64",
+	sha: "42ee05e82f0b1c9d8e7a6b5c4d3e2f1a09876543",
+	runId: "31300000001",
+	builtAt: "2026-08-14T12:00:00.000Z",
+	...over,
+});
+
+describe("what may be attached to the canary release", () => {
+	it("hands out the builds a person installs", () => {
+		for (const name of [
+			"canary-win-x64-dev-3.0-canary.zip",
+			"canary-macos-arm64-dev-3.0.dmg",
+			"canary-linux-x64-dev-3.0.tar.zst",
+			"dev3-cli-macos-arm64.tar.gz",
+		]) {
+			expect(classifyCanaryArtifact(name), `${name} is a file a human installs and must be attached`).toEqual({
+				upload: true,
+			});
+		}
+	});
+
+	// The manifest is how EVERY client discovers builds. A copy pinned to a release goes stale
+	// the moment the next publish overwrites the bucket, and then two files with the same name
+	// disagree about which build is current — with the wrong one served from the page a human
+	// was pointed at.
+	it("never attaches an update manifest, which would read as a second feed", () => {
+		const verdict = classifyCanaryArtifact("canary-win-x64-update.json");
+		expect(
+			verdict.upload,
+			"an *-update.json is being attached to the release. The app discovers builds through the S3 feed only; a copy on the release page is a second feed that is stale as soon as the next build publishes. Fix: keep the *-update.json rejection in classifyCanaryArtifact.",
+		).toBe(false);
+	});
+
+	// The one rule copied deliberately from release.yml, because the reason is the same on both
+	// surfaces: nothing has ever launched the installer, so handing it out would put the
+	// unvetted binary in front of users while the proven zip stayed decoration.
+	it("never attaches the Windows installer nothing has ever launched", () => {
+		const verdict = classifyCanaryArtifact("canary-win-x64-dev-3.0-canary-Setup-canary.zip");
+		expect(
+			verdict.upload,
+			"the self-extracting Windows installer is being attached. No job, test or proof has ever launched it — the launch proof spawns the tree inside the plain zip. Fix: keep the Setup rejection in classifyCanaryArtifact and grow verify:win-app-launch a second target before publishing it.",
+		).toBe(false);
+	});
+
+	it("never attaches the zstd tarball Windows cannot open", () => {
+		expect(
+			classifyCanaryArtifact("canary-win-x64-dev-3.0-canary.tar.zst").upload,
+			"the Windows .tar.zst is being attached. Windows tar.exe cannot read zstd, so it is the updater's file and a human who downloads it is simply stuck. Fix: keep the rejection; the zip is the file for people.",
+		).toBe(false);
+		expect(
+			classifyCanaryArtifact("canary-linux-x64-dev-3.0.tar.zst").upload,
+			"the LINUX .tar.zst is now rejected too, and on Linux that IS the human's download. Fix: scope the rejection to win-*.",
+		).toBe(true);
+	});
+
+	it("explains every rejection instead of dropping the file silently", () => {
+		for (const name of ["canary-win-x64-update.json", "x-Setup-canary.zip", "canary-win-x64-app.tar.zst"]) {
+			const verdict = classifyCanaryArtifact(name);
+			expect(verdict.upload).toBe(false);
+			expect(
+				"reason" in verdict && verdict.reason.length,
+				`${name} is rejected with no reason. The run log is the only place anyone sees why a file is missing from the release. Fix: give the branch a sentence.`,
+			).toBeGreaterThan(20);
+		}
+	});
+
+	it("labels each file with a platform the publisher actually builds", () => {
+		expect(platformOfArtifact("canary-win-x64-dev-3.0-canary.zip")).toBe("win-x64");
+		expect(platformOfArtifact("canary-macos-arm64-dev-3.0.dmg")).toBe("macos-arm64");
+		expect(platformOfArtifact("dev3-cli-something.tar.gz")).toBe("cli");
+	});
+
+	// Observed by running the publisher rather than by reading it: the CLI tarball carries the
+	// same os-arch token as the app build, so the table printed two rows labelled `macos-arm64`
+	// and nothing said which one was the app.
+	it("keeps the CLI tarball distinguishable from the app build for the same platform", () => {
+		expect(
+			platformOfArtifact("dev3-cli-macos-arm64.tar.gz"),
+			"the CLI tarball is labelled with a bare platform, identical to the DMG's label. A reader on the release page then sees two `macos-arm64` rows and cannot tell which file is the app. Fix: keep the cli- prefix.",
+		).toBe("cli-macos-arm64");
+		expect(platformOfArtifact("canary-macos-arm64-dev-3.0.dmg")).toBe("macos-arm64");
+	});
+});
+
+/**
+ * THE MERGE IS WHY THE LEDGER EXISTS. A canary run rebuilds only the platforms whose own feed
+ * is behind, so the release legitimately holds a Windows zip from one commit next to a DMG
+ * from an older one. Windows trees are not byte-reproducible either — one sha built three
+ * times gave three different zips — so a row must name the RUN, not just the commit.
+ */
+describe("the ledger of which run produced which file", () => {
+	it("replaces the row for a file this run rebuilt", () => {
+		const merged = mergeCanaryLedger(
+			{ assets: [entry({ runId: "1", sha: "aaaaaaaaa1", builtAt: "2026-08-13T00:00:00.000Z" })] },
+			[entry({ runId: "2", sha: "bbbbbbbbb2" })],
+		);
+		expect(merged.assets).toHaveLength(1);
+		expect(merged.assets[0]).toMatchObject({ runId: "2", sha: "bbbbbbbbb2" });
+	});
+
+	it("keeps the rows for platforms this run did NOT build", () => {
+		const merged = mergeCanaryLedger(
+			{ assets: [entry({ asset: "canary-macos-arm64-dev-3.0.dmg", platform: "macos-arm64", runId: "1" })] },
+			[entry({ runId: "2" })],
+		);
+		expect(
+			merged.assets.map((a) => `${a.asset}@${a.runId}`),
+			"a platform absent from this run lost its row, so the release body would claim every attached file came from this run while the older assets are still attached and downloadable. Fix: merge by asset name instead of replacing the ledger.",
+		).toEqual(["canary-macos-arm64-dev-3.0.dmg@1", "canary-win-x64-dev-3.0-canary.zip@2"]);
+	});
+
+	it("survives a first run with no ledger at all", () => {
+		expect(mergeCanaryLedger(null, [entry()]).assets).toHaveLength(1);
+	});
+
+	it("treats an unreadable ledger as absent rather than throwing mid-publish", () => {
+		expect(parseCanaryLedger("<!doctype html>")).toBeNull();
+		expect(parseCanaryLedger("{}"), "a ledger with no assets array must not be trusted").toBeNull();
+		expect(parseCanaryLedger(JSON.stringify({ assets: [entry()] }))?.assets).toHaveLength(1);
+	});
+});
+
+describe("the release body", () => {
+	const body = renderCanaryReleaseBody({
+		ledger: mergeCanaryLedger(null, [entry(), entry({ asset: "canary-macos-arm64-dev-3.0.dmg", platform: "macos-arm64" })]),
+		version: "1.44.0+canary.42ee05e8",
+		repoUrl: "https://github.com/h0x91b/dev-3.0",
+		generatedAt: "2026-08-14T12:00:00.000Z",
+	});
+
+	it("says in its first lines that this is not the stable download", () => {
+		const preview = body.split("\n").slice(0, 6).join("\n");
+		expect(
+			preview,
+			"the warning left the opening lines. The releases page shows only the beginning of the body under the title, and that preview is all most people read before clicking a download. Fix: keep the warning first.",
+		).toMatch(/not the release you want/i);
+		expect(preview).toMatch(/unsigned/i);
+	});
+
+	it("points at the stable release for anyone who landed here by mistake", () => {
+		expect(body).toContain("/releases/latest");
+	});
+
+	it("names the run behind every file, not just the commit", () => {
+		expect(
+			body,
+			"a row no longer links its run. Windows trees are not byte-reproducible (one sha, three runs, three different zips), so the commit alone does not identify the bytes anybody downloaded. Fix: keep the run column.",
+		).toContain("/actions/runs/31300000001");
+		expect(body).toContain("canary-win-x64-dev-3.0-canary.zip");
+		expect(body).toContain("canary-macos-arm64-dev-3.0.dmg");
+	});
+
+	// The in-app channel switch REFUSES on every non-macOS platform (src/bun/updater.ts: the
+	// running app IS the channel folder there, so an in-place switch would install where the
+	// launcher never starts) and its error text sends the user to "the releases page". This is
+	// that page, and it is the only Windows bootstrap there is.
+	it("tells a Windows user sent here by the app's refusal which file is theirs", () => {
+		expect(
+			body,
+			"the body no longer explains the arrival from the updater's cross-channel refusal. On Windows that refusal is the ONLY route to canary, and its message says to install the build from the releases page — landing on a page that does not mention it is a dead end. Fix: keep the section, and keep the win-x64 row it points at.",
+		).toMatch(/refusal/i);
+		expect(body).toContain("win-x64");
+	});
+
+	it("says updates do not come from this page", () => {
+		expect(
+			body,
+			"the body no longer states that the updater reads the S3 feed. Without it the next reader assumes the release page is a feed and 'fixes' ordering by editing releases. Fix: keep the section.",
+		).toMatch(/buildOrder/);
+	});
+
+	it("does not advertise its own bookkeeping file as a download", () => {
+		expect(
+			body.includes(`| ${CANARY_LEDGER_ASSET} |`) || body.includes(`[\`${CANARY_LEDGER_ASSET}\`]`),
+			`${CANARY_LEDGER_ASSET} is listed as a download. It is the provenance record, not a build. Fix: filter it out of the table.`,
+		).toBe(false);
+	});
+});
+
+/**
+ * THE ONE THAT WOULD SHIP A RELEASE NOBODY ASKED FOR. release.yml fires on tag pushes, and
+ * this publisher moves its tag on every canary publish. If the two ever overlap, each canary
+ * build starts a full stable release: signed DMGs to the stable feed, GitHub release notes for
+ * a version that was never cut, and a Homebrew cask pointing at a canary build.
+ */
+describe("the canary tag cannot start a stable release", () => {
+	/** The `tags:` list read out of release.yml itself, so a change there is caught here. */
+	const filters = (/^ {2}push:\n {4}tags:\s*\[([^\]]+)\]/m.exec(RELEASE_WORKFLOW)?.[1] ?? "")
+		.split(",")
+		.map((raw) => raw.trim().replace(/^["']|["']$/g, ""))
+		.filter(Boolean);
+
+	it("finds release.yml's tag filters to check against", () => {
+		expect(
+			filters,
+			"release.yml's `push: tags: [...]` list could not be read, so this test would pass by checking nothing. Fix: update the pattern above to match how the trigger is now written.",
+		).not.toEqual([]);
+	});
+
+	it("matches none of them", () => {
+		const hits = filters.filter((glob) =>
+			new RegExp(`^${glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`).test(CANARY_RELEASE_TAG),
+		);
+		expect(
+			hits,
+			`the canary tag "${CANARY_RELEASE_TAG}" matches release.yml's filter(s) ${hits.join(", ")}. Every canary publish moves that tag, so each one would start a full stable release — signed DMGs on the stable feed and a Homebrew cask edit pointing at a canary build. Fix: rename the canary tag, never widen the filter.`,
+		).toEqual([]);
+	});
+});
+
+/**
+ * `/releases/latest` skips prereleases, and that is the entire guard. Two callers outside CI
+ * depend on it: src/bun/rosetta.ts hands the URL to a user running the wrong architecture, and
+ * docs/index.html's download buttons point at it.
+ */
+describe("the canary release is never the default download", () => {
+	it("is created as a pre-release that is not Latest", () => {
+		const create = /release", "create"[\s\S]*?\);/.exec(SCRIPT)?.[0] ?? "";
+		expect(create, "the create call could not be found in the publisher").not.toBe("");
+		expect(
+			create,
+			"the canary release is created without --prerelease, so GitHub marks it Latest. src/bun/rosetta.ts and every download button on docs/index.html resolve /releases/latest, so casual visitors would be handed an unsigned build of whatever main was at. Fix: pass --prerelease.",
+		).toContain("--prerelease");
+		expect(
+			create,
+			"the canary release is created without --latest=false. --prerelease alone keeps it off /releases/latest today, but the explicit flag is what survives someone flipping the prerelease bit by hand. Fix: pass --latest=false.",
+		).toContain("--latest=false");
+	});
+
+	it("re-asserts both on every refresh, not only at creation", () => {
+		const edit = /release", "edit"[\s\S]*?\);/.exec(SCRIPT)?.[0] ?? "";
+		expect(edit, "the edit call could not be found in the publisher").not.toBe("");
+		expect(
+			edit,
+			"the refresh path does not re-assert --prerelease, so a release flipped to a full one by hand — or by a future gh default — stays that way and quietly becomes the default download. Fix: pass --prerelease on edit too.",
+		).toContain("--prerelease");
+		expect(edit, "the refresh path does not re-assert --latest=false. Same failure, same fix.").toContain("--latest=false");
+	});
+
+	// Not a style rule: the app must never learn to read releases. Ordering lives in
+	// `buildOrder` in the manifest, and a second source of truth would order builds by a
+	// version string or by publish date, which is exactly what the two channels cannot do.
+	it("leaves the updater reading the bucket and nothing else", () => {
+		const updater = read("../updater.ts");
+		expect(
+			/github\.com|api\.github/.test(updater),
+			"src/bun/updater.ts now references GitHub. The canary release page is a download surface for humans; making the app read it turns release publish dates into update ordering and breaks the channel rules. Fix: the feed is BASE_URL in the bucket.",
+		).toBe(false);
+	});
+});
+
+describe("the job that refreshes the release", () => {
+	const job = /^ {2}release-page:$[\s\S]*$/m.exec(CANARY_WORKFLOW)?.[0] ?? "";
+
+	it("exists at all", () => {
+		expect(job, "canary-publish.yml has no `release-page` job, so canary builds reach the bucket and no page. Fix: restore the job.").not.toBe("");
+	});
+
+	it("runs when ANY platform built, naming every platform the publisher has", () => {
+		const missing = CANARY_PLATFORMS.map((p) => `${p.os}-${p.arch}`).filter(
+			(key) => !job.includes(`needs.build-${key}.result == 'success'`),
+		);
+		expect(
+			missing,
+			`the release-page condition does not mention ${missing.join(", ")}. A run where only that platform built would leave the page untouched — the bucket would move and the download page would not, silently, forever. Fix: add the missing term.`,
+		).toEqual([]);
+	});
+
+	it("does not run on a quiet hour", () => {
+		expect(
+			job,
+			"the release-page job lost its `if:`, so every quiet hour rewrites the release body with no new build behind it. Fix: keep the any-platform-succeeded condition.",
+		).toMatch(/^ {4}if:/m);
+		expect(
+			job,
+			"the condition no longer requires a SUCCESSFUL build. With `always()` and nothing else, a run whose builds all failed would still refresh the page. Fix: compare each build's `result` to 'success'.",
+		).toContain("== 'success'");
+	});
+
+	// The proof gates the builds, and the builds gate this. Depending on `decide` alone would
+	// let the page refresh from artifacts of a run whose Windows packaging never passed.
+	it("hangs off the build jobs rather than off decide", () => {
+		expect(
+			job,
+			"the release-page job no longer needs the build jobs, so it can run before or without them and publish whatever happens to be in the artifact store. Fix: keep every build job in `needs`.",
+		).toMatch(/needs:.*build-win-x64/);
+	});
+
+	// The run also carries the Windows proof's artifacts, including the ~400 MB unpacked launch
+	// tree. Unfiltered, `merge-multiple: true` flattens every loose .exe and .dll of it into the
+	// directory the publisher uploads from — and each one gets attached to the release.
+	it("downloads only the release build artifacts", () => {
+		expect(
+			job,
+			"the artifact download is no longer scoped by `pattern: artifacts-*`. This run also holds the Windows proof's unpacked launch tree, so an unfiltered merge attaches hundreds of loose .exe and .dll files to the public release page. Fix: restore the pattern.",
+		).toMatch(/pattern:\s*artifacts-\*/);
+	});
+
+	it("is the only job allowed to write to the repository", () => {
+		expect(
+			job,
+			"the release-page job has no `permissions: contents: write`, and the workflow default is read — every publish would fail on the tag move. Fix: grant it at job level.",
+		).toMatch(/permissions:\s*\n\s+contents:\s*write/);
+		expect(
+			/^permissions:\n {2}contents:\s*read/m.test(CANARY_WORKFLOW),
+			"the workflow-level permission is no longer `contents: read`, so every build job can edit releases and refs too. Fix: keep the default read and grant write on the one job that needs it.",
+		).toBe(true);
+	});
+});

--- a/src/shared/canary-release.ts
+++ b/src/shared/canary-release.ts
@@ -1,0 +1,207 @@
+/**
+ * The canary channel's HUMAN-FACING download surface: one rolling GitHub pre-release.
+ *
+ * NOT A SECOND UPDATE FEED. The in-app updater reads `s3://h0x91b-releases/dev-3.0/` and
+ * orders builds by `buildOrder` in the manifest; nothing here is ever fetched by the app.
+ * This exists because a person who wants to shake out a canary build had no page to visit
+ * and had to be handed a raw bucket URL.
+ *
+ * ONE ROLLING ENTRY, not one release per publish. Measured on 145 runs of the hourly
+ * publisher: 4.2 publishes a day (peak 9), because the `decide` job skips every platform on
+ * an hour when main has not moved. A release per publish is ~30 entries a week, which buries
+ * every stable release. Per-day (`canary-YYYY-MM-DD`) is the documented fallback if the
+ * history is ever wanted. See decisions/2026/08/14/canary-rolling-github-prerelease.md.
+ *
+ * WHY COPIES AND NOT BUCKET LINKS: the canary keys at the bucket ROOT are overwritten in
+ * place by the next publish, so a link would silently change bytes under whoever downloads
+ * it. A release asset is fixed bytes, and the ledger below says which run produced each one.
+ */
+
+import { CANARY_PLATFORMS } from "./canary-publish";
+
+/**
+ * The tag the rolling release carries, moved to the newest published commit on every run.
+ *
+ * IT MUST NEVER MATCH release.yml's TAG FILTERS (`v*`, `test-*`). If it did, every canary
+ * publish would push a tag that starts a full stable release: signed DMGs, the stable feed,
+ * and a Homebrew cask edit pointing at a canary build. `canary-release.test.ts` pins this
+ * against the filters read out of release.yml itself, not against a copy of them.
+ */
+export const CANARY_RELEASE_TAG = "canary";
+
+/** The ledger's own file name, attached to the release next to the builds it describes. */
+export const CANARY_LEDGER_ASSET = "canary-assets.json";
+
+/**
+ * One downloadable file and the run that produced it.
+ *
+ * THE RUN, NOT THE SHA, IS THE IDENTITY. Windows trees are not byte-reproducible — one sha
+ * built three times gave three different zips (15-byte spread) — so "the build at 42ee05e8"
+ * does not name a specific file, and only the run id does.
+ */
+export type CanaryAssetEntry = {
+	/** File name as attached to the release. */
+	asset: string;
+	/** `os-arch` from {@link CANARY_PLATFORMS}, or `other` for the platform-agnostic CLI tarballs. */
+	platform: string;
+	/** Full commit the run built. */
+	sha: string;
+	/** GitHub Actions run id — the only thing that names these exact bytes. */
+	runId: string;
+	/** When the run attached it, ISO 8601. */
+	builtAt: string;
+};
+
+export type CanaryLedger = { assets: CanaryAssetEntry[] };
+
+/**
+ * Whether an artifact from a canary build belongs on the release page.
+ *
+ * A REJECTION IS A SENTENCE, not a boolean, because every one of these has burned someone:
+ * the installer nothing has ever launched, and a manifest that would read as a second feed.
+ */
+export type ArtifactVerdict = { upload: true } | { upload: false; reason: string };
+
+export function classifyCanaryArtifact(name: string): ArtifactVerdict {
+	if (name === CANARY_LEDGER_ASSET) {
+		return { upload: false, reason: "the ledger itself — attached separately, after it is merged" };
+	}
+	if (name.endsWith("-update.json")) {
+		return {
+			upload: false,
+			reason:
+				"an update manifest. The app discovers builds through the S3 feed only; a copy on the release page is a second feed that goes stale the moment the next build publishes.",
+		};
+	}
+	if (name.endsWith(".md")) {
+		return { upload: false, reason: "prose a build job hands to the release body, not a published file" };
+	}
+	if (/Setup/.test(name)) {
+		return {
+			upload: false,
+			reason:
+				"the self-extracting Windows installer. Nothing has ever launched it — the launch proof spawns the tree inside the zip — so handing it out would put the unvetted binary in front of users while the proven one stayed decoration.",
+		};
+	}
+	if (/^.*win-.*\.tar\.zst$/.test(name)) {
+		return {
+			upload: false,
+			reason:
+				"the Windows updater's own download. Windows tar.exe cannot read zstd, so a human cannot open it; the zip is the file for people.",
+		};
+	}
+	return { upload: true };
+}
+
+/**
+ * `os-arch` for a file name, or `other` when no platform token appears in it.
+ *
+ * The CLI tarballs carry the SAME `os-arch` token as the app build for that platform, so
+ * without the `cli-` prefix the table shows two rows labelled `macos-arm64` and the reader has
+ * to know which file is the app.
+ */
+export function platformOfArtifact(name: string): string {
+	const prefix = name.startsWith("dev3-cli-") ? "cli-" : "";
+	for (const { os, arch } of CANARY_PLATFORMS) {
+		if (name.includes(`${os}-${arch}`)) return `${prefix}${os}-${arch}`;
+	}
+	return prefix ? "cli" : "other";
+}
+
+/**
+ * Folds this run's uploads into what the release already carries.
+ *
+ * THE MERGE IS THE POINT. A canary run rebuilds only the platforms whose own feed is behind,
+ * so a release can legitimately hold a Windows zip from one commit next to a DMG from an
+ * older one. Dropping the previous entries would make the body claim every asset came from
+ * this run; keeping them unmerged would show two rows for one file.
+ */
+export function mergeCanaryLedger(previous: CanaryLedger | null, fresh: CanaryAssetEntry[]): CanaryLedger {
+	const byAsset = new Map<string, CanaryAssetEntry>();
+	for (const entry of previous?.assets ?? []) byAsset.set(entry.asset, entry);
+	for (const entry of fresh) byAsset.set(entry.asset, entry);
+	return { assets: [...byAsset.values()].sort((a, b) => a.asset.localeCompare(b.asset)) };
+}
+
+/** Parses a ledger read back off the release, tolerating anything that is not one. */
+export function parseCanaryLedger(raw: string): CanaryLedger | null {
+	try {
+		const parsed = JSON.parse(raw) as { assets?: unknown };
+		if (!Array.isArray(parsed.assets)) return null;
+		const assets = parsed.assets.filter(
+			(entry): entry is CanaryAssetEntry =>
+				!!entry && typeof (entry as CanaryAssetEntry).asset === "string" && typeof (entry as CanaryAssetEntry).sha === "string",
+		);
+		return { assets };
+	} catch {
+		return null;
+	}
+}
+
+export type CanaryBodyInput = {
+	ledger: CanaryLedger;
+	/** Version string out of this run's manifest, e.g. `1.44.0+canary.42ee05e8`. */
+	version: string;
+	/** `https://github.com/<owner>/<repo>` — every run link is built off it. */
+	repoUrl: string;
+	/** When this body was rendered, ISO 8601. */
+	generatedAt: string;
+};
+
+/**
+ * The release body. Written so the FIRST paragraph is the whole warning, because the release
+ * page shows the beginning of the body under the title and that preview is all most people
+ * read before clicking a download.
+ */
+export function renderCanaryReleaseBody({ ledger, version, repoUrl, generatedAt }: CanaryBodyInput): string {
+	const rows = ledger.assets
+		.filter((entry) => entry.asset !== CANARY_LEDGER_ASSET)
+		.map((entry) => {
+			const url = `${repoUrl}/releases/download/${CANARY_RELEASE_TAG}/${entry.asset}`;
+			const run = `[${entry.runId}](${repoUrl}/actions/runs/${entry.runId})`;
+			return `| ${entry.platform} | [\`${entry.asset}\`](${url}) | \`${entry.sha.slice(0, 9)}\` | ${run} | ${entry.builtAt} |`;
+		});
+
+	return [
+		`# Canary ${version}`,
+		"",
+		"**This is not the release you want unless you came here to test one.** It is built from",
+		"`main` automatically, it is unsigned on Windows, and it is replaced in place every time",
+		`main moves — the [Latest release](${repoUrl}/releases/latest) is the stable download.`,
+		"",
+		"## Downloads",
+		"",
+		"| Platform | File | Built from | Run | Attached |",
+		"| --- | --- | --- | --- | --- |",
+		...(rows.length > 0 ? rows : ["| — | _no assets attached yet_ | — | — | — |"]),
+		"",
+		"Each row names the RUN that produced those exact bytes, not just the commit: Windows",
+		"trees are not byte-reproducible, and a run only rebuilds the platforms whose feed is",
+		"behind, so rows can legitimately come from different commits.",
+		"",
+		"### Windows",
+		"",
+		"The zip is the tree a CI job actually launched and shut down cleanly. It is **unsigned**,",
+		"so the first launch shows SmartScreen's warning — that is the missing certificate, not a",
+		"malware verdict. Extract it with Explorer and run the executable inside; there is nothing",
+		"to install.",
+		"",
+		"### Sent here by the app's own refusal?",
+		"",
+		"Switching stable → canary in place only works on macOS: everywhere else the running app",
+		"IS the channel folder, so an in-place switch would install into a directory the launcher",
+		"never starts, and the updater refuses instead of silently doing nothing. Its message says",
+		"to install the other channel's build from the releases page — that is this page, and the",
+		"file is the one on the `win-x64` row above. Once it is running, canary updates itself",
+		"inside the canary channel.",
+		"",
+		"## Updates do not come from this page",
+		"",
+		"The in-app updater reads the canary feed in S3 and orders builds by `buildOrder`, never by",
+		"a version string or a GitHub release. This page is a download surface for people; deleting",
+		"it would not affect a single client.",
+		"",
+		`<sub>Rendered ${generatedAt} · tag \`${CANARY_RELEASE_TAG}\` is moved to the newest published commit on every publish.</sub>`,
+		"",
+	].join("\n");
+}


### PR DESCRIPTION
Canary builds existed only as keys in the S3 update bucket, so a human who wanted one had to be handed a raw bucket URL. On Windows that is the **only** bootstrap: `src/bun/updater.ts` refuses a cross-channel switch on every non-macOS platform and its error text says to "install the other channel's build once from the releases page" — a page that had no canary build on it.

`canary-publish.yml` now has a `release-page` job that refreshes **one rolling pre-release tagged `canary`**: it moves the tag to the published commit, rewrites the body and re-uploads the assets with `--clobber`. Rules live in `src/shared/canary-release.ts`, the I/O in `scripts/publish-canary-release.ts`.

**Cadence, measured over 145 runs of the workflow rather than assumed:** the hourly cron skips every platform when `main` has not moved, so real publishes are **4.2 a day (peak 9)**, not 24 — 91 of 145 ticks built nothing. A release per publish would be ~30 entries a week and would bury every stable release. **One per day (`canary-YYYY-MM-DD`) is the documented fallback** if the canary history is ever wanted: ~7 entries a week genuinely interleaved with stable ones, at ~400 MiB of assets a day.

**Nothing about updates changed.** Ordering still rides `buildOrder` in the bucket manifest; no client reads a GitHub release, and a test pins that `src/bun/updater.ts` never learns to.

Two shapes worth naming:
- **Copies, not bucket links.** The canary keys at the bucket root are overwritten in place, so a link would silently change bytes under whoever downloads it.
- **Each row names the run, not just the commit.** Windows trees are not byte-reproducible (one sha, three runs, a 15-byte spread), so a sha does not identify a file. Provenance lives in a small `canary-assets.json` asset and is merged per file, because a run rebuilds only the platforms whose own feed is behind.

Never the default download: `--prerelease --latest=false` on both the create and the refresh path, because `/releases/latest` is resolved by `src/bun/rosetta.ts` and by every download button on `docs/index.html`. A test also pins that the tag `canary` matches none of `release.yml`'s `v*` / `test-*` filters — inside either glob, every canary publish would start a full stable release including the Homebrew cask edit.

Verification, with the platform each claim executed on:
- 16 guards proven by mutation on **macOS**: each protected thing was broken in turn and the suite went red every time (dropped `--prerelease`, dropped `--latest=false`, unscoped artifact download, missing `contents: write`, workflow default flipped to write, deleted `if:`, a platform dropped from the condition, tag renamed into `v*`, ledger replaced instead of merged, `Setup` zip made uploadable, `update.json` made uploadable, linux `.tar.zst` wrongly rejected, run column dropped, warning dropped, Windows-refusal section dropped, updater pointed at GitHub).
- Both script paths **executed** against a stubbed `gh` on macOS — first run (create) and refresh (existing ledger, Windows-only rebuild): the older DMG kept its own run, the tag move fired, `--prerelease --latest=false` appeared on the edit.
- `bun run lint` clean; full `bun run test` green on macOS: 3829 mainview + 5653 bun + 769 cli, 0 failures.
- **Untested on Windows and untested against the real GitHub API** — the job itself has never run in CI. Acceptance is the release actually appearing on the page with a stable release still marked Latest, which happens on the first canary publish after merge.

Follow-up left out on purpose: `docs/install.md` says nothing about canary, and it is owned by another in-flight task right now.
