### PR TITLE
Close agent request dialogs on every client once one answers

### DIFF
--- a/change-logs/2026/08/14/fix-close-agent-dialogs-on-every-client.md
+++ b/change-logs/2026/08/14/fix-close-agent-dialogs-on-every-client.md
@@ -1,0 +1,3 @@
+Short: Agent dialogs close on every client
+
+Agent-initiated approval dialogs (a task asking to complete, or to start another task) are shown on every connected client — each open window plus every remote browser. Answering on one of them now closes the dialog on all the others instead of leaving a dead prompt behind.

--- a/src/bun/__tests__/agent-requests.test.ts
+++ b/src/bun/__tests__/agent-requests.test.ts
@@ -9,6 +9,11 @@ vi.mock("../logger", () => ({
 	}),
 }));
 
+const push = vi.fn();
+vi.mock("../rpc-handlers/shared-pure", () => ({
+	getPushMessage: () => push,
+}));
+
 import {
 	createAgentRequest,
 	resolveAgentRequest,
@@ -17,6 +22,7 @@ import {
 
 beforeEach(() => {
 	_resetAgentRequestsForTests();
+	push.mockClear();
 });
 
 describe("createAgentRequest", () => {
@@ -87,6 +93,30 @@ describe("resolveAgentRequest", () => {
 		const { requestId } = createAgentRequest("complete", "task-1", "proj-1");
 		expect(resolveAgentRequest(requestId, { approved: true })).toBe(true);
 		expect(resolveAgentRequest(requestId, { approved: true })).toBe(false);
+	});
+
+	it("broadcasts agentRequestResolved so other clients close their copy of the dialog", () => {
+		const { requestId } = createAgentRequest("launch", "task-1", "proj-1");
+
+		resolveAgentRequest(requestId, { approved: true, launch: { agentId: null, configId: null } });
+
+		expect(push).toHaveBeenCalledWith("agentRequestResolved", {
+			requestId,
+			kind: "launch",
+			taskId: "task-1",
+			projectId: "proj-1",
+		});
+	});
+
+	it("does not broadcast for an unknown or already-resolved request", () => {
+		const { requestId } = createAgentRequest("complete", "task-1", "proj-1");
+		resolveAgentRequest(requestId, { approved: false });
+		push.mockClear();
+
+		resolveAgentRequest(requestId, { approved: false });
+		resolveAgentRequest("nope", { approved: false });
+
+		expect(push).not.toHaveBeenCalled();
 	});
 
 	it("resolves every joined waiter with the same decision", async () => {

--- a/src/bun/agent-requests.ts
+++ b/src/bun/agent-requests.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "./logger";
+import { getPushMessage } from "./rpc-handlers/shared-pure";
 
 const log = createLogger("agent-requests");
 
@@ -82,6 +83,15 @@ export function resolveAgentRequest(requestId: string, decision: AgentRequestDec
 	pendingByRequestId.delete(requestId);
 	requestIdByKey.delete(dedupKey(entry.kind, entry.taskId));
 	entry.resolve(decision);
+	// The dialog was broadcast to every connected client (windows + remote
+	// browsers); whoever answered first owns the decision, so tell the rest to
+	// close theirs instead of leaving a dialog nobody can act on any more.
+	getPushMessage()?.("agentRequestResolved", {
+		requestId,
+		kind: entry.kind,
+		taskId: entry.taskId,
+		projectId: entry.projectId,
+	});
 	log.info("Agent request resolved", {
 		kind: entry.kind,
 		taskId: entry.taskId.slice(0, 8),

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -56,6 +56,7 @@ import RosettaWarningModal from "./components/RosettaWarningModal";
 import { initTaskSoundPlayback, playTaskCompletionSound, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "./task-sounds";
 import { offerMergeCompletion } from "./utils/offerMergeCompletion";
 import { taskDialogInfoFromSubject } from "./utils/taskDialogInfo";
+import { createAgentRequestAbort } from "./utils/agentRequestAbort";
 import { getRecentProjectIds, orderByRecency, recordProjectJump } from "./utils/recentProjects";
 import type { NavigationGuard } from "./navigation-guard";
 import { useTaskSwitcher } from "./hooks/useTaskSwitcher";
@@ -1676,6 +1677,9 @@ function App() {
 				subject?: TaskDialogSubject;
 			};
 			let approved = false;
+			// The same dialog is up on every connected client; the first answer
+			// closes the rest (see createAgentRequestAbort).
+			const abort = createAgentRequestAbort(requestId);
 			try {
 				approved = await confirm({
 					title: t("app.agentCompletionTitle"),
@@ -1685,10 +1689,16 @@ function App() {
 					cancelLabel: t("app.agentCompletionCancel"),
 					danger: true,
 					agentInitiated: true,
+					signal: abort.signal,
 				});
 			} catch (err) {
 				console.error("[App] confirm (agent-completion) failed:", err);
+			} finally {
+				abort.cleanup();
 			}
+			// Answered on another client — that client owns every side effect, and
+			// the CLI already has its decision.
+			if (abort.signal.aborted) return;
 			if (approved) {
 				// Leave the task's view BEFORE the worktree is destroyed (same
 				// reasoning as the branch-merged flow above). routeAfterTaskClosed sends
@@ -1718,8 +1728,18 @@ function App() {
 				queue.some((r) => r.requestId === request.requestId) ? queue : [...queue, request]
 			));
 		}
+		// Someone answered on another window / the remote browser: drop the request
+		// here too, whether it is on screen or still waiting in the queue.
+		function onAgentRequestResolved(e: Event) {
+			const { requestId } = (e as CustomEvent).detail as { requestId: string };
+			setLaunchRequests((queue) => queue.filter((r) => r.requestId !== requestId));
+		}
 		window.addEventListener("rpc:agentLaunchRequested", onAgentLaunchRequested);
-		return () => window.removeEventListener("rpc:agentLaunchRequested", onAgentLaunchRequested);
+		window.addEventListener("rpc:agentRequestResolved", onAgentRequestResolved);
+		return () => {
+			window.removeEventListener("rpc:agentLaunchRequested", onAgentLaunchRequested);
+			window.removeEventListener("rpc:agentRequestResolved", onAgentRequestResolved);
+		};
 	}, []);
 
 	const respondToLaunchRequest = useCallback((

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -51,6 +51,8 @@ vi.mock("../rpc", () => ({
 			markTaskSharedItemsRead: vi.fn().mockResolvedValue({ id: "updated-task" }),
 			listAgentSkills: vi.fn().mockResolvedValue([]),
 			respondToAgentCompletionRequest: vi.fn().mockResolvedValue(undefined),
+			respondToAgentLaunchRequest: vi.fn().mockResolvedValue(undefined),
+			checkAgentAvailability: vi.fn().mockResolvedValue([]),
 			getRemoteAccessQR: vi.fn().mockResolvedValue({
 				qrDataUrl: "data:image/png;base64,test",
 				accessUrl: "http://127.0.0.1:1234/?token=test",
@@ -2548,6 +2550,67 @@ describe("App keyboard shortcuts", () => {
 				priority: "P0",
 				labels: [{ id: "l1", name: "Feature", color: "#84cc16" }],
 			});
+		});
+	});
+
+	// Both agent dialogs are broadcast to every connected client (second window,
+	// remote browser). The first answer wins; the rest must close silently.
+	describe("agent request answered on another client", () => {
+		it("closes the completion dialog and skips this client's side effects", async () => {
+			vi.mocked(confirm).mockImplementation(((opts: { signal?: AbortSignal }) =>
+				new Promise<boolean>((resolve) => {
+					opts.signal?.addEventListener("abort", () => resolve(false));
+				})) as never);
+
+			await renderApp();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentCompletionRequested", {
+					detail: { requestId: "req-elsewhere", taskId: "t1", projectId: "p1", taskTitle: "Some task" },
+				}));
+			});
+			expect(vi.mocked(confirm)).toHaveBeenCalled();
+			expect(api.request.respondToAgentCompletionRequest).not.toHaveBeenCalled();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentRequestResolved", {
+					detail: { requestId: "req-elsewhere", kind: "complete", taskId: "t1", projectId: "p1" },
+				}));
+			});
+
+			// The winning client already answered the blocked CLI; this one must not
+			// send a second (declining) answer.
+			expect(api.request.respondToAgentCompletionRequest).not.toHaveBeenCalled();
+		});
+
+		it("closes the launch dialog without answering", async () => {
+			await renderApp();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentLaunchRequested", {
+					detail: {
+						requestId: "launch-elsewhere",
+						taskId: "t1",
+						projectId: "p1",
+						taskTitle: "Peer task",
+						targetStatus: "in-progress",
+						scratch: false,
+						requesterSeq: 42,
+						requesterTitle: "Asking task",
+						subject: { seqLabel: "7", projectName: "Alpha", overview: "Waiting to start." },
+					},
+				}));
+			});
+			expect(screen.getByRole("dialog", { name: /Peer task|Start/i })).toBeInTheDocument();
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentRequestResolved", {
+					detail: { requestId: "launch-elsewhere", kind: "launch", taskId: "t1", projectId: "p1" },
+				}));
+			});
+
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+			expect(api.request.respondToAgentLaunchRequest).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -65,6 +65,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	mergePromptResolved: (payload) => window.dispatchEvent(new CustomEvent("rpc:mergePromptResolved", { detail: payload })),
 	agentCompletionRequested: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentCompletionRequested", { detail: payload })),
 	agentLaunchRequested: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentLaunchRequested", { detail: payload })),
+	agentRequestResolved: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentRequestResolved", { detail: payload })),
 	updateAvailable: (payload) => window.dispatchEvent(new CustomEvent("rpc:updateAvailable", { detail: payload })),
 	portsUpdated: (payload) => window.dispatchEvent(new CustomEvent("rpc:portsUpdated", { detail: payload })),
 	exposedPortsChanged: (payload) => window.dispatchEvent(new CustomEvent("rpc:exposedPortsChanged", { detail: payload })),

--- a/src/mainview/utils/__tests__/agentRequestAbort.test.ts
+++ b/src/mainview/utils/__tests__/agentRequestAbort.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { createAgentRequestAbort } from "../agentRequestAbort";
+
+function fireResolved(detail: Record<string, unknown>) {
+	window.dispatchEvent(new CustomEvent("rpc:agentRequestResolved", { detail }));
+}
+
+describe("createAgentRequestAbort", () => {
+	it("aborts when the same request is answered on another client", () => {
+		const { signal, cleanup } = createAgentRequestAbort("req-1");
+
+		fireResolved({ requestId: "req-1", kind: "complete", taskId: "t1", projectId: "p1" });
+
+		expect(signal.aborted).toBe(true);
+		cleanup();
+	});
+
+	it("ignores another request's resolution", () => {
+		const { signal, cleanup } = createAgentRequestAbort("req-1");
+
+		fireResolved({ requestId: "req-2", kind: "launch", taskId: "t2", projectId: "p1" });
+
+		expect(signal.aborted).toBe(false);
+		cleanup();
+	});
+
+	it("stops listening after cleanup", () => {
+		const { signal, cleanup } = createAgentRequestAbort("req-1");
+		cleanup();
+
+		fireResolved({ requestId: "req-1", kind: "complete", taskId: "t1", projectId: "p1" });
+
+		expect(signal.aborted).toBe(false);
+	});
+});

--- a/src/mainview/utils/agentRequestAbort.ts
+++ b/src/mainview/utils/agentRequestAbort.ts
@@ -1,0 +1,25 @@
+/**
+ * Abort signal that fires when an agent-initiated request (`complete` /
+ * `launch`) is answered somewhere other than this dialog — a second window, or
+ * the remote browser served by the same app. The backend broadcasts the request
+ * to every connected client and pushes `agentRequestResolved` once the first
+ * answer lands, so without this the losing clients keep a dead dialog on screen.
+ *
+ * Wire the returned `signal` into `confirm()` and, after awaiting, check
+ * `signal.aborted` to skip this client's own resolution side effects — the CLI
+ * already got its answer from whoever won.
+ */
+export function createAgentRequestAbort(requestId: string): { signal: AbortSignal; cleanup: () => void } {
+	const controller = new AbortController();
+
+	const onResolved = (e: Event) => {
+		if ((e as CustomEvent).detail?.requestId === requestId) controller.abort();
+	};
+
+	window.addEventListener("rpc:agentRequestResolved", onResolved);
+
+	return {
+		signal: controller.signal,
+		cleanup: () => window.removeEventListener("rpc:agentRequestResolved", onResolved),
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4256,6 +4256,13 @@ export type AppRPCSchema = {
 			 * names the asking task so the user can see who wants this.
 			 */
 			agentLaunchRequested: AgentLaunchRequest;
+			/**
+			 * An agent-initiated request (`complete` or `launch`) got its answer.
+			 * Both dialogs are broadcast to every connected client, so the first
+			 * answer has to close the copies open on the other windows / remote
+			 * browsers — they can no longer decide anything.
+			 */
+			agentRequestResolved: { requestId: string; kind: "complete" | "launch"; taskId: string; projectId: string };
 			portsUpdated: { taskId: string; ports: PortInfo[] };
 			exposedPortsChanged: { taskId: string; ports: ExposedPort[] };
 			resourceUsageUpdated: { taskId: string; usage: ResourceUsage };


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

Agent-initiated approval dialogs — a task asking to complete (`dev3 task move --status completed`) and a task asking to start another one (`dev3 task move --task <other> --status in-progress`, `dev3 task create --scratch --run`) — are already broadcast to every connected client: each open window plus every remote browser. What was missing was the other half: once one client answered, the copies elsewhere stayed on screen with nothing left to decide.

`resolveAgentRequest` now pushes `agentRequestResolved` (`requestId`, `kind`, `taskId`, `projectId`) — a single choke point covering both request kinds, fired exactly once. The renderer closes the launch modal by filtering the queue, and the completion `confirm()` gets an `AbortSignal` (`createAgentRequestAbort`, mirroring the existing `mergePromptAbort` used by the Branch Merged prompt) so the losing client skips its own side effects and never sends a second, declining answer to the already-unblocked CLI.

Verified in headless Chromium against this worktree's dev server: both dialogs open, then vanish when `agentRequestResolved` arrives, console clean. Full suite green (mainview 3834, bun 5656, cli 769), `bun run lint` clean.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=be491612-f006-4cb9-8627-7cf08b35a67c) · `dev3://task/be491612-f006-4cb9-8627-7cf08b35a67c` _(dev3 added this footer — turn it off in Settings → Tasks.)_