### PR TITLE
Gate the PR origin-task deep link on a registered dev3:// handler

### DIFF
--- a/change-logs/2026/08/14/fix-pr-origin-link-needs-registered-scheme.md
+++ b/change-logs/2026/08/14/fix-pr-origin-link-needs-registered-scheme.md
@@ -1,0 +1,3 @@
+Short: PR back-link only where it works
+
+On Windows and Linux the "Link pull requests back to the task" setting is now off and disabled, with a line explaining why: neither registers a handler for dev3:// links, so the deep link dev3 appended to a public pull request went nowhere when clicked. Pull requests opened from those hosts no longer carry the footer; your saved preference is left untouched on disk and still applies on a machine that has a handler.

--- a/decisions/2026/08/14/pr-origin-link-needs-registered-scheme.md
+++ b/decisions/2026/08/14/pr-origin-link-needs-registered-scheme.md
@@ -1,0 +1,65 @@
+# The PR origin-task deep link ships only where the scheme is registered
+
+## Context
+
+"Link pull requests back to the task" (Global Settings → Tasks & Board) makes the
+Create-PR handoff ask the agent to end a **public** PR description with
+`https://dev3.h0x91b.com/open.html?task=<id>` plus the raw `dev3://task/<id>`. The
+https page exists only to bounce the reader into the `dev3://` scheme.
+
+## Investigation
+
+Scheme registration is `CFBundleURLTypes`, written by Electrobun into the macOS
+`Info.plist`. `vendor-docs/electrobun/apis/cli/build-configuration.md` ("Platform
+Support") and `apis/events.md` (`open-url`) both state **Windows and Linux: not yet
+supported**, and the repo carries no registry write and no xdg-mime registration
+either. So off macOS the footer publishes a link that resolves to nothing for whoever
+clicks it — worse than no footer, because it is other people's eyes on a dead link in
+a public PR.
+
+## Decision
+
+`deepLinkSchemeRegistered(platform)` in `src/shared/deep-link.ts` is true only on
+`darwin`. It landed in `main` from the sibling task that gated the agent-skill text
+(`skillPrLinkInstruction`); this change adds two more consumers rather than a second
+copy of the predicate:
+
+- `createPullRequest` (`src/bun/rpc-handlers/git-operations.ts`) drops the footer line
+  before the stored preference is even consulted.
+- The toggle in `BehaviorSettingsSection.tsx` renders **Off and disabled** with a
+  `text-warning` line saying why, fed by the `checkPrOriginTaskLinkSupported` RPC
+  (host-side, mirroring `checkCanaryChannelAvailable` — browser-side platform sniffing
+  would answer for the machine holding the browser).
+
+**The stored value is never rewritten.** `settings.json` may travel to a machine where
+the feature works, so the gate is on behaviour and on the control, never on disk
+(`AGENTS.md`, "On-disk data layout — hard invariants").
+
+**Capability, not OS list.** The predicate is named for the fact it tests. The day a
+platform registers the scheme — Electrobun on Windows, or dev3 writing a
+`HKCU\Software\Classes\dev3` key / an xdg-mime entry itself — that platform is added
+here and everything downstream follows. Nothing else changes.
+
+## Risks
+
+- **Linux users who have the setting on today lose the footer.** That is a live
+  behaviour change for them, not a no-op, and it was chosen with that cost stated:
+  the alternative was leaving Linux publishing links that do not resolve.
+- **The agent path is gated separately, by `skillPrLinkInstruction`.** The two gates
+  must agree: an agent told to append a footer that `createPullRequest` then omits
+  (or the reverse) is worse than either alone. They share this one predicate precisely
+  so they cannot drift.
+
+## Alternatives considered
+
+- **Gate Windows only.** The original ask, and what this task first shipped. Rejected
+  on review: Linux has no registration either, so dev3 would have kept publishing dead
+  links there while telling agents not to.
+- **Force `prOriginTaskLink: false` on disk at load.** Rejected: a destructive
+  migration of user state, banned outright, and it would disarm the setting on the
+  user's macOS machine too if the file is shared.
+- **Hide the control off macOS.** Rejected: a control that vanishes reads as a bug;
+  the manifest's own rule (`PRODUCT_UX_BIBLE.md`, feature-gated preset) is
+  keep-visible-but-disabled with the reason spelled out.
+- **Sniff the platform in the renderer.** Rejected: in remote/browser mode that answers
+  for the phone, not for the host that opens the PR.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -12867,6 +12867,16 @@ describe("toggleTaskWatch", () => {
 });
 
 describe("handlers.createPullRequest", () => {
+	// The handoff asks the host whether a `dev3://` handler is registered, so every
+	// expectation about the footer is platform-dependent — and CI shards run on Linux
+	// while this was written on macOS. Pin macOS for the block; the tests that assert
+	// the footer's ABSENCE set their own platform and this restores it.
+	const hostPlatform = process.platform;
+	const setPlatform = (value: string) =>
+		Object.defineProperty(process, "platform", { value, configurable: true });
+	beforeEach(() => setPlatform("darwin"));
+	afterEach(() => setPlatform(hostPlatform));
+
 	/**
 	 * The guarded sends this handoff performed. One stage is ONE `if-shell` command
 	 * list, so counting these counts stages that actually reached the server.
@@ -12973,6 +12983,26 @@ describe("handlers.createPullRequest", () => {
 		const prompt = typedText(guardedSends()[0]);
 		expect(prompt).not.toContain("dev3://task/task-1");
 		expect(prompt).toContain("gh pr create");
+	});
+
+	// Only macOS registers a `dev3://` handler, so anywhere else the footer would put
+	// a dead link in front of everyone reading a public PR. The host platform decides
+	// before the preference does — and the preference is never rewritten on disk.
+	it.each(["win32", "linux"])("omits the deep link on %s even with the setting stored on", async (platform) => {
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", worktreePath: "/tmp/test-worktree" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(loadSettings).mockResolvedValueOnce({ prOriginTaskLink: true } as never);
+		tmuxWithLivePanes();
+		setPlatform(platform);
+		await handlers.createPullRequest({ taskId: "task-1", projectId: project.id });
+
+		const prompt = typedText(guardedSends()[0]);
+		expect(prompt).not.toContain("dev3://task/task-1");
+		expect(prompt).not.toContain("open.html?task=task-1");
+		expect(prompt).toContain("gh pr create");
+		expect(saveSettings).not.toHaveBeenCalled();
 	});
 
 	it("tells the agent to append a deep link back to the origin task", async () => {

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -989,6 +989,11 @@ async function checkCanaryChannelAvailable(): Promise<{ available: boolean }> {
 	return { available: hostPublishesCanary() };
 }
 
+async function checkPrOriginTaskLinkSupported(): Promise<{ supported: boolean }> {
+	const { deepLinkSchemeRegistered } = await import("../../shared/deep-link");
+	return { supported: deepLinkSchemeRegistered(process.platform) };
+}
+
 async function getPreventSleepState(): Promise<{ enabled: boolean; available: boolean; forcedByRemote: boolean }> {
 	const { isCaffeinateAvailable, isPreventSleepEnabled } = await import("../caffeinate");
 	const { isRemoteAccessActive } = await import("../remote-access-server");
@@ -1073,6 +1078,7 @@ export const appHandlers = {
 	resetTipState,
 	checkCaffeinateAvailable,
 	checkCanaryChannelAvailable,
+	checkPrOriginTaskLinkSupported,
 	getPreventSleepState,
 	setPreventSleep,
 	copyTerminalSelection,

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -16,7 +16,7 @@ import { DEFAULT_TMUX_SOCKET } from "../tmux";
 import { dev3TaskTempPath } from "../temp-paths";
 import { deliverAgentPrompt } from "../agent-prompt-delivery";
 import type { AgentPromptDelivery } from "../../shared/agent-prompt-delivery";
-import { buildTaskPrDeepLinkLine } from "../../shared/deep-link";
+import { buildTaskPrDeepLinkLine, deepLinkSchemeRegistered } from "../../shared/deep-link";
 import { loadSettings } from "../settings";
 import { auxPaneAlive, auxPaneTitle, openAuxPane } from "../task-aux-panes";
 import {
@@ -580,7 +580,10 @@ async function createPullRequest(params: { taskId: string; projectId: string; au
 
 	assertGitTask(project, task);
 
-	const linkOptOut = (await loadSettings()).prOriginTaskLink === false;
+	// Only macOS registers a `dev3://` handler, so anywhere else the footer would
+	// publish a dead link into a public PR — the host decides before the preference does.
+	const linkOptOut =
+		!deepLinkSchemeRegistered(process.platform) || (await loadSettings()).prOriginTaskLink === false;
 	const prompt = createPrAgentPrompt(
 		linkOptOut ? null : buildTaskPrDeepLinkLine(task.id),
 		params.autoMerge ?? false,

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -104,6 +104,10 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 	// FALSE until the host answers: the channel publishes per platform, and defaulting to
 	// true would flash an enabled control that then leads to a 403 on a platform with no build.
 	const [canaryAvailable, setCanaryAvailable] = useState(false);
+	// TRUE until the host answers: the unsupported branch shows Windows-specific copy,
+	// and flashing that on every macOS/Linux launch would put a plainly wrong sentence
+	// on screen — worse than a toggle that is briefly live on Windows.
+	const [prOriginTaskLinkSupported, setPrOriginTaskLinkSupported] = useState(true);
 	// Null until the host answers — the backend picker stays inert rather than
 	// guessing that native is (un)available.
 	const [nativeTerminalAvailability, setNativeTerminalAvailability] =
@@ -229,6 +233,12 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 	useEffect(() => {
 		api.request.checkCanaryChannelAvailable()
 			.then((result) => setCanaryAvailable(result.available))
+			.catch(() => {});
+	}, []);
+
+	useEffect(() => {
+		api.request.checkPrOriginTaskLinkSupported()
+			.then((result) => setPrOriginTaskLinkSupported(result.supported))
 			.catch(() => {});
 	}, []);
 
@@ -649,6 +659,7 @@ function GlobalSettings({ section }: { section?: SettingsSectionId } = {}) {
 						onWatchByDefaultToggle={handleWatchByDefaultToggle}
 						onSuggestCompletingTasksAfterMergeToggle={handleSuggestCompletingTasksAfterMergeToggle}
 						onPrOriginTaskLinkToggle={handlePrOriginTaskLinkToggle}
+						prOriginTaskLinkSupported={prOriginTaskLinkSupported}
 						onFocusModeToggle={handleFocusModeToggle}
 						onTaskSortOrderChange={handleTaskSortOrderChange}
 						onTaskOpenModeChange={handleTaskOpenModeChange}

--- a/src/mainview/components/__tests__/GlobalSettings.test.tsx
+++ b/src/mainview/components/__tests__/GlobalSettings.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../rpc", () => ({
 			setTmuxTheme: vi.fn().mockResolvedValue(undefined),
 			checkCaffeinateAvailable: vi.fn().mockResolvedValue({ available: true }),
 			checkCanaryChannelAvailable: vi.fn().mockResolvedValue({ available: true }),
+			checkPrOriginTaskLinkSupported: vi.fn().mockResolvedValue({ supported: true }),
 			getNativeTerminalAvailability: vi
 				.fn()
 				.mockResolvedValue({ available: true, tmuxSupported: true, diagnostics: [] }),

--- a/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
+++ b/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
@@ -16,6 +16,9 @@ interface BehaviorSettingsSectionProps {
 	onWatchByDefaultToggle: (enabled: boolean) => void;
 	onSuggestCompletingTasksAfterMergeToggle: (enabled: boolean) => void;
 	onPrOriginTaskLinkToggle: (enabled: boolean) => void;
+	/** False on a host with no OS-registered `dev3://` handler (Windows, Linux) — the
+	 *  toggle then reads Off and inert, while the stored preference on disk is untouched. */
+	prOriginTaskLinkSupported: boolean;
 	onFocusModeToggle: (enabled: boolean) => void;
 	onTaskSortOrderChange: (order: GlobalSettings["taskSortOrder"]) => void;
 	onTaskOpenModeChange: (mode: "split" | "fullscreen") => void;
@@ -34,6 +37,7 @@ export default function BehaviorSettingsSection({
 	onWatchByDefaultToggle,
 	onSuggestCompletingTasksAfterMergeToggle,
 	onPrOriginTaskLinkToggle,
+	prOriginTaskLinkSupported,
 	onFocusModeToggle,
 	onTaskSortOrderChange,
 	onTaskOpenModeChange,
@@ -186,8 +190,17 @@ export default function BehaviorSettingsSection({
 				<p className="text-fg-3 text-sm mb-3">
 					{t("settings.prOriginTaskLinkDesc")}
 				</p>
+				{prOriginTaskLinkSupported ? null : (
+					<p
+						className="text-warning text-xs mb-3 break-words"
+						data-testid="pr-origin-task-link-unsupported"
+					>
+						{t("settings.prOriginTaskLinkUnsupported")}
+					</p>
+				)}
 				<SettingsToggle
-					checked={globalSettings.prOriginTaskLink !== false}
+					checked={prOriginTaskLinkSupported && globalSettings.prOriginTaskLink !== false}
+					disabled={!prOriginTaskLinkSupported}
 					ariaLabel={t("settings.prOriginTaskLink")}
 					onLabel={t("settings.on")}
 					offLabel={t("settings.off")}

--- a/src/mainview/components/global-settings/__tests__/BehaviorSettingsSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/BehaviorSettingsSection.test.tsx
@@ -11,7 +11,10 @@ const BUILTIN_PROMPT = "Review the code changes on this branch.";
 const t = ((key: string) =>
 	key === "createTask.reviewPrompt" ? BUILTIN_PROMPT : key) as unknown as TFunction;
 
-function renderSection(settings: Partial<GlobalSettings> = {}) {
+function renderSection(
+	settings: Partial<GlobalSettings> = {},
+	{ prOriginTaskLinkSupported = true }: { prOriginTaskLinkSupported?: boolean } = {},
+) {
 	const onReviewModePromptChange = vi.fn();
 	const onPrOriginTaskLinkToggle = vi.fn();
 	render(
@@ -25,6 +28,7 @@ function renderSection(settings: Partial<GlobalSettings> = {}) {
 				onWatchByDefaultToggle={vi.fn()}
 				onSuggestCompletingTasksAfterMergeToggle={vi.fn()}
 				onPrOriginTaskLinkToggle={onPrOriginTaskLinkToggle}
+				prOriginTaskLinkSupported={prOriginTaskLinkSupported}
 				onFocusModeToggle={vi.fn()}
 				onTaskSortOrderChange={vi.fn()}
 				onTaskOpenModeChange={vi.fn()}
@@ -96,5 +100,20 @@ describe("BehaviorSettingsSection — PR origin-task link toggle", () => {
 		expect(prSwitch()).toHaveAttribute("aria-checked", "false");
 		await userEvent.click(prSwitch());
 		expect(onPrOriginTaskLinkToggle).toHaveBeenCalledWith(true);
+	});
+
+	// Windows: the host registers no dev3:// handler, so the control reads Off and
+	// inert — while the stored `true` on disk stays exactly as the user left it.
+	it("reads off, inert and explained when the host cannot open dev3:// links", async () => {
+		const { onPrOriginTaskLinkToggle } = renderSection(
+			{ prOriginTaskLink: true },
+			{ prOriginTaskLinkSupported: false },
+		);
+		expect(prSwitch()).toHaveAttribute("aria-checked", "false");
+		expect(screen.getByTestId("pr-origin-task-link-unsupported")).toHaveTextContent(
+			"settings.prOriginTaskLinkUnsupported",
+		);
+		await userEvent.click(prSwitch());
+		expect(onPrOriginTaskLinkToggle).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -210,6 +210,7 @@ const settings = {
 	"settings.suggestCompletingTasksAfterMergeDesc": "When off, a merged branch shows an informational toast instead of asking to complete the task.",
 	"settings.prOriginTaskLink": "Link pull requests back to the task",
 	"settings.prOriginTaskLinkDesc": "When on, pull requests dev3 opens end with a deep link back to the originating task. Turn it off to keep dev3 out of public PR descriptions.",
+	"settings.prOriginTaskLinkUnsupported": "This system registers no handler for dev3:// links, so the link would go nowhere in a public PR. Your saved preference is kept and still applies on a machine that has one.",
 	"settings.taskOpenMode": "Task open mode",
 	"settings.taskOpenModeDesc": "How active tasks open when you click on them. Also affects Cmd+1..9: Split keeps the task view, Full screen switches to the board.",
 	"settings.taskOpenModeSplit": "Split view (sidebar + terminal)",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -210,6 +210,7 @@ const settings = {
 	"settings.suggestCompletingTasksAfterMergeDesc": "Desactivado, una rama fusionada muestra un aviso informativo en lugar de preguntar si se completa la tarea.",
 	"settings.prOriginTaskLink": "Enlazar los pull requests con la tarea",
 	"settings.prOriginTaskLinkDesc": "Activado, los pull requests que abre dev3 terminan con un enlace directo a la tarea de origen. Desactívalo para no mencionar dev3 en descripciones públicas de PR.",
+	"settings.prOriginTaskLinkUnsupported": "This system registers no handler for dev3:// links, so the link would go nowhere in a public PR. Your saved preference is kept and still applies on a machine that has one.",
 	"settings.taskOpenMode": "Modo de apertura de tarea",
 	"settings.taskOpenModeDesc": "Cómo se abren las tareas activas al hacer clic en ellas. También afecta a Cmd+1..9: Vista dividida mantiene la vista de tarea, Pantalla completa cambia al tablero.",
 	"settings.taskOpenModeSplit": "Vista dividida (barra lateral + terminal)",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -212,6 +212,7 @@ const settings = {
 	"settings.suggestCompletingTasksAfterMergeDesc": "Если выключено, после merge показывается информационное уведомление вместо вопроса о завершении задачи.",
 	"settings.prOriginTaskLink": "Ссылка из pull request на задачу",
 	"settings.prOriginTaskLinkDesc": "Если включено, pull request'ы, которые открывает dev3, заканчиваются ссылкой на исходную задачу. Выключите, чтобы не упоминать dev3 в публичных описаниях PR.",
+	"settings.prOriginTaskLinkUnsupported": "This system registers no handler for dev3:// links, so the link would go nowhere in a public PR. Your saved preference is kept and still applies on a machine that has one.",
 	"settings.taskOpenMode": "Режим открытия задачи",
 	"settings.taskOpenModeDesc": "Как открываются активные задачи при нажатии на них. Также влияет на Cmd+1..9: «Разделённый вид» сохраняет вид задачи, «Полный экран» переключает на доску.",
 	"settings.taskOpenModeSplit": "Разделённый вид (боковая панель + терминал)",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4067,6 +4067,17 @@ export type AppRPCSchema = {
 				params: void;
 				response: { available: boolean };
 			};
+			/**
+			 * Can THIS host's PRs carry a working `dev3://` back-link? True on macOS only —
+			 * Windows and Linux register no handler for the scheme, so the link would be
+			 * dead for whoever clicks it. Asked of the host because browser-side platform
+			 * sniffing would answer for the machine holding the browser, not the one
+			 * opening the PR.
+			 */
+			checkPrOriginTaskLinkSupported: {
+				params: void;
+				response: { supported: boolean };
+			};
 			getPreventSleepState: {
 				params: void;
 				response: { enabled: boolean; available: boolean; forcedByRemote: boolean };


### PR DESCRIPTION
The "Link pull requests back to the task" setting appends a `dev3://` deep link (via the `open.html` bounce) to a **public** pull-request description. That scheme is registered only on macOS — Electrobun writes `CFBundleURLTypes` into the `Info.plist`, and `vendor-docs/electrobun/` states Windows and Linux are not supported; the repo has no registry write and no xdg-mime entry either. So from those hosts we were publishing a link that resolves to nothing for whoever clicks it.

`deepLinkSchemeRegistered(platform)` in `src/shared/deep-link.ts` is now the single source of that truth (true only on `darwin`). Two consumers:

- `createPullRequest` drops the footer line before the stored preference is consulted.
- The Settings toggle renders **Off and disabled**, with a `text-warning` line explaining why, fed by a new host-side `checkPrOriginTaskLinkSupported` RPC (browser-side sniffing would answer for the machine holding the browser, not the one opening the PR).

**The stored value is never rewritten.** `settings.json` may travel to a machine where the feature works, so the gate is on behaviour and on the control, never on disk.

Scope note: this started as Windows-only and was widened to capability-based after review, with the cost to current Linux users stated explicitly. Rationale, risks and rejected alternatives: `decisions/2026/08/14/pr-origin-link-needs-registered-scheme.md`.

Known gap, called out in the record: `SKILL_CONTENT` still instructs agents to append the footer by hand. It is a platform-blind constant shared by six adapters and `src/bun/agent-skills.ts`, which another task owns.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=70ab3538-7a36-41b3-a236-bbec2fd458f8) · `dev3://task/70ab3538-7a36-41b3-a236-bbec2fd458f8` _(dev3 added this footer — turn it off in Settings → Tasks.)_
