### PR TITLE
Create and repair the Windows Desktop and Start Menu shortcuts from the app

### DIFF
--- a/change-logs/2026/08/14/feature-30-windows-desktop-shortcut.md
+++ b/change-logs/2026/08/14/feature-30-windows-desktop-shortcut.md
@@ -1,0 +1,3 @@
+Short: Windows gets a Desktop icon
+
+dev3 now creates its own Desktop and Start Menu shortcuts on Windows at startup, and repairs them when an update moves the app, so the app can be launched after a reboot without hunting through AppData. A shortcut you delete stays deleted, and a shortcut belonging to another app is never overwritten.

--- a/decisions/2026/08/14/windows-app-owns-its-shortcuts.md
+++ b/decisions/2026/08/14/windows-app-owns-its-shortcuts.md
@@ -44,6 +44,13 @@ Rules, in order: create when no `.lnk` exists and we never wrote one; leave a co
 **repair** one that points at another directory of ours (an update moved the app); never touch a
 shortcut belonging to something else; and never recreate one the user deleted after we wrote it —
 `~/.dev3.0/windows-shortcuts.json` records what we wrote, a new file that no other version reads.
+
+**On-disk rules for that file** (`AGENTS.md`, "On-disk data layout — hard invariants"): it is purely
+additive, it is never renamed, nothing is migrated or deleted at load time, and an older app version
+that knows nothing about it is unaffected. **Missing, empty or unparsable degrades to "we have no
+record" — meaning create — never to a crash:** `readState()` returns `{}` on any read or `JSON.parse`
+failure and logs a warning. The one cost of that fallback is honest: a user who deleted a shortcut
+and then lost this file gets it back once.
 The file name mirrors electrobun's `windowsShortcutFileName` byte for byte, including its quirk
 that only the literal channel `production` drops the suffix, so a box where Setup also ran does not
 end up with two icons.

--- a/decisions/2026/08/14/windows-app-owns-its-shortcuts.md
+++ b/decisions/2026/08/14/windows-app-owns-its-shortcuts.md
@@ -1,0 +1,84 @@
+# The Windows app writes and repairs its own shortcuts, and the Setup installer stays unpublished
+
+## Context
+
+A Windows user who downloads `canary-win-x64-dev-3.0-canary.zip` (or the stable zip attached by
+`windows-zip-on-the-release-page.md`) gets a launchable tree and no way to reach it again: no
+Desktop icon, no Start Menu entry, and an install directory nobody navigates to by hand. Arseny,
+on his own box: *"он ставится и запускается вот из этой папки, т.е. после рестарта я фиг найду
+как дев 3 запустить... нужна иконка на рабочем столе наврное"*, then *"а может вообще сделать
+инсталлер для винды"*.
+
+## Investigation
+
+Read out of electrobun v1.18.1 upstream, not guessed (`gh` code search over
+`blackboardsh/electrobun`, then the file itself):
+
+- `createWindowsShortcut` appears in **exactly one** file, `package/src/extractor/main.zig` — the
+  self-extracting Setup. Zero occurrences in the launcher and zero in the updater.
+- The extractor installs to `%LOCALAPPDATA%\<identifier>\<channel>\app\`, writes two `.lnk`
+  (Desktop + `…\Start Menu\Programs`) targeting `…\app\bin\launcher.exe`, and registers an
+  Add/Remove Programs entry.
+- `Updater.ts` `getAppDataDir()` carries the comment *"Use LOCALAPPDATA to match extractor
+  location"* — **the updater installs into the same managed directory and never touches a `.lnk`.**
+
+That last point corrects the premise this task started from. Arseny's screenshot shows
+`C:\Users\user\AppData\Local\dev3.electrobun.dev\canary\app\bin`, which is the canonical managed
+location, not a stray unzip folder: his app is installed exactly where it belongs and only the
+shortcut is missing.
+
+Why the Setup was withheld, twice, on the record:
+`downloadable-windows-build-is-the-launched-tree.md` and `windows-zip-on-the-release-page.md` both
+say the same thing — nothing has ever launched the Setup exe, and the file a summary hands a human
+must be a file the proof launched. Both call it deferred, not rejected. Measured here as well: the
+Setup zip is never staged into `artifacts-win-x64/`, so it is not in the bucket at all (an S3 `403`
+on that key is indistinguishable from absent without `ListBucket`).
+
+## Decision
+
+**The app writes and repairs its own shortcuts** — `src/bun/windows-shortcuts/`, called once at
+startup from `src/bun/index.ts`. `shortcut-plan.ts` is pure decision logic (unit-tested on macOS);
+`powershell-surface.ts` does the `WScript.Shell` calls, the same COM object the extractor uses.
+
+Rules, in order: create when no `.lnk` exists and we never wrote one; leave a correct one alone;
+**repair** one that points at another directory of ours (an update moved the app); never touch a
+shortcut belonging to something else; and never recreate one the user deleted after we wrote it —
+`~/.dev3.0/windows-shortcuts.json` records what we wrote, a new file that no other version reads.
+The file name mirrors electrobun's `windowsShortcutFileName` byte for byte, including its quirk
+that only the literal channel `production` drops the suffix, so a box where Setup also ran does not
+end up with two icons.
+
+This is also the **stable pointer** the side-by-side layout work needs: it satisfies a fixed
+runtime-discoverable location, a small file rewritten on update rather than a binary, survival of
+the old version directory's deletion, and — unlike a Setup-only shortcut — it works for a
+zip-unpacked user.
+
+**A directory junction at `app/` was evaluated and rejected**, from the extractor source:
+`windowsManagedPathsFromBaseDir` resolves each ancestor with `requirePlainWindowsDirectoryPhysical`
+and comments that *"a junction anywhere in LOCALAPPDATA/<identifier>/<channel> is therefore
+rejected"*, and `validateWindowsManagedChildIfExists(channel_dir, "app", …)` stats without
+following symlinks and accepts only a plain directory or file. A junction at `app` would make the
+upstream installer and uninstaller refuse the install location.
+
+## Risks
+
+- **Unverified on Windows.** Every line here was written and tested on macOS; the PowerShell calls
+  have never run. Acceptance is Arseny installing, rebooting, and launching from the icon.
+- **Startup cost:** up to four short PowerShell invocations on Windows only, off the critical path
+  and entirely best-effort — a failure logs a warning and the app starts anyway.
+- **A user who moves the app by hand** gets a stale shortcut repaired only if the new location is
+  under our identifier or matches what we recorded; otherwise it is left alone rather than clobbered.
+- **The Setup is still unpublished and still unproven.** This does not close that gap; it removes
+  the urgency behind it.
+
+## Alternatives considered
+
+- **Publish the Setup exe we already build.** It writes both shortcuts, registers an uninstaller,
+  and is the shape a real Windows release takes. Rejected for now on the standing rule that no job
+  has ever launched it, and because it does nothing for the users who already have the zip —
+  including the one who reported this. Deferred behind a second launch-proof target in CI.
+- **Build an NSIS/MSI/winget installer.** Most work of the three, and it buys nothing today: there
+  is no code-signing certificate (*"сертификата у меня нет и я покупать не хочу"*), so SmartScreen
+  warns either way.
+- **Ship a `create-shortcut.cmd` inside the zip.** Still requires navigating to the folder, which
+  is the problem being solved.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -40,6 +40,7 @@ import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
 import { ensureCodexConfigFile } from "./codex-config";
+import { ensureWindowsShortcuts } from "./windows-shortcuts";
 import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
@@ -236,6 +237,21 @@ if (shellEnv.path) {
 // Codex profile migration depends on `codex --version`. Run it only after the
 // user's shell PATH is available; the app bundle starts with a minimal PATH.
 ensureCodexConfigFile(homedir());
+
+// Windows has no other entry point: nothing but the unpublished Setup extractor
+// ever writes a .lnk, so without this a zip user cannot start dev3 after a reboot.
+// The channel decides the shortcut's name, so a wrong one would leave two icons.
+if (process.platform === "win32") {
+	getLocalVersion()
+		.then(({ channel }) =>
+			ensureWindowsShortcuts({
+				appName: electrobunConfig.app.name,
+				identifier: electrobunConfig.app.identifier,
+				channel,
+			}),
+		)
+		.catch((err) => log.warn("Skipping Windows shortcuts: the local channel is unknown", { error: String(err) }));
+}
 
 if (shellEnv.lang) {
 	process.env.LANG = shellEnv.lang;

--- a/src/bun/windows-shortcuts/__tests__/shortcut-plan.test.ts
+++ b/src/bun/windows-shortcuts/__tests__/shortcut-plan.test.ts
@@ -1,0 +1,96 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { planShortcuts, shortcutFileName, type ShortcutSite, type ShortcutState } from "../shortcut-plan";
+import { resolveLauncherPath } from "../index";
+
+const IDENTIFIER = "dev3.electrobun.dev";
+const LAUNCHER = "C:\\Users\\user\\AppData\\Local\\dev3.electrobun.dev\\canary\\app\\bin\\launcher.exe";
+const DESKTOP_LNK = "C:\\Users\\user\\Desktop\\dev-3.0 (Canary).lnk";
+
+function plan(sites: ShortcutSite[], state: ShortcutState = {}) {
+	return planShortcuts({ sites, launcherPath: LAUNCHER, state, identifier: IDENTIFIER });
+}
+
+describe("planShortcuts", () => {
+	it("creates a shortcut when none exists and we never wrote one", () => {
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: null }]);
+		expect(action.kind).toBe("create");
+	});
+
+	it("never recreates a shortcut the user deleted after we wrote it", () => {
+		const state: ShortcutState = { desktop: { path: DESKTOP_LNK, target: LAUNCHER } };
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: null }], state);
+		expect(action.kind).toBe("skip");
+		expect(action.reason).toContain("removed");
+	});
+
+	it("leaves a correct shortcut untouched", () => {
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: LAUNCHER }]);
+		expect(action.kind).toBe("skip");
+	});
+
+	it("treats a differently-spelled path to the same file as correct", () => {
+		const messy = "c:/Users/user/AppData/Local/dev3.electrobun.dev/canary/app/bin/LAUNCHER.EXE";
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: messy }]);
+		expect(action.kind).toBe("skip");
+	});
+
+	// The disqualifying outcome this whole module exists to prevent: an update
+	// moves the app and the Desktop icon stops working.
+	it("repairs a shortcut that points into an old directory of ours", () => {
+		const stale = "C:\\Users\\user\\AppData\\Local\\dev3.electrobun.dev\\canary\\app-1.43.0\\bin\\launcher.exe";
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: stale }]);
+		expect(action.kind).toBe("repair");
+	});
+
+	it("repairs a zip user's shortcut after the app moved, because we recorded writing it", () => {
+		const old = "D:\\Downloads\\dev-3.0-canary\\bin\\launcher.exe";
+		const state: ShortcutState = { desktop: { path: DESKTOP_LNK, target: old } };
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: old }], state);
+		expect(action.kind).toBe("repair");
+	});
+
+	it("does not clobber somebody else's shortcut with the same name", () => {
+		const foreign = "C:\\Program Files\\Other App\\other.exe";
+		const [action] = plan([{ slot: "desktop", path: DESKTOP_LNK, existingTarget: foreign }]);
+		expect(action.kind).toBe("skip");
+		expect(action.reason).toContain("unrelated");
+	});
+
+	it("plans both slots independently", () => {
+		const actions = plan([
+			{ slot: "desktop", path: DESKTOP_LNK, existingTarget: LAUNCHER },
+			{ slot: "startMenu", path: "C:\\Users\\user\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\dev-3.0 (Canary).lnk", existingTarget: null },
+		]);
+		expect(actions.map((action) => action.kind)).toEqual(["skip", "create"]);
+	});
+});
+
+describe("shortcutFileName", () => {
+	// Byte-for-byte agreement with electrobun's windowsShortcutFileName, or a box
+	// where Setup also ran ends up with two icons for one app.
+	it("suffixes non-production channels the way the extractor does", () => {
+		expect(shortcutFileName("dev-3.0", "canary")).toBe("dev-3.0 (Canary).lnk");
+		expect(shortcutFileName("dev-3.0", "dev")).toBe("dev-3.0 (Development).lnk");
+		expect(shortcutFileName("dev-3.0", "stable")).toBe("dev-3.0 (stable).lnk");
+		expect(shortcutFileName("dev-3.0", "production")).toBe("dev-3.0.lnk");
+	});
+
+	it("replaces characters Windows forbids in a file name", () => {
+		expect(shortcutFileName('dev:3/0*?"', "production")).toBe("dev_3_0___.lnk");
+		expect(shortcutFileName("dev-3.0 ", "production")).toBe("dev-3.0.lnk");
+	});
+});
+
+describe("resolveLauncherPath", () => {
+	// Native separators, so this asserts the same joining the app does at runtime
+	// rather than a Windows string this host cannot parse.
+	it("finds launcher.exe beside the running bun.exe", () => {
+		const sibling = join("app", "bin", "launcher.exe");
+		expect(resolveLauncherPath(join("app", "bin", "bun.exe"), (path) => path === sibling)).toBe(sibling);
+	});
+
+	it("returns null in a development tree with no launcher", () => {
+		expect(resolveLauncherPath("/usr/local/bin/bun", () => false)).toBeNull();
+	});
+});

--- a/src/bun/windows-shortcuts/index.ts
+++ b/src/bun/windows-shortcuts/index.ts
@@ -1,0 +1,123 @@
+/**
+ * Gives dev3 a Desktop icon and a Start Menu entry on Windows, and keeps them
+ * pointing at the app after an update moves it. Runs at startup, does nothing on
+ * any other platform, and never throws.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createLogger } from "../logger";
+import { DEV3_HOME } from "../paths";
+import { planShortcuts, shortcutFileName, type ShortcutSite, type ShortcutSlot, type ShortcutState } from "./shortcut-plan";
+import { powershellShortcutSurface, type WindowsShortcutSurface } from "./powershell-surface";
+
+const log = createLogger("windows-shortcuts");
+
+/**
+ * Sits beside the rest of `~/.dev3.0`: a new file, never a rename or a rewrite of
+ * an existing one, so an older app version reading the same directory is unaffected.
+ */
+const STATE_FILE = join(DEV3_HOME, "windows-shortcuts.json");
+
+function readState(): ShortcutState {
+	try {
+		return existsSync(STATE_FILE) ? (JSON.parse(readFileSync(STATE_FILE, "utf8")) as ShortcutState) : {};
+	} catch (err) {
+		log.warn("Could not read the shortcut state file, treating it as empty", { error: String(err) });
+		return {};
+	}
+}
+
+function writeState(state: ShortcutState): void {
+	try {
+		mkdirSync(DEV3_HOME, { recursive: true });
+		writeFileSync(STATE_FILE, `${JSON.stringify(state, null, 2)}\n`);
+	} catch (err) {
+		log.warn("Could not record which shortcuts we wrote", { error: String(err) });
+	}
+}
+
+/**
+ * `launcher.exe` sits next to the running `bun.exe`, which is the one path that
+ * cannot be wrong. Absent in a `bun run dev` tree — that is the guard that keeps
+ * a development run from planting an icon.
+ */
+export function resolveLauncherPath(execPath: string, fileExists: (path: string) => boolean): string | null {
+	const candidate = join(dirname(execPath), "launcher.exe");
+	return fileExists(candidate) ? candidate : null;
+}
+
+function desktopFallback(): string | null {
+	const profile = process.env.USERPROFILE;
+	return profile ? join(profile, "Desktop") : null;
+}
+
+function programsFallback(): string | null {
+	const appData = process.env.APPDATA;
+	return appData ? join(appData, "Microsoft", "Windows", "Start Menu", "Programs") : null;
+}
+
+export interface EnsureShortcutsOptions {
+	appName: string;
+	identifier: string;
+	channel: string;
+	surface?: WindowsShortcutSurface;
+}
+
+export function ensureWindowsShortcuts(options: EnsureShortcutsOptions): void {
+	if (process.platform !== "win32") return;
+
+	const surface = options.surface ?? powershellShortcutSurface;
+	try {
+		const launcherPath = resolveLauncherPath(process.execPath, existsSync);
+		if (!launcherPath) {
+			log.info("No launcher.exe beside the running executable — not a packaged build, skipping shortcuts");
+			return;
+		}
+
+		const fileName = shortcutFileName(options.appName, options.channel);
+		const directories: Record<ShortcutSlot, string | null> = {
+			desktop: surface.knownFolder("DesktopDirectory") ?? desktopFallback(),
+			startMenu: surface.knownFolder("Programs") ?? programsFallback(),
+		};
+
+		const sites: ShortcutSite[] = [];
+		for (const slot of ["desktop", "startMenu"] as ShortcutSlot[]) {
+			const dir = directories[slot];
+			if (!dir) {
+				log.warn("Could not resolve a Windows folder for the shortcut", { slot });
+				continue;
+			}
+			const path = join(dir, fileName);
+			sites.push({ slot, path, existingTarget: surface.readShortcutTarget(path) });
+		}
+
+		const state = readState();
+		const actions = planShortcuts({ sites, launcherPath, state, identifier: options.identifier });
+		let changed = false;
+
+		for (const action of actions) {
+			if (action.kind === "skip") {
+				log.info("Leaving a shortcut alone", { slot: action.slot, path: action.path, reason: action.reason });
+				continue;
+			}
+			const written = surface.writeShortcut({
+				lnkPath: action.path,
+				target: launcherPath,
+				workingDir: dirname(launcherPath),
+				iconPath: launcherPath,
+			});
+			if (!written) {
+				log.warn("Could not write the shortcut", { slot: action.slot, path: action.path, kind: action.kind });
+				continue;
+			}
+			log.info("Wrote a Windows shortcut", { slot: action.slot, path: action.path, kind: action.kind, reason: action.reason });
+			state[action.slot] = { path: action.path, target: launcherPath };
+			changed = true;
+		}
+
+		if (changed) writeState(state);
+	} catch (err) {
+		log.warn("Windows shortcut maintenance failed (non-fatal)", { error: String(err) });
+	}
+}

--- a/src/bun/windows-shortcuts/powershell-surface.ts
+++ b/src/bun/windows-shortcuts/powershell-surface.ts
@@ -1,0 +1,67 @@
+/**
+ * The Windows half: known folders and `.lnk` read/write, both through
+ * `WScript.Shell`, the same COM object electrobun's extractor uses — so a
+ * shortcut we write and one Setup wrote are the same kind of file.
+ *
+ * Every call is best effort. A shortcut is a convenience; nothing here may stop
+ * the app from starting.
+ */
+
+import { spawnSync } from "../spawn";
+
+export interface WindowsShortcutSurface {
+	/** Absolute path of a Windows known folder, or `null` when it cannot be resolved. */
+	knownFolder(name: "DesktopDirectory" | "Programs"): string | null;
+	/** Target of an existing `.lnk`, or `null` when the file is absent or unreadable. */
+	readShortcutTarget(lnkPath: string): string | null;
+	writeShortcut(input: { lnkPath: string; target: string; workingDir: string; iconPath: string }): boolean;
+}
+
+const POWERSHELL = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+
+/** PowerShell single-quoted literal: only `'` needs doubling inside one. */
+function quote(value: string): string {
+	return `'${value.split("'").join("''")}'`;
+}
+
+function runPowerShell(script: string): { ok: boolean; stdout: string } {
+	const result = spawnSync([POWERSHELL, "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	return { ok: result.exitCode === 0, stdout: result.stdout?.toString() ?? "" };
+}
+
+export const powershellShortcutSurface: WindowsShortcutSurface = {
+	knownFolder(name) {
+		const { ok, stdout } = runPowerShell(`[Environment]::GetFolderPath(${quote(name)})`);
+		const value = stdout.trim();
+		return ok && value.length > 0 ? value : null;
+	},
+
+	readShortcutTarget(lnkPath) {
+		const script = [
+			"$ErrorActionPreference = 'Stop'",
+			`if (-not (Test-Path -LiteralPath ${quote(lnkPath)} -PathType Leaf)) { exit 0 }`,
+			"$WshShell = New-Object -ComObject WScript.Shell",
+			`$WshShell.CreateShortcut(${quote(lnkPath)}).TargetPath`,
+		].join("; ");
+		const { ok, stdout } = runPowerShell(script);
+		const value = stdout.trim();
+		return ok && value.length > 0 ? value : null;
+	},
+
+	writeShortcut({ lnkPath, target, workingDir, iconPath }) {
+		const script = [
+			"$ErrorActionPreference = 'Stop'",
+			"$WshShell = New-Object -ComObject WScript.Shell",
+			`$Shortcut = $WshShell.CreateShortcut(${quote(lnkPath)})`,
+			`$Shortcut.TargetPath = ${quote(target)}`,
+			`$Shortcut.WorkingDirectory = ${quote(workingDir)}`,
+			`$Shortcut.IconLocation = ${quote(iconPath)}`,
+			"$Shortcut.WindowStyle = 1",
+			"$Shortcut.Save()",
+		].join("; ");
+		return runPowerShell(script).ok;
+	},
+};

--- a/src/bun/windows-shortcuts/shortcut-plan.ts
+++ b/src/bun/windows-shortcuts/shortcut-plan.ts
@@ -1,0 +1,123 @@
+/**
+ * Decides which Windows shortcuts to write, with no filesystem and no Win32 in
+ * sight, so the rules are exercised on the machines we develop on. The
+ * PowerShell side lives in `powershell-surface.ts`, same split as
+ * `windows-icons/`.
+ *
+ * Why the app does this at all: only electrobun's Setup extractor ever writes a
+ * `.lnk`, and the Setup is not published. A user who unpacked the zip therefore
+ * has no way to start dev3 after a reboot, and the updater — which installs into
+ * the same managed directory the extractor uses — has never created or refreshed
+ * a shortcut either. See the decision record `windows-app-owns-its-shortcuts`.
+ */
+
+export type ShortcutSlot = "desktop" | "startMenu";
+
+/** One `.lnk` we may write, plus what is at that path right now. */
+export interface ShortcutSite {
+	slot: ShortcutSlot;
+	path: string;
+	/** Target of the existing `.lnk`, or `null` when there is no file there. */
+	existingTarget: string | null;
+}
+
+/** What we wrote last time, persisted between runs. */
+export interface ShortcutRecord {
+	path: string;
+	target: string;
+}
+
+export type ShortcutState = Partial<Record<ShortcutSlot, ShortcutRecord>>;
+
+export type ShortcutActionKind = "create" | "repair" | "skip";
+
+export interface ShortcutAction {
+	slot: ShortcutSlot;
+	path: string;
+	kind: ShortcutActionKind;
+	/** Logged verbatim — a skipped shortcut must say which rule skipped it. */
+	reason: string;
+}
+
+export interface ShortcutPlanInput {
+	sites: ShortcutSite[];
+	/** Absolute path of the `launcher.exe` every shortcut must point at. */
+	launcherPath: string;
+	state: ShortcutState;
+	/** App identifier (`dev3.electrobun.dev`), a segment of the managed install path. */
+	identifier: string;
+}
+
+const SEPARATOR = String.fromCharCode(92);
+
+function normalizePath(value: string): string {
+	return value.trim().split("/").join(SEPARATOR).replace(/\\+$/, "").toLowerCase();
+}
+
+function samePath(a: string, b: string): boolean {
+	return normalizePath(a) === normalizePath(b);
+}
+
+/**
+ * A `.lnk` is ours to rewrite only when it points at a `launcher.exe` inside our
+ * identifier's install tree, or at exactly the target we recorded writing. Any
+ * other shortcut wearing the same file name belongs to somebody else.
+ */
+function isOurs(target: string, identifier: string, record: ShortcutRecord | undefined): boolean {
+	const segments = normalizePath(target).split(SEPARATOR);
+	if (segments[segments.length - 1] !== "launcher.exe") return false;
+	if (segments.includes(identifier.toLowerCase())) return true;
+	return record !== undefined && samePath(target, record.target);
+}
+
+/**
+ * The rules, in order. Deleting a shortcut we created is a decision the user
+ * made: it is recorded and never undone, which is what keeps this from being an
+ * app that re-plants an icon on every launch.
+ */
+export function planShortcuts(input: ShortcutPlanInput): ShortcutAction[] {
+	return input.sites.map((site): ShortcutAction => {
+		const record = input.state[site.slot];
+
+		if (site.existingTarget === null) {
+			if (record && samePath(record.path, site.path)) {
+				return { slot: site.slot, path: site.path, kind: "skip", reason: "we created this shortcut and the user removed it" };
+			}
+			return { slot: site.slot, path: site.path, kind: "create", reason: "no shortcut exists yet" };
+		}
+
+		if (samePath(site.existingTarget, input.launcherPath)) {
+			return { slot: site.slot, path: site.path, kind: "skip", reason: "shortcut already points at this app" };
+		}
+
+		if (isOurs(site.existingTarget, input.identifier, record)) {
+			return { slot: site.slot, path: site.path, kind: "repair", reason: `shortcut pointed at ${site.existingTarget}` };
+		}
+
+		return { slot: site.slot, path: site.path, kind: "skip", reason: `an unrelated shortcut points at ${site.existingTarget}` };
+	});
+}
+
+const FORBIDDEN_NAME_CHARS = new Set(["<", ">", ":", '"', "/", SEPARATOR, "|", "?", "*"]);
+
+/**
+ * Mirrors electrobun's `windowsShortcutFileName` byte for byte, including its
+ * quirk that only the literal channel `production` drops the suffix — our
+ * channels are `stable` / `canary` / `dev`, so a stable build is
+ * `dev-3.0 (stable).lnk`. Diverging would leave two icons for one app on a box
+ * where the Setup extractor also ran.
+ */
+export function shortcutFileName(appName: string, channel: string): string {
+	const display = channel === "production" ? appName : `${appName} (${channelLabel(channel)})`;
+	const sanitized = [...display]
+		.map((char) => (FORBIDDEN_NAME_CHARS.has(char) || char.charCodeAt(0) < 32 ? "_" : char))
+		.join("")
+		.replace(/[ .]+$/, "");
+	return `${sanitized.length > 0 ? sanitized : "Electrobun App"}.lnk`;
+}
+
+function channelLabel(channel: string): string {
+	if (channel === "canary") return "Canary";
+	if (channel === "dev") return "Development";
+	return channel;
+}


### PR DESCRIPTION
Hey — Claude here, the AI assistant that wrote this branch.

A Windows user who unpacks the release zip has no way to launch dev3 after a reboot: no Desktop icon, no Start Menu entry, and the app sits in a directory nobody navigates to by hand.

Read out of electrobun v1.18.1 upstream: `createWindowsShortcut` exists in exactly one file, the Setup extractor's `main.zig`. The launcher never writes a `.lnk`, and neither does the updater — even though `Updater.ts` installs into the very same `%LOCALAPPDATA%\<identifier>\<channel>\app\` directory the extractor uses. So a zip user never gets a shortcut, and a Setup user's shortcut is never refreshed.

This makes the app own that entry point:

- `src/bun/windows-shortcuts/shortcut-plan.ts` — pure decision logic, unit-tested on macOS.
- `src/bun/windows-shortcuts/powershell-surface.ts` — the `WScript.Shell` calls, the same COM object the extractor uses.
- Called once at startup from `src/bun/index.ts`, Windows only, entirely best-effort.

Rules: create when nothing is there; leave a correct shortcut alone; repair one pointing at another directory of ours (an update moved the app); never touch another app's shortcut; never recreate one the user deleted after we wrote it. The file name mirrors electrobun's `windowsShortcutFileName` byte for byte so a box where Setup also ran does not end up with two icons.

The self-extracting Setup stays unpublished — nothing has ever launched it, per `downloadable-windows-build-is-the-launched-tree.md` and `windows-zip-on-the-release-page.md`. Reasoning, the rejected junction-at-`app/` alternative, and why the installer was deferred rather than rejected are in `decisions/2026/08/14/windows-app-owns-its-shortcuts.md`.

Not verified on Windows yet — every line was written on macOS, so the PowerShell calls have never run.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c8c001ee-a064-452b-98a6-b3c2f16ec800) · `dev3://task/c8c001ee-a064-452b-98a6-b3c2f16ec800`
