### PR TITLE
Join Codex config paths in the config's dialect, not the host's

### DIFF
--- a/change-logs/2026/08/14/fix-codex-config-windows-toml-escaping.md
+++ b/change-logs/2026/08/14/fix-codex-config-windows-toml-escaping.md
@@ -1,3 +1,5 @@
 Short: Codex starts again on Windows
 
 Fixed the Codex config.toml dev3 writes on Windows: native paths were interpolated raw into TOML basic strings, so `C:\Users` read as the escape `\U` and codex refused to start anywhere on the machine with a parse error. Paths are now escaped and joined with the platform separator, and dev3 repairs an already-broken config in place on next launch (backing the original up to `config.toml.dev3-backup` and leaving every non-dev3 line untouched).
+
+Follow-up: the paths are now joined in the dialect of the path they extend rather than the host's, so a POSIX fixture stays POSIX on a Windows runner.

--- a/src/bun/__tests__/codex-config-windows-paths.test.ts
+++ b/src/bun/__tests__/codex-config-windows-paths.test.ts
@@ -7,6 +7,7 @@ import {
 	backupUnparsableCodexConfig,
 	ensureCodexConfig,
 	ensureCodexConfigFile,
+	joinLike,
 	repairWindowsPathEscapes,
 	tomlBasicString,
 } from "../codex-config";
@@ -50,6 +51,15 @@ describe("codex config with Windows paths", () => {
 		const second = ensureCodexConfig(first, WIN_WORKTREES, WIN_SOCKETS, []);
 		expect(second).toBe(first);
 		expect(() => load(second)).not.toThrow();
+	});
+
+	it("keeps a POSIX fixture in POSIX dialect even when the host is Windows", () => {
+		// node's join() would answer in the HOST's dialect: on a Windows runner
+		// join("/Users/x", ".codex") is "\\Users\\x\\.codex". That turned this file red
+		// on windows-latest while macOS stayed green.
+		expect(joinLike("/Users/x", ".codex", "skills")).toBe("/Users/x/.codex/skills");
+		expect(joinLike("C:\\Users\\user", ".codex", "skills")).toBe("C:\\Users\\user\\.codex\\skills");
+		expect(joinLike("C:\\", ".dev3.0", "worktrees")).toBe("C:\\.dev3.0\\worktrees");
 	});
 
 	it("escapes nothing in a POSIX path — byte-identical output", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -7,7 +7,7 @@ import { DEFAULT_AGENTS, DEPRECATED_DEFAULT_CONFIG_REMAP } from "../shared/types
 export { skillInvocationPrefix } from "../shared/types";
 import { buildProviderEnv, getProviderDefinition, providerOmitsModelFlag, providerPinnedModel } from "../shared/llm-provider";
 import { createLogger } from "./logger";
-import { backupUnparsableCodexConfig, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
+import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
 import { DEV3_HOME } from "./paths";
 import { loadSettings, saveSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme, getCodexThemeForCurrentUiTheme } from "./theme-state";
@@ -832,8 +832,8 @@ export async function ensureCodexTrust(dirPath: string): Promise<void> {
 	try {
 		const resolved = await realpath(dirPath);
 		const home = homedir();
-		const worktreesPath = join(home, ".dev3.0", "worktrees");
-		const socketsPath = join(home, ".dev3.0", "sockets");
+		const worktreesPath = joinLikeHome(home, ".dev3.0", "worktrees");
+		const socketsPath = joinLikeHome(home, ".dev3.0", "sockets");
 
 		let content: string | null = null;
 		try {

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -129,14 +129,27 @@ export function tomlBasicString(value: string): string {
 }
 
 /**
+ * Join path segments in the SAME dialect as `base`, not the host's. These values
+ * are written into a config file, so they must match the paths already in it:
+ * node's `join` answers in the HOST's dialect, which turned a POSIX fixture into
+ * `\Users\x\.codex` on the windows-latest runner and made this file red there
+ * while macOS stayed green.
+ */
+export function joinLike(base: string, ...segments: string[]): string {
+	const separator = /^[A-Za-z]:\\|\\/.test(base) ? "\\" : "/";
+	const trimmed = base.endsWith(separator) ? base.slice(0, -separator.length) : base;
+	return [trimmed, ...segments].join(separator);
+}
+
+/**
  * The filesystem grants dev3 writes into a permission profile. Paths are joined
  * with the platform separator (a native Windows path, not a `C:\Users\x/...`
  * hybrid) and quoted as TOML basic strings.
  */
 function dev3FilesystemLines(userHome: string, dev3Home: string): string[] {
 	return [
-		`${tomlBasicString(join(userHome, ".codex", "skills"))} = "read"`,
-		`${tomlBasicString(join(userHome, ".agents", "skills"))} = "read"`,
+		`${tomlBasicString(joinLike(userHome, ".codex", "skills"))} = "read"`,
+		`${tomlBasicString(joinLike(userHome, ".agents", "skills"))} = "read"`,
 		`${tomlBasicString(dev3Home)} = "write"`,
 	];
 }
@@ -892,8 +905,8 @@ export function ensureCodexProfileFile(
  */
 export function ensureCodexConfigFile(homePath: string): void {
 	const configPath = join(homePath, ".codex", "config.toml");
-	const worktreesPath = join(homePath, ".dev3.0", "worktrees");
-	const socketsPath = join(homePath, ".dev3.0", "sockets");
+	const worktreesPath = joinLike(homePath, ".dev3.0", "worktrees");
+	const socketsPath = joinLike(homePath, ".dev3.0", "sockets");
 	const codexVersion = detectCodexVersion();
 	const syntax = getCodexSyntaxForVersion(codexVersion);
 


### PR DESCRIPTION
Hi, Claude here (the AI that wrote #1369). Hotfix for the red Windows job on `main`.

`ensureCodexConfig` composed the skills/dev3 paths with node's `join`, which answers in the **host's** dialect. On `windows-latest` a POSIX fixture like `/Users/x` became `\Users\x\.codex\skills`, so three assertions in `codex-config*.test.ts` failed there while macOS and Linux stayed green — a genuine platform difference in our code, not a flake and not an environment quirk.

`joinLike()` now joins in the dialect of the path being extended: a Windows home gets backslashes, a POSIX one keeps forward slashes whatever the host is. Node's `join` stays only where a real filesystem path is needed. A unit test pins all three cases and fails on either host if the host dialect leaks back in.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=debf310b-749d-4041-ace6-57f71fbe61e5) · `dev3://task/debf310b-749d-4041-ace6-57f71fbe61e5` _(dev3 added this footer — turn it off in Settings → Tasks.)_
