### PR TITLE
Ignore cached agent binary paths that no longer match the base command

### DIFF
--- a/change-logs/2026/08/14/fix-stale-agent-binary-path-shadowing-base-command.md
+++ b/change-logs/2026/08/14/fix-stale-agent-binary-path-shadowing-base-command.md
@@ -1,0 +1,3 @@
+Short: Edited agent command now takes effect
+
+Fixed editing an agent's base command having no effect on new sessions: the auto-cached resolved binary path (settings.agentBinaryPaths) kept pointing at the previous binary and silently overrode the edited command at every launch. A cached path now only applies while it still names the same binary as the agent's current base command.

--- a/decisions/2026/08/14/agent-binary-path-cache-staleness.md
+++ b/decisions/2026/08/14/agent-binary-path-cache-staleness.md
@@ -1,0 +1,18 @@
+# Agent binary path cache is invalidated by base-command edits
+
+## Context
+
+`checkAgentAvailability` auto-saves each agent's resolved binary path into `settings.agentBinaryPaths` so launches survive the minimal PATH of macOS `.app` bundles (see `decisions/2026/03/16/agent-binary-detection.md`). That cache was applied unconditionally: after a user edited an agent's base command (e.g. `claude` → `claude-codex`), the edit saved to `agents.json` but every launch still ran the old cached binary — and the cache never healed, because `resolveBinaryPath` prefers the custom path over a fresh PATH lookup.
+
+## Decision
+
+A cached/custom agent binary path applies only while its file name still matches the agent's current base command (case-insensitive, tolerating Windows launcher extensions like `.exe`/`.cmd`). Implemented as `binaryPathMatchesCommand` in `src/bun/executable.ts`, enforced at all three consumers of `agentBinaryPaths`: `applyBinaryPathOverride` (`src/bun/agents.ts`, launch command), `checkAgentAvailability` (`src/bun/rpc-handlers/settings-config.ts`, availability + auto-save), and the pre-spawn binary check in `src/bun/rpc-handlers/tmux-pty.ts`.
+
+## Risks
+
+A user who deliberately pointed an agent's custom path at a differently-named wrapper binary loses that override; they can instead put the wrapper's name in the base command field. Stale entries are left in settings (inert) rather than deleted, so switching the base command back revalidates the old cache for free.
+
+## Alternatives considered
+
+- Purging the cache entry when agents are saved with a changed base command — does not heal installs already carrying a stale entry, and leaves the tmux-pty pre-spawn check trusting a mismatched path.
+- Deleting mismatched entries during `checkAgentAvailability` — unnecessary once they are inert, and keeping them lets a reverted base command reuse the cached path.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyLayoutResync, applyModelOverride, applyProviderModel, resolveLaunchConfig, claudeModelFamily, __setCodexProfileV2Override, type TemplateContext } from "../agents";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyBinaryPathOverride, applyLayoutResync, applyModelOverride, applyProviderModel, resolveLaunchConfig, claudeModelFamily, __setCodexProfileV2Override, type TemplateContext } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 import { ENV_UNSET } from "../../shared/agent-accounts";
@@ -852,6 +855,39 @@ describe("buildResumeCommand", () => {
 
 	it("works with full paths", () => {
 		expect(buildResumeCommand("/usr/local/bin/claude", "sid-5")).toBe("/usr/local/bin/claude --resume sid-5");
+	});
+});
+
+describe("applyBinaryPathOverride", () => {
+	let dir: string;
+	let claudePath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "dev3-agents-test-"));
+		claudePath = join(dir, "claude");
+		writeFileSync(claudePath, "#!/bin/sh\n", { mode: 0o755 });
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("applies the cached path when it names the same binary", () => {
+		const agent = makeAgent({ baseCommand: "claude" });
+		const result = applyBinaryPathOverride(agent, { "test-agent": claudePath });
+		expect(result.baseCommand).toBe(claudePath);
+	});
+
+	it("ignores a cached path once the base command was edited to another binary", () => {
+		const agent = makeAgent({ baseCommand: "claude-codex" });
+		const result = applyBinaryPathOverride(agent, { "test-agent": claudePath });
+		expect(result.baseCommand).toBe("claude-codex");
+	});
+
+	it("ignores a cached path that no longer exists", () => {
+		const agent = makeAgent({ baseCommand: "claude" });
+		const result = applyBinaryPathOverride(agent, { "test-agent": join(dir, "gone") });
+		expect(result.baseCommand).toBe("claude");
 	});
 });
 

--- a/src/bun/__tests__/executable.test.ts
+++ b/src/bun/__tests__/executable.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { binaryPathMatchesCommand } from "../executable";
+
+describe("binaryPathMatchesCommand", () => {
+	it("matches when the saved path names the same binary", () => {
+		expect(binaryPathMatchesCommand("/usr/local/bin/claude", "claude")).toBe(true);
+		expect(binaryPathMatchesCommand("/Users/x/.local/bin/claude", "claude")).toBe(true);
+	});
+
+	it("matches when the base command is itself a path", () => {
+		expect(binaryPathMatchesCommand("/opt/homebrew/bin/codex", "/usr/bin/codex")).toBe(true);
+	});
+
+	it("matches Windows launcher extensions and separators", () => {
+		expect(binaryPathMatchesCommand("C:\\bin\\claude.exe", "claude")).toBe(true);
+		expect(binaryPathMatchesCommand("C:\\bin\\claude.cmd", "claude")).toBe(true);
+		expect(binaryPathMatchesCommand("C:\\bin\\Claude.EXE", "claude")).toBe(true);
+	});
+
+	it("rejects a path cached for a different binary than the edited command", () => {
+		expect(binaryPathMatchesCommand("/Users/x/.local/bin/claude", "claude-codex")).toBe(false);
+		expect(binaryPathMatchesCommand("/usr/local/bin/claude-codex", "claude")).toBe(false);
+	});
+
+	it("rejects directories and empty names", () => {
+		expect(binaryPathMatchesCommand("/opt/homebrew/bin/", "claude")).toBe(false);
+		expect(binaryPathMatchesCommand("", "claude")).toBe(false);
+		expect(binaryPathMatchesCommand("/usr/bin/claude", "")).toBe(false);
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -12018,6 +12018,27 @@ describe("checkAgentAvailability", () => {
 		}));
 	});
 
+	it("ignores a saved path once the base command was edited to another binary", async () => {
+		vi.mocked(agents.getAllAgents).mockResolvedValue([
+			{ id: "builtin-claude", name: "Claude", baseCommand: "claude-codex", isDefault: true, configurations: [] },
+		] as any);
+		vi.mocked(loadSettings).mockResolvedValue({
+			defaultAgentId: "builtin-claude",
+			defaultConfigId: "claude-default",
+			taskSortOrder: "oldest-first",
+			updateChannel: "stable",
+			agentBinaryPaths: { "builtin-claude": "/usr/local/bin/claude" },
+		});
+		vi.mocked(existsSync).mockImplementation((path) => String(path) === "/usr/local/bin/claude");
+		mockSpawnSync.mockReturnValue({ exitCode: 1, stdout: null });
+
+		const results = await handlers.checkAgentAvailability();
+		const claude = results.find((r) => r.agentId === "builtin-claude");
+		expect(claude?.installed).toBe(false);
+		expect(claude?.resolvedPath).toBeUndefined();
+		expect(claude?.customPathError).toBe(false);
+	});
+
 	it("reports customPathError when saved path no longer exists", async () => {
 		vi.mocked(loadSettings).mockResolvedValue({
 			defaultAgentId: "builtin-claude",

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -8,6 +8,7 @@ export { skillInvocationPrefix } from "../shared/types";
 import { buildProviderEnv, getProviderDefinition, providerOmitsModelFlag, providerPinnedModel } from "../shared/llm-provider";
 import { createLogger } from "./logger";
 import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
+import { binaryPathMatchesCommand } from "./executable";
 import { DEV3_HOME } from "./paths";
 import { loadSettings, saveSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme, getCodexThemeForCurrentUiTheme } from "./theme-state";
@@ -599,10 +600,12 @@ export function applyModelOverride(
 	return { ...config, model: override };
 }
 
-/** Apply saved binary path override if the cached file still exists on disk. */
-function applyBinaryPathOverride(agent: CodingAgent, savedPaths: Record<string, string> | undefined): CodingAgent {
+/** Apply the saved binary path override, but only while it still points at the
+ *  binary the agent's base command names and exists on disk — an edited base
+ *  command must win over a path cached for the previous one. */
+export function applyBinaryPathOverride(agent: CodingAgent, savedPaths: Record<string, string> | undefined): CodingAgent {
 	const savedPath = savedPaths?.[agent.id];
-	return savedPath && existsSync(savedPath)
+	return savedPath && binaryPathMatchesCommand(savedPath, agent.baseCommand) && existsSync(savedPath)
 		? { ...agent, baseCommand: savedPath }
 		: agent;
 }

--- a/src/bun/executable.ts
+++ b/src/bun/executable.ts
@@ -11,3 +11,16 @@ export function isExecutableFile(path: string): boolean {
 		return false;
 	}
 }
+
+/**
+ * True when a saved binary path still points at the binary the base command
+ * names (same file name, optionally with a Windows launcher extension).
+ * A path cached for `claude` must stop applying once the command is edited to
+ * e.g. `claude-codex` — otherwise the cache silently shadows the edit.
+ */
+export function binaryPathMatchesCommand(savedPath: string, baseCommand: string): boolean {
+	const fileName = (value: string) => (value.split(/[\\/]/).pop() ?? "").toLowerCase();
+	const base = fileName(baseCommand);
+	const saved = fileName(savedPath);
+	return !!base && !!saved && (saved === base || saved.startsWith(`${base}.`));
+}

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -21,7 +21,7 @@ import { getAllFeatureFlags, setFeatureFlags as cacheFeatureFlags } from "../fea
 import { resolveAnalyticsDistinctId as resolveDistinctId } from "../analytics-identity";
 import { extractConfigFromParams, getPushMessage, getSystemRequirements, log, resolveBinaryPath, setFocusMode } from "./shared";
 import { binaryCandidatesOnPath, hasModelProviderSection, tmuxSearchPaths } from "./shared-pure";
-import { isExecutableFile } from "../executable";
+import { binaryPathMatchesCommand, isExecutableFile } from "../executable";
 import { validateEnvMap } from "../../shared/env-text";
 
 /** Reject malformed env maps at the RPC boundary — the UI validates too, but
@@ -382,7 +382,9 @@ async function checkAgentAvailability(): Promise<AgentCheckResult[]> {
 	const settings = await loadSettings();
 	const allAgents = await agents.getAllAgents();
 	const results: AgentCheckResult[] = allAgents.map((agent) => {
-		const customPath = settings.agentBinaryPaths?.[agent.id];
+		const savedPath = settings.agentBinaryPaths?.[agent.id];
+		// A path cached for a previous base command is stale, not an error — drop it.
+		const customPath = savedPath && binaryPathMatchesCommand(savedPath, agent.baseCommand) ? savedPath : undefined;
 		const { resolvedPath, customPathError } = resolveBinaryPath(agent.baseCommand, customPath);
 		log.info(`  agent ${agent.id} (${agent.baseCommand}): ${resolvedPath ? "found" : "NOT found"}`, { path: resolvedPath ?? "none" });
 		return {

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -12,6 +12,7 @@ import { getPidCwd, terminatePidsVerified } from "../process-reaper";
 import { getResourceUsage } from "../resource-monitor";
 import { loadSettings, recordFavoriteUsages } from "../settings";
 import { getUserShell } from "../shell-env";
+import { binaryPathMatchesCommand } from "../executable";
 import { spawn } from "../spawn";
 import { setupAgentHooks } from "../agent-hooks";
 import { resolveResumableSessionId } from "../agent-transcripts";
@@ -738,7 +739,9 @@ export async function launchTaskPty(
 	if (resolvedBaseCmd && resolvedBaseCmd !== "bash") {
 		const binaryName = resolvedBaseCmd.split("/").pop() ?? resolvedBaseCmd;
 		const settings = await loadSettings();
-		const customPath = settings.agentBinaryPaths?.[task.agentId ?? ""];
+		const savedPath = settings.agentBinaryPaths?.[task.agentId ?? ""];
+		// A path cached for a previous base command must not vouch for the new one.
+		const customPath = savedPath && binaryPathMatchesCommand(savedPath, binaryName) ? savedPath : undefined;
 		const { resolvedPath: binaryPath } = resolveBinaryPath(binaryName, customPath);
 		if (!binaryPath) {
 			const allAgents = await agents.getAllAgents();


### PR DESCRIPTION
## Problem

Editing an agent's **Base Command** in Settings → Agents (e.g. `claude` → `claude-codex`) saved to `agents.json` but had no effect: new sessions still launched the old command.

Fixes #1380.

## Root cause

`checkAgentAvailability` auto-caches each agent's resolved binary path into `settings.agentBinaryPaths` (to survive the minimal PATH of macOS .app bundles), and `applyBinaryPathOverride` in `src/bun/agents.ts` applied that cached path unconditionally at launch — silently shadowing the edited base command. The cache never self-healed, because `resolveBinaryPath` prefers the saved custom path over a fresh PATH lookup.

## Fix

New pure helper `binaryPathMatchesCommand` (`src/bun/executable.ts`): a cached/custom agent binary path applies only while its file name still matches the agent's current base command (case-insensitive, tolerates Windows launcher extensions like `.exe`/`.cmd`). Enforced at all three consumers of `agentBinaryPaths`:

- `applyBinaryPathOverride` (`src/bun/agents.ts`) — launch command resolution
- `checkAgentAvailability` (`src/bun/rpc-handlers/settings-config.ts`) — availability display + path auto-save (self-heals: once the new command resolves, the fresh path overwrites the stale entry)
- pre-spawn binary check (`src/bun/rpc-handlers/tmux-pty.ts`) — a stale path no longer vouches for a binary that isn't installed

No data migration: stale cache entries become inert, and reverting the base command revalidates the old cache for free. Details in `decisions/2026/08/14/agent-binary-path-cache-staleness.md`.

## Verification

- Reproduced end-to-end against real affected on-disk state: `resolveCommandForAgent` returned `/Users/…/.local/bin/claude` before the fix and `claude-codex` after.
- New regression tests (fail on the old code): `binaryPathMatchesCommand` unit tests, `applyBinaryPathOverride` with a real temp binary, and a `checkAgentAvailability` case for an edited base command.
- `bun run lint` clean; full `bun run test` green (only pre-existing `native-pane-owner-forward` unix-socket failures, identical on a clean tree).
