### PR TITLE
Prove dev3 pane run on Windows, and keep the PowerShell lookup refusing

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -142,6 +142,19 @@ jobs:
         timeout-minutes: 5
         run: bun run test:cli-packaged-e2e
 
+      # Seq 1548: `dev3 pane run` EXECUTED rather than asserted about. The pane-run
+      # composition is authored per dialect and every existing test for it runs on
+      # macOS, where PowerShell does not exist — so this runs the real runner against a
+      # real spec file and reads the log back: non-ASCII output intact (the console code
+      # page would mangle it), a non-zero exit code intact, and — Windows only — both
+      # callers of the PowerShell lookup still launching with %SystemRoot% deleted from
+      # the environment, where they used to throw. `always()` so a neighbour's failure
+      # cannot hide this verdict.
+      - name: Pane run executed (real shell, real log)
+        if: always()
+        timeout-minutes: 5
+        run: bun run test:pane-run-exec
+
       # Merged host-image manifest: generator, validator, deterministic assembly,
       # additive staging outside the install root, and rollback selection.
       - name: Packaged host image + manifest tests

--- a/change-logs/2026/08/15/fix-windows-powershell-lookup-fallback.md
+++ b/change-logs/2026/08/15/fix-windows-powershell-lookup-fallback.md
@@ -1,0 +1,3 @@
+Short: Pane runs proved on Windows
+
+The packaged Windows CI job now executes a real `dev3 pane run` and reads its log back — that path had never been run on Windows at all, only asserted about from macOS. The same step also settles why PowerShell resolution refuses instead of falling back to a PATH lookup when %SystemRoot% is missing: it launches that fallback for real and records Windows PowerShell failing to start with error 8009001d while reporting exit 0.

--- a/decisions/2026/08/15/no-powershell-fallback-without-systemroot.md
+++ b/decisions/2026/08/15/no-powershell-fallback-without-systemroot.md
@@ -1,0 +1,61 @@
+# No PowerShell PATH fallback when %SystemRoot% is absent
+
+## Context
+
+`powerShellPath()` (`src/shared/platform-launch.ts`) and `paneRunShell()` (`src/bun/pane-run-store.ts`)
+both resolve Windows PowerShell 5.1 under `%SystemRoot%` and throw when it is absent, while their
+sibling `defaultLaunchShellPath()` catches the same failure and degrades to `powershell.exe` on PATH.
+Seq 1548 was asked to remove that inconsistency by making the two throwing call sites degrade too.
+
+## Investigation
+
+Reachability first: both read the app's OWN `process.env` (no argument is passed), and Windows sets
+`SystemRoot` for every normal desktop process — so neither is reachable by an ordinary launch.
+
+The fallback was then written, and executed on `windows-latest` with `SystemRoot`, `SYSTEMROOT` and
+`WINDIR` deleted from the environment (run 31877226362). The lookup degraded exactly as intended —
+and the launch it produced was worthless:
+
+```
+Internal Windows PowerShell error.  Loading managed Windows PowerShell failed with error 8009001d.
+```
+
+`powershell.exe` is found on PATH and starts, but PowerShell 5.1 loads its managed runtime out of
+`%SystemRoot%` and cannot initialise without it. It printed nothing and **exited 0** — a silent
+success wearing the shape of a finished build. A control run in the same job, with the variable
+present, ran the identical generated script to completion and exited 5, so the script and the launch
+spec were never in question.
+
+The pane run in the same environment went further than that: the child `bun` process produced no
+output, wrote no status file and exited non-zero before any dev3 code ran. `%SystemRoot%` is missing
+for our own runtime too, so in that environment nothing dev3 decides at the lookup is even reachable.
+`paneRunShell`'s refusal is therefore covered by its unit test; the dialect's refusal, which IS
+reached in-process, is what the Windows step asserts.
+
+## Decision
+
+**The two launch-time call sites keep throwing, and the reason is now written next to them.** A
+fallback here converts a named refusal (`SystemRoot is required …`) into a run that dies with error
+8009001d and reports exit 0 — strictly worse for the agent reading that outcome.
+
+`defaultLaunchShellPath()` keeps its degradation: it runs during boot (`getUserShell`), where dying
+is worse than returning a shell that may not start.
+
+The evidence is not prose — `src/cli/__tests__/pane-run-exec.bun-e2e.ts` launches the rejected
+fallback for real on every Windows CI run and asserts it produces nothing, so the day PowerShell
+stops needing `%SystemRoot%`, that step says so.
+
+## Risks
+
+The e2e depends on a failure mode of Windows PowerShell 5.1. If a future Windows makes the fallback
+viable, the "produces nothing" check fails and this record must be revisited — which is the intended
+alarm, not a flake.
+
+## Alternatives considered
+
+- **Degrade to `powershell.exe` on PATH** — implemented, executed, rejected on the evidence above.
+- **Default `%SystemRoot%` to `C:\Windows`** (what `staged-host-runtime.ts` does for its own shell)
+  — does not help: the child inherits the same stripped environment, and it is the environment, not
+  the executable path, that PowerShell fails on.
+- **Inject `SystemRoot` into the child environment** — would work, but it is environment repair for
+  a case no normal launch reaches, at the cost of dev3 inventing a system path.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"test:cli-loopback-e2e": "bun src/bun/__tests__/cli-loopback-transport.bun-e2e.ts",
 		"test:headless-soak": "bun src/bun/__tests__/headless-remote-soak.bun-e2e.ts",
 		"test:cli-packaged-e2e": "bun src/cli/__tests__/cli-packaged-loopback.bun-e2e.ts",
+		"test:pane-run-exec": "bun src/cli/__tests__/pane-run-exec.bun-e2e.ts",
 		"test:terminal-state-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/terminal-state/__tests__",
 		"benchmark:terminal-state-spike": "bun src/bun/prototypes/terminal-state/benchmark.ts",
 		"test:stream-resync-spike": "bunx vitest run --config vitest.config.bun.ts src/bun/prototypes/stream-resync/__tests__",

--- a/src/bun/__tests__/pane-runs-vocabulary.test.ts
+++ b/src/bun/__tests__/pane-runs-vocabulary.test.ts
@@ -246,6 +246,9 @@ describe("paneRunShell — the one place a shell dialect genuinely differs", () 
 		expect(script.indexOf("$dev3Ok = $?")).toBeLessThan(script.indexOf("$dev3Code = $LASTEXITCODE"));
 	});
 
+	// Proved on windows-latest: PowerShell 5.1 without %SystemRoot% dies with
+	// "Internal Windows PowerShell error ... 8009001d" and exits 0, so a PATH
+	// fallback would hand the agent a silent no-op instead of this named refusal.
 	it("refuses to guess a PowerShell path when Windows names no SystemRoot", () => {
 		expect(() => paneRunShell("echo hi", { platform: "win32", env: {} })).toThrow(/SystemRoot is required/);
 	});

--- a/src/bun/__tests__/platform-launch.test.ts
+++ b/src/bun/__tests__/platform-launch.test.ts
@@ -63,6 +63,43 @@ describe("dialect selection", () => {
 	});
 });
 
+/**
+ * The dialect resolves its own shell whenever a caller passes no explicit path.
+ * It REFUSES rather than degrading, and that asymmetry with
+ * `defaultLaunchShellPath` is deliberate: boot must survive a stripped
+ * environment, but a launch into one cannot — Windows PowerShell 5.1 does not
+ * load without %SystemRoot% (error 8009001d, executed on windows-latest; see
+ * decisions/2026/08/15/no-powershell-fallback-without-systemroot.md).
+ */
+describe("Windows shell resolution without %SystemRoot%", () => {
+	const NAMES = ["SystemRoot", "SYSTEMROOT", "WINDIR", "windir"] as const;
+	const saved: Record<string, string | undefined> = {};
+	const d = launchDialect("win32");
+
+	beforeAll(() => {
+		for (const name of NAMES) {
+			saved[name] = process.env[name];
+			delete process.env[name];
+		}
+	});
+	afterAll(() => {
+		for (const name of NAMES) {
+			if (saved[name] === undefined) delete process.env[name];
+			else process.env[name] = saved[name];
+		}
+	});
+
+	it("refuses a launch by name instead of resolving a shell that cannot start", () => {
+		expect(() => d.scriptLaunch("C:\\tmp\\run.ps1", { cwd: "C:\\tmp", env: {} })).toThrow(/SystemRoot/);
+		expect(() => d.interactiveShellLaunch({ cwd: "C:\\tmp", env: {} })).toThrow(/SystemRoot/);
+		expect(() => d.runScript("C:\\tmp\\run.ps1")).toThrow(/SystemRoot/);
+	});
+
+	it("still lets the boot path degrade, which is the one caller that must not die", () => {
+		expect(defaultLaunchShellPath("win32", {})).toBe("powershell.exe");
+	});
+});
+
 describe("Windows PowerShell dialect", () => {
 	const d = launchDialect("win32");
 	const originalSystemRoot = process.env.SystemRoot;

--- a/src/bun/pane-run-store.ts
+++ b/src/bun/pane-run-store.ts
@@ -85,6 +85,9 @@ export interface PaneRunShellLookup {
 export function paneRunShell(command: string, lookup: PaneRunShellLookup): PaneRunShellSpec {
 	if (lookup.platform === "win32") {
 		const systemRoot = lookup.env.SystemRoot ?? lookup.env.SYSTEMROOT ?? lookup.env.WINDIR;
+		// Refused rather than guessed: PowerShell 5.1 cannot load without %SystemRoot%
+		// even when the binary is found on PATH, so a fallback would turn a named
+		// refusal into a run that dies with error 8009001d and exits 0.
 		if (!systemRoot) throw new Error("SystemRoot is required to run a pane command on Windows");
 		return {
 			executable: pathWin32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),

--- a/src/cli/__tests__/pane-run-exec.bun-e2e.ts
+++ b/src/cli/__tests__/pane-run-exec.bun-e2e.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env bun
+/**
+ * `dev3 pane run` EXECUTED, on this machine's real shell (seq 1548).
+ *
+ * The vitest suites assert what `paneRunShell` composes; they run on macOS and
+ * cannot see whether Windows PowerShell actually accepts that composition. This
+ * script runs the real pane-run process (`dev3 __pane-run`) against a real spec
+ * file and reads back what landed in the log and the status file:
+ *
+ *  1. the command's output reaches the log as UTF-8 — the Windows console code
+ *     page would turn a non-ASCII marker into mojibake without the encoding
+ *     prelude, and the log is the only channel an agent has;
+ *  2. a non-zero exit code arrives intact — `powershell -Command` does not
+ *     propagate one by itself, which is what the exit epilogue exists for;
+ *  3. Windows only: WHY neither caller of the PowerShell lookup may fall back to a
+ *     PATH lookup when %SystemRoot% is absent. It launches `powershell.exe` from PATH
+ *     in exactly that environment and records what Windows does with it — the control
+ *     run above, with the variable present, is what makes that verdict readable.
+ *
+ * The POSIX legs are the control that `/bin/sh -c` still behaves as before.
+ *
+ * Run: bun run test:pane-run-exec
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "../../bun/spawn";
+import { paneRunLogPath, paneRunSpecPath, paneRunStatusPath, PANE_RUN_VERB } from "../../bun/pane-run-store";
+import { launchDialect } from "../../shared/platform-launch";
+
+const IS_WINDOWS = process.platform === "win32";
+/** Non-ASCII on purpose: this is what a wrong output encoding destroys. */
+const MARKER = "dev3-pane-run-✓-проба";
+const CLI_ENTRY = join(import.meta.dir, "..", "main.ts");
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+function printMarkerAndExit(code: number): string {
+	return IS_WINDOWS ? `Write-Host '${MARKER}'; exit ${code}` : `printf '%s\\n' '${MARKER}'; exit ${code}`;
+}
+
+interface RunOutcome {
+	log: string;
+	status: { state?: string; exitCode?: number | null; detail?: string | null };
+	stdout: string;
+	stderr: string;
+	cliExitCode: number | null;
+}
+
+async function runPane(dir: string, runId: string, command: string): Promise<RunOutcome> {
+	writeFileSync(
+		paneRunSpecPath(dir, runId),
+		`${JSON.stringify({ runId, taskId: "e2e", command, cwd: dir, label: "", requestedAt: new Date().toISOString() })}\n`,
+		"utf8",
+	);
+	const child = spawn([process.execPath, CLI_ENTRY, PANE_RUN_VERB, dir, runId], {
+		cwd: dir,
+		// Closed stdin: the runner's "press Enter to close this pane" wait ends with
+		// the stream, which is how a pane run behaves when nobody is watching it.
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()]);
+	const cliExitCode = await child.exited;
+	const logPath = paneRunLogPath(dir, runId);
+	const statusPath = paneRunStatusPath(dir, runId);
+	return {
+		log: existsSync(logPath) ? readFileSync(logPath, "utf8") : "",
+		status: existsSync(statusPath) ? JSON.parse(readFileSync(statusPath, "utf8")) : {},
+		stdout,
+		stderr,
+		cliExitCode,
+	};
+}
+
+/**
+ * The other caller of the same lookup: the launch dialect resolves its own shell on
+ * every Windows task launch. This writes a real wrapper script the way dev3 does
+ * (BOM first, or PowerShell 5.1 reads it as ANSI) and launches it through the spec
+ * the dialect produced — so what is exercised is the launch, not the string.
+ */
+async function launchGeneratedScript(
+	dir: string,
+	name: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null; executable: string }> {
+	const d = launchDialect("win32");
+	const scriptPath = join(dir, `${name}${d.scriptExtension}`);
+	const body = [...d.header(), d.print(MARKER), "exit 5", ""].join("\n");
+	writeFileSync(scriptPath, d.scriptByteOrderMark + body, "utf8");
+	const launch = d.scriptLaunch(scriptPath, { cwd: dir, env: {} });
+	const child = spawn([launch.executable, ...launch.argv], { cwd: launch.cwd, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()]);
+	return { stdout, stderr, exitCode: await child.exited, executable: launch.executable };
+}
+
+/**
+ * The fallback dev3 does NOT use, executed so the refusal above is a measurement
+ * rather than an opinion: `powershell.exe` off PATH, same script, same stripped
+ * environment. Windows PowerShell 5.1 loads its managed runtime out of
+ * %SystemRoot% and cannot start without it, so this is what a "graceful
+ * degradation" would actually have handed the user.
+ */
+async function launchFallbackShell(dir: string): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+	const d = launchDialect("win32");
+	const scriptPath = join(dir, `wrapper-fallback${d.scriptExtension}`);
+	const body = [...d.header(), d.print(MARKER), "exit 5", ""].join("\n");
+	writeFileSync(scriptPath, d.scriptByteOrderMark + body, "utf8");
+	const child = spawn(["powershell.exe", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath], {
+		cwd: dir,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()]);
+	return { stdout, stderr, exitCode: await child.exited };
+}
+
+/** Printed whenever a Windows check fails: a verdict with no evidence is a guess. */
+function evidence(label: string, lines: Record<string, unknown>): void {
+	console.log(`  ---- ${label}`);
+	for (const [key, value] of Object.entries(lines)) {
+		console.log(`       ${key}: ${JSON.stringify(value)}`);
+	}
+}
+
+/**
+ * `main.ts` imports the generated build-info module, which a fresh checkout does
+ * not have (it is written during a build, never committed). Generating it is a
+ * prerequisite of running the CLI at all, not part of what this proves.
+ */
+async function ensureBuildInfo(): Promise<void> {
+	const generated = join(import.meta.dir, "..", "..", "shared", "build-info.generated.ts");
+	if (existsSync(generated)) return;
+	const script = join(import.meta.dir, "..", "..", "..", "scripts", "generate-build-info.ts");
+	const child = spawn([process.execPath, script], { stdout: "pipe", stderr: "pipe" });
+	if ((await child.exited) !== 0) throw new Error("could not generate build-info.generated.ts");
+}
+
+await ensureBuildInfo();
+const root = mkdtempSync(join(tmpdir(), "dev3-pane-run-e2e-"));
+
+try {
+	console.log(`pane run executed on ${process.platform}`);
+
+	const normal = await runPane(root, "run-0123456789ab", printMarkerAndExit(3));
+	check(normal.log.includes(MARKER), "the command's non-ASCII output reached the log intact (UTF-8, not the code page)");
+	check(normal.stdout.includes(MARKER), "the same output reached the pane");
+	check(normal.status.state === "exited", `the run ended in state 'exited' (got ${String(normal.status.state)})`);
+	check(normal.status.exitCode === 3, `the command's exit code 3 survived the shell (got ${String(normal.status.exitCode)})`);
+	check(normal.cliExitCode === 0, `the runner itself exited 0 (got ${String(normal.cliExitCode)})`);
+
+	if (IS_WINDOWS) {
+		// CONTROL first, with the environment untouched: it separates "the wrapper this
+		// dialect writes is good" from anything the stripped environment does to it.
+		const control = await launchGeneratedScript(root, "wrapper-control");
+		check(control.stdout.includes(MARKER), "a generated wrapper script runs through the dialect's own launch spec");
+		check(control.exitCode === 5, `that script's exit code arrives (got ${String(control.exitCode)})`);
+		if (!control.stdout.includes(MARKER) || control.exitCode !== 5) {
+			evidence("control wrapper", { executable: control.executable, stdout: control.stdout, stderr: control.stderr });
+		}
+
+		// The child inherits this process's environment, so removing the variable HERE
+		// is what puts both callers into the case under test — nothing is mocked, and the
+		// shell anything finds is whatever PATH resolves.
+		const saved = { SystemRoot: process.env.SystemRoot, SYSTEMROOT: process.env.SYSTEMROOT, WINDIR: process.env.WINDIR };
+		delete process.env.SystemRoot;
+		delete process.env.SYSTEMROOT;
+		delete process.env.WINDIR;
+		let stripped: RunOutcome;
+		let generated: Awaited<ReturnType<typeof launchGeneratedScript>> | null = null;
+		let launchError: unknown = null;
+		let wouldHaveBeen: Awaited<ReturnType<typeof launchFallbackShell>>;
+		try {
+			stripped = await runPane(root, "run-0123456789ac", printMarkerAndExit(4));
+			wouldHaveBeen = await launchFallbackShell(root);
+			// A throw here IS the defect under test, so it becomes a named failure rather
+			// than an uncaught crash that says nothing about which caller broke.
+			try {
+				generated = await launchGeneratedScript(root, "wrapper-stripped");
+			} catch (err) {
+				launchError = err;
+			}
+		} finally {
+			for (const [name, value] of Object.entries(saved)) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+		}
+
+		// MEASURED, not assumed: in this environment the runner never starts. The child
+		// bun process produces no output, writes no status and exits non-zero before any
+		// dev3 code runs — %SystemRoot% is missing for it too. So `paneRunShell`'s own
+		// refusal is unobservable HERE and is covered by its unit test instead; what is
+		// observable is that nothing dev3 could do at the lookup would have helped.
+		check(
+			!stripped.status.state && stripped.cliExitCode !== 0,
+			`the pane-run process could not start at all without %SystemRoot% (status ${String(stripped.status.state)}, exit ${String(stripped.cliExitCode)})`,
+		);
+		// The launch dialect IS reached in-process, so its refusal is the assertion that
+		// carries the decision — restoring a PATH fallback turns these two red.
+		check(generated === null, `the launch dialect refused too (it returned ${generated?.executable ?? "nothing"})`);
+		check(
+			String(launchError).includes("SystemRoot"),
+			`and refused by name (${String(launchError)})`,
+		);
+
+		// What a fallback would have bought instead, launched for real in this same
+		// environment: powershell.exe IS found on PATH, starts, and dies.
+		check(
+			!wouldHaveBeen.stdout.includes(MARKER),
+			"a PATH-resolved powershell.exe produces nothing in this environment — which is why there is no fallback",
+		);
+		evidence("what a PATH fallback would have run", {
+			exitCode: wouldHaveBeen.exitCode,
+			stdoutHasMarker: wouldHaveBeen.stdout.includes(MARKER),
+			stderr: wouldHaveBeen.stderr.replaceAll("\u0000", "").slice(0, 300),
+		});
+		evidence("pane run without %SystemRoot%", {
+			state: stripped.status.state,
+			exitCode: stripped.status.exitCode,
+			detail: stripped.status.detail,
+			cliExitCode: stripped.cliExitCode,
+			stdout: stripped.stdout.slice(0, 300),
+			stderr: stripped.stderr.slice(0, 300),
+		});
+	} else {
+		console.log("  skip - the %SystemRoot% fallback is Windows-only; POSIX has no such variable");
+	}
+} finally {
+	rmSync(root, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+	console.error(`\n${failures} check(s) failed`);
+	process.exit(1);
+}
+console.log("\nALL CHECKS PASSED");

--- a/src/shared/platform-launch.ts
+++ b/src/shared/platform-launch.ts
@@ -297,6 +297,12 @@ const POWERSHELL_SCRIPT_ARGS = ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "By
 function powerShellPath(shellPath?: string): string {
 	const explicit = shellPath?.trim();
 	if (explicit && /powershell(\.exe)?$|pwsh(\.exe)?$/i.test(explicit)) return explicit;
+	// NO fallback here, and that is a measured choice, not an oversight. Windows
+	// PowerShell 5.1 cannot load without %SystemRoot% at all — it dies with
+	// "Internal Windows PowerShell error ... 8009001d" and exits 0, proved on
+	// windows-latest (decisions/2026/08/15/no-powershell-fallback-without-systemroot.md).
+	// A PATH lookup would therefore buy a silent broken launch instead of this
+	// named refusal. Boot is the one place that degrades: see defaultLaunchShellPath.
 	return windowsPowerShellPath();
 }
 

--- a/src/shared/windows-ci-scope.ts
+++ b/src/shared/windows-ci-scope.ts
@@ -118,6 +118,12 @@ export const WINDOWS_SCOPE_PATHS = [
 	"src/bun/__tests__/git-op-script.test.ts",
 	"src/bun/__tests__/git-op-pane.bun-e2e.ts",
 	"src/bun/rpc-handlers/__tests__/git-op-pane-launch.test.ts",
+	// The same dialect as spoken by `dev3 pane run` (Seq 1548): its command composition
+	// and the runner that executes it. Under (1) for the same reason — only the Windows
+	// leg runs PowerShell, so an edit to either has to re-run the proof that executes it.
+	"src/bun/pane-run-store.ts",
+	"src/cli/commands/pane-exec.ts",
+	"src/cli/__tests__/pane-run-exec.bun-e2e.ts",
 	// This list and the script reading it decide the whole thing; changing either
 	// has to re-prove Windows rather than judging its own change out of scope.
 	"src/shared/windows-ci-scope.ts",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch). This PR turned into the opposite of what it set out to be, so the summary leads with that.

**Two of the three reported "POSIX-only" sites were misreadings.** `src/bun/pane-run-store.ts:99` and `native-terminal-registry/host-images/staged-host-runtime.ts:50` are the POSIX **arm** of functions that already branch on `win32` immediately above them (`git blame`: #1372 on 2026-08-14, and 2026-07-23). Neither is touched here.

**The third one was implemented, executed on Windows, and reverted on the evidence.** `powerShellPath()` and `paneRunShell()` throw when `%SystemRoot%` is absent, while `defaultLaunchShellPath()` degrades to `powershell.exe` on PATH — so the plan was to make them degrade too. Run 31877226362 on windows-latest, with the variable deleted from the environment, showed what that buys:

```
Internal Windows PowerShell error.  Loading managed Windows PowerShell failed with error 8009001d.
```

PowerShell 5.1 loads its managed runtime out of `%SystemRoot%`; the binary is found on PATH, starts, prints nothing, and **exits 0**. A control run in the same job with the variable present ran the identical generated script to completion and exited 5. So a "graceful degradation" would replace a named refusal with a silent no-op that reads as a passing build. Both call sites keep throwing, and the reason now lives next to them plus in `decisions/2026/08/15/no-powershell-fallback-without-systemroot.md`.

**What this PR actually adds is the proof that was missing.** `dev3 pane run` — the backend-agnostic pane layer — had *no* Windows execution coverage: every test for its shell composition runs on macOS, where PowerShell does not exist. The new `windows-conpty-package.yml` step runs the real runner against a real spec file and reads the log back (non-ASCII output intact, non-zero exit code intact), and launches the rejected fallback for real so that verdict is re-measured on every Windows run rather than believed from this description. `if: always()`, so a neighbour's failure cannot hide it.

The diff is additive: no POSIX or Windows code path changes behaviour, only comments, tests and CI.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ace137b4-63e6-4ba9-bbf6-01bc6d70aada) · `dev3://task/ace137b4-63e6-4ba9-bbf6-01bc6d70aada`