### PR TITLE
Port the dev-server pane to the platform launch dialect (Windows)

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -104,6 +104,28 @@ jobs:
         timeout-minutes: 6
         run: bun run test:git-op-pane-e2e
 
+      # Seq 1546: the Dev Server button was dead on Windows — it refused with "the
+      # dev-server pane requires the tmux backend, which is POSIX-only" before it
+      # read anything (issue #1387, reproduced by Arseny on his own box), and the
+      # wrapper behind it was hand-written bash launched through `/bin/bash`.
+      # Swapping only the launch would have been WORSE than the outage: PowerShell
+      # would half-run bash text and look like it started. So the E2E RUNS the
+      # wrapper on this runner and checks the dev command executed and read back
+      # all three env blocks, and that a crashed dev server reports its code
+      # instead of hanging on its own keypress prompt with no keyboard attached.
+      # The pure test pins the POSIX text and asserts the Windows properties; the
+      # launch test covers the call site, which an E2E calling the helper cannot.
+      # `always()`: a step that runs only when an unrelated one passes is evidence
+      # about that step, not about this one.
+      - name: Dev-server pane script + launch (pure, both dialects)
+        if: always()
+        run: bun run test:dev-server-script
+
+      - name: Dev-server pane wrapper executed (${{ matrix.os }})
+        if: always()
+        timeout-minutes: 5
+        run: bun run test:dev-server-pane-e2e
+
       - name: Windows self-update swap script (pure)
         run: bun run test:windows-update
 

--- a/change-logs/2026/08/15/fix-windows-dev-server-pane.md
+++ b/change-logs/2026/08/15/fix-windows-dev-server-pane.md
@@ -1,0 +1,5 @@
+Short: Dev server starts on Windows
+
+The Dev Server button and `dev3 dev-server start` no longer refuse on Windows with "the dev-server pane requires the tmux backend, which is POSIX-only": that refusal belonged to the nested tmux session the tmux backend hosts the server in, not to the pane, and a Windows task is always native. The pane's wrapper script is now written in the platform launch dialect (PowerShell there, byte-compatible bash on macOS and Linux) and launched through it instead of a hardcoded `/bin/bash`, and the marker that re-finds the pane no longer assumes a `.sh` file name. A project's own `devScript` is still the user's text in the user's shell — dev3 does not translate it, so a POSIX dev command still needs a Windows-compatible form.
+
+Fixes h0x91b/dev-3.0#1387

--- a/decisions/2026/08/15/dev-server-wrapper-ported-body-not-launch.md
+++ b/decisions/2026/08/15/dev-server-wrapper-ported-body-not-launch.md
@@ -1,0 +1,76 @@
+# Port the dev-server wrapper's BODY, and move the tmux refusal to the tmux session
+
+## Context
+
+On Windows the Dev Server button and `dev3 dev-server start` failed outright with
+`the dev-server pane requires the tmux backend, which is POSIX-only — no Windows
+equivalent exists` (reproduced by Arseny on Windows 10 Pro 22H2, dev3 v1.44.0,
+native backend; issue #1387). Two separate things were wrong, and fixing either
+alone is a trap:
+
+1. `runDevServer` called `assertPosixLaunchDialect("the dev-server pane")` as its
+   FIRST statement, so the native path never ran. The name was wrong too: the
+   thing that needs tmux is the nested `dev3-dev-<id>` session plus the viewer
+   pane that attaches to it, not the pane concept.
+2. The wrapper it would have run was hand-written bash — `#!/bin/bash`, `set -x`,
+   `[ $EXIT_CODE -ne 0 ]`, `read -n 1 -s` — launched with a hardcoded
+   `nativeLaunch: { executable: "/bin/bash" }`.
+
+Swapping only the launch (Seq 1544 deliberately did not) would have been worse
+than the outage: PowerShell would half-run bash text and the pane would look like
+it started.
+
+## Investigation
+
+A third defect was found on the way, in already-merged code. `auxPaneMarker`
+re-finds an auxiliary pane by substring-matching its launch command, and the
+suffixes carried file extensions (`dev.sh`, `col-agent.sh`). The dialect names a
+generated script `.ps1` on Windows, so on Windows the column-agent pane (merged in
+Seq 1544) launches and is then invisible to every later lookup — is it running,
+replace it, stop it. `gitOp` was safe only by luck (`git-`, no extension).
+
+## Decision
+
+- The wrapper body moved into `src/bun/dev-server-script.ts`
+  (`buildDevServerScript`), authored in the launch dialect. `runDevServer`
+  (`src/bun/rpc-handlers/tmux-pty.ts`) now composes it structurally and launches
+  it via `generatedScriptLaunch` / `generatedScriptName`.
+- `assertPosixLaunchDialect` moved down to the nested-tmux branch and was renamed
+  to `the nested dev-server tmux session`. A Windows task is always native
+  (`newTaskTerminalBackend`), so that branch is unreachable there.
+- `LaunchDialect` gained `traceOn()` / `traceOff()` (`set -x` / `Set-PSDebug`).
+- `AUX_PANE_PURPOSES` suffixes lost their extensions (`dev`, `col-agent`), which
+  also repairs the column-agent pane on Windows.
+
+**POSIX moved by exactly three lines**, deliberately, and they are pinned in their
+new form in `dev-server-script.test.ts`: `echo ""` + `echo "…$EXIT_CODE…"` became
+one `printf '\n…%s…\n' "$EXIT_CODE"`, and `read -n 1 -s` became the dialect's
+shell-portable read (identical under bash, which is what launches the file).
+Reproducing the old spelling would have meant adding dialect members that
+duplicate `print` and `readKey`, which this repo forbids; the sibling agent
+wrapper has always printed its exit notice with `printf`.
+
+## Risks
+
+- **The user's own `devScript` is NOT ported and cannot be.** It is the user's
+  text in the user's shell. `bun run dev` happens to be valid in both dialects;
+  `VITE_PORT=${DEV3_PORT0:-5173} bun run dev` is a PowerShell parse error. What
+  changes is that the failure is now the user's script failing in a live pane
+  instead of dev3 refusing to open one. Documenting the platform caveat next to
+  `devScript` is a separate, open product question.
+- The dev-server teardown (`killDevServerSession`, `buildDevServerStatus`) reads
+  process trees and port owners through `ps` and `lsof`. Those degrade to empty
+  on Windows rather than throwing, so start/stop work, but port detection and
+  descendant reaping are POSIX-only in practice. Out of scope here; unproven on
+  Windows either way.
+
+## Alternatives considered
+
+- **Guard the whole feature on Windows with a nicer message.** Rejected: the
+  wrapper is the only reason it could not run, and the button is the point.
+- **Translate the user's `devScript` to PowerShell.** Rejected outright — dev3
+  cannot know what the text means, and a half-translation is a silent wrong
+  command against the user's repo.
+- **Keep POSIX byte-identical by adding `echo`-shaped dialect members.** Rejected:
+  two ways to print one line, for legacy spelling that renders the same
+  characters.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
 		"test:agent-spawn-shell": "bunx vitest run --config vitest.config.bun.ts src/bun/rpc-handlers/__tests__/agent-spawn-shell-launch.test.ts src/bun/__tests__/launch-failure.test.ts",
 		"test:git-op-script": "bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/git-op-script.test.ts src/bun/rpc-handlers/__tests__/git-op-pane-launch.test.ts",
 		"test:git-op-pane-e2e": "bun src/bun/__tests__/git-op-pane.bun-e2e.ts",
+		"test:dev-server-script": "bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/dev-server-script.test.ts src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts",
+		"test:dev-server-pane-e2e": "bun src/bun/__tests__/dev-server-pane.bun-e2e.ts",
 		"test:windows-update-e2e": "bun src/bun/windows-update/__tests__/swap.win-e2e.ts",
 		"test:native-shell-launch": "bunx vitest run --config vitest.config.bun.ts src/bun/native-terminal-registry/__tests__/shell-launch.test.ts src/bun/native-terminal-registry/__tests__/shell-probe.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-runner.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-evidence.test.ts src/bun/native-terminal-registry/__tests__/windows-shell-matrix-support.test.ts src/bun/native-terminal-registry/__tests__/host-config.test.ts src/bun/native-terminal-registry/__tests__/protocol.test.ts src/bun/native-terminal-registry/__tests__/registry.test.ts src/bun/native-terminal-registry/__tests__/recovery.test.ts src/bun/native-terminal-registry/__tests__/client.test.ts src/bun/native-terminal-registry/__tests__/isolation.test.ts",
 		"test:native-live-parser-e2e": "bun src/bun/native-terminal-registry/__tests__/live-parser.bun-e2e.ts",

--- a/src/bun/__tests__/dev-server-pane.bun-e2e.ts
+++ b/src/bun/__tests__/dev-server-pane.bun-e2e.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+/**
+ * The dev-server pane's wrapper, EXECUTED on this runner's real platform (Seq 1546).
+ *
+ * "The pane opened" was never the question. The whole feature was dead on Windows
+ * because the wrapper was hand-written bash launched through `/bin/bash` (issue
+ * #1387: the Dev Server button answered "requires the tmux backend, which is
+ * POSIX-only"), and a bash body handed to PowerShell half-runs instead of failing
+ * — which is why porting only the launch would have been worse than the outage.
+ * So what is proved here is that the wrapper RUNS A COMMAND and that the command
+ * SEES ITS ENVIRONMENT:
+ *
+ *   start    the dev command actually executed, and read back DEV3_TASK_SEQ, the
+ *            project's own env var and DEV3_PORT0 — the three env blocks the
+ *            wrapper writes, in the dialect it writes them in
+ *   crash    a dev server that exits non-zero prints its code and does NOT hang
+ *            on its own "press any key" prompt with no keyboard attached
+ *   re-find  the script the pane launches carries the marker that later looks the
+ *            pane up (running? replace it? stop it?) on THIS platform's file name
+ *
+ * The POSIX legs are the control that none of this changed macOS/Linux.
+ *
+ * NOT proved here, and it cannot be: that a user's own `devScript` runs. Its text
+ * is the user's, in whatever shell they had in mind, and dev3 does not translate
+ * it. The probe below is deliberately a command that is valid in both dialects.
+ *
+ * Run: bun run test:dev-server-pane-e2e   (all three platforms)
+ */
+
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "../spawn";
+import { buildDevServerScript } from "../dev-server-script";
+import { generatedScriptLaunch, generatedScriptName, writeLaunchScript } from "../rpc-handlers/shared-pure";
+import { auxPaneMarker } from "../task-aux-panes";
+import { dev3TaskTempPath } from "../temp-paths";
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+const root = mkdtempSync(join(tmpdir(), "dev3-dev-server-e2e-"));
+const asPath = (...parts: string[]) => join(root, ...parts).replaceAll("\\", "/");
+
+/**
+ * The "dev server": a script that records the environment it was launched with
+ * and exits with the code it is told to. `bun <file>` is one of the few command
+ * lines that means the same thing in bash and in PowerShell — which is the point,
+ * since dev3 does not translate the user's own devScript.
+ */
+const PROBE = asPath("probe.mjs");
+const RECORD = asPath("record.json");
+writeFileSync(
+	PROBE,
+	[
+		"import { writeFileSync } from 'node:fs';",
+		`writeFileSync(${JSON.stringify(RECORD)}, JSON.stringify({`,
+		"  seq: process.env.DEV3_TASK_SEQ ?? null,",
+		"  project: process.env.DEV3_PROBE_PROJECT_VAR ?? null,",
+		"  port: process.env.DEV3_PORT0 ?? null,",
+		"  cwd: process.cwd(),",
+		"}));",
+		"process.exit(Number(process.argv[2] ?? 0));",
+	].join("\n"),
+	"utf8",
+);
+
+/**
+ * Run the wrapper exactly the way the pane does: written through
+ * `writeLaunchScript` (a Windows `.ps1` needs its byte-order mark) and launched
+ * through `generatedScriptLaunch` (the executable and argv are the app's).
+ *
+ * stdin is closed on purpose. The failure path ends in "press any key", and a
+ * wrapper that blocks there forever hangs the pane exactly as it hangs this run.
+ */
+async function runWrapper(exitCode: number): Promise<{ code: number; output: string; scriptPath: string }> {
+	rmSync(RECORD, { force: true });
+	const scriptPath = asPath(generatedScriptName("dev"));
+	await writeLaunchScript(
+		scriptPath,
+		buildDevServerScript({
+			devScript: `bun ${PROBE} ${exitCode}`,
+			envGroups: [
+				{ DEV3_PROBE_PROJECT_VAR: "from the project config" },
+				{ DEV3_TASK_SEQ: "1546", DEV3_WORKTREE_PATH: root.replaceAll("\\", "/") },
+				{ DEV3_PORT0: "51730" },
+			],
+			// A native pane has no nesting and no tmux binary — and on Windows there
+			// is no tmux at all. This is the shape the button actually takes there.
+			tmuxDetachCommand: null,
+		}),
+	);
+	const launch = generatedScriptLaunch(scriptPath);
+	const proc = spawn([launch.executable, ...launch.argv], {
+		cwd: root,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [out, err, code] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { code, output: `${out}\n${err}`, scriptPath };
+}
+
+console.log(`dev-server pane wrapper on ${process.platform}`);
+
+try {
+	console.log("\nstart — the dev command runs and sees its environment");
+	{
+		const { output } = await runWrapper(0);
+		check(existsSync(RECORD), "the dev command actually executed (it wrote its record)");
+		if (existsSync(RECORD)) {
+			const record = JSON.parse(readFileSync(RECORD, "utf8")) as Record<string, string | null>;
+			check(record.seq === "1546", `the task env block reached the command (DEV3_TASK_SEQ=${record.seq})`);
+			check(
+				record.project === "from the project config",
+				`the project env block reached the command (${record.project})`,
+			);
+			check(record.port === "51730", `the port env block reached the command (DEV3_PORT0=${record.port})`);
+		}
+		check(
+			!output.includes("Process exited with code"),
+			"a dev server that exits cleanly prints no failure notice",
+		);
+	}
+
+	console.log("\ncrash — a non-zero exit is reported and does not hang the pane");
+	{
+		const { output } = await runWrapper(7);
+		check(existsSync(RECORD), "the dev command executed before failing");
+		check(
+			output.includes("Process exited with code 7"),
+			`the pane shows the real exit code (output: ${JSON.stringify(output.trim().slice(-160))})`,
+		);
+		// Reaching this line at all is the proof: the run above is awaited to
+		// completion with no keyboard attached.
+		check(true, "the wrapper terminated instead of blocking on its own keypress prompt");
+	}
+
+	console.log("\nre-find — the launched script carries this platform's pane marker");
+	{
+		const taskId = "abcdef12-0000-0000-0000-000000000005";
+		const scriptPath = dev3TaskTempPath(taskId, generatedScriptName("dev"));
+		const launch = generatedScriptLaunch(scriptPath);
+		check(
+			[launch.executable, ...launch.argv].join(" ").includes(auxPaneMarker(taskId, "devServer")),
+			`the launch command matches the devServer marker (${scriptPath})`,
+		);
+		check(
+			process.platform === "win32"
+				? launch.executable.toLowerCase().includes("powershell") && scriptPath.endsWith(".ps1")
+				: launch.executable === "/bin/bash" && scriptPath.endsWith(".sh"),
+			`the pane launches ${launch.executable} for ${scriptPath}`,
+		);
+	}
+} finally {
+	rmSync(root, { recursive: true, force: true });
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/bun/__tests__/dev-server-script.test.ts
+++ b/src/bun/__tests__/dev-server-script.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The dev-server pane's wrapper script, per dialect (Seq 1546).
+ *
+ * POSIX is pinned as literal text: macOS and Linux users must keep the wrapper
+ * they have. Three lines DID move, deliberately, and they are pinned in their new
+ * form because reproducing the old spelling would have meant inventing dialect
+ * members that duplicate `print` and `readKey`:
+ *   `echo ""` + `echo "…$EXIT_CODE…"`  →  one `printf '\n…%s…\n' "$EXIT_CODE"`
+ *   `read -n 1 -s`                     →  the shell-portable read (identical under
+ *                                         bash, which is what launches this file)
+ * Nothing else changes, and the pane prints the same characters as before.
+ *
+ * Windows is asserted by PROPERTY — there is no previous text to match, and the
+ * properties chosen are the ones whose absence is silent rather than loud.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { buildDevServerScript } from "../dev-server-script";
+
+const realPlatform = process.platform;
+const realSystemRoot = process.env.SystemRoot;
+
+function asPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+	if (platform === "win32") process.env.SystemRoot ??= "C:\\Windows";
+}
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+	if (realSystemRoot === undefined) delete process.env.SystemRoot;
+	else process.env.SystemRoot = realSystemRoot;
+});
+
+const ENV_GROUPS: Record<string, string>[] = [
+	{ FOO: "bar baz" },
+	{ DEV3_TASK_ID: "abc", DEV3_TASK_TITLE: "Port the pane" },
+	{ DEV3_PORT0: "5173" },
+];
+const DEV_SCRIPT = "VITE_PORT=${DEV3_PORT0:-5173} bun run dev";
+const DETACH = '"/opt/tmux" detach-client 2>/dev/null || true';
+
+const POSIX_TMUX = [
+	"#!/bin/bash",
+	"export FOO='bar baz'",
+	"",
+	"export DEV3_TASK_ID='abc'",
+	"export DEV3_TASK_TITLE='Port the pane'",
+	"",
+	"export DEV3_PORT0='5173'",
+	"",
+	"set -x",
+	"VITE_PORT=${DEV3_PORT0:-5173} bun run dev",
+	"EXIT_CODE=$?",
+	"set +x",
+	"if [ $EXIT_CODE -ne 0 ]; then",
+	"  printf '\\nProcess exited with code %s. Press any key to close.\\n' \"$EXIT_CODE\"",
+	"  if [ -n \"$ZSH_VERSION\" ]; then read -k 1 -s; else read -n 1 -s; fi",
+	"fi",
+	'"/opt/tmux" detach-client 2>/dev/null || true',
+].join("\n") + "\n";
+
+describe("POSIX dev-server wrapper (pinned)", () => {
+	it("renders the tmux flavour exactly", () => {
+		asPlatform("darwin");
+		expect(buildDevServerScript({ devScript: DEV_SCRIPT, envGroups: ENV_GROUPS, tmuxDetachCommand: DETACH })).toBe(POSIX_TMUX);
+	});
+
+	it("omits the detach line for a native pane and nothing else", () => {
+		asPlatform("darwin");
+		const script = buildDevServerScript({ devScript: DEV_SCRIPT, envGroups: ENV_GROUPS, tmuxDetachCommand: null });
+		expect(script).toBe(POSIX_TMUX.replace(`${DETACH}\n`, ""));
+	});
+
+	it("drops empty env groups instead of emitting blank paragraphs", () => {
+		asPlatform("darwin");
+		const script = buildDevServerScript({ devScript: "bun run dev", envGroups: [{}, { A: "1" }, {}] });
+		expect(script).toBe(["#!/bin/bash", "export A='1'", "", "set -x", "bun run dev", "EXIT_CODE=$?", "set +x",
+			"if [ $EXIT_CODE -ne 0 ]; then",
+			"  printf '\\nProcess exited with code %s. Press any key to close.\\n' \"$EXIT_CODE\"",
+			"  if [ -n \"$ZSH_VERSION\" ]; then read -k 1 -s; else read -n 1 -s; fi",
+			"fi"].join("\n") + "\n");
+	});
+});
+
+describe("Windows dev-server wrapper (properties)", () => {
+	const windowsScript = () => {
+		asPlatform("win32");
+		return buildDevServerScript({ devScript: "bun run dev", envGroups: ENV_GROUPS, tmuxDetachCommand: null });
+	};
+
+	it("carries no bash spelling at all", () => {
+		const script = windowsScript();
+		expect(script).not.toContain("#!/bin/bash");
+		expect(script).not.toContain("set -x");
+		expect(script).not.toContain("set +x");
+		expect(script).not.toContain("if [ $EXIT_CODE -ne 0 ]");
+		expect(script).not.toMatch(/\bexport \w/);
+		expect(script).not.toMatch(/read -n 1 -s/);
+		expect(script).not.toContain("ZSH_VERSION");
+	});
+
+	it("spells the whole wrapper in PowerShell", () => {
+		const script = windowsScript();
+		expect(script.startsWith("$ErrorActionPreference = 'Continue'")).toBe(true);
+		expect(script).toContain("$env:DEV3_TASK_ID = 'abc'");
+		expect(script).toContain("Set-PSDebug -Trace 1");
+		expect(script).toContain("Set-PSDebug -Trace 0");
+		expect(script).toContain("if ($EXIT_CODE -ne 0) {");
+		expect(script).toContain("Write-Host");
+	});
+
+	it("reads the exit code back even when the command never set $LASTEXITCODE", () => {
+		// A PowerShell cmdlet leaves $LASTEXITCODE untouched, so a plain read of it
+		// would report the PREVIOUS command's success for a dev server that died.
+		expect(windowsScript()).toContain("$EXIT_CODE = if ($null -eq $LASTEXITCODE) { if ($?) { 0 } else { 1 } } else { $LASTEXITCODE }");
+	});
+
+	it("never blocks forever on the keypress when input is redirected", () => {
+		// Every non-interactive run — including the CI proof that executes this
+		// script — has redirected stdin, where RawUI.ReadKey throws.
+		expect(windowsScript()).toContain("[Console]::IsInputRedirected");
+	});
+
+	it("keeps the user's own devScript verbatim, because dev3 does not translate it", () => {
+		asPlatform("win32");
+		const script = buildDevServerScript({ devScript: DEV_SCRIPT, envGroups: [], tmuxDetachCommand: null });
+		expect(script).toContain(DEV_SCRIPT);
+	});
+});

--- a/src/bun/__tests__/task-aux-panes.test.ts
+++ b/src/bun/__tests__/task-aux-panes.test.ts
@@ -299,9 +299,23 @@ describe("native pane lookup by launch-command marker", () => {
 
 	it("owns the column-agent pane by its own marker, distinct from every other purpose", () => {
 		const marker = auxPaneMarker(TASK_ID, "columnAgent");
-		expect(marker).toContain("col-agent.sh");
+		expect(marker).toContain("col-agent");
 		expect(marker).not.toBe(auxPaneMarker(TASK_ID, "devServer"));
 		expect(marker).not.toBe(auxPaneMarker(TASK_ID, "gitOp"));
+	});
+
+	// The dialect names the generated script `.sh` on POSIX and `.ps1` on Windows.
+	// A marker carrying either extension matches only one of them, so the pane
+	// launches on the other platform and is then invisible to every later lookup —
+	// is it running, replace it, stop it (Seq 1546).
+	it("matches the launched script on BOTH platforms' file names", () => {
+		for (const purpose of ["devServer", "columnAgent"] as const) {
+			const marker = auxPaneMarker(TASK_ID, purpose);
+			expect(marker).not.toMatch(/\.(sh|ps1)$/);
+			for (const extension of [".sh", ".ps1"]) {
+				expect(auxPurposeOfCommand(TASK_ID, ["shell", marker + extension])).toBe(purpose);
+			}
+		}
 	});
 });
 

--- a/src/bun/__tests__/tmux-pty-devserver-selfhost.test.ts
+++ b/src/bun/__tests__/tmux-pty-devserver-selfhost.test.ts
@@ -157,6 +157,11 @@ vi.mock("../rpc-handlers/shared-pure", () => ({
 	buildScriptRunnerCommand: vi.fn(() => ""),
 	buildTaskLifecycleEnv: vi.fn(() => ({})),
 	escapeForDoubleQuotes: vi.fn((s: string) => s),
+	// The dev-server pane writes and launches its wrapper through the dialect
+	// (Seq 1546); the self-host refusal fires before either actually runs.
+	generatedScriptName: vi.fn((base: string) => `${base}.sh`),
+	generatedScriptLaunch: vi.fn((scriptPath: string) => ({ executable: "/bin/bash", argv: [scriptPath] })),
+	writeLaunchScript: vi.fn(async () => {}),
 	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 	portableReadKey: vi.fn(() => ""),
 	resolveBinaryPath: vi.fn(() => null),

--- a/src/bun/dev-server-script.ts
+++ b/src/bun/dev-server-script.ts
@@ -1,0 +1,61 @@
+/**
+ * The dev-server pane's wrapper script, authored in the platform launch dialect
+ * (Seq 1546).
+ *
+ * It used to be hand-written bash stitched together inside `runDevServer`: a
+ * `#!/bin/bash` shebang, `set -x`, `[ $EXIT_CODE -ne 0 ]`, `read -n 1 -s`. On
+ * Windows the pane launched that text through `/bin/bash`, a path that does not
+ * exist there — which is why the whole feature was dead on that platform.
+ *
+ * ONE thing this file does NOT solve, and cannot: {@link DevServerScriptOptions.devScript}
+ * is the USER's own command, written in whatever shell they had in mind. dev3
+ * spells the wrapper; it does not translate the body. A `VITE_PORT=${DEV3_PORT0}
+ * bun run dev` remains POSIX text no matter which dialect surrounds it, and under
+ * PowerShell it fails as a parse error. The wrapper's job is to stop being the
+ * thing that breaks, and to make that failure the user's script rather than a
+ * missing `/bin/bash`.
+ */
+
+import { indentLines, launchDialect } from "../shared/platform-launch";
+
+export interface DevServerScriptOptions {
+	/** The project's dev command, verbatim — see the file note above. */
+	devScript: string;
+	/**
+	 * Environment blocks, in order. Each becomes its own paragraph so the pane's
+	 * trace reads as project env / task env / ports rather than one wall.
+	 */
+	envGroups: Record<string, string>[];
+	/**
+	 * tmux only: the command that detaches the outer viewer client before this
+	 * pane closes, which keeps the inner tmux redraw from corrupting the outer
+	 * one. A native pane has no nesting and no tmux binary, so it passes null —
+	 * and on Windows there is no tmux at all.
+	 */
+	tmuxDetachCommand?: string | null;
+}
+
+const EXIT_CODE_VAR = "EXIT_CODE";
+
+/** The wrapper text for one dev-server pane, in the current platform's dialect. */
+export function buildDevServerScript(options: DevServerScriptOptions): string {
+	const d = launchDialect();
+	const envParagraphs = options.envGroups
+		.filter((group) => Object.keys(group).length > 0)
+		.flatMap((group) => [...d.envLines(group), ""]);
+	const failNotice = d.print("Process exited with code %s. Press any key to close.", {
+		blankBefore: true,
+		args: [d.exitCodeArg(EXIT_CODE_VAR)],
+	});
+	return [
+		...d.header(),
+		...envParagraphs,
+		// Only the user's command is traced: the exports above are dev3's business.
+		d.traceOn(),
+		options.devScript,
+		d.captureExitCode(EXIT_CODE_VAR),
+		d.traceOff(),
+		...d.branchOnFailure(EXIT_CODE_VAR, { fail: indentLines(2, [failNotice, d.readKey()]) }),
+		...(options.tmuxDetachCommand ? [options.tmuxDetachCommand] : []),
+	].join("\n") + "\n";
+}

--- a/src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts
+++ b/src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts
@@ -1,0 +1,197 @@
+/**
+ * How the dev-server pane is LAUNCHED, and where it refuses (Seq 1546).
+ *
+ * `runDevServer` used to refuse on Windows before it read anything — Arseny's
+ * own box answered the Dev Server button with "the dev-server pane requires the
+ * tmux backend, which is POSIX-only" (issue #1387). The refusal belonged to the
+ * NESTED TMUX SESSION the tmux backend hosts the server in, not to the pane, and
+ * a native task has neither.
+ *
+ * Sibling of `git-op-pane-launch.test.ts`: the E2E that executes the wrapper
+ * calls `generatedScriptLaunch` itself, so it stays green while the call site
+ * hands the pane a hardcoded `/bin/bash`. The script and the launch are two
+ * separate things and each needs its own proof.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getProject: vi.fn(),
+	getTask: vi.fn(),
+	openAuxPane: vi.fn(),
+	writeLaunchScript: vi.fn(async (_scriptPath: string, _body: string) => {}),
+	resolveOperationalProjectConfig: vi.fn(),
+	newSessionDetached: vi.fn(async () => ({ stdout: "", stderr: "" })),
+}));
+
+vi.mock("../shared", () => ({
+	getPushMessage: () => null,
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../data", () => ({
+	getProject: mocks.getProject,
+	getTask: mocks.getTask,
+	updateTask: vi.fn(),
+}));
+
+vi.mock("../settings-config", () => ({
+	resolveOperationalProjectConfig: mocks.resolveOperationalProjectConfig,
+}));
+
+vi.mock("../../task-aux-panes", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../task-aux-panes")>()),
+	openAuxPane: mocks.openAuxPane,
+	auxPaneAlive: vi.fn(async () => false),
+	closeAuxPane: vi.fn(),
+	findAuxPane: vi.fn(async () => null),
+	nativeAuxPaneShellPid: vi.fn(async () => null),
+}));
+
+vi.mock("../shared-pure", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../shared-pure")>()),
+	writeLaunchScript: mocks.writeLaunchScript,
+}));
+
+vi.mock("../../tmux", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../tmux")>();
+	return {
+		...actual,
+		tmux: {
+			...actual.tmux,
+			binaryPath: () => "/opt/homebrew/bin/tmux",
+			hasSession: vi.fn(async () => false),
+			newSessionDetached: mocks.newSessionDetached,
+			splitWindow: vi.fn(async () => ({ paneId: "%3" })),
+			selectPane: vi.fn(async () => {}),
+			setOption: vi.fn(async () => {}),
+			listPanes: vi.fn(async () => []),
+			killPane: vi.fn(async () => {}),
+			killSession: vi.fn(async () => {}),
+		},
+	};
+});
+
+vi.mock("../../port-scanner", () => ({
+	findPortHolders: vi.fn(async () => []),
+	waitForPortsFree: vi.fn(async () => []),
+	getLsofOutput: vi.fn(async () => ""),
+	parseLsofOutput: () => [],
+	buildProcessTree: vi.fn(async () => new Map()),
+	collectDescendants: () => [],
+	getSessionPanePids: vi.fn(async () => []),
+	collectTaskPids: vi.fn(async () => new Set()),
+	scanTaskPorts: vi.fn(async () => []),
+	getPortsForTask: () => [],
+	getResourceUsage: () => undefined,
+	clearPortDataForTask: vi.fn(),
+	getPidCwd: vi.fn(async () => null),
+	terminatePidsVerified: vi.fn(async () => []),
+}));
+
+import { runDevServer } from "../tmux-pty";
+
+const PROJECT = { id: "proj-1", name: "p", path: "/repo", defaultBaseBranch: "main" } as any;
+/** Windows stamps every new task `native` (`newTaskTerminalBackend`). */
+const NATIVE_TASK = {
+	id: "abcdef12-0000-0000-0000-000000000004",
+	title: "Run the dev server",
+	worktreePath: "/repo/wt",
+	terminalBackend: "native",
+	tmuxSocket: "dev3",
+} as any;
+const TMUX_TASK = { ...NATIVE_TASK, terminalBackend: "tmux" } as any;
+const isWindows = process.platform === "win32";
+
+/**
+ * Await INSIDE the platform override, not around it: `runDevServer` reads
+ * `process.platform` after its first await, so a synchronous restore would put
+ * the platform back before the code under test ever looks at it.
+ */
+async function asWindows<T>(run: () => Promise<T>): Promise<T> {
+	const real = process.platform;
+	const realSystemRoot = process.env.SystemRoot;
+	Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+	process.env.SystemRoot ??= "C:\\Windows";
+	try {
+		return await run();
+	} finally {
+		Object.defineProperty(process, "platform", { value: real, configurable: true });
+		if (realSystemRoot === undefined) delete process.env.SystemRoot;
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.getProject.mockResolvedValue(PROJECT);
+	mocks.getTask.mockResolvedValue(NATIVE_TASK);
+	mocks.resolveOperationalProjectConfig.mockResolvedValue({ devScript: "bun run dev", env: {}, portCount: 0 });
+	mocks.openAuxPane.mockResolvedValue({ backend: "native", paneId: "%9" });
+});
+
+describe(`dev-server pane launch on ${process.platform}`, () => {
+	it("never hands the pane a POSIX shell path that cannot exist here", async () => {
+		await runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id });
+		const launch = mocks.openAuxPane.mock.calls[0][0].nativeLaunch;
+		if (isWindows) {
+			expect(launch.executable).not.toBe("/bin/bash");
+			expect(launch.executable).not.toMatch(/^\/bin\//);
+			expect(launch.executable).toMatch(/(powershell|pwsh)(\.exe)?$/i);
+			expect(launch.argv).toContain("-File");
+			expect(launch.argv[launch.argv.length - 1]).toMatch(/\.ps1$/);
+		} else {
+			// The POSIX control: byte-identical to the literal it replaced.
+			expect(launch.executable).toBe("/bin/bash");
+			expect(launch.argv).toEqual([launch.argv[0]]);
+			expect(launch.argv[0]).toMatch(/\.sh$/);
+		}
+	});
+
+	it("writes the wrapper to the very path the pane launches", async () => {
+		await runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id });
+		const launch = mocks.openAuxPane.mock.calls[0][0].nativeLaunch;
+		expect(mocks.writeLaunchScript.mock.calls.map(([path]) => String(path)))
+			.toContain(launch.argv[launch.argv.length - 1]);
+	});
+
+	it("writes a wrapper in this platform's dialect, not hand-written bash", async () => {
+		await runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id });
+		const body = String(mocks.writeLaunchScript.mock.calls[0][1]);
+		if (isWindows) expect(body).not.toContain("#!/bin/bash");
+		else expect(body.startsWith("#!/bin/bash\n")).toBe(true);
+	});
+
+	it("launches the pane on a native task when the platform reports win32", async () => {
+		await asWindows(() => runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id }));
+		expect(mocks.openAuxPane).toHaveBeenCalledTimes(1);
+		const launch = mocks.openAuxPane.mock.calls[0][0].nativeLaunch;
+		expect(launch.executable).toMatch(/(powershell|pwsh)(\.exe)?$/i);
+		expect(launch.argv).toContain("-File");
+		// `-File` on a `.sh` is not a PowerShell script: the NAME has to move with
+		// the dialect, not just the interpreter.
+		expect(launch.argv[launch.argv.length - 1]).toMatch(/\.ps1$/);
+		// The refusal Arseny saw must be gone from the native path entirely.
+		expect(String(mocks.writeLaunchScript.mock.calls[0][1])).not.toContain("#!/bin/bash");
+	});
+
+	it("still refuses the NESTED TMUX SESSION on Windows instead of half-running it", async () => {
+		mocks.getTask.mockResolvedValue(TMUX_TASK);
+		await expect(asWindows(() => runDevServer({ taskId: TMUX_TASK.id, projectId: PROJECT.id })))
+			.rejects.toThrow(/tmux backend, which is POSIX-only/);
+		expect(mocks.newSessionDetached).not.toHaveBeenCalled();
+	});
+
+	// The marker re-finds the pane later (is it running, replace it, stop it) by
+	// substring-matching the launch command. An extension in it matches nothing on
+	// the other platform, so the pane launches and is then invisible forever.
+	it("re-finds the pane it just launched, on either platform's script name", async () => {
+		const { auxPaneMarker } = await import("../../task-aux-panes");
+		await asWindows(() => runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id }));
+		const windowsLaunch = mocks.openAuxPane.mock.calls[0][0].nativeLaunch;
+		expect(windowsLaunch.argv.join(" ")).toContain(auxPaneMarker(NATIVE_TASK.id, "devServer"));
+
+		mocks.openAuxPane.mockClear();
+		await runDevServer({ taskId: NATIVE_TASK.id, projectId: PROJECT.id });
+		const nativeLaunch = mocks.openAuxPane.mock.calls[0][0].nativeLaunch;
+		expect(nativeLaunch.argv.join(" ")).toContain(auxPaneMarker(NATIVE_TASK.id, "devServer"));
+	});
+});

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -67,8 +67,9 @@ import {
 	type AuxPaneHandle,
 	type AuxPanePlacement,
 } from "../task-aux-panes";
-import { getPushMessage, isActive, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildSetupStartupWrapper, buildEnvExports, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
+import { getPushMessage, isActive, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildSetupStartupWrapper, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
 import { assertPosixLaunchDialect, launchDialect } from "../../shared/platform-launch";
+import { buildDevServerScript } from "../dev-server-script";
 import { resolveOperationalProjectConfig } from "./settings-config";
 
 const devViewerPaneIds = new Map<string, string>();
@@ -1011,8 +1012,6 @@ export async function runDevServer(params: { taskId: string; projectId: string; 
 	// Echo the renderer's correlation id so a click that never reached a handler is
 	// distinguishable from one that did (seq 1407).
 	log.info("→ runDevServer", params);
-	// Both backends run the same bash wrapper; only its host differs.
-	assertPosixLaunchDialect("the dev-server pane");
 	try {
 		const project = await data.getProject(params.projectId);
 		const task = await data.getTask(project, params.taskId);
@@ -1023,7 +1022,7 @@ export async function runDevServer(params: { taskId: string; projectId: string; 
 
 		const native = taskTerminalBackendIdentity(task) === "native";
 		const devSession = devServerSessionName(task.id);
-		const devScriptPath = dev3TaskTempPath(task.id, "dev.sh");
+		const devScriptPath = dev3TaskTempPath(task.id, generatedScriptName("dev"));
 		const socket = task.tmuxSocket ?? DEFAULT_TMUX_SOCKET;
 
 		if (await isDevServerRunning(task, socket)) {
@@ -1068,38 +1067,23 @@ export async function runDevServer(params: { taskId: string; projectId: string; 
 			});
 		}
 
-		const portExports = devPorts.length > 0
-			? buildEnvExports(portPool.buildPortEnv(devPorts)).join("\n") + "\n"
-			: "";
-		const projectEnvExports = Object.keys(resolved.env ?? {}).length > 0
-			? buildEnvExports(resolved.env ?? {}).join("\n") + "\n"
-			: "";
-		// Same workspace env the setup/cleanup hooks get, so a devScript can
-		// reference root-resolved hooks ("$DEV3_PROJECT_PATH/...") too.
-		const lifecycleExports = buildEnvExports(buildTaskLifecycleEnv(project, task, task.worktreePath)).join("\n") + "\n";
-
-		const wrappedScript = [
-			`#!/bin/bash`,
-			...(projectEnvExports ? [projectEnvExports] : []),
-			lifecycleExports,
-			...(portExports ? [portExports] : []),
-			`set -x`,
-			resolved.devScript,
-			`EXIT_CODE=$?`,
-			`set +x`,
-			`if [ $EXIT_CODE -ne 0 ]; then`,
-			`  echo ""`,
-			`  echo "Process exited with code $EXIT_CODE. Press any key to close."`,
-			`  read -n 1 -s`,
-			`fi`,
-			// Detaching the outer viewer pane before this pane closes lets the inner
-			// tmux redraw without a watching client — it prevents escape-sequence
-			// corruption in the outer tmux. A native pane has no nesting and no
-			// tmux binary to call, so the line is tmux-only.
-			// Use the app-resolved binary: a PATH tmux of a different version cannot
-			// talk to this server at all ("server exited unexpectedly").
-			...(native ? [] : [`"${tmux.binaryPath()}" detach-client 2>/dev/null || true`]),
-		].join("\n") + "\n";
+		// Detaching the outer viewer pane before this pane closes lets the inner tmux
+		// redraw without a watching client — it prevents escape-sequence corruption in
+		// the outer tmux. A native pane has no nesting and no tmux binary to call, so
+		// the line is tmux-only. Use the app-resolved binary: a PATH tmux of a
+		// different version cannot talk to this server ("server exited unexpectedly").
+		const tmuxDetachCommand = native ? null : `"${tmux.binaryPath()}" detach-client 2>/dev/null || true`;
+		const wrappedScript = buildDevServerScript({
+			devScript: resolved.devScript,
+			envGroups: [
+				resolved.env ?? {},
+				// Same workspace env the setup/cleanup hooks get, so a devScript can
+				// reference root-resolved hooks ("$DEV3_PROJECT_PATH/...") too.
+				buildTaskLifecycleEnv(project, task, task.worktreePath),
+				devPorts.length > 0 ? portPool.buildPortEnv(devPorts) : {},
+			],
+			tmuxDetachCommand,
+		});
 		await writeLaunchScript(devScriptPath, wrappedScript);
 
 		// A native task has no tmux anything. The dev script runs directly in a
@@ -1118,7 +1102,7 @@ export async function runDevServer(params: { taskId: string; projectId: string; 
 				socket,
 				title: auxPaneTitle("devServer"),
 				tmuxCommand: `bash "${devScriptPath}"`,
-				nativeLaunch: { executable: "/bin/bash", argv: [devScriptPath] },
+				nativeLaunch: generatedScriptLaunch(devScriptPath),
 			});
 			log.info("← runDevServer done (native pane)", {
 				taskId: params.taskId,
@@ -1128,6 +1112,12 @@ export async function runDevServer(params: { taskId: string; projectId: string; 
 			return buildDevServerStatus(task, project.id, !!resolved.devScript.trim(), socket);
 		}
 
+		// Everything below hosts the dev server in a NESTED tmux session and views it
+		// through a second tmux pane. That is the tmux backend's shape, not a
+		// platform-neutral one, so it refuses here rather than half-running. A
+		// Windows task is always native (see `newTaskTerminalBackend`), so this is
+		// unreachable there — reaching it would be a wiring bug.
+		assertPosixLaunchDialect("the nested dev-server tmux session");
 		try {
 			// Client cwd is pinned inside newSessionDetached — never a mortal
 			// worktree, or a tmux server started by this client keeps it forever.

--- a/src/bun/task-aux-panes.ts
+++ b/src/bun/task-aux-panes.ts
@@ -102,6 +102,11 @@ interface AuxPanePurposeMeta {
 	 * The temp-file suffix whose path identifies this purpose's pane in a launch
 	 * command. Both backends launch a script under the task's temp prefix, so the
 	 * prefix alone is a stable, per-task, per-purpose marker.
+	 *
+	 * It carries NO file extension on purpose: the dialect names the generated
+	 * script `dev.sh` on POSIX and `dev.ps1` on Windows, so a marker ending in
+	 * `.sh` matches nothing on Windows — the pane is invisible to every later
+	 * lookup (is it running, replace it, stop it) even though it launched fine.
 	 */
 	scriptSuffix: string;
 	/** English label shown for the pane in the pager and pane picker. */
@@ -116,9 +121,9 @@ interface AuxPanePurposeMeta {
 }
 
 const AUX_PANE_PURPOSES: Record<AuxPanePurpose, AuxPanePurposeMeta> = {
-	devServer: { scriptSuffix: "dev.sh", title: "Dev Server", provenReplace: false },
+	devServer: { scriptSuffix: "dev", title: "Dev Server", provenReplace: false },
 	gitOp: { scriptSuffix: "git-", title: "Git", provenReplace: false },
-	columnAgent: { scriptSuffix: "col-agent.sh", title: "Column Agent", provenReplace: true },
+	columnAgent: { scriptSuffix: "col-agent", title: "Column Agent", provenReplace: true },
 };
 
 /** The substring that identifies a purpose's pane in a launch command. */

--- a/src/shared/platform-launch.ts
+++ b/src/shared/platform-launch.ts
@@ -88,6 +88,15 @@ export interface LaunchDialect {
 	/** Pause for whole seconds. */
 	sleepSeconds(seconds: number): string;
 	/**
+	 * Start / stop echoing every executed line INSIDE a script (`set -x`).
+	 *
+	 * Distinct from {@link LaunchScriptOptions.trace}, which traces a whole script
+	 * from the outside: the dev-server wrapper traces only the user's own command,
+	 * so its env exports do not scroll past before the dev server starts.
+	 */
+	traceOn(): string;
+	traceOff(): string;
+	/**
 	 * Write the number held in `varName` to `filePath` as plain ASCII digits.
 	 *
 	 * NOT a redirection. Windows PowerShell 5.1's `>` is `Out-File`, which writes
@@ -225,6 +234,8 @@ const posixDialect: LaunchDialect = {
 	runCommand: (argv) => argv.map(posixShellQuote).join(" "),
 	describeCommand: (argv) => describeArgv(argv, posixShellQuote),
 	sleepSeconds: (seconds) => `sleep ${seconds}`,
+	traceOn: () => "set -x",
+	traceOff: () => "set +x",
 	writeExitCodeFile: (varName, filePath) => `printf '%s' "$${varName}" > ${posixShellQuote(filePath)}`,
 	exitWith: (varName) => `exit $${varName}`,
 	captureExitCode: (varName) => `${varName}=$?`,
@@ -350,6 +361,8 @@ const windowsDialect: LaunchDialect = {
 	runCommand: (argv) => `$global:LASTEXITCODE = $null; & ${argv.map(powerShellQuote).join(" ")}`,
 	describeCommand: (argv) => describeArgv(argv, powerShellQuote),
 	sleepSeconds: (seconds) => `Start-Sleep -Seconds ${seconds}`,
+	traceOn: () => "Set-PSDebug -Trace 1",
+	traceOff: () => "Set-PSDebug -Trace 0",
 	// See the interface doc: `>` here would be UTF-16LE with a BOM.
 	writeExitCodeFile: (varName, filePath) =>
 		`[System.IO.File]::WriteAllText(${powerShellQuote(filePath)}, [string]$${varName})`,

--- a/src/shared/windows-ci-scope.ts
+++ b/src/shared/windows-ci-scope.ts
@@ -119,6 +119,15 @@ export const WINDOWS_SCOPE_PATHS = [
 	"src/bun/__tests__/git-op-script.test.ts",
 	"src/bun/__tests__/git-op-pane.bun-e2e.ts",
 	"src/bun/rpc-handlers/__tests__/git-op-pane-launch.test.ts",
+	// The dev-server pane (Seq 1546, issue #1387). Same criterion (1): its wrapper is
+	// the user's own dev command surrounded by dev3's, and only a Windows run can tell
+	// the two dialects apart. `task-aux-panes.ts` is in for the marker that re-finds
+	// the pane — it used to carry a `.sh`, which matches nothing on Windows.
+	"src/bun/dev-server-script.ts",
+	"src/bun/task-aux-panes.ts",
+	"src/bun/__tests__/dev-server-script.test.ts",
+	"src/bun/__tests__/dev-server-pane.bun-e2e.ts",
+	"src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts",
 	// The same dialect as spoken by `dev3 pane run` (Seq 1548): its command composition
 	// and the runner that executes it. Under (1) for the same reason — only the Windows
 	// leg runs PowerShell, so an edit to either has to re-run the proof that executes it.


### PR DESCRIPTION
The Dev Server button and `dev3 dev-server start` were dead on Windows: `runDevServer` called `assertPosixLaunchDialect("the dev-server pane")` as its **first** statement, so the native path never ran. Arseny reproduced it on his own box — issue #1387.

Two things were wrong, and fixing either alone is a trap:

1. **The guard was in the wrong place.** What needs tmux is the nested `dev3-dev-<id>` session plus the viewer pane that attaches to it — not the pane concept. The guard moved down to that branch (a Windows task is always `native`, so it is unreachable there).
2. **The wrapper was hand-written bash** (`#!/bin/bash`, `set -x`, `[ $EXIT_CODE -ne 0 ]`, `read -n 1 -s`) launched through a hardcoded `/bin/bash`. Porting only the launch would have been worse than the outage — PowerShell half-runs bash text and looks like it started.

The body now lives in `src/bun/dev-server-script.ts`, authored in the launch dialect (`traceOn`/`traceOff` added for `set -x` / `Set-PSDebug`), and the pane launches it through `generatedScriptLaunch`/`generatedScriptName`.

**Third defect, found on the way, in already-merged code:** `AUX_PANE_PURPOSES` markers carried file extensions (`dev.sh`, `col-agent.sh`). The dialect names a generated script `.ps1` on Windows, so a pane launched there was invisible to every later lookup — is it running, replace it, stop it. Extensions dropped; this also repairs the column-agent pane on Windows.

**POSIX moved by exactly three lines**, deliberately, pinned in their new form: the two `echo`s became one `printf`, and `read -n 1 -s` became the dialect's shell-portable read (identical under bash, which launches the file). `platform-launch-posix-golden.test.ts` is untouched and green — no other wrapper moved.

**What this does NOT fix, and cannot:** a project's `devScript` is the user's own text in the user's own shell. `bun run dev` is valid in both dialects; `VITE_PORT=\${DEV3_PORT0:-5173} bun run dev` is a PowerShell parse error. What changes is that the failure is now the user's script failing in a live pane instead of dev3 refusing to open one. Documenting that caveat next to `devScript` is a separate, open product question.

## Proof

Windows workflow run on this branch **before** merge: [31887058798](https://github.com/h0x91b/dev-3.0/actions/runs/31887058798) — `package-runtime (windows-latest)` green, both new steps green. From its log on the real runner:

```
← runDevServer done (native pane)          # the refusal is gone on the native path
error: the nested dev-server tmux session requires the tmux backend  # and still fires where it belongs
ok - the dev command actually executed (it wrote its record)
ok - the task env block reached the command (DEV3_TASK_SEQ=1546)
ok - the pane shows the real exit code                # crash reported, no hang on the keypress prompt
ok - the pane launches ...powershell.exe for ...-dev.ps1
```

Mutation branch `mutation/dev3-dev-server-bash-hardcode` restores the `/bin/bash` hardcode to confirm the Windows step goes red for it.

Fixes #1387

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=723a9754-9241-4fab-a26b-6dd87f347f98) · `dev3://task/723a9754-9241-4fab-a26b-6dd87f347f98`