### PR TITLE
Skip the file write when a task update changes nothing

### DIFF
--- a/change-logs/2026/08/16/fix-noop-task-update-write-storm.md
+++ b/change-logs/2026/08/16/fix-noop-task-update-write-storm.md
@@ -1,0 +1,3 @@
+Short: Stop no-op task updates freezing the app
+
+A task update that changes nothing no longer rewrites the project's tasks.json, and the Codex pane-session hook answers its steady-state no-op from cache instead of taking the file lock. On a large board an active Codex agent was rewriting a 14 MB tasks.json around eleven times a second, which pinned the main process event loop and froze the UI.

--- a/decisions/2026/08/16/no-op-task-update-skips-the-write.md
+++ b/decisions/2026/08/16/no-op-task-update-skips-the-write.md
@@ -1,0 +1,51 @@
+# A no-op task update skips the write
+
+## Context
+
+On 2026-08-16 the app froze. In the last three minutes before the user killed it,
+`data.updateTaskWith` logged 1005 writes for a single task, ~11 per second, all
+for the same Codex task on the base44 board — whose `tasks.json` is 14 MB across
+498 tasks. The same storm had run 613 times earlier that morning (07:01-07:08),
+alongside 1896 `Lock acquisition timed out` warnings across the day.
+
+The huge `Event loop stall detected` warnings in that log (933 s, 624 s, 424 s)
+are NOT related: each one matches a macOS clamshell-sleep window one-to-one in
+`pmset -g log`. The detector measures wall clock and cannot tell a blocked thread
+from a sleeping machine, so the real stall — the write storm — barely showed up in
+it. Do not trust that warning as a freeze signal until it is fixed.
+
+## Investigation
+
+`captureCodexPaneSession` (`src/bun/cli-socket-server.ts`) runs on every Codex
+lifecycle hook and calls `data.updateTaskWith`. Its mutator correctly returns
+`{ updates: {}, result: { changed: false } }` once the session id is recorded —
+but `updateTaskWith` called `rawSaveTasks` unconditionally, so every hook cost a
+strict re-parse plus a full serialize and atomic write of the whole board.
+
+## Decision
+
+`applyTaskUpdate` (`src/bun/data.ts`) now returns `{ task, changed }` and reports
+`changed: false` for an empty patch or a blocked status guard; `updateTask`,
+`updateTaskWith` and `setTaskTerminalBackend` save only when it is true. This
+matches what `setTaskPriority` and `setTaskTerminalBackend` already did by hand.
+
+On top of that, `captureCodexPaneSession` answers its steady-state no-op from the
+cached read (`codexPaneSessionAlreadyRecorded`) before taking the file lock, so a
+repeat hook does not even re-parse the board strictly.
+
+Guarded by `src/bun/__tests__/data-noop-write.test.ts` and a new case in
+`cli-socket-codex-capture.test.ts`; both assert on the file's inode, since atomic
+saves rename into place and therefore land a new inode on every real write.
+
+## Risks
+
+An empty patch no longer bumps `updatedAt`. Nothing used `updateTask(task, {})` as
+a touch, and a timestamp nobody changed has no reader. A patch whose values merely
+equal the current ones still writes — deep-comparing every field would cost more
+than the write it saves.
+
+## Alternatives considered
+
+Debouncing the Codex hook: hides the cost instead of removing it, and every other
+`updateTaskWith` caller keeps paying it. Shrinking `tasks.json`: worth doing, but
+it lowers the price of a pointless write rather than skipping it.

--- a/src/bun/__tests__/cli-socket-codex-capture.test.ts
+++ b/src/bun/__tests__/cli-socket-codex-capture.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import type { CliRequest, Project, Task } from "../../shared/types";
 
 // End-to-end for Codex per-pane session capture (decision 125): a real
@@ -149,6 +149,33 @@ describe("cli-socket — Codex per-pane session capture (e2e, real data)", () =>
 		const [main] = readPanes();
 		expect(main?.paneId).toBe("%7");
 		expect(main?.sessionId).toBe("codex-main-sess");
+	});
+
+	it("repeating the same hook never rewrites tasks.json", async () => {
+		await import("../data");
+		const { handleRequest } = await import("../cli-socket-server");
+
+		seed([makeTask({ sessionState: { panes: [codexPane("%2", null)] } })]);
+		const tasksFile = join(dev3Home, "data", PROJECT_SLUG, "tasks.json");
+		const hook = agentHook({
+			projectId: "proj-1",
+			taskId: "task-1",
+			event: "UserPromptSubmit",
+			sessionId: "steady-state-sess",
+			paneId: "%2",
+		});
+
+		await handleRequest(hook);
+		expect(readPanes()[0]?.sessionId).toBe("steady-state-sess");
+		// Atomic saves go through rename, so every write lands a NEW inode.
+		const inodeAfterCapture = statSync(tasksFile).ino;
+
+		// Codex fires this hook for the entire life of the session; each repeat used
+		// to cost a full parse+serialize+write of the whole board.
+		for (let i = 0; i < 5; i++) await handleRequest(hook);
+
+		expect(statSync(tasksFile).ino).toBe(inodeAfterCapture);
+		expect(readPanes()[0]?.sessionId).toBe("steady-state-sess");
 	});
 
 	it("is a no-op without a paneId (falls back to resume-last at recovery)", async () => {

--- a/src/bun/__tests__/data-noop-write.test.ts
+++ b/src/bun/__tests__/data-noop-write.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import type { Project, Task } from "../../shared/types";
+
+// A task update that changes nothing must not rewrite tasks.json. On a big board
+// (base44 runs a 14 MB file) an agent hook reporting an already-recorded value
+// used to burn a full parse+serialize+write per call, ~11 times a second, pinning
+// the event loop until the UI froze. See the 2026-08-16 freeze record.
+//
+// Proof is the inode: rawSaveTasks writes atomically through a rename, so every
+// real save lands a new one and a skipped save leaves it alone.
+
+const tempHome = mkdtempSync(join(tmpdir(), "dev3-noop-write-"));
+const dev3Home = join(tempHome, ".dev3.0");
+const originalHome = process.env.HOME;
+
+const PROJECT_PATH = "/tmp/noop-write-project";
+const PROJECT_SLUG = "tmp-noop-write-project";
+const tasksFile = () => join(dev3Home, "data", PROJECT_SLUG, "tasks.json");
+
+function makeProject(): Project {
+	return {
+		id: "proj-1",
+		name: "No-op Write Project",
+		path: PROJECT_PATH,
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt: "2026-08-16T00:00:00.000Z",
+		labels: [],
+	};
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		seq: 1,
+		projectId: "proj-1",
+		title: "No-op task",
+		description: "No-op task",
+		status: "in-progress",
+		baseBranch: "main",
+		worktreePath: null,
+		branchName: null,
+		groupId: null,
+		variantIndex: null,
+		agentId: null,
+		configId: null,
+		createdAt: "2026-08-16T00:00:00.000Z",
+		updatedAt: "2026-08-16T00:00:00.000Z",
+		notes: [],
+		...overrides,
+	};
+}
+
+/**
+ * Seed the board and settle it: the first strict load persists schema migrations,
+ * which is a legitimate write and would otherwise be mistaken for the no-op write
+ * under test. Returns the project and the inode to measure against.
+ */
+async function seedSettled(task: Task): Promise<{ project: Project; inode: number }> {
+	const project = makeProject();
+	writeFileSync(join(dev3Home, "projects.json"), JSON.stringify([project], null, 2));
+	mkdirSync(join(dev3Home, "data", PROJECT_SLUG), { recursive: true });
+	writeFileSync(tasksFile(), JSON.stringify([task], null, 2));
+
+	const data = await import("../data");
+	await data.updateTask(project, task.id, { title: task.title });
+	return { project, inode: statSync(tasksFile()).ino };
+}
+
+describe("data — a no-op task update never rewrites the file", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		process.env.HOME = tempHome;
+		rmSync(tempHome, { recursive: true, force: true });
+		mkdirSync(dev3Home, { recursive: true });
+	});
+
+	afterAll(() => {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	it("updateTaskWith: a mutator returning no updates leaves the file untouched", async () => {
+		const data = await import("../data");
+		const { project, inode } = await seedSettled(makeTask());
+		const settledAt = (await data.loadTasks(project))[0].updatedAt;
+
+		// Five repeats, as an agent hook would fire them.
+		for (let i = 0; i < 5; i++) {
+			const { result } = await data.updateTaskWith(project, "task-1", () => ({
+				updates: {},
+				result: { changed: false },
+			}));
+			expect(result.changed).toBe(false);
+		}
+
+		expect(statSync(tasksFile()).ino).toBe(inode);
+		expect((await data.loadTasks(project))[0].updatedAt).toBe(settledAt);
+	});
+
+	it("updateTaskWith: a mutator returning real updates does write", async () => {
+		const data = await import("../data");
+		const { project, inode } = await seedSettled(makeTask());
+
+		await data.updateTaskWith(project, "task-1", () => ({
+			updates: { title: "Renamed" },
+			result: undefined,
+		}));
+
+		expect(statSync(tasksFile()).ino).not.toBe(inode);
+		expect((await data.loadTasks(project))[0].title).toBe("Renamed");
+	});
+
+	it("updateTask: an empty patch leaves the file untouched", async () => {
+		const data = await import("../data");
+		const { project, inode } = await seedSettled(makeTask());
+		const settledAt = (await data.loadTasks(project))[0].updatedAt;
+
+		const updated = await data.updateTask(project, "task-1", {});
+
+		expect(statSync(tasksFile()).ino).toBe(inode);
+		expect(updated.updatedAt).toBe(settledAt);
+	});
+
+	it("updateTask: a blocked status guard leaves the file untouched", async () => {
+		const data = await import("../data");
+		const { project, inode } = await seedSettled(makeTask({ status: "todo" }));
+
+		const updated = await data.updateTask(project, "task-1", { status: "in-progress" }, { ifStatusNot: "todo" });
+
+		expect(statSync(tasksFile()).ino).toBe(inode);
+		expect(updated.status).toBe("todo");
+	});
+});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -317,6 +317,27 @@ function getCodexApprovalResumeStatus(
 }
 
 /**
+ * Cheap pre-check for {@link captureCodexPaneSession}: is this exact pane already
+ * carrying this exact session id? Reads through the cache (no lock, no strict
+ * re-parse) and answers false on any doubt — a stale or unreadable read only costs
+ * one trip through the real locked path, which is idempotent anyway.
+ */
+async function codexPaneSessionAlreadyRecorded(
+	project: Project,
+	taskId: string,
+	paneId: string,
+	sessionId: string,
+): Promise<boolean> {
+	try {
+		const task = await data.getTask(project, taskId);
+		const pane = task.sessionState?.panes?.find((p) => p.paneId === paneId);
+		return pane?.sessionId === sessionId;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Persist a Codex session id onto the sessionState pane it belongs to, so
  * resumeTask can `codex resume <id>` the exact session per pane — targeted
  * recovery for multi-session worktrees (e.g. reviving several bug hunters).
@@ -330,6 +351,11 @@ function getCodexApprovalResumeStatus(
  * paneId, adopt that entry — it is the main pane — recording both its paneId and
  * session id. Ambiguous cases (no match, ≠1 null-paneId entries) are skipped; a
  * later hook fires once ids settle. A no-op once the id is already recorded.
+ *
+ * The steady state is exactly that no-op — codex fires this hook continuously for
+ * the whole life of a session — so it is answered from the cached read BEFORE
+ * taking the file lock. Going through the lock for it made every hook re-parse the
+ * board strictly (14 MB on base44); see the 2026-08-16 freeze record.
  */
 async function captureCodexPaneSession(
 	project: Project,
@@ -338,6 +364,7 @@ async function captureCodexPaneSession(
 	sessionId: string,
 ): Promise<void> {
 	try {
+		if (await codexPaneSessionAlreadyRecorded(project, taskId, paneId, sessionId)) return;
 		const { task: updated, result } = await data.updateTaskWith(project, taskId, (current) => {
 			const panes = current.sessionState?.panes;
 			if (!panes?.length) return { updates: {}, result: { changed: false } };

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -1004,8 +1004,8 @@ export async function updateTask(
 		const tasks = await rawLoadTasks(project, { strict: true, persistMigrations: true });
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
-		const updatedTask = applyTaskUpdate(tasks, idx, updates, options);
-		await rawSaveTasks(project, tasks);
+		const { task: updatedTask, changed } = applyTaskUpdate(tasks, idx, updates, options);
+		if (changed) await rawSaveTasks(project, tasks);
 		return updatedTask;
 	});
 }
@@ -1026,8 +1026,8 @@ export async function updateTaskWith<T>(
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		const { updates, result } = await mutator(tasks[idx]);
-		const task = applyTaskUpdate(tasks, idx, updates, options);
-		await rawSaveTasks(project, tasks);
+		const { task, changed } = applyTaskUpdate(tasks, idx, updates, options);
+		if (changed) await rawSaveTasks(project, tasks);
 		return { task, result };
 	});
 }
@@ -1103,8 +1103,8 @@ export async function setTaskTerminalBackend(
 		const idx = tasks.findIndex((t) => t.id === taskId);
 		if (idx === -1) throw new Error(`Task not found: ${taskId}`);
 		if (tasks[idx][TERMINAL_BACKEND_FIELD] === backend) return tasks[idx];
-		const updated = applyTaskUpdate(tasks, idx, { [TERMINAL_BACKEND_FIELD]: backend });
-		await rawSaveTasks(project, tasks);
+		const { task: updated, changed } = applyTaskUpdate(tasks, idx, { [TERMINAL_BACKEND_FIELD]: backend });
+		if (changed) await rawSaveTasks(project, tasks);
 		return updated;
 	});
 }
@@ -1235,6 +1235,13 @@ export async function moveTaskToProject(
 	);
 }
 
+/**
+ * Apply `updates` to `tasks[idx]` in place. `changed` tells the caller whether the
+ * array was touched at all, so a no-op never rewrites the file: on a big board
+ * (base44 runs a 14 MB tasks.json) an agent hook that reports an already-recorded
+ * value used to burn a full parse+serialize+write per call, ~11 times a second,
+ * which pinned the event loop and froze the UI. See the 2026-08-16 freeze record.
+ */
 function applyTaskUpdate(
 	tasks: Task[],
 	idx: number,
@@ -1243,11 +1250,16 @@ function applyTaskUpdate(
 		ifStatus?: string;
 		ifStatusNot?: string;
 	},
-): Task {
+): { task: Task; changed: boolean } {
 	const currentTask = tasks[idx];
 	// Authoritative guard check (runs inside the file lock).
 	if (isStatusGuardBlocked(currentTask.status, options)) {
-		return currentTask;
+		return { task: currentTask, changed: false };
+	}
+	// An empty patch carries no information — bumping `updatedAt` for it would be
+	// the only reason to write, and nothing displays a timestamp nobody changed.
+	if (Object.keys(updates).length === 0) {
+		return { task: currentTask, changed: false };
 	}
 	const now = new Date().toISOString();
 	// A move to a different RENDERED column happens either when the builtin status
@@ -1284,7 +1296,7 @@ function applyTaskUpdate(
 
 	recordTitleOverviewHistory(tasks, idx, prevTitle, prevOverview, now);
 
-	return tasks[idx];
+	return { task: tasks[idx], changed: true };
 }
 
 /**


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that investigated and wrote this branch).

The app froze on 2026-08-16 around 10:19. In the three minutes before it was killed, `data.updateTaskWith` logged **1005 writes for a single task, ~11 per second** — all for one Codex task on the base44 board, whose `tasks.json` is **14 MB across 498 tasks**. The same storm had already run 613 times that morning at 07:01-07:08, alongside 1896 `Lock acquisition timed out` warnings across the day.

Cause: `captureCodexPaneSession` runs on every Codex lifecycle hook and calls `data.updateTaskWith`. Its mutator correctly reports "nothing to change" once the session id is recorded, but `updateTaskWith` called `rawSaveTasks` unconditionally — so every hook cost a strict re-parse plus a full serialize and atomic write of the whole board, pinning the main process event loop.

Changes:
- `applyTaskUpdate` returns `{ task, changed }`; an empty patch or a blocked status guard reports `changed: false`, and `updateTask` / `updateTaskWith` / `setTaskTerminalBackend` save only when it is true.
- `captureCodexPaneSession` answers its steady-state no-op from the cached read before taking the file lock.
- New `data-noop-write.test.ts` plus a case in `cli-socket-codex-capture.test.ts`; both assert on the file's inode, since atomic saves rename into place and land a new inode on every real write. All four were confirmed to fail against the pre-fix behaviour.

Worth flagging separately: the enormous `Event loop stall detected` warnings in that log (933 s, 624 s, 424 s) are **not** a bug — each matches a macOS clamshell-sleep window one-to-one in `pmset -g log`. The detector measures wall clock and cannot tell a blocked thread from a sleeping machine, so it hid the real stall. That deserves its own fix.

Details in `decisions/2026/08/16/no-op-task-update-skips-the-write.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=78932327-b3b0-4d4b-9ac8-bd9ce1cc4b71) · `dev3://task/78932327-b3b0-4d4b-9ac8-bd9ce1cc4b71`