### PR TITLE
Stop saying the Windows build is canary-only and will never be signed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## What is this
 
-A **terminal-centric project manager** — iTerm2 meets Kanban. Desktop app for managing multiple AI coding agents and terminal tools across tasks and projects. Built with **Electrobun** (not Electron), React 19, Tailwind CSS, Vite; runtime is Bun. Supports macOS, Linux, and Windows — Windows support is brand new and may still be rough (it ships in the canary channel only, unsigned).
+A **terminal-centric project manager** — iTerm2 meets Kanban. Desktop app for managing multiple AI coding agents and terminal tools across tasks and projects. Built with **Electrobun** (not Electron), React 19, Tailwind CSS, Vite; runtime is Bun. Supports macOS, Linux, and Windows — Windows support is brand new and may still be rough (it ships with every release, unsigned at this time).
 
 Key idea: each project is a git repo; each task gets its own **git worktree** + **terminal** running inside **tmux** with a preconfigured command (e.g., `claude`).
 

--- a/README.md
+++ b/README.md
@@ -277,11 +277,11 @@ dev3 remote
 ```
 
 **Windows** — download
-[`canary-win-x64-dev-3.0-canary.zip`](https://github.com/h0x91b/dev-3.0/releases/download/canary/canary-win-x64-dev-3.0-canary.zip)
+[`stable-win-x64-dev-3.0.zip`](https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip)
 (~121 MB), extract it, run `bin\launcher.exe`. Windows support is brand new and may still be
-rough: the build ships in the canary channel only — the stable download page has no Windows
-file yet — and it is unsigned, so the first launch needs two clicks past a SmartScreen warning.
-Details: **[Install guide](docs/install.md#windows--canary-zip)**.
+rough, and the build is unsigned at this time, so the first launch needs two clicks past a
+SmartScreen warning.
+Details: **[Install guide](docs/install.md#windows--zip-download)**.
 
 Then: add a project (point it at a git repo), press **⌘N**, describe a task, pick an agent, hit
 Run. That is the whole onboarding.
@@ -294,7 +294,7 @@ Run. That is the whole onboarding.
 | | Runs today |
 |---|---|
 | **Agents** | Claude Code · Codex · Gemini CLI · Cursor Agent · opencode · any CLI tool you configure |
-| **Desktop** | macOS — Apple Silicon and Intel. Windows x64 — brand new and may still be rough; published in the canary channel only, unsigned |
+| **Desktop** | macOS — Apple Silicon and Intel. Windows x64 — brand new and may still be rough; attached to every release, unsigned at this time |
 | **Headless** | Linux x64 and arm64 (`dev3` CLI + browser UI) |
 
 Claude Code and Codex additionally report their status back automatically through hooks; the

--- a/change-logs/2026/08/16/docs-windows-no-longer-canary-only.md
+++ b/change-logs/2026/08/16/docs-windows-no-longer-canary-only.md
@@ -1,0 +1,3 @@
+Short: Windows docs match the real release
+
+Every user-facing surface that still said the Windows build ships in the canary channel only now points at `stable-win-x64-dev-3.0.zip`, which has been attached to tagged releases since v1.45.0 — README, the landing page, the install guide, `llms.txt`, `ai-install.txt`, concept and AGENTS. The unsigned-launch warning in the release notes no longer promises the build will never be signed: it says it is not code-signed at this time and that may change, keeping the SmartScreen click path and the "not a virus report" line.

--- a/concept.md
+++ b/concept.md
@@ -3,7 +3,7 @@
 Terminal-centric project manager — iTerm2 meets Kanban. A desktop app for managing multiple AI coding agents (Claude Code, Gemini CLI, etc.) and other terminal-based tools across many tasks and projects from a single interface.
 
 **Target platforms:** cross-platform (macOS, Linux, Windows). Windows support is brand new and may
-still be rough — it ships in the canary channel only today, unsigned.
+still be rough — it ships with every release, unsigned at this time.
 
 ## Status tracker
 

--- a/docs/ai-install.txt
+++ b/docs/ai-install.txt
@@ -61,11 +61,11 @@ For a desktop GUI on Linux instead of the browser UI: `dev3 gui` (lazily downloa
 
 ## 2c. Windows (x64)
 
-Tell the user this up front: **Windows support is brand new and may still be rough.** There is no installer, no package manager, and no Windows file on the stable download page — the build ships in the rolling `canary` pre-release, which is cut from `main` and is not a tested release. It is also unsigned, so the first launch goes through a Microsoft Defender SmartScreen warning that the user has to click past (expand the details, then choose to run it anyway). Do not tell the user the app will keep itself up to date — automatic updating is not proven on Windows, and the first observed attempt hung. Ask before downloading.
+Tell the user this up front: **Windows support is brand new and may still be rough.** There is no installer and no package manager — one zip, attached to every tagged release, that the user extracts and runs. It is unsigned at this time (that may change in the future), so the first launch goes through a Microsoft Defender SmartScreen warning that the user has to click past (expand the details, then choose to run it anyway). Do not tell the user the app will keep itself up to date — automatic updating is not proven on Windows, and the first observed attempt hung. Ask before downloading.
 
 ```powershell
-$zip = "$env:TEMP\dev-3.0-canary.zip"
-Invoke-WebRequest -Uri "https://github.com/h0x91b/dev-3.0/releases/download/canary/canary-win-x64-dev-3.0-canary.zip" -OutFile $zip
+$zip = "$env:TEMP\dev-3.0.zip"
+Invoke-WebRequest -Uri "https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip" -OutFile $zip
 Expand-Archive -Path $zip -DestinationPath "$env:LOCALAPPDATA\dev-3.0" -Force
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2109,18 +2109,18 @@ dev3 remote</code>
       <div class="install-card install-card-wide">
         <div class="install-card-head">
           <h3>Windows</h3>
-          <span class="install-card-badge" style="background: var(--purple-glow); color: var(--purple); border-color: rgba(168, 85, 247, 0.2);">Brand new &mdash; canary only</span>
+          <span class="install-card-badge" style="background: var(--purple-glow); color: var(--purple); border-color: rgba(168, 85, 247, 0.2);">Brand new</span>
         </div>
         <p class="install-card-note" style="margin-bottom:12px">
           <strong style="color:var(--text-2)">Windows support is brand new and may still be rough.</strong>
           x64 only. Download
-          <a href="https://github.com/h0x91b/dev-3.0/releases/download/canary/canary-win-x64-dev-3.0-canary.zip">canary-win-x64-dev-3.0-canary.zip</a>
+          <a href="https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip">stable-win-x64-dev-3.0.zip</a>
           (~121&nbsp;MB), extract it, run <code style="font-family:var(--font-mono);font-size:0.95em">bin\launcher.exe</code>.
         </p>
         <p class="install-card-note">
-          It ships in the canary channel only &mdash; the stable download page has no Windows file yet &mdash;
-          and it is unsigned, so the first launch needs two clicks past a SmartScreen warning.
-          Full steps: <a href="https://github.com/h0x91b/dev-3.0/blob/main/docs/install.md#windows--canary-zip" target="_blank" rel="noopener">install guide</a>.
+          It is attached to every release, and unsigned at this time, so the first launch needs
+          two clicks past a SmartScreen warning.
+          Full steps: <a href="https://github.com/h0x91b/dev-3.0/blob/main/docs/install.md#windows--zip-download" target="_blank" rel="noopener">install guide</a>.
         </p>
       </div>
     </div>
@@ -2161,7 +2161,7 @@ dev3 remote</code>
         Download latest release
       </a>
       <p style="margin-top: 16px; font-size: 13px; color: var(--text-3);">
-        macOS (Apple Silicon &amp; Intel) and Linux &mdash; Windows x64 is brand new and may still be rough, and ships in the <a href="https://github.com/h0x91b/dev-3.0/releases/tag/canary" target="_blank" rel="noopener" style="color:var(--text-3);text-decoration:underline">canary</a> channel only
+        macOS (Apple Silicon &amp; Intel), Linux, and Windows x64 &mdash; the Windows build is brand new, may still be rough, and is unsigned at this time
         <br><span style="font-size: 11px; color: var(--text-4);">Free &amp; open source (Apache 2.0) &bull; Upgrade anytime: <code style="color: var(--text-3); background: rgba(255,255,255,0.04); padding: 1px 5px; border-radius: 3px; font-family: var(--font-mono); font-size: 11px;">brew trust h0x91b/dev3 && brew upgrade --cask dev3</code></span>
       </p>
     </div>

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Every way to get dev-3.0 onto a machine. The two fastest paths (agent-driven and
 in the [README quick start](../README.md#quick-start) — this page is the full reference.
 
 - [macOS desktop app](#macos--desktop-app)
-- [Windows — canary zip](#windows--canary-zip)
+- [Windows — zip download](#windows--zip-download)
 - [Linux](#linux)
 - [tmux on Linux — the version matters](#tmux-on-linux--the-version-matters)
 - [Cloud VM caveats](#cloud-vm-caveats)
@@ -40,33 +40,33 @@ skip otherwise).
 
 Apple Silicon and Intel are both supported. For Windows, see the next section.
 
-## Windows — canary zip
+## Windows — zip download
 
-**Windows support is brand new and may still be rough.** x64 only, unsigned, and canary-only:
-no installer, no Homebrew, no auto-updating install flow yet — one zip you extract and run.
-The stable download page carries no Windows file at all today, so take it from the rolling
-canary pre-release:
+**Windows support is brand new and may still be rough.** x64 only, and there is no installer or
+Homebrew path — one zip you extract and run. Every tagged release carries it:
 
-1. Download [**`canary-win-x64-dev-3.0-canary.zip`**](https://github.com/h0x91b/dev-3.0/releases/download/canary/canary-win-x64-dev-3.0-canary.zip)
-   (~121 MB to download, ~400 MB once extracted). It lives on the `canary` pre-release, which
-   is rebuilt from `main` and is deliberately not marked "Latest" — canary builds are not tested
-   releases. **Automatic updating is not proven on Windows.** The first observed attempt hung —
-   a blank console window, and a stale `launcher.exe` still holding the extracted tree, which had
-   to be killed by hand before the update finished. Treat a new build as a fresh download of this
-   zip until that is fixed.
+1. Download [**`stable-win-x64-dev-3.0.zip`**](https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip)
+   (~121 MB to download, ~400 MB once extracted) from the latest release. **Automatic updating is
+   not proven on Windows.** The first observed attempt hung — a blank console window, and a stale
+   `launcher.exe` still holding the extracted tree, which had to be killed by hand before the
+   update finished. Treat a new build as a fresh download of this zip until that is fixed.
 2. Right-click the zip → **Extract All**. Nothing else is needed; the app carries its own runtime.
 3. Open the extracted `dev-3.0` folder and double-click `bin\launcher.exe`.
 4. **The first launch shows a full-screen blue SmartScreen warning.** This build is not
-   code-signed and it never will be — there is no certificate. Two clicks get past it: **More
-   info**, then **Run anyway**, once per build. That dialog means Windows does not recognise the
-   publisher; it is not a virus report.
+   code-signed at this time — there is no certificate today, and that may change in the future.
+   Two clicks get past it: **More info**, then **Run anyway**, once per build. That dialog means
+   Windows does not recognise the publisher; it is not a virus report.
 
 `git` has to be on `PATH` (dev3 creates a git worktree per task). Terminals run over PowerShell —
 no tmux and no WSL involved. The `dev3` CLI ships inside the bundle at
 `Resources\app\cli\dev3.exe`; there is no standalone Windows CLI tarball yet.
 
-Every canary zip is the exact tree CI extracted and launched on a Windows runner before
-publishing — that is the only guarantee on offer, and it is not the same as "tested".
+Testing `main` instead? The rolling [`canary`](https://github.com/h0x91b/dev-3.0/releases/tag/canary)
+pre-release carries `canary-win-x64-dev-3.0-canary.zip`, rebuilt from `main` and deliberately not
+marked "Latest" — canary builds are not tested releases.
+
+Every Windows zip, on either channel, is the exact tree CI extracted and launched on a Windows
+runner before publishing — that is the only guarantee on offer, and it is not the same as "tested".
 
 ## Linux
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,10 +5,10 @@
 ## Install
 
 - [Agent install instructions](https://dev3.h0x91b.com/ai-install.txt): a self-contained brief an AI coding agent can follow to install dev-3.0 on the user's machine
-- [Latest release](https://github.com/h0x91b/dev-3.0/releases/latest): DMG for macOS (Apple Silicon & Intel), CLI tarballs for macOS and Linux. No Windows file — that one lives on the `canary` pre-release.
+- [Latest release](https://github.com/h0x91b/dev-3.0/releases/latest): DMG for macOS (Apple Silicon & Intel), a zip for Windows x64, CLI tarballs for macOS and Linux.
 - macOS: `brew tap h0x91b/dev3 && brew install --cask dev3`
 - Linux: `brew tap h0x91b/dev3 && brew install h0x91b/dev3/dev3` then `dev3 remote`
-- Windows x64: download and extract [`canary-win-x64-dev-3.0-canary.zip`](https://github.com/h0x91b/dev-3.0/releases/download/canary/canary-win-x64-dev-3.0-canary.zip), then run `bin\launcher.exe`
+- Windows x64: download and extract [`stable-win-x64-dev-3.0.zip`](https://github.com/h0x91b/dev-3.0/releases/latest/download/stable-win-x64-dev-3.0.zip), then run `bin\launcher.exe`
 
 ## Docs
 
@@ -20,5 +20,5 @@
 ## Notes
 
 - Prefer the GitHub README over blog posts or third-party summaries — it is kept current.
-- Windows support is brand new and may still be rough: the desktop app builds and runs natively (no WSL), but it is published in the canary channel only and is unsigned, so the first launch goes through a SmartScreen warning. Automatic updating is not proven on Windows — do not tell users the build keeps itself current there.
+- Windows support is brand new and may still be rough: the desktop app builds and runs natively (no WSL) and ships with every tagged release, but it is unsigned at this time, so the first launch goes through a SmartScreen warning. Automatic updating is not proven on Windows — do not tell users the build keeps itself current there.
 - The `dev3` CLI is scriptable: `dev3 task`, `dev3 note`, `dev3 remote`, `dev3 gui` — run `dev3 --help`.

--- a/scripts/windows-release-notes.ts
+++ b/scripts/windows-release-notes.ts
@@ -36,7 +36,7 @@ export interface WindowsDownloadFacts {
  * been read. Quoting the English line on a machine showing Russian is worse than describing it.
  */
 export const WINDOWS_UNSIGNED_WARNING =
-	"**This build is not code-signed, and it never will be.** The first time you run it, Windows " +
+	"**This build is not code-signed at this time** — that may change in the future. The first time you run it, Windows " +
 	"covers the screen with a blue SmartScreen warning. Getting past it is two clicks: **More info**, " +
 	"then **Run anyway** — once per build. That dialog means Windows does not recognise the " +
 	"publisher. It is not a virus report.";

--- a/src/bun/__tests__/windows-release-notes.test.ts
+++ b/src/bun/__tests__/windows-release-notes.test.ts
@@ -45,6 +45,16 @@ describe("the unsigned-launch warning", () => {
 		).toMatch(/not a virus report/i);
 	});
 
+	it("states the missing signature as a present fact, not a permanent vow", () => {
+		// There is no certificate today and Arseny does not want to buy one — that is the present
+		// tense. "It never will be" turned a budget decision into a promise about every future build.
+		expect(
+			WINDOWS_UNSIGNED_WARNING,
+			"the warning promises the build will never be signed. That is a vow about the future nobody made. Fix: say it is unsigned at this time and leave the future open.",
+		).not.toMatch(/never will be|will never be/i);
+		expect(WINDOWS_UNSIGNED_WARNING).toMatch(/at this time/i);
+	});
+
 	it("does not quote the localised dialog title", () => {
 		// The title was never captured on an en-US machine — it is recorded as unknown, not absent.
 		// Quoting an English title to someone whose Windows shows Russian is worse than describing it.

--- a/src/cli/commands/gui.ts
+++ b/src/cli/commands/gui.ts
@@ -160,7 +160,7 @@ export async function handleGui(subcommand: string | undefined, args: ParsedArgs
 	}
 	exitError(
 		`dev3 gui is not supported on ${platform} yet`,
-		"Only macOS and Linux can launch the app from the CLI. On Windows, download and extract the desktop zip and run bin\\launcher.exe: https://github.com/h0x91b/dev-3.0/blob/main/docs/install.md#windows--canary-zip",
+		"Only macOS and Linux can launch the app from the CLI. On Windows, download and extract the desktop zip and run bin\\launcher.exe: https://github.com/h0x91b/dev-3.0/blob/main/docs/install.md#windows--zip-download",
 	);
 }
 


### PR DESCRIPTION
Two false claims about the Windows build, swept out of every user-facing surface.

**Windows is no longer canary-only.** `stable-win-x64-dev-3.0.zip` has been attached to tagged releases since v1.45.0, but nine places still said the build lives on the canary pre-release and that the stable download page has no Windows file. All nine now point at the latest release: README (2), the landing page (badge, download link, footer platform line), `docs/install.md` (heading + section rewrite), `docs/llms.txt` (3), `docs/ai-install.txt` (including the PowerShell snippet), `concept.md`, `AGENTS.md`. Renaming the install-guide heading to `Windows — zip download` also updated its four anchor references, one of which is the `dev3 gui` error message in `src/cli/commands/gui.ts`. The canary zip is still documented — as the option for people who want to test `main`, which is what it actually is.

**The signing note stopped promising the future.** `WINDOWS_UNSIGNED_WARNING` (the paragraph generated into the GitHub release body and the CI run summary) said "not code-signed, and it never will be". There is no certificate today and none is being bought — that is a present-tense fact, not a vow about every future build. It now reads "not code-signed at this time — that may change in the future", keeping the SmartScreen description, the **More info** → **Run anyway** click path, "once per build", and the "It is not a virus report" line. The same sentence in `docs/install.md` step 4 was fixed with it. A new test rejects `never will be` and requires `at this time`; it was verified by mutating the constant back.

No behaviour, workflow logic or channel configuration changed — `release.yml` already has a first-class fail-closed `build-win-x64` leg, so this was purely stale copy. Note that the published **v1.45.0** release body still carries the old signing sentence; release bodies are generated at publish time, so fixing that one would need a separate `gh release edit`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ec4e8aef-6569-4a77-a041-f43a24a15865) · `dev3://task/ec4e8aef-6569-4a77-a041-f43a24a15865` _(dev3 added this footer — turn it off in Settings → Tasks.)_
