### PR TITLE
feat(telemetry): add a build-time VITE_TELEMETRY opt-out flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 VITE_POSTHOG_KEY=your_posthog_project_token
 VITE_POSTHOG_HOST=https://your-posthog-host
+
+# Telemetry switch, read at build time. `on` (the default when unset) keeps
+# Google Analytics and PostHog as they are; `off` compiles both out of the
+# bundle, including the public-IP lookup GA4 uses for geolocation.
+VITE_TELEMETRY=on

--- a/README.md
+++ b/README.md
@@ -315,6 +315,26 @@ rate-limit tracking and skill directories differ per agent — the full grid is 
 | [Diagnostic logs](docs/diagnostic-logs.md) | What is logged locally, for how long, and what is redacted |
 | [AGENTS.md](AGENTS.md) | Architecture and contributor guide |
 
+## Telemetry
+
+The app reports usage analytics so the project can see what is actually used:
+
+| Channel | What it sends |
+|---|---|
+| Google Analytics 4 | App launch, version, OS, screen resolution, language, screen navigation, a 10-minute heartbeat, agent launches, and unhandled errors. Identified by a random per-install id, geolocated via a public-IP lookup against `api.ipify.org`. Project *names* and file paths are deliberately never sent — only internal ids. |
+| PostHog | Task and project actions (created, moved, merged, pushed …) plus unhandled errors, under a random per-install id. Also delivers feature flags. Live in the official release builds; a build from source has no key and stays off. |
+
+Both are compiled in at build time and can be compiled out. Build from source with
+`VITE_TELEMETRY=off` in the repo-root `.env` (or in the environment) and no analytics code runs:
+no GA4 hits, no public-IP lookup, no PostHog client, no error autocapture. Feature flags then
+fall back to their shipped defaults. Leaving the variable unset means `on`, which is what the
+released binaries do.
+
+```bash
+echo 'VITE_TELEMETRY=off' >> .env
+bun run build
+```
+
 ## Development
 
 ```bash

--- a/change-logs/2026/08/16/feature-telemetry-opt-out.md
+++ b/change-logs/2026/08/16/feature-telemetry-opt-out.md
@@ -1,0 +1,3 @@
+Short: Build with telemetry off
+
+A build-time `VITE_TELEMETRY` flag can turn every analytics channel off. Setting `VITE_TELEMETRY=off` in the root `.env` compiles out the Google Analytics hits, the public-IP lookup that geolocates them, and the PostHog client, leaving feature flags on their shipped defaults. Unset still means on, so released builds and existing local builds behave exactly as before.

--- a/decisions/2026/08/16/telemetry-build-time-opt-out.md
+++ b/decisions/2026/08/16/telemetry-build-time-opt-out.md
@@ -1,0 +1,45 @@
+# Telemetry opt-out is a build-time flag, defaulting to on
+
+## Context
+
+Two analytics channels ship in the renderer — GA4 through the Measurement Protocol
+(`src/mainview/analytics.ts`) and PostHog (`src/mainview/posthog.ts`) — and neither had any way
+to turn off. People who build from source, and distributions that repackage the app, need a
+switch they can prove is off, not a runtime setting a future release could quietly reset.
+
+## Investigation
+
+Gating only the GA transport is not enough. `sendToGA` carries the seven event types, but
+`initAnalytics` separately fires the `api.ipify.org` lookup that supplies `ip_override`, starts
+the 10-minute heartbeat interval, and installs the global `error` / `unhandledrejection`
+listeners — none of which pass through `sendToGA`. PostHog needs its own gate because it turns
+itself on from build-time keys the release workflows inject, so "leave the key unset" is not a
+switch a downstream builder controls.
+
+## Decision
+
+One flag, `VITE_TELEMETRY`, read through `telemetryEnabled()` in `src/mainview/telemetry.ts`:
+anything other than the literal `off` means on, so an absent variable keeps today's behaviour
+exactly. `off` early-returns from both `sendToGA` and `initAnalytics`, and forces `posthog.ts`
+onto its existing no-op client regardless of `VITE_POSTHOG_KEY`/`VITE_POSTHOG_HOST` — which also
+suppresses the DEV-mode "key missing" throw, since a build that asked for no telemetry is not
+misconfigured. The flag is read per call rather than captured in a module constant so
+`vi.stubEnv` can flip it in tests; Vite still constant-folds it, and a `VITE_TELEMETRY=off`
+bundle compiles the helper down to `return !1` with both entry points returning before any
+network call.
+
+## Risks
+
+Feature flags stop being served when telemetry is off and fall back to `FEATURE_FLAG_DEFAULTS`
+in `src/shared/feature-flags.ts` — the same path a keyless source build already takes, so it is
+supported rather than new. `posthog-js` is still statically imported and therefore still in the
+bundle when off; it is never initialized, and removing it would mean making the module's export
+async. The default being on means the flag protects nobody who does not set it, which is the
+deliberate trade for leaving released builds untouched.
+
+## Alternatives considered
+
+A runtime settings toggle would be discoverable but leaves the code paths live and depends on
+the setting surviving every future migration. Honouring `DO_NOT_TRACK` / `navigator.doNotTrack`
+would change behaviour for existing users without them asking, which is exactly what the default
+is meant to avoid; the build-time flag can be composed with either later.

--- a/src/mainview/__tests__/analytics.test.ts
+++ b/src/mainview/__tests__/analytics.test.ts
@@ -513,3 +513,48 @@ describe("engagement_time_msec (real foreground time)", () => {
 		expect(initHit.events[1].params.engagement_time_msec).toBeUndefined();
 	});
 });
+
+describe("VITE_TELEMETRY=off", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.stubEnv("VITE_TELEMETRY", "off");
+		vi.useFakeTimers();
+		for (const key of Object.keys(store)) delete store[key];
+		destroyAnalytics();
+		fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+		fetchMock.mockClear();
+	});
+
+	afterEach(() => {
+		destroyAnalytics();
+		vi.useRealTimers();
+		vi.unstubAllEnvs();
+	});
+
+	it("makes no request at all on init — neither the GA hit nor the public-IP lookup", () => {
+		initAnalytics("1.0.0");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("starts no heartbeat", () => {
+		initAnalytics("1.0.0");
+		vi.advanceTimersByTime(60 * 60 * 1000);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("drops every explicit track call", () => {
+		initAnalytics("1.0.0");
+		trackEvent("ping");
+		trackPageView({ screen: "dashboard" });
+		trackDiffView("p1", "981-1");
+		trackAgentLaunched([], null, null);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("resumes sending once the flag is back to its default", () => {
+		vi.unstubAllEnvs();
+		initAnalytics("1.0.0");
+		expect(gaHits(fetchMock).length).toBe(1);
+	});
+});

--- a/src/mainview/__tests__/posthog-telemetry.test.ts
+++ b/src/mainview/__tests__/posthog-telemetry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * VITE_TELEMETRY=off has to outrank a configured PostHog key — "no telemetry" is a
+ * property of the build, not of whether someone remembered to leave the key out.
+ * The no-op client must still answer the flag APIs so feature-flags.ts lands on
+ * the shipped defaults instead of throwing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { posthogJs } = vi.hoisted(() => ({
+	posthogJs: {
+		init: vi.fn(() => ({
+			capture: vi.fn(),
+			getFeatureFlag: vi.fn(() => true),
+			onFeatureFlags: vi.fn(() => () => undefined),
+			reloadFeatureFlags: vi.fn(),
+			get_distinct_id: vi.fn(() => "real-id"),
+		})),
+	},
+}));
+
+vi.mock("posthog-js", () => ({ default: posthogJs }));
+// test-setup.ts mocks this module globally; this suite exercises the real one.
+vi.unmock("../posthog");
+
+async function loadClient() {
+	vi.resetModules();
+	return (await import("../posthog")).default;
+}
+
+beforeEach(() => {
+	posthogJs.init.mockClear();
+	vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_key");
+	vi.stubEnv("VITE_POSTHOG_HOST", "https://posthog.test");
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("posthog build-time telemetry gate", () => {
+	it("initializes when VITE_TELEMETRY is unset — the default is on", async () => {
+		const client = await loadClient();
+		expect(posthogJs.init).toHaveBeenCalledWith(
+			"phc_test_key",
+			expect.objectContaining({ api_host: "https://posthog.test" }),
+		);
+		expect(client.getFeatureFlag("anything")).toBe(true);
+	});
+
+	it("initializes with VITE_TELEMETRY=on", async () => {
+		vi.stubEnv("VITE_TELEMETRY", "on");
+		await loadClient();
+		expect(posthogJs.init).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not initialize with VITE_TELEMETRY=off, key and host notwithstanding", async () => {
+		vi.stubEnv("VITE_TELEMETRY", "off");
+		const client = await loadClient();
+		expect(posthogJs.init).not.toHaveBeenCalled();
+		expect(client.capture("task_created")).toBeUndefined();
+	});
+
+	it("falls back to shipped feature-flag defaults when off", async () => {
+		vi.stubEnv("VITE_TELEMETRY", "off");
+		const client = await loadClient();
+		expect(client.getFeatureFlag("any-flag")).toBeUndefined();
+		expect(client.get_distinct_id()).toBe("");
+		expect(client.onFeatureFlags(() => undefined)).toBeTypeOf("function");
+	});
+});

--- a/src/mainview/analytics.ts
+++ b/src/mainview/analytics.ts
@@ -5,6 +5,7 @@
 import type { CodingAgent } from "../shared/types";
 import type { Route } from "./state";
 import { api } from "./rpc";
+import { telemetryEnabled } from "./telemetry";
 import { randomUUID } from "./uuid";
 
 const GA_MEASUREMENT_ID = "G-L1NSQH6FGY";
@@ -192,6 +193,8 @@ function flushEngagementMs(): number {
 }
 
 function sendToGA(events: Array<{ name: string; params?: Record<string, unknown> }>): void {
+	if (!telemetryEnabled()) return;
+
 	// Flush once per hit and attach only to the first event — GA4 sums
 	// engagement_time_msec across events, so repeating it would multi-count the
 	// same interval. Floor at 1 so every hit carries a positive engagement.
@@ -222,6 +225,10 @@ function sendToGA(events: Array<{ name: string; params?: Record<string, unknown>
 
 /** Initialize GA4 with user properties and start heartbeat. */
 export function initAnalytics(appVersion: string): void {
+	// Gated separately from sendToGA: the ipify lookup, the heartbeat interval and
+	// the global error listeners below never pass through the transport.
+	if (!telemetryEnabled()) return;
+
 	clientId = getOrCreateClientId();
 	sessionId = getOrCreateSessionId();
 	sessionStartTime = Date.now();

--- a/src/mainview/posthog.ts
+++ b/src/mainview/posthog.ts
@@ -1,9 +1,13 @@
 import posthog from "posthog-js";
+import { telemetryEnabled } from "./telemetry";
 
+// VITE_TELEMETRY=off outranks a configured key: the build asked for no
+// telemetry, so a missing key is not a misconfiguration worth shouting about.
+const telemetry = telemetryEnabled();
 const apiKey = import.meta.env.VITE_POSTHOG_KEY;
 const apiHost = import.meta.env.VITE_POSTHOG_HOST;
 
-if ((!apiKey || !apiHost) && import.meta.env.DEV) {
+if (telemetry && (!apiKey || !apiHost) && import.meta.env.DEV) {
 	const variableName = !apiKey ? "VITE_POSTHOG_KEY" : "VITE_POSTHOG_HOST";
 	throw new Error(
 		`${variableName} variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once ${variableName} is configured`,
@@ -12,8 +16,8 @@ if ((!apiKey || !apiHost) && import.meta.env.DEV) {
 
 // The flag APIs are exposed next to capture so feature-flags.ts can refresh and
 // read flags; the rest of the posthog surface stays out of reach. With no key
-// configured the no-op client reports every flag as unset, which lands the app
-// on the shipped defaults in src/shared/feature-flags.ts.
+// configured — or telemetry off — the no-op client reports every flag as unset,
+// which lands the app on the shipped defaults in src/shared/feature-flags.ts.
 type PostHogClient = Pick<
 	typeof posthog,
 	"capture" | "getFeatureFlag" | "onFeatureFlags" | "reloadFeatureFlags" | "get_distinct_id"
@@ -26,7 +30,7 @@ type PostHogClient = Pick<
 // keeps the id it already had, and bun seeds itself from that same id.
 const injectedDistinctId = (window as unknown as { __DEV3_DISTINCT_ID__?: string }).__DEV3_DISTINCT_ID__;
 
-const client: PostHogClient = apiKey && apiHost
+const client: PostHogClient = telemetry && apiKey && apiHost
 	? posthog.init(apiKey, {
 		api_host: apiHost,
 		defaults: "2026-05-30",

--- a/src/mainview/telemetry.ts
+++ b/src/mainview/telemetry.ts
@@ -1,0 +1,5 @@
+// Build-time switch shared by every telemetry channel. Read per call so Vite
+// constant-folds it in a build while `vi.stubEnv` can still flip it in tests.
+export function telemetryEnabled(): boolean {
+	return import.meta.env.VITE_TELEMETRY !== "off";
+}


### PR DESCRIPTION
## Problem

There is currently no way to build dev3 with analytics turned off. GA4 (`src/mainview/analytics.ts`) initializes unconditionally from `main.tsx`, and PostHog (`src/mainview/posthog.ts`) turns itself on whenever `VITE_POSTHOG_KEY` + `VITE_POSTHOG_HOST` are present. There is no setting, no environment variable and no CLI flag for either. People who build from source — and anyone repackaging the app for a team or a distro — occasionally need to be able to say "this build sends nothing", and today they can only do that by patching the source.

## Design

One build-time flag, `VITE_TELEMETRY`, following the existing `VITE_POSTHOG_*` convention (root `.env`, documented in `.env.example`).

- **Default is `on`.** Anything other than the literal string `off` — including the variable being absent — behaves exactly as today. Nothing changes for existing users, source builds, or the release workflows.
- It is read through `telemetryEnabled()` in the new `src/mainview/telemetry.ts`, per call rather than in a module constant, so Vite still constant-folds it in a build while `vi.stubEnv` can flip it in tests.

## What `VITE_TELEMETRY=off` disables

| Gate | Why it is needed |
|---|---|
| `sendToGA()` | The single transport every GA4 event passes through — covers `first_visit`, `session_start`, `app_update`, `page_view`, `heartbeat`, `agent_launched`, `app_exception` without touching any `trackEvent` call site. |
| `initAnalytics()` | Gated **separately**, because three things never reach `sendToGA`: the `api.ipify.org` public-IP lookup that supplies `ip_override`, the 10-minute heartbeat `setInterval`, and the global `error` / `unhandledrejection` listeners installed by `setupErrorTracking()`. |
| `posthog.ts` | Forced onto the pre-existing no-op client **even when a key and host are configured**, so the flag is authoritative rather than "don't set a key". This also suppresses the DEV-mode "key missing" throw — a build that asked for no telemetry is not misconfigured. |

Feature flags keep working: the no-op client reports every flag as unset, which lands on `FEATURE_FLAG_DEFAULTS` in `src/shared/feature-flags.ts` — the same path a keyless source build already takes.

Nothing was removed and nothing else was refactored; this only adds the switch.

## How to verify

```bash
bun install
bun run lint
bun run test

# gate closed
echo 'VITE_TELEMETRY=off' >> .env
bun run build
grep -o 'function [A-Za-z0-9_$]*(){return!1}' dist/assets/index-*.js
grep -o 'if(![A-Za-z0-9_$]*())return;let [a-z]=String(Math.max' dist/assets/index-*.js
```

On my machine the helper compiled down to `function Xl(){return!1}`, with `if(!Xl())return;` sitting in front of both the `fetch(<GA endpoint>)` in `sendToGA` and the `resolvePublicIp()` call in `initAnalytics`. Building without the variable (or with `VITE_TELEMETRY=on`) produces `function Xl(){return!0}` instead, i.e. today's behaviour.

`posthog-js` is still statically imported and therefore still present in the bundle when off; it is simply never initialized (`Ql&&eu?…init(…):{capture:()=>void 0,…}` with `Ql` folded to `false`). Making it disappear entirely would require an async module export, which felt like more churn than this PR is worth — noted in the decision record.

## Tests

- `src/mainview/__tests__/analytics.test.ts` — a new `VITE_TELEMETRY=off` block: no request at all on init (neither the GA hit nor the ipify lookup), no heartbeat after an hour of fake timers, every explicit `trackEvent` / `trackPageView` / `trackDiffView` / `trackAgentLaunched` dropped, and sending resumes once the stub is removed. The rest of the file continues to exercise the live transport.
- `src/mainview/__tests__/posthog-telemetry.test.ts` — new: initializes when the flag is unset and when it is `on`; does **not** initialize with `off` despite a key and host being stubbed; the no-op client still answers the flag APIs.

Local run: `bun run lint` clean; `bun run test` green for mainview (255 files / 3848 tests) and cli (44 / 782). The bun project shows 10 failures in `src/bun/__tests__/native-pane-owner-forward.test.ts` (`listen EINVAL` — my temp dir blows past the macOS 104-char `sun_path` limit); they reproduce identically on a clean checkout of `main`, so they are environmental and unrelated.

## Also in this PR

- `change-logs/2026/08/16/feature-telemetry-opt-out.md`
- `decisions/2026/08/16/telemetry-build-time-opt-out.md` — why build-time and why the default is `on`
- A short **Telemetry** section in `README.md` stating what each channel sends and how to build with it off, plus the flag in `.env.example`. Happy to reword or drop that section if you would rather document it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
