### PR TITLE
Bound every tmux spawn so an unresponsive server cannot freeze the app

### DIFF
--- a/change-logs/2026/08/16/fix-bound-every-tmux-spawn.md
+++ b/change-logs/2026/08/16/fix-bound-every-tmux-spawn.md
@@ -1,0 +1,3 @@
+Short: App no longer freezes on startup
+
+Fixed the app hanging forever on the "Checking system…" startup screen, where Reload and Retry both re-armed the freeze. Every tmux command now gives up and cleans up after itself instead of waiting on an unresponsive tmux server — previously an unanswered command waited forever, and the pane pollers could pile up thousands of stuck tmux processes that saturated the machine and froze the app.

--- a/decisions/2026/08/16/bound-every-tmux-spawn.md
+++ b/decisions/2026/08/16/bound-every-tmux-spawn.md
@@ -1,0 +1,86 @@
+# Bound every tmux spawn, with a default timeout on the client
+
+## Context
+
+A user's app (v1.44.0, macOS, bundled tmux 3.6a) froze at startup on the
+"Checking system…" bootstrap phase and never recovered. Reload and Retry both
+re-armed the freeze. It had been stuck for ~20 minutes when reported.
+
+## Investigation
+
+The user's log named the hang precisely: `checkSystemRequirements` logged
+`-> checkSystemRequirements`, `git: found` and `tmux: found`, then neither
+`tmux binary set to` nor `<- checkSystemRequirements`. 13 invocations, 2
+completions. The only await in that gap is `commitTmuxBinary` →
+`selectTmuxBinary` → `probeTmuxServer`, which spawned
+`tmux -L dev3 display-message -p '#{version}'` and did a bare
+`await proc.exited`. A tmux client whose server does not answer never exits, so
+that RPC never settled; `App.tsx` holds `reqStatus === "checking"` until it
+does.
+
+That was the hang, but not the cause. A process listing from the machine showed
+**1323 tmux client processes, all in state `R`** — spinning, not blocked —
+overwhelmingly `capture-pane` from the pane pollers, accumulated at ~250/min
+between 14:57 and 15:02, then stopping exactly when the app itself wedged. They
+saturated the machine: the app's event loop stalled 0.5–31s, and the tmux
+server's own response time went from 4ms to 20–55s, with 3 of 7 commands never
+answering.
+
+`capturePane` reaches `run()` through `runChecked` with no bounds. Only 2 of
+~37 call sites in `TmuxClient` passed a timeout, so essentially every tmux
+command in the app was unbounded — which is what let a slow server convert
+routine polling into an unbounded process pile, which then made the server
+slower still. `binary.ts` was worse: its three probes bypass `TmuxClient`
+entirely and spawn tmux directly.
+
+The bundled binary is 3.6a, so the existing `KNOWN_BAD_TMUX_VERSION` warning
+(tmux 3.7 busy-spin) correctly did not fire. What pushed this 3.6a server into
+degradation was not determined; the pile-up is self-reinforcing once started,
+and bounding it does not depend on knowing the trigger.
+
+## Decision
+
+Bound every tmux spawn.
+
+- **New `src/bun/tmux/bounded-spawn.ts`** holds the one implementation of
+  "collect a process's output, kill and reap it if it overruns". The machinery
+  (`settled` / `until` / `readUntil` / TERM-then-KILL) moved out of `client.ts`
+  verbatim; `TmuxClient.run` now delegates to it and keeps only the tmux-shaped
+  error wrapping.
+- **`TmuxClient.run` applies `DEFAULT_RUN_TIMEOUT_MS` (10s)** when the caller
+  passes no bound. This is the change that caps the pile: a reaped
+  `capture-pane` costs one missed pane refresh, and the poller retries.
+- **`binary.ts` probes are bounded at `PROBE_TIMEOUT_MS` (3s)**. A server that
+  does not answer now returns the new `"unreachable"` status, deliberately
+  *not* `"mismatch"` — "no answer" is not evidence of version skew, and
+  reporting it as skew would send `selectTmuxBinary` hunting for a fallback
+  binary and tell the user to `kill-server` over a version nobody ever read.
+  `unreachable` keeps the preferred binary and logs a warning.
+- **`warnIfKnownBadTmux` no longer spawns at all** — `selectTmuxBinary` already
+  probed that binary's version, so it is passed in.
+
+## Risks
+
+- 10s is a judgement call, not a measurement. On a heavily loaded machine a
+  legitimate command could now fail where it previously waited. That is the
+  intended trade: a failed poll is recoverable, an unbounded pile is not. The
+  bound is per-call and overridable.
+- A reaped client leaves the server's own view of that command undefined. All
+  bounded calls here are reads or idempotent sets, so a retry is safe.
+- `probeTmuxVersion` timing out makes `selectTmuxBinary` report tmux as not
+  installed. That is a wrong diagnosis, but a visible one, and strictly better
+  than an infinite spinner.
+
+## Alternatives considered
+
+- **Only fix `probeTmuxServer`.** Cures the visible freeze and leaves the cause
+  — the unbounded `capture-pane` pile — in place.
+- **Bound each call site individually.** ~37 edits, and the next added method
+  starts unbounded again. A default on `run()` is the only version that stays
+  true.
+- **Cap concurrent tmux spawns instead of timing them out.** Queues the
+  spinners rather than reaping them; the app still stops refreshing panes and
+  the wedged clients still hold their sockets.
+- **Treat a timed-out server probe as `"mismatch"`.** Reuses an existing status
+  and needs no new branch, but produces an actively misleading "run
+  `kill-server`" instruction built on a version string that was never read.

--- a/src/bun/tmux/__tests__/binary.test.ts
+++ b/src/bun/tmux/__tests__/binary.test.ts
@@ -183,6 +183,61 @@ describe("selectTmuxBinary", () => {
 		expect(getTmuxServerVersionMismatch()).toBeNull();
 	});
 
+	// A tmux client talking to a wedged server never exits. These probes used to
+	// `await proc.exited` unbounded, so checkSystemRequirements never settled and
+	// the app sat on "Checking system…" forever, with Retry re-arming the hang.
+	// See decisions/2026/08/16/bound-every-tmux-spawn.md.
+	describe("a tmux process that never exits", () => {
+		/** Never resolves — exactly what a client blocked on a wedged server does. */
+		function wedgedProc() {
+			return { exited: new Promise<number>(() => {}), stdout: "", stderr: "", kill: vi.fn() } as any;
+		}
+
+		/** Run `work` while pushing fake time past the probe timeout + kill grace. */
+		async function underFakeTimers<T>(work: () => Promise<T>): Promise<T> {
+			vi.useFakeTimers();
+			try {
+				const promise = work();
+				await vi.advanceTimersByTimeAsync(10_000);
+				return await promise;
+			} finally {
+				vi.useRealTimers();
+			}
+		}
+
+		it("does not hang probeTmuxVersion — it gives up and reports the binary unusable", async () => {
+			mockSpawn.mockReturnValue(wedgedProc());
+			expect(await underFakeTimers(() => probeTmuxVersion(PREFERRED))).toBeUndefined();
+		});
+
+		it("kills the abandoned probe instead of leaking it", async () => {
+			const proc = wedgedProc();
+			mockSpawn.mockReturnValue(proc);
+			await underFakeTimers(() => probeTmuxVersion(PREFERRED));
+			expect(proc.kill).toHaveBeenCalled();
+		});
+
+		it("does not hang selectTmuxBinary when the server never answers", async () => {
+			mockSpawn.mockImplementation(((args: string[]) =>
+				args[1] === "-V" ? probeResult(0) : wedgedProc()) as any);
+			const chosen = await underFakeTimers(() => selectTmuxBinary(PREFERRED, [PATH_TMUX]));
+			expect(chosen).toBe(PREFERRED);
+			expect(getTmuxBinary()).toBe(PREFERRED);
+		});
+
+		it("does not mistake an unreachable server for a version mismatch", async () => {
+			// "No answer" is not evidence of skew: reporting a mismatch would send
+			// the caller hunting for a fallback binary and tell the user to
+			// kill-server over a version nobody ever read.
+			mockSpawn.mockImplementation(((args: string[]) =>
+				args[1] === "-V" ? probeResult(0) : wedgedProc()) as any);
+			await underFakeTimers(() => selectTmuxBinary(PREFERRED, [PATH_TMUX, "/usr/local/bin/tmux"]));
+			expect(getTmuxServerVersionMismatch()).toBeNull();
+			const probes = mockSpawn.mock.calls.filter((c) => (c[0] as string[]).includes("display-message"));
+			expect(probes).toHaveLength(1); // preferred only — no fallback scan
+		});
+	});
+
 	it("skips fallback candidates that do not exist on disk", async () => {
 		mockVersionAndServer(1, "server exited unexpectedly");
 		mockExistsSync.mockImplementation((path) => path === PREFERRED);

--- a/src/bun/tmux/__tests__/client.test.ts
+++ b/src/bun/tmux/__tests__/client.test.ts
@@ -377,6 +377,57 @@ describe("capturePane", () => {
 	});
 });
 
+// capture-pane is the highest-frequency command in the app (one per pane poll).
+// Unbounded, a server that stops answering turned those polls into a pile of
+// ~250 spinning clients per minute — 1323 of them in one field incident, which
+// saturated the machine and froze the app. The bound is what caps the pile.
+describe("the default command bound", () => {
+	/** Never resolves — a client whose server stopped answering. */
+	function wedgedProc() {
+		return makeProc({ stdout: "", stderr: "", exited: new Promise<number>(() => undefined), kill: vi.fn() });
+	}
+
+	// Asserting the DEFAULT is the point: an injected 5ms would stay green even if
+	// the production default were dropped entirely.
+	it("reaps a capture-pane that never answers, after 10s and not before", async () => {
+		const proc = wedgedProc();
+		const client = new TmuxClient({ spawn: vi.fn().mockReturnValue(proc) as never });
+		vi.useFakeTimers();
+		try {
+			const failure = client.capturePane({ target: "dev3-abc" }).catch((err: unknown) => err);
+			await vi.advanceTimersByTimeAsync(9_999);
+			expect(proc.kill).not.toHaveBeenCalled(); // still within budget
+			await vi.advanceTimersByTimeAsync(2);
+			expect(proc.kill).toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(1_100);
+			expect(await failure).toSatisfy(isTmuxTimeoutError);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("bounds a plain query too — a wedged list-sessions cannot hang its caller", async () => {
+		const proc = wedgedProc();
+		const client = new TmuxClient({ spawn: vi.fn().mockReturnValue(proc) as never });
+		vi.useFakeTimers();
+		try {
+			const failure = client.hasSession("dev3-abc").catch((err: unknown) => err);
+			await vi.advanceTimersByTimeAsync(12_000);
+			expect(await failure).toSatisfy(isTmuxTimeoutError);
+			expect(proc.kill).toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("still lets a caller ask for a tighter bound", async () => {
+		const proc = wedgedProc();
+		const client = new TmuxClient({ spawn: vi.fn().mockReturnValue(proc) as never });
+		const failure = await client.ensureServerToken({ candidate: "srv-token-1", timeoutMs: 5 }).catch((err: unknown) => err);
+		expect(failure).toSatisfy(isTmuxTimeoutError);
+	});
+});
+
 describe("sendKeysGuarded — one server command list, no check/send window", () => {
 	const GUARDED = { pane: "%3", serverToken: "srv-token-1", session: "dev3-task-abc12345" };
 

--- a/src/bun/tmux/binary.ts
+++ b/src/bun/tmux/binary.ts
@@ -12,6 +12,7 @@ import { createLogger } from "../logger";
 import { DEV3_HOME } from "../paths";
 import { spawn } from "../spawn";
 import { isExecutableFile } from "../executable";
+import { runBounded } from "./bounded-spawn";
 import { DEFAULT_TMUX_SOCKET } from "./constants";
 
 // Must be initialized before any module-load code below — sanitizeTmuxShim()
@@ -32,9 +33,17 @@ export function getTmuxBinary(): string {
 }
 
 type TmuxServerProbe = {
-	status: "compatible" | "no-server" | "mismatch";
+	status: "compatible" | "no-server" | "mismatch" | "unreachable";
 	serverVersion?: string;
 };
+
+/**
+ * Bounds for the probes below. A tmux client waiting on a wedged server never
+ * exits, so an unbounded probe hangs its caller forever — that is how startup
+ * froze on "Checking system…" (decisions/2026/08/16/bound-every-tmux-spawn.md).
+ * Matches SERVER_TOKEN_TIMEOUT_MS in ./client: a healthy server answers in ms.
+ */
+const PROBE_TIMEOUT_MS = 3_000;
 
 export interface TmuxServerVersionMismatch {
 	clientVersion: string;
@@ -60,11 +69,15 @@ function normalizeTmuxVersion(version: string): string {
 async function probeTmuxServer(binary: string, binaryVersion: string, socket: string): Promise<TmuxServerProbe> {
 	try {
 		const proc = spawn([binary, "-L", socket, "display-message", "-p", "#{version}"], { stdout: "pipe", stderr: "pipe" });
-		const [stdout, stderr, exitCode] = await Promise.all([
-			new Response(proc.stdout).text(),
-			new Response(proc.stderr).text(),
-			proc.exited,
-		]);
+		const outcome = await runBounded(proc, { timeoutMs: PROBE_TIMEOUT_MS });
+		// A server that does not answer tells us nothing about version skew, so
+		// this must NOT read as "mismatch" — that would send the caller hunting
+		// for a fallback binary and warn about a version it never saw.
+		if (outcome.kind === "stopped") {
+			log.warn("tmux server did not answer a version probe in time — treating it as unreachable", { binary, socket, timeoutMs: PROBE_TIMEOUT_MS });
+			return { status: "unreachable" };
+		}
+		const { stdout, stderr, exitCode } = outcome.value;
 		if (exitCode === 0) {
 			const serverVersion = normalizeTmuxVersion(stdout);
 			return {
@@ -84,9 +97,13 @@ async function probeTmuxServer(binary: string, binaryVersion: string, socket: st
 export async function probeTmuxVersion(binary: string): Promise<string | undefined> {
 	try {
 		const proc = spawn([binary, "-V"], { stdout: "pipe", stderr: "pipe" });
-		const stdout = (await new Response(proc.stdout).text()).trim();
-		const exitCode = await proc.exited;
-		return exitCode === 0 && /^tmux \d/.test(stdout) ? stdout : undefined;
+		const outcome = await runBounded(proc, { timeoutMs: PROBE_TIMEOUT_MS });
+		if (outcome.kind === "stopped") {
+			log.warn("tmux -V did not answer in time — treating this binary as unusable", { binary, timeoutMs: PROBE_TIMEOUT_MS });
+			return undefined;
+		}
+		const stdout = outcome.value.stdout.trim();
+		return outcome.value.exitCode === 0 && /^tmux \d/.test(stdout) ? stdout : undefined;
 	} catch {
 		return undefined;
 	}
@@ -260,7 +277,7 @@ export async function selectTmuxBinary(preferred: string, fallbackCandidates: st
 	}
 	setTmuxBinary(chosen.path);
 	updateTmuxShim(chosen.path);
-	await warnIfKnownBadTmux(chosen.path);
+	warnIfKnownBadTmux(chosen.path, chosen.version);
 	return chosen.path;
 }
 
@@ -270,20 +287,11 @@ export async function selectTmuxBinary(preferred: string, fallbackCandidates: st
 const KNOWN_BAD_TMUX_VERSION = /^tmux 3\.7/;
 let badTmuxWarned = false;
 
-async function warnIfKnownBadTmux(binary: string): Promise<void> {
-	if (badTmuxWarned) return;
-	try {
-		const proc = spawn([binary, "-V"], { stdout: "pipe", stderr: "ignore" });
-		const version = (await new Response(proc.stdout).text()).trim();
-		await proc.exited;
-		if (KNOWN_BAD_TMUX_VERSION.test(version)) {
-			badTmuxWarned = true;
-			log.warn(
-				"tmux 3.7 detected — it has a client busy-spin regression when several dev3 instances share a machine. Install the pinned keg: brew trust h0x91b/dev3 && brew install h0x91b/dev3/tmux@3.6",
-				{ binary, version },
-			);
-		}
-	} catch {
-		log.debug("tmux version probe failed", { binary });
-	}
+function warnIfKnownBadTmux(binary: string, version: string): void {
+	if (badTmuxWarned || !KNOWN_BAD_TMUX_VERSION.test(version)) return;
+	badTmuxWarned = true;
+	log.warn(
+		"tmux 3.7 detected — it has a client busy-spin regression when several dev3 instances share a machine. Install the pinned keg: brew trust h0x91b/dev3 && brew install h0x91b/dev3/tmux@3.6",
+		{ binary, version },
+	);
 }

--- a/src/bun/tmux/bounded-spawn.ts
+++ b/src/bun/tmux/bounded-spawn.ts
@@ -1,0 +1,140 @@
+/**
+ * Bounding a spawned tmux process — the ONE implementation of "wait for this
+ * process, but give up if it never answers".
+ *
+ * A tmux client whose server is wedged never exits on its own: it sits on the
+ * socket waiting for a reply that never comes. A bare `await proc.exited` on
+ * such a client hangs for the life of the app, and every caller behind it hangs
+ * with it (it froze startup on "Checking system…" — see
+ * decisions/2026/08/16/bound-every-tmux-spawn.md).
+ *
+ * Internal to the tmux module: TmuxClient and ./binary are the only consumers.
+ */
+import type { spawn } from "../spawn";
+
+type SpawnedProcess = ReturnType<typeof spawn>;
+
+/** How long a stopped child gets to die politely, then to be reaped after KILL. */
+const TERM_GRACE_MS = 500;
+const KILL_GRACE_MS = 500;
+
+export interface BoundedRunResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+/**
+ * `done` — the process answered. `stopped` — we gave up on it and killed it;
+ * `confirmed` says whether the child was actually seen to exit.
+ */
+export type BoundedOutcome =
+	| { kind: "done"; value: BoundedRunResult }
+	| { kind: "stopped"; confirmed: boolean };
+
+export interface SpawnBounds {
+	timeoutMs?: number;
+	signal?: AbortSignal;
+}
+
+/** Whether `work` settled within `ms`. Never rejects; used only to bound a wait. */
+async function settled(work: Promise<unknown>, ms: number): Promise<boolean> {
+	return await Promise.race([
+		work.then(
+			() => true,
+			() => true,
+		),
+		new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms)),
+	]);
+}
+
+/** `work`, or `fallback` as soon as `giveUp` settles — so no wait outlives the stop. */
+function until<T>(work: Promise<T>, giveUp: Promise<unknown>, fallback: T): Promise<T> {
+	return Promise.race([work.catch(() => fallback), giveUp.then(() => fallback)]);
+}
+
+/**
+ * Read a stream with an OWN reader so the stop can cancel it: handing the stream to
+ * `Response` locks it, and an abandoned `Response` read stays pending for the life of the
+ * process with the stream locked behind it.
+ */
+async function readUntil(stream: unknown, giveUp: Promise<unknown>): Promise<string> {
+	const readable = stream as ReadableStream<Uint8Array> | undefined;
+	// Anything that is not a live stream (a string, a Response, a test double) has no
+	// reader to cancel and cannot half-open, so read it the simple way.
+	if (!readable || typeof readable.getReader !== "function") {
+		return await until(new Response(readable as unknown as BodyInit).text(), giveUp, "");
+	}
+	const reader = readable.getReader();
+	void giveUp.then(() => reader.cancel().catch(() => undefined));
+	const decoder = new TextDecoder();
+	let text = "";
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (value) text += decoder.decode(value, { stream: true });
+		}
+		text += decoder.decode();
+	} catch {
+		// cancelled, or the pipe broke — whatever arrived is what we report
+	} finally {
+		reader.releaseLock();
+	}
+	return text;
+}
+
+/**
+ * Collect a spawned process's output under a timeout / abort signal. Without
+ * `bounds.timeoutMs` the wait is unbounded — pass one for anything that talks
+ * to a tmux server, which may never reply.
+ */
+export async function runBounded(proc: SpawnedProcess, bounds?: SpawnBounds): Promise<BoundedOutcome> {
+	let resolveStopped: (confirmed: boolean) => void = () => undefined;
+	// Settles when a stop has finished, with whether the child was confirmed gone.
+	const stopped = new Promise<boolean>((resolve) => {
+		resolveStopped = resolve;
+	});
+	let stopping = false;
+	const stop = async (): Promise<void> => {
+		if (stopping) return;
+		stopping = true;
+		// TERM, a bounded wait, then KILL, then a bounded reap.
+		try {
+			proc.kill("SIGTERM");
+		} catch {
+			// already gone
+		}
+		if (await settled(proc.exited, TERM_GRACE_MS)) return resolveStopped(true);
+		try {
+			proc.kill("SIGKILL");
+		} catch {
+			// already gone
+		}
+		resolveStopped(await settled(proc.exited, KILL_GRACE_MS));
+	};
+
+	const timer = bounds?.timeoutMs === undefined ? undefined : setTimeout(() => void stop(), Math.max(0, bounds.timeoutMs));
+	const onAbort = (): void => void stop();
+	bounds?.signal?.addEventListener("abort", onAbort, { once: true });
+
+	try {
+		// Every wait here ends when the stop does, so a half-open pipe or an `exited`
+		// that never settles cannot outlive the decision to give up.
+		const collected = Promise.all([
+			readUntil(proc.stdout, stopped),
+			readUntil(proc.stderr, stopped),
+			until(proc.exited, stopped, -1),
+		]).then(([stdout, stderr, exitCode]) => ({ stdout, stderr, exitCode }));
+
+		const result = await Promise.race([
+			collected.then((value) => ({ kind: "done" as const, value })),
+			stopped.then((confirmed) => ({ kind: "stopped" as const, confirmed })),
+		]);
+		if (result.kind === "done" && !stopping) return result;
+		return { kind: "stopped", confirmed: result.kind === "stopped" ? result.confirmed : await stopped };
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+		bounds?.signal?.removeEventListener("abort", onAbort);
+	}
+}

--- a/src/bun/tmux/client.ts
+++ b/src/bun/tmux/client.ts
@@ -22,6 +22,7 @@ import {
 	probeTmuxVersion,
 	selectTmuxBinary,
 } from "./binary";
+import { type BoundedRunResult, type SpawnBounds, runBounded } from "./bounded-spawn";
 import { DEFAULT_TMUX_SOCKET } from "./constants";
 import { activeTmuxConfigPath, tmuxClientCwd } from "./config";
 import { TmuxError, TmuxSpawnError, TmuxTimeoutError } from "./errors";
@@ -72,61 +73,20 @@ const GUARDED_SEND_MARKER = "dev3-pane-input-sent";
 const SERVER_TOKEN_OPTION = "@dev3_server_token";
 /** Bound for the token command: a wedged server must not hold a session's setup open. */
 const SERVER_TOKEN_TIMEOUT_MS = 3_000;
-const TERM_GRACE_MS = 500;
-const KILL_GRACE_MS = 500;
-
-/** Whether `work` settled within `ms`. Never rejects; used only to bound a wait. */
-async function settled(work: Promise<unknown>, ms: number): Promise<boolean> {
-	return await Promise.race([
-		work.then(
-			() => true,
-			() => true,
-		),
-		new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms)),
-	]);
-}
-
-/** `work`, or `fallback` as soon as `giveUp` settles — so no wait outlives the stop. */
-function until<T>(work: Promise<T>, giveUp: Promise<unknown>, fallback: T): Promise<T> {
-	return Promise.race([work.catch(() => fallback), giveUp.then(() => fallback)]);
-}
 
 /**
- * Read a stream with an OWN reader so the stop can cancel it: handing the stream to
- * `Response` locks it, and an abandoned `Response` read stays pending for the life of the
- * process with the stream locked behind it.
+ * Every tmux command here is non-interactive and answers in milliseconds on a
+ * healthy server. Unbounded, they do not merely hang their caller — they PILE
+ * UP: a field incident collected 1323 spinning `capture-pane` clients in five
+ * minutes (~250/min from the pane pollers), which saturated the machine, drove
+ * the server's own response time from 4ms to 55s, and froze the app. Reaping a
+ * straggler costs one missed pane refresh; the poller just tries again.
+ * Callers needing a tighter or looser bound pass their own.
+ * See decisions/2026/08/16/bound-every-tmux-spawn.md.
  */
-async function readUntil(stream: unknown, giveUp: Promise<unknown>): Promise<string> {
-	const readable = stream as ReadableStream<Uint8Array> | undefined;
-	// Anything that is not a live stream (a string, a Response, a test double) has no
-	// reader to cancel and cannot half-open, so read it the simple way.
-	if (!readable || typeof readable.getReader !== "function") {
-		return await until(new Response(readable as unknown as BodyInit).text(), giveUp, "");
-	}
-	const reader = readable.getReader();
-	void giveUp.then(() => reader.cancel().catch(() => undefined));
-	const decoder = new TextDecoder();
-	let text = "";
-	try {
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			if (value) text += decoder.decode(value, { stream: true });
-		}
-		text += decoder.decode();
-	} catch {
-		// cancelled, or the pipe broke — whatever arrived is what we report
-	} finally {
-		reader.releaseLock();
-	}
-	return text;
-}
+const DEFAULT_RUN_TIMEOUT_MS = 10_000;
 
-interface RunResult {
-	stdout: string;
-	stderr: string;
-	exitCode: number;
-}
+type RunResult = BoundedRunResult;
 
 export class TmuxClient {
 	private readonly spawnFn: SpawnFn;
@@ -174,11 +134,7 @@ export class TmuxClient {
 		return [getTmuxBinary(), "-L", socket ?? this.defaultSocket, ...args];
 	}
 
-	private async run(
-		socket: string | undefined,
-		args: string[],
-		bounds?: { timeoutMs?: number; signal?: AbortSignal },
-	): Promise<RunResult> {
+	private async run(socket: string | undefined, args: string[], bounds?: SpawnBounds): Promise<RunResult> {
 		let proc: SpawnedProcess;
 		try {
 			proc = this.spawnFn(this.argv(socket, args), { stdout: "pipe", stderr: "pipe" });
@@ -186,54 +142,10 @@ export class TmuxClient {
 			throw new TmuxSpawnError(getTmuxBinary(), err);
 		}
 
-		let resolveStopped: (confirmed: boolean) => void = () => undefined;
-		// Settles when a stop has finished, with whether the child was confirmed gone.
-		const stopped = new Promise<boolean>((resolve) => {
-			resolveStopped = resolve;
-		});
-		let stopping = false;
-		const stop = async (): Promise<void> => {
-			if (stopping) return;
-			stopping = true;
-			// TERM, a bounded wait, then KILL, then a bounded reap.
-			try {
-				proc.kill("SIGTERM");
-			} catch {
-				// already gone
-			}
-			if (await settled(proc.exited, TERM_GRACE_MS)) return resolveStopped(true);
-			try {
-				proc.kill("SIGKILL");
-			} catch {
-				// already gone
-			}
-			resolveStopped(await settled(proc.exited, KILL_GRACE_MS));
-		};
-
-		const timer = bounds?.timeoutMs === undefined ? undefined : setTimeout(() => void stop(), Math.max(0, bounds.timeoutMs));
-		const onAbort = (): void => void stop();
-		bounds?.signal?.addEventListener("abort", onAbort, { once: true });
-
-		try {
-			// Every wait here ends when the stop does, so a half-open pipe or an `exited`
-			// that never settles cannot outlive the decision to give up.
-			const collected = Promise.all([
-				readUntil(proc.stdout, stopped),
-				readUntil(proc.stderr, stopped),
-				until(proc.exited, stopped, -1),
-			]).then(([stdout, stderr, exitCode]) => ({ stdout, stderr, exitCode }));
-
-			const result = await Promise.race([
-				collected.then((value) => ({ kind: "done" as const, value })),
-				stopped.then((confirmed) => ({ kind: "stopped" as const, confirmed })),
-			]);
-			if (result.kind === "done" && !stopping) return result.value;
-			const confirmed = result.kind === "stopped" ? result.confirmed : await stopped;
-			throw new TmuxTimeoutError(args, bounds?.timeoutMs ?? 0, confirmed);
-		} finally {
-			if (timer !== undefined) clearTimeout(timer);
-			bounds?.signal?.removeEventListener("abort", onAbort);
-		}
+		const timeoutMs = bounds?.timeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
+		const outcome = await runBounded(proc, { ...bounds, timeoutMs });
+		if (outcome.kind === "done") return outcome.value;
+		throw new TmuxTimeoutError(args, timeoutMs, outcome.confirmed);
 	}
 
 	private async runChecked(socket: string | undefined, args: string[]): Promise<RunResult> {


### PR DESCRIPTION
A user's app froze at startup on the "Checking system…" phase and never recovered — Reload and Retry both re-armed the freeze. Reported stuck for ~20 minutes.

## What was actually wrong

`checkSystemRequirements` → `commitTmuxBinary` → `probeTmuxServer` spawned `tmux -L dev3 display-message -p '#{version}'` and did a bare `await proc.exited`. A tmux client whose server does not answer never exits, so the RPC never settled and `App.tsx` held `reqStatus === "checking"` forever. The user's log showed 13 invocations and 2 completions.

That was the symptom. A process listing from the machine showed **1323 tmux client processes in state `R`** — spinning, not blocked — almost all `capture-pane` from the pane pollers, accumulated at ~250/min over five minutes and stopping exactly when the app itself wedged. That pile saturated the machine: the app's event loop stalled 0.5–31s and the tmux server's own response time went from 4ms to 20–55s, with 3 of 7 commands never answering.

Only **2 of ~37** `TmuxClient` call sites passed a bound, so `capture-pane` — the highest-frequency command in the app — was unbounded. Unbounded plus a slow server produces an unbounded process pile, which makes the server slower still.

The binary was tmux 3.6a, so the existing `KNOWN_BAD_TMUX_VERSION` (3.7 busy-spin) warning correctly did not fire. What pushed this 3.6a server into degradation was not determined; the pile-up is self-reinforcing once started and bounding it does not depend on knowing the trigger.

## Changes

- **New `src/bun/tmux/bounded-spawn.ts`** — the one implementation of "collect a process's output, kill and reap it if it overruns". The machinery moved out of `client.ts` verbatim; `TmuxClient.run` keeps only the tmux-shaped error wrapping.
- **`TmuxClient.run` applies a 10s default bound** when the caller passes none. This is what caps the pile: a reaped `capture-pane` costs one missed pane refresh and the poller retries.
- **`binary.ts` probes bounded at 3s.** A server that does not answer returns a new `"unreachable"` status, deliberately *not* `"mismatch"` — "no answer" is not evidence of version skew, and reporting it as skew would send `selectTmuxBinary` hunting for a fallback binary and tell the user to `kill-server` over a version nobody ever read.
- **`warnIfKnownBadTmux` no longer spawns** — `selectTmuxBinary` already probed that version, so it is passed in.

Rationale and the alternatives considered are in `decisions/2026/08/16/bound-every-tmux-spawn.md`.

## Verification

`bun run lint` clean. tmux module 180/180, renderer 3840/0, CLI 782/0.

The guard was proven by breaking what it guards, twice: removing the probe bound makes the 4 new `binary.test.ts` tests time out (other 29 stay green); removing the default bound in `run()` fails 6 tests in `client.test.ts`.

The one remaining backend failure (`git-diff-recent`) is a pre-existing load flake — it passes in isolation, touches no tmux code, and a paired baseline run on clean `origin/main` fails across the same `git-*` / release-artifact family.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=5ce4046f-67fd-4277-bc3e-39299842afe8) · `dev3://task/5ce4046f-67fd-4277-bc3e-39299842afe8` _(dev3 added this footer — turn it off in Settings → Tasks.)_
