### PR TITLE
Clone a root .npmrc into new task worktrees

### DIFF
--- a/.dev3/config.json
+++ b/.dev3/config.json
@@ -3,6 +3,7 @@
   "devScript": "bun run dev",
   "portCount": 1,
   "clonePaths": [
+    ".npmrc",
     "node_modules",
     "build",
     "dist"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ changelog.json
 # dev-3.0 local config
 .dev3/config.local.json
 
+# Private npm registry / tokens — never ships with the repo
+.npmrc
+
 # Playwright MCP browser-test artifacts (screenshots, snapshots, console logs)
 .playwright-mcp/
 verify-*.png

--- a/change-logs/2026/08/16/fix-clone-npmrc-into-worktrees.md
+++ b/change-logs/2026/08/16/fix-clone-npmrc-into-worktrees.md
@@ -1,0 +1,3 @@
+Short: Worktrees keep your .npmrc
+
+A gitignored `.npmrc` at the project root is now cloned into every new task worktree, so installs there use the same registry and credentials as the main checkout instead of silently falling back to the public registry. The file is also gitignored in this repo so it can never be committed by accident.

--- a/src/bun/__tests__/cow-clone.test.ts
+++ b/src/bun/__tests__/cow-clone.test.ts
@@ -220,6 +220,7 @@ describe("WELL_KNOWN_CLONE_PATHS", () => {
 		expect(WELL_KNOWN_CLONE_PATHS).toContain("vendor/bundle");
 		expect(WELL_KNOWN_CLONE_PATHS).toContain("target");
 		expect(WELL_KNOWN_CLONE_PATHS).toContain(".env");
+		expect(WELL_KNOWN_CLONE_PATHS).toContain(".npmrc");
 	});
 
 	it("contains no absolute paths", () => {

--- a/src/bun/cow-clone.ts
+++ b/src/bun/cow-clone.ts
@@ -285,6 +285,9 @@ export const WELL_KNOWN_CLONE_PATHS = [
 	".build",
 
 	// Environment & secrets
+	// A root .npmrc usually carries a private registry or a token, so it is
+	// gitignored — without it a worktree installs against the public registry.
+	".npmrc",
 	".env",
 	".env.local",
 	".env.development.local",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch) — a small fix so task worktrees install packages the same way the main checkout does.

A `.npmrc` at the project root is normally gitignored (it carries a private registry or a token), so a fresh task worktree never got a copy of it and `bun install` there silently fell back to the public registry. On a machine where the public registry is unreachable, that means setup fails for every package that isn't already in the package manager's cache.

- `.npmrc` joins `WELL_KNOWN_CLONE_PATHS` in `src/bun/cow-clone.ts`, next to `.env` — auto-detected when a project is added, and CoW-cloned into each new worktree. Verified: it clones through `clonefile(2)` with contents intact.
- This project's own `.dev3/config.json` gets `.npmrc` in `clonePaths`, since auto-detection only runs at project-add time.
- `.gitignore` picks up `.npmrc` so the file can never be committed by accident.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c22fc97f-541d-4b46-9d85-098b1a6cf74e) · `dev3://task/c22fc97f-541d-4b46-9d85-098b1a6cf74e`