### PR TITLE
Pull an offscreen window back after a display change, and log both sides of the geometry

### DIFF
--- a/change-logs/2026/08/17/fix-display-change-geometry-diagnostics.md
+++ b/change-logs/2026/08/17/fix-display-change-geometry-diagnostics.md
@@ -1,0 +1,8 @@
+Short: Window survives a resolution change
+
+A window left hanging off every screen after a monitor resolution change (or a
+wake) is now pulled back onto a display, instead of only being clamped on the
+next app start. The same trigger writes one geometry line from the backend and
+one from the renderer into the log, and a terminal refit that throws is no longer
+swallowed silently — the three blind spots behind reports of a black terminal
+after a resolution change.

--- a/decisions/2026/08/17/display-change-poll-and-live-frame-clamp.md
+++ b/decisions/2026/08/17/display-change-poll-and-live-frame-clamp.md
@@ -1,0 +1,63 @@
+# Display-configuration polling and the live frame clamp
+
+## Context
+
+Two field reports: after a monitor resolution change the app showed a black
+terminal with content running past the window's right edge ("на любой задаче"),
+and after a long sleep one user lost mouse interaction while the keyboard kept
+working. The reporter confirmed a manual window resize does NOT fix it and that
+a restart does — which is exactly the asymmetry described below. Changing the
+resolution five times on a developer machine did not reproduce either symptom,
+so the root cause is still unproven and no blind behavioural fix was written.
+
+## Investigation
+
+- Electrobun exposes **no** display-configuration event and **no** sleep/wake
+  event. `Screen` is poll-only (`getAllDisplays()` → id / bounds / scaleFactor);
+  window events are limited to move / resize / focus / blur / close.
+- `resolveRestoreFrame` (`src/bun/window-state.ts`) already clamps a saved frame
+  into the current display bounds — but only on startup. Nothing clamps a *live*
+  window, which is a plausible reason a restart cures the symptom and a resize
+  does not.
+- `ghostty-web` captures `window.devicePixelRatio` in its renderer constructor and
+  never re-reads it, and it repaints only dirty rows (a full redraw needs a screen
+  switch, a resize, or an explicit force). A `term.resize` to unchanged cols/rows
+  is a no-op, so nudging a window by a few pixels cannot restore a lost canvas.
+- `refitToContainer` (`src/mainview/TerminalView.tsx`) swallowed every throw from
+  `proposeDimensions` / `term.resize` in an empty `catch`, so a failed refit on a
+  live terminal left no trace anywhere.
+
+## Decision
+
+`src/bun/display-watch.ts` polls the display layout every 5 s and reports either
+`displays` (layout signature changed) or `wake` (a tick arrived more than 3×
+late — timers do not run while asleep, and a sleep can end on the exact layout it
+started with). `handleDisplayConfigurationChange` in `window-manager.ts` logs both
+the window frame and the display bounds, and calls `offscreenFrameClamp` — which
+pulls a window back **only** when part of it covers no display at all, measured
+against the union of every display. The renderer mirrors its own geometry from
+`src/mainview/viewport-diagnostics.ts`, so one log file holds both sides and the
+next report arrives with evidence instead of hypotheses. The empty `catch` blocks
+now log through the existing renderer diagnostic sink.
+
+## Risks
+
+- The clamp moves a user's window. Guarded by the union-coverage test plus a 2 px
+  slack, so a window spanning two monitors and a hairline sliver are both left
+  alone; a fullscreen window is never touched, because macOS owns its frame.
+- Polling costs one FFI call per 5 s. Measured as noise next to the existing
+  pollers, and the watcher writes nothing while the layout is stable.
+- The reported symptoms may have another cause entirely. Nothing here claims to
+  fix them; the diagnostics exist precisely because the cause is unproven.
+
+## Alternatives considered
+
+- **Resize nudge on a trigger** (the existing first-paint trick from
+  `window-manager.ts`, replayed on display change). Dropped: the reporter says a
+  manual resize does not help, and an unchanged cols/rows resize cannot force the
+  canvas redraw the symptom needs.
+- **"First size change in X minutes" heuristic** as the trigger. Dropped: it
+  fires while the user drags a window edge after a quiet period, and misses two
+  resolution changes in a row.
+- **Clamping to the display containing the window's center, always.** Dropped:
+  it would yank a window the user deliberately spanned across two monitors.

--- a/src/bun/__tests__/display-watch.test.ts
+++ b/src/bun/__tests__/display-watch.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { displaySignature, startDisplayWatch, DISPLAY_WATCH_INTERVAL_MS } from "../display-watch";
+import type { DisplayLike } from "../window-state";
+
+const laptop: DisplayLike = { id: 1, bounds: { x: 0, y: 0, width: 1728, height: 1117 }, scaleFactor: 2 };
+const laptopLowRes: DisplayLike = { id: 1, bounds: { x: 0, y: 0, width: 1280, height: 800 }, scaleFactor: 2 };
+const laptopScaled: DisplayLike = { id: 1, bounds: { x: 0, y: 0, width: 1728, height: 1117 }, scaleFactor: 1 };
+
+/** Drives the watcher tick by tick with a clock the test owns. */
+function harness(displaysPerTick: DisplayLike[][], clockPerTick?: number[]) {
+	const events: { reason: string; signature: string }[] = [];
+	let tick = -1;
+	// A holder, not a bare `let`: TS cannot see that the mocked setInterval assigns
+	// it, and narrows a plain variable to `null` at the call below.
+	const timer: { fire: (() => void) | null } = { fire: null };
+	let clock = 0;
+
+	const stop = startDisplayWatch({
+		getDisplays: () => (tick < 0 ? displaysPerTick[0]! : displaysPerTick[Math.min(tick, displaysPerTick.length - 1)]!),
+		onChange: ({ reason, signature }) => events.push({ reason, signature }),
+		now: () => clock,
+		setInterval: (fn) => {
+			timer.fire = fn;
+			return 1;
+		},
+		clearInterval: () => {
+			timer.fire = null;
+		},
+	});
+
+	for (let i = 1; i < displaysPerTick.length; i++) {
+		tick = i;
+		clock += clockPerTick?.[i] ?? DISPLAY_WATCH_INTERVAL_MS;
+		timer.fire?.();
+	}
+	return { events, stop, isRunning: () => timer.fire !== null };
+}
+
+describe("displaySignature", () => {
+	it("changes when a display's resolution changes", () => {
+		expect(displaySignature([laptop])).not.toBe(displaySignature([laptopLowRes]));
+	});
+
+	it("changes when only the scale factor changes", () => {
+		expect(displaySignature([laptop])).not.toBe(displaySignature([laptopScaled]));
+	});
+
+	it("is order-independent, so display enumeration order cannot fake a change", () => {
+		const second: DisplayLike = { id: 2, bounds: { x: 1728, y: 0, width: 2560, height: 1440 }, scaleFactor: 1 };
+		expect(displaySignature([laptop, second])).toBe(displaySignature([second, laptop]));
+	});
+});
+
+describe("startDisplayWatch", () => {
+	it("reports a resolution change once, not on every tick after it", () => {
+		const { events } = harness([[laptop], [laptopLowRes], [laptopLowRes]]);
+		expect(events).toHaveLength(1);
+		expect(events[0]!.reason).toBe("displays");
+	});
+
+	it("stays silent while the layout is stable", () => {
+		const { events } = harness([[laptop], [laptop], [laptop]]);
+		expect(events).toEqual([]);
+	});
+
+	it("reports a wake even when the layout came back identical", () => {
+		const { events } = harness([[laptop], [laptop]], [0, DISPLAY_WATCH_INTERVAL_MS * 60]);
+		expect(events).toHaveLength(1);
+		expect(events[0]!.reason).toBe("wake");
+	});
+
+	it("does not call a stalled event loop a wake", () => {
+		const { events } = harness([[laptop], [laptop]], [0, DISPLAY_WATCH_INTERVAL_MS * 2]);
+		expect(events).toEqual([]);
+	});
+
+	it("prefers the layout change over the wake when both land on one tick", () => {
+		const { events } = harness([[laptop], [laptopLowRes]], [0, DISPLAY_WATCH_INTERVAL_MS * 60]);
+		expect(events).toHaveLength(1);
+		expect(events[0]!.reason).toBe("displays");
+	});
+
+	it("stops polling when stopped", () => {
+		const h = harness([[laptop], [laptop]]);
+		h.stop();
+		expect(h.isRunning()).toBe(false);
+	});
+
+	it("never lets a display read crash the caller's timer setup", () => {
+		const onChange = vi.fn();
+		expect(() =>
+			startDisplayWatch({
+				getDisplays: () => [],
+				onChange,
+				setInterval: () => 1,
+				clearInterval: () => {},
+			}),
+		).not.toThrow();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/bun/__tests__/offscreen-frame-clamp.test.ts
+++ b/src/bun/__tests__/offscreen-frame-clamp.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { clampFrameToDisplay, offscreenFrameClamp, type DisplayLike } from "../window-state";
+
+const laptop: DisplayLike = { id: 1, bounds: { x: 0, y: 0, width: 1728, height: 1117 }, scaleFactor: 2, isPrimary: true };
+const external: DisplayLike = { id: 2, bounds: { x: 1728, y: 0, width: 2560, height: 1440 }, scaleFactor: 1 };
+
+describe("clampFrameToDisplay", () => {
+	it("shrinks a frame that outgrew the display and pulls it inside", () => {
+		const frame = { x: 200, y: 100, width: 3000, height: 2000 };
+		expect(clampFrameToDisplay(frame, laptop.bounds)).toEqual({ x: 0, y: 0, width: 1728, height: 1117 });
+	});
+
+	it("leaves a frame that already fits untouched", () => {
+		const frame = { x: 100, y: 50, width: 1200, height: 800 };
+		expect(clampFrameToDisplay(frame, laptop.bounds)).toEqual(frame);
+	});
+});
+
+describe("offscreenFrameClamp", () => {
+	it("pulls back a window left hanging off the screen by a resolution drop", () => {
+		// The 2560-wide external display dropped to 1280; the window kept its size.
+		const shrunk: DisplayLike = { id: 2, bounds: { x: 1728, y: 0, width: 1280, height: 720 }, scaleFactor: 1 };
+		const frame = { x: 1728, y: 0, width: 2400, height: 1300 };
+		const result = offscreenFrameClamp(frame, [laptop, shrunk]);
+		expect(result).not.toBeNull();
+		expect(result!.display.id).toBe(2);
+		expect(result!.frame).toEqual({ x: 1728, y: 0, width: 1280, height: 720 });
+	});
+
+	it("leaves a window spanning two displays exactly where the user put it", () => {
+		const frame = { x: 1200, y: 100, width: 1400, height: 900 };
+		expect(offscreenFrameClamp(frame, [laptop, external])).toBeNull();
+	});
+
+	it("ignores a hairline sliver outside the display", () => {
+		const frame = { x: -1, y: 0, width: 1200, height: 800 };
+		expect(offscreenFrameClamp(frame, [laptop, external])).toBeNull();
+	});
+
+	it("rescues a window stranded on a display that was unplugged", () => {
+		const frame = { x: 2000, y: 200, width: 1200, height: 800 };
+		const result = offscreenFrameClamp(frame, [laptop]);
+		expect(result).not.toBeNull();
+		expect(result!.display.id).toBe(1);
+		expect(result!.frame).toEqual({ x: 528, y: 200, width: 1200, height: 800 });
+	});
+
+	it("does nothing when no display is known", () => {
+		expect(offscreenFrameClamp({ x: 0, y: 0, width: 800, height: 600 }, [])).toBeNull();
+	});
+});

--- a/src/bun/__tests__/window-manager.test.ts
+++ b/src/bun/__tests__/window-manager.test.ts
@@ -11,6 +11,7 @@ type FakeWindow = {
 	getSize: ReturnType<typeof vi.fn>;
 	setSize: ReturnType<typeof vi.fn>;
 	getFrame: ReturnType<typeof vi.fn>;
+	setFrame: ReturnType<typeof vi.fn>;
 	isFullScreen: ReturnType<typeof vi.fn>;
 	setFullScreen: ReturnType<typeof vi.fn>;
 	focus: ReturnType<typeof vi.fn>;
@@ -33,6 +34,7 @@ vi.mock("electrobun/bun", () => {
 		getSize: ReturnType<typeof vi.fn>;
 		setSize: ReturnType<typeof vi.fn>;
 		getFrame: ReturnType<typeof vi.fn>;
+		setFrame: ReturnType<typeof vi.fn>;
 		isFullScreen: ReturnType<typeof vi.fn>;
 		setFullScreen: ReturnType<typeof vi.fn>;
 		focus: ReturnType<typeof vi.fn>;
@@ -59,6 +61,9 @@ vi.mock("electrobun/bun", () => {
 			this.getSize = vi.fn(() => ({ width: 800, height: 600 }));
 			this.setSize = vi.fn();
 			this.getFrame = vi.fn(() => this.frame ?? { x: 0, y: 0, width: 800, height: 600 });
+			this.setFrame = vi.fn((x: number, y: number, width: number, height: number) => {
+				this.frame = { x, y, width, height };
+			});
 			this.isFullScreen = vi.fn(() => false);
 			this.setFullScreen = vi.fn();
 			this.focus = vi.fn();
@@ -117,6 +122,7 @@ import {
 	getFocusedWindow,
 	getAllWindows,
 	getWindowCount,
+	handleDisplayConfigurationChange,
 	__resetForTests,
 } from "../window-manager";
 
@@ -238,5 +244,60 @@ describe("window-manager", () => {
 
 		expect(onClosed).toHaveBeenCalledTimes(1);
 		expect(onClosed.mock.calls[0][1]).toBe(1);
+	});
+});
+
+describe("handleDisplayConfigurationChange", () => {
+	const shrunkDisplay = [{ id: 1, bounds: { x: 0, y: 0, width: 1280, height: 720 } }];
+
+	function spawnWithFrame(frame: { x: number; y: number; width: number; height: number }) {
+		createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {} });
+		const win = createdWindows[createdWindows.length - 1]!;
+		win.frame = frame;
+		return win;
+	}
+
+	it("pulls a window back when the new layout left it off every screen", () => {
+		const win = spawnWithFrame({ x: 0, y: 0, width: 1900, height: 1000 });
+
+		handleDisplayConfigurationChange("displays", shrunkDisplay);
+
+		expect(win.setFrame).toHaveBeenCalledWith(0, 0, 1280, 720);
+	});
+
+	it("leaves a window that still fits alone", () => {
+		const win = spawnWithFrame({ x: 10, y: 10, width: 800, height: 600 });
+
+		handleDisplayConfigurationChange("displays", shrunkDisplay);
+
+		expect(win.setFrame).not.toHaveBeenCalled();
+	});
+
+	it("never touches the frame of a fullscreen window — macOS owns it", () => {
+		const win = spawnWithFrame({ x: 0, y: 0, width: 1900, height: 1000 });
+		win.isFullScreen.mockReturnValue(true);
+
+		handleDisplayConfigurationChange("displays", shrunkDisplay);
+
+		expect(win.setFrame).not.toHaveBeenCalled();
+	});
+
+	it("keeps going after one window throws", () => {
+		const broken = spawnWithFrame({ x: 0, y: 0, width: 1900, height: 1000 });
+		broken.getFrame.mockImplementation(() => {
+			throw new Error("window is gone");
+		});
+		const healthy = spawnWithFrame({ x: 0, y: 0, width: 1900, height: 1000 });
+
+		expect(() => handleDisplayConfigurationChange("displays", shrunkDisplay)).not.toThrow();
+		expect(healthy.setFrame).toHaveBeenCalledWith(0, 0, 1280, 720);
+	});
+
+	it("handles a wake the same way, so a layout that flipped and flipped back is still checked", () => {
+		const win = spawnWithFrame({ x: 0, y: 0, width: 1900, height: 1000 });
+
+		handleDisplayConfigurationChange("wake", shrunkDisplay);
+
+		expect(win.setFrame).toHaveBeenCalledWith(0, 0, 1280, 720);
 	});
 });

--- a/src/bun/display-watch.ts
+++ b/src/bun/display-watch.ts
@@ -1,0 +1,71 @@
+import type { DisplayLike } from "./window-state";
+
+/**
+ * Electrobun exposes no display-configuration and no sleep/wake event (Screen is
+ * a poll-only API, and window events are limited to move/resize/focus/blur/close),
+ * so both are inferred here from one cheap timer.
+ */
+
+export type DisplayChangeReason = "displays" | "wake";
+
+/** Opaque timer handle — the global setInterval's return type differs per runtime. */
+type TimerHandle = unknown;
+
+export interface DisplayWatchOptions {
+	getDisplays: () => DisplayLike[];
+	onChange: (event: { reason: DisplayChangeReason; displays: DisplayLike[]; signature: string }) => void;
+	intervalMs?: number;
+	/** Injected in tests; the app uses the wall clock. */
+	now?: () => number;
+	setInterval?: (fn: () => void, ms: number) => TimerHandle;
+	clearInterval?: (handle: TimerHandle) => void;
+}
+
+/** Stable text form of the whole display layout — geometry and scale both matter. */
+export function displaySignature(displays: DisplayLike[]): string {
+	return displays
+		.map((d) => `${d.id}:${d.bounds.x},${d.bounds.y},${d.bounds.width},${d.bounds.height}@${d.scaleFactor ?? 1}`)
+		.sort()
+		.join("|");
+}
+
+/**
+ * Timers do not run while the machine is asleep, so a tick arriving much later
+ * than scheduled is the wake signal. The multiplier keeps ordinary event-loop
+ * stalls (GC, a busy machine) from being misread as a wake.
+ */
+const WAKE_GAP_MULTIPLIER = 3;
+
+export const DISPLAY_WATCH_INTERVAL_MS = 5000;
+
+/** Start polling; returns a stop function. */
+export function startDisplayWatch(opts: DisplayWatchOptions): () => void {
+	const intervalMs = opts.intervalMs ?? DISPLAY_WATCH_INTERVAL_MS;
+	const now = opts.now ?? Date.now;
+	const setTimer: (fn: () => void, ms: number) => TimerHandle =
+		opts.setInterval ?? ((fn, ms) => setInterval(fn, ms));
+	const clearTimer: (handle: TimerHandle) => void =
+		opts.clearInterval ?? ((handle) => clearInterval(handle as Parameters<typeof clearInterval>[0]));
+
+	let signature = displaySignature(opts.getDisplays());
+	let lastTick = now();
+
+	const handle = setTimer(() => {
+		const tick = now();
+		const slept = tick - lastTick > intervalMs * WAKE_GAP_MULTIPLIER;
+		lastTick = tick;
+
+		const displays = opts.getDisplays();
+		const next = displaySignature(displays);
+		const changed = next !== signature;
+		signature = next;
+
+		// A sleep/wake cycle can end on the exact layout it started with, so the
+		// signature alone would miss it — report the wake anyway. Both together
+		// still report once: a changed layout is the more specific reason.
+		if (changed) opts.onChange({ reason: "displays", displays, signature: next });
+		else if (slept) opts.onChange({ reason: "wake", displays, signature: next });
+	}, intervalMs);
+
+	return () => clearTimer(handle);
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,9 +1,11 @@
 import Electrobun, {
 	ApplicationMenu,
 	PATHS,
+	Screen,
 	Updater,
 	Utils,
 } from "electrobun/bun";
+import { startDisplayWatch } from "./display-watch";
 import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited, consumeRecentWatchedNotification, setAppForeground, setFocusMode, pushTerminalBell } from "./rpc-handlers";
 import {
 	startAutoCheck,
@@ -45,7 +47,7 @@ import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import { startLoopMonitor } from "./loop-monitor";
-import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
+import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
 import electrobunConfig, { cliBinaryName } from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
 import { existsSync, writeSync } from "node:fs";
@@ -521,6 +523,14 @@ startPortScanPoller(
 	},
 	getActiveSessionIds,
 );
+
+// Watch the display layout (no such event exists in Electrobun — see display-watch).
+// Logs both sides of the geometry after a resolution change or a wake, and pulls a
+// window back if the new layout left part of it on no screen.
+startDisplayWatch({
+	getDisplays: () => Screen.getAllDisplays(),
+	onChange: ({ reason, displays }) => handleDisplayConfigurationChange(reason, displays),
+});
 
 // Start background resource usage monitor (discovers tmux sessions directly, not via pty-server)
 startResourceMonitor((name, payload) => {

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -1,7 +1,7 @@
 import { BrowserView, BrowserWindow, Screen } from "electrobun/bun";
 import type { AppRPCSchema } from "../shared/types";
 import { createLogger } from "./logger";
-import { loadWindowState, saveWindowState, resolveRestoreFrame, displayContaining, type Rect } from "./window-state";
+import { loadWindowState, saveWindowState, resolveRestoreFrame, displayContaining, offscreenFrameClamp, type DisplayLike, type Rect } from "./window-state";
 import { isFreshStartMode } from "./fresh-start";
 import { applyWindowsWindowIcon } from "./windows-icons/apply-window-icon";
 
@@ -54,6 +54,50 @@ export function flushWindowState(): void {
 	}
 	const win = getFocusedWindow();
 	if (win) captureWindowState(win);
+}
+
+/**
+ * React to a display-configuration change (or a wake) reported by `display-watch`.
+ *
+ * The geometry line is the point of this function: two field reports of a broken
+ * layout after a resolution change arrived with no way to tell whether the window
+ * had outgrown the screen or the page had merely laid out stale. Pair it with the
+ * renderer's own `viewport` line to compare both sides.
+ *
+ * The clamp itself only fires when part of the window sits on no screen at all —
+ * the saved frame has always been clamped on startup (`resolveRestoreFrame`), the
+ * live window never was.
+ */
+export function handleDisplayConfigurationChange(reason: string, displays: DisplayLike[]): void {
+	for (const entry of windows) {
+		const win = entry.window;
+		try {
+			const frame = win.getFrame();
+			const fullscreen = win.isFullScreen();
+			const host = displayContaining(frame, displays);
+			log.info("Display configuration changed", {
+				reason,
+				id: entry.id,
+				fullscreen,
+				frame: `${frame.width}x${frame.height}+${frame.x}+${frame.y}`,
+				displays: displays.map((d) => `${d.id}:${d.bounds.width}x${d.bounds.height}@${d.scaleFactor ?? 1}`).join(" "),
+				host: host ? host.id : null,
+			});
+			// macOS owns a fullscreen window's frame; setFrame would fight it.
+			if (fullscreen) continue;
+			const pullBack = offscreenFrameClamp(frame, displays);
+			if (!pullBack) continue;
+			log.info("Pulling window back onto a screen", {
+				id: entry.id,
+				from: `${frame.width}x${frame.height}+${frame.x}+${frame.y}`,
+				to: `${pullBack.frame.width}x${pullBack.frame.height}+${pullBack.frame.x}+${pullBack.frame.y}`,
+				display: pullBack.display.id,
+			});
+			win.setFrame(pullBack.frame.x, pullBack.frame.y, pullBack.frame.width, pullBack.frame.height);
+		} catch (err) {
+			log.warn("Display change handling failed for one window", { id: entry.id, error: String(err) });
+		}
+	}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/bun/window-state.ts
+++ b/src/bun/window-state.ts
@@ -28,6 +28,8 @@ export interface WindowState {
 export interface DisplayLike {
 	id: number;
 	bounds: Rect;
+	scaleFactor?: number;
+	isPrimary?: boolean;
 }
 
 // New sibling file under ~/.dev3.0/ — never renames or touches projects.json/tasks.json
@@ -97,6 +99,59 @@ function clamp(v: number, lo: number, hi: number): number {
 	return Math.max(lo, Math.min(hi, v));
 }
 
+/** Fit a frame inside a display's bounds, shrinking it only if it does not fit. */
+export function clampFrameToDisplay(frame: Rect, bounds: Rect): Rect {
+	const width = Math.min(frame.width, bounds.width);
+	const height = Math.min(frame.height, bounds.height);
+	return {
+		x: clamp(frame.x, bounds.x, bounds.x + bounds.width - width),
+		y: clamp(frame.y, bounds.y, bounds.y + bounds.height - height),
+		width,
+		height,
+	};
+}
+
+function intersectionArea(a: Rect, b: Rect): number {
+	const w = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
+	const h = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
+	return w > 0 && h > 0 ? w * h : 0;
+}
+
+/**
+ * A window is only pulled back when part of it sits on NO screen at all — a
+ * window deliberately spanning two monitors must stay where the user put it, so
+ * we measure coverage against the union of every display (they tile without
+ * overlap in the global coordinate space, so summing intersections is exact).
+ *
+ * Returns null when nothing needs moving.
+ */
+export function offscreenFrameClamp(
+	frame: Rect,
+	displays: DisplayLike[],
+	tolerancePx = 2,
+): { frame: Rect; display: DisplayLike } | null {
+	if (!displays.length) return null;
+	const area = frame.width * frame.height;
+	if (area <= 0) return null;
+	const covered = displays.reduce((sum, d) => sum + intersectionArea(frame, d.bounds), 0);
+	// Slack for a hairline sliver: rounding and shadow insets must not count as offscreen.
+	const slack = tolerancePx * 2 * (frame.width + frame.height);
+	if (covered >= area - slack) return null;
+
+	let host = displays.find((d) => d.isPrimary) ?? displays[0]!;
+	let hostArea = 0;
+	for (const d of displays) {
+		const a = intersectionArea(frame, d.bounds);
+		if (a > hostArea) {
+			hostArea = a;
+			host = d;
+		}
+	}
+	const clamped = clampFrameToDisplay(frame, host.bounds);
+	if (boundsEqual(clamped, frame)) return null;
+	return { frame: clamped, display: host };
+}
+
 /**
  * Resolve a restorable frame for the saved state against the *current* displays.
  * Returns null when the saved screen is gone (e.g. laptop undocked) so the caller
@@ -112,12 +167,7 @@ export function resolveRestoreFrame(
 		displays.find((d) => boundsEqual(d.bounds, state.displayBounds));
 	if (!disp) return null;
 
-	const b = disp.bounds;
 	// Clamp the saved frame inside the display so it stays fully visible even if
 	// the display resolution changed since the state was written.
-	const width = Math.min(state.frame.width, b.width);
-	const height = Math.min(state.frame.height, b.height);
-	const x = clamp(state.frame.x, b.x, b.x + b.width - width);
-	const y = clamp(state.frame.y, b.y, b.y + b.height - height);
-	return { frame: { x, y, width, height }, fullscreen: state.fullscreen };
+	return { frame: clampFrameToDisplay(state.frame, disp.bounds), fullscreen: state.fullscreen };
 }

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -882,14 +882,34 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				// Adopt the PTY's shape instead and letterbox inside the container.
 				const pty = ptyGeometryRef.current;
 				if (pty && nativeRoleRef.current === "observer") {
-					try { term.resize(pty.cols, pty.rows); } catch { /* disposed */ }
+					try {
+						term.resize(pty.cols, pty.rows);
+					} catch (err) {
+						if (!disposed) {
+							logDiagnostic("refit", "error", "observer term.resize threw", { error: String(err), cols: pty.cols, rows: pty.rows });
+						}
+					}
 					return;
 				}
 				if (!fitAddon) return;
 				let dims: { cols: number; rows: number } | undefined;
-				try { dims = fitAddon.proposeDimensions(); } catch { return; /* disposed */ }
+				// A throw here on a LIVE terminal leaves the canvas frozen with no trace —
+				// exactly the blind spot behind the "terminal shows nothing after a
+				// resolution change" reports. Disposal still throws, and stays silent.
+				try {
+					dims = fitAddon.proposeDimensions();
+				} catch (err) {
+					if (!disposed) logDiagnostic("refit", "error", "proposeDimensions threw", { error: String(err) });
+					return;
+				}
 				if (!dims) return;
-				try { term.resize(dims.cols, dims.rows); } catch { /* disposed */ }
+				try {
+					term.resize(dims.cols, dims.rows);
+				} catch (err) {
+					if (!disposed) {
+						logDiagnostic("refit", "error", "term.resize threw", { error: String(err), cols: dims.cols, rows: dims.rows });
+					}
+				}
 			}
 
 			refitRef.current = refitToContainer;

--- a/src/mainview/__tests__/viewport-diagnostics.test.ts
+++ b/src/mainview/__tests__/viewport-diagnostics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../rpc", () => ({
+	api: { request: { logRendererDiagnostic: vi.fn(() => Promise.resolve()) } },
+}));
+
+import { api } from "../rpc";
+import { startViewportDiagnostics } from "../viewport-diagnostics";
+
+const logDiagnostic = api.request.logRendererDiagnostic as unknown as ReturnType<typeof vi.fn>;
+
+function setViewport(width: number, height: number, dpr: number) {
+	Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+	Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+	Object.defineProperty(window, "devicePixelRatio", { value: dpr, configurable: true });
+}
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	logDiagnostic.mockClear();
+	setViewport(1440, 900, 2);
+});
+
+afterEach(() => {
+	stop?.();
+	stop = null;
+	vi.useRealTimers();
+});
+
+describe("startViewportDiagnostics", () => {
+	it("reports the viewport once at startup", () => {
+		stop = startViewportDiagnostics();
+
+		expect(logDiagnostic).toHaveBeenCalledTimes(1);
+		expect(logDiagnostic.mock.calls[0][0]).toMatchObject({
+			tag: "viewport",
+			extra: { innerWidth: 1440, innerHeight: 900, devicePixelRatio: 2 },
+		});
+	});
+
+	it("reports a resolution change, including a devicePixelRatio flip", () => {
+		stop = startViewportDiagnostics();
+		logDiagnostic.mockClear();
+
+		setViewport(1280, 800, 1);
+		window.dispatchEvent(new Event("resize"));
+		vi.advanceTimersByTime(600);
+
+		expect(logDiagnostic).toHaveBeenCalledTimes(1);
+		expect(logDiagnostic.mock.calls[0][0].extra).toMatchObject({ innerWidth: 1280, devicePixelRatio: 1 });
+	});
+
+	it("writes nothing when a resize lands on the same geometry", () => {
+		stop = startViewportDiagnostics();
+		logDiagnostic.mockClear();
+
+		window.dispatchEvent(new Event("resize"));
+		vi.advanceTimersByTime(600);
+
+		expect(logDiagnostic).not.toHaveBeenCalled();
+	});
+
+	it("collapses a drag into one line instead of one per event", () => {
+		stop = startViewportDiagnostics();
+		logDiagnostic.mockClear();
+
+		for (const width of [1400, 1360, 1320, 1300]) {
+			setViewport(width, 900, 2);
+			window.dispatchEvent(new Event("resize"));
+			vi.advanceTimersByTime(50);
+		}
+		vi.advanceTimersByTime(600);
+
+		expect(logDiagnostic).toHaveBeenCalledTimes(1);
+		expect(logDiagnostic.mock.calls[0][0].extra).toMatchObject({ innerWidth: 1300 });
+	});
+
+	it("stops reporting after it is stopped", () => {
+		const stopFn = startViewportDiagnostics();
+		stopFn();
+		logDiagnostic.mockClear();
+
+		setViewport(1000, 700, 1);
+		window.dispatchEvent(new Event("resize"));
+		vi.advanceTimersByTime(600);
+
+		expect(logDiagnostic).not.toHaveBeenCalled();
+	});
+
+	it("survives a dead RPC bridge without throwing", () => {
+		logDiagnostic.mockImplementation(() => {
+			throw new Error("bridge is dead");
+		});
+
+		expect(() => {
+			stop = startViewportDiagnostics();
+		}).not.toThrow();
+	});
+});

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -14,6 +14,7 @@ import { initAutoFullscreen } from "./fullscreen";
 import { initKeyboardLock } from "./keyboard-lock";
 import { bootstrapZoom } from "./zoom";
 import { bootstrapScrollSpeed } from "./scroll-speed";
+import { startViewportDiagnostics } from "./viewport-diagnostics";
 import { getInitialThemeState, getWindowInjectedThemeState } from "./theme-bootstrap";
 import { initStreamerMode } from "./streamer-mode";
 import { buildChannelTitlePrefix } from "../shared/update-channel";
@@ -100,6 +101,10 @@ initFeatureFlags();
 
 // Load saved terminal scroll speed into cache before terminals mount
 bootstrapScrollSpeed();
+
+// Mirror the page's own geometry into the backend log — the other half of the
+// display-change diagnostic the backend writes (see viewport-diagnostics.ts).
+startViewportDiagnostics();
 
 // Apply saved locale before React mounts
 const savedLocale = localStorage.getItem("dev3-locale") || "en";

--- a/src/mainview/viewport-diagnostics.ts
+++ b/src/mainview/viewport-diagnostics.ts
@@ -1,0 +1,51 @@
+import { api } from "./rpc";
+
+/**
+ * Report the page's own view of its geometry into the backend log, so a broken
+ * layout after a resolution change or a wake can be read off one file: the
+ * backend writes the window frame and the display bounds, this writes what the
+ * page believes. If the two disagree the viewport went stale; if they agree the
+ * geometry was never the problem.
+ *
+ * Only real changes are reported, so an idle app writes nothing.
+ */
+
+const DEBOUNCE_MS = 500;
+
+export function startViewportDiagnostics(): () => void {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let last = "";
+
+	function report() {
+		const width = window.innerWidth;
+		const height = window.innerHeight;
+		const dpr = window.devicePixelRatio;
+		const signature = `${width}x${height}@${dpr}`;
+		if (signature === last) return;
+		last = signature;
+		try {
+			void api.request
+				.logRendererDiagnostic({
+					level: "info",
+					tag: "viewport",
+					message: "renderer viewport",
+					extra: { innerWidth: width, innerHeight: height, devicePixelRatio: dpr },
+				})
+				?.catch(() => {});
+		} catch {
+			/* diagnostics only — never break the app */
+		}
+	}
+
+	function schedule() {
+		if (timer) clearTimeout(timer);
+		timer = setTimeout(report, DEBOUNCE_MS);
+	}
+
+	report();
+	window.addEventListener("resize", schedule);
+	return () => {
+		if (timer) clearTimeout(timer);
+		window.removeEventListener("resize", schedule);
+	};
+}


### PR DESCRIPTION
Two field reports — a black terminal with content running past the window edge after a monitor resolution change, and lost mouse interaction after a long sleep — could not be reproduced, and the reporter confirmed a manual window resize does **not** fix it while a restart does. So this ships the one asymmetry that explains that pair plus the diagnostics needed to identify the cause on the next report; it deliberately does not guess at a behavioural fix.

**The asymmetry.** `resolveRestoreFrame` has always clamped a *saved* frame into the current display bounds on startup. Nothing ever clamped a *live* window, so a resolution change could leave part of it on no screen at all — and only a restart cured it. `offscreenFrameClamp` now pulls such a window back, measuring coverage against the union of every display so a window deliberately spanning two monitors and a hairline sliver are both left alone. A fullscreen window is never touched; macOS owns its frame.

**The trigger.** Electrobun exposes no display-configuration and no sleep/wake event, so `display-watch.ts` polls the layout every 5 s and reports `displays` (signature changed) or `wake` (a tick arrived 3× late — timers do not run while asleep, and a sleep can end on the layout it started with).

**The diagnostics.** The same trigger logs the window frame and the display bounds; `viewport-diagnostics.ts` mirrors the renderer's `innerWidth`/`innerHeight`/`devicePixelRatio`. One log file now holds both sides, so "the window outgrew the screen" and "the page laid out stale" stop being indistinguishable. The two empty `catch` blocks in `refitToContainer` now log through the existing renderer diagnostic sink — a refit that throws on a live terminal used to leave no trace anywhere.

Verified: full suite green (3876 + 5930 + 786), guards mutation-tested, and the renderer line confirmed end-to-end in a browser — it captured a `devicePixelRatio` flip from 2 to 1.

Decision record: `decisions/2026/08/17/display-change-poll-and-live-frame-clamp.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6d95c182-a97f-48ce-818e-6e8bdc47bfe3) · `dev3://task/6d95c182-a97f-48ce-818e-6e8bdc47bfe3`