### PR TITLE
Rebuild a terminal whose ghostty renderer died instead of leaving a blank pane

### DIFF
--- a/change-logs/2026/08/18/fix-terminal-renderer-crash-recovery.md
+++ b/change-logs/2026/08/18/fix-terminal-renderer-crash-recovery.md
@@ -1,0 +1,8 @@
+Short: Blank terminal now heals itself
+
+A terminal pane that went permanently blank — ghostty-web's render loop stops for
+good after a single throw inside a resize, so neither a window resize nor a
+fullscreen toggle brought it back — now rebuilds itself and reattaches to the
+still-running session. Both observed crashes are covered (an out-of-range
+codepoint and a WASM out-of-bounds access), and if three rebuilds in a row fail
+you get a toast offering the window reload that does fix it.

--- a/decisions/2026/08/18/terminal-renderer-crash-self-heal.md
+++ b/decisions/2026/08/18/terminal-renderer-crash-self-heal.md
@@ -1,0 +1,58 @@
+# Rebuild the terminal when ghostty-web's render loop dies
+
+## Context
+
+Users reported a terminal pane that showed nothing while the agent kept working:
+"на любой задаче", not a freeze, and immune to a window resize or a fullscreen
+toggle — only restarting the app helped. The geometry diagnostics added the day
+before (`display-change-poll-and-live-frame-clamp`) caught it on the first day.
+
+## Investigation
+
+Two crashes, both arriving through `term.resize` from `refitToContainer`:
+
+- `2026-08-18 10:19:17` — `RangeError: Arguments contain a value that is out of
+  range of code points`, at `cols: 257`, right after a PTY reconnect. The draw
+  path calls `String.fromCodePoint(cell.codepoint || 32)` with no range guard,
+  while the sibling `getChars()` in the same bundle does guard. Five more of these
+  sit in the logs on 08-15 and 08-16.
+- `2026-08-18 11:18:11` — `RuntimeError: Out of bounds memory access` at
+  `cols: 158`, triggered by dragging the artifact panel. 116 traps followed, frame
+  paced (a scrollbar-fade loop re-renders and re-throws), and eventually
+  `ghostty_terminal_resize` itself trapped: the WASM terminal is gone, not just
+  the frame.
+
+Why it is permanent: `startRenderLoop` schedules the next frame only *after*
+`renderer.render()` returns, with no try/catch, so one throw ends the loop for
+good — and the method is private, so nothing outside can restart it. Upstream main
+has since wrapped `resize` in try/catch and cancels the loop around it (its
+comment names "detached TypedArray views"), but the loop body is still unguarded
+and **there is no release after v0.4.0**, so a version bump cannot fix it.
+
+## Decision
+
+`recoverFromRendererCrash` in `src/mainview/TerminalView.tsx` rebuilds the pane:
+the three `catch` blocks in `refitToContainer` bump a `terminalGeneration` that the
+terminal effect depends on, so the old Terminal is disposed and a fresh one (fresh
+WASM handle) attaches, with tmux repainting into it. Budget: 3 rebuilds, reset
+after 60 s of health, then a toast offering `window.location.reload()` — the only
+cure left if the shared WASM module itself is corrupt.
+
+## Risks
+
+- A rebuild costs a reattach (tmux repaint) and drops local canvas scrollback
+  state. Acceptable against a permanently blank pane.
+- If a rebuilt terminal dies instantly, the budget stops the loop after 3 tries;
+  the toast is the escape hatch rather than an automatic page reload, which would
+  be a big hammer to fire without the user's knowledge.
+- The bad codepoint / OOB access itself is upstream and stays unfixed here.
+
+## Alternatives considered
+
+- **Restart the render loop instead of the terminal.** Impossible from outside:
+  `startRenderLoop` is private, and in the WASM-trap case even
+  `ghostty_terminal_resize` traps, so re-rendering could not help anyway.
+- **Vendor or pin ghostty-web's main.** Gets upstream's try/catch but takes us off
+  a released version onto a moving target, and leaves the loop body unguarded.
+- **Auto-reload the window on the first crash.** Cures it, but throws away every
+  pane's state for a fault that one pane rebuild usually fixes.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Terminal, FitAddon } from "ghostty-web";
 import { useT } from "./i18n";
 import { toast } from "./toast";
@@ -95,6 +95,10 @@ const TERMINAL_BASE_FONT_SIZE = 14;
  * already three dropped frames — worth a line, while staying quiet in normal use.
  */
 const TERMINAL_DISPOSE_BUDGET_MS = 50;
+/** Rebuilds allowed per mounted pane before we stop and ask for a window reload. */
+const MAX_RENDERER_RECOVERIES = 3;
+/** A pane healthy for this long earns its rebuild budget back. */
+const RECOVERY_BUDGET_RESET_MS = 60_000;
 
 /**
  * How long the sync gate waits for the first repaint before lifting itself.
@@ -272,6 +276,11 @@ interface TerminalViewProps {
 
 function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSessionLost, touchComposeMode }: TerminalViewProps) {
 	const t = useT();
+	// Rebuild budget for a dead ghostty renderer (see recoverFromRendererCrash).
+	const [terminalGeneration, setTerminalGeneration] = useState(0);
+	const recoveryAttemptsRef = useRef(0);
+	const lastRecoveryAtRef = useRef(0);
+	const recoverFromRendererCrashRef = useRef<((reason: string, error: string) => void) | null>(null);
 	// Mirror t in a ref so the long-lived terminal-setup effect's closures
 	// (e.g. the select-to-copy hint) always read the latest translator.
 	const tRef = useRef(t);
@@ -410,6 +419,42 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	) {
 		logDiagnostic("terminal-copy", level, message, extra);
 	}
+
+	/**
+	 * Rebuild the terminal after ghostty-web's renderer died.
+	 *
+	 * `startRenderLoop` schedules the next frame only AFTER a successful render and
+	 * is private, so a single throw inside `render()` stops the terminal forever:
+	 * the pane goes blank, the PTY and tmux keep running, and neither a resize nor a
+	 * fullscreen toggle can bring it back — only a fresh Terminal can. Both crashes
+	 * seen in the field arrive through `term.resize` (a JS `RangeError` from an
+	 * unguarded `String.fromCodePoint` in the draw path, and a WASM
+	 * `Out of bounds memory access`), which is why this hangs off that one catch.
+	 *
+	 * Bumping the generation re-runs the terminal effect: full dispose, fresh
+	 * Terminal, fresh WASM handle, and tmux repaints into it on attach.
+	 */
+	const recoverFromRendererCrash = useCallback((reason: string, error: string) => {
+		// The budget guards against a rebuild loop, not against a second crash an hour
+		// later — so a pane that has been healthy for a while starts over with a full
+		// budget instead of silently losing the ability to heal itself.
+		const now = Date.now();
+		if (now - lastRecoveryAtRef.current > RECOVERY_BUDGET_RESET_MS) recoveryAttemptsRef.current = 0;
+		lastRecoveryAtRef.current = now;
+		const attempt = recoveryAttemptsRef.current + 1;
+		// A rebuild that instantly dies again means the shared WASM module itself is
+		// corrupt — no number of retries fixes that, so stop and hand the user the
+		// one action that does (reloading the window; tmux keeps the session alive).
+		if (attempt > MAX_RENDERER_RECOVERIES) {
+			logDiagnostic("terminal-recover", "error", "giving up on terminal recovery", { reason, error, attempt });
+			toast.error(t("terminal.rendererCrashed"), { taskId, onClick: () => window.location.reload() });
+			return;
+		}
+		recoveryAttemptsRef.current = attempt;
+		logDiagnostic("terminal-recover", "warn", "rebuilding the terminal after a renderer crash", { reason, error, attempt });
+		setTerminalGeneration((generation) => generation + 1);
+	}, [t, taskId]);
+	recoverFromRendererCrashRef.current = recoverFromRendererCrash;
 
 	useEffect(() => {
 		const observer = new MutationObserver(() => {
@@ -887,6 +932,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					} catch (err) {
 						if (!disposed) {
 							logDiagnostic("refit", "error", "observer term.resize threw", { error: String(err), cols: pty.cols, rows: pty.rows });
+							recoverFromRendererCrashRef.current?.("observer-resize", String(err));
 						}
 					}
 					return;
@@ -899,7 +945,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				try {
 					dims = fitAddon.proposeDimensions();
 				} catch (err) {
-					if (!disposed) logDiagnostic("refit", "error", "proposeDimensions threw", { error: String(err) });
+					if (!disposed) {
+						logDiagnostic("refit", "error", "proposeDimensions threw", { error: String(err) });
+						recoverFromRendererCrashRef.current?.("propose-dimensions", String(err));
+					}
 					return;
 				}
 				if (!dims) return;
@@ -908,6 +957,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				} catch (err) {
 					if (!disposed) {
 						logDiagnostic("refit", "error", "term.resize threw", { error: String(err), cols: dims.cols, rows: dims.rows });
+						recoverFromRendererCrashRef.current?.("fit-resize", String(err));
 					}
 				}
 			}
@@ -1726,7 +1776,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				});
 			}
 		};
-	}, [ptyUrl, taskId]);
+	}, [ptyUrl, taskId, terminalGeneration]);
 
 	useEffect(() => {
 		try {

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -2,6 +2,8 @@ import { render, act, fireEvent, waitFor } from "@testing-library/react";
 import TerminalView, { type TerminalHandle, TERMINAL_SYNC_GATE_TIMEOUT_MS, buildResizeDance, buildCursorMoveSequence, clearStaleSelectionOnWrite, normalizePastedText } from "../TerminalView";
 import { I18nProvider } from "../i18n";
 import { api } from "../rpc";
+import { Terminal } from "ghostty-web";
+import { toast } from "../toast";
 import type { NativeStreamRole } from "../../shared/native-terminal-stream";
 import {
 	resetTerminalBidiForTests,
@@ -1827,5 +1829,118 @@ describe("TerminalView – remote sync gate", () => {
 			webSockets[0].onclose?.({ code: 4001, reason: "Unknown session", wasClean: false } as CloseEvent);
 		});
 		expect(view.queryByTestId("terminal-sync-gate")).toBeNull();
+	});
+});
+
+describe("TerminalView – renderer crash recovery", () => {
+	/**
+	 * ghostty-web's render loop reschedules only after a successful render and is
+	 * private, so one throw out of `term.resize` blanks the pane for good. These
+	 * cover the only cure available from outside: rebuild the terminal.
+	 */
+	const REFIT_DEBOUNCE_MS = 150;
+
+	/**
+	 * TerminalView replaces the addon's `proposeDimensions` with the real
+	 * scrollbar-free measurement, which needs live layout metrics and returns
+	 * undefined in happy-dom — so a refit would never reach `term.resize`. Put a
+	 * fixed geometry back on the very object TerminalView calls.
+	 */
+	function makeRefitsMeasurable() {
+		const addon = fitAddonHolder.current as unknown as { proposeDimensions: () => { cols: number; rows: number } };
+		addon.proposeDimensions = () => ({ cols: 80, rows: 24 });
+	}
+
+	async function settleObserver() {
+		makeRefitsMeasurable();
+		await act(async () => {
+			fireResize?.();
+			await new Promise((resolve) => setTimeout(resolve, REFIT_DEBOUNCE_MS));
+		});
+	}
+
+	async function crashOnNextRefit(error: Error) {
+		// A rebuilt terminal spends its first observer callback on the initial fit
+		// (fitAddon.fit(), which never reaches term.resize), so spend that one first.
+		await settleObserver();
+		mockTermInstance.resize.mockImplementationOnce(() => {
+			throw error;
+		});
+		await settleObserver();
+	}
+
+	it("rebuilds the terminal when a resize throws a WASM trap", async () => {
+		await renderAndSetup();
+		const builtBefore = vi.mocked(Terminal).mock.calls.length;
+
+		await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+
+		expect(vi.mocked(Terminal).mock.calls.length).toBeGreaterThan(builtBefore);
+	});
+
+	it("rebuilds it for the out-of-range codepoint crash too", async () => {
+		await renderAndSetup();
+		const builtBefore = vi.mocked(Terminal).mock.calls.length;
+
+		await crashOnNextRefit(new RangeError("Arguments contain a value that is out of range of code points"));
+
+		expect(vi.mocked(Terminal).mock.calls.length).toBeGreaterThan(builtBefore);
+	});
+
+	it("reports the crash to the backend log with the geometry it died on", async () => {
+		await renderAndSetup();
+		vi.mocked(api.request.logRendererDiagnostic).mockClear();
+
+		await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+
+		const tags = vi.mocked(api.request.logRendererDiagnostic).mock.calls.map((c) => (c[0] as { tag: string }).tag);
+		expect(tags).toContain("refit");
+		expect(tags).toContain("terminal-recover");
+	});
+
+	it("leaves a healthy terminal alone", async () => {
+		await renderAndSetup();
+		const builtBefore = vi.mocked(Terminal).mock.calls.length;
+		makeRefitsMeasurable();
+
+		await act(async () => {
+			fireResize?.();
+			await new Promise((resolve) => setTimeout(resolve, REFIT_DEBOUNCE_MS));
+		});
+
+		expect(mockTermInstance.resize).toHaveBeenCalled();
+		expect(vi.mocked(Terminal).mock.calls.length).toBe(builtBefore);
+		expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+	});
+
+	it("stops rebuilding after the budget and offers a window reload instead", async () => {
+		await renderAndSetup();
+
+		for (let i = 0; i < 4; i++) {
+			await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+		}
+		const builtAfterBudget = vi.mocked(Terminal).mock.calls.length;
+		await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+
+		expect(vi.mocked(toast.error)).toHaveBeenCalled();
+		expect(vi.mocked(Terminal).mock.calls.length).toBe(builtAfterBudget);
+	});
+
+	it("earns the budget back after a stretch of health", async () => {
+		await renderAndSetup();
+		for (let i = 0; i < 4; i++) {
+			await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+		}
+		expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+
+		const realNow = Date.now;
+		Date.now = () => realNow() + 10 * 60_000;
+		try {
+			const builtBefore = vi.mocked(Terminal).mock.calls.length;
+			await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+			expect(vi.mocked(Terminal).mock.calls.length).toBeGreaterThan(builtBefore);
+		} finally {
+			Date.now = realNow;
+		}
 	});
 });

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -245,6 +245,7 @@ const terminal = {
 	"terminal.filePreviewContentCopied": "Content copied",
 	"terminal.filePreviewRendered": "Rendered",
 	"terminal.filePreviewRaw": "Raw",
+	"terminal.rendererCrashed": "The terminal renderer crashed and could not restart itself. Click to reload the window — your session keeps running.",
 } as const;
 
 export default terminal;

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -245,6 +245,7 @@ const terminal = {
 	"terminal.filePreviewContentCopied": "Contenido copiado",
 	"terminal.filePreviewRendered": "Renderizado",
 	"terminal.filePreviewRaw": "Sin formato",
+	"terminal.rendererCrashed": "El renderizador del terminal falló y no pudo reiniciarse solo. Haz clic para recargar la ventana — tu sesión sigue activa.",
 };
 
 export default terminal;

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -253,6 +253,7 @@ const terminal = {
 	"terminal.filePreviewContentCopied": "Содержимое скопировано",
 	"terminal.filePreviewRendered": "Рендер",
 	"terminal.filePreviewRaw": "Исходник",
+	"terminal.rendererCrashed": "Отрисовщик терминала упал и не смог подняться сам. Нажмите, чтобы перезагрузить окно — сессия продолжает работать.",
 };
 
 export default terminal;


### PR DESCRIPTION
Found the black-terminal bug with the log lines to prove it — the geometry diagnostics from #1402 caught it on their first day. Reported upstream as coder/ghostty-web#189.

**Note:** #1404 was a dud — its branch had been deleted under it, so it squashed the already-merged #1402 diff and landed an empty commit. This PR carries the actual fix.

**Why it is permanent.** ghostty-web's `startRenderLoop` schedules the next frame only *after* `renderer.render()` returns, with no try/catch — one throw and the loop is over for good. The method is private, so nothing outside can restart it: the pane goes blank while the PTY, tmux and the agent keep running, and neither a window resize nor a fullscreen toggle brings it back. Only a fresh Terminal can.

**Two crashes seen in the field, both arriving through `term.resize`:**

| When | Error | Geometry | Trigger |
|---|---|---|---|
| 10:19:17 | `RangeError: Arguments contain a value that is out of range of code points` | `cols: 257` | PTY reconnect after a resolution change |
| 11:18:11 | `RuntimeError: Out of bounds memory access` | `cols: 158` | dragging the artifact panel |

The first comes from an unguarded `String.fromCodePoint(cell.codepoint || 32)` in the draw path — the sibling `getChars()` in the same bundle *does* range-guard. Five more sit in the logs on 08-15 and 08-16. The second is worse: 116 traps followed, frame-paced, and eventually `ghostty_terminal_resize` itself trapped, so the WASM terminal was gone, not just the frame.

The underlying resize/realloc race is already fixed upstream in coder/ghostty-web#132, but that fix is unreleased — npm's latest is still v0.4.0, which is what we ship — so a version bump cannot help today.

**The fix.** The three `catch` blocks in `refitToContainer` now bump a `terminalGeneration` the terminal effect depends on: the dead Terminal is disposed, a fresh one attaches, and tmux repaints into it. Budget of 3 rebuilds, reset after 60 s of health, then a toast offering the window reload that does cure a corrupt shared WASM module.

Verified: full suite green before the rebase (3882 + 5930 + 786), `TerminalView.test.tsx` green after it (97), the new guards mutation-tested (removing the recovery call fails 5 of 6; making the budget infinite fails 2), and a browser pass confirms terminals still mount exactly once with no remount churn.

Heads-up unrelated to this PR: `bun run lint` currently fails on a clean `origin/main` in `src/mainview/components/pr-review/markdown.tsx` (four `TS7031` implicit-any bindings), reproduced in a detached worktree of main with the same `node_modules`. Looks like a dependency-version drift from #1343 rather than anything in this branch.

Decision record: `decisions/2026/08/18/terminal-renderer-crash-self-heal.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6d95c182-a97f-48ce-818e-6e8bdc47bfe3) · `dev3://task/6d95c182-a97f-48ce-818e-6e8bdc47bfe3`