### PR TITLE
Keep a terminal painting through a bad frame, and notice a loop that stopped

### DIFF
--- a/change-logs/2026/08/18/fix-terminal-render-guard.md
+++ b/change-logs/2026/08/18/fix-terminal-render-guard.md
@@ -1,0 +1,7 @@
+Short: Terminal survives a bad frame
+
+The terminal now keeps painting through a frame that crashes instead of going
+blank for good, and a pane that stopped painting with no error at all is detected
+and rebuilt. Two catch blocks that used to swallow ghostty crashes silently now
+log them with the byte and frame counts around the failure, so a blank pane can be
+diagnosed from the log instead of guessed at.

--- a/decisions/2026/08/18/terminal-render-guard.md
+++ b/decisions/2026/08/18/terminal-render-guard.md
@@ -1,0 +1,62 @@
+# Guard every terminal frame instead of only the resize path
+
+## Context
+
+Third incident of a permanently blank terminal, 2026-08-18 ~14:00. The rebuild
+shipped hours earlier (`terminal-renderer-crash-self-heal`) never fired: the log
+held no `[refit]` line, no `[error]` line, nothing. The user restarted the app.
+
+## Investigation
+
+The earlier fix hangs off the three `catch` blocks in `refitToContainer`, so it
+only ever sees a crash that arrives through `term.resize`. Two other paths could
+kill the renderer with no trace at all, both by deliberate design:
+
+- `enqueueTermWrite`'s flush swallowed every throw from `batchTerm.write()` with
+  the comment "Swallow ghostty-web rendering errors" — added to stop thousands of
+  `app_exception` analytics events per session.
+- the socket's `onmessage` swallowed the same class for the same reason.
+
+And a frame can also stop arriving without throwing anywhere. The log could not
+distinguish "nothing was sent to the pane" from "bytes arrived and nothing
+painted", because nothing counted either.
+
+## Decision
+
+`src/mainview/terminal-render-guard.ts` wraps `renderer.render` the way the cursor
+gate and the bidi view already do (installed last, disposed first), and:
+
+- **swallows a throwing frame** so the vendor's private loop reaches its own
+  `requestAnimationFrame` — this is coder/ghostty-web#189's first ask, implemented
+  locally, and it is what keeps a pane alive at all;
+- **reports the first three failures then every 60th**, keeping the log usable
+  when a broken frame repeats at 60 fps;
+- **watches for a stall**: the vendor renders every frame whether or not anything
+  changed, so a *visible* pane with no frame for 6 s is a dead loop by definition.
+  Hidden windows are never judged, and a window returning from hidden gets a fresh
+  clock, because rAF is paused while hidden.
+
+Both signals route into the existing `recoverFromRendererCrash` rebuild. The two
+silent catches now log (throttled) with `socketBytes` / `socketBatches` /
+`msSinceLastByte` / frame counts, and the write path also asks for a rebuild.
+
+## Risks
+
+- Swallowing a frame hides a genuine vendor bug from analytics; the throttled log
+  line plus the rebuild are the compensation, and the counters make it visible.
+- The 6 s stall threshold is a guess. It cannot fire on a hidden window; a very
+  long main-thread block on a visible window would trigger a pointless rebuild,
+  bounded by the existing 3-rebuild budget.
+- The stall detector cannot tell a dead loop from a renderer that is alive but
+  painting nothing visible; the logged counters are what tells them apart after
+  the fact.
+
+## Alternatives considered
+
+- **Leave it to the upstream fix.** coder/ghostty-web#132 addresses the
+  resize/realloc race, but it is unreleased and does not make the loop survive a
+  throw — and the silent mode is not covered by it at all.
+- **Restart the loop instead of rebuilding.** `startRenderLoop` is private; there
+  is no public way in.
+- **Keep the swallows and only add logging.** Would have diagnosed the next
+  incident but left the pane dead, which is the part the user actually feels.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -23,6 +23,7 @@ import {
 } from "./terminal-bidi/flag";
 import { installBidiRender, uninstallBidiRender } from "./terminal-bidi/proxy";
 import { installCursorVisibilityGate, type CursorVisibilityGate } from "./terminal-cursor-focus";
+import { installRenderGuard, type RenderGuard } from "./terminal-render-guard";
 import { installGlyphCellFit, type GlyphCellFit } from "./terminal-glyph-cell-fit";
 import { getScrollThreshold } from "./scroll-speed";
 import { createWheelPacer } from "./wheel-pacer";
@@ -303,6 +304,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	const copyDiagnosticsRef = useRef<TerminalCopyDiagnostics | null>(null);
 	/** Hides the cursor while input would not reach this terminal. */
 	const cursorGateRef = useRef<CursorVisibilityGate | null>(null);
+	const renderGuardRef = useRef<RenderGuard | null>(null);
 	/** Keeps block, box-drawing and powerline glyphs on the cell background's box. */
 	const glyphFitRef = useRef<GlyphCellFit | null>(null);
 	// Native backend only. The watermark is what a reconnect resumes from, so it
@@ -639,6 +641,41 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 			if (getTerminalBidiEnabled() && term.renderer) {
 				installBidiRender(term.renderer);
+			}
+
+			// Outermost render wrapper: it must survive whatever the gates above do, and
+			// it is the only place that can keep the vendor's loop alive through a bad
+			// frame or notice that the loop stopped. Installed last, disposed first.
+			if (term.renderer) {
+				renderGuardRef.current = installRenderGuard(term.renderer, {
+					onFrameError: (error, consecutive) => {
+						if (disposed) return;
+						logDiagnostic("render-guard", "error", "render frame threw", {
+							error: String(error),
+							consecutive,
+							frames: renderGuardRef.current?.framesPainted() ?? 0,
+							socketBytes,
+							socketBatches,
+						});
+						if (consecutive === 1) recoverFromRendererCrashRef.current?.("render-frame", String(error));
+					},
+					onStalled: (msSinceLastFrame) => {
+						if (disposed) return;
+						// The two numbers that make this readable: whether the loop ever ran,
+						// and whether the PTY was feeding it while it went quiet.
+						logDiagnostic("render-guard", "error", "no frames painted while visible", {
+							msSinceLastFrame,
+							frames: renderGuardRef.current?.framesPainted() ?? 0,
+							socketBytes,
+							socketBatches,
+							msSinceLastByte: lastSocketByteAt ? Date.now() - lastSocketByteAt : null,
+							writeErrors,
+							socketErrors,
+						});
+						recoverFromRendererCrashRef.current?.("render-stalled", `no frames for ${msSinceLastFrame}ms`);
+					},
+				});
+				logDiagnostic("render-guard", "info", "render guard installed", { cols: term.cols, rows: term.rows });
 			}
 
 			// File paths in output become Cmd/Ctrl+Click links; open behavior is
@@ -1408,6 +1445,22 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		let writeScheduled = false;
 		/** Whether the pending batch carries bytes from the PTY, not our own clear. */
 		let pendingFromSocket = false;
+			/**
+			 * Byte/frame bookkeeping for the render guard's diagnostics. Without these a
+			 * blank pane cannot be told apart from a pane nothing was sent to — the exact
+			 * ambiguity that made the 2026-08-18 14:00 incident unreadable in the log.
+			 */
+			let socketBytes = 0;
+			let socketBatches = 0;
+			let lastSocketByteAt = 0;
+			let writeErrors = 0;
+			let socketErrors = 0;
+
+			function noteSocketBytes(len: number): void {
+				socketBytes += len;
+				socketBatches += 1;
+				lastSocketByteAt = Date.now();
+			}
 		// Reference to the terminal for batched writes (set by connectPty)
 		let batchTerm: Terminal | null = null;
 		// Rewrites SGR colors unreadable on the current background: pale/dim
@@ -1440,8 +1493,23 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 						// ghostty-web never fires onRender, so the write batch is
 						// the "content changed" signal for the link underlines.
 						linkUnderlines?.requestRedraw();
-					} catch {
-						// Swallow ghostty-web rendering errors
+					} catch (err) {
+						// Used to be swallowed outright to keep analytics from drowning in
+						// per-frame exceptions — which also hid the crash that leaves the pane
+						// blank for good. Throttled instead of silent, and it now asks for a
+						// rebuild: a throw here means ghostty's state, not this batch, is gone.
+						writeErrors += 1;
+						if (writeErrors <= 3 || writeErrors % 60 === 0) {
+							logDiagnostic("terminal-write", "error", "term.write threw", {
+								error: String(err),
+								batchLen: batch.length,
+								fromSocket,
+								writeErrors,
+								socketBytes,
+								socketBatches,
+							});
+						}
+						if (writeErrors === 1) recoverFromRendererCrashRef.current?.("term-write", String(err));
 					}
 				});
 			}
@@ -1575,15 +1643,23 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 							return;
 						}
 						const cleaned = event.data.replace(OSC52_RE, "");
-						if (cleaned) { pendingFromSocket = true; enqueueTermWrite(cleaned); }
+						if (cleaned) { pendingFromSocket = true; noteSocketBytes(cleaned.length); enqueueTermWrite(cleaned); }
 					} else {
 						// Binary data — decode and batch with text data
 						const str = new TextDecoder().decode(new Uint8Array(event.data));
-						if (str) { pendingFromSocket = true; enqueueTermWrite(str); }
+						if (str) { pendingFromSocket = true; noteSocketBytes(str.length); enqueueTermWrite(str); }
 					}
-				} catch {
-					// Swallow ghostty-web rendering errors to avoid flooding
-					// analytics with thousands of app_exception events per session.
+				} catch (err) {
+					// Same trade as the write batch above: throttled instead of silent, so a
+					// crash on the receiving path stops being invisible.
+					socketErrors += 1;
+					if (socketErrors <= 3 || socketErrors % 60 === 0) {
+						logDiagnostic("terminal-socket", "error", "socket message handling threw", {
+							error: String(err),
+							socketErrors,
+							socketBytes,
+						});
+					}
 				}
 			};
 
@@ -1713,6 +1789,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 			copyDiagnosticsRef.current?.dispose();
 			copyDiagnosticsRef.current = null;
+			renderGuardRef.current?.dispose();
+			renderGuardRef.current = null;
 			cursorGateRef.current?.dispose();
 			cursorGateRef.current = null;
 			glyphFitRef.current?.dispose();

--- a/src/mainview/__tests__/terminal-render-guard.test.ts
+++ b/src/mainview/__tests__/terminal-render-guard.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+import { installRenderGuard, DEFAULT_STALL_MS, type GuardableRenderer } from "../terminal-render-guard";
+
+/** A renderer whose paint the test controls, plus the vendor loop's own contract. */
+function makeHarness(opts: { visible?: boolean } = {}) {
+	const painted: number[] = [];
+	let throwWith: Error | null = null;
+	const renderer: GuardableRenderer = {
+		render() {
+			if (throwWith) throw throwWith;
+			painted.push(1);
+		},
+	};
+	let clock = 1_000;
+	const timer: { fire: (() => void) | null } = { fire: null };
+	let visible = opts.visible ?? true;
+	const frameErrors: Array<{ error: string; consecutive: number }> = [];
+	const stalls: number[] = [];
+
+	const guard = installRenderGuard(renderer, {
+		onFrameError: (error, consecutive) => frameErrors.push({ error: String(error), consecutive }),
+		onStalled: (ms) => stalls.push(ms),
+		now: () => clock,
+		isVisible: () => visible,
+		setInterval: (fn) => {
+			timer.fire = fn;
+			return 1;
+		},
+		clearInterval: () => {
+			timer.fire = null;
+		},
+	});
+
+	return {
+		guard,
+		frameErrors,
+		stalls,
+		painted,
+		/** One frame from the vendor's loop. Returns false if it propagated a throw. */
+		frame(): boolean {
+			try {
+				renderer.render({}, false, 0, {}, 1);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		crashWith(err: Error | null) {
+			throwWith = err;
+		},
+		advance(ms: number) {
+			clock += ms;
+		},
+		setVisible(v: boolean) {
+			visible = v;
+		},
+		tick() {
+			timer.fire?.();
+		},
+		isWatching: () => timer.fire !== null,
+	};
+}
+
+describe("installRenderGuard – surviving a bad frame", () => {
+	it("does not let a throwing frame escape, so the vendor loop lives", () => {
+		const h = makeHarness();
+		h.crashWith(new Error("RuntimeError: Out of bounds memory access"));
+
+		expect(h.frame()).toBe(true);
+		expect(h.frameErrors[0]).toMatchObject({ consecutive: 1 });
+	});
+
+	it("still paints once the bad frame passes", () => {
+		const h = makeHarness();
+		h.crashWith(new Error("boom"));
+		h.frame();
+		h.crashWith(null);
+
+		h.frame();
+
+		expect(h.guard.framesPainted()).toBe(1);
+		expect(h.guard.consecutiveErrors()).toBe(0);
+	});
+
+	it("reports the first three failures, then only every 60th — a broken frame repeats at 60fps", () => {
+		const h = makeHarness();
+		h.crashWith(new Error("boom"));
+
+		for (let i = 0; i < 120; i++) h.frame();
+
+		expect(h.frameErrors.map((e) => e.consecutive)).toEqual([1, 2, 3, 60, 120]);
+	});
+
+	it("passes the terminal's own arguments through untouched", () => {
+		const seen: unknown[][] = [];
+		const renderer: GuardableRenderer = { render: (...args: unknown[]) => void seen.push(args) };
+		installRenderGuard(renderer, {
+			onFrameError: vi.fn(),
+			onStalled: vi.fn(),
+			setInterval: () => 1,
+			clearInterval: () => {},
+		});
+
+		renderer.render("buffer", true, 42, "provider", 0.5);
+
+		expect(seen[0]).toEqual(["buffer", true, 42, "provider", 0.5]);
+	});
+});
+
+describe("installRenderGuard – noticing a loop that stopped", () => {
+	it("reports a visible pane that painted nothing for too long", () => {
+		const h = makeHarness();
+		h.frame();
+		h.advance(DEFAULT_STALL_MS + 1);
+
+		h.tick();
+
+		expect(h.stalls).toHaveLength(1);
+		expect(h.stalls[0]).toBeGreaterThan(DEFAULT_STALL_MS);
+	});
+
+	it("stays quiet while frames keep arriving", () => {
+		const h = makeHarness();
+		for (let i = 0; i < 5; i++) {
+			h.advance(1000);
+			h.frame();
+			h.tick();
+		}
+		expect(h.stalls).toEqual([]);
+	});
+
+	it("reports a stall once, not on every check", () => {
+		const h = makeHarness();
+		h.frame();
+		h.advance(DEFAULT_STALL_MS + 1);
+		h.tick();
+		h.advance(DEFAULT_STALL_MS + 1);
+		h.tick();
+
+		expect(h.stalls).toHaveLength(1);
+	});
+
+	it("arms again after the pane recovers", () => {
+		const h = makeHarness();
+		h.frame();
+		h.advance(DEFAULT_STALL_MS + 1);
+		h.tick();
+		h.frame();
+		h.advance(DEFAULT_STALL_MS + 1);
+		h.tick();
+
+		expect(h.stalls).toHaveLength(2);
+	});
+
+	it("never blames a hidden window, which legitimately paints nothing", () => {
+		const h = makeHarness();
+		h.frame();
+		h.setVisible(false);
+		h.advance(DEFAULT_STALL_MS * 10);
+		h.tick();
+
+		expect(h.stalls).toEqual([]);
+	});
+
+	it("gives a window that just came back a fresh chance to paint", () => {
+		const h = makeHarness();
+		h.frame();
+		h.setVisible(false);
+		h.advance(DEFAULT_STALL_MS * 10);
+		h.tick();
+		h.setVisible(true);
+		h.tick(); // first visible tick only restarts the clock
+		h.advance(DEFAULT_STALL_MS - 1);
+		h.tick();
+
+		expect(h.stalls).toEqual([]);
+	});
+
+	it("stops watching and restores the vendor render on dispose", () => {
+		const h = makeHarness();
+		h.guard.dispose();
+		h.frame();
+		h.advance(DEFAULT_STALL_MS * 10);
+
+		expect(h.isWatching()).toBe(false);
+		expect(h.guard.framesPainted()).toBe(0);
+	});
+});

--- a/src/mainview/terminal-render-guard.ts
+++ b/src/mainview/terminal-render-guard.ts
@@ -1,0 +1,134 @@
+/**
+ * Keep a ghostty terminal painting, whatever one frame does.
+ *
+ * ghostty-web's render loop schedules the next frame only after `render()`
+ * returns and is private, so a single throw stops the terminal forever with no
+ * way back (coder/ghostty-web#189). Worse, we have also seen a pane stop painting
+ * with no exception at all — nothing in the logs, nothing to catch.
+ *
+ * This wraps `renderer.render` the way the cursor gate and the bidi view already
+ * do, and does two things the vendor cannot do for us:
+ *
+ *  1. **Swallows a throwing frame.** Our wrapper returns normally, so the vendor's
+ *     loop reaches its `requestAnimationFrame` and the terminal survives a bad
+ *     frame instead of dying on it.
+ *  2. **Notices a loop that stopped.** The vendor renders every frame whether or
+ *     not anything changed, so a visible pane with no frames for seconds is a dead
+ *     loop by definition — the only signal that catches the silent failures.
+ */
+
+export interface GuardableRenderer {
+	render(
+		buffer: unknown,
+		forceAll?: boolean,
+		viewportY?: number,
+		scrollbackProvider?: unknown,
+		scrollbarOpacity?: number,
+	): void;
+}
+
+const ORIGINAL_RENDER = Symbol.for("dev3.terminalRenderGuard.originalRender");
+
+type WrappedRenderer = GuardableRenderer & {
+	[ORIGINAL_RENDER]?: GuardableRenderer["render"];
+};
+
+export interface RenderGuardOptions {
+	/** A frame threw. `consecutive` counts frames that failed in a row. */
+	onFrameError: (error: unknown, consecutive: number) => void;
+	/** No frame arrived for `stallMs` while the document was visible. */
+	onStalled: (msSinceLastFrame: number) => void;
+	/** How long without a frame counts as dead. */
+	stallMs?: number;
+	/** How often to check. */
+	checkIntervalMs?: number;
+	now?: () => number;
+	isVisible?: () => boolean;
+	setInterval?: (fn: () => void, ms: number) => unknown;
+	clearInterval?: (handle: unknown) => void;
+}
+
+export interface RenderGuard {
+	framesPainted(): number;
+	consecutiveErrors(): number;
+	dispose(): void;
+}
+
+/** Frames stop entirely in a hidden window, so the watchdog only judges a visible one. */
+export const DEFAULT_STALL_MS = 6000;
+export const DEFAULT_CHECK_INTERVAL_MS = 2000;
+/** Report the first failures, then only every Nth — a broken frame repeats at 60 fps. */
+const ERROR_REPORT_STRIDE = 60;
+
+export function installRenderGuard(renderer: GuardableRenderer, opts: RenderGuardOptions): RenderGuard {
+	const target = renderer as WrappedRenderer;
+	const now = opts.now ?? Date.now;
+	const isVisible = opts.isVisible ?? (() => typeof document === "undefined" || document.visibilityState === "visible");
+	const stallMs = opts.stallMs ?? DEFAULT_STALL_MS;
+	const setTimer = opts.setInterval ?? ((fn: () => void, ms: number) => setInterval(fn, ms));
+	const clearTimer = opts.clearInterval ?? ((handle: unknown) => clearInterval(handle as Parameters<typeof clearInterval>[0]));
+
+	let frames = 0;
+	let consecutive = 0;
+	let lastFrameAt = now();
+	// A window that just came back from hidden has legitimately painted nothing for
+	// minutes; the clock starts again from the moment it can paint.
+	let visibleSince = isVisible() ? lastFrameAt : null;
+	let stallReported = false;
+
+	if (!target[ORIGINAL_RENDER] && typeof renderer.render === "function") {
+		const original = renderer.render;
+		target[ORIGINAL_RENDER] = original;
+		target.render = function guardedRender(
+			buffer: unknown,
+			forceAll?: boolean,
+			viewportY?: number,
+			scrollbackProvider?: unknown,
+			scrollbarOpacity?: number,
+		) {
+			try {
+				original.call(this, buffer, forceAll, viewportY, scrollbackProvider, scrollbarOpacity);
+				frames += 1;
+				consecutive = 0;
+				lastFrameAt = now();
+				stallReported = false;
+			} catch (error) {
+				consecutive += 1;
+				if (consecutive <= 3 || consecutive % ERROR_REPORT_STRIDE === 0) {
+					opts.onFrameError(error, consecutive);
+				}
+				// Deliberately not rethrown: the vendor's loop must reach its own
+				// requestAnimationFrame, or this pane never paints again.
+			}
+		};
+	}
+
+	const handle = setTimer(() => {
+		const tick = now();
+		if (!isVisible()) {
+			visibleSince = null;
+			return;
+		}
+		if (visibleSince === null) {
+			visibleSince = tick;
+			return;
+		}
+		// Judge only the stretch this window was actually able to paint in.
+		const quietFor = tick - Math.max(lastFrameAt, visibleSince);
+		if (quietFor < stallMs || stallReported) return;
+		stallReported = true;
+		opts.onStalled(quietFor);
+	}, opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS);
+
+	return {
+		framesPainted: () => frames,
+		consecutiveErrors: () => consecutive,
+		dispose() {
+			clearTimer(handle);
+			const original = target[ORIGINAL_RENDER];
+			if (!original) return;
+			target.render = original;
+			delete target[ORIGINAL_RENDER];
+		},
+	};
+}


### PR DESCRIPTION
Third blank-terminal incident today, and the rebuild from #1405 never fired: the log held no `[refit]` line, no `[error]` line, nothing at all. That fix hangs off the three catches in `refitToContainer`, so it only ever sees a crash arriving through `term.resize`.

**Why the log was empty.** Two other paths killed the renderer silently, both on purpose:

- the write flush swallowed every throw from `batchTerm.write()` — comment: "Swallow ghostty-web rendering errors", added to stop thousands of `app_exception` events per session;
- the socket's `onmessage` swallowed the same class for the same reason.

And a frame can simply stop arriving without throwing anywhere. Nothing counted bytes or frames, so "nothing was sent to this pane" and "bytes arrived and nothing painted" looked identical in the log.

**What this adds.** `terminal-render-guard.ts` wraps `renderer.render` the way the cursor gate and bidi view already do — installed last, disposed first:

| Signal | Behaviour |
|---|---|
| A frame throws | Swallowed **by us**, so the vendor's private loop reaches its own `requestAnimationFrame` and the pane survives instead of dying on one frame. This is coder/ghostty-web#189's first ask, implemented locally |
| The same frame keeps throwing | First three reported, then every 60th — a broken frame repeats at 60 fps |
| A visible pane paints nothing for 6 s | A dead loop by definition: the vendor renders every frame whether or not anything changed. Hidden windows are never judged, and a window back from hidden gets a fresh clock, because rAF is paused while hidden |

Both signals route into the existing rebuild, with its 3-attempt budget. The two silent catches now log (throttled) with `socketBytes`, `socketBatches`, `msSinceLastByte` and frame counts, so the next incident is readable instead of blank.

Verified: renderer 3901, backend 5937, cli 797 — green (the two backend timeouts under parallel load pass in isolation and are the known flaky `git-diff-recent` / `create-release-artifacts` pair). Guards mutation-tested: rethrowing the frame fails 1 test, dropping the visibility check fails 2. Browser pass with a live terminal: `render guard installed` logged, `document.visibilityState` confirmed `visible`, and **zero** stall alarms over 18 s — no false positives.

Note for anyone rebasing: #1343's new deps (`streamdown`, `@streamdown/mermaid`) must actually be installed, or 8 renderer suites fail to load and `markdown.tsx` reports four `TS7031` errors that look like a main breakage. That was my earlier misread; main is fine.

Decision record: `decisions/2026/08/18/terminal-render-guard.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6d95c182-a97f-48ce-818e-6e8bdc47bfe3) · `dev3://task/6d95c182-a97f-48ce-818e-6e8bdc47bfe3`