### PR TITLE
Hide layout, zoom and close pane controls until a task has two panes

### DIFF
--- a/change-logs/2026/08/18/refactor-hide-single-pane-controls.md
+++ b/change-logs/2026/08/18/refactor-hide-single-pane-controls.md
@@ -1,0 +1,1 @@
+The pane toolbar in the task inspector now hides the layout, zoom and close-pane buttons until the task actually has a second pane, leaving only split, new window and the shortcuts cheat sheet on a single-pane terminal.

--- a/src/mainview/components/__tests__/TaskPaneControls.test.tsx
+++ b/src/mainview/components/__tests__/TaskPaneControls.test.tsx
@@ -104,16 +104,29 @@ describe("TaskPaneControls", () => {
 		expect(screen.queryByLabelText("New window")).not.toBeInTheDocument();
 	});
 
-	// ── Layout button: disabled at 1 pane ────────────────────────────────────
+	// ── Single pane: layout / zoom / close are not rendered at all ────────────
 
-	it("disables the layout button with a reason tooltip when only 1 pane", async () => {
+	it("hides layout, zoom and close for a single-pane task", async () => {
 		vi.mocked(api.request.taskPaneState).mockResolvedValue(TMUX_ONE_PANE);
 		renderControls();
 		await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
 		await new Promise((r) => setTimeout(r, 20));
-		const layoutBtn = screen.getByLabelText("Cycle layouts");
-		expect(layoutBtn).toBeDisabled();
-		expect(layoutBtn).toHaveAttribute("title", expect.stringContaining("2"));
+		expect(screen.queryByLabelText("Cycle layouts")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Choose pane layout")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Zoom pane (toggle)")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Close pane")).not.toBeInTheDocument();
+		// The controls that still make sense on one pane stay.
+		expect(screen.getByLabelText("Split horizontally")).toBeInTheDocument();
+		expect(screen.getByLabelText("Split vertically")).toBeInTheDocument();
+		expect(screen.getByLabelText("New window")).toBeInTheDocument();
+	});
+
+	it("hides layout, zoom and close until the pane state has loaded", () => {
+		vi.mocked(api.request.taskPaneState).mockReturnValue(new Promise<TaskPaneState>(() => {}));
+		renderControls();
+		expect(screen.queryByLabelText("Cycle layouts")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Zoom pane (toggle)")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Close pane")).not.toBeInTheDocument();
 	});
 
 	it("enables the layout button with 2+ panes", async () => {
@@ -134,7 +147,7 @@ describe("TaskPaneControls", () => {
 
 		renderControls();
 
-		await user.click(screen.getByLabelText("Close pane"));
+		await user.click(await screen.findByLabelText("Close pane"));
 
 		expect(onPicker).toHaveBeenCalledTimes(1);
 		expect((onPicker.mock.calls[0][0] as CustomEvent).detail).toEqual({ taskId: "task-1" });
@@ -156,7 +169,7 @@ describe("TaskPaneControls", () => {
 
 			renderControls();
 
-			await user.click(screen.getByLabelText("Close pane"));
+			await user.click(await screen.findByLabelText("Close pane"));
 
 			await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
 				taskId: "task-1",
@@ -165,39 +178,15 @@ describe("TaskPaneControls", () => {
 			expect(confirm).not.toHaveBeenCalled();
 		});
 
-		it("asks for confirmation when the last pane is closed, forces kill on accept", async () => {
-			const user = userEvent.setup();
+		it("offers no close control for a single-pane task, so the last pane cannot be killed here", async () => {
 			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
-			vi.mocked(confirm).mockResolvedValue(true);
-			vi.mocked(api.request.taskPaneAction).mockResolvedValue(makeState(0));
 
 			renderControls();
+			await waitFor(() => expect(api.request.taskPaneState).toHaveBeenCalled());
+			await new Promise((r) => setTimeout(r, 20));
 
-			await user.click(screen.getByLabelText("Close pane"));
-
-			expect(confirm).toHaveBeenCalledWith({
-				title: "Close the last pane?",
-				message: expect.stringContaining("only remaining pane"),
-				confirmLabel: "Close pane",
-				danger: true,
-			});
-			await waitFor(() => expect(api.request.taskPaneAction).toHaveBeenCalledWith({
-				taskId: "task-1",
-				action: { kind: "close", force: true },
-			}));
-		});
-
-		it("does not kill the last pane when the confirmation is dismissed", async () => {
-			const user = userEvent.setup();
-			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeState(1));
-			vi.mocked(confirm).mockResolvedValue(false);
-
-			renderControls();
-
-			await user.click(screen.getByLabelText("Close pane"));
-
-			expect(confirm).toHaveBeenCalled();
-			expect(api.request.taskPaneAction).not.toHaveBeenCalled();
+			expect(screen.queryByLabelText("Close pane")).not.toBeInTheDocument();
+			expect(confirm).not.toHaveBeenCalled();
 		});
 	});
 
@@ -314,20 +303,6 @@ describe("TaskPaneControls", () => {
 
 		releaseAction(TMUX_TWO_PANE);
 		await waitFor(() => expect(screen.getByLabelText("Split horizontally")).not.toBeDisabled());
-	});
-
-	it("does not say 'needs two panes' for a layout button that is merely busy", async () => {
-		const user = userEvent.setup();
-		vi.mocked(api.request.taskPaneAction).mockReturnValue(new Promise<TaskPaneState>(() => {}));
-		vi.mocked(api.request.taskPaneState).mockResolvedValue(TMUX_TWO_PANE);
-		renderControls();
-		await waitFor(() => expect(screen.getByLabelText("Cycle layouts")).not.toBeDisabled());
-
-		await user.click(screen.getByLabelText("Split horizontally"));
-
-		const layoutBtn = screen.getByLabelText("Cycle layouts");
-		expect(layoutBtn).toBeDisabled();
-		expect(layoutBtn).not.toHaveAttribute("title", expect.stringContaining("2"));
 	});
 
 	it("issues exactly one action for a double click on split", async () => {

--- a/src/mainview/components/task-info-panel/TaskPaneControls.tsx
+++ b/src/mainview/components/task-info-panel/TaskPaneControls.tsx
@@ -2,7 +2,6 @@ import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent as ReactM
 import { createPortal } from "react-dom";
 import { useT } from "../../i18n";
 import { api } from "../../rpc";
-import { confirm } from "../../confirm";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import { useNarrowViewport } from "../../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "../MobileBoardCarousel";
@@ -158,29 +157,6 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 			return;
 		}
 		if (action === "close") {
-			let count = 0;
-			try {
-				const state = paneState ?? await fetchPaneState(taskId);
-				count = state.panes.length;
-			} catch {
-				count = 0;
-			}
-			if (count <= 1) {
-				let confirmed = false;
-				try {
-					confirmed = await confirm({
-						title: t("tmux.closePaneConfirmTitle"),
-						message: t("tmux.closePaneConfirmMessage"),
-						confirmLabel: t("tmux.closePaneConfirmLabel"),
-						danger: true,
-					});
-				} catch {
-					confirmed = false;
-				}
-				if (!confirmed) return;
-				void withBusy(() => runPaneAction(taskId, { kind: "close", force: true }).catch(() => {}).finally(refreshState));
-				return;
-			}
 			const closeTarget = paneState?.backend === "native" ? currentNativePaneFocus(taskId) ?? undefined : undefined;
 			void withBusy(() => runPaneAction(taskId, { kind: "close", paneId: closeTarget }).catch(() => {}).finally(refreshState));
 			return;
@@ -232,26 +208,19 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 
 	// Capability checks (fall back to permissive defaults while state loads).
 	const supportsSplit = paneState === null || taskPaneSupports(paneState, "split");
-	const supportsZoom = paneState === null || taskPaneSupports(paneState, "zoom");
-	const supportsClose = paneState === null || taskPaneSupports(paneState, "close");
-	const canLayoutCycle = paneState !== null && taskPaneSupports(paneState, "layoutCycle");
-	const canLayoutPreset = paneState !== null && taskPaneSupports(paneState, "layoutPreset");
 	const showNewWindow = paneState !== null && taskPaneSupports(paneState, "newWindow");
 	const isNative = paneState?.backend === "native";
 
-	// An in-flight action withholds every mutating control, not just the one clicked:
-	// they all rewrite the same tree. Capability stays separate so the "needs two
-	// panes" tooltip never fires for a control that is merely busy.
-	const canSplit = supportsSplit && !actionBusy;
-	const canZoom = supportsZoom && !actionBusy;
-	const canClose = supportsClose && !actionBusy;
+	// Layout, zoom and close only mean anything once the task has a second pane —
+	// a single-pane terminal shows just split / new window / shortcuts.
+	const multiPane = (paneState?.panes.length ?? 0) > 1;
 
-	// Layout button is disabled when the backend has no layoutCycle capability (1 pane).
-	const layoutUnsupported = !canLayoutCycle && !canLayoutPreset;
-	const layoutDisabled = layoutUnsupported || actionBusy;
-	const layoutDisabledReason = layoutUnsupported && paneState !== null
-		? t("panes.layoutNeedsTwoPanes")
-		: undefined;
+	// An in-flight action withholds every mutating control, not just the one
+	// clicked: they all rewrite the same tree.
+	const canSplit = supportsSplit && !actionBusy;
+	const canZoom = !actionBusy;
+	const canClose = !actionBusy;
+	const layoutDisabled = actionBusy;
 
 	const tmuxBtnClass = "tmux-anim px-1.5 py-1 rounded text-dense font-medium transition-colors text-accent hover:bg-accent/20 bg-accent/10 border border-accent/25 flex items-center gap-1";
 	const tmuxBtnDisabledClass = "px-1.5 py-1 rounded text-dense font-medium text-fg-muted bg-elevated/50 border border-edge/50 flex items-center gap-1 cursor-not-allowed opacity-50";
@@ -315,23 +284,22 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 					</Tooltip>
 				)}
 
-				<Tooltip content={layoutDisabledReason ?? ""} detail={!layoutDisabled ? undefined : undefined}>
-					<div
-						className={`flex items-stretch rounded ${layoutDisabled ? "opacity-50 cursor-not-allowed" : "text-accent bg-accent/10 border border-accent/25"} overflow-hidden`}
-						onMouseEnter={!layoutUnsupported ? showLayout : undefined}
-						onMouseLeave={!layoutUnsupported ? hideLayout : undefined}
-					>
-						<button
-							className={`tmux-anim px-1.5 py-1 text-dense font-medium transition-colors ${layoutDisabled ? "text-fg-muted bg-elevated/50 border border-edge/50 cursor-not-allowed" : "text-accent hover:bg-accent/20"} flex items-center gap-1`}
-							disabled={layoutDisabled}
-							onClick={!layoutDisabled ? cycleLayout : undefined}
-							aria-label={t("tmux.nextLayoutDesc")}
-							title={layoutDisabledReason}
+				{multiPane && (
+					<Tooltip content={t("tmux.nextLayoutDesc")} detail={t("ttip.tmux.nextLayout")}>
+						<div
+							className={`flex items-stretch rounded ${layoutDisabled ? "opacity-50 cursor-not-allowed" : "text-accent bg-accent/10 border border-accent/25"} overflow-hidden`}
+							onMouseEnter={showLayout}
+							onMouseLeave={hideLayout}
 						>
-							{cycleIcon}
-							{!compact && <span>{t("panes.layoutLabel")}</span>}
-						</button>
-						{!layoutUnsupported && (
+							<button
+								className={`tmux-anim px-1.5 py-1 text-dense font-medium transition-colors ${layoutDisabled ? "text-fg-muted bg-elevated/50 border border-edge/50 cursor-not-allowed" : "text-accent hover:bg-accent/20"} flex items-center gap-1`}
+								disabled={layoutDisabled}
+								onClick={!layoutDisabled ? cycleLayout : undefined}
+								aria-label={t("tmux.nextLayoutDesc")}
+							>
+								{cycleIcon}
+								{!compact && <span>{t("panes.layoutLabel")}</span>}
+							</button>
 							<button
 								ref={layoutTriggerRef}
 								className="px-1 py-1 transition-colors hover:bg-accent/20 border-l border-accent/25 flex items-center justify-center"
@@ -348,20 +316,22 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 									<path d="M6 9 L12 15 L18 9" stroke="currentColor" />
 								</svg>
 							</button>
-						)}
-					</div>
-				</Tooltip>
+						</div>
+					</Tooltip>
+				)}
 
-				<Tooltip content={t("tmux.zoomDesc")} detail={t("ttip.tmux.zoom")}>
-					<button
-						className={canZoom ? tmuxBtnClass : tmuxBtnDisabledClass}
-						disabled={!canZoom}
-						onClick={canZoom ? handleAction("zoom") : undefined}
-						aria-label={t("tmux.zoomDesc")}
-					>
-						<ZoomPaneIcon className={tmuxSvgClass} />
-					</button>
-				</Tooltip>
+				{multiPane && (
+					<Tooltip content={t("tmux.zoomDesc")} detail={t("ttip.tmux.zoom")}>
+						<button
+							className={canZoom ? tmuxBtnClass : tmuxBtnDisabledClass}
+							disabled={!canZoom}
+							onClick={canZoom ? handleAction("zoom") : undefined}
+							aria-label={t("tmux.zoomDesc")}
+						>
+							<ZoomPaneIcon className={tmuxSvgClass} />
+						</button>
+					</Tooltip>
+				)}
 
 				<button
 					className={tmuxIconBtnClass}
@@ -377,21 +347,25 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 					<TmuxHintsIcon className="w-3.5 h-3.5" />
 				</button>
 
-				<div className="w-px self-stretch bg-edge mx-0.5" aria-hidden="true" />
+				{multiPane && (
+					<>
+						<div className="w-px self-stretch bg-edge mx-0.5" aria-hidden="true" />
 
-				<Tooltip content={t("tmux.closePaneDesc")} detail={t("ttip.tmux.closePane")}>
-					<button
-						className={`${canClose ? tmuxBtnClass : tmuxBtnDisabledClass} ${canClose ? "text-danger hover:bg-danger/20 bg-danger/10 border-danger/25" : ""}`}
-						disabled={!canClose}
-						onClick={canClose ? handleClosePane : undefined}
-						aria-label={t("tmux.closePaneDesc")}
-					>
-						<ClosePaneIcon className={tmuxSvgClass} />
-					</button>
-				</Tooltip>
+						<Tooltip content={t("tmux.closePaneDesc")} detail={t("ttip.tmux.closePane")}>
+							<button
+								className={`${canClose ? tmuxBtnClass : tmuxBtnDisabledClass} ${canClose ? "text-danger hover:bg-danger/20 bg-danger/10 border-danger/25" : ""}`}
+								disabled={!canClose}
+								onClick={canClose ? handleClosePane : undefined}
+								aria-label={t("tmux.closePaneDesc")}
+							>
+								<ClosePaneIcon className={tmuxSvgClass} />
+							</button>
+						</Tooltip>
+					</>
+				)}
 			</div>
 
-			{!layoutUnsupported && layoutOpen && createPortal(
+			{multiPane && layoutOpen && createPortal(
 				<div
 					ref={layoutMenuRef}
 					role="menu"

--- a/src/mainview/i18n/translations/en/panes.ts
+++ b/src/mainview/i18n/translations/en/panes.ts
@@ -3,7 +3,6 @@ const panes = {
 	"panes.chooseLayout": "Choose pane layout",
 	"panes.unzoom": "Unzoom",
 	"panes.actionFailed": "Pane action failed: {error}",
-	"panes.layoutNeedsTwoPanes": "Need at least 2 panes to cycle layouts",
 	"panes.nativeHintsTitle": "Terminal Shortcuts",
 	"panes.nativeNoPrefixKeys": "No ⌃B prefix — pane actions use the toolbar above",
 	"panes.nativeWindowsUnavailable": "Windows are tmux-only (not available on native tasks)",

--- a/src/mainview/i18n/translations/es/panes.ts
+++ b/src/mainview/i18n/translations/es/panes.ts
@@ -3,7 +3,6 @@ const panes = {
 	"panes.chooseLayout": "Elegir disposición de paneles",
 	"panes.unzoom": "Quitar zoom",
 	"panes.actionFailed": "La acción del panel falló: {error}",
-	"panes.layoutNeedsTwoPanes": "Se necesitan al menos 2 paneles para cambiar el diseño",
 	"panes.nativeHintsTitle": "Atajos de terminal",
 	"panes.nativeNoPrefixKeys": "Sin prefijo ⌃B — las acciones de panel usan la barra de herramientas",
 	"panes.nativeWindowsUnavailable": "Las ventanas son exclusivas de tmux (no disponibles en tareas nativas)",

--- a/src/mainview/i18n/translations/ru/panes.ts
+++ b/src/mainview/i18n/translations/ru/panes.ts
@@ -3,7 +3,6 @@ const panes = {
 	"panes.chooseLayout": "Выбрать раскладку панелей",
 	"panes.unzoom": "Убрать зум",
 	"panes.actionFailed": "Действие с панелью не удалось: {error}",
-	"panes.layoutNeedsTwoPanes": "Нужно минимум 2 панели для смены макета",
 	"panes.nativeHintsTitle": "Быстрые команды",
 	"panes.nativeNoPrefixKeys": "Префикс ⌃B не используется — управление панелями через панель инструментов",
 	"panes.nativeWindowsUnavailable": "Окна доступны только в tmux (недоступно в нативных задачах)",


### PR DESCRIPTION
The pane toolbar in the task inspector showed **Layout**, **Zoom pane** and **Close pane** on every task, even when the terminal had a single pane — layout and zoom were rendered disabled with a "needs at least 2 panes" tooltip, and close was a red button whose only effect was tearing down the whole session behind a confirmation dialog.

All three now render only once the task actually has a second pane. A single-pane terminal keeps split horizontally / split vertically / new window / the shortcuts cheat sheet. While the pane state is still loading nothing is rendered either, so the buttons never flash in and then disappear.

Follow-on cleanups that fall out of the gate:

- The last-pane confirm branch in `TaskPaneControls` is gone — the close control no longer exists at one pane, and `tmuxKillPane` already refuses to kill the last pane without `force`. The confirm strings stay in use by `ClosePanePicker` and `MobilePaneCarousel`.
- `layoutUnsupported` / `layoutDisabledReason` and the now-unreachable `panes.layoutNeedsTwoPanes` key (en/ru/es) are removed.
- The layout button finally gets its real tooltip (`ttip.tmux.nextLayout`) instead of an empty one that only ever carried the disabled reason.

Verified in a real browser (headless Chromium against this branch's dev-server): a single-pane task exposes no `Cycle layouts` / `Choose pane layout` / `Zoom pane (toggle)` / `Close pane` control, a two-pane task exposes all four, and the console is clean.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=54f4366a-f67a-439d-94ae-0aa7f2f58002) · `dev3://task/54f4366a-f67a-439d-94ae-0aa7f2f58002` _(dev3 added this footer — turn it off in Settings → Tasks.)_
