### PR TITLE
Attach the run-up to every terminal crash diagnostic

### DIFF
--- a/change-logs/2026/08/18/fix-terminal-render-guard.md
+++ b/change-logs/2026/08/18/fix-terminal-render-guard.md
@@ -4,4 +4,7 @@ The terminal now keeps painting through a frame that crashes instead of going
 blank for good, and a pane that stopped painting with no error at all is detected
 and rebuilt. Two catch blocks that used to swallow ghostty crashes silently now
 log them with the byte and frame counts around the failure, so a blank pane can be
-diagnosed from the log instead of guessed at.
+diagnosed from the log instead of guessed at. Every one of those log lines now also
+carries the last few things that happened to that terminal — successful resizes,
+scale-factor changes, backgrounding — plus how many panes are alive and how many
+have died, which is what identifies the trigger rather than just the symptom.

--- a/decisions/2026/08/18/terminal-crash-breadcrumbs.md
+++ b/decisions/2026/08/18/terminal-crash-breadcrumbs.md
@@ -1,0 +1,46 @@
+# Attach the run-up to every terminal crash log line
+
+## Context
+
+Three fixes shipped on 2026-08-18 for the "terminal shows nothing" reports, and all
+of them log the MOMENT of failure: the error, the dimensions it threw on, the byte
+and frame counters. None of them logs the seconds before it. Successful resizes were
+never recorded at all, so the one claim both field reports make — that a resize
+triggered it (a resolution change, an artifact pane being dragged) — cannot be
+confirmed or killed from a log file. The crash arrives roughly every other day, so a
+missed occurrence costs a day or two of waiting.
+
+## Decision
+
+`src/mainview/terminal-breadcrumbs.ts` — a bounded per-terminal ring of the last 16
+events (`open`, `resize`, `resize-observer`, `dpr`, `hidden`, `visible`,
+`frame-error`), formatted with times relative to the crash and attached as `trail`
+to every error payload in `TerminalView.tsx`: both render-guard callbacks, all three
+refit catches, and the write/socket catches.
+
+Consecutive identical events collapse into a count (`-4.0s→-0.1s resize 158x82 x40`)
+rather than occupying 40 slots. That is not only compression: a resize storm is
+itself a trigger signature, and without collapsing it would flush the older, more
+interesting entries out of the ring.
+
+A module-level `session` object (`liveTerminals`, `frameErrorPanes`, `crashes`) rides
+along in the same payloads. Every terminal shares ONE ghostty WASM module, so the
+first question a post-mortem asks is whether one pane broke or the module did — and
+no per-pane number can answer that.
+
+## Risks
+
+The trail lives in memory and dies with the pane, so a crash whose diagnostics never
+reach the backend (dead RPC bridge, decision 199) loses it too. The ring is written
+on every successful resize, which is the hot path — hence a plain array push with an
+early collapse and no allocation per frame.
+
+## Alternatives considered
+
+- **Log every successful resize at `info`.** Would have answered the same question,
+  but a resize drag emits dozens per second into a shared log file, and it still
+  would not tie the run-up to the crash line.
+- **Wait for the next occurrence and read the existing lines.** They cannot answer
+  it: that is precisely the gap this closes.
+- **Ship the trail to analytics instead.** The log file survives a restart and is
+  what the user can hand over; analytics needs a live network and a query.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -24,6 +24,7 @@ import {
 import { installBidiRender, uninstallBidiRender } from "./terminal-bidi/proxy";
 import { installCursorVisibilityGate, type CursorVisibilityGate } from "./terminal-cursor-focus";
 import { installRenderGuard, type RenderGuard } from "./terminal-render-guard";
+import { createBreadcrumbTrail } from "./terminal-breadcrumbs";
 import { installGlyphCellFit, type GlyphCellFit } from "./terminal-glyph-cell-fit";
 import { getScrollThreshold } from "./scroll-speed";
 import { createWheelPacer } from "./wheel-pacer";
@@ -100,6 +101,13 @@ const TERMINAL_DISPOSE_BUDGET_MS = 50;
 const MAX_RENDERER_RECOVERIES = 3;
 /** A pane healthy for this long earns its rebuild budget back. */
 const RECOVERY_BUDGET_RESET_MS = 60_000;
+
+/**
+ * App-session totals, deliberately module-level: every terminal shares ONE ghostty
+ * WASM module, so the question a post-mortem asks first is whether one pane broke
+ * or the whole module did. Per-pane numbers cannot answer that; these can.
+ */
+const session = { liveTerminals: 0, frameErrorPanes: 0, crashes: 0 };
 
 /**
  * How long the sync gate waits for the first repaint before lifting itself.
@@ -448,12 +456,25 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		// corrupt — no number of retries fixes that, so stop and hand the user the
 		// one action that does (reloading the window; tmux keeps the session alive).
 		if (attempt > MAX_RENDERER_RECOVERIES) {
-			logDiagnostic("terminal-recover", "error", "giving up on terminal recovery", { reason, error, attempt });
+			logDiagnostic("terminal-recover", "error", "giving up on terminal recovery", {
+				reason,
+				error,
+				attempt,
+				liveTerminals: session.liveTerminals,
+				sessionCrashes: session.crashes,
+			});
 			toast.error(t("terminal.rendererCrashed"), { taskId, onClick: () => window.location.reload() });
 			return;
 		}
 		recoveryAttemptsRef.current = attempt;
-		logDiagnostic("terminal-recover", "warn", "rebuilding the terminal after a renderer crash", { reason, error, attempt });
+		session.crashes += 1;
+		logDiagnostic("terminal-recover", "warn", "rebuilding the terminal after a renderer crash", {
+			reason,
+			error,
+			attempt,
+			liveTerminals: session.liveTerminals,
+			sessionCrashes: session.crashes,
+		});
 		setTerminalGeneration((generation) => generation + 1);
 	}, [t, taskId]);
 	recoverFromRendererCrashRef.current = recoverFromRendererCrash;
@@ -547,6 +568,14 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 
 	useEffect(() => {
 		let disposed = false;
+		// The run-up to a crash: successful resizes, dpr flips and backgrounding are
+		// invisible in the log otherwise, and they are the only trigger candidates the
+		// field reports name. Attached to every error payload below.
+		const trail = createBreadcrumbTrail();
+		let lastDpr = window.devicePixelRatio;
+		// Owned by this effect run, so a terminal that never opened cannot decrement
+		// the session count on cleanup.
+		let countedLive = false;
 		let fitAddon: FitAddon | null = null;
 		let ws: WebSocket | null = null;
 		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -622,6 +651,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 			console.log("[TerminalView] Terminal opened in DOM successfully");
 			termRef.current = term;
+			session.liveTerminals += 1;
+			countedLive = true;
+			trail.note("open", `${term.cols}x${term.rows} dpr${lastDpr}`);
 
 
 			// Beta: paint right-to-left rows in visual order (Settings → System →
@@ -650,12 +682,20 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				renderGuardRef.current = installRenderGuard(term.renderer, {
 					onFrameError: (error, consecutive) => {
 						if (disposed) return;
+						if (consecutive === 1) {
+							session.frameErrorPanes += 1;
+							trail.note("frame-error");
+						}
 						logDiagnostic("render-guard", "error", "render frame threw", {
 							error: String(error),
 							consecutive,
 							frames: renderGuardRef.current?.framesPainted() ?? 0,
 							socketBytes,
 							socketBatches,
+							// One pane or the shared WASM module: only the session totals say which.
+							liveTerminals: session.liveTerminals,
+							frameErrorPanes: session.frameErrorPanes,
+							trail: trail.format(),
 						});
 						if (consecutive === 1) recoverFromRendererCrashRef.current?.("render-frame", String(error));
 					},
@@ -671,6 +711,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 							msSinceLastByte: lastSocketByteAt ? Date.now() - lastSocketByteAt : null,
 							writeErrors,
 							socketErrors,
+							liveTerminals: session.liveTerminals,
+							frameErrorPanes: session.frameErrorPanes,
+							trail: trail.format(),
 						});
 						recoverFromRendererCrashRef.current?.("render-stalled", `no frames for ${msSinceLastFrame}ms`);
 					},
@@ -962,13 +1005,20 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				// its own width: those bytes were laid out for the writer's geometry and
 				// every line reaching the right edge would wrap in the wrong place.
 				// Adopt the PTY's shape instead and letterbox inside the container.
+				// A resolution change moves the whole canvas onto a different backing
+				// scale, which is the reported trigger and is otherwise unrecorded.
+				if (window.devicePixelRatio !== lastDpr) {
+					trail.note("dpr", `${lastDpr}->${window.devicePixelRatio}`);
+					lastDpr = window.devicePixelRatio;
+				}
 				const pty = ptyGeometryRef.current;
 				if (pty && nativeRoleRef.current === "observer") {
 					try {
 						term.resize(pty.cols, pty.rows);
+						trail.note("resize-observer", `${pty.cols}x${pty.rows}`);
 					} catch (err) {
 						if (!disposed) {
-							logDiagnostic("refit", "error", "observer term.resize threw", { error: String(err), cols: pty.cols, rows: pty.rows });
+							logDiagnostic("refit", "error", "observer term.resize threw", { error: String(err), cols: pty.cols, rows: pty.rows, trail: trail.format() });
 							recoverFromRendererCrashRef.current?.("observer-resize", String(err));
 						}
 					}
@@ -983,7 +1033,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					dims = fitAddon.proposeDimensions();
 				} catch (err) {
 					if (!disposed) {
-						logDiagnostic("refit", "error", "proposeDimensions threw", { error: String(err) });
+						logDiagnostic("refit", "error", "proposeDimensions threw", { error: String(err), trail: trail.format() });
 						recoverFromRendererCrashRef.current?.("propose-dimensions", String(err));
 					}
 					return;
@@ -991,9 +1041,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				if (!dims) return;
 				try {
 					term.resize(dims.cols, dims.rows);
+					trail.note("resize", `${dims.cols}x${dims.rows}`);
 				} catch (err) {
 					if (!disposed) {
-						logDiagnostic("refit", "error", "term.resize threw", { error: String(err), cols: dims.cols, rows: dims.rows });
+						logDiagnostic("refit", "error", "term.resize threw", { error: String(err), cols: dims.cols, rows: dims.rows, trail: trail.format() });
 						recoverFromRendererCrashRef.current?.("fit-resize", String(err));
 					}
 				}
@@ -1507,6 +1558,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 								writeErrors,
 								socketBytes,
 								socketBatches,
+								liveTerminals: session.liveTerminals,
+								trail: trail.format(),
 							});
 						}
 						if (writeErrors === 1) recoverFromRendererCrashRef.current?.("term-write", String(err));
@@ -1658,6 +1711,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 							error: String(err),
 							socketErrors,
 							socketBytes,
+							trail: trail.format(),
 						});
 					}
 				}
@@ -1730,8 +1784,12 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			if (disposed) return;
 			if (document.visibilityState === "hidden") {
 				wasHidden = true;
+				trail.note("hidden");
 				return;
 			}
+			// "Lost the terminal after the machine woke up" is the other half of the
+			// report, and a wake arrives here as a long stretch spent hidden.
+			if (wasHidden) trail.note("visible", event.type);
 			const term = termRef.current;
 			const fit = fitAddonRef.current;
 			if (!term || !fit) return;
@@ -1776,6 +1834,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			// so a debug line never reaches the file and the marker would not be durable.
 			logDiagnostic("terminal-dispose", "info", "cleanup started");
 			disposed = true;
+			if (countedLive) {
+				countedLive = false;
+				session.liveTerminals = Math.max(0, session.liveTerminals - 1);
+			}
 			document.removeEventListener("visibilitychange", reconnectPtyOnResume);
 			window.removeEventListener("pageshow", reconnectPtyOnResume);
 			window.removeEventListener("online", reconnectPtyOnResume);

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1898,6 +1898,36 @@ describe("TerminalView – renderer crash recovery", () => {
 		expect(tags).toContain("terminal-recover");
 	});
 
+	it("carries the run-up to the crash, so the trigger can be read off one log line", async () => {
+		await renderAndSetup();
+		vi.mocked(api.request.logRendererDiagnostic).mockClear();
+
+		await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+
+		const refit = vi
+			.mocked(api.request.logRendererDiagnostic)
+			.mock.calls.map((c) => c[0] as { tag: string; extra?: Record<string, unknown> })
+			.find((call) => call.tag === "refit");
+		// The successful resizes before the fatal one are the whole point: without them
+		// "did a resize trigger it?" cannot be answered from a log file.
+		expect(String(refit?.extra?.trail)).toMatch(/resize 80x24/);
+		expect(refit?.extra?.cols).toBe(80);
+	});
+
+	it("reports how many panes exist and how many died, which tells one pane from the shared module", async () => {
+		await renderAndSetup();
+		vi.mocked(api.request.logRendererDiagnostic).mockClear();
+
+		await crashOnNextRefit(new Error("RuntimeError: Out of bounds memory access"));
+
+		const recover = vi
+			.mocked(api.request.logRendererDiagnostic)
+			.mock.calls.map((c) => c[0] as { tag: string; extra?: Record<string, unknown> })
+			.find((call) => call.tag === "terminal-recover");
+		expect(recover?.extra?.liveTerminals).toBeGreaterThan(0);
+		expect(recover?.extra?.sessionCrashes).toBeGreaterThan(0);
+	});
+
 	it("leaves a healthy terminal alone", async () => {
 		await renderAndSetup();
 		const builtBefore = vi.mocked(Terminal).mock.calls.length;

--- a/src/mainview/__tests__/terminal-breadcrumbs.test.ts
+++ b/src/mainview/__tests__/terminal-breadcrumbs.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { createBreadcrumbTrail, BREADCRUMB_LIMIT } from "../terminal-breadcrumbs";
+
+/** A trail on a clock the test owns, so the relative times in the output are exact. */
+function makeTrail(limit?: number) {
+	let clock = 10_000;
+	const trail = createBreadcrumbTrail({ now: () => clock, limit });
+	return { trail, advance: (ms: number) => void (clock += ms) };
+}
+
+describe("createBreadcrumbTrail", () => {
+	it("writes nothing while the terminal is healthy", () => {
+		const { trail } = makeTrail();
+		expect(trail.format()).toBe("");
+		expect(trail.entries()).toBe(0);
+	});
+
+	it("reports events oldest first, timed relative to the crash", () => {
+		const { trail, advance } = makeTrail();
+		trail.note("resize", "158x82");
+		advance(2000);
+		trail.note("hidden");
+		advance(1000);
+
+		expect(trail.format()).toBe("-3.0s resize 158x82 | -1.0s hidden");
+	});
+
+	it("collapses a repeated event into a count, so a storm cannot flush the ring", () => {
+		const { trail, advance } = makeTrail();
+		for (let i = 0; i < 40; i++) {
+			trail.note("resize", "158x82");
+			advance(100);
+		}
+
+		expect(trail.entries()).toBe(1);
+		expect(trail.format()).toBe("-4.0s→-0.1s resize 158x82 x40");
+	});
+
+	it("keeps a changing sequence as separate events — the shape of a real resize drag", () => {
+		const { trail, advance } = makeTrail();
+		trail.note("resize", "158x82");
+		advance(100);
+		trail.note("resize", "146x82");
+		advance(100);
+		trail.note("resize", "158x82");
+
+		expect(trail.entries()).toBe(3);
+		expect(trail.format()).toBe("-0.2s resize 158x82 | -0.1s resize 146x82 | -0.0s resize 158x82");
+	});
+
+	it("drops the oldest event once the ring is full", () => {
+		const { trail } = makeTrail(3);
+		trail.note("a");
+		trail.note("b");
+		trail.note("c");
+		trail.note("d");
+
+		expect(trail.entries()).toBe(3);
+		expect(trail.format()).toBe("-0.0s b | -0.0s c | -0.0s d");
+	});
+
+	it("defaults to a bounded ring", () => {
+		const { trail } = makeTrail();
+		for (let i = 0; i < BREADCRUMB_LIMIT * 3; i++) trail.note(`event-${i}`);
+
+		expect(trail.entries()).toBe(BREADCRUMB_LIMIT);
+	});
+
+	it("omits the detail when there is none", () => {
+		const { trail } = makeTrail();
+		trail.note("frame-error");
+
+		expect(trail.format()).toBe("-0.0s frame-error");
+	});
+});

--- a/src/mainview/terminal-breadcrumbs.ts
+++ b/src/mainview/terminal-breadcrumbs.ts
@@ -1,0 +1,65 @@
+/**
+ * The last few things that happened to a terminal before it died.
+ *
+ * Every diagnostic we have describes the MOMENT of the crash — the error, the
+ * dimensions it threw on, how many bytes the PTY had sent. None of them describes
+ * the seconds BEFORE it, and that is the only place the trigger can be: both field
+ * reports blame a resize (a resolution change, an artifact pane being dragged), and
+ * successful resizes are never logged, so the claim cannot be confirmed or killed
+ * from a log file.
+ *
+ * A bounded ring costs nothing while the terminal is healthy and is attached to
+ * every error payload, so one log line carries its own run-up. Consecutive
+ * identical entries collapse into a count, which is what makes a resize STORM
+ * visible instead of pushing the interesting older entries out of the ring.
+ */
+
+export const BREADCRUMB_LIMIT = 16;
+
+interface Breadcrumb {
+	kind: string;
+	detail: string;
+	firstAt: number;
+	lastAt: number;
+	count: number;
+}
+
+export interface BreadcrumbTrail {
+	/** Record one event. Repeats of the same event collapse instead of filling the ring. */
+	note(kind: string, detail?: string): void;
+	/** Oldest first, times relative to now: `-4.2s→-3.8s resize 158x82 x3`. */
+	format(): string;
+	entries(): number;
+}
+
+export function createBreadcrumbTrail(opts: { now?: () => number; limit?: number } = {}): BreadcrumbTrail {
+	const now = opts.now ?? Date.now;
+	const limit = opts.limit ?? BREADCRUMB_LIMIT;
+	const ring: Breadcrumb[] = [];
+
+	function stamp(at: number, crumb: Breadcrumb): string {
+		const ago = (ms: number) => `-${((at - ms) / 1000).toFixed(1)}s`;
+		const when = crumb.count > 1 ? `${ago(crumb.firstAt)}→${ago(crumb.lastAt)}` : ago(crumb.lastAt);
+		const what = crumb.detail ? `${crumb.kind} ${crumb.detail}` : crumb.kind;
+		return crumb.count > 1 ? `${when} ${what} x${crumb.count}` : `${when} ${what}`;
+	}
+
+	return {
+		note(kind, detail = "") {
+			const at = now();
+			const last = ring[ring.length - 1];
+			if (last && last.kind === kind && last.detail === detail) {
+				last.lastAt = at;
+				last.count += 1;
+				return;
+			}
+			ring.push({ kind, detail, firstAt: at, lastAt: at, count: 1 });
+			if (ring.length > limit) ring.shift();
+		},
+		format() {
+			const at = now();
+			return ring.map((crumb) => stamp(at, crumb)).join(" | ");
+		},
+		entries: () => ring.length,
+	};
+}


### PR DESCRIPTION
Every terminal error line we log describes the **moment** of failure — the error, the dimensions it threw on, the byte and frame counters — and nothing before it. Successful resizes were never logged at all, so the one thing both field reports claim (a resize triggered it: a resolution change, an artifact pane being dragged) cannot be confirmed or killed from a log file. The crash lands roughly every other day, so each missed occurrence costs days.

- New `src/mainview/terminal-breadcrumbs.ts`: a bounded per-terminal ring of the last 16 events (`open`, `resize`, `resize-observer`, `dpr`, `hidden`, `visible`, `frame-error`), formatted relative to the crash and attached as `trail` to every error payload in `TerminalView` — both render-guard callbacks, all three refit catches, and the write/socket catches.
- Consecutive identical events collapse into a count (`-4.0s→-0.1s resize 158x82 x40`). Not just compression: a resize storm is itself a trigger signature, and without collapsing it would flush the older entries out of the ring.
- App-session totals (`liveTerminals`, `frameErrorPanes`, `sessionCrashes`) ride along in the same payloads. Every terminal shares one ghostty WASM module, so the first question a post-mortem asks is whether one pane broke or the module did, and no per-pane number answers that.
- Nothing visual changes; the ring is in-memory and silent while the terminal is healthy.

Decision record: `decisions/2026/08/18/terminal-crash-breadcrumbs.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6d95c182-a97f-48ce-818e-6e8bdc47bfe3) · `dev3://task/6d95c182-a97f-48ce-818e-6e8bdc47bfe3`
