### PR TITLE
Reset a terminal's screen once per instance, not on every reconnect

### DIFF
--- a/change-logs/2026/08/19/fix-reset-terminal-once-not-every-reconnect.md
+++ b/change-logs/2026/08/19/fix-reset-terminal-once-not-every-reconnect.md
@@ -1,0 +1,3 @@
+Short: Terminals stop dying after a resume
+
+A terminal pane no longer breaks — blank canvas, output frozen until restart — after the app has been in the background for a while. The screen reset that clears pixels inherited from a previous terminal now runs once when the terminal is built, instead of on every socket reconnect, which is what corrupted the renderer's state during a resume.

--- a/decisions/2026/08/19/reset-the-terminal-once-not-every-reconnect.md
+++ b/decisions/2026/08/19/reset-the-terminal-once-not-every-reconnect.md
@@ -1,0 +1,61 @@
+# Reset the terminal screen once per Terminal, not on every reconnect
+
+## Context
+
+From 2026-08-15 panes started dying: blank canvas, PTY and tmux alive, only a restart
+brought them back. Two signatures, both from inside ghostty's WASM module —
+`RangeError: Arguments contain a value that is out of range of code points` (a garbage
+codepoint sitting in a cell, hit by the draw path) and `RuntimeError: Out of bounds
+memory access`, the latter also out of `ghostty_terminal_write` on the very next batch.
+
+## Investigation
+
+The breadcrumb trail added in #1409 killed the standing theory: in all four captured
+crashes the ring covered the pane's entire life (37 s, 1316 s, 31 s, 359 s) with no
+`resize` and no `dpr` crumb at all. Geometry was never involved; the earlier
+occurrences only *looked* resize-triggered because `term.resize` was the single place
+we had a catch.
+
+What the evidence did point at:
+
+- The signatures appear in no log before `2026-08-15 20:43`, across every log going
+  back to February.
+- `ghostty-web` is pinned at `0.4.0` with an unchanged `sha512` in `bun.lock` since
+  March, so the vendor did not move.
+- Only two of our commits in that window touch the terminal. The other (#1360) is
+  keyboard-shortcut plumbing.
+- #1353 (`ddc019d6c`, 14 Aug) added `enqueueTermWrite("\x1bc")` — RIS, a full terminal
+  reset — to `connectPty`, so it ran on every tmux socket **re**connect: every resume
+  from background, every socket churn. The canary carrying it reached the machine
+  ~25 h before the first crash.
+- Every captured crash follows a `WS connected` by 8–37 s, and the trail's `visible`
+  crumb is that same reconnect.
+
+## Decision
+
+`connectPty` in `src/mainview/TerminalView.tsx` now writes RIS at most once per
+Terminal instance, guarded by an effect-scoped `screenResetForThisTerminal`. The reset
+exists because a freshly constructed ghostty Terminal paints the pixels the previous
+one left behind — that is a property of **constructing** a Terminal, not of opening a
+socket, and a reconnect reuses the same instance. A rebuilt terminal re-runs the effect
+and earns a fresh reset. `TerminalView.test.tsx` covers it: one RIS after the first
+connect, still one after a hide/show cycle.
+
+## Risks
+
+Correlation, not yet a proven mechanism: the crash lands seconds after the RIS, so the
+killer could equally be the tmux full redraw that the same reconnect triggers. Logs
+cannot separate the two. The machine sees 2–6 crashes a day with full diagnostics, so
+24–48 h of canary silence is the verdict. Should a stale screen reappear on resume, the
+correct fix is a targeted repaint request to tmux, never a reset of the emulator.
+
+## Alternatives considered
+
+- **Keep the RIS and swallow the fallout.** #1406's guard already rebuilds a dead pane,
+  so the symptom is survivable — but it left the user watching terminals blink several
+  times a day.
+- **Revert #1353 entirely.** Would bring back the real bug it fixed (task B showing
+  task A's screen until its first redraw). The bug was the *frequency*, not the reset.
+- **Build an isolated ghostty-web harness and hammer RIS until it crashes.** Real proof
+  and a gift to upstream, but hours of work while a one-line gate can be measured in
+  production within a day. Still worth doing if the silence does not arrive.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -576,6 +576,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		// Owned by this effect run, so a terminal that never opened cannot decrement
 		// the session count on cleanup.
 		let countedLive = false;
+		// One screen reset per Terminal instance. A rebuild re-runs this effect and
+		// therefore earns a fresh one; a reconnect does not.
+		let screenResetForThisTerminal = false;
 		let fitAddon: FitAddon | null = null;
 		let ws: WebSocket | null = null;
 		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1647,7 +1650,16 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			// showed task A's output until B's own redraw landed. RIS through the batched
 			// write path, which is what actually repaints. Skipped on a native resume:
 			// there the server sends a delta that expects the screen it left behind.
-			if (nativeSeqRef.current === null) enqueueTermWrite("\x1bc");
+			//
+			// ONCE PER TERMINAL, never per socket: leftover pixels are a property of
+			// constructing a Terminal, and a reconnect (resume from background, socket
+			// churn) reuses the same one. Resetting it on every reconnect is what
+			// started killing panes on 2026-08-15 — see the decision record
+			// reset-the-terminal-once-not-every-reconnect.
+			if (nativeSeqRef.current === null && !screenResetForThisTerminal) {
+				screenResetForThisTerminal = true;
+				enqueueTermWrite("\x1bc");
+			}
 			const diagnosticPtyUrl = ptyUrl.replace(/([?&]token=)[^&]+/, "$1***");
 			console.log("[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
 			let socket: WebSocket;

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -1822,6 +1822,26 @@ describe("TerminalView – remote sync gate", () => {
 		expect(view.queryByTestId("terminal-sync-gate")).not.toBeNull();
 	});
 
+	it("resets the screen once per terminal, not on every reconnect", async () => {
+		// The regression this guards: RIS on every socket meant a full ghostty reset
+		// on each resume from background, which corrupted the shared WASM buffer and
+		// killed panes from 2026-08-15 on. Leftover pixels belong to constructing a
+		// Terminal — a reconnect reuses the same one and must not reset it.
+		await renderAndSetup();
+		const resetsAfterFirstConnect = mockTermInstance.write.mock.calls.filter((call) => call[0] === "\x1bc").length;
+		expect(resetsAfterFirstConnect).toBe(1);
+
+		await act(async () => {
+			Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+			document.dispatchEvent(new Event("visibilitychange"));
+			Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+		await act(async () => { await new Promise((resolve) => setTimeout(resolve, 60)); });
+
+		expect(mockTermInstance.write.mock.calls.filter((call) => call[0] === "\x1bc").length).toBe(1);
+	});
+
 	it("lifts when the app refuses the session instead of blurring a dead canvas", async () => {
 		const view = await renderAndSetup();
 		await act(async () => {


### PR DESCRIPTION
Panes started dying on 2026-08-15: blank canvas, PTY and tmux alive, only a restart brought them back. Two signatures from inside ghostty's WASM module — a garbage codepoint hit by the draw path (`RangeError: ... out of range of code points`) and `Out of bounds memory access`, the latter also out of `ghostty_terminal_write` on the very next batch.

**The trail killed the standing theory.** In all four captured crashes the breadcrumb ring covered the pane's entire life (37 s, 1316 s, 31 s, 359 s) with no `resize` and no `dpr` crumb at all. Geometry was never involved; earlier occurrences only looked resize-triggered because `term.resize` was the one place we had a catch.

**What it pointed at instead:**

- the signatures appear in no log before `2026-08-15 20:43`, across every log back to February;
- `ghostty-web` is pinned at `0.4.0` with an unchanged `sha512` in `bun.lock` since March, so the vendor did not move;
- only two of our commits in that window touch the terminal, and the other (#1360) is keyboard-shortcut plumbing;
- #1353 added `enqueueTermWrite("\x1bc")` — RIS, a full terminal reset — to `connectPty`, so it ran on every tmux socket **re**connect: every resume from background, every socket churn. That canary reached the machine ~25 h before the first crash;
- every captured crash follows a `WS connected` by 8–37 s, and the trail's `visible` crumb is that same reconnect.

**The fix:** RIS at most once per Terminal instance. Leftover pixels are a property of *constructing* a ghostty Terminal, not of opening a socket, and a reconnect reuses the same instance; a rebuilt terminal earns a fresh reset. Covered by a test that fails when the guard is removed.

Correlation is not yet a proven mechanism — the crash lands seconds after the RIS, so the tmux full redraw the same reconnect triggers is not excluded. This machine sees 2–6 crashes a day with full diagnostics, so a day or two of canary silence is the verdict. Decision record: `decisions/2026/08/19/reset-the-terminal-once-not-every-reconnect.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6d95c182-a97f-48ce-818e-6e8bdc47bfe3) · `dev3://task/6d95c182-a97f-48ce-818e-6e8bdc47bfe3`