### PR TITLE
Open artifact overlays in the browser top layer

### DIFF
--- a/change-logs/2026/08/19/fix-artifact-template-top-layer-overlays.md
+++ b/change-logs/2026/08/19/fix-artifact-template-top-layer-overlays.md
@@ -1,0 +1,3 @@
+Short: Artifact menus stop getting clipped
+
+Menus and dropdowns in dev3 HTML artifacts no longer get cut off by the card, scroller, or sticky table header around them: the artifact starter now opens every overlay in the browser top layer and places it against its trigger, flipping above when the viewport is short. The starter ships a `.popover` menu primitive with keyboard, Escape, and outside-click handling so report authors never hand-roll an absolutely positioned panel again, and enhanced selects get the same lift for free.

--- a/decisions/2026/08/19/artifact-overlays-in-the-browser-top-layer.md
+++ b/decisions/2026/08/19/artifact-overlays-in-the-browser-top-layer.md
@@ -1,0 +1,38 @@
+# Artifact overlays live in the browser top layer
+
+## Context
+
+Agent-authored dev3 HTML artifacts repeatedly shipped with unusable menus. The user reported it as a recurring class of bug, not a one-off. The starter gave authors no overlay primitive, so every report invented one: a `position: absolute` panel with a small `z-index`, nested inside whatever card it belonged to.
+
+## Investigation
+
+Measured in headless Chromium on a real artifact (`A B C — имя ветки в git-баре`) and on the starter's own demo:
+
+- A hand-rolled `.menu` (134 px tall) inside a `.bar-frame { overflow-x: auto }` was clipped to 5 px — 96% of it gone. Its `z-index: 5` was irrelevant: the ancestor's overflow clips before stacking is ever consulted.
+- The Choices select in `.table-card { overflow: clip }` lost 30 px of its 144 px list whenever the table was short — one option of four unreachable.
+
+Both are the same failure: an overlay cannot escape an ancestor's overflow by tuning numbers. ECharts tooltips were checked too and are fine — ECharts confines them to the chart container itself.
+
+## Decision
+
+`app.js` promotes every panel that opens over the report into the browser **top layer** (`showPopover()` with `popover="manual"`), where no ancestor overflow or stacking context reaches it, and `placeOverlay()` owns its coordinates: placed against the trigger, flipped above it when the viewport is short, clamped inside the viewport, repositioned on scroll and resize.
+
+Two entry points, both in the shell:
+
+- Declarative `.popover` + `data-popover-trigger` markup (`initializePopovers`), with `aria-expanded`, arrow keys, Escape, outside-click dismissal, focus return, and close-on-item-click; `dev3Artifact.popover(panel, trigger)` registers a panel built after load.
+- Choices lists are lifted the same way off the library's own `showDropdown`/`hideDropdown` events (`initializeSelects`), so an author gets the fix without asking.
+
+`manual` rather than `auto`: `auto` light-dismiss fires before our own trigger click, reopening what the user just closed, and nested `auto` popovers dismiss each other — Choices must keep control of its list. `app.css` adds a `--dev3-z-nav` / `--dev3-z-overlay` / `--dev3-z-toast` scale so nothing guesses a number again, and `AUTHORING.md` bans hand-rolled absolute panels outright.
+
+## Risks
+
+`showPopover()` needs Chromium 114 / Safari 17 / Firefox 125. Below that the shell falls back to `position: fixed` with the same coordinates — verified by deleting `HTMLElement.prototype.showPopover` before the shell loads: the menu still spills 41 px past `overflow: clip` and stays hit-testable there. The fallback's high `z-index` is confined to the nearest ancestor stacking context, so a pathological wrapper could still cover it; no starter surface does.
+
+Placement is measured, not CSS anchor positioning (Chromium 125+, Safari 26+ only), which keeps one code path across every engine at the cost of a rAF-throttled scroll listener while a panel is open.
+
+## Alternatives considered
+
+- **Strip `overflow` from the clipping ancestors** — impossible: `.evidence-table-scroll` needs `overflow-x: auto` to scroll, and `.table-card` needs `clip` (not `hidden`) or the sticky table header unpins.
+- **A bigger `z-index` on overlays** — does not address clipping at all; it is exactly what the broken artifacts already tried.
+- **CSS anchor positioning** — less code, but Safari support only landed in 26 and the artifact viewer runs in WKWebView, so a JS fallback would be needed anyway.
+- **Reparent panels into `document.body` on open** — works, but it breaks Choices' internal DOM assumptions and moves author markup out from under report event delegation.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -60,7 +60,7 @@ The starter already pins ECharts 6.1.0, Choices.js 11.2.3, and noUiSlider 15.8.1
 
 `index.html` loads Apache ECharts 6.1.0 through a versioned cdnjs tag. Keep that tag intact when the report has charts. Offline, chart hosts show a notice while the rest of the report remains usable.
 
-The stable bridge lives in `app.js` and exposes `window.dev3Artifact.chart()`, `.color()`, `.enhance()`, `.setControl()`, and `.toast()`. Keep chart options, values, labels, filters, and interactions in `report.js`; use the exposed helpers there without editing the shell. The chart helper applies dev3 tokens, uses the SVG renderer for crisp print/PDF output, adds aria descriptions, re-renders on theme changes, and resizes with its container.
+The stable bridge lives in `app.js` and exposes `window.dev3Artifact.chart()`, `.color()`, `.enhance()`, `.popover()`, `.setControl()`, and `.toast()`. Keep chart options, values, labels, filters, and interactions in `report.js`; use the exposed helpers there without editing the shell. The chart helper applies dev3 tokens, uses the SVG renderer for crisp print/PDF output, adds aria descriptions, re-renders on theme changes, and resizes with its container.
 
 The shell declares the card surface as each chart's `backgroundColor`, because ECharts derives value-label contrast from it — without that, every label renders dark grey inside a white halo, which is illegible on the dark theme. Keep report code out of that decision: do not set `backgroundColor` or hand-color value labels unless the chart sits on a surface other than `--dev3-surface-raised`.
 
@@ -85,6 +85,29 @@ Keep form markup native and opt into the polished CDN controls with one attribut
 
 Use native checkbox, radio, and switch markup from `index.html`; `app.css` supplies the shared skin without report JavaScript.
 When report code changes an enhanced select or range, call `dev3Artifact.setControl(element, value)` so the native value, visual control, events, and output stay synchronized.
+
+## Menus, dropdowns, and anything that opens over the report
+
+**Never hand-roll `position: absolute` + `z-index` for a panel that opens.** It is the most common broken artifact: the card, the horizontal scroller, or the sticky table header around it clips the panel, and no z-index can win because the clip happens before stacking. Use the shell's popover — it puts the panel in the browser top layer, where no ancestor can clip it or paint over it:
+
+```html
+<div class="popover-anchor">
+  <button type="button" data-popover-trigger="branchMenu">refactor/…header-controls <span class="popover-caret" aria-hidden="true">▾</span></button>
+  <div class="popover" id="branchMenu">
+    <div class="popover-title">Branch</div>
+    <button type="button" data-action="copy-path">Copy worktree path</button>
+    <button type="button" data-action="checkout">Copy checkout command</button>
+    <hr>
+    <a href="https://example.com/pr/1412">Open pull request</a>
+  </div>
+</div>
+```
+
+The shell owns opening, `aria-expanded`, `aria-haspopup`, placement against the trigger, flipping above it when the viewport is short, clamping inside the viewport, repositioning on scroll and resize, arrow-key movement, Escape, outside-click dismissal, focus return, and hiding in print. Report code only listens for clicks on its own items. A menu closes on the item that was clicked; add `data-popover-keep-open` to an item that must not close it (a filter panel rather than a menu).
+
+For a panel built after load, register it with `dev3Artifact.popover(panel, triggerElement)` and drive it through the returned `open()`, `close()`, `toggle()`, and `isOpen`. Enhanced selects need nothing: the shell already lifts the Choices list into the top layer, so a filter inside `.table-card` or `.evidence-group` keeps every option reachable.
+
+Style overlays only through `.popover`, `.popover-title`, and plain `button`/`a`/`hr` children. Do not set `position`, `top`, `left`, `inset`, or `z-index` on a popover — the shell writes those. When something genuinely needs its own stacking order, use the `--dev3-z-nav`, `--dev3-z-overlay`, and `--dev3-z-toast` tokens instead of a new number.
 
 ## Tables
 
@@ -117,6 +140,7 @@ Choose Auto, Light, or Dark in the report, then print with Cmd/Ctrl+P. The style
 - Keep `Built with dev3 Artifacts` in the footer.
 - Keep the Auto → Light → Dark theme control.
 - Keep local navigation functional: a click must scroll, focus the section heading, and expose `aria-current`.
-- Use only the bundled `--dev3-*` semantic tokens for color.
+- Use only the bundled `--dev3-*` semantic tokens for color, and the `--dev3-z-*` tokens for stacking.
+- Route every panel that opens over the report through `.popover` / `dev3Artifact.popover()`; never hand-roll an absolutely positioned menu.
 - Keep the page responsive and keyboard-accessible.
 - Keep report content/data local; external libraries and live integrations are allowed.

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -1,4 +1,8 @@
     * { box-sizing: border-box; }
+    /* One scale for everything that stacks, so no panel has to guess a number.
+       Overlays live in the browser top layer, so their z-index only orders them
+       against each other. */
+    :root { --dev3-z-nav: 20; --dev3-z-overlay: 900; --dev3-z-toast: 1000; }
     html, body {
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
@@ -44,7 +48,7 @@
     .actions { gap: 8px; }
     .section-nav {
       position: sticky;
-      z-index: 20;
+      z-index: var(--dev3-z-nav);
       top: 0;
       display: flex;
       gap: 4px;
@@ -352,7 +356,7 @@
     .choices[data-type*="select-one"].is-open::after { margin-top: -2px; border-color: rgb(var(--dev3-accent)); transform: rotate(225deg); }
     .choices__list--single { padding: 0; }
     .choices__list--dropdown, .choices__list[aria-expanded] {
-      z-index: 30;
+      z-index: var(--dev3-z-overlay);
       margin-top: 5px;
       overflow: hidden;
       border: 1px solid rgb(var(--dev3-border));
@@ -373,6 +377,68 @@
       background: rgb(var(--dev3-accent) / .18);
       color: rgb(var(--dev3-text-primary));
     }
+    /* An open panel is lifted into the top layer, where the viewport is its
+       containing block, so the shell owns its coordinates and the UA defaults
+       (centred inset, auto margin, own border) must go. */
+    .choices__list--dropdown[popover], .choices__list[aria-expanded][popover],
+    .choices.is-flipped .choices__list--dropdown[popover] {
+      inset: auto;
+      margin: 0;
+      padding: 0;
+    }
+    /* Nothing an author writes can clip a menu that is in the top layer: a card
+       with overflow, a horizontal scroller, and a sticky header all stop
+       mattering. Hand-rolled `position: absolute` panels are the bug this
+       replaces — see AUTHORING.md. */
+    .popover-anchor { position: relative; }
+    .popover {
+      position: fixed;
+      z-index: var(--dev3-z-overlay);
+      min-width: 210px;
+      max-width: min(360px, calc(100vw - 24px));
+      overflow-y: auto;
+      inset: auto;
+      margin: 0;
+      padding: 4px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 12px;
+      background: rgb(var(--dev3-surface-elevated));
+      box-shadow: 0 18px 44px rgb(var(--dev3-shadow) / .3);
+      color: rgb(var(--dev3-text-primary));
+      overscroll-behavior: contain;
+    }
+    .popover:not([data-open]) { display: none; }
+    .popover-title {
+      padding: 7px 10px 5px;
+      color: rgb(var(--dev3-text-muted));
+      font-size: 10px;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .popover hr { margin: 4px 2px; border: 0; border-top: 1px solid rgb(var(--dev3-border)); }
+    .popover button, .popover a {
+      display: flex;
+      width: 100%;
+      min-height: 36px;
+      align-items: center;
+      gap: 9px;
+      padding: 8px 10px;
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: inherit;
+      font-size: 12px;
+      text-align: start;
+      text-decoration: none;
+    }
+    .popover button:hover, .popover a:hover, .popover button:focus-visible, .popover a:focus-visible {
+      background: rgb(var(--dev3-accent) / .14);
+      color: rgb(var(--dev3-accent));
+      transform: none;
+    }
+    [data-popover-trigger] .caret, [data-popover-trigger] .popover-caret { transition: transform .16s ease; }
+    [data-popover-trigger][aria-expanded="true"] .caret,
+    [data-popover-trigger][aria-expanded="true"] .popover-caret { transform: rotate(180deg); }
     /* clip, not hidden: hidden makes the card a scrollport and unpins the header. */
     .table-card { padding: 0; overflow: clip; }
     .table-head { padding: 16px 18px 12px; }
@@ -458,6 +524,7 @@
     .mini-fill { height: 100%; border-radius: 99px; background: rgb(var(--dev3-accent)); }
     .toast {
       position: fixed;
+      z-index: var(--dev3-z-toast);
       right: 22px;
       bottom: 22px;
       padding: 11px 14px;
@@ -532,6 +599,8 @@
       .eyebrow { font-size: 8px; }
       .muted, .section-copy { font-size: 9px; }
       .actions, .scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }
+      /* An overlay is a live interaction, never static output. */
+      .popover, [popover] { display: none !important; }
       .print-only { display: block !important; }
       .kpis { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
       .card { padding: 10px; }

--- a/src/assets/artifact-template/app.js
+++ b/src/assets/artifact-template/app.js
@@ -111,6 +111,145 @@
     });
   }
 
+  // ---- top-layer overlays ---------------------------------------------------
+  // The classic artifact bug is a menu nested in a card: the card clips it, a
+  // sticky header covers it, and the author is left tuning z-index numbers that
+  // cannot win. Every panel that opens over the report is promoted into the
+  // browser top layer instead, where no ancestor overflow or stacking context
+  // reaches it, and the shell places it against its trigger by hand.
+  const topLayerSupported = typeof HTMLElement.prototype.showPopover === "function";
+  const openOverlays = new Map();
+  const VIEWPORT_MARGIN = 8;
+
+  function placeOverlay(panel, anchor, options = {}) {
+    const gap = options.gap ?? 5;
+    const box = anchor.getBoundingClientRect();
+    panel.style.position = "fixed";
+    if (options.matchWidth) panel.style.width = `${Math.round(box.width)}px`;
+    panel.style.maxHeight = "";
+    const natural = panel.getBoundingClientRect().height;
+    const roomBelow = window.innerHeight - box.bottom - gap - VIEWPORT_MARGIN;
+    const roomAbove = box.top - gap - VIEWPORT_MARGIN;
+    const flip = natural > roomBelow && roomAbove > roomBelow;
+    const height = Math.min(natural, Math.max(flip ? roomAbove : roomBelow, 96));
+    panel.style.maxHeight = `${Math.round(height)}px`;
+    panel.style.top = `${Math.round(flip ? box.top - gap - height : box.bottom + gap)}px`;
+    const width = panel.getBoundingClientRect().width;
+    const overflowRight = box.left + width - (window.innerWidth - VIEWPORT_MARGIN);
+    const left = Math.max(VIEWPORT_MARGIN, box.left - Math.max(0, overflowRight));
+    panel.style.left = `${Math.round(left)}px`;
+    panel.dataset.placement = flip ? "top" : "bottom";
+  }
+
+  let overlayFrame;
+  function repositionOverlays() {
+    overlayFrame = undefined;
+    openOverlays.forEach((entry, panel) => placeOverlay(panel, entry.anchor, entry.options));
+  }
+  function scheduleReposition() {
+    if (!openOverlays.size || overlayFrame) return;
+    overlayFrame = requestAnimationFrame(repositionOverlays);
+  }
+  window.addEventListener("scroll", scheduleReposition, { capture: true, passive: true });
+  window.addEventListener("resize", scheduleReposition);
+
+  function openOverlay(panel, anchor, options = {}) {
+    panel.dataset.open = "true";
+    if (topLayerSupported) {
+      if (!panel.hasAttribute("popover")) panel.setAttribute("popover", "manual");
+      if (!panel.matches(":popover-open")) panel.showPopover();
+    }
+    openOverlays.set(panel, { anchor, options });
+    placeOverlay(panel, anchor, options);
+  }
+
+  function closeOverlay(panel) {
+    openOverlays.delete(panel);
+    delete panel.dataset.open;
+    if (topLayerSupported && panel.matches(":popover-open")) panel.hidePopover();
+  }
+
+  // ---- declarative popover menus --------------------------------------------
+  const popoverTriggers = new Map();
+
+  function popoverItems(panel) {
+    return [...panel.querySelectorAll('button, a[href], input, select, [tabindex]:not([tabindex="-1"])')]
+      .filter((item) => !item.disabled && item.offsetParent !== null);
+  }
+
+  function closePopover(panel, restoreFocus = true) {
+    const trigger = popoverTriggers.get(panel);
+    if (!panel.dataset.open) return;
+    const hadFocus = panel.contains(document.activeElement);
+    closeOverlay(panel);
+    trigger?.setAttribute("aria-expanded", "false");
+    if (restoreFocus && hadFocus) trigger?.focus();
+  }
+
+  function closeAllPopovers(except) {
+    popoverTriggers.forEach((_, panel) => { if (panel !== except) closePopover(panel, false); });
+  }
+
+  function openPopover(panel) {
+    const trigger = popoverTriggers.get(panel);
+    if (!trigger) return;
+    closeAllPopovers(panel);
+    openOverlay(panel, trigger, { gap: 6 });
+    trigger.setAttribute("aria-expanded", "true");
+    (popoverItems(panel)[0] || panel).focus({ preventScroll: true });
+  }
+
+  function togglePopover(panel) {
+    if (panel.dataset.open) closePopover(panel);
+    else openPopover(panel);
+  }
+
+  function initializePopovers(root) {
+    root.querySelectorAll("[data-popover-trigger]:not([data-popover-ready])").forEach((trigger) => {
+      const panel = document.getElementById(trigger.getAttribute("data-popover-trigger"));
+      if (!panel) return;
+      trigger.dataset.popoverReady = "true";
+      trigger.setAttribute("aria-haspopup", "true");
+      trigger.setAttribute("aria-expanded", "false");
+      panel.classList.add("popover");
+      if (!panel.hasAttribute("tabindex")) panel.setAttribute("tabindex", "-1");
+      popoverTriggers.set(panel, trigger);
+
+      trigger.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        togglePopover(panel);
+      });
+      // A menu closes on the action it was opened for; opt out per item when the
+      // panel is a filter panel rather than a menu.
+      panel.addEventListener("click", (event) => {
+        const item = event.target.closest("button, a[href]");
+        if (item && panel.contains(item) && !item.hasAttribute("data-popover-keep-open")) closePopover(panel);
+      });
+      panel.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+        const items = popoverItems(panel);
+        if (!items.length) return;
+        event.preventDefault();
+        const step = event.key === "ArrowDown" ? 1 : -1;
+        const index = items.indexOf(document.activeElement);
+        items[(index + step + items.length) % items.length].focus();
+      });
+    });
+  }
+
+  document.addEventListener("pointerdown", (event) => {
+    popoverTriggers.forEach((trigger, panel) => {
+      if (!panel.dataset.open) return;
+      if (panel.contains(event.target) || trigger.contains(event.target)) return;
+      closePopover(panel, false);
+    });
+  }, true);
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    popoverTriggers.forEach((_, panel) => { if (panel.dataset.open) closePopover(panel); });
+  });
+
   const selectControls = new Map();
   const sliderControls = new Map();
 
@@ -127,6 +266,15 @@
       });
       select.setAttribute("aria-hidden", "true");
       selectControls.set(select, instance);
+
+      // Choices anchors its list to the field, so a card with overflow eats it.
+      // The same top-layer lift keeps every option reachable.
+      const container = select.closest(".choices");
+      const dropdown = container?.querySelector(".choices__list--dropdown, .choices__list[aria-expanded]");
+      const field = container?.querySelector(".choices__inner");
+      if (!dropdown || !field) return;
+      select.addEventListener("showDropdown", () => openOverlay(dropdown, field, { matchWidth: true }));
+      select.addEventListener("hideDropdown", () => closeOverlay(dropdown));
     });
   }
 
@@ -193,6 +341,7 @@
   }
 
   function enhanceControls(root = document) {
+    initializePopovers(root);
     initializeSelects(root);
     initializeSliders(root);
   }
@@ -306,6 +455,7 @@
 
   const printClosedDetails = new Set();
   window.addEventListener("beforeprint", () => {
+    closeAllPopovers();
     document.querySelectorAll("details:not([open])").forEach((detail) => {
       printClosedDetails.add(detail);
       detail.open = true;
@@ -364,10 +514,36 @@
     applyArtifactTheme();
   });
 
+  // Report code that builds a panel after load registers it the same way the
+  // markup does, so a dynamic menu gets the same top layer and dismissal.
+  function popoverApi(panelOrId, anchor) {
+    const panel = typeof panelOrId === "string" ? document.getElementById(panelOrId) : panelOrId;
+    if (!panel) return { open() {}, close() {}, toggle() {}, get isOpen() { return false; } };
+    if (anchor) {
+      panel.classList.add("popover");
+      if (!panel.hasAttribute("tabindex")) panel.setAttribute("tabindex", "-1");
+      popoverTriggers.set(panel, anchor);
+      if (!panel.dataset.popoverReady) {
+        panel.dataset.popoverReady = "true";
+        panel.addEventListener("click", (event) => {
+          const item = event.target.closest("button, a[href]");
+          if (item && panel.contains(item) && !item.hasAttribute("data-popover-keep-open")) closePopover(panel);
+        });
+      }
+    }
+    return {
+      open: () => openPopover(panel),
+      close: () => closePopover(panel),
+      toggle: () => togglePopover(panel),
+      get isOpen() { return Boolean(panel.dataset.open); },
+    };
+  }
+
   window.dev3Artifact = Object.freeze({
     chart: dev3Chart,
     color: tokenColor,
     enhance: enhanceControls,
+    popover: popoverApi,
     setControl: setControlValue,
     toast: showToast,
   });

--- a/src/assets/artifact-template/index.html
+++ b/src/assets/artifact-template/index.html
@@ -92,7 +92,22 @@
     <section class="card table-card section-anchor" id="runs">
       <div class="section-head table-head">
         <div><h2 class="section-title">Recent agent runs</h2><div class="section-copy">Click a column heading to sort</div></div>
-        <div class="table-tools"><input id="search" type="search" placeholder="Search runs…"><select id="statusFilter" aria-label="Filter by status" data-ui-select><option value="all">All statuses</option><option value="Shipped">Shipped</option><option value="Review">Review</option><option value="Running">Running</option></select></div>
+        <div class="table-tools">
+          <input id="search" type="search" placeholder="Search runs…">
+          <select id="statusFilter" aria-label="Filter by status" data-ui-select><option value="all">All statuses</option><option value="Shipped">Shipped</option><option value="Review">Review</option><option value="Running">Running</option></select>
+          <!-- A menu inside a card: the shell lifts it into the top layer, so the
+               card's overflow and the sticky table header cannot clip it. -->
+          <div class="popover-anchor">
+            <button type="button" data-popover-trigger="runsMenu">Export <span class="popover-caret" aria-hidden="true">▾</span></button>
+            <div class="popover" id="runsMenu">
+              <div class="popover-title">Export runs</div>
+              <button type="button" data-export="csv">Copy as CSV</button>
+              <button type="button" data-export="markdown">Copy as Markdown</button>
+              <hr>
+              <button type="button" data-export="print">Open print view</button>
+            </div>
+          </div>
+        </div>
       </div>
       <table><thead><tr><th data-sort="name" tabindex="0">Run</th><th data-sort="status" tabindex="0">Status</th><th data-sort="agent" tabindex="0">Agent</th><th data-sort="progress" tabindex="0">Progress</th><th data-sort="cycle" tabindex="0">Cycle</th></tr></thead><tbody id="runRows"></tbody></table>
       <div class="empty" id="empty" hidden>No matching runs.</div>

--- a/src/assets/artifact-template/report.js
+++ b/src/assets/artifact-template/report.js
@@ -294,6 +294,16 @@
   });
   search?.addEventListener("input", renderTable);
   statusFilter?.addEventListener("change", renderTable);
+  document.getElementById("runsMenu")?.addEventListener("click", (event) => {
+    const format = event.target.closest("button[data-export]")?.dataset.export;
+    if (!format) return;
+    if (format === "print") return window.print();
+    const rows = [["Run", "Status", "Agent", "Cycle"], ...runs.map((r) => [r.name, r.status, r.agent, r.cycle])];
+    const text = rows.map((row) => (format === "csv" ? row.join(",") : `| ${row.join(" | ")} |`)).join("\n");
+    Promise.resolve(navigator.clipboard?.writeText(text))
+      .then(() => showToast(`${runs.length} runs copied`))
+      .catch(() => showToast("Copying needs clipboard permission"));
+  });
   document.querySelectorAll("th[data-sort]").forEach((heading) => {
     const sort = () => {
       sortDirection = sortKey === heading.dataset.sort ? -sortDirection : 1;

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -325,6 +325,46 @@ describe("bundled artifact starter contract", () => {
 		expect(css).toContain(".choices__item--selectable.is-highlighted");
 	});
 
+	it("opens every menu and dropdown in the browser top layer instead of stacking guesses", () => {
+		const html = readFileSync(htmlPath, "utf8");
+		const css = readFileSync(cssPath, "utf8");
+		const app = readFileSync(appPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+		const printBlock = css.slice(css.indexOf("@media print"));
+
+		// A hand-rolled absolute panel is clipped by the card around it, so the
+		// shell promotes overlays instead of ordering them.
+		expect(app).toContain("showPopover");
+		expect(app).toContain("hidePopover");
+		expect(app).toContain('setAttribute("popover", "manual")');
+		expect(app).toContain("function placeOverlay");
+		expect(app).toContain("function initializePopovers");
+		// The Choices list is anchored to its field, so it needs the same lift.
+		expect(app).toContain('select.addEventListener("showDropdown"');
+		expect(app).toContain('select.addEventListener("hideDropdown"');
+		// Placement, dismissal, and focus belong to the shell, not to report code.
+		expect(app).toContain('dataset.placement = flip ? "top" : "bottom"');
+		expect(app).toContain('if (event.key !== "Escape") return');
+		expect(app).toContain("scheduleReposition");
+		expect(app).toContain("popover: popoverApi");
+
+		// Anything that competes across panels goes through the scale; the single
+		// digits left are a table ordering its own pinned cells.
+		for (const token of ["--dev3-z-nav", "--dev3-z-overlay", "--dev3-z-toast"]) expect(css).toContain(token);
+		expect(css).toContain("z-index: var(--dev3-z-nav)");
+		expect(css).toContain("z-index: var(--dev3-z-overlay)");
+		expect(css).toContain("z-index: var(--dev3-z-toast)");
+		expect(css).not.toMatch(/z-index:\s*\d{2}/);
+		expect(css).toContain(".popover:not([data-open]) { display: none; }");
+		expect(printBlock).toContain(".popover, [popover] { display: none !important; }");
+
+		// The starter demonstrates the pattern where it used to break: inside a card.
+		expect(html).toContain('data-popover-trigger="runsMenu"');
+		expect(html).toContain('<div class="popover" id="runsMenu">');
+		expect(guide).toContain("Never hand-roll `position: absolute` + `z-index`");
+		expect(guide).toContain("dev3Artifact.popover(panel, triggerElement)");
+	});
+
 	it("keeps the selected theme and report structure in print output", () => {
 		const css = readFileSync(cssPath, "utf8");
 		const app = readFileSync(appPath, "utf8");


### PR DESCRIPTION
Menus and dropdowns in dev3 HTML artifacts kept shipping unusable. Measured on a real artifact: a hand-rolled `.menu` 134 px tall inside a `overflow-x: auto` bar rendered 5 px of itself — 96% clipped. Its `z-index: 5` was irrelevant, because an ancestor's overflow clips before stacking is consulted. Same failure in the starter's own demo: the Choices status filter inside `.table-card { overflow: clip }` lost one option of four whenever the table was short.

The shell now promotes every panel that opens over the report into the browser **top layer** (`showPopover()`), where no ancestor overflow or stacking context reaches it, and owns its coordinates — placed against the trigger, flipped above it when the viewport is short, clamped inside the viewport, repositioned on scroll and resize. Engines without `showPopover()` fall back to `position: fixed` with the same coordinates.

- New `.popover` + `data-popover-trigger` primitive: `aria-expanded`, arrow keys, Escape, outside-click dismissal, focus return, close-on-item-click, hidden in print. `dev3Artifact.popover(panel, trigger)` covers panels built after load.
- Choices lists are lifted off the library's own `showDropdown`/`hideDropdown`, so existing reports get the fix without changing markup.
- A `--dev3-z-nav` / `--dev3-z-overlay` / `--dev3-z-toast` scale replaces the literal numbers, and `AUTHORING.md` now bans hand-rolled absolute menus.
- The starter demos the pattern inside the table card — the spot where it used to break.

Rationale, measurements, and the rejected alternatives: `decisions/2026/08/19/artifact-overlays-in-the-browser-top-layer.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ffef9c73-0e28-498c-b9b4-9f09f1b5737b) · `dev3://task/ffef9c73-0e28-498c-b9b4-9f09f1b5737b`