### PR TITLE
Address variant senders by task id in the agent message envelope

### DIFF
--- a/change-logs/2026/08/19/fix-variant-agent-reply-address.md
+++ b/change-logs/2026/08/19/fix-variant-agent-reply-address.md
@@ -1,0 +1,3 @@
+Short: Variants get a working reply address
+
+A cross-task agent message sent from a task variant now carries the sender's task id as the reply address instead of `seq:<N>`, which every variant of a group shares and which the CLI rejects as ambiguous. The same address is used for the reply command handed back after an agent-initiated launch.

--- a/src/bun/__tests__/agent-message-envelope.test.ts
+++ b/src/bun/__tests__/agent-message-envelope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { wrapAgentMessage } from "../../shared/agent-message-envelope";
+import { agentReplyRef, wrapAgentMessage } from "../../shared/agent-message-envelope";
 
 describe("wrapAgentMessage", () => {
 	it("wraps the text with the sender seq and a reply command", () => {
@@ -27,5 +27,26 @@ describe("wrapAgentMessage", () => {
 	it("escapes markup in the sender title", () => {
 		const out = wrapAgentMessage("hi", { taskId: "t-1", seq: 9, title: "Fix <div> & span" });
 		expect(out).toContain("<from-title>Fix &lt;div&gt; &amp; span</from-title>");
+	});
+
+	it("addresses a variant sender by task id — its seq is shared with its siblings", () => {
+		const out = wrapAgentMessage("hi", { taskId: "7a9e61f4-1111-2222-3333-444455556666", seq: 1575, variantIndex: 1 });
+		expect(out).toContain("<from-task>7a9e61f4-1111-2222-3333-444455556666</from-task>");
+		expect(out).toContain('<reply-with>dev3 message --task 7a9e61f4-1111-2222-3333-444455556666 "your reply"</reply-with>');
+		expect(out).not.toContain("seq:1575");
+	});
+
+	it("keeps the seq address when the sender has no variant", () => {
+		const out = wrapAgentMessage("hi", { taskId: "t-1", seq: 1575, variantIndex: null });
+		expect(out).toContain('<reply-with>dev3 message --task seq:1575 "your reply"</reply-with>');
+	});
+});
+
+describe("agentReplyRef", () => {
+	it("prefers the seq handle, falls back to the id for a variant", () => {
+		expect(agentReplyRef({ id: "abc", seq: 42, variantIndex: null })).toBe("seq:42");
+		expect(agentReplyRef({ id: "abc", seq: 42 })).toBe("seq:42");
+		expect(agentReplyRef({ id: "abc", seq: 42, variantIndex: 0 })).toBe("abc");
+		expect(agentReplyRef({ id: "abc", seq: 42, variantIndex: 2 })).toBe("abc");
 	});
 });

--- a/src/bun/__tests__/cli-socket-launch-request.test.ts
+++ b/src/bun/__tests__/cli-socket-launch-request.test.ts
@@ -259,6 +259,37 @@ describe("task.move — agent-initiated launch approval", () => {
 		}));
 	});
 
+	it("addresses variants by task id — a variant group shares one seq", async () => {
+		const target = makeTask();
+		const variantRequester = { ...requester, variantIndex: 1 };
+		const project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([target, variantRequester]);
+		const pushFn = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(pushFn);
+		vi.mocked(launchTaskWithAgentChoice).mockResolvedValue({ ...target, status: "in-progress", variantIndex: 2 });
+
+		const respPromise = handleRequest(moveRequest({
+			taskId: TARGET_ID,
+			newStatus: "in-progress",
+			projectId: "proj-1",
+			sourceTaskId: REQUESTER_ID,
+		}));
+		await vi.waitFor(() => expect(pushFn).toHaveBeenCalled());
+		const [, payload] = pushFn.mock.calls[0] as [string, Record<string, unknown>];
+		resolveAgentRequest(payload.requestId as string, {
+			approved: true,
+			launch: { agentId: "builtin-claude", configId: "claude-auto", accountId: null },
+		});
+
+		const resp = await respPromise;
+		expect((resp.data as { replyCommand: string }).replyCommand).toBe(`dev3 message --task ${TARGET_ID} "your message"`);
+		expect(deliverLaunchHandoff).toHaveBeenCalledWith(expect.objectContaining({
+			source: expect.objectContaining({ seq: 3, variantIndex: 1 }),
+		}));
+	});
+
 	it("launches nothing when the user declines", async () => {
 		setupBoard(makeTask());
 		const pushFn = vi.fn();

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -182,7 +182,7 @@ is genuinely ambiguous (e.g., multiple possible dev servers, unclear base branch
    | \`$DEV3_PROJECT_PATH\` | Project root directory (the original repo checkout) |
    | \`$DEV3_PROJECT_NAME\` | Project name |
    | \`$DEV3_TASK_ID\` | Task UUID |
-   | \`$DEV3_TASK_SEQ\` | The task's human number, variant suffix included (\`1383\`, \`1383-1\`) — the \`seq:\` address every \`dev3 --task seq:<N>\` flag takes |
+   | \`$DEV3_TASK_SEQ\` | The task's human number, variant suffix included (\`1383\`, \`1383-1\`) — plain numbers work as \`--task seq:<N>\`; a variant shares its seq with its siblings, so address it by \`$DEV3_TASK_ID\` |
    | \`$DEV3_TASK_TITLE\` | Task title |
    | \`$DEV3_WORKTREE_PATH\` | This task's worktree directory |
    | \`$DEV3_BRANCH_NAME\` | The task's git branch |

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
 import type { AgentMessageSource, CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
 import { isValidNotificationDurationMs, NOTIFICATION_MAX_DURATION_MS, NOTIFICATION_MIN_DURATION_MS } from "../shared/duration";
+import { agentReplyRef } from "../shared/agent-message-envelope";
 import { socketMetaPathFor } from "../shared/socket-meta";
 import { isCliEndpointHandle } from "../shared/cli-endpoint";
 import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, appendTaskNote, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, titleFromDescription } from "../shared/types";
@@ -233,6 +234,7 @@ async function resolveAgentMessageSource(
 	return {
 		taskId: found.task.id,
 		seq: found.task.seq,
+		variantIndex: found.task.variantIndex,
 		title: getTaskTitle(found.task),
 		projectId: found.task.projectId,
 	};
@@ -299,7 +301,7 @@ async function requestAgentLaunchApproval(opts: {
 		task: launched,
 		seq: launched.seq,
 		title: getTaskTitle(launched),
-		replyCommand: `dev3 message --task seq:${launched.seq} "your message"`,
+		replyCommand: `dev3 message --task ${agentReplyRef(launched)} "your message"`,
 	};
 }
 

--- a/src/shared/agent-message-envelope.ts
+++ b/src/shared/agent-message-envelope.ts
@@ -6,19 +6,29 @@ import type { AgentMessageSource } from "./types";
  * human) and knows the exact command to answer with.
  */
 export function wrapAgentMessage(text: string, source: AgentMessageSource): string {
+	const ref = agentReplyRef({ id: source.taskId, seq: source.seq, variantIndex: source.variantIndex });
 	const lines = [
 		"<dev3-ai-message>",
-		`<from-task>seq:${source.seq}</from-task>`,
+		`<from-task>${ref}</from-task>`,
 	];
 	if (source.title) lines.push(`<from-title>${escapeXmlText(source.title)}</from-title>`);
 	lines.push(
-		`<reply-with>dev3 message --task seq:${source.seq} "your reply"</reply-with>`,
+		`<reply-with>dev3 message --task ${ref} "your reply"</reply-with>`,
 		"<message>",
 		text,
 		"</message>",
 		"</dev3-ai-message>",
 	);
 	return lines.join("\n");
+}
+
+/**
+ * The address a peer agent must use to reach this task. Every variant of one
+ * logical task shares its `seq`, so `--task seq:<N>` is rejected as ambiguous
+ * there — a variant is only addressable by its own task id.
+ */
+export function agentReplyRef(task: { id: string; seq: number; variantIndex?: number | null }): string {
+	return task.variantIndex != null ? task.id : `seq:${task.seq}`;
 }
 
 /** Minimal escaping for the single-line metadata tags (the body stays verbatim). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1931,8 +1931,14 @@ export interface ScheduledMessage {
 export interface AgentMessageSource {
 	/** Sender task id (used to skip wrapping when a task messages itself). */
 	taskId: string;
-	/** Sender's stable `seq` — the reply address (`--task seq:<N>`). */
+	/** Sender's stable `seq` — the reply address (`--task seq:<N>`) unless it is a variant. */
 	seq: number;
+	/**
+	 * Sender's variant index, when it is one attempt of a variant group. A group
+	 * shares one `seq`, so the reply address falls back to `taskId` — see
+	 * `agentReplyRef`.
+	 */
+	variantIndex?: number | null;
 	/** Sender's title, for human-readable context in the envelope. */
 	title?: string;
 	/**


### PR DESCRIPTION
A cross-task agent message sent from a task **variant** told the receiver to answer with `dev3 message --task seq:<N>`. Every variant of a group shares one `seq`, so the CLI rejects that ref as ambiguous — the reply never lands.

`agentReplyRef()` (new, in `src/shared/agent-message-envelope.ts`) now picks the address: `seq:<N>` for an ordinary task, the task id when `variantIndex != null`. Used by both `<from-task>` / `<reply-with>` in the envelope and by the `replyCommand` returned after an agent-initiated launch. `AgentMessageSource` carries `variantIndex`; the skill doc no longer claims `$DEV3_TASK_SEQ` with a variant suffix is a valid `seq:` address.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=5ccc97de-6098-448e-803a-a66a2bd8959b) · `dev3://task/5ccc97de-6098-448e-803a-a66a2bd8959b`