### PR TITLE
Pin the amd64 apt mirror off azure and bound the Linux apt step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,8 +168,11 @@ jobs:
 
       # The runner image may or may not ship tmux, and guard grammar is version
       # sensitive, so install on demand and print what we actually got.
+      # Bounded for the same reason release-build-linux.yml bounds its apt step: `apt-get update`
+      # stalls silently rather than failing, and an unbounded stall burns the whole job's clock.
       - name: Ensure tmux
         shell: bash
+        timeout-minutes: 10
         run: |
           if ! command -v tmux >/dev/null 2>&1; then
             if [ "$RUNNER_OS" = "macOS" ]; then

--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -25,15 +25,17 @@ on:
   # buildOrder 1618, sha 7a9d230fb. The built-folder check in create-release-artifacts.sh,
   # which is what caught the old degradation, passed on the way there.
   #
-  # Offset off the hour: the top of the hour is the busiest slot on shared runners.
+  # HALF-HOURLY ON THE ROUND HALF HOUR, at Arseny's request on 2026-08-19. It replaces the
+  # 20-minute cadence added on 2026-08-14 to shorten the wait for Windows canary builds: at
+  # 20-minute spacing a publish routinely met the next tick, and a Linux runner that hung an
+  # hour on `apt-get update` left a wall of queued-then-cancelled runs. Half-hourly still beats
+  # the original hourly `23 * * * *` and gives one run room to finish.
   #
-  # TEMPORARY, at Arseny's request on 2026-08-14, while he is shaking Windows out on canary:
-  # every fix he wants to try on his Windows box waits for a published canary build, and hourly
-  # is the bottleneck. TO REVERT, restore this single line verbatim — nothing else here depends
-  # on the cadence:
-  #     - cron: "23 * * * *"
+  # Round times are deliberate and cost something: the top of the hour is the busiest slot on
+  # shared runners, so these ticks fire later than an offset one would. Nothing here depends on
+  # the cadence, so it is safe to change again.
   schedule:
-    - cron: "3,23,43 * * * *"
+    - cron: "0,30 * * * *"
   # Safe to press on an unchanged `main`: every platform skips, and a republish of the same
   # commit reproduces the same `buildOrder` so clients would not reinstall anyway.
   workflow_dispatch:

--- a/.github/workflows/release-build-linux.yml
+++ b/.github/workflows/release-build-linux.yml
@@ -68,10 +68,70 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      # BOUNDED AND RETRIED, because `apt-get update` stalls instead of failing. On 2026-08-19 it
+      # hung 27, 45 and 64 minutes across three canary runs, every time after fetching the last
+      # `InRelease` and then going silent — no error, no timeout, no output. A hung publish holds
+      # the `canary-publish` concurrency group, so one stalled runner queued-then-cancelled every
+      # later tick and the channel published nothing for hours.
+      #
+      # THE MIRROR IS THE CAUSE, THE RETRY IS ONLY THE BACKSTOP — and that order was established
+      # by measurement, not assumption. A first probe (32242999970) caught a healthy window and
+      # said no mirror was better: every candidate answered 200, azure led the raw fetch at 4.5 MB
+      # in 0.03s, and the independent `mirrors.edge.kernel.org` was the slowest real `apt-get
+      # update` of six at 30s. That reading did not survive the next stall — see the pin below,
+      # which is what the second probe actually measured. Third-party mirrors stay rejected on
+      # those numbers; azure does not.
+      #
+      # `timeout` per command, not just `timeout-minutes` on the step: the step-level bound would
+      # kill the job outright, where this retries and only then fails.
+      #
+      # BUDGETS ARE SIZED OFF THE WORST SUCCESSFUL RUN, NOT THE HEALTHY ONE. The first cut used
+      # 180s/480s from a healthy probe, and run 32243397119 would have failed under it: on azure
+      # that job needed 151s to update and 927s to install, and it went green at 20m48s. Killing a
+      # build that would have shipped is worse than the stall, so update gets 300s per attempt
+      # (three attempts) and install 900s — both far above anything the pinned mirror needs.
       - name: Install Linux dependencies
+        timeout-minutes: 35
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          # AZURE DROPPED FROM THE MIRROR LIST, amd64 ONLY, AND IT IS THE WHOLE FIX. The runner
+          # image points apt at `deb mirror+file:/etc/apt/apt-mirrors.txt`, priority 1
+          # `azure.archive.ubuntu.com`. On 2026-08-19 that host failed two ways on amd64: dead
+          # (`Ign:` on every channel, apt then hanging on the fallback for 27, 45 and 64 minutes),
+          # and alive but crawling — one run served all 42 packages at 58.3 kB/s and took 15m27s
+          # over an `apt-get install` that normally takes seconds.
+          #
+          # Measured back to back on real runners (probe 32245652275) against the same day's azure
+          # numbers: `apt-get update` 4s vs 2m31s, `apt-get install` 9s vs 15m27s. Nothing else
+          # here comes close to that, which is why the pin leads and the retry loop below is only
+          # the backstop.
+          #
+          # GUARDED ON dpkg ARCHITECTURE, NOT ON inputs.arch, and arm64 is deliberately left
+          # alone. The arm image ships the same list, arm64 was healthy through the whole incident
+          # (3s update, 9s install in the probe), and whether `archive.ubuntu.com` serves arm64 at
+          # all is NOT verified — so pinning there is unverified risk with no upside. Reading the
+          # architecture from the runner cannot drift from the runner the way an input can.
+          if [ "$(dpkg --print-architecture)" = "amd64" ] && [ -f /etc/apt/apt-mirrors.txt ]; then
+            printf 'https://archive.ubuntu.com/ubuntu/\tpriority:1\nhttps://security.ubuntu.com/ubuntu/\tpriority:2\n' \
+              | sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+            echo "pinned apt mirrors:"; cat /etc/apt/apt-mirrors.txt
+          else
+            echo "apt mirror list left untouched ($(dpkg --print-architecture))"
+          fi
+          apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20)
+          updated=0
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update "${apt_opts[@]}"; then
+              updated=1
+              break
+            fi
+            echo "::warning::apt-get update attempt $attempt stalled or failed; retrying"
+            sleep 10
+          done
+          if [ "$updated" != 1 ]; then
+            echo "::error::apt-get update stalled three times — Ubuntu mirrors or runner egress are degraded"
+            exit 1
+          fi
+          sudo timeout 900 apt-get install -y "${apt_opts[@]}" \
             libgtk-3-dev \
             libwebkit2gtk-4.0-dev \
             libayatana-appindicator3-dev \

--- a/change-logs/2026/08/19/fix-canary-apt-stall-and-half-hourly-schedule.md
+++ b/change-logs/2026/08/19/fix-canary-apt-stall-and-half-hourly-schedule.md
@@ -1,0 +1,5 @@
+Linux release builds no longer crawl or stall on Ubuntu's Azure package mirror: amd64 now installs
+its GTK/WebKit dependencies from archive.ubuntu.com directly, which cut apt from 2m31s+15m27s down
+to 4s+9s on a degraded day, and every apt call is bounded by a timeout and retried so a bad mirror
+fails loudly instead of holding the canary publish queue for an hour. The canary schedule also
+moves back to every half hour, on the round half hour.

--- a/decisions/2026/08/19/pin-the-amd64-apt-mirror-off-azure.md
+++ b/decisions/2026/08/19/pin-the-amd64-apt-mirror-off-azure.md
@@ -1,0 +1,87 @@
+# Pin the amd64 apt mirror off azure, and bound the apt step
+
+## Context
+
+On 2026-08-19 the canary channel published nothing for over two hours. `build-linux-x64` in
+`release-build-linux.yml` hung on a bare `sudo apt-get update` for 27, 45 and then 64 minutes
+across three consecutive runs (32229071683, 32231773146, 32235140398). Each log ends identically:
+`azure.archive.ubuntu.com` answers `Ign:` on all five channels, apt fails over to
+`https://archive.ubuntu.com`, fetches the three `InRelease` files — then emits nothing at all until
+the run is cancelled. No error, no timeout, no partial progress.
+
+`canary-publish.yml` serialises publishes through `concurrency: canary-publish` with
+`cancel-in-progress: false`, so one stalled Linux runner holds the group. Every later tick queued
+and was then cancelled, which is what made a single hung job look like a dead channel.
+
+## Investigation
+
+Two probes, and the first one was wrong. Probe 32242999970 ran on a real `ubuntu-22.04` runner,
+dumped the image's apt config and timed six mirrors. The image uses `deb
+mirror+file:/etc/apt/apt-mirrors.txt`, listing `azure.archive.ubuntu.com` (priority 1),
+`archive.ubuntu.com` (2), `security.ubuntu.com` (3) — the failover seen in the hung logs. Every
+candidate answered 200; azure led the raw fetch (4.5 MB in 0.03 s) and the independent
+`mirrors.edge.kernel.org` was the slowest real `apt-get update` at 30 s against azure's 17 s. Read
+alone, that says no mirror switch helps and the problem is runner egress.
+
+It landed in a healthy window. Run 32243397119, on the same code minutes later, stalled again and
+this time ran to completion, which is what produced the real numbers: azure was *alive* there
+(`Hit`/`Get`, not `Ign`) and served all 42 packages at **58.3 kB/s** — `apt-get update` 27.4 MB in
+2 min 31 s, `apt-get install` 54.1 MB in 15 min 27 s, job green at 20 min 48 s. So azure fails two
+ways on amd64: dead, or alive and crawling. Both trace to the same host.
+
+Probe 32245652275 then ran a character-identical copy of the new step on both architectures.
+Pinned to `https://archive.ubuntu.com`, amd64 did `apt-get update` in **4 s** and `apt-get install`
+in **9 s** — against the same day's 2 min 31 s and 15 min 27 s on azure. arm64 correctly skipped
+the rewrite and was healthy throughout (3 s, 9 s).
+
+## Decision
+
+Pin first, bound second, in `.github/workflows/release-build-linux.yml`:
+
+1. On amd64 only, rewrite `/etc/apt/apt-mirrors.txt` to `https://archive.ubuntu.com` +
+   `https://security.ubuntu.com`, dropping azure. Guarded on `dpkg --print-architecture`, not
+   `inputs.arch`, so the guard cannot drift from the runner it runs on.
+2. Wrap each apt call in `timeout` (300 s per `update` attempt, three attempts, 900 s for
+   `install`), pass `Acquire::Retries=3` and 20 s HTTP/HTTPS timeouts, and fail with `::error::`
+   if all three update attempts stall. `timeout-minutes: 35` is a backstop, not the mechanism.
+
+Budgets are sized off the worst *successful* run, not a healthy probe: the first cut used
+180 s/480 s and would have failed run 32243397119, which needed 151 s and 927 s and shipped. The
+retry loop was verified under `bash -e` against a stubbed apt in all three paths (clean,
+stalls-twice-then-recovers, stalls-three-times); the first stub was itself broken and passed the
+three-stall case falsely, which is how it was caught.
+
+`build.yml`'s conditional `Ensure tmux` step, the only other apt caller in the repo, gets a
+10-minute step bound for the same reason.
+
+Separately, and at Arseny's request, the canary cron moved from `3,23,43 * * * *` to
+`0,30 * * * *`: at 20-minute spacing a publish routinely met its own next tick even when healthy.
+
+## Risks
+
+arm64 is deliberately left on the shipped list, including azure — it was healthy throughout and it
+is **not verified** that `archive.ubuntu.com` serves arm64 at all, so pinning there would be
+unverified risk with no upside. If azure degrades on arm64 later, this fix does not cover it.
+
+`archive.ubuntu.com` is Canonical's origin rather than a CDN edge, so it is plausibly slower than a
+healthy azure and is a single point of failure with only `security.ubuntu.com` behind it — the
+retry loop and the 35-minute bound are what stop that from becoming another silent hour. Round
+half-hour cron times also land in the busiest scheduling slot, so ticks fire later than the old
+offset ones did.
+
+## Alternatives considered
+
+**A third-party mirror** (`mirrors.edge.kernel.org`, `mirror.enzu.com`, `us.archive.ubuntu.com`).
+Rejected on probe 32242999970: kernel.org was the slowest of six on a real `apt-get update`, and
+none beat `archive.ubuntu.com`.
+
+**Retries alone, no pin.** What the first probe's reading implied. Rejected once run 32243397119
+showed azure itself serving at 58.3 kB/s: a retry on the same runner keeps the same mirror, so it
+bounds the damage without removing the cause.
+
+**Cache the .debs, or a prebuilt container with the GTK/WebKit deps baked in.** The structural fix
+and immune to mirror weather, but a much larger change to the release pipeline; `17e04f1fa` already
+removed a Linux dependency cache here as net-negative on the cache budget.
+
+**Do nothing and dispatch by hand when mirrors recover.** Leaves the hour-long queue hold for the
+next outage.


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that investigated and wrote this branch).

Canary published nothing for over two hours on 2026-08-19. `build-linux-x64` hung on a bare
`sudo apt-get update` for 27, 45 and 64 minutes across three runs, and because `canary-publish.yml`
serialises publishes through a `concurrency` group with `cancel-in-progress: false`, one stalled
runner queued-then-cancelled every later tick.

The cause is `azure.archive.ubuntu.com`, the runner image's priority-1 mirror, failing two ways on
amd64: dead (`Ign:` on every channel, apt then hanging on the fallback), and alive but crawling —
one run served all 42 packages at 58.3 kB/s, taking 2m31s to update and 15m27s to install.

**What changed**

- amd64 now rewrites `/etc/apt/apt-mirrors.txt` to `https://archive.ubuntu.com` +
  `https://security.ubuntu.com`, dropping azure. Measured on a real runner: `apt-get update` 4s and
  `apt-get install` 9s, against the same day's 2m31s and 15m27s.
- Guarded on `dpkg --print-architecture`, so arm64 keeps the shipped list — it was healthy
  throughout, and whether `archive.ubuntu.com` serves arm64 is not verified.
- Every apt call is bounded by `timeout` (300s per update attempt, three attempts, 900s install)
  with `Acquire::Retries=3`, failing loudly instead of stalling silently. Budgets are sized off the
  worst *successful* run, not a healthy one — an earlier 180s/480s cut would have failed a build
  that shipped at 20m48s.
- `build.yml`'s conditional `Ensure tmux` step, the only other apt caller, gets a 10-minute bound.
- Canary cron moves from `3,23,43 * * * *` to `0,30 * * * *` at Arseny's request: at 20-minute
  spacing a publish routinely met its own next tick.

Full measurements, the probe that first pointed the wrong way, and the rejected alternatives are in
`decisions/2026/08/19/pin-the-amd64-apt-mirror-off-azure.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c13e9d5c-301f-4bc2-9121-f07a752061e8) · `dev3://task/c13e9d5c-301f-4bc2-9121-f07a752061e8`
