### PR TITLE
Box the worktree-config and manual-completion buttons in the task panel

### DIFF
--- a/change-logs/2026/08/19/fix-boxed-panel-chrome-buttons.md
+++ b/change-logs/2026/08/19/fix-boxed-panel-chrome-buttons.md
@@ -1,0 +1,3 @@
+Short: Worktree config and I-decide get a box
+
+The worktree-config gear and the "I decide" completion toggle in the task info panel now carry the same bordered box as the buttons around them, instead of sitting flat in the bar.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -782,7 +782,7 @@ function TaskInfoPanel({
 				className={`task-anim flex items-center gap-1.5 px-2 py-1 rounded-lg transition-colors flex-shrink-0 ${
 					task.manualCompletion
 						? "text-accent bg-accent/10 border border-accent/25"
-						: "text-fg-3 hover:text-fg hover:bg-elevated"
+						: "text-fg-3 hover:text-fg hover:bg-elevated border border-edge"
 				}`}
 			>
 				{/* Icon only. Even the short "I decide" label cost bar width for a state
@@ -1032,7 +1032,7 @@ function TaskInfoPanel({
 		<Tooltip content={t("projectSettings.tabWorktree")} detail={t("ttip.infoPanel.worktreeConfig")}>
 			<button
 				onClick={() => navigate({ screen: "project-settings", projectId: project.id, tab: "worktree", worktreeTaskId: task.id })}
-				className="task-anim flex-shrink-0 p-1 rounded hover:bg-elevated transition-colors text-fg-3 hover:text-fg"
+				className="task-anim flex-shrink-0 px-1.5 py-1 rounded border border-edge hover:bg-elevated transition-colors text-fg-3 hover:text-fg"
 				aria-label={t("projectSettings.tabWorktree")}
 			>
 				<WorktreeSettingsIcon className="w-4 h-4" />


### PR DESCRIPTION
The worktree-config gear and the "I decide" (manual completion) toggle were the only two controls in the task info panel bars rendered without a box — the gear had no border at all, and the manual-completion toggle only grew one in its active state. Both now carry the same resting `border border-edge` box as their neighbours (terminal-shortcuts button, diff badge, pane controls), while the active accent border on the toggle stays as the state marker.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=91dd9bb1-c1ae-48fe-af25-f3c53fb45386) · `dev3://task/91dd9bb1-c1ae-48fe-af25-f3c53fb45386`