### PR TITLE
Report a frozen renderer from the backend via a heartbeat watchdog

### DIFF
--- a/change-logs/2026/08/19/chore-renderer-freeze-watchdog.md
+++ b/change-logs/2026/08/19/chore-renderer-freeze-watchdog.md
@@ -1,0 +1,1 @@
+A frozen app window now leaves a record in the log instead of nothing: each window beats into the backend every two seconds, and the backend — which survives the freeze — reports when the beats stop, what the window had on screen, and when they come back. A healthy session costs one log line per window, and repeated stalls are capped at five reports so the log stays readable.

--- a/decisions/2026/08/19/renderer-heartbeat-watchdog.md
+++ b/decisions/2026/08/19/renderer-heartbeat-watchdog.md
@@ -1,0 +1,69 @@
+# Judge a frozen window from the backend, not from inside it
+
+## Context
+
+On 2026-08-19 around 14:17 the UI froze hard. The log (`~/.dev3.0/logs/2026/08/2026-08-19.log`,
+pid 84000) held no cause — only a timing signature found afterwards: every
+renderer-driven call stopped mid-poll at 14:17:00.911 (the 4.5s `checkDevServer`
+loop died between ticks, and no `saveLastRoute` followed, so it was not a route
+change), while backend work continued normally for another 59 seconds until the
+user quit.
+
+## Investigation
+
+`terminal-render-guard` already watches for a dead ghostty render loop, but it
+runs its own `setInterval` **inside the renderer** — a wedged renderer never fires
+it, so it cannot see a whole-window freeze. Nothing in the renderer can: its
+timers, guards and error handlers are all dead with it.
+
+Corroborating evidence for where the CPU goes, from the same day:
+`/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent_2026-08-19-*.cpu_resource.diag`
+(10:29, 11:00, 11:37) all share one heaviest stack — `requestAnimationFrame` →
+`CanvasRenderingContext2D::fillText` → CoreText shaping, i.e. the terminal canvas —
+at 62–88% CPU with the webview footprint reaching 774 MB. None of them covers
+14:17, so they are a pattern, not the captured cause.
+
+## Decision
+
+The backend outlives the freeze, so it does the judging.
+
+- `src/mainview/renderer-heartbeat.ts` — each window beats every 2s
+  (`rendererHeartbeat` RPC) carrying only what the backend cannot know: the gap the
+  page measured itself, whether that gap spans a hidden stretch, and the live
+  terminal counts (now shared via `src/mainview/terminal-session-stats.ts`).
+- `src/bun/renderer-watchdog.ts` — `recordRendererHeartbeat` plus
+  `startRendererWatchdog` (wired in `src/bun/index.ts` next to `startLoopMonitor`,
+  its backend counterpart). Four lines exist: `started` (one positive marker per
+  window), `lost`, `resumed`, and `hiccup` for a stall that recovered on its own.
+  Each client is tracked separately, because several windows and remote browsers
+  beat into one backend.
+
+Log cost is the design constraint, at the user's explicit request: a healthy
+session is **one line per window**, and `MAX_HICCUPS_PER_CLIENT = 5` caps repeated
+stalls, with the last line flagging `furtherStallsSuppressed` so the silence after
+it is not misread.
+
+## Risks
+
+- **False "lost" on a window that is merely throttled.** A hidden window has its
+  timers throttled to roughly one tick a minute. Guarded twice: the last beat
+  carries `visible` (and the window beats once more on its way out), and a gap that
+  spans a hidden stretch is marked `hiddenSinceLastBeat` so it is never called a
+  stall. A first live run produced exactly this false positive (a 5.7s "hiccup" on
+  an occluded window) before the second guard existed.
+- **The `lost` path is not proven end-to-end.** The unit tests cover it, and
+  `started`/`hiccup` were observed live, but SIGSTOPping the WebContent process
+  produced no `lost` line — most likely because that window was not visible, which
+  is the guard above doing its job. Unverified against a genuinely visible frozen
+  window.
+- A beat every 2s per window is one extra RPC on an idle app.
+
+## Alternatives considered
+
+- **Watch existing renderer traffic instead of adding a beat.** Rejected: that
+  traffic is incidental, not periodic by contract, so "quiet" would not mean
+  "frozen".
+- **A watchdog inside the renderer.** That is what already exists and what failed —
+  a wedged thread cannot report on itself.
+- **Leave it and read the timing signature by hand each time.** Rejected: it took
+  a full investigation to find, and it names no cause.

--- a/src/bun/__tests__/renderer-watchdog.test.ts
+++ b/src/bun/__tests__/renderer-watchdog.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const logged = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+vi.mock("../logger", () => ({
+	createLogger: () => logged,
+}));
+
+import {
+	FORGET_MS,
+	MAX_HICCUPS_PER_CLIENT,
+	HICCUP_MS,
+	LOST_MS,
+	recordRendererHeartbeat,
+	resetRendererWatchdog,
+	startRendererWatchdog,
+	type RendererBeat,
+} from "../renderer-watchdog";
+
+/**
+ * The freeze this exists for (2026-08-19 ~14:17) left no cause in the log — only a
+ * timing signature. These lock the signature down: the backend must say a window
+ * went quiet, must not say it about a window that is merely hidden, and must not
+ * confuse one window with another.
+ */
+
+const CHECK_MS = 1_000;
+
+function beat(over: Partial<RendererBeat> = {}): RendererBeat {
+	return {
+		clientId: "win-a",
+		sinceLastBeatMs: 2_000,
+		visible: true,
+		hiddenSinceLastBeat: false,
+		terminals: 3,
+		frameErrorPanes: 0,
+		...over,
+	};
+}
+
+describe("renderer watchdog", () => {
+	let clock = 0;
+	let tick: () => void;
+	let stop: () => void;
+
+	function advanceTo(ms: number) {
+		clock = ms;
+		tick();
+	}
+
+	beforeEach(() => {
+		logged.info.mockReset();
+		logged.warn.mockReset();
+		resetRendererWatchdog();
+		clock = 0;
+		stop?.();
+		stop = startRendererWatchdog({
+			now: () => clock,
+			checkIntervalMs: CHECK_MS,
+			setInterval: (fn) => {
+				tick = fn;
+				return 1;
+			},
+			clearInterval: () => {},
+			context: () => ({ activeTask: "abcd1234" }),
+		});
+	});
+
+	it("marks the first beat of a window, so a silent log can be told from a broken channel", () => {
+		recordRendererHeartbeat(beat({ terminals: 2 }));
+		expect(logged.info).toHaveBeenCalledTimes(1);
+		expect(logged.info.mock.calls[0][0]).toContain("heartbeat started");
+		expect(logged.info.mock.calls[0][1]).toMatchObject({ client: "win-a", terminals: 2 });
+
+		clock = 2_000;
+		recordRendererHeartbeat(beat());
+		expect(logged.info).toHaveBeenCalledTimes(1);
+	});
+
+	it("stays silent while the beats keep coming", () => {
+		for (let at = 0; at < LOST_MS * 3; at += 2_000) {
+			clock = at;
+			recordRendererHeartbeat(beat());
+			advanceTo(at + 500);
+		}
+		expect(logged.warn).not.toHaveBeenCalled();
+	});
+
+	it("reports a visible window that went quiet, once, with what it was doing", () => {
+		recordRendererHeartbeat(beat({ terminals: 4, frameErrorPanes: 2 }));
+
+		advanceTo(LOST_MS - 1);
+		expect(logged.warn).not.toHaveBeenCalled();
+
+		advanceTo(LOST_MS);
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+		const [message, extra] = logged.warn.mock.calls[0];
+		expect(message).toContain("heartbeat lost");
+		expect(extra).toMatchObject({ client: "win-a", quietForMs: LOST_MS, terminals: 4, frameErrorPanes: 2, activeTask: "abcd1234" });
+
+		advanceTo(LOST_MS * 2);
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("says nothing about a hidden window — its timers are throttled by design", () => {
+		recordRendererHeartbeat(beat({ visible: false }));
+		advanceTo(LOST_MS * 4);
+		expect(logged.warn).not.toHaveBeenCalled();
+	});
+
+	it("reports the recovery with how long the window was gone", () => {
+		recordRendererHeartbeat(beat());
+		advanceTo(LOST_MS);
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+
+		clock = 30_000;
+		recordRendererHeartbeat(beat({ sinceLastBeatMs: 30_000 }));
+		// info #1 was the "started" marker for this window's first beat.
+		expect(logged.info).toHaveBeenCalledTimes(2);
+		const [message, extra] = logged.info.mock.calls[1];
+		expect(message).toContain("resumed");
+		expect(extra).toMatchObject({ client: "win-a", downMs: 30_000 });
+		// The recovery is not also a hiccup — one event, one line.
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports a stall the window measured itself and recovered from", () => {
+		recordRendererHeartbeat(beat());
+		clock = HICCUP_MS;
+		recordRendererHeartbeat(beat({ sinceLastBeatMs: HICCUP_MS }));
+
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+		const [message, extra] = logged.warn.mock.calls[0];
+		expect(message).toContain("hiccup");
+		expect(extra).toMatchObject({ client: "win-a", stalledMs: HICCUP_MS, activeTask: "abcd1234" });
+	});
+
+	it("does not call a gap a stall when the window was hidden across it", () => {
+		recordRendererHeartbeat(beat());
+		clock = 120_000;
+		// Coming back from hidden: a full minute of throttled timers, not a freeze.
+		recordRendererHeartbeat(beat({ sinceLastBeatMs: 118_000, visible: true, hiddenSinceLastBeat: true }));
+		expect(logged.warn).not.toHaveBeenCalled();
+	});
+
+	it("never floods the log: stalls stop being reported after the ceiling", () => {
+		recordRendererHeartbeat(beat());
+		for (let n = 1; n <= MAX_HICCUPS_PER_CLIENT + 20; n += 1) {
+			clock += HICCUP_MS;
+			recordRendererHeartbeat(beat({ sinceLastBeatMs: HICCUP_MS }));
+		}
+
+		expect(logged.warn).toHaveBeenCalledTimes(MAX_HICCUPS_PER_CLIENT);
+		// The last line admits it is the last one.
+		const last = logged.warn.mock.calls[MAX_HICCUPS_PER_CLIENT - 1][1];
+		expect(last).toMatchObject({ furtherStallsSuppressed: true });
+	});
+
+	it("judges each window on its own — a live one does not cover a frozen one", () => {
+		recordRendererHeartbeat(beat({ clientId: "frozen" }));
+		recordRendererHeartbeat(beat({ clientId: "alive" }));
+
+		for (let at = 2_000; at <= LOST_MS + 2_000; at += 2_000) {
+			clock = at;
+			recordRendererHeartbeat(beat({ clientId: "alive" }));
+			advanceTo(at + 100);
+		}
+
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+		expect(logged.warn.mock.calls[0][1]).toMatchObject({ client: "frozen" });
+	});
+
+	it("forgets a window that never came back, instead of tracking it forever", () => {
+		recordRendererHeartbeat(beat());
+		advanceTo(LOST_MS);
+		expect(logged.warn).toHaveBeenCalledTimes(1);
+
+		advanceTo(LOST_MS + FORGET_MS);
+		// Dropped, so a beat from a reloaded page starts clean: it reads as a brand-new
+		// window ("started" again), never as a recovery of the one that went away.
+		clock = LOST_MS + FORGET_MS + 1_000;
+		recordRendererHeartbeat(beat());
+		const messages = logged.info.mock.calls.map((call) => call[0]);
+		expect(messages).toEqual(["renderer heartbeat started", "renderer heartbeat started"]);
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -6,7 +6,8 @@ import Electrobun, {
 	Utils,
 } from "electrobun/bun";
 import { startDisplayWatch } from "./display-watch";
-import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited, consumeRecentWatchedNotification, setAppForeground, setFocusMode, pushTerminalBell } from "./rpc-handlers";
+import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskInProgress, startMergeDetectionPoller, startPRDetectionPoller, handlePaneExited, consumeRecentWatchedNotification, setAppForeground, setFocusMode, pushTerminalBell, getActiveContext } from "./rpc-handlers";
+import { startRendererWatchdog } from "./renderer-watchdog";
 import {
 	startAutoCheck,
 	checkForUpdateWithChannel,
@@ -502,6 +503,15 @@ await startRemoteAccessServer({
 // Silent during normal operation — only fires on stalls (e.g. accidental
 // sync I/O, GC pauses, runaway regex).
 startLoopMonitor();
+
+// The renderer half of the same idea: a wedged window cannot report itself, so we
+// judge the silence between its heartbeats from here. See renderer-watchdog.ts.
+startRendererWatchdog({
+	context: () => {
+		const { projectId, taskId } = getActiveContext();
+		return { activeProject: projectId?.slice(0, 8) ?? null, activeTask: taskId?.slice(0, 8) ?? null };
+	},
+});
 
 // Reconcile persisted lifecycle hints before background activity starts.
 await rehydrateTaskLifecycles();

--- a/src/bun/renderer-watchdog.ts
+++ b/src/bun/renderer-watchdog.ts
@@ -1,0 +1,142 @@
+/**
+ * Notice a window that stopped running JavaScript at all.
+ *
+ * `terminal-render-guard` already watches the ghostty render loop, but it runs
+ * its own `setInterval` inside the renderer: a wedged renderer never fires it,
+ * so a whole-window freeze leaves nothing in the log. The freeze on 2026-08-19
+ * ~14:17 was readable only as a timing signature after the fact — renderer RPC
+ * stopped mid-poll while the backend kept working for another minute.
+ *
+ * The backend survives that freeze, so it is the only place that can report it.
+ * Each renderer beats every {@link HEARTBEAT_INTERVAL_MS}; here we say when the
+ * beats stopped, what the window was doing at the time, and when they came back.
+ *
+ * Two failures, two lines:
+ *  - **lost/resumed** — the window froze (or died) for longer than {@link LOST_MS}.
+ *  - **hiccup** — the window stalled but recovered on its own; only the renderer
+ *    can measure this, so each beat reports the gap it saw.
+ */
+
+import { createLogger } from "./logger";
+
+const log = createLogger("renderer-watchdog");
+
+export interface RendererBeat {
+	/** Per page load, so several windows (and remote browsers) are judged apart. */
+	clientId: string;
+	/** Gap the renderer itself measured since its previous beat. */
+	sinceLastBeatMs: number;
+	/** A hidden window throttles timers legitimately — never called a freeze. */
+	visible: boolean;
+	/** The measured gap spans a hidden stretch, so throttling already explains it. */
+	hiddenSinceLastBeat: boolean;
+	terminals: number;
+	frameErrorPanes: number;
+}
+
+/** How often each renderer is expected to beat. Keep in lockstep with the renderer. */
+export const HEARTBEAT_INTERVAL_MS = 2_000;
+/** Silence past this counts as a frozen (or gone) window. */
+export const LOST_MS = 8_000;
+/** A renderer-measured gap past this is a stall that recovered by itself. */
+export const HICCUP_MS = 4_000;
+export const CHECK_INTERVAL_MS = 2_000;
+/** A window lost this long is closed or reloaded, not frozen — stop tracking it. */
+export const FORGET_MS = 60_000;
+/**
+ * Hard ceiling on stall reports per window. A healthy session costs exactly one
+ * line ("started"); everything else is a real symptom. A window that stalls over
+ * and over has said what it has to say in a handful of lines, and the log must stay
+ * readable — the point of this instrumentation is a freeze that stands out, not a
+ * stream nobody scrolls through.
+ */
+export const MAX_HICCUPS_PER_CLIENT = 5;
+
+interface ClientState {
+	lastBeatAt: number;
+	lastBeat: RendererBeat;
+	lostReportedAt: number | null;
+	hiccups: number;
+}
+
+export interface RendererWatchdogOptions {
+	/** Extra context the backend knows and the renderer does not need to send. */
+	context?: () => Record<string, string | number | boolean | null>;
+	now?: () => number;
+	setInterval?: (fn: () => void, ms: number) => unknown;
+	clearInterval?: (handle: unknown) => void;
+	checkIntervalMs?: number;
+}
+
+const clients = new Map<string, ClientState>();
+let getContext: NonNullable<RendererWatchdogOptions["context"]> = () => ({});
+let clock: () => number = Date.now;
+
+export function recordRendererHeartbeat(beat: RendererBeat): void {
+	const at = clock();
+	const known = clients.get(beat.clientId);
+	let hiccups = known?.hiccups ?? 0;
+
+	if (!known) {
+		// The one positive marker: without it, a window that never beat at all (old
+		// build, broken channel) reads exactly like a healthy silent one.
+		log.info("renderer heartbeat started", { client: beat.clientId, terminals: beat.terminals });
+	} else if (known.lostReportedAt != null) {
+		log.info("renderer heartbeat resumed", {
+			client: beat.clientId,
+			downMs: at - known.lastBeatAt,
+			terminals: beat.terminals,
+		});
+	} else if (beat.sinceLastBeatMs >= HICCUP_MS && !beat.hiddenSinceLastBeat && known.hiccups < MAX_HICCUPS_PER_CLIENT) {
+		hiccups = known.hiccups + 1;
+		log.warn("renderer hiccup — the window stalled and recovered on its own", {
+			client: beat.clientId,
+			stalledMs: beat.sinceLastBeatMs,
+			terminals: beat.terminals,
+			frameErrorPanes: beat.frameErrorPanes,
+			// Says the ceiling was hit, so silence afterwards is not read as "it stopped".
+			...(hiccups === MAX_HICCUPS_PER_CLIENT ? { furtherStallsSuppressed: true } : {}),
+			...getContext(),
+		});
+	}
+
+	clients.set(beat.clientId, { lastBeatAt: at, lastBeat: beat, lostReportedAt: null, hiccups });
+}
+
+/** Test seam: each suite starts from an empty registry. */
+export function resetRendererWatchdog(): void {
+	clients.clear();
+	getContext = () => ({});
+	clock = Date.now;
+}
+
+export function startRendererWatchdog(opts: RendererWatchdogOptions = {}): () => void {
+	clock = opts.now ?? Date.now;
+	getContext = opts.context ?? (() => ({}));
+	const setTimer = opts.setInterval ?? ((fn: () => void, ms: number) => setInterval(fn, ms));
+	const clearTimer = opts.clearInterval ?? ((handle: unknown) => clearInterval(handle as Parameters<typeof clearInterval>[0]));
+
+	const handle = setTimer(() => {
+		const tick = clock();
+		for (const [clientId, state] of clients) {
+			const quietFor = tick - state.lastBeatAt;
+			if (state.lostReportedAt != null) {
+				if (tick - state.lostReportedAt >= FORGET_MS) clients.delete(clientId);
+				continue;
+			}
+			// A hidden window is allowed to go quiet: the renderer beats once more on
+			// its way out, so the last report is what the window could actually do.
+			if (quietFor < LOST_MS || !state.lastBeat.visible) continue;
+			state.lostReportedAt = tick;
+			log.warn("renderer heartbeat lost — the window is frozen or gone", {
+				client: clientId,
+				quietForMs: quietFor,
+				terminals: state.lastBeat.terminals,
+				frameErrorPanes: state.lastBeat.frameErrorPanes,
+				...getContext(),
+			});
+		}
+	}, opts.checkIntervalMs ?? CHECK_INTERVAL_MS);
+
+	return () => clearTimer(handle);
+}

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -23,6 +23,7 @@ import { listAgentSkills as scanAgentSkills } from "../skills-catalog";
 import { spawn, spawnSync } from "../spawn";
 import { writeSystemClipboard } from "../system-clipboard";
 import { getPushMessage, getUploadedImageExtension, hideAppNative, log, logRendererError, logRendererDiagnostic, setActiveContext, setAppForeground, setStreamerPrivacy, setTerminalFocus } from "./shared";
+import { recordRendererHeartbeat } from "../renderer-watchdog";
 import { applyMenuContext, type MenuContext } from "../../shared/application-menu";
 import { loadSharedArtifactContent, loadSharedArtifactDownload, sharedArtifactHtmlPath } from "../shared-artifacts";
 import { isFullyQualifiedPath } from "../../shared/absolute-path";
@@ -1034,6 +1035,7 @@ async function copyTerminalSelection(params: { taskId: string; text: string; mou
 export const appHandlers = {
 	logRendererError,
 	logRendererDiagnostic,
+	rendererHeartbeat: recordRendererHeartbeat,
 	quitApp,
 	requestQuit,
 	consumePendingQuitDialog,

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -24,6 +24,7 @@ import {
 import { installBidiRender, uninstallBidiRender } from "./terminal-bidi/proxy";
 import { installCursorVisibilityGate, type CursorVisibilityGate } from "./terminal-cursor-focus";
 import { installRenderGuard, type RenderGuard } from "./terminal-render-guard";
+import { session } from "./terminal-session-stats";
 import { createBreadcrumbTrail } from "./terminal-breadcrumbs";
 import { installGlyphCellFit, type GlyphCellFit } from "./terminal-glyph-cell-fit";
 import { getScrollThreshold } from "./scroll-speed";
@@ -101,13 +102,6 @@ const TERMINAL_DISPOSE_BUDGET_MS = 50;
 const MAX_RENDERER_RECOVERIES = 3;
 /** A pane healthy for this long earns its rebuild budget back. */
 const RECOVERY_BUDGET_RESET_MS = 60_000;
-
-/**
- * App-session totals, deliberately module-level: every terminal shares ONE ghostty
- * WASM module, so the question a post-mortem asks first is whether one pane broke
- * or the whole module did. Per-pane numbers cannot answer that; these can.
- */
-const session = { liveTerminals: 0, frameErrorPanes: 0, crashes: 0 };
 
 /**
  * How long the sync gate waits for the first repaint before lifting itself.

--- a/src/mainview/__tests__/renderer-heartbeat.test.ts
+++ b/src/mainview/__tests__/renderer-heartbeat.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../rpc", () => ({
+	api: { request: { rendererHeartbeat: vi.fn(() => Promise.resolve()) } },
+}));
+
+import { api } from "../rpc";
+import { startRendererHeartbeat } from "../renderer-heartbeat";
+import { session } from "../terminal-session-stats";
+
+const heartbeat = api.request.rendererHeartbeat as unknown as ReturnType<typeof vi.fn>;
+
+function setVisibility(state: "visible" | "hidden") {
+	Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+}
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	heartbeat.mockClear();
+	heartbeat.mockImplementation(() => Promise.resolve());
+	setVisibility("visible");
+	session.liveTerminals = 0;
+	session.frameErrorPanes = 0;
+});
+
+afterEach(() => {
+	stop?.();
+	stop = null;
+	vi.useRealTimers();
+});
+
+describe("startRendererHeartbeat", () => {
+	it("beats immediately and then on the interval", () => {
+		stop = startRendererHeartbeat("win-a");
+		expect(heartbeat).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(2_000);
+		expect(heartbeat).toHaveBeenCalledTimes(2);
+		vi.advanceTimersByTime(4_000);
+		expect(heartbeat).toHaveBeenCalledTimes(4);
+	});
+
+	it("carries the gap it measured and the terminals on screen", () => {
+		session.liveTerminals = 3;
+		session.frameErrorPanes = 1;
+		stop = startRendererHeartbeat("win-a");
+
+		vi.advanceTimersByTime(9_000);
+		const calls = heartbeat.mock.calls;
+		const last = calls[calls.length - 1][0];
+		expect(last).toMatchObject({ clientId: "win-a", visible: true, terminals: 3, frameErrorPanes: 1 });
+		expect(last.sinceLastBeatMs).toBeGreaterThan(0);
+	});
+
+	it("beats once more on the way to hidden, so silence reads as throttling", () => {
+		stop = startRendererHeartbeat("win-a");
+		heartbeat.mockClear();
+
+		setVisibility("hidden");
+		document.dispatchEvent(new Event("visibilitychange"));
+
+		expect(heartbeat).toHaveBeenCalledTimes(1);
+		expect(heartbeat.mock.calls[0][0]).toMatchObject({ visible: false, hiddenSinceLastBeat: true });
+	});
+
+	it("stops marking gaps as hidden once the window is back on screen", () => {
+		stop = startRendererHeartbeat("win-a");
+		setVisibility("hidden");
+		document.dispatchEvent(new Event("visibilitychange"));
+		setVisibility("visible");
+		document.dispatchEvent(new Event("visibilitychange"));
+		heartbeat.mockClear();
+
+		// First beat back covers the hidden stretch; the next one is clean again.
+		vi.advanceTimersByTime(2_000);
+		expect(heartbeat.mock.calls[0][0]).toMatchObject({ visible: true, hiddenSinceLastBeat: false });
+	});
+
+	it("survives a backend that rejects — diagnostics never break the app", () => {
+		heartbeat.mockImplementation(() => Promise.reject(new Error("rpc down")));
+		stop = startRendererHeartbeat("win-a");
+		expect(() => vi.advanceTimersByTime(6_000)).not.toThrow();
+	});
+
+	it("stops beating once disposed", () => {
+		stop = startRendererHeartbeat("win-a");
+		stop();
+		stop = null;
+		heartbeat.mockClear();
+
+		vi.advanceTimersByTime(10_000);
+		setVisibility("hidden");
+		document.dispatchEvent(new Event("visibilitychange"));
+		expect(heartbeat).not.toHaveBeenCalled();
+	});
+});

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -15,6 +15,7 @@ import { initKeyboardLock } from "./keyboard-lock";
 import { bootstrapZoom } from "./zoom";
 import { bootstrapScrollSpeed } from "./scroll-speed";
 import { startViewportDiagnostics } from "./viewport-diagnostics";
+import { startRendererHeartbeat } from "./renderer-heartbeat";
 import { getInitialThemeState, getWindowInjectedThemeState } from "./theme-bootstrap";
 import { initStreamerMode } from "./streamer-mode";
 import { buildChannelTitlePrefix } from "../shared/update-channel";
@@ -105,6 +106,10 @@ bootstrapScrollSpeed();
 // Mirror the page's own geometry into the backend log — the other half of the
 // display-change diagnostic the backend writes (see viewport-diagnostics.ts).
 startViewportDiagnostics();
+
+// Beat into the backend log so a window that freezes leaves a record — the
+// backend outlives the freeze and names it (see bun/renderer-watchdog.ts).
+startRendererHeartbeat();
 
 // Apply saved locale before React mounts
 const savedLocale = localStorage.getItem("dev3-locale") || "en";

--- a/src/mainview/renderer-heartbeat.ts
+++ b/src/mainview/renderer-heartbeat.ts
@@ -1,0 +1,65 @@
+import { api } from "./rpc";
+import { session } from "./terminal-session-stats";
+
+/**
+ * Beat into the backend log so a frozen window leaves a record.
+ *
+ * Nothing inside a wedged renderer can report on itself — every timer, guard and
+ * error handler here is dead with it. The backend keeps running, so it is the one
+ * that names the freeze; this only has to keep saying "still alive" and carry the
+ * two numbers the backend cannot see (the gap this page measured, and how much
+ * terminal was on screen). Verdicts live in `bun/renderer-watchdog.ts`.
+ */
+
+/** Keep in lockstep with HEARTBEAT_INTERVAL_MS in bun/renderer-watchdog.ts. */
+const INTERVAL_MS = 2_000;
+
+/** Per page load: several windows and remote browsers beat into one backend. */
+function newClientId(): string {
+	return Math.random().toString(36).slice(2, 10);
+}
+
+export function startRendererHeartbeat(clientId = newClientId()): () => void {
+	let lastBeatAt = Date.now();
+	// A hidden window has its timers throttled to about one tick a minute, so a gap
+	// spanning a hidden stretch is not a stall. Only this page can tell the two
+	// apart — the backend just sees a big number.
+	let hiddenSinceLastBeat = document.visibilityState !== "visible";
+
+	function beat() {
+		const at = Date.now();
+		const sinceLastBeatMs = at - lastBeatAt;
+		lastBeatAt = at;
+		const hidden = hiddenSinceLastBeat || document.visibilityState !== "visible";
+		hiddenSinceLastBeat = document.visibilityState !== "visible";
+		try {
+			void api.request
+				.rendererHeartbeat({
+					clientId,
+					sinceLastBeatMs,
+					visible: document.visibilityState === "visible",
+					hiddenSinceLastBeat: hidden,
+					terminals: session.liveTerminals,
+					frameErrorPanes: session.frameErrorPanes,
+				})
+				?.catch(() => {});
+		} catch {
+			/* diagnostics only — never break the app */
+		}
+	}
+
+	const timer = setInterval(beat, INTERVAL_MS);
+	// A window on its way to hidden beats once more, so the backend's last report
+	// says "hidden" and its silence is read as throttling instead of a freeze.
+	function onVisibilityChange() {
+		hiddenSinceLastBeat = true;
+		beat();
+	}
+	document.addEventListener("visibilitychange", onVisibilityChange);
+	beat();
+
+	return () => {
+		clearInterval(timer);
+		document.removeEventListener("visibilitychange", onVisibilityChange);
+	};
+}

--- a/src/mainview/terminal-session-stats.ts
+++ b/src/mainview/terminal-session-stats.ts
@@ -1,0 +1,10 @@
+/**
+ * App-session terminal totals, deliberately module-level: every terminal shares
+ * ONE ghostty WASM module, so the question a post-mortem asks first is whether one
+ * pane broke or the whole module did. Per-pane numbers cannot answer that.
+ *
+ * Read by `TerminalView` (its own diagnostics) and by `renderer-heartbeat`, which
+ * ships them to the backend so a frozen window's last report says how much
+ * terminal was on screen when it went quiet.
+ */
+export const session = { liveTerminals: 0, frameErrorPanes: 0, crashes: 0 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4047,6 +4047,23 @@ export type AppRPCSchema = {
 				};
 				response: void;
 			};
+			/**
+			 * Liveness beat from a renderer, every ~2s. A wedged renderer cannot report
+			 * on itself — every timer and error handler in it is dead too — so the
+			 * backend judges the silence instead. See bun/renderer-watchdog.ts.
+			 */
+			rendererHeartbeat: {
+				params: {
+					clientId: string;
+					sinceLastBeatMs: number;
+					visible: boolean;
+					/** The gap spans a hidden stretch, where throttling explains it. */
+					hiddenSinceLastBeat: boolean;
+					terminals: number;
+					frameErrorPanes: number;
+				};
+				response: void;
+			};
 			listBranches: {
 				params: { projectId: string };
 				response: Array<{ name: string; isRemote: boolean }>;


### PR DESCRIPTION
A hard UI freeze on 2026-08-19 ~14:17 left no cause in the log — only a timing signature found afterwards: every renderer-driven call stopped mid-poll at 14:17:00.911 (the 4.5s `checkDevServer` loop died between ticks, and no `saveLastRoute` followed, so it was not a route change), while backend work continued normally for another 59 seconds until the app was quit.

`terminal-render-guard` cannot catch that class of failure: it runs its own `setInterval` inside the renderer, and a wedged renderer never fires it. Nothing inside the window can report on itself. The backend outlives the freeze, so it does the judging.

**What this adds**

- `src/mainview/renderer-heartbeat.ts` — each window beats every 2s (`rendererHeartbeat` RPC), carrying only what the backend cannot know: the gap the page measured itself, whether that gap spans a hidden stretch, and the live terminal counts.
- `src/bun/renderer-watchdog.ts` — `started` / `lost` / `resumed` / `hiccup`, wired in `src/bun/index.ts` next to `startLoopMonitor`, its backend counterpart. Each client is tracked separately, since several windows and remote browser clients beat into one backend.
- `src/mainview/terminal-session-stats.ts` — the app-session terminal counters moved out of `TerminalView` so the heartbeat can read them.

**Log cost, which was the design constraint**

A healthy session costs exactly one line per window (`renderer heartbeat started`); every other line is a real symptom. A freeze is 2 lines (`lost` + `resumed`), and repeated stalls are capped by `MAX_HICCUPS_PER_CLIENT = 5`, with the final line flagging `furtherStallsSuppressed` so the silence after it is not misread. For scale: 2026-08-19 had 30 app launches against a 36 091-line log, so the healthy cost is ~30 lines, under 0.1%.

The one positive line is deliberate — without it, a window that never beats at all (old build, broken channel) reads exactly like a healthy silent one.

**Verification**

Full suite green (mainview 3939, bun 5969, cli 797, zero failures) and `bun run lint` clean. The watchdog's guards were proven by mutation: removing the hidden-window exemption, removing report-once, and collapsing the per-window keying each fail the suite. The renderer→backend channel was confirmed live — `renderer heartbeat started` appears in the log on launch — and the first live run produced a genuine false positive (a 5673 ms "hiccup" on an occluded window, where WebKit throttles timers to roughly one tick a minute), which is what the `hiddenSinceLastBeat` guard now covers.

Known gap, recorded in the decision record: the `lost` line is unit-tested but not proven live. SIGSTOPping the WebContent process produced no line, most plausibly because that window was not visible — i.e. the visibility guard doing its job.

Background on where the CPU goes, for context rather than as a fix: three `com.apple.WebKit.WebContent` CPU reports from the same day (10:29, 11:00, 11:37) share one heaviest stack — `requestAnimationFrame` → `CanvasRenderingContext2D::fillText` → CoreText shaping, i.e. the terminal canvas — at 62–88% CPU with the webview footprint reaching 774 MB. None of them covers 14:17, so it is a pattern, not the captured cause.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=007adff2-5e46-47eb-b63a-c8615951704d) · `dev3://task/007adff2-5e46-47eb-b63a-c8615951704d` _(dev3 added this footer — turn it off in Settings → Tasks.)_
