### PR TITLE
Box the status control and make quick-complete its right segment

### DIFF
--- a/change-logs/2026/08/19/fix-status-control-segmented-box.md
+++ b/change-logs/2026/08/19/fix-status-control-segmented-box.md
@@ -1,0 +1,3 @@
+Short: Status chip and its check become one control
+
+The status control in the task info panel now reads as a single boxed control: it carries the same bordered box as the buttons around it, and the green "complete" check sits inside that box as a full-height right segment behind a hairline divider instead of floating loose next to the chip. Hover now lights the segment you are actually pointing at — the chip or the check — so the two click targets stay distinguishable.

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -813,13 +813,18 @@ function TaskInfoPanel({
 	// On narrow the chip is a primary touch target — bump it to ≥44px (§12.6).
 	// On narrow this is the one shrinkable region of a no-wrap bar: a long
 	// custom-column name truncates here instead of pushing the kebab off screen.
+	// Boxed like its neighbours (watch toggle, completion-owner) so the quick-complete
+	// check reads as a segment of the status control and not as a homeless icon: the
+	// border owns the group, the hairline divides the two click targets, and hover
+	// lives on the segments so each one still answers separately.
+	const showQuickComplete = !narrow && !movingStatus && getAllowedTransitions(task.status).includes("completed");
 	const statusDropdownButton = (
-		<div className={`flex items-center rounded-lg hover:bg-elevated transition-colors ${tight || narrow ? "min-w-0 shrink" : "flex-shrink-0"}`}>
+		<div className={`flex items-center rounded-lg border border-edge hover:border-edge-active transition-colors ${tight || narrow ? "min-w-0 shrink" : "flex-shrink-0"}`}>
 			<button
 				ref={statusTriggerRef}
 				onClick={toggleStatusMenu}
 				disabled={movingStatus}
-				className={`flex min-w-0 items-center gap-2 rounded-lg ${narrow ? "px-3 min-h-[2.75rem]" : "px-2.5 py-1"}`}
+				className={`flex min-w-0 items-center gap-2 transition-colors hover:bg-elevated ${showQuickComplete ? "rounded-l-lg" : "rounded-lg"} ${narrow ? "px-3 min-h-[2.75rem]" : "px-2.5 py-1"}`}
 			>
 				{activeCustomColumn ? (
 					<div
@@ -839,24 +844,27 @@ function TaskInfoPanel({
 					<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
 				</svg>
 			</button>
-			{!narrow && !movingStatus && getAllowedTransitions(task.status).includes("completed") && (
-				<Tooltip content={t("pipeline.completeTooltip")} disabled={quickCompleting}>
-					<button
-						data-testid="task-info-quick-complete"
-						onClick={handleQuickComplete}
-						disabled={quickCompleting}
-						aria-label={t("pipeline.completeTooltip")}
-						className={`mr-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md text-success transition-[color,background-color,opacity] ${
-							quickCompleting ? "bg-success/25 opacity-100" : "opacity-60 hover:bg-success/20 hover:opacity-100"
-						}`}
-					>
-						{quickCompleting ? (
-							<span className="h-3 w-3 animate-spin rounded-full border-2 border-success/30 border-t-success" />
-						) : (
-							<CompleteCheckIcon className="w-3 h-3" />
-						)}
-					</button>
-				</Tooltip>
+			{showQuickComplete && (
+				<>
+					<span className="h-4 w-px flex-shrink-0 bg-edge" aria-hidden="true" />
+					<Tooltip content={t("pipeline.completeTooltip")} disabled={quickCompleting}>
+						<button
+							data-testid="task-info-quick-complete"
+							onClick={handleQuickComplete}
+							disabled={quickCompleting}
+							aria-label={t("pipeline.completeTooltip")}
+							className={`flex flex-shrink-0 items-center justify-center self-stretch rounded-r-lg px-1.5 text-success transition-[color,background-color,opacity] ${
+								quickCompleting ? "bg-success/25 opacity-100" : "opacity-75 hover:bg-success/20 hover:opacity-100"
+							}`}
+						>
+							{quickCompleting ? (
+								<span className="h-3 w-3 animate-spin rounded-full border-2 border-success/30 border-t-success" />
+							) : (
+								<CompleteCheckIcon className="w-3 h-3" />
+							)}
+						</button>
+					</Tooltip>
+				</>
 			)}
 		</div>
 	);


### PR DESCRIPTION
The status control in the task info panel read as two unrelated things: a borderless chip (ring + status label + chevron) and a green quick-complete check floating beside it. Three reasons, all fixed here:

- **No box.** It was the only control in the Context bar without a border — the watch toggle, the completion-owner toggle and the priority badge all carry one. Without edges there is nothing for the check to belong to. It now uses the same `border border-edge` / `hover:border-edge-active` treatment as its neighbours.
- **No seam.** The check was separated by nothing but `mr-1`. A 1px `bg-edge` divider now splits the box into two segments, the same idiom as the diff toolbar's `recent` split-button.
- **Detached hover and washed-out check.** Hover used to light the whole box regardless of which half the pointer was over, and the check sat at `opacity-60`. Hover now belongs to the segments (`hover:bg-elevated` on the chip, `hover:bg-success/20` on the check) and the check goes to `opacity-75`, full box height.

Where the status has no transition to `completed`, the chip keeps a full `rounded-lg` so the box never looks clipped. As a side effect the check's hit area grows from 20×20 to 24×26 px. No behaviour, no markup structure, no accessible names change — both buttons, tooltips and ARIA labels are untouched.

UX manifest: compliant, no updates. The quick-complete check is a segment of the status control, not a fifth control against the Context bar's ≤4 budget (§5.1).

Verified in a real browser (headless Chromium, streamer mode) in both themes: segmented hover, visible seam, clean console. `bun run lint` clean; full `bun run test` green (3943 mainview / 5985 bun / 797 cli).

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=401b29a3-0217-449d-905d-8249bb2fd465) · `dev3://task/401b29a3-0217-449d-905d-8249bb2fd465` _(dev3 added this footer — turn it off in Settings → Tasks.)_
