### PR TITLE
Read the terminal viewport once per frame instead of once per row

### DIFF
--- a/change-logs/2026/08/19/fix-terminal-viewport-cache.md
+++ b/change-logs/2026/08/19/fix-terminal-viewport-cache.md
@@ -1,0 +1,3 @@
+Short: Busy terminal screens repaint sooner
+
+Redrawing a full terminal screen used to re-read and re-parse the entire screen once for every row on it, so a 46-row repaint did that work 46 times over. The screen is now read once per frame and sliced per row, which takes about 3.8 ms off every full repaint — the redraws behind scrolling, `vim`, and anything that rewrites the whole screen. Typing a single character is unaffected, because that only repaints a few rows.

--- a/decisions/2026/08/19/per-frame-viewport-cache.md
+++ b/decisions/2026/08/19/per-frame-viewport-cache.md
@@ -1,0 +1,133 @@
+# Read the terminal viewport once per frame instead of once per row
+
+## Context
+
+ghostty-web's `getLine(y)` is a compatibility shim over its own fast path, and it
+is quadratic by construction:
+
+```js
+getLine(A) {
+  this.update();
+  const B = this.getViewport();                 // the WHOLE screen, parsed
+  return B.slice(g, g + this._cols).map((E) => ({ ...E }));
+}
+```
+
+`getViewport()` is the vendor's own "key performance optimization" — one WASM
+call that parses every cell into a reusable pool. `getLine` throws that away by
+calling it again for every row it is asked for. `CanvasRenderer.render` asks
+per row, so a full repaint of a 200x46 screen parses 9 200 cells 46 times over:
+**423 200 cell parses to draw 9 200 cells.**
+
+This is the choppiness behind scrolling, `vim` redraws and anything that
+rewrites the whole screen. It is not the keystroke-echo path, which
+[terminal-latency-unbatch-writes](terminal-latency-unbatch-writes.md) fixed.
+
+## Investigation
+
+Read before written, because the pool is shared mutable state:
+
+- **`getViewport()` returns `this.cellPool` itself**, not a copy — which is why
+  the vendor's `getLine` copies per row. Anything caching it must copy too.
+- **`parseCellsIntoPool` is the only writer of that pool**, and only
+  `getViewport` calls it. Nothing else can corrupt a cached pool mid-frame.
+- **`getScrollbackLine` shares the WASM scratch buffer `viewportBufferPtr`** with
+  `getViewport`, so scrollback interleaving looked dangerous. It is not: it
+  parses into a fresh array and never touches `cellPool`.
+- **`getViewport`, `getLine`, `getDimensions`, `update`, `isRowDirty` are all on
+  the same class**, so the cache cannot straddle two objects with different
+  `_cols`/`_rows`.
+- **`isRowDirty` is a bare WASM call** with no `update()` inside, so the
+  renderer's per-row dirty scan was never part of the cost.
+- **A frame is synchronous**, so no bytes can arrive between the pool read and
+  the last row that reads from it.
+
+### Measured
+
+Real ghostty-web WASM, real `createBidiRenderable`, headless Chromium, 200x46
+screen. The A/B is by **capability**: both arms run the shipped code, and the
+"vendor" arm is handed a buffer whose `getViewport`/`update` are hidden, which
+is exactly the fallback branch. Two independent full runs; 1-minute load read at
+both ends of each and never above 6 (4.50 -> 4.26, then 4.31 -> 5.44).
+
+Load-immune, and the real point of the change:
+
+| Per full-repaint frame | vendor | cached |
+|---|---|---|
+| Full-viewport reads | 46 | **1** |
+| `update()` calls | 47 | **2** |
+| Cells produced | 9 200 | 9 200, byte-identical |
+
+Timings, 300 iterations per arm, rounds interleaved to cancel drift:
+
+| Stage | vendor AVERAGE | cached AVERAGE | vendor WORST | cached WORST |
+|---|---|---|---|---|
+| Buffer-read stage, run 1 | 3.97 ms | 0.21 ms | 4.7 ms | 0.3 ms |
+| Buffer-read stage, run 2 | 4.03 ms | 0.21 ms | 4.7 ms | 0.3 ms |
+| Whole `render()`, run 2 | 8.68 ms | 4.75 ms | 13.6 ms | 8.2 ms |
+
+The saving cross-checks four ways — 3.76, 3.82, 3.81 and 3.90 ms — from two
+isolated-stage rounds and the end-to-end `render()` delta. That the end-to-end
+delta equals the isolated-stage delta is the check that matters: it says the
+saving is the removed work and not a measurement artefact.
+
+**Two limits, stated so nobody misquotes the table.** Chromium's canvas is far
+cheaper than WebKit's, so the **absolute** millisecond saving carries over to the
+shipped engine but the **percentage** does not. And this pays only on a full
+repaint: a lone keystroke dirties about three rows and saves roughly 0.25 ms.
+
+## Decision
+
+`createBidiRenderable` in `src/mainview/terminal-bidi/proxy.ts` reads the
+viewport once per frame and slices rows out of it. `beginFrame()` drops the
+cache, which is the whole invalidation story — the proxy already had that hook
+for the cursor memo.
+
+- **`BidiRenderable` gains optional `getViewport()` and `update()`.** Optional
+  because every test fake and the bare-buffer path lack them, and those must keep
+  working unchanged.
+- **Rows are still copied out of the pool**, exactly as the vendor copies them.
+  Handing out pool-backed cells would alias shared mutable state for a saving
+  that has not been shown to matter.
+- **`update()` is called explicitly** before reading the pool rather than leaning
+  on the renderer calling `getCursor()` first. One extra WASM call per frame
+  against a dependency on someone else's call order.
+- **Three defensive fallbacks**, all to `inner.getLine(y)`: no `getViewport`, no
+  `update`, or a pool shorter than `cols * rows`. The last one latches, so a
+  vendor whose contract changed degrades to today's behaviour instead of
+  rendering garbage.
+
+Guarded by ten tests in `src/mainview/terminal-bidi/__tests__/proxy.test.ts`
+against a fake that mimics the shared pool. Three mutations were run against
+them: disabling the cache fails 2, aliasing the pool instead of copying fails 6,
+and never invalidating on `beginFrame` fails 1.
+
+## Risks
+
+- **The pool is shared mutable state and the cache holds it for a frame.**
+  Safe only because `getViewport` is its sole writer — verified in this version
+  of the vendor, not a guarantee. The length check is the tripwire, and it only
+  catches a size change, not a semantics change.
+- **A vendor upgrade could make `getLine` cheap** and leave this as dead
+  complexity. It would still be correct, just pointless.
+- **Measured in Chromium only.** No WKWebView number exists for this change; the
+  Swift harness the atlas work used no longer exists on disk.
+- **Nothing here helps scrollback.** With `viewportY > 0` the vendor forces every
+  row to repaint (`g > 0 ? !0 : ...`) without ever consulting `isRowDirty`, so
+  scrolling through history still repaints in full — each row is merely cheaper
+  now. That branch cannot be reached from this proxy.
+
+## Alternatives considered
+
+- **Return pool-backed slices with no copy.** Removes 9 200 object copies per
+  full repaint on top of this. Rejected for now: the cells would alias a buffer
+  the emulator rewrites, and the copy is not visible next to the 3.8 ms already
+  taken off. Worth revisiting only with a measurement that shows it.
+- **Cache reordered rows across frames.** Needs per-row invalidation the vendor's
+  dirty state does not give us at the granularity required, and would go stale
+  in exactly the cases that matter.
+- **Patch `getLine` on the vendor object.** Same effect, but it changes behaviour
+  for every caller including hover and link detection, which run outside a frame
+  and have no `beginFrame()` to invalidate against.
+- **Fix it upstream in ghostty-web.** The right long-term home; this had to land
+  against the version we ship.

--- a/src/mainview/terminal-bidi/__tests__/proxy.test.ts
+++ b/src/mainview/terminal-bidi/__tests__/proxy.test.ts
@@ -222,6 +222,166 @@ describe("createBidiRenderable", () => {
 	});
 });
 
+describe("createBidiRenderable — per-frame viewport cache", () => {
+	/**
+	 * Mimics ghostty-web: `getViewport()` hands back one reusable pool, and
+	 * `getLine()` re-reads that whole pool for every single row.
+	 */
+	function pooledBuffer(rows: GhosttyCell[][], cols = 4) {
+		const calls = { viewport: 0, update: 0, getLine: 0 };
+		const pool: GhosttyCell[] = [];
+		for (const r of rows) for (let x = 0; x < cols; x++) pool.push({ ...r[x] });
+		return {
+			calls,
+			pool,
+			update() {
+				calls.update += 1;
+			},
+			getViewport() {
+				calls.viewport += 1;
+				return pool;
+			},
+			getLine(y: number) {
+				calls.getLine += 1;
+				this.update();
+				this.getViewport();
+				if (y < 0 || y >= rows.length) return null;
+				return pool.slice(y * cols, y * cols + cols).map((c) => ({ ...c }));
+			},
+			getCursor: () => ({ x: 0, y: 0, visible: true }),
+			getDimensions: () => ({ cols, rows: rows.length }),
+			isRowDirty: () => false,
+			clearDirty: () => {},
+		};
+	}
+
+	const screen = () => [row("abcd"), row("efgh"), row("ijkl")];
+
+	it("reads the whole viewport once per frame, not once per row", () => {
+		const inner = pooledBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		proxy.getCursor();
+		for (let y = 0; y < 3; y++) proxy.getLine(y);
+
+		expect(inner.calls.viewport).toBe(1);
+		expect(inner.calls.getLine).toBe(0);
+	});
+
+	it("refreshes the render state before reading the pool", () => {
+		const inner = pooledBuffer(screen());
+		const order: string[] = [];
+		const realUpdate = inner.update.bind(inner);
+		const realViewport = inner.getViewport.bind(inner);
+		inner.update = () => {
+			order.push("update");
+			realUpdate();
+		};
+		inner.getViewport = () => {
+			order.push("viewport");
+			return realViewport();
+		};
+
+		const proxy = createBidiRenderable(inner);
+		proxy.beginFrame();
+		proxy.getLine(0);
+
+		expect(order).toEqual(["update", "viewport"]);
+	});
+
+	it("hands back the same cells the vendor's per-row path would", () => {
+		const rows = screen();
+		const cached = createBidiRenderable(pooledBuffer(rows));
+		const uncached = createBidiRenderable(innerBuffer(rows));
+
+		cached.beginFrame();
+		uncached.beginFrame();
+		for (let y = 0; y < 3; y++) {
+			expect(cached.getLine(y)).toEqual(uncached.getLine(y));
+		}
+	});
+
+	it("copies out of the pool instead of aliasing it", () => {
+		const inner = pooledBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		const line = proxy.getLine(0);
+		inner.pool[0].codepoint = 0x2603;
+
+		expect(line?.[0].codepoint).not.toBe(0x2603);
+	});
+
+	it("re-reads the pool on the next frame", () => {
+		const inner = pooledBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		proxy.getLine(0);
+		proxy.beginFrame();
+		const second = proxy.getLine(0);
+
+		expect(inner.calls.viewport).toBe(2);
+		expect(second?.[0].codepoint).toBe("a".codePointAt(0));
+	});
+
+	it("serves the cursor row from the same cache", () => {
+		const inner = pooledBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		proxy.getCursor();
+		proxy.getLine(0);
+
+		expect(inner.calls.viewport).toBe(1);
+	});
+
+	it("returns null past the last row, as the vendor does", () => {
+		const inner = pooledBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		expect(proxy.getLine(-1)).toBeNull();
+		expect(proxy.getLine(3)).toBeNull();
+	});
+
+	it("falls back to per-row reads when the buffer has no viewport call", () => {
+		const inner = innerBuffer(screen());
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		for (let y = 0; y < 3; y++) proxy.getLine(y);
+
+		expect(inner.calls.getLine).toEqual([0, 1, 2]);
+	});
+
+	it("falls back for good when the pool is smaller than the screen", () => {
+		const inner = pooledBuffer(screen());
+		let probes = 0;
+		inner.getViewport = () => {
+			probes += 1;
+			return inner.pool.slice(0, 2);
+		};
+		// Counted on its own, so the fallback's own reads cannot look like probes.
+		inner.getLine = (y: number) => {
+			inner.calls.getLine += 1;
+			if (y < 0 || y >= 3) return null;
+			return inner.pool.slice(y * 4, y * 4 + 4).map((c) => ({ ...c }));
+		};
+		const proxy = createBidiRenderable(inner);
+
+		proxy.beginFrame();
+		expect(proxy.getLine(0)).toEqual(screen()[0]);
+		proxy.getLine(1);
+		proxy.beginFrame();
+		proxy.getLine(2);
+
+		expect(probes).toBe(1);
+		expect(inner.calls.getLine).toBe(3);
+	});
+});
+
 describe("createBidiScrollback", () => {
 	it("reorders scrollback rows and passes the length through", () => {
 		const history = [row("שלום"), row("plain")];

--- a/src/mainview/terminal-bidi/proxy.ts
+++ b/src/mainview/terminal-bidi/proxy.ts
@@ -11,6 +11,10 @@ export interface BidiRenderable {
 	needsFullRedraw?(): boolean;
 	clearDirty(): void;
 	getGraphemeString?(row: number, col: number): string;
+	/** One-WASM-call read of the whole viewport into the emulator's cell pool. */
+	getViewport?(): GhosttyCell[] | null;
+	/** Refreshes the render state the pool is parsed from. */
+	update?(): unknown;
 }
 
 export interface BidiScrollbackProvider {
@@ -50,15 +54,48 @@ export function createBidiRenderable(
 	let lastVisualX = -1;
 	let forcedDirtyRow = -1;
 
+	// Per-frame viewport cache. The vendor's `getLine(y)` re-reads and re-parses
+	// the ENTIRE viewport for every row it is asked for, so a 46-row repaint pays
+	// 46 full-screen parses. The pool is read once per frame here and sliced.
+	let pool: GhosttyCell[] | null = null;
+	let poolCols = 0;
+	let poolRows = 0;
+	let poolUnusable = false;
+
 	function remember(row: number, reordered: ReorderedRow | null) {
 		mappedRow = row;
 		visualToLogical = reordered ? reordered.visualToLogical : null;
 	}
 
+	/**
+	 * A row of cells, copied out of the shared pool exactly as the vendor's own
+	 * `getLine` copies it — the pool is reused, so handing it out raw would alias.
+	 */
+	function readLine(y: number): GhosttyCell[] | null {
+		if (poolUnusable || !inner.getViewport || !inner.update) return inner.getLine(y);
+		if (!pool) {
+			const { cols, rows } = inner.getDimensions();
+			inner.update();
+			const cells = inner.getViewport();
+			if (!cells || cols <= 0 || rows <= 0 || cells.length < cols * rows) {
+				poolUnusable = true;
+				return inner.getLine(y);
+			}
+			pool = cells;
+			poolCols = cols;
+			poolRows = rows;
+		}
+		if (y < 0 || y >= poolRows) return null;
+		const start = y * poolCols;
+		const row: GhosttyCell[] = new Array(poolCols);
+		for (let i = 0; i < poolCols; i++) row[i] = { ...pool[start + i] };
+		return row;
+	}
+
 	function reorderCursorRow(y: number) {
 		if (cursorComputed && cursorRow === y) return;
 		cursorRow = y;
-		cursorLine = inner.getLine(y);
+		cursorLine = readLine(y);
 		cursorReorder = cursorLine ? reorderRow(cursorLine, engine) : null;
 		cursorComputed = true;
 	}
@@ -71,6 +108,7 @@ export function createBidiRenderable(
 			cursorReorder = null;
 			mappedRow = -1;
 			visualToLogical = null;
+			pool = null;
 		},
 
 		getLine(y: number) {
@@ -78,7 +116,7 @@ export function createBidiRenderable(
 				remember(y, cursorReorder);
 				return cursorReorder ? cursorReorder.cells : cursorLine;
 			}
-			const cells = inner.getLine(y);
+			const cells = readLine(y);
 			if (!cells) {
 				remember(-1, null);
 				return cells;


### PR DESCRIPTION
ghostty-web's `getLine(y)` re-reads and re-parses the **entire** viewport for every row it is asked for — its own `getViewport()` fast path, thrown away 46 times per full repaint. Drawing a 200x46 screen cost 423 200 cell parses to produce 9 200 cells.

`createBidiRenderable` now reads the viewport once per frame and slices rows out of it, invalidating on the `beginFrame()` hook it already had for the cursor memo. Rows are still copied out of the pool exactly as the vendor copies them, because `getViewport()` hands back shared mutable state.

Falls back to the vendor's per-row path when `getViewport`/`update` are absent (every test fake) or when the pool is shorter than `cols * rows` — the last one latches, so a changed vendor contract degrades to today's behaviour instead of rendering garbage.

## Measured

Real ghostty-web WASM, real proxy code, headless Chromium, 200x46. The A/B is by **capability**: both arms run the shipped code, and the "vendor" arm gets a buffer whose `getViewport`/`update` are hidden. Two independent runs; 1-minute load read at both ends and never above 6.

| Per full-repaint frame | vendor | cached |
|---|---|---|
| Full-viewport reads | 46 | **1** |
| Cells produced | 9 200 | 9 200, byte-identical |

| Stage (300 iters) | vendor AVERAGE | cached AVERAGE | vendor WORST | cached WORST |
|---|---|---|---|---|
| Buffer read | 4.03 ms | 0.21 ms | 4.7 ms | 0.3 ms |
| Whole `render()` | 8.68 ms | 4.75 ms | 13.6 ms | 8.2 ms |

The saving cross-checks four ways — 3.76 / 3.82 / 3.81 / 3.90 ms — the end-to-end delta matching the isolated-stage delta.

**Two limits, so the table is not misquoted.** Chromium's canvas is far cheaper than WebKit's, so the *absolute* saving carries over but the *percentage* does not. And it pays only on a full repaint: a lone keystroke dirties ~3 rows and saves ~0.25 ms.

With the production wrapper stack (cell-fit + atlas + bidi) the two paths paint **0.0000%** different pixels across colour, bold, italic, box-drawing, powerline, CJK, emoji, RTL, combining marks and ZWJ — against a differ shown to register 0.25% on a one-word change.

Ten new tests; three mutations of the new code each caught (cache off fails 2, pool aliased fails 6, no invalidation fails 1). Verified in the running app on a live terminal and in scrollback.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=7a9e61f4-bd74-4bc3-8dc6-017b2697fed4) · `dev3://task/7a9e61f4-bd74-4bc3-8dc6-017b2697fed4`
