### PR TITLE
Add a Copy PR link action to the task branch menu

### DIFF
--- a/change-logs/2026/08/20/feature-copy-pr-link-branch-menu.md
+++ b/change-logs/2026/08/20/feature-copy-pr-link-branch-menu.md
@@ -1,0 +1,3 @@
+Short: Copy PR link from branch menu
+
+The task's Branch menu now offers "Copy PR link" alongside the branch name, worktree path and checkout command, shown only when the task actually has a pull request. Pasting a PR URL elsewhere no longer means opening the PR in a browser first.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -517,6 +517,30 @@ describe("TaskInfoPanel", () => {
 			expect(within(menu).getByRole("menuitem", { name: "Copy branch name" })).toBeInTheDocument();
 			expect(within(menu).getByRole("menuitem", { name: "Copy worktree path" })).toBeInTheDocument();
 			expect(within(menu).getByRole("menuitem", { name: "Copy checkout command" })).toBeInTheDocument();
+			// A task without a PR must not offer to copy one.
+			expect(within(menu).queryByRole("menuitem", { name: "Copy PR link" })).not.toBeInTheDocument();
+		});
+
+		it("copies the PR link once the task has a PR", async () => {
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+			await act(async () => {
+				renderPanel(makeTask({
+					branchName: "dev3/my-branch",
+					prNumber: 20916,
+					prUrl: "https://github.com/h0x91b/dev-3.0/pull/20916",
+				}));
+			});
+
+			await user.click(screen.getByTestId("branch-chip"));
+			await user.click(screen.getByRole("menuitem", { name: "Copy PR link" }));
+
+			expect(writeText).toHaveBeenCalledWith("https://github.com/h0x91b/dev-3.0/pull/20916");
+			await waitFor(() => {
+				expect(vi.mocked(toast.success)).toHaveBeenCalledWith("PR link copied", { taskId: "t1" });
+			});
 		});
 
 		it("copies the checkout command and says so out loud", async () => {

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -593,6 +593,11 @@ export default function TaskGitActions({
 				value: `git checkout ${task.branchName}`,
 				done: t("infoPanel.checkoutCopied"),
 			},
+			// The PR badge opens the PR; pasting its URL somewhere else needed a
+			// round trip through the browser address bar until now.
+			...(prInfo?.url
+				? [{ key: "pr", label: t("infoPanel.copyPrLinkItem"), value: prInfo.url, done: t("infoPanel.prLinkCopied") }]
+				: []),
 		]
 		: [];
 

--- a/src/mainview/i18n/translations/en/infoPanel.ts
+++ b/src/mainview/i18n/translations/en/infoPanel.ts
@@ -99,6 +99,8 @@ const infoPanel = {
 	"infoPanel.copyBranchItem": "Copy branch name",
 	"infoPanel.copyPathItem": "Copy worktree path",
 	"infoPanel.copyCheckoutItem": "Copy checkout command",
+	"infoPanel.copyPrLinkItem": "Copy PR link",
+	"infoPanel.prLinkCopied": "PR link copied",
 	"infoPanel.checkoutCopied": "Checkout command copied",
 	"infoPanel.worktreePathCopied": "Worktree path copied",
 	"infoPanel.branchCopied": "Branch name copied",

--- a/src/mainview/i18n/translations/es/infoPanel.ts
+++ b/src/mainview/i18n/translations/es/infoPanel.ts
@@ -99,6 +99,8 @@ const infoPanel = {
 	"infoPanel.copyBranchItem": "Copiar el nombre de la rama",
 	"infoPanel.copyPathItem": "Copiar la ruta del worktree",
 	"infoPanel.copyCheckoutItem": "Copiar el comando checkout",
+	"infoPanel.copyPrLinkItem": "Copiar el enlace del PR",
+	"infoPanel.prLinkCopied": "Enlace del PR copiado",
 	"infoPanel.checkoutCopied": "Comando checkout copiado",
 	"infoPanel.worktreePathCopied": "Ruta del worktree copiada",
 	"infoPanel.branchCopied": "Nombre de la rama copiado",

--- a/src/mainview/i18n/translations/ru/infoPanel.ts
+++ b/src/mainview/i18n/translations/ru/infoPanel.ts
@@ -99,6 +99,8 @@ const infoPanel = {
 	"infoPanel.copyBranchItem": "Скопировать имя ветки",
 	"infoPanel.copyPathItem": "Скопировать путь к worktree",
 	"infoPanel.copyCheckoutItem": "Скопировать команду checkout",
+	"infoPanel.copyPrLinkItem": "Скопировать ссылку на PR",
+	"infoPanel.prLinkCopied": "Ссылка на PR скопирована",
 	"infoPanel.checkoutCopied": "Команда checkout скопирована",
 	"infoPanel.worktreePathCopied": "Путь к worktree скопирован",
 	"infoPanel.branchCopied": "Имя ветки скопировано",


### PR DESCRIPTION
The task header's **Branch** menu already copies the branch name, the worktree path and the checkout command. It did not copy the one string you most often need to paste elsewhere — the pull request URL — so getting it meant opening the PR in a browser and grabbing it from the address bar.

`Copy PR link` now sits as the fourth copy action, right above `Compare against`. It renders only when the task actually has a PR (from a pushed PR status, the branch check, or the sticky task fields), so a task without one sees the menu unchanged. It reuses the same clipboard helper as the other items, so the confirmation and the failure path are identical.

Covered by two new cases in `TaskInfoPanel.test.tsx`: the item is absent without a PR, and with one it writes the PR URL and toasts `PR link copied`. Verified in a real browser against a task with an open PR. Strings added for en/ru/es.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=382757ce-a6e2-4100-b781-ad90213546ee) · `dev3://task/382757ce-a6e2-4100-b781-ad90213546ee` _(dev3 added this footer — turn it off in Settings → Tasks.)_