### PR TITLE
Fit board label filter chips to the available row width

### DIFF
--- a/change-logs/2026/08/20/fix-label-filter-fills-row-width.md
+++ b/change-logs/2026/08/20/fix-label-filter-fills-row-width.md
@@ -1,0 +1,3 @@
+Short: Label filters fill the whole row
+
+The board's label filter row no longer stops after a fixed ten chips: it measures the free width and shows as many labels as actually fit, pushing the "+N more" button to the right end of the row and re-fitting on every resize.

--- a/src/mainview/components/LabelFilterBar.tsx
+++ b/src/mainview/components/LabelFilterBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useLayoutEffect, useState, type RefObject } from "react";
 import { ALL_PRIORITIES, type Label } from "../../shared/types";
 import { useT } from "../i18n";
 import LabelChip from "./LabelChip";
@@ -7,11 +7,14 @@ import HelpSpot from "./HelpSpot";
 import type { FilterFunnelGroup } from "../utils/taskFacets";
 import { isFacetTokenActive, toggleFacetToken } from "../utils/taskSearch";
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
+import { useContainerWidth } from "../hooks/useContainerWidth";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { PRIORITY_NAME_KEYS, PRIORITY_STYLES } from "./priorityStyles";
 
-/** How many label chips to show inline before the "+N more". */
-const MAX_INLINE_LABELS = 10;
+/** `gap-1.5` between the inline chips, in px — needed to predict the fit. */
+const CHIP_GAP = 6;
+/** Slack on the reserved "+N more" width so a digit change can't oscillate the fit. */
+const MORE_SLACK = 8;
 
 interface LabelFilterBarProps {
 	/** Project labels in the order configured in Project Settings. */
@@ -61,6 +64,62 @@ function PriorityFilterChips({
 	);
 }
 
+/** Rough "+N more" width used before the button has ever been laid out. */
+const MORE_FALLBACK = 60;
+
+/** How many chips of `widths` fit in `avail`, reserving room for "+N more". */
+function fitCount(widths: number[], avail: number, moreWidth: number): number {
+	const total = widths.reduce((sum, w, i) => sum + w + (i ? CHIP_GAP : 0), 0);
+	if (total <= avail) return widths.length;
+
+	const budget = avail - moreWidth - CHIP_GAP;
+	let used = 0;
+	let n = 0;
+	for (const w of widths) {
+		const next = used + w + (n ? CHIP_GAP : 0);
+		if (next > budget) break;
+		used = next;
+		n++;
+	}
+	return n;
+}
+
+/**
+ * How many label chips the row can show, or `null` while nothing is measurable
+ * (first paint, no layout engine) — then every chip renders, which is also the
+ * pass that measures them. Widths are cached per label id so a resize can
+ * re-fit without rendering the trimmed-away chips again.
+ */
+function useFittedChipCount(labels: Label[], rowRef: RefObject<HTMLDivElement | null>): number | null {
+	const rowWidth = useContainerWidth(rowRef);
+	const chipWidths = useRef(new Map<string, number>());
+	const moreWidth = useRef(0);
+	const [fit, setFit] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		const row = rowRef.current;
+		if (!row) return;
+
+		for (const el of row.querySelectorAll<HTMLElement>("[data-label-chip]")) {
+			const id = el.dataset.labelChip;
+			if (id && el.offsetWidth > 0) chipWidths.current.set(id, el.offsetWidth);
+		}
+		const moreEl = row.querySelector<HTMLElement>("[data-label-more]");
+		if (moreWidth.current === 0 && moreEl && moreEl.offsetWidth > 0) {
+			moreWidth.current = moreEl.offsetWidth + MORE_SLACK;
+		}
+
+		const widths = labels.map((label) => chipWidths.current.get(label.id) ?? 0);
+		if (rowWidth <= 0 || widths.some((w) => w <= 0)) {
+			setFit(null);
+			return;
+		}
+		setFit(fitCount(widths, rowWidth, moreWidth.current || MORE_FALLBACK));
+	}, [labels, rowWidth, fit, rowRef]);
+
+	return fit;
+}
+
 function LabelFilterBar({
 	labels,
 	searchQuery,
@@ -91,9 +150,11 @@ function LabelFilterBar({
 	}, [disableGlobalFindShortcut]);
 
 	const hasLabels = labels.length > 0;
-	// Only the first labels in the project settings order show inline; the rest
-	// live in the funnel, reachable via the "+N more" chip.
-	const shownLabels = labels.slice(0, MAX_INLINE_LABELS);
+	// Chips fill the row in the project settings order; whatever does not fit the
+	// measured width lives in the funnel, reachable via the "+N more" chip.
+	const chipRowRef = useRef<HTMLDivElement>(null);
+	const fit = useFittedChipCount(labels, chipRowRef);
+	const shownLabels = fit === null ? labels : labels.slice(0, fit);
 	const hiddenLabelCount = labels.length - shownLabels.length;
 
 	// Inline chips are a VIEW of the search string: active when the token is
@@ -215,32 +276,36 @@ function LabelFilterBar({
 				<PriorityFilterChips query={searchQuery} onChange={onSearchChange} />
 			</div>
 
-			{/* Labels — the project-configured order inline (wrapping to ~1.5 rows),
+			{/* Labels — the project-configured order fills the free width on one row,
 			    the rest behind "+N more" which opens the funnel's full label list. */}
 			{hasLabels && (
-				<div className="flex items-center gap-1.5 flex-wrap min-w-0">
+				<div className="flex items-center gap-1.5 flex-1 min-w-0">
 					<span className="flex items-center gap-1 text-xs text-fg-3 font-medium flex-shrink-0">
 						{t("labels.filterTitle")}:
 						<HelpSpot topicId="board.filter-bar" />
 					</span>
-					{shownLabels.map((label) => (
-						<LabelChip
-							key={label.id}
-							label={label}
-							size="sm"
-							active={isLabelActive(label)}
-							onClick={() => toggleLabel(label)}
-						/>
-					))}
-					{hiddenLabelCount > 0 && (
-						<button
-							type="button"
-							onClick={() => setFunnelOpen(true)}
-							className="text-dense font-medium text-fg-3 hover:text-fg px-1.5 py-0.5 rounded-full border border-edge hover:border-edge-active transition-colors flex-shrink-0"
-						>
-							{t("labels.moreLabels", { count: String(hiddenLabelCount) })}
-						</button>
-					)}
+					<div ref={chipRowRef} className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
+						{shownLabels.map((label) => (
+							<span key={label.id} data-label-chip={label.id} className="flex-shrink-0">
+								<LabelChip
+									label={label}
+									size="sm"
+									active={isLabelActive(label)}
+									onClick={() => toggleLabel(label)}
+								/>
+							</span>
+						))}
+						{hiddenLabelCount > 0 && (
+							<button
+								type="button"
+								data-label-more
+								onClick={() => setFunnelOpen(true)}
+								className="text-dense font-medium text-fg-3 hover:text-fg px-1.5 py-0.5 rounded-full border border-edge hover:border-edge-active transition-colors flex-shrink-0"
+							>
+								{t("labels.moreLabels", { count: String(hiddenLabelCount) })}
+							</button>
+						)}
+					</div>
 				</div>
 			)}
 		</div>

--- a/src/mainview/components/__tests__/LabelFilterBar.test.tsx
+++ b/src/mainview/components/__tests__/LabelFilterBar.test.tsx
@@ -106,15 +106,67 @@ describe("LabelFilterBar — inline label chips as a view of the string", () => 
 		expect(onSearchChange).toHaveBeenCalledWith("");
 	});
 
-	it("shows only the top-N labels inline with a '+N more' opening the funnel", async () => {
-		const user = userEvent.setup();
-		// 12 labels → 10 inline + "+2 more".
+	it("shows every label when the row cannot be measured (no layout engine)", () => {
 		const many: Label[] = Array.from({ length: 12 }, (_, i) => ({ id: `l${i}`, name: `Label${i}`, color: "#888888" }));
 		renderBar({ labels: many, filterGroups: GROUPS });
-		expect(screen.getByText("Label0")).toBeInTheDocument();
-		expect(screen.queryByText("Label11")).not.toBeInTheDocument();
-		await user.click(screen.getByText("+2 more"));
+		expect(screen.getByText("Label11")).toBeInTheDocument();
+		expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+	});
+});
+
+describe("LabelFilterBar — chips fill the measured width", () => {
+	const CHIP_W = 60;
+	const MORE_W = 70;
+	const ROW_W = 300;
+	let restore: (() => void)[] = [];
+
+	beforeEach(() => {
+		const rect = HTMLElement.prototype.getBoundingClientRect;
+		const offset = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+		Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+			configurable: true,
+			get(this: HTMLElement) {
+				if (this.hasAttribute("data-label-chip")) return CHIP_W;
+				if (this.hasAttribute("data-label-more")) return MORE_W;
+				return 0;
+			},
+		});
+		HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+			const width = this.querySelector("[data-label-chip]") ? ROW_W : 0;
+			return { width, height: 0, top: 0, left: 0, right: width, bottom: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+		};
+		restore = [
+			() => {
+				HTMLElement.prototype.getBoundingClientRect = rect;
+			},
+			() => {
+				if (offset) Object.defineProperty(HTMLElement.prototype, "offsetWidth", offset);
+				else delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetWidth;
+			},
+		];
+	});
+
+	afterEach(() => {
+		for (const fn of restore) fn();
+	});
+
+	it("keeps as many chips as fit and moves the rest behind '+N more'", async () => {
+		const user = userEvent.setup();
+		// 300px row, 60px chips + 6px gaps, 70px (+8 slack) reserved for "+N more"
+		// ⇒ 3 chips fit, 9 go to the funnel.
+		const many: Label[] = Array.from({ length: 12 }, (_, i) => ({ id: `l${i}`, name: `Label${i}`, color: "#888888" }));
+		renderBar({ labels: many, filterGroups: GROUPS });
+		expect(screen.getByText("Label2")).toBeInTheDocument();
+		expect(screen.queryByText("Label3")).not.toBeInTheDocument();
+		await user.click(screen.getByText("+9 more"));
 		expect(screen.getByTestId("filter-funnel-dropdown")).toBeInTheDocument();
+	});
+
+	it("shows no '+N more' when every chip fits", () => {
+		const few: Label[] = Array.from({ length: 3 }, (_, i) => ({ id: `l${i}`, name: `Label${i}`, color: "#888888" }));
+		renderBar({ labels: few, filterGroups: GROUPS });
+		expect(screen.getByText("Label2")).toBeInTheDocument();
+		expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
 	});
 });
 


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that did the work on this branch).

The board's label filter row stopped after a hard-coded ten chips (`MAX_INLINE_LABELS = 10`), so on a wide window the `+N more` button landed in the middle of the row with half the width still empty.

The row now measures instead of guessing:

- `useFittedChipCount` observes the chip row's width (via the existing `useContainerWidth`), measures each chip once and caches it per label id, then fits as many chips as the free width allows.
- `+N more` is only rendered when something genuinely does not fit, and its own measured width (plus a small slack, so a digit change can't oscillate the fit) is reserved before the chips are packed.
- The chip row became a single non-wrapping `flex-1 min-w-0 overflow-hidden` line; it re-fits on every resize.
- When nothing is measurable (first paint, or a test environment with no layout engine) every chip renders — that pass is also what measures them.

Verified in a real browser at 1200 / 1440 / 1680 / 2560 px: 6 + `+17 more`, 9 + `+14 more`, 13 + `+10 more` (ending 27px short of the row edge, nothing clipped), and at 2560 all 23 labels fit with no button at all. No console errors.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=aa541f0f-f8f4-4991-95d4-697ab5472c27) · `dev3://task/aa541f0f-f8f4-4991-95d4-697ab5472c27` _(dev3 added this footer — turn it off in Settings → Tasks.)_