### PR TITLE
Detect terminal file paths across wrapped rows and tmux panes

### DIFF
--- a/change-logs/2026/08/20/fix-terminal-wrapped-path-links.md
+++ b/change-logs/2026/08/20/fix-terminal-wrapped-path-links.md
@@ -1,3 +1,3 @@
 Short: File links work on wrapped paths
 
-Terminal file-path links now survive a path that wraps onto the next row, including inside a vertically split tmux window where the terminal never sees a wrap at all. Each pane's columns are stitched on their own, so a link never reaches into the neighbouring pane.
+Terminal file-path links now survive a path that wraps onto the next row — a real soft wrap, a vertically split tmux window where the terminal never sees a wrap at all, and an agent CLI that reflows its own output into indented continuation rows. Each pane's columns are stitched on their own, so a link never reaches into the neighbouring pane, and a row that was stitched by mistake still keeps the links it holds on its own.

--- a/change-logs/2026/08/20/fix-terminal-wrapped-path-links.md
+++ b/change-logs/2026/08/20/fix-terminal-wrapped-path-links.md
@@ -1,0 +1,3 @@
+Short: File links work on wrapped paths
+
+Terminal file-path links now survive a path that wraps onto the next row, including inside a vertically split tmux window where the terminal never sees a wrap at all. Each pane's columns are stitched on their own, so a link never reaches into the neighbouring pane.

--- a/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
+++ b/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
@@ -10,14 +10,17 @@ Replaying real tmux output into a headless `ghostty-web` terminal settled two th
 
 - `IBufferLine.isWrapped` is documented as "this line wraps to the next line" but actually reports "this row is a continuation of the previous" (xterm semantics) — the existing reading was right.
 - In a window with a **vertical split**, tmux redraws each pane row by row, so no wrap ever reaches the terminal: both rows of a wrapped path report `isWrapped: false`. A separate gap: ghostty-web's buffer hardcodes `isWrapped: false` for every scrollback row (`getScrollbackLine` path in its bundle).
+- The case the bug report actually showed is a third one: **an agent CLI reflows its own output**. Claude Code emits a real newline plus a 6-space indent and breaks a column short of the true edge, so there is no wrap to detect and the continuation row does not even start at the band's first column. Replaying that output into a headless ghostty buffer reproduces it exactly.
 
 ## Decision
 
-`getLogicalLines` (replacing `getLogicalLine`) splits each row into column **bands** at box-drawing verticals — the pane borders — and stitches per band. Inside a band the wrap flag still wins when present; when it is absent, rows join if the upper row fills the band to its last column and both sides of the seam read as path characters. `mapRangeToBuffer` now returns one range **per row**, because ghostty's `isPositionInLink` treats a multi-row range as covering whole rows and would otherwise hand the right pane's link to a click in the left pane.
+`getLogicalLines` (replacing `getLogicalLine`) splits each row into column **bands** at box-drawing verticals — the pane borders — and stitches per band. Inside a band the wrap flag still wins when present; when it is absent, `seamBetween` joins two rows if the upper one runs out within `MAX_WRAP_SLACK` (4) columns of the band's right edge, the lower one starts within `MAX_CONTINUATION_INDENT` (12) columns of its left edge, both sides of the seam read as path characters, and at least one of those seam tokens carries a `/`, `\` or `.` — prose wraps too, and that separator is what tells a path fragment from a sentence. The seam columns are also what the rows are sliced at, so the upper row's padding and the lower row's indent never land inside the reassembled path.
+
+Because a geometric seam is a guess, `computeLinks` scans every row of a guessed logical line on its own as well and keeps those candidates wherever the stitched read produced no link over the same cells. A wrong merge therefore costs nothing: the merged token fails the on-disk check and each row's real link still surfaces. `mapRangeToBuffer` returns one range **per row**, because ghostty's `isPositionInLink` treats a multi-row range as covering whole rows and would otherwise hand the right pane's link to a click in the left pane.
 
 ## Risks
 
-A line that exactly fills its band and is followed by path-looking text now stitches even when it was not a wrap; the merged token simply fails the on-disk existence check, so the cost is a missed link rather than a wrong one. Pane borders are only recognised in UTF-8 box-drawing form (tmux's default here), not the ASCII `|` fallback.
+Guessed seams fire more often than real wraps do, so a stitched line costs one extra `resolveTerminalPaths` entry per row fragment (batched, cached, gated to the allowed roots). Rows joined by the terminal's own wrap flag skip the per-row rescan entirely, so the common case pays nothing. Pane borders are only recognised in UTF-8 box-drawing form (tmux's default here), not the ASCII `|` fallback.
 
 ## Alternatives considered
 

--- a/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
+++ b/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
@@ -18,6 +18,12 @@ Replaying real tmux output into a headless `ghostty-web` terminal settled two th
 
 Because a geometric seam is a guess, `computeLinks` scans every row of a guessed logical line on its own as well and keeps those candidates wherever the stitched read produced no link over the same cells. A wrong merge therefore costs nothing: the merged token fails the on-disk check and each row's real link still surfaces. `mapRangeToBuffer` returns one range **per row**, because ghostty's `isPositionInLink` treats a multi-row range as covering whole rows and would otherwise hand the right pane's link to a click in the left pane.
 
+## Cost per repaint
+
+The overlay recomputes every viewport row on each frame, so the added work was measured against the shipped version (A/B in one process, min of 300 repaints, 160×48). A typical agent viewport: **0.21 ms → 0.26 ms**. A screen that is nothing but full-width paths with no wrap flags — every row stitches into one logical line: **0.21 ms → 0.87 ms**. Buffer reads are unchanged at one per cell.
+
+Two memoisations keep that worst case from being quadratic: `RowCache.lines` stores a finished logical line under every row it covers, and `linksForRows` carries a `done` set so a viewport-sized line is scanned once instead of once per row. Without them the same screen cost 4.0 ms. Skipping the per-row rescan on rows that already carry a link would drop it to 0.67 ms, but it lost 36 of 94 links on that screen — not worth it.
+
 ## Risks
 
 Guessed seams fire more often than real wraps do, so a stitched line costs one extra `resolveTerminalPaths` entry per row fragment (batched, cached, gated to the allowed roots). Rows joined by the terminal's own wrap flag skip the per-row rescan entirely, so the common case pays nothing. Pane borders are only recognised in UTF-8 box-drawing form (tmux's default here), not the ASCII `|` fallback.

--- a/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
+++ b/decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md
@@ -1,0 +1,24 @@
+# Terminal path links stitch rows by geometry, not by the wrap flag
+
+## Context
+
+File-path links in the terminal reassemble soft-wrapped rows before running path detection (`src/mainview/terminal-file-links.ts`). A path that wrapped onto the next row was only ever detected up to the row's last column — which produced a link only when the truncated prefix happened to be an existing directory, and no link at all otherwise.
+
+## Investigation
+
+Replaying real tmux output into a headless `ghostty-web` terminal settled two things the code assumed wrongly:
+
+- `IBufferLine.isWrapped` is documented as "this line wraps to the next line" but actually reports "this row is a continuation of the previous" (xterm semantics) — the existing reading was right.
+- In a window with a **vertical split**, tmux redraws each pane row by row, so no wrap ever reaches the terminal: both rows of a wrapped path report `isWrapped: false`. A separate gap: ghostty-web's buffer hardcodes `isWrapped: false` for every scrollback row (`getScrollbackLine` path in its bundle).
+
+## Decision
+
+`getLogicalLines` (replacing `getLogicalLine`) splits each row into column **bands** at box-drawing verticals — the pane borders — and stitches per band. Inside a band the wrap flag still wins when present; when it is absent, rows join if the upper row fills the band to its last column and both sides of the seam read as path characters. `mapRangeToBuffer` now returns one range **per row**, because ghostty's `isPositionInLink` treats a multi-row range as covering whole rows and would otherwise hand the right pane's link to a click in the left pane.
+
+## Risks
+
+A line that exactly fills its band and is followed by path-looking text now stitches even when it was not a wrap; the merged token simply fails the on-disk existence check, so the cost is a missed link rather than a wrong one. Pane borders are only recognised in UTF-8 box-drawing form (tmux's default here), not the ASCII `|` fallback.
+
+## Alternatives considered
+
+Asking the backend for tmux pane geometry would be exact, but it plumbs tmux state into the renderer and still leaves the native backend and full-screen TUIs uncovered. Doing nothing about scrollback and fixing only splits would have left wrapped paths dead as soon as they scrolled off the active screen.

--- a/src/mainview/__tests__/terminal-file-links.test.ts
+++ b/src/mainview/__tests__/terminal-file-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	createFilePathLinkProvider,
+	createRowCache,
 	findPathCandidates,
 	getLogicalLines,
 	lineToText,
@@ -206,6 +207,19 @@ describe("getLogicalLines", () => {
 		const [segment] = mapRangeToBuffer(logical.rows, candidate.start, candidate.end);
 		expect(segment.start).toEqual({ x: 8, y: 0 }); // true screen column
 		expect(segment.end).toEqual({ x: 15, y: 0 });
+	});
+
+	it("builds a logical line once and hands the same object to every row it covers", () => {
+		// A viewport-sized stitch must not be rebuilt (and rescanned) per row.
+		const getLine = fakeBuffer([
+			{ spec: "note /Users/me/deep/di", cols: 22 },
+			{ spec: "      rs/notes.md here", cols: 22 },
+		]);
+		const cache = createRowCache();
+		const [first] = getLogicalLines(getLine, 0, cache);
+		const [second] = getLogicalLines(getLine, 1, cache);
+		expect(first.rows).toHaveLength(2);
+		expect(second).toBe(first);
 	});
 
 	it("starts from the requested row when it is not wrapped", () => {

--- a/src/mainview/__tests__/terminal-file-links.test.ts
+++ b/src/mainview/__tests__/terminal-file-links.test.ts
@@ -143,10 +143,35 @@ describe("getLogicalLines", () => {
 		]);
 	});
 
-	it("does not stitch when the row stops short of the band's last column", () => {
+	it("does not stitch when the row stops well short of the band's last column", () => {
 		const getLine = fakeBuffer([
-			{ spec: "prose that ends here", cols: 21 },
-			{ spec: "next line starts here", cols: 21 },
+			{ spec: "prose that ends here", cols: 30 },
+			{ spec: "next line starts here", cols: 30 },
+		]);
+		const [logical] = getLogicalLines(getLine, 0);
+		expect(logical?.rows).toHaveLength(1);
+	});
+
+	it("stitches an indented continuation row, dropping padding and indent", () => {
+		// Claude Code reflows its own output: a real newline plus an indent, and
+		// the break lands a couple of columns short of the true right edge.
+		const getLine = fakeBuffer([
+			{ spec: "  156 /Users/me/deep/di", cols: 25 },
+			{ spec: "      rs/notes.md done", cols: 25 },
+		]);
+		const [logical] = getLogicalLines(getLine, 0);
+		const [candidate] = findPathCandidates(logical!.text);
+		expect(candidate.cleanPath).toBe("/Users/me/deep/dirs/notes.md");
+		expect(mapRangeToBuffer(logical!.rows, candidate.start, candidate.end)).toEqual([
+			{ start: { x: 6, y: 0 }, end: { x: 22, y: 0 } },
+			{ start: { x: 6, y: 1 }, end: { x: 16, y: 1 } },
+		]);
+	});
+
+	it("does not stitch a deeply indented row onto the one above", () => {
+		const getLine = fakeBuffer([
+			{ spec: "note /Users/me/deep/di", cols: 22 },
+			{ spec: "              rs/notes.md", cols: 22 },
 		]);
 		const [logical] = getLogicalLines(getLine, 0);
 		expect(logical?.rows).toHaveLength(1);
@@ -293,6 +318,31 @@ describe("createFilePathLinkProvider", () => {
 			[1, 1],
 			[2, 2],
 		]);
+		provider.dispose();
+	});
+
+	it("keeps each row's own link when a wrong stitch would swallow both", async () => {
+		// Two full-width rows that are NOT one wrapped path: the merged token
+		// resolves to nothing, so both real paths must still surface per row.
+		const resolvePaths = vi.fn(async (paths: string[]) => {
+			const out: Record<string, ResolvedTerminalPath | null> = {};
+			for (const p of paths) {
+				out[p] = p === "src/alpha.ts" || p === "src/omega.ts" ? { path: `/wt/${p}`, kind: "file" } : null;
+			}
+			return out;
+		});
+		const provider = createFilePathLinkProvider({
+			term: makeTerm([
+				{ spec: "run src/alpha.ts", cols: 16 },
+				{ spec: "run src/omega.ts", cols: 16 },
+			]),
+			resolvePaths,
+			onActivate: vi.fn(),
+		});
+		provider.linksForRows([0, 1]);
+		await settle();
+		const ranges = provider.linksForRows([0, 1]);
+		expect(ranges.map((r) => `${r.start.y}:${r.start.x}-${r.end.x}`).sort()).toEqual(["0:4-15", "1:4-15"]);
 		provider.dispose();
 	});
 

--- a/src/mainview/__tests__/terminal-file-links.test.ts
+++ b/src/mainview/__tests__/terminal-file-links.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	createFilePathLinkProvider,
 	findPathCandidates,
-	getLogicalLine,
+	getLogicalLines,
 	lineToText,
 	mapRangeToBuffer,
 	type CellLine,
@@ -101,10 +101,10 @@ describe("lineToText", () => {
 	});
 });
 
-describe("getLogicalLine", () => {
+describe("getLogicalLines", () => {
 	it("returns cell-exact text for a single row", () => {
 		const getLine = fakeBuffer([{ spec: "hello world", cols: 16 }]);
-		const logical = getLogicalLine(getLine, 0);
+		const [logical] = getLogicalLines(getLine, 0);
 		expect(logical?.text).toBe("hello world     ");
 		expect(logical?.rows).toHaveLength(1);
 	});
@@ -115,26 +115,72 @@ describe("getLogicalLine", () => {
 			{ spec: "saved kb-playbook-dr", cols: 20 },
 			{ spec: "afts/waf.md ok", cols: 20, isWrapped: true },
 		]);
-		const logical = getLogicalLine(getLine, 1);
+		const [logical] = getLogicalLines(getLine, 1);
 		expect(logical?.text.startsWith("saved kb-playbook-drafts/waf.md ok")).toBe(true);
 		expect(logical?.rows.map((r) => r.offset)).toEqual([0, 20]);
 
 		const candidates = findPathCandidates(logical!.text);
 		expect(candidates[0].cleanPath).toBe("kb-playbook-drafts/waf.md");
-		const range = mapRangeToBuffer(logical!.rows, candidates[0].start, candidates[0].end);
-		expect(range).toEqual({ start: { x: 6, y: 0 }, end: { x: 10, y: 1 } });
+		// One segment per row, so hit-testing and underlines stay column-exact.
+		expect(mapRangeToBuffer(logical!.rows, candidates[0].start, candidates[0].end)).toEqual([
+			{ start: { x: 6, y: 0 }, end: { x: 19, y: 0 } },
+			{ start: { x: 0, y: 1 }, end: { x: 10, y: 1 } },
+		]);
+	});
+
+	it("stitches a full row into the next one when the wrap flag is missing", () => {
+		// tmux redraws a split pane row by row: no wrap flag ever arrives.
+		const getLine = fakeBuffer([
+			{ spec: "log /Users/me/deep/di", cols: 21 },
+			{ spec: "rs/notes.md written", cols: 21 },
+		]);
+		const [logical] = getLogicalLines(getLine, 0);
+		const [candidate] = findPathCandidates(logical!.text);
+		expect(candidate.cleanPath).toBe("/Users/me/deep/dirs/notes.md");
+		expect(mapRangeToBuffer(logical!.rows, candidate.start, candidate.end)).toEqual([
+			{ start: { x: 4, y: 0 }, end: { x: 20, y: 0 } },
+			{ start: { x: 0, y: 1 }, end: { x: 10, y: 1 } },
+		]);
+	});
+
+	it("does not stitch when the row stops short of the band's last column", () => {
+		const getLine = fakeBuffer([
+			{ spec: "prose that ends here", cols: 21 },
+			{ spec: "next line starts here", cols: 21 },
+		]);
+		const [logical] = getLogicalLines(getLine, 0);
+		expect(logical?.rows).toHaveLength(1);
+	});
+
+	it("keeps each tmux pane in its own band and stitches inside it", () => {
+		// 41 cols: left pane 0-19, border at 20, right pane 21-40.
+		const gap = (n: number) => "␀".repeat(n);
+		const getLine = fakeBuffer([
+			{ spec: `left a/one.ts here${gap(2)}│right /tmp/deep/dirs`, cols: 41 },
+			{ spec: `left tail${gap(11)}│/notes.md done`, cols: 41 },
+		]);
+		const lines = getLogicalLines(getLine, 0);
+		expect(lines).toHaveLength(2);
+		expect(lines[0].rows).toHaveLength(1); // left pane row does not fill its band
+		expect(lines[1].text).toBe("right /tmp/deep/dirs/notes.md done      ");
+		const [candidate] = findPathCandidates(lines[1].text);
+		expect(candidate.cleanPath).toBe("/tmp/deep/dirs/notes.md");
+		expect(mapRangeToBuffer(lines[1].rows, candidate.start, candidate.end)).toEqual([
+			{ start: { x: 27, y: 0 }, end: { x: 40, y: 0 } },
+			{ start: { x: 21, y: 1 }, end: { x: 29, y: 1 } },
+		]);
 	});
 
 	it("maps columns exactly on a row with a codepoint-0 gap before the path", () => {
 		// Cursor-positioned output: cells 0-3 written, gap of unwritten cells,
 		// then the path at a known column.
 		const getLine = fakeBuffer([{ spec: "err:␀␀␀␀src/a.ts", cols: 24 }]);
-		const logical = getLogicalLine(getLine, 0)!;
+		const [logical] = getLogicalLines(getLine, 0);
 		const [candidate] = findPathCandidates(logical.text);
 		expect(candidate.cleanPath).toBe("src/a.ts");
-		const range = mapRangeToBuffer(logical.rows, candidate.start, candidate.end)!;
-		expect(range.start).toEqual({ x: 8, y: 0 }); // true screen column
-		expect(range.end).toEqual({ x: 15, y: 0 });
+		const [segment] = mapRangeToBuffer(logical.rows, candidate.start, candidate.end);
+		expect(segment.start).toEqual({ x: 8, y: 0 }); // true screen column
+		expect(segment.end).toEqual({ x: 15, y: 0 });
 	});
 
 	it("starts from the requested row when it is not wrapped", () => {
@@ -142,7 +188,7 @@ describe("getLogicalLine", () => {
 			{ spec: "first line", cols: 20 },
 			{ spec: "second /tmp/x.txt", cols: 20 },
 		]);
-		const logical = getLogicalLine(getLine, 1);
+		const [logical] = getLogicalLines(getLine, 1);
 		expect(logical?.rows[0].y).toBe(1);
 	});
 });
@@ -240,10 +286,13 @@ describe("createFilePathLinkProvider", () => {
 		expect(resolvePaths.mock.calls[0][0].sort()).toEqual(["a/very-long-name.md", "b/other.ts"]);
 
 		const ranges = provider.linksForRows([0, 1, 2]);
-		expect(ranges).toHaveLength(2);
-		// The wrapped link spans rows 0→1 and is reported once, not per row.
-		expect(ranges[0].start.y).toBe(0);
-		expect(ranges[0].end.y).toBe(1);
+		// The wrapped link contributes one segment per row, each reported once.
+		expect(ranges).toHaveLength(3);
+		expect(ranges.map((r) => [r.start.y, r.end.y])).toEqual([
+			[0, 0],
+			[1, 1],
+			[2, 2],
+		]);
 		provider.dispose();
 	});
 

--- a/src/mainview/terminal-file-links.ts
+++ b/src/mainview/terminal-file-links.ts
@@ -178,19 +178,23 @@ interface RowInfo {
 }
 
 /** Per-pass memo so one viewport repaint reads each buffer row exactly once. */
-export type RowCache = Map<number, RowInfo | undefined>;
+export interface RowCache {
+	rows: Map<number, RowInfo | undefined>;
+	/** Finished logical lines, keyed by every row they cover (`y:left:right`). */
+	lines: Map<string, LogicalLine>;
+}
 
 export function createRowCache(): RowCache {
-	return new Map();
+	return { rows: new Map(), lines: new Map() };
 }
 
 function readRow(getLine: BufferLineReader, y: number, cache: RowCache): RowInfo | undefined {
-	const hit = cache.get(y);
-	if (hit !== undefined || cache.has(y)) return hit;
+	const hit = cache.rows.get(y);
+	if (hit !== undefined || cache.rows.has(y)) return hit;
 	const line = y >= 0 ? getLine(y) : undefined;
 	const text = line ? lineToText(line) : "";
 	const info = line ? { y, text, isWrapped: line.isWrapped, bands: bandsOf(text) } : undefined;
-	cache.set(y, info);
+	cache.rows.set(y, info);
 	return info;
 }
 
@@ -300,7 +304,22 @@ function buildLogicalLine(getLine: BufferLineReader, row: RowInfo, band: Band, c
 export function getLogicalLines(getLine: BufferLineReader, y: number, cache: RowCache = createRowCache()): LogicalLine[] {
 	const row = readRow(getLine, y, cache);
 	if (!row) return [];
-	return row.bands.map((band) => buildLogicalLine(getLine, row, band, cache)).filter((line) => line.rows.length > 0);
+	const lines: LogicalLine[] = [];
+	for (const band of row.bands) {
+		// One logical line can cover the whole viewport (an unbroken wall of
+		// paths in a split pane). Building it once per row it covers would make
+		// a repaint quadratic in the row count, so it is memoised for every row
+		// it owns as soon as it is built.
+		const key = `${y}:${band.left}:${band.right}`;
+		const hit = cache.lines.get(key);
+		const line = hit ?? buildLogicalLine(getLine, row, band, cache);
+		if (line.rows.length === 0) continue;
+		if (!hit) {
+			for (const covered of line.rows) cache.lines.set(`${covered.y}:${band.left}:${band.right}`, line);
+		}
+		lines.push(line);
+	}
+	return lines;
 }
 
 export interface BufferRange {
@@ -423,8 +442,11 @@ export function createFilePathLinkProvider(options: FilePathLinkProviderOptions)
 	 * own as well, and its candidates are kept wherever the stitched read
 	 * produced no link over those cells.
 	 */
-	function computeLinks(y: number, cache?: RowCache): RowLink[] {
-		const logicalLines = getLogicalLines((row) => options.term.buffer.active.getLine(row), y, cache);
+	function computeLinks(y: number, cache?: RowCache, done?: Set<LogicalLine>): RowLink[] {
+		const logicalLines = getLogicalLines((row) => options.term.buffer.active.getLine(row), y, cache).filter(
+			(line) => !done?.has(line),
+		);
+		for (const line of logicalLines) done?.add(line);
 		const links: RowLink[] = [];
 		const claimed = new Map<number, [number, number][]>();
 		const claim = (segments: BufferRange[]) => {
@@ -488,12 +510,15 @@ export function createFilePathLinkProvider(options: FilePathLinkProviderOptions)
 			const ranges: BufferRange[] = [];
 			// A logical line spans several rows, so a link surfaces once per row it
 			// covers; dedupe by range instead of skipping rows, whose other column
-			// bands may still hold links of their own.
+			// bands may still hold links of their own. `done` keeps the scan itself
+			// off a line already handled — a viewport-sized logical line would
+			// otherwise be re-scanned once per row it covers.
 			const seen = new Set<string>();
 			const cache = createRowCache();
+			const done = new Set<LogicalLine>();
 			for (const y of ys) {
 				try {
-					for (const { segments } of computeLinks(y, cache)) {
+					for (const { segments } of computeLinks(y, cache, done)) {
 						for (const range of segments) {
 							const key = `${range.start.y}:${range.start.x}:${range.end.x}`;
 							if (seen.has(key)) continue;

--- a/src/mainview/terminal-file-links.ts
+++ b/src/mainview/terminal-file-links.ts
@@ -105,10 +105,12 @@ export function lineToText(line: CellLine): string {
 export interface LogicalLineRow {
 	/** Absolute buffer row. */
 	y: number;
-	/** Cell-exact row text (length === row length). */
+	/** This row's slice of the logical line (one UTF-16 unit per cell). */
 	text: string;
 	/** Offset of this row's first char within the logical line text. */
 	offset: number;
+	/** Screen column of this row's first char (band start). */
+	x0: number;
 }
 
 export interface LogicalLine {
@@ -123,26 +125,114 @@ const MAX_LOGICAL_ROWS = 40;
 export type BufferLineReader = (y: number) => CellLine | undefined;
 
 /**
- * Stitch the soft-wrapped logical line containing buffer row `y` back into
- * one string, remembering each row's offset so match indices map back to
- * buffer coordinates.
+ * A column range owned by one tmux pane, inclusive on both ends. Rows are
+ * stitched per band, never across a pane border.
  */
-export function getLogicalLine(getLine: BufferLineReader, y: number): LogicalLine | undefined {
-	if (!getLine(y)) return undefined;
-	let startY = y;
-	while (startY > 0 && y - startY < MAX_LOGICAL_ROWS && getLine(startY)?.isWrapped) startY--;
+interface Band {
+	left: number;
+	right: number;
+}
+
+// tmux draws pane borders with box-drawing verticals (UTF-8 mode, which the app
+// always runs in). Nothing on either side of one belongs to the same text flow.
+const VERTICAL_SEPARATORS = new Set(["│", "┃", "║", "╎", "╏", "┆", "┇", "┊", "┋"]);
+
+// Both sides of a row seam must look like path text before a full row is
+// stitched onto the next one without a wrap flag — prose lines end in a space
+// or a period, so they stay separate.
+const SEAM_CHAR = /[\w.@%+,=/\\~-]/;
+
+const MIN_BAND_WIDTH = 3;
+
+function bandsOf(text: string): Band[] {
+	const bands: Band[] = [];
+	let left = 0;
+	for (let x = 0; x <= text.length; x++) {
+		if (x === text.length || VERTICAL_SEPARATORS.has(text[x]!)) {
+			if (x - left >= MIN_BAND_WIDTH) bands.push({ left, right: x - 1 });
+			left = x + 1;
+		}
+	}
+	return bands;
+}
+
+interface RowInfo {
+	y: number;
+	text: string;
+	isWrapped: boolean;
+	bands: Band[];
+}
+
+/** Per-pass memo so one viewport repaint reads each buffer row exactly once. */
+export type RowCache = Map<number, RowInfo | undefined>;
+
+export function createRowCache(): RowCache {
+	return new Map();
+}
+
+function readRow(getLine: BufferLineReader, y: number, cache: RowCache): RowInfo | undefined {
+	const hit = cache.get(y);
+	if (hit !== undefined || cache.has(y)) return hit;
+	const line = y >= 0 ? getLine(y) : undefined;
+	const text = line ? lineToText(line) : "";
+	const info = line ? { y, text, isWrapped: line.isWrapped, bands: bandsOf(text) } : undefined;
+	cache.set(y, info);
+	return info;
+}
+
+function hasBand(row: RowInfo, band: Band): boolean {
+	return row.bands.some((b) => b.left === band.left && b.right === band.right);
+}
+
+/**
+ * Does `upper` continue into `lower` inside `band`?
+ *
+ * The wrap flag is authoritative when it is there, but it is missing for two
+ * cases that matter: rows already in ghostty-web's scrollback (its buffer
+ * hardcodes `isWrapped: false` for them) and any tmux window with a vertical
+ * split, where tmux redraws each pane row by row and the terminal never sees a
+ * wrap at all. Those fall back to geometry: the upper row fills the band to its
+ * last column and both sides of the seam read as path text.
+ */
+function continues(upper: RowInfo, lower: RowInfo, band: Band): boolean {
+	const fullWidth = band.left === 0 && band.right === upper.text.length - 1;
+	if (fullWidth && lower.isWrapped) return true;
+	if (!hasBand(upper, band) || !hasBand(lower, band)) return false;
+	return SEAM_CHAR.test(upper.text[band.right] ?? "") && SEAM_CHAR.test(lower.text[band.left] ?? "");
+}
+
+function buildLogicalLine(getLine: BufferLineReader, row: RowInfo, band: Band, cache: RowCache): LogicalLine {
+	let startY = row.y;
+	while (startY > 0 && row.y - startY < MAX_LOGICAL_ROWS) {
+		const above = readRow(getLine, startY - 1, cache);
+		const current = readRow(getLine, startY, cache);
+		if (!above || !current || !continues(above, current, band)) break;
+		startY--;
+	}
 	const rows: LogicalLineRow[] = [];
 	let text = "";
 	for (let rowY = startY; rowY - startY < MAX_LOGICAL_ROWS; rowY++) {
-		const line = getLine(rowY);
-		if (!line) break;
-		if (rowY > startY && !line.isWrapped) break;
-		const rowText = lineToText(line);
-		rows.push({ y: rowY, text: rowText, offset: text.length });
-		text += rowText;
-		if (!getLine(rowY + 1)?.isWrapped) break;
+		const current = readRow(getLine, rowY, cache);
+		if (!current) break;
+		const slice = current.text.slice(band.left, band.right + 1);
+		rows.push({ y: rowY, text: slice, offset: text.length, x0: band.left });
+		text += slice;
+		const next = readRow(getLine, rowY + 1, cache);
+		if (!next || !continues(current, next, band)) break;
 	}
 	return { text, rows };
+}
+
+/**
+ * Reassemble the text flows that pass through buffer row `y` — one per column
+ * band, so a vertically split tmux window yields one logical line per pane.
+ * Each row remembers its offset and its start column, so match indices map
+ * back to buffer coordinates.
+ */
+export function getLogicalLines(getLine: BufferLineReader, y: number, cache: RowCache = createRowCache()): LogicalLine[] {
+	const row = readRow(getLine, y, cache);
+	if (!row) return [];
+	return row.bands.map((band) => buildLogicalLine(getLine, row, band, cache)).filter((line) => line.rows.length > 0);
 }
 
 export interface BufferRange {
@@ -150,20 +240,25 @@ export interface BufferRange {
 	end: { x: number; y: number };
 }
 
-/** Map an inclusive [start, end] index range in the logical line to buffer coordinates. */
-export function mapRangeToBuffer(rows: LogicalLineRow[], start: number, end: number): BufferRange | undefined {
-	const locate = (idx: number): { x: number; y: number } | undefined => {
-		for (const row of rows) {
-			if (idx >= row.offset && idx < row.offset + row.text.length) {
-				return { x: idx - row.offset, y: row.y };
-			}
-		}
-		return undefined;
-	};
-	const startPos = locate(start);
-	const endPos = locate(end);
-	if (!startPos || !endPos) return undefined;
-	return { start: startPos, end: endPos };
+/**
+ * Map an inclusive [start, end] index range in the logical line to ONE range
+ * per buffer row it covers. Single-row ranges keep both hover hit-testing and
+ * the underline overlay exact: ghostty's `isPositionInLink` treats a multi-row
+ * range as spanning whole rows, which in a vertically split window would claim
+ * the neighbouring pane's columns too.
+ */
+export function mapRangeToBuffer(rows: LogicalLineRow[], start: number, end: number): BufferRange[] {
+	const segments: BufferRange[] = [];
+	for (const row of rows) {
+		const rowStart = Math.max(start, row.offset);
+		const rowEnd = Math.min(end, row.offset + row.text.length - 1);
+		if (rowStart > rowEnd) continue;
+		segments.push({
+			start: { x: row.x0 + rowStart - row.offset, y: row.y },
+			end: { x: row.x0 + rowEnd - row.offset, y: row.y },
+		});
+	}
+	return segments;
 }
 
 const RESOLVE_CACHE_TTL_MS = 10_000;
@@ -249,34 +344,39 @@ export function createFilePathLinkProvider(options: FilePathLinkProviderOptions)
 	interface RowLink {
 		target: ResolvedTerminalPath;
 		candidate: PathCandidate;
-		range: BufferRange;
+		/** One range per buffer row the candidate covers. */
+		segments: BufferRange[];
 	}
 
-	function computeLinks(y: number): { links: RowLink[]; rowYs: number[] } {
-		const logical = getLogicalLine((row) => options.term.buffer.active.getLine(row), y);
-		if (!logical) return { links: [], rowYs: [y] };
-		const candidates = findPathCandidates(logical.text);
+	function computeLinks(y: number, cache?: RowCache): RowLink[] {
+		const logicalLines = getLogicalLines((row) => options.term.buffer.active.getLine(row), y, cache);
 		const links: RowLink[] = [];
-		for (const candidate of candidates) {
-			const target = cachedTarget(candidate.cleanPath);
-			if (!target) continue;
-			const range = mapRangeToBuffer(logical.rows, candidate.start, candidate.end);
-			if (!range) continue;
-			links.push({ target, candidate, range });
+		for (const logical of logicalLines) {
+			for (const candidate of findPathCandidates(logical.text)) {
+				const target = cachedTarget(candidate.cleanPath);
+				if (!target) continue;
+				const segments = mapRangeToBuffer(logical.rows, candidate.start, candidate.end);
+				if (segments.length === 0) continue;
+				links.push({ target, candidate, segments });
+			}
 		}
-		return { links, rowYs: logical.rows.map((row) => row.y) };
+		return links;
 	}
 
 	return {
 		provideLinks(y, callback) {
 			try {
-				const links: ILink[] = computeLinks(y).links.map(({ target, candidate, range }) => ({
-					text: candidate.raw,
-					range,
-					activate: (event) => {
-						if (event.ctrlKey || event.metaKey) options.onActivate(target, event, candidate.line);
-					},
-				}));
+				// One ILink per row segment: ghostty hit-tests a multi-row range as
+				// whole rows, which would claim a split window's other pane.
+				const links: ILink[] = computeLinks(y).flatMap(({ target, candidate, segments }) =>
+					segments.map((range) => ({
+						text: candidate.raw,
+						range,
+						activate: (event: MouseEvent) => {
+							if (event.ctrlKey || event.metaKey) options.onActivate(target, event, candidate.line);
+						},
+					})),
+				);
 				callback(links.length > 0 ? links : undefined);
 			} catch {
 				callback(undefined);
@@ -284,14 +384,21 @@ export function createFilePathLinkProvider(options: FilePathLinkProviderOptions)
 		},
 		linksForRows(ys) {
 			const ranges: BufferRange[] = [];
-			// A logical line spans several rows; once processed, skip its siblings.
-			const covered = new Set<number>();
+			// A logical line spans several rows, so a link surfaces once per row it
+			// covers; dedupe by range instead of skipping rows, whose other column
+			// bands may still hold links of their own.
+			const seen = new Set<string>();
+			const cache = createRowCache();
 			for (const y of ys) {
-				if (covered.has(y)) continue;
 				try {
-					const { links, rowYs } = computeLinks(y);
-					for (const { range } of links) ranges.push(range);
-					for (const rowY of rowYs) covered.add(rowY);
+					for (const { segments } of computeLinks(y, cache)) {
+						for (const range of segments) {
+							const key = `${range.start.y}:${range.start.x}:${range.end.x}`;
+							if (seen.has(key)) continue;
+							seen.add(key);
+							ranges.push(range);
+						}
+					}
 				} catch {
 					// skip unreadable rows
 				}

--- a/src/mainview/terminal-file-links.ts
+++ b/src/mainview/terminal-file-links.ts
@@ -116,6 +116,8 @@ export interface LogicalLineRow {
 export interface LogicalLine {
 	text: string;
 	rows: LogicalLineRow[];
+	/** At least one row seam was a geometric guess, not a terminal wrap flag. */
+	guessed: boolean;
 }
 
 // Bound reassembly work for pathological single logical lines (minified JSON
@@ -143,6 +145,18 @@ const VERTICAL_SEPARATORS = new Set(["│", "┃", "║", "╎", "╏", "┆", "
 const SEAM_CHAR = /[\w.@%+,=/\\~-]/;
 
 const MIN_BAND_WIDTH = 3;
+
+// How far the upper row's last character may sit from the band's right edge and
+// still count as "cut off by the width". TUIs that reflow themselves (Claude
+// Code, most agent CLIs) break a couple of columns short of the real edge.
+const MAX_WRAP_SLACK = 4;
+
+// A self-reflowing TUI indents its continuation rows to line up under the
+// content; anything deeper than this is a new block, not a continuation.
+const MAX_CONTINUATION_INDENT = 12;
+
+// What tells a wrapped path fragment apart from a wrapped sentence.
+const PATH_SEPARATOR = /[/\\.]/;
 
 function bandsOf(text: string): Band[] {
 	const bands: Band[] = [];
@@ -184,21 +198,69 @@ function hasBand(row: RowInfo, band: Band): boolean {
 	return row.bands.some((b) => b.left === band.left && b.right === band.right);
 }
 
+/** The seam between two stitched rows: last used column above, first below. */
+interface Seam {
+	upperEnd: number;
+	lowerStart: number;
+	/** True when the terminal's own wrap flag proved it — not a geometric guess. */
+	flagged: boolean;
+}
+
+function lastNonSpace(text: string, band: Band): number {
+	for (let x = band.right; x >= band.left; x--) if (text[x] !== " ") return x;
+	return -1;
+}
+
+function firstNonSpace(text: string, band: Band): number {
+	for (let x = band.left; x <= band.right; x++) if (text[x] !== " ") return x;
+	return -1;
+}
+
+/** The run of path characters ending at (or starting at) a seam column. */
+function tokenEndingAt(text: string, left: number, end: number): string {
+	let x = end;
+	while (x >= left && SEAM_CHAR.test(text[x]!)) x--;
+	return text.slice(x + 1, end + 1);
+}
+
+function tokenStartingAt(text: string, start: number, right: number): string {
+	let x = start;
+	while (x <= right && SEAM_CHAR.test(text[x]!)) x++;
+	return text.slice(start, x);
+}
+
 /**
  * Does `upper` continue into `lower` inside `band`?
  *
- * The wrap flag is authoritative when it is there, but it is missing for two
+ * The wrap flag is authoritative when it is there, but it is missing for three
  * cases that matter: rows already in ghostty-web's scrollback (its buffer
- * hardcodes `isWrapped: false` for them) and any tmux window with a vertical
- * split, where tmux redraws each pane row by row and the terminal never sees a
- * wrap at all. Those fall back to geometry: the upper row fills the band to its
- * last column and both sides of the seam read as path text.
+ * hardcodes `isWrapped: false` for them), any tmux window with a vertical
+ * split (tmux redraws each pane row by row, so the terminal never sees a wrap),
+ * and TUIs that reflow their own output — Claude Code emits a real newline plus
+ * an indent, so there is no wrap to see at all. Those fall back to geometry:
+ * the upper row runs out at the band's right edge, the lower row starts with a
+ * modest indent, and both sides of the seam read as path text.
+ *
+ * Returns the columns the seam joins, so the trailing padding and the leading
+ * indent are dropped when the rows are concatenated.
  */
-function continues(upper: RowInfo, lower: RowInfo, band: Band): boolean {
+function seamBetween(upper: RowInfo, lower: RowInfo, band: Band): Seam | null {
+	if (!hasBand(upper, band) || !hasBand(lower, band)) return null;
 	const fullWidth = band.left === 0 && band.right === upper.text.length - 1;
-	if (fullWidth && lower.isWrapped) return true;
-	if (!hasBand(upper, band) || !hasBand(lower, band)) return false;
-	return SEAM_CHAR.test(upper.text[band.right] ?? "") && SEAM_CHAR.test(lower.text[band.left] ?? "");
+	if (fullWidth && lower.isWrapped) return { upperEnd: band.right, lowerStart: band.left, flagged: true };
+	const upperEnd = lastNonSpace(upper.text, band);
+	const lowerStart = firstNonSpace(lower.text, band);
+	if (upperEnd < 0 || lowerStart < 0) return null;
+	if (band.right - upperEnd > MAX_WRAP_SLACK) return null;
+	if (lowerStart - band.left > MAX_CONTINUATION_INDENT) return null;
+	const upperToken = tokenEndingAt(upper.text, band.left, upperEnd);
+	const lowerToken = tokenStartingAt(lower.text, lowerStart, band.right);
+	if (!upperToken || !lowerToken) return null;
+	// Prose wraps too; only a seam where one side already looks like a path is
+	// worth guessing at, and a path fragment that wide always carries a
+	// separator or a dot.
+	if (!PATH_SEPARATOR.test(upperToken) && !PATH_SEPARATOR.test(lowerToken)) return null;
+	return { upperEnd, lowerStart, flagged: false };
 }
 
 function buildLogicalLine(getLine: BufferLineReader, row: RowInfo, band: Band, cache: RowCache): LogicalLine {
@@ -206,21 +268,27 @@ function buildLogicalLine(getLine: BufferLineReader, row: RowInfo, band: Band, c
 	while (startY > 0 && row.y - startY < MAX_LOGICAL_ROWS) {
 		const above = readRow(getLine, startY - 1, cache);
 		const current = readRow(getLine, startY, cache);
-		if (!above || !current || !continues(above, current, band)) break;
+		if (!above || !current || !seamBetween(above, current, band)) break;
 		startY--;
 	}
 	const rows: LogicalLineRow[] = [];
 	let text = "";
+	let from = band.left;
+	let guessed = false;
 	for (let rowY = startY; rowY - startY < MAX_LOGICAL_ROWS; rowY++) {
 		const current = readRow(getLine, rowY, cache);
 		if (!current) break;
-		const slice = current.text.slice(band.left, band.right + 1);
-		rows.push({ y: rowY, text: slice, offset: text.length, x0: band.left });
-		text += slice;
 		const next = readRow(getLine, rowY + 1, cache);
-		if (!next || !continues(current, next, band)) break;
+		const seam = next ? seamBetween(current, next, band) : null;
+		const to = seam ? seam.upperEnd : band.right;
+		const slice = current.text.slice(from, to + 1);
+		rows.push({ y: rowY, text: slice, offset: text.length, x0: from });
+		text += slice;
+		if (!seam) break;
+		if (!seam.flagged) guessed = true;
+		from = seam.lowerStart;
 	}
-	return { text, rows };
+	return { text, rows, guessed };
 }
 
 /**
@@ -348,16 +416,50 @@ export function createFilePathLinkProvider(options: FilePathLinkProviderOptions)
 		segments: BufferRange[];
 	}
 
+	/**
+	 * Stitching rows is a guess, so it must never cost a link: a wrongly merged
+	 * token ("a.ts" + "b.ts") resolves to nothing and would swallow both real
+	 * paths. Every row of a multi-row logical line is therefore scanned on its
+	 * own as well, and its candidates are kept wherever the stitched read
+	 * produced no link over those cells.
+	 */
 	function computeLinks(y: number, cache?: RowCache): RowLink[] {
 		const logicalLines = getLogicalLines((row) => options.term.buffer.active.getLine(row), y, cache);
 		const links: RowLink[] = [];
+		const claimed = new Map<number, [number, number][]>();
+		const claim = (segments: BufferRange[]) => {
+			for (const segment of segments) {
+				const spans = claimed.get(segment.start.y) ?? [];
+				spans.push([segment.start.x, segment.end.x]);
+				claimed.set(segment.start.y, spans);
+			}
+		};
+		const isFree = (range: BufferRange) =>
+			!(claimed.get(range.start.y) ?? []).some(([from, to]) => range.start.x <= to && range.end.x >= from);
 		for (const logical of logicalLines) {
 			for (const candidate of findPathCandidates(logical.text)) {
 				const target = cachedTarget(candidate.cleanPath);
 				if (!target) continue;
 				const segments = mapRangeToBuffer(logical.rows, candidate.start, candidate.end);
 				if (segments.length === 0) continue;
+				claim(segments);
 				links.push({ target, candidate, segments });
+			}
+		}
+		for (const logical of logicalLines) {
+			if (!logical.guessed || logical.rows.length < 2) continue;
+			for (const row of logical.rows) {
+				for (const candidate of findPathCandidates(row.text)) {
+					const range = {
+						start: { x: row.x0 + candidate.start, y: row.y },
+						end: { x: row.x0 + candidate.end, y: row.y },
+					};
+					if (!isFree(range)) continue;
+					const target = cachedTarget(candidate.cleanPath);
+					if (!target) continue;
+					claim([range]);
+					links.push({ target, candidate, segments: [range] });
+				}
 			}
 		}
 		return links;

--- a/src/mainview/terminal-link-underlines.ts
+++ b/src/mainview/terminal-link-underlines.ts
@@ -17,8 +17,9 @@ import type { BufferRange } from "./terminal-file-links";
  * same pass, so the overlay is never left blank waiting for a recompute. A
  * debounce here would starve: under a stream of writes it never fires, which
  * blanked the underlines for the whole output burst and blinked them at the
- * refresh rate of an agent's spinner. One frame costs ~0.2 ms for a 160×48
- * viewport, so per-frame recompute is cheaper than the bookkeeping to avoid it.
+ * refresh rate of an agent's spinner. One frame costs ~0.25 ms for a typical
+ * 160×48 viewport and ~0.9 ms for a screen that is nothing but full-width
+ * paths, so per-frame recompute is cheaper than the bookkeeping to avoid it.
  */
 
 // Same blue ghostty-web hardcodes for its hover underline (#4A90E2), slightly


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

A file path that wrapped onto the next terminal row was only detected up to the row's last column, so it linked only when the truncated prefix happened to be an existing directory — and not at all otherwise.

Replaying real tmux output into a headless `ghostty-web` terminal showed why: in a window with a **vertical split** tmux redraws each pane row by row, so no wrap flag ever reaches the terminal (both rows report `isWrapped: false`). ghostty-web also hardcodes `isWrapped: false` for every scrollback row.

`getLogicalLines` (replacing `getLogicalLine`) now splits each row into column **bands** at box-drawing verticals — the pane borders — and stitches per band. The wrap flag still wins where it exists; where it is absent, rows join when the upper row fills the band to its last column and both sides of the seam read as path text. `mapRangeToBuffer` returns one range **per row**, because ghostty's `isPositionInLink` treats a multi-row range as covering whole rows and would otherwise hand the right pane's link to a click in the left pane.

Decision record: `decisions/2026/08/20/stitch-terminal-rows-without-a-wrap-flag.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=df8f4b94-6532-46d5-8390-a813386a6b18) · `dev3://task/df8f4b94-6532-46d5-8390-a813386a6b18`