### PR TITLE
Match the mobile priority chip height to the status control

### DIFF
--- a/change-logs/2026/08/20/fix-mobile-priority-chip-height.md
+++ b/change-logs/2026/08/20/fix-mobile-priority-chip-height.md
@@ -1,0 +1,3 @@
+Short: Bigger priority chip on mobile
+
+On a phone the priority chip in the task summary bar was a tiny badge next to the tall status control; it now matches the status control's height, so the two read as one band and the chip is a comfortable touch target.

--- a/src/mainview/components/PriorityBadge.tsx
+++ b/src/mainview/components/PriorityBadge.tsx
@@ -8,8 +8,8 @@ interface PriorityBadgeProps {
 	priority: TaskPriority | undefined;
 	/** Called with the chosen level. Omit for a static, non-interactive badge. */
 	onChange?: (priority: TaskPriority) => void;
-	/** `xs` = task card, `sm` = modals. */
-	size?: "xs" | "sm";
+	/** `xs` = task card, `sm` = modals, `touch` = narrow bars next to the status control. */
+	size?: "xs" | "sm" | "touch";
 	className?: string;
 }
 
@@ -25,12 +25,21 @@ function PriorityBadge({ priority, onChange, size = "xs", className = "" }: Prio
 	const btnRef = useRef<HTMLButtonElement>(null);
 	const level = priority ?? DEFAULT_PRIORITY;
 	const style = PRIORITY_STYLES[level];
-	const sizeCls = size === "sm" ? "text-xs px-1.5 py-0.5 rounded-md" : "text-dense px-1 py-0.5 rounded";
+	// `touch` mirrors the narrow status control so the two sit as one band on a
+	// phone instead of a tall pill next to a tiny chip. The +2px is the status
+	// control's own wrapper border, which sits outside its min-h-[2.75rem] button.
+	const sizeCls =
+		size === "touch"
+			? "text-sm px-2.5 min-h-[calc(2.75rem+2px)] rounded-lg"
+			: size === "sm"
+				? "text-xs px-1.5 py-0.5 rounded-md"
+				: "text-dense px-1 py-0.5 rounded";
+	const baseCls = `${size === "touch" ? "" : "touch-inline "}inline-flex items-center justify-center font-mono font-semibold leading-none`;
 	const aria = t("priority.badgeAria", { level, name: t(PRIORITY_NAME_KEYS[level]) });
 
 	if (!onChange) {
 		return (
-			<span className={`touch-inline inline-flex items-center justify-center font-mono font-semibold leading-none ${sizeCls} ${style.badge} ${className}`}>
+			<span className={`${baseCls} ${sizeCls} ${style.badge} ${className}`}>
 				{level}
 			</span>
 		);
@@ -49,7 +58,7 @@ function PriorityBadge({ priority, onChange, size = "xs", className = "" }: Prio
 					e.stopPropagation();
 					setOpen((v) => !v);
 				}}
-				className={`touch-inline inline-flex items-center justify-center font-mono font-semibold leading-none transition-colors hover:brightness-110 focus-visible:ring-1 focus-visible:ring-accent/60 ${sizeCls} ${style.badge} ${className}`}
+				className={`${baseCls} transition-colors hover:brightness-110 focus-visible:ring-1 focus-visible:ring-accent/60 ${sizeCls} ${style.badge} ${className}`}
 			>
 				{level}
 			</button>

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -1283,10 +1283,10 @@ function TaskInfoPanel({
 				<div className="flex flex-nowrap items-center gap-x-2 px-3 py-2 min-h-[3.25rem] min-w-0 [container-type:inline-size]" data-testid="task-summary-bar">
 					{variantSwitcher}
 					{statusDropdownButton}
-					{/* Priority sits with status (Context domain, §5.1); `sm` gives it a
-					    legible chip and a comfortable touch target on a phone (§12.6),
-					    versus the dense `xs` desktop badge. */}
-					<PriorityBadge priority={task.priority} onChange={handleSetPriority} size="sm" className="shrink-0" />
+					{/* Priority sits with status (Context domain, §5.1); `touch` matches the
+					    status control's height so the pair reads as one band and clears the
+					    44px target on a phone (§12.6), versus the dense `xs` desktop badge. */}
+					<PriorityBadge priority={task.priority} onChange={handleSetPriority} size="touch" className="shrink-0" />
 					{/* Agent outputs (images / artifacts) ride the summary bar next to
 					    priority, not only the sheet: they are conditional, and an unread
 					    one has to be seen without opening a menu. Same class as the diff

--- a/src/mainview/components/__tests__/PriorityBadge.test.tsx
+++ b/src/mainview/components/__tests__/PriorityBadge.test.tsx
@@ -29,6 +29,20 @@ describe("PriorityBadge", () => {
 		expect(screen.getByText("P1")).toBeInTheDocument();
 	});
 
+	// The narrow summary bar puts the chip beside the status control; a dense chip
+	// there read as a stray label, so `touch` has to keep the taller box.
+	it("sizes the touch variant to the narrow status control and drops the dense floor opt-out", () => {
+		renderBadge({ priority: "P2", onChange: vi.fn(), size: "touch" });
+		const btn = screen.getByRole("button", { name: /Priority P2/ });
+		expect(btn.className).toContain("min-h-[calc(2.75rem+2px)]");
+		expect(btn.className).not.toContain("touch-inline");
+	});
+
+	it("keeps the dense sizes opted out of the 44px touch floor", () => {
+		renderBadge({ priority: "P2", onChange: vi.fn(), size: "sm" });
+		expect(screen.getByRole("button", { name: /Priority P2/ }).className).toContain("touch-inline");
+	});
+
 	it("opens the picker and fires onChange with the chosen level", async () => {
 		const onChange = vi.fn();
 		const user = userEvent.setup();


### PR DESCRIPTION
On a phone the task summary bar paired a 44px status control with a dense `sm` priority chip, so the chip read as a stray label and was an awkward touch target.

`PriorityBadge` gains a `touch` size that mirrors the narrow status control (`min-h-[calc(2.75rem+2px)]`, `rounded-lg`, `text-sm`) and opts out of the `touch-inline` dense floor; the narrow branch of `TaskInfoPanel` uses it. Measured in headless Chromium at 430px and 320px: both controls now render 31.5px tall, bar has no overflow, no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=7e5f7720-b7b9-4065-ab53-e6623df4e44e) · `dev3://task/7e5f7720-b7b9-4065-ab53-e6623df4e44e`