### PR TITLE
Fix Kanban board showing only one task after a mid-fetch update

### DIFF
--- a/change-logs/2026/08/20/fix-kanban-shows-only-one-task.md
+++ b/change-logs/2026/08/20/fix-kanban-shows-only-one-task.md
@@ -1,0 +1,3 @@
+Short: Kanban no longer drops every card
+
+Fixed the Kanban board rendering only a single task after entering a project whose task list was fetched while a task update arrived. The board now merges live updates into the snapshot instead of discarding the whole snapshot, so leaving a task via the breadcrumb no longer requires a dashboard round trip to see the other cards.

--- a/decisions/2026/08/20/merge-pushed-tasks-into-board-snapshot.md
+++ b/decisions/2026/08/20/merge-pushed-tasks-into-board-snapshot.md
@@ -1,0 +1,35 @@
+# Merge pushed task updates into the board snapshot instead of dropping it
+
+## Context
+
+`ProjectView` fetches the project's tasks on mount / project change. PR #1144 added a guard
+(`taskUpdateEpochRef`) that skipped the whole `setTasks` dispatch if any `rpc:taskUpdated` push for
+that project arrived while the fetch was in flight — protecting a freshly pushed scheduled task from
+being overwritten by an older disk snapshot.
+
+## Investigation
+
+User report plus `~/.dev3.0/logs/2026/08/2026-08-20.log`: switching from a task in project A to a task
+in project B fires `getTasks` for B (2 ms) while the same tick writes a task update for the task being
+opened. `navigate` had already cleared `currentProjectTasks` (different project), the epoch guard threw
+the 1697-task snapshot away, and the `updateTask` push appended exactly one task. The board then showed
+a single card, and never refetched because `ProjectView` stays mounted while the split task view is open —
+only a dashboard round trip (remount) recovered it. The log confirms no `getTasks` fires when leaving the
+task via the breadcrumb.
+
+## Decision
+
+`src/mainview/components/ProjectView.tsx` now collects pushed tasks for the project into
+`inFlightTaskUpdatesRef` (a `Map<taskId, Task>`, cleared when a fetch starts) and overlays them onto the
+snapshot when it lands: pushed versions win per id, pushed tasks missing from the snapshot are appended.
+The dispatch always happens, so the board can never end up with a partial list.
+
+## Risks
+
+A task deleted between fetch start and resolve would be re-added if its update push arrived in that
+window — the same hole the previous guard had, and `removeTask` pushes clear it immediately.
+
+## Alternatives considered
+
+Keep the guard and schedule a refetch when it fires (extra round trip, still a window of wrong data);
+drop the guard entirely (reintroduces the #1144 scheduled-launch regression).

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -65,7 +65,8 @@ function ProjectView({
 	const [agents, setAgents] = useState<CodingAgent[]>([]);
 	const inlineDiff = useTaskInlineDiffState(activeTaskId);
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
-	const taskUpdateEpochRef = useRef(0);
+	const inFlightTaskUpdatesRef = useRef(new Map<string, Task>());
+	const tasksFetchInFlightRef = useRef(false);
 	const unresolvedRouteKeyRef = useRef<string | null>(null);
 	// Board fetch state — drives the skeleton / retry panel instead of letting a
 	// failed or slow load render as an empty board (remote/mobile).
@@ -82,36 +83,56 @@ function ProjectView({
 		}
 	}, [navigate, projectId]);
 
-	// A scheduled launch can push its new task while this view's initial fetch is
-	// in flight. Keep the live update instead of letting the older disk snapshot
-	// overwrite it when the request returns.
+	// A scheduled launch can push a new or changed task while this view's fetch is
+	// in flight. Collect those pushes and overlay them onto the snapshot instead of
+	// letting the older disk state overwrite them — dropping the whole snapshot
+	// would leave the board showing only the pushed cards until the next remount.
+	// Recording is limited to the in-flight window; outside it the normal
+	// `updateTask` path owns the card and the map would only retain dead objects.
 	useEffect(() => {
 		function onTaskUpdated(e: Event) {
+			if (!tasksFetchInFlightRef.current) return;
 			const { task } = (e as CustomEvent<{ task: Task }>).detail;
-			if (task?.projectId === projectId) taskUpdateEpochRef.current += 1;
+			if (task?.projectId === projectId) inFlightTaskUpdatesRef.current.set(task.id, task);
 		}
 		window.addEventListener("rpc:taskUpdated", onTaskUpdated);
 		return () => window.removeEventListener("rpc:taskUpdated", onTaskUpdated);
 	}, [projectId]);
 
 	useEffect(() => {
-		const taskUpdateEpoch = taskUpdateEpochRef.current;
+		const pushed = inFlightTaskUpdatesRef.current;
+		pushed.clear();
+		tasksFetchInFlightRef.current = true;
 		let cancelled = false;
 		setTasksStatus("loading");
 		(async () => {
 			try {
 				const tasks = await api.request.getTasks({ projectId });
+				// A superseded fetch must not touch the flag — a newer one owns it now.
 				if (cancelled) return;
-				if (taskUpdateEpoch === taskUpdateEpochRef.current) {
-					dispatch({ type: "setTasks", projectId, tasks });
+				tasksFetchInFlightRef.current = false;
+				// Fast path: nothing raced the fetch, so the snapshot ships untouched.
+				let merged = tasks;
+				if (pushed.size > 0) {
+					merged = tasks.map((task) => pushed.get(task.id) ?? task);
+					const known = new Set(tasks.map((task) => task.id));
+					for (const [id, task] of pushed) if (!known.has(id)) merged.push(task);
 				}
+				pushed.clear();
+				dispatch({ type: "setTasks", projectId, tasks: merged });
 				setTasksStatus("ready");
 			} catch (err) {
 				console.error("Failed to load tasks:", err);
-				if (!cancelled) setTasksStatus("error");
+				if (cancelled) return;
+				tasksFetchInFlightRef.current = false;
+				setTasksStatus("error");
 			}
 		})();
-		return () => { cancelled = true; };
+		return () => {
+			cancelled = true;
+			tasksFetchInFlightRef.current = false;
+			pushed.clear();
+		};
 	}, [projectId, dispatch, tasksReloadNonce]);
 
 	// A remote socket that dropped mid-session leaves the board frozen on a stale

--- a/src/mainview/components/__tests__/ProjectView.test.tsx
+++ b/src/mainview/components/__tests__/ProjectView.test.tsx
@@ -99,6 +99,49 @@ describe("ProjectView task-view layout", () => {
 
 		await Promise.resolve();
 		expect(dispatch).not.toHaveBeenCalledWith({ type: "setTasks", projectId: "p1", tasks: [] });
+		await waitFor(() =>
+			expect(dispatch).toHaveBeenCalledWith({
+				type: "setTasks",
+				projectId: "p1",
+				tasks: [{ id: "scheduled-task", projectId: "p1" }],
+			}),
+		);
+	});
+
+	// A push landing mid-fetch used to discard the entire snapshot, leaving the
+	// board with only the pushed card until the view remounted (dashboard round trip).
+	it("keeps the full snapshot when a task update lands mid-fetch", async () => {
+		let resolveTasks: (tasks: Task[]) => void;
+		const pendingTasks = new Promise<Task[]>((resolve) => {
+			resolveTasks = resolve;
+		});
+		const { api } = await import("../../rpc");
+		vi.mocked(api.request.getTasks).mockReturnValueOnce(pendingTasks);
+		const dispatch = vi.fn();
+
+		renderView({ dispatch });
+		await waitFor(() => expect(api.request.getTasks).toHaveBeenCalledWith({ projectId: "p1" }));
+
+		window.dispatchEvent(new CustomEvent("rpc:taskUpdated", {
+			detail: { task: { id: "b", projectId: "p1", status: "in-progress" } },
+		}));
+		resolveTasks!([
+			{ id: "a", projectId: "p1" } as Task,
+			{ id: "b", projectId: "p1", status: "todo" } as Task,
+			{ id: "c", projectId: "p1" } as Task,
+		]);
+
+		await waitFor(() =>
+			expect(dispatch).toHaveBeenCalledWith({
+				type: "setTasks",
+				projectId: "p1",
+				tasks: [
+					{ id: "a", projectId: "p1" },
+					{ id: "b", projectId: "p1", status: "in-progress" },
+					{ id: "c", projectId: "p1" },
+				],
+			}),
+		);
 	});
 
 	it("shows the empty-terminal placeholder when taskView is set but no task is selected", async () => {


### PR DESCRIPTION
Leaving a task via the breadcrumb sometimes landed on a Kanban board with a single card — the task just left — until a dashboard round trip restored the rest.

`ProjectView` fetched the project's tasks and, if any `rpc:taskUpdated` push for that project arrived while the fetch was in flight, discarded the whole snapshot (the `taskUpdateEpochRef` guard from #1144). When the fetch was triggered by switching projects, `currentProjectTasks` had just been cleared, so the only card left was the one the push carried — and no refetch followed, because `ProjectView` stays mounted while the split task view is open.

Pushed tasks are now collected per fetch and overlaid onto the snapshot (pushed version wins per id, unknown ids appended), so the live update is still preserved and the board can never end up partial.

Decision record: `decisions/2026/08/20/merge-pushed-tasks-into-board-snapshot.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=87094735-1b8e-4179-bc3f-b56c23998281) · `dev3://task/87094735-1b8e-4179-bc3f-b56c23998281`