### PR TITLE
Split the light-theme warning token into paper and ink

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,7 +79,8 @@ when you point at it. Never swap the two.
 | Danger | `--danger` | `#ff8987` | `#d61133` |
 | Success | `--success` | `#3fdf7e` | `#0e8a47` |
 | Success hover (fills) | `--success-hover` | `#04be58` | `#0a7239` |
-| Warning | `--warning` | `#f0d24e` | `#91760d` |
+| Warning (paper/border) | `--warning` | `#f0d24e` | `#e3b914` |
+| Warning ink (`text-warning-strong`) | `--warning-strong` | `#f0d24e` | `#46390f` |
 | Favorite (saved star) | `--favorite` | `#f9b63d` | `#a2710f` |
 | Awake | `--awake` | `#f49456` | `#bd5e0f` |
 | Achievement gold | `--stat-gold` | `#e5aa41` | `#9d6e0c` |
@@ -87,6 +88,15 @@ when you point at it. Never swap the two.
 
 The four warm roles are separated by **hue**, not just lightness, so they never
 read as one colour: warning 96° → gold 78° → awake 52° → fire 42°.
+
+**Warning is the one role whose light-theme value is split in two.** sRGB cannot
+make a colour that is both dark enough to carry text on white and still yellow —
+at the ~0.575 lightness every other light token sits at, yellow's chroma ceiling
+is 0.114 against danger's 0.218, so a "yellow ink" renders as brown mud. So in
+the light theme `--warning` is the **paper** (fills, tints, borders, bar fills)
+and `--warning-strong` is the **ink** that goes on it. Always write text as
+`text-warning-strong`, never `text-warning`. In the dark theme the two are the
+same yellow, so the rule costs nothing there.
 
 ### Background Gradient
 

--- a/change-logs/2026/08/20/fix-light-theme-yellow-readable.md
+++ b/change-logs/2026/08/20/fix-light-theme-yellow-readable.md
@@ -1,0 +1,3 @@
+Short: Light-theme yellow is yellow again
+
+The light theme's yellow read as dark brown and was hard to spot, because sRGB cannot make a colour that is both dark enough to carry text on white and still yellow. The role is now split: `--warning` is the paper (fills, borders, bar fills) and `--warning-strong` is the ink that goes on it, so warning text jumps from 4.0:1 to 9.6:1 contrast. The P2 priority chip and the Hibernate button additionally get a real yellow fill in the light theme. The dark theme is unchanged.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2683,7 +2683,7 @@ function App() {
 									<p className="text-danger text-xs font-medium">{t("remote.cloudflaredNotFound")}</p>
 									<p className="text-fg-2 text-xs">{t("remote.cloudflaredInstallHint")}</p>
 									<div className="flex items-center gap-2">
-										<code className="flex-1 text-warning bg-warning/10 px-3 py-2 rounded text-xs font-mono break-all select-all">
+										<code className="flex-1 text-warning-strong bg-warning/10 px-3 py-2 rounded text-xs font-mono break-all select-all">
 											{CLOUDFLARED_INSTALL_CMD}
 										</code>
 										<button
@@ -2740,12 +2740,12 @@ function App() {
 								<div className="flex items-start gap-2 rounded-lg bg-warning/10 border border-warning/20 px-2.5 py-2 text-left">
 									<span
 										aria-hidden="true"
-										className="text-warning text-sm leading-none mt-px shrink-0"
+										className="text-warning-strong text-sm leading-none mt-px shrink-0"
 										style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 									>
 										{"\uF071"}
 									</span>
-									<p className="text-warning/90 text-xs leading-snug">{t("remote.tunnelPropagationHint")}</p>
+									<p className="text-warning-strong/90 text-xs leading-snug">{t("remote.tunnelPropagationHint")}</p>
 								</div>
 							)}
 

--- a/src/mainview/components/AgentConfigPicker.tsx
+++ b/src/mainview/components/AgentConfigPicker.tsx
@@ -447,7 +447,7 @@ function AgentConfigPicker({
 						onClick={() => setUpdateOpen(true)}
 						className="col-span-full min-w-0 flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-warning/5 border border-warning/20 text-left hover:border-warning/40 transition-colors"
 					>
-						<span className="text-warning text-xs shrink-0">&#9888;</span>
+						<span className="text-warning-strong text-xs shrink-0">&#9888;</span>
 						<span className="text-fg-2 text-xs truncate">{t("recommendedUpdate.notice")}</span>
 						<span className="text-accent text-xs font-medium shrink-0 ml-auto">
 							{t("recommendedUpdate.review")}

--- a/src/mainview/components/AgentLaunchRequestModal.tsx
+++ b/src/mainview/components/AgentLaunchRequestModal.tsx
@@ -156,7 +156,7 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 
 					{agentNotInstalled && selectedAgent && (
 						<div id={NOT_INSTALLED_ID} className="p-3 rounded-lg bg-warning/10 border border-warning/20">
-							<p className="text-warning text-xs font-medium mb-1">
+							<p className="text-warning-strong text-xs font-medium mb-1">
 								{t("spawnAgent.notInstalled", { name: selectedAgent.name })}
 							</p>
 							{selectedAvailability?.installCommand && (

--- a/src/mainview/components/AutomationsPanel.tsx
+++ b/src/mainview/components/AutomationsPanel.tsx
@@ -21,7 +21,7 @@ function formatNextRun(iso: string | null, locale: string): string | null {
 function runStatusChip(run: AutomationRun, t: ReturnType<typeof useT>): { label: string; className: string } {
 	if (run.status === "created") return { label: t("automations.runCreated"), className: "text-success bg-success/10" };
 	if (run.status === "failed") return { label: t("automations.runFailed"), className: "text-danger bg-danger/10" };
-	return { label: t("automations.runMissed"), className: "text-warning bg-warning/10" };
+	return { label: t("automations.runMissed"), className: "text-warning-strong bg-warning/10" };
 }
 
 function AutomationsPanel({ project }: AutomationsPanelProps) {

--- a/src/mainview/components/BoardLoadFailed.tsx
+++ b/src/mainview/components/BoardLoadFailed.tsx
@@ -15,7 +15,7 @@ export default function BoardLoadFailed({ onRetry }: { onRetry: () => void }) {
 		<div className="flex-1 min-h-0 flex items-center justify-center p-6" data-testid="board-load-failed">
 			<div className="w-full max-w-sm bg-raised border border-edge rounded-2xl p-6 space-y-3 text-center">
 				<span
-					className="text-warning text-2xl leading-none block"
+					className="text-warning-strong text-2xl leading-none block"
 					style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 				>
 					{"\uf071"}

--- a/src/mainview/components/BootstrapScreen.tsx
+++ b/src/mainview/components/BootstrapScreen.tsx
@@ -67,7 +67,7 @@ export default function BootstrapScreen({
 			<div className="w-full max-w-md bg-raised border border-edge rounded-2xl shadow-2xl p-6 space-y-4">
 				<div className="flex items-center gap-3">
 					<span
-						className="text-warning text-2xl leading-none flex-shrink-0"
+						className="text-warning-strong text-2xl leading-none flex-shrink-0"
 						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 					>
 						{"\uf071"}

--- a/src/mainview/components/BugHuntersLightbox.tsx
+++ b/src/mainview/components/BugHuntersLightbox.tsx
@@ -210,11 +210,11 @@ function BugHuntersLightbox({ task, project, onClose }: BugHuntersLightboxProps)
 						{/* Warning for uninstalled agents */}
 						{agentNotInstalled && selectedAgent && (
 							<div className="p-3 rounded-lg bg-warning/10 border border-warning/20">
-								<p className="text-warning text-xs font-medium mb-1">
+								<p className="text-warning-strong text-xs font-medium mb-1">
 									{t("spawnAgent.notInstalled", { name: selectedAgent.name })}
 								</p>
 								{selectedAvailability?.installCommand && (
-									<code className="text-warning/80 bg-warning/5 px-2 py-0.5 rounded text-xs font-mono">
+									<code className="text-warning-strong/80 bg-warning/5 px-2 py-0.5 rounded text-xs font-mono">
 										{selectedAvailability.installCommand}
 									</code>
 								)}

--- a/src/mainview/components/ConnectionStatusPill.tsx
+++ b/src/mainview/components/ConnectionStatusPill.tsx
@@ -73,13 +73,13 @@ export default function ConnectionStatusPill() {
 			onClick={() => reconnectRpc()}
 			aria-label={t("conn.pill.retryAria")}
 			data-testid="connection-status-pill"
-			className="flex items-center gap-2 pl-2.5 pr-3 py-2 rounded-full bg-warning/15 border border-warning/40 text-warning shadow-lg backdrop-blur-sm hover:bg-warning/25 transition-colors"
+			className="flex items-center gap-2 pl-2.5 pr-3 py-2 rounded-full bg-warning/15 border border-warning/40 text-warning-strong shadow-lg backdrop-blur-sm hover:bg-warning/25 transition-colors"
 		>
 			<span className="w-2 h-2 rounded-full bg-warning animate-pulse" />
 			<span className="text-xs font-semibold whitespace-nowrap">
 				{t(STATE_LABEL[state as Exclude<RpcConnectionState, "connected">])}
 			</span>
-			<span className="text-warning/70 text-xs whitespace-nowrap">{t("conn.pill.retry")}</span>
+			<span className="text-warning-strong/70 text-xs whitespace-nowrap">{t("conn.pill.retry")}</span>
 		</button>
 	);
 }

--- a/src/mainview/components/DiagnosticsPanel.tsx
+++ b/src/mainview/components/DiagnosticsPanel.tsx
@@ -16,7 +16,7 @@ const KIND_LABEL: Record<DiagnosticKind, TranslationKey> = {
 
 function levelColor(level: DiagnosticEntry["level"]): string {
 	if (level === "error") return "text-danger";
-	if (level === "warn") return "text-warning";
+	if (level === "warn") return "text-warning-strong";
 	return "text-fg-3";
 }
 

--- a/src/mainview/components/FeatureFlagsModal.tsx
+++ b/src/mainview/components/FeatureFlagsModal.tsx
@@ -124,7 +124,7 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 				</div>
 
 				<div className="space-y-1">
-					{noClient && <p className="text-warning text-micro">{t("featureFlags.noClient")}</p>}
+					{noClient && <p className="text-warning-strong text-micro">{t("featureFlags.noClient")}</p>}
 					<p className="text-fg-3 text-xs">{t("featureFlags.distinctIdLabel")}</p>
 					<div className="flex items-center gap-2">
 						<code className="streamer-private flex-1 min-w-0 truncate px-3 py-2 rounded-lg bg-elevated border border-edge text-fg-2 text-xs font-mono">
@@ -146,7 +146,7 @@ export default function FeatureFlagsModal({ onClose }: FeatureFlagsModalProps) {
 						</button>
 					</div>
 					{idMismatch && (
-						<p className="text-warning text-micro">
+						<p className="text-warning-strong text-micro">
 							{t("featureFlags.idMismatch", { stored: storedId })}
 						</p>
 					)}

--- a/src/mainview/components/MemoryBreakdownPanel.tsx
+++ b/src/mainview/components/MemoryBreakdownPanel.tsx
@@ -21,7 +21,7 @@ export const PRESSURE_TEXT_CLASS: Record<MemoryPressure, string> = {
 	// Normal is deliberately neutral, not success-green: green means "Completed"
 	// in this app, and a permanently green header pill reads as a claim.
 	normal: "text-fg-3",
-	warn: "text-warning",
+	warn: "text-warning-strong",
 	critical: "text-danger",
 };
 
@@ -253,7 +253,7 @@ export default function MemoryBreakdownPanel({ snapshot, onSelectTask, onCloseOv
 							})}
 						</span>
 					)}
-					<span className={`ml-1.5 ${snapshot.swapping ? "text-warning" : "text-fg-muted"}`}>
+					<span className={`ml-1.5 ${snapshot.swapping ? "text-warning-strong" : "text-fg-muted"}`}>
 						{snapshot.swapping ? t("memory.swappingNow") : t("memory.swappingNot")}
 					</span>
 				</div>

--- a/src/mainview/components/OpenInPickerModal.tsx
+++ b/src/mainview/components/OpenInPickerModal.tsx
@@ -175,7 +175,7 @@ export default function OpenInPickerModal({ path, taskId, onClose }: OpenInPicke
 									</span>
 									<span className="flex items-center gap-1.5 flex-shrink-0">
 										{custom && (
-											<span className="px-1 py-0.5 rounded-[5px] bg-warning/15 text-warning text-nano font-bold uppercase tracking-wide leading-none">
+											<span className="px-1 py-0.5 rounded-[5px] bg-warning/15 text-warning-strong text-nano font-bold uppercase tracking-wide leading-none">
 												{t("openIn.customBadge")}
 											</span>
 										)}

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -70,7 +70,7 @@ function AddRowButton({ onClick, disabled, children }: { onClick: () => void; di
 function WarningNote({ children }: { children: ReactNode }) {
 	return (
 		<div className="flex items-start gap-2.5 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5">
-			<span className="mt-0.5 flex-shrink-0 text-warning text-base">&#9888;</span>
+			<span className="mt-0.5 flex-shrink-0 text-warning-strong text-base">&#9888;</span>
 			<p className="text-fg-2 text-xs leading-relaxed">{children}</p>
 		</div>
 	);

--- a/src/mainview/components/RateLimitIndicator.tsx
+++ b/src/mainview/components/RateLimitIndicator.tsx
@@ -88,7 +88,7 @@ function RateLimitIndicator({ compact = false }: { compact?: boolean }) {
 	const colorClasses = danger
 		? "text-danger bg-danger/15 border-danger/30"
 		: warn
-			? "text-warning bg-warning/15 border-warning/30"
+			? "text-warning-strong bg-warning/15 border-warning/30"
 			: "text-fg-3 border-transparent";
 
 	const openAccountsSettings = () => {

--- a/src/mainview/components/RosettaWarningModal.tsx
+++ b/src/mainview/components/RosettaWarningModal.tsx
@@ -47,7 +47,7 @@ export default function RosettaWarningModal({ command, kind, onClose }: RosettaW
 			>
 				<div className="flex items-center gap-3">
 					<span
-						className="text-warning text-2xl leading-none"
+						className="text-warning-strong text-2xl leading-none"
 						style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
 					>
 						{"\uf071"}
@@ -62,7 +62,7 @@ export default function RosettaWarningModal({ command, kind, onClose }: RosettaW
 					{kind === "brew" ? t("rosetta.instructionBrew") : t("rosetta.instructionDmg")}
 				</p>
 
-				<code className="block bg-base border border-edge rounded-lg px-3 py-2 text-xs font-mono text-warning break-all select-all">
+				<code className="block bg-base border border-edge rounded-lg px-3 py-2 text-xs font-mono text-warning-strong break-all select-all">
 					{command}
 				</code>
 

--- a/src/mainview/components/SpawnAgentModal.tsx
+++ b/src/mainview/components/SpawnAgentModal.tsx
@@ -185,7 +185,7 @@ function SpawnAgentModal({ task, project, onClose }: SpawnAgentModalProps) {
 						{/* Warning for uninstalled agents */}
 						{agentNotInstalled && selectedAgent && (
 							<div id={NOT_INSTALLED_ID} className="p-3 rounded-lg bg-warning/10 border border-warning/20">
-								<p className="text-warning text-xs font-medium mb-1">
+								<p className="text-warning-strong text-xs font-medium mb-1">
 									{t("spawnAgent.notInstalled", { name: selectedAgent.name })}
 								</p>
 								{selectedAvailability?.installCommand && (

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -481,7 +481,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const REVIEW_BADGE: Record<NonNullable<TaskPRBadgeInfo["reviewState"]>, { glyph: string | null; square?: boolean; cls: string; key: TranslationKey }> = {
 		approved: { glyph: null, square: true, cls: "text-success bg-success/10 hover:bg-success/20", key: "task.review.approved" },
 		changes_requested: { glyph: "", cls: "text-danger bg-danger/10 hover:bg-danger/20", key: "task.review.changesRequested" },
-		commented: { glyph: "", cls: "text-warning bg-warning/10 hover:bg-warning/20", key: "task.review.commented" },
+		commented: { glyph: "", cls: "text-warning-strong bg-warning/10 hover:bg-warning/20", key: "task.review.commented" },
 	};
 	const reviewMeta = prInfo?.reviewState ? REVIEW_BADGE[prInfo.reviewState] : null;
 	const reviewBadge = reviewMeta ? (
@@ -525,7 +525,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 					e.stopPropagation();
 					window.open(prInfo.url, "_blank");
 				}}
-				className="inline-flex h-5 flex-shrink-0 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-warning transition-colors hover:bg-warning/20"
+				className="inline-flex h-5 flex-shrink-0 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-warning-strong transition-colors hover:bg-warning/20"
 				aria-label={t.plural("task.prUnresolvedComments", unresolvedCount)}
 			>
 				<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF086"}</span>

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -1624,7 +1624,7 @@ function TaskDiffFileSection({
 							<span
 								data-testid="diff-exec-config-badge"
 								data-help-id="diff.exec-config"
-								className="inline-flex flex-shrink-0 items-center gap-1 px-1.5 py-0.5 rounded-md border text-micro font-bold bg-warning/10 text-warning border-warning/25"
+								className="inline-flex flex-shrink-0 items-center gap-1 px-1.5 py-0.5 rounded-md border text-micro font-bold bg-warning/10 text-warning-strong border-warning/25"
 							>
 								<span aria-hidden>⚠</span>
 								{/* The word costs the file name ~39px. Under ~28rem of pane it
@@ -3471,7 +3471,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 					</span>
 				)}
 				{payload.fallbackReason === "no-upstream" && (
-					<span className="px-2 py-1 rounded-md bg-warning/10 text-warning border border-warning/25 text-micro">
+					<span className="px-2 py-1 rounded-md bg-warning/10 text-warning-strong border border-warning/25 text-micro">
 						{t("infoPanel.diffFallbackNoUpstream", { ref: payload.compareLabel })}
 					</span>
 				)}
@@ -3585,7 +3585,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 						className={`inline-flex h-7 shrink-0 items-center rounded-md border px-2 text-micro font-mono ${
 							searchMatches.length > 0
 								? "border-edge bg-base text-fg-2"
-								: "border-warning/25 bg-warning/10 text-warning"
+								: "border-warning/25 bg-warning/10 text-warning-strong"
 						}`}
 					>
 						{searchStatusLabel}
@@ -4229,7 +4229,7 @@ function TaskDiffViewer({ task, project, request, onBack, navigationGuardRef }: 
 											<span className={`shrink-0 px-1.5 py-0.5 rounded-md border text-dense ${
 												skipped.reason === "binary"
 													? "bg-accent/10 text-accent border-accent/25"
-													: "bg-warning/10 text-warning border-warning/25"
+													: "bg-warning/10 text-warning-strong border-warning/25"
 											}`}>
 												{skipped.reason === "binary"
 													? t("infoPanel.diffSkippedReasonBinary")

--- a/src/mainview/components/TaskInfoPanel.tsx
+++ b/src/mainview/components/TaskInfoPanel.tsx
@@ -975,7 +975,7 @@ function TaskInfoPanel({
 				data-testid="task-hibernate-button"
 				onClick={handleHibernate}
 				disabled={hibernating}
-				className="task-anim flex items-center gap-1 px-2 py-1 rounded-lg transition-colors text-warning hover:text-warning hover:bg-warning/15 border border-warning/30 disabled:opacity-50"
+				className="task-anim warning-paper flex items-center gap-1 px-2 py-1 rounded-lg transition-colors text-warning-strong hover:text-warning-strong hover:bg-warning/15 border border-warning/30 disabled:opacity-50"
 				aria-label={t("task.hibernate")}
 			>
 				{hibernating ? (
@@ -1083,7 +1083,7 @@ function TaskInfoPanel({
 										>
 											<span>{t("task.prBadge", { number: String(metadataPrInfo.number) })}</span>
 											{(metadataPrInfo.unresolvedCount ?? 0) > 0 && (
-												<span className="inline-flex items-center gap-0.5 text-warning no-underline" aria-label={t.plural("task.prUnresolvedComments", metadataPrInfo.unresolvedCount ?? 0)}>
+												<span className="inline-flex items-center gap-0.5 text-warning-strong no-underline" aria-label={t.plural("task.prUnresolvedComments", metadataPrInfo.unresolvedCount ?? 0)}>
 													<span className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF086"}</span>
 													<span>{metadataPrInfo.unresolvedCount}</span>
 												</span>

--- a/src/mainview/components/TaskPrStatusPopover.tsx
+++ b/src/mainview/components/TaskPrStatusPopover.tsx
@@ -72,7 +72,7 @@ function checkGlyph(state: CheckState): string {
 function checkClass(state: CheckState): string {
 	switch (state) {
 		case "failure": return "text-danger";
-		case "pending": return "text-warning";
+		case "pending": return "text-warning-strong";
 		case "success": return "text-success";
 		default: return "text-fg-3";
 	}
@@ -319,13 +319,13 @@ export default function TaskPrStatusPopover({ prInfo, projectId, taskId, onShowU
 						<div className="font-semibold text-fg">{t("task.prStatusPopover", { number: String(prInfo.number) })}</div>
 						{prInfo.prTitle && <div className="mt-0.5 truncate text-fg-3" title={prInfo.prTitle}>{prInfo.prTitle}</div>}
 					</div>
-					{prInfo.isDraft && <span className="flex-shrink-0 rounded bg-warning/10 px-1.5 py-0.5 font-medium text-warning">{t("task.prDraft")}</span>}
+					{prInfo.isDraft && <span className="flex-shrink-0 rounded bg-warning/10 px-1.5 py-0.5 font-medium text-warning-strong">{t("task.prDraft")}</span>}
 				</div>
 			)}
 			{sheet && (prInfo.prTitle || prInfo.isDraft) && (
 				<div className="flex items-start justify-between gap-3">
 					{prInfo.prTitle && <div className="min-w-0 break-words text-fg-3">{prInfo.prTitle}</div>}
-					{prInfo.isDraft && <span className="flex-shrink-0 rounded bg-warning/10 px-1.5 py-0.5 font-medium text-warning">{t("task.prDraft")}</span>}
+					{prInfo.isDraft && <span className="flex-shrink-0 rounded bg-warning/10 px-1.5 py-0.5 font-medium text-warning-strong">{t("task.prDraft")}</span>}
 				</div>
 			)}
 
@@ -341,13 +341,13 @@ export default function TaskPrStatusPopover({ prInfo, projectId, taskId, onShowU
 						}}
 						title={t("task.prShowUnresolvedInDiff")}
 						aria-label={t("task.prShowUnresolvedInDiff")}
-						className="mt-2 flex items-center gap-1.5 rounded text-warning transition-colors hover:underline focus:ring-1 focus:ring-accent"
+						className="mt-2 flex items-center gap-1.5 rounded text-warning-strong transition-colors hover:underline focus:ring-1 focus:ring-accent"
 					>
 						<span className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{""}</span>
 						<span>{t.plural("task.prUnresolvedComments", prInfo.unresolvedCount)}</span>
 					</button>
 				) : (
-					<div className="mt-2 flex items-center gap-1.5 text-warning">
+					<div className="mt-2 flex items-center gap-1.5 text-warning-strong">
 						<span className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{""}</span>
 						<span>{t.plural("task.prUnresolvedComments", prInfo.unresolvedCount)}</span>
 					</div>

--- a/src/mainview/components/TaskTerminalBackendRow.tsx
+++ b/src/mainview/components/TaskTerminalBackendRow.tsx
@@ -131,7 +131,7 @@ export default function TaskTerminalBackendRow({
 			</p>
 			{!live &&
 				reasons.map((reason) => (
-					<p key={reason} className="text-warning text-xs">
+					<p key={reason} className="text-warning-strong text-xs">
 						{reason}
 					</p>
 				))}

--- a/src/mainview/components/TerminalPerfOverlay.tsx
+++ b/src/mainview/components/TerminalPerfOverlay.tsx
@@ -41,7 +41,7 @@ type Tone = "ok" | "warn" | "bad";
 
 function toneClass(tone: Tone): string {
 	if (tone === "bad") return "text-danger";
-	if (tone === "warn") return "text-warning";
+	if (tone === "warn") return "text-warning-strong";
 	return "text-fg-2";
 }
 

--- a/src/mainview/components/global-settings/AgentAccountsSection.tsx
+++ b/src/mainview/components/global-settings/AgentAccountsSection.tsx
@@ -110,7 +110,7 @@ function ApiProfileBadges({ api }: { api: AgentApiProfileInfo }) {
 	const host = apiBadgeHost(api.baseUrl);
 	return (
 		<>
-			<span className="text-warning text-xs px-1.5 py-0.5 bg-warning/10 rounded shrink-0">API</span>
+			<span className="text-warning-strong text-xs px-1.5 py-0.5 bg-warning/10 rounded shrink-0">API</span>
 			{host ? <span className="text-fg-3 text-xs font-mono truncate streamer-private">{host}</span> : null}
 		</>
 	);

--- a/src/mainview/components/global-settings/AgentSettingsSection.tsx
+++ b/src/mainview/components/global-settings/AgentSettingsSection.tsx
@@ -453,12 +453,12 @@ export default function AgentSettingsSection({
 															: "border-transparent text-fg-2 hover:bg-elevated-hover hover:text-fg"
 													}`}
 												>
-													<span className={isFavorite ? "text-warning" : "text-transparent"}>
+													<span className={isFavorite ? "text-warning-strong" : "text-transparent"}>
 														<StarIcon filled={isFavorite} />
 													</span>
 													<span className="flex-1 min-w-0 truncate">{getModeLeafLabel(config)}</span>
 													{config.requiresPxpipeProxy ? (
-														<span className="text-warning text-micro shrink-0">{t("settings.presetNeedsProxy")}</span>
+														<span className="text-warning-strong text-micro shrink-0">{t("settings.presetNeedsProxy")}</span>
 													) : null}
 													{activeAgent.defaultConfigId === config.id ? (
 														<span className="text-accent text-micro shrink-0">{t("settings.defaultBadge")}</span>
@@ -796,7 +796,7 @@ function PresetEditor({
 						title={isFavorite ? t("settings.favoriteRemoveHint") : t("settings.favoriteAddHint")}
 						className={`px-2.5 py-1 rounded-lg border text-xs flex items-center gap-1.5 transition-colors ${
 							isFavorite
-								? "bg-warning/10 border-warning/30 text-warning hover:bg-warning/15"
+								? "bg-warning/10 border-warning/30 text-warning-strong hover:bg-warning/15"
 								: "bg-elevated border-edge text-fg-2 hover:text-fg hover:border-edge-active"
 						}`}
 					>
@@ -1001,7 +1001,7 @@ function AgentFamilyField({
 			</Field>
 			{unrecognized ? (
 				<div className="p-3 rounded-lg bg-warning/5 border border-warning/20 space-y-1" role="status">
-					<p className="text-warning text-xs font-medium">{t("settings.familyMissingTitle")}</p>
+					<p className="text-warning-strong text-xs font-medium">{t("settings.familyMissingTitle")}</p>
 					<p className="text-fg-3 text-xs">
 						{t("settings.familyMissingBody", { command: agent.baseCommand || "—" })}
 					</p>
@@ -1071,7 +1071,7 @@ function AgentPane({
 								<div>
 									<p className="text-fg-3 text-xs mb-1">{t("settings.agentInstallHint")}</p>
 									<div className="flex items-center gap-1.5">
-										<code className="text-warning bg-warning/10 px-2 py-1 rounded text-xs font-mono">
+										<code className="text-warning-strong bg-warning/10 px-2 py-1 rounded text-xs font-mono">
 											{availability.installCommand}
 										</code>
 										<button

--- a/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
+++ b/src/mainview/components/global-settings/BehaviorSettingsSection.tsx
@@ -192,7 +192,7 @@ export default function BehaviorSettingsSection({
 				</p>
 				{prOriginTaskLinkSupported ? null : (
 					<p
-						className="text-warning text-xs mb-3 break-words"
+						className="text-warning-strong text-xs mb-3 break-words"
 						data-testid="pr-origin-task-link-unsupported"
 					>
 						{t("settings.prOriginTaskLinkUnsupported")}

--- a/src/mainview/components/global-settings/ModelCatalogSection.tsx
+++ b/src/mainview/components/global-settings/ModelCatalogSection.tsx
@@ -449,11 +449,11 @@ export default function ModelCatalogSection({ t }: { t: TFunction }) {
 							</button>
 						</Gated>
 						{listError ? (
-							<span className="text-xs text-warning">{t("catalog.listUnavailable")}</span>
+							<span className="text-xs text-warning-strong">{t("catalog.listUnavailable")}</span>
 						) : available === null ? null : available.length > 0 ? (
 							<span className="text-xs text-fg-3">{t("catalog.listLoaded", { count: String(available.length) })}</span>
 						) : (
-							<span className="text-xs text-warning">{t("catalog.listEmpty")}</span>
+							<span className="text-xs text-warning-strong">{t("catalog.listEmpty")}</span>
 						)}
 			</div>
 		</div>

--- a/src/mainview/components/global-settings/PxpipeProxySettingsSection.tsx
+++ b/src/mainview/components/global-settings/PxpipeProxySettingsSection.tsx
@@ -96,7 +96,7 @@ export default function PxpipeProxySettingsSection({
 			>
 				{/* Honesty callout — always visible, even when off. */}
 				<div className="rounded-xl border border-warning/30 bg-warning/10 p-3">
-					<p className="text-warning text-sm font-semibold mb-1">
+					<p className="text-warning-strong text-sm font-semibold mb-1">
 						{t("pxpipe.warningTitle")}
 					</p>
 					<p className="text-fg-2 text-xs leading-relaxed">{t("pxpipe.warningBody")}</p>

--- a/src/mainview/components/global-settings/TerminalBackendSetting.tsx
+++ b/src/mainview/components/global-settings/TerminalBackendSetting.tsx
@@ -103,7 +103,7 @@ export default function TerminalBackendSetting({
 								<div className="text-fg text-sm font-semibold">{option.title}</div>
 								<div className="text-fg-3 text-xs mt-0.5">{option.description}</div>
 								{option.reasons.map((reason) => (
-									<div key={reason} className="text-warning text-xs mt-1 break-words">
+									<div key={reason} className="text-warning-strong text-xs mt-1 break-words">
 										{reason}
 									</div>
 								))}

--- a/src/mainview/components/pr-review/GithubThreadView.tsx
+++ b/src/mainview/components/pr-review/GithubThreadView.tsx
@@ -87,7 +87,7 @@ export function GithubThreadView({
 					</span>
 				)}
 				{thread.isOutdated && (
-					<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-dense font-semibold text-warning">
+					<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-dense font-semibold text-warning-strong">
 						{t("infoPanel.prOutdatedBadge")}
 					</span>
 				)}

--- a/src/mainview/components/pr-review/PrConversationBlock.tsx
+++ b/src/mainview/components/pr-review/PrConversationBlock.tsx
@@ -81,7 +81,7 @@ export function PrConversationBlock({
 					<span className="rounded bg-base px-1.5 py-px font-mono text-micro text-fg-3">{conversation.length}</span>
 					<span aria-hidden="true" className="text-sm-plus text-fg-3">{expanded ? "▾" : "▸"}</span>
 					{unresolvedCount > 0 && (
-						<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-micro font-semibold text-warning">
+						<span className="rounded border border-warning/30 bg-warning/10 px-1.5 py-px text-micro font-semibold text-warning-strong">
 							{t.plural("infoPanel.prUnresolvedCount", unresolvedCount)}
 						</span>
 					)}

--- a/src/mainview/components/priorityStyles.ts
+++ b/src/mainview/components/priorityStyles.ts
@@ -43,10 +43,12 @@ export const PRIORITY_STYLES: Record<TaskPriority, PriorityStyle> = {
 		chipIdle: "text-awake border border-awake/30 opacity-60 hover:opacity-100",
 		chipActive: "text-awake bg-awake/15 border border-awake/30 ring-1 ring-awake",
 	},
+	// `warning-paper` is the light-theme-only fill that gives P2 its yellow back:
+	// yellow ink does not exist on white paper (see --warning in index.css).
 	P2: {
-		badge: "text-warning bg-warning/15 border border-warning/30",
-		chipIdle: "text-warning border border-warning/30 opacity-60 hover:opacity-100",
-		chipActive: "text-warning bg-warning/15 border border-warning/30 ring-1 ring-warning",
+		badge: "warning-paper text-warning-strong bg-warning/15 border border-warning/30",
+		chipIdle: "warning-paper text-warning-strong border border-warning/30 opacity-60 hover:opacity-100",
+		chipActive: "warning-paper text-warning-strong bg-warning/15 border border-warning/30 ring-1 ring-warning",
 	},
 	P3: {
 		badge: "text-success bg-success/15 border border-success/30",

--- a/src/mainview/components/rate-limit-ui.tsx
+++ b/src/mainview/components/rate-limit-ui.tsx
@@ -90,7 +90,7 @@ export function severityFill(percent: number): string {
 
 export function severityText(percent: number): string {
 	if (percent >= RATE_LIMIT_DANGER_PERCENT) return "text-danger";
-	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning";
+	if (percent >= RATE_LIMIT_WARN_PERCENT) return "text-warning-strong";
 	return "text-fg-2";
 }
 
@@ -225,7 +225,7 @@ export function CapturedNote({ capturedAt, now }: { capturedAt: number; now: num
 	const stale = age > STALE_AFTER_MS;
 	const label = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
 	return (
-		<span className={`flex items-center gap-1 text-xs tabular-nums ${stale ? "text-warning" : "text-fg-3"}`}>
+		<span className={`flex items-center gap-1 text-xs tabular-nums ${stale ? "text-warning-strong" : "text-fg-3"}`}>
 			{label}
 		</span>
 	);
@@ -243,7 +243,7 @@ export function CapturedAgeSuffix({ capturedAt, now }: { capturedAt: number; now
 	const short = age < 60_000 ? t("rateLimits.capturedAgeNow") : formatAge(age);
 	const full = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
 	return (
-		<span title={full} className={stale ? "text-warning" : "text-fg-3"}>
+		<span title={full} className={stale ? "text-warning-strong" : "text-fg-3"}>
 			{" · "}
 			{short}
 		</span>

--- a/src/mainview/components/task-info-panel/RemoteBetaWarning.tsx
+++ b/src/mainview/components/task-info-panel/RemoteBetaWarning.tsx
@@ -8,7 +8,7 @@ import { isRemote } from "../../utils/platform";
 export default function RemoteBetaWarning({ text }: { text: string }) {
 	if (!isRemote()) return null;
 	return (
-		<span className="mt-1.5 flex items-start gap-1.5 text-warning">
+		<span className="mt-1.5 flex items-start gap-1.5 text-warning-strong">
 			<span
 				aria-hidden
 				className="flex-shrink-0 leading-none"

--- a/src/mainview/components/task-info-panel/TaskDevServer.tsx
+++ b/src/mainview/components/task-info-panel/TaskDevServer.tsx
@@ -340,7 +340,7 @@ export default function TaskDevServer({ task, project, isTaskActive, compact = f
 	const isStarting = hasDevScript && isTaskActive && devState === "starting";
 
 	const stateClasses = !hasDevScript
-		? "text-warning hover:text-warning hover:bg-warning/15 cursor-pointer border border-dashed border-warning/40"
+		? "text-warning-strong hover:text-warning-strong hover:bg-warning/15 cursor-pointer border border-dashed border-warning/40"
 		: !isTaskActive
 			? "text-fg-muted/50 cursor-not-allowed border border-transparent"
 			: isStarting

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -305,7 +305,7 @@ export default function TaskGitActions({
 				<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0401}"}</span>
 				{t("task.prBadge", { number: String(prInfo.number) })}
 				{(prInfo.unresolvedCount ?? 0) > 0 && (
-					<span className="inline-flex items-center gap-0.5 text-warning" aria-label={t.plural("task.prUnresolvedComments", prInfo.unresolvedCount ?? 0)}>
+					<span className="inline-flex items-center gap-0.5 text-warning-strong" aria-label={t.plural("task.prUnresolvedComments", prInfo.unresolvedCount ?? 0)}>
 						<span className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF086"}</span>
 						<span>{prInfo.unresolvedCount}</span>
 					</span>

--- a/src/mainview/components/task-info-panel/TaskOpenIn.tsx
+++ b/src/mainview/components/task-info-panel/TaskOpenIn.tsx
@@ -106,7 +106,7 @@ export default function TaskOpenIn({ task, project, isTaskActive, showFileBrowse
 								<p className="text-fg-3 text-xs mb-3">{t("fileBrowser.notInstalledDesc")}</p>
 								{yaziLinuxHint && <p className="text-fg-3 text-xs mb-2">{t("fileBrowser.linuxBrewHint")}</p>}
 								<div className="flex items-center gap-2 mb-3">
-									<code className="flex-1 text-warning bg-warning/10 px-3 py-2 rounded text-xs font-mono break-all">
+									<code className="flex-1 text-warning-strong bg-warning/10 px-3 py-2 rounded text-xs font-mono break-all">
 										{yaziInstallCmd}
 									</code>
 									<Tooltip content={t("openIn.copyPath")} detail={t("ttip.infoPanel.copyPath")}>

--- a/src/mainview/components/task-info-panel/TaskPaneControls.tsx
+++ b/src/mainview/components/task-info-panel/TaskPaneControls.tsx
@@ -338,7 +338,7 @@ export default function TaskPaneControls({ taskId, compact = false }: TaskPaneCo
 							{/* Amber, matching Hibernate: the pane goes away, the work in the
 							    worktree does not. Red is reserved for the irreversible. */}
 							<button
-								className={`${canClose ? tmuxBtnClass : tmuxBtnDisabledClass} ${canClose ? "text-warning hover:text-warning hover:bg-warning/15 border-warning/30" : ""}`}
+								className={`${canClose ? tmuxBtnClass : tmuxBtnDisabledClass} ${canClose ? "text-warning-strong hover:text-warning-strong hover:bg-warning/15 border-warning/30" : ""}`}
 								disabled={!canClose}
 								onClick={canClose ? handleClosePane : undefined}
 								aria-label={t("tmux.closePaneDesc")}

--- a/src/mainview/components/task-info-panel/TaskScripts.tsx
+++ b/src/mainview/components/task-info-panel/TaskScripts.tsx
@@ -343,7 +343,7 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 					)}
 				</div>
 				{data?.package.multipleLockfiles && !pickerFor && (
-					<div className="flex-shrink-0 px-3 py-1.5 text-xs text-warning bg-warning/10 border-b border-warning/20">
+					<div className="flex-shrink-0 px-3 py-1.5 text-xs text-warning-strong bg-warning/10 border-b border-warning/20">
 						⚠ {t("scripts.warning.multipleLockfiles")}: {data.package.lockfiles.join(", ")}
 					</div>
 				)}

--- a/src/mainview/confirm.tsx
+++ b/src/mainview/confirm.tsx
@@ -278,7 +278,7 @@ function ConfirmDialog({ pending, close }: { pending: PendingConfirm; close: (re
 					<p
 						data-testid="confirm-deferred"
 						className={`flex items-start gap-2 text-sm leading-relaxed whitespace-pre-line ${
-							deferredState.muted ? "text-fg-3" : "text-warning"
+							deferredState.muted ? "text-fg-3" : "text-warning-strong"
 						}`}
 					>
 						{!deferredState.settled && (

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -86,7 +86,7 @@ html {
 	--success-fill: 15 118 54;
 	--success-fill-hover: 11 91 42;
 	--warning: 240 210 78;
-	--warning-strong: 240 210 78; /* warning ink on a warning-tinted fill */
+	--warning-strong: 240 210 78; /* the ink; on dark paper it is the same yellow */
 	/* Solid fills under white ink — --warning is a light yellow, unsuitable for
 	   filled buttons. These deeper values give white Lc ≥ 75. */
 	--warning-fill: 133 77 14;
@@ -201,8 +201,13 @@ html {
 	/* Solid fills under white ink. */
 	--success-fill: 10 114 57;
 	--success-fill-hover: 8 88 44;
-	--warning: 145 118 13;
-	--warning-strong: 118 96 9; /* --warning on a warning/10 fill is only 3.82:1 */
+	/* Yellow is the one hue sRGB cannot make dark and yellow at the same time:
+	   at the ~0.575 lightness every other light-theme token sits at, its chroma
+	   ceiling is 0.114 against danger's 0.218, so "yellow ink" renders as mud.
+	   So the roles split here — --warning is paper/border/fill, --warning-strong
+	   is the ink that goes on it (9.6:1 on a warning/15 chip). */
+	--warning: 227 185 20;
+	--warning-strong: 70 57 15;
 	/* Solid fills under white ink. */
 	--warning-fill: 105 86 9;
 	--warning-fill-hover: 82 67 7;
@@ -600,6 +605,27 @@ button {
 		align-items: center;
 		justify-content: center;
 	}
+}
+
+/* ---- Warning paper -------------------------------------------------------
+   Every other state role says "this is mine" with coloured ink. Yellow cannot:
+   see the --warning note above. So a control that must read as yellow carries
+   the hue in its background instead, and only in the light theme — in dark the
+   ink is already yellow and this rule is a deliberate no-op. Alpha 0.5 puts the
+   --warning-strong ink at 7.9:1 on the result. */
+[data-theme="light"] .warning-paper {
+	background-color: rgb(var(--warning) / 0.5);
+	/* The paper already says "yellow", so the outline goes back to the neutral
+	   one every other control wears — a yellow border on yellow paper reads as
+	   a fuzzy edge, not as a button. One step darker than --border-default,
+	   because the yellow paper eats the contrast a neutral button's outline
+	   gets for free: --border-active on this fill matches the 1.7:1 a plain
+	   button's edge has against its own surface. */
+	border-color: rgb(var(--border-active));
+}
+[data-theme="light"] .warning-paper:hover {
+	background-color: rgb(var(--warning) / 0.65);
+	border-color: rgb(var(--text-tertiary));
 }
 
 /* ---- Close-pane picker: marching-ants selection marquee -------------------

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -188,7 +188,7 @@ const VARIANT: Record<ToastVariant, { icon: string; border: string; text: string
 	error: { icon: "\uf06a", border: "border-danger/40", text: "text-danger", bar: "bg-danger" },
 	success: { icon: "\uf058", border: "border-success/40", text: "text-success", bar: "bg-success" },
 	info: { icon: "\uf05a", border: "border-accent/40", text: "text-accent", bar: "bg-accent" },
-	warning: { icon: "\uf071", border: "border-warning/40", text: "text-warning", bar: "bg-warning" },
+	warning: { icon: "\uf071", border: "border-warning/40", text: "text-warning-strong", bar: "bg-warning" },
 	// Envelope, not a severity glyph: this toast reports mail between agents.
 	agent: { icon: "\uf0e0", border: "border-agent/40", text: "text-agent", bar: "bg-agent" },
 };


### PR DESCRIPTION
The light theme's yellow read as dark brown and was hard to spot — most visibly on the `P2` priority chip and the `Hibernate` button.

That is not a badly picked hex. sRGB cannot produce a colour that is both dark enough to carry text on white and still yellow: at the ~0.575 lightness every other light-theme token sits at, yellow's chroma ceiling is 0.114 against `--danger`'s 0.218, so "yellow ink" can only render as mud.

So the role is split, light theme only:

- `--warning` is now the **paper** — fills, tints, borders, bar fills (`#91760d` → `#e3b914`).
- `--warning-strong` is the **ink** that goes on it (`#76600 9` → `#46390f`). Warning text moves from 4.04:1 to 9.62:1 contrast.
- Every `text-warning` call site becomes `text-warning-strong`. In the dark theme the two tokens are the same yellow, so this is a no-op there.
- A new light-theme-only `.warning-paper` class gives the `P2` chip and the `Hibernate` button a real yellow fill (7.9:1 for the ink on it) plus a neutral outline, so they keep a visible hue identity next to P0/P1/P3 instead of collapsing into a grey chip.

The outline under `.warning-paper` uses `--border-active` rather than `--border-default`: the yellow fill eats the contrast a neutral button's edge gets for free, and one step darker restores the same 1.7:1 that a plain button's outline has against its own surface.

The dark theme is unchanged — verified pixel-for-pixel on the same toolbar in both appearances.

`DESIGN.md` records the rule: warning text is always `text-warning-strong`, never `text-warning`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=573c4671-8de4-4fb5-aa75-549b53eb11c7) · `dev3://task/573c4671-8de4-4fb5-aa75-549b53eb11c7` _(dev3 added this footer — turn it off in Settings → Tasks.)_