### PR TITLE
Add dev3 artifact-template CLI to recover a missing starter path

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -48,7 +48,7 @@ Last updated: 2026-07-13
 | **Status hooks (automatic)** | Yes (6 hooks) | — | Yes (6 worktree-local hooks, automatically trusted) | — | — |
 | **Status management** | Automatic via hooks | Manual (SKILL.md) | Automatic via hooks with `user-questions`/legacy-session fallback | Manual (SKILL.md) | Manual (SKILL.md) |
 | **Rate-limit tracking** | Yes (statusLine wrapper injected via `--settings`, `dev3 statusline`) | — | Yes (rollout files + cached live monthly credits via `codex app-server`) | — | — |
-| **dev3 artifact starter** | Yes (`DEV3_ARTIFACT_TEMPLATE_DIR`) | Yes | Yes | Yes | Yes |
+| **dev3 artifact starter** | Yes (`DEV3_ARTIFACT_TEMPLATE_DIR`, restored by `dev3 artifact-template`) | Yes | Yes | Yes | Yes |
 
 ## Status Hooks
 

--- a/change-logs/2026/08/20/feature-artifact-template-cli.md
+++ b/change-logs/2026/08/20/feature-artifact-template-cli.md
@@ -1,0 +1,5 @@
+Short: Recover a missing artifact starter
+
+New `dev3 artifact-template` command copies this task's pristine dev3 artifact starter into `./dev3-artifact-report` and prints where it went. It is the recovery path when `$DEV3_ARTIFACT_TEMPLATE_DIR` is absent — that variable is baked into a session's environment at launch, so an older session or a shell that never inherited it could not reach the starter at all.
+
+Suggested by @DolevEpshtein (h0x91b/dev-3.0#1437)

--- a/decisions/2026/08/20/artifact-template-cli-recovery.md
+++ b/decisions/2026/08/20/artifact-template-cli-recovery.md
@@ -1,0 +1,43 @@
+# Artifact starter reachable through the CLI, not only through launch env
+
+## Context
+
+`DEV3_ARTIFACT_TEMPLATE_DIR` is exported by the generated launch script and set on the
+tmux session at task launch (`ensureArtifactTemplateEnv`, `src/bun/artifact-template.ts`,
+consumed in `src/bun/rpc-handlers/tmux-pty.ts`). Every agent launch path sets it, yet issue
+#1437 reports tasks where it is absent while a sibling task on the same host has it.
+
+## Investigation
+
+The variable is baked into an environment at spawn time. Two states reproduce the report
+without any launch path being buggy: a session started by an app version whose bundle had no
+`artifact-template` (or before the feature shipped) keeps running with the old environment,
+and a shell that never inherited the launch script's exports has no way to learn the path.
+`ensureArtifactTemplateEnv` deliberately degrades to an empty env rather than blocking a
+launch, so the failure is silent by design.
+
+## Decision
+
+Stop treating the launch environment as the only channel. `dev3 artifact-template`
+(`src/cli/commands/artifact-template.ts` → `artifact.template-dir` in
+`src/bun/cli-socket-server.ts`) provisions the starter from the bundle and copies it into
+`./dev3-artifact-report` — the destination the artifact workflow already documents — so the
+recovery is one command with no arguments to choose. Re-running it restores the managed files
+over an existing copy. The skill text now sends agents here instead of stopping at "starter
+provisioning failed".
+
+## Risks
+
+The command needs the app running, like every other socket-backed CLI command; a task whose
+app is closed gets the standard exit 2 rather than a starter. Copying into a fixed directory
+name means a report living somewhere else must be moved by hand — accepted, because a flag
+for it is exactly the complexity this command exists to avoid.
+
+## Alternatives considered
+
+Printing the path and letting the caller `cp -R` was the first cut; it needed a `--copy-to`
+flag and an offline fallback to be useful, which is more surface than the problem deserves.
+Re-exporting the variable into running sessions was rejected because an already-running
+process cannot have its environment rewritten. Making `ensureArtifactTemplateEnv` throw was
+rejected too — a broken bundle would then block task launches over a feature most tasks never
+use.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -21,7 +21,7 @@ import {
 	CLI_EXIT_CODE_ARTIFACT_ASSET_MISSING,
 	CLI_EXIT_CODE_ARTIFACT_SECRET_FOUND,
 } from "../../shared/cli-exit-codes";
-import { ARTIFACT_TEMPLATE_FILES } from "../artifact-template";
+import { ARTIFACT_TEMPLATE_FILES } from "../../shared/artifact-template";
 import { skillPrLinkInstruction } from "../../shared/agent-skill-content";
 import { hookCliDialect } from "../../shared/dev3-cli-path";
 

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -12,9 +12,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { MAX_SHARED_ARTIFACT_HTML_BYTES, type Project, type Task } from "../../shared/types";
+import { ARTIFACT_TEMPLATE_FILES, ARTIFACT_TEMPLATE_VERSION } from "../../shared/artifact-template";
 import {
-	ARTIFACT_TEMPLATE_FILES,
-	ARTIFACT_TEMPLATE_VERSION,
 	artifactTemplateDir,
 	ensureArtifactTemplate,
 	ensureArtifactTemplateEnv,

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -172,6 +172,10 @@ import { saveSharedImage } from "../shared-images";
 import { saveSharedArtifact } from "../shared-artifacts";
 import { closePaneRun, paneRunListing, readPaneRun, startPaneRun } from "../task-pane-runs";
 
+vi.mock("../artifact-template", () => ({
+	ensureArtifactTemplate: vi.fn(() => "/wt-container/artifact-template-v1"),
+}));
+
 vi.mock("../task-pane-runs", () => ({
 	PaneRunError: class PaneRunError extends Error {},
 	startPaneRun: vi.fn(async () => ({ runId: "run-0123456789ab", paneId: "pane-2", backend: "native", logPath: "/tmp/x.log", command: "bun run build" })),
@@ -1418,6 +1422,42 @@ describe("ui.show-artifact", () => {
 		expect(response.data).toMatchObject({ delivered: true, queued: true, stored: 1 });
 		expect(pushFn).toHaveBeenCalledWith("taskUpdated", expect.anything());
 		expect(pushCliShowArtifact).toHaveBeenCalledWith(expect.objectContaining({ taskId: task.id, newCount: 1 }));
+	});
+});
+
+describe("artifact.template-dir", () => {
+	it("provisions the starter on demand and answers with its path", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		const { ensureArtifactTemplate } = await import("../artifact-template");
+
+		const resp = await handleRequest(makeRequest("artifact.template-dir", {
+			taskId: task.id,
+			projectId: project.id,
+			worktreePath: "/wt-container/worktree",
+		}));
+
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toMatchObject({ dir: "/wt-container/artifact-template-v1", taskId: task.id });
+		expect(ensureArtifactTemplate).toHaveBeenCalledWith(project, task, { worktreePath: "/wt-container/worktree" });
+	});
+
+	it("reports the provisioning failure instead of inventing a path", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		const { ensureArtifactTemplate } = await import("../artifact-template");
+		vi.mocked(ensureArtifactTemplate).mockImplementationOnce(() => {
+			throw new Error("Bundled dev3 artifact template not found");
+		});
+
+		const resp = await handleRequest(makeRequest("artifact.template-dir", { taskId: task.id, projectId: project.id }));
+
+		expect(resp.ok).toBe(false);
+		expect(resp.error).toContain("artifact template not found");
 	});
 });
 

--- a/src/bun/artifact-template.ts
+++ b/src/bun/artifact-template.ts
@@ -6,21 +6,11 @@ import {
 	rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { ARTIFACT_TEMPLATE_FILES, artifactTemplateDirName } from "../shared/artifact-template";
 import type { Project, Task } from "../shared/types";
 import { createLogger } from "./logger";
 
 const log = createLogger("artifact-template");
-
-export const ARTIFACT_TEMPLATE_VERSION = 1;
-
-export const ARTIFACT_TEMPLATE_FILES = [
-	"AUTHORING.md",
-	"index.html",
-	"report.js",
-	"app.css",
-	"app.js",
-	"dev3-icon.png",
-] as const;
 
 interface EnsureArtifactTemplateOptions {
 	sourceDir?: string;
@@ -56,7 +46,7 @@ function taskContainerDir(project: Project, task: Task, worktreePath?: string): 
 }
 
 export function artifactTemplateDir(project: Project, task: Task, worktreePath?: string): string {
-	return join(taskContainerDir(project, task, worktreePath), `artifact-template-v${ARTIFACT_TEMPLATE_VERSION}`);
+	return join(taskContainerDir(project, task, worktreePath), artifactTemplateDirName());
 }
 
 /**
@@ -71,7 +61,7 @@ export function ensureArtifactTemplate(
 ): string {
 	const sourceDir = options.sourceDir ?? bundledArtifactTemplateDir();
 	const containerDir = options.taskContainerDir ?? taskContainerDir(project, task, options.worktreePath);
-	const targetDir = join(containerDir, `artifact-template-v${ARTIFACT_TEMPLATE_VERSION}`);
+	const targetDir = join(containerDir, artifactTemplateDirName());
 	mkdirSync(targetDir, { recursive: true });
 
 	for (const name of ARTIFACT_TEMPLATE_FILES) {

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1503,6 +1503,21 @@ const handlers: Record<string, Handler> = {
 		return { delivered: true, stored: 1, taskId: task.id };
 	},
 
+	/**
+	 * `dev3 artifact-template` — provision the task's pristine starter on demand
+	 * and answer with its absolute path, which the CLI then copies into the
+	 * worktree. The recovery path for a session whose `DEV3_ARTIFACT_TEMPLATE_DIR`
+	 * was baked at launch time and is therefore missing: an older app version, or
+	 * a shell that never inherited the launch env (issue #1437).
+	 */
+	"artifact.template-dir": async (params) => {
+		const { project, task } = await resolveTaskFromParams(params);
+		const worktreePath = typeof params.worktreePath === "string" && params.worktreePath ? params.worktreePath : undefined;
+		// Imported here, not at module scope: only this rarely-used route needs it.
+		const { ensureArtifactTemplate } = await import("./artifact-template");
+		return { dir: ensureArtifactTemplate(project, task, { worktreePath }), taskId: task.id, projectId: project.id };
+	},
+
 	// UI control: report what the app is currently showing, so the agent can decide
 	// whether a ping is even needed (e.g. skip if the user is already on this task).
 	"ui.state": async (params) => {

--- a/src/cli/__tests__/artifact-template.test.ts
+++ b/src/cli/__tests__/artifact-template.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleArtifactTemplate } from "../commands/artifact-template";
+import type { CliContext } from "../context";
+import type { ParsedArgs } from "../args";
+import type { CliResponse } from "../../shared/types";
+import { ARTIFACT_TEMPLATE_FILES } from "../../shared/artifact-template";
+
+vi.mock("../socket-client", () => ({
+	sendRequest: vi.fn(),
+}));
+
+import { sendRequest } from "../socket-client";
+const mockSend = vi.mocked(sendRequest);
+
+let stdoutOutput: string;
+let stderrOutput: string;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+const tempRoots: string[] = [];
+
+const SOCKET = "/tmp/test.sock";
+const TASK_ID = "aaaaaaaa-1111-2222-3333-444444444444";
+const CTX: CliContext = { projectId: "proj-001", taskId: TASK_ID, socketPath: SOCKET, worktreePath: "/wt-container/worktree" };
+
+function args(flags: Record<string, string> = {}): ParsedArgs {
+	return { positional: [], flags };
+}
+
+function okResp(dir: string): CliResponse {
+	return { id: "test-id", ok: true, data: { dir, taskId: TASK_ID, projectId: "proj-001" } };
+}
+
+function tempRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "dev3-artifact-cli-"));
+	tempRoots.push(root);
+	return root;
+}
+
+/** A pristine starter as the app would have provisioned it. */
+function starterDir(): string {
+	const dir = join(tempRoot(), "artifact-template-v1");
+	mkdirSync(dir, { recursive: true });
+	for (const name of ARTIFACT_TEMPLATE_FILES) writeFileSync(join(dir, name), `pristine ${name}`);
+	return dir;
+}
+
+/** Run the command as if the agent's cwd were a fresh worktree. */
+function inWorktree(): string {
+	const cwd = tempRoot();
+	cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
+	return cwd;
+}
+
+beforeEach(() => {
+	stdoutOutput = "";
+	stderrOutput = "";
+	stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stdoutOutput += String(chunk);
+		return true;
+	});
+	stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stderrOutput += String(chunk);
+		return true;
+	});
+	exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+		throw new Error(`EXIT_${code ?? 0}`);
+	}) as ReturnType<typeof vi.spyOn>;
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+	stderrSpy.mockRestore();
+	exitSpy.mockRestore();
+	cwdSpy?.mockRestore();
+	for (const dir of tempRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dev3 artifact-template", () => {
+	it("copies the starter into ./dev3-artifact-report and prints where it went", async () => {
+		mockSend.mockResolvedValue(okResp(starterDir()));
+		const cwd = inWorktree();
+
+		await handleArtifactTemplate(args(), SOCKET, CTX);
+
+		expect(mockSend).toHaveBeenCalledWith(
+			SOCKET,
+			"artifact.template-dir",
+			expect.objectContaining({ taskId: TASK_ID, worktreePath: "/wt-container/worktree" }),
+		);
+		const target = join(cwd, "dev3-artifact-report");
+		expect(readdirSync(target).sort()).toEqual([...ARTIFACT_TEMPLATE_FILES].sort());
+		expect(stdoutOutput).toBe(`${target}\n`);
+	});
+
+	it("restores the managed files over an existing copy", async () => {
+		mockSend.mockResolvedValue(okResp(starterDir()));
+		const cwd = inWorktree();
+		const target = join(cwd, "dev3-artifact-report");
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "app.css"), "mangled");
+		writeFileSync(join(target, "report.js"), "the agent's own work");
+
+		await handleArtifactTemplate(args(), SOCKET, CTX);
+
+		expect(readFileSync(join(target, "app.css"), "utf8")).toBe("pristine app.css");
+		expect(readFileSync(join(target, "report.js"), "utf8")).toBe("pristine report.js");
+	});
+
+	it("targets another task with --task", async () => {
+		mockSend.mockResolvedValue(okResp(starterDir()));
+		inWorktree();
+
+		await handleArtifactTemplate(args({ task: "seq:7" }), SOCKET, CTX);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "artifact.template-dir", expect.objectContaining({ taskId: "seq:7" }));
+	});
+
+	it("reports the app's failure instead of leaving a half-written copy", async () => {
+		mockSend.mockResolvedValue({ id: "test-id", ok: false, error: "Bundled dev3 artifact template not found" });
+		const cwd = inWorktree();
+
+		await expect(handleArtifactTemplate(args(), SOCKET, CTX)).rejects.toThrow("EXIT_1");
+		expect(stderrOutput).toContain("artifact template not found");
+		expect(readdirSync(cwd)).toEqual([]);
+	});
+
+	it("asks for --task when there is no task in context", async () => {
+		await expect(handleArtifactTemplate(args(), SOCKET, null)).rejects.toThrow("EXIT_3");
+		expect(stderrOutput).toContain("--task");
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});

--- a/src/cli/commands/artifact-template.ts
+++ b/src/cli/commands/artifact-template.ts
@@ -1,0 +1,48 @@
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+import { ARTIFACT_TEMPLATE_FILES } from "../../shared/artifact-template";
+import type { ParsedArgs } from "../args";
+import { expandShortId, type CliContext } from "../context";
+import { rejectUnknownFlags } from "../flag-validation";
+import { exitError, exitUsage } from "../output";
+import { sendRequest } from "../socket-client";
+
+const USAGE = "Usage: dev3 artifact-template [--task <id|seq:N>]";
+
+/** Where the copy lands, matching the path the artifact workflow already documents. */
+const TARGET_DIR_NAME = "dev3-artifact-report";
+
+/**
+ * `dev3 artifact-template` — put a fresh copy of this task's artifact starter
+ * into ./dev3-artifact-report and print where it went.
+ *
+ * `DEV3_ARTIFACT_TEMPLATE_DIR` is baked into a session's environment when the
+ * agent is launched, so a session started by an older app version — or a shell
+ * that never inherited that env — cannot reach the starter at all. This command
+ * is that recovery path (issue #1437). Re-running it restores the managed files
+ * over an existing copy.
+ */
+export async function handleArtifactTemplate(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
+	rejectUnknownFlags(args, ["task", "task-id"]);
+
+	const rawTaskId = args.flags.task || args.flags["task-id"] || context?.taskId;
+	if (!rawTaskId) exitUsage(`No task in context — pass --task.\n${USAGE}`);
+
+	const params: Record<string, unknown> = { taskId: expandShortId(String(rawTaskId), context) };
+	if (context?.projectId) params.projectId = context.projectId;
+	if (context?.worktreePath) params.worktreePath = context.worktreePath;
+
+	const response = await sendRequest(socketPath, "artifact.template-dir", params);
+	if (!response.ok) exitError(response.error || "Failed to provision the dev3 artifact starter");
+	const sourceDir = (response.data as { dir: string }).dir;
+
+	const target = resolvePath(process.cwd(), TARGET_DIR_NAME);
+	mkdirSync(target, { recursive: true });
+	for (const name of ARTIFACT_TEMPLATE_FILES) {
+		const source = join(sourceDir, name);
+		if (!existsSync(source)) exitError(`The dev3 artifact starter is incomplete — ${name} is missing from ${sourceDir}`);
+		copyFileSync(source, join(target, name));
+	}
+
+	process.stdout.write(`${target}\n`);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -422,6 +422,19 @@ const COMMANDS: CommandHelp[] = [
 		],
 	},
 	{
+		name: "artifact-template",
+		summary: "Copy this task's dev3 artifact starter into ./dev3-artifact-report.",
+		subcommands: [],
+		usage: "dev3 artifact-template [--task <id|seq:N>]",
+		details: [
+			"Provisions the pristine starter, copies it into ./dev3-artifact-report, and prints that path.",
+			"Re-running it restores the managed files over an existing copy.",
+			"Use it when $DEV3_ARTIFACT_TEMPLATE_DIR is unset: that variable is baked into the session",
+			"environment at launch, so an older session or a shell that never inherited it has no other way",
+			"to reach the starter.",
+		],
+	},
+	{
 		name: "inline-html",
 		summary: "Fold a multi-file HTML report into one self-contained file.",
 		subcommands: [],

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -25,6 +25,7 @@ import { handlePaneExec } from "./commands/pane-exec";
 import { PANE_RUN_VERB } from "../bun/pane-run-store";
 import { handleShowImage } from "./commands/show-image";
 import { handleShowArtifact } from "./commands/show-artifact";
+import { handleArtifactTemplate } from "./commands/artifact-template";
 import { handleInlineHtml } from "./commands/inline-html";
 import { handleStatusLine } from "./commands/statusline";
 import { handleCodexHook } from "./commands/codex-hook";
@@ -79,6 +80,7 @@ Commands:
   dev3 message "text" [--in <dur> | --at <hh:mm>] [--task <id>]  Send text to the task's live agent now, or schedule it (Send later)
   dev3 show-image <path> [--caption "..."] [<path> ...]  Show images (screenshots/renders) in an in-app viewer bound to the task; each --caption annotates the preceding image
   dev3 show-artifact <file.html> [--assets <file...>] [--title "..."]  Show a task-bound HTML artifact; local CSS, JS, and images are exported as ZIP
+  dev3 artifact-template [--task <id>]   Copy this task's dev3 artifact starter into ./dev3-artifact-report — recovery when $DEV3_ARTIFACT_TEMPLATE_DIR is missing
   dev3 inline-html <index.html|dir> -o <out.html> [--json]  Fold a multi-file HTML report into one self-contained file (for a gist / preview URL); refuses on missing assets or embedded credentials
   dev3 peek [--task <id>] [--pane <N|paneId>] [--lines <N>] [--json]  Read-only glance at a task's terminal: pane summary with output freshness + the tail of one pane
   dev3 pane list [--json]                Which terminal backend you are on, which panes exist, which one is yours
@@ -281,6 +283,8 @@ async function main(): Promise<void> {
 				return await handleShowImage(rawArgs.slice(1), socketPath, context);
 			case "show-artifact":
 				return await handleShowArtifact(rawArgs.slice(1), socketPath, context);
+			case "artifact-template":
+				return await handleArtifactTemplate(args, socketPath, context);
 			case "peek":
 				return await handlePeek(args, socketPath, context);
 			case "pane":

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -191,7 +191,7 @@ The layout is fixed; do not spend a turn listing or rediscovering it: \`AUTHORIN
 3. Keep the report's content and data local. External chart/UI libraries and live \`fetch\`/WebSocket integrations are allowed as documented in \`AUTHORING.md\`.
 4. Present the starter with \`dev3 show-artifact ./dev3-artifact-report/index.html --assets ./dev3-artifact-report/app.css ./dev3-artifact-report/report.js ./dev3-artifact-report/app.js ./dev3-artifact-report/dev3-icon.png --title "Report title"\`. Insert any report-specific local assets in the \`--assets\` list before \`--title\`.
 
-If the environment variable is unexpectedly missing, report that dev3 could not provision the starter instead of inventing a different template.
+If that variable is missing, run \`dev3 artifact-template\` — it copies the starter in for you. Never invent a different template.
 
 Asked to share the report **outside** the app — a link, a phone, a GitHub comment, someone else's inbox? That is a different job: load \`/dev3-share-artifact\`, which folds the multi-file report into one self-contained HTML with \`dev3 inline-html\` and publishes it as a gist with a verified preview URL.
 `;

--- a/src/shared/artifact-template.ts
+++ b/src/shared/artifact-template.ts
@@ -1,0 +1,15 @@
+export const ARTIFACT_TEMPLATE_VERSION = 1;
+
+export const ARTIFACT_TEMPLATE_FILES = [
+	"AUTHORING.md",
+	"index.html",
+	"report.js",
+	"app.css",
+	"app.js",
+	"dev3-icon.png",
+] as const;
+
+/** Directory name of the per-task starter, versioned so a new bundle never edits an old copy. */
+export function artifactTemplateDirName(): string {
+	return `artifact-template-v${ARTIFACT_TEMPLATE_VERSION}`;
+}


### PR DESCRIPTION
Fixes #1437.

`DEV3_ARTIFACT_TEMPLATE_DIR` is baked into a session's environment at launch, so a session started by an older app version — or any shell that never inherited the launch script's exports — has no way to reach the artifact starter, and the documented workflow dead-ends at "report that provisioning failed".

One command fixes it:

```
dev3 artifact-template [--task <id>]
```

It provisions the pristine starter from the bundle (new `artifact.template-dir` socket route), copies it into `./dev3-artifact-report` — the destination the artifact workflow already documents — and prints that path. Re-running it restores the managed files over an existing copy. The skill text and `AUTHORING.md` now send agents here instead of stopping.

`ARTIFACT_TEMPLATE_VERSION` / `ARTIFACT_TEMPLATE_FILES` moved to `src/shared/` so the CLI can share them.

Decision record: `decisions/2026/08/20/artifact-template-cli-recovery.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c74ff828-7f40-4cf6-a300-7dce987c93c4) · `dev3://task/c74ff828-7f40-4cf6-a300-7dce987c93c4`