### PR TITLE
Fix macOS x64 notarization: raise the staged bifrost min version

### DIFF
--- a/change-logs/2026/08/20/fix-macos-x64-notarization-bifrost-sdk.md
+++ b/change-logs/2026/08/20/fix-macos-x64-notarization-bifrost-sdk.md
@@ -1,0 +1,3 @@
+Short: Intel macOS builds ship again
+
+Fixed macOS x64 builds failing Apple notarization since the model-catalog proxy landed: the vendored bifrost binary for Intel declared an SDK of 10.4 and Apple rejects anything below 10.9, which failed the whole app archive. The staged copy now declares 10.15; arm64 was never affected.

--- a/decisions/2026/08/20/raise-bifrost-macos-min-version.md
+++ b/decisions/2026/08/20/raise-bifrost-macos-min-version.md
@@ -1,0 +1,64 @@
+# Raise the staged bifrost binary's declared macOS minimum
+
+## Context
+
+Every macOS **x64** canary publish started failing the moment the model-catalog proxy
+landed (#1391, `983a8646b`, 2026-08-20 17:06 UTC). Apple's notary returned status
+`Invalid`, `statusCode 4000`, one issue:
+
+```
+path:    dev-3.0-canary.app.zip/dev-3.0-canary.app/Contents/Resources/app/bifrost/bifrost-http
+message: The binary uses an SDK older than the 10.9 SDK.
+```
+
+A single nested binary fails the whole archive, so `.app.tar.zst` was never produced
+and the job died in `create-release-artifacts.sh`. arm64, Linux and Windows were
+unaffected.
+
+## Investigation
+
+`otool -l` on the pinned vendor downloads:
+
+| Target | Version load command | Declares |
+|---|---|---|
+| `darwin/amd64` v1.6.10 | `LC_VERSION_MIN_MACOSX` | version 10.4, **sdk 10.4** |
+| `darwin/amd64` v1.6.11 | `LC_VERSION_MIN_MACOSX` | version 10.4, **sdk 10.4** |
+| `darwin/arm64` v1.6.10 | `LC_BUILD_VERSION` | minos 11.0, sdk 11.0 |
+
+So it is the vendor's amd64 toolchain, not our packaging, and bumping the pin does
+not help — v1.6.11 has the identical header. The binary is unsigned, so there is no
+signature to invalidate by editing it.
+
+## Decision
+
+`scripts/stage-bifrost.ts` raises the declared minimum to **10.15** on the staged
+copy (`dist/bifrost/`), using `raiseMinMacOSVersion` in `src/bun/macho-min-version.ts`.
+10.15 rather than Apple's 10.9 floor because Go's own darwin/amd64 runtime requires
+10.15 — declaring less would be a lie the loader could act on.
+
+Two design points:
+
+- **The staged copy, never `vendor/`.** `fetch-bifrost.ts` keeps checking the pristine
+  download against `scripts/bifrost-pinned.json`, so the supply-chain pin stays honest.
+- **Two uint32s in place, not `vtool`.** `vtool -set-version-min` reaches the same
+  declared version but reorders the load-command table (311 bytes differ on the real
+  binary); `vtool -replace` swaps in a 32-byte `LC_BUILD_VERSION` and needs headerpad.
+  Our edit changes 2 bytes, moves no offset, and needs no Xcode CLT. Verified with
+  Apple's own `otool -l`, and the patched binary still runs (`--help`, exit 0).
+
+## Risks
+
+- Intel macOS older than 10.15 would refuse to load the sidecar. Not a real loss: the
+  Go runtime inside it already requires 10.15.
+- If the vendor later ships a proper `LC_BUILD_VERSION`, the patch becomes a silent
+  no-op — `raiseMinMacOSVersion` returns null and nothing is written.
+- The real proof is a notary round trip, which only CI can run.
+
+## Alternatives considered
+
+1. **Bump the pin** — checked, v1.6.11 has the same 10.4 header.
+2. **Drop the sidecar on darwin-x64** — kills the model catalog for every Intel Mac.
+3. **Build bifrost from source in CI** — needs a Go toolchain per runner and throws away
+   the checksum pin, for a two-byte header field.
+4. **Upstream fix** — asked for separately if it comes to that; it cannot unblock today's
+   releases.

--- a/scripts/stage-bifrost.ts
+++ b/scripts/stage-bifrost.ts
@@ -9,13 +9,36 @@
  * "no proxy in this build" instead of crashing.
  */
 
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { bifrostTarget } from "../src/shared/bifrost-release";
+import { formatVersion, raiseMinMacOSVersion, readMinMacOSVersion } from "../src/bun/macho-min-version";
 
 const ROOT = resolve(import.meta.dir, "..");
 const VENDOR_DIR = `${ROOT}/vendor/bifrost`;
 const DIST_DIR = `${ROOT}/dist/bifrost`;
+
+/** What the staged macOS binary must declare. Apple's notary floor is 10.9;
+ *  Go's own darwin/amd64 runtime needs 10.15, so declaring less would lie. */
+const STAGED_MIN_MACOS = { major: 10, minor: 15 };
+
+/**
+ * The vendor's darwin/amd64 build declares `sdk 10.4`, which makes Apple's notary
+ * reject the ENTIRE app archive ("The binary uses an SDK older than the 10.9 SDK").
+ * Patched on the staged copy, never in vendor/, so fetch-bifrost.ts still checks the
+ * pristine bytes against the pin. See decisions/2026/08/20/raise-bifrost-macos-min-version.md.
+ */
+function patchDarwinMinVersion(binaryPath: string): void {
+	const raw = new Uint8Array(readFileSync(binaryPath));
+	const before = readMinMacOSVersion(raw);
+	if (!before || before.commandOffset === null) return;
+	const patched = raiseMinMacOSVersion(raw, STAGED_MIN_MACOS.major, STAGED_MIN_MACOS.minor);
+	if (!patched) return;
+	writeFileSync(binaryPath, patched, { mode: 0o755 });
+	console.log(
+		`[stage-bifrost] raised declared macOS minimum ${formatVersion(before.sdk ?? 0)} -> ${STAGED_MIN_MACOS.major}.${STAGED_MIN_MACOS.minor} (Apple notary rejects below 10.9)`,
+	);
+}
 
 export function stageBifrost(): boolean {
 	const target = bifrostTarget(process.platform, process.arch);
@@ -27,6 +50,7 @@ export function stageBifrost(): boolean {
 	rmSync(DIST_DIR, { recursive: true, force: true });
 	// The whole directory travels: the binary plus its licence notices.
 	cpSync(VENDOR_DIR, DIST_DIR, { recursive: true });
+	if (target.platform === "darwin") patchDarwinMinVersion(`${DIST_DIR}/${target.binaryName}`);
 	console.log(`[stage-bifrost] staged dist/bifrost/${target.binaryName}`);
 	return true;
 }

--- a/src/bun/__tests__/macho-min-version.test.ts
+++ b/src/bun/__tests__/macho-min-version.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatVersion,
+	packVersion,
+	raiseMinMacOSVersion,
+	readMinMacOSVersion,
+} from "../macho-min-version";
+
+const MH_MAGIC_64 = 0xfeedfacf;
+const LC_VERSION_MIN_MACOSX = 0x24;
+const LC_BUILD_VERSION = 0x32;
+const LC_SOURCE_VERSION = 0x2a;
+
+/**
+ * Minimal 64-bit little-endian Mach-O carrying one version load command plus a
+ * trailing LC_SOURCE_VERSION, so the walk has to step over a neighbour to find it.
+ */
+function buildMachO(opts: { versionMin?: number; buildVersion?: boolean } = {}): Uint8Array {
+	const { versionMin, buildVersion = false } = opts;
+	const versionCmdSize = buildVersion ? 32 : versionMin !== undefined ? 16 : 0;
+	const sizeofcmds = versionCmdSize + 16;
+	const ncmds = (versionCmdSize > 0 ? 1 : 0) + 1;
+	const data = new Uint8Array(32 + sizeofcmds + 64);
+	const view = new DataView(data.buffer);
+
+	view.setUint32(0, MH_MAGIC_64, true);
+	view.setUint32(4, 0x01000007, true); // CPU_TYPE_X86_64
+	view.setUint32(12, 2, true); // MH_EXECUTE
+	view.setUint32(16, ncmds, true);
+	view.setUint32(20, sizeofcmds, true);
+
+	let off = 32;
+	if (buildVersion) {
+		view.setUint32(off, LC_BUILD_VERSION, true);
+		view.setUint32(off + 4, 32, true);
+		view.setUint32(off + 8, 1, true); // PLATFORM_MACOS
+		view.setUint32(off + 12, packVersion(11, 0), true);
+		view.setUint32(off + 16, packVersion(11, 0), true);
+		off += 32;
+	} else if (versionMin !== undefined) {
+		view.setUint32(off, LC_VERSION_MIN_MACOSX, true);
+		view.setUint32(off + 4, 16, true);
+		view.setUint32(off + 8, versionMin, true);
+		view.setUint32(off + 12, versionMin, true);
+		off += 16;
+	}
+	view.setUint32(off, LC_SOURCE_VERSION, true);
+	view.setUint32(off + 4, 16, true);
+	return data;
+}
+
+describe("packVersion / formatVersion", () => {
+	it("round-trips the xxxx.yy.zz encoding", () => {
+		expect(packVersion(10, 4)).toBe(0x000a0400);
+		expect(packVersion(10, 15)).toBe(0x000a0f00);
+		expect(formatVersion(packVersion(10, 4))).toBe("10.4");
+		expect(formatVersion(packVersion(13, 2, 1))).toBe("13.2.1");
+	});
+});
+
+describe("readMinMacOSVersion", () => {
+	it("finds LC_VERSION_MIN_MACOSX past a neighbouring command", () => {
+		const info = readMinMacOSVersion(buildMachO({ versionMin: packVersion(10, 4) }));
+		expect(info?.commandOffset).toBe(32);
+		expect(formatVersion(info?.sdk ?? 0)).toBe("10.4");
+		expect(info?.hasBuildVersion).toBe(false);
+	});
+
+	it("reports LC_BUILD_VERSION instead, as the arm64 build carries", () => {
+		const info = readMinMacOSVersion(buildMachO({ buildVersion: true }));
+		expect(info?.hasBuildVersion).toBe(true);
+		expect(info?.commandOffset).toBeNull();
+	});
+
+	it("returns null for anything that is not a thin 64-bit Mach-O", () => {
+		expect(readMinMacOSVersion(new Uint8Array([1, 2, 3]))).toBeNull();
+		expect(readMinMacOSVersion(new Uint8Array(64))).toBeNull();
+	});
+});
+
+describe("raiseMinMacOSVersion", () => {
+	it("raises 10.4 to the target and touches nothing else", () => {
+		const original = buildMachO({ versionMin: packVersion(10, 4) });
+		const patched = raiseMinMacOSVersion(original, 10, 15);
+		expect(patched).not.toBeNull();
+
+		const info = readMinMacOSVersion(patched!);
+		expect(formatVersion(info?.version ?? 0)).toBe("10.15");
+		expect(formatVersion(info?.sdk ?? 0)).toBe("10.15");
+
+		// Exactly the two uint32s changed — the same 8 bytes the real binary needs.
+		const differing = [...patched!].filter((byte, i) => byte !== original[i]).length;
+		expect(differing).toBeLessThanOrEqual(8);
+		expect(patched!.byteLength).toBe(original.byteLength);
+	});
+
+	it("is a no-op when the binary already declares enough", () => {
+		const already = buildMachO({ versionMin: packVersion(11, 0) });
+		expect(raiseMinMacOSVersion(already, 10, 15)).toBeNull();
+	});
+
+	it("never lowers a version", () => {
+		const high = buildMachO({ versionMin: packVersion(14, 0) });
+		expect(raiseMinMacOSVersion(high, 10, 15)).toBeNull();
+	});
+
+	it("leaves an LC_BUILD_VERSION binary alone", () => {
+		expect(raiseMinMacOSVersion(buildMachO({ buildVersion: true }), 10, 15)).toBeNull();
+	});
+
+	it("ignores non-Mach-O input", () => {
+		expect(raiseMinMacOSVersion(new Uint8Array([0xde, 0xad, 0xbe, 0xef]), 10, 15)).toBeNull();
+	});
+});

--- a/src/bun/macho-min-version.ts
+++ b/src/bun/macho-min-version.ts
@@ -1,0 +1,103 @@
+/**
+ * Raise the declared minimum macOS version of a Mach-O binary.
+ *
+ * Apple's notary service rejects any nested binary whose declared SDK is older
+ * than 10.9 ("The binary uses an SDK older than the 10.9 SDK.", status 4000) and
+ * fails the WHOLE archive. The vendored bifrost proxy's darwin/amd64 build ships
+ * `LC_VERSION_MIN_MACOSX version 10.4 sdk 10.4`; its arm64 build carries a modern
+ * LC_BUILD_VERSION, which is why only Intel notarization died.
+ *
+ * Rewriting the two uint32s in place touches exactly 8 bytes and moves nothing.
+ * Apple's own `vtool -set-version-min` reaches the same declared version but
+ * REORDERS the load-command table on the way (311 bytes differ on the real
+ * binary), and `vtool -replace` would swap in a 32-byte LC_BUILD_VERSION, which
+ * needs headerpad this binary has no guarantee of. Verified against `otool -l`.
+ */
+
+const MH_MAGIC_64 = 0xfeedfacf;
+const MACH_HEADER_SIZE = 32;
+const LC_VERSION_MIN_MACOSX = 0x24;
+const LC_BUILD_VERSION = 0x32;
+/** Apple's floor. A binary at or above this notarizes. */
+export const NOTARIZATION_MIN_MACOS = { major: 10, minor: 9 };
+
+export interface MinVersionInfo {
+	/** File offset of the LC_VERSION_MIN_MACOSX command, or null when absent. */
+	commandOffset: number | null;
+	/** Packed `version` field, or null. */
+	version: number | null;
+	/** Packed `sdk` field, or null. */
+	sdk: number | null;
+	/** A modern LC_BUILD_VERSION is present — nothing to raise. */
+	hasBuildVersion: boolean;
+}
+
+/** Packs X.Y.Z into the Mach-O `xxxx.yy.zz` uint32 encoding. */
+export function packVersion(major: number, minor: number, patch = 0): number {
+	return ((major & 0xffff) << 16) | ((minor & 0xff) << 8) | (patch & 0xff);
+}
+
+/** Reads the version load commands. Returns null for anything that is not a
+ *  thin 64-bit little-endian Mach-O — callers treat that as "not ours". */
+export function readMinMacOSVersion(data: Uint8Array): MinVersionInfo | null {
+	if (data.byteLength < MACH_HEADER_SIZE) return null;
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	if (view.getUint32(0, true) !== MH_MAGIC_64) return null;
+
+	const ncmds = view.getUint32(16, true);
+	const loadCommandsEnd = MACH_HEADER_SIZE + view.getUint32(20, true);
+	if (loadCommandsEnd > data.byteLength) return null;
+
+	const info: MinVersionInfo = {
+		commandOffset: null,
+		version: null,
+		sdk: null,
+		hasBuildVersion: false,
+	};
+	let off = MACH_HEADER_SIZE;
+	for (let i = 0; i < ncmds; i++) {
+		if (off + 8 > loadCommandsEnd) return null;
+		const cmd = view.getUint32(off, true);
+		const cmdsize = view.getUint32(off + 4, true);
+		if (cmdsize < 8 || off + cmdsize > loadCommandsEnd) return null;
+		if (cmd === LC_VERSION_MIN_MACOSX && cmdsize >= 16) {
+			info.commandOffset = off;
+			info.version = view.getUint32(off + 8, true);
+			info.sdk = view.getUint32(off + 12, true);
+		} else if (cmd === LC_BUILD_VERSION) {
+			info.hasBuildVersion = true;
+		}
+		off += cmdsize;
+	}
+	return info;
+}
+
+/**
+ * Returns a copy with `version` and `sdk` raised to the target, or null when
+ * nothing had to change (already high enough, LC_BUILD_VERSION, not a Mach-O).
+ * Never lowers a version.
+ */
+export function raiseMinMacOSVersion(
+	data: Uint8Array,
+	major: number,
+	minor: number,
+): Uint8Array | null {
+	const info = readMinMacOSVersion(data);
+	if (!info || info.commandOffset === null) return null;
+	const target = packVersion(major, minor);
+	if ((info.version ?? 0) >= target && (info.sdk ?? 0) >= target) return null;
+
+	const patched = new Uint8Array(data);
+	const view = new DataView(patched.buffer);
+	if ((info.version ?? 0) < target) view.setUint32(info.commandOffset + 8, target, true);
+	if ((info.sdk ?? 0) < target) view.setUint32(info.commandOffset + 12, target, true);
+	return patched;
+}
+
+/** Human-readable "10.4" from the packed encoding. */
+export function formatVersion(packed: number): string {
+	const patch = packed & 0xff;
+	const minor = (packed >> 8) & 0xff;
+	const major = packed >> 16;
+	return patch === 0 ? `${major}.${minor}` : `${major}.${minor}.${patch}`;
+}


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

Every macOS **x64** publish has failed notarization since the model-catalog proxy landed (#1391). Apple returns `Invalid` / `statusCode 4000` with one issue:

```
path:    .../Contents/Resources/app/bifrost/bifrost-http
message: The binary uses an SDK older than the 10.9 SDK.
```

The vendored `bifrost-http` for `darwin/amd64` declares `LC_VERSION_MIN_MACOSX version 10.4 sdk 10.4` (confirmed with `otool -l` on both v1.6.10 and v1.6.11, so bumping the pin does not help). The arm64 build carries a modern `LC_BUILD_VERSION`, which is why only Intel died. One bad nested binary fails the whole archive, so `.app.tar.zst` was never produced.

`scripts/stage-bifrost.ts` now raises the declared minimum to 10.15 on the **staged** copy only — `vendor/` stays pristine, so `fetch-bifrost.ts` still verifies the real download against the checksum pin. The edit rewrites two uint32s in place (2 bytes change, nothing moves); `vtool` would reorder the load-command table instead. Verified against `otool -l`, and the patched Intel binary still runs.

Rationale and alternatives: `decisions/2026/08/20/raise-bifrost-macos-min-version.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=67cbe361-d74d-49ed-af28-e218080fd32d) · `dev3://task/67cbe361-d74d-49ed-af28-e218080fd32d`