### PR TITLE
Add a text-size control to the dev3 artifact starter

### DIFF
--- a/change-logs/2026/08/20/feature-40-artifact-text-size-control.md
+++ b/change-logs/2026/08/20/feature-40-artifact-text-size-control.md
@@ -1,0 +1,3 @@
+Short: Resize text in any artifact
+
+The dev3 artifact starter now carries an A− / A+ text-size control beside the theme toggle: eight stops from 80% to 150%, the percentage readout doubles as reset, and the choice is remembered per browser. Every part of the report follows it — text, tables, KPI figures, chart labels and heights, checkboxes, switches, sliders, Choices dropdowns, and print output — because the shell is sized in rem/em and the chart bridge rescales every ECharts `fontSize` before rendering.

--- a/decisions/2026/08/20/artifact-text-size-root-rem-scale.md
+++ b/decisions/2026/08/20/artifact-text-size-root-rem-scale.md
@@ -1,0 +1,27 @@
+# Artifact text size is one root rem scale, not a zoom
+
+## Context
+
+An artifact is read inside dev3's sandboxed iframe, where the browser's own zoom belongs to the whole app, not to the report. Readers wanted the report's text bigger (or denser) on its own, so the starter needed a text-size control that every part of a report obeys — including ECharts, Choices, and noUiSlider, which dev3 does not own.
+
+## Investigation
+
+Three approaches were compared. CSS `zoom` on `.app` scales everything for free but leaves top-layer popovers, the toast, and fixed overlay placement outside the scaled subtree, and it fights the shell's own `getBoundingClientRect()` placement maths. A per-component size class multiplies the surface that has to remember the setting. A single root scale plus relative units touches every rule once and then needs no further maintenance.
+
+Vendor CSS decided the third option was viable: Choices 11 sizes its chips, search field, and select hint from `--choices-font-size-lg/md/sm`, so handing it rem values scales parts dev3 never styles. noUiSlider hardcodes only `.noUi-value-sub`, which the shell overrides anyway.
+
+## Decision
+
+`app.css` sets `html { font-size: calc(100% * var(--dev3-font-scale)) }` and every font size in the sheet is a rem — `em` where a glyph belongs to its own label (checkbox, radio, switch, slider handle, status dot). `app.js` owns eight steps from 0.8 to 1.5 (`FONT_SCALE_STEPS`), writes `--dev3-font-scale-user` on `<html>`, and persists to `localStorage` best-effort — the sandbox's opaque origin makes that throw, so the preference simply does not survive there.
+
+ECharts sizes are raw numbers, so `scaleOptionFonts()` in `app.js` rewrites every `fontSize` in an option tree before `setOption`, copying plain branches and passing functions and primitive data arrays through by reference. A scale change re-registers the chart theme and remounts, re-measures the sticky table-header offset, and repositions open overlays.
+
+Print follows the scale rather than resetting to 100%: the print rules are the same rem values, and `--dev3-print-chart-height` defaults to `9.6875rem` so enlarged chart labels get proportionally taller charts instead of colliding.
+
+## Risks
+
+A report that hardcodes a px font size in `index.html` or `report.js` stays at 100% while the page grows; `AUTHORING.md` forbids it and two tests assert `app.css` itself contains no px font size (`artifact-template.test.ts`, `artifactTemplateRuntime.test.ts`). `scaleOptionFonts` clones plain objects on every render, so a pathological option tree of nested objects (not data arrays, which are passed through) pays a small allocation cost.
+
+## Alternatives considered
+
+CSS `zoom` (breaks top-layer overlays and the shell's placement maths); scaling only `body` font-size (rem-based rules elsewhere would ignore it); resetting the scale for print (leaves half the print sheet scaled and half not, since print declares its own sizes).

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -34,6 +34,17 @@ Do not read or edit `app.css` or `app.js` unless the artifact format itself must
 
 The container grows with the viewport up to 1840px, so dense tables and dashboards use a wide monitor instead of leaving it empty. Because the panels are wide, put running prose in `<p class="prose">` (or any `.prose` block) to hold a readable line length; short `.muted` and `.section-copy` lines are capped for you. `.kpis` fits as many cards per row as the width allows, so a report may ship three or six KPI cards without a layout override.
 
+## Text size
+
+The topbar carries an `A− / 100% / A+` group beside the theme button. It steps the whole report between 80% and 150% in ten-point stops, the percentage doubles as the reset button, and the choice is remembered per browser (silently skipped in the sandboxed viewer, whose opaque origin has no storage). Keep the control in `.actions`.
+
+Everything in `app.css` is sized in `rem`, or in `em` for a glyph that belongs to its own label, so one root scale carries text, chart heights, checkboxes, switches, sliders, and the Choices dropdowns with it. Print follows the same scale — an enlarged report prints enlarged.
+
+Two rules for report code:
+
+- Never write a px font size in `index.html` or `report.js`. Use the shell's classes, or `rem` if a one-off is unavoidable.
+- Chart options are exempt: the shell rescales every `fontSize` number in an option tree before ECharts sees it, so `fontSize: 12` in `report.js` stays correct at every scale. Use `dev3Artifact.scaleFont(px)` for a px number ECharts does not read from `fontSize` (an `itemHeight`, a `grid.left` sized for labels), and `dev3Artifact.fontScale()` for the raw multiplier.
+
 ## Preview and share
 
 Pass every local dependency explicitly after `--assets`:
@@ -60,7 +71,7 @@ The starter already pins ECharts 6.1.0, Choices.js 11.2.3, and noUiSlider 15.8.1
 
 `index.html` loads Apache ECharts 6.1.0 through a versioned cdnjs tag. Keep that tag intact when the report has charts. Offline, chart hosts show a notice while the rest of the report remains usable.
 
-The stable bridge lives in `app.js` and exposes `window.dev3Artifact.chart()`, `.color()`, `.enhance()`, `.popover()`, `.setControl()`, and `.toast()`. Keep chart options, values, labels, filters, and interactions in `report.js`; use the exposed helpers there without editing the shell. The chart helper applies dev3 tokens, uses the SVG renderer for crisp print/PDF output, adds aria descriptions, re-renders on theme changes, and resizes with its container.
+The stable bridge lives in `app.js` and exposes `window.dev3Artifact.chart()`, `.color()`, `.enhance()`, `.fontScale()`, `.popover()`, `.scaleFont()`, `.setControl()`, and `.toast()`. Keep chart options, values, labels, filters, and interactions in `report.js`; use the exposed helpers there without editing the shell. The chart helper applies dev3 tokens, uses the SVG renderer for crisp print/PDF output, adds aria descriptions, re-renders on theme changes, and resizes with its container.
 
 The shell declares the card surface as each chart's `backgroundColor`, because ECharts derives value-label contrast from it — without that, every label renders dark grey inside a white halo, which is illegible on the dark theme. Keep report code out of that decision: do not set `backgroundColor` or hand-color value labels unless the chart sits on a surface other than `--dev3-surface-raised`.
 
@@ -138,7 +149,7 @@ Choose Auto, Light, or Dark in the report, then print with Cmd/Ctrl+P. The style
 - Keep `data-dev3-artifact-template="v1"` on `<html>`.
 - Keep the dev3 icon and a `DEV3 ARTIFACT · <CATEGORY>` eyebrow.
 - Keep `Built with dev3 Artifacts` in the footer.
-- Keep the Auto → Light → Dark theme control.
+- Keep the Auto → Light → Dark theme control and the `A− / 100% / A+` text-size control.
 - Keep local navigation functional: a click must scroll, focus the section heading, and expose `aria-current`.
 - Use only the bundled `--dev3-*` semantic tokens for color, and the `--dev3-z-*` tokens for stacking.
 - Route every panel that opens over the report through `.popover` / `dev3Artifact.popover()`; never hand-roll an absolutely positioned menu.

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -2,18 +2,21 @@
     /* One scale for everything that stacks, so no panel has to guess a number.
        Overlays live in the browser top layer, so their z-index only orders them
        against each other. */
-    :root { --dev3-z-nav: 20; --dev3-z-overlay: 900; --dev3-z-toast: 1000; }
+    :root { --dev3-font-scale: var(--dev3-font-scale-user, 1); --dev3-z-nav: 20; --dev3-z-overlay: 900; --dev3-z-toast: 1000; }
     html, body {
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
     }
-    html { scroll-behavior: smooth; }
+    /* Every font size in this sheet is a rem, so the text-size control moves one
+       number here and the whole report follows. Starting from 100% instead of a
+       px base keeps the reader's own browser font setting intact. */
+    html { scroll-behavior: smooth; font-size: calc(100% * var(--dev3-font-scale)); }
     body {
       margin: 0;
       padding: 24px;
       background: rgb(var(--dev3-surface-base));
       color: rgb(var(--dev3-text-primary));
-      font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font: .875rem/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
     .sr-only {
       position: absolute;
@@ -37,15 +40,22 @@
     .topbar { justify-content: space-between; gap: 20px; margin-bottom: 6px; }
     .brand { gap: 13px; }
     .brand img {
-      width: 48px;
-      height: 48px;
+      width: 3rem;
+      height: 3rem;
       border-radius: 14px;
       box-shadow: 0 10px 28px rgb(var(--dev3-accent) / .22);
     }
-    h1 { margin: 0; font-size: 22px; line-height: 1.15; letter-spacing: -.03em; }
+    h1 { margin: 0; font-size: 1.375rem; line-height: 1.15; letter-spacing: -.03em; }
     .eyebrow, .muted { color: rgb(var(--dev3-text-secondary)); }
-    .eyebrow { margin-bottom: 3px; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
-    .actions { gap: 8px; }
+    .eyebrow { margin-bottom: 3px; font-size: .6875rem; letter-spacing: .1em; text-transform: uppercase; }
+    /* A squeezed action row must lose a whole control to the next line, never
+       fold one control's label into two — a wrapped pill turns into an oval and
+       a wrapped button changes height. */
+    /* stretch, so the status pill, the segmented group, and the buttons share one
+       height at every text size instead of each computing its own. */
+    .actions { align-items: stretch; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+    .actions > * { flex: 0 0 auto; }
+    .actions button, .actions .status { white-space: nowrap; }
     .section-nav {
       position: sticky;
       z-index: var(--dev3-z-nav);
@@ -71,7 +81,7 @@
       padding: 9px 13px;
       border-radius: 9px;
       color: rgb(var(--dev3-text-secondary));
-      font-size: 12px;
+      font-size: .75rem;
       font-weight: 650;
       text-decoration: none;
       transition: background .18s ease, color .18s ease, box-shadow .18s ease;
@@ -82,7 +92,7 @@
       box-shadow: inset 0 0 0 1px rgb(var(--dev3-accent) / .28);
       color: rgb(var(--dev3-accent));
     }
-    .section-anchor { scroll-margin-top: 68px; }
+    .section-anchor { scroll-margin-top: 4.25rem; }
     .status {
       display: inline-flex;
       align-items: center;
@@ -92,11 +102,14 @@
       border-radius: 999px;
       background: rgb(var(--dev3-success) / .08);
       color: rgb(var(--dev3-success));
-      font-size: 12px;
+      font-size: .75rem;
     }
+    /* flex: 0 0 auto, or a tight row shrinks the width but not the height and the
+       circle reads as an ellipse. */
     .dot {
-      width: 7px;
-      height: 7px;
+      flex: 0 0 auto;
+      width: .58em;
+      height: .58em;
       border-radius: 50%;
       background: rgb(var(--dev3-success));
       box-shadow: 0 0 0 4px rgb(var(--dev3-success) / .12);
@@ -112,6 +125,8 @@
       transition: .16s ease;
     }
     button:hover { border-color: rgb(var(--dev3-accent) / .65); transform: translateY(-1px); }
+    button:disabled { opacity: .42; cursor: default; }
+    button:disabled:hover { border-color: rgb(var(--dev3-border)); transform: none; }
     button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, th:focus-visible,
     .choices.is-focused .choices__inner, .noUi-handle:focus-visible {
       outline: 2px solid rgb(var(--dev3-accent));
@@ -130,7 +145,7 @@
       color: rgb(var(--dev3-accent));
     }
     .grid { display: grid; gap: 14px; }
-    .kpis { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .kpis { grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); }
     .stack { display: grid; gap: 14px; }
     .card {
       padding: 16px;
@@ -145,12 +160,12 @@
       justify-content: space-between;
       gap: 10px;
       color: rgb(var(--dev3-text-secondary));
-      font-size: 11px;
+      font-size: .6875rem;
       letter-spacing: .06em;
       text-transform: uppercase;
     }
-    .kpi-value { margin: 8px 0 3px; font-size: 29px; font-weight: 760; letter-spacing: -.04em; }
-    .trend { color: rgb(var(--dev3-success)); font-size: 12px; }
+    .kpi-value { margin: 8px 0 3px; font-size: 1.8125rem; font-weight: 760; letter-spacing: -.04em; }
+    .trend { color: rgb(var(--dev3-success)); font-size: .75rem; }
     .trend.warn { color: rgb(var(--dev3-warning)); }
     .dashboard-grid {
       display: grid;
@@ -171,8 +186,8 @@
       gap: 12px;
       margin-bottom: 16px;
     }
-    .section-title { margin: 0; font-size: 15px; font-weight: 700; }
-    .section-copy { margin-top: 2px; color: rgb(var(--dev3-text-secondary)); font-size: 12px; }
+    .section-title { margin: 0; font-size: .9375rem; font-weight: 700; }
+    .section-copy { margin-top: 2px; color: rgb(var(--dev3-text-secondary)); font-size: .75rem; }
     .segmented {
       gap: 3px;
       padding: 3px;
@@ -181,10 +196,16 @@
       background: rgb(var(--dev3-surface-base));
     }
     .segmented button { padding: 6px 9px; border: 0; background: transparent; }
+    /* The readout is the reset button, so the group needs no fourth control. Its
+       width is fixed in ch so stepping 90% → 100% cannot shift the topbar. */
+    .text-size button { min-height: 30px; font-weight: 700; }
+    .text-size button[data-font-step="-1"] { font-size: .8125rem; }
+    .text-size button[data-font-step="1"] { font-size: 1.0625rem; }
+    .text-size .text-size-value { min-width: 4ch; color: rgb(var(--dev3-text-secondary)); font-size: .6875rem; font-variant-numeric: tabular-nums; }
     .segmented button.active { background: rgb(var(--dev3-accent)); color: rgb(var(--dev3-on-accent)); }
-    .chart-host { position: relative; height: 250px; overflow: hidden; }
+    .chart-host { position: relative; height: 15.625rem; overflow: hidden; }
     .chart-host svg { max-width: 100%; }
-    html.printing .chart-host { height: var(--dev3-print-chart-height, 155px); }
+    html.printing .chart-host { height: var(--dev3-print-chart-height, 9.6875rem); }
     html.printing .chart-host > div, html.printing .chart-host svg { width: 100% !important; height: 100% !important; }
     .chart-unavailable {
       display: flex;
@@ -195,7 +216,7 @@
       border: 1px dashed rgb(var(--dev3-border));
       border-radius: 12px;
       color: rgb(var(--dev3-text-muted));
-      font-size: 12px;
+      font-size: .75rem;
       text-align: center;
     }
     .controls { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
@@ -203,7 +224,7 @@
     .field.full { grid-column: 1 / -1; }
     .field label, .option-group legend {
       color: rgb(var(--dev3-text-secondary));
-      font-size: 11px;
+      font-size: .6875rem;
       letter-spacing: .05em;
       text-transform: uppercase;
     }
@@ -214,7 +235,7 @@
       border-radius: 999px;
       background: rgb(var(--dev3-accent) / .09);
       color: rgb(var(--dev3-accent));
-      font-size: 11px;
+      font-size: .6875rem;
       font-weight: 750;
       letter-spacing: 0;
       text-transform: none;
@@ -250,8 +271,10 @@
       white-space: nowrap;
       border: 0;
     }
-    .ui-range-control { height: 34px; margin: 7px 11px 18px; border: 0; background: transparent; box-shadow: none; }
-    .ui-range-control.noUi-horizontal { height: 7px; }
+    /* Slider geometry is em, so the handle stays a comfortable target next to
+       enlarged text instead of turning into a dot. */
+    .ui-range-control { height: 2.43em; margin: .5em .79em 1.29em; border: 0; background: transparent; box-shadow: none; }
+    .ui-range-control.noUi-horizontal { height: .5em; }
     .ui-range-control .noUi-base {
       border-radius: 999px;
       background: rgb(var(--dev3-border) / .72);
@@ -263,10 +286,10 @@
       box-shadow: 0 0 18px rgb(var(--dev3-accent) / .22);
     }
     .ui-range-control .noUi-handle {
-      top: -9px;
-      right: -13px;
-      width: 26px;
-      height: 26px;
+      top: -.64em;
+      right: -.93em;
+      width: 1.86em;
+      height: 1.86em;
       border: 2px solid rgb(var(--dev3-surface-raised));
       border-radius: 50%;
       background: rgb(var(--dev3-accent));
@@ -278,14 +301,14 @@
     .ui-range-control .noUi-handle::after { display: none; }
     .ui-range-control .noUi-touch-area { border-radius: inherit; }
     .ui-range-control .noUi-tooltip {
-      bottom: 34px;
+      bottom: 2.43em;
       padding: 4px 7px;
       border: 1px solid rgb(var(--dev3-border));
       border-radius: 7px;
       background: rgb(var(--dev3-surface-elevated));
       color: rgb(var(--dev3-text-primary));
       box-shadow: 0 6px 18px rgb(var(--dev3-shadow) / .2);
-      font-size: 10px;
+      font-size: .625rem;
       font-weight: 700;
       opacity: 0;
       transform: translate(-50%, 3px);
@@ -294,10 +317,10 @@
     .ui-range-control .noUi-handle:hover .noUi-tooltip,
     .ui-range-control .noUi-handle:focus .noUi-tooltip,
     .ui-range-control .noUi-active .noUi-tooltip { opacity: 1; transform: translate(-50%, 0); }
-    .ui-range-control .noUi-pips-horizontal { top: 11px; height: 22px; padding: 0; }
+    .ui-range-control .noUi-pips-horizontal { top: .79em; height: 1.57em; padding: 0; }
     .ui-range-control .noUi-marker-horizontal.noUi-marker { width: 1px; height: 4px; background: rgb(var(--dev3-border)); }
-    .ui-range-control .noUi-value-horizontal { top: 6px; color: rgb(var(--dev3-text-muted)); font-size: 9px; transform: translateX(-50%); }
-    .range-label { display: flex; justify-content: space-between; color: rgb(var(--dev3-text-secondary)); font-size: 11px; }
+    .ui-range-control .noUi-value-horizontal { top: 6px; color: rgb(var(--dev3-text-muted)); font-size: .5625rem; transform: translateX(-50%); }
+    .range-label { display: flex; justify-content: space-between; color: rgb(var(--dev3-text-secondary)); font-size: .6875rem; }
     .choice-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
     .option-group { min-width: 0; padding: 0; margin: 0; border: 0; }
     .option-group legend { margin-bottom: 6px; }
@@ -311,18 +334,20 @@
       border-radius: 10px;
       background: rgb(var(--dev3-surface-base));
       color: rgb(var(--dev3-text-secondary));
-      font-size: 12px;
+      font-size: .75rem;
       cursor: pointer;
       transition: border-color .16s ease, background .16s ease, color .16s ease;
     }
     .check:hover, .switch:hover { border-color: rgb(var(--dev3-accent) / .48); color: rgb(var(--dev3-text-primary)); }
     .check:has(input:checked), .switch:has(input:checked) { border-color: rgb(var(--dev3-accent) / .34); background: rgb(var(--dev3-accent) / .055); }
+    /* Control glyphs are sized in em, so a checkbox, radio, or switch grows with
+       the label beside it instead of shrinking against enlarged text. */
     .check input {
       appearance: none;
       display: grid;
       flex: 0 0 auto;
-      width: 18px;
-      height: 18px;
+      width: 1.5em;
+      height: 1.5em;
       padding: 0;
       place-items: center;
       border: 1px solid rgb(var(--dev3-border));
@@ -331,28 +356,39 @@
       box-shadow: none;
     }
     .check input[type="radio"] { border-radius: 50%; }
-    .check input[type="radio"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); box-shadow: inset 0 0 0 4px rgb(var(--dev3-surface-raised)); }
+    .check input[type="radio"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); box-shadow: inset 0 0 0 .33em rgb(var(--dev3-surface-raised)); }
     .check input[type="checkbox"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); }
-    .check input[type="checkbox"]:checked::after { width: 8px; height: 4px; border: solid rgb(var(--dev3-on-accent)); border-width: 0 0 2px 2px; content: ""; transform: translateY(-1px) rotate(-45deg); }
+    .check input[type="checkbox"]:checked::after { width: .66em; height: .33em; border: solid rgb(var(--dev3-on-accent)); border-width: 0 0 2px 2px; content: ""; transform: translateY(-1px) rotate(-45deg); }
     .switch input { position: absolute; width: 1px; height: 1px; opacity: 0; }
-    .switch > span { position: relative; flex: 0 0 auto; width: 38px; height: 22px; border-radius: 999px; background: rgb(var(--dev3-border)); transition: background .18s ease; }
-    .switch > span::after { position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; border-radius: 50%; background: rgb(var(--dev3-text-primary)); content: ""; transition: transform .18s ease; }
+    .switch > span { position: relative; flex: 0 0 auto; width: 3.17em; height: 1.83em; border-radius: 999px; background: rgb(var(--dev3-border)); transition: background .18s ease; }
+    .switch > span::after { position: absolute; top: .25em; left: .25em; width: 1.33em; height: 1.33em; border-radius: 50%; background: rgb(var(--dev3-text-primary)); content: ""; transition: transform .18s ease; }
     .switch input:checked + span { background: rgb(var(--dev3-accent)); }
-    .switch input:checked + span::after { background: rgb(var(--dev3-on-accent)); transform: translateX(16px); }
+    .switch input:checked + span::after { background: rgb(var(--dev3-on-accent)); transform: translateX(1.33em); }
     .switch input:focus-visible + span { outline: 2px solid rgb(var(--dev3-accent)); outline-offset: 2px; }
     .form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 2px; }
-    .choices { width: 100%; margin: 0; color: rgb(var(--dev3-text-primary)); }
-    .table-tools .choices { width: auto; min-width: 150px; }
+    /* Choices sizes its own chips, search field, and select hint from these three
+       variables, so handing it rem values is what makes a multi-select follow the
+       text-size control instead of staying at its 16/14/12px defaults. */
+    .choices {
+      width: 100%;
+      margin: 0;
+      color: rgb(var(--dev3-text-primary));
+      --choices-font-size-lg: 1rem;
+      --choices-font-size-md: .875rem;
+      --choices-font-size-sm: .75rem;
+    }
+    .choices__heading { font-size: .75rem; }
+    .table-tools .choices { width: auto; min-width: 9.5rem; }
     .choices__inner {
       min-height: 39px;
       padding: 7px 38px 7px 10px;
       border: 1px solid rgb(var(--dev3-border));
       border-radius: 10px;
       background: rgb(var(--dev3-surface-base));
-      font-size: 14px;
+      font-size: .875rem;
     }
     .is-open .choices__inner { border-color: rgb(var(--dev3-accent)); border-radius: 10px 10px 7px 7px; }
-    .choices[data-type*="select-one"]::after { right: 14px; width: 7px; height: 7px; margin-top: -6px; border: solid rgb(var(--dev3-text-muted)); border-width: 0 2px 2px 0; transform: rotate(45deg); }
+    .choices[data-type*="select-one"]::after { right: 14px; width: .5em; height: .5em; margin-top: -6px; border: solid rgb(var(--dev3-text-muted)); border-width: 0 2px 2px 0; transform: rotate(45deg); }
     .choices[data-type*="select-one"].is-open::after { margin-top: -2px; border-color: rgb(var(--dev3-accent)); transform: rotate(225deg); }
     .choices__list--single { padding: 0; }
     .choices__list--dropdown, .choices__list[aria-expanded] {
@@ -365,7 +401,7 @@
       box-shadow: 0 16px 36px rgb(var(--dev3-shadow) / .26);
       color: rgb(var(--dev3-text-primary));
     }
-    .choices__list--dropdown .choices__item, .choices__list[aria-expanded] .choices__item { padding: 9px 11px; font-size: 12px; }
+    .choices__list--dropdown .choices__item, .choices__list[aria-expanded] .choices__item { padding: 9px 11px; font-size: .75rem; }
     .choices__list--dropdown .choices__item--choice.is-selected,
     .choices__list[aria-expanded] .choices__item--choice.is-selected {
       background: rgb(var(--dev3-accent) / .1);
@@ -394,8 +430,8 @@
     .popover {
       position: fixed;
       z-index: var(--dev3-z-overlay);
-      min-width: 210px;
-      max-width: min(360px, calc(100vw - 24px));
+      min-width: 13rem;
+      max-width: min(22.5rem, calc(100vw - 24px));
       overflow-y: auto;
       inset: auto;
       margin: 0;
@@ -411,7 +447,7 @@
     .popover-title {
       padding: 7px 10px 5px;
       color: rgb(var(--dev3-text-muted));
-      font-size: 10px;
+      font-size: .625rem;
       letter-spacing: .08em;
       text-transform: uppercase;
     }
@@ -427,7 +463,7 @@
       border-radius: 8px;
       background: transparent;
       color: inherit;
-      font-size: 12px;
+      font-size: .75rem;
       text-align: start;
       text-decoration: none;
     }
@@ -451,9 +487,9 @@
       color: rgb(var(--dev3-text-primary));
       outline: none;
     }
-    .table-tools input { width: 190px; }
+    .table-tools input { width: 12rem; }
     table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
-    th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); text-align: left; font-size: 12px; }
+    th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); text-align: left; font-size: .75rem; }
     /* A vertical rule keeps the eye inside one column across a wide row; every
        cell owns its trailing edge so a pinned column can strengthen its own. */
     th:not(:last-child), td:not(:last-child) { border-inline-end: 1px solid rgb(var(--dev3-border) / .5); }
@@ -467,7 +503,7 @@
     thead th { position: sticky; z-index: 5; top: var(--dev3-table-head-top, 0px); background: rgb(var(--dev3-surface-raised)); box-shadow: inset 0 -1px 0 rgb(var(--dev3-border)); }
     th[data-sort] { cursor: pointer; }
     th[data-sort]:hover { color: rgb(var(--dev3-text-secondary)); }
-    th[data-sort]::after { margin-inline-start: 6px; content: "↕"; font-size: 10px; opacity: .3; }
+    th[data-sort]::after { margin-inline-start: 6px; content: "↕"; font-size: .625rem; opacity: .3; }
     th[data-sort]:hover::after { opacity: .65; }
     th[aria-sort]::after { color: rgb(var(--dev3-accent)); opacity: 1; }
     th[aria-sort="ascending"]::after { content: "↑"; }
@@ -480,24 +516,24 @@
     .evidence-book { display: grid; gap: 16px; }
     .evidence-toolbar, .evidence-legend { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
     .evidence-toolbar { justify-content: space-between; }
-    .evidence-toolbar .choices { min-width: min(360px, 100%); }
-    .evidence-legend { color: rgb(var(--dev3-text-secondary)); font-size: 11px; }
+    .evidence-toolbar .choices { min-width: min(22.5rem, 100%); }
+    .evidence-legend { color: rgb(var(--dev3-text-secondary)); font-size: .6875rem; }
     .evidence-marker { display: inline-flex; align-items: center; gap: 5px; }
-    .evidence-marker::before { width: 7px; height: 7px; border-radius: 50%; background: rgb(var(--dev3-text-muted)); content: ""; }
+    .evidence-marker::before { width: .58em; height: .58em; border-radius: 50%; background: rgb(var(--dev3-text-muted)); content: ""; }
     .evidence-marker.good::before { background: rgb(var(--dev3-success)); }
     .evidence-marker.bad::before { background: rgb(var(--dev3-danger)); }
     .evidence-marker.sig::before { background: rgb(var(--dev3-accent)); box-shadow: 0 0 0 3px rgb(var(--dev3-accent) / .16); }
     .evidence-group { overflow: hidden; border: 1px solid rgb(var(--dev3-border)); border-radius: 16px; background: rgb(var(--dev3-surface-raised)); }
     .evidence-group-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; padding: 16px 18px; border-bottom: 1px solid rgb(var(--dev3-border)); }
-    .evidence-group-title { margin: 0 0 4px; color: rgb(var(--dev3-text-primary)); font-size: 15px; }
+    .evidence-group-title { margin: 0 0 4px; color: rgb(var(--dev3-text-primary)); font-size: .9375rem; }
     .evidence-table-card + .evidence-table-card { border-top: 1px solid rgb(var(--dev3-border)); }
     .evidence-table-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; padding: 10px 14px 8px; background: rgb(var(--dev3-surface-elevated) / .42); }
-    .evidence-table-title { margin: 0; color: rgb(var(--dev3-text-secondary)); font-size: 12px; font-weight: 700; }
-    .evidence-table-meta { flex: 0 0 auto; color: rgb(var(--dev3-text-muted)); font: 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .evidence-table-title { margin: 0; color: rgb(var(--dev3-text-secondary)); font-size: .75rem; font-weight: 700; }
+    .evidence-table-meta { flex: 0 0 auto; color: rgb(var(--dev3-text-muted)); font: .625rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
     .evidence-table-scroll { max-width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-gutter: stable; }
     .evidence-table { width: max-content; min-width: 100%; font-variant-numeric: tabular-nums; }
-    .evidence-table th, .evidence-table td { padding: 6px 9px; white-space: nowrap; text-align: right; font-size: 10.5px; }
-    .evidence-table th { background: rgb(var(--dev3-surface-raised)); cursor: default; font-size: 9.5px; }
+    .evidence-table th, .evidence-table td { padding: 6px 9px; white-space: nowrap; text-align: right; font-size: .65625rem; }
+    .evidence-table th { background: rgb(var(--dev3-surface-raised)); cursor: default; font-size: .59375rem; }
     /* Its own scroller is the scrollport, so the page offset would push the
        header onto the rows instead of pinning it. */
     .evidence-table thead th { top: 0; }
@@ -512,15 +548,15 @@
     .evidence-table .bad, .evidence-table .neg { color: rgb(var(--dev3-danger)); }
     .evidence-table .flat, .evidence-table .dim { color: rgb(var(--dev3-text-muted)); }
     .evidence-table .sig { font-weight: 700; }
-    .evidence-table .wrap { min-width: 240px; white-space: normal; text-align: left; line-height: 1.45; }
+    .evidence-table .wrap { min-width: 15rem; white-space: normal; text-align: left; line-height: 1.45; }
     .evidence-table tr.regime td { border-top: 2px solid rgb(var(--dev3-accent) / .55); }
     .evidence-table tr.total td { border-top: 2px solid rgb(var(--dev3-border)); color: rgb(var(--dev3-text-primary)); font-weight: 700; }
-    .pill { display: inline-flex; padding: 4px 8px; border-radius: 999px; font-size: 11px; font-weight: 650; }
+    .pill { display: inline-flex; padding: 4px 8px; border-radius: 999px; font-size: .6875rem; font-weight: 650; }
     .pill.success { color: rgb(var(--dev3-success)); background: rgb(var(--dev3-success) / .1); }
     .pill.warning { color: rgb(var(--dev3-warning)); background: rgb(var(--dev3-warning) / .1); }
     .pill.accent { color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent) / .1); }
     .bar-cell { display: flex; align-items: center; gap: 9px; }
-    .mini-track { width: 76px; height: 6px; overflow: hidden; border-radius: 99px; background: rgb(var(--dev3-border)); }
+    .mini-track { width: 4.75rem; height: 6px; overflow: hidden; border-radius: 99px; background: rgb(var(--dev3-border)); }
     .mini-fill { height: 100%; border-radius: 99px; background: rgb(var(--dev3-accent)); }
     .toast {
       position: fixed;
@@ -548,7 +584,7 @@
       gap: 12px;
       padding: 18px 4px 2px;
       color: rgb(var(--dev3-text-muted));
-      font-size: 11px;
+      font-size: .6875rem;
     }
     .dev3-footer strong { color: rgb(var(--dev3-text-secondary)); font-weight: 650; }
     .dev3-footer a { color: rgb(var(--dev3-accent)); text-decoration: none; }
@@ -557,7 +593,7 @@
 
     /* A chart growing sideways needs height, or a wide panel reads as a strip. */
     @media (min-width: 1500px) {
-      .chart-host { height: 330px; }
+      .chart-host { height: 20.625rem; }
     }
     @media (max-width: 900px) {
       .kpis { grid-template-columns: repeat(2, 1fr); }
@@ -590,14 +626,14 @@
         background: rgb(var(--dev3-surface-base)) !important;
         color: rgb(var(--dev3-text-primary)) !important;
       }
-      body { padding: 0; font-size: 10px; }
+      body { padding: 0; font-size: .625rem; }
       .app { width: auto; gap: 8px; }
       .topbar { margin-bottom: 0; }
       .brand { gap: 9px; }
-      .brand img { width: 34px; height: 34px; border-radius: 10px; box-shadow: none; }
-      h1 { font-size: 17px; }
-      .eyebrow { font-size: 8px; }
-      .muted, .section-copy { font-size: 9px; }
+      .brand img { width: 2.125rem; height: 2.125rem; border-radius: 10px; box-shadow: none; }
+      h1 { font-size: 1.0625rem; }
+      .eyebrow { font-size: .5rem; }
+      .muted, .section-copy { font-size: .5625rem; }
       .actions, .scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }
       /* An overlay is a live interaction, never static output. */
       .popover, [popover] { display: none !important; }
@@ -606,23 +642,23 @@
       .card { padding: 10px; }
       .table-card { padding: 0; }
       .kpi { padding: 9px 10px; }
-      .kpi-top { font-size: 8px; }
-      .kpi-value { margin: 3px 0 1px; font-size: 20px; }
-      .trend { font-size: 8px; }
+      .kpi-top { font-size: .5rem; }
+      .kpi-value { margin: 3px 0 1px; font-size: 1.25rem; }
+      .trend { font-size: .5rem; }
       .dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
       .velocity-panel { grid-column: 1 / -1; }
       .pie-panel, .radar-panel { grid-column: auto; }
       .card, tr { break-inside: avoid; box-shadow: none; }
       .section { padding: 10px; }
       .section-head { margin-bottom: 6px; }
-      .section-title { font-size: 11px; }
+      .section-title { font-size: .6875rem; }
       .segmented { padding: 0; border: 0; background: transparent; }
-      .segmented button { display: none; padding: 3px 6px; font-size: 8px; }
+      .segmented button { display: none; padding: 3px 6px; font-size: .5rem; }
       .segmented button.active { display: block; }
-      .chart-host { height: var(--dev3-print-chart-height, 155px); }
+      .chart-host { height: var(--dev3-print-chart-height, 9.6875rem); }
       .chart-host > div, .chart-host svg { width: 100% !important; height: 100% !important; }
       .table-head { padding: 8px 10px 6px; }
-      th, td { padding: 5px 10px; font-size: 8px; }
+      th, td { padding: 5px 10px; font-size: .5rem; }
       thead { display: table-header-group; }
       /* Repeat the header on every page instead of pinning it to a scrollport. */
       thead th, .evidence-table th:first-child, .evidence-table td:first-child { position: static; box-shadow: none; }
@@ -631,17 +667,17 @@
       .evidence-toolbar, .evidence-legend { display: none !important; }
       .evidence-group { overflow: visible; border-radius: 8px; break-inside: auto; }
       .evidence-group-head { padding: 7px 9px; break-after: avoid; }
-      .evidence-group-title { font-size: 9px; }
+      .evidence-group-title { font-size: .5625rem; }
       .evidence-table-head { padding: 5px 7px 3px; break-after: avoid; }
-      .evidence-table-title { font-size: 7px; }
-      .evidence-table-meta { font-size: 6px; }
+      .evidence-table-title { font-size: .4375rem; }
+      .evidence-table-meta { font-size: .375rem; }
       .evidence-table-scroll { overflow: visible; }
       .evidence-table { width: 100%; min-width: 0; table-layout: auto; }
-      .evidence-table th, .evidence-table td { display: table-cell; padding: 1.5px 3px; white-space: normal; font-size: 6.2px; }
-      .evidence-table th { font-size: 5.8px; }
-      .pill { padding: 2px 5px; font-size: 7px; }
-      .mini-track { width: 52px; height: 4px; }
-      .dev3-footer { padding: 8px 2px 0; font-size: 8px; }
+      .evidence-table th, .evidence-table td { display: table-cell; padding: 1.5px 3px; white-space: normal; font-size: .3875rem; }
+      .evidence-table th { font-size: .3625rem; }
+      .pill { padding: 2px 5px; font-size: .4375rem; }
+      .mini-track { width: 3.25rem; height: 4px; }
+      .dev3-footer { padding: 8px 2px 0; font-size: .5rem; }
     }
     :root, [data-theme="dark"] { color-scheme: dark; --dev3-surface-base: 6 9 21; --dev3-surface-raised: 14 18 30; --dev3-surface-elevated: 21 26 41; --dev3-text-primary: 250 252 255; --dev3-text-secondary: 170 187 212; --dev3-text-muted: 82 98 121; --dev3-border: 32 38 55; --dev3-accent: 68 150 255; --dev3-success: 74 222 128; --dev3-warning: 250 204 21; --dev3-danger: 255 130 130; --dev3-on-accent: 255 255 255; --dev3-shadow: 0 0 0; }
     [data-theme="light"] { color-scheme: light; --dev3-surface-base: 240 242 250; --dev3-surface-raised: 255 255 255; --dev3-surface-elevated: 237 239 247; --dev3-text-primary: 15 23 42; --dev3-text-secondary: 71 85 105; --dev3-text-muted: 148 163 184; --dev3-border: 203 213 225; --dev3-accent: 59 130 246; --dev3-success: 22 163 74; --dev3-warning: 202 138 4; --dev3-danger: 220 38 38; --dev3-on-accent: 255 255 255; --dev3-shadow: 15 23 42; }

--- a/src/assets/artifact-template/app.js
+++ b/src/assets/artifact-template/app.js
@@ -12,6 +12,34 @@
 
   const prefersReducedMotion = () => matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+  // ---- text size ------------------------------------------------------------
+  // Every font size in app.css is a rem, so one root scale resizes the whole
+  // report. The bounds are the range the layout survives: below 80% the dense
+  // evidence tables stop being legible, above 150% the 12-column dashboard and
+  // the topbar run out of room on a laptop.
+  const FONT_SCALE_STEPS = [.8, .9, 1, 1.1, 1.2, 1.3, 1.4, 1.5];
+  const FONT_SCALE_KEY = "dev3-artifact-font-scale";
+  const DEFAULT_FONT_SCALE_INDEX = FONT_SCALE_STEPS.indexOf(1);
+
+  // A sandboxed artifact has an opaque origin, where touching localStorage
+  // throws instead of returning null, so the preference is best-effort.
+  function storedFontScaleIndex() {
+    try {
+      const stored = Number(localStorage.getItem(FONT_SCALE_KEY));
+      const index = FONT_SCALE_STEPS.indexOf(stored);
+      return index === -1 ? DEFAULT_FONT_SCALE_INDEX : index;
+    } catch { return DEFAULT_FONT_SCALE_INDEX; }
+  }
+
+  let fontScaleIndex = storedFontScaleIndex();
+  const fontScale = () => FONT_SCALE_STEPS[fontScaleIndex];
+  // Ahead of the control wiring below, so a remembered scale is in place before
+  // report code lays anything out.
+  document.documentElement.style.setProperty("--dev3-font-scale-user", String(fontScale()));
+  // ECharts sizes are raw px numbers, so chart text needs the multiplier applied
+  // by hand where CSS cannot reach.
+  const scaledFont = (px) => Math.round(px * fontScale() * 10) / 10;
+
   // ---- dev3 chart bridge ----------------------------------------------------
   // The pinned cdnjs script exposes window.echarts. Charts use the SVG renderer
   // so print/PDF output stays crisp. Offline charts degrade to a notice.
@@ -81,14 +109,15 @@
 
   // A sticky table header must land below the sticky section nav, and sit at the
   // very top when a report has no nav at all.
-  function trackStickyOffset() {
+  function applyStickyOffset() {
     const nav = document.querySelector(".section-nav");
-    const apply = () => {
-      const offset = nav ? Math.round(nav.getBoundingClientRect().height) : 0;
-      document.documentElement.style.setProperty("--dev3-table-head-top", `${offset}px`);
-    };
-    apply();
-    window.addEventListener("resize", apply);
+    const offset = nav ? Math.round(nav.getBoundingClientRect().height) : 0;
+    document.documentElement.style.setProperty("--dev3-table-head-top", `${offset}px`);
+  }
+
+  function trackStickyOffset() {
+    applyStickyOffset();
+    window.addEventListener("resize", applyStickyOffset);
   }
 
   // Report code owns sorting; the shell owns only the visible sort state, so
@@ -373,16 +402,16 @@
   function registerDev3ChartTheme() {
     if (!chartsAvailable) return;
     appliedChartTheme = document.documentElement.dataset.theme;
-    const axisLabel = { color: tokenColor("--dev3-text-muted") };
+    const axisLabel = { color: tokenColor("--dev3-text-muted"), fontSize: scaledFont(12) };
     const softSplit = { lineStyle: { color: tokenColor("--dev3-border", .6) } };
     window.echarts.registerTheme("dev3", {
       color: [tokenColor("--dev3-accent"), tokenColor("--dev3-success"), tokenColor("--dev3-warning"), tokenColor("--dev3-danger"), tokenColor("--dev3-text-secondary")],
       backgroundColor: "transparent",
-      textStyle: { fontFamily: CHART_FONT, color: tokenColor("--dev3-text-secondary") },
+      textStyle: { fontFamily: CHART_FONT, color: tokenColor("--dev3-text-secondary"), fontSize: scaledFont(12) },
       categoryAxis: { axisLine: { lineStyle: { color: tokenColor("--dev3-border") } }, axisTick: { show: false }, axisLabel, splitLine: { show: false } },
       valueAxis: { axisLine: { show: false }, axisTick: { show: false }, axisLabel, splitLine: softSplit },
-      legend: { textStyle: { color: tokenColor("--dev3-text-secondary"), fontSize: 11 }, itemWidth: 14, itemHeight: 9 },
-      radar: { axisName: { color: tokenColor("--dev3-text-muted"), fontSize: 10 }, axisLine: { lineStyle: { color: tokenColor("--dev3-border") } }, splitLine: softSplit, splitArea: { show: false } },
+      legend: { textStyle: { color: tokenColor("--dev3-text-secondary"), fontSize: scaledFont(11) }, itemWidth: 14, itemHeight: 9 },
+      radar: { axisName: { color: tokenColor("--dev3-text-muted"), fontSize: scaledFont(10) }, axisLine: { lineStyle: { color: tokenColor("--dev3-border") } }, splitLine: softSplit, splitArea: { show: false } },
     });
   }
 
@@ -391,8 +420,30 @@
     if (svg) svg.setAttribute("viewBox", `0 0 ${svg.getAttribute("width")} ${svg.getAttribute("height")}`);
   }
 
+  // A chart option is the one place a size is written as a raw number, so report
+  // code would otherwise keep its own labels at 100% while the page grew. The
+  // shell rescales every `fontSize` it finds instead, without touching the
+  // author's object: plain branches are copied, everything else (functions,
+  // primitive data arrays) is carried over by reference.
+  function isOptionBranch(value) {
+    if (Array.isArray(value)) return true;
+    if (!value || typeof value !== "object") return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function scaleOptionFonts(value) {
+    if (Array.isArray(value)) return value.some(isOptionBranch) ? value.map(scaleOptionFonts) : value;
+    if (!isOptionBranch(value)) return value;
+    const scaled = {};
+    Object.entries(value).forEach(([key, item]) => {
+      scaled[key] = key === "fontSize" && typeof item === "number" ? scaledFont(item) : scaleOptionFonts(item);
+    });
+    return scaled;
+  }
+
   function chartShellOption(option) {
-    return {
+    return scaleOptionFonts({
       // ECharts derives label contrast from the canvas background. Left
       // transparent it assumes white paper and paints every value label dark
       // grey inside a 2px white halo — illegible on the dark theme. Naming the
@@ -407,7 +458,7 @@
         textStyle: { color: tokenColor("--dev3-text-primary"), fontSize: 12 },
         ...(option.tooltip || {}),
       },
-    };
+    });
   }
 
   function dev3Chart(element, optionFactory) {
@@ -514,6 +565,42 @@
     applyArtifactTheme();
   });
 
+  function applyFontScale(options = {}) {
+    const scale = fontScale();
+    const percent = `${Math.round(scale * 100)}%`;
+    document.documentElement.style.setProperty("--dev3-font-scale-user", String(scale));
+    document.querySelectorAll("[data-font-step]").forEach((button) => {
+      const step = Number(button.dataset.fontStep);
+      if (step === 0) {
+        button.textContent = percent;
+        button.disabled = fontScaleIndex === DEFAULT_FONT_SCALE_INDEX;
+        return;
+      }
+      button.disabled = FONT_SCALE_STEPS[fontScaleIndex + step] === undefined;
+    });
+    if (options.announce) showToast(`Text size ${percent}`);
+    if (options.persist) {
+      try { localStorage.setItem(FONT_SCALE_KEY, String(scale)); } catch {}
+    }
+    // Chart labels are px numbers rather than rem, sticky offsets are measured in
+    // px, and an open menu was placed against a trigger that just changed size.
+    rethemeDev3Charts();
+    applyStickyOffset();
+    scheduleReposition();
+  }
+
+  function stepFontScale(step) {
+    const next = step === 0 ? DEFAULT_FONT_SCALE_INDEX : fontScaleIndex + step;
+    if (FONT_SCALE_STEPS[next] === undefined || next === fontScaleIndex) return;
+    fontScaleIndex = next;
+    applyFontScale({ announce: true, persist: true });
+  }
+
+  document.querySelectorAll("[data-font-step]").forEach((button) => {
+    button.addEventListener("click", () => stepFontScale(Number(button.dataset.fontStep)));
+  });
+  applyFontScale();
+
   // Report code that builds a panel after load registers it the same way the
   // markup does, so a dynamic menu gets the same top layer and dismissal.
   function popoverApi(panelOrId, anchor) {
@@ -543,7 +630,9 @@
     chart: dev3Chart,
     color: tokenColor,
     enhance: enhanceControls,
+    fontScale,
     popover: popoverApi,
+    scaleFont: scaledFont,
     setControl: setControlValue,
     toast: showToast,
   });

--- a/src/assets/artifact-template/index.html
+++ b/src/assets/artifact-template/index.html
@@ -21,6 +21,11 @@
       </div>
       <div class="actions">
         <span class="status"><span class="dot"></span>Live data</span>
+        <div class="segmented text-size" role="group" aria-label="Text size">
+          <button type="button" data-font-step="-1" title="Smaller text" aria-label="Smaller text">A−</button>
+          <button class="text-size-value" id="fontScaleValue" type="button" data-font-step="0" title="Reset text size to 100%" aria-label="Reset text size">100%</button>
+          <button type="button" data-font-step="1" title="Larger text" aria-label="Larger text">A+</button>
+        </div>
         <button class="ghost" id="artifactTheme" type="button" title="Theme: Follow host">◐ Auto</button>
         <button class="ghost" id="refresh" type="button">↻ Refresh</button>
         <button class="primary" id="runTop" type="button">Run scenario</button>

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -235,6 +235,29 @@ describe("bundled artifact starter contract", () => {
 		expect(css).toContain(".evidence-table tr.regime td");
 	});
 
+	it("scales the whole report from one root text size, including chart labels", () => {
+		const html = readFileSync(htmlPath, "utf8");
+		const css = readFileSync(cssPath, "utf8");
+		const app = readFileSync(appPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+
+		expect(html).toContain('class="segmented text-size"');
+		expect(html).toContain('data-font-step="-1"');
+		expect(html).toContain('id="fontScaleValue"');
+		expect(html).toContain('data-font-step="1"');
+		expect(css).toContain("--dev3-font-scale: var(--dev3-font-scale-user, 1)");
+		expect(css).toContain("font-size: calc(100% * var(--dev3-font-scale))");
+		// Choices sizes its own chips and search field from these variables.
+		expect(css).toContain("--choices-font-size-md: .875rem");
+		// A px font size anywhere in the shell would be a block that refuses to scale.
+		expect(css.match(/font(-size)?: *[0-9.]+px/g)).toBeNull();
+		expect(app).toContain("FONT_SCALE_STEPS");
+		expect(app).toContain("function scaleOptionFonts");
+		expect(app).toContain("dev3-artifact-font-scale");
+		expect(guide).toContain("## Text size");
+		expect(guide).toContain("dev3Artifact.scaleFont(px)");
+	});
+
 	it("loads versioned cdnjs primitives without brittle integrity hashes", () => {
 		const html = readFileSync(htmlPath, "utf8");
 		const app = readFileSync(appPath, "utf8");
@@ -265,7 +288,7 @@ describe("bundled artifact starter contract", () => {
 
 		expect(css).toContain("width: min(100%, clamp(1180px, 88vw, 1840px))");
 		expect(css).toContain(".prose { max-width: 72ch; }");
-		expect(css).toContain(".kpis { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }");
+		expect(css).toContain(".kpis { grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); }");
 		expect(css).toContain("@media (min-width: 1500px)");
 		expect(guide).toContain("`.prose`");
 	});
@@ -377,7 +400,7 @@ describe("bundled artifact starter contract", () => {
 		expect(css).toContain("break-inside: avoid");
 		expect(css).toContain("thead { display: table-header-group; }");
 		expect(css).toContain(".dashboard-grid > * { min-width: 0; }");
-		expect(css).toContain("var(--dev3-print-chart-height, 155px)");
+		expect(css).toContain("var(--dev3-print-chart-height, 9.6875rem)");
 		expect(app).toContain('document.querySelectorAll("details:not([open])")');
 		expect(app).toContain("element.getBoundingClientRect()");
 	});
@@ -420,7 +443,7 @@ describe("bundled artifact starter contract", () => {
 		expect(statSync(htmlPath).size).toBeLessThan(MAX_SHARED_ARTIFACT_HTML_BYTES);
 		// The shell stylesheet is not part of the authoring surface, so its budget
 		// only has to stay far below an inlined library.
-		expect(statSync(cssPath).size).toBeLessThan(34_000);
+		expect(statSync(cssPath).size).toBeLessThan(36_000);
 		expect(statSync(appPath).size).toBeLessThan(30_000);
 		expect(statSync(reportPath).size).toBeLessThan(15_000);
 	});

--- a/src/mainview/utils/__tests__/artifactTemplateRuntime.test.ts
+++ b/src/mainview/utils/__tests__/artifactTemplateRuntime.test.ts
@@ -5,9 +5,16 @@ import { afterEach, describe, expect, it } from "vitest";
 const templateDir = resolve(import.meta.dirname, "../../../assets/artifact-template");
 const reportSource = readFileSync(resolve(templateDir, "report.js"), "utf8");
 const appSource = readFileSync(resolve(templateDir, "app.js"), "utf8");
+const cssSource = readFileSync(resolve(templateDir, "app.css"), "utf8");
+const htmlSource = readFileSync(resolve(templateDir, "index.html"), "utf8");
+
+const textSizeControl =
+	'<div class="segmented text-size"><button data-font-step="-1">A−</button><button id="fontScaleValue" data-font-step="0">100%</button><button data-font-step="1">A+</button></div>';
 
 describe("artifact starter runtime", () => {
 	afterEach(() => {
+		localStorage.clear();
+		document.documentElement.removeAttribute("style");
 		document.documentElement.removeAttribute("data-theme");
 		document.body.replaceChildren();
 		delete (window as typeof window & { dev3Artifact?: unknown }).dev3Artifact;
@@ -29,5 +36,45 @@ describe("artifact starter runtime", () => {
 		window.dispatchEvent(new Event("afterprint"));
 		expect(details.open).toBe(false);
 		expect(document.documentElement.classList.contains("printing")).toBe(false);
+	});
+
+	it("steps the root text scale between its bounds and resets from the readout", () => {
+		document.body.innerHTML = `<div id="toast"></div>${textSizeControl}`;
+		window.eval(appSource);
+
+		const readout = document.getElementById("fontScaleValue") as HTMLButtonElement;
+		const smaller = document.querySelector<HTMLButtonElement>('[data-font-step="-1"]')!;
+		const larger = document.querySelector<HTMLButtonElement>('[data-font-step="1"]')!;
+		const scale = () => document.documentElement.style.getPropertyValue("--dev3-font-scale-user");
+
+		expect(scale()).toBe("1");
+		expect(readout.disabled).toBe(true);
+
+		larger.click();
+		expect(scale()).toBe("1.1");
+		expect(readout.textContent).toBe("110%");
+		expect(readout.disabled).toBe(false);
+
+		for (let step = 0; step < 8; step += 1) larger.click();
+		expect(scale()).toBe("1.5");
+		expect(larger.disabled).toBe(true);
+
+		readout.click();
+		expect(scale()).toBe("1");
+		expect(readout.textContent).toBe("100%");
+
+		for (let step = 0; step < 8; step += 1) smaller.click();
+		expect(scale()).toBe("0.8");
+		expect(smaller.disabled).toBe(true);
+	});
+
+	it("keeps the text-size control in the markup and every shell font size relative", () => {
+		expect(htmlSource).toContain('data-font-step="-1"');
+		expect(htmlSource).toContain('id="fontScaleValue"');
+		expect(htmlSource).toContain('data-font-step="1"');
+		expect(cssSource).toContain("font-size: calc(100% * var(--dev3-font-scale))");
+		// A px font size anywhere in the shell is a block of the report that would
+		// refuse to scale with the control.
+		expect(cssSource.match(/font(-size)?: *[0-9.]+px/g)).toBeNull();
 	});
 });


### PR DESCRIPTION
The artifact starter gets an `A− / 100% / A+` group beside the theme toggle: eight stops from 80% to 150%, the percentage readout doubles as reset, remembered per browser (best-effort — the sandboxed viewer's opaque origin has no storage).

The whole report follows one root scale, because `app.css` is now sized in `rem`, with `em` where a glyph belongs to its own label:

- text, tables, KPI figures, pills, evidence tables
- chart hosts and every ECharts `fontSize` — `scaleOptionFonts()` in `app.js` rewrites font sizes in an option tree before `setOption`, so a report's own chart labels scale without knowing the control exists
- checkboxes, radios, switches, the noUiSlider handle/pips/tooltip
- Choices chips, search field and select hint, via its `--choices-font-size-*` variables
- print, which keeps the chosen scale and grows `--dev3-print-chart-height` with it so enlarged labels do not collide

A scale change re-registers the chart theme and remounts, re-measures the sticky table-header offset, and repositions open overlays. Two tests assert `app.css` contains no px font size at all — verified by mutation, both fail when one is added.

Rationale and rejected alternatives (CSS `zoom`, per-component sizes, resetting the scale for print): `decisions/2026/08/20/artifact-text-size-root-rem-scale.md`.

QA in headless Chromium at 80% / 100% / 150%, light and dark, 1920 and 390 wide, plus print-to-PDF through the real `beforeprint` path.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=9b6ef43b-3992-4cc5-8948-a486d9778bed) · `dev3://task/9b6ef43b-3992-4cc5-8948-a486d9778bed`