### PR TITLE
Colour the behind commit count red in the task git row

### DIFF
--- a/change-logs/2026/08/20/fix-red-behind-commit-count.md
+++ b/change-logs/2026/08/20/fix-red-behind-commit-count.md
@@ -1,0 +1,3 @@
+Short: Red behind-commit warning
+
+The "N behind" half of the task git row is now red instead of muted grey — number and wording together, because being behind the base branch is a warning that a rebase is needed. The ahead half stays a quiet readout, and the combined "N ahead · N behind" line went back through the translation layer instead of hardcoded English.

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -1527,7 +1527,9 @@ describe("TaskInfoPanel", () => {
 				renderPanel(makeTask());
 			});
 
-			expect(screen.getAllByText(/2 commits behind/).length).toBeGreaterThanOrEqual(1);
+			const count = screen.getAllByTestId("behind-count")[0];
+			expect(count).toHaveClass("text-danger");
+			expect(count).toHaveTextContent("2 commits behind");
 		});
 
 		it("shows both ahead and behind when both > 0", async () => {
@@ -1541,8 +1543,11 @@ describe("TaskInfoPanel", () => {
 				renderPanel(makeTask());
 			});
 
-			expect(screen.getAllByText(/3 ahead/).length).toBeGreaterThanOrEqual(1);
-			expect(screen.getAllByText(/1 behind/).length).toBeGreaterThanOrEqual(1);
+			const count = screen.getAllByTestId("behind-count")[0];
+			expect(count).toHaveClass("text-danger");
+			// The wording is red together with the number; only the ahead half stays muted.
+			expect(count).toHaveTextContent("1 behind");
+			expect(count.parentElement).toHaveTextContent("3 ahead · 1 behind");
 		});
 
 		it("shows uncommitted changes badge", async () => {
@@ -1608,7 +1613,7 @@ describe("TaskInfoPanel", () => {
 
 			// One control carries both halves, so clicking either number opens the diff.
 			const summary = screen.getByText("+46").closest("button")!;
-			expect(summary).toContainElement(screen.getByText("1 ahead"));
+			expect(summary).toContainElement(screen.getAllByTestId("behind-count")[0]);
 			await user.click(summary);
 
 			expect(onOpenInlineDiff).toHaveBeenCalledWith({

--- a/src/mainview/components/task-info-panel/TaskGitActions.tsx
+++ b/src/mainview/components/task-info-panel/TaskGitActions.tsx
@@ -41,6 +41,22 @@ type GitActionButton = ReactElement<{
 	tabIndex?: number;
 }>;
 
+/** Placeholder passed into the translated string so the behind half can be split
+    off without matching digits that belong to the ahead count. */
+const BEHIND_SLOT = "\u0000";
+
+/** Colours the number AND its wording — a lone red digit is easy to miss, the
+    whole "N behind" phrase reads as the warning it is. */
+function BehindCount({ text, behind }: { text: string; behind: number }) {
+	const [before, after = ""] = text.split(BEHIND_SLOT);
+	return (
+		<>
+			{before}
+			<span className="text-danger" data-testid="behind-count">{behind}{after}</span>
+		</>
+	);
+}
+
 interface GitActionTooltipProps {
 	content: ReactNode;
 	detail?: ReactNode;
@@ -260,18 +276,21 @@ export default function TaskGitActions({
 
 	const branchStatusBadge = branchStatus && (branchStatus.ahead > 0 || branchStatus.behind > 0) ? (
 		<span className="flex items-center gap-1.5 text-micro flex-shrink-0">
-			{/* Ahead/behind is a readout, not a verdict — colour here competed with
-			    the uncommitted diff, which is the one thing on this row that is
-			    genuinely urgent. */}
+			{/* Only the behind count is a verdict — it means "rebase needed", so the
+			    number is red while the wording around it stays a muted readout. */}
 			{branchStatus.behind > 0 && branchStatus.ahead > 0 ? (
-				<span className="font-medium text-fg-3">
-					<span>{branchStatus.ahead} ahead</span>
-					<span className="text-fg-muted"> · </span>
-					<span>{branchStatus.behind} behind</span>
+				<span className="text-fg-3 font-medium">
+					<BehindCount
+						text={t("infoPanel.commitsAheadBehind", { ahead: String(branchStatus.ahead), behind: BEHIND_SLOT })}
+						behind={branchStatus.behind}
+					/>
 				</span>
 			) : branchStatus.behind > 0 ? (
 				<span className="text-fg-3 font-medium">
-					{t("infoPanel.commitsBehind", { count: String(branchStatus.behind) })}
+					<BehindCount
+						text={t("infoPanel.commitsBehind", { count: BEHIND_SLOT })}
+						behind={branchStatus.behind}
+					/>
 				</span>
 			) : (
 				<span className="text-fg-3 font-medium">


### PR DESCRIPTION
The "N behind" half of the task git row was muted grey, which read as a neutral readout. Being behind the base branch is a warning — it means a rebase is needed — so the number *and* its wording are now red (`text-danger`), while the "N ahead" half stays a quiet grey readout.

Also restores i18n for the combined line: it was hardcoded English (`{ahead} ahead · {behind} behind`) and now goes through the existing `infoPanel.commitsAheadBehind` key again, so ru/es render properly. The behind number is split out of the translated string through a placeholder, so word order in any locale is respected and the ahead digits can never be matched by mistake.

Verified in a browser: `136 ahead · 16 behind` renders with "16 behind" in `rgb(255, 137, 135)`. Full suite green (mainview 4240, bun 6256, cli 808) and `bun run lint` clean.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=25caf04b-0a41-4a1a-a568-5af69204c30f) · `dev3://task/25caf04b-0a41-4a1a-a568-5af69204c30f` _(dev3 added this footer — turn it off in Settings → Tasks.)_