### PR TITLE
Mark the selected sidebar scope with an accent pill

### DIFF
--- a/change-logs/2026/08/21/fix-sidebar-scope-switcher-active-state.md
+++ b/change-logs/2026/08/21/fix-sidebar-scope-switcher-active-state.md
@@ -1,0 +1,3 @@
+Short: Selected task scope now obvious
+
+The Active Tasks sidebar scope switcher (project / space / global) marked its selection only by a faint text-color shift and an outline-to-filled glyph swap, which was practically invisible at 20px. The selected scope now carries an accent-tinted pill, and the dashboard's All / Needs-you preset toggle uses the same accent pill so both switchers in that header speak one language.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -103,7 +103,14 @@ function ScopeGlyph({ outline, filled, active }: { outline: string; filled: stri
 
 /** Shared chrome for the three scope toggles — press feedback included. */
 const SCOPE_BUTTON_CLASS =
-	"inline-flex items-center justify-center h-5 w-5 leading-none transition-[color,scale] duration-150 ease-out active:scale-[0.96]";
+	"inline-flex items-center justify-center h-5 w-5 rounded-md leading-none transition-[color,background-color,scale] duration-150 ease-out active:scale-[0.96]";
+
+/**
+ * The glyph swap alone reads as noise at 20px — the selected scope carries an
+ * accent-tinted pill, the same "this control is on" language as the rest of the app.
+ */
+const SCOPE_STATE_CLASS = (active: boolean) =>
+	active ? "bg-accent/20 text-accent" : "text-fg-muted hover:text-fg-2 hover:bg-fg/5";
 
 function ActiveTasksSidebar({
 	project,
@@ -456,7 +463,7 @@ function ActiveTasksSidebar({
 										}}
 										aria-pressed={attentionOn === wantsAttention}
 										className={`px-2 py-0.5 rounded-md text-nano font-medium transition-colors ${
-											attentionOn === wantsAttention ? "bg-elevated text-fg" : "text-fg-3 hover:text-fg-2"
+											attentionOn === wantsAttention ? "bg-accent/20 text-accent" : "text-fg-3 hover:text-fg-2"
 										}`}
 										data-testid={`sidebar-preset-${key}`}
 									>
@@ -467,7 +474,11 @@ function ActiveTasksSidebar({
 						</div>
 					)}
 					{project && (
-					<div role="group" className="inline-flex items-center gap-px" aria-label={t("sidebar.scopeToggleTitle")}>
+					<div
+							role="group"
+							className="inline-flex items-center gap-px rounded-lg bg-raised p-0.5"
+							aria-label={t("sidebar.scopeToggleTitle")}
+						>
 						{/* Folder \u2014 this project only */}
 						<Tooltip content={t("sidebar.scopeProject")} detail={t("ttip.sidebar.scopeProject")} placement="bottom">
 							<button
@@ -475,9 +486,7 @@ function ActiveTasksSidebar({
 								onClick={() => setScope("project")}
 								aria-pressed={scope === "project"}
 								aria-label={t("sidebar.scopeProject")}
-								className={`${SCOPE_BUTTON_CLASS} ${
-									scope === "project" ? "text-fg" : "text-fg-muted hover:text-fg-2"
-								}`}
+								className={`${SCOPE_BUTTON_CLASS} ${SCOPE_STATE_CLASS(scope === "project")}`}
 								data-testid="sidebar-scope-project"
 							>
 								{/* Nerd Font: nf-fa-folder_open_o (U+F115) \u2192 nf-fa-folder_open (U+F07C) */}
@@ -503,9 +512,7 @@ function ActiveTasksSidebar({
 								className={`${SCOPE_BUTTON_CLASS} ${
 									siblingIds === null
 										? "text-fg-muted/40 cursor-not-allowed"
-										: scope === "space"
-											? "text-fg"
-											: "text-fg-muted hover:text-fg-2"
+										: SCOPE_STATE_CLASS(scope === "space")
 								}`}
 								data-testid="sidebar-scope-space"
 							>
@@ -521,9 +528,7 @@ function ActiveTasksSidebar({
 								onClick={() => setScope("global")}
 								aria-pressed={scope === "global"}
 								aria-label={t("sidebar.scopeGlobal")}
-								className={`${SCOPE_BUTTON_CLASS} ${
-									scope === "global" ? "text-fg" : "text-fg-muted hover:text-fg-2"
-								}`}
+								className={`${SCOPE_BUTTON_CLASS} ${SCOPE_STATE_CLASS(scope === "global")}`}
 								data-testid="sidebar-scope-global"
 							>
 								{/* Nerd Font: nf-cod-globe (U+EB01) \u2014 no filled counterpart, so the

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -1233,6 +1233,21 @@ describe("ActiveTasksSidebar — space scope", () => {
 		expect(screen.queryByTestId("sidebar-scope-space")).not.toBeInTheDocument();
 	});
 
+	it("tints only the selected scope with the accent pill", async () => {
+		const user = userEvent.setup();
+		const { api } = await import("../../rpc");
+		(api.request.getSpaces as ReturnType<typeof vi.fn>).mockResolvedValue(mockSpaces([["p1", "p2"]]));
+		renderSidebarWith([project, otherProject]);
+
+		const projectBtn = await screen.findByTestId("sidebar-scope-project");
+		expect(projectBtn.className).toContain("bg-accent/20");
+		expect(screen.getByTestId("sidebar-scope-global").className).not.toContain("bg-accent/20");
+
+		await user.click(screen.getByTestId("sidebar-scope-global"));
+		await waitFor(() => expect(screen.getByTestId("sidebar-scope-global").className).toContain("bg-accent/20"));
+		expect(screen.getByTestId("sidebar-scope-project").className).not.toContain("bg-accent/20");
+	});
+
 	it("disables the space button when spaces exist but the current project is in none", async () => {
 		const { api } = await import("../../rpc");
 		(api.request.getSpaces as ReturnType<typeof vi.fn>).mockResolvedValue(mockSpaces([["p2"]]));


### PR DESCRIPTION
The Active Tasks sidebar scope switcher (project / space / global) marked its selection only by a faint `text-fg` vs `text-fg-muted` shift plus an outline→filled glyph swap. At 20px that is practically invisible — you cannot tell which scope you are in.

The selected scope now carries an accent-tinted pill (`bg-accent/20 text-accent`) inside a `bg-raised` segmented container, matching the "this control is on" language used elsewhere in the app. The dashboard mount's `All / Needs you` preset toggle got the same accent pill, so both switchers in that header read the same way.

Verified in a real browser (headless Chromium, streamer mode) across all three scopes, dark and light themes; no console errors. Added a renderer test asserting only the selected scope carries the accent class.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=f4a7ccaf-dbe6-4f4c-87ea-d29a8f7cdca3) · `dev3://task/f4a7ccaf-dbe6-4f4c-87ea-d29a8f7cdca3`