### PR TITLE
Add a Stop tunnel button to Remote Access and make the modal a real dialog

### DIFF
--- a/change-logs/2026/08/21/feature-remote-access-stop-tunnel-button.md
+++ b/change-logs/2026/08/21/feature-remote-access-stop-tunnel-button.md
@@ -1,0 +1,3 @@
+Short: Stop button for the public tunnel
+
+The Remote Access modal now shows an explicit Stop button next to "Public tunnel active", so shutting the public Cloudflare tunnel down no longer depends on discovering that you have to uncheck the "Accessible from anywhere" checkbox. It clears the checkbox and tears the tunnel down, falling back to the local-network QR code.

--- a/change-logs/2026/08/21/feature-remote-access-stop-tunnel-button.md
+++ b/change-logs/2026/08/21/feature-remote-access-stop-tunnel-button.md
@@ -1,3 +1,3 @@
 Short: Stop button for the public tunnel
 
-The Remote Access modal now shows an explicit Stop button next to "Public tunnel active", so shutting the public Cloudflare tunnel down no longer depends on discovering that you have to uncheck the "Accessible from anywhere" checkbox. It clears the checkbox and tears the tunnel down, falling back to the local-network QR code.
+The Remote Access modal now shows an explicit Stop tunnel button next to "Public tunnel active", so shutting the public Cloudflare tunnel down no longer depends on discovering that you have to uncheck the "Accessible from anywhere" checkbox. The same modal became a real dialog along the way: it announces itself as one, traps keyboard focus, closes on Escape, and its tunnel-status line now uses the themed success color instead of a raw palette green that was unreadable in light mode.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -45,6 +45,7 @@ import StuckPreparationPopover from "./components/StuckPreparationPopover";
 import FolderPickerHost from "./components/FolderPickerModal";
 import KeyboardShortcutsModal, { type ShortcutsTab } from "./components/KeyboardShortcutsModal";
 import UpdatePopoverSimulatorModal from "./components/UpdatePopoverSimulatorModal";
+import RemoteAccessDialog from "./components/RemoteAccessDialog";
 import RemoteAccessExposedPorts from "./components/RemoteAccessExposedPorts";
 import { ConfirmHost, confirm } from "./confirm";
 import AgentLaunchRequestModal from "./components/AgentLaunchRequestModal";
@@ -2181,6 +2182,12 @@ function App() {
 		});
 	}, [applyRemoteQR]);
 
+	const closeRemoteQR = useCallback(() => {
+		setRemoteQR(null);
+		setRemoteUrlCopyState("idle");
+		setTunnelStarting(false);
+	}, []);
+
 	// Tear the public tunnel down and fall back to the local-network QR. Shared by
 	// the toggle and the explicit Stop button so both paths behave identically.
 	const stopRemoteTunnel = useCallback(() => {
@@ -2619,18 +2626,9 @@ function App() {
 				</div>
 			)}
 			{remoteQR && (
-				<div
-					className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-					onMouseDown={(e) => {
-						if (e.target === e.currentTarget) {
-							setRemoteQR(null);
-							setRemoteUrlCopyState("idle");
-							setTunnelStarting(false);
-						}
-					}}
-				>
-					<div className="bg-overlay border border-edge rounded-2xl shadow-2xl w-[28rem] p-6 space-y-4 text-center">
-						<h2 className="text-fg text-lg font-semibold">{t("remote.title")}</h2>
+				<RemoteAccessDialog titleId="remote-access-dialog-title" onClose={closeRemoteQR}>
+					<>
+						<h2 id="remote-access-dialog-title" className="text-fg text-lg font-semibold">{t("remote.title")}</h2>
 						<p className="text-fg-2 text-sm">{t("remote.subtitle")}</p>
 						<div className="flex justify-center relative">
 							{tunnelUrlPending ? (
@@ -2776,14 +2774,14 @@ function App() {
 
 							{tunnelWanted && remoteQR.tunnelState === "connected" && (
 								<div className="flex items-center gap-2">
-									<div className="w-2 h-2 rounded-full bg-green-400" />
-									<span className="text-green-400 text-xs">{t("remote.tunnelConnected")}</span>
+									<div className="w-2 h-2 rounded-full bg-success" />
+									<span className="text-success text-xs">{t("remote.tunnelConnected")}</span>
 									<button
 										type="button"
 										data-testid="remote-stop-tunnel"
 										onClick={stopRemoteTunnel}
 										title={t("remote.stopTunnelHint")}
-										className="ml-auto px-2 py-1 rounded-md border border-danger/30 text-danger text-xs hover:bg-danger/10 transition-colors"
+										className="ml-auto min-h-6 px-2 py-1.5 rounded-lg border border-edge text-fg-2 text-xs hover:text-fg hover:bg-elevated hover:border-edge-active transition-[color,background-color,border-color,transform] active:scale-[0.96]"
 									>
 										{t("remote.stopTunnel")}
 									</button>
@@ -2856,14 +2854,14 @@ function App() {
 							</button>
 							<button
 								type="button"
-								onClick={() => { setRemoteQR(null); setRemoteUrlCopyState("idle"); setTunnelStarting(false); }}
+								onClick={closeRemoteQR}
 								className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
 							>
 								{t("remote.close")}
 							</button>
 						</div>
-					</div>
-				</div>
+					</>
+				</RemoteAccessDialog>
 			)}
 			<StuckPreparationPopover tasks={state.currentProjectTasks} />
 			<FolderPickerHost />

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2181,6 +2181,20 @@ function App() {
 		});
 	}, [applyRemoteQR]);
 
+	// Tear the public tunnel down and fall back to the local-network QR. Shared by
+	// the toggle and the explicit Stop button so both paths behave identically.
+	const stopRemoteTunnel = useCallback(() => {
+		setTunnelWanted(false);
+		setTunnelStarting(false);
+		setRemoteAccessActive(false);
+		api.request.stopTunnel().then(() => {
+			api.request.getRemoteAccessQR({ tunnel: false }).then((res) => {
+				applyRemoteQR(res);
+				setQrCountdown(25);
+			}).catch(() => {});
+		}).catch(() => {});
+	}, [applyRemoteQR]);
+
 	// Listen for the Remote Access open request (header button, kebab, native menu)
 	useEffect(() => {
 		function onShowRemoteQR(e: Event) {
@@ -2701,13 +2715,7 @@ function App() {
 										if (want && remoteQR.cloudflaredInstalled && remoteQR.tunnelState === "idle") {
 											startRemoteTunnel();
 										} else if (!want && remoteQR.tunnelState === "connected") {
-											setRemoteAccessActive(false);
-											api.request.stopTunnel().then(() => {
-												api.request.getRemoteAccessQR({ tunnel: false }).then((res) => {
-													applyRemoteQR(res);
-													setQrCountdown(25);
-												}).catch(() => {});
-											}).catch(() => {});
+											stopRemoteTunnel();
 										}
 									}}
 									className="accent-accent w-4 h-4"
@@ -2770,6 +2778,15 @@ function App() {
 								<div className="flex items-center gap-2">
 									<div className="w-2 h-2 rounded-full bg-green-400" />
 									<span className="text-green-400 text-xs">{t("remote.tunnelConnected")}</span>
+									<button
+										type="button"
+										data-testid="remote-stop-tunnel"
+										onClick={stopRemoteTunnel}
+										title={t("remote.stopTunnelHint")}
+										className="ml-auto px-2 py-1 rounded-md border border-danger/30 text-danger text-xs hover:bg-danger/10 transition-colors"
+									>
+										{t("remote.stopTunnel")}
+									</button>
 								</div>
 							)}
 

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1983,6 +1983,26 @@ describe("App keyboard shortcuts", () => {
 			expect(screen.getByText("Connected")).toBeInTheDocument();
 		});
 
+		it("is a real dialog: labelled, focus pulled in, Escape closes it", async () => {
+			await renderApp();
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,test",
+					accessUrl: "http://192.168.0.1:1234/?token=test",
+					tunnelState: "idle",
+					cloudflaredInstalled: false,
+				},
+			}));
+
+			const dialog = await screen.findByRole("dialog");
+			expect(dialog).toHaveAttribute("aria-modal", "true");
+			expect(dialog).toHaveAccessibleName("Remote Access");
+			await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+
+			await userEvent.keyboard("{Escape}");
+			await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+		});
+
 		it("stops the tunnel and clears the toggle from the Stop button", async () => {
 			await renderApp();
 			vi.mocked(api.request.getRemoteAccessQR).mockResolvedValue({

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1983,6 +1983,39 @@ describe("App keyboard shortcuts", () => {
 			expect(screen.getByText("Connected")).toBeInTheDocument();
 		});
 
+		it("stops the tunnel and clears the toggle from the Stop button", async () => {
+			await renderApp();
+			vi.mocked(api.request.getRemoteAccessQR).mockResolvedValue({
+				qrDataUrl: "data:image/png;base64,local",
+				accessUrl: "http://192.168.0.1:1234/?token=local",
+				tunnelState: "idle",
+				cloudflaredInstalled: true,
+				interfaces: [],
+				selectedHost: "192.168.0.1",
+			});
+
+			window.dispatchEvent(new CustomEvent("rpc:showRemoteAccessQR", {
+				detail: {
+					qrDataUrl: "data:image/png;base64,tunnel",
+					accessUrl: "https://foo.trycloudflare.com/?token=t",
+					tunnelState: "connected",
+					cloudflaredInstalled: true,
+				},
+			}));
+
+			const stop = await screen.findByTestId("remote-stop-tunnel");
+			expect(screen.getByText("Public tunnel active")).toBeInTheDocument();
+
+			await userEvent.click(stop);
+
+			await waitFor(() => expect(api.request.stopTunnel).toHaveBeenCalled());
+			await waitFor(() => {
+				expect(screen.queryByTestId("remote-stop-tunnel")).not.toBeInTheDocument();
+			});
+			expect(screen.getByLabelText("Accessible from anywhere (Cloudflare Tunnel)", { selector: "input" })).not.toBeChecked();
+			expect(api.request.getRemoteAccessQR).toHaveBeenCalledWith({ tunnel: false });
+		});
+
 		it("resets consumed state when modal is reopened", async () => {
 			await renderApp();
 

--- a/src/mainview/components/InlineRename.tsx
+++ b/src/mainview/components/InlineRename.tsx
@@ -99,7 +99,7 @@ export default function InlineRename({
 				<button
 					onClick={() => save(value)}
 					disabled={saving}
-					className="flex-shrink-0 p-0.5 rounded hover:bg-elevated transition-colors text-green-400 hover:text-green-300"
+					className="flex-shrink-0 p-0.5 rounded hover:bg-elevated transition-colors text-success hover:text-success-hover"
 					title={t("task.rename")}
 					data-testid="rename-save"
 				>

--- a/src/mainview/components/RemoteAccessDialog.tsx
+++ b/src/mainview/components/RemoteAccessDialog.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { useFocusTrap } from "../utils/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+
+type RemoteAccessDialogProps = {
+	titleId: string;
+	onClose: () => void;
+	children: ReactNode;
+};
+
+/**
+ * Dialog shell for the Remote Access modal. It exists as its own component so
+ * the focus trap mounts and unmounts with the modal — `useFocusTrap` captures
+ * the trigger element on its first render, which is wrong if the hook lives in
+ * a host that is always mounted.
+ */
+function RemoteAccessDialog({ titleId, onClose, children }: RemoteAccessDialogProps) {
+	const trapRef = useFocusTrap<HTMLDivElement>();
+	useEscapeKey(onClose);
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div
+				ref={trapRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				tabIndex={-1}
+				className="bg-overlay border border-edge rounded-2xl shadow-2xl w-[28rem] p-6 space-y-4 text-center outline-none"
+			>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+export default RemoteAccessDialog;

--- a/src/mainview/components/RequirementsCheck.tsx
+++ b/src/mainview/components/RequirementsCheck.tsx
@@ -67,7 +67,7 @@ export default function RequirementsCheck({ results, checking, onRefresh, onRefr
 							>
 							<span className="mt-0.5 text-lg leading-none">
 								{req.installed ? (
-									<span className="text-green-400">&#10003;</span>
+									<span className="text-success">&#10003;</span>
 								) : (
 									<span className="text-danger">&#10007;</span>
 								)}
@@ -83,7 +83,7 @@ export default function RequirementsCheck({ results, checking, onRefresh, onRefr
 									<span
 										className={`text-xs px-1.5 py-0.5 rounded ${
 											req.installed
-												? "bg-green-400/15 text-green-400"
+												? "bg-success/15 text-success"
 												: req.optional
 													? "bg-yellow-400/15 text-yellow-400"
 													: "bg-danger/15 text-danger"
@@ -127,7 +127,7 @@ export default function RequirementsCheck({ results, checking, onRefresh, onRefr
 												)}
 											</button>
 											{copiedId === req.id && (
-												<span className="text-green-400 text-xs">
+												<span className="text-success text-xs">
 													{t("requirements.copied")}
 												</span>
 											)}

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -151,7 +151,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Recheck",
 	"remote.tunnelStarting": "Starting tunnel...",
 	"remote.tunnelConnected": "Public tunnel active",
-	"remote.stopTunnel": "Stop",
+	"remote.stopTunnel": "Stop tunnel",
 	"remote.stopTunnelHint": "Stop the public tunnel and go back to local-network access",
 	"remote.tunnelPropagationHint": "Give Cloudflare a few seconds to publish the domain. If the link errors with “domain not resolved”, wait a moment — or toggle this off and back on — then reopen it.",
 	"remote.tunnelFailed": "Tunnel failed to start",

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -151,6 +151,8 @@ const dashboard = {
 	"remote.recheckCloudflared": "Recheck",
 	"remote.tunnelStarting": "Starting tunnel...",
 	"remote.tunnelConnected": "Public tunnel active",
+	"remote.stopTunnel": "Stop",
+	"remote.stopTunnelHint": "Stop the public tunnel and go back to local-network access",
 	"remote.tunnelPropagationHint": "Give Cloudflare a few seconds to publish the domain. If the link errors with “domain not resolved”, wait a moment — or toggle this off and back on — then reopen it.",
 	"remote.tunnelFailed": "Tunnel failed to start",
 	"remote.copyUrl": "Copy URL",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -151,7 +151,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Verificar de nuevo",
 	"remote.tunnelStarting": "Iniciando túnel...",
 	"remote.tunnelConnected": "Túnel público activo",
-	"remote.stopTunnel": "Detener",
+	"remote.stopTunnel": "Detener túnel",
 	"remote.stopTunnelHint": "Detener el túnel público y volver al acceso por red local",
 	"remote.tunnelPropagationHint": "Dale a Cloudflare unos segundos para publicar el dominio. Si el enlace da el error «dominio no resuelto», espera un momento —o desactiva y vuelve a activar esta casilla— y ábrelo de nuevo.",
 	"remote.tunnelFailed": "No se pudo iniciar el túnel",

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -151,6 +151,8 @@ const dashboard = {
 	"remote.recheckCloudflared": "Verificar de nuevo",
 	"remote.tunnelStarting": "Iniciando túnel...",
 	"remote.tunnelConnected": "Túnel público activo",
+	"remote.stopTunnel": "Detener",
+	"remote.stopTunnelHint": "Detener el túnel público y volver al acceso por red local",
 	"remote.tunnelPropagationHint": "Dale a Cloudflare unos segundos para publicar el dominio. Si el enlace da el error «dominio no resuelto», espera un momento —o desactiva y vuelve a activar esta casilla— y ábrelo de nuevo.",
 	"remote.tunnelFailed": "No se pudo iniciar el túnel",
 	"remote.copyUrl": "Copiar URL",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -169,6 +169,8 @@ const dashboard = {
 	"remote.recheckCloudflared": "Проверить снова",
 	"remote.tunnelStarting": "Запуск туннеля...",
 	"remote.tunnelConnected": "Публичный туннель активен",
+	"remote.stopTunnel": "Остановить",
+	"remote.stopTunnelHint": "Остановить публичный туннель и вернуться к доступу по локальной сети",
 	"remote.tunnelPropagationHint": "Дайте Cloudflare пару секунд, чтобы опубликовать домен. Если по ссылке ошибка «домен не резолвится» — подождите немного или выключите и снова включите эту галочку, затем откройте заново.",
 	"remote.tunnelFailed": "Не удалось запустить туннель",
 	"remote.copyUrl": "Скопировать URL",

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -169,7 +169,7 @@ const dashboard = {
 	"remote.recheckCloudflared": "Проверить снова",
 	"remote.tunnelStarting": "Запуск туннеля...",
 	"remote.tunnelConnected": "Публичный туннель активен",
-	"remote.stopTunnel": "Остановить",
+	"remote.stopTunnel": "Остановить туннель",
 	"remote.stopTunnelHint": "Остановить публичный туннель и вернуться к доступу по локальной сети",
 	"remote.tunnelPropagationHint": "Дайте Cloudflare пару секунд, чтобы опубликовать домен. Если по ссылке ошибка «домен не резолвится» — подождите немного или выключите и снова включите эту галочку, затем откройте заново.",
 	"remote.tunnelFailed": "Не удалось запустить туннель",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

Stopping the public Cloudflare tunnel used to depend on noticing that you have to *uncheck* the "Accessible from anywhere" checkbox — nothing on the panel said so. The tunnel-status line now carries an explicit **Stop tunnel** button that clears the checkbox and tears the tunnel down, falling back to the local-network QR code.

A cross-discipline interface review of that panel turned up six more issues, all fixed here:

- **The Remote Access modal was never a dialog.** No `role="dialog"`, no `aria-modal`, no focus trap, no Escape handler — Tab from the freshly opened modal landed on the app chrome *behind* the overlay, so the new button (and Copy URL, and Close) were unreachable by keyboard. The shell moved into `RemoteAccessDialog.tsx` so `useFocusTrap` mounts and unmounts with the modal, which is what the hook needs to capture the right trigger element; `useEscapeKey` and the ARIA attributes come with it.
- **`bg-green-400` / `text-green-400` on the status line did not theme.** Measured against the light-theme surface it scored 1.52:1 — the label was unreadable and the dot missed even the 3:1 non-text floor. Now on the `success` token: 3.85:1. The same raw palette green is gone from `RequirementsCheck.tsx` and `InlineRename.tsx` too; the renderer no longer contains `green-400`.
- **The Stop button wore the destructive role without the confirmation it implies.** `danger` styling on a reversible action that fires immediately, right next to a checkbox that does the same thing with no friction. It is neutral now.
- **Hit area below the WCAG 2.5.8 floor on mobile** (22.2px at the app's mobile root font) — on the one surface that exists specifically for reaching dev3 from a phone. `min-h-6` plus a little more vertical padding: 25.5px there, 30px on desktop.
- **Radius and press feedback** brought in line with the surrounding buttons: `rounded-lg` matching the sibling hint box, and `active:scale-[0.96]` like the other 45 buttons in the renderer.
- **Label names its object** — "Stop tunnel" / "Остановить туннель" / "Detener túnel" — instead of leaving the consequence only in a `title` tooltip, which keyboard and touch users never see.

One verification gap worth stating plainly: **Escape is covered by a unit test, not by a real keystroke.** Headless Chromium in this environment never delivers an Escape keydown to the page — neither through the CLI browser nor through Playwright, while ordinary keys arrive normally — so the Escape path rests on `userEvent.keyboard("{Escape}")` exercising the real `useEscapeKey` chain, plus a mutation run that confirms the assertion fails when the hook is removed. Worth one manual press by a human reviewer.

`src/bun/__tests__/native-pane-owner-forward.test.ts` fails locally on this machine with `listen EINVAL` because the temp-dir socket path exceeds the macOS 104-character limit. Verified pre-existing: a clean `origin/main` worktree fails identically (10 failed / 8 passed). Everything else is green — renderer 4336, backend 6258, CLI 813.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ce7dc1be-777b-494c-94e6-c07a69dc6424) · `dev3://task/ce7dc1be-777b-494c-94e6-c07a69dc6424` _(dev3 added this footer — turn it off in Settings → Tasks.)_
