### PR TITLE
Add dev3 task open to focus the app on a task from the CLI

### DIFF
--- a/change-logs/2026/08/21/feature-task-open-cli-deep-link.md
+++ b/change-logs/2026/08/21/feature-task-open-cli-deep-link.md
@@ -1,0 +1,5 @@
+Short: Open a task from the CLI
+
+`dev3 task open [<id>]` brings the app to the front on a task — the CLI twin of a `dev3://task/<id>` link, but it needs no registered URL scheme, so it works on every platform. Without an id it targets the current worktree's task, it honors the split-vs-fullscreen open-mode preference, and it reopens a window when the app is sitting window-less in the dock.
+
+Suggested by @sworgkh (h0x91b/dev-3.0#632)

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -172,6 +172,13 @@ import { saveSharedImage } from "../shared-images";
 import { saveSharedArtifact } from "../shared-artifacts";
 import { closePaneRun, paneRunListing, readPaneRun, startPaneRun } from "../task-pane-runs";
 
+// `task.open` imports the window layer lazily; mocking it keeps electrobun out.
+vi.mock("../window-manager", () => ({
+	getWindowCount: vi.fn(() => 1),
+	focusFocusedWindow: vi.fn(() => true),
+	openNewWindow: vi.fn(),
+}));
+
 vi.mock("../artifact-template", () => ({
 	ensureArtifactTemplate: vi.fn(() => "/wt-container/artifact-template-v1"),
 }));
@@ -3449,5 +3456,53 @@ describe("vent.add", () => {
 		const resp = await handleRequest(makeRequest("vent.add", { name: "n", content: "" }));
 		expect(resp.ok).toBe(false);
 		expect(addVent).not.toHaveBeenCalled();
+	});
+});
+
+describe("task.open", () => {
+	it("focuses the live window and pushes the same nav an inbound deep link uses", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		const push = vi.fn();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(getPushMessage).mockReturnValue(push as never);
+		const wm = await import("../window-manager");
+		vi.mocked(wm.getWindowCount).mockReturnValue(1);
+
+		const resp = await handleRequest(makeRequest("task.open", { taskId: task.id, projectId: project.id }));
+
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toMatchObject({ taskId: task.id, projectId: project.id, delivered: true });
+		expect(wm.focusFocusedWindow).toHaveBeenCalled();
+		expect(push).toHaveBeenCalledWith("openDeepLink", { kind: "task", taskId: task.id, projectId: project.id });
+	});
+
+	it("stashes the target and reopens a window when the app sits window-less", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		const push = vi.fn();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(getPushMessage).mockReturnValue(push as never);
+		const wm = await import("../window-manager");
+		vi.mocked(wm.getWindowCount).mockReturnValue(0);
+
+		const resp = await handleRequest(makeRequest("task.open", { taskId: task.id, projectId: project.id }));
+
+		expect(resp.data).toMatchObject({ delivered: true, reopened: true });
+		expect(wm.openNewWindow).toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+		const { consumePendingDeepLinkNav } = await import("../deep-link-nav");
+		expect(consumePendingDeepLinkNav()).toEqual({ kind: "task", taskId: task.id, projectId: project.id });
+	});
+
+	it("fails on an unknown task", async () => {
+		vi.mocked(data.getProject).mockResolvedValue(makeProject());
+		vi.mocked(data.loadTasks).mockResolvedValue([]);
+
+		const resp = await handleRequest(makeRequest("task.open", { taskId: "nope-1234", projectId: "proj-1" }));
+
+		expect(resp.ok).toBe(false);
 	});
 });

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -7,6 +7,8 @@ import { isCliEndpointHandle } from "../shared/cli-endpoint";
 import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, appendTaskNote, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, titleFromDescription } from "../shared/types";
 import { CODEX_STATUS_HOOK_EVENTS, getCodexHookTargetStatus, type CodexStatusHookEvent } from "../shared/agent-hooks";
 import { CLAUDE_STOP_FAILURE_ERRORS, describeClaudeStopFailure, type ClaudeStopFailureError } from "../shared/agent-stop-failure";
+import type { DeepLinkNav } from "../shared/deep-link";
+import { markPendingDeepLinkNav } from "./deep-link-nav";
 import { SharedImageError, saveSharedImage } from "./shared-images";
 import { SharedArtifactError, saveSharedArtifact } from "./shared-artifacts";
 import { addAutomation, deleteAutomation, loadAutomations, updateAutomation } from "./automations-data";
@@ -1034,6 +1036,33 @@ const handlers: Record<string, Handler> = {
 		const { task: updated, state } = await switchTaskTerminalBackend(project, task, String(params.to));
 		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 		return { taskId: updated.id, projectId: project.id, ...state, liveBackend: null };
+	},
+
+	/**
+	 * `dev3 task open` — navigate the running UI to a task from outside the app.
+	 * Deliberately the same two paths as an inbound `dev3://task/<id>` link
+	 * (decisions/2026/08/04/dev3-url-scheme-deep-links.md), so the open-mode
+	 * preference and the cold-start pull-on-mount come for free.
+	 *
+	 * The window layer is imported lazily and never in headless remote mode,
+	 * which has no windows and must not drag in electrobun.
+	 */
+	"task.open": async (params) => {
+		const { project, task } = await resolveTaskFromParams(params);
+		const nav: DeepLinkNav = { kind: "task", taskId: task.id, projectId: project.id };
+		if (process.env.DEV3_HEADLESS !== "1") {
+			const { focusFocusedWindow, getWindowCount, openNewWindow } = await import("./window-manager");
+			if (getWindowCount() === 0) {
+				markPendingDeepLinkNav(nav);
+				openNewWindow();
+				return { taskId: task.id, projectId: project.id, delivered: true, reopened: true };
+			}
+			focusFocusedWindow();
+		}
+		const push = getPushMessage();
+		if (!push) return { taskId: task.id, projectId: project.id, delivered: false };
+		push("openDeepLink", nav);
+		return { taskId: task.id, projectId: project.id, delivered: true };
 	},
 
 	"task.setLabels": async (params) => {

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -1498,3 +1498,46 @@ describe("task create --scratch --run", () => {
 		).rejects.toThrow(`EXIT_${CLI_EXIT_CODE_LAUNCH_DECLINED}`);
 	});
 });
+
+describe("task open", () => {
+	it("sends task.open with the explicit id", async () => {
+		mockSend.mockResolvedValue(okResp({ taskId: FAKE_TASK.id, projectId: "proj-001", delivered: true }));
+
+		await handleTask("open", args(["aaaaaaaa"]), SOCKET, null);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.open", { taskId: "aaaaaaaa" });
+		expect(stdoutOutput).toContain("Opened task aaaaaaaa in the app.");
+	});
+
+	it("auto-detects the task and project from the worktree context", async () => {
+		mockSend.mockResolvedValue(okResp({ taskId: FAKE_TASK.id, projectId: "proj-001", delivered: true }));
+
+		await handleTask("open", args([]), SOCKET, CTX);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.open", {
+			taskId: CTX.taskId,
+			projectId: CTX.projectId,
+		});
+	});
+
+	it("reports a reopened window separately from a focused one", async () => {
+		mockSend.mockResolvedValue(okResp({ taskId: FAKE_TASK.id, delivered: true, reopened: true }));
+
+		await handleTask("open", args(["aaaaaaaa"]), SOCKET, null);
+
+		expect(stdoutOutput).toContain("Opening a window on task aaaaaaaa.");
+	});
+
+	it("says nothing was opened when the app has no renderer to navigate", async () => {
+		mockSend.mockResolvedValue(okResp({ taskId: FAKE_TASK.id, delivered: false }));
+
+		await handleTask("open", args(["aaaaaaaa"]), SOCKET, null);
+
+		expect(stdoutOutput).toContain("nothing was opened");
+	});
+
+	it("exits with a usage error when no task can be resolved", async () => {
+		await expect(handleTask("open", args([]), SOCKET, null)).rejects.toThrow(/EXIT_/);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -477,6 +477,37 @@ async function moveTask(args: ParsedArgs, socketPath: string, context: CliContex
 	process.stdout.write(`Moved task ${task.id.slice(0, 8)} → ${displayStatus}\n`);
 }
 
+/**
+ * `dev3 task open [<id>]` — bring the running app to the front on a task, the
+ * CLI twin of clicking a `dev3://task/<id>` link (and it works on every OS,
+ * because nothing here needs a registered URL scheme).
+ */
+async function openTask(args: ParsedArgs, socketPath: string, context: CliContext | null): Promise<void> {
+	rejectUnknownFlags(args, ["id", "task", "task-id", "project"]);
+	const taskId = resolveTaskId(args, context);
+	if (!taskId) {
+		exitUsage("Usage: dev3 task open <id|--task id|--task-id id|--id id> (or run inside a worktree)");
+	}
+
+	const params: Record<string, unknown> = { taskId };
+	const projectId = resolveProjectId(args.flags.project, context);
+	if (projectId) params.projectId = projectId;
+
+	const resp = await sendRequest(socketPath, "task.open", params);
+	if (!resp.ok) exitError(resp.error || "Failed to open the task");
+
+	const data = resp.data as { taskId: string; delivered: boolean; reopened?: boolean };
+	if (!data.delivered) {
+		process.stdout.write("App is running but has no window to navigate — nothing was opened.\n");
+		return;
+	}
+	process.stdout.write(
+		data.reopened
+			? `Opening a window on task ${data.taskId.slice(0, 8)}.\n`
+			: `Opened task ${data.taskId.slice(0, 8)} in the app.\n`,
+	);
+}
+
 interface TerminalBackendReport {
 	taskId: string;
 	backend: "tmux" | "native";
@@ -544,6 +575,8 @@ export async function handleTask(
 			return updateTask(args, socketPath, context);
 		case "move":
 			return moveTask(args, socketPath, context);
+		case "open":
+			return openTask(args, socketPath, context);
 		case "terminal-backend":
 			return taskTerminalBackend(args, socketPath, context);
 		case "list":
@@ -553,7 +586,7 @@ export async function handleTask(
 		default:
 			exitUsage(
 				`Unknown subcommand: task ${subcommand || "(none)"}` +
-				"\nAvailable: task show, task create, task update, task move, task terminal-backend",
+				"\nAvailable: task show, task create, task update, task move, task open, task terminal-backend",
 			);
 	}
 }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -110,6 +110,16 @@ const COMMANDS: CommandHelp[] = [
 					"the user, who picks the agent; exit 10 if they decline.",
 				],
 			},
+			{
+				name: "open",
+				usage: "dev3 task open [<id>] [--task <id>]",
+				summary: "Focus the app on a task (same navigation as a dev3://task/<id> link).",
+				details: [
+					"Without an id, targets the current worktree's task.",
+					"Honors the split-vs-fullscreen task open-mode preference.",
+					"Reopens a window when the app sits window-less in the dock.",
+				],
+			},
 		],
 	},
 	{


### PR DESCRIPTION
`dev3 task open [<id>]` navigates the running app to a task from outside it — the CLI twin of an inbound `dev3://task/<id>` deep link, minus the URL scheme, so it works on every platform (the scheme is macOS-only).

Deliberately thin: the new `task.open` socket handler reuses the deep-link machinery end to end. A live window is focused and gets an `openDeepLink` push (so the split-vs-fullscreen open-mode preference applies for free); a window-less app stashes the target via `markPendingDeepLinkNav` and reopens a window, which pulls it on mount. The window layer is imported lazily and skipped entirely under `DEV3_HEADLESS=1`, so headless remote mode never reaches electrobun.

Closes the last unshipped piece of h0x91b/dev-3.0#632.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=cc1ed30c-e99c-46b9-ab9f-e41bbad82ab5) · `dev3://task/cc1ed30c-e99c-46b9-ab9f-e41bbad82ab5`