### PR TITLE
Disable text selection on the Kanban board

### DIFF
--- a/change-logs/2026/08/21/fix-kanban-no-text-selection.md
+++ b/change-logs/2026/08/21/fix-kanban-no-text-selection.md
@@ -1,0 +1,3 @@
+Short: No stray text selection on the board
+
+Dragging across the Kanban board no longer smears a text selection over task titles and column headers — the board and the mobile column carousel are now non-selectable, like the controls they are. Renaming a column still lets you select inside its input.

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -712,7 +712,7 @@ function KanbanBoard({
 			{isCarousel ? (
 				<MobileBoardCarousel columns={carouselColumns} initialColumnId={initialColumnId} />
 			) : (
-				<div className="flex-1 min-h-0 flex gap-5 px-6 pb-6 pt-2 overflow-x-auto overflow-y-hidden kanban-scroll">
+				<div className="flex-1 min-h-0 flex gap-5 px-6 pb-6 pt-2 overflow-x-auto overflow-y-hidden kanban-scroll select-none">
 					{(() => {
 						// Add-column affordance (issue #222): a slim dashed ghost strip that
 						// reuses the board's "+" idiom — no toolbar button. It sits right

--- a/src/mainview/components/KanbanColumn.tsx
+++ b/src/mainview/components/KanbanColumn.tsx
@@ -505,7 +505,7 @@ function KanbanColumn({
 								if (e.key === "Enter") e.currentTarget.blur();
 								if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); setEditing(false); }
 							}}
-							className="text-fg text-sm font-semibold bg-transparent outline-none border-b border-accent flex-1 min-w-0"
+							className="text-fg text-sm font-semibold bg-transparent outline-none border-b border-accent flex-1 min-w-0 select-text"
 							autoFocus
 						/>
 					) : (

--- a/src/mainview/components/MobileBoardCarousel.tsx
+++ b/src/mainview/components/MobileBoardCarousel.tsx
@@ -92,7 +92,7 @@ function MobileBoardCarousel({ columns, initialColumnId }: { columns: CarouselCo
 
 	return (
 		<div
-			className="flex-1 min-h-0 flex flex-col"
+			className="flex-1 min-h-0 flex flex-col select-none"
 			role="group"
 			aria-roledescription={t("kanban.carouselRole")}
 			onKeyDown={handleKeyDown}


### PR DESCRIPTION
Dragging across the Kanban board smeared a text selection over task titles and column headers — pointless on a board whose cards are drag handles, and it looked like a rendering glitch.

- `select-none` on the board container and on the mobile column carousel.
- The column rename input opts back in with `select-text`.

Verified in a real browser with a paired test: with the fix a mouse drag across cards yields an empty `window.getSelection()`; with `select-none` removed the same drag selects card titles (Chromium's UA rule hides this on `draggable` cards, so the test strips `draggable` to emulate WebKit, which is what the desktop app runs).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=90b2a9ea-11d4-4197-b9e7-4578a5dc3c9c) · `dev3://task/90b2a9ea-11d4-4197-b9e7-4578a5dc3c9c`