### PR TITLE
Lead the tmux config-race record with its three conclusions

### DIFF
--- a/decisions/2026/08/21/tmux-shared-config-path-is-not-the-race.md
+++ b/decisions/2026/08/21/tmux-shared-config-path-is-not-the-race.md
@@ -1,7 +1,10 @@
 # The shared tmux config path is not a race — tmux never dies from a bad config
 
 Closed as not-a-bug. Read this before you reach for `/tmp/dev3-tmux-dark.conf` to explain
-`TmuxError: tmux -f failed (exit 1): server exited unexpectedly`.
+`TmuxError: tmux -f failed (exit 1): server exited unexpectedly`. If you are mid-incident,
+three answers up front: the shared config path is **not** the cause; the real cause of that
+error is **still unfound**; and the two places to start instead are the stale pid-keyed tmux
+socket files and resource pressure under `scripts/run-terminal-e2e.ts` — both in §3.
 
 ## 1. Context
 


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

Follow-up to #1461, four lines. That record has no code in it, so its readability *is* the deliverable, and the reader it was written for arrives mid-incident with a failing job and skims.

Two of its three conclusions were already at the top; the third — that the real cause of `server exited unexpectedly` is still unfound, and where to start instead — sat in §3. A skimmer therefore left with "not a race" and no next step, which is half of what the investigation produced. This restates all three in the opening paragraph.

No content re-argued, no findings added, nothing moved out of §3.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=eaa02352-b129-476d-a9e2-4866bfa84d9e) · `dev3://task/eaa02352-b129-476d-a9e2-4866bfa84d9e`
