### PR TITLE
Scope a QA app instance by honouring DEV3_HOME in one place

### DIFF
--- a/.claude/skills/debug-ui/SKILL.md
+++ b/.claude/skills/debug-ui/SKILL.md
@@ -57,6 +57,28 @@ That's it. `DEV3_REMOTE_PORT=${DEV3_PORT0:-0}` is wired into the repo's `dev` sc
 `portCount: 1` is committed in `.dev3/config.json`, so the dev app binds the exact port shown
 above (see [decision 093](../../../decisions/2026/06/30/dev-remote-port-from-pool.md)).
 
+## Scoped QA: a throwaway board instead of the real one
+
+`dev3 dev-server start` boots a full dev3 instance on **your real board** — another task's
+"Branch Merged — mark completed?" dialog is live and clickable in your browser, and another task's
+terminal is reachable by navigation. For anything that does not specifically need real data, run the
+scoped instance instead:
+
+```bash
+dev3 pane run "cd $PWD && bun run dev --qa"     # throwaway board: one fixture project, zero tasks
+dev3 pane run "cd $PWD && bun run dev --qa=virgin"   # completely empty home — first-run state
+dev3 pane logs <run-id>                          # it prints the scoped DEV3_HOME and a reset line
+```
+
+It binds the same `DEV3_PORT0` and prints the port, so steps 3–4 of the flow above are unchanged.
+The scoped root is stable per worktree, so a restart reuses the same board; `rm -rf` the printed
+root to start over.
+
+**What it does NOT isolate** — name these rather than assuming a clean room: the tmux socket
+directory (only `TMUX_TMPDIR` moves it, and dev3 sets it nowhere), the PowerShell history file on
+Windows, the user's own `~/.codex` / `~/.claude` agent configs, and `dev3` CLI commands run from
+inside a REAL worktree (cwd-based task detection outranks `$DEV3_HOME` by design).
+
 ## Gotchas
 
 - **The browser is a machine-global singleton — isolate per task or agents stomp each other.**

--- a/change-logs/2026/08/21/feature-scoped-qa-app-instance.md
+++ b/change-logs/2026/08/21/feature-scoped-qa-app-instance.md
@@ -1,0 +1,3 @@
+Short: Throwaway board for browser QA
+
+`bun run dev --qa` now launches the app against a throwaway data root instead of your real board, so browser verification cannot click another task's "Branch Merged" dialog or reach another task's live terminal. `--qa=virgin` gives a completely empty home — the state a brand-new user is in. `$DEV3_HOME` is now honoured by one shared resolver across the app, the CLI and the native terminal paths, which previously disagreed and produced a half-redirected instance.

--- a/decisions/2026/08/21/scoped-qa-app-instance.md
+++ b/decisions/2026/08/21/scoped-qa-app-instance.md
@@ -1,0 +1,105 @@
+# A QA app instance is scoped by redirecting DEV3_HOME, not by suppressing prompts
+
+## Context
+
+An app instance started for browser verification (`bun run dev`, or a task's dev-server)
+renders the developer's whole real board. Two vents reported the consequence: another task's
+"Branch Merged — mark this task as completed?" approval dialog is live and clickable inside the
+agent's own headless browser, and another task's live terminal is reachable by navigation, so a
+stray keystroke lands in someone else's agent session. Both times the agent aborted the
+verification and shipped the requested UI check as an explicit gap.
+
+A third consumer arrived mid-task: nobody on the team can reach dev3's first-run experience —
+no project, no config, nothing — without risking their real data, and that is the next macro-goal.
+
+## Investigation
+
+`DEV3_HOME` named **two different things**, and that is the root of the bug rather than an
+oversight. It was a constant in `src/bun/paths.ts` derived from `resolveUserHome()`, which
+ignored the environment variable — while exactly three modules honoured the variable, each with
+its own inline fallback chain: `native-terminal-registry/paths.ts`, `native-terminal-multipane/paths.ts`,
+`prototypes/detached-pty/state.ts`. Setting `DEV3_HOME` therefore produced a *half*-redirected
+instance, and every individual file looked correct in isolation.
+
+A second bypass class recomputes the root from `HOME` and honoured the variable nowhere:
+`src/cli/context.ts`, `src/cli/spaces.ts`, `src/cli/commands/install-hooks.ts`. The CLI is a
+separate process, so without it a scoped app instance is only half isolated — any `dev3` command
+run inside that session still resolves the user's real board.
+
+## Decision
+
+One source: `resolveDev3Home()` in `src/shared/dev3-home.ts` — `shared/`, because the app, the
+CLI and the native host must agree. `src/bun/paths.ts` builds its `DEV3_HOME` constant from it,
+and all three env-honouring modules plus the three CLI modules call it.
+
+**The name collision is kept, not renamed.** The constant and the variable now mean exactly the
+same thing, so reading either one is correct — which is the least surprising state available, and
+a rename would churn 40 importers for nothing. The next reader is protected by a tripwire instead:
+`src/bun/__tests__/dev3-home-single-source.test.ts` fails when a module composes the root from a
+user home itself, with a reasoned allowlist for the cases that legitimately want the real home
+(the installed CLI binary, the tmux shim, the user's own `~/.codex` and `~/.claude` config).
+
+`bun run dev --qa[=seeded|virgin]` (or `DEV3_QA_SCOPE`) points the launched app at a throwaway
+root under the OS temp dir (`scripts/qa-scope.ts`). `seeded` writes one throwaway git project and
+no tasks; `virgin` writes nothing, which is the state a brand-new user is in. Opt-in only — the
+plain `bun run dev` keeps showing the real board.
+
+**The redirect is not a migration.** Nothing under the real `~/.dev3.0` is read, renamed, moved or
+deleted; a scoped instance simply writes elsewhere. `projectSlug()` is untouched, and
+`src/cli/context.ts` keeps recomputing the slug inline exactly as before, so AGENTS.md on-disk
+invariants 1–5 all hold. Only `DEV3_HOME` and `DEV3_LOG_DIR` are redirected: `HOME` stays real,
+because the agent's own `dev3` CLI, git and module resolution read it.
+
+`configureTestIsolation` in `test-isolation.ts` stopped setting `DEV3_HOME`. It sets the sandbox
+`HOME`, from which the root is now derived, so the override was a redundant second source — and a
+harmful one: it OUTRANKED the `process.env.HOME = fixtureHome` that a dozen suites use to relocate
+the board, so they read the shared run root instead of their own fixture (43 failures across nine
+files, all fixed by that one deletion).
+
+## Risks
+
+**Read this before trusting the scoping: a scoped QA instance is NOT safe to hand a task that runs
+`dev3` CLI commands from a real worktree.** `detectFromWorktreePath` Strategy 2 derives the data
+root from the cwd path, so such a command reaches the real app and can act on real tasks whatever
+`$DEV3_HOME` says. The browser-facing threats are closed; this one is not.
+
+**What a scoped instance does NOT isolate.** Stated as a list rather than left to silence, because
+"scoped" reads as complete:
+
+| Leak | Why the home redirect cannot reach it | Closed here? |
+|---|---|---|
+| The tmux socket directory | tmux honours only `TMUX_TMPDIR`, which dev3 sets nowhere | **No** — follow-up |
+| The PowerShell history file (Windows) | PSReadLine resolves the per-user folder through the Windows shell API; measured — private `APPDATA`/`LOCALAPPDATA` still crossed in 10 of 12 rounds (Seq 1550) | **No** — its own task |
+| The `dev3` CLI, a separate process | It recomputed the root from `HOME` itself | **Partly.** `src/cli/context.ts`, `spaces.ts` and `install-hooks.ts` now share `resolveDev3Home()`, so the sockets dir, `projects.json`, `spaces.json` and the worktrees root follow the redirect — measured: `discoverSocket()` returns the scoped instance's socket. But `detectFromWorktreePath` Strategy 2 derives the home from the **cwd path** by design (the Codex sandbox rewrites `HOME`), so an agent running `dev3` from inside a REAL worktree still reaches the real app whatever `$DEV3_HOME` says |
+| The user's own `~/.codex` / `~/.claude` agent configs | Written from `homedir()`, not from the data root | **No**, and unchanged by this work |
+
+- **A scoped instance still shares the tmux socket directory** with the real app. tmux honours
+  only `TMUX_TMPDIR`, which nothing in dev3 sets, so sockets are still minted into the shared
+  system dir. The UI cannot reach another task (no task record exists in a scoped board), but the
+  underlying tmux server is one namespace. Handed back as a follow-up: setting `TMUX_TMPDIR`
+  requires every tmux invocation to agree or a client looks in the wrong dir and sees no server.
+- **The agent-config writes still target the real home** — `agents.ts`, `codex-config.ts` and
+  `agent-skills.ts` grant the real worktrees/sockets paths inside the user's own
+  `~/.codex/config.toml` and `~/.claude/settings.json`. Unchanged by this work (they read
+  `homedir()`, not the redirect), so no new harm; the cost is that a Codex agent launched inside a
+  scoped instance is not pre-trusted.
+- `scripts/dev-web-code.ts` reads the web access code from the real home by design, so the agent
+  and the scoped app agree on the token.
+- Subtree overrides (`DEV3_VIEWS_DIR`, `DEV3_GUI_BUNDLE_PATH`, the `DEV3_NATIVE_*` family,
+  `DEV3_TEST_ROOT`) are narrower than the root and were left alone. Note that `DEV3_TEMP_ROOT` in
+  `src/bun/temp-paths.ts` is a constant that reads the env var `DEV3_TEST_ROOT` — one letter apart,
+  and a trap of the same shape as the one fixed here.
+
+## Alternatives considered
+
+- **A suppression flag** (`DEV3_DISABLE_BACKGROUND_PROMPTS`) gating the dialog in `App.tsx` and the
+  pollers in `index.ts` — rejected: it fixes the dialog and leaves the other task's terminal
+  reachable, which was the second vent verbatim, and it makes every future cross-task prompt a
+  fresh chance to forget the gate.
+- **A read-only instance mode** rejecting mutating RPC at the handlers barrel — rejected: it blocks
+  the very mutation the QA run exists to verify, and terminal input is not RPC-shaped, so the
+  keystroke needs a separate block anyway.
+- **Renaming the constant** to break the name collision — rejected above.
+- **Auto-wiping the virgin root on every start** — rejected: a destructive default, and a mode that
+  erases state every boot cannot show what a *returning* first-run user sees. `dev` prints the
+  `rm -rf` line instead.

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -11,6 +11,7 @@
  */
 
 import { resolve } from "node:path";
+import { type QaScopeMode, qaScopeRoot, seedQaScope } from "./qa-scope";
 
 /** Lazy: `import.meta.dir` is a Bun-runtime value, absent when tests import this. */
 function repoRoot(): string {
@@ -53,14 +54,37 @@ export function devPlan(mode: DevMode, execPath: string): DevStep[] {
  */
 export function devRunEnv(
 	mode: DevMode,
-	source: { staticCode: string | null; port0: string | undefined },
+	source: { staticCode: string | null; port0: string | undefined; qaScope?: Record<string, string> },
 ): Record<string, string> {
 	const env: Record<string, string> = { DEV3_FRESH_START: "1" };
+	// QA scoping applies to both entry points: `--start` reuses the last build and
+	// is just as capable of clicking another task's completion dialog.
+	Object.assign(env, source.qaScope ?? {});
 	if (mode !== "dev") return env;
 	if (source.staticCode) env.DEV3_REMOTE_STATIC_CODE = source.staticCode;
 	// `${DEV3_PORT0:-0}`: 0 means "pick a free port".
 	env.DEV3_REMOTE_PORT = source.port0?.trim() || "0";
 	return env;
+}
+
+/**
+ * Opt-in, never inferred. The plain `bun run dev` is the main local dev flow and
+ * must keep showing the real board; only a run that explicitly asks gets a
+ * throwaway one.
+ *
+ * `seeded` gets one throwaway project (the QA default); `virgin` gets nothing, so
+ * an instance can be brought up in the state a brand-new user is actually in.
+ */
+export function qaScopeMode(
+	argv: readonly string[],
+	env: Record<string, string | undefined>,
+): QaScopeMode | null {
+	const flag = argv.find((arg) => arg === "--qa" || arg.startsWith("--qa="));
+	const requested = flag?.includes("=") ? flag.slice("--qa=".length).trim() : flag ? "seeded" : env.DEV3_QA_SCOPE?.trim();
+	if (!requested || requested === "0") return null;
+	if (requested === "virgin") return "virgin";
+	if (requested === "1" || requested === "seeded") return "seeded";
+	throw new Error(`[dev] unknown QA scope mode ${JSON.stringify(requested)} — use "seeded" or "virgin"`);
 }
 
 function runOrExit(step: DevStep): void {
@@ -181,9 +205,19 @@ function main(): void {
 	const mode: DevMode = process.argv.includes("--start") ? "start" : "dev";
 	for (const step of devPlan(mode, process.execPath)) runOrExit(step);
 
+	let qaScope: Record<string, string> | undefined;
+	const scopeMode = qaScopeMode(process.argv, process.env);
+	if (scopeMode) {
+		const root = qaScopeRoot(repoRoot(), scopeMode);
+		qaScope = seedQaScope(root, scopeMode);
+		console.log(`[dev] QA scope (${scopeMode}): DEV3_HOME=${qaScope.DEV3_HOME} — real ~/.dev3.0 untouched`);
+		console.log(`[dev] reset this scope with: rm -rf ${root}`);
+	}
+
 	const env = devRunEnv(mode, {
 		staticCode: mode === "dev" ? readDevWebCode() : null,
 		port0: process.env.DEV3_PORT0,
+		qaScope,
 	});
 
 	const child = Bun.spawn([process.execPath, ELECTROBUN_BIN, "dev"], {

--- a/scripts/qa-scope.ts
+++ b/scripts/qa-scope.ts
@@ -1,0 +1,131 @@
+/**
+ * Scoped data root for a QA app instance (`bun run dev --qa`).
+ *
+ * WHY: an instance started for browser verification renders the developer's whole
+ * real board, so another task's "Branch Merged — mark completed?" dialog is live
+ * and clickable and another task's live terminal is one navigation away. Two vents
+ * reported an agent aborting its verification rather than risk the click. Pointing
+ * `$DEV3_HOME` at a throwaway root removes the reachability instead of gating it:
+ * the other tasks are not in this instance's data at all.
+ *
+ * Two fixtures, because there are two jobs:
+ *   - `seeded`  — one throwaway git project, no tasks. The QA default.
+ *   - `virgin`  — nothing at all. The state a brand-new user is in, which nobody
+ *                 could reach before without risking their real data.
+ *
+ * The redirect never touches the real `~/.dev3.0` — no rename, no move, no
+ * delete, nothing read out of it. See
+ * `decisions/2026/08/21/scoped-qa-app-instance.md`.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Project } from "../src/shared/types";
+
+export type QaScopeMode = "seeded" | "virgin";
+
+function safeRealpath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
+
+/**
+ * Stable per worktree AND per mode, so a restart reuses the same scoped board
+ * instead of handing back a fresh one, and the seeded fixture can never leak into
+ * a virgin first-run. Deliberately NOT keyed by pid, unlike `test-isolation.ts`.
+ */
+export function qaScopeRoot(worktreeRoot: string, mode: QaScopeMode, tempRoot = tmpdir()): string {
+	const id = createHash("sha256").update(safeRealpath(worktreeRoot)).digest("hex").slice(0, 12);
+	return join(tempRoot, "dev3-qa", id, mode);
+}
+
+/**
+ * Only `DEV3_HOME` and `DEV3_LOG_DIR` are redirected. `HOME` deliberately stays
+ * real: the agent's own `dev3` CLI, git and module resolution all read it, and
+ * moving it would break the QA run rather than isolate it. `DEV3_TEST_ROOT` (the
+ * OS scratch root behind `dev3TempPath`) also stays real — task scratch files are
+ * not board state, and folding them in here would put them inside the data root.
+ */
+export function qaScopeEnv(root: string): Record<string, string> {
+	return {
+		DEV3_HOME: join(root, "home", ".dev3.0").replaceAll("\\", "/"),
+		DEV3_LOG_DIR: join(root, "logs").replaceAll("\\", "/"),
+	};
+}
+
+export function qaFixtureRepo(root: string): string {
+	return join(root, "fixture-repo");
+}
+
+/**
+ * One throwaway git project and NO tasks. A task the QA run needs is created
+ * through the UI, which is both safe here and a real exercise of the flow —
+ * hand-seeding `tasks.json` would only add a fixture whose shape can drift from
+ * the `Task` type without anything noticing.
+ */
+export function qaFixtureProject(repoPath: string, createdAt: string): Project {
+	return {
+		id: "0da3f0a0-0000-4000-8000-000000000001",
+		name: "QA Fixture",
+		path: repoPath.replaceAll("\\", "/"),
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		createdAt,
+		portCount: 0,
+	};
+}
+
+export type QaScopeRunner = (command: string[], cwd: string) => void;
+
+/** Injectable: vitest stubs the Bun runtime, so a real spawn is not available there. */
+const bunRunner: QaScopeRunner = (command, cwd) => {
+	const result = Bun.spawnSync(command, { cwd, stdout: "ignore", stderr: "pipe", env: process.env });
+	if (result.exitCode !== 0) {
+		const detail = result.stderr ? new TextDecoder().decode(result.stderr).trim() : "";
+		throw new Error(`[qa-scope] ${command.join(" ")} failed (exit ${result.exitCode}) ${detail}`);
+	}
+};
+
+/**
+ * Idempotent, and non-destructive on purpose: an existing scoped root is reused
+ * as-is, board state included. Re-virginising is a deliberate `rm -rf` of the
+ * printed root, never a silent wipe on start — a mode that erases state every
+ * boot cannot show what a returning first-run user sees.
+ */
+export function seedQaScope(
+	root: string,
+	mode: QaScopeMode,
+	now = new Date().toISOString(),
+	run: QaScopeRunner = bunRunner,
+): Record<string, string> {
+	const env = qaScopeEnv(root);
+	// The data root and log dir are created even for `virgin`: an absent parent is
+	// not "a new user", it is a different failure, and the app creates this dir on
+	// first run anyway.
+	for (const dir of [env.DEV3_HOME, env.DEV3_LOG_DIR]) mkdirSync(dir, { recursive: true });
+	if (mode === "virgin") return env;
+
+	const repo = qaFixtureRepo(root);
+	mkdirSync(repo, { recursive: true });
+	if (!existsSync(join(repo, ".git"))) {
+		run(["git", "init", "--initial-branch=main"], repo);
+		run(["git", "config", "user.email", "qa@dev3.invalid"], repo);
+		run(["git", "config", "user.name", "dev3 QA fixture"], repo);
+		writeFileSync(join(repo, "README.md"), "Throwaway repo for scoped dev3 QA. Safe to delete.\n");
+		run(["git", "add", "README.md"], repo);
+		run(["git", "commit", "-m", "QA fixture"], repo);
+	}
+
+	const projectsFile = join(env.DEV3_HOME, "projects.json");
+	if (!existsSync(projectsFile)) {
+		writeFileSync(projectsFile, `${JSON.stringify([qaFixtureProject(repo, now)], null, 2)}\n`);
+	}
+	return env;
+}

--- a/src/bun/__tests__/dev3-home-redirect.test.ts
+++ b/src/bun/__tests__/dev3-home-redirect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveDev3Home } from "../paths";
+import { resolveDev3Home } from "../../shared/dev3-home";
 
 describe("resolveDev3Home", () => {
 	it("honours DEV3_HOME over the user home", () => {

--- a/src/bun/__tests__/dev3-home-redirect.test.ts
+++ b/src/bun/__tests__/dev3-home-redirect.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveDev3Home } from "../paths";
+
+describe("resolveDev3Home", () => {
+	it("honours DEV3_HOME over the user home", () => {
+		expect(resolveDev3Home({ DEV3_HOME: "/scratch/qa/.dev3.0", HOME: "/Users/real" }))
+			.toBe("/scratch/qa/.dev3.0");
+	});
+
+	it("falls back to ~/.dev3.0 when the override is absent or blank", () => {
+		expect(resolveDev3Home({ HOME: "/Users/real" })).toBe("/Users/real/.dev3.0");
+		expect(resolveDev3Home({ DEV3_HOME: "   ", HOME: "/Users/real" })).toBe("/Users/real/.dev3.0");
+	});
+
+	it("normalises an override the way every concatenated path expects", () => {
+		// Backslashes and a trailing slash would break the `startsWith` prefix checks
+		// that decide whether a path is dev3-managed.
+		expect(resolveDev3Home({ DEV3_HOME: "C:\\scratch\\qa\\.dev3.0\\", HOME: "/Users/real" }))
+			.toBe("C:/scratch/qa/.dev3.0");
+	});
+
+	it("keeps the native-terminal path families on the same root as the app", async () => {
+		// The half-redirect this converged: these modules honoured DEV3_HOME while the
+		// app's own DEV3_HOME did not, so a redirected instance was half-scoped.
+		const previous = process.env.DEV3_HOME;
+		process.env.DEV3_HOME = "/scratch/qa/.dev3.0";
+		try {
+			const registry = await import("../native-terminal-registry/paths");
+			const multipane = await import("../native-terminal-multipane/paths");
+			for (const key of ["DEV3_NATIVE_SESSIONS_DIR", "DEV3_NATIVE_MULTIPANE_DIR"]) delete process.env[key];
+
+			expect(registry.sessionsRootDir()).toBe("/scratch/qa/.dev3.0/native-sessions");
+			expect(registry.detachedHostCwd()).toBe("/scratch/qa/.dev3.0");
+			expect(multipane.multipaneRootDir()).toBe("/scratch/qa/.dev3.0/native-multipane");
+		} finally {
+			if (previous === undefined) delete process.env.DEV3_HOME;
+			else process.env.DEV3_HOME = previous;
+		}
+	});
+});

--- a/src/bun/__tests__/dev3-home-single-source.test.ts
+++ b/src/bun/__tests__/dev3-home-single-source.test.ts
@@ -71,6 +71,21 @@ describe("the dev3 data root has one source", () => {
 		}
 	});
 
+	it("nobody reaches the resolver through a paths module that suites mock by name", () => {
+		// 45 suites do `vi.mock("../paths", () => ({ DEV3_HOME: "..." }))` — a factory
+		// listing exports by name. A module importing the resolver through `paths.ts`
+		// gets `undefined` the moment one of those suites reaches it, and the symptom
+		// is a stack-trace error in someone else's file.
+		const offenders: string[] = [];
+		for (const entry of readdirSync(APP_ROOT, { recursive: true, encoding: "utf-8" })) {
+			const rel = entry.replaceAll("\\", "/");
+			if (!rel.endsWith(".ts") || rel.includes("__tests__/")) continue;
+			const source = readFileSync(join(APP_ROOT, rel), "utf-8");
+			if (/import\s*\{[^}]*resolveDev3Home[^}]*\}\s*from\s*"[./]*paths"/.test(source)) offenders.push(rel);
+		}
+		expect(offenders, "import resolveDev3Home from shared/dev3-home, not through a paths module").toEqual([]);
+	});
+
 	it("the CLI resolves the same root, because it is a separate process", () => {
 		// Without this the isolation is half: a scoped app instance plus a dev3 CLI
 		// still pointed at the user's real board.

--- a/src/bun/__tests__/dev3-home-single-source.test.ts
+++ b/src/bun/__tests__/dev3-home-single-source.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Tripwire for the trap that caused the original bug: `DEV3_HOME` names BOTH a
+ * derived constant and an environment variable. While the constant ignored the
+ * variable, three modules honoured the variable and the app did not, so a
+ * redirected instance was half-scoped — and every individual file looked right.
+ *
+ * They agree now, because the constant is built from the variable. This test keeps
+ * them that way by failing when a module composes the data root from a user home
+ * itself instead of going through `resolveDev3Home`.
+ */
+
+// `import.meta.dir` is a Bun value and is undefined under vitest.
+const APP_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Every entry is a deliberate exception with a reason. A new file cannot be added
+ * casually — the point is that composing the root yourself becomes a decision
+ * someone has to argue for.
+ */
+const ALLOWED: Record<string, string> = {
+	"paths.ts": "the single source itself",
+	"rate-limit-monitor.ts": "locates the INSTALLED dev3 CLI binary, which lives in the real home even when the data root is redirected",
+	"tmux/binary.ts": "same: the real ~/.dev3.0/bin/tmux shim, not board state",
+	"index.ts": "appends the real ~/.dev3.0/bin to the user's shell rc — about the installed CLI, not this instance's data",
+	"agents.ts": "grants an agent CLI access to the real worktrees/sockets; scoping those is the follow-up task",
+	"codex-config.ts": "same as agents.ts — writes real paths into the user's own ~/.codex/config.toml",
+	"agent-skills.ts": "skill TEXT shown to agents, plus the real sockets path in ~/.claude/settings.json",
+	"conversation-search.ts": "reads historical transcripts, which exist only under the real home",
+};
+
+function composesDev3HomeItself(source: string): boolean {
+	// A literal `.dev3.0` on the same line as something home-shaped, in code rather
+	// than in a comment or a template shown to the user.
+	return source
+		.split("\n")
+		.filter((line) => !/^\s*(\*|\/\/|\/\*)/.test(line))
+		.some((line) => /\.dev3\.0/.test(line) && /home|HOME|USERPROFILE/i.test(line));
+}
+
+describe("the dev3 data root has one source", () => {
+	it("no app module composes ~/.dev3.0 outside the allowlist", () => {
+		const offenders: string[] = [];
+		for (const entry of readdirSync(APP_ROOT, { recursive: true, encoding: "utf-8" })) {
+			const rel = entry.replaceAll("\\", "/");
+			if (!rel.endsWith(".ts")) continue;
+			if (rel.includes("__tests__/")) continue;
+			// Generated, not authored: bundled changelog prose quotes user-facing paths.
+			if (rel.endsWith(".generated.ts") || rel === "changelog-bundled.ts") continue;
+			if (rel in ALLOWED) continue;
+			if (composesDev3HomeItself(readFileSync(join(APP_ROOT, rel), "utf-8"))) offenders.push(rel);
+		}
+		expect(offenders, "compose the data root via resolveDev3Home(), or add a reasoned allowlist entry").toEqual([]);
+	});
+
+	it("all three modules that started the bug no longer compose it themselves", () => {
+		// The exact three non-test places that honoured env.DEV3_HOME with their own
+		// inline fallback chain while the app's own DEV3_HOME ignored it.
+		for (const file of [
+			"native-terminal-registry/paths.ts",
+			"native-terminal-multipane/paths.ts",
+			"prototypes/detached-pty/state.ts",
+		]) {
+			const source = readFileSync(join(APP_ROOT, file), "utf-8");
+			expect(composesDev3HomeItself(source), `${file} must use resolveDev3Home`).toBe(false);
+			expect(source).toContain("resolveDev3Home");
+		}
+	});
+
+	it("the CLI resolves the same root, because it is a separate process", () => {
+		// Without this the isolation is half: a scoped app instance plus a dev3 CLI
+		// still pointed at the user's real board.
+		for (const file of ["context.ts", "spaces.ts", "commands/install-hooks.ts"]) {
+			const source = readFileSync(join(APP_ROOT, "..", "cli", file), "utf-8");
+			expect(source, `src/cli/${file} must use resolveDev3Home`).toContain("resolveDev3Home");
+		}
+	});
+});

--- a/src/bun/__tests__/qa-scope.test.ts
+++ b/src/bun/__tests__/qa-scope.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { qaFixtureProject, qaScopeEnv, qaScopeRoot, seedQaScope } from "../../../scripts/qa-scope";
+import { devRunEnv, qaScopeMode } from "../../../scripts/dev";
+import { testScopedPath } from "../../../test-scoped-path";
+
+describe("QA scope selection", () => {
+	it("stays off unless explicitly asked", () => {
+		expect(qaScopeMode([], {})).toBeNull();
+		expect(qaScopeMode(["--start"], {})).toBeNull();
+		expect(qaScopeMode([], { DEV3_QA_SCOPE: "0" })).toBeNull();
+	});
+
+	it("accepts the flag and the env var, in both modes", () => {
+		expect(qaScopeMode(["--qa"], {})).toBe("seeded");
+		expect(qaScopeMode(["--qa=seeded"], {})).toBe("seeded");
+		expect(qaScopeMode(["--qa=virgin"], {})).toBe("virgin");
+		expect(qaScopeMode([], { DEV3_QA_SCOPE: "1" })).toBe("seeded");
+		expect(qaScopeMode([], { DEV3_QA_SCOPE: "virgin" })).toBe("virgin");
+	});
+
+	it("refuses an unknown mode instead of silently picking one", () => {
+		expect(() => qaScopeMode(["--qa=readonly"], {})).toThrow(/unknown QA scope mode/);
+	});
+
+	it("gives seeded and virgin separate roots, so a fixture cannot leak into a first-run", () => {
+		const seeded = qaScopeRoot("/repo/worktree", "seeded", "/tmp");
+		const virgin = qaScopeRoot("/repo/worktree", "virgin", "/tmp");
+		expect(seeded).not.toBe(virgin);
+		expect(qaScopeRoot("/repo/other", "seeded", "/tmp")).not.toBe(seeded);
+		// Stable across calls: a restart must reuse the same board.
+		expect(qaScopeRoot("/repo/worktree", "seeded", "/tmp")).toBe(seeded);
+	});
+
+	it("redirects the data root and logs, and nothing else", () => {
+		expect(Object.keys(qaScopeEnv("/tmp/scope")).sort()).toEqual(["DEV3_HOME", "DEV3_LOG_DIR"]);
+		// HOME staying real is load-bearing: the agent's dev3 CLI and git read it.
+		expect(qaScopeEnv("/tmp/scope")).not.toHaveProperty("HOME");
+	});
+
+	it("carries the scope into the app's launch environment for both entry points", () => {
+		const scope = { DEV3_HOME: "/tmp/scope/home/.dev3.0", DEV3_LOG_DIR: "/tmp/scope/logs" };
+		for (const mode of ["dev", "start"] as const) {
+			const env = devRunEnv(mode, { staticCode: null, port0: undefined, qaScope: scope });
+			expect(env.DEV3_HOME).toBe(scope.DEV3_HOME);
+			expect(env.DEV3_LOG_DIR).toBe(scope.DEV3_LOG_DIR);
+		}
+	});
+
+	it("leaves DEV3_HOME unset when no scope was requested", () => {
+		const env = devRunEnv("dev", { staticCode: null, port0: "1234" });
+		expect(env).not.toHaveProperty("DEV3_HOME");
+	});
+});
+
+describe("QA scope seeding", () => {
+	it("virgin mode creates the root and leaves it genuinely empty", () => {
+		const root = testScopedPath("qa-virgin");
+		const env = seedQaScope(root, "virgin");
+		expect(existsSync(env.DEV3_HOME)).toBe(true);
+		expect(existsSync(join(env.DEV3_HOME, "projects.json"))).toBe(false);
+		expect(existsSync(join(root, "fixture-repo"))).toBe(false);
+	});
+
+	it("seeded mode writes one throwaway project and no tasks", () => {
+		const root = testScopedPath("qa-seeded");
+		const commands: string[][] = [];
+		const env = seedQaScope(root, "seeded", "2026-08-21T00:00:00.000Z", (command) => commands.push(command));
+		const projects = JSON.parse(readFileSync(join(env.DEV3_HOME, "projects.json"), "utf-8"));
+		expect(projects).toHaveLength(1);
+		expect(projects[0].path).toBe(join(root, "fixture-repo"));
+		// No tasks file at all — nothing to raise a completion dialog about.
+		expect(existsSync(join(env.DEV3_HOME, "data"))).toBe(false);
+		// The fixture repo is a real git repo, initialised on `main` and committed to,
+		// so the project's defaultBaseBranch resolves.
+		expect(commands[0]).toEqual(["git", "init", "--initial-branch=main"]);
+		expect(commands[commands.length - 1]).toEqual(["git", "commit", "-m", "QA fixture"]);
+	});
+
+	it("is idempotent: a second run keeps the board that is already there", () => {
+		const root = testScopedPath("qa-idempotent");
+		const env = seedQaScope(root, "seeded");
+		const projectsFile = join(env.DEV3_HOME, "projects.json");
+		const edited = JSON.parse(readFileSync(projectsFile, "utf-8"));
+		edited[0].name = "renamed by the user";
+		writeFileSync(projectsFile, JSON.stringify(edited));
+
+		seedQaScope(root, "seeded");
+		expect(JSON.parse(readFileSync(projectsFile, "utf-8"))[0].name).toBe("renamed by the user");
+	});
+
+	it("names a project the app can actually load", () => {
+		const project = qaFixtureProject("/tmp/repo", "2026-08-21T00:00:00.000Z");
+		expect(project.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(project.defaultBaseBranch).toBe("main");
+		// No dev script: a QA fixture must not be able to spawn a second app instance.
+		expect(project.devScript).toBe("");
+	});
+});

--- a/src/bun/__tests__/test-isolation.test.ts
+++ b/src/bun/__tests__/test-isolation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { tmpdir } from "node:os";
 import { INHERITED_TASK_CONTEXT_ENV, deriveTestRunRoot, testWorktreeId } from "../../../test-isolation";
-import { resolveDev3Home } from "../paths";
+import { resolveDev3Home } from "../../shared/dev3-home";
 
 describe("test process isolation", () => {
 	it("derives different roots for different worktrees", () => {

--- a/src/bun/__tests__/test-isolation.test.ts
+++ b/src/bun/__tests__/test-isolation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { tmpdir } from "node:os";
 import { INHERITED_TASK_CONTEXT_ENV, deriveTestRunRoot, testWorktreeId } from "../../../test-isolation";
+import { resolveDev3Home } from "../paths";
 
 describe("test process isolation", () => {
 	it("derives different roots for different worktrees", () => {
@@ -25,7 +26,10 @@ describe("test process isolation", () => {
 		expect(root).toBeTruthy();
 		expect(process.env.HOME).toContain(root);
 		expect(tmpdir()).toContain(root);
-		expect(process.env.DEV3_HOME).toContain(root);
+		// Derived from the sandbox HOME rather than pinned, so a suite that moves HOME
+		// to its own fixture still moves the data root with it.
+		expect(process.env.DEV3_HOME).toBeUndefined();
+		expect(resolveDev3Home()).toContain(root);
 		expect(process.env.DEV3_LOG_DIR).toContain(root);
 		expect(process.env.XDG_CONFIG_HOME).toContain(root);
 		expect(process.env.XDG_RUNTIME_DIR).toContain(root);

--- a/src/bun/native-terminal-multipane/paths.ts
+++ b/src/bun/native-terminal-multipane/paths.ts
@@ -13,6 +13,7 @@
 
 import { join } from "node:path";
 import { isValidSessionId } from "../native-terminal-registry/paths";
+import { resolveDev3Home } from "../paths";
 
 export const NATIVE_MULTIPANE_DIR_ENV = "DEV3_NATIVE_MULTIPANE_DIR";
 
@@ -20,9 +21,7 @@ export const NATIVE_MULTIPANE_DIR_ENV = "DEV3_NATIVE_MULTIPANE_DIR";
 export function multipaneRootDir(): string {
 	const explicit = process.env[NATIVE_MULTIPANE_DIR_ENV];
 	if (explicit) return explicit;
-	const dev3Home =
-		process.env.DEV3_HOME || `${process.env.HOME || process.env.USERPROFILE || "/tmp"}/.dev3.0`;
-	return join(dev3Home, "native-multipane");
+	return join(resolveDev3Home(), "native-multipane");
 }
 
 // Max 56 chars: a real coordinator id is `dev3-task-<uuid>` (46 chars), and the

--- a/src/bun/native-terminal-multipane/paths.ts
+++ b/src/bun/native-terminal-multipane/paths.ts
@@ -13,7 +13,8 @@
 
 import { join } from "node:path";
 import { isValidSessionId } from "../native-terminal-registry/paths";
-import { resolveDev3Home } from "../paths";
+// From `shared/` rather than through `../paths`, which 45 suites mock by name.
+import { resolveDev3Home } from "../../shared/dev3-home";
 
 export const NATIVE_MULTIPANE_DIR_ENV = "DEV3_NATIVE_MULTIPANE_DIR";
 

--- a/src/bun/native-terminal-registry/paths.ts
+++ b/src/bun/native-terminal-registry/paths.ts
@@ -15,7 +15,10 @@
  */
 
 import { dirname, join } from "node:path";
-import { resolveDev3Home } from "../paths";
+// Straight from `shared/`, NOT re-exported through `../paths`: 45 suites mock that
+// module with a factory that lists its exports by name, and any of them reaching
+// this file would get `undefined` for a function stripped from the mock.
+import { resolveDev3Home } from "../../shared/dev3-home";
 import type { CaptureProducerDigest } from "./capture-digest";
 
 export const NATIVE_SESSIONS_DIR_ENV = "DEV3_NATIVE_SESSIONS_DIR";

--- a/src/bun/native-terminal-registry/paths.ts
+++ b/src/bun/native-terminal-registry/paths.ts
@@ -15,6 +15,7 @@
  */
 
 import { dirname, join } from "node:path";
+import { resolveDev3Home } from "../paths";
 import type { CaptureProducerDigest } from "./capture-digest";
 
 export const NATIVE_SESSIONS_DIR_ENV = "DEV3_NATIVE_SESSIONS_DIR";
@@ -23,8 +24,13 @@ export const NATIVE_HOST_IMAGES_DIR_ENV = "DEV3_NATIVE_HOST_IMAGES_DIR";
 
 export const NATIVE_SESSION_LOCKS_DIR_ENV = "DEV3_NATIVE_SESSION_LOCKS_DIR";
 
+/**
+ * Read per call, not once at import: these helpers are used by tests that repoint
+ * `$DEV3_HOME` between cases. The resolution itself is shared with the app's
+ * `DEV3_HOME` so a scoped instance cannot end up half-redirected.
+ */
 function dev3HomeDir(): string {
-	return process.env.DEV3_HOME || `${process.env.HOME || process.env.USERPROFILE || "/tmp"}/.dev3.0`;
+	return resolveDev3Home();
 }
 
 /** Root of the registry namespace: env override, else additive `~/.dev3.0/native-sessions/`. */

--- a/src/bun/paths.ts
+++ b/src/bun/paths.ts
@@ -1,9 +1,18 @@
-import { resolveUserHome } from "../shared/user-home";
+import { resolveDev3Home } from "../shared/dev3-home";
 
-const HOME = resolveUserHome();
+/** Re-exported so app modules have one import for both forms of the root. */
+export { resolveDev3Home };
 
-/** Root directory for all dev-3.0 data: projects, tasks, worktrees, logs */
-export const DEV3_HOME = `${HOME}/.dev3.0`;
+/**
+ * Root directory for all dev-3.0 data: projects, tasks, worktrees, logs.
+ *
+ * Resolved once at module load, because the launcher sets `$DEV3_HOME` before the
+ * app boots and a root that could drift mid-run would split one instance's state
+ * across two directories. Callers that must re-read the environment per call (the
+ * native-terminal path helpers, whose tests repoint it between cases) call
+ * `resolveDev3Home` directly instead.
+ */
+export const DEV3_HOME = resolveDev3Home();
 
 /**
  * Root for virtual ("Operations") boards. A virtual project's synthetic `path`

--- a/src/bun/paths.ts
+++ b/src/bun/paths.ts
@@ -1,7 +1,9 @@
 import { resolveDev3Home } from "../shared/dev3-home";
 
-/** Re-exported so app modules have one import for both forms of the root. */
-export { resolveDev3Home };
+// Deliberately NOT re-exported. 45 suites mock this module with a factory that
+// lists its exports by name, so a module importing the resolver through here
+// would get `undefined` whenever one of those suites reaches it. Import it from
+// `shared/dev3-home` directly.
 
 /**
  * Root directory for all dev-3.0 data: projects, tasks, worktrees, logs.

--- a/src/bun/prototypes/detached-pty/state.ts
+++ b/src/bun/prototypes/detached-pty/state.ts
@@ -16,6 +16,7 @@
 
 import { existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { resolveDev3Home } from "../../paths";
 
 export interface PtyProtoState {
 	/** PID of the detached host process that owns the shell. */
@@ -37,8 +38,7 @@ export interface PtyProtoState {
 export function stateDir(): string {
 	const explicit = process.env.DEV3_PTY_PROTO_DIR;
 	if (explicit) return explicit;
-	const dev3Home = process.env.DEV3_HOME || `${process.env.HOME || "/tmp"}/.dev3.0`;
-	return join(dev3Home, "pty-proto");
+	return join(resolveDev3Home(), "pty-proto");
 }
 
 export function stateFile(): string {

--- a/src/bun/prototypes/detached-pty/state.ts
+++ b/src/bun/prototypes/detached-pty/state.ts
@@ -16,7 +16,8 @@
 
 import { existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { resolveDev3Home } from "../../paths";
+// From `shared/` rather than through `../../paths`, which 45 suites mock by name.
+import { resolveDev3Home } from "../../../shared/dev3-home";
 
 export interface PtyProtoState {
 	/** PID of the detached host process that owns the shell. */

--- a/src/cli/commands/install-hooks.ts
+++ b/src/cli/commands/install-hooks.ts
@@ -1,8 +1,9 @@
 import { dirname, join } from "node:path";
 import { exitError } from "../output";
 import { writeClaudeHooks, writeCodexHooks } from "../../shared/agent-hooks";
+import { resolveDev3Home } from "../../shared/dev3-home";
 
-const WORKTREES_DIR = `${process.env.HOME || "/tmp"}/.dev3.0/worktrees`;
+const WORKTREES_DIR = `${resolveDev3Home()}/worktrees`;
 
 /**
  * Walk up from cwd to find the worktree root

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -5,6 +5,7 @@ import type { Project } from "../shared/types";
 import { parseSocketMeta, socketMetaFileName } from "../shared/socket-meta";
 import { projectStorageKey, toPosixSeparators } from "../shared/project-storage-key";
 import { resolveUserHome } from "../shared/user-home";
+import { resolveDev3Home } from "../shared/dev3-home";
 import {
 	isCliEndpointHandle,
 	parseCliEndpointRecord,
@@ -13,7 +14,10 @@ import {
 } from "../shared/cli-endpoint";
 
 const HOME = resolveUserHome();
-const DEV3_HOME = `${HOME}/.dev3.0`;
+// Same source as the app's own root, so a CLI command run inside a scoped
+// instance resolves that instance's board instead of the user's real one. The
+// project slug below is untouched and stays in lockstep (AGENTS.md invariant 4).
+const DEV3_HOME = resolveDev3Home();
 const SOCKETS_DIR = `${DEV3_HOME}/sockets`;
 const WORKTREES_DIR = `${DEV3_HOME}/worktrees`;
 const PROJECTS_FILE = `${DEV3_HOME}/projects.json`;

--- a/src/cli/spaces.ts
+++ b/src/cli/spaces.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "node:fs";
-import { resolveUserHome } from "../shared/user-home";
+import { resolveDev3Home } from "../shared/dev3-home";
 import type { SpacesFile } from "../shared/types";
 import { spacesOfProject } from "../shared/types";
 import type { ProjectDirect } from "./context";
 
 // Additive sibling file next to projects.json — absent until the user makes a
 // space, and an unreadable file contributes nothing rather than throwing.
-const DEV3_HOME = `${resolveUserHome()}/.dev3.0`;
+const DEV3_HOME = resolveDev3Home();
 const SPACES_FILE = `${DEV3_HOME}/spaces.json`;
 
 function readProjectsForSiblings(): ProjectDirect[] {

--- a/src/shared/dev3-home.ts
+++ b/src/shared/dev3-home.ts
@@ -1,0 +1,32 @@
+import { resolveUserHome } from "./user-home";
+
+/**
+ * The one place that decides where the dev-3.0 data root is.
+ *
+ * Lives in `shared/` because THREE processes must agree on the answer: the app,
+ * the `dev3` CLI (which recomputes it independently — see `src/cli/context.ts`),
+ * and the native terminal host. When they disagree, an instance is half-scoped:
+ * that is the bug this function exists to make impossible.
+ *
+ * `$DEV3_HOME` is a REDIRECT, never a migration — an instance pointed elsewhere
+ * simply writes elsewhere. Nothing under the real `~/.dev3.0` is renamed, moved
+ * or deleted, so the frozen on-disk layout invariants (AGENTS.md) hold. See
+ * `decisions/2026/08/21/scoped-qa-app-instance.md`.
+ *
+ * Beware the name: `DEV3_HOME` is both this environment variable and the derived
+ * constant in `src/bun/paths.ts`. They agree only because that constant is built
+ * from this function. `src/bun/__tests__/dev3-home-single-source.test.ts` fails if
+ * a module starts composing the root itself again.
+ *
+ * Normalised to forward slashes for the same reason `resolveUserHome` is: the
+ * result is concatenated into paths as a string, and a mixed-separator root would
+ * break the prefix comparisons that decide whether a path is dev3-managed.
+ */
+export function resolveDev3Home(env: Record<string, string | undefined> = process.env): string {
+	const override = env.DEV3_HOME?.trim();
+	if (override) {
+		const forward = override.replaceAll("\\", "/");
+		return forward.length > 1 && forward.endsWith("/") ? forward.slice(0, -1) : forward;
+	}
+	return `${resolveUserHome(env)}/.dev3.0`;
+}

--- a/test-isolation.ts
+++ b/test-isolation.ts
@@ -76,10 +76,14 @@ export function configureTestIsolation(suite: string, worktreeRoot = process.cwd
 		if (key.startsWith(INHERITED_NATIVE_SESSION_ENV_PREFIX)) delete process.env[key];
 	}
 
+	// Deliberately NOT setting DEV3_HOME: the data root is derived from HOME by
+	// `resolveDev3Home`, so the sandbox HOME above already lands it at `dev3Home`.
+	// Setting it explicitly would make it OUTRANK a suite's own `process.env.HOME =
+	// fixtureHome`, which is how dozens of suites relocate the board — they would
+	// silently read this run's shared root instead of their fixture.
 	Object.assign(process.env, {
 		DEV3_TEST_ROOT: root,
 		DEV3_TEST_WORKTREE_ID: testWorktreeId(worktreeRoot),
-		DEV3_HOME: dev3Home,
 		DEV3_LOG_DIR: join(root, "logs"),
 		HOME: home,
 		TMPDIR: temp,


### PR DESCRIPTION
Hey, Claude here — the AI assistant that wrote this branch.

An app instance started for browser QA renders the developer's whole real board, so another task's "Branch Merged — mark this task as completed?" dialog is live and clickable inside the agent's own headless browser, and another task's live terminal is one navigation away. Two vents reported an agent aborting its verification rather than risk the click.

`DEV3_HOME` named **two different things**, which is the root rather than an oversight: a constant in `src/bun/paths.ts` derived from the user's home that *ignored* the environment variable, plus the variable itself, which exactly three modules honoured with their own inline fallback chains. Setting it produced a half-redirected instance while every individual file looked correct.

**What this does**

- `resolveDev3Home()` in `src/shared/dev3-home.ts` is the single source — `shared/`, because the app, the `dev3` CLI and the native host are three processes that must agree. `paths.ts` builds its constant from it; the three env-honouring modules and the three CLI modules that recomputed the root from `HOME` now call it.
- `bun run dev --qa[=seeded|virgin]` launches the app against a throwaway root. `seeded` gives one fixture project and no tasks; `virgin` gives an empty home — the state a brand-new user is in, which nobody could reach before without risking real data.
- A tripwire test fails if a module composes the root itself again, or routes the resolver back through `paths.ts`. Both were proven by mutation, not assumed.

**The name collision is kept deliberately.** Constant and variable now mean the same thing, so reading either is correct; renaming would churn 40 importers for nothing. The tripwire is the protection instead.

**⚠️ This moves test isolation itself.** `configureTestIsolation` stops pinning `DEV3_HOME`: the sandbox `HOME` already derives the root, so the pin was a redundant second source — and a harmful one, because it *outranked* the `process.env.HOME = fixtureHome` that nine suites use to relocate their board (43 failures, fixed by deleting one line). Sibling suites assert against this harness, so please weigh them rather than just the touched files.

**The isolation is partial, and deliberately labelled so.** `detectFromWorktreePath` derives the data root from the cwd path by design (the Codex sandbox rewrites `HOME`), so **a scoped QA instance is not safe to hand a task that runs `dev3` CLI commands from a real worktree** — such a command reaches the real app whatever `$DEV3_HOME` says. Measured, not reasoned. Also outside the boundary and unchanged: the tmux socket directory (only `TMUX_TMPDIR` moves it), the PowerShell history file on Windows, and the user's own `~/.codex` / `~/.claude` configs. Full list in `decisions/2026/08/21/scoped-qa-app-instance.md`.

Verified live: the scoped instance came up while the real board carried 53 tasks and 6 working agents — it registered its socket in the scoped tree, showed only the throwaway fixture, and a deep link at a real task id resolved to nothing.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6345260e-fc35-428f-bf08-a55b6977e1e9) · `dev3://task/6345260e-fc35-428f-bf08-a55b6977e1e9`
