### PR TITLE
Offer Add variant on virtual (Operations) boards

### DIFF
--- a/change-logs/2026/08/22/fix-add-variant-on-operations-boards.md
+++ b/change-logs/2026/08/22/fix-add-variant-on-operations-boards.md
@@ -1,0 +1,6 @@
+Short: Add variant works on Operations
+
+The Launch task dialog now offers "+ Add variant" on Operations (non-git) boards instead of
+silently leaving the slot empty. The old guard assumed parallel operations would clobber a
+shared folder, but each variant is its own task and gets its own work dir, so they never
+collided.

--- a/decisions/2026/08/22/variants-allowed-on-virtual-boards.md
+++ b/decisions/2026/08/22/variants-allowed-on-virtual-boards.md
@@ -1,0 +1,51 @@
+# Variants are allowed on virtual (Operations) boards
+
+## Context
+
+`LaunchVariantsModal` hid the `+ Add variant` button whenever `project.kind === "virtual"`.
+The guard landed with the virtual Operations board itself (`f0e0290b0`, PR #725) and its
+comment gave two reasons: there is no git diff to compare parallel attempts against, and
+"a shared fixed folder would have multiple agents clobbering each other". A user hit the
+empty footer slot and read it as a regression.
+
+## Investigation
+
+The clobbering claim is over-broad, and the disproof was already on disk. The Operations
+board held a live variant group (`groupId 87537dfb`) whose two tasks each had their own
+existing work dir — `ops/operations/2fae9007/work` and `ops/operations/0f5c3bd4/work`.
+`git.virtualWorkDir` (`src/bun/git.ts:850`) keys the folder on `shortId(task.id)`, and a
+variant is its own task, so the managed case structurally cannot collide.
+
+The one regime that can is an explicitly chosen folder: `task-lifecycle.ts:476-479`
+deliberately copies `sourceTask.opsWorkDir` onto every variant, so a user-picked folder is
+shared by construction. That collision is structural but **unobserved** — no one has run
+two variants against one picked folder and watched them interfere.
+
+The second reason (no git diff) never justified hiding the control either: variants are
+parallel attempts, and comparing them by reading their terminals is how operations work
+anyway.
+
+## Decision
+
+Removed the `isVirtual` guard in `src/mainview/components/LaunchVariantsModal.tsx` — the
+button renders on every board kind. The inverted assertion lives in
+`LaunchVariantsModal.test.tsx` ("offers the Add Variant button on virtual boards too").
+The task card's `+ Variant` (`TaskCard.tsx:1189`) was already unguarded and stays that
+way; it was never the defect.
+
+## Risks
+
+The picked-folder regime stays unguarded and is the real hazard: variants launched from a
+task with `opsWorkDir` set all target that one folder. Deliberately left alone rather than
+guarded silently — a warning at launch time (the existing `ops.create.workDirConflict`
+wording covers the hazard) is proposed separately and needs a decision of its own.
+
+## Alternatives considered
+
+- **Keep the guard, add a muted line explaining it** (mirroring `ops.gitUnavailable` in the
+  inspector git bar). Rejected once the harm was disproven: it would have explained a
+  restriction that should not exist.
+- **Remove the card's `+ Variant` instead**, making the guard consistent. Rejected for the
+  same reason — it removes working functionality on a false premise.
+- **Guard only when `opsWorkDir` is set.** Correct in principle, but the collision there is
+  still unobserved, so it is proposed separately rather than folded in here.

--- a/src/mainview/components/LaunchVariantsModal.tsx
+++ b/src/mainview/components/LaunchVariantsModal.tsx
@@ -60,12 +60,6 @@ function LaunchVariantsModal({
 }: LaunchVariantsModalProps) {
 	const t = useT();
 
-	// Virtual ("Operations") boards run a single agent per operation — there is
-	// no git diff to compare parallel attempts against, and a shared fixed
-	// folder would have multiple agents clobbering each other. Hide the
-	// add-variant affordance so an operation is always one agent + one folder.
-	const isVirtual = project.kind === "virtual";
-
 	function makeDefaultVariant(): VariantRow {
 		// Try global default agent, fall back to first available
 		let agentId: string | null = globalSettings.defaultAgentId ?? null;
@@ -452,16 +446,15 @@ function LaunchVariantsModal({
 				{/* Footer — wraps on a phone-width viewport instead of squeezing the
 				    labels into one-word-per-line columns. */}
 				<div className="px-6 py-4 border-t border-edge flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
-					{isVirtual ? (
-						<div />
-					) : (
-						<button
-							onClick={addVariant}
-							className={`text-accent hover:text-accent-emphasis text-sm font-medium whitespace-nowrap ${pressClass}`}
-						>
-							{t("launch.addVariant")}
-						</button>
-					)}
+					{/* Available on every board kind, virtual included: a variant is its
+					    own task, and `git.virtualWorkDir` keys the operation folder on
+					    the task id, so parallel operations cannot collide. */}
+					<button
+						onClick={addVariant}
+						className={`text-accent hover:text-accent-emphasis text-sm font-medium whitespace-nowrap ${pressClass}`}
+					>
+						{t("launch.addVariant")}
+					</button>
 
 					<div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-2">
 						<button

--- a/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
+++ b/src/mainview/components/__tests__/LaunchVariantsModal.test.tsx
@@ -390,12 +390,13 @@ describe("LaunchVariantsModal", () => {
 			expect(getHarnessButtons()).toHaveLength(1);
 		});
 
-		it("hides the Add Variant button for virtual (Operations) boards", () => {
-			const project = makeProject({ kind: "virtual" });
-			renderModal(project);
+		it("offers the Add Variant button on virtual (Operations) boards too", async () => {
+			const user = userEvent.setup();
+			renderModal(makeProject({ kind: "virtual" }));
 
-			expect(screen.queryByText("+ Add variant")).not.toBeInTheDocument();
-			expect(getHarnessButtons()).toHaveLength(1);
+			await user.click(screen.getByText("+ Add variant"));
+
+			expect(getHarnessButtons()).toHaveLength(2);
 		});
 	});
 


### PR DESCRIPTION
The Launch task dialog hid `+ Add variant` on any board with `project.kind === "virtual"`, leaving an empty footer slot that reads as a regression. The guard shipped with the Operations board itself (#725) on the premise that parallel operations would clobber a shared folder.

That premise is over-broad, and the disproof was already on disk: an Operations board held a live variant group (`groupId 87537dfb`) whose two tasks each had their own existing work dir. `git.virtualWorkDir` keys the operation folder on `shortId(task.id)`, and a variant is its own task, so the managed case structurally cannot collide.

Removed the guard. The task card's `+ Variant` was already unguarded and is untouched — it was never the defect.

Still open, deliberately not folded in here: `task-lifecycle.ts:476-479` copies `sourceTask.opsWorkDir` onto every variant, so a *user-picked* folder is shared by construction. That collision is structural but **unobserved**, so it gets its own decision rather than a silent guard.

Rationale and rejected alternatives: `decisions/2026/08/22/variants-allowed-on-virtual-boards.md`.

Verified on a live Operations board in a browser: the button renders, adds variant #2, both remove controls appear, no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=678d6a15-6b20-43c9-9a19-5a70cc8a9a07) · `dev3://task/678d6a15-6b20-43c9-9a19-5a70cc8a9a07`