### PR TITLE
Record that the Add-variant question flipped mid-investigation

### DIFF
--- a/decisions/2026/08/22/variants-allowed-on-virtual-boards.md
+++ b/decisions/2026/08/22/variants-allowed-on-virtual-boards.md
@@ -8,6 +8,12 @@ comment gave two reasons: there is no git diff to compare parallel attempts agai
 "a shared fixed folder would have multiple agents clobbering each other". A user hit the
 empty footer slot and read it as a regression.
 
+**The question flipped mid-investigation, and that is the point of this record.** The task
+was opened as "explain why the button is hidden" — the planned change was a muted line in
+the empty slot, mirroring `ops.gitUnavailable` in the inspector git bar. Checking the
+guard's own premise is what turned it into "the hiding was wrong". Nobody changed their
+mind; the evidence arrived and the ask stopped making sense.
+
 ## Investigation
 
 The clobbering claim is over-broad, and the disproof was already on disk. The Operations


### PR DESCRIPTION
Docs only — one paragraph in `decisions/2026/08/22/variants-allowed-on-virtual-boards.md`.

The record already showed the reversed *conclusion* (the guard was wrong) but not the reversed *question*. The task was opened as "explain why the button is hidden", and the planned change was a muted line in the empty footer slot; checking the guard's own premise is what turned it into "the hiding was wrong". Without that sentence, the next person to read the guard's history sees someone changing their mind rather than evidence arriving.

No changelog entry: this task's entry (`change-logs/2026/08/22/fix-add-variant-on-operations-boards.md`) already shipped in #1467 and describes the same behaviour change — one worktree, one entry.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=678d6a15-6b20-43c9-9a19-5a70cc8a9a07) · `dev3://task/678d6a15-6b20-43c9-9a19-5a70cc8a9a07`