### PR TITLE
Turn the header project switcher into a segmented control grouped by space

### DIFF
--- a/change-logs/2026/08/22/feature-project-switcher-affordance-and-spaces.md
+++ b/change-logs/2026/08/22/feature-project-switcher-affordance-and-spaces.md
@@ -1,0 +1,3 @@
+Short: Project switcher is now visible
+
+The header project breadcrumb became one segmented control — the project name and the dropdown chevron now share a bordered shell, the same grammar as the back/forward pair beside it, so the switcher is visible instead of being a 12px glyph nobody clicked. Its list is also grouped by space now: each space is a tinted header with a hairline running to the edge, its projects sit indented off a vertical rule so they read as filed under it, and every space holding the current project is hoisted to the top (spaceless projects land under Home). The ⌘1-9 badges keep following board order.

--- a/decisions/2026/08/22/switcher-hoists-current-space-keeps-board-shortcuts.md
+++ b/decisions/2026/08/22/switcher-hoists-current-space-keeps-board-shortcuts.md
@@ -1,0 +1,37 @@
+# Header switcher hoists the current space, but ⌘N stays on board order
+
+## Context
+
+The header project breadcrumb's dropdown listed every project in one flat board-ordered
+list. With spaces shipped, the projects a user actually switches between (the current
+project's neighbours) could sit anywhere in that list, below the scroll fold.
+
+## Decision
+
+`groupProjectsForSwitcher` (`src/mainview/utils/spaceGroups.ts`) wraps
+`groupProjectsForDashboard` and moves every space that contains the current project to the
+front, keeping their relative order. The computed `Home` group is never hoisted — "no space"
+is not a space, even when the current project sits there. Zero spaces still returns `null`,
+so `GlobalHeader` keeps its flat list byte-identical.
+
+The ⌘0-9 badges are computed from board order into `switcherShortcutById` before grouping, so
+a row's badge keeps matching the shortcut that actually fires. This mirrors what the ⌘K
+palette already does with `shortcutIndexById` when recency reorders its rows.
+
+Same file, `GlobalHeader.tsx`: the breadcrumb name and its chevron now live inside one
+bordered segmented shell, reusing the back/forward control's markup so the two read as one
+language.
+
+## Risks
+
+Row positions move as the user navigates — the same project sits in a different place
+depending on which board is open. Accepted: the neighbours-first list is what the switcher is
+for, and the ⌘N badge is the stable handle for muscle memory. A project in several spaces
+still renders once per space (dashboard behaviour, kept deliberately).
+
+## Alternatives considered
+
+Dashboard order untouched (predictable, but the current project's neighbours can be under the
+scroll fold); recency ordering like the ⌘K palette (a second, competing ordering rule for the
+same set of projects); one menu button for the whole segment (loses the one-click path back to
+the kanban board).

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -1,10 +1,12 @@
 import { Fragment, useState, useEffect, useRef, useCallback, useSyncExternalStore } from "react";
 import type { Project, Task, UpdateChangelog } from "../../shared/types";
-import { getTaskTitle, taskSeqLabel, ACTIVE_STATUSES, isBuiltinOpsProject, orderProjectsForDisplay } from "../../shared/types";
+import { getTaskTitle, taskSeqLabel, ACTIVE_STATUSES, isBuiltinOpsProject, isSpaceSensitive, orderProjectsForDisplay } from "../../shared/types";
 import type { Route } from "../state";
 import { useT } from "../i18n";
 import { parseDisplayVersion } from "../../shared/update-channel";
-import { useProjectPrivacy } from "../sensitive-projects";
+import { MASK_CLASS, useProjectPrivacy } from "../sensitive-projects";
+import { useSpaces } from "../useSpaces";
+import { groupProjectsForSwitcher } from "../utils/spaceGroups";
 import { useCompact } from "../utils/useCompact";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { api, isElectrobun } from "../rpc";
@@ -80,6 +82,7 @@ const COUNTS_CACHE_TTL = 30_000;
 function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, canGoBack, canGoForward, updateVersion, updateAnnouncement, updateChangelog, updateDownloadStatus, remoteAccessActive }: GlobalHeaderProps) {
 	const t = useT();
 	const privacy = useProjectPrivacy();
+	const { file: spacesFile } = useSpaces();
 	const compact = useCompact();
 	const isNarrow = useNarrowViewport(CAROUSEL_MAX_WIDTH);
 	// This page is the far end of a remote session, not the desktop window. Read
@@ -366,6 +369,69 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 	// Built-in Operations board pinned first; ⌘0 jumps to it, ⌘1-9 to the rest.
 	const availableProjects = orderProjectsForDisplay(projects.filter((p) => !p.deleted));
 	const switcherHasPinnedBuiltin = availableProjects.length > 0 && isBuiltinOpsProject(availableProjects[0]);
+	// ⌘N stays keyed to BOARD order, so the badge keeps matching the shortcut once
+	// spaces regroup the rows (same split as the ⌘K palette's shortcutIndexById).
+	const switcherShortcutById: Record<string, string> = {};
+	availableProjects.forEach((p, idx) => {
+		if (isBuiltinOpsProject(p)) {
+			switcherShortcutById[p.id] = "0";
+			return;
+		}
+		const nonBuiltinIdx = switcherHasPinnedBuiltin ? idx - 1 : idx;
+		if (nonBuiltinIdx < 9) switcherShortcutById[p.id] = String(nonBuiltinIdx + 1);
+	});
+	// Spaces group the switcher exactly as they group the dashboard, except the
+	// current project's own space is hoisted first. null = no space holds a
+	// visible project, and the flat list below stays byte-identical to today's.
+	const switcherGroups = groupProjectsForSwitcher(availableProjects, spacesFile, currentProjectId);
+	const sensitiveProjectIds = new Set(projects.filter((p) => p.sensitive).map((p) => p.id));
+
+	// One switcher row. `keyPrefix` disambiguates a project that belongs to
+	// several spaces and therefore renders under each of them.
+	function renderSwitcherRow(p: Project, keyPrefix: string) {
+		const isCurrent = currentProjectId === p.id;
+		const count = projectTaskCounts[p.id];
+		const isBuiltin = isBuiltinOpsProject(p);
+		const locked = privacy.isLocked(p);
+		const shortcutLabel = switcherShortcutById[p.id];
+		return (
+			<button
+				key={`${keyPrefix}:${p.id}`}
+				aria-disabled={locked || undefined}
+				title={locked ? t("streamer.projectLocked") : undefined}
+				onClick={() => {
+					setShowProjectDropdown(false);
+					navigate({ screen: "project", projectId: p.id });
+				}}
+				className={`w-full text-left px-3 py-2 flex items-center gap-2 transition-colors ${
+					isCurrent ? "bg-accent/10 text-accent" : "text-fg-2 hover:bg-elevated hover:text-fg"
+				}`}
+			>
+				{isBuiltin && (
+					<span className="text-accent flex-shrink-0 text-sm-plus" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0E7}"}</span>
+				)}
+				{locked && (
+					<span aria-hidden="true" className="text-fg-muted flex-shrink-0 text-sm-plus" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F033E}"}</span>
+				)}
+				<span className={`truncate text-sm flex-1 ${privacy.maskClass(p)}`}>{isBuiltin ? t("ops.boardName") : p.name}</span>
+				{isBuiltin && (
+					<span className="flex-shrink-0 px-1 py-0.5 rounded bg-raised text-fg-3 text-nano font-medium uppercase tracking-wide">{t("ops.badgeSystem")}</span>
+				)}
+				<span className="text-micro text-fg-muted flex-shrink-0">
+					{count != null
+						? count > 0
+							? t.plural("header.activeTaskCount", count)
+							: t("header.noActiveTasks")
+						: ""}
+				</span>
+				{shortcutLabel && (
+					<kbd className="flex-shrink-0 inline-flex items-center gap-0.5 text-dense text-fg-muted/60 font-mono">
+						<span className="text-micro">{"⌘"}</span>{shortcutLabel}
+					</kbd>
+				)}
+			</button>
+		);
+	}
 
 	// Narrow viewport: the simple, dispatch-style right-cluster actions fold into
 	// a single kebab → BottomSheet. The Command Palette gets a touch entry here
@@ -476,78 +542,70 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 								</span>
 							)
 						) : seg.isProjectDropdown ? (
-							<div className="relative flex items-center gap-0.5" ref={projectDropdownRef}>
-								{seg.onClick ? (
-									<button
-										onClick={seg.onClick}
-										className="text-accent hover:text-accent-emphasis transition-colors truncate"
-									>
-										{seg.label}
-									</button>
-								) : (
-									<span className="text-fg font-semibold truncate">{seg.label}</span>
-								)}
-								<Tooltip content={t("header.switchProject")} detail={t("ttip.header.switchProject")}>
-									<button
-										onClick={() => setShowProjectDropdown((v) => !v)}
-										className="header-anim text-fg-muted hover:text-fg transition-colors flex-shrink-0 p-0.5 rounded hover:bg-elevated"
-										aria-label={t("header.switchProject")}
-									>
-										<span className={`inline-block transition-transform ${showProjectDropdown ? "rotate-180" : ""}`}>
-											<DropdownIcon className="w-3 h-3 block" />
-										</span>
-									</button>
-							</Tooltip>
+							<div className="relative flex-shrink-0 min-w-0" ref={projectDropdownRef}>
+								{/* Segmented control, same grammar as the back/forward pair on the
+								    left: name half opens the board, chevron half opens the switcher. */}
+								<div className="flex items-stretch min-w-0 rounded-md border border-edge bg-raised overflow-hidden">
+									{seg.onClick ? (
+										<button
+											onClick={seg.onClick}
+											className="header-anim px-2 py-[3px] min-w-0 text-accent hover:text-accent-emphasis hover:bg-elevated transition-colors truncate"
+										>
+											{seg.label}
+										</button>
+									) : (
+										<span className="px-2 py-[3px] min-w-0 text-fg font-semibold truncate">{seg.label}</span>
+									)}
+									<span className="w-px self-stretch bg-edge flex-shrink-0" aria-hidden="true" />
+									<Tooltip content={t("header.switchProject")} detail={t("ttip.header.switchProject")}>
+										<button
+											onClick={() => setShowProjectDropdown((v) => !v)}
+											aria-haspopup="menu"
+											aria-expanded={showProjectDropdown}
+											className={`header-anim px-1.5 py-[3px] flex items-center transition-colors ${
+												showProjectDropdown ? "text-fg bg-elevated" : "text-fg-3 hover:text-fg hover:bg-elevated"
+											}`}
+											aria-label={t("header.switchProject")}
+											data-testid="project-switcher-toggle"
+										>
+											<span className={`inline-block transition-transform ${showProjectDropdown ? "rotate-180" : ""}`}>
+												<DropdownIcon className="w-3.5 h-3.5 block" />
+											</span>
+										</button>
+									</Tooltip>
+								</div>
 								{showProjectDropdown && (
-									<div className="absolute left-0 top-full mt-1.5 w-72 bg-overlay border border-edge rounded-xl shadow-2xl z-50 py-1 max-h-80 overflow-y-auto">
-										{availableProjects.map((p, idx) => {
-											const isCurrent = currentProjectId === p.id;
-											const count = projectTaskCounts[p.id];
-											const isBuiltin = isBuiltinOpsProject(p);
-											const locked = privacy.isLocked(p);
-											// \u23180 for the pinned built-in board; \u23181-9 for the rest.
-											const nonBuiltinIdx = switcherHasPinnedBuiltin ? idx - 1 : idx;
-											const shortcutLabel = isBuiltin ? "0" : (nonBuiltinIdx < 9 ? String(nonBuiltinIdx + 1) : null);
-											return (
-												<button
-													key={p.id}
-													aria-disabled={locked || undefined}
-													title={locked ? t("streamer.projectLocked") : undefined}
-													onClick={() => {
-														setShowProjectDropdown(false);
-														navigate({ screen: "project", projectId: p.id });
-													}}
-													className={`w-full text-left px-3 py-2 flex items-center gap-2 transition-colors ${
-														isCurrent
-															? "bg-accent/10 text-accent"
-															: "text-fg-2 hover:bg-elevated hover:text-fg"
-													}`}
-												>
-													{isBuiltin && (
-														<span className="text-accent flex-shrink-0 text-sm-plus" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{""}</span>
-													)}
-													{locked && (
-														<span aria-hidden="true" className="text-fg-muted flex-shrink-0 text-sm-plus" style={{ fontFamily: "\'JetBrainsMono Nerd Font Mono\'" }}>{"\u{F033E}"}</span>
-													)}
-													<span className={`truncate text-sm flex-1 ${privacy.maskClass(p)}`}>{isBuiltin ? t("ops.boardName") : p.name}</span>
-													{isBuiltin && (
-														<span className="flex-shrink-0 px-1 py-0.5 rounded bg-raised text-fg-3 text-nano font-medium uppercase tracking-wide">{t("ops.badgeSystem")}</span>
-													)}
-													<span className="text-micro text-fg-muted flex-shrink-0">
-														{count != null
-															? count > 0
-																? t.plural("header.activeTaskCount", count)
-																: t("header.noActiveTasks")
-															: ""}
-													</span>
-													{shortcutLabel && (
-														<kbd className="flex-shrink-0 inline-flex items-center gap-0.5 text-dense text-fg-muted/60 font-mono">
-															<span className="text-micro">{"\u2318"}</span>{shortcutLabel}
-														</kbd>
-													)}
-												</button>
-											);
-										})}
+									<div role="menu" className="absolute left-0 top-full mt-1.5 w-72 bg-overlay border border-edge rounded-xl shadow-2xl z-50 py-1 max-h-80 overflow-y-auto">
+										{switcherGroups === null ? (
+											availableProjects.map((p) => renderSwitcherRow(p, "flat"))
+										) : (
+											<>
+												{/* The builtin Operations board never joins a space; it stays
+												    pinned above every group, exactly as on the dashboard. */}
+												{availableProjects.filter(isBuiltinOpsProject).map((p) => renderSwitcherRow(p, "builtin"))}
+												{switcherGroups.map((group) => {
+													const masked = group.space ? isSpaceSensitive(group.space, sensitiveProjectIds) : false;
+													return (
+														<div key={group.space?.id ?? "home"} className="pt-2 first:pt-0">
+															{/* Label, then a hairline running to the edge — the same
+															    grammar the Keyboard settings use for their sections. */}
+															<div className="px-3 pb-1 flex items-center gap-2">
+																<span className={`text-nano font-semibold uppercase tracking-wider truncate ${group.space ? "text-accent/90" : "text-fg-3"} ${masked ? MASK_CLASS : ""}`}>
+																	{group.space ? group.space.name : t("spaces.homeGroup")}
+																</span>
+																<span className="text-nano text-fg-muted tabular-nums flex-shrink-0">{group.projects.length}</span>
+																<span aria-hidden="true" className={`h-px flex-1 ${group.space ? "bg-accent/25" : "bg-edge/60"}`} />
+															</div>
+															{/* The trunk: rows sit indented off a vertical rule, so a
+															    project reads as filed under its space. */}
+															<div className={`ml-3 border-l ${group.space ? "border-accent/30" : "border-edge/60"}`}>
+																{group.projects.map((p) => renderSwitcherRow(p, group.space?.id ?? "home"))}
+															</div>
+														</div>
+													);
+												})}
+											</>
+										)}
 									</div>
 								)}
 							</div>

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -35,6 +35,7 @@ vi.mock("../../rpc", () => ({
 				interfaces: [],
 				selectedHost: "192.168.0.1",
 			}),
+			getSpaces: vi.fn().mockResolvedValue({ version: 1, spaces: [], order: [] }),
 			listAgentAccounts: vi.fn().mockResolvedValue({
 				claude: { accounts: [], activeId: null, systemIdentity: null },
 				codex: { accounts: [], activeId: null, currentIdentity: null },
@@ -207,6 +208,7 @@ describe("GlobalHeader — project switcher dropdown", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockedApi.request.getTasks.mockResolvedValue([]);
+		mockedApi.request.getSpaces.mockResolvedValue({ version: 1, spaces: [], order: [] });
 	});
 
 	it("shows chevron button next to project name when inside a project", () => {
@@ -215,6 +217,26 @@ describe("GlobalHeader — project switcher dropdown", () => {
 		expect(chevron).toBeInTheDocument();
 		// Project name text is rendered separately from the chevron
 		expect(screen.getByText("Project Alpha")).toBeInTheDocument();
+	});
+
+	it("declares the chevron as a menu trigger and reflects the open state", async () => {
+		const user = userEvent.setup();
+		renderHeader({ screen: "project", projectId: "p1" });
+		const chevron = getChevronButton();
+		expect(chevron).toHaveAttribute("aria-haspopup", "menu");
+		expect(chevron).toHaveAttribute("aria-expanded", "false");
+		await user.click(chevron);
+		expect(chevron).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("keeps the name and the chevron inside one bordered segmented control", () => {
+		renderHeader({ screen: "project", projectId: "p1", activeTaskId: "t1" }, [project1, project2], vi.fn(), [
+			{ id: "t1", seq: 1, title: "Task 1", status: "in-progress" } as Task,
+		]);
+		const shell = getChevronButton().parentElement!;
+		expect(shell).toHaveClass("border-edge");
+		// Both halves live in that shell — the chevron is no longer a loose glyph.
+		expect(within(shell).getByRole("button", { name: "Project Alpha" })).toBeInTheDocument();
 	});
 
 	it("does not show project dropdown on dashboard", () => {
@@ -385,6 +407,68 @@ describe("GlobalHeader — project switcher dropdown", () => {
 		await user.click(getChevronButton());
 
 		expect(await screen.findAllByText("No active tasks")).toHaveLength(2);
+	});
+
+	describe("space grouping", () => {
+		const project4: Project = { ...project2, id: "p4", name: "Project Delta" };
+
+		function withSpaces() {
+			// Board order puts sp_other first; the current project (p1) is in sp_dev,
+			// so sp_dev must still be rendered first.
+			mockedApi.request.getSpaces.mockResolvedValue({
+				version: 1,
+				spaces: [
+					{ id: "sp_dev", name: "Dev Space", parentId: null, projectIds: ["p1", "p2"], createdAt: 1 },
+					{ id: "sp_other", name: "Other Space", parentId: null, projectIds: ["p2"], createdAt: 2 },
+				],
+				order: ["sp_other", "sp_dev"],
+			});
+		}
+
+		async function openSwitcher() {
+			const user = userEvent.setup();
+			renderHeader({ screen: "project", projectId: "p1" }, [project1, project2, project4]);
+			await user.click(getChevronButton());
+			return await screen.findByRole("menu");
+		}
+
+		it("hoists the current project's space above the other groups, Home last", async () => {
+			withSpaces();
+			const menu = await openSwitcher();
+			await within(menu).findByText("Dev Space");
+			const headers = within(menu)
+				.getAllByText(/Dev Space|Other Space|Home/)
+				.map((el) => el.textContent);
+			expect(headers).toEqual(["Dev Space", "Other Space", "Home"]);
+		});
+
+		it("lists a project under every space it belongs to, plus once under Home", async () => {
+			withSpaces();
+			const menu = await openSwitcher();
+			await within(menu).findByText("Dev Space");
+			// Beta is in both spaces → two rows; Delta has no space → the Home group.
+			expect(within(menu).getAllByText("Project Beta")).toHaveLength(2);
+			expect(within(menu).getAllByText("Project Delta")).toHaveLength(1);
+		});
+
+		it("keeps the ⌘N badge on board order, not on the regrouped row order", async () => {
+			withSpaces();
+			const menu = await openSwitcher();
+			await within(menu).findByText("Dev Space");
+			const rows = within(menu).getAllByRole("button");
+			const badgeOf = (name: string) =>
+				rows.find((r) => r.textContent?.includes(name))?.querySelector("kbd")?.textContent;
+			// p1 is board index 0 → ⌘1, even though it now sits under a hoisted space.
+			expect(badgeOf("Project Alpha")).toBe("⌘1");
+			expect(badgeOf("Project Beta")).toBe("⌘2");
+			expect(badgeOf("Project Delta")).toBe("⌘3");
+		});
+
+		it("stays flat when no space holds a visible project", async () => {
+			const menu = await openSwitcher();
+			expect(within(menu).queryByText("Home")).not.toBeInTheDocument();
+			expect(within(menu).getAllByRole("button")).toHaveLength(3);
+		});
 	});
 
 	it("shows downloading indicator when updateDownloadStatus is downloading", () => {

--- a/src/mainview/utils/__tests__/spaceGroups.test.ts
+++ b/src/mainview/utils/__tests__/spaceGroups.test.ts
@@ -1,4 +1,4 @@
-import { HOME_GROUP_ID, filterDashboardGroups, groupProjectsForDashboard } from "../spaceGroups";
+import { HOME_GROUP_ID, filterDashboardGroups, groupProjectsForDashboard, groupProjectsForSwitcher } from "../spaceGroups";
 import type { Project, Space, SpacesFile } from "../../../shared/types";
 
 const proj = (id: string, over?: Partial<Project>): Project => ({
@@ -127,5 +127,37 @@ describe("filterDashboardGroups", () => {
 		expect(out.map((g) => g.space?.id ?? "home")).toEqual(["sp_1", "sp_2"]);
 		expect(out[0].projects.map((p) => p.id)).toEqual(["a"]);
 		expect(out[1].projects.map((p) => p.id)).toEqual(["a", "b"]);
+	});
+});
+
+describe("groupProjectsForSwitcher", () => {
+	const projects = [proj("a"), proj("b"), proj("c"), proj("loose")];
+
+	it("returns null when there are no active spaces", () => {
+		expect(groupProjectsForSwitcher(projects, fileOf([]), "a")).toBeNull();
+	});
+
+	it("hoists every space holding the current project, keeping their relative order", () => {
+		const file = fileOf([sp("sp_1", ["a"]), sp("sp_2", ["b", "c"]), sp("sp_3", ["c", "b"])]);
+		const out = groupProjectsForSwitcher(projects, file, "b")!;
+		expect(out.map((g) => g.space?.id ?? "home")).toEqual(["sp_2", "sp_3", "sp_1", "home"]);
+	});
+
+	it("leaves the order untouched when the current project has no space", () => {
+		const file = fileOf([sp("sp_1", ["a"]), sp("sp_2", ["b"])]);
+		const out = groupProjectsForSwitcher(projects, file, "loose")!;
+		expect(out.map((g) => g.space?.id ?? "home")).toEqual(["sp_1", "sp_2", "home"]);
+	});
+
+	it("never hoists the Home group above real spaces", () => {
+		const file = fileOf([sp("sp_1", ["a"])]);
+		const out = groupProjectsForSwitcher(projects, file, "loose")!;
+		expect(out[out.length - 1].space).toBeNull();
+	});
+
+	it("keeps dashboard order when there is no current project", () => {
+		const file = fileOf([sp("sp_1", ["a"]), sp("sp_2", ["b"])]);
+		const out = groupProjectsForSwitcher(projects, file, null)!;
+		expect(out.map((g) => g.space?.id ?? "home")).toEqual(["sp_1", "sp_2", "home"]);
 	});
 });

--- a/src/mainview/utils/spaceGroups.ts
+++ b/src/mainview/utils/spaceGroups.ts
@@ -50,6 +50,34 @@ export function groupProjectsForDashboard(
 	return groups;
 }
 
+/**
+ * Group the header project switcher the same way the dashboard groups, with one
+ * difference: every space the CURRENT project belongs to is hoisted to the top,
+ * so its neighbours are the first rows under the cursor. Returns null when no
+ * space holds a visible project — the caller keeps its flat list.
+ *
+ * The builtin Operations board is excluded here; the caller keeps it pinned.
+ */
+export function groupProjectsForSwitcher(
+	visibleProjects: Project[],
+	file: SpacesFile,
+	currentProjectId: string | null,
+): DashboardGroup[] | null {
+	const groups = groupProjectsForDashboard(visibleProjects, file);
+	if (groups === null) return null;
+	if (!currentProjectId) return groups;
+
+	const current: DashboardGroup[] = [];
+	const rest: DashboardGroup[] = [];
+	for (const group of groups) {
+		// The Home group is never hoisted: "no space" is not the current space,
+		// even when the current project happens to sit there.
+		const isCurrentSpace = group.space !== null && group.space.projectIds.includes(currentProjectId);
+		(isCurrentSpace ? current : rest).push(group);
+	}
+	return [...current, ...rest];
+}
+
 interface GroupFilter {
 	/** null = all, `HOME_GROUP_ID` = the computed Home group, else a space id. */
 	selectedSpaceId: string | null;


### PR DESCRIPTION
The header project breadcrumb's dropdown was reached through a bare 12px chevron floating 2px beside the project name — nothing said it was a control, so most people never found the switcher at all. Its list was also a flat, board-ordered list, which since Spaces shipped means the projects a user actually switches between can sit anywhere in it.

**Affordance.** The project name and the chevron now share one bordered segmented shell, reusing the markup of the back/forward pair on the left of the same header. Both actions survive: the name half opens the project's board, the chevron half opens the switcher. The chevron grew to 14px, gained `aria-haspopup="menu"` / `aria-expanded`, and each half lights on its own hover.

**Grouping.** `groupProjectsForSwitcher` wraps the dashboard's own grouping and hoists every space containing the current project to the front, so its neighbours are the first rows. Each space is a tinted header with a hairline running to the edge, and its projects sit indented off a vertical rule, so a project reads as filed under its space. `Home` (no space) is never hoisted and always sits last. The builtin Operations board stays pinned above every group, and with zero spaces the list stays flat exactly as before.

The ⌘0-9 badges are computed from board order before grouping, so a badge keeps matching the shortcut that actually fires — the same split the ⌘K palette already uses.

Reasoning: `decisions/2026/08/22/switcher-hoists-current-space-keeps-board-shortcuts.md`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=156bee63-6cf5-419f-bf5b-3f22a3ea4457) · `dev3://task/156bee63-6cf5-419f-bf5b-3f22a3ea4457` _(dev3 added this footer — turn it off in Settings → Tasks.)_