### PR TITLE
Widen the header project switcher menu and pin it inside narrow viewports

### DIFF
--- a/change-logs/2026/08/22/fix-widen-header-project-switcher.md
+++ b/change-logs/2026/08/22/fix-widen-header-project-switcher.md
@@ -1,0 +1,3 @@
+Short: Wider project switcher menu
+
+The header project switcher menu grew from 18rem to 24rem, because a row carries the space indent, an active-task count and a ⌘N badge beside the project name — real project names were being cut off. On a narrow viewport the menu now pins to the window edges under the header instead of running off the right side of the screen.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -574,8 +574,10 @@ function GlobalHeader({ route, projects, tasks, navigate, goBack, goForward, can
 										</button>
 									</Tooltip>
 								</div>
+								{/* `w-96`, not `w-72`: a row carries the space indent, an active-task
+								    count and a shortcut badge beside the project name. */}
 								{showProjectDropdown && (
-									<div role="menu" className="absolute left-0 top-full mt-1.5 w-72 bg-overlay border border-edge rounded-xl shadow-2xl z-50 py-1 max-h-80 overflow-y-auto">
+									<div role="menu" className="absolute left-0 top-full mt-1.5 w-96 max-md:fixed max-md:inset-x-3 max-md:top-14 max-md:mt-0 max-md:w-auto bg-overlay border border-edge rounded-xl shadow-2xl z-50 py-1 max-h-80 overflow-y-auto">
 										{switcherGroups === null ? (
 											availableProjects.map((p) => renderSwitcherRow(p, "flat"))
 										) : (


### PR DESCRIPTION
The project switcher menu was `w-72` (18rem) from before it carried anything else. Since it gained the space indent, an active-task count and a ⌘N badge on every row, real project names no longer fit — the pinned `[ Operations ]` board rendered as `[ Operatio…`.

The menu is now `w-96` (24rem). Measured on the live UI with 23 projects across 4 spaces: zero rows clip their name (`scrollWidth === clientWidth` on every name span), where the old width clipped several.

While measuring I found the menu also ran off the right edge of a phone-width viewport — it is anchored to the breadcrumb, which sits ~160px in, so at 390px wide it ended at 448px. That predates this change and the extra width made it worse, so it is fixed here too: below `md` the menu pins to the window edges under the header (`max-md:fixed max-md:inset-x-3 max-md:top-14`). Verified at 390×844: left 12px, right 378px, inside the viewport.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=156bee63-6cf5-419f-bf5b-3f22a3ea4457) · `dev3://task/156bee63-6cf5-419f-bf5b-3f22a3ea4457` _(dev3 added this footer — turn it off in Settings → Tasks.)_