### PR TITLE
Build the merge commit subject from the branch commits or task title

### DIFF
--- a/change-logs/2026/08/22/fix-merge-commit-subject-source.md
+++ b/change-logs/2026/08/22/fix-merge-commit-subject-source.md
@@ -1,0 +1,3 @@
+Short: Merge commits get a real subject
+
+Merging a task now takes its commit subject from the branch's own commits — reused verbatim when the branch has a single commit — or from the task title, instead of the first 80 characters of the task description with a trailing ellipsis. A scratch placeholder, an already-truncated title, or a title with a newline never reaches the subject, and nothing is ever truncated.

--- a/decisions/2026/08/22/merge-subject-from-branch-commits-not-description.md
+++ b/decisions/2026/08/22/merge-subject-from-branch-commits-not-description.md
@@ -1,0 +1,95 @@
+# The squash-merge subject comes from the branch's commits or the task title, never the description
+
+## Context
+
+dev3's own Merge button squash-merges a task branch into the base branch and commits with
+`git commit -F <file>`. The file held `task.title` — and `task.title` is
+`titleFromDescription(description)` (`src/shared/types.ts`), the first 80 characters of the task
+DESCRIPTION with a `…` appended, whenever nobody renamed the task. So a prose brief, often
+Russian, often carrying backticks, became a permanent commit subject cut mid-sentence.
+
+Reported from the rts-dots2 board (`da4fb07`) and corroborated here: 87 subjects on this repo's
+`origin/main` contain `…`, 86 of them truncated briefs — e.g. `8f6fd84`,
+`"если мы в проекте что уже в спейсе каком-то то дефолт вью должен…"`. None of the 86 carry the
+`(#NNNN)` suffix GitHub's squash merge appends, which is what points at dev3's own path rather
+than GitHub's.
+
+## Investigation
+
+One construction site, `writeMergeCommitMessage` (`src/bun/git-op-script.ts`), one caller,
+`mergeTask` (`src/bun/rpc-handlers/git-operations.ts`). No truncation happens at merge time — the
+title arrives already truncated from task creation (`data.createTask`, `updateTaskDescription`,
+and the CLI's `task update`). The PR path is unaffected: it hands the merge to GitHub.
+
+**The diagnostic for telling the two merge paths apart** (the rts-dots2 coordinator's, verified in
+code here): GitHub's squash merge appends `(#NNNN)` to the subject, dev3's local squash does not.
+A subject with no `(#NNNN)` came from `mergeTask`; one with it came from GitHub. Use that first
+when a bad subject shows up on a base branch.
+
+`titleFromDescription` is worth reading before trusting the ellipsis as a marker: every truncating
+branch of it appends `…`, including the word-boundary one, so a trailing ellipsis is an EXACT
+marker of "this string is a derived fragment", not a symptom test. A description shorter than the
+limit becomes the title verbatim with no marker — so a short prose sentence is indistinguishable
+from a deliberate title, by construction.
+
+Three couplings that make that gate trustworthy rather than lucky, and that the next editor of
+`titleFromDescription` needs to see:
+
+- The marker is exact **by construction of that function**. A new truncating path that does not
+  append `…` makes the merge gate leak silently, with no test failing.
+- All three call sites pass the default limit of 80 — `data.ts:877`, `rpc-handlers/task-lifecycle.ts:726`,
+  `cli-socket-server.ts:683`. A fourth call site with a different limit does not break the marker,
+  but it does mean "80 characters" stops describing what a truncated title is.
+- A human-written title that legitimately ends in an ellipsis is misread as derived. The
+  consequence is that the subject falls back to the first commit's subject, which is a good
+  subject anyway, so the failure mode is benign.
+
+Two deterministic sources were already on disk and unused: the branch's own commit messages, and
+the task title, which the agent protocol already asks agents to set as a concise imperative.
+
+## Decision
+
+`buildMergeCommitMessage` (`src/bun/git-op-script.ts`), fed by
+`git.listBranchCommitMessages(worktreePath, baseRef)` (`git log --reverse --no-merges --format=%B%x00`):
+
+- exactly one commit on the branch → reuse its message verbatim, subject and body;
+- several → the task title is the subject, the commit subjects become a `- …` body;
+- a title that is not subject-shaped — empty, a `Scratch — HH:MM` placeholder, or ending in `…`
+  / `...` — falls back to the first commit's subject;
+- a title over 72 characters yields to a commit subject when one exists, and is used **in full**
+  when none does. Nothing is ever truncated: truncation is the defect.
+- neither a commit nor a usable title → `Merge <branch>`;
+- only the first line of a title is ever considered, so no newline can reach a subject.
+
+No model is involved anywhere on this path, by requirement. Existing history is untouched — this
+is a forward fix.
+
+## Risks
+
+The task title is user-owned and unchanged by this work, so a multi-commit branch under a title
+nobody improved still gets a mediocre (but whole, un-ellipsised) subject. A branch whose only
+commit is a merge commit reads as zero commits and falls back to the title. `--no-merges` drops an
+integration merge's message from the body, which is deliberate but does mean a body can be shorter
+than the branch's commit count.
+
+## Alternatives considered
+
+- **Truncate more carefully** (word boundary, no ellipsis) — still a description fragment; the
+  source is the problem, not the cut.
+- **Generate the subject with a model** — explicitly forbidden for this task, and unnecessary once
+  the branch's own commits are read.
+- **Fix `titleFromDescription`** — titles are partly user-owned and shown all over the UI; changing
+  their semantics to make a commit subject nicer is the wrong lever.
+- **Rewrite the 86 bad subjects on main** — history rewriting, far more dangerous than the defect.
+- **Refuse a short prose title too** — a description under 80 characters becomes the title verbatim
+  and passes the shape gate, so "Так, баг. Я в проекте, где нету origin никакого" can become a
+  subject. The path to it is narrow: a single-commit branch never consults the title at all, so
+  this needs a multi-commit branch that nobody retitled. **Refused, not merely tolerated:**
+  separating prose from an imperative requires a model, a model is forbidden here, and therefore
+  passing the user's own complete words through is the only honest option left — and strictly
+  better than mutilating them. A future reviewer proposing a prose-detection heuristic is
+  re-opening a closed decision.
+- **Change `titleFromDescription` instead (fix the title, not the subject)** — refused as out of
+  bounds, not overlooked. It would rewrite task titles product-wide, which is a user-visible change
+  with its own blast radius and its own approval; a merge-subject fix does not get to do that on
+  the way past.

--- a/src/bun/__tests__/git-op-pane.bun-e2e.ts
+++ b/src/bun/__tests__/git-op-pane.bun-e2e.ts
@@ -11,7 +11,9 @@
  *   conflict git's own CONFLICT message reaches the pane, verdict NON-zero, and
  *            the script terminates rather than hanging on its own keypress prompt
  *   merge    a squash commit lands with a subject carrying a double quote — the
- *            case `-m '<title>'` mangles under PowerShell 5.1 argument quoting
+ *            case `-m '<title>'` mangles under PowerShell 5.1 argument quoting —
+ *            and that subject is the branch commit's own message, not the task's
+ *            truncated description (Seq 1640)
  *
  * WHY IT MUST RUN ON WINDOWS: the whole defect class here is invisible from
  * macOS. Two examples this file exists to catch, both of which look like success
@@ -34,11 +36,13 @@ import { join } from "node:path";
 import { spawn } from "../spawn";
 import {
 	buildGitOpScript,
+	buildMergeCommitMessage,
 	mergeGitOpSpec,
 	pushGitOpSpec,
 	rebaseGitOpSpec,
 	writeMergeCommitMessage,
 } from "../git-op-script";
+import { listBranchCommitMessages } from "../git";
 import { generatedScriptLaunch, generatedScriptName, writeLaunchScript } from "../rpc-handlers/shared-pure";
 
 let failures = 0;
@@ -328,14 +332,26 @@ async function testMerge(root: string): Promise<void> {
 	await git(work, "checkout", "-b", "feature");
 	await Bun.write(join(work, "feature.txt"), "feature\n");
 	await git(work, "add", "-A");
-	await git(work, "commit", "-m", "feature work");
+	// The exact shape `-m '<title>'` could not carry: a double quote, a single
+	// quote and a `$`, all in one subject. It is the COMMIT's message here, because
+	// a single-commit branch's message is what the subject is built from (Seq 1640).
+	const title = `Fix the "quoted" thing — it's $HOME, not %HOME%`;
+	await git(work, "commit", "-m", title);
+
+	// The composition the merge handler runs: read the branch's commits, choose the
+	// subject, write the file. The task title is deliberately the defect's shape — a
+	// chopped-off description — and must lose to the commit's own message.
+	const commits = await listBranchCommitMessages(work, "main");
+	check(commits.length === 1, `the branch's single commit was read back (got ${commits.length})`);
+	const message = buildMergeCommitMessage({
+		commits,
+		taskTitle: "The game draws its own cursor (`drawCursor()` in `src/render/draw-world.ts`,…",
+		branchName: "feature",
+	});
 	await git(work, "checkout", "main");
 
-	// The exact shape `-m '<title>'` could not carry: a double quote, a single
-	// quote and a `$`, all in one subject.
-	const title = `Fix the "quoted" thing — it's $HOME, not %HOME%`;
 	const messagePath = join(scripts, "merge-message.txt").replaceAll("\\", "/");
-	await writeMergeCommitMessage(messagePath, title);
+	await writeMergeCommitMessage(messagePath, message);
 	const exitFilePath = join(scripts, "merge.exit").replaceAll("\\", "/");
 
 	const { code, output } = await runPaneScript(
@@ -356,6 +372,7 @@ async function testMerge(root: string): Promise<void> {
 	await checkVerdictBytes(exitFilePath);
 	const subject = await git(work, "log", "-1", "--format=%s");
 	check(subject === title, `the commit subject round-tripped byte for byte (got: ${subject})`);
+	check(!subject.includes("…"), "no truncated task description reached the subject");
 	const files = await git(work, "show", "--name-only", "--format=", "HEAD");
 	check(files.includes("feature.txt"), "the squashed content is in the commit");
 	check(output.includes("Merge complete"), "the pane shows the success line");

--- a/src/bun/__tests__/merge-commit-message.test.ts
+++ b/src/bun/__tests__/merge-commit-message.test.ts
@@ -1,0 +1,278 @@
+/**
+ * The squash-merge commit subject (Seq 1640).
+ *
+ * The defect this guards against is permanent by nature: a merge subject cannot
+ * be fixed after the fact without rewriting history, and this repo's own main
+ * carries 86 subjects that are the first 80 characters of a task DESCRIPTION with
+ * a trailing ellipsis. Two halves are covered here:
+ *  - `buildMergeCommitMessage`, the pure choice of source — including every
+ *    awkward title (scratch placeholder, ellipsis, newline, over-long, empty).
+ *  - `listBranchCommitMessages` against a REAL repo, because a canned stdout
+ *    would prove nothing about the `%B%x00` format or the merge-base range.
+ *
+ * The third describe is a SOURCE guard over the call sites, because the two above
+ * are assertions on helpers: they stay green while a caller hands `task.title`
+ * straight to `writeMergeCommitMessage`, which is exactly the bug. What it adds on
+ * top of the behavioural coverage is the SECOND caller — a new merge path that
+ * skips the builder fails here.
+ *
+ * The handler itself is covered where it can actually run:
+ * `rpc-handlers/__tests__/git-op-pane-launch.test.ts` invokes `mergeTask` and
+ * asserts the bytes handed to `git commit -F`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+vi.mock("../paths", () => ({
+	DEV3_HOME: "/tmp/dev3-test",
+}));
+
+vi.mock("../spawn", async () => {
+	const { createSpawnMock } = await import("./git-test-helpers");
+	return createSpawnMock(() => "[]");
+});
+
+import { buildMergeCommitMessage } from "../git-op-script";
+import { listBranchCommitMessages } from "../git";
+import { createTestRepo, cleanup, g, type TestRepo } from "./git-test-helpers";
+
+const TRUNCATED_TITLE = "The game draws its own cursor (`drawCursor()` in `src/render/draw-world.ts`,…";
+
+describe("buildMergeCommitMessage", () => {
+	it("reuses a single commit's message verbatim, subject and body", () => {
+		const message = "Hide the OS pointer over the canvas\n\nThe canvas draws its own cursor.";
+		expect(buildMergeCommitMessage({
+			commits: [message],
+			taskTitle: TRUNCATED_TITLE,
+			branchName: "feat/cursor",
+		})).toBe(`${message}\n`);
+	});
+
+	it("uses the task title as subject and the commit subjects as body", () => {
+		expect(buildMergeCommitMessage({
+			commits: ["Add the cursor sprite\n\nbody one", "Hide the OS pointer"],
+			taskTitle: "Hide the OS cursor over the game canvas",
+			branchName: "feat/cursor",
+		})).toBe("Hide the OS cursor over the game canvas\n\n- Add the cursor sprite\n- Hide the OS pointer\n");
+	});
+
+	it("never lets a truncated description become the subject", () => {
+		const message = buildMergeCommitMessage({
+			commits: ["Add the cursor sprite", "Hide the OS pointer"],
+			taskTitle: TRUNCATED_TITLE,
+			branchName: "feat/cursor",
+		});
+		expect(message).not.toContain("…");
+		expect(message.split("\n")[0]).toBe("Add the cursor sprite");
+	});
+
+	// Separate from the long real-world title above: a SHORT title ending in the
+	// ellipsis must be rejected for the mark alone, not because it is over-long.
+	it("rejects a short title that still ends in an ellipsis", () => {
+		const message = buildMergeCommitMessage({
+			commits: ["First commit", "Second commit"],
+			taskTitle: "The game draws its own…",
+			branchName: "feat/x",
+		});
+		expect(message.split("\n")[0]).toBe("First commit");
+	});
+
+	it("rejects an ASCII three-dot truncation too", () => {
+		const message = buildMergeCommitMessage({
+			commits: ["First commit", "Second commit"],
+			taskTitle: "если мы в проекте что уже в спейсе каком-то то дефолт вью...",
+			branchName: "feat/x",
+		});
+		expect(message.split("\n")[0]).toBe("First commit");
+	});
+
+	it("rejects a scratch placeholder title", () => {
+		const message = buildMergeCommitMessage({
+			commits: ["Rename the pane", "Fix the label"],
+			taskTitle: "Scratch — 14:32",
+			branchName: "chore/scratch",
+		});
+		expect(message.split("\n")[0]).toBe("Rename the pane");
+	});
+
+	it("yields an over-long title to a commit subject", () => {
+		const long = `Do the thing ${"x".repeat(80)}`;
+		const message = buildMergeCommitMessage({
+			commits: ["Do the thing", "Then the other thing"],
+			taskTitle: long,
+			branchName: "feat/x",
+		});
+		expect(message.split("\n")[0]).toBe("Do the thing");
+	});
+
+	it("keeps an over-long title in full when there is no commit to borrow from", () => {
+		const long = `Do the thing ${"x".repeat(80)}`;
+		const message = buildMergeCommitMessage({ commits: [], taskTitle: long, branchName: "feat/x" });
+		// Never truncated: an unabbreviated long subject is readable, a chopped one is not.
+		expect(message).toBe(`${long}\n`);
+	});
+
+	it("keeps a subject on one line when the title carries a newline", () => {
+		const message = buildMergeCommitMessage({
+			commits: [],
+			taskTitle: "Hide the OS cursor\nand draw ours instead",
+			branchName: "feat/cursor",
+		});
+		expect(message).toBe("Hide the OS cursor\n");
+	});
+
+	it("passes backticks and quotes through untouched", () => {
+		const title = "Fix `drawCursor()` and the \"quoted\" $HOME thing";
+		expect(buildMergeCommitMessage({ commits: [], taskTitle: title, branchName: "feat/x" }))
+			.toBe(`${title}\n`);
+	});
+
+	it("falls back to the branch name when there is neither a commit nor a usable title", () => {
+		expect(buildMergeCommitMessage({ commits: [], taskTitle: "   ", branchName: "feat/x" }))
+			.toBe("Merge feat/x\n");
+	});
+
+	it("ignores empty commit messages", () => {
+		expect(buildMergeCommitMessage({
+			commits: ["", "   \n\n", "Real work here"],
+			taskTitle: TRUNCATED_TITLE,
+			branchName: "feat/x",
+		})).toBe("Real work here\n");
+	});
+
+	it("always ends in exactly one newline and never a blank subject", () => {
+		for (const commits of [[], ["a"], ["a", "b"], ["a\n\nbody\n\n"]]) {
+			const message = buildMergeCommitMessage({ commits, taskTitle: "A real title", branchName: "b" });
+			expect(message.endsWith("\n")).toBe(true);
+			expect(message.endsWith("\n\n")).toBe(false);
+			expect(message.split("\n")[0]!.trim().length).toBeGreaterThan(0);
+		}
+	});
+});
+
+/**
+ * Real repositories, so a saturated box makes these slow rather than wrong: the
+ * sibling git-* suites run on the default 5 s and are the repo's best-known
+ * under-load flakes. 30 s is still far above anything a working machine needs.
+ */
+describe("listBranchCommitMessages", { timeout: 30_000 }, () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	function commit(subject: string, body?: string): void {
+		g(`git commit --allow-empty -m "${subject}"${body ? ` -m "${body}"` : ""}`, repo.local);
+	}
+
+	it("returns the branch's own commits, oldest first, with their bodies", async () => {
+		g("git checkout -b feature", repo.local);
+		commit("First thing", "Why the first thing.");
+		commit("Second thing");
+
+		const messages = await listBranchCommitMessages(repo.local, "main");
+		expect(messages).toEqual(["First thing\n\nWhy the first thing.", "Second thing"]);
+	});
+
+	it("returns one message for a single-commit branch and excludes base history", async () => {
+		g("git checkout -b feature", repo.local);
+		commit("Only commit", "With a body\n\nand a blank line inside it.");
+
+		const messages = await listBranchCommitMessages(repo.local, "main");
+		expect(messages).toEqual(["Only commit\n\nWith a body\n\nand a blank line inside it."]);
+	});
+
+	it("returns nothing for a branch with zero commits", async () => {
+		g("git checkout -b feature", repo.local);
+		expect(await listBranchCommitMessages(repo.local, "main")).toEqual([]);
+	});
+
+	it("returns nothing when the base ref does not resolve", async () => {
+		g("git checkout -b feature", repo.local);
+		commit("Some work");
+		expect(await listBranchCommitMessages(repo.local, "origin/nope")).toEqual([]);
+	});
+
+	it("keeps commits made after a merge of the base branch into the branch", async () => {
+		g("git checkout -b feature", repo.local);
+		commit("Branch work");
+		g("git checkout main", repo.local);
+		commit("Base work");
+		g("git checkout feature", repo.local);
+		g("git merge main --no-edit", repo.local);
+		commit("More branch work");
+
+		// The integration merge commit is dropped: its message describes the merge,
+		// not the work being landed.
+		const messages = await listBranchCommitMessages(repo.local, "main");
+		expect(messages).toEqual(["Branch work", "More branch work"]);
+	});
+});
+
+// ── Source guard: the call site, not just the helper ─────────────────────────
+
+const BUN_DIR = join(import.meta.dirname, "..");
+
+function tsFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "__tests__" || entry.name === "prototypes" || entry.name === "node_modules") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...tsFiles(full));
+		else if (entry.name.endsWith(".ts")) out.push(full);
+	}
+	return out;
+}
+
+/** The argument list of every `writeMergeCommitMessage(...)` call in `source`. */
+function messageCallArgs(source: string): string[] {
+	const calls: string[] = [];
+	const needle = "writeMergeCommitMessage(";
+	for (let at = source.indexOf(needle); at !== -1; at = source.indexOf(needle, at + 1)) {
+		let depth = 0;
+		let i = at + needle.length - 1;
+		for (; i < source.length; i++) {
+			if (source[i] === "(") depth++;
+			else if (source[i] === ")" && --depth === 0) break;
+		}
+		calls.push(source.slice(at + needle.length, i));
+	}
+	return calls;
+}
+
+describe("the merge handler's call site", () => {
+	const callers = tsFiles(BUN_DIR)
+		.map((file) => ({ file, args: messageCallArgs(readFileSync(file, "utf-8")) }))
+		.filter(({ file, args }) => args.length > 0 && !file.endsWith("git-op-script.ts"));
+
+	it("has exactly one caller, in the git-operations handler", () => {
+		expect(callers.map((c) => c.file.slice(BUN_DIR.length + 1))).toEqual([
+			join("rpc-handlers", "git-operations.ts"),
+		]);
+	});
+
+	it("builds every message with buildMergeCommitMessage", () => {
+		expect(callers.length).toBeGreaterThan(0);
+		for (const { file, args } of callers) {
+			for (const arg of args) {
+				expect(arg, `${file} passes a raw message to writeMergeCommitMessage`)
+					.toContain("buildMergeCommitMessage(");
+			}
+		}
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -92,6 +92,7 @@ vi.mock("../git", () => ({
 	refExists: vi.fn().mockResolvedValue(true),
 	isRefMergedInto: vi.fn().mockResolvedValue(false),
 	getBranchStatus: vi.fn(),
+	listBranchCommitMessages: vi.fn().mockResolvedValue([]),
 	getTaskDiff: vi.fn(),
 	getUncommittedChanges: vi.fn(),
 	getUnpushedCount: vi.fn(),

--- a/src/bun/git-op-script.ts
+++ b/src/bun/git-op-script.ts
@@ -295,6 +295,70 @@ export function mergeGitOpSpec(opts: {
  * would prepend one on Windows and it would become the first bytes of the
  * commit subject.
  */
-export async function writeMergeCommitMessage(messagePath: string, title: string): Promise<void> {
-	await Bun.write(messagePath, `${title}\n`);
+export async function writeMergeCommitMessage(messagePath: string, message: string): Promise<void> {
+	await Bun.write(messagePath, `${message.replace(/\s+$/, "")}\n`);
+}
+
+/** Longest subject git's own tooling formats without wrapping. */
+const SUBJECT_SOFT_LIMIT = 72;
+
+/** A scratch task's placeholder title (`Scratch — 14:32`) says nothing about the work. */
+const SCRATCH_TITLE = /^Scratch\s+—\s+\d{1,2}:\d{2}$/;
+
+/**
+ * A task title is only a subject when it reads like one. Rejected: empty, the
+ * scratch placeholder, and anything ending in the ellipsis `titleFromDescription`
+ * appends — that mark means the title IS a chopped-off description, which is the
+ * defect this whole module exists to stop. A newline can never reach a subject,
+ * so only the first line is ever considered.
+ */
+function titleAsSubject(taskTitle: string): { subject: string; overLong: boolean } | null {
+	const subject = (taskTitle.split("\n")[0] ?? "").trim();
+	if (!subject) return null;
+	if (SCRATCH_TITLE.test(subject)) return null;
+	if (/[…]$|\.\.\.$/.test(subject)) return null;
+	return { subject, overLong: subject.length > SUBJECT_SOFT_LIMIT };
+}
+
+function subjectOf(commitMessage: string): string {
+	return (commitMessage.split("\n")[0] ?? "").trim();
+}
+
+/**
+ * The squash-merge commit message, built from what git and the task already know.
+ *
+ * NO GENERATION, by requirement: every branch of this either copies a commit
+ * message the author wrote or copies the task title, and the previous behaviour —
+ * `task.title`, which is the first 80 characters of the task DESCRIPTION whenever
+ * no one renamed the task — is what put 86 truncated prose fragments with a
+ * trailing ellipsis into this repo's own main.
+ *
+ * `commits` are the branch's commits, oldest first, full `%B` bodies.
+ *  - exactly one → reuse it verbatim, subject and body. The author already wrote
+ *    the message for this change; re-deriving it can only lose information.
+ *  - several → the task title is the subject, the commit subjects are the body.
+ *  - a title that is not subject-shaped (see `titleAsSubject`) falls back to the
+ *    first commit's subject, and an over-long title yields to one too — but is
+ *    used in full when there is no commit to borrow from. Never truncated.
+ *  - nothing usable at all (no commits, no title) → `Merge <branch>`.
+ */
+export function buildMergeCommitMessage(opts: {
+	commits: string[];
+	taskTitle: string;
+	branchName: string;
+}): string {
+	const commits = opts.commits.map((c) => c.replace(/\s+$/, "")).filter((c) => c.trim().length > 0);
+	if (commits.length === 1) return `${commits[0]!.trim()}\n`;
+
+	const commitSubjects = commits.map(subjectOf).filter(Boolean);
+	const title = titleAsSubject(opts.taskTitle);
+	const fallback = commitSubjects[0] ?? `Merge ${opts.branchName}`;
+	const subject = !title
+		? fallback
+		: title.overLong && commitSubjects.length > 0
+			? commitSubjects[0]!
+			: title.subject;
+
+	const body = commitSubjects.length > 1 ? commitSubjects.map((s) => `- ${s}`).join("\n") : "";
+	return body ? `${subject}\n\n${body}\n` : `${subject}\n`;
 }

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -2020,6 +2020,33 @@ export async function getBehindOriginCount(
 	return parseInt(result.stdout, 10) || 0;
 }
 
+/**
+ * Full messages of the commits this branch adds on top of `baseRef`, oldest
+ * first. Feeds the squash-merge commit message, so it reads `%B` (subject AND
+ * body) and separates records with NUL — a commit body contains blank lines and
+ * anything printable, so no textual delimiter is safe.
+ *
+ * An unresolvable `baseRef` yields `[]` rather than the whole history: the caller
+ * then falls back to the task title, which is far better than pasting every
+ * commit message in the repo into one subject.
+ *
+ * `--no-merges` drops "Merge branch 'main' into feature" — it describes an
+ * integration step, never the work being landed.
+ */
+export async function listBranchCommitMessages(
+	worktreePath: string,
+	baseRef: string,
+): Promise<string[]> {
+	const mergeBase = await run(["git", "merge-base", baseRef, "HEAD"], worktreePath);
+	if (!mergeBase.ok || !mergeBase.stdout) return [];
+	const log = await run(
+		["git", "log", "--reverse", "--no-merges", "--format=%B%x00", `${mergeBase.stdout}..HEAD`],
+		worktreePath,
+	);
+	if (!log.ok) return [];
+	return log.stdout.split("\0").map((m) => m.trim()).filter((m) => m.length > 0);
+}
+
 export async function getUpstreamRef(
 	worktreePath: string,
 ): Promise<string | null> {

--- a/src/bun/rpc-handlers/__tests__/git-op-pane-launch.test.ts
+++ b/src/bun/rpc-handlers/__tests__/git-op-pane-launch.test.ts
@@ -48,6 +48,9 @@ vi.mock("../../git", () => ({
 	fetchCompareRef: vi.fn(async () => true),
 	getBehindOriginCount: vi.fn(async () => 0),
 	resolveRef: vi.fn(async () => "1111111111111111111111111111111111111111"),
+	// One commit, so the merge subject is that commit's message — the same shape a
+	// real single-commit task branch has.
+	listBranchCommitMessages: vi.fn(async () => ["Do the thing"]),
 }));
 
 vi.mock("../../task-aux-panes", () => ({
@@ -82,6 +85,7 @@ vi.mock("../../lifecycle/activities", () => ({
 vi.mock("../../lifecycle/merge-fingerprint", () => ({ getMergeCompletionFingerprint: vi.fn() }));
 
 import { gitOperationHandlers } from "../git-operations";
+import { dev3TaskTempPath } from "../../temp-paths";
 
 const PROJECT = { id: "proj-1", name: "p", path: "/repo", defaultBaseBranch: "main" } as any;
 const TASK = {
@@ -136,6 +140,36 @@ describe(`git-op pane launch on ${process.platform}`, () => {
 			expect(written).toContain(launch.argv[launch.argv.length - 1]);
 		});
 	}
+
+	/**
+	 * The merge SUBJECT, asserted on the file `git commit -F` will read, through the
+	 * real handler (Seq 1640). The task title here is the defect's exact shape — the
+	 * first 80 characters of a description, ellipsis included — so a handler that
+	 * passed `task.title` straight through would land it in permanent history.
+	 */
+	it("writes the branch commit's message as the merge subject, never the truncated title", async () => {
+		mocks.getTask.mockResolvedValue({
+			...TASK,
+			title: "The game draws its own cursor (`drawCursor()` in `src/render/draw-world.ts`,…",
+		});
+		// `Bun.write` is a no-op stub under vitest (see src/bun/test-setup.ts), so the
+		// message is intercepted at the write instead of read back from disk.
+		const writes: Array<[string, string]> = [];
+		const realWrite = (globalThis as any).Bun.write;
+		(globalThis as any).Bun.write = async (path: string, body: string) => {
+			writes.push([String(path), String(body)]);
+			return 0;
+		};
+		try {
+			await gitOperationHandlers.mergeTask({ taskId: TASK.id, projectId: PROJECT.id });
+		} finally {
+			(globalThis as any).Bun.write = realWrite;
+		}
+
+		const messagePath = dev3TaskTempPath(TASK.id, "git-merge-message.txt");
+		expect(writes.map(([path]) => path)).toContain(messagePath);
+		expect(writes.find(([path]) => path === messagePath)?.[1]).toBe("Do the thing\n");
+	});
 
 	// The same assertion the windows-latest leg makes natively, forced from any
 	// platform, so the regression is catchable in an ordinary local run too.

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -8,6 +8,7 @@ import {
 	type TaskDiffResponse,
 	type ScheduledMessageTarget,
 	type UnsavedWork,
+	getTaskTitle,
 	resolveTaskCompareBaseBranch,
 } from "../../shared/types";
 import * as data from "../data";
@@ -31,6 +32,7 @@ import { getPushMessage, log } from "./shared";
 import { generatedScriptLaunch, generatedScriptName, writeLaunchScript } from "./shared-pure";
 import {
 	buildGitOpScript,
+	buildMergeCommitMessage,
 	mergeGitOpSpec,
 	pushGitOpSpec,
 	rebaseGitOpSpec,
@@ -586,8 +588,16 @@ async function mergeTask(params: { taskId: string; projectId: string; expectRout
 		if (!checkoutCommand) throw new Error(`Base branch ${baseBranch} does not exist locally or on origin`);
 	}
 
+	// The subject comes from the branch's own commits or the task title — never
+	// from `task.title` alone, which is the first 80 characters of the DESCRIPTION
+	// whenever nobody renamed the task, ellipsis included.
 	const messagePath = dev3TaskTempPath(task.id, "git-merge-message.txt");
-	await writeMergeCommitMessage(messagePath, task.title);
+	const commits = await git.listBranchCommitMessages(task.worktreePath, rebaseCheckRef);
+	await writeMergeCommitMessage(messagePath, buildMergeCommitMessage({
+		commits,
+		taskTitle: getTaskTitle(task),
+		branchName: branchForMerge,
+	}));
 
 	// With a remote, "merge" that stops at the local base branch is a half-landing:
 	// the squash commit sits in the main clone, origin/<base> never hears about it,


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

**These two fixes compose, and the order mattered.** Because #1482 landed first, `listBranchCommitMessages` reads the *resolved* compare ref rather than a hardcoded `origin/<base>` — so the merge subject is built against a local base in a repo with no remote, which is exactly the kind of repo the original report came from. Without #1482 this feature would have silently degraded there.

**Rebased onto #1479 and #1482, verified by inverse diff:** `git diff origin/main...HEAD` removes exactly three lines, all three mine (the old `writeMergeCommitMessage` signature, its body, and the old `task.title` call). A clean-looking rebase that reverted upstream work could not survive that check — reverted upstream lines show up as removals attributed to nobody. `mergeTask` still routes through `findOpenPullRequest` / `mergeViaPullRequest` first, `rebaseCheckRef` still resolves through `resolveCompareRef`, and both `remote-base-ok` justifications are intact.

**Where the root cause actually sits.** The merge path never truncated anything — the chopped string arrives already chopped. `mergeTask` wrote `task.title` into the file `git commit -F` reads, and `task.title` *is* `titleFromDescription(description)` (`src/shared/types.ts:2795`): the first 80 characters of the task DESCRIPTION plus a `…`, whenever nobody renamed the task. So a reviewer should check the *choice of source*, not any truncation logic at merge time.

This repo's own `origin/main` carries 86 subjects of that shape (e.g. `8f6fd84`). The diagnostic that separates the two merge paths: GitHub's squash merge appends `(#NNNN)` to the subject, dev3's local squash does not — none of the 86 have it. A commit subject is permanent, so this is a forward fix; existing history is untouched.

The subject now comes from sources that already existed on disk, with no model involved anywhere:

- `git.listBranchCommitMessages()` reads the branch's commits (`git log --reverse --no-merges --format=%B%x00`).
- `buildMergeCommitMessage()` picks: exactly one commit → reuse its message verbatim, subject and body; several → the task title is the subject and the commit subjects become the body.
- A title that is not subject-shaped — empty, a `Scratch — HH:MM` placeholder, or ending in `…` / `...` — falls back to the first commit's subject. Every truncating branch of `titleFromDescription` appends the ellipsis, including the word-boundary one, so that mark is an exact marker of a derived fragment rather than a symptom test.
- An over-long title (>72 chars) yields to a commit subject when one exists and is used *in full* when none does — never trading one truncation for another. Only a title's first line is ever read, so a newline cannot structurally reach a subject.
- An unresolvable base ref returns `[]` **deliberately**, exactly like a branch with zero commits, so a bad base ref falls back to the title instead of dumping every commit message in the repository into one subject. The reason is a comment on the function in `src/bun/git.ts`, at the point where someone would be tempted to turn the silent empty into an error.
- Neither a commit nor a usable title → `Merge <branch>`.

**Independent of whether anyone renamed the task, in every case but one.** Single commit → the commit's own message wins and the title is never consulted. Multi-commit with a derived, ellipsised, scratch or empty title → the first commit's subject. The one residual: multi-commit plus a short prose title (a description under 80 characters, so no ellipsis marker), which becomes the subject — whole and human, but prose. Refusing that would need prose detection, i.e. a model, which this task forbids.

Task titles keep their current semantics — `titleFromDescription` is untouched, and a user-edited title is never rewritten.

One construction site (`writeMergeCommitMessage`) and one caller (`mergeTask`); the PR path still delegates its merge to GitHub, and a PR's own title is written by the agent, not derived from the task. Covered by `src/bun/__tests__/merge-commit-message.test.ts` (pure rules, real-repo `listBranchCommitMessages`, plus a source guard against a second unguarded caller), by a new assertion in `rpc-handlers/__tests__/git-op-pane-launch.test.ts` that runs the real `mergeTask` and checks the bytes handed to `git commit -F`, and by the executed pane E2E. Decision record: `decisions/2026/08/22/merge-subject-from-branch-commits-not-description.md`.

Reported by the coordinator of the rts-dots2 board.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=638cf30e-7bb9-4bf8-bb87-a990c30c6aa4) · `dev3://task/638cf30e-7bb9-4bf8-bb87-a990c30c6aa4`


