### PR TITLE
Name PR-review tasks after what they review

### DIFF
--- a/change-logs/2026/08/23/feature-review-task-board-identity.md
+++ b/change-logs/2026/08/23/feature-review-task-board-identity.md
@@ -1,0 +1,3 @@
+Short: Review tasks name themselves
+
+A PR-review task is now called "Review of #493 from Arseny Pavlenko about pin tmux to a vendored keg" instead of the first 80 characters of the review prompt, so several reviews on the board are finally distinguishable at a glance; a branch with no pull request falls back to the branch, its commit author and its subject. That title is a draft built from the pull request's own words — the built-in review prompt tells the reviewing agent to replace it with what the diff actually does, and to leave a verdict overview: safe to merge, merge after fixes or do not merge, followed by how many blockers, fixes and nitpicks it found.

--- a/decisions/2026/08/23/dev3-names-review-tasks-the-prompt-owns-the-verdict.md
+++ b/decisions/2026/08/23/dev3-names-review-tasks-the-prompt-owns-the-verdict.md
@@ -1,0 +1,82 @@
+# dev3 drafts a review task's name; the agent owns the final one
+
+## Context
+
+Every PR-review card on the board read the same thing: `Review the code changes
+on this branch. Your task is to perform a thorough…`. A review task's description
+leads with the PR-review preset preamble (`DEFAULT_PR_REVIEW_PROMPT`), the user
+usually adds no text of their own, and `titleFromDescription` then truncates that
+shared preamble at 80 characters. N review tasks therefore produced N identical
+titles, differing only in the `#493` PR badge beside them. The overview was
+whatever the reviewing agent happened to write, or empty.
+
+## Investigation
+
+The obvious fix is to put the naming rule in the prompt and let the agent rename
+itself. The prompt is overridable at two levels — project `reviewModePrompt`, then
+global `reviewModePrompt`, then the built-in (`resolvePresetPrompt`) — so a rule
+that lives only in the prompt silently skips every user who already customised it,
+and those are exactly the users most likely to run many reviews. It also leaves
+the card anonymous until the agent gets round to renaming.
+
+dev3 already knows enough to name the task at creation. `findOpenPullRequest`
+(`gh pr list --head`) was one `--json` field list away from returning the PR title
+and author, and a branch with no pull request still has a commit tip whose `%an`
+and `%s` name its author and its subject.
+
+The verdict half is different in kind: no merge verdict and no finding counts
+exist before the review runs, so only the agent can write them. That half has to
+live in the prompt, and an overridden prompt genuinely misses it.
+
+## Decision
+
+**Both surfaces, and the agent is the author of the final text on both.** dev3
+only fills the gap between creation and the agent's first free moment.
+
+- **Title — dev3 drafts it at creation, the agent replaces it.**
+  `reviewTaskTitle` / `reviewTitleTopic` (`src/shared/types.ts`) compose
+  `Review of #493 from <author> about <five words>` out of the pull request's own
+  title; `reviewTitleForBranch` in `src/bun/rpc-handlers/task-lifecycle.ts`
+  gathers the parts and `createTask` writes the result as `Task.title`.
+  `DEFAULT_PR_REVIEW_PROMPT` spells out the same shape and tells the agent to set
+  it itself with `dev3 task update --title`, calling dev3's version a draft: dev3
+  can only repeat what the PR title claimed, while the agent has read the diff.
+  dev3 writes `title`, never `customTitle` and never `titleEditedByUser`, so the
+  user-edited title protection is untouched — a title the user typed still wins
+  through `getTaskTitle`, and the agent's own rename still works.
+- **Overview — the prompt only.** `dev3 overview set "<verdict>. <counts>"`,
+  verdict out of `Safe to merge` / `Merge after fixes` / `Do not merge`, counts as
+  numbers, under 500 characters. No verdict exists before the review runs, so
+  there is nothing for dev3 to draft here.
+
+Supporting extractions, each used by both its old and new caller rather than
+duplicated: `git.localBranchNameForRef` (the `refs/remotes/<ref>` rule that
+`createWorktree` had inline) and `git.refAuthorAndSubject`.
+
+## Risks
+
+- A user with an overridden review prompt gets the good title and no verdict
+  overview. Unavoidable: the verdict cannot be produced anywhere but the agent.
+  The override surfaces show the built-in text to diff against.
+- Creating a review task now waits on one `gh pr list` (15 s cap) plus one
+  `git log`. Both failures are caught and fall back to today's derived title.
+- `gh pr list --head <branch>` is unreliable for cross-repo (fork) pull requests,
+  so a fork review may fall back to `Review of <branch> from <commit author>
+  about <commit subject>` instead of the PR number. Still distinguishable, and
+  the PR badge on the card still appears once the identity poll matches it.
+- The Create Task modal still previews no title for a review task with no text of
+  the user's own; the composed title appears on the card after creation. The
+  modal would need its own PR lookup to preview it.
+
+## Alternatives considered
+
+- **Prompt only.** Costs nothing, but misses overridden prompts and leaves the
+  card anonymous for the first minutes.
+- **dev3 only.** Deterministic and immediate, but no verdict overview at all, and
+  the "about" clause would forever be the PR author's own wording rather than what
+  a reviewer found in the diff. Rejected explicitly by the user: naming the task
+  is the agent's job too, dev3's version is a first draft.
+- **Composing the title in the renderer**, where the Create Task modal already
+  derives `generatedTitle`. Rejected: the modal has the branch but not the PR
+  author, only one of the two branch-picking paths has resolved the PR, and a
+  second composer on the bun side would have been needed anyway.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -2246,6 +2246,38 @@ describe("task.update", () => {
 		expect(result.titlePreserved).toBe(false);
 	});
 
+	// The whole review-task naming design rests on this: dev3 writes a DRAFT title
+	// at creation and the reviewing agent is told to replace it. The draft lives in
+	// `title` with NO customTitle at all, which is a shape the guard's other cases
+	// never exercise — if it were protected, the prompt's instruction could not be
+	// carried out and every review card would keep the PR author's own wording.
+	it("lets an agent rename over dev3's drafted review title", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			title: "Review of #493 from Arseny Pavlenko about pin tmux to a vendored",
+			customTitle: undefined,
+			titleEditedByUser: false,
+		});
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(data.updateTask).mockResolvedValue({ ...task, customTitle: "Review of #493 from Arseny Pavlenko about drop the PATH shim" });
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(
+			makeRequest("task.update", {
+				taskId: task.id,
+				projectId: "proj-1",
+				title: "Review of #493 from Arseny Pavlenko about drop the PATH shim",
+			}),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect((resp.data as { titlePreserved: boolean }).titlePreserved).toBe(false);
+		const call = vi.mocked(data.updateTask).mock.calls[0][2];
+		expect(call.customTitle).toBe("Review of #493 from Arseny Pavlenko about drop the PATH shim");
+		expect(call.titleEditedByUser).toBeUndefined();
+	});
+
 	it("overwrites user-edited title when --force is set", async () => {
 		const project = makeProject();
 		const task = makeTask({ customTitle: "User-set title", titleEditedByUser: true });

--- a/src/bun/__tests__/git-branch-ops.test.ts
+++ b/src/bun/__tests__/git-branch-ops.test.ts
@@ -78,6 +78,8 @@ import {
 	deriveForkUrl,
 	fetchFork,
 	isForeignBranchRef,
+	localBranchNameForRef,
+	refAuthorAndSubject,
 	pullOrigin,
 	_resetFetchState,
 	_resetCompareRefCache,
@@ -904,5 +906,44 @@ describe("isForeignBranchRef", () => {
 	it("git failure → foreign, never trusted", async () => {
 		queueResponse(1, "", "fatal: not a git repository");
 		expect(await isForeignBranchRef("/not-a-repo", "origin/feat/x")).toBe(true);
+	});
+});
+
+// ─── localBranchNameForRef / refAuthorAndSubject ─────────────────────────────
+
+describe("localBranchNameForRef", () => {
+	it("strips the remote that owns the ref, origin and fork alike", async () => {
+		queueResponse(0, "abc123\n");
+		expect(await localBranchNameForRef("/repo", "origin/feat/x")).toBe("feat/x");
+		queueResponse(0, "abc123\n");
+		expect(await localBranchNameForRef("/repo", "yanive/feat/x")).toBe("feat/x");
+	});
+
+	// The reason this asks git instead of cutting at the first slash: `feat/x` is
+	// itself a legal local branch name, and cutting would review `x`.
+	it("leaves a local branch name that merely contains a slash alone", async () => {
+		queueResponse(1, "", "fatal: Needed a single revision");
+		expect(await localBranchNameForRef("/repo", "feat/x")).toBe("feat/x");
+	});
+});
+
+describe("refAuthorAndSubject", () => {
+	it("splits git's NUL-separated author and subject", async () => {
+		queueResponse(0, `Jane Doe\0Rework the parser\n`);
+		expect(await refAuthorAndSubject("/repo", "origin/feat/x")).toEqual({
+			author: "Jane Doe", subject: "Rework the parser",
+		});
+	});
+
+	// A subject can hold anything a commit message's first line holds, including
+	// the colons and parentheses the topic condenser later strips.
+	it("keeps the subject verbatim, punctuation included", async () => {
+		queueResponse(0, `Ann\0feat(remote): serve it (#12)\n`);
+		expect(await refAuthorAndSubject("/repo", "b")).toMatchObject({ subject: "feat(remote): serve it (#12)" });
+	});
+
+	it("answers nulls when the ref is not there, instead of throwing", async () => {
+		queueResponse(1, "", "fatal: bad revision");
+		expect(await refAuthorAndSubject("/repo", "gone")).toEqual({ author: null, subject: null });
 	});
 });

--- a/src/bun/__tests__/github.test.ts
+++ b/src/bun/__tests__/github.test.ts
@@ -666,8 +666,30 @@ describe("github", () => {
 				mockGhRepoView(JSON.stringify([{ number: 1475, url: "https://github.com/h0x91b/dev-3.0/pull/1475" }]));
 				const { findOpenPullRequest } = await import("../github");
 				await expect(findOpenPullRequest(PROJECT, "/tmp/wt", "dev3/t")).resolves.toEqual({
-					pr: { number: 1475, url: "https://github.com/h0x91b/dev-3.0/pull/1475" },
+					pr: { number: 1475, url: "https://github.com/h0x91b/dev-3.0/pull/1475", title: null, author: null },
 					isGitHub: true,
+				});
+			});
+
+			// The two fields a review task is named after. A GitHub display name is
+			// optional, so the login has to carry the naming when it is missing.
+			it("prefers the author's display name and falls back to the login", async () => {
+				const { findOpenPullRequest } = await import("../github");
+				mockGhRepoView(JSON.stringify([
+					{ number: 1, url: "u", title: "Pin tmux", author: { login: "h0x91b", name: "Arseny Pavlenko" } },
+				]));
+				await expect(findOpenPullRequest(PROJECT, "/tmp/wt", "b")).resolves.toMatchObject({
+					pr: { title: "Pin tmux", author: "Arseny Pavlenko" },
+				});
+
+				mockGhRepoView(JSON.stringify([{ number: 1, url: "u", title: "", author: { login: "h0x91b", name: "" } }]));
+				await expect(findOpenPullRequest(PROJECT, "/tmp/wt", "b")).resolves.toMatchObject({
+					pr: { title: null, author: "h0x91b" },
+				});
+
+				mockGhRepoView(JSON.stringify([{ number: 1, url: "u" }]));
+				await expect(findOpenPullRequest(PROJECT, "/tmp/wt", "b")).resolves.toMatchObject({
+					pr: { title: null, author: null },
 				});
 			});
 

--- a/src/bun/__tests__/preset-prompt.test.ts
+++ b/src/bun/__tests__/preset-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { COORDINATOR_PROMPT, resolvePresetPrompt } from "../../shared/types";
+import { COORDINATOR_PROMPT, DEFAULT_PR_REVIEW_PROMPT, resolvePresetPrompt, reviewTaskTitle, reviewTitleTopic } from "../../shared/types";
 
 const BUILTIN = "Review the code changes on this branch.";
 
@@ -58,5 +58,94 @@ describe("COORDINATOR_PROMPT", () => {
 
 	it("is English-only, so a locale file can never half-translate a behavioural rule", () => {
 		expect(COORDINATOR_PROMPT).not.toMatch(/[Ѐ-ӿ]/);
+	});
+});
+
+describe("DEFAULT_PR_REVIEW_PROMPT", () => {
+	// The half of a review task's board identity that only the agent can produce.
+	// dev3 names the card at creation; the verdict and the counts cannot be known
+	// before the review is done, so they have to be asked for here.
+	it("asks for an overview that is a merge verdict plus numbers", () => {
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain("dev3 overview set");
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain("Safe to merge");
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain("Merge after fixes");
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain("Do not merge");
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/counts are numbers/);
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/Under 500 characters/);
+	});
+
+	// The agent owns the title too, not just the overview: dev3's creation-time
+	// title is a draft built from the PR's own words, and only the agent has read
+	// the diff. A prompt that said "fix it if it looks wrong" got that backwards.
+	it("tells the agent to set the title itself, and spells out the shape", () => {
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain("dev3 task update --title");
+		expect(DEFAULT_PR_REVIEW_PROMPT).toContain(
+			"Review of #<PR number> from <the author, a readable name> about <what it changes, five words>",
+		);
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/Review of #493 from Arseny Pavlenko about pin tmux/);
+	});
+
+	it("calls dev3's creation-time title a draft to be replaced, not a result to keep", () => {
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/DRAFT title/);
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/Treat it as a draft and replace it/);
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/neither is optional/);
+	});
+
+	it("says what to do when there is no pull request to number", () => {
+		expect(DEFAULT_PR_REVIEW_PROMPT).toMatch(/No pull request\?.*branch name/s);
+	});
+
+	it("is English-only, for the same reason the coordinator prompt is", () => {
+		expect(DEFAULT_PR_REVIEW_PROMPT).not.toMatch(/[Ѐ-ӿ]/);
+	});
+});
+
+describe("reviewTaskTitle", () => {
+	it("reads as one sentence a human can scan on a card", () => {
+		expect(reviewTaskTitle({ prNumber: 493, author: "Arseny Pavlenko", topic: "Pin tmux to a vendored keg" }))
+			.toBe("Review of #493 from Arseny Pavlenko about Pin tmux to a vendored");
+	});
+
+	it("drops a clause it cannot fill instead of writing a placeholder", () => {
+		expect(reviewTaskTitle({ prNumber: 12, author: null, topic: null })).toBe("Review of #12");
+		expect(reviewTaskTitle({ branch: "feat/x", author: "Ann", topic: null })).toBe("Review of feat/x from Ann");
+		expect(reviewTaskTitle({ prNumber: 12, author: null, topic: "Speed up boot" }))
+			.toBe("Review of #12 about Speed up boot");
+	});
+
+	// "" is the signal that means "keep whatever title the task already has".
+	it("returns nothing when it cannot even name what is under review", () => {
+		expect(reviewTaskTitle({})).toBe("");
+		expect(reviewTaskTitle({ branch: "  ", author: "Ann", topic: "x" })).toBe("");
+	});
+
+	it("prefers the pull request number over the branch", () => {
+		expect(reviewTaskTitle({ prNumber: 7, branch: "feat/x" })).toBe("Review of #7");
+	});
+});
+
+describe("reviewTitleTopic", () => {
+	it("spends its five words on the change, not on ceremony", () => {
+		expect(reviewTitleTopic("feat(remote): serve the board over a tunnel")).toBe("serve the board over a");
+		expect(reviewTitleTopic("fix!: drop the shim")).toBe("drop the shim");
+		expect(reviewTitleTopic("Pin tmux to a vendored keg (#493)")).toBe("Pin tmux to a vendored");
+	});
+
+	// A trailing "…" is this repo's marker for a title nobody has written yet, so a
+	// condensed topic must never end in one.
+	it("never ends in the unnamed-task ellipsis", () => {
+		expect(reviewTitleTopic("one two three four five six seven")).not.toMatch(/…$/);
+	});
+
+	it("does not end on the punctuation that led into the words it dropped", () => {
+		expect(reviewTitleTopic("fix: show branch-merged dialog only once, respect cancel"))
+			.toBe("show branch-merged dialog only once");
+		expect(reviewTitleTopic("Rework the parser and the — lexer")).toBe("Rework the parser and the");
+	});
+
+	it("survives blank and whitespace-only input", () => {
+		expect(reviewTitleTopic(null)).toBe("");
+		expect(reviewTitleTopic("   \n ")).toBe("");
+		expect(reviewTitleTopic("feat:")).toBe("");
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -89,6 +89,8 @@ vi.mock("../git", () => ({
 	resolveCompareRef: vi.fn(async (path: string, baseBranch: string, explicit?: string) =>
 		explicit || git.detectDefaultCompareRef(path, baseBranch)),
 	isForeignBranchRef: vi.fn().mockResolvedValue(false),
+	localBranchNameForRef: vi.fn(async (_path: string, ref: string) => ref.replace(/^origin\//, "")),
+	refAuthorAndSubject: vi.fn().mockResolvedValue({ author: null, subject: null }),
 	refExists: vi.fn().mockResolvedValue(true),
 	isRefMergedInto: vi.fn().mockResolvedValue(false),
 	getBranchStatus: vi.fn(),
@@ -5608,7 +5610,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: "" }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: "", title: null, author: null }, isGitHub: true });
 
 		const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 		expect(result.prNumber).toBe(42);
@@ -5628,7 +5630,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: prUrl }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: prUrl, title: null, author: null }, isGitHub: true });
 		const push = vi.fn();
 		setPushMessage(push);
 
@@ -5695,7 +5697,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 10, url: "" }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 10, url: "", title: null, author: null }, isGitHub: true });
 
 		const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 		expect(result.prNumber).toBe(10);
@@ -7328,7 +7330,7 @@ describe("handlers.mergeTask", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 1475, url: "" }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 1475, url: "", title: null, author: null }, isGitHub: true });
 		vi.mocked(github.resolveMergeMethod).mockResolvedValue("squash");
 		vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "", stderr: "", code: 0 });
 
@@ -7354,7 +7356,7 @@ describe("handlers.mergeTask", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 7, url: "" }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 7, url: "", title: null, author: null }, isGitHub: true });
 		vi.mocked(github.runGitHub).mockResolvedValue({
 			ok: false, stdout: "", stderr: "Pull request #7 is not mergeable: the base branch policy prohibits the merge", code: 1,
 		});
@@ -7373,7 +7375,7 @@ describe("handlers.mergeTask", () => {
 		vi.mocked(data.getProject).mockResolvedValue(project);
 		vi.mocked(data.getTask).mockResolvedValue(task);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
-		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 9, url: "" }, isGitHub: true });
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 9, url: "", title: null, author: null }, isGitHub: true });
 
 		await expect(
 			handlers.mergeTask({ taskId: "task-1", projectId: "proj-1", expectRoute: "local-squash" }),
@@ -13224,6 +13226,143 @@ describe("createTask foreignCode", () => {
 		await handlers.createTask({ projectId: project.id, description: "An operation" });
 
 		expect(git.isForeignBranchRef).not.toHaveBeenCalled();
+	});
+});
+
+// ================================================================
+// createTask — a review task's identity on the board
+// ================================================================
+
+/**
+ * Every assertion here is about the TITLE A REVIEW TASK ENDS UP WITH, not about
+ * the string builder: the whole complaint was that N review cards read the same,
+ * and only the create path decides that.
+ */
+describe("createTask review title", () => {
+	function titleOf(): string | undefined {
+		return vi.mocked(data.addTask).mock.calls[0]?.[3]?.title;
+	}
+
+	beforeEach(() => {
+		vi.mocked(data.getProject).mockReset();
+		vi.mocked(data.addTask).mockReset();
+		vi.mocked(git.isForeignBranchRef).mockResolvedValue(false);
+		vi.mocked(git.localBranchNameForRef).mockImplementation(async (_p, ref) => ref.replace(/^origin\//, ""));
+		vi.mocked(git.refAuthorAndSubject).mockResolvedValue({ author: null, subject: null });
+		vi.mocked(github.findOpenPullRequest).mockReset();
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: null, isGitHub: true });
+		const project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.addTask).mockResolvedValue(makeTask({ status: "todo", worktreePath: null }));
+	});
+
+	it("names the task after the pull request, its author and what it changes", async () => {
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({
+			pr: { number: 493, url: "u", title: "fix: pin tmux to a vendored keg (#493)", author: "Arseny Pavlenko" },
+			isGitHub: true,
+		});
+
+		await handlers.createTask({
+			projectId: "proj-1",
+			description: "Review the code changes on this branch. Your task is to perform a thorough review",
+			existingBranch: "origin/fix/tmux",
+			taskType: "pr-review",
+		});
+
+		expect(titleOf()).toBe("Review of #493 from Arseny Pavlenko about pin tmux to a vendored");
+	});
+
+	it("gives two review tasks on different branches two different titles", async () => {
+		vi.mocked(github.findOpenPullRequest)
+			.mockResolvedValueOnce({ pr: { number: 1, url: "u", title: "Add remote mode", author: "Ann" }, isGitHub: true })
+			.mockResolvedValueOnce({ pr: { number: 2, url: "u", title: "Drop the shim", author: "Bo" }, isGitHub: true });
+		const description = "Review the code changes on this branch.";
+
+		await handlers.createTask({ projectId: "proj-1", description, existingBranch: "origin/a", taskType: "pr-review" });
+		const first = titleOf();
+		vi.mocked(data.addTask).mockClear();
+		await handlers.createTask({ projectId: "proj-1", description, existingBranch: "origin/b", taskType: "pr-review" });
+
+		expect(first).toBe("Review of #1 from Ann about Add remote mode");
+		expect(titleOf()).toBe("Review of #2 from Bo about Drop the shim");
+		expect(titleOf()).not.toBe(first);
+	});
+
+	it("falls back to the branch and its commit tip when there is no pull request", async () => {
+		vi.mocked(git.refAuthorAndSubject).mockResolvedValue({ author: "Jane Doe", subject: "Rework the parser" });
+
+		await handlers.createTask({
+			projectId: "proj-1", description: "Review", existingBranch: "yanive/feat/x", taskType: "pr-review",
+		});
+
+		expect(titleOf()).toBe("Review of yanive/feat/x from Jane Doe about Rework the parser");
+	});
+
+	// The negative case that must not read as "from unknown": no PR, no readable
+	// author. A shorter honest title still tells the cards apart.
+	it("drops the author clause when nobody can be named", async () => {
+		await handlers.createTask({
+			projectId: "proj-1", description: "Review", existingBranch: "origin/feat/x", taskType: "pr-review",
+		});
+
+		expect(titleOf()).toBe("Review of feat/x");
+	});
+
+	it("keeps the review title even when the caller derived one from the description", async () => {
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({
+			pr: { number: 7, url: "u", title: "Speed up boot", author: "Ann" }, isGitHub: true,
+		});
+
+		await handlers.createTask({
+			projectId: "proj-1", description: "Review", title: "look at the migration path",
+			existingBranch: "origin/feat/x", taskType: "pr-review",
+		});
+
+		expect(titleOf()).toBe("Review of #7 from Ann about Speed up boot");
+	});
+
+	it("leaves a non-review task's title alone", async () => {
+		await handlers.createTask({
+			projectId: "proj-1", description: "My own work", title: "My own work", existingBranch: "origin/feat/x",
+		});
+
+		expect(titleOf()).toBe("My own work");
+		expect(github.findOpenPullRequest).not.toHaveBeenCalled();
+	});
+
+	it("keeps the derived title when gh and git both fail, instead of a broken one", async () => {
+		vi.mocked(github.findOpenPullRequest).mockRejectedValue(new Error("gh exploded"));
+
+		await handlers.createTask({
+			projectId: "proj-1", description: "Review", title: "derived", existingBranch: "origin/feat/x",
+			taskType: "pr-review",
+		});
+
+		expect(titleOf()).toBe("derived");
+	});
+
+	// The other half of the same invariant, guarded from this side: dev3 must write
+	// the draft into `title` only. Claiming a user edit here would make the CLI
+	// guard refuse the agent's rename, and the prompt's title step would be dead.
+	it("writes the draft as a plain title and never claims a user edit", async () => {
+		vi.mocked(github.findOpenPullRequest).mockResolvedValue({
+			pr: { number: 7, url: "u", title: "Speed up boot", author: "Ann" }, isGitHub: true,
+		});
+
+		await handlers.createTask({
+			projectId: "proj-1", description: "Review", existingBranch: "origin/feat/x", taskType: "pr-review",
+		});
+
+		const extras = vi.mocked(data.addTask).mock.calls[0]?.[3];
+		expect(extras?.title).toBe("Review of #7 from Ann about Speed up boot");
+		expect(extras?.titleEditedByUser).toBeUndefined();
+		expect(extras?.customTitle).toBeUndefined();
+	});
+
+	it("never asks GitHub for a review task with no branch to review", async () => {
+		await handlers.createTask({ projectId: "proj-1", description: "Review", taskType: "pr-review" });
+
+		expect(github.findOpenPullRequest).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1010,16 +1010,8 @@ export async function createWorktree(
 	}
 
 	if (existingBranch) {
-		// Check if this is a remote tracking ref (origin/xxx, yanive/xxx, etc.)
-		const isRemoteRef = (await run(
-			["git", "rev-parse", "--verify", `refs/remotes/${existingBranch}`],
-			project.path,
-		)).ok;
-
-		// For remote refs, extract local branch name by stripping the remote prefix
-		const resolvedBranch = isRemoteRef
-			? existingBranch.slice(existingBranch.indexOf("/") + 1)
-			: existingBranch;
+		const resolvedBranch = await localBranchNameForRef(project.path, existingBranch);
+		const isRemoteRef = resolvedBranch !== existingBranch;
 
 		log.info("Creating worktree from existing branch", {
 			wtPath, existingBranch, resolvedBranch, isRemoteRef, taskId: task.id,
@@ -1505,6 +1497,32 @@ export async function isForeignBranchRef(projectPath: string, existingBranch?: s
 	// tell" — and an unknown provenance is treated as foreign, never as trusted.
 	if (remotes.length === 0) return true;
 	return remotes.includes(ref.slice(0, slash));
+}
+
+/**
+ * The plain branch name behind a ref a task starts on: `origin/feat/x` and the
+ * fork remote's `arditti/feat/x` both become `feat/x`, a local name is returned
+ * untouched. Keyed off `refs/remotes/<ref>` existing rather than off the first
+ * slash, because `feat/x` is itself a legal local branch name.
+ */
+export async function localBranchNameForRef(projectPath: string, ref: string): Promise<string> {
+	const isRemoteRef = (await run(["git", "rev-parse", "--verify", `refs/remotes/${ref}`], projectPath)).ok;
+	return isRemoteRef ? ref.slice(ref.indexOf("/") + 1) : ref;
+}
+
+/**
+ * Who wrote the tip of a ref and what they called it — the fallback identity for
+ * a review task whose branch has no pull request to name it. `%an` is the commit
+ * author's own name, so a fork branch still names its real author.
+ */
+export async function refAuthorAndSubject(
+	projectPath: string,
+	ref: string,
+): Promise<{ author: string | null; subject: string | null }> {
+	const result = await run(["git", "log", "-1", "--format=%an%x00%s", ref], projectPath, { timeoutMs: 10_000 });
+	if (!result.ok) return { author: null, subject: null };
+	const [author, subject] = result.stdout.split("\0");
+	return { author: author?.trim() || null, subject: subject?.trim() || null };
 }
 
 /**

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -419,8 +419,12 @@ export async function runGitHub(
 
 /** What one `gh pr list --head` answer tells a caller. */
 export interface OpenPullRequestProbe {
-	/** The open PR whose head is this branch, or null when there is none. */
-	pr: { number: number; url: string } | null;
+	/**
+	 * The open PR whose head is this branch, or null when there is none. `title`
+	 * and `author` are what a review task is named after; both are null when gh
+	 * returned them empty, never a placeholder string.
+	 */
+	pr: { number: number; url: string; title: string | null; author: string | null } | null;
 	/** False ONLY when gh definitively said this is not a GitHub repo. */
 	isGitHub: boolean;
 }
@@ -440,7 +444,7 @@ export async function findOpenPullRequest(
 	const result = await runGitHub(
 		project,
 		cwd,
-		["pr", "list", "--head", headBranch, "--state", "open", "--json", "number,url", "--limit", "1"],
+		["pr", "list", "--head", headBranch, "--state", "open", "--json", "number,url,title,author", "--limit", "1"],
 		{ timeoutMs: options?.timeoutMs },
 	);
 	const isGitHub = result.ok || !isNotAGitHubRepoError(result);
@@ -448,8 +452,18 @@ export async function findOpenPullRequest(
 		try {
 			const prs = JSON.parse(result.stdout);
 			if (Array.isArray(prs) && prs.length > 0 && typeof prs[0].number === "number") {
+				const author = prs[0].author as { name?: unknown; login?: unknown } | null | undefined;
+				// A GitHub display name is optional, the login never is, and the login is
+				// what a human recognises anyway when the name is missing.
+				const authorName = [author?.name, author?.login]
+					.find((candidate) => typeof candidate === "string" && candidate.trim()) as string | undefined;
 				return {
-					pr: { number: prs[0].number, url: typeof prs[0].url === "string" ? prs[0].url : "" },
+					pr: {
+						number: prs[0].number,
+						url: typeof prs[0].url === "string" ? prs[0].url : "",
+						title: typeof prs[0].title === "string" && prs[0].title.trim() ? prs[0].title : null,
+						author: authorName?.trim() ?? null,
+					},
 					isGitHub,
 				};
 			}

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -277,7 +277,9 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 		prDetection,
 	]);
 	const remoteIsGitHub = hasRemote && detected.isGitHub;
-	let prInfo = detected.pr;
+	// Only the identity travels on from here; the probe's title/author exist for
+	// naming a review task, not for the branch-status payload.
+	let prInfo: { number: number; url: string } | null = detected.pr;
 	if (!prInfo && task.prNumber != null && task.prUrl) {
 		// The sticky number outlives the branch it was opened from: rename the
 		// branch, or inherit the number from the review task this one grew out of,

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1,8 +1,9 @@
 import type { LaunchVariant, NativeTerminalAvailability, Project, Task, TaskPriority, TaskStatus, TaskTerminalBackendInfo, TaskType } from "../../shared/types";
 import type { TerminalBackendIdentity } from "../../shared/terminal-backend-identity";
-import { ACTIVE_STATUSES, DRAFT_TASK_ACTIVATION_ERROR, titleFromDescription } from "../../shared/types";
+import { ACTIVE_STATUSES, DRAFT_TASK_ACTIVATION_ERROR, reviewTaskTitle, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
+import * as github from "../github";
 import { resolveAgentRequest, setAgentRequestLaunchChoice, type AgentLaunchChoice } from "../agent-requests";
 import { loadSettingsSync, recordFavoriteUsages } from "../settings";
 import { emitTaskSound } from "../lifecycle/executor";
@@ -36,6 +37,35 @@ function isScratchPlaceholderDescription(description: string): boolean {
  * this never enters `description`: a draft's description must stay empty so
  * "Save" remains unavailable until the user actually writes the prompt.
  */
+/**
+ * A DRAFT name for a PR-review task, at creation, from what dev3 already knows
+ * about the branch. The reviewing agent owns the final title — the preset prompt
+ * tells it to replace this one once it has read the diff, which dev3 never does.
+ * This exists because the card must not be anonymous in the meantime, and because
+ * the prompt is overridable per project and app-wide: a naming rule that lived
+ * only there would silently skip every user who customised it.
+ * Best-effort; "" means "keep the description-derived title".
+ */
+async function reviewTitleForBranch(project: Project, existingBranch: string): Promise<string> {
+	try {
+		const branch = await git.localBranchNameForRef(project.path, existingBranch);
+		const probe = await github.findOpenPullRequest(project, project.path, branch, { timeoutMs: 15_000 });
+		let author = probe.pr?.author ?? null;
+		let topic = probe.pr?.title ?? null;
+		// No pull request, or one gh could not fully describe: the branch tip still
+		// knows who wrote it and what they called it.
+		if (!author || !topic) {
+			const tip = await git.refAuthorAndSubject(project.path, existingBranch);
+			author ??= tip.author;
+			topic ??= tip.subject;
+		}
+		return reviewTaskTitle({ prNumber: probe.pr?.number ?? null, branch, author, topic });
+	} catch (err) {
+		log.warn("reviewTitleForBranch failed, keeping the derived title", { error: String(err) });
+		return "";
+	}
+}
+
 function draftPlaceholderTitle(now: Date = new Date()): string {
 	const hh = String(now.getHours()).padStart(2, "0");
 	const mm = String(now.getMinutes()).padStart(2, "0");
@@ -141,6 +171,13 @@ async function createTask(params: { projectId: string; description: string; titl
 	const foreignCode = project.kind === "virtual"
 		? false
 		: await git.isForeignBranchRef(project.path, params.existingBranch);
+	// A review task's draft identity beats a title derived from the description: the
+	// description leads with the review preamble, so every review card otherwise
+	// reads the same. A title the USER typed still wins — the modal sends that as
+	// `customTitle` after creation, which getTaskTitle prefers over this one.
+	const reviewTitle = params.taskType === "pr-review" && params.existingBranch && project.kind !== "virtual" && !isScratch
+		? await reviewTitleForBranch(project, params.existingBranch)
+		: "";
 	const extras: Parameters<typeof data.addTask>[3] = {
 		...(params.existingBranch ? { existingBranch: params.existingBranch } : {}),
 		...(foreignCode ? { foreignCode: true } : {}),
@@ -150,7 +187,9 @@ async function createTask(params: { projectId: string; description: string; titl
 		// A preset preamble leads the description, so the caller supplies the title
 		// derived from the user's own text. Never for a scratch task, whose
 		// description is a placeholder.
-		...(!isScratch && params.title?.trim() ? { title: params.title.trim() } : {}),
+		...(reviewTitle
+			? { title: reviewTitle }
+			: !isScratch && params.title?.trim() ? { title: params.title.trim() } : {}),
 		...(params.opsWorkDir ? { opsWorkDir: params.opsWorkDir } : {}),
 		...(params.priority ? { priority: params.priority } : {}),
 		...(params.taskType ? { taskType: params.taskType } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -449,7 +449,28 @@ Start by analyzing what was changed, then evaluate:
 - Edge cases and error handling
 - Security considerations
 
-Provide a structured review with actionable feedback.`;
+Provide a structured review with actionable feedback.
+
+BEFORE YOU FINISH, make this review readable on the board. Both steps are your
+job, and neither is optional — a board of review tasks that all look alike is
+useless to the person who has to pick one.
+
+1. Title — set it yourself with \`dev3 task update --title "..."\`, in this shape:
+
+       Review of #<PR number> from <the author, a readable name> about <what it changes, five words>
+
+   Example: Review of #493 from Arseny Pavlenko about pin tmux to a vendored keg
+
+   dev3 already put a DRAFT title of this shape on the task at creation, built from
+   the pull request's own title. Treat it as a draft and replace it: you have read
+   the diff and it has not, so the "about" clause should say what the change
+   actually does, not what its title claimed. Keep the number and the author unless
+   they are wrong. No pull request? Put the branch name where \`#<PR number>\` goes.
+2. Overview — \`dev3 overview set "<verdict>. <counts>"\`. Under 500 characters, a
+   sticky note and not the review itself. The verdict is one of "Safe to merge",
+   "Merge after fixes" or "Do not merge", and the counts are numbers, not prose.
+   Example: Safe to merge, nothing serious found. 0 blockers, 2 worth fixing,
+   3 nitpicks across 11 files.`;
 
 /**
  * Preamble the Coordinator task-type preset injects into a new task's
@@ -2873,6 +2894,52 @@ export function titleFromDescription(
 		return truncated.slice(0, lastSpace) + "\u2026";
 	}
 	return truncated + "\u2026";
+}
+
+/** Words of the "about" clause in a review title \u2014 five, as the board asks for. */
+const REVIEW_TITLE_TOPIC_WORDS = 5;
+
+/**
+ * The "about \u2026" clause of a review title, condensed from a pull-request title or
+ * a commit subject. Drops the conventional-commit prefix and GitHub's squash
+ * `(#123)` suffix, both of which would spend words on things the card already
+ * shows, then keeps the first {@link REVIEW_TITLE_TOPIC_WORDS} words. No
+ * ellipsis on purpose: a trailing `\u2026` is this project's marker for a title
+ * nobody has written yet (see `titleFromDescription`).
+ */
+export function reviewTitleTopic(source: string | null | undefined): string {
+	const text = (source ?? "")
+		.replace(/\s+/g, " ")
+		.replace(/\s*\(#\d+\)\s*$/, "")
+		.replace(/^\s*\w+(\([^)]*\))?!?:\s*/, "")
+		.trim();
+	if (!text) return "";
+	// Cutting at five words lands mid-sentence, so the join often ends on the comma
+	// or dash that led into the words we dropped.
+	return text.split(" ").slice(0, REVIEW_TITLE_TOPIC_WORDS).join(" ").replace(/[,;:—–-]+$/, "");
+}
+
+/**
+ * Board identity for a PR-review task. Every review card used to read "Review the
+ * code changes on this branch. Your task is to perform a thorough\u2026" \u2014 the preset
+ * preamble run through {@link titleFromDescription} \u2014 so N reviews produced N
+ * indistinguishable cards. Each clause is dropped rather than filled with a
+ * placeholder when its part is unknown, so a branch with no pull request and no
+ * readable author still gets a shorter honest title instead of "from unknown".
+ * Returns "" when even the subject is unknown, which means "keep the old title".
+ */
+export function reviewTaskTitle(parts: {
+	prNumber?: number | null;
+	branch?: string | null;
+	author?: string | null;
+	topic?: string | null;
+}): string {
+	const branch = parts.branch?.trim();
+	const subject = parts.prNumber != null ? `#${parts.prNumber}` : branch;
+	if (!subject) return "";
+	const author = parts.author?.trim();
+	const topic = reviewTitleTopic(parts.topic);
+	return `Review of ${subject}${author ? ` from ${author}` : ""}${topic ? ` about ${topic}` : ""}`;
 }
 
 /**


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

Every PR-review card on the board read the same thing — `Review the code changes on this branch. Your task is to perform a thorough…` — because a review task's description leads with the review preset preamble and `titleFromDescription` truncates it at 80 characters. N reviews, N identical titles. The overview was whatever the agent happened to write, or nothing.

**Naming the task is the reviewing agent's job**, alongside the verdict. `DEFAULT_PR_REVIEW_PROMPT` now spells out the shape and tells the agent to set it itself:

```
Review of #<PR number> from <the author, a readable name> about <what it changes, five words>
```

**dev3 writes a draft of that same shape at creation**, from the pull request's own title, author display name (falling back to the login) and number — with the conventional-commit prefix and GitHub's `(#123)` suffix dropped. No pull request? The branch tip still names its author and its subject: `Review of feat/x from Jane Doe about Rework the parser`. Every clause is dropped rather than filled with a placeholder, so nothing ever reads "from unknown".

The draft exists for two reasons the prompt cannot cover: the card must not stay anonymous between creation and the agent's first free moment, and the review prompt is overridable per project and app-wide — a naming rule living only in the prompt silently skips everyone who ever customised it. The agent still replaces it, because dev3 can only repeat what the PR title claimed while the agent has read the diff.

**Overview**, prompt only, since no verdict exists before the review runs: `dev3 overview set "<verdict>. <counts>"` — verdict out of `Safe to merge` / `Merge after fixes` / `Do not merge`, counts as numbers, under 500 characters. For example: *Safe to merge, nothing serious found. 0 blockers, 2 worth fixing, 3 nitpicks across 11 files.*

The user-edited-title protection is untouched: dev3 writes `title`, never `customTitle` and never `titleEditedByUser`, so a hand-typed name still wins and the agent's own `dev3 task update --title` still works.

Reasoning and the alternatives that lost are in `decisions/2026/08/23/dev3-names-review-tasks-the-prompt-owns-the-verdict.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6631c811-df96-4037-9ec2-e0f37e18f418) · `dev3://task/6631c811-df96-4037-9ec2-e0f37e18f418`
