### PR TITLE
Persist an append-only log of agent messages per project

### DIFF
--- a/change-logs/2026/08/23/feature-agent-message-log.md
+++ b/change-logs/2026/08/23/feature-agent-message-log.md
@@ -1,0 +1,3 @@
+Short: Agent messages are now logged
+
+Every message delivered into a task's agent is now recorded in an append-only per-project log at `~/.dev3.0/data/<project>/messages/YYYY-MM-DD.jsonl`, so task-to-task traffic survives the 30-second toast that used to be its only trace. Each row names both ends by task id and seq, the body (or the spill-file pointer for a body too large to type), whether it was immediate or scheduled, and the delivery outcome including attempts that landed nowhere. History is kept for 30 days and older day-files are deleted whole; a new `readAgentMessageLog` RPC reads it back newest-first.

--- a/decisions/2026/08/23/append-only-agent-message-log.md
+++ b/decisions/2026/08/23/append-only-agent-message-log.md
@@ -1,0 +1,109 @@
+# Append-only agent message log, partitioned by day
+
+## Context
+
+Agent-to-agent messages left no trace. `dev3 message` types straight into the
+recipient's pane; the only record was a transient `agentMessage` push rendered as
+a 30-second toast carrying a 60-character preview. Scheduled messages live in
+`Task.scheduledMessages` and are deleted on delivery. A user who stepped away for
+a day could not reconstruct what a coordinator and its workers said to each other,
+and no UI could ever show a task-to-task traffic graph. This also blocks the 3D
+coordinator-traffic visualization concept (task Seq 1648).
+
+This change writes a new file tree under `~/.dev3.0/`, which walks straight into
+the frozen on-disk invariants in [`AGENTS.md`](../../../../AGENTS.md#on-disk-data-layout--hard-invariants-mandatory):
+that directory is shared with every installed version of the app on the machine,
+`projectSlug()` is frozen, and neither renames nor destructive load-time
+migrations are allowed. The record of that rule being learned the hard way is
+[`revert-project-slug-dash-escape`](../../../04/20/revert-project-slug-dash-escape.md),
+where a slug change plus a startup rename left an older app version staring at an
+empty Kanban board.
+
+## Investigation
+
+Three questions decided the shape.
+
+**Where does a row get written?** `deliverToTarget` in
+`src/bun/scheduled-message-scheduler.ts` is documented as the one seam shared by
+immediate `dev3 message` sends and queued "Send later" fires — the obvious hook.
+It turned out to be the wrong one: `fireScheduledMessage` drops a message for a
+finished task *before* calling it, so a log hooked there would have been silent on
+exactly the case a user investigating a silence needs. Logging therefore happens at
+the two outcome points (`recordMessageAttempt`, called from `fireScheduledMessage`
+and `sendMessageImmediately`), where a final `AgentPromptDelivery` exists.
+
+**Can a single `messages.jsonl` be trimmed?** No, not while staying append-only.
+The only way to trim one file is to rewrite it, and a rewrite loses rows whenever
+two app instances do it at once — the installed app plus a dev build a task's
+`devScript` booted is the normal state of this machine, not an edge case.
+
+**Is a concurrent append safe?** Yes, while one row is one `write()`. A file opened
+`O_APPEND` has its seek-and-write serialised by the kernel, so two processes cannot
+overwrite each other's bytes; a buffer large enough to be split by a short write
+could tear a line across another. Bodies over `AGENT_MESSAGE_SPILL_THRESHOLD_BYTES`
+(4 KB) already travel as a spill-file pointer, so real rows sit far below the cap.
+
+## Decision
+
+`~/.dev3.0/data/<projectSlug>/messages/YYYY-MM-DD.jsonl` — one append-only file
+per project per local day, in a NEW directory beside the existing `tasks.json`.
+Nothing is renamed, nothing is migrated, and an older app version simply never
+opens the directory. `projectSlug()` is used as-is, untouched.
+
+- **Writer / reader / retention:** `src/bun/agent-message-log.ts`
+  (`appendAgentMessageLog`, `readAgentMessageLog`, `pruneAgentMessageLog`). One row
+  is one `appendFileSync` at mode `0600`. Appending never throws — a message that
+  was delivered must not be reported as failed because a log write hit a disk error.
+- **Row shape:** `src/shared/agent-message-log.ts` — pure and shared, so the writer,
+  the reader and the renderer cannot disagree about what a row means. Rows are
+  capped at `AGENT_MESSAGE_LOG_MAX_ROW_BYTES` (8 KiB); an oversized row shrinks its
+  `body` and keeps every metadata field, because a row whose recipient or verdict
+  had been dropped would be worthless to a traffic graph.
+- **Retention:** `AGENT_MESSAGE_LOG_RETENTION_DAYS = 30`. Expired day-files are
+  deleted whole — no rewrite, no rename. Pruning runs from the write path, at most
+  once per day per project, mirroring `pruneLogFiles` in `src/bun/logger.ts`. The
+  reader returns `oldestDay` and `retentionDays`, so trimmed history reads as
+  trimmed rather than as silence.
+- **Call site:** `recordMessageAttempt` in `src/bun/scheduled-message-scheduler.ts`.
+  Every attempt is recorded, `not-delivered` included.
+- **Read path:** the `readAgentMessageLog` RPC in
+  `src/bun/rpc-handlers/notes-labels.ts`. `ScheduledMessage.spilledPath` was added
+  so a row can state that it holds a pointer instead of guessing from the wording.
+
+## Risks
+
+- **Message bodies land on disk unencrypted**, exactly as the agents wrote them,
+  including paths and anything a human pasted by mistake. The file is `0600`, the
+  same as the native-terminal stream taps, and nothing is filtered: a redacted
+  traffic log would not answer the question it exists for. 30 days is the bound.
+- **A spill pointer can outlive its file.** Oversized bodies are written into the
+  task directory, which dies with the task on cleanup. An old row's `spillPath` may
+  name a file that is gone; the row then documents that a large message was sent,
+  and nothing more.
+- **A row is written after delivery, so an app killed mid-send logs nothing.** The
+  window is milliseconds, and the alternative — a row written before delivery —
+  would claim traffic that never happened.
+- **Seq 1655 is moving the delivery boundary** to hold a message's text in memory
+  until the human stops typing. A message held in that window is owed to a recipient
+  and not yet delivered, and this log deliberately cannot express that state. See
+  "Alternatives considered".
+- **A day boundary is local time**, so a day-file straddles a timezone change. It
+  costs at most one mis-filed row and keeps the convention `logger.ts` already uses.
+
+## Alternatives considered
+
+- **One `messages.jsonl` per project, compacted when it grows.** What the original
+  request named. Rejected: compaction is a whole-file rewrite, which is not
+  append-only and loses rows when two app instances run it concurrently.
+- **One `messages.jsonl`, rotated to `messages.1.jsonl`.** Rejected: a rotation is a
+  rename under `~/.dev3.0/`, and the invariants forbid renames there outright rather
+  than case by case.
+- **A per-task file.** Rejected: traffic is *between* tasks, and a per-task file
+  cannot be read as a graph.
+- **SQLite.** Rejected: a new binary format two app versions must agree on, with
+  cross-process locking, to replace a text file the user can `tail`.
+- **Recording held (not yet delivered) messages.** Deliberately out of scope, not
+  designed out: the row already carries `status`, so a `held` value plus an amending
+  row would express it without a schema break. It needs a second file, because a
+  pending row must be removable and this one is append-only — and Arseny has already
+  accepted losing a held message when the app dies. Left for its own decision.

--- a/src/bun/__tests__/agent-message-log-callsite.test.ts
+++ b/src/bun/__tests__/agent-message-log-callsite.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The log is only worth anything if a real send writes to it. These cases drive
+ * the two public entry points — the immediate `dev3 message` send and a queued
+ * "Send later" fire — and then read the file back off a real (redirected) disk.
+ * Nothing here asserts against the writer directly.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-msglog-cs-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../git", () => ({
+	projectSlug: (p: string) => p.replace(/^\//, "").replaceAll("/", "-"),
+	taskDir: (_p: unknown, t: { id: string }) => `${home}/worktrees/proj/${t.id.slice(0, 8)}`,
+}));
+vi.mock("../data", () => ({
+	loadProjects: vi.fn(async () => []),
+	loadVirtualProjects: vi.fn(async () => []),
+	loadTasks: vi.fn(async () => []),
+	getProject: vi.fn(async () => project),
+	getTask: vi.fn(),
+	updateTaskWith: vi.fn(async (_p: unknown, _id: unknown, mutator: (t: unknown) => unknown) => {
+		await mutator(makeTask());
+		return { task: makeTask(), result: undefined };
+	}),
+}));
+vi.mock("../agent-prompt", () => ({
+	sendPromptToAgentPane: vi.fn(async () => true),
+	sendPromptToPane: vi.fn(async () => true),
+}));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => true),
+	sendPromptToNativePane: vi.fn(async () => true),
+}));
+vi.mock("../pty-server", () => ({ DEFAULT_TMUX_SOCKET: "dev3" }));
+vi.mock("../rpc-handlers", () => ({
+	getPushMessage: vi.fn(() => vi.fn()),
+	pushCliToast: vi.fn(),
+	pushCliAttention: vi.fn(),
+	pushAgentMessage: vi.fn(),
+}));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import type { Project, Task } from "../../shared/types";
+import { messageLogDir, readAgentMessageLog, resetAgentMessageLogPruneState } from "../agent-message-log";
+import { fireScheduledMessage, sendMessageImmediately } from "../scheduled-message-scheduler";
+
+const project = { id: "proj-1", name: "Proj", path: "/Users/x/repo" } as unknown as Project;
+
+function makeTask(overrides: Record<string, unknown> = {}): Task {
+	return {
+		id: "task-12345678",
+		projectId: "proj-1",
+		seq: 1650,
+		title: "Worker",
+		status: "in-progress",
+		scheduledMessages: [],
+		sessionState: { panes: [{ paneId: "%1", agentCmd: "claude", sessionId: null, agentId: null, configId: null }] },
+		...overrides,
+	} as unknown as Task;
+}
+
+const source = { taskId: "coordinator-task", seq: 1141, title: "Coordinator", projectId: "proj-1" };
+
+beforeEach(() => {
+	resetAgentMessageLogPruneState();
+	rmSync(messageLogDir(project), { recursive: true, force: true });
+});
+
+describe("an immediate send", () => {
+	it("writes one row naming both ends and the outcome", async () => {
+		await sendMessageImmediately(makeTask(), "check CI and continue", null, source);
+
+		const { rows } = readAgentMessageLog(project);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			fromTaskId: "coordinator-task",
+			fromSeq: 1141,
+			fromTitle: "Coordinator",
+			toTaskId: "task-12345678",
+			toSeq: 1650,
+			toTitle: "Worker",
+			toProjectId: "proj-1",
+			kind: "immediate",
+			// The body as the sender wrote it, not the pseudo-XML envelope it travels in.
+			body: "check CI and continue",
+			bodyKind: "text",
+		});
+		expect(["delivered", "unconfirmed"]).toContain(rows[0]?.status);
+	});
+
+	it("records a message with no agent sender as having none", async () => {
+		await sendMessageImmediately(makeTask(), "rebase finished", null, null);
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]).toMatchObject({ fromTaskId: null, fromSeq: null, toSeq: 1650 });
+	});
+
+	it("marks an oversized body as a pointer and keeps the file path", async () => {
+		await sendMessageImmediately(makeTask(), "y".repeat(5_000), null, source);
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]?.bodyKind).toBe("spill-pointer");
+		expect(rows[0]?.spillPath).toContain("/messages/message-");
+		// The row carries the pointer the pane got, not the 5 KB body.
+		expect(rows[0]?.body).toContain("too large to type");
+	});
+});
+
+describe("a queued fire", () => {
+	it("writes a scheduled row carrying the time it was queued for", async () => {
+		const at = new Date(Date.now() - 1000).toISOString();
+		const message = { id: "msg-1", text: "wake up", at, target: { kind: "agent" as const }, source };
+		await fireScheduledMessage(project, makeTask({ scheduledMessages: [message] }), message, { late: true });
+
+		const { rows } = readAgentMessageLog(project);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ kind: "scheduled", scheduledFor: at, body: "wake up", fromSeq: 1141 });
+	});
+
+	it("records an attempt that landed nowhere rather than staying silent", async () => {
+		const message = { id: "msg-2", text: "too late", at: new Date().toISOString(), target: { kind: "agent" as const }, source };
+		// A finished task has no live agent: nothing is delivered, and that is the
+		// exact state a user reconstructing a silence needs to find in the log.
+		await fireScheduledMessage(project, makeTask({ status: "completed" }), message, { late: false });
+
+		const { rows } = readAgentMessageLog(project);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ status: "not-delivered", body: "too late", toSeq: 1650 });
+	});
+});

--- a/src/bun/__tests__/agent-message-log.test.ts
+++ b/src/bun/__tests__/agent-message-log.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+
+// A real filesystem, redirected: the point of these cases is that appends land as
+// bytes and that pruning deletes files, neither of which a mocked fs can prove.
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-msglog-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import type { Project } from "../../shared/types";
+import {
+	AGENT_MESSAGE_LOG_MAX_ROW_BYTES,
+	AGENT_MESSAGE_LOG_RETENTION_DAYS,
+	AGENT_MESSAGE_LOG_TRUNCATION_MARK,
+	parseAgentMessageLogRow,
+	serializeAgentMessageLogRow,
+	type AgentMessageLogInput,
+} from "../../shared/agent-message-log";
+import {
+	appendAgentMessageLog,
+	messageLogDir,
+	pruneAgentMessageLog,
+	readAgentMessageLog,
+	resetAgentMessageLogPruneState,
+} from "../agent-message-log";
+
+const project = { id: "proj-1", name: "Proj", path: "/Users/x/repo" } as unknown as Project;
+
+function makeRow(overrides: Partial<AgentMessageLogInput> = {}): AgentMessageLogInput {
+	return {
+		at: "2026-08-23T10:00:00.000Z",
+		fromTaskId: "sender-task",
+		fromSeq: 1141,
+		fromTitle: "Coordinator",
+		toTaskId: "recipient-task",
+		toSeq: 1650,
+		toTitle: "Worker",
+		toProjectId: "proj-1",
+		kind: "immediate",
+		body: "check CI and continue",
+		bodyKind: "text",
+		status: "delivered",
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	resetAgentMessageLogPruneState();
+	rmSync(messageLogDir(project), { recursive: true, force: true });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("row serialisation", () => {
+	it("round-trips a row through one line", () => {
+		const line = serializeAgentMessageLogRow(makeRow());
+		expect(line.endsWith("\n")).toBe(true);
+		expect(line.indexOf("\n")).toBe(line.length - 1);
+		const parsed = parseAgentMessageLogRow(line);
+		expect(parsed).toMatchObject({ v: 1, fromSeq: 1141, toSeq: 1650, body: "check CI and continue" });
+	});
+
+	it("clamps an oversized row to the ceiling and keeps the metadata", () => {
+		const line = serializeAgentMessageLogRow(makeRow({ body: "x".repeat(AGENT_MESSAGE_LOG_MAX_ROW_BYTES * 3) }));
+		expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(AGENT_MESSAGE_LOG_MAX_ROW_BYTES);
+		const parsed = parseAgentMessageLogRow(line);
+		// The body shrank; who spoke to whom and how it went survived intact.
+		expect(parsed?.body.endsWith(AGENT_MESSAGE_LOG_TRUNCATION_MARK)).toBe(true);
+		expect(parsed).toMatchObject({ toSeq: 1650, fromSeq: 1141, status: "delivered" });
+	});
+
+	it("never cuts a multi-byte character in half", () => {
+		const line = serializeAgentMessageLogRow(makeRow({ body: "ы".repeat(AGENT_MESSAGE_LOG_MAX_ROW_BYTES) }));
+		const parsed = parseAgentMessageLogRow(line);
+		expect(parsed).not.toBeNull();
+		expect(parsed?.body).not.toContain("�");
+	});
+
+	it("rejects a torn or junk line instead of throwing", () => {
+		expect(parseAgentMessageLogRow('{"v":1,"at":"2026-08-23T10:00:00.000Z","toTaskId":"t","toS')).toBeNull();
+		expect(parseAgentMessageLogRow("")).toBeNull();
+		expect(parseAgentMessageLogRow("not json at all")).toBeNull();
+		// Valid JSON but missing the fields a traffic graph cannot do without.
+		expect(parseAgentMessageLogRow('{"v":1,"at":"x","toTaskId":"t","body":"b"}')).toBeNull();
+	});
+});
+
+describe("append and read", () => {
+	it("appends into a day-file beside tasks.json and reads it back newest-first", () => {
+		const day = new Date(2026, 7, 23, 12, 0, 0);
+		appendAgentMessageLog(project, makeRow({ body: "first" }), day);
+		appendAgentMessageLog(project, makeRow({ body: "second" }), day);
+
+		expect(messageLogDir(project)).toBe(`${home}/data/Users-x-repo/messages`);
+		const raw = readFileSync(`${messageLogDir(project)}/2026-08-23.jsonl`, "utf8");
+		expect(raw.split("\n").filter(Boolean)).toHaveLength(2);
+
+		const page = readAgentMessageLog(project);
+		expect(page.rows.map((r) => r.body)).toEqual(["second", "first"]);
+		expect(page.oldestDay).toBe("2026-08-23");
+		expect(page.retentionDays).toBe(AGENT_MESSAGE_LOG_RETENTION_DAYS);
+		expect(page.hasMore).toBe(false);
+	});
+
+	it("orders across days, newest day first", () => {
+		appendAgentMessageLog(project, makeRow({ body: "older" }), new Date(2026, 7, 21, 9, 0, 0));
+		appendAgentMessageLog(project, makeRow({ body: "newer" }), new Date(2026, 7, 22, 9, 0, 0));
+		const page = readAgentMessageLog(project);
+		expect(page.rows.map((r) => r.body)).toEqual(["newer", "older"]);
+		expect(page.oldestDay).toBe("2026-08-21");
+	});
+
+	it("honours the limit and says older rows remain", () => {
+		const day = new Date(2026, 7, 23, 12, 0, 0);
+		for (let i = 0; i < 5; i++) appendAgentMessageLog(project, makeRow({ body: `m${i}` }), day);
+		const page = readAgentMessageLog(project, 2);
+		expect(page.rows.map((r) => r.body)).toEqual(["m4", "m3"]);
+		expect(page.hasMore).toBe(true);
+	});
+
+	it("skips a truncated trailing line and keeps every complete row", () => {
+		const day = new Date(2026, 7, 23, 12, 0, 0);
+		appendAgentMessageLog(project, makeRow({ body: "first" }), day);
+		appendAgentMessageLog(project, makeRow({ body: "second" }), day);
+		// A file cut short — the last line lost its tail and its newline.
+		appendFileSync(`${messageLogDir(project)}/2026-08-23.jsonl`, '{"v":1,"at":"2026-08-2');
+		const page = readAgentMessageLog(project);
+		expect(page.rows.map((r) => r.body)).toEqual(["second", "first"]);
+	});
+
+	it("answers an empty page for a project that has never sent a message", () => {
+		const page = readAgentMessageLog(project);
+		expect(page).toEqual({ rows: [], oldestDay: null, retentionDays: AGENT_MESSAGE_LOG_RETENTION_DAYS, hasMore: false });
+	});
+
+	it("survives an unwritable log directory without throwing", () => {
+		const dir = messageLogDir(project);
+		mkdirSync(dir.slice(0, dir.lastIndexOf("/")), { recursive: true });
+		// A plain file where the directory should be: mkdir and append both fail.
+		writeFileSync(dir, "not a directory");
+		expect(() => appendAgentMessageLog(project, makeRow(), new Date(2026, 7, 23))).not.toThrow();
+		rmSync(dir, { force: true });
+	});
+});
+
+describe("retention", () => {
+	it("deletes day-files past the window and keeps the boundary day", () => {
+		const now = new Date(2026, 7, 23, 12, 0, 0);
+		const dayMs = 24 * 60 * 60 * 1000;
+		const boundary = new Date(now.getTime() - (AGENT_MESSAGE_LOG_RETENTION_DAYS - 1) * dayMs);
+		const expired = new Date(now.getTime() - AGENT_MESSAGE_LOG_RETENTION_DAYS * dayMs);
+		// Written directly, so the write path's own prune cannot pre-empt the case.
+		mkdirSync(messageLogDir(project), { recursive: true });
+		for (const [day, body] of [[expired, "expired"], [boundary, "boundary"], [now, "today"]] as const) {
+			const stamp = `${day.getFullYear()}-${String(day.getMonth() + 1).padStart(2, "0")}-${String(day.getDate()).padStart(2, "0")}`;
+			writeFileSync(`${messageLogDir(project)}/${stamp}.jsonl`, serializeAgentMessageLogRow(makeRow({ body })));
+		}
+
+		expect(pruneAgentMessageLog(project, now)).toBe(1);
+		const bodies = readAgentMessageLog(project).rows.map((r) => r.body);
+		expect(bodies).toEqual(["today", "boundary"]);
+	});
+
+	it("prunes from the write path, once per day per project", () => {
+		const now = new Date(2026, 7, 23, 12, 0, 0);
+		const expired = new Date(now.getTime() - 400 * 24 * 60 * 60 * 1000);
+		appendAgentMessageLog(project, makeRow({ body: "ancient" }), expired);
+		resetAgentMessageLogPruneState();
+		appendAgentMessageLog(project, makeRow({ body: "today" }), now);
+		expect(readAgentMessageLog(project).rows.map((r) => r.body)).toEqual(["today"]);
+	});
+
+	it("leaves foreign files in the directory alone", () => {
+		const now = new Date(2026, 7, 23, 12, 0, 0);
+		appendAgentMessageLog(project, makeRow(), now);
+		writeFileSync(`${messageLogDir(project)}/README.txt`, "hands off");
+		expect(pruneAgentMessageLog(project, new Date(2027, 0, 1))).toBe(1);
+		expect(readFileSync(`${messageLogDir(project)}/README.txt`, "utf8")).toBe("hands off");
+	});
+});

--- a/src/bun/agent-message-log.ts
+++ b/src/bun/agent-message-log.ts
@@ -1,0 +1,168 @@
+/**
+ * Append-only, per-project log of every message delivered into a task's agent.
+ *
+ * Layout: `~/.dev3.0/data/<projectSlug>/messages/YYYY-MM-DD.jsonl` — a NEW
+ * directory beside the existing `tasks.json`, which is the only shape the on-disk
+ * invariants in AGENTS.md allow. Nothing existing is renamed, nothing is migrated,
+ * and an older app version simply never opens this directory.
+ *
+ * Why one file per day rather than the single `messages.jsonl` the request named:
+ * retention has to be real, and the only way to trim a single append-only file is
+ * to rewrite it — which stops being append-only and loses rows when two app
+ * instances (the installed app plus a dev build) do it at the same moment.
+ * Deleting a whole expired day-file needs no rewrite and no rename.
+ *
+ * Concurrency: one row is one `appendFileSync` on a file opened `O_APPEND`, so the
+ * kernel serialises the seek-and-write and two processes can never overwrite each
+ * other's bytes. Rows are capped at `AGENT_MESSAGE_LOG_MAX_ROW_BYTES` so a single
+ * `write()` always carries the whole line — a buffer big enough to be split could
+ * tear one row across another. A reader that meets a torn line skips it.
+ *
+ * Privacy: bodies land unencrypted, exactly as the agents wrote them, including
+ * paths and anything pasted by mistake. The file is `0600`, same as the terminal
+ * stream taps, and nothing is filtered — a redacted traffic log would not answer
+ * the question it exists for.
+ */
+
+import { appendFileSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
+import type { Project } from "../shared/types";
+import {
+	AGENT_MESSAGE_LOG_RETENTION_DAYS,
+	type AgentMessageLogInput,
+	type AgentMessageLogPage,
+	type AgentMessageLogRow,
+	parseAgentMessageLogRow,
+	serializeAgentMessageLogRow,
+} from "../shared/agent-message-log";
+import { DEV3_HOME } from "./paths";
+import { projectSlug } from "./git";
+import { createLogger } from "./logger";
+
+const log = createLogger("agent-message-log");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DAY_FILE_RE = /^(\d{4})-(\d{2})-(\d{2})\.jsonl$/;
+
+/** Local-day stamp, matching the diagnostic log's convention. */
+function dayStamp(at: Date): string {
+	return `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
+}
+
+/** The per-project directory holding the day-files. */
+export function messageLogDir(project: Project): string {
+	return `${DEV3_HOME}/data/${projectSlug(project.path)}/messages`;
+}
+
+function dayFile(project: Project, at: Date): string {
+	return `${messageLogDir(project)}/${dayStamp(at)}.jsonl`;
+}
+
+function parseDay(fileName: string): number | null {
+	const match = DAY_FILE_RE.exec(fileName);
+	if (!match) return null;
+	const [year, month, day] = [Number(match[1]), Number(match[2]), Number(match[3])];
+	const date = new Date(year, month - 1, day);
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+	return date.getTime();
+}
+
+/**
+ * Delete day-files outside the retention window. Best-effort and silent: a
+ * concurrent writer or a permission change must never break message delivery.
+ * Returns how many files went.
+ */
+export function pruneAgentMessageLog(project: Project, now: Date = new Date()): number {
+	const dir = messageLogDir(project);
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+	const cutoff = today - (AGENT_MESSAGE_LOG_RETENTION_DAYS - 1) * DAY_MS;
+	let removed = 0;
+	try {
+		for (const name of readdirSync(dir)) {
+			const day = parseDay(name);
+			if (day === null || day >= cutoff) continue;
+			try {
+				unlinkSync(`${dir}/${name}`);
+				removed += 1;
+			} catch {
+				// Another instance may have removed it already.
+			}
+		}
+	} catch {
+		// No directory yet, or unreadable — nothing to prune.
+	}
+	return removed;
+}
+
+let lastPrunedDay = new Map<string, string>();
+
+function pruneIfNeeded(project: Project, now: Date): void {
+	const today = dayStamp(now);
+	if (lastPrunedDay.get(project.id) === today) return;
+	lastPrunedDay.set(project.id, today);
+	pruneAgentMessageLog(project, now);
+}
+
+/** Test seam: forget which projects were pruned today. */
+export function resetAgentMessageLogPruneState(): void {
+	lastPrunedDay = new Map();
+}
+
+/**
+ * Append one row. Never throws: a message that was delivered must not be reported
+ * as failed because a log write lost a race with a disk error.
+ */
+export function appendAgentMessageLog(project: Project, input: AgentMessageLogInput, now: Date = new Date()): void {
+	const line = serializeAgentMessageLogRow(input);
+	const file = dayFile(project, now);
+	try {
+		mkdirSync(messageLogDir(project), { recursive: true });
+		appendFileSync(file, line, { mode: 0o600 });
+	} catch (err) {
+		log.warn("Failed to append to the message log", { projectId: project.id, error: String(err) });
+		return;
+	}
+	pruneIfNeeded(project, now);
+}
+
+/**
+ * Read recent history, newest first. Torn and unparseable lines are skipped —
+ * losing one row beats losing the day it lives in.
+ */
+export function readAgentMessageLog(project: Project, limit = 500): AgentMessageLogPage {
+	const dir = messageLogDir(project);
+	let days: string[];
+	try {
+		days = readdirSync(dir).filter((name) => parseDay(name) !== null).sort();
+	} catch {
+		return { rows: [], oldestDay: null, retentionDays: AGENT_MESSAGE_LOG_RETENTION_DAYS, hasMore: false };
+	}
+	const oldestDay = days[0] ? days[0].slice(0, -".jsonl".length) : null;
+	const rows: AgentMessageLogRow[] = [];
+	let hasMore = false;
+	for (const name of [...days].reverse()) {
+		if (rows.length >= limit) {
+			hasMore = true;
+			break;
+		}
+		let content: string;
+		try {
+			content = readFileSync(`${dir}/${name}`, "utf8");
+		} catch {
+			continue;
+		}
+		const dayRows: AgentMessageLogRow[] = [];
+		for (const line of content.split("\n")) {
+			const row = parseAgentMessageLogRow(line);
+			if (row) dayRows.push(row);
+		}
+		dayRows.reverse();
+		for (const row of dayRows) {
+			if (rows.length >= limit) {
+				hasMore = true;
+				break;
+			}
+			rows.push(row);
+		}
+	}
+	return { rows, oldestDay, retentionDays: AGENT_MESSAGE_LOG_RETENTION_DAYS, hasMore };
+}

--- a/src/bun/rpc-handlers/notes-labels.ts
+++ b/src/bun/rpc-handlers/notes-labels.ts
@@ -1,6 +1,8 @@
 import type { ColumnAgentConfig, CustomColumn, Label, NoteSource, Project, Task, TaskNote, TaskStatus } from "../../shared/types";
 import { LABEL_COLORS, appendTaskNote } from "../../shared/types";
+import type { AgentMessageLogPage } from "../../shared/agent-message-log";
 import * as data from "../data";
+import { readAgentMessageLog as readMessageLog } from "../agent-message-log";
 import { getPushMessage, log } from "./shared";
 import { dispatchLifecycleEvent } from "../lifecycle/service";
 
@@ -307,7 +309,18 @@ async function deleteTaskNote(params: { taskId: string; projectId: string; noteI
 	return updated;
 }
 
+/**
+ * Read the project's message log. Read-only and never throws on a missing file: a
+ * project that has had no agent traffic yet answers with an empty page rather than
+ * an error the caller has to special-case.
+ */
+async function readAgentMessageLog(params: { projectId: string; limit?: number }): Promise<AgentMessageLogPage> {
+	const project = await data.getProject(params.projectId);
+	return readMessageLog(project, params.limit);
+}
+
 export const notesLabelsHandlers = {
+	readAgentMessageLog,
 	createLabel,
 	updateLabel,
 	deleteLabel,

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -14,6 +14,7 @@ import type { AgentPromptDelivery } from "../shared/agent-prompt-delivery";
 import { deliverAgentPrompt } from "./agent-prompt-delivery";
 import { wrapAgentMessage } from "../shared/agent-message-envelope";
 import { spillOversizedAgentMessage } from "./agent-message-spill";
+import { appendAgentMessageLog } from "./agent-message-log";
 // Import push via the barrel (not ./rpc-handlers/shared) so tests that mock
 // `../rpc-handlers` — e.g. the cli-socket lost-update race suites, which reach
 // this module through cli-socket-server — don't load the real Electrobun-backed
@@ -72,6 +73,46 @@ async function deliverToTarget(task: Task, message: ScheduledMessage): Promise<A
 	const delivery = await deliverAgentPrompt(task, text, message.target, { coalesceSubmit: true });
 	if (message.source) announceAgentMessage(task, message, delivery);
 	return delivery;
+}
+
+/**
+ * Write the attempt to the project's append-only message log — the only durable
+ * record that one task spoke to another.
+ *
+ * Called from the two OUTCOME points rather than from `deliverToTarget`, because a
+ * message can end without ever reaching a pane: a finished task is dropped before
+ * delivery is attempted, and "we tried and nothing landed" is exactly the state a
+ * user reconstructing a silence needs to find. Every attempt is logged,
+ * `not-delivered` included, and the row carries the real verdict, never an intent.
+ */
+async function recordMessageAttempt(task: Task, message: ScheduledMessage, delivery: AgentPromptDelivery): Promise<void> {
+	try {
+		const project = await data.getProject(task.projectId);
+		const source = message.source;
+		appendAgentMessageLog(project, {
+			at: new Date().toISOString(),
+			fromTaskId: source?.taskId ?? null,
+			fromSeq: source?.seq ?? null,
+			...(source?.title ? { fromTitle: source.title } : {}),
+			...(source?.projectId ? { fromProjectId: source.projectId } : {}),
+			toTaskId: task.id,
+			toSeq: task.seq,
+			toTitle: getTaskTitle(task),
+			toProjectId: task.projectId,
+			// A queued item carries the time it was queued for; an immediate send has none.
+			kind: message.at ? "scheduled" : "immediate",
+			...(message.at ? { scheduledFor: message.at } : {}),
+			body: message.text,
+			bodyKind: message.spilledPath ? "spill-pointer" : "text",
+			...(message.spilledPath ? { spillPath: message.spilledPath } : {}),
+			status: delivery.status,
+			...(delivery.reason ? { reason: delivery.reason } : {}),
+			...(delivery.detail ? { detail: delivery.detail } : {}),
+		});
+	} catch (err) {
+		// Logging is observability, never a delivery precondition.
+		log.warn("Could not record the message in the project log", { taskId: task.id.slice(0, 8), error: String(err) });
+	}
 }
 
 /**
@@ -151,6 +192,7 @@ export async function fireScheduledMessage(
 			log.warn("Scheduled message delivery threw", { taskId: task.id.slice(0, 8), error: String(err) });
 		}
 	}
+	await recordMessageAttempt(task, message, delivery);
 	const updated = await removeFromQueue(project, task, message.id);
 	const preview = messagePreview(message.text);
 	if (delivery.status === "not-delivered") {
@@ -206,7 +248,7 @@ export async function scheduleMessage(
 	}
 	// Spilled at queue time, not at delivery: the queue lives in tasks.json, and 20
 	// pending messages of the full allowed length would put megabytes in there.
-	const { text } = await spillOversizedAgentMessage(task, validated);
+	const { text, spilledPath } = await spillOversizedAgentMessage(task, validated);
 	const at = new Date(input.at);
 	if (!Number.isFinite(at.getTime()) || at.getTime() <= Date.now()) {
 		throw new Error("Scheduled message time must be in the future");
@@ -217,6 +259,7 @@ export async function scheduleMessage(
 		at: at.toISOString(),
 		target: normalizeTarget(input.target),
 		...(input.source ? { source: input.source } : {}),
+		...(spilledPath ? { spilledPath } : {}),
 	};
 	const { task: updated } = await data.updateTaskWith<void>(project, task.id, (current) => {
 		const queue = current.scheduledMessages ?? [];
@@ -264,13 +307,16 @@ export async function sendMessageImmediately(
 		throw new Error("Cannot send a message to a completed or cancelled task");
 	}
 	const { text: payload, spilledPath } = await spillOversizedAgentMessage(task, trimmed);
-	const delivery = await deliverToTarget(task, {
+	const message: ScheduledMessage = {
 		id: "",
 		text: payload,
 		at: "",
 		target: normalizeTarget(target),
 		...(source ? { source } : {}),
-	});
+		...(spilledPath ? { spilledPath } : {}),
+	};
+	const delivery = await deliverToTarget(task, message);
+	await recordMessageAttempt(task, message, delivery);
 	if (delivery.status === "not-delivered") {
 		throw new Error("Could not deliver the message — the task has no live agent session.");
 	}

--- a/src/shared/agent-message-log.ts
+++ b/src/shared/agent-message-log.ts
@@ -1,0 +1,147 @@
+/**
+ * The on-disk shape of one delivered message, and the rules that keep the file
+ * append-only and safe for two app instances at once.
+ *
+ * Until this existed, task-to-task traffic left no trace: `dev3 message` types
+ * straight into the recipient's pane and the only record was a 30-second toast.
+ * A user who stepped away could not reconstruct what the coordinator and its
+ * workers said to each other.
+ *
+ * Pure and shared: the bun writer, the reader and the renderer all speak this
+ * type, so a row can never mean two different things at the two ends.
+ */
+
+import type { AgentPromptDeliveryStatus } from "./agent-prompt-delivery";
+
+/** Schema version. Bumped only when a reader must branch; readers skip unknown values. */
+export const AGENT_MESSAGE_LOG_VERSION = 1;
+
+/**
+ * Hard ceiling on one serialised row, including its newline.
+ *
+ * Load-bearing for concurrency, not for disk. Appends from two processes are
+ * interleaving-safe only while each row is a single `write()`; a buffer large
+ * enough to be split by a short write could tear a line in half. Bodies over
+ * {@link AGENT_MESSAGE_SPILL_THRESHOLD_BYTES} (4 KB) already travel as a
+ * spill-file pointer, so a real row sits far below this.
+ */
+export const AGENT_MESSAGE_LOG_MAX_ROW_BYTES = 8_192;
+
+/** Days of history kept. Older day-files are deleted, not compacted. */
+export const AGENT_MESSAGE_LOG_RETENTION_DAYS = 30;
+
+/** Marker appended to a body clipped by {@link AGENT_MESSAGE_LOG_MAX_ROW_BYTES}. */
+export const AGENT_MESSAGE_LOG_TRUNCATION_MARK = "…[truncated by the message log]";
+
+/**
+ * What the recipient's pane actually received.
+ *
+ * - `text` — the body itself, verbatim.
+ * - `spill-pointer` — the body was too large to type, so a file was written next
+ *   to the task and the pane got a pointer to it. `spillPath` names that file.
+ *   It lives in the task directory and dies with the task on cleanup, so an old
+ *   row's pointer may name a file that no longer exists — the row then documents
+ *   that a large message was sent, and nothing more.
+ */
+export type AgentMessageBodyKind = "text" | "spill-pointer";
+
+/** Immediate `dev3 message` send versus a queued "Send later" fire. */
+export type AgentMessageLogKind = "immediate" | "scheduled";
+
+/** One delivered (or attempted) message. Written once, never amended. */
+export interface AgentMessageLogRow {
+	v: number;
+	/** ISO timestamp of the delivery attempt, not of authoring. */
+	at: string;
+	/** Sender task, or null when no agent wrote it (a UI button, a dev3 hand-off). */
+	fromTaskId: string | null;
+	fromSeq: number | null;
+	fromTitle?: string;
+	fromProjectId?: string;
+	toTaskId: string;
+	toSeq: number;
+	toTitle?: string;
+	toProjectId: string;
+	kind: AgentMessageLogKind;
+	/** ISO time the message was queued for, on `scheduled` rows only. */
+	scheduledFor?: string;
+	body: string;
+	bodyKind: AgentMessageBodyKind;
+	spillPath?: string;
+	/** The delivery verdict — `unconfirmed` is its own answer, never folded away. */
+	status: AgentPromptDeliveryStatus;
+	reason?: string;
+	detail?: string;
+}
+
+/** Everything needed to write a row, minus the version and the clock. */
+export type AgentMessageLogInput = Omit<AgentMessageLogRow, "v">;
+
+/** One page of history, as the reader returns it and the renderer receives it. */
+export interface AgentMessageLogPage {
+	/** Newest first. */
+	rows: AgentMessageLogRow[];
+	/**
+	 * The oldest day still on disk (`YYYY-MM-DD`), or null when there is no history
+	 * at all. A reader shows this so trimmed history reads as trimmed, not as
+	 * silence: everything before this day was deleted by the retention policy.
+	 */
+	oldestDay: string | null;
+	/** Days of history the retention policy keeps. */
+	retentionDays: number;
+	/** True when `limit` cut the answer short and older rows still exist on disk. */
+	hasMore: boolean;
+}
+
+function utf8Bytes(text: string): number {
+	return new TextEncoder().encode(text).length;
+}
+
+/** Clip `body` so the whole row fits the ceiling. Returns the body to store. */
+export function clampLogBody(body: string, overheadBytes: number): string {
+	const budget = AGENT_MESSAGE_LOG_MAX_ROW_BYTES - overheadBytes - utf8Bytes(AGENT_MESSAGE_LOG_TRUNCATION_MARK);
+	if (utf8Bytes(body) <= AGENT_MESSAGE_LOG_MAX_ROW_BYTES - overheadBytes) return body;
+	if (budget <= 0) return AGENT_MESSAGE_LOG_TRUNCATION_MARK;
+	// Walk back from the byte budget so a multi-byte character is never cut in half.
+	let end = Math.min(body.length, budget);
+	while (end > 0 && utf8Bytes(body.slice(0, end)) > budget) end -= 1;
+	return body.slice(0, end) + AGENT_MESSAGE_LOG_TRUNCATION_MARK;
+}
+
+/**
+ * Serialise one row into exactly one line, guaranteed to fit the ceiling.
+ *
+ * The body is clamped against the size of everything else in the row, so a long
+ * body shrinks and the metadata always survives — a row whose recipient or
+ * outcome had been dropped would be worthless to a traffic graph.
+ */
+export function serializeAgentMessageLogRow(input: AgentMessageLogInput): string {
+	const row: AgentMessageLogRow = { v: AGENT_MESSAGE_LOG_VERSION, ...input };
+	const line = `${JSON.stringify(row)}\n`;
+	if (utf8Bytes(line) <= AGENT_MESSAGE_LOG_MAX_ROW_BYTES) return line;
+	const overhead = utf8Bytes(`${JSON.stringify({ ...row, body: "" })}\n`);
+	return `${JSON.stringify({ ...row, body: clampLogBody(row.body, overhead) })}\n`;
+}
+
+/**
+ * Parse one line, or null when it cannot be trusted.
+ *
+ * A torn or half-written line is expected rather than exceptional: the app can be
+ * killed mid-append, and a reader that threw on one bad byte would lose the whole
+ * day. Anything without a recipient and a timestamp is discarded.
+ */
+export function parseAgentMessageLogRow(line: string): AgentMessageLogRow | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object") return null;
+	const row = parsed as Partial<AgentMessageLogRow>;
+	if (typeof row.at !== "string" || typeof row.toTaskId !== "string" || typeof row.body !== "string") return null;
+	if (typeof row.toSeq !== "number" || typeof row.status !== "string") return null;
+	return row as AgentMessageLogRow;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,7 @@ import type { TaskPaneState, TaskPaneAction, TaskPaneBackendKind } from "./task-
 import type { DeepLinkNav } from "./deep-link";
 import type { UpdateChannel } from "./update-channel";
 import type { AgentPromptDelivery } from "./agent-prompt-delivery";
+import type { AgentMessageLogPage } from "./agent-message-log";
 
 // ---- Changelog ----
 
@@ -2322,6 +2323,12 @@ export interface ScheduledMessage {
 	target: ScheduledMessageTarget;
 	/** Set when another task's agent sent it — wraps the text at fire time. */
 	source?: AgentMessageSource;
+	/**
+	 * The file the real body was written to when it was too large to type, leaving
+	 * {@link text} a pointer to it. Carried so the message log can say a row holds a
+	 * pointer rather than a body, instead of guessing from the wording.
+	 */
+	spilledPath?: string;
 }
 
 /**
@@ -4675,6 +4682,11 @@ export type AppRPCSchema = {
 			deleteTaskNote: {
 				params: { taskId: string; projectId: string; noteId: string };
 				response: Task;
+			};
+			/** Read the project's append-only message log, newest first. */
+			readAgentMessageLog: {
+				params: { projectId: string; limit?: number };
+				response: AgentMessageLogPage;
 			};
 			taskPaneState: {
 				params: { taskId: string };


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

Agent-to-agent messages left no trace. `dev3 message` types straight into the recipient's pane; the only record was a transient push rendered as a 30-second toast carrying a 60-character preview, and a scheduled message is deleted from `Task.scheduledMessages` on delivery. A user who stepped away for a day could not reconstruct what a coordinator and its workers said to each other, and no UI could show a task-to-task traffic graph.

This adds an append-only per-project log at `~/.dev3.0/data/<projectSlug>/messages/YYYY-MM-DD.jsonl` — a NEW directory beside the existing `tasks.json`. Nothing is renamed, nothing is migrated, `projectSlug()` is untouched, and an older app version simply never opens the directory.

## Two things worth a reviewer's attention

**The original delivery seam skipped the `not-delivered` case entirely — this is a defect fix, not just plumbing.** `deliverToTarget` is documented as the one seam shared by immediate sends and queued fires, so it was the obvious hook. It is the wrong one: `fireScheduledMessage` drops a message for a finished task *before* calling it, so a log hooked there would have been silent on exactly the case a user investigating a silence needs to see. Logging therefore happens at the two outcome points (`recordMessageAttempt`), where a final `AgentPromptDelivery` exists. Every attempt is recorded.

**Day-partitioned rather than one `messages.jsonl`, because retention has to be real.** The only way to trim a single append-only file is to rewrite it — which stops being append-only and loses rows whenever two app instances do it at once. The installed app plus a dev build a task's `devScript` booted is the normal state of a dev machine, not an edge case. Deleting a whole expired day-file needs no rewrite and no rename, which is also the only shape the on-disk invariants allow.

## The rest of the design

- **Concurrent appends** are safe because one row is one `appendFileSync` on an `O_APPEND` file: the kernel serialises the seek-and-write. Rows are hard-capped at `AGENT_MESSAGE_LOG_MAX_ROW_BYTES` (8 KiB) so a single `write()` always carries the whole line; an oversized row shrinks its `body` and keeps every metadata field, since a row missing its recipient or verdict is worthless to a traffic graph. A reader that meets a truncated line skips it.
- **Retention** is 30 days, pruned from the write path at most once per day per project, mirroring `pruneLogFiles` in `src/bun/logger.ts`. The reader returns `oldestDay` and `retentionDays`, so trimmed history reads as trimmed rather than as silence.
- **Oversized bodies** reuse the existing spill mechanism instead of inventing a second one: the row records `bodyKind: "spill-pointer"` plus the path. That file lives in the task directory and dies with the task on cleanup, so an old pointer may name a file that is gone — the row then documents that a large message was sent, and nothing more. `ScheduledMessage.spilledPath` was added so the row can state this rather than guess it from the wording.
- **Privacy:** bodies land unencrypted, exactly as the agents wrote them, including paths and anything pasted by mistake. The file is `0600`, the same as the native-terminal stream taps, and nothing is filtered — a redacted traffic log would not answer the question it exists for. 30 days is the bound.
- **Read path:** a new `readAgentMessageLog` RPC, returning rows newest-first. No renderer surface is added; this PR owns the data, and the visualization concept is a separate task.

Prerequisite for the 3D coordinator-traffic visualization concept. Decision record: `decisions/2026/08/23/append-only-agent-message-log.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=362f03fe-3136-4dbe-a117-54e87173f352) · `dev3://task/362f03fe-3136-4dbe-a117-54e87173f352`
