### PR TITLE
Inherit the requester's priority on an agent-initiated launch

### DIFF
--- a/change-logs/2026/08/23/feature-launch-dialog-priority.md
+++ b/change-logs/2026/08/23/feature-launch-dialog-priority.md
@@ -1,0 +1,5 @@
+Short: Launched tasks inherit your priority
+
+A task an agent asks to start now inherits the requesting task's priority instead of always landing on P3, and the launch approval dialog's priority badge became a picker, so you can set the band before the task starts. An explicit priority on the target task still wins, and the priority you pick is applied even if the dialog approves itself while you are away.
+
+Suggested by @markkesty (h0x91b/dev-3.0#1496)

--- a/decisions/2026/08/23/launched-task-inherits-requester-priority.md
+++ b/decisions/2026/08/23/launched-task-inherits-requester-priority.md
@@ -1,0 +1,27 @@
+# Launched task inherits the requester's priority
+
+## Context
+
+An agent asking the user to set another task running (`dev3 task move --task seq:N --status in-progress`, or `dev3 task create --scratch --run`) produced a task on the default P3 band. A P0 investigation spawning three helpers therefore watched them sink below every P4 on the board — issue #1496.
+
+## Decision
+
+Two changes, both in the approval path:
+
+1. **Inheritance.** `resolveLaunchPriority` (`src/bun/cli-socket-server.ts`) resolves the band the launch will use: the target's own `task.priority` when set, otherwise the requesting task's. `Task.priority` is `undefined` until someone sets it explicitly, which is exactly the "no priority was specified" signal — a scratch peer and a `task create` without `--priority` both qualify. The value travels to the dialog as `AgentLaunchRequest.defaultPriority`.
+2. **Override.** The launch dialog's subject-card priority badge became a picker (`TaskDialogSubjectCard.onPriorityChange`, an opt-in the other dialogs do not pass). The pick rides in `AgentLaunchChoice.priority` and is mirrored to the pending request, so an auto-approval that fires with nobody watching still uses it. `launchTaskWithAgentChoice` applies it through `data.setTaskPriority` — priority is group-wide, so it cannot go in the single-task `taskPatch` — before dispatching the move, and re-reads the task so the lifecycle event carries fresh state.
+
+The fallback lives on the bun side (`choice.priority ?? defaultPriority`), not in the dialog: an auto-approval with no client attached carries no launch choice at all.
+
+`PriorityPicker` had to move too. It was a `z-50` portal using `useEscapeKey`, which inside a `z-[60]` dialog meant invisible *and* Escape-closes-the-whole-dialog — the exact failure `utils/overlay-layers.ts` documents. It now registers via `useOverlayLayer` at `z-[9999]`, matching `Select`.
+
+## Risks
+
+- Inheritance reads "explicit P3" and "never set" as the same thing, because `CreateTaskModal` deliberately omits `priority` when it equals the default. A user who consciously picked P3 on a To Do task will see it inherit P0 from a P0 requester. The dialog shows the band and lets them fix it, and no other stored state distinguishes the two cases.
+- `PriorityPicker` no longer registers an Android back layer (`useOverlayLayer` does not, `useEscapeKey` did), so hardware Back with the picker open now closes the surrounding surface. This matches every other portalled panel in the app.
+
+## Alternatives considered
+
+- **Inherit unconditionally**, ignoring the target's own priority — rejected: it silently overwrites a band the user set by hand.
+- **A separate labelled priority row in the dialog**, like `CreateTaskModal` — rejected: the subject card already shows a priority badge in the identity row, so this duplicates it and leaves two numbers on screen that can disagree.
+- **A `--priority` flag on `dev3 task create --scratch --run`** — not done. It would let an agent request a band, but the issue asks for inheritance plus a user control, and every extra launch knob is one more thing an agent can get wrong.

--- a/src/bun/__tests__/cli-socket-launch-request.test.ts
+++ b/src/bun/__tests__/cli-socket-launch-request.test.ts
@@ -252,13 +252,98 @@ describe("task.move — agent-initiated launch approval", () => {
 			taskId: TARGET_ID,
 			projectId: "proj-1",
 			targetStatus: "in-progress",
-			choice: launch,
+			// P3 both sides: neither task set one, so nothing is inherited.
+			choice: { ...launch, priority: "P3" },
 		});
 		// A plain move would have ignored the picked agent entirely.
 		expect(moveTask).not.toHaveBeenCalled();
 		expect(deliverLaunchHandoff).toHaveBeenCalledWith(expect.objectContaining({
 			childTaskId: TARGET_ID,
 			source: expect.objectContaining({ seq: 3 }),
+		}));
+	});
+
+	it("defaults the launch to the requester's priority when the target has none", async () => {
+		// Issue #1496: a P0 agent's helper used to start at P3 and sink to the
+		// bottom of the board.
+		const target = makeTask();
+		const project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([target, { ...requester, priority: "P0" as const }]);
+		const pushFn = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(pushFn);
+		vi.mocked(launchTaskWithAgentChoice).mockResolvedValue({ ...target, status: "in-progress" });
+
+		const respPromise = handleRequest(moveRequest({
+			taskId: TARGET_ID,
+			newStatus: "in-progress",
+			projectId: "proj-1",
+			sourceTaskId: REQUESTER_ID,
+		}));
+		await vi.waitFor(() => expect(pushFn).toHaveBeenCalled());
+		const [, payload] = pushFn.mock.calls[0] as [string, Record<string, unknown>];
+		expect(payload.defaultPriority).toBe("P0");
+
+		// Auto-approval with nobody watching carries no choice at all; the
+		// inherited priority must still be applied.
+		resolveAgentRequest(payload.requestId as string, { approved: true });
+		await respPromise;
+		expect(launchTaskWithAgentChoice).toHaveBeenCalledWith(expect.objectContaining({
+			choice: expect.objectContaining({ priority: "P0" }),
+		}));
+	});
+
+	it("keeps the target's own priority — an explicit band is not overwritten", async () => {
+		const target = makeTask({ priority: "P4" });
+		const project = makeProject();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([target, { ...requester, priority: "P0" as const }]);
+		const pushFn = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(pushFn);
+		vi.mocked(launchTaskWithAgentChoice).mockResolvedValue({ ...target, status: "in-progress" });
+
+		const respPromise = handleRequest(moveRequest({
+			taskId: TARGET_ID,
+			newStatus: "in-progress",
+			projectId: "proj-1",
+			sourceTaskId: REQUESTER_ID,
+		}));
+		await vi.waitFor(() => expect(pushFn).toHaveBeenCalled());
+		const [, payload] = pushFn.mock.calls[0] as [string, Record<string, unknown>];
+		expect(payload.defaultPriority).toBe("P4");
+
+		resolveAgentRequest(payload.requestId as string, { approved: true });
+		await respPromise;
+		expect(launchTaskWithAgentChoice).toHaveBeenCalledWith(expect.objectContaining({
+			choice: expect.objectContaining({ priority: "P4" }),
+		}));
+	});
+
+	it("launches with the priority the user picked in the dialog", async () => {
+		const target = makeTask();
+		setupBoard(target);
+		const pushFn = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(pushFn);
+		vi.mocked(launchTaskWithAgentChoice).mockResolvedValue({ ...target, status: "in-progress" });
+
+		const respPromise = handleRequest(moveRequest({
+			taskId: TARGET_ID,
+			newStatus: "in-progress",
+			projectId: "proj-1",
+			sourceTaskId: REQUESTER_ID,
+		}));
+		await vi.waitFor(() => expect(pushFn).toHaveBeenCalled());
+		const [, payload] = pushFn.mock.calls[0] as [string, Record<string, unknown>];
+
+		resolveAgentRequest(payload.requestId as string, {
+			approved: true,
+			launch: { agentId: null, configId: null, priority: "P1" },
+		});
+		await respPromise;
+		expect(launchTaskWithAgentChoice).toHaveBeenCalledWith(expect.objectContaining({
+			choice: expect.objectContaining({ priority: "P1" }),
 		}));
 	});
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -411,6 +411,7 @@ const {
 	emitTaskSound,
 	runCleanupScript,
 	portableReadKey,
+	launchTaskWithAgentChoice,
 } = await import("../rpc-handlers");
 const {
 	nativeHunterColumnRatios,
@@ -1350,6 +1351,62 @@ describe("handlers.reorderProjects", () => {
 
 		expect(data.reorderProjects).toHaveBeenCalledWith(["proj-2", "proj-1"]);
 		expect(result).toEqual(projects);
+	});
+});
+
+describe("launchTaskWithAgentChoice", () => {
+	beforeEach(() => vi.clearAllMocks());
+	// `clearAllMocks` keeps implementations, and these tests have to stub the whole
+	// lifecycle write path — so drop them explicitly or later suites inherit them.
+	afterEach(() => {
+		vi.mocked(data.updateTask).mockReset();
+		vi.mocked(data.getTask).mockReset();
+		vi.mocked(data.getProject).mockReset();
+		vi.mocked(data.setTaskPriority).mockReset();
+	});
+
+	it("applies the launch priority group-wide before the task moves", async () => {
+		// Issue #1496: the launch dialog's priority pick (or the inherited default)
+		// is not part of the single-task patch — priority belongs to the group.
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", status: "todo", priority: "P3" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.setTaskPriority).mockResolvedValue([{ ...task, priority: "P0" }]);
+		vi.mocked(data.updateTask).mockImplementation(async (_p, _id, patch) => ({ ...task, ...patch }));
+		const push = vi.fn();
+		setPushMessage(push);
+
+		await launchTaskWithAgentChoice({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			choice: { agentId: null, configId: null, priority: "P0" },
+		});
+
+		expect(data.setTaskPriority).toHaveBeenCalledWith(project, "task-1", "P0");
+		expect(push).toHaveBeenCalledWith("taskUpdated", {
+			projectId: "proj-1",
+			task: expect.objectContaining({ priority: "P0" }),
+		});
+	});
+
+	it("leaves the priority alone when the launch asks for the one already stored", async () => {
+		const project = makeProject();
+		const task = makeTask({ id: "task-1", status: "todo", priority: "P1" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(data.updateTask).mockImplementation(async (_p, _id, patch) => ({ ...task, ...patch }));
+		setPushMessage(vi.fn());
+
+		await launchTaskWithAgentChoice({
+			taskId: "task-1",
+			projectId: "proj-1",
+			targetStatus: "in-progress",
+			choice: { agentId: null, configId: null, priority: "P1" },
+		});
+
+		expect(data.setTaskPriority).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/bun/agent-requests.ts
+++ b/src/bun/agent-requests.ts
@@ -1,3 +1,4 @@
+import type { TaskPriority } from "../shared/types";
 import { createLogger } from "./logger";
 import { getPushMessage } from "./rpc-handlers/shared-pure";
 
@@ -9,12 +10,14 @@ const log = createLogger("agent-requests");
  */
 export type AgentRequestKind = "complete" | "launch";
 
-/** The agent/config/account the user picked in the launch dialog. */
+/** The agent/config/account/priority the user picked in the launch dialog. */
 export interface AgentLaunchChoice {
 	agentId: string | null;
 	configId: string | null;
 	/** undefined → registry default; null → system login; string → that account. */
 	accountId?: string | null;
+	/** undefined → the request's `defaultPriority`; otherwise the user's pick. */
+	priority?: TaskPriority;
 }
 
 export interface AgentRequestDecision {

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1,10 +1,10 @@
 import { existsSync, readdirSync, unlinkSync, mkdirSync } from "node:fs";
-import type { AgentMessageSource, CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskStatus, TaskType, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
+import type { AgentMessageSource, CliRequest, CliResponse, CustomColumn, Label, Project, Task, TaskPriority, TaskStatus, TaskType, TaskNote, NoteSource, SharedArtifact, SharedImage } from "../shared/types";
 import { isValidNotificationDurationMs, NOTIFICATION_MAX_DURATION_MS, NOTIFICATION_MIN_DURATION_MS } from "../shared/duration";
 import { agentReplyRef } from "../shared/agent-message-envelope";
 import { socketMetaPathFor } from "../shared/socket-meta";
 import { isCliEndpointHandle } from "../shared/cli-endpoint";
-import { ACTIVE_STATUSES, ALL_STATUSES, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, TASK_TYPES, agentLaunchAutoApproveMs, appendTaskNote, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, normalizeTaskType, presetPromptForTaskType, titleFromDescription, withPresetPrompt, withoutPresetPrompt } from "../shared/types";
+import { ACTIVE_STATUSES, ALL_STATUSES, DEFAULT_PRIORITY, DEV3_REPO_CONFIG_KEYS, ID_PREFIX_MIN_LENGTH, LABEL_COLORS, TASK_TYPES, agentLaunchAutoApproveMs, appendTaskNote, buildTaskDialogSubject, getTaskTitle, isStatusGuardBlocked, normalizePriority, normalizeTaskType, presetPromptForTaskType, titleFromDescription, withPresetPrompt, withoutPresetPrompt } from "../shared/types";
 import { CODEX_STATUS_HOOK_EVENTS, getCodexHookTargetStatus, type CodexStatusHookEvent } from "../shared/agent-hooks";
 import { CLAUDE_STOP_FAILURE_ERRORS, describeClaudeStopFailure, type ClaudeStopFailureError } from "../shared/agent-stop-failure";
 import type { DeepLinkNav } from "../shared/deep-link";
@@ -252,9 +252,27 @@ type LaunchApprovalOutcome =
 	| { approved: true; task: Task; seq: number; title: string; replyCommand: string };
 
 /**
+ * Priority an agent-initiated launch starts on. A target that never had one set
+ * (a scratch peer, or a task created without `--priority`) inherits the
+ * requesting task's band, so a P0 agent's helpers do not sink to P3 — issue
+ * #1496. An explicit priority on the target always wins, and the user can still
+ * override either in the launch dialog. Unreadable requester ⇒ the plain default.
+ */
+async function resolveLaunchPriority(task: Task, requester: AgentMessageSource): Promise<TaskPriority> {
+	if (task.priority) return task.priority;
+	try {
+		const found = await resolveTaskAcrossProjects(requester.taskId);
+		return found?.task.priority ?? DEFAULT_PRIORITY;
+	} catch {
+		return DEFAULT_PRIORITY;
+	}
+}
+
+/**
  * Ask the user to approve an agent-initiated launch, then perform it with the
- * agent/config/account they picked in the dialog. Blocks until the user answers,
- * exactly like the completion approval — the requesting CLI waits on the socket.
+ * agent/config/account/priority they picked in the dialog. Blocks until the user
+ * answers, exactly like the completion approval — the requesting CLI waits on the
+ * socket.
  *
  * The launched task's first message tells it who started it (`deliverLaunchHandoff`),
  * so the two agents can talk over the existing cross-task envelope.
@@ -274,6 +292,7 @@ async function requestAgentLaunchApproval(opts: {
 	// A launch is reversible, so an unanswered dialog approves itself rather than
 	// pinning the requesting agent to a dead socket. The completion dialog
 	// deliberately does not do this — it destroys a worktree.
+	const defaultPriority = await resolveLaunchPriority(task, requester);
 	const autoApproveAfterMs = agentLaunchAutoApproveMs(await loadSettings());
 	const { requestId, decision, isNew, autoApproveAt } = createAgentRequest(
 		"launch",
@@ -294,6 +313,7 @@ async function requestAgentLaunchApproval(opts: {
 			// Same read-only context card as the completion dialog, so the user
 			// recognizes which task an agent wants to set running.
 			subject: buildTaskDialogSubject(task, project),
+			defaultPriority,
 			autoApproveAt,
 		});
 	}
@@ -301,12 +321,15 @@ async function requestAgentLaunchApproval(opts: {
 	const answer = await decision;
 	if (!answer.approved) return { approved: false };
 
+	// An auto-approval with no client watching carries no launch choice at all —
+	// the inherited priority must still apply, so it is resolved here, not in the
+	// dialog.
 	const choice: AgentLaunchChoice = answer.launch ?? { agentId: null, configId: null };
 	const launched = await launchTaskWithAgentChoice({
 		taskId: task.id,
 		projectId: project.id,
 		targetStatus,
-		choice,
+		choice: { ...choice, priority: choice.priority ?? defaultPriority },
 	});
 	// Fire-and-forget: the handoff waits for the child's agent pane, which takes
 	// far longer than the requesting agent should sit blocked on a socket.

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -310,9 +310,19 @@ export async function launchTaskWithAgentChoice(params: {
 }): Promise<Task> {
 	log.info("→ launchTaskWithAgentChoice", { taskId: params.taskId.slice(0, 8), status: params.targetStatus });
 	const project = await data.getProject(params.projectId);
-	const task = await data.getTask(project, params.taskId);
+	const stored = await data.getTask(project, params.taskId);
+	const { agentId, configId, accountId, priority } = params.choice;
+
+	// Priority lands before the move so the card never appears in the wrong sort
+	// band, and goes through the group-wide setter rather than `taskPatch`.
+	if (priority !== undefined && priority !== stored.priority) {
+		for (const changed of await data.setTaskPriority(project, stored.id, priority)) {
+			getPushMessage()?.("taskUpdated", { projectId: project.id, task: changed });
+		}
+	}
+	// Re-read so the lifecycle event carries the task it will actually patch.
+	const task = priority !== undefined ? await data.getTask(project, params.taskId) : stored;
 	const existingBranch = getSourceTaskBranch(task, project);
-	const { agentId, configId, accountId } = params.choice;
 
 	const launched = await dispatchLifecycleEvent(project.id, task.id, {
 		type: "moveRequested",

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -9,7 +9,7 @@ import { statusKey } from "./i18n/status";
 import { columnAgentFailureCopy } from "./utils/columnAgentFailureToast";
 import { handleMenuAction } from "./menuRouter";
 import { trackPageView, trackEvent, registerAgents } from "./analytics";
-import type { AgentLaunchRequest, AppRPCSchema, CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskDialogSubject, TaskStatus, UpdateChangelog } from "../shared/types";
+import type { AgentLaunchRequest, AppRPCSchema, CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskDialogSubject, TaskPriority, TaskStatus, UpdateChangelog } from "../shared/types";
 import { orderProjectsForDisplay, taskSeqLabel, getTaskTitle } from "../shared/types";
 import type { DeepLinkNav } from "../shared/deep-link";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
@@ -1883,7 +1883,7 @@ function App() {
 	const respondToLaunchRequest = useCallback((
 		requestId: string,
 		approved: boolean,
-		launch?: { agentId: string | null; configId: string | null; accountId?: string | null },
+		launch?: { agentId: string | null; configId: string | null; accountId?: string | null; priority?: TaskPriority },
 	) => {
 		setLaunchRequests((queue) => queue.filter((r) => r.requestId !== requestId));
 		if (approved) trackEvent("task_moved", { to_status: "in-progress", agent_requested: true });

--- a/src/mainview/__tests__/AgentLaunchRequestModal.test.tsx
+++ b/src/mainview/__tests__/AgentLaunchRequestModal.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../rpc", () => ({
 			// synchronously inside its effect and tears the whole tree down.
 			listAgentAccounts: vi.fn(() => Promise.resolve({ agents: [] })),
 			getAgentRateLimits: vi.fn(() => Promise.resolve(null)),
+			updateAgentLaunchChoice: vi.fn(() => Promise.resolve(undefined)),
 		},
 	},
 }));
@@ -45,6 +46,7 @@ vi.mock("../components/AgentConfigPicker", () => ({
 }));
 
 import AgentLaunchRequestModal from "../components/AgentLaunchRequestModal";
+import { api } from "../rpc";
 
 function makeRequest(overrides?: Partial<AgentLaunchRequest>): AgentLaunchRequest {
 	return {
@@ -56,6 +58,7 @@ function makeRequest(overrides?: Partial<AgentLaunchRequest>): AgentLaunchReques
 		scratch: false,
 		requesterSeq: 3,
 		requesterTitle: "Asking task",
+		defaultPriority: "P2",
 		autoApproveAt: null,
 		subject: {
 			seqLabel: "7",
@@ -112,6 +115,7 @@ describe("AgentLaunchRequestModal", () => {
 			agentId: "builtin-claude",
 			configId: "claude-auto",
 			accountId: undefined,
+			priority: "P2",
 		});
 	});
 
@@ -122,6 +126,56 @@ describe("AgentLaunchRequestModal", () => {
 		await user.click(await screen.findByRole("button", { name: "Decline" }));
 
 		expect(onRespond).toHaveBeenCalledWith(false);
+	});
+
+	it("seeds the priority picker with the priority the launch would use", async () => {
+		// The requester's band when the target never had one of its own (#1496).
+		renderModal(makeRequest({ defaultPriority: "P0", subject: { ...makeRequest().subject, priority: "P3" } }));
+
+		expect(await screen.findByRole("button", { name: /^Priority P0/ })).toBeInTheDocument();
+	});
+
+	it("launches with the priority the user picked instead of the default", async () => {
+		const user = userEvent.setup();
+		const { onRespond } = renderModal(makeRequest({ defaultPriority: "P3" }));
+
+		await user.click(await screen.findByRole("button", { name: /^Priority P3/ }));
+		await user.click(await screen.findByRole("menuitemradio", { name: /P1/ }));
+
+		expect(api.request.updateAgentLaunchChoice).not.toHaveBeenCalled(); // no auto-approve deadline
+
+		const launch = await screen.findByTestId("agent-launch-accept");
+		await waitFor(() => expect(launch).toBeEnabled());
+		await user.click(launch);
+
+		expect(onRespond).toHaveBeenCalledWith(true, expect.objectContaining({ priority: "P1" }));
+	});
+
+	it("mirrors a priority change to the pending request so an auto-approval uses it", async () => {
+		const user = userEvent.setup();
+		renderModal(makeRequest({ defaultPriority: "P3", autoApproveAt: Date.now() + 5 * 60_000 }));
+
+		await user.click(await screen.findByRole("button", { name: /^Priority P3/ }));
+		await user.click(await screen.findByRole("menuitemradio", { name: /P0/ }));
+
+		expect(api.request.updateAgentLaunchChoice).toHaveBeenCalledWith({
+			requestId: "req-1",
+			launch: expect.objectContaining({ priority: "P0" }),
+		});
+	});
+
+	it("closes the priority picker on Escape without declining the launch", async () => {
+		// The dialog's own Esc handler mounts first; only the overlay-layer stack
+		// keeps it from throwing away the whole request (utils/overlay-layers.ts).
+		const user = userEvent.setup();
+		const { onRespond } = renderModal();
+
+		await user.click(await screen.findByRole("button", { name: /^Priority P2/ }));
+		await screen.findByRole("menu");
+		await user.keyboard("{Escape}");
+
+		expect(screen.queryByRole("menu")).toBeNull();
+		expect(onRespond).not.toHaveBeenCalled();
 	});
 
 	it("says a scratch task starts with no prompt", async () => {

--- a/src/mainview/components/AgentLaunchRequestModal.tsx
+++ b/src/mainview/components/AgentLaunchRequestModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { AgentCheckResult, AgentLaunchRequest, CodingAgent, GlobalSettings } from "../../shared/types";
+import type { AgentCheckResult, AgentLaunchRequest, CodingAgent, GlobalSettings, TaskPriority } from "../../shared/types";
 import { api } from "../rpc";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useToggleFavorite } from "../hooks/useToggleFavorite";
@@ -11,6 +11,14 @@ import AgentPickerSkeleton from "./AgentPickerSkeleton";
 import TaskDialogSubjectCard from "./TaskDialogSubjectCard";
 
 const NOT_INSTALLED_ID = "agent-launch-not-installed";
+
+/** What the dialog hands back on approval — the agent pick plus the priority. */
+interface LaunchChoice {
+	agentId: string | null;
+	configId: string | null;
+	accountId?: string | null;
+	priority?: TaskPriority;
+}
 
 /** Whole seconds left until `at`, floored at 0. */
 function secondsUntil(at: number): number {
@@ -26,7 +34,7 @@ function formatCountdown(totalSeconds: number): string {
 interface AgentLaunchRequestModalProps {
 	request: AgentLaunchRequest;
 	/** Answers the blocked CLI. `launch` is only set when approved. */
-	onRespond: (approved: boolean, launch?: { agentId: string | null; configId: string | null; accountId?: string | null }) => void;
+	onRespond: (approved: boolean, launch?: LaunchChoice) => void;
 }
 
 /**
@@ -49,6 +57,10 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 	const [configId, setConfigId] = useState<string | null>(null);
 	// Per-launch account (undefined → the registry default preselect).
 	const [accountId, setAccountId] = useState<string | null | undefined>(undefined);
+	// Seeded from the request: the target's own priority, or the requesting task's
+	// when it never had one (issue #1496). Editable — this launch is the moment to
+	// decide how urgent the new task is.
+	const [priority, setPriority] = useState<TaskPriority>(request.defaultPriority);
 	const [launching, setLaunching] = useState(false);
 	const [agentAvailability, setAgentAvailability] = useState<AgentCheckResult[]>([]);
 
@@ -94,7 +106,7 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 
 	// Mirror every pick back to the pending request, so an auto-approval that
 	// fires while the user is away launches with what they last selected.
-	function reportChoice(next: { agentId: string | null; configId: string | null; accountId?: string | null }) {
+	function reportChoice(next: LaunchChoice) {
 		if (!autoApproveAt) return;
 		api.request.updateAgentLaunchChoice({ requestId: request.requestId, launch: next }).catch(() => {});
 	}
@@ -114,7 +126,7 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 	function handleLaunch() {
 		if (agentNotInstalled) return;
 		setLaunching(true);
-		onRespond(true, { agentId, configId, accountId });
+		onRespond(true, { agentId, configId, accountId, priority });
 	}
 
 	return (
@@ -158,7 +170,11 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 						body={request.scratch ? t("agentLaunch.scratchHasNoPrompt") : (request.subject.overview ?? undefined)}
 						seqLabel={request.subject.seqLabel}
 						projectName={request.subject.projectName}
-						priority={request.subject.priority}
+						priority={priority}
+						onPriorityChange={(next) => {
+							setPriority(next);
+							reportChoice({ agentId, configId, accountId, priority: next });
+						}}
 						labels={request.subject.labels}
 					/>
 
@@ -172,12 +188,12 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 							onChange={(next) => {
 								setAgentId(next.agentId);
 								setConfigId(next.configId);
-								reportChoice({ ...next, accountId });
+								reportChoice({ ...next, accountId, priority });
 							}}
 							accountId={accountId}
 							onAccountChange={(next) => {
 								setAccountId(next);
-								reportChoice({ agentId, configId, accountId: next });
+								reportChoice({ agentId, configId, accountId: next, priority });
 							}}
 							pxpipeProxyEnabled={globalSettings.pxpipeProxyEnabled ?? false}
 							showFavorites

--- a/src/mainview/components/PriorityPicker.tsx
+++ b/src/mainview/components/PriorityPicker.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ALL_PRIORITIES, DEFAULT_PRIORITY, type TaskPriority } from "../../shared/types";
-import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useT } from "../i18n";
+import { useOverlayLayer } from "../utils/useOverlayLayer";
 import { PRIORITY_NAME_KEYS, PRIORITY_STYLES } from "./priorityStyles";
 
 interface PriorityPickerProps {
@@ -49,7 +49,12 @@ function PriorityPicker({ selected, onSelect, onClose, anchorEl }: PriorityPicke
 		rowRefs.current[idx >= 0 ? idx : 0]?.focus();
 	}, [anchorEl, current]);
 
-	useEscapeKey(onClose);
+	// Registered as an overlay layer, not a plain Esc listener: inside a dialog the
+	// modal's own handler mounts first and would close the whole dialog instead of
+	// this popover (see utils/overlay-layers.ts).
+	const anchorRef = useRef<HTMLElement | null>(anchorEl);
+	anchorRef.current = anchorEl;
+	useOverlayLayer(pickerRef, { onDismiss: onClose, triggerRef: anchorRef });
 
 	useEffect(() => {
 		function handleClick(e: MouseEvent) {
@@ -80,7 +85,9 @@ function PriorityPicker({ selected, onSelect, onClose, anchorEl }: PriorityPicke
 			ref={pickerRef}
 			role="menu"
 			aria-label={t("priority.pickerTitle")}
-			className="fixed z-50 bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active overflow-hidden py-1 max-w-[calc(100vw-1rem)]"
+			// Above every dialog (z-[60]…z-[80]), matching `Select`'s portalled panel:
+			// a popover behind the modal that opened it is simply invisible.
+			className="fixed z-[9999] bg-overlay rounded-xl shadow-2xl shadow-black/40 border border-edge-active overflow-hidden py-1 max-w-[calc(100vw-1rem)]"
 			style={{ top: pos.top, left: pos.left, width: 200, visibility: visible ? "visible" : "hidden" }}
 			onClick={(e) => e.stopPropagation()}
 		>

--- a/src/mainview/components/TaskDialogSubjectCard.tsx
+++ b/src/mainview/components/TaskDialogSubjectCard.tsx
@@ -11,8 +11,14 @@ export interface TaskDialogSubjectCardProps {
 	seqLabel?: string;
 	/** Owning project's display name. */
 	projectName?: string;
-	/** Task importance band, shown as a static `P{n}` badge. */
+	/** Task importance band, shown as a `P{n}` badge in the identity row. */
 	priority?: TaskPriority;
+	/**
+	 * Makes that badge a picker. Only the launch dialog passes it: the priority a
+	 * task starts on is part of the decision being made there, so it is a field,
+	 * not a fact. Everywhere else the badge stays read-only.
+	 */
+	onPriorityChange?: (priority: TaskPriority) => void;
 	/** Resolved task labels; read-only chips under the body. */
 	labels?: Label[];
 	/**
@@ -25,8 +31,8 @@ export interface TaskDialogSubjectCardProps {
 }
 
 /**
- * The read-only "which task is this about" card shared by every dialog that acts
- * on one task — the agent completion confirm, the merge prompt, and the
+ * The "which task is this about" card shared by every dialog that acts on one
+ * task — the agent completion confirm, the merge prompt, and the
  * agent launch request. The identity row (seq · project · priority) matters most
  * when the dialog fires while the user is looking at a different board.
  */
@@ -36,6 +42,7 @@ function TaskDialogSubjectCard({
 	seqLabel,
 	projectName,
 	priority,
+	onPriorityChange,
 	labels,
 	tone = "accent",
 	onTitleClick,
@@ -54,7 +61,14 @@ function TaskDialogSubjectCard({
 							<span className="truncate max-w-[12rem]">{projectName}</span>
 						</>
 					)}
-					{priority && <PriorityBadge priority={priority} size="sm" className="ml-auto" />}
+					{priority && (
+						<PriorityBadge
+							priority={priority}
+							onChange={onPriorityChange}
+							size="sm"
+							className="ml-auto"
+						/>
+					)}
 				</div>
 			)}
 			<div className="flex items-start gap-2">

--- a/src/mainview/components/__tests__/PriorityBadge.test.tsx
+++ b/src/mainview/components/__tests__/PriorityBadge.test.tsx
@@ -56,6 +56,18 @@ describe("PriorityBadge", () => {
 		expect(onChange).toHaveBeenCalledWith("P0");
 	});
 
+	// Portalled to <body>, so it competes with dialogs on z-index alone. Below
+	// them it is simply invisible — which is what a z-50 panel was inside the
+	// z-[60] agent-launch dialog.
+	it("floats the picker above every dialog layer", async () => {
+		const user = userEvent.setup();
+		renderBadge({ priority: "P2", onChange: vi.fn() });
+
+		await user.click(screen.getByRole("button", { name: /Priority P2/ }));
+
+		expect((await screen.findByRole("menu")).className).toContain("z-[9999]");
+	});
+
 	it("does not fire onChange when the current level is re-selected", async () => {
 		const onChange = vi.fn();
 		const user = userEvent.setup();

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -285,6 +285,8 @@ You may ask the user to set another task running. You never launch anything your
 - **An existing To Do task** → \`dev3 task move --task seq:<N> --status in-progress\`. Same command as a normal board move; because the task is not yours, it turns into an approval request instead.
 - **A throwaway peer agent** → \`dev3 task create --scratch --run\`. A scratch task has **no prompt by design** — it starts idle, and you drive it with messages.
 
+A launched task **inherits your priority** unless it already has one of its own, so a P0 investigation's helpers do not start at the bottom of the board — and the approval dialog lets the user change that band before it starts. You do not pass a priority yourself.
+
 On approval you get the new task's \`seq\` and the command to talk to it; it is told you started it and replies to you. **Declined** → exit code 10, nothing was launched: ask the user what to change instead of retrying the same request. **Timeout** → the dialog may still be open, so the task may start without you hearing back.
 
 An unanswered launch dialog **approves itself after a few minutes** (5 by default, configurable, and the user can switch it off) — so a user who stepped away costs you a delay, not a dead end. Wait for the answer instead of retrying: a second request for the same task joins the first one and does NOT restart its clock.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2635,6 +2635,13 @@ export interface AgentLaunchRequest {
 	requesterTitle: string;
 	subject: TaskDialogSubject;
 	/**
+	 * Priority the launch applies unless the user picks another in the dialog:
+	 * the target's own explicit priority, or the requester's when the target
+	 * never had one set (a scratch peer, or a task created without `--priority`).
+	 * An urgent agent's helpers inherit its urgency instead of sinking to P3.
+	 */
+	defaultPriority: TaskPriority;
+	/**
 	 * Epoch ms at which the request approves itself, or null when auto-approval
 	 * is off. The countdown is only a mirror — the timer that actually fires
 	 * lives in the bun process, so closing the window cannot stall the agent.
@@ -5101,19 +5108,19 @@ export type AppRPCSchema = {
 				params: {
 					requestId: string;
 					approved: boolean;
-					launch?: { agentId: string | null; configId: string | null; accountId?: string | null };
+					launch?: { agentId: string | null; configId: string | null; accountId?: string | null; priority?: TaskPriority };
 				};
 				response: void;
 			};
 			/**
-			 * Mirror the dialog's current agent/config/account pick into the pending
-			 * request, so an auto-approval that fires while nobody is watching still
-			 * launches with what the user last selected rather than the global default.
+			 * Mirror the dialog's current agent/config/account/priority pick into the
+			 * pending request, so an auto-approval that fires while nobody is watching
+			 * still launches with what the user last selected rather than the defaults.
 			 */
 			updateAgentLaunchChoice: {
 				params: {
 					requestId: string;
-					launch: { agentId: string | null; configId: string | null; accountId?: string | null };
+					launch: { agentId: string | null; configId: string | null; accountId?: string | null; priority?: TaskPriority };
 				};
 				response: void;
 			};


### PR DESCRIPTION
Closes #1496.

A task an agent asked the user to start always landed on the default P3, so a P0 investigation's helpers sank below every P4 on the board. Two changes, both in the approval path:

**Inheritance.** The launch now resolves the band it will use before asking: the target's own `task.priority` when it has one, otherwise the requesting task's. `Task.priority` stays `undefined` until someone sets it explicitly, which is exactly the "no priority was specified" signal — a scratch peer and a `dev3 task create` without `--priority` both qualify. The value ships to the dialog as `AgentLaunchRequest.defaultPriority`, and the fallback lives on the bun side, so an auto-approval that fires with nobody watching still applies it.

**Override.** The launch dialog's subject-card priority badge is now a picker (an opt-in prop the completion and merge dialogs do not pass). The pick rides in `AgentLaunchChoice.priority`, is mirrored into the pending request so an auto-approval uses it, and is written through `data.setTaskPriority` — priority is group-wide, so it cannot go in the single-task patch — before the move is dispatched.

`PriorityPicker` had to move too: it was a `z-50` portal using `useEscapeKey`, which inside a `z-[60]` dialog meant invisible *and* Escape-closes-the-whole-dialog — the exact failure `utils/overlay-layers.ts` documents. It now registers via `useOverlayLayer` at `z-[9999]`, matching `Select`. Verified in a browser that the picker still behaves on a board card, in Create Task, and in the launch dialog.

Reasoning and the trade-offs (explicit-P3 reads as unset; the picker no longer registers an Android back layer) are in `decisions/2026/08/23/launched-task-inherits-requester-priority.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=988221be-039f-473a-9fa1-09b9ceaaf0c3) · `dev3://task/988221be-039f-473a-9fa1-09b9ceaaf0c3`
