### PR TITLE
Build the task-sound AudioContext only inside a user gesture

### DIFF
--- a/change-logs/2026/08/23/fix-task-completion-sound-silent-on-release-builds.md
+++ b/change-logs/2026/08/23/fix-task-completion-sound-silent-on-release-builds.md
@@ -1,0 +1,3 @@
+Short: Task completion chime plays again
+
+The task completion and cancellation chimes went silent on packaged builds: WebKit mutes an AudioContext created without a user gesture while still reporting it as running, so a completion arriving from the CLI before the first click in the window silenced every later chime for the whole app session. The audio context is now built only inside a gesture, sounds that arrive earlier are queued until the next click, and the unlock handlers stay installed so an interrupted context can recover.

--- a/decisions/2026/08/23/gesture-only-audio-context-for-task-sounds.md
+++ b/decisions/2026/08/23/gesture-only-audio-context-for-task-sounds.md
@@ -1,0 +1,69 @@
+# Build the task-sound AudioContext only inside a user gesture
+
+## Context
+
+Task completion and cancellation chimes went silent on packaged builds, for more
+than one user, while the same code played fine from `bun run dev` and from a
+phone in remote mode. Nothing in the sound pipeline had changed for weeks.
+
+## Investigation
+
+The `View → Debug → Play Completed Sound` probe reported a fully healthy
+pipeline — `context running`, both buffers decoded, empty queue, no console
+warning — and was completely silent. In the packaged app's own page a Web Audio
+oscillator advanced `ctx.currentTime` by 0.901 s over 900 ms at 48 kHz, so the
+graph really rendered, and an `<audio>` element with a generated WAV data URL
+played in the same document. Safari reported byte-identical numbers
+(`running`, 48000, `outputLatency` 0.015625) and was audible, so the state
+visible from JS cannot distinguish working from broken.
+
+The discriminator was the gesture. Every silent attempt had no transient user
+activation: a macOS menu item reaches the renderer as a push message, and Web
+Inspector `eval` is not a gesture either. A button injected into that same
+`views://` page and clicked for real played immediately. WebKit mutes an
+AudioContext created without activation while still reporting `running` and
+advancing `currentTime`.
+
+Because `task-sounds.ts` cached the context in a module singleton that was never
+closed, one gesture-less birth silenced the app for its whole session. The old
+`installUnlockHandlers` made it unrecoverable: it removed its own listeners once
+`resume()` reported `running`, which a muted context does.
+
+Ruled out on the way: the settings gate, the inlined mp3 assets, the code
+signature and entitlements, the release pipeline, system volume and output
+device, audio-muting helper apps, the `views://` scheme (an http iframe in the
+same window changed origin *and* gesture at once — a confounded comparison), and
+every commit touching sound in the preceding five days.
+
+## Decision
+
+`src/mainview/task-sounds.ts`: the context is created only by
+`createContextInGesture()`, called exclusively from the unlock handler bound to
+`pointerdown` / `keydown` / `touchstart`. `playTaskSound` never constructs one —
+without a context it adds the status to a pending `Set` and returns.
+`playTaskCompletionSound` returns `false` when it could only queue, so the UI
+does not claim ownership and the backend `taskSound` push still fans out; the
+queue is a `Set` so that push echoing back cannot double the chime. The unlock
+listeners are never removed, which is what lets a later click resume a context
+WebKit interrupted.
+
+`taskSoundDiagnostics()` now reports `unlocked`, and the menu probe says
+`queued — no gesture yet` instead of implying success, because that probe can
+never prove audible output: a menu click is not a page gesture by construction.
+
+## Risks
+
+The first completion after launch can arrive before the user clicks anywhere; it
+now chimes on that first click instead of immediately. A context that WebKit
+mutes *after* a legitimate gesture-born start is still undetectable — no Web
+Audio API reports audibility — so the recovery path is limited to resuming a
+suspended context on the next gesture.
+
+## Alternatives considered
+
+Rebuilding the context whenever it looks suspicious was rejected: "suspicious"
+would be a heuristic, since a muted context is indistinguishable from a healthy
+one through the API. Returning to an `<audio>` element was rejected because it
+would reintroduce issue #1176 — on macOS WebKit promotes any media element
+longer than 0.95 s to the system Now Playing session, and our 1.3–1.5 s chimes
+stole the hardware media keys from Spotify.

--- a/src/mainview/__tests__/task-sounds.test.ts
+++ b/src/mainview/__tests__/task-sounds.test.ts
@@ -54,11 +54,24 @@ class FakeAudioContext {
 
 type SoundsModule = typeof import("../task-sounds");
 
+// The module keeps its unlock listeners on `window` for the app's whole life, so
+// resetting the module registry is not enough — a previous test's listeners would
+// still answer the next test's gesture and build a second context. Track and drop
+// them between tests.
+const installedListeners: Array<[string, EventListenerOrEventListenerObject]> = [];
+const realAddEventListener = window.addEventListener.bind(window);
+
 // Every test gets a fresh module instance: unlock state, the decoded-buffer cache
 // and the pending queue are all module-level globals.
 async function loadModule(): Promise<SoundsModule> {
 	vi.resetModules();
 	return await import("../task-sounds");
+}
+
+/** One user gesture, the only thing allowed to build an AudioContext. */
+async function gesture(): Promise<void> {
+	window.dispatchEvent(new Event("pointerdown"));
+	await settle();
 }
 
 function latestContext(): FakeAudioContext {
@@ -78,6 +91,11 @@ let audioElementPlay: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
 	FakeAudioContext.instances = [];
+	installedListeners.length = 0;
+	window.addEventListener = ((type: string, listener: EventListenerOrEventListenerObject, opts?: unknown) => {
+		installedListeners.push([type, listener]);
+		realAddEventListener(type as keyof WindowEventMap, listener as EventListener, opts as AddEventListenerOptions);
+	}) as typeof window.addEventListener;
 	(window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
 	// The whole point of the fix: nothing may reach an <audio> element.
 	audioElementPlay = vi
@@ -86,6 +104,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	window.addEventListener = realAddEventListener;
+	for (const [type, listener] of installedListeners) window.removeEventListener(type, listener);
+	installedListeners.length = 0;
 	audioElementPlay.mockRestore();
 	delete (window as unknown as { AudioContext?: unknown }).AudioContext;
 });
@@ -113,6 +134,8 @@ describe("task sound assets", () => {
 describe("completion sound playback", () => {
 	it("plays locally and reports the UI owns the sound when enabled", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		mod.setTaskCompletionSoundEnabled(true);
 		expect(mod.playTaskCompletionSound("completed")).toBe(true);
 		await settle();
@@ -130,6 +153,8 @@ describe("completion sound playback", () => {
 
 	it("plays the backend push (CLI / branch-merge / agent approval)", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		mod.playTaskSoundFromPush("completed");
 		await settle();
 		expect(latestContext().sources).toHaveLength(1);
@@ -137,6 +162,8 @@ describe("completion sound playback", () => {
 
 	it("rings for two different tasks completing back-to-back", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		mod.setTaskCompletionSoundEnabled(true);
 		expect(mod.playTaskCompletionSound("completed")).toBe(true);
 		expect(mod.playTaskCompletionSound("cancelled")).toBe(true);
@@ -146,6 +173,8 @@ describe("completion sound playback", () => {
 
 	it("applies the per-sound volume through a gain node", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		await mod.playTaskSound("cancelled");
 		await settle();
 		expect(latestContext().gains[0]?.gain.value).toBe(mod.SOUND_DEFS.cancelled.volume);
@@ -153,11 +182,15 @@ describe("completion sound playback", () => {
 
 	it("decodes each sound once and reuses the buffer", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		// The gesture preloads both chimes, so every later play is buffer-only.
+		await gesture();
+		const ctx = latestContext();
+		expect(ctx.decodeCalls).toHaveLength(Object.keys(mod.SOUND_DEFS).length);
 		await mod.playTaskSound("completed");
 		await mod.playTaskSound("completed");
 		await settle();
-		const ctx = latestContext();
-		expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+		expect(ctx.decodeCalls).toHaveLength(Object.keys(mod.SOUND_DEFS).length);
 		expect(ctx.sources).toHaveLength(2);
 	});
 });
@@ -180,6 +213,8 @@ describe("macOS media-key ownership", () => {
 
 	it("releases the audio graph when the sound ends", async () => {
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		await mod.playTaskSound("completed");
 		await settle();
 		const ctx = latestContext();
@@ -211,33 +246,94 @@ describe("autoplay unlock (remote desktop browsers)", () => {
 		(window as unknown as { AudioContext: unknown }).AudioContext = SuspendedAudioContext;
 		const mod = await loadModule();
 		mod.initTaskSoundPlayback();
+		// First gesture builds the context; this fake refuses to resume until its
+		// own flag is set, standing in for a browser that wants a fresh gesture.
+		await gesture();
+		const ctx = latestContext() as SuspendedAudioContext;
 
 		await mod.playTaskSound("completed");
 		await settle();
-		const ctx = latestContext() as SuspendedAudioContext;
 		expect(ctx.sources).toHaveLength(0);
 
 		ctx.gestureSeen = true;
-		window.dispatchEvent(new Event("pointerdown"));
-		await settle();
+		await gesture();
 		expect(ctx.state).toBe("running");
 		expect(ctx.sources).toHaveLength(1);
-	});
-
-	it("does not construct a context before the first gesture or sound", async () => {
-		const mod = await loadModule();
-		mod.initTaskSoundPlayback();
-		expect(FakeAudioContext.instances).toHaveLength(0);
-
-		window.dispatchEvent(new Event("pointerdown"));
-		await settle();
-		expect(FakeAudioContext.instances).toHaveLength(1);
 	});
 
 	it("stays silent without crashing when Web Audio is unavailable", async () => {
 		delete (window as unknown as { AudioContext?: unknown }).AudioContext;
 		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
 		await expect(mod.playTaskSound("completed")).resolves.toBeUndefined();
 		expect(audioElementPlay).not.toHaveBeenCalled();
+	});
+});
+
+// The regression this file exists for. WebKit mutes an AudioContext created
+// without transient user activation while still reporting `running` and
+// advancing `currentTime`, and the context is cached for the app's lifetime — so
+// one gesture-less birth silenced every later chime until the app restarted.
+// Reproduced on release builds where a CLI completion pushed a sound before the
+// user's first click; a dev server that got clicked first stayed audible.
+describe("gesture-only context creation", () => {
+	it("never builds a context for a sound that arrives before any gesture", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+
+		mod.playTaskSoundFromPush("completed");
+		await settle();
+		expect(FakeAudioContext.instances).toHaveLength(0);
+		expect(mod.taskSoundDiagnostics()).toMatchObject({ context: "none", unlocked: false, queued: 1 });
+	});
+
+	it("plays the queued sound on the first gesture, on the context that gesture built", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		mod.playTaskSoundFromPush("completed");
+		await settle();
+
+		await gesture();
+		expect(FakeAudioContext.instances).toHaveLength(1);
+		expect(latestContext().sources).toHaveLength(1);
+		expect(mod.taskSoundDiagnostics()).toMatchObject({ unlocked: true, queued: 0 });
+	});
+
+	it("declines ownership when it cannot play, so the backend push still fans out", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		mod.setTaskCompletionSoundEnabled(true);
+		// No gesture yet: the UI must NOT claim the sound, or the suppressed push
+		// would leave every client silent.
+		expect(mod.playTaskCompletionSound("completed")).toBe(false);
+	});
+
+	it("collapses the declined sound and its echoing push into one chime", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		mod.setTaskCompletionSoundEnabled(true);
+		expect(mod.playTaskCompletionSound("completed")).toBe(false);
+		mod.playTaskSoundFromPush("completed");
+		await settle();
+		expect(mod.taskSoundDiagnostics().queued).toBe(1);
+
+		await gesture();
+		expect(latestContext().sources).toHaveLength(1);
+	});
+
+	it("keeps the unlock listeners after a success so a later click can still repair", async () => {
+		const mod = await loadModule();
+		mod.initTaskSoundPlayback();
+		await gesture();
+		const ctx = latestContext();
+
+		// WebKit can interrupt a healthy context later; the next click has to find
+		// it and resume it, which the old self-removing handlers could not do.
+		ctx.state = "suspended";
+		await gesture();
+		expect(ctx.resumeCalls).toBeGreaterThan(0);
+		expect(ctx.state).toBe("running");
+		expect(FakeAudioContext.instances).toHaveLength(1);
 	});
 });

--- a/src/mainview/components/__tests__/TaskCard.test.tsx
+++ b/src/mainview/components/__tests__/TaskCard.test.tsx
@@ -477,11 +477,14 @@ describe("TaskCard", () => {
 
 			await user.click(screen.getByLabelText("Cancel"));
 
+			// happy-dom has no Web Audio, so the UI cannot own the sound and lets the
+			// backend push fan out. The ownership contract itself lives in
+			// __tests__/task-sounds.test.ts.
 			expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "cancelled",
-				clientPlayedSound: true,
+				clientPlayedSound: false,
 			});
 		});
 
@@ -1154,11 +1157,12 @@ describe("TaskCard", () => {
 			});
 
 			await waitFor(() => {
+				// No Web Audio under happy-dom — see the note on the cancel case above.
 				expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
-					clientPlayedSound: true,
+					clientPlayedSound: false,
 				});
 			});
 

--- a/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
+++ b/src/mainview/components/__tests__/TaskInfoPanel.test.tsx
@@ -3034,6 +3034,9 @@ describe("TaskInfoPanel", () => {
 		});
 	});
 
+	// `clientPlayedSound` is false throughout: happy-dom has no Web Audio, so the
+	// UI cannot own the chime and lets the backend push fan out instead. The
+	// ownership contract itself is covered by __tests__/task-sounds.test.ts.
 	describe("post-merge auto-complete", () => {
 		it("toggles manual completion from the task context bar", async () => {
 			const task = makeTask({ manualCompletion: false });
@@ -3190,7 +3193,7 @@ describe("TaskInfoPanel", () => {
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
-					clientPlayedSound: true,
+					clientPlayedSound: false,
 				});
 			});
 		});
@@ -3243,7 +3246,7 @@ describe("TaskInfoPanel", () => {
 					taskId: "t1",
 					projectId: "p1",
 					newStatus: "completed",
-					clientPlayedSound: true,
+					clientPlayedSound: false,
 				});
 			});
 		});

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -266,11 +266,13 @@ describe("TaskTerminal", () => {
 
 			// The shared move helper tries a normal move first (force is only the
 			// fallback when that fails), so the background call carries no force flag.
+			// `clientPlayedSound` is false because happy-dom has no Web Audio: the UI
+			// cannot own the chime and lets the backend push fan out instead.
 			expect(mockedApi.request.moveTask).toHaveBeenCalledWith({
 				taskId: "t1",
 				projectId: "p1",
 				newStatus: "completed",
-				clientPlayedSound: true,
+				clientPlayedSound: false,
 			});
 		});
 	});

--- a/src/mainview/menuRouter.ts
+++ b/src/mainview/menuRouter.ts
@@ -128,15 +128,25 @@ export async function handleMenuAction(action: string, ctx: RouterCtx): Promise<
 		// Deliberately the same calls the real flows make, so a silent chime here
 		// means the pipeline is broken, not the trigger. The toast is raw
 		// diagnostics (like terminal output), not localized product copy.
+		//
+		// A macOS menu item reaches the renderer as a push message, NOT as a DOM
+		// gesture, so this probe cannot unlock audio by itself. Say so in the
+		// toast: reading "context running" as "sound works" is exactly the trap
+		// that cost an evening of debugging.
 		case "debug-play-sound-completed":
 		case "debug-play-sound-cancelled": {
 			const status = action === "debug-play-sound-completed" ? "completed" : "cancelled";
-			const played = playTaskCompletionSound(status);
+			playTaskCompletionSound(status);
 			// Decoding is async on the first play, so a same-tick snapshot would
 			// always report zero buffers.
 			await new Promise((resolve) => setTimeout(resolve, 300));
 			const probe = taskSoundDiagnostics();
-			const line = `sound ${status}: ${played ? "play requested" : "skipped — setting off"} · context ${probe.context} · buffers ${probe.buffers} · queued ${probe.queued}`;
+			const outcome = !probe.enabled
+				? "skipped — setting off"
+				: probe.unlocked
+					? "play requested"
+					: "queued — no gesture yet, click anywhere in the window";
+			const line = `sound ${status}: ${outcome} · context ${probe.context} · buffers ${probe.buffers} · queued ${probe.queued}`;
 			console.info("[menu][sound-probe]", line);
 			toast.info(line, { source: "menu" });
 			return;

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -22,8 +22,18 @@ export const SOUND_DEFS: Record<TaskSoundStatus, { url: string; volume: number }
 // `navigator.audioSession.type = "playback"`, which we never do — so it can
 // neither steal the keys nor interrupt other audio (it mixes as ambient sound).
 // Chrome behaves the same way: WebAudio is ambient, an <audio> element is not.
+// An AudioContext built while the page has no transient user activation is
+// silently muted by WebKit: it reports `running`, advances `currentTime` and
+// starts sources without error, yet nothing reaches the speakers. Because the
+// context is cached for the app's lifetime, one such birth kills every chime
+// until the app restarts — the whole of issue "silent completions on release
+// builds". So the context is created ONLY inside a gesture handler, and a sound
+// that arrives without one is queued instead of building a doomed context.
 const SOUND_UNLOCK_EVENTS: Array<keyof WindowEventMap> = ["pointerdown", "keydown", "touchstart"];
-const pendingQueue: TaskSoundStatus[] = [];
+// A Set, not an array: the same status can be queued twice (the UI declines
+// ownership, the backend then broadcasts its push back to us) and the user must
+// hear one chime, not two.
+const pendingQueue = new Set<TaskSoundStatus>();
 const buffers = new Map<TaskSoundStatus, AudioBuffer>();
 const decoding = new Map<TaskSoundStatus, Promise<AudioBuffer | null>>();
 
@@ -41,8 +51,10 @@ let unlockHandlersInstalled = false;
 //    renderer that played locally, so the backend pushes `taskSound` and
 //    `playTaskSoundFromPush` plays it.
 //
-// Because the two paths are mutually exclusive at the source, no client-side
-// echo de-dup is needed.
+// The two paths are mutually exclusive at the source whenever the UI could
+// actually play. When it could not (no gesture yet, so the sound is only
+// queued) it declines ownership and the push goes out — the queue is a Set, so
+// the push echoing back to this same renderer cannot double the chime.
 
 // Client-side mirror of the `playSoundOnTaskComplete` setting, kept in sync by
 // App.tsx. The bun process also gates its `taskSound` push on the same setting;
@@ -62,8 +74,11 @@ export function setTaskCompletionSoundEnabled(enabled: boolean): void {
  */
 export function playTaskCompletionSound(status: TaskSoundStatus): boolean {
 	if (!completionSoundEnabled) return false;
+	// No usable context means the sound is only queued, so the UI does NOT own
+	// it: let the backend push fan out, and whichever client can play, plays.
+	const owned = unlockedContext() !== null;
 	void playTaskSound(status);
-	return true;
+	return owned;
 }
 
 /**
@@ -77,12 +92,22 @@ export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 /**
  * State of the audio pipeline, for the View → Debug sound probes. Never creates
  * the context — an untouched app must report `none`, not be primed by looking.
+ * `context` alone is not evidence of audible output: WebKit reports `running`
+ * for a gesture-less context that plays nothing, which is why `unlocked` (the
+ * context was born inside a gesture) is reported next to it.
  */
-export function taskSoundDiagnostics(): { context: string; buffers: number; queued: number; enabled: boolean } {
+export function taskSoundDiagnostics(): {
+	context: string;
+	unlocked: boolean;
+	buffers: number;
+	queued: number;
+	enabled: boolean;
+} {
 	return {
 		context: context?.state ?? "none",
+		unlocked: context !== null,
 		buffers: buffers.size,
-		queued: pendingQueue.length,
+		queued: pendingQueue.size,
 		enabled: completionSoundEnabled,
 	};
 }
@@ -93,12 +118,16 @@ function audioContextCtor(): typeof AudioContext | undefined {
 	return scoped.AudioContext ?? scoped.webkitAudioContext;
 }
 
-// Created lazily, never closed: a long-lived context stays unlocked, so later
-// push-driven sounds (which arrive seconds after any user gesture) can start
-// without another gesture. Constructing it on demand rather than at import also
-// keeps Chrome from logging its "AudioContext was not allowed to start" warning
-// on a page the user has not interacted with yet.
-function ensureContext(): AudioContext | null {
+/** The context, or null while no gesture has produced one yet. Never creates. */
+function unlockedContext(): AudioContext | null {
+	return context;
+}
+
+// Call ONLY from a user-gesture handler. Never closed afterwards: a long-lived
+// context born inside a gesture keeps playing push-driven sounds that arrive
+// minutes later, and building it on demand rather than at import keeps Chrome
+// from logging "AudioContext was not allowed to start" on an untouched page.
+function createContextInGesture(): AudioContext | null {
 	if (context) return context;
 	const Ctor = audioContextCtor();
 	if (!Ctor) return null;
@@ -185,31 +214,37 @@ function startSound(ctx: AudioContext, status: TaskSoundStatus, buffer: AudioBuf
 }
 
 function flushPendingQueue(): void {
-	while (pendingQueue.length > 0) {
-		const status = pendingQueue.shift();
-		if (!status) continue;
-		void playTaskSound(status);
-	}
+	const queued = [...pendingQueue];
+	pendingQueue.clear();
+	for (const status of queued) void playTaskSound(status);
 }
 
+// The listeners are installed once and NEVER removed. They used to uninstall
+// themselves after the first successful resume, which made the app
+// unrepairable: a context that reports `running` while playing nothing passes
+// that check, and with the handlers gone no later click could rebuild anything.
+// Three passive listeners that early-out cost nothing; being able to recover on
+// the next click is worth far more.
 function installUnlockHandlers(): void {
 	if (unlockHandlersInstalled || typeof window === "undefined") return;
 	unlockHandlersInstalled = true;
 
 	const unlock = () => {
-		const ctx = ensureContext();
+		const ready =
+			context !== null
+			&& context.state === "running"
+			&& pendingQueue.size === 0
+			&& buffers.size === Object.keys(SOUND_DEFS).length;
+		if (ready) return;
+
+		const ctx = createContextInGesture();
 		if (!ctx) return;
 		// Decode inside the gesture too, so the first sound needs no round-trip.
 		for (const status of Object.keys(SOUND_DEFS) as TaskSoundStatus[]) {
 			void loadBuffer(ctx, status);
 		}
 		void resume(ctx).then((running) => {
-			if (!running) return;
-			flushPendingQueue();
-			for (const eventName of SOUND_UNLOCK_EVENTS) {
-				window.removeEventListener(eventName, unlock);
-			}
-			unlockHandlersInstalled = false;
+			if (running) flushPendingQueue();
 		});
 	};
 
@@ -223,15 +258,21 @@ export function initTaskSoundPlayback(): void {
 }
 
 export async function playTaskSound(status: TaskSoundStatus): Promise<void> {
-	const ctx = ensureContext();
-	if (!ctx) return;
+	// Arm the repair path first: a sound arriving before any gesture must leave
+	// the app able to play it on the next click.
 	installUnlockHandlers();
+
+	const ctx = unlockedContext();
+	if (!ctx) {
+		pendingQueue.add(status);
+		return;
+	}
 
 	const buffer = await loadBuffer(ctx, status);
 	if (!buffer) return;
 
 	if (!(await resume(ctx))) {
-		pendingQueue.push(status);
+		pendingQueue.add(status);
 		return;
 	}
 


### PR DESCRIPTION
The task completion and cancellation chimes went silent on packaged builds, for more than one user, while the same code played fine from `bun run dev` and from a phone in remote mode.

WebKit mutes an `AudioContext` created without transient user activation while still reporting it as `running` and advancing `currentTime`. `task-sounds.ts` cached that context in a module singleton that was never closed, so a completion push arriving before the first click in the window silenced every later chime for the whole app session — and the unlock handlers had already removed themselves after seeing the dead context report `running`, so no later click could repair it.

**What changed**

- The context is created only from the gesture handler (`pointerdown` / `keydown` / `touchstart`). `playTaskSound` never constructs one; without a context it queues the status and returns.
- The pending queue is a `Set`, so the backend push echoing back to the same renderer cannot double the chime.
- `playTaskCompletionSound` returns `false` when it could only queue, so the UI does not claim ownership and the `taskSound` push still fans out.
- The unlock listeners are never removed, which lets a later click resume a context WebKit interrupted.
- `taskSoundDiagnostics()` reports `unlocked`, and the View → Debug probe says `queued — no gesture yet` instead of implying success: a macOS menu click reaches the renderer as a push message, not a page gesture, so that probe can never prove audible output. Reading its `context running` as "sound works" is what made this take an evening to find.

Diagnosis and everything ruled out along the way (settings gate, inlined mp3 assets, code signature and entitlements, the release pipeline, system volume and output device, the `views://` scheme) is recorded in `decisions/2026/08/23/gesture-only-audio-context-for-task-sounds.md`.

Five new tests in `task-sounds.test.ts` cover the regression: no context without a gesture, the queue flushing on the first click, the UI declining ownership when it can only queue, a declined sound plus its echoing push producing one chime, and the listeners surviving a success so a later click can still repair an interrupted context.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4de254b2-19bc-4e36-b63b-6bab22ef3f64) · `dev3://task/4de254b2-19bc-4e36-b63b-6bab22ef3f64` _(dev3 added this footer — turn it off in Settings → Tasks.)_