### PR TITLE
Show a Back to Kanban empty state for a closed task's terminal pane

### DIFF
--- a/change-logs/2026/08/24/fix-closed-task-back-to-kanban.md
+++ b/change-logs/2026/08/24/fix-closed-task-back-to-kanban.md
@@ -1,0 +1,1 @@
+Completing or cancelling a task while its view is open no longer leaves the terminal pane showing a "Task environment error / restart session" card for a worktree that was removed on purpose. The pane now shows a plain empty state naming the outcome with a single Back to Kanban button, and it stops polling the dead session.

--- a/src/mainview/components/BackToKanbanEmptyState.tsx
+++ b/src/mainview/components/BackToKanbanEmptyState.tsx
@@ -1,0 +1,43 @@
+import { useT } from "../i18n";
+
+interface BackToKanbanEmptyStateProps {
+	/** Headline explaining why this pane has nothing to show. */
+	message: string;
+	/** Optional second line with the detail behind the headline. */
+	hint?: string;
+	onBack: () => void;
+	testId?: string;
+}
+
+/**
+ * The dead-end pane of a task surface: no task selected, or the open task is
+ * closed and its worktree is gone. Both cases offer exactly one way out, so
+ * they share this state instead of showing recovery buttons for a workspace
+ * that no longer exists.
+ */
+function BackToKanbanEmptyState({ message, hint, onBack, testId }: BackToKanbanEmptyStateProps) {
+	const t = useT();
+	return (
+		<div
+			data-testid={testId}
+			className="h-full w-full flex flex-col items-center justify-center gap-4 bg-base px-6 text-center"
+		>
+			<div className="space-y-1">
+				<p className="text-fg-muted text-sm">{message}</p>
+				{hint && <p className="text-fg-muted text-xs max-w-sm">{hint}</p>}
+			</div>
+			<button
+				type="button"
+				onClick={onBack}
+				className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-edge bg-raised text-fg-3 hover:text-fg hover:bg-raised-hover hover:border-edge-active transition-colors text-sm"
+			>
+				<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+				</svg>
+				<span>{t("project.backToKanban")}</span>
+			</button>
+		</div>
+	);
+}
+
+export default BackToKanbanEmptyState;

--- a/src/mainview/components/ProjectView.tsx
+++ b/src/mainview/components/ProjectView.tsx
@@ -13,6 +13,7 @@ import ActiveTasksSidebar from "./ActiveTasksSidebar";
 import { useState } from "react";
 import { useT } from "../i18n";
 import TaskWorkspacePane from "./TaskWorkspacePane";
+import BackToKanbanEmptyState from "./BackToKanbanEmptyState";
 import { createUnresolvedCommentsDiffRequest, useTaskInlineDiffState } from "./task-inline-diff";
 import { trackDiffView } from "../analytics";
 import { taskSeqLabel } from "../../shared/types";
@@ -214,19 +215,10 @@ function ProjectView({
 				skipCopyModeReset={skipCopyModeReset}
 			/>
 		) : (
-			<div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-base px-6 text-center">
-				<span className="text-fg-muted text-sm">{t("project.selectTaskForTerminal")}</span>
-				<button
-					type="button"
-					onClick={() => navigate({ screen: "project", projectId })}
-					className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-edge bg-raised text-fg-3 hover:text-fg hover:bg-raised-hover hover:border-edge-active transition-colors text-sm"
-				>
-					<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-					</svg>
-					<span>{t("project.backToKanban")}</span>
-				</button>
-			</div>
+			<BackToKanbanEmptyState
+				message={t("project.selectTaskForTerminal")}
+				onBack={() => navigate({ screen: "project", projectId })}
+			/>
 		);
 
 		// Narrow (mobile) viewports keep the terminal full-width — there is no room

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -9,6 +9,7 @@ import TerminalView from "../TerminalView";
 import type { TerminalHandle } from "../TerminalView";
 import TaskInfoPanel from "./TaskInfoPanel";
 import TaskPreparingView from "./TaskPreparingView";
+import BackToKanbanEmptyState from "./BackToKanbanEmptyState";
 import ExtraKeyBar from "./ExtraKeyBar";
 import TerminalComposer, { type TerminalComposerApi } from "./TerminalComposer";
 import MobilePaneCarousel from "./MobilePaneCarousel";
@@ -63,6 +64,10 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	const task = tasks.find((t) => t.id === taskId);
 	const project = projects.find((p) => p.id === projectId);
 	const isPreparing = task?.preparing === true;
+	// Completed/cancelled by design: the worktree and the session are gone on
+	// purpose, so every recovery offer in here would be a lie. This view has one
+	// honest exit, and it must win over the error and restart screens below.
+	const isClosed = task?.status === "completed" || task?.status === "cancelled";
 
 	// Detect native backend from the task record (available before state loads).
 	const isNative = task?.terminalBackend === "native";
@@ -171,7 +176,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	// ── Tmux PTY URL effect (skipped for native) ──────────────────────────────
 	useEffect(() => {
 		if (isNative) return;
-		if (isPreparing) return;
+		if (isPreparing || isClosed) return;
 		let cancelled = false;
 		(async () => {
 			console.log("[TaskTerminal] Requesting PTY URL for task", taskId.slice(0, 8));
@@ -193,14 +198,14 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 			}
 		})();
 		return () => { cancelled = true; };
-	}, [taskId, isPreparing, isNative]);
+	}, [taskId, isPreparing, isNative, isClosed]);
 
 	// ── Native pane state ──────────────────────────────────────────────────────
 	// Every arrival — this poll, the inspector toolbar's poll, or any pane action's
 	// own response — comes through the bus, so a toolbar click repaints the canvas
 	// as soon as the server answers instead of on the next poll tick.
 	useEffect(() => {
-		if (!isNative || isPreparing) return;
+		if (!isNative || isPreparing || isClosed) return;
 		setAbsentReads(0);
 		return subscribePaneState(taskId, (state) => {
 			setNativePaneState(state);
@@ -247,12 +252,12 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 				return next;
 			});
 		});
-	}, [taskId, isPreparing, isNative]);
+	}, [taskId, isPreparing, isNative, isClosed]);
 
 	// Reconciliation only: the server owns the tree, and a failed read is how this
 	// view learns the session died.
 	useEffect(() => {
-		if (!isNative || isPreparing) return;
+		if (!isNative || isPreparing || isClosed) return;
 		let cancelled = false;
 		const fetch = async () => {
 			try {
@@ -264,7 +269,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		void fetch();
 		const timer = setInterval(() => { void fetch(); }, NATIVE_PANE_POLL_MS);
 		return () => { cancelled = true; clearInterval(timer); };
-	}, [taskId, isPreparing, isNative]);
+	}, [taskId, isPreparing, isNative, isClosed]);
 
 	// ── Fetch per-pane URLs when new panes appear ─────────────────────────────
 	useEffect(() => {
@@ -329,13 +334,13 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	useEffect(() => {
 		function onPtyDied(e: Event) {
 			const detail = (e as CustomEvent).detail;
-			if (detail?.taskId === taskId) {
+			if (detail?.taskId === taskId && !isClosed) {
 				void classifyAndSetError();
 			}
 		}
 		window.addEventListener("rpc:ptyDied", onPtyDied);
 		return () => window.removeEventListener("rpc:ptyDied", onPtyDied);
-	}, [taskId, task?.worktreePath]);
+	}, [taskId, task?.worktreePath, isClosed]);
 
 	// Fallback timeout for cases where ptyDied doesn't fire
 	useEffect(() => {
@@ -437,6 +442,20 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		} finally {
 			setRestarting(false);
 		}
+	}
+
+	// A closed task has no workspace left to recover, so the only thing this pane
+	// owes the user is the way out — same empty state the task view shows when no
+	// task is selected.
+	if (isClosed) {
+		return (
+			<BackToKanbanEmptyState
+				testId="terminal-task-closed-screen"
+				message={task?.status === "cancelled" ? t("terminal.taskCancelledTitle") : t("terminal.taskCompletedTitle")}
+				hint={t("terminal.taskClosedHint")}
+				onBack={() => navigate({ screen: "project", projectId })}
+			/>
+		);
 	}
 
 	if (isPreparing && task && project) {

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -135,6 +135,64 @@ describe("TaskTerminal", () => {
 		}
 	});
 
+	describe("Closed task", () => {
+		it("offers the way out instead of a recovery card once the task is completed", async () => {
+			const navigate = vi.fn();
+			const user = userEvent.setup();
+			// The optimistic completion drops the worktree, which is what used to
+			// classify the pane as a broken environment.
+			const closed = makeTask({ status: "completed", worktreePath: null, branchName: null });
+
+			await act(async () => {
+				renderTerminal({ tasks: [closed], navigate });
+			});
+
+			expect(screen.getByTestId("terminal-task-closed-screen")).toBeInTheDocument();
+			expect(screen.getByText("This task is completed")).toBeInTheDocument();
+			expect(screen.queryByText("Task environment error")).not.toBeInTheDocument();
+			expect(mockedApi.request.getPtyUrl).not.toHaveBeenCalled();
+
+			await user.click(screen.getByText("Back to Kanban"));
+			expect(navigate).toHaveBeenCalledWith({ screen: "project", projectId: "p1" });
+		});
+
+		it("names the cancellation when the task was cancelled", async () => {
+			await act(async () => {
+				renderTerminal({ tasks: [makeTask({ status: "cancelled", worktreePath: null })] });
+			});
+
+			expect(screen.getByText("This task is cancelled")).toBeInTheDocument();
+		});
+
+		it("replaces a live terminal with the closed screen when the task completes under it", async () => {
+			mockedApi.request.getPtyUrl.mockResolvedValue({ url: "ws://pty/1" });
+			const { rerender } = render(
+				<I18nProvider>
+					<TaskTerminal projectId="p1" taskId="t1" tasks={[makeTask()]} projects={[project]} navigate={vi.fn()} dispatch={vi.fn()} />
+				</I18nProvider>,
+			);
+			await waitFor(() => expect(screen.getByTestId("terminal-view")).toBeInTheDocument());
+
+			await act(async () => {
+				rerender(
+					<I18nProvider>
+						<TaskTerminal
+							projectId="p1"
+							taskId="t1"
+							tasks={[makeTask({ status: "completed", worktreePath: null })]}
+							projects={[project]}
+							navigate={vi.fn()}
+							dispatch={vi.fn()}
+						/>
+					</I18nProvider>,
+				);
+			});
+
+			expect(screen.getByTestId("terminal-task-closed-screen")).toBeInTheDocument();
+			expect(screen.queryByTestId("terminal-view")).not.toBeInTheDocument();
+		});
+	});
+
 	describe("handleMove sets movedAt", () => {
 		it("sets movedAt when completing task from error screen", async () => {
 			const user = userEvent.setup();

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -2,6 +2,9 @@ const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Connecting...",
 	"terminal.syncing": "Syncing terminal...",
+	"terminal.taskCompletedTitle": "This task is completed",
+	"terminal.taskCancelledTitle": "This task is cancelled",
+	"terminal.taskClosedHint": "Its terminal and worktree were removed when the task closed — there is nothing left to run here.",
 	"terminal.envError": "Task environment error",
 	"terminal.worktreeNotFound": "The task's working directory no longer exists. This can happen when the worktree is removed externally.",
 	"terminal.errorPath": "Worktree not found:",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -2,6 +2,9 @@ const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Conectando...",
 	"terminal.syncing": "Sincronizando terminal...",
+	"terminal.taskCompletedTitle": "Esta tarea está completada",
+	"terminal.taskCancelledTitle": "Esta tarea está cancelada",
+	"terminal.taskClosedHint": "Su terminal y su worktree se eliminaron al cerrar la tarea: ya no queda nada que ejecutar aquí.",
 	"terminal.envError": "Error del entorno de la tarea",
 	"terminal.worktreeNotFound": "El directorio de trabajo de la tarea ya no existe. Esto puede ocurrir cuando el worktree se elimina externamente.",
 	"terminal.errorPath": "Worktree no encontrado:",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -2,6 +2,9 @@ const terminal = {
 	// TaskTerminal
 	"terminal.connecting": "Подключение...",
 	"terminal.syncing": "Синхронизация терминала...",
+	"terminal.taskCompletedTitle": "Задача завершена",
+	"terminal.taskCancelledTitle": "Задача отменена",
+	"terminal.taskClosedHint": "Её терминал и worktree удалены при закрытии задачи — запускать больше нечего.",
 	"terminal.envError": "Ошибка окружения задачи",
 	"terminal.worktreeNotFound": "Рабочая директория задачи больше не существует. Это может произойти, если worktree был удалён извне.",
 	"terminal.errorPath": "Worktree не найден:",


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that made this change).

Completing or cancelling a task while its own view is open used to leave the terminal pane on the `Task environment error — Worktree not found` card, offering *Resume session / Complete / Cancel Task* for a worktree that was deleted on purpose. That path is reached from any surface that does not navigate away — the Active Tasks sidebar row's ✓, a completion driven from another window, or a header ✓ whose navigation did not apply.

The pane now renders the same dead-end empty state the task view already uses when no task is selected: one line naming the outcome (completed / cancelled), one line of detail, and a single **Back to Kanban** button. `TaskTerminal` also stops requesting PTY urls and polling pane state for a closed task, so a dead session is no longer hammered every 2.5s.

- `BackToKanbanEmptyState` extracted from `ProjectView`'s "select a task" placeholder and reused, so both dead ends look identical.
- New keys `terminal.taskCompletedTitle` / `terminal.taskCancelledTitle` / `terminal.taskClosedHint` in en/ru/es.
- Three renderer tests: the closed screen replaces the error card without calling `getPtyUrl`, the cancelled wording, and a live terminal swapping to the closed screen when the task completes under it.

Verified in a browser (scoped QA board, streamer mode): completing a running task from the sidebar row swaps the live terminal for the empty state, and *Back to Kanban* lands on the board with no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=018e0416-e023-4d3f-bdb1-7d81c62eb9fc) · `dev3://task/018e0416-e023-4d3f-bdb1-7d81c62eb9fc`