### PR TITLE
Link file paths mentioned without their directory in terminal output

### DIFF
--- a/.claude/skills/debug-ui/SKILL.md
+++ b/.claude/skills/debug-ui/SKILL.md
@@ -118,10 +118,21 @@ inside a REAL worktree (cwd-based task detection outranks `$DEV3_HOME` by design
   mobile from the *physical* `screen.width` (`< 1024` → mobile; `src/mainview/hooks/useMobile.tsx`,
   deliberately not `innerWidth`), and a mobile device held in landscape gets
   `MobilePortraitGate`: a "rotate your device" overlay plus `inert` on the whole app — screenshots
-  still work, clicks do nothing. Current `agent-browser` (0.6.0) emulates `screen.*` together with
-  the viewport, so a `set viewport 1440 900` before `open` reports `screen.width = 1440` and the
-  gate stays off; with no viewport set at all it defaults to 1280×720, also fine. You only hit the
-  gate by asking for a phone-sized landscape viewport — that is the app working as designed.
+  still work, clicks do nothing. `agent-browser` 0.6.0 emulated `screen.*` together with the
+  viewport, so `set viewport 1440 900` before `open` was enough. **0.34.0 does not** — `screen`
+  stays at the headless display's 800×600 no matter the viewport (`--window-size` in `--args`
+  does not move it either), so every desktop QA run lands in the gate. Override it with an init
+  script instead, registered before the first navigation:
+
+  ```bash
+  printf 'for (const k of ["width","availWidth"]) Object.defineProperty(screen, k, { get: () => 1600, configurable: true });\nfor (const k of ["height","availHeight"]) Object.defineProperty(screen, k, { get: () => 1000, configurable: true });\n' > /tmp/screen-desktop.js
+  agent-browser close                      # a running session keeps its old init scripts
+  agent-browser set viewport 1600 1000
+  agent-browser open "http://localhost:$PORT/?token=$CODE&streamer=on" --init-script /tmp/screen-desktop.js
+  ```
+
+  With that, `screen.width` reports 1600 and the gate stays off. You otherwise only hit the gate
+  by asking for a phone-sized landscape viewport — that is the app working as designed.
   Measured across the common sizes: `2560×1440`, `1920×1080`, `1600×900`, `1440×900`, `1366×768`,
   `1280×720`, `1024×768`, `768×1024` and phone portrait `390×844` all render and click fine
   (`screen.width` always equals the requested width); only landscape `844×390` shows the gate, goes

--- a/change-logs/2026/08/24/fix-terminal-links-nested-file-paths.md
+++ b/change-logs/2026/08/24/fix-terminal-links-nested-file-paths.md
@@ -1,0 +1,3 @@
+Short: Clickable links for nested file paths
+
+Terminal file links now resolve a file named without its directory — "architecture.md" for `docs/architecture.md` — by matching it as a unique path suffix in the task's git file index, so an agent listing several docs no longer underlines only the one that happens to sit at the repo root. Ambiguous names stay unlinked rather than opening a guessed file.

--- a/decisions/2026/08/24/terminal-links-unique-suffix-fallback.md
+++ b/decisions/2026/08/24/terminal-links-unique-suffix-fallback.md
@@ -1,0 +1,21 @@
+# Terminal file links: unique-suffix fallback for paths named without their directory
+
+## Context
+
+Agents name files the way prose does — "Docs updated: platform-status.md, architecture.md, components/scout-agent.md, TODO.md" — while the files live under `docs/`. Terminal links resolved a relative candidate only against the worktree root and then the project root, so in that sentence exactly one token underlined: `TODO.md`, the only file that happens to sit at the root. The feature looked broken precisely where agents mention files most.
+
+## Investigation
+
+Reproduced from the reporting screenshot: `docs/platform-status.md` and `docs/architecture.md` exist in the project, `TODO.md` is at the root, and only the root file resolved. The candidate regex in `src/mainview/terminal-file-links.ts` had matched every one of them — the loss happened in `resolveTerminalPaths`, whose `resolvePath(base, candidate)` can only find a file whose printed path is already base-relative.
+
+## Decision
+
+`resolveBySuffix` in `src/bun/rpc-handlers/terminal-paths.ts`: when every base has been tried as-is and failed, look the candidate up as a path **suffix** at a segment boundary in that base's file index, built from `git ls-files --cached --others --exclude-standard` and cached per base for 15s (so one listing serves a whole viewport of candidates). Only a **unique** match becomes a link — `dup.md` in two directories stays unlinked, because opening the wrong file is worse than not offering the link. Explicitly rooted candidates (`./x`, `../x`) and anything containing `..` are excluded: they state where they live. Direct resolution across all bases still runs first, so a file that exists where the output said it does can never lose to a suffix match elsewhere.
+
+## Risks
+
+A suffix match can be unique in a base yet point at a file the output did not mean (a mention of a sibling repo's `architecture.md` opening ours). Bounded by the segment-boundary rule and by the resolve staying inside the existing home-dir + project-root gate. Repos over 50k listed files drop the index entirely and keep the old behavior; git-less bases (`ls-files` fails) do too. The index is 15s stale, so a just-moved file can link to its old path for that window — same staleness class as the existing 10s resolve cache.
+
+## Alternatives considered
+
+Pick the shallowest match when several exist (rejected: silently opens a coin-flip file, and the shallowest is not the likeliest — `docs/` beats the root here). Walk the filesystem instead of asking git (rejected: `ls-files` already honours `.gitignore`, so `node_modules` never enters the index). Resolve against the pane's real cwd (rejected: dev3 does not track a per-pane cwd, and the mentions are relative to the repo, not to wherever the shell happens to sit).

--- a/src/bun/rpc-handlers/__tests__/terminal-paths.test.ts
+++ b/src/bun/rpc-handlers/__tests__/terminal-paths.test.ts
@@ -31,14 +31,38 @@ vi.mock("../../spawn", () => ({
 	spawn: vi.fn(),
 }));
 
+// The suffix fallback indexes a base with `git ls-files`; the fixtures below are
+// plain temp dirs, so the listing is served from this fake instead of git.
+const gitFiles: Record<string, string[]> = {};
+const runGit = vi.fn(async (_cmd: string[], cwd: string) => {
+	const files = gitFiles[cwd];
+	if (!files) return { ok: false, stdout: "", stderr: "not a git repository" };
+	return { ok: true, stdout: files.join("\0"), stderr: "" };
+});
+vi.mock("../../git", () => ({ run: (...args: unknown[]) => runGit(...(args as [string[], string])) }));
+
 import { terminalPathHandlers as appHandlers } from "../terminal-paths";
 
 beforeAll(() => {
 	mkdirSync(join(worktree, "src"), { recursive: true });
+	mkdirSync(join(worktree, "docs", "components"), { recursive: true });
+	mkdirSync(join(worktree, "a"), { recursive: true });
+	mkdirSync(join(worktree, "b"), { recursive: true });
 	mkdirSync(projectDir, { recursive: true });
 	writeFileSync(join(worktree, "src", "index.ts"), "export {};\n");
+	writeFileSync(join(worktree, "docs", "architecture.md"), "# arch\n");
+	writeFileSync(join(worktree, "docs", "components", "scout.md"), "# scout\n");
+	writeFileSync(join(worktree, "a", "dup.md"), "a\n");
+	writeFileSync(join(worktree, "b", "dup.md"), "b\n");
 	writeFileSync(join(projectDir, "readme.md"), "# hi\n");
 	writeFileSync(join(tmp, "notes.txt"), "hello\n");
+	gitFiles[worktree] = [
+		"src/index.ts",
+		"docs/architecture.md",
+		"docs/components/scout.md",
+		"a/dup.md",
+		"b/dup.md",
+	];
 });
 
 afterAll(() => {
@@ -102,6 +126,47 @@ describe("resolveTerminalPaths", () => {
 		});
 		expect(resolved["/etc/hosts"]).toBeNull();
 		expect(resolved[`${"../".repeat(12)}etc/hosts`]).toBeNull();
+	});
+
+	it("resolves a bare filename to the one nested file whose path ends with it", async () => {
+		const { resolved } = await appHandlers.resolveTerminalPaths({
+			taskId: "task-1",
+			projectId: "proj-1",
+			paths: ["architecture.md", "components/scout.md"],
+		});
+		expect(resolved["architecture.md"]).toEqual({
+			path: join(worktree, "docs", "architecture.md"),
+			kind: "file",
+		});
+		expect(resolved["components/scout.md"]).toEqual({
+			path: join(worktree, "docs", "components", "scout.md"),
+			kind: "file",
+		});
+	});
+
+	it("leaves an ambiguous suffix unresolved rather than guessing a file", async () => {
+		const { resolved } = await appHandlers.resolveTerminalPaths({
+			taskId: "task-1",
+			projectId: "proj-1",
+			// dup.md exists twice; "cout.md" is a suffix but not at a segment boundary.
+			paths: ["dup.md", "cout.md", "./architecture.md", "../docs/architecture.md"],
+		});
+		expect(resolved["dup.md"]).toBeNull();
+		expect(resolved["cout.md"]).toBeNull();
+		expect(resolved["./architecture.md"]).toBeNull();
+		expect(resolved["../docs/architecture.md"]).toBeNull();
+	});
+
+	it("reuses the file index across calls instead of listing per candidate", async () => {
+		// Warm, then assert the second call adds no listing of its own.
+		await appHandlers.resolveTerminalPaths({ taskId: "task-1", projectId: "proj-1", paths: ["architecture.md"] });
+		const before = runGit.mock.calls.length;
+		await appHandlers.resolveTerminalPaths({
+			taskId: "task-1",
+			projectId: "proj-1",
+			paths: ["architecture.md", "components/scout.md", "nowhere.md"],
+		});
+		expect(runGit.mock.calls.length).toBe(before);
 	});
 
 	it("relative paths resolve to null without a project context", async () => {

--- a/src/bun/rpc-handlers/terminal-paths.ts
+++ b/src/bun/rpc-handlers/terminal-paths.ts
@@ -5,6 +5,7 @@ import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { Utils } from "../electrobun-platform";
 import type { FilePreviewResult, ResolvedTerminalPath } from "../../shared/types";
 import * as data from "../data";
+import { run as runGit } from "../git";
 import { spawn } from "../spawn";
 import { log } from "./shared";
 
@@ -12,6 +13,12 @@ import { log } from "./shared";
  * Backend for Cmd/Ctrl+Click file-path links in terminal output: resolve
  * regex-detected candidates against the task worktree / project directory,
  * open them per the user's setting, and feed the in-app preview modal.
+ *
+ * A relative candidate that does not exist under a base is looked up a second
+ * time as a path SUFFIX in that base's git file index, so the way agents
+ * actually name files in prose ("architecture.md" for `docs/architecture.md`)
+ * becomes a link. Only a unique match counts — see
+ * decisions/2026/08/24/terminal-links-unique-suffix-fallback.md.
  *
  * All three handlers take client-supplied paths, so every path they touch is
  * gated to {@link allowedRoots} — the home directory plus registered project
@@ -86,6 +93,77 @@ async function terminalPathBases(params: { taskId?: string; projectId?: string }
 	return bases;
 }
 
+const FILE_INDEX_TTL_MS = 15_000;
+const FILE_INDEX_LIST_TIMEOUT_MS = 3_000;
+// Above this a "unique" suffix match stops being trustworthy to compute cheaply,
+// so the whole index is dropped and the base keeps plain relative resolution.
+const FILE_INDEX_MAX_FILES = 50_000;
+
+/** Repo-relative paths grouped by basename; `null` = too many to disambiguate. */
+type FileIndex = Map<string, string[] | null> | null;
+const FILE_INDEX_MAX_PER_BASENAME = 16;
+
+const fileIndexCache = new Map<string, { at: number; index: FileIndex }>();
+
+/**
+ * Every file git knows about under `base` (tracked plus untracked-not-ignored),
+ * grouped by basename. Cheap enough to rebuild on a TTL — one `git ls-files`
+ * per base per 15s, regardless of how many candidates ask for it.
+ */
+async function fileIndexFor(base: string): Promise<FileIndex> {
+	const hit = fileIndexCache.get(base);
+	if (hit && Date.now() - hit.at < FILE_INDEX_TTL_MS) return hit.index;
+	const index = await buildFileIndex(base);
+	fileIndexCache.set(base, { at: Date.now(), index });
+	return index;
+}
+
+async function buildFileIndex(base: string): Promise<FileIndex> {
+	const result = await runGit(["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], base, {
+		timeoutMs: FILE_INDEX_LIST_TIMEOUT_MS,
+	});
+	if (!result.ok) return null;
+	const paths = result.stdout.split("\0").filter(Boolean);
+	if (paths.length > FILE_INDEX_MAX_FILES) {
+		log.warn("terminal-paths: file index skipped, repo too large", { base, files: paths.length });
+		return null;
+	}
+	const index: NonNullable<FileIndex> = new Map();
+	for (const path of paths) {
+		const basename = path.slice(path.lastIndexOf("/") + 1);
+		const known = index.get(basename);
+		if (known === null) continue;
+		if (!known) {
+			index.set(basename, [path]);
+		} else if (known.length >= FILE_INDEX_MAX_PER_BASENAME) {
+			index.set(basename, null);
+		} else {
+			known.push(path);
+		}
+	}
+	return index;
+}
+
+// An explicit relative path ("./x", "../x") states where it lives; only a
+// path the output left rooted at nothing gets searched.
+const EXPLICITLY_ROOTED = /^\.{1,2}\//;
+
+/**
+ * The one file under `base` whose path ends in `candidate` at a segment
+ * boundary. Ambiguous matches resolve to nothing: no link beats a link that
+ * opens the wrong file.
+ */
+async function resolveBySuffix(base: string, candidate: string, roots: string[]): Promise<ResolvedTerminalPath | null> {
+	if (EXPLICITLY_ROOTED.test(candidate) || candidate.split("/").includes("..")) return null;
+	const index = await fileIndexFor(base);
+	if (!index) return null;
+	const known = index.get(candidate.slice(candidate.lastIndexOf("/") + 1));
+	if (!known) return null;
+	const matches = known.filter((path) => path === candidate || path.endsWith(`/${candidate}`));
+	if (matches.length !== 1) return null;
+	return statPathKind(resolvePath(base, matches[0]!), roots);
+}
+
 async function resolveTerminalPaths(params: {
 	taskId?: string;
 	projectId?: string;
@@ -104,13 +182,18 @@ async function resolveTerminalPaths(params: {
 			resolved[raw] = await statPathKind(resolvePath(expanded), roots);
 			continue;
 		}
+		let hit: ResolvedTerminalPath | null = null;
 		for (const base of bases) {
-			const hit = await statPathKind(resolvePath(base, expanded), roots);
-			if (hit) {
-				resolved[raw] = hit;
-				break;
-			}
+			hit = await statPathKind(resolvePath(base, expanded), roots);
+			if (hit) break;
 		}
+		// Only once every base has been tried as-is: a file that exists where the
+		// output said it does must never lose to a suffix match somewhere else.
+		for (const base of bases) {
+			if (hit) break;
+			hit = await resolveBySuffix(base, expanded, roots);
+		}
+		resolved[raw] = hit;
 	}
 	return { resolved };
 }


### PR DESCRIPTION
## The bug

An agent writes the way prose does — "Docs updated: platform-status.md, architecture.md, components/scout-agent.md, TODO.md" — while those files live under `docs/`. In that sentence exactly one token underlined: `TODO.md`, the only file that happens to sit at the repo root.

`resolveTerminalPaths` resolved a relative candidate only as `resolvePath(base, candidate)` against the task worktree and then the project root, so a file named without its directory could never be found. The candidate regex had matched every one of them; the link was lost during resolution.

## The fix

`resolveBySuffix` in `src/bun/rpc-handlers/terminal-paths.ts`: once every base has been tried as-is and failed, look the candidate up as a path **suffix at a segment boundary** in that base's file index, built from `git ls-files --cached --others --exclude-standard` and cached per base for 15s (one listing serves a whole viewport of candidates, so no per-candidate spawn).

Deliberate limits:

- **Unique match only.** `dup.md` living in two directories stays unlinked — opening the wrong file is worse than not offering the link.
- **Direct resolution still wins.** All bases are tried as-is first, so a file that exists where the output said it does can never lose to a suffix match elsewhere.
- **Explicitly rooted candidates are excluded** (`./x`, `../x`, anything containing `..`) — they state where they live.
- Repos over 50k listed files, and bases where `ls-files` fails, drop the index and keep the previous behavior.

Resolution stays inside the existing home-dir + project-root scope gate.

Also in here: `.claude/skills/debug-ui/SKILL.md` documents the `agent-browser` 0.34 workaround — it stopped emulating `screen.*` with the viewport, so every desktop browser-QA run was landing in the app's mobile-portrait gate (inert, unclickable) until an `--init-script` overrides `screen.width`.

## Verification

- `src/bun/rpc-handlers/__tests__/terminal-paths.test.ts`: nested basename resolves, `components/scout.md` resolves through a directory prefix, ambiguous `dup.md` and non-boundary `cout.md` stay null, `./x` / `../x` stay null, and the index is listed once across calls rather than per candidate.
- Browser QA against the reporting project's terminal: `platform-status.md`, `architecture.md` and `TODO.md` all underline, `nope-xyz.md` does not, and Cmd+click on `platform-status.md` opens `docs/platform-status.md` in the preview modal.

Decision record: `decisions/2026/08/24/terminal-links-unique-suffix-fallback.md`.
