### PR TITLE
Send clicked messages instantly instead of holding them for a quiet pane

### DIFF
--- a/change-logs/2026/08/24/fix-send-to-agent-button-is-instant-again.md
+++ b/change-logs/2026/08/24/fix-send-to-agent-button-is-instant-again.md
@@ -1,0 +1,3 @@
+Short: Send to agent works instantly again
+
+"Send to agent" under a review comment, "Send now" on a scheduled message, and the note a newly launched agent receives all go into the terminal the moment you click, instead of waiting for the pane to go quiet. The quiet-pane hold now applies only to `dev3 message` and messages that fire on a timer, which is the traffic it was built for.

--- a/decisions/2026/08/24/a-click-is-never-held.md
+++ b/decisions/2026/08/24/a-click-is-never-held.md
@@ -1,0 +1,65 @@
+# A click is never held — only CLI and queued messages wait for a quiet pane
+
+## Context
+
+`decisions/2026/08/23/hold-the-agent-message-not-just-its-enter.md` moved the hold
+from the Enter to the whole message: nothing is typed until the pane goes quiet
+(15 s of message traffic, 60 s after a human keystroke). It asked for that hold at
+`scheduled-message-scheduler.deliverToTarget` — the seam every message path shares —
+and that seam turned out to carry click paths too.
+
+The visible consequence: a user pressed "Send to agent" under a review comment and
+the terminal stayed empty. The button reported success, nothing appeared, so they
+re-clicked, tried the other send buttons, and finally copied the text and pasted it
+by hand — at which point it went in. Reported over Telegram the day after the merge.
+
+## Investigation
+
+`sendAgentMessageNow` (the RPC behind all four send buttons in `TaskDiffViewer`) and
+`deliverLaunchHandoff` both go through `sendMessageImmediately`, which asked for the
+hold unconditionally. Before the 08/23 change the text was typed at once and only
+the Enter waited, so the button always *looked* like it worked; after it, the whole
+message sat in dev3's memory with no trace on screen. The chip's "Send now" on a
+queued message had the same shape.
+
+## Decision
+
+`hold` becomes the caller's call. `deliverToTarget(task, message, hold)` takes it as
+a required argument, `sendMessageImmediately(..., { hold })` defaults it to **true**
+(the CLI path, which is what #1495 was about), and the three paths that exist because
+a user just clicked something pass `hold: false`:
+
+- `rpc-handlers/pr-comments.sendAgentMessageNow` — the review / PR-thread send buttons.
+- `sendScheduledMessageNow` — the scheduled-message chip's "Send now".
+- `agent-launch-handoff.deliverLaunchHandoff` — the note a just-booted child agent
+  hears; nobody has typed into that pane yet and its launcher is waiting on the reply.
+
+`dev3 message` (immediate and `--in`/`--at`) and the scheduler's own due fires keep
+the hold, so issue #1495 stays fixed for the traffic it was about: agent-to-agent
+bursts and anything arriving while the user types.
+
+## Risks
+
+- **A click can still land in a half-written line.** If the user has an unfinished
+  prompt in the agent's input box and then clicks "Send to agent", the review text is
+  appended to it and submitted together. That was the behaviour for months before
+  08/21 and it is the price of a button that visibly does something.
+- **Five review comments sent in five clicks are five agent turns.** The coalescing
+  that a hold would give up is real; a "send all comments" control already exists for
+  the batch case, and Claude Code queues text typed during a turn.
+- **The handoff note now submits ~800 ms after the pane appears.** If an agent CLI is
+  slower than that to accept input the note is lost; the poll only proves the pane is
+  alive, not that the TUI is ready. Pre-08/21 timing, so not a new class of failure.
+
+## Alternatives considered
+
+- **Type immediately, hold only the Enter, for clicks** — the user's own fallback
+  ("как минимум писаться, а Enter попозже"). Keeps burst coalescing, but the agent
+  still does nothing for up to a minute after a click, and the mid-line risk is
+  identical, because the text goes in either way.
+- **Gate on `message.source`** (hold agent-to-agent only). Rejected once already in
+  `decisions/2026/08/21/hold-the-enter-behind-dev3-message.md`: a human sending three
+  `dev3 message` lines in a row has the same burst problem. Origin, not authorship,
+  is the axis that actually separates these cases.
+- **Keep the hold and show pending messages in the UI.** A queue indicator is more
+  machinery than the problem needs, and the user asked for the button to be instant.

--- a/src/bun/__tests__/agent-launch-handoff.test.ts
+++ b/src/bun/__tests__/agent-launch-handoff.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const getProject = vi.fn();
+const getTask = vi.fn();
+vi.mock("../data", () => ({
+	getProject: (...args: unknown[]) => getProject(...args),
+	getTask: (...args: unknown[]) => getTask(...args),
+}));
+
+const sendMessageImmediately = vi.fn();
+vi.mock("../scheduled-message-scheduler", () => ({
+	sendMessageImmediately: (...args: unknown[]) => sendMessageImmediately(...args),
+}));
+
+const pushCliToast = vi.fn();
+vi.mock("../rpc-handlers", () => ({
+	pushCliToast: (...args: unknown[]) => pushCliToast(...args),
+}));
+
+import { deliverLaunchHandoff, HANDOFF_MESSAGE } from "../agent-launch-handoff";
+
+const project = { id: "p1", path: "/tmp/proj" };
+const source = { taskId: "parent", seq: 7, title: "Parent" };
+
+function liveTask(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "child-1234",
+		status: "in-progress",
+		preparing: false,
+		sessionState: { panes: [{ paneId: "%1" }] },
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	getProject.mockResolvedValue(project);
+	sendMessageImmediately.mockResolvedValue({ status: "delivered", spilledPath: null });
+});
+
+describe("deliverLaunchHandoff", () => {
+	it("delivers the note once the child's agent pane is up", async () => {
+		getTask.mockResolvedValue(liveTask());
+		await expect(deliverLaunchHandoff({ projectId: "p1", childTaskId: "child-1234", source })).resolves.toBe(true);
+		expect(sendMessageImmediately).toHaveBeenCalledWith(expect.objectContaining({ id: "child-1234" }), HANDOFF_MESSAGE, null, source, { hold: false });
+	});
+
+	// A held handoff would leave a freshly booted agent idle for the whole quiet
+	// window while its launcher waits for a reply that cannot come.
+	it("never holds the note — the child hears it at once", async () => {
+		getTask.mockResolvedValue(liveTask());
+		await deliverLaunchHandoff({ projectId: "p1", childTaskId: "child-1234", source });
+		expect(sendMessageImmediately.mock.calls[0]?.[4]).toEqual({ hold: false });
+	});
+
+	it("gives up without sending when the child is already terminal", async () => {
+		getTask.mockResolvedValue(liveTask({ status: "cancelled" }));
+		await expect(deliverLaunchHandoff({ projectId: "p1", childTaskId: "child-1234", source })).resolves.toBe(false);
+		expect(sendMessageImmediately).not.toHaveBeenCalled();
+	});
+
+	it("waits for the pane and toasts when it never comes up", async () => {
+		getTask.mockResolvedValue(liveTask({ preparing: true }));
+		let clock = 0;
+		const result = await deliverLaunchHandoff({
+			projectId: "p1",
+			childTaskId: "child-1234",
+			source,
+			sleep: async () => { clock += 1_000; },
+			now: () => clock,
+		});
+		expect(result).toBe(false);
+		expect(sendMessageImmediately).not.toHaveBeenCalled();
+		expect(pushCliToast).toHaveBeenCalledWith(expect.objectContaining({ level: "error" }));
+	});
+});

--- a/src/bun/__tests__/pr-comments.test.ts
+++ b/src/bun/__tests__/pr-comments.test.ts
@@ -243,7 +243,15 @@ describe("sendAgentMessageNow", () => {
 	it("delivers the text to the task's live agent", async () => {
 		sendMessageImmediately.mockResolvedValue({ status: "delivered", spilledPath: null });
 		await prCommentsHandlers.sendAgentMessageNow({ taskId: "t1", projectId: "p1", text: "fix it" });
-		expect(sendMessageImmediately).toHaveBeenCalledWith(task, "fix it");
+		expect(sendMessageImmediately).toHaveBeenCalledWith(task, "fix it", null, null, { hold: false });
+	});
+
+	// The user clicked the button and is watching the terminal: a held message would
+	// type nothing at all, which is exactly what "the button does nothing" looked like.
+	it("never holds the send — the review text goes in while the user watches", async () => {
+		sendMessageImmediately.mockResolvedValue({ status: "delivered", spilledPath: null });
+		await prCommentsHandlers.sendAgentMessageNow({ taskId: "t1", projectId: "p1", text: "fix it" });
+		expect(sendMessageImmediately.mock.calls[0]?.[4]).toEqual({ hold: false });
 	});
 
 	it("propagates delivery failures", async () => {

--- a/src/bun/__tests__/scheduled-message-scheduler.test.ts
+++ b/src/bun/__tests__/scheduled-message-scheduler.test.ts
@@ -281,12 +281,15 @@ describe("cancel / send-now / immediate", () => {
 		expect(pushFn).toHaveBeenCalledWith("taskUpdated", expect.anything());
 	});
 
-	it("sendScheduledMessageNow delivers and removes the item", async () => {
+	// "Send now" on the chip is a click, so it types at once — the same reason the
+	// review comment's "Send to agent" does. A hold here looked like a dead button.
+	it("sendScheduledMessageNow delivers at once and removes the item", async () => {
 		const task = makeTask();
 		vi.mocked(data.getTask).mockResolvedValue(task as never);
 		mockUpdateTaskWith(task);
 		await sendScheduledMessageNow(project, task.id, "msg-1");
-		expect(holdMessageForAgentPane).toHaveBeenCalled();
+		expect(sendPromptToAgentPane).toHaveBeenCalled();
+		expect(holdMessageForAgentPane).not.toHaveBeenCalled();
 	});
 
 	it("sendScheduledMessageNow throws for an unknown message id", async () => {
@@ -299,6 +302,23 @@ describe("cancel / send-now / immediate", () => {
 		const task = makeTask();
 		await sendMessageImmediately(task as never, "hello now");
 		expect(holdMessageForAgentPane).toHaveBeenCalledWith(expect.objectContaining({ id: "task-12345678" }), "hello now", task.sessionState.panes);
+	});
+
+	// The click paths (a review comment's "Send to agent", the launch handoff) opt out
+	// of the hold: the user is watching that pane and a held message reads as a button
+	// that did nothing. Asserted on the tmux helpers rather than on the flag, so the
+	// test breaks if the flag stops reaching the backend.
+	it("sendMessageImmediately types and submits at once when the caller opts out of the hold", async () => {
+		const task = makeTask();
+		await sendMessageImmediately(task as never, "fix this", null, null, { hold: false });
+		expect(sendPromptToAgentPane).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }), "fix this", task.sessionState.panes);
+		expect(holdMessageForAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("sendMessageImmediately holds by default — an omitted flag is never an instant send", async () => {
+		await sendMessageImmediately(makeTask() as never, "hello now");
+		expect(holdMessageForAgentPane).toHaveBeenCalled();
+		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
 	});
 
 	it("sendMessageImmediately wraps a cross-task message in the envelope", async () => {
@@ -409,6 +429,16 @@ describe("scheduled-message scheduler — native-backend tasks", () => {
 			{ hold: true },
 		);
 		expect(sendPromptToAgentPane).not.toHaveBeenCalled();
+	});
+
+	it("carries the caller's opt-out into the native adapter", async () => {
+		const task = nativeTask();
+		await sendMessageImmediately(task as never, "fix this", null, null, { hold: false });
+		expect(sendPromptToNativeAgentPane).toHaveBeenCalledWith(
+			expect.objectContaining({ id: task.id }),
+			"fix this",
+			{ hold: false },
+		);
 	});
 
 	it("sendMessageImmediately still fails honestly when no native agent is live", async () => {

--- a/src/bun/agent-launch-handoff.ts
+++ b/src/bun/agent-launch-handoff.ts
@@ -51,7 +51,10 @@ export async function deliverLaunchHandoff(opts: {
 				return false;
 			}
 			if (!task.preparing && (task.sessionState?.panes?.length ?? 0) > 0) {
-				await sendMessageImmediately(task, HANDOFF_MESSAGE, null, opts.source);
+				// Not held: this is the first thing a just-booted agent hears, into a pane
+				// nobody has typed into yet. Waiting for it to "go quiet" would leave the
+				// child sitting idle for the whole window with the launcher watching.
+				await sendMessageImmediately(task, HANDOFF_MESSAGE, null, opts.source, { hold: false });
 				log.info("Handoff delivered", { taskId: shortId, fromSeq: opts.source.seq });
 				return true;
 			}

--- a/src/bun/rpc-handlers/pr-comments.ts
+++ b/src/bun/rpc-handlers/pr-comments.ts
@@ -222,11 +222,16 @@ async function getTaskPrComments(params: { taskId: string; projectId: string; fo
  * Type text into the task's live agent pane right now. A review too large to be
  * typed is spilled to a file by `sendMessageImmediately` itself, which reports the
  * path back so the toast can name it.
+ *
+ * Never held (`hold: false`). This is the "Send to agent" button under a review
+ * comment: the user clicked it and is looking at the terminal, so the text has to go
+ * in and run while they watch. Holding it for a quiet pane made the button look
+ * broken — nothing appeared, and people re-clicked or pasted by hand (#1495 fallout).
  */
 async function sendAgentMessageNow(params: { taskId: string; projectId: string; text: string }): Promise<{ spilledPath: string | null }> {
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
-	const { spilledPath } = await sendMessageImmediately(task, params.text);
+	const { spilledPath } = await sendMessageImmediately(task, params.text, null, null, { hold: false });
 	return { spilledPath };
 }
 

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -62,8 +62,12 @@ function messagePreview(text: string): string {
  *
  * The ONE seam shared by immediate `dev3 message` sends and queued
  * "Send later" fires, so the two can never drift apart again.
+ *
+ * `hold` is the caller's call, not this seam's. A message that travelled through a
+ * CLI or a queue waits for the pane to go quiet; text the user just clicked "Send to
+ * agent" on does not — see {@link sendMessageImmediately}.
  */
-async function deliverToTarget(task: Task, message: ScheduledMessage): Promise<AgentPromptDelivery> {
+async function deliverToTarget(task: Task, message: ScheduledMessage, hold: boolean): Promise<AgentPromptDelivery> {
 	// Agent-to-agent traffic is wrapped at delivery time, so the queue (and the
 	// card chip that previews it) keeps the plain text the sender wrote.
 	const text = message.source ? wrapAgentMessage(message.text, message.source, task.projectId) : message.text;
@@ -71,7 +75,7 @@ async function deliverToTarget(task: Task, message: ScheduledMessage): Promise<A
 	// writing three in a row, or several peers reporting at once) then become one
 	// agent turn, and no text lands in the middle of the user's own line. See
 	// agent-message-hold.ts.
-	const delivery = await deliverAgentPrompt(task, text, message.target, { hold: true });
+	const delivery = await deliverAgentPrompt(task, text, message.target, { hold });
 	if (message.source) announceAgentMessage(task, message, delivery);
 	return delivery;
 }
@@ -183,12 +187,14 @@ export async function fireScheduledMessage(
 	project: Project,
 	task: Task,
 	message: ScheduledMessage,
-	opts: { late: boolean },
+	opts: { late: boolean; hold?: boolean },
 ): Promise<{ delivery: AgentPromptDelivery; task: Task }> {
 	let delivery: AgentPromptDelivery = { status: "not-delivered", reason: "pane-absent", detail: "the task is finished" };
 	if (!isTerminal(task.status)) {
 		try {
-			delivery = await deliverToTarget(task, message);
+			// A fire on the clock is message traffic and waits for a quiet pane. The chip's
+			// "Send now" is a click, and a click has to do something visible: it opts out.
+			delivery = await deliverToTarget(task, message, opts.hold !== false);
 		} catch (err) {
 			delivery = { status: "not-delivered", reason: "backend-failure", detail: String(err) };
 			log.warn("Scheduled message delivery threw", { taskId: task.id.slice(0, 8), error: String(err) });
@@ -289,7 +295,7 @@ export async function sendScheduledMessageNow(project: Project, taskId: string, 
 	const task = await data.getTask(project, taskId);
 	const message = (task.scheduledMessages ?? []).find((m) => m.id === messageId);
 	if (!message) throw new Error("Scheduled message not found");
-	const { task: updated } = await fireScheduledMessage(project, task, message, { late: false });
+	const { task: updated } = await fireScheduledMessage(project, task, message, { late: false, hold: false });
 	return updated;
 }
 
@@ -300,12 +306,19 @@ export async function sendScheduledMessageNow(project: Project, taskId: string, 
  * Throws ONLY when nothing was sent, because a caller that catches reports a failure
  * and re-sends — and a re-send into a live agent is a double submit. An unconfirmed
  * send is therefore returned, not thrown, and the caller must say so out loud.
+ *
+ * `hold` defaults to true — the CLI path, where a burst of peer messages must become
+ * one turn and nothing may land in the middle of the user's line (issue #1495). A
+ * caller acting on a click the user just made passes `hold: false`: the user is
+ * watching that pane and expects to see their text go in, so a hold reads to them as
+ * a button that did nothing.
  */
 export async function sendMessageImmediately(
 	task: Task,
 	text: string,
 	target?: ScheduledMessageTarget | null,
 	source?: AgentMessageSource | null,
+	opts: { hold?: boolean } = {},
 ): Promise<AgentPromptDelivery & { spilledPath: string | null }> {
 	const trimmed = validateText(text);
 	if (isTerminal(task.status)) {
@@ -320,7 +333,7 @@ export async function sendMessageImmediately(
 		...(source ? { source } : {}),
 		...(spilledPath ? { spilledPath } : {}),
 	};
-	const delivery = await deliverToTarget(task, message);
+	const delivery = await deliverToTarget(task, message, opts.hold !== false);
 	await recordMessageAttempt(task, message, delivery);
 	if (delivery.status === "not-delivered") {
 		throw new Error("Could not deliver the message — the task has no live agent session.");


### PR DESCRIPTION
Follow-up to #1504. Holding the whole message until the pane goes quiet was right for `dev3 message`, but the hold was asked for at the seam every message path shares — so the "Send to agent" button under a review comment typed nothing at all. It reported success, the terminal stayed empty, and people re-clicked or pasted the text by hand.

`hold` is now the caller's call. It still defaults to true (the CLI path #1495 was about), and the three paths that exist because the user just clicked something opt out:

- the review / PR-thread "Send to agent" buttons (`sendAgentMessageNow`)
- "Send now" on a scheduled-message chip
- the handoff note a just-booted agent receives from its launcher

`dev3 message` (immediate and `--in`/`--at`) and the scheduler's own due fires keep the hold, so #1495 stays fixed for agent-to-agent bursts and for anything arriving while the user types.

Decision record: `decisions/2026/08/24/a-click-is-never-held.md`.

Verified in a browser against a scoped QA board: an inline review comment clicked through to the agent's terminal in ~1 second and the task moved to "Agent is Working" while I watched. Four mutants killed (each call site dropping its flag, the seam ignoring it, the default flipping).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=51e4af76-1d21-49f5-aafe-a3b69024cce6) · `dev3://task/51e4af76-1d21-49f5-aafe-a3b69024cce6`
