### PR TITLE
Give every hand-typed path field a Browse button

### DIFF
--- a/change-logs/2026/08/24/feature-file-picker-for-binary-paths.md
+++ b/change-logs/2026/08/24/feature-file-picker-for-binary-paths.md
@@ -1,3 +1,3 @@
-Short: Browse for a CLI binary instead of typing it
+Short: Browse instead of typing paths by hand
 
-The folder picker can now pick a file, and the two places that used to demand a hand-typed path — the custom binary path in Settings → Agents and the requirements screen — got a "Browse…" button next to the input. Dotfiles are shown by default there, since most CLI binaries live under ~/.local/bin or ~/.bun/bin, and pointing the picker at a file opens its folder with that file already selected.
+Every field that used to demand a hand-typed path now has a "Browse…" button. The folder picker learned to pick a file, so the custom binary path in Settings → Agents and the requirements screen can point at a CLI on disk; dotfiles are shown there by default and a "Hidden files" toggle works everywhere. It also learned a confined mode used by Clone Paths and Sparse Checkout in project settings: the picker opens at the project root, refuses to leave it, and stores the path relative to the repo, with a second button for picking several folders at once.

--- a/change-logs/2026/08/24/feature-file-picker-for-binary-paths.md
+++ b/change-logs/2026/08/24/feature-file-picker-for-binary-paths.md
@@ -1,0 +1,3 @@
+Short: Browse for a CLI binary instead of typing it
+
+The folder picker can now pick a file, and the two places that used to demand a hand-typed path — the custom binary path in Settings → Agents and the requirements screen — got a "Browse…" button next to the input. Dotfiles are shown by default there, since most CLI binaries live under ~/.local/bin or ~/.bun/bin, and pointing the picker at a file opens its folder with that file already selected.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2426,13 +2426,18 @@ function App() {
 	// Requirements check failed \u2014 a real, actionable screen; keep it ahead of the
 	// generic bootstrap loader.
 	if (reqStatus === "failed") {
+		// The host has to come along: this screen returns early, and its "Browse…"
+		// button would otherwise queue a picker request nothing ever renders.
 		return (
-			<RequirementsCheck
-				results={reqResults}
-				checking={reqChecking}
-				onRefresh={checkRequirements}
-				onRefreshResults={refreshResults}
-			/>
+			<>
+				<RequirementsCheck
+					results={reqResults}
+					checking={reqChecking}
+					onRefresh={checkRequirements}
+					onRefreshResults={refreshResults}
+				/>
+				<FolderPickerHost />
+			</>
 		);
 	}
 

--- a/src/mainview/components/FolderPickerModal.tsx
+++ b/src/mainview/components/FolderPickerModal.tsx
@@ -71,6 +71,9 @@ const NF = {
 	filter: "\uF0B0",         // nf-fa-filter
 	close: "\uF00D",          // nf-fa-times
 	loading: "\uF1CE",        // nf-fa-circle_o_notch (spinning)
+	file: "\uF016",           // nf-fa-file_o
+	eye: "\uF06E",            // nf-fa-eye
+	eyeSlash: "\uF070",       // nf-fa-eye_slash
 	plus: "\uF067",           // nf-fa-plus (safer than nf-md-folder_plus — see NF note above)
 } as const;
 
@@ -169,7 +172,7 @@ export default function FolderPickerHost() {
 
 	return (
 		<FolderPickerModal
-			key={request.options.initialPath ?? "__root__"}
+			key={`${request.options.mode ?? "folder"}:${request.options.initialPath ?? "__root__"}`}
 			options={request.options}
 			onClose={handleClose}
 		/>
@@ -195,6 +198,11 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 	const [homeEntries, setHomeEntries] = useState<Set<string>>(new Set());
 	const [driveRoots, setDriveRoots] = useState<string[]>([]);
 	const [treeKey, setTreeKey] = useState(0);
+	const fileMode = options.mode === "file";
+	const [showHidden, setShowHidden] = useState(options.showHidden === true);
+	// A file the caller pointed at (or the user typed): the tree opens on its
+	// folder with the file already selected, so Select is live immediately.
+	const [pinnedFile, setPinnedFile] = useState<string | null>(null);
 	const [newFolderInput, setNewFolderInput] = useState<string | null>(null);
 	const [newFolderError, setNewFolderError] = useState<string | null>(null);
 	const [creatingFolder, setCreatingFolder] = useState(false);
@@ -204,17 +212,40 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 
 	const listingsRef = useRef<Map<string, FolderListing>>(new Map());
 
+	// Read through a ref so toggling "show hidden" does not change the identity
+	// of `listDir` — the initial-load effect and the tree's data loader both
+	// depend on it and must not re-run on a toggle.
+	const showHiddenRef = useRef(showHidden);
+	showHiddenRef.current = showHidden;
+	const listDir = useCallback(
+		(path: string | null): Promise<FolderListing> =>
+			api.request.listDirectory({ path, includeFiles: fileMode, showHidden: showHiddenRef.current }),
+		[fileMode],
+	);
+
+	/** List `path`; in file mode a path that IS a file resolves to its folder, with the file picked. */
+	const loadForPath = useCallback(async (path: string | null): Promise<{ listing: FolderListing; pick: string | null }> => {
+		const listing = await listDir(path);
+		if (fileMode && listing.error && listing.parent) {
+			const parent = await listDir(listing.parent);
+			const hit = parent.entries.find((e) => !e.isDir && e.path === listing.path);
+			if (hit) return { listing: parent, pick: hit.path };
+		}
+		return { listing, pick: null };
+	}, [listDir, fileMode]);
+
 	// Initial load: open the picker at `initialPath` (or home) AND fetch the
 	// home listing in parallel so we can populate sidebar shortcuts.
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
 			try {
-				const initial = await api.request.listDirectory({ path: options.initialPath ?? null });
+				const { listing: initial, pick } = await loadForPath(options.initialPath ?? null);
 				if (cancelled) return;
 				listingsRef.current.set(initial.path, initial);
 				setCurrentRoot(initial.path);
-				setManualPath(initial.path);
+				setManualPath(pick ?? initial.path);
+				setPinnedFile(pick);
 				setListingError(initial.error ?? null);
 				setHome(initial.home);
 				setDriveRoots(initial.roots ?? []);
@@ -224,7 +255,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 				if (initial.path === initial.home) {
 					setHomeEntries(new Set(initial.entries.filter((e) => e.isDir).map((e) => e.name)));
 				} else {
-					const homeListing = await api.request.listDirectory({ path: initial.home });
+					const homeListing = await listDir(initial.home);
 					if (cancelled) return;
 					listingsRef.current.set(homeListing.path, homeListing);
 					setHomeEntries(new Set(homeListing.entries.filter((e) => e.isDir).map((e) => e.name)));
@@ -235,7 +266,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 			}
 		})();
 		return () => { cancelled = true; };
-	}, [options.initialPath]);
+	}, [options.initialPath, loadForPath, listDir]);
 
 	// Escape cancels the inline "new folder" input first, otherwise closes the modal.
 	useEscapeKey(() => {
@@ -251,17 +282,29 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 		setListingError(null);
 		setPreselectRoot(selectOnArrival);
 		try {
-			const listing = await api.request.listDirectory({ path });
+			const { listing, pick } = await loadForPath(path);
 			listingsRef.current.set(listing.path, listing);
 			setCurrentRoot(listing.path);
-			setManualPath(listing.path);
+			setManualPath(pick ?? listing.path);
+			setPinnedFile(pick);
 			setListingError(listing.error ?? null);
 			setFilterText("");
 			setTreeKey((k) => k + 1);
 		} catch (err) {
 			setListingError(String(err));
 		}
-	}, []);
+	}, [loadForPath]);
+
+	// Toggling dotfiles changes what every listing contains, so the cache goes
+	// and the tree remounts on the folder the user is already looking at.
+	const toggleHidden = useCallback(() => {
+		setShowHidden((prev) => {
+			showHiddenRef.current = !prev;
+			return !prev;
+		});
+		listingsRef.current.clear();
+		if (currentRoot) void navigateTo(currentRoot);
+	}, [currentRoot, navigateTo]);
 
 	const handleManualSubmit = useCallback((e: FormEvent) => {
 		e.preventDefault();
@@ -351,8 +394,21 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 				{/* Header */}
 				<div className="px-5 py-3 border-b border-edge flex items-center justify-between gap-3">
 					<h2 id="folder-picker-title" className="text-fg text-base font-semibold truncate">
-						{options.title ?? t("folderPicker.title")}
+						{options.title ?? t(fileMode ? "folderPicker.titleFile" : "folderPicker.title")}
 					</h2>
+					<button
+						type="button"
+						onClick={toggleHidden}
+						aria-pressed={showHidden}
+						data-testid="folder-picker-hidden-toggle"
+						title={t("folderPicker.showHidden")}
+						className={`ml-auto inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors ${
+							showHidden ? "text-fg bg-elevated" : "text-fg-3 hover:text-fg hover:bg-elevated"
+						}`}
+					>
+						<Glyph glyph={showHidden ? NF.eye : NF.eyeSlash} size="0.85rem" />
+						<span>{t("folderPicker.showHidden")}</span>
+					</button>
 					<button
 						type="button"
 						onClick={() => onClose(null)}
@@ -485,10 +541,10 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 								</span>
 								<input
 									type="text"
-									aria-label={t("folderPicker.filterAriaLabel")}
+									aria-label={t(fileMode ? "folderPicker.filterFilesAriaLabel" : "folderPicker.filterAriaLabel")}
 									value={filterText}
 									onChange={(e) => setFilterText(e.target.value)}
-									placeholder={t("folderPicker.filterPlaceholder")}
+									placeholder={t(fileMode ? "folderPicker.filterFilesPlaceholder" : "folderPicker.filterPlaceholder")}
 									spellCheck={false}
 									autoCorrect="off"
 									autoCapitalize="off"
@@ -500,7 +556,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 						{/* New folder toolbar (only when enabled by caller). The destination
 						     is spelled out on both the button and the form — the folder the
 						     user highlighted, not always the one the tree is rooted at. */}
-						{options.allowCreateFolder && createTarget && (
+						{options.allowCreateFolder && !fileMode && createTarget && (
 							<div className="px-4 py-1.5 border-b border-edge flex flex-col gap-1 flex-shrink-0 bg-raised/20">
 								{newFolderInput === null ? (
 									<button
@@ -580,10 +636,13 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 									key={treeKey}
 									rootPath={currentRoot}
 									listingsRef={listingsRef}
+									listDir={listDir}
 									filterText={filterText}
 									multi={options.multi}
+									fileMode={fileMode}
 									home={home}
 									preselectRoot={preselectRoot}
+									preselectPath={pinnedFile}
 									onSelect={setSelectedPath}
 									onNavigate={(p) => void navigateTo(p)}
 								/>
@@ -681,40 +740,51 @@ function SidebarItem({ glyph, label, subLabel, path, active, onClick }: SidebarI
 interface FolderTreeProps {
 	rootPath: string;
 	listingsRef: React.MutableRefObject<Map<string, FolderListing>>;
+	listDir: (path: string | null) => Promise<FolderListing>;
 	filterText: string;
 	multi: boolean;
+	/** Files are listed and are the only selectable rows. */
+	fileMode: boolean;
 	home: string;
 	/** Start with the "current folder" row selected (used right after creating one). */
 	preselectRoot: boolean;
+	/** Start with this file row selected (the caller's current value). */
+	preselectPath: string | null;
 	onSelect: (paths: string[]) => void;
 	onNavigate: (path: string) => void;
 }
 
-function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectRoot, onSelect, onNavigate }: FolderTreeProps) {
+function FolderTree({ rootPath, listingsRef, listDir, filterText, multi, fileMode, home, preselectRoot, preselectPath, onSelect, onNavigate }: FolderTreeProps) {
 	const t = useT();
 	// The folder the tree is rooted at is a legitimate answer, so it gets its own
 	// row. Without it the only way to pick the folder you navigated into was to
 	// go back out to its parent and find it there.
 	const [rootSelected, setRootSelected] = useState(preselectRoot);
+	const [pinned, setPinned] = useState<string | null>(preselectPath);
+	/** Paths seen as files in a parent listing — see getItem below. */
+	const filesRef = useRef<Set<string>>(new Set());
 	const dataLoader = useMemo(() => ({
 		async getItem(itemId: string): Promise<FolderNode> {
 			if (itemId === rootPath) {
 				return { path: rootPath, name: basename(rootPath), isDir: true, isRoot: true };
 			}
-			return { path: itemId, name: basename(itemId), isDir: true, isRoot: false };
+			// A child's kind is known from its parent listing; only a directly
+			// requested item can miss the cache, and those are folders we walked into.
+			const isDir = !fileMode || !filesRef.current.has(itemId);
+			return { path: itemId, name: basename(itemId), isDir, isRoot: false };
 		},
 		async getChildrenWithData(parentId: string): Promise<Array<{ id: string; data: FolderNode }>> {
 			const cached = listingsRef.current.get(parentId);
-			const listing = cached ?? await api.request.listDirectory({ path: parentId });
+			const listing = cached ?? await listDir(parentId);
 			if (!cached) listingsRef.current.set(listing.path, listing);
 			return listing.entries
-				.filter((e) => e.isDir)
-				.map((e) => ({
-					id: e.path,
-					data: { path: e.path, name: e.name, isDir: true, isRoot: false },
-				}));
+				.filter((e) => fileMode || e.isDir)
+				.map((e) => {
+					if (!e.isDir) filesRef.current.add(e.path);
+					return { id: e.path, data: { path: e.path, name: e.name, isDir: e.isDir, isRoot: false } };
+				});
 		},
-	}), [rootPath, listingsRef]);
+	}), [rootPath, listingsRef, listDir, fileMode]);
 
 	// hotkeysCoreFeature is what gives the tree arrow-key navigation, so it is
 	// not optional — a single-select picker has to be keyboard-operable too.
@@ -732,27 +802,37 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 	const selectedItems = tree.getSelectedItems();
 	const selectionKey = selectedItems.map((i) => i.getId()).sort().join(",");
 	useEffect(() => {
+		if (pinned) {
+			onSelect([pinned]);
+			return;
+		}
 		if (rootSelected) {
 			onSelect([rootPath]);
 			return;
 		}
 		const allPaths = selectedItems
-			.map((i) => i.getItemData()?.path)
-			.filter((p): p is string => p !== undefined)
+			.map((i) => i.getItemData())
+			// In file mode a folder row is only a way to walk deeper — the caller
+			// asked for a file, so a highlighted folder must not arm "Select".
+			.filter((d): d is FolderNode => d !== undefined && (!fileMode || !d.isDir))
+			.map((d) => d.path)
 			.sort();
 		const topLevel = allPaths.filter(
 			(p) => !allPaths.some((ancestor) => ancestor !== p && p.startsWith(ancestor + "/")),
 		);
 		onSelect(topLevel);
-	}, [selectionKey, rootSelected, rootPath, onSelect]);
+	}, [selectionKey, rootSelected, pinned, rootPath, fileMode, onSelect]);
 
 	const selectRootRow = useCallback(() => {
 		tree.setSelectedItems([]);
+		setPinned(null);
 		setRootSelected(true);
 	}, [tree]);
 
 	const handleDoubleClick = useCallback((item: ItemInstance<FolderNode>) => {
-		onNavigate(item.getItemData().path);
+		const data = item.getItemData();
+		if (!data.isDir) return;
+		onNavigate(data.path);
 	}, [onNavigate]);
 
 	const allItems = tree.getItems();
@@ -784,7 +864,8 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 
 	return (
 		<div {...tree.getContainerProps()} className="outline-none flex flex-col" role="tree">
-			{/* The current folder, as a pickable row. */}
+			{/* The current folder, as a pickable row — meaningless when the caller wants a file. */}
+			{!fileMode && (
 			<button
 				type="button"
 				data-testid="folder-picker-current-row"
@@ -806,10 +887,11 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 					{t("folderPicker.currentFolder")}
 				</span>
 			</button>
+			)}
 			{empty && !filter && (
 				<div className="px-3 py-6 text-center">
 					<div className="text-fg-3 text-xs">{t("folderPicker.emptyFolder")}</div>
-					<div className="text-fg-muted text-xs mt-1">{t("folderPicker.emptyFolderHint")}</div>
+					{!fileMode && <div className="text-fg-muted text-xs mt-1">{t("folderPicker.emptyFolderHint")}</div>}
 				</div>
 			)}
 			{empty && filter && (
@@ -822,7 +904,7 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 				const level = item.getItemMeta().level;
 				const expanded = item.isExpanded();
 				const loading = item.isLoading?.() ?? false;
-				const selected = item.isSelected();
+				const selected = item.isSelected() || pinned === data.path;
 				const itemProps = item.getProps();
 				return (
 					<button
@@ -832,6 +914,7 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 						onClick={(e) => {
 							itemProps.onClick?.(e);
 							setRootSelected(false);
+							setPinned(null);
 							// Single-select callers expect exactly one folder, but
 							// headless-tree's selectionFeature still honors
 							// Cmd/Ctrl/Shift+click to accumulate selection. Collapse
@@ -848,7 +931,9 @@ function FolderTree({ rootPath, listingsRef, filterText, multi, home, preselectR
 						}`}
 					>
 						{data.isDir ? <ChevronGlyph expanded={expanded} /> : <ChevronPlaceholder />}
-						<FolderGlyph open={expanded && data.isDir} />
+						{data.isDir
+							? <FolderGlyph open={expanded} />
+							: <Glyph glyph={NF.file} size="0.95rem" className="text-fg-3" />}
 						<span className="truncate flex-1 min-w-0">{data.name}</span>
 						{loading && <Glyph glyph={NF.loading} size="0.8rem" className="text-fg-muted ml-1" spin />}
 					</button>

--- a/src/mainview/components/FolderPickerModal.tsx
+++ b/src/mainview/components/FolderPickerModal.tsx
@@ -15,6 +15,7 @@ import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { useFocusTrap } from "../utils/useFocusTrap";
 import {
+	relativeToRoot,
 	subscribeFolderPicker,
 	type FolderPickerRequest,
 } from "../folder-picker";
@@ -37,8 +38,21 @@ function basename(p: string): string {
 /** Build crumbs. The root "/" crumb has no text label — rendered with a drive
  *  icon instead, so we never get a "/ / Users" double-slash artefact. */
 interface Crumb { label: string | null; path: string; isRoot: boolean }
-function buildBreadcrumbs(path: string): Crumb[] {
+function buildBreadcrumbs(path: string, confineTo?: string | null): Crumb[] {
 	if (!path) return [];
+	// Confined: the trail starts at the confinement root, because a crumb the
+	// picker refuses to open is worse than no crumb.
+	if (confineTo) {
+		const rel = relativeToRoot(confineTo, path);
+		const crumbs: Crumb[] = [{ label: basename(confineTo), path: confineTo, isRoot: false }];
+		if (rel === "" || rel === path) return crumbs;
+		let acc = confineTo;
+		for (const part of rel.split("/").filter(Boolean)) {
+			acc += "/" + part;
+			crumbs.push({ label: part, path: acc, isRoot: false });
+		}
+		return crumbs;
+	}
 	const root: Crumb = { label: null, path: "/", isRoot: true };
 	if (path === "/") return [root];
 	const parts = path.split("/").filter(Boolean);
@@ -49,6 +63,12 @@ function buildBreadcrumbs(path: string): Crumb[] {
 		crumbs.push({ label: part, path: acc, isRoot: false });
 	}
 	return crumbs;
+}
+
+/** Is `candidate` the confinement root or inside it? */
+function isInsideRoot(root: string, candidate: string): boolean {
+	const rel = relativeToRoot(root, candidate);
+	return rel === "" || rel !== candidate;
 }
 
 // ── Nerd Font glyphs ───────────────────────────────────────────────
@@ -163,7 +183,9 @@ export default function FolderPickerHost() {
 
 	const handleClose = useCallback((result: string[] | null) => {
 		if (!request) return;
-		if (result && result.length > 0) result.forEach(pushRecent);
+		// A confined pick is a folder inside one project — useless as a global
+		// shortcut, and it would push the real recents out of the list.
+		if (result && result.length > 0 && !request.options.confineTo) result.forEach(pushRecent);
 		request.resolve(result);
 		setRequest(null);
 	}, [request]);
@@ -193,12 +215,13 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 	const [listingError, setListingError] = useState<string | null>(null);
 	const [selectedPath, setSelectedPath] = useState<string[]>([]);
 	const [filterText, setFilterText] = useState("");
-	const [recentPaths] = useState<string[]>(() => loadRecent());
+	const [recentPaths] = useState<string[]>(() => (options.confineTo ? [] : loadRecent()));
 	const [home, setHome] = useState<string>("");
 	const [homeEntries, setHomeEntries] = useState<Set<string>>(new Set());
 	const [driveRoots, setDriveRoots] = useState<string[]>([]);
 	const [treeKey, setTreeKey] = useState(0);
 	const fileMode = options.mode === "file";
+	const confineTo = options.confineTo ?? null;
 	const [showHidden, setShowHidden] = useState(options.showHidden === true);
 	// A file the caller pointed at (or the user typed): the tree opens on its
 	// folder with the file already selected, so Select is live immediately.
@@ -225,6 +248,10 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 
 	/** List `path`; in file mode a path that IS a file resolves to its folder, with the file picked. */
 	const loadForPath = useCallback(async (path: string | null): Promise<{ listing: FolderListing; pick: string | null }> => {
+		if (confineTo && path && !isInsideRoot(confineTo, path)) {
+			const inside = await listDir(confineTo);
+			return { listing: { ...inside, error: t("folderPicker.outsideRoot") }, pick: null };
+		}
 		const listing = await listDir(path);
 		if (fileMode && listing.error && listing.parent) {
 			const parent = await listDir(listing.parent);
@@ -232,7 +259,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 			if (hit) return { listing: parent, pick: hit.path };
 		}
 		return { listing, pick: null };
-	}, [listDir, fileMode]);
+	}, [listDir, fileMode, confineTo, t]);
 
 	// Initial load: open the picker at `initialPath` (or home) AND fetch the
 	// home listing in parallel so we can populate sidebar shortcuts.
@@ -240,7 +267,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 		let cancelled = false;
 		(async () => {
 			try {
-				const { listing: initial, pick } = await loadForPath(options.initialPath ?? null);
+				const { listing: initial, pick } = await loadForPath(options.initialPath ?? confineTo);
 				if (cancelled) return;
 				listingsRef.current.set(initial.path, initial);
 				setCurrentRoot(initial.path);
@@ -266,7 +293,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 			}
 		})();
 		return () => { cancelled = true; };
-	}, [options.initialPath, loadForPath, listDir]);
+	}, [options.initialPath, confineTo, loadForPath, listDir]);
 
 	// Escape cancels the inline "new folder" input first, otherwise closes the modal.
 	useEscapeKey(() => {
@@ -298,10 +325,11 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 	// Toggling dotfiles changes what every listing contains, so the cache goes
 	// and the tree remounts on the folder the user is already looking at.
 	const toggleHidden = useCallback(() => {
-		setShowHidden((prev) => {
-			showHiddenRef.current = !prev;
-			return !prev;
-		});
+		// The ref has to flip BEFORE navigating: a state updater runs at render
+		// time, which is after the listing request has already gone out.
+		const next = !showHiddenRef.current;
+		showHiddenRef.current = next;
+		setShowHidden(next);
 		listingsRef.current.clear();
 		if (currentRoot) void navigateTo(currentRoot);
 	}, [currentRoot, navigateTo]);
@@ -320,7 +348,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 		}
 	}, [manualPath, navigateTo]);
 
-	const breadcrumbs = useMemo(() => buildBreadcrumbs(currentRoot ?? ""), [currentRoot]);
+	const breadcrumbs = useMemo(() => buildBreadcrumbs(currentRoot ?? "", confineTo), [currentRoot, confineTo]);
 
 	const handleSelect = useCallback(() => {
 		if (selectedPath.length === 0) return;
@@ -359,6 +387,11 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 	// Build sidebar shortcuts — only those that actually exist under $HOME.
 	const quickPlaces = useMemo(() => {
 		const items: Array<{ label: string; path: string; glyph: string }> = [];
+		// Confined: every shortcut out there is a place the picker will refuse to
+		// open, so the root is the only one left standing.
+		if (confineTo) {
+			return [{ label: options.confineLabel ?? basename(confineTo), path: confineTo, glyph: NF.folderOpen }];
+		}
 		if (home) {
 			items.push({ label: t("folderPicker.home"), path: home, glyph: NF.home });
 			if (homeEntries.has("Desktop")) items.push({ label: "Desktop", path: `${home}/Desktop`, glyph: NF.desktop });
@@ -373,7 +406,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 			items.push({ label: t("folderPicker.rootLabel"), path: "/", glyph: NF.hardDrive });
 		}
 		return items;
-	}, [home, homeEntries, driveRoots, t]);
+	}, [home, homeEntries, driveRoots, confineTo, options.confineLabel, t]);
 
 	return (
 		<div
@@ -640,6 +673,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 									filterText={filterText}
 									multi={options.multi}
 									fileMode={fileMode}
+									hideCurrentRow={fileMode || (!!confineTo && currentRoot === confineTo)}
 									home={home}
 									preselectRoot={preselectRoot}
 									preselectPath={pinnedFile}
@@ -745,6 +779,8 @@ interface FolderTreeProps {
 	multi: boolean;
 	/** Files are listed and are the only selectable rows. */
 	fileMode: boolean;
+	/** Drop the "current folder" row — it is meaningless for a file pick, and empty for a confinement root. */
+	hideCurrentRow: boolean;
 	home: string;
 	/** Start with the "current folder" row selected (used right after creating one). */
 	preselectRoot: boolean;
@@ -754,7 +790,7 @@ interface FolderTreeProps {
 	onNavigate: (path: string) => void;
 }
 
-function FolderTree({ rootPath, listingsRef, listDir, filterText, multi, fileMode, home, preselectRoot, preselectPath, onSelect, onNavigate }: FolderTreeProps) {
+function FolderTree({ rootPath, listingsRef, listDir, filterText, multi, fileMode, hideCurrentRow, home, preselectRoot, preselectPath, onSelect, onNavigate }: FolderTreeProps) {
 	const t = useT();
 	// The folder the tree is rooted at is a legitimate answer, so it gets its own
 	// row. Without it the only way to pick the folder you navigated into was to
@@ -865,7 +901,7 @@ function FolderTree({ rootPath, listingsRef, listDir, filterText, multi, fileMod
 	return (
 		<div {...tree.getContainerProps()} className="outline-none flex flex-col" role="tree">
 			{/* The current folder, as a pickable row — meaningless when the caller wants a file. */}
-			{!fileMode && (
+			{!hideCurrentRow && (
 			<button
 				type="button"
 				data-testid="folder-picker-current-row"
@@ -891,7 +927,8 @@ function FolderTree({ rootPath, listingsRef, listDir, filterText, multi, fileMod
 			{empty && !filter && (
 				<div className="px-3 py-6 text-center">
 					<div className="text-fg-3 text-xs">{t("folderPicker.emptyFolder")}</div>
-					{!fileMode && <div className="text-fg-muted text-xs mt-1">{t("folderPicker.emptyFolderHint")}</div>}
+					{/* The hint says "pick it as it is" — only true while that row exists. */}
+					{!hideCurrentRow && <div className="text-fg-muted text-xs mt-1">{t("folderPicker.emptyFolderHint")}</div>}
 				</div>
 			)}
 			{empty && filter && (

--- a/src/mainview/components/ListEditor.tsx
+++ b/src/mainview/components/ListEditor.tsx
@@ -1,3 +1,17 @@
+/**
+ * A list whose rows can be filled from a picker instead of typed. Opt-in per
+ * call site: the same editor also holds CLI flags, where a Browse button would
+ * be nonsense.
+ */
+export interface ListEditorBrowse {
+	/** Row button: pick one value to replace that row. */
+	pickOne: () => Promise<string | null>;
+	/** Footer button: pick several values to append. */
+	pickMany: () => Promise<string[] | null>;
+	label: string;
+	rowLabel: string;
+}
+
 /** Reusable list editor for string arrays (additionalArgs, clonePaths, etc.) */
 export function ListEditor({
 	items,
@@ -5,6 +19,7 @@ export function ListEditor({
 	placeholder,
 	addLabel,
 	removeLabel,
+	browse,
 }: {
 	items: string[];
 	onChange: (items: string[]) => void;
@@ -12,6 +27,7 @@ export function ListEditor({
 	addLabel: string;
 	/** Accessible name for each row's remove button. */
 	removeLabel: string;
+	browse?: ListEditorBrowse;
 }) {
 	return (
 		<div className="space-y-1.5">
@@ -31,6 +47,26 @@ export function ListEditor({
 						spellCheck={false}
 						className="flex-1 min-w-0 px-3 py-1.5 bg-base border border-edge rounded-lg text-fg text-sm font-mono placeholder-fg-muted outline-none focus:border-accent/40 transition-colors"
 					/>
+					{browse && (
+						<button
+							type="button"
+							onClick={() => {
+								void browse.pickOne().then((picked) => {
+									// Cancelled, or an empty result (the confinement root itself) —
+									// either way, do not write it into the row.
+									if (!picked) return;
+									const next = [...items];
+									next[i] = picked;
+									onChange(next);
+								});
+							}}
+							aria-label={browse.rowLabel}
+							title={browse.rowLabel}
+							className="flex-shrink-0 px-2 py-1.5 rounded-lg border border-edge text-fg-2 text-xs font-medium outline-none hover:bg-elevated hover:text-fg focus-visible:ring-2 focus-visible:ring-accent/50 transition-colors"
+						>
+							{browse.label}
+						</button>
+					)}
 					<button
 						type="button"
 						onClick={() => onChange(items.filter((_, j) => j !== i))}
@@ -44,13 +80,31 @@ export function ListEditor({
 					</button>
 				</div>
 			))}
-			<button
-				type="button"
-				onClick={() => onChange([...items, ""])}
-				className="px-2 py-1 -ml-2 rounded-lg text-accent text-xs font-medium outline-none hover:bg-accent/10 focus-visible:ring-2 focus-visible:ring-accent/50 transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96]"
-			>
-				+ {addLabel}
-			</button>
+			<div className="flex items-center gap-1">
+				<button
+					type="button"
+					onClick={() => onChange([...items, ""])}
+					className="px-2 py-1 -ml-2 rounded-lg text-accent text-xs font-medium outline-none hover:bg-accent/10 focus-visible:ring-2 focus-visible:ring-accent/50 transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96]"
+				>
+					+ {addLabel}
+				</button>
+				{browse && (
+					<button
+						type="button"
+						onClick={() => {
+							void browse.pickMany().then((picked) => {
+								if (!picked || picked.length === 0) return;
+								const existing = new Set(items.filter((p) => p.trim() !== ""));
+								const fresh = picked.filter((p) => !existing.has(p));
+								onChange([...items.filter((p) => p.trim() !== ""), ...fresh]);
+							});
+						}}
+						className="px-2 py-1 rounded-lg text-accent text-xs font-medium outline-none hover:bg-accent/10 focus-visible:ring-2 focus-visible:ring-accent/50 transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96]"
+					>
+						+ {browse.label}
+					</button>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/src/mainview/components/ProjectSettings.tsx
+++ b/src/mainview/components/ProjectSettings.tsx
@@ -8,7 +8,8 @@ import { COORDINATOR_PROMPT, CUSTOM_COLUMN_INSTRUCTION_MAX_CHARS, DEFAULT_PR_REV
 import type { AppAction, Route } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
-import { ListEditor } from "./ListEditor";
+import { ListEditor, type ListEditorBrowse } from "./ListEditor";
+import { openFolderPicker, openFolderPickerMulti } from "../folder-picker";
 import AgentConfigPicker from "./AgentConfigPicker";
 import AutomationsPanel from "./AutomationsPanel";
 import ColorSwatchPicker from "./ColorSwatchPicker";
@@ -784,6 +785,26 @@ function ConfigForm({ config, onChange, inherited, projectId, projectPath, envSt
 		onChange({ ...config, [field]: value });
 	}
 
+	// Both path lists are stored relative to the repo root, so the picker is
+	// locked inside it and hands back relative paths. Without a known root there
+	// is nothing to be relative to, so the buttons stay away.
+	const repoBrowse: ListEditorBrowse | undefined = projectPath
+		? {
+			label: t("folderPicker.browse"),
+			rowLabel: t("folderPicker.browseInProject"),
+			pickOne: () => openFolderPicker({
+				confineTo: projectPath,
+				confineLabel: t("folderPicker.projectRoot"),
+				title: t("folderPicker.titleInProject"),
+			}),
+			pickMany: () => openFolderPickerMulti({
+				confineTo: projectPath,
+				confineLabel: t("folderPicker.projectRoot"),
+				title: t("folderPicker.titleInProject"),
+			}),
+		}
+		: undefined;
+
 	async function runAutoDetect() {
 		setDetecting(true);
 		setDetectFeedback(null);
@@ -957,6 +978,7 @@ function ConfigForm({ config, onChange, inherited, projectId, projectPath, envSt
 					placeholder={inheritedHint("clonePaths") || "node_modules"}
 					addLabel={t("projectSettings.addClonePath")}
 					removeLabel={t("listEditor.removeItem")}
+					browse={repoBrowse}
 				/>
 			</div>
 
@@ -1001,6 +1023,7 @@ function ConfigForm({ config, onChange, inherited, projectId, projectPath, envSt
 						placeholder={t("projectSettings.sparseCheckoutPlaceholder")}
 						addLabel={t("projectSettings.sparseCheckoutAddPath")}
 						removeLabel={t("listEditor.removeItem")}
+						browse={repoBrowse}
 					/>
 				)}
 			</div>

--- a/src/mainview/components/RequirementsCheck.tsx
+++ b/src/mainview/components/RequirementsCheck.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import type { RequirementCheckResult } from "../../shared/types";
 import { useT } from "../i18n";
 import { api } from "../rpc";
+import { openFilePicker } from "../folder-picker";
 
 interface Props {
 	results: RequirementCheckResult[];
@@ -23,6 +24,14 @@ export default function RequirementsCheck({ results, checking, onRefresh, onRefr
 		setCopiedId(id);
 		setTimeout(() => setCopiedId((prev) => (prev === id ? null : prev)), 2000);
 	}, []);
+
+	const handleBrowse = useCallback(async (reqId: string) => {
+		const picked = await openFilePicker({ initialPath: customPaths[reqId]?.trim() || null });
+		if (!picked) return;
+		setCustomPaths((prev) => ({ ...prev, [reqId]: picked }));
+		setPathErrors((prev) => ({ ...prev, [reqId]: false }));
+		inputRefs.current[reqId]?.focus();
+	}, [customPaths]);
 
 	const handleSetCustomPath = useCallback(async (reqId: string) => {
 		const path = customPaths[reqId]?.trim();
@@ -161,6 +170,14 @@ export default function RequirementsCheck({ results, checking, onRefresh, onRefr
 													placeholder={`/path/to/${req.name.toLowerCase()}`}
 													className={`flex-1 bg-base border rounded px-2 py-1 text-xs font-mono text-fg placeholder:text-fg-muted focus:border-accent ${hasPathError ? "border-danger" : "border-edge"}`}
 												/>
+												<button
+													type="button"
+													onClick={() => void handleBrowse(req.id)}
+													aria-label={t("folderPicker.browseAria", { name: req.name })}
+													className="px-2.5 py-1 rounded border border-edge text-fg-2 text-xs font-medium hover:bg-elevated hover:text-fg transition-colors shrink-0"
+												>
+													{t("folderPicker.browse")}
+												</button>
 												<button
 													type="button"
 													onClick={() => handleSetCustomPath(req.id)}

--- a/src/mainview/components/__tests__/FolderPickerModal.test.tsx
+++ b/src/mainview/components/__tests__/FolderPickerModal.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import FolderPickerHost from "../FolderPickerModal";
-import { openFolderPicker } from "../../folder-picker";
+import { openFilePicker, openFolderPicker } from "../../folder-picker";
 import { I18nProvider } from "../../i18n";
 
 vi.mock("../../rpc", () => ({
@@ -268,6 +268,94 @@ describe("FolderPickerHost", () => {
 		expect(screen.getByText("zebra-notes")).toBeInTheDocument();
 		expect(screen.queryByText("aardvark")).not.toBeInTheDocument();
 		expect(screen.queryByText("midnight")).not.toBeInTheDocument();
+	});
+});
+
+describe("FolderPickerHost file mode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.removeItem("dev3-folder-picker-recent");
+	});
+
+	it("lists files, resolves with the picked file, and never asks the backend to hide them", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockResolvedValue(
+			mockListing("/opt/homebrew/bin", [
+				{ name: "lib", isDir: true },
+				{ name: "claude", isDir: false },
+			]),
+		);
+
+		renderHost();
+		const picked = openFilePicker({ initialPath: "/opt/homebrew/bin" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		expect(mockedApi.request.listDirectory).toHaveBeenCalledWith({
+			path: "/opt/homebrew/bin",
+			includeFiles: true,
+			showHidden: true,
+		});
+
+		await user.click(await screen.findByText("claude"));
+		await waitFor(() => expect(screen.getByText("Select")).not.toBeDisabled());
+		await user.click(screen.getByText("Select"));
+		await expect(picked).resolves.toBe("/opt/homebrew/bin/claude");
+	});
+
+	it("refuses to arm Select on a folder — the caller asked for a file", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockResolvedValue(
+			mockListing("/opt/homebrew/bin", [{ name: "lib", isDir: true }]),
+		);
+
+		renderHost();
+		openFilePicker({ initialPath: "/opt/homebrew/bin" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		// The whole-folder row is gone in file mode …
+		expect(screen.queryByTestId("folder-picker-current-row")).not.toBeInTheDocument();
+		// … and highlighting a subfolder leaves Select dead.
+		await user.click(await screen.findByText("lib"));
+		expect(screen.getByText("Select")).toBeDisabled();
+	});
+
+	it("opens on the folder of a file it was pointed at, with that file already selected", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockImplementation(async ({ path }) =>
+			path === "/opt/homebrew/bin/claude"
+				? { ...mockListing("/opt/homebrew/bin/claude", []), error: "ENOTDIR" }
+				: mockListing("/opt/homebrew/bin", [{ name: "claude", isDir: false }]),
+		);
+
+		renderHost();
+		const picked = openFilePicker({ initialPath: "/opt/homebrew/bin/claude" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		// The ENOTDIR from the file itself must not reach the user as an error.
+		await waitFor(() => expect(screen.getByText("Select")).not.toBeDisabled());
+		expect(screen.queryByText(/ENOTDIR/)).not.toBeInTheDocument();
+		await user.click(screen.getByText("Select"));
+		await expect(picked).resolves.toBe("/opt/homebrew/bin/claude");
+	});
+
+	it("re-reads the folder without dotfiles when the hidden toggle is switched off", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockResolvedValue(
+			mockListing("/Users/test", [{ name: ".bun", isDir: true }]),
+		);
+
+		renderHost();
+		openFilePicker({ initialPath: "/Users/test" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		await user.click(screen.getByTestId("folder-picker-hidden-toggle"));
+		await waitFor(() =>
+			expect(mockedApi.request.listDirectory).toHaveBeenCalledWith({
+				path: "/Users/test",
+				includeFiles: true,
+				showHidden: false,
+			}),
+		);
 	});
 });
 

--- a/src/mainview/components/__tests__/FolderPickerModal.test.tsx
+++ b/src/mainview/components/__tests__/FolderPickerModal.test.tsx
@@ -359,6 +359,88 @@ describe("FolderPickerHost file mode", () => {
 	});
 });
 
+describe("FolderPickerHost confined to a project root", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.setItem("dev3-folder-picker-recent", JSON.stringify(["/Users/test/elsewhere"]));
+	});
+
+	afterEach(() => {
+		localStorage.removeItem("dev3-folder-picker-recent");
+	});
+
+	it("resolves with a path relative to the root, not an absolute one", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockResolvedValue(
+			mockListing("/Users/test/repo", [{ name: "packages", isDir: true }]),
+		);
+
+		renderHost();
+		const picked = openFolderPicker({ confineTo: "/Users/test/repo" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		await user.click(await screen.findByText("packages"));
+		await waitFor(() => expect(screen.getByText("Select")).not.toBeDisabled());
+		await user.click(screen.getByText("Select"));
+
+		await expect(picked).resolves.toBe("packages");
+	});
+
+	it("hides every shortcut that leads out of the root, including recents", async () => {
+		mockedApi.request.listDirectory.mockResolvedValue(mockListing("/Users/test/repo", []));
+
+		renderHost();
+		openFolderPicker({ confineTo: "/Users/test/repo", confineLabel: "Project root" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		const sidebar = await screen.findByTestId("folder-picker-sidebar");
+		expect(within(sidebar).getByText("Project root")).toBeInTheDocument();
+		expect(within(sidebar).queryByText("Home")).not.toBeInTheDocument();
+		expect(within(sidebar).queryByText("Root")).not.toBeInTheDocument();
+		expect(within(sidebar).queryByText("elsewhere")).not.toBeInTheDocument();
+		// Picking the root itself would store an empty string — no row for it.
+		expect(screen.queryByTestId("folder-picker-current-row")).not.toBeInTheDocument();
+	});
+
+	it("refuses a typed path that escapes the root and says so", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockImplementation(async ({ path }) =>
+			mockListing(path ?? "/Users/test/repo", []),
+		);
+
+		renderHost();
+		openFolderPicker({ confineTo: "/Users/test/repo" });
+		await screen.findByTestId("folder-picker-backdrop");
+
+		await user.clear(screen.getByLabelText("Folder path"));
+		await user.type(screen.getByLabelText("Folder path"), "/etc{Enter}");
+
+		expect(await screen.findByText(/outside the project/)).toBeInTheDocument();
+		// And it stayed put rather than showing /etc's contents.
+		expect(mockedApi.request.listDirectory).not.toHaveBeenCalledWith(
+			expect.objectContaining({ path: "/etc" }),
+		);
+	});
+
+	it("keeps a confined pick out of the global recents list", async () => {
+		const user = userEvent.setup();
+		mockedApi.request.listDirectory.mockResolvedValue(
+			mockListing("/Users/test/repo", [{ name: "packages", isDir: true }]),
+		);
+
+		renderHost();
+		const picked = openFolderPicker({ confineTo: "/Users/test/repo" });
+		await screen.findByTestId("folder-picker-backdrop");
+		await user.click(await screen.findByText("packages"));
+		await waitFor(() => expect(screen.getByText("Select")).not.toBeDisabled());
+		await user.click(screen.getByText("Select"));
+		await picked;
+
+		expect(JSON.parse(localStorage.getItem("dev3-folder-picker-recent") ?? "[]"))
+			.toEqual(["/Users/test/elsewhere"]);
+	});
+});
+
 describe("FolderPickerHost narrow viewport", () => {
 	const originalInnerWidth = window.innerWidth;
 	const originalMatchMedia = window.matchMedia;

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProjectSettings from "../ProjectSettings";
 import { api } from "../../rpc";
+import { openFolderPicker, openFolderPickerMulti } from "../../folder-picker";
 import { I18nProvider } from "../../i18n";
 import type { Project, Task } from "../../../shared/types";
 import type { AppAction, Route } from "../../state";
@@ -34,6 +35,11 @@ vi.mock("../../rpc", () => ({
 			getGlobalSettings: vi.fn().mockResolvedValue({}),
 		},
 	},
+}));
+
+vi.mock("../../folder-picker", () => ({
+	openFolderPicker: vi.fn(),
+	openFolderPickerMulti: vi.fn(),
 }));
 
 vi.mock("../../confirm", () => ({
@@ -257,6 +263,40 @@ describe("ProjectSettings", () => {
 			await renderProjectSettings(mockProject, { clonePaths: ["node_modules"] });
 			await goToProjectTab();
 			expect(screen.getByText("Auto-detect")).toBeInTheDocument();
+		});
+
+		it("fills a clone-path row from a picker locked to the project root", async () => {
+			const user = userEvent.setup();
+			vi.mocked(openFolderPicker).mockResolvedValue("packages/api");
+			await renderProjectSettings(mockProject, { clonePaths: ["node_modules"] });
+			await goToProjectTab();
+
+			await user.click(screen.getByLabelText("Pick a folder inside the project"));
+
+			// Confined to the project's own root, and the row got the RELATIVE
+			// path the field stores — an absolute one would break cloning.
+			expect(vi.mocked(openFolderPicker).mock.calls[0][0]).toMatchObject({
+				confineTo: "/tmp/test",
+			});
+			await vi.waitFor(() =>
+				expect(screen.getByDisplayValue("packages/api")).toBeInTheDocument(),
+			);
+		});
+
+		it("appends several folders at once via the footer browse button", async () => {
+			const user = userEvent.setup();
+			vi.mocked(openFolderPickerMulti).mockResolvedValue(["packages/a", "packages/b"]);
+			await renderProjectSettings(mockProject, { clonePaths: ["node_modules"] });
+			await goToProjectTab();
+
+			await user.click(screen.getByText("+ Browse…"));
+
+			await vi.waitFor(() => {
+				expect(screen.getByDisplayValue("packages/a")).toBeInTheDocument();
+				expect(screen.getByDisplayValue("packages/b")).toBeInTheDocument();
+				// The row that was already there survives.
+				expect(screen.getByDisplayValue("node_modules")).toBeInTheDocument();
+			});
 		});
 	});
 

--- a/src/mainview/components/global-settings/AgentSettingsSection.tsx
+++ b/src/mainview/components/global-settings/AgentSettingsSection.tsx
@@ -21,6 +21,7 @@ import Select, { type SelectOption } from "../Select";
 import { confirm } from "../../confirm";
 import { toast } from "../../toast";
 import { api } from "../../rpc";
+import { openFilePicker } from "../../folder-picker";
 import type { TFunction, TranslationKey } from "../../i18n";
 import { buildPickerGroups, getModeLeafLabel, getModelGroupLabel, type PickerGroup } from "../../utils/agentPicker";
 import { useToggleFavorite } from "../../hooks/useToggleFavorite";
@@ -1110,6 +1111,17 @@ function AgentPane({
 											availability.customPathError ? "border-danger" : "border-edge"
 										}`}
 									/>
+									<button
+										type="button"
+										onClick={() => {
+											void openFilePicker({ initialPath: customPath.trim() || null })
+												.then((picked) => { if (picked) onCustomPathChange(picked); });
+										}}
+										aria-label={t("folderPicker.browseAria", { name: agent.baseCommand })}
+										className="px-2.5 py-1 rounded border border-edge text-fg-2 text-xs font-medium hover:bg-elevated hover:text-fg transition-colors shrink-0"
+									>
+										{t("folderPicker.browse")}
+									</button>
 									<button
 										type="button"
 										onClick={onSavePath}

--- a/src/mainview/folder-picker.ts
+++ b/src/mainview/folder-picker.ts
@@ -26,6 +26,14 @@ export interface FolderPickerOptions {
 	mode?: "folder" | "file";
 	/** Start with dotfiles visible. File mode defaults to true: most CLI binaries live under ~/.local/bin, ~/.bun/bin and friends. */
 	showHidden?: boolean;
+	/**
+	 * Lock the picker inside this folder and hand the caller paths RELATIVE to
+	 * it. For fields that store a repo-relative path (clone paths, sparse
+	 * checkout) an absolute path is not a worse answer — it is a broken one.
+	 */
+	confineTo?: string | null;
+	/** Sidebar label for the confinement root. Defaults to its folder name. */
+	confineLabel?: string;
 	/** Enable multi-selection (Cmd/Shift+click). */
 	multi: boolean;
 }
@@ -48,9 +56,33 @@ function enqueue(request: FolderPickerRequest): void {
 	}
 }
 
+/** Normalise separators and drop a trailing slash so prefix maths is safe on Windows too. */
+function normalizeSeparators(p: string): string {
+	return p.replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+/**
+ * Rebase an absolute path onto `root`. The picker's confinement is what keeps
+ * a path inside the root, so an outsider here means a bug upstream — returning
+ * it unchanged is louder than silently emitting `../..`.
+ */
+export function relativeToRoot(root: string, full: string): string {
+	const r = normalizeSeparators(root);
+	const f = normalizeSeparators(full);
+	if (f === r) return "";
+	return f.startsWith(r + "/") ? f.slice(r.length + 1) : full;
+}
+
+function resolveResult(options: FolderPickerOptions, result: string[] | null): string[] | null {
+	if (!result || !options.confineTo) return result;
+	const root = options.confineTo;
+	return result.map((p) => relativeToRoot(root, p)).filter((p) => p !== "");
+}
+
 export function openFolderPicker(options: Omit<FolderPickerOptions, "multi"> = {}): Promise<string | null> {
 	return new Promise<string | null>((resolve) => {
-		enqueue({ options: { ...options, multi: false }, resolve: (result) => resolve(result?.[0] ?? null) });
+		const opts: FolderPickerOptions = { ...options, multi: false };
+		enqueue({ options: opts, resolve: (result) => resolve(resolveResult(opts, result)?.[0] ?? null) });
 	});
 }
 
@@ -66,7 +98,8 @@ export function openFilePicker(options: Omit<FolderPickerOptions, "multi" | "mod
 
 export function openFolderPickerMulti(options: Omit<FolderPickerOptions, "multi"> = {}): Promise<string[] | null> {
 	return new Promise<string[] | null>((resolve) => {
-		enqueue({ options: { ...options, multi: true }, resolve });
+		const opts: FolderPickerOptions = { ...options, multi: true };
+		enqueue({ options: opts, resolve: (result) => resolve(resolveResult(opts, result)) });
 	});
 }
 

--- a/src/mainview/folder-picker.ts
+++ b/src/mainview/folder-picker.ts
@@ -19,6 +19,13 @@ export interface FolderPickerOptions {
 	 * Default: false (existing call sites are for picking existing folders).
 	 */
 	allowCreateFolder?: boolean;
+	/**
+	 * What the caller wants back. In `"file"` mode folders are still walkable
+	 * but only a file can be selected — that is how a CLI binary gets picked.
+	 */
+	mode?: "folder" | "file";
+	/** Start with dotfiles visible. File mode defaults to true: most CLI binaries live under ~/.local/bin, ~/.bun/bin and friends. */
+	showHidden?: boolean;
 	/** Enable multi-selection (Cmd/Shift+click). */
 	multi: boolean;
 }
@@ -44,6 +51,16 @@ function enqueue(request: FolderPickerRequest): void {
 export function openFolderPicker(options: Omit<FolderPickerOptions, "multi"> = {}): Promise<string | null> {
 	return new Promise<string | null>((resolve) => {
 		enqueue({ options: { ...options, multi: false }, resolve: (result) => resolve(result?.[0] ?? null) });
+	});
+}
+
+/** Pick a single existing file (e.g. a CLI binary). Folders are walkable, not selectable. */
+export function openFilePicker(options: Omit<FolderPickerOptions, "multi" | "mode" | "allowCreateFolder"> = {}): Promise<string | null> {
+	return new Promise<string | null>((resolve) => {
+		enqueue({
+			options: { showHidden: true, ...options, mode: "file", multi: false },
+			resolve: (result) => resolve(result?.[0] ?? null),
+		});
 	});
 }
 

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -255,6 +255,12 @@ const common = {
 	"folderPicker.noMatches": "No loaded folder matches “{query}”",
 	"folderPicker.selectedCountLabel_one": "{count} folder selected",
 	"folderPicker.selectedCountLabel_other": "{count} folders selected",
+	"folderPicker.titleFile": "Select a file",
+	"folderPicker.filterFilesPlaceholder": "Filter…",
+	"folderPicker.filterFilesAriaLabel": "Filter files and folders",
+	"folderPicker.showHidden": "Hidden files",
+	"folderPicker.browse": "Browse…",
+	"folderPicker.browseAria": "Choose the {name} binary on disk",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "Stuck on Fetching origin?",

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -261,6 +261,10 @@ const common = {
 	"folderPicker.showHidden": "Hidden files",
 	"folderPicker.browse": "Browse…",
 	"folderPicker.browseAria": "Choose the {name} binary on disk",
+	"folderPicker.browseInProject": "Pick a folder inside the project",
+	"folderPicker.titleInProject": "Select a folder inside the project",
+	"folderPicker.projectRoot": "Project root",
+	"folderPicker.outsideRoot": "That path is outside the project — this field only takes paths inside it.",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "Stuck on Fetching origin?",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -254,6 +254,12 @@ const common = {
 	"folderPicker.noMatches": "Ninguna carpeta cargada coincide con «{query}»",
 	"folderPicker.selectedCountLabel_one": "{count} carpeta seleccionada",
 	"folderPicker.selectedCountLabel_other": "{count} carpetas seleccionadas",
+	"folderPicker.titleFile": "Selecciona un archivo",
+	"folderPicker.filterFilesPlaceholder": "Filtrar…",
+	"folderPicker.filterFilesAriaLabel": "Filtrar archivos y carpetas",
+	"folderPicker.showHidden": "Archivos ocultos",
+	"folderPicker.browse": "Examinar…",
+	"folderPicker.browseAria": "Elegir el binario de {name} en el disco",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "¿Atascado en Fetching origin?",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -260,6 +260,10 @@ const common = {
 	"folderPicker.showHidden": "Archivos ocultos",
 	"folderPicker.browse": "Examinar…",
 	"folderPicker.browseAria": "Elegir el binario de {name} en el disco",
+	"folderPicker.browseInProject": "Elegir una carpeta dentro del proyecto",
+	"folderPicker.titleInProject": "Selecciona una carpeta dentro del proyecto",
+	"folderPicker.projectRoot": "Raíz del proyecto",
+	"folderPicker.outsideRoot": "Esa ruta está fuera del proyecto — este campo solo acepta rutas dentro de él.",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "¿Atascado en Fetching origin?",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -262,6 +262,10 @@ const common = {
 	"folderPicker.showHidden": "Скрытые файлы",
 	"folderPicker.browse": "Обзор…",
 	"folderPicker.browseAria": "Выбрать бинарник {name} на диске",
+	"folderPicker.browseInProject": "Выбрать папку внутри проекта",
+	"folderPicker.titleInProject": "Выберите папку внутри проекта",
+	"folderPicker.projectRoot": "Корень проекта",
+	"folderPicker.outsideRoot": "Этот путь вне проекта — поле принимает только пути внутри него.",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "Зависло на Fetching origin?",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -256,6 +256,12 @@ const common = {
 	"folderPicker.selectedCountLabel_few": "{count} папки выбраны",
 	"folderPicker.selectedCountLabel_many": "{count} папок выбрано",
 	"folderPicker.selectedCountLabel_other": "{count} папок выбрано",
+	"folderPicker.titleFile": "Выберите файл",
+	"folderPicker.filterFilesPlaceholder": "Фильтр…",
+	"folderPicker.filterFilesAriaLabel": "Фильтр файлов и папок",
+	"folderPicker.showHidden": "Скрытые файлы",
+	"folderPicker.browse": "Обзор…",
+	"folderPicker.browseAria": "Выбрать бинарник {name} на диске",
 
 	// Stuck preparation popover (clone hangs on Fetching origin — macOS FDA)
 	"stuckPrep.popoverTitle": "Зависло на Fetching origin?",


### PR DESCRIPTION
Four fields still demanded a hand-typed absolute or repo-relative path. All four now have a **Browse…** button, and the folder picker grew the two modes that made that possible.

## File mode — `openFilePicker()`

Used by the custom binary path in Settings → Agents and by the requirements screen.

- Files are listed and are the only selectable rows; folders stay walkable but never arm **Select**, and the "current folder" row is hidden.
- Dotfiles are on by default here (most CLI binaries live under `~/.local/bin`, `~/.bun/bin`), with a **Hidden files** toggle in the header that works in folder mode too.
- Pointing the picker at a file — which is what the field's current value is — opens its folder with that file already selected instead of surfacing an `ENOTDIR`.

## Confined mode — `confineTo`

Used by **Clone Paths** and **Worktree File Filter (Sparse Checkout)** in project settings, which store paths *relative to the repo root*. An absolute path there is not a worse answer, it is a broken one.

- The picker opens at the project root and refuses to leave it: shortcuts out of the root are gone, breadcrumbs start at the root, and a typed path outside it is rejected with a message rather than followed.
- Results come back relative to the root; picking the root itself yields nothing rather than an empty entry.
- Confined picks are kept out of the global "Recent" list — they are one project's folders, not shortcuts.
- `ListEditor` grew an opt-in `browse` prop: a button per row, plus a `+ Browse…` footer button that appends several folders in one go. Opt-in because the same editor also holds CLI flags, where a Browse button would be nonsense.

The backend `listDirectory` already supported `includeFiles`/`showHidden`; no RPC change. `FolderPickerHost` is now also mounted on the requirements screen, which returns early from `App` and would otherwise have queued a picker request nothing renders.

Verified in a browser on both modes: picking `/opt/homebrew/bin/claude` lands in the agent path field and reopening starts on that folder with the file selected; in project settings the picker opens at the project root, `/etc` is refused with "That path is outside the project", and picking `packages` stores exactly `packages`. No console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=e8415183-5b5b-4ea8-8be0-83987a3e3ed5) · `dev3://task/e8415183-5b5b-4ea8-8be0-83987a3e3ed5`