### PR TITLE
Make the setup-failure notice depend on whether the agent started

### DIFF
--- a/change-logs/2026/08/25/fix-setup-failed-notice-agent-aware.md
+++ b/change-logs/2026/08/25/fix-setup-failed-notice-agent-aware.md
@@ -1,0 +1,3 @@
+Short: Setup-failure notice stops lying
+
+The "Setup failed" popup used to claim the agent was never started and offer to start it anyway — but in the default parallel launch mode the agent is already running, and that button destroyed it along with its context. The notice now knows which happened: a live agent gets a small dismissible strip offering to re-run setup, a never-started agent keeps the dialog with the re-run leading. Dismissing it sticks instead of returning on the next task switch, and "Re-run project setup" is also available from the Scripts dropdown.

--- a/decisions/2026/08/25/setup-failure-offer-depends-on-whether-the-agent-started.md
+++ b/decisions/2026/08/25/setup-failure-offer-depends-on-whether-the-agent-started.md
@@ -1,0 +1,59 @@
+# The setup-failure offer depends on whether the agent had already started
+
+## Context
+
+A `setupScript` that exits non-zero raised one modal card in the task pane:
+"the agent was not started … Start agent anyway". That sentence is only true for
+some launches, and the button behind it is destructive for the rest.
+
+## Investigation
+
+`buildSetupStartupWrapper` (`src/bun/rpc-handlers/shared-pure.ts`) emits the
+agent's `tmux split-window` BEFORE the setup script in `parallel` mode and AFTER
+it in `blocking` mode. `parallel` is the default for every project
+(`src/bun/data.ts`), and native sessions ignore the mode entirely — they always
+gate the agent behind setup. So in the common case the failure finds a live
+agent, while the card claims the opposite and its primary button calls
+`restartTask`, which destroys the whole session (`pty.destroySessionAwaited`)
+and relaunches without setup: a working agent and its context, gone.
+
+Three smaller faults with the same root: the card `autoFocus`ed that destructive
+button, so a setup failing minutes into a session moved the keyboard out of the
+terminal and turned the next Enter into a session kill; the only way to close it
+was a button labelled "Show setup log" that showed nothing; and the dismissal
+lived in component state, which `key={taskId}` (`TaskWorkspacePane.tsx`) throws
+away on every task switch, so the popup came back.
+
+## Decision
+
+`launchTaskPty` records `Task.setupFailedAgentRunning` next to the exit code,
+decided where the wrapper's shape is known (`!nativeBackend && mode ===
+"parallel"`). `TaskTerminal` renders from it: a live agent gets a non-modal
+strip with a re-run and a ✕, a never-started agent gets the dialog, with the
+re-run leading and "start anyway" demoted to a fallback. Dismissing calls
+`dismissSetupFailure`, which clears the verdict in the task, so it cannot return
+in this component or a second viewer.
+
+`rerunSetupScript` runs the setup script alone in an auxiliary pane
+(`openAuxPane`, purpose `setupRerun`) and arms a fresh watch, so a second
+failure raises the notice again. It is also a pinned row in the existing Scripts
+dropdown — a rare recovery action belongs in an existing overflow, not in a new
+always-visible button on the app's densest surface.
+
+## Risks
+
+`setupFailedAgentRunning` describes the launch, not the present: an agent that
+has since exited still reads as running, and the strip then offers a re-run
+where the dialog would have offered a restart. The task's restart affordances
+are untouched, so that costs a click, not a recovery path.
+
+## Alternatives considered
+
+- **Keep one card, only fix the copy and confirm the destructive button.**
+  Cheap, but the message stays vague in the case that matters most.
+- **Count panes at render time instead of recording the launch.** Truth over a
+  guess, but it needs a live tmux probe per viewer and still cannot tell the
+  agent's pane from an auxiliary one.
+- **Drop the overlay entirely for a strip in the task panel.** Cleanest, but it
+  moves a surface and would leave a never-started agent with no visible way back
+  to its prompt.

--- a/src/bun/__tests__/setup-failure-report.test.ts
+++ b/src/bun/__tests__/setup-failure-report.test.ts
@@ -78,6 +78,40 @@ describe("setup wrapper — recording a failed setupScript", () => {
 	});
 });
 
+// A re-run happens when a session already exists, so the point is what the
+// script does NOT do: split a pane, exec an agent, or touch tmux at all.
+describe("setup re-run wrapper", () => {
+	const RERUN_ARGS = { setupPath: "/tmp/dev3-T-setup.sh", shellPath: "/bin/zsh", setupExitPath: "/tmp/dev3-T-setup-exit" };
+
+	it("runs the setup script and nothing else", async () => {
+		const { buildSetupRerunScript } = await import("../rpc-handlers/shared-pure");
+		const script = buildSetupRerunScript(RERUN_ARGS);
+
+		expect(script).toContain("/tmp/dev3-T-setup.sh");
+		expect(script).not.toContain("split-window");
+		expect(script).not.toContain("tmux");
+		expect(script).not.toContain("dev3-T-cmd.sh");
+	});
+
+	// Same channel as the launch wrapper: without the file a second failure is
+	// invisible and the notice never comes back.
+	it("reports a second failure through the same exit-code file", async () => {
+		const { buildSetupRerunScript } = await import("../rpc-handlers/shared-pure");
+		const lines = buildSetupRerunScript(RERUN_ARGS).split("\n").map((l) => l.trim());
+
+		const write = lines.findIndex((l) => l === `printf '%s' "$S" > '/tmp/dev3-T-setup-exit'`);
+		const shell = lines.findIndex((l) => l === "exec '/bin/zsh'");
+		expect(write).toBeGreaterThan(-1);
+		expect(shell).toBeGreaterThan(write);
+	});
+
+	it("records nothing on the success path", async () => {
+		const { buildSetupRerunScript } = await import("../rpc-handlers/shared-pure");
+		const script = buildSetupRerunScript(RERUN_ARGS);
+		expect(script.slice(script.indexOf("✓ Setup done"))).not.toContain("dev3-T-setup-exit");
+	});
+});
+
 // ---- The watcher ----
 
 describe("watchSetupFailure", () => {

--- a/src/bun/__tests__/tmux-pty-native-launch.test.ts
+++ b/src/bun/__tests__/tmux-pty-native-launch.test.ts
@@ -24,6 +24,19 @@ vi.mock("../data", () => ({
 	getProject: vi.fn(),
 	getTask: vi.fn(),
 	updateTask: vi.fn(async () => undefined),
+	loadProjects: vi.fn(async () => []),
+	loadVirtualProjects: vi.fn(async () => []),
+}));
+
+vi.mock("../task-aux-panes", () => ({
+	openAuxPane: vi.fn(async () => ({ backend: "tmux", paneId: "%9" })),
+	auxPaneTitle: vi.fn((purpose: string) => purpose),
+	AuxPaneUnavailableError: class extends Error {},
+	closeAuxPane: vi.fn(),
+	replaceAuxPanes: vi.fn(),
+	splitTaskPane: vi.fn(),
+	auxPaneMarker: vi.fn(() => ""),
+	findAuxPane: vi.fn(async () => null),
 }));
 
 vi.mock("../pty-server", () => ({
@@ -34,6 +47,7 @@ vi.mock("../pty-server", () => ({
 	createSession: vi.fn(),
 	createNativeTaskSession: vi.fn(async () => undefined),
 	destroySession: vi.fn(),
+	destroySessionAwaited: vi.fn(async () => undefined),
 	capturePane: vi.fn(),
 	listPaneIds: vi.fn(async () => ["%1"]),
 	tmuxSessionExists: vi.fn(async () => true),
@@ -177,6 +191,9 @@ vi.mock("../rpc-handlers/shared-pure", () => ({
 	buildAgentRetryWrapper: vi.fn(() => "#!/bin/bash\n# retry\n"),
 	buildCmdScript: vi.fn(() => "#!/bin/bash\n"),
 	buildSetupStartupWrapper: vi.fn(() => "#!/bin/bash\n# startup\n"),
+	buildSetupRerunScript: vi.fn(() => "#!/bin/bash\n# rerun\n"),
+	generatedScriptLaunch: vi.fn((p: string) => ({ executable: "/bin/zsh", argv: [p] })),
+	generatedScriptName: vi.fn((base: string) => `${base}.sh`),
 	buildEnvExports: vi.fn(() => []),
 	buildScriptRunnerCommand: vi.fn((scriptPath: string) => `/bin/zsh ${scriptPath}`),
 	buildTaskLifecycleEnv: vi.fn((_p: Project, task: Task) => ({ DEV3_TASK_ID: task.id })),
@@ -202,9 +219,11 @@ import * as watch from "../setup-failure-watch";
 import * as pty from "../pty-server";
 import { setupExitCodePath } from "../temp-paths";
 import * as sharedPure from "../rpc-handlers/shared-pure";
+import * as settingsConfig from "../rpc-handlers/settings-config";
+import * as auxPanes from "../task-aux-panes";
 import { tmux } from "../tmux";
 
-const { launchTaskPty } = await import("../rpc-handlers/tmux-pty");
+const { launchTaskPty, tmuxPtyHandlers } = await import("../rpc-handlers/tmux-pty");
 
 // ---- Fixtures ----
 
@@ -407,7 +426,7 @@ describe("setup-script wrapper — one flavour per backend", () => {
 		expect(vi.mocked(data.updateTask)).toHaveBeenCalledWith(
 			expect.anything(),
 			task.id,
-			{ setupFailedExitCode: 127 },
+			{ setupFailedExitCode: 127, setupFailedAgentRunning: true },
 		);
 		expect(push).toHaveBeenCalledWith(
 			"taskUpdated",
@@ -430,8 +449,84 @@ describe("setup-script wrapper — one flavour per backend", () => {
 		expect(vi.mocked(data.updateTask)).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.any(String),
-			{ setupFailedExitCode: null },
+			{ setupFailedExitCode: null, setupFailedAgentRunning: null },
 		);
+	});
+
+	// Which offer the pane may make hangs entirely on this flag: a parallel tmux
+	// launch splits the agent pane BEFORE setup, so a failure finds it alive and
+	// "start the agent anyway" would destroy a working session.
+	it("records that the agent was already running for a parallel tmux launch", async () => {
+		const task = makeTask({ terminalBackend: "tmux" });
+		await launchTaskPty(setupProject({ setupScriptLaunchMode: "parallel" }), task, WORKTREE, null, null, true);
+
+		const onFailure = vi.mocked(watch.watchSetupFailure).mock.calls[0][1];
+		vi.mocked(data.updateTask).mockClear();
+		await onFailure(1);
+
+		expect(vi.mocked(data.updateTask)).toHaveBeenCalledWith(
+			expect.anything(),
+			task.id,
+			{ setupFailedExitCode: 1, setupFailedAgentRunning: true },
+		);
+	});
+
+	it("records that the agent never started for a blocking tmux launch", async () => {
+		const task = makeTask({ terminalBackend: "tmux" });
+		await launchTaskPty(setupProject({ setupScriptLaunchMode: "blocking" }), task, WORKTREE, null, null, true);
+
+		const onFailure = vi.mocked(watch.watchSetupFailure).mock.calls[0][1];
+		vi.mocked(data.updateTask).mockClear();
+		await onFailure(1);
+
+		expect(vi.mocked(data.updateTask)).toHaveBeenCalledWith(
+			expect.anything(),
+			task.id,
+			{ setupFailedExitCode: 1, setupFailedAgentRunning: false },
+		);
+	});
+
+	// The re-run computes the same answer the launch did instead of reading the
+	// task back — a dismissal clears the flag, and reading it there made every
+	// re-run failure claim the agent had never started.
+	it("re-run recomputes whether the agent is running rather than reading it back", async () => {
+		const task = makeTask({ terminalBackend: "tmux", setupFailedAgentRunning: null });
+		const project = setupProject({ setupScriptLaunchMode: "parallel" });
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(settingsConfig.resolveOperationalProjectConfig).mockResolvedValue({
+			setupScript: "bun install\n", setupScriptLaunchMode: "parallel", env: {}, devScript: "", portCount: 0,
+		} as never);
+
+		await tmuxPtyHandlers.rerunSetupScript({ taskId: task.id });
+
+		const onFailure = vi.mocked(watch.watchSetupFailure).mock.calls[vi.mocked(watch.watchSetupFailure).mock.calls.length - 1][1];
+		vi.mocked(data.updateTask).mockClear();
+		await onFailure(1);
+
+		expect(vi.mocked(data.updateTask)).toHaveBeenCalledWith(
+			expect.anything(),
+			task.id,
+			{ setupFailedExitCode: 1, setupFailedAgentRunning: true },
+		);
+	});
+
+	// The whole point of a re-run is that the session survives it.
+	it("re-run opens its own pane and never restarts the session", async () => {
+		const task = makeTask({ terminalBackend: "tmux" });
+		const project = setupProject();
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(settingsConfig.resolveOperationalProjectConfig).mockResolvedValue({
+			setupScript: "bun install\n", setupScriptLaunchMode: "parallel", env: {}, devScript: "", portCount: 0,
+		} as never);
+
+		await tmuxPtyHandlers.rerunSetupScript({ taskId: task.id });
+
+		expect(vi.mocked(auxPanes.openAuxPane)).toHaveBeenCalledWith(
+			expect.objectContaining({ purpose: "setupRerun" }),
+		);
+		expect(pty.destroySessionAwaited).not.toHaveBeenCalled();
 	});
 
 	it("asks for the tmux flavour for an unmarked task", async () => {

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -247,6 +247,39 @@ export function buildSetupStartupWrapper(opts: {
 	].join("\n") + "\n";
 }
 
+/**
+ * The re-run wrapper: the setup script alone, in a pane of its own.
+ *
+ * No `split-window`, no agent exec — a re-run happens when a session already
+ * exists, and the whole point is to leave it alone. The failure branch writes the
+ * same exit-code file the launch wrapper does, so a second failure raises the
+ * notice again through the same watch, and drops into a shell so the user can
+ * fix things by hand where the script died.
+ */
+export function buildSetupRerunScript(opts: {
+	setupPath: string;
+	shellPath: string;
+	setupExitPath: string;
+}): string {
+	const d = launchDialect();
+	return [
+		...d.header(),
+		d.runScript(opts.setupPath, { shellPath: opts.shellPath, trace: true }),
+		d.captureExitCode("S"),
+		...d.branchOnFailure("S", {
+			fail: indentLines(2, [
+				d.print(d.style("✗ Setup failed (exit %s)", "error"), { args: [d.exitCodeArg("S")] }),
+				d.writeExitCodeFile("S", opts.setupExitPath),
+				d.execReplacing(d.interactiveShellCommand(opts.shellPath)),
+			]),
+		}),
+		d.print(d.style("✓ Setup done", "success")),
+		d.print(d.style("Closing in 15s — press any key to close now", "dim")),
+		d.readKey({ timeoutSeconds: 15 }),
+		"exit 0",
+	].join("\n") + "\n";
+}
+
 const FALLBACK_BIN_PATHS = [
 	"/opt/homebrew/bin",
 	"/usr/local/bin",

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -71,7 +71,7 @@ import {
 	type AuxPaneHandle,
 	type AuxPanePlacement,
 } from "../task-aux-panes";
-import { getPushMessage, isActive, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildSetupStartupWrapper, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
+import { getPushMessage, isActive, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildSetupRerunScript, buildSetupStartupWrapper, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
 import { assertPosixLaunchDialect, launchDialect } from "../../shared/platform-launch";
 import { buildDevServerScript } from "../dev-server-script";
 import { resolveOperationalProjectConfig } from "./settings-config";
@@ -651,8 +651,9 @@ export async function launchTaskPty(
 	// Any launch supersedes the previous run's setup verdict — including the
 	// "start anyway" relaunch, which is itself the answer to that verdict.
 	if (task.setupFailedExitCode != null) {
-		await data.updateTask(project, task.id, { setupFailedExitCode: null });
+		await data.updateTask(project, task.id, { setupFailedExitCode: null, setupFailedAgentRunning: null });
 		task.setupFailedExitCode = null;
+		task.setupFailedAgentRunning = null;
 	}
 	stopSetupFailureWatch(task.id);
 	clearSetupExitCode(task.id);
@@ -842,9 +843,16 @@ export async function launchTaskPty(
 		await writeLaunchScript(startupPath, startupScript);
 		tmuxCmd = buildScriptRunnerCommand(startupPath, { shellPath: userShell });
 		isSetupWrapper = true;
+		// Which offer the pane may make is decided HERE, where the wrapper's shape is
+		// known — a parallel tmux launch has already split the agent pane above, so a
+		// later failure finds it alive. Native ignores launchMode and always gates.
+		const agentRunning = !nativeBackend && setupScriptLaunchMode === "parallel";
 		// Only this process can see the wrapper's verdict — see setup-failure-watch.
 		watchSetupFailure(task.id, async (exitCode) => {
-			const updated = await data.updateTask(project, task.id, { setupFailedExitCode: exitCode });
+			const updated = await data.updateTask(project, task.id, {
+				setupFailedExitCode: exitCode,
+				setupFailedAgentRunning: agentRunning,
+			});
 			getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 		});
 	}
@@ -1788,6 +1796,78 @@ async function restartTask(params: { taskId: string }): Promise<string> {
 	const url = `ws://localhost:${pty.getPtyPort()}?session=${params.taskId}`;
 	log.info("← restartTask", { url });
 	return url;
+}
+
+/** Forget a setup verdict and tell every viewer, so the notice cannot come back. */
+async function clearSetupFailure(project: Project, task: Task): Promise<void> {
+	stopSetupFailureWatch(task.id);
+	clearSetupExitCode(task.id);
+	const updated = await data.updateTask(project, task.id, { setupFailedExitCode: null, setupFailedAgentRunning: null });
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+}
+
+async function dismissSetupFailure(params: { taskId: string }): Promise<void> {
+	log.info("→ dismissSetupFailure", { taskId: params.taskId.slice(0, 8) });
+	const { task, project } = await findTaskAcrossProjects(params.taskId);
+	if (!task || !project) throw new Error(`Cannot dismiss: task ${params.taskId} not found`);
+	await clearSetupFailure(project, task);
+}
+
+async function rerunSetupScript(params: { taskId: string }): Promise<void> {
+	log.info("→ rerunSetupScript", { taskId: params.taskId.slice(0, 8) });
+	const { task, project } = await findTaskAcrossProjects(params.taskId);
+	if (!task || !project) throw new Error(`Cannot re-run setup: task ${params.taskId} not found`);
+	if (!task.worktreePath) throw new Error("Task has no worktree");
+
+	const resolved = await resolveOperationalProjectConfig(project, task.worktreePath, { foreignCode: task.foreignCode });
+	if (!resolved.setupScript.trim()) throw new Error("No setup script configured");
+
+	const prefix = dev3TaskTempPath(task.id);
+	const ext = launchDialect().scriptExtension;
+	const setupPath = `${prefix}-setup${ext}`;
+	const rerunPath = `${prefix}-setup-rerun${ext}`;
+	await writeLaunchScript(setupPath, resolved.setupScript + "\n");
+
+	// Clear BEFORE the pane opens: the click is the answer to the old verdict, and
+	// the fresh watch below is what brings the notice back if this run fails too.
+	await clearSetupFailure(project, task);
+
+	const shellPath = getUserShell();
+	await writeLaunchScript(rerunPath, buildSetupRerunScript({ setupPath, shellPath, setupExitPath: setupExitCodePath(task.id) }));
+
+	const env = {
+		...(resolved.env ?? {}),
+		...buildTaskLifecycleEnv(project, task, task.worktreePath),
+	};
+	const ports = portPool.getPortAssignments(task.id);
+	if (ports.length > 0) Object.assign(env, portPool.buildPortEnv(ports));
+
+	// A re-run starts no agent, so the answer is the same one the launch computed —
+	// and it must be recomputed rather than read back from the task, which a
+	// dismissal may already have cleared.
+	const agentRunning = taskTerminalBackendIdentity(task) !== "native"
+		&& (resolved.setupScriptLaunchMode ?? "parallel") === "parallel";
+	watchSetupFailure(task.id, async (exitCode) => {
+		const updated = await data.updateTask(project, task.id, {
+			setupFailedExitCode: exitCode,
+			setupFailedAgentRunning: agentRunning,
+		});
+		getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+	});
+
+	const handle = await openAuxPane({
+		task,
+		purpose: "setupRerun",
+		placement: "below",
+		size: "35%",
+		cwd: task.worktreePath,
+		env,
+		socket: task.tmuxSocket ?? DEFAULT_TMUX_SOCKET,
+		title: auxPaneTitle("setupRerun"),
+		tmuxCommand: buildScriptRunnerCommand(rerunPath, { shellPath }),
+		nativeLaunch: generatedScriptLaunch(rerunPath),
+	});
+	log.info("← rerunSetupScript done", { taskId: params.taskId.slice(0, 8), paneId: handle.paneId });
 }
 
 async function getProjectPtyUrl(params: { projectId: string }): Promise<string> {
@@ -3211,4 +3291,6 @@ export const tmuxPtyHandlers = {
 	spawnBugHuntersInTask,
 	resumeTask,
 	restartTask,
+	rerunSetupScript,
+	dismissSetupFailure,
 };

--- a/src/bun/task-aux-panes.ts
+++ b/src/bun/task-aux-panes.ts
@@ -51,7 +51,7 @@ import { createLogger } from "./logger";
 const log = createLogger("task-aux-panes");
 
 /** Which action owns the pane. One live pane per purpose per task, at most. */
-export type AuxPanePurpose = "devServer" | "gitOp" | "columnAgent";
+export type AuxPanePurpose = "devServer" | "gitOp" | "columnAgent" | "setupRerun";
 
 /** Where the new pane lands relative to the pane it splits off. */
 export type AuxPanePlacement = "right" | "below";
@@ -124,6 +124,7 @@ const AUX_PANE_PURPOSES: Record<AuxPanePurpose, AuxPanePurposeMeta> = {
 	devServer: { scriptSuffix: "dev", title: "Dev Server", provenReplace: false },
 	gitOp: { scriptSuffix: "git-", title: "Git", provenReplace: false },
 	columnAgent: { scriptSuffix: "col-agent", title: "Column Agent", provenReplace: true },
+	setupRerun: { scriptSuffix: "setup-rerun", title: "Setup", provenReplace: false },
 };
 
 /** The substring that identifies a purpose's pane in a launch command. */

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -3,6 +3,7 @@ import type { Task, Project, TaskSessionState } from "../../shared/types";
 import { getTaskOpenMode, taskClosedHomeRoute, type AppAction, type Route } from "../state";
 import { api } from "../rpc";
 import { useT } from "../i18n";
+import { toast } from "../toast";
 import { trackEvent } from "../analytics";
 import { moveTaskToStatus } from "../utils/moveTaskToStatus";
 import TerminalView from "../TerminalView";
@@ -94,13 +95,38 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 	const [hibernated, setHibernated] = useState(false);
 	const [restarting, setRestarting] = useState(false);
 	// A `setupScript` that exits non-zero leaves a live shell behind, so nothing
-	// else in here reads as broken — the pane just never got its agent. Dismissing
-	// only hides the card; every launch clears the flag, which re-arms it.
+	// else in here reads as broken. What the pane may OFFER depends on whether the
+	// agent was already running when it failed — see `setupFailedAgentRunning`.
+	// Dismissing clears the verdict in the task, so it cannot come back when this
+	// component is re-created (key={taskId}) or in a second viewer.
 	const setupFailedExitCode = task?.setupFailedExitCode ?? null;
+	const setupFailedAgentRunning = task?.setupFailedAgentRunning === true;
 	const [setupFailureDismissed, setSetupFailureDismissed] = useState(false);
+	const [rerunningSetup, setRerunningSetup] = useState(false);
 	useEffect(() => {
 		if (setupFailedExitCode == null) setSetupFailureDismissed(false);
 	}, [setupFailedExitCode]);
+
+	const dismissSetupFailure = useCallback(() => {
+		setSetupFailureDismissed(true);
+		api.request.dismissSetupFailure({ taskId }).catch((err) => {
+			console.error("[TaskTerminal] dismissSetupFailure failed:", err);
+		});
+	}, [taskId]);
+
+	async function handleRerunSetup() {
+		setRerunningSetup(true);
+		try {
+			await api.request.rerunSetupScript({ taskId });
+			setSetupFailureDismissed(true);
+			if (isNative) await fetchPaneState(taskId);
+		} catch (err) {
+			console.error("[TaskTerminal] rerunSetupScript failed:", err);
+			toast.error(t("terminal.setupRerunFailed", { error: String(err) }));
+		} finally {
+			setRerunningSetup(false);
+		}
+	}
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// ── Native multi-pane state ─────────────────────────────────────────────────
@@ -444,6 +470,100 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		}
 	}
 
+	const showSetupFailure = setupFailedExitCode != null && !setupFailureDismissed;
+	const setupFailedTitle = t("terminal.setupFailedTitle", { code: String(setupFailedExitCode) });
+	const rerunSetupLabel = rerunningSetup ? t("terminal.setupRerunning") : t("terminal.setupFailedRerun");
+
+	// The agent is alive and typing into it still works, so this must not be a
+	// modal: a dialog here would cover a running session and — with autofocus —
+	// swallow the next Enter into a button. A strip states the fact and offers the
+	// only action that helps, which is re-running setup, never a session restart.
+	const setupFailedStrip = showSetupFailure && setupFailedAgentRunning && (
+		<div
+			data-testid="terminal-setup-failed-strip"
+			role="status"
+			className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 px-3 py-2 rounded-lg bg-raised border border-danger/40 shadow-lg max-w-[calc(100%-1rem)]"
+		>
+			<span className="text-danger shrink-0">⚠</span>
+			<div className="min-w-0">
+				<div className="text-fg text-sm font-medium truncate">{setupFailedTitle}</div>
+				<div className="text-fg-3 text-xs">{t("terminal.setupFailedAgentRunningDesc")}</div>
+			</div>
+			<button
+				onClick={handleRerunSetup}
+				disabled={rerunningSetup}
+				className="shrink-0 px-3 py-1.5 bg-elevated text-fg-2 rounded text-xs font-medium hover:bg-elevated-hover transition-colors disabled:opacity-50"
+			>
+				{rerunSetupLabel}
+			</button>
+			<button
+				onClick={dismissSetupFailure}
+				aria-label={t("terminal.setupFailedDismiss")}
+				className="shrink-0 px-2 py-1 text-fg-3 rounded hover:bg-elevated-hover hover:text-fg transition-colors"
+			>
+				✕
+			</button>
+		</div>
+	);
+
+	// The agent never started, so nothing is behind this to interrupt: a dialog is
+	// honest here. Re-running setup leads, because starting the agent on a broken
+	// worktree is the fallback, not the fix.
+	const setupFailedCard = showSetupFailure && !setupFailedAgentRunning && (
+		<div className="absolute inset-0 z-20 flex items-center justify-center p-4" onClick={dismissSetupFailure}>
+			<div
+				data-testid="terminal-setup-failed-card"
+				role="alertdialog"
+				aria-labelledby="setup-failed-title"
+				onClick={(event) => event.stopPropagation()}
+				onKeyDown={(event) => {
+					if (event.key !== "Escape") return;
+					event.stopPropagation();
+					dismissSetupFailure();
+				}}
+				className="relative bg-raised border border-edge rounded-lg p-6 space-y-4 w-[28rem] max-w-[calc(100vw-2rem)] shadow-2xl"
+			>
+				<button
+					autoFocus
+					onClick={dismissSetupFailure}
+					aria-label={t("terminal.setupFailedDismiss")}
+					className="absolute top-3 right-3 px-2 py-1 text-fg-3 rounded hover:bg-elevated-hover hover:text-fg transition-colors"
+				>
+					✕
+				</button>
+				<div id="setup-failed-title" className="flex items-center gap-2 font-medium text-danger pr-8">
+					<span className="text-lg">⚠</span>
+					<span>{setupFailedTitle}</span>
+				</div>
+				<p className="text-fg-3 text-sm">{t("terminal.setupFailedDesc")}</p>
+				<div className="flex gap-3 pt-2">
+					<button
+						onClick={handleRerunSetup}
+						disabled={rerunningSetup}
+						className="flex-1 px-4 py-2 bg-accent-fill text-white rounded text-sm font-medium hover:bg-accent-fill-hover transition-colors disabled:opacity-50"
+					>
+						{rerunSetupLabel}
+					</button>
+					<button
+						onClick={handleStartFresh}
+						disabled={restarting}
+						className="flex-1 px-4 py-2 bg-elevated text-fg-2 rounded text-sm font-medium hover:bg-elevated-hover transition-colors disabled:opacity-50"
+					>
+						{restarting ? t("terminal.connecting") : t("terminal.setupFailedStartAnyway")}
+					</button>
+				</div>
+				<p className="text-fg-muted text-xs">{t("terminal.setupFailedHint")}</p>
+			</div>
+		</div>
+	);
+
+	const setupFailedNotice = (
+		<>
+			{setupFailedStrip}
+			{setupFailedCard}
+		</>
+	);
+
 	// A closed task has no workspace left to recover, so the only thing this pane
 	// owes the user is the way out — same empty state the task view shows when no
 	// task is selected.
@@ -763,6 +883,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 						/>
 					)}
 					<MobilePaneCarousel taskId={taskId}>{nativeTerminalArea}</MobilePaneCarousel>
+					{setupFailedNotice}
 					{touchInput && focusedPaneHandle && (
 						<div className={rawMode ? "hidden" : "contents"}>
 							<TerminalComposer handle={focusedPaneHandle} task={task} project={project} dispatch={dispatch} apiRef={composerApiRef} />
@@ -873,6 +994,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 						</div>
 					</div>
 				)}
+				{setupFailedNotice}
 				{touchInput && focusedPaneHandle && (
 					<div className={rawMode ? "hidden" : "contents"}>
 						<TerminalComposer handle={focusedPaneHandle} task={task} project={project} dispatch={dispatch} apiRef={composerApiRef} />
@@ -915,39 +1037,6 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		</div>
 	);
 
-	const setupFailedCard = setupFailedExitCode != null && !setupFailureDismissed && (
-		<div className="absolute inset-0 z-20 flex items-center justify-center p-4">
-			<div
-				data-testid="terminal-setup-failed-card"
-				role="alertdialog"
-				aria-labelledby="setup-failed-title"
-				className="bg-raised border border-edge rounded-lg p-6 space-y-4 w-[28rem] max-w-[calc(100vw-2rem)] shadow-2xl"
-			>
-				<div id="setup-failed-title" className="flex items-center gap-2 font-medium text-danger">
-					<span className="text-lg">⚠</span>
-					<span>{t("terminal.setupFailedTitle", { code: String(setupFailedExitCode) })}</span>
-				</div>
-				<p className="text-fg-3 text-sm">{t("terminal.setupFailedDesc")}</p>
-				<div className="flex gap-3 pt-2">
-					<button
-						autoFocus
-						onClick={handleStartFresh}
-						disabled={restarting}
-						className="flex-1 px-4 py-2 bg-accent-fill text-white rounded text-sm font-medium hover:bg-accent-fill-hover transition-colors disabled:opacity-50"
-					>
-						{restarting ? t("terminal.connecting") : t("terminal.setupFailedStartAnyway")}
-					</button>
-					<button
-						onClick={() => setSetupFailureDismissed(true)}
-						className="flex-1 px-4 py-2 bg-elevated text-fg-2 rounded text-sm font-medium hover:bg-elevated-hover transition-colors"
-					>
-						{t("terminal.setupFailedShowLog")}
-					</button>
-				</div>
-				<p className="text-fg-muted text-xs">{t("terminal.setupFailedHint")}</p>
-			</div>
-		</div>
-	);
 
 	return (
 		<div className="relative h-full w-full flex flex-col overflow-hidden">
@@ -971,14 +1060,14 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 					<MobileWindowCarousel taskId={taskId} onSwitch={() => setWindowEpoch((e) => e + 1)}>
 						<MobilePaneCarousel taskId={taskId} refreshKey={windowEpoch}>{terminalArea}</MobilePaneCarousel>
 					</MobileWindowCarousel>
-					{setupFailedCard}
+					{setupFailedNotice}
 				</div>
 			) : (
 				<div className="relative isolate flex-1 min-h-0 overflow-hidden">
 					{terminalArea}
 					{ptyUrl && <PaneZoomBadge taskId={taskId} />}
 					{ptyUrl && <ClosePanePicker taskId={taskId} />}
-					{setupFailedCard}
+					{setupFailedNotice}
 				</div>
 			)}
 			{touchInput && termHandle && (

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -11,6 +11,8 @@ vi.mock("../../rpc", () => ({
 			getPtyUrl: vi.fn(),
 			resumeTask: vi.fn(),
 			restartTask: vi.fn(),
+			rerunSetupScript: vi.fn(),
+			dismissSetupFailure: vi.fn(),
 			moveTask: vi.fn(),
 			cancelTaskPreparation: vi.fn(),
 			checkWorktreeExists: vi.fn(),
@@ -703,11 +705,13 @@ describe("TaskTerminal", () => {
 		});
 	});
 	// A failed setupScript leaves a live shell in the pane, so nothing else here
-	// reads as broken — the agent simply never started. The card is the only way
-	// back to the task's prompt.
-	describe("setup-failed recovery card", () => {
+	// reads as broken. Which offer the pane may make depends on whether the agent
+	// was already running when setup failed — see `setupFailedAgentRunning`.
+	describe("setup-failure notice", () => {
 		beforeEach(() => {
 			mockedApi.request.getPtyUrl.mockResolvedValue({ url: "ws://localhost:1234" });
+			mockedApi.request.dismissSetupFailure.mockResolvedValue(undefined);
+			mockedApi.request.rerunSetupScript.mockResolvedValue(undefined);
 		});
 
 		it("stays hidden while the setup script succeeded", async () => {
@@ -717,24 +721,87 @@ describe("TaskTerminal", () => {
 
 			await waitFor(() => expect(screen.getByTestId("terminal-view")).toBeInTheDocument());
 			expect(screen.queryByTestId("terminal-setup-failed-card")).not.toBeInTheDocument();
+			expect(screen.queryByTestId("terminal-setup-failed-strip")).not.toBeInTheDocument();
 		});
 
-		it("offers the exit code and both ways out when setup failed", async () => {
-			await act(async () => {
-				renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 127 })] });
+		describe("agent never started (blocking / native launch)", () => {
+			it("offers the exit code, a setup re-run and the agent as a fallback", async () => {
+				await act(async () => {
+					renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 127 })] });
+				});
+
+				const card = await screen.findByTestId("terminal-setup-failed-card");
+				expect(card).toHaveTextContent("127");
+				expect(screen.getByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
+				expect(screen.getByRole("button", { name: /start agent anyway/i })).toBeInTheDocument();
+				// The pane keeps running underneath — the card never replaces the log.
+				expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
 			});
 
-			const card = await screen.findByTestId("terminal-setup-failed-card");
-			expect(card).toHaveTextContent("127");
-			expect(screen.getByRole("button", { name: /start agent anyway/i })).toBeInTheDocument();
-			expect(screen.getByRole("button", { name: /show setup log/i })).toBeInTheDocument();
-			// The pane keeps running underneath — the card never replaces the log.
-			expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+			// The old card autofocused the session-destroying button, so the next Enter
+			// typed into a terminal landed on it.
+			it("never autofocuses the destructive button", async () => {
+				await act(async () => {
+					renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 1 })] });
+				});
+
+				await screen.findByTestId("terminal-setup-failed-card");
+				expect(screen.getByRole("button", { name: /start agent anyway/i })).not.toHaveFocus();
+			});
+
+			it("relaunches the agent without re-running setup", async () => {
+				const user = userEvent.setup();
+				mockedApi.request.restartTask.mockResolvedValue("ws://localhost:4321?session=t1");
+
+				await act(async () => {
+					renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 1 })] });
+				});
+
+				await screen.findByTestId("terminal-setup-failed-card");
+				await act(async () => {
+					await user.click(screen.getByRole("button", { name: /start agent anyway/i }));
+				});
+
+				expect(mockedApi.request.restartTask).toHaveBeenCalledWith({ taskId: "t1" });
+			});
 		});
 
-		it("relaunches the agent without re-running setup", async () => {
+		describe("agent already running (parallel tmux launch)", () => {
+			const runningTask = () => makeTask({ setupFailedExitCode: 1, setupFailedAgentRunning: true });
+
+			// A dialog over a live agent covers the session and swallows keystrokes.
+			it("shows a strip instead of a dialog, with no restart offer", async () => {
+				await act(async () => {
+					renderTerminal({ tasks: [runningTask()] });
+				});
+
+				await screen.findByTestId("terminal-setup-failed-strip");
+				expect(screen.queryByTestId("terminal-setup-failed-card")).not.toBeInTheDocument();
+				expect(screen.queryByRole("button", { name: /start agent anyway/i })).not.toBeInTheDocument();
+				expect(screen.getByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
+			});
+
+			it("re-runs setup without touching the session", async () => {
+				const user = userEvent.setup();
+
+				await act(async () => {
+					renderTerminal({ tasks: [runningTask()] });
+				});
+
+				await screen.findByTestId("terminal-setup-failed-strip");
+				await act(async () => {
+					await user.click(screen.getByRole("button", { name: /re-run setup/i }));
+				});
+
+				expect(mockedApi.request.rerunSetupScript).toHaveBeenCalledWith({ taskId: "t1" });
+				expect(mockedApi.request.restartTask).not.toHaveBeenCalled();
+			});
+		});
+
+		// A local-only dismissal came back every time this component was re-created
+		// (key={taskId} on task switch), which read as a popup that cannot be closed.
+		it("clears the verdict in the task when dismissed", async () => {
 			const user = userEvent.setup();
-			mockedApi.request.restartTask.mockResolvedValue("ws://localhost:4321?session=t1");
 
 			await act(async () => {
 				renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 1 })] });
@@ -742,25 +809,11 @@ describe("TaskTerminal", () => {
 
 			await screen.findByTestId("terminal-setup-failed-card");
 			await act(async () => {
-				await user.click(screen.getByRole("button", { name: /start agent anyway/i }));
-			});
-
-			expect(mockedApi.request.restartTask).toHaveBeenCalledWith({ taskId: "t1" });
-		});
-
-		it("dismisses to the setup log without touching the session", async () => {
-			const user = userEvent.setup();
-
-			await act(async () => {
-				renderTerminal({ tasks: [makeTask({ setupFailedExitCode: 1 })] });
-			});
-
-			await screen.findByTestId("terminal-setup-failed-card");
-			await act(async () => {
-				await user.click(screen.getByRole("button", { name: /show setup log/i }));
+				await user.click(screen.getByRole("button", { name: /dismiss/i }));
 			});
 
 			expect(screen.queryByTestId("terminal-setup-failed-card")).not.toBeInTheDocument();
+			expect(mockedApi.request.dismissSetupFailure).toHaveBeenCalledWith({ taskId: "t1" });
 			expect(mockedApi.request.restartTask).not.toHaveBeenCalled();
 			expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
 		});

--- a/src/mainview/components/task-info-panel/TaskScripts.tsx
+++ b/src/mainview/components/task-info-panel/TaskScripts.tsx
@@ -15,6 +15,7 @@ import { useT } from "../../i18n";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import Tooltip from "../Tooltip";
 import { ScriptsIcon } from "../TaskIcons";
+import { useResolvedTaskProject } from "./useResolvedTaskProject";
 
 const DEFAULT_PLACEMENT_IDX = SCRIPT_PLACEMENTS.indexOf("right");
 
@@ -96,6 +97,12 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 	placementIdxRef.current = placementIdx;
 	const taskRef = useRef(task);
 	taskRef.current = task;
+	// The project's own setupScript is not a package.json script, so it is a pinned
+	// row rather than a list entry. It lives here because re-running setup after
+	// dismissing the failure notice is a rare recovery action, and the manifest puts
+	// those in an existing overflow instead of a new always-visible button.
+	const resolvedProject = useResolvedTaskProject(task, project);
+	const hasSetupScript = !!resolvedProject.setupScript?.trim();
 
 	const refresh = useCallback(async () => {
 		try {
@@ -211,6 +218,19 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 		};
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [task.id, isTaskActive]);
+
+	async function runSetupScript() {
+		setBusy(true);
+		setError(null);
+		try {
+			await api.request.rerunSetupScript({ taskId: task.id });
+			closeDropdown();
+		} catch (err) {
+			setError(t("scripts.error.rerunSetupFailed", { error: String(err) }));
+		} finally {
+			setBusy(false);
+		}
+	}
 
 	async function launch(name: string, source: ScriptSource, placement: ScriptPlacement) {
 		setBusy(true);
@@ -402,6 +422,18 @@ export default function TaskScripts({ task, project, isTaskActive }: TaskScripts
 									className="w-full bg-base border border-edge rounded-lg px-2.5 py-1.5 text-sm text-fg placeholder:text-fg-muted focus:border-accent"
 								/>
 							</div>
+						)}
+
+						{hasSetupScript && (
+							<button
+								data-testid="scripts-rerun-setup"
+								onClick={runSetupScript}
+								disabled={busy}
+								className="flex-shrink-0 w-full text-left px-3 py-2 border-b border-edge hover:bg-elevated-hover disabled:opacity-50"
+							>
+								<div className="text-sm text-fg-2">{t("scripts.rerunSetup")}</div>
+								<div className="text-micro text-fg-3">{t("scripts.rerunSetupDesc")}</div>
+							</button>
 						)}
 
 						{/* Scrollable list */}

--- a/src/mainview/i18n/translations/en/scripts.ts
+++ b/src/mainview/i18n/translations/en/scripts.ts
@@ -23,6 +23,9 @@ const scripts = {
 	"scripts.picker.cancel": "Cancel",
 	"scripts.picker.back": "Back",
 	"scripts.error.runFailed": "Failed to run \"{name}\": {error}",
+	"scripts.error.rerunSetupFailed": "Could not re-run setup: {error}",
+	"scripts.rerunSetup": "Re-run project setup",
+	"scripts.rerunSetupDesc": "Runs the project's setup script in its own pane. The agent keeps running.",
 };
 
 export default scripts;

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -34,8 +34,12 @@ const terminal = {
 	"terminal.setupFailedTitle": "Setup failed (exit {code})",
 	"terminal.setupFailedDesc": "The project setup script did not finish, so the agent was not started. You can start it anyway — the task prompt is preserved.",
 	"terminal.setupFailedStartAnyway": "Start agent anyway",
-	"terminal.setupFailedShowLog": "Show setup log",
-	"terminal.setupFailedHint": "Dependencies may be missing. Setup will not be re-run.",
+	"terminal.setupFailedRerun": "Re-run setup",
+	"terminal.setupRerunning": "Running setup…",
+	"terminal.setupRerunFailed": "Could not re-run setup: {error}",
+	"terminal.setupFailedDismiss": "Dismiss",
+	"terminal.setupFailedAgentRunningDesc": "The agent is running — dependencies may be missing.",
+	"terminal.setupFailedHint": "Dependencies may be missing. Re-running setup leaves the agent alone; starting it fresh does not.",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Terminal panes",

--- a/src/mainview/i18n/translations/es/scripts.ts
+++ b/src/mainview/i18n/translations/es/scripts.ts
@@ -23,6 +23,9 @@ const scripts = {
 	"scripts.picker.cancel": "Cancelar",
 	"scripts.picker.back": "Atrás",
 	"scripts.error.runFailed": "Error al ejecutar \"{name}\": {error}",
+	"scripts.error.rerunSetupFailed": "No se pudo volver a ejecutar el setup: {error}",
+	"scripts.rerunSetup": "Volver a ejecutar el setup del proyecto",
+	"scripts.rerunSetupDesc": "Ejecuta el script de setup del proyecto en su propio panel. El agente sigue en marcha.",
 };
 
 export default scripts;

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -34,8 +34,12 @@ const terminal = {
 	"terminal.setupFailedTitle": "El setup falló (código {code})",
 	"terminal.setupFailedDesc": "El script de configuración del proyecto no terminó, así que el agente no se inició. Puedes iniciarlo igualmente — el prompt de la tarea se conserva.",
 	"terminal.setupFailedStartAnyway": "Iniciar el agente igualmente",
-	"terminal.setupFailedShowLog": "Ver el log del setup",
-	"terminal.setupFailedHint": "Puede que falten dependencias. El setup no se volverá a ejecutar.",
+	"terminal.setupFailedRerun": "Volver a ejecutar el setup",
+	"terminal.setupRerunning": "Ejecutando el setup…",
+	"terminal.setupRerunFailed": "No se pudo volver a ejecutar el setup: {error}",
+	"terminal.setupFailedDismiss": "Cerrar",
+	"terminal.setupFailedAgentRunningDesc": "El agente está en marcha — puede que falten dependencias.",
+	"terminal.setupFailedHint": "Puede que falten dependencias. Volver a ejecutar el setup no toca al agente; iniciarlo de cero sí.",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Paneles del terminal",

--- a/src/mainview/i18n/translations/ru/scripts.ts
+++ b/src/mainview/i18n/translations/ru/scripts.ts
@@ -23,6 +23,9 @@ const scripts = {
 	"scripts.picker.cancel": "Отмена",
 	"scripts.picker.back": "Назад",
 	"scripts.error.runFailed": "Не удалось запустить \"{name}\": {error}",
+	"scripts.error.rerunSetupFailed": "Не удалось перезапустить setup: {error}",
+	"scripts.rerunSetup": "Перезапустить setup проекта",
+	"scripts.rerunSetupDesc": "Запускает setup-скрипт проекта в отдельном пейне. Агент продолжает работать.",
 };
 
 export default scripts;

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -34,8 +34,12 @@ const terminal = {
 	"terminal.setupFailedTitle": "Setup упал (код {code})",
 	"terminal.setupFailedDesc": "Скрипт настройки проекта не доработал, поэтому агент не был запущен. Его можно запустить всё равно — промпт задачи сохранён.",
 	"terminal.setupFailedStartAnyway": "Всё равно запустить агента",
-	"terminal.setupFailedShowLog": "Показать лог setup",
-	"terminal.setupFailedHint": "Зависимости могут быть не установлены. Setup повторно не запустится.",
+	"terminal.setupFailedRerun": "Перезапустить setup",
+	"terminal.setupRerunning": "Setup идёт…",
+	"terminal.setupRerunFailed": "Не удалось перезапустить setup: {error}",
+	"terminal.setupFailedDismiss": "Закрыть",
+	"terminal.setupFailedAgentRunningDesc": "Агент работает — зависимостей может не быть.",
+	"terminal.setupFailedHint": "Зависимостей может не быть. Перезапуск setup агента не трогает, запуск с нуля — трогает.",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Панели терминала",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2039,11 +2039,18 @@ export interface Task {
 	/**
 	 * Exit code of a `setupScript` that failed during launch, reported by the
 	 * setup wrapper itself (the script runs inside the pane, so bun cannot see
-	 * its result). Non-null means the agent was never started in `blocking` /
-	 * native launches; the task pane offers to start it anyway. Cleared by the
-	 * next launch.
+	 * its result). Cleared by the next launch, by re-running setup, and by the
+	 * user dismissing the notice.
 	 */
 	setupFailedExitCode?: number | null;
+	/**
+	 * Whether the agent was already running when that setup failed. A `parallel`
+	 * tmux launch splits the agent pane BEFORE setup, so the failure finds a live
+	 * agent; `blocking` and native launches gate the agent behind setup, so it
+	 * never started. The two need opposite offers — restarting the session is
+	 * recovery in one case and destruction of a working agent in the other.
+	 */
+	setupFailedAgentRunning?: boolean | null;
 	/** Additive lifecycle runtime hint; older app versions ignore this field. */
 	runtimeState?: TaskRuntimeState;
 	/**
@@ -4373,6 +4380,20 @@ export type AppRPCSchema = {
 			restartTask: {
 				params: { taskId: string };
 				response: string;
+			};
+			/**
+			 * Re-run the project's `setupScript` in its own auxiliary pane, leaving the
+			 * agent and every other pane untouched. Clears the previous setup verdict and
+			 * arms a fresh watch, so a second failure raises the notice again.
+			 */
+			rerunSetupScript: {
+				params: { taskId: string };
+				response: void;
+			};
+			/** Drop a setup-failure verdict the user has acknowledged. */
+			dismissSetupFailure: {
+				params: { taskId: string };
+				response: void;
 			};
 			getProjectPtyUrl: {
 				params: { projectId: string };


### PR DESCRIPTION
## Summary

The "Setup failed" card in the task pane claimed the agent was never started and offered to start it anyway. That is only true for some launches, and destructive for the rest.

`buildSetupStartupWrapper` emits the agent's `tmux split-window` **before** the setup script in `parallel` mode (the default for every project) and **after** it in `blocking` mode; native sessions always gate the agent behind setup. So in the common case the failure finds a live agent, while the card said the opposite — and its primary button called `restartTask`, which destroys the whole session and relaunches without setup, taking a working agent and its context with it.

Three smaller faults shared the same root:

- The card `autoFocus`ed that destructive button, so a setup failing minutes into a session moved the keyboard out of the terminal and turned the next Enter into a session kill.
- The only way to close it was a button labelled "Show setup log", which showed nothing — the log was already on screen behind it.
- Dismissal lived in component state, and `key={taskId}` throws that away on every task switch, so the popup came back.

## What changed

- `launchTaskPty` records `Task.setupFailedAgentRunning` next to the exit code, decided where the wrapper's shape is known.
- `TaskTerminal` renders from it: a live agent gets a non-modal strip with a re-run and a ✕; a never-started agent gets the dialog, with the re-run leading and "start anyway" demoted to a fallback. Plus ✕, Escape, backdrop click, no autofocus on the destructive button, and the notice now renders on the native backend too (it never did).
- Dismissing calls `dismissSetupFailure`, which clears the verdict in the task, so it cannot return in this component or in a second viewer.
- New `rerunSetupScript` runs the setup script alone in an auxiliary pane (`openAuxPane`, purpose `setupRerun`) and arms a fresh watch, so a second failure raises the notice again. It is also a pinned row in the existing Scripts dropdown — a rare recovery action belongs in an existing overflow, not in a new always-visible button on the app's densest surface.

Reasoning and rejected alternatives: `decisions/2026/08/25/setup-failure-offer-depends-on-whether-the-agent-started.md`.

## Verification

Driven end to end against a scoped QA board with a deliberately failing setup script: the flag is recorded as `agentRunning: true` on a parallel tmux launch, the strip renders over a live agent, dismissing clears the verdict on disk, and a re-run opens its own pane and raises the strip (not the dialog) when setup fails again.

`bun run lint` clean. Renderer and CLI suites green. The bun shard fails a set of git-shell-heavy suites (`git-diff-*`, `git-clone-progress`, `merge-commit-message`, `sandbox-project`, `create-release-artifacts*`) on this machine with 5s timeouts and zero assertion errors, under a sustained load average around 15-30; none of them is reachable from the changed files.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=8a96bae4-4190-4f00-b5f2-4fffdaf72bc1) · `dev3://task/8a96bae4-4190-4f00-b5f2-4fffdaf72bc1` _(dev3 added this footer — turn it off in Settings → Tasks.)_