### PR TITLE
Suppress the update auto-restart countdown while remote access is on

### DIFF
--- a/change-logs/2026/08/25/fix-no-auto-restart-while-remote.md
+++ b/change-logs/2026/08/25/fix-no-auto-restart-while-remote.md
@@ -1,0 +1,3 @@
+Short: No auto-restart while remote is on
+
+The update toast's 5-minute auto-restart countdown no longer runs while remote access is engaged — a public tunnel that is up or coming up, or any browser attached. The toast says why and keeps the manual "Restart to Update" button, the timer stops if a remote session appears mid-countdown, and it starts a fresh five minutes once remote access goes away.

--- a/decisions/2026/08/25/remote-engaged-gates-the-update-countdown.md
+++ b/decisions/2026/08/25/remote-engaged-gates-the-update-countdown.md
@@ -1,0 +1,50 @@
+# Which meaning of "remote is active" gates the update countdown
+
+## Context
+
+The update-ready toast in `GlobalHeader.tsx` runs a 5-minute countdown and then
+restarts the app by itself. While remote access is on, the person that restart cuts
+off is the one holding a phone or a browser tab — the one who cannot see the timer.
+The countdown must not run at all in that state.
+
+## Investigation
+
+"Remote is active" is not one state in this codebase:
+
+| State | Where | Why it is or is not the gate |
+|---|---|---|
+| LAN server listening | `startRemoteAccessServer` runs unconditionally at boot (`src/bun/index.ts`) | Permanently true — gating on it would kill the countdown forever |
+| Tunnel `starting` / `connected` | `getTunnelState()`, `cloudflare-tunnel.ts` | Deliberate: on the desktop the main tunnel starts only from the Remote Access modal, never at boot |
+| Browser clients attached | `rpcClients.size`, `getConnectedClientCount()` | Somebody is literally driving the app right now |
+| Tunnel `failed` / `idle` | same | Not remote — nothing is reachable |
+| `isHeadless()` — this process *is* `dev3 remote` | `getUpdateRestartContext` | Already gated separately, and stays gated |
+
+## Decision
+
+Gate on `isRemoteAccessActive()` (`src/bun/remote-access-server.ts`), extended to
+count a tunnel in `starting` as well as `connected`, so the predicate matches the
+"remote on" state the header already paints. `getUpdateRestartContext` returns it as
+`remoteActive`; `GlobalHeader` creates the countdown interval only while it is false,
+re-reads it every 5s while the toast is up, and shows `update.remoteNoAutoRestart`
+plus the plain "Restart to Update" button when it is true. Remote coming on mid-
+countdown stops the timer; remote going away starts a fresh five minutes, because the
+machine was only just handed back.
+
+## Risks
+
+- A tunnel stuck in `starting` suppresses the countdown indefinitely. Acceptable: the
+  manual restart is always there, and the alternative is restarting under a user.
+- The 5s poll adds one cheap local RPC per 5s, and only while an update toast is on
+  screen.
+- Unknown context (RPC failed) still lets the countdown run visibly, exactly as today;
+  the auto-restart itself stays fail-closed on `headless === false`.
+
+## Alternatives considered
+
+- **Connected clients only** — a user who turned the tunnel on and put the phone down
+  would still get restarted out from under them.
+- **Tunnel only** — misses a LAN browser on a box with no cloudflared.
+- **A settings flag "remote enabled"** — no such flag exists; remote is a live state,
+  not a preference.
+- **Pause and resume the countdown** — rejected: a resumed 12 seconds is worse than a
+  fresh five minutes, and Arseny asked for the timer not to start.

--- a/src/bun/__tests__/remote-access-server.test.ts
+++ b/src/bun/__tests__/remote-access-server.test.ts
@@ -55,6 +55,7 @@ vi.mock("../jwt", () => ({
 
 vi.mock("../cloudflare-tunnel", () => ({
 	getTunnelUrl: vi.fn().mockReturnValue(null),
+	getTunnelState: vi.fn().mockReturnValue("idle"),
 }));
 
 vi.mock("../settings", () => ({
@@ -417,5 +418,38 @@ describe("closeUpstreamSocket (F5)", () => {
 	it("is a no-op for a missing upstream", () => {
 		expect(() => closeUpstreamSocket(undefined)).not.toThrow();
 		expect(() => closeUpstreamSocket(null)).not.toThrow();
+	});
+});
+
+// ================================================================
+// isRemoteAccessActive — the predicate the update countdown reads
+// ================================================================
+
+import { isRemoteAccessActive } from "../remote-access-server";
+import { getTunnelState } from "../cloudflare-tunnel";
+
+describe("isRemoteAccessActive", () => {
+	const mockedTunnelState = vi.mocked(getTunnelState);
+
+	it("is false with the tunnel idle and nobody attached", () => {
+		mockedTunnelState.mockReturnValue("idle");
+		expect(isRemoteAccessActive()).toBe(false);
+	});
+
+	// The LAN server always listens, so only a deliberate tunnel counts — and it counts
+	// from the moment the user asks for it, not once cloudflared finishes handshaking.
+	it("is true while the tunnel is still starting", () => {
+		mockedTunnelState.mockReturnValue("starting");
+		expect(isRemoteAccessActive()).toBe(true);
+	});
+
+	it("is true once the tunnel is connected", () => {
+		mockedTunnelState.mockReturnValue("connected");
+		expect(isRemoteAccessActive()).toBe(true);
+	});
+
+	it("is false when the tunnel failed", () => {
+		mockedTunnelState.mockReturnValue("failed");
+		expect(isRemoteAccessActive()).toBe(false);
 	});
 });

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -790,12 +790,19 @@ export function getConnectedClientCount(): number {
 }
 
 /**
- * Whether the app is currently reachable / being used remotely: either the
- * Cloudflare tunnel is connected, or at least one browser client is attached.
- * While true, sleep prevention is forced on regardless of the user setting.
+ * Whether the app is currently reachable / being used remotely: the Cloudflare
+ * tunnel is up (or coming up), or at least one browser client is attached.
+ * While true, sleep prevention is forced on regardless of the user setting, and
+ * the update toast refuses to run its auto-restart countdown.
+ *
+ * The LAN server itself is always listening, so "the server exists" can never be
+ * the signal — it would be permanently true. `starting` counts: the user has just
+ * asked for the tunnel deliberately, and that is the state the header already
+ * paints as remote-on.
  */
 export function isRemoteAccessActive(): boolean {
-	return getTunnelState() === "connected" || rpcClients.size > 0;
+	const tunnel = getTunnelState();
+	return tunnel === "connected" || tunnel === "starting" || rpcClients.size > 0;
 }
 
 /**

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -306,14 +306,21 @@ async function applyUpdate(): Promise<{ restarting: boolean; message?: string }>
 
 /**
  * What the update popover needs to warn before restarting: whether this is a
- * headless box at all, and how many tasks are mid-flight right now.
+ * headless box at all, whether the app is being reached remotely, and how many
+ * tasks are mid-flight right now.
  *
- * It is a WARNING, not a gate. A restart does not kill an agent — tmux sessions are
- * detached and lifecycles are rehydrated at boot — so the button stays enabled; the
- * count just lets someone on a phone decide to wait a minute.
+ * The task count is a WARNING, not a gate. A restart does not kill an agent — tmux
+ * sessions are detached and lifecycles are rehydrated at boot — so the button stays
+ * enabled; the count just lets someone on a phone decide to wait a minute.
+ *
+ * `remoteActive` IS a gate, but only over the unattended countdown: nobody in a
+ * browser can see a timer running on the desktop, so it must not fire under them.
+ * The manual restart stays available in every state.
  */
-async function getUpdateRestartContext(): Promise<{ headless: boolean; tasksInProgress: number }> {
+async function getUpdateRestartContext(): Promise<{ headless: boolean; remoteActive: boolean; tasksInProgress: number }> {
 	const headless = isHeadless();
+	const { isRemoteAccessActive } = await import("../remote-access-server");
+	const remoteActive = isRemoteAccessActive();
 	let tasksInProgress = 0;
 	try {
 		const projects = [...await data.loadProjects(), ...await data.loadVirtualProjects()];
@@ -324,7 +331,7 @@ async function getUpdateRestartContext(): Promise<{ headless: boolean; tasksInPr
 	} catch (err) {
 		log.warn("getUpdateRestartContext: could not count in-progress tasks", { error: String(err) });
 	}
-	return { headless, tasksInProgress };
+	return { headless, remoteActive, tasksInProgress };
 }
 
 async function saveLastRoute({ route }: { route: string }): Promise<void> {

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -103,6 +103,9 @@ interface BreadcrumbSegment {
 /** Cache TTL for project task counts (30 seconds) */
 const COUNTS_CACHE_TTL = 30_000;
 
+/** How often the update toast re-reads remote/headless state while it is on screen. */
+const RESTART_CONTEXT_POLL_MS = 5_000;
+
 function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForward, canGoBack, canGoForward, updateVersion, updateAnnouncement, updateChangelog, updateDownloadStatus, remoteAccessActive, helpDiscovered, tourRunning }: GlobalHeaderProps) {
 	const t = useT();
 	const highlightHelp = !helpDiscovered && !tourRunning && HELP_ATTRACTOR_SCREENS.has(route.screen);
@@ -120,7 +123,7 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 	const overflowMenuRef = useRef<HTMLDivElement>(null);
 	const [showUpdateDropdown, setShowUpdateDropdown] = useState(false);
 	const [restarting, setRestarting] = useState(false);
-	const [restartContext, setRestartContext] = useState<{ headless: boolean; tasksInProgress: number } | null>(null);
+	const [restartContext, setRestartContext] = useState<{ headless: boolean; remoteActive: boolean; tasksInProgress: number } | null>(null);
 	const [showToast, setShowToast] = useState(false);
 	const [countdown, setCountdown] = useState(0);
 	const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -150,23 +153,39 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 	// the version the same way the popover does or the two disagree.
 	const offeredBuild = parseDisplayVersion(updateVersion ?? "");
 
-	// Show toast with 5min countdown on every update announcement — the first one
-	// and each periodic reminder for a postponed, already-downloaded version.
+	// Someone is on the far end of this app right now — a connected browser, or the
+	// public tunnel up. The countdown below must not run in that state: the person a
+	// relaunch would cut off is exactly the one who cannot see the timer.
+	const remoteEngaged = restartContext?.remoteActive === true;
+
+	// Show the toast on every update announcement — the first one and each periodic
+	// reminder for a postponed, already-downloaded version. Keeping this separate from
+	// the timer below is what lets the timer stop and start on remote state without
+	// re-opening a toast the user postponed.
 	useEffect(() => {
-		if (updateVersion) {
-			setShowToast(true);
-			setCountdown(300);
-			countdownRef.current = setInterval(() => {
-				setCountdown((prev) => {
-					if (prev <= 1) return 0;
-					return prev - 1;
-				});
-			}, 1000);
-			return () => {
-				if (countdownRef.current) clearInterval(countdownRef.current);
-			};
-		}
+		if (updateVersion) setShowToast(true);
 	}, [updateVersion, updateAnnouncement]);
+
+	// The 5-minute countdown itself. It exists only while the toast is up AND remote
+	// access is off; flipping remote on mid-countdown stops it, flipping remote off
+	// starts a fresh five minutes rather than resuming a stale one — the user only
+	// just handed the machine back.
+	useEffect(() => {
+		if (!showToast || !updateVersion) return;
+		if (remoteEngaged) {
+			setCountdown(0);
+			return;
+		}
+		setCountdown(300);
+		const id = setInterval(() => {
+			setCountdown((prev) => (prev <= 1 ? 0 : prev - 1));
+		}, 1000);
+		countdownRef.current = id;
+		return () => {
+			clearInterval(id);
+			if (countdownRef.current === id) countdownRef.current = null;
+		};
+	}, [showToast, updateVersion, updateAnnouncement, remoteEngaged]);
 
 	// Auto-restart when countdown reaches 0.
 	//
@@ -182,21 +201,28 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 	// as "this is a desktop", which is exactly how a phone tab could restart a remote
 	// server unattended. Not knowing means not restarting; the button still works.
 	useEffect(() => {
-		if (countdown === 0 && showToast && restartContext?.headless === false) {
+		if (countdown === 0 && showToast && restartContext?.headless === false && !remoteEngaged) {
 			if (countdownRef.current) clearInterval(countdownRef.current);
 			handleRestart();
 		}
-	}, [countdown, showToast, restartContext]);
+	}, [countdown, showToast, restartContext, remoteEngaged]);
 
-	// What a restart would interrupt, and whether it keeps the remote link. Fetched
-	// once per offered update rather than polled: it feeds a warning on a deliberate
-	// action, not a live indicator.
+	// What a restart would interrupt, and whether anyone is reaching this app remotely.
+	// Re-read on a slow tick WHILE THE TOAST IS UP, because the remote half of it gates
+	// an unattended restart: a phone that connects during those five minutes has to stop
+	// the timer, and a tunnel the user shuts down has to release it. Once the toast is
+	// gone this is a one-shot again — it feeds a warning on a deliberate action.
 	useEffect(() => {
 		if (!updateVersion) return;
-		api.request.getUpdateRestartContext()
-			.then(setRestartContext)
-			.catch(() => setRestartContext(null));
-	}, [updateVersion]);
+		let cancelled = false;
+		const read = () => api.request.getUpdateRestartContext()
+			.then((ctx) => { if (!cancelled) setRestartContext(ctx); })
+			.catch(() => { if (!cancelled) setRestartContext(null); });
+		read();
+		if (!showToast) return () => { cancelled = true; };
+		const id = setInterval(read, RESTART_CONTEXT_POLL_MS);
+		return () => { cancelled = true; clearInterval(id); };
+	}, [updateVersion, showToast]);
 
 	// Close whichever header dropdown is open on Escape.
 	useEscapeKey(
@@ -1074,6 +1100,11 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 								navigate({ screen: "changelog" });
 							}}
 						/>
+						{remoteEngaged && (
+							<div className="text-fg-3 text-xs mt-2" data-testid="update-remote-no-countdown">
+								{t("update.remoteNoAutoRestart")}
+							</div>
+						)}
 						<div className="flex items-center gap-2 mt-2.5">
 							<button
 								onClick={() => { dismissToast(); handleRestart(); }}

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../rpc", () => ({
 			applyUpdate: vi.fn(),
 			// The update plaque asks what a restart would interrupt (and whether it keeps
 			// the remote link) as soon as an update is offered.
-			getUpdateRestartContext: vi.fn().mockResolvedValue({ headless: false, tasksInProgress: 0 }),
+			getUpdateRestartContext: vi.fn().mockResolvedValue({ headless: false, remoteActive: false, tasksInProgress: 0 }),
 			saveLastRoute: vi.fn(),
 			renameTask: vi.fn(),
 			// `behindOrigin` > 0 keeps the pull button rendered — it hides when there is nothing to pull.
@@ -808,7 +808,7 @@ describe("GlobalHeader — update countdown", () => {
 		mockedApi.request.saveLastRoute.mockResolvedValue(undefined as any);
 		// Auto-restart now requires a KNOWN non-headless context, so each test states
 		// it — `clearAllMocks` clears calls but not an implementation a sibling set.
-		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, tasksInProgress: 0 });
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, remoteActive: false, tasksInProgress: 0 });
 	});
 
 	afterEach(() => {
@@ -909,7 +909,7 @@ describe("GlobalHeader — update countdown", () => {
 	// `dev3 remote` server, where an unattended restart from a phone tab is exactly
 	// what the quiet-window policy refuses. Not knowing means not restarting.
 	it("does NOT auto-restart on a headless box", async () => {
-		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: true, tasksInProgress: 0 });
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: true, remoteActive: false, tasksInProgress: 0 });
 		renderHeader({ screen: "dashboard" }, [project1], vi.fn(), [], { updateVersion: "1.2.3" });
 
 		act(() => { vi.advanceTimersByTime(300_000); });
@@ -926,6 +926,55 @@ describe("GlobalHeader — update countdown", () => {
 		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
 
 		expect(mockedApi.request.applyUpdate).not.toHaveBeenCalled();
+	});
+
+	// Remote access on = somebody may be driving this machine from a browser or a phone.
+	// They cannot see a countdown running on the desktop, so it must not run at all —
+	// not "run and refuse to fire". The manual button stays, with a line saying why.
+	it("never runs the countdown while remote access is engaged", async () => {
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, remoteActive: true, tasksInProgress: 0 });
+		renderHeader({ screen: "dashboard" }, [project1], vi.fn(), [], { updateVersion: "1.2.3" });
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+		expect(screen.queryByText(/Restart to Update \(\d+s\)/)).not.toBeInTheDocument();
+		expect(screen.getByText("Restart to Update")).toBeInTheDocument();
+		expect(screen.getByTestId("update-remote-no-countdown")).toBeInTheDocument();
+
+		act(() => { vi.advanceTimersByTime(300_000); });
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+		expect(mockedApi.request.applyUpdate).not.toHaveBeenCalled();
+	});
+
+	it("stops a running countdown when a remote session appears mid-flight", async () => {
+		renderHeader({ screen: "dashboard" }, [project1], vi.fn(), [], { updateVersion: "1.2.3" });
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+		act(() => { vi.advanceTimersByTime(10_000); });
+		expect(screen.getByText(/Restart to Update \(\d+s\)/)).toBeInTheDocument();
+
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, remoteActive: true, tasksInProgress: 0 });
+		await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+
+		expect(screen.queryByText(/Restart to Update \(\d+s\)/)).not.toBeInTheDocument();
+		expect(screen.getByTestId("update-remote-no-countdown")).toBeInTheDocument();
+
+		act(() => { vi.advanceTimersByTime(300_000); });
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+		expect(mockedApi.request.applyUpdate).not.toHaveBeenCalled();
+	});
+
+	// The other direction, and deliberately a FULL five minutes rather than the
+	// remainder of an old one: the machine was just handed back.
+	it("starts a fresh five minutes once remote access goes away", async () => {
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, remoteActive: true, tasksInProgress: 0 });
+		renderHeader({ screen: "dashboard" }, [project1], vi.fn(), [], { updateVersion: "1.2.3" });
+		await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+		expect(screen.queryByText(/Restart to Update \(\d+s\)/)).not.toBeInTheDocument();
+
+		mockedApi.request.getUpdateRestartContext.mockResolvedValue({ headless: false, remoteActive: false, tasksInProgress: 0 });
+		await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+
+		expect(screen.getByText(/Restart to Update \(300s\)/)).toBeInTheDocument();
+		expect(screen.queryByTestId("update-remote-no-countdown")).not.toBeInTheDocument();
 	});
 
 	it("shows an error toast and re-enables restart when applyUpdate fails (issue #813)", async () => {

--- a/src/mainview/i18n/translations/en/updates.ts
+++ b/src/mainview/i18n/translations/en/updates.ts
@@ -14,6 +14,7 @@ const updates = {
 	"update.restartBtn": "Restart to Update",
 	"update.restartCountdown": "Restart to Update ({seconds}s)",
 	"update.postponeBtn": "Postpone",
+	"update.remoteNoAutoRestart": "Remote access is on, so nothing restarts on its own. Restart when it suits you.",
 	"update.restarting": "Restarting...",
 	"update.checking": "Checking...",
 	"update.downloading": "Downloading...",

--- a/src/mainview/i18n/translations/es/updates.ts
+++ b/src/mainview/i18n/translations/es/updates.ts
@@ -14,6 +14,7 @@ const updates = {
 	"update.restartBtn": "Reiniciar para actualizar",
 	"update.restartCountdown": "Reiniciar para actualizar ({seconds}s)",
 	"update.postponeBtn": "Posponer",
+	"update.remoteNoAutoRestart": "El acceso remoto está activo, así que nada se reinicia solo. Reinicia cuando te venga bien.",
 	"update.restarting": "Reiniciando...",
 	"update.checking": "Verificando...",
 	"update.downloading": "Descargando...",

--- a/src/mainview/i18n/translations/ru/updates.ts
+++ b/src/mainview/i18n/translations/ru/updates.ts
@@ -14,6 +14,7 @@ const updates = {
 	"update.restartBtn": "Перезапустить",
 	"update.restartCountdown": "Перезапустить ({seconds}с)",
 	"update.postponeBtn": "Отложить",
+	"update.remoteNoAutoRestart": "Удалённый доступ включён — сам ничего не перезапустится. Перезапустите, когда будет удобно.",
 	"update.restarting": "Перезапуск...",
 	"update.checking": "Проверка...",
 	"update.downloading": "Загрузка...",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4511,7 +4511,7 @@ export type AppRPCSchema = {
 			};
 			getUpdateRestartContext: {
 				params: void;
-				response: { headless: boolean; tasksInProgress: number };
+				response: { headless: boolean; remoteActive: boolean; tasksInProgress: number };
 			};
 			saveLastRoute: {
 				params: { route: string };


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

The update-ready toast runs a 5-minute countdown and then restarts the app on its own. While remote access is engaged, the person that restart cuts off is the one holding a phone or a browser tab — the one who cannot see the timer. Now the timer simply does not start in that state.

**What "remote is active" means here.** The LAN server is always listening, so that can never be the signal. The gate is `isRemoteAccessActive()` — the Cloudflare tunnel up or coming up, or at least one browser client attached — extended to count a `starting` tunnel so the predicate matches the "remote on" state the header already paints. `getUpdateRestartContext` returns it as `remoteActive`; the desktop-only `headless === false` gate on the actual restart is unchanged.

- No countdown while remote is engaged: the toast shows a line saying why (`update.remoteNoAutoRestart`, en/ru/es) and keeps the plain **Restart to Update** button.
- Remote appearing mid-countdown stops the timer; remote going away starts a fresh five minutes rather than resuming a stale one.
- The toast re-reads that state every 5s while it is on screen, and only while it is on screen.

Reasoning and the states that were rejected: `decisions/2026/08/25/remote-engaged-gates-the-update-countdown.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=055e4ca5-e8aa-404d-8db1-f3871e863e50) · `dev3://task/055e4ca5-e8aa-404d-8db1-f3871e863e50`