### PR TITLE
Center header nav chevrons inside their buttons

### DIFF
--- a/change-logs/2026/08/25/fix-center-header-nav-chevrons.md
+++ b/change-logs/2026/08/25/fix-center-header-nav-chevrons.md
@@ -1,0 +1,3 @@
+Short: Header arrows sit centred again
+
+The back, forward, project-switcher and variant-switcher chevrons in the global header now centre inside their buttons instead of drifting to the left edge. On touch devices the 24px touch-target floor grows those buttons past their padding, and the glyphs had no explicit centring to follow; the back and forward chevrons were also drawn a stroke's width off-centre inside their own icon box.

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -544,13 +544,16 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 		<div className="relative z-30 flex items-center justify-between px-2.5 py-2.5 border-b border-edge flex-shrink-0 glass-header" data-collapse-on-compose>
 			{/* Breadcrumbs */}
 			<nav className="flex items-center gap-2 text-sm min-w-0" aria-label={t("nav.appHeader")}>
-				{/* Back / forward navigation — segmented history control (Safari toolbar style) */}
+				{/* Back / forward navigation — segmented history control (Safari toolbar style).
+					    Both halves centre their glyph explicitly: on a coarse pointer the 24px
+					    touch floor grows the box past its padding, and content that is not
+					    centred then parks at the left edge. */}
 				<div className="flex items-stretch flex-shrink-0 -ml-1.5 rounded-md border border-edge bg-raised overflow-hidden">
 					<Tooltip content={t("header.navBack")} detail={t("ttip.header.navBack")}>
 						<button
 							onClick={goBack}
 							disabled={!canGoBack}
-							className={`header-anim px-1.5 py-[5px] transition-colors ${
+							className={`header-anim px-1.5 py-[5px] inline-flex items-center justify-center transition-colors ${
 								canGoBack
 									? "text-fg-3 hover:text-fg hover:bg-elevated"
 									: "text-fg-muted/40 cursor-default"
@@ -565,7 +568,7 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 						<button
 							onClick={goForward}
 							disabled={!canGoForward}
-							className={`header-anim px-1.5 py-[5px] transition-colors ${
+							className={`header-anim px-1.5 py-[5px] inline-flex items-center justify-center transition-colors ${
 								canGoForward
 									? "text-fg-3 hover:text-fg hover:bg-elevated"
 									: "text-fg-muted/40 cursor-default"
@@ -619,7 +622,7 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 											onClick={() => setShowProjectDropdown((v) => !v)}
 											aria-haspopup="menu"
 											aria-expanded={showProjectDropdown}
-											className={`header-anim px-1.5 py-[3px] flex items-center transition-colors ${
+											className={`header-anim px-1.5 py-[3px] flex items-center justify-center transition-colors ${
 												showProjectDropdown ? "text-fg bg-elevated" : "text-fg-3 hover:text-fg hover:bg-elevated"
 											}`}
 											aria-label={t("header.switchProject")}

--- a/src/mainview/components/HeaderIcons.tsx
+++ b/src/mainview/components/HeaderIcons.tsx
@@ -38,11 +38,13 @@ function svgBase(className?: string, strokeWidth = 1.7): SVGProps<SVGSVGElement>
 }
 
 // 01 — Back: the chevron lunges left, a ghost echo trails off.
+// Path spans x 8.75-15.25, so its box is centred on the 24×24 viewBox — the old
+// 8-14.5 leaned a stroke's width left of centre inside the button.
 export function BackIcon({ className }: HeaderIconProps) {
 	return (
 		<svg {...svgBase(className, 2)}>
-			<path d="M14.5 5.5 8 12l6.5 6.5" className="hdr hdr-back" />
-			<path d="M14.5 5.5 8 12l6.5 6.5" className="hdr hdr-back-ghost" opacity="0" />
+			<path d="M15.25 5.5 8.75 12l6.5 6.5" className="hdr hdr-back" />
+			<path d="M15.25 5.5 8.75 12l6.5 6.5" className="hdr hdr-back-ghost" opacity="0" />
 		</svg>
 	);
 }
@@ -51,8 +53,8 @@ export function BackIcon({ className }: HeaderIconProps) {
 export function ForwardIcon({ className }: HeaderIconProps) {
 	return (
 		<svg {...svgBase(className, 2)}>
-			<path d="M9.5 5.5 16 12l-6.5 6.5" className="hdr hdr-fwd" />
-			<path d="M9.5 5.5 16 12l-6.5 6.5" className="hdr hdr-fwd-ghost" opacity="0" />
+			<path d="M8.75 5.5 15.25 12l-6.5 6.5" className="hdr hdr-fwd" />
+			<path d="M8.75 5.5 15.25 12l-6.5 6.5" className="hdr hdr-fwd-ghost" opacity="0" />
 		</svg>
 	);
 }

--- a/src/mainview/components/TaskBreadcrumbBadge.tsx
+++ b/src/mainview/components/TaskBreadcrumbBadge.tsx
@@ -60,7 +60,7 @@ function TaskBreadcrumbBadge({ task, groupMembers, agents, isFullPage, navigate,
 					aria-expanded={open}
 					aria-label={t("header.switchVariant")}
 					data-testid="variant-breadcrumb-toggle"
-					className={`header-anim px-1 py-[3px] flex items-center transition-colors ${
+					className={`header-anim px-1 py-[3px] flex items-center justify-center transition-colors ${
 						open ? "text-fg bg-elevated" : "text-fg-3 hover:text-fg hover:bg-elevated"
 					}`}
 				>


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

The back, forward, project-switcher and variant-switcher chevrons in the global header rendered off-centre inside their buttons — most visibly on a phone, where they hug the left edge of the tap target.

Two causes, both fixed:

- **No explicit centring.** Those buttons relied on padding alone. On a coarse pointer the global 24px touch-target floor (`index.css`, `@media (pointer: coarse)`) grows the box past its padding, and a `block` svg / flex child with no `justify-center` then parks at the left edge. Measured in a browser: forcing the box to 40px shifted the glyph 7px left. They now carry `inline-flex items-center justify-center` (back/forward) and `justify-center` (both dropdown chevrons).
- **Off-centre icon geometry.** `BackIcon` spanned x 8–14.5 and `ForwardIcon` x 9.5–16 in a 24×24 viewBox, so each leaned 0.75 units (0.44px at render size) out of its own box — the pair visibly splayed apart around the divider. Both are now symmetric at x 8.75–15.25.

Verified in headless Chromium: path-box centre vs button centre is `dx=0, dy=0` for all three controls, both at natural size and with the 24px touch floor applied under phone device emulation (before: `dx=-0.44 / +0.44`, and `-7.44` with an inflated box).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=72adfe5d-374f-466e-929a-add6cc678b64) · `dev3://task/72adfe5d-374f-466e-929a-add6cc678b64`