### PR TITLE
Keep the coordinator's bookkeeping out of the user's messages

### DIFF
--- a/change-logs/2026/08/25/fix-coordinator-prompt-keeps-bookkeeping-in-reasoning.md
+++ b/change-logs/2026/08/25/fix-coordinator-prompt-keeps-bookkeeping-in-reasoning.md
@@ -1,0 +1,3 @@
+Short: Coordinator status messages stay short
+
+The built-in Coordinator prompt now tells the agent to keep its internal bookkeeping — relay chains, ruled-out hypotheses, child transcripts, self-correction — in its reasoning instead of the messages the user reads, and to keep each status to one line per task plus the pending decision. The reversal rule also names its addressee: announce a reversal to the user first, saying what no longer holds, what replaces it, and who was already told the old version.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -493,8 +493,11 @@ NO CODE, and the line is precise — both halves matter.
 - Not allowed: forming an engineering judgement by reading source. That is the children's job.
 - Need a cheap re-check yourself? Use a sub-agent. Anything that touches the repository gets a real dev3 task.
 
-EVERY REPLY IS A SELF-CONTAINED STATUS. This is the rule that matters most and the one nobody guesses.
+EVERY REPLY IS A SELF-CONTAINED STATUS, AND IT IS SHORT. This is the rule that matters most and the one nobody guesses.
 The user does not see or read your conversations with child tasks. A reply that only makes sense to someone who followed the thread is worthless to them. End every message with the state of the board: which tasks exist, where each one stands, what landed, what is waiting on the user.
+Self-contained is not the same as long. You speak for a whole group of agents, so you are the one place where a hundred tasks either become a clear picture or become noise. One line per task, then the decision waiting on the user. A line that changes neither what he knows nor what he decides does not go in.
+
+KEEP YOUR BOOKKEEPING IN YOUR REASONING, NEVER IN THE USER'S SPACE. Everything you must track to do this job — who reported what, which relay went where, hypotheses you ruled out, what a child's transcript said, your own second-guessing — belongs in your thinking. Weigh it there in full, out loud, then send the conclusion alone. Anything the user reads (messages, notes, overviews) is a finished statement, not your working notes. His attention is the scarcest thing on this board: a wall of internal accounting costs him the picture just as completely as telling him nothing.
 
 THE BOARD RIDES IN ON MESSAGES. Every message dev3 delivers to you — a child reporting, a peer asking, a scheduled wake-up — ends with a \`<dev3-board>\` block: every task not parked in To Do, every task finished in the last 24 hours, and how long each one's terminal has been quiet. It is built as the message is typed, so it is seconds old. Read it and use it; do not spend a turn on \`dev3 task list\` to learn what it just told you.
 
@@ -518,7 +521,7 @@ FACTS MAY GO CHILD-TO-CHILD: a file, a line, a measurement. DECISIONS COME THROU
 
 MARK YOUR RECOMMENDATION AS RECOMMENDED. When you put options in front of the user, say which one you recommend and why. Staying neutral hands your job back to him.
 
-ANNOUNCE A REVERSAL AS A REVERSAL, out loud, and withdraw it from everyone you already passed it to.
+ANNOUNCE A REVERSAL AS A REVERSAL, TO THE USER FIRST, in one line that says what no longer holds, what replaces it, and who was already told the old version. Then withdraw it from each of them by name. Anything less leaves a child carrying a cancelled instruction as if it were current.
 
 DO NOT TURN "NOT CHECKED" INTO "BROKEN" when relaying. They are different findings, and the second one sends someone to fix working code.
 


### PR DESCRIPTION
The built-in Coordinator preamble (`COORDINATOR_PROMPT` in `src/shared/types.ts`) told the agent to send a self-contained status with every reply, but never told it what to leave out. The result is what the user actually sees on a busy board: a wall of relay chains, ruled-out theories and per-child transcript quotes, in which the state of a hundred tasks disappears. A coordinator speaks for a whole group of agents, so its output is the one place where the board either becomes clear or becomes noise.

Three edits, all prompt text:

- `EVERY REPLY IS A SELF-CONTAINED STATUS` gains `AND IT IS SHORT`, plus a paragraph saying self-contained is not the same as long: one line per task, then the decision waiting on the user, and nothing that changes neither what he knows nor what he decides.
- New rule `KEEP YOUR BOOKKEEPING IN YOUR REASONING, NEVER IN THE USER'S SPACE`. Internal accounting — who reported what, which relay went where, discarded hypotheses, a child's transcript, self-correction — is weighed in the agent's thinking and only the conclusion is sent. Names the user-facing surfaces explicitly (messages, notes, overviews) so "user space" is not read as the chat alone.
- `ANNOUNCE A REVERSAL AS A REVERSAL` gets an addressee and required content: to the user first, saying what no longer holds, what replaces it, and who was already told the old version, then withdraw it from each of them by name. Previously it said only "out loud", with no addressee, which is how a cancelled instruction keeps travelling as if current.

Existing custom prompts are untouched: the constant is only the default that Settings and per-project overrides fall back to.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=99afde4d-2b1a-4688-9d52-007b2de64cc9) · `dev3://task/99afde4d-2b1a-4688-9d52-007b2de64cc9` _(dev3 added this footer — turn it off in Settings → Tasks.)_
