### PR TITLE
Release task ports under the cross-process assignment lock

### DIFF
--- a/change-logs/2026/08/25/fix-port-release-lost-update.md
+++ b/change-logs/2026/08/25/fix-port-release-lost-update.md
@@ -1,0 +1,1 @@
+Releasing a task's ports no longer races a second app instance allocating ports at the same moment: the release now takes the same cross-process lock as allocation and re-reads the assignment file first, so a peer's just-persisted task can no longer be erased from port-assignments.json and its ports handed out twice.

--- a/decisions/2026/07/04/port-alloc-file-lock.md
+++ b/decisions/2026/07/04/port-alloc-file-lock.md
@@ -1,5 +1,11 @@
 # 102 — Serialize port allocation with a cross-process file lock
 
+> **Superseded in part by
+> [`decisions/2026/08/25/release-ports-under-the-assignment-lock.md`](../../08/25/release-ports-under-the-assignment-lock.md).**
+> The sentence below claiming `releasePorts()` keeps using the in-memory cache is
+> no longer true: release now takes the same lock and re-reads from disk. The
+> sync getters do still read the cache.
+
 ## Context
 
 `allocatePorts()` (`src/bun/port-pool.ts`) is async and `await`s an OS-level

--- a/decisions/2026/08/25/release-ports-under-the-assignment-lock.md
+++ b/decisions/2026/08/25/release-ports-under-the-assignment-lock.md
@@ -1,0 +1,64 @@
+# Release task ports under the assignment lock
+
+Supersedes part of
+[`decisions/2026/07/04/port-alloc-file-lock.md`](../../07/04/port-alloc-file-lock.md),
+which stated that only allocation is contended.
+
+## Context
+
+`allocatePorts()` has taken `withFileLock(ASSIGNMENTS_FILE, ...)` and re-read
+`port-assignments.json` from disk inside the critical section since the
+concurrent-allocation fix. `releasePorts()` did neither: it mutated the
+in-memory cache and wrote the whole map back. Two app instances share
+`~/.dev3.0` (installed app plus a dev build is a supported setup), so a release
+in one instance could overwrite an allocation the other had just persisted — a
+lost update. The erased task's ports then read as free and could be handed to a
+second task, which is exactly the overlapping-`DEV3_PORT0` failure the allocate
+side was hardened against.
+
+## Decision
+
+`releasePorts()` (`src/bun/port-pool.ts`) mirrors `allocatePorts()`: the whole
+read-decide-write section runs inside `withFileLock(ASSIGNMENTS_FILE, ...)` with
+a fresh `readFromDisk()` under the lock. The function is now `async`; its single
+production caller, the `releasePorts` lifecycle effect in
+`src/bun/lifecycle/executor.ts`, awaits it.
+
+A `FileLockTimeoutError` is caught and logged rather than thrown. Release runs
+inside teardown, whose effect policy is `continue`, so a rejection would only
+produce a generic lifecycle warning while the task record disappears anyway.
+
+The sync getters (`getPortAssignments()`, `getAllAssignments()`) deliberately
+keep reading the in-memory cache. They sit on hot paths — every dev-server
+start, every agent launch, every env build — and a stale read there costs at
+worst one redundant allocation, which the locked allocate path then resolves
+correctly.
+
+## Risks
+
+- **A timed-out release orphans its record.** Nothing else prunes
+  `port-assignments.json`, so those ports leave the allocatable map for good.
+  Bounded and cheap: at most `MAX_PORT_COUNT` (20) ports out of a 10000-port
+  range per occurrence, nothing is held at the OS level, and the explicit
+  `"Ports left assigned"` error line makes a growing file diagnosable.
+- **Older installed builds do not take this lock on release.** Until every copy
+  on the machine is updated, the race survives in the old copy. Inherent to any
+  fix of a shared-file protocol; no on-disk format changed, so old and new
+  builds read and write the same file.
+- **Teardown now waits on a lock** (5s per attempt, 3 attempts, stale locks
+  broken at 10s) where it previously never blocked. Contention here is a
+  millisecond-scale map rewrite, except against an allocation walking a nearly
+  exhausted range — where allocation is already failing.
+
+## Alternatives considered
+
+- **Prune orphaned taskIds at boot** (`rehydrateTaskLifecycles()` already loads
+  every project and task). Rejected: the task list is a snapshot, so a peer
+  instance creating a task and allocating between the snapshot and the prune
+  would have its ports revoked — reintroducing the very lost update this record
+  fixes, in a worse form.
+- **Make the release effect `"abort"`** so a failed release stops teardown.
+  Rejected: it trades a few leaked ports for a task stuck mid-teardown with a
+  live worktree.
+- **Move the sync getters onto disk reads too.** Rejected as unnecessary churn
+  on hot paths for a stale read the locked allocate path already corrects.

--- a/src/bun/__tests__/port-pool.test.ts
+++ b/src/bun/__tests__/port-pool.test.ts
@@ -165,22 +165,41 @@ describe("port-pool", () => {
 	describe("releasePorts", () => {
 		it("releases ports for a task", async () => {
 			await allocatePorts("task-r", 2);
-			const released = releasePorts("task-r");
+			const released = await releasePorts("task-r");
 			expect(released).toHaveLength(2);
 			expect(getPortAssignments("task-r")).toEqual([]);
 		});
 
-		it("returns empty array for unknown task", () => {
-			const released = releasePorts("nonexistent");
+		it("returns empty array for unknown task", async () => {
+			const released = await releasePorts("nonexistent");
 			expect(released).toEqual([]);
 		});
 
 		it("makes released ports available for re-allocation", async () => {
 			await allocatePorts("task-free", 3);
-			releasePorts("task-free");
+			await releasePorts("task-free");
 			// After release, these ports can be assigned to another task
 			const all = getAllAssignments();
 			expect(all["task-free"]).toBeUndefined();
+		});
+
+		it("does not drop a peer allocation that landed while releasing", async () => {
+			// Regression: releasePorts() rewrote port-assignments.json from the
+			// in-memory cache without the cross-process lock allocatePorts()
+			// holds. A second app instance allocating between this process's
+			// load and its save had its record silently erased, freeing its
+			// ports for a duplicate assignment. Simulate the peer by writing
+			// behind the cache, the way another process would.
+			await allocatePorts("task-old", 2);
+			const filePath = join(TEST_HOME, "port-assignments.json");
+			const onDisk = JSON.parse(readFileSync(filePath, "utf-8"));
+			onDisk["task-peer"] = [19998, 19999];
+			writeFileSync(filePath, JSON.stringify(onDisk));
+
+			await releasePorts("task-old");
+
+			_resetState();
+			expect(getPortAssignments("task-peer")).toEqual([19998, 19999]);
 		});
 	});
 

--- a/src/bun/__tests__/port-pool.test.ts
+++ b/src/bun/__tests__/port-pool.test.ts
@@ -52,12 +52,28 @@ vi.mock("node:dgram", () => ({
 	},
 }));
 
+// Real locking by default; individual tests make acquisition fail on demand.
+const lockControl = vi.hoisted(() => ({ failWith: null as Error | null }));
+
+vi.mock("../file-lock", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../file-lock")>();
+	return {
+		...actual,
+		withFileLock: (path: string, fn: () => Promise<unknown>, options?: unknown) => {
+			if (lockControl.failWith) return Promise.reject(lockControl.failWith);
+			return actual.withFileLock(path, fn, options as never);
+		},
+	};
+});
+
+import { FileLockTimeoutError } from "../file-lock";
 import { allocatePorts, releasePorts, getPortAssignments, getAllAssignments, buildPortEnv, _resetState } from "../port-pool";
 
 describe("port-pool", () => {
 	beforeEach(() => {
 		_resetState();
 		portsInUse = new Set();
+		lockControl.failWith = null;
 		mkdirSync(TEST_HOME, { recursive: true });
 	});
 
@@ -200,6 +216,28 @@ describe("port-pool", () => {
 
 			_resetState();
 			expect(getPortAssignments("task-peer")).toEqual([19998, 19999]);
+			expect(getPortAssignments("task-old")).toEqual([]);
+		});
+
+		it("leaves the assignment on disk when the lock cannot be taken", async () => {
+			// Teardown must not stall or throw on a contended lock: the effect
+			// runs with the "continue" policy, so a rejection here would only
+			// surface as a generic lifecycle warning. Swallow the timeout, keep
+			// the record intact rather than writing an unsynchronized map.
+			await allocatePorts("task-stuck", 2);
+			const filePath = join(TEST_HOME, "port-assignments.json");
+			const before = JSON.parse(readFileSync(filePath, "utf-8"));
+
+			lockControl.failWith = new FileLockTimeoutError(`${filePath}.lock`, 5000, 3);
+			const released = await releasePorts("task-stuck");
+
+			expect(released).toEqual([]);
+			expect(JSON.parse(readFileSync(filePath, "utf-8"))).toEqual(before);
+		});
+
+		it("propagates a lock failure that is not a timeout", async () => {
+			lockControl.failWith = new Error("EACCES: permission denied");
+			await expect(releasePorts("task-any")).rejects.toThrow("EACCES");
 		});
 	});
 

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -738,7 +738,7 @@ export async function executeLifecycleEffect(
 			await killPreparationProcesses(ctx.task.id);
 			return {};
 		case "releasePorts":
-			portPool.releasePorts(ctx.task.id);
+			await portPool.releasePorts(ctx.task.id);
 			return {};
 		case "sendEvent":
 			return { followUp: effect.event };

--- a/src/bun/port-pool.ts
+++ b/src/bun/port-pool.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { createSocket } from "node:dgram";
 import { createServer } from "node:net";
 import { createLogger } from "./logger";
-import { withFileLock } from "./file-lock";
+import { withFileLock, FileLockTimeoutError } from "./file-lock";
 import { DEV3_HOME } from "./paths";
 
 const log = createLogger("port-pool");
@@ -170,17 +170,28 @@ export async function releasePorts(taskId: string): Promise<number[]> {
 	// Same critical section as allocatePorts: a peer instance sharing
 	// ~/.dev3.0 may have persisted allocations while we waited, and writing
 	// back the stale in-memory cache would drop them.
-	return withFileLock(ASSIGNMENTS_FILE, async () => {
-		assignments = readFromDisk();
-		const data = assignments;
-		const ports = data[taskId];
-		if (!ports) return [];
+	try {
+		return await withFileLock(ASSIGNMENTS_FILE, async () => {
+			assignments = readFromDisk();
+			const data = assignments;
+			const ports = data[taskId];
+			if (!ports) return [];
 
-		delete data[taskId];
-		save();
-		log.info("Ports released", { taskId: taskId.slice(0, 8), ports });
-		return ports;
-	});
+			delete data[taskId];
+			save();
+			log.info("Ports released", { taskId: taskId.slice(0, 8), ports });
+			return ports;
+		});
+	} catch (err) {
+		if (!(err instanceof FileLockTimeoutError)) throw err;
+		// Release runs during teardown, which must not stall on a contended lock.
+		// The record survives on disk: its ports drop out of the allocatable map
+		// until some later release removes them, which costs a few ports out of
+		// 10000 and locks nothing at the OS level. Log it by name so a growing
+		// port-assignments.json is diagnosable instead of mysterious.
+		log.error("Ports left assigned: assignment lock unavailable", { taskId: taskId.slice(0, 8) });
+		return [];
+	}
 }
 
 /** Get ports currently assigned to a task (without allocating). */

--- a/src/bun/port-pool.ts
+++ b/src/bun/port-pool.ts
@@ -166,15 +166,21 @@ export async function allocatePorts(taskId: string, count: number): Promise<numb
 }
 
 /** Release ports assigned to a task. Returns the released ports. */
-export function releasePorts(taskId: string): number[] {
-	const data = ensureLoaded();
-	const ports = data[taskId];
-	if (!ports) return [];
+export async function releasePorts(taskId: string): Promise<number[]> {
+	// Same critical section as allocatePorts: a peer instance sharing
+	// ~/.dev3.0 may have persisted allocations while we waited, and writing
+	// back the stale in-memory cache would drop them.
+	return withFileLock(ASSIGNMENTS_FILE, async () => {
+		assignments = readFromDisk();
+		const data = assignments;
+		const ports = data[taskId];
+		if (!ports) return [];
 
-	delete data[taskId];
-	save();
-	log.info("Ports released", { taskId: taskId.slice(0, 8), ports });
-	return ports;
+		delete data[taskId];
+		save();
+		log.info("Ports released", { taskId: taskId.slice(0, 8), ports });
+		return ports;
+	});
 }
 
 /** Get ports currently assigned to a task (without allocating). */


### PR DESCRIPTION
## Problem

\eleasePorts()\ in \src/bun/port-pool.ts\ rewrote \~/.dev3.0/port-assignments.json\ from the in-memory cache without taking the cross-process file lock that \llocatePorts()\ has held since the concurrent-allocation race was fixed (see the comment above \llocatePorts\, and the existing regression test \does not assign overlapping ports to concurrent allocations\).

The same lost-update race therefore still existed on the release path, across two app instances sharing \~/.dev3.0/\ (installed app + dev build — a supported setup per the on-disk invariants):

1. Instance A allocates ports for task X (under the lock) and persists.
2. Instance B concurrently releases task Y's ports. It loaded its cache earlier, deletes Y, and writes the whole stale map back — erasing A's just-persisted record for task X.
3. A later allocation no longer sees task X's ports as assigned and can hand them to another task → two tasks get overlapping \DEV3_PORT0\ values, which is exactly the dev-server bind-clash failure mode the allocate-side fix describes.

Found by direct code inspection while auditing cross-process state mutation paths (this file's allocate path was already hardened; release was missed).

## Fix

Mirror \llocatePorts\: run the read-decide-write section of \eleasePorts\ inside \withFileLock(ASSIGNMENTS_FILE, ...)\ with a fresh \eadFromDisk()\ inside the critical section. The function becomes async; its single production caller (the lifecycle executor's \eleasePorts\ effect) now awaits it.

## Testing

- New deterministic regression test \does not drop a peer allocation that landed while releasing\ in \src/bun/__tests__/port-pool.test.ts\: allocates, mutates the assignment file behind the in-memory cache (simulating a peer process), releases, then asserts the peer's record survives a fresh reload.
- Mutant check: with the old implementation restored, the new test fails (\1 failed | 20 passed\); with the fix, all 21 pass:
  \\\
  bunx vitest run --config vitest.config.bun.ts src/bun/__tests__/port-pool.test.ts
  Test Files  1 passed (1)
  Tests       21 passed (21)
  \\\
- Adjacent suites that mock/exercise \eleasePorts\ (\cli-socket-task-move-cleanup.test.ts\) pass. \
ative-teardown.test.ts\ fails identically (7) on unmodified \main\ on this Windows machine — POSIX-only cleanup-script session by design, pre-existing and unrelated.
- Type check: \	sc --noEmit\ reports zero errors under \src/\.