### PR TITLE
Give artifact dashboard panels a full row by default

### DIFF
--- a/change-logs/2026/08/25/fix-artifact-dashboard-grid-panel-collapse.md
+++ b/change-logs/2026/08/25/fix-artifact-dashboard-grid-panel-collapse.md
@@ -1,0 +1,3 @@
+Short: Artifact panels no longer collapse
+
+A panel dropped into an artifact's `.dashboard-grid` without a width class used to land in a single column of the 12-column grid and render as an ~86px sliver with one word per line. Unsized panels now take the whole row, and authors can place them side by side with the new `span-3` … `span-9` classes, which apply above 900px and go full width below that and in print.

--- a/decisions/2026/08/25/artifact-dashboard-grid-defaults-to-a-full-row.md
+++ b/decisions/2026/08/25/artifact-dashboard-grid-defaults-to-a-full-row.md
@@ -1,0 +1,21 @@
+# Artifact `.dashboard-grid` defaults to a full row
+
+## Context
+
+`.dashboard-grid` in the artifact starter (`src/assets/artifact-template/app.css`) is a 12-column grid, and only the starter's own demo panels (`.velocity-panel`, `.pie-panel`, `.radar-panel`, `.scenario-panel`) carried a `grid-column: span N`. An author writing their own panel — the normal case, since the demo panels get deleted — got a child with no span, which CSS grid places in exactly one column. On a 1150px-wide artifact pane that is an 86px column: every word on its own line, long tokens clipped by the card.
+
+## Investigation
+
+Reproduced from a real shipped artifact (`24-hour GitHub triage`, `shared-artifacts/b36abdb6…`), whose `#findings` section is a bare `<section class="dashboard-grid">` with two `<article class="card section">` children. In headless Chromium the computed grid was twelve 85.5px tracks and both panels measured 86px wide. With the fix they measure the full row; adding `span-6` gives 544px each at 1150px, and below 901px they go full width with zero horizontal overflow.
+
+## Decision
+
+`.dashboard-grid > *` now sets `grid-column: 1 / -1`, and opt-in widths `.span-3` … `.span-9` live inside `@media (min-width: 901px)`. `1 / -1`, not `span 12`, because the same grid drops to one column below 900px and to two columns in print — a `span 12` default would create implicit columns and overflow there. The widths sit inside the media query rather than being reset in the narrow one so their higher specificity cannot leak into the collapsed layouts. Documented in `AUTHORING.md`; guarded by `src/bun/__tests__/artifact-template.test.ts`.
+
+## Risks
+
+An author who wants two panels side by side must now add a class; without one they get a readable full-width stack instead of a dense row. Existing artifacts already published are unaffected — they carry their own copy of `app.css`.
+
+## Alternatives considered
+
+Turning the grid into `repeat(auto-fit, minmax(…, 1fr))` would size panels automatically but breaks the 8/4 and 7/5 asymmetric layouts the starter demonstrates. Defaulting to `span 6` keeps density but leaves a lone panel half-width next to dead space, which is the same "looks broken" report in a milder form.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -32,6 +32,8 @@ Do not read or edit `app.css` or `app.js` unless the artifact format itself must
 
 `.card` already carries its own padding, so a bare `<section class="card">` looks right with plain content inside it. `.section` and `.kpi` set a roomier padding, and `.table-card` intentionally drops it so a table can run edge to edge. Never re-pad a card from report markup.
 
+`.dashboard-grid` is a 12-column grid. A panel inside it takes the whole row unless you give it a width, so a card you drop in never collapses into a sliver. To put panels side by side add `span-3` … `span-9` (`<article class="card section span-6">`); the widths apply above 900px and every panel goes full width below that and in print.
+
 The container grows with the viewport up to 1840px, so dense tables and dashboards use a wide monitor instead of leaving it empty. Because the panels are wide, put running prose in `<p class="prose">` (or any `.prose` block) to hold a readable line length; short `.muted` and `.section-copy` lines are capped for you. `.kpis` fits as many cards per row as the width allows, so a report may ship three or six KPI cards without a layout override.
 
 ## Text size

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -172,11 +172,24 @@
       grid-template-columns: repeat(12, minmax(0, 1fr));
       gap: 14px;
     }
-    .dashboard-grid > * { min-width: 0; }
+    /* 1 / -1, not span 12: a panel without a width class takes the whole row
+       instead of collapsing into a 1/12 sliver, and it survives the narrow and
+       print grids that have fewer than 12 columns. */
+    .dashboard-grid > * { min-width: 0; grid-column: 1 / -1; }
     .velocity-panel { grid-column: span 8; }
     .pie-panel { grid-column: span 4; }
     .radar-panel { grid-column: span 7; }
     .scenario-panel { grid-column: span 5; }
+    /* Opt-in widths for author panels, live only where 12 columns exist. */
+    @media (min-width: 901px) {
+      .dashboard-grid > .span-3 { grid-column: span 3; }
+      .dashboard-grid > .span-4 { grid-column: span 4; }
+      .dashboard-grid > .span-5 { grid-column: span 5; }
+      .dashboard-grid > .span-6 { grid-column: span 6; }
+      .dashboard-grid > .span-7 { grid-column: span 7; }
+      .dashboard-grid > .span-8 { grid-column: span 8; }
+      .dashboard-grid > .span-9 { grid-column: span 9; }
+    }
     .section { padding: 18px; }
     .section-head {
       display: flex;

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -292,6 +292,22 @@ describe("bundled artifact starter contract", () => {
 		expect(guide).toContain("`.prose`");
 	});
 
+	it("gives an unsized dashboard panel the whole row instead of a 1/12 sliver", () => {
+		const css = readFileSync(cssPath, "utf8");
+		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+
+		// span 12 would overflow the narrow and print grids, which have fewer columns.
+		expect(css).toContain(".dashboard-grid > * { min-width: 0; grid-column: 1 / -1; }");
+		expect(css).not.toContain(".dashboard-grid > * { min-width: 0; grid-column: span 12; }");
+		// The opt-in widths only exist where the 12 columns do.
+		const spanBlock = css.match(/@media \(min-width: 901px\) \{([\s\S]*?)\n {4}\}/)?.[1] || "";
+		for (const span of [3, 4, 5, 6, 7, 8, 9]) {
+			expect(spanBlock).toContain(`.dashboard-grid > .span-${span} { grid-column: span ${span}; }`);
+		}
+		expect(guide).toContain("`.dashboard-grid` is a 12-column grid");
+		expect(guide).toContain("`span-3` … `span-9`");
+	});
+
 	it("gives every table zebra rows, row hover, column rules, and a pinned header", () => {
 		const css = readFileSync(cssPath, "utf8");
 		const app = readFileSync(appPath, "utf8");
@@ -398,7 +414,7 @@ describe("bundled artifact starter contract", () => {
 		expect(css).toContain(".scenario-panel, .table-tools, .toast, .print-hidden { display: none !important; }");
 		expect(css).toContain("break-inside: avoid");
 		expect(css).toContain("thead { display: table-header-group; }");
-		expect(css).toContain(".dashboard-grid > * { min-width: 0; }");
+		expect(css).toContain(".dashboard-grid > * { min-width: 0; grid-column: 1 / -1; }");
 		expect(css).toContain("var(--dev3-print-chart-height, 9.6875rem)");
 		expect(app).toContain('document.querySelectorAll("details:not([open])")');
 		expect(app).toContain("element.getBoundingClientRect()");
@@ -442,7 +458,7 @@ describe("bundled artifact starter contract", () => {
 		expect(statSync(htmlPath).size).toBeLessThan(MAX_SHARED_ARTIFACT_HTML_BYTES);
 		// The shell stylesheet is not part of the authoring surface, so its budget
 		// only has to stay far below an inlined library.
-		expect(statSync(cssPath).size).toBeLessThan(36_000);
+		expect(statSync(cssPath).size).toBeLessThan(37_000);
 		expect(statSync(appPath).size).toBeLessThan(30_000);
 		expect(statSync(reportPath).size).toBeLessThan(15_000);
 	});


### PR DESCRIPTION
A panel dropped into an artifact's `.dashboard-grid` without a width class landed in a single track of the 12-column grid and rendered as an ~86px sliver — one word per line, long tokens clipped. Reproduced from the shipped `24-hour GitHub triage` artifact: computed grid was twelve 85.5px tracks, both panels 86px wide.

`.dashboard-grid > *` now defaults to `grid-column: 1 / -1` (not `span 12`, which would overflow the 1-column narrow grid and the 2-column print grid), and opt-in widths `.span-3` … `.span-9` live inside `@media (min-width: 901px)`. Verified in headless Chromium: unsized panels take the full row, `span-6` gives 544px each at 1150px, and 700px/480px collapse to full width with zero horizontal overflow.

Docs in `AUTHORING.md`; guard in `src/bun/__tests__/artifact-template.test.ts` (proven red when the old rule is restored). Decision record: `decisions/2026/08/25/artifact-dashboard-grid-defaults-to-a-full-row.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=531cbe95-9323-4b37-a749-7346ad86ed29) · `dev3://task/531cbe95-9323-4b37-a749-7346ad86ed29`