### PR TITLE
Pin the Codex hook dialect in tests so the Windows proof passes

### DIFF
--- a/change-logs/2026/08/25/fix-codex-config-tests-read-the-host-dialect.md
+++ b/change-logs/2026/08/25/fix-codex-config-tests-read-the-host-dialect.md
@@ -1,0 +1,7 @@
+Short: Windows proof green again
+
+The Codex hook-block tests hardcoded the POSIX spelling of the dev3 CLI, so they
+failed on the windows-latest proof job where the generated command is a quoted
+`dev3.exe` path with no shell guard. `ensureCodexConfig` now takes the hook
+dialect as an option, and the tests pin both dialects explicitly so each runner
+covers the other platform's output too.

--- a/decisions/2026/08/25/guard-codex-status-hooks-on-dev3-task-env.md
+++ b/decisions/2026/08/25/guard-codex-status-hooks-on-dev3-task-env.md
@@ -55,7 +55,10 @@ invocations and no error; with it, all invocations as before.
 The guard is POSIX-only. Codex derives the hook runner from the session shell
 (`build_hooks_for_config`, `codex-rs/core/src/session/mod.rs`), which on Windows
 is `cmd.exe /c` **or** `powershell -Command`, and no single expression is valid
-in both. Windows keeps the bare command.
+in both. Windows keeps the bare command — and that position is now asserted, not
+merely documented: `ensureCodexConfig` takes the dialect as an option, so
+`codex-config.test.ts` runs its hook-block cases against both dialects on every
+runner and the Windows case checks that no guard is written.
 
 `ensureDev3HooksBlock` additionally collects `[[hooks.*]]` groups whose every
 handler is dev3's own status handler, so an orphaned copy is absorbed instead of

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -5,7 +5,10 @@ import {
 	getCodexSyntaxForVersion,
 	parseCodexVersion,
 	pickCodexProfileLaunchFlag,
+	tomlBasicString,
 } from "../codex-config";
+import { codexHookCommand } from "../../shared/agent-hooks";
+import { hookCliDialect } from "../../shared/dev3-cli-path";
 
 describe("ensureCodexConfig", () => {
 	const WORKTREES_PATH = "/Users/testuser/.dev3.0/worktrees";
@@ -714,14 +717,43 @@ enabled = true
 	});
 });
 
-describe("ensureCodexConfig dev3 hook block (idempotence and self-healing)", () => {
+/**
+ * The hook command is spelled per platform, so these run against BOTH dialects
+ * on every runner instead of whichever one the host happens to be. Reading the
+ * host's dialect is exactly what made these seven red on windows-latest while
+ * macOS stayed green — same trap `joinLike` exists for.
+ */
+const POSIX_DIALECT = hookCliDialect({ platform: "darwin" });
+const WINDOWS_DIALECT = hookCliDialect({
+	platform: "win32",
+	execDir: "C:\\Program Files\\dev3",
+	homeDir: "C:\\Users\\dev",
+	exists: () => false,
+});
+
+/** Every spelling of our handler an older build or the other platform leaves behind. */
+const ALL_HOOK_COMMAND_SPELLINGS = [
+	codexHookCommand(POSIX_DIALECT),
+	`${POSIX_DIALECT.cli} hook codex`,
+	codexHookCommand(WINDOWS_DIALECT),
+];
+
+describe.each([
+	["POSIX", POSIX_DIALECT],
+	["Windows", WINDOWS_DIALECT],
+])("ensureCodexConfig dev3 hook block on %s (idempotence and self-healing)", (_name, dialect) => {
 	const WORKTREES_PATH = "/Users/testuser/.dev3.0/worktrees";
 	const SOCKETS_PATH = "/Users/testuser/.dev3.0/sockets";
-	const NEW = { codexVersion: "0.147.0" };
+	const NEW = { codexVersion: "0.147.0", dialect };
 	const ensure = (content: string | null) =>
 		ensureCodexConfig(content, WORKTREES_PATH, SOCKETS_PATH, [], NEW);
-	const dev3Handlers = (config: string) => (config.match(/dev3 hook codex/g) ?? []).length;
+	/** Handlers carrying the `hook codex` subcommand, in any CLI spelling. */
+	const dev3Handlers = (config: string) => (config.match(/hook codex/g) ?? []).length;
 	const groups = (config: string) => (config.match(/^\[\[hooks\.[A-Za-z]+\]\]$/gm) ?? []).length;
+	/** The exact `command = "…"` line this dialect writes, TOML escaping included. */
+	const commandLine = (command: string) => `command = ${tomlBasicString(command)}`;
+	const ourCommandLine = commandLine(codexHookCommand(dialect));
+	const count = (haystack: string, needle: string) => haystack.split(needle).length - 1;
 
 	it("declares each status hook exactly once, however often it runs", () => {
 		let config = ensure(null);
@@ -792,11 +824,24 @@ describe("ensureCodexConfig dev3 hook block (idempotence and self-healing)", () 
 		expect(dev3Handlers(config)).toBe(7);
 	});
 
-	it("guards the command it writes into the user's config", () => {
+	it("writes the command this platform's hook runner can actually execute", () => {
 		const config = ensure(null);
-		expect(config).toContain(
-			`command = "sh -c '[ -z \\"$DEV3_TASK_ID\\" ] || exec ~/.dev3.0/bin/dev3 hook codex'"`,
-		);
+		expect(count(config, ourCommandLine)).toBe(6);
+
+		if (dialect.posixShell) {
+			// The env guard is what keeps a foreign Codex session free (#1527).
+			expect(config).toContain(
+				`command = "sh -c '[ -z \\"$DEV3_TASK_ID\\" ] || exec ~/.dev3.0/bin/dev3 hook codex'"`,
+			);
+			return;
+		}
+		// Windows keeps the bare command on purpose: the runner there may be
+		// cmd.exe OR PowerShell and no one guard expression is valid in both, so a
+		// guard would cost every Windows task its status moves. See
+		// decisions/2026/08/25/guard-codex-status-hooks-on-dev3-task-env.md.
+		expect(config).toContain(commandLine(`${dialect.cli} hook codex`));
+		expect(config).not.toContain("sh -c");
+		expect(config).not.toContain("DEV3_TASK_ID");
 	});
 
 	it("leaves alone a hook the user wrote themselves that calls the dev3 CLI", () => {
@@ -827,19 +872,17 @@ describe("ensureCodexConfig dev3 hook block (idempotence and self-healing)", () 
 
 	it("still collects an orphan left by an older build, or by the other platform", () => {
 		const orphaned = ensure(null).replace("# >>> dev3 status hooks (generated — do not edit) >>>\n", "");
-		const guarded = `sh -c '[ -z \\"$DEV3_TASK_ID\\" ] || exec ~/.dev3.0/bin/dev3 hook codex'`;
 
-		for (const spelling of [
-			"~/.dev3.0/bin/dev3 hook codex",
-			`\\"C:/Users/dev/.dev3.0/bin/dev3.exe\\" hook codex`,
-		]) {
-			const healed = ensure(orphaned.replaceAll(guarded, spelling));
+		for (const spelling of ALL_HOOK_COMMAND_SPELLINGS) {
+			// Re-spell the orphan the way the other platform, or an older build,
+			// would have written it — then heal it with THIS dialect.
+			const foreign = orphaned.replaceAll(ourCommandLine, commandLine(spelling));
+			const healed = ensure(foreign);
 			expect(dev3Handlers(healed)).toBe(6);
 			expect(groups(healed)).toBe(6);
-			// Nothing but the freshly written, guarded block is left.
+			// Nothing but the freshly written block is left.
 			expect((healed.match(/^command = /gm) ?? []).length).toBe(6);
-			expect((healed.match(new RegExp(guarded.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) ?? []).length)
-				.toBe(6);
+			expect(count(healed, ourCommandLine)).toBe(6);
 		}
 	});
 });

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -45,6 +45,13 @@ interface CodexConfig {
 
 interface CodexConfigOptions {
 	codexVersion?: string | null;
+	/**
+	 * How the hook command is spelled. Same reason `joinLike` exists: reading the
+	 * host's dialect makes an assertion about the other platform's output
+	 * impossible to write, and the tests then only ever cover the runner they are
+	 * on. Production leaves it unset and gets the host's dialect.
+	 */
+	dialect?: HookCliDialect;
 }
 
 interface CodexVersion {
@@ -805,7 +812,7 @@ export function ensureCodexConfig(
 	}
 
 	// --- 6. Ensure dev3's status hooks are declared in the file ---
-	config = ensureDev3HooksBlock(config);
+	config = ensureDev3HooksBlock(config, options.dialect);
 
 	return config;
 }
@@ -859,9 +866,9 @@ export function buildDev3CodexHooksBlock(options?: { dialect?: HookCliDialect })
  * twelve, and a stranger's Codex session pays for all of them. So anything left
  * that is unmistakably ours is collected by content too.
  */
-function ensureDev3HooksBlock(config: string): string {
+function ensureDev3HooksBlock(config: string, dialect?: HookCliDialect): string {
 	const stripped = stripOrphanedDev3HookTables(config.replace(DEV3_HOOKS_BLOCK, "\n"));
-	return appendBlock(stripped, `\n${buildDev3CodexHooksBlock()}`);
+	return appendBlock(stripped, `\n${buildDev3CodexHooksBlock({ dialect })}`);
 }
 
 /** `[[hooks.<Event>]]`, the head of one array-of-tables group. */


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

`windows package / package-runtime (windows-latest)` has been red on every run since 1b01e9740 (#1533). Seven tests in `codex-config.test.ts` fail there, always the same seven, always real `AssertionError`s.

The production behaviour shipped in #1533 is correct and unchanged. The tests were wrong about Windows: they hardcoded the POSIX spelling of the hook command (`~/.dev3.0/bin/dev3 hook codex` and the `sh -c '[ -z "$DEV3_TASK_ID" ] || exec …'` guard), while `ensureCodexConfig` reads the *host's* dialect and on windows-latest writes a quoted `dev3.exe` path with no guard — deliberately, because the Windows hook runner may be `cmd.exe` or PowerShell.

`ensureCodexConfig` now accepts the dialect as an option (the same seam `buildCodexHooks` and `buildDev3CodexHooksBlock` already had, which is why `codex-hook-guard.test.ts` was never affected). The hook-block cases run against both dialects on every runner, so each platform now covers the other's output — the same class of bug `joinLike` exists for. The Windows case asserts the documented position explicitly: bare command, no guard.

Reproduced locally first by forcing the Windows dialect, which gave the identical 7 failed / 74 passed / 81 total and the identical assertion messages. Proven on a real windows-latest runner via `workflow_dispatch` on this branch. Guard proven still guarding with two mutants: dropping the env guard from `codexHookCommand` turns 6 tests red, and weakening the orphan selector to "mentions the dev3 CLI" turns the user's-own-hook test red on both dialects.

The decision record is updated in the same change so the Windows position is asserted rather than only documented.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=cdf2d778-9e76-417a-9732-6a4d3bf42b31) · `dev3://task/cdf2d778-9e76-417a-9732-6a4d3bf42b31`