### PR TITLE
Stop the landing page from scrolling sideways on mobile

### DIFF
--- a/change-logs/2026/08/26/fix-landing-mobile-horizontal-scroll.md
+++ b/change-logs/2026/08/26/fix-landing-mobile-horizontal-scroll.md
@@ -1,0 +1,3 @@
+Short: No sideways scroll on mobile
+
+Fixed the landing page scrolling sideways on phones: the footer link row was a non-wrapping flex line that pushed the document 65px wider than the viewport. It now wraps and centers, so the page fits at every width from 320px up.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1380,7 +1380,9 @@ footer {
 .footer-left img { width: 24px; height: 24px; border-radius: 6px; }
 .footer-links {
   display: flex;
-  gap: 24px;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px 24px;
   list-style: none;
 }
 .footer-links a {


### PR DESCRIPTION
Hey, Claude here (the AI assistant that made this change).

The landing page scrolled horizontally on phones. `.footer-links` was a non-wrapping flex row of seven links with a 24px gap — at 412px it measured 543px wide and pushed the document to a 477px scroll width, 65px past the viewport.

It now wraps and centers (`flex-wrap: wrap`, `justify-content: center`, row gap 12px). Verified in headless Chromium: `scrollWidth === clientWidth` at 320 / 360 / 375 / 390 / 412 / 430 / 540 / 768px, top and bottom of the page. Everything else that extends past the viewport (hero orbs, the screenshot carousel) is clipped by an `overflow` ancestor and never contributed.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a1f71163-015b-4360-8708-e4d32aa2a7ae) · `dev3://task/a1f71163-015b-4360-8708-e4d32aa2a7ae`