### PR TITLE
Give the top-right corner one owner so toasts stop hiding the update prompt

### DIFF
--- a/change-logs/2026/08/26/fix-update-prompt-and-toasts-share-one-stack.md
+++ b/change-logs/2026/08/26/fix-update-prompt-and-toasts-share-one-stack.md
@@ -1,0 +1,3 @@
+Short: Update prompt no longer hides under toasts
+
+The update-ready prompt and the toast stack no longer overlap in the top-right corner. The prompt now pins above the toasts inside a single column, so an arriving notification can never cover its version header, its "what's new" list, or its Restart button.

--- a/decisions/2026/08/26/one-owner-per-screen-corner.md
+++ b/decisions/2026/08/26/one-owner-per-screen-corner.md
@@ -1,0 +1,50 @@
+# One owner per screen corner
+
+## Context
+
+The update-ready prompt (`GlobalHeader`) and the toast stack (`ToastHost`) both positioned
+themselves at `fixed top-14 right-4`. Two independent stacks at one anchor cannot know how
+tall the other is, so they simply landed on top of each other: the toast host's `z-[55]`
+covered the prompt's `z-50`, hiding its version header, its close button, and — with two
+toasts on screen — its Restart button.
+
+## Investigation
+
+Raising or swapping z-indexes cannot fix this: whichever wins covers the loser. The corner
+already had a working precedent in the codebase — `StatusDock` owns the bottom-left corner
+so that two independent remote status pills cannot overlap, and declares its safe-area
+insets once.
+
+## Decision
+
+`ToastHost` (`src/mainview/toast.tsx`) is the single owner of the top-right corner. It
+always renders its fixed column now — even with an empty stack — and exposes a pinned slot
+above the toasts through `usePinnedToastSlot()`. The update prompt portals into that slot
+instead of positioning itself (`GlobalHeader.tsx`), gets the toast card's width for a shared
+trailing edge, and is separated from the transient pile by twice the intra-group gap
+(`gap-5` outer, `gap-2.5` inner) so the two read as "a decision waiting for you" and "things
+that just happened".
+
+The prompt goes above the toasts because it is not a toast: it never expires, is never
+evicted by capacity, and carries a restart deadline.
+
+`src/bun/__tests__/one-owner-per-screen-corner.test.ts` scans the renderer for `fixed` +
+vertical + horizontal edge class combinations and fails when two files claim one corner.
+Verified by mutation: restoring the old `fixed top-14 right-4` on the prompt fails both
+assertions.
+
+## Risks
+
+The prompt is invisible if `ToastHost` is not mounted. It is mounted unconditionally in
+`App.tsx`, and there is deliberately no fallback to a second fixed position — that fallback
+would be the bug. Tests that render the header without a host must mock
+`usePinnedToastSlot`; two suites do.
+
+## Alternatives considered
+
+- **Separate corners** — the prompt to bottom-right. Cheap, but adds a third floating zone
+  and puts the auto-restart countdown where nobody looks.
+- **Drop the auto-shown prompt** and pulse a header chip with the countdown instead. Quietest
+  option, but a five-minute unattended restart deserves more than a chip.
+- **Suppress toasts while the prompt is up.** The toast feed is how agent activity reaches the
+  user; muting it loses information.

--- a/src/bun/__tests__/one-owner-per-screen-corner.test.ts
+++ b/src/bun/__tests__/one-owner-per-screen-corner.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/**
+ * Two independent `fixed` stacks pinned to the same screen corner land on top of
+ * each other, because neither can know how tall the other one is. Raising a
+ * z-index does not fix that — the winner simply covers the loser. It shipped
+ * once: an arriving toast hid the update prompt's header and its close button,
+ * both being `fixed top-14 right-4`.
+ *
+ * So a corner gets exactly one owner and everything else that belongs there
+ * renders inside it — `ToastHost`'s pinned slot for the top-right, `StatusDock`
+ * for the bottom-left.
+ */
+const DECLARED_OWNERS: Record<string, string> = {
+	"top-right": "src/mainview/toast.tsx",
+	// Positions itself through `style` for the safe-area insets, so the class
+	// scanner below cannot see it. Declared here instead.
+	"bottom-left": "src/mainview/components/StatusDock.tsx",
+	"bottom-right": "src/mainview/components/TerminalPerfOverlay.tsx",
+};
+
+/** `fixed` + a vertical edge + a horizontal edge in one class list = a corner claim. */
+const CORNER_CLAIM = /\bfixed\b[^"`}]*?\b(top|bottom)-\d[\w.[\]/-]*[^"`}]*?\b(left|right)-\d[\w.[\]/-]*/g;
+
+async function rendererFiles(): Promise<string[]> {
+	const entries = await readdir(path.join(ROOT, "src/mainview"), { recursive: true });
+	return entries
+		.map((entry) => `src/mainview/${entry.split(path.sep).join("/")}`)
+		.filter((file) => file.endsWith(".tsx") && !file.includes("__tests__"))
+		.sort();
+}
+
+/** corner -> files positioning themselves there via Tailwind classes. */
+async function scanCornerClaims(): Promise<Map<string, string[]>> {
+	const byCorner = new Map<string, string[]>();
+	for (const file of await rendererFiles()) {
+		const text = await readFile(path.join(ROOT, file), "utf8");
+		for (const match of text.matchAll(CORNER_CLAIM)) {
+			const corner = `${match[1]}-${match[2]}`;
+			const files = byCorner.get(corner) ?? [];
+			if (!files.includes(file)) files.push(file);
+			byCorner.set(corner, files);
+		}
+	}
+	return byCorner;
+}
+
+describe("one owner per screen corner", () => {
+	it("gives every claimed corner exactly one owner", async () => {
+		const shared = [...(await scanCornerClaims())]
+			.filter(([, files]) => files.length > 1)
+			.map(([corner, files]) => `${corner}: ${files.join(", ")}`);
+		expect(shared).toEqual([]);
+	});
+
+	it("keeps each corner owned by the surface that declares it", async () => {
+		const claims = await scanCornerClaims();
+		for (const [corner, owner] of Object.entries(DECLARED_OWNERS)) {
+			const found = claims.get(corner) ?? [];
+			if (found.length === 0) {
+				// Owner positions itself outside the class scanner's reach (safe-area
+				// insets in `style`). Prove it still positions itself at all.
+				const text = await readFile(path.join(ROOT, owner), "utf8");
+				expect(/safe-area-inset|\bfixed\b/.test(text), `${owner} no longer positions itself`).toBe(true);
+				continue;
+			}
+			expect(found, `unexpected owner of ${corner}`).toEqual([owner]);
+		}
+	});
+});

--- a/src/mainview/__tests__/toast.test.tsx
+++ b/src/mainview/__tests__/toast.test.tsx
@@ -2,7 +2,8 @@ import type { ReactElement } from "react";
 import { act, fireEvent, render as rtlRender, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "../i18n";
-import { setToastSuppressed, taskToastContext, ToastHost, toast } from "../toast";
+import { createPortal } from "react-dom";
+import { setToastSuppressed, taskToastContext, ToastHost, toast, usePinnedToastSlot } from "../toast";
 
 /** `ToastHost` localizes its dismiss label, so every render needs the provider. */
 function render(ui: ReactElement) {
@@ -643,4 +644,31 @@ describe("toast service", () => {
 		expect(await screen.findByText("First queued")).toBeInTheDocument();
 		expect(screen.getByText("Second queued")).toBeInTheDocument();
 	});
+});
+
+describe("ToastHost — the pinned slot owns the corner with the toasts", () => {
+	function Pinned() {
+		const slot = usePinnedToastSlot();
+		return slot ? createPortal(<div data-testid="pinned">Update ready</div>, slot) : null;
+	}
+
+	it("exposes the slot with an empty stack, because that is when a prompt needs it most", () => {
+		render(<><ToastHost /><Pinned /></>);
+		expect(screen.getByTestId("pinned")).toBeInTheDocument();
+	});
+
+	it("keeps the pinned surface above the toasts inside one stack", async () => {
+		render(<><ToastHost /><Pinned /></>);
+		act(() => toast.info("Agent shared 2 images"));
+
+		const pinned = await screen.findByTestId("pinned");
+		const card = toastCard();
+		// Same fixed container: neither can cover the other, whatever either one's height.
+		const stack = pinned.closest("div.fixed");
+		expect(stack).not.toBeNull();
+		expect(stack?.contains(card)).toBe(true);
+		// Pinned first in DOM order, so it renders at the top of the column.
+		expect(pinned.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
 });

--- a/src/mainview/components/GlobalHeader.tsx
+++ b/src/mainview/components/GlobalHeader.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState, useEffect, useRef, useCallback, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import type { CodingAgent, Project, Task, UpdateChangelog } from "../../shared/types";
 import { getTaskTitle, taskSeqLabel, ACTIVE_STATUSES, isBuiltinOpsProject, isSpaceSensitive, orderProjectsForDisplay, projectDisplayName } from "../../shared/types";
 import type { Route } from "../state";
@@ -13,7 +14,7 @@ import { useEscapeKey } from "../hooks/useEscapeKey";
 import { api, isElectrobun } from "../rpc";
 import { isRemote } from "../utils/platform";
 import { subscribeFullscreen, isFullscreenActive, isFullscreenSupported, toggleFullscreen } from "../fullscreen";
-import { toast } from "../toast";
+import { toast, usePinnedToastSlot } from "../toast";
 import TmuxSessionManager from "./TmuxSessionManager";
 import InlineRename from "./InlineRename";
 import NativeBackendMark from "./NativeBackendMark";
@@ -127,6 +128,7 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 	const [restarting, setRestarting] = useState(false);
 	const [restartContext, setRestartContext] = useState<{ headless: boolean; remoteActive: boolean; tasksInProgress: number } | null>(null);
 	const [showToast, setShowToast] = useState(false);
+	const pinnedToastSlot = usePinnedToastSlot();
 	const [countdown, setCountdown] = useState(0);
 	const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [showProjectDropdown, setShowProjectDropdown] = useState(false);
@@ -1109,10 +1111,14 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 				</div>
 			</BottomSheet>
 		)}
-		{/* Toast notification for update ready */}
-		{showToast && updateVersion && (
-			<div className="fixed top-14 right-4 z-50 animate-slide-in-right">
-				<div className="bg-overlay border border-accent/30 rounded-xl shadow-2xl p-4 w-80 flex items-start gap-3">
+		{/* The update prompt is not a toast: it never expires, it is never evicted, and
+		    it carries a restart deadline. So it does NOT own a corner of its own — it
+		    pins into the toast host's slot, above the transient pile, and the two can no
+		    longer cover each other. Width matches a toast card so the column has one
+		    trailing edge. */}
+		{showToast && updateVersion && pinnedToastSlot && createPortal(
+			<div className="animate-slide-in-right pointer-events-auto" data-testid="update-prompt-pinned">
+				<div className="bg-overlay border border-accent/30 rounded-xl shadow-2xl p-4 w-[26rem] max-w-[calc(100vw-2rem)] flex items-start gap-3">
 					<UpdateReadyIcon className="w-5 h-5 text-accent mt-0.5 flex-shrink-0" />
 					<div className="flex-1 min-w-0">
 						<div className="text-fg text-sm font-semibold">
@@ -1158,14 +1164,16 @@ function GlobalHeader({ route, projects, tasks, agents, navigate, goBack, goForw
 					</div>
 					<button
 						onClick={dismissToast}
+						aria-label={t("update.postponeBtn")}
 						className="text-fg-muted hover:text-fg transition-colors flex-shrink-0"
 					>
-						<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
 							<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
 						</svg>
 					</button>
 				</div>
-			</div>
+			</div>,
+			pinnedToastSlot,
 		)}
 		</>
 	);

--- a/src/mainview/components/__tests__/FirstRun.test.tsx
+++ b/src/mainview/components/__tests__/FirstRun.test.tsx
@@ -44,7 +44,11 @@ vi.mock("../../rpc", () => ({
 	},
 }));
 vi.mock("../../analytics", () => ({ trackEvent: vi.fn(), agentNameFromId: vi.fn(() => "unknown") }));
-vi.mock("../../toast", () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }));
+vi.mock("../../toast", () => ({
+	toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+	// No ToastHost here, so the header's update prompt has no slot to portal into.
+	usePinnedToastSlot: () => null,
+}));
 vi.mock("../../utils/moveTaskToStatus", () => ({ moveTaskToStatus: vi.fn(async () => true) }));
 vi.mock("../../utils/confirmTaskCompletion", () => ({ confirmTaskCompletion: vi.fn().mockResolvedValue(true) }));
 vi.mock("../../utils/ansi-to-html", () => ({ ansiToHtml: vi.fn((s: string) => s) }));

--- a/src/mainview/components/__tests__/GlobalHeader.test.tsx
+++ b/src/mainview/components/__tests__/GlobalHeader.test.tsx
@@ -54,6 +54,10 @@ vi.mock("../../toast", () => ({
 		info: vi.fn(),
 		success: vi.fn(),
 	},
+	// Stands in for the real ToastHost slot, which no header test mounts. Body is
+	// the honest substitute: the update prompt portals somewhere queryable, exactly
+	// as it does in the app.
+	usePinnedToastSlot: () => document.body,
 }));
 
 import { api } from "../../rpc";

--- a/src/mainview/toast.tsx
+++ b/src/mainview/toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useNarrowViewport } from "./hooks/useNarrowViewport";
 import { useT } from "./i18n";
 import type { TranslationKey } from "./i18n";
@@ -192,6 +192,36 @@ const VARIANT: Record<ToastVariant, { icon: string; border: string; text: string
 	// Envelope, not a severity glyph: this toast reports mail between agents.
 	agent: { icon: "\uf0e0", border: "border-agent/40", text: "text-agent", bar: "bg-agent" },
 };
+
+// THE TOP-RIGHT CORNER HAS EXACTLY ONE OWNER, and it is the host below. A second
+// `fixed top-14 right-4` stack cannot know how tall the first one is, so the two
+// simply land on top of each other — the update prompt used to disappear under an
+// arriving toast. Anything persistent that belongs in this corner portals into the
+// slot instead and gets stacked, the same way StatusDock owns the bottom-left one.
+let pinnedSlot: HTMLElement | null = null;
+const pinnedSlotListeners = new Set<() => void>();
+
+function setPinnedSlot(node: HTMLElement | null): void {
+	if (pinnedSlot === node) return;
+	pinnedSlot = node;
+	for (const listener of pinnedSlotListeners) listener();
+}
+
+/**
+ * The node above the transient toast stack, for a surface that must stay put until
+ * the user acts on it (the update prompt). `null` until {@link ToastHost} mounts —
+ * render nothing then rather than falling back to your own fixed position.
+ */
+export function usePinnedToastSlot(): HTMLElement | null {
+	return useSyncExternalStore(
+		(onChange) => {
+			pinnedSlotListeners.add(onChange);
+			return () => pinnedSlotListeners.delete(onChange);
+		},
+		() => pinnedSlot,
+		() => null,
+	);
+}
 
 function rendererIsActive(): boolean {
 	if (typeof document === "undefined") return true;
@@ -400,10 +430,17 @@ export function ToastHost({ onTaskOverflow, resolveOrigin }: ToastHostProps = {}
 		};
 	}, []);
 
-	if (!toasts.length) return null;
-
+	// NO EARLY RETURN even with an empty stack: the pinned slot is a portal target, so
+	// it has to exist in the DOM before the update prompt can ask for it — and the
+	// prompt is at its most useful precisely when no toast is on screen.
 	return (
-		<div className="fixed top-14 right-4 z-[55] flex flex-col gap-2.5 pointer-events-none">
+		<div className="fixed top-14 right-4 z-[55] flex flex-col gap-5 pointer-events-none">
+			{/* Pinned above the transient pile, separated by twice the intra-group gap so
+			    the two read as "a decision waiting for you" and "things that just
+			    happened" rather than one undifferentiated column. */}
+			<div ref={setPinnedSlot} className="flex flex-col gap-2.5 empty:hidden" />
+			{toasts.length > 0 && (
+			<div className="flex flex-col gap-2.5">
 			{toasts.map(({ entry, paused, context, onClick }) => (
 				<ToastCard
 					key={entry.id}
@@ -445,6 +482,8 @@ export function ToastHost({ onTaskOverflow, resolveOrigin }: ToastHostProps = {}
 						</span>
 					</button>
 				</div>
+			)}
+			</div>
 			)}
 		</div>
 	);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

The update-ready prompt and the toast stack both positioned themselves at `fixed top-14 right-4`. Two independent stacks at one anchor cannot know how tall the other is, so they landed on top of each other — the toast host's `z-[55]` covered the prompt's `z-50`, hiding its version header, its close button, and (with two toasts on screen) its Restart button. Raising a z-index cannot fix that: whichever wins simply covers the loser.

## What changed

`ToastHost` (`src/mainview/toast.tsx`) is now the single owner of the top-right corner, mirroring what `StatusDock` already does for the bottom-left. It always renders its fixed column — even with an empty stack — and exposes a pinned slot above the toasts through `usePinnedToastSlot()`. The update prompt portals into that slot instead of positioning itself, takes the toast card's width for a shared trailing edge, and is separated from the transient pile by twice the intra-group gap (`gap-5` outer, `gap-2.5` inner) so the two read as "a decision waiting for you" and "things that just happened".

The prompt sits above the toasts because it is not a toast: it never expires, is never evicted by capacity, and carries a restart deadline. Its close button also gained an `aria-label`.

Placement was decided against `better-interface`, `better-layout` and `better-ui`; the reasoning, and the rejected alternatives (separate corners, replacing the auto-shown panel with a header chip, suppressing toasts while it is up), are recorded in `decisions/2026/08/26/one-owner-per-screen-corner.md`.

## Guard

`src/bun/__tests__/one-owner-per-screen-corner.test.ts` scans the renderer for `fixed` + vertical-edge + horizontal-edge class combinations and fails when two files claim one corner. Verified by mutation: restoring the old `fixed top-14 right-4` on the prompt fails both assertions, and it caught a third corner owner (`TerminalPerfOverlay`, sole owner of bottom-right) that reading the code by eye had missed.

Verified in headless Chromium at 1600×1000 and 390×844 — one column, prompt on top, `Clear all` under the pile, no horizontal overflow, no console errors.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=7b4dd01c-fdcd-450d-893b-7b4b10678223) · `dev3://task/7b4dd01c-fdcd-450d-893b-7b4b10678223` _(dev3 added this footer — turn it off in Settings → Tasks.)_
