### PR TITLE
Render .mmd Mermaid files like markdown in preview and diff

### DIFF
--- a/change-logs/2026/08/26/feature-45-mmd-mermaid-render.md
+++ b/change-logs/2026/08/26/feature-45-mmd-mermaid-render.md
@@ -1,0 +1,3 @@
+Short: Mermaid .mmd files render as diagrams
+
+Standalone Mermaid files (`.mmd`) now render the same way markdown does: the file preview you get from Cmd/Ctrl+Clicking a path opens the drawn diagram with a Raw toggle, and in the diff viewer a changed `.mmd` file gets the Preview toggle and shows the resulting diagram instead of raw diagram source.

--- a/src/mainview/components/FilePreviewModal.tsx
+++ b/src/mainview/components/FilePreviewModal.tsx
@@ -8,6 +8,7 @@ import { formatBytes } from "../utils/formatBytes";
 import { writeClipboardText } from "../utils/clipboard-write";
 import type { FilePreviewResult } from "../../shared/types";
 import { MarkdownDocument } from "./pr-review/markdown";
+import { isRenderableDocPath, toRenderableMarkdown } from "./pr-review/markdown-files";
 
 interface FilePreviewModalProps {
 	path: string;
@@ -69,7 +70,7 @@ export default function FilePreviewModal({ path, line, taskId, onClose }: FilePr
 		}
 	}, [preview]);
 
-	const isMarkdown = /\.(md|markdown)$/i.test(path);
+	const isRenderable = isRenderableDocPath(path);
 	const textContent = preview?.kind === "text" ? preview.content : null;
 	const slash = path.lastIndexOf("/");
 	const fileName = slash >= 0 ? path.slice(slash + 1) : path;
@@ -110,9 +111,9 @@ export default function FilePreviewModal({ path, line, taskId, onClose }: FilePr
 			case "text":
 				return (
 					<div className="min-h-0 flex-1 overflow-auto p-4">
-						{isMarkdown && !showRaw ? (
+						{isRenderable && !showRaw ? (
 							<MarkdownDocument
-								body={preview.content}
+								body={toRenderableMarkdown(preview.content, path)}
 								className="max-w-[70ch] mx-auto"
 								imageBaseDir={dirName || null}
 							/>
@@ -207,7 +208,7 @@ export default function FilePreviewModal({ path, line, taskId, onClose }: FilePr
 							</p>
 						)}
 					</div>
-					{isMarkdown && textContent !== null && (
+					{isRenderable && textContent !== null && (
 						<div className="shrink-0 flex rounded-lg border border-edge overflow-hidden text-xs">
 							{([false, true] as const).map((raw) => (
 								<button

--- a/src/mainview/components/TaskDiffViewer.tsx
+++ b/src/mainview/components/TaskDiffViewer.tsx
@@ -30,6 +30,7 @@ import { PrConversationBlock } from "./pr-review/PrConversationBlock";
 import { GithubThreadView, OutdatedThreadsGroup, type ThreadSendState } from "./pr-review/GithubThreadView";
 import { buildThreadFixPrompt, groupGithubThreadsByFile, isLineRenderedInDiff, locateThread, partitionThreadsForDiff } from "./pr-review/mapping";
 import { MarkdownDocument } from "./pr-review/markdown";
+import { isMermaidPath, isRenderableDocPath, toRenderableMarkdown } from "./pr-review/markdown-files";
 import {
 	MarkdownRichDiff,
 	useMarkdownDiffBlocks,
@@ -993,6 +994,7 @@ function MarkdownPreviewReview({
 	const commentedLines = useMemo(() => commentedLinesBySide(comments), [comments]);
 	const threads = useMemo(() => collectMarkdownPreviewThreads(comments), [comments]);
 	const documentSide = getMarkdownPreviewSide(file);
+	const documentPath = diffFilePath(file);
 
 	// The button follows the live selection; the composer, once open, keeps the
 	// range it was opened with even after the browser drops the highlight.
@@ -1052,10 +1054,14 @@ function MarkdownPreviewReview({
 						)
 						: (
 							<MarkdownDocument
-								body={previewSource}
+								body={toRenderableMarkdown(previewSource, documentPath)}
 								imageBaseDir={imageBaseDir}
 								imageRootDir={imageRootDir}
-								sourceLines={{ lineOffset: 1, commentedLines: commentedLines[documentSide] }}
+								// A fenced diagram is one block whose lines no longer line up
+								// with the file's, so `.mmd` carries no line anchors.
+								sourceLines={isMermaidPath(documentPath)
+									? null
+									: { lineOffset: 1, commentedLines: commentedLines[documentSide] }}
 							/>
 						)
 					: <div className="text-sm text-fg-muted">{t("infoPanel.diffMdPreviewEmpty")}</div>}
@@ -1337,16 +1343,23 @@ function findDiffFileByPath(files: TaskDiffFile[], path: string | undefined): Ta
 	)) ?? null;
 }
 
-/** Markdown files get a per-file source-diff ↔ rendered-preview toggle (issue #1063). */
+function diffFilePath(file: TaskDiffFile): string {
+	return file.newPath ?? file.oldPath ?? file.displayPath;
+}
+
+/** Renderable documents — markdown and `.mmd` diagrams — get a per-file
+ * source-diff ↔ rendered-preview toggle (issue #1063). */
 export function isMarkdownDiffFile(file: TaskDiffFile): boolean {
-	const path = file.newPath ?? file.oldPath ?? file.displayPath;
-	return /\.(md|markdown)$/i.test(path);
+	return isRenderableDocPath(diffFilePath(file));
 }
 
 /** Only a two-sided change has something to colour: added/untracked files are
- * all-new and deleted files all-gone, so those preview as a plain document. */
+ * all-new and deleted files all-gone, so those preview as a plain document. A
+ * `.mmd` file has no prose blocks to diff — it always previews as the diagram. */
 export function isMarkdownRichDiffFile(file: TaskDiffFile): boolean {
-	return isMarkdownDiffFile(file) && file.status !== "added" && file.status !== "untracked" && file.status !== "deleted";
+	return isMarkdownDiffFile(file)
+		&& !isMermaidPath(diffFilePath(file))
+		&& file.status !== "added" && file.status !== "untracked" && file.status !== "deleted";
 }
 
 /** Preview renders what the change produced: the new content, or for deletions

--- a/src/mainview/components/__tests__/FilePreviewModal.test.tsx
+++ b/src/mainview/components/__tests__/FilePreviewModal.test.tsx
@@ -1,9 +1,25 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import FilePreviewModal from "../FilePreviewModal";
 import { I18nProvider } from "../../i18n";
+import { installImmediateIntersectionObserver } from "../../test-utils/immediate-intersection";
 import type { FilePreviewResult } from "../../../shared/types";
 
 const readFilePreview = vi.fn<(params: { path: string }) => Promise<FilePreviewResult>>();
+
+const mermaid = vi.hoisted(() => ({ initialize: vi.fn(), render: vi.fn() }));
+
+vi.mock("@streamdown/mermaid", () => ({
+	createMermaidPlugin: () => ({
+		name: "mermaid",
+		type: "diagram",
+		language: "mermaid",
+		getMermaid: (config?: unknown) => {
+			if (config) mermaid.initialize(config);
+			return mermaid;
+		},
+	}),
+}));
 
 // isElectrobun=false — the browser/remote case, where host-side open actions
 // must not render (they would act invisibly on the host machine).
@@ -19,6 +35,8 @@ vi.mock("../../rpc", () => ({
 	},
 }));
 
+installImmediateIntersectionObserver();
+
 function renderModal(path = "/wt/docs/guide.md", line?: number) {
 	return render(
 		<I18nProvider>
@@ -30,6 +48,10 @@ function renderModal(path = "/wt/docs/guide.md", line?: number) {
 describe("FilePreviewModal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mermaid.render.mockResolvedValue({
+			svg: '<svg data-testid="rendered-mermaid"></svg>',
+			diagramType: "flowchart-v2",
+		});
 	});
 
 	it("hides host-side open actions in browser mode but keeps copy actions", async () => {
@@ -61,6 +83,28 @@ describe("FilePreviewModal", () => {
 		);
 		expect(screen.getByRole("button", { name: "Raw" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Rendered" })).toHaveAttribute("aria-pressed", "true");
+	});
+
+	it("renders a .mmd file as a Mermaid diagram, with the same Raw toggle", async () => {
+		const user = userEvent.setup();
+		readFilePreview.mockResolvedValue({
+			kind: "text",
+			content: "flowchart LR\nA --> B\n",
+			truncated: false,
+			size: 22,
+		});
+		renderModal("/wt/docs/chart.mmd");
+
+		await waitFor(() => expect(mermaid.render).toHaveBeenCalled());
+		expect(mermaid.render).toHaveBeenCalledWith(
+			expect.stringMatching(/^mermaid-/),
+			"flowchart LR\nA --> B\n",
+		);
+		expect(screen.getByTestId("rendered-mermaid")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Raw" }));
+		expect(screen.getByText("flowchart LR")).toBeInTheDocument();
+		expect(screen.queryByTestId("rendered-mermaid")).not.toBeInTheDocument();
 	});
 
 	it("renders code with line numbers and highlights the target line", async () => {

--- a/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskDiffViewer.test.tsx
@@ -3682,6 +3682,27 @@ describe("TaskDiffViewer — GitHub PR review layer", () => {
 			expect(within(preview).getByTestId("markdown-document").querySelector("h1")?.textContent).toBe("Gone");
 		});
 
+		it("previews a modified .mmd file as the diagram, never as a rich prose diff", async () => {
+			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
+				id: "docs/chart.mmd",
+				displayPath: "docs/chart.mmd",
+				oldPath: "docs/chart.mmd",
+				newPath: "docs/chart.mmd",
+				oldContent: "flowchart LR\nA --> B\n",
+				newContent: "flowchart LR\nA --> C\n",
+			}));
+			renderViewer();
+
+			const preview = await screen.findByTestId("diff-md-preview");
+			expect(screen.getByRole("button", { name: /toggle markdown preview for docs\/chart\.mmd/i }))
+				.toHaveAttribute("aria-pressed", "true");
+			// Diagram source has no prose blocks to colour, and the fenced diagram
+			// carries no per-line anchors for selection comments.
+			expect(within(preview).queryByTestId("markdown-rich-diff")).toBeNull();
+			const document = within(preview).getByTestId("markdown-document");
+			expect(document.querySelector("[data-md-line-start]")).toBeNull();
+		});
+
 		it("shows a placeholder when previewing an empty markdown file", async () => {
 			vi.mocked(api.request.getTaskDiff).mockResolvedValue(markdownFilePayload({
 				status: "added",

--- a/src/mainview/components/pr-review/__tests__/markdown-files.test.ts
+++ b/src/mainview/components/pr-review/__tests__/markdown-files.test.ts
@@ -1,0 +1,26 @@
+import { isMarkdownPath, isMermaidPath, isRenderableDocPath, toRenderableMarkdown } from "../markdown-files";
+
+describe("markdown-files", () => {
+	it("recognizes markdown and mermaid documents by extension", () => {
+		expect(isMarkdownPath("docs/guide.md")).toBe(true);
+		expect(isMarkdownPath("docs/GUIDE.Markdown")).toBe(true);
+		expect(isMarkdownPath("docs/chart.mmd")).toBe(false);
+
+		expect(isMermaidPath("docs/chart.mmd")).toBe(true);
+		expect(isMermaidPath("docs/CHART.MMD")).toBe(true);
+		expect(isMermaidPath("docs/guide.md")).toBe(false);
+
+		expect(isRenderableDocPath("docs/chart.mmd")).toBe(true);
+		expect(isRenderableDocPath("docs/guide.md")).toBe(true);
+		expect(isRenderableDocPath("src/a.ts")).toBe(false);
+		// Not a suffix match: `.mmdx` and `readme.mdx` are other formats.
+		expect(isRenderableDocPath("docs/chart.mmdx")).toBe(false);
+		expect(isRenderableDocPath("docs/readme.mdx")).toBe(false);
+	});
+
+	it("fences mermaid sources and leaves markdown untouched", () => {
+		expect(toRenderableMarkdown("flowchart LR\nA --> B\n", "docs/chart.mmd"))
+			.toBe("```mermaid\nflowchart LR\nA --> B\n```");
+		expect(toRenderableMarkdown("# Title\n", "docs/guide.md")).toBe("# Title\n");
+	});
+});

--- a/src/mainview/components/pr-review/markdown-files.ts
+++ b/src/mainview/components/pr-review/markdown-files.ts
@@ -1,0 +1,20 @@
+/** Which file paths dev3 can show as a rendered document instead of source. */
+
+export function isMarkdownPath(path: string): boolean {
+	return /\.(md|markdown)$/i.test(path);
+}
+
+/** Standalone Mermaid diagram source (`.mmd`), rendered as a single diagram. */
+export function isMermaidPath(path: string): boolean {
+	return /\.mmd$/i.test(path);
+}
+
+export function isRenderableDocPath(path: string): boolean {
+	return isMarkdownPath(path) || isMermaidPath(path);
+}
+
+/** A `.mmd` file is diagram source, not markdown: fencing it is what makes the
+ * markdown renderer's mermaid plugin draw it. */
+export function toRenderableMarkdown(content: string, path: string): string {
+	return isMermaidPath(path) ? `\`\`\`mermaid\n${content.trimEnd()}\n\`\`\`` : content;
+}


### PR DESCRIPTION
Standalone Mermaid files (`.mmd`) now get the same rendered-document treatment as `.md`: the file preview modal draws the diagram with a **Rendered / Raw** toggle, and the diff viewer offers the per-file **Preview** toggle and previews the resulting diagram instead of raw diagram source. No new dependency — the markdown renderer already draws `mermaid` fences, so a `.mmd` file is fenced and handed to it.

Two deliberate differences from `.md`: diagram source has no prose blocks, so a modified `.mmd` never gets the rich prose diff (it always previews as the diagram), and the fence shifts line numbers, so the preview carries no per-line anchors for selection comments.

## Checklist

Full rules live in [`AGENTS.md`](https://github.com/h0x91b/dev-3.0/blob/main/AGENTS.md) and [`CONTRIBUTING.md`](https://github.com/h0x91b/dev-3.0/blob/main/CONTRIBUTING.md); this is the short list of things reviews most often bounce on. Delete the lines that do not apply.

- [x] Changelog entry under `change-logs/YYYY/MM/DD/` dated to the **expected merge day**, not the day work started (`feature-` entries need a `Short:` line)
- [x] Rebased on current `origin/main`
- [x] `bun run lint` clean and `bun run test:full` green — the plain `bun run test` skips the slow e2e suites that CI runs
- [x] User-facing strings go through `t()` and exist in all three locales (en / ru / es) — no new strings; the existing `Rendered`/`Raw`/`Preview` keys are reused
- [x] UI change: manual browser QA done; screenshots taken in streamer mode (`&streamer=on`)
- [x] PR is out of draft before requesting review

## Verification

`bun run lint` clean. Renderer 301 files / 4702 tests green, CLI 50 files / 868 tests green, backend 408/409 files green.

One backend file fails on my machine and I could not make it pass: `src/bun/__tests__/native-pane-owner-forward.test.ts` (10 tests), every one with `listen EINVAL` when binding its unix socket. The sandbox `TMPDIR` makes the socket path ~118 characters, over the ~104-byte `sun_path` limit, so it is a path-length limit rather than a code failure — it reproduces on an untouched tree and this change is renderer-only.

Browser QA in headless Chromium, streamer mode on, no console errors: a changed `.mmd` file in the diff viewer renders the diagram with **Preview** pressed and toggles back to the source diff; the file preview modal renders the diagram and switches to numbered source on **Raw**; `.md` and `.ts` files behave as before.
