### PR TITLE
Add dev3 attention --clear to lower the badge

### DIFF
--- a/change-logs/2026/08/27/feature-attention-clear.md
+++ b/change-logs/2026/08/27/feature-attention-clear.md
@@ -1,0 +1,3 @@
+Short: Clear the attention badge from the CLI
+
+`dev3 attention --clear` takes the red badge back down and drops every accumulated reason with it, so an agent that raised an alert during an incident can lower it once the incident is over instead of leaving a badge that outlives its cause. Clearing is never queued or silenced — it goes through even while Focus Mode is on, and it also removes badge events that were queued for that task, so a cleared badge cannot reappear when the queue flushes.

--- a/decisions/2026/08/27/attention-clear-ignores-focus-mode-and-silencing.md
+++ b/decisions/2026/08/27/attention-clear-ignores-focus-mode-and-silencing.md
@@ -1,0 +1,44 @@
+# `dev3 attention --clear` ignores Focus Mode and project silencing
+
+## Context
+
+`dev3 attention "reason"` lights the red task-card badge; reasons accumulate (newest 5 kept)
+and the badge only came down when the user opened the task. There was no inverse command, so a
+badge raised during an incident kept showing stale reasons long after the incident ended.
+
+## Investigation
+
+The badge is renderer state only (`bellCounts` / `bellReasons` in `src/mainview/state.ts`) — no
+disk, no `Task` field. Raising it is gated twice: `pushCliAttention`
+(`src/bun/rpc-handlers/shared.ts`) queues the push while Focus Mode or immersive terminal
+suppression is active, and `App.tsx` drops it when the project is silenced for streaming.
+
+## Decision
+
+`dev3 attention --clear` (`handleAttention` in `src/cli/commands/ui-control.ts`) sends
+`ui.attention` with `clear: true`. The socket handler (`src/bun/cli-socket-server.ts`) pushes
+`cliAttention` with `clear: true` **without** consulting either gate, and calls
+`dropQueuedAttention` (`src/bun/rpc-handlers/shared.ts`) to remove the task's queued attention
+calls *and* queued terminal bells — both light the same badge, so a clear that spared them
+would let the badge reappear at the next flush. `App.tsx` dispatches `clearBell` for the task,
+also bypassing the silencing check. Clearing displays nothing, so neither gate protects
+anything here; both would only keep a stale badge alive.
+
+`--clear` takes no reason. A "resolution reason" that replaced the accumulated list was
+rejected: it keeps the badge lit, which is the exact failure this command exists to fix.
+`--clear "text"` parses as `clear="text"` in the CLI's flag parser, so a valued `--clear` is a
+usage error rather than a silently swallowed argument.
+
+## Risks
+
+Clearing while the project is silenced on camera is invisible to the user until they leave
+streamer mode — acceptable, since the alternative is a badge nobody can lower. An agent could
+clear a badge the user has not seen yet; that is the same trade-off `dev3 attention` already
+makes in the other direction.
+
+## Alternatives considered
+
+- **Resolution reason replacing the list** — rejected, badge stays lit.
+- **Both `--clear` and a resolution reason** — rejected as two spellings for one job.
+- **Honouring Focus Mode / silencing on clear** — rejected: it would queue a clear behind the
+  badge it is meant to remove.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -97,6 +97,7 @@ vi.mock("../rpc-handlers", () => {
 		isTerminalFocusActive: vi.fn(() => false),
 		isNotificationSuppressed: vi.fn(() => false),
 		pushCliAttention: vi.fn(),
+		dropQueuedAttention: vi.fn(),
 		pushCliToast: vi.fn(),
 		pushCliShowImage: vi.fn(),
 		pushCliShowArtifact: vi.fn(),
@@ -171,7 +172,7 @@ vi.mock("node:fs", () => ({
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
-import { activateTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, pushCliAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "../rpc-handlers";
+import { activateTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, pushCliAttention, dropQueuedAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "../rpc-handlers";
 import { loadSettings } from "../settings";
 import { deliverAgentPrompt } from "../agent-prompt-delivery";
 import { runDevServer, stopDevServer, restartDevServer, getDevServerStatus } from "../rpc-handlers/tmux-pty";
@@ -1806,6 +1807,27 @@ describe("ui control (notify / attention / state)", () => {
 		expect(resp.ok).toBe(true);
 		expect(resp.data).toMatchObject({ delivered: true, taskId: task.id });
 		expect(pushFn).toHaveBeenCalledWith("cliAttention", { taskId: task.id, reason: "PR ready" });
+	});
+
+	it("ui.attention --clear: lowers the badge even while focus mode suppresses new ones", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		const pushFn = vi.fn();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(getPushMessage).mockReturnValue(pushFn);
+		vi.mocked(loadSettings).mockReturnValueOnce({ focusMode: true } as never);
+		vi.mocked(isNotificationSuppressed).mockReturnValue(true);
+
+		const resp = await handleRequest(
+			makeRequest("ui.attention", { taskId: task.id, projectId: project.id, reason: "", clear: true }),
+		);
+
+		expect(resp.ok).toBe(true);
+		expect(resp.data).toMatchObject({ delivered: true, taskId: task.id });
+		expect(dropQueuedAttention).toHaveBeenCalledWith(task.id);
+		expect(pushCliAttention).not.toHaveBeenCalled();
+		expect(pushFn).toHaveBeenCalledWith("cliAttention", { taskId: task.id, reason: "", clear: true });
 	});
 
 	it("ui.state: reports foreground and active context", async () => {

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -409,6 +409,9 @@ const {
 	setTerminalFocus,
 	setFocusMode,
 	isNotificationSuppressed,
+	pushCliAttention,
+	pushTerminalBell,
+	dropQueuedAttention,
 	emitTaskSound,
 	runCleanupScript,
 	portableReadKey,
@@ -13121,6 +13124,28 @@ describe("notifyWatchedTaskStatusChange", () => {
 
 		expect(Utils.showNotification).toHaveBeenCalledTimes(1);
 		expect(push).toHaveBeenCalledWith("webNotification", expect.objectContaining({ taskId: task.id }));
+	});
+});
+
+describe("dropQueuedAttention (dev3 attention --clear)", () => {
+	afterEach(() => {
+		setTerminalFocus(false);
+		setPushMessage(() => {});
+	});
+
+	it("drops a task's queued badges so the flush cannot resurrect them", () => {
+		const push = vi.fn();
+		setPushMessage(push);
+		setTerminalFocus(true);
+		pushCliAttention({ taskId: "task-cleared", projectId: "proj-1", reason: "blocked" });
+		pushTerminalBell("task-cleared");
+		pushCliAttention({ taskId: "task-other", projectId: "proj-1", reason: "still waiting" });
+
+		dropQueuedAttention("task-cleared");
+		setTerminalFocus(false);
+
+		expect(push).toHaveBeenCalledTimes(1);
+		expect(push).toHaveBeenCalledWith("cliAttention", expect.objectContaining({ taskId: "task-other" }));
 	});
 });
 

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -18,7 +18,7 @@ import type { AgentLaunchChoice } from "../shared/types";
 import { deliverLaunchHandoff } from "./agent-launch-handoff";
 import * as data from "./data";
 import { loadSpacesFile } from "./spaces-data";
-import { createScratchTask, deleteTask, getPushMessage, getPushMessageLocal, launchTaskWithAgentChoice, moveTask, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, pushCliAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "./rpc-handlers";
+import { createScratchTask, deleteTask, getPushMessage, getPushMessageLocal, launchTaskWithAgentChoice, moveTask, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, dropQueuedAttention, pushCliAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "./rpc-handlers";
 import { getDevServerStatus, runDevServer, stopDevServer, restartDevServer } from "./rpc-handlers/tmux-pty";
 import { getTmuxLayout } from "./pty-server";
 import { scheduleMessage as scheduleMessageCore, sendMessageImmediately } from "./scheduled-message-scheduler";
@@ -1531,11 +1531,21 @@ const handlers: Record<string, Handler> = {
 		return { delivered: true, mode: "toast", taskId };
 	},
 
-	// UI control: light the red attention badge on a task card with a reason.
+	// UI control: light the red attention badge on a task card with a reason,
+	// or (--clear) take it back down together with its accumulated reasons.
 	"ui.attention": async (params) => {
 		const reason = ((params.reason as string) ?? "").trim();
 		const { project, task } = await resolveTaskFromParams(params);
 		if ((await loadSettings()).focusMode) setFocusMode(true);
+		if (params.clear === true) {
+			// Never queued and never silenced: a stale badge has to go down even
+			// while Focus Mode or a silenced project holds new badges back.
+			dropQueuedAttention(task.id);
+			const clearPush = getPushMessage();
+			if (!clearPush) return { delivered: false, taskId: task.id };
+			clearPush("cliAttention", { taskId: task.id, reason: "", clear: true });
+			return { delivered: true, taskId: task.id, projectId: project.id };
+		}
 		if (isNotificationSuppressed()) {
 			pushCliAttention({ taskId: task.id, projectId: task.projectId, reason });
 			return { delivered: true, queued: true, taskId: task.id, projectId: project.id };

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -27,6 +27,7 @@ export {
 	isNotificationSuppressed,
 	queueTerminalFocusToast,
 	queueTerminalFocusAttention,
+	dropQueuedAttention,
 	isProjectSilenced,
 	setStreamerPrivacy,
 	pushCliToast,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -289,6 +289,21 @@ export function queueTerminalFocusAttention(payload: TerminalFocusAttentionPaylo
 	queuedTerminalNotifications.push({ kind: "attention", payload });
 }
 
+/**
+ * Drop a task's queued badge events (`dev3 attention --clear`). Attention calls
+ * and terminal bells light the same badge, so both go — otherwise a badge
+ * cleared during Focus Mode reappears when the queue flushes.
+ */
+export function dropQueuedAttention(taskId: string): void {
+	for (let i = queuedTerminalNotifications.length - 1; i >= 0; i--) {
+		const queued = queuedTerminalNotifications[i];
+		const isBadge = queued.kind === "attention" || queued.kind === "terminalBell";
+		if (isBadge && queued.payload.taskId === taskId) {
+			queuedTerminalNotifications.splice(i, 1);
+		}
+	}
+}
+
 export function pushCliToast(payload: TerminalFocusToastPayload): void {
 	if (isProjectSilenced(payload.projectId)) return;
 	if (isNotificationSuppressed()) {

--- a/src/cli/__tests__/ui-control.test.ts
+++ b/src/cli/__tests__/ui-control.test.ts
@@ -254,6 +254,41 @@ describe("attention", () => {
 		await expect(handleAttention(args(["x"]), SOCKET, CTX)).rejects.toThrow("EXIT_1");
 		expect(stderrOutput).toContain("Task not found");
 	});
+
+	it("clears the badge with --clear and sends no reason", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, taskId: CTX.taskId }));
+
+		await handleAttention(args([], { clear: "true" }), SOCKET, CTX);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "ui.attention", {
+			taskId: CTX.taskId,
+			reason: "",
+			clear: true,
+			projectId: CTX.projectId,
+		});
+		expect(stdoutOutput).toContain("Attention badge cleared");
+	});
+
+	it("refuses --clear together with a reason", async () => {
+		await expect(handleAttention(args(["all clear"], { clear: "true" }), SOCKET, CTX)).rejects.toThrow("EXIT_3");
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(stderrOutput).toContain("--clear cannot carry a reason");
+	});
+
+	// `--clear "text"` parses as clear="text": reject it instead of swallowing the text.
+	it("refuses a valued --clear", async () => {
+		await expect(handleAttention(args([], { clear: "all clear" }), SOCKET, CTX)).rejects.toThrow("EXIT_3");
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(stderrOutput).toContain("--clear takes no value");
+	});
+
+	it("reports a windowless app when clearing", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: false, taskId: CTX.taskId }));
+
+		await handleAttention(args([], { clear: "true" }), SOCKET, CTX);
+
+		expect(stdoutOutput).toContain("nothing to clear");
+	});
 });
 
 // ─── ui state ────────────────────────────────────────────────────────────────

--- a/src/cli/commands/ui-control.ts
+++ b/src/cli/commands/ui-control.ts
@@ -121,15 +121,26 @@ export async function handleNotify(
 /**
  * `dev3 attention "reason"` — light the red attention badge on a task card, with
  * an optional hoverable reason. Same visual surface as the terminal bell.
+ * `dev3 attention --clear` takes the badge back down with its reasons.
  */
 export async function handleAttention(
 	args: ParsedArgs,
 	socketPath: string,
 	context: CliContext | null,
 ): Promise<void> {
-	rejectUnknownFlags(args, ["task", "task-id", "project", "reason"]);
+	rejectUnknownFlags(args, ["task", "task-id", "project", "reason", "clear"]);
+
+	const clear = "clear" in args.flags;
+	// `--clear "text"` would silently swallow the text as the flag's value, so a
+	// valued --clear is a usage error rather than a half-understood command.
+	if (clear && args.flags.clear !== "true") {
+		exitUsage("--clear takes no value. Lower the badge with `dev3 attention --clear`.");
+	}
 
 	const reason = (args.positional[0] ?? args.flags.reason ?? "").toString().trim();
+	if (clear && reason) {
+		exitUsage("--clear cannot carry a reason. Raise with `dev3 attention \"reason\"`, lower with `dev3 attention --clear`.");
+	}
 	if (reason.length > NOTIFY_MAX_LEN) {
 		exitUsage(`Reason too long (${reason.length} chars). Keep it under ${NOTIFY_MAX_LEN} characters.`);
 	}
@@ -140,13 +151,24 @@ export async function handleAttention(
 	}
 
 	const params: Record<string, unknown> = { taskId: expandShortId(rawTaskId, context), reason };
+	if (clear) params.clear = true;
 	const projectId = resolveProjectId(args.flags.project, context);
 	if (projectId) params.projectId = projectId;
 
 	const resp = await sendRequest(socketPath, "ui.attention", params);
-	if (!resp.ok) exitError(resp.error || "Failed to raise attention");
+	if (!resp.ok) exitError(resp.error || (clear ? "Failed to clear attention" : "Failed to raise attention"));
 
 	const data = resp.data as { delivered: boolean; taskId: string; queued?: boolean; suppressed?: boolean };
+	if (clear) {
+		// Clearing is never queued or suppressed — a badge that outlived its cause
+		// must go down even while Focus Mode is on.
+		if (!data.delivered) {
+			process.stdout.write("App is running but has no open window — nothing to clear.\n");
+			return;
+		}
+		process.stdout.write(`Attention badge cleared on task ${data.taskId.slice(0, 8)}.\n`);
+		return;
+	}
 	if (data.queued) {
 		process.stdout.write("Attention badge queued until Focus Mode ends.\n");
 		return;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -435,12 +435,15 @@ const COMMANDS: CommandHelp[] = [
 	},
 	{
 		name: "attention",
-		summary: "Light the red attention badge on a task card, with an optional reason.",
+		summary: "Light the red attention badge on a task card, or clear it.",
 		subcommands: [],
-		usage: 'dev3 attention "reason" [--task <id>]',
+		usage: 'dev3 attention "reason" | --clear [--task <id>]',
 		details: [
 			"Same visual surface as the terminal bell; the reason shows on hover.",
-			"The badge clears when the user opens the task.",
+			"Reasons accumulate (newest 5 kept) until the badge is cleared.",
+			"--clear      Lower the badge now and drop every accumulated reason.",
+			"The badge also clears when the user opens the task.",
+			"--clear takes no reason; clear a resolved alert, then raise a new one if needed.",
 			"Targets the current worktree's task; override with --task <id>.",
 		],
 	},

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -81,6 +81,7 @@ Commands:
   dev3 dev-server status [task-id]      Show task dev server status
   dev3 notify "msg" [--level info|success|error] [--desktop]  Show an in-app toast (or OS notification); clicking opens the task
   dev3 attention "reason" [--task <id>] Light the red attention badge on the task card (reason shows on hover)
+  dev3 attention --clear [--task <id>]  Lower the attention badge and drop its accumulated reasons
   dev3 message "text" [--in <dur> | --at <hh:mm>] [--task <id>]  Send text to the task's live agent now, or schedule it (Send later)
   dev3 show-image <path> [--caption "..."] [<path> ...]  Show images (screenshots/renders) in an in-app viewer bound to the task; each --caption annotates the preceding image
   dev3 show-artifact <file.html> [--assets <file...>] [--title "..."]  Show a task-bound HTML artifact; local CSS, JS, and images are exported as ZIP

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1501,8 +1501,14 @@ function App() {
 	// the terminal bell, but carries a hoverable reason.
 	useEffect(() => {
 		function onCliAttention(e: Event) {
-			const { taskId, projectId, reason } = (e as CustomEvent).detail as { taskId: string; projectId?: string; reason: string };
+			const { taskId, projectId, reason, clear } = (e as CustomEvent).detail as { taskId: string; projectId?: string; reason: string; clear?: boolean };
 			if (!taskId) return;
+			// Clearing shows nothing, so a silenced project must not keep a stale
+			// badge lit; only raising a badge is gated on display silencing.
+			if (clear) {
+				dispatch({ type: "clearBell", taskId });
+				return;
+			}
 			if (isProjectSilencedForDisplay(projectId)) return;
 			dispatch({ type: "addBell", taskId, reason: reason ?? "" });
 		}

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1311,6 +1311,32 @@ describe("App keyboard shortcuts", () => {
 
 			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-bell-count", "2"));
 		});
+
+		it("lowers the badge when `dev3 attention --clear` arrives", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue(oneProject);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliAttention", {
+					detail: { taskId: "t-overflow", projectId: "p1", reason: "blocked" },
+				}));
+				window.dispatchEvent(new CustomEvent("rpc:cliAttention", {
+					detail: { taskId: "t-overflow", projectId: "p1", reason: "still blocked" },
+				}));
+			});
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-bell-count", "2"));
+
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliAttention", {
+					detail: { taskId: "t-overflow", projectId: "p1", reason: "", clear: true },
+				}));
+			});
+
+			await waitFor(() => expect(screen.getByTestId("project-screen")).toHaveAttribute("data-bell-count", "0"));
+		});
 	});
 
 	describe("route restore on launch", () => {

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -212,6 +212,7 @@ const SKILL_GET_ATTENTION = `
 Pull the user back to this task deliberately — enough that they never miss something that needs them, never as per-step noise. These commands auto-target the current worktree's task:
 
 - \`dev3 attention "reason"\` — red badge on the task card; persists until the user opens the task (reasons accumulate, up to 5). Default for anything that needs the user.
+- \`dev3 attention --clear\` — lower that badge and drop every reason with it, the moment the thing you raised it for is resolved and the user never came. A badge that outlives its cause trains the user to ignore badges.
 - \`dev3 notify "message" [--level info|success|error] [--duration <seconds>]\` — clickable in-app toast (ephemeral; duration is 2s–30s, the \`s\` suffix is optional). \`--duration\` applies only to in-app toasts.
 - \`dev3 notify "message" [--level info|success|error] --desktop\` — sends a native OS notification that shows even when the app is backgrounded; do not combine \`--desktop\` with \`--duration\`.
 - \`dev3 show-image <path> [--caption "..."] [<path> ...]\` — **show the user actual images** (screenshots, \`agent-browser\` captures, rendered charts) in an in-app viewer; files are copied into the worktree, and **each \`--caption\` annotates the image it immediately follows** (e.g. \`dev3 show-image before.png --caption "current bug" after.png --caption "after my fix"\`). If pixels exist and are relevant, put them in front of the user — never just describe a picture or leave a path they must open themselves.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5431,9 +5431,10 @@ export type AppRPCSchema = {
 			/**
 			 * CLI-initiated attention signal (`dev3 attention`). Lights the red bell
 			 * badge on the task card with a hoverable `reason`, same surface the
-			 * terminal bell uses.
+			 * terminal bell uses. `clear: true` (`dev3 attention --clear`) lowers the
+			 * badge and drops every accumulated reason instead of adding one.
 			 */
-			cliAttention: { taskId: string; reason: string };
+			cliAttention: { taskId: string; reason: string; clear?: boolean };
 			/**
 			 * CLI-shared images (`dev3 show-image`). Carries the task's shared images
 			 * so the renderer can raise the attention badge and open the lightbox


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

`dev3 attention "reason"` could raise the red task-card badge but nothing could lower it — reasons accumulate (newest 5 kept) and the badge only came down when the user opened the task, so a badge raised during an incident kept showing stale reasons long after it was over.

`dev3 attention --clear` now lowers the badge and drops every accumulated reason with it. Details:

- Spelling matches its siblings (`overview clear`, `label set --clear`); `--clear` takes no reason, and a valued `--clear "text"` is a usage error rather than a silently swallowed argument.
- Clearing bypasses Focus Mode and project silencing, and drops the task's queued attention calls *and* queued terminal bells (`dropQueuedAttention`) — otherwise a cleared badge reappears at the next flush.
- `--help`, the top-level command listing and the shipped agent skill (`SKILL_GET_ATTENTION`) all document the flag. `ask-dev3` needed no change: it describes the badge in prose and never names the command.
- Covered in the CLI, backend and renderer suites; verified in a browser against a scoped QA board (badge raised → count 3 → cleared → gone).

Decision record: `decisions/2026/08/27/attention-clear-ignores-focus-mode-and-silencing.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=e572c610-c357-47a6-a827-289f2530dce5) · `dev3://task/e572c610-c357-47a6-a827-289f2530dce5`