### PR TITLE
Stop leaving dead tmux socket files on the machine

### DIFF
--- a/change-logs/2026/08/27/fix-tmux-socket-file-leak.md
+++ b/change-logs/2026/08/27/fix-tmux-socket-file-leak.md
@@ -1,0 +1,3 @@
+Short: Stop leaving dead tmux sockets
+
+dev3 no longer accumulates dead tmux socket files in the system temp directory forever: every test that mints a pid-keyed socket now unlinks it, and the app sweeps dev3-prefixed sockets with nothing listening on them once at startup. Two leaking test temp directories were fixed the same way. Measured on the maintainer's machine: 1 374 stale socket files and 25 591 leftover directories, none of which anything ever removed.

--- a/decisions/2026/08/27/tmux-socket-liveness-by-connect-not-ps.md
+++ b/decisions/2026/08/27/tmux-socket-liveness-by-connect-not-ps.md
@@ -1,0 +1,79 @@
+# Dead tmux sockets are detected by connecting to them, not by reading `ps`
+
+## Context
+
+tmux leaves its socket FILE on disk when the server dies, and `kill-server` does
+not unlink it. Every dev3 test that mints a pid-keyed socket name
+(`dev3-live-test-<pid>`, `dev3-seam-<pid>`, …) therefore added one file that
+nothing ever removed. Measured on the maintainer's machine on 2026-08-27:
+**1 413 socket files in `/tmp/tmux-501` behind 6 live servers**, growing by one
+per e2e run. No observed harm — tmux unlinks a stale socket and starts fresh —
+so this is hygiene, not an incident.
+
+Fixing it needs one dangerous question answered correctly: *is anything still
+using this socket?* Getting it wrong deletes the socket of the app's own running
+tmux server.
+
+## Investigation
+
+The obvious check is the process table: a tmux server advertises its socket in
+its process title, `tmux: server (/private/tmp/tmux-501/dev3-live-guarded-42)`.
+The fixtures in `src/bun/__tests__/terminal-e2e-guard.test.ts` assert exactly
+that string, so it reads as established fact.
+
+**It is not true on macOS.** Measured with `ps -Ao pid=,command=` against a live
+54-session dev3 server: that server appears as the single word `tmux`, with no
+socket path anywhere in the output. tmux clients do show their `-L <name>` argv;
+servers do not. A first implementation built on this parsed the real process
+table, found **zero** live servers, and proposed deleting 1 343 files including
+the socket of the running app — caught only by a dry run before anything was
+unlinked. The guard's own fixtures were synthetic, and a comment is not evidence.
+
+A `connect()` to the unix socket answers the question directly and needs no
+process table at all. Verified both directions: the live `dev3` socket connects
+(and still had all 54 sessions afterwards), and real leftover files answer
+`ENOENT`.
+
+## Decision
+
+`src/bun/tmux/socket-files.ts` holds the socket-directory resolution
+(`$TMUX_TMPDIR` else `/tmp`, plus `tmux-<uid>` — mirroring tmux's `make_label()`),
+`removeTmuxSocketFile`, and the pure sweep decision `selectSweepableSockets`.
+`src/bun/tmux/socket-sweep.ts` holds the IO shell: `probeSocketLiveness` (a
+bounded `net.connect`, where `ENOENT`/`ECONNREFUSED` means dead and anything else
+means `unknown`) and `sweepDeadTmuxSockets`, wired into startup in
+`src/bun/index.ts` next to `sweepStaleWorktreeTrust`.
+
+Five conditions must all hold before a file is unlinked: `dev3-` prefix, owned by
+our uid, actually a socket, older than one minute, and nothing listening.
+`unknown` liveness keeps the file. `TmuxClient.killServer()` kills the server and
+unlinks the socket in one call, and every e2e script that mints a pid-keyed
+socket calls it.
+
+The split into two files is load-bearing: `socket-files.ts` imports only
+`node:fs`/`node:path`, so a renderer test can use the unlink helper without
+pulling in the logger or `tmux/binary.ts`'s module-load side effects.
+
+## Risks
+
+- A socket whose server is mid-bind could read as dead. The one-minute age gate
+  covers it, and the app's own long-lived `dev3` socket is additionally outside
+  the `dev3-` prefix.
+- pid reuse could put a live server on a name we consider stale; the connect
+  probe answers per-file at sweep time, so this is exactly what it rules out.
+- The probe opens and immediately drops a connection on a live tmux server. tmux
+  handles that the same way it handles a crashed client; verified against a live
+  54-session server with no session loss.
+- `terminal-e2e-guard.ts` still cannot see a leaked tmux SERVER on macOS, for the
+  reason above. Not changed here — it catches tmux clients, and widening it is a
+  separate question.
+
+## Alternatives considered
+
+- **`ps` parsing** — measured wrong on macOS; see above.
+- **`lsof -U`** — exact, but seconds of runtime and an extra external binary for
+  a startup path.
+- **`tmux -L <name> has-session`** — tmux starts a server for most commands, so
+  probing 1 400 sockets would spawn servers rather than find them.
+- **Age alone (delete anything older than N days)** — cannot distinguish a live
+  long-running server from garbage, which is the whole problem.

--- a/src/bun/__tests__/agent-message-spill.test.ts
+++ b/src/bun/__tests__/agent-message-spill.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../logger", () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
@@ -24,6 +24,11 @@ const task = { id: "t1", projectId: "p1" } as Task;
 beforeEach(async () => {
 	vi.clearAllMocks();
 	getProject.mockResolvedValue({ id: "p1", path: "/tmp/proj" });
+	await rm(taskDirRoot, { recursive: true, force: true });
+});
+
+// beforeEach alone leaves the LAST run's directory on disk, one per pid, forever.
+afterAll(async () => {
 	await rm(taskDirRoot, { recursive: true, force: true });
 });
 

--- a/src/bun/__tests__/native-message-owner-routing.bun-e2e.ts
+++ b/src/bun/__tests__/native-message-owner-routing.bun-e2e.ts
@@ -555,6 +555,9 @@ async function runSender(): Promise<void> {
 				// best-effort
 			}
 		}
+		// Unconditional: a half-started sentinel still left a socket FILE behind,
+		// and tmux never unlinks one. The name is pid-keyed, so nothing else owns it.
+		await tmux.killServer({ socket: sentinelSocket });
 		try {
 			rmSync(root, { recursive: true, force: true });
 		} catch {

--- a/src/bun/__tests__/native-task-terminal.bun-e2e.ts
+++ b/src/bun/__tests__/native-task-terminal.bun-e2e.ts
@@ -1045,6 +1045,9 @@ async function run(): Promise<void> {
 				// best-effort
 			}
 		}
+		// Unconditional: a half-started sentinel still left a socket FILE behind,
+		// and tmux never unlinks one. The name is pid-keyed, so nothing else owns it.
+		await tmux.killServer({ socket: sentinelSocket });
 		try {
 			rmSync(root, { recursive: true, force: true });
 		} catch {

--- a/src/bun/__tests__/pane-exit-e2e.ts
+++ b/src/bun/__tests__/pane-exit-e2e.ts
@@ -10,12 +10,15 @@
  */
 // electrobun + data + agents are stubbed via --preload (see pane-exit-e2e-preload.ts)
 import { spawnSync as nodeSpawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Project, Task, PaneSessionEntry } from "../../shared/types";
 import * as pty from "../pty-server";
 import { launchTaskPty, handlePaneExited } from "../rpc-handlers/tmux-pty";
+// Leaf import, not the tmux barrel: this script runs under a preload that mocks
+// whole modules, and the barrel pulls in far more than the unlink helper.
+import { removeTmuxSocketFile } from "../tmux/socket-files";
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -79,6 +82,9 @@ function tmuxSync(args: string[]): ReturnType<typeof nodeSpawnSync> {
 function cleanup(): void {
 	try { pty.destroySession(TASK_ID, TEST_SOCKET); } catch { /* ignore */ }
 	try { tmuxSync(["-L", TEST_SOCKET, "kill-server"]); } catch { /* ignore */ }
+	// kill-server leaves the socket FILE behind, and this name is pid-keyed.
+	removeTmuxSocketFile(TEST_SOCKET);
+	try { rmSync(WORK_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 
 async function waitFor(fn: () => boolean, timeoutMs = 10_000, intervalMs = 100): Promise<void> {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -326,6 +326,16 @@ log.info("CLI socket server ready", { path: cliSocketPath });
 	sweepStaleWorktreeTrust();
 }
 
+// tmux never unlinks a socket file when its server dies, and every pid-keyed
+// socket name is one file that would otherwise stay forever. Conservative:
+// dev3-prefixed, ours, no live server behind it, older than a minute.
+{
+	const { sweepDeadTmuxSockets } = await import("./tmux");
+	sweepDeadTmuxSockets().catch((err) => {
+		log.warn("Startup tmux socket sweep failed (non-fatal)", { err: String(err) });
+	});
+}
+
 // Side-effect: starts the PTY WebSocket server (dynamic import so PATH is patched first)
 const { setOnPtyDied, setOnBell, setOnIdle, setOnPaneExited, setOnOsc52Copy, getActiveSessionIds, getPtyPort, registerBackpressureProbe } = await import("./pty-server");
 const { setNativeDevServerProbe, startPortScanPoller, stopPortScanPoller } = await import("./port-scanner");

--- a/src/bun/terminal-backend/__tests__/contract-conformance.test.ts
+++ b/src/bun/terminal-backend/__tests__/contract-conformance.test.ts
@@ -94,16 +94,23 @@ async function codeOf(run: () => Promise<unknown>): Promise<TerminalBackendError
 }
 
 describe.each(CASES)("TerminalBackend contract — $name", (testCase) => {
-	let cleanupFn: (() => void) | undefined;
+	// A list, not one slot: two tests below build a second harness of their own, and
+	// a single slot silently dropped their cleanup — one leaked temp dir per run.
+	const cleanups: (() => void)[] = [];
 
 	afterEach(() => {
-		cleanupFn?.();
-		cleanupFn = undefined;
+		for (const cleanup of cleanups.splice(0)) cleanup();
 	});
 
-	function world() {
+	/** Every harness in this suite comes from here, so none escapes cleanup. */
+	function harnessOf(): ReturnType<ConformanceCase["setup"]> {
 		const harness = testCase.setup();
-		cleanupFn = harness.cleanup;
+		if (harness.cleanup) cleanups.push(harness.cleanup);
+		return harness;
+	}
+
+	function world() {
+		const harness = harnessOf();
 		return { ...harness, backend: harness.create() };
 	}
 
@@ -268,7 +275,7 @@ describe.each(CASES)("TerminalBackend contract — $name", (testCase) => {
 	});
 
 	it("keeps view ids stable for a fresh controller and lets it capture (reconnect)", async () => {
-		const harness = testCase.setup();
+		const harness = harnessOf();
 		const owner = harness.create();
 		const created = await owner.openSession({ id: SESSION, cwd: CWD });
 		const attachment = await owner.attachView(SESSION);
@@ -295,7 +302,7 @@ describe.each(CASES)("TerminalBackend contract — $name", (testCase) => {
 	});
 
 	it("keeps the session alive across dispose (sessions are persistent)", async () => {
-		const harness = testCase.setup();
+		const harness = harnessOf();
 		const backend = harness.create();
 		const created = await backend.openSession({ id: SESSION, cwd: CWD });
 		await backend.dispose();

--- a/src/bun/terminal-backend/__tests__/fake-coordinator-world.ts
+++ b/src/bun/terminal-backend/__tests__/fake-coordinator-world.ts
@@ -6,22 +6,27 @@
  * (killViewProcess, geometry) the conformance suite needs.
  */
 
+import { rmSync } from "node:fs";
 import { NATIVE_MULTIPANE_DIR_ENV } from "../../native-terminal-multipane/paths";
 import { createFakeRegistry, type FakeRegistry } from "../../native-terminal-multipane/__tests__/fake-panes";
 import type { CoordinatorDeps } from "../../native-terminal-multipane/coordinator";
 
 export class FakeCoordinatorWorld {
 	readonly registry: FakeRegistry;
+	private readonly tempDir: string;
 
 	constructor() {
 		// Use a fresh temp dir override so coordinator records don't collide.
-		const tmp = `/tmp/dev3-fake-coordinator-${Math.random().toString(36).slice(2)}`;
-		process.env[NATIVE_MULTIPANE_DIR_ENV] = tmp;
+		this.tempDir = `/tmp/dev3-fake-coordinator-${Math.random().toString(36).slice(2)}`;
+		process.env[NATIVE_MULTIPANE_DIR_ENV] = this.tempDir;
 		this.registry = createFakeRegistry();
 	}
 
 	cleanup(): void {
 		delete process.env[NATIVE_MULTIPANE_DIR_ENV];
+		// One dir per instance, so without this every test run leaves one behind
+		// forever: 25 591 of them had piled up in /tmp before this line existed.
+		rmSync(this.tempDir, { recursive: true, force: true });
 	}
 
 	deps(): Partial<CoordinatorDeps> {

--- a/src/bun/terminal-backend/__tests__/tmux-backend.live-e2e.test.ts
+++ b/src/bun/terminal-backend/__tests__/tmux-backend.live-e2e.test.ts
@@ -71,6 +71,8 @@ describe.skipIf(!TMUX_VERSION || process.platform === "win32")(
 		afterAll(async () => {
 			await backend.dispose();
 			await client.killSession(SESSION, { bestEffort: true }).catch(() => {});
+			// The pid-keyed socket FILE outlives the server unless we unlink it.
+			await client.killServer({ socket });
 			rmSync(workDir, { recursive: true, force: true });
 		});
 

--- a/src/bun/tmux/__tests__/client.test.ts
+++ b/src/bun/tmux/__tests__/client.test.ts
@@ -14,7 +14,11 @@ import {
 	STATUS_GEOMETRY_FORMAT,
 } from "../formats";
 import { activeTmuxConfigPath } from "../config";
+import { tmuxSocketPath } from "../socket-files";
 import { DEV3_HOME } from "../../paths";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 
 // The client is constructed with an INJECTED fake spawn — the only seam its
 // own tests use. Assertions target external behavior: the argv handed to
@@ -64,6 +68,43 @@ describe("argv construction", () => {
 		const client = new TmuxClient({ spawn: spawnFn as never, socket: "custom" });
 		await client.killSession("s");
 		expect(argvOf(spawnFn).slice(0, 3)).toEqual(["tmux", "-L", "custom"]);
+	});
+
+	it("killServer kills the server AND unlinks the socket file tmux leaves behind", async () => {
+		const root = mkdtempSync(join(tmpdir(), "dev3-socket-file-"));
+		const previous = process.env.TMUX_TMPDIR;
+		process.env.TMUX_TMPDIR = root;
+		try {
+			const socketPath = tmuxSocketPath("dev3-live-test-42");
+			mkdirSync(dirname(socketPath), { recursive: true });
+			writeFileSync(socketPath, "");
+			const { client, spawnFn } = makeClient();
+			await client.killServer({ socket: "dev3-live-test-42" });
+			expect(argvOf(spawnFn)).toEqual(["tmux", "-L", "dev3-live-test-42", "kill-server"]);
+			expect(existsSync(socketPath)).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.TMUX_TMPDIR;
+			else process.env.TMUX_TMPDIR = previous;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("killServer still unlinks the socket file when there is no server to kill", async () => {
+		const root = mkdtempSync(join(tmpdir(), "dev3-socket-file-"));
+		const previous = process.env.TMUX_TMPDIR;
+		process.env.TMUX_TMPDIR = root;
+		try {
+			const socketPath = tmuxSocketPath("dev3-live-test-43");
+			mkdirSync(dirname(socketPath), { recursive: true });
+			writeFileSync(socketPath, "");
+			const { client } = makeClient({ exited: Promise.resolve(1), stderr: "no server running" });
+			await expect(client.killServer({ socket: "dev3-live-test-43" })).resolves.toBeUndefined();
+			expect(existsSync(socketPath)).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.TMUX_TMPDIR;
+			else process.env.TMUX_TMPDIR = previous;
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("pipes stdout and stderr for every run", async () => {

--- a/src/bun/tmux/__tests__/guarded-send.bun-e2e.ts
+++ b/src/bun/tmux/__tests__/guarded-send.bun-e2e.ts
@@ -109,6 +109,8 @@ async function tearDown(): Promise<void> {
 	for (const session of [MINE, OTHER]) {
 		await client.killSession(session, { socket: SOCKET, bestEffort: true }).catch(() => undefined);
 	}
+	// The pid-keyed socket FILE outlives the server unless we unlink it.
+	await client.killServer({ socket: SOCKET });
 	rmSync(root, { recursive: true, force: true });
 }
 

--- a/src/bun/tmux/__tests__/socket-files.test.ts
+++ b/src/bun/tmux/__tests__/socket-files.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+	SWEEP_MIN_AGE_MS,
+	type SocketLiveness,
+	isSweepCandidate,
+	selectSweepableSockets,
+	tmuxSocketDir,
+	tmuxSocketPath,
+} from "../socket-files";
+
+const NOW = 1_800_000_000_000;
+const OLD = NOW - SWEEP_MIN_AGE_MS - 1;
+const US = 501;
+
+function facts(
+	name: string,
+	over: { uid?: number; mtimeMs?: number; isSocket?: boolean; liveness?: SocketLiveness } = {},
+) {
+	return {
+		name,
+		uid: over.uid ?? US,
+		mtimeMs: over.mtimeMs ?? OLD,
+		isSocket: over.isSocket ?? true,
+		liveness: over.liveness ?? ("dead" as SocketLiveness),
+	};
+}
+
+function sweep(files: ReturnType<typeof facts>[]) {
+	return selectSweepableSockets({ files, ourUid: US, nowMs: NOW });
+}
+
+describe("tmuxSocketDir", () => {
+	it("mirrors tmux: /tmp plus tmux-<uid>, and TMPDIR is deliberately ignored", () => {
+		expect(tmuxSocketDir({ TMPDIR: "/var/folders/zz/" }, 501)).toBe("/tmp/tmux-501");
+	});
+
+	it("follows TMUX_TMPDIR when tmux would, so a scoped instance sweeps its own dir", () => {
+		expect(tmuxSocketDir({ TMUX_TMPDIR: "/scratch" }, 501)).toBe("/scratch/tmux-501");
+	});
+
+	it("treats an empty TMUX_TMPDIR as unset", () => {
+		expect(tmuxSocketDir({ TMUX_TMPDIR: "" }, 7)).toBe("/tmp/tmux-7");
+	});
+
+	it("composes a full socket path", () => {
+		expect(tmuxSocketPath("dev3-live-test-42", {}, 501)).toBe("/tmp/tmux-501/dev3-live-test-42");
+	});
+});
+
+describe("isSweepCandidate", () => {
+	it("is what decides whether a file is worth a connect at all", () => {
+		expect(isSweepCandidate(facts("dev3-seam-1"), US, NOW)).toBe(true);
+		expect(isSweepCandidate(facts("default"), US, NOW)).toBe(false);
+		expect(isSweepCandidate(facts("dev3-seam-1", { uid: 502 }), US, NOW)).toBe(false);
+		expect(isSweepCandidate(facts("dev3-seam-1", { isSocket: false }), US, NOW)).toBe(false);
+		expect(isSweepCandidate(facts("dev3-seam-1", { mtimeMs: NOW - 1_000 }), US, NOW)).toBe(false);
+	});
+});
+
+describe("selectSweepableSockets", () => {
+	it("removes a dev3 socket of ours with nothing listening on it", () => {
+		expect(sweep([facts("dev3-live-test-99")]).remove).toEqual(["dev3-live-test-99"]);
+	});
+
+	// The guard this whole module exists to keep. Break the liveness check in
+	// selectSweepableSockets and this is the test that goes red.
+	it("KEEPS a socket that something is still listening on", () => {
+		const decision = sweep([facts("dev3-live-test-99"), facts("dev3-seam-100", { liveness: "listening" })]);
+		expect(decision.remove).toEqual(["dev3-live-test-99"]);
+		expect(decision.kept).toBe(1);
+	});
+
+	it("KEEPS a socket whose liveness could not be established — unknown is not dead", () => {
+		expect(sweep([facts("dev3-seam-100", { liveness: "unknown" })]).remove).toEqual([]);
+	});
+
+	it("keeps the app's own default socket while its server is live", () => {
+		expect(sweep([facts("dev3", { liveness: "listening" })]).remove).toEqual([]);
+	});
+
+	it("never touches a socket that is not dev3-prefixed", () => {
+		expect(sweep([facts("default"), facts("claude-swarm"), facts("mysocket")]).remove).toEqual([]);
+	});
+
+	it("never touches a socket belonging to another user", () => {
+		expect(sweep([facts("dev3-seam-1", { uid: 502 })]).remove).toEqual([]);
+	});
+
+	it("never touches something in that directory that is not a socket", () => {
+		expect(sweep([facts("dev3-seam-1", { isSocket: false })]).remove).toEqual([]);
+	});
+
+	it("leaves a freshly created socket alone — its server may still be binding", () => {
+		expect(sweep([facts("dev3-seam-1", { mtimeMs: NOW - 1_000 })]).remove).toEqual([]);
+	});
+
+	it("counts kept as everything it did not remove", () => {
+		const decision = sweep([facts("dev3-seam-1"), facts("default"), facts("dev3-seam-2")]);
+		expect(decision.remove).toEqual(["dev3-seam-1", "dev3-seam-2"]);
+		expect(decision.kept).toBe(1);
+	});
+});

--- a/src/bun/tmux/__tests__/socket-sweep.test.ts
+++ b/src/bun/tmux/__tests__/socket-sweep.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { join } from "node:path";
+import { probeSocketLiveness, sweepDeadTmuxSockets } from "../socket-sweep";
+import { tmuxSocketDir } from "../socket-files";
+
+let root = "";
+let dir = "";
+let previousTmpdir: string | undefined;
+const servers: net.Server[] = [];
+
+/**
+ * A socket file with no listener — exactly what tmux leaves behind. Made the
+ * honest way: a child process binds it and is SIGKILLed, so nothing unlinks it.
+ * `server.close()` would remove the file and prove nothing.
+ */
+function orphanedSocketFile(path: string): void {
+	// A hard exit skips the unlink that `server.close()` would do, which is
+	// exactly how a dead tmux server leaves its socket behind.
+	const script = `require("node:net").createServer().listen(${JSON.stringify(path)},()=>process.exit(0));`;
+	const child = spawnSync(process.execPath, ["-e", script], { timeout: 10_000 });
+	if (!existsSync(path)) throw new Error(`failed to orphan a socket at ${path}: ${child.stderr?.toString() ?? ""}`);
+}
+
+/** Backdate a path past SWEEP_MIN_AGE_MS so the age gate does not hide the result. */
+function backdate(path: string): void {
+	const old = new Date(Date.now() - 10 * 60_000);
+	utimesSync(path, old, old);
+}
+
+function listenOn(path: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		servers.push(server);
+		server.once("error", reject);
+		server.listen(path, () => resolve());
+	});
+}
+
+beforeEach(() => {
+	// Short root on purpose: a unix socket path is capped at ~104 bytes, and the
+	// suite's own TMPDIR is already long enough to blow that on its own.
+	root = mkdtempSync("/tmp/d3sw-");
+	previousTmpdir = process.env.TMUX_TMPDIR;
+	process.env.TMUX_TMPDIR = root;
+	dir = tmuxSocketDir();
+	mkdirSync(dir, { recursive: true });
+});
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) await new Promise<void>((r) => server.close(() => r()));
+	if (previousTmpdir === undefined) delete process.env.TMUX_TMPDIR;
+	else process.env.TMUX_TMPDIR = previousTmpdir;
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === "win32")("probeSocketLiveness", () => {
+	it("reports a socket with a listener as listening", async () => {
+		const path = join(dir, "dev3-live-probe");
+		await listenOn(path);
+		expect(await probeSocketLiveness(path)).toBe("listening");
+	});
+
+	it("reports an orphaned socket file — the whole point of this module — as dead", async () => {
+		const path = join(dir, "dev3-orphan-probe");
+		orphanedSocketFile(path);
+		expect(statSync(path).isSocket()).toBe(true);
+		expect(await probeSocketLiveness(path)).toBe("dead");
+	});
+
+	it("reports a path that is not there as dead", async () => {
+		expect(await probeSocketLiveness(join(dir, "dev3-never-existed"))).toBe("dead");
+	});
+});
+
+describe.skipIf(process.platform === "win32")("sweepDeadTmuxSockets", () => {
+	it("removes an orphaned dev3 socket and leaves a live one alone", async () => {
+		const orphan = join(dir, "dev3-live-test-99991");
+		const alive = join(dir, "dev3-live-test-99992");
+		orphanedSocketFile(orphan);
+		backdate(orphan);
+		await listenOn(alive);
+		backdate(alive);
+
+		const result = await sweepDeadTmuxSockets();
+
+		expect(existsSync(orphan)).toBe(false);
+		expect(existsSync(alive)).toBe(true);
+		expect(result.removed).toBe(1);
+	});
+
+	it("leaves a non-dev3 socket, a plain file and a fresh socket untouched", async () => {
+		const foreign = join(dir, "default");
+		const plainFile = join(dir, "dev3-not-a-socket");
+		const fresh = join(dir, "dev3-live-test-99993");
+		orphanedSocketFile(foreign);
+		backdate(foreign);
+		writeFileSync(plainFile, "");
+		backdate(plainFile);
+		orphanedSocketFile(fresh); // deliberately NOT backdated
+
+		const result = await sweepDeadTmuxSockets();
+
+		expect(existsSync(foreign)).toBe(true);
+		expect(existsSync(plainFile)).toBe(true);
+		expect(existsSync(fresh)).toBe(true);
+		expect(result.removed).toBe(0);
+	});
+});

--- a/src/bun/tmux/__tests__/tmux-client-live-e2e.test.ts
+++ b/src/bun/tmux/__tests__/tmux-client-live-e2e.test.ts
@@ -73,6 +73,8 @@ describe.skipIf(!TMUX_VERSION)("TmuxClient against a live tmux server", () => {
 		for (const name of [SESSION, "dev3-livetest2"]) {
 			await client.killSession(name, { bestEffort: true }).catch(() => {});
 		}
+		// The pid-keyed socket FILE outlives the server unless we unlink it.
+		await client.killServer({ socket: SOCKET });
 		rmSync(workDir, { recursive: true, force: true });
 	});
 

--- a/src/bun/tmux/client.ts
+++ b/src/bun/tmux/client.ts
@@ -28,6 +28,7 @@ import { activeTmuxConfigPath, tmuxClientCwd } from "./config";
 import { TmuxError, TmuxSpawnError, TmuxTimeoutError } from "./errors";
 import type { TmuxFormat } from "./formats";
 import { PANE_ID_FORMAT, PANE_SIGHTING_FORMAT } from "./formats";
+import { removeTmuxSocketFile } from "./socket-files";
 
 type SpawnFn = typeof defaultSpawn;
 type SpawnedProcess = ReturnType<SpawnFn>;
@@ -176,6 +177,17 @@ export class TmuxClient {
 	/** `kill-session -t`. */
 	killSession(session: string, opts?: CommandOpts): Promise<void> {
 		return this.runCommand(opts?.socket, ["kill-session", "-t", session], opts);
+	}
+
+	/**
+	 * `kill-server`, then unlink the socket file it leaves behind. tmux never
+	 * removes that file itself, so whoever mints a socket name has to — this is
+	 * the one call that does both. Always best-effort: there may be no server.
+	 */
+	async killServer(opts?: SocketOpt): Promise<void> {
+		const socket = opts?.socket ?? this.defaultSocket;
+		await this.run(socket, ["kill-server"]).catch(() => undefined);
+		removeTmuxSocketFile(socket);
 	}
 
 	/** `list-sessions -F` parsed through a typed format declaration. */

--- a/src/bun/tmux/index.ts
+++ b/src/bun/tmux/index.ts
@@ -9,6 +9,8 @@
  * - config.ts      bundled tmux config generator + client-cwd policy
  * - themes.ts      Catppuccin plugin payload
  * - alt-click.ts   pure logic for the Alt/Option-click cursor-move gesture
+ * - socket-files.ts  the socket FILE on disk: path resolution + sweep decision
+ * - socket-sweep.ts  the IO shell that applies that decision at startup
  * - errors.ts      TmuxError / TmuxSpawnError
  *
  * HARD RULE: never spawn `tmux` directly outside this module — always go
@@ -17,6 +19,18 @@
 export { tmux, TmuxClient } from "./client";
 export type { TmuxClientOptions, SplitOrientation, TmuxLayoutName } from "./client";
 export { DEFAULT_TMUX_SOCKET, CAPTURE_SCROLLBACK_START_LINE } from "./constants";
+export {
+	tmuxSocketDir,
+	tmuxSocketPath,
+	removeTmuxSocketFile,
+	isSweepCandidate,
+	selectSweepableSockets,
+	SWEEP_SOCKET_PREFIX,
+	SWEEP_MIN_AGE_MS,
+} from "./socket-files";
+export type { SocketFileFacts, SocketLiveness, SweepDecision } from "./socket-files";
+export { sweepDeadTmuxSockets, probeSocketLiveness } from "./socket-sweep";
+export type { SweepResult } from "./socket-sweep";
 export { TmuxError, isTmuxError, TmuxSpawnError, isTmuxSpawnError, TmuxTimeoutError, isTmuxTimeoutError } from "./errors";
 export {
 	tmuxFormat,

--- a/src/bun/tmux/socket-files.ts
+++ b/src/bun/tmux/socket-files.ts
@@ -1,0 +1,110 @@
+/**
+ * The tmux socket FILE, as opposed to the tmux server behind it.
+ *
+ * tmux leaves the socket file on disk when its server dies, and `kill-server`
+ * does not unlink it. Every pid-keyed socket name (`dev3-live-test-<pid>`) is
+ * therefore one file that never goes away — 1353 of them accumulated on the
+ * maintainer's machine behind a single live server before this module existed.
+ *
+ * dev3 does not compose the socket directory anywhere else: the client always
+ * passes `-L <name>` and tmux resolves the directory itself. This is the one
+ * place that mirrors that resolution, and it is read-only about it — nothing
+ * here sets TMUX_TMPDIR or renames anything.
+ */
+import { unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/** Only files with this prefix are ever swept. Never widen it. */
+export const SWEEP_SOCKET_PREFIX = "dev3-";
+
+/**
+ * A socket younger than this is left alone even when nothing answers on it: a
+ * server that has just been asked for may not have finished binding.
+ */
+export const SWEEP_MIN_AGE_MS = 60_000;
+
+/**
+ * Where tmux puts `-L <name>`: `$TMUX_TMPDIR` else `/tmp`, plus `tmux-<uid>`.
+ * Mirrors tmux's own `make_label()`; `/tmp` is hardcoded there, so TMPDIR is
+ * deliberately not consulted.
+ */
+export function tmuxSocketDir(env: NodeJS.ProcessEnv = process.env, uid = process.getuid?.() ?? 0): string {
+	const base = env.TMUX_TMPDIR && env.TMUX_TMPDIR.length > 0 ? env.TMUX_TMPDIR : "/tmp";
+	return join(base, `tmux-${uid}`);
+}
+
+export function tmuxSocketPath(socket: string, env?: NodeJS.ProcessEnv, uid?: number): string {
+	return join(tmuxSocketDir(env, uid), socket);
+}
+
+/**
+ * Unlink one socket file. Returns whether a file was actually removed, so a
+ * caller can tell "cleaned up" from "was never there".
+ */
+export function removeTmuxSocketFile(socket: string, env?: NodeJS.ProcessEnv): boolean {
+	try {
+		unlinkSync(tmuxSocketPath(socket, env));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Whether anything is listening on a socket file. `unknown` is not a synonym for
+ * `dead`: an unreadable socket protects itself.
+ */
+export type SocketLiveness = "listening" | "dead" | "unknown";
+
+export interface SocketFileFacts {
+	readonly name: string;
+	readonly uid: number;
+	readonly mtimeMs: number;
+	/** Guards against unlinking something in that directory that is not a socket. */
+	readonly isSocket: boolean;
+	readonly liveness: SocketLiveness;
+}
+
+export interface SweepDecision {
+	readonly remove: readonly string[];
+	readonly kept: number;
+}
+
+/**
+ * Cheap, no-IO pre-filter: worth probing at all? Prefix, ownership and age only,
+ * so the sweep opens a connection to a couple of dozen files instead of every
+ * socket on the machine.
+ */
+export function isSweepCandidate(
+	file: Pick<SocketFileFacts, "name" | "uid" | "isSocket" | "mtimeMs">,
+	ourUid: number,
+	nowMs: number,
+	minAgeMs = SWEEP_MIN_AGE_MS,
+): boolean {
+	if (!file.name.startsWith(SWEEP_SOCKET_PREFIX)) return false;
+	if (file.uid !== ourUid) return false;
+	if (!file.isSocket) return false;
+	return nowMs - file.mtimeMs >= minAgeMs;
+}
+
+/**
+ * Which socket files are safe to unlink. Pure, because a cleanup guard that
+ * stops guarding looks exactly like a clean machine.
+ *
+ * Five conditions, all required: dev3-prefixed name, owned by us, actually a
+ * socket, older than {@link SWEEP_MIN_AGE_MS}, and NOTHING listening on it.
+ */
+export function selectSweepableSockets(input: {
+	readonly files: readonly SocketFileFacts[];
+	readonly ourUid: number;
+	readonly nowMs: number;
+	readonly minAgeMs?: number;
+}): SweepDecision {
+	const remove: string[] = [];
+	for (const file of input.files) {
+		if (!isSweepCandidate(file, input.ourUid, input.nowMs, input.minAgeMs)) continue;
+		if (file.liveness !== "dead") continue;
+		remove.push(file.name);
+	}
+	return { remove, kept: input.files.length - remove.length };
+}

--- a/src/bun/tmux/socket-sweep.ts
+++ b/src/bun/tmux/socket-sweep.ts
@@ -1,0 +1,128 @@
+/**
+ * The IO shell around {@link selectSweepableSockets}: read the socket directory,
+ * ask each candidate socket whether anything is listening, unlink what the pure
+ * decision allows.
+ *
+ * WHY A CONNECT PROBE AND NOT THE PROCESS TABLE. The obvious check is to look for
+ * `tmux: server (/tmp/tmux-501/<name>)` in `ps`, and the fixtures in
+ * `terminal-e2e-guard.test.ts` assume that string exists. MEASURED on macOS 15:
+ * it does not. A live tmux server appears in `ps -Ao pid=,command=` as the single
+ * word `tmux`, with no socket path anywhere, so a ps-based sweep sees ZERO live
+ * servers and would have deleted the socket of the app's own running server. A
+ * connect() to the socket answers the question directly instead: listening, or
+ * nothing there. Verified against a live 54-session dev3 server (still 54
+ * sessions afterwards) and against real leftover files.
+ *
+ * Split from socket-files.ts on purpose — that module has no dependencies beyond
+ * node:fs, so a renderer test can import the unlink helper without dragging in
+ * the logger, the spawn wrapper, or the tmux binary's module-load side effects.
+ */
+import { readdirSync, statSync, unlinkSync } from "node:fs";
+import net from "node:net";
+import { join } from "node:path";
+import { createLogger } from "../logger";
+import {
+	type SocketFileFacts,
+	type SocketLiveness,
+	isSweepCandidate,
+	selectSweepableSockets,
+	tmuxSocketDir,
+} from "./socket-files";
+
+const log = createLogger("tmux");
+
+const PROBE_TIMEOUT_MS = 300;
+const PROBE_BATCH = 32;
+
+/**
+ * Is anything listening on this unix socket? A dead tmux socket answers ENOENT
+ * or ECONNREFUSED depending on the platform; every other outcome — a timeout, a
+ * permission error — is `unknown`, which keeps the file.
+ */
+export function probeSocketLiveness(path: string, timeoutMs = PROBE_TIMEOUT_MS): Promise<SocketLiveness> {
+	return new Promise((resolve) => {
+		const socket = net.connect({ path });
+		const done = (verdict: SocketLiveness): void => {
+			socket.removeAllListeners();
+			try {
+				socket.destroy();
+			} catch {
+				// already gone
+			}
+			resolve(verdict);
+		};
+		socket.setTimeout(timeoutMs, () => done("unknown"));
+		socket.once("connect", () => done("listening"));
+		socket.once("error", (err: NodeJS.ErrnoException) => {
+			done(err.code === "ENOENT" || err.code === "ECONNREFUSED" ? "dead" : "unknown");
+		});
+	});
+}
+
+type RawFacts = Omit<SocketFileFacts, "liveness">;
+
+function readSocketFiles(dir: string): RawFacts[] {
+	let names: string[];
+	try {
+		names = readdirSync(dir);
+	} catch {
+		return [];
+	}
+	const files: RawFacts[] = [];
+	for (const name of names) {
+		try {
+			const stat = statSync(join(dir, name));
+			files.push({ name, uid: stat.uid, mtimeMs: stat.mtimeMs, isSocket: stat.isSocket() });
+		} catch {
+			// Vanished between readdir and stat, or unreadable — leave it alone.
+		}
+	}
+	return files;
+}
+
+export interface SweepResult {
+	readonly removed: number;
+	readonly kept: number;
+}
+
+/**
+ * Remove dev3-prefixed socket files with nothing listening on them. Runs once at
+ * startup; best-effort by construction, since every failure mode is "one stale
+ * file stays on disk".
+ */
+export async function sweepDeadTmuxSockets(): Promise<SweepResult> {
+	if (process.platform === "win32") return { removed: 0, kept: 0 };
+	const dir = tmuxSocketDir();
+	const raw = readSocketFiles(dir);
+	const ourUid = process.getuid?.() ?? -1;
+	const nowMs = Date.now();
+	// Only candidates are probed: prefix, ownership and age are free, a connect is
+	// not. Batched, because a first sweep on a machine that has been leaking for
+	// months has over a thousand of them and each probe holds a descriptor.
+	const files: SocketFileFacts[] = [];
+	for (let i = 0; i < raw.length; i += PROBE_BATCH) {
+		const batch = raw.slice(i, i + PROBE_BATCH);
+		files.push(
+			...(await Promise.all(
+				batch.map(async (file) => ({
+					...file,
+					liveness: isSweepCandidate(file, ourUid, nowMs)
+						? await probeSocketLiveness(join(dir, file.name))
+						: ("unknown" as SocketLiveness),
+				})),
+			)),
+		);
+	}
+	const decision = selectSweepableSockets({ files, ourUid, nowMs });
+	let removed = 0;
+	for (const name of decision.remove) {
+		try {
+			unlinkSync(join(dir, name));
+			removed += 1;
+		} catch {
+			// Another instance swept it first, or it is not ours to remove.
+		}
+	}
+	if (removed > 0) log.info("swept dead tmux socket files", { dir, removed, kept: decision.kept });
+	return { removed, kept: decision.kept };
+}

--- a/src/mainview/__tests__/shift-keys-e2e.test.ts
+++ b/src/mainview/__tests__/shift-keys-e2e.test.ts
@@ -30,6 +30,9 @@ import {
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+// Leaf import, not the tmux barrel: the barrel's binary module has module-load
+// side effects that have no business running in a renderer test.
+import { removeTmuxSocketFile } from "../../bun/tmux/socket-files";
 
 // ── Production tmux config ────────────────────────────────────────────────────
 // Copied from src/bun/pty-server.ts (TMUX_CONFIG constant).
@@ -256,6 +259,8 @@ describe.skipIf(!tmuxAvailable || !python3Available)(
 				stdio: "ignore",
 				env: isolatedTmuxEnv(),
 			});
+			// kill-server leaves the socket FILE behind, and this name is pid-keyed.
+			removeTmuxSocketFile(tmuxSocket);
 			pythonProc?.kill();
 			if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
 		});


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

dev3 was leaving dead tmux socket files on the machine forever. tmux keeps the socket FILE on disk when its server dies, and `kill-server` does not unlink it, so every pid-keyed socket name an e2e script mints (`dev3-live-test-<pid>`, `dev3-seam-<pid>`, …) added one file that nothing ever removed. Measured on the maintainer's machine: **1 413 files in `/tmp/tmux-501` behind 6 live servers**, growing by one per e2e run. No observed harm — tmux unlinks a stale socket and starts fresh — so this is hygiene, not an incident, and the change is deliberately small.

### What changed

- **`TmuxClient.killServer()`** kills the server and unlinks its socket in one call, so "whoever mints a socket owns removing it" is a single typed method rather than a convention. Every e2e script that mints a pid-keyed socket now calls it (`dev3-seam`, `dev3-live-test`, `dev3-live-guarded`, `dev3-e2e`, `dev3-native-task-e2e`, `dev3-native-message-e2e`).
- **A conservative startup sweep** (`sweepDeadTmuxSockets`, wired in next to `sweepStaleWorktreeTrust`). Five conditions must all hold before anything is unlinked: `dev3-` prefix, owned by our uid, actually a socket, older than a minute, and nothing listening on it.
- **Two leaking test temp directories**, same class of bug: `FakeCoordinatorWorld` never removed its own dir (25 591 leftovers in `/tmp`), two conformance tests built a harness whose cleanup was silently dropped, and the message-spill suite cleaned up in `beforeEach` only, leaving the last run's dir behind.

### The one non-obvious bit

The natural liveness check is `ps` — a tmux server advertises its socket in its process title, and the fixtures in `terminal-e2e-guard.test.ts` assert exactly that string. **On macOS it is not true**: a live 54-session dev3 server appears in `ps -Ao pid=,command=` as the single word `tmux`, with no path anywhere. A first implementation built on that found zero live servers and would have deleted the running app's own socket. The sweep uses a bounded `net.connect()` instead — listening, dead, or unknown, where unknown keeps the file. Full reasoning in `decisions/2026/08/27/tmux-socket-liveness-by-connect-not-ps.md`.

### Evidence

- **Per-family socket counts before and after running each script**: `dev3-seam` 361→361, `dev3-live-test` 320→320, `dev3-live-guarded` 82→82, `dev3-e2e` 195→195, `dev3-native-task-e2e` 59→59, `dev3-native-message-e2e` 44→44. Counterfactual with the cleanup removed and nothing else changed: +1 each.
- **The sweep on the real machine**: 1 374 removed, 39 kept, and **zero of the 6 sockets that were listening** were touched (the live `dev3` server still had all 55 sessions afterwards).
- **The liveness guard is mutation-verified**: deleting the `file.liveness !== "dead"` check turns three tests red, including one that unlinks a genuinely listening socket on disk.
- Leftover-directory counts are zero-delta across two consecutive runs of each affected suite.

### Two things found on the way, not fixed here

- `test:pane-e2e` is broken on `main` (`Export named 'findConfig' not found in module src/bun/agents.ts` — its preload mocks `agents.ts` without that export). Proven pre-existing by stripping this branch's edits out of that file and re-running. It is not in `TERMINAL_E2E_SCRIPTS`, so CI never runs it.
- `terminal-e2e-guard` cannot see a leaked tmux *server* on macOS, for the same `ps` reason. It still catches tmux clients.

Also still unremoved, for the record, and left alone here: ~626 per-task script files in `/tmp` (`dev3-<task-uuid>-run.sh`, `-setup.sh`, `-cleanup.sh`, `-cmd.sh`, `-dev.sh`, `-startup.sh`, `-pane-runs/`), plus the long-lived `dev3-shell/`, `dev3-tmux-{dark,light}.conf` and `dev3-catppuccin/`. The task-keyed ones are the obvious next candidate; they need care, since a live task's run script must not be swept.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ecc2a956-b549-49a4-878d-eb2a9daa77e8) · `dev3://task/ecc2a956-b549-49a4-878d-eb2a9daa77e8`
