### PR TITLE
Describe the real board delivery seam in the coordinator-board header

### DIFF
--- a/change-logs/2026/08/27/docs-coordinator-board-header-real-delivery-seam.md
+++ b/change-logs/2026/08/27/docs-coordinator-board-header-real-delivery-seam.md
@@ -1,0 +1,3 @@
+The module header of `src/shared/coordinator-board.ts` described a `UserPromptSubmit` hook that was built and then removed before the feature shipped, and cited a decision record that does not exist. It now describes the real delivery seam (the `coordinatorBoardEpilogue` trailer on `deliverAgentPrompt`), names the user's own pane typing as a known limitation instead of omitting it, and points at the record that actually shipped.
+
+Suggested by @mcaldas (h0x91b/dev-3.0#1539)

--- a/src/bun/coordinator-board.ts
+++ b/src/bun/coordinator-board.ts
@@ -1,5 +1,6 @@
 /**
- * Collect the `<dev3-board>` snapshot a coordinator receives on every turn.
+ * Collect the `<dev3-board>` snapshot a coordinator receives on every delivered
+ * message.
  *
  * The contract and the rendering live in `shared/coordinator-board`; this module
  * only gathers the facts. The design constraint that shapes it: this runs on

--- a/src/shared/coordinator-board.ts
+++ b/src/shared/coordinator-board.ts
@@ -1,5 +1,6 @@
 /**
- * The `<dev3-board>` snapshot a coordinator agent receives on every turn.
+ * The `<dev3-board>` snapshot dev3 appends to every message it delivers to a
+ * coordinator agent.
  *
  * A coordinator's picture of the board used to be a snapshot it had to refresh
  * by hand (`COORDINATOR_PROMPT`: "not a feed"), which cost a tool call and only
@@ -7,12 +8,17 @@
  * walks the child tasks, changes things, comes back to the coordinator and asks
  * a question — and the coordinator answers from a picture taken before that walk.
  *
- * So the snapshot rides the turn instead. It is injected by the
- * `UserPromptSubmit` hook, which fires for EVERY turn — the user's own Enter and
- * a peer agent's `dev3 message` alike, since a delivered message is text plus an
- * Enter and reaches the harness as an ordinary prompt.
+ * So the snapshot rides the delivery instead: `renderCoordinatorBoard` is called
+ * by `coordinatorBoardEpilogue` (`src/bun/coordinator-board.ts`), which
+ * `deliverToTarget` hands to `deliverAgentPrompt` as its epilogue — the one seam
+ * behind immediate `dev3 message` sends, the "Send to agent" UI and scheduled fires.
  *
- * Two rules hold this together:
+ * KNOWN LIMITATION: the user typing into the pane himself carries no block, since
+ * those keystrokes reach the pty directly and nothing hooks that path.
+ * `COORDINATOR_PROMPT` names the gap and tells a coordinator to re-read the board
+ * when the user speaks to it after a silence.
+ *
+ * Three rules hold this together:
  *  - Board state is a PASSENGER of a turn, never its driver. Nothing here may
  *    wake an agent up; a timer that pushed the board into a pane on its own
  *    would make the coordinator chatter and burn tokens on "nothing changed".
@@ -26,9 +32,9 @@
  *    once, so 45 of 60 panes carry one identical timestamp that jumps in a herd.
  *    See `decisions/2026/08/25/board-age-is-column-age-not-terminal-silence.md`.
  *
- * Rendering is pure and lives in shared/ so the socket payload and the hook
- * output can never drift apart. See
- * `decisions/2026/08/25/inject-the-board-into-every-coordinator-turn.md`.
+ * This module holds the contract plus the pure renderer; `src/bun/coordinator-board.ts`
+ * fills that contract from live task state. See
+ * `decisions/2026/08/25/ride-the-board-in-on-messages-to-a-coordinator.md`.
  */
 
 import { formatAge } from "./task-peek";


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that made this change).

The module header of `src/shared/coordinator-board.ts` described a `UserPromptSubmit` hook design that was built and then removed before the feature shipped, and cited a decision-record path that does not exist. Reported in #1539 by @mcaldas.

All three reported claims verified against the code:

- **No hook.** `renderCoordinatorBoard` has exactly one production caller, `coordinatorBoardEpilogue` (`src/bun/coordinator-board.ts:105`), handed to `deliverAgentPrompt` as its `epilogue` by `deliverToTarget` (`src/bun/scheduled-message-scheduler.ts:79`) — the shared seam behind immediate `dev3 message` sends, "Send to agent", and scheduled fires. The `UserPromptSubmit` hooks dev3 installs (`src/shared/agent-hooks.ts:220,269`) only run `dev3 task move`.
- **No hook output to drift against.** The `shared/` justification named a consumer that does not exist; replaced with the real reason (contract plus pure renderer, filled by the bun-side collector).
- **Dangling record path.** `inject-the-board-into-every-coordinator-turn` had exactly 1 hit in the whole tree — that header line. The record shipped as `ride-the-board-in-on-messages-to-a-coordinator.md`, which documents the removal.

The header now describes the real delivery seam, states the user's own pane typing as a KNOWN LIMITATION (consistent with what `COORDINATOR_PROMPT` already says), and points at the record that exists. It also fixes a "Two rules" count over a three-item list, and the same "on every turn" phrasing in the sibling `src/bun/coordinator-board.ts` header.

Comment-only: no behaviour change, no new tests. The pane-typing gap itself is deliberately out of scope.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c52711d9-1fe2-4b4c-b353-5c659f4edd89) · `dev3://task/c52711d9-1fe2-4b4c-b353-5c659f4edd89`
