### PR TITLE
Stop non-installed builds from writing the managed dev3 CLI

### DIFF
--- a/change-logs/2026/08/27/fix-dev-builds-no-longer-replace-the-managed-cli.md
+++ b/change-logs/2026/08/27/fix-dev-builds-no-longer-replace-the-managed-cli.md
@@ -1,0 +1,3 @@
+Short: Dev builds stop hijacking the dev3 CLI
+
+Running the dev loop (`bun run dev`, or `dev3 dev-server start`) no longer overwrites the machine-wide `~/.dev3.0/bin/dev3` that every agent and terminal runs — a source run used to point it at the `bun` binary (breaking every command with `Script not found`), and a local app build used to copy its own unmerged branch build over it silently. Only an installed build writes that name now; a developer who wants their branch's CLI there can opt in with `DEV3_INSTALL_MANAGED_CLI=1`.

--- a/decisions/2026/08/27/dev-builds-never-write-the-managed-cli.md
+++ b/decisions/2026/08/27/dev-builds-never-write-the-managed-cli.md
@@ -1,0 +1,80 @@
+# Dev builds never write the managed `~/.dev3.0/bin/dev3`
+
+## Context
+
+`~/.dev3.0/bin/dev3` is a single, frozen, machine-wide entry. Agent hooks, the injected dev3
+skill and lifecycle `onExit` commands all invoke the CLI through that absolute path (`DEV3_CLI`
+in `src/shared/agent-hooks.ts`), and every installed version of the app on the machine shares
+the same `~/.dev3.0` (AGENTS.md, on-disk invariants). There is one name, so whoever writes it
+last owns the CLI every agent and the user run.
+
+Running `bun run dev` — the project's own documented dev loop, and what `dev3 dev-server start`
+executes — was writing it. On a machine with several agents doing browser QA in parallel, the
+rule was "whichever agent ran the dev loop most recently wins the shared CLI". Three independent
+sightings landed in one night (2026-08-26/27) before anyone connected them.
+
+## Investigation
+
+Two observed failure shapes, and they came from **two different write paths**, not one:
+
+| Shape | Write path | What the user sees |
+|---|---|---|
+| `bin/dev3` symlinked to the `bun` runtime | `src/bun/headless-entry.ts` → `ensureDev3CliSymlink(DEV3_HOME, process.execPath)`; under `bun run …` `process.execPath` **is** bun | every command dies with `error: Script not found "tasks"` |
+| `bin/dev3` replaced by a 76 MB build from an unmerged branch | `src/bun/index.ts` startup `installBinary()` copies `<bundle>/Resources/app/cli/dev3` over it | nothing — the CLI works, from the wrong code |
+
+Both reproduced before the fix: a source-run `dev3 remote start` produced
+`bin/dev3 -> /opt/homebrew/Cellar/bun/1.3.14/bin/bun`, and one `dev3 dev-server start` moved the
+real `~/.dev3.0/bin/dev3` from the installed app's build `c8cdeb2d` to this worktree's `2107fbc9`.
+
+There is **no repair timer** and nothing self-heals. The two-minute "recovery" in the first
+sighting was simply the next writer: the installed app rewrites the name on every launch, so a
+relaunch (or another agent's dev loop) overwrote the broken entry.
+
+A third writer, `installDev3Cli` in `src/bun/rpc-handlers/settings-config.ts`, exists behind
+Settings → "Install dev3 CLI". It is a deliberate user action and is left alone.
+
+## Decision
+
+`src/bun/managed-cli-guard.ts` holds one predicate, `mayWriteManagedCli`, and both automatic
+entry points call it before touching the name (`src/bun/index.ts` around `installBinary`,
+`src/bun/headless-entry.ts` around `ensureDev3CliSymlink`).
+
+Rule order is load-bearing:
+
+1. The `dev` channel Electrobun bakes into a locally built bundle (`Resources/version.json`)
+   positively identifies a non-install → refuse, unless `DEV3_INSTALL_MANAGED_CLI=1`.
+2. **Any other channel is an install, and this answer must come before the source check** — the
+   desktop app's own main process runs a `bun` binary from inside its bundle
+   (`…/Contents/MacOS/bun`), so a source check placed first would refuse the installed app and
+   break exactly what the guard protects.
+3. A bare `bun` (`detectInstallMethod(…) === "source"`) has nothing to install → refuse, and the
+   opt-in deliberately does **not** reach here: honouring it would aim the shared name at the bun
+   runtime, which is the original crash.
+4. No channel readable and not bun → fail **open**, so an install with an unfamiliar layout keeps
+   working.
+
+The opt-in is explicit, never default, and reversible the way `dev3 doctor` already documents:
+relaunch the installed app and it rewrites the name from its own bundle.
+
+## Risks
+
+- **Fail-open on an unreadable channel.** A future non-install arrangement that carries no
+  `version.json` and is not bun would still write. Chosen over the alternative, which is silently
+  breaking real installs.
+- **The channel string is Electrobun's, not ours.** If it ever stops baking `channel: "dev"` into
+  local builds, the first rule goes quiet. The source check still catches the bun shape.
+- **Nothing stops a fourth writer.** The guard is convention plus a comment, not an enforced
+  invariant — same posture as the "always go through TmuxClient" rule.
+
+## Alternatives considered
+
+- **A second filename for dev builds** (`bin/dev3-dev`). Rejected: dev3 already has a second name,
+  `dev3-self`, for instance pinning, and nothing generated ever names a second CLI, so the shim
+  would exist and be reached by nobody.
+- **Keep writing, restore on exit.** Rejected: an agent's dev server is killed far more often than
+  it exits, so the restore is the path least likely to run. It also cannot survive N agents running
+  the dev loop concurrently — restoring "the previous value" would resurrect another branch's build.
+- **Do nothing and document it.** Rejected: the silent shape (a working CLI from the wrong branch)
+  produces no symptom at all, so documentation cannot be acted on.
+- **Renaming or moving anything under `~/.dev3.0`.** Forbidden outright by the frozen on-disk
+  layout rules.

--- a/src/bun/__tests__/managed-cli-guard.test.ts
+++ b/src/bun/__tests__/managed-cli-guard.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	DEV_BUILD_CHANNEL,
+	MANAGED_CLI_OPT_IN_ENV,
+	mayWriteManagedCli,
+	resolveBuildChannel,
+} from "../managed-cli-guard";
+
+const DEV3_HOME = "/Users/x/.dev3.0";
+
+function verdict(over: Partial<Parameters<typeof mayWriteManagedCli>[0]> = {}) {
+	return mayWriteManagedCli({
+		buildChannel: "canary",
+		execPath: "/opt/homebrew/Cellar/dev3/1.48.1/libexec/dev3",
+		dev3Home: DEV3_HOME,
+		platform: "darwin",
+		env: {},
+		...over,
+	});
+}
+
+describe("mayWriteManagedCli", () => {
+	it("lets an installed build own the shared CLI", () => {
+		expect(verdict().write).toBe(true);
+	});
+
+	it("refuses a dev-channel build — the `bun run dev` bundle", () => {
+		const v = verdict({ buildChannel: DEV_BUILD_CHANNEL });
+		expect(v.write).toBe(false);
+		expect(v.why).toContain("not an install");
+	});
+
+	it("refuses a source run, where execPath is the bun binary", () => {
+		const v = verdict({ buildChannel: null, execPath: "/opt/homebrew/Cellar/bun/1.3.14/bin/bun" });
+		expect(v.write).toBe(false);
+		expect(v.why).toContain("running from source");
+	});
+
+	it("does NOT refuse the installed app's own bundled bun — a known channel decides first", () => {
+		// The desktop app's main process IS a `bun` binary inside the bundle. If the
+		// source check ran before the channel check, this guard would break the app
+		// it exists to protect.
+		expect(verdict({ buildChannel: "canary", execPath: "/Applications/dev-3.0.app/Contents/MacOS/bun" }).write).toBe(
+			true,
+		);
+	});
+
+	it("fails open when no channel can be read and the binary is a real install", () => {
+		expect(verdict({ buildChannel: null }).write).toBe(true);
+	});
+
+	it("honours the explicit opt-in for a dev build, which does have a CLI to hand over", () => {
+		expect(verdict({ buildChannel: DEV_BUILD_CHANNEL, env: { [MANAGED_CLI_OPT_IN_ENV]: "1" } }).write).toBe(true);
+	});
+
+	it("does not let the opt-in resurrect a source run — bun is not a CLI", () => {
+		const v = verdict({
+			buildChannel: null,
+			execPath: "/opt/homebrew/Cellar/bun/1.3.14/bin/bun",
+			env: { [MANAGED_CLI_OPT_IN_ENV]: "1" },
+		});
+		expect(v.write).toBe(false);
+		expect(v.why).toContain("running from source");
+	});
+
+	it("treats anything other than exactly `1` as no opt-in", () => {
+		for (const value of ["0", "", "true", "yes"]) {
+			expect(verdict({ buildChannel: DEV_BUILD_CHANNEL, env: { [MANAGED_CLI_OPT_IN_ENV]: value } }).write).toBe(false);
+		}
+	});
+
+	it("always says why, so a skipped install is never silent", () => {
+		expect(verdict({ buildChannel: DEV_BUILD_CHANNEL }).why.length).toBeGreaterThan(10);
+		expect(verdict().why.length).toBeGreaterThan(10);
+	});
+});
+
+const roots: string[] = [];
+function bundle(channel: string | null, name = "dev-3.0.app"): string {
+	const root = mkdtempSync(join(tmpdir(), "dev3-guard-"));
+	roots.push(root);
+	const resources = join(root, name, "Contents", "Resources");
+	mkdirSync(join(resources, "app", "cli"), { recursive: true });
+	if (channel !== null) {
+		writeFileSync(join(resources, "version.json"), JSON.stringify({ version: "1.48.1", channel }));
+	}
+	return join(resources, "app", "cli", "dev3");
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveBuildChannel", () => {
+	it("reads the channel from the Resources dir above the binary", () => {
+		expect(resolveBuildChannel(bundle("dev", "dev-3.0-dev.app"))).toBe("dev");
+		expect(resolveBuildChannel(bundle("canary"))).toBe("canary");
+	});
+
+	it("returns null when the bundle carries no version.json", () => {
+		expect(resolveBuildChannel(bundle(null))).toBeNull();
+	});
+
+	it("returns null for a path with no Resources ancestor at all", () => {
+		expect(resolveBuildChannel("/opt/homebrew/Cellar/dev3/1.48.1/libexec/dev3")).toBeNull();
+	});
+
+	it("returns null rather than throwing on a corrupt version.json", () => {
+		const binary = bundle("canary");
+		writeFileSync(join(binary, "..", "..", "..", "version.json"), "{ not json");
+		expect(resolveBuildChannel(binary)).toBeNull();
+	});
+
+	it("terminates at the filesystem root instead of looping", () => {
+		expect(resolveBuildChannel("/")).toBeNull();
+	});
+});

--- a/src/bun/headless-entry.ts
+++ b/src/bun/headless-entry.ts
@@ -24,6 +24,7 @@ import { handlers, setPushMessage, getPushMessage, handleBellAutoStatus, isTaskI
 import { createLogger, getLogPath } from "./logger";
 import { DEV3_HOME } from "./paths";
 import { ensureDev3CliSymlink } from "./cli-self-install";
+import { managedCliWriteAllowed } from "./managed-cli-guard";
 import { applyFullShellEnvToProcess, getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
 import { startRemoteAccessServer, pushToBrowserClients, getServerPort, getAccessUrl } from "./remote-access-server";
@@ -175,7 +176,11 @@ if (!process.env.DEV3_VIEWS_DIR) {
 // the CLI by that absolute path (agent-hooks.ts `DEV3_CLI`). The GUI keeps it
 // current; a headless `dev3 remote` box otherwise inherits a stale/dangling
 // entry, so every hook fails with "…/.dev3.0/bin/dev3: not found".
-ensureDev3CliSymlink(DEV3_HOME, process.execPath);
+//
+// Not from a source checkout, though: there `process.execPath` IS the `bun`
+// binary, so this used to aim the shared name at bun and every `dev3` command
+// on the machine died with `Script not found "tasks"`. See managed-cli-guard.ts.
+if (managedCliWriteAllowed(process.execPath, DEV3_HOME)) ensureDev3CliSymlink(DEV3_HOME, process.execPath);
 
 // ── Resolve shell PATH + LANG + key gh config vars (same as GUI entry) ──
 process.env.SHELL = getUserShell();

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -42,6 +42,7 @@ import { startRemoteAccessServer, pushToBrowserClients } from "./remote-access-s
 import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
+import { managedCliWriteAllowed } from "./managed-cli-guard";
 import { ensureCodexConfigFile } from "./codex-config";
 import { ensureWindowsShortcuts } from "./windows-shortcuts";
 import { makeTitle } from "./app-utils";
@@ -164,7 +165,12 @@ log.info("Log files", { dir: getLogPath() });
 
 	// Windows ships `dev3.exe`; the bundle name is owned by electrobun.config so
 	// the copy map and this install path can never disagree.
-	installBinary(cliBinaryName());
+	//
+	// A dev-channel build (`bun run dev`) is deliberately not allowed here: this
+	// copy owns the CLI every agent on the machine runs, and a worktree build
+	// landing on it silently swaps everyone onto an unmerged branch. See
+	// managed-cli-guard.ts.
+	if (managedCliWriteAllowed(PATHS.VIEWS_FOLDER, DEV3_HOME)) installBinary(cliBinaryName());
 
 	// Install dev3 skill into all supported AI agent directories (~/.claude, ~/.codex, etc.).
 	// Overwritten on every start to match the running app version (same pattern as CLI binary).

--- a/src/bun/managed-cli-guard.ts
+++ b/src/bun/managed-cli-guard.ts
@@ -1,0 +1,140 @@
+/**
+ * Who is allowed to write the machine-wide `~/.dev3.0/bin/dev3`.
+ *
+ * That path is FROZEN and SHARED: agent hooks, the injected dev3 skill and
+ * lifecycle onExit commands all invoke the CLI through it (`DEV3_CLI` in
+ * `src/shared/agent-hooks.ts`), and every installed version of the app on the
+ * machine reads the same `~/.dev3.0` (see the on-disk invariants in AGENTS.md).
+ * There is exactly one entry, so whoever writes last owns every agent's CLI.
+ *
+ * A build that is NOT the installed app must therefore not touch it. Running
+ * `bun run dev` in a worktree is a normal, hourly thing on this machine — it
+ * must not swap the CLI every other agent and the user are running. Two shapes
+ * of that were observed in one night, from two different write paths:
+ *   - the headless entry pointed the name at the `bun` binary (every `dev3`
+ *     command then died with `Script not found "tasks"`), and
+ *   - the GUI entry copied an unmerged branch's 76 MB build over it, which
+ *     "works" and is worse, because nobody notices.
+ * See `decisions/2026/08/27/dev-builds-never-write-the-managed-cli.md`.
+ *
+ * The opt-in exists because a developer may genuinely want their branch's CLI
+ * on PATH. It is explicit (`DEV3_INSTALL_MANAGED_CLI=1`), never the default, and
+ * the way back is the one `dev3 doctor` already prints: relaunch the installed
+ * app, which rewrites the name from its own bundle.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { detectInstallMethod } from "../shared/self-update";
+import { createLogger } from "./logger";
+
+const log = createLogger("managed-cli-guard");
+
+/** Set to `1` to let a non-installed build write the shared CLI anyway. */
+export const MANAGED_CLI_OPT_IN_ENV = "DEV3_INSTALL_MANAGED_CLI";
+
+/** Channel Electrobun bakes into a locally built (`bun run dev`) bundle. */
+export const DEV_BUILD_CHANNEL = "dev";
+
+export interface ManagedCliWriteInput {
+	/** Channel of the running bundle; `null` when there is none to read. */
+	buildChannel: string | null;
+	/** `process.execPath` — the binary actually running, not what it would install. */
+	execPath: string;
+	dev3Home: string;
+	platform: NodeJS.Platform;
+	env: Record<string, string | undefined>;
+}
+
+export interface ManagedCliWriteVerdict {
+	write: boolean;
+	/** One sentence, logged verbatim — a skipped write must never be silent. */
+	why: string;
+}
+
+/**
+ * Decide whether this build may write `<dev3Home>/bin/dev3`.
+ *
+ * Pure, and the rule order is the whole design:
+ *
+ *  1. A `dev` channel is a positive identification of a local build — and the
+ *     ONLY place the opt-in means anything, because a dev build is the only
+ *     non-install that has a real CLI binary to hand over.
+ *  2. ANY OTHER CHANNEL IS AN INSTALL, and that answer must come BEFORE the
+ *     source check — the desktop app's own main process runs a `bun` binary
+ *     from inside its bundle, so the source check alone would refuse the
+ *     installed app and break the very thing it protects.
+ *  3. A bare `bun` (`bun run …`) has no CLI to install at all, so the opt-in
+ *     deliberately does NOT reach here: honouring it would aim the shared name
+ *     at the bun runtime, which is the exact `Script not found "tasks"` failure
+ *     this guard exists to stop.
+ *  4. Anything left is a brew keg / tarball / bundle we could not read a channel
+ *     from. Fail OPEN — a real install whose layout is unfamiliar keeps working.
+ */
+export function mayWriteManagedCli(input: ManagedCliWriteInput): ManagedCliWriteVerdict {
+	if (input.buildChannel === DEV_BUILD_CHANNEL) {
+		if (input.env[MANAGED_CLI_OPT_IN_ENV] === "1") {
+			return { write: true, why: `${MANAGED_CLI_OPT_IN_ENV}=1 — this dev build was explicitly allowed` };
+		}
+		return {
+			write: false,
+			why: `this is a ${DEV_BUILD_CHANNEL}-channel build, not an install — it must not own the shared CLI`,
+		};
+	}
+	if (input.buildChannel) return { write: true, why: `installed build on the ${input.buildChannel} channel` };
+	if (detectInstallMethod(input.execPath, input.platform, input.dev3Home) === "source") {
+		return { write: false, why: "this is running from source (`bun run …`), which has no CLI to install" };
+	}
+	return { write: true, why: "installed build" };
+}
+
+/**
+ * Read the channel Electrobun baked into the bundle holding `fromPath`.
+ *
+ * `version.json` always sits in a directory literally named `Resources`, on
+ * every platform (`resourcesDir` in electrobun's `Updater.ts`), so walking up
+ * for that name is the one lookup that works for the GUI (from the views
+ * folder) and for the CLI binary (from `Resources/app/cli/dev3`) alike.
+ * Returns null rather than guessing — the caller fails open.
+ */
+export function resolveBuildChannel(fromPath: string): string | null {
+	let dir = fromPath;
+	for (let depth = 0; depth < 8; depth++) {
+		if (basename(dir) === "Resources") {
+			const file = join(dir, "version.json");
+			if (existsSync(file)) {
+				try {
+					const parsed = JSON.parse(readFileSync(file, "utf-8")) as { channel?: unknown };
+					if (typeof parsed.channel === "string" && parsed.channel) return parsed.channel;
+				} catch {
+					return null;
+				}
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return null;
+}
+
+/**
+ * The one call every entry point makes before touching `<dev3Home>/bin/dev3`.
+ *
+ * `bundlePath` is whatever sits inside the running bundle (the views folder for
+ * the GUI, the binary itself for a headless server); the channel is read by
+ * walking up from it. Logs the verdict either way, so a skipped install is
+ * visible in the log rather than looking like the write silently failed.
+ */
+export function managedCliWriteAllowed(bundlePath: string, dev3Home: string): boolean {
+	const verdict = mayWriteManagedCli({
+		buildChannel: resolveBuildChannel(bundlePath),
+		execPath: process.execPath,
+		dev3Home,
+		platform: process.platform,
+		env: process.env,
+	});
+	if (verdict.write) log.info("Installing the managed dev3 CLI", { bundlePath, why: verdict.why });
+	else log.info("Leaving the managed dev3 CLI alone", { bundlePath, why: verdict.why });
+	return verdict.write;
+}

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -263,6 +263,12 @@ async function toggleFavoriteAgent(params: { agentId: string; configId: string }
  * freshly built CLI talking to the installed app is why new flags look broken.
  * See `writeDev3SelfShim` for why arming the second name — never `bin/dev3` —
  * is what keeps agent hooks out of a guest instance.
+ *
+ * DELIBERATELY NOT gated by `managedCliWriteAllowed`. That guard stops a build
+ * from claiming the shared CLI behind the user's back; this handler runs only
+ * because they pressed "Install dev3 CLI" in Settings, which is the whole point
+ * of the button on a dev build. It is the in-app twin of the
+ * `DEV3_INSTALL_MANAGED_CLI=1` env opt-in.
  */
 async function installDev3Cli(): Promise<{ installedFrom: string; selfShimPath: string; selfInstance: string }> {
 	log.info("→ installDev3Cli");


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

`~/.dev3.0/bin/dev3` is a single, frozen, machine-wide entry — agent hooks, the injected dev3 skill and lifecycle `onExit` commands all invoke the CLI through it, and every installed version of the app shares the same `~/.dev3.0`. Running the project's own dev loop (`bun run dev`, which is what `dev3 dev-server start` executes) was writing that name, so on a machine running several agents in parallel the rule was "whichever agent ran the dev loop most recently owns everyone's CLI".

Two failure shapes were observed in one night, and they came from **two different write paths**:

| Shape | Write path | Symptom |
|---|---|---|
| `bin/dev3` symlinked to the `bun` runtime | `src/bun/headless-entry.ts` → `ensureDev3CliSymlink(DEV3_HOME, process.execPath)`, where `process.execPath` under `bun run …` *is* bun | every command dies with `error: Script not found "tasks"` |
| `bin/dev3` replaced by a 76 MB build from an unmerged branch | `src/bun/index.ts` startup `installBinary()` | none — the CLI works, from the wrong code |

Both were reproduced before the fix, and there is no repair timer: the "self-heal" people saw was simply the next writer.

This adds one predicate, `mayWriteManagedCli` (`src/bun/managed-cli-guard.ts`), and both automatic entry points consult it. A `dev`-channel bundle and a bare `bun` run are refused; any other channel is treated as an install and writes as before; an unreadable channel fails open so a real install with an unfamiliar layout keeps working. The rule order matters — the desktop app's own main process runs a `bun` binary from inside its bundle, so the channel check must come before the source check or the guard would refuse the installed app.

`DEV3_INSTALL_MANAGED_CLI=1` is an explicit opt-in for a developer who does want their branch's CLI on PATH. It deliberately does not override the source refusal, because a `bun` run has no CLI binary to hand over. Settings → "Install dev3 CLI" is untouched: it is a deliberate user action and the in-app twin of that env var.

Rationale and the alternatives that lost: `decisions/2026/08/27/dev-builds-never-write-the-managed-cli.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=dac7a6f3-54c9-41a5-8f6c-5b1e0f5da6ac) · `dev3://task/dac7a6f3-54c9-41a5-8f6c-5b1e0f5da6ac`