### PR TITLE
Stop the completion dialog claiming pushed commits will be lost

### DIFF
--- a/change-logs/2026/08/27/fix-completion-warning-cross-branch-push.md
+++ b/change-logs/2026/08/27/fix-completion-warning-cross-branch-push.md
@@ -1,0 +1,5 @@
+Short: No false lost-commit warning
+
+The completion dialog no longer claims commits will be lost when the branch was pushed to a differently named remote branch: it now asks whether the work is on any remote at all, instead of only looking for `origin/<branch-name>`. A branch that genuinely has nothing on a remote still warns exactly as loudly as before.
+
+Suggested by @vit-pavlenko (h0x91b/dev-3.0#1545)

--- a/decisions/2026/08/27/preserved-means-reachable-from-any-remote.md
+++ b/decisions/2026/08/27/preserved-means-reachable-from-any-remote.md
@@ -1,0 +1,54 @@
+# "Preserved" means reachable from any remote ref, not present under `origin/<branch>`
+
+## Context
+
+The completion dialog warns "N commits never pushed — will be lost" before a worktree is
+destroyed. Its number came from `getUnpushedCount`, which asks one question: does
+`origin/<current-branch-name>` exist? A branch pushed under a different name
+(`git push origin HEAD:feature/example`) has no such ref, so a branch whose every commit sits
+on the remote was reported as about to be lost (issue #1545, reported by @vit-pavlenko).
+
+A false loss warning on the completion path is worse than a wrong number: it trains the user to
+click through the one warning that must never be ignored, and a genuinely unpushed branch looks
+identical to this false one.
+
+## Investigation
+
+Reproduced exactly as the issue describes. With `git push origin HEAD:feature/example`:
+`origin/dev3/task-1` does not resolve, no upstream is configured (no `-u`), and
+`git rev-list --count HEAD --not --remotes` is `0` — every commit is on the remote. So consulting
+the configured upstream alone does **not** fix the reported case; reachability does, and it also
+covers the `-u` variant, because an upstream that was pushed to is itself a remote ref.
+
+`git rev-list --count HEAD --not --remotes` cannot be folded into `getUnpushedCount` itself: on a
+brand-new task branch with no commits of its own it is `0`, which would flip that function's `-1`
+sentinel to `0` for merge detection (`src/bun/lifecycle/activities.ts`) and send a
+just-created branch into the content-merge path, where it reads as merged.
+
+## Decision
+
+`unpushed` on `BranchStatus`/`UnsavedWork` now means "commits that exist on no remote", and is
+produced by a new `getUnpreservedCount` (`src/bun/git.ts`), used by `getBranchStatus` and
+`getUnsavedWork` (`src/bun/rpc-handlers/git-operations.ts`) — the two feeds of the completion
+dialog. It delegates to `getUnpushedCount` whenever `origin/<branch>` exists, and otherwise
+returns `0` only when HEAD is reachable from some remote ref; anything else keeps `-1`.
+
+`getUnpushedCount` is unchanged and keeps both remaining callers — merge detection and PR polling
+(`pollTaskPrStatus`) — because they deliberately ask the name-based question: `gh pr list --head
+<branch>` and the content-merge guard are both about this branch's own name.
+
+## Risks
+
+A branch pushed under another name that then gained more local commits still reports `-1`, so the
+dialog names `ahead` and overstates how many commits are actually at risk. That is the safe
+direction — loud, never silent — and it is the only case where the wording ("never pushed") is
+still loose. A repo with no remote refs at all is untouched: the reachability count is its whole
+history, which is not `0`, so it keeps `-1` and the dialog keeps using `ahead`.
+
+## Alternatives considered
+
+Always counting via `--not --remotes` and dropping the `-1` sentinel gives an exact number in
+every case, but changes the message for the ordinary never-pushed branch and makes the
+"pushed but not merged" line fire for work that was never pushed — new false statements in
+exchange for precision nobody asked for. Fixing only the wording ("the branch *name* was not
+pushed") leaves the count wrong and the warning still loud on preserved work.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"build:native": "bun scripts/build-native.ts",
 		"start": "bun scripts/dev.ts --start",
 		"lint": "bun scripts/lint.ts",
-		"test": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && DEV3_TEST_CONCURRENT=1 concurrently --group --names mainview,bun,cli \"$VT vitest run --exclude '**/shift-keys-e2e*'\" \"$VT vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*' --exclude '**/tmux-client-live*' --exclude '**/parity-corpus.live-e2e*' --exclude '**/tmux-backend.live-e2e*'\" \"$VT vitest run --config vitest.config.cli.ts\"",
+		"test": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && DEV3_TEST_CONCURRENT=1 concurrently --group --names mainview,bun,cli \"$VT vitest run --exclude '**/shift-keys-e2e*'\" \"$VT vitest run --config vitest.config.bun.ts --exclude '**/git-worktree*' --exclude '**/git-merge-detection*' --exclude '**/git-unpreserved-count*' --exclude '**/tmux-client-live*' --exclude '**/parity-corpus.live-e2e*' --exclude '**/tmux-backend.live-e2e*'\" \"$VT vitest run --config vitest.config.cli.ts\"",
 		"test:full": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && DEV3_TEST_CONCURRENT=1 concurrently --group --names mainview,bun,cli \"$VT vitest run\" \"$VT vitest run --config vitest.config.bun.ts\" \"$VT vitest run --config vitest.config.cli.ts\"",
 		"test:bun": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.bun.ts",
 		"test:cli": "VT=$(command -v rtk >/dev/null 2>&1 && echo rtk || echo bunx) && $VT vitest run --config vitest.config.cli.ts",

--- a/src/bun/__tests__/git-unpreserved-count.test.ts
+++ b/src/bun/__tests__/git-unpreserved-count.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `getUnpreservedCount` against real git repos — the completion dialog's "what
+ * would deleting this worktree destroy" number. Mocked spawn cannot answer this:
+ * the whole question is which refs a real git considers HEAD reachable from.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("../paths", () => ({ DEV3_HOME: "/tmp/dev3-test" }));
+
+vi.mock("../spawn", async () => {
+	const { createSpawnMock } = await import("./git-test-helpers");
+	return createSpawnMock();
+});
+
+import { getUnpreservedCount, getUnpushedCount } from "../git";
+import { createTestRepo, cleanup, makeTaskCommits, g, GIT_ENV, type TestRepo } from "./git-test-helpers";
+
+describe("getUnpreservedCount", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+		g("git checkout -b dev3/task-branch", repo.local);
+		makeTaskCommits(repo.local);
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("pushed under the same name: nothing is at risk", async () => {
+		g("git push -u origin dev3/task-branch", repo.local);
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(0);
+	});
+
+	it("pushed under the same name, then one more commit: that commit is at risk", async () => {
+		g("git push -u origin dev3/task-branch", repo.local);
+		writeFileSync(join(repo.local, "later.ts"), "export const later = 1;\n");
+		g("git add later.ts", repo.local);
+		g('git commit -m "feat: later"', repo.local);
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(1);
+	});
+
+	it("pushed under a DIFFERENT name: nothing is at risk (issue #1545)", async () => {
+		g("git push origin HEAD:feature/example", repo.local);
+		g("git fetch origin", repo.local);
+
+		// The premise of the issue: both refs are the same commit, yet there is no
+		// origin/<branch>, which is all the name-based check ever looked at.
+		expect(g("git rev-parse HEAD", repo.local).trim())
+			.toBe(g("git rev-parse origin/feature/example", repo.local).trim());
+		expect(await getUnpushedCount(repo.local, "dev3/task-branch")).toBe(-1);
+
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(0);
+	});
+
+	it("pushed under a different name, then one more commit: still warns", async () => {
+		g("git push origin HEAD:feature/example", repo.local);
+		g("git fetch origin", repo.local);
+		writeFileSync(join(repo.local, "later.ts"), "export const later = 1;\n");
+		g("git add later.ts", repo.local);
+		g('git commit -m "feat: later"', repo.local);
+
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(-1);
+	});
+
+	it("never pushed at all: warns, loudly", async () => {
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(-1);
+	});
+
+	it("never pushed, and a sibling branch is on the remote: still warns", async () => {
+		g("git push origin main:main", repo.local);
+		g("git fetch origin", repo.local);
+		expect(await getUnpreservedCount(repo.local, "dev3/task-branch")).toBe(-1);
+	});
+
+	it("repo with no remote at all: warns", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "dev3-git-noremote-"));
+		execSync("git init -q -b main .", { cwd: dir, env: GIT_ENV });
+		writeFileSync(join(dir, "a.ts"), "export const a = 1;\n");
+		execSync("git add a.ts && git commit -qm initial", { cwd: dir, env: GIT_ENV });
+		execSync("git checkout -qb dev3/task-branch", { cwd: dir, env: GIT_ENV });
+		writeFileSync(join(dir, "b.ts"), "export const b = 2;\n");
+		execSync("git add b.ts && git commit -qm work", { cwd: dir, env: GIT_ENV });
+
+		expect(await getUnpreservedCount(dir, "dev3/task-branch")).toBe(-1);
+		cleanup({ dir, local: dir });
+	});
+
+	it("returns 0 for an empty branch name", async () => {
+		expect(await getUnpreservedCount(repo.local, "")).toBe(0);
+	});
+});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -98,6 +98,7 @@ vi.mock("../git", () => ({
 	getTaskDiff: vi.fn(),
 	getUncommittedChanges: vi.fn(),
 	getUnpushedCount: vi.fn(),
+	getUnpreservedCount: vi.fn(),
 	getBehindOriginCount: vi.fn().mockResolvedValue(0),
 	getBranchDiffStats: vi.fn(),
 	canRebaseCleanly: vi.fn(),
@@ -5355,7 +5356,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.detectDefaultCompareRef).mockResolvedValueOnce("main");
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 2, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 1, insertions: 5, deletions: 0, fileStats: [] });
 		vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 
@@ -5376,7 +5377,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.detectDefaultCompareRef).mockResolvedValueOnce("origin/main");
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(1);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(1);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 1, insertions: 1, deletions: 0, fileStats: [] });
 		vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 
@@ -5395,7 +5396,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 3, behind: 2 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 10, deletions: 5 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(1);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(1);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 4, insertions: 50, deletions: 20, fileStats: [{path:"a.ts",insertions:50,deletions:20},{path:"b.ts",insertions:0,deletions:0},{path:"c.ts",insertions:0,deletions:0},{path:"d.ts",insertions:0,deletions:0}] });
 		vi.mocked(git.canRebaseCleanly).mockResolvedValue(true);
 
@@ -5422,7 +5423,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 
 		const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
@@ -5439,7 +5440,7 @@ describe("handlers.getBranchStatus", () => {
 			vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 			vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind });
 			vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-			vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+			vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
 			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 			vi.mocked(git.canRebaseCleanly).mockResolvedValue(true);
 		}
@@ -5523,7 +5524,7 @@ describe("handlers.getBranchStatus", () => {
 			vi.mocked(git.getCurrentBranch).mockResolvedValue("fix/mine");
 			vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 3 });
 			vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-			vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+			vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
 			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 			vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", exitCode: 0 } as any);
 		}
@@ -5598,7 +5599,7 @@ describe("handlers.getBranchStatus", () => {
 			vi.mocked(git.getCurrentBranch).mockResolvedValue("feature/source-v2");
 			vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 2, behind: 0 });
 			vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-			vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+			vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 			vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 			vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", exitCode: 0 } as any);
@@ -5670,7 +5671,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 5, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 3, insertions: 30, deletions: 10, fileStats: [] });
 		vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", code: 0 });
 
@@ -5690,7 +5691,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 
 		const push = vi.fn();
@@ -5700,8 +5701,8 @@ describe("handlers.getBranchStatus", () => {
 
 		// Should have synced the stored branchName
 		expect(data.updateTask).toHaveBeenCalledWith(project, "task-1", { branchName: "dev3/fix-login" });
-		// Should pass live branch name to getUnpushedCount
-		expect(git.getUnpushedCount).toHaveBeenCalledWith("/tmp/wt", "dev3/fix-login");
+		// Should pass live branch name to getUnpreservedCount
+		expect(git.getUnpreservedCount).toHaveBeenCalledWith("/tmp/wt", "dev3/fix-login");
 		// Must notify the renderer so the header/cards re-render with the new
 		// branch instead of showing the stale name until a reload.
 		expect(push).toHaveBeenCalledWith("taskUpdated", {
@@ -5719,7 +5720,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 
 		const push = vi.fn();
@@ -5740,7 +5741,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: "", title: null, author: null }, isGitHub: true });
 
@@ -5760,7 +5761,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 42, url: prUrl, title: null, author: null }, isGitHub: true });
 		const push = vi.fn();
@@ -5784,7 +5785,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: null, isGitHub: true });
 
@@ -5806,7 +5807,7 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 0, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 		vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", code: 0 });
 
@@ -5827,12 +5828,56 @@ describe("handlers.getBranchStatus", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 1, behind: 0 });
 		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
-		vi.mocked(git.getUnpushedCount).mockResolvedValue(0);
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
 		vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 		vi.mocked(github.findOpenPullRequest).mockResolvedValue({ pr: { number: 10, url: "", title: null, author: null }, isGitHub: true });
 
 		const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
 		expect(result.prNumber).toBe(10);
+	});
+});
+
+// The completion dialog's data source: the number it renders "will be lost" from.
+describe("handlers.getUnsavedWork", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	function setup() {
+		const project = makeProject();
+		const task = makeTask({ worktreePath: "/tmp/wt", branchName: "dev3/t" });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.getTask).mockResolvedValue(task);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/t");
+		vi.mocked(git.getUncommittedChanges).mockResolvedValue({ insertions: 0, deletions: 0 });
+		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 3, behind: 0 });
+	}
+
+	it("asks what is preserved anywhere, not what is on origin/<branch>", async () => {
+		setup();
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(0);
+
+		const result = await handlers.getUnsavedWork({ taskId: "task-1", projectId: "proj-1" });
+
+		expect(git.getUnpreservedCount).toHaveBeenCalledWith("/tmp/wt", "dev3/t");
+		expect(git.getUnpushedCount).not.toHaveBeenCalled();
+		// 0 with commits ahead is the cross-branch push (issue #1545): the dialog
+		// must stay silent, because nothing would be lost.
+		expect(result).toEqual({ insertions: 0, deletions: 0, unpushed: 0, ahead: 3 });
+	});
+
+	it("keeps the never-pushed sentinel when nothing is preserved", async () => {
+		setup();
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
+
+		const result = await handlers.getUnsavedWork({ taskId: "task-1", projectId: "proj-1" });
+		expect(result).toEqual({ insertions: 0, deletions: 0, unpushed: -1, ahead: 3 });
+	});
+
+	it("passes a partial count through", async () => {
+		setup();
+		vi.mocked(git.getUnpreservedCount).mockResolvedValue(2);
+
+		const result = await handlers.getUnsavedWork({ taskId: "task-1", projectId: "proj-1" });
+		expect(result).toEqual({ insertions: 0, deletions: 0, unpushed: 2, ahead: 3 });
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -2017,6 +2017,42 @@ export async function getUnpushedCount(
 	return parseInt(result.stdout, 10) || 0;
 }
 
+/**
+ * Commits that exist on no remote — the honest answer to "what would deleting
+ * this worktree destroy". Same -1/0/N contract as {@link getUnpushedCount}, and
+ * the same answer whenever `origin/<branch>` exists.
+ *
+ * The name-based check alone called preserved work lost: `git push origin
+ * HEAD:other-name` leaves no `origin/<branch>`, so a branch whose every commit
+ * is on the remote reported the never-pushed sentinel (issue #1545). Fall back
+ * to reachability from ANY remote ref — a fork or a configured upstream counts,
+ * because both are remote refs. A repo with no remote refs at all preserves
+ * nothing, and there the reachability count is the whole history, so it stays
+ * -1 exactly as before.
+ *
+ * Anything not fully preserved keeps the -1 sentinel rather than a partial
+ * count: the loss warning must stay loud, and only the provably-safe case is
+ * allowed to go quiet.
+ *
+ * Deliberately separate from {@link getUnpushedCount}: merge detection and PR
+ * polling ask the name-based question on purpose, and -1 is what keeps a
+ * brand-new branch out of their content-merge path.
+ */
+export async function getUnpreservedCount(
+	worktreePath: string,
+	branchName: string,
+): Promise<number> {
+	const named = await getUnpushedCount(worktreePath, branchName);
+	if (named >= 0) return named;
+
+	const anywhere = await run(
+		["git", "rev-list", "--count", "HEAD", "--not", "--remotes"],
+		worktreePath,
+	);
+	if (!anywhere.ok) return -1;
+	return parseInt(anywhere.stdout, 10) === 0 ? 0 : -1;
+}
+
 export async function getBehindOriginCount(
 	worktreePath: string,
 	branchName: string,

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -242,7 +242,7 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 	if (compareRefBranch && compareRefBranch !== baseBranch) {
 		await git.fetchCompareRef(project.path, compareRefBranch);
 	}
-	// Also refresh origin/<task-branch> so getUnpushedCount reflects out-of-band remote pushes.
+	// Also refresh origin/<task-branch> so getUnpreservedCount reflects out-of-band remote pushes.
 	if (hasRemote && branchForPush && branchForPush !== baseBranch && branchForPush !== compareRefBranch) {
 		await git.fetchOrigin(project.path, branchForPush);
 	}
@@ -269,7 +269,7 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 	const [status, uncommitted, unpushed, remoteAhead, branchDiff, detected] = await Promise.all([
 		git.getBranchStatus(task.worktreePath, ref),
 		git.getUncommittedChanges(task.worktreePath),
-		git.getUnpushedCount(task.worktreePath, branchForPush),
+		git.getUnpreservedCount(task.worktreePath, branchForPush),
 		// origin/<branch> was refreshed above, so this is the live answer to "would a
 		// plain push be refused as non-fast-forward".
 		hasRemote ? git.getBehindOriginCount(task.worktreePath, branchForPush) : Promise.resolve(0),
@@ -347,7 +347,7 @@ async function getUnsavedWork(params: { taskId: string; projectId: string }): Pr
 	const ref = await resolveCompareRef(project, resolveTaskCompareBaseBranch(task, project));
 	const [uncommitted, unpushed, counts] = await Promise.all([
 		git.getUncommittedChanges(task.worktreePath),
-		git.getUnpushedCount(task.worktreePath, branchForPush),
+		git.getUnpreservedCount(task.worktreePath, branchForPush),
 		git.getBranchStatus(task.worktreePath, ref),
 	]);
 	return { ...uncommitted, unpushed, ahead: counts.ahead };

--- a/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
+++ b/src/mainview/utils/__tests__/confirmTaskCompletion.test.ts
@@ -16,7 +16,7 @@ const mockedBranchStatus = vi.mocked(api.request.getBranchStatus);
 const mockedUnsavedWork = vi.mocked(api.request.getUnsavedWork);
 const mockedConfirm = vi.mocked(confirm);
 
-const t = ((key: string) => key) as never;
+const t = Object.assign((key: string) => key, { plural: (key: string) => key }) as never;
 
 const baseTask = {
 	id: "t1",
@@ -125,6 +125,41 @@ describe("confirmTaskCompletion", () => {
 
 		expect(ok).toBe(true);
 		expect(mockedConfirm).not.toHaveBeenCalled();
+	});
+
+	// Issue #1545: `git push origin HEAD:other-name` leaves no origin/<branch>, so
+	// the backend used to answer -1 here and the dialog claimed preserved commits
+	// would be lost. `unpushed: 0` with commits ahead is what that push now looks
+	// like — unmerged, yes; at risk, no.
+	it("never says work will be lost when every commit is on a remote", async () => {
+		mockedBranchStatus.mockResolvedValue({
+			insertions: 0,
+			deletions: 0,
+			unpushed: 0,
+			ahead: 3,
+			mergedByContent: false,
+		} as Awaited<ReturnType<typeof api.request.getBranchStatus>>);
+
+		await confirmTaskCompletion(baseTask, project, "completed", t);
+
+		const message = mockedConfirm.mock.calls[0]![0].message!;
+		expect(message).toContain("task.warnUnmerged");
+		expect(message).not.toContain("task.warnNeverPushed");
+		expect(message).not.toContain("task.warnUnpushed");
+	});
+
+	it("still says work will be lost when nothing is preserved", async () => {
+		mockedBranchStatus.mockResolvedValue({
+			insertions: 0,
+			deletions: 0,
+			unpushed: -1,
+			ahead: 3,
+			mergedByContent: false,
+		} as Awaited<ReturnType<typeof api.request.getBranchStatus>>);
+
+		await confirmTaskCompletion(baseTask, project, "completed", t);
+
+		expect(mockedConfirm.mock.calls[0]![0].message!).toContain("task.warnNeverPushed");
 	});
 
 	describe("alwaysConfirm (one-click quick-complete)", () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3109,7 +3109,10 @@ export interface BranchStatus {
 	canRebase: boolean;
 	insertions: number;
 	deletions: number;
-	unpushed: number; // -1 = never pushed, 0 = all pushed, N = N unpushed commits
+	// Commits that exist on no remote: -1 = nothing of this branch is preserved
+	// anywhere, 0 = everything is on a remote (under this branch's name or any
+	// other), N = N commits missing from `origin/<branch>`. See `getUnpreservedCount`.
+	unpushed: number;
 	mergedByContent: boolean; // true if git diff base HEAD is empty (squash/rebase merge)
 	diffFiles: number; // total files changed in branch vs base
 	diffInsertions: number; // total lines added in branch vs base
@@ -3144,7 +3147,10 @@ export interface BranchStatus {
 export interface UnsavedWork {
 	insertions: number;
 	deletions: number;
-	unpushed: number; // -1 = never pushed, 0 = all pushed, N = N unpushed commits
+	// Commits that exist on no remote: -1 = nothing of this branch is preserved
+	// anywhere, 0 = everything is on a remote (under this branch's name or any
+	// other), N = N commits missing from `origin/<branch>`. See `getUnpreservedCount`.
+	unpushed: number;
 	ahead: number; // commits ahead of the base branch, per the last known origin ref
 }
 


### PR DESCRIPTION
Hey — Claude here, the AI assistant that worked on this branch.

Fixes #1545. A branch pushed to a differently named remote branch (`git push origin HEAD:feature/example`) has no `origin/<branch>`, and the completion check only ever looked for that ref — so it returned the never-pushed sentinel and the dialog announced that commits already sitting on the remote would be lost. A false loss warning on the completion path is the expensive kind: it trains you to click through the one warning that must never be ignored.

**What changed.** `unpushed` on `BranchStatus`/`UnsavedWork` now means "commits that exist on no remote", produced by a new `getUnpreservedCount` in `src/bun/git.ts` and used by `getBranchStatus` and `getUnsavedWork` — the two feeds of the completion dialog. It delegates to `getUnpushedCount` whenever `origin/<branch>` exists, and otherwise returns 0 only when HEAD is reachable from some remote ref (a fork or a configured upstream is a remote ref too). Anything not fully preserved keeps `-1`, so the true warning stays exactly as loud as before.

`getUnpushedCount` is unchanged and keeps its other two callers — merge detection and PR polling — because they deliberately ask the name-based question, and its `-1` is what keeps a brand-new branch out of the content-merge path.

Rationale and the alternatives considered: `decisions/2026/08/27/preserved-means-reachable-from-any-remote.md`.

Reported by @vit-pavlenko, whose write-up included the exact reproduction — that made this a short investigation instead of a long one. Thank you.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=954a3295-ef9f-4433-a1ce-51599ded7a35) · `dev3://task/954a3295-ef9f-4433-a1ce-51599ded7a35`