### PR TITLE
Close a successful pane run's pane after 10 seconds

### DIFF
--- a/change-logs/2026/08/27/fix-auto-close-successful-pane-runs.md
+++ b/change-logs/2026/08/27/fix-auto-close-successful-pane-runs.md
@@ -1,0 +1,3 @@
+Short: Green pane runs close themselves
+
+A command an agent ran in a neighbouring pane (`dev3 pane run` — builds, test runs) no longer parks the pane at "press Enter to close" once it succeeds: a run that exits 0 closes its own pane after 10 seconds. A run that failed or was killed still keeps its pane open until you dismiss it, because that output is what you came to read.

--- a/decisions/2026/08/27/auto-close-successful-pane-runs.md
+++ b/decisions/2026/08/27/auto-close-successful-pane-runs.md
@@ -1,0 +1,37 @@
+# Auto-close a pane run only when it succeeded
+
+## Context
+
+`dev3 pane run` held its pane open forever after the command ended (`waitForDismissal` in
+`src/cli/commands/pane-exec.ts`), printing "press Enter to close this pane". Agents open a pane per
+build or test run and never come back to it, so a working session leaves a row of dead panes the user
+has to close by hand. Reported by a user: "Dev3 spins terminals ... and leave them open with option
+to press enter to close."
+
+## Decision
+
+`paneRunDismissal(exitCode)` in `src/shared/pane-runs.ts` decides what a finished pane does:
+exit code 0 closes the pane after `PANE_RUN_AUTO_CLOSE_SECONDS` (10s, a key press closes it sooner);
+anything else — non-zero, or the `null` a signal death writes — waits for Enter as before. The wait
+itself lives in `waitForDismissal`, racing a keypress against `Bun.sleep`. The skill text
+(`SKILL_PANES` in `src/shared/agent-skill-content.ts`) now also tells the agent to `dev3 pane close`
+a run it is done with, since nothing else ever closes a watcher's pane.
+
+Closing a green pane loses nothing: a pane run mirrors every byte into its log file, so the output is
+still readable through `dev3 pane logs <run-id>`.
+
+## Risks
+
+A user who looks away for 15 seconds will not find the successful run on screen; the log is the
+fallback. The 10 seconds are a fixed number with no setting behind it — deliberately, to keep this
+out of the settings surface until someone actually asks for a different value.
+
+## Alternatives considered
+
+Closing every finished pane immediately (a red build would vanish before it could be read); a
+`--close-on-exit` flag plus a project setting (a whole settings surface for a default nobody has
+disputed yet); leaving the code alone and only instructing the agent to clean up (relies on the agent
+remembering, and the litter is created by the ordinary green path).
+
+The UI's "Run script" pane (`src/bun/script-runner.ts`) keeps its `read` wait: that path mirrors
+nothing to a log, so closing its pane would destroy the only copy of the output.

--- a/src/bun/__tests__/pane-runs-vocabulary.test.ts
+++ b/src/bun/__tests__/pane-runs-vocabulary.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import {
+	PANE_RUN_AUTO_CLOSE_SECONDS,
 	PANE_RUN_COMMAND_MAX_LENGTH,
 	PANE_RUN_TAIL_DEFAULT_LINES,
 	PANE_RUN_TAIL_MAX_LINES,
@@ -16,6 +17,7 @@ import {
 	isPaneRunId,
 	isPaneRunLabel,
 	paneRunCommandProblem,
+	paneRunDismissal,
 	paneRunOutcomeLine,
 	paneRunTail,
 	renderPaneRunListing,
@@ -173,6 +175,24 @@ describe("status decoding", () => {
 		const decoded = decodePaneRunStatus({ runId: "run-0123456789ab", state: "exited", exitCode: null });
 		expect(decoded?.exitCode).toBeNull();
 		expect(decoded?.state).toBe("exited");
+	});
+});
+
+describe("what a finished pane does with itself", () => {
+	it("closes a clean run on the timer, and says how long it has", () => {
+		const plan = paneRunDismissal(0);
+		expect(plan.autoCloseMs).toBe(PANE_RUN_AUTO_CLOSE_SECONDS * 1000);
+		expect(plan.message).toContain(`${PANE_RUN_AUTO_CLOSE_SECONDS}s`);
+	});
+
+	it("keeps a failed run on screen forever — its output is the whole point", () => {
+		expect(paneRunDismissal(1).autoCloseMs).toBeNull();
+		expect(paneRunDismissal(1).message).toBe("press Enter to close this pane");
+	});
+
+	it("treats an unreadable outcome as a failure, never as a success", () => {
+		// null is what a signal death writes: killed is not clean.
+		expect(paneRunDismissal(null).autoCloseMs).toBeNull();
 	});
 });
 

--- a/src/cli/__tests__/pane-run-exec.bun-e2e.ts
+++ b/src/cli/__tests__/pane-run-exec.bun-e2e.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { spawn } from "../../bun/spawn";
 import { paneRunLogPath, paneRunSpecPath, paneRunStatusPath, PANE_RUN_VERB } from "../../bun/pane-run-store";
 import { launchDialect } from "../../shared/platform-launch";
+import { PANE_RUN_AUTO_CLOSE_SECONDS } from "../../shared/pane-runs";
 
 const IS_WINDOWS = process.platform === "win32";
 /** Non-ASCII on purpose: this is what a wrong output encoding destroys. */
@@ -80,6 +81,30 @@ async function runPane(dir: string, runId: string, command: string): Promise<Run
 		stderr,
 		cliExitCode,
 	};
+}
+
+/**
+ * The same runner, but with stdin HELD OPEN — a real pane, with a human in front of
+ * it who presses nothing. Only this configuration can show whether a finished pane
+ * closes itself: with stdin closed the wait ends instantly either way.
+ */
+function startHeldPane(dir: string, runId: string, command: string) {
+	writeFileSync(
+		paneRunSpecPath(dir, runId),
+		`${JSON.stringify({ runId, taskId: "e2e", command, cwd: dir, label: "", requestedAt: new Date().toISOString() })}\n`,
+		"utf8",
+	);
+	return spawn([process.execPath, CLI_ENTRY, PANE_RUN_VERB, dir, runId], {
+		cwd: dir,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
+/** Resolves to the exit code, or to null if the process outlived the deadline. */
+async function exitedWithin(child: ReturnType<typeof spawn>, ms: number): Promise<number | null> {
+	return await Promise.race([child.exited, Bun.sleep(ms).then(() => null)]);
 }
 
 /**
@@ -156,6 +181,17 @@ try {
 	check(normal.status.state === "exited", `the run ended in state 'exited' (got ${String(normal.status.state)})`);
 	check(normal.status.exitCode === 3, `the command's exit code 3 survived the shell (got ${String(normal.status.exitCode)})`);
 	check(normal.cliExitCode === 0, `the runner itself exited 0 (got ${String(normal.cliExitCode)})`);
+
+	// A pane nobody touches: the green one must go away by itself, the red one must not.
+	const clean = startHeldPane(root, "run-0123456789ad", printMarkerAndExit(0));
+	const cleanExit = await exitedWithin(clean, (PANE_RUN_AUTO_CLOSE_SECONDS + 8) * 1000);
+	if (cleanExit === null) clean.kill();
+	check(cleanExit === 0, `a successful run closed its own pane with nobody pressing anything (got ${String(cleanExit)})`);
+
+	const failed = startHeldPane(root, "run-0123456789ae", printMarkerAndExit(3));
+	const failedExit = await exitedWithin(failed, (PANE_RUN_AUTO_CLOSE_SECONDS + 5) * 1000);
+	check(failedExit === null, `a failed run kept its pane open past the auto-close window (got ${String(failedExit)})`);
+	failed.kill();
 
 	if (IS_WINDOWS) {
 		// CONTROL first, with the environment untouched: it separates "the wrapper this

--- a/src/cli/commands/pane-exec.ts
+++ b/src/cli/commands/pane-exec.ts
@@ -20,7 +20,13 @@
 import { appendFileSync, closeSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn } from "../../bun/spawn";
 import { paneRunShell, paneRunLogPath, paneRunSpecPath, paneRunStatusPath } from "../../bun/pane-run-store";
-import { decodePaneRunSpec, isPaneRunId, type PaneRunSpec, type PaneRunState } from "../../shared/pane-runs";
+import {
+	decodePaneRunSpec,
+	isPaneRunId,
+	paneRunDismissal,
+	type PaneRunSpec,
+	type PaneRunState,
+} from "../../shared/pane-runs";
 import { CLI_EXIT_CODE_SUCCESS } from "../../shared/cli-exit-codes";
 import { exitInternalError, exitUsage } from "../output";
 
@@ -69,17 +75,28 @@ async function pump(stream: unknown, logFd: number): Promise<void> {
 	for await (const chunk of stream as AsyncIterable<Uint8Array>) mirror(logFd, chunk);
 }
 
-/**
- * Hold the pane open after the command ends, so a finished build stays on screen
- * instead of the pane vanishing the moment it succeeds. The agent never needs this
- * — it reads the log — so the wait exists purely for the human watching.
- */
-async function waitForDismissal(): Promise<void> {
-	process.stdout.write("[dev3] press Enter to close this pane\n");
+/** Resolves on the first byte from the pane's keyboard, or when stdin ends. */
+async function keyPressed(): Promise<void> {
 	for await (const _chunk of Bun.stdin.stream()) {
 		void _chunk;
 		return;
 	}
+}
+
+/**
+ * Hold the pane open after the command ends, so a finished build stays on screen
+ * instead of the pane vanishing the moment it succeeds. The agent never needs this
+ * — it reads the log — so the wait exists purely for the human watching, and a
+ * clean run gives that human a few seconds rather than a pane to close by hand.
+ */
+async function waitForDismissal(exitCode: number | null): Promise<void> {
+	const { autoCloseMs, message } = paneRunDismissal(exitCode);
+	process.stdout.write(`[dev3] ${message}\n`);
+	if (autoCloseMs === null) {
+		await keyPressed();
+		return;
+	}
+	await Promise.race([keyPressed(), Bun.sleep(autoCloseMs)]);
 }
 
 export async function handlePaneExec(rawArgs: string[]): Promise<void> {
@@ -174,6 +191,6 @@ export async function handlePaneExec(rawArgs: string[]): Promise<void> {
 		// Already closed or already broken — nothing left to do with it.
 	}
 
-	await waitForDismissal();
+	await waitForDismissal(signalled ? null : exitCode);
 	process.exit(CLI_EXIT_CODE_SUCCESS);
 }

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -16,6 +16,7 @@ import {
 	AGENT_MESSAGE_HOLD_IDLE_SECONDS,
 } from "./agent-message-hold-timing";
 import { deepLinkSchemeRegistered } from "./deep-link";
+import { PANE_RUN_AUTO_CLOSE_SECONDS } from "./pane-runs";
 
 /**
  * How the agent should link a PR back to its task — or why it must not. The
@@ -251,6 +252,8 @@ dev3 pane close <run-id>                      # close that pane (kills the comma
 \`\`\`
 
 The outcome line distinguishes **still running** from **finished, exit code N** — never treat a quiet tail as a finished command. Runs are non-interactive (stdin is closed): builds, tests, servers, watchers. Quick one-shot commands stay inline in your own shell, and the project's canonical dev server is \`dev3 dev-server start\`, not a pane run.
+
+**Clean up after yourself — a finished pane the user has to close by hand is litter.** A run that exits 0 closes its own pane after ${PANE_RUN_AUTO_CLOSE_SECONDS} seconds, so the ordinary green case needs nothing from you. Everything else stays on screen deliberately: a failed run keeps its pane so the user can read it, and a server or watcher you started keeps running until something stops it. Once you have read what you needed from a run you are done with, \`dev3 pane close <run-id>\` — do not leave a watcher or a red build parked in the user's terminal after the work that needed it is over.
 
 Reading the SCREEN of a pane you did not start (the user's own pane, "look at the error on the right") is a different thing and is **tmux-only today**: \`dev3 peek --pane <N>\` returns a screen tail on a tmux task, and on a native task it returns the pane summary with no tail, because the native host publishes no screen snapshot. \`dev3 pane list\` says which case you are in.
 

--- a/src/shared/pane-runs.ts
+++ b/src/shared/pane-runs.ts
@@ -36,6 +36,28 @@ export const PANE_RUN_LABEL_MAX_LENGTH = 40;
 /** Where the new pane lands relative to the agent's own pane. */
 export type PaneRunPlacement = "right" | "below";
 
+/** How long a SUCCESSFUL run's pane stays on screen before it closes itself. */
+export const PANE_RUN_AUTO_CLOSE_SECONDS = 10;
+
+export interface PaneRunDismissal {
+	/** null = wait for the human, forever. */
+	readonly autoCloseMs: number | null;
+	readonly message: string;
+}
+
+/**
+ * What a finished pane does with itself. A clean run closes on a timer so finished
+ * panes stop piling up; anything else — a non-zero exit, a signal, an outcome we
+ * cannot read — keeps the pane, because its output is what the human came for.
+ */
+export function paneRunDismissal(exitCode: number | null): PaneRunDismissal {
+	if (exitCode !== 0) return { autoCloseMs: null, message: "press Enter to close this pane" };
+	return {
+		autoCloseMs: PANE_RUN_AUTO_CLOSE_SECONDS * 1000,
+		message: `closing this pane in ${PANE_RUN_AUTO_CLOSE_SECONDS}s — press Enter to close it now`,
+	};
+}
+
 /**
  * A run id is minted by the app and appears in a file name, a process argv, and a
  * pane's launch command, so it stays deliberately narrow.


### PR DESCRIPTION
A command an agent runs in a neighbouring pane (`dev3 pane run` — builds, test runs) used to park its pane forever at `press Enter to close this pane`. Agents open a pane per run and never come back, so a working session leaves a row of dead panes for the user to close by hand. Reported by a user.

A run that exits 0 now closes its own pane after 10 seconds (a key press closes it sooner). Anything else keeps the pane exactly as before — a non-zero exit, or the `null` a signal death writes — because that output is what the user came to read. Closing a green pane loses nothing: a pane run mirrors every byte into its log, still readable via `dev3 pane logs <run-id>`.

- `paneRunDismissal(exitCode)` in `src/shared/pane-runs.ts` is the whole rule, pure and unit-tested; `waitForDismissal` in `src/cli/commands/pane-exec.ts` races a keypress against `Bun.sleep`.
- The dev3 skill (`SKILL_PANES`) now tells the agent to `dev3 pane close` a run it is done with — nothing else ever closes a watcher's pane.
- The UI's "Run script" pane (`src/bun/script-runner.ts`) deliberately keeps its `read` wait: that path mirrors nothing to a log, so closing it would destroy the only copy of the output.
- Rationale in `decisions/2026/08/27/auto-close-successful-pane-runs.md`.

Covered by the pane-run e2e with stdin held open — the only configuration that can show a pane closing itself: a successful run exits on its own, a failed one is still alive past the auto-close window. A mutant that auto-closes unconditionally turns the second check red.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2c2461a9-5459-4c4d-9e91-0a6937722ea8) · `dev3://task/2c2461a9-5459-4c4d-9e91-0a6937722ea8` _(dev3 added this footer — turn it off in Settings → Tasks.)_