### PR TITLE
Warn when a description edit will not reach a running agent

### DIFF
--- a/change-logs/2026/08/27/fix-description-edit-never-reaches-a-running-agent.md
+++ b/change-logs/2026/08/27/fix-description-edit-never-reaches-a-running-agent.md
@@ -1,0 +1,3 @@
+Short: Warn when a description edit misses the agent
+
+A task's description is delivered as its agent's first prompt at launch and nothing re-delivers it, so rewriting a running task's brief changed the board while its agent never found out. `dev3 task update --description` on a task with a live agent now prints a note saying so and suggests the `dev3 message` command to send alongside it; the same warning is spelled out in `dev3 task update --help` and in the dev3 skill every agent loads at startup.

--- a/decisions/2026/08/27/warn-when-a-description-edit-misses-a-running-agent.md
+++ b/decisions/2026/08/27/warn-when-a-description-edit-misses-a-running-agent.md
@@ -1,0 +1,52 @@
+# Warn when a description edit misses a running agent
+
+## Context
+
+A coordinator widened a running child task's scope by rewriting its `description` with
+`dev3 task update --description`, then treated the brief as delivered. The child never found out and
+sat idle for twenty-five minutes until it was sent a `dev3 message`. Nothing in the CLI, the help
+text, or the dev3 skill said the edit does not reach a live agent — while `--type`'s own help text
+advertises that it *does* tell a running agent, which invites the reader to generalise.
+
+## Investigation
+
+The description is templated into the agent's launch command
+(`resolveCommandForProject` → `buildTaskPrompt`, `src/bun/rpc-handlers/tmux-pty.ts:705`), and the
+Claude adapter attaches the prompt only `if (!resume)` (`src/shared/agent-adapters/claude.ts`). The
+`task.update` socket handler pushes `taskUpdated` to the renderer and calls `deliverAgentPrompt`
+**only** for a `--type` change (`src/bun/cli-socket-server.ts:970`). So nothing pushes a description
+edit to the agent: a fresh launch reads the new text, a resume does not, and the agent otherwise sees
+it only if it re-runs `dev3 current` / `dev3 task show`, both of which print live task state.
+
+## Decision
+
+Say it at the keyboard as well as in the docs, without changing delivery behaviour.
+
+- `taskAgentSessionLooksLive()` in `src/shared/types.ts` — a pure predicate over the same field
+  subset `isTaskDisconnected()` reads. Derived from persisted state, never probed, so it may only
+  decide whether to *tell* the user something.
+- `updateTask()` in `src/cli/commands/task.ts` prints a note after a successful `--description`
+  update when that predicate holds, naming the `dev3 message --task <id>` command to send too
+  (carrying `--project` when the caller passed one).
+- Wording added to `dev3 task update --help` (`src/cli/help.ts`) and to the dev3 skill
+  (`src/shared/agent-skill-content.ts`), so every agent learns it at startup.
+
+`--title` is left silent on purpose: it is equally undelivered, but an agent renames its own task on
+every session start, so a hint there would fire constantly on a correct action. A title is a card
+label, not the brief.
+
+## Risks
+
+The predicate can be wrong in the harmless direction only — a stale `runtimeState` makes it print a
+note for an agent that is already gone (advice that costs one `dev3 message` attempt), or stay quiet
+about a task whose runtime hint was written `idle` while its agent lives. Neither affects delivery.
+The note is one extra line on a common command; it fires only on `--description`, only on live tasks.
+
+## Alternatives considered
+
+- **Make `--description` actually notify the agent like `--type` does.** A behaviour change, and it
+  would type into an agent mid-turn on every edit — deliberately out of scope, a separate decision.
+- **Docs only.** Cheapest, but the trap is at the keyboard; the coordinator that hit it had read the
+  skill.
+- **Probe the terminal backend for a live agent pane before printing.** Accurate, but it makes a
+  cheap metadata write depend on tmux/native reachability, and being wrong here costs nothing.

--- a/src/cli/__tests__/task.test.ts
+++ b/src/cli/__tests__/task.test.ts
@@ -625,6 +625,50 @@ describe("task update", () => {
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 
+	// The description is the agent's first prompt at launch and nothing re-delivers
+	// it, so a rewrite on a live task has to say so at the keyboard.
+	it("warns that a running agent will not see a new description", async () => {
+		mockSend.mockResolvedValue(okResp({ task: FAKE_TASK, titlePreserved: false }));
+
+		await handleTask("update", args(["aaaaaaaa"], { description: "Now also fix it" }), SOCKET, null);
+
+		expect(stdoutOutput).toContain("running agent will NOT see this");
+		expect(stdoutOutput).toContain("dev3 message --task aaaaaaaa");
+	});
+
+	it("carries --project into the suggested message for a cross-project task", async () => {
+		mockSend.mockResolvedValue(okResp({ task: FAKE_TASK, titlePreserved: false }));
+
+		await handleTask(
+			"update",
+			args(["aaaaaaaa"], { description: "Now also fix it", project: "proj-002" }),
+			SOCKET,
+			null,
+		);
+
+		expect(stdoutOutput).toContain("dev3 message --task aaaaaaaa --project proj-002");
+	});
+
+	it("stays quiet when no agent is running to miss the edit", async () => {
+		mockSend.mockResolvedValue(okResp({
+			task: { ...FAKE_TASK, status: "todo", worktreePath: null },
+			titlePreserved: false,
+		}));
+
+		await handleTask("update", args(["aaaaaaaa"], { description: "Brief for later" }), SOCKET, null);
+
+		expect(stdoutOutput).toContain("Updated task");
+		expect(stdoutOutput).not.toContain("running agent");
+	});
+
+	it("stays quiet for a title-only update on a running task", async () => {
+		mockSend.mockResolvedValue(okResp({ task: FAKE_TASK, titlePreserved: false }));
+
+		await handleTask("update", args(["aaaaaaaa"], { title: "Renamed by the agent" }), SOCKET, null);
+
+		expect(stdoutOutput).not.toContain("running agent");
+	});
+
 	it("prints a notice when the server reports titlePreserved=true (issue #564)", async () => {
 		mockSend.mockResolvedValue(okResp({
 			task: { ...FAKE_TASK, customTitle: "User-set title" },

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1,5 +1,5 @@
 import type { CliResponse, Task, TaskStatus, TaskType, TaskHistoryEntry, TaskNote } from "../../shared/types";
-import { STATUS_LABELS, ACTIVE_STATUSES, ALL_STATUSES, DEFAULT_PRIORITY, DRAFT_TASK_ACTIVATION_ERROR, TASK_TYPES, getTaskTitle, getTaskOverview, normalizePriority, normalizeTaskType, taskCompletesManually } from "../../shared/types";
+import { STATUS_LABELS, ACTIVE_STATUSES, ALL_STATUSES, DEFAULT_PRIORITY, DRAFT_TASK_ACTIVATION_ERROR, TASK_TYPES, getTaskTitle, getTaskOverview, normalizePriority, normalizeTaskType, taskAgentSessionLooksLive, taskCompletesManually } from "../../shared/types";
 import { CLI_EXIT_CODE_COMPLETION_DECLINED, CLI_EXIT_CODE_LAUNCH_DECLINED, CLI_EXIT_CODE_TASK_IS_DRAFT } from "../../shared/cli-exit-codes";
 import { CODEX_STOP_HOOK_FLAG, CODEX_STOP_HOOK_SUCCESS_JSON, TOLERATE_APP_OFFLINE_FLAG } from "../../shared/agent-hooks";
 import { sendRequest } from "../socket-client";
@@ -316,6 +316,16 @@ async function updateTask(args: ParsedArgs, socketPath: string, context: CliCont
 		);
 	}
 	process.stdout.write(`Updated task ${task.id.slice(0, 8)}: ${getTaskTitle(task)}\n`);
+	// The trap this exists for: a description is the agent's first prompt at
+	// launch and nothing re-delivers it, so rewriting a live task's brief reaches
+	// the board and not the agent. Docs are read once; the mistake happens here.
+	if (params.description !== undefined && taskAgentSessionLooksLive(task)) {
+		const projectFlag = args.flags.project ? ` --project ${args.flags.project}` : "";
+		process.stdout.write(
+			`Note: the running agent will NOT see this — a description is delivered as its first prompt at launch, and nothing re-delivers it.\n`
+			+ `Tell it too: dev3 message --task ${task.id.slice(0, 8)}${projectFlag} "<what changed>"\n`,
+		);
+	}
 }
 
 async function requestCompletion(

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -98,6 +98,8 @@ const COMMANDS: CommandHelp[] = [
 				details: [
 					"--title <text>        New title (cannot be empty).",
 					'--description <text>  New description ("" clears it); use - to read it from stdin.',
+					"                      A running agent never sees this — the description is its first prompt at",
+					"                      launch and nothing re-delivers it; send `dev3 message` as well.",
 					"--priority <P0..P4>   Set importance (P0 highest … P4 lowest); applies to the whole variant group.",
 					"                      Only set priority when the user asks — never on your own initiative.",
 					"--manual-completion on|off  Control whether merge detection suggests completing this task.",

--- a/src/mainview/__tests__/types.test.ts
+++ b/src/mainview/__tests__/types.test.ts
@@ -1,6 +1,7 @@
 import {
 	compareTaskSortRank,
 	isTaskDisconnected,
+	taskAgentSessionLooksLive,
 	taskSortRank,
 	hexToRgb,
 	titleFromDescription,
@@ -871,6 +872,38 @@ describe("isTaskDisconnected — a session that died with the app", () => {
 		const disconnectedP0 = dead({ priority: "P0" });
 		expect(compareTaskSortRank(disconnectedP0, { priority: "P4" })).toBeGreaterThan(0);
 		expect(compareTaskSortRank(disconnectedP0, { priority: "P0", hibernated: true })).toBeLessThan(0);
+	});
+});
+
+describe("taskAgentSessionLooksLive — is there an agent that would miss a description edit", () => {
+	const live = (over: Partial<Task> = {}): Partial<Task> => ({
+		status: "in-progress",
+		worktreePath: "/wt",
+		runtimeState: { runtime: "running", updatedAt: 1 },
+		...over,
+	});
+
+	it("is true for a task running in an active column", () => {
+		expect(taskAgentSessionLooksLive(live())).toBe(true);
+		expect(taskAgentSessionLooksLive(live({ status: "review-by-user" }))).toBe(true);
+	});
+
+	it("says nothing is live before the launch that will read the description", () => {
+		expect(taskAgentSessionLooksLive(live({ status: "todo" }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ worktreePath: null }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ draft: true }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ preparing: true }))).toBe(false);
+	});
+
+	it("says nothing is live once the session is gone", () => {
+		expect(taskAgentSessionLooksLive(live({ hibernated: true }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ shuttingDown: true }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ status: "completed" }))).toBe(false);
+		expect(taskAgentSessionLooksLive(live({ runtimeState: { runtime: "idle", updatedAt: 1 } }))).toBe(false);
+	});
+
+	it("treats a task whose runtime was never persisted as live, same as the sort bands do", () => {
+		expect(taskAgentSessionLooksLive(live({ runtimeState: undefined }))).toBe(true);
 	});
 });
 

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -108,6 +108,10 @@ Each task has a priority \`P0\` (highest) … \`P4\` (lowest), default \`P3\`; t
 A task may be the board's **coordinator**: it manages other tasks instead of doing their work. \`dev3 task show\` prints it as \`Type:\`, its card is dashed green, it sorts above every priority band, and it never auto-completes. A task may also be a **pr-review**, which is only named on the card and changes nothing else. \`dev3 task update --type coordinator|pr-review|standard\` sets or clears the type; either way dev3 rewrites the role preamble in the description and tells the running agent, so the badge and the agent behind it always agree. \`dev3 task create --title "..." --type <same values>\` starts a task with its role already set, so there is no window in which the card claims a role its description never carried.
 
 **Never promote or demote a task on your own initiative — least of all yourself.** Who coordinates is the user's call, in the same protected class as priority.
+
+## Editing a description never reaches a running agent
+
+\`--type\` is the ONLY flag that tells a live agent anything. A task's description is delivered as its agent's first prompt at launch and nothing re-delivers it — not a resume, not a push — so \`dev3 task update --description\` on a running task changes the board and the agent never finds out (it only sees the new text if it happens to re-run \`dev3 current\` / \`dev3 task show\` itself). Widening or correcting a running task's brief takes both: the \`--description\` edit for the record, and \`dev3 message --task <id>\` so its agent actually hears it. On a task that has not started, the edit alone is enough.
 `;
 
 const SKILL_CUSTOM_COLUMNS = `

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -358,6 +358,20 @@ export function isTaskDisconnected(task: TaskSortFields): boolean {
 }
 
 /**
+ * Does this task look like it has an agent session running right now? Derived
+ * from persisted state only — nothing is probed — so it may only decide whether
+ * to TELL the user something, never whether a delivery happened. A launch that
+ * has not happened yet (`todo`, draft, preparing) reads false on purpose: such a
+ * task still gets its description as the agent's first prompt.
+ */
+export function taskAgentSessionLooksLive(task: TaskSortFields): boolean {
+	if (task.hibernated || task.draft || task.preparing || task.shuttingDown) return false;
+	if (!task.worktreePath) return false;
+	if (!task.status || !ACTIVE_STATUSES.includes(task.status)) return false;
+	return !isTaskDisconnected(task);
+}
+
+/**
  * Sort rank of a task: its {@link priorityRank}, plus {@link HIBERNATED_SORT_OFFSET}
  * when hibernated, {@link DISCONNECTED_SORT_OFFSET} when its session died, or
  * {@link COORDINATOR_SORT_OFFSET} when it is a live coordinator. None of the


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

A task's `description` is delivered as its agent's first prompt at launch (`buildTaskPrompt`, attached only `if (!resume)`), and nothing re-delivers it: `task.update` calls `deliverAgentPrompt` only for a `--type` change. So rewriting a running task's brief with `dev3 task update --description` updates the board while its agent never finds out — it sees the new text only if it happens to re-run `dev3 current` / `dev3 task show` itself. That cost a live task 25 minutes of standing still, and nothing anywhere said it.

This does not change delivery behaviour; it makes the silence audible in three places.

- `taskAgentSessionLooksLive()` (`src/shared/types.ts`) — pure predicate over the same field subset `isTaskDisconnected()` reads. Derived from persisted state, never probed, so it may only decide whether to *tell* the user something.
- `dev3 task update --description` on a task with a live agent now prints a note saying the agent will not see it, plus the `dev3 message --task <id>` command to send too (carrying `--project` when the caller passed one). A task that has not launched yet stays quiet — its description still is the first prompt.
- The same wording added to `dev3 task update --help` and to the dev3 skill every agent loads at startup.

`--title` is left silent on purpose: equally undelivered, but agents rename their own task on every session start, so a hint there would fire constantly on a correct action.

Decision record: `decisions/2026/08/27/warn-when-a-description-edit-misses-a-running-agent.md`. No tip added — scored 2 on the coolness rubric (a caveat, not a capability), and the CLI now says it at the moment of the mistake, which beats a tip. No browser QA: nothing renders.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=40758ec0-3e69-4614-92bf-f9481c17bfb8) · `dev3://task/40758ec0-3e69-4614-92bf-f9481c17bfb8`