### PR TITLE
Replay pending completion dialogs to a renderer on connect

### DIFF
--- a/change-logs/2026/08/27/fix-orphaned-completion-approval-dialog.md
+++ b/change-logs/2026/08/27/fix-orphaned-completion-approval-dialog.md
@@ -1,0 +1,3 @@
+Short: Reloading no longer strands an approval
+
+A window that reloaded while an agent was waiting for completion approval used to take the only copy of that dialog with it, leaving the agent blocked and the task unable to ask again for the rest of the app session. A connecting window now picks up any completion request that is still waiting and re-draws it.

--- a/decisions/2026/08/27/replay-pending-completion-dialogs-on-renderer-connect.md
+++ b/decisions/2026/08/27/replay-pending-completion-dialogs-on-renderer-connect.md
@@ -1,0 +1,75 @@
+# Replay pending completion dialogs to a renderer when it connects
+
+## Context
+
+An agent-initiated completion request (`dev3 task move --status completed`) blocks the CLI for up
+to 10 minutes while the user answers a dialog. The request lives in `pendingByRequestId`
+(`src/bun/agent-requests.ts`); the dialog lives *only* as a React `confirm()` promise inside
+whichever renderers were connected when `agentCompletionRequested` was pushed.
+
+That push is a one-shot event. A renderer that goes away before answering — a remote-browser tab
+refresh is the cheap case — takes the only copy of the dialog with it. The entry survives, and
+because `createAgentRequest` de-duplicates on `complete:<taskId>` and *joins* an existing promise,
+every later retry attaches to a request that no client will ever draw. Unlike `launch`, the
+`complete` kind deliberately has no auto-approve timer (`cli-socket-server.ts`: "A launch is
+reversible… The completion dialog deliberately does not do this — it destroys a worktree"), so
+nothing ever expires it. Net effect: that task can never raise a completion dialog again for the
+rest of the app session, and each agent attempt burns a full 10-minute block with no explanation.
+
+## Investigation
+
+Found while refuting an unrelated report (task 4ebac127 / Seq 1696) and reproduced before any fix:
+a request pushed to renderer A, then a fresh renderer B, a retry that pushes nothing to B, and 24
+hours of fake clock with both callers still blocked and `moveTask` never called. A control proved
+the clock itself works — a request created *with* `autoApproveAfterMs` settles under the same
+advance — and a mutant that added `autoApproveAfterMs` at the `complete` call site turned the
+reproduction red on exactly the "no expiry" assertion, then green again when removed.
+
+Browser QA on a scoped `--qa` board corrected one thing and found another. A **graceful** tab
+reload does not orphan the request: the reloaded page replays it, and the trigger for an orphan is
+an **ungraceful** loss of the renderer — verified by killing the browser outright, after which the
+blocked CLI was still waiting with nothing on screen anywhere. And the first cut of this fix turned
+that orphan into a silent auto-decline: `confirm()` is fail-closed, so replaying before
+`ConfirmHost` had mounted resolved `false` with no dialog drawn and told the agent the user had
+declined a dialog nobody ever saw. That is why the replay now waits for
+`whenConfirmHostMounted()` and skips rather than answering if the host never appears.
+
+An app *quit* does **not** produce this bug: the map is in-memory, so the process death takes the
+request with it, the blocked CLI sees `Empty response from server` immediately
+(`src/cli/socket-client.ts`), and its retry creates a genuinely new request. Verified in
+`~/.dev3.0/logs/2026/08/2026-08-22.log`, where pid 90303 held two pending completion requests and
+quit at 21:14:25 with a fresh pid up three seconds later.
+
+## Decision
+
+The renderer asks, rather than the backend guessing. `createAgentRequest` now stores the dialog
+payload (`AgentRequestDialog`: title + `TaskDialogSubject`) on the pending entry, and
+`listPendingAgentRequests(kind)` exposes the unanswered ones. A new RPC,
+`listPendingCompletionRequests` (`src/bun/rpc-handlers/task-lifecycle.ts`), returns them, and
+`App.tsx` calls it once the completion-dialog effect is listening, feeding each through the same
+`showCompletionDialog` routine the push uses. A ref-held set of request ids keeps the push and the
+replay from stacking two confirms for one request.
+
+Deliberately unchanged: no expiry and no auto-approval for `complete`. A completion still happens
+only because a human clicked approve.
+
+## Risks
+
+- A pending request whose CLI has already timed out is still replayed, so the user may be asked
+  about a request nobody is waiting on. Approving it completes the task, which is what the dialog
+  says it does — but the agent will not see the answer. Accepted: the alternative is tracking
+  socket liveness per request, which is a much larger change for a narrower win.
+- The replay fires on every re-run of that effect, not strictly on connect. The id set makes the
+  extra calls no-ops; the cost is one cheap in-memory RPC.
+- An app restart still strands nothing but also recovers nothing — see below.
+
+## Alternatives considered
+
+- **Give `complete` a TTL.** Cheap, but it must never auto-approve (worktree destruction), so it
+  could only auto-*decline* — which silently refuses a completion the user never saw, and loses
+  the request anyway. Rejected.
+- **Drop the request when its renderer disconnects.** Requires per-client ownership the request
+  layer does not have, and would kill a request that a *second* connected window is still showing.
+- **Persist pending requests across an app restart.** Rejected as actively harmful: after a
+  restart the requesting CLI is already dead (it got `Empty response from server`), so approving a
+  restored dialog would complete a task with no agent waiting on the answer.

--- a/src/bun/__tests__/agent-requests.test.ts
+++ b/src/bun/__tests__/agent-requests.test.ts
@@ -16,10 +16,20 @@ vi.mock("../rpc-handlers/shared-pure", () => ({
 
 import {
 	createAgentRequest,
+	listPendingAgentRequests,
 	resolveAgentRequest,
 	setAgentRequestLaunchChoice,
 	_resetAgentRequestsForTests,
 } from "../agent-requests";
+import type { TaskDialogSubject } from "../../shared/types";
+
+const SUBJECT: TaskDialogSubject = {
+	seqLabel: "42",
+	projectName: "Test Project",
+	priority: "P3",
+	labels: [],
+	overview: null,
+};
 
 beforeEach(() => {
 	_resetAgentRequestsForTests();
@@ -202,5 +212,57 @@ describe("auto-approval", () => {
 
 	it("ignores a choice reported for an unknown request", () => {
 		expect(setAgentRequestLaunchChoice("nope", { variants: [{ agentId: null, configId: null }] })).toBe(false);
+	});
+});
+
+// A dialog lives only as a promise inside a renderer, and the push that draws it
+// fires once. Without this list, a renderer that reloads before answering leaves
+// the request alive and unanswerable for the rest of the app session, because a
+// retrying agent joins the same entry instead of triggering a second push.
+describe("listPendingAgentRequests", () => {
+	it("returns a pending request so a renderer that connects later can redraw it", () => {
+		const { requestId } = createAgentRequest("complete", "task-1", "proj-1", {
+			dialog: { taskTitle: "Ship the thing", subject: SUBJECT },
+		});
+
+		expect(listPendingAgentRequests("complete")).toEqual([
+			{ requestId, taskId: "task-1", projectId: "proj-1", dialog: { taskTitle: "Ship the thing", subject: SUBJECT } },
+		]);
+	});
+
+	it("stops returning a request once it is answered", () => {
+		const { requestId } = createAgentRequest("complete", "task-1", "proj-1", {
+			dialog: { taskTitle: "Ship the thing", subject: SUBJECT },
+		});
+		resolveAgentRequest(requestId, { approved: false });
+
+		expect(listPendingAgentRequests("complete")).toEqual([]);
+	});
+
+	it("keeps a joined retry to ONE entry, so the reconnecting renderer draws one dialog", () => {
+		const first = createAgentRequest("complete", "task-1", "proj-1", {
+			dialog: { taskTitle: "Ship the thing", subject: SUBJECT },
+		});
+		const retry = createAgentRequest("complete", "task-1", "proj-1", {
+			dialog: { taskTitle: "Ship the thing", subject: SUBJECT },
+		});
+
+		expect(retry.isNew).toBe(false);
+		expect(listPendingAgentRequests("complete")).toHaveLength(1);
+		expect(listPendingAgentRequests("complete")[0].requestId).toBe(first.requestId);
+	});
+
+	it("does not mix the kinds", () => {
+		createAgentRequest("complete", "task-1", "proj-1", { dialog: { taskTitle: "A", subject: SUBJECT } });
+		createAgentRequest("launch", "task-2", "proj-1", { dialog: { taskTitle: "B", subject: SUBJECT } });
+
+		expect(listPendingAgentRequests("complete").map((r) => r.taskId)).toEqual(["task-1"]);
+		expect(listPendingAgentRequests("launch").map((r) => r.taskId)).toEqual(["task-2"]);
+	});
+
+	it("omits a request created without a dialog — there would be nothing to draw", () => {
+		createAgentRequest("complete", "task-1", "proj-1");
+
+		expect(listPendingAgentRequests("complete")).toEqual([]);
 	});
 });

--- a/src/bun/__tests__/cli-socket-completion-request.test.ts
+++ b/src/bun/__tests__/cli-socket-completion-request.test.ts
@@ -86,7 +86,7 @@ vi.mock("node:fs", () => ({
 
 import * as data from "../data";
 import { moveTask, getPushMessage } from "../rpc-handlers";
-import { resolveAgentRequest, _resetAgentRequestsForTests } from "../agent-requests";
+import { listPendingAgentRequests, resolveAgentRequest, _resetAgentRequestsForTests } from "../agent-requests";
 
 const { handleRequest } = await import("../cli-socket-server");
 
@@ -209,6 +209,38 @@ describe("task.requestCompletion", () => {
 		expect(resp.ok).toBe(true);
 		expect(resp.data).toEqual({ approved: false });
 		expect(moveTask).not.toHaveBeenCalled();
+	});
+
+	// The orphan: a renderer that reloads before answering takes the only copy of
+	// the dialog with it. The request stays alive, and the agent's retry joins it
+	// rather than pushing again — so without the pending list the user can never
+	// be asked again and the task can never be completed this app session.
+	it("keeps a request answerable after the renderer that owned its dialog reloaded", async () => {
+		setupTask(makeTask());
+		const rendererA = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(rendererA);
+
+		const first = handleRequest(makeRequest({ taskId: "task-abc12345", projectId: "proj-1" }));
+		await vi.waitFor(() => expect(rendererA).toHaveBeenCalledTimes(1));
+
+		// The tab reloads. The new renderer gets no push — it has to ask.
+		const rendererB = vi.fn();
+		vi.mocked(getPushMessage).mockReturnValue(rendererB);
+		const retry = handleRequest(makeRequest({ taskId: "task-abc12345", projectId: "proj-1" }));
+		await new Promise((r) => setTimeout(r, 10));
+		expect(rendererB).not.toHaveBeenCalled();
+
+		// ...and asking finds the request, with everything needed to draw it.
+		const pending = listPendingAgentRequests("complete");
+		expect(pending).toHaveLength(1);
+		expect(pending[0].dialog.taskTitle).toBe("Test task");
+		expect(pending[0].dialog.subject.projectName).toBe("Test Project");
+
+		// Answering the redrawn dialog releases BOTH blocked callers.
+		resolveAgentRequest(pending[0].requestId, { approved: false });
+		const [respA, respB] = await Promise.all([first, retry]);
+		expect(respA.data).toEqual({ approved: false });
+		expect(respB.data).toEqual({ approved: false });
 	});
 
 	it("joins an existing pending request instead of pushing a second dialog", async () => {

--- a/src/bun/agent-requests.ts
+++ b/src/bun/agent-requests.ts
@@ -1,4 +1,4 @@
-import type { AgentLaunchChoice } from "../shared/types";
+import type { AgentLaunchChoice, TaskDialogSubject } from "../shared/types";
 import { createLogger } from "./logger";
 import { getPushMessage } from "./rpc-handlers/shared-pure";
 
@@ -16,6 +16,16 @@ export interface AgentRequestDecision {
 	launch?: AgentLaunchChoice;
 }
 
+/**
+ * What a renderer needs to draw the completion dialog, beyond the ids it already
+ * gets. Kept on the pending entry so a client that arrives AFTER the original
+ * push can still be handed the dialog — see {@link listPendingAgentRequests}.
+ */
+export interface AgentRequestDialog {
+	taskTitle: string;
+	subject: TaskDialogSubject;
+}
+
 interface PendingAgentRequest {
 	requestId: string;
 	kind: AgentRequestKind;
@@ -23,6 +33,8 @@ interface PendingAgentRequest {
 	projectId: string;
 	decision: Promise<AgentRequestDecision>;
 	resolve: (decision: AgentRequestDecision) => void;
+	/** Present when the caller supplied one; absent kinds are not replayable. */
+	dialog?: AgentRequestDialog;
 	/** Auto-approval timer, when the request was created with a deadline. */
 	autoApproveTimer?: ReturnType<typeof setTimeout>;
 	/** Epoch ms the timer fires at; mirrored to the dialog for its countdown. */
@@ -51,6 +63,8 @@ export function createAgentRequest(
 	opts: {
 		/** Approve the request automatically after this many ms. 0/omitted ⇒ never. */
 		autoApproveAfterMs?: number;
+		/** Lets a renderer that connects later be handed this dialog. */
+		dialog?: AgentRequestDialog;
 	} = {},
 ): { requestId: string; decision: Promise<AgentRequestDecision>; isNew: boolean; autoApproveAt: number | null } {
 	const key = dedupKey(kind, taskId);
@@ -73,7 +87,10 @@ export function createAgentRequest(
 
 	const autoApproveAfterMs = opts.autoApproveAfterMs ?? 0;
 	const autoApproveAt = autoApproveAfterMs > 0 ? Date.now() + autoApproveAfterMs : null;
-	const entry: PendingAgentRequest = { requestId, kind, taskId, projectId, decision, resolve, autoApproveAt };
+	const entry: PendingAgentRequest = {
+		requestId, kind, taskId, projectId, decision, resolve, autoApproveAt,
+		...(opts.dialog ? { dialog: opts.dialog } : {}),
+	};
 	pendingByRequestId.set(requestId, entry);
 	requestIdByKey.set(key, requestId);
 
@@ -103,6 +120,27 @@ export function setAgentRequestLaunchChoice(requestId: string, launch: AgentLaun
 	if (!entry) return false;
 	entry.launchChoice = launch;
 	return true;
+}
+
+/**
+ * Every pending request of a kind that still has nobody to answer it.
+ *
+ * A dialog lives only as a promise inside a renderer, and the push that created
+ * it is a one-shot event. So a renderer that reloads — a remote browser tab
+ * refresh is the cheap case — leaves the entry alive with no dialog behind it,
+ * and because a retry JOINS instead of re-pushing, the request could never be
+ * drawn again. A connecting renderer asks for this list and re-draws what it
+ * finds, which is what makes the entry reachable again.
+ */
+export function listPendingAgentRequests(
+	kind: AgentRequestKind,
+): Array<{ requestId: string; taskId: string; projectId: string; dialog: AgentRequestDialog }> {
+	const out: Array<{ requestId: string; taskId: string; projectId: string; dialog: AgentRequestDialog }> = [];
+	for (const entry of pendingByRequestId.values()) {
+		if (entry.kind !== kind || !entry.dialog) continue;
+		out.push({ requestId: entry.requestId, taskId: entry.taskId, projectId: entry.projectId, dialog: entry.dialog });
+	}
+	return out;
 }
 
 /** Resolve a pending request with the user's decision. Returns false if the request is unknown/expired. */

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -1530,17 +1530,18 @@ const handlers: Record<string, Handler> = {
 			throw new Error("No app window is connected — cannot ask the user for approval");
 		}
 
-		const { requestId, decision, isNew } = createAgentRequest("complete", task.id, project.id);
+		// Kept ON the request, not just pushed: the push is a one-shot event, so a
+		// renderer that reloads before answering could never be handed the dialog
+		// again (a retry joins instead of re-pushing). It asks for this on connect.
+		const dialog = {
+			taskTitle: getTaskTitle(task),
+			// Full read-only context (project, seq, priority, labels, overview)
+			// so the user recognizes which task the prompt destroys.
+			subject: buildTaskDialogSubject(task, project),
+		};
+		const { requestId, decision, isNew } = createAgentRequest("complete", task.id, project.id, { dialog });
 		if (isNew) {
-			push("agentCompletionRequested", {
-				requestId,
-				taskId: task.id,
-				projectId: project.id,
-				taskTitle: getTaskTitle(task),
-				// Full read-only context (project, seq, priority, labels, overview)
-				// so the user recognizes which task the prompt destroys.
-				subject: buildTaskDialogSubject(task, project),
-			});
+			push("agentCompletionRequested", { requestId, taskId: task.id, projectId: project.id, ...dialog });
 		}
 
 		const { approved } = await decision;

--- a/src/bun/rpc-handlers/task-lifecycle.ts
+++ b/src/bun/rpc-handlers/task-lifecycle.ts
@@ -1,10 +1,10 @@
-import type { AgentLaunchChoice, LaunchVariant, NativeTerminalAvailability, Project, Task, TaskPriority, TaskStatus, TaskTerminalBackendInfo, TaskType } from "../../shared/types";
+import type { AgentCompletionRequest, AgentLaunchChoice, LaunchVariant, NativeTerminalAvailability, Project, Task, TaskPriority, TaskStatus, TaskTerminalBackendInfo, TaskType } from "../../shared/types";
 import type { TerminalBackendIdentity } from "../../shared/terminal-backend-identity";
 import { ACTIVE_STATUSES, BUILTIN_OPS_BOARD_NAME, DRAFT_TASK_ACTIVATION_ERROR, reviewTaskTitle, titleFromDescription } from "../../shared/types";
 import * as data from "../data";
 import * as git from "../git";
 import * as github from "../github";
-import { resolveAgentRequest, setAgentRequestLaunchChoice } from "../agent-requests";
+import { listPendingAgentRequests, resolveAgentRequest, setAgentRequestLaunchChoice } from "../agent-requests";
 import { loadSettingsSync, recordFavoriteUsages } from "../settings";
 import { emitTaskSound } from "../lifecycle/executor";
 import { getPushMessage, isActive, log } from "./shared";
@@ -899,6 +899,22 @@ async function setTaskManualCompletion(params: { taskId: string; projectId: stri
 	return updated;
 }
 
+/**
+ * Completion dialogs still waiting for an answer, for a renderer that just
+ * connected. `agentCompletionRequested` is a one-shot push, so a window that
+ * reloads before answering would otherwise leave the request unanswerable: the
+ * blocked agent's retry joins the same entry instead of triggering a new push.
+ */
+async function listPendingCompletionRequests(): Promise<AgentCompletionRequest[]> {
+	return listPendingAgentRequests("complete").map((r) => ({
+		requestId: r.requestId,
+		taskId: r.taskId,
+		projectId: r.projectId,
+		taskTitle: r.dialog.taskTitle,
+		subject: r.dialog.subject,
+	}));
+}
+
 async function respondToAgentCompletionRequest(params: { requestId: string; approved: boolean }): Promise<void> {
 	const known = resolveAgentRequest(params.requestId, { approved: params.approved });
 	if (!known) {
@@ -1174,6 +1190,7 @@ export const taskLifecycleHandlers = {
 	scheduleTaskLaunch,
 	cancelScheduledLaunch,
 	startScheduledLaunchNow,
+	listPendingCompletionRequests,
 	respondToAgentCompletionRequest,
 	respondToAgentLaunchRequest,
 	updateAgentLaunchChoice,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -52,7 +52,7 @@ import KeyboardShortcutsModal, { type ShortcutsTab } from "./components/Keyboard
 import UpdatePopoverSimulatorModal from "./components/UpdatePopoverSimulatorModal";
 import RemoteAccessDialog from "./components/RemoteAccessDialog";
 import RemoteAccessExposedPorts from "./components/RemoteAccessExposedPorts";
-import { ConfirmHost, confirm } from "./confirm";
+import { ConfirmHost, confirm, whenConfirmHostMounted } from "./confirm";
 import AgentLaunchRequestModal from "./components/AgentLaunchRequestModal";
 import AboutModal from "./components/AboutModal";
 import FeatureFlagsModal from "./components/FeatureFlagsModal";
@@ -615,6 +615,10 @@ function App() {
 	// Navigation guard for unsaved-changes prompts (e.g. ProjectSettings, diff viewer)
 	const navigationGuardRef = useRef<NavigationGuard | null>(null);
 	const [pendingNavigation, setPendingNavigation] = useState<Route | null>(null);
+
+	// Completion dialogs this window already has on screen, so the push and the
+	// on-connect replay of the same request cannot stack two confirms.
+	const completionDialogsShowingRef = useRef<Set<string>>(new Set());
 
 	// Latest route mirror — async event handlers read this to make routing decisions
 	// without re-subscribing every navigation.
@@ -1867,13 +1871,22 @@ function App() {
 	// Listen for agent-initiated completion requests — the CLI is blocked on a
 	// socket waiting for the user's decision, so always respond, even on cancel.
 	useEffect(() => {
-		async function onAgentCompletionRequested(e: Event) {
-			const { requestId, taskId, taskTitle, subject } = (e as CustomEvent).detail as {
-				requestId: string;
-				taskId: string;
-				taskTitle: string;
-				subject?: TaskDialogSubject;
-			};
+		// One dialog per request on this client. The push and the on-connect replay
+		// can both name the same request (a reload that raced the push), and two
+		// stacked confirms for one approval is worse than the bug being fixed. The
+		// set lives in a ref because this effect re-runs on every `t`/`navigate`
+		// identity change — a set rebuilt per run would forget what is on screen.
+		const showing = completionDialogsShowingRef.current;
+
+		async function showCompletionDialog(request: {
+			requestId: string;
+			taskId: string;
+			taskTitle: string;
+			subject?: TaskDialogSubject;
+		}) {
+			const { requestId, taskId, taskTitle, subject } = request;
+			if (showing.has(requestId)) return;
+			showing.add(requestId);
 			let approved = false;
 			// The same dialog is up on every connected client; the first answer
 			// closes the rest (see createAgentRequestAbort).
@@ -1893,6 +1906,7 @@ function App() {
 				console.error("[App] confirm (agent-completion) failed:", err);
 			} finally {
 				abort.cleanup();
+				showing.delete(requestId);
 			}
 			// Answered on another client — that client owns every side effect, and
 			// the CLI already has its decision.
@@ -1912,7 +1926,31 @@ function App() {
 				console.error("respondToAgentCompletionRequest failed:", err),
 			);
 		}
+
+		function onAgentCompletionRequested(e: Event) {
+			void showCompletionDialog((e as CustomEvent).detail);
+		}
 		window.addEventListener("rpc:agentCompletionRequested", onAgentCompletionRequested);
+
+		// The push above is a one-shot event. A window that reloads before answering
+		// would otherwise never be offered the dialog again — the blocked agent's
+		// retry joins the same request instead of triggering a new push — so the
+		// request would sit unanswerable for the rest of the app session. Ask what
+		// is still pending as soon as this client is listening.
+		api.request.listPendingCompletionRequests({}).then(async (pending) => {
+			if (pending.length === 0) return;
+			// `confirm()` is fail-closed, and this runs during startup: calling it
+			// before ConfirmHost has mounted would resolve `false` with no dialog on
+			// screen and answer "declined" for a user who was never asked. Rather
+			// than auto-decline, leave the request pending — the next window to
+			// connect replays it again.
+			if (!await whenConfirmHostMounted()) {
+				console.error("[App] pending completion dialogs skipped — ConfirmHost never mounted");
+				return;
+			}
+			for (const request of pending) void showCompletionDialog(request);
+		}).catch((err) => console.error("listPendingCompletionRequests failed:", err));
+
 		return () => window.removeEventListener("rpc:agentCompletionRequested", onAgentCompletionRequested);
 	}, [dispatch, navigate, t]);
 

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -53,6 +53,7 @@ vi.mock("../rpc", () => ({
 			markTaskSharedItemsRead: vi.fn().mockResolvedValue({ id: "updated-task" }),
 			listAgentSkills: vi.fn().mockResolvedValue([]),
 			respondToAgentCompletionRequest: vi.fn().mockResolvedValue(undefined),
+			listPendingCompletionRequests: vi.fn().mockResolvedValue([]),
 			respondToAgentLaunchRequest: vi.fn().mockResolvedValue(undefined),
 			checkAgentAvailability: vi.fn().mockResolvedValue([]),
 			getRemoteAccessQR: vi.fn().mockResolvedValue({
@@ -170,6 +171,9 @@ import { confirm } from "../confirm";
 vi.mock("../confirm", () => ({
 	confirm: vi.fn().mockResolvedValue(false),
 	ConfirmHost: () => null,
+	// The stubbed host is always "mounted" here — the real readiness wait is
+	// covered in confirm.test.tsx against the real ConfirmHost.
+	whenConfirmHostMounted: vi.fn().mockResolvedValue(true),
 }));
 import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "../task-sounds";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
@@ -2734,6 +2738,47 @@ describe("App keyboard shortcuts", () => {
 				priority: "P0",
 				labels: [{ id: "l1", name: "Feature", color: "#84cc16" }],
 			});
+		});
+	});
+
+	// `agentCompletionRequested` is a one-shot push, so a window that reloads
+	// before answering never sees it again — and the blocked agent's retry joins
+	// the same request rather than pushing a second time. A connecting client asks
+	// what is still pending, which is what makes the request answerable at all.
+	describe("pending completion requests on connect", () => {
+		it("draws a dialog for a request that was pushed before this window existed", async () => {
+			vi.mocked(api.request.listPendingCompletionRequests).mockResolvedValue([
+				{ requestId: "req-orphan", taskId: "t1", projectId: "p1", taskTitle: "Stranded task", subject: undefined },
+			] as never);
+			vi.mocked(confirm).mockResolvedValue(false);
+
+			await renderApp();
+
+			await waitFor(() => {
+				expect(api.request.respondToAgentCompletionRequest).toHaveBeenCalledWith({
+					requestId: "req-orphan",
+					approved: false,
+				});
+			});
+		});
+
+		it("does not stack two dialogs when the push and the replay name the same request", async () => {
+			vi.mocked(api.request.listPendingCompletionRequests).mockResolvedValue([
+				{ requestId: "req-dup", taskId: "t1", projectId: "p1", taskTitle: "Same task", subject: undefined },
+			] as never);
+			// Never settles, so the first dialog is still open when the push arrives.
+			vi.mocked(confirm).mockImplementation((() => new Promise<boolean>(() => {})) as never);
+
+			await renderApp();
+			await waitFor(() => expect(vi.mocked(confirm)).toHaveBeenCalledTimes(1));
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentCompletionRequested", {
+					detail: { requestId: "req-dup", taskId: "t1", projectId: "p1", taskTitle: "Same task" },
+				}));
+			});
+
+			expect(vi.mocked(confirm)).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/mainview/__tests__/confirm.test.tsx
+++ b/src/mainview/__tests__/confirm.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
-import { ConfirmHost, confirm } from "../confirm";
+import { ConfirmHost, confirm, whenConfirmHostMounted } from "../confirm";
 import { I18nProvider } from "../i18n";
 
 function renderHost() {
@@ -404,5 +404,29 @@ describe("confirm service", () => {
 
 		await expect(result!).resolves.toBe(false);
 		expect(screen.queryByText("Already resolved")).not.toBeInTheDocument();
+	});
+});
+
+// `confirm()` is fail-closed: with no host it resolves `false` and draws nothing.
+// A startup caller that read that as "the user declined" would answer on the
+// user's behalf for a dialog nobody saw — which is exactly what the replay of a
+// pending completion request did before it learned to wait.
+describe("whenConfirmHostMounted", () => {
+	it("resolves false when no host ever mounts, instead of pretending one did", async () => {
+		await expect(whenConfirmHostMounted(120)).resolves.toBe(false);
+	});
+
+	it("resolves true once the host is on screen", async () => {
+		renderHost();
+		await expect(whenConfirmHostMounted(1000)).resolves.toBe(true);
+	});
+
+	it("resolves true for a host that mounts a moment later", async () => {
+		const waiting = whenConfirmHostMounted(2000);
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 80));
+			renderHost();
+		});
+		await expect(waiting).resolves.toBe(true);
 	});
 });

--- a/src/mainview/confirm.tsx
+++ b/src/mainview/confirm.tsx
@@ -120,6 +120,32 @@ export function confirm(options: ConfirmOptions): Promise<boolean | string> {
 	});
 }
 
+/**
+ * Resolves once `<ConfirmHost />` can actually draw a dialog, or `false` if it
+ * has not mounted within `timeoutMs`.
+ *
+ * `confirm()` is fail-closed: with no host it resolves `false` immediately and
+ * draws nothing. For a user-triggered confirm that is right — the host is long
+ * mounted by then. For anything fired during startup it is not: a caller that
+ * treats `false` as "the user said no" would answer on the user's behalf for a
+ * dialog nobody ever saw. Such callers wait for this first.
+ */
+export function whenConfirmHostMounted(timeoutMs = 10_000): Promise<boolean> {
+	if (listener) return Promise.resolve(true);
+	return new Promise((resolve) => {
+		const started = Date.now();
+		const poll = setInterval(() => {
+			if (listener) {
+				clearInterval(poll);
+				resolve(true);
+			} else if (Date.now() - started >= timeoutMs) {
+				clearInterval(poll);
+				resolve(false);
+			}
+		}, 50);
+	});
+}
+
 export function ConfirmHost() {
 	const [pending, setPending] = useState<PendingConfirm | null>(null);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2706,6 +2706,19 @@ export interface TaskDialogSubject {
 }
 
 /**
+ * An agent asking the user for permission to complete its own task — the payload
+ * of the `agentCompletionRequested` push, and of `listPendingCompletionRequests`
+ * for a renderer that connected after the push went out.
+ */
+export interface AgentCompletionRequest {
+	requestId: string;
+	taskId: string;
+	projectId: string;
+	taskTitle: string;
+	subject: TaskDialogSubject;
+}
+
+/**
  * An agent asking the user to set ANOTHER task running — the payload of the
  * `agentLaunchRequested` push. Carries who asked (`requesterSeq`/`requesterTitle`)
  * so the dialog can name the agent, and the same read-only subject card the
@@ -5224,6 +5237,17 @@ export type AppRPCSchema = {
 				response: void;
 			};
 			/**
+			 * Completion dialogs that are still waiting for an answer. A renderer
+			 * asks on connect, because `agentCompletionRequested` is a one-shot push:
+			 * a window that reloads before answering would otherwise never see the
+			 * dialog again, and the blocked agent's retry joins the same request
+			 * rather than triggering a new push.
+			 */
+			listPendingCompletionRequests: {
+				params: Record<string, never>;
+				response: AgentCompletionRequest[];
+			};
+			/**
 			 * Renderer answers an `agentLaunchRequested` dialog. Approval hands back
 			 * the variants + priority the user composed, and the blocked CLI request
 			 * launches the task with them; decline releases it with a refusal.
@@ -5313,7 +5337,7 @@ export type AppRPCSchema = {
 			 * carries the read-only task context shown in the dialog (overview lives
 			 * on `subject.overview`).
 			 */
-			agentCompletionRequested: { requestId: string; taskId: string; projectId: string; taskTitle: string; subject: TaskDialogSubject };
+			agentCompletionRequested: AgentCompletionRequest;
 			/**
 			 * Emitted when an agent asks to set ANOTHER task running — either
 			 * `dev3 task move --task <other> --status <active>` or


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

An agent-initiated completion request blocks its CLI for up to 10 minutes while the user answers a dialog. That dialog lived **only** as a `confirm()` promise inside whichever renderers were connected when `agentCompletionRequested` was pushed, and that push is a one-shot event.

So if a renderer went away ungracefully before answering, the request stayed alive with nothing able to draw it. Because `createAgentRequest` de-duplicates on `complete:<taskId>` and *joins*, every later retry attached to a request no client would ever render — and unlike `launch`, the `complete` kind deliberately has no auto-approve timer, so nothing expired it. Net effect: that task could never ask for approval again for the rest of the app session, and each attempt burned a full 10-minute block.

The pending entry now carries its dialog payload, `listPendingCompletionRequests` exposes the unanswered ones, and a connecting renderer redraws them.

One trap worth calling out: `confirm()` is fail-closed, so the first cut of this replayed too early and resolved `false` with no dialog on screen — telling the agent the user had *declined* something nobody saw. Browser QA caught that. The replay now waits for `whenConfirmHostMounted()` and skips rather than answering if the host never appears.

No auto-approval and no expiry were added: a completion still happens only because a human clicked approve.

Reasoning and the alternatives that lost are in `decisions/2026/08/27/replay-pending-completion-dialogs-on-renderer-connect.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4ebac127-928a-4725-bd8b-350ce7b7fdf0) · `dev3://task/4ebac127-928a-4725-bd8b-350ce7b7fdf0`