### PR TITLE
Stack artifact tables on narrow screens instead of scrolling them

### DIFF
--- a/change-logs/2026/08/27/fix-responsive-artifact-tables.md
+++ b/change-logs/2026/08/27/fix-responsive-artifact-tables.md
@@ -1,0 +1,3 @@
+Short: Artifact tables stack instead of scrolling
+
+Tables in dev3 HTML artifacts no longer scroll sideways or drop columns on narrow screens. Below 768px of the table's own container each row becomes a stack of labelled lines, with the shell copying every column heading onto the cells beneath it, so a plain `<table>` needs no new markup to get it. This removes the `.evidence-table-scroll` horizontal scroller and the rule that hid the third and fifth column below 560px, which silently deleted data; print still gets real columns and a repeating header.

--- a/decisions/2026/08/27/artifact-tables-stack-instead-of-scrolling.md
+++ b/decisions/2026/08/27/artifact-tables-stack-instead-of-scrolling.md
@@ -1,0 +1,59 @@
+# Artifact tables stack instead of scrolling
+
+## Context
+
+Tables in the dev3 HTML artifact starter (`src/assets/artifact-template/`) were unreadable on a narrow
+screen in two different ways. Dense ledgers wrapped in `.evidence-table-scroll` scrolled horizontally
+(`overflow-x: auto` over a `width: max-content` table), and plain tables in `.table-card` were worse: the
+card's `overflow: clip` meant columns past the edge were not scrollable but simply *gone*, while a
+`@media (max-width: 560px)` rule additionally hid the third and fifth columns outright. Measured at 375px,
+the 7-column run table clipped to 345px of a needed 512px and the 12-column ledger to 296px of 1094px.
+
+## Investigation
+
+A headless-Chromium pass over a probe artifact (7-column table with a long-text column, 12-column
+evidence ledger) counted elements whose `scrollWidth` exceeded their `clientWidth`: two offenders at 768px
+and two at 375px before the change, zero at 1440/768/375px after. The in-app viewer was cleared as a
+suspect by reading it — `TaskArtifactViewer.tsx` renders a bare `h-full w-full` iframe with no width
+constraint or scroll container of its own, so the artifact's own CSS owned the whole bug.
+
+## Decision
+
+The stacking threshold is **768px, matched against the table's own container**, not the viewport
+(`container: dev3-table / inline-size` on `.table-card` and `.evidence-table-scroll`, queried by
+`@container dev3-table (max-width: 768px)` in `app.css`). 768 is the same narrow gate the app uses
+(`PRODUCT_UX_BIBLE.md` §12.1), so "narrow" means one thing across the product. A container query rather
+than a media query because a table can be narrow while the page is wide — verified: in a 398px panel at a
+1400px viewport the table stacks, which a media query would get wrong. A stacked row is a
+`grid` of `repeat(auto-fit, minmax(13rem, 1fr))`, so cells pair up while there is room (3 across at 768px)
+and drop to one per line on a phone, with `.wrap` cells spanning the full width.
+
+Cell labels come from the shell, not from authors: `labelTableCells()` in `app.js` copies each
+`thead` heading onto the cells beneath it and re-runs from a `MutationObserver` because `report.js`
+renders rows after the shell boots. **Authors write nothing new** — a plain `<table>` with a real
+`<thead>` is the entire contract, and there is no `data-label` attribute to keep in sync.
+
+A table with very many columns is deliberately *not* capped, truncated, or folded behind a
+"show more": its cells are the payload, and hiding some of them is the data-loss bug being removed here.
+Such a table simply gets long vertically, which scrolls in the direction phones already scroll.
+
+## Risks
+
+`container-type: inline-size` applies layout and style containment to `.table-card`, which could in
+principle clip an absolutely-positioned descendant; the shell's popovers and enhanced selects use the
+browser top layer, so they are unaffected, and no console errors or clipping appeared in QA. Paper is
+narrow enough to trip the container query, so `@media print` resets both wrappers to `container: normal`
+— verified against a rendered PDF, which keeps real columns and a repeating header. The header row is
+hidden while stacked, so `data-sort` headings are not clickable on a phone; a report that must stay
+sortable there puts a sort `<select>` in `.table-tools`, and `AUTHORING.md` now says so. Existing task
+worktrees keep their already-provisioned `artifact-template-v1` copy, so the fix reaches new tasks first.
+
+## Alternatives considered
+
+**Keep the scroller and only restyle it** — rejected: the requirement is no horizontal scrolling at all,
+and a scroller hides columns behind a gesture. **A `data-label` attribute per cell** (the classic
+pure-CSS stacking pattern) — rejected: it is a permanent tax on every future artifact author and drifts
+out of sync with the headings the moment a column is renamed. **Label above value in every cell** —
+rejected as unnecessarily tall once `auto-fit` proved it could pair cells up without any per-cell markup.
+**A viewport media query at 560px** (reusing the existing breakpoint) — rejected: it lies for a table in a
+narrow panel, and 560 would leave a 6-column table squeezed between 560 and 768px.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -183,11 +183,13 @@ Every table gets its reading aids from the shell: alternating row tint, a full-r
 
 Mark a sortable heading with `data-sort` plus `tabindex="0"`; the shell maintains `aria-sort` and renders the ascending/descending caret, so report code only has to sort the data. A heading without `data-sort` renders as a plain label with no pointer cursor.
 
+**No table scrolls sideways, and you write nothing to get that.** Below 768px of the table's own container each row stops being a row of columns and becomes a stack of labelled lines; the shell copies every `thead` heading onto the cells beneath it, so a plain `<table>` with a real `<thead>` is the whole requirement. Never add a horizontal scroller, a `width: max-content`, or a `white-space: nowrap` around a table — that is the pattern this replaces. Two consequences worth knowing: a table needs a `<thead>` or its stacked cells have no labels, and the header row is hidden while stacked, so a report that must stay sortable on a phone puts a sort `<select>` in `.table-tools`. Print is unaffected — paper always gets real columns and a repeating header.
+
 ## Dense evidence tables
 
 Keep decision summaries and charts first, then preserve exhaustive source rows in a visible evidence ledger. Large mechanically produced datasets may live in an additional classic JavaScript asset such as `evidence-data.js`; list it in `--assets`, load it before `report.js`, and keep only rendering logic in `report.js`.
 
-Wrap wide tables in `.evidence-table-scroll` and add `.evidence-table` to the table. The shell keeps every column reachable with horizontal scrolling on narrow screens and lays all columns out for print. The first column is pinned while the numbers scroll past it, so put the row's identity there — a day, a cohort, a file — and never a value that only makes sense next to its neighbours. Reuse the semantic source markers `.good`, `.bad`, `.sig`, `.flat`, `.dim`, `.sep`, `.regime`, and `.total`; the shell maps them to dev3 tokens, quiet typographic significance emphasis, column separators, rollout boundaries, and total rows.
+Wrap wide tables in `.evidence-table-scroll` and add `.evidence-table` to the table. The wrapper keeps its name but no longer scrolls: it is what makes the table measure its own box, so a ledger inside a half-width panel stacks while the page is still wide. Put the row's identity in the first column — a day, a cohort, a file — and never a value that only makes sense next to its neighbours; it is the line a reader looks for first in both the tabular and the stacked form. Mark a prose cell `.wrap` and it takes the full width instead of one column when stacked. Reuse the semantic source markers `.good`, `.bad`, `.sig`, `.flat`, `.dim`, `.sep`, `.regime`, and `.total`; the shell maps them to dev3 tokens, quiet typographic significance emphasis, column separators, rollout boundaries, and total rows.
 
 ## Print and PDF
 

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -490,6 +490,9 @@
     [data-popover-trigger][aria-expanded="true"] .popover-caret { transform: rotate(180deg); }
     /* clip, not hidden: hidden makes the card a scrollport and unpins the header. */
     .table-card { padding: 0; overflow: clip; }
+    /* A table answers to the box it sits in, not to the window: one inside a
+       half-width panel has to stack while the page is still wide. */
+    .table-card, .evidence-table-scroll { container: dev3-table / inline-size; }
     .table-head { padding: 16px 18px 12px; }
     .table-tools { gap: 8px; }
     .table-tools input, .table-tools select {
@@ -502,7 +505,7 @@
     }
     .table-tools input { width: 12rem; }
     table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
-    th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); text-align: left; font-size: .75rem; }
+    th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); overflow-wrap: break-word; text-align: left; font-size: .75rem; }
     /* A vertical rule keeps the eye inside one column across a wide row; every
        cell owns its trailing edge so a pinned column can strengthen its own. */
     th:not(:last-child), td:not(:last-child) { border-inline-end: 1px solid rgb(var(--dev3-border) / .5); }
@@ -543,17 +546,13 @@
     .evidence-table-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; padding: 10px 14px 8px; background: rgb(var(--dev3-surface-elevated) / .42); }
     .evidence-table-title { margin: 0; color: rgb(var(--dev3-text-secondary)); font-size: .75rem; font-weight: 700; }
     .evidence-table-meta { flex: 0 0 auto; color: rgb(var(--dev3-text-muted)); font: .625rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
-    .evidence-table-scroll { max-width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-gutter: stable; }
-    .evidence-table { width: max-content; min-width: 100%; font-variant-numeric: tabular-nums; }
-    .evidence-table th, .evidence-table td { padding: 6px 9px; white-space: nowrap; text-align: right; font-size: .65625rem; }
+    /* Kept as the table's query container; it deliberately does not scroll. */
+    .evidence-table-scroll { max-width: 100%; }
+    .evidence-table { width: 100%; font-variant-numeric: tabular-nums; }
+    .evidence-table th, .evidence-table td { padding: 6px 9px; text-align: right; font-size: .65625rem; }
     .evidence-table th { background: rgb(var(--dev3-surface-raised)); cursor: default; font-size: .59375rem; }
-    /* Its own scroller is the scrollport, so the page offset would push the
-       header onto the rows instead of pinning it. */
-    .evidence-table thead th { top: 0; }
-    /* The label column stays put while the numbers scroll past it. */
-    .evidence-table th:first-child, .evidence-table td:first-child { position: sticky; inset-inline-start: 0; border-inline-end-color: rgb(var(--dev3-border)); text-align: left; }
-    .evidence-table thead th:first-child { z-index: 6; }
-    .evidence-table tbody td:first-child { z-index: 1; background-color: rgb(var(--dev3-surface-raised)); background-image: linear-gradient(var(--dev3-row-tint, transparent), var(--dev3-row-tint, transparent)); }
+    /* The row's identity reads as a label, not as one more number. */
+    .evidence-table th:first-child, .evidence-table td:first-child { border-inline-end-color: rgb(var(--dev3-border)); text-align: left; }
     .evidence-table th.grp { border-left: 1px solid rgb(var(--dev3-border)); text-align: center; color: rgb(var(--dev3-text-secondary)); }
     .evidence-table .sep { border-left: 1px solid rgb(var(--dev3-border)); }
     .evidence-table .day { color: rgb(var(--dev3-text-primary)); font-weight: 650; }
@@ -561,7 +560,7 @@
     .evidence-table .bad, .evidence-table .neg { color: rgb(var(--dev3-danger)); }
     .evidence-table .flat, .evidence-table .dim { color: rgb(var(--dev3-text-muted)); }
     .evidence-table .sig { font-weight: 700; }
-    .evidence-table .wrap { min-width: 15rem; white-space: normal; text-align: left; line-height: 1.45; }
+    .evidence-table .wrap { text-align: left; line-height: 1.45; }
     .evidence-table tr.regime td { border-top: 2px solid rgb(var(--dev3-accent) / .55); }
     .evidence-table tr.total td { border-top: 2px solid rgb(var(--dev3-border)); color: rgb(var(--dev3-text-primary)); font-weight: 700; }
     .pill { display: inline-flex; padding: 4px 8px; border-radius: 999px; font-size: .6875rem; font-weight: 650; }
@@ -623,11 +622,36 @@
       .choice-grid { grid-template-columns: 1fr; }
       .table-tools { align-items: stretch; flex-direction: column; }
       .table-tools input { width: 100%; }
-      th:nth-child(3), td:nth-child(3), th:nth-child(5), td:nth-child(5) { display: none; }
-      .evidence-table th:nth-child(3), .evidence-table td:nth-child(3), .evidence-table th:nth-child(5), .evidence-table td:nth-child(5) { display: table-cell; }
       .evidence-group-head, .evidence-toolbar { align-items: stretch; flex-direction: column; }
       .evidence-toolbar .choices { width: 100%; min-width: 0; }
       .dev3-footer { align-items: flex-start; flex-direction: column; }
+    }
+    /* No table ever scrolls sideways. Past the narrow gate a row stops being a
+       row of columns and becomes a stack of labelled lines, so a 20-column table
+       still fits a phone — long vertically, never wide. auto-fit pairs cells up
+       while there is room and drops to one per line on the narrowest screens. */
+    @container dev3-table (max-width: 768px) {
+      /* Every cell carries its own heading now, and a row of headings is exactly
+         the width pressure being removed. */
+      thead { display: none; }
+      table, tbody { display: block; }
+      tbody tr { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: 2px 16px; padding: 12px 16px; border-top: 1px solid rgb(var(--dev3-border)); }
+      tbody th, tbody td { display: block; padding: 4px 0; border: 0; text-align: left; font-size: .75rem; }
+      /* The shell copies thead text onto each cell, so authors write no labels. */
+      tbody td[data-dev3-label]::before {
+        display: block;
+        color: rgb(var(--dev3-text-muted));
+        content: attr(data-dev3-label);
+        font-size: .5625rem;
+        font-weight: 600;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+      }
+      /* Its own selector outranks the generic cell rule, so a stacked ledger cell
+         has to be told again not to hug the right edge. */
+      .evidence-table th, .evidence-table td { text-align: left; font-size: .6875rem; }
+      /* A prose cell takes the whole width instead of one 13rem column. */
+      .evidence-table .wrap { grid-column: 1 / -1; }
     }
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
@@ -684,8 +708,10 @@
       .evidence-table-head { padding: 5px 7px 3px; break-after: avoid; }
       .evidence-table-title { font-size: .4375rem; }
       .evidence-table-meta { font-size: .375rem; }
-      .evidence-table-scroll { overflow: visible; }
-      .evidence-table { width: 100%; min-width: 0; table-layout: auto; }
+      /* Paper is narrow enough to trip the stacking query, and print wants real
+         columns with a repeating header — so the query container goes away. */
+      .table-card, .evidence-table-scroll { container: normal; }
+      .evidence-table { width: 100%; table-layout: auto; }
       .evidence-table th, .evidence-table td { display: table-cell; padding: 1.5px 3px; white-space: normal; font-size: .3875rem; }
       .evidence-table th { font-size: .3625rem; }
       .pill { padding: 2px 5px; font-size: .4375rem; }

--- a/src/assets/artifact-template/app.js
+++ b/src/assets/artifact-template/app.js
@@ -369,10 +369,38 @@
     });
   }
 
+  // A narrow table stacks each row into labelled lines, and the label has to come
+  // from the column heading. The shell copies it onto every cell so report markup
+  // stays a plain <table> with no per-cell label attribute to keep in sync.
+  function labelTableCells(root = document) {
+    root.querySelectorAll("table").forEach((table) => {
+      const headings = Array.from(table.querySelectorAll("thead tr:last-of-type th"), (th) => th.textContent.trim());
+      if (!headings.length) return;
+      table.querySelectorAll("tbody tr").forEach((row) => {
+        Array.from(row.cells).forEach((cell, index) => {
+          // A spanning cell (empty state, total) belongs to no single column.
+          if (cell.colSpan > 1) return;
+          const label = headings[index];
+          if (label) cell.setAttribute("data-dev3-label", label);
+        });
+      });
+    });
+  }
+
+  let queuedLabelPass = 0;
+  function scheduleTableLabels() {
+    if (queuedLabelPass) return;
+    queuedLabelPass = requestAnimationFrame(() => {
+      queuedLabelPass = 0;
+      labelTableCells();
+    });
+  }
+
   function enhanceControls(root = document) {
     initializePopovers(root);
     initializeSelects(root);
     initializeSliders(root);
+    labelTableCells(root);
   }
 
   function setControlValue(control, value) {
@@ -552,6 +580,13 @@
   trackStickyOffset();
   initializeSortIndicators();
   enhanceControls();
+
+  // report.js renders and re-renders rows after the shell has run, so relabel
+  // whenever a table's contents change. childList only — writing the attribute
+  // must not retrigger the pass.
+  new MutationObserver((records) => {
+    if (records.some((record) => record.target instanceof Element && record.target.closest("table"))) scheduleTableLabels();
+  }).observe(document.body, { childList: true, subtree: true });
 
   // ---- generic shell controls -----------------------------------------------
   let themeMode = "auto";

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -342,8 +342,6 @@ describe("bundled artifact starter contract", () => {
 		expect(css).toContain("top: var(--dev3-table-head-top, 0px)");
 		// hidden would turn the card into a scrollport and unpin the header.
 		expect(css).toContain(".table-card { padding: 0; overflow: clip; }");
-		// The evidence scroller is its own scrollport, so the page offset must not apply.
-		expect(css).toContain(".evidence-table thead th { top: 0; }");
 		expect(css).toContain('th[aria-sort="descending"]::after');
 		expect(app).toContain("function trackStickyOffset");
 		expect(app).toContain("--dev3-table-head-top");
@@ -352,15 +350,33 @@ describe("bundled artifact starter contract", () => {
 		expect(guide).toContain("## Tables");
 	});
 
-	it("keeps the pinned evidence label column readable while the numbers scroll", () => {
+	it("stacks a table into labelled lines instead of scrolling it sideways", () => {
 		const css = readFileSync(cssPath, "utf8");
+		const app = readFileSync(appPath, "utf8");
 		const guide = readFileSync(join(sourceDir, "AUTHORING.md"), "utf8");
+		const stackedBlock = css.slice(css.indexOf("@container dev3-table"));
 		const printBlock = css.slice(css.indexOf("@media print"));
 
-		expect(css).toContain("inset-inline-start: 0");
-		expect(css).toContain("background-image: linear-gradient(var(--dev3-row-tint, transparent)");
-		expect(printBlock).toContain(".evidence-table th:first-child, .evidence-table td:first-child { position: static;");
-		expect(guide).toContain("The first column is pinned");
+		// No table may reintroduce a horizontal scroller or an unwrappable cell.
+		// `.section-nav` is the one sanctioned inline scroller and is not a table.
+		const scrollers = css.match(/[^\n]*overflow-x:\s*auto[^\n]*/g) || [];
+		expect(scrollers).toHaveLength(1);
+		expect(css.slice(0, css.indexOf("overflow-x: auto"))).toMatch(/\.section-nav\s*\{[^}]*$/);
+		expect(css).not.toMatch(/width:\s*max-content/);
+		// A cell must be able to wrap, or the table grows past its container.
+		const evidenceCells = css.match(/\.evidence-table th, \.evidence-table td \{([^}]*)\}/)?.[1] || "";
+		expect(evidenceCells).not.toContain("nowrap");
+		expect(css).toContain("overflow-wrap: break-word");
+		// The table measures its own box, so one in a narrow panel stacks too.
+		expect(css).toContain(".table-card, .evidence-table-scroll { container: dev3-table / inline-size; }");
+		expect(stackedBlock).toContain("thead { display: none; }");
+		expect(stackedBlock).toContain("content: attr(data-dev3-label)");
+		// Paper is narrow enough to match the query, so print drops the container.
+		expect(printBlock).toContain(".table-card, .evidence-table-scroll { container: normal; }");
+		// Labels come from the shell, so a plain <table> needs no new markup.
+		expect(app).toContain("function labelTableCells");
+		expect(app).toContain('cell.setAttribute("data-dev3-label", label)');
+		expect(guide).toContain("No table scrolls sideways");
 	});
 
 	it("keeps dense-table significance markers typographic", () => {
@@ -479,10 +495,12 @@ describe("bundled artifact starter contract", () => {
 		// makes artifact HTML unreadable for agents (the reason we load from CDN).
 		expect(statSync(htmlPath).size).toBeLessThan(120_000);
 		expect(statSync(htmlPath).size).toBeLessThan(MAX_SHARED_ARTIFACT_HTML_BYTES);
-		// The shell stylesheet is not part of the authoring surface, so its budget
-		// only has to stay far below an inlined library.
-		expect(statSync(cssPath).size).toBeLessThan(37_000);
-		expect(statSync(appPath).size).toBeLessThan(30_000);
+		// The shell stylesheet and script are not part of the authoring surface, so
+		// their budgets only have to stay far below an inlined library — these are
+		// ~25x under one, and both sat at 98%+ of the previous caps before the
+		// responsive-table work, which left no room for any real change.
+		expect(statSync(cssPath).size).toBeLessThan(40_000);
+		expect(statSync(appPath).size).toBeLessThan(33_000);
 		expect(statSync(reportPath).size).toBeLessThan(15_000);
 	});
 });


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

Tables in dev3 HTML artifacts scrolled sideways on narrow screens, and plain tables were worse than that: `.table-card`'s `overflow: clip` meant columns past the edge were not scrollable but simply gone, while a `max-width: 560px` rule additionally hid the third and fifth columns outright. Measured at 375px on a probe artifact, the 7-column run table clipped to 345px of a needed 512px and the 12-column ledger to 296px of 1094px.

Now no table scrolls sideways at any width. Below **768px of the table's own container** each row becomes a stack of labelled lines. The threshold is matched with a CSS container query rather than a media query because a table can be narrow while the page is wide — verified: in a 398px panel at a 1400px viewport it stacks, which a media query would get wrong. A stacked row is a `repeat(auto-fit, minmax(13rem, 1fr))` grid, so cells pair up while there is room (3 across at 768px) and drop to one per line on a phone.

**Authors write nothing new.** `labelTableCells()` in the shell copies each `thead` heading onto the cells beneath it and re-runs from a `MutationObserver`, since `report.js` renders rows after the shell boots. A plain `<table>` with a real `<thead>` is the whole contract — there is no `data-label` attribute to keep in sync. Removed along the way: the `.evidence-table-scroll` horizontal scroller, the sticky first column it existed to compensate for, and the column-hiding rule that silently deleted data.

A table with very many columns is deliberately not capped or folded behind a "show more" — its cells are the payload, so it just gets long vertically. Print is unaffected: paper is narrow enough to trip the container query, so `@media print` resets both wrappers to `container: normal`, verified against a rendered PDF that keeps real columns and a repeating header.

Verified in headless Chromium at 1440/768/375px in both light and dark themes by counting elements whose `scrollWidth` exceeds their `clientWidth`: two offenders at 768px and two at 375px before, zero at every width after. The in-app viewer was cleared as a suspect — it renders a bare `h-full w-full` iframe with no width constraint of its own.

Two starter budgets in `artifact-template.test.ts` were raised (css 37k→40k, js 30k→33k); both files sat at 98%+ of the previous caps before this work, leaving no room for any real change, and they remain ~25x under an inlined chart library. The suite's two assertions that encoded the old scrolling contract were replaced with ones that guard the new one, and that guard was proven by restoring the scroller and watching it fail.

Reasoning and rejected alternatives: `decisions/2026/08/27/artifact-tables-stack-instead-of-scrolling.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=feae280b-bc88-49b8-b152-c6c032139636) · `dev3://task/feae280b-bc88-49b8-b152-c6c032139636`
