### PR TITLE
Add a setting for dimming inactive tmux panes

### DIFF
--- a/change-logs/2026/08/27/feature-optional-pane-dimming.md
+++ b/change-logs/2026/08/27/feature-optional-pane-dimming.md
@@ -1,0 +1,5 @@
+Short: Turn off inactive pane dimming
+
+Settings → Terminal has a new "Dim inactive panes" toggle. tmux terminals darken every split except the focused one; switching it off gives all panes the same colors, and the change reaches running sessions immediately instead of waiting for a restart.
+
+Suggested by @vit-pavlenko (h0x91b/dev-3.0#1568)

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -2002,6 +2002,25 @@ describe("handlers.saveGlobalSettings", () => {
 
 		expect(pty.applyTmuxTheme).not.toHaveBeenCalled();
 	});
+
+	// Pane dimming lives in the tmux config, so switching it has to reach the live
+	// server the same way a shell change does — otherwise the toggle only takes
+	// effect after an app restart.
+	it.skipIf(process.platform === "win32")("re-sources tmux when pane dimming is switched off", async () => {
+		vi.mocked(loadSettings).mockResolvedValue({ updateChannel: "stable" } as GlobalSettings);
+
+		await handlers.saveGlobalSettings({ updateChannel: "stable", dimInactivePanes: false } as GlobalSettings);
+
+		expect(pty.applyTmuxTheme).toHaveBeenCalled();
+	});
+
+	it.skipIf(process.platform === "win32")("leaves tmux alone when pane dimming stays at its default", async () => {
+		vi.mocked(loadSettings).mockResolvedValue({ updateChannel: "stable" } as GlobalSettings);
+
+		await handlers.saveGlobalSettings({ updateChannel: "stable", dimInactivePanes: true } as GlobalSettings);
+
+		expect(pty.applyTmuxTheme).not.toHaveBeenCalled();
+	});
 });
 
 describe("handlers.setTmuxTheme", () => {

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -185,6 +185,7 @@ describe("saveSettings", () => {
 			updateChannel: "canary",
 			terminalPathOpenMode: "reveal",
 			terminalShell: "sh",
+			dimInactivePanes: false,
 			theme: "light",
 			analyticsDistinctId: "11111111-2222-3333-4444-555555555555",
 			resolvedTheme: "light",

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -16,6 +16,7 @@ import {
 	isUpdateAlreadyReady,
 } from "./updater";
 import { loadSettings, loadSettingsSync } from "./settings";
+import { setTmuxPaneDimming, writeTmuxConfigs } from "./tmux/config";
 import { telemetryBootstrapScript } from "./analytics-identity";
 import { shouldAutoOpenDevTools } from "./devtools-auto-open";
 import { installSignalQuitConfirmation, isQuitConfirmed, markQuitConfirmed, markQuitDialogPending } from "./quit-manager";
@@ -492,6 +493,13 @@ setPushMessage((name, payload) => {
 // Initialize the backend gate before background pollers and CLI requests can
 // raise agent notifications. Queued entries flush when Focus Mode is disabled.
 setFocusMode(loadSettingsSync().focusMode === true);
+
+// The tmux configs were written at import time on the built-in default (dimmed);
+// hand the module the user's own answer and rewrite them before any pane spawns.
+if (loadSettingsSync().dimInactivePanes === false) {
+	setTmuxPaneDimming(false);
+	writeTmuxConfigs();
+}
 
 // `exposedPortsChanged` rides its own hook because port-tunnels lives below
 // rpc-handlers — same broadcast target as above.

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -13,7 +13,7 @@ import * as rosetta from "../rosetta";
 import * as repoConfig from "../repo-config";
 import * as pty from "../pty-server";
 import { tmux } from "../tmux";
-import { writeTmuxConfigs } from "../tmux/config";
+import { setTmuxPaneDimming, writeTmuxConfigs } from "../tmux/config";
 import { loadSettings, saveSettings } from "../settings";
 import { toggleFavorite } from "../../shared/favorites";
 import { DEV3_HOME } from "../paths";
@@ -191,23 +191,29 @@ function getShellAvailability(): ShellAvailability {
 }
 
 /**
- * Push the new shell everywhere a live process still reads the old one.
+ * Rewrite the tmux configs and source them into every live server, so a setting
+ * the config embeds takes effect without restarting the app.
  *
- * `$SHELL` is what the native backend launches (`defaultNativeShellLaunchSpec`)
- * and `default-shell` in the tmux config is what a pane the user splits off
- * inherits. Both are frozen at boot, so without this the picker only takes
- * effect after a restart while Settings already reports the new shell.
+ * `refreshShell` additionally updates `$SHELL`: it is what the native backend
+ * launches (`defaultNativeShellLaunchSpec`) and `default-shell` in the tmux
+ * config is what a pane the user splits off inherits. Both are frozen at boot,
+ * so without this the picker only takes effect after a restart while Settings
+ * already reports the new shell.
  *
  * The theme is re-applied, not chosen: sourcing the config into a live server
  * goes through `applyTmuxTheme`, which also pins the active themed config path.
  */
-async function applyShellChange(theme: "dark" | "light"): Promise<void> {
+async function applyTmuxConfigChange(
+	theme: "dark" | "light",
+	options: { refreshShell: boolean; dimInactivePanes: boolean },
+): Promise<void> {
 	try {
-		process.env.SHELL = getUserShell();
+		if (options.refreshShell) process.env.SHELL = getUserShell();
+		setTmuxPaneDimming(options.dimInactivePanes);
 		writeTmuxConfigs();
 		await pty.applyTmuxTheme(theme);
 	} catch (err) {
-		log.warn("Failed to push the shell change into tmux (non-fatal)", { error: String(err) });
+		log.warn("Failed to push the settings change into tmux (non-fatal)", { error: String(err) });
 	}
 }
 
@@ -232,8 +238,13 @@ async function saveGlobalSettings(params: GlobalSettings): Promise<void> {
 	// `resolvedTheme` may be absent (nothing has called setTmuxTheme yet); the
 	// live in-memory theme is the fallback, never a hardcoded "dark" — that would
 	// flip a light-theme user's terminals on an unrelated shell change.
-	if (process.platform !== "win32" && stored.terminalShell !== next.terminalShell) {
-		await applyShellChange(next.resolvedTheme ?? getCurrentUiTheme());
+	const shellChanged = stored.terminalShell !== next.terminalShell;
+	const dimChanged = (stored.dimInactivePanes !== false) !== (next.dimInactivePanes !== false);
+	if (process.platform !== "win32" && (shellChanged || dimChanged)) {
+		await applyTmuxConfigChange(next.resolvedTheme ?? getCurrentUiTheme(), {
+			refreshShell: shellChanged,
+			dimInactivePanes: next.dimInactivePanes !== false,
+		});
 	}
 	getPushMessage()?.("globalSettingsUpdated", next);
 	log.info("← saveGlobalSettings done");

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -158,6 +158,8 @@ function normalizeSettings(data: Record<string, unknown>): GlobalSettings {
 			d.terminalShell === "zsh" || d.terminalShell === "bash" || d.terminalShell === "sh"
 				? d.terminalShell
 				: undefined,
+		// Default-on toggle — only an explicit false is a stored opt-out.
+		dimInactivePanes: d.dimInactivePanes === false ? false : undefined,
 		focusMode: d.focusMode === true ? true : undefined,
 		// Default-on toggle — only an explicit false is a stored opt-out.
 		agentRateLimitTracking: d.agentRateLimitTracking === false ? false : undefined,

--- a/src/bun/tmux/__tests__/config.test.ts
+++ b/src/bun/tmux/__tests__/config.test.ts
@@ -7,6 +7,8 @@ vi.mock("../../logger", () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
+import { readFileSync } from "node:fs";
+
 import {
 	TMUX_CONF_DARK_PATH,
 	TMUX_CONF_LIGHT_PATH,
@@ -14,7 +16,9 @@ import {
 	setActiveTmuxTheme,
 	buildThemeConfig,
 	PANE_CWD_FORMAT,
+	setTmuxPaneDimming,
 	tmuxClientCwd,
+	writeTmuxConfigs,
 } from "../config";
 import { DEV3_HOME } from "../../paths";
 
@@ -96,6 +100,50 @@ describe("buildThemeConfig", () => {
 			expect(config).not.toContain("/etc/tmux.conf");
 			expect(config).not.toContain("~/.tmux.conf");
 			expect(config).not.toContain("~/.config/tmux/tmux.conf");
+		}
+	});
+
+	// The Catppuccin plugin dims inactive panes itself, so the override has to be
+	// sourced AFTER it — and both states must emit the lines, because these configs
+	// are re-sourced into a live server where an omitted line keeps its old value.
+	it("dims inactive panes by default", () => {
+		const config = buildThemeConfig("mocha");
+		expect(config).toContain('set -gF window-style "bg=#{@thm_mantle},fg=#{@thm_overlay_1}"');
+		expect(config).toContain('set -gF pane-border-style "fg=#{@thm_surface_1},bg=#{@thm_mantle}"');
+	});
+
+	it("gives every pane the active colors when dimming is off", () => {
+		const config = buildThemeConfig("mocha", false);
+		expect(config).toContain('set -gF window-style "bg=#{@thm_bg},fg=#{@thm_fg}"');
+		expect(config).toContain('set -gF pane-border-style "fg=#{@thm_surface_1},bg=#{@thm_bg}"');
+		expect(config).not.toContain("@thm_overlay_1");
+	});
+
+	it("overrides the plugin's own pane styling rather than being overridden by it", () => {
+		const config = buildThemeConfig("latte", false);
+		expect(config.indexOf('set -gF window-style "bg=#{@thm_bg}')).toBeGreaterThan(
+			config.indexOf("catppuccin_tmux.conf"),
+		);
+	});
+
+	// The preference is pushed in rather than read from settings.ts: this module
+	// writes its configs at import time, and importing the settings loader made
+	// every suite that mocks `../settings` fail to collect.
+	it("writes the pushed-in dimming preference to both themed configs", () => {
+		try {
+			setTmuxPaneDimming(false);
+			writeTmuxConfigs();
+			for (const path of [TMUX_CONF_DARK_PATH, TMUX_CONF_LIGHT_PATH]) {
+				expect(readFileSync(path, "utf-8")).toContain('set -gF window-style "bg=#{@thm_bg},fg=#{@thm_fg}"');
+			}
+			setTmuxPaneDimming(true);
+			writeTmuxConfigs();
+			for (const path of [TMUX_CONF_DARK_PATH, TMUX_CONF_LIGHT_PATH]) {
+				expect(readFileSync(path, "utf-8")).toContain('set -gF window-style "bg=#{@thm_mantle},fg=#{@thm_overlay_1}"');
+			}
+		} finally {
+			setTmuxPaneDimming(true);
+			writeTmuxConfigs();
 		}
 	});
 

--- a/src/bun/tmux/config.ts
+++ b/src/bun/tmux/config.ts
@@ -237,7 +237,28 @@ set -g status-right "#{E:@catppuccin_status_application}#{E:@catppuccin_status_s
 set -g status-left ""
 `;
 
-export function buildThemeConfig(flavor: "mocha" | "latte"): string {
+/**
+ * How much an unfocused pane differs from the focused one.
+ *
+ * Catppuccin's own config darkens every inactive pane so the focused split is
+ * obvious; the user can switch that off (`dimInactivePanes`), and then every
+ * pane keeps the theme's normal background and foreground. Both states emit the
+ * lines: these configs are re-sourced into a LIVE tmux server, where a merely
+ * omitted line leaves the previous value in effect.
+ */
+function paneDimConfig(dimInactivePanes: boolean): string {
+	const bg = dimInactivePanes ? "#{@thm_mantle}" : "#{@thm_bg}";
+	const fg = dimInactivePanes ? "#{@thm_overlay_1}" : "#{@thm_fg}";
+	return [
+		"",
+		"# Inactive pane contrast (Settings → Terminal → Dim inactive panes)",
+		`set -gF window-style "bg=${bg},fg=${fg}"`,
+		`set -gF pane-border-style "fg=#{@thm_surface_1},bg=${bg}"`,
+		"",
+	].join("\n");
+}
+
+export function buildThemeConfig(flavor: "mocha" | "latte", dimInactivePanes = true): string {
 	const pluginDir = CATPPUCCIN_PLUGIN_DIR;
 	return [
 		`# dev3 tmux config — Catppuccin ${flavor}`,
@@ -246,6 +267,7 @@ export function buildThemeConfig(flavor: "mocha" | "latte"): string {
 		`source "${pluginDir}/themes/catppuccin_${flavor}_tmux.conf"`,
 		`source "${pluginDir}/catppuccin_options_tmux.conf"`,
 		`source "${pluginDir}/catppuccin_tmux.conf"`,
+		paneDimConfig(dimInactivePanes),
 		TMUX_CONFIG_FUNCTIONAL,
 		shellEnvConfig(),
 		TMUX_STATUS_BAR,
@@ -253,14 +275,27 @@ export function buildThemeConfig(flavor: "mocha" | "latte"): string {
 }
 
 /**
+ * The `dimInactivePanes` preference, pushed in by the host at startup and on
+ * every settings save. Held here rather than read from `settings.ts`: this
+ * module writes its configs at import time, and importing the settings loader
+ * for that would drag the whole settings graph into every module that touches
+ * tmux.
+ */
+let dimInactivePanes = true;
+
+export function setTmuxPaneDimming(enabled: boolean): void {
+	dimInactivePanes = enabled;
+}
+
+/**
  * Rewrite both themed configs. Called at startup, and again when a setting the
- * config embeds changes — today that is the shell, whose path is baked into
- * `default-shell`.
+ * config embeds changes: the shell (baked into `default-shell`) and whether
+ * inactive panes are dimmed.
  */
 export function writeTmuxConfigs(): void {
 	writeShellInit();
-	writeFileSync(TMUX_CONF_DARK_PATH, buildThemeConfig("mocha"));
-	writeFileSync(TMUX_CONF_LIGHT_PATH, buildThemeConfig("latte"));
+	writeFileSync(TMUX_CONF_DARK_PATH, buildThemeConfig("mocha", dimInactivePanes));
+	writeFileSync(TMUX_CONF_LIGHT_PATH, buildThemeConfig("latte", dimInactivePanes));
 }
 
 // Write Catppuccin plugin files + both themed configs + shell init at startup

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -487,6 +487,21 @@ function GlobalSettings({
 		[persistSettingChange],
 	);
 
+	const handleDimInactivePanesToggle = useCallback(
+		(enabled: boolean) => {
+			persistSettingChange(
+				{ dimInactivePanes: enabled },
+				{
+					tracking: {
+						setting: "dim_inactive_panes",
+						value: enabled ? "on" : "off",
+					},
+				},
+			);
+		},
+		[persistSettingChange],
+	);
+
 	const handleTerminalShellChange = useCallback(
 		(shell: ShellFlavor | undefined) => {
 			persistSettingChange(
@@ -833,9 +848,11 @@ function GlobalSettings({
 						terminalPathOpenMode={globalSettings.terminalPathOpenMode}
 						terminalShell={globalSettings.terminalShell}
 						shellAvailability={shellAvailability}
+						dimInactivePanes={globalSettings.dimInactivePanes}
 						onNewTaskTerminalBackendChange={handleNewTaskTerminalBackendChange}
 						onTerminalPathOpenModeChange={handleTerminalPathOpenModeChange}
 						onTerminalShellChange={handleTerminalShellChange}
+						onDimInactivePanesToggle={handleDimInactivePanesToggle}
 					/>
 				);
 			case "agents":

--- a/src/mainview/components/global-settings/TerminalSettingsSection.tsx
+++ b/src/mainview/components/global-settings/TerminalSettingsSection.tsx
@@ -24,6 +24,7 @@ import {
 	terminalFontStack,
 } from "../../terminal-font";
 import SettingsEntry from "./SettingsEntry";
+import SettingsToggle from "./SettingsToggle";
 import TerminalBackendSetting from "./TerminalBackendSetting";
 import TerminalFontGallery from "./TerminalFontGallery";
 import SettingsSection from "./SettingsSection";
@@ -44,9 +45,11 @@ export default function TerminalSettingsSection({
 	terminalPathOpenMode,
 	terminalShell,
 	shellAvailability,
+	dimInactivePanes,
 	onNewTaskTerminalBackendChange,
 	onTerminalPathOpenModeChange,
 	onTerminalShellChange,
+	onDimInactivePanesToggle,
 }: {
 	t: TFunction;
 	scrollSpeed: number;
@@ -57,9 +60,11 @@ export default function TerminalSettingsSection({
 	terminalPathOpenMode: TerminalPathOpenMode | undefined;
 	terminalShell: ShellFlavor | undefined;
 	shellAvailability: ShellAvailability | null;
+	dimInactivePanes: boolean | undefined;
 	onNewTaskTerminalBackendChange: (backend: TerminalBackendIdentity) => void;
 	onTerminalPathOpenModeChange: (mode: TerminalPathOpenMode) => void;
 	onTerminalShellChange: (shell: ShellFlavor | undefined) => void;
+	onDimInactivePanesToggle: (enabled: boolean) => void;
 }) {
 	const resolved = shellAvailability?.resolved ?? null;
 	// Windows answers with no POSIX resolution at all — the whole choice is moot
@@ -89,6 +94,22 @@ export default function TerminalSettingsSection({
 					availability={nativeTerminalAvailability}
 					onChange={onNewTaskTerminalBackendChange}
 				/>
+			</SettingsEntry>
+
+			<SettingsEntry anchor="terminal-dim-inactive-panes">
+				<div>
+					<p className="block text-fg text-sm font-semibold mb-2">
+						{t("settings.dimInactivePanes")}
+					</p>
+					<p className="text-fg-3 text-sm mb-3">{t("settings.dimInactivePanesDesc")}</p>
+					<SettingsToggle
+						checked={dimInactivePanes !== false}
+						ariaLabel={t("settings.dimInactivePanes")}
+						onLabel={t("settings.on")}
+						offLabel={t("settings.off")}
+						onToggle={() => onDimInactivePanesToggle(dimInactivePanes === false)}
+					/>
+				</div>
 			</SettingsEntry>
 
 			{showShellPicker && (

--- a/src/mainview/components/global-settings/__tests__/TerminalSettingsSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/TerminalSettingsSection.test.tsx
@@ -41,9 +41,11 @@ function Harness(props: {
 			terminalPathOpenMode={undefined}
 			terminalShell={props.terminalShell}
 			shellAvailability={props.availability}
+			dimInactivePanes={undefined}
 			onNewTaskTerminalBackendChange={vi.fn()}
 			onTerminalPathOpenModeChange={vi.fn()}
 			onTerminalShellChange={props.onTerminalShellChange}
+			onDimInactivePanesToggle={vi.fn()}
 		/>
 	);
 }
@@ -100,6 +102,59 @@ describe("TerminalSettingsSection — shell picker", () => {
 	});
 });
 
+describe("TerminalSettingsSection — pane dimming", () => {
+	function renderDimming(dimInactivePanes: boolean | undefined) {
+		const onDimInactivePanesToggle = vi.fn();
+		render(
+			<I18nProvider>
+				<DimHarness value={dimInactivePanes} onToggle={onDimInactivePanesToggle} />
+			</I18nProvider>,
+		);
+		return { onDimInactivePanesToggle };
+	}
+
+	it("reads as on for an install that never touched the setting", () => {
+		renderDimming(undefined);
+		expect(screen.getByRole("switch", { name: "Dim inactive panes" })).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("switches dimming off", async () => {
+		const { onDimInactivePanesToggle } = renderDimming(undefined);
+		await userEvent.click(screen.getByRole("switch", { name: "Dim inactive panes" }));
+		expect(onDimInactivePanesToggle).toHaveBeenCalledWith(false);
+	});
+
+	it("switches dimming back on", async () => {
+		const { onDimInactivePanesToggle } = renderDimming(false);
+		const toggle = screen.getByRole("switch", { name: "Dim inactive panes" });
+		expect(toggle).toHaveAttribute("aria-checked", "false");
+		await userEvent.click(toggle);
+		expect(onDimInactivePanesToggle).toHaveBeenCalledWith(true);
+	});
+});
+
+function DimHarness({ value, onToggle }: { value: boolean | undefined; onToggle: (enabled: boolean) => void }) {
+	const t = useT();
+	return (
+		<TerminalSettingsSection
+			t={t}
+			scrollSpeed={1}
+			terminalFontFamily=""
+			terminalFontSize={DEFAULT_TERMINAL_FONT_SIZE}
+			newTaskTerminalBackend={undefined}
+			nativeTerminalAvailability={null}
+			terminalPathOpenMode={undefined}
+			terminalShell={undefined}
+			shellAvailability={MAC}
+			dimInactivePanes={value}
+			onNewTaskTerminalBackendChange={vi.fn()}
+			onTerminalPathOpenModeChange={vi.fn()}
+			onTerminalShellChange={vi.fn()}
+			onDimInactivePanesToggle={onToggle}
+		/>
+	);
+}
+
 // The font tests read raw keys instead of English, so a copy change cannot turn a
 // passing assertion red — they are about the control's behaviour, not its wording.
 /** The gallery has its own radiogroup; the backend picker on the same page has another. */
@@ -124,9 +179,11 @@ function renderFontSection(family = "", size = DEFAULT_TERMINAL_FONT_SIZE) {
 				terminalPathOpenMode="preview"
 				terminalShell={undefined}
 				shellAvailability={MAC}
+				dimInactivePanes={undefined}
 				onNewTaskTerminalBackendChange={vi.fn()}
 				onTerminalPathOpenModeChange={vi.fn()}
 				onTerminalShellChange={vi.fn()}
+				onDimInactivePanesToggle={vi.fn()}
 			/>
 		</I18nProvider>,
 	);

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -195,6 +195,8 @@ const settings = {
 	"settings.terminalShellResolved": "Running {path}",
 	"settings.terminalShellMissing": "{shell} is not installed on this machine — using {path} instead.",
 	"settings.terminalShellNotInstalled": "not installed",
+	"settings.dimInactivePanes": "Dim inactive panes",
+	"settings.dimInactivePanesDesc": "Darken every split except the one you are typing in, so the focused pane stands out. tmux terminals only.",
 	"settings.terminalPathOpenMode": "File path click action",
 	"settings.terminalPathOpenModeDesc": "What ⌘-clicking (Ctrl on Linux) a file path in terminal output does. Remote browser sessions always preview in dev3.",
 	"settings.terminalPathOpenModePreview": "Preview in dev3",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -195,6 +195,8 @@ const settings = {
 	"settings.terminalShellResolved": "Ejecutando {path}",
 	"settings.terminalShellMissing": "{shell} no está instalado en esta máquina; se usa {path} en su lugar.",
 	"settings.terminalShellNotInstalled": "no instalado",
+	"settings.dimInactivePanes": "Atenuar paneles inactivos",
+	"settings.dimInactivePanesDesc": "Oscurece todos los paneles salvo aquel en el que estás escribiendo, para que el panel activo destaque. Solo en terminales tmux.",
 	"settings.terminalPathOpenMode": "Acción al hacer clic en una ruta",
 	"settings.terminalPathOpenModeDesc": "Qué hace ⌘-clic (Ctrl en Linux) sobre una ruta de archivo en la salida del terminal. Las sesiones remotas en el navegador siempre muestran la vista previa en dev3.",
 	"settings.terminalPathOpenModePreview": "Vista previa en dev3",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -201,6 +201,8 @@ const settings = {
 	"settings.terminalShellResolved": "Запускается {path}",
 	"settings.terminalShellMissing": "{shell} не установлен на этой машине — используется {path}.",
 	"settings.terminalShellNotInstalled": "не установлен",
+	"settings.dimInactivePanes": "Затемнять неактивные панели",
+	"settings.dimInactivePanesDesc": "Приглушать все панели, кроме той, в которой вы печатаете, чтобы активная была заметна. Только для терминалов tmux.",
 	"settings.terminalPathOpenMode": "Действие по клику на путь к файлу",
 	"settings.terminalPathOpenModeDesc": "Что делает ⌘-клик (Ctrl в Linux) по пути к файлу в выводе терминала. Удалённые сессии в браузере всегда показывают предпросмотр в dev3.",
 	"settings.terminalPathOpenModePreview": "Предпросмотр в dev3",

--- a/src/mainview/settings-registry.ts
+++ b/src/mainview/settings-registry.ts
@@ -272,6 +272,15 @@ export const SETTINGS_ENTRIES = [
 		storage: "sidecar",
 	},
 	{
+		id: "terminal-dim-inactive-panes",
+		category: "terminal",
+		titleKey: "settings.dimInactivePanes",
+		descriptionKey: "settings.dimInactivePanesDesc",
+		anchor: "terminal-dim-inactive-panes",
+		globalField: "dimInactivePanes",
+		storage: "global",
+	},
+	{
 		id: "terminal-shell",
 		category: "terminal",
 		titleKey: "settings.terminalShell",
@@ -551,6 +560,7 @@ export const GLOBAL_SETTINGS_FIELDS = [
 	"skipQuitDialog",
 	"importShellEnv",
 	"terminalShell",
+	"dimInactivePanes",
 	"focusMode",
 	"agentRateLimitTracking",
 	"watchByDefault",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1206,6 +1206,13 @@ export interface GlobalSettings {
 	 * Ignored on Windows, which runs PowerShell.
 	 */
 	terminalShell?: ShellFlavor;
+	/**
+	 * Darken every pane except the focused one in a tmux terminal, so the split
+	 * that takes the keyboard is obvious. Default on; set to `false` to give all
+	 * panes the same background and foreground. tmux backend only — the native
+	 * backend never dimmed anything.
+	 */
+	dimInactivePanes?: boolean;
 	focusMode?: boolean; // when true, queue agent-initiated attention UI and viewer events until Focus Mode ends
 	/**
 	 * Track agent rate-limit windows (Claude via an injected statusLine wrapper,


### PR DESCRIPTION
Closes #1568.

tmux terminals darken every pane except the focused one (`window-style` from the bundled Catppuccin config). That is now a preference instead of a fixed behaviour: **Settings → Terminal → Dim inactive panes**, default on.

- `buildThemeConfig()` emits the pane styling itself, after the Catppuccin plugin is sourced, and emits it in **both** states — these configs are re-sourced into a live tmux server, where an omitted line keeps its old value.
- Switching the toggle rewrites the configs and sources them into every live server, so running sessions change immediately (same path a shell change already used, generalized to `applyTmuxConfigChange`).
- Native-backend sessions never dimmed anything, so the copy says tmux terminals only.

Verified in a browser against a scoped QA board: the toggle flips the generated `dev3-tmux-dark.conf` and the live `tmux -L dev3 show -g window-style` between `bg=#181825,fg=#7f849c` (dimmed) and the active colors, with no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=9e770b18-0325-4a4e-8399-d336b172f991) · `dev3://task/9e770b18-0325-4a4e-8399-d336b172f991`