### PR TITLE
Declare IS_SANDBOX=1 for Claude launches when running as root

### DIFF
--- a/change-logs/2026/08/27/fix-claude-bypass-mode-under-root.md
+++ b/change-logs/2026/08/27/fix-claude-bypass-mode-under-root.md
@@ -1,0 +1,3 @@
+Short: Claude sessions start when dev3 runs as root
+
+Claude Code refuses to start under root whenever bypass mode is reachable, which killed every session on a box running dev3 as root (a container or Kubernetes pod). dev3 now declares `IS_SANDBOX=1` for Claude launches when it is running as root, so bypass and Accept Edits presets work there instead of exiting immediately.

--- a/decisions/2026/08/27/claude-bypass-mode-under-root.md
+++ b/decisions/2026/08/27/claude-bypass-mode-under-root.md
@@ -1,0 +1,53 @@
+# Declare IS_SANDBOX=1 for Claude launches when dev3 runs as root
+
+## Context
+
+On a Linux box where dev3 runs as root — a Kubernetes pod, a container image with
+no unprivileged user — every Claude session died instantly. dev3 passes
+`--allow-dangerously-skip-permissions` on *every* Claude launch (so the user can
+toggle bypass with Shift+Tab), and that alone is enough to trip Claude Code's
+root guard.
+
+## Investigation
+
+Read the installed `@anthropic-ai/claude-code/cli.js`. The guard is a single site
+in `setup()`, and it fires on the *reachability* of bypass mode, not on its use:
+
+```js
+if (permissionMode === "bypassPermissions" || allowDangerouslySkipPermissions) {
+  if (process.platform !== "win32" && process.getuid?.() === 0 &&
+      process.env.IS_SANDBOX !== "1" && !CLAUDE_CODE_BUBBLEWRAP)
+    console.error("--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons"),
+    process.exit(1)
+}
+```
+
+Three consequences: `--allow-dangerously-skip-permissions` is guarded exactly
+like the hard `--dangerously-skip-permissions`; `--permission-mode
+bypassPermissions` trips it with no flag at all; and the only two escapes are
+`IS_SANDBOX=1` and `CLAUDE_CODE_BUBBLEWRAP`. Root itself is fine — only bypass
+mode is refused.
+
+## Decision
+
+`claudeDefaultEnv(uid, platform)` in `src/bun/agents.ts` adds `IS_SANDBOX: "1"`
+to the Claude defaults when `process.getuid() === 0` on a non-Windows platform,
+and `getDefaultEnvForAgent` returns it for every Claude-family launch. Both seams
+(`resolveCommandForAgent`, `resolveCommandForProject`) go through that function,
+and a preset's own `envVars` are merged after the defaults, so an explicit
+`IS_SANDBOX` still wins. No flag is stripped and no permission mode is rewritten.
+
+## Risks
+
+`IS_SANDBOX=1` is a claim about the environment, and dev3 makes it from one fact:
+the process is root. A root user on a normal desktop Linux install would get the
+same claim — but that user asked for a bypass preset, and the alternative is a
+session that will not start.
+
+## Alternatives considered
+
+Strip the flags under uid 0. Rejected: to actually get Claude to boot it would
+also have to rewrite `permissionMode` away from `bypassPermissions`, so a bypass
+preset would silently mean something else, and an unattended agent would then sit
+on permission prompts nobody is there to answer — which is worse than not
+starting.

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyBinaryPathOverride, applyLayoutResync, migrateOldFormat, applyModelOverride, applyProviderModel, resolveLaunchConfig, claudeModelFamily, __setCodexProfileV2Override, type TemplateContext } from "../agents";
+import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyBinaryPathOverride, applyLayoutResync, migrateOldFormat, applyModelOverride, applyProviderModel, resolveLaunchConfig, claudeModelFamily, claudeDefaultEnv, getDefaultEnvForAgent, __setCodexProfileV2Override, type TemplateContext } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 import { ENV_UNSET } from "../../shared/agent-accounts";
@@ -1400,5 +1400,29 @@ describe("claudeModelFamily", () => {
 		expect(claudeModelFamily("claude-haiku-4-5")).toBe("haiku");
 		expect(claudeModelFamily("claude-fable-5")).toBe("fable");
 		expect(claudeModelFamily("openrouter/deepseek-v4")).toBeNull();
+	});
+});
+
+describe("claudeDefaultEnv — Claude's bypass guard under uid 0", () => {
+	it("declares the sandbox when running as root on a non-Windows box", () => {
+		expect(claudeDefaultEnv(0, "linux").IS_SANDBOX).toBe("1");
+	});
+
+	it("stays out of the way for an ordinary user", () => {
+		expect(claudeDefaultEnv(501, "linux").IS_SANDBOX).toBeUndefined();
+		expect(claudeDefaultEnv(0, "win32").IS_SANDBOX).toBeUndefined();
+		expect(claudeDefaultEnv(undefined, "linux").IS_SANDBOX).toBeUndefined();
+	});
+
+	it("keeps the other Claude defaults in every case", () => {
+		for (const env of [claudeDefaultEnv(0, "linux"), claudeDefaultEnv(501, "darwin")]) {
+			expect(env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe("1");
+			expect(env.CLAUDE_CODE_NO_FLICKER).toBe("1");
+		}
+	});
+
+	it("reaches a Claude launch's env, and only a Claude one", () => {
+		expect(getDefaultEnvForAgent(makeAgent())).toEqual(claudeDefaultEnv());
+		expect(getDefaultEnvForAgent(makeAgent({ baseCommand: "codex" }))).toEqual({});
 	});
 });

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -605,11 +605,25 @@ export const CLAUDE_DEFAULT_ENV: Record<string, string> = {
 	CLAUDE_CODE_NO_FLICKER: "1",
 };
 
+/**
+ * Claude's defaults, plus the sandbox declaration a root box needs: Claude Code
+ * exits(1) under uid 0 the moment bypass mode is merely reachable, and dev3
+ * passes --allow-dangerously-skip-permissions on every launch.
+ * See decisions/2026/08/27/claude-bypass-mode-under-root.md.
+ */
+export function claudeDefaultEnv(
+	uid = process.getuid?.(),
+	platform: string = process.platform,
+): Record<string, string> {
+	const sandbox: Record<string, string> = platform !== "win32" && uid === 0 ? { IS_SANDBOX: "1" } : {};
+	return { ...CLAUDE_DEFAULT_ENV, ...sandbox };
+}
+
 /** Build default env vars for an agent based on which CLI it is. */
 export function getDefaultEnvForAgent(agent: CodingAgent, config?: AgentConfiguration): Record<string, string> {
 	const baseCmd = config?.baseCommandOverride || agent.baseCommand;
 	if (isClaudeCommand(baseCmd, agent.agentFamily)) {
-		return { ...CLAUDE_DEFAULT_ENV };
+		return claudeDefaultEnv();
 	}
 	return {};
 }


### PR DESCRIPTION
On a Linux box where dev3 runs as root — a Kubernetes pod, a container image with no unprivileged user — every Claude session died on startup.

Claude Code's root guard fires on the *reachability* of bypass mode, not its use. In the installed `cli.js`:

```js
if (permissionMode === "bypassPermissions" || allowDangerouslySkipPermissions) {
  if (process.platform !== "win32" && process.getuid?.() === 0 &&
      process.env.IS_SANDBOX !== "1" && !CLAUDE_CODE_BUBBLEWRAP)
    console.error("--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons"),
    process.exit(1)
}
```

dev3 passes `--allow-dangerously-skip-permissions` on **every** Claude launch (so Shift+Tab can toggle bypass), so uid 0 meant an instant `exit(1)` regardless of preset. `--permission-mode bypassPermissions` trips the same guard with no flag at all, which is why merely omitting the flag would not have been enough.

`claudeDefaultEnv()` in `src/bun/agents.ts` now adds `IS_SANDBOX: "1"` when `process.getuid() === 0` on a non-Windows platform — one of the guard's own two documented escapes, and a root container is exactly the sandbox it exempts. Both launch seams read it through `getDefaultEnvForAgent`, and a preset's `envVars` are merged after the defaults, so an explicit `IS_SANDBOX` still wins. No flag is stripped and no permission mode is rewritten.

Rationale and the rejected alternative: `decisions/2026/08/27/claude-bypass-mode-under-root.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b3b48d37-4562-4b6a-940f-ba24d6511b93) · `dev3://task/b3b48d37-4562-4b6a-940f-ba24d6511b93`