### PR TITLE
Stop renderer tests from calling Google Analytics, and cut their 12k-line output to 589

### DIFF
--- a/change-logs/2026/08/27/fix-quiet-renderer-test-output.md
+++ b/change-logs/2026/08/27/fix-quiet-renderer-test-output.md
@@ -1,0 +1,3 @@
+Short: Renderer tests stop spamming 12k log lines
+
+The renderer test run printed 12 192 lines of output and now prints 589. Along the way it turned up real defects rather than just noise: the suite was firing Google Analytics hits and an ipify lookup from every dev machine and CI runner, three test files were missing `getSpaces` from their RPC mock, and `TaskCard`, `SpaceGroupedProjects` and the agent-traffic ledger were rendering lists with missing or colliding React keys. Terminal and RPC setup traces moved to an opt-in debug channel (`localStorage["dev3-debug"] = "terminal,rpc"`), React's repeated act(...) boilerplate is now one tallied line per file, and the FolderPickerModal test that failed on ubuntu CI was fixed at its real cause.

--- a/decisions/2026/08/27/folder-picker-test-waited-on-the-wrong-element.md
+++ b/decisions/2026/08/27/folder-picker-test-waited-on-the-wrong-element.md
@@ -1,0 +1,72 @@
+# The FolderPicker CI flake waited on an element that is always there
+
+## Context
+
+`components/__tests__/FolderPickerModal.test.tsx > FolderPickerHost confined to a project
+root > refuses a typed path that escapes the root and says so` failed on ubuntu CI
+(shard 5/5) while the file on its own was green 21/21 on macOS. Reported as a flake, with a
+hypothesis that `user.type` is slow and `findByText`'s 1000 ms default runs out.
+
+## Investigation
+
+The hypothesis was wrong, and the failure dump already contained the disproof: the
+breadcrumb strip showed a crumb `etc` whose title was **`/Users/test/repo/etc`**. The app
+had not been asked for `/etc` at all — it had been asked for a path *inside* the confine
+root, which is legal, so the refusal correctly never rendered.
+
+The sequence, confirmed by gating the first `listDirectory` call and printing the input's
+value at each step:
+
+| Step | `Folder path` value |
+|---|---|
+| after `findByTestId("folder-picker-backdrop")` | `""` |
+| after `user.clear(input)` | `""` |
+| after the initial listing lands | `"/Users/test/repo"` |
+| after `user.type(input, "/etc{Enter}")` | `"/Users/test/repo/etc"` |
+
+The backdrop is in the DOM from the **first** render, while the path input stays empty
+until the initial listing resolves. So `user.clear` ran against an empty input and did
+nothing, the confine root then arrived and filled it, and `/etc` was appended.
+
+Deterministic mutant: make **only the first** `listDirectory` call `await setTimeout(D)`.
+
+| `D` | Unfixed test |
+|---|---|
+| 1, 2, 3, 4, 5, 6, 8, 10, 12 ms | fails every run |
+| 16 ms and up | passes |
+
+Past ~16 ms the listing lands *after* the Enter, so the refusal renders and `findByText`
+resolves before the late listing clobbers it. That narrow window is why the file alone is
+green, why a shard is needed to see it, and why an earlier attempt with a fixed 40 ms and
+300 ms delay "proved" the test was fine.
+
+## Decision
+
+`components/__tests__/FolderPickerModal.test.tsx` waits for the state it actually depends
+on before touching the input:
+
+```ts
+await waitFor(() =>
+    expect(screen.getByLabelText("Folder path")).toHaveValue("/Users/test/repo"),
+);
+```
+
+Not a timeout bump — no timeout was involved. With the fix, `D` = 1, 4, 8 and 12 ms all
+pass; shard 5/5 ran green 3/3 (`vitest list --shard=5/5` confirms the file is in that
+shard).
+
+## Risks
+
+- Only this one case is fixed. Any other test that touches the picker's path input right
+  after the backdrop has the same latent trap; today no other one does.
+
+## Alternatives considered
+
+- **Raise `findByText`'s timeout.** Would not help: the refusal is never rendered at all
+  because the app was handed a legal path.
+- **Wait on `folder-picker-sidebar` or a tree row instead.** Works by accident for some
+  cases; the input's value is the state the test actually depends on, so that is what it
+  waits on.
+- **Make `navigateTo` ignore a late initial listing.** A product change to fix a test that
+  synchronises on the wrong thing, and the late-listing overwrite is correct behaviour for
+  a real user who has not typed anything.

--- a/decisions/2026/08/27/tally-act-warnings-and-block-test-network.md
+++ b/decisions/2026/08/27/tally-act-warnings-and-block-test-network.md
@@ -1,0 +1,88 @@
+# Tally act(...) warnings, gate debug traces, and block the network in renderer tests
+
+## Context
+
+One `bunx vitest run` over `src/mainview` printed **12 192 lines**. Measured composition:
+
+| Source | Blocks | ~Lines |
+|---|---|---|
+| React act(...) boilerplate, 7 lines each | 680 | 4 760 |
+| `[TerminalView]` / `[TaskTerminal]` / `[main]` / `[browser-rpc]` debug logs | ~450 | ~1 400 |
+| `Failed to load spaces: getSpaces is not a function` + stack | 79 | ~950 |
+| Google Analytics CORS refusals | 24 | 48 |
+| `ECONNREFUSED 127.0.0.1:3000` dumps | 15 | 120 |
+
+The backend and CLI suites were already clean (297 and 40 lines), so this is entirely a
+renderer problem. At that volume a genuine warning is unfindable, which is the actual
+cost — not the disk.
+
+## Investigation
+
+Two of the categories were defects wearing log-noise as a disguise.
+
+`analytics.ts` asks `telemetryEnabled()`, and **nothing opts out under vitest**: the
+build-time flag is unset, no host injects `window.__DEV3_TELEMETRY_OPT_OUT__`, and the
+runtime toggle is off. So the suite really did dial Google Analytics and ipify from every
+dev machine and every CI runner. happy-dom's CORS preflight failed, so no payload landed —
+but the request left the box. Separately, importing `rpc.ts` is enough to POST `/rpc`,
+which happy-dom resolves against its own default origin `localhost:3000` where nothing
+listens.
+
+The `getSpaces` gap was three hand-written RPC mocks (`App`, `ProjectSettings`,
+`AddProjectModal`) that had drifted behind `useSpaces`. `TaskCard`,
+`SpaceGroupedProjects` and the agent-traffic ledger were building lists without keys, or
+with keys that collide when two messages share a millisecond.
+
+For the act(...) warnings, fixing them at the source means converting every render helper
+to `await act(async () => …)` and awaiting it at ~250 call sites across ~15 files. That is
+a real improvement and a separate job; it is not log hygiene.
+
+## Decision
+
+Four changes, all in `src/mainview`.
+
+1. **`test-setup.ts` tallies act(...) warnings** instead of letting React reprint the
+   boilerplate: one line per test file naming each component and its count
+   (`act(): updates outside act(...) — GlobalHeader×81, RateLimitIndicator×68`). The
+   signal is kept in full at ~1% of the volume; the stray updates themselves are
+   untouched and still visible per file. `_actOffenderForTests` handles the inlined and
+   `%s` phrasings plus the suspense and post-teardown variants.
+2. **`debug-log.ts` — opt-in renderer debug channels** (`terminal`, `rpc`, `boot`). ON in
+   the app, OFF under vitest, either default overridable with
+   `localStorage["dev3-debug"] = "terminal,rpc"` / `"*"` / `"off"`. The app keeps the
+   traces it was written to have; the suite does not. `dev-server-trace.ts` drops its
+   console mirror under test for the same reason — there is no bridge to lose there.
+3. **`test-setup.ts` rejects every http(s) and origin-relative `fetch`.** No suite under
+   `src/mainview` starts a server (no `Bun.serve`, no `createServer`), so nothing legitimate
+   is lost, and a test that wants a response mocks it. This is the gate that stops the
+   telemetry egress; the fix is deliberately at the transport rather than in
+   `telemetryEnabled()`, because `telemetry-gate.test.ts` exists to assert the gate's
+   default is ON and must keep asserting that.
+4. **Recharts' `width(0) and height(0)` warning is dropped.** happy-dom has no layout
+   engine, so every chart in every test is 0×0 and the warning can never carry information
+   there.
+
+Guarded by `src/mainview/__tests__/test-setup.test.ts` and
+`src/mainview/__tests__/debug-log.test.ts`. Result: **589 lines, 4 818 tests green.**
+
+## Risks
+
+- The act(...) tally makes stray updates cheaper to ignore. Mitigated by keeping the
+  per-file counts in the output rather than swallowing them; the counts are what a future
+  cleanup will work down.
+- Blocking `fetch` wholesale will bite the first test that legitimately wants a local
+  server. It fails loudly with `network blocked in tests`, which names its own cause.
+- The debug channel changes nothing in the app today, but a future reader of
+  `[TerminalView]` logs has to know the override exists. It is documented in
+  `debug-log.ts` and in the changelog entry.
+
+## Alternatives considered
+
+- **Fix all 680 act(...) warnings.** Correct, and ~250 mechanical edits across ~15 test
+  files with real flake risk. Worth doing on its own; not worth bundling into a log cleanup.
+- **Suppress act(...) warnings entirely.** Three lines, and it destroys a signal that
+  predicts flakes in a repo that already has a flake problem.
+- **Opt telemetry out inside `telemetryEnabled()` under vitest.** Cleaner-looking, but it
+  inverts the default that `telemetry-gate.test.ts` is built to guard.
+- **Delete the `[TerminalView]` logs.** They exist because terminal attach failures are
+  painful to debug; taking them away from the app to quiet the tests is the wrong trade.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -4,6 +4,7 @@ import { useT } from "./i18n";
 import { toast } from "./toast";
 import { api, isElectrobun } from "./rpc";
 import { getShiftKeySequence } from "./shift-key-sequences";
+import { debugLog } from "./debug-log";
 import { encodeResizeSequence } from "../shared/resize-protocol";
 import {
 	claimMessage,
@@ -513,7 +514,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			// \x1b)B     = Designate G1 as US-ASCII
 			// \x1b[!p    = DECSTR (Soft Terminal Reset)
 			ws.send("\x0f\x1b(B\x1b)B\x1b[!p");
-			console.log("[TerminalView] Soft reset sent");
+			debugLog("terminal", "[TerminalView] Soft reset sent");
 		}
 
 		function handleHardReset() {
@@ -526,7 +527,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					term.reset();
 					term.renderer?.remeasureFont();
 				} catch { /* disposed */ }
-				console.log("[TerminalView] Hard reset: term.reset() + remeasureFont()");
+				debugLog("terminal", "[TerminalView] Hard reset: term.reset() + remeasureFont()");
 			}
 
 			if (ws?.readyState !== WebSocket.OPEN) return;
@@ -548,7 +549,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 					}, 50);
 				} catch { /* disposed */ }
 			}
-			console.log("[TerminalView] Hard reset sent");
+			debugLog("terminal", "[TerminalView] Hard reset sent");
 		}
 
 		window.addEventListener("rpc:terminalSoftReset", handleSoftReset);
@@ -647,14 +648,14 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			log: logCopyEvent,
 		});
 
-		console.log("[TerminalView] useEffect fired", { ptyUrl, taskId: taskId.slice(0, 8) });
+		debugLog("terminal", "[TerminalView] useEffect fired", { ptyUrl, taskId: taskId.slice(0, 8) });
 
 		// Preload bundled font before creating the terminal.
 		// Canvas rendering doesn't trigger CSS @font-face loading, so the
 		// font must be ready before ghostty-web measures it for cell metrics.
 		const TERMINAL_FONT = terminalFontStack();
 		document.fonts.load(`${effectiveTerminalFontSize()}px ${TERMINAL_FONT}`).then(() => {
-			console.log("[TerminalView] Font preloaded, starting setup");
+			debugLog("terminal", "[TerminalView] Font preloaded, starting setup");
 			if (!disposed) setup();
 		}).catch(() => {
 			console.warn("[TerminalView] Font preload failed, starting setup with fallback");
@@ -670,7 +671,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				return;
 			}
 
-			console.log("[TerminalView] Creating ghostty-web Terminal instance...");
+			debugLog("terminal", "[TerminalView] Creating ghostty-web Terminal instance...");
 			const term = new Terminal({
 				fontSize: scaledTerminalFontSize(),
 				fontFamily: TERMINAL_FONT,
@@ -679,13 +680,13 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				theme: resolvedTheme === "light" ? LIGHT_TERMINAL_THEME : DARK_TERMINAL_THEME,
 			});
 
-			console.log("[TerminalView] Terminal created, loading FitAddon...");
+			debugLog("terminal", "[TerminalView] Terminal created, loading FitAddon...");
 			fitAddon = new FitAddon();
 			fitAddon.proposeDimensions = proposeDimensionsWithoutScrollbarReserve.bind(fitAddon);
 			fitAddonRef.current = fitAddon;
 			term.loadAddon(fitAddon);
 
-			console.log("[TerminalView] Opening terminal in DOM...");
+			debugLog("terminal", "[TerminalView] Opening terminal in DOM...");
 			try {
 				term.open(containerRef.current);
 			} catch (err) {
@@ -697,7 +698,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				});
 				return;
 			}
-			console.log("[TerminalView] Terminal opened in DOM successfully");
+			debugLog("terminal", "[TerminalView] Terminal opened in DOM successfully");
 			termRef.current = term;
 			session.liveTerminals += 1;
 			countedLive = true;
@@ -1144,7 +1145,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 						return;
 					}
 					didInitialFit = true;
-					console.log("[TerminalView] Container has dimensions, fitting terminal", {
+					debugLog("terminal", "[TerminalView] Container has dimensions, fitting terminal", {
 						width: el.clientWidth,
 						height: el.clientHeight,
 					});
@@ -1167,7 +1168,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 								const seq = getShiftKeySequence(event);
 								if (seq) {
 									const hex = Array.from(seq, c => c.charCodeAt(0).toString(16).padStart(2, "0")).join(" ");
-									console.log(`[ShiftKey] intercepted ${event.code} → sending ${seq.length}B: ${hex}`);
+									debugLog("terminal", `[ShiftKey] intercepted ${event.code} → sending ${seq.length}B: ${hex}`);
 									if (wsRef.current?.readyState === WebSocket.OPEN) {
 										wsRef.current.send(seq);
 									}
@@ -1230,7 +1231,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 								blur: () => { try { hiddenTextarea?.blur(); } catch { /* disposed */ } },
 							});
 
-							console.log("[TerminalView] Terminal fitted, connecting PTY...");
+							debugLog("terminal", "[TerminalView] Terminal fitted, connecting PTY...");
 							connectPty(term, fitAddon!);
 						} catch (err) {
 							console.error("[TerminalView] Post-layout setup FAILED:", err);
@@ -1745,7 +1746,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				writeToTerminal("\x1bc", false);
 			}
 			const diagnosticPtyUrl = ptyUrl.replace(/([?&]token=)[^&]+/, "$1***");
-			console.log("[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
+			debugLog("terminal", "[TerminalView] Creating WebSocket connection to", diagnosticPtyUrl);
 			let socket: WebSocket;
 			try {
 				socket = new WebSocket(ptyUrlWithSince(ptyUrl, nativeSeqRef.current));
@@ -1757,15 +1758,15 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			}
 			ws = socket;
 			wsRef.current = ws;
-			console.log("[TerminalView] WebSocket created, readyState:", ws.readyState);
+			debugLog("terminal", "[TerminalView] WebSocket created, readyState:", ws.readyState);
 
 			socket.onopen = () => {
 				if (socket !== ws) return;
-				console.log("[TerminalView] WebSocket OPEN");
+				debugLog("terminal", "[TerminalView] WebSocket OPEN");
 				if (disposed) return;
 				reconnectAttempt = 0;
 				const dims = fit.proposeDimensions();
-				console.log("[TerminalView] Proposed dimensions:", dims);
+				debugLog("terminal", "[TerminalView] Proposed dimensions:", dims);
 				if (dims) {
 					// See buildResizeDance() — row-nudge keeps text wrapping
 					// identical between the two paints. See decision 041.
@@ -1922,7 +1923,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		// setup() is called after font preload above — not here directly
 
 		return () => {
-			console.log("[TerminalView] Cleanup (unmount/re-render)", { taskId: taskId.slice(0, 8) });
+			debugLog("terminal", "[TerminalView] Cleanup (unmount/re-render)", { taskId: taskId.slice(0, 8) });
 			// term.dispose() and fitAddon.dispose() are synchronous, so a slow one blocks
 			// the renderer for its whole duration. A duration logged afterwards can only
 			// describe a cleanup that FINISHED, so a permanent hang would leave no trace
@@ -1935,7 +1936,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			// only evidence a permanent hang can produce. Console AND the durable sink:
 			// the console does not survive a restart, and the sink does not survive a
 			// dead bridge (decision 199).
-			console.debug("[TerminalView] cleanup started", { taskId: taskId.slice(0, 8) });
+			debugLog("terminal", "[TerminalView] cleanup started", { taskId: taskId.slice(0, 8) });
 			// info, not debug: prod/staging/canary run the logger at a minimum of info,
 			// so a debug line never reaches the file and the marker would not be durable.
 			logDiagnostic("terminal-dispose", "info", "cleanup started");
@@ -2009,7 +2010,7 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 				termRef.current = null;
 			}
 			const disposeMs = Math.round(performance.now() - disposeStartedAt);
-			console.debug("[TerminalView] cleanup finished", { taskId: taskId.slice(0, 8), disposeMs });
+			debugLog("terminal", "[TerminalView] cleanup finished", { taskId: taskId.slice(0, 8), disposeMs });
 			logDiagnostic("terminal-dispose", "info", "cleanup finished", { disposeMs });
 			if (disposeMs >= TERMINAL_DISPOSE_BUDGET_MS) {
 				console.warn("[TerminalView] cleanup exceeded its budget", {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../rpc", () => ({
 			getRosettaWarning: vi.fn().mockResolvedValue(null),
 			checkGhAvailable: vi.fn().mockResolvedValue({ available: true, notInstalled: false }),
 			getProjects: vi.fn().mockResolvedValue([]),
+			getSpaces: vi.fn().mockResolvedValue({ version: 1, spaces: [], order: [] }),
 			getLastRoute: vi.fn().mockResolvedValue({ route: null }),
 			saveLastRoute: vi.fn().mockResolvedValue(undefined),
 			quitApp: vi.fn().mockResolvedValue(undefined),

--- a/src/mainview/__tests__/debug-log.test.ts
+++ b/src/mainview/__tests__/debug-log.test.ts
@@ -1,0 +1,42 @@
+import { debugEnabled, debugLog, underTest } from "../debug-log";
+
+// The whole point of the channel is that terminal/rpc setup traces stay in the app and
+// stay out of the test output — 1.4k lines of one renderer run were these.
+describe("renderer debug channels", () => {
+	beforeEach(() => {
+		localStorage.removeItem("dev3-debug");
+	});
+
+	it("knows it is under test", () => {
+		expect(underTest()).toBe(true);
+	});
+
+	it("is silent by default here", () => {
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		debugLog("terminal", "[TerminalView] noise");
+		expect(spy).not.toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	it("opens the channels the override names, and only those", () => {
+		localStorage.setItem("dev3-debug", "terminal, boot");
+		expect(debugEnabled("terminal")).toBe(true);
+		expect(debugEnabled("boot")).toBe(true);
+		expect(debugEnabled("rpc")).toBe(false);
+	});
+
+	it("opens everything on * and closes everything on off", () => {
+		localStorage.setItem("dev3-debug", "*");
+		expect(debugEnabled("rpc")).toBe(true);
+		localStorage.setItem("dev3-debug", "off");
+		expect(debugEnabled("rpc")).toBe(false);
+	});
+
+	it("logs once the channel is open", () => {
+		localStorage.setItem("dev3-debug", "terminal");
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		debugLog("terminal", "[TerminalView] wanted");
+		expect(spy).toHaveBeenCalledWith("[TerminalView] wanted");
+		spy.mockRestore();
+	});
+});

--- a/src/mainview/__tests__/test-setup.test.ts
+++ b/src/mainview/__tests__/test-setup.test.ts
@@ -1,3 +1,5 @@
+import { _actOffenderForTests, _isBlockedTestUrl, _isUnlayoutableChartWarning } from "../test-setup";
+
 // Guards the localStorage substitute installed by test-setup.ts — Node 26's
 // experimental global shadows happy-dom's and is undefined without
 // --localstorage-file, which took the whole mainview suite down (decision 164).
@@ -24,5 +26,64 @@ describe("test environment storage", () => {
 	it("returns null for a missing key", () => {
 		expect(localStorage.getItem("never-written")).toBeNull();
 		expect(localStorage.key(99)).toBeNull();
+	});
+});
+
+// The act(...) tally replaces React's seven-line boilerplate, which one renderer run
+// repeated 680 times. It must recognise every phrasing React uses, or the noise is
+// back; and it must never swallow an unrelated console.error.
+describe("act(...) warning tally", () => {
+	it("names the component from an inlined message", () => {
+		expect(_actOffenderForTests([
+			"An update to GlobalHeader inside a test was not wrapped in act(...).\n",
+		])).toBe("GlobalHeader");
+	});
+
+	it("names the component from React's %s form", () => {
+		expect(_actOffenderForTests([
+			"An update to %s inside a test was not wrapped in act(...).",
+			"RateLimitIndicator",
+		])).toBe("RateLimitIndicator");
+	});
+
+	it("recognises the suspense and post-teardown phrasings", () => {
+		expect(_actOffenderForTests([
+			"A suspended resource finished loading inside a test, but the event was not wrapped in act(...)",
+		])).toBe("<suspended resource>");
+		expect(_actOffenderForTests([
+			"The current testing environment is not configured to support act(...)",
+		])).toBe("<after teardown>");
+	});
+
+	it("lets an unrelated error through", () => {
+		expect(_actOffenderForTests(["Failed to load spaces:", new Error("boom")])).toBeNull();
+		expect(_actOffenderForTests([{ not: "a string" }])).toBeNull();
+	});
+
+	it("blocks every http(s) and origin-relative request", () => {
+		expect(_isBlockedTestUrl("https://www.google-analytics.com/mp/collect?x=1")).toBe(true);
+		expect(_isBlockedTestUrl("https://api.ipify.org")).toBe(true);
+		expect(_isBlockedTestUrl(new URL("http://example.com/x"))).toBe(true);
+		// happy-dom dials its own origin for these, which is why they count too.
+		expect(_isBlockedTestUrl("http://127.0.0.1:3000/rpc")).toBe(true);
+		expect(_isBlockedTestUrl("/rpc")).toBe(true);
+		expect(_isBlockedTestUrl({ url: "/push/key" })).toBe(true);
+		// Not a network request at all — data URLs and blobs stay usable.
+		expect(_isBlockedTestUrl("data:text/plain,hi")).toBe(false);
+		expect(_isBlockedTestUrl("blob:abc")).toBe(false);
+		expect(_isBlockedTestUrl(undefined)).toBe(false);
+	});
+
+	it("actually rejects an off-machine fetch", async () => {
+		await expect(fetch("https://www.google-analytics.com/mp/collect")).rejects.toThrow(
+			/network blocked in tests/,
+		);
+	});
+
+	it("drops only the unlayoutable-chart warning", () => {
+		expect(_isUnlayoutableChartWarning([
+			"The width(0) and height(0) of chart should be greater than 0, please check the style of container",
+		])).toBe(true);
+		expect(_isUnlayoutableChartWarning(["[task-sounds] playback refused"])).toBe(false);
 	});
 });

--- a/src/mainview/components/SpaceGroupedProjects.tsx
+++ b/src/mainview/components/SpaceGroupedProjects.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type DragEvent, type ReactNode } from "react";
+import { Fragment, useEffect, useState, type DragEvent, type ReactNode } from "react";
 import { isSpaceSensitive, type Project, type Space } from "../../shared/types";
 import { HOME_GROUP_ID, type DashboardGroup } from "../utils/spaceGroups";
 import { MASK_CLASS } from "../sensitive-projects";
@@ -222,7 +222,12 @@ function SpaceGroupedProjects({
 								<span className="text-fg-muted text-xs tabular-nums">{group.projects.length}</span>
 							</div>
 							<div className={ROWS_CLASS}>
-								{group.projects.map((project) => renderBottomBlockProject(project, group.projects))}
+								{group.projects.map((project) => (
+									// The caller's node carries no key of its own.
+									<Fragment key={`no-space:${project.id}`}>
+										{renderBottomBlockProject(project, group.projects)}
+									</Fragment>
+								))}
 							</div>
 						</div>
 					);

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, type Dispatch } from "react";
+import { Fragment, useState, useRef, useEffect, useLayoutEffect, type Dispatch } from "react";
 import { toast } from "../toast";
 import { createPortal } from "react-dom";
 import type { CodingAgent, DevServerSummary, PortInfo, Project, ResourceUsage, Task, TaskPRBadgeInfo, TaskStatus } from "../../shared/types";
@@ -580,7 +580,16 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const [configRef, configTruncated] = useIsTruncated<HTMLSpanElement>(configLabel);
 
 	// ---- SIGNALS zone: read-only facts, grouped git / run / time -------------
-	const gitSignals = [prBadge, mergeBadge, reviewBadge, commentBadge].filter(Boolean);
+	// Keyed here rather than on each badge: they are built as standalone nodes above
+	// and only become a list at this point.
+	const gitSignals = ([
+		["pr", prBadge],
+		["merge", mergeBadge],
+		["review", reviewBadge],
+		["comment", commentBadge],
+	] as const)
+		.filter(([, node]) => Boolean(node))
+		.map(([key, node]) => <Fragment key={key}>{node}</Fragment>);
 	const runSignals: React.ReactNode[] = [];
 	if (isActive && ports && ports.length > 0) {
 		runSignals.push(

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type Dispatch, type ReactNode
 import type { Task, Project, TaskSessionState } from "../../shared/types";
 import { getTaskOpenMode, taskClosedHomeRoute, type AppAction, type Route } from "../state";
 import { api } from "../rpc";
+import { debugLog } from "../debug-log";
 import { useT } from "../i18n";
 import { toast } from "../toast";
 import { trackEvent } from "../analytics";
@@ -205,16 +206,16 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		if (isPreparing || isClosed) return;
 		let cancelled = false;
 		(async () => {
-			console.log("[TaskTerminal] Requesting PTY URL for task", taskId.slice(0, 8));
+			debugLog("terminal", "[TaskTerminal] Requesting PTY URL for task", taskId.slice(0, 8));
 			try {
 				const result = await api.request.getPtyUrl({ taskId });
 				if (cancelled) return;
 				if ("recoverable" in result) {
-					console.log("[TaskTerminal] Recoverable session detected", result.sessionState);
+					debugLog("terminal", "[TaskTerminal] Recoverable session detected", result.sessionState);
 					setRecoverable(result.sessionState);
 					setHibernated(result.hibernated === true);
 				} else {
-					console.log("[TaskTerminal] Got PTY URL:", result.url);
+					debugLog("terminal", "[TaskTerminal] Got PTY URL:", result.url);
 					setPtyUrl(result.url);
 				}
 			} catch (err) {

--- a/src/mainview/components/__tests__/AddProjectModal.test.tsx
+++ b/src/mainview/components/__tests__/AddProjectModal.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../../rpc", () => ({
 				}),
 			),
 			saveGlobalSettings: vi.fn(),
+			getSpaces: vi.fn(() => Promise.resolve({ version: 1, spaces: [], order: [] })),
 		},
 	},
 }));

--- a/src/mainview/components/__tests__/FolderPickerModal.test.tsx
+++ b/src/mainview/components/__tests__/FolderPickerModal.test.tsx
@@ -411,6 +411,13 @@ describe("FolderPickerHost confined to a project root", () => {
 		renderHost();
 		openFolderPicker({ confineTo: "/Users/test/repo" });
 		await screen.findByTestId("folder-picker-backdrop");
+		// The backdrop is on screen from the first render, while the path input stays
+		// empty until the initial listing lands. Clearing before that is a no-op, the
+		// root then arrives, and "/etc" gets typed onto the END of it — which IS inside
+		// the root, so no refusal ever appears. That was the ubuntu CI flake.
+		await waitFor(() =>
+			expect(screen.getByLabelText("Folder path")).toHaveValue("/Users/test/repo"),
+		);
 
 		await user.clear(screen.getByLabelText("Folder path"));
 		await user.type(screen.getByLabelText("Folder path"), "/etc{Enter}");

--- a/src/mainview/components/__tests__/ProjectSettings.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSettings.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../rpc", () => ({
 			getProjects: vi.fn().mockResolvedValue([]),
 			getAgents: vi.fn().mockResolvedValue([]),
 			getGlobalSettings: vi.fn().mockResolvedValue({}),
+			getSpaces: vi.fn().mockResolvedValue({ version: 1, spaces: [], order: [] }),
 		},
 	},
 }));

--- a/src/mainview/components/agent-traffic/AgentTrafficLog.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficLog.tsx
@@ -162,7 +162,7 @@ function Ledger({
 	const t = useT();
 	let day: string | null = null;
 	const out: React.ReactNode[] = [];
-	for (const row of rows) {
+	for (const [index, row] of rows.entries()) {
 		const rowDay = localDay(row.at);
 		if (rowDay !== day) {
 			day = rowDay;
@@ -175,7 +175,9 @@ function Ledger({
 				</div>,
 			);
 		}
-		const key = `${row.at}-${row.toTaskId}-${row.fromSeq ?? "x"}`;
+		// Two messages from one sender to one task in the same millisecond are a real
+		// case (a split reply arrives as three), so the index has to be part of the key.
+		const key = `${row.at}-${row.toTaskId}-${row.fromSeq ?? "x"}-${index}`;
 		const openable = knownTasks?.has(row.toTaskId) ?? false;
 		out.push(
 			openable ? (

--- a/src/mainview/debug-log.ts
+++ b/src/mainview/debug-log.ts
@@ -1,0 +1,37 @@
+/**
+ * Renderer debug channels: chatty setup traces that are load-bearing when a terminal
+ * refuses to attach, and pure noise the rest of the time.
+ *
+ * They stay ON in the app (that is what they were written for) and OFF under vitest,
+ * where they buried the actual test output. Either default is overridable from
+ * devtools: `localStorage["dev3-debug"] = "terminal,rpc"`, `"*"`, or `"off"`.
+ */
+
+export type DebugChannel = "terminal" | "rpc" | "boot";
+
+export function underTest(): boolean {
+	if (import.meta.env?.MODE === "test") return true;
+	return typeof process !== "undefined" && !!process.env?.VITEST;
+}
+
+function readOverride(): string | null {
+	try {
+		return globalThis.localStorage?.getItem("dev3-debug") ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Resolved per call: the flag is set from devtools mid-session, not at boot. */
+export function debugEnabled(channel: DebugChannel): boolean {
+	const override = readOverride();
+	if (override === null) return !underTest();
+	if (override === "off") return false;
+	const wanted = override.split(",").map((part) => part.trim());
+	return wanted.includes("*") || wanted.includes(channel);
+}
+
+export function debugLog(channel: DebugChannel, ...args: unknown[]): void {
+	if (!debugEnabled(channel)) return;
+	console.log(...args);
+}

--- a/src/mainview/dev-server-trace.ts
+++ b/src/mainview/dev-server-trace.ts
@@ -21,6 +21,7 @@
  */
 
 import { api } from "./rpc";
+import { underTest } from "./debug-log";
 
 export type DevServerOp = "runDevServer" | "stopDevServer" | "checkDevServer";
 
@@ -74,10 +75,13 @@ function emit(
 	extra: Record<string, string | number | boolean | null>,
 ): void {
 	// The console mirror is what remains when the bridge cannot carry the sink.
-	// `debug` keeps it out of the way unless the reader is looking for it.
+	// `debug` keeps it out of the way unless the reader is looking for it. Under
+	// vitest there is no bridge to lose, so the mirror is only noise.
 	if (!shouldEmit(op, boundary)) return;
-	const consoleFn = level === "warn" ? console.warn : console.debug;
-	consoleFn(`[dev-server] ${op} ${boundary}`, extra);
+	if (!underTest()) {
+		const consoleFn = level === "warn" ? console.warn : console.debug;
+		consoleFn(`[dev-server] ${op} ${boundary}`, extra);
+	}
 	try {
 		const request = api.request.logRendererDiagnostic({
 			level,

--- a/src/mainview/main.tsx
+++ b/src/mainview/main.tsx
@@ -9,6 +9,7 @@ import { I18nProvider, resolveInitialLocale } from "./i18n";
 import { MobileProvider, detectMobile } from "./hooks/useMobile";
 import { initAnalytics } from "./analytics";
 import { initFeatureFlags } from "./feature-flags";
+import { debugLog } from "./debug-log";
 import { api, isElectrobun } from "./rpc";
 import { initAutoFullscreen } from "./fullscreen";
 import { initKeyboardLock } from "./keyboard-lock";
@@ -122,11 +123,11 @@ startRendererHeartbeat();
 document.documentElement.lang = resolveInitialLocale();
 
 async function bootstrap() {
-	console.log("[main] bootstrap() starting...");
+	debugLog("boot", "[main] bootstrap() starting...");
 	try {
-		console.log("[main] Initializing ghostty-web...");
+		debugLog("boot", "[main] Initializing ghostty-web...");
 		await init();
-		console.log("[main] ghostty-web initialized");
+		debugLog("boot", "[main] ghostty-web initialized");
 	} catch (err) {
 		console.error("[main] ghostty-web init() FAILED:", err);
 		console.error("[main] This will prevent terminal rendering. Error:", {
@@ -154,7 +155,7 @@ async function bootstrap() {
 		document.title = "dev-3.0";
 	}
 
-	console.log("[main] Rendering React app...");
+	debugLog("boot", "[main] Rendering React app...");
 	// RootErrorBoundary wraps the providers (not just <App/>) so a crash in
 	// I18nProvider/MobileProvider themselves still renders a visible fallback
 	// instead of a blank, unmounted tree.
@@ -171,7 +172,7 @@ async function bootstrap() {
 			</RootErrorBoundary>
 		</StrictMode>,
 	);
-	console.log("[main] React app rendered");
+	debugLog("boot", "[main] React app rendered");
 }
 
 bootstrap().catch((err) => {

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -4,6 +4,7 @@ import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "./zoom";
 import { createWatchdogState, decidePingOutcome, shouldAllowReload } from "./rpc-watchdog";
 import { recordDiagnostic, RPC_STATUS_EVENT, type RpcConnectionState } from "./diagnostics";
 import { createRemoteSession, type RemoteSessionState, type SocketLike } from "./remote-session";
+import { debugLog } from "./debug-log";
 
 // ── Transport connection state ──────────────────────────────────────
 // Surfaced to the bootstrap screen so a stuck "Loading…" can tell the user
@@ -372,7 +373,7 @@ function initBrowserApi(): ApiShape {
 	// by initStreamerMode) instead of wiping the whole query.
 	const urlParams = new URLSearchParams(window.location.search);
 	const qrToken = urlParams.get("token") || "";
-	console.log("[browser-rpc] init", { isViteDevServer, hasQrToken: !!qrToken, protocol: wsProtocol });
+	debugLog("rpc", "[browser-rpc] init", { isViteDevServer, hasQrToken: !!qrToken, protocol: wsProtocol });
 	if (qrToken) {
 		urlParams.delete("token");
 		const rest = urlParams.toString();
@@ -458,7 +459,7 @@ function initBrowserApi(): ApiShape {
 		callbacks: {
 			onStateChange: (state) => setRpcState(mapSessionState(state)),
 			onSocketOpen: (socket) => {
-				console.log("[browser-rpc] WS OPEN");
+				debugLog("rpc", "[browser-rpc] WS OPEN");
 				activeSocket = socket;
 				flushQueuedRequests(socket);
 			},

--- a/src/mainview/test-setup.ts
+++ b/src/mainview/test-setup.ts
@@ -121,3 +121,96 @@ process.stderr.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
 	_suppressAbortErrors = false;
 	return _origStderrWrite(chunk, ...args as []);
 }) as typeof process.stderr.write;
+
+// Collapse React's act(...) warnings into one tallied line per test file.
+//
+// The warning itself is worth keeping — a stray update means a test asserted before
+// its component settled, which is how flakes are born. What is not worth keeping is
+// React re-printing the same seven-line boilerplate for every single occurrence: one
+// renderer run emitted 680 of them, ~4.7k lines, which buried everything else in the
+// output. The tally below names every offending component and how often it fired, so
+// nothing is hidden — it is the same signal at 1% of the volume.
+const _actTally = new Map<string, number>();
+const _origConsoleError = console.error.bind(console);
+
+/** Component name lands either inlined or as React's `%s` argument. */
+export function _actOffenderForTests(args: unknown[]): string | null {
+	const format = typeof args[0] === "string" ? args[0] : "";
+	if (/^A suspended resource finished loading inside a test/.test(format)) {
+		return "<suspended resource>";
+	}
+	// A stray update that landed after the test's act environment was torn down.
+	if (/^The current testing environment is not configured to support act/.test(format)) {
+		return "<after teardown>";
+	}
+	const inlined = /^An update to (\S+) inside a test was not wrapped in act/.exec(format);
+	if (!inlined) return null;
+	return inlined[1] === "%s" ? String(args[1] ?? "unknown") : inlined[1];
+}
+
+console.error = ((...args: unknown[]) => {
+	const offender = _actOffenderForTests(args);
+	if (offender === null) {
+		_origConsoleError(...args);
+		return;
+	}
+	_actTally.set(offender, (_actTally.get(offender) ?? 0) + 1);
+}) as typeof console.error;
+
+// Recharts measures its container and warns when it comes back 0×0. happy-dom has no
+// layout engine, so every chart in every test is 0×0 and the warning can never mean
+// anything here — unlike in a browser, where it is a real finding.
+const _origConsoleWarn = console.warn.bind(console);
+
+export function _isUnlayoutableChartWarning(args: unknown[]): boolean {
+	const first = typeof args[0] === "string" ? args[0] : "";
+	return /The width\(0\) and height\(0\) of chart should be greater than 0/.test(first);
+}
+
+console.warn = ((...args: unknown[]) => {
+	if (_isUnlayoutableChartWarning(args)) return;
+	_origConsoleWarn(...args);
+}) as typeof console.warn;
+
+// No unit test makes a real HTTP request. Two separate leaks were doing exactly that:
+//
+//  - analytics.ts asks telemetryEnabled(), which is "on" unless something opts out, and
+//    nothing does under vitest — so every renderer run fired ~24 Google Analytics hits
+//    and an ipify lookup from the dev machine and from every CI runner, and printed
+//    happy-dom's CORS refusal for each.
+//  - importing rpc.ts is enough to POST /rpc, which happy-dom resolves against its
+//    default origin localhost:3000 where nothing listens — 15 raw ECONNREFUSED dumps
+//    per run, from files that never meant to talk to a server.
+//
+// No suite in src/mainview starts a server of its own (no Bun.serve, no createServer),
+// so blocking every http(s) call costs nothing and a test that needs one mocks it.
+const _origFetch = globalThis.fetch;
+
+export function _isBlockedTestUrl(input: unknown): boolean {
+	const raw = typeof input === "string"
+		? input
+		: input instanceof URL
+			? input.href
+			: typeof (input as { url?: unknown })?.url === "string"
+				? (input as { url: string }).url
+				: "";
+	// Relative URLs count: happy-dom resolves them against its own origin and dials it.
+	return /^https?:/i.test(raw) || raw.startsWith("/");
+}
+
+if (typeof _origFetch === "function") {
+	globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+		if (_isBlockedTestUrl(input)) {
+			return Promise.reject(new Error("network blocked in tests"));
+		}
+		return _origFetch(input, init);
+	}) as typeof fetch;
+}
+
+
+afterAll(() => {
+	if (_actTally.size === 0) return;
+	const tally = [..._actTally].map(([name, count]) => `${name}×${count}`).join(", ");
+	_actTally.clear();
+	_origConsoleError(`act(): updates outside act(...) — ${tally}`);
+});


### PR DESCRIPTION
## The renderer test suite was calling out to Google Analytics and ipify

Read this part first — it is the most important thing in the commit, and it was only found because it was buried in 12k lines of test log.

`analytics.ts` sends through `sendToGA`, gated on `telemetryEnabled()`. Under vitest **nothing opts that gate out**: the build-time flag `VITE_TELEMETRY` is unset, no host injects `window.__DEV3_TELEMETRY_OPT_OUT__` (that is done by the app shell, which does not exist here), and the runtime toggle is off. There is no test-time opt-out source at all. So every `bunx vitest run` over `src/mainview` — on every developer machine and every CI runner — issued roughly 24 requests to `https://www.google-analytics.com/mp/collect` plus a public-IP lookup against `https://api.ipify.org`.

Being precise about what did and did not leave the machine:

- **No event payload landed.** happy-dom refused the CORS preflight, so the `POST` body — client id, session id, user properties, event params — was never sent.
- **The preflight itself reached Google.** An `OPTIONS` to `google-analytics.com` carrying the measurement id and API secret in the query string did go out, from the runner's own address, on every test run.
- **ipify received a request from every runner**, which is a service whose entire purpose is to observe and echo the caller's public IP.

Fixed at the transport rather than at the gate: `test-setup.ts` now rejects every `http(s)` and origin-relative `fetch`. Deliberately **not** in `telemetryEnabled()` — `telemetry-gate.test.ts` exists to assert that gate's default is ON and must keep asserting it, so flipping the default there would hollow out the test that guards it. No suite under `src/mainview` starts a server of its own (no `Bun.serve`, no `createServer`), so blocking wholesale costs nothing, and a test that wants a response mocks it. A guard test covers the predicate and the rejection.

The same block also stops a second, harmless-but-noisy leak: importing `rpc.ts` is enough to `POST /rpc`, which happy-dom resolves against its own default origin `localhost:3000` where nothing listens — 15 raw `ECONNREFUSED` dumps per run.

## The rest: 12 192 lines of test output down to 589

−95%, −11 603 lines. The backend and CLI suites were already clean (297 and 40 lines); this was entirely a renderer problem.

| Source | Blocks | ~Lines | Change |
|---|---|---|---|
| React's 7-line `act(...)` boilerplate | 680 | 4 760 | Collapsed to one tallied line per test file — `act(): updates outside act(...) — GlobalHeader×81, RateLimitIndicator×68`. Same signal, ~1% of the volume; the stray updates themselves are untouched and still counted per file. |
| `[TerminalView]` / `[TaskTerminal]` / `[main]` / `[browser-rpc]` traces | ~450 | ~1 400 | New `debug-log.ts` with `terminal` / `rpc` / `boot` channels. **ON in the app exactly as before**, OFF under vitest, either default overridable via `localStorage["dev3-debug"] = "terminal,rpc"` / `"*"` / `"off"`. |
| `Failed to load spaces: getSpaces is not a function` + stack | 79 | ~950 | Three RPC mocks (`App`, `ProjectSettings`, `AddProjectModal`) had drifted behind `useSpaces`. |
| Google Analytics CORS refusals | 24 | 48 | The finding above. |
| `ECONNREFUSED 127.0.0.1:3000` dumps | 15 | 120 | Same network block. |
| recharts `width(0) and height(0)` | 9 | ~27 | Dropped — happy-dom has no layout engine, so every chart in every test is 0×0 and the warning cannot carry information there. |

## Missing and colliding React keys

Real defects, also surfaced by reading the noise: `TaskCard` (the four git signal badges), `SpaceGroupedProjects` (the no-space bottom block), and the agent-traffic ledger, whose key was `${row.at}-${row.toTaskId}-${row.fromSeq}` — two messages from one sender to one task in the same millisecond are a routine case, since a split reply arrives as three.

## The FolderPickerModal flake, fixed at its cause

`FolderPickerHost confined to a project root > refuses a typed path that escapes the root and says so` failed on ubuntu CI (shard 5/5) while the file alone was green 21/21. It was not a timeout, and it reproduces on clean `origin/main`.

The test waited on `findByTestId("folder-picker-backdrop")`, which is in the DOM from the **first** render, while the `Folder path` input stays empty until the initial listing lands. So `user.clear` ran against an empty input and did nothing, the confine root then arrived and filled it, and `/etc` was appended: `/Users/test/repo/etc` — which *is* inside the root, so the refusal correctly never rendered. The CI failure dump already proved it: a breadcrumb `etc` with `title="/Users/test/repo/etc"`.

Deterministic mutant — make **only the first** `listDirectory` call `await setTimeout(D)`:

| `D` | Unfixed | Fixed |
|---|---|---|
| 1, 2, 3, 4, 5, 6, 8, 10, 12 ms | fails every run | passes |
| ≥16 ms | passes | passes |

Past ~16 ms the listing lands after the Enter, so the refusal renders and `findByText` resolves before the late listing clobbers it. That narrow window is why the file alone is green, why a shard is needed to see it, and why earlier attempts with fixed 40 ms and 300 ms delays "proved" the test was fine. The fix is a synchronisation point, not a timeout: `waitFor(input toHaveValue(root))` before clearing. Shard 5/5 ran green 3/3, and `vitest list --shard=5/5` confirms the file is in that shard.

## Verification

- Renderer suite: **310 files, 4 818 tests green**, four full runs, the last one at load 15+.
- `bun run lint`: clean.
- New guards: `src/mainview/__tests__/test-setup.test.ts` (10 tests) and `src/mainview/__tests__/debug-log.test.ts` (5 tests).
- CLI suite: 904 tests green.
- **The backend suite was never green on my box** — 16 → 12 → 4 failures as I lowered the worker count, on a machine sitting at load 15–18 from other agents. Zero `AssertionError` (only `STACK_TRACE_ERROR` and timeouts), the failure set shifts between runs, and the diff touches no file under `src/bun` / `src/cli` / `src/shared`, so the backend suite cannot reach it by import graph. `git-merge-detection.test.ts` on its own: 27/27 green. Saying this plainly rather than claiming a green `test:full` — CI is the arbiter.

## Left deliberately alone

- The ~680 stray `act(...)` updates themselves: ~250 mechanical edits across ~15 test files, worth doing on its own, not worth bundling into a log cleanup. The per-file counts stay in the output so the work can be tracked down.
- `Headless Tree: Circular reference` and a duplicate `/Users/test/Downloads` key in the FolderPicker tests (~7 lines). Cause identified: that mock is `mockResolvedValue(mockListing("/Users/test", …))`, which returns the same listing for every requested path, so the tree gets children equal to the parent's siblings. A fixture artifact, not a product bug.

Records: `decisions/2026/08/27/tally-act-warnings-and-block-test-network.md` and `decisions/2026/08/27/folder-picker-test-waited-on-the-wrong-element.md`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b28075ac-d34b-49d5-849c-2d6ff131f900) · `dev3://task/b28075ac-d34b-49d5-849c-2d6ff131f900` _(dev3 added this footer — turn it off in Settings → Tasks.)_
