### PR TITLE
Close a failed pane run's pane after 30 minutes

### DIFF
--- a/change-logs/2026/08/28/fix-bound-failed-pane-run-dismissal.md
+++ b/change-logs/2026/08/28/fix-bound-failed-pane-run-dismissal.md
@@ -1,0 +1,3 @@
+Short: Failed panes also close themselves
+
+A pane run that failed no longer waits for Enter forever — it closes itself after 30 minutes, long enough to read the output and short enough that dead panes stop piling up, while a successful run still goes after 10 seconds. The dev3 skill now states closing finished panes as the agent's own duty rather than something the timer handles for it.

--- a/decisions/2026/08/27/auto-close-successful-pane-runs.md
+++ b/decisions/2026/08/27/auto-close-successful-pane-runs.md
@@ -1,5 +1,8 @@
 # Auto-close a pane run only when it succeeded
 
+> Superseded on 2026-08-28 by `decisions/2026/08/28/bound-every-pane-run-dismissal.md`: a failed run
+> no longer waits for Enter forever — it gets a 30-minute window instead.
+
 ## Context
 
 `dev3 pane run` held its pane open forever after the command ended (`waitForDismissal` in

--- a/decisions/2026/08/28/bound-every-pane-run-dismissal.md
+++ b/decisions/2026/08/28/bound-every-pane-run-dismissal.md
@@ -1,0 +1,39 @@
+# Every pane run closes itself eventually, failures included
+
+## Context
+
+`decisions/2026/08/27/auto-close-successful-pane-runs.md` gave a successful run a 10-second timer and
+left everything else waiting for Enter forever. That split turned out to be the wrong half of the
+problem: a session's panes are mostly *red* ones — a failed `test:full`, a build that did not compile
+— so the user still ended up with a row of panes to close by hand, and reported exactly that again
+with a screenshot of two `exit code 1` panes sitting on `press Enter to close this pane`.
+
+## Decision
+
+`paneRunDismissal(exitCode)` in `src/shared/pane-runs.ts` now returns a timer for every outcome:
+`PANE_RUN_AUTO_CLOSE_SECONDS` (10s) on exit code 0, `PANE_RUN_FAILED_AUTO_CLOSE_SECONDS` (30 minutes)
+on anything else, including the `null` a signal death writes. A key press still closes a pane sooner.
+`autoCloseMs` lost its `null` case with the branch that read it (`waitForDismissal` in
+`src/cli/commands/pane-exec.ts`) — no outcome asks to wait forever, so no code models it.
+
+30 minutes is chosen so the output of a failure is still on screen when the user comes back from
+lunch, while yesterday's red builds are not. The pane is a courtesy either way: the full output lives
+in the run's log and `dev3 pane logs <run-id>` reads it after the pane is gone.
+
+The skill text (`SKILL_PANES` in `src/shared/agent-skill-content.ts`) now states closing panes as the
+agent's own duty — `dev3 pane close <run-id>` per run and a `dev3 pane list` check before ending a
+turn — and demotes the timer to a backstop for panes the agent abandoned.
+
+## Risks
+
+A failure nobody looked at within 30 minutes disappears from the screen; the log is the fallback, and
+the timer is the only thing standing between a long session and a wall of dead panes. Both numbers
+stay constants with no setting behind them, deliberately, until someone asks for a different value.
+The 30-minute path cannot be waited out in a test — it is proven by the unit assertion on the
+constant plus an e2e run with the constant temporarily shrunk to 3 seconds.
+
+## Alternatives considered
+
+Keeping failures on screen forever (what the user just rejected); one timer for both (a green run
+does not deserve 30 minutes of screen, and a red one does not survive 10 seconds of attention); a
+per-project setting (a settings surface for a number nobody has disputed twice yet).

--- a/src/bun/__tests__/pane-runs-vocabulary.test.ts
+++ b/src/bun/__tests__/pane-runs-vocabulary.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from "vitest";
 import {
 	PANE_RUN_AUTO_CLOSE_SECONDS,
 	PANE_RUN_COMMAND_MAX_LENGTH,
+	PANE_RUN_FAILED_AUTO_CLOSE_SECONDS,
 	PANE_RUN_TAIL_DEFAULT_LINES,
 	PANE_RUN_TAIL_MAX_LINES,
 	clampPaneRunTail,
@@ -185,14 +186,22 @@ describe("what a finished pane does with itself", () => {
 		expect(plan.message).toContain(`${PANE_RUN_AUTO_CLOSE_SECONDS}s`);
 	});
 
-	it("keeps a failed run on screen forever — its output is the whole point", () => {
-		expect(paneRunDismissal(1).autoCloseMs).toBeNull();
-		expect(paneRunDismissal(1).message).toBe("press Enter to close this pane");
+	it("gives a failed run the long window — its output is the whole point", () => {
+		const plan = paneRunDismissal(1);
+		expect(plan.autoCloseMs).toBe(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS * 1000);
+		expect(plan.message).toContain("30m");
+	});
+
+	it("holds a failure far longer than a success — but every outcome is bounded", () => {
+		for (const exitCode of [0, 1, 137, null]) {
+			expect(paneRunDismissal(exitCode).autoCloseMs).toBeGreaterThan(0);
+		}
+		expect(paneRunDismissal(1).autoCloseMs).toBeGreaterThan(paneRunDismissal(0).autoCloseMs * 10);
 	});
 
 	it("treats an unreadable outcome as a failure, never as a success", () => {
 		// null is what a signal death writes: killed is not clean.
-		expect(paneRunDismissal(null).autoCloseMs).toBeNull();
+		expect(paneRunDismissal(null).autoCloseMs).toBe(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS * 1000);
 	});
 });
 

--- a/src/cli/__tests__/pane-run-exec.bun-e2e.ts
+++ b/src/cli/__tests__/pane-run-exec.bun-e2e.ts
@@ -182,7 +182,9 @@ try {
 	check(normal.status.exitCode === 3, `the command's exit code 3 survived the shell (got ${String(normal.status.exitCode)})`);
 	check(normal.cliExitCode === 0, `the runner itself exited 0 (got ${String(normal.cliExitCode)})`);
 
-	// A pane nobody touches: the green one must go away by itself, the red one must not.
+	// A pane nobody touches: the green one goes away on its own short timer, the red
+	// one stays for the long window — proven here by it still being alive well past
+	// the green timer, since waiting out the real 30 minutes is not a test.
 	const clean = startHeldPane(root, "run-0123456789ad", printMarkerAndExit(0));
 	const cleanExit = await exitedWithin(clean, (PANE_RUN_AUTO_CLOSE_SECONDS + 8) * 1000);
 	if (cleanExit === null) clean.kill();
@@ -190,7 +192,10 @@ try {
 
 	const failed = startHeldPane(root, "run-0123456789ae", printMarkerAndExit(3));
 	const failedExit = await exitedWithin(failed, (PANE_RUN_AUTO_CLOSE_SECONDS + 5) * 1000);
-	check(failedExit === null, `a failed run kept its pane open past the auto-close window (got ${String(failedExit)})`);
+	check(
+		failedExit === null,
+		`a failed run kept its pane open past the green auto-close window (got ${String(failedExit)})`,
+	);
 	failed.kill();
 
 	if (IS_WINDOWS) {

--- a/src/cli/commands/pane-exec.ts
+++ b/src/cli/commands/pane-exec.ts
@@ -86,16 +86,12 @@ async function keyPressed(): Promise<void> {
 /**
  * Hold the pane open after the command ends, so a finished build stays on screen
  * instead of the pane vanishing the moment it succeeds. The agent never needs this
- * — it reads the log — so the wait exists purely for the human watching, and a
- * clean run gives that human a few seconds rather than a pane to close by hand.
+ * — it reads the log — so the wait exists purely for the human watching, and it is
+ * always bounded: nothing here ever leaves a pane for the user to close by hand.
  */
 async function waitForDismissal(exitCode: number | null): Promise<void> {
 	const { autoCloseMs, message } = paneRunDismissal(exitCode);
 	process.stdout.write(`[dev3] ${message}\n`);
-	if (autoCloseMs === null) {
-		await keyPressed();
-		return;
-	}
 	await Promise.race([keyPressed(), Bun.sleep(autoCloseMs)]);
 }
 

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -16,7 +16,7 @@ import {
 	AGENT_MESSAGE_HOLD_IDLE_SECONDS,
 } from "./agent-message-hold-timing";
 import { deepLinkSchemeRegistered } from "./deep-link";
-import { PANE_RUN_AUTO_CLOSE_SECONDS } from "./pane-runs";
+import { PANE_RUN_AUTO_CLOSE_SECONDS, PANE_RUN_FAILED_AUTO_CLOSE_SECONDS } from "./pane-runs";
 
 /**
  * How the agent should link a PR back to its task — or why it must not. The
@@ -263,7 +263,9 @@ dev3 pane close <run-id>                      # close that pane (kills the comma
 
 The outcome line distinguishes **still running** from **finished, exit code N** — never treat a quiet tail as a finished command. Runs are non-interactive (stdin is closed): builds, tests, servers, watchers. Quick one-shot commands stay inline in your own shell, and the project's canonical dev server is \`dev3 dev-server start\`, not a pane run.
 
-**Clean up after yourself — a finished pane the user has to close by hand is litter.** A run that exits 0 closes its own pane after ${PANE_RUN_AUTO_CLOSE_SECONDS} seconds, so the ordinary green case needs nothing from you. Everything else stays on screen deliberately: a failed run keeps its pane so the user can read it, and a server or watcher you started keeps running until something stops it. Once you have read what you needed from a run you are done with, \`dev3 pane close <run-id>\` — do not leave a watcher or a red build parked in the user's terminal after the work that needed it is over.
+**Close every pane you are done with — this is your job, not the user's.** \`dev3 pane close <run-id>\` the moment you have read what you came for. Do it per run, as you go, and again before you end a turn: \`dev3 pane list\` must show nothing of yours except panes still doing work you still need. A watcher, a dev server, or a red build parked in the user's terminal after the work that needed it is over is litter, and the user is the one who has to clear it.
+
+The pane's own timer is a backstop for panes you abandon, never a substitute for closing them: a run that exits 0 closes itself after ${PANE_RUN_AUTO_CLOSE_SECONDS} seconds, and a failed one after ${Math.round(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS / 60)} minutes, so its output is still on screen when the user comes back. Closing a pane never destroys anything you need — the full output stays in the run's log and \`dev3 pane logs <run-id>\` reads it afterwards.
 
 Reading the SCREEN of a pane you did not start (the user's own pane, "look at the error on the right") is a different thing and is **tmux-only today**: \`dev3 peek --pane <N>\` returns a screen tail on a tmux task, and on a native task it returns the pane summary with no tail, because the native host publishes no screen snapshot. \`dev3 pane list\` says which case you are in.
 

--- a/src/shared/pane-runs.ts
+++ b/src/shared/pane-runs.ts
@@ -39,19 +39,33 @@ export type PaneRunPlacement = "right" | "below";
 /** How long a SUCCESSFUL run's pane stays on screen before it closes itself. */
 export const PANE_RUN_AUTO_CLOSE_SECONDS = 10;
 
+/**
+ * How long a FAILED run's pane stays. Long enough that the output is still there
+ * when the user comes back from lunch, short enough that yesterday's red builds
+ * are not still on screen today.
+ */
+export const PANE_RUN_FAILED_AUTO_CLOSE_SECONDS = 30 * 60;
+
 export interface PaneRunDismissal {
-	/** null = wait for the human, forever. */
-	readonly autoCloseMs: number | null;
+	/** Every outcome closes eventually — a pane is never left waiting forever. */
+	readonly autoCloseMs: number;
 	readonly message: string;
 }
 
 /**
- * What a finished pane does with itself. A clean run closes on a timer so finished
- * panes stop piling up; anything else — a non-zero exit, a signal, an outcome we
- * cannot read — keeps the pane, because its output is what the human came for.
+ * What a finished pane does with itself. Every pane closes itself eventually so
+ * finished panes stop piling up; a clean run goes quickly, and anything else — a
+ * non-zero exit, a signal, an outcome we cannot read — gets the long window,
+ * because its output is what the human came for.
  */
 export function paneRunDismissal(exitCode: number | null): PaneRunDismissal {
-	if (exitCode !== 0) return { autoCloseMs: null, message: "press Enter to close this pane" };
+	if (exitCode !== 0) {
+		const minutes = Math.round(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS / 60);
+		return {
+			autoCloseMs: PANE_RUN_FAILED_AUTO_CLOSE_SECONDS * 1000,
+			message: `closing this pane in ${minutes}m — press Enter to close it now`,
+		};
+	}
 	return {
 		autoCloseMs: PANE_RUN_AUTO_CLOSE_SECONDS * 1000,
 		message: `closing this pane in ${PANE_RUN_AUTO_CLOSE_SECONDS}s — press Enter to close it now`,


### PR DESCRIPTION
Follow-up to #1565. That change closed a pane run's pane 10 seconds after a *successful* run and left every other outcome waiting for Enter forever. In practice the panes that pile up are the red ones — a failed `test:full`, a build that did not compile — so the original complaint came back with a screenshot of two `exit code 1` panes still sitting on `press Enter to close this pane`.

Now every outcome carries a timer: 10 seconds on exit code 0, 30 minutes on a non-zero exit or the `null` a signal death writes. A key press still closes a pane sooner, and the full output stays in the run's log either way (`dev3 pane logs <run-id>`). `PaneRunDismissal.autoCloseMs` lost its `null` case along with the branch that read it — no outcome asks to wait forever, so nothing models it.

The skill text now states closing finished panes as the agent's own duty (`dev3 pane close <run-id>` per run, plus a `dev3 pane list` check before ending a turn) and demotes the timer to a backstop for panes the agent abandoned.

The 30-minute path cannot be waited out in a test; it is covered by the unit assertion on the constant plus an e2e run with the constant temporarily shrunk to 3 seconds, which turned the "failed pane is still alive" check red as expected.

Decision record: `decisions/2026/08/28/bound-every-pane-run-dismissal.md` (supersedes the 08/27 one).

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2c2461a9-5459-4c4d-9e91-0a6937722ea8) · `dev3://task/2c2461a9-5459-4c4d-9e91-0a6937722ea8`