### PR TITLE
Harden the remote-access static code against brute force

### DIFF
--- a/change-logs/2026/08/28/fix-harden-remote-static-access-code.md
+++ b/change-logs/2026/08/28/fix-harden-remote-static-access-code.md
@@ -1,0 +1,3 @@
+Short: Remote access code harder to guess
+
+Hardened the remote-access static code (`dev3 remote --static-code` / `DEV3_REMOTE_STATIC_CODE`) against brute force: the minimum length is now 8 characters instead of 4, and a code set straight into the environment below that makes the server refuse to start rather than silently ignore it. Failed `/auth/exchange` attempts are now throttled per client — 5 failures per 30 seconds, then a 429 with `Retry-After` — checked before the submitted code is even compared. Only failures count and a success clears the record, so several devices can still enrol back to back and nobody can lock the owner out.

--- a/decisions/2026/08/28/throttle-remote-auth-exchange.md
+++ b/decisions/2026/08/28/throttle-remote-auth-exchange.md
@@ -1,0 +1,92 @@
+# Throttle /auth/exchange, and refuse a static code shorter than 8
+
+## Context
+
+`--static-code` / `DEV3_REMOTE_STATIC_CODE` replaces the rotating single-use QR
+token with a fixed one, so that several devices and browsers can enrol without
+scanning a fresh QR from the host each time. That reuse is the feature and stays
+— the code is a long-lived, multi-use credential by design.
+
+The weakness was that it could simply be guessed. The CLI accepted a 4-character
+code (~1M combinations), and `POST /auth/exchange` had no attempt counter, no
+delay and no 429 — a script could walk the whole space. `checkOrigin` is not a
+defence here: it returns `true` when a request carries no `Origin` header, which
+a non-browser client just omits.
+
+## Decision
+
+**Minimum length is 8** (`MIN_REMOTE_STATIC_CODE_LENGTH`,
+`src/shared/remote-static-code.ts`), enforced by the one validator that the
+`dev3 remote` flag parser, the systemd unit writer, and the server all call.
+
+**A weak code set straight into the env is a hard startup failure**, not a
+silent downgrade: `assertStaticCodeStrongEnough()` runs first thing in
+`startRemoteAccessServer()` and throws. Both CLI entry points already reject a
+short code at flag-parse time, so reaching the server with one means the env var
+was set directly (Docker, a hand-written unit, an exported shell) — unattended
+contexts where a log line goes unread. Quietly falling back to rotating QR
+tokens would break the caller's saved URL with a plain 401 that reads as "auth
+is broken" rather than "your code is too short". The error message names the
+cause and never contains the code itself, because it also goes to the log.
+
+**The throw is scoped to the env, and only the env.** The gate reads
+`process.env.DEV3_REMOTE_STATIC_CODE` directly rather than `getStaticCode()`,
+which is about to grow a settings-backed fallback (`staticAccessCode`, seq 1735
+/ PR #1586). `startRemoteAccessServer()` is a top-level `await` on the app's
+boot path, so a typo in a settings field would otherwise take the whole app
+down, with the only fix living inside the app that no longer starts. The rule
+for any UI-editable source is the opposite one: reject the **value** — drop it,
+log it, show the error in its own field — never the boot. A source-level test
+pins the read, because the second source does not exist in this branch yet.
+
+**Failed exchanges are throttled** (`src/bun/remote-auth-rate-limit.ts`):
+5 failures per 30 s per key, then 429 with `Retry-After`, checked *before* the
+submitted credential is compared. Three properties do the work:
+
+- **Only failures count, and a success clears the record.** A device that knows
+  the code is never delayed, so several devices still enrol back to back, and a
+  typo before the right code costs nothing.
+- **The key is the socket peer address** (`server.requestIP(req)`), never
+  `X-Forwarded-For` / `CF-Connecting-IP`. Those headers are attacker-controlled
+  on a direct connection, so keying on them would hand out a fresh budget per
+  request — a fake defence. The consequence is deliberate: behind a tunnel every
+  request shares one peer address, so all tunnel traffic shares one budget.
+- **A block always expires.** The window is 30 s and never escalates, so the
+  worst an attacker can inflict on the owner is a half-minute wait on a new
+  enrolment — and only when they share a bucket (i.e. behind the tunnel).
+  Existing devices are untouched: `/auth/refresh` carries a signed cookie, is
+  not guessable, and is deliberately left unthrottled so live sessions survive
+  an attack in progress.
+
+At 5 tries per 30 s, one bucket yields ~14 400 guesses a day against a space of
+36^8 ≈ 2.8·10^12 for an 8-character alphanumeric code. Guessing stops being a
+strategy.
+
+## Risks
+
+- **Shared bucket behind a tunnel.** An attacker hammering the public URL can
+  make the owner's *new* enrolment wait up to 30 s. Accepted: bounded, never
+  permanent, and existing sessions keep working. Note the CLI already refuses to
+  combine `--static-code` with a public tunnel, so this is mostly the BYO-tunnel
+  and QR-token case.
+- **A desktop app whose environment carries a short code now fails to start**
+  instead of booting without remote access. That is the point of the loud
+  failure, but it is a behaviour change for anyone who exported a 4-7 character
+  code.
+- **In-memory throttle state.** A restart clears it. Restarting the server is
+  not something a remote attacker can do, so the reset is not a bypass.
+
+## Alternatives considered
+
+- **A delay instead of a 429** — sleep before answering a failed attempt. Does
+  not stop a parallel attacker: 1000 concurrent guesses are all still evaluated,
+  just slowly. Rejected.
+- **A global counter across all callers** — catches IP rotation, but hands an
+  attacker a way to freeze the owner out from anywhere. Rejected; a per-peer
+  budget plus a socket-derived key covers the realistic cases without the
+  lockout.
+- **Keying on `clientIp` (the header-derived value already used for logging)** —
+  reads better through a tunnel, but is spoofable on a direct connection, which
+  is exactly the case that matters on LAN. Rejected.
+- **Making the static code single-use or rotating it** — would defeat its
+  purpose; enrolling several devices from one code is why it exists.

--- a/src/bun/__tests__/remote-access-auth.test.ts
+++ b/src/bun/__tests__/remote-access-auth.test.ts
@@ -7,7 +7,7 @@
  * exercised end-to-end at the Request/Response seam.
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
-import { rmSync } from "node:fs";
+import { rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -68,14 +68,20 @@ import {
 	checkOrigin,
 	handleAuthExchange,
 	handleAuthRefresh,
+	assertStaticCodeStrongEnough,
 } from "../remote-access-server";
 import { initSecret, createQrToken, _resetForTests } from "../jwt";
+import { AUTH_FAILURE_LIMIT, _resetAuthRateLimitForTests } from "../remote-auth-rate-limit";
+import { MIN_REMOTE_STATIC_CODE_LENGTH } from "../../shared/remote-static-code";
 
 const testSecretDir = join(tmpdir(), `dev3-remote-auth-test-${process.pid}`);
 const testSecretFile = join(testSecretDir, "remote-jwt-secret");
 
 beforeEach(async () => {
 	delete process.env.DEV3_REMOTE_STATIC_CODE;
+	// Failed exchanges are throttled per key; without this reset the accumulated
+	// 401s from earlier tests in this file would 429 the later ones.
+	_resetAuthRateLimitForTests();
 	_resetForTests();
 	rmSync(testSecretDir, { recursive: true, force: true });
 	await initSecret(testSecretFile);
@@ -321,17 +327,17 @@ describe("handleAuthExchange (QR flow)", () => {
 
 describe("handleAuthExchange (static code)", () => {
 	beforeEach(() => {
-		process.env.DEV3_REMOTE_STATIC_CODE = "sesame";
+		process.env.DEV3_REMOTE_STATIC_CODE = "sesame42";
 	});
 
 	it("accepts the static code and sets a session cookie", async () => {
-		const resp = await handleAuthExchange(exchangeRequest("sesame"));
+		const resp = await handleAuthExchange(exchangeRequest("sesame42"));
 		expect(resp.status).toBe(200);
 		expect(cookieValue(resp.headers.get("set-cookie"))).toBeTruthy();
 	});
 
 	it("rejects a wrong code with 401", async () => {
-		const resp = await handleAuthExchange(exchangeRequest("wrong"));
+		const resp = await handleAuthExchange(exchangeRequest("wrong123"));
 		expect(resp.status).toBe(401);
 	});
 
@@ -339,6 +345,111 @@ describe("handleAuthExchange (static code)", () => {
 		const qr = await createQrToken();
 		const resp = await handleAuthExchange(exchangeRequest(qr));
 		expect(resp.status).toBe(401);
+	});
+});
+
+// ── Brute-force throttle ─────────────────────────────────────────────
+
+describe("handleAuthExchange throttling", () => {
+	beforeEach(() => {
+		process.env.DEV3_REMOTE_STATIC_CODE = "sesame42";
+	});
+
+	it("429s a guessing peer once it burns its budget, and stops evaluating codes", async () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) {
+			const resp = await handleAuthExchange(exchangeRequest(`guess-${i}`), { rateLimitKey: "10.0.0.9" });
+			expect(resp.status).toBe(401);
+		}
+		const blocked = await handleAuthExchange(exchangeRequest("guess-next"), { rateLimitKey: "10.0.0.9" });
+		expect(blocked.status).toBe(429);
+		expect(Number(blocked.headers.get("retry-after"))).toBeGreaterThan(0);
+
+		// Even the correct code is refused while the budget is spent — the throttle
+		// runs before the comparison, so a blocked attacker learns nothing.
+		const correctWhileBlocked = await handleAuthExchange(exchangeRequest("sesame42"), { rateLimitKey: "10.0.0.9" });
+		expect(correctWhileBlocked.status).toBe(429);
+	});
+
+	it("never locks out another peer — the owner's device still enrols", async () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT + 3; i++) {
+			await handleAuthExchange(exchangeRequest(`guess-${i}`), { rateLimitKey: "10.0.0.9" });
+		}
+		const owner = await handleAuthExchange(exchangeRequest("sesame42"), { rateLimitKey: "10.0.0.42" });
+		expect(owner.status).toBe(200);
+		expect(cookieValue(owner.headers.get("set-cookie"))).toBeTruthy();
+	});
+
+	it("lets several devices enrol back to back on one key — success is never counted", async () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT * 3; i++) {
+			const resp = await handleAuthExchange(exchangeRequest("sesame42"), { rateLimitKey: "10.0.0.42" });
+			expect(resp.status).toBe(200);
+		}
+	});
+
+	it("clears the record on success, so a typo before the right code costs nothing", async () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT - 1; i++) {
+			await handleAuthExchange(exchangeRequest("typo1234"), { rateLimitKey: "10.0.0.42" });
+		}
+		expect((await handleAuthExchange(exchangeRequest("sesame42"), { rateLimitKey: "10.0.0.42" })).status).toBe(200);
+		// Budget is full again: another run of failures still fits before a 429.
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) {
+			const resp = await handleAuthExchange(exchangeRequest("typo1234"), { rateLimitKey: "10.0.0.42" });
+			expect(resp.status).toBe(401);
+		}
+	});
+
+	it("throttles QR-token guessing too, not just the static code", async () => {
+		delete process.env.DEV3_REMOTE_STATIC_CODE;
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) {
+			expect((await handleAuthExchange(exchangeRequest(`bad.${i}`), { rateLimitKey: "10.0.0.9" })).status).toBe(401);
+		}
+		expect((await handleAuthExchange(exchangeRequest("bad.x"), { rateLimitKey: "10.0.0.9" })).status).toBe(429);
+	});
+});
+
+// ── Startup gate on a weak static code ───────────────────────────────
+
+describe("assertStaticCodeStrongEnough", () => {
+	it("passes when no static code is configured", () => {
+		delete process.env.DEV3_REMOTE_STATIC_CODE;
+		expect(() => assertStaticCodeStrongEnough()).not.toThrow();
+	});
+
+	it("throws on a code set straight into the env below the minimum", () => {
+		process.env.DEV3_REMOTE_STATIC_CODE = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH - 1);
+		expect(() => assertStaticCodeStrongEnough()).toThrow(/at least 8 characters/);
+	});
+
+	it("accepts exactly the minimum", () => {
+		process.env.DEV3_REMOTE_STATIC_CODE = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH);
+		expect(() => assertStaticCodeStrongEnough()).not.toThrow();
+	});
+
+	// The gate runs as a top-level await on the app's boot path, so whatever it
+	// can throw on can take the whole app down. That is acceptable for an env var
+	// (unattended, and the CLI already rejected it) and NOT acceptable for a
+	// UI-editable source: a typo in a settings field would leave a dead app with
+	// no way to fix it from inside the app. Pinned at source level because the
+	// second source does not exist here yet — this fails the moment someone
+	// "tidies" the body into getStaticCode(), which is where that source lands.
+	it("reads the env var directly, never the resolved code", () => {
+		const src = readFileSync(new URL("../remote-access-server.ts", import.meta.url), "utf8");
+		const body = src.slice(src.indexOf("export function assertStaticCodeStrongEnough"));
+		const fn = body.slice(0, body.indexOf("\n}\n") + 3);
+		expect(fn).toContain("process.env.DEV3_REMOTE_STATIC_CODE");
+		expect(fn).not.toContain("getStaticCode(");
+	});
+
+	it("never puts the code itself in the error message (it reaches the log)", () => {
+		process.env.DEV3_REMOTE_STATIC_CODE = "hunter2";
+		let message = "";
+		try {
+			assertStaticCodeStrongEnough();
+		} catch (err) {
+			message = String(err);
+		}
+		expect(message).toContain("at least 8 characters");
+		expect(message).not.toContain("hunter2");
 	});
 });
 

--- a/src/bun/__tests__/remote-auth-rate-limit.test.ts
+++ b/src/bun/__tests__/remote-auth-rate-limit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the /auth/exchange failure throttle. Time is injected, so no
+ * test sleeps and the window boundary is exercised exactly.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	AUTH_FAILURE_LIMIT,
+	AUTH_FAILURE_WINDOW_MS,
+	authAttemptRetryAfterS,
+	recordAuthFailure,
+	clearAuthFailures,
+	_resetAuthRateLimitForTests,
+} from "../remote-auth-rate-limit";
+
+const T0 = 1_000_000;
+
+beforeEach(() => {
+	_resetAuthRateLimitForTests();
+});
+
+describe("auth exchange throttle", () => {
+	it("allows attempts up to the limit, then blocks", () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) {
+			expect(authAttemptRetryAfterS("1.2.3.4", T0)).toBeNull();
+			recordAuthFailure("1.2.3.4", T0);
+		}
+		expect(authAttemptRetryAfterS("1.2.3.4", T0)).not.toBeNull();
+	});
+
+	it("reports a positive Retry-After that shrinks as the window drains", () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) recordAuthFailure("1.2.3.4", T0);
+		const first = authAttemptRetryAfterS("1.2.3.4", T0)!;
+		expect(first).toBeGreaterThan(0);
+		expect(first).toBeLessThanOrEqual(Math.ceil(AUTH_FAILURE_WINDOW_MS / 1000));
+		const later = authAttemptRetryAfterS("1.2.3.4", T0 + AUTH_FAILURE_WINDOW_MS / 2)!;
+		expect(later).toBeLessThan(first);
+	});
+
+	it("frees the key once the window has passed (a block is never permanent)", () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) recordAuthFailure("1.2.3.4", T0);
+		expect(authAttemptRetryAfterS("1.2.3.4", T0)).not.toBeNull();
+		expect(authAttemptRetryAfterS("1.2.3.4", T0 + AUTH_FAILURE_WINDOW_MS + 1)).toBeNull();
+	});
+
+	it("keeps buckets independent per key", () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) recordAuthFailure("1.2.3.4", T0);
+		expect(authAttemptRetryAfterS("1.2.3.4", T0)).not.toBeNull();
+		expect(authAttemptRetryAfterS("5.6.7.8", T0)).toBeNull();
+	});
+
+	it("a success wipes the record, so a typo does not linger", () => {
+		for (let i = 0; i < AUTH_FAILURE_LIMIT - 1; i++) recordAuthFailure("1.2.3.4", T0);
+		clearAuthFailures("1.2.3.4");
+		for (let i = 0; i < AUTH_FAILURE_LIMIT; i++) {
+			expect(authAttemptRetryAfterS("1.2.3.4", T0)).toBeNull();
+			recordAuthFailure("1.2.3.4", T0);
+		}
+	});
+
+	it("bounds a sustained attack to a low guess rate", () => {
+		// The property that makes an 8-char code hopeless rather than merely slow:
+		// over an hour, one key cannot exceed limit-per-window.
+		const hourMs = 60 * 60 * 1000;
+		let guesses = 0;
+		for (let now = T0; now < T0 + hourMs; now += 100) {
+			if (authAttemptRetryAfterS("1.2.3.4", now) === null) {
+				guesses++;
+				recordAuthFailure("1.2.3.4", now);
+			}
+		}
+		const ceiling = AUTH_FAILURE_LIMIT * (hourMs / AUTH_FAILURE_WINDOW_MS) + AUTH_FAILURE_LIMIT;
+		expect(guesses).toBeLessThanOrEqual(ceiling);
+	});
+});

--- a/src/bun/remote-access-server.ts
+++ b/src/bun/remote-access-server.ts
@@ -18,6 +18,8 @@ import { networkInterfaces } from "node:os";
 import QRCode from "qrcode";
 import type { RemoteNetInterface } from "../shared/types";
 import { NATIVE_STREAM_SINCE_PARAM, parseSinceParam } from "../shared/native-terminal-stream";
+import { remoteStaticCodeError } from "../shared/remote-static-code";
+import { authAttemptRetryAfterS, recordAuthFailure, clearAuthFailures } from "./remote-auth-rate-limit";
 import { PATHS } from "./electrobun-platform";
 import { createLogger } from "./logger";
 import { isCustomTunnelProviderActive } from "./tunnel-provider";
@@ -110,11 +112,17 @@ async function isSessionAuthenticated(req: Request): Promise<boolean> {
 interface AuthHandlerContext {
 	clientIp?: string;
 	ua?: string;
+	/**
+	 * Socket peer address, used as the throttle bucket for failed exchanges.
+	 * Deliberately NOT `clientIp`, which is read from headers a direct caller
+	 * controls and could rotate at will.
+	 */
+	rateLimitKey?: string;
 	onQrConsumed?: () => void;
 }
 
 /**
- * POST /auth/exchange — trade a one-time QR token (or the dev static code)
+ * POST /auth/exchange — trade a one-time QR token (or the static code)
  * for a session cookie. Exported for handler-level tests.
  */
 export async function handleAuthExchange(req: Request, ctx: AuthHandlerContext = {}): Promise<Response> {
@@ -122,6 +130,14 @@ export async function handleAuthExchange(req: Request, ctx: AuthHandlerContext =
 	if (!checkOrigin(req)) {
 		log.warn("Auth exchange: origin mismatch", { ip: clientIp, ua, origin: req.headers.get("origin") });
 		return new Response("Forbidden", { status: 403 });
+	}
+	// Throttle before the credential is even read: a static code is long-lived
+	// and multi-use by design, so an unthrottled endpoint makes it guessable.
+	const throttleKey = ctx.rateLimitKey ?? "unknown";
+	const retryAfterS = authAttemptRetryAfterS(throttleKey);
+	if (retryAfterS !== null) {
+		log.warn("Auth exchange: throttled", { ip: clientIp, ua, retryAfterS });
+		return new Response("Too many attempts", { status: 429, headers: { "Retry-After": String(retryAfterS) } });
 	}
 	try {
 		const body = await req.json() as { token?: string };
@@ -135,10 +151,12 @@ export async function handleAuthExchange(req: Request, ctx: AuthHandlerContext =
 		const staticCode = getStaticCode();
 		if (staticCode) {
 			if (body.token !== staticCode) {
+				recordAuthFailure(throttleKey);
 				log.warn("Auth exchange: invalid static code", { ip: clientIp, ua });
 				return new Response("Invalid or expired token", { status: 401 });
 			}
 			const sessionToken = await createSessionToken();
+			clearAuthFailures(throttleKey);
 			log.info("Auth exchange: static code accepted", { ip: clientIp, ua });
 			ctx.onQrConsumed?.();
 			return Response.json({ ok: true }, { headers: { "Set-Cookie": buildSessionCookie(sessionToken) } });
@@ -148,9 +166,11 @@ export async function handleAuthExchange(req: Request, ctx: AuthHandlerContext =
 			// Do NOT clear an existing cookie here: a consumed QR token replayed
 			// from browser history must not kill a still-valid session — the
 			// client falls back to /auth/refresh with that cookie.
+			recordAuthFailure(throttleKey);
 			log.warn("Auth exchange: invalid/expired QR token", { ip: clientIp, ua });
 			return new Response("Invalid or expired token", { status: 401 });
 		}
+		clearAuthFailures(throttleKey);
 		log.info("Auth exchange: success", { ip: clientIp, ua });
 		ctx.onQrConsumed?.();
 		return Response.json({ ok: true }, { headers: { "Set-Cookie": buildSessionCookie(sessionToken) } });
@@ -624,6 +644,7 @@ export function resolveListenPort(): number {
 }
 
 export async function startRemoteAccessServer(options: StartOptions): Promise<void> {
+	assertStaticCodeStrongEnough();
 	await initSecret();
 	requestHandler = options.rpcHandler;
 	ptyPortGetter = options.getPtyPort;
@@ -652,7 +673,11 @@ export async function startRemoteAccessServer(options: StartOptions): Promise<vo
 
 			// ── Auth endpoints (no session required) ──
 			if (url.pathname === "/auth/exchange" && req.method === "POST") {
-				return handleAuthExchange(req, { clientIp, ua, onQrConsumed: qrConsumedCallback ?? undefined });
+				// The throttle bucket is the socket peer, not `clientIp`: the
+				// headers `clientIp` comes from are set by the caller on a direct
+				// connection, so an attacker could mint a fresh budget per request.
+				const peer = server.requestIP(req)?.address || "unknown";
+				return handleAuthExchange(req, { clientIp, ua, rateLimitKey: peer, onQrConsumed: qrConsumedCallback ?? undefined });
 			}
 
 			if (url.pathname === "/auth/refresh" && req.method === "POST") {
@@ -936,6 +961,34 @@ export function resolveAccessHost(host?: string): string {
  */
 export function getStaticCode(): string | null {
 	return process.env.DEV3_REMOTE_STATIC_CODE || null;
+}
+
+/**
+ * Refuse to serve remote access on an ENV-supplied static code short enough to
+ * guess. Reads `process.env` directly, deliberately NOT `getStaticCode()`.
+ *
+ * Both CLI entry points reject a short code at flag-parse time, so reaching the
+ * server with one means the env var was set directly (Docker, a hand-written
+ * unit file, an exported shell). Those are unattended contexts where a log line
+ * goes unread, and silently downgrading to rotating QR tokens would break the
+ * caller's saved URL with a plain 401 — an outage that reads as "auth broken"
+ * rather than "your code is too short". So: throw, and name the cause.
+ *
+ * A code from any UI-editable source must NOT come through here. This runs as a
+ * top-level await on the app's boot path, so a typo in a settings field would
+ * take the whole app down with no way to fix it from inside the app. Such a
+ * source rejects the *value* — drop it, log it, surface the error in its own
+ * field — never the boot.
+ */
+export function assertStaticCodeStrongEnough(): void {
+	const code = process.env.DEV3_REMOTE_STATIC_CODE || null;
+	if (!code) return;
+	const problem = remoteStaticCodeError(code);
+	if (!problem) return;
+	throw new Error(
+		`DEV3_REMOTE_STATIC_CODE ${problem}. It is a long-lived, multi-use credential ` +
+		"fronting full terminal access; refusing to start remote access on a guessable code.",
+	);
 }
 
 export async function getAccessUrl(host?: string): Promise<string> {

--- a/src/bun/remote-auth-rate-limit.ts
+++ b/src/bun/remote-auth-rate-limit.ts
@@ -1,0 +1,71 @@
+/**
+ * Failure throttle for POST /auth/exchange.
+ *
+ * Only *failed* exchanges are counted, and a success clears the caller's
+ * record. A device that knows the code is therefore never delayed, no matter
+ * what an attacker is doing — that is what keeps this a throttle rather than a
+ * lockout, and it is why several devices can still enrol back to back.
+ *
+ * Keyed on the socket peer address supplied by the caller, never on
+ * X-Forwarded-For / CF-Connecting-IP: those are attacker-controlled on a direct
+ * connection, so keying on them would hand out a fresh budget per request.
+ * Behind a tunnel every request shares one peer address, so tunnel traffic
+ * shares one budget — deliberate; see the decision record
+ * `decisions/2026/08/28/throttle-remote-auth-exchange.md`.
+ */
+
+/** Failed exchanges allowed per key inside the window before 429s start. */
+export const AUTH_FAILURE_LIMIT = 5;
+
+/** Sliding window the failures are counted over. */
+export const AUTH_FAILURE_WINDOW_MS = 30_000;
+
+/** Hard cap on tracked keys, so a LAN attacker cannot grow the map forever. */
+const MAX_TRACKED_KEYS = 1_000;
+
+/** key → timestamps of recent failures, oldest first. */
+const failures = new Map<string, number[]>();
+
+function recent(key: string, now: number): number[] {
+	const times = failures.get(key);
+	if (!times) return [];
+	const cutoff = now - AUTH_FAILURE_WINDOW_MS;
+	const live = times.filter((t) => t > cutoff);
+	if (live.length === 0) failures.delete(key);
+	else failures.set(key, live);
+	return live;
+}
+
+/**
+ * Seconds the caller must wait before another exchange is even evaluated, or
+ * null when the attempt is allowed. Checked before the code is compared, so a
+ * throttled attacker learns nothing from the response.
+ */
+export function authAttemptRetryAfterS(key: string, now: number = Date.now()): number | null {
+	const live = recent(key, now);
+	if (live.length < AUTH_FAILURE_LIMIT) return null;
+	const freeAt = live[0] + AUTH_FAILURE_WINDOW_MS;
+	return Math.max(1, Math.ceil((freeAt - now) / 1000));
+}
+
+export function recordAuthFailure(key: string, now: number = Date.now()): void {
+	const live = recent(key, now);
+	live.push(now);
+	failures.set(key, live);
+	if (failures.size > MAX_TRACKED_KEYS) {
+		// Map iterates in insertion order: drop the least recently created keys.
+		for (const oldest of failures.keys()) {
+			failures.delete(oldest);
+			if (failures.size <= MAX_TRACKED_KEYS) break;
+		}
+	}
+}
+
+/** A correct code wipes the record — a typo must not linger into the next try. */
+export function clearAuthFailures(key: string): void {
+	failures.delete(key);
+}
+
+export function _resetAuthRateLimitForTests(): void {
+	failures.clear();
+}

--- a/src/cli/__tests__/remote-service.test.ts
+++ b/src/cli/__tests__/remote-service.test.ts
@@ -20,6 +20,7 @@ import {
 import { writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import type { ParsedArgs } from "../args";
+import { MIN_REMOTE_STATIC_CODE_LENGTH } from "../../shared/remote-static-code";
 
 function args(flags: Record<string, string> = {}, positional: string[] = []): ParsedArgs {
 	return { positional, flags };
@@ -72,8 +73,8 @@ describe("buildExecStartArgs", () => {
 	});
 
 	it("maps --port / --no-tunnel / --expose-ports / --static-code", () => {
-		const out = buildExecStartArgs(args({ port: "3017", "no-tunnel": "true", "expose-ports": "3000,5173", "static-code": "letmein" }));
-		expect(out).toEqual(["remote", "start", "--no-detach", "--port", "3017", "--no-tunnel", "--expose-ports=3000,5173", "--static-code=letmein"]);
+		const out = buildExecStartArgs(args({ port: "3017", "no-tunnel": "true", "expose-ports": "3000,5173", "static-code": "letmein1" }));
+		expect(out).toEqual(["remote", "start", "--no-detach", "--port", "3017", "--no-tunnel", "--expose-ports=3000,5173", "--static-code=letmein1"]);
 	});
 
 	it("forces --no-detach so systemd keeps the foreground process (never bare --detach)", () => {
@@ -87,11 +88,29 @@ describe("buildExecStartArgs", () => {
 		expect(stderrText()).toContain("--port must be an integer");
 	});
 
-	// F1: install-service must enforce the same ≥4 minimum that `remote start`
+	// F1: install-service must enforce the same minimum that `remote start`
 	// does — otherwise systemd Restart=on-failure loops forever on a too-short code.
-	it("rejects a static-code shorter than 4 chars (no silent systemd restart loop)", () => {
+	it("rejects a static-code shorter than the minimum (no silent systemd restart loop)", () => {
 		expect(() => buildExecStartArgs(args({ "static-code": "ab" }))).toThrow("__exit__");
-		expect(stderrText()).toContain("--static-code must be at least 4 characters");
+		expect(stderrText()).toContain(`--static-code must be at least ${MIN_REMOTE_STATIC_CODE_LENGTH} characters`);
+	});
+
+	// Literal 7/8: a boundary expressed via MIN_… would move with the constant and
+	// survive someone lowering it, which is exactly the regression to catch.
+	it("rejects a 7-character code — the minimum is pinned at 8", () => {
+		expect(MIN_REMOTE_STATIC_CODE_LENGTH).toBe(8);
+		expect(() => buildExecStartArgs(args({ "static-code": "abcdefg", "no-tunnel": "true" }))).toThrow("__exit__");
+		expect(buildExecStartArgs(args({ "static-code": "abcdefgh", "no-tunnel": "true" }))).toContain("--static-code=abcdefgh");
+	});
+
+	// Boundary, both sides — relative to the constant, so it keeps holding if the
+	// minimum is ever raised.
+	it("rejects one character below the minimum and accepts exactly the minimum", () => {
+		const tooShort = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH - 1);
+		expect(() => buildExecStartArgs(args({ "static-code": tooShort, "no-tunnel": "true" }))).toThrow("__exit__");
+
+		const exact = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH);
+		expect(buildExecStartArgs(args({ "static-code": exact, "no-tunnel": "true" }))).toContain(`--static-code=${exact}`);
 	});
 
 	// F7: systemd splits ExecStart on whitespace, so a code with a space would be
@@ -107,15 +126,15 @@ describe("buildExecStartArgs", () => {
 	});
 
 	it("accepts a valid static-code when paired with --no-tunnel", () => {
-		const out = buildExecStartArgs(args({ "static-code": "letmein", "no-tunnel": "true" }));
-		expect(out).toContain("--static-code=letmein");
+		const out = buildExecStartArgs(args({ "static-code": "letmein1", "no-tunnel": "true" }));
+		expect(out).toContain("--static-code=letmein1");
 		expect(out).toContain("--no-tunnel");
 	});
 
 	// Safety gate: a non-rotating static code must never front a default-on public
 	// tunnel — the unit would expose a guessable, replayable bearer code.
 	it("rejects --static-code without --no-tunnel (no static code on a public tunnel)", () => {
-		expect(() => buildExecStartArgs(args({ "static-code": "letmein" }))).toThrow("__exit__");
+		expect(() => buildExecStartArgs(args({ "static-code": "letmein1" }))).toThrow("__exit__");
 		expect(stderrText()).toContain("cannot be combined with a public tunnel");
 	});
 });

--- a/src/cli/__tests__/remote.test.ts
+++ b/src/cli/__tests__/remote.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { handleRemote, printAccessForState, computeDetachedChildArgs, awaitTunnelReady, isTunnelLive, REMOTE_TUNNEL_WAIT } from "../commands/remote";
 import type { ParsedArgs } from "../args";
+import { MIN_REMOTE_STATIC_CODE_LENGTH } from "../../shared/remote-static-code";
 
 /**
  * On the happy path `handleRemote` boots the headless server in-process via
@@ -236,10 +237,42 @@ describe("dev3 remote --static-code safety gate", () => {
 		});
 	});
 
-	it("still enforces the 4-char minimum", async () => {
+	it("still enforces the minimum length", async () => {
 		await withRemoteEnvRestored(async () => {
 			await expect(handleRemote(undefined, args({ "static-code": "ab", "no-tunnel": "true" }))).rejects.toThrow("__exit__");
-			expect(stderrText()).toContain("at least 4 characters");
+			expect(stderrText()).toContain(`at least ${MIN_REMOTE_STATIC_CODE_LENGTH} characters`);
+		});
+	});
+
+	// The code is a long-lived, multi-use bearer credential fronting a terminal,
+	// so its length is the whole search space. Literal 7/8, NOT the constant: a
+	// boundary written in terms of MIN_… moves with it and survives a lowering.
+	it("rejects a 7-character code — the minimum is pinned at 8", async () => {
+		expect(MIN_REMOTE_STATIC_CODE_LENGTH).toBe(8);
+		await withRemoteEnvRestored(async () => {
+			await expect(
+				handleRemote(undefined, args({ "static-code": "abcdefg", "no-tunnel": "true" })),
+			).rejects.toThrow("__exit__");
+		});
+		await withRemoteEnvRestored(async () => {
+			await handleRemote(undefined, args({ "static-code": "abcdefgh", "no-tunnel": "true", "no-detach": "true" }));
+			expect(process.env.DEV3_REMOTE_STATIC_CODE).toBe("abcdefgh");
+		});
+	});
+
+	it("rejects one character below the minimum and accepts exactly the minimum", async () => {
+		await withRemoteEnvRestored(async () => {
+			const tooShort = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH - 1);
+			await expect(
+				handleRemote(undefined, args({ "static-code": tooShort, "no-tunnel": "true" })),
+			).rejects.toThrow("__exit__");
+			expect(stderrText()).toContain(`at least ${MIN_REMOTE_STATIC_CODE_LENGTH} characters`);
+		});
+
+		await withRemoteEnvRestored(async () => {
+			const exact = "a".repeat(MIN_REMOTE_STATIC_CODE_LENGTH);
+			await handleRemote(undefined, args({ "static-code": exact, "no-tunnel": "true", "no-detach": "true" }));
+			expect(process.env.DEV3_REMOTE_STATIC_CODE).toBe(exact);
 		});
 	});
 });

--- a/src/cli/commands/remote-service.ts
+++ b/src/cli/commands/remote-service.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import type { ParsedArgs } from "../args";
 import { exitError, exitUsage } from "../output";
 import { rejectUnknownFlags } from "../flag-validation";
+import { remoteStaticCodeError } from "../../shared/remote-static-code";
 
 /**
  * `dev3 remote install-service` / `uninstall-service` — manage a **systemd
@@ -77,8 +78,9 @@ export function buildExecStartArgs(args: ParsedArgs): string[] {
 		// and enabled, but every `dev3 remote start` it spawns exits non-zero, and
 		// Restart=on-failure turns that into a silent restart loop (only visible in
 		// journalctl). Validate at install time instead.
-		if (code.length < 4) {
-			exitUsage(`--static-code must be at least 4 characters (got "${code}")`);
+		const problem = remoteStaticCodeError(code);
+		if (problem) {
+			exitUsage(`--static-code ${problem}`);
 		}
 		// systemd splits ExecStart on whitespace (no shell), so a code with spaces
 		// would be parsed as extra positional args and crash the server on every

--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -8,6 +8,7 @@ import { rejectUnknownFlags } from "../flag-validation";
 import { sendRequest } from "../socket-client";
 import { installRemoteService, uninstallRemoteService } from "./remote-service";
 import { CLI_EXIT_CODE_APP_NOT_RUNNING } from "../../shared/cli-exit-codes";
+import { MIN_REMOTE_STATIC_CODE_LENGTH, remoteStaticCodeError } from "../../shared/remote-static-code";
 import {
 	REMOTE_DIR,
 	REMOTE_LOG_FILE,
@@ -104,8 +105,9 @@ Flags (start):
   --static-code=<value>
       Use a fixed access code instead of a rotating short-lived JWT.
       The QR/URL token will be exactly <value>; auto-refresh is disabled.
-      For local dev only — do NOT expose a static code on the public
-      internet. Minimum length: 4 characters.
+      The code is long-lived and reusable, so several devices can enrol from
+      it — which also means it is worth guessing. Requires --no-tunnel, and
+      failed attempts are throttled. Minimum length: ${MIN_REMOTE_STATIC_CODE_LENGTH} characters.
 
 Connection options shown on startup:
   ① Public tunnel URL (Cloudflare quick tunnel, unless --no-tunnel)
@@ -190,8 +192,9 @@ function collectRemoteEnv(args: ParsedArgs): Record<string, string> {
 	}
 	if (args.flags["static-code"] && args.flags["static-code"] !== "true") {
 		const code = args.flags["static-code"];
-		if (code.length < 4) {
-			exitUsage(`--static-code must be at least 4 characters (got "${code}")`);
+		const problem = remoteStaticCodeError(code);
+		if (problem) {
+			exitUsage(`--static-code ${problem}`);
 		}
 		remoteEnv.DEV3_REMOTE_STATIC_CODE = code;
 	} else if (args.flags["static-code"] === "true") {

--- a/src/shared/remote-static-code.ts
+++ b/src/shared/remote-static-code.ts
@@ -1,0 +1,24 @@
+/**
+ * Validation shared by every entry point that can set a remote-access static
+ * code: the `dev3 remote` flag parser, the systemd unit writer, and the
+ * server's own startup check on DEV3_REMOTE_STATIC_CODE.
+ *
+ * The code is a long-lived, multi-use bearer credential fronting full terminal
+ * access — reuse is the feature — so its length is the entire search space an
+ * attacker has to cover. `/auth/exchange` throttles guesses; the length is what
+ * makes throttled guessing hopeless rather than merely slow.
+ */
+
+export const MIN_REMOTE_STATIC_CODE_LENGTH = 8;
+
+/**
+ * Human-readable reason the code is unusable, or null when it is fine.
+ * Reports the length rather than echoing the code — the same message is written
+ * to the server log, which the code itself must never reach.
+ */
+export function remoteStaticCodeError(code: string): string | null {
+	if (code.length < MIN_REMOTE_STATIC_CODE_LENGTH) {
+		return `must be at least ${MIN_REMOTE_STATIC_CODE_LENGTH} characters (got ${code.length})`;
+	}
+	return null;
+}


### PR DESCRIPTION
The static access code (`dev3 remote --static-code` / `DEV3_REMOTE_STATIC_CODE`) is a long-lived, multi-use credential by design — that reuse stays. What changes is that it can no longer be guessed.

**Minimum length 8** (was 4), behind one shared validator (`src/shared/remote-static-code.ts`) that the `dev3 remote` flag parser, the systemd unit writer and the server all call. A code set straight into the env below that is a hard startup failure, not a silent fallback to rotating QR tokens — the CLI paths already reject one, so reaching the server with a weak code means an unattended context where a log line goes unread and a plain 401 would read as "auth is broken". The error names the cause and never contains the code.

**Failed `/auth/exchange` attempts are throttled** (`src/bun/remote-auth-rate-limit.ts`): 5 per 30 s per key, then 429 with `Retry-After`, checked before the submitted credential is compared. Only failures count and a success clears the record, so several devices still enrol back to back and a typo costs nothing. The key is the socket peer address (`server.requestIP`), never `X-Forwarded-For` / `CF-Connecting-IP` — those are attacker-controlled on a direct connection, so keying on them would hand out a fresh budget per request. Behind a tunnel that means one shared bucket; the block always expires in 30 s and `/auth/refresh` stays unthrottled, so live sessions survive an attack and the owner cannot be locked out.

Rationale, trade-offs and rejected alternatives: `decisions/2026/08/28/throttle-remote-auth-exchange.md`.

Both protections are covered by tests that fail when the protection is removed — verified by mutation (lowering the constant to 4, and stubbing the throttle check to null).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=72631bbe-307a-43d5-892e-aba90cac5d0c) · `dev3://task/72631bbe-307a-43d5-892e-aba90cac5d0c`