### PR TITLE
Let a plain mouse wheel reach horizontal-only scroll containers

### DIFF
--- a/change-logs/2026/08/29/fix-plain-mouse-wheel-horizontal-scroll.md
+++ b/change-logs/2026/08/29/fix-plain-mouse-wheel-horizontal-scroll.md
@@ -1,0 +1,3 @@
+Short: Mouse wheel now scrolls the board
+
+A plain mouse has no horizontal axis, so horizontal-only containers were unreachable without a trackpad — the Kanban board simply would not move. A vertical wheel now scrolls sideways whenever nothing under the pointer can scroll vertically, which covers the board and the folder-picker breadcrumb; short sideways strips such as the contribution heatmap, the image thumbnail row and the model-catalog table opt in explicitly. Code blocks in pull-request and diff markdown now wrap instead of scrolling sideways.

--- a/decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md
+++ b/decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md
@@ -1,0 +1,50 @@
+# Giving a plain mouse wheel a way into horizontal-only scroll containers
+
+## Context
+
+The UI had been driven almost exclusively from a Mac trackpad. A trackpad's
+two-finger swipe arrives as a wheel event carrying `deltaX`; a plain mouse has
+no horizontal axis and can only ever produce `deltaY`. Chromium does not
+translate a vertical wheel onto a container that can only scroll sideways.
+
+## Investigation
+
+Driven in headless Chromium with `agent-browser mouse wheel`, which goes through
+CDP `Input.dispatchMouseEvent type=mouseWheel` and yields a trusted event
+`{deltaX: 0, deltaY: 120, deltaMode: 0, wheelDeltaY: -120}` — identical to a
+Windows or Linux notch. On the real board, 12 notches left `scrollLeft` at 0
+while 896px of columns sat off-screen; the same 12 events carrying a horizontal
+delta drove it to the end. A bare `overflow-x:auto; overflow-y:hidden` probe with
+no dev3 code behaved the same, confirming this is Chromium's own behaviour rather
+than a regression. `Shift`+wheel could not be tested at all: Chromium performs
+that mapping above `Input.dispatchMouseEvent`, proven with a two-axis control
+probe that moved vertically under `Shift`+wheel.
+
+## Decision
+
+One document-level bridge, `src/mainview/utils/horizontal-wheel.ts`, installed
+from `App.tsx`. `resolveHorizontalWheelTarget` walks from the event target to the
+root; the first vertically-scrollable ancestor wins and the event is left alone,
+otherwise the nearest horizontally-scrollable ancestor gets `scrollLeft += deltaY`
+and the event is consumed. Containers listed in `WHEEL_X_SELECTOR` — short,
+unmistakably sideways strips carrying `data-wheel-x`, plus markdown tables and
+mermaid diagrams — win on sight even when the page behind them scrolls. Code
+blocks in `.dev3-pr-md` wrap instead (`TaskDiffViewer.css`), matching the
+`overflow-wrap: anywhere` the surrounding document already uses.
+
+## Risks
+
+The opt-in list pins the page whenever the cursor rests on one of those strips.
+That is why prose containers are deliberately excluded: a code block inside a
+7600px diff would otherwise freeze the page every time the pointer crossed it.
+Wrapping code blocks is a visible rendering change to pull-request bodies and is
+reversible in one CSS declaration.
+
+## Alternatives considered
+
+Per-container `onWheel` handlers: same behaviour, repeated in a dozen components,
+and blind to markdown-generated DOM such as `<pre>` and `<table>`. An
+always-visible horizontal scrollbar: measured as ineffective — even an explicitly
+styled `::-webkit-scrollbar` reserved zero layout height in this Chromium, so the
+bar stays an overlay. Documenting the arrow keys, which move 40px per press:
+undiscoverable and 15 presses wide.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -16,6 +16,7 @@ import type { DeepLinkNav } from "../shared/deep-link";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 import { isRemote } from "./utils/platform";
 import { isTypingContext } from "./utils/typing-context";
+import { installHorizontalWheelBridge } from "./utils/horizontal-wheel";
 import { matchesShortcut } from "./keymap";
 import { setShortcutOverrides } from "./keymap-store";
 import { syncTerminalBidiFromGlobalSettings } from "./terminal-bidi/flag";
@@ -179,6 +180,10 @@ function App() {
 		// genuinely stale tmux copy-mode session.
 		skipNextTerminalCopyResetRef.current = false;
 	}, [terminalImmersiveVisible]);
+
+	// A plain mouse has no horizontal axis, so horizontal-only containers (the
+	// board above all) were unreachable without a trackpad.
+	useEffect(() => installHorizontalWheelBridge(), []);
 
 	useEffect(() => {
 		return () => {

--- a/src/mainview/components/FolderPickerModal.tsx
+++ b/src/mainview/components/FolderPickerModal.tsx
@@ -461,7 +461,7 @@ function FolderPickerModal({ options, onClose }: ModalProps) {
 					? "flex flex-col flex-1 min-h-[18rem]"
 					: "flex h-[min(36rem,80vh)] min-h-0"}>
 					{narrow ? (
-						<div data-testid="folder-picker-places-strip" className="flex gap-1.5 px-3 py-2 border-b border-edge bg-raised/40 overflow-x-auto flex-shrink-0">
+						<div data-testid="folder-picker-places-strip" data-wheel-x className="flex gap-1.5 px-3 py-2 border-b border-edge bg-raised/40 overflow-x-auto flex-shrink-0">
 							{quickPlaces.map((place) => {
 								const active = currentRoot === place.path;
 								return (

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -203,12 +203,19 @@
 	border-radius: 0.25rem;
 	padding: 0.0625rem 0.25rem;
 }
+/* Wraps rather than scrolls: a mouse has no horizontal axis, and stealing the
+   wheel for a code block would pin a long PR body every time the cursor crossed
+   one. The surrounding document already wraps (`overflow-wrap: anywhere`). */
 .dev3-pr-md pre {
 	background: rgb(var(--surface-base));
 	border: 1px solid rgb(var(--border-default));
 	border-radius: 0.5rem;
 	padding: 0.5rem 0.75rem;
-	overflow-x: auto;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+.dev3-pr-md pre code {
+	white-space: inherit;
 }
 .dev3-pr-md pre code {
 	background: transparent;

--- a/src/mainview/components/TaskImageViewer.tsx
+++ b/src/mainview/components/TaskImageViewer.tsx
@@ -394,6 +394,7 @@ export default function TaskImageViewer({ images, initialIndex, onClose, taskId,
 				{images.length > 1 && (
 					<div
 						ref={thumbStripRef}
+						data-wheel-x
 						className="flex-shrink-0 flex justify-center gap-2 overflow-x-auto px-4 py-3 border-t border-edge bg-raised"
 					>
 						{images.map((img, i) => {

--- a/src/mainview/components/UpdatePopoverSimulatorModal.tsx
+++ b/src/mainview/components/UpdatePopoverSimulatorModal.tsx
@@ -151,7 +151,7 @@ export default function UpdatePopoverSimulatorModal({ onClose }: { onClose: () =
 								)}
 
 								<div className="text-fg-3 text-xs font-medium pt-1">{t("updateSim.rawPayload")}</div>
-								<pre className="text-fg-2 text-micro font-mono bg-base rounded-lg p-3 overflow-x-auto">
+								<pre data-wheel-x className="text-fg-2 text-micro font-mono bg-base rounded-lg p-3 overflow-x-auto">
 									{JSON.stringify(preview.changelog, null, 2)}
 								</pre>
 							</div>

--- a/src/mainview/components/global-settings/AgentAccountsSection.tsx
+++ b/src/mainview/components/global-settings/AgentAccountsSection.tsx
@@ -286,7 +286,7 @@ function LoginFlowCard({
 		<div className="bg-base border border-accent/30 rounded-lg p-3 space-y-2.5">
 			<p className="text-fg-2 text-xs">{t("settings.accountsLoginHint")}</p>
 			<div className="flex items-center gap-1.5">
-				<code className="flex-1 bg-elevated border border-edge rounded px-2 py-1.5 text-xs font-mono text-fg overflow-x-auto whitespace-nowrap">
+				<code data-wheel-x className="flex-1 bg-elevated border border-edge rounded px-2 py-1.5 text-xs font-mono text-fg overflow-x-auto whitespace-nowrap">
 					{flow.loginCommand}
 				</code>
 				<button

--- a/src/mainview/components/global-settings/AgentSettingsSection.tsx
+++ b/src/mainview/components/global-settings/AgentSettingsSection.tsx
@@ -649,7 +649,7 @@ function CommandPreview({
 	const parts = command.split(/(\{\{\w+\}\})/g);
 
 	return (
-		<div className="bg-base border border-edge rounded-lg p-3 font-mono text-xs leading-relaxed overflow-x-auto">
+		<div data-wheel-x className="bg-base border border-edge rounded-lg p-3 font-mono text-xs leading-relaxed overflow-x-auto">
 			{envLine ? (
 				<div className="text-fg-3 mb-1">
 					<span className="text-fg-muted">env: </span>

--- a/src/mainview/components/global-settings/ModelCatalogSection.tsx
+++ b/src/mainview/components/global-settings/ModelCatalogSection.tsx
@@ -134,7 +134,7 @@ function EditTable({
 	children,
 }: { columns: string[]; actionsLabel: string; children: React.ReactNode }) {
 	return (
-		<div className="overflow-x-auto rounded-xl border border-edge bg-raised">
+		<div data-wheel-x className="overflow-x-auto rounded-xl border border-edge bg-raised">
 			<table className="w-full text-sm border-collapse">
 				<thead>
 					<tr className="border-b border-edge">

--- a/src/mainview/components/stats/ContributionHeatmap.tsx
+++ b/src/mainview/components/stats/ContributionHeatmap.tsx
@@ -73,7 +73,7 @@ export function ContributionHeatmap({ days, maxCount, legendLess, legendMore, to
 	}, [weeks]);
 
 	return (
-		<div ref={scrollRef} className="overflow-x-auto">
+		<div ref={scrollRef} data-wheel-x className="overflow-x-auto">
 			<div className="inline-flex flex-col gap-1">
 				{/* Month labels, column-aligned with the grid below. */}
 				<div

--- a/src/mainview/utils/__tests__/horizontal-wheel.test.ts
+++ b/src/mainview/utils/__tests__/horizontal-wheel.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { installHorizontalWheelBridge, resolveHorizontalWheelTarget } from "../horizontal-wheel";
+
+/** happy-dom reports zero for every layout box, so scroll metrics are stubbed. */
+function sized(el: HTMLElement, m: { sw?: number; cw?: number; sh?: number; ch?: number }) {
+	Object.defineProperty(el, "scrollWidth", { value: m.sw ?? 0, configurable: true });
+	Object.defineProperty(el, "clientWidth", { value: m.cw ?? 0, configurable: true });
+	Object.defineProperty(el, "scrollHeight", { value: m.sh ?? 0, configurable: true });
+	Object.defineProperty(el, "clientHeight", { value: m.ch ?? 0, configurable: true });
+	return el;
+}
+
+function make(overflowX: string, overflowY: string, m: Parameters<typeof sized>[1]) {
+	const el = document.createElement("div");
+	el.style.overflowX = overflowX;
+	el.style.overflowY = overflowY;
+	document.body.appendChild(el);
+	return sized(el, m);
+}
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	sized(document.body, { sw: 100, cw: 100, sh: 100, ch: 100 });
+	sized(document.documentElement, { sw: 100, cw: 100, sh: 100, ch: 100 });
+});
+
+describe("resolveHorizontalWheelTarget", () => {
+	it("hands a vertical delta to a horizontal-only container — the Kanban board", () => {
+		// overflow-x-auto + overflow-y-hidden, 572px of columns off-screen.
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		const card = document.createElement("div");
+		board.appendChild(sized(card, {}));
+
+		expect(resolveHorizontalWheelTarget(card, 120)).toBe(board);
+	});
+
+	it("refuses when an ancestor can scroll vertically — a wide code block inside the diff", () => {
+		const diff = make("auto", "auto", { sw: 1001, cw: 1001, sh: 7601, ch: 803 });
+		const pre = document.createElement("pre");
+		pre.style.overflowX = "auto";
+		pre.style.overflowY = "hidden";
+		diff.appendChild(sized(pre, { sw: 2616, cw: 860, sh: 39, ch: 39 }));
+
+		// The pre is horizontal-only, but the diff behind it owns the wheel.
+		expect(resolveHorizontalWheelTarget(pre, 120)).toBeNull();
+	});
+
+	it("refuses when the horizontal container is already at that edge", () => {
+		const strip = make("auto", "hidden", { sw: 900, cw: 500, sh: 40, ch: 40 });
+		strip.scrollLeft = 400;
+		expect(resolveHorizontalWheelTarget(strip, 120)).toBeNull();
+		expect(resolveHorizontalWheelTarget(strip, -120)).toBe(strip);
+	});
+
+	it("refuses a container whose overflow-x is hidden even when the content is wider", () => {
+		const clipped = make("hidden", "hidden", { sw: 2000, cw: 500, sh: 40, ch: 40 });
+		expect(resolveHorizontalWheelTarget(clipped, 120)).toBeNull();
+	});
+
+	it("lets an opted-in strip win over a scrolling page — the contribution heatmap", () => {
+		const page = make("hidden", "auto", { sw: 1600, cw: 1600, sh: 2800, ch: 917 });
+		const heatmap = document.createElement("div");
+		heatmap.setAttribute("data-wheel-x", "");
+		heatmap.style.overflowX = "auto";
+		heatmap.style.overflowY = "hidden";
+		page.appendChild(sized(heatmap, { sw: 1400, cw: 900, sh: 137, ch: 137 }));
+
+		expect(resolveHorizontalWheelTarget(heatmap, 120)).toBe(heatmap);
+	});
+
+	it("still gives the page the wheel when the opted-in strip has no room left", () => {
+		const page = make("hidden", "auto", { sw: 1600, cw: 1600, sh: 2800, ch: 917 });
+		const strip = document.createElement("div");
+		strip.setAttribute("data-wheel-x", "");
+		strip.style.overflowX = "auto";
+		strip.style.overflowY = "hidden";
+		page.appendChild(sized(strip, { sw: 1400, cw: 900, sh: 137, ch: 137 }));
+		strip.scrollLeft = 500;
+
+		expect(resolveHorizontalWheelTarget(strip, 120)).toBeNull();
+	});
+
+	it("returns null when nothing scrolls at all", () => {
+		const plain = make("visible", "visible", { sw: 500, cw: 500, sh: 40, ch: 40 });
+		expect(resolveHorizontalWheelTarget(plain, 120)).toBeNull();
+	});
+});
+
+describe("installHorizontalWheelBridge", () => {
+	let teardown: () => void;
+	afterEach(() => teardown?.());
+
+	/** happy-dom's WheelEvent silently drops `ctrlKey`, so it is defined by hand. */
+	function wheel(target: Element, init: WheelEventInit & { ctrlKey?: boolean }) {
+		const e = new WheelEvent("wheel", { bubbles: true, cancelable: true, ...init });
+		Object.defineProperty(e, "ctrlKey", { value: !!init.ctrlKey, configurable: true });
+		target.dispatchEvent(e);
+		return e;
+	}
+
+	it("scrolls the board sideways by the vertical delta and consumes the event", () => {
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+
+		const e = wheel(board, { deltaX: 0, deltaY: 120 });
+
+		expect(board.scrollLeft).toBe(120);
+		expect(e.defaultPrevented).toBe(true);
+	});
+
+	it("leaves a horizontal delta alone — the trackpad path is untouched", () => {
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+
+		const e = wheel(board, { deltaX: 120, deltaY: 0 });
+
+		expect(board.scrollLeft).toBe(0);
+		expect(e.defaultPrevented).toBe(false);
+	});
+
+	it("leaves ctrl+wheel alone so pinch-zoom keeps working", () => {
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+
+		const e = wheel(board, { deltaX: 0, deltaY: 120, ctrlKey: true });
+
+		expect(board.scrollLeft).toBe(0);
+		expect(e.defaultPrevented).toBe(false);
+	});
+
+	it("stops listening after teardown", () => {
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+		teardown();
+
+		wheel(board, { deltaX: 0, deltaY: 120 });
+
+		expect(board.scrollLeft).toBe(0);
+	});
+});

--- a/src/mainview/utils/horizontal-wheel.ts
+++ b/src/mainview/utils/horizontal-wheel.ts
@@ -1,0 +1,75 @@
+/**
+ * Gives a plain mouse wheel a way into horizontal-only scroll containers.
+ *
+ * A mouse has no horizontal axis — ever. Chromium does not translate a vertical
+ * wheel onto a container that can only scroll sideways, so surfaces like the
+ * Kanban board were literally unreachable with a mouse while a trackpad's
+ * two-finger swipe drove them fine.
+ *
+ * The rule is deliberately narrow: a vertical delta is handed to a horizontal
+ * container ONLY when nothing between the pointer and the page can scroll
+ * vertically. The moment a vertically-scrollable ancestor shows up it wins, so
+ * wheeling over a wide code block inside the diff still scrolls the diff — we
+ * never steal a wheel that already had a job.
+ */
+
+const SCROLLABLE_OVERFLOW = /auto|scroll|overlay/;
+
+/**
+ * Strips that want the wheel even though the page behind them scrolls: short,
+ * unmistakably sideways rows where "move this strip" is the only thing a wheel
+ * over them could sensibly mean. Prose containers are deliberately absent — a
+ * code block inside a long diff must not pin the page.
+ */
+export const WHEEL_X_SELECTOR = '[data-wheel-x], .dev3-pr-md table, .dev3-pr-md [data-streamdown="mermaid"] [role="application"]';
+
+function canScrollVertically(el: Element): boolean {
+	if (el.scrollHeight <= el.clientHeight + 1) return false;
+	return SCROLLABLE_OVERFLOW.test(getComputedStyle(el).overflowY);
+}
+
+function canScrollHorizontally(el: Element): boolean {
+	if (el.scrollWidth <= el.clientWidth + 1) return false;
+	return SCROLLABLE_OVERFLOW.test(getComputedStyle(el).overflowX);
+}
+
+/** Room left in the direction the wheel is asking for, in pixels. */
+function roomFor(el: Element, delta: number): number {
+	return delta > 0 ? el.scrollWidth - el.clientWidth - el.scrollLeft : el.scrollLeft;
+}
+
+/**
+ * The element a vertical wheel delta should scroll sideways, or `null` when the
+ * event belongs to the browser (something can scroll vertically, nothing can
+ * scroll horizontally, or the horizontal container is already at that edge).
+ */
+export function resolveHorizontalWheelTarget(start: Element | null, deltaY: number): HTMLElement | null {
+	let candidate: HTMLElement | null = null;
+	// The vertical check runs over the WHOLE chain, not just up to the first
+	// horizontal container: a wide `<pre>` sitting inside the scrolling diff must
+	// lose, or the page stops moving whenever the pointer rests on a code block.
+	// An opted-in strip is the exception and wins on sight.
+	for (let el: Element | null = start; el; el = el.parentElement) {
+		if (el.matches(WHEEL_X_SELECTOR) && canScrollHorizontally(el)) {
+			return roomFor(el, deltaY) > 0 ? (el as HTMLElement) : null;
+		}
+		if (canScrollVertically(el)) return null;
+		if (!candidate && canScrollHorizontally(el)) candidate = el as HTMLElement;
+	}
+	if (!candidate) return null;
+	return roomFor(candidate, deltaY) > 0 ? candidate : null;
+}
+
+/** Installs the bridge on `document`; returns the teardown. */
+export function installHorizontalWheelBridge(doc: Document = document): () => void {
+	function onWheel(e: WheelEvent) {
+		// A horizontal delta already works, and ctrl+wheel is zoom, not scroll.
+		if (e.deltaX !== 0 || e.deltaY === 0 || e.ctrlKey || e.defaultPrevented) return;
+		const target = resolveHorizontalWheelTarget(e.target as Element | null, e.deltaY);
+		if (!target) return;
+		target.scrollLeft += e.deltaY;
+		e.preventDefault();
+	}
+	doc.addEventListener("wheel", onWheel, { passive: false });
+	return () => doc.removeEventListener("wheel", onWheel);
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that ran the audit and wrote this branch).

The UI had been driven almost exclusively from a Mac trackpad. A trackpad swipe carries a horizontal wheel delta; a plain mouse has no horizontal axis at all, and Chromium does not translate a vertical wheel onto a container that can only scroll sideways. On the real board that meant 896 px of columns were unreachable with a mouse — twelve notches left `scrollLeft` at 0.

**What changed**

- New document-level bridge, `src/mainview/utils/horizontal-wheel.ts`, installed from `App.tsx`. A vertical delta is handed to the nearest horizontally-scrollable ancestor only when nothing between the pointer and the page can scroll vertically, so a wheel that already had a job is never stolen. Trackpad deltas and `ctrl`+wheel pass straight through.
- Short, unmistakably sideways strips opt in with `data-wheel-x` and win even over a scrolling page: contribution heatmap, image thumbnail row, folder-picker places strip, model-catalog table, the agent config and login-command blocks, the update-popover payload. Markdown tables and mermaid diagrams join them through `WHEEL_X_SELECTOR`.
- Code blocks in pull-request and diff markdown now wrap instead of scrolling sideways, matching the `overflow-wrap: anywhere` the surrounding document already used.

**Verified in a real browser**, driving Chromium with trusted `mouseWheel` events (`deltaX: 0, deltaY: 120, wheelDeltaY: -120`, identical to a Windows notch): the real board goes 0 → 598, its full range; the folder-picker breadcrumb 0 → 360; a wheel over a column's card list still scrolls that list and leaves the board still; `ctrl`+wheel leaves the board alone; the shipped CSS puts PR code blocks on `white-space: pre-wrap` with no horizontal overflow left.

One thing the audit could not settle: `shift`+wheel is untestable through CDP, because Chromium performs that mapping above `Input.dispatchMouseEvent` — proven with a two-axis control probe. So this branch does not rely on it.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=5218ced6-446d-4a9e-a895-aab2e2010a55) · `dev3://task/5218ced6-446d-4a9e-a895-aab2e2010a55`