### PR TITLE
Resume the conversation a pane was told to resume, not a new one

### DIFF
--- a/change-logs/2026/08/31/fix-resume-conversation-from-another-directory.md
+++ b/change-logs/2026/08/31/fix-resume-conversation-from-another-directory.md
@@ -1,0 +1,3 @@
+Short: Resuming keeps the right conversation
+
+Fix a pane whose conversation started in another directory silently getting a brand-new conversation on the first recovery. Such a transcript stays in its original directory's store, but the agent still creates an empty store directory for the task's own worktree — enough for the resume resolver to conclude the session was dead and fall back to starting fresh. It now records the conversation's origin directory and checks that store before healing.

--- a/decisions/2026/08/29/resume-checks-the-conversation-origin-store.md
+++ b/decisions/2026/08/29/resume-checks-the-conversation-origin-store.md
@@ -1,0 +1,82 @@
+# Resume checks the conversation's origin store
+
+## Context
+
+`verify-resume-session-id-against-transcripts.md` made resume self-healing: a
+stored id whose transcript is gone is replaced by the newest transcript for that
+worktree, and by the agent's own `--continue` when the store is empty. Its stated
+intent is that the resolver "never downgrades a resume it cannot check."
+
+A pane whose conversation began in a *different* directory defeats that intent
+without tripping any of its guards.
+
+## Investigation
+
+Measured against Claude Code 2.1.246. A session was created with cwd `A`, then
+resumed with `claude -p --resume <id>` from cwd `B`:
+
+- The conversation stayed in **A's** store — `<config>/projects/<encoded-A>/<id>.jsonl`
+  grew 107 612 → 127 456 bytes, with the new records stamped `"cwd":"<B>"`.
+  Resume is cwd-independent and never migrates the file.
+- `<config>/projects/<encoded-B>/` **was created**, containing only an empty
+  `memory/` subdirectory and no `.jsonl`.
+
+Re-measured on review against 2.1.236 (same result) and against 2.1.112, where
+the same id resumed from another cwd instead fails with `No conversation found
+with session ID` and exits 1, creating no store dir. So cwd-independent resume
+arrived somewhere between those two versions, and the trap only exists above it.
+
+That empty directory is the trap. In `resolveResumableSessionId`
+(`src/bun/agent-transcripts.ts`) the early-out `!store.dirs.some(existsSync)`
+does not fire, because the directory exists; `sessionIdsNewestFirst` returns
+`[]`; so the function reaches `ids[0] ?? null` and yields **null** — which the
+Claude adapter turns into `--continue`, which in a directory with no
+conversation starts a brand new one. The stored id was alive the whole time.
+
+Symptom: the pane launches correctly once, and the first recovery (app restart,
+hibernate/wake, pane relaunch) silently swaps the conversation for an empty one,
+leaving only a `log.warn`.
+
+## Decision
+
+`PaneSessionEntry.sessionOriginCwd` records the directory whose store holds the
+conversation, and `resolveResumableSessionId` takes an `originCwd` and checks
+that store before falling back. Absent on every pane whose session began where
+the task lives, so the healing behaviour is unchanged for them.
+
+The check sits *after* `ids.includes(stored)` deliberately: the task's own store
+is still the best answer when it has one, and a pane that later starts local
+sessions must not have them outrank the id it was told to resume.
+
+## Risks
+
+- **An older Claude Code turns this into a dead pane.** Below the version that
+  made resume cwd-independent, `--resume <foreign id>` from the worktree exits 1
+  and kills the pane — the failure
+  `verify-resume-session-id-against-transcripts.md` exists to prevent. dev3 does
+  not detect the agent's version, so whichever path eventually sets
+  `sessionOriginCwd` owns that risk and should keep the field off panes it cannot
+  vouch for.
+- **The field only survives if every `sessionState` write carries it.** That write
+  in `launchTaskPty` replaces pane[0] wholesale, so the entry is rebuilt on each
+  launch and resume; it now carries the origin forward while the resumed id is
+  unchanged, and drops it on a substituted id, which belongs to the local store.
+- **One more reverse-engineered behaviour.** The empty-`memory/` directory is not
+  documented and may stop being created. If it does, the earlier `existsSync`
+  guard starts firing and the stored id passes through untouched — the safe
+  direction, so the change degrades rather than breaks.
+- **Nothing sets the field yet.** `dev3 conversations import` does not resume, so
+  today this is a latent fix. It becomes load-bearing the moment any path resumes
+  a conversation that began outside the task's own worktree.
+
+## Alternatives considered
+
+- **Search every store dir for the id.** Removes the need for a stored field, but
+  turns an O(1) check into a scan of every project directory on the machine, and
+  a same-id collision across stores would resolve arbitrarily.
+- **Suppress healing entirely when the id came from elsewhere.** Simpler, but
+  gives up the repair the earlier record exists to provide — a genuinely dead
+  pointer would then kill the pane again.
+- **Persist the transcript path rather than the origin cwd.** The path moves
+  between config dirs (an agent account changes the store root); the cwd is what
+  every store keys on, so it survives that.

--- a/src/bun/__tests__/agent-transcripts.test.ts
+++ b/src/bun/__tests__/agent-transcripts.test.ts
@@ -23,6 +23,22 @@ function seedTranscript(sessionId: string, ageSeconds: number): void {
 	utimesSync(file, when, when);
 }
 
+/** Seed a transcript for an arbitrary working directory — a conversation's origin store. */
+function seedTranscriptFor(cwd: string, sessionId: string): void {
+	const dir = join(home, ".claude", "projects", claudeEncodePath(cwd));
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${sessionId}.jsonl`), `${JSON.stringify({ type: "assistant", cwd, sessionId })}\n`);
+}
+
+/**
+ * The worktree's own store as a pane resumed from elsewhere really finds it: the
+ * directory EXISTS (the agent creates it on resume) but holds no transcript,
+ * because the conversation stayed in the origin's store.
+ */
+function seedEmptyWorktreeStore(): void {
+	mkdirSync(join(transcriptDir(), "memory"), { recursive: true });
+}
+
 beforeEach(() => {
 	home = mkdtempSync(join(tmpdir(), "agent-transcripts-"));
 });
@@ -86,6 +102,38 @@ describe("resolveResumableSessionId", () => {
 			sessionId: null,
 			substituted: false,
 		});
+	});
+
+	it("keeps an id whose conversation lives in the origin store", () => {
+		// Without the origin lookup the empty-but-present worktree store yields
+		// null, which becomes `--continue`, which starts a BRAND NEW conversation
+		// and silently orphans the one the pane was resuming.
+		const origin = "/Users/dev/code/my-app";
+		seedEmptyWorktreeStore();
+		seedTranscriptFor(origin, "elsewhere-1");
+
+		expect(
+			resolveResumableSessionId("claude", WORKTREE, "elsewhere-1", home, undefined, origin),
+		).toEqual({ sessionId: "elsewhere-1", substituted: false });
+	});
+
+	it("does not let a later local session hijack an id from the origin store", () => {
+		const origin = "/Users/dev/code/my-app";
+		seedTranscript("local-session", 10);
+		seedTranscriptFor(origin, "elsewhere-1");
+
+		expect(
+			resolveResumableSessionId("claude", WORKTREE, "elsewhere-1", home, undefined, origin),
+		).toEqual({ sessionId: "elsewhere-1", substituted: false });
+	});
+
+	it("still heals when the origin store has lost the conversation too", () => {
+		seedTranscript("survivor", 10);
+		seedEmptyWorktreeStore();
+
+		expect(
+			resolveResumableSessionId("claude", WORKTREE, "gone", home, undefined, "/Users/dev/code/my-app"),
+		).toEqual({ sessionId: "survivor", substituted: true });
 	});
 });
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -10472,6 +10472,60 @@ describe("launchTaskPty", () => {
 		}
 	});
 
+	// This write replaces pane[0] wholesale, so it is the one place an origin
+	// store can silently disappear — after which resume resolves the id against
+	// an empty worktree store and starts a brand new conversation instead.
+	describe("sessionOriginCwd across the sessionState rewrite", () => {
+		const ORIGIN = "/Users/dev/code/my-app";
+		const withOrigin = () => makeTask({
+			sessionState: {
+				panes: [{
+					agentCmd: "claude",
+					sessionId: "from-elsewhere",
+					agentId: "builtin-claude",
+					configId: "claude-default",
+					sessionOriginCwd: ORIGIN,
+				}],
+			},
+		});
+		const persistedPane = () => {
+			const call = vi.mocked(data.updateTask).mock.calls.find(([, , updates]) => (updates as any)?.sessionState);
+			return (call?.[2] as any)?.sessionState?.panes?.[0];
+		};
+
+		it("carries the origin store forward when the same id is resumed", async () => {
+			const task = withOrigin();
+			mockTaskWrites(task);
+
+			await launchTaskPty(makeProject(), task, "/tmp/wt", "builtin-claude", "claude-default", false, true, {
+				sessionId: "from-elsewhere",
+			});
+
+			expect(persistedPane()).toMatchObject({ sessionId: "from-elsewhere", sessionOriginCwd: ORIGIN });
+		});
+
+		it("drops the origin store when the resolver substituted a different id", async () => {
+			const task = withOrigin();
+			mockTaskWrites(task);
+
+			await launchTaskPty(makeProject(), task, "/tmp/wt", "builtin-claude", "claude-default", false, true, {
+				sessionId: "healed-local",
+			});
+
+			expect(persistedPane()).toMatchObject({ sessionId: "healed-local" });
+			expect(persistedPane()?.sessionOriginCwd).toBeUndefined();
+		});
+
+		it("leaves a fresh launch without an origin store", async () => {
+			const task = withOrigin();
+			mockTaskWrites(task);
+
+			await launchTaskPty(makeProject(), task, "/tmp/wt", "builtin-claude", "claude-default");
+
+			expect(persistedPane()?.sessionOriginCwd).toBeUndefined();
+		});
+	});
+
 	it("throws without creating a PTY session when command resolution fails", async () => {
 		const project = makeProject();
 		const task = makeTask();

--- a/src/bun/agent-transcripts.ts
+++ b/src/bun/agent-transcripts.ts
@@ -66,6 +66,9 @@ export function resolveResumableSessionId(
 	storedSessionId: string | null | undefined,
 	home: string = resolveUserHome(),
 	family?: AgentFamily,
+	/** The directory whose store actually holds this pane's conversation, when it
+	 *  is not the task's own. Checked before healing. */
+	originCwd?: string | null,
 ): ResumeTarget {
 	const stored = storedSessionId ?? null;
 	const store = storeFor(agentCmd, worktreePath, home, family);
@@ -74,6 +77,20 @@ export function resolveResumableSessionId(
 
 	const ids = sessionIdsNewestFirst(store.dirs, store.ext);
 	if (ids.includes(stored)) return { sessionId: stored, substituted: false };
+
+	// A conversation that began elsewhere never migrates into this worktree's
+	// store: a resume appends to the original file and only stamps the new cwd
+	// into the new records. The agent DOES create the worktree's store directory
+	// though — empty, holding just `memory/` — so the early-out above sees a
+	// store that exists, finds no ids in it, and would heal a live id to null,
+	// i.e. `--continue`, i.e. a brand new conversation.
+	if (originCwd) {
+		const origin = storeFor(agentCmd, originCwd, home, family);
+		if (origin && sessionIdsNewestFirst(origin.dirs, origin.ext).includes(stored)) {
+			return { sessionId: stored, substituted: false };
+		}
+	}
+
 	return { sessionId: ids[0] ?? null, substituted: true };
 }
 

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -722,6 +722,13 @@ export async function launchTaskPty(
 		if (!skipSessionPersist) {
 			const effectiveSessionId = resume ? sessionId
 				: (agents.supportsPreAssignedSessionId(resolvedBaseCmd, resolvedAgentFamily) ? freshSessionId : null);
+			// This write replaces pane[0] wholesale, so an origin store the resolver
+			// still needs has to be carried across it. It belongs to one specific id:
+			// a substituted id was found in this worktree's own store, so it drops.
+			const priorMain = task.sessionState?.panes?.[0];
+			const carriedOriginCwd = resume && effectiveSessionId && effectiveSessionId === priorMain?.sessionId
+				? priorMain.sessionOriginCwd ?? undefined
+				: undefined;
 			const paneEntry = {
 				agentCmd: resolvedBaseCmd,
 				sessionId: effectiveSessionId ?? null,
@@ -729,6 +736,7 @@ export async function launchTaskPty(
 				configId: configId ?? task.configId,
 				accountId: task.accountId,
 				agentFamily: resolvedAgentFamily,
+				sessionOriginCwd: carriedOriginCwd,
 			};
 			mainPaneEntry = paneEntry;
 			const sessionState = { panes: [paneEntry] };
@@ -1631,6 +1639,7 @@ function resolveResumeTarget(task: Task, pane: PaneSessionEntry, label: string):
 		pane.sessionId,
 		undefined,
 		pane.agentFamily ?? undefined,
+		pane.sessionOriginCwd,
 	);
 	if (target.substituted) {
 		log.warn("Stored session id has no transcript — resuming the newest conversation instead", {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2870,6 +2870,12 @@ export interface PaneSessionEntry {
 	 *  carrying the task description. Absent on panes stored by older versions,
 	 *  which fall back to the command-name guess. */
 	agentFamily?: AgentFamily | null;
+	/** For a pane whose conversation started in ANOTHER directory: the directory it
+	 *  started in. Its transcript stays in that directory's store forever — a resume
+	 *  appends to the original file and only stamps the new cwd into new records — so
+	 *  recovery must look there, not in the task's own worktree store. Absent on every
+	 *  pane whose session began where the task lives. */
+	sessionOriginCwd?: string | null;
 }
 
 /** Captured session state for agent recovery after tmux death / app restart. */


### PR DESCRIPTION
Picking up the first of the two pieces suggested on #1541.

A pane whose conversation began in a **different directory** than the task's worktree loses that conversation on its first recovery. `#1587` never hits this because it does not resume imported conversations, but the bug is live on `main` for any pane in that shape.

## What happens

Measured against Claude Code 2.1.246 — a session created with cwd `A`, then resumed from cwd `B`:

- The conversation stays in **A's** store. `<config>/projects/<encoded-A>/<id>.jsonl` grew 107 612 → 127 456 bytes, and the new records carry `"cwd":"<B>"`. Resume is cwd-independent and never migrates the file.
- `<config>/projects/<encoded-B>/` **is created anyway** — containing only an empty `memory/` and no `.jsonl`.

That empty directory is what does the damage. In `resolveResumableSessionId`:

```
!store.dirs.some(existsSync)   → does not fire; the directory exists
sessionIdsNewestFirst(...)     → []
ids[0] ?? null                 → null
```

and `null` is `--continue`, which in a directory with no conversation starts a brand new one. The stored id was alive the whole time.

So the pane launches correctly once, and the first app restart / hibernate-wake / pane relaunch silently swaps the conversation for an empty one, leaving a `log.warn` as the only trace.

## The fix

`PaneSessionEntry.sessionOriginCwd` records the directory whose store holds the conversation, and the resolver checks that store before falling back. Absent on every pane whose session began where the task lives, so healing is unchanged for them.

The check sits **after** `ids.includes(stored)` deliberately: the task's own store is still the best answer when it has one, and a pane that later starts local sessions must not have them outrank the id it was told to resume. That ordering is the second test.

This extends `decisions/2026/08/01/verify-resume-session-id-against-transcripts.md` rather than contradicting it — its stated intent is that the resolver "never downgrades a resume it cannot check", and this is a case where the store *looks* checkable but is not. Reasoning recorded in `decisions/2026/08/29/resume-checks-the-conversation-origin-store.md`.

## Honest scope

**Nothing sets the field yet.** `dev3 conversations import` does not resume, so today this is a latent fix. It becomes load-bearing the moment any path resumes a conversation that began outside the task's own worktree — which is exactly what the `dev3 import` piece would do.

Both new tests fail without the change: one with the orphaning (`sessionId: null`), one with a later local session hijacking the id.

## Verifying

```
mkdir -p /tmp/d3t && export TMPDIR=/tmp/d3t
bunx vitest run --config vitest.config.bun.ts   # 7538/7538, 441 files
bunx vitest run --config vitest.config.cli.ts   #   985/985,  52 files
bunx vitest run --config vitest.config.ts       #  4998/4998, 318 files
```

Sequential and with a short `TMPDIR` on purpose: `bun run test` runs the three configs concurrently, and on a loaded machine that produces timeout-shaped failures that look like regressions. The default `/var/folders/…` path also pushes unix socket paths past the macOS 104-char limit.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=01f966d1-a8db-47a2-b211-aafd0d44c0b9) · `dev3://task/01f966d1-a8db-47a2-b211-aafd0d44c0b9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qxk78djwJDoFb8ZdHVpsk5
