### PR TITLE
Compact the agent usage panel and fix its cut-off bars

### DIFF
--- a/change-logs/2026/08/29/fix-compact-agent-usage-panel.md
+++ b/change-logs/2026/08/29/fix-compact-agent-usage-panel.md
@@ -1,0 +1,3 @@
+Short: Agent usage panel fits without scrolling
+
+The header rate-limit panel is about half as tall: each limit window is now one dense "label · bar · % · resets in" line instead of text stacked over a full-width bar, the capture age rides that line instead of taking its own, an account with no reading says so on its headline, and the oversized Account settings button at the bottom became a link in the panel's header row. Usage bars inside a card also render full width again in the desktop app, and a long workspace name now elides instead of pushing the plan and Default chips off the panel's right edge.

--- a/decisions/2026/08/29/compact-the-agent-usage-panel.md
+++ b/decisions/2026/08/29/compact-the-agent-usage-panel.md
@@ -1,0 +1,52 @@
+# Compact the agent usage panel
+
+## Context
+
+`decisions/2026/08/29/default-account-switch-lives-in-the-usage-flyout.md` turned the header
+rate-limit tooltip into a panel that lists **every** Claude and Codex account, not just the ones
+with a reading. The card design was inherited from the old tooltip, which never showed more than
+a couple of cards. With nine accounts the panel measured 840px against a 448px flyout — the user
+saw a scrollbar, half the accounts below the fold, and a 46px sticky "Account settings" button
+eating the bottom of a panel that was already short of room.
+
+## Investigation
+
+Two rendering bugs made it worse, both invisible in Chromium:
+
+- Every usage bar inside a card rendered at ~40% width in the desktop app. The card is a
+  `<button>` with `display: flex; flex-direction: column`, and WebKit's UA stylesheet sets
+  `align-items: flex-start` on `button` — so each row shrank to its own text width. Chromium does
+  not, which is why the browser QA pass showed full-width bars.
+- `AccountCardHeader` held the workspace name at its natural width (`whitespace-nowrap shrink-0`),
+  so a long one pushed the plan and "Default" chips past the panel's `overflow-x-hidden` edge
+  instead of eliding.
+
+## Decision
+
+Density, not fewer facts — nothing was dropped from the panel.
+
+- `WindowBarRow` (`src/mainview/components/rate-limit-ui.tsx`) is one dense
+  `label · bar · % · resets in` line, the same grammar the launch account picker already uses.
+- Capture age rides the last quota line as a `· 15h` suffix (`CapturedAgeSuffix`); the standalone
+  `CapturedNote` is deleted. `hasQuotaLines()` puts the age on the headline for a reading with
+  nothing to plot (an unlimited account).
+- An account with no reading says "no recent data" on its headline instead of on a second line.
+- `ACCOUNT_CARD_CLASS` carries an explicit `items-stretch`, and the panel container uses `p-1.5`
+  so the cards' `rounded-md` is concentric with the flyout's `rounded-xl`.
+- The sticky footer button is gone; "Account settings" is a text link sharing the panel's header
+  row with the hint, whose copy shrank to one line in all three locales.
+
+Measured on a nine-account board: 840px → 425px, no scrollbar.
+
+## Risks
+
+The WebKit fix is verified by geometry, not by running WebKit — browser QA here is Chromium, where
+the bug never reproduced. `items-stretch` is the correct explicit value in every engine, so the
+worst case is that it fixes nothing rather than that it breaks something.
+
+## Alternatives considered
+
+Raising `HeaderFlyoutPanel`'s `maxHeight` — it is shared with the memory-headroom readout, and a
+taller panel still wastes the same space per account. Hiding accounts with no reading behind a
+"show all" toggle — the panel exists to compare accounts, and the switchable set must be visible
+to be switchable.

--- a/src/mainview/components/AgentUsagePanel.tsx
+++ b/src/mainview/components/AgentUsagePanel.tsx
@@ -10,8 +10,10 @@ import {
 	ACCOUNT_CARD_CLASS,
 	AccountCardHeader,
 	AccountQuotaLines,
+	CapturedAgeSuffix,
 	SOURCE_NAMES,
 	type AccountLine,
+	hasQuotaLines,
 	resolveAccount,
 } from "./rate-limit-ui";
 
@@ -174,7 +176,7 @@ function UsageRowCard({
 				row.isDefault ? "border-accent/50" : ""
 			} ${inert ? "cursor-default" : "cursor-pointer hover:bg-elevated-hover"} transition-colors`}
 		>
-			<div className="flex items-center gap-2">
+			<div className="flex items-center gap-1.5">
 				<span
 					aria-hidden
 					className={`w-3 h-3 rounded-full border-2 shrink-0 ${
@@ -192,16 +194,20 @@ function UsageRowCard({
 					<span className="text-fg-3 text-micro px-1 py-px bg-raised rounded shrink-0">{row.chip}</span>
 				) : null}
 				{row.isDefault ? (
-					<span className="text-success text-micro px-1.5 py-0.5 bg-success/15 rounded shrink-0">
+					<span className="text-success text-micro px-1 py-px bg-success/15 rounded shrink-0">
 						{t("settings.accountsActive")}
 					</span>
 				) : null}
+				{/* An account with nothing to plot says so on its headline instead of
+				    spending a whole second line on three muted words. */}
+				{!row.snap ? <span className="text-fg-muted text-micro shrink-0">{t("rateLimits.noRecentData")}</span> : null}
+				{row.snap && !hasQuotaLines(row.snap) ? (
+					<span className="shrink-0 tabular-nums">
+						<CapturedAgeSuffix capturedAt={row.snap.capturedAt} now={now} />
+					</span>
+				) : null}
 			</div>
-			{row.snap ? (
-				<AccountQuotaLines snap={row.snap} now={now} />
-			) : (
-				<span className="text-fg-muted">{t("rateLimits.noRecentData")}</span>
-			)}
+			{row.snap && hasQuotaLines(row.snap) ? <AccountQuotaLines snap={row.snap} now={now} /> : null}
 		</button>
 	);
 }
@@ -285,19 +291,33 @@ export default function AgentUsagePanel({
 	};
 
 	return (
-		<div className="p-3 space-y-3 text-xs">
-			<p className="text-fg-3 leading-snug">
-				{interactive ? t("rateLimits.panelSubtitle") : t("rateLimits.pinToSwitch")}
-			</p>
+		// p-1.5 (6px) inside the flyout's rounded-xl (12px) makes the cards'
+		// rounded-md (6px) concentric with the panel's own corners.
+		<div className="p-1.5 space-y-1.5 text-xs">
+			{/* Hint and the way out share one line. The way out used to be a
+			    full-width bordered button pinned to the bottom on its own sticky
+			    strip — 46px of chrome for a link nobody opens twice. */}
+			<div className="flex items-baseline gap-2 px-2 pt-0.5 pb-0.5">
+				<p className="min-w-0 flex-1 text-fg-3 leading-snug">
+					{interactive ? t("rateLimits.panelSubtitle") : t("rateLimits.pinToSwitch")}
+				</p>
+				<button
+					type="button"
+					onClick={onOpenSettings}
+					className="shrink-0 rounded text-accent hover:text-accent-emphasis active:scale-[0.96] transition-[color,scale]"
+				>
+					{t("rateLimits.manageAccounts")}
+				</button>
+			</div>
 			{blocks.map((block) => {
 				// One tab stop per group: the current default, or the first row.
 				const stop = block.rows.find((row) => row.isDefault) ?? block.rows[0];
 				return (
-					<div key={block.kind} className="space-y-1.5">
-						<div className="text-fg-2 font-semibold uppercase tracking-wider">
+					<div key={block.kind} className="space-y-1">
+						<div className="px-2 text-fg-muted text-micro font-semibold uppercase tracking-wider">
 							{SOURCE_NAMES[block.kind] ?? block.kind}
 						</div>
-						<div role="radiogroup" aria-label={SOURCE_NAMES[block.kind] ?? block.kind} className="space-y-1.5">
+						<div role="radiogroup" aria-label={SOURCE_NAMES[block.kind] ?? block.kind} className="space-y-1">
 							{block.rows.map((row, index) => (
 								<UsageRowCard
 									key={row.key}
@@ -320,17 +340,6 @@ export default function AgentUsagePanel({
 					</div>
 				);
 			})}
-			{/* Sticky, because a user with several accounts scrolls past the fold and
-			    the way out of this panel must not be the thing below it. */}
-			<div className="sticky bottom-0 -mx-3 -mb-3 px-3 pb-3 pt-2 bg-overlay">
-				<button
-					type="button"
-					onClick={onOpenSettings}
-					className="w-full px-3 py-1.5 rounded-lg border border-edge text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
-				>
-					{t("rateLimits.manageAccounts")}
-				</button>
-			</div>
 		</div>
 	);
 }

--- a/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
+++ b/src/mainview/components/__tests__/AgentAccountIndicator.test.tsx
@@ -304,7 +304,7 @@ describe("AgentAccountIndicator", () => {
 
 		// System login is unlimited; the managed account has no snapshot at all.
 		expect(await screen.findByText("∞ unlimited")).toBeTruthy();
-		expect(screen.getByText("no recent usage data")).toBeTruthy();
+		expect(screen.getByText("no recent data")).toBeTruthy();
 	});
 
 	it("shows reset countdowns and the captured note inline", async () => {
@@ -379,7 +379,7 @@ describe("AgentAccountIndicator", () => {
 		await user.click(await screen.findByTestId("agent-account-trigger"));
 		await screen.findByText("34% used"); // system row has data…
 		// …but the API row gets neither bars nor a misleading "no data" note.
-		expect(screen.queryByText("no recent usage data")).toBeNull();
+		expect(screen.queryByText("no recent data")).toBeNull();
 	});
 
 	it("exposes the popover as a keyboard-reachable radio menu", async () => {

--- a/src/mainview/components/__tests__/AgentUsagePanel.test.tsx
+++ b/src/mainview/components/__tests__/AgentUsagePanel.test.tsx
@@ -98,7 +98,7 @@ describe("AgentUsagePanel", () => {
 		expect(screen.getByText("Work Claude")).toBeTruthy();
 		expect(screen.getByText("Home Claude")).toBeTruthy();
 		expect(screen.getByText("42% used")).toBeTruthy();
-		expect(screen.getAllByText("no recent usage data").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("no recent data").length).toBeGreaterThan(0);
 	});
 
 	it("marks the current default and leaves it inert", async () => {
@@ -130,7 +130,7 @@ describe("AgentUsagePanel", () => {
 
 	it("stays read-only until the panel is pinned", async () => {
 		renderPanel(accounts(), false);
-		expect(screen.getByText(/Click the pill to pin this panel/)).toBeTruthy();
+		expect(screen.getByText(/Click the pill to pin/)).toBeTruthy();
 		// The row a hovering pointer would land on: live in the pinned panel, inert here.
 		const home = screen.getAllByRole("radio").find((r) => r.textContent?.includes("Home Claude"));
 		expect(home?.getAttribute("aria-disabled")).toBe("true");

--- a/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
+++ b/src/mainview/components/__tests__/RateLimitIndicator.test.tsx
@@ -303,7 +303,9 @@ describe("RateLimitIndicator", () => {
 		renderIndicator();
 		await act(async () => {});
 		await openUsagePanel();
-		expect(await screen.findByText("captured just now")).toBeTruthy();
+		// Provenance rides the last quota line as a "· now" suffix; the full
+		// sentence is its title.
+		expect(await screen.findByTitle("captured just now")).toBeTruthy();
 	});
 
 	it("flags a stale reading with its age and the warning tint", async () => {
@@ -326,7 +328,7 @@ describe("RateLimitIndicator", () => {
 		renderIndicator();
 		await act(async () => {});
 		await openUsagePanel();
-		const note = await screen.findByText("captured 20m ago");
+		const note = await screen.findByTitle("captured 20m ago");
 		expect(note.className).toContain("text-warning");
 	});
 

--- a/src/mainview/components/rate-limit-ui.tsx
+++ b/src/mainview/components/rate-limit-ui.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useLocale, useT } from "../i18n";
 import type { AgentRateLimitSnapshot, RateLimitSource, RateLimitWindow } from "../../shared/rate-limits";
 import {
@@ -107,43 +108,54 @@ export function UsageBar({ percent, className }: { percent: number; className: s
 	);
 }
 
-/** One limit window inside an account card: label + reset + percent over a bar. */
+/**
+ * One limit window as a single dense line: `label · bar · % · reset`, the same
+ * grammar the launch account picker uses. It replaced a two-line "text over a
+ * full-width bar" block — two windows plus a provenance line made every account
+ * card ~90px tall, so a handful of accounts could not be compared without
+ * scrolling the panel.
+ */
 export function WindowBarRow({
 	label,
 	usedPercent,
 	resetsAt,
 	now,
 	detail,
+	trailing,
 }: {
 	label: string;
 	usedPercent: number;
 	resetsAt: number | null;
 	now: number;
 	detail?: string;
+	/** Rides the last line of a card (capture age), instead of its own line. */
+	trailing?: ReactNode;
 }) {
 	const t = useT();
 	const percent = Math.round(usedPercent);
 	const reset = formatResetDelta(resetsAt, now);
 	return (
 		<div className="flex flex-col gap-[0.1875rem]">
-			<div className="flex items-baseline gap-2">
-				<span className="min-w-0 truncate font-medium text-fg-3">{label}</span>
-				{reset && (
-					<span className="ml-auto shrink-0 tabular-nums text-fg-muted">{t("rateLimits.resetsIn", { time: reset })}</span>
-				)}
-				<span className={`shrink-0 font-medium tabular-nums ${reset ? "" : "ml-auto"} ${severityText(percent)}`}>
-					{t("rateLimits.percentUsed", { percent })}
+			<div className="flex items-center gap-1.5">
+				<span className="min-w-[1.5rem] shrink-0 font-medium tabular-nums text-fg-3">{label}</span>
+				<UsageBar percent={usedPercent} className="h-1 min-w-[3rem] flex-1" />
+				<span className="shrink-0 whitespace-nowrap tabular-nums">
+					<span className={`font-semibold ${severityText(percent)}`}>{t("rateLimits.percentUsed", { percent })}</span>
+					{reset && <span className="text-fg-3"> · {t("rateLimits.resetsIn", { time: reset })}</span>}
+					{trailing}
 				</span>
 			</div>
-			<UsageBar percent={usedPercent} className="h-1.5 w-full" />
 			{detail && <span className="text-fg-muted">{detail}</span>}
 		</div>
 	);
 }
 
 /** Shared card chrome, so surfaces that have an account but no usage reading
- *  (the usage modal) render an identical-looking card. */
-export const ACCOUNT_CARD_CLASS = "flex flex-col gap-1.5 rounded-md border border-edge bg-raised/65 px-2.5 py-2";
+ *  (the usage panel) render an identical-looking card. `items-stretch` is not
+ *  redundant: WebKit's UA stylesheet centres a <button>'s flex children, which
+ *  shrank every usage bar inside one to its own text width. */
+export const ACCOUNT_CARD_CLASS =
+	"flex flex-col items-stretch gap-1 rounded-md border border-edge bg-raised/65 px-2 py-1";
 
 /** Card headline: provider name, account identity, plan/API chips. */
 export function AccountCardHeader({
@@ -171,7 +183,9 @@ export function AccountCardHeader({
 		<div className="flex items-center gap-1.5">
 			<span className="text-fg-2 font-medium shrink-0">{SOURCE_NAMES[source] ?? source}</span>
 			{displayName && <span className="min-w-0 truncate text-fg-3 streamer-private">{displayName}</span>}
-			{showOrg && <span className="text-fg-muted whitespace-nowrap shrink-0 streamer-private">· {account?.organization}</span>}
+			{/* The workspace shrinks too. Held at its natural width it pushed the plan
+			    and "Default" chips off the panel's right edge instead of eliding. */}
+			{showOrg && <span className="min-w-0 truncate text-fg-muted streamer-private">· {account?.organization}</span>}
 			{account?.planLabel && (
 				<span className="text-accent text-micro px-1 py-px bg-accent/10 rounded shrink-0">{account.planLabel}</span>
 			)}
@@ -198,10 +212,21 @@ export function AccountQuotaLines({ snap, now }: { snap: AgentRateLimitSnapshot;
 	// The monthly_credits window mirrors snap.monthlyCredits; the dedicated row
 	// below renders it with its used/limit detail, so skip the duplicate here.
 	const windows = snap.windows.filter((w: RateLimitWindow) => !(w.id === "monthly_credits" && monthly));
+	// Provenance rides the last quota line as a "· 15h" suffix. On its own line it
+	// cost every card a full row for four characters.
+	const age = <CapturedAgeSuffix capturedAt={snap.capturedAt} now={now} />;
+	const lastWindowIndex = monthly ? -1 : windows.length - 1;
 	return (
 		<>
-			{windows.map((win) => (
-				<WindowBarRow key={win.id} label={windowLabel(win)} usedPercent={win.usedPercent} resetsAt={win.resetsAt} now={now} />
+			{windows.map((win, index) => (
+				<WindowBarRow
+					key={win.id}
+					label={windowLabel(win)}
+					usedPercent={win.usedPercent}
+					resetsAt={win.resetsAt}
+					now={now}
+					trailing={index === lastWindowIndex ? age : undefined}
+				/>
 			))}
 			{monthly && (
 				<WindowBarRow
@@ -209,6 +234,7 @@ export function AccountQuotaLines({ snap, now }: { snap: AgentRateLimitSnapshot;
 					usedPercent={Math.max(0, 100 - monthly.remainingPercent)}
 					resetsAt={monthly.resetsAt}
 					now={now}
+					trailing={age}
 					detail={t("rateLimits.monthlyUsage", {
 						used: numberFormat.format(monthly.used),
 						limit: numberFormat.format(monthly.limit),
@@ -219,27 +245,16 @@ export function AccountQuotaLines({ snap, now }: { snap: AgentRateLimitSnapshot;
 			{snap.creditsBalance != null && !unlimited && (
 				<span className="text-fg-3">{t("rateLimits.credits", { balance: snap.creditsBalance })}</span>
 			)}
-			<CapturedNote capturedAt={snap.capturedAt} now={now} />
 		</>
 	);
 }
 
-/**
- * Per-card provenance line: how long ago this account's rate-limit reading was
- * captured. Data is only refreshed while a session for that account is active,
- * so anything beyond a few minutes may be stale — flagged in the warning tint
- * once past STALE_AFTER_MS so a reading from days ago never reads as live.
- */
-export function CapturedNote({ capturedAt, now }: { capturedAt: number; now: number }) {
-	const t = useT();
-	const age = Math.max(0, now - capturedAt);
-	const stale = age > STALE_AFTER_MS;
-	const label = age < 60_000 ? t("rateLimits.capturedNow") : t("rateLimits.captured", { time: formatAge(age) });
-	return (
-		<span className={`flex items-center gap-1 text-xs tabular-nums ${stale ? "text-warning-strong" : "text-fg-3"}`}>
-			{label}
-		</span>
-	);
+/** Whether a reading has anything to plot. An unlimited account has no window
+ *  at all, so its card is a headline only — and its capture age has to ride
+ *  that headline rather than dangle on a line of its own. */
+export function hasQuotaLines(snap: AgentRateLimitSnapshot): boolean {
+	if (snap.monthlyCredits || snap.windows.length > 0) return true;
+	return snap.creditsBalance != null && !isUnlimitedRateLimitSnapshot(snap);
 }
 
 /**

--- a/src/mainview/i18n/translations/en/dashboard.ts
+++ b/src/mainview/i18n/translations/en/dashboard.ts
@@ -140,8 +140,8 @@ const dashboard = {
 	"rateLimits.panelTitle": "Agent rate limits",
 	"rateLimits.openAccounts": "Open agent usage and accounts",
 	"rateLimits.manageAccounts": "Account settings",
-	"rateLimits.panelSubtitle": "Usage per account. Pick the account new launches start with — running sessions keep their current login.",
-	"rateLimits.pinToSwitch": "Usage per account. Click the pill to pin this panel, then pick the account new launches start with.",
+	"rateLimits.panelSubtitle": "Pick the default for new launches.",
+	"rateLimits.pinToSwitch": "Click the pill to pin, then pick a default.",
 	"rateLimits.defaultSwitched": "{label} is now the default for new launches",
 	"rateLimits.makeDefault": "Make {label} the default account",
 	"rateLimits.used": "used",
@@ -154,7 +154,7 @@ const dashboard = {
 	"rateLimits.captured": "captured {time} ago",
 	"rateLimits.capturedNow": "captured just now",
 	"rateLimits.capturedAgeNow": "just now",
-	"rateLimits.noRecentData": "no recent usage data",
+	"rateLimits.noRecentData": "no recent data",
 	"rateLimits.quotaExhausted": "No quota left — this launch will fail until it resets.",
 
 	// Remote Access QR Modal

--- a/src/mainview/i18n/translations/es/dashboard.ts
+++ b/src/mainview/i18n/translations/es/dashboard.ts
@@ -138,8 +138,8 @@ const dashboard = {
 	"rateLimits.panelTitle": "Límites de agentes",
 	"rateLimits.openAccounts": "Abrir el uso y las cuentas de agentes",
 	"rateLimits.manageAccounts": "Configuración de cuentas",
-	"rateLimits.panelSubtitle": "Uso por cuenta. Elige la cuenta con la que arrancan los nuevos lanzamientos — las sesiones en ejecución mantienen su login actual.",
-	"rateLimits.pinToSwitch": "Uso por cuenta. Haz clic en la píldora para fijar este panel y luego elige la cuenta con la que arrancan los nuevos lanzamientos.",
+	"rateLimits.panelSubtitle": "Elige la cuenta por defecto para nuevos lanzamientos.",
+	"rateLimits.pinToSwitch": "Haz clic en la píldora para fijar y elegir.",
 	"rateLimits.defaultSwitched": "{label} es ahora la cuenta predeterminada para los nuevos lanzamientos",
 	"rateLimits.makeDefault": "Hacer que {label} sea la cuenta predeterminada",
 	"rateLimits.used": "usado",
@@ -152,7 +152,7 @@ const dashboard = {
 	"rateLimits.captured": "capturado hace {time}",
 	"rateLimits.capturedNow": "capturado ahora mismo",
 	"rateLimits.capturedAgeNow": "ahora mismo",
-	"rateLimits.noRecentData": "sin datos de uso recientes",
+	"rateLimits.noRecentData": "sin datos recientes",
 	"rateLimits.quotaExhausted": "Sin cuota disponible — este lanzamiento fallará hasta que se restablezca.",
 
 	// Remote Access QR Modal

--- a/src/mainview/i18n/translations/ru/dashboard.ts
+++ b/src/mainview/i18n/translations/ru/dashboard.ts
@@ -156,8 +156,8 @@ const dashboard = {
 	"rateLimits.panelTitle": "Лимиты агентов",
 	"rateLimits.openAccounts": "Открыть использование и аккаунты агентов",
 	"rateLimits.manageAccounts": "Настройки аккаунтов",
-	"rateLimits.panelSubtitle": "Использование по аккаунтам. Выберите аккаунт, с которым будут стартовать новые запуски — запущенные сессии сохранят текущий логин.",
-	"rateLimits.pinToSwitch": "Использование по аккаунтам. Нажмите на плашку, чтобы закрепить панель, и выберите аккаунт для новых запусков.",
+	"rateLimits.panelSubtitle": "Аккаунт по умолчанию для новых запусков.",
+	"rateLimits.pinToSwitch": "Нажмите на плашку, чтобы закрепить и выбрать.",
 	"rateLimits.defaultSwitched": "{label} теперь аккаунт по умолчанию для новых запусков",
 	"rateLimits.makeDefault": "Сделать {label} аккаунтом по умолчанию",
 	"rateLimits.used": "использовано",
@@ -170,7 +170,7 @@ const dashboard = {
 	"rateLimits.captured": "снято {time} назад",
 	"rateLimits.capturedNow": "снято только что",
 	"rateLimits.capturedAgeNow": "только что",
-	"rateLimits.noRecentData": "нет свежих данных об использовании",
+	"rateLimits.noRecentData": "нет свежих данных",
 	"rateLimits.quotaExhausted": "Лимит исчерпан — запуск будет падать до сброса.",
 
 	// Remote Access QR Modal


### PR DESCRIPTION
The header rate-limit pill's panel had grown to 840px against a 448px flyout: nine accounts meant a scrollbar, half of them below the fold, and a 46px sticky "Account settings" button eating the bottom of a panel already short of room.

Density, not fewer facts — nothing was removed from the readout.

- Each limit window is one dense `label · bar · % · resets in` line, the grammar the launch account picker already uses, instead of text stacked over a full-width bar.
- Capture age rides the last quota line as a `· 15h` suffix; the standalone `CapturedNote` is gone. An unlimited account, which has no window to plot, carries the age on its headline.
- An account with no reading says "no recent data" on its headline instead of on a second line.
- The sticky footer button becomes a text link sharing the header row with the hint, whose copy shrank to one line in en/ru/es.
- Panel padding drops to `p-1.5` so the cards' `rounded-md` is concentric with the flyout's `rounded-xl`.

Measured on a nine-account board: **840px → 425px, no scrollbar.**

Two rendering bugs the Chromium QA pass could not see are fixed too:

- Every usage bar inside a card rendered at ~40% width in the desktop app. The card is a `<button>` with `display: flex`, and WebKit's UA stylesheet sets `align-items: flex-start` on `button`, so each row shrank to its own text width. The card class now sets `items-stretch` explicitly.
- A long workspace name was held at its natural width and pushed the plan and "Default" chips past the panel's clipped right edge; it truncates now.

Decision record: `decisions/2026/08/29/compact-the-agent-usage-panel.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=7c66a8c9-e246-46be-911b-6bc55c714c71) · `dev3://task/7c66a8c9-e246-46be-911b-6bc55c714c71`