### PR TITLE
Publish native terminal death only when the last pane closes

### DIFF
--- a/.github/workflows/windows-conpty-package.yml
+++ b/.github/workflows/windows-conpty-package.yml
@@ -356,6 +356,16 @@ jobs:
         timeout-minutes: 6
         run: bun run test:native-multipane-e2e
 
+      # Seq 1744: closing one pane must close that pane only. Driven through the
+      # close RPC the renderer calls, not through the pane helpers beside it, so a
+      # regression in the handler is caught too. The reported failure was on
+      # Windows and the code is platform-neutral, which is exactly why this leg
+      # runs it here as well as on POSIX.
+      - name: Pane close keeps the task's terminal E2E
+        if: always()
+        timeout-minutes: 6
+        run: bun run test:aux-pane-close-e2e
+
       - name: Explicit Windows shell launch matrix
         if: always() && runner.os == 'Windows'
         shell: powershell

--- a/change-logs/2026/08/29/fix-pane-close-no-longer-kills-the-terminal.md
+++ b/change-logs/2026/08/29/fix-pane-close-no-longer-kills-the-terminal.md
@@ -1,0 +1,3 @@
+Short: Closing a pane no longer kills the terminal
+
+Closing one pane of a native task's terminal used to replace the whole terminal with the "session ended" screen when the pane happened to be the one the task was launched with, hiding panes whose agents were still running. The task's terminal now reports itself over only when its last pane closes.

--- a/decisions/2026/08/29/pane-set-decides-terminal-death.md
+++ b/decisions/2026/08/29/pane-set-decides-terminal-death.md
@@ -1,0 +1,65 @@
+# The pane set decides when a native task's terminal is over, not the pane's key
+
+## Context
+
+Arseny reported on Windows (29 Aug 2026) that closing one auxiliary pane of a task
+shut the whole task down while a second auxiliary pane was still in use. The brief
+treated it as a Windows bug on the native backend.
+
+It is not a Windows bug. `ptyDied` is the only signal that ends a task's terminal in
+the UI: `TaskTerminal.tsx` returns early on it and replaces the entire terminal —
+every pane, alive or not — with the "session ended" screen. Pane 1 of a native task
+is bound under the bare `taskId` in `pty-server.ts`, and both `createNativeTaskSession`
+and `reattachNativeTaskSession` passed `onClosed: () => markNativeClosed(session)`,
+which published that death unconditionally. Panes 2..N live under a composite
+`taskId~paneId` key and published nothing, by an explicit comment.
+
+So the outcome depended on which KEY the closing pane held rather than on whether
+anything survived it.
+
+## Investigation
+
+`src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts` drives the real close RPC
+(`taskPaneAction`, what the renderer's `runPaneAction` calls) against real hosts and
+shells. On macOS, before the fix: closing any pane 2..N of three or four published
+nothing, while closing pane 1 left both siblings in the pane set with live host and
+shell pids and published one `ptyDied`. Observed, on this platform, not inferred —
+and not a reproduction of Arseny's gesture, which nobody has been able to run.
+
+## Decision
+
+`markNativeClosed` (`src/bun/pty-server.ts`) now reads the task's pane set and
+publishes `ptyDied` only when no pane survives the one that closed; the closed pane
+is discounted by id, because the read races the close it reacts to. A surviving pane
+set instead drops the stale bare-key session (`dropStaleNativeBinding`), so the
+survivor that slides into index 0 rebinds on the next viewer attach — `getPanePtyUrl`
+picks the bare-key pane by POSITION, so leaving the dead entry would render a live
+pane as a dead one. Panes 2..N now route through the same function, so the rule is
+one rule.
+
+**The last pane.** What the code did before: pane 1 closing ended the terminal
+whatever else was alive, and an aux pane closing never did — so a task whose pane 1
+had already gone could lose its final pane and still show a terminal. What we chose:
+the pane set running out IS the terminal ending, so the last close publishes the
+death whichever pane it happens to be, and the user gets the "session ended" screen
+with its Restart button. The alternative — never publishing, and letting the pane
+poll's `sessionAbsent` path draw the empty state — was rejected: it needs two
+consecutive absent reads, so it is strictly slower at saying the same thing.
+
+## Risks
+
+A pane host that dies while siblings live now leaves the task's terminal up with a
+dead pane box in it, which is the intended reading but a visible change. The pane-set
+read is asynchronous, so the death arrives a few milliseconds later than it used to;
+an unreadable pane set is deliberately treated as "no panes survive", keeping the
+old behaviour as the failure mode. The e2e's negative assertions therefore need a
+settle window — asserting the instant the RPC resolves passed against a
+deliberately broken build during this task's own mutation check.
+
+## Alternatives considered
+
+Suppressing the death at the close call site (`nativePaneAction`) instead: rejected,
+because a pane also dies when its shell exits, and that path would have kept the bug.
+Rebinding the bare key to a survivor inside `markNativeClosed` rather than dropping
+it: rejected as a second implementation of what `reattachNativeTaskSession` already
+does on the next attach.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"test:pane-input-native-e2e": "bun src/bun/__tests__/pane-input-native.bun-e2e.ts",
 		"test:native-owner-routing-e2e": "bun src/bun/native-terminal-registry/__tests__/owner-routing.bun-e2e.ts",
 		"test:native-multipane-e2e": "bun src/bun/native-terminal-multipane/__tests__/multipane.bun-e2e.ts",
+		"test:aux-pane-close-e2e": "bun src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts",
 		"test:native-capture-e2e": "bun src/bun/terminal-backend/__tests__/native-capture.bun-e2e.ts",
 		"test:session-lock-e2e": "bun src/bun/native-terminal-registry/__tests__/session-lock.bun-e2e.ts",
 		"test:capture-cost-e2e": "bun src/bun/terminal-backend/__tests__/capture-cost.bun-e2e.ts",

--- a/src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts
+++ b/src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts
@@ -84,13 +84,13 @@ const task = {
 	terminalBackend: "native",
 };
 
-/** `projectSlug()` is frozen: `/a/b/c` → `a-b-c`. Recomputed, never imported early. */
-function slugOf(path: string): string {
-	return path.replace(/^\//, "").replaceAll("/", "-");
-}
+// The real slug function, never a local re-derivation: a hand-rolled POSIX
+// version writes the task file under a path containing a drive letter on Windows,
+// where the whole run dies in `mkdir` before a single pane exists.
+const { projectSlug } = await import("../git");
 
 writeFileSync(join(home, "projects.json"), JSON.stringify([project]));
-const dataDir = join(home, "data", slugOf(projectPath));
+const dataDir = join(home, "data", projectSlug(projectPath));
 mkdirSync(dataDir, { recursive: true });
 writeFileSync(join(dataDir, "tasks.json"), JSON.stringify([task]));
 

--- a/src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts
+++ b/src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env bun
+/**
+ * Closing one auxiliary pane must close THAT pane and nothing else (seq 1744).
+ *
+ * The report: on Windows, a task with two auxiliary panes shut down entirely when
+ * the FIRST of them was closed, while the second was still in use. Losing a task's
+ * terminal under a running agent is the worst shape of bug this app has, so the
+ * guard has to sit on the path the UI really takes, not on a helper beside it.
+ *
+ * WHAT THIS PROVES AND WHAT IT CANNOT. It exercises the real call chain a close
+ * click runs — `taskPaneAction` (the RPC the renderer's `runPaneAction` calls) →
+ * `nativePaneAction` → `closeNativeTaskPane` → the native backend → the
+ * coordinator — against real hosts, real shells and a real on-disk pane record.
+ * It is evidence about that code path on whichever platform runs it. It is NOT a
+ * reproduction of the reported gesture: nobody clicks anything here, and a
+ * platform-specific failure only counts when this file has gone green or red on
+ * that platform's own runner.
+ *
+ * Every pane close in the matrix is checked for the same three things, because
+ * "the task shut down" can arrive by three different doors:
+ *   1. the surviving panes are still in the pane set,
+ *   2. their shells and hosts are still running,
+ *   3. no `ptyDied` was published for the task — that push is what makes the
+ *      renderer replace the terminal with the "session ended" screen, so it is
+ *      the task dying as far as the user is concerned.
+ *
+ * Run: bun src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let failures = 0;
+function check(condition: boolean, message: string): void {
+	if (condition) console.log(`  ok   - ${message}`);
+	else {
+		failures++;
+		console.error(`  FAIL - ${message}`);
+	}
+}
+
+const isWindows = process.platform === "win32";
+
+// ── The temp world, wired BEFORE any dev3 module loads ────────────────────────
+// `DEV3_HOME` is read once at module load, so every import below has to be dynamic.
+const root = mkdtempSync(join(tmpdir(), "dev3-aux-close-e2e-"));
+const home = join(root, "home");
+const projectPath = join(root, "project");
+const worktreePath = join(root, "worktree");
+mkdirSync(home, { recursive: true });
+mkdirSync(projectPath, { recursive: true });
+mkdirSync(worktreePath, { recursive: true });
+process.env.DEV3_HOME = home;
+process.env.DEV3_NATIVE_SESSIONS_DIR = join(root, "sessions");
+process.env.DEV3_NATIVE_MULTIPANE_DIR = join(root, "multipane");
+
+const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_ID = "22222222-2222-4222-8222-222222222222";
+
+const project = {
+	id: PROJECT_ID,
+	name: "aux-close-e2e",
+	path: projectPath,
+	setupScript: "",
+	devScript: "",
+	cleanupScript: "",
+	defaultBaseBranch: "main",
+	createdAt: new Date(0).toISOString(),
+};
+
+const task = {
+	id: TASK_ID,
+	projectId: PROJECT_ID,
+	seq: 1,
+	title: "aux pane close",
+	description: "",
+	status: "in-progress",
+	branch: "e2e/aux-close",
+	baseBranch: "main",
+	worktreePath,
+	createdAt: new Date(0).toISOString(),
+	updatedAt: new Date(0).toISOString(),
+	terminalBackend: "native",
+};
+
+/** `projectSlug()` is frozen: `/a/b/c` → `a-b-c`. Recomputed, never imported early. */
+function slugOf(path: string): string {
+	return path.replace(/^\//, "").replaceAll("/", "-");
+}
+
+writeFileSync(join(home, "projects.json"), JSON.stringify([project]));
+const dataDir = join(home, "data", slugOf(projectPath));
+mkdirSync(dataDir, { recursive: true });
+writeFileSync(join(dataDir, "tasks.json"), JSON.stringify([task]));
+
+const { defineShellLaunchSpec } = await import("../native-terminal-registry/shell-launch");
+const { isProcessAlive } = await import("../native-terminal-registry/process-identity");
+const pty = await import("../pty-server");
+const { taskPanesHandlers } = await import("../rpc-handlers/task-panes");
+const { nativeTaskPanesState, stopNativeTaskPanes } = await import("../native-task-panes");
+
+/** A shell that sits there: the panes must be alive for "did it survive" to mean anything. */
+function shellLaunch() {
+	return defineShellLaunchSpec(
+		isWindows
+			? { executable: "powershell.exe", argv: ["-NoLogo", "-NoProfile", "-NoExit"], cwd: worktreePath, env: {} }
+			: { executable: "/bin/bash", argv: ["--norc", "--noprofile"], cwd: worktreePath, env: {} },
+	);
+}
+
+/** Every `ptyDied` the backend published, in order. Empty is the passing state. */
+const ptyDeaths: string[] = [];
+
+/**
+ * How long a `ptyDied` decision is given to arrive before "it never came" counts.
+ *
+ * The verdict is taken asynchronously — the pane set has to be read off disk after
+ * the close — so asserting the instant the RPC resolves would pass while the death
+ * is still in flight. That false green is real: it hid a deliberately broken build
+ * during this task's own mutation check.
+ */
+const DEATH_SETTLE_MS = 1_500;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Resolves as soon as a death is published, or after the settle budget. */
+async function waitForDeath(): Promise<boolean> {
+	const deadline = Date.now() + DEATH_SETTLE_MS;
+	for (;;) {
+		if (ptyDeaths.length > 0) return true;
+		if (Date.now() >= deadline) return false;
+		await sleep(50);
+	}
+}
+
+interface PaneFacts {
+	paneId: string;
+	hostPid: number;
+	shellPid: number;
+}
+
+async function paneFacts(): Promise<PaneFacts[]> {
+	const state = await nativeTaskPanesState(TASK_ID);
+	if (!state) return [];
+	return state.panes.map((pane) => ({ paneId: pane.paneId, hostPid: pane.hostPid, shellPid: pane.shellPid }));
+}
+
+/**
+ * Open `count` extra panes through the same RPC the "+ pane" and agent-spawn
+ * gestures use, and attach a viewer to each one exactly as the renderer does —
+ * `getPanePtyUrl` is what registers a pane's own PTY session, and a pane nobody
+ * ever viewed would not exercise the bookkeeping a close has to unwind.
+ */
+async function openPanes(count: number): Promise<PaneFacts[]> {
+	for (let i = 0; i < count; i++) {
+		await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "splitH" } });
+	}
+	const panes = await paneFacts();
+	for (const pane of panes) {
+		await taskPanesHandlers.getPanePtyUrl({ taskId: TASK_ID, paneId: pane.paneId });
+	}
+	return panes;
+}
+
+/**
+ * One case of the matrix: build a pane set, close the pane at `victimIndex`
+ * through the close RPC, and demand that everything else survives.
+ */
+async function closeCase(label: string, paneCount: number, victimIndex: number): Promise<void> {
+	ptyDeaths.length = 0;
+	await pty.createNativeTaskSession(TASK_ID, PROJECT_ID, worktreePath, shellLaunch());
+	try {
+		const before = await openPanes(paneCount - 1);
+		if (before.length !== paneCount) {
+			check(false, `${label}: expected ${paneCount} panes before the close, got ${before.length}`);
+			return;
+		}
+		const victim = before[victimIndex]!;
+		const survivors = before.filter((_, i) => i !== victimIndex);
+
+		await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "close", paneId: victim.paneId },
+		});
+
+		// The death verdict is asynchronous, so "no death" is only meaningful after
+		// the budget has passed with nothing published.
+		await sleep(DEATH_SETTLE_MS);
+
+		const after = await paneFacts();
+		const afterIds = new Set(after.map((pane) => pane.paneId));
+		check(
+			after.length === paneCount - 1,
+			`${label}: ${paneCount - 1} pane(s) remain after closing pane ${victimIndex + 1} of ${paneCount} — got ${after.length}`,
+		);
+		check(
+			survivors.every((pane) => afterIds.has(pane.paneId)),
+			`${label}: every pane except the closed one is still in the pane set`,
+		);
+		check(!afterIds.has(victim.paneId), `${label}: the closed pane is gone from the pane set`);
+		check(
+			survivors.every((pane) => isProcessAlive(pane.shellPid) && isProcessAlive(pane.hostPid)),
+			`${label}: every surviving pane's shell and host are still running`,
+		);
+		check(
+			ptyDeaths.length === 0,
+			`${label}: the task's terminal was never reported dead — ptyDied fired ${ptyDeaths.length} time(s)`,
+		);
+	} finally {
+		await stopNativeTaskPanes(TASK_ID).catch(() => {});
+		try {
+			pty.destroySession(TASK_ID);
+		} catch {
+			/* already gone */
+		}
+	}
+}
+
+/**
+ * Close a three-pane set one pane at a time. The first two closes must publish
+ * nothing; the close that empties the set must publish exactly one death — that is
+ * the "session ended" screen appearing when there is genuinely nothing left.
+ */
+async function lastPaneCase(): Promise<void> {
+	const label = "closing every pane";
+	ptyDeaths.length = 0;
+	await pty.createNativeTaskSession(TASK_ID, PROJECT_ID, worktreePath, shellLaunch());
+	try {
+		const panes = await openPanes(2);
+		if (panes.length !== 3) {
+			check(false, `${label}: expected 3 panes to start from, got ${panes.length}`);
+			return;
+		}
+		// Last first, so the pane holding the bare taskId is the one that empties the set.
+		for (const pane of [...panes].reverse().slice(0, 2)) {
+			await taskPanesHandlers.taskPaneAction({ taskId: TASK_ID, action: { kind: "close", paneId: pane.paneId } });
+		}
+		await sleep(DEATH_SETTLE_MS);
+		check(ptyDeaths.length === 0, `${label}: nothing died while panes remained — got ${ptyDeaths.length}`);
+
+		// `force`, because the last pane is refused without it by design.
+		await taskPanesHandlers.taskPaneAction({
+			taskId: TASK_ID,
+			action: { kind: "close", paneId: panes[0]!.paneId, force: true },
+		});
+		check(await waitForDeath(), `${label}: the last pane closing DID end the task's terminal`);
+		check(ptyDeaths.every((key) => key === TASK_ID), `${label}: the death was published for this task`);
+	} finally {
+		await stopNativeTaskPanes(TASK_ID).catch(() => {});
+		try {
+			pty.destroySession(TASK_ID);
+		} catch {
+			/* already gone */
+		}
+	}
+}
+
+async function run(): Promise<void> {
+	pty.setOnPtyDied((sessionKey) => ptyDeaths.push(sessionKey));
+	try {
+		// The reported gesture, at code-path level: three panes, close the FIRST
+		// auxiliary one (index 1 — index 0 is the agent's own pane).
+		console.log("\n# three panes, closing the first auxiliary one");
+		await closeCase("first aux of three", 3, 1);
+
+		// Question B, the other half: if only the first is special, this one passes
+		// while the case above fails. If neither is special, both pass.
+		console.log("\n# three panes, closing the second auxiliary one");
+		await closeCase("second aux of three", 3, 2);
+
+		console.log("\n# four panes, closing a middle one");
+		await closeCase("middle of four", 4, 1);
+
+		// Question D: the agent's own pane is a pane like any other while others remain.
+		console.log("\n# three panes, closing the agent pane itself");
+		await closeCase("agent pane of three", 3, 0);
+
+		// The other half of the rule, and the deliberate choice: the pane set running
+		// out IS the task's terminal ending, so the last close must still say so.
+		console.log("\n# closing every pane in turn — only the last one ends the task");
+		await lastPaneCase();
+	} finally {
+		try {
+			rmSync(root, { recursive: true, force: true });
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
+run()
+	.then(() => {
+		if (failures > 0) {
+			console.error(`\n${failures} check(s) FAILED`);
+			process.exit(1);
+		}
+		console.log("\nALL CHECKS PASSED");
+		process.exit(0);
+	})
+	.catch((error) => {
+		console.error("\nERROR:", error);
+		process.exit(1);
+	});

--- a/src/bun/pty-server.ts
+++ b/src/bun/pty-server.ts
@@ -25,6 +25,7 @@ import {
 	startNativeTaskPanes,
 	recoverNativeTaskPanes,
 	stopNativeTaskPanes,
+	nativeTaskPanesState,
 } from "./native-task-panes";
 import { paneSessionKey, parsePaneSessionKey } from "../shared/pane-session-key";
 import { deferHeldAgentMessagesForTask, flushHeldAgentMessagesForTask } from "./agent-message-hold";
@@ -305,13 +306,81 @@ function ingestPtyOutput(session: PtySession, data: string | Uint8Array): void {
 	if (session.backend === "native" || session.clients.size > 0) enqueuePtyData(session, cleaned);
 }
 
-/** One death path for both create and reattach, so their bookkeeping cannot drift. */
+/**
+ * One death path for both create and reattach, so their bookkeeping cannot drift.
+ *
+ * `ptyDied` is the task's terminal reporting itself over: the renderer replaces
+ * the WHOLE terminal with the "session ended" screen, so publishing it while
+ * other panes are alive hides running work behind a dead-looking task (seq 1744).
+ * Pane 1 is bound under the bare taskId, which is what made closing it — or its
+ * shell simply exiting — read as the task ending. So the pane set decides, not
+ * the pane's key: death is published only when this pane was the last one.
+ * A surviving pane set instead drops the stale binding, and the survivor that
+ * takes index 0 adopts the bare key on the next viewer attach.
+ */
 function markNativeClosed(session: PtySession): void {
+	const closedPaneId = session.native?.paneId ?? null;
 	session.native = null;
 	session.appliedCols = undefined;
 	session.appliedRows = undefined;
-	log.info("Native PTY session closed", { taskId: shortId(session.taskId) });
-	onPtyDiedCallback?.(session.taskId);
+	log.info("Native PTY session closed", { taskId: shortId(session.taskId), paneId: closedPaneId });
+	void publishNativeDeathIfLastPane(session, closedPaneId);
+}
+
+/**
+ * Publish `ptyDied` only when no pane of the task survives this one.
+ *
+ * The pane-set read races the close it reacts to — the coordinator may not have
+ * republished the record yet — so the CLOSED pane is discounted by id rather
+ * than trusted to be absent. An unreadable pane set is treated as no panes: the
+ * honest end state for a task whose terminal cannot be found at all.
+ */
+async function publishNativeDeathIfLastPane(session: PtySession, closedPaneId: string | null): Promise<void> {
+	const taskId = session.taskId;
+	let survivors = 0;
+	try {
+		const state = await nativeTaskPanesState(taskId);
+		survivors = (state?.panes ?? []).filter((pane) => pane.paneId !== closedPaneId).length;
+	} catch (err) {
+		log.warn("Could not read the pane set after a native pane closed; treating the task as ended", {
+			taskId: shortId(taskId),
+			error: String(err),
+		});
+	}
+	if (survivors === 0) {
+		onPtyDiedCallback?.(taskId);
+		return;
+	}
+	log.info("A native pane closed while others remain; the task's terminal stays alive", {
+		taskId: shortId(taskId),
+		paneId: closedPaneId,
+		survivors,
+	});
+	// The bare-key entry now points at a pane that is gone. Left in place, the
+	// survivor that slides into index 0 is handed this dead session by
+	// `getPanePtyUrl` (which picks the bare key by POSITION) and renders as a dead
+	// pane while its shell is running. Dropping it makes the next attach rebind.
+	dropStaleNativeBinding(session);
+}
+
+/** Forget a native session whose pane is gone, leaving sibling panes untouched. */
+function dropStaleNativeBinding(session: PtySession): void {
+	if (sessions.get(session.registryKey) !== session) return;
+	if (session.batchTimer) {
+		clearTimeout(session.batchTimer);
+		session.batchTimer = null;
+	}
+	session.pendingData = "";
+	for (const client of session.clients) {
+		try {
+			client.close();
+		} catch {
+			// already closed
+		}
+	}
+	session.clients.clear();
+	forgetSession(session.registryKey);
+	sessions.delete(session.registryKey);
 }
 
 /**
@@ -558,14 +627,11 @@ export async function ensureNativePanePtySession(
 				onOutput: (bytes) => ingestPtyOutput(session, bytes),
 				onRoleChange: () => broadcastNativeRoles(session),
 				onGeometry: (size) => applyNativeGeometry(session, size),
-				onClosed: () => {
-					session.native = null;
-					session.appliedCols = undefined;
-					session.appliedRows = undefined;
-					log.info("Native pane session closed", { taskId: shortId(taskId), paneId });
-					// Fire ptyDied only for the FIRST pane (bare key) — additional panes
-					// closing don't signal task death.
-				},
+				// Same rule as pane 1 since seq 1744: the PANE SET decides whether the
+				// task's terminal is over, not which key the closing pane happened to
+				// hold. An aux pane closing beside live siblings publishes nothing; the
+				// last pane of the set does, whichever pane that turns out to be.
+				onClosed: () => markNativeClosed(session),
 			},
 			paneId,
 		);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

Closing one pane of a native task's terminal could take the whole terminal with it. Pane 1 is bound under the bare `taskId` in `pty-server.ts`, and its `onClosed` published `ptyDied` unconditionally — the signal `TaskTerminal.tsx` returns early on, replacing every pane with the "session ended" screen while sibling panes and their agents were still running. Panes 2..N published nothing, so the outcome depended on which key the closing pane happened to hold rather than on whether anything survived it.

`markNativeClosed` now reads the task's pane set and publishes death only when nothing survives the pane that closed (the closed pane is discounted by id, because the read races the close). A surviving set instead drops the stale bare-key binding, so the pane that slides into index 0 rebinds on the next viewer attach — `getPanePtyUrl` picks that key by position, so leaving the dead entry would render a live pane as a dead one. Panes 2..N now route through the same function, making it one rule: the last pane closing ends the terminal, whichever pane that is.

**Evidence, and its limits.** The report came from Windows; the code is platform-neutral and the failure reproduces on macOS. `src/bun/__tests__/aux-pane-close-keeps-task.bun-e2e.ts` drives the close RPC the renderer calls (`taskPaneAction`) against real hosts and shells: before the fix, closing pane 1 of three left both siblings alive and published one `ptyDied`; after it, nothing is published until the set empties. The test was written before the fix and observed red; both guards were then re-proved by mutation — forcing the death to always publish turns 5 checks red, and neutering the handler's close turns 9 red. It also runs on the Windows CI leg.

This is **not** a reproduction of the reported gesture: nobody has a Windows machine to click on. The decision to merge rests on code-path evidence plus the macOS observation.

The last-pane behaviour was an explicit choice and is written up in `decisions/2026/08/29/pane-set-decides-terminal-death.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=5dd481bf-e414-4159-a87a-8b7f4995fd5c) · `dev3://task/5dd481bf-e414-4159-a87a-8b7f4995fd5c`

**Follow-up commit.** The Windows leg caught a defect in the test itself: it re-derived the project slug with a POSIX one-liner instead of calling the frozen, exported `projectSlug`, so on Windows it wrote the task file under a path containing a drive letter and died in `mkdir` before a single pane existed. Re-implementing a path rule inline is a defect generator; the function exists so there is exactly one of it.

Of the two mutations, the second is the load-bearing one: forcing the death signal to always publish only shows the assertions bite, while neutering the close *inside the RPC handler* is what shows the test reaches the real call site rather than a helper beside it.
