### PR TITLE
Show the pull-request badge on Active Tasks sidebar rows

### DIFF
--- a/change-logs/2026/08/30/feature-30-pr-badge-active-tasks-sidebar.md
+++ b/change-logs/2026/08/30/feature-30-pr-badge-active-tasks-sidebar.md
@@ -1,0 +1,3 @@
+Short: PR badge on Active Tasks cards
+
+The Active Tasks sidebar now shows each task's pull request the way the board does: number, merge state, review verdict and unresolved-comment count, hovering any of them for the checks breakdown and clicking to open the PR. It costs no extra network calls — the state is already on the task, kept fresh by the same push the board follows.

--- a/change-logs/2026/08/30/feature-30-pr-badge-active-tasks-sidebar.md
+++ b/change-logs/2026/08/30/feature-30-pr-badge-active-tasks-sidebar.md
@@ -1,3 +1,3 @@
 Short: PR badge on Active Tasks cards
 
-The Active Tasks sidebar now shows each task's pull request the way the board does: number, merge state, review verdict and unresolved-comment count, hovering any of them for the checks breakdown and clicking to open the PR. It costs no extra network calls — the state is already on the task, kept fresh by the same push the board follows.
+The Active Tasks sidebar now shows each task's pull request the way the board does: number, merge state, review verdict and unresolved-comment count, hovering any of them for the checks breakdown and clicking to open the PR. It costs no extra network calls — the state is already on the task, kept fresh by the same push the board follows. On this narrow row the merge verdict shows as its glyph, with the word in the tooltip, so the whole cluster fits one line.

--- a/decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md
+++ b/decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md
@@ -1,0 +1,61 @@
+# Active Tasks sidebar gets the PR badge, but not the board's PR discovery poll
+
+## Context
+
+The Kanban card, the task info panel and the info panel's git bar all carry the pull-request
+badge cluster (number, mergeability, review verdict, unresolved comments). The Active Tasks
+sidebar did not, and a comment in `ActiveTasksSidebar.tsx` explained why: "the sidebar tracks no
+live PR map". Read as a constraint, that comment says the badge needs a network channel the
+sidebar does not have.
+
+## Investigation
+
+It does not. PR state reaches the renderer through two channels, and neither belongs to the board:
+
+1. **Persisted on the task.** `task.prNumber` / `task.prUrl` carry identity; `task.prStatusCache`
+   (`TaskPRStatusCache`) carries CI status, review state, unresolved count, merge state, the check
+   list, the PR title and the draft flag. The backend `prWatch` activity writes both through the
+   `persistPrStatus` effect (`src/bun/lifecycle/executor.ts`). Any surface holding a `Task` already
+   holds everything the four badges need.
+2. **The `taskPrStatus` push.** A renderer-wide `window` CustomEvent emitted on `prDetected`
+   (`src/bun/lifecycle/machine.ts`). Every mounted surface can subscribe.
+
+The board's `getProjectPRs` poll adds exactly one thing on top: **discovery** — matching a branch
+name to an open PR for a task whose sticky identity was never persisted. It is per project every
+60 s, not per card.
+
+## Decision
+
+The sidebar renders the badge from the two free channels and does **not** take the discovery poll.
+`useTaskPrBadges` (`src/mainview/hooks/useTaskPrBadges.ts`) takes `discoverProjectIds` as an
+opt-in; `KanbanBoard` passes its board projects, `ActiveTasksSidebar` passes nothing.
+
+The number is the whole argument: the board's poll fans out to **one** project (or a space's
+members), while the sidebar in global scope spans **every** project on the machine — the same code
+would fire one `gh` invocation per project per minute, dozens on a busy dashboard, to recover data
+three other paths already persist. Identity is written independently by the board poll
+(`persistProjectPrIdentities`), by `getTaskGitStatus`'s probe
+(`src/bun/rpc-handlers/git-operations.ts`), and by peer-review `prWatch` in the review columns.
+
+The badge cluster itself moved into `TaskPrBadges.tsx` and both surfaces render that one component,
+so they cannot drift.
+
+## Risks
+
+A pull request that no board visit, no git-status fetch and no peer review has ever touched shows
+no badge in the sidebar. That is today's behaviour rather than a regression, and it degrades
+honestly: a task with identity but no polled state shows the number alone — never a spinner, never
+a guessed approval. Every badge past the number is independently null-guarded.
+
+The subtle one: `prDetected` pushes `taskPrStatus` but **not** `taskUpdated`. A surface that
+listens only to `taskUpdated` — as the sidebar did — would show a `prStatusCache` that goes stale
+mid-session. `useTaskPrBadges` owns that listener so no future surface has to rediscover it.
+
+## Alternatives considered
+
+- **Give the sidebar the same poll.** Rejected on the fan-out above.
+- **Lift the PR map to a common owner (App/state).** Buys nothing today: the board's poll is the
+  only network consumer, and a shared owner would still have to decide which projects to poll for.
+  Worth revisiting only if a third surface needs discovery.
+- **Number-only badge, no status colour.** Rejected as unnecessarily degraded once it was clear the
+  full cache is already on the task.

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -11,6 +11,10 @@ record wins and this file stays an index. Write the entry in full only while no 
 exists; that is the case for 84 of the entries below, and their reasoning lives nowhere
 else, so do not compact them by deleting it.
 
+## 2026-08-30 — Sidebar rows carry the task_card PR badge cluster
+
+`surfaces.sidebar` may render `git_status_badge` — the shared `TaskPrBadges` component, leading the row's signals line, without the board's discovery poll. Why: `decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md`.
+
 ## 2026-08-27 — Notification preferences have one Settings home
 
 - **Rule:** Settings → Notifications owns focus, watch default, sound, browser alerts, and Web Push; anchors stay stable. **Why:** `decisions/2026/08/27/notification-preferences-settings-home.md`.

--- a/docs/ux/ux-architecture.yaml
+++ b/docs/ux/ux-architecture.yaml
@@ -417,7 +417,7 @@ ux_architecture:
       evidence: ["src/mainview/components/GlobalSettings.tsx", "src/mainview/components/ProjectSettings.tsx (59.9K)", "src/mainview/components/global-settings/*"]
     sidebar:
       purpose: "Active tasks list / quick jump across running agents, with global-scope toggle."
-      allowed: ["destination", "task_jump", "terminal_hover_preview", "search", "variant_dots", "native_backend_mark"]
+      allowed: ["destination", "task_jump", "terminal_hover_preview", "search", "variant_dots", "native_backend_mark", "git_status_badge"]
       forbidden: ["durable_configuration"]
       variant_dots: "Same capped clickable dots + SiblingPopover as task_card (see surfaces.task_card.variant_dots); placed in the card's bottom status row, mirroring the kanban card position."
       queue_policy: "Readiness tiers are NEEDS YOU (review-by-user, user-questions, review-by-colleague) → project custom columns → WAITING (in-progress, review-by-ai). Per-task bells are visual notifications and never alter tier membership."

--- a/src/bun/__tests__/ux-docs-budget.test.ts
+++ b/src/bun/__tests__/ux-docs-budget.test.ts
@@ -50,7 +50,16 @@ const BUDGET_KB: Record<string, number> = {
 	// ambient readout is exactly what this manifest exists to prevent. Compaction was the
 	// alternative and it meant deleting other rules' why — the failure the note above names.
 	// Reasoning: decisions/2026/08/29/default-account-switch-lives-in-the-usage-flyout.md.
-	"ux-architecture.yaml": 115,
+	//
+	// 115 → 116 for one token: `git_status_badge` in `surfaces.sidebar.allowed`, because the
+	// Active Tasks row now carries the task_card PR cluster. Twenty bytes, and the smallest
+	// manifest change there is — but `main` had 7 bytes of headroom left, so the merge came to
+	// 115.013 KB. Compaction ran first and found nothing free: no trailing whitespace, no
+	// duplicate evidence paths, no blank-line runs, so the next 13 bytes would have come out of
+	// another rule's why. `allowed` is the gate ux-principal reads to decide placement, so
+	// leaving the token out would have made the shipped badge read as unsanctioned.
+	// Reasoning: decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md.
+	"ux-architecture.yaml": 116,
 	"UX_DECISIONS.md": 80,
 };
 

--- a/src/mainview/components/ActiveTaskRow.tsx
+++ b/src/mainview/components/ActiveTaskRow.tsx
@@ -1,5 +1,5 @@
 import { useState, type Dispatch } from "react";
-import type { CodingAgent, Label, PortInfo, Project, Task, TaskPriority, TaskStatus } from "../../shared/types";
+import type { CodingAgent, Label, PortInfo, Project, Task, TaskPRBadgeInfo, TaskPriority, TaskStatus } from "../../shared/types";
 import { getAllowedTransitions, getTaskTitle, isCoordinatorTask, isTaskDisconnected } from "../../shared/types";
 import { api } from "../rpc";
 import { toast } from "../toast";
@@ -16,6 +16,7 @@ import PipelineDropdown from "./PipelineDropdown";
 import PriorityBadge from "./PriorityBadge";
 import StatusMenuPortal from "./StatusMenuPortal";
 import TaskCardRail from "./TaskCardRail";
+import TaskPrBadges from "./TaskPrBadges";
 import TaskShutdownOverlay from "./TaskShutdownOverlay";
 import Tooltip from "./Tooltip";
 import VariantDots from "./VariantDots";
@@ -44,6 +45,8 @@ interface ActiveTaskRowProps {
 	groupMembers: Task[];
 	projectBadgeName?: string;
 	ports?: PortInfo[];
+	/** The task's pull request, when anything has ever seen one. */
+	prInfo?: TaskPRBadgeInfo;
 	statusColors: Record<TaskStatus, string>;
 	/** Custom-column colour when parked in one, else the built-in status hue. */
 	color: string;
@@ -77,6 +80,7 @@ export default function ActiveTaskRow({
 	groupMembers,
 	projectBadgeName,
 	ports,
+	prInfo,
 	statusColors,
 	color,
 	now,
@@ -268,6 +272,10 @@ export default function ActiveTaskRow({
 				<div className="mt-1.5 flex items-center gap-1 min-w-0 flex-wrap">
 					<PriorityBadge priority={task.priority} onChange={onSetPriority} />
 					<div className="text-nano text-fg-3 font-mono shrink-0">#{task.seq}</div>
+						{/* Git group leads the signals, mirroring the board bottom bar. */}
+						{prInfo && (
+							<TaskPrBadges prInfo={prInfo} projectId={task.projectId} taskId={task.id} />
+						)}
 					{assignedLabels.length > 0 && (
 						<div className="flex flex-wrap gap-0.5 min-w-0">
 							{assignedLabels.map((label) => (

--- a/src/mainview/components/ActiveTaskRow.tsx
+++ b/src/mainview/components/ActiveTaskRow.tsx
@@ -272,10 +272,12 @@ export default function ActiveTaskRow({
 				<div className="mt-1.5 flex items-center gap-1 min-w-0 flex-wrap">
 					<PriorityBadge priority={task.priority} onChange={onSetPriority} />
 					<div className="text-nano text-fg-3 font-mono shrink-0">#{task.seq}</div>
-						{/* Git group leads the signals, mirroring the board bottom bar. */}
-						{prInfo && (
-							<TaskPrBadges prInfo={prInfo} projectId={task.projectId} taskId={task.id} />
-						)}
+					{/* Git group leads the signals, mirroring the board bottom bar. The
+					    merge verdict goes glyph-only here: its word is 77px of a 200px
+					    line, and it survives in the tooltip, the name and the popover. */}
+					{prInfo && (
+						<TaskPrBadges prInfo={prInfo} projectId={task.projectId} taskId={task.id} compact />
+					)}
 					{assignedLabels.length > 0 && (
 						<div className="flex flex-wrap gap-0.5 min-w-0">
 							{assignedLabels.map((label) => (
@@ -294,35 +296,15 @@ export default function ActiveTaskRow({
 						size="sm"
 						testId={`variant-indicator-${task.id}`}
 					/>
-					{agePart && (
-						<Tooltip
-							content={t("sidebar.statusChanged", {
-								ago:
-									agePart.unit === "s" && agePart.value < 1
-										? t("activity.justNow")
-										: t(AGE_UNIT_KEY[agePart.unit] as Parameters<typeof t>[0], {
-												count: String(agePart.value),
-											}),
-								date: new Date(task.movedAt!).toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" }),
-							})}
-						>
-							<span
-								className="ml-auto shrink-0 flex items-center gap-0.5 text-nano text-fg-3 font-mono whitespace-nowrap"
-								data-testid={`sidebar-status-age-${task.id}`}
-							>
-								<span aria-hidden className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
-									{""}
-								</span>
-								{compactAge(task.movedAt, now)}
-							</span>
-						</Tooltip>
-					)}
 				</div>
 
 				{/* IDENTITY — one muted line, last. Same order as the card: the
-				    backend qualifies the task, so it precedes the agent badge. */}
+				    backend qualifies the task, so it precedes the agent badge. The
+				    status age rides this line rather than the signals line: it is
+				    metadata, and its 22px were what pushed a PR badge onto row two. */}
+				<div className="mt-1 flex items-center gap-1.5 min-w-0">
 				<Tooltip content={agentSummary} disabled={!agentSummary}>
-					<div className="mt-1 flex items-center gap-1.5 min-w-0" data-testid={`sidebar-identity-${task.id}`}>
+					<div className="flex min-w-0 flex-1 items-center gap-1.5" data-testid={`sidebar-identity-${task.id}`}>
 						<NativeBackendMark task={task} className="w-3 h-3" testId={`sidebar-native-backend-${task.id}`} />
 						{agent && <AgentLauncherBadge agent={agent} size={12} />}
 						{isCoordinatorTask(task) && (
@@ -364,6 +346,30 @@ export default function ActiveTaskRow({
 						<div className="min-w-0 flex-1 truncate text-nano font-mono text-fg-muted">{agentSummary}</div>
 					</div>
 				</Tooltip>
+				{agePart && (
+					<Tooltip
+						content={t("sidebar.statusChanged", {
+							ago:
+								agePart.unit === "s" && agePart.value < 1
+									? t("activity.justNow")
+									: t(AGE_UNIT_KEY[agePart.unit] as Parameters<typeof t>[0], {
+											count: String(agePart.value),
+										}),
+							date: new Date(task.movedAt!).toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" }),
+						})}
+					>
+						<span
+							className="shrink-0 flex items-center gap-0.5 text-nano text-fg-3 font-mono whitespace-nowrap"
+							data-testid={`sidebar-status-age-${task.id}`}
+						>
+							<span aria-hidden className="leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>
+								{""}
+							</span>
+							{compactAge(task.movedAt, now)}
+						</span>
+					</Tooltip>
+				)}
+				</div>
 
 				{/* Port indicators */}
 				{ports && ports.length > 0 && (

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -6,6 +6,7 @@ import { PRIORITY_NAME_KEYS } from "./priorityStyles";
 import { groupTasksIntoTiers } from "./sidebarTiers";
 import { toast } from "../toast";
 import { useStatusColors } from "../hooks/useStatusColors";
+import { useTaskPrBadges } from "../hooks/useTaskPrBadges";
 import { useTerminalPreview } from "../hooks/useTerminalPreview";
 import { api } from "../rpc";
 import type { AppAction, Route } from "../state";
@@ -279,10 +280,17 @@ function ActiveTasksSidebar({
 		return map;
 	}, [allProjects, project]);
 
+	// PR badges from what each task already carries, kept fresh by the
+	// `taskPrStatus` push. No `discoverProjectIds`: this surface spans EVERY
+	// project in global scope, so the board's branch->PR lookup would fan out to
+	// one `gh` call per project per minute instead of one. See
+	// decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md.
+	const knowsProject = useCallback((projectId: string) => projectById.has(projectId), [projectById]);
+	const taskPrMap = useTaskPrBadges({ tasks: activeTasks, knowsProject });
+
 	// Facet resolver + funnel pool for the token-DSL filter. Labels/statuses are
 	// resolved per the task's OWN project (the pool may be cross-project in
-	// global scope). The sidebar tracks no live PR map — the matcher falls back to
-	// the task's own sticky prNumber/prUrl, so PR search still works here.
+	// global scope).
 	const resolver: FacetResolver = useMemo(() => ({
 		agents,
 		labelsFor: (task) => {
@@ -301,7 +309,8 @@ function ActiveTasksSidebar({
 		// Space names come from the task's OWN project, so a cross-project pool
 		// can be filtered by space; a single-project pool yields one value.
 		spaceNamesFor: (task) => spacesOfProject(spaces, task.projectId).map((s) => s.name),
-	}), [agents, projectById, taskPorts, spaces, t]);
+		prNumberFor: (task) => taskPrMap.get(task.id)?.number ?? null,
+	}), [agents, projectById, taskPorts, taskPrMap, spaces, t]);
 
 	const priorityCandidates = useMemo<FilterFunnelOption[]>(
 		() => ALL_PRIORITIES.map((p) => ({ facet: "priority" as const, value: p, label: `${p} — ${t(PRIORITY_NAME_KEYS[p])}` })),
@@ -723,6 +732,7 @@ function ActiveTasksSidebar({
 											groupMembers={groupMembers}
 											projectBadgeName={showProjectBadge ? taskProject?.name ?? t("sidebar.unknownProject") : undefined}
 											ports={taskPorts.get(task.id)}
+											prInfo={taskPrMap.get(task.id)}
 											statusColors={statusColors}
 											color={taskColor(task)}
 											now={now}

--- a/src/mainview/components/KanbanBoard.tsx
+++ b/src/mainview/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch } from "react";
 import { toast } from "../toast";
-import type { BoardColumnSlot, CustomColumn, DevServerSummary, GlobalSettings, Label, PortInfo, PRInfo, Project, ResourceUsage, Space, Task, TaskPRBadgeInfo, TaskStatus } from "../../shared/types";
+import type { BoardColumnSlot, CustomColumn, DevServerSummary, GlobalSettings, Label, PortInfo, Project, ResourceUsage, Space, Task, TaskStatus } from "../../shared/types";
 import { ALL_STATUSES, ACTIVE_STATUSES, ALL_PRIORITIES, getBoardColumns, laneAcceptsProject, laneColumnIdForProject, laneKey, normalizeLaneName, DEFAULT_PRIORITY } from "../../shared/types";
 import { PRIORITY_NAME_KEYS } from "./priorityStyles";
 
@@ -18,7 +18,7 @@ import { partitionTasksByStatus } from "./partitionTasks";
 import LabelFilterBar from "./LabelFilterBar";
 import { matchesTaskQuery } from "../utils/taskSearch";
 import { buildFilterGroups, taskQueryContext, isAttentionTask, type FacetResolver, type FilterFunnelOption } from "../utils/taskFacets";
-import { startVisibilityAwarePoll } from "../utils/poll";
+import { useTaskPrBadges } from "../hooks/useTaskPrBadges";
 import { useTipRotation } from "../hooks/useTipRotation";
 import { useColumnCollapse } from "../hooks/useColumnCollapse";
 import { moveTaskToStatus } from "../utils/moveTaskToStatus";
@@ -52,61 +52,6 @@ interface KanbanBoardProps {
 	activeTaskId?: string;
 	disableGlobalFindShortcut?: boolean;
 	onOpenUnresolvedComments?: (task: Task) => void;
-}
-
-type PRIdentity = Pick<TaskPRBadgeInfo, "number" | "url">;
-
-function samePRIdentity(left: TaskPRBadgeInfo | null | undefined, right: PRIdentity): boolean {
-	return left?.number === right.number && left.url === right.url;
-}
-
-function taskPRBadgeFromStoredData(task: Task, identity?: PRIdentity): TaskPRBadgeInfo | null {
-	const cache = task.prStatusCache;
-	const sticky = task.prNumber != null && task.prUrl ? { number: task.prNumber, url: task.prUrl } : undefined;
-	const cachedIdentity = cache?.url ? { number: cache.number, url: cache.url } : undefined;
-	const pr = identity ?? sticky ?? cachedIdentity;
-	if (!pr) return null;
-	const cached = cache && samePRIdentity({ number: cache.number, url: cache.url }, pr) ? cache : null;
-	return {
-		number: pr.number,
-		url: pr.url,
-		autoMergeEnabled: cached?.autoMergeEnabled ?? null,
-		ciStatus: cached?.ciStatus ?? null,
-		reviewState: cached?.reviewState ?? null,
-		reviewDecision: cached?.reviewDecision ?? null,
-		unresolvedCount: cached?.unresolvedCount ?? null,
-		mergeState: cached?.mergeState ?? null,
-		checks: cached?.checks ?? [],
-		prTitle: cached?.prTitle ?? null,
-		isDraft: cached?.isDraft ?? null,
-	};
-}
-
-function mergeTaskPRBadge(task: Task, identity: PRIdentity | undefined, existing: TaskPRBadgeInfo | undefined): TaskPRBadgeInfo | null {
-	const stored = taskPRBadgeFromStoredData(task, identity);
-	if (!stored) return null;
-	if (!existing || !samePRIdentity(existing, stored)) return stored;
-	return {
-		...stored,
-		autoMergeEnabled: existing.autoMergeEnabled ?? stored.autoMergeEnabled,
-		ciStatus: existing.ciStatus ?? stored.ciStatus,
-		reviewState: existing.reviewState ?? stored.reviewState,
-		reviewDecision: existing.reviewDecision ?? stored.reviewDecision,
-		unresolvedCount: existing.unresolvedCount ?? stored.unresolvedCount,
-		mergeState: existing.mergeState ?? stored.mergeState,
-		checks: existing.checks && existing.checks.length > 0 ? existing.checks : stored.checks,
-		prTitle: existing.prTitle ?? stored.prTitle,
-		isDraft: existing.isDraft ?? stored.isDraft,
-	};
-}
-
-function hydrateTaskPRMap(tasks: Task[], previous = new Map<string, TaskPRBadgeInfo>()): Map<string, TaskPRBadgeInfo> {
-	const next = new Map<string, TaskPRBadgeInfo>();
-	for (const task of tasks) {
-		const badge = mergeTaskPRBadge(task, undefined, previous.get(task.id));
-		if (badge) next.set(task.id, badge);
-	}
-	return next;
 }
 
 function KanbanBoard({
@@ -168,10 +113,6 @@ function KanbanBoard({
 	// its own collapse memory instead of inheriting the anchor project's.
 	const collapseState = useColumnCollapse(space ? `space-${space.id}` : project.id);
 
-	// PR badge data for task cards. Seed from persisted task metadata so the board
-	// stays useful while the first live GitHub lookup is still in flight.
-	const [taskPrMap, setTaskPrMap] = useState<Map<string, TaskPRBadgeInfo>>(() => hydrateTaskPRMap(tasks));
-
 	const handleSetMoving = useCallback((taskId: string, isMoving: boolean) => {
 		setMovingTaskIds((prev) => {
 			const next = new Set(prev);
@@ -193,109 +134,17 @@ function KanbanBoard({
 		return () => window.removeEventListener("rpc:globalSettingsUpdated", onSettingsUpdated);
 	}, []);
 
-	useEffect(() => {
-		setTaskPrMap((prev) => {
-			const next = new Map<string, TaskPRBadgeInfo>();
-			for (const task of tasks) {
-				const existing = prev.get(task.id);
-				const badge = existing ?? taskPRBadgeFromStoredData(task);
-				if (badge) next.set(task.id, badge);
-			}
-			if (next.size === prev.size && [...next.keys()].every((taskId) => prev.has(taskId))) return prev;
-			return next;
-		});
-	}, [project.id, tasks]);
-
-	// Fetch open PRs for the project and map branch names to task IDs. CI/review
-	// state is supplied separately by the background poller's `taskPrStatus`
-	// push, so preserve any already-known ci/review fields when rebuilding here.
+	// PR badge data for task cards: what each task already carries (sticky
+	// prNumber/prUrl + prStatusCache), refreshed in-session by the `taskPrStatus`
+	// push, plus a per-project branch->PR lookup so a PR whose identity was never
+	// persisted still gets a badge. Virtual (Operations) boards have no git repo,
+	// so they get no lookup instead of a doomed RPC every 60s.
 	const gitProjectIds = useMemo(
 		() => boardProjects.filter((p) => p.kind !== "virtual").map((p) => p.id),
 		[boardProjects],
 	);
-	const fetchPRs = useCallback(() => {
-		// One lookup per member project: a branch name is only unique inside its own
-		// repository, so the branch→PR map is per project too.
-		Promise.all(
-			gitProjectIds.map((projectId) =>
-				api.request.getProjectPRs({ projectId }).then(
-					(prs: PRInfo[]) => [projectId, prs] as const,
-					() => [projectId, [] as PRInfo[]] as const,
-				),
-			),
-		).then((results) => {
-			const branchToPR = new Map<string, { number: number; url: string }>();
-			for (const [projectId, prs] of results) {
-				for (const pr of prs) {
-					branchToPR.set(`${projectId}::${pr.headRefName}`, { number: pr.number, url: pr.url });
-				}
-			}
-			setTaskPrMap((prev) => {
-				const map = new Map<string, TaskPRBadgeInfo>();
-				for (const task of tasks) {
-					const discovered = task.branchName ? branchToPR.get(`${task.projectId}::${task.branchName}`) : undefined;
-					const stored = taskPRBadgeFromStoredData(task, discovered);
-					const existing = prev.get(task.id);
-					const badge = stored && existing && samePRIdentity(existing, stored) ? existing : stored;
-					if (badge) map.set(task.id, badge);
-				}
-				return map;
-			});
-		}).catch(() => {});
-	}, [gitProjectIds, tasks]);
-
-	useEffect(() => {
-		// Virtual (Operations) boards have no git repo, branches, or PRs — skip the
-		// poll entirely instead of firing a doomed getProjectPRs RPC every 60s.
-		if (gitProjectIds.length === 0) return;
-		return startVisibilityAwarePoll({ fn: fetchPRs, intervalMs: 60_000 });
-	}, [fetchPRs, gitProjectIds]);
-
-	// CI/review status pushed by the background PR poller — merge onto the
-	// existing PR badge entry (carrying number/url forward if already known).
-	useEffect(() => {
-		function onPrStatus(e: Event) {
-			const detail = (e as CustomEvent).detail as {
-				projectId: string;
-				taskId: string;
-				prNumber: number | null;
-				prUrl: string | null;
-				autoMergeEnabled?: TaskPRBadgeInfo["autoMergeEnabled"];
-				ciStatus: TaskPRBadgeInfo["ciStatus"];
-				reviewState: TaskPRBadgeInfo["reviewState"];
-				reviewDecision?: TaskPRBadgeInfo["reviewDecision"];
-				unresolvedCount: TaskPRBadgeInfo["unresolvedCount"];
-				mergeState: TaskPRBadgeInfo["mergeState"];
-				checks: TaskPRBadgeInfo["checks"];
-				prTitle: TaskPRBadgeInfo["prTitle"];
-				isDraft: TaskPRBadgeInfo["isDraft"];
-			};
-			if (!projectById.has(detail.projectId)) return;
-			setTaskPrMap((prev) => {
-				const existing = prev.get(detail.taskId);
-				const number = detail.prNumber ?? existing?.number;
-				const url = detail.prUrl ?? existing?.url;
-				if (number === undefined || url === undefined) return prev;
-				const next = new Map(prev);
-				next.set(detail.taskId, {
-					number,
-					url,
-					autoMergeEnabled: detail.autoMergeEnabled,
-					ciStatus: detail.ciStatus,
-					reviewState: detail.reviewState,
-					reviewDecision: detail.reviewDecision,
-					unresolvedCount: detail.unresolvedCount,
-					mergeState: detail.mergeState,
-					checks: detail.checks ?? [],
-					prTitle: detail.prTitle,
-					isDraft: detail.isDraft,
-				});
-				return next;
-			});
-		}
-		window.addEventListener("rpc:taskPrStatus", onPrStatus);
-		return () => window.removeEventListener("rpc:taskPrStatus", onPrStatus);
-	}, [projectById]);
+	const knowsProject = useCallback((projectId: string) => projectById.has(projectId), [projectById]);
+	const taskPrMap = useTaskPrBadges({ tasks, discoverProjectIds: gitProjectIds, knowsProject });
 
 	// Global dragend listener to clear drag state
 	useEffect(() => {

--- a/src/mainview/components/TaskCard.tsx
+++ b/src/mainview/components/TaskCard.tsx
@@ -7,7 +7,6 @@ import { getTaskOpenMode, type AppAction, type Route } from "../state";
 import { api } from "../rpc";
 import { confirm } from "../confirm";
 import { useT } from "../i18n";
-import type { TranslationKey } from "../i18n";
 import { formatBytes } from "../utils/formatBytes";
 import { formatCountdown } from "../../shared/duration";
 import { trackEvent, agentNameFromId } from "../analytics";
@@ -37,8 +36,7 @@ import AgentLauncherBadge, { resolveAgentLauncherIcon } from "./AgentLauncherBad
 import { PREPARING_STAGE_LABELS } from "./TaskPreparingView";
 import Tooltip from "./Tooltip";
 import TaskShutdownOverlay from "./TaskShutdownOverlay";
-import TaskPrStatusPopover from "./TaskPrStatusPopover";
-import { summarizeMergeability, type PRMergeabilityReason } from "../../shared/pr-status";
+import TaskPrBadges from "./TaskPrBadges";
 
 /** Deferred-time glyph: the scheduled-launch badge and the "send later" menu row. */
 function ClockIcon({ className }: { className?: string }) {
@@ -430,116 +428,10 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	const openUnresolvedInDiff = onOpenUnresolvedComments
 		? () => onOpenUnresolvedComments(task)
 		: undefined;
-	const prBadge = prInfo ? (
-		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					window.open(prInfo.url, "_blank");
-				}}
-				className="inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded bg-success/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-success transition-colors hover:bg-success/20"
-				aria-label={t("task.openPR", { number: String(prInfo.number) })}
-			>
-				<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0401}"}</span>
-				<span className="leading-none">{t("task.prNumber", { number: String(prInfo.number) })}</span>
-			</button>
-		</TaskPrStatusPopover>
-	) : null;
-
-	// PR status badges. Every badge opens the pull request; hovering any one of
-	// them opens the shared checks/conflict popover.
-	//
-	// Mergeability replaces the old standalone CI badge — GitHub's merge-state
-	// already folds failing/blocking checks into one verdict, and the popover
-	// keeps the per-check breakdown for detail.
-	const MERGE_BADGE_REASON: Record<PRMergeabilityReason, TranslationKey> = {
-		conflict: "task.mergeBadge.conflict",
-		blocked: "task.mergeBadge.blocked",
-		behind: "task.mergeBadge.behind",
-		draft: "task.mergeBadge.draft",
-		unstable: "task.mergeBadge.unstable",
-		hooks: "task.mergeBadge.blocked",
-	};
-	const mergeability = prInfo ? summarizeMergeability(prInfo.mergeState) : null;
-	const mergeBadge = mergeability && mergeability.state !== "unknown" ? (() => {
-		const ok = mergeability.state === "mergeable";
-		const label = ok
-			? t("task.mergeBadge.mergeable")
-			: mergeability.reason
-				? t(MERGE_BADGE_REASON[mergeability.reason])
-				: t("task.mergeBadge.notMergeable");
-		return (
-			<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
-				<button
-					type="button"
-					onClick={(e) => {
-						e.stopPropagation();
-						window.open(prInfo!.url, "_blank");
-					}}
-					className={`inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-dense font-semibold leading-none transition-colors ${ok ? "text-success bg-success/10 hover:bg-success/20" : "text-danger bg-danger/10 hover:bg-danger/20"}`}
-					aria-label={t(ok ? "task.mergeBadge.mergeableAria" : "task.mergeBadge.notMergeableAria")}
-				>
-					<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{ok ? "\u{F0623}" : "\uf05e"}</span>
-					<span className="truncate leading-none">{label}</span>
-				</button>
-			</TaskPrStatusPopover>
-		);
-	})() : null;
-	const REVIEW_BADGE: Record<NonNullable<TaskPRBadgeInfo["reviewState"]>, { glyph: string | null; square?: boolean; cls: string; key: TranslationKey }> = {
-		approved: { glyph: null, square: true, cls: "text-success bg-success/10 hover:bg-success/20", key: "task.review.approved" },
-		changes_requested: { glyph: "", cls: "text-danger bg-danger/10 hover:bg-danger/20", key: "task.review.changesRequested" },
-		commented: { glyph: "", cls: "text-warning-strong bg-warning/10 hover:bg-warning/20", key: "task.review.commented" },
-	};
-	const reviewMeta = prInfo?.reviewState ? REVIEW_BADGE[prInfo.reviewState] : null;
-	const reviewBadge = reviewMeta ? (
-		<TaskPrStatusPopover prInfo={prInfo!} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					window.open(prInfo!.url, "_blank");
-				}}
-				className={`inline-flex flex-shrink-0 items-center rounded font-mono text-dense font-semibold leading-none transition-colors ${reviewMeta.square ? "h-5 w-5 justify-center p-0" : "h-5 gap-1 px-1.5 py-0.5"} ${reviewMeta.cls}`}
-				aria-label={t(reviewMeta.key)}
-			>
-				{reviewMeta.glyph === null ? (
-					<svg
-						className="h-3.5 w-3.5"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						aria-hidden="true"
-					>
-						<circle cx="8.5" cy="7.5" r="3" />
-						<path d="M3.5 19c.4-3.2 2.1-5 5-5s4.6 1.8 5 5" />
-						<path d="m15 17 2 2 4-5" />
-					</svg>
-				) : (
-					<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{reviewMeta.glyph}</span>
-				)}
-			</button>
-		</TaskPrStatusPopover>
-	) : null;
-	const unresolvedCount = prInfo?.unresolvedCount ?? 0;
-	const commentBadge = prInfo && unresolvedCount > 0 ? (
-		<TaskPrStatusPopover prInfo={prInfo} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff}>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					window.open(prInfo.url, "_blank");
-				}}
-				className="inline-flex h-5 flex-shrink-0 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-warning-strong transition-colors hover:bg-warning/20"
-				aria-label={t.plural("task.prUnresolvedComments", unresolvedCount)}
-			>
-				<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF086"}</span>
-				<span className="leading-none">{unresolvedCount}</span>
-			</button>
-		</TaskPrStatusPopover>
+	// PR signals — the same cluster the Active Tasks sidebar renders, extracted so
+	// the two surfaces cannot drift.
+	const prBadges = prInfo ? (
+		<TaskPrBadges prInfo={prInfo} projectId={project.id} taskId={task.id} onShowUnresolved={openUnresolvedInDiff} />
 	) : null;
 
 	function handleShowDescription(e: React.MouseEvent) {
@@ -588,14 +480,7 @@ function TaskCard({ task, project, dispatch, navigate, agents, onLaunchVariants,
 	// ---- SIGNALS zone: read-only facts, grouped git / run / time -------------
 	// Keyed here rather than on each badge: they are built as standalone nodes above
 	// and only become a list at this point.
-	const gitSignals = ([
-		["pr", prBadge],
-		["merge", mergeBadge],
-		["review", reviewBadge],
-		["comment", commentBadge],
-	] as const)
-		.filter(([, node]) => Boolean(node))
-		.map(([key, node]) => <Fragment key={key}>{node}</Fragment>);
+	const gitSignals = prBadges ? [<Fragment key="pr">{prBadges}</Fragment>] : [];
 	const runSignals: React.ReactNode[] = [];
 	if (isActive && ports && ports.length > 0) {
 		runSignals.push(

--- a/src/mainview/components/TaskPrBadges.tsx
+++ b/src/mainview/components/TaskPrBadges.tsx
@@ -24,6 +24,13 @@ interface TaskPrBadgesProps {
 	taskId: string;
 	/** Makes the popover's unresolved-comments row a deep link into the diff. */
 	onShowUnresolved?: () => void;
+	/**
+	 * Narrow hosts (the ~200px Active Tasks row) drop the merge verdict's word
+	 * and keep its glyph: the word is 77px of a 200px line, which is what forced
+	 * the row to wrap. The word itself survives in the tooltip, the accessible
+	 * name, and the popover.
+	 */
+	compact?: boolean;
 }
 
 /**
@@ -40,7 +47,7 @@ interface TaskPrBadgesProps {
  * already folds failing/blocking checks into one verdict, and the popover keeps
  * the per-check breakdown for detail.
  */
-export default function TaskPrBadges({ prInfo, projectId, taskId, onShowUnresolved }: TaskPrBadgesProps) {
+export default function TaskPrBadges({ prInfo, projectId, taskId, onShowUnresolved, compact = false }: TaskPrBadgesProps) {
 	const t = useT();
 	const mergeability = summarizeMergeability(prInfo.mergeState);
 	const reviewMeta = prInfo.reviewState ? REVIEW_BADGE[prInfo.reviewState] : null;
@@ -77,11 +84,12 @@ export default function TaskPrBadges({ prInfo, projectId, taskId, onShowUnresolv
 							e.stopPropagation();
 							window.open(prInfo.url, "_blank");
 						}}
-						className={`inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-dense font-semibold leading-none transition-colors ${ok ? "text-success bg-success/10 hover:bg-success/20" : "text-danger bg-danger/10 hover:bg-danger/20"}`}
-						aria-label={t(ok ? "task.mergeBadge.mergeableAria" : "task.mergeBadge.notMergeableAria")}
+						className={`inline-flex flex-shrink-0 items-center rounded font-mono text-dense font-semibold leading-none transition-colors ${compact ? "h-5 w-5 justify-center p-0" : "h-5 max-w-full gap-1 px-1.5 py-0.5"} ${ok ? "text-success bg-success/10 hover:bg-success/20" : "text-danger bg-danger/10 hover:bg-danger/20"}`}
+						aria-label={`${t(ok ? "task.mergeBadge.mergeableAria" : "task.mergeBadge.notMergeableAria")} — ${mergeLabel}`}
+						title={compact ? mergeLabel : undefined}
 					>
 						<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{ok ? "\u{F0623}" : "\uf05e"}</span>
-						<span className="truncate leading-none">{mergeLabel}</span>
+						{!compact && <span className="truncate leading-none">{mergeLabel}</span>}
 					</button>
 				</TaskPrStatusPopover>
 			)}

--- a/src/mainview/components/TaskPrBadges.tsx
+++ b/src/mainview/components/TaskPrBadges.tsx
@@ -1,0 +1,140 @@
+import type { TaskPRBadgeInfo } from "../../shared/types";
+import { summarizeMergeability, type PRMergeabilityReason } from "../../shared/pr-status";
+import { useT, type TranslationKey } from "../i18n";
+import TaskPrStatusPopover from "./TaskPrStatusPopover";
+
+const MERGE_BADGE_REASON: Record<PRMergeabilityReason, TranslationKey> = {
+	conflict: "task.mergeBadge.conflict",
+	blocked: "task.mergeBadge.blocked",
+	behind: "task.mergeBadge.behind",
+	draft: "task.mergeBadge.draft",
+	unstable: "task.mergeBadge.unstable",
+	hooks: "task.mergeBadge.blocked",
+};
+
+const REVIEW_BADGE: Record<NonNullable<TaskPRBadgeInfo["reviewState"]>, { glyph: string | null; square?: boolean; cls: string; key: TranslationKey }> = {
+	approved: { glyph: null, square: true, cls: "text-success bg-success/10 hover:bg-success/20", key: "task.review.approved" },
+	changes_requested: { glyph: "\uf071", cls: "text-danger bg-danger/10 hover:bg-danger/20", key: "task.review.changesRequested" },
+	commented: { glyph: "\uf075", cls: "text-warning-strong bg-warning/10 hover:bg-warning/20", key: "task.review.commented" },
+};
+
+interface TaskPrBadgesProps {
+	prInfo: TaskPRBadgeInfo;
+	projectId: string;
+	taskId: string;
+	/** Makes the popover's unresolved-comments row a deep link into the diff. */
+	onShowUnresolved?: () => void;
+}
+
+/**
+ * The task's pull-request signal cluster: number, mergeability, review verdict,
+ * unresolved comments. Every badge opens the PR; hovering any one of them opens
+ * the shared checks/conflict popover.
+ *
+ * Rendered as a fragment of siblings so the host's flex row keeps laying them
+ * out one by one. Each badge past the number is independently null-guarded, so a
+ * PR whose state nothing has polled yet shows the number alone — never a
+ * spinner and never a guessed verdict.
+ *
+ * Mergeability replaces a standalone CI badge on purpose: GitHub's merge-state
+ * already folds failing/blocking checks into one verdict, and the popover keeps
+ * the per-check breakdown for detail.
+ */
+export default function TaskPrBadges({ prInfo, projectId, taskId, onShowUnresolved }: TaskPrBadgesProps) {
+	const t = useT();
+	const mergeability = summarizeMergeability(prInfo.mergeState);
+	const reviewMeta = prInfo.reviewState ? REVIEW_BADGE[prInfo.reviewState] : null;
+	const unresolvedCount = prInfo.unresolvedCount ?? 0;
+	const ok = mergeability.state === "mergeable";
+	const mergeLabel = ok
+		? t("task.mergeBadge.mergeable")
+		: mergeability.reason
+			? t(MERGE_BADGE_REASON[mergeability.reason])
+			: t("task.mergeBadge.notMergeable");
+
+	return (
+		<>
+			<TaskPrStatusPopover prInfo={prInfo} projectId={projectId} taskId={taskId} onShowUnresolved={onShowUnresolved}>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						window.open(prInfo.url, "_blank");
+					}}
+					className="inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded bg-success/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-success transition-colors hover:bg-success/20"
+					aria-label={t("task.openPR", { number: String(prInfo.number) })}
+				>
+					<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\u{F0401}"}</span>
+					<span className="leading-none">{t("task.prNumber", { number: String(prInfo.number) })}</span>
+				</button>
+			</TaskPrStatusPopover>
+
+			{mergeability.state !== "unknown" && (
+				<TaskPrStatusPopover prInfo={prInfo} projectId={projectId} taskId={taskId} onShowUnresolved={onShowUnresolved}>
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							window.open(prInfo.url, "_blank");
+						}}
+						className={`inline-flex h-5 max-w-full flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-dense font-semibold leading-none transition-colors ${ok ? "text-success bg-success/10 hover:bg-success/20" : "text-danger bg-danger/10 hover:bg-danger/20"}`}
+						aria-label={t(ok ? "task.mergeBadge.mergeableAria" : "task.mergeBadge.notMergeableAria")}
+					>
+						<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{ok ? "\u{F0623}" : "\uf05e"}</span>
+						<span className="truncate leading-none">{mergeLabel}</span>
+					</button>
+				</TaskPrStatusPopover>
+			)}
+
+			{reviewMeta && (
+				<TaskPrStatusPopover prInfo={prInfo} projectId={projectId} taskId={taskId} onShowUnresolved={onShowUnresolved}>
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							window.open(prInfo.url, "_blank");
+						}}
+						className={`inline-flex flex-shrink-0 items-center rounded font-mono text-dense font-semibold leading-none transition-colors ${reviewMeta.square ? "h-5 w-5 justify-center p-0" : "h-5 gap-1 px-1.5 py-0.5"} ${reviewMeta.cls}`}
+						aria-label={t(reviewMeta.key)}
+					>
+						{reviewMeta.glyph === null ? (
+							<svg
+								className="h-3.5 w-3.5"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<circle cx="8.5" cy="7.5" r="3" />
+								<path d="M3.5 19c.4-3.2 2.1-5 5-5s4.6 1.8 5 5" />
+								<path d="m15 17 2 2 4-5" />
+							</svg>
+						) : (
+							<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{reviewMeta.glyph}</span>
+						)}
+					</button>
+				</TaskPrStatusPopover>
+			)}
+
+			{unresolvedCount > 0 && (
+				<TaskPrStatusPopover prInfo={prInfo} projectId={projectId} taskId={taskId} onShowUnresolved={onShowUnresolved}>
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							window.open(prInfo.url, "_blank");
+						}}
+						className="inline-flex h-5 flex-shrink-0 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 font-mono text-dense font-semibold leading-none text-warning-strong transition-colors hover:bg-warning/20"
+						aria-label={t.plural("task.prUnresolvedComments", unresolvedCount)}
+					>
+						<span className="text-micro leading-none" style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}>{"\uF086"}</span>
+						<span className="leading-none">{unresolvedCount}</span>
+					</button>
+				</TaskPrStatusPopover>
+			)}
+		</>
+	);
+}

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -1483,7 +1483,11 @@ describe("pull-request badges", () => {
 			},
 		})]);
 
-		expect(screen.getByText("Conflicts")).toBeInTheDocument();
+		// On this ~200px row the merge verdict is glyph-only, so the word has to
+		// survive in the accessible name and the tooltip instead of on screen.
+		const merge = screen.getByLabelText("PR is not mergeable — click to open the PR — Conflicts");
+		expect(merge).toHaveAttribute("title", "Conflicts");
+		expect(merge).not.toHaveTextContent("Conflicts");
 		expect(screen.getByLabelText("Changes requested — click to open the PR")).toBeInTheDocument();
 		expect(screen.getByLabelText("3 unresolved comments")).toBeInTheDocument();
 	});
@@ -1494,6 +1498,28 @@ describe("pull-request badges", () => {
 
 		await user.hover(screen.getByLabelText("Open PR #1591"));
 		await waitFor(() => expect(screen.getByTestId("pr-status-popover")).toBeInTheDocument());
+	});
+
+	it("keeps the merge verdict's word out of the row but reachable", () => {
+		renderWith([prTask({
+			prStatusCache: {
+				number: 1591,
+				url: "https://github.com/h0x91b/dev-3.0/pull/1591",
+				ciStatus: "success",
+				reviewState: "approved",
+				reviewDecision: "approved",
+				unresolvedCount: 0,
+				mergeState: { mergeable: "MERGEABLE", status: "CLEAN" },
+				checks: [],
+				prTitle: "Ship the badge",
+				isDraft: false,
+				cachedAt: "2026-08-30T00:00:00Z",
+			},
+		})]);
+
+		// The word is 77px of a 200px line; it must not be rendered as text here.
+		expect(screen.queryByText("Mergeable")).not.toBeInTheDocument();
+		expect(screen.getByLabelText("PR is mergeable — click to open the PR — Mergeable")).toBeInTheDocument();
 	});
 
 	it("renders no PR badge for a task nothing has ever seen a PR for", () => {
@@ -1530,6 +1556,6 @@ describe("pull-request badges", () => {
 		}));
 
 		await waitFor(() => expect(screen.getByLabelText("PR approved — click to open the PR")).toBeInTheDocument());
-		expect(screen.getByText("Mergeable")).toBeInTheDocument();
+		expect(screen.getByLabelText("PR is mergeable — click to open the PR — Mergeable")).toHaveAttribute("title", "Mergeable");
 	});
 });

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -32,6 +32,8 @@ vi.mock("../../rpc", () => ({
 			getAllProjectTasks: vi.fn(() => Promise.resolve([])),
 			getSpaces: vi.fn(() => Promise.resolve({ version: 1, spaces: [], order: [] })),
 			setTaskPriority: vi.fn(() => Promise.resolve([])),
+			getProjectPRs: vi.fn(() => Promise.resolve([])),
+			refreshTaskPrStatus: vi.fn(() => Promise.resolve(undefined)),
 			// Feature-discovery tip rotation (useTipRotation).
 			getGlobalSettings: vi.fn(() => Promise.resolve({ tipsDisabled: true })),
 			getTipState: vi.fn(() => Promise.resolve({ snoozedUntil: 0, seen: {}, rotationIndex: 0 })),
@@ -1425,5 +1427,109 @@ describe("ActiveTasksSidebar — dashboard mount (no current project)", () => {
 		});
 		await user.click(screen.getByTestId("sidebar-preset-all"));
 		await waitFor(() => expect(screen.getByText("Привет! как сам?")).toBeInTheDocument());
+	});
+});
+
+describe("pull-request badges", () => {
+	const prTask = (overrides?: Partial<Task>) => makeTask({
+		prNumber: 1591,
+		prUrl: "https://github.com/h0x91b/dev-3.0/pull/1591",
+		...overrides,
+	});
+
+	function renderWith(tasks: Task[]) {
+		return render(
+			<I18nProvider>
+				<ActiveTasksSidebar
+					project={project}
+					tasks={tasks}
+					activeTaskId={undefined}
+					dispatch={vi.fn()}
+					navigate={vi.fn()}
+					agents={[claudeAgent]}
+					bellCounts={new Map()}
+					taskPorts={new Map()}
+				/>
+			</I18nProvider>,
+		);
+	}
+
+	it("shows the PR number from the task's sticky fields and opens the PR on click", async () => {
+		const user = userEvent.setup();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		renderWith([prTask()]);
+
+		const badge = screen.getByLabelText("Open PR #1591");
+		expect(badge).toHaveTextContent("#1591");
+		await user.click(badge);
+		expect(open).toHaveBeenCalledWith("https://github.com/h0x91b/dev-3.0/pull/1591", "_blank");
+		open.mockRestore();
+	});
+
+	it("renders merge state, review verdict and unresolved comments from the persisted cache", () => {
+		renderWith([prTask({
+			prStatusCache: {
+				number: 1591,
+				url: "https://github.com/h0x91b/dev-3.0/pull/1591",
+				ciStatus: "success",
+				reviewState: "changes_requested",
+				reviewDecision: "changes_requested",
+				unresolvedCount: 3,
+				mergeState: { mergeable: "CONFLICTING", status: "DIRTY" },
+				checks: [],
+				prTitle: "Ship the badge",
+				isDraft: false,
+				cachedAt: "2026-08-30T00:00:00Z",
+			},
+		})]);
+
+		expect(screen.getByText("Conflicts")).toBeInTheDocument();
+		expect(screen.getByLabelText("Changes requested — click to open the PR")).toBeInTheDocument();
+		expect(screen.getByLabelText("3 unresolved comments")).toBeInTheDocument();
+	});
+
+	it("opens the shared status popover on hover", async () => {
+		const user = userEvent.setup();
+		renderWith([prTask()]);
+
+		await user.hover(screen.getByLabelText("Open PR #1591"));
+		await waitFor(() => expect(screen.getByTestId("pr-status-popover")).toBeInTheDocument());
+	});
+
+	it("renders no PR badge for a task nothing has ever seen a PR for", () => {
+		renderWith([makeTask()]);
+		expect(screen.queryByLabelText(/Open PR/)).not.toBeInTheDocument();
+		expect(screen.getByText("Привет! как сам?")).toBeInTheDocument();
+	});
+
+	it("never fires the board's per-project PR discovery lookup", async () => {
+		const { api } = await import("../../rpc");
+		renderWith([prTask()]);
+		await waitFor(() => expect(screen.getByLabelText("Open PR #1591")).toBeInTheDocument());
+		expect(api.request.getProjectPRs).not.toHaveBeenCalled();
+	});
+
+	it("follows the taskPrStatus push, which carries PR state instead of taskUpdated", async () => {
+		renderWith([prTask()]);
+		expect(screen.queryByLabelText("PR approved — click to open the PR")).not.toBeInTheDocument();
+
+		window.dispatchEvent(new CustomEvent("rpc:taskPrStatus", {
+			detail: {
+				projectId: "p1",
+				taskId: "t1",
+				prNumber: 1591,
+				prUrl: "https://github.com/h0x91b/dev-3.0/pull/1591",
+				ciStatus: "success",
+				reviewState: "approved",
+				unresolvedCount: 0,
+				mergeState: { mergeable: "MERGEABLE", status: "CLEAN" },
+				checks: [],
+				prTitle: "Ship the badge",
+				isDraft: false,
+			},
+		}));
+
+		await waitFor(() => expect(screen.getByLabelText("PR approved — click to open the PR")).toBeInTheDocument());
+		expect(screen.getByText("Mergeable")).toBeInTheDocument();
 	});
 });

--- a/src/mainview/hooks/useTaskPrBadges.ts
+++ b/src/mainview/hooks/useTaskPrBadges.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { PRInfo, Task, TaskPRBadgeInfo } from "../../shared/types";
+import { api } from "../rpc";
+import { startVisibilityAwarePoll } from "../utils/poll";
+import { hydrateTaskPRMap, samePRMap, type PRIdentity } from "../utils/taskPrBadge";
+
+interface UseTaskPrBadgesOptions {
+	tasks: Task[];
+	/**
+	 * Projects to discover PRs for by matching branch names (`getProjectPRs`,
+	 * once per project per minute). Omit it and the map is built purely from what
+	 * each task already carries — no network at all. A surface that spans every
+	 * project (the Active Tasks sidebar in global scope) must omit it: the same
+	 * poll that costs the board one lookup would cost it one per project.
+	 */
+	discoverProjectIds?: string[];
+	/** Ignore `taskPrStatus` pushes for projects this surface is not showing. */
+	knowsProject?: (projectId: string) => boolean;
+}
+
+/**
+ * Per-task PR badge data for any surface holding a task list.
+ *
+ * Two channels feed it, and the second one is easy to miss: the backend pushes
+ * `taskPrStatus` — NOT `taskUpdated` — when prWatch sees new PR state, so a
+ * surface that only listens to `taskUpdated` shows a `prStatusCache` that goes
+ * stale mid-session.
+ */
+export function useTaskPrBadges({ tasks, discoverProjectIds, knowsProject }: UseTaskPrBadgesOptions): Map<string, TaskPRBadgeInfo> {
+	// Branch-matched identities from the discovery poll: they are not on the task
+	// yet, so hydration would drop them on the next task update without this.
+	const discovered = useRef(new Map<string, PRIdentity>());
+	const identityOf = useCallback(
+		(task: Task) => (task.branchName ? discovered.current.get(`${task.projectId}::${task.branchName}`) : undefined),
+		[],
+	);
+	const [map, setMap] = useState<Map<string, TaskPRBadgeInfo>>(() => hydrateTaskPRMap(tasks, undefined, identityOf));
+
+	const rehydrate = useCallback(() => {
+		setMap((prev) => {
+			const next = hydrateTaskPRMap(tasks, prev, identityOf);
+			return samePRMap(prev, next) ? prev : next;
+		});
+	}, [tasks, identityOf]);
+
+	useEffect(rehydrate, [rehydrate]);
+
+	const projectIdsKey = discoverProjectIds?.join(",") ?? "";
+	useEffect(() => {
+		if (!projectIdsKey) return;
+		const projectIds = projectIdsKey.split(",");
+		const fetchPRs = () => {
+			// One lookup per project: a branch name is only unique inside its own
+			// repository, so the branch→PR map is per project too.
+			Promise.all(
+				projectIds.map((projectId) =>
+					api.request.getProjectPRs({ projectId }).then(
+						(prs: PRInfo[]) => [projectId, prs] as const,
+						() => [projectId, [] as PRInfo[]] as const,
+					),
+				),
+			).then((results) => {
+				const next = new Map<string, PRIdentity>();
+				for (const [projectId, prs] of results) {
+					for (const pr of prs) next.set(`${projectId}::${pr.headRefName}`, { number: pr.number, url: pr.url });
+				}
+				discovered.current = next;
+				rehydrate();
+			}).catch(() => {});
+		};
+		return startVisibilityAwarePoll({ fn: fetchPRs, intervalMs: 60_000 });
+	}, [projectIdsKey, rehydrate]);
+
+	useEffect(() => {
+		function onPrStatus(e: Event) {
+			const detail = (e as CustomEvent).detail as {
+				projectId: string;
+				taskId: string;
+				prNumber: number | null;
+				prUrl: string | null;
+			} & Omit<TaskPRBadgeInfo, "number" | "url">;
+			if (knowsProject && !knowsProject(detail.projectId)) return;
+			setMap((prev) => {
+				const existing = prev.get(detail.taskId);
+				const number = detail.prNumber ?? existing?.number;
+				const url = detail.prUrl ?? existing?.url;
+				if (number === undefined || url === undefined) return prev;
+				const next = new Map(prev);
+				next.set(detail.taskId, {
+					number,
+					url,
+					autoMergeEnabled: detail.autoMergeEnabled,
+					ciStatus: detail.ciStatus,
+					reviewState: detail.reviewState,
+					reviewDecision: detail.reviewDecision,
+					unresolvedCount: detail.unresolvedCount,
+					mergeState: detail.mergeState,
+					checks: detail.checks ?? [],
+					prTitle: detail.prTitle,
+					isDraft: detail.isDraft,
+				});
+				return next;
+			});
+		}
+		window.addEventListener("rpc:taskPrStatus", onPrStatus);
+		return () => window.removeEventListener("rpc:taskPrStatus", onPrStatus);
+	}, [knowsProject]);
+
+	return map;
+}

--- a/src/mainview/utils/taskPrBadge.ts
+++ b/src/mainview/utils/taskPrBadge.ts
@@ -1,0 +1,91 @@
+import type { Task, TaskPRBadgeInfo } from "../../shared/types";
+
+export type PRIdentity = Pick<TaskPRBadgeInfo, "number" | "url">;
+
+export function samePRIdentity(left: TaskPRBadgeInfo | null | undefined, right: PRIdentity): boolean {
+	return left?.number === right.number && left.url === right.url;
+}
+
+/**
+ * The PR badge a task carries on its own, with no network at all: sticky
+ * `prNumber`/`prUrl` for identity plus the `prStatusCache` the backend prWatch
+ * activity persists. Every status field falls back to null, so a task whose PR
+ * nothing has polled yet yields an identity-only badge rather than nothing.
+ */
+export function taskPRBadgeFromStoredData(task: Task, identity?: PRIdentity): TaskPRBadgeInfo | null {
+	const cache = task.prStatusCache;
+	const sticky = task.prNumber != null && task.prUrl ? { number: task.prNumber, url: task.prUrl } : undefined;
+	const cachedIdentity = cache?.url ? { number: cache.number, url: cache.url } : undefined;
+	const pr = identity ?? sticky ?? cachedIdentity;
+	if (!pr) return null;
+	const cached = cache && samePRIdentity({ number: cache.number, url: cache.url }, pr) ? cache : null;
+	return {
+		number: pr.number,
+		url: pr.url,
+		autoMergeEnabled: cached?.autoMergeEnabled ?? null,
+		ciStatus: cached?.ciStatus ?? null,
+		reviewState: cached?.reviewState ?? null,
+		reviewDecision: cached?.reviewDecision ?? null,
+		unresolvedCount: cached?.unresolvedCount ?? null,
+		mergeState: cached?.mergeState ?? null,
+		checks: cached?.checks ?? [],
+		prTitle: cached?.prTitle ?? null,
+		isDraft: cached?.isDraft ?? null,
+	};
+}
+
+/** Stored data, with the fresher in-session fields of a same-PR entry kept. */
+export function mergeTaskPRBadge(
+	task: Task,
+	identity: PRIdentity | undefined,
+	existing: TaskPRBadgeInfo | undefined,
+): TaskPRBadgeInfo | null {
+	const stored = taskPRBadgeFromStoredData(task, identity);
+	if (!stored) return null;
+	if (!existing || !samePRIdentity(existing, stored)) return stored;
+	return {
+		...stored,
+		autoMergeEnabled: existing.autoMergeEnabled ?? stored.autoMergeEnabled,
+		ciStatus: existing.ciStatus ?? stored.ciStatus,
+		reviewState: existing.reviewState ?? stored.reviewState,
+		reviewDecision: existing.reviewDecision ?? stored.reviewDecision,
+		unresolvedCount: existing.unresolvedCount ?? stored.unresolvedCount,
+		mergeState: existing.mergeState ?? stored.mergeState,
+		checks: existing.checks && existing.checks.length > 0 ? existing.checks : stored.checks,
+		prTitle: existing.prTitle ?? stored.prTitle,
+		isDraft: existing.isDraft ?? stored.isDraft,
+	};
+}
+
+export function hydrateTaskPRMap(
+	tasks: Task[],
+	previous = new Map<string, TaskPRBadgeInfo>(),
+	identityOf?: (task: Task) => PRIdentity | undefined,
+): Map<string, TaskPRBadgeInfo> {
+	const next = new Map<string, TaskPRBadgeInfo>();
+	for (const task of tasks) {
+		const badge = mergeTaskPRBadge(task, identityOf?.(task), previous.get(task.id));
+		if (badge) next.set(task.id, badge);
+	}
+	return next;
+}
+
+/** True when two badge maps are interchangeable, so a re-render can be skipped. */
+export function samePRMap(a: Map<string, TaskPRBadgeInfo>, b: Map<string, TaskPRBadgeInfo>): boolean {
+	if (a.size !== b.size) return false;
+	for (const [taskId, badge] of a) {
+		const other = b.get(taskId);
+		if (!other) return false;
+		if (badge === other) continue;
+		const keys = Object.keys(badge) as (keyof TaskPRBadgeInfo)[];
+		if (keys.length !== Object.keys(other).length) return false;
+		for (const key of keys) {
+			if (key === "checks") {
+				if ((badge.checks?.length ?? 0) !== (other.checks?.length ?? 0)) return false;
+				continue;
+			}
+			if (badge[key] !== other[key]) return false;
+		}
+	}
+	return true;
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

The Active Tasks sidebar was the one surface that showed a task without its pull request. It now carries the same badge cluster the Kanban card does — PR number, merge state, review verdict, unresolved-comment count — each badge opening the PR on click and the shared checks/conflict popover on hover.

The cluster itself moved out of `TaskCard.tsx` into `TaskPrBadges.tsx`, and the badge-map plumbing (stored task data + the `taskPrStatus` push + the board's optional branch→PR lookup) into a `useTaskPrBadges` hook, so the two surfaces share one implementation instead of two that can drift.

The sidebar costs no extra network calls: PR state is already persisted on the task (`prNumber`/`prUrl` + `prStatusCache`) and stays fresh through the `taskPrStatus` push. It deliberately skips the board's `getProjectPRs` discovery poll — in global scope the sidebar spans every project, so that poll would fan out to one `gh` lookup per project per minute where the board needs one. Reasoning and the degraded case are in `decisions/2026/08/30/sidebar-pr-badge-without-discovery-poll.md`.

A pull request with no polled state yet renders as the number alone — no spinner, no guessed approval — and a task with no PR renders exactly as before.

Known gap, deliberately out of scope: the Dashboard's Activity list still has no badge. Its rows are single `<button>` elements, so a nested badge button needs the row restructured — a different change on a different surface.

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6397ff4a-1bfd-4b33-9501-217918311296) · `dev3://task/6397ff4a-1bfd-4b33-9501-217918311296`


---

**On the five local backend timeouts, so nobody re-litigates them:** a renderer-only diff cannot cause a timeout in three git-spawning suites that import nothing from `src/mainview`. The same three suites, at the same commit, re-run in isolation at load average 10 pass 43 of 43 — the local run that showed them red was at load average 19.91, with zero `AssertionError` in it.
