### PR TITLE
Retry git worktree add on config-lock contention

### DIFF
--- a/change-logs/2026/08/30/fix-worktree-add-config-lock-retry.md
+++ b/change-logs/2026/08/30/fix-worktree-add-config-lock-retry.md
@@ -1,0 +1,3 @@
+Short: Variant starts no longer lose a git lock race
+
+Starting a task with several variants could fail with "could not lock config file .git/config: File exists", because the variants write their branch tracking config at the same moment. Worktree creation now retries up to three times with backoff, cleaning up the half-created branch between attempts.

--- a/decisions/2026/08/30/retry-worktree-add-on-config-lock.md
+++ b/decisions/2026/08/30/retry-worktree-add-on-config-lock.md
@@ -1,0 +1,40 @@
+# Retry `git worktree add` on config-lock contention
+
+## Context
+
+Starting a task with several variants runs several `git worktree add` against the
+same repository at once. Each one writes the new branch's upstream config into the
+shared `.git/config`, so the losers of the `config.lock` race die with
+`error: could not lock config file .git/config: File exists` /
+`error: unable to write upstream branch configuration`, and the task bounces back
+to To Do.
+
+## Investigation
+
+Reproduced by holding `.git/config.lock` and running
+`git worktree add -b dev3/task-xxxx ../wt origin/main`: git exits 255 **after the
+branch already exists** — modern git spawns `git branch` as a child before it
+creates the worktree directory, and `install_branch_config` failing there is fatal.
+A naive retry therefore fails with "a branch named … already exists".
+
+## Decision
+
+`worktreeAddWithRetry` in `src/bun/git.ts` wraps all five `git worktree add` call
+sites in `createWorktree`. It retries only on lock contention
+(`isGitLockContention`: `could not lock config file`, or any `*.lock … File exists`)
+with a 200/500/1200 ms backoff, and before each retry re-runs
+`reclaimStaleWorktreeDir` plus a `git branch -D` of the branch **that attempt
+created** — never a branch that already existed, which is why the caller passes the
+branch name explicitly instead of the helper guessing it.
+
+## Risks
+
+Three retries add up to ~1.9 s to a genuinely stuck start (a stale `config.lock`
+nobody owns). Retrying an add that already checked something out is prevented by
+matching stderr, not by exit code.
+
+## Alternatives considered
+
+A repo-wide mutex around worktree creation would serialize variants and remove the
+race entirely, but it only covers dev3's own processes — the user's shell, an agent,
+or another dev3 install can hold `config.lock` just the same. Retrying handles both.

--- a/src/bun/__tests__/git-worktree.test.ts
+++ b/src/bun/__tests__/git-worktree.test.ts
@@ -34,7 +34,7 @@ import {
 	recoverStaleInitializingWorktrees,
 	taskDir,
 } from "../git";
-import { createTestRepo, cleanup, makeTaskCommits, g, type TestRepo } from "./git-test-helpers";
+import { createTestRepo, cleanup, makeTaskCommits, g, spawnedCommands, type TestRepo } from "./git-test-helpers";
 
 // ─── Shared factories ────────────────────────────────────────────────────────
 
@@ -559,6 +559,59 @@ describe("createWorktree", () => {
 
 		g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
 		g("git branch -D dev3/task-dddddddd", repo.local);
+	});
+
+	// Variants of one task race for .git/config.lock while writing the new
+	// branch's upstream config; the loser exits after the branch already exists.
+	it("retries through .git/config lock contention held by another git process", async () => {
+		const project = makeProject(repo.local);
+		const task = makeTask({ id: "abababab-cdcd-efef-0101-232323232323" });
+		const lockPath = join(repo.local, ".git", "config.lock");
+		writeFileSync(lockPath, "");
+		const before = spawnedCommands.length;
+		// Released only once the first attempt has provably failed — the retry's
+		// `branch -D` of the leftover branch is what proves it. A timer here would
+		// let the lock expire before git ever reached the config write.
+		const release = setInterval(() => {
+			const cleanedUp = spawnedCommands
+				.slice(before)
+				.some((cmd) => cmd.join(" ").includes("branch -D dev3/task-abababab"));
+			if (cleanedUp) rmSync(lockPath, { force: true });
+		}, 5);
+
+		try {
+			const result = await createWorktree(project, task);
+			expect(existsSync(result.worktreePath)).toBe(true);
+			expect(result.branchName).toBe("dev3/task-abababab");
+			const adds = spawnedCommands
+				.slice(before)
+				.filter((cmd) => cmd.join(" ").includes("worktree add"));
+			expect(adds.length).toBeGreaterThanOrEqual(2);
+			g(`git worktree remove --force "${result.worktreePath}"`, repo.local);
+			g("git branch -D dev3/task-abababab", repo.local);
+		} finally {
+			clearInterval(release);
+			rmSync(lockPath, { force: true });
+		}
+	});
+
+	it("gives up after 3 retries when the config lock is never released", async () => {
+		const project = makeProject(repo.local);
+		const task = makeTask({ id: "bcbcbcbc-cdcd-efef-0101-232323232323" });
+		const lockPath = join(repo.local, ".git", "config.lock");
+		writeFileSync(lockPath, "");
+		const before = spawnedCommands.length;
+
+		try {
+			await expect(createWorktree(project, task)).rejects.toThrow(/could not lock config file/);
+			const adds = spawnedCommands
+				.slice(before)
+				.filter((cmd) => cmd.join(" ").includes("worktree add"));
+			expect(adds).toHaveLength(4);
+		} finally {
+			rmSync(lockPath, { force: true });
+			g("git branch -D dev3/task-bcbcbcbc", repo.local);
+		}
 	});
 });
 

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -961,6 +961,41 @@ async function reclaimStaleWorktreeDir(project: Project, wtPath: string): Promis
 	await run(["git", "worktree", "prune"], project.path);
 }
 
+const WORKTREE_ADD_RETRY_DELAYS_MS = [200, 500, 1_200];
+
+/** Lock files git creates per-operation: another git process holds one right now. */
+function isGitLockContention(stderr: string): boolean {
+	return /could not lock config file/i.test(stderr)
+		|| (/\.lock/.test(stderr) && /File exists/i.test(stderr));
+}
+
+/**
+ * `git worktree add` writes the new branch's tracking config into the repo-wide
+ * .git/config, so variants of one task starting together lose the race for
+ * config.lock ("could not lock config file … File exists"). The loser only has
+ * to wait — but the failed attempt already created the branch, so every retry
+ * re-runs the same reclaim the first attempt did.
+ */
+async function worktreeAddWithRetry(
+	args: string[],
+	project: Project,
+	wtPath: string,
+	createdBranch: string | undefined,
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+	let result = await run(args, project.path);
+	for (const delayMs of WORKTREE_ADD_RETRY_DELAYS_MS) {
+		if (result.ok || !isGitLockContention(result.stderr)) break;
+		log.warn("Worktree add hit git lock contention, retrying", { wtPath, delayMs, stderr: result.stderr });
+		await new Promise((resolve) => setTimeout(resolve, delayMs));
+		await reclaimStaleWorktreeDir(project, wtPath);
+		if (createdBranch && await localBranchExists(project.path, createdBranch)) {
+			await run(["git", "branch", "-D", createdBranch], project.path);
+		}
+		result = await run(args, project.path);
+	}
+	return result;
+}
+
 export async function createWorktree(
 	project: Project,
 	task: Task,
@@ -986,14 +1021,20 @@ export async function createWorktree(
 		await reclaimStaleWorktreeDir(project, wtPath);
 		// A leftover variant branch (re-run of a task that kept its branch) is
 		// checked out instead of recreated, so its commits survive the re-run.
-		const variantAddArgs = await localBranchExists(project.path, variantBranchName)
+		const variantBranchSurvived = await localBranchExists(project.path, variantBranchName);
+		const variantAddArgs = variantBranchSurvived
 			? ["git", "worktree", "add", wtPath, variantBranchName]
 			: ["git", "worktree", "add", "-b", variantBranchName, wtPath, resolvedBase];
 
 		const result = await measureGitStep(
 			"createWorktree.variant.worktreeAdd",
 			{ taskId: task.id.slice(0, 8), wtPath, variantBranchName, base: resolvedBase },
-			() => run(variantAddArgs, project.path),
+			() => worktreeAddWithRetry(
+				variantAddArgs,
+				project,
+				wtPath,
+				variantBranchSurvived ? undefined : variantBranchName,
+			),
 		);
 
 		if (!result.ok) {
@@ -1022,9 +1063,11 @@ export async function createWorktree(
 		const result = await measureGitStep(
 			"createWorktree.existing.worktreeAdd",
 			{ taskId: task.id.slice(0, 8), wtPath, resolvedBranch, isRemoteRef },
-			() => run(
+			() => worktreeAddWithRetry(
 				["git", "worktree", "add", wtPath, resolvedBranch],
-				project.path,
+				project,
+				wtPath,
+				undefined,
 			),
 		);
 
@@ -1042,9 +1085,11 @@ export async function createWorktree(
 				const trackResult = await measureGitStep(
 					"createWorktree.existing.trackRemoteBranch",
 					{ taskId: task.id.slice(0, 8), wtPath, resolvedBranch, existingBranch },
-					() => run(
+					() => worktreeAddWithRetry(
 						["git", "worktree", "add", "--track", "-b", resolvedBranch, wtPath, existingBranch],
-						project.path,
+						project,
+						wtPath,
+						resolvedBranch,
 					),
 				);
 				if (!trackResult.ok) {
@@ -1064,9 +1109,11 @@ export async function createWorktree(
 				const fallbackResult = await measureGitStep(
 					"createWorktree.existing.fallbackBranch",
 					{ taskId: task.id.slice(0, 8), wtPath, taskBranch, resolvedBranch },
-					() => run(
+					() => worktreeAddWithRetry(
 						["git", "worktree", "add", "-b", taskBranch, wtPath, resolvedBranch],
-						project.path,
+						project,
+						wtPath,
+						taskBranch,
 					),
 				);
 				if (!fallbackResult.ok) {
@@ -1162,9 +1209,11 @@ export async function createWorktree(
 	const result = await measureGitStep(
 		"createWorktree.default.worktreeAdd",
 		{ taskId: task.id.slice(0, 8), wtPath, branch, resolvedBase },
-		() => run(
+		() => worktreeAddWithRetry(
 			["git", "worktree", "add", "-b", branch, wtPath, resolvedBase],
-			project.path,
+			project,
+			wtPath,
+			branch,
 		),
 	);
 


### PR DESCRIPTION
Starting a task with several variants runs several `git worktree add` against the same repo at once. Each writes the new branch's upstream config into the shared `.git/config`, so the losers of the `config.lock` race die with `could not lock config file .git/config: File exists` / `unable to write upstream branch configuration` and the task bounces back to To Do.

`worktreeAddWithRetry` now wraps all five `git worktree add` call sites in `createWorktree`: it retries only on lock contention (200/500/1200 ms backoff) and, before each retry, re-runs the stale-worktree reclaim plus a `git branch -D` of the branch **that attempt** created — git creates the branch before it fails, so a naive retry would hit "a branch named … already exists".

Reasoning and the reproduction: `decisions/2026/08/30/retry-worktree-add-on-config-lock.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ea2506bc-dd78-43b5-b46e-1e5bbb975b31) · `dev3://task/ea2506bc-dd78-43b5-b46e-1e5bbb975b31`