### PR TITLE
Keep the paste gap before a held message's Enter

### DIFF
--- a/change-logs/2026/08/30/fix-held-message-enter-swallowed.md
+++ b/change-logs/2026/08/30/fix-held-message-enter-swallowed.md
@@ -1,0 +1,3 @@
+Short: dev3 message no longer gets stuck unsent
+
+A `dev3 message` sometimes pasted its whole text into the receiving Claude Code pane without submitting it, and every later message then piled onto the same unsubmitted input box. The Enter that ends a held burst now keeps the same 800 ms gap behind it that button hand-offs already had, so the agent's input layer cannot read it as part of the paste.

--- a/decisions/2026/08/30/held-message-enter-keeps-the-paste-gap.md
+++ b/decisions/2026/08/30/held-message-enter-keeps-the-paste-gap.md
@@ -1,0 +1,53 @@
+# The held message's Enter keeps the hand-off's paste gap
+
+## Context
+
+`dev3 message` sometimes landed its whole text in the receiving Claude Code pane and never
+submitted it. From then on the pane stayed stuck: every later message was appended to the same
+unsubmitted input box, so a stream of messages piled up and the receiving agent read none of them.
+
+## Investigation
+
+`AGENT_PROMPT_ENTER_DELAY_MS` (800 ms) exists precisely because Claude Code's input layer reads a
+fast "text then CR" as one paste, newline included, and inserts it into the prompt box instead of
+submitting. Button hand-offs (`agentPromptStages`) carry that gap as a stage delay.
+
+Held messages did not. In
+[`hold-the-enter-behind-dev3-message`](../21/hold-the-enter-behind-dev3-message.md) the text was
+typed on arrival and the Enter followed ten seconds later, so no gap was needed. When
+[`hold-the-agent-message-not-just-its-enter`](../23/hold-the-agent-message-not-just-its-enter.md)
+moved the TEXT into the hold as well, `release()` came to call `deliver()` and then `submit()`
+back to back — two `tmux send-keys` spawns apart, tens of milliseconds — which is exactly the
+window the 800 ms constant was introduced to avoid. The app's own logs support this: over five
+days no `held agent message submit did not land` warning was ever written, so tmux always accepted
+the Enter and the receiving app swallowed it.
+
+## Decision
+
+The gap moves to where the Enter is produced, per backend, so the hold module keeps meaning
+*when* the burst is released rather than *how* it is typed:
+
+- tmux — `agentPromptSubmitStages()` (`src/bun/agent-prompt.ts`) carries
+  `delayBeforeMs: AGENT_PROMPT_ENTER_DELAY_MS`. It fits under `PANE_INPUT_LIMITS.maxTotalDelayMs`
+  (2 s) and the default 5 s deadline.
+- native — the held `submit` in `performNativeDelivery` (`src/bun/agent-prompt-native.ts`) goes
+  through `scheduleAgentPromptSubmit`, the same helper the hand-off path uses.
+
+## Risks
+
+- The user can start typing inside the extra 800 ms and his keystrokes then ride into the submitted
+  burst. That race is unchanged in kind — the delivery already spans two guarded sends — and 800 ms
+  after a 15 s hold is a rounding error against it.
+- 800 ms is a heuristic against another program's paste detection, not a proof. A far slower box
+  could still deliver the CR inside the paste window; the failure mode is unchanged and visible on
+  screen.
+
+## Alternatives considered
+
+- **Send Enter twice.** Breaks the load-bearing "one burst, one Enter" invariant: when the first CR
+  does submit, the second lands in the agent's running turn and can submit whatever the user has
+  typed since.
+- **Capture the pane after the Enter and re-send when the text is still sitting there.** Genuinely
+  robust, but it needs pane-content parsing on tmux and has no counterpart at all on native.
+- **Put the sleep in `release()`.** One place for both backends, but it makes the hold module own a
+  Claude-Code paste detail and pushes the wait outside the pane-input seam's deadline accounting.

--- a/src/bun/__tests__/agent-prompt-native.test.ts
+++ b/src/bun/__tests__/agent-prompt-native.test.ts
@@ -161,6 +161,10 @@ describe("sendPromptToNativeAgentPane — this process owns the lease", () => {
 		expect(writes).toEqual([]);
 
 		await vi.advanceTimersByTimeAsync(AGENT_MESSAGE_HOLD_IDLE_MS);
+		expect(writes).toEqual(["one", "two"]);
+
+		// The CR keeps the hand-off's gap behind it, or the burst's last paste swallows it.
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
 		expect(writes).toEqual(["one", "two", "\r"]);
 
 		resetAgentMessageHolds();
@@ -172,7 +176,7 @@ describe("sendPromptToNativeAgentPane — this process owns the lease", () => {
 
 		await sendPromptToNativeAgentPane(task(), "one", { hold: true });
 		flushHeldAgentMessagesForTask(TASK_ID);
-		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
 		expect(writes).toEqual(["one", "\r"]);
 
 		resetAgentMessageHolds();

--- a/src/bun/__tests__/agent-prompt.test.ts
+++ b/src/bun/__tests__/agent-prompt.test.ts
@@ -263,9 +263,15 @@ describe("the held dev3 message — nothing reaches the pane until it goes quiet
 		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
 		expect(tmux.sendKeysGuarded).not.toHaveBeenCalled();
 
-		await vi.advanceTimersByTimeAsync(AGENT_MESSAGE_HOLD_IDLE_MS);
-		expect(tmux.sendKeysGuarded).toHaveBeenCalledTimes(2);
+		// Exactly to the release: the text goes in and the Enter does not follow it yet.
+		await vi.advanceTimersByTimeAsync(AGENT_MESSAGE_HOLD_IDLE_MS - AGENT_PROMPT_ENTER_DELAY_MS);
+		expect(tmux.sendKeysGuarded).toHaveBeenCalledTimes(1);
 		expect(sentChunks(0)).toEqual([{ literal: "check CI" }]);
+
+		// The Enter keeps the hand-off's gap behind it: sent in the same millisecond,
+		// Claude Code reads the paste and the CR as one paste and never submits.
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
+		expect(tmux.sendKeysGuarded).toHaveBeenCalledTimes(2);
 		expect(sentChunks(1)).toEqual([{ keys: ["Enter"] }]);
 		expect(sentPane(1)).toBe("%1");
 	});
@@ -277,7 +283,7 @@ describe("the held dev3 message — nothing reaches the pane until it goes quiet
 		}
 		expect(tmux.sendKeysGuarded).not.toHaveBeenCalled();
 
-		await vi.advanceTimersByTimeAsync(AGENT_MESSAGE_HOLD_IDLE_MS);
+		await vi.advanceTimersByTimeAsync(AGENT_MESSAGE_HOLD_IDLE_MS + AGENT_PROMPT_ENTER_DELAY_MS);
 		expect(tmux.sendKeysGuarded).toHaveBeenCalledTimes(4);
 		expect(sentChunks(0)).toEqual([{ literal: "one" }]);
 		expect(sentChunks(1)).toEqual([{ literal: "two" }]);
@@ -313,7 +319,7 @@ describe("the held dev3 message — nothing reaches the pane until it goes quiet
 	it("lands the moment the user submits his own line", async () => {
 		await holdMessageForAgentPane(TASK, "check CI", [agentPane("%1")]);
 		flushHeldAgentMessagesForTask(TASK_ID);
-		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ENTER_DELAY_MS);
 
 		expect(tmux.sendKeysGuarded).toHaveBeenCalledTimes(2);
 		expect(sentChunks(0)).toEqual([{ literal: "check CI" }]);

--- a/src/bun/agent-prompt-native.ts
+++ b/src/bun/agent-prompt-native.ts
@@ -117,7 +117,9 @@ function performNativeDelivery(
 				// there is — the same assumption the held CR has always been sent on.
 				return true;
 			},
-			submit: () => terminal.write(SUBMIT_KEY),
+			// The same gap a hand-off leaves: a CR written straight after the last paste
+			// is read as part of it, and the burst never gets submitted.
+			submit: () => scheduleAgentPromptSubmit(() => terminal.write(SUBMIT_KEY), { paneId }),
 		},
 		{ taskId: taskId.slice(0, 8), paneId },
 	);

--- a/src/bun/agent-prompt.ts
+++ b/src/bun/agent-prompt.ts
@@ -189,9 +189,14 @@ function agentMessageTextStages(prompt: string): PaneInputStage[] {
  * The submit-only program the Enter that ends a burst is delivered as. Separate from
  * the text because the seam caps a program's in-band delays at two seconds
  * ({@link PANE_INPUT_LIMITS}) and the quiet window is many times that.
+ *
+ * It still carries the hand-off's own gap: two back-to-back `send-keys` are milliseconds
+ * apart, and Claude Code then reads the burst's last paste and the CR as one paste with a
+ * newline in it — the text sits in the box unsubmitted, and every later message stacks
+ * onto it.
  */
 function agentPromptSubmitStages(): PaneInputStage[] {
-	return [{ steps: [{ kind: "key", key: "enter" }] }];
+	return [{ delayBeforeMs: AGENT_PROMPT_ENTER_DELAY_MS, steps: [{ kind: "key", key: "enter" }] }];
 }
 
 /**


### PR DESCRIPTION
A `dev3 message` sometimes pasted its whole text into the receiving Claude Code pane and never submitted it, and every later message then piled onto the same unsubmitted input box.

`AGENT_PROMPT_ENTER_DELAY_MS` (800 ms) exists because Claude Code reads a fast "text then CR" as one paste with a newline in it. Button hand-offs carry that gap; held messages lost it when the text moved into the hold — `release()` calls `deliver()` and `submit()` back to back, two `send-keys` spawns apart. The app's logs show no `submit did not land` warning in five days, so tmux always accepted the Enter and the receiving app swallowed it.

The gap now rides with the Enter itself, per backend: a `delayBeforeMs` on the tmux submit stage, and `scheduleAgentPromptSubmit` on the native one.

Decision record: `decisions/2026/08/30/held-message-enter-keeps-the-paste-gap.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=fc5e168c-2d0e-426d-ac3c-2899944f5197) · `dev3://task/fc5e168c-2d0e-426d-ac3c-2899944f5197`