### PR TITLE
Allow creating a space from the Add Project dialog

### DIFF
--- a/change-logs/2026/08/30/fix-create-space-from-add-project.md
+++ b/change-logs/2026/08/30/fix-create-space-from-add-project.md
@@ -1,0 +1,3 @@
+Short: Create a space while adding a project
+
+The Add Project dialog's space picker said "type a name to create one" but had no way to do it — no create row, and Enter did nothing, because the project it would belong to did not exist yet. Typing a name now adds it as a chip and the space is created together with the project.

--- a/decisions/2026/08/30/deferred-space-names-in-add-project.md
+++ b/decisions/2026/08/30/deferred-space-names-in-add-project.md
@@ -1,0 +1,21 @@
+# Deferred space names in the Add Project dialog
+
+## Context
+
+`SpacePicker` always rendered the empty state "No spaces yet — type a name to create one", but `ProjectSpacesField` passed `onCreateNew` only in connected mode. In the Add Project dialog (deferred mode) the create row therefore never appeared and Enter did nothing, so the copy promised something the dialog could not do.
+
+## Investigation
+
+The gap is not accidental: `createSpace` in `src/bun/spaces-data.ts` rejects an empty member list ("A space is never empty"), and `setProjectSpaces` soft-deletes a space whose last member leaves. Creating the space eagerly from the dialog would need either an empty space (breaking the invariant) or a stray space left behind whenever the user cancels the dialog.
+
+## Decision
+
+The deferred value became `DeferredSpaces = { spaceIds, newNames }` (`src/mainview/components/ProjectSpacesField.tsx`). A typed name is held as `newNames` and shown as a chip and as an already-ticked picker row; `applyDeferredSpaces(projectId, value)` creates each name with the new project as its first member and then writes the whole membership set once. `SpacePicker.onCreateNew` is now required, so no host can show the promise without honouring it.
+
+## Risks
+
+A name typed in the dialog is not reserved: another window can create the same name first, and the dialog then creates a second space with that name. Space names are not unique anywhere in the app, so this is a duplicate row, not a failure. If the clone succeeds and space creation fails, the project still exists and only a toast reports the miss — same as before.
+
+## Alternatives considered
+
+Allow `createSpace` with no members and let the dialog clean up on cancel — rejected: it weakens a backend invariant to serve one form, and a crashed or force-closed dialog leaks an empty space. Rewording the empty state to hide creation in deferred mode — rejected: the user explicitly wanted to create a space right there.

--- a/src/mainview/components/AddProjectModal.tsx
+++ b/src/mainview/components/AddProjectModal.tsx
@@ -11,7 +11,7 @@ import posthog from "../posthog";
 import { openFolderPicker, openFolderPickerMulti } from "../folder-picker";
 import { toast } from "../toast";
 import { useFocusTrap } from "../utils/useFocusTrap";
-import ProjectSpacesField from "./ProjectSpacesField";
+import ProjectSpacesField, { applyDeferredSpaces, type DeferredSpaces } from "./ProjectSpacesField";
 
 interface AddProjectModalProps {
 	dispatch: Dispatch<AppAction>;
@@ -40,16 +40,18 @@ function AddProjectModal({ dispatch, onClose, initialSpaceIds, onGitProjectsAdde
 	const [initializing, setInitializing] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [cloneOutput, setCloneOutput] = useState<string[]>([]);
-	const [pendingSpaceIds, setPendingSpaceIds] = useState<string[]>(initialSpaceIds ?? []);
+	const [pendingSpaces, setPendingSpaces] = useState<DeferredSpaces>({
+		spaceIds: initialSpaceIds ?? [],
+		newNames: [],
+	});
 	const cloneProgressIdRef = useRef<string | null>(null);
 	const urlInputRef = useRef<HTMLInputElement>(null);
 
 	// Membership is applied after the project exists; failures only toast —
 	// the project itself was created fine.
 	async function applyPendingSpaces(projectId: string) {
-		if (pendingSpaceIds.length === 0) return;
 		try {
-			await api.request.setProjectSpaces({ projectId, spaceIds: pendingSpaceIds });
+			await applyDeferredSpaces(projectId, pendingSpaces);
 		} catch (err) {
 			toast.error(t("spaces.failedUpdate", { error: String(err) }), { source: "dashboard" });
 		}
@@ -459,7 +461,7 @@ function AddProjectModal({ dispatch, onClose, initialSpaceIds, onGitProjectsAdde
 				{/* Optional space memberships, applied after the project is created */}
 				<div className="flex items-center gap-3">
 					<span className="text-fg-2 text-sm font-medium flex-shrink-0">{t("spaces.fieldLabel")}</span>
-					<ProjectSpacesField mode="deferred" value={pendingSpaceIds} onChange={setPendingSpaceIds} />
+					<ProjectSpacesField mode="deferred" value={pendingSpaces} onChange={setPendingSpaces} />
 				</div>
 				</>
 				)}

--- a/src/mainview/components/ProjectSpacesField.tsx
+++ b/src/mainview/components/ProjectSpacesField.tsx
@@ -7,11 +7,71 @@ import { useT } from "../i18n";
 import { useSpaces } from "../useSpaces";
 import SpacePicker from "./SpacePicker";
 
+/** A membership choice made before the project exists: spaces that already are,
+ *  plus names the user typed, which become spaces once the project id is known. */
+export interface DeferredSpaces {
+	spaceIds: string[];
+	newNames: string[];
+}
+
+export const EMPTY_DEFERRED_SPACES: DeferredSpaces = { spaceIds: [], newNames: [] };
+
+/** Turn a deferred choice into real membership. Creating first, then setting the
+ *  whole set, keeps one write per project regardless of how many names were typed. */
+export async function applyDeferredSpaces(projectId: string, value: DeferredSpaces): Promise<void> {
+	if (value.spaceIds.length === 0 && value.newNames.length === 0) return;
+	const createdIds: string[] = [];
+	for (const name of value.newNames) {
+		const space = await api.request.createSpace({ name, projectIds: [projectId] });
+		createdIds.push(space.id);
+	}
+	await api.request.setProjectSpaces({ projectId, spaceIds: [...value.spaceIds, ...createdIds] });
+}
+
 type ProjectSpacesFieldProps =
 	| { projectId: string; mode?: "connected" }
 	/** Deferred mode: pure controlled value for forms where the project id does
 	 *  not exist yet (create-project). No RPC calls happen inside the field. */
-	| { mode: "deferred"; value: string[]; onChange: (spaceIds: string[]) => void };
+	| { mode: "deferred"; value: DeferredSpaces; onChange: (value: DeferredSpaces) => void };
+
+function Chip({
+	name,
+	onRemove,
+	removeLabel,
+	testId,
+	masked,
+	badge,
+}: {
+	name: string;
+	onRemove: () => void;
+	removeLabel: string;
+	testId: string;
+	masked?: boolean;
+	badge?: string;
+}) {
+	return (
+		<span
+			className="group/chip inline-flex items-center gap-1.5 rounded-full border border-accent/30 bg-accent/10 pl-2.5 pr-1 py-1 text-xs text-accent"
+			data-testid={testId}
+		>
+			<span aria-hidden="true" className="w-1.5 h-1.5 rounded-full bg-accent/70 flex-shrink-0" />
+			<span className={`font-medium leading-none truncate max-w-[10rem] ${masked ? MASK_CLASS : ""}`}>{name}</span>
+			{badge && <span className="text-dense leading-none uppercase tracking-wide text-accent/70 flex-shrink-0">{badge}</span>}
+			<button
+				type="button"
+				onClick={onRemove}
+				title={removeLabel}
+				aria-label={removeLabel}
+				className="touch-inline flex items-center justify-center w-4 h-4 rounded-full flex-shrink-0 text-accent/70 bg-accent/15 opacity-0 group-hover/chip:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:text-accent hover:bg-accent/30 transition-[opacity,background-color,color]"
+				data-testid={`${testId}-remove`}
+			>
+				<svg aria-hidden="true" focusable="false" className="w-2 h-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+			</button>
+		</span>
+	);
+}
 
 /**
  * Self-contained membership field: a chip per space, each removable, plus a
@@ -25,13 +85,18 @@ function ProjectSpacesField(props: ProjectSpacesFieldProps) {
 	const anchorRef = useRef<HTMLButtonElement>(null);
 
 	const connected = props.mode !== "deferred";
+	const deferred = connected ? EMPTY_DEFERRED_SPACES : (props as { value: DeferredSpaces }).value;
 	const selectedIds = connected
 		? spacesOfProject(file.spaces, (props as { projectId: string }).projectId).map((s) => s.id)
-		: (props as { value: string[] }).value;
+		: deferred.spaceIds;
+
+	function emitDeferred(next: DeferredSpaces) {
+		(props as { onChange: (value: DeferredSpaces) => void }).onChange(next);
+	}
 
 	async function persist(nextIds: string[]) {
 		if (!connected) {
-			(props as { onChange: (ids: string[]) => void }).onChange(nextIds);
+			emitDeferred({ ...deferred, spaceIds: nextIds });
 			return;
 		}
 		const { projectId } = props as { projectId: string };
@@ -52,15 +117,26 @@ function ProjectSpacesField(props: ProjectSpacesFieldProps) {
 		void persist(next);
 	}
 
-	// Inline create needs a first member (a space is never empty), so it only
-	// exists in connected mode where the project id is real.
+	// A space is never empty, so a deferred host cannot create one yet: it keeps
+	// the name as a chip and `applyDeferredSpaces` creates it with the project.
 	async function handleCreateNew(name: string) {
+		if (!connected) {
+			const exists = [...spaces.map((s) => s.name), ...deferred.newNames].some(
+				(n) => n.toLowerCase() === name.toLowerCase(),
+			);
+			if (!exists) emitDeferred({ ...deferred, newNames: [...deferred.newNames, name] });
+			return;
+		}
 		const { projectId } = props as { projectId: string };
 		try {
 			await api.request.createSpace({ name, projectIds: [projectId] });
 		} catch (err) {
 			toast.error(t("spaces.failedCreate", { error: String(err) }));
 		}
+	}
+
+	function handleTogglePending(name: string) {
+		emitDeferred({ ...deferred, newNames: deferred.newNames.filter((n) => n !== name) });
 	}
 
 	const selectedSpaces = spaces.filter((s) => selectedIds.includes(s.id));
@@ -73,26 +149,24 @@ function ProjectSpacesField(props: ProjectSpacesFieldProps) {
 			    the chip, where the thing being removed is. */}
 			<div className="flex flex-wrap items-center gap-1.5">
 				{selectedSpaces.map((space) => (
-					<span
+					<Chip
 						key={space.id}
-						className="group/chip inline-flex items-center gap-1.5 rounded-full border border-accent/30 bg-accent/10 pl-2.5 pr-1 py-1 text-xs text-accent"
-						data-testid={`space-chip-${space.id}`}
-					>
-						<span aria-hidden="true" className="w-1.5 h-1.5 rounded-full bg-accent/70 flex-shrink-0" />
-						<span className={`font-medium leading-none truncate max-w-[10rem] ${space.sensitive ? MASK_CLASS : ""}`}>{space.name}</span>
-						<button
-							type="button"
-							onClick={() => handleToggle(space.id)}
-							title={t("spaces.removeFromSpace", { name: space.name })}
-							aria-label={t("spaces.removeFromSpace", { name: space.name })}
-							className="touch-inline flex items-center justify-center w-4 h-4 rounded-full flex-shrink-0 text-accent/70 bg-accent/15 opacity-0 group-hover/chip:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:text-accent hover:bg-accent/30 transition-[opacity,background-color,color]"
-							data-testid={`space-chip-remove-${space.id}`}
-						>
-							<svg aria-hidden="true" focusable="false" className="w-2 h-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
-								<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-							</svg>
-						</button>
-					</span>
+						name={space.name}
+						masked={!!space.sensitive}
+						onRemove={() => handleToggle(space.id)}
+						removeLabel={t("spaces.removeFromSpace", { name: space.name })}
+						testId={`space-chip-${space.id}`}
+					/>
+				))}
+				{deferred.newNames.map((name) => (
+					<Chip
+						key={`pending-${name}`}
+						name={name}
+						badge={t("spaces.pendingNew")}
+						onRemove={() => handleTogglePending(name)}
+						removeLabel={t("spaces.removeFromSpace", { name })}
+						testId={`space-chip-new-${name}`}
+					/>
 				))}
 				<button
 					ref={anchorRef}
@@ -112,7 +186,9 @@ function ProjectSpacesField(props: ProjectSpacesFieldProps) {
 					spaces={spaces}
 					selectedIds={selectedIds}
 					onToggle={handleToggle}
-					onCreateNew={connected ? handleCreateNew : undefined}
+					onCreateNew={handleCreateNew}
+					pendingNames={deferred.newNames}
+					onTogglePending={handleTogglePending}
 					anchorEl={anchorRef.current}
 					onClose={() => setPickerOpen(false)}
 				/>

--- a/src/mainview/components/SpacePicker.tsx
+++ b/src/mainview/components/SpacePicker.tsx
@@ -12,9 +12,14 @@ interface SpacePickerProps {
 	selectedIds: string[];
 	/** Toggle membership. The parent owns persistence. */
 	onToggle: (spaceId: string) => void;
-	/** Create a space with the typed name (the parent decides the first member).
-	 *  Omitted when creation is impossible, e.g. no project exists yet. */
-	onCreateNew?: (name: string) => void;
+	/** Create a space with the typed name. Always available: a parent whose
+	 *  project does not exist yet holds the name until it does. */
+	onCreateNew: (name: string) => void;
+	/** Names accepted but not created yet, shown as already-ticked rows so the
+	 *  picker never claims "no spaces" right after one was added. */
+	pendingNames?: string[];
+	/** Drop a pending name again. Required whenever `pendingNames` is passed. */
+	onTogglePending?: (name: string) => void;
 	anchorEl: HTMLElement;
 	onClose: () => void;
 }
@@ -30,7 +35,60 @@ function fuzzyMatch(text: string, query: string): boolean {
 	return qi === q.length;
 }
 
-function SpacePicker({ spaces, selectedIds, onToggle, onCreateNew, anchorEl, onClose }: SpacePickerProps) {
+function Row({
+	label,
+	checked,
+	onClick,
+	testId,
+	masked,
+	badge,
+}: {
+	label: string;
+	checked: boolean;
+	onClick: () => void;
+	testId: string;
+	masked?: boolean;
+	badge?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="w-full text-left px-2 py-1.5 rounded-lg flex items-center gap-2.5 hover:bg-elevated-hover transition-colors"
+			data-testid={testId}
+			aria-pressed={checked}
+		>
+			{/* A box on the left, filled or empty, says "several of these can be
+			    on" before anything is clicked. A checkmark that only exists when
+			    selected leaves an unselected row looking like a one-shot menu item. */}
+			<span
+				aria-hidden="true"
+				className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
+					checked ? "bg-accent border-accent text-white" : "border-edge-active text-transparent"
+				}`}
+			>
+				<svg className="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+				</svg>
+			</span>
+			<span className={`text-xs text-fg flex-1 truncate ${masked ? MASK_CLASS : ""}`}>{label}</span>
+			{badge && (
+				<span className="text-dense leading-none uppercase tracking-wide text-accent/80 flex-shrink-0">{badge}</span>
+			)}
+		</button>
+	);
+}
+
+function SpacePicker({
+	spaces,
+	selectedIds,
+	onToggle,
+	onCreateNew,
+	pendingNames = [],
+	onTogglePending,
+	anchorEl,
+	onClose,
+}: SpacePickerProps) {
 	const t = useT();
 	const [query, setQuery] = useState("");
 	const [pos, setPos] = useState({ top: 0, left: 0 });
@@ -39,11 +97,10 @@ function SpacePicker({ spaces, selectedIds, onToggle, onCreateNew, anchorEl, onC
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const filtered = query ? spaces.filter((s) => fuzzyMatch(s.name, query)) : spaces;
+	const filteredPending = query ? pendingNames.filter((n) => fuzzyMatch(n, query)) : pendingNames;
 
-	const showCreate =
-		!!onCreateNew &&
-		query.trim().length > 0 &&
-		!spaces.some((s) => s.name.toLowerCase() === query.trim().toLowerCase());
+	const taken = [...spaces.map((s) => s.name), ...pendingNames].map((n) => n.toLowerCase());
+	const showCreate = query.trim().length > 0 && !taken.includes(query.trim().toLowerCase());
 
 	// Position the picker relative to anchor, clamped to viewport
 	useLayoutEffect(() => {
@@ -84,9 +141,10 @@ function SpacePicker({ spaces, selectedIds, onToggle, onCreateNew, anchorEl, onC
 
 	function createFromQuery() {
 		const name = query.trim();
-		if (!name || !onCreateNew) return;
+		if (!name) return;
 		onCreateNew(name);
 		setQuery("");
+		inputRef.current?.focus();
 	}
 
 	function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -118,38 +176,29 @@ function SpacePicker({ spaces, selectedIds, onToggle, onCreateNew, anchorEl, onC
 			</div>
 
 			<div className="max-h-48 overflow-y-auto p-1">
-				{filtered.length === 0 && !showCreate && (
+				{filtered.length === 0 && filteredPending.length === 0 && !showCreate && (
 					<div className="px-3 py-4 text-xs text-fg-muted text-center">{t("spaces.noSpaces")}</div>
 				)}
-				{filtered.map((space) => {
-					const isOn = selectedIds.includes(space.id);
-					return (
-						<button
-							key={space.id}
-							type="button"
-							onClick={() => onToggle(space.id)}
-							className="w-full text-left px-2 py-1.5 rounded-lg flex items-center gap-2.5 hover:bg-elevated-hover transition-colors"
-							data-testid={`space-picker-row-${space.id}`}
-							aria-pressed={isOn}
-						>
-							{/* A box on the left, filled or empty, says "several of these
-							    can be on" before anything is clicked. A checkmark that
-							    only exists when selected leaves an unselected row looking
-							    like a one-shot menu item. */}
-							<span
-								aria-hidden="true"
-								className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
-									isOn ? "bg-accent border-accent text-white" : "border-edge-active text-transparent"
-								}`}
-							>
-								<svg className="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
-									<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-								</svg>
-							</span>
-							<span className={`text-xs text-fg flex-1 truncate ${space.sensitive ? MASK_CLASS : ""}`}>{space.name}</span>
-						</button>
-					);
-				})}
+				{filtered.map((space) => (
+					<Row
+						key={space.id}
+						label={space.name}
+						masked={!!space.sensitive}
+						checked={selectedIds.includes(space.id)}
+						onClick={() => onToggle(space.id)}
+						testId={`space-picker-row-${space.id}`}
+					/>
+				))}
+				{filteredPending.map((name) => (
+					<Row
+						key={`pending-${name}`}
+						label={name}
+						checked
+						badge={t("spaces.pendingNew")}
+						onClick={() => onTogglePending?.(name)}
+						testId={`space-picker-pending-${name}`}
+					/>
+				))}
 
 				{showCreate && (
 					<button

--- a/src/mainview/components/__tests__/ProjectSpacesField.test.tsx
+++ b/src/mainview/components/__tests__/ProjectSpacesField.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "../../i18n";
-import ProjectSpacesField from "../ProjectSpacesField";
+import ProjectSpacesField, { applyDeferredSpaces, EMPTY_DEFERRED_SPACES } from "../ProjectSpacesField";
 import type { SpacesFile } from "../../../shared/types";
 
 const file: SpacesFile = {
@@ -68,7 +68,7 @@ describe("ProjectSpacesField — connected mode", () => {
 			</I18nProvider>,
 		);
 		await waitFor(() => expect(screen.getByTestId("space-chip-sp_a")).toBeInTheDocument());
-		await user.click(screen.getByTestId("space-chip-remove-sp_a"));
+		await user.click(screen.getByTestId("space-chip-sp_a-remove"));
 		expect(api.request.setProjectSpaces).toHaveBeenCalledWith({ projectId: "p1", spaceIds: [] });
 	});
 
@@ -98,13 +98,67 @@ describe("ProjectSpacesField — deferred mode", () => {
 		const { api } = await import("../../rpc");
 		render(
 			<I18nProvider>
-				<ProjectSpacesField mode="deferred" value={[]} onChange={onChange} />
+				<ProjectSpacesField mode="deferred" value={EMPTY_DEFERRED_SPACES} onChange={onChange} />
 			</I18nProvider>,
 		);
 		await waitFor(() => expect(screen.getByTestId("project-spaces-edit")).toBeInTheDocument());
 		await user.click(screen.getByTestId("project-spaces-edit"));
 		await user.click(screen.getByTestId("space-picker-row-sp_a"));
-		expect(onChange).toHaveBeenCalledWith(["sp_a"]);
+		expect(onChange).toHaveBeenCalledWith({ spaceIds: ["sp_a"], newNames: [] });
+		expect(api.request.setProjectSpaces).not.toHaveBeenCalled();
+	});
+
+	it("offers inline create and keeps the typed name as a pending chip", async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		const { api } = await import("../../rpc");
+		const { rerender } = render(
+			<I18nProvider>
+				<ProjectSpacesField mode="deferred" value={EMPTY_DEFERRED_SPACES} onChange={onChange} />
+			</I18nProvider>,
+		);
+		await waitFor(() => expect(screen.getByTestId("project-spaces-edit")).toBeInTheDocument());
+		await user.click(screen.getByTestId("project-spaces-edit"));
+		await user.type(screen.getByPlaceholderText("Search or create…"), "AI");
+		await user.click(screen.getByTestId("space-picker-create"));
+		expect(onChange).toHaveBeenCalledWith({ spaceIds: [], newNames: ["AI"] });
+		expect(api.request.createSpace).not.toHaveBeenCalled();
+
+		rerender(
+			<I18nProvider>
+				<ProjectSpacesField mode="deferred" value={{ spaceIds: [], newNames: ["AI"] }} onChange={onChange} />
+			</I18nProvider>,
+		);
+		expect(screen.getByTestId("space-chip-new-AI")).toBeInTheDocument();
+		expect(screen.getByTestId("space-picker-pending-AI")).toBeInTheDocument();
+	});
+
+	it("drops a pending name when its chip is removed", async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		render(
+			<I18nProvider>
+				<ProjectSpacesField mode="deferred" value={{ spaceIds: ["sp_a"], newNames: ["AI"] }} onChange={onChange} />
+			</I18nProvider>,
+		);
+		await waitFor(() => expect(screen.getByTestId("space-chip-new-AI")).toBeInTheDocument());
+		await user.click(screen.getByTestId("space-chip-new-AI-remove"));
+		expect(onChange).toHaveBeenCalledWith({ spaceIds: ["sp_a"], newNames: [] });
+	});
+});
+
+describe("applyDeferredSpaces", () => {
+	it("creates every typed name, then writes the whole membership set once", async () => {
+		const { api } = await import("../../rpc");
+		await applyDeferredSpaces("p9", { spaceIds: ["sp_a"], newNames: ["AI"] });
+		expect(api.request.createSpace).toHaveBeenCalledWith({ name: "AI", projectIds: ["p9"] });
+		expect(api.request.setProjectSpaces).toHaveBeenCalledWith({ projectId: "p9", spaceIds: ["sp_a", "sp_new"] });
+	});
+
+	it("writes nothing when the user picked nothing", async () => {
+		const { api } = await import("../../rpc");
+		await applyDeferredSpaces("p9", EMPTY_DEFERRED_SPACES);
+		expect(api.request.createSpace).not.toHaveBeenCalled();
 		expect(api.request.setProjectSpaces).not.toHaveBeenCalled();
 	});
 });

--- a/src/mainview/components/__tests__/SpacePicker.test.tsx
+++ b/src/mainview/components/__tests__/SpacePicker.test.tsx
@@ -17,6 +17,7 @@ function renderPicker(over?: Partial<React.ComponentProps<typeof SpacePicker>>) 
 		selectedIds: ["sp_a"],
 		onToggle: vi.fn(),
 		onCreateNew: vi.fn(),
+		onTogglePending: vi.fn(),
 		anchorEl: anchor,
 		onClose: vi.fn(),
 		...over,
@@ -48,9 +49,26 @@ describe("SpacePicker", () => {
 		expect(props.onCreateNew).toHaveBeenCalledWith("Gamma");
 	});
 
-	it("hides the create affordance when onCreateNew is not provided", async () => {
+	it("creates on Enter so the typed name never needs a mouse", async () => {
 		const user = userEvent.setup();
-		renderPicker({ onCreateNew: undefined });
+		const props = renderPicker();
+		await user.type(screen.getByPlaceholderText("Search or create…"), "Gamma{Enter}");
+		expect(props.onCreateNew).toHaveBeenCalledWith("Gamma");
+	});
+
+	it("shows a pending name as a ticked row instead of the empty state", async () => {
+		const user = userEvent.setup();
+		const props = renderPicker({ spaces: [], selectedIds: [], pendingNames: ["Gamma"] });
+		expect(screen.queryByText("No spaces yet — type a name to create one")).not.toBeInTheDocument();
+		const row = screen.getByTestId("space-picker-pending-Gamma");
+		expect(row).toHaveAttribute("aria-pressed", "true");
+		await user.click(row);
+		expect(props.onTogglePending).toHaveBeenCalledWith("Gamma");
+	});
+
+	it("does not offer to create a name that is already pending", async () => {
+		const user = userEvent.setup();
+		renderPicker({ spaces: [], selectedIds: [], pendingNames: ["Gamma"] });
 		await user.type(screen.getByPlaceholderText("Search or create…"), "Gamma");
 		expect(screen.queryByTestId("space-picker-create")).not.toBeInTheDocument();
 	});

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -792,6 +792,7 @@ const settings = {
 	"spaces.searchPlaceholder": "Search or create…",
 	"spaces.noSpaces": "No spaces yet — type a name to create one",
 	"spaces.createSpace": "Create space “{name}”",
+	"spaces.pendingNew": "New",
 	"spaces.autoDeleted": "Space “{name}” was removed — its last project left",
 	"spaces.failedCreate": "Failed to create space: {error}",
 	"spaces.failedUpdate": "Failed to update spaces: {error}",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -793,6 +793,7 @@ const settings = {
 	"spaces.searchPlaceholder": "Buscar o crear…",
 	"spaces.noSpaces": "Aún no hay espacios — escribe un nombre para crear uno",
 	"spaces.createSpace": "Crear espacio “{name}”",
+	"spaces.pendingNew": "Nuevo",
 	"spaces.autoDeleted": "El espacio “{name}” se eliminó — su último proyecto lo dejó",
 	"spaces.failedCreate": "No se pudo crear el espacio: {error}",
 	"spaces.failedUpdate": "No se pudieron actualizar los espacios: {error}",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -816,6 +816,7 @@ const settings = {
 	"spaces.searchPlaceholder": "Найти или создать…",
 	"spaces.noSpaces": "Пространств пока нет — введите название, чтобы создать",
 	"spaces.createSpace": "Создать пространство «{name}»",
+	"spaces.pendingNew": "Новое",
 	"spaces.autoDeleted": "Пространство «{name}» удалено — из него ушёл последний проект",
 	"spaces.failedCreate": "Не удалось создать пространство: {error}",
 	"spaces.failedUpdate": "Не удалось обновить пространства: {error}",


### PR DESCRIPTION
The Add Project dialog's space picker showed "No spaces yet — type a name to create one", but nothing happened however you typed: `ProjectSpacesField` passed `onCreateNew` only in connected mode, so the create row never rendered and Enter was a no-op. The copy promised something the dialog could not do.

The dialog cannot create the space eagerly — `createSpace` rejects an empty member list and the project does not exist yet. So the deferred value became `DeferredSpaces = { spaceIds, newNames }`: a typed name is held as a chip (and as an already-ticked picker row, marked NEW), and `applyDeferredSpaces` creates it with the new project as its first member before writing the whole membership set once. `SpacePicker.onCreateNew` is now required, so no host can show the promise without honouring it.

Verified end to end in a headless browser against a scoped QA board: typing a name shows "Create space", Enter and the click both work, and adding the project lands it inside the new space on the dashboard and in the rail.

Decision record: `decisions/2026/08/30/deferred-space-names-in-add-project.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6429b2ac-5302-419b-b738-12be033a8bd9) · `dev3://task/6429b2ac-5302-419b-b738-12be033a8bd9`