### PR TITLE
Run the wheel bridge only where the pointer has no horizontal axis

### DIFF
--- a/change-logs/2026/08/31/fix-trackpad-vertical-scroll-drifted-sideways.md
+++ b/change-logs/2026/08/31/fix-trackpad-vertical-scroll-drifted-sideways.md
@@ -1,0 +1,3 @@
+Short: Trackpad scrolls straight again
+
+On a trackpad a vertical two-finger swipe arrives with a horizontal delta of exactly zero, which is indistinguishable from a mouse notch — so the new mouse-wheel bridge grabbed it and pushed the Kanban board sideways instead of scrolling. The bridge now stays dormant on macOS, and anywhere else it switches itself off permanently the first time it sees a horizontal delta, which is proof a touchpad is in use.

--- a/decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md
+++ b/decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md
@@ -1,5 +1,7 @@
 # Giving a plain mouse wheel a way into horizontal-only scroll containers
 
+Superseded on 2026-08-31 by `decisions/2026/08/31/wheel-bridge-only-where-there-is-no-horizontal-axis.md`: this record assumed a trackpad always carries a horizontal delta, which is false for its vertical swipe, so the bridge no longer runs on every platform.
+
 ## Context
 
 The UI had been driven almost exclusively from a Mac trackpad. A trackpad's

--- a/decisions/2026/08/31/wheel-bridge-only-where-there-is-no-horizontal-axis.md
+++ b/decisions/2026/08/31/wheel-bridge-only-where-there-is-no-horizontal-axis.md
@@ -1,0 +1,50 @@
+# The wheel bridge only runs where the pointing device has no horizontal axis
+
+## Context
+
+`decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md` added a
+document-level bridge that hands a purely vertical wheel delta to a
+horizontal-only scroll container, so a plain mouse could reach the Kanban board.
+It keyed on `deltaX === 0` as the signature of a mouse.
+
+## Investigation
+
+That signature is wrong. A trackpad's *vertical* two-finger swipe also arrives
+with `deltaX` exactly 0 — only its sideways swipe carries a horizontal delta.
+The audit that produced the bridge simulated a trackpad by setting `deltaX` by
+hand and never drove a physical one, so the assumption went unchallenged until
+the merged build reached a Mac: an ordinary vertical scroll pushed the board
+sideways.
+
+Confirmed in a real browser against the running app. On this Mac, twelve
+vertical notches now leave `scrollLeft` at 0 while a horizontal delta still
+drives the board to 360. With `navigator.platform` spoofed to `Win32` through
+`page.addInitScript`, the same twelve notches move it 0 → 572, and a single
+horizontal delta afterwards switches the bridge off so the next twelve leave it
+at 0.
+
+## Decision
+
+`installHorizontalWheelBridge` keeps a per-install `hasHorizontalAxis` flag. It
+starts `true` on macOS, which ships a trackpad, and is set `true` for good the
+first time any wheel event carries a non-zero `deltaX`. While it is `true`
+nothing is intercepted. Everything else about the bridge — the
+vertically-scrollable-ancestor rule and `WHEEL_X_SELECTOR` — is unchanged.
+
+## Risks
+
+A Mac driven by a plain mouse gets no bridge, and neither does a Windows or
+Linux machine after its touchpad has been used once in that session, even if the
+user later switches to a mouse without reloading. Both were accepted over the
+alternative: a wrong guess makes ordinary vertical scrolling drift sideways,
+which is far worse than a horizontal container needing `Shift`+wheel or its
+scrollbar.
+
+## Alternatives considered
+
+Fingerprinting the device from the delta itself — integer multiples of 120 for a
+mouse, small or fractional values for a trackpad. Rejected: a fast trackpad
+flick produces large integer deltas too, so it trades a certain regression for a
+probabilistic one, and a physical trackpad could not be driven here to falsify
+it. Reverting the bridge outright: leaves the original bug, which is the whole
+reason Windows and Linux users could not move the board at all.

--- a/src/mainview/utils/__tests__/horizontal-wheel.test.ts
+++ b/src/mainview/utils/__tests__/horizontal-wheel.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { installHorizontalWheelBridge, resolveHorizontalWheelTarget } from "../horizontal-wheel";
+import * as platform from "../platform";
 
 /** happy-dom reports zero for every layout box, so scroll metrics are stubbed. */
 function sized(el: HTMLElement, m: { sw?: number; cw?: number; sh?: number; ch?: number }) {
@@ -88,7 +89,15 @@ describe("resolveHorizontalWheelTarget", () => {
 
 describe("installHorizontalWheelBridge", () => {
 	let teardown: () => void;
-	afterEach(() => teardown?.());
+
+	beforeEach(() => {
+		// Default the suite to a mouse-only machine; the trackpad cases opt in.
+		vi.spyOn(platform, "isMac").mockReturnValue(false);
+	});
+	afterEach(() => {
+		teardown?.();
+		vi.restoreAllMocks();
+	});
 
 	/** happy-dom's WheelEvent silently drops `ctrlKey`, so it is defined by hand. */
 	function wheel(target: Element, init: WheelEventInit & { ctrlKey?: boolean }) {
@@ -123,6 +132,31 @@ describe("installHorizontalWheelBridge", () => {
 		teardown = installHorizontalWheelBridge();
 
 		const e = wheel(board, { deltaX: 0, deltaY: 120, ctrlKey: true });
+
+		expect(board.scrollLeft).toBe(0);
+		expect(e.defaultPrevented).toBe(false);
+	});
+
+	it("never bridges on macOS — a trackpad's vertical swipe also carries deltaX 0", () => {
+		vi.spyOn(platform, "isMac").mockReturnValue(true);
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+
+		const e = wheel(board, { deltaX: 0, deltaY: 120 });
+
+		expect(board.scrollLeft).toBe(0);
+		expect(e.defaultPrevented).toBe(false);
+	});
+
+	it("switches itself off for good once a horizontal delta proves a touchpad", () => {
+		const board = make("auto", "hidden", { sw: 2172, cw: 1600, sh: 876, ch: 876 });
+		teardown = installHorizontalWheelBridge();
+
+		// One sideways swipe: the device has a horizontal axis.
+		wheel(board, { deltaX: 40, deltaY: 0 });
+		board.scrollLeft = 0;
+		// Its vertical swipe must now be left entirely alone.
+		const e = wheel(board, { deltaX: 0, deltaY: 120 });
 
 		expect(board.scrollLeft).toBe(0);
 		expect(e.defaultPrevented).toBe(false);

--- a/src/mainview/utils/horizontal-wheel.ts
+++ b/src/mainview/utils/horizontal-wheel.ts
@@ -6,12 +6,16 @@
  * Kanban board were literally unreachable with a mouse while a trackpad's
  * two-finger swipe drove them fine.
  *
- * The rule is deliberately narrow: a vertical delta is handed to a horizontal
- * container ONLY when nothing between the pointer and the page can scroll
- * vertically. The moment a vertically-scrollable ancestor shows up it wins, so
- * wheeling over a wide code block inside the diff still scrolls the diff — we
- * never steal a wheel that already had a job.
+ * Two rules keep it narrow. A vertical delta is handed to a horizontal container
+ * only when nothing between the pointer and the page can scroll vertically — the
+ * first vertically-scrollable ancestor wins, so wheeling over a wide code block
+ * inside the diff still scrolls the diff. And it only ever runs for a pointing
+ * device that has no horizontal axis at all: a trackpad's *vertical* swipe
+ * arrives with `deltaX` exactly 0, indistinguishable from a mouse notch, so
+ * bridging on a trackpad turned plain vertical scrolling into sideways drift.
  */
+
+import { isMac } from "./platform";
 
 const SCROLLABLE_OVERFLOW = /auto|scroll|overlay/;
 
@@ -60,11 +64,26 @@ export function resolveHorizontalWheelTarget(start: Element | null, deltaY: numb
 	return roomFor(candidate, deltaY) > 0 ? candidate : null;
 }
 
-/** Installs the bridge on `document`; returns the teardown. */
+/**
+ * Installs the bridge on `document`; returns the teardown.
+ *
+ * The bridge stays dormant on any machine whose pointing device has a horizontal
+ * axis, because there is no way to tell that device's *vertical* gesture from a
+ * mouse notch — both arrive as `deltaX: 0`. macOS ships a trackpad, so it is
+ * excluded outright; anywhere else the first horizontal delta of the session
+ * proves a touchpad is in use and switches the bridge off for good.
+ */
 export function installHorizontalWheelBridge(doc: Document = document): () => void {
+	let hasHorizontalAxis = isMac();
+
 	function onWheel(e: WheelEvent) {
-		// A horizontal delta already works, and ctrl+wheel is zoom, not scroll.
-		if (e.deltaX !== 0 || e.deltaY === 0 || e.ctrlKey || e.defaultPrevented) return;
+		if (e.deltaX !== 0) {
+			hasHorizontalAxis = true;
+			return;
+		}
+		if (hasHorizontalAxis) return;
+		// ctrl+wheel is zoom, not scroll.
+		if (e.deltaY === 0 || e.ctrlKey || e.defaultPrevented) return;
 		const target = resolveHorizontalWheelTarget(e.target as Element | null, e.deltaY);
 		if (!target) return;
 		target.scrollLeft += e.deltaY;


### PR DESCRIPTION
Hey, Claude here — the AI that wrote #1592 and therefore this regression too.

#1592 keyed the mouse-wheel bridge on `deltaX === 0` as the signature of a mouse. That is wrong: a trackpad's **vertical** two-finger swipe also arrives with `deltaX` exactly 0 — only its sideways swipe carries a horizontal delta. So on a Mac an ordinary vertical scroll was grabbed by the bridge and pushed the Kanban board sideways. The original audit simulated a trackpad by setting `deltaX` by hand and never drove a physical one, which is how the assumption survived.

**The fix.** `installHorizontalWheelBridge` keeps a `hasHorizontalAxis` flag. It starts `true` on macOS, which ships a trackpad, and latches `true` for good the first time any wheel event carries a non-zero `deltaX` — proof a touchpad is in use, which also covers Windows and Linux laptops that #1592 overlooked. While it is `true` nothing is intercepted. The ancestor rule and `WHEEL_X_SELECTOR` are untouched.

**Verified in a real browser** against the running app:

| Platform | Input | `scrollLeft` |
|---|---|---|
| real macOS | 12 vertical notches | 0 — dormant, drift gone |
| real macOS | horizontal delta | 360 — native trackpad path intact |
| `navigator.platform` spoofed to `Win32` | 12 vertical notches | 572 — full range, #1592's fix still works |
| spoofed `Win32`, after one horizontal delta | 12 vertical notches | 0 — touchpad learned, bridge off |

Two new tests, and both guards are proven by mutation: dropping the macOS default reddens exactly one, dropping the latch reddens exactly the other.

**Known trade-off:** a Mac driven by a plain mouse gets no bridge, and a Windows or Linux machine loses it for the session once its touchpad is used. Both were accepted deliberately — a wrong guess makes ordinary vertical scrolling drift sideways, which is worse than a horizontal container needing `Shift`+wheel or its scrollbar. Fingerprinting the device from delta magnitude was considered and rejected: a fast trackpad flick also produces large integer deltas, and no physical trackpad could be driven here to falsify it.

Decision record `decisions/2026/08/29/plain-mouse-wheel-horizontal-scroll.md` is marked superseded, with the reasoning in `decisions/2026/08/31/wheel-bridge-only-where-there-is-no-horizontal-axis.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=5218ced6-446d-4a9e-a895-aab2e2010a55) · `dev3://task/5218ced6-446d-4a9e-a895-aab2e2010a55`