### PR TITLE
Give a long agent message a receipt that survives a lost head

### DIFF
--- a/change-logs/2026/08/31/fix-agent-message-head-loss-receipt.md
+++ b/change-logs/2026/08/31/fix-agent-message-head-loss-receipt.md
@@ -1,0 +1,5 @@
+Short: Long agent messages keep a recoverable copy
+
+A `dev3 message` over 1 500 bytes now also lands on disk next to the receiving task, and the envelope names that copy on its last line, just before the closing tag. A receiver that finds a closing `</dev3-ai-message>` with no opening line knows the delivery lost its head and can read the whole message from the named file instead of acting on half a ruling. Each task keeps its newest 50 receipts.
+
+Suggested by @yhattav (h0x91b/dev-3.0#1608)

--- a/decisions/2026/08/31/agent-message-receipt-survives-a-lost-head.md
+++ b/decisions/2026/08/31/agent-message-receipt-survives-a-lost-head.md
@@ -1,0 +1,78 @@
+# A long agent message carries a receipt, because we cannot promise it arrives whole
+
+## Context
+
+Issue #1608 (@yhattav, dev3 v1.35.1, tmux, macOS): roughly one in three `dev3 message`
+deliveries over ~1.5 KB reached the receiving agent with its BEGINNING missing — the
+prompt starting mid-sentence, the tail and the closing `</dev3-ai-message>` always intact.
+A truncated delivery is worse than a failed one: the head is where the framing and the
+constraints live, and the receiver cannot tell anything is gone.
+
+## Investigation
+
+Measured on current main, macOS, tmux backend. 67 sends through the production transport
+and 8 deliveries into a real Claude Code 2.1.220, with **zero head loss**:
+
+- Quiet pane, 1000–4800 bytes, 6 reps each (30 sends) into `stty raw; cat > sink` through
+  the real `TmuxClient.sendKeysGuarded`: byte-exact every time.
+- Same, with the pane also printing ~1000 lines/s (30 sends): byte-exact.
+- Blocked reader — the pane sets raw mode and does not read stdin for 3 s while the
+  payload lands (7 sends, 500–4800 bytes): byte-exact. tmux buffers on the master side.
+- Real Claude Code: 2981 bytes idle (transcript-verified byte-exact), 2925 bytes with only
+  a 30 ms gap before the Enter, 3000 bytes into a pane that had just been given work, and
+  v1.35.1's uncoordinated scheme (two 3 KB messages 300 ms apart, each firing its own
+  Enter) — three reps, every turn carried both messages whole. They MERGE, never truncate.
+
+So the bytes do not die in the CLI socket, the hold queue, the paste, tmux, or the pty. The
+only remaining candidate is the receiving agent CLI's input layer, which dev3 does not own.
+One receiver-side behaviour is real and visible: Claude Code collapses a fast multi-chunk
+raw write into `[Pasted text #N]` placeholders (three of them for 3 KB), sometimes leaving
+one stray character after them — exactly the reporter's "single stray character before the
+message body". On 2.1.220 those placeholders expand correctly on submit.
+
+Version context: the reporter runs v1.35.1 (14 Jul 2026). The hold-and-coalesce path
+(`agent-message-hold.ts`, one hold per pane, exactly one Enter per burst) landed 23 Aug and
+first shipped in v1.48.0, so he does not have it. His Claude Code version is unknown.
+
+## Decision
+
+Deliver the second half of "whole, or the receiver is told": **make silent partial delivery
+impossible rather than promise an integrity we cannot prove**.
+
+- `writeAgentMessageReceipt` (`src/bun/agent-message-spill.ts`) writes any body over
+  `AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES` (1 500 — where the field report starts) to
+  `<taskDir>/messages/receipts/`, and prunes to the newest `AGENT_MESSAGE_RECEIPT_KEEP`
+  (50). Its own directory, never beside the spill files: a spill is the only copy of a body
+  that was never typed, so pruning must not be able to reach one. Best-effort — a receipt
+  that cannot be written is logged and the message still goes out.
+- `wrapAgentMessage` (`src/shared/agent-message-envelope.ts`) takes `fullCopyPath` and emits
+  `<full-copy>…</full-copy>` as the LAST line before `</dev3-ai-message>`. Head loss by
+  definition removes the beginning, so a pointer placed last cannot be eaten by the thing it
+  exists to survive.
+- `deliverToTarget` (`src/bun/scheduled-message-scheduler.ts`) writes the receipt for agent
+  traffic only; a human watching the pane sees what happened to his own message.
+- The agent protocol text (`src/shared/agent-skill-content.ts`) states the rule and its
+  limit: a closing tag with no opening line means a lost head, read the named file and say
+  the delivery was truncated — and this catches a lost HEAD only, never a gap in the middle.
+
+The spill threshold stays at 4 000. Lowering it would degrade a channel that measures clean.
+
+## Risks
+
+- The rule is blind to a middle loss, which leaves both tags in place. Stated in the
+  protocol text rather than left implied.
+- One extra line in every long envelope, and one file write per long message. Bounded at 50
+  files per task, and the directory dies with the task.
+- Only Claude Code 2.1.220 was driven, on tmux. Another harness, another version, or the
+  native backend may lose bytes differently; that axis stays open.
+
+## Alternatives considered
+
+- **Bracketed paste** (`ESC[200~ … ESC[201~`) so the receiver treats the payload as one
+  atomic paste. It targets the placeholder collapse that was actually observed, but a
+  harness that does not enable bracketed paste would receive raw escape bytes — turning a
+  cosmetic problem into a real one — and no measurement shows the collapse is lossy.
+- **Lowering the spill threshold to ~1 500** so nothing risky is ever typed. It moves the
+  boundary without naming a mechanism, and makes nearly every peer report a two-step read.
+- **A byte count in the envelope** for the receiver to verify. A model cannot reliably count
+  bytes, so the check would be theatre.

--- a/src/bun/__tests__/agent-message-receipt.test.ts
+++ b/src/bun/__tests__/agent-message-receipt.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The receipt a long `dev3 message` carries: what a receiver holding only the END of a
+ * delivery still has (issue #1608).
+ *
+ * Driven through `sendMessageImmediately` — the same entry point the CLI's
+ * `dev3 message` goes through — rather than through the spill helper, so the envelope
+ * these assertions read is the one that would actually be typed into a pane.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let taskRoot = "";
+
+vi.mock("../data", () => ({
+	loadProjects: vi.fn(async () => []),
+	loadVirtualProjects: vi.fn(async () => []),
+	loadTasks: vi.fn(async () => []),
+	getProject: vi.fn(async () => ({ id: "proj-1", name: "Proj" })),
+	getTask: vi.fn(),
+	updateTaskWith: vi.fn(),
+}));
+vi.mock("../git", () => ({ taskDir: vi.fn(() => taskRoot) }));
+vi.mock("../agent-prompt", () => ({
+	sendPromptToAgentPane: vi.fn(async () => true),
+	sendPromptToPane: vi.fn(async () => true),
+	holdMessageForAgentPane: vi.fn(async () => ({ status: "held" })),
+	holdMessageForPane: vi.fn(async () => ({ status: "held" })),
+}));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => true),
+	sendPromptToNativePane: vi.fn(async () => true),
+}));
+vi.mock("../pty-server", () => ({ DEFAULT_TMUX_SOCKET: "dev3" }));
+vi.mock("../agent-message-log", () => ({ appendAgentMessageLog: vi.fn() }));
+vi.mock("../coordinator-board", () => ({ coordinatorBoardEpilogue: vi.fn(async () => "") }));
+vi.mock("../rpc-handlers", () => ({
+	getPushMessage: vi.fn(() => vi.fn()),
+	pushCliToast: vi.fn(),
+	pushCliAttention: vi.fn(),
+	pushAgentMessage: vi.fn(),
+}));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { holdMessageForAgentPane } from "../agent-prompt";
+import { sendMessageImmediately } from "../scheduled-message-scheduler";
+import { writeAgentMessageReceipt } from "../agent-message-spill";
+import { AGENT_MESSAGE_RECEIPT_KEEP, AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES, type Task } from "../../shared/types";
+
+const SOURCE = { taskId: "sender-1234", seq: 7, title: "Sender", projectId: "proj-1" };
+
+function task(): Task {
+	return {
+		id: "task-12345678",
+		projectId: "proj-1",
+		seq: 42,
+		title: "Receiver",
+		status: "in-progress",
+		sessionState: { panes: [{ paneId: "%1", agentCmd: "claude", sessionId: null, agentId: null, configId: null }] },
+	} as unknown as Task;
+}
+
+/** A body of exactly `bytes` UTF-8 bytes, with a recognisable first and last line. */
+function body(bytes: number): string {
+	const head = "HEAD-OF-THE-MESSAGE: the ruling lives here.\n";
+	const tail = "\nTAIL-OF-THE-MESSAGE.";
+	return head + "filler ".repeat(Math.max(1, Math.ceil((bytes - head.length - tail.length) / 7))) + tail;
+}
+
+/** The envelope that would have been typed into the pane. */
+function deliveredPrompt(): string {
+	const calls = vi.mocked(holdMessageForAgentPane).mock.calls;
+	return String(calls[calls.length - 1]?.[1] ?? "");
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	taskRoot = mkdtempSync(join(tmpdir(), "dev3-receipt-"));
+});
+
+afterEach(() => {
+	rmSync(taskRoot, { recursive: true, force: true });
+});
+
+describe("a long agent message carries a receipt the lost head cannot take with it", () => {
+	it("names the copy on the LAST line before the closing tag, and the copy is byte-exact", async () => {
+		const text = body(3_000);
+		await sendMessageImmediately(task(), text, null, SOURCE, { subject: "long report" });
+
+		const prompt = deliveredPrompt();
+		const lines = prompt.split("\n");
+		expect(lines[lines.length - 1]).toBe("</dev3-ai-message>");
+		const receiptLine = lines[lines.length - 2] ?? "";
+		expect(receiptLine).toMatch(/^<full-copy>.+<\/full-copy>$/);
+
+		const path = receiptLine.slice("<full-copy>".length, -"</full-copy>".length);
+		expect(readFileSync(path, "utf8")).toBe(text);
+	});
+
+	it("survives a head cut: everything before the body can be gone and the path is still there", async () => {
+		const text = body(3_000);
+		await sendMessageImmediately(task(), text, null, SOURCE, { subject: "long report" });
+
+		const prompt = deliveredPrompt();
+		// What a receiver that lost its head holds: the last third of the delivery.
+		const truncated = prompt.slice(Math.floor(prompt.length * 0.66));
+		expect(truncated).not.toContain("<dev3-ai-message>");
+		expect(truncated).not.toContain("HEAD-OF-THE-MESSAGE");
+		expect(truncated).toContain("</dev3-ai-message>");
+		const path = /<full-copy>(.+)<\/full-copy>/.exec(truncated)?.[1] ?? "";
+		expect(readFileSync(path, "utf8")).toContain("HEAD-OF-THE-MESSAGE");
+	});
+
+	it("leaves a short message exactly as it was: no receipt line, no file", async () => {
+		await sendMessageImmediately(task(), "short ruling", null, SOURCE, { subject: "short" });
+
+		expect(deliveredPrompt()).not.toContain("<full-copy>");
+		expect(existsSync(join(taskRoot, "messages", "receipts"))).toBe(false);
+	});
+
+	it("writes nothing for a human's own message — only agent traffic is wrapped", async () => {
+		await sendMessageImmediately(task(), body(3_000), null, null, { subject: "typed by the user" });
+
+		expect(deliveredPrompt()).not.toContain("<full-copy>");
+		expect(existsSync(join(taskRoot, "messages", "receipts"))).toBe(false);
+	});
+});
+
+describe("the receipts directory is bounded, not accumulating", () => {
+	it(`keeps the newest ${AGENT_MESSAGE_RECEIPT_KEEP} and deletes the rest`, async () => {
+		const dir = join(taskRoot, "messages", "receipts");
+		for (let i = 0; i < AGENT_MESSAGE_RECEIPT_KEEP + 12; i += 1) {
+			await writeAgentMessageReceipt(task(), `${i}:${"x".repeat(AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES)}`);
+		}
+		expect(readdirSync(dir).length).toBe(AGENT_MESSAGE_RECEIPT_KEEP);
+	});
+
+	it("does not reach the spill files: they live outside the receipts directory", async () => {
+		await writeAgentMessageReceipt(task(), "y".repeat(AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES));
+		const [name] = readdirSync(join(taskRoot, "messages", "receipts"));
+		expect(name).toMatch(/^message-/);
+		// The spill path is `<root>/messages/message-*.md`; pruning only ever lists
+		// `<root>/messages/receipts`, so a spilled body is never a pruning candidate.
+		expect(readdirSync(join(taskRoot, "messages")).filter((n) => n.endsWith(".md"))).toEqual([]);
+	});
+
+	it("a message still goes out when its receipt cannot be written", async () => {
+		rmSync(taskRoot, { recursive: true, force: true });
+		taskRoot = "/dev/null/not-a-directory";
+
+		const delivery = await sendMessageImmediately(task(), body(3_000), null, SOURCE, { subject: "long report" });
+
+		expect(delivery.status).toBe("held");
+		expect(deliveredPrompt()).toContain("HEAD-OF-THE-MESSAGE");
+		expect(deliveredPrompt()).not.toContain("<full-copy>");
+		taskRoot = mkdtempSync(join(tmpdir(), "dev3-receipt-"));
+	});
+});

--- a/src/bun/agent-message-spill.ts
+++ b/src/bun/agent-message-spill.ts
@@ -8,8 +8,14 @@
  * is written next to the task and the agent is told to read it.
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
-import { AGENT_MESSAGE_SPILL_THRESHOLD_BYTES, type Task } from "../shared/types";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import {
+	AGENT_MESSAGE_RECEIPT_KEEP,
+	AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES,
+	AGENT_MESSAGE_SPILL_THRESHOLD_BYTES,
+	type Task,
+} from "../shared/types";
 import { utf8Length } from "../shared/pane-input";
 import * as data from "./data";
 import { taskDir } from "./git";
@@ -57,4 +63,55 @@ export async function spillOversizedAgentMessage(task: Task, text: string): Prom
 	await writeFile(path, text, "utf8");
 	log.info("Agent message spilled to file", { taskId: task.id.slice(0, 8), bytes, path });
 	return { text: spillPointerText(path, bytes), spilledPath: path };
+}
+
+/**
+ * Receipts live in their own directory, never beside the spill files: a spill is the ONLY
+ * copy of a body that was never typed, and pruning must not be able to reach one.
+ */
+function messageReceiptDir(taskRoot: string): string {
+	return `${taskRoot}/messages/receipts`;
+}
+
+/**
+ * Delete every receipt past the newest {@link AGENT_MESSAGE_RECEIPT_KEEP}. The name
+ * carries an ISO stamp, so lexicographic order is chronological order.
+ */
+async function pruneReceipts(dir: string): Promise<void> {
+	const names = (await readdir(dir)).filter((name) => name.startsWith("message-")).sort();
+	for (const name of names.slice(0, Math.max(0, names.length - AGENT_MESSAGE_RECEIPT_KEEP))) {
+		await rm(`${dir}/${name}`, { force: true });
+	}
+}
+
+/**
+ * Write a long body next to the task and return that path — the message's receipt.
+ *
+ * The text is still typed in full; this is the copy the receiver falls back to when what
+ * reached it is not what was sent. Delivery into a terminal ends in an agent CLI's input
+ * layer, which dev3 does not own, and issue #1608 is a report of a head arriving missing
+ * from one — so every body big enough to be at risk keeps a copy the receiver can name.
+ *
+ * Bounded, not accumulating: the newest {@link AGENT_MESSAGE_RECEIPT_KEEP} survive and the
+ * directory dies with the task. Best-effort by design — a receipt that could not be
+ * written must never cost the message itself, so a failure is logged and delivery goes on.
+ */
+export async function writeAgentMessageReceipt(task: Task, text: string): Promise<string | null> {
+	const bytes = utf8Length(text);
+	if (bytes < AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES) return null;
+	try {
+		const project = await data.getProject(task.projectId);
+		// A stamp alone collides when two peers report in the same millisecond, and the
+		// loser would silently overwrite the winner's receipt.
+		const stamp = `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+		const dir = messageReceiptDir(taskDir(project, task));
+		const path = `${dir}/message-${stamp}.md`;
+		await mkdir(dir, { recursive: true });
+		await writeFile(path, text, "utf8");
+		await pruneReceipts(dir);
+		return path;
+	} catch (err) {
+		log.warn("Could not write the message receipt", { taskId: task.id.slice(0, 8), bytes, error: String(err) });
+		return null;
+	}
 }

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -14,7 +14,7 @@ import type { AgentPromptDelivery } from "../shared/agent-prompt-delivery";
 import { deliverAgentPrompt } from "./agent-prompt-delivery";
 import { coordinatorBoardEpilogue } from "./coordinator-board";
 import { wrapAgentMessage } from "../shared/agent-message-envelope";
-import { spillOversizedAgentMessage } from "./agent-message-spill";
+import { spillOversizedAgentMessage, writeAgentMessageReceipt } from "./agent-message-spill";
 import { appendAgentMessageLog } from "./agent-message-log";
 // Import push via the barrel (not ./rpc-handlers/shared) so tests that mock
 // `../rpc-handlers` — e.g. the cli-socket lost-update race suites, which reach
@@ -71,8 +71,12 @@ function messagePreview(text: string): string {
 async function deliverToTarget(task: Task, message: ScheduledMessage, hold: boolean): Promise<AgentPromptDelivery> {
 	// Agent-to-agent traffic is wrapped at delivery time, so the queue (and the
 	// card chip that previews it) keeps the plain text the sender wrote.
+	// A long body also lands on disk, and the envelope names that copy at its very end —
+	// the one position a lost head cannot take with it (issue #1608). Only agent traffic:
+	// a human watching the pane sees what happened to his own message.
+	const receiptPath = message.source ? await writeAgentMessageReceipt(task, message.text) : null;
 	const text = message.source
-		? wrapAgentMessage(message.text, message.source, task.projectId, message.subject)
+		? wrapAgentMessage(message.text, message.source, task.projectId, message.subject, receiptPath)
 		: message.text;
 	// A coordinator's picture of the board goes stale between the messages it
 	// receives: things moved while it was not being spoken to. So every message

--- a/src/shared/agent-message-envelope.ts
+++ b/src/shared/agent-message-envelope.ts
@@ -14,12 +14,18 @@ export const REPLY_SUBJECT_PLACEHOLDER = "what your reply is about";
  *
  * `receiverProjectId` is the project of the task being written TO — it decides
  * whether the reply command needs `--project` (see {@link agentReplyCommand}).
+ *
+ * `fullCopyPath` is the receipt for a long body (see `agent-message-spill.ts`). It goes
+ * LAST, after the body, because that is the only position a lost head cannot take with
+ * it: a receiver holding a closing tag and no opening one still holds the way back to
+ * the whole text.
  */
 export function wrapAgentMessage(
 	text: string,
 	source: AgentMessageSource,
 	receiverProjectId: string,
 	subject?: string,
+	fullCopyPath?: string | null,
 ): string {
 	// A record queued before `seqShared` existed only knows it was a variant, so it
 	// keeps the old pessimistic address rather than risking an ambiguous seq.
@@ -51,8 +57,9 @@ export function wrapAgentMessage(
 		"<message>",
 		text,
 		"</message>",
-		"</dev3-ai-message>",
 	);
+	if (fullCopyPath) lines.push(`<full-copy>${escapeXmlText(fullCopyPath)}</full-copy>`);
+	lines.push("</dev3-ai-message>");
 	return lines.join("\n");
 }
 

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -282,6 +282,7 @@ Use it when work genuinely belongs in its own session (a parallel investigation,
 - One task is one inbox: it lands in that task's agent pane, never a shell split, so a task running several agents cannot be addressed pane by pane.
 - A peer on ANOTHER project needs \`--project <id>\`, else a bare \`--task seq:<N>\` is looked up on your own board and reported as "task not found". An incoming message's reply command already includes it when needed.
 - A live variant group shares one seq — name the member with \`--variant <i>\` (the card's \`<seq>-<i>\` suffix) rather than digging out its UUID.
+- **An incoming message you are reading from its middle lost its head.** A long one carries a \`<full-copy>\` path just before its closing tag; if you see that closing tag with no \`<dev3-ai-message>\` opening line above it, read the named file — that is the whole message — and say the delivery arrived truncated. This catches a lost HEAD only: a gap in the MIDDLE leaves both tags in place and is invisible.
 - Nothing goes in on arrival: it waits for ~${AGENT_MESSAGE_HOLD_IDLE_SECONDS}s of quiet on that pane, ~${AGENT_MESSAGE_HOLD_HUMAN_IDLE_SECONDS}s if the user has been typing, and lands at once when they press Enter. Messages arriving together become ONE turn and none corrupts a line being typed — so send three thoughts as three messages, and expect a reply about ${AGENT_MESSAGE_HOLD_IDLE_SECONDS} seconds after the peer writes.
 `;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2698,6 +2698,23 @@ export const MAX_SCHEDULED_MESSAGE_LENGTH = 80_000;
  */
 export const AGENT_MESSAGE_SPILL_THRESHOLD_BYTES = 4_000;
 
+/**
+ * UTF-8 bytes of message body above which a copy is kept on disk as well — the
+ * message's receipt, named at the END of the envelope so a lost head cannot take the
+ * way back with it (issue #1608). Below it the body still travels as text alone.
+ *
+ * 1 500 because that is where the field report starts: every truncated arrival in
+ * #1608 was over roughly 1.5 KB, and shorter messages arrived whole.
+ */
+export const AGENT_MESSAGE_RECEIPT_THRESHOLD_BYTES = 1_500;
+
+/**
+ * How many receipts one task keeps. Writing the newest deletes the oldest beyond this,
+ * so a long-lived coordinator receiving thousands of reports holds a bounded directory
+ * rather than a growing one. Everything older is already in the project's message log.
+ */
+export const AGENT_MESSAGE_RECEIPT_KEEP = 50;
+
 /** Raster image extensions accepted by `dev3 show-image` (lowercase, no dot).
  * SVG is excluded on purpose — an inline data-URI SVG in the webview is an XSS
  * vector, and screenshots/renders are raster anyway. Shared by the CLI (early


### PR DESCRIPTION
Hi — this is Claude, the AI assistant that worked on this branch.

Fixes the reportable half of #1608 (thanks @yhattav — the report had a repro, a frequency and a size range, which is what made the measurement possible).

## What was measured first

67 sends through the production transport and 8 deliveries into a real Claude Code 2.1.220, on current main, tmux, macOS — **zero head loss**:

- quiet pane, 1000–4800 bytes, 30 sends into `stty raw; cat > sink` through the real `TmuxClient.sendKeysGuarded`: byte-exact;
- same with the pane printing ~1000 lines/s (30 sends): byte-exact;
- blocked reader — the pane ignores stdin for 3 s while the payload lands (7 sends): byte-exact;
- real Claude Code: 2981 bytes transcript-verified byte-exact, 2925 bytes with only a 30 ms gap before the Enter, and v1.35.1's uncoordinated scheme (two 3 KB messages 300 ms apart, each firing its own Enter) — every turn carried both messages whole.

So the bytes do not die in the CLI socket, the hold queue, the paste, tmux or the pty. The only candidate left is the receiving agent CLI's input layer, which dev3 does not own — and the reporter runs v1.35.1, which predates the hold-and-coalesce path (first shipped v1.48.0).

## What this changes

Since "arrives whole" cannot be promised, silent partial delivery is made impossible instead:

- a body over 1 500 bytes is also written to `<taskDir>/messages/receipts/`, pruned to the newest 50 per task, in its own directory so pruning can never reach a spill file;
- the envelope names that copy as its **last** line, before the closing tag — the one position a lost head cannot take with it;
- the agent protocol text states the rule and its limit: a closing tag with no opening line means a lost head, read the named file and say the delivery was truncated. It catches a lost HEAD only; a gap in the middle leaves both tags in place.

The 4 000-byte spill threshold is unchanged — lowering it would degrade a channel that measures clean.

Reasoning and the rejected alternatives (bracketed paste, a lower spill threshold, a byte count in the envelope): `decisions/2026/08/31/agent-message-receipt-survives-a-lost-head.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=cc442173-0809-424f-92d3-38e34d835f0c) · `dev3://task/cc442173-0809-424f-92d3-38e34d835f0c`