### PR TITLE
Move a republished artifact to the end of the task's artifact list

### DIFF
--- a/change-logs/2026/08/31/fix-republished-artifact-goes-last.md
+++ b/change-logs/2026/08/31/fix-republished-artifact-goes-last.md
@@ -1,0 +1,3 @@
+Short: Republished artifact moves to the end
+
+Re-publishing an artifact now moves its row to the end of the task's artifact list instead of keeping its original position. Every surface opens a task's artifacts at the last one, so the report you just updated is the one on screen — no more paging back to it after every publish.

--- a/decisions/2026/08/31/republished-artifact-moves-to-the-end.md
+++ b/decisions/2026/08/31/republished-artifact-moves-to-the-end.md
@@ -1,0 +1,37 @@
+# A republished artifact moves to the end of the task's list
+
+## Context
+
+`appendArtifactVersion` deliberately merged a republish back into the FIRST record
+sharing its key, so a row the user already knew "would not jump". That reasoning ignored
+the other half of the system: every surface that opens the artifact viewer does so at
+`artifacts.length - 1` (`App.tsx`, `TaskInfoPanel.tsx`). With three artifacts where only
+the first is ever revised, each publish opened the viewer on artifact 3 and the user had
+to page back two rows to the one that had just changed.
+
+## Decision
+
+`appendArtifactVersion` (`src/shared/artifact-versions.ts`) now returns the merged record
+appended at the end of the list, with the other rows keeping their relative order. The
+record still inherits the target's `id`, so nothing pointing at it breaks — only its
+position changes. Sorting the list by publish time would have been equivalent and more
+fragile; the array order already is publish order.
+
+`TaskArtifactViewer` keys its index-reset effect on the `artifacts` array identity rather
+than on its length: a republish hands over a fresh list of the *same* size, so the length
+dep never fired and the viewer stayed on whichever row the user was holding.
+
+## Risks
+
+- **A row the user knows moves.** That is the point, and it is the only way the "open at
+  the last one" convention shared by every surface can be right.
+- **The viewer now jumps to the fresh publish even if the user had paged elsewhere.** Same
+  behaviour as before for an appended artifact; a republish is no less deliberate.
+
+## Alternatives considered
+
+- **Keep the order, and pass the merged row's index in the push payload.** Rejected: the
+  artifact list itself would still read newest-in-the-middle everywhere it is rendered
+  (`SharedOutputsList`), and every future caller would have to remember the index dance.
+- **Sort the list by `createdAt` at render time.** Rejected: it puts the ordering rule in
+  N consumers instead of in the one place that folds a publish in.

--- a/src/bun/__tests__/artifact-versions.test.ts
+++ b/src/bun/__tests__/artifact-versions.test.ts
@@ -54,7 +54,7 @@ describe("appendArtifactVersion", () => {
 		expect(artifacts).toHaveLength(1);
 		expect(pruned).toEqual([]);
 		const merged = artifacts[0];
-		// The row keeps its original identity so it does not move or lose its place.
+		// The row keeps its original identity, so nothing pointing at it breaks.
 		expect(merged.id).toBe("a");
 		expect(merged.version).toBe(2);
 		expect(merged.isUnread).toBe(true);
@@ -63,6 +63,15 @@ describe("appendArtifactVersion", () => {
 		expect(merged.name).toBe("report2.html");
 		expect(merged.bytes).toBe(200);
 		expect(merged.previousVersions?.map((entry) => entry.storedPath)).toEqual([first.storedPath]);
+	});
+
+	it("moves the republished row to the end so the viewer opens on it", () => {
+		const other = (n: number) => publish({ id: `other-${n}`, title: `Other ${n}`, groupKey: artifactGroupKey({ title: `Other ${n}` }) });
+		const existing = [publish({ id: "a", createdAt: 1 }), other(1), other(2)];
+		const { artifacts } = appendArtifactVersion(existing, publish({ id: "b", createdAt: 2 }));
+
+		expect(artifacts.map((artifact) => artifact.id)).toEqual(["other-1", "other-2", "a"]);
+		expect(artifacts[artifacts.length - 1].version).toBe(2);
 	});
 
 	it("keeps a differently titled artifact as its own row", () => {

--- a/src/mainview/components/TaskArtifactViewer.tsx
+++ b/src/mainview/components/TaskArtifactViewer.tsx
@@ -98,10 +98,13 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, onClose, t
 		[group, selectedVersion],
 	);
 
+	// Keyed on the array identity, not its length: a republish hands over a fresh
+	// list of the same size whose last row is the artifact that was just published,
+	// and the viewer has to land on it rather than sit on whatever index it held.
 	useEffect(() => {
 		setPick(null);
 		setIndex(Math.max(0, Math.min(artifacts.length - 1, initialIndex)));
-	}, [artifacts.length, initialIndex]);
+	}, [artifacts, initialIndex]);
 
 	// What the user typed into a version's form and never sent. Held here rather
 	// than in the artifact because the frame is opaque-origin — every storage API

--- a/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
@@ -139,6 +139,23 @@ describe("TaskArtifactViewer", () => {
 		expect(frame).toBeInTheDocument();
 	});
 
+	it("follows a republish that reorders a list of the same length", async () => {
+		const { rerender } = render(
+			<I18nProvider><TaskArtifactViewer taskId="t1" artifacts={[artifact("a"), artifact("b"), artifact("c")]} initialIndex={2} onClose={vi.fn()} /></I18nProvider>,
+		);
+		await userEvent.click(screen.getByLabelText("Previous artifact"));
+		expect(screen.getByText("Artifact b")).toBeInTheDocument();
+
+		// Re-publishing "a" moves its row to the end; the length never changes, so the
+		// viewer has to key on the list itself to land on what was just published.
+		rerender(
+			<I18nProvider><TaskArtifactViewer taskId="t1" artifacts={[artifact("b"), artifact("c"), artifact("a")]} initialIndex={2} onClose={vi.fn()} /></I18nProvider>,
+		);
+
+		expect(screen.getByText("Artifact a")).toBeInTheDocument();
+		expect(screen.getByText("3 / 3")).toBeInTheDocument();
+	});
+
 	it("toggles fullscreen and closes", async () => {
 		const onClose = vi.fn();
 		render(<I18nProvider><TaskArtifactViewer taskId="t1" artifacts={[artifact("a")]} initialIndex={0} onClose={onClose} /></I18nProvider>);

--- a/src/shared/artifact-versions.ts
+++ b/src/shared/artifact-versions.ts
@@ -77,9 +77,12 @@ export function artifactAtVersion(artifact: SharedArtifact, version: number): Sh
  * Fold a fresh publish into the task's artifact list.
  *
  * Records sharing the incoming key — including legacy ones grouped by title —
- * collapse into a single artifact at the FIRST matching position, so a row the
- * user already knows does not jump. Versions are renumbered 1..N because each
- * legacy record claims version 1, then trimmed to `cap`.
+ * collapse into a single artifact, keeping the target's id so nothing that
+ * points at it breaks. The merged row moves to the END of the list: every
+ * surface opens a task's artifacts at the last one, so the row just published
+ * has to be the last one or the user pages back to it after every publish.
+ * Versions are renumbered 1..N because each legacy record claims version 1,
+ * then trimmed to `cap`.
  */
 export function appendArtifactVersion(
 	existing: SharedArtifact[],
@@ -118,8 +121,7 @@ export function appendArtifactVersion(
 		previousVersions: kept.slice(0, -1),
 	};
 	return {
-		artifacts: existing.filter((artifact) => artifact === target || recordGroupKey(artifact) !== key)
-			.map((artifact) => (artifact === target ? merged : artifact)),
+		artifacts: [...existing.filter((artifact) => recordGroupKey(artifact) !== key), merged],
 		pruned,
 	};
 }


### PR DESCRIPTION
Re-publishing an artifact kept its row at its original position, while every surface that opens the artifact viewer opens it at `artifacts.length - 1`. With three artifacts where only the first is ever revised, each publish landed the viewer on artifact 3 and the user had to page back two rows to the one that had just changed.

`appendArtifactVersion` now appends the merged record at the end of the list (other rows keep their relative order); the record still inherits the target's `id`, so nothing pointing at it breaks. `TaskArtifactViewer` keys its index-reset effect on the `artifacts` array identity rather than its length — a republish hands over a fresh list of the *same* size, so the length dep never fired and the viewer stayed on whichever row the user was holding.

Decision record: `decisions/2026/08/31/republished-artifact-moves-to-the-end.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=d2ab8a8a-0642-44e8-8007-0f6affa80411) · `dev3://task/d2ab8a8a-0642-44e8-8007-0f6affa80411`