### PR TITLE
Cap the Remote Access dialog height so it fits every screen

### DIFF
--- a/change-logs/2026/08/31/fix-remote-access-dialog-fits-viewport.md
+++ b/change-logs/2026/08/31/fix-remote-access-dialog-fits-viewport.md
@@ -1,0 +1,3 @@
+Short: Remote Access dialog fits any screen
+
+The Remote Access dialog no longer runs off the top and bottom of the window once the access-code, tunnel and exposed-ports blocks are all present. Its height is now capped against the viewport with a scrolling body, the heading and the Copy URL / Close row stay pinned, the QR shrinks on short windows, and the sign-in URL is clamped to two lines beside the copy button. Verified from 1280x720 up to 1920x1080, on a 500px-tall window and on a 390x844 phone viewport.

--- a/decisions/2026/08/31/remote-access-dialog-height-cap.md
+++ b/decisions/2026/08/31/remote-access-dialog-height-cap.md
@@ -1,0 +1,43 @@
+# Cap the Remote Access dialog against the viewport instead of letting it grow
+
+## Context
+
+The Remote Access modal grew one block at a time — interface picker, sign-in URL,
+"Access code is on" (four paragraphs plus a copy button), the tunnel toggle with its
+status line, stop button and propagation warning, and finally the exposed-ports list.
+Its shell was a single `w-[28rem] p-6 space-y-4` div inside a centred flex backdrop
+with no height cap, so once several of those blocks were live the dialog was taller
+than the window: the heading was clipped at the top edge and the `Copy URL` / `Close`
+row at the bottom, with nothing scrollable. Reported on a *wide* desktop window, so
+every smaller screen was worse.
+
+## Decision
+
+`src/mainview/components/RemoteAccessDialog.tsx` is now a three-part shell: a pinned
+`header`, a `min-h-0 flex-1 overflow-y-auto` body, and a pinned `footer`, inside
+`max-h-full flex flex-col` with `p-4` on the backdrop. The dialog is `w-full
+max-w-[28rem]` rather than a fixed `w-[28rem]`, so it also fits a 390px phone.
+`src/mainview/App.tsx` passes the heading as `header` and the action row as `footer`;
+the QR box is `QR_BOX_SIZE = "w-[min(14rem,26vh)] h-[min(14rem,26vh)]"` so it shrinks
+on short windows instead of eating a fixed 224px; and the sign-in URL — which wrapped
+over seven lines — is `line-clamp-2` with the full value in `title`, since the copy
+button right beside it is how anyone actually transfers it.
+
+Note `line-clamp-*` must not be combined with the `block` utility: Tailwind's `block`
+wins the cascade over `display: -webkit-box` and the clamp silently does nothing.
+
+## Risks
+
+The body scrolls, so a block can now sit below the fold. Accepted: the alternative is
+content off-screen with no way to reach it. The QR at `26vh` is 187px on a 720px-tall
+window — still comfortably scannable, and it is the QR that made the fixed-height
+version unfixable by scrolling alone.
+
+## Alternatives considered
+
+- **Scroll only, no QR shrink** — leaves a 224px QR on a 688px dialog; the scroll
+  hides the problem rather than fixing the proportions.
+- **Fold the access-code explanation behind a disclosure** — a new interaction and
+  new copy in three locales for a block the scroll already handles.
+- **Move the exposed-ports list to Settings** — that is a placement decision, not a
+  layout one; handed back to the user as an option instead of being done here.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -99,6 +99,9 @@ import PushEnrollmentInvite from "./components/PushEnrollmentInvite";
 /** Command shown when cloudflared is missing (Cloudflare Tunnel remote access). */
 const CLOUDFLARED_INSTALL_CMD = "brew install cloudflared";
 
+/** QR box in the Remote Access modal: 14rem, shrinking on short windows so it stays a scannable share of the height. */
+const QR_BOX_SIZE = "w-[min(14rem,26vh)] h-[min(14rem,26vh)]";
+
 /** QR token rotation period; the token's own TTL (`QR_TOKEN_TTL_S`) adds 5s headroom. */
 const QR_REFRESH_SECONDS = 60;
 
@@ -2946,12 +2949,66 @@ function App() {
 				</div>
 			)}
 			{remoteQR && (
-				<RemoteAccessDialog titleId="remote-access-dialog-title" onClose={closeRemoteQR}>
+				<RemoteAccessDialog
+					titleId="remote-access-dialog-title"
+					onClose={closeRemoteQR}
+					header={<h2 id="remote-access-dialog-title" className="text-fg text-lg font-semibold">{t("remote.title")}</h2>}
+					footer={remoteQR.serverStatus && !remoteQR.serverStatus.running ? undefined : (
+						<div className="flex items-center justify-center gap-2">
+							<button
+								type="button"
+								onClick={async () => {
+									if (qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying") return;
+									setRemoteUrlCopyState("copying");
+									try {
+										await navigator.clipboard.writeText(remoteQR.accessUrl);
+										setRemoteUrlCopyState("copied");
+										setTimeout(() => setRemoteUrlCopyState("idle"), 2000);
+									} catch {
+										setRemoteUrlCopyState("idle");
+									}
+								}}
+								disabled={qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying"}
+								aria-label={t(remoteCopyLabel)}
+								className={`inline-flex min-w-[7.25rem] items-center justify-center gap-1.5 px-4 py-2 text-sm rounded-lg transition-[background-color,color,transform] active:scale-[0.98] ${qrConsumed || tunnelUrlPending ? "bg-elevated text-fg-3 cursor-not-allowed" : remoteUrlCopyState === "copying" ? "bg-accent/80 text-white cursor-wait" : remoteUrlCopyState === "copied" ? "bg-success-fill text-white hover:bg-success-fill-hover" : "bg-accent-fill text-white hover:bg-accent-fill-hover"}`}
+							>
+								{remoteUrlCopyState === "copying" && (
+									<svg
+										className="w-3.5 h-3.5 animate-spin"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										aria-hidden="true"
+									>
+										<circle cx="12" cy="12" r="9" strokeWidth="3" opacity="0.25" />
+										<path d="M21 12a9 9 0 0 1-9 9" strokeWidth="3" strokeLinecap="round" />
+									</svg>
+								)}
+								{remoteUrlCopyState === "copied" && (
+									<span
+										aria-hidden="true"
+										className="leading-none"
+										style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
+									>
+										{"\uF00C"}
+									</span>
+								)}
+								{t(remoteCopyLabel)}
+							</button>
+							<button
+								type="button"
+								onClick={closeRemoteQR}
+								className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
+							>
+								{t("remote.close")}
+							</button>
+						</div>
+					)}
+				>
 					{remoteQR.serverStatus && !remoteQR.serverStatus.running ? (
 						// Nothing is listening, so there is no URL and no QR to show — a code
 						// minted on port 0 would look scannable and go nowhere.
 						<>
-							<h2 id="remote-access-dialog-title" className="text-fg text-lg font-semibold">{t("remote.title")}</h2>
 							<RemoteAccessDownNotice
 								status={remoteQR.serverStatus}
 								onOpenSettings={() => {
@@ -2962,13 +3019,12 @@ function App() {
 						</>
 					) : (
 					<>
-						<h2 id="remote-access-dialog-title" className="text-fg text-lg font-semibold">{t("remote.title")}</h2>
 						<p className="text-fg-2 text-sm">{t("remote.subtitle")}</p>
 						<div className="flex justify-center relative">
 							{tunnelUrlPending ? (
 								<div
 									data-testid="remote-qr-pending"
-									className="w-56 h-56 rounded-lg bg-base border border-edge flex flex-col items-center justify-center gap-3 px-4"
+									className={`${QR_BOX_SIZE} rounded-lg bg-base border border-edge flex flex-col items-center justify-center gap-3 px-4`}
 								>
 									<svg className="w-7 h-7 animate-spin text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
 										<circle cx="12" cy="12" r="9" strokeWidth="3" opacity="0.25" />
@@ -2978,7 +3034,7 @@ function App() {
 									<span className="text-fg-muted text-xs leading-snug">{t("remote.qrWaitingTunnelHint")}</span>
 								</div>
 							) : (
-								<img src={remoteQR.qrDataUrl} alt="QR Code" className={`w-56 h-56 rounded-lg transition-[opacity,filter] duration-500 streamer-private-media ${qrConsumed ? "opacity-20 grayscale" : ""}`} />
+								<img src={remoteQR.qrDataUrl} alt="QR Code" className={`${QR_BOX_SIZE} rounded-lg transition-[opacity,filter] duration-500 streamer-private-media ${qrConsumed ? "opacity-20 grayscale" : ""}`} />
 							)}
 							{qrConsumed && !tunnelUrlPending && (
 								<div className="absolute inset-0 flex items-center justify-center">
@@ -3031,7 +3087,15 @@ function App() {
 						)}
 						{!tunnelUrlPending && (
 							<div className={`bg-base rounded-lg p-3 ${qrConsumed ? "opacity-40" : ""}`}>
-								<code className={`text-xs break-all streamer-private ${qrConsumed ? "text-fg-3" : "text-fg select-all"}`}>{remoteQR.accessUrl}</code>
+								{/* Clamped: a tunnel URL with a sign-in token wraps over seven lines and
+								    pushed the action row off screen. The copy button below carries it. */}
+								<code
+									data-testid="remote-access-url"
+									title={remoteQR.accessUrl}
+									className={`text-xs break-all line-clamp-2 streamer-private ${qrConsumed ? "text-fg-3" : "text-fg select-all"}`}
+								>
+									{remoteQR.accessUrl}
+								</code>
 							</div>
 						)}
 
@@ -3232,56 +3296,6 @@ function App() {
 						</div>
 
 						<RemoteAccessExposedPorts />
-
-						<div className="flex items-center justify-center gap-2">
-							<button
-								type="button"
-								onClick={async () => {
-									if (qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying") return;
-									setRemoteUrlCopyState("copying");
-									try {
-										await navigator.clipboard.writeText(remoteQR.accessUrl);
-										setRemoteUrlCopyState("copied");
-										setTimeout(() => setRemoteUrlCopyState("idle"), 2000);
-									} catch {
-										setRemoteUrlCopyState("idle");
-									}
-								}}
-								disabled={qrConsumed || tunnelUrlPending || remoteUrlCopyState === "copying"}
-								aria-label={t(remoteCopyLabel)}
-								className={`inline-flex min-w-[7.25rem] items-center justify-center gap-1.5 px-4 py-2 text-sm rounded-lg transition-[background-color,color,transform] active:scale-[0.98] ${qrConsumed || tunnelUrlPending ? "bg-elevated text-fg-3 cursor-not-allowed" : remoteUrlCopyState === "copying" ? "bg-accent/80 text-white cursor-wait" : remoteUrlCopyState === "copied" ? "bg-success-fill text-white hover:bg-success-fill-hover" : "bg-accent-fill text-white hover:bg-accent-fill-hover"}`}
-							>
-								{remoteUrlCopyState === "copying" && (
-									<svg
-										className="w-3.5 h-3.5 animate-spin"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										aria-hidden="true"
-									>
-										<circle cx="12" cy="12" r="9" strokeWidth="3" opacity="0.25" />
-										<path d="M21 12a9 9 0 0 1-9 9" strokeWidth="3" strokeLinecap="round" />
-									</svg>
-								)}
-								{remoteUrlCopyState === "copied" && (
-									<span
-										aria-hidden="true"
-										className="leading-none"
-										style={{ fontFamily: "'JetBrainsMono Nerd Font Mono'" }}
-									>
-										{"\uF00C"}
-									</span>
-								)}
-								{t(remoteCopyLabel)}
-							</button>
-							<button
-								type="button"
-								onClick={closeRemoteQR}
-								className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"
-							>
-								{t("remote.close")}
-							</button>
-						</div>
 					</>
 					)}
 				</RemoteAccessDialog>

--- a/src/mainview/components/RemoteAccessDialog.tsx
+++ b/src/mainview/components/RemoteAccessDialog.tsx
@@ -5,6 +5,10 @@ import { useEscapeKey } from "../hooks/useEscapeKey";
 type RemoteAccessDialogProps = {
 	titleId: string;
 	onClose: () => void;
+	/** Pinned above the scroll area — stays readable however tall the body grows. */
+	header?: ReactNode;
+	/** Pinned below the scroll area — the primary action is never scrolled off. */
+	footer?: ReactNode;
 	children: ReactNode;
 };
 
@@ -13,14 +17,18 @@ type RemoteAccessDialogProps = {
  * the focus trap mounts and unmounts with the modal — `useFocusTrap` captures
  * the trigger element on its first render, which is wrong if the hook lives in
  * a host that is always mounted.
+ *
+ * The body scrolls inside a viewport-capped box: this modal's content grows
+ * with tunnel state, access-code state and exposed ports, and used to run off
+ * both edges of a 720px-tall window.
  */
-function RemoteAccessDialog({ titleId, onClose, children }: RemoteAccessDialogProps) {
+function RemoteAccessDialog({ titleId, onClose, header, footer, children }: RemoteAccessDialogProps) {
 	const trapRef = useFocusTrap<HTMLDivElement>();
 	useEscapeKey(onClose);
 
 	return (
 		<div
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
 			onMouseDown={(e) => {
 				if (e.target === e.currentTarget) onClose();
 			}}
@@ -31,9 +39,17 @@ function RemoteAccessDialog({ titleId, onClose, children }: RemoteAccessDialogPr
 				aria-modal="true"
 				aria-labelledby={titleId}
 				tabIndex={-1}
-				className="bg-overlay border border-edge rounded-2xl shadow-2xl w-[28rem] p-6 space-y-4 text-center outline-none"
+				data-testid="remote-access-dialog"
+				className="bg-overlay border border-edge rounded-2xl shadow-2xl w-full max-w-[28rem] max-h-full flex flex-col text-center outline-none"
 			>
-				{children}
+				{header && <div className="shrink-0 px-6 pt-6 pb-3">{header}</div>}
+				<div
+					data-testid="remote-access-dialog-body"
+					className={`min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 space-y-4 ${header ? "pt-1" : "pt-6"} ${footer ? "pb-1" : "pb-6"}`}
+				>
+					{children}
+				</div>
+				{footer && <div className="shrink-0 px-6 pb-6 pt-3">{footer}</div>}
 			</div>
 		</div>
 	);

--- a/src/mainview/components/__tests__/RemoteAccessDialog.test.tsx
+++ b/src/mainview/components/__tests__/RemoteAccessDialog.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RemoteAccessDialog from "../RemoteAccessDialog";
+
+/**
+ * The modal's content grows with tunnel state, access code and exposed ports.
+ * Before the height cap it ran off both edges of a 720px-tall window: the
+ * heading was clipped at the top and the action row at the bottom, with
+ * nothing scrollable. These assertions guard that shape.
+ */
+describe("RemoteAccessDialog", () => {
+	function renderDialog() {
+		return render(
+			<RemoteAccessDialog
+				titleId="t"
+				onClose={vi.fn()}
+				header={<h2 id="t">Remote access</h2>}
+				footer={<button type="button">Close</button>}
+			>
+				<p>body content</p>
+			</RemoteAccessDialog>,
+		);
+	}
+
+	it("caps the dialog against the viewport and stacks header/body/footer", () => {
+		renderDialog();
+		const dialog = screen.getByTestId("remote-access-dialog");
+		expect(dialog.className).toContain("max-h-full");
+		expect(dialog.className).toContain("flex-col");
+		// The backdrop keeps the dialog off the window edges on short/narrow screens.
+		expect(dialog.parentElement?.className).toContain("p-4");
+	});
+
+	it("scrolls the body instead of growing the dialog", () => {
+		renderDialog();
+		const body = screen.getByTestId("remote-access-dialog-body");
+		expect(body.className).toContain("overflow-y-auto");
+		// Without min-h-0 a flex child refuses to shrink and the cap does nothing.
+		expect(body.className).toContain("min-h-0");
+	});
+
+	it("keeps the heading and the action row outside the scroll area", () => {
+		renderDialog();
+		const body = screen.getByTestId("remote-access-dialog-body");
+		expect(body).not.toContainElement(screen.getByRole("heading", { name: "Remote access" }));
+		expect(body).not.toContainElement(screen.getByRole("button", { name: "Close" }));
+		expect(body).toContainElement(screen.getByText("body content"));
+	});
+
+	it("fits a narrow phone viewport", () => {
+		renderDialog();
+		const dialog = screen.getByTestId("remote-access-dialog");
+		// w-full + max-w, never a fixed w-[28rem] that overflows a 390px screen.
+		expect(dialog.className).toContain("w-full");
+		expect(dialog.className).toContain("max-w-[28rem]");
+		expect(dialog.className).not.toMatch(/(^|\s)w-\[28rem\]/);
+	});
+});


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that made this change).

The Remote Access dialog was taller than the window once the access-code block, the tunnel section and the exposed-ports list were all present — measured at **1150px** with no height cap, so the heading was clipped at the top edge and the `Copy URL` / `Close` row at the bottom, with nothing scrollable. It did not fit even at 1920x1080.

**What changed**

- `RemoteAccessDialog` is now a three-part shell — pinned `header`, `min-h-0 flex-1 overflow-y-auto` body, pinned `footer` — inside `max-h-full flex flex-col`, with `p-4` on the backdrop. `w-full max-w-[28rem]` replaces the fixed `w-[28rem]`, so it also fits a 390px phone.
- The QR box is `w-[min(14rem,26vh)]`, shrinking on short windows instead of eating a fixed 224px.
- The sign-in URL, which wrapped over seven lines, is clamped to two with the full value in `title`; the copy button beside it is how it actually gets transferred.

**Measured after the change** (dialog rect vs. viewport, action row inside the window):

| Viewport | Dialog height | Fits | Close reachable |
|---|---|---|---|
| 1280x720 | 688 | yes | yes |
| 1280x800 | 768 | yes | yes |
| 1440x900 | 868 | yes | yes |
| 1512x982 | 950 | yes | yes |
| 1728x1117 | 1038 | yes | yes |
| 1920x1080 | 1038 | yes | yes |
| 1280x500 (short window) | 468 | yes | yes |
| 390x844 (phone) | 820 | yes | yes |

Before the change every desktop row above read `fits: false` with the dialog 1150px tall.

Rationale and rejected alternatives: `decisions/2026/08/31/remote-access-dialog-height-cap.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=da977652-775a-4de1-b770-1296c89e6b2f) · `dev3://task/da977652-775a-4de1-b770-1296c89e6b2f`
