### PR TITLE
Back up the project list hourly, and stop tests reaching the real dev3 home

### DIFF
--- a/change-logs/2026/08/31/fix-project-backups-and-test-isolation.md
+++ b/change-logs/2026/08/31/fix-project-backups-and-test-isolation.md
@@ -1,0 +1,3 @@
+Short: Project list now backed up hourly
+
+The project list is now snapshotted hourly (72 kept) alongside the existing daily copies, and both are driven by a timer instead of only by a save — an app left running for days previously snapshotted nothing at all. A separate last-known-good copy is kept that no rotation can evict, so a collapsed project list can never become the only surviving backup. Separately, the test harness now drops every inherited DEV3_ environment variable rather than six named ones, closing a hole where a shell exporting DEV3_HOME made the backend suites resolve the real ~/.dev3.0 instead of their sandbox.

--- a/decisions/2026/08/31/default-deny-dev3-env-in-test-isolation.md
+++ b/decisions/2026/08/31/default-deny-dev3-env-in-test-isolation.md
@@ -1,0 +1,56 @@
+# Default-deny every inherited DEV3_ var in test isolation
+
+## Context
+
+`configureTestIsolation` sandboxes HOME, TMPDIR and the XDG dirs for every Vitest
+process, then scrubbed exactly six named `DEV3_TASK_*`-ish vars plus the
+`DEV3_NATIVE_SESSION_` prefix. `resolveDev3Home` reads `env.DEV3_HOME` FIRST and
+returns it verbatim, before it ever looks at HOME — and `DEV3_HOME` was on
+neither scrub list. So a suite started from any shell exporting it (the scoped QA
+instance exports exactly that) resolved the user's live `~/.dev3.0` at module
+load, with the sandbox silently bypassed.
+
+## Investigation
+
+A dev3 agent pane exports 13 `DEV3_*` vars. Nine survived the old scrub,
+including `DEV3_PROJECT_PATH` (the real checkout), `DEV3_WORKTREE_ROOT`,
+`DEV3_ARTIFACT_TEMPLATE_DIR`, `DEV3_AGENT_ACCOUNT_ID` and `DEV3_USER_ENV`. The
+named list was not merely missing `DEV3_HOME`; it was structurally the wrong
+shape, because it had to be edited every time dev3 gained a var, and nothing
+failed when it was not.
+
+No CI job and no test reads any `DEV3_*` var from the environment. The single
+exception is `DEV3_TEST_CONCURRENT`, set by the `bun run test` scripts and read
+by the Vitest config for its worker budget immediately after isolation returns.
+
+## Decision
+
+Two layers, in `test-isolation.ts`.
+
+Mechanism: default-deny. Drop every `DEV3_*` var and preserve only the
+`DEV3_TEST_` prefix (`PRESERVED_TEST_ENV_PREFIX`), so a var dev3 gains later is
+safe with nobody editing this file.
+
+Outcome: `assertDev3HomeIsSandboxed`, called at the end of
+`configureTestIsolation`, resolves the root through the PRODUCTION resolver and
+throws if it lands outside the run root. That turns "quietly writes to the user's
+real data root" into a refusal to start, whatever future override slips through.
+
+## Risks
+
+Default-deny drops a var some future harness genuinely wants inherited. The
+failure is loud and local (a test reading an env var it no longer gets), and the
+fix is to name it under the `DEV3_TEST_` prefix. `PANE_INJECTED_ENV_SAMPLE` is
+illustrative only — the scrub is a prefix rule, so that list going stale cannot
+reopen the hole.
+
+This bug did NOT cause the 31 Aug 2026 `projects.json` incident; the damage there
+included EPERM failures in a different tree, which a test writing to a wrong path
+does not produce. It is fixed on its own merits.
+
+## Alternatives considered
+
+Setting `DEV3_HOME` to the sandbox was rejected: it OUTRANKS `HOME`, and dozens
+of suites relocate the board by assigning `process.env.HOME`, so they would all
+silently read the shared run root instead of their own fixture. Adding
+`DEV3_HOME` to the named list was rejected as the same shape that just failed.

--- a/decisions/2026/08/31/project-list-backups-hourly-and-a-copy-rotation-cannot-evict.md
+++ b/decisions/2026/08/31/project-list-backups-hourly-and-a-copy-rotation-cannot-evict.md
@@ -1,0 +1,77 @@
+# Project list gets hourly backups and one copy rotation cannot evict
+
+## Context
+
+On 31 Aug 2026 `~/.dev3.0/projects.json` was destroyed on the maintainer's own
+machine. All 1865 tasks referenced a project id that was no longer in the file,
+so the whole board was unreachable. He had worked on 28, 29 and 30 August and
+there was no backup for any of those days.
+
+## Investigation
+
+Measured in the code, not inferred. `backupProjectsDaily` writes
+`projects-YYYY-MM-DD.json.bak` holding the PRE-write contents, at most once per
+calendar day (first write of the day wins and is never overwritten), keeping
+`PROJECTS_BACKUP_RETENTION_DAYS = 7`. It is called from `rawSaveProjects` — so on
+every mutation — and once at app startup.
+
+That explains the gap exactly: a backup requires either a project-list mutation
+or an app start. He added no project on 28-30 Aug and the app was not restarted,
+so nothing fired. The startup hook's own comment claimed "at least one fresh
+backup per day the app is used", which is false for a long-running app: it
+guarantees one per day the app is STARTED.
+
+Two corrections to what the incident looked like. Retention is 7, not 3, so with
+only three dated files present nothing was near eviction. And the 453-byte
+one-project backup written at 18:58:30 was not a degenerate snapshot of a healthy
+file — it is the pre-write copy of the file as it stood after the list had already
+been destroyed and re-added by hand.
+
+Meanwhile the task store was properly protected: 72 hourly snapshots under
+`data/<slug>/tasks-backups`. The less important file had the better scheme.
+
+## Decision
+
+`src/bun/data.ts`, `src/bun/index.ts`.
+
+1. `writeHourlySnapshot` — the task store's hourly bucket-and-prune logic
+   extracted and now shared, so the two stores cannot drift into different levels
+   of protection. `writeHourlyTasksBackup` is a thin call over it.
+2. `backupProjectsHourly` writes `projects-backups/YYYY-MM-DDTHHZ.json`, 72 kept.
+   The daily `.bak` files stay: 7 days of calendar cover is wider than 72 hours,
+   and they are additive sibling paths, so nothing on disk is moved or renamed.
+3. A 30-minute timer in `index.ts` drives both schemes, so every hour the app is
+   alive gets a snapshot whether or not anything was edited. This is the part that
+   would have produced 28-30 August.
+4. `projects-last-known-good.json`, advanced by `advanceLastKnownGoodProjects`
+   and never pruned, so no rotation can leave a degenerate copy as the only one.
+
+The threshold is the argument. It advances unless the list COLLAPSED — more than
+half gone at once — and never on unparseable bytes. "Never shrink" would be its
+own bug: a user deleting one project would freeze the file forever and it would
+go on holding projects they meant to be rid of. "Always advance" is what lets a
+wipe become the only survivor. A collapse is the one shape ordinary editing never
+produces, so it is the one shape worth refusing.
+
+## Risks
+
+`projects-last-known-good.json` can hold a stale list after a legitimate
+collapse — a user who deliberately removes almost every project keeps an old copy
+on local disk until the list grows back. It is local-only and never read
+automatically; restoring from it is a human act.
+
+72 hourly copies of a ~31 KB file cost ~2 MB, the same order as the task store's
+own backups.
+
+The timer means the app now touches `~/.dev3.0` every 30 minutes while idle. The
+writes are new sibling files only, so the frozen on-disk layout invariants hold.
+
+## Alternatives considered
+
+Replacing the daily scheme with the hourly one was rejected: 72 hours is less
+calendar cover than 7 days, so it would trade one gap for another. Refusing to
+write a degenerate snapshot at all was rejected — a snapshot that lies about the
+current state is worse than one that records an emptied list, and the file the
+user needs protected is the good copy, not the recent one. A count-based
+exemption inside the pruner (keep the largest snapshot in the window) was
+rejected as harder to reason about than one plainly named file.

--- a/src/bun/__tests__/data-projects-backup.test.ts
+++ b/src/bun/__tests__/data-projects-backup.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 	mkdirSync(TEST_HOME, { recursive: true });
 });
 
-import { addProject, backupProjectsDaily, updateProject } from "../data";
+import { addProject, backupProjectsDaily, backupProjectsHourly, updateProject } from "../data";
 
 const PROJECTS_FILE = `${TEST_HOME}/projects.json`;
 
@@ -100,5 +100,78 @@ describe("daily projects.json backups", () => {
 		await backupProjectsDaily();
 
 		expect(existsSync(todayBackupFile())).toBe(true);
+	});
+});
+
+describe("hourly projects.json backups", () => {
+	const HOURLY_DIR = `${TEST_HOME}/projects-backups`;
+	const LAST_GOOD = `${TEST_HOME}/projects-last-known-good.json`;
+
+	function listHourly(): string[] {
+		return existsSync(HOURLY_DIR)
+			? readdirSync(HOURLY_DIR).filter((f) => /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/.test(f)).sort()
+			: [];
+	}
+
+	it("snapshots on a timer tick with no save at all", async () => {
+		// The measured defect: 28-30 Aug 2026 have no copy because both schemes
+		// only fired on a save or at startup, and the app stayed up for days.
+		seedProjects([{ id: "a", name: "A", path: "/tmp/a" } as Project]);
+
+		await backupProjectsHourly();
+
+		expect(listHourly()).toHaveLength(1);
+		expect(JSON.parse(readFileSync(`${HOURLY_DIR}/${listHourly()[0]}`, "utf-8"))).toHaveLength(1);
+	});
+
+	it("keeps one snapshot per hour and prunes beyond 72", async () => {
+		seedProjects([{ id: "a", name: "A", path: "/tmp/a" } as Project]);
+		const hour = new Date("2026-08-31T10:00:00.000Z");
+
+		await backupProjectsHourly(hour);
+		await backupProjectsHourly(new Date("2026-08-31T10:59:59.000Z"));
+		expect(listHourly()).toEqual(["2026-08-31T10Z.json"]);
+
+		for (let i = 0; i < 80; i++) {
+			writeFileSync(`${HOURLY_DIR}/2026-05-${String((i % 28) + 1).padStart(2, "0")}T${String(i % 24).padStart(2, "0")}Z.json`, "[]");
+		}
+		await backupProjectsHourly(new Date("2026-08-31T12:00:00.000Z"));
+		expect(listHourly().length).toBeLessThanOrEqual(72);
+	});
+
+	it("keeps a good copy that no rotation can evict", async () => {
+		seedProjects(Array.from({ length: 29 }, (_, i) => ({ id: `p${i}`, name: `P${i}`, path: `/tmp/p${i}` }) as Project));
+		await backupProjectsHourly(new Date("2026-08-31T10:00:00.000Z"));
+		expect(JSON.parse(readFileSync(LAST_GOOD, "utf-8"))).toHaveLength(29);
+
+		// The wreck arrives as the next hour's pre-write content.
+		seedProjects([{ id: "only", name: "dev-3.0", path: "/tmp/only" } as Project]);
+		await backupProjectsHourly(new Date("2026-08-31T11:00:00.000Z"));
+
+		// The hourly slot faithfully holds the wreck; the good copy is untouched.
+		expect(JSON.parse(readFileSync(`${HOURLY_DIR}/2026-08-31T11Z.json`, "utf-8"))).toHaveLength(1);
+		expect(JSON.parse(readFileSync(LAST_GOOD, "utf-8"))).toHaveLength(29);
+	});
+
+	it("still advances the good copy when a user deletes a project or two", async () => {
+		// A rule that refused every shrink would freeze this file forever and go on
+		// holding projects the user meant to be rid of.
+		seedProjects(Array.from({ length: 10 }, (_, i) => ({ id: `p${i}`, name: `P${i}`, path: `/tmp/p${i}` }) as Project));
+		await backupProjectsHourly(new Date("2026-08-31T10:00:00.000Z"));
+
+		seedProjects(Array.from({ length: 8 }, (_, i) => ({ id: `p${i}`, name: `P${i}`, path: `/tmp/p${i}` }) as Project));
+		await backupProjectsHourly(new Date("2026-08-31T11:00:00.000Z"));
+
+		expect(JSON.parse(readFileSync(LAST_GOOD, "utf-8"))).toHaveLength(8);
+	});
+
+	it("never lets unreadable bytes become the good copy", async () => {
+		seedProjects([{ id: "a", name: "A", path: "/tmp/a" } as Project]);
+		await backupProjectsHourly(new Date("2026-08-31T10:00:00.000Z"));
+
+		writeFileSync(PROJECTS_FILE, "{ truncated");
+		await backupProjectsHourly(new Date("2026-08-31T11:00:00.000Z"));
+
+		expect(JSON.parse(readFileSync(LAST_GOOD, "utf-8"))).toHaveLength(1);
 	});
 });

--- a/src/bun/__tests__/test-isolation.test.ts
+++ b/src/bun/__tests__/test-isolation.test.ts
@@ -5,8 +5,13 @@ import { join } from "node:path";
 import { createServer } from "node:net";
 import { testScopedPath, testSocketPath } from "../../../test-scoped-path";
 import {
-	INHERITED_TASK_CONTEXT_ENV,
+	DEV3_ENV_PREFIX,
 	MAX_UNIX_SOCKET_PATH_BYTES,
+	PANE_INJECTED_ENV_SAMPLE,
+	PRESERVED_TEST_ENV_PREFIX,
+	assertDev3HomeIsSandboxed,
+	cleanupTestIsolation,
+	configureTestIsolation,
 	deriveTestRunRoot,
 	deriveTestSocketRoot,
 	testWorktreeId,
@@ -83,29 +88,57 @@ describe("test process isolation", () => {
 		expect(() => testScopedPath("s.sock")).toThrow(/testSocketPath/);
 	});
 
-	it("scrubs the task context of the agent that started this run", () => {
-		// These suites usually run INSIDE a dev3 task pane. Leaving DEV3_TASK_SEQ or
-		// DEV3_PANE_ID set would let a module quietly pick up the agent's own task
-		// and produce a different verdict locally than in CI.
-		for (const key of INHERITED_TASK_CONTEXT_ENV) expect(process.env[key]).toBeUndefined();
+	it("leaves this run carrying no pane-injected DEV3_ var at all", () => {
+		// These suites usually run INSIDE a dev3 task pane, which exports its data
+		// home, its checkout, its worktree, its ports and its task. Anything that
+		// survived here would let a module quietly test the agent's OWN environment.
+		const root = process.env.DEV3_TEST_ROOT as string;
+		// Anything left outside the harness's own DEV3_TEST_ namespace has to be a
+		// path this run owns — DEV3_LOG_DIR is set by the isolation itself.
+		const escaped = Object.keys(process.env)
+			.filter((key) => key.startsWith(DEV3_ENV_PREFIX) && !key.startsWith(PRESERVED_TEST_ENV_PREFIX))
+			.filter((key) => !process.env[key]?.startsWith(root));
+		expect(escaped).toEqual([]);
 	});
 
-	it("scrubs the native session config of the pane this run started in", () => {
-		// An agent pane on the native backend exports its own host's
-		// DEV3_NATIVE_SESSION_* — which a launcher test would otherwise read as if
-		// the launcher had set it.
-		expect(Object.keys(process.env).filter((key) => key.startsWith("DEV3_NATIVE_SESSION_"))).toEqual([]);
+	it("scrubs a DEV3_ var nobody listed, including one invented after this test", () => {
+		// The point of default-deny: the scrub is a prefix rule, so a var dev3 gains
+		// later is dropped with nobody editing test-isolation.ts. A named list is
+		// what let DEV3_HOME through while dutifully scrubbing six lesser vars.
+		const injected = [...PANE_INJECTED_ENV_SAMPLE, "DEV3_SOMETHING_INVENTED_LATER"];
+		withRestoredEnv(() => {
+			for (const key of injected) process.env[key] = "/Users/real/leaked";
+			process.env.DEV3_TEST_CONCURRENT = "1";
+
+			const root = configureTestIsolation("guard", "/repo/worktrees/guard-scrub");
+			try {
+				for (const key of injected) expect(process.env[key]).toBeUndefined();
+				// The harness's own namespace must survive: the Vitest config reads
+				// DEV3_TEST_CONCURRENT for its worker budget right after this returns.
+				expect(process.env.DEV3_TEST_CONCURRENT).toBe("1");
+				expect(process.env.DEV3_TEST_ROOT).toBe(root);
+			} finally {
+				cleanupTestIsolation(root);
+			}
+		});
 	});
 
-	it("names every task-context var dev3 injects into a pane", () => {
-		// A new injected var must be added to the scrub list in the same change.
-		expect([...INHERITED_TASK_CONTEXT_ENV]).toEqual([
-			"DEV3_TASK_ID",
-			"DEV3_TASK_SEQ",
-			"DEV3_TASK_TITLE",
-			"DEV3_PANE_ID",
-			"DEV3_WORKTREE_PATH",
-			"DEV3_BRANCH_NAME",
-		]);
+	it("refuses to start when the data root still escapes to the real home", () => {
+		// The outcome check rather than the mechanism: if a later change lets some
+		// override through, the run dies here instead of writing to the live board.
+		expect(() => assertDev3HomeIsSandboxed("/tmp/dev3-tests/elsewhere")).toThrow(
+			/outside the run root/,
+		);
 	});
 });
+
+/** Run `body` with the process environment restored afterwards, whatever it did. */
+function withRestoredEnv(body: () => void): void {
+	const saved = { ...process.env };
+	try {
+		body();
+	} finally {
+		for (const key of Object.keys(process.env)) delete process.env[key];
+		Object.assign(process.env, saved);
+	}
+}

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -28,7 +28,21 @@ const PROJECTS_BACKUP_RETENTION_DAYS = 7;
 const PROJECTS_BACKUP_FILE_PATTERN = /^projects-\d{4}-\d{2}-\d{2}\.json\.bak$/;
 const TASK_BACKUPS_DIR = "tasks-backups";
 const TASK_BACKUP_RETENTION_HOURS = 72;
-const TASK_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
+const HOURLY_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
+// The project list gets the same hourly cover as the task store: losing it makes
+// every board unreachable, so it cannot be the less protected of the two. New
+// sibling paths only — nothing existing is moved or renamed (AGENTS.md).
+const PROJECTS_BACKUPS_DIR = `${DEV3_HOME}/projects-backups`;
+const PROJECTS_BACKUP_RETENTION_HOURS = 72;
+/**
+ * The copy no rotation can evict.
+ *
+ * Hourly and daily snapshots both rotate, so a run of degenerate ones can push
+ * every good copy out of the window — which is how the only same-day copy of a
+ * 29-project list came to hold one project. This file is advanced only when the
+ * list has not COLLAPSED, so a non-degenerate copy always survives.
+ */
+const LAST_KNOWN_GOOD_PROJECTS_FILE = `${DEV3_HOME}/projects-last-known-good.json`;
 // `name` is display-only: `path` is deliberately absent, so a rename never moves
 // a data dir, worktree dir or slug (AGENTS.md on-disk invariants).
 type ProjectUpdates = Partial<Pick<Project, "name" | "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels" | "sensitive" | "reviewModePrompt" | "coordinatorPrompt" | "env" | "conversationImportOfferedAt">>;
@@ -54,8 +68,52 @@ function tasksBackupDir(project: Project): string {
 	return `${DEV3_HOME}/data/${projectSlug(project.path)}/${TASK_BACKUPS_DIR}`;
 }
 
-function tasksBackupFileName(now: Date = new Date()): string {
+function hourlyBackupFileName(now: Date = new Date()): string {
 	return `${now.toISOString().slice(0, 13)}Z.json`;
+}
+
+/**
+ * At most one pre-write snapshot per entry hour, decided with stat() rather than
+ * by reading two whole files. The hour is captured before reading, so a
+ * boundary-spanning read stays in its start hour. See decision 204.
+ *
+ * Shared by the task store and the project list so the two can never drift into
+ * different levels of protection. Returns the bytes it snapshotted, or null when
+ * the hour was already covered or the source does not exist yet.
+ */
+async function writeHourlySnapshot(
+	sourceFile: string,
+	backupDir: string,
+	retentionHours: number,
+	now: Date = new Date(),
+): Promise<string | null> {
+	const backupFile = `${backupDir}/${hourlyBackupFileName(now)}`;
+
+	try {
+		await stat(backupFile);
+		return null; // This hour is already snapshotted.
+	} catch (err: any) {
+		if (err.code !== "ENOENT") throw err;
+	}
+
+	let currentContent: string;
+	try {
+		currentContent = await readFile(sourceFile, "utf8");
+	} catch (err: any) {
+		if (err.code === "ENOENT") return null;
+		throw err;
+	}
+
+	await mkdir(backupDir, { recursive: true });
+	await writeFile(backupFile, currentContent);
+
+	const backupFiles = (await readdir(backupDir))
+		.filter((entry) => HOURLY_BACKUP_FILE_PATTERN.test(entry))
+		.sort();
+	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - retentionHours))) {
+		await unlink(`${backupDir}/${staleFile}`);
+	}
+	return currentContent;
 }
 
 export function deriveTaskBaseBranch(project: Project, existingBranch?: string | null): string {
@@ -220,6 +278,9 @@ async function rawSaveProjects(projects: Project[]): Promise<void> {
 	await backupProjectsDaily().catch((err) => {
 		log.warn("Failed to write daily projects backup (non-fatal)", { err });
 	});
+	await backupProjectsHourly().catch((err) => {
+		log.warn("Failed to write hourly projects backup (non-fatal)", { err });
+	});
 	await atomicWriteFile(PROJECTS_FILE, JSON.stringify(projects, null, 2));
 	projectsCache.delete(PROJECTS_FILE);
 	log.info(`Saved ${projects.length} project(s)`);
@@ -255,6 +316,61 @@ export async function backupProjectsDaily(now: Date = new Date()): Promise<void>
 	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - PROJECTS_BACKUP_RETENTION_DAYS))) {
 		await unlink(`${DEV3_HOME}/${staleFile}`);
 	}
+}
+
+/** How many projects a `projects.json` payload holds, or null if it is not a
+ *  readable list — unparseable bytes must never advance the good copy. */
+function countProjects(content: string): number | null {
+	try {
+		const parsed = JSON.parse(content);
+		return Array.isArray(parsed) ? parsed.length : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Advance the un-evictable copy, unless the list COLLAPSED — more than half of
+ * it gone at once.
+ *
+ * The threshold is the whole argument. "Never shrink" would be its own bug: a
+ * user who deletes a project would freeze this file forever and it would go on
+ * holding data they meant to be rid of. "Always advance" is what makes a wipe
+ * the only surviving copy. A collapse is the one shape no ordinary editing
+ * produces, so it is the one shape worth refusing.
+ */
+async function advanceLastKnownGoodProjects(content: string): Promise<void> {
+	const incoming = countProjects(content);
+	if (incoming === null) return;
+
+	let existing: number | null = null;
+	try {
+		existing = countProjects(await readFile(LAST_KNOWN_GOOD_PROJECTS_FILE, "utf8"));
+	} catch (err: any) {
+		if (err.code !== "ENOENT") throw err;
+	}
+
+	if (existing !== null && incoming * 2 < existing) {
+		log.warn("Refusing to advance last-known-good projects: list collapsed", { incoming, existing });
+		return;
+	}
+	await atomicWriteFile(LAST_KNOWN_GOOD_PROJECTS_FILE, content);
+}
+
+/**
+ * Hourly safety snapshot of the project list, the same scheme the task store has
+ * had — plus the un-evictable good copy. Driven by saves AND by a timer, because
+ * a save-only trigger snapshots nothing on a day nobody edits a project, which
+ * is exactly why 28-30 Aug 2026 have no copy at all.
+ */
+export async function backupProjectsHourly(now: Date = new Date()): Promise<void> {
+	const snapshotted = await writeHourlySnapshot(
+		PROJECTS_FILE,
+		PROJECTS_BACKUPS_DIR,
+		PROJECTS_BACKUP_RETENTION_HOURS,
+		now,
+	);
+	if (snapshotted !== null) await advanceLastKnownGoodProjects(snapshotted);
 }
 
 // ---- Projects (public API — all mutators use file lock) ----
@@ -752,42 +868,8 @@ async function rawSaveTasks(
 	log.info(`Saved ${tasks.length} task(s)`, { projectId: project.id });
 }
 
-/**
- * At most one pre-save snapshot per entry hour, decided with stat() rather than by
- * reading two whole files. The hour is captured before reading, so a boundary-spanning
- * read stays in its start hour. See decision 204.
- */
 async function writeHourlyTasksBackup(project: Project, filePath: string): Promise<void> {
-	const backupDir = tasksBackupDir(project);
-	const backupFile = `${backupDir}/${tasksBackupFileName()}`;
-
-	try {
-		await stat(backupFile);
-		return; // This hour is already snapshotted.
-	} catch (err: any) {
-		if (err.code !== "ENOENT") throw err;
-	}
-
-	let currentContent: string;
-	try {
-		currentContent = await readFile(filePath, "utf8");
-	} catch (err: any) {
-		if (err.code === "ENOENT") {
-			return;
-		}
-		throw err;
-	}
-
-	await mkdir(backupDir, { recursive: true });
-	await writeFile(backupFile, currentContent);
-
-	const backupFiles = (await readdir(backupDir))
-		.filter((entry) => TASK_BACKUP_FILE_PATTERN.test(entry))
-		.sort();
-
-	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - TASK_BACKUP_RETENTION_HOURS))) {
-		await unlink(`${backupDir}/${staleFile}`);
-	}
+	await writeHourlySnapshot(filePath, tasksBackupDir(project), TASK_BACKUP_RETENTION_HOURS);
 }
 
 // ---- Tasks (public API — all mutators use file lock) ----

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -307,14 +307,23 @@ applyFullShellEnvToProcess(shellEnv, (await loadSettings()).importShellEnv !== f
 const cliSocketPath = startSocketServer();
 log.info("CLI socket server ready", { path: cliSocketPath });
 
-// Daily projects.json safety snapshot (projects-YYYY-MM-DD.json.bak, 7 days kept).
-// Saves also trigger it, but projects.json can go untouched for weeks — the
-// startup hook guarantees at least one fresh backup per day the app is used.
+// projects.json safety snapshots: daily .bak files (7 kept) plus hourly ones
+// (72 kept), matching the cover the task store already had.
+//
+// The timer is the point of this block. Both schemes fired only on a save or at
+// startup, so an app left running for days snapshotted nothing — 28-30 Aug 2026
+// have no copy for exactly that reason, while the board was edited all three
+// days. Ticking below the hourly bucket gives every hour the app is alive one.
 {
-	const { backupProjectsDaily } = await import("./data");
-	backupProjectsDaily().catch((err) => {
-		log.warn("Startup projects backup failed (non-fatal)", { err });
-	});
+	// Half the hourly bucket, so no bucket can be skipped by drift.
+	const PROJECTS_BACKUP_TICK_MS = 30 * 60 * 1000;
+	const { backupProjectsDaily, backupProjectsHourly } = await import("./data");
+	const snapshotProjects = () => {
+		backupProjectsDaily().catch((err) => log.warn("Daily projects backup failed (non-fatal)", { err }));
+		backupProjectsHourly().catch((err) => log.warn("Hourly projects backup failed (non-fatal)", { err }));
+	};
+	snapshotProjects();
+	setInterval(snapshotProjects, PROJECTS_BACKUP_TICK_MS).unref?.();
 }
 
 // Exclude the worktrees root from OS backups (Time Machine) once at startup.

--- a/test-isolation.ts
+++ b/test-isolation.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { resolveDev3Home } from "./src/shared/dev3-home";
 
 function safeRealpath(path: string): string {
 	try {
@@ -50,29 +51,49 @@ export function deriveTestRunRoot(
 }
 
 /**
- * Task-context vars dev3 injects into every agent pane. A suite run BY an agent
- * inherits the agent's OWN task, so anything reading them would silently test
- * that task instead of its fixture — passing locally and failing in CI, or the
- * reverse. Scrubbed so every suite starts from "no task in scope"; a test that
- * wants one sets it explicitly.
+ * The only `DEV3_*` namespace a test process may inherit.
+ *
+ * Every other `DEV3_*` var dev3 exports into an agent pane is a redirect into the
+ * REAL user environment — its data home, its project checkout, its worktree, its
+ * ports, its task, its native-terminal host — and a suite started from such a
+ * pane inherits all of them. So the rule is default-deny: drop every `DEV3_*`
+ * var and keep only this prefix, which belongs to the test harness itself
+ * (`DEV3_TEST_CONCURRENT`, set by the `bun run test` scripts, is read by the
+ * Vitest config immediately after this returns).
+ *
+ * A named scrub list is what let `DEV3_HOME` through. It OUTRANKS `HOME` in
+ * `resolveDev3Home`, so a pane exporting it pointed every backend suite at the
+ * live `~/.dev3.0` at module load — while the list went on faithfully scrubbing
+ * the six task-context vars it did know about. Under default-deny a newly added
+ * var is safe without anyone remembering this file.
  */
-export const INHERITED_TASK_CONTEXT_ENV = [
+export const PRESERVED_TEST_ENV_PREFIX = "DEV3_TEST_";
+
+/** Prefix of everything the scrub considers, so both sides read the same word. */
+export const DEV3_ENV_PREFIX = "DEV3_";
+
+/** The vars dev3 actually injects into an agent pane, for the guard test to
+ *  prove the scrub against. Illustrative, NOT the scrub's input — the scrub is
+ *  a prefix rule, so this list going stale cannot reopen the hole. */
+export const PANE_INJECTED_ENV_SAMPLE = [
+	"DEV3_HOME",
 	"DEV3_TASK_ID",
 	"DEV3_TASK_SEQ",
 	"DEV3_TASK_TITLE",
 	"DEV3_PANE_ID",
 	"DEV3_WORKTREE_PATH",
+	"DEV3_WORKTREE_ROOT",
 	"DEV3_BRANCH_NAME",
+	"DEV3_PROJECT_PATH",
+	"DEV3_PROJECT_NAME",
+	"DEV3_ARTIFACT_TEMPLATE_DIR",
+	"DEV3_AGENT_ACCOUNT_ID",
+	"DEV3_USER_ENV",
+	"DEV3_CLI_SOCKET",
+	"DEV3_NATIVE_SESSION_ID",
+	"DEV3_NATIVE_SESSIONS_DIR",
+	"DEV3_PORT0",
 ] as const;
-
-/**
- * Same problem, worse blast radius: an agent pane on the native terminal backend
- * exports its host's own `DEV3_NATIVE_SESSION_*` config, and a launcher test
- * asserting "this flag is absent unless requested" then reads the pane's value
- * out of the inherited environment. `DEV3_NATIVE_SESSIONS_DIR` (plural) is a
- * test-owned override and deliberately does not match this prefix.
- */
-const INHERITED_NATIVE_SESSION_ENV_PREFIX = "DEV3_NATIVE_SESSION_";
 
 /**
  * Move every implicit user/global path used by a test process into a sandbox.
@@ -96,16 +117,17 @@ export function configureTestIsolation(suite: string, worktreeRoot = process.cwd
 		mkdirSync(dir, { recursive: true });
 	}
 
-	for (const key of INHERITED_TASK_CONTEXT_ENV) delete process.env[key];
 	for (const key of Object.keys(process.env)) {
-		if (key.startsWith(INHERITED_NATIVE_SESSION_ENV_PREFIX)) delete process.env[key];
+		if (key.startsWith(DEV3_ENV_PREFIX) && !key.startsWith(PRESERVED_TEST_ENV_PREFIX)) {
+			delete process.env[key];
+		}
 	}
 
-	// Deliberately NOT setting DEV3_HOME: the data root is derived from HOME by
-	// `resolveDev3Home`, so the sandbox HOME above already lands it at `dev3Home`.
-	// Setting it explicitly would make it OUTRANK a suite's own `process.env.HOME =
-	// fixtureHome`, which is how dozens of suites relocate the board — they would
-	// silently read this run's shared root instead of their fixture.
+	// DEV3_HOME is SCRUBBED above and deliberately not set again: the data root is
+	// derived from HOME by `resolveDev3Home`, so the sandbox HOME below already
+	// lands it at `dev3Home`. Setting it would make it OUTRANK a suite's own
+	// `process.env.HOME = fixtureHome`, which is how dozens of suites relocate the
+	// board — they would read this run's shared root instead of their fixture.
 	Object.assign(process.env, {
 		DEV3_TEST_ROOT: root,
 		DEV3_TEST_SOCKET_ROOT: socketRoot,
@@ -122,7 +144,27 @@ export function configureTestIsolation(suite: string, worktreeRoot = process.cwd
 		XDG_RUNTIME_DIR: runtime,
 	});
 
+	assertDev3HomeIsSandboxed(root);
 	return root;
+}
+
+/**
+ * The outcome check, as opposed to the mechanism above: whatever the environment
+ * arrived as, the data root the code will actually use has to be inside this
+ * run's sandbox. Throwing here aborts the whole Vitest process before a single
+ * suite loads a module, which is the difference between a loud refusal to start
+ * and a run that quietly writes into the user's live `~/.dev3.0`.
+ *
+ * Resolved through the production resolver on purpose — asserting against a
+ * locally recomposed path would pass even if the resolver's precedence changed.
+ */
+export function assertDev3HomeIsSandboxed(root: string): void {
+	const resolved = resolveDev3Home();
+	if (resolved.startsWith(root.replaceAll("\\", "/"))) return;
+	throw new Error(
+		`Test isolation failed: dev3 home resolved to ${resolved}, outside the run root ${root}. ` +
+			`Refusing to run — a suite would write to the real user data root.`,
+	);
 }
 
 export function cleanupTestIsolation(root: string, socketRoot?: string): void {


### PR DESCRIPTION
## Summary

Hi, this is Claude (the AI assistant that worked on this branch). Two independent defects found while investigating the 31 Aug 2026 loss of `~/.dev3.0/projects.json` on the maintainer's machine. Neither is claimed to be the cause of that incident — see the note at the end.

**1. The project list was barely backed up.** `backupProjectsDaily` only ever fired on a project-list mutation or at app startup, so an app left running for days snapshotted nothing at all: 28, 29 and 30 August have no copy, while the board was edited on all three days. Meanwhile the task store already had 72 hourly snapshots — the file whose loss makes every board unreachable had the weaker scheme.

- The task store's hourly bucket-and-prune logic is extracted into `writeHourlySnapshot` and now shared, so the two stores cannot drift apart.
- `backupProjectsHourly` writes `projects-backups/YYYY-MM-DDTHHZ.json`, 72 kept. The daily `.bak` files stay: 7 days of calendar cover is wider than 72 hours, and both are additive sibling paths, so nothing on disk is moved or renamed.
- A 30-minute timer drives both schemes, so every hour the app is alive gets a snapshot whether or not anything was edited. This is the part that would have produced 28-30 August.
- `projects-last-known-good.json` is never pruned, so no rotation can leave a degenerate copy as the only one. It advances unless the list *collapsed* — more than half gone at once — and never on unparseable bytes. "Never shrink" would freeze the file forever and keep holding projects the user meant to delete; "always advance" is what lets a wipe become the only survivor.

**2. Test isolation leaked the real environment.** `configureTestIsolation` sandboxed HOME but scrubbed only six named `DEV3_*` vars. `resolveDev3Home` reads `DEV3_HOME` *first* and returns it verbatim, so a suite started from any shell exporting it resolved the live `~/.dev3.0` at module load. A dev3 agent pane exports 13 `DEV3_*` vars and nine survived that scrub, including `DEV3_PROJECT_PATH` pointing at the real checkout.

- Default-deny: drop every `DEV3_*` var, preserve only the `DEV3_TEST_` prefix, so a var added later is safe with nobody editing the file.
- `assertDev3HomeIsSandboxed` resolves the root through the production resolver and throws before any suite loads a module if it lands outside the run root.

Both guards are proven by mutation in both directions (too-loose and too-strict thresholds each caught by exactly the intended test). Decision records: `decisions/2026/08/31/`.

**Attribution note.** The isolation hole did not cause the 31 Aug incident: that damage included EPERM failures in a different tree, which a test writing to a wrong path does not produce. The git-\* suites fail intermittently on a loaded machine; a paired baseline on the identical two suites at the same moment gave 1 failure of 70 on this branch and 2 of 70 on `origin/main`, so those are load, not this change.

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=0baceeea-c7cc-405a-87ea-c8463037128e) · `dev3://task/0baceeea-c7cc-405a-87ea-c8463037128e`
