### PR TITLE
Back up every file of user state, not just projects.json

### DIFF
--- a/change-logs/2026/09/01/feature-40-back-up-all-user-state.md
+++ b/change-logs/2026/09/01/feature-40-back-up-all-user-state.md
@@ -1,0 +1,3 @@
+Short: Hourly backups of all your state
+
+Every file of user state in ~/.dev3.0 now gets the hourly safety copies that projects.json already had — spaces, settings, agent presets, Operations boards and the model catalog, each with a last-known-good copy that rotation can never evict and that refuses to advance onto a collapsed file. Credentials are deliberately left out, and restoring is always a manual step: see docs/state-backups.md.

--- a/decisions/2026/09/01/back-up-every-file-of-user-state.md
+++ b/decisions/2026/09/01/back-up-every-file-of-user-state.md
@@ -1,0 +1,94 @@
+# Back up every file of user state, with a per-file collapse rule
+
+## Context
+
+On 2026-08-31 something wiped part of `~/.dev3.0` — `projects.json`, `logs/`,
+`bin/`, `sockets/`. The cause was never found. PR #1620 gave `projects.json`
+hourly snapshots plus a `projects-last-known-good.json` that rotation cannot
+evict, driven by a 30-minute timer because the original defect was the trigger:
+the old scheme only fired on a save or at app startup, so days when nobody edited
+a project got no copy at all.
+
+A day later the same incident turned out to have taken `spaces.json` as well, and
+there was no backup of it anywhere. `settings.json`, `agents.json`,
+`virtual-projects.json` and `model-catalog.json` had the identical hole. The fix
+had been written for one file when six had the same problem.
+
+## Investigation
+
+Reading every `${DEV3_HOME}/...` path in `src/` produced 20 top-level files. Six
+are user state — authored by the user and unrecoverable without them. The rest
+split into derived/ephemeral state (`port-assignments.json`, `window-state.json`,
+`last-route.json`, `tip-state.json`, `preferences.json`, `install-date.json`,
+`terminal-backend.json`, `remote/state.json`, `web-push-subscriptions.json`) and
+credentials (`model-catalog-keys.json`, `web-push-keys.json`,
+`remote-jwt-secret`, `dev-web-access-code`). The full table with a reason per
+file is in `docs/state-backups.md`.
+
+## Decision
+
+`src/bun/state-backup.ts` owns one registry, `PROTECTED_STATE_FILES`, and the
+mechanism `writeHourlySnapshot` that `data.ts` already had. `data.ts` imports it
+for the task store and delegates `backupProjectsHourly` to the registry entry, so
+there is exactly one implementation. `src/bun/index.ts` ticks
+`snapshotProtectedState()` every 30 minutes, which is the ONLY trigger the five
+new files have — none of them gets a pre-write hook, because the timer is what
+actually fixed the measured defect and adding five hooks is five more places to
+get wrong.
+
+**Collapse rule, per file, not one generic rule.** The `projects.json` rule
+("refuse when more than half the entries went at once") is honest for a list and
+dishonest for anything else, so each file states its own:
+
+| File | Rule | Why that rule |
+|---|---|---|
+| `projects.json`, `virtual-projects.json`, `agents.json` | Half the array gone at once | Unchanged from #1620. Deleting a project or dropping a few removed presets is ordinary; halving is not. |
+| `spaces.json` | Half the `spaces` array gone, and only for a file this loader could read back (`version === 1`, both arrays present) | Deletion here is SOFT — a deleted space stays in the array — so the count only grows during ordinary use, which makes any halving unambiguous. The shape check matters separately: a file dev3 cannot parse must never become the good copy no matter how large it is. |
+| `model-catalog.json` | Half of `providers.length + models.length` gone | Both halves are user-authored and a wipe takes both; either one missing entirely means the bytes are not a catalog. |
+| `settings.json` | Refuse only when the incoming keys are a strict SUBSET of the good copy's AND fewer than half remain | Key count alone is wrong here: the loader drops every default-valued field before writing, so a user turning one toggle back to its default legitimately removes a key. The shape worth refusing is the one that happened — the file vanished and came back written from `DEFAULT_SETTINGS`, four keys where twenty had been. That is a pure subset with massive loss; ordinary editing either introduces a key or drops a handful. |
+
+**Per-file directories, not one dated snapshot directory.** A single directory
+holding all files per timestamp would make a point-in-time restore look coherent,
+and the coherence would be a lie: the pair that genuinely cross-references
+(`projects.json` ↔ `data/<slug>/tasks.json`) can never share a directory, because
+tasks live under the project's own data dir. A shared directory would also couple
+the writers — one unreadable file would leave an incomplete set that still looks
+like a moment in time. Instead every file keeps `<stem>-backups/` beside itself,
+and the hourly filename is identical across directories, so a coherent restore is
+still a matter of matching names. `projects-backups/` and
+`projects-last-known-good.json` keep the exact paths #1620 shipped.
+
+**Credentials are excluded.** Copying a live API key into up to 72 dated files,
+each alive for three days, is a permanent widening of exposure; what it buys back
+is a 30-second re-paste. Losing `spaces.json` is unrecoverable, losing a key is an
+errand — the asymmetry decides it. Any future credential added to the list must
+be written with the original's file mode.
+
+**No restore in this change.** `docs/state-backups.md` documents the manual copy
+(quit the app, keep the current file, copy the backup in). A `dev3 restore-state`
+command is worth its own task; an automatic restore-on-startup is explicitly
+never going to exist, because silently overwriting live user state turns one bad
+day into two.
+
+## Risks
+
+- The new files are timer-only, so a copy can be up to 30 minutes stale. Accepted:
+  the incident being defended against is a whole-file wipe, not a lost edit.
+- `agents.json` written in the pre-array legacy format counts as `null` and never
+  advances its good copy. Self-correcting — `getAllAgents` rewrites it as an array
+  on the next load — and failing closed is the right direction.
+- Six new sibling paths appear in `~/.dev3.0`. Additive only; older app versions
+  never read them (AGENTS.md on-disk rule 5).
+
+## Alternatives considered
+
+- **One generic "half the entries" rule for every file.** Rejected: it has no
+  honest meaning for `settings.json`, and forcing one would either freeze that
+  file or wave a defaults-only rewrite through.
+- **A single dated directory holding all files.** Rejected above — the coherence
+  it promises is unavailable for the one pair that needs it.
+- **Snapshot on every save, like `projects.json` does.** Rejected as the primary
+  trigger: save-only cover is the exact defect #1620 diagnosed. The projects save
+  hook is kept because it already exists and costs nothing.
+- **Snapshot everything in the data root.** Rejected: 72 copies of
+  `port-assignments.json` is noise that buries the copies that matter.

--- a/docs/state-backups.md
+++ b/docs/state-backups.md
@@ -1,0 +1,102 @@
+# Backups of your dev3 state
+
+dev3 keeps hourly copies of every file of user state in `~/.dev3.0`, so a wipe,
+a bad write, or a corrupted file is recoverable. It never restores anything by
+itself — restoring is a deliberate manual step, described at the bottom.
+
+## What is copied
+
+Every hour the app is running (checked twice an hour), each protected file gets:
+
+- `~/.dev3.0/<name>-backups/YYYY-MM-DDTHHZ.json` — one copy per hour, the newest
+  72 kept, so roughly three days of history.
+- `~/.dev3.0/<name>-last-known-good.json` — a single copy that rotation can never
+  evict. It only advances when the incoming file still looks intact, so a run of
+  wrecked hours cannot push the last good copy out of the window.
+
+| File | Why it is protected |
+|---|---|
+| `projects.json` | The project list. Losing it makes every board unreachable and re-adding a project by hand gives it a new id, orphaning all its tasks. |
+| `virtual-projects.json` | The Operations boards. Same failure as above, for boards with no git repo behind them. |
+| `spaces.json` | Your spaces. Authored entirely by hand and reconstructable from nothing else. |
+| `settings.json` | Default agent, binary paths, update channel, theme. Losing it silently reset the update channel to `stable` on a canary install. |
+| `agents.json` | Your agent presets. Tens of kilobytes of hand-tuned configuration. |
+| `model-catalog.json` | The providers and named models you defined for the proxy sidecar. |
+| `data/<project>/tasks.json` | Every task on a board, with its own `tasks-backups/` directory on the same scheme. |
+
+## What is deliberately NOT copied
+
+Keeping 72 dated copies of a file that means nothing when restored is worse than
+keeping none — it buries the copies that matter and it costs a real decision to
+tell them apart later.
+
+| File | Why not |
+|---|---|
+| `port-assignments.json` | Derived from the live task set and rewritten constantly. A restored copy describes ports that are no longer assigned to anything. |
+| `remote/state.json` | A handoff record for a server process that is already gone. Restoring it points the app at a dead pid and a dead tunnel. |
+| `window-state.json`, `last-route.json` | Window geometry and the last screen you had open. Recreated the moment you move the window or navigate. |
+| `tip-state.json` | Which "Did you know?" tips you have seen. Losing it shows a few tips again. |
+| `preferences.json` | The last folder you picked in the folder picker. |
+| `install-date.json` | Derived. A fresh one just restarts the "installed on" clock. |
+| `terminal-backend.json` | A single terminal-backend choice, re-made in one click. |
+| `web-push-subscriptions.json` | Push endpoints registered by devices. A restored copy resurrects endpoints the push service has already dropped; devices re-subscribe on their next visit. |
+| `logs/`, `sockets/`, `bin/`, `worktrees/`, `vents/` | Runtime scratch, disposable by design. |
+
+### Credentials are excluded on purpose
+
+`model-catalog-keys.json` (upstream API keys), `web-push-keys.json` (the VAPID
+keypair), `remote-jwt-secret` and `dev-web-access-code` are **not** copied.
+
+A live API key's safety comes from existing in exactly one place at mode `0600`.
+Snapshotting it hourly would multiply it into up to 72 dated files, each living
+for three days, every one of them picked up by an OS backup, a `cp -r ~/.dev3.0`,
+or a support bundle. The exposure that buys is permanent; what it saves is a
+30-second re-paste from the provider's dashboard, or a regenerated secret that
+costs one re-auth. Losing `spaces.json` is unrecoverable; losing an API key is an
+errand. The two do not deserve the same treatment.
+
+If a credential file is ever added to the protected list, it must be written with
+the same mode as the original.
+
+## Restoring
+
+There is **no automatic restore**. An app that silently overwrites live state at
+startup turns one bad day into two, so this is always something you do yourself,
+with the app closed.
+
+1. **Quit dev3 completely.** A running app holds these files and will overwrite
+   whatever you put there.
+2. **Pick a copy.** The last-known-good file is the safe default:
+
+   ```sh
+   ls -la ~/.dev3.0/spaces-last-known-good.json
+   ```
+
+   For a specific point in time, list the hourly directory — the names are UTC
+   hours, and the same name in two directories is the same moment, so
+   `spaces-backups/2026-08-31T10Z.json` and `settings-backups/2026-08-31T10Z.json`
+   belong together:
+
+   ```sh
+   ls ~/.dev3.0/spaces-backups/
+   ```
+
+3. **Keep what is there now**, in case the copy turns out to be the wrong one:
+
+   ```sh
+   cp ~/.dev3.0/spaces.json ~/.dev3.0/spaces.json.before-restore
+   ```
+
+4. **Copy the backup into place**, and only then start dev3:
+
+   ```sh
+   cp ~/.dev3.0/spaces-last-known-good.json ~/.dev3.0/spaces.json
+   ```
+
+The same four steps work for `projects.json`, `virtual-projects.json`,
+`settings.json`, `agents.json` and `model-catalog.json`. Tasks live per project
+at `~/.dev3.0/data/<project-slug>/tasks.json`, with their copies beside them in
+`tasks-backups/`.
+
+**Restoring `model-catalog.json` does not restore its API keys** — they were never
+copied. Re-paste them in Settings once the catalog is back.

--- a/src/bun/__tests__/state-backup.test.ts
+++ b/src/bun/__tests__/state-backup.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+
+const TEST_HOME = vi.hoisted(() => `${process.env.DEV3_TEST_ROOT}/state-backup`);
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("../paths", () => ({ DEV3_HOME: TEST_HOME }));
+
+beforeEach(() => {
+	rmSync(TEST_HOME, { recursive: true, force: true });
+	mkdirSync(TEST_HOME, { recursive: true });
+});
+
+import {
+	countArrayEntries,
+	countCatalogEntries,
+	countSpaces,
+	PROTECTED_STATE_FILES,
+	protectedStateFile,
+	settingsAdvance,
+	snapshotProtectedState,
+	snapshotStateFile,
+	STATE_BACKUP_RETENTION_HOURS,
+} from "../state-backup";
+
+const HOUR_A = new Date("2026-08-31T10:00:00.000Z");
+const HOUR_B = new Date("2026-08-31T11:00:00.000Z");
+const SLOT_A = "2026-08-31T10Z.json";
+const SLOT_B = "2026-08-31T11Z.json";
+
+function write(basename: string, value: unknown): void {
+	writeFileSync(`${TEST_HOME}/${basename}`, JSON.stringify(value, null, 2));
+}
+
+function listSlots(stem: string): string[] {
+	const dir = `${TEST_HOME}/${stem}-backups`;
+	return existsSync(dir)
+		? readdirSync(dir).filter((f) => /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/.test(f)).sort()
+		: [];
+}
+
+function readGood(stem: string): unknown {
+	return JSON.parse(readFileSync(`${TEST_HOME}/${stem}-last-known-good.json`, "utf-8"));
+}
+
+function projects(count: number): unknown[] {
+	return Array.from({ length: count }, (_, i) => ({ id: `p${i}`, name: `P${i}`, path: `/tmp/p${i}` }));
+}
+
+function agents(count: number): unknown[] {
+	return Array.from({ length: count }, (_, i) => ({ id: `a${i}`, name: `A${i}`, baseCommand: "claude" }));
+}
+
+function spaces(count: number): unknown {
+	const ids = Array.from({ length: count }, (_, i) => `sp_${i}`);
+	return { version: 1, spaces: ids.map((id) => ({ id, name: id, projectIds: ["p0"] })), order: ids };
+}
+
+function catalog(providers: number, models: number): unknown {
+	return {
+		providers: Array.from({ length: providers }, (_, i) => ({ id: `pr${i}`, kind: "openrouter" })),
+		models: Array.from({ length: models }, (_, i) => ({ name: `m${i}`, providerId: "pr0" })),
+	};
+}
+
+function settings(extra: Record<string, unknown>): unknown {
+	return { defaultAgentId: "builtin-claude", defaultConfigId: "x", taskSortOrder: "oldest-first", updateChannel: "canary", ...extra };
+}
+
+/** The whole registry, with a realistic payload and a stem, for the table-driven cases. */
+const FIXTURES = [
+	{ id: "projects", basename: "projects.json", stem: "projects", payload: () => projects(3) },
+	{ id: "virtual-projects", basename: "virtual-projects.json", stem: "virtual-projects", payload: () => projects(2) },
+	{ id: "spaces", basename: "spaces.json", stem: "spaces", payload: () => spaces(4) },
+	{ id: "agents", basename: "agents.json", stem: "agents", payload: () => agents(5) },
+	{ id: "model-catalog", basename: "model-catalog.json", stem: "model-catalog", payload: () => catalog(2, 3) },
+	{ id: "settings", basename: "settings.json", stem: "settings", payload: () => settings({ theme: "dark", focusMode: true }) },
+] as const;
+
+describe("the protected-state registry", () => {
+	it("covers exactly the files the fixtures describe", () => {
+		expect(PROTECTED_STATE_FILES.map((e) => e.id).sort()).toEqual(FIXTURES.map((f) => f.id).sort());
+	});
+
+	it("derives sibling paths inside the data root, moving nothing that exists", () => {
+		for (const fixture of FIXTURES) {
+			const entry = protectedStateFile(fixture.id);
+			expect(entry.file).toBe(`${TEST_HOME}/${fixture.basename}`);
+			expect(entry.backupDir).toBe(`${TEST_HOME}/${fixture.stem}-backups`);
+			expect(entry.lastKnownGoodFile).toBe(`${TEST_HOME}/${fixture.stem}-last-known-good.json`);
+			expect(entry.retentionHours).toBe(STATE_BACKUP_RETENTION_HOURS);
+		}
+	});
+
+	it("keeps the paths projects.json already shipped with", () => {
+		// An older app version reads these exact names — see AGENTS.md on-disk rules.
+		const entry = protectedStateFile("projects");
+		expect(entry.backupDir).toBe(`${TEST_HOME}/projects-backups`);
+		expect(entry.lastKnownGoodFile).toBe(`${TEST_HOME}/projects-last-known-good.json`);
+	});
+});
+
+describe("hourly snapshots, per protected file", () => {
+	for (const fixture of FIXTURES) {
+		it(`snapshots ${fixture.basename} on a timer tick with no save at all`, async () => {
+			const payload = fixture.payload();
+			write(fixture.basename, payload);
+
+			await snapshotProtectedState(HOUR_A);
+
+			expect(listSlots(fixture.stem)).toEqual([SLOT_A]);
+			const snapshot = JSON.parse(readFileSync(`${TEST_HOME}/${fixture.stem}-backups/${SLOT_A}`, "utf-8"));
+			expect(snapshot).toEqual(payload);
+			expect(readGood(fixture.stem)).toEqual(payload);
+		});
+
+		it(`writes at most one ${fixture.basename} snapshot per hour`, async () => {
+			write(fixture.basename, fixture.payload());
+
+			await snapshotProtectedState(HOUR_A);
+			await snapshotProtectedState(new Date("2026-08-31T10:59:59.000Z"));
+
+			expect(listSlots(fixture.stem)).toEqual([SLOT_A]);
+		});
+
+		it(`snapshots nothing when ${fixture.basename} does not exist yet`, async () => {
+			await snapshotProtectedState(HOUR_A);
+
+			expect(listSlots(fixture.stem)).toEqual([]);
+			expect(existsSync(`${TEST_HOME}/${fixture.stem}-last-known-good.json`)).toBe(false);
+		});
+
+		it(`never lets unreadable ${fixture.basename} bytes become the good copy`, async () => {
+			const payload = fixture.payload();
+			write(fixture.basename, payload);
+			await snapshotProtectedState(HOUR_A);
+
+			writeFileSync(`${TEST_HOME}/${fixture.basename}`, "{ truncated");
+			await snapshotProtectedState(HOUR_B);
+
+			// The hourly slot records the wreck faithfully; the good copy does not move.
+			expect(readFileSync(`${TEST_HOME}/${fixture.stem}-backups/${SLOT_B}`, "utf-8")).toBe("{ truncated");
+			expect(readGood(fixture.stem)).toEqual(payload);
+		});
+	}
+
+	it("gives one file's failure no power over the others", async () => {
+		for (const fixture of FIXTURES) write(fixture.basename, fixture.payload());
+		// A plain file where the backup directory has to go: mkdir fails with ENOTDIR.
+		writeFileSync(`${TEST_HOME}/spaces-backups`, "not a directory");
+
+		await snapshotProtectedState(HOUR_A);
+
+		expect(listSlots("projects")).toEqual([SLOT_A]);
+		expect(listSlots("settings")).toEqual([SLOT_A]);
+		expect(listSlots("model-catalog")).toEqual([SLOT_A]);
+	});
+});
+
+describe("what each counter is willing to count", () => {
+	// `null` means "these bytes are not this file" — the collapse rule turns that
+	// into a refusal, so a counter that guesses is a counter that lets a wreck
+	// through. Asserted directly: through the registry a throwing counter looks
+	// exactly like a refusing one, and only one of the two is intended.
+
+	it("counts a plain JSON array, and nothing else", () => {
+		expect(countArrayEntries(JSON.stringify(projects(4)))).toBe(4);
+		expect(countArrayEntries("{}")).toBe(null);
+		expect(countArrayEntries("{ truncated")).toBe(null);
+	});
+
+	it("counts spaces only in a file this app could read back", () => {
+		expect(countSpaces(JSON.stringify(spaces(4)))).toBe(4);
+		expect(countSpaces(JSON.stringify({ ...(spaces(4) as object), version: 2 }))).toBe(null);
+		expect(countSpaces(JSON.stringify({ ...(spaces(4) as object), order: null }))).toBe(null);
+		expect(countSpaces(JSON.stringify({ version: 1, order: [] }))).toBe(null);
+		expect(countSpaces(JSON.stringify(projects(4)))).toBe(null);
+	});
+
+	it("counts both halves of the catalog, and refuses a file missing either", () => {
+		expect(countCatalogEntries(JSON.stringify(catalog(2, 3)))).toBe(5);
+		expect(countCatalogEntries(JSON.stringify({ ...(catalog(2, 3) as object), providers: null }))).toBe(null);
+		expect(countCatalogEntries(JSON.stringify({ ...(catalog(2, 3) as object), models: undefined }))).toBe(null);
+		expect(countCatalogEntries(JSON.stringify(projects(4)))).toBe(null);
+	});
+});
+
+describe("the collapse rule, per file, in both directions", () => {
+	async function twoHours(basename: string, first: unknown, second: unknown): Promise<void> {
+		write(basename, first);
+		await snapshotProtectedState(HOUR_A);
+		write(basename, second);
+		await snapshotProtectedState(HOUR_B);
+	}
+
+	it("projects.json: refuses a wiped list, accepts a deleted project or two", async () => {
+		await twoHours("projects.json", projects(29), projects(1));
+		expect(readGood("projects")).toHaveLength(29);
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		await twoHours("projects.json", projects(10), projects(8));
+		expect(readGood("projects")).toHaveLength(8);
+	});
+
+	it("virtual-projects.json: refuses a wiped list, accepts a removed board", async () => {
+		await twoHours("virtual-projects.json", projects(6), projects(0));
+		expect(readGood("virtual-projects")).toHaveLength(6);
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		await twoHours("virtual-projects.json", projects(6), projects(5));
+		expect(readGood("virtual-projects")).toHaveLength(5);
+	});
+
+	it("agents.json: refuses a wiped preset list, accepts presets removed by a release", async () => {
+		await twoHours("agents.json", agents(20), agents(3));
+		expect(readGood("agents")).toHaveLength(20);
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		await twoHours("agents.json", agents(20), agents(16));
+		expect(readGood("agents")).toHaveLength(16);
+	});
+
+	it("spaces.json: refuses a wiped file, accepts an ordinary new space", async () => {
+		// Deletion is soft — a space stays in the array — so a shrinking count is
+		// already abnormal and a halved one is unambiguous.
+		await twoHours("spaces.json", spaces(8), spaces(2));
+		expect((readGood("spaces") as { spaces: unknown[] }).spaces).toHaveLength(8);
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		await twoHours("spaces.json", spaces(8), spaces(9));
+		expect((readGood("spaces") as { spaces: unknown[] }).spaces).toHaveLength(9);
+	});
+
+	it("spaces.json: refuses a file whose shape it does not recognise", async () => {
+		// GROWN, not shrunk, so the collapse rule would wave it through — only the
+		// shape check can refuse a file this loader could not read back.
+		write("spaces.json", spaces(3));
+		await snapshotProtectedState(HOUR_A);
+
+		write("spaces.json", { ...(spaces(9) as object), version: 2 });
+		await snapshotProtectedState(HOUR_B);
+
+		expect((readGood("spaces") as { spaces: unknown[] }).spaces).toHaveLength(3);
+	});
+
+	it("spaces.json: refuses a grown file that lost its display order", async () => {
+		write("spaces.json", spaces(3));
+		await snapshotProtectedState(HOUR_A);
+
+		write("spaces.json", { ...(spaces(9) as object), order: null });
+		await snapshotProtectedState(HOUR_B);
+
+		expect((readGood("spaces") as { spaces: unknown[] }).spaces).toHaveLength(3);
+	});
+
+	it("model-catalog.json: refuses a wiped catalog, accepts a removed model", async () => {
+		await twoHours("model-catalog.json", catalog(3, 9), catalog(1, 1));
+		expect(readGood("model-catalog")).toEqual(catalog(3, 9));
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		await twoHours("model-catalog.json", catalog(3, 9), catalog(3, 7));
+		expect(readGood("model-catalog")).toEqual(catalog(3, 7));
+	});
+
+	it("model-catalog.json: refuses a grown file that lost its provider list", async () => {
+		write("model-catalog.json", catalog(2, 2));
+		await snapshotProtectedState(HOUR_A);
+
+		write("model-catalog.json", { ...(catalog(4, 8) as object), providers: null });
+		await snapshotProtectedState(HOUR_B);
+
+		expect(readGood("model-catalog")).toEqual(catalog(2, 2));
+	});
+
+	it("settings.json: refuses a file recreated from defaults, accepts a toggle going back to default", async () => {
+		const rich = settings({ theme: "dark", focusMode: true, tipsDisabled: true, analyticsDistinctId: "abc", agentBinaryPaths: {}, externalApps: [] });
+		// Exactly the 31 Aug shape: the file came back holding DEFAULT_SETTINGS only.
+		await twoHours("settings.json", rich, settings({}));
+		expect(readGood("settings")).toEqual(rich);
+
+		rmSync(TEST_HOME, { recursive: true, force: true });
+		mkdirSync(TEST_HOME, { recursive: true });
+		const trimmed = settings({ theme: "dark", focusMode: true, tipsDisabled: true, analyticsDistinctId: "abc", agentBinaryPaths: {} });
+		await twoHours("settings.json", rich, trimmed);
+		expect(readGood("settings")).toEqual(trimmed);
+	});
+
+	it("settings.json: a key the good copy never had is proof of a real edit, whatever the size", () => {
+		// Counting keys alone would refuse this; the subset test is what saves it.
+		const before = JSON.stringify(settings({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 }));
+		const after = JSON.stringify({ defaultAgentId: "builtin-claude", brandNewKey: true });
+		expect(settingsAdvance(after, before)).toBe(true);
+	});
+
+	it("settings.json: refuses bytes that are not an object at all", () => {
+		expect(settingsAdvance("[]", JSON.stringify(settings({})))).toBe(false);
+		expect(settingsAdvance("{ truncated", JSON.stringify(settings({})))).toBe(false);
+	});
+
+	it("accepts the very first copy of every file, with nothing to compare against", async () => {
+		for (const fixture of FIXTURES) write(fixture.basename, fixture.payload());
+		await snapshotProtectedState(HOUR_A);
+		for (const fixture of FIXTURES) expect(readGood(fixture.stem)).toEqual(fixture.payload());
+	});
+});
+
+describe("retention", () => {
+	it("evicts the oldest hour once the window is full, and never the good copy", async () => {
+		write("spaces.json", spaces(4));
+		await snapshotProtectedState(HOUR_A);
+
+		const dir = `${TEST_HOME}/spaces-backups`;
+		// Fill the window to exactly the cap with older hours, the earliest first.
+		for (let i = 0; i < STATE_BACKUP_RETENTION_HOURS; i++) {
+			const day = String((i % 28) + 1).padStart(2, "0");
+			const hour = String(i % 24).padStart(2, "0");
+			writeFileSync(`${dir}/2026-05-${day}T${hour}Z.json`, "{}");
+		}
+		const oldest = readdirSync(dir).sort()[0];
+		expect(oldest).toBe("2026-05-01T00Z.json");
+
+		write("spaces.json", spaces(5));
+		await snapshotProtectedState(HOUR_B);
+
+		const kept = listSlots("spaces");
+		expect(kept).toHaveLength(STATE_BACKUP_RETENTION_HOURS);
+		expect(kept).not.toContain(oldest);
+		expect(kept).toContain(SLOT_B);
+		expect((readGood("spaces") as { spaces: unknown[] }).spaces).toHaveLength(5);
+	});
+
+	it("leaves the good copy standing after the whole window has rotated out", async () => {
+		write("projects.json", projects(12));
+		await snapshotProtectedState(HOUR_A);
+		expect(readGood("projects")).toHaveLength(12);
+
+		// 80 further hours of a one-project wreck: every good hourly slot rotates away.
+		write("projects.json", projects(1));
+		for (let i = 0; i < 80; i++) {
+			await snapshotStateFile(protectedStateFile("projects"), new Date(Date.UTC(2026, 8, 1 + Math.floor(i / 24), i % 24)));
+		}
+
+		expect(listSlots("projects").length).toBeLessThanOrEqual(STATE_BACKUP_RETENTION_HOURS);
+		expect(listSlots("projects")).not.toContain(SLOT_A);
+		expect(readGood("projects")).toHaveLength(12);
+	});
+});

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -785,6 +785,7 @@ Point, don't dig. Name where to look and stop — deep diagnosis is \`/diagnosin
 - Environment or setup acting up → \`dev3 doctor\` first.
 - Disk filling up → \`dev3 doctor --worktrees\`. Per project it shows what \`~/.dev3.0/worktrees\` holds and how much is reclaimable: orphaned folders whose task record is gone, worktrees whose teardown never finished, old diffs/logs. Report-only; \`--prune-orphans\` / \`--prune-older-than 30d\` delete, and anything on an unmerged \`dev3/task-*\` branch is skipped without \`--force-unmerged\`.
 - The task's terminal died → **Resume Agent Session** restarts the agent with its conversation intact (\`--continue\`), picking up right where it stopped.
+- Spaces, settings, agent presets, projects or the model catalog came back empty → dev3 keeps hourly copies of each, plus a last-known-good copy that rotation never evicts. Restoring is manual and always starts with quitting the app: \`docs/state-backups.md\` has the exact steps and the table of what is and is not copied (credentials deliberately are not).
 - "Why does dev3 behave this way?" → the relevant record in \`decisions/\` usually explains it.
 - Something crashed or misbehaved → the app logs, plus the decision record for that subsystem.
 

--- a/src/bun/data.ts
+++ b/src/bun/data.ts
@@ -15,6 +15,7 @@ import { detectClonePaths } from "./cow-clone";
 import { withFileLock } from "./file-lock";
 import { persistTaskBlobs, splitTaskBlobs } from "./task-blobs";
 import { readNewTaskTerminalBackendPreference } from "./terminal-backend-preference";
+import { protectedStateFile, snapshotStateFile, writeHourlySnapshot } from "./state-backup";
 import { projectSlug } from "./git";
 
 const log = createLogger("data");
@@ -28,21 +29,6 @@ const PROJECTS_BACKUP_RETENTION_DAYS = 7;
 const PROJECTS_BACKUP_FILE_PATTERN = /^projects-\d{4}-\d{2}-\d{2}\.json\.bak$/;
 const TASK_BACKUPS_DIR = "tasks-backups";
 const TASK_BACKUP_RETENTION_HOURS = 72;
-const HOURLY_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
-// The project list gets the same hourly cover as the task store: losing it makes
-// every board unreachable, so it cannot be the less protected of the two. New
-// sibling paths only — nothing existing is moved or renamed (AGENTS.md).
-const PROJECTS_BACKUPS_DIR = `${DEV3_HOME}/projects-backups`;
-const PROJECTS_BACKUP_RETENTION_HOURS = 72;
-/**
- * The copy no rotation can evict.
- *
- * Hourly and daily snapshots both rotate, so a run of degenerate ones can push
- * every good copy out of the window — which is how the only same-day copy of a
- * 29-project list came to hold one project. This file is advanced only when the
- * list has not COLLAPSED, so a non-degenerate copy always survives.
- */
-const LAST_KNOWN_GOOD_PROJECTS_FILE = `${DEV3_HOME}/projects-last-known-good.json`;
 // `name` is display-only: `path` is deliberately absent, so a rename never moves
 // a data dir, worktree dir or slug (AGENTS.md on-disk invariants).
 type ProjectUpdates = Partial<Pick<Project, "name" | "setupScript" | "setupScriptLaunchMode" | "devScript" | "cleanupScript" | "defaultBaseBranch" | "githubAuthHost" | "githubAuthLogin" | "clonePaths" | "labels" | "customColumns" | "columnOrder" | "autoReviewEnabled" | "peerReviewEnabled" | "sparseCheckoutEnabled" | "sparseCheckoutPaths" | "builtinColumnAgents" | "customStatusLabels" | "sensitive" | "reviewModePrompt" | "coordinatorPrompt" | "env" | "conversationImportOfferedAt">>;
@@ -66,54 +52,6 @@ function tasksFile(project: Project): string {
 
 function tasksBackupDir(project: Project): string {
 	return `${DEV3_HOME}/data/${projectSlug(project.path)}/${TASK_BACKUPS_DIR}`;
-}
-
-function hourlyBackupFileName(now: Date = new Date()): string {
-	return `${now.toISOString().slice(0, 13)}Z.json`;
-}
-
-/**
- * At most one pre-write snapshot per entry hour, decided with stat() rather than
- * by reading two whole files. The hour is captured before reading, so a
- * boundary-spanning read stays in its start hour. See decision 204.
- *
- * Shared by the task store and the project list so the two can never drift into
- * different levels of protection. Returns the bytes it snapshotted, or null when
- * the hour was already covered or the source does not exist yet.
- */
-async function writeHourlySnapshot(
-	sourceFile: string,
-	backupDir: string,
-	retentionHours: number,
-	now: Date = new Date(),
-): Promise<string | null> {
-	const backupFile = `${backupDir}/${hourlyBackupFileName(now)}`;
-
-	try {
-		await stat(backupFile);
-		return null; // This hour is already snapshotted.
-	} catch (err: any) {
-		if (err.code !== "ENOENT") throw err;
-	}
-
-	let currentContent: string;
-	try {
-		currentContent = await readFile(sourceFile, "utf8");
-	} catch (err: any) {
-		if (err.code === "ENOENT") return null;
-		throw err;
-	}
-
-	await mkdir(backupDir, { recursive: true });
-	await writeFile(backupFile, currentContent);
-
-	const backupFiles = (await readdir(backupDir))
-		.filter((entry) => HOURLY_BACKUP_FILE_PATTERN.test(entry))
-		.sort();
-	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - retentionHours))) {
-		await unlink(`${backupDir}/${staleFile}`);
-	}
-	return currentContent;
 }
 
 export function deriveTaskBaseBranch(project: Project, existingBranch?: string | null): string {
@@ -318,59 +256,15 @@ export async function backupProjectsDaily(now: Date = new Date()): Promise<void>
 	}
 }
 
-/** How many projects a `projects.json` payload holds, or null if it is not a
- *  readable list — unparseable bytes must never advance the good copy. */
-function countProjects(content: string): number | null {
-	try {
-		const parsed = JSON.parse(content);
-		return Array.isArray(parsed) ? parsed.length : null;
-	} catch {
-		return null;
-	}
-}
-
 /**
- * Advance the un-evictable copy, unless the list COLLAPSED — more than half of
- * it gone at once.
+ * Hourly safety snapshot of the project list, plus its un-evictable good copy.
  *
- * The threshold is the whole argument. "Never shrink" would be its own bug: a
- * user who deletes a project would freeze this file forever and it would go on
- * holding data they meant to be rid of. "Always advance" is what makes a wipe
- * the only surviving copy. A collapse is the one shape no ordinary editing
- * produces, so it is the one shape worth refusing.
- */
-async function advanceLastKnownGoodProjects(content: string): Promise<void> {
-	const incoming = countProjects(content);
-	if (incoming === null) return;
-
-	let existing: number | null = null;
-	try {
-		existing = countProjects(await readFile(LAST_KNOWN_GOOD_PROJECTS_FILE, "utf8"));
-	} catch (err: any) {
-		if (err.code !== "ENOENT") throw err;
-	}
-
-	if (existing !== null && incoming * 2 < existing) {
-		log.warn("Refusing to advance last-known-good projects: list collapsed", { incoming, existing });
-		return;
-	}
-	await atomicWriteFile(LAST_KNOWN_GOOD_PROJECTS_FILE, content);
-}
-
-/**
- * Hourly safety snapshot of the project list, the same scheme the task store has
- * had — plus the un-evictable good copy. Driven by saves AND by a timer, because
- * a save-only trigger snapshots nothing on a day nobody edits a project, which
- * is exactly why 28-30 Aug 2026 have no copy at all.
+ * The scheme itself lives in `state-backup.ts`, where every other file of user
+ * state shares it; this stays as the pre-write hook on the save path, which the
+ * timer-driven files do not have.
  */
 export async function backupProjectsHourly(now: Date = new Date()): Promise<void> {
-	const snapshotted = await writeHourlySnapshot(
-		PROJECTS_FILE,
-		PROJECTS_BACKUPS_DIR,
-		PROJECTS_BACKUP_RETENTION_HOURS,
-		now,
-	);
-	if (snapshotted !== null) await advanceLastKnownGoodProjects(snapshotted);
+	await snapshotStateFile(protectedStateFile("projects"), now);
 }
 
 // ---- Projects (public API — all mutators use file lock) ----

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -307,23 +307,26 @@ applyFullShellEnvToProcess(shellEnv, (await loadSettings()).importShellEnv !== f
 const cliSocketPath = startSocketServer();
 log.info("CLI socket server ready", { path: cliSocketPath });
 
-// projects.json safety snapshots: daily .bak files (7 kept) plus hourly ones
-// (72 kept), matching the cover the task store already had.
+// User-state safety snapshots: hourly copies (72 kept) of every file in the
+// registry — projects, virtual projects, spaces, agents, settings, the model
+// catalog — plus the daily projects.json .bak files (7 kept).
 //
 // The timer is the point of this block. Both schemes fired only on a save or at
 // startup, so an app left running for days snapshotted nothing — 28-30 Aug 2026
 // have no copy for exactly that reason, while the board was edited all three
-// days. Ticking below the hourly bucket gives every hour the app is alive one.
+// days. Ticking below the hourly bucket gives every hour the app is alive one,
+// and it is the ONLY trigger the files outside data.ts have.
 {
 	// Half the hourly bucket, so no bucket can be skipped by drift.
-	const PROJECTS_BACKUP_TICK_MS = 30 * 60 * 1000;
-	const { backupProjectsDaily, backupProjectsHourly } = await import("./data");
-	const snapshotProjects = () => {
+	const STATE_BACKUP_TICK_MS = 30 * 60 * 1000;
+	const { backupProjectsDaily } = await import("./data");
+	const { snapshotProtectedState } = await import("./state-backup");
+	const snapshotUserState = () => {
 		backupProjectsDaily().catch((err) => log.warn("Daily projects backup failed (non-fatal)", { err }));
-		backupProjectsHourly().catch((err) => log.warn("Hourly projects backup failed (non-fatal)", { err }));
+		snapshotProtectedState().catch((err) => log.warn("Hourly state backup failed (non-fatal)", { err }));
 	};
-	snapshotProjects();
-	setInterval(snapshotProjects, PROJECTS_BACKUP_TICK_MS).unref?.();
+	snapshotUserState();
+	setInterval(snapshotUserState, STATE_BACKUP_TICK_MS).unref?.();
 }
 
 // Exclude the worktrees root from OS backups (Time Machine) once at startup.

--- a/src/bun/state-backup.ts
+++ b/src/bun/state-backup.ts
@@ -1,0 +1,264 @@
+/**
+ * Hourly safety snapshots for every file of user state under ~/.dev3.0.
+ *
+ * On 2026-08-31 something wiped a chunk of the data root. `projects.json` got
+ * this cover afterwards; `spaces.json`, `settings.json`, `agents.json`,
+ * `virtual-projects.json` and `model-catalog.json` had the same hole and were
+ * lost with it. This module is that one scheme, generalised, so the next file
+ * added to the data root is protected by joining a list rather than by
+ * re-implementing anything.
+ *
+ * Every path here is an ADDITIVE sibling (AGENTS.md on-disk rule 5): nothing
+ * existing is moved or renamed, and an older app version simply never reads
+ * these files. There is deliberately no restore-on-startup — see
+ * docs/state-backups.md.
+ */
+
+import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import { atomicWriteFile } from "./atomic-write";
+import { createLogger } from "./logger";
+import { DEV3_HOME } from "./paths";
+
+const log = createLogger("state-backup");
+
+export const HOURLY_BACKUP_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}Z\.json$/;
+
+/** Three days of hourly copies — the window in which a wipe is noticed. */
+export const STATE_BACKUP_RETENTION_HOURS = 72;
+
+/**
+ * May the incoming bytes become the copy no rotation can evict?
+ *
+ * Per file, because the shapes differ and a rule bent to cover all of them is a
+ * rule that protects none of them properly. Returning false freezes the good
+ * copy for this tick; the dated hourly slot still records the incoming bytes
+ * faithfully either way.
+ */
+export type AdvancePredicate = (incoming: string, existing: string | null) => boolean;
+
+export interface ProtectedStateFile {
+	/** Stable name, used in logs and in the docs table. */
+	id: string;
+	file: string;
+	backupDir: string;
+	lastKnownGoodFile: string;
+	retentionHours: number;
+	advance: AdvancePredicate;
+}
+
+// ---- Collapse predicates ----
+
+function parseJson(content: string): unknown {
+	try {
+		return JSON.parse(content);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Entries in a top-level JSON array, or null when the bytes are not one. */
+export function countArrayEntries(content: string): number | null {
+	const parsed = parseJson(content);
+	return Array.isArray(parsed) ? parsed.length : null;
+}
+
+/** Spaces recorded in `spaces.json`, deleted ones included — deletion is soft,
+ *  so this count only ever grows during ordinary use. */
+export function countSpaces(content: string): number | null {
+	const parsed = parseJson(content) as { version?: unknown; spaces?: unknown; order?: unknown } | undefined;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+	if (parsed.version !== 1 || !Array.isArray(parsed.spaces) || !Array.isArray(parsed.order)) return null;
+	return parsed.spaces.length;
+}
+
+/** Providers plus named models — the two halves of the catalog a user authored. */
+export function countCatalogEntries(content: string): number | null {
+	const parsed = parseJson(content) as { providers?: unknown; models?: unknown } | undefined;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+	if (!Array.isArray(parsed.providers) || !Array.isArray(parsed.models)) return null;
+	return parsed.providers.length + parsed.models.length;
+}
+
+/**
+ * The list rule, unchanged from the one `projects.json` shipped with: advance
+ * unless more than half the entries went at once.
+ *
+ * The threshold is the whole argument. "Never shrink" would be its own bug — a
+ * user who deletes a project would freeze the good copy forever and it would go
+ * on holding data they meant to be rid of. "Always advance" is what makes a wipe
+ * the only surviving copy. A collapse is the one shape no ordinary editing
+ * produces, so it is the one shape worth refusing.
+ */
+export function collapseGuard(count: (content: string) => number | null): AdvancePredicate {
+	return (incoming, existing) => {
+		const incomingCount = count(incoming);
+		if (incomingCount === null) return false; // Unreadable bytes are never "good".
+		if (existing === null) return true;
+		const existingCount = count(existing);
+		if (existingCount === null) return true; // Anything readable beats an unreadable good copy.
+		return incomingCount * 2 >= existingCount;
+	};
+}
+
+function topLevelKeys(content: string): string[] | null {
+	const parsed = parseJson(content);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+	return Object.keys(parsed);
+}
+
+/**
+ * `settings.json` is an object, so counting entries is the wrong instrument: the
+ * loader drops every default-valued field before writing, so a user turning one
+ * toggle back to its default legitimately removes a key.
+ *
+ * The shape actually worth refusing is the one that happened — the file vanished
+ * and came back written from `DEFAULT_SETTINGS`, four keys where twenty had
+ * been, which is how a canary build came to read `updateChannel: "stable"` and
+ * swap the whole app mid-flight. That shape is a strict SUBSET of the good copy
+ * with most of it gone. Ordinary editing either introduces a key or drops a
+ * handful, so requiring both conditions leaves normal use untouched.
+ */
+export const settingsAdvance: AdvancePredicate = (incoming, existing) => {
+	const incomingKeys = topLevelKeys(incoming);
+	if (incomingKeys === null) return false;
+	if (existing === null) return true;
+	const existingKeys = topLevelKeys(existing);
+	if (existingKeys === null) return true;
+	const known = new Set(existingKeys);
+	const gainedAKey = incomingKeys.some((key) => !known.has(key));
+	if (gainedAKey) return true;
+	return incomingKeys.length * 2 >= existingKeys.length;
+};
+
+// ---- The registry ----
+
+function protect(id: string, basename: string, advance: AdvancePredicate): ProtectedStateFile {
+	const stem = basename.replace(/\.json$/, "");
+	return {
+		id,
+		file: `${DEV3_HOME}/${basename}`,
+		backupDir: `${DEV3_HOME}/${stem}-backups`,
+		lastKnownGoodFile: `${DEV3_HOME}/${stem}-last-known-good.json`,
+		retentionHours: STATE_BACKUP_RETENTION_HOURS,
+		advance,
+	};
+}
+
+/**
+ * Every file of user state in the data root, and nothing else.
+ *
+ * A file earns a place here by being authored by the user and unrecoverable
+ * without them. Derived or ephemeral state (window geometry, the last route,
+ * port assignments, which tips were seen) is cheaper to recreate than to keep 72
+ * copies of, and credentials are deliberately absent: multiplying a live API key
+ * into 72 dated files widens its exposure far more than re-pasting it costs.
+ * The full table, with the reason per file, is in docs/state-backups.md.
+ */
+export const PROTECTED_STATE_FILES: ProtectedStateFile[] = [
+	protect("projects", "projects.json", collapseGuard(countArrayEntries)),
+	protect("virtual-projects", "virtual-projects.json", collapseGuard(countArrayEntries)),
+	protect("spaces", "spaces.json", collapseGuard(countSpaces)),
+	protect("agents", "agents.json", collapseGuard(countArrayEntries)),
+	protect("model-catalog", "model-catalog.json", collapseGuard(countCatalogEntries)),
+	protect("settings", "settings.json", settingsAdvance),
+];
+
+export function protectedStateFile(id: string): ProtectedStateFile {
+	const entry = PROTECTED_STATE_FILES.find((candidate) => candidate.id === id);
+	if (!entry) throw new Error(`No protected state file registered under id "${id}"`);
+	return entry;
+}
+
+// ---- The mechanism ----
+
+function hourlyBackupFileName(now: Date): string {
+	return `${now.toISOString().slice(0, 13)}Z.json`;
+}
+
+/**
+ * At most one snapshot per entry hour, decided with stat() rather than by
+ * reading two whole files. The hour is captured before reading, so a
+ * boundary-spanning read stays in its start hour. See decision 204.
+ *
+ * Shared by the task store and every registered state file so the two can never
+ * drift into different levels of protection. Returns the bytes it snapshotted,
+ * or null when the hour was already covered or the source does not exist yet.
+ */
+export async function writeHourlySnapshot(
+	sourceFile: string,
+	backupDir: string,
+	retentionHours: number,
+	now: Date = new Date(),
+): Promise<string | null> {
+	const backupFile = `${backupDir}/${hourlyBackupFileName(now)}`;
+
+	try {
+		await stat(backupFile);
+		return null; // This hour is already snapshotted.
+	} catch (err: any) {
+		if (err.code !== "ENOENT") throw err;
+	}
+
+	let currentContent: string;
+	try {
+		currentContent = await readFile(sourceFile, "utf8");
+	} catch (err: any) {
+		if (err.code === "ENOENT") return null;
+		throw err;
+	}
+
+	await mkdir(backupDir, { recursive: true });
+	await writeFile(backupFile, currentContent);
+
+	const backupFiles = (await readdir(backupDir))
+		.filter((entry) => HOURLY_BACKUP_FILE_PATTERN.test(entry))
+		.sort();
+	for (const staleFile of backupFiles.slice(0, Math.max(0, backupFiles.length - retentionHours))) {
+		await unlink(`${backupDir}/${staleFile}`);
+	}
+	return currentContent;
+}
+
+/**
+ * Advance the un-evictable copy, unless this file's predicate refuses.
+ *
+ * Hourly and daily snapshots both rotate, so a run of degenerate ones can push
+ * every good copy out of the window — which is how the only same-day copy of a
+ * 29-project list came to hold one project.
+ */
+async function advanceLastKnownGood(entry: ProtectedStateFile, content: string): Promise<void> {
+	let existing: string | null = null;
+	try {
+		existing = await readFile(entry.lastKnownGoodFile, "utf8");
+	} catch (err: any) {
+		if (err.code !== "ENOENT") throw err;
+	}
+
+	if (!entry.advance(content, existing)) {
+		log.warn("Refusing to advance last-known-good copy: state collapsed", { id: entry.id });
+		return;
+	}
+	await atomicWriteFile(entry.lastKnownGoodFile, content);
+}
+
+/** Snapshot one registered file and advance its good copy if the bytes qualify. */
+export async function snapshotStateFile(entry: ProtectedStateFile, now: Date = new Date()): Promise<void> {
+	const snapshotted = await writeHourlySnapshot(entry.file, entry.backupDir, entry.retentionHours, now);
+	if (snapshotted !== null) await advanceLastKnownGood(entry, snapshotted);
+}
+
+/**
+ * Snapshot every registered file. Driven by a timer, because a save-only trigger
+ * snapshots nothing on a day nobody edits — which is exactly why 28-30 Aug 2026
+ * have no copy at all. One file failing must not cost the others their tick, so
+ * each is guarded on its own.
+ */
+export async function snapshotProtectedState(now: Date = new Date()): Promise<void> {
+	for (const entry of PROTECTED_STATE_FILES) {
+		try {
+			await snapshotStateFile(entry, now);
+		} catch (err) {
+			log.warn("State snapshot failed (non-fatal)", { id: entry.id, error: String(err) });
+		}
+	}
+}


### PR DESCRIPTION
Hi — this is Claude, the AI assistant that wrote this branch.

On 2026-08-31 something wiped part of `~/.dev3.0`. PR #1620 gave `projects.json` hourly snapshots plus a last-known-good copy that rotation cannot evict. A day later it turned out the same incident had also taken `spaces.json`, which had no backup at all — the fix had been written for one file when six had the same hole.

This generalises that scheme into a registry in `src/bun/state-backup.ts`. `spaces.json`, `settings.json`, `agents.json`, `virtual-projects.json` and `model-catalog.json` now get the same hourly copies (72 kept) and the same un-evictable last-known-good file, driven by the existing 30-minute timer. `data.ts` delegates to the registry, so the mechanism has one implementation rather than two.

**The collapse rule is stated per file, because one generic rule is honestly wrong for `settings.json`.** Array halving covers the lists. `spaces.json` adds a shape check, since soft deletion makes its count monotonic and a large unparseable file would otherwise sail past a count rule. `settings.json` uses a strict-subset-plus-halving rule: the loader drops every default-valued field before writing, so counting keys alone would refuse ordinary edits — the shape worth refusing is a `DEFAULT_SETTINGS` rewrite, which is a pure subset with most of it gone.

**Directories stay per file** rather than one shared dated directory. The point-in-time coherence a shared directory promises is unavailable for the one pair that actually cross-references — `projects.json` and `data/<slug>/tasks.json` — because tasks live under the project's own data dir. Identical hourly filenames across directories give the same coherence by name-matching, without coupling the writers.

**Credentials are deliberately excluded**, and so is derived or ephemeral state. `docs/state-backups.md` carries the full table with a reason per file, plus the manual restore steps. There is no restore-on-startup, by design.

Every path is an additive sibling — nothing under `~/.dev3.0` is moved or renamed, and `projects-backups/` keeps the exact paths #1620 shipped.

Reasoning and the alternatives considered: `decisions/2026/09/01/back-up-every-file-of-user-state.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=d9d7b384-7d51-4d97-a132-e02c801e55a5) · `dev3://task/d9d7b384-7d51-4d97-a132-e02c801e55a5`
