### PR TITLE
Repair double-encoded UTF-8 in shared/types.ts and guard against it

### DIFF
--- a/.claude/skills/debug-ui/SKILL.md
+++ b/.claude/skills/debug-ui/SKILL.md
@@ -61,8 +61,8 @@ above (see [decision 093](../../../decisions/2026/06/30/dev-remote-port-from-poo
 
 `dev3 dev-server start` boots a full dev3 instance on **your real board** — another task's
 "Branch Merged — mark completed?" dialog is live and clickable in your browser, and another task's
-terminal is reachable by navigation. For anything that does not specifically need real data, run the
-scoped instance instead:
+terminal is reachable by navigation. It stays the default anyway, because it is the build the user
+runs; reach for the scoped board when the QA would touch real tasks, real accounts, or a live dialog:
 
 ```bash
 dev3 pane run "cd $PWD && bun run dev --qa"     # throwaway board: one fixture project, zero tasks
@@ -70,9 +70,10 @@ dev3 pane run "cd $PWD && bun run dev --qa=virgin"   # completely empty home —
 dev3 pane logs <run-id>                          # it prints the scoped DEV3_HOME and a reset line
 ```
 
-It binds the same `DEV3_PORT0` and prints the port, so steps 3–4 of the flow above are unchanged.
-The scoped root is stable per worktree, so a restart reuses the same board; `rm -rf` the printed
-root to start over.
+It binds the same `DEV3_PORT0` and prints the port, so step 3 of the flow above is unchanged.
+**Step 4 is not:** `dev3 dev-server stop` does not own a pane run, so close it with
+`dev3 pane close <run-id>` instead. The scoped root is stable per worktree, so a restart reuses
+the same board; `rm -rf` the printed root to start over.
 
 **What it does NOT isolate** — name these rather than assuming a clean room: the tmux socket
 directory (only `TMUX_TMPDIR` moves it, and dev3 sets it nowhere), the PowerShell history file on
@@ -101,8 +102,11 @@ inside a REAL worktree (cwd-based task detection outranks `$DEV3_HOME` by design
   *another* worktree — it won't have your changes. (Re)start THIS task's dev-server and confirm
   with `dev3 --version` (commit hash should match `git log -1`) + that your change actually
   renders. Don't assume.
-- **Tell the user before `dev3 dev-server start`** (visible side effect), and stop it after
-  (step 4) unless they want it kept.
+- **Tell the user before you start the app any way at all** (visible side effect), and stop it
+  after (step 4) unless they want it kept.
+- **`dev3` says `app not running`? Stop and tell the user.** Every route in this skill needs the
+  CLI, so there is nothing to fall back to. Never launch the app yourself — a bare `bun run dev`
+  opens a native window on the user's screen, which they did not ask for.
 - **No `DEV3_PORT0`?** (portCount 0, or an older worktree where it was never allocated) — run
   your own fixed-port server instead:
   `dev3 remote --no-detach --no-tunnel --static-code $CODE --port 47823` → `:47823/?token=$CODE`.

--- a/change-logs/2026/09/01/fix-mojibake-in-shared-types.md
+++ b/change-logs/2026/09/01/fix-mojibake-in-shared-types.md
@@ -1,0 +1,3 @@
+Short: Fix garbled dashes in review prompt
+
+The AI Review column's default prompt showed garbled characters instead of dashes ("worth surfacing â add a short"), and 44 more mangled arrows, degree signs and dashes sat in the same file's comments — a commit two months ago had re-saved it with the wrong text encoding. All 46 are repaired, and a new test scans every tracked text file so the next occurrence fails CI instead of shipping.

--- a/decisions/2026/08/31/guard-against-double-encoded-utf8.md
+++ b/decisions/2026/08/31/guard-against-double-encoded-utf8.md
@@ -1,0 +1,45 @@
+# Guard against double-encoded UTF-8 in source text
+
+## Context
+
+The AI Review column's default prompt rendered "worth surfacing â add a short" and
+"<1â3 sentence summary>" in the agent's terminal and in Project Settings. Every project on
+this build showed it, because the text is `DEFAULT_REVIEW_PROMPT` in `src/shared/types.ts` —
+not per-project state.
+
+## Investigation
+
+`src/shared/types.ts` held 46 double-encoded characters: 20 em dashes, 13 degree signs,
+10 arrows, one en dash, one ellipsis, one command symbol. `git blame` put all of them in a
+single commit, `ec6f01de8c` ("Fix double complete/cancel sound in remote mode", 2026-06-28),
+whose parent is clean and whose subject has nothing to do with punctuation — some tool in
+that session read the file as UTF-8 and wrote it back as Latin-1, mangling only the lines it
+rewrote (193 em dashes elsewhere in the file survived intact). No other tracked text file in
+the repo is affected, and neither `projects.json` nor `tasks.json` carries a saved copy.
+
+The reason it survived two months: the result is still valid UTF-8, so nothing fails. The file
+compiles, `bun run lint` is happy, every test passes, and a diff review shows the mangled run
+as one odd-looking character in an otherwise correct line. Only the rendered prompt gives it away.
+
+## Decision
+
+Repaired the 46 runs in place (byte-level replacement of the six known sequences), and added
+`src/bun/__tests__/mojibake-guard.test.ts`: it reads every tracked text file as Latin-1, finds
+runs of C2/C3 lead bytes, and reports a run only when decoding it through Latin-1 twice yields
+printable text — which leaves genuine Latin-1 characters (degree, section, middot) alone. The
+test names the offending file and prints "mangled -> intended" so the fix is mechanical. Its
+own patterns are written with `\u` escapes, or the file would trip its own guard.
+
+## Risks
+
+The detector is heuristic: a file that legitimately contains the literal two-character sequence
+an em dash mangles into would be a false positive. No such file exists here, and the failure
+message makes the call obvious. It scans the whole tree on every backend run — 2.7 s.
+
+## Alternatives considered
+
+A pre-commit hook was rejected: hooks are per-machine and this repo's other text invariants
+(decision-record names, UX doc budgets, the agent command-line budget) are all asserted as
+tests, so CI catches it for every contributor. Restricting the scan to prompt constants was
+rejected too — the same commit mangled 44 characters outside them, and the next one will land
+somewhere else.

--- a/src/bun/__tests__/mojibake-guard.test.ts
+++ b/src/bun/__tests__/mojibake-guard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A UTF-8 file re-saved as if it were Latin-1 turns every em dash and arrow into
+ * two mangled characters, and nothing fails: the file is still valid UTF-8 and
+ * TypeScript compiles it. That is exactly how 46 mangled characters — two of them
+ * inside DEFAULT_REVIEW_PROMPT, which every project's AI review agent reads —
+ * rode into src/shared/types.ts unnoticed and shipped.
+ * See decisions/2026/08/31/guard-against-double-encoded-utf8.md.
+ *
+ * Every pattern here is written with \u escapes on purpose: a literal example
+ * would make this file trip its own guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO = fileURLToPath(new URL("../../..", import.meta.url));
+
+/**
+ * Runs of C2/C3 lead bytes — how double-encoded UTF-8 always looks. A run counts
+ * as mojibake only once re-decoding it through Latin-1 yields printable text,
+ * which leaves genuine Latin-1 characters (degree, section, middot) alone.
+ */
+const RUN = /(?:[\u00c2\u00c3][\u0080-\u00bf])+/g;
+
+const TEXT_FILE = /\.(ts|tsx|js|jsx|css|html|json|md|yml|yaml|sh|ps1)$/;
+
+function trackedTextFiles(): string[] {
+	const ls = spawnSync("git", ["ls-files", "-z"], { cwd: REPO, encoding: "utf8" });
+	if (ls.status !== 0) throw new Error(`git ls-files failed: ${ls.stderr}`);
+	return ls.stdout.split("\0").filter((path) => path && TEXT_FILE.test(path));
+}
+
+/** Reads a string's code units back as bytes and decodes them as UTF-8, or null. */
+function undoLatin1(text: string): string | null {
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(
+			Uint8Array.from(text, (char) => char.charCodeAt(0) & 0xff),
+		);
+	} catch {
+		return null;
+	}
+}
+
+/** Each mojibake run in `path`, rendered as "mangled -> intended". */
+function mojibake(path: string): string[] {
+	const latin1 = readFileSync(`${REPO}/${path}`, "latin1");
+	const found: string[] = [];
+	for (const [run] of latin1.matchAll(RUN)) {
+		const asWritten = undoLatin1(run);
+		const intended = asWritten === null ? null : undoLatin1(asWritten);
+		if (intended === null || /\p{C}/u.test(intended)) continue;
+		found.push(`${asWritten} -> ${intended}`);
+	}
+	return found;
+}
+
+describe("source text encoding", () => {
+	it("carries no double-encoded UTF-8", () => {
+		const offenders = trackedTextFiles()
+			.map((path) => ({ path, runs: mojibake(path) }))
+			.filter(({ runs }) => runs.length > 0)
+			.map(({ path, runs }) => `${path}: ${runs.join(", ")}`);
+		expect(
+			offenders,
+			"Cause: the file was written by a tool that read UTF-8 as Latin-1, so its punctuation " +
+				"is now two characters wide. It still compiles, so only the rendered text reveals it.\n" +
+				"Fix: replace each mangled run with the character shown after the arrow.",
+		).toEqual([]);
+	});
+
+	it("detects the mangling it guards against", () => {
+		// The six bytes an em dash becomes after one Latin-1 round trip.
+		const mangled = "\u00c3\u00a2\u00c2\u0080\u00c2\u0094";
+		const asWritten = undoLatin1(mangled);
+		expect(asWritten).not.toBeNull();
+		expect(undoLatin1(asWritten as string)).toBe("—");
+	});
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -190,7 +190,7 @@ export const STATUS_COLORS_LIGHT_INK: Record<TaskStatus, string> = {
 	cancelled: "#d20346",      // passes as-is (Lc ~71)
 };
 
-/** Convert "#rrggbb" â "R G B" for use as CSS variable value */
+/** Convert "#rrggbb" → "R G B" for use as CSS variable value */
 export function hexToRgb(hex: string): string {
 	const r = parseInt(hex.slice(1, 3), 16);
 	const g = parseInt(hex.slice(3, 5), 16);
@@ -454,9 +454,9 @@ For medium/high severity: fix directly and commit.
 For minor/cosmetic: leave alone. Do NOT break existing functionality.
 
 As the very last step (after any commits), you MUST hand the task back to the user by moving it yourself:
-- If you found problems, committed fixes, or have anything worth surfacing â add a short \`dev3 note add "<1â3 sentence summary>"\` and then run:
+- If you found problems, committed fixes, or have anything worth surfacing — add a short \`dev3 note add "<1–3 sentence summary>"\` and then run:
     dev3 task move --status user-questions
-- If the diff is clean and nothing needed changing â run:
+- If the diff is clean and nothing needed changing — run:
     dev3 task move --status review-by-user
 
 Do not skip this step. Move the task exactly once, at the end.`;
@@ -1152,8 +1152,8 @@ export interface GlobalSettings {
 	 */
 	staticAccessCode?: string;
 	cloneBaseDirectory?: string;
-	customBinaryPaths?: Record<string, string>; // requirementId â custom binary path
-	agentBinaryPaths?: Record<string, string>; // agentId â resolved binary path
+	customBinaryPaths?: Record<string, string>; // requirementId → custom binary path
+	agentBinaryPaths?: Record<string, string>; // agentId → resolved binary path
 	/**
 	 * Paths the user typed into Settings -> Agents -> Custom path, kept apart
 	 * from the auto-cached `agentBinaryPaths`: only the cache may be discarded
@@ -1263,7 +1263,7 @@ export interface GlobalSettings {
 	/**
 	 * Remembered state of the Watch toggle in the launch/create-variant modal.
 	 * When a task is launched, the toggle's on/off choice is persisted here and
-	 * reused as the default for the next launch. Undefined â default to unwatched.
+	 * reused as the default for the next launch. Undefined → default to unwatched.
 	 */
 	watchByDefault?: boolean;
 	/** When false, merged branches show a notice instead of a completion prompt. */
@@ -1520,8 +1520,8 @@ export interface ProviderSettings {
 export type ProviderConfig = Partial<Record<LlmProvider, ProviderSettings>>;
 
 export interface TipState {
-	snoozedUntil: number; // timestamp â all tips hidden until this time
-	seen: Record<string, number>; // tipId â last-seen timestamp
+	snoozedUntil: number; // timestamp — all tips hidden until this time
+	seen: Record<string, number>; // tipId → last-seen timestamp
 	rotationIndex: number;
 }
 
@@ -1557,20 +1557,20 @@ export interface CustomColumn {
 }
 
 // Colors ordered to maximize perceptual distance between consecutive picks
-// (each step jumps ~150Â° around the color wheel: warmâcoolâwarmâcoolâ¦)
+// (each step jumps ~150° around the color wheel: warm→cool→warm→cool…)
 export const LABEL_COLORS = [
-	"#ef4444", // red       0Â°
-	"#14b8a6", // teal    174Â°
-	"#f97316", // orange   25Â°
-	"#8b5cf6", // violet  258Â°
-	"#84cc16", // lime     80Â°
-	"#ec4899", // pink    322Â°
-	"#06b6d4", // cyan    188Â°
-	"#eab308", // yellow   50Â°
-	"#3b82f6", // blue    217Â°
-	"#22c55e", // green   142Â°
-	"#f43f5e", // rose    350Â°
-	"#6366f1", // indigo  239Â°
+	"#ef4444", // red       0°
+	"#14b8a6", // teal    174°
+	"#f97316", // orange   25°
+	"#8b5cf6", // violet  258°
+	"#84cc16", // lime     80°
+	"#ec4899", // pink    322°
+	"#06b6d4", // cyan    188°
+	"#eab308", // yellow   50°
+	"#3b82f6", // blue    217°
+	"#22c55e", // green   142°
+	"#f43f5e", // rose    350°
+	"#6366f1", // indigo  239°
 ] as const;
 
 // ---- Repo-local config (.dev3/config.json) ----
@@ -1630,7 +1630,7 @@ export interface Dev3RepoConfig {
 	env?: Record<string, string>;
 }
 
-/** Keys of Dev3RepoConfig â used for merge logic. */
+/** Keys of Dev3RepoConfig — used for merge logic. */
 export const DEV3_REPO_CONFIG_KEYS: (keyof Dev3RepoConfig)[] = [
 	"setupScript",
 	"setupScriptLaunchMode",
@@ -1820,9 +1820,9 @@ export function withoutPresetPrompt(description: string, prompt: string): string
 }
 
 /**
- * True for the single hardcoded "Operations" board â the special, pinned virtual
+ * True for the single hardcoded "Operations" board — the special, pinned virtual
  * project. Distinct from user-created virtual boards (which have `kind: "virtual"`
- * but `builtin` unset). Used for pin-first ordering, the â0 shortcut, and the
+ * but `builtin` unset). Used for pin-first ordering, the ⌘0 shortcut, and the
  * special `[ Operations ]` / SYSTEM identity treatment.
  */
 export function isBuiltinOpsProject(p: Pick<Project, "kind" | "builtin">): boolean {
@@ -2187,7 +2187,7 @@ export interface Task {
 	 * Surfaced in the hover-preview popover above the terminal snapshot so
 	 * the user can re-enter focus fast after a long break. `description` is
 	 * the raw original user request and must NOT be used as a substitute.
-	 * When `userOverview` is set, it takes precedence for display â agents
+	 * When `userOverview` is set, it takes precedence for display — agents
 	 * keep writing here freely, but the user won't see it until they revert.
 	 */
 	overview?: string | null;
@@ -2204,7 +2204,7 @@ export interface Task {
 	 * Task modal or inline rename). Titles set by an agent through
 	 * `dev3 task update --title` leave this flag at `false`. The user-edited
 	 * marker shown to agents and the CLI overwrite-guard both key off this
-	 * flag â NOT off `customTitle != null` â so agent-set titles can still
+	 * flag — NOT off `customTitle != null` — so agent-set titles can still
 	 * be re-rewritten by later agents while a real user-typed title is
 	 * preserved for the entire task lifetime.
 	 */
@@ -2272,7 +2272,7 @@ export interface Task {
 	/**
 	 * Append-only log of the task's title/overview as they changed over time.
 	 * Written automatically by the data layer whenever the *effective*
-	 * (displayed) title or overview changes â and seeded once at creation. Each
+	 * (displayed) title or overview changes — and seeded once at creation. Each
 	 * entry is a full snapshot of both values, so it is self-contained. Not
 	 * surfaced in the UI yet; kept for a future history view and for search.
 	 */
@@ -2409,9 +2409,9 @@ export interface Task {
 	 * removed but a fixed folder is never auto-removed. Ignored for git projects.
 	 */
 	opsWorkDir?: string | null;
-	/** Last-launch timestamps (ISO) per package.json script â used to sort the Scripts dropdown. */
+	/** Last-launch timestamps (ISO) per package.json script — used to sort the Scripts dropdown. */
 	scriptLastRunAt?: Record<string, string>;
-	/** Last-used placement per package.json script â pre-selects it in the placement picker. */
+	/** Last-used placement per package.json script — pre-selects it in the placement picker. */
 	scriptLastPlacement?: Record<string, ScriptPlacement>;
 	/**
 	 * Git-diff stats captured at completion time (before the worktree is removed),
@@ -2764,7 +2764,7 @@ export interface PackageScripts {
 	runner: ScriptRunner;
 	/** Runner was auto-detected from a lockfile (vs falling back to npm). */
 	runnerAutoDetected: boolean;
-	/** Multiple lockfiles found â runner is ambiguous. */
+	/** Multiple lockfiles found — runner is ambiguous. */
 	multipleLockfiles: boolean;
 	/** Lockfiles actually present in the worktree. */
 	lockfiles: string[];
@@ -2847,7 +2847,7 @@ export const STUCK_PREPARATION_FETCH_THRESHOLD_MS = 60 * 1000;
 
 /** Per-pane session info for recovery. */
 export interface PaneSessionEntry {
-	/** tmux pane ID (e.g. "%0", "%5") â stable within a tmux server lifetime, unique across sessions. */
+	/** tmux pane ID (e.g. "%0", "%5") — stable within a tmux server lifetime, unique across sessions. */
 	paneId?: string | null;
 	/** The resolved agent base command (e.g. "claude", "/usr/local/bin/codex"). */
 	agentCmd: string;
@@ -2881,7 +2881,7 @@ export interface PaneSessionEntry {
 
 /** Captured session state for agent recovery after tmux death / app restart. */
 export interface TaskSessionState {
-	/** Panes in order â index 0 is the main pane, rest are extra agent panes. */
+	/** Panes in order — index 0 is the main pane, rest are extra agent panes. */
 	panes: PaneSessionEntry[];
 }
 
@@ -3072,7 +3072,7 @@ export interface TaskHistoryEntry {
 	changed: TaskHistoryChange;
 }
 
-/** Humanize a status slug for display in notifications (e.g. "in-progress" â "In Progress"). */
+/** Humanize a status slug for display in notifications (e.g. "in-progress" → "In Progress"). */
 export function formatStatus(status: string): string {
 	return status
 		.split("-")
@@ -3608,13 +3608,13 @@ export type ExposedPortKind = "quick" | "shared";
 /**
  * A dev-server port (or group of ports) being shared publicly through a
  * Cloudflare quick-tunnel. `kind: "quick"` is one cloudflared per port
- * â its own random `*.trycloudflare.com` URL. `kind: "shared"` is one
- * cloudflared shared between multiple ports of the same task â those ports
+ * → its own random `*.trycloudflare.com` URL. `kind: "shared"` is one
+ * cloudflared shared between multiple ports of the same task — those ports
  * are reached via `<url>/p/<port>/...` on the headless server which proxies
  * the request to localhost:<port>. Shared mode lets a frontend and backend
  * talk to each other via relative URLs (no CORS, no hardcoded URLs).
  *
- * State is runtime-only â never persists to tasks.json. Tunnels are torn
+ * State is runtime-only — never persists to tasks.json. Tunnels are torn
  * down on explicit stop, after two consecutive port-scan misses (~20 s),
  * on task removal, and on app shutdown.
  */
@@ -3622,7 +3622,7 @@ export interface ExposedPort {
 	taskId: string;
 	kind: ExposedPortKind;
 	/**
-	 * For `quick`, exactly one element â the dev-server port. For `shared`,
+	 * For `quick`, exactly one element — the dev-server port. For `shared`,
 	 * the full set of ports reachable through this tunnel.
 	 */
 	ports: number[];
@@ -5744,7 +5744,7 @@ export type AppRPCSchema = {
 			agentsUpdated: CodingAgent[];
 			/**
 			 * Emitted when the main window gains focus shortly after a watched-task notification fired.
-			 * The renderer navigates to the referenced task â implements click-to-open for native notifications.
+			 * The renderer navigates to the referenced task — implements click-to-open for native notifications.
 			 */
 			openTaskFromNotification: { taskId: string; projectId: string };
 			/**
@@ -5851,7 +5851,7 @@ export type AppRPCSchema = {
 			/**
 			 * CI/checks + PR-review state for a task's associated PR, emitted by the
 			 * background PR poller (`checkOpenPRsForPromotion`). Drives the CI and
-			 * review badges on the task card. Passive status â NOT gated by Focus
+			 * review badges on the task card. Passive status — NOT gated by Focus
 			 * Mode (only the bell/notification raised alongside it is).
 			 */
 			taskPrStatus: {
@@ -5902,7 +5902,7 @@ export type AppRPCSchema = {
 			 * RPC call, state mutation) based on its `current` view/task/project.
 			 *
 			 * Bun-side side effects (open external URL, dialog, display-popup) do
-			 * not go through this channel â they execute in `src/bun/index.ts`.
+			 * not go through this channel — they execute in `src/bun/index.ts`.
 			 */
 			menuAction: { action: string };
 			/**


### PR DESCRIPTION
## Summary

The AI Review column's default prompt rendered garbled characters instead of dashes — `worth surfacing â add a short` and `<1â3 sentence summary>`. The text is `DEFAULT_REVIEW_PROMPT` in `src/shared/types.ts`, not per-project state, so every project on this build read it that way.

`src/shared/types.ts` held **46 double-encoded characters**: 20 em dashes, 13 degree signs, 10 arrows, one en dash, one ellipsis, one command symbol. `git blame` puts all of them in a single commit, `ec6f01de8c` ("Fix double complete/cancel sound in remote mode", 2026-06-28), whose parent is clean and whose subject has nothing to do with punctuation — a tool in that session read the file as UTF-8 and wrote it back as Latin-1, mangling only the lines it rewrote. The other 193 em dashes in the file survived, which is why it went unnoticed for two months.

It survived because the result is still valid UTF-8: the file compiles, `bun run lint` is happy, every test passes, and in a diff each mangled run looks like one odd character in an otherwise correct line. Only the rendered prompt gives it away.

## What this changes

- **`src/shared/types.ts`** — all 46 runs repaired. The only C2/C3 sequences left are genuine `°`, `§`, `·`.
- **`src/bun/__tests__/mojibake-guard.test.ts`** (new) — reads every tracked text file as Latin-1 and reports a run only when decoding it through Latin-1 twice yields printable text, so genuine Latin-1 characters stay untouched. Failure names the file and prints `mangled -> intended`. Its own patterns use `\u` escapes, or the file would trip its own guard.
- **`.claude/skills/debug-ui/SKILL.md`** — three small corrections found while QA'ing this change. Its `Scoped QA` section was appended over the main flow: step 4 still said `dev3 dev-server stop`, which does not own a `dev3 pane run` (close it with `dev3 pane close <run-id>`); nothing covered the CLI being unreachable, so the apparent way out was launching the app by hand, which opens a native window on the user's screen; and the "tell the user first" warning was pinned to one command instead of any app launch.
- Decision record + changelog entry.

## Verification

The guard was proven by breaking what it guards: reintroducing one mangled em dash into `types.ts` failed the test with `src/shared/types.ts: â -> —`, and reverting made it green again.

The repaired prompt was read back out of the running app — `dev3 dev-server start`, Project Settings → Project Config → Review Prompt — where the textarea value contains proper em and en dashes and no mojibake. That doubles as proof the served bundle was this branch, since `main`'s bundle shows the garbled text.

`bun run lint` clean; `bun run test` green after the rebase (mainview 5060, bun 7550, cli 1003, zero failures). Browser console clean. The full suite is left to CI per the repo's local-E2E policy.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ab0d6f17-0983-4a11-abb1-44c787ba4559) · `dev3://task/ab0d6f17-0983-4a11-abb1-44c787ba4559` _(dev3 added this footer — turn it off in Settings → Tasks.)_
