### PR TITLE
Title each window with the task or project it shows

### DIFF
--- a/change-logs/2026/09/03/feature-per-window-native-title.md
+++ b/change-logs/2026/09/03/feature-per-window-native-title.md
@@ -1,0 +1,5 @@
+Short: Window titles name their task
+
+Each desktop window now shows what it displays in its native title bar — `<task> · dev-3.0` on a task, `<project> · dev-3.0` on a board — so a multi-monitor layout of several windows is tellable apart in the title bar, Mission Control and the Window menu. Streamer mode keeps a sensitive project's name out of the title, exactly as it already did for the browser tab.
+
+Suggested by @yhattav (h0x91b/dev-3.0#1632)

--- a/decisions/2026/09/02/per-window-native-title.md
+++ b/decisions/2026/09/02/per-window-native-title.md
@@ -1,0 +1,44 @@
+# Per-window native title from the renderer's route context
+
+## Context
+
+Every dev-3.0 window carried the identical static title (`dev-3.0 vX.Y.Z [build]`) set once at
+`BrowserWindow` creation. With multi-window (⇧⌘N) on several displays there was no way to tell which
+window showed which task — not in the title bar, not in Mission Control, not in the Window menu
+(issue #1632). The renderer already computed exactly the right string for `document.title`
+(`App.tsx`, the route-title effect), but a webview's `document.title` does not propagate to the
+native window in Electrobun.
+
+## Decision
+
+The renderer reports only the **context** (task title, project name, or the streamer-mode
+placeholder) over a new RPC request `setWindowTitleContext`; the host composes the final title with
+`composeWindowTitle(base, context)` (`src/bun/app-utils.ts`) and calls `BrowserWindow.setTitle`.
+
+Two points worth knowing:
+
+- **The handler is per window.** `createAppWindow` (`src/bun/window-manager.ts`) spreads the shared
+  `handlers` object and overrides `setWindowTitleContext` with a closure over a back-reference to its
+  own window. The shared handler cannot do it: it has no idea which window called, and routing
+  through `getFocusedWindow()` would let a background window retitle the focused one. The closure is
+  cleared on `close` so a late report cannot touch a dead window.
+- **The renderer sends the context, not the whole title.** The host keeps ownership of the base
+  (version + build time), which the renderer's own base title does not carry — forwarding the
+  computed `document.title` would have silently dropped the build timestamp from dev window titles.
+
+The remote transport dispatches from the shared `handlers`, so `app-handlers.ts` keeps a deliberate
+no-op entry: a browser client already owns its tab title, and it must never retitle a desktop window.
+
+## Risks
+
+`setTitle` is wrapped in try/catch — a window torn down natively between the report and the call
+would otherwise throw inside an RPC handler. Native titling is not covered by an automated test
+(no headless desktop window); the routing, composition and teardown behaviour are.
+
+## Alternatives considered
+
+- **Global handler + `getFocusedWindow()`** — wrong window on every report from a background window.
+- **Plumb a window id through `preload` and have the renderer pass it** — more moving parts and a new
+  trust boundary for no gain over the closure.
+- **Poll `document.title` from the host** — Electrobun exposes no such read, and polling would fight
+  the effect that owns the value.

--- a/src/bun/__tests__/app-utils.test.ts
+++ b/src/bun/__tests__/app-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getISOWeek, formatDateTime, makeTitle } from "../app-utils";
+import { getISOWeek, formatDateTime, makeTitle, composeWindowTitle } from "../app-utils";
 
 describe("getISOWeek", () => {
 	it("returns week 1 for Jan 1 2024 (Monday)", () => {
@@ -97,5 +97,23 @@ describe("makeTitle", () => {
 		expect(makeTitle("1.2.3", "now", "prod")).toBe("dev-3.0 v1.2.3 [now]");
 		expect(makeTitle("1.2.3", "now", "stable")).toBe("dev-3.0 v1.2.3 [now]");
 		expect(makeTitle("1.2.3", "now", undefined)).toBe("dev-3.0 v1.2.3 [now]");
+	});
+});
+
+describe("composeWindowTitle", () => {
+	it("puts the route context in front of the base title", () => {
+		expect(composeWindowTitle("dev-3.0 v1.2.3 [now]", "Fix auth race")).toBe(
+			"Fix auth race · dev-3.0 v1.2.3 [now]",
+		);
+	});
+
+	it("keeps the base title alone when there is no context", () => {
+		expect(composeWindowTitle("dev-3.0 v1.2.3 [now]", null)).toBe("dev-3.0 v1.2.3 [now]");
+		expect(composeWindowTitle("dev-3.0", undefined)).toBe("dev-3.0");
+		expect(composeWindowTitle("dev-3.0", "   ")).toBe("dev-3.0");
+	});
+
+	it("trims a padded context", () => {
+		expect(composeWindowTitle("dev-3.0", "  My Project  ")).toBe("My Project · dev-3.0");
 	});
 });

--- a/src/bun/__tests__/window-manager.test.ts
+++ b/src/bun/__tests__/window-manager.test.ts
@@ -14,9 +14,13 @@ type FakeWindow = {
 	setFrame: ReturnType<typeof vi.fn>;
 	isFullScreen: ReturnType<typeof vi.fn>;
 	setFullScreen: ReturnType<typeof vi.fn>;
+	setTitle: ReturnType<typeof vi.fn>;
 	focus: ReturnType<typeof vi.fn>;
 	on: ReturnType<typeof vi.fn>;
 	handlers: Record<string, () => void>;
+	/** The RPC request handlers this window's own rpc instance was built with. */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	rpcRequests: Record<string, (...args: any[]) => any>;
 	frame?: { x: number; y: number; width: number; height: number };
 };
 
@@ -37,13 +41,17 @@ vi.mock("electrobun/bun", () => {
 		setFrame: ReturnType<typeof vi.fn>;
 		isFullScreen: ReturnType<typeof vi.fn>;
 		setFullScreen: ReturnType<typeof vi.fn>;
+		setTitle: ReturnType<typeof vi.fn>;
 		focus: ReturnType<typeof vi.fn>;
 		on: ReturnType<typeof vi.fn>;
 		handlers: Record<string, () => void>;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		rpcRequests: Record<string, (...args: any[]) => any>;
 		frame?: { x: number; y: number; width: number; height: number };
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		constructor(opts?: any) {
 			this.frame = opts?.frame;
+			this.rpcRequests = opts?.rpc?.__requests ?? {};
 			const fakeSend: Record<string, ReturnType<typeof vi.fn>> = {};
 			const handlers: Record<string, () => void> = {};
 			this.webview = {
@@ -66,6 +74,7 @@ vi.mock("electrobun/bun", () => {
 			});
 			this.isFullScreen = vi.fn(() => false);
 			this.setFullScreen = vi.fn();
+			this.setTitle = vi.fn();
 			this.focus = vi.fn();
 			this.on = vi.fn((name: string, handler: () => void) => {
 				handlers[name] = handler;
@@ -76,7 +85,10 @@ vi.mock("electrobun/bun", () => {
 	}
 	return {
 		BrowserView: {
-			defineRPC: vi.fn(() => ({ setTransport: vi.fn() })),
+			// __requests exposes the per-window request handlers to the test; the
+			// real defineRPC keeps them private inside the transport.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			defineRPC: vi.fn((opts: any) => ({ setTransport: vi.fn(), __requests: opts?.handlers?.requests ?? {} })),
 		},
 		BrowserWindow: FakeBrowserWindow,
 		Screen: {
@@ -223,6 +235,45 @@ describe("window-manager", () => {
 		expect(secondWin.frame?.y).toBeLessThanOrEqual(54);
 		// x must not exceed wa.width - window.width (= 1920 - 1824 = 96)
 		expect(secondWin.frame?.x).toBeLessThanOrEqual(96);
+	});
+
+	it("titles only the window whose renderer reported the context", () => {
+		spawn();
+		spawn();
+
+		const [first, second] = createdWindows;
+		second.rpcRequests.setWindowTitleContext({ context: "Fix auth race" });
+
+		expect(second.setTitle).toHaveBeenCalledWith("Fix auth race · dev-3.0");
+		expect(first.setTitle).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the bare base title when the route has no context", () => {
+		spawn();
+		const [win] = createdWindows;
+
+		win.rpcRequests.setWindowTitleContext({ context: null });
+
+		expect(win.setTitle).toHaveBeenCalledWith("dev-3.0");
+	});
+
+	it("ignores a title report that arrives after the window closed", () => {
+		spawn();
+		const [win] = createdWindows;
+		win.handlers.close?.();
+
+		expect(() => win.rpcRequests.setWindowTitleContext({ context: "Late" })).not.toThrow();
+		expect(win.setTitle).not.toHaveBeenCalled();
+	});
+
+	it("survives a setTitle that throws (window torn down natively)", () => {
+		spawn();
+		const [win] = createdWindows;
+		win.setTitle.mockImplementation(() => {
+			throw new Error("window is gone");
+		});
+
+		expect(() => win.rpcRequests.setWindowTitleContext({ context: "Boom" })).not.toThrow();
 	});
 
 	it("invokes onClosed with the remaining window count", () => {

--- a/src/bun/app-utils.ts
+++ b/src/bun/app-utils.ts
@@ -37,3 +37,13 @@ export const formatDateTime = (d: Date) => {
 /** Builds the window title string, marking non-stable channels (see above). */
 export const makeTitle = (version: string, dt: string, buildChannel?: string) =>
 	`${buildChannelTitlePrefix(buildChannel)}dev-3.0 v${version} [${dt}]`;
+
+/**
+ * Prefixes a window's base title with the route context the renderer reports
+ * (task or project name, or the streamer-mode placeholder). The context goes
+ * first because Mission Control and the Window menu truncate the tail.
+ */
+export const composeWindowTitle = (base: string, context: string | null | undefined) => {
+	const trimmed = context?.trim();
+	return trimmed ? `${trimmed} · ${base}` : base;
+};

--- a/src/bun/rpc-handlers/app-handlers.ts
+++ b/src/bun/rpc-handlers/app-handlers.ts
@@ -106,6 +106,15 @@ async function setWindowForeground(params: { focused: boolean }): Promise<void> 
 	setAppForeground(params.focused);
 }
 
+/**
+ * Titling a window is per-window work, so `window-manager` overrides this in each
+ * window's own RPC instance. This entry exists for the remote transport, whose
+ * browser clients report a context they already applied to their own tab title.
+ */
+async function setWindowTitleContext(_params: { context: string | null }): Promise<void> {
+	// Intentionally empty — see above.
+}
+
 /** The renderer gates transient notifications while terminal immersive fullscreen owns the screen. */
 async function setTerminalFocusHandler(params: { active: boolean }): Promise<void> {
 	setTerminalFocus(params.active);
@@ -1052,6 +1061,7 @@ export const appHandlers = {
 	openNewWindow,
 	hideApp,
 	setWindowForeground,
+	setWindowTitleContext,
 	setTerminalFocus: setTerminalFocusHandler,
 	setActiveContext: setActiveContextHandler,
 	setStreamerPrivacy: setStreamerPrivacyHandler,

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -1,6 +1,7 @@
 import { BrowserView, BrowserWindow, Screen } from "electrobun/bun";
 import type { AppRPCSchema } from "../shared/types";
 import { createLogger } from "./logger";
+import { composeWindowTitle } from "./app-utils";
 import { loadWindowState, saveWindowState, resolveRestoreFrame, displayContaining, offscreenFrameClamp, type DisplayLike, type Rect } from "./window-state";
 import { isFreshStartMode } from "./fresh-start";
 import { applyWindowsWindowIcon } from "./windows-icons/apply-window-icon";
@@ -138,11 +139,25 @@ export interface CreateAppWindowOptions {
  * close handlers don't need to do that themselves.
  */
 export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
+	// Each window titles itself: the renderer reports its own route context, and
+	// only the window that sent it may be retitled. The shared `handlers` object
+	// cannot do that (it has no idea which window called), hence the per-window
+	// override below over a back-reference filled in right after creation.
+	let self: BrowserWindow | null = null;
+	const setWindowTitleContext = ({ context }: { context: string | null }): void => {
+		if (!self) return;
+		try {
+			self.setTitle(composeWindowTitle(opts.title, context));
+		} catch (err) {
+			log.debug("setTitle failed", { error: String(err) });
+		}
+	};
+
 	const rpc = BrowserView.defineRPC<AppRPCSchema>({
 		maxRequestTime: opts.maxRequestTime ?? 120_000,
 		handlers: {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			requests: opts.handlers as any,
+			requests: { ...opts.handlers, setWindowTitleContext } as any,
 			messages: {},
 		},
 	});
@@ -190,6 +205,8 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 	// bundle's own icon already reaches the dock and the launcher.
 	applyWindowsWindowIcon(win.ptr as unknown as number);
 
+	self = win;
+
 	const id = ++seq;
 	const entry: WindowEntry = { window: win, id };
 	windows.add(entry);
@@ -203,6 +220,7 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 	});
 
 	win.on("close", () => {
+		self = null; // a late title report must not touch a closed window
 		windows.delete(entry);
 		if (focusedWindow === win) {
 			focusedWindow = firstWindow();

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -658,7 +658,9 @@ function App() {
 	}, [state.route]);
 
 	// Drive document.title from the current route so the browser tab shows the
-	// project/task name — the only orientation cue in remote (browser) mode.
+	// project/task name — the only orientation cue in remote (browser) mode. The
+	// same context also goes to the host, which titles this window natively (the
+	// only way to tell several windows apart in Mission Control / Window menu).
 	// Streamer mode locks every project the user flagged `sensitive`: it cannot be
 	// entered, so a stray click during a recording cannot expose it.
 	const streamerModeOn = useStreamerMode();
@@ -679,20 +681,21 @@ function App() {
 		const { route } = state;
 		if (!baseTitleRef.current) baseTitleRef.current = document.title;
 		const base = baseTitleRef.current || "dev-3.0";
-		let prefix = "";
+		let context: string | null = null;
 		// A tab title cannot be blurred (CSS reaches the document, not the chrome),
 		// so a sensitive project's context is replaced rather than masked.
 		const locked = isRouteLocked(route);
 		if (locked) {
-			prefix = `${t("streamer.privateTitle")} · `;
+			context = t("streamer.privateTitle");
 		} else if (route.screen === "project" || route.screen === "project-terminal" || route.screen === "project-settings") {
 			const project = state.projects.find((p) => p.id === route.projectId);
-			if (project) prefix = `${project.name} · `;
+			if (project) context = project.name;
 		} else if (route.screen === "task") {
 			const task = state.currentProjectTasks.find((task) => task.id === route.taskId);
-			if (task) prefix = `${getTaskTitle(task)} · `;
+			if (task) context = getTaskTitle(task);
 		}
-		document.title = prefix ? `${prefix}${base}` : base;
+		document.title = context ? `${context} · ${base}` : base;
+		void api.request.setWindowTitleContext?.({ context })?.catch?.(() => { /* best-effort */ });
 	}, [state.route, state.currentProjectTasks, state.projects, isRouteLocked, t]);
 
 	// Route persistence is enabled only after the initial restore attempt has

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -31,6 +31,7 @@ vi.mock("../rpc", () => ({
 			consumePendingNotificationNav: vi.fn().mockResolvedValue(null),
 			openNewWindow: vi.fn().mockResolvedValue(undefined),
 			hideApp: vi.fn().mockResolvedValue(undefined),
+			setWindowTitleContext: vi.fn().mockResolvedValue(undefined),
 			listTmuxSessions: vi.fn().mockResolvedValue([]),
 			getProjectCurrentBranch: vi.fn().mockResolvedValue({ branch: "main", isBaseBranch: true, isDirty: false }),
 			pullProjectMain: vi.fn(),
@@ -3003,6 +3004,38 @@ describe("App keyboard shortcuts", () => {
 
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 			expect(api.request.respondToAgentLaunchRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	// The route context reaches two places: this window's tab title, and the host,
+	// which turns it into the native window title — the only way to tell several
+	// windows apart in Mission Control.
+	describe("window title", () => {
+		// App captures whatever document.title holds at mount as the base title, so
+		// a previous test's title would otherwise become this one's suffix.
+		beforeEach(() => {
+			document.title = "dev-3.0";
+		});
+
+		it("reports the project name on a board route", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1" }),
+			});
+
+			await renderApp();
+
+			expect(document.title).toBe("Alpha · dev-3.0");
+			expect(api.request.setWindowTitleContext).toHaveBeenCalledWith({ context: "Alpha" });
+		});
+
+		it("reports no context on the dashboard", async () => {
+			await renderApp();
+
+			expect(document.title).toBe("dev-3.0");
+			expect(api.request.setWindowTitleContext).toHaveBeenCalledWith({ context: null });
 		});
 	});
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5533,6 +5533,17 @@ export type AppRPCSchema = {
 				response: void;
 			};
 			/**
+			 * Renderer reports the route context (task / project name, or the
+			 * streamer-mode placeholder) so the native window title names what the
+			 * window shows — the only way to tell several windows apart. Handled per
+			 * window in `window-manager`; a no-op for remote browser clients, which
+			 * already own their own tab title.
+			 */
+			setWindowTitleContext: {
+				params: { context: string | null };
+				response: void;
+			};
+			/**
 			 * Renderer tells the backend when terminal immersive fullscreen owns the
 			 * screen so agent notifications can queue until the user exits.
 			 */


### PR DESCRIPTION
Every dev-3.0 window carried the identical static title, so a multi-window setup showed N indistinguishable entries in the title bar, Mission Control and the Window menu (#1632).

The renderer already computed the right string for `document.title`, but a webview's title does not propagate to the native window in Electrobun. It now reports the route **context** (task title, project name, or the streamer-mode placeholder) over a new `setWindowTitleContext` request; the host composes `<context> · <base>` and calls `BrowserWindow.setTitle`, keeping the base (version + build time) it already owned.

The handler is per window — `createAppWindow` overrides it in each window's own RPC instance over a back-reference to that window, so only the window that reported gets retitled (the shared `handlers` object has no idea which window called, and routing through the focused window would let a background window retitle the foreground one). The remote transport keeps a deliberate no-op: a browser client already owns its tab title. Streamer-mode privacy comes along for free, since the masked context is computed in the same effect.

Decision record: `decisions/2026/09/02/per-window-native-title.md`.

Closes #1632

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2e63ea12-9621-45a2-9773-2e30e1c6d24f) · `dev3://task/2e63ea12-9621-45a2-9773-2e30e1c6d24f`
