### PR TITLE
Show the message subject in the pending-message popover

### DIFF
--- a/change-logs/2026/09/03/fix-queue-popover-shows-subject.md
+++ b/change-logs/2026/09/03/fix-queue-popover-shows-subject.md
@@ -1,0 +1,3 @@
+Short: Message queue shows the subject
+
+The pending-message popover on a task card and in the session bar now leads with the sender's one-line subject instead of the raw message body, with the full body still available on hover. A message queued without a subject keeps showing its body.

--- a/src/mainview/components/ScheduledMessagesChip.tsx
+++ b/src/mainview/components/ScheduledMessagesChip.tsx
@@ -143,7 +143,10 @@ function ScheduledMessagesChip({ task, project, dispatch, placement = "up" }: Sc
 				>
 					{sorted.map((m) => (
 						<div key={m.id} className="px-3 py-1.5">
-							<div className="text-xs text-fg-2 truncate" title={m.text}>{m.text}</div>
+							{/* The sender's own one-liner, which is what the subject exists for: the
+							    head of an agent's body is the envelope naming itself. Body on hover,
+							    and it is the whole line for anything queued without a subject. */}
+							<div className="text-xs text-fg-2 truncate" title={m.text}>{m.subject ?? m.text}</div>
 							<div className="mt-1 flex items-center justify-between gap-2">
 								<span className="text-dense text-fg-3">
 									{formatCountdown(new Date(m.at).getTime() - Date.now())}

--- a/src/mainview/components/__tests__/ScheduledMessagesChip.test.tsx
+++ b/src/mainview/components/__tests__/ScheduledMessagesChip.test.tsx
@@ -67,6 +67,30 @@ describe("ScheduledMessagesChip", () => {
 		expect(mockedApi.request.cancelScheduledMessage).toHaveBeenCalledWith({ taskId: "t1", projectId: "p1", messageId: "m1" });
 	});
 
+	it("leads with the subject and keeps the body on hover", async () => {
+		renderChip(makeTask([
+			{
+				id: "m1",
+				text: "a very long agent body nobody reads in a popover",
+				subject: "PR 1577 merged, main green",
+				at: new Date(Date.now() + 600_000).toISOString(),
+				target: { kind: "agent" },
+			},
+		]));
+		await userEvent.click(screen.getByTestId("task-card-scheduled-message-badge"));
+		const line = screen.getByText("PR 1577 merged, main green");
+		expect(line.getAttribute("title")).toBe("a very long agent body nobody reads in a popover");
+		expect(screen.queryByText("a very long agent body nobody reads in a popover")).toBeNull();
+	});
+
+	it("falls back to the body when nothing carried a subject", async () => {
+		renderChip(makeTask([
+			{ id: "m1", text: "continue", at: new Date(Date.now() + 600_000).toISOString(), target: { kind: "agent" } },
+		]));
+		await userEvent.click(screen.getByTestId("task-card-scheduled-message-badge"));
+		expect(screen.getByText("continue")).toBeTruthy();
+	});
+
 	it("sends the soonest message immediately from the popover", async () => {
 		renderChip(makeTask([
 			{ id: "m1", text: "continue", at: new Date(Date.now() + 600_000).toISOString(), target: { kind: "agent" } },


### PR DESCRIPTION
The pending-message popover (task card + inspector session bar) showed the raw message body. For agent-to-agent traffic that body starts with the sender naming itself, so the line taught the reader nothing — which is exactly why `--subject` exists.

The popover now leads with the subject, keeps the full body on hover (`title`), and falls back to the body for anything queued without one (a human "Send later", or a row from before subjects were required).

The other two surfaces already prefer the subject — the violet arrival toast (`preview: message.subject ?? …` in `announceAgentMessage`) and both agent-traffic rows — so this closes the last one.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a0595826-9bc0-4f4c-a2dc-f4f97f41976c) · `dev3://task/a0595826-9bc0-4f4c-a2dc-f4f97f41976c`
