### PR TITLE
Triple the renderer RPC request timeout so large clones don't time out

### DIFF
--- a/change-logs/2026/09/03/fix-clone-rpc-timeout.md
+++ b/change-logs/2026/09/03/fix-clone-rpc-timeout.md
@@ -1,0 +1,3 @@
+Short: Clones no longer time out
+
+Tripled the renderer RPC request timeout from 2 to 6 minutes so cloning a large repo through the Add Project dialog no longer fails with 'RPC "cloneAndAddProject" timed out'. The timeout is a last-resort backstop — the bridge watchdog still detects a genuinely dead connection in seconds.

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -173,13 +173,19 @@ interface ApiShape {
 	request: RequestProxy;
 }
 
-const RPC_TIMEOUT_MS = 120_000;
+// 6 minutes. Governs every renderer→host request on both transports. It is a
+// last-resort "give up" backstop, not the liveness detector — the bridge
+// watchdog (4s ping) and the browser socket-close handler catch a dead
+// connection in seconds. The one thing that legitimately runs long is a fresh
+// clone (cloneAndAddProject): a large repo on a slow network routinely blew
+// past the old 2-minute cap, so the whole cap is tripled.
+const RPC_TIMEOUT_MS = 360_000;
 
 // Wrap api.request to enrich timeout errors with the method name.
 // Electrobun rejects with a generic "RPC request timed out." — no indication
 // of which method failed.  This proxy catches that and re-throws with context
 // so the unhandled-rejection tracker (analytics.ts) and console show something
-// actionable like: 'RPC "getBranchStatus" timed out (120 000 ms)'.
+// actionable like: 'RPC "getBranchStatus" timed out (360 000 ms)'.
 function enrichRequest(rawRequest: RequestProxy): RequestProxy {
 	return new Proxy(rawRequest, {
 		get(target: RequestProxy, prop: string | symbol, receiver: unknown) {
@@ -205,7 +211,7 @@ function enrichRequest(rawRequest: RequestProxy): RequestProxy {
 // function is never called.
 // Liveness-probe timing for the bridge watchdog. The ping races a short timeout
 // (independent of RPC_TIMEOUT_MS) so a jammed socket is detected in seconds, not
-// the 2-minute request timeout.
+// the full request timeout.
 const PING_TIMEOUT_MS = 4_000;
 const PING_INTERVAL_MS = 30_000;
 const RELOAD_MIN_GAP_MS = 30_000;


### PR DESCRIPTION
## Problem

Cloning a large repo through the Add Project dialog routinely fails with:

```
Error: RPC "cloneAndAddProject" timed out (120000 ms)
```

The clone genuinely takes longer than the 2-minute RPC cap on a large repo or a slow network — the request is still running fine on the host, but the renderer gives up.

## Change

Tripled the renderer RPC request timeout from **2 → 6 minutes** (`RPC_TIMEOUT_MS` in `src/mainview/rpc.ts`, `120_000` → `360_000`).

It is a single global constant governing every renderer→host request on both transports (the Electrobun `maxRequestTime` and the browser WebSocket `setTimeout`). Electrobun's `maxRequestTime` is fixed at RPC-definition time, so there is no clean per-method override — the whole cap moves.

That is safe because the RPC timeout is a **last-resort backstop, not the liveness detector**: the bridge watchdog (4s ping every 30s) and the browser socket-close handler already catch a genuinely dead connection in seconds. Raising the give-up ceiling only affects requests that are legitimately still in flight.

## Test plan

- `bunx vitest run --config vitest.config.ts` for the rpc transport / watchdog / analytics suites — 73/73 pass.
- Clone a large repo via **Add Project → Clone**; it now completes instead of failing at the 2-minute mark.

## How to verify

1. Open **Add Project** (the `+` in the project switcher), pick the **Clone** tab.
2. Paste a large repo URL and clone — expect it to finish, not error with `RPC "cloneAndAddProject" timed out`.
3. A genuinely unreachable host still surfaces quickly via the connection pill / bridge watchdog, not only after the 6-minute cap.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=8b9ea208-d293-4ff7-8e08-08b6dfa18ea4) · `dev3://task/8b9ea208-d293-4ff7-8e08-08b6dfa18ea4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)