### PR TITLE
Fix Codex launch failure from orphaned MCP approval tables

### DIFF
--- a/change-logs/2026/09/03/fix-codex-orphaned-mcp-tools-block.md
+++ b/change-logs/2026/09/03/fix-codex-orphaned-mcp-tools-block.md
@@ -1,0 +1,5 @@
+Short: Codex tasks no longer die on stale MCP approvals
+
+Fixed Codex tasks failing to launch with "invalid transport" when a per-theme dev3 profile still held an approval table for an MCP server that had left the config; dev3 now prunes those orphaned `mcp_servers.*` entries at startup and before every Codex spawn.
+
+Suggested by @OrenZak (h0x91b/dev-3.0#1640)

--- a/decisions/2026/09/03/prune-orphaned-codex-mcp-approvals.md
+++ b/decisions/2026/09/03/prune-orphaned-codex-mcp-approvals.md
@@ -1,0 +1,49 @@
+# Prune orphaned `mcp_servers.*` approvals from dev3's Codex profile files
+
+## Context
+
+dev3 launches Codex with a theme-selected profile (`--profile dev3-dark` / `dev3-light`), whose settings
+live in `~/.codex/<profile>.config.toml` (profile-v2, codex ≥0.134). Codex persists per-tool approval
+decisions into the *active profile file* as `[mcp_servers.<server>.tools.<tool>] approval_mode = "approve"`.
+When that server's body later leaves the effective config, the profile file keeps a table with no
+transport, and Codex refuses to load it at all — the task dies at launch with `invalid transport`
+(issue #1640). Only the theme the user actually ran accumulated the block, so it looked like a
+fresh-task-only regression.
+
+## Investigation
+
+Verified against codex-cli 0.151.0 with an isolated `CODEX_HOME`:
+
+- `[mcp_servers.x.tools.t]` alone in the profile file → `invalid transport`, load aborts.
+- Same table, but `[mcp_servers.x] command = "echo"` present in the *main* `config.toml` → loads fine.
+  The main config's body rescues the profile's approval table.
+- A body table with only `enabled = true` (no `command`/`url`) → still `invalid transport`.
+
+So "has a transport" means the body carries a key other than `tools`/`enabled`, and the check must
+consider the main config, not the profile file alone.
+
+## Decision
+
+`pruneOrphanedMcpServers()` in `src/bun/codex-config.ts` drops every `[mcp_servers.<name>.…]` table
+whose server declares no transport in the profile file *and* is not defined by
+`~/.codex/config.toml` (`codexServersWithTransport()`). It fails closed exactly like
+`pruneCodexProjectEntries`: unparsable input, an unparsable result, or any collateral parse-level
+change returns the original text — a file dev3 mangles is worse than a stale approval.
+
+`ensureCodexProfileFile()` runs it before upserting dev3's settings, and the loop over the managed
+profiles moved into an exported `ensureCodexProfileFiles(homePath)` so `ensureCodexTrust()`
+(`src/bun/agents.ts`) can repair the files before *every* Codex spawn. Startup-only repair would not
+be enough: the orphan appears mid-session, after the app has already patched the file.
+
+## Risks
+
+An MCP server declared through a key we do not recognize as a transport would be pruned along with its
+approvals. Mitigated by treating *any* key except `tools`/`enabled` as a transport, so only genuinely
+body-less entries are targets, and by the fail-closed re-parse comparison.
+
+## Alternatives considered
+
+Rewriting the profile file from scratch on every launch (loses user edits and Codex's own state);
+never letting Codex persist approvals into a dev3 profile (not something dev3 controls); leaving the
+main `config.toml` orphans alone was deliberate — that file is the user's, and dev3 does not write
+`mcp_servers` there.

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
 	ensureCodexConfig,
+	codexServersWithTransport,
 	ensureCodexProfileFile,
 	getCodexSyntaxForVersion,
+	pruneOrphanedMcpServers,
 	parseCodexVersion,
 	pickCodexProfileLaunchFlag,
 	tomlBasicString,
@@ -634,6 +636,98 @@ sandbox_mode = "workspace-write"
 			expect(result.match(/^web_search\s*=/gm)).toHaveLength(1);
 			expect(result).toContain('web_search = "live"');
 			expect(result).not.toContain('web_search = "disabled"');
+		});
+
+		it("drops an orphaned approval table that would break the launch (issue #1640)", () => {
+			const existing = `web_search = "live"
+
+[mcp_servers."mcp-s".tools.search]
+approval_mode = "approve"
+`;
+			const result = ensureCodexProfileFile(existing, { web_search: '"live"' });
+			expect(result).not.toContain("mcp_servers");
+			expect(result).toContain('web_search = "live"');
+		});
+
+		it("keeps an approval table whose server the main config defines", () => {
+			const existing = `[mcp_servers.mcp-s.tools.search]
+approval_mode = "approve"
+`;
+			const result = ensureCodexProfileFile(existing, {}, new Set(["mcp-s"]));
+			expect(result).toContain("[mcp_servers.mcp-s.tools.search]");
+		});
+	});
+
+	describe("pruneOrphanedMcpServers", () => {
+		it("removes a server whose body carries no transport", () => {
+			const content = `[mcp_servers.x]
+enabled = true
+
+[mcp_servers.x.tools.t]
+approval_mode = "approve"
+`;
+			expect(pruneOrphanedMcpServers(content)).not.toContain("mcp_servers");
+		});
+
+		it("keeps a stdio server and its approvals", () => {
+			const content = `[mcp_servers.x]
+command = "echo"
+
+[mcp_servers.x.tools.t]
+approval_mode = "approve"
+`;
+			expect(pruneOrphanedMcpServers(content)).toBe(content);
+		});
+
+		it("keeps an http server declared by url", () => {
+			const content = `[mcp_servers.x]
+url = "https://example.com/mcp"
+`;
+			expect(pruneOrphanedMcpServers(content)).toBe(content);
+		});
+
+		it("prunes only the orphan, leaving neighbours untouched", () => {
+			const content = `model = "gpt-5.4"
+
+[mcp_servers.good]
+command = "echo"
+
+[mcp_servers.gone.tools.t]
+approval_mode = "approve"
+
+[tui]
+theme = "dark"
+`;
+			const result = pruneOrphanedMcpServers(content);
+			expect(result).toContain("[mcp_servers.good]");
+			expect(result).not.toContain("gone");
+			expect(result).toContain('model = "gpt-5.4"');
+			expect(result).toContain("[tui]");
+		});
+
+		it("leaves unparsable content alone", () => {
+			const content = "this is = = not toml\n";
+			expect(pruneOrphanedMcpServers(content)).toBe(content);
+		});
+	});
+
+	describe("codexServersWithTransport", () => {
+		it("reports only servers that declare a transport", () => {
+			const content = `[mcp_servers.a]
+command = "echo"
+
+[mcp_servers.b]
+url = "https://example.com/mcp"
+
+[mcp_servers.c.tools.t]
+approval_mode = "approve"
+`;
+			expect([...codexServersWithTransport(content)].sort()).toEqual(["a", "b"]);
+		});
+
+		it("returns an empty set for null or unparsable content", () => {
+			expect(codexServersWithTransport(null).size).toBe(0);
+			expect(codexServersWithTransport("= =\n").size).toBe(0);
 		});
 	});
 });

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -7,7 +7,7 @@ import { DEFAULT_AGENTS, DEPRECATED_DEFAULT_CONFIG_REMAP } from "../shared/types
 export { skillInvocationPrefix } from "../shared/types";
 import { buildProviderEnv, getProviderDefinition, providerOmitsModelFlag, providerPinnedModel } from "../shared/llm-provider";
 import { createLogger } from "./logger";
-import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, type CodexProfileLaunchFlag } from "./codex-config";
+import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, ensureCodexProfileFiles, getCodexSyntaxForVersion, type CodexProfileLaunchFlag } from "./codex-config";
 import { agentBinaryPathOverride } from "./executable";
 import { DEV3_HOME } from "./paths";
 // Writer and pruner share one path constant: whatever registers an entry must
@@ -1027,15 +1027,19 @@ export async function ensureCodexTrust(dirPath: string): Promise<void> {
 
 		if (content != null) backupUnparsableCodexConfig(CODEX_CONFIG, content);
 
+		const codexVersion = getCodexVersionCached();
 		const updated = ensureCodexConfig(content, worktreesPath, socketsPath, [worktreesPath, resolved], {
-			codexVersion: getCodexVersionCached(),
+			codexVersion,
 		});
-		if (updated === content) {
-			return;
+		if (updated !== content) {
+			writeFileSync(CODEX_CONFIG, updated, "utf-8");
+			log.info("Registered worktree as trusted in ~/.codex/config.toml", { path: resolved });
 		}
 
-		writeFileSync(CODEX_CONFIG, updated, "utf-8");
-		log.info("Registered worktree as trusted in ~/.codex/config.toml", { path: resolved });
+		// Repairs the orphaned `[mcp_servers.*.tools]` tables Codex writes into the
+		// active profile during a session — they make the NEXT launch fail with
+		// "invalid transport" (issue #1640).
+		if (getCodexSyntaxForVersion(codexVersion).profileV2) ensureCodexProfileFiles(home);
 	} catch (err) {
 		// Non-fatal — worst case the user sees the trust dialog
 		log.warn("Failed to register Codex worktree trust", { error: String(err) });

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -358,6 +358,18 @@ function stableStringify(value: unknown): string {
  * thing raw-text editing exists to avoid.
  */
 function removeProjectBlocks(content: string, targets: Set<string>): string {
+	return removeTableBlocks(content, (line) => {
+		const projectPath = projectPathFromHeader(line);
+		return projectPath != null && targets.has(projectPath);
+	});
+}
+
+/**
+ * Drop every table whose header the predicate selects, along with its
+ * sub-tables' lines. Shared by the `[projects."…"]` and `[mcp_servers.…]`
+ * pruners; see `removeProjectBlocks` for why trailing comments are held back.
+ */
+function removeTableBlocks(content: string, isTarget: (headerLine: string) => boolean): string {
 	const out: string[] = [];
 	let removing = false;
 	let trailingBlanks = 0;
@@ -373,8 +385,7 @@ function removeProjectBlocks(content: string, targets: Set<string>): string {
 		const trimmed = line.trim();
 		const isHeader = trimmed.startsWith("[") && trimmed.endsWith("]");
 		if (isHeader) {
-			const projectPath = projectPathFromHeader(line);
-			if (projectPath != null && targets.has(projectPath)) {
+			if (isTarget(line)) {
 				if (removing) {
 					pending = []; // between two removed blocks — nothing to re-attach to
 				} else {
@@ -464,6 +475,104 @@ export function pruneCodexProjectEntries(
 	}
 
 	log.info("Pruned dev3 trust entries from Codex config.toml", { entries: targets.size });
+	return stripped;
+}
+
+/**
+ * Keys that describe how to reach an MCP server. Codex accepts a stdio server
+ * (`command`) or a streamable-HTTP one (`url`); everything else in the body —
+ * `tools`, `enabled` — is metadata and does NOT satisfy its transport check.
+ * Anything unrecognized counts as a transport so an unknown-but-valid server
+ * definition is never deleted.
+ */
+const MCP_NON_TRANSPORT_KEYS = new Set(["tools", "enabled"]);
+
+interface CodexMcpConfig {
+	mcp_servers?: Record<string, Record<string, unknown> | undefined>;
+}
+
+/** Server names whose body in this TOML text declares a transport. */
+export function codexServersWithTransport(content: string | null): Set<string> {
+	const names = new Set<string>();
+	if (content == null) return names;
+	let parsed: CodexMcpConfig;
+	try {
+		parsed = load(content) as CodexMcpConfig;
+	} catch {
+		return names;
+	}
+	for (const [name, body] of Object.entries(parsed.mcp_servers ?? {})) {
+		if (body != null && Object.keys(body).some((key) => !MCP_NON_TRANSPORT_KEYS.has(key))) {
+			names.add(name);
+		}
+	}
+	return names;
+}
+
+/** The server name an `[mcp_servers.…]` header (or a sub-table of one) names. */
+function mcpServerNameFromHeader(line: string): string | null {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[[")) return null;
+	const segments = splitTomlKeyPath(trimmed.slice(1, -1));
+	if (segments == null || segments.length < 2 || segments[0] !== "mcp_servers") return null;
+	return segments[1];
+}
+
+/**
+ * Drop `[mcp_servers.<name>.…]` tables that carry no transport anywhere in the
+ * effective config. Codex persists per-tool approvals into the ACTIVE profile
+ * file as `[mcp_servers.<name>.tools.<tool>]`; when the server's body later
+ * disappears, that leftover table has no `command`/`url` and Codex refuses to
+ * load the file at all ("invalid transport"), so the task dies at launch —
+ * theme-dependent, because only the profile the user ran accumulated it
+ * (issue #1640). `definedElsewhere` carries the servers the main `config.toml`
+ * defines: those bodies rescue the tools table, so it stays.
+ *
+ * Fails closed exactly like `pruneCodexProjectEntries`: unparsable input, an
+ * unparsable result, or any collateral change returns the original text.
+ */
+export function pruneOrphanedMcpServers(
+	content: string,
+	definedElsewhere: ReadonlySet<string> = new Set(),
+): string {
+	let parsed: CodexMcpConfig;
+	try {
+		parsed = load(content) as CodexMcpConfig;
+	} catch {
+		return content;
+	}
+
+	const withTransport = codexServersWithTransport(content);
+	const targets = new Set(
+		Object.keys(parsed.mcp_servers ?? {}).filter(
+			(name) => !withTransport.has(name) && !definedElsewhere.has(name),
+		),
+	);
+	if (targets.size === 0) return content;
+
+	const stripped = removeTableBlocks(content, (line) => {
+		const name = mcpServerNameFromHeader(line);
+		return name != null && targets.has(name);
+	});
+
+	let after: CodexMcpConfig;
+	try {
+		after = load(stripped) as CodexMcpConfig;
+	} catch {
+		log.warn("Pruning orphaned Codex MCP entries would break the file, leaving it alone");
+		return content;
+	}
+
+	const expected = { ...parsed, mcp_servers: { ...(parsed.mcp_servers ?? {}) } };
+	for (const target of targets) delete expected.mcp_servers[target];
+	if (Object.keys(expected.mcp_servers).length === 0) delete (expected as CodexMcpConfig).mcp_servers;
+
+	if (stableStringify(after) !== stableStringify(expected)) {
+		log.warn("Pruning orphaned Codex MCP entries changed unrelated config, leaving it alone");
+		return content;
+	}
+
+	log.info("Pruned orphaned Codex MCP server entries", { servers: [...targets].join(", ") });
 	return stripped;
 }
 
@@ -1398,13 +1507,16 @@ function ensureProfileSettings(
 /**
  * Patch a per-profile Codex config file (profile-v2 style: one file per
  * profile under `~/.codex/<name>.config.toml`). Upserts root-level key/value
- * pairs while preserving any other content the user may have added.
+ * pairs while preserving any other content the user may have added, and drops
+ * the orphaned `[mcp_servers.*.tools]` tables Codex leaves behind (issue #1640).
  */
 export function ensureCodexProfileFile(
 	content: string | null,
 	settings: Record<string, string>,
+	definedElsewhere: ReadonlySet<string> = new Set(),
 ): string {
 	let result = content ?? "";
+	if (result !== "") result = pruneOrphanedMcpServers(result, definedElsewhere);
 	for (const [key, value] of Object.entries(settings)) {
 		result = upsertRootLine(result, key, value);
 	}
@@ -1450,6 +1562,25 @@ export function ensureCodexConfigFile(homePath: string): void {
 	}
 
 	if (!syntax.profileV2) return;
+	ensureCodexProfileFiles(homePath);
+}
+
+/**
+ * Write the dev3 settings into every managed per-profile file and repair the
+ * orphaned MCP tables Codex accumulates there. Runs at startup and again before
+ * every Codex spawn (`ensureCodexTrust`): the orphan appears DURING a session,
+ * when the user approves a tool and the server later leaves the config, so a
+ * startup-only repair would still let the next launch die (issue #1640).
+ */
+export function ensureCodexProfileFiles(homePath: string): void {
+	let mainConfigServers: ReadonlySet<string> = new Set();
+	try {
+		mainConfigServers = codexServersWithTransport(
+			readFileSync(join(homePath, ".codex", "config.toml"), "utf-8"),
+		);
+	} catch {
+		// No main config (or unreadable) — nothing defines a server elsewhere.
+	}
 
 	for (const profileName of MANAGED_DEV3_PROFILES) {
 		const profilePath = join(homePath, ".codex", `${profileName}.config.toml`);
@@ -1461,7 +1592,7 @@ export function ensureCodexConfigFile(homePath: string): void {
 				// Per-profile file doesn't exist yet — will create.
 			}
 
-			const updated = ensureCodexProfileFile(existing, DEV3_PROFILE_SETTINGS);
+			const updated = ensureCodexProfileFile(existing, DEV3_PROFILE_SETTINGS, mainConfigServers);
 			if (updated !== existing) {
 				writeFileSync(profilePath, updated, "utf-8");
 				log.info("Codex per-profile config patched", { path: profilePath });


### PR DESCRIPTION
Fixes #1640.

A Codex task died at launch with `invalid transport in mcp_servers.<server>` whenever the theme's profile file (`~/.codex/dev3-<theme>.config.toml`) still held a `[mcp_servers.<server>.tools.<tool>]` approval table for a server whose body had since left the config. Codex writes those approvals into the active profile itself, so the failure was theme-dependent and looked like a fresh-task regression.

`pruneOrphanedMcpServers()` (`src/bun/codex-config.ts`) now drops any `mcp_servers.<name>` namespace that declares no transport in the profile file and is not defined by the main `config.toml` — a server defined there rescues the approval table, verified against codex-cli 0.151.0. It fails closed like `pruneCodexProjectEntries`: unparsable input, unparsable result, or any collateral parse-level change leaves the file untouched.

The managed-profile loop moved into an exported `ensureCodexProfileFiles()`, called at startup and from `ensureCodexTrust()` before every Codex spawn — the orphan appears mid-session, so a startup-only repair would still let the next launch die.

Decision record: `decisions/2026/09/03/prune-orphaned-codex-mcp-approvals.md`

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4d8cadc0-d456-412d-b0f1-e5062d3137bf) · `dev3://task/4d8cadc0-d456-412d-b0f1-e5062d3137bf`
