### PR TITLE
Revive the pane-exit e2e suite and put it in the CI gate

### DIFF
--- a/change-logs/2026/09/04/fix-pane-exit-e2e-revived-and-gated.md
+++ b/change-logs/2026/09/04/fix-pane-exit-e2e-revived-and-gated.md
@@ -1,0 +1,1 @@
+The `test:pane-e2e` pane-exit reconciliation suite died at import time because its preload mocked `agents.ts` and `data.ts` with hand-listed exports that had since fallen behind the real modules. The mocks now spread the real module and override only what the test needs, and the script joined the live terminal e2e CI gate so it can never rot unnoticed again.

--- a/decisions/2026/09/04/spread-real-modules-in-bun-preload-mocks.md
+++ b/decisions/2026/09/04/spread-real-modules-in-bun-preload-mocks.md
@@ -1,0 +1,44 @@
+# Spread the real module in bun preload mocks instead of listing exports
+
+## Context
+
+`bun run test:pane-e2e` had been dead on `main` since at least 2026-08-10. It failed with
+`SyntaxError: Export named 'findConfig' not found in module src/bun/agents.ts` — an
+import-time death, so zero assertions ran and any count of failing tests read as zero. The
+script was also absent from `TERMINAL_E2E_SCRIPTS`, so CI never ran it: broken and unrun at
+the same time, which looks like coverage and provides none.
+
+## Investigation
+
+The preload (`src/bun/__tests__/pane-exit-e2e-preload.ts`) replaced whole modules with
+object literals enumerating their exports by name. `agent-hooks-refresh.ts` gained
+`import { findConfig } from "./agents"` in commit `5fdd4c04` (2026-08-10, PR #1327) and the
+mock was never updated; behind it `data.ts` had the same rot on `newTaskTerminalBackend`.
+Fixing one export only surfaced the next.
+
+## Decision
+
+Each `mock.module(...)` in that preload now spreads the real module and overrides only the
+handful of functions the test actually needs — `const realAgents = await import("../agents")`,
+then `{ ...realAgents, resolveCommandForProject: ... }`. That makes the mock structurally
+complete forever: a new export in the real module is simply present. The `electrobun/bun`
+mock stays enumerated, since there is no real module to spread here. `test:pane-e2e` was
+added to `TERMINAL_E2E_SCRIPTS` (`src/bun/terminal-e2e-guard.ts`), with its
+`dev3-e2e-` socket/temp naming added to `OUR_PROCESS_PATTERNS` and `OUR_TEMP_PREFIXES`.
+
+## Risks
+
+Spreading gives un-overridden exports their real implementations, so a code path the test
+does not exercise today could start touching disk or spawning processes. Contained by
+`configureTestIsolation("pane-e2e")`, which already redirects HOME/TMPDIR to a throwaway
+root, and by the terminal e2e gate's own orphan and temp-leak checks.
+
+## Alternatives considered
+
+Add the missing export to the literal — rejected: it fixes this instance and leaves the
+trap. Delete the suite — rejected: it is the only coverage of pane-exit reconciliation
+through the real `launchTaskPty` flow against a live tmux server; `task-panes.test.ts`
+covers `handlePaneExited` only at unit level. A repo-wide guard asserting mocks enumerate
+every export — rejected: this is the only `mock.module` preload in the repo (all other
+mocking goes through vitest), so the spread pattern removes the class outright and a guard
+would police a population of one.

--- a/src/bun/__tests__/pane-exit-e2e-preload.ts
+++ b/src/bun/__tests__/pane-exit-e2e-preload.ts
@@ -16,7 +16,9 @@ mock.module("electrobun/bun", () => ({
 (globalThis as any).__e2eTask = null as any;
 (globalThis as any).__e2eProject = null as any;
 
+const realData = await import("../data");
 mock.module("../data", () => ({
+	...realData,
 	updateTask: async (_proj: any, _taskId: string, updates: any) => {
 		if (updates.sessionState) (globalThis as any).__e2eSessionState = updates.sessionState;
 		return { ...(globalThis as any).__e2eTask, ...updates };
@@ -29,7 +31,13 @@ mock.module("../data", () => ({
 	loadTasks: async () => [],
 }));
 
+// Spread the REAL module so the mock can never go stale: an enumerated export list
+// silently drops a name the moment agents.ts grows one, and the whole script then dies
+// at import time with zero tests run (that is exactly how this suite rotted).
+const realAgents = await import("../agents");
+
 mock.module("../agents", () => ({
+	...realAgents,
 	resolveCommandForProject: async () => ({
 		command: "exec sleep 999",
 		extraEnv: {},
@@ -51,24 +59,32 @@ mock.module("../agents", () => ({
 	buildResumeCommand: () => null,
 }));
 
+const realAgentHooks = await import("../agent-hooks");
 mock.module("../agent-hooks", () => ({
+	...realAgentHooks,
 	setupAgentHooks: () => {},
 }));
 
+const realSettings = await import("../settings");
 mock.module("../settings", () => ({
+	...realSettings,
 	loadSettings: async () => ({}),
 	loadSettingsSync: () => ({}),
 	recordFavoriteUsages: async () => {},
 	saveSettings: async () => {},
 }));
 
+const realPortPool = await import("../port-pool");
 mock.module("../port-pool", () => ({
+	...realPortPool,
 	allocatePorts: async () => [],
 	getPortAssignments: () => [],
 	buildPortEnv: () => ({}),
 }));
 
+const realPortScanner = await import("../port-scanner");
 mock.module("../port-scanner", () => ({
+	...realPortScanner,
 	buildProcessTree: async () => new Map(),
 	clearDevServerSummaryForTask: () => {},
 	schedulePortScanSoon: () => {},
@@ -84,11 +100,15 @@ mock.module("../port-scanner", () => ({
 	waitForPortsFree: async () => [],
 }));
 
+const realResourceMonitor = await import("../resource-monitor");
 mock.module("../resource-monitor", () => ({
+	...realResourceMonitor,
 	getResourceUsage: () => undefined,
 }));
 
+const realRepoConfig = await import("../repo-config");
 mock.module("../repo-config", () => ({
+	...realRepoConfig,
 	resolveProjectConfig: (_proj: any) => _proj,
 	resolveOperationalProjectConfig: (_proj: any) => _proj,
 	migrateProjectConfig: () => {},

--- a/src/bun/__tests__/terminal-e2e-guard.test.ts
+++ b/src/bun/__tests__/terminal-e2e-guard.test.ts
@@ -55,6 +55,7 @@ describe("the gated script list", () => {
 			"native-owner-routing-e2e",
 			"native-multipane-e2e",
 			"native-message-e2e",
+			"pane-e2e",
 		]);
 	});
 

--- a/src/bun/terminal-e2e-guard.ts
+++ b/src/bun/terminal-e2e-guard.ts
@@ -30,6 +30,7 @@ export const TERMINAL_E2E_SCRIPTS: readonly E2eScript[] = [
 	{ name: "native-owner-routing-e2e", tier: "fast", proves: "cross-process routing never invokes tmux" },
 	{ name: "native-multipane-e2e", tier: "fast", proves: "multi-pane lifecycle tears down every owned process tree" },
 	{ name: "native-message-e2e", tier: "fast", proves: "CLI message delivery leaves the tmux surface byte-identical" },
+	{ name: "pane-e2e", tier: "fast", proves: "pane-exit reconciliation through the real launchTaskPty flow on a live tmux server" },
 ];
 
 /**
@@ -43,6 +44,7 @@ export const OUR_PROCESS_PATTERNS: readonly RegExp[] = [
 	/dev3-pane-input(-owner)?-e2e-/,
 	/dev3-native-registry-e2e-/,
 	/dev3-native-message-e2e-/,
+	/dev3-e2e-/,
 	/dev3-multipane-e2e-/,
 	/dev3-live-/,
 	/[/\\]d3or-/,
@@ -89,6 +91,7 @@ export const OUR_TEMP_PREFIXES: readonly string[] = [
 	"dev3-pane-input-owner-e2e-",
 	"dev3-native-registry-e2e-",
 	"dev3-native-message-e2e-",
+	"dev3-e2e-",
 	"dev3-multipane-e2e-",
 	"d3or-",
 ];


### PR DESCRIPTION
Hi, this is Claude (the AI assistant working on this branch).

`bun run test:pane-e2e` had been dead on `main` since 2026-08-10 and CI never noticed, because the script is not in `TERMINAL_E2E_SCRIPTS`. It failed at import time — `SyntaxError: Export named 'findConfig' not found in module src/bun/agents.ts` — so zero assertions ran and a count of failing tests read as zero.

Cause: the preload replaced whole modules with object literals listing their exports by name. `agent-hooks-refresh.ts` gained `findConfig` in #1327 and the mock was never updated; behind it `data.ts` had the same rot on `newTaskTerminalBackend`.

- Each `mock.module(...)` in `pane-exit-e2e-preload.ts` now spreads the real module and overrides only what the test needs, so a new export can never break it again.
- `test:pane-e2e` joins `TERMINAL_E2E_SCRIPTS`, with its `dev3-e2e-` socket/temp naming added to the orphan and temp-leak patterns.
- Swept every other `package.json` script absent from CI and ran them: all pass. `test:capture-cost-e2e` is a long benchmark by design, not a failure. One rotted script, so no repo-wide guard is proposed — this is the only `mock.module` preload in the repo, and the spread pattern removes the trap class outright.

Local: whole terminal e2e gate green (8 scripts, 43.5 s, no orphans), `bun run lint` clean, `bun run test` 13 724 passing.

Browser QA does not apply — no visual surface. No tips: considered, the gate is internal tooling.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=9532eb7a-d419-41d0-82f3-f503b22b21d4) · `dev3://task/9532eb7a-d419-41d0-82f3-f503b22b21d4`
