### PR TITLE
Drop quotes around the agent message toast preview

### DIFF
--- a/change-logs/2026/09/04/fix-drop-agent-toast-quotes.md
+++ b/change-logs/2026/09/04/fix-drop-agent-toast-quotes.md
@@ -1,0 +1,3 @@
+Short: Agent toast preview without quotes
+
+The agent-message toast no longer wraps the message preview in typographic quotes — the preview reads as plain text in all three locales.

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1226,7 +1226,7 @@ describe("App keyboard shortcuts", () => {
 
 			expect(screen.getByText("#7 Coordinator → #42 Receiver")).toBeInTheDocument();
 			await userEvent.click(
-				await screen.findByRole("button", { name: "#7 Coordinator → #42 Receiver — “check the payload”" }),
+				await screen.findByRole("button", { name: "#7 Coordinator → #42 Receiver — check the payload" }),
 			);
 			await waitFor(() => {
 				expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-receiver");

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -87,7 +87,7 @@ const common = {
 	"toast.source.update": "Update",
 	"toast.source.dashboard": "Dashboard",
 	"toast.source.terminal": "Terminal",
-	"toast.agentMessage": "“{preview}”",
+	"toast.agentMessage": "{preview}",
 	"toast.dismiss": "Dismiss",
 	"toast.clearAll": "Clear all",
 	"common.close": "Close",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -87,7 +87,7 @@ const common = {
 	"toast.source.update": "Actualización",
 	"toast.source.dashboard": "Panel",
 	"toast.source.terminal": "Terminal",
-	"toast.agentMessage": "«{preview}»",
+	"toast.agentMessage": "{preview}",
 	"toast.dismiss": "Descartar",
 	"toast.clearAll": "Descartar todo",
 	"common.close": "Cerrar",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -89,7 +89,7 @@ const common = {
 	"toast.source.update": "Обновление",
 	"toast.source.dashboard": "Дашборд",
 	"toast.source.terminal": "Терминал",
-	"toast.agentMessage": "«{preview}»",
+	"toast.agentMessage": "{preview}",
 	"toast.dismiss": "Закрыть",
 	"toast.clearAll": "Убрать все",
 	"common.close": "Закрыть",


### PR DESCRIPTION
The agent-message toast wrapped the message preview in typographic quotes (`“…”` in English, `«…»` in Russian and Spanish). Removed them from the `toast.agentMessage` key in all three locales; the preview now renders as plain text. Updated the one test expectation that asserted the quoted button label.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=037c0168-3c63-46f7-b220-99ed72428671) · `dev3://task/037c0168-3c63-46f7-b220-99ed72428671`