### PR TITLE
Push every desktop event to remote clients, not only windows

### DIFF
--- a/change-logs/2026/09/04/fix-remote-clients-miss-desktop-pushes.md
+++ b/change-logs/2026/09/04/fix-remote-clients-miss-desktop-pushes.md
@@ -1,0 +1,3 @@
+Short: Remote terminals notice when they die
+
+A terminal that exited kept looking alive in a browser or on a phone: the desktop app announced the death to its own windows only, so the remote view sat on a bare `[exited]` with no "Terminal session ended" screen until a reload. Nine events were affected in all — terminal deaths, port and dev-server updates, resource and rate-limit readings, and update prompts — and every push in the desktop entry now goes to attached browsers as well, guarded by a test so a new one cannot forget.

--- a/decisions/2026/09/04/push-every-desktop-event-to-remote-clients.md
+++ b/decisions/2026/09/04/push-every-desktop-event-to-remote-clients.md
@@ -1,0 +1,51 @@
+# One push helper in the desktop entry, so remote clients stop missing events
+
+## Context
+
+The desktop process serves two audiences at once: its own Electrobun windows, and whatever browser is
+attached over the remote-access server (a phone, a laptop on the LAN, a Cloudflare tunnel). `dev3 remote`
+(`src/bun/headless-entry.ts`) has no windows, so it pushes everything with `pushToBrowserClients`. The
+desktop entry (`src/bun/index.ts`) wired the same hooks by hand with `broadcastToAllWindows`, and only some
+of those call sites also pushed to browsers.
+
+## Investigation
+
+Reproduced on a real remote client (seq 1745): a QA-scoped board served by the desktop host, driven in a
+browser. Killing the task's tmux session left the browser showing a bare `[exited]` in an empty terminal
+canvas, unchanged 53 s later — no "Terminal session ended" card, no Resume button, and nothing that
+self-corrects (the "fallback timeout for cases where ptyDied doesn't fire" in `TaskTerminal.tsx` is an empty
+`setTimeout`). Dispatching `rpc:ptyDied` by hand in that same tab rendered the full session-ended card
+immediately, which proves the renderer half was never the problem — only the push was missing.
+
+Grepping every call site showed it was not one event but a seam: four wiring blocks plus the updater pushed
+to windows alone — `ptyDied`, `projectPtyDied`, `portsUpdated`, `devServerUpdated`, `resourceUsageUpdated`,
+`systemMemoryUpdated`, `agentRateLimitsUpdated`, `updateAvailable`, `updateDownloadProgress`. Headless sends
+every one of them to browsers, so a phone attached to the desktop app was strictly worse off than the same
+phone attached to `dev3 remote`.
+
+## Decision
+
+`src/bun/push-targets.ts` exports `pushEverywhere(name, payload)`, which calls `broadcastToAllWindows` and
+`pushToBrowserClients` in turn. Every push in `src/bun/index.ts` goes through it; the entry no longer imports
+either single-audience helper. The updater's two events are included deliberately, for parity with headless.
+
+`src/bun/__tests__/push-targets-wiring.test.ts` fails if a bare `broadcastToAllWindows` or
+`pushToBrowserClients` call reappears in `index.ts`, in either direction, and
+`src/bun/__tests__/push-targets.test.ts` proves the helper reaches both targets. `index.ts` cannot be
+imported by a test — Electrobun APIs, top-level await, it opens a window — so the chain is deliberately
+proved in those two halves rather than end to end.
+
+## Risks
+
+Remote browsers now receive events they never saw: resource-usage and rate-limit ticks add WebSocket traffic
+to a phone (small payloads on an existing socket, and the same traffic headless has always sent), and
+`updateAvailable` can now prompt a remote viewer about a desktop-side restart. `sendToFocusedWindow` stays as
+it is — it answers a click in one particular window (the update-check outcome) and has no remote counterpart.
+
+## Alternatives considered
+
+Fixing `ptyDied` alone: smallest diff, but it leaves six events broken and nothing stops the next hook from
+repeating the mistake. Routing the hooks through the already-wired `getPushMessage()`: no new module, but it
+adds a debug log per resource tick and drags init order into it. Unifying the desktop and headless wiring
+into one shared module: kills the drift at the root, but it is a large diff across the two riskiest boot
+files and changes headless behaviour nobody reported a problem with.

--- a/src/bun/__tests__/push-targets-wiring.test.ts
+++ b/src/bun/__tests__/push-targets-wiring.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The desktop entry must not push to one audience only.
+ *
+ * `src/bun/index.ts` serves Electrobun windows AND whatever browser is attached
+ * over the remote-access server, and its hooks were wired by hand: four of them
+ * broadcast to windows alone, so eight events never left the desktop. The one
+ * users saw was `ptyDied` — a remote phone kept rendering a terminal that had
+ * exited, with no "session ended" screen and no way back short of a reload.
+ *
+ * `index.ts` cannot be imported by a test (Electrobun APIs, top-level await, it
+ * opens a window), so the chain is proved in two halves: `push-targets.test.ts`
+ * proves `pushEverywhere` reaches both audiences, and this file proves every push
+ * in `index.ts` goes through it. Neither half is worth much without the other.
+ *
+ * `sendToFocusedWindow` stays allowed on purpose: it answers a click in one
+ * specific window (the update-check outcome), which has no remote counterpart.
+ *
+ * See decisions/2026/09/04/push-every-desktop-event-to-remote-clients.md.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const ENTRY_PATH = fileURLToPath(new URL("../index.ts", import.meta.url));
+const ENTRY = readFileSync(ENTRY_PATH, "utf8");
+
+/** Lines carrying a call to one of the single-audience push helpers. */
+function offendingLines(helper: string): string[] {
+	return ENTRY.split("\n")
+		.map((line, i) => ({ line: line.trim(), n: i + 1 }))
+		.filter(({ line }) => line.includes(`${helper}(`))
+		.map(({ line, n }) => `index.ts:${n}  ${line}`);
+}
+
+describe("desktop entry push wiring", () => {
+	it("never broadcasts to windows alone", () => {
+		const offenders = offendingLines("broadcastToAllWindows");
+		expect(
+			offenders,
+			"Cause: `broadcastToAllWindows` reaches Electrobun windows only, so a browser attached over " +
+				"remote access never hears the event — that is how a dead terminal kept looking alive on a phone.\n" +
+				"Fix: call `pushEverywhere` from ./push-targets instead.\n" +
+				`Offending:\n${offenders.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("never pushes to browsers alone", () => {
+		const offenders = offendingLines("pushToBrowserClients");
+		expect(
+			offenders,
+			"Cause: `pushToBrowserClients` skips the desktop windows, which is the same bug pointed the other way.\n" +
+				"Fix: call `pushEverywhere` from ./push-targets instead.\n" +
+				`Offending:\n${offenders.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("imports neither single-audience helper", () => {
+		const imports = ENTRY.split("\n").filter(
+			(line) =>
+				line.startsWith("import") &&
+				(line.includes("broadcastToAllWindows") || line.includes("pushToBrowserClients")),
+		);
+		expect(imports, `Fix: import { pushEverywhere } from "./push-targets" instead.\n${imports.join("\n")}`).toEqual([]);
+	});
+
+	it("still routes the events that were lost, by name", () => {
+		// The four literal-named pushes from the four blocks that were window-only.
+		// The pollers hand their own `(name, payload)` through, so the absence guards
+		// above are what cover those.
+		for (const event of ["ptyDied", "projectPtyDied", "updateAvailable", "updateDownloadProgress"]) {
+			expect(ENTRY, `${event} must be published through pushEverywhere`).toContain(`pushEverywhere("${event}"`);
+		}
+	});
+});

--- a/src/bun/__tests__/push-targets.test.ts
+++ b/src/bun/__tests__/push-targets.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `pushEverywhere` is the only push the desktop entry is allowed to use, because
+ * it is the only one that reaches both audiences: the Electrobun windows and any
+ * browser attached over the remote-access server. Reaching one and not the other
+ * is exactly the bug this module exists to close — a remote client kept rendering
+ * a terminal the app already knew was dead.
+ *
+ * The companion guard, `push-targets-wiring.test.ts`, asserts that every call
+ * site in `src/bun/index.ts` actually goes through here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const broadcastToAllWindows = vi.fn();
+const pushToBrowserClients = vi.fn();
+
+vi.mock("../window-manager", () => ({ broadcastToAllWindows }));
+vi.mock("../remote-access-server", () => ({ pushToBrowserClients }));
+
+const { pushEverywhere } = await import("../push-targets");
+
+describe("pushEverywhere", () => {
+	beforeEach(() => {
+		broadcastToAllWindows.mockClear();
+		pushToBrowserClients.mockClear();
+	});
+
+	it("delivers a terminal death to desktop windows AND remote browsers", () => {
+		pushEverywhere("ptyDied", { taskId: "task-1" });
+
+		expect(broadcastToAllWindows).toHaveBeenCalledWith("ptyDied", { taskId: "task-1" });
+		expect(pushToBrowserClients).toHaveBeenCalledWith("ptyDied", { taskId: "task-1" });
+	});
+
+	it("passes name and payload through untouched, whatever the event", () => {
+		const payload = { taskId: "task-2", ports: [3000, 5173] };
+		pushEverywhere("portsUpdated", payload);
+
+		expect(broadcastToAllWindows).toHaveBeenCalledWith("portsUpdated", payload);
+		expect(pushToBrowserClients).toHaveBeenCalledWith("portsUpdated", payload);
+		// Same object, not a copy: the renderer contract is the payload as built.
+		expect(broadcastToAllWindows.mock.calls[0][1]).toBe(payload);
+		expect(pushToBrowserClients.mock.calls[0][1]).toBe(payload);
+	});
+
+	it("pushes exactly once per target per call", () => {
+		pushEverywhere("projectPtyDied", { projectId: "p1" });
+
+		expect(broadcastToAllWindows).toHaveBeenCalledTimes(1);
+		expect(pushToBrowserClients).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -39,7 +39,7 @@ import { resolveUserHome } from "../shared/user-home";
 import { normalizeEnvPath } from "../shared/env-path";
 import { applyFullShellEnvToProcess, getShellRcFiles, getUserShell, resolveShellEnv } from "./shell-env";
 import { startSocketServer, stopSocketServer } from "./cli-socket-server";
-import { startRemoteAccessServerGuarded, setRemoteAccessStatusHook, pushToBrowserClients } from "./remote-access-server";
+import { startRemoteAccessServerGuarded, setRemoteAccessStatusHook } from "./remote-access-server";
 import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
 import { installAgentSkills } from "./agent-skills";
@@ -50,7 +50,8 @@ import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import { startLoopMonitor } from "./loop-monitor";
-import { createAppWindow, broadcastToAllWindows, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
+import { createAppWindow, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
+import { pushEverywhere } from "./push-targets";
 import electrobunConfig, { cliBinaryName } from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
 import { existsSync, writeSync } from "node:fs";
@@ -495,11 +496,11 @@ await openMainWindow();
 log.info("Main window created");
 readiness.arm();
 
-// Wire push messages: every open renderer window + any connected browser clients.
+// Wire push messages. Every push in this file goes through `pushEverywhere`, so
+// an open window and an attached browser always hear the same events.
 setPushMessage((name, payload) => {
 	log.debug("Push to renderer", { name });
-	broadcastToAllWindows(name, payload);
-	pushToBrowserClients(name, payload);
+	pushEverywhere(name, payload);
 });
 
 // Initialize the backend gate before background pollers and CLI requests can
@@ -516,10 +517,7 @@ if (loadSettingsSync().dimInactivePanes === false) {
 // `exposedPortsChanged` rides its own hook because port-tunnels lives below
 // rpc-handlers — same broadcast target as above.
 import("./port-tunnels").then(({ setPortTunnelsPushHook }) => {
-	setPortTunnelsPushHook((name, payload) => {
-		broadcastToAllWindows(name, payload);
-		pushToBrowserClients(name, payload);
-	});
+	setPortTunnelsPushHook(pushEverywhere);
 }).catch((err) => log.warn("port-tunnels push hook setup failed", { error: String(err) }));
 
 // Start remote access server (serves UI + RPC + PTY proxy on LAN).
@@ -530,8 +528,7 @@ import("./port-tunnels").then(({ setPortTunnelsPushHook }) => {
 // Electrobun kills the worker outright a millisecond after the window appeared.
 // A failure here is a failure of remote access ALONE; it never costs the app.
 setRemoteAccessStatusHook((status) => {
-	broadcastToAllWindows("remoteAccessStatusChanged", status);
-	pushToBrowserClients("remoteAccessStatusChanged", status);
+	pushEverywhere("remoteAccessStatusChanged", status);
 });
 await startRemoteAccessServerGuarded({
 	rpcHandler: async (method: string, params: any) => {
@@ -584,7 +581,7 @@ setNativeDevServerProbe(async (task, socket) => {
 startPortScanPoller(
 	(name, payload) => {
 		try {
-			broadcastToAllWindows(name, payload);
+			pushEverywhere(name, payload);
 		} catch (err) {
 			log.error("Failed to push port update", { error: String(err) });
 		}
@@ -603,7 +600,7 @@ startDisplayWatch({
 // Start background resource usage monitor (discovers tmux sessions directly, not via pty-server)
 startResourceMonitor((name, payload) => {
 	try {
-		broadcastToAllWindows(name, payload);
+		pushEverywhere(name, payload);
 	} catch (err) {
 		log.error("Failed to push resource usage update", { error: String(err) });
 	}
@@ -643,7 +640,7 @@ setTimeout(() => {
 // Start background agent rate-limit monitor (Claude dump / Codex rollouts + monthly credits)
 startRateLimitMonitor((name, payload) => {
 	try {
-		broadcastToAllWindows(name, payload);
+		pushEverywhere(name, payload);
 	} catch (err) {
 		log.error("Failed to push rate-limit update", { error: String(err) });
 	}
@@ -672,19 +669,21 @@ startScheduledMessageScheduler();
 const { startFocusTracker, stopFocusTracker } = await import("./focus-tracker");
 startFocusTracker();
 
-// Wire PTY death notifications
+// Wire PTY death notifications. This is what replaces a dead terminal with the
+// "session ended" screen, so it has to reach an attached browser too — without it
+// a phone keeps rendering a terminal that exited minutes ago.
 setOnPtyDied((sessionKey) => {
 	try {
 		if (sessionKey.startsWith("project-")) {
 			const projectId = sessionKey.slice(8);
-			log.info("Project terminal died, notifying renderer", { projectId: projectId.slice(0, 8) });
-			broadcastToAllWindows("projectPtyDied", { projectId });
+			log.info("Project terminal died, notifying clients", { projectId: projectId.slice(0, 8) });
+			pushEverywhere("projectPtyDied", { projectId });
 		} else {
-			log.info("PTY died, notifying renderer", { taskId: sessionKey.slice(0, 8) });
-			broadcastToAllWindows("ptyDied", { taskId: sessionKey });
+			log.info("PTY died, notifying clients", { taskId: sessionKey.slice(0, 8) });
+			pushEverywhere("ptyDied", { taskId: sessionKey });
 		}
 	} catch (err) {
-		log.error("Failed to notify renderer about PTY death", {
+		log.error("Failed to notify clients about PTY death", {
 			sessionKey: sessionKey.slice(0, 8),
 			error: String(err),
 			stack: (err as Error)?.stack ?? "no stack",
@@ -751,8 +750,7 @@ setOnOsc52Copy((payload) => {
 	// Still forward to renderer (diagnostics) and remote browser clients
 	// (where the user's clipboard is the browser, not the host).
 	try {
-		broadcastToAllWindows("osc52Clipboard", payload);
-		pushToBrowserClients("osc52Clipboard", payload);
+		pushEverywhere("osc52Clipboard", payload);
 	} catch (err) {
 		log.error("Failed to forward OSC 52 clipboard payload", {
 			taskId: payload.taskId.slice(0, 8),
@@ -939,7 +937,7 @@ Electrobun.events.on("reopen", () => {
 
 // Helper to push update progress to the renderer
 const sendUpdateProgress = (status: string, progress?: number) => {
-	broadcastToAllWindows("updateDownloadProgress", { status, progress });
+	pushEverywhere("updateDownloadProgress", { status, progress });
 };
 
 // --- Menu Event Handlers ---
@@ -999,7 +997,7 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 				// of downloading the same tar again (issue #1072).
 				if (isUpdateAlreadyReady(result.version)) {
 					sendUpdateProgress("idle");
-					broadcastToAllWindows("updateAvailable", {
+					pushEverywhere("updateAvailable", {
 						version: result.version,
 						changelog: result.changelog,
 						reminder: true,
@@ -1009,7 +1007,7 @@ Electrobun.events.on("application-menu-clicked", async (e) => {
 				sendUpdateProgress("downloading", 0);
 				const dlResult = await downloadUpdateForChannel(settings.updateChannel, sendUpdateProgress);
 				if (dlResult.ok) {
-					broadcastToAllWindows("updateAvailable", { version: result.version, changelog: result.changelog });
+					pushEverywhere("updateAvailable", { version: result.version, changelog: result.changelog });
 				} else {
 					sendUpdateProgress("error");
 					sendToFocusedWindow("updateCheckOutcome", { status: "error", detail: dlResult.error || "Download failed" });
@@ -1073,7 +1071,7 @@ startAutoCheck(
 		const dlResult = await downloadUpdateForChannel(settings.updateChannel, sendUpdateProgress);
 		if (dlResult.ok) {
 			log.info("Auto-download complete, notifying renderer", { version });
-			broadcastToAllWindows("updateAvailable", { version, changelog });
+			pushEverywhere("updateAvailable", { version, changelog });
 		} else {
 			log.error("Auto-download failed", { error: dlResult.error });
 			sendUpdateProgress("error");
@@ -1082,7 +1080,7 @@ startAutoCheck(
 	sendUpdateProgress,
 	(version, changelog) => {
 		log.info("Re-prompting for the downloaded update", { version });
-		broadcastToAllWindows("updateAvailable", { version, changelog, reminder: true });
+		pushEverywhere("updateAvailable", { version, changelog, reminder: true });
 	},
 );
 

--- a/src/bun/push-targets.ts
+++ b/src/bun/push-targets.ts
@@ -1,0 +1,23 @@
+/**
+ * One push, every client the desktop host serves.
+ *
+ * The desktop process has two audiences at once: its own Electrobun windows and
+ * whatever browser is attached over the remote-access server (a phone, a laptop
+ * on the LAN, a tunnel). A hook that only broadcasts to windows leaves those
+ * browsers rendering state the app already knows is stale — a dead terminal that
+ * still looks alive, most visibly. `dev3 remote` never had the gap because it has
+ * no windows to broadcast to, so every miss lived in the desktop entry alone.
+ *
+ * Every push in `src/bun/index.ts` goes through here, and
+ * `__tests__/push-targets-wiring.test.ts` fails if a bare `broadcastToAllWindows`
+ * call reappears there.
+ */
+
+import { broadcastToAllWindows } from "./window-manager";
+import { pushToBrowserClients } from "./remote-access-server";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function pushEverywhere(name: string, payload: any): void {
+	broadcastToAllWindows(name, payload);
+	pushToBrowserClients(name, payload);
+}


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that wrote this branch).

A terminal that had exited kept looking alive in a remote browser or on a phone. Reproduced on a real remote client: killing a task's tmux session left the browser on a bare `[exited]` in an empty canvas, unchanged 53 s later — no "Terminal session ended" card, no Resume button, and nothing that self-corrects (the "fallback timeout for cases where ptyDied doesn't fire" in `TaskTerminal.tsx` is an empty `setTimeout`). Dispatching `rpc:ptyDied` by hand in that same tab rendered the full card immediately, so the renderer half was never the problem — only the push was missing.

It was not one event. `src/bun/index.ts` serves Electrobun windows *and* any browser attached over the remote-access server, and its hooks were wired by hand: four blocks plus the updater broadcast to windows alone, so nine events never left the desktop — `ptyDied`, `projectPtyDied`, `portsUpdated`, `devServerUpdated`, `resourceUsageUpdated`, `systemMemoryUpdated`, `agentRateLimitsUpdated`, `updateAvailable`, `updateDownloadProgress`. `dev3 remote` sends every one of them to browsers, so a phone attached to the desktop app was strictly worse off than the same phone attached to headless.

`src/bun/push-targets.ts` now exports `pushEverywhere(name, payload)`, which fans out to both audiences; every push in the desktop entry goes through it, and the entry imports neither single-audience helper any more. The updater's two events are included deliberately, for parity with headless.

`index.ts` cannot be imported by a test (Electrobun APIs, top-level await, it opens a window), so the guard is deliberately two halves: `push-targets.test.ts` proves the helper reaches both targets, and `push-targets-wiring.test.ts` fails if a bare `broadcastToAllWindows` or `pushToBrowserClients` call reappears in `index.ts` in either direction. Reintroducing the old windows-only `ptyDied` line turns it red.

Verified after the fix on the same remote client: both the task terminal and the project terminal show their session-ended screens within seconds of the real death.

Rationale: `decisions/2026/09/04/push-every-desktop-event-to-remote-clients.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2dee28a7-9d49-486a-aebf-a00fd439f91e) · `dev3://task/2dee28a7-9d49-486a-aebf-a00fd439f91e`
