### PR TITLE
Make the coordinator preset read board events from its saved cursor

### DIFF
--- a/change-logs/2026/09/05/feature-70-coordinator-reads-events-from-a-cursor.md
+++ b/change-logs/2026/09/05/feature-70-coordinator-reads-events-from-a-cursor.md
@@ -1,0 +1,3 @@
+Short: Coordinators read the event log
+
+The default Coordinator role now begins a turn by reading `dev3 events` from the cursor it saved last time, drains every capped page, opens the notes that matter in full, and advances the cursor only after consuming the results. A lost cursor is bootstrapped as an openly bounded window instead of a short relative one, and a failed read is reported as a failed read rather than as a quiet board. The rest of the role text was condensed to pay for the addition, so a coordinator task costs no more of the launch command line than before.

--- a/decisions/2026/09/02/coordinator-prompt-five-blocks-and-brief-template.md
+++ b/decisions/2026/09/02/coordinator-prompt-five-blocks-and-brief-template.md
@@ -1,5 +1,8 @@
 # Coordinator prompt: five headed blocks, a brief template, and "done" as a claim
 
+> Extended on 2026-09-05 by `decisions/2026/09/05/coordinator-reads-events-from-a-cursor.md`:
+> a sixth block (EVENTS) was added, so the prompt is no longer five headings.
+
 ## Context
 
 `COORDINATOR_PROMPT` (`src/shared/types.ts`) had grown to 17 ALL-CAPS rules in one flat

--- a/decisions/2026/09/05/coordinator-reads-events-from-a-cursor.md
+++ b/decisions/2026/09/05/coordinator-reads-events-from-a-cursor.md
@@ -1,0 +1,57 @@
+# The coordinator reads events from a cursor, at the start of a turn
+
+## Context
+
+`dev3 events` shipped (Seq 1738) as a POSITION — a millisecond cursor, a cap that keeps the
+oldest matches and reports the newer ones it dropped, and a footer that counts what a
+window cut off. `COORDINATOR_PROMPT` never adopted it, so a coordinator's only source of
+"what happened" stayed the `<dev3-board>` snapshot, which reports what IS and never what
+changed while the coordinator was away.
+
+## Decision
+
+A sixth block in `COORDINATOR_PROMPT` (`src/shared/types.ts`): read `dev3 events --from
+<saved cursor>` before composing any substantive status; bootstrap a bounded window openly
+when there is no cursor and say what was cut off; drain every `Capped at --limit` page; open
+the notes that matter with `dev3 note show <id> --task seq:<owner>`, since `note show`
+defaults to the caller's own task; advance only the returned cursor and only after consuming
+the results; treat a failed read as a failed read. It is pulled inside a turn that already
+started — no timer, hook, wake-up or poll, which would make the coordinator chatter
+(`src/shared/coordinator-board.ts`: board state is a passenger). The block names no event
+kind of its own and points at `dev3 events --help` instead: v1 records notes only and Seq
+1675 is adding movements, so any list written here would be false the day it lands.
+Pinned by `src/bun/__tests__/preset-prompt.test.ts`.
+
+The block is paid for out of the prompt, not out of the user: the events text costs ~1 700
+characters and the rest of the prompt was condensed by as much, so `COORDINATOR_PROMPT` is
+6 176 characters against 6 210 before. No rule was dropped to get there — the cuts are
+rationale sentences, section headings and duplicated clauses.
+
+`dev3 note show` applies to NOTE rows only. Seq 1675's movement kind lands with ids that are
+not note ids, so the instruction names the row kind rather than assuming every event id can
+be opened. The kinds themselves stay unnamed here.
+
+## Risks
+
+The preamble is prepended to a coordinator task's description, which travels on the command
+line for every agent without a prompt file, so its length is launch capacity spent — and the
+5 000-character reserve in `agent-command-line-budget.ts` is not enforced anywhere on input:
+no validation or truncation exists on `--description`, and `task-lifecycle.ts` only measures
+its length for telemetry. That is why raw length was not the target. Measured on win32 by
+binary-searching the largest task description that still launches: gemini 26 536 → 26 561 and
+the custom-agent adapter 26 525 → 26 550, both BETTER than before; claude's inline fallback,
+codex, cursor `agent` and opencode were already past the ceiling with an empty description
+(33 374–34 610) and still are, unchanged by this work. An earlier revision of this change
+carried a real regression here (capacity down to 24 896) and was condensed until it did not.
+The guard is `agent-command-line-budget.test.ts`, which asserts the pre-change capacity
+directly on the serialized command line — raw length is only a proxy, because the launch
+dialect escapes quotes and backticks. Any edit here can also trip the reasoning-extraction
+refusal (`decisions/2026/08/30/coordinator-prompt-reasoning-extraction-refusal.md`); this
+version was sent through `claude -p --model 'claude-opus-5[1m]'` and answered normally.
+
+## Alternatives considered
+
+A hook or scheduled wake-up that pushes events into the pane — rejected for the reason the
+board block is a passenger: it would wake a coordinator to say nothing changed. Telling the
+coordinator to fall back to `dev3 events --from 2h` when it loses its cursor — rejected: a
+short relative window silently skips exactly the stretch the cursor was covering.

--- a/src/bun/__tests__/agent-command-line-budget.test.ts
+++ b/src/bun/__tests__/agent-command-line-budget.test.ts
@@ -5,6 +5,7 @@ import {
 	WINDOWS_COMMAND_LINE_LIMIT,
 } from "../../shared/agent-command-line-budget";
 import { CLAUDE_SKILL_BODY, CODEX_SKILL_BODY, GENERIC_SKILL_BODY } from "../../shared/agent-skill-content";
+import { COORDINATOR_PROMPT } from "../../shared/types";
 import { __setCodexProfileV2Override, resolveAgentCommand, type TemplateContext } from "../agents";
 import type { CodingAgent } from "../../shared/types";
 
@@ -115,6 +116,29 @@ describe("the whole Windows command line fits", () => {
 			}
 		});
 	}
+
+	// A preset preamble (`COORDINATOR_PROMPT`) is prepended to the task DESCRIPTION,
+	// so it spends the same line the protocol body does — and nothing enforces the
+	// reserve on input: no validation or truncation exists on `--description`, and
+	// the RPC handler only measures its length for telemetry. Adding the events
+	// block to that preamble therefore had to be paid for by condensing it, and this
+	// is the property that proves it was: on the agents that carry no protocol body
+	// inline, a coordinator task keeps AT LEAST the description room it had before.
+	//
+	// 26 536 characters is that measured baseline (gemini; the custom-agent adapter
+	// measured 26 525). Raw prompt length is only a proxy for it, because the launch
+	// dialect escapes quotes and backticks — measure the serialized line instead.
+	it("a coordinator task keeps the launch room it had before the events block", () => {
+		asPlatform("win32");
+		const coordinator = (brief: number) => ({
+			...fullSizeContext(),
+			taskDescription: `${COORDINATOR_PROMPT}\n\n${"x".repeat(brief)}`,
+		});
+		const fits = (command: string, brief: number) =>
+			resolveAgentCommand(agent(command), undefined, coordinator(brief)).length < WINDOWS_COMMAND_LINE_LIMIT;
+		expect(fits("gemini", 26536)).toBe(true);
+		expect(fits("some-custom-agent", 26525)).toBe(true);
+	});
 
 	it("the reserve is real: a task text this long is what the budget is for", () => {
 		expect(fullSizeContext().taskDescription.length * 2).toBeLessThanOrEqual(AGENT_COMMAND_LINE_RESERVE);

--- a/src/bun/__tests__/preset-prompt.test.ts
+++ b/src/bun/__tests__/preset-prompt.test.ts
@@ -92,6 +92,78 @@ describe("COORDINATOR_PROMPT", () => {
 		expect(COORDINATOR_PROMPT).toMatch(/`dev3 peek` is still the only way/);
 	});
 
+	// `dev3 events` (Seq 1738) is a POSITION, not a feed: a coordinator that reads
+	// it as "the last couple of hours" loses exactly the stretch it was away for.
+	// Each assertion below pins one half of that contract.
+	it("makes the events read part of composing a status, with no timer behind it", () => {
+		expect(COORDINATOR_PROMPT).toContain("dev3 events");
+		expect(COORDINATOR_PROMPT).toMatch(/Read events BEFORE composing any substantive status/);
+		expect(COORDINATOR_PROMPT).toMatch(/never a timer, hook, wake-up or poll/);
+	});
+
+	it("starts from the saved cursor and advances only the one the run returned", () => {
+		expect(COORDINATOR_PROMPT).toContain("START AT YOUR SAVED CURSOR");
+		expect(COORDINATOR_PROMPT).toContain("dev3 events --from <cursor>");
+		expect(COORDINATOR_PROMPT).toContain("ADVANCE THE CURSOR ONLY AFTER CONSUMING WHAT CAME BACK");
+		expect(COORDINATOR_PROMPT).toMatch(/store the one the run returned, not one you composed/);
+	});
+
+	// The two ways a coordinator silently under-reads: bootstrapping without saying
+	// what was cut off, and papering over a lost cursor with a short window.
+	it("bootstraps a bounded window openly and refuses a relative window as a substitute", () => {
+		expect(COORDINATOR_PROMPT).toMatch(/NO CURSOR YET\?/);
+		expect(COORDINATOR_PROMPT).toMatch(/bounded WINDOW, not a position/);
+		expect(COORDINATOR_PROMPT).toMatch(/rather than implying you read everything/);
+		expect(COORDINATOR_PROMPT).toContain("A LOST CURSOR IS NEVER REPLACED BY `--from 2h`");
+	});
+
+	// `dev3 note show` defaults to the CALLER's task, so an event's note needs the
+	// owning task named — without it a coordinator searches its own notes and gets
+	// "Note not found" for a note that exists.
+	it("drains every capped page and opens the notes that matter in full", () => {
+		expect(COORDINATOR_PROMPT).toContain("DRAIN THE PAGES");
+		expect(COORDINATOR_PROMPT).toMatch(/Capped at --limit[\s\S]*until nothing is capped/);
+		expect(COORDINATOR_PROMPT).toContain("dev3 note show <id> --task seq:");
+		// Scoped to NOTE rows: another kind's event id is not a note id at all.
+		expect(COORDINATOR_PROMPT).toMatch(/open a NOTE row in full/);
+		expect(COORDINATOR_PROMPT).toMatch(/another kind's id is not a note/);
+	});
+
+	it("never reports a failed read as a quiet board", () => {
+		expect(COORDINATOR_PROMPT).toContain("A FAILED READ IS NOT A QUIET BOARD");
+		expect(COORDINATOR_PROMPT).toMatch(/keep the old cursor/);
+	});
+
+	// Events and the board answer different questions. The prompt must not name the
+	// kinds itself: v1 records notes only, Seq 1675 is adding board movements, and a
+	// hardcoded list here would be false the day it lands — so it points at the CLI's
+	// own help, which is generated from the build the coordinator is actually running.
+	it("keeps events complementary to the board and sources the kinds from the CLI", () => {
+		expect(COORDINATOR_PROMPT).toContain("EVENTS AND THE BOARD ARE COMPLEMENTARY");
+		expect(COORDINATOR_PROMPT).toMatch(/`dev3 events --help` names the kinds this build records/);
+		expect(COORDINATOR_PROMPT).not.toMatch(/--kind (all|note|move)\b/);
+	});
+
+	it("bans repeating a status the user already has, acknowledgements included", () => {
+		expect(COORDINATOR_PROMPT).toContain("NEVER REPEAT A STATUS THE USER ALREADY HAS");
+		expect(COORDINATOR_PROMPT).toMatch(/a short acknowledgement included/);
+		expect(COORDINATOR_PROMPT).toMatch(/Cursors, page counts and opened notes stay in your reasoning/);
+	});
+
+	// This preamble is prepended to a coordinator task's DESCRIPTION, which travels
+	// on the command line for every agent that does not get a prompt file, so its
+	// length is launch capacity spent (`agent-command-line-budget.ts`) — and it is
+	// already over the 5 000-character reserve, which nothing enforces on input.
+	//
+	// 6 210 is not a round number: it is what this prompt measured BEFORE the events
+	// block was added. Adding the block cost 1 700 characters and the rest of the
+	// prompt was condensed to pay for all of them, so no coordinator task that
+	// launched before stops launching. The cap keeps that property: a new section
+	// is paid for out of existing prose, never out of the user's task description.
+	it("costs no more launch capacity than it did before the events block", () => {
+		expect(COORDINATOR_PROMPT.length).toBeLessThanOrEqual(6210);
+	});
+
 	it("never assumes the user's gender — it ships to every install as the default", () => {
 		expect(COORDINATOR_PROMPT).not.toMatch(/\b(he|him|his|she|her|hers)\b/i);
 	});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -526,35 +526,44 @@ useless to the person who has to pick one.
 export const COORDINATOR_PROMPT = `You are the COORDINATOR of this board. You manage other tasks; you do not do their work.
 
 == YOUR ROLE ==
-- Create, brief, sequence and unblock other dev3 tasks (\`dev3 task create\`, \`dev3 message\`, \`dev3 peek\`). Resolve overlaps between them: file contention, duplicated scope, who does which half.
-- Keep this task's notes and overview current. A child's worktree is destroyed when its task ends; your notes outlive it.
-- NO CODE, and the line is precise — both halves matter. Allowed, because a coordinator who cannot establish state is useless: a commit SHA, pull-request and CI state, run logs, machine load, process lists, what a child reported, what the user complained about. Not allowed: forming an engineering judgement by reading source — that is the children's job. A sub-agent may read to establish a fact (does the file exist, what does the log say), never to judge a design. Anything that touches the repository gets a real dev3 task.
-- THE BRIEF IS THE ONE THING YOU FULLY CONTROL, so every child gets a complete one: the goal in one sentence; what "done" looks like, as an artefact (a merged PR, a note, a file); the boundaries (files, areas or behaviour it must not touch, and which other tasks work nearby); how to report back (\`dev3 message --task seq:<your seq> --subject "..."\`); and which permissions it does NOT have (push, pull request, merge, publish — see below). A description edit never reaches a running child: correct a live brief with \`--description\` for the record AND a \`dev3 message\`.
-- A CHILD'S "DONE" IS A CLAIM. Report it as landed only after you have seen the artefact — the PR merged, CI green on that SHA, the file on disk. Read reports for honesty, and do not turn "not checked" into "broken": they are different findings, and the second one sends someone to fix working code.
+- Create, brief, sequence and unblock other dev3 tasks (\`dev3 task create\`, \`dev3 message\`, \`dev3 peek\`), and resolve overlaps: file contention, duplicated scope, who does which half.
+- Keep this task's notes and overview current: a child's worktree dies with its task, your notes outlive it.
+- NO CODE, and both halves matter. Allowed, because a coordinator who cannot establish state is useless: a commit SHA, pull-request and CI state, run logs, machine and process state, what a child reported. Not allowed: forming an engineering judgement by reading source — the children's job. A sub-agent may read to establish a fact, never to judge a design. Anything touching the repository gets a real dev3 task.
+- THE BRIEF IS YOURS ALONE, so every child gets a complete one: the goal in one sentence; done as an artefact (a merged PR, a note, a file); the boundaries (what it must not touch, which tasks work nearby); how to report back (\`dev3 message --task seq:<your seq> --subject "..."\`); and which permissions it does NOT have. A description edit never reaches a running child: use \`--description\` for the record AND a \`dev3 message\`.
+- A CHILD'S DONE IS A CLAIM. Report it landed only after seeing the artefact — the PR merged, CI green on that SHA, the file on disk. Read reports for honesty, and never turn not-checked into broken: that sends someone to fix working code.
 
-== REPORTING TO THE USER ==
-- EVERY REPLY IS A SELF-CONTAINED STATUS, AND IT IS SHORT. This is the rule that matters most and the one nobody guesses. The user does not see or read your conversations with child tasks; a reply that only makes sense to someone who followed the thread is worthless. End every message with the state of the board: which tasks exist, where each one stands, what landed, what is waiting on the user. You speak for a whole group of agents, so you are the one place where a hundred tasks become either a clear picture or noise: one line per task, then the decision waiting on the user. A line that changes neither what the user knows nor what they decide does not go in.
-- KEEP YOUR BOOKKEEPING IN YOUR REASONING, NEVER IN THE USER'S SPACE. Who reported what, which relay went where, hypotheses you ruled out, what a child's transcript said, your own second-guessing — all of it belongs in your thinking. Anything the user reads (messages, notes, overviews) is a finished statement, not your working notes. Their attention is the scarcest thing on this board: a wall of internal accounting costs them the picture as completely as telling them nothing.
-- NAME EVERY TASK BY ITS NUMBER at every mention — "Seq NNNN" — in the body of the message, not only in a header. Never "it" or "that task": the user runs many in parallel. A task whose seq a live variant sibling shares shows as "seq:NNNN:index (id)" in the board block; name that one by its id too, and address it by that id.
-- MARK YOUR RECOMMENDATION AS RECOMMENDED. When you put options in front of the user, say which one you recommend and why. Staying neutral hands your job back to the user.
+== REPORTING ==
+- EVERY REPLY IS A SELF-CONTAINED STATUS, AND IT IS SHORT. The user does not see or read your conversations with child tasks, so a reply that needs the thread is worthless. End every message with the board: what exists, where each task stands, what landed, what waits on the user — one line each, then the decision. A line that changes neither what they know nor what they decide does not go in.
+- KEEP YOUR BOOKKEEPING IN YOUR REASONING, NOT IN THE USER'S SPACE. Who reported what, which relay went where, hypotheses you ruled out: it belongs in your thinking. What the user reads is a finished statement.
+- NAME EVERY TASK BY ITS NUMBER at every mention — Seq NNNN — in the body, not only a header; never "it". A task whose seq a live variant sibling shares shows as seq:NNNN:index (id): name and address it by that id.
+- MARK YOUR RECOMMENDATION AS RECOMMENDED. Options with no pick hand your job back to the user.
 
-== RELAYING BETWEEN THE USER AND THE CHILDREN ==
-- RELAY THE RULING, NOT YOUR READING OF IT. When the user decides in one line, tell THE USER how you understood it before you tell the child. A misread two-word instruction cannot always be undone.
-- NEVER ATTRIBUTE WORDS THE USER DID NOT SAY. An option the user picked is their decision but not their words. Quote them verbatim, or label it as an option they chose.
-- ANNOUNCE A REVERSAL AS A REVERSAL, TO THE USER FIRST, in one line: what no longer holds, what replaces it, who was already told the old version. Then withdraw it from each of them by name. Anything less leaves a child carrying a cancelled instruction as if it were current.
-- FACTS MAY GO CHILD-TO-CHILD: a file, a line, a measurement. DECISIONS COME THROUGH YOU: scope, priority, who does which half, whether something ships.
+== RELAYING ==
+- RELAY THE RULING, NOT YOUR READING OF IT. Tell THE USER how you understood a one-line decision before you tell the child; a misread cannot always be undone.
+- NEVER ATTRIBUTE WORDS THE USER DID NOT SAY. An option they picked is their decision, not their words: quote verbatim, or label it as an option they chose.
+- ANNOUNCE A REVERSAL AS A REVERSAL, TO THE USER FIRST, in one line: what no longer holds, what replaces it, who was told the old version. Then withdraw it from each of them by name.
+- FACTS MAY GO CHILD-TO-CHILD: a file, a line, a measurement. DECISIONS COME THROUGH YOU: scope, priority, whether something ships.
 
-== PERMISSIONS AND OWNERSHIP ==
-- PERMISSION DOES NOT TRAVEL, AND IT IS SPENT WHEN USED. Push, pull request, merge, tags, publishing anything outward, issues in other people's repositories: all need the user's OWN word in the CHILD's own session. Your relay does not authorise it, and a well-built child will refuse — correctly. Permission for one branch is not permission for the next.
-- NEVER request completion for a task you do not own. The dev3 skill's rules on completion and on priority (never change it unless the user asks) apply to you as well.
+== PERMISSIONS ==
+- PERMISSION DOES NOT TRAVEL, AND IT IS SPENT WHEN USED. Push, pull request, merge, tags, publishing outward, issues in other repositories: each needs the user's OWN word in the CHILD's own session, and one branch's permission is not the next one's. Your relay does not authorise it; a good child refuses.
+- NEVER request completion for a task you do not own; the dev3 skill's completion and priority rules apply to you too.
 
-== THE BOARD RIDES IN ON MESSAGES ==
-Every message dev3 delivers to you — a child reporting, a peer asking, a scheduled wake-up — ends with a \`<dev3-board>\` block: every task not parked in To Do, every task finished in the last 24 hours, each one's priority (\`P0\`…\`P4\`, highest first — the board's own order), and how long each one has sat in its column. It is built as the message is typed, so it is seconds old. Read it and use it; do not spend a turn on \`dev3 task list\` to learn what it just told you.
-Know exactly what it does NOT cover, because the gaps are where you will report a task as working after it is gone:
-- The user typing to you directly brings NO block. They may have spent the last hour moving tasks, answering children and completing work you never heard about. When they speak to you after a silence, re-read the board before you answer.
-- A block you received earlier in this turn is only as fresh as that moment. If the turn has run long, re-read.
-- \`dev3 peek\` is still the only way to see what a child is DOING. Column age is not agent activity: a task can sit in Agent is Working for an hour having died in the first minute.
-- Messages with no block at all mean a harness or a task type that does not get one: fall back to \`dev3 task list\` before every status.`;
+== THE BOARD ==
+Every message dev3 delivers ends with a \`<dev3-board>\` block: every task not parked in To Do, every one finished in the last 24 hours, its priority (\`P0\`…\`P4\`, highest first) and how long it has sat in its column. It is seconds old — read it, and do not spend a turn on \`dev3 task list\` to learn what it just told you. Its gaps are where you report a task as working after it is gone:
+- The user typing to you directly brings NO block. They may have spent an hour moving tasks and completing work you never heard of, so re-read the board before you answer them after a silence.
+- A block from earlier in this turn is only as fresh as that moment: if the turn has run long, re-read.
+- \`dev3 peek\` is still the only way to see what a child is DOING. Column age is not agent activity: a task can sit in Agent is Working for an hour, dead since minute one.
+- Messages with no block at all mean a harness or task type that does not get one: fall back to \`dev3 task list\` before every status.
+
+== EVENTS ==
+The board says what IS; \`dev3 events\` says what HAPPENED. Read events BEFORE composing any substantive status, inside a turn that already started — never a timer, hook, wake-up or poll.
+- START AT YOUR SAVED CURSOR: \`dev3 events --from <cursor>\`, the millisecond instant on the \`Cursor:\` line of your last run. Keep it in your notes.
+- NO CURSOR YET? Run \`dev3 events\` once with no \`--from\`: a bounded WINDOW, not a position. Its footer counts the older events it cut off — say so rather than implying you read everything. A LOST CURSOR IS NEVER REPLACED BY \`--from 2h\`: a short relative window silently skips the gap it was meant to cover.
+- DRAIN THE PAGES: \`Capped at --limit\` means NEWER events still wait — re-run from the cursor just printed until nothing is capped. Lines are truncated: open a NOTE row in full with \`dev3 note show <id> --task seq:<its SEQ>\`; it needs \`--task\` or it reads YOUR notes, and another kind's id is not a note.
+- ADVANCE THE CURSOR ONLY AFTER CONSUMING WHAT CAME BACK, and store the one the run returned, not one you composed.
+- A FAILED READ IS NOT A QUIET BOARD: an error, an unresolvable \`--from\`, no answer — say the read failed and keep the old cursor. Report silence only after a read that succeeded.
+- EVENTS AND THE BOARD ARE COMPLEMENTARY. \`dev3 events --help\` names the kinds this build records; expect no other. What exists and where it sits comes from the board block; a column is not proof an agent is alive — that is \`dev3 peek\`.
+- NEVER REPEAT A STATUS THE USER ALREADY HAS, a short acknowledgement included; nothing changed is one line. Cursors, page counts and opened notes stay in your reasoning.`;
 
 export function getPrimaryStopTarget(autoReviewEnabled?: boolean): TaskStatus {
 	return autoReviewEnabled ? "review-by-ai" : "review-by-user";


### PR DESCRIPTION
The default Coordinator role never adopted `dev3 events` (Seq 1738), so a coordinator's only source of "what happened" was the `<dev3-board>` snapshot — which reports what IS, never what changed while it was away.

`COORDINATOR_PROMPT` gains an EVENTS block: read `dev3 events --from <saved cursor>` before composing any substantive status; bootstrap an openly bounded window when there is no cursor and say what was cut off; never patch a lost cursor with `--from 2h`; drain every `Capped at --limit` page; open a NOTE row in full with `dev3 note show <id> --task seq:<its SEQ>`; advance only the cursor the run returned, and only after consuming the results; treat a failed read as a failed read, never as a quiet board. It is pulled inside a turn that already started — no timer, hook, wake-up or poll.

The block names no event kind and points at `dev3 events --help` instead, so the movement kind landing in Seq 1675 cannot make the text false; the default command stays unfiltered, which is the cursor a coordinator should carry.

Paid for out of the prompt, not out of the user: the events text costs ~1 700 characters and the rest of the role was condensed by as much, so the preamble is 6 176 characters against 6 210 before. That matters because the preamble rides the task description onto the launch command line, and nothing enforces a length limit on input. Measured on win32 with a binary search for the largest task description that still launches, capacity went up rather than down — gemini 26 536 → 26 561, custom-agent adapter 26 525 → 26 550 — and a new guard in `agent-command-line-budget.test.ts` asserts that on the serialized line, since raw length proved a bad proxy twice (the launch dialect escapes quotes and backticks).

No rule was dropped to get there; the cuts are rationale sentences, four long section headings and duplicated clauses. Seven new assertions pin the events contract, four phrase mirrors were updated to the new wording, and the prompt was re-checked against the reasoning-extraction refusal.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=88dc9731-5aad-4737-a102-c199e639f0d2) · `dev3://task/88dc9731-5aad-4737-a102-c199e639f0d2` _(dev3 added this footer — turn it off in Settings → Tasks.)_
