### PR TITLE
Open artifact links in the browser and keep in-page anchors scrolling

### DIFF
--- a/change-logs/2026/09/07/fix-artifact-links-open-in-browser.md
+++ b/change-logs/2026/09/07/fix-artifact-links-open-in-browser.md
@@ -1,0 +1,3 @@
+Short: Artifact links finally open
+
+Links inside a rendered artifact used to be dead clicks — the sandboxed frame blocked them. External links now open in the browser, and in-page `#anchor` links scroll to their section instead of opening a tab on the app's own URL.

--- a/decisions/2026/09/07/artifact-links-open-in-the-browser.md
+++ b/decisions/2026/09/07/artifact-links-open-in-the-browser.md
@@ -1,0 +1,51 @@
+# Artifact links: allow-popups plus base target, minus the in-page anchors
+
+## Context
+
+Every link in a rendered artifact was a dead click. The document lives in a
+`srcdoc` iframe sandboxed with `allow-scripts` only (`ArtifactFrame.tsx`), so
+top navigation is forbidden and `_blank` needs `allow-popups`.
+
+## Investigation
+
+Measured in a real sandboxed frame (headless Chromium, the composed document
+served from a throwaway host page), not reasoned about:
+
+- `allow-popups` + `<base target="_blank">` opens external links in a browser
+  tab, as intended.
+- The same default catches `#section`. A `srcdoc` document inherits the PARENT
+  page's URL as its base URL, so an anchor click opened a tab on the app's own
+  URL (`…/#bottom`) instead of scrolling. Without `allow-popups` the identical
+  click was refused outright: `Blocked opening … because the request was made in
+  a sandboxed frame whose 'allow-popups' permission is not set`.
+- A relative `report.html` resolves the same way and opens a tab on an app URL.
+  Left as-is: artifact assets are inlined at compose time, so a relative *page*
+  link has no destination either way, and taking it back would cost more code
+  than the case is worth.
+
+## Decision
+
+Two lines plus one small script:
+
+- `ArtifactFrame.tsx` — `sandbox="allow-scripts allow-popups"`.
+- `composeArtifactDocument` injects `<base target="_blank">` (no href, so a
+  report's own `<base href>` still sets the base URL).
+- `src/mainview/utils/artifactLinks.ts` — an injected click handler that takes
+  `a[href^="#"]` back off that default: `preventDefault` plus `scrollIntoView`
+  on the target, by id or `name`, percent-decoded; a bare `#` scrolls to the top.
+
+## Risks
+
+`allow-popups` also lets report code call `window.open` for real. That is the
+price of the two-line route; the frame keeps its opaque origin, and the popup it
+opens inherits the sandbox. The desktop path (a popup from a nested sandboxed
+frame reaching the `new-window-open` intercept in `window-manager.ts`, which
+forwards http(s) to `Utils.openExternal`) is verified in a browser, not yet in
+the Electrobun shell.
+
+## Alternatives considered
+
+Intercepting every click and posting the URL to the viewer, which opens it from
+its own origin — the desktop-proven path terminal links already use. It works
+and needs no sandbox change, but it is ~5× the code (a link classifier, a
+`window.open` patch, a host handler) for what a browser default does for free.

--- a/src/mainview/components/ArtifactFrame.tsx
+++ b/src/mainview/components/ArtifactFrame.tsx
@@ -51,7 +51,11 @@ const ArtifactFrame = forwardRef<ArtifactFrameHandle, ArtifactFrameProps>(
 			<iframe
 				ref={frameRef}
 				title={title}
-				sandbox="allow-scripts"
+				// allow-popups is what lets a link leave the report: with
+				// `<base target="_blank">` in the document the browser opens it in a
+				// tab (desktop: the new-window intercept hands it to the OS browser).
+				// Without it every link in a report is a blocked, dead click.
+				sandbox="allow-scripts allow-popups"
 				srcDoc={html}
 				onLoad={onReady}
 				className={className}

--- a/src/mainview/components/__tests__/ArtifactFrame.test.tsx
+++ b/src/mainview/components/__tests__/ArtifactFrame.test.tsx
@@ -23,7 +23,9 @@ function mount(html = "<html>one</html>") {
 describe("ArtifactFrame", () => {
 	it("renders a sandboxed srcdoc iframe and never creates a native webview", () => {
 		const { iframe, view } = mount();
-		expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+		// allow-popups is load-bearing: without it every link in a report is a
+		// blocked, dead click. See artifactLinks.ts.
+		expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-popups");
 		expect(iframe.getAttribute("srcdoc")).toBe("<html>one</html>");
 		// The separate <electrobun-webview> host was removed; see
 		// decisions/2026/09/05/artifact-viewer-back-in-the-page.md.

--- a/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
+++ b/src/mainview/components/__tests__/TaskArtifactViewer.test.tsx
@@ -120,7 +120,7 @@ describe("TaskArtifactViewer", () => {
 		render(<I18nProvider><TaskArtifactViewer taskId="t1" artifacts={[artifact("a"), artifact("b", true)]} initialIndex={1} onClose={vi.fn()} /></I18nProvider>);
 		expect(screen.getByText("Artifact b")).toBeInTheDocument();
 		const frame = await screen.findByTitle("Artifact b");
-		expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+		expect(frame).toHaveAttribute("sandbox", "allow-scripts allow-popups");
 		await waitFor(() => expect(frame.getAttribute("srcdoc")).toContain("data:image/png;base64,AAA"));
 	});
 

--- a/src/mainview/utils/__tests__/artifactLinks.test.ts
+++ b/src/mainview/utils/__tests__/artifactLinks.test.ts
@@ -1,0 +1,65 @@
+import { artifactLinksScript, installArtifactLinks } from "../artifactLinks";
+
+// A fresh document per case: the installer registers a document-level listener,
+// and a shared document would keep the previous case's handler — whose
+// preventDefault makes every later handler bail as already-handled.
+function harness(html: string) {
+	const doc = document.implementation.createHTMLDocument("artifact");
+	doc.body.innerHTML = html;
+	const scrolled: unknown[] = [];
+	installArtifactLinks({ document: doc, scrollTo: (...args: unknown[]) => scrolled.push(args) });
+	return { doc, scrolled };
+}
+
+function click(doc: Document, selector: string) {
+	const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+	doc.querySelector(selector)!.dispatchEvent(event);
+	return event;
+}
+
+function spyScroll(doc: Document, selector: string): unknown[] {
+	const target = doc.querySelector(selector)! as HTMLElement & { scrollIntoView: unknown };
+	const calls: unknown[] = [];
+	target.scrollIntoView = (arg: unknown) => calls.push(arg);
+	return calls;
+}
+
+describe("artifact in-page anchors", () => {
+	it("scrolls to the target instead of opening a tab on the app's own URL", () => {
+		const { doc } = harness('<a id="jump" href="#section">go</a><h2 id="section">here</h2>');
+		const calls = spyScroll(doc, "#section");
+		expect(click(doc, "#jump").defaultPrevented).toBe(true);
+		expect(calls).toEqual([{ block: "start", behavior: "smooth" }]);
+	});
+
+	it("finds a percent-encoded target, a name= target, and survives a missing one", () => {
+		const { doc } = harness('<a id="a" href="#a%20b">x</a><a id="n" href="#named">y</a><a id="m" href="#gone">z</a>'
+			+ '<h2 id="a b">t</h2><a name="named"></a>');
+		const encoded = spyScroll(doc, '[id="a b"]');
+		const named = spyScroll(doc, '[name="named"]');
+		expect(click(doc, "#a").defaultPrevented).toBe(true);
+		expect(click(doc, "#n").defaultPrevented).toBe(true);
+		expect(click(doc, "#m").defaultPrevented).toBe(true);
+		expect(encoded).toHaveLength(1);
+		expect(named).toHaveLength(1);
+	});
+
+	it("sends a bare # to the top", () => {
+		const { doc, scrolled } = harness('<a id="top" href="#">top</a>');
+		expect(click(doc, "#top").defaultPrevented).toBe(true);
+		expect(scrolled).toEqual([[0, 0]]);
+	});
+
+	// Everything that is not an in-page anchor stays with `<base target="_blank">`.
+	it("leaves an external, relative or javascript: link to the frame", () => {
+		const { doc } = harness('<a id="ext" href="https://example.com/">x</a>'
+			+ '<a id="rel" href="report.html">y</a><a id="js" href="javascript:alert(1)">z</a>');
+		for (const id of ["#ext", "#rel", "#js"]) expect(click(doc, id).defaultPrevented).toBe(false);
+	});
+
+	it("serializes into a script tag carrying the installer", () => {
+		const script = artifactLinksScript();
+		expect(script).toContain("data-dev3-artifact-links");
+		expect(script.endsWith("(window);</script>")).toBe(true);
+	});
+});

--- a/src/mainview/utils/artifactDocument.ts
+++ b/src/mainview/utils/artifactDocument.ts
@@ -1,5 +1,6 @@
 import { artifactBridgeScript } from "./artifactBridge";
 import { artifactChannelScript } from "./artifactChannel";
+import { artifactLinksScript } from "./artifactLinks";
 
 interface ArtifactAssetPayload {
 	name: string;
@@ -135,7 +136,11 @@ export function composeArtifactDocument(
 	);
 
 	// The channel goes first: every other injected script reaches for it by name.
-	const injected = `<meta http-equiv="Content-Security-Policy" content="${CSP}">${artifactChannelScript()}${assetRuntimeScript(assets)}${findScript()}${artifactBridgeScript(canSendToAgent)}${saveImageLabel ? saveImageMenuScript(saveImageLabel) : ""}`;
+	// `<base target="_blank">` sends every link to the browser (the frame carries
+	// `allow-popups` for it); it carries no href, so a report's own `<base href>`
+	// still sets the document base URL. `artifactLinksScript` takes the in-page
+	// anchors back off that default.
+	const injected = `<meta http-equiv="Content-Security-Policy" content="${CSP}"><base target="_blank">${artifactChannelScript()}${assetRuntimeScript(assets)}${findScript()}${artifactLinksScript()}${artifactBridgeScript(canSendToAgent)}${saveImageLabel ? saveImageMenuScript(saveImageLabel) : ""}`;
 	if (/<head(?:\s|>)/i.test(html)) return html.replace(/<head([^>]*)>/i, `<head$1>${injected}`);
 	if (/<html(?:\s|>)/i.test(html)) return html.replace(/<html([^>]*)>/i, `<html$1><head>${injected}</head>`);
 	const body = html.replace(/<!doctype[^>]*>/i, "");

--- a/src/mainview/utils/artifactLinks.ts
+++ b/src/mainview/utils/artifactLinks.ts
@@ -1,0 +1,46 @@
+/**
+ * In-page anchors inside an artifact.
+ *
+ * External links are handled by the frame itself: `<base target="_blank">` plus
+ * `allow-popups` on the sandbox (see `ArtifactFrame.tsx`). That default catches
+ * `#section` too, and a `srcdoc` document's base URL is the PARENT page's URL —
+ * so an anchor click opened a new tab showing the app instead of scrolling.
+ * Measured in a real sandboxed frame; see
+ * `decisions/2026/09/07/artifact-links-open-in-the-browser.md`.
+ *
+ * Same authoring rule as the channel and the bridge: a real function, serialized
+ * by {@link artifactLinksScript}, so it may reference nothing outside its own
+ * body except the argument it is handed.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function installArtifactLinks(win: any): void {
+	const doc = win && win.document;
+	if (!doc || !doc.addEventListener) return;
+
+	doc.addEventListener("click", function (event: { defaultPrevented?: boolean; target?: any; preventDefault(): void }) {
+		if (event.defaultPrevented) return;
+		const anchor = event.target && event.target.closest ? event.target.closest('a[href^="#"]') : null;
+		if (!anchor) return;
+		event.preventDefault();
+		const id = anchor.getAttribute("href").slice(1);
+		if (!id) {
+			win.scrollTo(0, 0);
+			return;
+		}
+		let decoded = id;
+		try {
+			decoded = decodeURIComponent(id);
+		} catch (_err) {
+			decoded = id;
+		}
+		const target = doc.getElementById(decoded) || doc.getElementById(id)
+			|| (doc.getElementsByName ? doc.getElementsByName(decoded)[0] : null);
+		if (target && target.scrollIntoView) target.scrollIntoView({ block: "start", behavior: "smooth" });
+	}, true);
+}
+
+/** The injected `<script>` that keeps in-page anchors scrolling this document. */
+export function artifactLinksScript(): string {
+	return `<script data-dev3-artifact-links>(${installArtifactLinks.toString()})(window);</script>`;
+}


### PR DESCRIPTION
Links inside a rendered artifact were dead clicks: the document sits in a `srcdoc` iframe sandboxed with `allow-scripts` only, so top navigation is forbidden and `_blank` needs `allow-popups`.

Two lines plus one small script:

- `ArtifactFrame.tsx` — `sandbox="allow-scripts allow-popups"`
- `composeArtifactDocument` injects `<base target="_blank">` (no href, so a report's own `<base href>` still sets the base URL)
- `src/mainview/utils/artifactLinks.ts` — 27 lines of code taking `a[href^="#"]` back off that default

That last piece is not optional, and it was measured rather than assumed: a `srcdoc` document inherits the **parent page's URL** as its base URL, so with `base target="_blank"` a click on `#section` opened a browser tab on the app's own URL instead of scrolling. Without `allow-popups` the same click was refused outright (`Blocked opening … because the request was made in a sandboxed frame whose 'allow-popups' permission is not set`).

A relative `report.html` still opens a tab on an app URL — left as-is deliberately: assets are inlined at compose time, so a relative *page* link has no destination either way.

Verified in a real sandboxed frame (headless Chromium, the actual composed document): external link → one new tab; `#anchor` → scrolls 350px, zero new tabs, frame still `about:srcdoc`; no console errors. The desktop popup path (nested sandboxed frame → `new-window-open` intercept → `Utils.openExternal`) is **not** yet verified inside the Electrobun shell.

Decision record: `decisions/2026/09/07/artifact-links-open-in-the-browser.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=fcc8709f-cd41-423a-8c15-0b4e7ed2a952) · `dev3://task/fcc8709f-cd41-423a-8c15-0b4e7ed2a952`