### PR TITLE
Record every dev3 notify in a local notification history

### DIFF
--- a/change-logs/2026/09/08/feature-40-notification-history.md
+++ b/change-logs/2026/09/08/feature-40-notification-history.md
@@ -1,0 +1,3 @@
+Short: dev3 notify calls are recorded
+
+Every `dev3 notify` the app handles is now written to `~/.dev3.0/notifications/YYYY-MM-DD.jsonl` with its time, level, surface (toast or desktop), the task it points at, the worktree it was sent from and what the app actually did with it — delivered, queued behind Focus Mode, or dropped because no window was open. History is kept for 30 days and nothing leaves the machine; notifications from a silenced project are still recorded nowhere. Nothing is shown in the UI yet — this release only starts collecting.

--- a/decisions/2026/09/07/notification-history-log-is-global-not-per-project.md
+++ b/decisions/2026/09/07/notification-history-log-is-global-not-per-project.md
@@ -1,0 +1,73 @@
+# The notification history is one global log, not a per-project one
+
+## Context
+
+`dev3 notify` was the loudest thing an agent could do and the only one that left
+no trace: a toast lives seconds, an OS notification dies on dismissal, and one
+sent during Focus Mode may never be seen at all. The plan is to show notification
+events in the agent-traffic timeline, but only after a couple of days of real
+data — so this change collects and shows nothing.
+
+The obvious home was the agent message log (`~/.dev3.0/data/<slug>/messages/`),
+which already solved day-files, retention and concurrent appends.
+
+## Investigation
+
+Two facts ruled that shape out. A notification can be sent with no task at all
+(`dev3 notify "done"` from any shell), so there is no project to file it under —
+per-project storage would silently drop exactly the calls a human makes. And a
+notification is addressed to the human, while a message is addressed to another
+task's agent and always has both ends; folding one into the other would make
+both unreadable.
+
+A third fact shaped the outcome field rather than the location: `dev3 notify`
+fans the same toast out to every live dev3 instance so it reaches whichever app
+the user is looking at. Without a marker each instance would record the same
+notification, turning one ping into N rows.
+
+## Decision
+
+`~/.dev3.0/notifications/YYYY-MM-DD.jsonl` — a new top-level directory beside
+`data/` and `logs/`, nothing renamed and nothing migrated, so an older installed
+version simply never opens it (AGENTS.md on-disk invariants). Every row carries
+its own `projectId`, so a per-project view is a filter rather than a layout.
+
+- Schema, clamping and parsing: `src/shared/notification-log.ts`.
+- Writer, day-files and 30-day pruning: `src/bun/notification-log.ts`.
+- Call site: the `ui.notify` handler in `src/bun/cli-socket-server.ts`, via
+  `buildNotificationLogBase` and `recordNotification`.
+- The CLI (`src/cli/commands/ui-control.ts`) adds `sourceTaskId` (the worktree
+  the command ran in, which is not the same fact as the task it points at),
+  `sourceSessionId`, and `fanout: true` on the duplicate deliveries.
+
+Three deliberate limits:
+
+- **The outcome is recorded, not guessed.** `delivered`, `queued` (with the
+  suppression sources that held it) and `no-window` are separate answers. What
+  the user did with a delivered notification is not knowable and is not stored.
+- **A silenced project writes no row at all.** `deliverTaskNotification` drops a
+  silenced project's notification so it leaves no trace on screen, "now or after
+  streamer mode goes off". A log the timeline will later render would put that
+  trace back, so the row is not written.
+- **Sub-agent provenance does not exist and is not faked.** Measured, not
+  assumed: a Claude Code sub-agent inherits its parent's `CLAUDE_CODE_SESSION_ID`,
+  `CLAUDE_PID` and `CLAUDE_CODE_CHILD_SESSION` verbatim, so nothing in the
+  environment separates them. `sourceSessionId` separates two agent sessions in
+  one task and nothing finer; every other harness leaves it absent.
+
+## Risks
+
+An older `dev3` binary against a newer app sends no `fanout` marker, so a
+multi-instance notification would record one row per instance until the CLI
+catches up (it self-installs from the app, so the window is short). Rows are
+plain text at `0600` including whatever an agent wrote into a message — the same
+privacy posture as the message log, and nothing here has a telemetry path.
+
+## Alternatives considered
+
+Per-project files under `data/<slug>/notifications/`, rejected because a
+task-less notification has no project. A single append-only `notifications.jsonl`,
+rejected because trimming it means rewriting it, which stops being append-only
+and loses rows when two instances trim at once. Writing the row in the CLI
+process instead of the app, rejected because only the app knows the outcome —
+whether a window existed and whether suppression held it back.

--- a/src/bun/__tests__/cli-socket-handlers.test.ts
+++ b/src/bun/__tests__/cli-socket-handlers.test.ts
@@ -97,6 +97,8 @@ vi.mock("../rpc-handlers", () => {
 		getActiveContext: vi.fn(() => ({ projectId: null, taskId: null })),
 		isTerminalFocusActive: vi.fn(() => false),
 		isNotificationSuppressed: vi.fn(() => false),
+		activeNotificationSuppression: vi.fn(() => []),
+		isProjectSilenced: vi.fn(() => false),
 		pushCliAttention: vi.fn(),
 		dropQueuedAttention: vi.fn(),
 		pushCliToast: vi.fn(),
@@ -107,6 +109,10 @@ vi.mock("../rpc-handlers", () => {
 		queueTerminalFocusToast: vi.fn(),
 	};
 });
+
+vi.mock("../notification-log", () => ({
+	appendNotificationLog: vi.fn(),
+}));
 
 vi.mock("../task-start-ref", () => ({
 	resolveTaskStartRef: vi.fn(async () => undefined),
@@ -183,7 +189,8 @@ vi.mock("node:fs", () => ({
 import * as data from "../data";
 import * as git from "../git";
 import * as pty from "../pty-server";
-import { activateTask, createTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, pushCliAttention, dropQueuedAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "../rpc-handlers";
+import { activateTask, createTask, moveTask, runCleanupScript, emitTaskSound, getPushMessage, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, activeNotificationSuppression, isProjectSilenced, pushCliAttention, dropQueuedAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "../rpc-handlers";
+import { appendNotificationLog } from "../notification-log";
 import { loadSettings } from "../settings";
 import { deliverAgentPrompt } from "../agent-prompt-delivery";
 import { runDevServer, stopDevServer, restartDevServer, getDevServerStatus } from "../rpc-handlers/tmux-pty";
@@ -266,6 +273,8 @@ function makeRequest(method: string, params: Record<string, unknown> = {}): CliR
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(isNotificationSuppressed).mockReturnValue(false);
+	vi.mocked(activeNotificationSuppression).mockReturnValue([]);
+	vi.mocked(isProjectSilenced).mockReturnValue(false);
 	vi.mocked(moveTask).mockImplementation(async (params) => {
 		const project = await data.getProject(params.projectId);
 		const task = (await data.loadTasks(project)).find((candidate) => candidate.id === params.taskId);
@@ -2009,6 +2018,118 @@ describe("ui control (notify / attention / state)", () => {
 		expect(resp.data).toMatchObject({ delivered: true, queued: true });
 		expect(pushFn).not.toHaveBeenCalled();
 		expect(setFocusMode).toHaveBeenCalledWith(true);
+	});
+
+	it("ui.notify: records a delivered toast with its target and caller", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		await handleRequest(
+			makeRequest("ui.notify", {
+				message: "build green",
+				level: "success",
+				taskId: task.id,
+				projectId: project.id,
+				sourceTaskId: task.id,
+				sourceSessionId: "session-abc",
+			}),
+		);
+
+		expect(appendNotificationLog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				mode: "toast",
+				level: "success",
+				message: "build green",
+				outcome: "delivered",
+				taskId: task.id,
+				taskSeq: task.seq,
+				projectId: project.id,
+				sourceTaskId: task.id,
+				sourceSeq: task.seq,
+				sourceSessionId: "session-abc",
+			}),
+		);
+	});
+
+	it("ui.notify: records a task-less notification with null provenance, never a guess", async () => {
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		await handleRequest(makeRequest("ui.notify", { message: "hello", level: "info" }));
+
+		const row = vi.mocked(appendNotificationLog).mock.calls[0][0];
+		expect(row).toMatchObject({ taskId: null, taskSeq: null, projectId: null, sourceTaskId: null, sourceSeq: null });
+		expect(row).not.toHaveProperty("sourceSessionId");
+		expect(row).not.toHaveProperty("sourceTitle");
+	});
+
+	it("ui.notify: records a queued row naming what held it back", async () => {
+		vi.mocked(isNotificationSuppressed).mockReturnValue(true);
+		vi.mocked(activeNotificationSuppression).mockReturnValue(["focusMode"]);
+
+		await handleRequest(makeRequest("ui.notify", { message: "later", level: "info" }));
+
+		expect(appendNotificationLog).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "queued", suppressedBy: ["focusMode"] }),
+		);
+	});
+
+	it("ui.notify: records `no-window` when nothing could be shown", async () => {
+		vi.mocked(getPushMessage).mockReturnValue(null);
+
+		const resp = await handleRequest(makeRequest("ui.notify", { message: "unseen" }));
+
+		expect(resp.data).toMatchObject({ delivered: false });
+		expect(appendNotificationLog).toHaveBeenCalledWith(expect.objectContaining({ outcome: "no-window" }));
+	});
+
+	it("ui.notify: the CLI's fan-out copy is not recorded a second time", async () => {
+		vi.mocked(getPushMessage).mockReturnValue(vi.fn());
+
+		await handleRequest(makeRequest("ui.notify", { message: "once", fanout: true }));
+
+		expect(appendNotificationLog).not.toHaveBeenCalled();
+	});
+
+	it("ui.notify: a silenced project leaves no row, on either surface", async () => {
+		const project = makeProject();
+		const task = makeTask();
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(isProjectSilenced).mockReturnValue(true);
+		vi.mocked(isNotificationSuppressed).mockReturnValue(true);
+
+		await handleRequest(makeRequest("ui.notify", { message: "hidden", taskId: task.id, projectId: project.id }));
+		await handleRequest(
+			makeRequest("ui.notify", { message: "hidden", desktop: true, taskId: task.id, projectId: project.id }),
+		);
+
+		expect(appendNotificationLog).not.toHaveBeenCalled();
+	});
+
+	it("ui.notify: --desktop records the desktop surface", async () => {
+		const project = makeProject();
+		const task = makeTask({ seq: 7 });
+		vi.mocked(data.getProject).mockResolvedValue(project);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+
+		await handleRequest(
+			makeRequest("ui.notify", { message: "needs you", desktop: true, taskId: task.id, projectId: project.id }),
+		);
+
+		expect(appendNotificationLog).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "desktop", outcome: "delivered", taskId: task.id }),
+		);
+	});
+
+	it("ui.notify: a rejected request writes nothing", async () => {
+		await handleRequest(makeRequest("ui.notify", { message: "   " }));
+		await handleRequest(makeRequest("ui.notify", { message: "x", level: "warning" }));
+
+		expect(appendNotificationLog).not.toHaveBeenCalled();
 	});
 
 	it("ui.attention: focus mode queues the badge", async () => {

--- a/src/bun/__tests__/notification-log.test.ts
+++ b/src/bun/__tests__/notification-log.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+
+// A real filesystem, redirected: the point of these cases is that appends land as
+// bytes and that pruning deletes files, neither of which a mocked fs can prove.
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-notiflog-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import {
+	NOTIFICATION_LOG_MAX_ROW_BYTES,
+	NOTIFICATION_LOG_RETENTION_DAYS,
+	NOTIFICATION_LOG_TRUNCATION_MARK,
+	NOTIFICATION_LOG_VERSION,
+	parseNotificationLogRow,
+	serializeNotificationLogRow,
+	type NotificationLogInput,
+} from "../../shared/notification-log";
+import { appendNotificationLog, notificationLogDir, pruneNotificationLog, resetNotificationLogPruneState } from "../notification-log";
+
+function makeRow(overrides: Partial<NotificationLogInput> = {}): NotificationLogInput {
+	return {
+		at: "2026-09-07T10:00:00.000Z",
+		mode: "toast",
+		level: "info",
+		message: "build green",
+		taskId: "task-1",
+		taskSeq: 1813,
+		taskTitle: "Record notification history",
+		projectId: "proj-1",
+		projectName: "dev-3.0",
+		sourceTaskId: "task-1",
+		sourceSeq: 1813,
+		outcome: "delivered",
+		...overrides,
+	};
+}
+
+function readDay(day: string): string[] {
+	return readFileSync(`${notificationLogDir()}/${day}.jsonl`, "utf8").split("\n").filter(Boolean);
+}
+
+beforeEach(() => {
+	resetNotificationLogPruneState();
+	rmSync(notificationLogDir(), { recursive: true, force: true });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("notification log rows", () => {
+	it("round-trips a row through serialize and parse", () => {
+		const input = makeRow();
+		const parsed = parseNotificationLogRow(serializeNotificationLogRow(input));
+		expect(parsed).toEqual({ v: NOTIFICATION_LOG_VERSION, ...input });
+	});
+
+	it("serialises to exactly one line", () => {
+		const line = serializeNotificationLogRow(makeRow({ message: "two\nlines" }));
+		expect(line.endsWith("\n")).toBe(true);
+		expect(line.slice(0, -1)).not.toContain("\n");
+	});
+
+	it("keeps a queued row's suppression sources", () => {
+		const parsed = parseNotificationLogRow(
+			serializeNotificationLogRow(makeRow({ outcome: "queued", suppressedBy: ["focusMode", "terminalImmersive"] })),
+		);
+		expect(parsed?.suppressedBy).toEqual(["focusMode", "terminalImmersive"]);
+	});
+
+	it("clips an oversized message but keeps every other field", () => {
+		const line = serializeNotificationLogRow(makeRow({ message: "x".repeat(NOTIFICATION_LOG_MAX_ROW_BYTES * 2) }));
+		expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(NOTIFICATION_LOG_MAX_ROW_BYTES);
+		const parsed = parseNotificationLogRow(line);
+		expect(parsed?.message.endsWith(NOTIFICATION_LOG_TRUNCATION_MARK)).toBe(true);
+		expect(parsed?.outcome).toBe("delivered");
+		expect(parsed?.taskSeq).toBe(1813);
+	});
+
+	it("never cuts a multi-byte character in half", () => {
+		const line = serializeNotificationLogRow(makeRow({ message: "ё".repeat(NOTIFICATION_LOG_MAX_ROW_BYTES) }));
+		const parsed = parseNotificationLogRow(line);
+		expect(parsed?.message).not.toContain("�");
+		expect(JSON.parse(line.trim()).message).toBe(parsed?.message);
+	});
+
+	it("rejects a torn line instead of throwing", () => {
+		const line = serializeNotificationLogRow(makeRow());
+		expect(parseNotificationLogRow(line.slice(0, 30))).toBeNull();
+		expect(parseNotificationLogRow("")).toBeNull();
+		expect(parseNotificationLogRow("null")).toBeNull();
+	});
+
+	it("rejects a row missing the facts that make it a notification", () => {
+		expect(parseNotificationLogRow(JSON.stringify({ at: "now", message: "hi", mode: "toast", level: "info" }))).toBeNull();
+		expect(parseNotificationLogRow(JSON.stringify({ message: "hi", mode: "toast", level: "info", outcome: "delivered" }))).toBeNull();
+	});
+});
+
+describe("notification log on disk", () => {
+	it("appends into a day-file named for the local day", () => {
+		appendNotificationLog(makeRow(), new Date(2026, 8, 7, 23, 30));
+		expect(readdirSync(notificationLogDir())).toEqual(["2026-09-07.jsonl"]);
+		expect(JSON.parse(readDay("2026-09-07")[0]).message).toBe("build green");
+	});
+
+	it("appends rather than overwriting", () => {
+		const day = new Date(2026, 8, 7, 9, 0);
+		appendNotificationLog(makeRow({ message: "first" }), day);
+		appendNotificationLog(makeRow({ message: "second" }), day);
+		expect(readDay("2026-09-07").map((line) => JSON.parse(line).message)).toEqual(["first", "second"]);
+	});
+
+	it("writes the file 0600", () => {
+		appendNotificationLog(makeRow(), new Date(2026, 8, 7));
+		const { statSync } = require("node:fs");
+		expect(statSync(`${notificationLogDir()}/2026-09-07.jsonl`).mode & 0o777).toBe(0o600);
+	});
+
+	it("does not throw when the directory cannot be written", () => {
+		mkdirSync(home, { recursive: true });
+		writeFileSync(notificationLogDir(), "not a directory");
+		expect(() => appendNotificationLog(makeRow(), new Date(2026, 8, 7))).not.toThrow();
+		rmSync(notificationLogDir(), { force: true });
+	});
+
+	it("deletes day-files outside the retention window and keeps the edge", () => {
+		const now = new Date(2026, 8, 7);
+		mkdirSync(notificationLogDir(), { recursive: true });
+		const dayMs = 24 * 60 * 60 * 1000;
+		const oldest = new Date(now.getTime() - (NOTIFICATION_LOG_RETENTION_DAYS - 1) * dayMs);
+		const expired = new Date(now.getTime() - NOTIFICATION_LOG_RETENTION_DAYS * dayMs);
+		const stamp = (date: Date) =>
+			`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+		for (const date of [oldest, expired]) {
+			appendFileSync(`${notificationLogDir()}/${stamp(date)}.jsonl`, "{}\n");
+		}
+		appendFileSync(`${notificationLogDir()}/notes.txt`, "not a day file\n");
+
+		expect(pruneNotificationLog(now)).toBe(1);
+		const left = readdirSync(notificationLogDir());
+		expect(left).toContain(`${stamp(oldest)}.jsonl`);
+		expect(left).not.toContain(`${stamp(expired)}.jsonl`);
+		expect(left).toContain("notes.txt");
+	});
+
+	it("prunes once per day, not on every append", () => {
+		const day = new Date(2026, 8, 7, 8, 0);
+		mkdirSync(notificationLogDir(), { recursive: true });
+		appendFileSync(`${notificationLogDir()}/2020-01-01.jsonl`, "{}\n");
+		appendNotificationLog(makeRow(), day);
+		expect(readdirSync(notificationLogDir())).not.toContain("2020-01-01.jsonl");
+
+		appendFileSync(`${notificationLogDir()}/2020-01-02.jsonl`, "{}\n");
+		appendNotificationLog(makeRow(), new Date(2026, 8, 7, 9, 0));
+		expect(readdirSync(notificationLogDir())).toContain("2020-01-02.jsonl");
+	});
+});

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -21,7 +21,9 @@ import { deliverLaunchHandoff } from "./agent-launch-handoff";
 import * as data from "./data";
 import { loadSpacesFile } from "./spaces-data";
 import { resolveTaskStartRef } from "./task-start-ref";
-import { createScratchTask, createTask, deleteTask, getPushMessage, getPushMessageLocal, launchTaskWithAgentChoice, moveTask, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, dropQueuedAttention, pushCliAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "./rpc-handlers";
+import { createScratchTask, createTask, deleteTask, getPushMessage, getPushMessageLocal, launchTaskWithAgentChoice, moveTask, notifyFromCliDesktop, isAppForeground, getActiveContext, isNotificationSuppressed, activeNotificationSuppression, isProjectSilenced, dropQueuedAttention, pushCliAttention, pushCliToast, pushCliShowImage, pushCliShowArtifact, setFocusMode, clearMergeNotification } from "./rpc-handlers";
+import { appendNotificationLog } from "./notification-log";
+import type { NotificationLogInput, NotificationLogMode, NotificationLogOutcome } from "../shared/notification-log";
 import { getDevServerStatus, runDevServer, stopDevServer, restartDevServer } from "./rpc-handlers/tmux-pty";
 import { getTmuxLayout } from "./pty-server";
 import { scheduleMessage as scheduleMessageCore, sendMessageImmediately } from "./scheduled-message-scheduler";
@@ -342,6 +344,83 @@ async function resolveAgentMessageSource(
 		title: getTaskTitle(found.task),
 		projectId: found.task.projectId,
 	};
+}
+
+/** Everything a notification row knows before the app tries to deliver it. */
+type NotificationLogBase = Omit<NotificationLogInput, "at" | "mode" | "outcome" | "suppressedBy">;
+
+/**
+ * Collect the facts a notification row is made of. The caller's worktree
+ * (`sourceTaskId`) is resolved separately from the notification's target,
+ * because `dev3 notify --task <other>` addresses someone else's card; when the
+ * caller was not in a worktree the source stays null rather than borrowing the
+ * target's identity.
+ */
+async function buildNotificationLogBase(
+	params: Record<string, unknown>,
+	notification: {
+		message: string;
+		level: "info" | "success" | "error";
+		durationMs: unknown;
+		task: Task | null;
+		projectId: string | null;
+		projectName: string | null;
+	},
+): Promise<NotificationLogBase> {
+	const { message, level, durationMs, task, projectId, projectName } = notification;
+	const base: NotificationLogBase = {
+		level,
+		message,
+		taskId: task?.id ?? null,
+		taskSeq: task?.seq ?? null,
+		projectId,
+		sourceTaskId: null,
+		sourceSeq: null,
+	};
+	if (typeof durationMs === "number") base.durationMs = durationMs;
+	if (task) base.taskTitle = getTaskTitle(task);
+	if (projectName) base.projectName = projectName;
+	const sessionId = typeof params.sourceSessionId === "string" ? params.sourceSessionId.trim() : "";
+	if (sessionId) base.sourceSessionId = sessionId;
+
+	const sourceTaskId = typeof params.sourceTaskId === "string" ? params.sourceTaskId.trim() : "";
+	if (!sourceTaskId) return base;
+	try {
+		const found = await resolveTaskAcrossProjects(sourceTaskId);
+		if (found) {
+			base.sourceTaskId = found.task.id;
+			base.sourceSeq = found.task.seq;
+			base.sourceTitle = getTaskTitle(found.task);
+			base.sourceProjectId = found.task.projectId;
+		}
+	} catch {
+		// An ambiguous or stale sender ref is not knowledge — the source stays null.
+	}
+	return base;
+}
+
+/**
+ * Write one notification row, unless this delivery is the CLI's fan-out copy.
+ *
+ * `dev3 notify` sends the same toast to every live dev3 instance so it reaches
+ * whichever app the user is looking at. That is one notification, not N, so only
+ * the instance the CLI addressed first records it.
+ */
+function recordNotification(
+	params: Record<string, unknown>,
+	base: NotificationLogBase,
+	mode: NotificationLogMode,
+	outcome: NotificationLogOutcome,
+): void {
+	if (params.fanout === true) return;
+	const suppressedBy = outcome === "queued" ? activeNotificationSuppression() : [];
+	appendNotificationLog({
+		...base,
+		at: new Date().toISOString(),
+		mode,
+		outcome,
+		...(suppressedBy.length ? { suppressedBy } : {}),
+	});
 }
 
 /**
@@ -1783,6 +1862,10 @@ const handlers: Record<string, Handler> = {
 	},
 
 	// UI control: surface an in-app toast (or native OS notification) from the CLI.
+	//
+	// Every accepted request is also appended to the notification log. The write
+	// is deliberately last and never throws: a toast the user already saw must
+	// not turn into a CLI error because a disk write failed.
 	"ui.notify": async (params) => {
 		const message = ((params.message as string) ?? "").trim();
 		if (!message) throw new Error("message is required");
@@ -1818,6 +1901,9 @@ const handlers: Record<string, Handler> = {
 			projectName = resolved.project.name;
 		}
 
+		// Resolved before delivery so the row can be written whatever happens next.
+		const logBase = await buildNotificationLogBase(params, { message, level, durationMs, task, projectId, projectName });
+
 		if (desktop) {
 			if (!task || !projectId) {
 				throw new Error("desktop notification requires a task — run inside a worktree or pass --task <id>");
@@ -1827,7 +1913,13 @@ const handlers: Record<string, Handler> = {
 				body: message,
 				projectName: projectName ?? undefined,
 			});
-			return { delivered: true, mode: "desktop", taskId: task.id, queued: isNotificationSuppressed() };
+			const queued = isNotificationSuppressed();
+			// A silenced project drops the notification without a trace on screen —
+			// see `deliverTaskNotification`. Recording it would put that trace back.
+			if (!isProjectSilenced(task.projectId)) {
+				recordNotification(params, logBase, "desktop", queued ? "queued" : "delivered");
+			}
+			return { delivered: true, mode: "desktop", taskId: task.id, queued };
 		}
 
 		const payload = {
@@ -1840,12 +1932,21 @@ const handlers: Record<string, Handler> = {
 		};
 		if (isNotificationSuppressed()) {
 			pushCliToast(payload);
+			// Same rule as the desktop path: `pushCliToast` drops a silenced
+			// project's toast outright instead of queuing it.
+			if (!isProjectSilenced(projectId)) {
+				recordNotification(params, logBase, "toast", "queued");
+			}
 			return { delivered: true, mode: "toast", taskId, queued: true };
 		}
 
 		const push = getPushMessage();
-		if (!push) return { delivered: false, mode: "toast" };
+		if (!push) {
+			recordNotification(params, logBase, "toast", "no-window");
+			return { delivered: false, mode: "toast" };
+		}
 		push("cliToast", payload);
+		recordNotification(params, logBase, "toast", "delivered");
 		return { delivered: true, mode: "toast", taskId };
 	},
 

--- a/src/bun/notification-log.ts
+++ b/src/bun/notification-log.ts
@@ -1,0 +1,119 @@
+/**
+ * Append-only log of every `dev3 notify` the app handled.
+ *
+ * Layout: `~/.dev3.0/notifications/YYYY-MM-DD.jsonl` — a NEW top-level directory
+ * beside `data/` and `logs/`, which is the only shape the on-disk invariants in
+ * AGENTS.md allow. Nothing existing is renamed, nothing is migrated, and an older
+ * app version simply never opens this directory.
+ *
+ * Why global rather than per-project like the message log: a notification can be
+ * sent with no task and therefore no project (`dev3 notify "done"` from any
+ * shell). Splitting the same event stream by whether a task happened to be in
+ * context would make "every notification, in order" impossible to read in one
+ * pass. Every row carries its `projectId`, so a per-project view is a filter.
+ *
+ * Why one file per day: retention has to be real, and trimming a single
+ * append-only file means rewriting it — which stops being append-only and loses
+ * rows when two app instances do it at the same moment. Deleting a whole expired
+ * day-file needs no rewrite and no rename.
+ *
+ * Concurrency: one row is one `appendFileSync` on a file opened `O_APPEND`, so
+ * the kernel serialises the seek-and-write and two processes can never overwrite
+ * each other's bytes. Rows are capped at `NOTIFICATION_LOG_MAX_ROW_BYTES` so a
+ * single `write()` always carries the whole line. A reader that meets a torn
+ * line skips it.
+ *
+ * Privacy: messages land unencrypted, exactly as the agents wrote them. The file
+ * is `0600`, same as the message log, and nothing leaves the machine — this log
+ * has no telemetry path and is never uploaded.
+ */
+
+import { appendFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { NOTIFICATION_LOG_RETENTION_DAYS, type NotificationLogInput, serializeNotificationLogRow } from "../shared/notification-log";
+import { DEV3_HOME } from "./paths";
+import { createLogger } from "./logger";
+
+const log = createLogger("notification-log");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DAY_FILE_RE = /^(\d{4})-(\d{2})-(\d{2})\.jsonl$/;
+
+/** Local-day stamp, matching the message log's convention. */
+function dayStamp(at: Date): string {
+	return `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
+}
+
+/** The directory holding the day-files. */
+export function notificationLogDir(): string {
+	return `${DEV3_HOME}/notifications`;
+}
+
+function dayFile(at: Date): string {
+	return `${notificationLogDir()}/${dayStamp(at)}.jsonl`;
+}
+
+function parseDay(fileName: string): number | null {
+	const match = DAY_FILE_RE.exec(fileName);
+	if (!match) return null;
+	const [year, month, day] = [Number(match[1]), Number(match[2]), Number(match[3])];
+	const date = new Date(year, month - 1, day);
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+	return date.getTime();
+}
+
+/**
+ * Delete day-files outside the retention window. Best-effort and silent: a
+ * concurrent writer or a permission change must never break a notification.
+ * Returns how many files went.
+ */
+export function pruneNotificationLog(now: Date = new Date()): number {
+	const dir = notificationLogDir();
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+	const cutoff = today - (NOTIFICATION_LOG_RETENTION_DAYS - 1) * DAY_MS;
+	let removed = 0;
+	try {
+		for (const name of readdirSync(dir)) {
+			const day = parseDay(name);
+			if (day === null || day >= cutoff) continue;
+			try {
+				unlinkSync(`${dir}/${name}`);
+				removed += 1;
+			} catch {
+				// Another instance may have removed it already.
+			}
+		}
+	} catch {
+		// No directory yet, or unreadable — nothing to prune.
+	}
+	return removed;
+}
+
+let lastPrunedDay: string | null = null;
+
+function pruneIfNeeded(now: Date): void {
+	const today = dayStamp(now);
+	if (lastPrunedDay === today) return;
+	lastPrunedDay = today;
+	pruneNotificationLog(now);
+}
+
+/** Test seam: forget that today was already pruned. */
+export function resetNotificationLogPruneState(): void {
+	lastPrunedDay = null;
+}
+
+/**
+ * Append one row. Never throws: a notification the user already saw must not be
+ * reported as failed because a log write lost a race with a disk error.
+ */
+export function appendNotificationLog(input: NotificationLogInput, now: Date = new Date()): void {
+	const line = serializeNotificationLogRow(input);
+	try {
+		mkdirSync(notificationLogDir(), { recursive: true });
+		appendFileSync(dayFile(now), line, { mode: 0o600 });
+	} catch (err) {
+		log.warn("Failed to append to the notification log", { error: String(err) });
+		return;
+	}
+	pruneIfNeeded(now);
+}

--- a/src/bun/rpc-handlers.ts
+++ b/src/bun/rpc-handlers.ts
@@ -25,6 +25,7 @@ export {
 	setFocusMode,
 	isTerminalFocusActive,
 	isNotificationSuppressed,
+	activeNotificationSuppression,
 	queueTerminalFocusToast,
 	queueTerminalFocusAttention,
 	dropQueuedAttention,

--- a/src/bun/rpc-handlers/shared.ts
+++ b/src/bun/rpc-handlers/shared.ts
@@ -237,6 +237,15 @@ export function isNotificationSuppressed(): boolean {
 	return notificationSuppressionSources.size > 0;
 }
 
+/**
+ * Which modes are currently holding notifications back, in a stable order.
+ * `isNotificationSuppressed` answers whether; the notification log records why.
+ */
+export function activeNotificationSuppression(): NotificationSuppressionSource[] {
+	const order: NotificationSuppressionSource[] = ["focusMode", "terminalImmersive"];
+	return order.filter((source) => notificationSuppressionSources.has(source));
+}
+
 function flushQueuedNotifications(): void {
 	if (isNotificationSuppressed() || queuedTerminalNotifications.length === 0) return;
 

--- a/src/cli/__tests__/ui-control.test.ts
+++ b/src/cli/__tests__/ui-control.test.ts
@@ -63,9 +63,14 @@ beforeEach(() => {
 	mockSend.mockReset();
 	mockEndpoints.mockReset();
 	mockEndpoints.mockReturnValue([]);
+	// The harness that runs these tests may itself be an agent session, and the
+	// session id is read from the ambient environment — so every case states
+	// whether one exists instead of inheriting the developer's.
+	delete process.env.CLAUDE_CODE_SESSION_ID;
 });
 
 afterEach(() => {
+	delete process.env.CLAUDE_CODE_SESSION_ID;
 	stdoutSpy.mockRestore();
 	stderrSpy.mockRestore();
 	exitSpy.mockRestore();
@@ -84,8 +89,53 @@ describe("notify", () => {
 			level: "info",
 			taskId: CTX.taskId,
 			projectId: CTX.projectId,
+			sourceTaskId: CTX.taskId,
 		});
 		expect(stdoutOutput).toContain("Toast sent");
+	});
+
+	it("names the caller's worktree separately from the task it points at", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, mode: "toast", taskId: "other-task" }));
+
+		await handleNotify(args(["look at this"], { task: "other-task" }), SOCKET, CTX);
+
+		expect(mockSend.mock.calls[0][2]).toMatchObject({ taskId: "other-task", sourceTaskId: CTX.taskId });
+	});
+
+	it("passes the harness session id when the environment carries one", async () => {
+		process.env.CLAUDE_CODE_SESSION_ID = "session-xyz";
+		mockSend.mockResolvedValue(okResp({ delivered: true, mode: "toast", taskId: CTX.taskId }));
+
+		await handleNotify(args(["hi"]), SOCKET, CTX);
+
+		expect(mockSend.mock.calls[0][2]).toMatchObject({ sourceSessionId: "session-xyz" });
+	});
+
+	it("omits the session id rather than inventing one when the environment has none", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, mode: "toast", taskId: CTX.taskId }));
+
+		await handleNotify(args(["hi"]), SOCKET, CTX);
+
+		expect(mockSend.mock.calls[0][2]).not.toHaveProperty("sourceSessionId");
+	});
+
+	it("omits the caller's worktree when the command ran outside one", async () => {
+		mockSend.mockResolvedValue(okResp({ delivered: true, mode: "toast", taskId: null }));
+
+		await handleNotify(args(["hi"]), SOCKET, null);
+
+		expect(mockSend.mock.calls[0][2]).not.toHaveProperty("sourceTaskId");
+	});
+
+	it("marks the fan-out copies so only the primary is recorded", async () => {
+		mockEndpoints.mockReturnValue([SOCKET, "/tmp/guest-a.sock"]);
+		mockSend.mockResolvedValue(okResp({ delivered: true, mode: "toast", taskId: CTX.taskId }));
+
+		await handleNotify(args(["build is green"]), SOCKET, CTX);
+
+		const [primary, fanout] = mockSend.mock.calls;
+		expect(primary[2]).not.toHaveProperty("fanout");
+		expect(fanout[2]).toMatchObject({ fanout: true });
 	});
 
 	it("delivers the toast to every live instance, not just the one it dialed", async () => {

--- a/src/cli/commands/ui-control.ts
+++ b/src/cli/commands/ui-control.ts
@@ -9,6 +9,19 @@ import { parseNotificationDuration } from "../../shared/duration";
 const NOTIFY_MAX_LEN = 500;
 
 /**
+ * The harness session that ran this command, when the environment names one.
+ *
+ * Measured, not assumed: a Claude Code sub-agent inherits its parent's
+ * `CLAUDE_CODE_SESSION_ID` verbatim, so this separates two agent sessions in one
+ * task but never a sub-agent from its parent. Every other harness leaves it
+ * unset, and unset stays unset — a guessed sender is worse than a missing one.
+ */
+function callerSessionId(): string | null {
+	const raw = (process.env.CLAUDE_CODE_SESSION_ID ?? "").trim();
+	return raw ? raw : null;
+}
+
+/**
  * Deliver the same in-app toast to every OTHER live dev3 instance, best-effort.
  *
  * A toast is presentation with no persisted state, so a second delivery costs
@@ -21,10 +34,13 @@ const NOTIFY_MAX_LEN = 500;
 async function fanOutToast(primarySocketPath: string, params: Record<string, unknown>): Promise<number> {
 	const others = allLiveSocketPaths().filter((path) => path !== primarySocketPath);
 	if (!others.length) return 0;
+	// `fanout` tells the receiving app this is the same notification arriving a
+	// second time, so only the primary writes it to the notification log.
+	const fanoutParams = { ...params, fanout: true };
 	const results = await Promise.all(
 		others.map(async (path) => {
 			try {
-				return (await sendRequest(path, "ui.notify", params)).ok;
+				return (await sendRequest(path, "ui.notify", fanoutParams)).ok;
 			} catch {
 				return false;
 			}
@@ -79,6 +95,11 @@ export async function handleNotify(
 	const params: Record<string, unknown> = { message, level };
 	if (durationMs !== undefined) params.durationMs = durationMs;
 	if (desktop) params.desktop = true;
+	// Who sent it, for the notification log. The worktree the command ran in is a
+	// different fact from the task it points at (`--task <other>`), so both travel.
+	if (context?.taskId) params.sourceTaskId = context.taskId;
+	const sessionId = callerSessionId();
+	if (sessionId) params.sourceSessionId = sessionId;
 
 	if (rawTaskId) {
 		params.taskId = expandShortId(rawTaskId, context);

--- a/src/shared/notification-log.ts
+++ b/src/shared/notification-log.ts
@@ -1,0 +1,172 @@
+/**
+ * The on-disk shape of one `dev3 notify` call, and the rules that keep the file
+ * append-only and safe for two app instances at once.
+ *
+ * A notification is the loudest thing an agent can do and the only one that
+ * leaves no trace: a toast lives 5 seconds, an OS notification is gone once the
+ * user dismisses it, and a notification that arrived during Focus Mode may never
+ * be seen at all. This log records the request and what the app did with it, so
+ * "did it ping me while I was away, and about what" has an answer.
+ *
+ * Deliberately NOT the agent message log: `dev3 message` types into another
+ * task's agent and always has a sender and a recipient task, while a
+ * notification is addressed to the human and may carry no task at all. Folding
+ * one into the other would make both unreadable.
+ *
+ * Pure and shared: the writer, any future reader and the renderer all speak this
+ * type, so a row can never mean two different things at the two ends.
+ */
+
+/** Schema version. Bumped only when a reader must branch; readers skip unknown values. */
+export const NOTIFICATION_LOG_VERSION = 1;
+
+/**
+ * Hard ceiling on one serialised row, including its newline.
+ *
+ * Load-bearing for concurrency, not for disk: appends from two processes are
+ * interleaving-safe only while each row is a single `write()`. The CLI already
+ * caps a message at 500 characters, so a real row sits far below this.
+ */
+export const NOTIFICATION_LOG_MAX_ROW_BYTES = 4_096;
+
+/** Days of history kept. Older day-files are deleted, not compacted. */
+export const NOTIFICATION_LOG_RETENTION_DAYS = 30;
+
+/** Marker appended to a message clipped by {@link NOTIFICATION_LOG_MAX_ROW_BYTES}. */
+export const NOTIFICATION_LOG_TRUNCATION_MARK = "…[truncated by the notification log]";
+
+/** In-app toast versus a native OS notification (`--desktop`). */
+export type NotificationLogMode = "toast" | "desktop";
+
+/** The `--level` an agent chose. Same three values the CLI accepts. */
+export type NotificationLogLevel = "info" | "success" | "error";
+
+/**
+ * What the app did with the request — the request and its fate are separate
+ * facts, and a log that recorded only "notify was called" would answer nothing.
+ *
+ * - `delivered` — handed to an open window (toast) or fired natively (desktop).
+ * - `queued` — Focus Mode or immersive terminal held it back for a later flush.
+ *   Whether the user ever saw the flush is not knowable here.
+ * - `no-window` — the app was running with no window to show it in; nothing
+ *   appeared and nothing was queued.
+ */
+export type NotificationLogOutcome = "delivered" | "queued" | "no-window";
+
+/** Why delivery was held back, when it was. Mirrors `NotificationSuppressionSource`. */
+export type NotificationLogSuppression = "focusMode" | "terminalImmersive";
+
+/** One notification request and its outcome. Written once, never amended. */
+export interface NotificationLogRow {
+	v: number;
+	/** ISO timestamp of when the app handled the request, not of authoring. */
+	at: string;
+	mode: NotificationLogMode;
+	level: NotificationLogLevel;
+	/** The text as the agent wrote it, clipped only by the row ceiling. */
+	message: string;
+	/** Custom toast lifetime in milliseconds, on `--duration` calls only. */
+	durationMs?: number;
+
+	/** Task the notification points at — null when it was sent without one. */
+	taskId: string | null;
+	taskSeq: number | null;
+	taskTitle?: string;
+	projectId: string | null;
+	projectName?: string;
+
+	/**
+	 * The worktree the command actually ran in, which is NOT always the task the
+	 * notification points at: `dev3 notify --task <other>` addresses someone
+	 * else's card. Null when the caller was not inside a worktree (a human shell,
+	 * a script), and that null is a real answer rather than a gap to fill.
+	 */
+	sourceTaskId: string | null;
+	sourceSeq: number | null;
+	sourceTitle?: string;
+	sourceProjectId?: string;
+	/**
+	 * The harness session id the caller's environment carried, when it carried
+	 * one (`CLAUDE_CODE_SESSION_ID` today). It separates two agent sessions in one
+	 * task; it does NOT separate a sub-agent from its parent, because a Claude
+	 * Code sub-agent inherits the parent's id verbatim — measured, not assumed.
+	 * Absent for every harness that exposes nothing, and absence stays absence.
+	 */
+	sourceSessionId?: string;
+
+	outcome: NotificationLogOutcome;
+	/** Present only on `queued` rows: every suppression source that was active. */
+	suppressedBy?: NotificationLogSuppression[];
+}
+
+/** Everything needed to write a row, minus the version. */
+export type NotificationLogInput = Omit<NotificationLogRow, "v">;
+
+/** One page of history, as a reader returns it. */
+export interface NotificationLogPage {
+	/** Newest first. */
+	rows: NotificationLogRow[];
+	/**
+	 * The oldest day still on disk (`YYYY-MM-DD`), or null when there is no
+	 * history at all. Trimmed history must read as trimmed, not as silence:
+	 * everything before this day was deleted by the retention policy.
+	 */
+	oldestDay: string | null;
+	/** Days of history the retention policy keeps. */
+	retentionDays: number;
+	/** True when `limit` cut the answer short and older rows still exist on disk. */
+	hasMore: boolean;
+}
+
+function utf8Bytes(text: string): number {
+	return new TextEncoder().encode(text).length;
+}
+
+/** Clip `message` so the whole row fits the ceiling. Returns the text to store. */
+export function clampNotificationMessage(message: string, overheadBytes: number): string {
+	const budget = NOTIFICATION_LOG_MAX_ROW_BYTES - overheadBytes - utf8Bytes(NOTIFICATION_LOG_TRUNCATION_MARK);
+	if (utf8Bytes(message) <= NOTIFICATION_LOG_MAX_ROW_BYTES - overheadBytes) return message;
+	if (budget <= 0) return NOTIFICATION_LOG_TRUNCATION_MARK;
+	// Walk back from the byte budget so a multi-byte character is never cut in half.
+	let end = Math.min(message.length, budget);
+	while (end > 0 && utf8Bytes(message.slice(0, end)) > budget) end -= 1;
+	return message.slice(0, end) + NOTIFICATION_LOG_TRUNCATION_MARK;
+}
+
+/**
+ * Serialise one row into exactly one line, guaranteed to fit the ceiling.
+ *
+ * The message is clamped against the size of everything else, so a long message
+ * shrinks and the metadata always survives — a row whose outcome had been
+ * dropped would be worthless.
+ */
+export function serializeNotificationLogRow(input: NotificationLogInput): string {
+	const row: NotificationLogRow = { v: NOTIFICATION_LOG_VERSION, ...input };
+	const line = `${JSON.stringify(row)}\n`;
+	if (utf8Bytes(line) <= NOTIFICATION_LOG_MAX_ROW_BYTES) return line;
+	const overhead = utf8Bytes(`${JSON.stringify({ ...row, message: "" })}\n`);
+	return `${JSON.stringify({ ...row, message: clampNotificationMessage(row.message, overhead) })}\n`;
+}
+
+/**
+ * Parse one line, or null when it cannot be trusted.
+ *
+ * A torn or half-written line is expected rather than exceptional: the app can
+ * be killed mid-append, and a reader that threw on one bad byte would lose the
+ * whole day. Anything without a timestamp, a message and an outcome is discarded.
+ */
+export function parseNotificationLogRow(line: string): NotificationLogRow | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object") return null;
+	const row = parsed as Partial<NotificationLogRow>;
+	if (typeof row.at !== "string" || typeof row.message !== "string") return null;
+	if (typeof row.mode !== "string" || typeof row.level !== "string" || typeof row.outcome !== "string") return null;
+	return row as NotificationLogRow;
+}


### PR DESCRIPTION
`dev3 notify` was the loudest thing an agent could do and the only one that left no trace: a toast lives seconds, an OS notification dies on dismissal, and one sent during Focus Mode may never be seen at all. Every notification the app handles is now appended to `~/.dev3.0/notifications/YYYY-MM-DD.jsonl` — `0600`, 30-day retention by deleting whole expired day-files, nothing renamed and nothing migrated, so an older installed version simply never opens it.

**This ships collection only — there is no UI.** No renderer file is in the diff. Showing these events in the agent-traffic timeline is deliberately a later change, once a couple of days of real data exist.

### The row

Time, surface (`toast` / `desktop`), level, message and duration; the task it points at; the worktree it was sent from — a separate fact, because `dev3 notify --task <other>` points at someone else's card while running in your own; and the outcome: `delivered`, `queued` (naming which suppression source held it), or `no-window`.

### Why a global log rather than a per-project one

A notification can be sent with no task at all, so there is no project to file it under — per-project storage would silently drop exactly the calls a human makes. Every row carries its own `projectId`, so a per-project view is a filter rather than a layout. One file per day because trimming a single append-only file means rewriting it, which stops being append-only and loses rows when two instances trim at once. Full reasoning in `decisions/2026/09/07/notification-history-log-is-global-not-per-project.md`.

### Three things it deliberately does not know

- **Sub-agent identity does not exist and is not faked.** Measured, not assumed: a Claude Code sub-agent inherits its parent's `CLAUDE_CODE_SESSION_ID`, `CLAUDE_PID` and `CLAUDE_CODE_CHILD_SESSION` verbatim. `sourceSessionId` separates two agent sessions in one task and nothing finer; every other harness leaves it absent, and absence stays absence.
- **Whether the user saw it.** `delivered` means handed to an open window or fired natively, no more.
- **Silenced (streamer-mode) projects write no row at all.** `deliverTaskNotification` drops those so they leave no trace on screen "now or after streamer mode goes off"; a log a future timeline renders would put that trace back.

`dev3 notify` fans the same toast out to every live instance so it reaches whichever app the user is looking at; the CLI marks the copies with `fanout: true` so only the primary writes a row.

Nothing here has a telemetry path and nothing leaves the machine.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=575c4054-7deb-4e1f-980b-ac65034ea001) · `dev3://task/575c4054-7deb-4e1f-980b-ac65034ea001` _(dev3 added this footer — turn it off in Settings → Tasks.)_
