### PR TITLE
Take the terminal cell height from the font's line box

### DIFF
--- a/change-logs/2026/09/08/fix-terminal-cell-line-height.md
+++ b/change-logs/2026/09/08/fix-terminal-cell-line-height.md
@@ -1,0 +1,5 @@
+Short: Terminal lines get their real spacing
+
+Terminal rows are now spaced the way the font was designed to be set, instead of being derived from the ink of a capital "M" plus a guess: at font size 16 JetBrains Mono goes from 17 px to its designed 21 px, so descenders no longer touch the next line and the terminal matches Ghostty, Terminal.app, iTerm2 and VS Code at the same nominal size. Cell width is unchanged.
+
+Suggested by @vit-pavlenko (h0x91b/dev-3.0#1668)

--- a/decisions/2026/09/08/cell-height-from-the-font-line-box.md
+++ b/decisions/2026/09/08/cell-height-from-the-font-line-box.md
@@ -1,0 +1,74 @@
+# Terminal cell height comes from the font's line box, not from the ink of an "M"
+
+## Context
+
+Issue #1668: at terminal font size 16 with JetBrains Mono, dev3 set lines 17 CSS px
+apart while Ghostty, Terminal.app, iTerm2 and VS Code all set them 21 px apart.
+Descenders of one row touched the next. The reporter also measured a 10 px cell
+width against Ghostty's 9.5 px.
+
+## Investigation
+
+`measureFont()` in `ghostty-web@0.4.0` (`dist/ghostty-web.js:1366`) is
+
+```js
+const m = ctx.measureText("M");
+const asc  = m.actualBoundingBoxAscent  || fontSize * 0.8;
+const desc = m.actualBoundingBoxDescent || fontSize * 0.2;
+return { width: Math.ceil(m.width), height: Math.ceil(asc + desc) + 2, baseline: Math.ceil(asc) + 1 };
+```
+
+Measured over all 16 bundled fonts x 12 sizes (8-32), in headless Chromium **and** in
+WKWebView — the engine the desktop app actually renders in:
+
+- `actualBoundingBoxDescent` of "M" is **0 in 15 of the 16 fonts**, so the `||` fallback
+  fires on nearly every path and replaces a legitimate zero with `fontSize * 0.2`.
+- The result therefore never contains the font's own line metrics. At size 16 it is
+  17 px for JetBrains Mono (designed 21), 19-ish for Hack (designed 19), and 17 for
+  0xProto (designed 25) — every font within a pixel or two of the same cell.
+- `fontBoundingBoxAscent + fontBoundingBoxDescent` **is** the designed line box.
+  Chromium and WKWebView returned byte-identical integers in all 192 font/size pairs,
+  and those integers are the font's `hhea` ascender/descender scaled per side —
+  cross-checked against the woff2 tables with fontTools (JetBrains Mono: 1020/-300
+  over 1000 upm = 1.32 em = 21 px at 16).
+
+Live proof in the running app (QA board, JetBrains Mono 16, 1440x786 pane): the canvas
+went from 1440x782 (46 rows x 17) to 1440x777 (37 rows x 21), columns unchanged at 144.
+
+## Decision
+
+`src/mainview/terminal-cell-metrics.ts` wraps the renderer's `measureFont` — the same
+instance-wrapping pattern as `terminal-glyph-cell-fit.ts` and the cursor gate — and
+replaces `height` and `baseline` with `ceil(fontBoundingBoxAscent)` plus
+`ceil(fontBoundingBoxDescent)`. Each side is ceiled on its own so neither is cropped.
+A measurement the engine cannot answer falls back to the vendor's own cell verbatim.
+`TerminalView.tsx` installs it before the glyph cell fit and disposes it after.
+
+**The cell width is deliberately left on the vendor's `Math.ceil` in CSS pixels.**
+Rounding it in device pixels would reproduce Ghostty's 9.5 px, but it lands the cell
+*narrower than the glyph advance* in 67 of the 192 measured pairs (up to a full CSS
+pixel), and the reference-font clamp in `terminal-font.ts` is built on that ceil —
+see `decisions/2026/08/25/terminal-font-width-is-clamped-to-the-reference.md`. The
+remaining 0.5 px per column is reported in the issue rather than fixed here.
+
+## Risks
+
+- **Fewer visible rows in the same pane.** At size 16 a 786 px pane goes from 46 rows
+  to 37. That is the point — it matches every other terminal — but it is a visible
+  change for every user.
+- **0xProto declares 1.56 em**, so its cell grows from 17 px to 25 px at size 16. That
+  is the font's own design and Ghostty renders it the same way, but it is the largest
+  jump of the bundled set.
+- The wrapper reaches a `private` vendor method by cast. A vendor rename breaks it
+  silently — the unit suite asserts the resulting cell, which is what would catch it.
+
+## Alternatives considered
+
+- **Patch `node_modules`.** Not a deliverable; the next install erases it.
+- **Fork ghostty-web.** Disproportionate for one formula, and the wrapper pattern for
+  this renderer already exists in five places.
+- **Upstream first.** Still worth doing (`||` should be `??`, and the height should come
+  from the line box), but it cannot ship dev3's fix on any timeline we control.
+- **`actualBoundingBoxDescent` with `??` instead of `||`.** Fixes the swallowed zero but
+  keeps the cell tied to the ink of one capital letter, which is not a line metric: for
+  JetBrains Mono at 16 it yields `ceil(11.68 + 0) + 2` = 14 px, worse than today.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -34,6 +34,7 @@ import { installRenderGuard, type RenderGuard } from "./terminal-render-guard";
 import { session } from "./terminal-session-stats";
 import { createTerminalLatencyProbe, registerLatencyProbe } from "./terminal-latency";
 import { createBreadcrumbTrail } from "./terminal-breadcrumbs";
+import { installCellLineBox, type CellLineBox } from "./terminal-cell-metrics";
 import { installGlyphCellFit, type GlyphCellFit } from "./terminal-glyph-cell-fit";
 import { installGlyphAtlas, type GlyphAtlasHandle } from "./terminal-glyph-atlas";
 import { getScrollThreshold } from "./scroll-speed";
@@ -345,6 +346,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 	/** Hides the cursor while input would not reach this terminal. */
 	const cursorGateRef = useRef<CursorVisibilityGate | null>(null);
 	const renderGuardRef = useRef<RenderGuard | null>(null);
+	/** Gives the cell the height the font was designed to be set at. */
+	const cellLineBoxRef = useRef<CellLineBox | null>(null);
 	/** Keeps block, box-drawing and powerline glyphs on the cell background's box. */
 	const glyphFitRef = useRef<GlyphCellFit | null>(null);
 	const glyphAtlasRef = useRef<GlyphAtlasHandle | null>(null);
@@ -793,6 +796,10 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			if (term.renderer) {
 				cursorGateRef.current = installCursorVisibilityGate(term.renderer);
 				cursorGateRef.current.setCursorVisible(inputReachesTerminal());
+				// BEFORE the glyph fit, which fits glyphs to whatever cell this leaves:
+				// the vendor's cell ignores the font's line metrics entirely, so every
+				// font came out ~17px tall at size 16 (issue #1668).
+				cellLineBoxRef.current = installCellLineBox(term.renderer);
 				// Powerline prompts and block-drawn bars are only flush if the glyph
 				// shares the background's cell box; the vendor's own metrics do not.
 				glyphFitRef.current = installGlyphCellFit(term.renderer);
@@ -2096,6 +2103,8 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 			glyphAtlasRef.current = null;
 			glyphFitRef.current?.dispose();
 			glyphFitRef.current = null;
+			cellLineBoxRef.current?.dispose();
+			cellLineBoxRef.current = null;
 			layoutObserver?.disconnect();
 			mouseCleanup?.();
 			linkUnderlines?.dispose();

--- a/src/mainview/__tests__/terminal-cell-metrics.test.ts
+++ b/src/mainview/__tests__/terminal-cell-metrics.test.ts
@@ -1,0 +1,138 @@
+// Drives ghostty-web's REAL CanvasRenderer, so the cell the terminal actually
+// grids on is what is asserted — not our own abstraction over it.
+//
+// The stub font in `recordingCtx` carries the vendor's bug: an "M" whose ink is
+// 12 + 3 = 15 tall inside a line box of 14 + 4 = 18. The vendor's formula
+// (`ceil(ink) + 2`) therefore gives a 17px cell with the baseline at 13, and the
+// font's designed 18px line box never enters it.
+import { CanvasRenderer } from "ghostty-web";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { recordingCtx } from "../terminal-bidi/__tests__/fixtures";
+import {
+	clearCellMetricsCache,
+	installCellLineBox,
+	isCellLineBoxInstalled,
+	lineBoxCell,
+} from "../terminal-cell-metrics";
+
+const VENDOR_HEIGHT = 17;
+const VENDOR_BASELINE = 13;
+const LINE_BOX_HEIGHT = 18;
+const LINE_BOX_BASELINE = 14;
+const CELL_WIDTH = 10;
+
+let getContextSpy: ReturnType<typeof vi.spyOn>;
+
+function stubContext(ctx: Record<string, unknown>) {
+	getContextSpy = vi
+		.spyOn(HTMLCanvasElement.prototype, "getContext")
+		.mockImplementation(() => ctx as unknown as CanvasRenderingContext2D);
+}
+
+beforeEach(() => {
+	clearCellMetricsCache();
+	stubContext(recordingCtx().ctx);
+});
+
+afterEach(() => {
+	getContextSpy.mockRestore();
+});
+
+function newRenderer() {
+	return new CanvasRenderer(document.createElement("canvas"), {
+		fontSize: 15,
+		fontFamily: "monospace",
+		cursorBlink: false,
+		devicePixelRatio: 1,
+	});
+}
+
+describe("lineBoxCell", () => {
+	it("takes the font's designed line box, ascent and descent each ceiled", () => {
+		// JetBrains Mono at size 16, as both Chromium and WKWebView report it.
+		expect(lineBoxCell({ fontBoundingBoxAscent: 16, fontBoundingBoxDescent: 5 } as TextMetrics))
+			.toEqual({ height: 21, baseline: 16 });
+	});
+
+	it("ceils each side separately, so neither ascent nor descent is cropped", () => {
+		// The same font's unrounded metrics: 1020/1000 and 300/1000 of 16px.
+		expect(lineBoxCell({ fontBoundingBoxAscent: 16.32, fontBoundingBoxDescent: 4.8 } as TextMetrics))
+			.toEqual({ height: 22, baseline: 17 });
+	});
+
+	it("keeps a legitimate zero descent instead of substituting a guess", () => {
+		expect(lineBoxCell({ fontBoundingBoxAscent: 14, fontBoundingBoxDescent: 0 } as TextMetrics))
+			.toEqual({ height: 14, baseline: 14 });
+	});
+
+	it("refuses a measurement it cannot use", () => {
+		expect(lineBoxCell({} as TextMetrics)).toBeNull();
+		expect(lineBoxCell({ fontBoundingBoxAscent: Number.NaN, fontBoundingBoxDescent: 4 } as TextMetrics)).toBeNull();
+		expect(lineBoxCell({ fontBoundingBoxAscent: 0, fontBoundingBoxDescent: 4 } as TextMetrics)).toBeNull();
+		expect(lineBoxCell({ fontBoundingBoxAscent: 16, fontBoundingBoxDescent: -2 } as TextMetrics)).toBeNull();
+	});
+});
+
+describe("installCellLineBox", () => {
+	it("the vendor's own cell ignores the font's line box", () => {
+		const metrics = newRenderer().getMetrics();
+		expect(metrics.height).toBe(VENDOR_HEIGHT);
+		expect(metrics.baseline).toBe(VENDOR_BASELINE);
+	});
+
+	it("replaces the cell height and baseline with the font's line box", () => {
+		const renderer = newRenderer();
+		installCellLineBox(renderer);
+		const metrics = renderer.getMetrics();
+		expect(metrics.height).toBe(LINE_BOX_HEIGHT);
+		expect(metrics.baseline).toBe(LINE_BOX_BASELINE);
+	});
+
+	it("leaves the cell width on the vendor's ceil of the advance", () => {
+		const renderer = newRenderer();
+		installCellLineBox(renderer);
+		expect(renderer.getMetrics().width).toBe(CELL_WIDTH);
+	});
+
+	it("re-applies itself when the font changes", () => {
+		const renderer = newRenderer();
+		installCellLineBox(renderer);
+		renderer.setFontSize(20);
+		// The stub font reports the same box at any size; what matters is that the
+		// vendor's remeasure did not put its own formula back.
+		expect(renderer.getMetrics().height).toBe(LINE_BOX_HEIGHT);
+	});
+
+	it("restores the vendor's cell on dispose, and survives a second dispose", () => {
+		const renderer = newRenderer();
+		const handle = installCellLineBox(renderer);
+		expect(isCellLineBoxInstalled(renderer)).toBe(true);
+		handle.dispose();
+		expect(isCellLineBoxInstalled(renderer)).toBe(false);
+		expect(renderer.getMetrics().height).toBe(VENDOR_HEIGHT);
+		expect(renderer.getMetrics().baseline).toBe(VENDOR_BASELINE);
+		handle.dispose();
+		expect(renderer.getMetrics().height).toBe(VENDOR_HEIGHT);
+	});
+
+	it("installs once, so a second install cannot stack a wrapper", () => {
+		const renderer = newRenderer();
+		const first = installCellLineBox(renderer);
+		installCellLineBox(renderer);
+		first.dispose();
+		expect(isCellLineBoxInstalled(renderer)).toBe(false);
+		expect(renderer.getMetrics().height).toBe(VENDOR_HEIGHT);
+	});
+
+	it("keeps the vendor's cell when the engine reports no line box", () => {
+		getContextSpy.mockRestore();
+		const recorder = recordingCtx();
+		// An engine that answers measureText without the fontBoundingBox fields.
+		recorder.ctx.measureText = () => ({ width: 9.5, actualBoundingBoxAscent: 12, actualBoundingBoxDescent: 3 });
+		stubContext(recorder.ctx);
+		const renderer = newRenderer();
+		installCellLineBox(renderer);
+		expect(renderer.getMetrics().height).toBe(VENDOR_HEIGHT);
+		expect(renderer.getMetrics().baseline).toBe(VENDOR_BASELINE);
+	});
+});

--- a/src/mainview/terminal-cell-metrics.ts
+++ b/src/mainview/terminal-cell-metrics.ts
@@ -1,0 +1,112 @@
+/**
+ * Give the terminal cell the height the font was designed to be set at.
+ *
+ * ghostty-web derives the cell from the INK box of a capital "M":
+ * `Math.ceil(actualBoundingBoxAscent + actualBoundingBoxDescent) + 2`. "M" has no
+ * descender, so `actualBoundingBoxDescent` is 0 in 15 of the 16 bundled fonts and
+ * a `||` fallback substitutes `fontSize * 0.2` — the ink of one capital plus a
+ * guess. The font's own line metrics never enter the result, so every font ends up
+ * within a pixel of the same cell: at size 16 the vendor gives 17 px for JetBrains
+ * Mono (designed 21), for Hack (19), and for 0xProto (25) alike. Descenders of one
+ * row then touch the next, and the same text is visibly tighter than in Ghostty,
+ * Terminal.app, iTerm2 or VS Code — issue #1668.
+ *
+ * `fontBoundingBoxAscent + fontBoundingBoxDescent` is that designed line box. Both
+ * engines that matter here agree on it: measured over 16 bundled fonts x 12 sizes,
+ * Chromium and WKWebView return identical integers in all 192 pairs, and those
+ * integers are the font's `hhea` ascender/descender scaled per side (verified
+ * against the woff2 tables with fontTools).
+ *
+ * The cell WIDTH is deliberately left on the vendor's `Math.ceil` in CSS pixels.
+ * Rounding it in device pixels would match Ghostty's 9.5 px more closely, but it
+ * lands narrower than the glyph advance in 67 of those 192 pairs and the reference
+ * clamp in `terminal-font.ts` is built on the ceil — see
+ * `decisions/2026/09/08/cell-height-from-the-font-line-box.md`.
+ */
+
+interface CellMetrics {
+	width: number;
+	height: number;
+	baseline: number;
+}
+
+/**
+ * Reached by cast, not by structural type: `measureFont` and the font fields are
+ * `private` on the vendor's `CanvasRenderer`.
+ */
+interface MeasurableRenderer {
+	measureFont(): CellMetrics;
+	remeasureFont(): void;
+	fontSize?: number;
+	fontFamily?: string;
+}
+
+const ORIGINAL_MEASURE_FONT = Symbol.for("dev3.terminalCellMetrics.originalMeasureFont");
+
+type WrappedRenderer = MeasurableRenderer & {
+	[ORIGINAL_MEASURE_FONT]?: MeasurableRenderer["measureFont"];
+};
+
+export interface CellLineBox {
+	/** Restore the vendor's own cell metrics and remeasure. Safe to call twice. */
+	dispose(): void;
+}
+
+/**
+ * The font's designed line box, in whole CSS pixels, or null when the engine
+ * cannot answer. Each side is ceiled on its own so neither the ascent nor the
+ * descent is ever cropped; Chromium and WebKit already hand over integers, so the
+ * ceil only guards an engine that does not.
+ */
+export function lineBoxCell(metrics: TextMetrics): { height: number; baseline: number } | null {
+	const ascent = metrics.fontBoundingBoxAscent;
+	const descent = metrics.fontBoundingBoxDescent;
+	if (!Number.isFinite(ascent) || !Number.isFinite(descent)) return null;
+	if (!(ascent > 0) || descent < 0) return null;
+	const baseline = Math.ceil(ascent);
+	const height = baseline + Math.ceil(descent);
+	return { height, baseline };
+}
+
+let measuringCtx: CanvasRenderingContext2D | null | undefined;
+
+/** Drops the cached measuring context. Exported for tests. */
+export function clearCellMetricsCache(): void {
+	measuringCtx = undefined;
+}
+
+export function installCellLineBox(renderer: object): CellLineBox {
+	const target = renderer as WrappedRenderer;
+
+	if (!target[ORIGINAL_MEASURE_FONT] && typeof target.measureFont === "function") {
+		const original = target.measureFont;
+		target[ORIGINAL_MEASURE_FONT] = original;
+		target.measureFont = function lineBoxMeasureFont(this: MeasurableRenderer): CellMetrics {
+			const vendor = original.call(this);
+			if (measuringCtx === undefined) measuringCtx = document.createElement("canvas").getContext("2d");
+			if (!measuringCtx) return vendor;
+			measuringCtx.font = `${this.fontSize}px ${this.fontFamily}`;
+			const box = lineBoxCell(measuringCtx.measureText("M"));
+			// A degenerate measurement must not shrink the terminal to nothing: the
+			// vendor's own cell, wrong as it is, still renders.
+			if (!box) return vendor;
+			return { width: vendor.width, height: box.height, baseline: box.baseline };
+		};
+		// The constructor already measured with the vendor's formula.
+		if (typeof target.remeasureFont === "function") target.remeasureFont();
+	}
+
+	return {
+		dispose() {
+			const original = target[ORIGINAL_MEASURE_FONT];
+			if (!original) return;
+			target.measureFont = original;
+			delete target[ORIGINAL_MEASURE_FONT];
+			if (typeof target.remeasureFont === "function") target.remeasureFont();
+		},
+	};
+}
+
+export function isCellLineBoxInstalled(renderer: object): boolean {
+	return (renderer as WrappedRenderer)[ORIGINAL_MEASURE_FONT] !== undefined;
+}

--- a/src/mainview/terminal-glyph-cell-fit.ts
+++ b/src/mainview/terminal-glyph-cell-fit.ts
@@ -2,13 +2,18 @@
  * Put box-drawing, block and powerline glyphs on the same integer cell box the
  * cell background is painted on.
  *
- * ghostty-web derives the cell from the INK box of a capital "M" — `measureFont`
- * is `Math.ceil(ascent + descent) + 2` tall and `Math.ceil(advance)` wide — but
- * draws every glyph into the font's own line box at the font's own advance. The
- * two boxes disagree on both axes: at 14px JetBrains Mono the cell is 16px tall
- * against an 18px line box, and 9px wide against an 8.4px advance. So a
- * powerline cap lands 2.5px above the background segment it is supposed to join,
- * and each full block leaves a 0.6px seam against its neighbour.
+ * ghostty-web draws every glyph into the font's own line box at the font's own
+ * advance, but grids on a cell that is `Math.ceil(advance)` wide. The two
+ * disagree on width: at 14px JetBrains Mono the cell is 9px against an 8.4px
+ * advance, so each full block leaves a 0.6px seam against its neighbour.
+ *
+ * The height axis used to disagree too — the vendor's cell came from the INK box
+ * of a capital "M" and was 16px against an 18px line box, putting a powerline cap
+ * 2.5px above the background segment it joins. `terminal-cell-metrics.ts` now
+ * gives the cell the font's own line box, so on that axis the fit is close to an
+ * identity transform; it still has to run, because the width axis has not moved
+ * and because a partial glyph is fitted from a line box that is measured
+ * unrounded while the cell is whole pixels.
  *
  * Native Ghostty avoids this by constraining these glyphs to the cell. This does
  * the same, for exactly the codepoints that are meant to touch the cell edges,


### PR DESCRIPTION
Terminal rows were spaced by the ink box of a capital "M" plus a guess, so the font's own line metrics never reached the grid. `measureFont` in `ghostty-web@0.4.0` reads `actualBoundingBoxDescent` of "M" — legitimately `0` in 15 of the 16 bundled fonts — and a `||` treats that zero as a failure, substituting `fontSize * 0.2` on essentially every path. At size 16 the result is ~17 px for every font alike: JetBrains Mono (designed for 21), Hack (19), 0xProto (25). Descenders touched the next row and the same text read visibly tighter than in Ghostty, Terminal.app, iTerm2 or VS Code.

`src/mainview/terminal-cell-metrics.ts` wraps the renderer's `measureFont` — the same instance-wrapping pattern the glyph cell fit and the cursor gate already use on this renderer — and returns `ceil(fontBoundingBoxAscent) + ceil(fontBoundingBoxDescent)` for height and baseline, each side ceiled on its own so neither is cropped. A measurement the engine cannot answer falls back to the vendor's cell verbatim. No `node_modules` edit, no fork, no dependency change.

**Cell width is deliberately unchanged**, so this refs #1668 rather than closing it. Ghostty's 9.5 px comes from rounding in device pixels; measured over 16 bundled fonts x 12 sizes (192 pairs), that rounding lands the cell narrower than the glyph advance in 67 of them, and the reference-font clamp in `terminal-font.ts` is built on the current `ceil`. The width axis is tracked as bounded follow-up work.

Evidence: the 17 px / 21 px numbers reproduce identically in headless Chromium and in WKWebView across all 192 font/size pairs, and `fontBoundingBox*` was cross-checked against the `hhea` tables of all 17 shipped woff2 files with fontTools. Live, a 1440x786 pane goes from 1440x782 (46 rows x 17) to 1440x777 (37 x 21) with columns unchanged at 144 — fewer rows in the same pane is the intended, visible consequence. Rationale and alternatives: `decisions/2026/09/08/cell-height-from-the-font-line-box.md`.

Reported by @vit-pavlenko.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=389f330e-5d1a-40a3-a50e-54650135ef94) · `dev3://task/389f330e-5d1a-40a3-a50e-54650135ef94` _(dev3 added this footer — turn it off in Settings → Tasks.)_
