### PR TITLE
Quantize the terminal cell width on the device pixel grid

### DIFF
--- a/change-logs/2026/09/08/fix-terminal-cell-width-device-grid.md
+++ b/change-logs/2026/09/08/fix-terminal-cell-width-device-grid.md
@@ -1,0 +1,5 @@
+Short: Terminal columns match other terminals
+
+Terminal cell width is now quantized on the device pixel grid the way native Ghostty does it, instead of being rounded up in CSS pixels: at font size 16 JetBrains Mono goes from 10 px to Ghostty's 9.5 px per column on a 2x display. The old rounding also let two bundled fonts (Hack and Meslo LG S) render wider than the reference font at sizes 15, 20, 25 and 30 in the desktop app, and made the desktop app and remote browser mode disagree on the column count for the same font — both are fixed. Font list, font sizes, the picker and zoom are unchanged.
+
+Suggested by @vit-pavlenko (h0x91b/dev-3.0#1668)

--- a/decisions/2026/09/08/cell-height-from-the-font-line-box.md
+++ b/decisions/2026/09/08/cell-height-from-the-font-line-box.md
@@ -1,5 +1,11 @@
 # Terminal cell height comes from the font's line box, not from the ink of an "M"
 
+> Partly superseded on 2026-09-08 by `decisions/2026/09/08/cell-width-on-the-device-pixel-grid.md`:
+> the width axis is no longer left on the vendor's `ceil`, and this record's reason for leaving it
+> there — that device rounding would break the reference clamp — turned out to be backwards.
+> Measurement showed the `ceil` is what breaks the clamp, in 8 of 400 font/size pairs in WKWebView.
+> The height decision below stands unchanged.
+
 ## Context
 
 Issue #1668: at terminal font size 16 with JetBrains Mono, dev3 set lines 17 CSS px
@@ -40,7 +46,9 @@ went from 1440x782 (46 rows x 17) to 1440x777 (37 rows x 21), columns unchanged 
 `src/mainview/terminal-cell-metrics.ts` wraps the renderer's `measureFont` — the same
 instance-wrapping pattern as `terminal-glyph-cell-fit.ts` and the cursor gate — and
 replaces `height` and `baseline` with `ceil(fontBoundingBoxAscent)` plus
-`ceil(fontBoundingBoxDescent)`. Each side is ceiled on its own so neither is cropped.
+`ceil(fontBoundingBoxDescent)`. Each side is ceiled on its own so neither is cropped by this code — though both engines were
+later measured returning integers already, in all 400 font/size pairs including fractional sizes,
+so in practice the ceil never binds and the quantization is the engine's own.
 A measurement the engine cannot answer falls back to the vendor's own cell verbatim.
 `TerminalView.tsx` installs it before the glyph cell fit and disposes it after.
 

--- a/decisions/2026/09/08/cell-width-on-the-device-pixel-grid.md
+++ b/decisions/2026/09/08/cell-width-on-the-device-pixel-grid.md
@@ -1,0 +1,108 @@
+# Terminal cell width is quantized on the device pixel grid, not ceiled in CSS pixels
+
+Companion to `cell-height-from-the-font-line-box.md`, which shipped the height axis of
+issue #1668 and deliberately left the width alone. This record closes the width axis and
+**supersedes that record's claim** that device rounding would break the reference clamp —
+measurement showed the opposite.
+
+## Context
+
+Issue #1668 also reported a wider cell than Ghostty: 10 CSS px against 9.5 for JetBrains
+Mono at size 16 on a 2x display. The height record called Ghostty's rule an inference from
+that one number and declined to act on it.
+
+## Investigation
+
+**Ghostty's rule, read from Ghostty** (`ghostty-org/ghostty`, `src/font/Metrics.zig`,
+`fn calc()`, `main` as of 2026-09-08):
+
+```zig
+const cell_width  = @round(face_width);   // in px at the render scale — device pixels
+const cell_height = @round(face_height);
+```
+
+Its own comment gives the reason and accepts the cost:
+
+> We use `@round` for the cell width to limit the difference from the "true" width value
+> to no more than 0.5px. This is a better approximation of the authorial intent of the
+> font than ceiling would be, and makes the apparent spacing match better between low and
+> high DPI displays. […] This does mean that it's possible for a glyph to overflow the
+> edge of the cell by a pixel if it has no side bearings, but in reality such glyphs are
+> generally meant to connect to adjacent glyphs in some way so it's not really an issue.
+
+So 9.5 CSS px is exactly `@round(9.6 × 2) / 2`. The inference is now a fact.
+
+Two equivalences make the rule transferable, both measured rather than assumed:
+`face_width` is the **max advance over printable ASCII 32–126**, and that equals the
+advance of `"M"` — which is what ghostty-web measures — in **all 400** bundled font/size
+pairs; and Ghostty's vertical metrics come from `hhea`, then OS/2 `sTypo*`, then `usWin*`,
+which is what both browser engines already report as `fontBoundingBox*`.
+
+**Our `ceil` is not merely 0.5 px coarser — it breaks an invariant we wrote ourselves.**
+Sweeping the advance of `"M"` for all 16 bundled fonts at every user size 8–32, at the
+fractional sizes `scaledTerminalFontSize()` actually produces, in Chromium and WKWebView
+(400 pairs per engine):
+
+| Rule | Reference-clamp violations | Desktop vs browser disagree on the cell |
+|---|---|---|
+| `ceil` in CSS px (before) | **8 of 400**, WKWebView only | **8 of 400** |
+| `round` in CSS px | 0 | 0 |
+| `round` on the device grid | 0 | 0 |
+
+The eight are Hack and MesloLGS (`scale: 0.9966`) at sizes 15, 20, 25, 30. The trimmed
+size puts the advance a hair above an integer and `ceil` promotes the hair to a whole
+pixel: at size 15 Chromium measures 8.9946 and WKWebView 9.0001, so `ceil` yields 9 and
+10. Confirmed end to end through the real `CanvasRenderer` — in WKWebView, Hack and Meslo
+at user size 15 grid a **10 px** cell against the reference font's **9 px**, which is
+precisely what `terminal-font.ts` exists to prevent, and both become 9 px under the new
+rule.
+
+## Decision
+
+`deviceGridWidth()` in `src/mainview/terminal-cell-metrics.ts` returns
+`max(1, round(advance × ratio)) / ratio`, and the `measureFont` wrapper uses it for
+`width`. The ratio read is **the renderer's own captured `devicePixelRatio`**, never
+`window.devicePixelRatio`: the vendor reads the window value once in its constructor and
+every later `resize()` scales the canvas by that captured number, so sizing the cell from
+the live window value would let the cell and the canvas transform disagree. Reading the
+same field keeps them in lockstep.
+
+The `scale` constants in `BUNDLED_TERMINAL_FONTS`, the font list, the picker and app zoom
+are untouched — measurement showed the clamp holds with the current constants.
+
+Verified through the real renderer with the full wrapper stack (cell metrics, glyph cell
+fit, glyph atlas) at both ratios: stacked full blocks show zero unlit device columns and
+rows across a 190×84 device-pixel band, the box-drawing vertical rule has ink on both
+sides of every interior cell boundary, and every cell of a 20-column text row still
+carries ink. At ratio 1 the result is always an integer, so nothing downstream meets a
+fraction on a non-retina display.
+
+## Risks
+
+- **A fractional CSS cell width (9.5) is new.** `width × ratio` is an integer by
+  construction, so every atlas source rect and cell origin still lands on whole device
+  pixels, and the glyph atlas already keys its cache on the cell width and reads the same
+  ratio. Verified at ratio 2; a ratio the code has never seen (2.5, 3) is untested.
+- **A cell can be up to half a device pixel narrower than the glyph advance.** This is
+  Ghostty's documented trade-off, and the glyph classes its comment names — the ones meant
+  to join their neighbours — are exactly the ones `terminal-glyph-cell-fit.ts` pins to the
+  cell.
+- **Monitor switch is unchanged, and still imperfect.** The vendor captures the ratio once
+  and dev3's DPR-change path only records a breadcrumb, so after moving a window to a
+  display of a different scale the canvas backing scale is stale until the pane is
+  rebuilt — as it was before this change. The cell now shares that staleness instead of
+  contradicting it. Fixing the lifecycle is deliberately out of scope.
+- **Column counts are not promised to equal Ghostty's.** The rule matches; pane geometry,
+  padding and scrollbar handling are ours and were not compared against a running Ghostty.
+
+## Alternatives considered
+
+- **`round` in CSS pixels.** Fixes the clamp violation and the engine split, keeps integer
+  cells, and would have been the fallback if the fractional-width checks had failed — but
+  stays 0.5 px per column wider than Ghostty on every retina display, leaving #1668's
+  width complaint half answered.
+- **Keep `ceil`.** Rejected once the clamp violation was measured: it is not a cosmetic
+  0.5 px, it is a broken invariant in the engine the desktop app actually runs.
+- **Rewrite the `scale` constants or the clamp.** Measured as unnecessary.
+- **Patch `node_modules` or fork ghostty-web.** Same reasoning as the height record: the
+  wrapper is ours, the vendor's formula is not.

--- a/src/mainview/__tests__/terminal-cell-metrics.test.ts
+++ b/src/mainview/__tests__/terminal-cell-metrics.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recordingCtx } from "../terminal-bidi/__tests__/fixtures";
 import {
 	clearCellMetricsCache,
+	deviceGridWidth,
 	installCellLineBox,
 	isCellLineBoxInstalled,
 	lineBoxCell,
@@ -38,12 +39,12 @@ afterEach(() => {
 	getContextSpy.mockRestore();
 });
 
-function newRenderer() {
+function newRenderer(devicePixelRatio = 1) {
 	return new CanvasRenderer(document.createElement("canvas"), {
 		fontSize: 15,
 		fontFamily: "monospace",
 		cursorBlink: false,
-		devicePixelRatio: 1,
+		devicePixelRatio,
 	});
 }
 
@@ -73,6 +74,44 @@ describe("lineBoxCell", () => {
 	});
 });
 
+describe("deviceGridWidth", () => {
+	it("quantizes on the device grid, which on a 1x display is just whole CSS pixels", () => {
+		// JetBrains Mono at size 16: advance 9.6.
+		expect(deviceGridWidth(9.6, 1)).toBe(10);
+		expect(deviceGridWidth(8.4, 1)).toBe(8);
+	});
+
+	it("gives a half CSS pixel on a 2x display — a whole device pixel", () => {
+		// 9.6 x 2 = 19.2 device px, rounded to 19, which is Ghostty's 9.5 CSS px.
+		expect(deviceGridWidth(9.6, 2)).toBe(9.5);
+		expect(deviceGridWidth(8.4, 2)).toBe(8.5);
+	});
+
+	it("never collapses a cell to zero", () => {
+		expect(deviceGridWidth(0.2, 1)).toBe(1);
+		expect(deviceGridWidth(0.1, 2)).toBe(0.5);
+	});
+
+	it("holds the reference clamp where the vendor's ceil breaks it", () => {
+		// The measured case: Hack at user size 15 lands on 8.9946 in Chromium and
+		// 9.0001 in WKWebView, and `ceil` splits those into 9 and 10 — wider than the
+		// reference font's own cell. Quantizing agrees with itself and with the
+		// reference across that hair.
+		const reference = deviceGridWidth(9, 2);
+		expect(deviceGridWidth(8.9946, 2)).toBe(reference);
+		expect(deviceGridWidth(9.0001, 2)).toBe(reference);
+		expect(Math.ceil(8.9946)).not.toBe(Math.ceil(9.0001));
+	});
+
+	it("refuses what it cannot use, so the caller can fall back", () => {
+		expect(deviceGridWidth(Number.NaN, 2)).toBeNull();
+		expect(deviceGridWidth(0, 2)).toBeNull();
+		expect(deviceGridWidth(9.6, 0)).toBeNull();
+		expect(deviceGridWidth(9.6, undefined)).toBeNull();
+		expect(deviceGridWidth(9.6, Number.NaN)).toBeNull();
+	});
+});
+
 describe("installCellLineBox", () => {
 	it("the vendor's own cell ignores the font's line box", () => {
 		const metrics = newRenderer().getMetrics();
@@ -88,10 +127,32 @@ describe("installCellLineBox", () => {
 		expect(metrics.baseline).toBe(LINE_BOX_BASELINE);
 	});
 
-	it("leaves the cell width on the vendor's ceil of the advance", () => {
+	it("replaces the vendor's ceiled width with the device-grid width", () => {
+		// The stub advance is 9.5, which the vendor ceils to 10.
+		expect(newRenderer().getMetrics().width).toBe(CELL_WIDTH);
 		const renderer = newRenderer();
 		installCellLineBox(renderer);
-		expect(renderer.getMetrics().width).toBe(CELL_WIDTH);
+		expect(renderer.getMetrics().width).toBe(10); // round(9.5) at ratio 1
+	});
+
+	it("lands on a half CSS pixel at a 2x ratio, matching Ghostty", () => {
+		const renderer = newRenderer(2);
+		installCellLineBox(renderer);
+		// 9.5 x 2 = 19 device px exactly, so the CSS width stays 9.5 rather than 10.
+		expect(renderer.getMetrics().width).toBe(9.5);
+	});
+
+	it("reads the renderer's own ratio, not the window's", () => {
+		const original = window.devicePixelRatio;
+		Object.defineProperty(window, "devicePixelRatio", { value: 3, configurable: true });
+		try {
+			const renderer = newRenderer(2);
+			installCellLineBox(renderer);
+			// A window ratio of 3 would give round(9.5 * 3) / 3 = 9.333…
+			expect(renderer.getMetrics().width).toBe(9.5);
+		} finally {
+			Object.defineProperty(window, "devicePixelRatio", { value: original, configurable: true });
+		}
 	});
 
 	it("re-applies itself when the font changes", () => {

--- a/src/mainview/terminal-cell-metrics.ts
+++ b/src/mainview/terminal-cell-metrics.ts
@@ -1,5 +1,6 @@
 /**
- * Give the terminal cell the height the font was designed to be set at.
+ * Give the terminal cell the size native Ghostty gives it: the height the font was
+ * designed to be set at, and a width quantized on the device pixel grid.
  *
  * ghostty-web derives the cell from the INK box of a capital "M":
  * `Math.ceil(actualBoundingBoxAscent + actualBoundingBoxDescent) + 2`. "M" has no
@@ -17,11 +18,18 @@
  * integers are the font's `hhea` ascender/descender scaled per side (verified
  * against the woff2 tables with fontTools).
  *
- * The cell WIDTH is deliberately left on the vendor's `Math.ceil` in CSS pixels.
- * Rounding it in device pixels would match Ghostty's 9.5 px more closely, but it
- * lands narrower than the glyph advance in 67 of those 192 pairs and the reference
- * clamp in `terminal-font.ts` is built on the ceil — see
- * `decisions/2026/09/08/cell-height-from-the-font-line-box.md`.
+ * The WIDTH is the vendor's `Math.ceil(advance)` in CSS pixels, and that is a bug of
+ * its own. Native Ghostty rounds the advance on the DEVICE pixel grid
+ * (`@round(face_width)`, `src/font/Metrics.zig`), which is where its 9.5 px against
+ * our 10 px comes from. Measured over the 16 bundled fonts at every size 8-32, at
+ * the fractional sizes the reference clamp actually produces, `Math.ceil` promotes a
+ * sub-hundredth measurement difference into a whole pixel: at size 15 Chromium
+ * measures Hack at 8.9946 and WKWebView at 9.0001, so the desktop app grids one pixel
+ * per column wider than the same font in remote mode, and both Hack and MesloLGS end
+ * up WIDER than the reference font at sizes 15, 20, 25 and 30 — breaking the one
+ * invariant `terminal-font.ts` exists to hold. Rounding on the device grid holds it in
+ * all 400 measured pairs, in both engines, at both DPRs, with the `scale` constants
+ * untouched. See `decisions/2026/09/08/cell-width-on-the-device-pixel-grid.md`.
  */
 
 interface CellMetrics {
@@ -39,6 +47,16 @@ interface MeasurableRenderer {
 	remeasureFont(): void;
 	fontSize?: number;
 	fontFamily?: string;
+	/**
+	 * The renderer's OWN captured ratio — read this, never `window.devicePixelRatio`.
+	 * The vendor reads it once in its constructor and every later `resize()` scales
+	 * the canvas by that captured value, so a cell sized from the live window ratio
+	 * would disagree with the canvas transform the moment a window moves to a display
+	 * of a different scale. Reading the same field keeps the two in lockstep: after a
+	 * monitor switch both are equally stale until the pane is rebuilt, which is
+	 * already true of the canvas today and is not this module's to fix.
+	 */
+	devicePixelRatio?: number;
 }
 
 const ORIGINAL_MEASURE_FONT = Symbol.for("dev3.terminalCellMetrics.originalMeasureFont");
@@ -55,8 +73,9 @@ export interface CellLineBox {
 /**
  * The font's designed line box, in whole CSS pixels, or null when the engine
  * cannot answer. Each side is ceiled on its own so neither the ascent nor the
- * descent is ever cropped; Chromium and WebKit already hand over integers, so the
- * ceil only guards an engine that does not.
+ * descent is ever cropped by THIS code; both engines were measured returning
+ * integers already — in all 400 font/size pairs, fractional sizes included — so in
+ * practice the ceil never binds and the quantization is the engine's own.
  */
 export function lineBoxCell(metrics: TextMetrics): { height: number; baseline: number } | null {
 	const ascent = metrics.fontBoundingBoxAscent;
@@ -66,6 +85,26 @@ export function lineBoxCell(metrics: TextMetrics): { height: number; baseline: n
 	const baseline = Math.ceil(ascent);
 	const height = baseline + Math.ceil(descent);
 	return { height, baseline };
+}
+
+/**
+ * The advance quantized on the device pixel grid, the way native Ghostty does it, or
+ * null when there is nothing better than the vendor's own number.
+ *
+ * A fractional CSS result is intended: at a ratio of 2, `9.5` is a whole 19 device
+ * pixels, which is the point. At ratio 1 the result is always an integer, so nothing
+ * downstream sees a fraction on a non-retina display.
+ *
+ * `Math.round` matches Ghostty's `@round`, and so does its cost: a cell can land up
+ * to half a device pixel narrower than the glyph advance. Ghostty accepts that
+ * deliberately — the only glyphs that fill their advance edge to edge are the ones
+ * meant to join their neighbours, and `terminal-glyph-cell-fit.ts` already pins
+ * exactly those to the cell.
+ */
+export function deviceGridWidth(advance: number, ratio: number | undefined): number | null {
+	if (!Number.isFinite(advance) || !(advance > 0)) return null;
+	if (!Number.isFinite(ratio) || !(ratio! > 0)) return null;
+	return Math.max(1, Math.round(advance * ratio!)) / ratio!;
 }
 
 let measuringCtx: CanvasRenderingContext2D | null | undefined;
@@ -86,11 +125,20 @@ export function installCellLineBox(renderer: object): CellLineBox {
 			if (measuringCtx === undefined) measuringCtx = document.createElement("canvas").getContext("2d");
 			if (!measuringCtx) return vendor;
 			measuringCtx.font = `${this.fontSize}px ${this.fontFamily}`;
-			const box = lineBoxCell(measuringCtx.measureText("M"));
+			// "M" is what the vendor measures, and for every bundled font it is also the
+			// widest printable ASCII advance — the quantity Ghostty takes its cell from.
+			const metrics = measuringCtx.measureText("M");
+			const box = lineBoxCell(metrics);
+			const width = deviceGridWidth(metrics.width, this.devicePixelRatio);
 			// A degenerate measurement must not shrink the terminal to nothing: the
-			// vendor's own cell, wrong as it is, still renders.
-			if (!box) return vendor;
-			return { width: vendor.width, height: box.height, baseline: box.baseline };
+			// vendor's own cell, wrong as it is, still renders. Each axis falls back on
+			// its own, so one bad number cannot drag the other back.
+			if (!box && width === null) return vendor;
+			return {
+				width: width ?? vendor.width,
+				height: box ? box.height : vendor.height,
+				baseline: box ? box.baseline : vendor.baseline,
+			};
 		};
 		// The constructor already measured with the vendor's formula.
 		if (typeof target.remeasureFont === "function") target.remeasureFont();


### PR DESCRIPTION
Second half of #1668, after the height axis shipped in #1674. Native Ghostty quantizes the terminal cell width on the **device** pixel grid — `cell_width = @round(face_width)` in `src/font/Metrics.zig` — and its own comment says why: rounding keeps the error under half a pixel, approximates the font's authorial intent better than ceiling, and keeps apparent spacing consistent between low and high DPI displays. It explicitly accepts that a glyph with no side bearings may overflow by a pixel, because such glyphs are the ones meant to connect to their neighbours. That is where its 9.5 px against our 10 px comes from at JetBrains Mono 16 on a 2x display.

**Our `ceil` in CSS pixels is not merely half a pixel coarser — it breaks an invariant this repo wrote for itself.** Measured over the 16 bundled fonts at every user size 8–32, at the fractional sizes `scaledTerminalFontSize()` actually produces, in Chromium and in WKWebView (400 pairs per engine):

| Rule | Reference-clamp violations | Desktop vs browser disagree on the cell |
| --- | --- | --- |
| `ceil` in CSS px (before) | **8 of 400**, WKWebView only | **8 of 400** |
| `round` in CSS px | 0 | 0 |
| `round` on the device grid (this PR) | 0 | 0 |

Hack and MesloLGS (`scale: 0.9966`) at sizes 15, 20, 25 and 30 land the advance a hair above an integer, and `ceil` promotes the hair to a whole pixel: at size 15 Chromium measures 8.9946 and WKWebView 9.0001, so the desktop app grids a **10 px** cell where the reference font gets 9 px — exactly what the clamp in `terminal-font.ts` exists to prevent — while remote browser mode grids 9 px, giving the two a different column count for the same font. Confirmed end to end through the real `CanvasRenderer`; both are 9 px after this change.

`deviceGridWidth()` returns `max(1, round(advance × ratio)) / ratio`, reading **the renderer's own captured `devicePixelRatio`** rather than `window.devicePixelRatio`: the vendor reads the window value once in its constructor and every later `resize()` scales the canvas by that captured number, so sizing the cell from the live value would let the cell and the canvas transform disagree. The `scale` constants, the font list, the picker, app zoom and the shipped height are untouched — the clamp holds with the current constants.

A fractional CSS width (9.5) is new and intended: `width × ratio` is an integer by construction, so every atlas source rect and cell origin still lands on whole device pixels, and at ratio 1 the result is always an integer. Verified through the full wrapper stack (cell metrics, glyph cell fit, glyph atlas) at both ratios: stacked full blocks show zero unlit device columns and rows across a 190×84 device-pixel band, the box-drawing vertical rule has ink on both sides of every interior cell boundary, and a 20-column text row keeps ink in all 20 cells. Live, a 1440 px pane goes from 160 columns × 9 px to 180 × 8 at JetBrainsMono NF 14, and a ten-character drag selection highlights exactly 80 px.

Not claimed: column counts equal to a running Ghostty (the rule matches its source; pane geometry, padding and scrollbar are ours and were not compared side by side), ratios 2.5 and 3, and no change to the monitor-switch lifecycle — the vendor's captured ratio still goes stale on a display change as it did before, and the cell now shares that staleness instead of contradicting it. Rationale, risks and alternatives: `decisions/2026/09/08/cell-width-on-the-device-pixel-grid.md`, which also supersedes the height record's claim that device rounding would break the clamp.

Refs #1668. Reported by @vit-pavlenko.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=389f330e-5d1a-40a3-a50e-54650135ef94) · `dev3://task/389f330e-5d1a-40a3-a50e-54650135ef94` _(dev3 added this footer — turn it off in Settings → Tasks.)_
