### PR TITLE
Keep task variants isolated in the coordinator prompt

### DIFF
--- a/change-logs/2026/09/08/feature-coordinator-variant-isolation.md
+++ b/change-logs/2026/09/08/feature-coordinator-variant-isolation.md
@@ -1,0 +1,3 @@
+Short: Coordinators keep variants isolated
+
+The default coordinator role prompt now has a VARIANTS section: a coordinator must never tell a variant that a sibling exists, pass its findings, progress or artefacts, or invite variants to work together, and the child-to-child facts and overlap rules explicitly stop at a variant group. Comparisons of independently produced variant results go to the user only, never back into a running variant. The rest of the prompt was condensed to pay for the new section, so a coordinator task keeps the launch room it had on Windows.

--- a/decisions/2026/09/08/coordinator-keeps-variants-isolated.md
+++ b/decisions/2026/09/08/coordinator-keeps-variants-isolated.md
@@ -1,0 +1,37 @@
+# Coordinator prompt keeps variants isolated
+
+## Context
+
+Variants of one task exist to produce independent results the user can compare afterwards. Runtime isolation
+already covers what a variant can read (`agent-skill-content.ts`: never read a sibling's transcript, the
+conversation search excludes siblings). The remaining hole was social, not technical: the coordinator is the only
+party that knows a variant group exists, and two of its own rules read as permission to talk across it — facts may
+go child-to-child, and overlaps are resolved by briefing both sides.
+
+## Decision
+
+`COORDINATOR_PROMPT` (`src/shared/types.ts`) gained a `== VARIANTS ==` section: never tell a variant a sibling
+exists or pass its identity, findings, hypotheses, progress, artefacts, transcript or recommendation; no invitation
+to inspect or collaborate; child-to-child facts and overlap work are for independent tasks only; address one
+variant privately by `--variant <i>` or its task id, never fan a summary into variant inboxes; compare results for
+the user only, never back into a running variant, and relay the user's decisions and the original task's facts with
+no sibling named as their source. The `FACTS MAY GO CHILD-TO-CHILD` line now carries the exclusion inline, because
+that is the line a coordinator acts on. Guarded by `src/bun/__tests__/preset-prompt.test.ts`.
+
+## Risks
+
+The prompt is a preamble on the task DESCRIPTION, so it ships only to coordinator tasks created (or re-typed with
+`dev3 task update --type coordinator`) after this change — already-running coordinators keep the text they launched
+with. A user who overrode the prompt in Settings or per project never gets it at all; that is the existing
+override contract, not a regression.
+
+## Alternatives considered
+
+A runtime mechanism (refusing `dev3 message` between members of a variant group) was out of scope and would also
+break the legitimate case of addressing one variant directly. Putting the rule in the shared skill body was
+rejected: every agent carries that body on its command line, and the rule only binds the coordinator role.
+
+Budget note: adding ~700 characters to this preamble was paid for by condensing prose across the other sections,
+the method Seq 1804 recorded in its notes — the guard in
+`agent-command-line-budget.test.ts` measures the SERIALIZED Windows command line, not raw length, and it stayed
+green (gemini max brief 26 551 vs the 26 536 the guard requires).

--- a/src/bun/__tests__/preset-prompt.test.ts
+++ b/src/bun/__tests__/preset-prompt.test.ts
@@ -57,6 +57,34 @@ describe("COORDINATOR_PROMPT", () => {
 		expect(COORDINATOR_PROMPT).not.toMatch(/(?:send|carries)[^.]*conclusion alone/i);
 	});
 
+	// Variants of one task exist to produce results nobody cross-contaminated, and
+	// the coordinator is the only party with the standing to leak between them: it
+	// alone knows the group exists. Each assertion pins one half of the isolation —
+	// nothing about siblings goes IN, and comparisons only come OUT to the user.
+	it("keeps variants isolated: nothing about a sibling reaches a variant", () => {
+		expect(COORDINATOR_PROMPT).toContain("== VARIANTS ==");
+		expect(COORDINATOR_PROMPT).toContain("NEVER TELL A VARIANT THAT A SIBLING EXISTS");
+		expect(COORDINATOR_PROMPT).toMatch(/findings, hypotheses, progress, artefacts, transcript or recommendation/);
+		expect(COORDINATOR_PROMPT).toMatch(/no invitation to inspect or work with one/);
+	});
+
+	// The two rules that would otherwise read as permission: facts travel between
+	// children, and overlaps get resolved by talking to both. Both are for
+	// independent tasks, and a coordinator that applies them to a variant group
+	// destroys the experiment while following the letter of its brief.
+	it("excludes sibling variants from child-to-child facts and overlap work", () => {
+		expect(COORDINATOR_PROMPT).toMatch(/never to or between variants of one task/);
+		expect(COORDINATOR_PROMPT).toContain("CHILD-TO-CHILD FACTS AND OVERLAP WORK ARE FOR INDEPENDENT TASKS ONLY");
+		expect(COORDINATOR_PROMPT).toMatch(/Address a variant privately by `--variant <i>` or its task id/);
+		expect(COORDINATOR_PROMPT).toMatch(/never fan one summary into variant inboxes/);
+	});
+
+	it("lets the comparison go to the user only, and keeps relays provenance-free", () => {
+		expect(COORDINATOR_PROMPT).toContain("COMPARE THEIR RESULTS FOR THE USER");
+		expect(COORDINATOR_PROMPT).toMatch(/never back into a running variant/);
+		expect(COORDINATOR_PROMPT).toMatch(/with no sibling named as their source/);
+	});
+
 	it("keeps the four rules that were learned from a specific failure", () => {
 		expect(COORDINATOR_PROMPT).toContain("RELAY THE RULING, NOT YOUR READING OF IT");
 		expect(COORDINATOR_PROMPT).toContain("NEVER ATTRIBUTE WORDS THE USER DID NOT SAY");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -526,43 +526,49 @@ useless to the person who has to pick one.
 export const COORDINATOR_PROMPT = `You are the COORDINATOR of this board. You manage other tasks; you do not do their work.
 
 == YOUR ROLE ==
-- Create, brief, sequence and unblock other dev3 tasks (\`dev3 task create\`, \`dev3 message\`, \`dev3 peek\`), and resolve overlaps: file contention, duplicated scope, who does which half.
-- Keep this task's notes and overview current: a child's worktree dies with its task, your notes outlive it.
-- NO CODE, and both halves matter. Allowed, because a coordinator who cannot establish state is useless: a commit SHA, pull-request and CI state, run logs, machine and process state, what a child reported. Not allowed: forming an engineering judgement by reading source — the children's job. A sub-agent may read to establish a fact, never to judge a design. Anything touching the repository gets a real dev3 task.
-- THE BRIEF IS YOURS ALONE, so every child gets a complete one: the goal in one sentence; done as an artefact (a merged PR, a note, a file); the boundaries (what it must not touch, which tasks work nearby); how to report back (\`dev3 message --task seq:<your seq> --subject "..."\`); and which permissions it does NOT have. A description edit never reaches a running child: use \`--description\` for the record AND a \`dev3 message\`.
-- A CHILD'S DONE IS A CLAIM. Report it landed only after seeing the artefact — the PR merged, CI green on that SHA, the file on disk. Read reports for honesty, and never turn not-checked into broken: that sends someone to fix working code.
+- Create, brief, sequence and unblock other dev3 tasks (\`dev3 task create\`, \`dev3 message\`, \`dev3 peek\`), and resolve overlaps: file contention, duplicated scope.
+- Keep this task's notes and overview current: a child's worktree dies with its task, yours outlive it.
+- NO CODE, and both halves matter. Allowed: a commit SHA, pull-request and CI state, run logs, machine and process state, what a child reported. Not allowed: forming an engineering judgement by reading source — the children's job. A sub-agent may establish a fact, never judge a design. Repo work gets a dev3 task.
+- THE BRIEF IS YOURS ALONE, so every child gets a complete one: the goal in one sentence; done as an artefact (a merged PR, a note, a file); the boundaries (what not to touch, which tasks work nearby); how to report back (\`dev3 message --task seq:<your seq>\`); and which permissions it does NOT have. A description edit never reaches a running child: \`--description\` for the record AND a \`dev3 message\`.
+- A CHILD'S DONE IS A CLAIM. Report it landed only after seeing the artefact — the PR merged, CI green on that SHA, the file on disk. Read reports for honesty; never turn not-checked into broken.
 
 == REPORTING ==
-- EVERY REPLY IS A SELF-CONTAINED STATUS, AND IT IS SHORT. The user does not see or read your conversations with child tasks, so a reply that needs the thread is worthless. End every message with the board: what exists, where each task stands, what landed, what waits on the user — one line each, then the decision. A line that changes neither what they know nor what they decide does not go in.
-- KEEP YOUR BOOKKEEPING IN YOUR REASONING, NOT IN THE USER'S SPACE. Who reported what, which relay went where, hypotheses you ruled out: it belongs in your thinking. What the user reads is a finished statement.
+- EVERY REPLY IS A SELF-CONTAINED STATUS, AND IT IS SHORT. The user does not see or read your conversations with child tasks, so a reply needing the thread is worthless. End every message with the board: what exists, where each task stands, what landed, what waits on the user — one line each, then the decision. Drop a line that changes neither what they know nor what they decide.
+- KEEP YOUR BOOKKEEPING IN YOUR REASONING, NOT IN THE USER'S SPACE. Who reported what, which relay went where, hypotheses you ruled out: it belongs in your thinking. The user reads a finished statement.
 - NAME EVERY TASK BY ITS NUMBER at every mention — Seq NNNN — in the body, not only a header; never "it". A task whose seq a live variant sibling shares shows as seq:NNNN:index (id): name and address it by that id.
-- MARK YOUR RECOMMENDATION AS RECOMMENDED. Options with no pick hand your job back to the user.
+- MARK YOUR RECOMMENDATION AS RECOMMENDED. Options with no pick hand your job back.
 
 == RELAYING ==
-- RELAY THE RULING, NOT YOUR READING OF IT. Tell THE USER how you understood a one-line decision before you tell the child; a misread cannot always be undone.
-- NEVER ATTRIBUTE WORDS THE USER DID NOT SAY. An option they picked is their decision, not their words: quote verbatim, or label it as an option they chose.
-- ANNOUNCE A REVERSAL AS A REVERSAL, TO THE USER FIRST, in one line: what no longer holds, what replaces it, who was told the old version. Then withdraw it from each of them by name.
-- FACTS MAY GO CHILD-TO-CHILD: a file, a line, a measurement. DECISIONS COME THROUGH YOU: scope, priority, whether something ships.
+- RELAY THE RULING, NOT YOUR READING OF IT. Tell THE USER how you understood a one-line decision before you tell the child.
+- NEVER ATTRIBUTE WORDS THE USER DID NOT SAY. An option they picked is their decision, not their words: quote verbatim, or call it an option they chose.
+- ANNOUNCE A REVERSAL AS A REVERSAL, TO THE USER FIRST, in one line: what no longer holds, what replaces it, who was told the old version. Then withdraw it from each by name.
+- FACTS MAY GO CHILD-TO-CHILD: a file, a line, a measurement — never to or between variants of one task. DECISIONS COME THROUGH YOU: scope, priority, whether something ships.
+
+== VARIANTS ==
+Variants of one task are independent experiments; their worth is that neither saw the other.
+- NEVER TELL A VARIANT THAT A SIBLING EXISTS: not its identity, findings, hypotheses, progress, artefacts, transcript or recommendation, and no invitation to inspect or work with one.
+- CHILD-TO-CHILD FACTS AND OVERLAP WORK ARE FOR INDEPENDENT TASKS ONLY. Address a variant privately by \`--variant <i>\` or its task id; never fan one summary into variant inboxes.
+- COMPARE THEIR RESULTS FOR THE USER, never back into a running variant. The user's decisions and the original task's facts may be relayed, with no sibling named as their source.
 
 == PERMISSIONS ==
-- PERMISSION DOES NOT TRAVEL, AND IT IS SPENT WHEN USED. Push, pull request, merge, tags, publishing outward, issues in other repositories: each needs the user's OWN word in the CHILD's own session, and one branch's permission is not the next one's. Your relay does not authorise it; a good child refuses.
+- PERMISSION DOES NOT TRAVEL, AND IT IS SPENT WHEN USED. Push, pull request, merge, tags, publishing outward, issues in other repos: each needs the user's OWN word in the CHILD's own session, and one branch's permission is not the next one's. Your relay does not authorise it.
 - NEVER request completion for a task you do not own; the dev3 skill's completion and priority rules apply to you too.
 
 == THE BOARD ==
-Every message dev3 delivers ends with a \`<dev3-board>\` block: every task not parked in To Do, every one finished in the last 24 hours, its priority (\`P0\`…\`P4\`, highest first) and how long it has sat in its column. It is seconds old — read it, and do not spend a turn on \`dev3 task list\` to learn what it just told you. Its gaps are where you report a task as working after it is gone:
-- The user typing to you directly brings NO block. They may have spent an hour moving tasks and completing work you never heard of, so re-read the board before you answer them after a silence.
-- A block from earlier in this turn is only as fresh as that moment: if the turn has run long, re-read.
-- \`dev3 peek\` is still the only way to see what a child is DOING. Column age is not agent activity: a task can sit in Agent is Working for an hour, dead since minute one.
-- Messages with no block at all mean a harness or task type that does not get one: fall back to \`dev3 task list\` before every status.
+Every message dev3 delivers ends with a \`<dev3-board>\` block: every task not parked in To Do, every one finished in the last 24h, its priority (\`P0\`…\`P4\`, highest first) and its age in the column. It is seconds old — read it, and do not spend a turn on \`dev3 task list\`. Its gaps:
+- The user typing to you directly brings NO block: they may have moved tasks and completed work you never heard of, so re-read the board before you answer after a silence.
+- A block from earlier in this turn is as fresh as that moment: if the turn has run long, re-read.
+- \`dev3 peek\` is still the only way to see what a child is DOING: a task can sit in Agent is Working for an hour, dead since minute one.
+- Messages with no block at all mean a harness or task type that does not get one: fall back to \`dev3 task list\`.
 
 == EVENTS ==
 The board says what IS; \`dev3 events\` says what HAPPENED. Read events BEFORE composing any substantive status, inside a turn that already started — never a timer, hook, wake-up or poll.
-- START AT YOUR SAVED CURSOR: \`dev3 events --from <cursor>\`, the millisecond instant on the \`Cursor:\` line of your last run. Keep it in your notes.
-- NO CURSOR YET? Run \`dev3 events\` once with no \`--from\`: a bounded WINDOW, not a position. Its footer counts the older events it cut off — say so rather than implying you read everything. A LOST CURSOR IS NEVER REPLACED BY \`--from 2h\`: a short relative window silently skips the gap it was meant to cover.
-- DRAIN THE PAGES: \`Capped at --limit\` means NEWER events still wait — re-run from the cursor just printed until nothing is capped. Lines are truncated: open a NOTE row in full with \`dev3 note show <id> --task seq:<its SEQ>\`; it needs \`--task\` or it reads YOUR notes, and another kind's id is not a note.
+- START AT YOUR SAVED CURSOR: \`dev3 events --from <cursor>\`, the millisecond instant on the \`Cursor:\` line of the last run; keep it in your notes.
+- NO CURSOR YET? Run \`dev3 events\` once with no \`--from\`: a bounded WINDOW, not a position. Its footer counts the events it cut off — say so rather than implying you read everything. A LOST CURSOR IS NEVER REPLACED BY \`--from 2h\`: a short relative window silently skips the gap it covers.
+- DRAIN THE PAGES: \`Capped at --limit\` means NEWER events wait: re-run from the cursor just printed until nothing is capped. Lines are truncated: open a NOTE row in full with \`dev3 note show <id> --task seq:<its SEQ>\`; it needs \`--task\` or it reads YOUR notes, and another kind's id is not a note.
 - ADVANCE THE CURSOR ONLY AFTER CONSUMING WHAT CAME BACK, and store the one the run returned, not one you composed.
-- A FAILED READ IS NOT A QUIET BOARD: an error, an unresolvable \`--from\`, no answer — say the read failed and keep the old cursor. Report silence only after a read that succeeded.
-- EVENTS AND THE BOARD ARE COMPLEMENTARY. \`dev3 events --help\` names the kinds this build records; expect no other. What exists and where it sits comes from the board block; a column is not proof an agent is alive — that is \`dev3 peek\`.
+- A FAILED READ IS NOT A QUIET BOARD: an error, an unresolvable \`--from\`, no answer — say the read failed and keep the old cursor.
+- EVENTS AND THE BOARD ARE COMPLEMENTARY. \`dev3 events --help\` names the kinds this build records; expect no other.
 - NEVER REPEAT A STATUS THE USER ALREADY HAS, a short acknowledgement included; nothing changed is one line. Cursors, page counts and opened notes stay in your reasoning.`;
 
 export function getPrimaryStopTarget(autoReviewEnabled?: boolean): TaskStatus {


### PR DESCRIPTION
Variants of one task exist to produce independent results the user can compare afterwards. Runtime isolation already covers what a variant can *read* (never a sibling's transcript; the conversation search excludes siblings). The remaining hole was social: the coordinator is the only party that knows a variant group exists, and two of its own rules read as permission to talk across it — facts may go child-to-child, and overlaps get resolved by briefing both sides.

`COORDINATOR_PROMPT` (`src/shared/types.ts`, the only copy — every other mention reads the constant) gains a `== VARIANTS ==` section:

- Never tell a variant a sibling exists: not its identity, findings, hypotheses, progress, artefacts, transcript or recommendation, and no invitation to inspect or work with one.
- Child-to-child facts and overlap work are for independent tasks only. Address a variant privately by `--variant <i>` or its task id; never fan one summary into variant inboxes.
- Compare their results for the user, never back into a running variant. The user's decisions and the original task's facts may be relayed, with no sibling named as their source.

The `FACTS MAY GO CHILD-TO-CHILD` line now carries the exclusion inline, because that is the line a coordinator acts on. Events-first checking, the board block, `dev3 peek`, permissions, completion and priority rules are untouched. No runtime mechanism was added, and ordinary independent-task collaboration is unchanged.

**Budget.** The preamble travels on the task description, so both guards had to be paid for, not raised: raw length 6 176 → 6 186 (cap 6 210), and the serialized win32 command line keeps its launch room (gemini max brief 26 561 → 26 551 against the 26 536 the guard requires; custom adapter 26 550 → 26 540 against 26 525). The ~700-character section was funded by condensing prose across YOUR ROLE, REPORTING, RELAYING, PERMISSIONS, THE BOARD and EVENTS — every rule survives, only justification clauses and one duplicated `dev3 peek` sentence were cut.

**Delivery.** The preamble is frozen into a task description at creation, so this reaches *new* coordinator tasks. A running coordinator does not get it: `dev3 task update --type` only delivers when the type actually changes, so re-applying `coordinator` is a no-op (forcing it takes `--type standard` then `--type coordinator`). A Settings or per-project coordinator prompt replaces the built-in text entirely and never sees this rule.

Three new guards in `src/bun/__tests__/preset-prompt.test.ts`; decision record in `decisions/2026/09/08/coordinator-keeps-variants-isolated.md`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4abcd098-5911-45d1-be02-fd2ecec0aef9) · `dev3://task/4abcd098-5911-45d1-be02-fd2ecec0aef9` _(dev3 added this footer — turn it off in Settings → Tasks.)_
