### PR TITLE
Explain a Codex CLI too old for the preset's model instead of an opaque 400

### DIFF
--- a/change-logs/2026/09/08/fix-codex-model-cli-version-notice.md
+++ b/change-logs/2026/09/08/fix-codex-model-cli-version-notice.md
@@ -1,0 +1,5 @@
+Short: Codex explains a too-old CLI
+
+Launching a Codex preset whose model the installed CLI predates now prints a dev3 notice naming the installed version, the version the model needs and how to upgrade, instead of dying on an opaque upstream 400. The default GPT-6 Astra preset on Codex CLI older than 0.153.1 was the reported case; the launch still proceeds so nothing that worked before is blocked.
+
+Suggested by @ittaiz (h0x91b/dev-3.0#1667)

--- a/decisions/2026/09/08/codex-model-cli-version-notice.md
+++ b/decisions/2026/09/08/codex-model-cli-version-notice.md
@@ -1,0 +1,68 @@
+# Codex model/CLI mismatch is a notice, not a gate
+
+## Context
+
+The default Codex preset (`codex-default`) pins `gpt-6-astra`. On a Codex CLI
+that predates the model, the launch prints `Model metadata for 'gpt-6-astra' not
+found`, reaches the API anyway, and dies on a 400 saying the model "requires a
+newer version of Codex". Nothing in that chain mentions dev3 or the preset, so
+the failure reads as an auth or config problem (issue #1667). dev3 already
+probes `codex --version` for config syntax and never consulted it here.
+
+## Investigation
+
+The reporter observed failure on 0.144.4 and success on 0.153.4; neither is the
+boundary. Bisecting `codex-rs/models-manager/models.json` through the openai/codex
+contents API per release tag (2026-09-08) puts the model's first appearance at
+`rust-v0.153.1` — `rust-v0.153.0` does not carry it. `model-provider-info/src/lib.rs`
+gains it later still, between 0.153.1 and 0.153.4.
+
+Two things stayed unverified and shaped the decision. The 400 is issued by the
+API, which enforces a client-version floor of its own; probing it costs a paid
+request, so whether 0.153.1–0.153.3 actually launch is untested. And the local
+probe is cached for the app's lifetime, so a binary upgraded underneath a running
+dev3 reports the old version.
+
+## Decision
+
+Requirements live in `src/shared/agent-model-cli-requirements.ts` as a
+model → minimum-version map (`CODEX_MODEL_MIN_CLI_VERSION`), keyed on the MODEL
+rather than on a preset so a hand-built preset with the same model is covered
+identically. `evaluateCodexModelSupport` returns `too-old` only when both the
+floor and the installed version are known.
+
+`applyModelVersionNotice` (`src/bun/rpc-handlers/tmux-pty.ts`) wraps the launch
+in `buildModelVersionGateWrapper` (`rpc-handlers/shared-pure.ts`) when the verdict
+is `too-old`. The wrapper prints the mismatch, the floor and how to upgrade, waits
+up to 20 seconds for a keypress, and then **runs the original launch unchanged**.
+
+It is deliberately a notice and not a block: the failure being fixed is opacity,
+and a stale probe or an untested 0.153.x must not be able to stop a launch that
+would have worked. `launchModel` on `ResolvedAgentCommand` carries the model after
+provider pinning and API-profile overrides, and is undefined under a third-party
+backend or a routed model — the vendor's floor says nothing about those endpoints.
+
+`src/bun/__tests__/agent-model-cli-requirements.test.ts` fails when a builtin
+Codex preset names a model absent from the map, so adding a preset for a fresh
+model forces its author to state the requirement (`null` is a valid answer).
+
+## Risks
+
+The floor may be too low if the API's own client gate is stricter than 0.153.1;
+a user between 0.153.1 and 0.153.3 would then see the old opaque 400 with no
+notice. Raising the entry is a one-line change. The 20-second wait delays an
+unattended launch that hits the mismatch — bounded, and only on a mismatch.
+
+## Alternatives considered
+
+**Change the default preset off `gpt-6-astra`.** Downgrades the default for every
+user to fix a minority's CLI.
+
+**Substitute a compatible model automatically.** Produces a working agent, but a
+silently different model is its own opaque failure.
+
+**Block the launch outright** (the issue's option 1). A stale or wrong probe then
+takes away a preset that works; nothing about the reported pain requires it.
+
+**Pattern-match the upstream 400 in the pane** (the issue's option 2). Needs
+terminal-output scanning dev3 does not do, and only fires after the pane dies.

--- a/src/bun/__tests__/agent-model-cli-requirements.test.ts
+++ b/src/bun/__tests__/agent-model-cli-requirements.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+	CODEX_MODEL_MIN_CLI_VERSION,
+	evaluateCodexModelSupport,
+	isCliVersionAtLeast,
+	parseCliVersion,
+} from "../../shared/agent-model-cli-requirements";
+import { DEFAULT_AGENTS } from "../../shared/types";
+
+describe("parseCliVersion", () => {
+	it("reads the version out of a --version line", () => {
+		expect(parseCliVersion("codex-cli 0.153.4")).toEqual({ major: 0, minor: 153, patch: 4 });
+		expect(parseCliVersion("OpenAI Codex (v0.131.2)")).toEqual({ major: 0, minor: 131, patch: 2 });
+	});
+
+	it("returns null when there is no version to read", () => {
+		expect(parseCliVersion("")).toBeNull();
+		expect(parseCliVersion("command not found")).toBeNull();
+	});
+});
+
+describe("isCliVersionAtLeast", () => {
+	const threshold = { major: 0, minor: 153, patch: 1 };
+
+	it("compares minor before patch", () => {
+		expect(isCliVersionAtLeast({ major: 0, minor: 144, patch: 9 }, threshold)).toBe(false);
+		expect(isCliVersionAtLeast({ major: 0, minor: 153, patch: 0 }, threshold)).toBe(false);
+		expect(isCliVersionAtLeast({ major: 0, minor: 153, patch: 1 }, threshold)).toBe(true);
+		expect(isCliVersionAtLeast({ major: 1, minor: 0, patch: 0 }, threshold)).toBe(true);
+	});
+
+	it("treats an unknown version as not sufficient", () => {
+		expect(isCliVersionAtLeast(null, threshold)).toBe(false);
+	});
+});
+
+describe("evaluateCodexModelSupport", () => {
+	it("flags the reported case: 0.144.4 cannot run gpt-6-astra (issue #1667)", () => {
+		expect(evaluateCodexModelSupport("gpt-6-astra", "codex-cli 0.144.4")).toEqual({
+			status: "too-old",
+			model: "gpt-6-astra",
+			installed: "0.144.4",
+			required: "0.153.1",
+		});
+	});
+
+	it("accepts the version the reporter upgraded to", () => {
+		expect(evaluateCodexModelSupport("gpt-6-astra", "codex-cli 0.153.4").status).toBe("ok");
+	});
+
+	it("accepts the first release that ships the model", () => {
+		expect(evaluateCodexModelSupport("gpt-6-astra", "codex-cli 0.153.1").status).toBe("ok");
+		expect(evaluateCodexModelSupport("gpt-6-astra", "codex-cli 0.153.0").status).toBe("too-old");
+	});
+
+	it("says nothing about a model with no known floor", () => {
+		expect(evaluateCodexModelSupport("gpt-5.6-sol", "codex-cli 0.100.0").status).toBe("unknown");
+	});
+
+	// An unreadable probe must never turn into a warning the user cannot act on.
+	it("stays silent when the version or the model is unknown", () => {
+		expect(evaluateCodexModelSupport("gpt-6-astra", null).status).toBe("unknown");
+		expect(evaluateCodexModelSupport("gpt-6-astra", "codex").status).toBe("unknown");
+		expect(evaluateCodexModelSupport(undefined, "codex-cli 0.144.4").status).toBe("unknown");
+		expect(evaluateCodexModelSupport("some-future-model", "codex-cli 0.144.4").status).toBe("unknown");
+	});
+});
+
+describe("every builtin Codex model states its CLI requirement", () => {
+	it("has a map entry for each model a builtin preset pins", () => {
+		const codex = DEFAULT_AGENTS.find((agent) => agent.id === "builtin-codex");
+		expect(codex).toBeDefined();
+		const models = [...new Set((codex?.configurations ?? []).map((c) => c.model).filter((m): m is string => !!m))];
+		expect(models.length).toBeGreaterThan(0);
+		const unlisted = models.filter((model) => !(model in CODEX_MODEL_MIN_CLI_VERSION));
+		// Adding a preset for a freshly released model must state its floor —
+		// `null` is a valid answer, silence is not. That silence is exactly what
+		// made gpt-6-astra the opaque default failure in issue #1667.
+		expect(unlisted).toEqual([]);
+	});
+});

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -5,11 +5,11 @@ import {
 	ensureCodexProfileFile,
 	getCodexSyntaxForVersion,
 	pruneOrphanedMcpServers,
-	parseCodexVersion,
 	pickCodexProfileLaunchFlag,
 	tomlBasicString,
 } from "../codex-config";
 import { codexHookCommand } from "../../shared/agent-hooks";
+import { parseCliVersion } from "../../shared/agent-model-cli-requirements";
 import { hookCliDialect } from "../../shared/dev3-cli-path";
 
 describe("ensureCodexConfig", () => {
@@ -69,12 +69,12 @@ describe("ensureCodexConfig", () => {
 
 	describe("Codex version compatibility", () => {
 		it("parses Codex CLI version output", () => {
-			expect(parseCodexVersion("codex-cli 0.133.0")).toEqual({
+			expect(parseCliVersion("codex-cli 0.133.0")).toEqual({
 				major: 0,
 				minor: 133,
 				patch: 0,
 			});
-			expect(parseCodexVersion("OpenAI Codex (v0.131.2)")).toEqual({
+			expect(parseCliVersion("OpenAI Codex (v0.131.2)")).toEqual({
 				major: 0,
 				minor: 131,
 				patch: 2,

--- a/src/bun/__tests__/platform-launch-posix-golden.test.ts
+++ b/src/bun/__tests__/platform-launch-posix-golden.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
 	buildAgentRetryWrapper,
 	buildCmdScript,
+	buildModelVersionGateWrapper,
 	buildEnvExports,
 	buildScriptRunnerCommand,
 	buildSetupStartupWrapper,
@@ -175,6 +176,50 @@ describe("POSIX agent-not-found retry wrapper", () => {
 				shellPath: SHELL,
 			}),
 		).toBe(AGENT_RETRY_WRAPPER);
+	});
+});
+
+const MODEL_VERSION_GATE_WRAPPER = [
+	"#!/bin/bash",
+	"",
+	"printf '\\n\\033[1;31m✗ %s %s is too old for model %s\\033[0m\\n' 'codex' '0.144.4' 'gpt-6-astra'",
+	"printf '\\033[2mThat model needs %s or newer. Older versions reach the API and are\\033[0m\\n' '0.153.1'",
+	"printf '\\033[2mrefused with a 400 that mentions neither dev-3.0 nor this preset.\\033[0m\\n\\n'",
+	"printf '\\033[1mUpgrade:\\033[0m %s\\n' 'brew upgrade codex'",
+	"printf '\\033[2m%s\\033[0m\\n' 'Or pick a preset on an older model.'",
+	"printf '\\n\\033[2mStarting anyway in %ss — press any key to start now.\\033[0m\\n\\n' '20'",
+	'if [ -n "$ZSH_VERSION" ]; then read -t 20 -k 1 -s; elif [ -n "$BASH_VERSION" ]; then read -t 20 -n 1 -s; else sleep 20; fi',
+	"exec codex --model gpt-6-astra",
+	"",
+].join("\n");
+
+describe("POSIX model/CLI version notice (issue #1667)", () => {
+	it("renders the notice and then execs the launch unchanged", () => {
+		expect(
+			buildModelVersionGateWrapper({
+				model: "gpt-6-astra",
+				installedVersion: "0.144.4",
+				requiredVersion: "0.153.1",
+				binaryName: "codex",
+				upgradeCmd: "brew upgrade codex",
+				alternativeHint: "Or pick a preset on an older model.",
+				command: "codex --model gpt-6-astra",
+			}),
+		).toBe(MODEL_VERSION_GATE_WRAPPER);
+	});
+
+	it("omits the alternatives line when there is none", () => {
+		const script = buildModelVersionGateWrapper({
+			model: "gpt-6-astra",
+			installedVersion: "0.144.4",
+			requiredVersion: "0.153.1",
+			binaryName: "codex",
+			upgradeCmd: "brew upgrade codex",
+			command: "codex",
+		});
+		expect(script).not.toContain("Or pick a preset");
+		// The launch itself always survives — this is a notice, never a block.
+		expect(script).toContain("exec codex");
 	});
 });
 

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -214,6 +214,7 @@ vi.mock("../agents", () => ({
 	ensureClaudeTrust: vi.fn(),
 	ensureCodexTrust: vi.fn(),
 	ensureGeminiTrust: vi.fn(),
+	getCodexVersionCached: vi.fn(() => null),
 	isClaudeCommand: vi.fn(() => false),
 	skillInvocationPrefix: vi.fn((command: string) => (command === "codex" ? "$" : "/")),
 	supportsPreAssignedSessionId: vi.fn(() => false),
@@ -12908,6 +12909,7 @@ describe("triggerColumnAgentIfNeeded", () => {
 			config: undefined,
 			extraEnv: {},
 			agentFamily: undefined,
+			launchModel: undefined,
 		});
 	});
 
@@ -12990,6 +12992,7 @@ describe("triggerColumnAgentIfNeeded", () => {
 			config: undefined,
 			extraEnv: {},
 			agentFamily: undefined,
+			launchModel: undefined,
 		});
 		vi.mocked(setupAgentHooks).mockResolvedValueOnce("--dangerously-bypass-hook-trust");
 

--- a/src/bun/__tests__/tmux-pty-native-launch.test.ts
+++ b/src/bun/__tests__/tmux-pty-native-launch.test.ts
@@ -125,6 +125,7 @@ vi.mock("../agents", () => ({
 	ensureClaudeTrust: vi.fn(async () => undefined),
 	ensureCodexTrust: vi.fn(async () => undefined),
 	ensureGeminiTrust: vi.fn(async () => undefined),
+	getCodexVersionCached: vi.fn(() => null),
 }));
 
 vi.mock("../../shared/agent-adapters/registry", () => ({
@@ -191,6 +192,7 @@ vi.mock("../rpc-handlers/shared-pure", () => ({
 	buildAgentEnv: vi.fn(() => ({ DEV3_AGENT: "claude" })),
 	buildAgentRetryWrapper: vi.fn(() => "#!/bin/bash\n# retry\n"),
 	buildCmdScript: vi.fn(() => "#!/bin/bash\n"),
+	buildModelVersionGateWrapper: vi.fn(() => "#!/bin/bash\n# version-notice\n"),
 	buildSetupStartupWrapper: vi.fn(() => "#!/bin/bash\n# startup\n"),
 	buildSetupRerunScript: vi.fn(() => "#!/bin/bash\n# rerun\n"),
 	generatedScriptLaunch: vi.fn((p: string) => ({ executable: "/bin/zsh", argv: [p] })),
@@ -215,6 +217,7 @@ vi.mock("../setup-failure-watch", () => ({
 	stopSetupFailureWatch: vi.fn(),
 }));
 
+import * as agents from "../agents";
 import * as data from "../data";
 import * as watch from "../setup-failure-watch";
 import * as pty from "../pty-server";
@@ -278,6 +281,65 @@ function tmuxCalls(): string[] {
 beforeEach(() => {
 	vi.clearAllMocks();
 	written.clear();
+});
+
+describe("Codex model/CLI version notice (issue #1667)", () => {
+	function resolveAsCodex(model: string | undefined) {
+		vi.mocked(agents.resolveCommandForProject).mockResolvedValue({
+			command: "codex --model gpt-6-astra",
+			extraEnv: {},
+			agent: { baseCommand: "codex" },
+			config: undefined,
+			agentFamily: "codex",
+			launchModel: model,
+		} as never);
+	}
+
+	it("wraps the launch in the notice when the installed Codex predates the model", async () => {
+		resolveAsCodex("gpt-6-astra");
+		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.144.4");
+
+		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
+
+		expect(sharedPure.buildModelVersionGateWrapper).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "gpt-6-astra",
+				installedVersion: "0.144.4",
+				requiredVersion: "0.153.1",
+				binaryName: "codex",
+				command: "codex --model gpt-6-astra",
+			}),
+		);
+	});
+
+	it("says nothing on a Codex new enough to run the model", async () => {
+		resolveAsCodex("gpt-6-astra");
+		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.153.4");
+
+		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
+
+		expect(sharedPure.buildModelVersionGateWrapper).not.toHaveBeenCalled();
+	});
+
+	it("says nothing when the version could not be read", async () => {
+		resolveAsCodex("gpt-6-astra");
+		vi.mocked(agents.getCodexVersionCached).mockReturnValue(null);
+
+		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
+
+		expect(sharedPure.buildModelVersionGateWrapper).not.toHaveBeenCalled();
+	});
+
+	it("never touches a non-Codex launch", async () => {
+		// `clearAllMocks` keeps implementations, so restore the Claude default the
+		// module factory installs before asserting the negative.
+		vi.mocked(agents.resolveCommandForProject).mockResolvedValue({ command: "claude", extraEnv: {} } as never);
+		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.144.4");
+
+		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
+
+		expect(sharedPure.buildModelVersionGateWrapper).not.toHaveBeenCalled();
+	});
 });
 
 describe("unmarked task — the legacy tmux path is untouched", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -389,7 +389,7 @@ function getCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
  * ensureCodexTrust, blocking the main loop each time.
  */
 let cachedCodexVersion: string | null | undefined;
-function getCodexVersionCached(): string | null {
+export function getCodexVersionCached(): string | null {
 	if (cachedCodexVersion === undefined) {
 		cachedCodexVersion = detectCodexVersion();
 	}
@@ -775,6 +775,12 @@ export interface ResolvedAgentCommand<A extends CodingAgent | null = CodingAgent
 	config: AgentConfiguration | undefined;
 	extraEnv: Record<string, string>;
 	agentFamily: AgentFamily | undefined;
+	/** The model id this launch actually carries, after provider pinning and API
+	 *  profile overrides — what a CLI-capability gate must be judged on, not the
+	 *  preset's own `model`. Undefined when a third-party backend delivers the
+	 *  model via env, since then the request never reaches the vendor endpoint
+	 *  whose version floor the gate knows about. */
+	launchModel: string | undefined;
 }
 
 export async function resolveCommandForAgent(
@@ -810,18 +816,33 @@ export async function resolveCommandForAgent(
 	await applyClaudeAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 	await applyCodexAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 	const routed = await applyModelRoleLaunch(baseCmd, config, extraEnv, providerOpts, agentWithPath.agentFamily);
-	const command = resolveAgentCommand(
-		agentWithPath,
-		resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel),
-		ctx,
-		routed.options,
-	);
+	const launchConfig = resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel);
+	const command = resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
 	// `agent` stays the stored record — callers derive the base command from it,
 	// and swapping in the override path there would change what they persist.
 	// The family rides alongside instead: a path override can pin one the stored
 	// record does not carry, and every caller needs the same answer to resume,
 	// trust and hook this launch exactly the way it was built.
-	return { command, agent, config, extraEnv, agentFamily: agentWithPath.agentFamily };
+	return {
+		command,
+		agent,
+		config,
+		extraEnv,
+		agentFamily: agentWithPath.agentFamily,
+		launchModel: nativeLaunchModel(launchConfig, providerOpts, routed.pinnedModel),
+	};
+}
+
+/** The model a CLI-capability gate may judge, or undefined when this launch does
+ *  not talk to the agent vendor's own endpoint (a third-party backend or a
+ *  routed/proxied model), where the vendor's version floor says nothing. */
+function nativeLaunchModel(
+	config: AgentConfiguration | undefined,
+	options: CommandOptions,
+	pinnedModel: boolean,
+): string | undefined {
+	if (options.llmProvider || pinnedModel) return undefined;
+	return config?.model;
 }
 
 /** The launch-time model pipeline shared by both resolveCommand* entry points:
@@ -926,13 +947,16 @@ export async function resolveCommandForProject(
 		await applyClaudeAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 		await applyCodexAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 		const routed = await applyModelRoleLaunch(baseCmd, config, extraEnv, providerOpts, agentWithPath.agentFamily);
-		const command = resolveAgentCommand(
-			agentWithPath,
-			resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel),
-			ctx,
-			routed.options,
-		);
-		return { command, agent, config, extraEnv, agentFamily: agentWithPath.agentFamily };
+		const launchConfig = resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel);
+		const command = resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
+		return {
+			command,
+			agent,
+			config,
+			extraEnv,
+			agentFamily: agentWithPath.agentFamily,
+			launchModel: nativeLaunchModel(launchConfig, providerOpts, routed.pinnedModel),
+		};
 	}
 
 	log.warn("Default agent not found, falling back to bash", {
@@ -945,6 +969,7 @@ export async function resolveCommandForProject(
 		config: undefined,
 		extraEnv: buildTaskEnv(project, taskTitle, "", worktreePath),
 		agentFamily: undefined,
+		launchModel: undefined,
 	};
 }
 

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -2,6 +2,7 @@ import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { load } from "js-toml";
 import { buildCodexHooks, CODEX_STATUS_HOOK_EVENTS, mentionsDev3Cli } from "../shared/agent-hooks";
+import { type CliVersion, isCliVersionAtLeast, parseCliVersion } from "../shared/agent-model-cli-requirements";
 import type { HookCliDialect } from "../shared/dev3-cli-path";
 import { createLogger } from "./logger";
 import { spawnSync } from "./spawn";
@@ -54,11 +55,7 @@ interface CodexConfigOptions {
 	dialect?: HookCliDialect;
 }
 
-interface CodexVersion {
-	major: number;
-	minor: number;
-	patch: number;
-}
+type CodexVersion = CliVersion;
 
 interface CodexSyntax {
 	filesystemRootKey: ":project_roots" | ":workspace_roots";
@@ -621,35 +618,17 @@ export function pruneCodexTrustEntries(
 	return removed;
 }
 
-export function parseCodexVersion(output: string): CodexVersion | null {
-	const match = output.match(/\bv?(\d+)\.(\d+)\.(\d+)\b/);
-	if (match == null) return null;
-
-	return {
-		major: Number(match[1]),
-		minor: Number(match[2]),
-		patch: Number(match[3]),
-	};
-}
-
-function isVersionAtLeast(version: CodexVersion | null, threshold: CodexVersion): boolean {
-	if (version == null) return false;
-	if (version.major !== threshold.major) return version.major > threshold.major;
-	if (version.minor !== threshold.minor) return version.minor > threshold.minor;
-	return version.patch >= threshold.patch;
-}
-
 export function getCodexSyntaxForVersion(versionText: string | null | undefined): CodexSyntax {
-	const version = versionText != null ? parseCodexVersion(versionText) : null;
+	const version = versionText != null ? parseCliVersion(versionText) : null;
 	return {
-		filesystemRootKey: isVersionAtLeast(version, CODEX_WORKSPACE_ROOTS_RENAME_VERSION)
+		filesystemRootKey: isCliVersionAtLeast(version, CODEX_WORKSPACE_ROOTS_RENAME_VERSION)
 			? ":workspace_roots"
 			: LEGACY_CODEX_SYNTAX.filesystemRootKey,
-		hooksFeatureKey: isVersionAtLeast(version, CODEX_HOOKS_RENAME_VERSION)
+		hooksFeatureKey: isCliVersionAtLeast(version, CODEX_HOOKS_RENAME_VERSION)
 			? "hooks"
 			: LEGACY_CODEX_SYNTAX.hooksFeatureKey,
-		profileV2: isVersionAtLeast(version, CODEX_PROFILE_V2_VERSION),
-		unixSocketsAsMap: isVersionAtLeast(version, CODEX_UNIX_SOCKETS_MAP_VERSION),
+		profileV2: isCliVersionAtLeast(version, CODEX_PROFILE_V2_VERSION),
+		unixSocketsAsMap: isCliVersionAtLeast(version, CODEX_UNIX_SOCKETS_MAP_VERSION),
 	};
 }
 

--- a/src/bun/rpc-handlers/shared-pure.ts
+++ b/src/bun/rpc-handlers/shared-pure.ts
@@ -186,6 +186,59 @@ export function buildAgentRetryWrapper(opts: {
 	return [...d.header(), "", ...check, "", ...loop, ""].join("\n");
 }
 
+/** Seconds the model-version notice stays on screen before the launch continues
+ *  on its own. An unattended launch (a peer agent spawning this one, an
+ *  auto-start) must never sit on a keypress forever. */
+const MODEL_VERSION_GATE_TIMEOUT_SECONDS = 20;
+
+/**
+ * Wrapper shown when the installed agent CLI predates the model the preset
+ * pins. It explains the mismatch and then runs the launch anyway.
+ *
+ * Deliberately a notice and not a block. The probe can be stale or wrong (a
+ * `--version` read once per app run, a binary swapped underneath it), and the
+ * failure this fixes is opacity, not the launch itself: the reporter's pane died
+ * on an upstream 400 that named neither dev3 nor an upgrade path (#1667).
+ */
+export function buildModelVersionGateWrapper(opts: {
+	model: string;
+	installedVersion: string;
+	requiredVersion: string;
+	binaryName: string;
+	upgradeCmd: string;
+	alternativeHint?: string;
+	/** The launch this notice precedes, run in place once the notice is read. */
+	command: string;
+}): string {
+	const d = launchDialect();
+	const lines = [
+		d.print(d.style("✗ %s %s is too old for model %s", "error"), {
+			blankBefore: true,
+			args: [d.quote(opts.binaryName), d.quote(opts.installedVersion), d.quote(opts.model)],
+		}),
+		d.print(d.style("That model needs %s or newer. Older versions reach the API and are", "dim"), {
+			args: [d.quote(opts.requiredVersion)],
+		}),
+		d.print(d.style("refused with a 400 that mentions neither dev-3.0 nor this preset.", "dim"), {
+			blankAfter: true,
+		}),
+		d.print(`${d.style("Upgrade:", "bold")} %s`, { args: [d.quote(opts.upgradeCmd)] }),
+	];
+	if (opts.alternativeHint) {
+		lines.push(d.print(d.style("%s", "dim"), { args: [d.quote(opts.alternativeHint)] }));
+	}
+	lines.push(
+		d.print(d.style("Starting anyway in %ss — press any key to start now.", "dim"), {
+			blankBefore: true,
+			blankAfter: true,
+			args: [d.quote(String(MODEL_VERSION_GATE_TIMEOUT_SECONDS))],
+		}),
+		d.readKey({ timeoutSeconds: MODEL_VERSION_GATE_TIMEOUT_SECONDS }),
+		d.execReplacing(opts.command),
+	);
+	return [...d.header(), "", ...lines, ""].join("\n");
+}
+
 /**
  * The setup/startup wrapper: run the project's setup script, then hand the view
  * to the agent wrapper.

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -6,6 +6,8 @@ import * as git from "../git";
 import * as pty from "../pty-server";
 import * as agents from "../agents";
 import { getAgentAdapter } from "../../shared/agent-adapters/registry";
+import { agentKey } from "../../shared/agent-adapters/families";
+import { evaluateCodexModelSupport } from "../../shared/agent-model-cli-requirements";
 import * as portPool from "../port-pool";
 import * as repoConfig from "../repo-config";
 import { buildProcessTree, clearDevServerSummaryForTask, clearPortDataForTask, collectDescendants, collectTaskPids, findPortHolders, getLsofOutput, getPortsForTask, getSessionPanePids, parseLsofOutput, scanTaskPorts, schedulePortScanSoon, waitForPortsFree } from "../port-scanner";
@@ -75,7 +77,7 @@ import {
 	type AuxPaneHandle,
 	type AuxPanePlacement,
 } from "../task-aux-panes";
-import { getPushMessage, isActive, AGENT_ENV_DEFAULTS, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildSetupRerunScript, buildSetupStartupWrapper, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
+import { getPushMessage, isActive, AGENT_ENV_DEFAULTS, buildAgentEnv, buildAgentRetryWrapper, buildCmdScript, buildModelVersionGateWrapper, buildSetupRerunScript, buildSetupStartupWrapper, buildScriptRunnerCommand, buildTaskLifecycleEnv, generatedScriptLaunch, generatedScriptName, log, resolveBinaryPath, writeLaunchScript } from "./shared-pure";
 import { assertPosixLaunchDialect, launchDialect } from "../../shared/platform-launch";
 import { buildDevServerScript } from "../dev-server-script";
 import { resolveOperationalProjectConfig } from "./settings-config";
@@ -629,6 +631,46 @@ async function launchNativeTaskSession(
 	log.info("launchTaskPty DONE — native session created", { taskId: task.id.slice(0, 8) });
 }
 
+/** How to raise the Codex version. Deliberately not a single command: dev3 does
+ *  not know which package manager put the binary there, and a `brew upgrade` line
+ *  printed to an npm install is worse than naming both. */
+const CODEX_UPGRADE_COMMAND = "brew upgrade codex   (npm: npm install -g @openai/codex@latest)";
+
+/**
+ * Prefix a Codex launch with the model/CLI mismatch notice when the installed
+ * binary predates the model the preset pins (#1667). Returns `command`
+ * untouched for every other case — another agent, an unreadable
+ * `codex --version`, a model with no known floor, a third-party backend.
+ */
+async function applyModelVersionNotice(
+	taskId: string,
+	command: string,
+	opts: { baseCmd: string; family: AgentFamily | undefined; launchModel: string | undefined; userShell?: string },
+): Promise<string> {
+	if (agentKey(opts.baseCmd, opts.family) !== "codex") return command;
+	const support = evaluateCodexModelSupport(opts.launchModel, agents.getCodexVersionCached());
+	if (support.status !== "too-old") return command;
+
+	log.warn("Codex CLI predates the launch model", {
+		taskId: taskId.slice(0, 8),
+		model: support.model,
+		installed: support.installed,
+		required: support.required,
+	});
+	const script = buildModelVersionGateWrapper({
+		model: support.model,
+		installedVersion: support.installed,
+		requiredVersion: support.required,
+		binaryName: "codex",
+		upgradeCmd: CODEX_UPGRADE_COMMAND,
+		alternativeHint: "Or pick a preset on an older model — those run on the installed version.",
+		command,
+	});
+	const scriptPath = dev3TaskTempPath(taskId, generatedScriptName("model-version-notice"));
+	await writeLaunchScript(scriptPath, script);
+	return buildScriptRunnerCommand(scriptPath, { shellPath: opts.userShell });
+}
+
 export async function launchTaskPty(
 	project: Project,
 	task: Task,
@@ -677,6 +719,7 @@ export async function launchTaskPty(
 	let resolvedBaseCmd = "";
 	let resolvedPermissionMode: PermissionMode | undefined;
 	let resolvedAgentFamily: AgentFamily | undefined;
+	let resolvedLaunchModel: string | undefined;
 	let mainPaneEntry: NonNullable<Task["sessionState"]>["panes"][number] | null = null;
 
 	try {
@@ -706,6 +749,7 @@ export async function launchTaskPty(
 			resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 			resolvedPermissionMode = resolved.config?.permissionMode;
 			resolvedAgentFamily = resolved.agentFamily;
+			resolvedLaunchModel = resolved.launchModel;
 		} else {
 			log.info("Resolving command for project", { projectName: project.name });
 			const resolved = await agents.resolveCommandForProject(
@@ -721,6 +765,7 @@ export async function launchTaskPty(
 			resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 			resolvedPermissionMode = resolved.config?.permissionMode;
 			resolvedAgentFamily = resolved.agentFamily;
+			resolvedLaunchModel = resolved.launchModel;
 		}
 
 		// Persist session state as pane[0] for the main agent pane.
@@ -830,6 +875,12 @@ export async function launchTaskPty(
 		stopTarget,
 		permissionMode: resolvedPermissionMode,
 		family: resolvedAgentFamily,
+	});
+	tmuxCmd = await applyModelVersionNotice(task.id, tmuxCmd, {
+		baseCmd: resolvedBaseCmd,
+		family: resolvedAgentFamily,
+		launchModel: resolvedLaunchModel,
+		userShell,
 	});
 
 	const nativeBackend = taskTerminalBackendIdentity(task) === "native";
@@ -2737,6 +2788,7 @@ async function spawnAgentInTask(params: {
 	let extraEnv: Record<string, string>;
 	let resolvedBaseCmd = "";
 	let resolvedAgentFamily: AgentFamily | undefined;
+	let resolvedLaunchModel: string | undefined;
 	let launchedAgentId = params.agentId;
 	let launchedConfigId = params.configId;
 
@@ -2751,6 +2803,7 @@ async function spawnAgentInTask(params: {
 		extraEnv = resolved.extraEnv;
 		resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 		resolvedAgentFamily = resolved.agentFamily;
+		resolvedLaunchModel = resolved.launchModel;
 		launchedAgentId = resolved.agent?.id ?? params.agentId;
 		launchedConfigId = resolved.config?.id ?? params.configId;
 	} else {
@@ -2768,6 +2821,7 @@ async function spawnAgentInTask(params: {
 		extraEnv = resolved.extraEnv;
 		resolvedBaseCmd = resolved.config?.baseCommandOverride || resolved.agent?.baseCommand || "";
 		resolvedAgentFamily = resolved.agentFamily;
+		resolvedLaunchModel = resolved.launchModel;
 		launchedAgentId = resolved.agent?.id ?? null;
 		launchedConfigId = resolved.config?.id ?? null;
 	}
@@ -2779,6 +2833,11 @@ async function spawnAgentInTask(params: {
 	tmuxCmd = await applyAgentHooksToCommand(task.worktreePath, resolvedBaseCmd, tmuxCmd, {
 		stopTarget: project.autoReviewEnabled ? "review-by-ai" : "review-by-user",
 		family: resolvedAgentFamily,
+	});
+	tmuxCmd = await applyModelVersionNotice(task.id, tmuxCmd, {
+		baseCmd: resolvedBaseCmd,
+		family: resolvedAgentFamily,
+		launchModel: resolvedLaunchModel,
 	});
 
 	const env: Record<string, string> = {

--- a/src/shared/agent-model-cli-requirements.ts
+++ b/src/shared/agent-model-cli-requirements.ts
@@ -1,0 +1,84 @@
+/**
+ * Which agent CLI version a model needs, and the pure comparison used to decide
+ * it. A model id newer than the installed CLI does not fail locally: Codex
+ * prints "Model metadata for <id> not found", talks to the API anyway, and the
+ * API answers 400 "requires a newer version of Codex". The pane then dies with
+ * no dev3-level explanation, which reads as an auth or config problem (#1667).
+ *
+ * The requirement is keyed on the MODEL, not on a preset, so a preset the user
+ * built by hand with the same model is gated identically.
+ */
+
+export interface CliVersion {
+	major: number;
+	minor: number;
+	patch: number;
+}
+
+/** First `major.minor.patch` in a `--version` line (`codex-cli 0.153.4`). */
+export function parseCliVersion(output: string): CliVersion | null {
+	const match = output.match(/\bv?(\d+)\.(\d+)\.(\d+)\b/);
+	if (match == null) return null;
+	return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+export function isCliVersionAtLeast(version: CliVersion | null, threshold: CliVersion): boolean {
+	if (version == null) return false;
+	if (version.major !== threshold.major) return version.major > threshold.major;
+	if (version.minor !== threshold.minor) return version.minor > threshold.minor;
+	return version.patch >= threshold.patch;
+}
+
+/**
+ * Minimum Codex CLI release per model dev3 ships a preset for. `null` means
+ * "no known floor" — every Codex release dev3 supports can run it.
+ *
+ * `gpt-6-astra` first appears in `codex-rs/models-manager/models.json` at
+ * upstream tag `rust-v0.153.1`; `rust-v0.153.0` does not carry it. Verified
+ * against the openai/codex contents API per tag, 2026-09-08. The API also
+ * enforces a minimum client version of its own, which cannot be probed without
+ * spending a request — so an install between 0.153.1 and the reporter's known
+ * good 0.153.4 is untested, and this floor is the earliest release where the
+ * CLI itself knows the model.
+ *
+ * `src/shared/__tests__/agent-model-cli-requirements.test.ts` fails when a
+ * builtin Codex preset names a model absent from this map: adding a preset for
+ * a fresh model must state its requirement, even when that is `null`.
+ */
+export const CODEX_MODEL_MIN_CLI_VERSION: Readonly<Record<string, string | null>> = {
+	"gpt-6-astra": "0.153.1",
+	"gpt-5.6-luna": null,
+	"gpt-5.6-sol": null,
+	"gpt-5.6-terra": null,
+	"gpt-5.5": null,
+};
+
+export type ModelCliSupport =
+	| { status: "ok" }
+	/** No floor is known for this model, or the CLI version could not be read. */
+	| { status: "unknown" }
+	| { status: "too-old"; model: string; installed: string; required: string };
+
+/**
+ * Whether the installed Codex can run `model`. Unknown beats a guess in both
+ * directions: an unreadable `codex --version` and an unlisted model both return
+ * "unknown", so the launch proceeds exactly as it does today.
+ */
+export function evaluateCodexModelSupport(
+	model: string | undefined | null,
+	versionText: string | null | undefined,
+): ModelCliSupport {
+	if (!model) return { status: "unknown" };
+	const required = CODEX_MODEL_MIN_CLI_VERSION[model];
+	if (required == null) return { status: "unknown" };
+	const parsedRequired = parseCliVersion(required);
+	const installed = versionText != null ? parseCliVersion(versionText) : null;
+	if (parsedRequired == null || installed == null) return { status: "unknown" };
+	if (isCliVersionAtLeast(installed, parsedRequired)) return { status: "ok" };
+	return {
+		status: "too-old",
+		model,
+		installed: `${installed.major}.${installed.minor}.${installed.patch}`,
+		required,
+	};
+}


### PR DESCRIPTION
The default Codex preset pins `gpt-6-astra`. On a Codex CLI that predates the model, the launch warns `Model metadata for 'gpt-6-astra' not found`, reaches the API anyway, and dies on a 400 saying the model "requires a newer version of Codex". Nothing in that chain names dev3, the preset, or the upgrade — it reads as an auth or config problem. dev3 already probes `codex --version` for config syntax and never consulted it for model selection.

## Where the boundary actually is

The report observed 0.144.4 broken and 0.153.4 working; neither is the boundary. Bisecting `codex-rs/models-manager/models.json` through the openai/codex contents API, one fetch per release tag, puts the model's first appearance at **`rust-v0.153.1`** — `rust-v0.153.0` does not carry it. That file is what emits the missing-metadata warning.

## What this adds

`src/shared/agent-model-cli-requirements.ts` declares the floor per **model** rather than per preset, so a preset a user built by hand with the same model is covered identically. When the probed version is provably below the floor, the launch is prefixed with a notice naming the installed version, the required version and how to upgrade — and then **runs the original launch unchanged**.

It is deliberately a notice and not a block: the version probe is cached for the app's lifetime and can be stale, and whether 0.153.1–0.153.3 actually launch is untested (the API enforces a client-version floor of its own, which cannot be probed without spending a request). Nothing that worked before stops working, including unattended launches with nobody to press a key.

`launchModel` on `ResolvedAgentCommand` carries the model after provider pinning and API-profile overrides, and is `undefined` under a third-party backend or a routed model — the vendor's floor says nothing about those endpoints.

`src/bun/__tests__/agent-model-cli-requirements.test.ts` fails when a builtin Codex preset names a model absent from the map, so adding a preset for a freshly released model forces its author to state the requirement (`null` is a valid answer, silence is not). That silence is what made this the *default* failure path.

Rationale and the alternatives considered: `decisions/2026/09/08/codex-model-cli-version-notice.md`.

Closes #1667

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=e17fa7b6-fb38-4341-888f-327164ceb207) · `dev3://task/e17fa7b6-fb38-4341-888f-327164ceb207` _(dev3 added this footer — turn it off in Settings → Tasks.)_
