### PR TITLE
Keep agent approval dialogs open on backdrop clicks

### DIFF
--- a/change-logs/2026/09/08/fix-agent-approval-dialog-outside-click.md
+++ b/change-logs/2026/09/08/fix-agent-approval-dialog-outside-click.md
@@ -1,0 +1,3 @@
+Short: Approval dialogs survive stray clicks
+
+An agent's approval dialog no longer closes — and no longer counts as a decline — when you click the empty space around it. That applies to the launch request an agent raises to start another task, and to the completion and cancellation requests it raises through the shared confirmation dialog; all three hold a blocked CLI, so answering them stays a deliberate act via the buttons or Escape. Ordinary dialogs still close on an outside click as before.

--- a/decisions/2026/09/08/agent-approval-dialogs-ignore-backdrop-clicks.md
+++ b/decisions/2026/09/08/agent-approval-dialogs-ignore-backdrop-clicks.md
@@ -1,0 +1,48 @@
+# Agent approval dialogs ignore backdrop clicks
+
+## Context
+
+Every agent-initiated approval — a launch request (`AgentLaunchRequestModal`), a
+completion request and a cancellation request (both `confirm({ agentInitiated: true })`)
+— holds a blocked `dev3` CLI on the other end. The dialog appears unprompted,
+often while the user is clicking somewhere else, and both surfaces dismissed on a
+backdrop `mousedown` by answering `false`. The requesting agent then received
+"user declined" (exit code 10) for a dialog nobody read. Reproduced repeatedly on
+coordinator-created task starts (Seq1826, Seq1828).
+
+## Decision
+
+Backdrop dismissal is off for these dialogs.
+
+- `src/mainview/components/AgentLaunchRequestModal.tsx` — the backdrop's
+  `onMouseDown` no longer answers; it only calls `preventDefault()`.
+- `src/mainview/confirm.tsx` — `dismissOnBackdrop` now defaults to
+  `!agentInitiated` instead of `true`. An explicit `dismissOnBackdrop` still wins
+  either way, and ordinary user-triggered confirms are unchanged.
+
+Both surfaces `preventDefault()` the press they ignore. Without it the browser
+moves focus to `body`, which costs a keyboard or screen-reader user their place
+in the dialog until the next Tab pulls them back through the focus trap.
+
+Escape still declines on both surfaces, and the Decline/Cancel button is still
+autofocused: cancelling stays available, it just has to be deliberate. Nothing
+about the queue, the auto-approval countdown, retry/dedupe or the timeout changes
+— ignoring the backdrop is never read as approval, the request simply stays
+pending.
+
+## Risks
+
+A user who learned to dismiss these dialogs by clicking away now has to press
+Escape or Decline. That is the point, and both remain one action. A dialog that
+somehow renders with no reachable buttons would be harder to escape — the focus
+trap plus the Escape handler make that unlikely.
+
+## Alternatives considered
+
+- **Fix only the launch modal.** Rejected: completion and cancellation requests
+  are the same blocked-CLI contract with the same misclick.
+- **Require a full press-and-release on the backdrop** (`mousedown` and `mouseup`
+  both outside). Still declines on a deliberate-looking stray click, which is
+  exactly what happened.
+- **Turn backdrop dismissal off app-wide.** Out of scope; ordinary menus and
+  modals lose nothing by closing on an outside click.

--- a/src/mainview/__tests__/AgentLaunchRequestModal.test.tsx
+++ b/src/mainview/__tests__/AgentLaunchRequestModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import type { AgentLaunchRequest, CodingAgent, GlobalSettings } from "../../shared/types";
@@ -131,6 +131,57 @@ describe("AgentLaunchRequestModal", () => {
 		await user.click(await screen.findByRole("button", { name: "Decline" }));
 
 		expect(onRespond).toHaveBeenCalledWith(false);
+	});
+
+	// A blocked CLI is waiting on this answer, and the dialog can arrive while the
+	// user is clicking somewhere else entirely. Dismissing it as a decline threw
+	// away launches the user never even read.
+	it("stays open on a click outside, leaving the request unanswered", async () => {
+		const user = userEvent.setup();
+		const { onRespond } = renderModal();
+
+		const backdrop = (await screen.findByRole("dialog")).parentElement!;
+		await user.click(backdrop);
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(onRespond).not.toHaveBeenCalled();
+	});
+
+	it("keeps focus on Decline when the click outside lands", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		const decline = await screen.findByRole("button", { name: "Decline" });
+		await waitFor(() => expect(decline).toHaveFocus());
+		await user.click((await screen.findByRole("dialog")).parentElement!);
+
+		expect(decline).toHaveFocus();
+	});
+
+	it("stays open when a drag starts outside and is released inside", async () => {
+		const { onRespond } = renderModal();
+
+		const dialog = await screen.findByRole("dialog");
+		const backdrop = dialog.parentElement!;
+		fireEvent.mouseDown(backdrop);
+		fireEvent.mouseUp(dialog);
+		fireEvent.click(dialog);
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(onRespond).not.toHaveBeenCalled();
+	});
+
+	it("stays open when a drag starts inside and is released outside", async () => {
+		const { onRespond } = renderModal();
+
+		const dialog = await screen.findByRole("dialog");
+		const backdrop = dialog.parentElement!;
+		fireEvent.mouseDown(dialog);
+		fireEvent.mouseUp(backdrop);
+		fireEvent.click(backdrop);
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(onRespond).not.toHaveBeenCalled();
 	});
 
 	it("seeds the priority picker with the priority the launch would use", async () => {

--- a/src/mainview/__tests__/confirm.test.tsx
+++ b/src/mainview/__tests__/confirm.test.tsx
@@ -128,6 +128,39 @@ describe("confirm service", () => {
 		expect(await screen.findByText("AI agent request")).toBeInTheDocument();
 	});
 
+	// Same contract as the launch dialog: an agent request holds a blocked CLI, so
+	// a stray click on empty space must not answer it.
+	it("ignores backdrop clicks on agent-initiated confirms", async () => {
+		const user = userEvent.setup();
+		renderHost();
+		let result: Promise<boolean>;
+		act(() => {
+			result = confirm({ title: "Agent asks", message: "M", agentInitiated: true, confirmLabel: "Confirm" });
+		});
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(dialog.parentElement!);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		await expect(result!).resolves.toBe(false);
+	});
+
+	it("still dismisses an ordinary confirm on a backdrop click", async () => {
+		const user = userEvent.setup();
+		renderHost();
+		let result: Promise<boolean>;
+		act(() => {
+			result = confirm({ title: "Plain ask", message: "M", confirmLabel: "Confirm" });
+		});
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(dialog.parentElement!);
+
+		await expect(result!).resolves.toBe(false);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
 	it("does not show the AI agent badge for regular confirms", async () => {
 		renderHost();
 		act(() => {

--- a/src/mainview/components/AgentLaunchRequestModal.tsx
+++ b/src/mainview/components/AgentLaunchRequestModal.tsx
@@ -165,11 +165,16 @@ function AgentLaunchRequestModal({ request, onRespond }: AgentLaunchRequestModal
 		onRespond(true, { variants, priority });
 	}
 
+	// The backdrop deliberately does not dismiss: a CLI is blocked on this answer,
+	// so a stray click on empty space must not decline someone's launch. Declining
+	// stays deliberate — the Decline button or Escape. Its only job is to swallow
+	// the press, which keeps focus on the autofocused Decline instead of dropping
+	// it on `body`.
 	return (
 		<div
 			className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
 			onMouseDown={(e) => {
-				if (e.target === e.currentTarget) onRespond(false);
+				if (e.target === e.currentTarget) e.preventDefault();
 			}}
 		>
 			<div

--- a/src/mainview/confirm.tsx
+++ b/src/mainview/confirm.tsx
@@ -93,7 +93,12 @@ export interface ConfirmOptions {
 	alternativeAction?: ConfirmAlternativeAction;
 	/** Render the three actions as consequence-explaining cards. */
 	outcomeCards?: ConfirmOutcomeCards;
-	/** Defaults to true. Disable when closing without a choice would be ambiguous. */
+	/**
+	 * Defaults to true, except for `agentInitiated` dialogs where it defaults to
+	 * false: an agent's CLI is blocked on the answer, so a stray click on empty
+	 * space would decline a request the user never read. Disable it explicitly
+	 * whenever closing without a choice would be ambiguous.
+	 */
 	dismissOnBackdrop?: boolean;
 }
 
@@ -258,6 +263,9 @@ function ConfirmDialog({ pending, close }: { pending: PendingConfirm; close: (re
 	const deferredState = useDeferredBlock(pending.deferred);
 	const gateActive = Boolean(pending.deferred?.gateConfirm) && !deferredState.settled;
 	const dangerTone = pending.tone === "danger";
+	// An agent request holds a blocked CLI, so an outside click is far more likely
+	// to be a misclick than an answer — opt those out of backdrop dismissal.
+	const dismissOnBackdrop = pending.dismissOnBackdrop ?? !pending.agentInitiated;
 
 	// Auto-close when the caller's signal aborts (task resolved elsewhere).
 	useEffect(() => {
@@ -276,7 +284,11 @@ function ConfirmDialog({ pending, close }: { pending: PendingConfirm; close: (re
 		<div
 			className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
 			onMouseDown={(e) => {
-				if (e.target === e.currentTarget && pending.dismissOnBackdrop !== false) close(false);
+				if (e.target !== e.currentTarget) return;
+				if (dismissOnBackdrop) close(false);
+				// Swallow the press instead, so a dialog that stays open keeps focus on
+				// its buttons rather than dropping it on `body`.
+				else e.preventDefault();
 			}}
 		>
 			<div


### PR DESCRIPTION
An agent's approval dialog closed — and answered "declined" — when you clicked the empty space around it. The launch dialog's backdrop called `onRespond(false)` on `mousedown`, so a stray click sent the blocked `dev3` CLI exactly what the Decline button sends: exit code 10. The completion and cancellation approvals share that misclick through `confirm({ agentInitiated: true })`.

Backdrop dismissal is now off for all three:

- `AgentLaunchRequestModal.tsx` — the backdrop only swallows the press (`preventDefault`), it no longer answers.
- `confirm.tsx` — `dismissOnBackdrop` defaults to `!agentInitiated`; an explicit value still wins, so ordinary dialogs keep closing on an outside click.

Swallowing the press is deliberate: without it focus drops to `body`, and a keyboard user loses their place in a dialog that stayed open.

Escape still declines, both buttons still work, and the queue, auto-approval countdown, dedupe/retry, timeout and hook-managed statuses are untouched.

Verified with a live run on an isolated seeded QA board (real request, real blocked CLI): three clicks outside leave the dialog open with the countdown ticking and focus on Decline; explicit Decline and Escape exit 10; the completion dialog behaves the same and "Keep session" exits 6. Six new unit tests, four of which fail when the handlers are reverted.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=be829390-bd54-4d1c-a740-49eb7d7dc367) · `dev3://task/be829390-bd54-4d1c-a740-49eb7d7dc367` _(dev3 added this footer — turn it off in Settings → Tasks.)_
