### PR TITLE
Keep zero-message projects on the agent traffic stage

### DIFF
--- a/change-logs/2026/09/08/fix-traffic-zero-message-projects.md
+++ b/change-logs/2026/09/08/fix-traffic-zero-message-projects.md
@@ -1,3 +1,3 @@
 Short: Boards with no traffic stay on the traffic stage
 
-Agent traffic's node stage no longer drops a project whose tasks exchanged no messages in the window — in practice every board without a coordinator — so each visible project keeps its own named block with ordinary task cards instead of vanishing, and the project that did carry traffic keeps its group label.
+Agent traffic's node stage no longer drops a project whose tasks exchanged no messages in the window, so each visible project keeps its own named block with ordinary task cards instead of vanishing, and the project that did carry traffic keeps its group label.

--- a/change-logs/2026/09/08/fix-traffic-zero-message-projects.md
+++ b/change-logs/2026/09/08/fix-traffic-zero-message-projects.md
@@ -1,0 +1,3 @@
+Short: Boards with no traffic stay on the traffic stage
+
+Agent traffic's node stage no longer drops a project whose tasks exchanged no messages in the window — in practice every board without a coordinator — so each visible project keeps its own named block with ordinary task cards instead of vanishing, and the project that did carry traffic keeps its group label.

--- a/decisions/2026/09/08/traffic-stage-eligibility-is-per-project.md
+++ b/decisions/2026/09/08/traffic-stage-eligibility-is-per-project.md
@@ -7,11 +7,17 @@ conversation alone": tasks that exchanged nothing in the window are counted into
 collapsed quiet band instead of drawn, which is what stopped a 43-task board from
 burying its four messages.
 
-Applied globally, that rule also decides whether a *project* exists. Only a board
-running a coordinator generates agent messages, so on an all-projects view every
-other board — group box, cards and all — was silently missing, and with a single
-conversing project left, `grouped` (`projectIds.length > 1`) went false and even
-that project lost its named block.
+Applied globally, that rule also decides whether a *project* exists: on an
+all-projects view a board with zero messages in the window was silently missing,
+group box, cards and all. With a single conversing project left, `grouped`
+(`projectIds.length > 1`) then went false and even that project lost its named
+block.
+
+The bug was reported as "projects without a coordinator are omitted", and it is
+worth being precise about that: what was measured is the zero-message rule.
+Whether a coordinator is the only thing that ever produces agent traffic was never
+verified and is not what this record claims — a coordinator-less board that does
+exchange messages was always drawn.
 
 ## Investigation
 

--- a/decisions/2026/09/08/traffic-stage-eligibility-is-per-project.md
+++ b/decisions/2026/09/08/traffic-stage-eligibility-is-per-project.md
@@ -1,0 +1,54 @@
+# Traffic stage eligibility is per project, not per message count
+
+## Context
+
+Experiment 2 of Agent traffic (`TrafficNodes` / `layoutTraffic`) opens on "the
+conversation alone": tasks that exchanged nothing in the window are counted into a
+collapsed quiet band instead of drawn, which is what stopped a 43-task board from
+burying its four messages.
+
+Applied globally, that rule also decides whether a *project* exists. Only a board
+running a coordinator generates agent messages, so on an all-projects view every
+other board — group box, cards and all — was silently missing, and with a single
+conversing project left, `grouped` (`projectIds.length > 1`) went false and even
+that project lost its named block.
+
+## Investigation
+
+Reproduced in `layoutTraffic` directly: two projects, one with a coordinator and one
+message, one with two ordinary tasks and none. Result: `placed` held only the first
+project's two cards, `groups` was `[]`, `quietCount` was 2. Cause is the
+zero-message eligibility filter (`active = awake.filter(node => messages.has(...))`),
+not anything reading `taskType === "coordinator"` — nothing in selection, rendering
+or the project-visibility filters keys on a coordinator.
+
+## Decision
+
+In `layoutTraffic` (`src/mainview/components/agent-traffic/nodes-layout.ts`),
+eligibility is computed per project: a project with no message-carrying awake node in
+the window has all of its awake tasks promoted into the conversation band, so it gets
+its own group with ordinary cards. Those promoted tasks leave the quiet band, so
+`quietCount` stays honest and nothing is drawn twice.
+
+Nothing else changes: no coordinator node or relationship is invented, hibernated and
+completed tasks keep their existing treatment (a project holding only hibernated tasks
+still earns no block), and eligibility reads the whole window's records — which
+`TrafficNodes` passes as `layoutRecords` independently of the replay cursor — so card
+positions do not move as a replay advances.
+
+## Risks
+
+A silent project draws every one of its awake tasks, so a board with many awake,
+never-messaging tasks gets a large block. It sits in its own group and buries no
+conversation, which is the reasoning the quiet band was built on, but if such a block
+becomes unwieldy the fix is a per-project cap folding the remainder back into the
+quiet band — not a return to zero-message eligibility.
+
+## Alternatives considered
+
+- Draw a named but empty placeholder block for a silent project and leave its cards to
+  the quiet toggle. Honest, but an empty box answers none of the questions the stage
+  exists to answer.
+- Promote only the first row (five cards) per silent project. Bounded, but invites
+  "why only five of my tasks" with no visible reason; kept in reserve as the risk
+  mitigation above.

--- a/src/mainview/__tests__/nodes-layout.test.ts
+++ b/src/mainview/__tests__/nodes-layout.test.ts
@@ -446,6 +446,52 @@ describe("obstacle-aware traffic routing", () => {
 			assertClear(result);
 		});
 
+		// Only a board with a coordinator produces agent traffic, so eligibility keyed
+		// on message volume erased every other project from the stage — group box,
+		// cards and all — and took the named group off the surviving project too.
+		it("gives a project with no traffic its own named block beside a conversing one", () => {
+			const tasks = [...projectTasks("a"), task("solo1", 20, { projectId: "b" }), task("solo2", 21, { projectId: "b" })];
+			const result = collapsed(tasks, projectRows("a"));
+			expect(result.groups.map(group => group.projectId)).toEqual(["a", "b"]);
+			expect(result.placed.map(card => `${card.node.projectId}/${card.node.id}`).sort())
+				.toEqual(["a/hub", "a/worker", "b/solo1", "b/solo2"]);
+			// No coordinator is invented for the silent project, and its cards are not
+			// double-counted by the quiet band that would otherwise have hidden them.
+			expect(result.placed.filter(card => card.hub).map(card => card.node.projectId)).toEqual(["a"]);
+			expect(result.placed.every(card => card.node.projectId !== "b" || card.messages === 0)).toBe(true);
+			expect(result.quietCount).toBe(1);
+			assertClear(result);
+		});
+
+		// The silent project's tasks are drawn once, whichever way the bands are set.
+		it("never draws a promoted task twice when the quiet band opens", () => {
+			const tasks = [...projectTasks("a"), task("solo", 20, { projectId: "b" })];
+			const result = scene(tasks, projectRows("a"));
+			expect(result.placed.filter(card => card.node.id === "solo")).toHaveLength(1);
+			expect(result.quietCount).toBe(1);
+		});
+
+		// The window's whole traffic decides eligibility, not the replay cursor, so a
+		// coordinator arriving mid-replay cannot reshuffle either project's cards.
+		it("keeps a silent project's cards in place once the other project goes quiet", () => {
+			const tasks = [...projectTasks("a"), task("solo", 20, { projectId: "b" })];
+			const withTraffic = collapsed(tasks, projectRows("a"));
+			const noTraffic = collapsed(tasks, []);
+			expect(noTraffic.groups.map(group => group.projectId)).toEqual(["a", "b"]);
+			expect(noTraffic.placed.map(card => card.node.id).sort()).toEqual(["hub", "quiet", "solo", "worker"]);
+			expect(withTraffic.placed.find(card => card.node.id === "solo")).toMatchObject({ messages: 0, hub: false });
+		});
+
+		// Hibernated and completed tasks keep their existing treatment: neither state
+		// earns a project a block of its own.
+		it("leaves a project holding only hibernated tasks in the parked band", () => {
+			const tasks = [...projectTasks("a"), task("asleep", 20, { projectId: "b", hibernated: true })];
+			const result = collapsed(tasks, projectRows("a"));
+			expect(result.groups.map(group => group.projectId)).toEqual([]);
+			expect(result.placed.every(card => card.node.projectId === "a")).toBe(true);
+			expect(result.parkedCount).toBe(2);
+		});
+
 		it("keeps single-ended recipients visible and counts every attempt once", () => {
 			const tasks = [task("a", 1), task("b", 1, { projectId: "q" })];
 			const rows = [row("", "a", { fromTaskId: null, fromSeq: null }),

--- a/src/mainview/__tests__/nodes-layout.test.ts
+++ b/src/mainview/__tests__/nodes-layout.test.ts
@@ -446,9 +446,9 @@ describe("obstacle-aware traffic routing", () => {
 			assertClear(result);
 		});
 
-		// Only a board with a coordinator produces agent traffic, so eligibility keyed
-		// on message volume erased every other project from the stage — group box,
-		// cards and all — and took the named group off the surviving project too.
+		// Eligibility keyed on message volume erased a whole project from the stage —
+		// group box, cards and all — and took the named group off the surviving
+		// project too, since grouping switches on at more than one visible project.
 		it("gives a project with no traffic its own named block beside a conversing one", () => {
 			const tasks = [...projectTasks("a"), task("solo1", 20, { projectId: "b" }), task("solo2", 21, { projectId: "b" })];
 			const result = collapsed(tasks, projectRows("a"));

--- a/src/mainview/components/agent-traffic/nodes-layout.ts
+++ b/src/mainview/components/agent-traffic/nodes-layout.ts
@@ -132,9 +132,8 @@ export function layoutTraffic(
 	const awake = sorted.filter((node) => !node.task?.hibernated);
 	// Eligibility is per project, not per message count: a project whose window
 	// holds zero messages still gets its block. Volume decides which cards a
-	// *conversation* buries, never whether a board exists — and in practice only
-	// boards running a coordinator carry traffic, so the old zero-message rule
-	// erased every other one from the stage.
+	// *conversation* buries, never whether a board exists — the old zero-message
+	// rule erased a whole board from the stage, group box and all.
 	const silent = new Set(awake.map((node) => node.projectId));
 	for (const node of awake) if (messages.has(node.key)) silent.delete(node.projectId);
 	const conversing = (node: TrafficNode) => messages.has(node.key) || silent.has(node.projectId);

--- a/src/mainview/components/agent-traffic/nodes-layout.ts
+++ b/src/mainview/components/agent-traffic/nodes-layout.ts
@@ -130,8 +130,16 @@ export function layoutTraffic(
 	);
 	const parked = sorted.filter((node) => node.task?.hibernated === true);
 	const awake = sorted.filter((node) => !node.task?.hibernated);
-	const active = awake.filter((node) => messages.has(node.key));
-	const quiet = awake.filter((node) => !messages.has(node.key));
+	// Eligibility is per project, not per message count: a project whose window
+	// holds zero messages still gets its block. Volume decides which cards a
+	// *conversation* buries, never whether a board exists — and in practice only
+	// boards running a coordinator carry traffic, so the old zero-message rule
+	// erased every other one from the stage.
+	const silent = new Set(awake.map((node) => node.projectId));
+	for (const node of awake) if (messages.has(node.key)) silent.delete(node.projectId);
+	const conversing = (node: TrafficNode) => messages.has(node.key) || silent.has(node.projectId);
+	const active = awake.filter(conversing);
+	const quiet = awake.filter((node) => !conversing(node));
 	const placed: PlacedNode[] = [];
 	const positions = new Map<string, PlacedNode>();
 	const groups: TrafficScene["groups"] = [];


### PR DESCRIPTION
Agent traffic's Experiment 2 stage decided whether a **project** exists from the same rule that decides which **cards** a conversation buries: `layoutTraffic` built the drawn set as `active = awake.filter(node => messages.has(node.key))` and then derived the project group list from that drawn set. A project with zero messages in the selected window therefore produced no cards and no group box at all, and — because grouping only switches on above one visible project — the project that *did* carry traffic lost its named block too.

Eligibility is now a property of the project rather than of a message count: a project with no message-carrying awake node in the window has its awake tasks drawn, so every visible project keeps its own named group with ordinary task cards. Promoted tasks leave the quiet band, so its count stays honest and nothing is drawn twice. No coordinator node or relationship is invented; hibernated and completed tasks keep their existing treatment; eligibility reads the whole window's records, so card positions do not move while a replay advances.

The defect was reported as "projects without a coordinator are omitted". What is measured and reproduced here is the zero-message rule — coordinator exclusivity was never verified and is not claimed anywhere in the change.

A task that leaves the conversation stays individually reachable: the quiet-band toggle expands it back inside its own project block, and the inspector's Tasks tab lists and opens it with the band collapsed. Both routes pre-date this change and are untouched.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=7a2bbfe7-cdf8-4c01-ae35-66c29e791d8c) · `dev3://task/7a2bbfe7-cdf8-4c01-ae35-66c29e791d8c` _(dev3 added this footer — turn it off in Settings → Tasks.)_
