### PR TITLE
Open the agent traffic screen from the agent-message toast

### DIFF
--- a/change-logs/2026/09/08/feature-80-message-toast-opens-traffic.md
+++ b/change-logs/2026/09/08/feature-80-message-toast-opens-traffic.md
@@ -1,0 +1,3 @@
+Short: Message toast opens agent traffic
+
+Clicking the violet toast that reports one agent writing to another now opens the agent traffic screen when the traffic beta is on, so the sender, the receiver and the full text are all in front of you instead of just the receiving task. With the beta off the toast still opens the receiving task, and the destination is decided at click time so a toast that outlives the toggle follows the current setting.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -47,7 +47,7 @@ import { setToastSuppressed, taskToastContext, ToastHost, toast, type ToastEntry
 import { useSpaces } from "./useSpaces";
 import AgentTrafficScreen from "./components/agent-traffic/AgentTrafficScreen";
 import { noteTrafficArrival } from "./agent-traffic";
-import { OPEN_AGENT_TRAFFIC_LOG_EVENT } from "./agent-traffic-events";
+import { OPEN_AGENT_TRAFFIC_LOG_EVENT, openAgentTrafficLog } from "./agent-traffic-events";
 import { getAgentTrafficEnabled, syncAgentTrafficFromGlobalSettings } from "./agent-traffic-flag";
 import { useAgentTrafficEnabled } from "./hooks/useAgentTrafficEnabled";
 import StuckPreparationPopover from "./components/StuckPreparationPopover";
@@ -1655,8 +1655,9 @@ function App() {
 
 	// One agent wrote into another task's agent (`dev3 message` from a worktree).
 	// Its own violet variant and a two-identity source line — the only toast whose
-	// event has a sender AND a receiver. The click goes to the RECEIVER: that is
-	// where the text landed and where the reply gets typed.
+	// event has a sender AND a receiver. With the traffic beta on, the click opens
+	// the traffic screen, where both identities and the full text live; with it off
+	// it falls back to the RECEIVER, where the text landed and the reply gets typed.
 	useEffect(() => {
 		function onAgentMessage(e: Event) {
 			const { taskId, projectId, fromProjectId, toSeq, toTitle, fromSeq, fromTitle, preview } = (e as CustomEvent)
@@ -1678,7 +1679,18 @@ function App() {
 			toast.agent(t("toast.agentMessage", { preview }), {
 				context: `${from} → ${to}`,
 				taskId,
-				onClick: () => openTaskFromNotification(taskId, projectId),
+				// Read the flag at CLICK time, not here: a toast can outlive a toggle.
+				onClick: () => {
+					if (!getAgentTrafficEnabled()) {
+						openTaskFromNotification(taskId, projectId);
+						return;
+					}
+					// Already there — the shortcut toggles, but a toast has nothing to
+					// toggle back to, and navigating again would stack a second identical
+					// history entry and make Back a dead key.
+					if (routeRef.current.screen === "agent-traffic") return;
+					openAgentTrafficLog();
+				},
 			});
 		}
 		window.addEventListener("rpc:agentMessage", onAgentMessage);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -195,7 +195,7 @@ vi.mock("../confirm", () => ({
 import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEnabled } from "../task-sounds";
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
 import { setStreamerMode } from "../streamer-mode";
-import { setAgentTrafficEnabledForTests } from "../agent-traffic-flag";
+import { setAgentTrafficEnabledForTests, syncAgentTrafficFromGlobalSettings } from "../agent-traffic-flag";
 import { OPEN_AGENT_TRAFFIC_LOG_EVENT } from "../agent-traffic-events";
 
 const mockedAdjustZoom = vi.mocked(adjustZoom);
@@ -1456,7 +1456,19 @@ describe("App keyboard shortcuts", () => {
 		afterEach(() => {
 			setStreamerMode(false);
 			delete document.documentElement.dataset.streamer;
+			setAgentTrafficEnabledForTests(false);
 		});
+
+		/** Flip the beta on the way production does: through the settings mirror. */
+		function enableTrafficBeta() {
+			act(() => {
+				syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: true });
+			});
+		}
+
+		function toastButton() {
+			return screen.findByRole("button", { name: "#7 Coordinator → #42 Receiver — check the payload" });
+		}
 
 		async function renderWithBoard() {
 			vi.mocked(api.request.getProjects).mockResolvedValue(twoProjects);
@@ -1494,6 +1506,89 @@ describe("App keyboard shortcuts", () => {
 			await waitFor(() => {
 				expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-receiver");
 			});
+		});
+
+		it("opens the traffic screen instead of the task when the beta is on", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			dispatchAgentMessage();
+
+			await userEvent.click(await toastButton());
+
+			expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
+			// It is a route, not an overlay: the app header and Back come with it.
+			expect(document.querySelector('header[aria-label="Application header"]')).not.toBeNull();
+			// The fallback must NOT fire as well — that would navigate behind the screen.
+			expect(screen.queryByTestId("project-screen")).toBeNull();
+
+			// Back returns to where the click came from, in one press.
+			await userEvent.click(screen.getByRole("button", { name: /^Back/ }));
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-project-id", "p1");
+			expect(screen.queryByTestId("agent-traffic-screen")).toBeNull();
+		});
+
+		// The toast outlives the toggle, so the destination cannot be captured when
+		// the toast is built — it has to be decided at click time.
+		it("follows a beta switched on after the toast was already on screen", async () => {
+			await renderWithBoard();
+			dispatchAgentMessage();
+			enableTrafficBeta();
+
+			await userEvent.click(await toastButton());
+
+			expect(screen.getByTestId("agent-traffic-screen")).toBeInTheDocument();
+		});
+
+		// The shortcut toggles the screen; a toast has nothing to toggle back to, so
+		// it stays put. Navigating again would push a second identical route and make
+		// the next Back press do nothing visible.
+		it("stays put, and adds no history entry, when the click lands on the screen itself", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			await userEvent.keyboard("{Shift>}{Meta>}m{/Meta}{/Shift}");
+			expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
+
+			dispatchAgentMessage();
+			await userEvent.click(await toastButton());
+
+			expect(screen.getAllByTestId("agent-traffic-screen")).toHaveLength(1);
+
+			// One Back leaves the screen. A duplicated entry would land on it again.
+			await userEvent.click(screen.getByRole("button", { name: /^Back/ }));
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-project-id", "p1");
+			expect(screen.queryByTestId("agent-traffic-screen")).toBeNull();
+		});
+
+		// Keyboard parity: the toast's hit area is a real button, and Enter on it
+		// must reach the same destination a pointer click does.
+		it("opens the traffic screen from the keyboard too", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			dispatchAgentMessage();
+
+			(await toastButton()).focus();
+			await userEvent.keyboard("{Enter}");
+
+			expect(screen.getByTestId("agent-traffic-screen")).toBeInTheDocument();
+		});
+
+		// An ordinary `dev3 notify` toast is not traffic — the beta must not steal
+		// its click away from the task it points at.
+		it("leaves an unrelated CLI toast pointing at its task", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliToast", {
+					detail: { taskId: "t-receiver", projectId: "p1", message: "build finished", level: "success" },
+				}));
+			});
+
+			await userEvent.click(await screen.findByRole("button", { name: /build finished/ }));
+
+			await waitFor(() => {
+				expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-receiver");
+			});
+			expect(screen.queryByTestId("agent-traffic-screen")).toBeNull();
 		});
 
 		it("drops the toast when the SENDER's project is sensitive on camera", async () => {


### PR DESCRIPTION
The violet toast that reports one agent writing into another task (`dev3 message`) used to click through to the receiving task, always. With the Agent traffic beta on it now opens the routed traffic screen instead — where both identities and the full text live — through the canonical entry action. With the beta off it keeps the old task-open behaviour exactly.

Three branches, in order:

- Beta off → `openTaskFromNotification(taskId, projectId)`, unchanged.
- Already on the traffic screen → nothing. `⇧⌘M` is a toggle and can step back; a toast has nothing to toggle back to, and navigating again would push a second identical route through `pushRoute`, which does not dedupe — the next Back press would look like a dead key.
- Otherwise → `openAgentTrafficLog()`, the same event the header readout, `⇧⌘M`, the native View menu and the command palette fire. Route, history and project scope stay owned by the screen.

The flag is read inside the click handler rather than captured when the toast is built: a toast outlives a settings toggle, and the beta can flip from Settings or from another remote client while it is on screen.

The toast's hit area was already a real `<button>` with an `aria-label` of `"<context> — <message>"`, so keyboard activation and the focus ring come for free. Appearance, copy and the context line are unchanged, and an ordinary `dev3 notify` toast still opens its own task.

Five cases cover it in `App.test.tsx`. Mutation-checked: removing the flag branch fails four of them, removing the already-on-screen guard fails the fifth on exactly its Back assertion.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=33b36064-ffe1-45bb-b4be-482c35a056b3) · `dev3://task/33b36064-ffe1-45bb-b4be-482c35a056b3` _(dev3 added this footer — turn it off in Settings → Tasks.)_
