### PR TITLE
Skin every standard artifact form control on the element itself

### DIFF
--- a/change-logs/2026/09/09/feature-30-artifact-template-form-controls.md
+++ b/change-logs/2026/09/09/feature-30-artifact-template-form-controls.md
@@ -1,0 +1,3 @@
+Short: Artifact inputs stop looking native
+
+Every standard form control in the artifact template is now skinned on the element itself instead of only inside a `.field` wrapper, so a bare `<textarea>` or `<select>` an author drops into a report matches the rest of the shell. Textareas get a real box, their own font and auto-growing height; a plain `<select>` draws its own caret; and file, color, search, number, date, multi-select, checkbox and radio glyphs, placeholders, and the disabled, read-only and invalid states all follow the dev3 tokens in both themes.

--- a/decisions/2026/09/09/artifact-form-controls-live-on-the-element.md
+++ b/decisions/2026/09/09/artifact-form-controls-live-on-the-element.md
@@ -1,0 +1,24 @@
+# Artifact form controls are skinned on the element, not on `.field`
+
+## Context
+
+The artifact starter styled inputs only through `.field input, .field select`, and checkbox/radio glyphs only through `.check input`. `<textarea>` had no rule at all — not even in the `button, input, select { font: inherit; }` reset. A report that wrote a plain textarea (which `REFERENCE.md` explicitly invites for the send-to-agent flow) shipped a 20-column UA box in the UA font, next to a fully styled form.
+
+## Decision
+
+`src/assets/artifact-template/app.css` now hangs the shell off the elements — `input:where(:not(.choices__input)), textarea, select` — and leaves `.field` with the width only. The special types re-specify what they need further down: range, checkbox/radio glyphs, file, color, submit-like inputs. A plain `<select>` gets `appearance: none` plus its own caret, so it no longer needs `data-ui-select` to stop being native chrome.
+
+Two mechanics make this hold and must survive any edit:
+
+- **`:where()` keeps the base rules at element specificity (0,0,1).** That is what lets `.field`, `.table-tools`, `.check`, `.switch` and the per-type blocks win on their own details without `!important`. Replacing a `:where()` with a plain `:not()` raises the specificity and silently breaks the overrides.
+- **The caret is two `linear-gradient` triangles, not a data-URI SVG,** because a data URI cannot read `--dev3-text-muted` and would need one hardcoded hex per theme. Consequently a shorthand `background:` anywhere downstream wipes the caret — `.table-tools` had to move to `background-color:` for exactly this reason.
+
+Coverage is guarded by `src/bun/__tests__/artifact-template.test.ts` ("skins every standard control on the element itself"). The CSS size cap in the same file moved from 44 000 to 54 000 bytes; the shell stylesheet is not an authoring surface, and 49.5 KB is still ~20x under an inlined chart library, which is what that cap actually guards.
+
+## Risks
+
+`select[multiple] option:checked` uses a flat gradient because browsers ignore `background-color` there; if a future engine honours the plain property, the gradient still renders correctly. `field-sizing: content` on `textarea` is progressive — engines without it fall back to `min-height` plus `rows`.
+
+## Alternatives considered
+
+Keeping the styling gated on `.field` and only documenting the wrapper harder: rejected, because the failure is silent and lands in published reports rather than in review. Styling only `textarea` and leaving the rest: rejected, the same gap existed for every other control type.

--- a/src/assets/artifact-template/AUTHORING.md
+++ b/src/assets/artifact-template/AUTHORING.md
@@ -32,6 +32,7 @@ Write the class — never a `<style>` block, never a hex color, never a px font 
 | A hue | `tone-1` … `tone-6` or `tone-gold` on a card, KPI, pill — everything inside follows |
 | A chart | `<div class="chart-host" id="…" role="img">` + `dev3Artifact.chart()` in `report.js` |
 | A select, slider, switch | native markup + `data-ui-select` / `data-ui-slider`; `.check`, `.switch`, `.option-group` skin the rest |
+| Any other input | plain `<input>`, `<textarea>`, `<select>` — the shell already skins every type, checkbox and radio glyphs included, with or without a `.field` wrapper. Write no styles for them |
 | A menu that opens | `.popover-anchor` → `data-popover-trigger` + `.popover` — never `position: absolute` + `z-index` |
 | A short clip | plain `<video controls playsinline preload="metadata" poster="clips/x.png">` with an MP4 or WebM under the report directory — 16 MB per clip, 48 MB in total. `REFERENCE.md` § Bundled video clips |
 

--- a/src/assets/artifact-template/REFERENCE.md
+++ b/src/assets/artifact-template/REFERENCE.md
@@ -182,11 +182,12 @@ Keep form markup native and opt into the polished controls with one attribute. T
   <label class="check field full"><input type="checkbox" checked> Include experimental presets</label>
   <fieldset class="option-group field full"><legend>Review mode</legend><div class="choice-grid"><label class="check"><input type="radio" name="mode" checked> Automatic</label><label class="check"><input type="radio" name="mode"> Manual</label></div></fieldset>
   <label class="switch field full"><input type="checkbox" checked><span aria-hidden="true"></span> Auto-refresh</label>
+  <div class="field full"><label for="notes">Notes</label><textarea id="notes" rows="3" placeholder="Anything the agent should know…"></textarea></div>
   <div class="form-actions field full"><button type="reset">Reset</button><button class="primary" type="submit">Apply</button></div>
 </form>
 ```
 
-`.controls` is a two-column grid; `.field.full` spans both. `.check`, `.switch`, and `.option-group` skin native checkbox, radio, and switch markup without report JavaScript. A `.segmented` group of buttons (`<button class="active">`) toggles a view; report code flips `.active` and calls `remount()` on the chart. When report code changes an enhanced select or range, call `dev3Artifact.setControl(element, value)` so the native value, visual control, events, and output stay synchronized. `dev3Artifact.toast("Saved")` shows the transient message in `#toast`.
+`.controls` is a two-column grid; `.field.full` spans both. `.check`, `.switch`, and `.option-group` skin native checkbox, radio, and switch markup without report JavaScript. Every other standard control is skinned on the element itself — text, search, number, date, email, password, `textarea`, a plain `<select>` (its own caret, no `data-ui-select` needed), `select[multiple]`, `file`, `color`, checkbox and radio glyphs, plus placeholder, hover, focus ring, `:disabled`, `:read-only` and `:user-invalid` states. A `.field` wrapper adds the label and the full width; without one the control still looks right, so a control dropped straight into a panel or a table cell never needs styles of its own. A `.segmented` group of buttons (`<button class="active">`) toggles a view; report code flips `.active` and calls `remount()` on the chart. When report code changes an enhanced select or range, call `dev3Artifact.setControl(element, value)` so the native value, visual control, events, and output stay synchronized. `dev3Artifact.toast("Saved")` shows the transient message in `#toast`.
 
 ## Menus, dropdowns, and anything that opens over the report
 

--- a/src/assets/artifact-template/app.css
+++ b/src/assets/artifact-template/app.css
@@ -140,7 +140,7 @@
       background: rgb(var(--dev3-success));
       box-shadow: 0 0 0 4px rgb(var(--dev3-success) / .12);
     }
-    button, input, select { font: inherit; }
+    button, input, select, textarea { font: inherit; }
     button {
       padding: 8px 12px;
       border: 1px solid rgb(var(--dev3-border));
@@ -153,7 +153,7 @@
     button:hover { border-color: rgb(var(--dev3-accent) / .65); transform: translateY(-1px); }
     button:disabled { opacity: .42; cursor: default; }
     button:disabled:hover { border-color: rgb(var(--dev3-border)); transform: none; }
-    button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, th:focus-visible,
+    button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, th:focus-visible,
     .choices.is-focused .choices__inner, .noUi-handle:focus-visible {
       outline: 2px solid rgb(var(--dev3-accent));
       outline-offset: 2px;
@@ -306,25 +306,154 @@
       letter-spacing: 0;
       text-transform: none;
     }
-    .field input, .field select {
-      width: 100%;
+    /* One shell for every control, hung off the elements rather than off
+       `.field`, so a bare <textarea> or <select> dropped into a hand-written
+       panel matches the form above it instead of being a raw UA box. The
+       glyph, slider, file, and color types re-specify what they need further
+       down; keeping the shell at element specificity is what lets them, and
+       lets `.field` and `.table-tools` win on their own details. */
+    input:where(:not(.choices__input)), textarea, select {
       padding: 9px 10px;
       border: 1px solid rgb(var(--dev3-border));
       border-radius: 10px;
       background: rgb(var(--dev3-surface-base));
       color: rgb(var(--dev3-text-primary));
+      caret-color: rgb(var(--dev3-accent));
       outline: none;
+      transition: border-color .16s ease, box-shadow .16s ease, background-color .16s ease;
     }
-    .field input:focus, .field select:focus {
+    input:where(:not(.choices__input)):hover, textarea:hover, select:hover { border-color: rgb(var(--dev3-accent) / .48); }
+    input:where(:not(.choices__input)):focus, textarea:focus, select:focus {
       border-color: rgb(var(--dev3-accent));
       box-shadow: 0 0 0 3px rgb(var(--dev3-accent) / .12);
+    }
+    input:where([type="submit"], [type="reset"], [type="button"]) { background: rgb(var(--dev3-surface-elevated)); cursor: pointer; }
+    input:where([type="image"], [type="hidden"]) { padding: 0; border: 0; background: none; }
+    ::placeholder { color: rgb(var(--dev3-text-muted)); opacity: 1; }
+    :disabled { cursor: not-allowed; opacity: .62; }
+    input:read-only:where(:not([type="checkbox"], [type="radio"], [type="range"])), textarea:read-only,
+    input:disabled, textarea:disabled, select:disabled {
+      background-color: rgb(var(--dev3-surface-elevated));
+      color: rgb(var(--dev3-text-secondary));
+    }
+    /* `:user-invalid` fires only after the reader has touched the field, so an
+       untouched required input is not red the moment the report opens. */
+    :is(input, textarea, select):is(:user-invalid, [aria-invalid="true"]) { border-color: rgb(var(--dev3-danger)); }
+    :is(input, textarea, select):is(:user-invalid, [aria-invalid="true"]):focus { box-shadow: 0 0 0 3px rgb(var(--dev3-danger) / .16); }
+    .field input:where(:not([type="checkbox"], [type="radio"], [type="submit"], [type="reset"], [type="button"])), .field select, .field textarea { width: 100%; }
+    /* A default textarea is 20 columns of UA font. It gets a real box, and where
+       `field-sizing` is supported it grows with the text instead of handing the
+       reader a two-line slot and a drag handle. */
+    textarea {
+      width: 100%;
+      min-height: 5.5rem;
+      max-height: 60vh;
+      field-sizing: content;
+      line-height: 1.5;
+      resize: vertical;
+    }
+    /* A data-URI arrow cannot read a CSS variable, so the caret is two gradient
+       triangles and stays on the same token as the Choices chevron. */
+    select {
+      appearance: none;
+      padding-right: 30px;
+      background-image:
+        linear-gradient(45deg, transparent 50%, rgb(var(--dev3-text-muted)) 50%),
+        linear-gradient(135deg, rgb(var(--dev3-text-muted)) 50%, transparent 50%);
+      background-repeat: no-repeat;
+      background-position: right 17px center, right 12px center;
+      background-size: 5px 5px;
+      cursor: pointer;
+    }
+    select:hover, select:focus {
+      background-image:
+        linear-gradient(45deg, transparent 50%, rgb(var(--dev3-accent)) 50%),
+        linear-gradient(135deg, rgb(var(--dev3-accent)) 50%, transparent 50%);
+    }
+    select[multiple], select[size]:not([size="1"]) { padding-right: 10px; background-image: none; cursor: default; }
+    select[multiple] option { padding: 4px 6px; border-radius: 6px; }
+    /* A selected row in a multi-select ignores background-color; a flat gradient
+       is the only fill browsers honour there. */
+    select[multiple] option:checked { background: linear-gradient(rgb(var(--dev3-accent) / .3), rgb(var(--dev3-accent) / .3)); color: rgb(var(--dev3-text-primary)); }
+    /* Windows and Linux paint the native popup from these; macOS ignores them. */
+    option, optgroup { background: rgb(var(--dev3-surface-elevated)); color: rgb(var(--dev3-text-primary)); }
+    input[type="search"]:where(:not(.choices__input)) { appearance: none; }
+    input[type="search"]:where(:not(.choices__input))::-webkit-search-cancel-button {
+      appearance: none;
+      width: .85em;
+      height: .85em;
+      background: rgb(var(--dev3-text-muted));
+      cursor: pointer;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 3.5l9 9M12.5 3.5l-9 9' stroke='%23000' stroke-width='2' stroke-linecap='round' fill='none'/%3E%3C/svg%3E") center / contain no-repeat;
+    }
+    input[type="search"]:where(:not(.choices__input))::-webkit-search-cancel-button:hover { background: rgb(var(--dev3-text-primary)); }
+    input[type="number"]::-webkit-inner-spin-button { opacity: .5; }
+    input[type="number"]:hover::-webkit-inner-spin-button,
+    input[type="number"]:focus::-webkit-inner-spin-button { opacity: 1; }
+    input::-webkit-calendar-picker-indicator { cursor: pointer; opacity: .55; transition: opacity .16s ease; }
+    input:hover::-webkit-calendar-picker-indicator, input:focus::-webkit-calendar-picker-indicator { opacity: 1; }
+    /* A file input's UA chrome is the loudest control on any page it lands on:
+       a dashed well plus a ghost button reads as a drop target instead. */
+    input[type="file"] {
+      width: 100%;
+      padding: 7px;
+      border: 1px dashed rgb(var(--dev3-border));
+      border-radius: 10px;
+      background: rgb(var(--dev3-surface-base));
+      color: rgb(var(--dev3-text-secondary));
+      cursor: pointer;
+      font-size: .75rem;
+      transition: border-color .16s ease;
+    }
+    input[type="file"]:hover { border-color: rgb(var(--dev3-accent) / .5); }
+    input[type="file"]::file-selector-button {
+      margin-right: 10px;
+      padding: 6px 11px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 8px;
+      background: rgb(var(--dev3-surface-elevated));
+      color: rgb(var(--dev3-text-primary));
+      cursor: pointer;
+      font: inherit;
+      transition: border-color .16s ease;
+    }
+    input[type="file"]::file-selector-button:hover { border-color: rgb(var(--dev3-accent) / .65); }
+    input[type="color"] {
+      width: 2.9em;
+      height: 2.35em;
+      padding: 3px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 9px;
+      background: rgb(var(--dev3-surface-base));
+      cursor: pointer;
+    }
+    input[type="color"]:hover { border-color: rgb(var(--dev3-accent) / .5); }
+    input[type="color"]::-webkit-color-swatch-wrapper { padding: 0; }
+    input[type="color"]::-webkit-color-swatch { border: 0; border-radius: 6px; }
+    input[type="color"]::-moz-color-swatch { border: 0; border-radius: 6px; }
+    /* A bare fieldset is UA chrome too; `.option-group` still opts out of it. */
+    fieldset {
+      min-width: 0;
+      padding: 12px 14px;
+      border: 1px solid rgb(var(--dev3-border));
+      border-radius: 12px;
+    }
+    legend {
+      padding: 0 6px;
+      color: rgb(var(--dev3-text-secondary));
+      font-size: .6875rem;
+      letter-spacing: .05em;
+      text-transform: uppercase;
     }
     input[type="range"] {
       height: 28px;
       padding: 0;
       border: 0;
+      border-radius: 0;
+      background: none;
       box-shadow: none;
       accent-color: rgb(var(--dev3-accent));
+      cursor: pointer;
     }
     input[data-ui-slider].is-enhanced {
       position: absolute;
@@ -407,10 +536,12 @@
     .check:hover, .switch:hover { border-color: rgb(var(--dev3-accent) / .48); color: rgb(var(--dev3-text-primary)); }
     .check:has(input:checked), .switch:has(input:checked) { border-color: rgb(var(--dev3-accent) / .34); background: rgb(var(--dev3-accent) / .055); }
     /* Control glyphs are sized in em, so a checkbox, radio, or switch grows with
-       the label beside it instead of shrinking against enlarged text. */
-    .check input {
+       the label beside it instead of shrinking against enlarged text. They hang
+       off the element rather than off `.check`, so a checkbox in a paragraph or
+       a table cell is the same glyph as one in a form row. */
+    input:where([type="checkbox"], [type="radio"]) {
       appearance: none;
-      display: grid;
+      display: inline-grid;
       flex: 0 0 auto;
       width: 1.5em;
       height: 1.5em;
@@ -420,11 +551,17 @@
       border-radius: 5px;
       background: rgb(var(--dev3-surface-raised));
       box-shadow: none;
+      cursor: pointer;
+      transition: border-color .16s ease, background .16s ease;
+      vertical-align: -.3em;
     }
-    .check input[type="radio"] { border-radius: 50%; }
-    .check input[type="radio"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); box-shadow: inset 0 0 0 .33em rgb(var(--dev3-surface-raised)); }
-    .check input[type="checkbox"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); }
-    .check input[type="checkbox"]:checked::after { width: .66em; height: .33em; border: solid rgb(var(--dev3-on-accent)); border-width: 0 0 2px 2px; content: ""; transform: translateY(-1px) rotate(-45deg); }
+    input:where([type="checkbox"], [type="radio"]):hover { border-color: rgb(var(--dev3-accent) / .55); }
+    input[type="radio"] { border-radius: 50%; }
+    input[type="radio"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); box-shadow: inset 0 0 0 .33em rgb(var(--dev3-surface-raised)); }
+    input[type="checkbox"]:checked { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); }
+    input[type="checkbox"]:checked::after { width: .66em; height: .33em; border: solid rgb(var(--dev3-on-accent)); border-width: 0 0 2px 2px; content: ""; transform: translateY(-1px) rotate(-45deg); }
+    input[type="checkbox"]:indeterminate { border-color: rgb(var(--dev3-accent)); background: rgb(var(--dev3-accent)); }
+    input[type="checkbox"]:indeterminate::after { width: .62em; border-top: 2px solid rgb(var(--dev3-on-accent)); content: ""; }
     .switch input { position: absolute; width: 1px; height: 1px; opacity: 0; }
     .switch > span { position: relative; flex: 0 0 auto; width: 3.17em; height: 1.83em; border-radius: 999px; background: rgb(var(--dev3-border)); transition: background .18s ease; }
     .switch > span::after { position: absolute; top: .25em; left: .25em; width: 1.33em; height: 1.33em; border-radius: 50%; background: rgb(var(--dev3-text-primary)); content: ""; transition: transform .18s ease; }
@@ -551,15 +688,18 @@
     :not(html, body):has(> table), .table-card, .evidence-table-scroll { container: dev3-table / inline-size; }
     .table-head { padding: 16px 18px 12px; }
     .table-tools { gap: 8px; }
+    /* background-color, not the shorthand: the select's caret is a background
+       image and a shorthand here would wipe it. */
     .table-tools input, .table-tools select {
       padding: 7px 9px;
       border: 1px solid rgb(var(--dev3-border));
       border-radius: 9px;
-      background: rgb(var(--dev3-surface-base));
+      background-color: rgb(var(--dev3-surface-base));
       color: rgb(var(--dev3-text-primary));
       outline: none;
     }
     .table-tools input { width: 12rem; }
+    .table-tools select { padding-right: 26px; background-position: right 14px center, right 9px center; }
     table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
     th, td { padding: 11px 18px; border-top: 1px solid rgb(var(--dev3-border)); overflow-wrap: break-word; text-align: left; font-size: .75rem; }
     /* A vertical rule keeps the eye inside one column across a wide row; every

--- a/src/assets/artifact-template/index.html
+++ b/src/assets/artifact-template/index.html
@@ -78,6 +78,7 @@
           <label class="check field full"><input id="experiments" type="checkbox" checked> Include experimental agent presets</label>
           <fieldset class="option-group field full"><legend>Review mode</legend><div class="choice-grid"><label class="check"><input type="radio" name="reviewMode" value="automatic" checked> Automatic</label><label class="check"><input type="radio" name="reviewMode" value="manual"> Manual</label></div></fieldset>
           <label class="switch field full"><input type="checkbox" checked><span aria-hidden="true"></span> Auto-refresh forecasts</label>
+          <div class="field full"><label for="scenarioNotes">Notes for the run</label><textarea id="scenarioNotes" rows="3" placeholder="Anything the agent should know before it starts…"></textarea></div>
           <div class="form-actions field full"><button type="reset">Reset</button><button class="primary" type="submit">Simulate</button></div>
         </form>
       </article>

--- a/src/bun/__tests__/artifact-template.test.ts
+++ b/src/bun/__tests__/artifact-template.test.ts
@@ -260,6 +260,50 @@ describe("bundled artifact starter contract", () => {
 		expect(app).toContain("takes no arguments");
 	});
 
+	// A control only looked right when the author remembered a `.field` wrapper or
+	// a `data-ui-*` attribute, so a hand-written panel shipped a raw UA textarea
+	// and a native select next to the styled form above it.
+	it("skins every standard control on the element itself, not only inside .field", () => {
+		const css = readFileSync(cssPath, "utf8");
+		const html = readFileSync(htmlPath, "utf8");
+
+		// The shell hangs off the elements; `.field` is left with the width only.
+		expect(css).toContain("input:where(:not(.choices__input)), textarea, select {");
+		// The width is `.field`'s only remaining job, and a glyph or a submit
+		// button must never take it.
+		expect(css).toContain(
+			'.field input:where(:not([type="checkbox"], [type="radio"], [type="submit"], [type="reset"], [type="button"])), .field select, .field textarea { width: 100%; }',
+		);
+		// A textarea was the one control with no rule at all, down to its font.
+		expect(css).toContain("button, input, select, textarea { font: inherit; }");
+		expect(css).toMatch(/textarea \{[^}]*field-sizing: content;/);
+		expect(css).toMatch(/textarea \{[^}]*resize: vertical;/);
+		// A plain <select> draws its own caret, so it needs no `data-ui-select` to
+		// stop being native chrome — and the caret is a token, not a data URI.
+		expect(css).toMatch(/select \{[^}]*appearance: none;/);
+		expect(css).toContain("linear-gradient(135deg, rgb(var(--dev3-text-muted)) 50%, transparent 50%)");
+		// A shorthand `background` next to the caret would silently wipe it.
+		expect(css).toContain(".table-tools input, .table-tools select {");
+		expect(css).toMatch(/\.table-tools input, \.table-tools select \{[^}]*background-color: rgb\(var\(--dev3-surface-base\)\);/);
+		// Glyphs, not `.check` rows: a checkbox in prose or a table cell matches.
+		expect(css).toContain('input:where([type="checkbox"], [type="radio"]) {');
+		expect(css).toContain('input[type="checkbox"]:indeterminate');
+		for (const rule of [
+			"::placeholder",
+			":user-invalid",
+			'input[type="file"]::file-selector-button',
+			'input[type="color"]::-webkit-color-swatch',
+			'input[type="search"]',
+			"select[multiple]",
+			"textarea:read-only",
+		]) {
+			expect(css).toContain(rule);
+		}
+		// The demo carries the control the reports were getting wrong.
+		expect(html).toContain('<textarea id="scenarioNotes"');
+		expect(docs).toContain("| Any other input |");
+	});
+
 	it("scales the whole report from one root text size, including chart labels", () => {
 		const html = readFileSync(htmlPath, "utf8");
 		const css = readFileSync(cssPath, "utf8");
@@ -539,8 +583,10 @@ describe("bundled artifact starter contract", () => {
 		// their budgets only have to stay far below an inlined library — these are
 		// ~25x under one, and both sat at 98%+ of the previous caps before the
 		// responsive-table work, which left no room for any real change. The CSS
-		// cap moved again for the gold/viz palette and the tone classes.
-		expect(statSync(cssPath).size).toBeLessThan(44_000);
+		// cap moved again for the gold/viz palette and the tone classes, and once
+		// more for the full standard-control set (textarea, plain select caret,
+		// file, color, invalid and disabled states).
+		expect(statSync(cssPath).size).toBeLessThan(54_000);
 		expect(statSync(appPath).size).toBeLessThan(34_000);
 		expect(statSync(reportPath).size).toBeLessThan(15_000);
 	});


### PR DESCRIPTION
The artifact starter styled inputs only through `.field input, .field select`, and checkbox/radio glyphs only through `.check input`. `<textarea>` had no rule at all — not even in the `font: inherit` reset — so a report that wrote a plain textarea (which `REFERENCE.md` explicitly invites for the send-to-agent flow) shipped a 20-column UA box in the UA font next to a fully styled form. Same for a `<select>` without `data-ui-select`, which kept native chrome.

The shell now hangs off the elements and `.field` is left with the width only, so a control dropped straight into a hand-written panel or a table cell looks right with no wrapper and no attribute:

- `textarea` — real box, inherited font, `field-sizing: content`, vertical resize
- plain `<select>` — own caret drawn from tokens, `select[multiple]` with a visible selection
- `file`, `color`, `search`, `number`, `date`/`time` — token-styled chrome instead of UA chrome
- checkbox and radio glyphs on the element, including `:indeterminate`
- `::placeholder`, hover, focus ring, `:disabled`, `:read-only`, `:user-invalid` / `aria-invalid`

Two mechanics are load-bearing and documented in `decisions/2026/09/09/artifact-form-controls-live-on-the-element.md`: `:where()` keeps the base rules at element specificity so `.field` / `.table-tools` / `.check` still win, and the select caret is two gradients rather than a data URI so it can read `--dev3-text-muted` — which is why `.table-tools` moved to `background-color`.

The CSS size cap in `artifact-template.test.ts` moved 44 000 → 54 000 bytes; the shell stylesheet is not an authoring surface and 49.5 KB is still ~20x under an inlined chart library, which is what that cap guards.

Verified in a headless browser against a page exercising every control type, dark and light.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=130ec0be-adcd-4895-ad8b-09f32fee542c) · `dev3://task/130ec0be-adcd-4895-ad8b-09f32fee542c`