### PR TITLE
Default agent traffic to projects with recorded activity

### DIFF
--- a/change-logs/2026/09/10/feature-70-active-projects-traffic-scope.md
+++ b/change-logs/2026/09/10/feature-70-active-projects-traffic-scope.md
@@ -1,0 +1,3 @@
+Short: Agent traffic opens on active projects
+
+Agent traffic's project filter gained an "All active projects" scope and opens on it, so boards with no recorded event in the chosen window no longer take up the stage. Activity means a recorded message or task movement inside the window — not a running status, not a coordinator, not the project merely existing — and while history is still loading nothing is filtered out, because unread is not the same as inactive. "All projects" stays exactly as unfiltered as it was, and arriving from a project still opens on that project.

--- a/decisions/2026/09/10/active-traffic-scope-from-recorded-events.md
+++ b/decisions/2026/09/10/active-traffic-scope-from-recorded-events.md
@@ -1,0 +1,72 @@
+# Active-project traffic scope is read off recorded events, and never applied while loading
+
+## Context
+
+Agent traffic's project scope offered two shapes: every visible project, or one named
+project. On a machine with twenty boards and two busy ones, the default spent the stage on
+eighteen blocks holding nothing. A third scope — "All active projects", and the one a fresh
+entry opens on — needed a definition of "active" that the screen can actually prove.
+
+## Investigation
+
+Three candidate definitions were on the table, and two are unusable:
+
+- **Running status / a live runtime** — describes right now, not the window. A board whose
+  agents worked all morning and went quiet ten minutes ago would drop out of an hour that is
+  full of its work.
+- **Has a coordinator** — a role, not an event. It both over- and under-counts: an idle
+  coordinator keeps an empty board on stage, and a project that never used one is erased.
+- **Has a recorded event in the window** — what `traffic-timeline.ts` already assembles for
+  replay, and the only one made of facts the screen can cite.
+
+The timeline's union is `task` (a movement written into `Task.movements`) plus `message` (an
+agent-message-log row). Its `notification` kind is a control value with no arm behind it
+(`AgentTrafficScreen.tsx`, `TimelineKind`), so notifications are deliberately not evidence
+here yet — and become evidence the day that arm lands, with nothing in this code to change.
+
+## Decision
+
+`src/mainview/components/agent-traffic/traffic-scope.ts` owns the vocabulary and the
+resolution. `activeProjectIds()` reads membership off timeline events — both ends of a
+message, the owning project of a movement. `scopeProjectIds()` maps a scope value to the ids
+it admits, or `null` for "no filter at all"; `admits()` is the one place `null` is read as
+"everything", which keeps an empty set and an absent filter from ever being conflated.
+
+`AgentTrafficScreen.tsx` builds one **unscoped** window timeline for this, because deriving
+membership from scoped data is circular — a project filtered out could never prove it
+belonged. That timeline is also independent of the replay cursor, so membership holds still
+while the cursor walks the window (bible §5.9 "History is recorded events").
+
+Two guarantees are load-bearing:
+
+- **`ALL_PROJECTS` resolves to `null`**, so that path stays byte-identical to the unfiltered
+  one it has always been — including the per-project block eligibility Seq 1827 restored in
+  `nodes-layout.ts`, which this change deliberately does not touch. Narrowing happens
+  upstream, on which nodes reach the stage.
+- **`settled` gates the filter.** History arrives page by page; a window whose rows have not
+  loaded holds no evidence in either direction. Until `useTrafficData` reports both reads
+  done, `active` admits everything, so "not read yet" is never presented as "nothing
+  happened". The screen's own loading readout already names that state.
+
+`TrafficOrbit` asks `isAggregateScope()` instead of `scope === "all"`, so neither
+all-project scope pins a primary lane while both still refit the camera when switched.
+
+## Risks
+
+- Membership widens when a live event arrives for a project that had none. That is intended
+  ("recompute when events actually arrive"), and it is deliberately **not** part of the
+  playback reset key: a new project appearing must not restart the reader's replay.
+- A project whose movements were evicted from `Task.movements` and whose messages fell out of
+  retention reads as inactive for that window. It is genuinely unrecorded there; "All
+  projects" is one click away and unchanged.
+
+## Alternatives considered
+
+- **Filtering `data.projects` before the stages** — the stages derive their blocks from
+  nodes, not from that list (`layoutTraffic`), so it would have been a second, redundant
+  gate that could disagree with the first.
+- **Re-deriving the window clip inside `traffic-scope.ts`** instead of consuming timeline
+  events — cheaper by one timeline build, and guaranteed to drift from
+  `taskEvents`/`messageEvents` the first time either changes.
+- **A separate persisted setting** for the default scope — a durable preference for a beta
+  screen's ephemeral view state, and the manifest keeps view state on the surface.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1620,3 +1620,51 @@ describe("Replay reconstructs the board at the cursor", () => {
 		expect(caption()).not.toContain("Hibernation");
 	});
 });
+
+describe("AgentTrafficScreen project scope", () => {
+	/** Two boards, one of which said nothing all window and never moved a card. */
+	function setUpTwoProjects() {
+		projectFixtures.value = [
+			{ id: "proj-1", name: "Project One" },
+			{ id: "proj-2", name: "Project Two" },
+		];
+		additionalTasks.value = [{
+			id: "task-idle", projectId: "proj-2", seq: 91, title: "Idle worker",
+			status: "in-progress", taskType: null, overview: "Nothing recorded",
+		}];
+		projectPages.value = {
+			"proj-1": { rows: [row({ subject: "Live chatter" })], oldestDay: "2026-08-01", retentionDays: 30, hasMore: false },
+			"proj-2": { rows: [], oldestDay: null, retentionDays: 30, hasMore: false },
+		};
+	}
+	const taskStat = () => document.querySelectorAll(".traffic-stat b")[1]?.textContent;
+	const scopeName = () => document.querySelector(".traffic-summary strong")?.textContent;
+	const cardTitles = () => screen.getAllByTestId("traffic-node-card").map((card) => card.textContent ?? "").join(" | ");
+
+	it("opens on the active projects and leaves the silent board off the stage", async () => {
+		setUpTwoProjects();
+		renderLog(vi.fn(), null);
+		await waitFor(() => expect(scopeName()).toBe("All active projects"));
+		// proj-1's three tasks only: proj-2 exists and is running, and neither is a
+		// recorded event, so it does not occupy the stage.
+		await waitFor(() => expect(taskStat()).toBe("3"));
+		expect(cardTitles()).not.toContain("Idle worker");
+	});
+
+	it("keeps All projects unfiltered, silent board and all", async () => {
+		setUpTwoProjects();
+		renderLog(vi.fn(), null);
+		await waitFor(() => expect(taskStat()).toBe("3"));
+		await choose("Project", "All projects");
+		await waitFor(() => expect(scopeName()).toBe("All projects"));
+		expect(taskStat()).toBe("4");
+		await waitFor(() => expect(cardTitles()).toContain("Idle worker"));
+	});
+
+	it("still honours the project the user arrived from, over the active default", async () => {
+		setUpTwoProjects();
+		renderLog(vi.fn(), "proj-2");
+		await waitFor(() => expect(scopeName()).toBe("Project Two"));
+		expect(taskStat()).toBe("1");
+	});
+});

--- a/src/mainview/__tests__/traffic-scope.test.ts
+++ b/src/mainview/__tests__/traffic-scope.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessageLogRow } from "../../shared/agent-message-log";
+import type { Task, TaskMovement, TaskStatus } from "../../shared/types";
+import type { TrafficRecord } from "../components/agent-traffic/traffic-model";
+import { buildTimeline } from "../components/agent-traffic/traffic-timeline";
+import {
+	ACTIVE_PROJECTS,
+	ALL_PROJECTS,
+	activeProjectIds,
+	admits,
+	isAggregateScope,
+	scopeProjectIds,
+} from "../components/agent-traffic/traffic-scope";
+
+const T0 = Date.parse("2026-09-09T09:00:00.000Z");
+const at = (minutes: number) => new Date(T0 + minutes * 60_000).toISOString();
+const WINDOW = { start: T0, end: T0 + 60 * 60_000 };
+
+let ids = 0;
+const created = (minutes: number, to: TaskStatus): TaskMovement => ({
+	id: `mv${++ids}`, at: at(minutes), kind: "created", to, toColumnId: null,
+});
+const task = (id: string, projectId: string, movements: TaskMovement[], over: Partial<Task> = {}): Task =>
+	({ id, projectId, seq: 1, title: id, description: "", status: "in-progress", movements, ...over }) as Task;
+
+const record = (key: string, minutes: number, over: Partial<AgentMessageLogRow> = {}): TrafficRecord => ({
+	key,
+	row: {
+		v: 1, at: at(minutes), fromTaskId: "a", fromSeq: 1, toTaskId: "b", toSeq: 2,
+		toProjectId: "p-to", kind: "immediate", body: key, bodyKind: "text", status: "delivered", ...over,
+	} as AgentMessageLogRow,
+});
+
+const active = (input: { records?: TrafficRecord[]; tasks?: Task[] }) =>
+	[...activeProjectIds(buildTimeline({ records: input.records ?? [], tasks: input.tasks ?? [], ...WINDOW }))].sort();
+
+describe("active project membership", () => {
+	it("counts both ends of a message, so the sending board is not dropped", () => {
+		expect(active({ records: [record("m1", 10, { fromProjectId: "p-from" })] })).toEqual(["p-from", "p-to"]);
+	});
+
+	it("counts a recorded movement on its own, with nothing said all window", () => {
+		expect(active({ tasks: [task("t1", "p-quiet", [created(20, "todo")])] })).toEqual(["p-quiet"]);
+	});
+
+	it("leaves out a project whose only task is a running coordinator that never moved", () => {
+		// Existing, running, and a coordinator — none of that is a recorded event.
+		const tasks = [task("coord", "p-idle", [], { taskType: "coordinator", runtime: "running" } as Partial<Task>)];
+		expect(active({ tasks })).toEqual([]);
+	});
+
+	it("keeps a project that has events but no coordinator at all", () => {
+		// No coordinator anywhere in this project, and it stays in on its events alone.
+		const tasks = [task("t1", "p-plain", [created(5, "todo")], { taskType: null })];
+		expect(active({ tasks })).toEqual(["p-plain"]);
+	});
+
+	it("ignores events outside the selected window, on either arm", () => {
+		expect(active({
+			records: [record("early", -30, { toProjectId: "p-early" }), record("late", 120, { toProjectId: "p-late" })],
+			tasks: [task("t1", "p-before", [created(-5, "todo")]), task("t2", "p-after", [created(90, "todo")])],
+		})).toEqual([]);
+	});
+});
+
+describe("scope resolution", () => {
+	const settled = { active: new Set(["p1"]), settled: true };
+
+	it("leaves All projects entirely unfiltered, even when nothing is active", () => {
+		expect(scopeProjectIds({ scope: ALL_PROJECTS, active: new Set(), settled: true })).toBeNull();
+	});
+
+	it("narrows All active projects to the recorded set", () => {
+		expect(scopeProjectIds({ scope: ACTIVE_PROJECTS, ...settled })).toEqual(new Set(["p1"]));
+	});
+
+	it("admits nothing under All active projects when the window is genuinely empty", () => {
+		const resolved = scopeProjectIds({ scope: ACTIVE_PROJECTS, active: new Set(), settled: true });
+		expect(resolved).toEqual(new Set());
+		expect(admits(resolved, "p1")).toBe(false);
+	});
+
+	it("admits everything while history is still loading — unread is not inactive", () => {
+		expect(scopeProjectIds({ scope: ACTIVE_PROJECTS, active: new Set(), settled: false })).toBeNull();
+	});
+
+	it("narrows an explicit project to itself, whatever is active", () => {
+		expect(scopeProjectIds({ scope: "p9", ...settled })).toEqual(new Set(["p9"]));
+	});
+});
+
+describe("admits and aggregate scopes", () => {
+	it("passes anything when there is no filter, and rejects an absent id when there is", () => {
+		expect(admits(null, undefined)).toBe(true);
+		expect(admits(new Set(["p1"]), undefined)).toBe(false);
+		expect(admits(new Set(["p1"]), "p1")).toBe(true);
+		expect(admits(new Set(["p1"]), "p2")).toBe(false);
+	});
+
+	it("treats both all-project scopes as having no lane to pin, a project id as having one", () => {
+		expect(isAggregateScope(ALL_PROJECTS)).toBe(true);
+		expect(isAggregateScope(ACTIVE_PROJECTS)).toBe(true);
+		expect(isAggregateScope(undefined)).toBe(true);
+		expect(isAggregateScope("p1")).toBe(false);
+	});
+});

--- a/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
@@ -35,6 +35,13 @@ import {
 	buildTimeline,
 	type TrafficTimelineEvent,
 } from "./traffic-timeline";
+import {
+	ACTIVE_PROJECTS,
+	ALL_PROJECTS,
+	activeProjectIds,
+	admits,
+	scopeProjectIds,
+} from "./traffic-scope";
 import "./traffic-orbit.css";
 import "./traffic-nodes.css";
 
@@ -312,7 +319,12 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 	const calendarDay = isCalendarDay(windowSize);
 	const data = useTrafficData(calendarDay ? start : undefined);
 	const { experiment, choose } = useTrafficExperiment();
-	const [scope, setScope] = useState(projectId ?? "all");
+	// Arriving without a project opens on the active projects, not on all of them:
+	// eighteen empty blocks are eighteen blocks of stage the busy two could have
+	// had. A project the user came from still wins — an explicit subject beats a
+	// default — and the initialiser runs once, so their own later pick survives
+	// every re-render and every reload of the window.
+	const [scope, setScope] = useState(projectId ?? ACTIVE_PROJECTS);
 	const [selected, setSelected] = useState<string | null>(null);
 	const [recordKey, setRecordKey] = useState<string | null>(null);
 	const [pair, setPair] = useState<string | null>(null);
@@ -329,26 +341,53 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 	const [showFilters, setShowFilters] = useState(false);
 	const [focusRequest, setFocusRequest] = useState(0);
 	const [followRequest, setFollowRequest] = useState(0);
+	/**
+	 * The window's whole recorded union, before any scope or filter runs.
+	 *
+	 * Deliberately unscoped: it is what decides which projects the `active` scope
+	 * admits, and deriving that from scoped data would be circular — a project
+	 * filtered out could never prove it belonged. It is also independent of the
+	 * replay cursor, so membership holds still while the cursor walks the window
+	 * and only moves when the window changes or a live event actually arrives.
+	 */
+	const windowTimeline = useMemo(
+		() =>
+			buildTimeline({
+				records: trafficRecords(data.rows),
+				tasks: data.tasks,
+				start,
+				end,
+			}),
+		[data.rows, data.tasks, start, end],
+	);
+	const scopeProjects = useMemo(
+		() =>
+			scopeProjectIds({
+				scope,
+				active: activeProjectIds(windowTimeline),
+				settled: !data.loading && !data.historyLoading,
+			}),
+		[scope, windowTimeline, data.loading, data.historyLoading],
+	);
 	const scopedRows = useMemo(
 		() =>
 			data.rows.filter(
 				(row) =>
-					scope === "all" ||
-					row.toProjectId === scope ||
-					row.fromProjectId === scope,
+					admits(scopeProjects, row.toProjectId) ||
+					admits(scopeProjects, row.fromProjectId),
 			),
-		[data.rows, scope],
+		[data.rows, scopeProjects],
 	);
 	const records = useMemo(() => trafficRecords(scopedRows), [scopedRows]);
 	const scopedTasks = useMemo(
 		() =>
 			data.tasks.filter(
 				(task) =>
-					(scope === "all" || task.projectId === scope) &&
+					admits(scopeProjects, task.projectId) &&
 					task.status !== "completed" &&
 					task.status !== "cancelled",
 			),
-		[data.tasks, scope],
+		[data.tasks, scopeProjects],
 	);
 	const allNodes = useMemo(
 		() => trafficNodes(data.tasks, scopedRows),
@@ -371,8 +410,8 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 	);
 	const showMessages = kinds.has("message");
 	const scopedAllTasks = useMemo(
-		() => (scope === "all" ? data.tasks : data.tasks.filter((task) => task.projectId === scope)),
-		[data.tasks, scope],
+		() => data.tasks.filter((task) => admits(scopeProjects, task.projectId)),
+		[data.tasks, scopeProjects],
 	);
 	/**
 	 * What the window CAN carry, before any filter runs.
@@ -472,15 +511,13 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 		);
 		return allNodes.filter(
 			(node) =>
-				(scope === "all" ||
-					node.projectId === scope ||
-					endpoints.has(node.key)) &&
+				(admits(scopeProjects, node.projectId) || endpoints.has(node.key)) &&
 				(scopedTasks.some(
 					(task) => endpointKey(task.projectId, task.id) === node.key,
 				) ||
 					endpoints.has(node.key)),
 		);
-	}, [allNodes, timeRows, scope, scopedTasks]);
+	}, [allNodes, timeRows, scopeProjects, scopedTasks]);
 	const selectedNode = selected ? nodeMap.get(selected) : undefined;
 	const record = records.find((record) => record.key === recordKey);
 	const taskList = nodes
@@ -630,7 +667,11 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 					clearSelection();
 				}}
 				options={[
-					{ value: "all", label: t("traffic.orbit.allProjects") },
+					// The scope the screen opens on leads the list, then the two aggregate
+					// scopes stay adjacent above the per-project entries, so the list reads
+					// broad → narrow in one gradient.
+					{ value: ACTIVE_PROJECTS, label: t("traffic.orbit.activeProjects") },
+					{ value: ALL_PROJECTS, label: t("traffic.orbit.allProjects") },
 					...data.projects.map((project) => ({
 						value: project.id,
 						label: project.name,
@@ -765,7 +806,11 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 				<div>
 					<strong>
 						{data.projects.find((project) => project.id === scope)?.name ??
-							t("traffic.orbit.allProjects")}
+							t(
+								scope === ACTIVE_PROJECTS
+									? "traffic.orbit.activeProjects"
+									: "traffic.orbit.allProjects",
+							)}
 					</strong>
 					{/* Only a live cursor rebuilds anything: Experiment 1 has none at
 					    all, and Experiment 2 on Live is showing the board as it is. Both

--- a/src/mainview/components/agent-traffic/TrafficOrbit.tsx
+++ b/src/mainview/components/agent-traffic/TrafficOrbit.tsx
@@ -21,6 +21,7 @@ import {
 	type TrafficNode,
 	type TrafficRecord,
 } from "./traffic-model";
+import { ALL_PROJECTS, isAggregateScope } from "./traffic-scope";
 
 interface Props {
 	projects?: { id: string; name: string }[];
@@ -167,8 +168,10 @@ export default function TrafficOrbit(props: Props) {
 						labelPriority.set(key, 1000 + records.length - index);
 				}
 			}
-			const scope = latest.current.scope ?? "all";
-			const all = scope === "all";
+			const scope = latest.current.scope ?? ALL_PROJECTS;
+			// Any aggregate scope has no single project to pin as the primary lane;
+			// the narrowing itself already happened upstream of these nodes.
+			const all = isAggregateScope(scope);
 			const projects = [
 				...new Set([
 					...input.map((node) => node.projectId),

--- a/src/mainview/components/agent-traffic/traffic-scope.ts
+++ b/src/mainview/components/agent-traffic/traffic-scope.ts
@@ -1,0 +1,87 @@
+/**
+ * Which projects the traffic stage admits.
+ *
+ * The scope control used to offer exactly two shapes — every visible project, or
+ * one named project — so a machine with twenty boards and two busy ones spent the
+ * stage on eighteen empty blocks. `active` is a third shape: the projects a
+ * recorded event in the current window actually touched.
+ *
+ * "Recorded" is the whole definition. Membership is read off the replay timeline,
+ * so it is exactly what the screen can already prove happened — never a running
+ * status, never a coordinator, never "the project exists". A project with a
+ * coordinator and no events is out; a project with events and no coordinator is
+ * in. The timeline is also where a further event kind lands (§5.9's notification
+ * arm is a control value with no arm behind it yet), so that kind becomes
+ * evidence of activity here the day it becomes an event, with nothing to change.
+ */
+
+import type { TrafficTimelineEvent } from "./traffic-timeline";
+
+/** Every project the user can see, unfiltered — the pre-existing behaviour. */
+export const ALL_PROJECTS = "all";
+/** Only the projects a recorded event in the window touched. */
+export const ACTIVE_PROJECTS = "active";
+
+/**
+ * True when the scope names no single project, so a stage has no lane to pin and
+ * no block to keep alive on its own.
+ */
+export function isAggregateScope(scope: string | undefined): boolean {
+	return scope === undefined || scope === ALL_PROJECTS || scope === ACTIVE_PROJECTS;
+}
+
+/**
+ * Projects touched by the events handed in.
+ *
+ * A message counts for both ends: the sender's project is as much a participant
+ * as the recipient's, and a cross-project message that only counted its
+ * destination would drop the board the work came from.
+ */
+export function activeProjectIds(
+	events: readonly TrafficTimelineEvent[],
+): Set<string> {
+	const ids = new Set<string>();
+	for (const event of events) {
+		if (event.kind === "task") {
+			ids.add(event.node.projectId);
+			continue;
+		}
+		const { row } = event.record;
+		ids.add(row.toProjectId);
+		if (row.fromProjectId) ids.add(row.fromProjectId);
+	}
+	return ids;
+}
+
+/**
+ * The project ids a scope admits, or `null` for "no project filter at all".
+ *
+ * `null` is not an empty set and the two must never be conflated: an empty set
+ * admits nothing, `null` admits everything. `ALL_PROJECTS` returns `null` so it
+ * stays byte-identical to the unfiltered path it has always been.
+ *
+ * `settled` is the honesty gate. History arrives page by page, and a window whose
+ * rows have not loaded yet holds no evidence in either direction — §5.9's
+ * "unrecorded state is unknown". Filtering on it would present "not read yet" as
+ * "nothing happened" and hide a busy board behind the loading indicator, so until
+ * the read finishes `active` admits everything and the screen's own loading
+ * readout says why.
+ */
+export function scopeProjectIds(input: {
+	scope: string;
+	active: ReadonlySet<string>;
+	settled: boolean;
+}): ReadonlySet<string> | null {
+	if (input.scope === ALL_PROJECTS) return null;
+	if (input.scope !== ACTIVE_PROJECTS) return new Set([input.scope]);
+	return input.settled ? input.active : null;
+}
+
+/** Whether a project id passes the resolved scope; `null` passes anything. */
+export function admits(
+	projects: ReadonlySet<string> | null,
+	projectId: string | null | undefined,
+): boolean {
+	if (!projects) return true;
+	return !!projectId && projects.has(projectId);
+}

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -177,6 +177,7 @@ const common = {
 	"traffic.orbit.history": "History",
 	"traffic.orbit.resume": "Resume animation",
 	"traffic.orbit.pause": "Pause animation",
+	"traffic.orbit.activeProjects": "All active projects",
 	"traffic.orbit.allProjects": "All projects",
 	"traffic.orbit.project": "Project",
 	"traffic.orbit.search": "Search tasks and messages",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -177,6 +177,7 @@ const common = {
 	"traffic.orbit.history": "Historial",
 	"traffic.orbit.resume": "Reanudar animación",
 	"traffic.orbit.pause": "Pausar animación",
+	"traffic.orbit.activeProjects": "Proyectos activos",
 	"traffic.orbit.allProjects": "Todos los proyectos",
 	"traffic.orbit.project": "Proyecto",
 	"traffic.orbit.search": "Buscar tareas y mensajes",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -189,6 +189,7 @@ const common = {
 	"traffic.orbit.history": "История",
 	"traffic.orbit.resume": "Продолжить анимацию",
 	"traffic.orbit.pause": "Приостановить анимацию",
+	"traffic.orbit.activeProjects": "Активные проекты",
 	"traffic.orbit.allProjects": "Все проекты",
 	"traffic.orbit.project": "Проект",
 	"traffic.orbit.search": "Поиск задач и сообщений",


### PR DESCRIPTION
Agent traffic's project scope offered two shapes — every visible project, or one named project — so a machine with twenty boards and two busy ones spent the stage on eighteen empty blocks. This adds a third shape, **All active projects**, and makes it the scope a fresh entry opens on.

## What "active" means

A **recorded event in the selected window**, and only that: a task movement written into `Task.movements`, or an agent-message-log row. Membership is read off the union `traffic-timeline.ts` already assembles for replay, so it is exactly what the screen can prove happened — never a running status, never a coordinator, never "the project exists". A project with a coordinator and no events is out; a project with events and no coordinator is in.

The timeline's `notification` kind is a control value with no arm behind it, so notifications are deliberately not evidence yet — and become evidence the day that arm lands, with nothing in this code to change.

## New module

`src/mainview/components/agent-traffic/traffic-scope.ts` owns the vocabulary and the resolution:

- `activeProjectIds(events)` — both ends of a message, the owning project of a movement.
- `scopeProjectIds({scope, active, settled})` — the admitted ids, or `null` for "no filter at all".
- `admits(set | null, id)` — the single place `null` reads as "everything", so an empty set and an absent filter can never be conflated.
- `isAggregateScope(scope)` — whether a stage has a lane to pin.

## Two guarantees that are load-bearing

**`ALL_PROJECTS` resolves to `null`**, so that path stays byte-identical to the unfiltered one it has always been — including the per-project block eligibility restored in #1685 (`nodes-layout.ts` is not touched by a single line). Narrowing happens upstream, on which nodes reach the stage.

**`settled` gates the filter.** History arrives page by page, and a window whose rows have not loaded holds no evidence in either direction. Until both reads finish, `active` admits everything, so "not read yet" is never presented as "nothing happened".

Membership also comes from an **unscoped** timeline independent of the replay cursor: deriving it from scoped data would be circular, and a cursor-dependent set would shuffle cards as the reader steps through the window. It is deliberately not part of the playback reset key — a new project appearing must not restart a replay in progress.

`TrafficOrbit` now asks `isAggregateScope()` instead of `scope === "all"`, so neither all-project scope pins a primary lane while both still refit the camera when switched. `TrafficNodes` needed no change.

## Measured on a live board

Same hour, same window, "Fit everything on screen" pressed in both: zoom to fit **12% → 46%**, project blocks **13 → 2**, cards on stage **23 → 9**, recorded attempts 22 → 22 (nothing lost). At 12% the cards are unreadable squares and the one board with traffic is a tiny row in the middle.

Rationale and rejected alternatives: `decisions/2026/09/10/active-traffic-scope-from-recorded-events.md`.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b115ca93-2e98-40a0-82f9-1d2def758810) · `dev3://task/b115ca93-2e98-40a0-82f9-1d2def758810` _(dev3 added this footer — turn it off in Settings → Tasks.)_
