### PR TITLE
Give the markdown document preview its own typography

### DIFF
--- a/change-logs/2026/09/10/feature-30-markdown-preview-typography.md
+++ b/change-logs/2026/09/10/feature-30-markdown-preview-typography.md
@@ -1,0 +1,3 @@
+Short: Prettier markdown document preview
+
+Rendered markdown documents — the diff viewer's whole-file preview and the file preview a Cmd/Ctrl+Click on a terminal path opens — now use a real document type scale instead of the compact PR-comment styling: bigger body text, breathing room between blocks, a proper heading hierarchy with accent rules, borderless code chips, zebra tables with a tinted header, and coloured list markers. PR comment threads keep their compact look.

--- a/change-logs/2026/09/10/feature-30-markdown-preview-typography.md
+++ b/change-logs/2026/09/10/feature-30-markdown-preview-typography.md
@@ -1,3 +1,3 @@
 Short: Prettier markdown document preview
 
-Rendered markdown documents — the diff viewer's whole-file preview and the file preview a Cmd/Ctrl+Click on a terminal path opens — now use a real document type scale instead of the compact PR-comment styling: bigger body text, breathing room between blocks, a proper heading hierarchy with accent rules, borderless code chips, zebra tables with a tinted header, and coloured list markers. PR comment threads keep their compact look.
+Rendered markdown documents — the diff viewer's whole-file preview and the file preview a Cmd/Ctrl+Click on a terminal path opens — now use a real document type scale instead of the compact PR-comment styling: bigger body text, breathing room between blocks, a heading hierarchy with accent rules, borderless code chips, zebra tables with an accent-tinted header, accent list markers and checkboxes, and one frame around a code fence instead of three. PR comment threads keep their compact look.

--- a/decisions/2026/09/10/markdown-document-preview-gets-its-own-typography.md
+++ b/decisions/2026/09/10/markdown-document-preview-gets-its-own-typography.md
@@ -1,0 +1,39 @@
+# Markdown document preview gets its own typography, not the comment scope's
+
+## Context
+
+Rendered markdown reaches the user through three surfaces, all styled by one CSS block in
+`src/mainview/components/TaskDiffViewer.css`: PR comment bodies (`.dev3-pr-md`), the whole-file
+preview in the diff viewer, and the `FilePreviewModal` a Cmd/Ctrl+Click on a terminal path opens.
+The comment scope was written for short GitHub replies — `0.375rem` block margins, every heading
+flattened to `0.9375rem`, a bordered chip on every inline `code`. A 200-line design document
+rendered through those rules reads as one grey wall: nothing separates a heading from the
+paragraph under it, and a path-heavy document turns into a field of boxes.
+
+## Decision
+
+`.dev3-md-doc` — the class `MarkdownContent` adds only when `document` is set — now carries a
+full document type scale instead of two heading overrides: larger body size and looser leading,
+per-level heading rhythm, borderless tinted code chips, an accent-tinted table header with zebra
+rows, an accent blockquote wash, coloured list markers and a gradient `hr`. The comment scope is
+untouched, so PR threads keep their compact look.
+
+Colour follows one rule from `better-colors`: one hue, one meaning. `--accent` stays the link
+hue, so inline code chips are neutral ink on a neutral wash; the colour the user asked for comes
+from structure (heading rules, table header, quote bar, markers), never from re-using the link
+colour decoratively.
+
+## Risks
+
+The document scope now overrides `text-sm leading-relaxed` set on the parent wrapper in
+`markdown.tsx`. A future refactor that moves the doc class onto that same element would make the
+font-size declaration collide instead of cascade. `.dev3-md-diff` sits on the same element as
+`.dev3-md-doc` in `markdown-diff.tsx`, so the rich-diff washes now paint under the new table and
+quote backgrounds — both are transparent tints, and the block wash stays visible.
+
+## Alternatives considered
+
+A separate `.dev3-md-reader` class applied only by `FilePreviewModal` would have left the diff
+preview dense; the two surfaces show the same whole documents and should not diverge. Rewriting
+`.dev3-pr-md` itself was rejected because GitHub comment threads genuinely want the compact
+rhythm — a two-line reply with `1.75` leading and `1.5rem` heading gaps looks broken.

--- a/decisions/2026/09/10/markdown-document-preview-gets-its-own-typography.md
+++ b/decisions/2026/09/10/markdown-document-preview-gets-its-own-typography.md
@@ -18,10 +18,14 @@ per-level heading rhythm, borderless tinted code chips, an accent-tinted table h
 rows, an accent blockquote wash, coloured list markers and a gradient `hr`. The comment scope is
 untouched, so PR threads keep their compact look.
 
-Colour follows one rule from `better-colors`: one hue, one meaning. `--accent` stays the link
-hue, so inline code chips are neutral ink on a neutral wash; the colour the user asked for comes
-from structure (heading rules, table header, quote bar, markers), never from re-using the link
-colour decoratively.
+Colour comes from the app's existing tokens and **no new ones**. A first pass introduced a
+teal `--md-chrome` on the `better-colors` argument that `--accent` already means "link" inside
+prose; that was rejected on review — a hue nothing else in dev3 uses reads as a foreign palette,
+which is worse than the overlap it avoided. Structural chrome (heading rules, the h3 bar, list
+markers, checkboxes, the table header, the `hr`) is therefore `--accent`, and everything that
+repeats often or would collide is a neutral wash off `--text-primary`: code chips, table zebra,
+and the blockquote — whose bar stays `--border-active`, because an accent-tinted block with a
+left bar is already `.dev3-md-commented`, the marker for a block carrying a review comment.
 
 ## Risks
 
@@ -36,4 +40,6 @@ quote backgrounds — both are transparent tints, and the block wash stays visib
 A separate `.dev3-md-reader` class applied only by `FilePreviewModal` would have left the diff
 preview dense; the two surfaces show the same whole documents and should not diverge. Rewriting
 `.dev3-pr-md` itself was rejected because GitHub comment threads genuinely want the compact
-rhythm — a two-line reply with `1.75` leading and `1.5rem` heading gaps looks broken.
+rhythm — a two-line reply with `1.75` leading and `1.5rem` heading gaps looks broken. A dedicated
+document hue (the rejected `--md-chrome`) is recorded above; `--agent` violet was never an option,
+since it means agent traffic.

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -192,8 +192,10 @@
 	text-decoration: underline;
 	text-underline-offset: 2px;
 }
+/* `--accent-hover` is the fill token: on dark it goes deeper, so a link would
+   dim on hover. Text and icons lift through `--accent-emphasis`. */
 .dev3-pr-md a:hover {
-	color: rgb(var(--accent-hover));
+	color: rgb(var(--accent-emphasis));
 }
 .dev3-pr-md code {
 	font-family: 'JetBrainsMono Nerd Font Mono', monospace;
@@ -292,26 +294,234 @@
 }
 
 /* ---- Markdown document preview (.dev3-md-doc) ----
-   The per-file diff preview renders whole .md files, so headings keep a real
-   hierarchy (PR comments flatten them all to one compact size). */
+   Whole .md files, not GitHub replies: a document type scale with real heading
+   hierarchy, reading rhythm, and `--md-chrome` (teal) on every structural
+   accent — heading rules, quote bar, table head, list markers, code chips — so
+   the accent hue keeps meaning "link". */
+.dev3-md-doc {
+	font-size: 0.9375rem;
+	line-height: 1.75;
+}
+.dev3-md-doc p,
+.dev3-md-doc ul,
+.dev3-md-doc ol,
+.dev3-md-doc blockquote,
+.dev3-md-doc pre,
+.dev3-md-doc table {
+	margin: 0.875rem 0;
+}
+.dev3-md-doc h1,
+.dev3-md-doc h2,
+.dev3-md-doc h3,
+.dev3-md-doc h4,
+.dev3-md-doc h5,
+.dev3-md-doc h6 {
+	font-weight: 700;
+	line-height: 1.3;
+	letter-spacing: -0.01em;
+}
 .dev3-md-doc h1 {
-	font-size: 1.375rem;
-	margin: 0.875rem 0 0.375rem;
+	font-size: 1.5rem;
+	margin: 0 0 1rem;
 }
 .dev3-md-doc h2 {
 	font-size: 1.1875rem;
-	margin: 0.75rem 0 0.375rem;
+	margin: 1.875rem 0 0.625rem;
 }
 .dev3-md-doc h3 {
+	position: relative;
 	font-size: 1.0625rem;
+	margin: 1.5rem 0 0.5rem;
+	padding-left: 0.75rem;
 }
-.dev3-md-doc h4 {
-	font-size: 1rem;
+/* The bar replaces a rule: an h3 is a sub-section, so its marker leads the text
+   instead of closing the block off. */
+.dev3-md-doc h3::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0.2em;
+	bottom: 0.2em;
+	width: 3px;
+	border-radius: 999px;
+	background: rgb(var(--md-chrome));
 }
-.dev3-md-doc h1,
-.dev3-md-doc h2 {
-	border-bottom: 1px solid rgb(var(--border-default));
-	padding-bottom: 0.25rem;
+.dev3-md-doc h4,
+.dev3-md-doc h5,
+.dev3-md-doc h6 {
+	font-size: 0.9375rem;
+	margin: 1.25rem 0 0.375rem;
+	color: rgb(var(--text-secondary));
+}
+/* A fading rule instead of a full-width border: it reads as a title underline
+   rather than a divider that also cuts off the text below it. */
+.dev3-md-doc h1::after,
+.dev3-md-doc h2::after {
+	content: "";
+	display: block;
+	margin-top: 0.5rem;
+	border-radius: 2px;
+	background: linear-gradient(90deg, rgb(var(--md-chrome)), rgb(var(--md-chrome) / 0));
+}
+.dev3-md-doc h1::after {
+	height: 2px;
+}
+.dev3-md-doc h2::after {
+	height: 1px;
+	background: linear-gradient(90deg, rgb(var(--md-chrome) / 0.6), rgb(var(--md-chrome) / 0));
+}
+.dev3-md-doc ul,
+.dev3-md-doc ol {
+	padding-left: 1.5rem;
+}
+.dev3-md-doc li {
+	margin: 0.3125rem 0;
+}
+.dev3-md-doc li::marker {
+	color: rgb(var(--md-chrome));
+	font-weight: 700;
+}
+.dev3-md-doc li > ul,
+.dev3-md-doc li > ol {
+	margin: 0.3125rem 0;
+}
+/* A task-list item carries its own box, so the disc would be a second marker. */
+.dev3-md-doc li:has(> input[type="checkbox"]) {
+	list-style: none;
+}
+.dev3-md-doc input[type="checkbox"] {
+	accent-color: rgb(var(--md-chrome));
+	width: 0.9em;
+	height: 0.9em;
+	margin-right: 0.375rem;
+	vertical-align: -0.1em;
+}
+.dev3-md-doc a {
+	text-decoration-thickness: 1.5px;
+	text-underline-offset: 3px;
+	text-decoration-color: rgb(var(--accent) / 0.5);
+}
+.dev3-md-doc a:hover {
+	text-decoration-color: currentColor;
+}
+/* Chip, not box: a path-heavy document renders dozens of these, and a border on
+   every one turns the page into a grid. Size is relative so a `code` span in a
+   heading grows with it. */
+.dev3-md-doc code {
+	font-size: 0.875em;
+	background: rgb(var(--md-chrome) / 0.13);
+	border: none;
+	border-radius: 0.3125rem;
+	padding: 0.1em 0.35em;
+	/* A long path wraps mid-chip; each fragment keeps its own padding and
+	   corners instead of one chip sliced open across two lines. */
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+.dev3-md-doc pre {
+	font-size: 0.8125rem;
+	line-height: 1.65;
+	border-color: rgb(var(--md-chrome) / 0.28);
+	border-radius: 0.625rem;
+	padding: 0.875rem 1rem;
+}
+.dev3-md-doc pre code {
+	font-size: inherit;
+	background: transparent;
+	padding: 0;
+}
+/* Streamdown nests a fence and a table in two padded, bordered boxes of its own,
+   each drawn with shadcn tokens this app does not define — three frames around
+   one block. The document scope keeps exactly one: the `pre` / `table` itself. */
+.dev3-md-doc [data-streamdown="code-block"],
+.dev3-md-doc [data-streamdown="table-wrapper"] {
+	margin: 0.875rem 0;
+	padding: 0;
+	border: none;
+	background: none;
+	gap: 0.25rem;
+}
+.dev3-md-doc [data-streamdown="code-block-body"],
+.dev3-md-doc [data-streamdown="table-wrapper"] > div {
+	padding: 0;
+	border: none;
+	background: none;
+	border-radius: 0;
+}
+.dev3-md-doc [data-streamdown="code-block"] > pre,
+.dev3-md-doc [data-streamdown="code-block-body"] > pre,
+.dev3-md-doc [data-streamdown="table-wrapper"] table {
+	margin: 0;
+}
+.dev3-md-doc [data-streamdown="code-block-header"] {
+	height: auto;
+	padding-left: 0.125rem;
+	font-family: var(--dev3-mono-stack);
+	font-size: 0.6875rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: rgb(var(--md-chrome));
+}
+.dev3-md-doc blockquote {
+	border-left: 3px solid rgb(var(--md-chrome) / 0.75);
+	border-radius: 0 0.5rem 0.5rem 0;
+	background: rgb(var(--md-chrome) / 0.07);
+	padding: 0.625rem 0.875rem;
+	color: rgb(var(--text-secondary));
+}
+.dev3-md-doc blockquote > :first-child {
+	margin-top: 0;
+}
+.dev3-md-doc blockquote > :last-child {
+	margin-bottom: 0;
+}
+.dev3-md-doc hr {
+	height: 2px;
+	border: none;
+	border-radius: 2px;
+	margin: 1.875rem 0;
+	background: linear-gradient(
+		90deg,
+		rgb(var(--md-chrome) / 0) 0%,
+		rgb(var(--md-chrome) / 0.55) 50%,
+		rgb(var(--md-chrome) / 0) 100%
+	);
+}
+.dev3-md-doc img {
+	border-radius: 0.5rem;
+	outline: 1px solid rgb(var(--outline-ink) / 0.1);
+	outline-offset: -1px;
+}
+/* The comment scope keeps the table on `display: block` so a wide one scrolls;
+   that same block clips the rounded corners of the header row. */
+.dev3-md-doc table {
+	border-collapse: separate;
+	border-spacing: 0;
+	border: 1px solid rgb(var(--border-default));
+	border-radius: 0.625rem;
+	/* The comment scope's `display: block` makes the frame stretch the full
+	   column while the rows keep their own width — the border has to hug the
+	   content, and `max-width` leaves a wide table scrolling. */
+	width: max-content;
+	max-width: 100%;
+}
+.dev3-md-doc th,
+.dev3-md-doc td {
+	border: none;
+	border-bottom: 1px solid rgb(var(--border-default) / 0.55);
+	padding: 0.4375rem 0.75rem;
+}
+.dev3-md-doc tr:last-child > td {
+	border-bottom: none;
+}
+.dev3-md-doc th {
+	background: rgb(var(--md-chrome) / 0.18);
+	border-bottom: 1px solid rgb(var(--md-chrome) / 0.35);
+	color: rgb(var(--text-primary));
+	font-weight: 700;
+}
+.dev3-md-doc tbody tr:nth-child(even) > td {
+	background: rgb(var(--text-primary) / 0.05);
 }
 
 /* ---- Markdown rich diff (.dev3-md-diff) ----

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -219,6 +219,12 @@
 .dev3-pr-md pre code {
 	white-space: inherit;
 }
+/* Streamdown emits one span per source line and carries the line break in the
+   markup, not in the text — without this every fence collapses into one
+   run-on line. (Its own stylesheet does this; we do not import it.) */
+.dev3-pr-md pre code > span {
+	display: block;
+}
 .dev3-pr-md pre code {
 	background: transparent;
 	border: none;
@@ -454,13 +460,27 @@
 .dev3-md-doc [data-streamdown="table-wrapper"] table {
 	margin: 0;
 }
-.dev3-md-doc [data-streamdown="code-block-header"] {
+/* Same treatment for a mermaid fence: the diagram box is the single frame, the
+   language row above it is a label rather than a 2rem-tall empty strip. */
+.dev3-md-doc [data-streamdown="mermaid-block"] {
+	margin: 0.875rem 0;
+	padding: 0;
+	border: none;
+	background: none;
+	gap: 0.25rem;
+}
+.dev3-md-doc [data-streamdown="mermaid-block"] > div:has([data-streamdown="mermaid"]) {
+	border: 1px solid rgb(var(--border-default));
+	border-radius: 0.625rem;
+	background: rgb(var(--surface-base));
+}
+.dev3-md-doc [data-streamdown="code-block-header"],
+.dev3-md-doc [data-streamdown="mermaid-block"] > div:first-child {
 	height: auto;
 	padding-left: 0.125rem;
 	font-family: var(--dev3-mono-stack);
 	font-size: 0.6875rem;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
+	letter-spacing: 0.06em;
 	color: rgb(var(--text-muted));
 }
 /* Neutral bar and wash: an accent-tinted block with a left bar is already taken
@@ -478,6 +498,23 @@
 }
 .dev3-md-doc blockquote > :last-child {
 	margin-bottom: 0;
+}
+/* `<details>` arrives with no styling at all — a bare disclosure triangle over
+   body text reads as a stray line rather than a collapsed section. */
+.dev3-md-doc details {
+	margin: 0.875rem 0;
+	border: 1px solid rgb(var(--border-default));
+	border-radius: 0.625rem;
+	background: rgb(var(--text-primary) / 0.03);
+	padding: 0.5rem 0.875rem;
+}
+.dev3-md-doc summary {
+	cursor: pointer;
+	font-weight: 600;
+	color: rgb(var(--text-secondary));
+}
+.dev3-md-doc details[open] > summary {
+	margin-bottom: 0.375rem;
 }
 .dev3-md-doc hr {
 	height: 2px;

--- a/src/mainview/components/TaskDiffViewer.css
+++ b/src/mainview/components/TaskDiffViewer.css
@@ -295,9 +295,10 @@
 
 /* ---- Markdown document preview (.dev3-md-doc) ----
    Whole .md files, not GitHub replies: a document type scale with real heading
-   hierarchy, reading rhythm, and `--md-chrome` (teal) on every structural
-   accent — heading rules, quote bar, table head, list markers, code chips — so
-   the accent hue keeps meaning "link". */
+   hierarchy and reading rhythm. Structural chrome — heading rules, the h3 bar,
+   list markers, checkboxes, the table head, the rule — is `--accent`, the app's
+   own hue; everything else (code chips, quote, zebra) is a neutral wash off
+   `--text-primary`, so the page carries one colour, not a second palette. */
 .dev3-md-doc {
 	font-size: 0.9375rem;
 	line-height: 1.75;
@@ -344,7 +345,7 @@
 	bottom: 0.2em;
 	width: 3px;
 	border-radius: 999px;
-	background: rgb(var(--md-chrome));
+	background: rgb(var(--accent));
 }
 .dev3-md-doc h4,
 .dev3-md-doc h5,
@@ -361,14 +362,14 @@
 	display: block;
 	margin-top: 0.5rem;
 	border-radius: 2px;
-	background: linear-gradient(90deg, rgb(var(--md-chrome)), rgb(var(--md-chrome) / 0));
+	background: linear-gradient(90deg, rgb(var(--accent)), rgb(var(--accent) / 0));
 }
 .dev3-md-doc h1::after {
 	height: 2px;
 }
 .dev3-md-doc h2::after {
 	height: 1px;
-	background: linear-gradient(90deg, rgb(var(--md-chrome) / 0.6), rgb(var(--md-chrome) / 0));
+	background: linear-gradient(90deg, rgb(var(--accent) / 0.6), rgb(var(--accent) / 0));
 }
 .dev3-md-doc ul,
 .dev3-md-doc ol {
@@ -378,7 +379,7 @@
 	margin: 0.3125rem 0;
 }
 .dev3-md-doc li::marker {
-	color: rgb(var(--md-chrome));
+	color: rgb(var(--accent));
 	font-weight: 700;
 }
 .dev3-md-doc li > ul,
@@ -390,7 +391,7 @@
 	list-style: none;
 }
 .dev3-md-doc input[type="checkbox"] {
-	accent-color: rgb(var(--md-chrome));
+	accent-color: rgb(var(--accent));
 	width: 0.9em;
 	height: 0.9em;
 	margin-right: 0.375rem;
@@ -409,7 +410,8 @@
    heading grows with it. */
 .dev3-md-doc code {
 	font-size: 0.875em;
-	background: rgb(var(--md-chrome) / 0.13);
+	/* Neutral, not accent: a chip is not a link, and a document is full of them. */
+	background: rgb(var(--text-primary) / 0.08);
 	border: none;
 	border-radius: 0.3125rem;
 	padding: 0.1em 0.35em;
@@ -421,7 +423,6 @@
 .dev3-md-doc pre {
 	font-size: 0.8125rem;
 	line-height: 1.65;
-	border-color: rgb(var(--md-chrome) / 0.28);
 	border-radius: 0.625rem;
 	padding: 0.875rem 1rem;
 }
@@ -460,12 +461,15 @@
 	font-size: 0.6875rem;
 	letter-spacing: 0.08em;
 	text-transform: uppercase;
-	color: rgb(var(--md-chrome));
+	color: rgb(var(--text-muted));
 }
+/* Neutral bar and wash: an accent-tinted block with a left bar is already taken
+   in this stylesheet — `.dev3-md-commented` marks a block carrying a review
+   comment, and a quote must not look like one. */
 .dev3-md-doc blockquote {
-	border-left: 3px solid rgb(var(--md-chrome) / 0.75);
+	border-left: 3px solid rgb(var(--border-active));
 	border-radius: 0 0.5rem 0.5rem 0;
-	background: rgb(var(--md-chrome) / 0.07);
+	background: rgb(var(--text-primary) / 0.045);
 	padding: 0.625rem 0.875rem;
 	color: rgb(var(--text-secondary));
 }
@@ -482,15 +486,13 @@
 	margin: 1.875rem 0;
 	background: linear-gradient(
 		90deg,
-		rgb(var(--md-chrome) / 0) 0%,
-		rgb(var(--md-chrome) / 0.55) 50%,
-		rgb(var(--md-chrome) / 0) 100%
+		rgb(var(--accent) / 0) 0%,
+		rgb(var(--accent) / 0.55) 50%,
+		rgb(var(--accent) / 0) 100%
 	);
 }
 .dev3-md-doc img {
 	border-radius: 0.5rem;
-	outline: 1px solid rgb(var(--outline-ink) / 0.1);
-	outline-offset: -1px;
 }
 /* The comment scope keeps the table on `display: block` so a wide one scrolls;
    that same block clips the rounded corners of the header row. */
@@ -515,8 +517,8 @@
 	border-bottom: none;
 }
 .dev3-md-doc th {
-	background: rgb(var(--md-chrome) / 0.18);
-	border-bottom: 1px solid rgb(var(--md-chrome) / 0.35);
+	background: rgb(var(--accent) / 0.14);
+	border-bottom: 1px solid rgb(var(--accent) / 0.3);
 	color: rgb(var(--text-primary));
 	font-weight: 700;
 }

--- a/src/mainview/components/pr-review/markdown.tsx
+++ b/src/mainview/components/pr-review/markdown.tsx
@@ -161,7 +161,10 @@ export function MarkdownContent({
 			key={`${rendererConfig.theme}:${isDocument}:${imageBaseDir ?? ""}:${imageRootDir ?? ""}:${lineOffset ?? ""}:${commentedSignature}`}
 			mode="static"
 			dir="auto"
-			className={`space-y-0${isDocument ? " dev3-md-doc" : ""}`}
+			// `space-y-0` zeroes `margin-top` on every block but the first, and it
+			// outranks the stylesheet — a document needs its own top margins to put
+			// more air above a heading than below it, so it opts out.
+			className={isDocument ? "dev3-md-doc" : "space-y-0"}
 			components={components}
 			controls={false}
 			lineNumbers={false}

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -242,6 +242,15 @@ html {
 	--hint-border: 202 138 4;  /* amber-600 */
 	--hint-typed: 185 28 28;   /* red-700 — the already-typed prefix */
 
+	/* ---- Rendered markdown documents ----
+	   Structural chrome of a document (heading rules, quote bar, table head,
+	   list markers, code chips): teal, because no state token owns that hue —
+	   not --accent, which means "link" inside prose, and not --agent, which
+	   means agent traffic. */
+	--md-chrome: 45 212 191;
+	/* Hairline over arbitrary imagery: pure ink, never a tinted neutral. */
+	--outline-ink: 255 255 255;
+
 	/* ---- Background gradient ---- */
 	--bg-grad-angle: 115deg;
 	--bg-grad-from: #060916;
@@ -367,6 +376,10 @@ html {
 	--hint-fg: 28 25 23;
 	--hint-border: 180 83 9;   /* amber-700 */
 	--hint-typed: 185 28 28;
+
+	/* ---- Rendered markdown documents ---- */
+	--md-chrome: 13 148 136;   /* teal-600 — the dark teal is invisible on paper */
+	--outline-ink: 0 0 0;
 
 	/* ---- Background gradient ---- */
 	/* Hue travels 256° → 291° → 293°, one direction. Sits at L 0.899 → 0.775:

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -242,15 +242,6 @@ html {
 	--hint-border: 202 138 4;  /* amber-600 */
 	--hint-typed: 185 28 28;   /* red-700 — the already-typed prefix */
 
-	/* ---- Rendered markdown documents ----
-	   Structural chrome of a document (heading rules, quote bar, table head,
-	   list markers, code chips): teal, because no state token owns that hue —
-	   not --accent, which means "link" inside prose, and not --agent, which
-	   means agent traffic. */
-	--md-chrome: 45 212 191;
-	/* Hairline over arbitrary imagery: pure ink, never a tinted neutral. */
-	--outline-ink: 255 255 255;
-
 	/* ---- Background gradient ---- */
 	--bg-grad-angle: 115deg;
 	--bg-grad-from: #060916;
@@ -376,10 +367,6 @@ html {
 	--hint-fg: 28 25 23;
 	--hint-border: 180 83 9;   /* amber-700 */
 	--hint-typed: 185 28 28;
-
-	/* ---- Rendered markdown documents ---- */
-	--md-chrome: 13 148 136;   /* teal-600 — the dark teal is invisible on paper */
-	--outline-ink: 0 0 0;
 
 	/* ---- Background gradient ---- */
 	/* Hue travels 256° → 291° → 293°, one direction. Sits at L 0.899 → 0.775:


### PR DESCRIPTION
Rendered markdown documents — the diff viewer's whole-file preview and the file preview a Cmd/Ctrl+Click on a terminal path opens — were styled by the compact PR-comment scope: `0.375rem` block margins, every heading flattened to one size, a bordered chip on every inline `code` span. A long document read as one grey wall, and a path-heavy one as a field of boxes.

`.dev3-md-doc` (the scope `MarkdownContent` adds only for whole documents) now carries a real document type scale:

- larger body size and looser leading, with block rhythm to match
- per-level heading hierarchy: a fading rule under `h1`/`h2`, a leading bar on `h3`, secondary ink on `h4`+
- borderless code chips that keep their padding and corners when a long path wraps
- zebra tables with a tinted header row, one frame that hugs the content instead of stretching the column
- a quote wash with a bar, coloured list markers and task-list checkboxes, a fading `hr`, a real card for `<details>`
- Streamdown wraps a code fence, a table and a mermaid diagram in three nested frames each (two of them drawn with shadcn tokens this app does not define) — the document scope keeps one

**Colour uses the app's own tokens, no new ones.** Structural chrome (heading rules, the `h3` bar, list markers, checkboxes, the table header, the `hr`) is `--accent`; code chips, table zebra and the blockquote are neutral washes off `--text-primary`. The quote bar stays `--border-active` on purpose: an accent-tinted block with a left bar is already `.dev3-md-commented`, the marker for a block carrying a review comment.

Three bugs surfaced while shooting the element gallery and are fixed here:

| Bug | Cause | Fix |
| --- | --- | --- |
| A multi-line code fence rendered as one run-on line | Streamdown emits one span per source line and carries the break in the markup, not the text; we do not import its stylesheet | those spans are `display: block` (comment scope too — it was broken there as well) |
| No block had a `margin-top`, so a heading had no more air above it than below | `space-y-0` on the Streamdown root outranks the stylesheet | the document scope drops that class |
| A link darkened on hover in the dark theme | `--accent-hover` is the fill token | `--accent-emphasis`, the text/icon token |

PR comment threads keep their compact rhythm. Verified in a real browser against a Markdown element gallery — every standard element in one document — on both themes.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2b9ca94b-9141-4ef5-a818-0034a8dd18a6) · `dev3://task/2b9ca94b-9141-4ef5-a818-0034a8dd18a6`
