### PR TITLE
Read the recorded notification archive back over RPC

### DIFF
--- a/change-logs/2026/09/09/feature-notification-history-read-api.md
+++ b/change-logs/2026/09/09/feature-notification-history-read-api.md
@@ -1,0 +1,3 @@
+Short: Read the recorded notification archive
+
+Added a read API over the notification archive `dev3 notify` already writes: a paged, newest-first reader with per-project scoping applied before anything reaches the wire, its RPC method, and a renderer store that caches a page and refreshes when this instance appends a row. Data only — nothing displays it yet.

--- a/decisions/2026/09/09/notification-archive-read-api.md
+++ b/decisions/2026/09/09/notification-archive-read-api.md
@@ -1,0 +1,50 @@
+# Notification archive: a read API before anything renders it
+
+## Context
+
+`dev3 notify` has been appending every notification to `~/.dev3.0/notifications/YYYY-MM-DD.jsonl`
+since the writer shipped, and nothing could read it back. A first attempt bundled the reader with a
+timeline, a level filter, a bubble component and a placement engine in one branch; the size was
+rejected and the work was split, with this task taking the data half and the presentation halves
+going to their own tasks.
+
+## Decision
+
+Three pieces, all data:
+
+- `readNotificationLog` in `src/bun/notification-log.ts` — newest-first paging over the day-files,
+  skipping torn and unparseable lines. `projectIds` is a **visibility allowlist applied during the
+  read**, not a display filter, so a project the user marked sensitive never puts its notification
+  text on the wire. A row with **no** project is always kept: a notification sent from a plain shell
+  belongs to nobody, and hiding it would answer a different question than the caller asked.
+- `readNotificationLog` RPC (`src/shared/types.ts`, handler in `rpc-handlers/notes-labels.ts`) plus
+  the renderer store `src/mainview/notification-traffic.ts`, which caches one page and refreshes on
+  `notificationLogChanged`.
+- `src/mainview/notification-event.ts` — normalization, and the three rules that are cheap to get
+  wrong: an unrecorded source invents nothing (`taskId: null` means the archive did not record it,
+  not that there was no task); a claimed source is not an identity (`sourceSessionId` separates two
+  sessions, and a Claude Code sub-agent inherits its parent's id verbatim, measured); and a request
+  is not its fate (`queued` / `no-window` must never fold into `delivered`).
+
+Two things were deliberately left out. **Only this instance's own appends are announced** — learning
+about another running instance's writes needs a filesystem watcher, which a pull API does not, so
+the watcher belongs to whichever task needs live refresh. And the store **ships with no React
+caller**: the consuming hook belongs with timeline consumption. It is pending a consumer, not dead
+code, and no UI was added here to make it look used.
+
+## Risks
+
+An empty archive and a trimmed archive must not look alike. The page carries `oldestDay`,
+`newestDay` and `retentionDays`, and both days null means "collection never started here" rather
+than "nothing happened"; a reader that assumed 30 days of history would invent the difference.
+
+The store having no caller will read as dead code in review. That is the recorded cost of keeping
+this slice small.
+
+## Alternatives considered
+
+Returning raw rows and letting each consumer interpret them — rejected because the three rules above
+would then be re-decided at every render site, and one of those decisions would be wrong.
+
+Shipping the filesystem watcher with the reader — rejected: it is a live-update mechanism, unrelated
+to reading, and it refactors the pre-existing agent-message watcher along the way.

--- a/src/bun/__tests__/notification-log-read.test.ts
+++ b/src/bun/__tests__/notification-log-read.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+
+// A real filesystem, redirected: what is under test is reading day-files off disk,
+// including a torn line and a day the retention prune already deleted.
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-notifread-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../rpc-handlers/shared-pure", () => ({ getPushMessage: () => null }));
+
+import { NOTIFICATION_LOG_RETENTION_DAYS, type NotificationLogInput, serializeNotificationLogRow } from "../../shared/notification-log";
+import { notificationLogDir, readNotificationLog } from "../notification-log";
+
+const dir = () => notificationLogDir();
+
+function row(overrides: Partial<NotificationLogInput> = {}): string {
+	return serializeNotificationLogRow({
+		at: "2026-09-07T10:00:00.000Z",
+		mode: "toast",
+		level: "info",
+		message: "build green",
+		taskId: "task-1",
+		taskSeq: 11,
+		projectId: "proj-1",
+		sourceTaskId: "task-1",
+		sourceSeq: 11,
+		outcome: "delivered",
+		...overrides,
+	});
+}
+
+function writeDay(day: string, lines: string[]): void {
+	mkdirSync(dir(), { recursive: true });
+	writeFileSync(`${dir()}/${day}.jsonl`, lines.join(""));
+}
+
+beforeEach(() => rmSync(dir(), { recursive: true, force: true }));
+afterEach(() => rmSync(dir(), { recursive: true, force: true }));
+
+describe("readNotificationLog", () => {
+	it("answers an empty page with a null day range when nothing was ever recorded", () => {
+		const page = readNotificationLog();
+		expect(page).toEqual({
+			rows: [],
+			oldestDay: null,
+			newestDay: null,
+			retentionDays: NOTIFICATION_LOG_RETENTION_DAYS,
+			hasMore: false,
+		});
+	});
+
+	it("returns rows newest first across days and reports the real day range", () => {
+		writeDay("2026-09-05", [row({ message: "oldest", at: "2026-09-05T09:00:00.000Z" })]);
+		writeDay("2026-09-07", [
+			row({ message: "middle", at: "2026-09-07T09:00:00.000Z" }),
+			row({ message: "newest", at: "2026-09-07T18:00:00.000Z" }),
+		]);
+		const page = readNotificationLog();
+		expect(page.rows.map(item => item.message)).toEqual(["newest", "middle", "oldest"]);
+		expect(page.oldestDay).toBe("2026-09-05");
+		expect(page.newestDay).toBe("2026-09-07");
+		expect(page.hasMore).toBe(false);
+	});
+
+	it("reports a gap in the middle as a gap, not as continuous history", () => {
+		// 09-06 is missing: either nothing happened, or a prune took it. The reader
+		// must not fabricate the day, and the range must still span the real edges.
+		writeDay("2026-09-05", [row({ message: "before the gap" })]);
+		writeDay("2026-09-08", [row({ message: "after the gap" })]);
+		const page = readNotificationLog();
+		expect(page.rows).toHaveLength(2);
+		expect([page.oldestDay, page.newestDay]).toEqual(["2026-09-05", "2026-09-08"]);
+	});
+
+	it("stops at the limit and says older rows are still on disk", () => {
+		writeDay("2026-09-07", [row({ message: "a" }), row({ message: "b" }), row({ message: "c" })]);
+		const page = readNotificationLog({ limit: 2 });
+		expect(page.rows.map(item => item.message)).toEqual(["c", "b"]);
+		expect(page.hasMore).toBe(true);
+	});
+
+	it("skips a torn line instead of losing the day it lives in", () => {
+		writeDay("2026-09-07", [row({ message: "before" }), '{"v":1,"at":"2026-09-0', "\n", row({ message: "after" })]);
+		expect(readNotificationLog().rows.map(item => item.message)).toEqual(["after", "before"]);
+	});
+
+	it("ignores files that are not day-files", () => {
+		writeDay("2026-09-07", [row({ message: "real" })]);
+		writeFileSync(`${dir()}/notes.txt`, "not a log\n");
+		writeFileSync(`${dir()}/2026-13-40.jsonl`, row({ message: "impossible day" }));
+		const page = readNotificationLog();
+		expect(page.rows.map(item => item.message)).toEqual(["real"]);
+		expect(page.newestDay).toBe("2026-09-07");
+	});
+
+	describe("project filtering", () => {
+		beforeEach(() => {
+			writeDay("2026-09-07", [
+				row({ message: "visible project", projectId: "proj-1" }),
+				row({ message: "sensitive project", projectId: "proj-secret" }),
+				row({ message: "no project at all", projectId: null, taskId: null, taskSeq: null, sourceTaskId: null, sourceSeq: null }),
+			]);
+		});
+
+		it("keeps allowed projects and always keeps rows with no project", () => {
+			const page = readNotificationLog({ projectIds: ["proj-1"] });
+			expect(page.rows.map(item => item.message)).toEqual(["no project at all", "visible project"]);
+		});
+
+		it("an empty allowlist means only the rows that belong to nobody", () => {
+			const page = readNotificationLog({ projectIds: [] });
+			expect(page.rows.map(item => item.message)).toEqual(["no project at all"]);
+		});
+
+		it("no allowlist means no filtering", () => {
+			expect(readNotificationLog().rows).toHaveLength(3);
+		});
+	});
+});

--- a/src/bun/notification-log.ts
+++ b/src/bun/notification-log.ts
@@ -28,9 +28,17 @@
  * has no telemetry path and is never uploaded.
  */
 
-import { appendFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
-import { NOTIFICATION_LOG_RETENTION_DAYS, type NotificationLogInput, serializeNotificationLogRow } from "../shared/notification-log";
+import { appendFileSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
+import {
+	NOTIFICATION_LOG_RETENTION_DAYS,
+	type NotificationLogInput,
+	type NotificationLogPage,
+	type NotificationLogRow,
+	parseNotificationLogRow,
+	serializeNotificationLogRow,
+} from "../shared/notification-log";
 import { DEV3_HOME } from "./paths";
+import { getPushMessage } from "./rpc-handlers/shared-pure";
 import { createLogger } from "./logger";
 
 const log = createLogger("notification-log");
@@ -116,4 +124,80 @@ export function appendNotificationLog(input: NotificationLogInput, now: Date = n
 		return;
 	}
 	pruneIfNeeded(now);
+	// The row is on disk, so a reader's cached page is now stale. Only this
+	// instance's own appends are announced: learning about another instance's
+	// writes needs a filesystem watcher, which a read API does not.
+	try {
+		getPushMessage()?.("notificationLogChanged", {});
+	} catch (err) {
+		log.warn("Failed to announce the persisted notification", { error: String(err) });
+	}
+}
+
+/** What a reader asks for. Both fields are optional; the defaults read everything. */
+export interface NotificationLogQuery {
+	/** Newest N rows. */
+	limit?: number;
+	/**
+	 * Keep only rows belonging to these projects, plus every row that has no
+	 * project at all — a notification sent from a plain shell belongs to nobody
+	 * and hiding it would be a different answer than the caller asked for.
+	 *
+	 * Exists so a project the user marked sensitive never puts its notification
+	 * text on the wire, rather than being filtered after it arrives.
+	 */
+	projectIds?: readonly string[] | null;
+}
+
+/**
+ * Read recent history, newest first. Torn and unparseable lines are skipped —
+ * losing one row beats losing the day it lives in.
+ *
+ * Never throws and never invents: no archive at all answers with an empty page
+ * whose `oldestDay` and `newestDay` are both null, which is what "collection has
+ * not started here" looks like and is not the same as "nothing happened".
+ */
+export function readNotificationLog(query: NotificationLogQuery = {}): NotificationLogPage {
+	const limit = Math.max(0, Math.trunc(query.limit ?? 500));
+	const allowed = query.projectIds ? new Set(query.projectIds) : null;
+	const dir = notificationLogDir();
+	let days: string[];
+	try {
+		days = readdirSync(dir).filter(name => parseDay(name) !== null).sort();
+	} catch {
+		return { rows: [], oldestDay: null, newestDay: null, retentionDays: NOTIFICATION_LOG_RETENTION_DAYS, hasMore: false };
+	}
+	const stamp = (name: string) => name.slice(0, -".jsonl".length);
+	const oldestDay = days[0] ? stamp(days[0]) : null;
+	const newestDay = days.length ? stamp(days[days.length - 1]) : null;
+	const rows: NotificationLogRow[] = [];
+	let hasMore = false;
+	for (const name of [...days].reverse()) {
+		if (rows.length >= limit) {
+			hasMore = true;
+			break;
+		}
+		let content: string;
+		try {
+			content = readFileSync(`${dir}/${name}`, "utf8");
+		} catch {
+			continue;
+		}
+		const dayRows: NotificationLogRow[] = [];
+		for (const line of content.split("\n")) {
+			const row = parseNotificationLogRow(line);
+			if (!row) continue;
+			if (allowed && row.projectId !== null && !allowed.has(row.projectId)) continue;
+			dayRows.push(row);
+		}
+		dayRows.reverse();
+		for (const row of dayRows) {
+			if (rows.length >= limit) {
+				hasMore = true;
+				break;
+			}
+			rows.push(row);
+		}
+	}
+	return { rows, oldestDay, newestDay, retentionDays: NOTIFICATION_LOG_RETENTION_DAYS, hasMore };
 }

--- a/src/bun/rpc-handlers/notes-labels.ts
+++ b/src/bun/rpc-handlers/notes-labels.ts
@@ -1,9 +1,11 @@
 import type { ColumnAgentConfig, CustomColumn, Label, NoteSource, Project, Task, TaskNote, TaskStatus } from "../../shared/types";
 import { LABEL_COLORS, appendTaskNote } from "../../shared/types";
 import type { AgentMessageLogPage } from "../../shared/agent-message-log";
+import type { NotificationLogPage } from "../../shared/notification-log";
 import * as data from "../data";
 import { messageLogDir, readAgentMessageLog as readMessageLog } from "../agent-message-log";
 import { watchAgentMessageLog } from "../agent-message-log-watch";
+import { readNotificationLog as readNotifications } from "../notification-log";
 import { getPushMessage, log } from "./shared";
 import { dispatchLifecycleEvent } from "../lifecycle/service";
 
@@ -321,8 +323,18 @@ async function readAgentMessageLog(params: { projectId: string; limit?: number }
 	return readMessageLog(project, params.limit);
 }
 
+/**
+ * Read the global notification archive. Read-only; a machine that has never had a
+ * notification answers with an empty page rather than an error, and the empty
+ * page's null day range is what "collection has not started here" looks like.
+ */
+async function readNotificationLog(params: { limit?: number; projectIds?: string[] }): Promise<NotificationLogPage> {
+	return readNotifications({ limit: params.limit, projectIds: params.projectIds });
+}
+
 export const notesLabelsHandlers = {
 	readAgentMessageLog,
+	readNotificationLog,
 	createLabel,
 	updateLabel,
 	deleteLabel,

--- a/src/mainview/__tests__/notification-event.test.ts
+++ b/src/mainview/__tests__/notification-event.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import type { NotificationLogRow } from "../../shared/notification-log";
+import { notificationEvents } from "../notification-event";
+
+function notification(overrides: Partial<NotificationLogRow> = {}): NotificationLogRow {
+	return {
+		v: 1,
+		at: "2026-09-07T10:00:00.000Z",
+		mode: "toast",
+		level: "info",
+		message: "build green",
+		taskId: "task-a",
+		taskSeq: 11,
+		taskTitle: "Task A as it was named then",
+		projectId: "proj-1",
+		sourceTaskId: "task-a",
+		sourceSeq: 11,
+		sourceProjectId: "proj-1",
+		outcome: "delivered",
+		...overrides,
+	};
+}
+
+/** The reader returns newest first, so tests feed events in that order too. */
+const newestFirst = (...rows: NotificationLogRow[]) => [...rows].reverse();
+
+describe("notificationEvents", () => {
+	it("returns events oldest first with the row kept verbatim", () => {
+		const events = notificationEvents(newestFirst(
+			notification({ at: "2026-09-07T09:00:00.000Z", message: "first" }),
+			notification({ at: "2026-09-07T11:00:00.000Z", message: "second" }),
+		));
+		expect(events.map(event => event.row.message)).toEqual(["first", "second"]);
+		expect(events[0].at).toBe(Date.parse("2026-09-07T09:00:00.000Z"));
+	});
+
+	it("keeps both ends when the notification was addressed at another task", () => {
+		const [event] = notificationEvents([notification({
+			taskId: "task-b", taskSeq: 22, taskTitle: "Task B",
+			sourceTaskId: "task-a", sourceSeq: 11, sourceTitle: "Task A",
+		})]);
+		expect(event.target).toEqual({ projectId: "proj-1", taskId: "task-b", seq: 22, title: "Task B" });
+		expect(event.origin).toEqual({ projectId: "proj-1", taskId: "task-a", seq: 11, title: "Task A" });
+		expect(event.crossAddressed).toBe(true);
+	});
+
+	it("does not call a notification cross-addressed when both ends are the same card", () => {
+		expect(notificationEvents([notification()])[0].crossAddressed).toBe(false);
+	});
+
+	it("invents no sender and no card when the archive recorded none", () => {
+		const [event] = notificationEvents([notification({
+			taskId: null, taskSeq: null, taskTitle: undefined, projectId: null,
+			sourceTaskId: null, sourceSeq: null, sourceProjectId: undefined,
+		})]);
+		expect(event.target).toBeNull();
+		expect(event.origin).toBeNull();
+		expect(event.crossAddressed).toBe(false);
+	});
+
+	it("keeps a target the board no longer has, rather than dropping the anchor", () => {
+		const [event] = notificationEvents([notification({ taskId: "deleted-task", taskSeq: 99 })]);
+		expect(event.target?.taskId).toBe("deleted-task");
+	});
+
+	it("carries suppression only on a queued row", () => {
+		const queued = notificationEvents([notification({ outcome: "queued", suppressedBy: ["focusMode"] })])[0];
+		expect(queued.suppressedBy).toEqual(["focusMode"]);
+		// A stray field on a delivered row is data we do not trust: the outcome is
+		// what says whether anything held it back.
+		const delivered = notificationEvents([notification({ outcome: "delivered", suppressedBy: ["focusMode"] })])[0];
+		expect(delivered.suppressedBy).toEqual([]);
+	});
+
+	it("drops a row whose timestamp cannot be parsed instead of dating it to 1970", () => {
+		const events = notificationEvents(newestFirst(
+			notification({ at: "not a date", message: "broken" }),
+			notification({ at: "2026-09-07T10:00:00.000Z", message: "real" }),
+		));
+		expect(events.map(event => event.row.message)).toEqual(["real"]);
+	});
+
+	it("gives two identical notifications two distinct keys", () => {
+		const events = notificationEvents([notification(), notification()]);
+		expect(new Set(events.map(event => event.key)).size).toBe(2);
+	});
+
+	describe("stable identity", () => {
+		// The page arrives newest-first and is truncated at `limit` from the OLD end,
+		// so every one of these is a different way for a key to move.
+		const twin = notification({ message: "identical twin" });
+
+		it("re-reading the same page yields the same keys", () => {
+			const page = newestFirst(
+				notification({ at: "2026-09-07T09:00:00.000Z" }),
+				twin,
+				twin,
+				notification({ at: "2026-09-07T12:00:00.000Z" }),
+			);
+			expect(notificationEvents(page).map(event => event.key))
+				.toEqual(notificationEvents([...page]).map(event => event.key));
+		});
+
+		it("does not collapse two identical notifications into one", () => {
+			const events = notificationEvents([twin, twin, twin]);
+			expect(events).toHaveLength(3);
+			expect(new Set(events.map(event => event.key)).size).toBe(3);
+		});
+
+		it("a newer row prepended by a live append renumbers nothing", () => {
+			const before = notificationEvents([twin, twin]).map(event => event.key);
+			const after = notificationEvents([notification({ at: "2026-09-08T10:00:00.000Z" }), twin, twin]);
+			// The two twins keep their keys; only the arrival is new.
+			expect(after.slice(0, 2).map(event => event.key)).toEqual(before);
+		});
+
+		it("a longer page revealing an OLDER identical row renumbers nothing", () => {
+			// This is the case a page-relative index gets wrong: the short page held two
+			// twins, `load more` reveals a third, older one.
+			const shortPage = notificationEvents([twin, twin]).map(event => event.key);
+			const longPage = notificationEvents([twin, twin, twin]).map(event => event.key);
+			expect(longPage.slice(1)).toEqual(shortPage);
+		});
+
+		it("keys stay unique across a page that mixes twins with ordinary rows", () => {
+			const events = notificationEvents(newestFirst(
+				notification({ at: "2026-09-07T08:00:00.000Z" }),
+				twin,
+				notification({ at: "2026-09-07T10:00:00.000Z" }),
+				twin,
+				twin,
+			));
+			expect(new Set(events.map(event => event.key)).size).toBe(events.length);
+		});
+	});
+});
+
+describe("a notification with no task and no project", () => {
+	// Reported from combined QA as "the project allowlist drops project-less rows,
+	// so a notification sent without a task is invisible". The reader disproves it
+	// on disk (notification-log-read.test.ts: an allowlist always keeps a row with
+	// no project, and an EMPTY allowlist keeps exactly those). This is the other
+	// half: normalization must not drop it either, so whatever swallowed it lives
+	// downstream of both.
+	const rows = [
+		notification({
+			level: "error",
+			message: "sent from a plain shell",
+			taskId: null, taskSeq: null, taskTitle: undefined,
+			projectId: null,
+			sourceTaskId: null, sourceSeq: null, sourceTitle: undefined, sourceProjectId: undefined,
+		}),
+	];
+
+	it("survives normalization with both endpoints null, rather than being dropped", () => {
+		const [event] = notificationEvents(rows);
+		expect(event).toBeDefined();
+		expect(event.target).toBeNull();
+		expect(event.origin).toBeNull();
+		expect(event.crossAddressed).toBe(false);
+	});
+
+});

--- a/src/mainview/__tests__/notification-traffic.test.ts
+++ b/src/mainview/__tests__/notification-traffic.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NotificationLogPage, NotificationLogRow } from "../../shared/notification-log";
+
+const readNotificationLog = vi.fn();
+vi.mock("../rpc", () => ({ api: { request: { readNotificationLog: (...args: unknown[]) => readNotificationLog(...args) } } }));
+
+import {
+	getNotificationTrafficState,
+	loadNotificationTraffic,
+	noteNotificationArrival,
+	resetNotificationTrafficStore,
+	subscribeNotificationTraffic,
+} from "../notification-traffic";
+
+function row(message: string): NotificationLogRow {
+	return {
+		v: 1, at: "2026-09-07T10:00:00.000Z", mode: "toast", level: "info", message,
+		taskId: null, taskSeq: null, projectId: null, sourceTaskId: null, sourceSeq: null,
+		outcome: "delivered",
+	};
+}
+
+function page(rows: NotificationLogRow[], overrides: Partial<NotificationLogPage> = {}): NotificationLogPage {
+	return {
+		rows,
+		oldestDay: rows.length ? "2026-09-07" : null,
+		newestDay: rows.length ? "2026-09-07" : null,
+		retentionDays: 30,
+		hasMore: false,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	readNotificationLog.mockReset();
+	resetNotificationTrafficStore();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("notification traffic store", () => {
+	it("an archive that was never written reads as a null day range, not as an error", async () => {
+		readNotificationLog.mockResolvedValue(page([]));
+		await loadNotificationTraffic();
+		const state = getNotificationTrafficState();
+		expect(state).toMatchObject({ rows: [], oldestDay: null, newestDay: null, loaded: true, error: false });
+	});
+
+	it("passes the project allowlist through to the read, and omits it when there is none", async () => {
+		readNotificationLog.mockResolvedValue(page([]));
+		await loadNotificationTraffic({ limit: 10, projectIds: ["proj-1"] });
+		expect(readNotificationLog).toHaveBeenLastCalledWith({ limit: 10, projectIds: ["proj-1"] });
+		await loadNotificationTraffic({ projectIds: null });
+		expect(readNotificationLog).toHaveBeenLastCalledWith({ limit: 10 });
+	});
+
+	it("ignores a slow reply that a newer load already superseded", async () => {
+		let releaseFirst: (value: NotificationLogPage) => void = () => {};
+		readNotificationLog.mockImplementationOnce(() => new Promise(resolve => { releaseFirst = resolve; }));
+		readNotificationLog.mockResolvedValueOnce(page([row("second")]));
+		const first = loadNotificationTraffic();
+		const second = loadNotificationTraffic();
+		await second;
+		releaseFirst(page([row("first")]));
+		await first;
+		expect(getNotificationTrafficState().rows.map(item => item.message)).toEqual(["second"]);
+	});
+
+	it("keeps what is on screen when the read fails, and says so", async () => {
+		readNotificationLog.mockResolvedValueOnce(page([row("kept")]));
+		await loadNotificationTraffic();
+		readNotificationLog.mockRejectedValueOnce(new Error("transport"));
+		await loadNotificationTraffic();
+		const state = getNotificationTrafficState();
+		expect(state.rows.map(item => item.message)).toEqual(["kept"]);
+		expect(state.error).toBe(true);
+	});
+
+	it("coalesces a burst of appends into one re-read", async () => {
+		readNotificationLog.mockResolvedValue(page([row("a")]));
+		await loadNotificationTraffic();
+		readNotificationLog.mockClear();
+		for (let index = 0; index < 5; index += 1) noteNotificationArrival();
+		await vi.advanceTimersByTimeAsync(200);
+		expect(readNotificationLog).toHaveBeenCalledTimes(1);
+	});
+
+	it("a re-read after an append keeps the last query rather than resetting it", async () => {
+		readNotificationLog.mockResolvedValue(page([]));
+		await loadNotificationTraffic({ limit: 42, projectIds: ["proj-1"] });
+		readNotificationLog.mockClear();
+		noteNotificationArrival();
+		await vi.advanceTimersByTimeAsync(200);
+		expect(readNotificationLog).toHaveBeenCalledWith({ limit: 42, projectIds: ["proj-1"] });
+	});
+
+	it("notifies subscribers on every state change", async () => {
+		const listener = vi.fn();
+		subscribeNotificationTraffic(listener);
+		readNotificationLog.mockResolvedValue(page([row("a")]));
+		await loadNotificationTraffic();
+		// One for the loading flag, one for the answer.
+		expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2);
+	});
+});

--- a/src/mainview/notification-event.ts
+++ b/src/mainview/notification-event.ts
@@ -1,0 +1,121 @@
+/**
+ * Turn archived `dev3 notify` rows into events a reader can render.
+ *
+ * Data only: no component, no styling, no timeline. It lives beside the store
+ * that fetches the rows rather than under `components/`, because nothing here
+ * knows what a notification looks like on screen.
+ *
+ * Why a normalizer rather than passing rows around: three rules about a
+ * notification are easy to get wrong and expensive to get wrong, so they are
+ * decided once, here, instead of at every render site.
+ *
+ * 1. An UNRECORDED source invents nothing. A row can carry `taskId: null` and
+ *    `sourceTaskId: null`, and both nulls mean "the archive did not record this" —
+ *    not "there was no worktree" and not "nobody sent it". An event with no
+ *    endpoint at all is unanchored: it belongs to no card, and must never be
+ *    attached to a neighbouring one because one happened to be nearby.
+ * 2. A CLAIMED source is not a trusted identity. `sourceSessionId` separates two
+ *    agent sessions in one task and nothing more: a Claude Code sub-agent inherits
+ *    its parent's id verbatim (measured, see `shared/notification-log.ts`), so it
+ *    is never rendered as "sent by sub-agent X". `taskTitle`/`sourceTitle` are
+ *    snapshots of what the title was at write time, not the task's live name.
+ * 3. The REQUEST and its FATE are separate facts. `queued` and `no-window` mean
+ *    the user may never have seen it; folding them into `delivered` would answer
+ *    the one question the archive exists to answer.
+ */
+import type {
+	NotificationLogLevel,
+	NotificationLogMode,
+	NotificationLogOutcome,
+	NotificationLogRow,
+	NotificationLogSuppression,
+} from "../shared/notification-log";
+
+/** A task a notification points at, or came from. Ids only — identity is the board's job. */
+export interface NotificationEndpoint {
+	projectId: string;
+	taskId: string;
+	/** Seq as recorded, not as it is now. Null when the archive did not have one. */
+	seq: number | null;
+	/** Title as recorded. Absent when the archive did not have one. */
+	title?: string;
+}
+
+/** One archived notification, ready to render. */
+export interface TrafficNotificationEvent {
+	/**
+	 * Stable across a refresh, a prepend and a longer page: a fingerprint of the
+	 * row plus how many identical rows sit NEWER than it. Two genuinely identical
+	 * notifications keep two events rather than collapsing into one, and neither a
+	 * new row nor a revealed older row renumbers what already had a key.
+	 */
+	key: string;
+	/** Epoch ms of `row.at`. */
+	at: number;
+	/** The archive row, verbatim. */
+	row: NotificationLogRow;
+	/** The card this is about, or null when the archive recorded none. */
+	target: NotificationEndpoint | null;
+	/** The card it was sent from, or null when the archive recorded no source. */
+	origin: NotificationEndpoint | null;
+	/** True when both ends exist and are different cards — `notify --task <other>`. */
+	crossAddressed: boolean;
+	level: NotificationLogLevel;
+	mode: NotificationLogMode;
+	outcome: NotificationLogOutcome;
+	/** Sources that held delivery back. Empty unless `outcome === "queued"`. */
+	suppressedBy: NotificationLogSuppression[];
+}
+
+function endpoint(projectId: string | null, taskId: string | null, seq: number | null, title?: string): NotificationEndpoint | null {
+	if (!projectId || !taskId) return null;
+	return { projectId, taskId, seq, ...(title ? { title } : {}) };
+}
+
+/**
+ * Chronological (oldest first) events for `rows`, which arrive newest first.
+ *
+ * A row whose `at` cannot be parsed is DROPPED rather than coerced to epoch 0 —
+ * a timestamp of "1970" would sort a broken row in front of real history and
+ * make the replay lie about when things happened.
+ */
+export function notificationEvents(rows: readonly NotificationLogRow[]): TrafficNotificationEvent[] {
+	const occurrences = new Map<string, number>();
+	const events: TrafficNotificationEvent[] = [];
+	// Counted from the NEWEST end, which is the order `rows` already arrives in.
+	//
+	// This is load-bearing and was got wrong once. Two genuinely identical rows are
+	// told apart only by how many identical rows sit beside them, and the page is
+	// truncated at `limit` from the OLD end — so counting from the oldest row in the
+	// page renumbers every duplicate the moment a longer page reveals an older one,
+	// and every key changes on "load more". Counting from the newest end is stable
+	// under pagination: an older row appearing takes the next index up and touches
+	// nothing already numbered. A live append cannot disturb it either, because two
+	// rows identical to the millisecond would have to arrive for the group to grow
+	// at the new end, and the writer already de-duplicates the fan-out that could
+	// produce them.
+	for (const row of rows) {
+		const at = Date.parse(row.at);
+		if (!Number.isFinite(at)) continue;
+		const fingerprint = JSON.stringify(row);
+		const occurrence = occurrences.get(fingerprint) ?? 0;
+		occurrences.set(fingerprint, occurrence + 1);
+		const target = endpoint(row.projectId, row.taskId, row.taskSeq, row.taskTitle);
+		const origin = endpoint(row.sourceProjectId ?? row.projectId, row.sourceTaskId, row.sourceSeq, row.sourceTitle);
+		events.push({
+			key: `notification:${fingerprint}:${occurrence}`,
+			at,
+			row,
+			target,
+			origin,
+			crossAddressed: !!target && !!origin && target.taskId !== origin.taskId,
+			level: row.level,
+			mode: row.mode,
+			outcome: row.outcome,
+			suppressedBy: row.outcome === "queued" ? row.suppressedBy ?? [] : [],
+		});
+	}
+	// Built newest-first for stable keys, returned oldest-first because that is the
+	// order a timeline is read in.
+	return events.reverse();
+}

--- a/src/mainview/notification-traffic.ts
+++ b/src/mainview/notification-traffic.ts
@@ -1,0 +1,109 @@
+/**
+ * Renderer-side store for the global `dev3 notify` archive.
+ *
+ * One global state rather than the message log's per-project map, because the
+ * archive itself is global: a notification sent from a plain shell has no project
+ * to file it under. Narrowing to the projects the user can see is a parameter of
+ * the read (so a sensitive project's text never reaches the renderer at all), not
+ * a shape of the store.
+ */
+
+import type { NotificationLogPage, NotificationLogRow } from "../shared/notification-log";
+import { api } from "./rpc";
+
+export interface NotificationTrafficState {
+	/** Newest first, exactly as the reader returned them. */
+	rows: NotificationLogRow[];
+	/** Oldest day on disk, `YYYY-MM-DD`, or null when the archive is empty. */
+	oldestDay: string | null;
+	/** Newest day on disk. Null with `oldestDay` means collection never started here. */
+	newestDay: string | null;
+	retentionDays: number;
+	/** True when the page was cut short and older rows exist on disk. */
+	hasMore: boolean;
+	loading: boolean;
+	loaded: boolean;
+	error?: boolean;
+}
+
+const EMPTY: NotificationTrafficState = {
+	rows: [],
+	oldestDay: null,
+	newestDay: null,
+	retentionDays: 30,
+	hasMore: false,
+	loading: false,
+	loaded: false,
+};
+
+let state: NotificationTrafficState = EMPTY;
+const listeners = new Set<() => void>();
+
+/** Coalesce a burst of appends into one read, the same 100ms the message log uses. */
+const REFETCH_DEBOUNCE_MS = 100;
+let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+let lastQuery: { limit: number; projectIds: string[] | null } = { limit: 500, projectIds: null };
+let loadVersion = 0;
+
+export function getNotificationTrafficState(): NotificationTrafficState {
+	return state;
+}
+
+export function subscribeNotificationTraffic(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+function patch(next: Partial<NotificationTrafficState>): void {
+	state = { ...state, ...next };
+	for (const listener of listeners) listener();
+}
+
+export async function loadNotificationTraffic(query: { limit?: number; projectIds?: string[] | null } = {}): Promise<void> {
+	const limit = query.limit ?? lastQuery.limit;
+	const projectIds = query.projectIds === undefined ? lastQuery.projectIds : query.projectIds;
+	lastQuery = { limit, projectIds };
+	const version = ++loadVersion;
+	patch({ loading: true, error: false });
+	try {
+		const page: NotificationLogPage = await api.request.readNotificationLog({
+			limit,
+			...(projectIds ? { projectIds } : {}),
+		});
+		// A later load already answered; this reply is stale, not wrong.
+		if (loadVersion !== version) return;
+		patch({
+			rows: page.rows,
+			oldestDay: page.oldestDay,
+			newestDay: page.newestDay,
+			retentionDays: page.retentionDays,
+			hasMore: page.hasMore,
+			loading: false,
+			loaded: true,
+		});
+	} catch {
+		// An empty archive answers with an empty page, so a throw is a transport
+		// failure: keep whatever was already shown rather than blanking it.
+		if (loadVersion !== version) return;
+		patch({ loading: false, loaded: true, error: true });
+	}
+}
+
+/** Called on `notificationLogChanged`. Re-reads with the last query, debounced. */
+export function noteNotificationArrival(): void {
+	if (refetchTimer) clearTimeout(refetchTimer);
+	refetchTimer = setTimeout(() => {
+		refetchTimer = null;
+		void loadNotificationTraffic();
+	}, REFETCH_DEBOUNCE_MS);
+}
+
+/** Test seam: drop the cached page, every listener and any pending refetch. */
+export function resetNotificationTrafficStore(): void {
+	if (refetchTimer) clearTimeout(refetchTimer);
+	refetchTimer = null;
+	state = EMPTY;
+	lastQuery = { limit: 500, projectIds: null };
+	loadVersion = 0;
+	listeners.clear();
+}

--- a/src/mainview/rpc.ts
+++ b/src/mainview/rpc.ts
@@ -121,6 +121,7 @@ const pushMessageHandlers: Record<string, (payload: any) => void> = {
 	openDeepLink: (payload) => window.dispatchEvent(new CustomEvent("rpc:openDeepLink", { detail: payload })),
 	cliToast: (payload) => window.dispatchEvent(new CustomEvent("rpc:cliToast", { detail: payload })),
 	agentMessageLogChanged: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentMessageLogChanged", { detail: payload })),
+	notificationLogChanged: (payload) => window.dispatchEvent(new CustomEvent("rpc:notificationLogChanged", { detail: payload })),
 	agentMessage: (payload) => window.dispatchEvent(new CustomEvent("rpc:agentMessage", { detail: payload })),
 	cliAttention: (payload) => window.dispatchEvent(new CustomEvent("rpc:cliAttention", { detail: payload })),
 	cliShowImage: (payload) => window.dispatchEvent(new CustomEvent("rpc:cliShowImage", { detail: payload })),

--- a/src/shared/notification-log.ts
+++ b/src/shared/notification-log.ts
@@ -112,6 +112,15 @@ export interface NotificationLogPage {
 	 * everything before this day was deleted by the retention policy.
 	 */
 	oldestDay: string | null;
+	/**
+	 * The newest day on disk (`YYYY-MM-DD`), or null when there is no history.
+	 *
+	 * Together with {@link oldestDay} this is the ONLY honest answer to "how far
+	 * back does this go" — the collection started when the writer shipped, not
+	 * when the app was installed, and a reader that assumed 30 days of history
+	 * would invent the difference.
+	 */
+	newestDay: string | null;
 	/** Days of history the retention policy keeps. */
 	retentionDays: number;
 	/** True when `limit` cut the answer short and older rows still exist on disk. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,7 @@ export type { TelemetryProfile } from "./telemetry-profile";
 import type { PosixShellResolution, ShellFlavor } from "./posix-shell";
 import type { AgentPromptDelivery } from "./agent-prompt-delivery";
 import type { AgentMessageLogPage } from "./agent-message-log";
+import type { NotificationLogPage } from "./notification-log";
 import type { LowBatteryStatus } from "./low-battery";
 export type { LowBatteryStatus, OutputStyleOutcome } from "./low-battery";
 
@@ -5381,6 +5382,18 @@ export type AppRPCSchema = {
 				params: { projectId: string; limit?: number };
 				response: AgentMessageLogPage;
 			};
+			/**
+			 * Read the global `dev3 notify` archive, newest first.
+			 *
+			 * Deliberately not per project: a notification can be sent with no task and
+			 * therefore no project, so splitting the stream by project would make
+			 * "every notification, in order" unanswerable. `projectIds` narrows it, and
+			 * a row with no project is always kept.
+			 */
+			readNotificationLog: {
+				params: { limit?: number; projectIds?: string[] };
+				response: NotificationLogPage;
+			};
 			taskPaneState: {
 				params: { taskId: string };
 				response: TaskPaneState;
@@ -6036,6 +6049,13 @@ export type AppRPCSchema = {
 			 */
 			/** A durable append completed; refresh the recipient project log, including failed attempts. */
 			agentMessageLogChanged: { projectId: string };
+			/**
+			 * A notification row was appended to the global archive by THIS instance.
+			 * No payload: the archive is one global stream, so there is nothing to
+			 * scope the refresh to. Another instance's appends are not announced —
+			 * that needs a filesystem watcher, which a read API does not.
+			 */
+			notificationLogChanged: Record<string, never>;
 			agentMessage: {
 				/** Receiving task — the click target, and the inbox that got the text. */
 				taskId: string;


### PR DESCRIPTION
Reads the already-persisted notification archive back, so recorded notifications can be shown somewhere. Data layer only — this PR renders nothing.

`dev3 notify` has been writing every notification to `~/.dev3.0/notifications/YYYY-MM-DD.jsonl` for a while, and nothing could read it. This adds:

- **`readNotificationLog(query)`** — newest-first paging over the day files, with project scoping. A row that carries no project is always kept, so a notification never disappears because it has no project to be scoped by.
- **RPC transport** — `readNotificationLog` on the schema, its handler, and a `notificationLogChanged` push event. The event announces **only this instance's own appends**: learning about another instance's writes needs a filesystem watcher, and a read API has none. Both the schema comment and the append site say so, rather than promising more than the code does.
- **Identity normalization** that invents nothing. Three rules, documented in `src/mainview/notification-event.ts`: an unrecorded source stays unrecorded; a claimed source is not a trusted identity (a Claude Code sub-agent inherits its parent's `sourceSessionId` verbatim — measured, not assumed); the request and its fate are separate facts.
- **A renderer store** that loads a page and debounces arrivals.

**The store and the normalizer ship with no caller, on purpose.** The consumer is a separate task that owns the timeline and list; adding UI here purely to make the data layer look used was explicitly ruled out. The decision record states this plainly so it is not mistaken for dead code.

Split out of a larger branch that did the whole feature end to end (29 files, +3281/−127) and was rejected for size. Presentation — cloud, geometry, placement, timeline, filters, counts, i18n — is deliberately absent, along with the shared day-file watcher. On-disk retention is untouched.

12 files, +800/−2: 358 source, 389 tests, 53 docs. Three independently reviewable commits.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=0df767d9-865c-42fe-a9b2-2a4ca073be79) · `dev3://task/0df767d9-865c-42fe-a9b2-2a4ca073be79` _(dev3 added this footer — turn it off in Settings → Tasks.)_
