### PR TITLE
Read agent-traffic task cards like compact Active Tasks rows

### DIFF
--- a/change-logs/2026/09/10/feature-60-traffic-cards-read-like-active-tasks.md
+++ b/change-logs/2026/09/10/feature-60-traffic-cards-read-like-active-tasks.md
@@ -1,0 +1,3 @@
+Short: Traffic cards match Active Tasks
+
+Task cards in Agent traffic (Experiment 2) now read like the compact Active Tasks rows they represent: the lifecycle rail with its stage ring runs down the left edge, the status colour washes the whole card instead of only marking its top edge, and the title, status word and overview are set at the same pitch as everywhere else in the app instead of poster-sized. Nothing was added to the card and nothing about replay changed — the status still comes from the recorded board moves at the cursor, never from today's board.

--- a/decisions/2026/09/10/traffic-card-borrows-the-rail-not-the-component.md
+++ b/decisions/2026/09/10/traffic-card-borrows-the-rail-not-the-component.md
@@ -1,0 +1,72 @@
+# The traffic card borrows the Active Tasks rail's look, not its component
+
+## Context
+
+Experiment 2 of Agent traffic drew task cards that looked like nothing else in the
+app: an 18px headline, three lines of overview, a status word buried in the body,
+and the status colour reduced to a 2px hairline. The ask was to make them read
+like the compact Active Tasks rows (`ActiveTaskRow.tsx`) they stand for, without
+turning the scene into a second Kanban board.
+
+## Investigation
+
+`TaskCardRail.tsx` is the component that draws the rail — the coloured strip,
+`PipelineRing`, and the upright stacked status word. Mounting it inside the
+traffic card does not work, for two independent reasons:
+
+1. It renders two `<button>`s (open the status menu, complete the task). The
+   traffic card's root **is** a `<button>`, so that is invalid markup and the
+   inner buttons are unreachable by keyboard.
+2. Both buttons are new actions inside the replay scene, which is explicitly out
+   of scope — the scene has click-to-select and double-click-to-focus, and gains
+   nothing else.
+
+`ActiveTaskRow` itself is worse: 20 props, and it calls `moveTaskToStatus`,
+`moveTaskToCustomColumn`, `toast` and `dispatch` directly.
+
+The upright status word is the rail's most recognizable feature, but it is a
+short form — `WORKING`, `ASKING`, `PR`. The traffic card needs the *full* label,
+because it also has to say `Status not recorded` and `Hibernated`, which have no
+short form, and because `agent-traffic-ui.test.tsx` asserts the full replayed
+label on the card as a truthfulness guard. Showing both words duplicates the
+status on a 300px card; showing only the short one loses information and breaks
+that guard.
+
+## Decision
+
+Borrow the vocabulary, not the component (`Card()` in `TrafficNodes.tsx`,
+`.traffic-node-rail` in `traffic-nodes.css`):
+
+- A non-interactive `<span className="traffic-node-rail">` at the card's left
+  edge, 20px wide (`--node-rail`, the same `w-5` the Kanban card uses), washed
+  `color-mix(var(--node-status) 14%)`.
+- `PipelineRing` is imported and reused as-is (it is pure — `status`, `size`,
+  `tooltip`), fed the **projected** status at the replay cursor. A parked card or
+  one with no recorded state gets the bare strip: a ring would claim a stage
+  neither has.
+- **No upright status word.** The full status word stays in the card body, restyled
+  to the app's uppercase tracked lifecycle type. This is the one deliberate
+  difference from the sidebar.
+- The rail is `aria-hidden`; the card's own `aria-label` already carries the status.
+- The status colour washes the card surface (`6%`), the way an Active Tasks row
+  carries `${color}0f`, and the type scale drops to the app's pitch (title 18→15px
+  at weight 500, overview 13→12px, status word 11→10px uppercase).
+- At the `compact` detail tier the ring is hidden and the strip stays; at `cell`
+  the existing rule that hides every child already hides the rail.
+
+## Risks
+
+The rail eats 20px of a 300px card, so a long title clamps a word earlier. The
+type-scale drop frees more vertical room than the rail costs horizontally, so
+`CARD_HEIGHT` stays at the 234 that `fix-traffic-card-text-clipping` set — but
+that means the card now has slack at the bottom, and a future row added to it
+must re-check the height rather than assume it fits.
+
+## Alternatives considered
+
+- **Mount `TaskCardRail`** — rejected: nested buttons, and new actions in the scene.
+- **Rail word instead of the body's status word** — rejected: loses
+  `Status not recorded` / `Hibernated`, and breaks the replay-truthfulness tests.
+- **Rail word in addition to it** — rejected: the same status twice on one small card.
+- **Copy `RAIL_LABEL_KEY` into the traffic module** — rejected: a duplicated status
+  label map drifts, and with no upright word it is not needed at all.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1579,6 +1579,19 @@ describe("Replay reconstructs the board at the cursor", () => {
 		expect(card("#22").getAttribute("data-history")).toBeNull();
 	});
 
+	it("draws the lifecycle rail from the replayed status, and a bare strip without one", async () => {
+		await replayFromStart();
+		await next();
+		const rail = card("#22").querySelector(".traffic-node-rail")!;
+		// The same stage ring the Kanban card and the Active Tasks row carry, reading
+		// the projection at the cursor — in-progress is stage 2 — not today's status.
+		expect(rail.querySelector("[role='img']")!.getAttribute("aria-label")).toBe("Stage 2 of 7");
+		// Silent to assistive tech: the card's own aria-label already says the status.
+		expect(rail.getAttribute("aria-hidden")).toBe("true");
+		// task-c has no recorded past, so there is no stage to claim: strip only.
+		expect(card("#33").querySelector(".traffic-node-rail")!.children.length).toBe(0);
+	});
+
 	it("drops every historical marker on Live and shows the states as they are", async () => {
 		await replayFromStart();
 		await userEvent.click(screen.getByRole("button", { name: "Live" }));

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -14,6 +14,7 @@ import {
 	useStatusColorsInk,
 } from "../../hooks/useStatusColors";
 import { useReducedMotion } from "../../utils/useReducedMotion";
+import PipelineRing from "../PipelineRing";
 import {
 	layoutTraffic,
 	pointAt,
@@ -1022,6 +1023,10 @@ function Card({
 	const limited = replaying && node.task && projection.confidence !== "recorded"
 		? projection.confidence
 		: null;
+	// The lifecycle rail the rest of the app draws down the left edge of a task
+	// card. It carries the projected status, so a parked card and a card with no
+	// recorded state get the bare strip — a ring would claim a stage neither has.
+	const railStatus = placed.parked ? null : (projection.status ?? null);
 	return (
 		<button
 			type="button"
@@ -1045,9 +1050,15 @@ function Card({
 			onClick={() => !unborn && onSelect(node.key)}
 			onDoubleClick={() => !unborn && onFocus(node.key)}
 		>
+			{/* Hidden from assistive tech: the card's own aria-label already says the
+			    status, and the ring would only repeat the stage as a second voice. */}
+			<span className="traffic-node-rail" aria-hidden="true">
+				{railStatus && (
+					<PipelineRing status={railStatus} size="compact" tooltip={false} />
+				)}
+			</span>
 			<span className="traffic-node-full">
 				<span className="traffic-node-head">
-					<i className="traffic-node-dot" aria-hidden="true" />
 					<b>{nodeSeq(node)}</b>
 					{node.task?.taskType === "coordinator" && (
 						<em>{t("traffic.orbit.coordinator")}</em>

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -158,8 +158,18 @@
 	text-align: left;
 	border: 0;
 	border-radius: 10px;
+	/* Matches the 20px (w-5) rail of a Kanban card and an Active Tasks row. */
+	--node-rail: 20px;
 	color: rgb(var(--text-primary));
-	background: rgb(var(--surface-elevated) / 0.96);
+	/* Same grammar as an Active Tasks row: the status colour washes the whole
+	   surface faintly instead of only marking an edge. */
+	background:
+		linear-gradient(
+			0deg,
+			color-mix(in srgb, var(--node-status) 6%, transparent),
+			color-mix(in srgb, var(--node-status) 6%, transparent)
+		),
+		rgb(var(--surface-elevated) / 0.96);
 	box-shadow:
 		0 8px 22px rgb(0 0 0 / 0.13),
 		inset 0 0 0 1px rgb(var(--border-default) / 0.55);
@@ -168,10 +178,25 @@
 .traffic-node-card::before {
 	content: "";
 	position: absolute;
-	inset: 0 14px auto;
+	inset: 0 14px auto var(--node-rail);
 	height: 2px;
 	background: var(--node-status);
 	opacity: 0.85;
+}
+/* The lifecycle rail of the Active Tasks row and the Kanban card, brought over
+   as a strip only: the traffic card keeps its full status word in the body, so
+   the rail carries the stage ring and never a second, shorter status word. It is
+   deliberately inert — the scene has no move-to menu and gains none here. */
+.traffic-node-rail {
+	position: absolute;
+	inset: 0 auto 0 0;
+	width: var(--node-rail);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-top: 13px;
+	background: color-mix(in srgb, var(--node-status) 14%, transparent);
+	pointer-events: none;
 }
 .traffic-node-card.is-coordinator {
 	background:
@@ -203,8 +228,8 @@
 .traffic-node-full {
 	display: flex;
 	flex-direction: column;
-	gap: 9px;
-	padding: 15px 17px;
+	gap: 7px;
+	padding: 13px 15px 13px calc(var(--node-rail) + 12px);
 	height: 100%;
 }
 /* Never let flex shrink a clamped block below a whole line — a shrunk line box
@@ -217,8 +242,8 @@
 	display: flex;
 	align-items: center;
 	gap: 7px;
-	font-size: 11px;
-	color: rgb(var(--text-tertiary));
+	font-size: 10px;
+	color: rgb(var(--text-muted));
 }
 .traffic-node-dot {
 	width: 5px;
@@ -240,26 +265,33 @@
 	margin-left: auto;
 	font-family: var(--dev3-mono-stack);
 }
+/* The sidebar's title weight, not a headline: this is a task row that happens to
+   sit on a stage, so it reads at the same pitch as everywhere else in the app. */
 .traffic-node-full > strong {
-	font-size: 18px;
-	line-height: 1.3;
-	font-weight: 600;
+	font-size: 15px;
+	line-height: 1.35;
+	font-weight: 500;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }
+/* Kept as the card's full status word — the rail carries no second, shorter one.
+   Set in the uppercase tracked type the app uses for a lifecycle label. */
 .traffic-node-state {
 	color: var(--node-ink);
-	font-size: 11px;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 .traffic-node-overview {
-	font-size: 13px;
-	line-height: 1.55;
-	color: rgb(var(--text-secondary));
+	font-size: 12px;
+	line-height: 1.5;
+	color: rgb(var(--text-tertiary));
 	display: -webkit-box;
 	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
@@ -283,12 +315,17 @@
 	display: flex;
 	position: absolute;
 	top: 9px;
-	left: 10px;
+	left: calc(var(--node-rail) + 6px);
 	flex-direction: column;
 	gap: 7px;
 	transform-origin: 0 0;
 	transform: scale(var(--node-inverse));
-	width: calc((100% - 20px) / var(--node-inverse));
+	width: calc((100% - var(--node-rail) - 16px) / var(--node-inverse));
+}
+/* Zoomed out, the ring is a few pixels of noise while the coloured strip still
+   reads. The strip stays, the ring waits for the full tier. */
+.traffic-nodes[data-detail="compact"] .traffic-node-rail > * {
+	display: none;
 }
 .traffic-node-compact .traffic-node-head {
 	font-size: 9px;
@@ -302,8 +339,14 @@
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }
+/* Uppercase and tracking cost about a third of the width, and the compact body is
+   the narrowest place the status word lives — "Agent is Working" clipped to
+   "AGENT IS WORK…". A truncated status is worse than an unstyled one. */
 .traffic-node-compact .traffic-node-state {
 	font-size: 10px;
+	text-transform: none;
+	letter-spacing: normal;
+	font-weight: 500;
 }
 .traffic-nodes[data-detail="cell"] .traffic-node-card {
 	background: var(--node-status);


### PR DESCRIPTION
The Experiment 2 task card looked like nothing else in the app: an 18px headline, a status word buried in the body, and the status colour reduced to a 2px hairline. It now reads like the compact Active Tasks row it stands for.

- The lifecycle rail runs down the left edge — a 20px strip (`--node-rail`, the same `w-5` a Kanban card uses) carrying `PipelineRing` with the stage number, reused as-is.
- The status colour washes the whole surface at 6% instead of only marking the top edge; the hairline stays and now starts after the rail.
- Type drops to the app's pitch: title 18px/600 → 15px/500, overview 13px → 12px, status word 10px uppercase with tracking.

Nothing was added to the card and nothing about replay changed. The ring reads the **projected** status at the replay cursor, never today's board, and a card with no recorded past gets the bare strip rather than a ring claiming a stage it never had. No new fields, controls, menus or settings — click still selects, double-click still focuses.

Preserved rather than re-solved: #1694's clipping fix (`CARD_HEIGHT` 234, non-shrinking rows, the confidence row removed with `data-history` retained) and #1693's completion stamp, confetti and reduced-motion behavior. The `cell` tier still degrades to plain coloured tiles, and at the `compact` tier the status word stays plain — uppercase plus tracking clipped it to "AGENT IS WORK…".

Two deliberate differences from the sidebar, both in `decisions/2026/09/10/traffic-card-borrows-the-rail-not-the-component.md`: no upright status word on the rail (its short forms cannot express `Status not recorded` or `Hibernated`, and the full label is asserted as a replay-truthfulness guard), and no priority, labels or agent identity (those are current values, not replayed ones, so adding them would widen the "Overviews and titles are current" footnote). `TaskCardRail` itself is not mounted — it renders two buttons, which would be invalid markup inside the card's own `<button>` and would add actions to the scene.

Verified live in a browser across all three detail tiers (82%, 56%, 23%) with a clean console, plus the traffic, layout, camera, playback, celebration, minimap and Active Tasks sidebar suites.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a4cd7efa-3ff9-4f5e-8600-f34ae278e549) · `dev3://task/a4cd7efa-3ff9-4f5e-8600-f34ae278e549` _(dev3 added this footer — turn it off in Settings → Tasks.)_
