### PR TITLE
Space dropped file paths off typed terminal text

### DIFF
--- a/change-logs/2026/09/10/fix-space-dropped-terminal-paths.md
+++ b/change-logs/2026/09/10/fix-space-dropped-terminal-paths.md
@@ -1,0 +1,3 @@
+Short: Dropped image paths no longer glue to text
+
+Dropping a file into a terminal now inserts its worktree path with a space on each side, so it no longer glues onto whatever you had already typed — and no extra space is added when the cursor already sits after one.

--- a/src/mainview/TerminalView.tsx
+++ b/src/mainview/TerminalView.tsx
@@ -47,6 +47,7 @@ import { isLargeTextPaste, uploadPastedText } from "./utils/uploadPastedText";
 import { imageFilesFromClipboard } from "./utils/clipboardImageFiles";
 import { createAnsiThemeFilter } from "./utils/ansi-theme-adapt";
 import { submitPastedText } from "./terminal-submit";
+import { spaceDroppedPaths } from "./terminal-drop-spacing";
 import { createFilePathLinkProvider, type FilePathLinkProvider } from "./terminal-file-links";
 import { createOsc8Tracker, createOsc8LinkProvider } from "./terminal-osc8-links";
 import { cellFromMouseEvent } from "./terminal-cell-hit";
@@ -2583,7 +2584,9 @@ function TerminalView({ ptyUrl, taskId, projectId, onReady, onNativeStatus, onSe
 		}
 
 		if (wsRef.current?.readyState === WebSocket.OPEN) {
-			wsRef.current.send(text);
+			const cursor = termRef.current?.buffer?.active;
+			const line = cursor?.getLine?.((cursor.baseY ?? 0) + (cursor.cursorY ?? 0));
+			wsRef.current.send(spaceDroppedPaths(text, line, cursor?.cursorX ?? 0));
 		}
 		try { termRef.current?.focus(); } catch { /* disposed */ }
 	}

--- a/src/mainview/__tests__/TerminalView.test.tsx
+++ b/src/mainview/__tests__/TerminalView.test.tsx
@@ -682,8 +682,29 @@ describe("TerminalView – drag-and-drop", () => {
 			});
 		});
 		await waitFor(() => {
-			expect(lastWebSocket?.send).toHaveBeenCalledWith("/tmp/uploads/notes.txt");
+			expect(lastWebSocket?.send).toHaveBeenCalledWith("/tmp/uploads/notes.txt ");
 		});
+	});
+
+	it("spaces the pasted path off text the user already typed", async () => {
+		mockedUploadFileBase64.mockResolvedValue({ path: "/tmp/uploads/shot.png" } as any);
+		// Cursor sits right after "look at" on the current input line.
+		mockBufferActive.cursorX = 7;
+		const cells = "look at";
+		(mockBufferActive as Record<string, unknown>).getLine = () => ({
+			getCell: (x: number) => (cells[x] ? { getChars: () => cells[x], getWidth: () => 1 } : undefined),
+		});
+
+		await renderAndSetup();
+		const terminal = document.querySelector("[data-terminal='true']")!;
+		dispatchDrop(terminal, [new File(["shot"], "shot.png", { type: "image/png", lastModified: 1711600000000 })]);
+
+		await waitFor(() => {
+			expect(lastWebSocket?.send).toHaveBeenCalledWith(" /tmp/uploads/shot.png ");
+		});
+
+		mockBufferActive.cursorX = 0;
+		delete (mockBufferActive as Record<string, unknown>).getLine;
 	});
 });
 

--- a/src/mainview/__tests__/terminal-drop-spacing.test.ts
+++ b/src/mainview/__tests__/terminal-drop-spacing.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { spaceDroppedPaths, type DropSpacingLine } from "../terminal-drop-spacing";
+
+/** A line whose cells come from `text`; a wide char occupies two cells. */
+function line(text: string): DropSpacingLine {
+	const cells: { chars: string; width: number }[] = [];
+	for (const ch of text) {
+		const width = ch.codePointAt(0)! > 0xffff ? 2 : 1;
+		cells.push({ chars: ch, width });
+		if (width === 2) cells.push({ chars: "", width: 0 });
+	}
+	return { getCell: (x) => (cells[x] ? { getChars: () => cells[x].chars, getWidth: () => cells[x].width } : undefined) };
+}
+
+describe("spaceDroppedPaths", () => {
+	it("adds a space on both sides when the cursor sits after typed text", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", line("look at"), 7)).toBe(" /tmp/a.png ");
+	});
+
+	it("does not double a space the user already typed", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", line("look at "), 8)).toBe("/tmp/a.png ");
+	});
+
+	it("adds no leading space at the start of the line", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", line(""), 0)).toBe("/tmp/a.png ");
+	});
+
+	it("treats a blank cell as a separator", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", line("hi"), 5)).toBe("/tmp/a.png ");
+	});
+
+	it("keeps a space after a wide char whose spacer cell reads blank", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", line("see 🙂"), 6)).toBe(" /tmp/a.png ");
+	});
+
+	it("separates a second drop from the first", () => {
+		const first = spaceDroppedPaths("/tmp/a.png", line("look"), 4);
+		expect(first).toBe(" /tmp/a.png ");
+		// The first drop left a trailing space, so the second adds none of its own.
+		expect(spaceDroppedPaths("/tmp/b.png", line(`look${first}`), 4 + first.length)).toBe("/tmp/b.png ");
+	});
+
+	it("falls back to no leading space when the buffer is unreadable", () => {
+		expect(spaceDroppedPaths("/tmp/a.png", undefined, 12)).toBe("/tmp/a.png ");
+	});
+
+	it("never touches spaces inside the dropped text", () => {
+		expect(spaceDroppedPaths("/tmp/a.png /tmp/b.png", line("x"), 1)).toBe(" /tmp/a.png /tmp/b.png ");
+	});
+});

--- a/src/mainview/terminal-drop-spacing.ts
+++ b/src/mainview/terminal-drop-spacing.ts
@@ -1,0 +1,27 @@
+/** The slice of ghostty's buffer API needed to read the cell left of the cursor. */
+export interface DropSpacingCell {
+	getChars(): string;
+	getWidth(): number;
+}
+
+export interface DropSpacingLine {
+	getCell(x: number): DropSpacingCell | undefined;
+}
+
+function needsLeadingSpace(line: DropSpacingLine | undefined, cursorX: number): boolean {
+	if (!line || cursorX <= 0) return false;
+	const chars = line.getCell(cursorX - 1)?.getChars() ?? "";
+	if (chars.trim() !== "") return true;
+	// A wide char (emoji, CJK) leaves a blank spacer cell behind it, so a blank
+	// right after one is still real content the path must not glue onto.
+	return chars === "" && cursorX >= 2 && (line.getCell(cursorX - 2)?.getWidth() ?? 1) === 2;
+}
+
+/**
+ * Separate dropped paths from what the user already typed: a leading space
+ * unless the cursor already sits after one, and always a trailing space so the
+ * next keystroke does not glue onto the path.
+ */
+export function spaceDroppedPaths(text: string, line: DropSpacingLine | undefined, cursorX: number): string {
+	return (needsLeadingSpace(line, cursorX) ? " " : "") + text + " ";
+}


### PR DESCRIPTION
Dropping a file into a task terminal sent the uploaded worktree path to the PTY raw, so with `look at` already typed on the input line the agent received `look at/tmp/…/shot.png` as one token — and the next keystroke glued onto the other end of the path.

`handleDrop` in `src/mainview/TerminalView.tsx` now routes the payload through a new pure helper, `src/mainview/terminal-drop-spacing.ts`. It reads the cell immediately left of the cursor from ghostty's buffer and adds a leading space only when one is needed: a visible character gets a space, a space the user already typed does not, the start of the line does not, and a blank cell right after a wide character (emoji, CJK) does — that blank is the wide char's spacer, not a separator. When the buffer cannot be read (terminal being recreated) no leading space is guessed. The trailing space is unconditional, because cells right of the cursor are always blank on screen and a typed space cannot be told from empty there; a second drop then reads the space the first one left and adds none of its own. Spaces inside the path are untouched — the `\ ` escaping happens earlier and is unchanged.

The four textarea surfaces (`insertPathAtCursor` in CreateTaskModal, TaskDetailModal, ScheduleMessageModal, NoteItem) already insert the path on its own line and were never affected, so the change is confined to the terminal.

Covered by a new unit suite (mid-text, start of line, existing space, blank cell, emoji spacer, two drops in a row, unreadable buffer, spaces inside the dropped text) plus an updated and one new TerminalView drop test. Verified live in a browser against a scoped QA board: the pre-fix build produced `echo look at/tmp/…/shot.png`, the fixed build `echo look at /tmp/…/shot.png `.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ddc835fd-157c-4ef4-a1ed-570f377e0f3f) · `dev3://task/ddc835fd-157c-4ef4-a1ed-570f377e0f3f` _(dev3 added this footer — turn it off in Settings → Tasks.)_
