### PR TITLE
Suppress the agent-message toast on the Agent traffic screen

### DIFF
--- a/change-logs/2026/09/10/fix-suppress-agent-message-toast-on-traffic-screen.md
+++ b/change-logs/2026/09/10/fix-suppress-agent-message-toast-on-traffic-screen.md
@@ -1,0 +1,3 @@
+Short: No message toast on the traffic screen
+
+The violet agent-message toast no longer appears in a window that is already showing the Agent traffic screen, where the same message lands in full. Other windows, other routes, and every unrelated toast are untouched.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1672,6 +1672,10 @@ function App() {
 				preview: string;
 			};
 			if (!taskId || !preview) return;
+			// This window is already showing the traffic screen, where the message
+			// lands in full — a toast previewing it would cover its own destination.
+			// Per window, via this renderer's own route: another window keeps its toast.
+			if (getAgentTrafficEnabled() && routeRef.current.screen === "agent-traffic") return;
 			// Either side sensitive on camera drops the whole toast: it names both.
 			if (isProjectSilencedForDisplay(projectId) || isProjectSilencedForDisplay(fromProjectId)) return;
 			const from = [`#${fromSeq}`, fromTitle].filter(Boolean).join(" ");

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1545,10 +1545,10 @@ describe("App keyboard shortcuts", () => {
 		it("stays put, and adds no history entry, when the click lands on the screen itself", async () => {
 			await renderWithBoard();
 			enableTrafficBeta();
+			dispatchAgentMessage();
 			await userEvent.keyboard("{Shift>}{Meta>}m{/Meta}{/Shift}");
 			expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
 
-			dispatchAgentMessage();
 			await userEvent.click(await toastButton());
 
 			expect(screen.getAllByTestId("agent-traffic-screen")).toHaveLength(1);
@@ -1589,6 +1589,46 @@ describe("App keyboard shortcuts", () => {
 				expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t-receiver");
 			});
 			expect(screen.queryByTestId("agent-traffic-screen")).toBeNull();
+		});
+
+		// The traffic screen already shows the message in full; a toast on top of it
+		// previews what is right there and covers its own destination.
+		it("raises no toast while this window is on the traffic screen", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			await userEvent.keyboard("{Shift>}{Meta>}m{/Meta}{/Shift}");
+			expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
+
+			dispatchAgentMessage();
+
+			expect(screen.queryByText("#7 Coordinator → #42 Receiver")).not.toBeInTheDocument();
+		});
+
+		// Off the screen the toast is the only signal there is — the beta being on
+		// must not silence it board-wide.
+		it("still raises the toast on another route with the beta on", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			dispatchAgentMessage();
+
+			expect(await toastButton()).toBeInTheDocument();
+		});
+
+		// Suppression is about THIS message on ITS screen, not about muting the
+		// traffic screen: an ordinary `dev3 notify` still gets through there.
+		it("leaves an unrelated CLI toast visible on the traffic screen", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			await userEvent.keyboard("{Shift>}{Meta>}m{/Meta}{/Shift}");
+			expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
+
+			act(() => {
+				window.dispatchEvent(new CustomEvent("rpc:cliToast", {
+					detail: { taskId: "t-receiver", projectId: "p1", message: "build finished", level: "success" },
+				}));
+			});
+
+			expect(await screen.findByRole("button", { name: /build finished/ })).toBeInTheDocument();
 		});
 
 		it("drops the toast when the SENDER's project is sensitive on camera", async () => {


### PR DESCRIPTION
The violet agent-message toast (`dev3 message` from one agent to another) no longer appears in a window that is already showing the Agent traffic screen, where the same message lands in full — the preview was covering its own destination.

One early return in the `rpc:agentMessage` handler in `src/mainview/App.tsx`, before the toast is built:

```ts
if (getAgentTrafficEnabled() && routeRef.current.screen === "agent-traffic") return;
```

The route is read from `routeRef`, this renderer's own state, so the decision is per window — another window on the board keeps its toast. The flag check preserves the feature-disabled fallback: with the beta off nothing is suppressed and the click still falls back to the receiving task.

Untouched: delivery, `rpc:agentMessageLogChanged` (history, unread, arrival tracking), logging, ordinary `dev3 notify` success/info/error toasts, OS desktop notifications, and the toast's existing click behaviour. No new setting, no schema change.

Three new tests cover suppression on the traffic route, the toast still being raised on another route with the beta on, and an unrelated CLI toast still showing on the traffic screen. Verified live in headless Chromium on a scoped QA board: same window, same event — suppressed on the traffic screen, present on the dashboard.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4b499bf0-0f9c-4be2-b2d6-95131d6cac16) · `dev3://task/4b499bf0-0f9c-4be2-b2d6-95131d6cac16` _(dev3 added this footer — turn it off in Settings → Tasks.)_
