### PR TITLE
Drop the Agent traffic route's own title row

### DIFF
--- a/change-logs/2026/09/10/refactor-traffic-route-header.md
+++ b/change-logs/2026/09/10/refactor-traffic-route-header.md
@@ -1,0 +1,1 @@
+Agent traffic no longer draws its own title row: the route's breadcrumb already names the screen, so the live/history readout and the stage action (Replay in Experiment 2, the animation toggle in Experiment 1) now ride at the end of the existing filter toolbar. The graph gets that whole row of height back, and on a phone the stage action stays reachable instead of being hidden.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -752,6 +752,68 @@ describe("AgentTrafficScreen kind filter gate", () => {
 	});
 });
 
+/**
+ * The screen is a route the app's own breadcrumb already names, so it carries no
+ * title row of its own — the readout and the stage action ride in the toolbar
+ * the other view controls live in. What these guard is that the row is gone AND
+ * that nothing it used to carry got dropped with it.
+ */
+describe("AgentTrafficScreen route header", () => {
+	const tail = () =>
+		document.querySelector(".traffic-toolbar > .traffic-toolbar-tail");
+
+	it("has no title row, and keeps the readout and Replay in the toolbar", async () => {
+		setPage([row()]);
+		renderLog();
+		await messageRows(1);
+		expect(document.querySelector(".traffic-header")).toBeNull();
+		expect(screen.queryByRole("heading", { name: "Agent traffic" })).toBeNull();
+		const toolbarTail = tail();
+		expect(toolbarTail).not.toBeNull();
+		expect(toolbarTail?.querySelector(".traffic-live")?.textContent).toMatch(
+			/^(Live|History)$/,
+		);
+		expect(
+			within(toolbarTail as HTMLElement).getByRole("button", {
+				name: "Replay",
+			}),
+		).toBeTruthy();
+	});
+
+	it("still restarts the replay from the toolbar's Replay", async () => {
+		const counter = () =>
+			document.querySelector(".traffic-event-counter")?.textContent;
+		setPage([
+			row({ at: new Date(Date.now() - 20 * 60000).toISOString(), subject: "First" }),
+			row({ subject: "Second" }),
+		]);
+		renderLog();
+		await waitFor(() => expect(counter()).toBe("1 / 2"));
+		// Live drops the cursor, so a counter back at the first event can only come
+		// from the button restarting the replay.
+		await userEvent.click(screen.getByRole("button", { name: "Live" }));
+		await waitFor(() => expect(counter()).not.toBe("1 / 2"));
+		await userEvent.click(screen.getByRole("button", { name: "Replay" }));
+		await waitFor(() => expect(counter()).toBe("1 / 2"));
+	});
+
+	it("carries Experiment 1's animation toggle in the toolbar", async () => {
+		settings.value = { agentTrafficExperiment: "1" };
+		setPage([row()]);
+		renderLog();
+		await waitFor(() => expect(tail()).not.toBeNull());
+		const toggle = within(tail() as HTMLElement).getByRole("button", {
+			name: "Pause animation",
+		});
+		await userEvent.click(toggle);
+		expect(
+			within(tail() as HTMLElement).getByRole("button", {
+				name: "Resume animation",
+			}),
+		).toHaveAttribute("aria-pressed", "true");
+	});
+});
+
 describe("AgentTrafficScreen presentation picker", () => {
 	const nodeCards = () => screen.queryAllByTestId("traffic-node-card");
 	const orbit = () => screen.queryByLabelText("Project traffic map");

--- a/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
@@ -10,7 +10,6 @@ import { useReducedMotion } from "../../utils/useReducedMotion";
 import { getStatusLabel } from "../../utils/statusLabel";
 import BottomSheet from "../BottomSheet";
 import Select from "../Select";
-import { AgentTrafficIcon } from "../HeaderIcons";
 import TrafficOrbit from "./TrafficOrbit";
 import TrafficNodes from "./TrafficNodes";
 import TrafficPlayback from "./TrafficPlayback";
@@ -658,6 +657,12 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 			</button>
 		);
 	}
+	const liveLabel =
+		data.loading || data.historyLoading
+			? t("traffic.loading")
+			: (experiment === "2" ? playback.index < 0 && !calendarDay : until === null)
+				? t("traffic.orbit.live")
+				: t("traffic.orbit.history");
 	const filters = (
 		<>
 			<Select
@@ -708,46 +713,6 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 			<span className="sr-only" role="status">
 				{t.plural("traffic.orbit.messageCount", visible.length)}
 			</span>
-			<header className="traffic-header">
-				<AgentTrafficIcon className="w-5 h-5 text-agent" />
-				<h2>{t("traffic.label")}</h2>
-				<div className="traffic-header-tail">
-					<span className="traffic-live" role="status">
-						{data.loading || data.historyLoading
-							? t("traffic.loading")
-							: (
-										experiment === "2"
-											? playback.index < 0 && !calendarDay
-											: until === null
-								  )
-								? t("traffic.orbit.live")
-								: t("traffic.orbit.history")}
-					</span>
-					{experiment === "2" && (
-						<button
-							className="traffic-replay-start"
-							onClick={() => {
-								clearSelection();
-								setShowInspector(false);
-								setFollowRequest((value) => value + 1);
-								playback.restart();
-							}}
-							disabled={!playback.events.length}
-						>
-							<TrafficIcon name="replay" />
-							{t("traffic.replay.restart")}
-						</button>
-					)}
-					{experiment === "1" && (
-						<button
-							onClick={() => setPaused((value) => !value)}
-							aria-pressed={paused}
-						>
-							{t(paused ? "traffic.orbit.resume" : "traffic.orbit.pause")}
-						</button>
-					)}
-				</div>
-			</header>
 			<div className="traffic-toolbar">
 				{/* One control per axis, in the toolbar the other view controls already
 				    live in — never a second filter cluster. It renders only once the
@@ -791,6 +756,40 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 						{t("traffic.orbit.messages")}
 					</button>
 				)}
+				{/* The route's breadcrumb already names this screen, so it owns no title
+				    row of its own; the live/history readout and the one stage action ride
+				    at the end of the toolbar the other view controls already live in. */}
+				<div className="traffic-toolbar-tail">
+					<span className="traffic-live" role="status" title={liveLabel}>
+						{liveLabel}
+					</span>
+					{experiment === "2" && (
+						<button
+							className="traffic-replay-start"
+							onClick={() => {
+								clearSelection();
+								setShowInspector(false);
+								setFollowRequest((value) => value + 1);
+								playback.restart();
+							}}
+							disabled={!playback.events.length}
+							aria-label={t("traffic.replay.restart")}
+						>
+							<TrafficIcon name="replay" />
+							<span className="traffic-action-label">
+								{t("traffic.replay.restart")}
+							</span>
+						</button>
+					)}
+					{experiment === "1" && (
+						<button
+							onClick={() => setPaused((value) => !value)}
+							aria-pressed={paused}
+						>
+							{t(paused ? "traffic.orbit.resume" : "traffic.orbit.pause")}
+						</button>
+					)}
+				</div>
 			</div>
 			{experiment === "2" && narrowControls && (
 				<BottomSheet

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -23,14 +23,6 @@
 	position: relative;
 	background: rgb(var(--surface-base));
 }
-.traffic-view[data-experiment="2"] .traffic-header {
-	min-height: 50px;
-	padding: 8px 20px;
-	background: rgb(var(--surface-raised) / 0.55);
-}
-.traffic-view[data-experiment="2"] .traffic-header h2 {
-	font-size: 17px;
-}
 .traffic-view[data-experiment="2"] .traffic-summary {
 	gap: 18px;
 	padding: 10px 22px;
@@ -68,8 +60,12 @@
 	color: rgb(var(--text-secondary));
 	background: rgb(var(--surface-elevated));
 }
-.traffic-header-tail .traffic-replay-start {
+.traffic-toolbar-tail .traffic-replay-start {
 	background: rgb(var(--accent-fill));
+	color: white;
+}
+.traffic-toolbar-tail .traffic-replay-start:hover:not(:disabled) {
+	background: rgb(var(--accent-fill-hover));
 	color: white;
 }
 .traffic-nodes {
@@ -821,9 +817,6 @@
 	.traffic-view[data-experiment="2"] .traffic-stat {
 		display: none;
 	}
-	.traffic-view[data-experiment="2"] .traffic-header {
-		padding: 8px 12px;
-	}
 	.traffic-view[data-experiment="2"] .traffic-toolbar {
 		gap: 6px;
 		padding: 8px 12px;
@@ -979,6 +972,26 @@
 @media (max-width: 900px) {
 	.traffic-view[data-experiment="2"] .traffic-toolbar {
 		flex-wrap: nowrap;
+	}
+	/* Between 700 and 900 this toolbar never wraps, so the tail shrinks instead:
+	   the readout keeps its dot and ellipsizes, and Replay drops to its icon (the
+	   label stays as its accessible name and tooltip). Below 700 there is no room
+	   left to shrink into, and the wrap rule below gives the tail its own row. */
+	.traffic-view[data-experiment="2"] .traffic-toolbar-tail {
+		gap: 6px;
+		flex: 0 1 auto;
+	}
+	.traffic-view[data-experiment="2"] .traffic-toolbar-tail .traffic-live {
+		max-width: 92px;
+		font-size: 11px;
+	}
+	.traffic-view[data-experiment="2"]
+		.traffic-toolbar-tail
+		.traffic-action-label {
+		display: none;
+	}
+	.traffic-view[data-experiment="2"] .traffic-replay-start {
+		padding: 6px 8px;
 	}
 	.traffic-view[data-experiment="2"] .traffic-experiment {
 		min-width: 0;
@@ -1245,5 +1258,22 @@
 	}
 	.traffic-celebration-badge {
 		animation: none;
+	}
+}
+
+/* Phone width: the row of filter controls alone fills it, so the readout and the
+   stage action take a row of their own rather than being squeezed out of the
+   nowrap toolbar above. The label comes back with the space. */
+@media (max-width: 700px) {
+	.traffic-view[data-experiment="2"] .traffic-toolbar {
+		flex-wrap: wrap;
+	}
+	.traffic-view[data-experiment="2"] .traffic-toolbar-tail .traffic-live {
+		max-width: none;
+	}
+	.traffic-view[data-experiment="2"]
+		.traffic-toolbar-tail
+		.traffic-action-label {
+		display: inline;
 	}
 }

--- a/src/mainview/components/agent-traffic/traffic-orbit.css
+++ b/src/mainview/components/agent-traffic/traffic-orbit.css
@@ -47,33 +47,23 @@
 	cursor: default;
 	opacity: 0.5;
 }
-.traffic-header {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	min-height: 60px;
-	padding: 12px 20px;
-	background: rgb(var(--surface-overlay) / 0.7);
-	border-bottom: 1px solid rgb(var(--border-default) / 0.5);
-}
-.traffic-header h2 {
-	margin: 0;
-	font-size: 18px;
-	font-weight: 600;
-}
 .traffic-orbit-name {
 	padding: 6px 14px;
 	color: rgb(var(--accent));
 	background: rgb(var(--accent) / 0.12);
 	border-radius: 8px;
 }
-.traffic-header-tail {
+/* Sized against `.traffic-toolbar > div`, which caps the filter controls' width
+   and would otherwise squeeze the tail too. */
+.traffic-toolbar > .traffic-toolbar-tail {
 	display: flex;
 	align-items: center;
 	gap: 12px;
 	margin-left: auto;
+	min-width: 0;
+	max-width: none;
 }
-.traffic-header-tail button,
+.traffic-toolbar-tail button,
 .traffic-timeline button,
 .traffic-inspector-heading button,
 .traffic-detail-actions button,
@@ -84,7 +74,7 @@
 	background: rgb(var(--surface-elevated));
 	color: rgb(var(--text-secondary));
 }
-.traffic-header-tail button:hover,
+.traffic-toolbar-tail button:hover,
 .traffic-timeline button:hover,
 .traffic-inspector button:hover {
 	background: rgb(var(--surface-elevated-hover));
@@ -93,6 +83,8 @@
 .traffic-live {
 	color: rgb(var(--success));
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .traffic-live::before {
 	content: "";
@@ -514,21 +506,13 @@
 	}
 }
 @media (max-width: 700px) {
-	.traffic-header {
-		padding: 8px 12px;
-		min-height: 48px;
-		gap: 8px;
-	}
-	.traffic-header h2 {
-		font-size: 14px;
-	}
 	.traffic-orbit-name {
 		display: none;
 	}
-	.traffic-header-tail {
+	.traffic-toolbar > .traffic-toolbar-tail {
 		gap: 6px;
 	}
-	.traffic-header-tail button {
+	.traffic-toolbar-tail button {
 		padding: 5px;
 	}
 	.traffic-toolbar {
@@ -609,16 +593,9 @@
 }
 
 @media (max-width: 700px) {
-	.traffic-header > svg,
-	.traffic-header h2,
-	.traffic-header-tail > button:last-child {
-		display: none;
-	}
-	.traffic-header {
-		min-height: 40px;
-		padding: 4px 12px;
-	}
-	.traffic-header-tail {
+	/* The wrapped toolbar gives the tail its own row instead of dropping the
+	   stage action, which the old header row hid outright at this width. */
+	.traffic-toolbar > .traffic-toolbar-tail {
 		width: 100%;
 		justify-content: space-between;
 		margin-left: 0;


### PR DESCRIPTION
The Agent traffic screen is a routed destination whose breadcrumb already names it, so its own title row (icon + `Agent traffic` heading) was a duplicate that cost the graph a whole row of height. The row is removed and everything it carried moves to a right-aligned tail at the end of the filter toolbar the other view controls already live in:

- the live / history / loading readout (`role="status"`, logic unchanged, extracted to a `liveLabel` const),
- Experiment 2's `Replay` (accent fill kept),
- Experiment 1's `Pause animation` / `Resume animation` toggle.

No new controls, no duplicated controls, no graph or card changes. `.traffic-header*` rules are deleted and `.traffic-header-tail` becomes `.traffic-toolbar-tail`, sized as `.traffic-toolbar > .traffic-toolbar-tail` so the toolbar's `> div` width cap does not squeeze it.

Measured in headless Chromium against a scoped dev-server board:

| Width | Before | After |
|---|---|---|
| 1600×1000, E2 | header row 50 px, graph area 662 px | no header row, graph area 712 px |
| 880 px, E2 | header row + toolbar | one toolbar row, readout ellipsizes, `Replay` drops to its icon (label stays as `aria-label` + tooltip), no h-scroll |
| 420 px, E2 | header row showed only the readout — icon, title and `Replay` were `display:none` | toolbar wraps, the tail gets its own row, `Replay` reachable |

That phone width needed two thresholds rather than one: between 700 and 900 px the Experiment 2 toolbar is deliberately `flex-wrap: nowrap`, so the tail shrinks inside the row; below 700 px there is nothing left to shrink into and an explicit wrap gives it a row of its own. The intermediate state overlapped the filters and the whole vitest suite stayed green through it — only the browser showed it.

Three tests in `agent-traffic-ui.test.tsx` guard the result: no `.traffic-header` and no `Agent traffic` heading; `Replay` still restarts the replay (proved through a Live round trip, not by presence); Experiment 1's toggle lives in the tail and flips `aria-pressed`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4eabdb8b-f264-4122-8392-b23df3480197) · `dev3://task/4eabdb8b-f264-4122-8392-b23df3480197` _(dev3 added this footer — turn it off in Settings → Tasks.)_
