### PR TITLE
Open agent traffic on Live with Follow instead of autoplaying the last hour

### DIFF
--- a/change-logs/2026/09/10/fix-traffic-enters-live-follow.md
+++ b/change-logs/2026/09/10/fix-traffic-enters-live-follow.md
@@ -1,0 +1,3 @@
+Short: Agent traffic opens on Live
+
+Opening Agent traffic now lands on Live with the camera following instead of automatically replaying the trailing hour; replay is still one press of Play (or the toolbar's Replay), and it still starts at the beginning of the window.

--- a/decisions/2026/09/08/agent-traffic-becomes-a-destination.md
+++ b/decisions/2026/09/08/agent-traffic-becomes-a-destination.md
@@ -1,5 +1,12 @@
 # Agent traffic becomes a destination, and entry replays the trailing hour
 
+> Partly superseded on 2026-09-10 by
+> `decisions/2026/09/10/agent-traffic-enters-live-not-replaying.md`: entry no longer
+> autoplays the trailing hour — the screen opens on Live with the camera following, and
+> replay is started deliberately. Everything else here (the route, `scopeProjectId`, the
+> nav-budget exception, the deleted overlay) still holds, as does the `ENTRY_WINDOW =
+> "hour"` period default.
+
 ## Context
 
 Agent traffic shipped as a fullscreen modal: a portal with a focus trap, an Escape

--- a/decisions/2026/09/10/agent-traffic-enters-live-not-replaying.md
+++ b/decisions/2026/09/10/agent-traffic-enters-live-not-replaying.md
@@ -1,0 +1,40 @@
+# Agent traffic enters on Live with Follow, not on an automatic replay
+
+## Context
+
+`decisions/2026/09/08/agent-traffic-becomes-a-destination.md` ruled that entering the
+Agent traffic route autoplays the trailing hour once. Living with it reversed the
+ruling: the reader opens the screen to see what is happening *now*, and an automatic
+replay takes the stage — the cursor sits in the past, cards are reconstructed from
+recorded board moves, and the first interaction anyone has is stopping something they
+never asked to start.
+
+## Decision
+
+Entry is Live. `AgentTrafficScreen.tsx` drops the one-shot autoplay effect, its
+`autoplayed` ref, `startEntryReplay`, and the `useReducedMotion` read that only served
+it. With no cursor placed, `useTrafficPlayback` stays at `index === -1`, which is Live,
+and `TrafficNodes` keeps its `follow` default of `true` — so the camera follows live
+traffic on arrival with no new state and no new control.
+
+Replay is untouched and still explicit: the transport's Play, the toolbar's `Replay`,
+and Space all call `playPause()`, which starts at the window's first event. The period
+default (`ENTRY_WINDOW = "hour"`), the project/time filters, both experiments, manual
+camera interaction and the notification/history data are unchanged.
+`useTrafficPlayback.seekToTime` keeps its contract and its tests; it simply has no
+caller on the entry path any more.
+
+## Risks
+
+- A reader who liked the automatic recap now has to press Play. That is the point of
+  the reversal, and the control is the most prominent one in the transport.
+- Seq 1833 is adding a notification arm to the same screen's readiness gating. The gate
+  that arm was meant to feed (the autoplay latch) no longer exists, so nothing about
+  entry depends on when notifications settle.
+
+## Alternatives considered
+
+- **A setting to choose entry mode.** Rejected: it is one small default, and a toggle
+  for it is exactly the control creep the UX bible warns about.
+- **Keep the autoplay under `prefers-reduced-motion` only.** Rejected: the objection is
+  that the stage is hijacked, not that it moves.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -523,12 +523,12 @@ describe("AgentTrafficScreen live orbit", () => {
 // Two presentations, one feature. The picker chooses between them; the Settings
 // toggle still decides whether any of it exists (agent-traffic-flag.test.tsx).
 /**
- * Entering the screen is its own contract: the trailing hour, the cursor at that
- * hour's start, and the replay started exactly once. What these guard is the
- * "once" — the window's start slides with the clock and a live message can land
- * at any moment, so a naive effect restarts the replay under the user's hands.
+ * Entering the screen is its own contract: Live, with the camera following, and
+ * nothing playing. The screen used to replay the trailing hour by itself, which
+ * took the stage before the reader had asked for anything. Replay is still there
+ * — it just has to be asked for, and it still starts at the window's beginning.
  */
-describe("AgentTrafficScreen entry replay", () => {
+describe("AgentTrafficScreen entry", () => {
 	/** The tests' default is reduced-motion; motion has to be asked for. */
 	function allowMotion() {
 		return vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
@@ -539,8 +539,12 @@ describe("AgentTrafficScreen entry replay", () => {
 
 	const counter = () => document.querySelector(".traffic-event-counter")?.textContent;
 	const playLabel = () => screen.getByTestId("traffic-play").getAttribute("aria-label");
+	const liveActive = () =>
+		screen.getByRole("button", { name: "Live" }).className.includes("is-active");
+	const following = () =>
+		document.querySelector(".traffic-nodes")?.getAttribute("data-follow");
 
-	it("starts the trailing hour from its first message, playing", async () => {
+	it("opens on Live with the camera following and no replay running", async () => {
 		const media = allowMotion();
 		try {
 			setPage([
@@ -549,51 +553,83 @@ describe("AgentTrafficScreen entry replay", () => {
 				row({ subject: "Newest" }),
 			]);
 			renderLog();
-			await waitFor(() => expect(playLabel()).toBe("Pause replay"));
-			expect(counter()).toBe("1 / 3");
-			expect(document.querySelector(".traffic-event-subject")?.textContent).toContain("Oldest in the hour");
+			await waitFor(() => expect(counter()).toBe("3 / 3"));
+			// No cursor: the readout stands on the newest event, Live is the active
+			// mode, the transport is idle and the stage is following.
+			expect(playLabel()).toBe("Play replay");
+			expect(liveActive()).toBe(true);
+			expect(following()).toBe("true");
+			expect(document.querySelector(".traffic-event-subject")?.textContent).toContain("Newest");
+			// A settled load with motion allowed is exactly where the old autoplay
+			// fired; nothing may start it after the fact either.
+			await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+			expect(playLabel()).toBe("Play replay");
+			expect(liveActive()).toBe(true);
 		} finally {
 			media.mockRestore();
 		}
 	});
 
-	it("does not restart when a live message arrives mid-replay", async () => {
+	it("keeps taking live arrivals while it sits on Live", async () => {
+		const media = allowMotion();
+		try {
+			setPage([row({ at: new Date(Date.now() - 30 * 60000).toISOString(), subject: "First" })]);
+			renderLog();
+			await waitFor(() => expect(counter()).toBe("1 / 1"));
+			setPage([...page.value.rows, row({ subject: "Arrived while watching" })]);
+			act(() => noteTrafficArrival("proj-1"));
+			await waitFor(() => expect(counter()).toBe("2 / 2"));
+			expect(playLabel()).toBe("Play replay");
+			expect(liveActive()).toBe(true);
+			expect(document.querySelector(".traffic-event-subject")?.textContent).toContain(
+				"Arrived while watching",
+			);
+		} finally {
+			media.mockRestore();
+		}
+	});
+
+	it("still replays the window from its first event when Play is pressed", async () => {
 		const media = allowMotion();
 		try {
 			setPage([
-				row({ at: new Date(Date.now() - 30 * 60000).toISOString(), subject: "First" }),
-				row({ at: new Date(Date.now() - 10 * 60000).toISOString(), subject: "Second" }),
+				row({ at: new Date(Date.now() - 50 * 60000).toISOString(), subject: "Oldest in the hour" }),
+				row({ at: new Date(Date.now() - 20 * 60000).toISOString(), subject: "Middle" }),
+				row({ subject: "Newest" }),
 			]);
 			renderLog();
-			await waitFor(() => expect(playLabel()).toBe("Pause replay"));
-			fireEvent.click(screen.getByRole("button", { name: "Next message" }));
-			expect(counter()).toBe("2 / 2");
-			setPage([...page.value.rows, row({ subject: "Arrived while watching" })]);
-			act(() => noteTrafficArrival("proj-1"));
-			// The replay's event list is frozen, so the cursor stays where the user
-			// left it and the arrival does not extend the run under them.
-			await act(async () => { await Promise.resolve(); });
-			expect(counter()).toBe("2 / 2");
-			expect(playLabel()).toBe("Play replay");
-			// It did land in the data, though — Live shows all three.
+			await waitFor(() => expect(counter()).toBe("3 / 3"));
+			await userEvent.click(screen.getByTestId("traffic-play"));
+			expect(counter()).toBe("1 / 3");
+			expect(playLabel()).toBe("Pause replay");
+			expect(liveActive()).toBe(false);
+			expect(document.querySelector(".traffic-event-subject")?.textContent).toContain("Oldest in the hour");
+			// And Live hands the stage back.
 			await userEvent.click(screen.getByRole("button", { name: "Live" }));
 			expect(counter()).toBe("3 / 3");
+			expect(playLabel()).toBe("Play replay");
 		} finally {
 			media.mockRestore();
 		}
 	});
 
-	it("leaves an empty hour parked, and keeps it parked when a message lands", async () => {
+	it("re-entering the screen comes back on Live, not on the last cursor", async () => {
 		const media = allowMotion();
 		try {
-			setPage([row({ at: new Date(Date.now() - 5 * 3600000).toISOString(), subject: "Hours ago" })]);
+			setPage([
+				row({ at: new Date(Date.now() - 50 * 60000).toISOString(), subject: "Oldest in the hour" }),
+				row({ subject: "Newest" }),
+			]);
+			const first = renderLog();
+			await waitFor(() => expect(counter()).toBe("2 / 2"));
+			await userEvent.click(screen.getByTestId("traffic-play"));
+			expect(counter()).toBe("1 / 2");
+			first.unmount();
 			renderLog();
-			await waitFor(() => expect(counter()).toBe("0 / 0"));
+			await waitFor(() => expect(counter()).toBe("2 / 2"));
 			expect(playLabel()).toBe("Play replay");
-			setPage([...page.value.rows, row({ subject: "Just now" })]);
-			act(() => noteTrafficArrival("proj-1"));
-			await waitFor(() => expect(counter()).toBe("1 / 1"));
-			expect(playLabel()).toBe("Play replay");
+			expect(liveActive()).toBe(true);
+			expect(following()).toBe("true");
 		} finally {
 			media.mockRestore();
 		}
@@ -615,17 +651,6 @@ describe("AgentTrafficScreen entry replay", () => {
 				"Nothing matches this filter.",
 			),
 		);
-	});
-
-	it("parks the cursor at the start instead of playing under reduced motion", async () => {
-		setPage([
-			row({ at: new Date(Date.now() - 40 * 60000).toISOString(), subject: "Oldest in the hour" }),
-			row({ subject: "Newest" }),
-		]);
-		renderLog();
-		await waitFor(() => expect(counter()).toBe("1 / 2"));
-		expect(playLabel()).toBe("Play replay");
-		expect(document.querySelector(".traffic-event-subject")?.textContent).toContain("Oldest in the hour");
 	});
 });
 
@@ -788,11 +813,9 @@ describe("AgentTrafficScreen route header", () => {
 			row({ subject: "Second" }),
 		]);
 		renderLog();
-		await waitFor(() => expect(counter()).toBe("1 / 2"));
-		// Live drops the cursor, so a counter back at the first event can only come
-		// from the button restarting the replay.
-		await userEvent.click(screen.getByRole("button", { name: "Live" }));
-		await waitFor(() => expect(counter()).not.toBe("1 / 2"));
+		// Entry has no cursor, so a counter at the first event can only come from
+		// the button starting the replay.
+		await waitFor(() => expect(counter()).toBe("2 / 2"));
 		await userEvent.click(screen.getByRole("button", { name: "Replay" }));
 		await waitFor(() => expect(counter()).toBe("1 / 2"));
 	});
@@ -924,11 +947,9 @@ describe("AgentTrafficScreen presentation picker", () => {
 		]);
 		renderLog();
 		await messageRows(2);
-		// The routed screen autoplays its entry window, so the cursor starts in the
-		// PAST and the cards are reconstructed. This assertion is about the live card
-		// treatment, so return to Live first — under a cursor, a task with no
-		// recorded movements is correctly "Status not recorded", not "Completed".
-		await userEvent.click(screen.getByRole("button", { name: "Live" }));
+		// Entry is Live, so the cards already carry their current treatment — under a
+		// replay cursor, a task with no recorded movements would correctly read
+		// "Status not recorded" rather than "Completed".
 		await userEvent.click(screen.getByTestId("traffic-nodes-parked-toggle"));
 		const cards = nodeCards() as HTMLElement[];
 		const asleep = cards.find((card) =>
@@ -1460,9 +1481,8 @@ it.each(["held", "delivered", "unconfirmed", "not-delivered"] as const)("%s send
 	const rendered = renderLog();
 	try {
 		await act(async () => { await vi.advanceTimersByTimeAsync(1); });
-		// Entry autoplays the trailing hour; this test is about the live flights, so
-		// hand the cursor back to Live before stepping.
-		fireEvent.click(screen.getByRole("button", { name: "Live" }));
+		// Entry is already Live; this test is about the live flights, so step from
+		// there.
 		fireEvent.click(screen.getByRole("button", { name: "Next message" }));
 		advance(0);
 		expect(document.querySelectorAll("circle.traffic-flight")).toHaveLength(1);
@@ -1670,10 +1690,8 @@ describe("Replay reconstructs the board at the cursor", () => {
 		setUpHistory();
 		renderLog();
 		await waitFor(() => expect(screen.getAllByTestId("traffic-node-card").length).toBeGreaterThan(0));
-		// Entry autoplay lands the cursor in the past, so the claim is true on arrival.
-		await waitFor(() => expect(summary()).toContain("rebuilt from recorded board moves"));
-		// Experiment 2 on Live shows the board as it is, so it must not claim a rebuild.
-		await userEvent.click(screen.getByRole("button", { name: "Live" }));
+		// Entry is Live, and experiment 2 on Live shows the board as it is, so it
+		// must not claim a rebuild.
 		expect(summary()).toContain("Task states are current");
 		const play = await screen.findByRole("button", { name: "Play replay" });
 		await waitFor(() => expect(play.hasAttribute("disabled")).toBe(false));
@@ -1691,10 +1709,8 @@ describe("Replay reconstructs the board at the cursor", () => {
 		setUpHistory();
 		renderLog();
 		await waitFor(() => expect(screen.getAllByTestId("traffic-node-card").length).toBeGreaterThan(0));
-		// Entry autoplay already put the cursor in the past, so the disclosure is
-		// there on arrival — it belongs to the cursor, not to a click.
-		await waitFor(() => expect(caption()).toContain("Hibernation"));
-		await userEvent.click(screen.getByRole("button", { name: "Live" }));
+		// Entry is Live, and the disclosure belongs to the cursor — no cursor, no
+		// disclosure.
 		expect(caption()).not.toContain("Hibernation");
 		const play = await screen.findByRole("button", { name: "Play replay" });
 		await waitFor(() => expect(play.hasAttribute("disabled")).toBe(false));

--- a/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
@@ -6,7 +6,6 @@ import { useGlobalShortcut } from "../../hooks/useGlobalShortcut";
 import { useNarrowViewport } from "../../hooks/useNarrowViewport";
 import { getOverlayLayerElements } from "../../utils/overlay-layers";
 import { isTypingContext } from "../../utils/typing-context";
-import { useReducedMotion } from "../../utils/useReducedMotion";
 import { getStatusLabel } from "../../utils/statusLabel";
 import BottomSheet from "../BottomSheet";
 import Select from "../Select";
@@ -548,50 +547,11 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 	useEffect(() => {
 		markTrafficSeen();
 	}, []);
-	// Autoplay the trailing hour ONCE per entry to this screen.
-	//
-	// The ref, not a piece of state, is what makes "once" true: the window's start
-	// slides with the clock and a live append arrives at any moment, so an effect
-	// keyed off the data would restart the replay under the user's cursor — and a
-	// manual pause has to stand. It arms on the first render where the load has
-	// settled, INCLUDING a settled load that found nothing, so an empty window
-	// stays parked instead of springing to life when the next event lands. Reduced
-	// motion keeps the cursor at the start of the window and skips the playing.
-	//
-	// It counts `playback.events`, not the message list: an hour with no messages
-	// but with recorded task movements is NOT an empty window, and this replays it.
-	//
-	// The load gate below covers both arms the timeline has — messages and tasks
-	// both come from `data`. A notification arm would add a third, and its settled
-	// signal must read Seq 1825's `status === "ready" || status === "failed"` — NOT
-	// `!notifications.loading`, which is true before the first read has even been
-	// asked for and would arm this one-shot latch on a stream that never came.
-	const reducedMotion = useReducedMotion();
-	const autoplayed = useRef(false);
-	const enterReplay = useRef(startEntryReplay);
-	enterReplay.current = startEntryReplay;
-	const eventCount = playback.events.length;
-	useEffect(() => {
-		if (autoplayed.current || experiment !== "2") return;
-		if (data.loading || data.historyLoading) return;
-		autoplayed.current = true;
-		if (!eventCount) return;
-		enterReplay.current(reducedMotion);
-	}, [experiment, data.loading, data.historyLoading, eventCount, reducedMotion]);
-
-	/**
-	 * Put the cursor on the first event of the entry window and start playing (or,
-	 * under reduced motion, just park it there).
-	 *
-	 * `seekToTime` rather than `seek(0)`: it lands on the first event at or after
-	 * the window's start and returns false without moving anything when every
-	 * recorded event precedes it. A clamp to the newest event would turn "nothing
-	 * happened in this hour" into "the hour started here", which is the reading the
-	 * empty-window rule exists to prevent.
-	 */
-	function startEntryReplay(parkOnly: boolean) {
-		playback.seekToTime(start, !parkOnly);
-	}
+	// Entry is Live, with the camera following. No cursor is placed and nothing
+	// plays on arrival: the screen's first job is to show what is happening now,
+	// and an automatic replay of the trailing hour hijacked the stage before the
+	// reader had asked for anything. Replay stays fully available — the transport's
+	// Play (and Space) start it from the window's beginning on demand.
 	// Space toggles the replay, the way it does in a media player — same action as
 	// the transport's Play/Pause button, including its restart-when-finished
 	// semantics. Hand-written and non-remappable: `Space` is a `RESERVED_CODE` in


### PR DESCRIPTION
Entering the Agent traffic route now lands on Live with the camera following, instead of automatically replaying the trailing hour. This reverses the entry-autoplay ruling from `decisions/2026/09/08/agent-traffic-becomes-a-destination.md`: the reader opens the screen to see what is happening now, and the automatic replay took the stage — cursor in the past, cards reconstructed from recorded board moves, and the first interaction being to stop something nobody asked to start.

`AgentTrafficScreen.tsx` drops the one-shot autoplay effect, its `autoplayed` ref, `startEntryReplay`, and the `useReducedMotion` read that served only them. With no cursor placed, `useTrafficPlayback` stays at `index === -1` (that is Live) and `TrafficNodes` keeps its existing `follow: true` default, so Live + Follow needs no new state and no new control.

Replay stays explicit and unchanged: the transport's Play, the toolbar's Replay and Space all start at the window's first event. The period default (`ENTRY_WINDOW = "hour"`), project/time filters, both experiments, manual camera interaction and notification/history data are untouched; `useTrafficPlayback.seekToTime` keeps its contract and its tests and simply has no caller on the entry path any more.

Also here: the entry tests rewritten around the new contract (first entry, re-entry, live arrivals, explicit Replay), a new decision record, a partial-supersede note on the 2026-09-08 one, and a changelog entry.

Note for the notification work in flight: its `notificationsSettled` is consumed only inside the autoplay latch, which no longer exists — that flag has no consumer after this change.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a7ecb16b-cb77-41cd-9e07-bf66b071e50d) · `dev3://task/a7ecb16b-cb77-41cd-9e07-bf66b071e50d` _(dev3 added this footer — turn it off in Settings → Tasks.)_
