### PR TITLE
Restore every window of the last session, not only the focused one

### DIFF
--- a/change-logs/2026/09/10/feature-restore-all-windows.md
+++ b/change-logs/2026/09/10/feature-restore-all-windows.md
@@ -1,0 +1,3 @@
+Short: Restore every window after restart
+
+Every window open at shutdown now reopens where it was — its own position, size, screen and macOS fullscreen state — instead of only the last focused one. A window you close on purpose stays closed, and a saved window whose screen is gone reopens visible on an available display.

--- a/decisions/2026/09/10/persist-every-window-of-a-session.md
+++ b/decisions/2026/09/10/persist-every-window-of-a-session.md
@@ -31,6 +31,20 @@ window down at once and must not shrink the session written by `flushWindowState
 An empty snapshot is never written — quitting from a window-less dock keeps the last
 known geometry, matching the previous behaviour.
 
+## The part that is not obvious: `frame` reaches only the first window
+
+Measured on macOS with three restored windows: Electrobun's `new BrowserWindow({ frame })`
+places the FIRST window of the process and nothing after it — windows two and three
+opened stacked on window one, ignoring the geometry the constructor was given (the same
+is true of the pre-existing centered cascade, whose offset never applied either). So
+`createAppWindow` re-applies the frame with `win.setFrame()` for every window but the
+first.
+
+The call has to wait for `dom-ready`. Issued immediately after the constructor, the
+frame landed on the *wrong* window — with three windows restored, one of them ended up
+carrying another one's geometry while a third never moved. The native side is still
+creating the window at that point.
+
 ## Risks
 
 macOS cannot restore a fullscreen window's Space, so several restored fullscreen windows

--- a/decisions/2026/09/10/persist-every-window-of-a-session.md
+++ b/decisions/2026/09/10/persist-every-window-of-a-session.md
@@ -1,0 +1,46 @@
+# Persist every window of a session, not just the focused one
+
+## Context
+
+`~/.dev3.0/window-state.json` held a single window: `captureWindowState()` wrote the
+focused window's geometry and `createAppWindow` restored it only for the first window
+of a launch (`windows.size === 0`). A user with several `Window > New` windows got one
+window back after an update restart or a quit, the rest lost.
+
+## Investigation
+
+Three facts shaped the design. Electrobun exposes no window identity that survives a
+restart, so a restored window is geometry only — no route, no per-window context.
+macOS owns a fullscreen window's frame, so the *windowed* frame must be tracked
+separately per window (it already was, but in one module-level variable shared by all
+windows). And `~/.dev3.0` is read by every installed version of the app, so the file
+format could not simply change shape.
+
+## Decision
+
+`window-state.ts` now stores `{ ...firstWindow, windows: WindowState[] }` — the array is
+the session, and the first window's fields are duplicated at the top level so an older
+install still restores its main window from the same file (`loadWindowStates` reads
+either shape). `window-manager.ts` keeps `lastWindowedFrame` per registry entry and
+snapshots every open window (`captureAllWindowStates`); `index.ts` reopens one window
+per saved entry at launch, focusing the first.
+
+Close and quit are told apart by `isQuitConfirmed()`: closing a window while the app
+runs re-snapshots the remaining set (so it does not come back), while a quit tears every
+window down at once and must not shrink the session written by `flushWindowState()`.
+An empty snapshot is never written — quitting from a window-less dock keeps the last
+known geometry, matching the previous behaviour.
+
+## Risks
+
+macOS cannot restore a fullscreen window's Space, so several restored fullscreen windows
+land in newly created Spaces in creation order, not the user's original arrangement.
+Window *identity* is not restored: which task or route a window showed is not persisted,
+so all restored windows open on the app's normal landing route.
+
+## Alternatives considered
+
+A per-window state file keyed by a generated id — rejected: the ids are meaningless
+across restarts and it multiplies files under `~/.dev3.0`. Writing only the array and
+dropping the legacy top-level fields — rejected: an older install would read the file as
+invalid and lose main-window restore, which the on-disk layout rules forbid.

--- a/src/bun/__tests__/window-session.test.ts
+++ b/src/bun/__tests__/window-session.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Multi-window session persistence: every open window is remembered, a window
+// closed on purpose is forgotten, and a quit teardown is not mistaken for one.
+
+type FakeWindow = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	webview: any;
+	getSize: ReturnType<typeof vi.fn>;
+	setSize: ReturnType<typeof vi.fn>;
+	getFrame: ReturnType<typeof vi.fn>;
+	setFrame: ReturnType<typeof vi.fn>;
+	isFullScreen: ReturnType<typeof vi.fn>;
+	setFullScreen: ReturnType<typeof vi.fn>;
+	setTitle: ReturnType<typeof vi.fn>;
+	focus: ReturnType<typeof vi.fn>;
+	on: ReturnType<typeof vi.fn>;
+	handlers: Record<string, () => void>;
+	frame?: { x: number; y: number; width: number; height: number };
+};
+
+const globalBag = globalThis as typeof globalThis & { __sessionWindows: FakeWindow[] };
+globalBag.__sessionWindows = [];
+const createdWindows: FakeWindow[] = globalBag.__sessionWindows;
+
+const LAPTOP = { id: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 }, workArea: { x: 0, y: 0, width: 1920, height: 1080 }, isPrimary: true };
+const EXTERNAL = { id: 2, bounds: { x: 1920, y: 0, width: 2560, height: 1440 }, workArea: { x: 1920, y: 0, width: 2560, height: 1440 } };
+
+const displayBag = globalThis as typeof globalThis & { __displays: unknown[] };
+displayBag.__displays = [LAPTOP, EXTERNAL];
+
+vi.mock("electrobun/bun", () => {
+	const bag = globalThis as typeof globalThis & { __sessionWindows: FakeWindow[]; __displays: typeof LAPTOP[] };
+	class FakeBrowserWindow {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		webview: any;
+		getSize = vi.fn(() => ({ width: 800, height: 600 }));
+		setSize = vi.fn();
+		getFrame: ReturnType<typeof vi.fn>;
+		setFrame: ReturnType<typeof vi.fn>;
+		isFullScreen = vi.fn(() => false);
+		setFullScreen = vi.fn();
+		setTitle = vi.fn();
+		focus = vi.fn();
+		on: ReturnType<typeof vi.fn>;
+		handlers: Record<string, () => void> = {};
+		frame?: { x: number; y: number; width: number; height: number };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		constructor(opts?: any) {
+			this.frame = opts?.frame;
+			this.webview = {
+				rpc: { send: {} },
+				openDevTools: vi.fn(),
+				on: vi.fn(),
+			};
+			this.getFrame = vi.fn(() => this.frame ?? { x: 0, y: 0, width: 800, height: 600 });
+			this.setFrame = vi.fn((x: number, y: number, width: number, height: number) => {
+				this.frame = { x, y, width, height };
+			});
+			this.on = vi.fn((name: string, handler: () => void) => {
+				this.handlers[name] = handler;
+			});
+			bag.__sessionWindows.push(this as unknown as FakeWindow);
+		}
+	}
+	return {
+		BrowserView: { defineRPC: vi.fn(() => ({ setTransport: vi.fn() })) },
+		BrowserWindow: FakeBrowserWindow,
+		Screen: {
+			getPrimaryDisplay: () => bag.__displays[0],
+			getAllDisplays: () => bag.__displays,
+		},
+	};
+});
+
+// In-memory disk: the real window-state serialization runs, nothing touches ~/.dev3.0.
+const files = new Map<string, string>();
+vi.mock("node:fs", () => ({
+	existsSync: (p: string) => files.has(p),
+	readFileSync: (p: string) => {
+		const v = files.get(p);
+		if (v === undefined) throw new Error(`ENOENT ${p}`);
+		return v;
+	},
+	writeFileSync: (p: string, data: string) => void files.set(p, data),
+	mkdirSync: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { createAppWindow, flushWindowState, loadWindowSession, __resetForTests } from "../window-manager";
+import { markQuitConfirmed, __resetQuitConfirmedForTests } from "../quit-manager";
+import type { WindowState } from "../window-state";
+
+function spawn(restore?: WindowState) {
+	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {}, restore });
+}
+
+/** The persisted session, read back exactly the way a launch reads it. */
+function savedSession(): WindowState[] {
+	return loadWindowSession();
+}
+
+beforeEach(() => {
+	createdWindows.length = 0;
+	files.clear();
+	displayBag.__displays = [LAPTOP, EXTERNAL];
+	__resetForTests();
+	__resetQuitConfirmedForTests();
+	vi.useFakeTimers();
+});
+
+describe("multi-window session persistence", () => {
+	it("remembers every open window, with its own frame and display", () => {
+		spawn();
+		spawn();
+		createdWindows[0].frame = { x: 10, y: 20, width: 800, height: 600 };
+		createdWindows[1].frame = { x: 2000, y: 100, width: 1200, height: 900 };
+
+		flushWindowState();
+
+		const session = savedSession();
+		expect(session).toHaveLength(2);
+		expect(session[0].frame).toEqual({ x: 10, y: 20, width: 800, height: 600 });
+		expect(session[0].displayId).toBe(1);
+		expect(session[1].frame).toEqual({ x: 2000, y: 100, width: 1200, height: 900 });
+		expect(session[1].displayId).toBe(2);
+	});
+
+	it("records a fullscreen window with the frame it would exit into", () => {
+		spawn();
+		const win = createdWindows[0];
+		// Windowed first, so the pre-fullscreen frame is the one on record.
+		win.frame = { x: 100, y: 100, width: 900, height: 700 };
+		win.handlers.resize?.();
+		vi.advanceTimersByTime(600);
+
+		win.isFullScreen.mockReturnValue(true);
+		win.frame = { x: 0, y: 0, width: 1920, height: 1080 };
+		flushWindowState();
+
+		const [state] = savedSession();
+		expect(state.fullscreen).toBe(true);
+		expect(state.frame).toEqual({ x: 100, y: 100, width: 900, height: 700 });
+	});
+
+	it("forgets a window the user closed, and keeps the rest", () => {
+		spawn();
+		spawn();
+		createdWindows[0].frame = { x: 10, y: 20, width: 800, height: 600 };
+		createdWindows[1].frame = { x: 2000, y: 100, width: 1200, height: 900 };
+		flushWindowState();
+
+		createdWindows[1].handlers.close?.();
+
+		const session = savedSession();
+		expect(session).toHaveLength(1);
+		expect(session[0].frame).toEqual({ x: 10, y: 20, width: 800, height: 600 });
+	});
+
+	it("keeps the whole session when the windows close as part of a quit", () => {
+		spawn();
+		spawn();
+		flushWindowState();
+		expect(savedSession()).toHaveLength(2);
+
+		markQuitConfirmed();
+		createdWindows[0].handlers.close?.();
+		createdWindows[1].handlers.close?.();
+
+		expect(savedSession()).toHaveLength(2);
+	});
+
+	it("keeps the last snapshot when the final window closes, so the dock still reopens somewhere sane", () => {
+		spawn();
+		createdWindows[0].frame = { x: 10, y: 20, width: 800, height: 600 };
+		flushWindowState();
+
+		createdWindows[0].handlers.close?.();
+
+		expect(savedSession()).toHaveLength(1);
+	});
+
+	it("debounced move/resize saves cover every open window", () => {
+		spawn();
+		spawn();
+		createdWindows[0].frame = { x: 5, y: 5, width: 700, height: 500 };
+		createdWindows[1].frame = { x: 2100, y: 15, width: 800, height: 600 };
+
+		createdWindows[1].handlers.move?.();
+		vi.advanceTimersByTime(600);
+
+		expect(savedSession().map((s) => s.frame.x)).toEqual([5, 2100]);
+	});
+});
+
+describe("restoring a saved session", () => {
+	const onExternal: WindowState = {
+		frame: { x: 2100, y: 100, width: 1000, height: 800 },
+		fullscreen: false,
+		displayId: 2,
+		displayBounds: EXTERNAL.bounds,
+	};
+
+	it("places a restored window on its saved screen", () => {
+		spawn(onExternal);
+		expect(createdWindows[0].frame).toEqual(onExternal.frame);
+	});
+
+	it("re-enters fullscreen for a window saved fullscreen", () => {
+		spawn({ ...onExternal, fullscreen: true });
+		const win = createdWindows[0];
+		// The fullscreen call is deferred to dom-ready, then a short timeout.
+		const domReady = win.webview.on.mock.calls.find((c: unknown[]) => c[0] === "dom-ready")?.[1] as () => void;
+		domReady();
+		vi.advanceTimersByTime(200);
+		expect(win.setFullScreen).toHaveBeenCalledWith(true);
+	});
+
+	it("falls back to a visible default when the saved display is gone", () => {
+		displayBag.__displays = [LAPTOP];
+		spawn(onExternal);
+
+		const frame = createdWindows[0].frame!;
+		expect(frame.x).toBeGreaterThanOrEqual(0);
+		expect(frame.x + frame.width).toBeLessThanOrEqual(LAPTOP.bounds.width);
+		expect(frame.y + frame.height).toBeLessThanOrEqual(LAPTOP.bounds.height);
+	});
+
+	it("clamps a saved frame that no longer fits its display", () => {
+		displayBag.__displays = [{ ...LAPTOP, bounds: { x: 0, y: 0, width: 1280, height: 720 }, workArea: { x: 0, y: 0, width: 1280, height: 720 } }, EXTERNAL];
+		spawn({ frame: { x: 900, y: 600, width: 1600, height: 1000 }, fullscreen: false, displayId: 1, displayBounds: LAPTOP.bounds });
+
+		expect(createdWindows[0].frame).toEqual({ x: 0, y: 0, width: 1280, height: 720 });
+	});
+
+	it("a window opened while others are up is not given the saved geometry", () => {
+		spawn(onExternal);
+		spawn();
+
+		expect(createdWindows[1].frame).not.toEqual(onExternal.frame);
+	});
+});

--- a/src/bun/__tests__/window-session.test.ts
+++ b/src/bun/__tests__/window-session.test.ts
@@ -98,6 +98,13 @@ function spawn(restore?: WindowState) {
 	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {}, restore });
 }
 
+/** Fire every dom-ready listener the window registered. */
+function domReady(win: FakeWindow): void {
+	for (const call of win.webview.on.mock.calls as [string, () => void][]) {
+		if (call[0] === "dom-ready") call[1]();
+	}
+}
+
 /** The persisted session, read back exactly the way a launch reads it. */
 function savedSession(): WindowState[] {
 	return loadWindowSession();
@@ -213,8 +220,7 @@ describe("restoring a saved session", () => {
 		spawn({ ...onExternal, fullscreen: true });
 		const win = createdWindows[0];
 		// The fullscreen call is deferred to dom-ready, then a short timeout.
-		const domReady = win.webview.on.mock.calls.find((c: unknown[]) => c[0] === "dom-ready")?.[1] as () => void;
-		domReady();
+		domReady(win);
 		vi.advanceTimersByTime(200);
 		expect(win.setFullScreen).toHaveBeenCalledWith(true);
 	});
@@ -234,6 +240,23 @@ describe("restoring a saved session", () => {
 		spawn({ frame: { x: 900, y: 600, width: 1600, height: 1000 }, fullscreen: false, displayId: 1, displayBounds: LAPTOP.bounds });
 
 		expect(createdWindows[0].frame).toEqual({ x: 0, y: 0, width: 1280, height: 720 });
+	});
+
+	it("re-applies the frame of a second window at dom-ready, which the create option alone never reaches", () => {
+		spawn();
+		spawn(onExternal);
+		const win = createdWindows[1];
+		expect(win.setFrame).not.toHaveBeenCalled(); // too early at construction — it would move the wrong window
+
+		domReady(win);
+
+		expect(win.setFrame).toHaveBeenCalledWith(2100, 100, 1000, 800);
+	});
+
+	it("leaves the first window's frame to the create option", () => {
+		spawn(onExternal);
+		domReady(createdWindows[0]);
+		expect(createdWindows[0].setFrame).not.toHaveBeenCalled();
 	});
 
 	it("a window opened while others are up is not given the saved geometry", () => {

--- a/src/bun/__tests__/window-state.test.ts
+++ b/src/bun/__tests__/window-state.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 import {
-	loadWindowState,
-	saveWindowState,
+	loadWindowStates,
+	saveWindowStates,
 	displayContaining,
 	resolveRestoreFrame,
 	type WindowState,
@@ -29,21 +30,50 @@ const baseState: WindowState = {
 	displayBounds: { x: 0, y: 0, width: 1920, height: 1080 },
 };
 
-describe("loadWindowState / saveWindowState", () => {
-	it("round-trips a valid state", () => {
+const secondState: WindowState = {
+	frame: { x: 2100, y: 40, width: 900, height: 600 },
+	fullscreen: true,
+	displayId: 2,
+	displayBounds: { x: 1920, y: 0, width: 2560, height: 1440 },
+};
+
+describe("loadWindowStates / saveWindowStates", () => {
+	it("round-trips every window of a session, in order", () => {
 		const path = tmpFile();
-		saveWindowState(baseState, path);
-		expect(loadWindowState(path)).toEqual(baseState);
+		saveWindowStates([baseState, secondState], path);
+		expect(loadWindowStates(path)).toEqual([baseState, secondState]);
 	});
 
-	it("returns null when the file does not exist", () => {
-		expect(loadWindowState(join(tmpdir(), "nope-does-not-exist.json"))).toBeNull();
+	it("also writes the first window at the top level, so an older install still restores it", () => {
+		const path = tmpFile();
+		saveWindowStates([baseState, secondState], path);
+		const raw = JSON.parse(readFileSync(path, "utf-8"));
+		expect(raw.frame).toEqual(baseState.frame);
+		expect(raw.fullscreen).toBe(baseState.fullscreen);
+		expect(raw.displayId).toBe(baseState.displayId);
 	});
 
-	it("returns null for structurally invalid state", () => {
+	it("reads a file written by the old single-window format", () => {
 		const path = tmpFile();
-		saveWindowState({ ...baseState, frame: { x: 0, y: 0, width: 0, height: 0 } } as WindowState, path);
-		expect(loadWindowState(path)).toBeNull();
+		writeFileSync(path, JSON.stringify(baseState), "utf-8");
+		expect(loadWindowStates(path)).toEqual([baseState]);
+	});
+
+	it("returns an empty session when the file does not exist", () => {
+		expect(loadWindowStates(join(tmpdir(), "nope-does-not-exist.json"))).toEqual([]);
+	});
+
+	it("drops structurally invalid entries and keeps the good ones", () => {
+		const path = tmpFile();
+		const broken = { ...baseState, frame: { x: 0, y: 0, width: 0, height: 0 } };
+		writeFileSync(path, JSON.stringify({ ...baseState, windows: [broken, secondState] }), "utf-8");
+		expect(loadWindowStates(path)).toEqual([secondState]);
+	});
+
+	it("returns an empty session for a wholly invalid file", () => {
+		const path = tmpFile();
+		writeFileSync(path, "{not json", "utf-8");
+		expect(loadWindowStates(path)).toEqual([]);
 	});
 });
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -51,7 +51,8 @@ import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import { startLoopMonitor } from "./loop-monitor";
-import { createAppWindow, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
+import { createAppWindow, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, loadWindowSession, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
+import type { WindowState } from "./window-state";
 import { pushEverywhere } from "./push-targets";
 import electrobunConfig, { cliBinaryName } from "../../electrobun.config";
 import { BUILD_TIME } from "../shared/build-info.generated";
@@ -453,9 +454,10 @@ function failDesktopLaunch(timeoutMs: number): void {
 	void hardExit(CLI_EXIT_CODE_RENDERER_UNAVAILABLE);
 }
 
-async function openMainWindow() {
+async function openMainWindow(restore?: WindowState) {
 	const buildChannel = await Updater.localInfo.channel();
 	return createAppWindow({
+		restore,
 		title: makeTitle(APP_VERSION, lastBuildTime, buildChannel),
 		url,
 		handlers: handlers as unknown as Record<string, (...args: unknown[]) => unknown>,
@@ -493,8 +495,18 @@ setOpenNewWindow(() => {
 	void openMainWindow();
 });
 
-await openMainWindow();
+// Reopen every window the last session ended with, each on its own saved
+// screen/geometry. A first run (or fresh-start dev mode) has no session and
+// gets the usual single window.
+const restoreSession = loadWindowSession();
+if (restoreSession.length > 1) log.info("Restoring window session", { windows: restoreSession.length });
+const primaryWindow = await openMainWindow(restoreSession[0]);
 log.info("Main window created");
+for (const state of restoreSession.slice(1)) await openMainWindow(state);
+// Creation order decides key focus, so hand it back to the primary window.
+if (restoreSession.length > 1) {
+	try { primaryWindow.focus(); } catch (err) { log.debug("Focusing the restored primary window failed", { error: String(err) }); }
+}
 readiness.arm();
 
 // Wire push messages. Every push in this file goes through `pushEverywhere`, so

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -2,13 +2,22 @@ import { BrowserView, BrowserWindow, Screen } from "electrobun/bun";
 import type { AppRPCSchema } from "../shared/types";
 import { createLogger } from "./logger";
 import { composeWindowTitle } from "./app-utils";
-import { loadWindowState, saveWindowState, resolveRestoreFrame, displayContaining, offscreenFrameClamp, type DisplayLike, type Rect } from "./window-state";
+import { loadWindowStates, saveWindowStates, resolveRestoreFrame, displayContaining, offscreenFrameClamp, type DisplayLike, type Rect, type WindowState } from "./window-state";
 import { isFreshStartMode } from "./fresh-start";
+import { isQuitConfirmed } from "./quit-manager";
 import { applyWindowsWindowIcon } from "./windows-icons/apply-window-icon";
 
 const log = createLogger("window-manager");
 
-type WindowEntry = { window: BrowserWindow; id: number };
+type WindowEntry = {
+	window: BrowserWindow;
+	id: number;
+	/**
+	 * Last known *windowed* frame — kept per window because getFrame() while the
+	 * window is in fullscreen returns the fullscreen rect, not the size to exit into.
+	 */
+	lastWindowedFrame: Rect | null;
+};
 
 // Registry of every dev-3.0 window that is currently open.
 // We keep our own set (in addition to Electrobun's internal BrowserWindowMap)
@@ -18,43 +27,64 @@ const windows = new Set<WindowEntry>();
 let focusedWindow: BrowserWindow | null = null;
 let seq = 0;
 
-// Debounced persistence of the main window's geometry so we can restore it after
-// an update restart (otherwise the window jumps to center on relaunch).
+// Debounced persistence of every open window's geometry so a restart can put
+// them all back (otherwise they jump to a centered cascade on relaunch).
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
-// Last known *windowed* frame — kept separately because getFrame() while the
-// window is in fullscreen returns the fullscreen rect, not the size to exit into.
-let lastWindowedFrame: Rect | null = null;
 
-function captureWindowState(win: BrowserWindow): void {
-	// Fresh-start (dev) mode never persists geometry — it must not clobber the
-	// shared ~/.dev3.0/window-state.json that the real install restores from.
-	if (isFreshStartMode()) return;
+function entryState(entry: WindowEntry): WindowState | null {
 	try {
+		const win = entry.window;
 		const fullscreen = win.isFullScreen();
 		const frame = win.getFrame();
-		if (!fullscreen) lastWindowedFrame = frame;
-		const windowed = lastWindowedFrame ?? frame;
+		if (!fullscreen) entry.lastWindowedFrame = frame;
+		const windowed = entry.lastWindowedFrame ?? frame;
 		const displays = Screen.getAllDisplays();
 		const disp = displayContaining(fullscreen ? frame : windowed, displays) ?? Screen.getPrimaryDisplay();
-		saveWindowState({ frame: windowed, fullscreen, displayId: disp.id, displayBounds: disp.bounds });
+		return { frame: windowed, fullscreen, displayId: disp.id, displayBounds: disp.bounds };
 	} catch (err) {
-		log.debug("captureWindowState failed", { error: String(err) });
+		log.debug("captureWindowState failed", { id: entry.id, error: String(err) });
+		return null;
 	}
 }
 
-function scheduleWindowStateSave(win: BrowserWindow): void {
-	if (saveTimer) clearTimeout(saveTimer);
-	saveTimer = setTimeout(() => captureWindowState(win), 500);
+/** Snapshot every open window, in creation order, into the shared state file. */
+function captureAllWindowStates(): void {
+	// Fresh-start (dev) mode never persists geometry — it must not clobber the
+	// shared ~/.dev3.0/window-state.json that the real install restores from.
+	if (isFreshStartMode()) return;
+	const states: WindowState[] = [];
+	for (const entry of windows) {
+		const state = entryState(entry);
+		if (state) states.push(state);
+	}
+	// Nothing left to record: keep the previous snapshot rather than writing an
+	// empty session, so quitting from a window-less dock still reopens a window
+	// where the user last had one.
+	if (!states.length) return;
+	saveWindowStates(states);
 }
 
-/** Persist the focused window's geometry immediately (called on quit / update restart). */
+function scheduleWindowStateSave(): void {
+	if (saveTimer) clearTimeout(saveTimer);
+	saveTimer = setTimeout(() => captureAllWindowStates(), 500);
+}
+
+/** Persist every open window's geometry immediately (called on quit / update restart). */
 export function flushWindowState(): void {
 	if (saveTimer) {
 		clearTimeout(saveTimer);
 		saveTimer = null;
 	}
-	const win = getFocusedWindow();
-	if (win) captureWindowState(win);
+	captureAllWindowStates();
+}
+
+/**
+ * The windows to reopen at launch, in creation order. Empty in fresh-start (dev)
+ * mode and on a first run — the caller then opens its usual single window.
+ */
+export function loadWindowSession(): WindowState[] {
+	if (isFreshStartMode()) return [];
+	return loadWindowStates();
 }
 
 /**
@@ -126,6 +156,12 @@ export interface CreateAppWindowOptions {
 	 * `<script>` tag instead).
 	 */
 	preload?: string;
+	/**
+	 * Geometry this window is being restored into (one entry of the persisted
+	 * session). Omitted for a window the user opens now — only the very first
+	 * window of a launch falls back to the saved primary geometry.
+	 */
+	restore?: WindowState | null;
 }
 
 /**
@@ -162,18 +198,19 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		},
 	});
 
-	// Restore the *first* window to its last position/screen (incl. macOS
-	// fullscreen). Extra windows keep the centered cascade so they don't stack.
+	// Restore a window to its last position/screen (incl. macOS fullscreen):
+	// either the slot the launch handed us, or — for the first window of a run
+	// with no explicit slot — the saved primary geometry. A window the user opens
+	// while others are up keeps the centered cascade so they don't stack.
 	// In fresh-start (dev) mode we skip the restore entirely and always open a
 	// default centered, windowed frame — no geometry, no fullscreen.
 	let frame: Rect;
 	let restoreFullScreen = false;
-	const saved = windows.size === 0 && !isFreshStartMode() ? loadWindowState() : null;
+	const saved = opts.restore ?? (windows.size === 0 ? loadWindowSession()[0] ?? null : null);
 	const restored = saved ? resolveRestoreFrame(saved, Screen.getAllDisplays()) : null;
 	if (restored) {
 		frame = restored.frame;
 		restoreFullScreen = restored.fullscreen;
-		lastWindowedFrame = restored.frame;
 		log.info("Restoring window geometry", { fullscreen: restoreFullScreen, ...restored.frame });
 	} else {
 		// ~95% of the primary display work area, centered. Additional windows are
@@ -208,7 +245,7 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 	self = win;
 
 	const id = ++seq;
-	const entry: WindowEntry = { window: win, id };
+	const entry: WindowEntry = { window: win, id, lastWindowedFrame: restored ? restored.frame : frame };
 	windows.add(entry);
 	focusedWindow = win;
 	log.info("Window created", { id, total: windows.size });
@@ -226,6 +263,11 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 			focusedWindow = firstWindow();
 		}
 		log.info("Window closed", { id, remaining: windows.size });
+		// A window the user closed on purpose must not come back on the next
+		// launch, so re-snapshot what is left. During a quit every window closes
+		// at once — that is teardown, not a decision, and the session written by
+		// flushWindowState must survive it.
+		if (!isQuitConfirmed()) captureAllWindowStates();
 		opts.onClosed?.(win, windows.size);
 	});
 
@@ -234,8 +276,8 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 	// which must not touch the shared persisted state (captureWindowState also
 	// short-circuits, but not attaching avoids pointless timers).
 	if (!isFreshStartMode()) {
-		win.on("move", () => scheduleWindowStateSave(win));
-		win.on("resize", () => scheduleWindowStateSave(win));
+		win.on("move", () => scheduleWindowStateSave());
+		win.on("resize", () => scheduleWindowStateSave());
 	}
 
 	if (restoreFullScreen) {

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -236,6 +236,15 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		...(opts.preload ? { preload: opts.preload } : {}),
 	});
 
+	// The `frame` option above only reaches the FIRST window of the process —
+	// every later one opens stacked on the existing window, ignoring both the
+	// cascade offset and a restored geometry (measured on macOS: three windows
+	// asked for three frames, all three landed on the first one's). We re-apply
+	// the frame ourselves at dom-ready: called right after the constructor the
+	// same call lands on the wrong window, because the native side is still
+	// creating this one. Skipped when restoring into fullscreen, which macOS owns.
+	const needsFrameApply = windows.size > 0 && !restoreFullScreen;
+
 	// Windows draws a system-fallback icon in the window and the taskbar because
 	// electrobun never assigns one to its window class; we set it ourselves from
 	// the icon already embedded in our executables. No-op off Windows, where the
@@ -304,6 +313,13 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		win.webview.on("dom-ready", () => {
 			if (nudged) return; // a reload re-fires dom-ready; one nudge per window
 			nudged = true;
+			if (needsFrameApply) {
+				try {
+					win.setFrame(frame.x, frame.y, frame.width, frame.height);
+				} catch (err) {
+					log.warn("Applying the window frame failed", { error: String(err) });
+				}
+			}
 			setTimeout(() => {
 				try {
 					const size = win.getSize();

--- a/src/bun/window-state.ts
+++ b/src/bun/window-state.ts
@@ -12,7 +12,7 @@ export interface Rect {
 	height: number;
 }
 
-/** Persisted geometry of the main window, restored across app restarts (e.g. updates). */
+/** Persisted geometry of one window, restored across app restarts (e.g. updates). */
 export interface WindowState {
 	/** Last *windowed* frame (never the fullscreen rect, so we have a sane size to exit fullscreen into). */
 	frame: Rect;
@@ -60,21 +60,33 @@ function isValidState(s: unknown): s is WindowState {
 	);
 }
 
-export function loadWindowState(path: string = STATE_PATH): WindowState | null {
+/**
+ * Every window that was open when the app last shut down, in creation order.
+ * Empty when the file is missing or holds nothing usable.
+ *
+ * The file also carries the first window's fields at the top level, so an older
+ * install that only knows the single-window shape still restores its main
+ * window from the same file (the on-disk layout is shared between versions).
+ */
+export function loadWindowStates(path: string = STATE_PATH): WindowState[] {
 	try {
-		if (!existsSync(path)) return null;
-		const raw = JSON.parse(readFileSync(path, "utf-8"));
-		return isValidState(raw) ? raw : null;
+		if (!existsSync(path)) return [];
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+		const list = raw?.windows;
+		if (Array.isArray(list)) return list.filter(isValidState);
+		return isValidState(raw) ? [raw] : [];
 	} catch (err) {
 		log.warn("Failed to load window state", { error: String(err) });
-		return null;
+		return [];
 	}
 }
 
-export function saveWindowState(state: WindowState, path: string = STATE_PATH): void {
+export function saveWindowStates(states: WindowState[], path: string = STATE_PATH): void {
 	try {
 		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, JSON.stringify(state), "utf-8");
+		// `...states[0]` is the compatibility half: older versions read only these
+		// top-level fields and would otherwise see an unreadable file.
+		writeFileSync(path, JSON.stringify({ ...states[0], windows: states }), "utf-8");
 	} catch (err) {
 		log.warn("Failed to save window state", { error: String(err) });
 	}


### PR DESCRIPTION
Every window open at shutdown now reopens where it was — its own position, size, screen and macOS fullscreen state — instead of only the last focused one.

`~/.dev3.0/window-state.json` becomes `{ ...firstWindow, windows: WindowState[] }`: the array is the session, while the first window's fields stay at the top level so an older install still restores its main window from the same file. Both shapes are readable in both directions; measured live, the worst case of a downgrade is a session that shrinks to one window, never a broken file.

`window-manager.ts` keeps the last windowed frame per registry entry and snapshots every open window; `index.ts` reopens one window per saved entry and hands focus back to the first. Closing a window on purpose re-snapshots what is left, so it does not come back; a quit tears every window down at once and must not shrink the session, which `isQuitConfirmed()` tells apart. An empty snapshot is never written, so quitting from a window-less dock keeps the last known geometry. A saved display that is gone falls back to a centered window on an available screen, and a frame that no longer fits is clamped inside its display.

One non-obvious limitation drove half the change: Electrobun's `new BrowserWindow({ frame })` places only the FIRST window of the process — three windows asked for three frames and all three landed on the first one's, and the long-standing centered-cascade offset for extra windows never applied either. The frame is now re-applied with `setFrame()` for every window after the first, at `dom-ready`: issued right after the constructor the same call lands on the wrong window. Recorded in `decisions/2026/09/10/persist-every-window-of-a-session.md`.

Verified live on macOS with an isolated instance: the same three-window session file fed to both builds restored one window on `main` and all three, on their own frames, on this branch — geometry read back from `CGWindowListCopyWindowInfo` rather than the app's own logs. Windows and Linux were not run; the close-vs-quit split, fullscreen restore and the missing-display fallback are covered by unit tests (the two guards proven by mutation), not by a live run.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c63e1b68-5308-411c-9eb9-957f9b1dbeda) · `dev3://task/c63e1b68-5308-411c-9eb9-957f9b1dbeda` _(dev3 added this footer — turn it off in Settings → Tasks.)_
