### PR TITLE
Auto-confirm the quit dialog after a 10s countdown

### DIFF
--- a/change-logs/2026/09/10/feature-quit-dialog-countdown.md
+++ b/change-logs/2026/09/10/feature-quit-dialog-countdown.md
@@ -1,0 +1,3 @@
+Short: Quit dialog quits itself in 10s
+
+The "Sessions keep running" quit confirmation now shows a 10-second countdown and confirms the quit on its own when nobody answers it, so a quit triggered while you walk away no longer parks the app on a dialog. The first click or keystroke drops the countdown and hands the decision back to you, and Cancel or Escape closes the dialog as before.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -109,6 +109,9 @@ const QR_REFRESH_SECONDS = 60;
 /** Whether the Debug → Terminal Performance overlay is showing. */
 const TERMINAL_PERF_KEY = "dev3-terminal-perf";
 
+/** Unanswered quit dialog auto-confirms after this long — sessions survive in tmux either way. */
+const QUIT_AUTO_CONFIRM_SECONDS = 10;
+
 type RemoteAccessQRData = {
 	qrDataUrl: string;
 	accessUrl: string;
@@ -293,6 +296,12 @@ function App() {
 	// Quit dialog
 	const [showQuitDialog, setShowQuitDialog] = useState(false);
 	const [dontShowAgain, setDontShowAgain] = useState(false);
+	const [quitSecondsLeft, setQuitSecondsLeft] = useState(QUIT_AUTO_CONFIRM_SECONDS);
+	const [quitTimerStopped, setQuitTimerStopped] = useState(false);
+	// Read by the auto-confirm timer, which is armed once per dialog and would
+	// otherwise close over the checkbox value from the moment it opened.
+	const dontShowAgainRef = useRef(dontShowAgain);
+	dontShowAgainRef.current = dontShowAgain;
 
 	// Pending agent-initiated launch requests; only the head is on screen.
 	const [launchRequests, setLaunchRequests] = useState<AgentLaunchRequest[]>([]);
@@ -303,6 +312,7 @@ function App() {
 	useEffect(() => {
 		function onShowQuitDialog() {
 			setDontShowAgain(false);
+			setQuitTimerStopped(false);
 			setShowQuitDialog(true);
 		}
 		window.addEventListener("rpc:showQuitDialog", onShowQuitDialog);
@@ -319,6 +329,7 @@ function App() {
 			.then((pending) => {
 				if (pending) {
 					setDontShowAgain(false);
+					setQuitTimerStopped(false);
 					setShowQuitDialog(true);
 				}
 			})
@@ -1466,8 +1477,36 @@ function App() {
 	}, [dispatch]);
 
 	function handleConfirmQuit() {
-		api.request.quitApp({ dontShowAgain }).catch(() => {});
+		api.request.quitApp({ dontShowAgain: dontShowAgainRef.current }).catch(() => {});
 	}
+
+	// The dialog only tells the user sessions survive, so leaving it unanswered
+	// should not park the quit forever. Ticking off a deadline (not a per-tick
+	// budget) keeps the number honest while the window is backgrounded.
+	//
+	// The first key or click proves somebody is at the machine, and from then on
+	// the quit is theirs to confirm: only an abandoned dialog fires by itself.
+	useEffect(() => {
+		if (!showQuitDialog || quitTimerStopped) return;
+		const deadline = Date.now() + QUIT_AUTO_CONFIRM_SECONDS * 1000;
+		setQuitSecondsLeft(QUIT_AUTO_CONFIRM_SECONDS);
+		const id = setInterval(() => {
+			const left = Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
+			setQuitSecondsLeft(left);
+			if (left === 0) {
+				clearInterval(id);
+				api.request.quitApp({ dontShowAgain: dontShowAgainRef.current }).catch(() => {});
+			}
+		}, 250);
+		const stop = () => setQuitTimerStopped(true);
+		window.addEventListener("keydown", stop);
+		window.addEventListener("pointerdown", stop);
+		return () => {
+			clearInterval(id);
+			window.removeEventListener("keydown", stop);
+			window.removeEventListener("pointerdown", stop);
+		};
+	}, [showQuitDialog, quitTimerStopped]);
 
 	// Check gh availability after requirements pass (non-blocking)
 	useEffect(() => {
@@ -3070,7 +3109,12 @@ function App() {
 							/>
 							<span className="text-fg-2 text-sm">{t("quit.dontShowAgain")}</span>
 						</label>
-						<div className="flex justify-end gap-2 pt-1">
+						<div className="flex items-center justify-end gap-2 pt-1">
+							{!quitTimerStopped && (
+								<span className="mr-auto text-fg-muted text-xs tabular-nums" aria-live="off">
+									{t("quit.autoQuitIn", { seconds: String(quitSecondsLeft) })}
+								</span>
+							)}
 							<button
 								onClick={() => setShowQuitDialog(false)}
 								className="px-4 py-2 text-sm rounded-lg text-fg-2 hover:text-fg hover:bg-elevated transition-colors"

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -360,6 +360,67 @@ describe("App keyboard shortcuts", () => {
 			await userEvent.click(screen.getByRole("button", { name: "Quit" }));
 			expect(api.request.quitApp).toHaveBeenCalledWith({ dontShowAgain: true });
 		});
+
+		it("counts down and quits on its own after 10 seconds", async () => {
+			vi.mocked(api.request.quitApp).mockResolvedValue(undefined);
+			await renderApp();
+			vi.useFakeTimers();
+			try {
+				requestQuitDialog();
+				expect(screen.getByText("Quitting in 10s")).toBeInTheDocument();
+				act(() => vi.advanceTimersByTime(4_000));
+				expect(screen.getByText("Quitting in 6s")).toBeInTheDocument();
+				expect(api.request.quitApp).not.toHaveBeenCalled();
+				act(() => vi.advanceTimersByTime(6_000));
+				expect(api.request.quitApp).toHaveBeenCalledWith({ dontShowAgain: false });
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("the first click drops the countdown — only an abandoned dialog quits itself", async () => {
+			vi.mocked(api.request.quitApp).mockResolvedValue(undefined);
+			await renderApp();
+			requestQuitDialog();
+			await userEvent.click(screen.getByRole("checkbox"));
+			expect(screen.queryByText(/Quitting in/)).not.toBeInTheDocument();
+			vi.useFakeTimers();
+			try {
+				act(() => vi.advanceTimersByTime(15_000));
+				expect(api.request.quitApp).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("a keystroke drops the countdown too", async () => {
+			vi.mocked(api.request.quitApp).mockResolvedValue(undefined);
+			await renderApp();
+			requestQuitDialog();
+			await userEvent.keyboard("{Tab}");
+			expect(screen.queryByText(/Quitting in/)).not.toBeInTheDocument();
+			vi.useFakeTimers();
+			try {
+				act(() => vi.advanceTimersByTime(15_000));
+				expect(api.request.quitApp).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("stops counting down once the dialog is dismissed", async () => {
+			vi.mocked(api.request.quitApp).mockResolvedValue(undefined);
+			await renderApp();
+			requestQuitDialog();
+			await userEvent.keyboard("{Escape}");
+			vi.useFakeTimers();
+			try {
+				act(() => vi.advanceTimersByTime(15_000));
+				expect(api.request.quitApp).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe("hide (Cmd+H / Ctrl+H)", () => {

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -52,6 +52,7 @@ const common = {
 	"quit.dontShowAgain": "Don't show again",
 	"quit.confirm": "Quit",
 	"quit.cancel": "Cancel",
+	"quit.autoQuitIn": "Quitting in {seconds}s",
 
 	// Generic confirmation dialog (imperative confirm() service)
 	"confirmDialog.cancel": "Cancel",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -52,6 +52,7 @@ const common = {
 	"quit.dontShowAgain": "No mostrar de nuevo",
 	"quit.confirm": "Salir",
 	"quit.cancel": "Cancelar",
+	"quit.autoQuitIn": "Salida en {seconds} s",
 
 	// Generic confirmation dialog (imperative confirm() service)
 	"confirmDialog.cancel": "Cancelar",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -54,6 +54,7 @@ const common = {
 	"quit.dontShowAgain": "Больше не показывать",
 	"quit.confirm": "Выйти",
 	"quit.cancel": "Отмена",
+	"quit.autoQuitIn": "Выход через {seconds} с",
 
 	// Generic confirmation dialog (imperative confirm() service)
 	"confirmDialog.cancel": "Отмена",


### PR DESCRIPTION
The "Sessions keep running" quit confirmation now carries a 10-second countdown and confirms the quit on its own when nobody answers it, so a quit fired on the way out of the room no longer parks the app on a dialog.

- The countdown is drawn from a deadline, not a per-tick budget, so a backgrounded window shows a number that matches when the quit actually fires.
- The first click or keystroke drops the countdown and hands the decision back to the user — only an abandoned dialog quits itself. The label disappears at that moment.
- "Don't show again" is read through a ref, so an auto-confirm respects the box as it stands at the moment it fires rather than when the dialog opened.
- Cancel, Escape and a backdrop click close the dialog and kill the timer as before.

Verified in the running app (countdown ticking, dialog alive past 15s after one click) plus four renderer tests; the click guard was mutation-checked by removing the listener.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=0f6e0fe6-4b46-4914-9d15-ed4810f15555) · `dev3://task/0f6e0fe6-4b46-4914-9d15-ed4810f15555`
