### PR TITLE
Show messages the user sent as their own sender in agent traffic

### DIFF
--- a/change-logs/2026/09/10/feature-user-messages-in-agent-traffic.md
+++ b/change-logs/2026/09/10/feature-user-messages-in-agent-traffic.md
@@ -1,0 +1,3 @@
+Short: See your own messages in traffic
+
+Messages you send to an agent — the diff viewer's "Send to agent" button and the "Send later" modal — now appear in Agent traffic as coming from you, live and in replay, with a "You" marker flying its message to the recipient card. Provenance is stamped by the two handlers that can prove a human acted, never guessed from a message having no sending agent: an artifact form submit, a dev3 hand-off and a `dev3 message` run outside a worktree all look identical to that and stay unattributed.

--- a/decisions/2026/09/10/stamp-message-origin-never-infer-it.md
+++ b/decisions/2026/09/10/stamp-message-origin-never-infer-it.md
@@ -1,0 +1,71 @@
+# Stamp message origin at the call site, never infer it from a missing sender
+
+## Context
+
+Agent traffic could show one task talking to another, but not the user talking to
+a task, even though the user's messages were already on disk: every send goes
+through one seam (`recordMessageAttempt` in `src/bun/scheduled-message-scheduler.ts`)
+and every send is logged, sender or no sender. What was missing was any way to say
+*who* sent a row that has no sending agent.
+
+The tempting shortcut is that `fromTaskId === null` means the user. It does not.
+
+## Investigation
+
+Enumerated every path that reaches the delivery seam with no `AgentMessageSource`:
+
+| Path | Actually is |
+|---|---|
+| `sendAgentMessageNow` (`rpc-handlers/pr-comments.ts`) — the diff viewer's "Send to agent" | the user |
+| `scheduleMessage` (`rpc-handlers/git-operations.ts`) — the "Send later" modal | the user |
+| `sendArtifactMessageToAgent` (`rpc-handlers/artifact-messages.ts`) | a human, but a published artifact reaches anyone the link reached |
+| `dev3 message` run outside a worktree (`cli-socket-server.ts`) | unknown — an agent with a wrong `cwd` produces a byte-identical call |
+| `deliverLaunchHandoff` (`agent-launch-handoff.ts`) | dev3 itself |
+
+Four of the five wear the same face at the seam. Reading the shape of the row
+therefore mislabels three of them.
+
+## Decision
+
+`AgentMessageLogRow.origin?: AgentMessageOrigin` (`src/shared/agent-message-log.ts`),
+optional and additive, stamped **by the caller** and only by a caller that can
+prove a human acted — currently the two handlers above. `isUserOrigin()` in that
+same file is the single predicate; the renderer, the traffic store and the graph
+model all call it rather than comparing inline, so the rule cannot be re-derived
+differently in three places.
+
+`ScheduledMessage.origin` carries the same value through `tasks.json`, because a
+"Send later" fires hours after it was authored and nothing at fire time could
+tell who wrote it.
+
+In the graph, `fromKey()` returns a synthetic per-project endpoint
+(`USER_ENDPOINT_ID`, `traffic-model.ts`) for a proven user row, so the existing
+layout, edge routing, flight animation and replay all work unchanged. The marker
+renders as its own `UserCard` in `TrafficNodes.tsx` rather than a branch inside
+`Card`: it shares none of the task grammar there, and routing a human through the
+task card printed "status not recorded" and `#—` about a person.
+
+## Risks
+
+- **The safe direction is asymmetric.** An envelope-wrapped or agent-sent message
+  is provably not the user; an *unmarked* row is merely unknown. Any future caller
+  that stamps `origin: "user"` without proof puts a false claim in a durable log.
+  The predicate and the two call-site tests exist to make that visible in review.
+- A task whose id literally equals `dev3:user` shadows the marker in that project.
+  The task wins, which is the safe direction, and it is covered by a test.
+- Experiment 1 (`TrafficOrbit`) draws the user as an ordinary orb; only its label
+  is corrected to "You". A dedicated mesh treatment is deliberately not in this
+  change.
+
+## Alternatives considered
+
+- **Infer from `fromTaskId === null`.** Rejected: mislabels three paths, including
+  dev3's own hand-off, and the mislabelling is silent and durable.
+- **Derive origin from harness `UserPromptSubmit` hooks.** A real option and the
+  subject of a follow-up task, but it identifies nothing on its own: the hook fires
+  for anything typed into the pane, and dev3 types into panes constantly
+  (see the comment at `agent-prompt-delivery.ts:66`). It also needs dedup against
+  the two paths above, which already write a row for the same submission.
+- **Store the full prompt body for every submission.** Rejected here as a scope
+  widening that would routinely capture pasted secrets; it deserves its own
+  decision rather than arriving as a side effect.

--- a/src/bun/__tests__/agent-message-origin-callsites.test.ts
+++ b/src/bun/__tests__/agent-message-origin-callsites.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The two handlers that are allowed to claim a message was the user's.
+ *
+ * Provenance is only as honest as its call sites: the field means nothing if the
+ * one handler that serves a click forgets to stamp it, or if a handler that
+ * cannot prove anything stamps it anyway. So these cases drive the real handlers
+ * and read the argument the scheduler was actually called with.
+ *
+ * The scheduler itself is mocked here on purpose — the disk-level behaviour is
+ * covered in `agent-message-origin.test.ts`, and what is at stake here is only
+ * what each handler asks for.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../scheduled-message-scheduler", () => ({
+	sendMessageImmediately: vi.fn(async () => ({ status: "delivered", spilledPath: null })),
+	scheduleMessage: vi.fn(async () => task),
+	cancelScheduledMessage: vi.fn(),
+	sendScheduledMessageNow: vi.fn(),
+}));
+vi.mock("../data", () => ({
+	getProject: vi.fn(async () => project),
+	getTask: vi.fn(async () => task),
+	loadProjects: vi.fn(async () => [project]),
+	loadVirtualProjects: vi.fn(async () => []),
+	loadTasks: vi.fn(async () => [task]),
+}));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../github", () => ({}));
+// git-operations reaches Electrobun through the terminal and lifecycle layers,
+// neither of which this file exercises. Stubbed at the widest points rather than
+// leaf by leaf, so the mock wall does not have to track their internals.
+vi.mock("../tmux", () => ({ DEFAULT_TMUX_SOCKET: "dev3", tmux: {} }));
+vi.mock("../task-aux-panes", () => ({ auxPaneAlive: vi.fn(), auxPaneTitle: vi.fn(), openAuxPane: vi.fn() }));
+vi.mock("../lifecycle/service", () => ({ lifecycleActorRuntime: {} }));
+vi.mock("../agent-prompt-delivery", () => ({ deliverAgentPrompt: vi.fn() }));
+// The handler barrel's shared module pulls in Electrobun, which cannot start a
+// socket server in a test process — stubbed down to the one thing they use.
+vi.mock("../rpc-handlers/shared", () => ({
+	log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import type { Project, Task } from "../../shared/types";
+import { prCommentsHandlers } from "../rpc-handlers/pr-comments";
+import { artifactMessageHandlers } from "../rpc-handlers/artifact-messages";
+import { gitOperationHandlers } from "../rpc-handlers/git-operations";
+import { scheduleMessage, sendMessageImmediately } from "../scheduled-message-scheduler";
+
+const project = { id: "proj-1", name: "Proj", path: "/Users/x/repo" } as unknown as Project;
+const task = { id: "task-1", projectId: "proj-1", seq: 7, title: "Worker", status: "in-progress" } as unknown as Task;
+
+beforeEach(() => {
+	vi.mocked(sendMessageImmediately).mockClear();
+});
+
+describe("the Send to agent button", () => {
+	it("claims the user as the origin", async () => {
+		await prCommentsHandlers.sendAgentMessageNow({ taskId: "task-1", projectId: "proj-1", text: "fix this thread" });
+
+		const [, , , source, opts] = vi.mocked(sendMessageImmediately).mock.calls[0]!;
+		expect(opts).toMatchObject({ origin: "user" });
+		// The user is not an agent: the row must still have no sender task.
+		expect(source).toBeNull();
+	});
+});
+
+describe("the Send later modal", () => {
+	it("claims the user at queue time, not at fire time", async () => {
+		await gitOperationHandlers.scheduleMessage({
+			taskId: "task-1",
+			projectId: "proj-1",
+			at: new Date(Date.now() + 60_000).toISOString(),
+			text: "rebase in an hour",
+			target: { kind: "agent" },
+		});
+
+		const [, , input] = vi.mocked(scheduleMessage).mock.calls[0]!;
+		expect(input).toMatchObject({ origin: "user" });
+	});
+});
+
+describe("a form inside a published artifact", () => {
+	it("claims nothing, because the submitter may be anyone the link reached", async () => {
+		await artifactMessageHandlers.sendArtifactMessageToAgent({
+			taskId: "task-1",
+			text: "looks wrong on page 2",
+			artifactTitle: "Shard report",
+			version: 2,
+			versionCount: 3,
+		});
+
+		const [, , , , opts] = vi.mocked(sendMessageImmediately).mock.calls[0]!;
+		expect(opts?.origin).toBeUndefined();
+	});
+});

--- a/src/bun/__tests__/agent-message-origin.test.ts
+++ b/src/bun/__tests__/agent-message-origin.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Provenance on a message log row: it is stamped by the caller, it survives a
+ * delay, and it is ABSENT everywhere the caller could not prove a human acted.
+ *
+ * The absence cases carry the weight. A null sender is worn by four different
+ * things — an artifact form submit, a dev3 hand-off, a `dev3 message` run
+ * outside a worktree, and the user — so a reader that treats "no sender" as
+ * "the user" mislabels three of them. These cases fail the moment someone
+ * re-derives origin from the row's shape instead of reading what was stamped.
+ *
+ * Same redirected-disk harness as `agent-message-log-callsite.test.ts`: the row
+ * is read back off a real file, never asserted against the writer.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-msglog-origin-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../git", () => ({
+	projectSlug: (p: string) => p.replace(/^\//, "").replaceAll("/", "-"),
+	taskDir: (_p: unknown, t: { id: string }) => `${home}/worktrees/proj/${t.id.slice(0, 8)}`,
+}));
+vi.mock("../data", () => ({
+	loadProjects: vi.fn(async () => []),
+	loadVirtualProjects: vi.fn(async () => []),
+	loadTasks: vi.fn(async () => []),
+	getProject: vi.fn(async () => project),
+	getTask: vi.fn(),
+	updateTaskWith: vi.fn(async (_p: unknown, _id: unknown, mutator: (t: unknown) => { updates: Partial<Task> }) => {
+		const { updates } = mutator(makeTask());
+		return { task: { ...makeTask(), ...updates }, result: undefined };
+	}),
+}));
+vi.mock("../agent-prompt", () => ({
+	sendPromptToAgentPane: vi.fn(async () => true),
+	sendPromptToPane: vi.fn(async () => true),
+	holdMessageForAgentPane: vi.fn(async () => ({ status: "held" })),
+	holdMessageForPane: vi.fn(async () => ({ status: "held" })),
+}));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => true),
+	sendPromptToNativePane: vi.fn(async () => true),
+}));
+vi.mock("../pty-server", () => ({ DEFAULT_TMUX_SOCKET: "dev3" }));
+vi.mock("../rpc-handlers", () => ({
+	getPushMessage: vi.fn(() => vi.fn()),
+	pushCliToast: vi.fn(),
+	pushCliAttention: vi.fn(),
+	pushAgentMessage: vi.fn(),
+}));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import type { Project, ScheduledMessage, Task } from "../../shared/types";
+import { isUserOrigin } from "../../shared/agent-message-log";
+import { messageLogDir, readAgentMessageLog, resetAgentMessageLogPruneState } from "../agent-message-log";
+import { fireScheduledMessage, scheduleMessage, sendMessageImmediately } from "../scheduled-message-scheduler";
+
+const project = { id: "proj-1", name: "Proj", path: "/Users/x/repo" } as unknown as Project;
+
+function makeTask(overrides: Record<string, unknown> = {}): Task {
+	return {
+		id: "task-12345678",
+		projectId: "proj-1",
+		seq: 1650,
+		title: "Worker",
+		status: "in-progress",
+		scheduledMessages: [],
+		sessionState: { panes: [{ paneId: "%1", agentCmd: "claude", sessionId: null, agentId: null, configId: null }] },
+		...overrides,
+	} as unknown as Task;
+}
+
+/** A peer agent's `dev3 message` — the traffic that already had a sender. */
+const source = { taskId: "coordinator-task", seq: 1141, title: "Coordinator", projectId: "proj-1" };
+
+beforeEach(() => {
+	resetAgentMessageLogPruneState();
+	rmSync(messageLogDir(project), { recursive: true, force: true });
+});
+
+describe("a send the caller proved was the user's", () => {
+	it("records the origin, the recipient and the time together", async () => {
+		const before = Date.now();
+		await sendMessageImmediately(makeTask(), "look at the failing shard", null, null, { origin: "user" });
+
+		const { rows } = readAgentMessageLog(project);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			origin: "user",
+			// No agent wrote it, and that stays true — origin does not invent a sender.
+			fromTaskId: null,
+			fromSeq: null,
+			toTaskId: "task-12345678",
+			toSeq: 1650,
+			toProjectId: "proj-1",
+			kind: "immediate",
+			body: "look at the failing shard",
+		});
+		const at = Date.parse(rows[0]!.at);
+		expect(at).toBeGreaterThanOrEqual(before);
+		expect(at).toBeLessThanOrEqual(Date.now());
+	});
+
+	it("carries the origin across the delay of a Send later", async () => {
+		// Queued now, fired later: nothing at fire time could tell who wrote it, so
+		// the queue record is the only thing that can carry the answer.
+		const queued = await scheduleMessage(project, makeTask(), {
+			text: "start the rebase when CI is green",
+			at: new Date(Date.now() + 60_000).toISOString(),
+			origin: "user",
+		});
+		const stored = (queued.scheduledMessages ?? [])[0]! as ScheduledMessage;
+		expect(stored.origin).toBe("user");
+
+		const fired = { ...stored, at: new Date(Date.now() - 1_000).toISOString() };
+		await fireScheduledMessage(project, makeTask({ scheduledMessages: [fired] }), fired, { late: true });
+
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]).toMatchObject({ origin: "user", kind: "scheduled", scheduledFor: fired.at });
+	});
+
+	it("writes exactly one row per submission", async () => {
+		await sendMessageImmediately(makeTask(), "one click", null, null, { origin: "user" });
+		const { rows } = readAgentMessageLog(project);
+		expect(rows.filter((row) => isUserOrigin(row))).toHaveLength(1);
+	});
+});
+
+describe("a send nobody could attribute to the user", () => {
+	it("leaves a peer agent's message unmarked", async () => {
+		await sendMessageImmediately(makeTask(), "shard 3 is green", null, source);
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]?.origin).toBeUndefined();
+		expect(isUserOrigin(rows[0]!)).toBe(false);
+	});
+
+	it("leaves a sender-less send unmarked rather than guessing", async () => {
+		// This is the artifact form submit, the dev3 hand-off and a `dev3 message`
+		// run outside a worktree — all of them reach this exact call shape.
+		await sendMessageImmediately(makeTask(), "rebase finished", null, null);
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]).toMatchObject({ fromTaskId: null, fromSeq: null });
+		expect(rows[0]?.origin).toBeUndefined();
+		expect(isUserOrigin(rows[0]!)).toBe(false);
+	});
+
+	it("leaves an unmarked queued fire unmarked after the delay too", async () => {
+		const at = new Date(Date.now() - 1_000).toISOString();
+		const message = { id: "m-1", text: "wake up", at, target: { kind: "agent" as const }, source };
+		await fireScheduledMessage(project, makeTask({ scheduledMessages: [message] }), message, { late: true });
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]?.origin).toBeUndefined();
+	});
+
+	it("keeps the origin off an attempt that landed nowhere, without losing the verdict", async () => {
+		// A drop is still recorded, and a dropped user message is still the user's:
+		// origin describes who wrote it, never whether it arrived.
+		const message = { id: "m-2", text: "too late", at: new Date().toISOString(), target: { kind: "agent" as const }, origin: "user" as const };
+		await fireScheduledMessage(project, makeTask({ status: "completed" }), message, { late: false });
+		const { rows } = readAgentMessageLog(project);
+		expect(rows[0]).toMatchObject({ origin: "user", status: "not-delivered" });
+	});
+});

--- a/src/bun/__tests__/pr-comments.test.ts
+++ b/src/bun/__tests__/pr-comments.test.ts
@@ -243,7 +243,7 @@ describe("sendAgentMessageNow", () => {
 	it("delivers the text to the task's live agent", async () => {
 		sendMessageImmediately.mockResolvedValue({ status: "delivered", spilledPath: null });
 		await prCommentsHandlers.sendAgentMessageNow({ taskId: "t1", projectId: "p1", text: "fix it" });
-		expect(sendMessageImmediately).toHaveBeenCalledWith(task, "fix it", null, null, { hold: false });
+		expect(sendMessageImmediately).toHaveBeenCalledWith(task, "fix it", null, null, { hold: false, origin: "user" });
 	});
 
 	// The user clicked the button and is watching the terminal: a held message would
@@ -251,7 +251,7 @@ describe("sendAgentMessageNow", () => {
 	it("never holds the send — the review text goes in while the user watches", async () => {
 		sendMessageImmediately.mockResolvedValue({ status: "delivered", spilledPath: null });
 		await prCommentsHandlers.sendAgentMessageNow({ taskId: "t1", projectId: "p1", text: "fix it" });
-		expect(sendMessageImmediately.mock.calls[0]?.[4]).toEqual({ hold: false });
+		expect(sendMessageImmediately.mock.calls[0]?.[4]).toMatchObject({ hold: false });
 	});
 
 	it("propagates delivery failures", async () => {

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -966,7 +966,9 @@ async function scheduleMessage(params: {
 }): Promise<Task> {
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
-	return scheduleMessageCore(project, task, { text: params.text, at: params.at, target: params.target });
+	// The only caller is ScheduleMessageModal, so a human typed this. Stamped at
+	// queue time because the fire happens hours later, when nothing could tell.
+	return scheduleMessageCore(project, task, { text: params.text, at: params.at, target: params.target, origin: "user" });
 }
 
 /** Cancel one pending scheduled message (chip → "Cancel"). */

--- a/src/bun/rpc-handlers/pr-comments.ts
+++ b/src/bun/rpc-handlers/pr-comments.ts
@@ -231,7 +231,10 @@ async function getTaskPrComments(params: { taskId: string; projectId: string; fo
 async function sendAgentMessageNow(params: { taskId: string; projectId: string; text: string }): Promise<{ spilledPath: string | null }> {
 	const project = await data.getProject(params.projectId);
 	const task = await data.getTask(project, params.taskId);
-	const { spilledPath } = await sendMessageImmediately(task, params.text, null, null, { hold: false });
+	// `origin: "user"` is provable here and only here-and-alike: this handler exists
+	// solely to serve a click in the app's own UI. Nothing infers it from the null
+	// sender, which artifact submits and dev3 hand-offs also have.
+	const { spilledPath } = await sendMessageImmediately(task, params.text, null, null, { hold: false, origin: "user" });
 	return { spilledPath };
 }
 

--- a/src/bun/scheduled-message-scheduler.ts
+++ b/src/bun/scheduled-message-scheduler.ts
@@ -11,6 +11,7 @@ import {
 } from "../shared/types";
 import * as data from "./data";
 import type { AgentPromptDelivery } from "../shared/agent-prompt-delivery";
+import type { AgentMessageOrigin } from "../shared/agent-message-log";
 import { deliverAgentPrompt } from "./agent-prompt-delivery";
 import { coordinatorBoardEpilogue } from "./coordinator-board";
 import { wrapAgentMessage } from "../shared/agent-message-envelope";
@@ -115,6 +116,9 @@ async function recordMessageAttempt(task: Task, message: ScheduledMessage, deliv
 			toProjectId: task.projectId,
 			// A queued item carries the time it was queued for; an immediate send has none.
 			kind: message.at ? "scheduled" : "immediate",
+			// Carried from the call site, never inferred here: a null `source` is
+			// four different things and only two of them are the user.
+			...(message.origin ? { origin: message.origin } : {}),
 			...(message.at ? { scheduledFor: message.at } : {}),
 			...(message.subject ? { subject: message.subject } : {}),
 			body: message.text,
@@ -271,6 +275,8 @@ export async function scheduleMessage(
 		source?: AgentMessageSource | null;
 		/** The sender's one-liner; stored with the message and logged at fire time. */
 		subject?: string | null;
+		/** Set only by a caller that can prove a human queued this. */
+		origin?: AgentMessageOrigin;
 	},
 ): Promise<Task> {
 	const validated = validateText(input.text);
@@ -295,6 +301,7 @@ export async function scheduleMessage(
 		at: at.toISOString(),
 		target: normalizeTarget(input.target),
 		...(input.source ? { source: input.source } : {}),
+		...(input.origin ? { origin: input.origin } : {}),
 		...(spilledPath ? { spilledPath } : {}),
 	};
 	const { task: updated } = await data.updateTaskWith<void>(project, task.id, (current) => {
@@ -343,7 +350,7 @@ export async function sendMessageImmediately(
 	text: string,
 	target?: ScheduledMessageTarget | null,
 	source?: AgentMessageSource | null,
-	opts: { hold?: boolean; subject?: string | null } = {},
+	opts: { hold?: boolean; subject?: string | null; origin?: AgentMessageOrigin } = {},
 ): Promise<AgentPromptDelivery & { spilledPath: string | null }> {
 	const trimmed = validateText(text);
 	if (isTerminal(task.status)) {
@@ -361,6 +368,7 @@ export async function sendMessageImmediately(
 		at: "",
 		target: normalizeTarget(target),
 		...(source ? { source } : {}),
+		...(opts.origin ? { origin: opts.origin } : {}),
 		...(spilledPath ? { spilledPath } : {}),
 	};
 	const delivery = await deliverToTarget(task, message, opts.hold !== false);

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1173,6 +1173,32 @@ it("Follow reveals its hibernated endpoint and replay never uses a future delive
 	).toBe(true);
 });
 
+it("draws the user as a sender for a message they proved they sent", async () => {
+	setPage([row({ fromTaskId: null, fromSeq: null, fromTitle: undefined, origin: "user" })]);
+	renderLog();
+	const [messageRow] = await messageRows(1);
+	// The list and the graph must say the same thing: an em-dash here beside a
+	// "You" on the canvas reads as two different facts about one message.
+	expect(messageRow.textContent).toContain("You → #22");
+
+	const marker = screen.getByTestId("traffic-user-card");
+	expect(marker.textContent).toContain("You");
+	// None of the task grammar leaks onto a person: no seq, no status line.
+	expect(marker.textContent).not.toContain("#");
+	// And it is a real endpoint, so the recipient card is drawn beside it.
+	expect(screen.getAllByTestId("traffic-node-card")).toHaveLength(1);
+});
+
+it("draws no user marker for a sender-less message that proved nothing", async () => {
+	// The dev3 hand-off shape. Identical to the case above but for `origin`, and
+	// it stays out of the message list too — which is why this one cannot wait on
+	// a message row the way the case above does.
+	setPage([row({ fromTaskId: null, fromSeq: null, fromTitle: undefined })]);
+	renderLog();
+	await screen.findByTestId("traffic-node-scene");
+	expect(screen.queryByTestId("traffic-user-card")).toBeNull();
+});
+
 it("Focus reveals a hibernated task selected from the task list without waking it", async () => {
 	taskExtras.value = { "task-c": { hibernated: true } };
 	setPage([row()]);

--- a/src/mainview/__tests__/agent-traffic.test.ts
+++ b/src/mainview/__tests__/agent-traffic.test.ts
@@ -73,6 +73,22 @@ describe("derivePairs", () => {
 		expect(derivePairs([row({ fromTaskId: null, fromSeq: null })])).toHaveLength(0);
 	});
 
+	// The user IS a sender, so the same sender-less shape must not swallow them.
+	// The two cases sit together deliberately: they differ only by `origin`.
+	it("keeps a pair for a message the user proved they sent", () => {
+		const pairs = derivePairs([row({ fromTaskId: null, fromSeq: null, origin: "user" })]);
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].toSeq).toBe(22);
+	});
+
+	it("does not fold the user's messages into the same pair as an unproven hand-off", () => {
+		const pairs = derivePairs([
+			row({ fromTaskId: null, fromSeq: null, origin: "user" }),
+			row({ fromTaskId: null, fromSeq: null, at: new Date(NOW - 1_000).toISOString() }),
+		]);
+		expect(pairs).toHaveLength(1);
+	});
+
 	// One unproven message taints the pair: that is the thing the human has to look at.
 	it("marks a pair unsettled when any of its rows is unproven", () => {
 		const pairs = derivePairs([
@@ -110,6 +126,13 @@ describe("unreadRows", () => {
 	it("ignores rows with no sending agent", () => {
 		const rows = [row({ at: new Date(NOW).toISOString(), fromTaskId: null, fromSeq: null })];
 		expect(unreadRows(rows, NOW - 30_000)).toHaveLength(0);
+	});
+
+	// …but the user's own message is traffic worth a badge, and it wears the same
+	// sender-less shape. Only `origin` separates this case from the one above.
+	it("counts a message the user sent", () => {
+		const rows = [row({ at: new Date(NOW).toISOString(), fromTaskId: null, fromSeq: null, origin: "user" })];
+		expect(unreadRows(rows, NOW - 30_000)).toHaveLength(1);
 	});
 
 	// A fresh install has no "last time you clicked", so 30 days of history must

--- a/src/mainview/__tests__/traffic-model.test.ts
+++ b/src/mainview/__tests__/traffic-model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessageLogRow } from "../../shared/agent-message-log";
 import type { Task } from "../../shared/types";
-import { endpointKey, nodeSeq, routeKey, trafficNodes, trafficRecords } from "../components/agent-traffic/traffic-model";
+import { USER_ENDPOINT_ID, endpointKey, fromKey, nodeSeq, routeKey, trafficNodes, trafficRecords } from "../components/agent-traffic/traffic-model";
 
 const row = (overrides: Partial<AgentMessageLogRow> = {}): AgentMessageLogRow => ({
 	v: 1, at: "2026-09-05T10:00:00.000Z", fromTaskId: "sender", fromSeq: 11,
@@ -34,6 +34,42 @@ describe("traffic model", () => {
 	it("does not merge equal ids across projects or invent human nodes", () => {
 		expect(trafficNodes([task(), task({ projectId: "second" })], [])).toHaveLength(2);
 		expect(trafficNodes([], [row({ fromTaskId: null, fromSeq: null })])).toHaveLength(1);
+	});
+
+	it("gives a proven user message a sender endpoint in the recipient's project", () => {
+		const userRow = row({ fromTaskId: null, fromSeq: null, fromProjectId: undefined, origin: "user" });
+		expect(fromKey(userRow)).toBe(endpointKey("second", USER_ENDPOINT_ID));
+		const nodes = trafficNodes([], [userRow]);
+		const marker = nodes.find(node => node.user);
+		expect(marker).toMatchObject({ projectId: "second", seq: null });
+		// No task behind it, so nothing downstream can read a status off the human.
+		expect(marker?.task).toBeUndefined();
+	});
+
+	it("still invents nothing for a sender-less row that proved nothing", () => {
+		// An artifact submit, a dev3 hand-off and a `dev3 message` run outside a
+		// worktree all look exactly like this, and none of them is the user.
+		const anonymous = row({ fromTaskId: null, fromSeq: null });
+		expect(fromKey(anonymous)).toBeNull();
+		expect(trafficNodes([], [anonymous]).some(node => node.user)).toBe(false);
+	});
+
+	it("keeps one user endpoint per project rather than one per message", () => {
+		const nodes = trafficNodes([], [
+			row({ fromTaskId: null, fromSeq: null, origin: "user" }),
+			row({ fromTaskId: null, fromSeq: null, origin: "user", toTaskId: "other", at: "2026-09-05T10:02:00.000Z" }),
+			row({ fromTaskId: null, fromSeq: null, origin: "user", toProjectId: "third", at: "2026-09-05T10:03:00.000Z" }),
+		]);
+		expect(nodes.filter(node => node.user).map(node => node.projectId).sort()).toEqual(["second", "third"]);
+	});
+
+	it("cannot collide with a task whose id happens to be the sentinel", () => {
+		const nodes = trafficNodes([task({ id: USER_ENDPOINT_ID, projectId: "second" })], [
+			row({ fromTaskId: null, fromSeq: null, origin: "user" }),
+		]);
+		// The task keeps its own identity: a real task is never redrawn as the human.
+		expect(nodes.filter(node => node.id === USER_ENDPOINT_ID)).toHaveLength(1);
+		expect(nodes.find(node => node.id === USER_ENDPOINT_ID)?.user).toBeUndefined();
 	});
 
 	it("folds reverse cross-project direction without conflating other projects", () => {

--- a/src/mainview/agent-traffic.ts
+++ b/src/mainview/agent-traffic.ts
@@ -1,6 +1,6 @@
 /** Shared recipient-project log store for the header and live traffic surface. */
 
-import type { AgentMessageLogPage, AgentMessageLogRow } from "../shared/agent-message-log";
+import { isUserOrigin, type AgentMessageLogPage, type AgentMessageLogRow } from "../shared/agent-message-log";
 import type { AgentPromptDeliveryStatus } from "../shared/agent-prompt-delivery";
 import { api } from "./rpc";
 
@@ -61,8 +61,11 @@ export function markTrafficSeen(): void {
 export function unreadRows(rows: AgentMessageLogRow[], since = trafficSeenAt()): AgentMessageLogRow[] {
 	return rows.filter((row) => {
 		const at = Date.parse(row.at);
-		// Anything dev3 itself sent is not traffic between two agents.
-		if (Number.isNaN(at) || (row.fromSeq === null && row.fromTaskId === null)) return false;
+		// Anything dev3 itself sent is not traffic. A message the user sent is,
+		// which is why the sender-less check asks about provenance rather than
+		// treating every null sender as dev3.
+		if (Number.isNaN(at)) return false;
+		if (row.fromSeq === null && row.fromTaskId === null && !isUserOrigin(row)) return false;
 		return at > since;
 	});
 }
@@ -130,7 +133,7 @@ function rowTime(row: AgentMessageLogRow): number {
 }
 
 function pairKey(row: AgentMessageLogRow): string {
-	const from = row.fromTaskId ?? `seq:${row.fromSeq ?? "?"}`;
+	const from = row.fromTaskId ?? (isUserOrigin(row) ? "dev3:user" : `seq:${row.fromSeq ?? "?"}`);
 	return [JSON.stringify([row.fromProjectId ?? row.toProjectId, from]), JSON.stringify([row.toProjectId, row.toTaskId])].sort().join("|");
 }
 
@@ -138,8 +141,9 @@ function pairKey(row: AgentMessageLogRow): string {
 export function derivePairs(rows: AgentMessageLogRow[]): TrafficPair[] {
 	const byKey = new Map<string, TrafficPair>();
 	for (const row of rows) {
-		// A row with no sender is a hand-off from dev3 itself, not agent traffic.
-		if (row.fromSeq === null && row.fromTaskId === null) continue;
+		// A row with no sender AND no proven origin is a hand-off from dev3 itself,
+		// not traffic. A row the user sent is traffic and keeps its pair.
+		if (row.fromSeq === null && row.fromTaskId === null && !isUserOrigin(row)) continue;
 		const key = pairKey(row);
 		const at = rowTime(row);
 		const existing = byKey.get(key);

--- a/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
@@ -27,6 +27,7 @@ import {
 	fromKey,
 	toKey,
 	routeKey,
+	senderLabel,
 	type TrafficRecord,
 } from "./traffic-model";
 import {
@@ -604,7 +605,7 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 			>
 				<span className="traffic-message-meta">
 					<b>
-						{row.fromSeq === null ? "—" : `#${row.fromSeq}`} → #{row.toSeq}
+						{senderLabel(row, t("traffic.node.you"))} → #{row.toSeq}
 					</b>
 					<time dateTime={row.at}>{format(row.at)}</time>
 				</span>
@@ -951,8 +952,7 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 							</div>
 							<div className="traffic-detail">
 								<b>
-									{record.row.fromSeq === null ? "—" : `#${record.row.fromSeq}`}{" "}
-									→ #{record.row.toSeq}
+									{senderLabel(record.row, t("traffic.node.you"))} → #{record.row.toSeq}
 								</b>
 								<h3 className="streamer-private">
 									{record.row.subject || t("traffic.orbit.noSubject")}

--- a/src/mainview/components/agent-traffic/TrafficIcon.tsx
+++ b/src/mainview/components/agent-traffic/TrafficIcon.tsx
@@ -12,6 +12,9 @@ const paths = {
 	message: "M4 4h16v12H9l-5 4ZM8 8h8M8 12h5",
 	check: "m4 12.5 5.5 5.5L20 6",
 	cross: "M6 6l12 12M18 6 6 18",
+	// Head and shoulders. The smallest mark that reads as a person rather than a
+	// task at the sizes this scene zooms through.
+	user: "M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM4.5 21a7.5 7.5 0 0 1 15 0",
 } as const;
 export default function TrafficIcon({ name }: { name: keyof typeof paths }) {
 	return (

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -744,6 +744,27 @@ export default function TrafficNodes({
 				</svg>
 				<div className="traffic-nodes-cards">
 					{scene.placed.map((placed) => {
+						// The user marker never reaches `Card`: it has no task to project.
+						if (placed.node.user)
+							return (
+								<UserCard
+									key={placed.node.key}
+									placed={placed}
+									messageCount={messageCounts.get(placed.node.key) ?? 0}
+									selected={selected === placed.node.key}
+									dim={selected !== null && selected !== placed.node.key}
+									active={
+										activeFrom === placed.node.key ||
+										activeTo === placed.node.key
+									}
+									scale={view.scale}
+									onSelect={(key) => {
+										manual();
+										onSelect(key);
+									}}
+									onFocus={focus}
+								/>
+							);
 						const projection =
 							projections.get(placed.node.key) ??
 							projectTaskAt(placed.node.task, cursorAt);
@@ -957,6 +978,58 @@ function CompletionBurst({
 				{line}
 			</span>
 		</div>
+	);
+}
+
+/**
+ * The person using the app, drawn as its own thing rather than through {@link Card}.
+ *
+ * Deliberately not a branch inside `Card`: it shares none of the task grammar
+ * there — no status, no overview, no seq, no replay projection, all of which
+ * would print something false about a human ("status not recorded", "#—"). It
+ * also keeps this feature out of a function another task owns.
+ */
+function UserCard({
+	placed,
+	messageCount,
+	selected,
+	dim,
+	active,
+	scale,
+	onSelect,
+	onFocus,
+}: {
+	placed: PlacedNode;
+	messageCount: number;
+	selected: boolean;
+	dim: boolean;
+	active: boolean;
+	scale: number;
+	onSelect: (key: string) => void;
+	onFocus: (key: string) => void;
+}) {
+	const t = useT();
+	return (
+		<button
+			type="button"
+			data-testid="traffic-user-card"
+			className={`traffic-node-card traffic-user-card ${selected ? "is-selected" : ""} ${dim ? "is-dim" : ""} ${active ? "is-lit" : ""}`}
+			style={{
+				left: placed.x,
+				top: placed.y,
+				width: placed.width,
+				height: placed.height,
+				["--node-inverse" as string]: 1 / scale,
+			}}
+			aria-label={`${t("traffic.node.you")} · ${t.plural("traffic.orbit.messageCount", messageCount)}`}
+			aria-pressed={selected}
+			onClick={() => onSelect(placed.node.key)}
+			onDoubleClick={() => onFocus(placed.node.key)}
+		>
+			<TrafficIcon name="user" />
+			<strong>{t("traffic.node.you")}</strong>
+			<span className="traffic-node-count">{messageCount}</span>
+		</button>
 	);
 }
 

--- a/src/mainview/components/agent-traffic/TrafficOrbit.tsx
+++ b/src/mainview/components/agent-traffic/TrafficOrbit.tsx
@@ -337,14 +337,18 @@ export default function TrafficOrbit(props: Props) {
 					label.hidden = true;
 					label.tabIndex = -1;
 					label.type = "button";
-					label.className = `traffic-node-label ${coordinator ? "is-coordinator" : ""} ${node.key === selected ? "is-selected" : ""}`;
+					label.className = `traffic-node-label ${coordinator ? "is-coordinator" : ""} ${node.user ? "is-user" : ""} ${node.key === selected ? "is-selected" : ""}`;
+					// The user has no seq and no title, and the task fallbacks would print
+					// "#—" and "historical" about a person. One honest label instead.
 					const seq = document.createElement("b");
-					seq.textContent = nodeSeq(node);
+					seq.textContent = node.user ? t("traffic.node.you") : nodeSeq(node);
 					label.append(seq);
-					const title = document.createElement("span");
-					title.className = "streamer-private";
-					title.textContent = node.title || t("traffic.orbit.historical");
-					label.append(title);
+					if (!node.user) {
+						const title = document.createElement("span");
+						title.className = "streamer-private";
+						title.textContent = node.title || t("traffic.orbit.historical");
+						label.append(title);
+					}
 					if (coordinator) {
 						const role = document.createElement("small");
 						role.textContent = t("traffic.orbit.coordinator");

--- a/src/mainview/components/agent-traffic/TrafficPlayback.tsx
+++ b/src/mainview/components/agent-traffic/TrafficPlayback.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { useTrafficPlayback } from "./useTrafficPlayback";
 import type { TrafficTimelineEvent } from "./traffic-timeline";
 import TrafficIcon from "./TrafficIcon";
+import { senderLabel } from "./traffic-model";
 
 type Props = {
 	playback: ReturnType<typeof useTrafficPlayback>;
@@ -179,7 +180,7 @@ function describeEvent(
 		const { row } = event.record;
 		return {
 			icon: "message",
-			lead: `${row.fromSeq == null ? "—" : `#${row.fromSeq}`} → #${row.toSeq}`,
+			lead: `${senderLabel(row, t("traffic.node.you"))} → #${row.toSeq}`,
 			text: row.subject || row.body.slice(0, 120),
 			private: true,
 		};

--- a/src/mainview/components/agent-traffic/traffic-model.ts
+++ b/src/mainview/components/agent-traffic/traffic-model.ts
@@ -1,12 +1,39 @@
-import type { AgentMessageLogRow } from "../../../shared/agent-message-log";
+import { isUserOrigin, type AgentMessageLogRow } from "../../../shared/agent-message-log";
 import { getTaskTitle, taskSeqLabel, type Task } from "../../../shared/types";
 
 export const endpointKey = (projectId: string, taskId: string) => JSON.stringify([projectId, taskId]);
-export const fromKey = (row: AgentMessageLogRow) => row.fromTaskId ? endpointKey(row.fromProjectId ?? row.toProjectId, row.fromTaskId) : null;
+
+/**
+ * The endpoint id standing for the person using the app.
+ *
+ * Not a task id and deliberately not shaped like one — a UUID could in principle
+ * collide, and a reader meeting this in a key must be able to see at a glance
+ * that no task is meant. One per project rather than one globally, so the marker
+ * sits inside the project group its message went to instead of floating between
+ * the group boxes with an edge crossing the whole scene.
+ */
+export const USER_ENDPOINT_ID = "dev3:user";
+
+export const userEndpointKey = (projectId: string) => endpointKey(projectId, USER_ENDPOINT_ID);
+
+/**
+ * The sender endpoint, or null when nothing is known about who sent it.
+ *
+ * Three answers, not two: a task, the user, or unknown. A row with no sender is
+ * still null — an artifact form submit, a dev3 hand-off and a `dev3 message` run
+ * outside a worktree all look like that, and none of them is the user.
+ */
+export const fromKey = (row: AgentMessageLogRow) => row.fromTaskId
+	? endpointKey(row.fromProjectId ?? row.toProjectId, row.fromTaskId)
+	: isUserOrigin(row) ? userEndpointKey(row.toProjectId) : null;
 export const toKey = (row: AgentMessageLogRow) => endpointKey(row.toProjectId, row.toTaskId);
 export const routeKey = (row: AgentMessageLogRow) => JSON.stringify([fromKey(row), toKey(row)].sort());
 export interface TrafficRecord { key: string; row: AgentMessageLogRow }
-export interface TrafficNode { key: string; projectId: string; id: string; seq: number | null; title: string; task?: Task }
+export interface TrafficNode {
+	key: string; projectId: string; id: string; seq: number | null; title: string; task?: Task;
+	/** The person using the app, not a task. Has no seq, no status and no card. */
+	user?: boolean;
+}
 
 // Occurrences preserve identical attempts; prepending rows cannot renumber old occurrences.
 export function trafficRecords(rows: AgentMessageLogRow[]): TrafficRecord[] {
@@ -26,6 +53,15 @@ export function trafficNodes(tasks: Task[], rows: AgentMessageLogRow[]): Traffic
 		nodes.set(key, { key, projectId: task.projectId, id: task.id, seq: task.seq, title: getTaskTitle(task), task });
 	}
 	for (const row of rows) {
+		// One user endpoint per project that the user actually wrote into. Never
+		// pre-seeded for every project: a marker on a board the user never messaged
+		// would claim an exchange that did not happen.
+		if (isUserOrigin(row)) {
+			const key = userEndpointKey(row.toProjectId);
+			if (!nodes.has(key)) {
+				nodes.set(key, { key, projectId: row.toProjectId, id: USER_ENDPOINT_ID, seq: null, title: "", user: true });
+			}
+		}
 		for (const [projectId, id, seq, title] of [
 			[row.fromProjectId ?? row.toProjectId, row.fromTaskId, row.fromSeq, row.fromTitle],
 			[row.toProjectId, row.toTaskId, row.toSeq, row.toTitle],
@@ -36,6 +72,19 @@ export function trafficNodes(tasks: Task[], rows: AgentMessageLogRow[]): Traffic
 		}
 	}
 	return [...nodes.values()];
+}
+
+/**
+ * How a row's sender reads in a list: a task's seq, the user, or an em-dash.
+ *
+ * Three answers in one place, because they are rendered in three (the message
+ * list, the inspector and the replay strip) and two of them saying "—" while the
+ * canvas says "You" would be two different facts about one message.
+ * `you` is passed in rather than looked up so this file stays free of i18n.
+ */
+export function senderLabel(row: AgentMessageLogRow, you: string): string {
+	if (row.fromSeq !== null) return `#${row.fromSeq}`;
+	return isUserOrigin(row) ? you : "—";
 }
 
 export function nodeSeq(node: TrafficNode): string {

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -194,6 +194,35 @@
 	background: color-mix(in srgb, var(--node-status) 14%, transparent);
 	pointer-events: none;
 }
+/* The person, not a task: no status stripe, no card grammar, and an accent ring
+   instead of a border so it reads as a different kind of thing at every zoom. */
+.traffic-user-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	text-align: center;
+	background:
+		linear-gradient(135deg, rgb(var(--accent) / 0.1), transparent 70%),
+		rgb(var(--surface-elevated));
+	box-shadow:
+		0 8px 22px rgb(0 0 0 / 0.13),
+		inset 0 0 0 1.5px rgb(var(--accent) / 0.55);
+}
+.traffic-user-card::before {
+	display: none;
+}
+.traffic-user-card .traffic-icon {
+	width: 34px;
+	height: 34px;
+	color: rgb(var(--accent));
+}
+.traffic-user-card strong {
+	font-size: 15px;
+	color: rgb(var(--text-primary));
+}
+
 .traffic-node-card.is-coordinator {
 	background:
 		linear-gradient(135deg, rgb(var(--success) / 0.065), transparent 70%),

--- a/src/mainview/i18n/translations/en/common.ts
+++ b/src/mainview/i18n/translations/en/common.ts
@@ -170,6 +170,7 @@ const common = {
 	"traffic.celebration.age": "Completed · {duration} since created",
 	"traffic.celebration.underMinute": "under a minute",
 	"traffic.node.statusUnrecorded": "Status not recorded",
+	"traffic.node.you": "You",
 	"traffic.nodes.currentOnlyDimensions": "Hibernation, project and variant are not recorded, so those stay current",
 	"traffic.nodes.follow": "Follow",
 	"traffic.nodes.focus": "Focus",

--- a/src/mainview/i18n/translations/es/common.ts
+++ b/src/mainview/i18n/translations/es/common.ts
@@ -170,6 +170,7 @@ const common = {
 	"traffic.celebration.age": "Completada · {duration} desde su creación",
 	"traffic.celebration.underMinute": "menos de un minuto",
 	"traffic.node.statusUnrecorded": "Estado no registrado",
+	"traffic.node.you": "Tú",
 	"traffic.nodes.currentOnlyDimensions": "La hibernación, el proyecto y la variante no se registran: se muestran los actuales",
 	"traffic.nodes.follow": "Seguir",
 	"traffic.nodes.focus": "Enfocar",

--- a/src/mainview/i18n/translations/ru/common.ts
+++ b/src/mainview/i18n/translations/ru/common.ts
@@ -180,6 +180,7 @@ const common = {
 	"traffic.celebration.age": "Завершена · {duration} с создания",
 	"traffic.celebration.underMinute": "меньше минуты",
 	"traffic.node.statusUnrecorded": "Статус не записан",
+	"traffic.node.you": "Вы",
 	"traffic.nodes.currentOnlyDimensions": "Хибернация, проект и вариант не записываются — они показаны текущими",
 	"traffic.nodes.follow": "Следовать",
 	"traffic.nodes.focus": "Фокус",

--- a/src/shared/agent-message-log.ts
+++ b/src/shared/agent-message-log.ts
@@ -48,6 +48,28 @@ export type AgentMessageBodyKind = "text" | "spill-pointer";
 /** Immediate `dev3 message` send versus a queued "Send later" fire. */
 export type AgentMessageLogKind = "immediate" | "scheduled";
 
+/**
+ * Who submitted the message, on the rows where dev3 can prove it.
+ *
+ * `"user"` is stamped at the call site by the few paths that are provably a human
+ * acting in this app — never derived from a row's shape. A null sender is NOT the
+ * user: it is also a dev3 hand-off, an artifact form submit, and a `dev3 message`
+ * run outside a worktree, which are three different things wearing the same face.
+ * Absent therefore means unknown, and a reader must treat it as unknown.
+ */
+export type AgentMessageOrigin = "user";
+
+/**
+ * The one place that answers "did the user send this?".
+ *
+ * A predicate rather than an inline comparison so the rule cannot be re-derived
+ * differently in the two renderers and the store — the failure it guards against
+ * is one surface quietly deciding a null sender is good enough.
+ */
+export function isUserOrigin(row: Pick<AgentMessageLogRow, "origin">): boolean {
+	return row.origin === "user";
+}
+
 /** One delivered (or attempted) message. Written once, never amended. */
 export interface AgentMessageLogRow {
 	v: number;
@@ -63,6 +85,13 @@ export interface AgentMessageLogRow {
 	toTitle?: string;
 	toProjectId: string;
 	kind: AgentMessageLogKind;
+	/**
+	 * Provenance, when it is provable. Absent on every row written before this
+	 * existed and on every path that cannot prove who acted — see
+	 * {@link AgentMessageOrigin}. Additive and optional: an older app reads the row
+	 * and ignores the field.
+	 */
+	origin?: AgentMessageOrigin;
 	/** ISO time the message was queued for, on `scheduled` rows only. */
 	scheduledFor?: string;
 	/**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,7 +12,7 @@ import type { TelemetryProfile } from "./telemetry-profile";
 export type { TelemetryProfile } from "./telemetry-profile";
 import type { PosixShellResolution, ShellFlavor } from "./posix-shell";
 import type { AgentPromptDelivery } from "./agent-prompt-delivery";
-import type { AgentMessageLogPage } from "./agent-message-log";
+import type { AgentMessageLogPage, AgentMessageOrigin } from "./agent-message-log";
 import type { NotificationLogPage } from "./notification-log";
 import type { LowBatteryStatus } from "./low-battery";
 export type { LowBatteryStatus, OutputStyleOutcome } from "./low-battery";
@@ -2705,6 +2705,12 @@ export interface ScheduledMessage {
 	target: ScheduledMessageTarget;
 	/** Set when another task's agent sent it — wraps the text at fire time. */
 	source?: AgentMessageSource;
+	/**
+	 * Provenance carried from the moment of authoring to the moment of delivery,
+	 * because a "Send later" fires hours after the user wrote it and nothing at
+	 * fire time could tell who did. Additive and optional in `tasks.json`.
+	 */
+	origin?: AgentMessageOrigin;
 	/**
 	 * The file the real body was written to when it was too large to type, leaving
 	 * {@link text} a pointer to it. Carried so the message log can say a row holds a


### PR DESCRIPTION
Messages the user sends to an agent now appear in Agent traffic as coming from them, in both presentations and in replay, instead of arriving from nowhere.

Nothing about delivery changes. Every send already went through one seam and was already written to the per-project message log, sender or no sender — what was missing was any way to say *who* sent a row that has no sending agent, and any way to draw them.

## Provenance is stamped, never inferred

`AgentMessageLogRow.origin` is optional, additive and set **at the call site** by the two paths that can prove a human acted: the diff viewer / PR-comment "Send to agent" button, and the "Send later" modal. `ScheduledMessage.origin` carries it through `tasks.json`, because a queued message fires hours later when nothing could tell who wrote it.

The tempting shortcut — treating `fromTaskId === null` as "the user" — is wrong and stays out. That shape is also worn by an artifact form submit, a `dev3 message` run outside a worktree, and dev3's own launch hand-off. Absent means **unknown**. `isUserOrigin()` is the single predicate the store, the graph model and both presentations call, so the rule cannot be re-derived differently in three places.

## Rendering reuses what exists

A proven user row gets a synthetic per-project sender endpoint, so the existing layout, edge routing, flight animation and replay work unchanged — `traffic-timeline.ts` needed no edit at all. The marker renders as its own `UserCard` rather than a branch inside `Card`: it shares none of the task grammar there, and routing a person through the task card printed "status not recorded" and `#—` about a human. `senderLabel()` gives the message list, the inspector and the replay strip one shared answer, so the canvas and the lists cannot disagree about the same message.

Experiment 1 (the orbit) draws the user as an ordinary orb; only its label is corrected, deliberately.

## Verified

Beyond the suites, one real end-to-end submission was driven on an isolated QA board with the message log wiped first: the real "Send later" modal → `origin: "user"` in `tasks.json` → the scheduler firing five minutes later → one log row → the "You" card wired to the recipient, and `You → #203` in both the message list and the replay strip.

## Known limitations

- Artifact form submits and `dev3 message` run outside a worktree stay unattributed.
- Prompts typed straight into the terminal are not recorded — that is a separate task, and the hard part there is that the submit event also fires for text dev3 itself types into the pane.
- A "Send later" row's `at` is the delivery time, not the authoring time.
- This records message submissions only. It is not a record of the user navigating to or opening anything.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=3a55344b-276c-47f6-91ba-9f30f4a6fddd) · `dev3://task/3a55344b-276c-47f6-91ba-9f30f4a6fddd` _(dev3 added this footer — turn it off in Settings → Tasks.)_
