### PR TITLE
Record a human's terminal prompt as their own message in agent traffic

### DIFF
--- a/agent-support-matrix.md
+++ b/agent-support-matrix.md
@@ -60,7 +60,7 @@ Injected into `.claude/settings.local.json`.
 
 | Hook event | Status transition | Purpose |
 |------------|------------------|---------|
-| `UserPromptSubmit` | → `in-progress` | User sent a message, agent starts working |
+| `UserPromptSubmit` | → `in-progress` | User sent a message, agent starts working. A **second** entry on the same event, `dev3 hook claude-prompt`, reads the payload's `prompt` and `prompt_id` and reports the submission for Agent traffic; the status-move entry above is untouched, so recording can never cost a task its board position |
 | `PreToolUse` | → `in-progress` | Agent is about to call a tool (also catches post-permission resume) |
 | `PostToolUse` | → `in-progress` | A tool finished, including answers submitted to `AskUserQuestion` |
 | `PermissionRequest` | → `user-questions` | Agent needs user approval for a tool call |
@@ -81,6 +81,8 @@ Generated in each task's `.codex/hooks.json` and **declared in `~/.codex/config.
 | `PermissionRequest` | → `user-questions` | Codex is waiting for a tool or network approval |
 | `PostToolUse` | → `in-progress` | Clears the waiting state after an approved tool finishes |
 | `Stop` | → `review-by-ai` / `review-by-user` | One atomic server-side transition selects the correct review target and returns valid JSON to Codex |
+
+The `UserPromptSubmit` payload also carries the submitted `prompt` and a `turn_id`, both forwarded on the existing `task.agentHook` request so a human's terminal prompt reaches Agent traffic without a second dev3 process per prompt. Whether a submission was the human is decided app-side against the receipts dev3 leaves for everything it types itself (`decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md`).
 
 Beyond status, the `SessionStart`/`UserPromptSubmit` hook payloads carry the Codex `session_id` (the resumable rollout id), and the hook process inherits `$TMUX_PANE`. dev3 records that id onto the matching `sessionState` pane so recovery can `codex resume <id>` the exact per-pane session — Codex has no launch-time session-id flag, so this is the only way to target a specific session (see decision 125).
 

--- a/change-logs/2026/09/10/feature-terminal-prompts-in-agent-traffic.md
+++ b/change-logs/2026/09/10/feature-terminal-prompts-in-agent-traffic.md
@@ -1,0 +1,3 @@
+Short: Your terminal prompts in agent traffic
+
+Prompts you type into a task's terminal now appear in Agent traffic as your own messages, on Claude Code and Codex. dev3 records what it types into every pane and matches the harness's prompt-submit hook against it, so a peer's message, a Send to agent click, a held burst and the task brief handed to the agent at launch are never mistaken for you, and nothing is counted twice. Prompts the harness submits by itself, such as a subagent completion notice, stay unattributed rather than becoming yours. Only a short preview is stored, never the prompt itself.

--- a/decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md
+++ b/decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md
@@ -40,9 +40,9 @@ dev3 answers the hook by elimination, and keeps a receipt for every elimination.
 - `recordTerminalPromptSubmission` (`src/bun/agent-terminal-prompt-log.ts`) throws a submission out
   if it opens with a dev3 envelope, if it opens with ANY pseudo-XML tag, if it consumes a receipt,
   or if its submission id was already seen.
-- The tag rule (`looksMachineGenerated`) is deliberately wider than any list dev3 could keep
-  current: harness-generated prompts wear a tag, dev3 leaves no receipt for them because dev3 did
-  not type them, and an unknown future one must stay unclassified rather than become the user.
+- The tag rule (`looksMachineGenerated`) is wider than any list dev3 could keep current, but it is
+  **not sufficient** — see the falsified assumption below. It catches the tagged harness prompts
+  and nothing else.
 - What survives every one of those tests is stamped `origin: "user"` and written as an ordinary
   message-log row.
 - Matching is by containment with length floors (`src/shared/agent-terminal-prompt.ts`), because
@@ -55,6 +55,42 @@ dev3 answers the hook by elimination, and keeps a receipt for every elimination.
 - Only a clamped one-line preview is stored. The prompt body is read in-process to classify it and
   dropped — recording every prompt would be a far wider data set than the message log and would
   routinely capture pasted secrets.
+
+## Falsified after this was written — the guarantee is not established
+
+The assumption that harness-generated prompts are recognisable by shape did not survive contact.
+Seq1863's teammate experiment (2026-09-10, raw payloads in
+`/Users/arsenyp/dev3-reports/teammate-message-origin/`) observed a `UserPromptSubmit` in the lead's
+own session that nobody typed: 5 898 characters opening with `# Autonomous loop check`, plain
+Markdown, no tag. Its payload keys are **byte-identical** to a human prompt's — `cwd`,
+`hook_event_name`, `permission_mode`, `prompt`, `prompt_id`, `scratchpad_dir`, `session_id`,
+`transcript_path` — so there is no structural field to branch on. What triggered it is unknown and
+one bounded retry did not reproduce it.
+
+Consequence, stated plainly: **dev3 cannot prove that an unclaimed, untagged submission came from a
+human.** Subtraction bounds what dev3 caused, not what the harness causes.
+
+### The owner decided the looser rule is what he wants
+
+Asked to choose between narrowing the field to a provable `"terminal"`, parking the feature, and
+building positive keystroke evidence, Arseny ruled (verbatim, 2026-09-10):
+
+> «Я не очень понимаю, в том плане, что если тебе кто-то послал при помощи dev3 message-а, то он в
+> XML-е обёрнутый. А все остальные случаи можно считать спокойно за юзера. То есть даже если ты сам
+> себе сделаешь postpone сообщения обратно, ну типа сделал postpone, чтобы сообщение послалось через
+> 5 минут, ну хер с ним, пусть он показывает, как будто от юзера.»
+
+So `origin: "user"` stays, and the residual imprecision is accepted by the person it misleads: a
+peer message is excluded because it is wrapped, and everything else counts as him. The
+`# Autonomous loop check` prompt would be shown as his — that is the accepted cost, not an
+oversight. A text-prefix blacklist remains rejected: it would grow forever behind a harness nobody
+controls, and the tag rule already removes the obvious machine chatter (subagent completion
+notices) without pretending to be exhaustive.
+
+The same experiment closed the teammate question in the other direction: a teammate *delivery* does
+not raise `UserPromptSubmit` at all, only text a human types in the teammate's pane does. The
+session-mismatch guard this record proposed as future work is therefore unnecessary and was not
+built.
 
 ## Risks
 
@@ -69,10 +105,8 @@ dev3 answers the hook by elimination, and keeps a receipt for every elimination.
   simply records nothing — the prompt field is optional on the wire.
 - Three of five harnesses (Cursor Agent, Gemini CLI, OpenCode) have no hooks, so their terminal
   prompts stay invisible. Stated, not worked around.
-- **Teammate sessions remain unknown.** A Claude Code teammate's prompt was not exercised, and if it
-  raises `UserPromptSubmit` without a leading tag it would be recorded as the user. The discriminator
-  that would settle it — comparing the payload's `session_id` against the session dev3 pre-assigned
-  to the pane's lead agent, and refusing to classify on a proven mismatch — is not built here.
+- **Untagged harness prompts are recorded as the user**, and the payload offers nothing to
+  distinguish them from a human's. Accepted by the owner rather than solved; see his ruling above.
 - **Nothing has been observed end to end in a running app.** Every dev3-side behaviour above is
   covered by unit tests only; what was verified live is the harness half (which payloads arrive,
   and when).

--- a/decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md
+++ b/decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md
@@ -1,0 +1,89 @@
+# Prove a terminal prompt is the user by subtraction, with receipts
+
+## Context
+
+Agent traffic shows agents talking to each other. The human who starts most of those turns is
+invisible, so a graph of a working day reads as machines conversing with nobody. The obvious
+source of that missing half is the harness's own `UserPromptSubmit` hook, which dev3 already
+installs on Claude Code and Codex — the two harnesses of five that have hooks at all.
+
+The hook cannot answer the question it looks like it answers. It fires for whatever was submitted
+in the pane, and dev3 types into that pane constantly: peer `dev3 message` deliveries, the
+Send-to-agent button, the Send-later modal, PR and rebase hand-offs, artifact replies, held
+bursts. Two earlier proposals were rejected before this one: a per-pane timing window (its failure
+mode is a silent false "the user said this"), and treating the absence of a `<dev3-ai-message>`
+envelope as proof of a human (it is only proof of the negative case).
+
+## Investigation
+
+Measured against claude 2.1.267 and codex-cli 0.153.4 rather than assumed:
+
+- Claude Code **does** fire `UserPromptSubmit` for a prompt supplied as a launch argument —
+  verified with a capture hook for both `claude -p "<text>"` and an interactive `claude "<text>"`.
+  Left alone, every task's own description would have been recorded as the user's first message.
+- The Claude payload carries `prompt` and `prompt_id`, a stable per-submission id.
+- **The harness submits prompts of its own.** Finishing a Task subagent raises a SECOND
+  `UserPromptSubmit` in the same session carrying `<task-notification>…`, with its own `prompt_id`
+  and nothing marking it as generated — observed, not theorised. dev3 typed none of it, so no
+  receipt can cover it and only the shape of the text can.
+- Codex's `user-prompt-submit.command.input` schema, read out of the shipped binary, requires
+  `prompt`, `session_id` and `turn_id`. Schema-verified, not observed live: `codex exec` fires no
+  hooks, and observing one live would mean editing the user's global `~/.codex/config.toml`.
+
+## Decision
+
+dev3 answers the hook by elimination, and keeps a receipt for every elimination.
+
+- `noteDev3TypedPrompt` (`src/bun/agent-typed-prompt-claims.ts`) records the text of every prompt
+  dev3 causes: once at `deliverAgentPrompt` — the single seam every delivery passes through — and
+  once per launch site in `rpc-handlers/tmux-pty.ts` for the brief and a column agent's prompt.
+- `recordTerminalPromptSubmission` (`src/bun/agent-terminal-prompt-log.ts`) throws a submission out
+  if it opens with a dev3 envelope, if it opens with ANY pseudo-XML tag, if it consumes a receipt,
+  or if its submission id was already seen.
+- The tag rule (`looksMachineGenerated`) is deliberately wider than any list dev3 could keep
+  current: harness-generated prompts wear a tag, dev3 leaves no receipt for them because dev3 did
+  not type them, and an unknown future one must stay unclassified rather than become the user.
+- What survives every one of those tests is stamped `origin: "user"` and written as an ordinary
+  message-log row.
+- Matching is by containment with length floors (`src/shared/agent-terminal-prompt.ts`), because
+  the pane composes: a burst joins several deliveries, a board snapshot trails them, the harness
+  appends its protocol body to a launch argument. Receipts are consumed, so two identical sends
+  need two receipts.
+- Claude gets a **second** `UserPromptSubmit` hook entry (`dev3 hook claude-prompt`) beside the
+  status move, which is untouched. Codex carries the prompt on its existing `task.agentHook`
+  payload and costs the pane no extra process.
+- Only a clamped one-line preview is stored. The prompt body is read in-process to classify it and
+  dropped — recording every prompt would be a far wider data set than the message log and would
+  routinely capture pasted secrets.
+
+## Risks
+
+- **Over-suppression is the chosen failure direction.** A human prompt that quotes something dev3
+  typed, or that is submitted while a dev3 message sits unsent in the input box, loses its row.
+  That costs one missing row; the opposite error writes a peer's words down as the user's.
+- **Two app processes on one task.** A forwarded native delivery now leaves a receipt on the owner
+  side as well (`deliverNativePromptAsOwner`), so whichever process the hook reaches can answer for
+  the text. What remains unhandled is a receipt left in a third process that neither decided nor
+  typed.
+- **Codex is schema-verified only.** If the live payload differs from the shipped schema, Codex
+  simply records nothing — the prompt field is optional on the wire.
+- Three of five harnesses (Cursor Agent, Gemini CLI, OpenCode) have no hooks, so their terminal
+  prompts stay invisible. Stated, not worked around.
+- **Teammate sessions remain unknown.** A Claude Code teammate's prompt was not exercised, and if it
+  raises `UserPromptSubmit` without a leading tag it would be recorded as the user. The discriminator
+  that would settle it — comparing the payload's `session_id` against the session dev3 pre-assigned
+  to the pane's lead agent, and refusing to classify on a proven mismatch — is not built here.
+- **Nothing has been observed end to end in a running app.** Every dev3-side behaviour above is
+  covered by unit tests only; what was verified live is the harness half (which payloads arrive,
+  and when).
+
+## Alternatives considered
+
+- **Timing window against `deliverAgentPrompt`** — rejected in report 02: a mismatch is silent and
+  falsely attributes a peer's message to the user.
+- **Envelope absence as proof** — only sound in the negative direction; it says nothing about the
+  UI send paths, hand-offs or the launch brief, all of which are unwrapped.
+- **Suppressing the first prompt of a session** — a blanket rule that both misses a second launch
+  path and eats a real first human prompt.
+- **Folding recording into the existing status-move hook** — one command, one blast radius: a bug
+  in recording would then cost every task its board status.

--- a/src/bun/__tests__/agent-hooks.test.ts
+++ b/src/bun/__tests__/agent-hooks.test.ts
@@ -34,7 +34,8 @@ describe("buildClaudeHooks", () => {
 		expect(hooks).toHaveProperty("PostToolUse");
 		expect(hooks).toHaveProperty("PermissionRequest");
 		expect(hooks).toHaveProperty("Stop");
-		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		// Two entries: the status move, plus the recorder that reads the prompt.
+		expect(hooks.UserPromptSubmit).toHaveLength(2);
 		expect(hooks.PreToolUse).toHaveLength(1);
 		expect(hooks.PostToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
@@ -49,6 +50,17 @@ describe("buildClaudeHooks", () => {
 		expect(cmd).toContain("--status in-progress");
 		expect(cmd).toContain("--if-status-not review-by-ai");
 		expect(cmd).not.toContain("review-by-user");
+	});
+
+	it("records the prompt from a SECOND entry, leaving the status move untouched", () => {
+		const hooks = buildClaudeHooks();
+		const [move, record] = hooks.UserPromptSubmit;
+
+		// The status move is what every task's board position depends on, so the
+		// recorder is added beside it rather than folded into it.
+		expect(move!.hooks[0]!.command).toContain("task move --status in-progress");
+		expect(record!.hooks[0]!.command).toBe(`${DEV3_CLI} hook claude-prompt`);
+		expect(record!.hooks[0]!.timeout).toBe(5);
 	});
 
 	it("PreToolUse hook moves to in-progress with --if-status-not guard", () => {
@@ -166,7 +178,7 @@ describe("buildClaudeHooks", () => {
 				for (const entry of group.hooks) {
 					// Either "dev3 task move --status X" or a "dev3 hook <name>" adapter
 					// that reads the event from stdin — never a UUID either way.
-					expect(entry.command).toMatch(/task move --status|hook claude-stop-failure/);
+					expect(entry.command).toMatch(/task move --status|hook claude-stop-failure|hook claude-prompt/);
 					expect(entry.command).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/);
 				}
 			}
@@ -228,7 +240,8 @@ describe("mergeClaudeHooks", () => {
 
 		expect(result.hooks).toBeDefined();
 		const hooks = result.hooks as Record<string, MatcherGroup[]>;
-		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		// Two entries: the status move, plus the recorder that reads the prompt.
+		expect(hooks.UserPromptSubmit).toHaveLength(2);
 		expect(hooks.PreToolUse).toHaveLength(1);
 		expect(hooks.PostToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
@@ -281,7 +294,8 @@ describe("mergeClaudeHooks", () => {
 		const second = mergeClaudeHooks(first as Record<string, unknown>);
 		const hooks = second.hooks as Record<string, MatcherGroup[]>;
 
-		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		// Two entries: the status move, plus the recorder that reads the prompt.
+		expect(hooks.UserPromptSubmit).toHaveLength(2);
 		expect(hooks.PreToolUse).toHaveLength(1);
 		expect(hooks.PermissionRequest).toHaveLength(1);
 		expect(hooks.Stop).toHaveLength(1);
@@ -479,7 +493,8 @@ describe("writeClaudeHooks", () => {
 		const content = JSON.parse(readFileSync(settingsPath, "utf-8"));
 		const hooks = content.hooks as Record<string, MatcherGroup[]>;
 
-		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		// Two entries: the status move, plus the recorder that reads the prompt.
+		expect(hooks.UserPromptSubmit).toHaveLength(2);
 		expect(hooks.Stop).toHaveLength(1);
 		expect(hooks.Stop[0].hooks[0].command).toContain("task move --status");
 		expect(content.permissions.allow).toContain(DEV3_BASH_PERMISSION);

--- a/src/bun/__tests__/agent-terminal-prompt-log.test.ts
+++ b/src/bun/__tests__/agent-terminal-prompt-log.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Recording a terminal submission as the user's — read back off a real log file,
+ * never asserted against the writer.
+ *
+ * Every suppression case here is a way dev3 itself causes a `UserPromptSubmit`:
+ * a peer message, the Send-to-agent and Send-later paths (which write their own
+ * row already), a held burst, and the task brief handed over as a launch
+ * argument. If any of them starts producing a row, the traffic graph gains a
+ * human who never typed, or counts one message twice.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+
+const home = vi.hoisted(() => require("node:fs").mkdtempSync(`${require("node:os").tmpdir()}/dev3-termprompt-`) as string);
+vi.mock("../paths", () => ({ DEV3_HOME: home, OPS_DIR: `${home}/ops`, SANDBOX_DIR: `${home}/sandbox` }));
+vi.mock("../git", () => ({
+	projectSlug: (p: string) => p.replace(/^\//, "").replaceAll("/", "-"),
+}));
+vi.mock("../rpc-handlers/shared-pure", () => ({ getPushMessage: vi.fn(() => vi.fn()) }));
+vi.mock("../agent-message-log-watch", () => ({ noteLocalMessageLogAppend: vi.fn() }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import type { Project, Task } from "../../shared/types";
+import { isUserOrigin } from "../../shared/agent-message-log";
+import { AGENT_MESSAGE_BURST_SEPARATOR, wrapAgentMessage } from "../../shared/agent-message-envelope";
+import { TERMINAL_PROMPT_PREVIEW_MAX_CHARS } from "../../shared/agent-terminal-prompt";
+import { messageLogDir, readAgentMessageLog, resetAgentMessageLogPruneState } from "../agent-message-log";
+import { noteDev3TypedPrompt, resetTypedPromptClaims } from "../agent-typed-prompt-claims";
+import { recordTerminalPromptSubmission, resetPromptSubmissionMemory } from "../agent-terminal-prompt-log";
+
+const project = { id: "proj-1", name: "Proj", path: "/Users/x/repo" } as unknown as Project;
+const task = { id: "task-12345678", projectId: "proj-1", seq: 1848, title: "Worker" } as unknown as Task;
+
+function submit(prompt: string, overrides: Record<string, unknown> = {}) {
+	return recordTerminalPromptSubmission({
+		project,
+		task,
+		harness: "claude",
+		prompt,
+		sessionId: "session-1",
+		submissionId: `prompt-${Math.random()}`,
+		...overrides,
+	});
+}
+
+function rows() {
+	return readAgentMessageLog(project).rows;
+}
+
+beforeEach(() => {
+	rmSync(messageLogDir(project), { recursive: true, force: true });
+	resetAgentMessageLogPruneState();
+	resetTypedPromptClaims();
+	resetPromptSubmissionMemory();
+});
+
+describe("a prompt dev3 did not cause", () => {
+	it("is written as the user's, addressed to the task whose pane it was typed in", () => {
+		expect(submit("please rebase this branch")).toBe("recorded");
+
+		const [row] = rows();
+		expect(row).toBeDefined();
+		expect(isUserOrigin(row!)).toBe(true);
+		expect(row!.fromTaskId).toBeNull();
+		expect(row!.toTaskId).toBe(task.id);
+		expect(row!.toSeq).toBe(1848);
+		expect(row!.body).toBe("please rebase this branch");
+	});
+
+	it("stores a preview, never the prompt", () => {
+		submit(`${"x".repeat(500)} SECRET-TAIL`);
+
+		const [row] = rows();
+		expect(row!.body.length).toBeLessThanOrEqual(TERMINAL_PROMPT_PREVIEW_MAX_CHARS);
+		expect(row!.body).not.toContain("SECRET-TAIL");
+	});
+});
+
+describe("submissions dev3 caused", () => {
+	it("does not record a peer message, which arrives wrapped", () => {
+		const wrapped = wrapAgentMessage("do the thing", { taskId: "t-9", seq: 9 }, project.id, "the thing");
+		expect(submit(wrapped)).toBe("envelope");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("does not record the harness's own subagent-completion prompt", () => {
+		// Observed on claude 2.1.267: finishing a Task subagent raises a SECOND
+		// UserPromptSubmit in the same session, with its own prompt id and nothing
+		// marking it as generated. dev3 typed none of it, so no receipt exists and
+		// only the shape of the text can save it.
+		const notification = "<task-notification>\n<task-id>a7a60b2f2e83f827c</task-id>\n<result>PONG</result>\n</task-notification>";
+		expect(submit(notification)).toBe("machine-tagged");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("does not record slash-command scaffolding or a reminder either", () => {
+		expect(submit("<command-name>/review</command-name>\nrun it")).toBe("machine-tagged");
+		expect(submit("<system-reminder>the plan is stale</system-reminder>")).toBe("machine-tagged");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("still records a human prompt that merely contains a tag further in", () => {
+		expect(submit("why does <task-notification> keep showing up?")).toBe("recorded");
+		expect(rows()).toHaveLength(1);
+	});
+
+	it("does not record what a UI send typed, so the row that path already wrote is not doubled", () => {
+		// sendAgentMessageNow / scheduleMessage both go through deliverAgentPrompt,
+		// which leaves this receipt, and both write their own row with origin "user".
+		noteDev3TypedPrompt(task.id, "Please look at this diff hunk");
+		expect(submit("Please look at this diff hunk")).toBe("dev3-typed");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("does not record the task brief handed over as a launch argument", () => {
+		noteDev3TypedPrompt(task.id, "Record terminal user messages reliably, without duplicates.");
+		const asSubmitted = "Record terminal user messages reliably, without duplicates.\n\n# dev3 — Task Lifecycle Protocol\n…";
+		expect(submit(asSubmitted)).toBe("dev3-typed");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("does not record a held burst, composed of several deliveries plus a trailer", () => {
+		noteDev3TypedPrompt(task.id, "first peer body, long enough to match");
+		noteDev3TypedPrompt(task.id, "second peer body, long enough to match");
+		const composed = [
+			"first peer body, long enough to match",
+			"second peer body, long enough to match",
+			"<dev3-board>snapshot</dev3-board>",
+		].join(AGENT_MESSAGE_BURST_SEPARATOR);
+		expect(submit(composed)).toBe("dev3-typed");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("records the human's next prompt after a receipt was spent", () => {
+		noteDev3TypedPrompt(task.id, "a peer message with enough length");
+		expect(submit("a peer message with enough length")).toBe("dev3-typed");
+		expect(submit("now do what it said")).toBe("recorded");
+		expect(rows()).toHaveLength(1);
+	});
+});
+
+describe("exactly once", () => {
+	it("writes one row when the same submission is reported twice", () => {
+		expect(submit("ship it", { submissionId: "prompt-7" })).toBe("recorded");
+		expect(submit("ship it", { submissionId: "prompt-7" })).toBe("duplicate");
+		expect(rows()).toHaveLength(1);
+	});
+
+	it("writes two rows for two submissions of the same text", () => {
+		submit("again", { submissionId: "prompt-1" });
+		submit("again", { submissionId: "prompt-2" });
+		expect(rows()).toHaveLength(2);
+	});
+
+	it("refuses to record when the harness identified nothing", () => {
+		expect(submit("who sent this", { sessionId: null, submissionId: null })).toBe("unidentified");
+		expect(rows()).toHaveLength(0);
+	});
+
+	it("ignores an empty submission", () => {
+		expect(submit("   ")).toBe("empty");
+		expect(rows()).toHaveLength(0);
+	});
+});

--- a/src/bun/__tests__/agent-terminal-prompt.test.ts
+++ b/src/bun/__tests__/agent-terminal-prompt.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The rules that separate a human's terminal prompt from dev3's own writing,
+ * and the receipts that make the separation provable rather than guessed.
+ *
+ * The cases that carry the weight are the negative ones: a peer's message, a
+ * held burst, and the task brief handed over as a launch argument all reach the
+ * prompt-submit hook looking exactly like someone typing. Each of them has its
+ * own case here, and each fails the moment the receipt is dropped or matched
+ * loosely.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { wrapAgentMessage } from "../../shared/agent-message-envelope";
+import { AGENT_MESSAGE_BURST_SEPARATOR } from "../../shared/agent-message-envelope";
+import {
+	TERMINAL_PROMPT_PREVIEW_MAX_CHARS,
+	isDev3EnvelopeText,
+	promptSubmissionKey,
+	submissionMatchesTypedText,
+	terminalPromptPreview,
+} from "../../shared/agent-terminal-prompt";
+import {
+	TYPED_PROMPT_CLAIM_LIMIT,
+	TYPED_PROMPT_CLAIM_TTL_MS,
+	claimDev3TypedPrompt,
+	noteDev3TypedPrompt,
+	resetTypedPromptClaims,
+	typedPromptClaimCount,
+} from "../agent-typed-prompt-claims";
+
+const TASK = "task-1";
+
+beforeEach(() => {
+	resetTypedPromptClaims();
+});
+
+describe("the envelope test", () => {
+	it("recognises what wrapAgentMessage actually produces", () => {
+		const wrapped = wrapAgentMessage("hi", { taskId: "t-1", seq: 7, title: "Peer" }, "proj-1", "a subject");
+		expect(isDev3EnvelopeText(wrapped)).toBe(true);
+	});
+
+	it("still recognises the first member of a burst", () => {
+		const first = wrapAgentMessage("one", { taskId: "t-1", seq: 7 }, "proj-1", "first");
+		const second = wrapAgentMessage("two", { taskId: "t-2", seq: 8 }, "proj-1", "second");
+		expect(isDev3EnvelopeText(`${first}${AGENT_MESSAGE_BURST_SEPARATOR}${second}`)).toBe(true);
+	});
+
+	it("does not claim a human prompt that merely mentions the tag later on", () => {
+		expect(isDev3EnvelopeText("why does <dev3-ai-message> show up in my terminal?")).toBe(false);
+	});
+});
+
+describe("matching what dev3 typed", () => {
+	it("matches the same text through different line endings and trailing space", () => {
+		expect(submissionMatchesTypedText("hello there\r\nsecond line\n\n", "hello there\nsecond line")).toBe(true);
+	});
+
+	it("matches a launch brief the harness extended with its protocol body", () => {
+		expect(submissionMatchesTypedText("Fix the auth race\n\n# dev3 protocol\n...", "Fix the auth race")).toBe(true);
+	});
+
+	it("matches one member inside a composed burst", () => {
+		const submitted = `<dev3-ai-message>a</dev3-ai-message>\n\nthe second peer's whole body here\n\n<dev3-board>…</dev3-board>`;
+		expect(submissionMatchesTypedText(submitted, "the second peer's whole body here")).toBe(true);
+	});
+
+	it("refuses a short fragment sitting in the middle of a human prompt", () => {
+		// "ok" as a hand-off must not swallow every prompt containing the word.
+		expect(submissionMatchesTypedText("looks ok to me, ship it", "ok")).toBe(false);
+	});
+});
+
+describe("the receipts", () => {
+	it("consumes a receipt once, so an identical second submission is not covered", () => {
+		noteDev3TypedPrompt(TASK, "run the migration now please");
+		expect(claimDev3TypedPrompt(TASK, "run the migration now please")).toBe(true);
+		expect(claimDev3TypedPrompt(TASK, "run the migration now please")).toBe(false);
+	});
+
+	it("keeps one receipt per delivery, so two identical sends are both covered", () => {
+		noteDev3TypedPrompt(TASK, "run the migration now please");
+		noteDev3TypedPrompt(TASK, "run the migration now please");
+		expect(claimDev3TypedPrompt(TASK, "run the migration now please")).toBe(true);
+		expect(claimDev3TypedPrompt(TASK, "run the migration now please")).toBe(true);
+		expect(claimDev3TypedPrompt(TASK, "run the migration now please")).toBe(false);
+	});
+
+	it("never lets one task's receipt cover another task's pane", () => {
+		noteDev3TypedPrompt(TASK, "a message with enough length");
+		expect(claimDev3TypedPrompt("task-2", "a message with enough length")).toBe(false);
+	});
+
+	it("expires, so an old receipt cannot swallow a prompt hours later", () => {
+		const t0 = 1_000_000;
+		noteDev3TypedPrompt(TASK, "a message with enough length", t0);
+		expect(claimDev3TypedPrompt(TASK, "a message with enough length", t0 + TYPED_PROMPT_CLAIM_TTL_MS + 1)).toBe(false);
+	});
+
+	it("drops the oldest receipts rather than growing without bound", () => {
+		for (let i = 0; i < TYPED_PROMPT_CLAIM_LIMIT + 10; i += 1) {
+			noteDev3TypedPrompt(TASK, `delivery number ${i} of many`);
+		}
+		expect(typedPromptClaimCount(TASK)).toBe(TYPED_PROMPT_CLAIM_LIMIT);
+		expect(claimDev3TypedPrompt(TASK, "delivery number 0 of many")).toBe(false);
+	});
+
+	it("ignores an empty delivery instead of leaving a receipt that matches nothing", () => {
+		noteDev3TypedPrompt(TASK, "   \n  ");
+		expect(typedPromptClaimCount(TASK)).toBe(0);
+	});
+});
+
+describe("what gets stored", () => {
+	it("clamps a long prompt and drops its tail entirely", () => {
+		const preview = terminalPromptPreview(`${"x".repeat(400)}SECRET-TAIL`);
+		expect(preview.length).toBeLessThanOrEqual(TERMINAL_PROMPT_PREVIEW_MAX_CHARS);
+		expect(preview).not.toContain("SECRET-TAIL");
+	});
+
+	it("collapses a pasted block onto one line", () => {
+		expect(terminalPromptPreview("first\n\n   second\tthird")).toBe("first second third");
+	});
+});
+
+describe("submission identity", () => {
+	it("separates two harnesses that reuse an id", () => {
+		expect(promptSubmissionKey("claude", "s", "p")).not.toBe(promptSubmissionKey("codex", "s", "p"));
+	});
+
+	it("is null when the harness gave nothing to identify the submission by", () => {
+		expect(promptSubmissionKey("claude", null, undefined)).toBeNull();
+	});
+});

--- a/src/bun/__tests__/agent-typed-prompt-callsite.test.ts
+++ b/src/bun/__tests__/agent-typed-prompt-callsite.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The receipts are only as complete as the places that leave them.
+ *
+ * `deliverAgentPrompt` is the one seam every dev3-caused prompt passes through —
+ * peer messages, the Send-to-agent and Send-later paths, hand-offs, held bursts.
+ * If it stops leaving a receipt, every one of those is recorded as something the
+ * user typed, silently and on every send. So this drives the real function and
+ * reads the receipt back.
+ *
+ * The launch argument is the other source, and it does not pass through that
+ * seam. Its wiring is asserted at the end as a deletion guard: proof that the
+ * call is still there, not proof that it fires — the behaviour it produces is
+ * covered in `agent-terminal-prompt-log.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+
+vi.mock("../agent-hooks-refresh", () => ({ refreshClaudeHooksForTask: vi.fn(async () => {}) }));
+vi.mock("../agent-prompt", () => ({
+	sendPromptToAgentPane: vi.fn(async () => ({ status: "delivered", deliveryId: "d", backend: "tmux", paneId: "%1", retryableAsNewDelivery: false })),
+	sendPromptToPane: vi.fn(async () => ({ status: "delivered", deliveryId: "d", backend: "tmux", paneId: "%1", retryableAsNewDelivery: false })),
+	holdMessageForAgentPane: vi.fn(async () => ({ status: "held" })),
+	holdMessageForPane: vi.fn(async () => ({ status: "held" })),
+}));
+vi.mock("../agent-prompt-native", () => ({
+	sendPromptToNativeAgentPane: vi.fn(async () => ({ status: "unconfirmed" })),
+	sendPromptToNativePane: vi.fn(async () => ({ status: "unconfirmed" })),
+}));
+vi.mock("../task-terminal-backend", () => ({ taskTerminalBackendIdentity: () => "tmux" }));
+
+import type { Task } from "../../shared/types";
+import { deliverAgentPrompt } from "../agent-prompt-delivery";
+import { claimDev3TypedPrompt, resetTypedPromptClaims } from "../agent-typed-prompt-claims";
+
+const task = { id: "task-1", projectId: "proj-1", seq: 1, title: "T" } as unknown as Task;
+
+beforeEach(() => {
+	resetTypedPromptClaims();
+});
+
+describe("deliverAgentPrompt", () => {
+	it("leaves a receipt for the text it is about to type", async () => {
+		await deliverAgentPrompt(task, "a peer message long enough to match");
+		expect(claimDev3TypedPrompt(task.id, "a peer message long enough to match")).toBe(true);
+	});
+
+	it("leaves it for a HELD message too, which is typed minutes later", async () => {
+		await deliverAgentPrompt(task, "a held message long enough to match", { kind: "agent" }, { hold: true });
+		expect(claimDev3TypedPrompt(task.id, "a held message long enough to match")).toBe(true);
+	});
+
+	it("leaves it before the text can land, not after the send returns", async () => {
+		const { sendPromptToAgentPane } = await import("../agent-prompt");
+		vi.mocked(sendPromptToAgentPane).mockImplementationOnce(async () => {
+			// The hook can fire while the send is still in flight.
+			expect(claimDev3TypedPrompt(task.id, "typed while the send is in flight")).toBe(true);
+			return { status: "delivered", deliveryId: "d", backend: "tmux", paneId: "%1", retryableAsNewDelivery: false } as never;
+		});
+		await deliverAgentPrompt(task, "typed while the send is in flight");
+	});
+});
+
+describe("the launch argument", () => {
+	it("still registers a receipt at both launch sites", () => {
+		const source = readFileSync(new URL("../rpc-handlers/tmux-pty.ts", import.meta.url), "utf-8");
+		// The task brief and a column agent's prompt both reach the agent as launch
+		// arguments, and Claude Code fires UserPromptSubmit for them.
+		expect(source.split("noteDev3TypedPrompt(").length - 1).toBe(2);
+	});
+});

--- a/src/bun/__tests__/agent-typed-prompt-owner-receipt.test.ts
+++ b/src/bun/__tests__/agent-typed-prompt-owner-receipt.test.ts
@@ -1,0 +1,46 @@
+/**
+ * A native delivery forwarded to the app process holding the pane's writer
+ * lease leaves its receipt on BOTH sides.
+ *
+ * The sender's process decided to type and noted it there; the pane's
+ * prompt-submit hook, however, reaches whichever process owns the task's CLI
+ * socket. With one receipt in the wrong process, a forwarded peer message is
+ * recorded as something the user typed — the one attribution failure this
+ * feature must not have. Own file because the callsite suite mocks this module
+ * away.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agent-prompt", () => ({ scheduleAgentPromptSubmit: vi.fn(), markAgentPane: vi.fn() }));
+vi.mock("../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../native-pane-owner", () => ({ forwardToOwner: vi.fn(), resolvePaneOwner: vi.fn() }));
+vi.mock("../native-task-panes", () => ({ nativeTaskPanesState: vi.fn() }));
+vi.mock("../pty-server", () => ({
+	// No terminal here: the receipt must be left before the delivery can fail,
+	// because the hook fires for what was typed, not for what succeeded.
+	nativePaneTerminal: vi.fn(() => null),
+	ensureNativePanePtySession: vi.fn(),
+	reattachNativeTaskSession: vi.fn(),
+}));
+
+import { deliverNativePromptAsOwner } from "../agent-prompt-native";
+import { claimDev3TypedPrompt, resetTypedPromptClaims } from "../agent-typed-prompt-claims";
+
+beforeEach(() => {
+	resetTypedPromptClaims();
+});
+
+describe("deliverNativePromptAsOwner", () => {
+	it("leaves a receipt in the process that actually types", async () => {
+		await deliverNativePromptAsOwner({
+			taskId: "task-1",
+			paneId: "pane-1",
+			text: "a forwarded peer message body",
+		});
+
+		expect(claimDev3TypedPrompt("task-1", "a forwarded peer message body")).toBe(true);
+	});
+});

--- a/src/bun/agent-prompt-delivery.ts
+++ b/src/bun/agent-prompt-delivery.ts
@@ -31,6 +31,7 @@ import { holdMessageForAgentPane, holdMessageForPane, sendPromptToAgentPane, sen
 import { sendPromptToNativeAgentPane, sendPromptToNativePane } from "./agent-prompt-native";
 import { taskTerminalBackendIdentity } from "./task-terminal-backend";
 import { refreshClaudeHooksForTask } from "./agent-hooks-refresh";
+import { noteDev3TypedPrompt } from "./agent-typed-prompt-claims";
 
 /**
  * Text appended once at the end of the agent's turn, after every message in the
@@ -69,6 +70,12 @@ export async function deliverAgentPrompt(
 	// settings file behind us. Done at hold time too: a held message may land many
 	// seconds later, but nothing else runs on its behalf in between.
 	await refreshClaudeHooksForTask(task);
+
+	// That same UserPromptSubmit is indistinguishable from the user typing, so
+	// leave the receipt BEFORE the text can be submitted: this is the one seam
+	// every dev3-caused prompt passes through, which is what makes the receipts a
+	// complete set rather than a list of the paths someone remembered.
+	noteDev3TypedPrompt(task.id, prompt);
 
 	if (taskTerminalBackendIdentity(task) === "native") {
 		// The native arm folds the trailer in NOW rather than at release time, so a

--- a/src/bun/agent-prompt-native.ts
+++ b/src/bun/agent-prompt-native.ts
@@ -37,6 +37,7 @@ import { type AgentPromptDelivery, agentPromptHeld } from "../shared/agent-promp
 import { AGENT_MESSAGE_HOLD_IDLE_MS } from "../shared/agent-message-hold-timing";
 import { scheduleAgentPromptSubmit } from "./agent-prompt";
 import { agentMessageHoldKey, holdAgentMessage } from "./agent-message-hold";
+import { noteDev3TypedPrompt } from "./agent-typed-prompt-claims";
 import { createLogger } from "./logger";
 import { forwardToOwner, resolvePaneOwner } from "./native-pane-owner";
 import type { NativeTaskTerminal } from "./native-task-terminal";
@@ -170,6 +171,11 @@ async function bindPane(task: Task, paneId: string): Promise<NativeTaskTerminal 
  * rather than a phantom success.
  */
 export async function deliverNativePromptAsOwner(params: NativePromptDeliveryParams): Promise<boolean> {
+	// The sender's process already holds a receipt for this text, but the pane's
+	// prompt-submit hook reaches whichever process owns the task's CLI socket —
+	// which, on a forwarded delivery, may be this one. A receipt on both sides is
+	// what keeps a forwarded peer message from being recorded as the user.
+	noteDev3TypedPrompt(params.taskId, params.text);
 	const terminal = nativePaneTerminal(params.taskId, params.paneId);
 	if (!terminal) return false;
 	if (terminal.hostRole() !== "writer") {

--- a/src/bun/agent-terminal-prompt-log.ts
+++ b/src/bun/agent-terminal-prompt-log.ts
@@ -1,0 +1,130 @@
+/**
+ * Recording ordinary human prompts typed into a task's terminal, so agent
+ * traffic shows the person who started a turn and not only the agents talking
+ * to each other.
+ *
+ * The event comes from the harness's own prompt-submit hook. Everything hard
+ * about it is deciding whether the human submitted it — see
+ * `agent-typed-prompt-claims.ts` for the receipts this consults, and
+ * `../shared/agent-terminal-prompt.ts` for the pure rules.
+ *
+ * The row carries a clamped preview, never the prompt. `origin: "user"` is
+ * stamped here because this path CAN prove a human acted: the harness reported a
+ * submission, dev3 holds no receipt for it, and it carries no dev3 envelope.
+ */
+
+import type { Project, Task } from "../shared/types";
+import {
+	type PromptSubmitHarness,
+	isDev3EnvelopeText,
+	looksMachineGenerated,
+	normalizeSubmittedPrompt,
+	promptSubmissionKey,
+	terminalPromptPreview,
+} from "../shared/agent-terminal-prompt";
+import { appendAgentMessageLog } from "./agent-message-log";
+import { claimDev3TypedPrompt } from "./agent-typed-prompt-claims";
+import { createLogger } from "./logger";
+
+const log = createLogger("agent-terminal-prompt");
+
+/**
+ * Why a submission was or was not written down. Returned rather than logged
+ * alone so the hook adapter and its tests can assert the reason, and so a
+ * silently-dropped prompt is never indistinguishable from a recorded one.
+ */
+export type TerminalPromptOutcome =
+	| "recorded"
+	| "empty"
+	| "envelope"
+	| "machine-tagged"
+	| "dev3-typed"
+	| "duplicate"
+	| "unidentified";
+
+/**
+ * How long one submission id is remembered. A hook can be delivered twice (a
+ * retry, or two dev3 processes reachable on the same socket path), and the two
+ * deliveries carry the SAME id — which is the only reason exactly-once is
+ * provable here rather than guessed from text and timing.
+ */
+export const PROMPT_SUBMISSION_MEMORY_MS = 10 * 60_000;
+
+/** Bounded so a long-lived app cannot grow this without limit. */
+export const PROMPT_SUBMISSION_MEMORY_LIMIT = 512;
+
+let seenSubmissions = new Map<string, number>();
+
+function alreadySeen(key: string, now: number): boolean {
+	for (const [seen, at] of seenSubmissions) {
+		if (at <= now - PROMPT_SUBMISSION_MEMORY_MS) seenSubmissions.delete(seen);
+	}
+	if (seenSubmissions.has(key)) return true;
+	seenSubmissions.set(key, now);
+	if (seenSubmissions.size > PROMPT_SUBMISSION_MEMORY_LIMIT) {
+		const oldest = seenSubmissions.keys().next().value;
+		if (oldest !== undefined) seenSubmissions.delete(oldest);
+	}
+	return false;
+}
+
+/** Test seam: forget which submissions were recorded. */
+export function resetPromptSubmissionMemory(): void {
+	seenSubmissions = new Map();
+}
+
+export interface TerminalPromptSubmission {
+	project: Project;
+	task: Task;
+	harness: PromptSubmitHarness;
+	prompt: string;
+	sessionId?: string | null;
+	submissionId?: string | null;
+}
+
+/**
+ * Record one submission as the user's, or say why it is not one.
+ *
+ * The order of the tests is the argument: a submission dev3 caused is thrown out
+ * before anything is written, and only what survives all of them is called the
+ * human's.
+ */
+export function recordTerminalPromptSubmission(
+	submission: TerminalPromptSubmission,
+	now: Date = new Date(),
+): TerminalPromptOutcome {
+	const { project, task, harness, prompt } = submission;
+	const text = normalizeSubmittedPrompt(prompt);
+	if (!text) return "empty";
+	if (isDev3EnvelopeText(text)) return "envelope";
+	// Whatever else opens with a tag is the harness talking to itself — a subagent
+	// completion notice, slash-command scaffolding, a reminder. dev3 left no
+	// receipt for those because dev3 did not type them, so without this they would
+	// be recorded as the user.
+	if (looksMachineGenerated(text)) return "machine-tagged";
+	if (claimDev3TypedPrompt(task.id, text, now.getTime())) return "dev3-typed";
+
+	const key = promptSubmissionKey(harness, submission.sessionId, submission.submissionId);
+	// No identity means no way to tell a redelivered hook from a second prompt.
+	// Writing anyway would double-count a turn in the graph, which is the exact
+	// failure this feature was asked not to introduce.
+	if (!key) return "unidentified";
+	if (alreadySeen(key, now.getTime())) return "duplicate";
+
+	appendAgentMessageLog(project, {
+		at: now.toISOString(),
+		fromTaskId: null,
+		fromSeq: null,
+		toTaskId: task.id,
+		toSeq: task.seq,
+		...(task.title ? { toTitle: task.title } : {}),
+		toProjectId: project.id,
+		kind: "immediate",
+		origin: "user",
+		body: terminalPromptPreview(text),
+		bodyKind: "text",
+		status: "delivered",
+	}, now);
+	log.info("recorded a terminal prompt as the user's", { taskId: task.id.slice(0, 8), harness });
+	return "recorded";
+}

--- a/src/bun/agent-typed-prompt-claims.ts
+++ b/src/bun/agent-typed-prompt-claims.ts
@@ -1,0 +1,101 @@
+/**
+ * The receipts for everything dev3 types into a task's agent.
+ *
+ * A prompt-submit hook cannot say who submitted, so dev3 answers it by
+ * elimination: every prompt dev3 causes leaves a claim here, and a hook whose
+ * text matches no claim is the human at the keyboard. The claim is consumed when
+ * it matches, so two identical peer messages need two claims and the second
+ * submission cannot be waved through by the first one's receipt.
+ *
+ * In memory on purpose. A claim is only meaningful between "dev3 decided to type
+ * this" and "the harness reported it submitted", which is seconds to minutes
+ * inside one app process; persisting it would outlive the pane it describes and
+ * would be one more place a prompt's text sits on disk.
+ *
+ * Known limit, stated rather than papered over: when another dev3 app process
+ * owns the pane's writer lease, the delivery is forwarded to it and the claim is
+ * still noted here, in the process that decided to send. The hook reaches the
+ * process that owns the task's CLI socket. Those are the same process in every
+ * ordinary install; two app processes sharing one task are the case where a
+ * dev3-typed prompt can be recorded as the user's.
+ */
+
+import { normalizeSubmittedPrompt, submissionMatchesTypedText } from "../shared/agent-terminal-prompt";
+
+/**
+ * How long a receipt is worth keeping. A held message waits for the pane to go
+ * quiet before a single character is typed, and the wait is open-ended, so the
+ * window has to be generous — but not unbounded: an expired claim only costs a
+ * suppressed row, while an immortal one would swallow a human prompt that
+ * happens to quote it hours later.
+ */
+export const TYPED_PROMPT_CLAIM_TTL_MS = 30 * 60_000;
+
+/**
+ * Receipts kept per task. Deliveries far outnumber submissions (a message that
+ * never lands still leaves a claim), so the list is bounded and the oldest goes
+ * first.
+ */
+export const TYPED_PROMPT_CLAIM_LIMIT = 64;
+
+interface TypedPromptClaim {
+	text: string;
+	expiresAt: number;
+}
+
+let claimsByTask = new Map<string, TypedPromptClaim[]>();
+
+function live(claims: TypedPromptClaim[], now: number): TypedPromptClaim[] {
+	return claims.filter((claim) => claim.expiresAt > now);
+}
+
+/**
+ * Record that dev3 is about to type `text` into `taskId`'s agent. Called for the
+ * text as dev3 hands it over, before the pane composes a burst around it —
+ * matching is by containment precisely so that composition does not matter.
+ */
+export function noteDev3TypedPrompt(taskId: string, text: string, now: number = Date.now()): void {
+	const normalized = normalizeSubmittedPrompt(text);
+	if (!normalized) return;
+	const existing = live(claimsByTask.get(taskId) ?? [], now);
+	existing.push({ text: normalized, expiresAt: now + TYPED_PROMPT_CLAIM_TTL_MS });
+	claimsByTask.set(taskId, existing.slice(-TYPED_PROMPT_CLAIM_LIMIT));
+}
+
+/**
+ * Consume the receipt for `submitted`, if dev3 left one.
+ *
+ * True means dev3 caused this submission and it must not be recorded as the
+ * user's. Consuming is the whole point: the same text typed twice is two
+ * submissions and needs two receipts.
+ */
+export function claimDev3TypedPrompt(taskId: string, submitted: string, now: number = Date.now()): boolean {
+	const claims = live(claimsByTask.get(taskId) ?? [], now);
+	// Newest first: a re-sent message should spend its own receipt rather than an
+	// older one that another submission may still be about to match.
+	let index = -1;
+	for (let i = claims.length - 1; i >= 0; i -= 1) {
+		const claim = claims[i];
+		if (claim && submissionMatchesTypedText(submitted, claim.text)) {
+			index = i;
+			break;
+		}
+	}
+	if (index === -1) {
+		claimsByTask.set(taskId, claims);
+		return false;
+	}
+	claims.splice(index, 1);
+	claimsByTask.set(taskId, claims);
+	return true;
+}
+
+/** How many receipts are still live for a task. Diagnostics and tests only. */
+export function typedPromptClaimCount(taskId: string, now: number = Date.now()): number {
+	return live(claimsByTask.get(taskId) ?? [], now).length;
+}
+
+/** Test seam: forget every receipt. */
+export function resetTypedPromptClaims(): void {
+	claimsByTask = new Map();
+}

--- a/src/bun/cli-socket-server.ts
+++ b/src/bun/cli-socket-server.ts
@@ -29,6 +29,7 @@ import { getTmuxLayout } from "./pty-server";
 import { scheduleMessage as scheduleMessageCore, sendMessageImmediately } from "./scheduled-message-scheduler";
 import { NATIVE_PROMPT_DELIVERY_METHOD, deliverNativePromptAsOwner } from "./agent-prompt-native";
 import { deliverAgentPrompt } from "./agent-prompt-delivery";
+import { recordTerminalPromptSubmission } from "./agent-terminal-prompt-log";
 import type { AgentPromptDeliveryStatus } from "../shared/agent-prompt-delivery";
 import { NATIVE_PANE_INPUT_METHOD, runNativePaneInputAsOwner } from "./pane-input-native";
 import type { PaneInputProgram } from "../shared/pane-input";
@@ -1674,7 +1675,42 @@ const handlers: Record<string, Handler> = {
 			await captureCodexPaneSession(project, task.id, paneId, sessionId);
 		}
 
+		// Codex carries the submitted text on the same payload, so recording rides
+		// on the status hook rather than costing the pane a second dev3 process.
+		if (event === "UserPromptSubmit" && typeof params.prompt === "string") {
+			recordTerminalPromptSubmission({
+				project,
+				task: updated,
+				harness: "codex",
+				prompt: params.prompt,
+				sessionId,
+				submissionId: typeof params.turnId === "string" ? params.turnId : null,
+			});
+		}
+
 		return updated;
+	},
+
+	/**
+	 * A harness reported that a prompt was submitted in a task's pane. Whether
+	 * that was the human is decided in `recordTerminalPromptSubmission`, which
+	 * throws out everything dev3 itself typed before writing anything.
+	 *
+	 * Returns the verdict rather than a bare ok, so a suppressed submission is
+	 * distinguishable from a recorded one in the hook's own logs and tests.
+	 */
+	"task.promptSubmitted": async (params) => {
+		const { project, task } = await resolveTaskFromParams(params);
+		const harness = params.harness === "codex" ? "codex" : "claude";
+		const outcome = recordTerminalPromptSubmission({
+			project,
+			task,
+			harness,
+			prompt: typeof params.prompt === "string" ? params.prompt : "",
+			sessionId: typeof params.sessionId === "string" ? params.sessionId : null,
+			submissionId: typeof params.submissionId === "string" ? params.submissionId : null,
+		});
+		return { outcome };
 	},
 
 	// Claude Code's StopFailure hook: an API error ended the turn, so the agent is

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -49,6 +49,7 @@ import {
 	validAltClickPanes,
 } from "../tmux";
 import { markAgentPane } from "../agent-prompt";
+import { noteDev3TypedPrompt } from "../agent-typed-prompt-claims";
 import { clearSetupExitCode, dev3TaskTempPath, setupExitCodePath } from "../temp-paths";
 import { stopSetupFailureWatch, watchSetupFailure } from "../setup-failure-watch";
 import { taskTerminalBackendIdentity } from "../task-terminal-backend";
@@ -713,6 +714,11 @@ export async function launchTaskPty(
 		projectPath: project.path,
 		worktreePath,
 	};
+	// The brief reaches the agent as a launch argument, and Claude Code fires
+	// UserPromptSubmit for it exactly as if the user had typed it. Leave the
+	// receipt here or every task's own description is recorded as the user's
+	// first message.
+	noteDev3TypedPrompt(task.id, ctx.taskDescription);
 
 	let tmuxCmd: string;
 	let extraEnv: Record<string, string>;
@@ -1063,6 +1069,9 @@ export async function launchColumnAgent(
 		projectPath: project.path,
 		worktreePath,
 	};
+	// A column agent runs in the same worktree, so its own launch prompt reaches
+	// the prompt-submit hook under this task's id too.
+	noteDev3TypedPrompt(task.id, prompt);
 
 	let tmuxCmd: string;
 	let extraEnv: Record<string, string>;

--- a/src/cli/__tests__/claude-prompt-hook.test.ts
+++ b/src/cli/__tests__/claude-prompt-hook.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Claude Code's `UserPromptSubmit` adapter. It reports a submission and does
+ * nothing else — the task's status is moved by the other entry on the same
+ * event, which this must never be able to disturb.
+ *
+ * Payload shape verified against claude 2.1.267: `prompt` and `prompt_id` are
+ * both present, and `prompt_id` is what makes exactly-once provable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliContext } from "../context";
+
+vi.mock("../socket-client", () => ({
+	sendRequest: vi.fn(),
+}));
+
+import { sendRequest } from "../socket-client";
+import { handleClaudePrompt } from "../commands/claude-prompt";
+
+const mockSend = vi.mocked(sendRequest);
+const SOCKET = "/tmp/test.sock";
+const CONTEXT: CliContext = {
+	projectId: "project-1",
+	taskId: "task-1",
+	socketPath: SOCKET,
+};
+
+const PAYLOAD = {
+	session_id: "session-1",
+	prompt_id: "prompt-9",
+	hook_event_name: "UserPromptSubmit",
+	prompt: "rebase and push",
+	transcript_path: "/tmp/transcript.jsonl",
+	cwd: "/tmp/worktree",
+};
+
+let stderr = "";
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stderr = "";
+	stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stderr += String(chunk);
+		return true;
+	});
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	stderrSpy.mockRestore();
+});
+
+describe("handleClaudePrompt", () => {
+	it("reports the submission with its identity, and nothing about the transcript", async () => {
+		mockSend.mockResolvedValue({ id: "1", ok: true, data: { outcome: "recorded" } });
+
+		await handleClaudePrompt(JSON.stringify(PAYLOAD), SOCKET, CONTEXT);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.promptSubmitted", {
+			taskId: "task-1",
+			projectId: "project-1",
+			harness: "claude",
+			prompt: "rebase and push",
+			sessionId: "session-1",
+			submissionId: "prompt-9",
+		}, expect.anything());
+		// transcript_path is global conversation surveillance and is never read.
+		const [, , params] = mockSend.mock.calls[0]!;
+		expect(JSON.stringify(params)).not.toContain("transcript");
+	});
+
+	it("stays silent on another hook event", async () => {
+		await handleClaudePrompt(JSON.stringify({ ...PAYLOAD, hook_event_name: "Stop" }), SOCKET, CONTEXT);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it("sends nothing for an empty prompt", async () => {
+		await handleClaudePrompt(JSON.stringify({ ...PAYLOAD, prompt: "  " }), SOCKET, CONTEXT);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it("does nothing outside a task worktree", async () => {
+		await handleClaudePrompt(JSON.stringify(PAYLOAD), SOCKET, null);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it("swallows unparseable input rather than failing the prompt", async () => {
+		await expect(handleClaudePrompt("not json", SOCKET, CONTEXT)).resolves.toBeUndefined();
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it("swallows a socket failure, since a traffic row is never worth erasing a prompt", async () => {
+		mockSend.mockRejectedValue(new Error("app is down"));
+		await expect(handleClaudePrompt(JSON.stringify(PAYLOAD), SOCKET, CONTEXT)).resolves.toBeUndefined();
+		expect(stderr).toContain("app is down");
+	});
+});

--- a/src/cli/__tests__/codex-hook.test.ts
+++ b/src/cli/__tests__/codex-hook.test.ts
@@ -86,6 +86,46 @@ describe("handleCodexHook", () => {
 		expect(stdout).toBe("{}");
 	});
 
+	it("carries the submitted prompt and its turn id on UserPromptSubmit", async () => {
+		mockSend.mockResolvedValue({ id: "1", ok: true, data: {} });
+
+		await handleCodexHook(
+			JSON.stringify({
+				hook_event_name: "UserPromptSubmit",
+				session_id: "session-3",
+				turn_id: "turn-8",
+				prompt: "rebase and push",
+				transcript_path: "/tmp/rollout.jsonl",
+			}),
+			SOCKET,
+			CONTEXT,
+		);
+
+		expect(mockSend).toHaveBeenCalledWith(SOCKET, "task.agentHook", {
+			taskId: "task-1",
+			projectId: "project-1",
+			event: "UserPromptSubmit",
+			sessionId: "session-3",
+			prompt: "rebase and push",
+			turnId: "turn-8",
+		}, { timeoutMs: 3_000, connectAttempts: 2, retryDelayMs: 50 });
+		// The rollout transcript is never read: that would be conversation capture,
+		// not one submission.
+		expect(JSON.stringify(mockSend.mock.calls[0]![2])).not.toContain("rollout");
+	});
+
+	it("carries no prompt on the other lifecycle events", async () => {
+		mockSend.mockResolvedValue({ id: "1", ok: true, data: {} });
+
+		await handleCodexHook(
+			JSON.stringify({ hook_event_name: "Stop", session_id: "s", prompt: "leftover" }),
+			SOCKET,
+			CONTEXT,
+		);
+
+		expect(mockSend.mock.calls[0]![2]).not.toHaveProperty("prompt");
+	});
+
 	it("is a successful no-op outside a dev3 task", async () => {
 		await handleCodexHook(
 			JSON.stringify({ hook_event_name: "Stop" }),

--- a/src/cli/commands/claude-prompt.ts
+++ b/src/cli/commands/claude-prompt.ts
@@ -1,0 +1,64 @@
+import type { CliContext } from "../context";
+import { sendRequest } from "../socket-client";
+
+/**
+ * What Claude Code hands a `UserPromptSubmit` hook on stdin. Verified against
+ * claude 2.1.267: `prompt_id` is a stable per-submission id, which is what lets
+ * dev3 record a submission exactly once instead of matching on text and timing.
+ */
+interface ClaudePromptPayload {
+	prompt: string;
+	sessionId?: string;
+	promptId?: string;
+}
+
+function parsePayload(rawInput: string): ClaudePromptPayload | null {
+	try {
+		const parsed = JSON.parse(rawInput) as Record<string, unknown>;
+		if (parsed.hook_event_name !== "UserPromptSubmit") return null;
+		if (typeof parsed.prompt !== "string" || !parsed.prompt.trim()) return null;
+		return {
+			prompt: parsed.prompt,
+			...(typeof parsed.session_id === "string" ? { sessionId: parsed.session_id } : {}),
+			...(typeof parsed.prompt_id === "string" ? { promptId: parsed.prompt_id } : {}),
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Internal adapter for Claude Code's `UserPromptSubmit` hook: report the
+ * submission so agent traffic can show a human message, and nothing else.
+ *
+ * The task's status is moved by the OTHER entry on the same event, which is
+ * untouched. This one is pure recording, so every path here is quiet and
+ * successful — a hook that exited non-zero would erase the user's prompt, and a
+ * traffic row is never worth that.
+ */
+export async function handleClaudePrompt(
+	rawInput: string,
+	socketPath: string | null,
+	context: CliContext | null,
+): Promise<void> {
+	const payload = parsePayload(rawInput);
+	if (!payload || !socketPath || !context?.taskId) return;
+
+	try {
+		const response = await sendRequest(socketPath, "task.promptSubmitted", {
+			taskId: context.taskId,
+			projectId: context.projectId,
+			harness: "claude",
+			prompt: payload.prompt,
+			...(payload.sessionId ? { sessionId: payload.sessionId } : {}),
+			...(payload.promptId ? { submissionId: payload.promptId } : {}),
+		}, { timeoutMs: 3_000, connectAttempts: 2, retryDelayMs: 50 });
+		if (!response.ok) {
+			process.stderr.write(`dev3 Claude prompt hook: ${response.error || "recording failed"}\n`);
+		}
+	} catch (error) {
+		process.stderr.write(
+			`dev3 Claude prompt hook: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
+	}
+}

--- a/src/cli/commands/codex-hook.ts
+++ b/src/cli/commands/codex-hook.ts
@@ -9,6 +9,10 @@ import { sendRequest } from "../socket-client";
 interface CodexHookPayload {
 	event: CodexStatusHookEvent;
 	sessionId?: string;
+	/** The submitted text, on `UserPromptSubmit` only. */
+	prompt?: string;
+	/** Codex's own per-turn identity — how a redelivered hook is recognised. */
+	turnId?: string;
 }
 
 function parsePayload(rawInput: string): CodexHookPayload | null {
@@ -16,6 +20,8 @@ function parsePayload(rawInput: string): CodexHookPayload | null {
 		const parsed = JSON.parse(rawInput) as {
 			hook_event_name?: unknown;
 			session_id?: unknown;
+			prompt?: unknown;
+			turn_id?: unknown;
 		};
 		if (typeof parsed.hook_event_name !== "string") return null;
 		if (!CODEX_STATUS_HOOK_EVENTS.includes(parsed.hook_event_name as CodexStatusHookEvent)) {
@@ -24,6 +30,8 @@ function parsePayload(rawInput: string): CodexHookPayload | null {
 		return {
 			event: parsed.hook_event_name as CodexStatusHookEvent,
 			...(typeof parsed.session_id === "string" ? { sessionId: parsed.session_id } : {}),
+			...(typeof parsed.prompt === "string" && parsed.prompt.trim() ? { prompt: parsed.prompt } : {}),
+			...(typeof parsed.turn_id === "string" ? { turnId: parsed.turn_id } : {}),
 		};
 	} catch {
 		return null;
@@ -59,6 +67,10 @@ export async function handleCodexHook(
 				event: payload.event,
 				...(payload.sessionId ? { sessionId: payload.sessionId } : {}),
 				...(paneId ? { paneId } : {}),
+				// Carried on the status hook so a submitted prompt costs the pane no
+				// second dev3 process; what happens to it is decided app-side.
+				...(payload.event === "UserPromptSubmit" && payload.prompt ? { prompt: payload.prompt } : {}),
+				...(payload.turnId ? { turnId: payload.turnId } : {}),
 			}, { timeoutMs: 3_000, connectAttempts: 2, retryDelayMs: 50 });
 			if (!response.ok) {
 				process.stderr.write(`dev3 Codex hook: ${response.error || "status update failed"}\n`);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -30,6 +30,7 @@ import { handleArtifactTemplate } from "./commands/artifact-template";
 import { handleInlineHtml } from "./commands/inline-html";
 import { handleStatusLine } from "./commands/statusline";
 import { handleCodexHook } from "./commands/codex-hook";
+import { handleClaudePrompt } from "./commands/claude-prompt";
 import { handleClaudeStopFailure } from "./commands/claude-stop-failure";
 import { handleDoctor } from "./commands/doctor";
 import { handleUpdate } from "./commands/update";
@@ -211,6 +212,16 @@ async function main(): Promise<void> {
 		// Internal lifecycle adapter. It intentionally remains successful when
 		// the app is offline so a status-sync failure can never block Codex.
 		return await handleCodexHook(
+			await Bun.stdin.text(),
+			socketPath || context?.socketPath || null,
+			context,
+		);
+	}
+	if (command === "hook" && subcommand === "claude-prompt") {
+		// Internal: Claude Code's UserPromptSubmit, read for recording only. It
+		// never blocks or fails the prompt — the status move is a separate entry
+		// on the same event.
+		return await handleClaudePrompt(
 			await Bun.stdin.text(),
 			socketPath || context?.socketPath || null,
 			context,

--- a/src/shared/agent-hooks.ts
+++ b/src/shared/agent-hooks.ts
@@ -52,6 +52,13 @@ export function codexHookCommand(dialect: HookCliDialect = DEFAULT_DIALECT): str
 
 export const CODEX_DEV3_HOOK_COMMAND = codexHookCommand();
 export const CLAUDE_STOP_FAILURE_HOOK_SUBCOMMAND = "hook claude-stop-failure";
+/**
+ * Reads the submitted prompt off stdin so agent traffic can show the human who
+ * started a turn. A SECOND entry beside the status move rather than a rewrite of
+ * it: every task's board status depends on that command, and folding a new job
+ * into it would put recording and status sync in one blast radius.
+ */
+export const CLAUDE_PROMPT_HOOK_SUBCOMMAND = "hook claude-prompt";
 export const CODEX_STATUS_HOOK_EVENTS = [
 	"SessionStart",
 	"UserPromptSubmit",
@@ -219,6 +226,13 @@ export function buildClaudeHooks(
 	return {
 		UserPromptSubmit: [
 			{ hooks: [{ type: "command", command: workingCmd }] },
+			{
+				hooks: [{
+					type: "command",
+					command: `${dialect.cli} ${CLAUDE_PROMPT_HOOK_SUBCOMMAND}`,
+					timeout: 5,
+				}],
+			},
 		],
 		PreToolUse: [
 			{ hooks: [{ type: "command", command: workingCmd }] },

--- a/src/shared/agent-terminal-prompt.ts
+++ b/src/shared/agent-terminal-prompt.ts
@@ -1,0 +1,146 @@
+/**
+ * The rules that decide whether a harness prompt-submit hook is the human.
+ *
+ * A `UserPromptSubmit` hook fires for whatever was submitted in the agent's pane,
+ * and dev3 types into that pane constantly — peer `dev3 message` deliveries, the
+ * Send-to-agent and Send-later buttons, hand-offs, and the task brief handed to
+ * the agent as a launch argument (verified: Claude Code fires the hook for that
+ * too). So the event alone proves nothing, and the absence of an envelope proves
+ * nothing either.
+ *
+ * What does prove it is subtraction with a receipt: dev3 records the text of
+ * every prompt IT causes, and a submission that matches none of them is the
+ * user's. This module holds the pure half of that — normalisation, the envelope
+ * test, the match, and the preview that is the only part of a prompt ever
+ * written down.
+ */
+
+/**
+ * Longest preview kept for one terminal submission.
+ *
+ * The prompt body itself is never stored: recording every prompt the user types
+ * would be a far wider data set than the message log (which only holds text
+ * deliberately addressed to another task) and would routinely capture pasted
+ * secrets. A clamped one-line preview is what the traffic surfaces render, and
+ * nothing here needs more.
+ */
+export const TERMINAL_PROMPT_PREVIEW_MAX_CHARS = 240;
+
+/**
+ * Shortest dev3-typed text that may be matched by containment rather than by
+ * equality. A two-character hand-off ("ok") would otherwise be a substring of
+ * half the prompts a human writes and would silently swallow their rows.
+ */
+export const TYPED_PROMPT_MIN_NEEDLE_CHARS = 16;
+
+/** The first line of everything dev3 wraps before typing it into a pane. */
+export const DEV3_ENVELOPE_TAGS = ["<dev3-ai-message>", "<dev3-artifact-message>"] as const;
+
+/**
+ * One submitted text, comparable. Line endings differ between the pane, the hook
+ * payload and the string dev3 typed, and trailing whitespace is added by the
+ * submit itself — neither difference is a different message.
+ */
+export function normalizeSubmittedPrompt(text: string): string {
+	return text.replaceAll("\r\n", "\n").replaceAll("\r", "\n").trim();
+}
+
+/**
+ * True when the submission opens with a dev3 envelope, which no human writes and
+ * dev3 always writes for a peer message, a hand-off or an artifact reply.
+ *
+ * Only the NEGATIVE direction is trustworthy: wrapped is never the user, but
+ * unwrapped is not yet the user. It stays as a second, independent test so a
+ * peer's message is still recognised if its claim expired or was consumed.
+ */
+export function isDev3EnvelopeText(text: string): boolean {
+	const firstLine = normalizeSubmittedPrompt(text).split("\n", 1)[0]?.trimStart() ?? "";
+	return DEV3_ENVELOPE_TAGS.some((tag) => firstLine.startsWith(tag));
+}
+
+/** A pseudo-XML tag opening the first line: `<task-notification>`, `<command-name>`, … */
+const MACHINE_TAG_RE = /^<[a-z][a-z0-9-]*>/u;
+
+/**
+ * True when the submission opens with a machine tag, whoever wrote it.
+ *
+ * The harness submits prompts of its own, and they are indistinguishable from a
+ * human's at the hook: Claude Code raises a second `UserPromptSubmit` carrying
+ * `<task-notification>…` when a subagent finishes — same session, its own
+ * prompt id, nothing marking it as generated. Observed, not theorised (claude
+ * 2.1.267). Slash-command scaffolding and reminders wear the same shape.
+ *
+ * So the rule is structural and deliberately wider than any list dev3 could keep
+ * current: a submission that begins with a tag is machinery and stays
+ * unclassified. A human who genuinely opens a prompt with `<foo>` loses that one
+ * row — the direction we choose every time.
+ */
+export function looksMachineGenerated(text: string): boolean {
+	const firstLine = normalizeSubmittedPrompt(text).split("\n", 1)[0]?.trimStart() ?? "";
+	return MACHINE_TAG_RE.test(firstLine);
+}
+
+/**
+ * Shortest dev3-typed text that may be matched as a PREFIX. A launch brief and a
+ * hand-off always lead their submission, but the harness appends to them (the
+ * dev3 protocol body, an interpolated append-prompt), so equality would miss
+ * them and a short task description would then be recorded as a prompt the user
+ * typed.
+ */
+export const TYPED_PROMPT_MIN_PREFIX_CHARS = 4;
+
+/**
+ * True when `submitted` carries text dev3 typed.
+ *
+ * Three ways to match, widest first, because the pane composes: a held burst
+ * joins several messages with a separator, a board snapshot is appended after
+ * them, a launch argument is extended with the protocol body, and the whole
+ * thing arrives as one prompt. Every piece dev3 put there disqualifies the
+ * submission from being called the user's.
+ *
+ * The length floors run in the safe direction on purpose. Matching too eagerly
+ * costs one unrecorded human prompt; matching too little writes down a peer's
+ * message as something the user said, which is the failure this must not have.
+ */
+export function submissionMatchesTypedText(submitted: string, typed: string): boolean {
+	const haystack = normalizeSubmittedPrompt(submitted);
+	const needle = normalizeSubmittedPrompt(typed);
+	if (!needle || !haystack) return false;
+	if (haystack === needle) return true;
+	if (needle.length >= TYPED_PROMPT_MIN_PREFIX_CHARS && haystack.startsWith(needle)) return true;
+	if (needle.length < TYPED_PROMPT_MIN_NEEDLE_CHARS) return false;
+	return haystack.includes(needle);
+}
+
+/**
+ * The single line stored for a submission: whitespace collapsed so a pasted
+ * block does not render as one very tall row, and clamped.
+ */
+export function terminalPromptPreview(text: string): string {
+	const oneLine = normalizeSubmittedPrompt(text).replaceAll(/\s+/gu, " ");
+	if (oneLine.length <= TERMINAL_PROMPT_PREVIEW_MAX_CHARS) return oneLine;
+	return `${oneLine.slice(0, TERMINAL_PROMPT_PREVIEW_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+/**
+ * The harnesses whose prompt-submit hook dev3 reads. Both hand over a stable
+ * per-submission id, which is what makes exactly-once provable rather than
+ * guessed: Claude Code's `prompt_id`, Codex's `turn_id`.
+ */
+export type PromptSubmitHarness = "claude" | "codex";
+
+/**
+ * Identity of ONE submission, stable across a redelivered hook.
+ *
+ * Null when the harness gave no ids at all — the caller then has no way to tell a
+ * retry from a second submission, and refuses to record rather than risk writing
+ * the same prompt twice.
+ */
+export function promptSubmissionKey(
+	harness: PromptSubmitHarness,
+	sessionId: string | null | undefined,
+	submissionId: string | null | undefined,
+): string | null {
+	if (!sessionId && !submissionId) return null;
+	return `${harness}:${sessionId ?? "no-session"}:${submissionId ?? "no-submission"}`;
+}


### PR DESCRIPTION
Prompts typed into a task's terminal now reach Agent traffic as the user's own rows, on Claude Code and Codex — the two harnesses that have prompt-submit hooks. Until now the graph showed agents talking to each other with the person who started every turn invisible.

A `UserPromptSubmit` hook fires for whatever was submitted in the pane, and dev3 types into that pane constantly, so the event proves nothing on its own. dev3 therefore leaves a receipt for every prompt it causes — at `deliverAgentPrompt`, on the owner side of a forwarded native delivery, and at each launch site for the brief handed over as a launch argument — and consumes it exactly once when the hook reports that text. A peer's message, a Send-to-agent click, a Send-later fire, a held burst and the task brief are all excluded that way, so nothing is double-counted with the rows the UI paths already write.

Verified against claude 2.1.267 rather than assumed: the hook does fire for a prompt passed as a launch argument (so without that receipt every task's own description would have been recorded as the user's first message), and finishing a Task subagent raises a second `UserPromptSubmit` carrying `<task-notification>` with its own prompt id and nothing marking it as generated. Anything opening with a pseudo-XML tag therefore stays unclassified. Claude's `prompt_id` and Codex's `turn_id` (schema-verified out of the codex-cli binary) give exactly-once without matching on text or timing.

What this deliberately does not claim is recorded in `decisions/2026/09/10/prove-a-terminal-prompt-is-the-user.md`: an untagged prompt the harness submits by itself is indistinguishable from a human's in the payload, and the owner chose to accept that rather than narrow the field.

Claude gets a second `UserPromptSubmit` entry beside the status move rather than a rewrite of it — every task's board position depends on that command. Codex carries the prompt on the payload it already sends. Only a clamped one-line preview is stored; the body is classified in process and dropped.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=352ef085-6a1c-415d-a6f9-3558ca686163) · `dev3://task/352ef085-6a1c-415d-a6f9-3558ca686163`