### PR TITLE
Keep traffic cards legible when the overview frames the whole graph

### DIFF
--- a/change-logs/2026/09/10/fix-mobile-traffic-card-readability.md
+++ b/change-logs/2026/09/10/fix-mobile-traffic-card-readability.md
@@ -1,0 +1,3 @@
+Short: Traffic cards stay readable on a phone
+
+Agent traffic (Experiment 2) no longer opens on a stage of blank coloured rectangles: the automatic overview stops at the zoom where a card still shows its number, title and status, and pan, zoom and Live Follow reach the rest. Pressing "Fit everything on screen" still frames the whole graph exactly as before.

--- a/decisions/2026/09/10/overview-framing-floor-keeps-cards-legible.md
+++ b/decisions/2026/09/10/overview-framing-floor-keeps-cards-legible.md
@@ -1,0 +1,51 @@
+# The automatic traffic overview never frames below the legible tier
+
+## Context
+
+Experiment 2 of Agent traffic frames the whole graph on open, on resize, and whenever Live
+Follow falls back to the overview. Card detail is a function of zoom: below `0.36` the
+`cell` tier hides the entire card body (`traffic-nodes.css`,
+`.traffic-nodes[data-detail="cell"] .traffic-node-card > * { display: none }`), leaving a bare
+coloured rectangle.
+
+On a phone the two rules meet badly. Measured on a 390×844 viewport (stage 390×419, nine
+cards): the fit lands at **18%**, so entry is nine blank rectangles with no seq, title or
+status anywhere on screen — reported as a side finding by Seq 1862 and re-measured here on
+`main`. It is not a mobile-only defect: 41 cards on a 1440×900 stage fit at **14%** and give
+the same wall of blank cells.
+
+## Decision
+
+`overviewScale()` in `src/mainview/components/agent-traffic/traffic-camera.ts` now takes a
+`floor`, and `fit()` in `TrafficNodes.tsx` passes `IDENTITY_SCALE` (0.36) — the same constant
+the `cell`/`compact` boundary uses, so the floor and the CSS tier cannot drift apart. The
+automatic overview therefore opens at the lowest zoom where a card still carries its identity
+and shows a centred part of the graph instead of all of it illegibly.
+
+The user's own controls are untouched: pan, wheel zoom and the ± buttons still reach
+`MIN_SCALE` (0.14), and the explicit **Fit everything on screen** button (plus the minimap's
+fit) passes `exact` and stays a true whole-graph fit — the label would otherwise lie.
+
+Detail-tier arithmetic moved into `traffic-camera.ts` as `detailTier()` / `IDENTITY_SCALE` /
+`FULL_DETAIL_SCALE` so it is unit-testable; happy-dom has no layout engine, so the component's
+own `fitNodes` cannot be exercised in a test.
+
+## Risks
+
+On a board large enough that even a desktop fit falls under 36%, entry now shows a subset of
+the graph rather than all of it. That is deliberate — the "all of it" being replaced was
+blank — but it is a visible change for big boards, not only for phones. The Fit button is the
+escape hatch.
+
+The floor is an absolute scale, like `MAX_SCALE` and the overview ceiling next to it. It is
+calibrated on `CARD_WIDTH = 300`; a much wider or narrower card would need it re-measured.
+
+## Alternatives considered
+
+- **Keep the whole-graph fit and give the `cell` tier a tiny label** (seq only). Preserves the
+  overview, but at 18% a 300px card is 55px wide, and Seq 1837 already measured counters as
+  unreadable at 43%. Identity would be a number and nothing else.
+- **Reflow the graph into one column on a narrow stage.** A layout rewrite, explicitly out of
+  scope, and it would change the desktop graph's meaning too.
+- **Floor only below a viewport breakpoint.** A magic width for a defect that is about scene
+  size, not screen size — the 41-card desktop measurement above is the counter-example.

--- a/src/mainview/__tests__/traffic-camera.test.ts
+++ b/src/mainview/__tests__/traffic-camera.test.ts
@@ -1,7 +1,11 @@
 import {
+	FULL_DETAIL_SCALE,
+	IDENTITY_SCALE,
 	MAX_SCALE,
 	clampToBounds,
+	detailTier,
 	frameExchange,
+	overviewScale,
 	stageCeiling,
 } from "../components/agent-traffic/traffic-camera";
 import type { PlacedNode } from "../components/agent-traffic/nodes-layout";
@@ -131,5 +135,40 @@ describe("clamping the framed pair to the scene", () => {
 		const camera = clampToBounds({ x: -9999, y: 9999, scale: 1 }, fourK, flat);
 		expect(camera.x + 200).toBeCloseTo(fourK.width / 2);
 		expect(camera.y + 150).toBeCloseTo(fourK.height / 2);
+	});
+});
+
+describe("overview framing floor", () => {
+	// The graph the phone report was measured on: nine cards in three rows.
+	const graph = { width: 1852, height: 1074 };
+	const phone = { width: 390, height: 419 };
+	const laptop = { width: 1440, height: 603 };
+	const fourK = { width: 3840, height: 1863 };
+
+	it("opens a phone stage in a tier where a card still has its identity", () => {
+		expect(overviewScale(phone, graph, 0.85)).toBeLessThan(IDENTITY_SCALE);
+		expect(detailTier(overviewScale(phone, graph, 0.85))).toBe("cell");
+		const floored = overviewScale(phone, graph, 0.85, IDENTITY_SCALE);
+		expect(floored).toBe(IDENTITY_SCALE);
+		expect(detailTier(floored)).not.toBe("cell");
+	});
+
+	it("leaves a stage that already fits legibly untouched", () => {
+		for (const stage of [laptop, fourK]) {
+			const plain = overviewScale(stage, graph, 0.85);
+			expect(plain).toBeGreaterThan(IDENTITY_SCALE);
+			expect(overviewScale(stage, graph, 0.85, IDENTITY_SCALE)).toBe(plain);
+		}
+	});
+
+	it("keeps a hand-asked fit a true fit, floor or not", () => {
+		expect(overviewScale(phone, graph, 0.85, 0)).toBe(overviewScale(phone, graph, 0.85));
+	});
+
+	it("puts the tier boundary exactly where the card body appears", () => {
+		expect(detailTier(IDENTITY_SCALE - 0.001)).toBe("cell");
+		expect(detailTier(IDENTITY_SCALE)).toBe("compact");
+		expect(detailTier(FULL_DETAIL_SCALE - 0.001)).toBe("compact");
+		expect(detailTier(FULL_DETAIL_SCALE)).toBe("full");
 	});
 });

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -48,7 +48,7 @@ import type { useTrafficPlayback } from "./useTrafficPlayback";
 import TrafficIcon from "./TrafficIcon";
 import TrafficMinimap from "./TrafficMinimap";
 import TrafficMessageBubble from "./TrafficMessageBubble";
-import { MAX_SCALE, frameExchange, stageCeiling } from "./traffic-camera";
+import { IDENTITY_SCALE, MAX_SCALE, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
 	projects?: {
@@ -250,14 +250,14 @@ export default function TrafficNodes({
 	);
 	useEffect(() => () => cancelAnimationFrame(camera.current), []);
 	const fitNodes = useCallback(
-		(targets: Pick<PlacedNode, "x" | "y" | "width" | "height">[], maximum: number, instant = false) => {
+		(targets: Pick<PlacedNode, "x" | "y" | "width" | "height">[], maximum: number, instant = false, floor = 0) => {
 			const box = { width: frame.current?.clientWidth ?? 0, height: frame.current?.clientHeight ?? 0 };
 			if (!box.width || !box.height || !targets.length) return;
 			const left = Math.min(...targets.map((p) => p.x)) - 70;
 			const top = Math.min(...targets.map((p) => p.y)) - 86;
 			const width = Math.max(...targets.map((p) => p.x + p.width)) + 70 - left;
 			const height = Math.max(...targets.map((p) => p.y + p.height)) + 86 - top;
-			const scale = Math.min(stageCeiling(box, maximum), (box.width - 52) / width, (box.height - 80) / height);
+			const scale = overviewScale(box, { width, height }, maximum, floor);
 			move(
 				{
 					scale,
@@ -269,8 +269,17 @@ export default function TrafficNodes({
 		},
 		[move],
 	);
+	/**
+	 * The automatic overview — on open, on resize, and whenever Live Follow falls
+	 * back to it — never goes below the tier where a card carries its identity.
+	 * On a phone the whole graph fits only at ~18%, and a stage of blank coloured
+	 * rectangles cannot be read at all; a centred, legible part of it can, and pan
+	 * and zoom reach the rest. `exact` is the user asking for the whole graph by
+	 * hand (the Fit button, the minimap), which stays a true fit.
+	 */
 	const fit = useCallback(
-		(instant = false) => fitNodes(scene.groups.length ? scene.groups : scene.placed, 0.85, instant),
+		(instant = false, exact = false) =>
+			fitNodes(scene.groups.length ? scene.groups : scene.placed, 0.85, instant, exact ? 0 : IDENTITY_SCALE),
 		[fitNodes, scene.placed, scene.groups],
 	);
 	/** The scene's outer edge with the same padding `fitNodes` leaves around it. */
@@ -628,8 +637,7 @@ export default function TrafficNodes({
 	const activeRecipient = activeTo ? nodeByKey.get(activeTo) : undefined;
 	const labelPoint = activeEdge ? pointAt(activeEdge.points, 0.5) : activeRecipient ?
 		{ x: activeRecipient.x + activeRecipient.width / 2, y: activeRecipient.y } : undefined;
-	const detail =
-		view.scale < 0.36 ? "cell" : view.scale < 0.7 ? "compact" : "full";
+	const detail = detailTier(view.scale);
 	const visiblePairs = new Map<
 		string,
 		{ count: number; status: string; at: number }
@@ -905,7 +913,7 @@ export default function TrafficNodes({
 					width={frame.current?.clientWidth ?? 0}
 					height={frame.current?.clientHeight ?? 0}
 					onNavigate={(target) => { manual(); move(target, true); }}
-					onFit={() => { manual(); overviewMode.current = true; fit(); }}
+					onFit={() => { manual(); overviewMode.current = true; fit(false, true); }}
 				/>
 			)}
 			<div className="traffic-camera-controls">
@@ -926,7 +934,7 @@ export default function TrafficNodes({
 					onClick={() => {
 						manual();
 						overviewMode.current = true;
-						fit();
+						fit(false, true);
 					}}
 					aria-label={t("traffic.nodes.fit")}
 				>

--- a/src/mainview/components/agent-traffic/traffic-camera.ts
+++ b/src/mainview/components/agent-traffic/traffic-camera.ts
@@ -41,6 +41,49 @@ export function stageCeiling(viewport: Viewport, calibrated: number): number {
 }
 
 /**
+ * Lowest zoom at which a card still carries its identity — seq, title, status.
+ * Below it every card is a bare coloured rectangle: `.traffic-nodes[data-detail="cell"]`
+ * hides the whole card body, so the tier boundary and this floor are one number.
+ */
+export const IDENTITY_SCALE = 0.36;
+
+/** Above this a card shows every row it has, not just the compact three. */
+export const FULL_DETAIL_SCALE = 0.7;
+
+export function detailTier(scale: number): "cell" | "compact" | "full" {
+	return scale < IDENTITY_SCALE
+		? "cell"
+		: scale < FULL_DETAIL_SCALE
+			? "compact"
+			: "full";
+}
+
+/**
+ * Zoom the overview opens at, for a scene of `content` on a stage of `viewport`.
+ *
+ * `floor` is what keeps a phone out of the `cell` tier. A 390px stage fits the
+ * whole graph only at ~18%, where the stage is nine blank rectangles and the
+ * screen carries no information at all; framing a centred, legible part of it
+ * instead leaves pan and zoom to reach the rest. Passed as 0 when the user asked
+ * for the whole graph by hand, which stays a true fit.
+ */
+export function overviewScale(
+	viewport: Viewport,
+	content: Viewport,
+	calibrated: number,
+	floor = 0,
+): number {
+	return Math.max(
+		floor,
+		Math.min(
+			stageCeiling(viewport, calibrated),
+			(viewport.width - 52) / content.width,
+			(viewport.height - 80) / content.height,
+		),
+	);
+}
+
+/**
  * Pull a camera back inside the scene so it never frames emptiness.
  *
  * Framing a pair centres on that pair, which is right on a stage the scene


### PR DESCRIPTION
On a phone, Agent traffic (Experiment 2) opened as a stage of blank coloured rectangles. Two rules that are each right on their own meet badly there: `fit()` frames the **whole** graph on open, on resize and whenever Live Follow falls back to the overview, while `traffic-nodes.css` hides the entire card body below zoom `0.36` (`[data-detail="cell"]`). Measured in the running app on a 390×844 viewport (stage 390×423, nine cards): the fit lands at **18%**, so entry carried zero task titles — no seq, no name, no status.

It is not a mobile-only defect: 41 cards on a 1440×900 stage fit at **14%** and give the same wall of blank cells.

The automatic overview now takes a floor — `IDENTITY_SCALE` (0.36), the very constant that defines the `cell`/`compact` boundary, so the camera floor and the CSS tier cannot drift apart. Entry frames a centred, legible part of the graph instead of all of it illegibly.

- `traffic-camera.ts` — framing arithmetic extracted into a pure `overviewScale(viewport, content, calibrated, floor)`; `IDENTITY_SCALE`, `FULL_DETAIL_SCALE` and `detailTier()` live there now.
- `TrafficNodes.tsx` — `fit()` passes the floor; the **Fit everything on screen** button and the minimap's fit pass `exact` and stay a true whole-graph fit, so the label keeps telling the truth.
- Pan, wheel zoom and the ± buttons still reach `MIN_SCALE` (0.14) — the floor never fights the hand.

Measured before/after: 390×844 `0.1829` → **`0.36`** (`cell` → `compact`, 9/9 cards named); 1440×900 `0.472875` unchanged (screenshots byte-identical); 3840×2160 `1.61212` unchanged; 41 cards at 1440×900 `0.144236` → **`0.36`**. Re-measured on this rebased head, which already includes #1709's toolbar geometry — nothing here touches the toolbar, layout or any CSS.

The cost, stated plainly: on a board whose whole graph only fits below 36%, entry now shows a subset rather than everything. The Fit button is the escape hatch, and what it replaces was blank. Rationale, alternatives and risks: `decisions/2026/09/10/overview-framing-floor-keeps-cards-legible.md`.

Not verified: a physical phone (all measurements are CSS viewports in headless Chromium, so pan is proven with synthetic pointer events rather than a finger), light theme, ru/es locales, and Windows.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=52fca766-2dbf-4c5e-b5c9-0e3256c0cda1) · `dev3://task/52fca766-2dbf-4c5e-b5c9-0e3256c0cda1` _(dev3 added this footer — turn it off in Settings → Tasks.)_
