### PR TITLE
Ship agent traffic on by default with a tri-state opt-out

### DIFF
--- a/change-logs/2026/09/11/feature-agent-traffic-on-by-default.md
+++ b/change-logs/2026/09/11/feature-agent-traffic-on-by-default.md
@@ -1,0 +1,3 @@
+Short: Agent traffic is on by default
+
+Agent traffic and its log are now on out of the box instead of hidden behind an off-by-default beta toggle. The Settings → System → Advanced Experience switch still turns it off, and that choice is now stored as an explicit `false` so it survives restarts; installs that had switched the beta off before this change left no stored value and get the feature back on.

--- a/decisions/2026/09/11/agent-traffic-default-on-tri-state.md
+++ b/decisions/2026/09/11/agent-traffic-default-on-tri-state.md
@@ -1,0 +1,37 @@
+# Agent traffic ships on, and its setting becomes tri-state
+
+## Context
+
+`experimentalAgentTraffic` shipped as an off-by-default beta. The feature is now good enough
+to be on for everyone, but the Settings switch must keep working as a real opt-out.
+
+## Investigation
+
+The field was stored as `true | undefined`: the sanitizer in `src/bun/settings.ts` kept only an
+explicit `true`, and the toggle handler in `GlobalSettings.tsx` wrote `undefined` for "off". So
+"the user turned it off" and "the user never chose" were byte-identical on disk. That is fine for
+a default-off flag and fatal for a default-on one.
+
+## Decision
+
+The field becomes tri-state, following the `lowBatteryEnabled` precedent: the sanitizer keeps any
+boolean, the toggle writes `enabled` directly, and every reader treats absent as on
+(`!== false` in `src/mainview/agent-traffic-flag.ts` and `AdvancedExperienceSection.tsx`). The
+module flag in `agent-traffic-flag.ts` initialises to `true` so the pre-settings render matches
+the default.
+
+## Risks
+
+Opt-outs recorded **before** this change cannot be honoured — they were stored as "no key", which
+is indistinguishable from a fresh install, and no other on-disk trace of the choice exists. Those
+users get the feature back on and must switch it off once more; from then on the choice sticks.
+How many installs that affects is unknown — nothing on disk or in telemetry counts them. No migration
+can recover the difference, and guessing (e.g. treating any user with stored settings as an opt-out)
+would silently hide the feature from everyone who never touched it.
+
+## Alternatives considered
+
+Writing a `agentTrafficDisabled` legacy key at load time for existing installs — rejected, it
+would have to guess which installs opted out, and rule 3 of the on-disk layout invariants forbids
+inventing user state during a load-time migration. Leaving the beta off — rejected, that is the
+task.

--- a/src/bun/__tests__/settings.test.ts
+++ b/src/bun/__tests__/settings.test.ts
@@ -94,6 +94,20 @@ describe("saveSettings", () => {
 		expect((await loadSettings()).lowBatteryEnabled).toBe(false);
 	});
 
+	/**
+	 * Agent traffic is default-on, so absent must stay absent (the renderer reads it
+	 * as "on") while an explicit false survives as the user's opt-out.
+	 */
+	it("keeps both explicit agent-traffic choices and stores no default", async () => {
+		expect((await loadSettings()).experimentalAgentTraffic).toBeUndefined();
+
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ experimentalAgentTraffic: false }), null, 2), "utf-8");
+		expect((await loadSettings()).experimentalAgentTraffic).toBe(false);
+
+		writeFileSync(settingsPath, JSON.stringify(makeSettings({ experimentalAgentTraffic: true }), null, 2), "utf-8");
+		expect((await loadSettings()).experimentalAgentTraffic).toBe(true);
+	});
+
 	// Absent = the docked artifact panel, which is what every existing install gets
 	// without ever being asked. An explicit false is the user picking the panel and
 	// must survive a restart as a choice, not collapse back into "unset".

--- a/src/bun/settings.ts
+++ b/src/bun/settings.ts
@@ -207,8 +207,10 @@ function normalizeSettings(data: Record<string, unknown>): GlobalSettings {
 				: undefined,
 		// Default-off beta toggle — only an explicit true is a stored opt-in.
 		experimentalTerminalBidi: d.experimentalTerminalBidi === true ? true : undefined,
-		// Default-off beta toggle — only an explicit true is a stored opt-in.
-		experimentalAgentTraffic: d.experimentalAgentTraffic === true ? true : undefined,
+		// Default-on beta toggle — both booleans are stored, because an explicit
+		// false is the user opting out and must not collapse into "never chose".
+		experimentalAgentTraffic:
+			typeof d.experimentalAgentTraffic === "boolean" ? d.experimentalAgentTraffic : undefined,
 		// Only a recorded pick survives; anything else falls back to the default view.
 		agentTrafficExperiment: d.agentTrafficExperiment === "1" || d.agentTrafficExperiment === "2"
 			? d.agentTrafficExperiment

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -1556,8 +1556,16 @@ describe("App keyboard shortcuts", () => {
 			});
 		}
 
+		/** The opted-out user: the beta ships on, so "off" is a stored false. */
+		function disableTrafficBeta() {
+			act(() => {
+				syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: false });
+			});
+		}
+
 		it("names both sides and clicks through to the receiving task", async () => {
 			await renderWithBoard();
+			disableTrafficBeta();
 			dispatchAgentMessage();
 
 			expect(screen.getByText("#7 Coordinator → #42 Receiver")).toBeInTheDocument();

--- a/src/mainview/__tests__/agent-traffic-flag.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-flag.test.tsx
@@ -17,10 +17,10 @@ import { getAvailableTipsCount } from "../tips";
 import AgentTrafficIndicator from "../components/agent-traffic/AgentTrafficIndicator";
 
 /**
- * The agent-traffic beta ships off, and while off it must leave NO trace: no
- * header control, no listed shortcut, no menu row, no palette command, no tip.
+ * The agent-traffic beta ships on, and once switched off it must leave NO trace:
+ * no header control, no listed shortcut, no menu row, no palette command, no tip.
  * Each surface is asserted in both states, because "hidden" is only meaningful
- * next to a proof that it appears when the user opts in.
+ * next to a proof that it appears while the feature is on.
  */
 
 const page: AgentMessageLogPage = { rows: [], oldestDay: null, retentionDays: 30, hasMore: false };
@@ -72,27 +72,29 @@ function browserLabels(nodes: ReturnType<typeof buildBrowserMenu>): string[] {
 }
 
 describe("agent-traffic feature flag", () => {
-	it("defaults to off", () => {
-		expect(getAgentTrafficEnabled()).toBe(false);
+	it("is on for settings that carry no stored choice", () => {
+		setAgentTrafficEnabledForTests(false);
+		syncAgentTrafficFromGlobalSettings({});
+		expect(getAgentTrafficEnabled()).toBe(true);
 	});
 
-	it("only an explicit true switches it on, and the change is announced", () => {
+	it("only an explicit false switches it off, and the change is announced", () => {
 		const seen: boolean[] = [];
 		const listener = (e: Event) => seen.push((e as CustomEvent<boolean>).detail);
 		window.addEventListener("agent-traffic-flag-changed", listener);
 
 		syncAgentTrafficFromGlobalSettings({});
-		expect(getAgentTrafficEnabled()).toBe(false);
-
-		syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: true });
 		expect(getAgentTrafficEnabled()).toBe(true);
 
-		// Same value again is not a change — no second event.
-		syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: true });
 		syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: false });
+		expect(getAgentTrafficEnabled()).toBe(false);
+
+		// Same value again is not a change — no second event.
+		syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: false });
+		syncAgentTrafficFromGlobalSettings({ experimentalAgentTraffic: true });
 
 		window.removeEventListener("agent-traffic-flag-changed", listener);
-		expect(seen).toEqual([true, false]);
+		expect(seen).toEqual([true, false, true]);
 	});
 
 	it.each(["bar", "menu", "sheet"] as const)("renders no %s control while off", (variant) => {

--- a/src/mainview/agent-traffic-flag.ts
+++ b/src/mainview/agent-traffic-flag.ts
@@ -1,5 +1,5 @@
 // ── Agent-traffic feature flag ──
-// Whether the agent-to-agent traffic readout and its log exist at all. Beta, off
+// Whether the agent-to-agent traffic readout and its log exist at all. Beta, on
 // by default, lives in Settings → System → Advanced Experience next to BiDi.
 //
 // The value is a GlobalSettings field rather than localStorage so it follows the
@@ -14,7 +14,7 @@
 
 export const AGENT_TRAFFIC_FLAG_CHANGED_EVENT = "agent-traffic-flag-changed" as const;
 
-let enabled = false;
+let enabled = true;
 
 export function getAgentTrafficEnabled(): boolean {
 	return enabled;
@@ -24,7 +24,8 @@ export function getAgentTrafficEnabled(): boolean {
 export function syncAgentTrafficFromGlobalSettings(settings: {
 	experimentalAgentTraffic?: boolean;
 }): void {
-	const next = settings.experimentalAgentTraffic === true;
+	// Only an explicit false turns it off; absent means the user never chose.
+	const next = settings.experimentalAgentTraffic !== false;
 	if (next === enabled) return;
 	enabled = next;
 	window.dispatchEvent(

--- a/src/mainview/components/GlobalSettings.tsx
+++ b/src/mainview/components/GlobalSettings.tsx
@@ -639,7 +639,8 @@ function GlobalSettings({
 	const handleAgentTrafficToggle = useCallback(
 		(enabled: boolean) => {
 			persistSettingChange(
-				{ experimentalAgentTraffic: enabled ? true : undefined },
+				// Stored either way: an explicit false is the opt-out from a default-on beta.
+				{ experimentalAgentTraffic: enabled },
 				{
 					tracking: {
 						setting: "experimental_agent_traffic",

--- a/src/mainview/components/global-settings/AdvancedExperienceSection.tsx
+++ b/src/mainview/components/global-settings/AdvancedExperienceSection.tsx
@@ -5,8 +5,8 @@ import SettingsSection from "./SettingsSection";
 import SettingsToggle from "./SettingsToggle";
 
 /**
- * Home for beta behaviour that is useful but not yet stable enough to be on by
- * default. Every entry here ships off and states its own limitations.
+ * Home for beta behaviour that is still labelled experimental and states its own
+ * limitations. Most entries ship off; agent traffic ships on and can be turned off.
  */
 export default function AdvancedExperienceSection({
 	t,
@@ -20,7 +20,8 @@ export default function AdvancedExperienceSection({
 	onAgentTrafficToggle: (enabled: boolean) => void;
 }) {
 	const bidiEnabled = globalSettings.experimentalTerminalBidi === true;
-	const trafficEnabled = globalSettings.experimentalAgentTraffic === true;
+	// Default-on, unlike its neighbours: absent is "never chose", not "off".
+	const trafficEnabled = globalSettings.experimentalAgentTraffic !== false;
 
 	return (
 		<SettingsSection

--- a/src/mainview/components/global-settings/__tests__/AdvancedExperienceSection.test.tsx
+++ b/src/mainview/components/global-settings/__tests__/AdvancedExperienceSection.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { GlobalSettings } from "../../../../shared/types";
+import { I18nProvider, type TFunction } from "../../../i18n";
+import AdvancedExperienceSection from "../AdvancedExperienceSection";
+
+// Stub translator: return the key so assertions are stable and locale-agnostic.
+const t = Object.assign((key: string) => key, {
+	plural: (key: string, count: number) => `${key}|${count}`,
+}) as unknown as TFunction;
+
+function renderSection(globalSettings: Partial<GlobalSettings>) {
+	const onAgentTrafficToggle = vi.fn();
+	render(
+		<I18nProvider>
+			<AdvancedExperienceSection
+				t={t}
+				globalSettings={globalSettings as GlobalSettings}
+				onTerminalBidiToggle={() => {}}
+				onAgentTrafficToggle={onAgentTrafficToggle}
+			/>
+		</I18nProvider>,
+	);
+	return { onAgentTrafficToggle, toggle: screen.getByLabelText("settings.agentTraffic") };
+}
+
+/**
+ * Agent traffic is the one default-on entry of this section, so the toggle has to
+ * read three stored states apart: no choice (on), an explicit off, an explicit on.
+ */
+describe("AdvancedExperienceSection — agent traffic", () => {
+	it("shows on when nothing is stored", () => {
+		expect(renderSection({}).toggle.getAttribute("aria-checked")).toBe("true");
+	});
+
+	it("shows off for a stored opt-out", () => {
+		expect(renderSection({ experimentalAgentTraffic: false }).toggle.getAttribute("aria-checked")).toBe("false");
+	});
+
+	it("shows on for a stored opt-in", () => {
+		expect(renderSection({ experimentalAgentTraffic: true }).toggle.getAttribute("aria-checked")).toBe("true");
+	});
+
+	it("asks to turn it off from the default state", async () => {
+		const { onAgentTrafficToggle, toggle } = renderSection({});
+		await userEvent.click(toggle);
+		expect(onAgentTrafficToggle).toHaveBeenCalledWith(false);
+	});
+
+	it("asks to turn it back on from a stored opt-out", async () => {
+		const { onAgentTrafficToggle, toggle } = renderSection({ experimentalAgentTraffic: false });
+		await userEvent.click(toggle);
+		expect(onAgentTrafficToggle).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/mainview/i18n/translations/en/settings.ts
+++ b/src/mainview/i18n/translations/en/settings.ts
@@ -595,7 +595,7 @@ const settings = {
 	// Advanced Experience — beta behaviour, every entry ships off
 	"settings.categoryAdvancedExperience": "Advanced Experience",
 	"settings.categoryAdvancedExperienceDesc":
-		"Beta behaviour that is useful but not stable yet. Everything here is off by default.",
+		"Beta behaviour that is useful but not stable yet. Each entry says whether it is on by default.",
 	"settings.terminalBidi": "Right-to-left text in terminals (BiDi)",
 	"settings.terminalBidiDesc":
 		"Reorder Hebrew, Arabic and Persian output so it reads correctly in terminal panes instead of appearing reversed. Applies to open panes immediately.",

--- a/src/mainview/i18n/translations/es/settings.ts
+++ b/src/mainview/i18n/translations/es/settings.ts
@@ -596,7 +596,7 @@ const settings = {
 	// Advanced Experience — beta behaviour, every entry ships off
 	"settings.categoryAdvancedExperience": "Experiencia avanzada",
 	"settings.categoryAdvancedExperienceDesc":
-		"Comportamiento en beta: útil, pero todavía no estable. Todo aquí está desactivado por defecto.",
+		"Comportamiento en beta: útil, pero todavía no estable. Cada opción indica su valor por defecto.",
 	"settings.terminalBidi": "Texto de derecha a izquierda en terminales (BiDi)",
 	"settings.terminalBidiDesc":
 		"Reordena la salida en hebreo, árabe y persa para que se lea correctamente en las terminales en lugar de aparecer invertida. Se aplica de inmediato a los paneles abiertos.",

--- a/src/mainview/i18n/translations/ru/settings.ts
+++ b/src/mainview/i18n/translations/ru/settings.ts
@@ -615,7 +615,7 @@ const settings = {
 	// Advanced Experience — beta behaviour, every entry ships off
 	"settings.categoryAdvancedExperience": "Продвинутые возможности",
 	"settings.categoryAdvancedExperienceDesc":
-		"Бета-поведение: полезное, но ещё не стабильное. Всё здесь по умолчанию выключено.",
+		"Бета-поведение: полезное, но ещё не стабильное. У каждого пункта своё значение по умолчанию.",
 	"settings.terminalBidi": "Текст справа налево в терминале (BiDi)",
 	"settings.terminalBidiDesc":
 		"Переставляет вывод на иврите, арабском и персидском так, чтобы он читался правильно, а не зеркально. Применяется к открытым панелям сразу.",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1199,9 +1199,10 @@ export interface GlobalSettings {
 	 */
 	experimentalTerminalBidi?: boolean;
 	/**
-	 * Beta: the agent-traffic readout in the header and its 30-day log. Off by
-	 * default, and while off the feature leaves no trace — no header control, no
-	 * ⇧⌘M, no menu item, no palette command, no tip.
+	 * Beta: the agent-traffic readout in the header and its 30-day log. On by
+	 * default — absent means "never chose", and an explicit `false` is the user
+	 * saying "off", which must survive a restart. While off the feature leaves no
+	 * trace — no header control, no ⇧⌘M, no menu item, no palette command, no tip.
 	 */
 	experimentalAgentTraffic?: boolean;
 	/**


### PR DESCRIPTION
Agent traffic now ships on instead of hiding behind an off-by-default beta toggle, and the Settings switch becomes a real opt-out.

`experimentalAgentTraffic` was stored as `true | absent`, so "turned it off" and "never chose" were the same bytes on disk. It is now tri-state, following the `lowBatteryEnabled` precedent: the sanitizer keeps any boolean, the toggle writes `enabled` directly, and readers treat absent as on.

Known limitation, recorded in `decisions/2026/09/11/agent-traffic-default-on-tri-state.md`: opt-outs made **before** this change cannot be honoured — the old off path deleted the key, which is byte-identical to a fresh install, and no other on-disk trace exists. How many installs that affects is unknown. Those users get the feature back on and must switch it off once more; from then on the choice sticks.

Unchanged: routes and automatic route opening, message recording, and the default presentation (Experiment 2).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b8527cc3-2fb8-4940-b5bd-a6e20ab3ab2d) · `dev3://task/b8527cc3-2fb8-4940-b5bd-a6e20ab3ab2d`
