### PR TITLE
Place the traffic user marker above the cards and drop the bare count

### DIFF
--- a/change-logs/2026/09/11/fix-traffic-user-node-above-tasks.md
+++ b/change-logs/2026/09/11/fix-traffic-user-node-above-tasks.md
@@ -1,0 +1,3 @@
+Short: You node sits above the traffic graph
+
+On the Agent traffic graph the "You" marker now sits above the coordinator and the task cards instead of being parked at the end of the card grid, and the bare message-count number is gone from both the user marker and the task cards — the count carried no label and the wire thickness already shows message volume. The user marker's accessible label still spells the count out in words.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1186,7 +1186,14 @@ it("draws the user as a sender for a message they proved they sent", async () =>
 	// None of the task grammar leaks onto a person: no seq, no status line.
 	expect(marker.textContent).not.toContain("#");
 	// And it is a real endpoint, so the recipient card is drawn beside it.
+	const [card] = screen.getAllByTestId("traffic-node-card");
 	expect(screen.getAllByTestId("traffic-node-card")).toHaveLength(1);
+	// The person is the origin of the conversation, so they sit above it.
+	expect(parseFloat(marker.style.top)).toBeLessThan(parseFloat(card.style.top));
+	// A bare number on a card explains nothing; the wire's thickness carries volume.
+	expect(document.querySelectorAll(".traffic-node-count")).toHaveLength(0);
+	// The count survives where it is spelled out — the marker's accessible name.
+	expect(marker.getAttribute("aria-label")).toContain("1 recorded message");
 });
 
 it("draws no user marker for a sender-less message that proved nothing", async () => {

--- a/src/mainview/__tests__/nodes-layout.test.ts
+++ b/src/mainview/__tests__/nodes-layout.test.ts
@@ -69,6 +69,24 @@ describe("layoutTraffic", () => {
 		expect(edges).toHaveLength(2);
 	});
 
+	it("places the user above the coordinator and every task", () => {
+		const tasks = [coordinator("a", 11), task("b", 22), task("c", 33)];
+		const rows = [
+			row(null as unknown as string, "a", { fromSeq: null, origin: "user" }),
+			row("a", "b"),
+			row("a", "c"),
+		];
+		const { placed } = scene(tasks, rows);
+		const you = placed.find((node) => node.node.user);
+		expect(you).toBeDefined();
+		for (const other of placed.filter((node) => !node.node.user)) {
+			expect(other.y).toBeGreaterThan(you?.y as number);
+		}
+		// Centred over the grid the same way the coordinator is, not parked in it.
+		const hub = placed.find((node) => node.hub)!;
+		expect((you as { x: number }).x + CARD_WIDTH / 2).toBe(hub.x + hub.width / 2);
+	});
+
 	it("places five workers in the first row below the coordinator", () => {
 		const tasks = [coordinator("hub", 1), ...Array.from({ length: 6 }, (_, i) => task(`t${i}`, i + 2))];
 		const { placed } = scene(tasks, tasks.slice(1).map(t => row("hub", t.id)));

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -819,7 +819,6 @@ export default function TrafficNodes({
 							<Card
 								key={placed.node.key}
 								placed={placed}
-								messageCount={messageCounts.get(placed.node.key) ?? 0}
 								selected={selected === placed.node.key}
 								dim={
 									selected !== null &&
@@ -1075,14 +1074,12 @@ function UserCard({
 		>
 			<TrafficIcon name="user" />
 			<strong>{t("traffic.node.you")}</strong>
-			<span className="traffic-node-count">{messageCount}</span>
 		</button>
 	);
 }
 
 function Card({
 	placed,
-	messageCount,
 	selected,
 	dim,
 	active,
@@ -1098,7 +1095,6 @@ function Card({
 	onFocus,
 }: {
 	placed: PlacedNode;
-	messageCount: number;
 	selected: boolean;
 	dim: boolean;
 	active: boolean;
@@ -1183,7 +1179,6 @@ function Card({
 					{node.task?.taskType === "coordinator" && (
 						<em>{t("traffic.orbit.coordinator")}</em>
 					)}
-					<span className="traffic-node-count">{messageCount}</span>
 				</span>
 				<strong className="streamer-private">
 					{node.title || t("traffic.orbit.historical")}

--- a/src/mainview/components/agent-traffic/nodes-layout.ts
+++ b/src/mainview/components/agent-traffic/nodes-layout.ts
@@ -106,6 +106,9 @@ function pairs(records: TrafficRecord[]): Map<string, PairState> {
 	return found;
 }
 
+/** Cards that go in the grid — not the user marker, not a coordinator. */
+const isWorker = (node: TrafficNode) => !node.user && node.task?.taskType !== "coordinator";
+
 /** Stable task ordering keeps replay and new message volume from moving cards. */
 export function layoutTraffic(
 	nodes: TrafficNode[],
@@ -177,15 +180,19 @@ export function layoutTraffic(
 		const projectActive = active.filter(node => node.projectId === projectId);
 		const projectQuiet = quiet.filter(node => node.projectId === projectId);
 		const projectParked = parked.filter(node => node.projectId === projectId);
-		const normalCount = projectActive.filter(node => node.task?.taskType !== "coordinator").length;
+		const normalCount = projectActive.filter(isWorker).length;
 		const columns = normalCount > 24 ? 6 : 5;
 		const bands = [projectActive, ...(options.showQuiet ? [projectQuiet] : []), ...(options.showParked ? [projectParked] : [])];
 		const occupiedColumns = grouped
-			? Math.min(columns, Math.max(...bands.map(members => members.filter(node => node.task?.taskType !== "coordinator").length)))
+			? Math.min(columns, Math.max(...bands.map(members => members.filter(isWorker).length)))
 			: columns;
 		const workerWidth = occupiedColumns ? occupiedColumns * (CARD_WIDTH + GAP_X) - GAP_X : 0;
-		const hasCoordinator = bands.some(members => members.some(node => node.task?.taskType === "coordinator"));
-		const gridWidth = Math.max(workerWidth, hasCoordinator ? COORDINATOR_WIDTH : 0);
+		// The centred rows above the grid: the user marker, then any coordinator.
+		const headWidth = Math.max(
+			bands.some(members => members.some(node => node.user)) ? CARD_WIDTH : 0,
+			bands.some(members => members.some(node => node.task?.taskType === "coordinator")) ? COORDINATOR_WIDTH : 0,
+		);
+		const gridWidth = Math.max(workerWidth, headWidth);
 		const workerOffset = grouped ? (gridWidth - workerWidth) / 2 : 0;
 		const offsetX = grouped ? groupX + 32 : 0;
 		const offsetY = grouped ? groupY + 96 : 0;
@@ -196,8 +203,15 @@ export function layoutTraffic(
 			contentHeight = Math.max(contentHeight, y + (node.task?.taskType === "coordinator" ? COORDINATOR_HEIGHT : CARD_HEIGHT) + 28);
 		};
 		const band = (members: TrafficNode[]) => {
-			const coordinators = members.filter(node => node.task?.taskType === "coordinator");
-			const normal = members.filter(node => node.task?.taskType !== "coordinator");
+			// The person is the origin of the conversation, so they sit above it:
+			// user marker first, then the coordinator, then the task grid.
+			const you = members.filter(node => node.user);
+			const coordinators = members.filter(node => !node.user && node.task?.taskType === "coordinator");
+			const normal = members.filter(isWorker);
+			for (const node of you) {
+				add(node, (gridWidth - CARD_WIDTH) / 2, cursorY);
+				cursorY += COORDINATOR_STEP;
+			}
 			for (const node of coordinators) {
 				add(node, (gridWidth - COORDINATOR_WIDTH) / 2, cursorY);
 				cursorY += COORDINATOR_STEP;

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -303,10 +303,6 @@
 	font-size: 10px;
 	color: rgb(var(--success));
 }
-.traffic-node-count {
-	margin-left: auto;
-	font-family: var(--dev3-mono-stack);
-}
 /* The sidebar's title weight, not a headline: this is a task row that happens to
    sit on a stage, so it reads at the same pitch as everywhere else in the app. */
 .traffic-node-full > strong {


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

On the Agent traffic graph (Experiment 2) the "You" marker used to be placed in the task grid, so it landed in the last cell of the bottom row — below the coordinator and below every task it is talking to. It now gets its own centred row above the coordinator, so the scene reads top-down: person → coordinator → workers. A new `isWorker()` helper keeps the marker out of the worker grid's column math, and the scene head width accounts for it.

The bare number on each card is gone too. It was `messageCount` — how many rows of the visible time window name that node as sender or recipient — rendered with no label and no unit. Wire thickness already carries message volume and comes from a separate map (`visiblePairs`), so it is untouched; the count is still spelled out in the user marker's accessible name.

Verified on a live board at 3840×2160, 1440×900 and 390×844: You on top in all three, zero counters, no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=925859db-613d-4a43-98c4-b66a9fa91bff) · `dev3://task/925859db-613d-4a43-98c4-b66a9fa91bff`
