### PR TITLE
Re-take the traffic replay snapshot once the whole timeline has loaded

### DIFF
--- a/change-logs/2026/09/11/fix-replay-snapshot-waits-for-task-history.md
+++ b/change-logs/2026/09/11/fix-replay-snapshot-waits-for-task-history.md
@@ -1,0 +1,3 @@
+Short: Replay no longer loses task events
+
+Starting a replay in Agent traffic while the screen was still loading froze a timeline that had only messages on it, so recorded board movements and notifications never played back until a filter was toggled or Restart was pressed. The snapshot is now re-taken once, when every arm of the timeline has finished loading, keeping the reader on the same event and still ignoring anything that arrives after that.

--- a/src/mainview/__tests__/traffic-playback.test.tsx
+++ b/src/mainview/__tests__/traffic-playback.test.tsx
@@ -1,8 +1,18 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Task } from "../../shared/types";
 import type { TrafficRecord } from "../components/agent-traffic/traffic-model";
-import { messageEvents } from "../components/agent-traffic/traffic-timeline";
+import {
+	messageEvents,
+	taskEvents,
+	type TrafficTimelineEvent,
+} from "../components/agent-traffic/traffic-timeline";
 import { useTrafficPlayback } from "../components/agent-traffic/useTrafficPlayback";
+
+/** Seconds past 10:00, as an ISO instant — fractions land between two messages. */
+function at(second: number): string {
+	return new Date(Date.UTC(2026, 8, 7, 10, 0, 0) + second * 1000).toISOString();
+}
 
 function record(key: string, second: number): TrafficRecord {
 	return {
@@ -300,6 +310,77 @@ describe("traffic playback", () => {
 			});
 			act(() => result.current.live());
 			expect(result.current.cursor.at).toBeNull();
+		});
+	});
+
+	describe("a snapshot taken before the load settled", () => {
+		// Board movements and notifications arrive after the first messages, so a
+		// Play pressed during the load froze a timeline missing whole kinds of
+		// event — and only a filter change or a Restart ever brought them back.
+		const late = taskEvents(
+			[
+				{
+					id: "receiver",
+					projectId: "project",
+					seq: 2,
+					movements: [
+						{ id: "m1", at: at(1.5), kind: "created", to: "todo" },
+						{ id: "m2", at: at(2.5), kind: "moved", from: "todo", to: "in-progress" },
+					],
+				} as unknown as Task,
+			],
+			Date.UTC(2026, 8, 7, 10, 0, 0),
+			Date.UTC(2026, 8, 7, 11, 0, 0),
+		);
+		const settled = [...baseEvents, ...late];
+
+		function loading(events: TrafficTimelineEvent[] = baseEvents) {
+			return renderHook(
+				(props: { events: TrafficTimelineEvent[]; ready: boolean }) =>
+					useTrafficPlayback(props.events, true, "project", props.ready),
+				{ initialProps: { events, ready: false } },
+			);
+		}
+
+		it("re-takes it when the late arms land, holding the reader in place", () => {
+			const { result, rerender } = loading();
+			act(() => result.current.playPause());
+			expect(result.current.events).toHaveLength(3);
+			rerender({ events: settled, ready: true });
+			expect(result.current.events.map((event) => event.kind)).toEqual([
+				"message", "task", "message", "task", "message",
+			]);
+			// Same event under the cursor, same playback state — only the index moved.
+			expect(result.current.currentRecord).toBe(first);
+			expect(result.current.index).toBe(0);
+			expect(result.current.playing).toBe(true);
+			act(() => vi.advanceTimersByTime(defaultInterval));
+			expect(result.current.current?.kind).toBe("task");
+		});
+
+		it("re-takes it once, then holds against everything that arrives later", () => {
+			const { result, rerender } = loading();
+			act(() => result.current.seek(2));
+			rerender({ events: settled, ready: true });
+			expect(result.current.events).toHaveLength(5);
+			expect(result.current.currentRecord).toBe(third);
+			expect(result.current.index).toBe(4);
+			const held = result.current.events;
+			rerender({
+				events: [...settled, ...messageEvents([record("latest", 9)])],
+				ready: true,
+			});
+			expect(result.current.events).toBe(held);
+			expect(result.current.index).toBe(4);
+		});
+
+		it("leaves a reader who never started in live mode", () => {
+			const { result, rerender } = loading();
+			rerender({ events: settled, ready: true });
+			expect(result.current.index).toBe(-1);
+			expect(result.current.events).toHaveLength(5);
+			expect(result.current.playing).toBe(false);
+			expect(vi.getTimerCount()).toBe(0);
 		});
 	});
 });

--- a/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
+++ b/src/mainview/components/agent-traffic/AgentTrafficScreen.tsx
@@ -543,10 +543,18 @@ function TrafficView({ projectId, onOpenTask }: Props) {
 	// length, and a cursor that survives that points at an event which is no longer
 	// there. Field order matches the key Seq 1823 assembles at integration.
 	const kindKey = [...kinds].sort().join(",");
+	// All three arms of the timeline, and only ever asked once per load. An `idle`
+	// archive is deliberately NOT ready — nobody has asked it anything yet — while
+	// `failed` is, because a transport failure must not park replay forever.
+	const timelineReady =
+		!data.loading &&
+		!data.tasksLoading &&
+		(notifications.status === "ready" || notifications.status === "failed");
 	const playback = useTrafficPlayback(
 		timeline,
 		experiment === "2",
 		`${scope}:${windowSize}:${filter}:${kindKey}:${pair}:${query}`,
+		timelineReady,
 	);
 	const graphRecords =
 		playback.index < 0

--- a/src/mainview/components/agent-traffic/useTrafficData.ts
+++ b/src/mainview/components/agent-traffic/useTrafficData.ts
@@ -12,6 +12,10 @@ export function useTrafficData(cutoff?: number) {
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [historyLoading, setHistoryLoading] = useState(false);
+	// Separate from `loading`, which flips on the first traffic page — long before
+	// the board itself is in. Replay snapshots the timeline, so it needs to know
+	// when the task arm has actually arrived, not when the screen stopped spinning.
+	const [tasksLoading, setTasksLoading] = useState(true);
 	const [error, setError] = useState(false);
 	const [revision, setRevision] = useState(0);
 	const [limit, setLimit] = useState(500);
@@ -38,6 +42,7 @@ export function useTrafficData(cutoff?: number) {
 		window.addEventListener("rpc:taskRemoved", onRemove);
 		window.addEventListener("rpc:projectUpdated", reload);
 		setLoading(true);
+		setTasksLoading(true);
 		setHistoryLoading(cutoff !== undefined && Number.isFinite(cutoff));
 		setError(false);
 		async function loadProjectTraffic(projectId: string) {
@@ -63,18 +68,19 @@ export function useTrafficData(cutoff?: number) {
 				const visible = allProjects.filter(project => !isLocked(project.id) && !isLocked(project));
 				if (cancelled) return;
 				setProjects(visible);
-				await Promise.allSettled(visible.flatMap(project => [
-					loadProjectTraffic(project.id),
-					api.request.getTasks({ projectId: project.id }).then(loaded => {
-						if (cancelled) return;
-						const snapshot = loaded.filter(task => !updated.has(endpointKey(task.projectId, task.id)));
-						const pushed = [...updated.values()].filter((task): task is Task => task !== null && task.projectId === project.id);
-						setTasks(current => [...current.filter(task => task.projectId !== project.id), ...snapshot, ...pushed]);
-						setLoading(false);
-					}).catch(() => { if (!cancelled) setError(true); }),
-				]));
+				const taskLoads = visible.map(project => api.request.getTasks({ projectId: project.id }).then(loaded => {
+					if (cancelled) return;
+					const snapshot = loaded.filter(task => !updated.has(endpointKey(task.projectId, task.id)));
+					const pushed = [...updated.values()].filter((task): task is Task => task !== null && task.projectId === project.id);
+					setTasks(current => [...current.filter(task => task.projectId !== project.id), ...snapshot, ...pushed]);
+					setLoading(false);
+				}).catch(() => { if (!cancelled) setError(true); }));
+				// Announced as soon as the board is in, without waiting for traffic
+				// paging: the two arms load independently and replay only needs this one.
+				void Promise.allSettled(taskLoads).then(() => { if (!cancelled) setTasksLoading(false); });
+				await Promise.allSettled([...visible.map(project => loadProjectTraffic(project.id)), ...taskLoads]);
 			} catch { if (!cancelled) setError(true); }
-			finally { if (!cancelled) { setLoading(false); setHistoryLoading(false); } }
+			finally { if (!cancelled) { setLoading(false); setTasksLoading(false); setHistoryLoading(false); } }
 		})();
 		return () => {
 			cancelled = true;
@@ -87,7 +93,7 @@ export function useTrafficData(cutoff?: number) {
 	const pages = useMemo(() => visibleProjects.map(project => getTrafficState(project.id)), [visibleProjects, tick]);
 	const rows = useMemo(() => pages.flatMap(page => page.rows).filter(row => !isLocked(row.fromProjectId) && !isLocked(row.toProjectId)).sort((a, b) => Date.parse(b.at) - Date.parse(a.at)), [pages, isLocked]);
 	const projectIds = new Set(visibleProjects.map(project => project.id));
-	return { projects: visibleProjects, tasks: tasks.filter(task => projectIds.has(task.projectId)), rows, loading, historyLoading,
+	return { projects: visibleProjects, tasks: tasks.filter(task => projectIds.has(task.projectId)), rows, loading, historyLoading, tasksLoading,
 		error: error || pages.some(page => page.error), hasMore: pages.some(page => page.hasMore), limit,
 		oldestDay: pages.map(page => page.oldestDay).filter((day): day is string => !!day).sort()[0],
 		retentionDays: pages[0]?.retentionDays ?? 30,

--- a/src/mainview/components/agent-traffic/useTrafficPlayback.ts
+++ b/src/mainview/components/agent-traffic/useTrafficPlayback.ts
@@ -15,6 +15,8 @@ interface PlaybackState {
 	playing: boolean;
 	ended: boolean;
 	revision: number;
+	/** Whether the timeline this snapshot froze was the finished one. */
+	ready: boolean;
 }
 
 /**
@@ -29,6 +31,16 @@ export function useTrafficPlayback(
 	timeline: TrafficTimelineEvent[],
 	enabled: boolean,
 	scopeKey: string,
+	/**
+	 * Whether every arm of the timeline has finished its first load.
+	 *
+	 * Defaults to true so a caller with nothing async keeps the plain behaviour.
+	 * A caller that loads messages, board movements and notifications separately
+	 * must pass the real answer: pressing Play mid-load otherwise freezes a
+	 * timeline that is missing whole kinds of event, and only a filter change or
+	 * a Restart ever brings them back.
+	 */
+	ready = true,
 ) {
 	const chronological = useMemo(() => sortTimeline(timeline), [timeline]);
 	const [speed, updateSpeed] = useState(1);
@@ -40,6 +52,7 @@ export function useTrafficPlayback(
 		playing: false,
 		ended: false,
 		revision: 0,
+		ready: true,
 	});
 	const active = enabled && state.scopeKey === scopeKey;
 	const events = active && state.events ? state.events : chronological;
@@ -58,6 +71,40 @@ export function useTrafficPlayback(
 			}));
 		}
 	}, [enabled, scopeKey, state.scopeKey]);
+
+	/**
+	 * Re-take a snapshot that was frozen too early — once, and without moving the
+	 * reader.
+	 *
+	 * The snapshot exists to protect a running replay from live arrivals, and that
+	 * stays: an event that shows up after the load settled is still ignored until
+	 * Restart or Live. This only covers the one case the snapshot cannot defend,
+	 * where it captured a timeline whose task and notification arms had not landed
+	 * yet. The cursor is carried over by event key, so play/pause and the reader's
+	 * position survive; card states are recomputed from the cursor's TIME, so a
+	 * movement inserted behind the cursor is already reflected on the board.
+	 */
+	useEffect(() => {
+		if (!ready || !enabled) return;
+		setState((previous) => {
+			if (previous.ready || !previous.events) return previous;
+			if (previous.scopeKey !== scopeKey) return previous;
+			const key = previous.events[previous.index]?.key;
+			const moved = key
+				? chronological.findIndex((event) => event.key === key)
+				: -1;
+			return {
+				...previous,
+				ready: true,
+				events: chronological,
+				index:
+					moved >= 0
+						? moved
+						: Math.min(previous.index, chronological.length - 1),
+				revision: previous.revision + 1,
+			};
+		});
+	}, [ready, enabled, scopeKey, chronological]);
 
 	useEffect(() => {
 		if (!playing) return;
@@ -96,6 +143,7 @@ export function useTrafficPlayback(
 				revision: previous.revision + 1,
 				playing: resume,
 				ended: false,
+				ready,
 			};
 		});
 	}


### PR DESCRIPTION
Pressing Play in Agent traffic while the screen was still loading froze a timeline that had only messages on it. `useTrafficPlayback.activate()` snapshots the timeline on the first interaction — deliberately, so a live message cannot yank a running replay — but it had no way to tell a short timeline from an unfinished one. The three arms load independently (messages page in first, board movements from `getTasks`, notifications from the archive), so recorded task movements never entered replay until the reader changed a filter or pressed Restart.

`data.loading` could not answer "is the board in yet": it flips false on the first traffic page, long before `getTasks` resolves. So `useTrafficData` now exposes a separate `tasksLoading`, `useTrafficPlayback` takes an optional `ready` flag and re-takes its snapshot exactly once when the load settles — carrying the cursor over by event key, so play/pause and the reader's position survive — and `AgentTrafficScreen` computes readiness from all three sources.

A snapshot taken after the load settled still ignores everything that arrives later; that behaviour keeps its existing test. Two new tests cover the re-take and the fact that it happens only once.

Verified in a browser on the running app at 3840×2160, 1600×1000, 1152×800 and 390×844 — the replay cursor lands on recorded task events at every width, console clean.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b4df6dfa-5fd6-4cd7-ae33-a2cfb5f9f663) · `dev3://task/b4df6dfa-5fd6-4cd7-ae33-a2cfb5f9f663`
