### PR TITLE
Keep the agent-traffic summary in flow so stage overlays cannot cover it

### DIFF
--- a/change-logs/2026/09/11/fix-traffic-summary-overlap.md
+++ b/change-logs/2026/09/11/fix-traffic-summary-overlap.md
@@ -1,0 +1,3 @@
+Short: Agent traffic labels no longer collide
+
+The Agent traffic scope title and its hint no longer sit under the "N tasks with no messages" pills: the summary row keeps its own surface above the stage at every width instead of floating over it. The map caption at the bottom of the stage also got a plate, so it stays readable over the dot grid.

--- a/decisions/2026/09/11/traffic-summary-stays-in-flow.md
+++ b/decisions/2026/09/11/traffic-summary-stays-in-flow.md
@@ -1,0 +1,48 @@
+# The Agent traffic summary stays in flow, never floated over the stage
+
+## Context
+
+On the Coordination view (`data-experiment="2"`) the scope title ("All active projects") and its
+hint were absolutely positioned over the node stage at widths `≥ 901px`, with a transparent
+background. The user reported the hint rendered underneath the "N tasks with no messages" /
+"N parked" pills, and that the labels were unreadable over the dot grid.
+
+## Investigation
+
+The two boxes were anchored to **different containing blocks** with hardcoded pixel offsets, both
+introduced by the same commit (#1673):
+
+- `.traffic-summary` → `position: absolute; top: 108px` inside `.traffic-view` (view top).
+- `.traffic-nodes-bands` → `top: 65px` inside `.traffic-nodes` (stage top, i.e. below the toolbar).
+
+So the pills' real vertical position is `toolbarHeight + 65`, and they clear the summary only when
+the toolbar is taller than about 96px. Measured in a real browser against these stylesheets with a
+faithful DOM: toolbar 57px → pills at 122–147, summary hint at 137–150. The overlap is
+unconditional at desktop widths and has nothing to do with viewport size; every toolbar change
+moves one box and not the other. Below 901px the float never applied, and there the layout was
+already correct.
+
+## Decision
+
+Deleted the `@media (min-width: 901px)` block in
+`src/mainview/components/agent-traffic/traffic-nodes.css` that floated the summary and shifted the
+bands. The summary now renders in flow above the stage at every width, on its own
+`--surface-base` surface, and the stage overlays keep their single origin. Both magic numbers are
+gone, so the layout no longer depends on the toolbar's height. The map caption at the bottom of the
+stage got the same plate treatment as the band pills (`--surface-raised / 0.92` plus an inset
+hairline), for the same readability reason.
+
+## Risks
+
+The stage loses about 52px of height on desktop (measured 1023 → 971 at 1920×1080), and the screen
+loses the "labels floating over the canvas" look. Neither affects the camera, the layout algorithm,
+or any behaviour.
+
+## Alternatives considered
+
+- **Retune `top: 65px` to clear the summary.** Rejected: it is the same magic number against the
+  same wrong origin, so the next toolbar change breaks it again.
+- **Keep the float, move the pills to the bottom-left.** Rejected: that corner belongs to the map
+  caption, and the bottom-right to the camera controls.
+- **Measure the toolbar in JS and publish it as a custom property.** Rejected as far more machinery
+  than a layout this static needs.

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -23,6 +23,10 @@
 	position: relative;
 	background: rgb(var(--surface-base));
 }
+/* Stays in flow at every width. Floated over the stage it was anchored to the
+   view while the stage overlays are anchored to the stage, so the two drifted
+   apart with the toolbar's height and the quiet/parked pills landed on top of
+   these labels. */
 .traffic-view[data-experiment="2"] .traffic-summary {
 	gap: 18px;
 	padding: 10px 22px;
@@ -588,6 +592,11 @@
 	font-size: 10px;
 	color: rgb(var(--text-tertiary));
 	pointer-events: none;
+	/* Same plate as the band pills: bare text over the dot grid reads as noise. */
+	padding: 5px 8px;
+	border-radius: 7px;
+	background: rgb(var(--surface-raised) / 0.92);
+	box-shadow: inset 0 0 0 1px rgb(var(--border-default) / 0.5);
 }
 .traffic-icon {
 	width: 16px;
@@ -986,21 +995,6 @@
 	height: 20px;
 	border-radius: 2px;
 	background: rgb(var(--accent));
-}
-
-@media (min-width: 901px) {
-	.traffic-view[data-experiment="2"] .traffic-summary {
-		position: absolute;
-		top: 108px;
-		left: 0;
-		right: 0;
-		z-index: 2;
-		background: transparent;
-		pointer-events: none;
-	}
-	.traffic-view[data-experiment="2"] .traffic-nodes-bands {
-		top: 65px;
-	}
 }
 
 .traffic-filter-fields {


### PR DESCRIPTION
Hey, Claude here — the AI assistant that worked on this branch.

On the Coordination traffic view the scope title ("All active projects") and its hint rendered underneath the "N tasks with no messages" / "N parked" pills, and sat unreadable directly on the stage's dot grid.

Cause: two absolutely positioned boxes with hardcoded offsets anchored to **different containing blocks**, both from #1673. `.traffic-summary` used `top: 108px` inside `.traffic-view` (screen top), while `.traffic-nodes-bands` uses `top: 65px` inside `.traffic-nodes` (stage top, below the toolbar). The pills therefore sit at `toolbarHeight + 65` and only clear the summary when the toolbar is taller than ~96px — it is 57px, so they always overlapped at widths from 901px up. The same media block also set `background: transparent` on the summary, which is the readability half of the report.

Fix: the summary stays in flow at every width on its own surface, and the floating media block is gone, so both magic numbers disappear and the layout no longer tracks the toolbar's height. The bottom-left map caption got the same plate as the band pills for the same readability reason. CSS only — 9 insertions, 15 deletions in `traffic-nodes.css`. Cost: the stage loses 52px of height on desktop (1023 → 971 at 1920×1080).

Verified in the running app at 3840×2160, 1920×1080, 1280×900 and 390×900: zero overlap at all four, no console errors. Reasoning recorded in `decisions/2026/09/11/traffic-summary-stays-in-flow.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=17008bcd-a11b-41fd-ae6e-d53e5b44358b) · `dev3://task/17008bcd-a11b-41fd-ae6e-d53e5b44358b` _(dev3 added this footer — turn it off in Settings → Tasks.)_
