### PR TITLE
Open dev-launch windows without activating the app

### DIFF
--- a/change-logs/2026/09/11/fix-dev-launch-no-focus-steal.md
+++ b/change-logs/2026/09/11/fix-dev-launch-no-focus-steal.md
@@ -1,0 +1,3 @@
+Short: Dev builds no longer steal focus
+
+A local dev launch (`bun run dev`, `bun run start`, the task dev server) now opens its window without activating the app, so starting a dev build no longer pulls you out of a fullscreen app or switches your macOS Space. Ordinary app launches and windows you open yourself still come to the front as before.

--- a/decisions/2026/09/11/dev-launch-opens-without-activating.md
+++ b/decisions/2026/09/11/dev-launch-opens-without-activating.md
@@ -1,0 +1,54 @@
+# A dev launch opens its window without activating the app
+
+## Context
+
+Starting a dev build (`bun run dev` / the task dev server) yanked the user out of
+whatever they were doing: the new window took foreground, and because macOS follows
+the frontmost app, a fullscreen app on another Space was swapped away mid-use.
+Ordinary launches must keep coming to the front — the user asked for those.
+
+## Investigation
+
+Electrobun's `BrowserWindow` takes an undocumented `activate` option (default `true`)
+that reaches `showWindow(ptr, activate)` in the prebuilt `libNativeWrapper.dylib`.
+Disassembling that symbol (`objdump --macho -d`, `_showWindow` at `0x308bc`) shows the
+whole difference:
+
+- `activate == true` → `orderFront:`, `makeKeyAndOrderFront:`, then
+  `[NSApp activateIgnoringOtherApps:YES]` — the foreground steal.
+- `activate == false` → `orderFrontRegardless` alone — the window is ordered in
+  (visible on its Space even while the app is inactive), the app never activates.
+
+So the lever already exists; nothing needed hiding, delaying, or re-focusing.
+
+## Decision
+
+`createAppWindow` forwards an `activate` option to the constructor (`window-manager.ts`),
+and `src/bun/index.ts` passes `shouldActivateLaunchWindow()` (`fresh-start.ts`) for the
+windows a LAUNCH opens. That helper is `!isFreshStartMode()` — `DEV3_FRESH_START=1`, the
+marker the dev scripts already set, is the authoritative "this is a dev launch" signal.
+Windows opened later (Cmd+Shift+N, a notification click, `dev3 ui focus`) are untouched
+and still activate.
+
+Measured on macOS 15 (Darwin 24.6.0), user sitting in a fullscreen app: before the fix the
+dev app became frontmost within ~10s of launch; after it, 61/61 frontmost samples stayed on
+the user's app, and the dev window sat fully rendered on ordinary Space 3 while the active
+Space stayed the fullscreen one (`CGSCopySpacesForWindows` / `CGSGetActiveSpace`).
+
+## Risks
+
+The dev window opens behind whatever is in front, so on a normal Space it appears without
+focus — intended, but it is a behaviour change for anyone used to the build ending with the
+app in their face. If a future electrobun bump changes what `activate: false` maps to, the
+window could stop being ordered in at all; the guard is the pair of tests in
+`window-manager-fresh.test.ts`, which only prove the flag is passed, not what the native
+side does with it.
+
+## Alternatives considered
+
+- Activate and then hide/re-focus the previous app — a visible flicker and a race with the
+  user; explicitly ruled out.
+- Gate on the `dev` build channel instead of fresh-start — wrong axis: a dev-channel build
+  the user double-clicks in Finder must come to the front.
+- Patch the launcher (`open -g`) — `electrobun dev` spawns the bundle's `launcher` binary
+  directly, never through `open`, so there is no such flag to pass.

--- a/src/bun/__tests__/fresh-start.test.ts
+++ b/src/bun/__tests__/fresh-start.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { isFreshStartMode } from "../fresh-start";
+import { isFreshStartMode, shouldActivateLaunchWindow } from "../fresh-start";
 
 const ORIGINAL = process.env.DEV3_FRESH_START;
 
@@ -24,5 +24,17 @@ describe("isFreshStartMode", () => {
 			process.env.DEV3_FRESH_START = v;
 			expect(isFreshStartMode()).toBe(false);
 		}
+	});
+});
+
+describe("shouldActivateLaunchWindow", () => {
+	it("an ordinary launch still comes to the front", () => {
+		delete process.env.DEV3_FRESH_START;
+		expect(shouldActivateLaunchWindow()).toBe(true);
+	});
+
+	it("a dev launch opens without taking foreground", () => {
+		process.env.DEV3_FRESH_START = "1";
+		expect(shouldActivateLaunchWindow()).toBe(false);
 	});
 });

--- a/src/bun/__tests__/window-manager-fresh.test.ts
+++ b/src/bun/__tests__/window-manager-fresh.test.ts
@@ -21,6 +21,7 @@ type FakeWindow = {
 	on: ReturnType<typeof vi.fn>;
 	handlers: Record<string, () => void>;
 	frame?: { x: number; y: number; width: number; height: number };
+	activate?: boolean;
 };
 
 const globalBag = globalThis as typeof globalThis & { __fakeWindows: FakeWindow[] };
@@ -41,9 +42,11 @@ vi.mock("electrobun/bun", () => {
 		on: ReturnType<typeof vi.fn>;
 		handlers: Record<string, () => void>;
 		frame?: { x: number; y: number; width: number; height: number };
+		activate?: boolean;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		constructor(opts?: any) {
 			this.frame = opts?.frame;
+			this.activate = opts?.activate;
 			const handlers: Record<string, () => void> = {};
 			this.webview = {
 				rpc: { send: new Proxy({} as Record<string, ReturnType<typeof vi.fn>>, { get(t, p: string) { if (!(p in t)) t[p] = vi.fn(); return t[p]; } }) },
@@ -98,8 +101,8 @@ afterEach(() => {
 	else process.env.DEV3_FRESH_START = ORIGINAL;
 });
 
-function spawn() {
-	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {} });
+function spawn(activate?: boolean) {
+	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {}, ...(activate === undefined ? {} : { activate }) });
 }
 
 /** Fire every registered dom-ready listener, then let their timers run. */
@@ -148,6 +151,20 @@ describe("window-manager fresh-start mode", () => {
 		expect(createdWindows[0].getSize).not.toHaveBeenCalled();
 		expect(createdWindows[0].setSize).not.toHaveBeenCalled();
 		expect(createdWindows[0].setFullScreen).not.toHaveBeenCalled();
+	});
+
+	// A dev launch fires while the user is in another app, often fullscreen on
+	// another Space: taking foreground would yank them out of it.
+	it("takes foreground by default — an ordinary launch behaves as before", () => {
+		delete process.env.DEV3_FRESH_START;
+		spawn();
+		expect(createdWindows[0].activate).toBe(true);
+	});
+
+	it("opens without taking foreground when the caller asks not to activate", () => {
+		process.env.DEV3_FRESH_START = "1";
+		spawn(false);
+		expect(createdWindows[0].activate).toBe(false);
 	});
 
 	it("nudges the first paint only once, even if dom-ready fires again", () => {

--- a/src/bun/fresh-start.ts
+++ b/src/bun/fresh-start.ts
@@ -18,3 +18,16 @@
 export function isFreshStartMode(): boolean {
 	return process.env.DEV3_FRESH_START === "1";
 }
+
+/**
+ * Whether the windows opened BY A LAUNCH may take foreground. A dev launch fires
+ * while the user is working in another app — often fullscreen on another Space —
+ * so activating would yank them out of it. An ordinary launch is the user opening
+ * the app and must come to the front as always.
+ *
+ * Windows the user opens later (Cmd+Shift+N, a notification click) are unaffected:
+ * they activate in every mode.
+ */
+export function shouldActivateLaunchWindow(): boolean {
+	return !isFreshStartMode();
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -51,6 +51,7 @@ import { makeTitle } from "./app-utils";
 import { buildApplicationMenu, getMenuContext, MENU_ACTIONS, onMenuContextChange } from "../shared/application-menu";
 import { openLogsDirectory } from "./menu-actions";
 import { startLoopMonitor } from "./loop-monitor";
+import { shouldActivateLaunchWindow } from "./fresh-start";
 import { createAppWindow, focusFocusedWindow, getFocusedWindow, getWindowCount, handleDisplayConfigurationChange, loadWindowSession, sendToFocusedWindow, setOpenNewWindow, flushWindowState } from "./window-manager";
 import type { WindowState } from "./window-state";
 import { pushEverywhere } from "./push-targets";
@@ -454,10 +455,11 @@ function failDesktopLaunch(timeoutMs: number): void {
 	void hardExit(CLI_EXIT_CODE_RENDERER_UNAVAILABLE);
 }
 
-async function openMainWindow(restore?: WindowState) {
+async function openMainWindow(restore?: WindowState, activate = true) {
 	const buildChannel = await Updater.localInfo.channel();
 	return createAppWindow({
 		restore,
+		activate,
 		title: makeTitle(APP_VERSION, lastBuildTime, buildChannel),
 		url,
 		handlers: handlers as unknown as Record<string, (...args: unknown[]) => unknown>,
@@ -500,9 +502,14 @@ setOpenNewWindow(() => {
 // gets the usual single window.
 const restoreSession = loadWindowSession();
 if (restoreSession.length > 1) log.info("Restoring window session", { windows: restoreSession.length });
-const primaryWindow = await openMainWindow(restoreSession[0]);
-log.info("Main window created");
-for (const state of restoreSession.slice(1)) await openMainWindow(state);
+// A dev launch (`bun run dev` / the task dev server) must not pull the user out
+// of whatever they are doing: the window opens without activating the app, so no
+// foreground steal and no Space switch away from a fullscreen app. Only these
+// launch windows — a window the user opens later still comes to the front.
+const activateOnLaunch = shouldActivateLaunchWindow();
+const primaryWindow = await openMainWindow(restoreSession[0], activateOnLaunch);
+log.info("Main window created", { activate: activateOnLaunch });
+for (const state of restoreSession.slice(1)) await openMainWindow(state, activateOnLaunch);
 // Creation order decides key focus, so hand it back to the primary window.
 if (restoreSession.length > 1) {
 	try { primaryWindow.focus(); } catch (err) { log.debug("Focusing the restored primary window failed", { error: String(err) }); }

--- a/src/bun/window-manager.ts
+++ b/src/bun/window-manager.ts
@@ -162,6 +162,13 @@ export interface CreateAppWindowOptions {
 	 * window of a launch falls back to the saved primary geometry.
 	 */
 	restore?: WindowState | null;
+	/**
+	 * Whether showing the window also activates the app (macOS
+	 * `activateIgnoringOtherApps:`). False orders the window in without taking
+	 * foreground, so a launch cannot pull the user out of a fullscreen app or
+	 * switch their Space. Defaults to true — only the dev launch opts out.
+	 */
+	activate?: boolean;
 }
 
 /**
@@ -233,6 +240,7 @@ export function createAppWindow(opts: CreateAppWindowOptions): BrowserWindow {
 		url: opts.url,
 		rpc,
 		frame,
+		activate: opts.activate ?? true,
 		...(opts.preload ? { preload: opts.preload } : {}),
 	});
 


### PR DESCRIPTION
Starting a dev build (`bun run dev`, `bun run start`, the task dev server) pulled the user out of whatever they were doing: the new window took foreground, and because macOS follows the frontmost app, a fullscreen app on another Space got swapped away mid-use.

The activation is not in the launcher — `electrobun dev` spawns the bundle's `launcher` binary directly, never through macOS `open`. It happens at native window creation: electrobun's `BrowserWindow` takes an undocumented `activate?: boolean` (default `true`) that reaches `showWindow(ptr, activate)` in the prebuilt `libNativeWrapper.dylib`. Disassembling that symbol shows exactly two branches:

- `activate == true` → `orderFront:` + `makeKeyAndOrderFront:` + `[NSApp activateIgnoringOtherApps:YES]` — the foreground steal.
- `activate == false` → `orderFrontRegardless` alone — the window is ordered in and visible on its Space, the app never activates.

**The change:** `createAppWindow` forwards an `activate` option to the constructor (default `true`), and the windows a *launch* opens pass `shouldActivateLaunchWindow()` — `!isFreshStartMode()`, keyed on `DEV3_FRESH_START=1`, the marker the dev scripts already set. Windows opened later (Cmd+Shift+N, a notification click, `dev3 ui focus`) still activate in every mode. Ordinary/production launches are unchanged. No new toggle, no delayed hide/refocus, no window-manager redesign; fresh-start geometry rules and multi-window restore are untouched.

**Verified natively on macOS 15 (Darwin 24.6.0)**, sampling the frontmost app every 0.5s across a dev-server start while sitting in a fullscreen app:

| Run | Frontmost samples | Verdict |
|---|---|---|
| Before | dev build became frontmost within ~10s of launch | reproduced |
| After | 61 of 61 samples stayed on the user's app | no foreground steal |

Space check after the fix (`CGSCopySpacesForWindows` / `CGSGetActiveSpace`): the dev window landed on ordinary Space 3, fully rendered, while the active Space stayed the fullscreen one. Not verified: the same flow on Windows/Linux (the code is one boolean passed through; the analysed branch is the macOS wrapper).

Reasoning and the disassembly are recorded in `decisions/2026/09/11/dev-launch-opens-without-activating.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=3b0652c6-3a5b-41c9-a252-0b3dce07deb0) · `dev3://task/3b0652c6-3a5b-41c9-a252-0b3dce07deb0` _(dev3 added this footer — turn it off in Settings → Tasks.)_
