### PR TITLE
Trail the notification preview into the card it belongs to

### DIFF
--- a/change-logs/2026/09/11/feature-notification-preview-tail.md
+++ b/change-logs/2026/09/11/feature-notification-preview-tail.md
@@ -1,0 +1,3 @@
+Short: Notify preview points at its card
+
+The notification preview on the Agent traffic stage now trails two shrinking puffs out of its card-facing edge, so it reads as belonging to the one card that sent it rather than floating above the whole row. They flip to the cloud's top edge when it hangs below its card.

--- a/decisions/2026/09/11/notification-preview-cloud-on-sender-card.md
+++ b/decisions/2026/09/11/notification-preview-cloud-on-sender-card.md
@@ -39,9 +39,16 @@ Three rulings:
    the whole point of a preview, and colour alone does not survive a colour-blind
    reader or a screenshot. It reuses the inspector's existing
    `traffic.notification.level.*` keys, so this shipped with no new strings.
-3. **No puff trail and no camera motion.** The trail in the reference cost real
-   height for decoration; the anchor over the card already says which card sent
-   it. An off-frame sender gets no preview, and the stage never pans on its own
+3. **A two-puff trail, and no camera motion.** The first cut shipped without the
+   trail, on the argument that the anchor over the card already says which card
+   sent it. On screen it did not: a cloud floating above a row of cards reads as
+   belonging to the row, not to one card. Two ellipses drifting diagonally out of
+   the body's card-facing edge fix that, and they cost about 28px of height (15px
+   compact) — paid deliberately. Two, not the reference's three: a third adds
+   height without adding meaning at these sizes. They drift sideways rather than
+   straight down, because a vertical column of puffs reads as a dotted leader
+   line instead of the thought-bubble grammar everybody already knows.
+   An off-frame sender still gets no preview, and the stage never pans on its own
    to bring one back.
 
 ## Risks

--- a/src/mainview/__tests__/traffic-notification-cloud.test.tsx
+++ b/src/mainview/__tests__/traffic-notification-cloud.test.tsx
@@ -6,7 +6,10 @@ import type { Task, TaskMovement, TaskStatus } from "../../shared/types";
 import { I18nProvider } from "../i18n";
 import { notificationEvents } from "../notification-event";
 import TrafficNodes from "../components/agent-traffic/TrafficNodes";
-import { notificationCloud } from "../components/agent-traffic/notification-cloud";
+import {
+	notificationCloud,
+	notificationCloudPuffs,
+} from "../components/agent-traffic/notification-cloud";
 import {
 	endpointKey,
 	trafficRecords,
@@ -156,6 +159,60 @@ describe("the notification cloud outline", () => {
 		expect(compact.path).toContain("C");
 	});
 
+	it("trails exactly two puffs toward the card, shrinking as they go", () => {
+		const cloud = notificationCloud(220, 34, false);
+		// The card sits well to the left of a cloud leaning off its shoulder.
+		const puffs = notificationCloudPuffs(cloud, 40, false);
+		expect(puffs).toHaveLength(2);
+		const [near, far] = puffs;
+		// Smaller the further it gets, or it reads as a second cloud rather than a
+		// thought trailing off.
+		expect(far.rx).toBeLessThan(near.rx);
+		expect(far.ry).toBeLessThan(near.ry);
+		// Diagonal, not a vertical column: straight down reads as a leader line.
+		expect(far.cx).toBeLessThan(near.cx);
+		expect(far.cy).toBeGreaterThan(near.cy);
+		// Below the body, and inside the drawn box on every side.
+		expect(near.cy - near.ry).toBeGreaterThan(cloud.content.y + cloud.content.height);
+		expect(far.cy + far.ry).toBeLessThanOrEqual(cloud.height);
+		expect(far.cx - far.rx).toBeGreaterThan(0);
+	});
+
+	it("aims the far puff at the card, wherever the card is", () => {
+		const cloud = notificationCloud(220, 34, false);
+		// The far puff lands ON the target, so the trail ends over the card and not
+		// at a fixed offset that happens to miss it.
+		expect(notificationCloudPuffs(cloud, 40, false)[1].cx).toBeCloseTo(40);
+		expect(notificationCloudPuffs(cloud, 200, false)[1].cx).toBeCloseTo(200);
+		// A card directly underneath gets a straight trail rather than a bent one.
+		const straight = notificationCloudPuffs(cloud, cloud.width / 2, false);
+		expect(straight[0].cx).toBeCloseTo(cloud.width / 2);
+		expect(straight[1].cx).toBeCloseTo(cloud.width / 2);
+	});
+
+	it("flips the trail above the body when the cloud hangs below its card", () => {
+		const above = notificationCloud(220, 34, false, false);
+		const below = notificationCloud(220, 34, false, true);
+		// Same box either way — only the side the trail leaves from changes.
+		expect(below.height).toBe(above.height);
+		expect(below.content.y).toBeGreaterThan(above.content.y);
+		const puffs = notificationCloudPuffs(below, 40, false);
+		for (const puff of puffs) {
+			expect(puff.cy).toBeLessThan(below.content.y);
+			expect(puff.cy - puff.ry).toBeGreaterThanOrEqual(0);
+		}
+		// Still the far one that is further out.
+		expect(puffs[1].cy).toBeLessThan(puffs[0].cy);
+	});
+
+	it("keeps the compact trail smaller than the full one", () => {
+		const full = notificationCloud(220, 34, false);
+		const compact = notificationCloud(220, 34, true);
+		expect(notificationCloudPuffs(compact, 40, true)[0].rx).toBeLessThan(
+			notificationCloudPuffs(full, 40, false)[0].rx,
+		);
+	});
+
 	it("survives a box narrower than its own corners without a negative step", () => {
 		const { path } = notificationCloud(6, 14, true);
 		expect(path).not.toContain("NaN");
@@ -170,6 +227,9 @@ describe("the notification preview on the traffic stage", () => {
 		expect(cloud.dataset.level).toBe("success");
 		expect(cloud.textContent).toContain("backfill finished, 4812 rows written");
 		expect(cloud.textContent).toContain("success");
+		// The trail is what says WHICH card this belongs to, so it is not optional
+		// decoration: a cloud with no puffs floats unattributed.
+		expect(cloud.querySelectorAll(".traffic-notification-cloud-puff")).toHaveLength(2);
 	});
 
 	it("marks an error apart from an info, in words and not only in colour", () => {

--- a/src/mainview/components/agent-traffic/TrafficNotificationCloud.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNotificationCloud.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import type { NotificationLogLevel } from "../../../shared/notification-log";
 import { useT } from "../../i18n";
-import { notificationCloud } from "./notification-cloud";
+import { notificationCloud, notificationCloudPuffs } from "./notification-cloud";
 
 /**
  * What `dev3 notify` said, previewed over the card that sent it.
@@ -50,15 +50,31 @@ export default function TrafficNotificationCloud({
 		observer.observe(element);
 		return () => observer.disconnect();
 	}, [message, compact]);
-	const cloud = notificationCloud(box.width, box.height, compact);
-	// Above the card by default, below it when the card sits too close to the top
-	// edge for the cloud to fit — the same rule the message bubble follows.
-	const below = anchor.y < cloud.height + 16;
-	const left = Math.max(
+	// Measured once to learn the height, then rebuilt with the side settled: the
+	// trail flips to the other edge when the cloud hangs below its card, and that
+	// changes where the body sits inside the same box.
+	const below = anchor.y < notificationCloud(box.width, box.height, compact).height + 16;
+	const cloud = notificationCloud(box.width, box.height, compact, below);
+	// Leaning off to one side, not centred over the card. Centred, the trail has
+	// nowhere diagonal to go: it drops straight down through the gap between two
+	// neighbouring cards and points at nothing. Leaning puts the body over the
+	// space beside the card and lets the puffs walk back onto it.
+	const lean = Math.min(cloud.width * 0.3, 70);
+	const centre = Math.max(
 		cloud.width / 2 + 8,
-		Math.min(width - cloud.width / 2 - 8, anchor.x),
+		Math.min(width - cloud.width / 2 - 8, anchor.x + lean),
 	);
-	const top = anchor.y + (below ? 14 : -10);
+	// The trail's small end all but touches the card, which is the whole point of
+	// it: 2px of clearance, not the 10px a tail-less cloud wanted.
+	const top = anchor.y + (below ? 2 : -2);
+	// Where the card is, in the cloud's own pixel space. Derived from the CLAMPED
+	// position, so a cloud shoved sideways by the frame's edge still aims its trail
+	// at the card rather than at where it wanted to be.
+	const puffs = notificationCloudPuffs(
+		cloud,
+		anchor.x - (centre - cloud.width / 2),
+		compact,
+	);
 	// An off-frame sender gets no preview at all rather than a cloud pinned to the
 	// edge pointing at nothing: the stage never moves on its own to bring it back.
 	const offFrame =
@@ -69,7 +85,7 @@ export default function TrafficNotificationCloud({
 			data-testid="traffic-notification-cloud"
 			data-level={level}
 			style={{
-				left,
+				left: centre,
 				top,
 				width: cloud.width,
 				height: cloud.height,
@@ -84,6 +100,16 @@ export default function TrafficNotificationCloud({
 				aria-hidden="true"
 			>
 				<path d={cloud.path} />
+				{puffs.map((puff) => (
+					<ellipse
+						key={`${puff.cx}:${puff.cy}`}
+						className="traffic-notification-cloud-puff"
+						cx={puff.cx}
+						cy={puff.cy}
+						rx={puff.rx}
+						ry={puff.ry}
+					/>
+				))}
 			</svg>
 			<div
 				ref={ref}

--- a/src/mainview/components/agent-traffic/notification-cloud.ts
+++ b/src/mainview/components/agent-traffic/notification-cloud.ts
@@ -1,5 +1,5 @@
 /**
- * The outline of a notification preview, as one closed path.
+ * The outline of a notification preview, as one closed path plus its trail.
  *
  * Geometry only: no colour, no text, no React. The shape is a single cubic-bezier
  * wave over a rounded box — deliberately NOT a union of circles. A row of equal
@@ -27,14 +27,47 @@ const AMPLITUDES = {
 	full: [0.94, 0.58, 1, 0.7],
 } as const;
 
+/**
+ * One of the two puffs that tie the cloud to the card it belongs to.
+ *
+ * Ellipses, not circles, and they aim AT a point rather than drifting by a fixed
+ * offset. The fixed-offset version shipped first and was wrong on screen: with
+ * the cloud centred over its card the puffs drifted into the gap between two
+ * neighbours and pointed at nothing. Two is the whole trail — a third adds
+ * height without adding meaning at the sizes this preview lives at.
+ */
+export interface NotificationCloudPuff {
+	cx: number;
+	cy: number;
+	rx: number;
+	ry: number;
+}
+
+/** How big the trail is, relative to the full-size one. */
+function trailScale(compact: boolean): number {
+	return compact ? 0.72 : 1;
+}
+
+/**
+ * The trail's own height, so the body can be offset by it when the cloud hangs
+ * below its card and the puffs have to rise instead of fall.
+ */
+export function notificationTrailHeight(compact: boolean): number {
+	return (22 + 5.5) * trailScale(compact) + RIM;
+}
+
 export interface NotificationCloudGeometry {
 	/** One closed path in the geometry's own pixel space. Never a second subpath. */
 	path: string;
-	/** Total drawn size, rim included. */
+	/** Total drawn size, trail and rim included. */
 	width: number;
 	height: number;
 	/** Where the caller's content sits inside the outline. */
 	content: { x: number; y: number; width: number; height: number };
+	/** The body's outer edge on the side the card is — where the trail starts. */
+	trailEdge: number;
+	/** +1 when the trail falls out of the body, −1 when it rises out of it. */
+	trailDirection: 1 | -1;
 }
 
 /**
@@ -48,7 +81,12 @@ export function notificationCloud(
 	width: number,
 	height: number,
 	compact: boolean,
+	below = false,
 ): NotificationCloudGeometry {
+	const trail = notificationTrailHeight(compact);
+	// The trail always points AT the card, so hanging below its card flips it: the
+	// body moves down by the trail's height and the puffs rise out of its crest.
+	const shift = below ? trail : 0;
 	const amplitude = compact ? 14 : 28;
 	const radius = compact ? 9 : 16;
 	// Padding INSIDE the outline, not around it. The wave's valley line and the
@@ -63,7 +101,7 @@ export function notificationCloud(
 	const bottom = (compact ? 4 : 8) + RIM;
 	// The wave never leaves the outline box sideways, so the sides need only the rim.
 	const x = RIM + 1;
-	const y = top;
+	const y = top + shift;
 	const amps = compact ? AMPLITUDES.compact : AMPLITUDES.full;
 	// A crest cannot start inside a corner arc, so the wave spans the box minus
 	// both radii — and a preview narrower than that gets one flat-ish crest rather
@@ -87,7 +125,42 @@ export function notificationCloud(
 	return {
 		path,
 		width: box + x * 2,
-		height: top + height + padY * 2 + bottom,
+		height: top + height + padY * 2 + bottom + trail,
 		content: { x: x + padX, y: y + padY, width, height },
+		// Measured from the crest and not from the valley when it rises, or the
+		// puffs would sit inside the wave.
+		trailEdge: below ? y - top + RIM : floor + RIM,
+		trailDirection: below ? -1 : 1,
 	};
+}
+
+/**
+ * The trail from the cloud's body to `targetX` — the card's own centre, in the
+ * geometry's pixel space.
+ *
+ * Separate from `notificationCloud` on purpose: the target is only known after
+ * the caller has clamped the cloud to its frame, and clamping needs the width
+ * that `notificationCloud` is what computes. Aiming rather than drifting is what
+ * makes the trail mean "this belongs to THAT card" — the puffs end over the card
+ * whether the cloud sits above it, beside it, or shoved sideways by the frame.
+ */
+export function notificationCloudPuffs(
+	cloud: NotificationCloudGeometry,
+	targetX: number,
+	compact: boolean,
+): NotificationCloudPuff[] {
+	const scale = trailScale(compact);
+	// Starts under the body's middle and walks to the target, so a cloud leaning
+	// off to one side gets a visibly diagonal trail and a centred one a straight
+	// one. Both point at the card; only the angle differs.
+	const from = cloud.width / 2;
+	return [
+		{ at: 0.45, dy: 8, rx: 13, ry: 8 },
+		{ at: 1, dy: 22, rx: 7.5, ry: 5.5 },
+	].map((puff) => ({
+		cx: from + (targetX - from) * puff.at,
+		cy: cloud.trailEdge + cloud.trailDirection * puff.dy * scale,
+		rx: puff.rx * scale,
+		ry: puff.ry * scale,
+	}));
 }

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -747,6 +747,14 @@
 	stroke-width: 1.5;
 	filter: drop-shadow(0 8px 22px rgb(0 0 0 / 0.28));
 }
+/* The trail shares the body's fill and stroke, so it reads as the same object
+   drifting off rather than two decorations that happen to sit nearby. */
+.traffic-notification-cloud-puff {
+	fill: rgb(var(--surface-overlay));
+	stroke: rgb(var(--cloud-tone) / 0.55);
+	stroke-width: 1.5;
+	paint-order: stroke fill;
+}
 .traffic-notification-cloud-body {
 	position: absolute;
 	display: flex;


### PR DESCRIPTION
The notification preview itself already landed on main through #1720, which carried it along with the Live-arrival delta. This PR is only the trail that ties it to its card.

Without it, a cloud hanging over a row of cards reads as belonging to the row. Two ellipses now leave the body's card-facing edge and end over the card that sent the notification.

The first cut drifted them by a fixed offset and was wrong on screen: with the cloud centred over its card the puffs fell into the gap between two neighbours and pointed at nothing. So they **aim** instead — the far puff lands on the card's own centre, computed from the cloud's clamped position, and the body leans aside by 30% of its width to give the diagonal somewhere to go. A card directly underneath still gets a straight trail; a cloud shoved sideways by the frame's edge still points at its card.

`notificationCloudPuffs()` is a second pure function rather than part of `notificationCloud()`, because the target is only known after clamping and clamping needs the width the first function computes.

Two ellipses, not the reference's three — the third buys height and no meaning at these sizes. The trail flips to the cloud's top edge when the card sits too close to the frame's top for the cloud to fit above it.

Size grows, deliberately: **183 × 55 → 183 × 76** compact, **273 × 92 → 273 × 121** at full detail. That is the price of the attribution.

Checked at 3840×2160, 1440×900 and 390×844 CSS viewports: two puffs each, inside the frame, no horizontal overflow, clean console.

`decisions/2026/09/11/notification-preview-cloud-on-sender-card.md` said "no puff trail" and is corrected in the same commit.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=fecb6132-cbf2-47fe-958d-9ab4f67650b8) · `dev3://task/fecb6132-cbf2-47fe-958d-9ab4f67650b8`
