### PR TITLE
Order agent-traffic cards by their board column

### DIFF
--- a/change-logs/2026/09/11/feature-traffic-kanban-card-order.md
+++ b/change-logs/2026/09/11/feature-traffic-kanban-card-order.md
@@ -1,0 +1,3 @@
+Short: Traffic cards ordered like the board
+
+Agent traffic's node stage now orders task cards by their own Kanban column instead of by seq alone: the column nearest the coordinator is the one the board puts first, so active work sits closest and Completed/Cancelled trail at the far end. To Do cards are left off the stage entirely — their wires go with them, while the message log and replay timeline keep every row — and during replay the column is read at the playback cursor so a task's current status no longer leaks into historical ordering.

--- a/decisions/2026/09/11/traffic-cards-follow-board-column-order.md
+++ b/decisions/2026/09/11/traffic-cards-follow-board-column-order.md
@@ -1,0 +1,72 @@
+# Agent traffic orders cards by board column, and drops silent To Do cards
+
+## Context
+
+Experiment 2 of Agent traffic (`TrafficNodes`) laid its task cards out by `seq`
+alone. On a busy board that reads as noise: a finished task from last week sits
+next to the coordinator while the task actually running is three rows down, and
+the backlog (To Do) fills the grid with cards that have never said anything.
+
+## Investigation
+
+The board already owns a column order: `getBoardColumns` in `src/shared/types.ts`
+merges every visible project's columns into one display order, honours a user's
+`columnOrder`, hides columns that do not apply, and keeps an occupied column
+standing. Nothing about a lifecycle needed inventing — the stage only had to read
+that order. The historical status at a replay cursor was also already solved, by
+`projectTaskAt` in `agent-traffic/task-history.ts`.
+
+## Decision
+
+`agent-traffic/kanban-order.ts` turns `getBoardColumns` into two answers about a
+node: `rank` (index of its column, so rank 0 is nearest the coordinator) and
+`todo` (its column at the cursor is the built-in To Do lane). `layoutTraffic`
+takes it as `options.board`, sorts by rank before `seq`, and filters To Do cards
+out of the scene. `TrafficNodes` builds it from its existing `projections` map, so
+the column is read at the playback cursor and the live status never leaks into
+historical ordering.
+
+To Do is hidden unconditionally — a message it exchanged does not buy it a card.
+That is not an oversight about dangling wires: an edge is only routed when BOTH
+endpoints have a position (`positions.get` in `layoutTraffic`), so a hidden
+endpoint takes its wire off the stage with it, and the message log and the replay
+timeline keep every row regardless. A conversing To Do card was allowed on stage
+in the first version of this change; it was removed as an unrequested exception.
+
+One deliberate carve-out:
+
+- **A card whose column cannot be resolved sorts after every column**: the user
+  marker (no task), a ghost the message log remembers but the board no longer
+  holds, and a task whose `movements` never recorded the cursor's instant. Rank is
+  `columns.length`. Guessing one of these into a lane would be a claim about
+  history that nothing supports, and it keeps the user marker exactly where it
+  already sat (last), so Seq1869's work on that marker is untouched.
+
+## Risks
+
+Card order now depends on the replay cursor, so scrubbing re-flows the grid where
+it previously only faded cards in. That was a documented invariant in
+`TrafficNodes` ("the layout must stay frozen while cards appear") and the comment
+is updated: appearing still never re-flows, ordering deliberately does. On a
+window with heavy status churn a scrub therefore animates card positions. The
+"keeps the layout still" expectation in `agent-traffic-ui.test.tsx` still holds
+because a card's rank does not change across its own creation step — the frozen
+box is guaranteed for an unchanged rank, not for every scrub.
+
+Hiding To Do applies to replay too, so a task that sat in the backlog at the
+cursor is absent from the reconstructed stage. That fixture in
+`agent-traffic-ui.test.tsx` was therefore born into Your Review instead of To Do;
+every case it covers (no future-status leak, forwards/backwards symmetry, an
+unknown past, a card withheld until its recorded creation) is unchanged and still
+asserted — only the status it starts from moved to one the stage draws.
+
+## Alternatives considered
+
+- **A hardcoded lifecycle array in the traffic module.** Rejected: it would
+  silently disagree with a user who reordered their board, and would need editing
+  every time a column is added.
+- **Order by live `task.status` even under replay.** Rejected outright — it is the
+  exact leak `task-history.ts` exists to prevent.
+- **Keep a conversing To Do card on stage** so its wire has an endpoint. Shipped
+  first, then removed: the ask was no To Do cards, full stop, and the wire concern
+  turned out to be unfounded — an unplaced endpoint drops its own edge.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1628,13 +1628,19 @@ describe("Replay reconstructs the board at the cursor", () => {
 	 * into the earlier part of the replay.
 	 *
 	 * The timeline that produces, oldest first:
-	 *   1 task  created        (-25)   task-b appears, To Do
-	 *   2 task  -> in-progress (-22)
-	 *   3 msg   to task-c      (-21)
-	 *   4 msg   First exchange (-20)
-	 *   5 task  -> completed   (-15)   ← a step with NO message anywhere near it
-	 *   6 msg   Second exchange(-10)
+	 *   1 task  created           (-25)   task-b appears, Your Review
+	 *   2 task  -> in-progress    (-22)
+	 *   3 msg   to task-c         (-21)
+	 *   4 msg   First exchange    (-20)
+	 *   5 task  -> completed      (-15)   ← a step with NO message anywhere near it
+	 *   6 msg   Second exchange   (-10)
 	 * task-c has no movements at all, so it contributes no steps and no history.
+	 *
+	 * task-b is deliberately born into Your Review rather than To Do: a To Do card
+	 * is not drawn at all (see `kanbanOrder`), so a fixture starting there could
+	 * assert nothing about the cursor. Every case below — no future-status leak,
+	 * forwards/backwards symmetry, an unknown past, and the card withheld until its
+	 * recorded creation — needs a status the stage actually draws.
 	 */
 	function setUpHistory() {
 		setPage([
@@ -1646,8 +1652,8 @@ describe("Replay reconstructs the board at the cursor", () => {
 			"task-b": {
 				status: "completed",
 				movements: [
-					{ id: "m1", at: ago(25), kind: "created", to: "todo", toColumnId: null },
-					{ id: "m2", at: ago(22), kind: "status", from: "todo", to: "in-progress", fromColumnId: null, toColumnId: null },
+					{ id: "m1", at: ago(25), kind: "created", to: "review-by-user", toColumnId: null },
+					{ id: "m2", at: ago(22), kind: "status", from: "review-by-user", to: "in-progress", fromColumnId: null, toColumnId: null },
 					{ id: "m3", at: ago(15), kind: "status", from: "in-progress", to: "completed", fromColumnId: null, toColumnId: null },
 				],
 			},
@@ -1720,7 +1726,7 @@ describe("Replay reconstructs the board at the cursor", () => {
 
 	it("never reads the current completed status back into the past", async () => {
 		await replayFromStart();
-		expect(card("#22").textContent).toContain("To Do");
+		expect(card("#22").textContent).toContain("Your Review");
 		await next();
 		expect(card("#22").textContent).toContain("Agent is Working");
 		expect(card("#22").textContent).not.toContain("Completed");

--- a/src/mainview/__tests__/kanban-order.test.ts
+++ b/src/mainview/__tests__/kanban-order.test.ts
@@ -1,0 +1,194 @@
+import type { AgentMessageLogRow } from "../../shared/agent-message-log";
+import type { BoardProject, Task, TaskMovement } from "../../shared/types";
+import { kanbanOrder } from "../components/agent-traffic/kanban-order";
+import { layoutTraffic } from "../components/agent-traffic/nodes-layout";
+import { projectTaskAt } from "../components/agent-traffic/task-history";
+import { trafficNodes, trafficRecords } from "../components/agent-traffic/traffic-model";
+
+const project: BoardProject = { id: "p", kind: "git" } as unknown as BoardProject;
+
+function task(id: string, seq: number, over: Partial<Task> = {}): Task {
+	return { id, projectId: "p", seq, title: id, status: "in-progress", taskType: null, ...over } as unknown as Task;
+}
+
+function row(from: string | null, to: string, over: Partial<AgentMessageLogRow> = {}): AgentMessageLogRow {
+	return {
+		v: 1,
+		at: "2026-09-07T10:00:00.000Z",
+		fromTaskId: from,
+		fromSeq: 1,
+		fromTitle: from ?? "",
+		toTaskId: to,
+		toSeq: 2,
+		toTitle: to,
+		toProjectId: "p",
+		kind: "immediate",
+		body: "hello",
+		bodyKind: "text",
+		status: "delivered",
+		...over,
+	} as AgentMessageLogRow;
+}
+
+const ms = (minute: number) => Date.parse(`2026-09-07T10:${String(minute).padStart(2, "0")}:00.000Z`);
+
+/** The stage as it opens, with the board order applied at `cursorAt`. */
+function stage(
+	tasks: Task[],
+	rows: AgentMessageLogRow[],
+	options: { cursorAt?: number | null; projects?: BoardProject[]; showQuiet?: boolean } = {},
+) {
+	const cursorAt = options.cursorAt ?? null;
+	const nodes = trafficNodes(tasks, rows);
+	const board = kanbanOrder(options.projects ?? [project], nodes, (node) => projectTaskAt(node.task, cursorAt));
+	return layoutTraffic(nodes, trafficRecords(rows), { board, showQuiet: options.showQuiet });
+}
+
+/** Card ids in reading order — the order the grid actually puts them in. */
+function reading(scene: ReturnType<typeof layoutTraffic>): string[] {
+	return [...scene.placed]
+		.sort((a, b) => a.y - b.y || a.x - b.x)
+		.map((placed) => placed.node.id);
+}
+
+describe("kanbanOrder", () => {
+	it("orders cards by their board column, terminal columns last", () => {
+		const tasks = [
+			task("done", 1, { status: "completed" }),
+			task("asking", 2, { status: "user-questions" }),
+			task("killed", 3, { status: "cancelled" }),
+			task("working", 4, { status: "in-progress" }),
+			task("mine", 5, { status: "review-by-user" }),
+		];
+		const scene = stage(tasks, tasks.map((t) => row("working", t.id)));
+		expect(reading(scene)).toEqual(["working", "asking", "mine", "done", "killed"]);
+	});
+
+	it("keeps the coordinator above the grid whatever column it sits in", () => {
+		const tasks = [
+			task("hub", 1, { status: "completed", taskType: "coordinator" }),
+			task("working", 2, { status: "in-progress" }),
+		];
+		const scene = stage(tasks, [row("hub", "working")]);
+		const hub = scene.placed.find((placed) => placed.hub);
+		expect(hub?.node.id).toBe("hub");
+		expect(scene.placed.find((p) => p.node.id === "working")!.y).toBeGreaterThan(hub!.y);
+	});
+
+	it("orders by seq inside one column", () => {
+		const tasks = [task("b", 22), task("a", 11), task("c", 33)];
+		const scene = stage(tasks, tasks.map((t) => row("a", t.id)));
+		expect(reading(scene)).toEqual(["a", "b", "c"]);
+	});
+
+	it("sorts a custom column where the board puts it", () => {
+		const projects: BoardProject[] = [
+			{ id: "p", kind: "git", customColumns: [{ id: "hold", name: "On hold" }] } as unknown as BoardProject,
+		];
+		const tasks = [
+			task("done", 1, { status: "completed" }),
+			task("held", 2, { status: "in-progress", customColumnId: "hold" }),
+			task("working", 3, { status: "in-progress" }),
+		];
+		const scene = stage(tasks, tasks.map((t) => row("working", t.id)), { projects });
+		expect(reading(scene)).toEqual(["working", "held", "done"]);
+	});
+
+	it("falls back to the status column when the custom column id is dangling", () => {
+		const tasks = [task("ghost", 1, { status: "in-progress", customColumnId: "gone" }), task("done", 2, { status: "completed" })];
+		const scene = stage(tasks, tasks.map((t) => row("ghost", t.id)));
+		expect(reading(scene)).toEqual(["ghost", "done"]);
+	});
+
+	it("sorts a card with no known column after every column", () => {
+		const tasks = [task("done", 1, { status: "completed" }), task("working", 2, { status: "in-progress" })];
+		// The sender is not on the board at all — the log remembers it, nothing else does.
+		const scene = stage(tasks, [row("stranger", "working"), row("working", "done")]);
+		expect(reading(scene)).toEqual(["working", "done", "stranger"]);
+	});
+});
+
+describe("layoutTraffic To Do eligibility", () => {
+	it("leaves To Do cards off the stage", () => {
+		const tasks = [
+			task("queued", 1, { status: "todo" }),
+			task("working", 2, { status: "in-progress" }),
+			task("mine", 3, { status: "review-by-user" }),
+		];
+		const scene = stage(tasks, [row("working", "mine")]);
+		expect(reading(scene)).toEqual(["working", "mine"]);
+	});
+
+	it("drops a To Do card that exchanged a message, and its wire with it", () => {
+		const tasks = [task("queued", 1, { status: "todo" }), task("working", 2, { status: "in-progress" })];
+		const scene = stage(tasks, [row("working", "queued")]);
+		expect(reading(scene)).toEqual(["working"]);
+		// The row stays in the log; the stage just has nowhere to draw it.
+		expect(scene.edges).toHaveLength(0);
+	});
+
+	it("never routes a wire to a card it dropped", () => {
+		const tasks = [
+			task("queued", 1, { status: "todo" }),
+			task("working", 2, { status: "in-progress" }),
+			task("mine", 3, { status: "review-by-user" }),
+		];
+		const scene = stage(tasks, [row("working", "mine"), row("working", "queued"), row("queued", "mine")]);
+		const drawn = new Set(scene.placed.map((placed) => placed.node.key));
+		for (const edge of scene.edges) {
+			expect(drawn.has(edge.from)).toBe(true);
+			expect(drawn.has(edge.to)).toBe(true);
+		}
+		expect(reading(scene)).toEqual(["working", "mine"]);
+	});
+
+	it("keeps every To Do card off a board whose window is silent", () => {
+		const tasks = [task("queued", 1, { status: "todo" }), task("working", 2, { status: "in-progress" })];
+		const scene = stage(tasks, []);
+		expect(reading(scene)).toEqual(["working"]);
+	});
+});
+
+describe("kanbanOrder under replay", () => {
+	const movements = (entries: [number, Task["status"]][]): TaskMovement[] =>
+		entries.map(([minute, to], index) => ({
+			at: new Date(ms(minute)).toISOString(),
+			kind: index === 0 ? "created" : "moved",
+			to,
+			from: index === 0 ? null : entries[index - 1][1],
+		})) as unknown as TaskMovement[];
+
+	const late = task("late", 1, {
+		status: "completed",
+		movements: movements([[0, "todo"], [10, "in-progress"], [50, "completed"]]),
+	});
+	const steady = task("steady", 2, {
+		status: "user-questions",
+		movements: movements([[0, "user-questions"]]),
+	});
+	const rows = [row("steady", "late")];
+
+	it("sorts a task by the column it was in at the cursor, not the one it is in now", () => {
+		// At 10:20 `late` was still in progress, so it leads; live it is completed and trails.
+		expect(reading(stage([late, steady], rows, { cursorAt: ms(20) }))).toEqual(["late", "steady"]);
+		expect(reading(stage([late, steady], rows, { cursorAt: null }))).toEqual(["steady", "late"]);
+	});
+
+	it("drops a card that was still in To Do at the cursor", () => {
+		const idle = task("idle", 3, {
+			status: "in-progress",
+			movements: movements([[0, "todo"], [40, "in-progress"]]),
+		});
+		const shown = (cursorAt: number) =>
+			reading(stage([late, steady, idle], rows, { cursorAt, showQuiet: true }));
+		expect(shown(ms(20))).not.toContain("idle");
+		expect(shown(ms(45))).toContain("idle");
+	});
+
+	it("keeps a card whose past was never recorded", () => {
+		const unrecorded = task("mystery", 9, { status: "todo", movements: [] });
+		// Live status says To Do, but nothing proves it was To Do then — so it stays.
+		expect(reading(stage([late, steady, unrecorded], rows, { cursorAt: ms(20), showQuiet: true })))
+			.toContain("mystery");
+	});
+});

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -7,7 +7,7 @@ import {
 	useState,
 	type CSSProperties,
 } from "react";
-import { getTaskOverview } from "../../../shared/types";
+import { getTaskOverview, type BoardProject } from "../../../shared/types";
 import { useT } from "../../i18n";
 import { getStatusLabel } from "../../utils/statusLabel";
 import {
@@ -16,6 +16,7 @@ import {
 } from "../../hooks/useStatusColors";
 import { useReducedMotion } from "../../utils/useReducedMotion";
 import PipelineRing from "../PipelineRing";
+import { kanbanOrder } from "./kanban-order";
 import {
 	layoutTraffic,
 	pointAt,
@@ -51,11 +52,11 @@ import TrafficMessageBubble from "./TrafficMessageBubble";
 import { IDENTITY_SCALE, MAX_SCALE, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
-	projects?: {
-		id: string;
+	/** Board columns come off these, so the stage orders cards the way the Kanban does. */
+	projects?: (BoardProject & {
 		name: string;
 		customStatusLabels?: Record<string, string>;
-	}[];
+	})[];
 	scope?: string;
 	nodes: TrafficNode[];
 	records: TrafficRecord[];
@@ -138,8 +139,10 @@ export default function TrafficNodes({
 	// The cursor is the ONLY input to the historical projection, and the projection
 	// is a pure function of it — which is what makes scrubbing backwards reverse the
 	// stage exactly, with no accumulated state to unwind. Deliberately NOT folded
-	// into `nodes` upstream: the layout must stay frozen while cards appear, so
-	// `scene` keeps depending on the full node set and only Card props move.
+	// into `nodes` upstream: `scene` keeps depending on the full node set, so a card
+	// appearing never re-flows the grid. Column ORDER does follow the cursor, via
+	// `board` below — a card completed after the replayed instant must not already
+	// be sorted with the finished ones.
 	const cursorAt = playback?.cursor.at ?? null;
 	const projections = useMemo(() => {
 		const result = new Map<string, TaskProjection>();
@@ -180,13 +183,21 @@ export default function TrafficNodes({
 						node.key,
 					))),
 	);
+	const board = useMemo(
+		() =>
+			kanbanOrder(projects ?? [], nodes, (node) =>
+				projections.get(node.key) ?? projectTaskAt(node.task, cursorAt),
+			),
+		[projects, nodes, projections, cursorAt],
+	);
 	const scene = useMemo(
 		() =>
 			layoutTraffic(nodes, layoutRecords, {
 				showQuiet,
 				showParked: showParked || replayParked,
+				board,
 			}),
-		[nodes, layoutRecords, showQuiet, showParked, replayParked],
+		[nodes, layoutRecords, showQuiet, showParked, replayParked, board],
 	);
 	const [view, setView] = useState<View>({ x: 0, y: 0, scale: 1 });
 	const viewRef = useRef(view);

--- a/src/mainview/components/agent-traffic/kanban-order.ts
+++ b/src/mainview/components/agent-traffic/kanban-order.ts
@@ -1,0 +1,71 @@
+/**
+ * Where a traffic card sits relative to the coordinator: its own board column.
+ *
+ * The order is the board's, not a second lifecycle invented here — `getBoardColumns`
+ * already merges every visible project's columns into one display order (custom
+ * columns included, hidden ones dropped), so a user who reorders their Kanban
+ * reorders the stage with it. Rank 0 is the column nearest the coordinator, so
+ * Completed and Cancelled land at the far end simply because that is where the
+ * board puts them.
+ *
+ * The status is read from the replay projection, never from `task.status` — at a
+ * cursor an hour back the live status is not what the card was.
+ */
+
+import { getBoardColumns, laneKey, type BoardProject, type TaskStatus } from "../../../shared/types";
+import type { TaskProjection } from "./task-history";
+import type { TrafficNode } from "./traffic-model";
+
+export interface KanbanOrder {
+	/** Lower sits closer to the coordinator. Cards with no known column sort last. */
+	rank(node: TrafficNode): number;
+	/** A To Do card at the cursor — board backlog, not conversation. */
+	todo(node: TrafficNode): boolean;
+}
+
+/**
+ * A card whose column cannot be resolved — the user marker, a ghost the message
+ * log remembers but the board no longer holds, a task whose past was never
+ * recorded — sorts after every column rather than being guessed into one: it has
+ * no position on the board, and the live status is not evidence about the cursor.
+ */
+export function kanbanOrder(
+	projects: BoardProject[],
+	nodes: TrafficNode[],
+	projection: (node: TrafficNode) => TaskProjection,
+): KanbanOrder {
+	// A column holding cards is never hidden, same rule the board itself applies.
+	const occupiedStatuses = new Set<TaskStatus>();
+	for (const node of nodes) {
+		const status = projection(node).status;
+		if (status) occupiedStatuses.add(status);
+	}
+	const columns = getBoardColumns(projects, { occupiedStatuses });
+	const rankByLane = new Map<string, number>();
+	const laneByCustom = new Map<string, string>();
+	columns.forEach((slot, index) => {
+		rankByLane.set(laneKey(slot), index);
+		if (slot.type === "custom")
+			for (const member of slot.members)
+				laneByCustom.set(`${member.projectId}::${member.columnId}`, laneKey(slot));
+	});
+	const unplaceable = columns.length;
+	const lanes = new Map<string, string | null>();
+	const laneOf = (node: TrafficNode): string | null => {
+		const cached = lanes.get(node.key);
+		if (cached !== undefined) return cached;
+		const { status, columnId } = projection(node);
+		// A dangling custom column id (its column was deleted) falls back to the
+		// underlying status, exactly as the board does.
+		const lane = (columnId ? laneByCustom.get(`${node.projectId}::${columnId}`) : undefined) ?? status ?? null;
+		lanes.set(node.key, lane);
+		return lane;
+	};
+	return {
+		rank: (node) => {
+			const lane = laneOf(node);
+			return (lane === null ? undefined : rankByLane.get(lane)) ?? unplaceable;
+		},
+		todo: (node) => laneOf(node) === "todo",
+	};
+}

--- a/src/mainview/components/agent-traffic/nodes-layout.ts
+++ b/src/mainview/components/agent-traffic/nodes-layout.ts
@@ -1,3 +1,4 @@
+import type { KanbanOrder } from "./kanban-order";
 import { createTrafficRouter } from "./nodes-routing";
 import { baseBus, laneGridLines, planLanes, type LanePlan } from "./wire-lanes";
 import { fromKey, toKey, type TrafficNode, type TrafficRecord } from "./traffic-model";
@@ -61,6 +62,11 @@ export interface SceneOptions {
 	showQuiet?: boolean;
 	/** Draw the hibernated band. Off by default. */
 	showParked?: boolean;
+	/**
+	 * Board column order, from [[kanbanOrder]]. Absent = plain seq order, which is
+	 * what a caller with no project list (and the layout's own unit tests) gets.
+	 */
+	board?: KanbanOrder;
 }
 
 interface PairState {
@@ -109,7 +115,12 @@ function pairs(records: TrafficRecord[]): Map<string, PairState> {
 /** Cards that go in the grid — not the user marker, not a coordinator. */
 const isWorker = (node: TrafficNode) => !node.user && node.task?.taskType !== "coordinator";
 
-/** Stable task ordering keeps replay and new message volume from moving cards. */
+/**
+ * Message volume never moves a card: the order is the board's column order (when
+ * `options.board` is given) and then seq, so a busy task cannot climb the stage.
+ * The board column is read at the replay cursor, so scrubbing back does move a
+ * card that has since been completed back to where it actually was.
+ */
 export function layoutTraffic(
 	nodes: TrafficNode[],
 	records: TrafficRecord[],
@@ -134,7 +145,14 @@ export function layoutTraffic(
 		}
 	}
 
-	const sorted = [...nodes].sort((a, b) =>
+	const board = options.board;
+	// To Do is board backlog, not conversation, so it never reaches the stage — a
+	// message it exchanged does not buy it a card. Its wires go with it: an edge
+	// needs BOTH endpoints placed, so nothing is left dangling. Hidden here only —
+	// the message log and the replay timeline keep every row either way.
+	const eligible = board ? nodes.filter(node => !board.todo(node)) : nodes;
+	const sorted = [...eligible].sort((a, b) =>
+		(board ? board.rank(a) - board.rank(b) : 0) ||
 		(a.seq ?? Number.MAX_SAFE_INTEGER) - (b.seq ?? Number.MAX_SAFE_INTEGER) ||
 		a.key.localeCompare(b.key),
 	);


### PR DESCRIPTION
Experiment 2 laid its cards out by `seq` alone, so a finished task sat next to the coordinator while the running one was rows away and the backlog filled half the grid.

Each card is now ranked by its own Kanban column, read off `getBoardColumns` — so a user who reorders their board reorders the stage, and Completed/Cancelled land at the far end because that is where the board puts them. Order inside a column is unchanged (`seq`).

To Do cards never reach the stage at all: a task is interesting from the moment it goes into work until it ends in Completed or Cancelled. An edge is only routed when both endpoints have a position, so a hidden card takes its wire with it and nothing is left dangling; the message log and the replay timeline keep every row either way.

The column is read at the replay cursor via `projectTaskAt`, so a task's current status no longer leaks into historical ordering, and an unrecorded past is never treated as To Do. A card whose column cannot be resolved — the user marker, a ghost the log remembers but the board no longer holds, a task with no recorded movements — sorts after every column rather than being guessed into one.

Coordinator and user-marker geometry from #1713 is untouched.

The replay fixture in `agent-traffic-ui.test.tsx` is now born into Your Review instead of To Do, because a To Do card is not drawn: every case it covers — no future-status leak, forwards/backwards symmetry, an unknown past, and a card withheld until its recorded creation — is unchanged and still asserted.

Card order now follows the replay cursor, so scrubbing can re-flow the grid where it previously only faded cards in. That trade-off and the rest of the rationale are in `decisions/2026/09/11/traffic-cards-follow-board-column-order.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b91da7d4-8c5b-4bf5-8561-18bb2a885579) · `dev3://task/b91da7d4-8c5b-4bf5-8561-18bb2a885579` _(dev3 added this footer — turn it off in Settings → Tasks.)_
