### PR TITLE
Preview a live notification arrival over the card that sent it

### DIFF
--- a/change-logs/2026/09/11/feature-live-notification-preview.md
+++ b/change-logs/2026/09/11/feature-live-notification-preview.md
@@ -1,0 +1,3 @@
+Short: Notifications preview in Live too
+
+A `dev3 notify` that fires while Agent traffic is following live now previews over the card that sent it, the same cloud the replay cursor already drew, and clears itself a few seconds later. Opening the screen on a full archive stays silent — only a genuinely fresh arrival is shown.

--- a/change-logs/2026/09/11/feature-notification-preview-on-traffic-stage.md
+++ b/change-logs/2026/09/11/feature-notification-preview-on-traffic-stage.md
@@ -1,0 +1,3 @@
+Short: Notify previews on the traffic stage
+
+Agent traffic now previews an archived `dev3 notify` over the card that sent it while the replay cursor stands on it — the text, plus its level as a word and a colour, in a cloud outline of its own so it never reads as one more message between two cards. A notification the archive recorded no sender for shows nothing on the stage and stays in the inspector list, which can say so in words.

--- a/decisions/2026/09/11/live-notification-preview-has-its-own-arrival-path.md
+++ b/decisions/2026/09/11/live-notification-preview-has-its-own-arrival-path.md
@@ -1,0 +1,54 @@
+# The live notification preview needs its own arrival path, not a cursor
+
+## Context
+
+`decisions/2026/09/11/notification-preview-cloud-on-sender-card.md` added the cloud that
+previews an archived notification over the card that sent it. It reads `playback.current`,
+which only ever names an event while a replay cursor is standing on one. In Live Follow
+`useTrafficPlayback` keeps `index === -1` and `current === null`, so a notification arriving
+while the user watches the stage showed nothing at all.
+
+## Investigation
+
+Messages already have a second, live-only arm that has nothing to do with the cursor: an
+effect diffs `layoutRecords`, launches a flight for any record younger than 10 s while not
+replaying, and lets the flight resolve the bubble. There is no cursor involved, and that is
+what makes it work in Live. The notification arm had no equivalent.
+
+## Decision
+
+Mirror that effect for notifications in `TrafficNodes.tsx`: diff `playback.events` filtered
+to `kind === "notification"` against a seen-set held in a ref, take the newest arrival that
+is both unseen and younger than `LIVE_NOTIFICATION_FRESH_MS` (10 s), hold it in
+`liveNotification`, and clear it after `LIVE_NOTIFICATION_MS` (6 s). `activeNotification`
+now reads the cursor while replaying and `liveNotification` otherwise, so replay behaviour is
+unchanged.
+
+Three things are deliberately silent, and all three fall out of the same two guards. The
+first pass only seeds the seen-set, so opening the screen on a full archive previews nothing.
+The set keeps seeding while replaying, so returning to Live does not replay what fired
+meanwhile. The freshness window covers a refetch that re-delivers old rows and a reconnect
+backlog, neither of which is a new arrival in time.
+
+No camera work, no placement engine, no new controls: an arrival from an off-frame or
+unrecorded sender still shows nothing, exactly as in replay.
+
+## Risks
+
+Two lifetimes now exist side by side — the cloud's 6 s and the message flight's 2.4 s — so a
+notification can outlive the bubble of the message that caused it. That is preferred to
+matching them: a notification is read as text and needs longer than a travelling dot.
+
+A rapid burst collapses to one preview: each arrival replaces the previous one and restarts
+the timer, the same single-slot rule the completion celebration already uses. A queue would
+walk the stage through a backlog long after the moment.
+
+## Alternatives considered
+
+Moving the live cursor onto arrivals — rejected: `index` is the replay cursor, and driving it
+from Live would make the scrubber, the projections and the visible-message cut-off all move
+on their own.
+
+Pushing the arrival straight from `rpc:notificationLogChanged` — rejected: the event carries
+no row, and reading the archive a second time beside the store would bypass both the project
+privacy scoping and the kind filters that `playback.events` has already applied.

--- a/decisions/2026/09/11/notification-preview-cloud-on-sender-card.md
+++ b/decisions/2026/09/11/notification-preview-cloud-on-sender-card.md
@@ -1,0 +1,62 @@
+# The notification preview is a bezier cloud over the sender's card
+
+## Context
+
+Notifications became the third arm of the replay timeline
+(`decisions/2026/09/10/notification-arm-on-the-replay-timeline.md`) but only
+appeared in the inspector list. Standing on a notification, the stage showed
+nothing — the reader had to look away from the cards to find out what had just
+been said. An earlier attempt at a stage preview was rejected for being far too
+large for the card it hangs over.
+
+## Investigation
+
+Six silhouettes were drawn to scale side by side and measured (Seq 1825; the
+reference artifact is preserved outside the repo). What the measurement settled:
+a union of circles degenerates into a ridged bar exactly where the preview is
+smallest, because the lobe radius is capped by the height budget above one line
+of text. A cubic-bezier wave has no repeated primitive to read as scalloping and
+its amplitude is independent of any corner radius, so it still undulates at a
+50px total height. The user picked that variant.
+
+## Decision
+
+`notificationCloud()`
+(`src/mainview/components/agent-traffic/notification-cloud.ts`) returns one
+closed path plus where the content sits inside it — geometry only, no React and
+no colour. `TrafficNotificationCloud` measures its own text and draws the outline
+at exact pixel size (a 1:1 viewBox, never a stretched one, or the corner arcs
+distort). `TrafficNodes` renders it while the playback cursor stands on a
+notification.
+
+Three rulings:
+
+1. **It hangs over the SENDER, never the target.** The archive's `origin` is the
+   only card that actually did something. With no sender recorded, the stage
+   shows nothing at all rather than borrowing a nearby card — the list already
+   says "sender not recorded" in words, and the stage cannot.
+2. **The level is a word as well as a colour.** `success` / `info` / `error` is
+   the whole point of a preview, and colour alone does not survive a colour-blind
+   reader or a screenshot. It reuses the inspector's existing
+   `traffic.notification.level.*` keys, so this shipped with no new strings.
+3. **No puff trail and no camera motion.** The trail in the reference cost real
+   height for decoration; the anchor over the card already says which card sent
+   it. An off-frame sender gets no preview, and the stage never pans on its own
+   to bring one back.
+
+## Risks
+
+The message bubble is not cleared when a notification becomes current, so a
+lingering bubble and a fresh cloud can be on screen together — consistent with
+the existing "the lit wire stays lit on a non-message step" rule, and they are
+told apart by shape and tone. In `happy-dom` the text measures 0, so the
+component falls back to its initial box: the geometry is unit-tested separately
+and the rendered size is covered only in the browser.
+
+## Alternatives considered
+
+Reusing `TrafficMessageBubble` with a different tone: rejected, a notification is
+not an exchange between two cards and a rectangle with a tail says it is.
+Anchoring on the target card: rejected, it reads as the target having said
+something. Scaling one cloud with `preserveAspectRatio="none"`: rejected, it
+distorts the corner arcs at every aspect ratio the text produces.

--- a/src/mainview/__tests__/traffic-notification-cloud.test.tsx
+++ b/src/mainview/__tests__/traffic-notification-cloud.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentMessageLogRow } from "../../shared/agent-message-log";
 import type { NotificationLogRow } from "../../shared/notification-log";
 import type { Task, TaskMovement, TaskStatus } from "../../shared/types";
@@ -187,6 +187,76 @@ describe("the notification preview on the traffic stage", () => {
 
 	it("shows nothing while the cursor is on a message rather than a notification", () => {
 		render(draw(playbackStub(null)));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+});
+
+/** Live: the cursor stands nowhere, so `index` is -1 and `current` is null. */
+function livePlayback(events: TrafficTimelineEvent[]): ReturnType<typeof useTrafficPlayback> {
+	return {
+		...playbackStub(null),
+		events,
+		index: -1,
+		cursor: { at: null, index: -1, total: events.length, playing: false, kind: null },
+	} as unknown as ReturnType<typeof useTrafficPlayback>;
+}
+
+/** An arrival stamped against the real clock, which is what freshness is measured on. */
+function arrival(msAgo: number, over: Partial<NotificationLogRow> = {}): TrafficTimelineEvent {
+	return notificationEvent({ at: new Date(Date.now() - msAgo).toISOString(), ...over });
+}
+
+describe("the notification preview in Live Follow", () => {
+	afterEach(() => vi.useRealTimers());
+
+	it("previews a notification that arrives while Live is running", () => {
+		const { rerender } = render(draw(livePlayback([])));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+
+		rerender(draw(livePlayback([arrival(200)])));
+		const cloud = screen.getByTestId("traffic-notification-cloud");
+		expect(cloud.dataset.level).toBe("success");
+		expect(cloud.textContent).toContain("backfill finished, 4812 rows written");
+	});
+
+	it("stays silent on the first archive read, however much it carries", () => {
+		render(
+			draw(
+				livePlayback([
+					arrival(400, { message: "one" }),
+					arrival(300, { message: "two" }),
+					arrival(200, { message: "three" }),
+				]),
+			),
+		);
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+
+	it("stays silent for a row that is merely new to this reader, not new in time", () => {
+		const { rerender } = render(draw(livePlayback([])));
+		rerender(draw(livePlayback([arrival(60_000)])));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+
+	it("takes the preview back down after its bounded lifetime", () => {
+		vi.useFakeTimers();
+		const { rerender } = render(draw(livePlayback([])));
+		rerender(draw(livePlayback([arrival(200)])));
+		expect(screen.getByTestId("traffic-notification-cloud")).toBeTruthy();
+
+		act(() => void vi.advanceTimersByTime(6100));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+
+	it("does not re-preview a notification the archive hands back unchanged", () => {
+		vi.useFakeTimers();
+		const events = [arrival(200)];
+		const { rerender } = render(draw(livePlayback([])));
+		rerender(draw(livePlayback(events)));
+		act(() => void vi.advanceTimersByTime(6100));
+
+		// A refetch returning the same row: a different array, the same key.
+		rerender(draw(livePlayback([...events])));
 		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
 	});
 });

--- a/src/mainview/__tests__/traffic-notification-cloud.test.tsx
+++ b/src/mainview/__tests__/traffic-notification-cloud.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentMessageLogRow } from "../../shared/agent-message-log";
+import type { NotificationLogRow } from "../../shared/notification-log";
+import type { Task, TaskMovement, TaskStatus } from "../../shared/types";
+import { I18nProvider } from "../i18n";
+import { notificationEvents } from "../notification-event";
+import TrafficNodes from "../components/agent-traffic/TrafficNodes";
+import { notificationCloud } from "../components/agent-traffic/notification-cloud";
+import {
+	endpointKey,
+	trafficRecords,
+	type TrafficNode,
+} from "../components/agent-traffic/traffic-model";
+import type { TrafficTimelineEvent } from "../components/agent-traffic/traffic-timeline";
+import type { useTrafficPlayback } from "../components/agent-traffic/useTrafficPlayback";
+
+const NOW = Date.parse("2026-09-11T12:00:00.000Z");
+const at = (minutes: number) => new Date(NOW + minutes * 60_000).toISOString();
+
+function movement(id: string, minutes: number, to: TaskStatus, kind: TaskMovement["kind"] = "status"): TaskMovement {
+	return { id, at: at(minutes), kind, to };
+}
+
+function task(id: string, seq: number): Task {
+	return {
+		id,
+		projectId: "project",
+		seq,
+		title: `Task ${seq}`,
+		status: "in-progress",
+		movements: [movement(`${id}-0`, -90, "todo", "created"), movement(`${id}-1`, -60, "in-progress")],
+	} as unknown as Task;
+}
+
+function node(value: Task): TrafficNode {
+	return {
+		key: endpointKey(value.projectId, value.id),
+		projectId: value.projectId,
+		id: value.id,
+		seq: value.seq,
+		title: `Task ${value.seq}`,
+		task: value,
+	};
+}
+
+const message: AgentMessageLogRow = {
+	v: 1,
+	at: at(-5),
+	fromTaskId: "task-a",
+	fromSeq: 1,
+	fromProjectId: "project",
+	toTaskId: "task-b",
+	toSeq: 2,
+	toProjectId: "project",
+	kind: "immediate",
+	subject: "ping",
+	body: "ping",
+	bodyKind: "text",
+	status: "delivered",
+} as AgentMessageLogRow;
+const records = trafficRecords([message]);
+
+function notificationRow(over: Partial<NotificationLogRow> = {}): NotificationLogRow {
+	return {
+		v: 1,
+		at: at(0),
+		mode: "toast",
+		level: "success",
+		message: "backfill finished, 4812 rows written",
+		taskId: "task-b",
+		taskSeq: 2,
+		projectId: "project",
+		sourceProjectId: "project",
+		sourceTaskId: "task-a",
+		sourceSeq: 1,
+		outcome: "delivered",
+		...over,
+	} as NotificationLogRow;
+}
+
+/** The notification arm of the timeline, as the playback cursor hands it over. */
+function notificationEvent(over: Partial<NotificationLogRow> = {}): TrafficTimelineEvent {
+	const [event] = notificationEvents([notificationRow(over)]);
+	return { kind: "notification", at: event.at, key: event.key, notification: event };
+}
+
+function playbackStub(current: TrafficTimelineEvent | null): ReturnType<typeof useTrafficPlayback> {
+	return {
+		events: current ? [current] : [],
+		current,
+		currentRecord: null,
+		cursor: { at: current?.at ?? null, index: 0, total: 1, playing: false, kind: current?.kind ?? null },
+		index: 0,
+		playing: false,
+		ended: false,
+		speed: 1,
+		intervalMs: 1000,
+		revision: 1,
+		setSpeed: vi.fn(),
+		playPause: vi.fn(),
+		restart: vi.fn(),
+		step: vi.fn(),
+		seek: vi.fn(),
+		seekToTime: vi.fn(),
+		live: vi.fn(),
+	} as unknown as ReturnType<typeof useTrafficPlayback>;
+}
+
+function draw(playback?: ReturnType<typeof useTrafficPlayback>) {
+	return (
+		<I18nProvider>
+			<TrafficNodes
+				nodes={[node(task("task-a", 1)), node(task("task-b", 2))]}
+				records={records}
+				layoutRecords={records}
+				selected={null}
+				onSelect={vi.fn()}
+				paused={false}
+				ready
+				scope="project"
+				playback={playback}
+			/>
+		</I18nProvider>
+	);
+}
+
+describe("the notification cloud outline", () => {
+	it("is a single closed outline, never a union of circles", () => {
+		const { path } = notificationCloud(220, 34, false);
+		// One `M` and one `Z`: a second subpath would be a lobe, and a lobe is the
+		// repeated primitive this shape exists to avoid.
+		expect(path.match(/M/g)).toHaveLength(1);
+		expect(path.match(/Z/g)).toHaveLength(1);
+		expect(path).toContain("C");
+		expect(path).not.toContain("NaN");
+	});
+
+	it("insets the content past the corner arc, not merely inside the drawn box", () => {
+		const cloud = notificationCloud(220, 34, false);
+		const rightGap = cloud.width - (cloud.content.x + cloud.content.width);
+		// Flush against the outline the text pokes through the wave and the corner —
+		// seen in the browser before the padding existed. The gap has to clear the
+		// corner radius, not just the stroke.
+		expect(cloud.content.x).toBeGreaterThan(6);
+		expect(rightGap).toBeGreaterThan(6);
+		expect(cloud.content.y).toBeGreaterThan(0);
+		expect(cloud.content.y + cloud.content.height).toBeLessThan(cloud.height);
+	});
+
+	it("spends less height on the wave when compact, for the same text", () => {
+		const full = notificationCloud(220, 34, false);
+		const compact = notificationCloud(220, 34, true);
+		expect(compact.height).toBeLessThan(full.height);
+		// The wave survives the shrink rather than flattening into a rounded box.
+		expect(compact.path).toContain("C");
+	});
+
+	it("survives a box narrower than its own corners without a negative step", () => {
+		const { path } = notificationCloud(6, 14, true);
+		expect(path).not.toContain("NaN");
+		expect(path.match(/M/g)).toHaveLength(1);
+	});
+});
+
+describe("the notification preview on the traffic stage", () => {
+	it("previews the text and its level over the card that sent it", () => {
+		render(draw(playbackStub(notificationEvent())));
+		const cloud = screen.getByTestId("traffic-notification-cloud");
+		expect(cloud.dataset.level).toBe("success");
+		expect(cloud.textContent).toContain("backfill finished, 4812 rows written");
+		expect(cloud.textContent).toContain("success");
+	});
+
+	it("marks an error apart from an info, in words and not only in colour", () => {
+		const { rerender } = render(draw(playbackStub(notificationEvent({ level: "error" }))));
+		expect(screen.getByTestId("traffic-notification-cloud").textContent).toContain("error");
+
+		rerender(draw(playbackStub(notificationEvent({ level: "info" }))));
+		expect(screen.getByTestId("traffic-notification-cloud").textContent).toContain("info");
+	});
+
+	it("shows nothing on the stage when the archive recorded no sender", () => {
+		render(draw(playbackStub(notificationEvent({ sourceTaskId: null }))));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+
+	it("shows nothing while the cursor is on a message rather than a notification", () => {
+		render(draw(playbackStub(null)));
+		expect(screen.queryByTestId("traffic-notification-cloud")).toBeNull();
+	});
+});

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -44,6 +44,7 @@ import {
 	type TrafficRecord,
 } from "./traffic-model";
 import type { TrafficTimelineEvent } from "./traffic-timeline";
+import type { TrafficNotificationEvent } from "../../notification-event";
 import type { useTrafficPlayback } from "./useTrafficPlayback";
 import TrafficIcon from "./TrafficIcon";
 import TrafficMinimap from "./TrafficMinimap";
@@ -99,6 +100,11 @@ const DROP_MS = 1200;
 const DROP_GAP_MS = 500;
 const DROP_FADE_MS = 200;
 const FOLLOW_IDLE_MS = 3500;
+/** A live notification is only previewed while it is genuinely fresh, and only for
+ *  a bounded moment — same freshness window a live message flight already uses, so
+ *  a refetch, a reconnect backlog or the first archive read stay silent. */
+const LIVE_NOTIFICATION_FRESH_MS = 10000;
+const LIVE_NOTIFICATION_MS = 6000;
 const MIN_SCALE = 0.14;
 
 /** Latest message on the timeline, for the camera and the wire that only speak messages. */
@@ -200,6 +206,9 @@ export default function TrafficNodes({
 	const camera = useRef<number>(0);
 	const overviewMode = useRef(true);
 	const known = useRef<Set<string> | null>(null);
+	const knownNotifications = useRef<Set<string> | null>(null);
+	const [liveNotification, setLiveNotification] =
+		useState<TrafficNotificationEvent | null>(null);
 	const edgeByKey = useMemo(
 		() => new Map(scene.edges.map((edge) => [edge.key, edge])),
 		[scene.edges],
@@ -582,6 +591,39 @@ export default function TrafficNodes({
 		}
 		known.current = current;
 	}, [layoutRecords, ready, paused, replaying, follow]);
+	// Live. The replay cursor never moves in Live, so the cloud needs its own arrival
+	// path — the same shape the message flight above already has. The first pass only
+	// seeds the seen-set, so opening the screen on an archive full of notifications is
+	// silent; it keeps seeding while replaying, or returning to Live would show every
+	// notification that fired meanwhile. The freshness window is what makes a refetch
+	// that re-delivers old rows, and a reconnect backlog, silent too.
+	useEffect(() => {
+		if (!ready) return;
+		const seen = new Set<string>();
+		let newest: TrafficNotificationEvent | undefined;
+		const first = !knownNotifications.current;
+		for (const event of playback?.events ?? []) {
+			if (event.kind !== "notification") continue;
+			seen.add(event.key);
+			if (
+				!first &&
+				!knownNotifications.current!.has(event.key) &&
+				Date.now() - event.at < LIVE_NOTIFICATION_FRESH_MS &&
+				(!newest || event.at > newest.at)
+			)
+				newest = event.notification;
+		}
+		knownNotifications.current = seen;
+		if (newest && !replaying && !paused) setLiveNotification(newest);
+	}, [playback?.events, ready, replaying, paused]);
+	useEffect(() => {
+		if (!liveNotification) return;
+		const timer = setTimeout(
+			() => setLiveNotification(null),
+			LIVE_NOTIFICATION_MS,
+		);
+		return () => clearTimeout(timer);
+	}, [liveNotification]);
 	useEffect(() => {
 		if (!flights.length) return;
 		let raf = 0;
@@ -641,10 +683,14 @@ export default function TrafficNodes({
 	// when the archive recorded no sender. An unattributed notification stays in
 	// the inspector list, where it can say so in words; inventing a sender on the
 	// stage is the one thing the archive exists not to do.
-	const activeNotification =
-		!playback?.ended && playback?.current?.kind === "notification"
+	// In Live the cursor stands nowhere, so the preview comes from the arrival the
+	// effect above caught instead. Replay keeps deciding alone: a replay step that is
+	// not a notification shows nothing, exactly as before.
+	const activeNotification = replaying
+		? !playback?.ended && playback?.current?.kind === "notification"
 			? playback.current.notification
-			: undefined;
+			: undefined
+		: (liveNotification ?? undefined);
 	const notificationSender = activeNotification?.origin
 		? nodeByKey.get(
 				endpointKey(

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -48,6 +48,7 @@ import type { useTrafficPlayback } from "./useTrafficPlayback";
 import TrafficIcon from "./TrafficIcon";
 import TrafficMinimap from "./TrafficMinimap";
 import TrafficMessageBubble from "./TrafficMessageBubble";
+import TrafficNotificationCloud from "./TrafficNotificationCloud";
 import { IDENTITY_SCALE, MAX_SCALE, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
@@ -635,6 +636,23 @@ export default function TrafficNodes({
 			? edgeByKey.get([activeFrom, activeTo].sort().join("|"))
 			: undefined;
 	const activeRecipient = activeTo ? nodeByKey.get(activeTo) : undefined;
+	// The notification the cursor is standing on, previewed over the card that SENT
+	// it — never over the card it was about, and never over a neighbouring card
+	// when the archive recorded no sender. An unattributed notification stays in
+	// the inspector list, where it can say so in words; inventing a sender on the
+	// stage is the one thing the archive exists not to do.
+	const activeNotification =
+		!playback?.ended && playback?.current?.kind === "notification"
+			? playback.current.notification
+			: undefined;
+	const notificationSender = activeNotification?.origin
+		? nodeByKey.get(
+				endpointKey(
+					activeNotification.origin.projectId,
+					activeNotification.origin.taskId,
+				),
+			)
+		: undefined;
 	const labelPoint = activeEdge ? pointAt(activeEdge.points, 0.5) : activeRecipient ?
 		{ x: activeRecipient.x + activeRecipient.width / 2, y: activeRecipient.y } : undefined;
 	const detail = detailTier(view.scale);
@@ -875,6 +893,22 @@ export default function TrafficNodes({
 					width={frame.current?.clientWidth ?? 1000}
 					height={frame.current?.clientHeight ?? 500}
 					failed={active.row.status === "not-delivered"}
+				/>
+			)}
+			{activeNotification && notificationSender && (
+				<TrafficNotificationCloud
+					key={activeNotification.key}
+					message={activeNotification.row.message}
+					level={activeNotification.level}
+					anchor={{
+						x:
+							view.x +
+							(notificationSender.x + notificationSender.width / 2) * view.scale,
+						y: view.y + notificationSender.y * view.scale,
+					}}
+					width={frame.current?.clientWidth ?? 1000}
+					height={frame.current?.clientHeight ?? 500}
+					compact={detail !== "full"}
 				/>
 			)}
 			{!scene.placed.length && (

--- a/src/mainview/components/agent-traffic/TrafficNotificationCloud.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNotificationCloud.tsx
@@ -1,0 +1,100 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { NotificationLogLevel } from "../../../shared/notification-log";
+import { useT } from "../../i18n";
+import { notificationCloud } from "./notification-cloud";
+
+/**
+ * What `dev3 notify` said, previewed over the card that sent it.
+ *
+ * Deliberately not the message bubble: a notification is not an exchange between
+ * two cards, so it gets its own silhouette and its own tone. The level is carried
+ * by a word as well as by colour — the three levels are the whole point of the
+ * preview, and colour alone does not survive a colour-blind reader or a
+ * screenshot.
+ *
+ * The full text stays in the inspector list. This is a preview: two lines, then
+ * an ellipsis.
+ */
+export default function TrafficNotificationCloud({
+	message,
+	level,
+	anchor,
+	width,
+	height,
+	compact,
+}: {
+	message: string;
+	level: NotificationLogLevel;
+	/** Top centre of the sending card, in frame coordinates. */
+	anchor: { x: number; y: number };
+	/** The frame's own size, for clamping and for hiding an off-frame sender. */
+	width: number;
+	height: number;
+	/** Zoomed far enough out that a full-size cloud would swamp its card. */
+	compact: boolean;
+}) {
+	const t = useT();
+	const ref = useRef<HTMLDivElement>(null);
+	// A first guess, replaced on the first layout pass. It only has to be close
+	// enough that the very first paint is not wildly mis-clamped.
+	const [box, setBox] = useState({ width: 180, height: 34 });
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+		const measure = () => {
+			if (element.offsetWidth && element.offsetHeight)
+				setBox({ width: element.offsetWidth, height: element.offsetHeight });
+		};
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [message, compact]);
+	const cloud = notificationCloud(box.width, box.height, compact);
+	// Above the card by default, below it when the card sits too close to the top
+	// edge for the cloud to fit — the same rule the message bubble follows.
+	const below = anchor.y < cloud.height + 16;
+	const left = Math.max(
+		cloud.width / 2 + 8,
+		Math.min(width - cloud.width / 2 - 8, anchor.x),
+	);
+	const top = anchor.y + (below ? 14 : -10);
+	// An off-frame sender gets no preview at all rather than a cloud pinned to the
+	// edge pointing at nothing: the stage never moves on its own to bring it back.
+	const offFrame =
+		anchor.x < 0 || anchor.x > width || anchor.y < 0 || anchor.y > height;
+	return (
+		<div
+			className={`traffic-notification-cloud level-${level} ${compact ? "is-compact" : ""} ${below ? "is-below" : ""}`}
+			data-testid="traffic-notification-cloud"
+			data-level={level}
+			style={{
+				left,
+				top,
+				width: cloud.width,
+				height: cloud.height,
+				visibility: offFrame ? "hidden" : undefined,
+			}}
+		>
+			<svg
+				className="traffic-notification-cloud-outline"
+				width={cloud.width}
+				height={cloud.height}
+				viewBox={`0 0 ${cloud.width} ${cloud.height}`}
+				aria-hidden="true"
+			>
+				<path d={cloud.path} />
+			</svg>
+			<div
+				ref={ref}
+				className="traffic-notification-cloud-body"
+				style={{ left: cloud.content.x, top: cloud.content.y }}
+			>
+				<span className="traffic-notification-cloud-level">
+					{t(`traffic.notification.level.${level}`)}
+				</span>
+				<strong className="streamer-private">{message}</strong>
+			</div>
+		</div>
+	);
+}

--- a/src/mainview/components/agent-traffic/notification-cloud.ts
+++ b/src/mainview/components/agent-traffic/notification-cloud.ts
@@ -1,0 +1,93 @@
+/**
+ * The outline of a notification preview, as one closed path.
+ *
+ * Geometry only: no colour, no text, no React. The shape is a single cubic-bezier
+ * wave over a rounded box — deliberately NOT a union of circles. A row of equal
+ * circles reads as machined scalloping the shorter it gets, and the preview is at
+ * its shortest exactly where it matters (a one-line message on a zoomed-out
+ * stage). A wave has no repeated primitive, and its amplitude is independent of
+ * any corner radius, so a 50px-high preview still undulates.
+ *
+ * Chosen from six candidates measured side by side; the reference lives outside
+ * the repo (Seq 1825, `silhouette-reference/`).
+ */
+
+/** Stroke allowance, so the outline is not clipped by its own SVG box. */
+const RIM = 1.5;
+
+/**
+ * A fixed wave, never `Math.random`.
+ *
+ * The outline must be byte-identical on every repaint — a random one would redraw
+ * a different cloud on a theme flip or a re-measure. Two different sequences
+ * because a compact preview fits three crests where a full one fits four.
+ */
+const AMPLITUDES = {
+	compact: [1, 0.6, 0.88],
+	full: [0.94, 0.58, 1, 0.7],
+} as const;
+
+export interface NotificationCloudGeometry {
+	/** One closed path in the geometry's own pixel space. Never a second subpath. */
+	path: string;
+	/** Total drawn size, rim included. */
+	width: number;
+	height: number;
+	/** Where the caller's content sits inside the outline. */
+	content: { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * The outline around a content box of `width` × `height` pixels.
+ *
+ * `compact` halves the wave and the corner radius rather than scaling the whole
+ * shape: the height budget above a line of text is the entire problem here, and
+ * a uniformly scaled cloud spends it on padding instead of on the wave.
+ */
+export function notificationCloud(
+	width: number,
+	height: number,
+	compact: boolean,
+): NotificationCloudGeometry {
+	const amplitude = compact ? 14 : 28;
+	const radius = compact ? 9 : 16;
+	// Padding INSIDE the outline, not around it. The wave's valley line and the
+	// corner arcs are the box's own edges, so content laid out flush against them
+	// reads as poking through the silhouette — measured in the browser, not
+	// guessed. Horizontally it clears the corner arc; vertically it only has to
+	// clear the line itself.
+	const padX = radius * 0.55;
+	const padY = 3;
+	const box = width + padX * 2;
+	const top = amplitude + RIM + 1;
+	const bottom = (compact ? 4 : 8) + RIM;
+	// The wave never leaves the outline box sideways, so the sides need only the rim.
+	const x = RIM + 1;
+	const y = top;
+	const amps = compact ? AMPLITUDES.compact : AMPLITUDES.full;
+	// A crest cannot start inside a corner arc, so the wave spans the box minus
+	// both radii — and a preview narrower than that gets one flat-ish crest rather
+	// than a negative step.
+	const step = Math.max(0, box - radius * 2) / amps.length;
+	let path = `M${x},${y + radius}A${radius},${radius} 0 0,1 ${x + radius},${y}`;
+	let at = x + radius;
+	amps.forEach((ratio, index) => {
+		const to = index === amps.length - 1 ? x + box - radius : at + step;
+		const crest = y - amplitude * ratio;
+		path += `C${at + (to - at) * 0.26},${crest} ${at + (to - at) * 0.74},${crest} ${to},${y}`;
+		at = to;
+	});
+	const floor = y + height + padY * 2;
+	path +=
+		`A${radius},${radius} 0 0,1 ${x + box},${y + radius}` +
+		`V${floor - radius}` +
+		`A${radius},${radius} 0 0,1 ${x + box - radius},${floor}` +
+		`H${x + radius}` +
+		`A${radius},${radius} 0 0,1 ${x},${floor - radius}Z`;
+	return {
+		path,
+		width: box + x * 2,
+		height: top + height + padY * 2 + bottom,
+		content: { x: x + padX, y: y + padY, width, height },
+	};
+}

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -653,6 +653,65 @@
 	top: -22px;
 	transform: scaleY(-1);
 }
+/* The `dev3 notify` preview over the card that sent it. Its own silhouette, so a
+   notification never reads as one more message between two cards. */
+.traffic-notification-cloud {
+	--cloud-tone: var(--agent);
+	position: absolute;
+	z-index: 4;
+	pointer-events: none;
+	transform: translate(-50%, -100%);
+}
+.traffic-notification-cloud.is-below {
+	transform: translate(-50%, 0);
+}
+.traffic-notification-cloud.level-success {
+	--cloud-tone: var(--success);
+}
+.traffic-notification-cloud.level-error {
+	--cloud-tone: var(--danger);
+}
+.traffic-notification-cloud-outline {
+	position: absolute;
+	inset: 0;
+	overflow: visible;
+	fill: rgb(var(--surface-overlay));
+	stroke: rgb(var(--cloud-tone) / 0.55);
+	stroke-width: 1.5;
+	filter: drop-shadow(0 8px 22px rgb(0 0 0 / 0.28));
+}
+.traffic-notification-cloud-body {
+	position: absolute;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	width: max-content;
+}
+.traffic-notification-cloud-level {
+	font-size: 10px;
+	font-weight: 600;
+	line-height: 1;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: rgb(var(--cloud-tone));
+}
+.traffic-notification-cloud-body strong {
+	display: -webkit-box;
+	max-width: 250px;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.25;
+}
+/* Zoomed out the cloud sits over a card a fraction of its size, so the text drops
+   to one line and the level word carries the meaning on its own. */
+.traffic-notification-cloud.is-compact .traffic-notification-cloud-body strong {
+	-webkit-line-clamp: 1;
+	max-width: 168px;
+	font-size: 11px;
+}
 .traffic-playback {
 	margin: 0 16px 8px;
 	background: rgb(var(--surface-raised) / 0.88);


### PR DESCRIPTION
Stacked on #1718 (Seq 1834), which adds the notification cloud. This PR adds the missing live arm; its own delta is the last commit only.

## The problem

The cloud reads `playback.current` — the replay cursor. In Live Follow `useTrafficPlayback` keeps `index === -1` and `current === null`, so a `dev3 notify` firing while the user watches the stage previewed nothing at all.

## The change

Mirror the live arm messages already have. An effect diffs `playback.events` filtered to `kind === "notification"` against a seen-set in a ref, takes the newest arrival that is both unseen and younger than 10 s, holds it in `liveNotification`, and a second effect clears it after 6 s. `activeNotification` reads the cursor while replaying and `liveNotification` otherwise, so the replay branch is byte-identical and everything downstream of it — sender attribution, the unrecorded/offscreen omission, the geometry, the CSS, the camera — is untouched.

Four cases stay silent, and each falls out of one of the two guards:

| Case | Guard |
|---|---|
| Opening the screen on a full archive | the first pass only seeds the seen-set |
| Returning to Live after a replay | the set keeps seeding while replaying |
| A refetch re-delivering the same rows | their keys are already in the set |
| A reconnect backlog | the rows are older than the freshness window |

No camera work, no placement engine, no new controls: an arrival from an off-frame or unrecorded sender still shows nothing.

## Verification

5 new tests beside the 8 that already existed; each new one was proven by mutating the guard it watches and confirming it goes red (live fallback removed → 2 fail, first-pass seeding removed → 1, freshness window forced true → 1). `traffic*` and `agent-traffic*` — 16 files, 251 tests — green on the rebased head, `bun run lint` clean.

Driven in a browser against an isolated QA instance with a real `dev3 notify` through the CLI socket, so the whole chain ran for real. At 3840×2160, 1440×900 and 390×844: 0 clouds on open with a 3-row archive present, 1 in-frame cloud a second after the arrival, 0 again after 7 s, no horizontal overflow, no console errors. Replay re-checked by stepping 13 steps back — the cloud appears only on notification steps.

`test:full` was not run locally; that is CI's job.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=04af0c99-af92-47a1-90ea-759bef548cce) · `dev3://task/04af0c99-af92-47a1-90ea-759bef548cce` _(dev3 added this footer — turn it off in Settings → Tasks.)_
