### PR TITLE
Size the agent-traffic scene layer to the graph it paints

### DIFF
--- a/change-logs/2026/09/11/fix-traffic-scene-layer-size.md
+++ b/change-logs/2026/09/11/fix-traffic-scene-layer-size.md
@@ -1,0 +1,3 @@
+Short: Traffic stage stops leaving card ghosts
+
+The Agent traffic node stage painted every card from a layer that measured zero by zero, because the scene and its card container had no size of their own while all their contents were absolutely positioned. Both now carry the same width and height the wires already used, so the layer the browser invalidates covers the graph it actually draws.

--- a/decisions/2026/09/11/size-the-traffic-scene-layer.md
+++ b/decisions/2026/09/11/size-the-traffic-scene-layer.md
@@ -1,0 +1,52 @@
+# Size the traffic scene layer instead of forcing a repaint
+
+## Context
+
+Agent traffic Experiment 2 left clipped card fragments on screen at low zoom: cards
+rendered at an earlier, larger detail tier stayed painted in vertical bands beside the
+correct `cell`-tier rectangles, and a pan cleared them instantly. The obvious reaches —
+`will-change`, `translateZ(0)`, an unconditional redraw tick — are all blanket GPU
+workarounds that hide a cause instead of naming one, so none of them was taken.
+
+## Investigation
+
+`.traffic-nodes-scene` and `.traffic-nodes-cards` measured **0×0** while painting the
+whole graph: both are `position: absolute` with no size, and every card inside them is
+absolutely positioned, so nothing gives the boxes height. Measured in the running app
+(`getBoundingClientRect`) at 3840×2160, 1440×900 and 390×844 — zero at all three, while
+the sibling `<svg class="traffic-nodes-wires">`, which is given `width`/`height`
+explicitly, measured the real scene. That asymmetry also shows in the original report:
+the residue is cards only, and no stale wire fragments appear beside them.
+
+One hypothesis for why that matters — untested here — is that an empty layout box yields
+a damage rect that misses the painted descendants. It is a hypothesis, not a measured
+cause, and nothing below depends on it being right.
+
+The artifact itself was **not** reproduced: it did not appear in headless Chromium (via
+`agent-browser`) or headless WebKit (via `playwright-core`), on a standalone harness or
+on the running app. Those clean runs establish only that these configurations did not
+show it — not why. The reported behaviour comes from the native Electrobun window, and
+that is where reproduction and verification still have to happen.
+
+## Decision
+
+`TrafficNodes.tsx` passes `scene.width` / `scene.height` into the scene div's inline
+style — the same two numbers already handed to the wires `<svg>` a few lines below — and
+`.traffic-nodes-cards` takes `width: 100%; height: 100%` off it in `traffic-nodes.css`.
+Guarded by "sizes the transformed scene layer to the graph it paints" in
+`src/mainview/__tests__/agent-traffic-ui.test.tsx`, which fails without the change.
+
+## Risks
+
+The causal link to the reported artifact is **unproven**. The zero-sized boxes are
+measured; that they are what produced the fragments is not. Nobody has watched the
+fragments stop appearing in the native window. If they survive, this change is still
+correct on its own terms and the next suspect is elsewhere; do not layer a GPU workaround
+on top of it without first reproducing in the native window.
+
+## Alternatives considered
+
+`will-change: transform` or `translateZ(0)` on the scene — promotes a layer and usually
+masks the symptom, but pins a full-graph texture in video memory and explains nothing. A
+redraw tick on camera change — burns a frame forever to paper over one invalidation bug.
+Both were rejected as blanket workarounds.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1217,6 +1217,21 @@ it("paints each wire with its own colour token and leaves an idle wire still", a
 	expect(document.querySelector(".traffic-wire-flow")).toBeNull();
 });
 
+it("sizes the transformed scene layer to the graph it paints", async () => {
+	// Every card inside is absolutely positioned, so without an explicit size the
+	// scene collapses to 0x0 while painting the whole graph — the layer shape that
+	// left card fragments on screen until a pan repainted them.
+	setPage([row()]);
+	renderLog();
+	await messageRows(1);
+	const scene = screen.getByTestId("traffic-node-scene");
+	const wires = document.querySelector<SVGSVGElement>(".traffic-nodes-wires")!;
+	expect(scene.style.width).toBe(`${wires.getAttribute("width")}px`);
+	expect(scene.style.height).toBe(`${wires.getAttribute("height")}px`);
+	expect(Number.parseFloat(scene.style.width)).toBeGreaterThan(0);
+	expect(Number.parseFloat(scene.style.height)).toBeGreaterThan(0);
+});
+
 it("Focus reveals a hibernated task selected from the task list without waking it", async () => {
 	taskExtras.value = { "task-c": { hibernated: true } };
 	setPage([row()]);

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -786,6 +786,11 @@ export default function TrafficNodes({
 				className="traffic-nodes-scene"
 				data-testid="traffic-node-scene"
 				style={{
+					/* Sized, not collapsed: every card is absolutely positioned, so without
+					   these the transformed layer measures 0x0 while painting the whole
+					   graph. The wires <svg> already carries the same two numbers. */
+					width: scene.width,
+					height: scene.height,
 					transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
 				}}
 			>

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -99,6 +99,13 @@
 .traffic-nodes-scene {
 	transform-origin: 0 0;
 }
+/* Fills the scene instead of collapsing to nothing: the cards inside are all
+   absolutely positioned, so a zero-height box would paint the whole graph from
+   a layer that measures 0x0. The scene's size comes from the inline style. */
+.traffic-nodes-cards {
+	width: 100%;
+	height: 100%;
+}
 .traffic-project-group {
 	position: absolute;
 	border: 1px solid rgb(var(--border-default) / 0.4);


### PR DESCRIPTION
Hi, this is Claude (the AI assistant that worked on this branch).

`.traffic-nodes-scene` — the layer that carries the camera `transform` — and `.traffic-nodes-cards` both measured **0 × 0** while painting the whole graph. Both are `position: absolute` with no size of their own, and every card inside them is absolutely positioned, so nothing gave the boxes any extent. The sibling `<svg class="traffic-nodes-wires">` was the only one handed `width`/`height` explicitly.

Measured with `getBoundingClientRect()` in the running app:

| Viewport | scene before | cards before | wires | scene/cards after |
|---|---|---|---|---|
| 3840 × 2160 | 0 × 0 | 0 × 0 | 2753 × 1551 | 2750 × 1549 |
| 1440 × 900 | 0 × 0 | 0 × 0 | 808 × 455 | 808 × 455 |
| 390 × 844 | 0 × 0 | 0 × 0 | 611 × 344 | 615 × 346 |

The scene div now takes `scene.width` / `scene.height` — the same two numbers already passed to the wires `<svg>` a few lines below — and `.traffic-nodes-cards` takes `width: 100%; height: 100%` off it. 27 lines of code and test across three files; the rest is a decision record and a changelog entry.

### Scope and what is not claimed

This started from a report of clipped card fragments left on the Experiment 2 stage at low zoom, cleared by a pan. **The causal link between the zero-sized boxes and those fragments is unproven.** The sizes are measured; that they produced the artifact is not. The artifact did not appear in headless Chromium or headless WebKit, on a standalone harness or on the running app — which establishes only that it did not show in those configurations, not why. The report came from the native Electrobun window, and that is where reproduction and verification still have to happen.

So this is a **candidate fix for a real structural defect**, correct on its own terms whatever the artifact turns out to be. No `will-change`, no `translateZ(0)`, no redraw loop — the reasoning for rejecting each is in `decisions/2026/09/11/size-the-traffic-scene-layer.md`. If the fragments survive, please do not stack a GPU workaround on top of this without reproducing natively first.

Guarded by "sizes the transformed scene layer to the graph it paints" in `agent-traffic-ui.test.tsx`, verified to fail without the change.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=f6757392-0fe9-493d-b49e-d0935b36812f) · `dev3://task/f6757392-0fe9-493d-b49e-d0935b36812f` _(dev3 added this footer — turn it off in Settings → Tasks.)_
