### PR TITLE
Draw the traffic user only while their message plays, over its recipient

### DIFF
--- a/change-logs/2026/09/11/fix-traffic-user-speech-bubble.md
+++ b/change-logs/2026/09/11/fix-traffic-user-speech-bubble.md
@@ -1,0 +1,3 @@
+Short: You appear only while you speak
+
+On the Agent traffic graph you are no longer a card in the grid with permanent wires fanning out of it. While one of your messages is playing — live or in replay — a human icon appears over the task you wrote to, with what you said in a speech bubble above its head, and disappears again with the message; a later message to another task draws it there instead.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1181,19 +1181,50 @@ it("draws the user as a sender for a message they proved they sent", async () =>
 	// "You" on the canvas reads as two different facts about one message.
 	expect(messageRow.textContent).toContain("You → #22");
 
-	const marker = screen.getByTestId("traffic-user-card");
-	expect(marker.textContent).toContain("You");
-	// None of the task grammar leaks onto a person: no seq, no status line.
-	expect(marker.textContent).not.toContain("#");
-	// And it is a real endpoint, so the recipient card is drawn beside it.
-	const [card] = screen.getAllByTestId("traffic-node-card");
+	// The person takes no place on the stage: only the recipient has a card, no
+	// wire runs out of a human, and nothing permanent stands in for one. They
+	// are drawn only while a message of theirs is playing — the next test.
 	expect(screen.getAllByTestId("traffic-node-card")).toHaveLength(1);
-	// The person is the origin of the conversation, so they sit above it.
-	expect(parseFloat(marker.style.top)).toBeLessThan(parseFloat(card.style.top));
+	expect(screen.queryByTestId("traffic-user-speaker")).toBeNull();
+	expect(document.querySelectorAll(".traffic-wire")).toHaveLength(0);
 	// A bare number on a card explains nothing; the wire's thickness carries volume.
 	expect(document.querySelectorAll(".traffic-node-count")).toHaveLength(0);
-	// The count survives where it is spelled out — the marker's accessible name.
-	expect(marker.getAttribute("aria-label")).toContain("1 recorded message");
+});
+
+it("puts the person over the task they wrote to, with their words above their head", async () => {
+	const subject = "Rework the traffic marker";
+	setPage([row({ fromTaskId: null, fromSeq: null, fromTitle: undefined, origin: "user", subject })]);
+	renderLog();
+	await waitFor(() => expect(screen.getByRole("button", { name: /^Replay$/ })).not.toBeDisabled());
+	await userEvent.click(screen.getByRole("button", { name: /^Replay$/ }));
+	const speaker = screen.getByTestId("traffic-user-speaker");
+	const bubble = screen.getByTestId("traffic-user-speech");
+	expect(bubble.textContent).toBe(subject);
+	// Bubble, then head, then the card that received the message.
+	expect(bubble.parentElement).toBe(speaker);
+	const [card] = screen.getAllByTestId("traffic-node-card");
+	expect(parseFloat(speaker.style.top)).toBeLessThan(parseFloat(card.style.top));
+	expect(speaker.style.left).toBe(card.style.left);
+	// And the wire's own subject bubble does not say the same thing twice.
+	expect(document.querySelector(".traffic-edge-subject")).toBeNull();
+});
+
+it("takes the person away again once another message is playing", async () => {
+	setPage([
+		row({ toTaskId: "task-b", toSeq: 33, toTitle: "Worker", subject: "Agent to agent" }),
+		row({ fromTaskId: null, fromSeq: null, fromTitle: undefined, origin: "user",
+			at: new Date(Date.now() - 60000).toISOString(), subject: "Human to agent" }),
+	]);
+	renderLog();
+	await waitFor(() => expect(screen.getByRole("button", { name: /^Replay$/ })).not.toBeDisabled());
+	await userEvent.click(screen.getByRole("button", { name: /^Replay$/ }));
+	// Replay opens on the older message, which is the person's.
+	expect(screen.getByTestId("traffic-user-speech").textContent).toBe("Human to agent");
+	await userEvent.click(screen.getByRole("button", { name: "Next message" }));
+	// The next message is between two agents, so the human is gone — their old
+	// words must never hang over a conversation they are not part of.
+	expect(screen.queryByTestId("traffic-user-speaker")).toBeNull();
+	expect(document.querySelector(".traffic-edge-subject")?.textContent).toBe("Agent to agent");
 });
 
 it("draws no user marker for a sender-less message that proved nothing", async () => {
@@ -1203,7 +1234,7 @@ it("draws no user marker for a sender-less message that proved nothing", async (
 	setPage([row({ fromTaskId: null, fromSeq: null, fromTitle: undefined })]);
 	renderLog();
 	await screen.findByTestId("traffic-node-scene");
-	expect(screen.queryByTestId("traffic-user-card")).toBeNull();
+	expect(screen.queryByTestId("traffic-user-speaker")).toBeNull();
 });
 
 it("paints each wire with its own colour token and leaves an idle wire still", async () => {

--- a/src/mainview/__tests__/nodes-layout.test.ts
+++ b/src/mainview/__tests__/nodes-layout.test.ts
@@ -69,22 +69,26 @@ describe("layoutTraffic", () => {
 		expect(edges).toHaveLength(2);
 	});
 
-	it("places the user above the coordinator and every task", () => {
+	it("keeps the person off the stage: no card of their own and no wire", () => {
 		const tasks = [coordinator("a", 11), task("b", 22), task("c", 33)];
 		const rows = [
 			row(null as unknown as string, "a", { fromSeq: null, origin: "user" }),
 			row("a", "b"),
 			row("a", "c"),
 		];
-		const { placed } = scene(tasks, rows);
-		const you = placed.find((node) => node.node.user);
-		expect(you).toBeDefined();
-		for (const other of placed.filter((node) => !node.node.user)) {
-			expect(other.y).toBeGreaterThan(you?.y as number);
-		}
-		// Centred over the grid the same way the coordinator is, not parked in it.
+		const { placed, edges } = scene(tasks, rows);
+		// A person has no lifetime on the board, so nothing permanent stands for
+		// them: TrafficNodes draws them over the recipient while their message
+		// plays, and the grid closes over them again afterwards.
+		expect(placed.some((node) => node.node.user)).toBe(false);
+		expect(placed).toHaveLength(3);
+		expect(edges.map((edge) => [edge.from, edge.to].join(" → ")).some((pair) => pair.includes("dev3:user"))).toBe(false);
+		// The coordinator is back at the top of its own grid, nothing above it.
 		const hub = placed.find((node) => node.hub)!;
-		expect((you as { x: number }).x + CARD_WIDTH / 2).toBe(hub.x + hub.width / 2);
+		for (const other of placed.filter((node) => !node.hub)) {
+			expect(other.y).toBeGreaterThan(hub.y);
+		}
+		expect(hub.y).toBe(0);
 	});
 
 	it("places five workers in the first row below the coordinator", () => {

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 	type CSSProperties,
 } from "react";
+import { isUserOrigin } from "../../../shared/agent-message-log";
 import { getTaskOverview, type BoardProject } from "../../../shared/types";
 import { useT } from "../../i18n";
 import { getStatusLabel } from "../../utils/statusLabel";
@@ -270,12 +271,16 @@ export default function TrafficNodes({
 		[reduced],
 	);
 	useEffect(() => () => cancelAnimationFrame(camera.current), []);
+	// A person appears above the card they wrote to, which above the top row is
+	// outside the cards' own bounds — so the framing keeps that strip clear, or
+	// the human's head and words are cut off by the top edge of the stage.
+	const speakerPad = records.some(({ row }) => isUserOrigin(row)) ? SPEAKER_RESERVE : 0;
 	const fitNodes = useCallback(
 		(targets: Pick<PlacedNode, "x" | "y" | "width" | "height">[], maximum: number, instant = false, floor = 0) => {
 			const box = { width: frame.current?.clientWidth ?? 0, height: frame.current?.clientHeight ?? 0 };
 			if (!box.width || !box.height || !targets.length) return;
 			const left = Math.min(...targets.map((p) => p.x)) - 70;
-			const top = Math.min(...targets.map((p) => p.y)) - 86;
+			const top = Math.min(...targets.map((p) => p.y)) - 86 - speakerPad;
 			const width = Math.max(...targets.map((p) => p.x + p.width)) + 70 - left;
 			const height = Math.max(...targets.map((p) => p.y + p.height)) + 86 - top;
 			const scale = overviewScale(box, { width, height }, maximum, floor);
@@ -288,7 +293,7 @@ export default function TrafficNodes({
 				instant,
 			);
 		},
-		[move],
+		[move, speakerPad],
 	);
 	/**
 	 * The automatic overview — on open, on resize, and whenever Live Follow falls
@@ -310,11 +315,11 @@ export default function TrafficNodes({
 		if (!targets.length) return undefined;
 		return {
 			left: Math.min(...targets.map((p) => p.x)) - 70,
-			top: Math.min(...targets.map((p) => p.y)) - 86,
+			top: Math.min(...targets.map((p) => p.y)) - 86 - speakerPad,
 			right: Math.max(...targets.map((p) => p.x + p.width)) + 70,
 			bottom: Math.max(...targets.map((p) => p.y + p.height)) + 86,
 		};
-	}, [scene.groups, scene.placed]);
+	}, [scene.groups, scene.placed, speakerPad]);
 	const resizeFollow = useRef<(() => void) | null>(null);
 	const fitRef = useRef(fit);
 	fitRef.current = fit;
@@ -390,8 +395,14 @@ export default function TrafficNodes({
 			const edge = sender && edgeByKey.get(
 				[sender.node.key, recipient.node.key].sort().join("|"),
 			);
+			// A message from a person has no sender card and no wire: the human is
+			// drawn over the recipient, so the frame has to hold the strip above it
+			// or the camera centres the card and the speaker falls off the top.
+			const speaking = isUserOrigin(record.row)
+				? [{ ...recipient, y: recipient.y - SPEAKER_RESERVE, height: SPEAKER_RESERVE }]
+				: [];
 			move(
-				frameExchange(viewport, sender ? [sender, recipient] : [recipient], edge?.points ?? [], sceneBounds),
+				frameExchange(viewport, sender ? [sender, recipient] : [recipient, ...speaking], edge?.points ?? [], sceneBounds),
 				reduced,
 				playback?.playing ? Math.min(500, playback.intervalMs * 0.9) : 500,
 			);
@@ -710,6 +721,18 @@ export default function TrafficNodes({
 				),
 			)
 		: undefined;
+	// The person only exists while they are speaking. They appear over the task
+	// they wrote to, with what they said above their head, and go again with the
+	// message — no card in the grid, no wire, nothing left behind. Text, lifetime
+	// and hidden-while-offscreen behaviour are the wire bubble's; only the anchor
+	// and the fact that a human is drawn at all are new.
+	const speaker = active && activeRecipient && isUserOrigin(active.row)
+		? {
+			at: activeRecipient,
+			text: active.row.subject || active.row.body.slice(0, 120),
+			failed: active.row.status === "not-delivered",
+		}
+		: null;
 	const labelPoint = activeEdge ? pointAt(activeEdge.points, 0.5) : activeRecipient ?
 		{ x: activeRecipient.x + activeRecipient.width / 2, y: activeRecipient.y } : undefined;
 	const detail = detailTier(view.scale);
@@ -870,28 +893,8 @@ export default function TrafficNodes({
 					})}
 				</svg>
 				<div className="traffic-nodes-cards">
+					{speaker && <UserSpeaker at={speaker.at} text={speaker.text} failed={speaker.failed} />}
 					{scene.placed.map((placed) => {
-						// The user marker never reaches `Card`: it has no task to project.
-						if (placed.node.user)
-							return (
-								<UserCard
-									key={placed.node.key}
-									placed={placed}
-									messageCount={messageCounts.get(placed.node.key) ?? 0}
-									selected={selected === placed.node.key}
-									dim={selected !== null && selected !== placed.node.key}
-									active={
-										activeFrom === placed.node.key ||
-										activeTo === placed.node.key
-									}
-									scale={view.scale}
-									onSelect={(key) => {
-										manual();
-										onSelect(key);
-									}}
-									onFocus={focus}
-								/>
-							);
 						const projection =
 							projections.get(placed.node.key) ??
 							projectTaskAt(placed.node.task, cursorAt);
@@ -948,7 +951,7 @@ export default function TrafficNodes({
 					)}
 				</div>
 			</div>
-			{active && labelPoint && (
+			{active && labelPoint && !speaker && (
 				<TrafficMessageBubble
 					subject={active.row.subject || active.row.body.slice(0, 120)}
 					anchor={{ x: view.x + labelPoint.x * view.scale, y: view.y + labelPoint.y * view.scale }}
@@ -1123,54 +1126,45 @@ function CompletionBurst({
 	);
 }
 
+/** Air between the person's feet and the top edge of the card they wrote to. */
+const SPEAKER_GAP = 18;
+/** Strip the camera keeps clear above the cards for a person who may speak. */
+const SPEAKER_RESERVE = 210;
+
 /**
- * The person using the app, drawn as its own thing rather than through {@link Card}.
+ * The person using the app, for as long as one of their messages is playing.
  *
- * Deliberately not a branch inside `Card`: it shares none of the task grammar
- * there — no status, no overview, no seq, no replay projection, all of which
- * would print something false about a human ("status not recorded", "#—"). It
- * also keeps this feature out of a function another task owns.
+ * Drawn over the recipient rather than placed in the scene: a human is not a
+ * work item with a lifetime on the board, so a permanent card in the grid — and
+ * the permanent fan of wires out of it — would claim a presence nobody has. Not
+ * a branch of {@link Card} either: it shares none of the task grammar there (no
+ * status, no seq, no replay projection), all of which would print something
+ * false about a person.
  */
-function UserCard({
-	placed,
-	messageCount,
-	selected,
-	dim,
-	active,
-	scale,
-	onSelect,
-	onFocus,
-}: {
-	placed: PlacedNode;
-	messageCount: number;
-	selected: boolean;
-	dim: boolean;
-	active: boolean;
-	scale: number;
-	onSelect: (key: string) => void;
-	onFocus: (key: string) => void;
+function UserSpeaker({ at, text, failed }: {
+	at: PlacedNode;
+	text: string;
+	failed: boolean;
 }) {
 	const t = useT();
 	return (
-		<button
-			type="button"
-			data-testid="traffic-user-card"
-			className={`traffic-node-card traffic-user-card ${selected ? "is-selected" : ""} ${dim ? "is-dim" : ""} ${active ? "is-lit" : ""}`}
-			style={{
-				left: placed.x,
-				top: placed.y,
-				width: placed.width,
-				height: placed.height,
-				["--node-inverse" as string]: 1 / scale,
-			}}
-			aria-label={`${t("traffic.node.you")} · ${t.plural("traffic.orbit.messageCount", messageCount)}`}
-			aria-pressed={selected}
-			onClick={() => onSelect(placed.node.key)}
-			onDoubleClick={() => onFocus(placed.node.key)}
+		<div
+			data-testid="traffic-user-speaker"
+			className="traffic-user-speaker"
+			// Anchored by its feet — the CSS lifts it by its own height, so a
+			// two-line bubble grows upwards instead of pushing into the card.
+			style={{ left: at.x, top: at.y - SPEAKER_GAP, width: at.width }}
+			aria-label={t("traffic.node.you")}
 		>
-			<TrafficIcon name="user" />
+			<span
+				data-testid="traffic-user-speech"
+				className={`traffic-user-speech streamer-private ${failed ? "is-failed" : ""}`}
+			>
+				{text}
+			</span>
+			<span className="traffic-user-disc"><TrafficIcon name="user" /></span>
 			<strong>{t("traffic.node.you")}</strong>
-		</button>
+		</div>
 	);
 }
 

--- a/src/mainview/components/agent-traffic/nodes-layout.ts
+++ b/src/mainview/components/agent-traffic/nodes-layout.ts
@@ -13,6 +13,12 @@ const COORDINATOR_HEIGHT = CARD_HEIGHT;
 const GAP_X = 52;
 const ROW_STEP = 360;
 const COORDINATOR_STEP = 340;
+/** What a node occupies on the stage. */
+function footprint(node: TrafficNode): { width: number; height: number } {
+	return node.task?.taskType === "coordinator"
+		? { width: COORDINATOR_WIDTH, height: COORDINATOR_HEIGHT }
+		: { width: CARD_WIDTH, height: CARD_HEIGHT };
+}
 
 export interface PlacedNode {
 	node: TrafficNode;
@@ -112,8 +118,8 @@ function pairs(records: TrafficRecord[]): Map<string, PairState> {
 	return found;
 }
 
-/** Cards that go in the grid — not the user marker, not a coordinator. */
-const isWorker = (node: TrafficNode) => !node.user && node.task?.taskType !== "coordinator";
+/** Cards that go in the grid, as opposed to the coordinator above it. */
+const isWorker = (node: TrafficNode) => node.task?.taskType !== "coordinator";
 
 /**
  * Message volume never moves a card: the order is the board's column order (when
@@ -122,10 +128,16 @@ const isWorker = (node: TrafficNode) => !node.user && node.task?.taskType !== "c
  * card that has since been completed back to where it actually was.
  */
 export function layoutTraffic(
-	nodes: TrafficNode[],
+	allNodes: TrafficNode[],
 	records: TrafficRecord[],
 	options: SceneOptions = {},
 ): TrafficScene {
+	// The person never takes a place on the stage. They are not a work item with
+	// a lifetime: they appear over whichever task they just wrote to, say their
+	// piece and are gone, so a permanent marker and a permanent fan of wires from
+	// it would both claim a presence that does not exist. TrafficNodes draws that
+	// appearance transiently, from the message that is playing.
+	const nodes = allNodes.filter((node) => !node.user);
 	const byKey = new Map(nodes.map((node) => [node.key, node]));
 	const state = pairs(records);
 	const partners = new Map<string, Set<string>>();
@@ -182,8 +194,7 @@ export function layoutTraffic(
 		const coordinator = node.task?.taskType === "coordinator";
 		const position: PlacedNode = {
 			node, x, y,
-			width: coordinator ? COORDINATOR_WIDTH : CARD_WIDTH,
-			height: coordinator ? COORDINATOR_HEIGHT : CARD_HEIGHT,
+			...footprint(node),
 			partners: partners.get(node.key)?.size ?? 0,
 			messages: messages.get(node.key) ?? 0,
 			hub: coordinator && !node.task?.hibernated,
@@ -205,12 +216,8 @@ export function layoutTraffic(
 			? Math.min(columns, Math.max(...bands.map(members => members.filter(isWorker).length)))
 			: columns;
 		const workerWidth = occupiedColumns ? occupiedColumns * (CARD_WIDTH + GAP_X) - GAP_X : 0;
-		// The centred rows above the grid: the user marker, then any coordinator.
-		const headWidth = Math.max(
-			bands.some(members => members.some(node => node.user)) ? CARD_WIDTH : 0,
-			bands.some(members => members.some(node => node.task?.taskType === "coordinator")) ? COORDINATOR_WIDTH : 0,
-		);
-		const gridWidth = Math.max(workerWidth, headWidth);
+		const hasCoordinator = bands.some(members => members.some(node => node.task?.taskType === "coordinator"));
+		const gridWidth = Math.max(workerWidth, hasCoordinator ? COORDINATOR_WIDTH : 0);
 		const workerOffset = grouped ? (gridWidth - workerWidth) / 2 : 0;
 		const offsetX = grouped ? groupX + 32 : 0;
 		const offsetY = grouped ? groupY + 96 : 0;
@@ -218,18 +225,11 @@ export function layoutTraffic(
 		let contentHeight = 0;
 		const add = (node: TrafficNode, x: number, y: number) => {
 			place(node, offsetX + x, offsetY + y);
-			contentHeight = Math.max(contentHeight, y + (node.task?.taskType === "coordinator" ? COORDINATOR_HEIGHT : CARD_HEIGHT) + 28);
+			contentHeight = Math.max(contentHeight, y + footprint(node).height + 28);
 		};
 		const band = (members: TrafficNode[]) => {
-			// The person is the origin of the conversation, so they sit above it:
-			// user marker first, then the coordinator, then the task grid.
-			const you = members.filter(node => node.user);
-			const coordinators = members.filter(node => !node.user && node.task?.taskType === "coordinator");
+			const coordinators = members.filter(node => node.task?.taskType === "coordinator");
 			const normal = members.filter(isWorker);
-			for (const node of you) {
-				add(node, (gridWidth - CARD_WIDTH) / 2, cursorY);
-				cursorY += COORDINATOR_STEP;
-			}
 			for (const node of coordinators) {
 				add(node, (gridWidth - COORDINATOR_WIDTH) / 2, cursorY);
 				cursorY += COORDINATOR_STEP;

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -222,33 +222,93 @@
 	background: color-mix(in srgb, var(--node-status) 14%, transparent);
 	pointer-events: none;
 }
-/* The person, not a task: no status stripe, no card grammar, and an accent ring
-   instead of a border so it reads as a different kind of thing at every zoom. */
-.traffic-user-card {
+/* The person, for as long as their message is playing: an icon over the card
+   they wrote to, with no card of their own. Nothing of the card grammar —
+   surface, status rail, title rows — applies to a human. */
+.traffic-user-speaker {
+	position: absolute;
+	z-index: 2;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
-	gap: 6px;
+	justify-content: flex-end;
+	gap: 8px;
+	pointer-events: none;
 	text-align: center;
+	color: rgb(var(--text-primary));
+	transform: translateY(-100%);
+	animation: traffic-speaker-in 0.22s cubic-bezier(0.2, 0, 0, 1);
+}
+@keyframes traffic-speaker-in {
+	from { opacity: 0; transform: translateY(calc(-100% + 6px)); }
+	to { opacity: 1; transform: translateY(-100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+	.traffic-user-speaker {
+		animation: none;
+	}
+}
+.traffic-user-disc {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 76px;
+	height: 76px;
+	border-radius: 50%;
 	background:
-		linear-gradient(135deg, rgb(var(--accent) / 0.1), transparent 70%),
+		linear-gradient(135deg, rgb(var(--accent) / 0.16), transparent 70%),
 		rgb(var(--surface-elevated));
 	box-shadow:
-		0 8px 22px rgb(0 0 0 / 0.13),
+		0 8px 22px rgb(0 0 0 / 0.16),
 		inset 0 0 0 1.5px rgb(var(--accent) / 0.55);
+	transition: box-shadow 0.18s cubic-bezier(0.2, 0, 0, 1);
 }
-.traffic-user-card::before {
-	display: none;
-}
-.traffic-user-card .traffic-icon {
-	width: 34px;
-	height: 34px;
+.traffic-user-speaker .traffic-icon {
+	width: 38px;
+	height: 38px;
 	color: rgb(var(--accent));
 }
-.traffic-user-card strong {
+.traffic-user-speaker strong {
 	font-size: 15px;
-	color: rgb(var(--text-primary));
+}
+/* What the person is saying, over their own head. Same bubble language as the
+   wire subject, but glued to the person in scene space instead of chasing a
+   point on the wire — a speaker's words do not float away from the speaker. */
+.traffic-user-speech {
+	--message-tone: var(--agent);
+	position: absolute;
+	bottom: calc(100% + 14px);
+	left: 50%;
+	transform: translateX(-50%);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	width: max-content;
+	max-width: 264px;
+	padding: 9px 13px;
+	border-radius: 12px;
+	background: rgb(var(--surface-overlay));
+	box-shadow: 0 8px 25px rgb(0 0 0 / 0.2), inset 0 0 0 1px rgb(var(--message-tone) / 0.3);
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.35;
+	text-align: left;
+}
+.traffic-user-speech.is-failed {
+	--message-tone: var(--danger);
+}
+.traffic-user-speech::after {
+	content: "";
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	width: 12px;
+	height: 12px;
+	margin-left: -6px;
+	background: rgb(var(--surface-overlay));
+	box-shadow: inset 0 0 0 1px rgb(var(--message-tone) / 0.3);
+	clip-path: polygon(0 0, 100% 0, 50% 100%);
 }
 
 .traffic-node-card.is-coordinator {


### PR DESCRIPTION
On the Agent traffic graph (Experiment 2) the person using the app is no longer a permanent node. There is no task-sized "You" card in the grid and no permanent fan of wires out of a human.

While one of their messages is playing — live or in replay — a compact human icon appears over the task that message went to, with what they said in a speech bubble above its head, and it goes away with the message. A later message to another task draws it there instead. The wire's own subject bubble is suppressed for those messages so the text is said once.

- `layoutTraffic` drops user endpoints, so they take no place on the stage and produce no edge.
- `TrafficNodes` draws the speaker from the currently playing record, reusing the existing message text, lifetime and hidden-while-offscreen behaviour.
- The camera keeps a 210px strip clear above the cards while the window holds user messages, otherwise the head and bubble were cut off by the top edge of the stage.

Sender attribution, the recorded history, the message list's `You → #NNNN` and the `isUserOrigin` rule are untouched — only the presentation changed. Experiment 1 still renders its own user node; nothing there was modified.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=92e518a5-8c0e-4707-be1b-b3b0f4a3a642) · `dev3://task/92e518a5-8c0e-4707-be1b-b3b0f4a3a642` _(dev3 added this footer — turn it off in Settings → Tasks.)_
