### PR TITLE
Keep Escape inside a task view instead of navigating to the board

### DIFF
--- a/change-logs/2026/09/11/fix-taskview-escape-no-longer-navigates.md
+++ b/change-logs/2026/09/11/fix-taskview-escape-no-longer-navigates.md
@@ -1,0 +1,3 @@
+Short: Escape stays in the task
+
+Escape inside a task view no longer steps back to the board — it belongs to whatever runs in the terminal, so interrupting an agent with Escape can no longer throw you out of the task. The old guard only skipped navigation while the first terminal node held focus, which is why a second native pane or a just-clicked button turned an interrupt into a navigation. Modals, popovers and menus opened on top of a task still close on Escape.

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -41,8 +41,13 @@ this page and the website all read from it.
 | Zoom in / out / reset | ⌘= / ⌘- / ⌘0 | Ctrl+= / Ctrl+- / Ctrl+0 |
 | Hard refresh | ⌘R | Ctrl+R |
 | Toggle project terminal / open Quick Shell | ⌘` / ⇧⌘` | Ctrl+` / Ctrl+Shift+` |
-| Close dialog / step back | Esc | Esc |
+| Close dialog / step back (not inside a task) | Esc | Esc |
 | Quit / Hide | ⌘Q / ⌘H | Ctrl+Q / Ctrl+H |
+
+**Escape never leaves a task view.** Inside a task, Esc belongs to whatever runs in the terminal —
+it is how you interrupt the agent — so the app does not step back to the board on it. Modals,
+popovers and menus opened on top of a task still close on Esc, as everywhere else. Use ⌘K, `G`
+then `D`/`P`, or the breadcrumb to leave a task.
 
 ### In a browser (`dev3 remote`)
 

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -2780,8 +2780,13 @@ function App() {
 				e.preventDefault();
 				navigate({ screen: "project", projectId: route.projectId });
 			} else if (route.screen === "project" && (route.activeTaskId || route.taskView)) {
-				e.preventDefault();
-				navigate({ screen: "project", projectId: route.projectId });
+				// Inside a task view Escape belongs to the agent, not to navigation:
+				// it is how you interrupt the running agent. The old "step back to
+				// the board" branch fired whenever focus was not inside the first
+				// [data-terminal] node — a second native pane, a just-clicked header
+				// button — and threw the user out mid-interrupt. No preventDefault:
+				// the keystroke stays unconsumed so the terminal keeps receiving it.
+				return;
 			} else if (route.screen === "project") {
 				e.preventDefault();
 				navigate({ screen: "dashboard" });

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -2224,6 +2224,51 @@ describe("App keyboard shortcuts", () => {
 				zone.remove();
 			}
 		});
+
+		it("Escape inside a task view does not navigate, and stays unconsumed for the terminal", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", activeTaskId: "t1" }),
+			});
+			await renderApp();
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t1");
+
+			// Focus deliberately outside any [data-terminal] node: the old guard only
+			// skipped navigation while the terminal held focus, which is exactly how
+			// an interrupt turned into "back to the board".
+			(document.body as HTMLElement).focus();
+
+			// Registered after the app's own window listener, so it observes whether
+			// the app consumed the key. Unconsumed is what lets the shell have it.
+			let prevented: boolean | null = null;
+			const observe = (e: KeyboardEvent) => { prevented = e.defaultPrevented; };
+			window.addEventListener("keydown", observe);
+			try {
+				await userEvent.keyboard("{Escape}");
+			} finally {
+				window.removeEventListener("keydown", observe);
+			}
+
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-active-task-id", "t1");
+			expect(prevented).toBe(false);
+		});
+
+		it("Escape in the split task view (taskView, no active task) does not navigate either", async () => {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "project", projectId: "p1", taskView: true }),
+			});
+			await renderApp();
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-task-view", "true");
+
+			await userEvent.keyboard("{Escape}");
+
+			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-task-view", "true");
+		});
 	});
 
 	describe("project switching (Cmd+1..9)", () => {

--- a/src/mainview/i18n/translations/en/keymap.ts
+++ b/src/mainview/i18n/translations/en/keymap.ts
@@ -32,7 +32,7 @@ const keymap = {
 	"keymap.shortcut.goTo": "Go to… (D dashboard · P project · T tasks · S settings · digit = project N; P/T + digit = project N board/tasks)",
 	"keymap.shortcut.zoomOutToSpace": "Zoom out to the space board",
 	"keymap.shortcut.focusSearch": "Focus search",
-	"keymap.shortcut.escape": "Close dialog / step back",
+	"keymap.shortcut.escape": "Close dialog / step back (not inside a task — the agent gets it)",
 	"keymap.shortcut.newTask": "New task",
 	"keymap.shortcut.addProject": "Add project",
 	"keymap.shortcut.newWindow": "New window",

--- a/src/mainview/i18n/translations/es/keymap.ts
+++ b/src/mainview/i18n/translations/es/keymap.ts
@@ -29,7 +29,7 @@ const keymap = {
 	"keymap.shortcut.goTo": "Ir a… (D panel · P proyecto · T tareas · S ajustes · dígito = proyecto N; P/T + dígito = tablero/tareas del proyecto N)",
 	"keymap.shortcut.zoomOutToSpace": "Ampliar al tablero del espacio",
 	"keymap.shortcut.focusSearch": "Enfocar búsqueda",
-	"keymap.shortcut.escape": "Cerrar diálogo / volver atrás",
+	"keymap.shortcut.escape": "Cerrar diálogo / volver atrás (no dentro de una tarea — ahí lo recibe el agente)",
 	"keymap.shortcut.newTask": "Nueva tarea",
 	"keymap.shortcut.addProject": "Añadir proyecto",
 	"keymap.shortcut.newWindow": "Nueva ventana",

--- a/src/mainview/i18n/translations/ru/keymap.ts
+++ b/src/mainview/i18n/translations/ru/keymap.ts
@@ -29,7 +29,7 @@ const keymap = {
 	"keymap.shortcut.goTo": "Перейти к… (D дашборд · P проект · T задачи · S настройки · цифра = проект N; P/T + цифра = доска/задачи проекта N)",
 	"keymap.shortcut.zoomOutToSpace": "Выйти на доску пространства",
 	"keymap.shortcut.focusSearch": "Фокус в поиск",
-	"keymap.shortcut.escape": "Закрыть диалог / шаг назад",
+	"keymap.shortcut.escape": "Закрыть диалог / шаг назад (кроме открытой задачи — там его получает агент)",
 	"keymap.shortcut.newTask": "Новая задача",
 	"keymap.shortcut.addProject": "Добавить проект",
 	"keymap.shortcut.newWindow": "Новое окно",


### PR DESCRIPTION
Escape inside a task view stepped back to the project board. That is also how you interrupt a running agent, so the interrupt regularly threw the user out of the task instead.

The only thing holding the navigation back was this guard in the app-level Escape handler:

```js
const terminalEl = document.querySelector('[data-terminal="true"]');
if (terminalEl?.contains(document.activeElement)) return;
```

`querySelector` is singular. A multi-pane task on the native backend renders one `TerminalView` per pane (`TaskTerminal.tsx`), so several such nodes exist and only the first was ever inspected — Escape with focus in pane 2+ fell straight through to the navigation branch. The same miss happens whenever focus sits on any non-terminal control in the task view, e.g. a header button that was just clicked.

The task-view branch now returns and does nothing, deliberately without `preventDefault`, so the keystroke stays unconsumed and the terminal keeps receiving it. `useGlobalShortcut` listens on `window` in the bubble phase, so the terminal's own handler runs first either way — an app-level handler there could never steal the key, only add an unwanted side effect.

Everything else in that handler is untouched: the quit dialog still closes on Escape, and Escape still steps back from Settings, Project Settings, the project terminal, the agent-traffic screen and the project board. Modals, popovers and menus opened on top of a task keep their own dismissals — those register through `useEscapeKey` / `registerBackLayer`, a separate mechanism.

Since the documented app shortcut changed meaning, the `escape` entry's description was updated in all three locales and `docs/keyboard-shortcuts.md` gained the row change plus a short note on how to leave a task view (⌘K, `G` then `D`/`P`, or the breadcrumb).

Two new cases in `App.test.tsx` cover it: the `activeTaskId` route with focus forced outside any terminal (the exact case the old guard missed) asserting both that the route is unchanged and that the event comes out with `defaultPrevented === false`, and the split `taskView: true` route. Reverting the branch to its old body fails both and leaves the pre-existing Escape tests passing.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=c27d3ba1-5e8d-4d6a-8764-6ad423aee2aa) · `dev3://task/c27d3ba1-5e8d-4d6a-8764-6ad423aee2aa` _(dev3 added this footer — turn it off in Settings → Tasks.)_
