### PR TITLE
Make a terminal pane opt-in instead of the default for long commands

### DIFF
--- a/change-logs/2026/09/11/fix-panes-only-when-asked.md
+++ b/change-logs/2026/09/11/fix-panes-only-when-asked.md
@@ -1,0 +1,3 @@
+Short: Agents open panes far less often
+
+Agents no longer split a pane for every long command: the injected protocol and the `/dev3-tmux` skill now treat your own shell as the default and reserve a pane for what the user asked to watch or for a process that must outlive the agent's turn. Builds, test suites and checks stay inline however long they take.

--- a/decisions/2026/09/11/panes-are-opt-in-not-a-default-for-long-commands.md
+++ b/decisions/2026/09/11/panes-are-opt-in-not-a-default-for-long-commands.md
@@ -1,0 +1,48 @@
+# A pane is opt-in, not the default for anything long-running
+
+## Context
+
+The injected protocol told every agent that "Anything long-running or streaming (build, test run,
+watcher, log tail) goes in a neighbouring pane instead of blocking your own tool call"
+(`SKILL_PANES` in `src/shared/agent-skill-content.ts`). The only named alternative was "quick
+one-shot commands", with no threshold for "quick". Agents therefore split a pane for routine work,
+and the user's terminal filled with panes he never asked for.
+
+## Investigation
+
+An audit of every pane instruction (task Seq 1880) found the softer criterion — "long-running **and
+the user benefits from watching live**" — existed only in `/dev3-tmux`, an optional skill an agent
+rarely loads, while the unconditional wording sat in the mandatory system prompt. A grep of past
+Claude transcripts showed the real pane runs were dominated by `bun run dev --qa`, `vitest run` and
+`test:full` — exactly the commands the repo's own rules already say to start elsewhere. The tmux
+skill also carried an incentive pointing the wrong way: "Long-running commands stealing your tool
+slot … a tmux pane fires-and-forgets and you get your next tool call back immediately."
+
+## Decision
+
+The trigger is now the user, not the command. `SKILL_PANES` states that the agent's own shell is the
+default and names two cases for a pane: the user asked to watch something run, or the process must
+outlive the turn (watcher, log tail, long-lived process). Builds, test suites and checks stay inline
+however long they take, and the section says plainly that a pane is not a way to free up a tool
+call. `TMUX_SKILL_BODY` §3 in `src/bun/agent-skills.ts` was rewritten to the same three cases, and
+its "stealing your tool slot" pitfall was inverted into "opening a pane to free up your own tool
+call". `src/bun/__tests__/agent-skills.test.ts` pins the new heading and the default-to-your-shell
+line.
+
+The backend-truth lines from `decisions/2026/08/14/backend-agnostic-pane-runs.md` (`dev3 pane list`,
+never assume tmux) are untouched — that incident was about an agent believing a false statement
+about its terminal, not about how often it splits.
+
+## Risks
+
+Agents will now block their own tool call on slow builds and test runs, so a turn can take longer
+before anything is reported. A genuinely useful live view may be missed when the user did not think
+to ask for one. Both are cheaper than a terminal the user has to clear.
+
+## Alternatives considered
+
+Deleting the section entirely — rejected, it re-runs the Windows incident where an agent with no
+statement about its backend reached for tmux that does not exist. Moving it into a user-invocable
+skill — rejected as an extra hop that also hides the pane commands when they are genuinely needed.
+Keeping the wording and adding a duration threshold — rejected because models estimate duration
+poorly in advance and "Anything long-running" would still lead the paragraph.

--- a/src/bun/__tests__/agent-skills.test.ts
+++ b/src/bun/__tests__/agent-skills.test.ts
@@ -176,7 +176,9 @@ describe("dev3 skill content", () => {
 
 	it("teaches the backend-neutral pane commands, so a Windows agent is not sent to a binary it has no chance of finding", () => {
 		for (const skill of [CLAUDE_SKILL_BODY, getCodexSkillContent(), getGenericSkillContent()]) {
-			expect(skill).toContain("## Panes — run long commands next to yourself");
+			expect(skill).toContain("## Panes — for what the user wants to watch");
+			// A pane is opt-in: the user asked, or the process outlives the turn. Slowness alone is not a trigger.
+			expect(skill).toContain("**Your own shell is the default.**");
 			expect(skill).toContain("dev3 pane list");
 			expect(skill).toContain("dev3 pane run");
 			expect(skill).toContain("dev3 pane logs");

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -330,14 +330,13 @@ Re-query \`list-panes\` / \`list-windows\` whenever you need a pane id — cache
 
 ## 3. When to use a tmux pane vs inline Bash
 
-Run a command **in a separate tmux pane** when at least one of these is true:
+**Inline Bash is the default.** Run a command **in a separate tmux pane** only when one of these is true:
 
-- It is **long-running** and the user benefits from watching live (dev server, build watcher, log tail, test watcher).
-- It produces **streaming logs** that the user might want to scroll through later.
-- You want to **demo or debug interactively** — let the user see exactly what happened, not a post-hoc summary.
-- The user explicitly says "run it in a pane / tab / window" or "so I can see it".
+- The user asked for it — "run it in a pane / tab / window", "so I can see it", "run the build on the right".
+- The process must **outlive your turn** and someone will watch it: a dev process, a watcher, a log tail.
+- You are **demoing or debugging in front of the user** and they need to see it happen, not a summary afterwards.
 
-Keep using **inline Bash** for quick one-shot commands (file reads, short git, type-checks, single test runs) where streaming visibility adds nothing.
+Everything else stays inline, builds, test suites and checks included, however long they take. Being slow is not a reason — a pane is a window into the user's terminal, not a way to free up your own tool call.
 
 **Do NOT use a tmux pane as a substitute for the canonical dev server** — the project has \`dev3 dev-server start\` for that, which is wired to \`devScript\` and the UI. Use ad-hoc panes for things the user wants to *watch alongside* the dev server, not to replace it.
 
@@ -440,7 +439,7 @@ Useful when you start a watcher in a pane and want to verify a few minutes later
 - **Killing user-owned panes/windows.** The user may have things running you cannot see (a debugger, a REPL, a long upload). Default to creating new panes; only destroy what you created yourself, or what the user explicitly asked you to remove.
 - **Running the canonical dev server in an ad-hoc pane.** Use \`dev3 dev-server start\` instead — it integrates with the UI and \`devScript\`. Ad-hoc panes are for things the user wants to *watch on the side*.
 - **Opening a new-window for a background process.** \`new-window\` hides the process behind a tab — the user has to click to see it. For celery, docker exec, watchers, log tails, dev servers — use \`split-window\` so the output sits next to the agent. Only open a new window when the user explicitly asks for a tab.
-- **Long-running commands stealing your tool slot.** Inline \`bun run dev\` from the Bash tool blocks your tool call for a long time. A tmux pane fires-and-forgets and you get your next tool call back immediately.
+- **Opening a pane to free up your own tool call.** A slow build or a long test run belongs inline — waiting is yours to do. Split only for a process that has to keep running after your turn ends, and only when the user will look at it.
 `;
 
 const CLAUDE_TMUX_SKILL = `---

--- a/src/shared/agent-skill-content.ts
+++ b/src/shared/agent-skill-content.ts
@@ -226,21 +226,20 @@ For ANY question about project configuration — setup/dev/cleanup scripts, clon
 `;
 
 const SKILL_PANES = `
-## Panes — run long commands next to yourself
+## Panes — for what the user wants to watch
 
-Your terminal has panes the user watches live. **Never assume which backend you are on** — dev3 runs tmux and a native backend, and tmux does not exist on Windows at all. \`dev3 pane list\` names the backend, every pane, which is yours, and what a screen read can do here.
-
-Anything long-running or streaming (build, test run, watcher, log tail) goes in a neighbouring pane instead of blocking your own tool call, read back from the run's log — which works on every backend and OS:
+\`dev3 pane run\` puts one command in a pane beside yours, on every backend and OS, where the user sees it live. **Your own shell is the default.** Open a pane in two cases: the user asked to watch something run ("run the build on the right"), or the process must outlive your turn — a watcher, a log tail, a long-lived process someone keeps an eye on. Everything else stays inline — builds, test suites, checks — however long they take. A pane is a window into the user's terminal, not a way to free up your own tool call.
 
 \`\`\`bash
-dev3 pane run "bun run build" --label Build   # opens a pane to your right, prints a run id
-dev3 pane logs <run-id> [--lines 400]         # outcome + tail (1..2000, default 200)
-dev3 pane close <run-id>                      # close that pane (kills the command)
+dev3 pane list                                 # which backend you are on — never assume, tmux is absent on Windows
+dev3 pane run "npm run watch" --label Watch    # opens a pane to your right, prints a run id
+dev3 pane logs <run-id> [--lines 400]          # outcome + tail (1..2000, default 200)
+dev3 pane close <run-id>                       # close that pane (kills the command)
 \`\`\`
 
-The outcome line distinguishes **still running** from **finished, exit code N** — never read a quiet tail as a finished command. Runs are non-interactive (stdin closed): builds, tests, servers, watchers. Quick one-shot commands stay inline in your own shell, and the canonical dev server is \`dev3 dev-server start\`, not a pane run.
+The outcome line distinguishes **still running** from **finished, exit code N** — never read a quiet tail as a finished command. Runs are non-interactive: stdin is closed. The canonical dev server is \`dev3 dev-server start\`, not a pane run.
 
-**Closing panes is your job, not the user's.** \`dev3 pane close <run-id>\` the moment you have read what you came for — per run as you go, and again before ending a turn, so \`dev3 pane list\` shows nothing of yours but work still needed. A watcher, dev server or red build parked in their terminal is litter they must clear. The auto-close timer is a backstop for abandoned panes, not a substitute: exit 0 closes itself after ${PANE_RUN_AUTO_CLOSE_SECONDS} seconds, a failure after ${Math.round(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS / 60)} minutes so the user still sees it. Closing destroys nothing — the output stays in the run's log.
+**Closing panes is your job, not the user's.** \`dev3 pane close <run-id>\` the moment you have read what you came for — per run as you go, and again before ending a turn, so \`dev3 pane list\` shows nothing of yours but work still needed. The auto-close timer is a backstop for abandoned panes, not a substitute: exit 0 closes itself after ${PANE_RUN_AUTO_CLOSE_SECONDS} seconds, a failure after ${Math.round(PANE_RUN_FAILED_AUTO_CLOSE_SECONDS / 60)} minutes so the user still sees it. Closing destroys nothing — the output stays in the run's log.
 
 Reading the SCREEN of a pane you did not start ("look at the error on the right") is a different thing and **tmux-only today**: \`dev3 peek --pane <N>\` returns a tail on tmux, only the pane summary on native. On tmux you may also drive tmux directly for layout work the user asks for (rename / swap / move windows, resize) — load \`/dev3-tmux\`. On native those commands do not exist.
 `;


### PR DESCRIPTION
The injected dev3 protocol told every agent that *anything* long-running or streaming goes into a neighbouring pane, leaving only undefined "quick one-shot commands" inline. Agents split panes for routine builds and test runs, and the user's terminal filled with panes nobody asked for. A grep of past transcripts shows the real pane runs were dominated by `bun run dev --qa`, `vitest run` and `test:full` — commands the repo already says to start elsewhere.

The trigger is now the user, not the command:

- `SKILL_PANES` (`src/shared/agent-skill-content.ts`) makes the agent's own shell the default and names two cases for a pane — the user asked to watch something run, or the process must outlive the turn (watcher, log tail, long-lived process). Builds, test suites and checks stay inline however long they take.
- `TMUX_SKILL_BODY` §3 (`src/bun/agent-skills.ts`) carries the same three cases, and its "Long-running commands stealing your tool slot" pitfall is inverted into "opening a pane to free up your own tool call".
- The backend-truth lines from `decisions/2026/08/14/backend-agnostic-pane-runs.md` (`dev3 pane list`, never assume tmux) are untouched.

Both bodies stay under `AGENT_SKILL_BODY_LIMIT`; the section is now shorter than before. Decision record: `decisions/2026/09/11/panes-are-opt-in-not-a-default-for-long-commands.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=946e4a2b-fa45-4923-a7d4-0bf952c48b2f) · `dev3://task/946e4a2b-fa45-4923-a7d4-0bf952c48b2f`