### PR TITLE
Show the task number on zoomed-out traffic cards and lift the project name above its frame

### DIFF
--- a/change-logs/2026/09/11/feature-traffic-cell-seq-number.md
+++ b/change-logs/2026/09/11/feature-traffic-cell-seq-number.md
@@ -1,3 +1,3 @@
 Short: Task numbers on zoomed-out traffic cards
 
-Zoomed all the way out on the Agent traffic graph, a card used to be an anonymous coloured rectangle. It now carries its task number, sized to the card and shrinking as the number gains digits, with the ink picked per card so it reads on any status colour.
+Zoomed all the way out on the Agent traffic graph, a card used to be an anonymous coloured rectangle. It now carries its task number, sized to the card and shrinking as the number gains digits, with the ink picked per card so it reads on any status colour. The project name now hangs above its group frame at every zoom instead of being clipped to a few letters and landing on top of the cards.

--- a/change-logs/2026/09/11/feature-traffic-cell-seq-number.md
+++ b/change-logs/2026/09/11/feature-traffic-cell-seq-number.md
@@ -1,0 +1,3 @@
+Short: Task numbers on zoomed-out traffic cards
+
+Zoomed all the way out on the Agent traffic graph, a card used to be an anonymous coloured rectangle. It now carries its task number, sized to the card and shrinking as the number gains digits, with the ink picked per card so it reads on any status colour.

--- a/src/mainview/__tests__/traffic-cell-seq.test.ts
+++ b/src/mainview/__tests__/traffic-cell-seq.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	cellSeqFontSize,
+	cellSeqInk,
+} from "../components/agent-traffic/cell-seq";
+import { CARD_HEIGHT, CARD_WIDTH } from "../components/agent-traffic/nodes-layout";
+
+const size = (label: string) => cellSeqFontSize(label, CARD_WIDTH, CARD_HEIGHT);
+
+describe("cellSeqFontSize", () => {
+	it("shrinks as the seq gains digits", () => {
+		expect(size("4")).toBeGreaterThan(size("49"));
+		expect(size("49")).toBeGreaterThan(size("493"));
+		expect(size("493")).toBeGreaterThan(size("1883"));
+	});
+
+	it("keeps every label inside the card", () => {
+		for (const label of ["4", "49", "493", "1883", "49-1", "1883-12"]) {
+			const fontSize = cellSeqFontSize(label, CARD_WIDTH, CARD_HEIGHT);
+			expect(fontSize * label.length * 0.62).toBeLessThanOrEqual(CARD_WIDTH);
+			expect(fontSize).toBeLessThanOrEqual(CARD_HEIGHT);
+		}
+	});
+
+	it("scales with the card, so a wider coordinator gets a bigger number", () => {
+		expect(cellSeqFontSize("1883", 370, CARD_HEIGHT)).toBeGreaterThan(
+			cellSeqFontSize("1883", CARD_WIDTH, CARD_HEIGHT),
+		);
+	});
+});
+
+describe("cellSeqInk", () => {
+	it("goes dark on a bright status fill", () => {
+		expect(cellSeqInk("#ffe55f")).toBe("rgba(0, 0, 0, 0.72)");
+		expect(cellSeqInk("#3cf3b0")).toBe("rgba(0, 0, 0, 0.72)");
+	});
+
+	it("goes light on a dark status fill", () => {
+		expect(cellSeqInk("#0182b0")).toBe("rgba(255, 255, 255, 0.86)");
+		expect(cellSeqInk("#4b59ff")).toBe("rgba(255, 255, 255, 0.86)");
+	});
+
+	it("falls back to the theme ink when the card has no status colour", () => {
+		expect(cellSeqInk(undefined)).toBe("rgb(var(--text-primary))");
+		expect(cellSeqInk("rgb(var(--text-tertiary))")).toBe(
+			"rgb(var(--text-primary))",
+		);
+	});
+});

--- a/src/mainview/__tests__/traffic-group-heading.test.ts
+++ b/src/mainview/__tests__/traffic-group-heading.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	headingTop,
+	headingWidth,
+} from "../components/agent-traffic/group-heading";
+import { SCENE_PAD_Y } from "../components/agent-traffic/traffic-camera";
+import { CARD_WIDTH } from "../components/agent-traffic/nodes-layout";
+
+describe("headingTop", () => {
+	it("hangs the name above the frame at every zoom", () => {
+		for (const scale of [0.1, 0.14, 0.36, 0.7, 1, 2.2]) {
+			expect(headingTop(scale)).toBeLessThan(0);
+		}
+	});
+
+	it("keeps the same 22px gap on screen while there is room for it", () => {
+		expect(headingTop(1)).toBe(-22);
+		expect(headingTop(0.5) * 0.5).toBe(-22);
+	});
+
+	it("never rises above the padding the scene bounds reserve", () => {
+		// Beyond it the camera clamp cuts the name off at the top of the viewport.
+		expect(headingTop(0.14)).toBe(-SCENE_PAD_Y);
+		expect(headingTop(0.05)).toBe(-SCENE_PAD_Y);
+	});
+});
+
+describe("headingWidth", () => {
+	it("tracks the group while the group is wide enough on screen", () => {
+		expect(headingWidth(600, 1)).toBe(552);
+	});
+
+	it("stays readable when the group shrinks to a few pixels", () => {
+		// A 300-wide group at 14% is 42px on screen — "rts-do…" and nothing more.
+		expect(headingWidth(CARD_WIDTH, 0.14)).toBe(150);
+	});
+});

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -53,7 +53,8 @@ import TrafficMinimap from "./TrafficMinimap";
 import TrafficMessageBubble from "./TrafficMessageBubble";
 import TrafficNotificationCloud from "./TrafficNotificationCloud";
 import { cellSeqFontSize, cellSeqInk } from "./cell-seq";
-import { IDENTITY_SCALE, MAX_SCALE, detailTier, frameExchange, overviewScale } from "./traffic-camera";
+import { headingTop, headingWidth } from "./group-heading";
+import { IDENTITY_SCALE, MAX_SCALE, SCENE_PAD_Y, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
 	/** Board columns come off these, so the stage orders cards the way the Kanban does. */
@@ -281,9 +282,9 @@ export default function TrafficNodes({
 			const box = { width: frame.current?.clientWidth ?? 0, height: frame.current?.clientHeight ?? 0 };
 			if (!box.width || !box.height || !targets.length) return;
 			const left = Math.min(...targets.map((p) => p.x)) - 70;
-			const top = Math.min(...targets.map((p) => p.y)) - 86 - speakerPad;
+			const top = Math.min(...targets.map((p) => p.y)) - SCENE_PAD_Y - speakerPad;
 			const width = Math.max(...targets.map((p) => p.x + p.width)) + 70 - left;
-			const height = Math.max(...targets.map((p) => p.y + p.height)) + 86 - top;
+			const height = Math.max(...targets.map((p) => p.y + p.height)) + SCENE_PAD_Y - top;
 			const scale = overviewScale(box, { width, height }, maximum, floor);
 			move(
 				{
@@ -316,9 +317,9 @@ export default function TrafficNodes({
 		if (!targets.length) return undefined;
 		return {
 			left: Math.min(...targets.map((p) => p.x)) - 70,
-			top: Math.min(...targets.map((p) => p.y)) - 86 - speakerPad,
+			top: Math.min(...targets.map((p) => p.y)) - SCENE_PAD_Y - speakerPad,
 			right: Math.max(...targets.map((p) => p.x + p.width)) + 70,
-			bottom: Math.max(...targets.map((p) => p.y + p.height)) + 86,
+			bottom: Math.max(...targets.map((p) => p.y + p.height)) + SCENE_PAD_Y,
 		};
 	}, [scene.groups, scene.placed, speakerPad]);
 	const resizeFollow = useRef<(() => void) | null>(null);
@@ -820,7 +821,7 @@ export default function TrafficNodes({
 			>
 				{scene.groups.map(group => (
 					<div key={group.projectId} className="traffic-project-group" style={{ left: group.x, top: group.y, width: group.width, height: group.height }}>
-						<div className="traffic-project-heading" style={{ transform: `scale(${1 / view.scale})`, width: Math.max(40, (group.width - 48) * view.scale) }}>
+						<div className="traffic-project-heading" style={{ top: headingTop(view.scale), transform: `scale(${1 / view.scale})`, width: headingWidth(group.width, view.scale) }}>
 							{projectById.get(group.projectId)?.name ?? t("traffic.orbit.project")}
 						</div>
 					</div>

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -52,6 +52,7 @@ import TrafficIcon from "./TrafficIcon";
 import TrafficMinimap from "./TrafficMinimap";
 import TrafficMessageBubble from "./TrafficMessageBubble";
 import TrafficNotificationCloud from "./TrafficNotificationCloud";
+import { cellSeqFontSize, cellSeqInk } from "./cell-seq";
 import { IDENTITY_SCALE, MAX_SCALE, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
@@ -1233,6 +1234,9 @@ function Card({
 	// card. It carries the projected status, so a parked card and a card with no
 	// recorded state get the bare strip — a ring would claim a stage neither has.
 	const railStatus = placed.parked ? null : (projection.status ?? null);
+	// No `#` at the cell tier: the glyph costs a fifth of the width and the
+	// number is already unmistakable.
+	const cellLabel = nodeSeq(node).replace(/^#/, "");
 	return (
 		<button
 			type="button"
@@ -1290,6 +1294,18 @@ function Card({
 						{latest.row.subject || latest.row.body.slice(0, 100)}
 					</span>
 				)}
+			</span>
+			{/* The whole card at the cell tier: the body is hidden there, and a
+			    rectangle with no number on it cannot be told from its neighbour. */}
+			<span
+				className="traffic-node-cell"
+				aria-hidden="true"
+				style={{
+					fontSize: cellSeqFontSize(cellLabel, placed.width, placed.height),
+					color: cellSeqInk(statusColor),
+				}}
+			>
+				{cellLabel}
 			</span>
 			<span className="traffic-node-compact">
 				<span className="traffic-node-head">

--- a/src/mainview/components/agent-traffic/cell-seq.ts
+++ b/src/mainview/components/agent-traffic/cell-seq.ts
@@ -1,0 +1,48 @@
+/**
+ * The seq number a card carries at the `cell` tier, where the body is hidden and
+ * the card is a bare coloured rectangle. Without it a zoomed-out stage is a wall
+ * of anonymous blocks.
+ */
+
+/** Width one digit takes at font-size 1, plus the side room left around the label. */
+const DIGIT_ADVANCE = 0.62;
+const USABLE_WIDTH = 0.72;
+/** Ceiling for a one-digit seq, which the width alone would let grow past the card. */
+const USABLE_HEIGHT = 0.78;
+
+/**
+ * Font size, in scene units, that keeps `label` inside a `width`×`height` card.
+ * A one-digit seq is height-bound and huge; each extra character makes the width
+ * bind harder, so `1883` and `49-1` shrink to roughly half of `4`.
+ */
+export function cellSeqFontSize(
+	label: string,
+	width: number,
+	height: number,
+): number {
+	const chars = Math.max(1, label.length);
+	return Math.round(
+		Math.min(
+			height * USABLE_HEIGHT,
+			(width * USABLE_WIDTH) / (chars * DIGIT_ADVANCE),
+		),
+	);
+}
+
+/**
+ * Ink that reads on a card filled with `background`. At this tier the fill is the
+ * raw status colour — bright pastels in dark theme, saturated mid-darks in light
+ * — so the choice is made per card from its own luminance, not from the theme.
+ */
+export function cellSeqInk(background: string | undefined): string {
+	const hex = /^#([0-9a-f]{6})$/i.exec(background?.trim() ?? "");
+	if (!hex) return "rgb(var(--text-primary))";
+	const value = Number.parseInt(hex[1], 16);
+	const channel = (shift: number) => {
+		const srgb = ((value >> shift) & 0xff) / 255;
+		return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+	};
+	const luminance =
+		0.2126 * channel(16) + 0.7152 * channel(8) + 0.0722 * channel(0);
+	return luminance > 0.36 ? "rgba(0, 0, 0, 0.72)" : "rgba(255, 255, 255, 0.86)";
+}

--- a/src/mainview/components/agent-traffic/group-heading.ts
+++ b/src/mainview/components/agent-traffic/group-heading.ts
@@ -1,0 +1,28 @@
+import { SCENE_PAD_Y } from "./traffic-camera";
+
+/** Screen height of the heading line plus the gap it keeps above the frame. */
+const HEADING_LIFT = 22;
+/** Screen width a project name gets even when its group is narrower than that. */
+const MIN_HEADING_WIDTH = 150;
+
+/**
+ * Where a project name sits, in scene units, above its group frame.
+ *
+ * The heading renders at a fixed screen size (it carries the inverse zoom), so
+ * in scene units it grows as the stage shrinks: left inside the frame it swallows
+ * the top padding and lands on the cards. It hangs above the frame instead, and
+ * never higher than the padding the scene bounds already reserve — beyond that
+ * the camera clamp would cut it off at the top of the viewport.
+ */
+export function headingTop(scale: number): number {
+	return -Math.min(HEADING_LIFT / scale, SCENE_PAD_Y);
+}
+
+/**
+ * Screen width the heading may use. A group zoomed down to 35px wide would clip
+ * its own name to two letters, which is the same as having no name at all, so a
+ * short name is allowed to overhang the frame it belongs to.
+ */
+export function headingWidth(groupWidth: number, scale: number): number {
+	return Math.max(MIN_HEADING_WIDTH, (groupWidth - 48) * scale);
+}

--- a/src/mainview/components/agent-traffic/traffic-camera.ts
+++ b/src/mainview/components/agent-traffic/traffic-camera.ts
@@ -11,6 +11,9 @@ type Viewport = { width: number; height: number };
 /** Highest zoom the stage ever reaches, framed or hand-driven. */
 export const MAX_SCALE = 2.2;
 
+/** Scene padding above and below the content — framing and the bounds share it. */
+export const SCENE_PAD_Y = 86;
+
 /** The scene's outer edge, padding included — what a camera may never overshoot. */
 export interface SceneBounds {
 	left: number;

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -465,6 +465,23 @@
 .traffic-nodes[data-detail="cell"] .traffic-node-card::before {
 	display: none;
 }
+.traffic-node-cell {
+	display: none;
+}
+/* The seq is the only thing left on the card here, so it owns the whole box.
+   Its size comes from the inline style — it scales with the card, not with the
+   zoom, so the number stays inside the rectangle at every scale. */
+.traffic-nodes[data-detail="cell"] .traffic-node-cell {
+	display: flex;
+	position: absolute;
+	inset: 0;
+	align-items: center;
+	justify-content: center;
+	font-weight: 700;
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: -0.02em;
+}
 .traffic-node-card.is-parked {
 	filter: grayscale(1);
 	opacity: 0.65;

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -113,9 +113,10 @@
 	background: rgb(var(--surface-raised) / 0.25);
 	pointer-events: none;
 }
+/* `top` and `width` come from the inline style — both depend on the zoom, see
+   group-heading.ts. The name hangs above the frame, never inside it. */
 .traffic-project-heading {
 	position: absolute;
-	top: 20px;
 	left: 24px;
 	transform-origin: top left;
 	font-size: 13px;


### PR DESCRIPTION
Zoomed all the way out, the Agent traffic graph was a wall of anonymous coloured rectangles with clipped project names lying on top of them. Two fixes.

**The task number on the card.** At the `cell` tier the card body is hidden, so the card now carries its seq instead — sized in scene units as `min(height × 0.78, width × 0.72 / (chars × 0.62))`, so a one-digit seq is huge, a four-digit one about half that, and neither ever leaves the rectangle at any zoom. The ink is picked per card from the luminance of its own status fill, which is a bright pastel in dark theme and a saturated mid-dark in light theme. The `#` is dropped — it costs a fifth of the width and the number reads fine without it.

**The project name above the frame.** The heading carries the inverse zoom, so at 14% its fixed 18px height is 128 scene units against a 64-unit top padding: it landed on the cards, and its width was capped at the group's on-screen width, which clipped `rts-dots2` to `rts-do…`. It now hangs above the frame by `min(22 / zoom, 86)` scene units — a constant 22px gap on screen, never higher than the padding the scene bounds already reserve, so the camera clamp cannot cut it off — and gets a 150px floor on its width.

New pure helpers `cell-seq.ts` and `group-heading.ts` with 11 unit tests; the scene's vertical padding is now the shared `SCENE_PAD_Y` constant. Verified in a browser at 14%, 23%, 62% and 127% in dark theme; light-theme ink is covered by tests, not by eye.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=8aaae2d2-0499-48a8-acda-ddcfd078a718) · `dev3://task/8aaae2d2-0499-48a8-acda-ddcfd078a718` _(dev3 added this footer — turn it off in Settings → Tasks.)_