### PR TITLE
Keep the New Task launch dialog's agent presets and favorites live

### DIFF
--- a/change-logs/2026/09/11/fix-live-agents-in-new-task-launch.md
+++ b/change-logs/2026/09/11/fix-live-agents-in-new-task-launch.md
@@ -1,0 +1,3 @@
+Short: Fresh presets in New Task launch
+
+The launch dialog opened from New Task (Scratch Task / Save & Start) now follows preset changes live instead of showing a snapshot taken the first time that modal was opened in the session, and starring a preset in Settings reaches every surface at once. Presets seeded by connecting a model provider, renames, duplicates and favorites pointing at them all appear without restarting the app.

--- a/decisions/2026/09/11/app-owned-agent-state-must-follow-the-push.md
+++ b/decisions/2026/09/11/app-owned-agent-state-must-follow-the-push.md
@@ -1,0 +1,43 @@
+# App-owned agent and favorites state must follow the pushes
+
+## Context
+
+The launch dialog reached from **New Task → Scratch Task / Save & Start** is rendered by
+`App.tsx` (`LaunchVariantsModal`), which fed it `agents` from local state loaded exactly once —
+the first time `createTaskProjectId` became set, guarded by `agentSettingsLoaded`. Connecting a
+model provider from inside that dialog seeds two `Best value` presets (`seedPresetForTier`), and
+they stayed invisible until the app restarted: the locked offers disappeared (correct — a provider
+now exists) and nothing replaced them, so the user was left with fewer options than before.
+Diagnosed in Seq 1884; every sibling surface (board `Run`, Spawn Agent, Bug Hunters, agent launch
+request) was already live through `useAgents()`.
+
+## Investigation
+
+`AgentConfigPicker` carried a comment asserting that the agent list "refreshes itself off the
+`agentsUpdated` push" — true everywhere except the one surface `App.tsx` owned, which is why the
+bug survived review. Favorites failed for a second, independent reason: `toggleFavoriteAgent`
+persisted the list and returned it to the caller, but never fanned out `globalSettingsUpdated`.
+The Settings screen keeps its own `globalSettings` state, so a star set there never reached
+`App.tsx`, and `resolveFavoriteChips` silently drops a favorite that does not resolve.
+
+## Decision
+
+`App.tsx` uses `useAgents()` (`src/mainview/hooks/useAgents.ts`) — no local agent state, no
+one-shot guard; analytics registration now re-runs off the same value. `toggleFavoriteAgent`
+(`src/bun/rpc-handlers/settings-config.ts`) pushes `globalSettingsUpdated` like
+`saveGlobalSettings` does. The rule going forward: no surface keeps a fetch-once copy of agents or
+settings, and every handler that mutates them fans out its push.
+
+## Risks
+
+`useAgents()` fetches on mount, so the agents RPC now runs at startup instead of on first New Task
+— it replaced an existing mount-time `getAgents()` call for analytics, so the call count is
+unchanged. The push echoes back to the renderer that triggered the toggle; it sets the same value,
+so the extra render is idempotent.
+
+## Alternatives considered
+
+Lifting the Settings screen's `globalSettings` into `App.tsx` would fix favorites without touching
+the handler, but it is a broad state refactor and would leave every other surface depending on
+prop plumbing instead of the push. Re-fetching settings when the launch dialog mounts would still
+go stale while the dialog is open.

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -1980,6 +1980,20 @@ describe("handlers.saveGlobalSettings", () => {
 		expect(push).toHaveBeenCalledWith("globalSettingsUpdated", settings);
 	});
 
+	// Starring a preset in Settings has to reach the launch dialog, which keeps
+	// its own copy of the settings: without the push the favorite was saved and
+	// invisible everywhere but the screen it was starred on.
+	it("broadcasts the settings after a favorite is toggled", async () => {
+		vi.mocked(loadSettings).mockResolvedValue({ updateChannel: "stable" } as GlobalSettings);
+		await handlers.toggleFavoriteAgent({ agentId: "builtin-claude", configId: "cfg-1" });
+		expect(push).toHaveBeenCalledWith(
+			"globalSettingsUpdated",
+			expect.objectContaining({
+				favorites: [expect.objectContaining({ agentId: "builtin-claude", configId: "cfg-1" })],
+			}),
+		);
+	});
+
 	// The renderer sends a whole snapshot taken when it loaded, and the analytics id
 	// is minted by the host afterwards — trusting the payload erased it, so the
 	// install got a fresh id (and lost its flag targeting) on every launch.

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -303,6 +303,9 @@ async function toggleFavoriteAgent(params: { agentId: string; configId: string }
 	const favorites = toggleFavorite(settings.favorites ?? [], params.agentId, params.configId, Date.now());
 	const next: GlobalSettings = { ...settings, favorites };
 	await saveSettings(next);
+	// Every other surface keeps its own copy of the settings — the Settings
+	// screen's star would otherwise never reach the launch dialog's favorites.
+	getPushMessage()?.("globalSettingsUpdated", next);
 	log.info("← toggleFavoriteAgent", { count: favorites.length });
 	return next;
 }

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -10,10 +10,11 @@ import { statusKey } from "./i18n/status";
 import { columnAgentFailureCopy } from "./utils/columnAgentFailureToast";
 import { handleMenuAction } from "./menuRouter";
 import { trackPageView, trackEvent, registerAgents } from "./analytics";
-import type { AgentLaunchChoice, AgentLaunchRequest, AppRPCSchema, CodingAgent, GlobalSettings as GlobalSettingsType, Project, RemoteAccessStatus, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskDialogSubject, TaskStatus, UpdateChangelog } from "../shared/types";
+import type { AgentLaunchChoice, AgentLaunchRequest, AppRPCSchema, GlobalSettings as GlobalSettingsType, Project, RemoteAccessStatus, RemoteNetInterface, RequirementCheckResult, RosettaWarningInfo, SharedArtifact, SharedImage, Task, TaskDialogSubject, TaskStatus, UpdateChangelog } from "../shared/types";
 import { orderProjectsForDisplay, getTaskTitle } from "../shared/types";
 import type { DeepLinkNav } from "../shared/deep-link";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
+import { useAgents } from "./hooks/useAgents";
 import { isRemote } from "./utils/platform";
 import { isTypingContext } from "./utils/typing-context";
 import { installHorizontalWheelBridge } from "./utils/horizontal-wheel";
@@ -477,8 +478,10 @@ function App() {
 			document.querySelector<HTMLButtonElement>("[data-testid='shared-artifacts-badge']")?.focus();
 		});
 	}, []);
-	const [agents, setAgents] = useState<CodingAgent[]>([]);
-	const [agentSettingsLoaded, setAgentSettingsLoaded] = useState(false);
+	// Live for the app's lifetime: the launch dialog this state feeds outlives
+	// every visit to Settings and every provider connect, so a fetch-once
+	// snapshot hid presets seeded or renamed after the first New Task modal.
+	const agents = useAgents();
 	const [globalSettings, setGlobalSettings] = useState<GlobalSettingsType>({
 		defaultAgentId: "builtin-claude",
 		defaultConfigId: "claude-auto",
@@ -2563,29 +2566,11 @@ function App() {
 		return () => window.removeEventListener("rpc:openCreateTaskModal", onOpenCreateTaskModal);
 	}, [openCreateTaskModal]);
 
-	// Load agents before the subsequent launch dialog opens. Skill autocomplete
-	// accepts both agent syntaxes because that dialog chooses the final agent.
-	const agentSettingsLoadingRef = useRef(false);
+	// Register agents with analytics so events like `task_moved` can carry a
+	// human-readable agent name, re-registering when a preset is renamed.
 	useEffect(() => {
-		if (!createTaskProjectId || agentSettingsLoaded || agentSettingsLoadingRef.current) return;
-		agentSettingsLoadingRef.current = true;
-		Promise.all([api.request.getAgents(), api.request.getGlobalSettings()])
-			.then(([nextAgents, nextSettings]) => {
-				setAgents(nextAgents);
-				setGlobalSettings(nextSettings);
-				setAgentSettingsLoaded(true);
-			})
-			.catch(() => {})
-			.finally(() => {
-				agentSettingsLoadingRef.current = false;
-			});
-	}, [agentSettingsLoaded, createTaskProjectId]);
-
-	// Register agents with analytics on mount so events like `task_moved` can
-	// carry a human-readable agent name (the modal load above is lazy).
-	useEffect(() => {
-		api.request.getAgents().then(registerAgents).catch(() => {});
-	}, []);
+		if (agents.length > 0) registerAgents(agents);
+	}, [agents]);
 
 	useEffect(() => {
 		function onOpenAddProjectModal() {

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -43,6 +43,13 @@ vi.mock("../rpc", () => ({
 				codex: { accounts: [], activeId: null, currentIdentity: null },
 			}),
 			getAgents: vi.fn().mockResolvedValue([]),
+			createTask: vi.fn(),
+			renameTask: vi.fn(),
+			setTaskLabels: vi.fn(),
+			spawnVariants: vi.fn(),
+			scheduleTaskLaunch: vi.fn(),
+			addAttempts: vi.fn(),
+			toggleTaskWatch: vi.fn(),
 			getGlobalSettings: vi.fn().mockResolvedValue({
 				defaultAgentId: "builtin-claude",
 				defaultConfigId: "claude-default",
@@ -2117,6 +2124,118 @@ describe("App keyboard shortcuts", () => {
 			});
 
 			expect(await screen.findByText("New Task")).toBeInTheDocument();
+		});
+	});
+
+	// The launch dialog that New Task opens is owned by App, and App used to load
+	// the presets exactly once per session. Connecting a provider from inside that
+	// dialog seeds new presets, and they stayed invisible until an app restart
+	// (Seq 1884): the offers vanished and nothing replaced them.
+	describe("New Task → launch dialog follows preset changes", () => {
+		const baseClaude = {
+			id: "builtin-claude",
+			name: "Claude",
+			baseCommand: "claude",
+			isDefault: true,
+			configurations: [{ id: "claude-default", name: "Default (Sonnet 5)", model: "claude-sonnet-5" }],
+			defaultConfigId: "claude-default",
+		};
+		const seededClaude = {
+			...baseClaude,
+			configurations: [
+				...baseClaude.configurations,
+				// The shape `seedPresetForTier` writes when a provider is connected:
+				// its own group label is what the Model field offers.
+				{
+					id: "best-value",
+					name: "Best value",
+					groupLabel: "Best value",
+					model: "claude-sonnet-5",
+					modelRoles: { main: "ds-v41-flash" },
+					seededTier: "practical" as const,
+				},
+			],
+		};
+
+		async function openLaunchDialogFromScratch() {
+			vi.mocked(api.request.getProjects).mockResolvedValue([
+				{ id: "p1", name: "Alpha", path: "/a", setupScript: "", devScript: "", cleanupScript: "", defaultBaseBranch: "main", createdAt: "" },
+			]);
+			vi.mocked(api.request.getLastRoute).mockResolvedValue({
+				route: JSON.stringify({ screen: "task", projectId: "p1", taskId: "t1" }),
+			});
+			vi.mocked(api.request.createTask).mockResolvedValue({
+				id: "t-scratch",
+				seq: 7,
+				projectId: "p1",
+				title: "Scratch — 12:00",
+				description: "Scratch — 12:00",
+				status: "todo",
+				baseBranch: "main",
+				worktreePath: null,
+				branchName: null,
+				groupId: null,
+				variantIndex: null,
+				agentId: null,
+				configId: null,
+				createdAt: "2026-01-01T00:00:00Z",
+				updatedAt: "2026-01-01T00:00:00Z",
+			});
+
+			await renderApp();
+			await userEvent.keyboard("{Meta>}n{/Meta}");
+			await userEvent.click(await screen.findByText("Scratch Task"));
+			// The launch dialog's Model field — proof onCreateAndRun landed.
+			await waitFor(() => expect(document.getElementById("variant-0-model")).toBeTruthy());
+			return document.getElementById("variant-0-model") as HTMLButtonElement;
+		}
+
+		async function modelOptionLabels(modelButton: HTMLButtonElement): Promise<string[]> {
+			await userEvent.click(modelButton);
+			const overlays = document.querySelectorAll(".bg-overlay.border");
+			const dropdown = overlays[overlays.length - 1];
+			const labels = Array.from(dropdown?.querySelectorAll("button") ?? []).map((b) => b.textContent?.trim() ?? "");
+			await userEvent.click(modelButton);
+			return labels;
+		}
+
+		it("offers a preset seeded after the dialog opened", async () => {
+			vi.mocked(api.request.getAgents).mockResolvedValue([baseClaude]);
+			const modelButton = await openLaunchDialogFromScratch();
+
+			expect((await modelOptionLabels(modelButton)).join("|")).not.toContain("Best value");
+
+			// What `saveAgents` fans out when Connect a provider seeds the presets.
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentsUpdated", { detail: [seededClaude] }));
+			});
+
+			expect((await modelOptionLabels(modelButton)).join("|")).toContain("Best value");
+		});
+
+		it("renders a favorite pointing at a preset that arrived on the push", async () => {
+			vi.mocked(api.request.getAgents).mockResolvedValue([baseClaude]);
+			vi.mocked(api.request.getGlobalSettings).mockResolvedValue({
+				defaultAgentId: "builtin-claude",
+				defaultConfigId: "claude-default",
+				taskSortOrder: "oldest-first",
+				updateChannel: "stable",
+				favorites: [{ agentId: "builtin-claude", configId: "best-value", uses: 1, lastUsedAt: 1 }],
+			});
+			await openLaunchDialogFromScratch();
+
+			const favTrigger = document.getElementById("variant-0-favorites") as HTMLButtonElement;
+			await userEvent.click(favTrigger);
+			// Unresolvable against the pre-push list, so the chip is dropped.
+			expect(document.body.textContent).not.toContain("Best value");
+			await userEvent.click(favTrigger);
+
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("rpc:agentsUpdated", { detail: [seededClaude] }));
+			});
+
+			await userEvent.click(favTrigger);
+			await waitFor(() => expect(document.body.textContent).toContain("Best value"));
 		});
 	});
 

--- a/src/mainview/components/AgentConfigPicker.tsx
+++ b/src/mainview/components/AgentConfigPicker.tsx
@@ -477,9 +477,9 @@ function AgentConfigPicker({
 				/>
 			)}
 
-			{/* Connecting seeds the catalog and the presets, and the agent list
-			    refreshes itself off the `agentsUpdated` push; only the catalog has no
-			    push of its own, so the picker re-reads it here. */}
+			{/* Connecting seeds the catalog and the presets. The presets arrive on the
+			    `agentsUpdated` push, which every owner of the `agents` prop must
+			    follow (`useAgents`); the catalog has no push, so re-read it here. */}
 			{connectOpen && (
 				<ConnectProviderModal
 					onClose={() => setConnectOpen(false)}


### PR DESCRIPTION
The launch dialog reached from **New Task → Scratch Task / Save & Start** showed a snapshot of the agent presets taken once per session, the first time that modal was ever opened. Anything created afterwards was invisible there until the app restarted — including the two `Best value` presets dev3 seeds when a model provider is connected. Connecting OpenRouter from inside that very dialog therefore left the user with strictly fewer options than before: the locked cheap-model offers correctly disappeared (a provider now exists) and their replacements never arrived. Diagnosed in Seq 1884.

Two independent defects were behind it.

1. `App.tsx` kept `agents` in local state loaded by a one-shot effect guarded by `agentSettingsLoaded`, and dropped the `agentsUpdated` push the backend fans out on every `saveAgents`. It now uses `useAgents()` — the same live hook every sibling surface (board `Run`, Spawn Agent, Bug Hunters, agent launch request) already used. Analytics registration re-runs off that value instead of its own mount-time fetch, so the RPC count is unchanged.
2. `toggleFavoriteAgent` persisted the favorite and returned it to its caller but never pushed `globalSettingsUpdated`. The Settings screen keeps its own settings copy, so a star set there reached nothing else, and `resolveFavoriteChips` silently drops a favorite it cannot resolve. It now pushes, exactly like `saveGlobalSettings`. This was not Seq 1884's predicted cause — `App.tsx` has followed that push for a long time; `globalSettings` was never frozen.

Also corrected: the comment in `AgentConfigPicker.tsx` claiming the agent list refreshes itself everywhere, which is what let the bug survive review.

Picker grouping, native models and the locked offers are untouched — no picker redesign, no state refactor.

## Coverage

Three regression tests, each verified to fail on a deliberately re-broken build rather than merely passing:

- `App.test.tsx` → "offers a preset seeded after the dialog opened" — renders **App**, drives Cmd+N → `Scratch Task` → the real `LaunchVariantsModal`, then dispatches `rpc:agentsUpdated` with a preset in the exact shape `seedPresetForTier` writes.
- `App.test.tsx` → "renders a favorite pointing at a preset that arrived on the push" — same App-owned path; the chip is asserted absent before the push and present after.
- `rpc-handlers.test.ts` → "broadcasts the settings after a favorite is toggled".

Verified live on an isolated seeded board (`DEV3_QA_SCOPE=seeded`), never against real state: connecting OpenRouter with a fabricated key from inside the launch dialog makes `Best value` and `Best value · Smart` selectable the moment the modal closes; a preset starred in Settings mid-session shows as a favorite chip and applies the whole Harness/Model/Mode triple; cancel-and-reopen stays fresh; 420 / 1440 / 2560 px all render and click. A routed launch was driven end to end — the sidecar started on demand for that instance and the agent session reported `openrouter/ds-v41-flash[1m]` — with no upstream request and no paid inference.

Decision record: `decisions/2026/09/11/app-owned-agent-state-must-follow-the-push.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=fd8ded03-c111-417a-96d8-394735eb0109) · `dev3://task/fd8ded03-c111-417a-96d8-394735eb0109` _(dev3 added this footer — turn it off in Settings → Tasks.)_