### PR TITLE
Keep the traffic speaker clear of cards and stop clipping their words

### DIFF
--- a/change-logs/2026/09/11/fix-traffic-speaker-clearance.md
+++ b/change-logs/2026/09/11/fix-traffic-speaker-clearance.md
@@ -1,0 +1,3 @@
+Short: User's words never land on a card
+
+In Agent traffic, the person and their speech bubble now step aside to the nearest free space when the card above their recipient is taken — a short dashed tether keeps the recipient unambiguous — and the bubble shows four whole lines instead of two plus a sliced third.

--- a/src/mainview/__tests__/agent-traffic-ui.test.tsx
+++ b/src/mainview/__tests__/agent-traffic-ui.test.tsx
@@ -1203,8 +1203,16 @@ it("puts the person over the task they wrote to, with their words above their he
 	// Bubble, then head, then the card that received the message.
 	expect(bubble.parentElement).toBe(speaker);
 	const [card] = screen.getAllByTestId("traffic-node-card");
-	expect(parseFloat(speaker.style.top)).toBeLessThan(parseFloat(card.style.top));
-	expect(speaker.style.left).toBe(card.style.left);
+	// Nothing stands in that space here, so the pair keeps it: centred on the card,
+	// clear of its top edge, and no tether to explain a move they did not make.
+	expect(speaker.dataset.placement).toBe("above");
+	expect(parseFloat(speaker.style.top) + parseFloat(speaker.style.height))
+		.toBeLessThan(parseFloat(card.style.top));
+	expect(parseFloat(speaker.style.left) + parseFloat(speaker.style.width) / 2)
+		.toBe(parseFloat(card.style.left) + parseFloat(card.style.width) / 2);
+	expect(screen.queryByTestId("traffic-speaker-tether")).toBeNull();
+	// Four lines of what they said, in a box that does not slice the fifth.
+	expect(bubble.firstElementChild?.className).toBe("traffic-user-speech-text");
 	// And the wire's own subject bubble does not say the same thing twice.
 	expect(document.querySelector(".traffic-edge-subject")).toBeNull();
 });

--- a/src/mainview/__tests__/speaker-placement.test.ts
+++ b/src/mainview/__tests__/speaker-placement.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+	placeSpeaker,
+	SPEAKER_GAP,
+	SPEAKER_HEIGHT,
+	SPEAKER_WIDTH,
+	type SpeakerRect,
+} from "../components/agent-traffic/speaker-placement";
+
+const card = (x: number, y: number, width = 300, height = 234): SpeakerRect => ({ x, y, width, height });
+
+const overlaps = (a: SpeakerRect, b: SpeakerRect) =>
+	a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
+
+describe("placeSpeaker", () => {
+	it("stands the pair over the card they wrote to when that space is free", () => {
+		const recipient = card(600, 800);
+		const spot = placeSpeaker(recipient, [recipient]);
+		expect(spot.natural).toBe(true);
+		expect(spot.tether).toBeUndefined();
+		// Centred on the card, feet a gap above its top edge.
+		expect(spot.x + spot.width / 2).toBe(recipient.x + recipient.width / 2);
+		expect(spot.y + spot.height).toBe(recipient.y - SPEAKER_GAP);
+	});
+
+	it("moves the pair off a card that stands where they would have stood", () => {
+		// The screenshot case: a coordinator above the grid, the person writing to a
+		// card in the top row directly under it.
+		const recipient = card(600, 800);
+		const coordinator = card(560, 460, 370, 234);
+		const spot = placeSpeaker(recipient, [recipient, coordinator]);
+		expect(spot.natural).toBe(false);
+		expect(overlaps(spot, coordinator)).toBe(false);
+		expect(overlaps(spot, recipient)).toBe(false);
+	});
+
+	it("draws a tether between the displaced pair and the recipient", () => {
+		const recipient = card(600, 800);
+		const spot = placeSpeaker(recipient, [recipient, card(560, 460, 370, 234)]);
+		const tether = spot.tether!;
+		expect(tether).toBeDefined();
+		// It leaves the person themselves — the middle of the box, not its corner —
+		// and lands on the recipient's own edge.
+		expect(tether.from.x).toBe(spot.x + spot.width / 2);
+		expect(tether.to.x).toBeGreaterThanOrEqual(recipient.x);
+		expect(tether.to.x).toBeLessThanOrEqual(recipient.x + recipient.width);
+		expect(tether.to.y).toBeGreaterThanOrEqual(recipient.y);
+		expect(tether.to.y).toBeLessThanOrEqual(recipient.y + recipient.height);
+		const run = Math.hypot(tether.to.x - tether.from.x, tether.to.y - tether.from.y);
+		expect(run).toBeLessThanOrEqual(SPEAKER_WIDTH);
+	});
+
+	it("keeps clear of every card in a dense grid, not only the one above", () => {
+		// Four neighbours in a row plus a coordinator over the middle: the only free
+		// air is to the side, and the pair has to find it.
+		const recipient = card(600, 800);
+		const cards = [
+			card(0, 800), card(300, 800), recipient, card(900, 800), card(1200, 800),
+			card(560, 500, 370, 234),
+		];
+		const spot = placeSpeaker(recipient, cards);
+		for (const other of cards) expect(overlaps(spot, other)).toBe(false);
+	});
+
+	it("follows the recipient when replay reorders the grid", () => {
+		// Same message, same cards, different order: the pair belongs to whichever
+		// card holds the recipient now, not to where it stood a step ago.
+		const first = card(300, 800);
+		const second = card(900, 800);
+		expect(placeSpeaker(first, [first, second]).x).toBeLessThan(
+			placeSpeaker(second, [first, second]).x,
+		);
+	});
+
+	it("reserves the pair's real footprint, bubble included", () => {
+		const spot = placeSpeaker(card(0, 600), []);
+		expect(spot.width).toBe(SPEAKER_WIDTH);
+		expect(spot.height).toBe(SPEAKER_HEIGHT);
+	});
+
+	it("takes the least covered spot rather than none when the stage is full", () => {
+		// Boxed in on every side. There is no clean answer, and refusing to draw the
+		// person would be worse than drawing them somewhere legible-ish with a tether.
+		const recipient = card(600, 800);
+		const walls = [
+			recipient,
+			card(600, 400, 300, 380),
+			card(100, 700, 480, 400),
+			card(920, 700, 480, 400),
+			card(600, 1052, 300, 380),
+		];
+		const spot = placeSpeaker(recipient, walls);
+		expect(spot.natural).toBe(false);
+		expect(spot.tether).toBeDefined();
+		expect(overlaps(spot, recipient)).toBe(false);
+	});
+});

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -25,6 +25,13 @@ import {
 	type PlacedNode,
 } from "./nodes-layout";
 import {
+	placeSpeaker,
+	SPEAKER_GAP,
+	SPEAKER_HEIGHT,
+	SPEAKER_WIDTH,
+	type SpeakerPlacement,
+} from "./speaker-placement";
+import {
 	projectTaskAt,
 	type TaskProjection,
 } from "./task-history";
@@ -231,6 +238,11 @@ export default function TrafficNodes({
 		() => new Map(scene.placed.map((node) => [node.node.key, node])),
 		[scene.placed],
 	);
+	/** The cards as they stand now, for the camera's speaker placement. */
+	const placedRef = useRef(scene.placed);
+	placedRef.current = scene.placed;
+	/** Where the person stands right now, or null when nobody is speaking. */
+	const speakerRef = useRef<SpeakerPlacement | null>(null);
 	const projectById = useMemo(
 		() => new Map((projects ?? []).map((project) => [project.id, project])),
 		[projects],
@@ -310,16 +322,22 @@ export default function TrafficNodes({
 			fitNodes(scene.groups.length ? scene.groups : scene.placed, 0.85, instant, exact ? 0 : IDENTITY_SCALE),
 		[fitNodes, scene.placed, scene.groups],
 	);
-	/** The scene's outer edge with the same padding `fitNodes` leaves around it. */
+	/**
+	 * The scene's outer edge with the same padding `fitNodes` leaves around it —
+	 * and, when a person may speak, room on every side rather than only above.
+	 * This box is what the camera clamps an exchange to, so a pair standing below
+	 * or beside the outermost card is pushed back off-screen without it.
+	 */
 	const sceneBounds = useMemo(() => {
 		const targets: { x: number; y: number; width: number; height: number }[] =
 			scene.groups.length ? scene.groups : scene.placed;
 		if (!targets.length) return undefined;
+		const sideways = speakerPad ? SPEAKER_WIDTH + SPEAKER_GAP : 0;
 		return {
-			left: Math.min(...targets.map((p) => p.x)) - 70,
+			left: Math.min(...targets.map((p) => p.x)) - 70 - sideways,
 			top: Math.min(...targets.map((p) => p.y)) - SCENE_PAD_Y - speakerPad,
-			right: Math.max(...targets.map((p) => p.x + p.width)) + 70,
-			bottom: Math.max(...targets.map((p) => p.y + p.height)) + SCENE_PAD_Y,
+			right: Math.max(...targets.map((p) => p.x + p.width)) + 70 + sideways,
+			bottom: Math.max(...targets.map((p) => p.y + p.height)) + SCENE_PAD_Y + speakerPad,
 		};
 	}, [scene.groups, scene.placed, speakerPad]);
 	const resizeFollow = useRef<(() => void) | null>(null);
@@ -398,11 +416,10 @@ export default function TrafficNodes({
 				[sender.node.key, recipient.node.key].sort().join("|"),
 			);
 			// A message from a person has no sender card and no wire: the human is
-			// drawn over the recipient, so the frame has to hold the strip above it
-			// or the camera centres the card and the speaker falls off the top.
-			const speaking = isUserOrigin(record.row)
-				? [{ ...recipient, y: recipient.y - SPEAKER_RESERVE, height: SPEAKER_RESERVE }]
-				: [];
+			// drawn beside the recipient, so the frame has to hold the box they will
+			// actually take — wherever the collision search puts it — or the camera
+			// centres the card and the speaker falls off the edge.
+			const speaking = isUserOrigin(record.row) ? [placeSpeaker(recipient, placedRef.current)] : [];
 			move(
 				frameExchange(viewport, sender ? [sender, recipient] : [recipient, ...speaking], edge?.points ?? [], sceneBounds),
 				reduced,
@@ -423,8 +440,12 @@ export default function TrafficNodes({
 			const node = nodeByKey.get(nodeKey);
 			if (!viewport.width || !viewport.height || !node) return;
 			overviewMode.current = false;
+			// A board move does not take the person away — the step before it may
+			// still be theirs, exactly as the wire it lit stays lit. So whoever is
+			// on the stage is framed with the card, or their words go under the
+			// toolbar while they are still being said.
 			move(
-				frameExchange(viewport, [node], [], sceneBounds),
+				frameExchange(viewport, [node, ...(speakerRef.current ? [speakerRef.current] : [])], [], sceneBounds),
 				reduced,
 				playback?.playing ? Math.min(500, playback.intervalMs * 0.9) : 500,
 			);
@@ -728,13 +749,16 @@ export default function TrafficNodes({
 	// message — no card in the grid, no wire, nothing left behind. Text, lifetime
 	// and hidden-while-offscreen behaviour are the wire bubble's; only the anchor
 	// and the fact that a human is drawn at all are new.
+	// Where they stand is decided against the cards as they are laid out right
+	// now, so a replay step that reorders the grid moves the pair with it.
 	const speaker = active && activeRecipient && isUserOrigin(active.row)
 		? {
-			at: activeRecipient,
+			at: placeSpeaker(activeRecipient, scene.placed),
 			text: active.row.subject || active.row.body.slice(0, 120),
 			failed: active.row.status === "not-delivered",
 		}
 		: null;
+	speakerRef.current = speaker?.at ?? null;
 	const labelPoint = activeEdge ? pointAt(activeEdge.points, 0.5) : activeRecipient ?
 		{ x: activeRecipient.x + activeRecipient.width / 2, y: activeRecipient.y } : undefined;
 	const detail = detailTier(view.scale);
@@ -833,6 +857,21 @@ export default function TrafficNodes({
 					viewBox={`0 0 ${scene.width} ${scene.height}`}
 					aria-hidden="true"
 				>
+					{/* Only when the pair had to move: a short run from them to the card
+					    they are talking to, so standing elsewhere never costs the reader
+					    the answer to "to whom?". Same scale-invariant stroke as a wire. */}
+					{speaker?.at.tether && (
+						<line
+							data-testid="traffic-speaker-tether"
+							className="traffic-speaker-tether"
+							x1={speaker.at.tether.from.x}
+							y1={speaker.at.tether.from.y}
+							x2={speaker.at.tether.to.x}
+							y2={speaker.at.tether.to.y}
+							strokeWidth={2 / view.scale}
+							strokeDasharray={`${6 / view.scale} ${5 / view.scale}`}
+						/>
+					)}
 					{scene.edges.map((edge) => {
 						const visiblePair = visiblePairs.get(edge.key);
 						if (replaying && !visiblePair) return null;
@@ -1128,10 +1167,8 @@ function CompletionBurst({
 	);
 }
 
-/** Air between the person's feet and the top edge of the card they wrote to. */
-const SPEAKER_GAP = 18;
 /** Strip the camera keeps clear above the cards for a person who may speak. */
-const SPEAKER_RESERVE = 210;
+const SPEAKER_RESERVE = SPEAKER_HEIGHT + SPEAKER_GAP;
 
 /**
  * The person using the app, for as long as one of their messages is playing.
@@ -1144,7 +1181,7 @@ const SPEAKER_RESERVE = 210;
  * false about a person.
  */
 function UserSpeaker({ at, text, failed }: {
-	at: PlacedNode;
+	at: SpeakerPlacement;
 	text: string;
 	failed: boolean;
 }) {
@@ -1153,16 +1190,21 @@ function UserSpeaker({ at, text, failed }: {
 		<div
 			data-testid="traffic-user-speaker"
 			className="traffic-user-speaker"
-			// Anchored by its feet — the CSS lifts it by its own height, so a
-			// two-line bubble grows upwards instead of pushing into the card.
-			style={{ left: at.x, top: at.y - SPEAKER_GAP, width: at.width }}
+			data-placement={at.natural ? "above" : "displaced"}
+			// The box is the pair's real footprint, the same one the collision
+			// search and the camera used — bubble, air, head and label — so what is
+			// reserved on the stage is what is drawn on it.
+			style={{ left: at.x, top: at.y, width: at.width, height: at.height }}
 			aria-label={t("traffic.node.you")}
 		>
 			<span
 				data-testid="traffic-user-speech"
 				className={`traffic-user-speech streamer-private ${failed ? "is-failed" : ""}`}
 			>
-				{text}
+				{/* The clamp lives on the inner span, which carries no padding: on a
+				    padded box WebKit hides the overflow at the content edge and the
+				    padding below it shows the top of the next line, sliced. */}
+				<span className="traffic-user-speech-text">{text}</span>
 			</span>
 			<span className="traffic-user-disc"><TrafficIcon name="user" /></span>
 			<strong>{t("traffic.node.you")}</strong>

--- a/src/mainview/components/agent-traffic/speaker-placement.ts
+++ b/src/mainview/components/agent-traffic/speaker-placement.ts
@@ -1,0 +1,103 @@
+/**
+ * Where the transient person and their speech bubble stand.
+ *
+ * The natural place is directly above the card they wrote to, and that is the
+ * first thing tried. It is not always free: a coordinator sits above the grid,
+ * and replay reorders the cards under the cursor, so the same recipient is above
+ * open space in one step and under a card in the next. When the natural place is
+ * taken the pair moves together to the nearest free space and a short tether
+ * says which card they are talking to.
+ */
+
+export interface SpeakerRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+/** Bubble, air, head and label — what the pair actually occupies on the stage. */
+export const SPEAKER_WIDTH = 292;
+export const SPEAKER_HEIGHT = 212;
+/** Air between the pair and whatever it stands next to. */
+export const SPEAKER_GAP = 18;
+/** Cards are given this much elbow room so the pair never grazes one. */
+const CLEARANCE = 12;
+/** Box bottom → the middle of the head: where a tether leaves the person. */
+const LABEL_TO_HEAD = 66;
+
+export interface SpeakerPlacement extends SpeakerRect {
+	/** False when the pair stands anywhere but its natural spot above the card. */
+	natural: boolean;
+	/** Drawn only when displaced: pair edge → recipient edge, shortest run. */
+	tether?: { from: { x: number; y: number }; to: { x: number; y: number } };
+}
+
+const overlap = (a: SpeakerRect, b: SpeakerRect) =>
+	Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x)) *
+	Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y));
+
+/** The point of `rect` closest to `point` — where a tether meets a box. */
+function nearest(rect: SpeakerRect, point: { x: number; y: number }) {
+	return {
+		x: Math.min(Math.max(point.x, rect.x), rect.x + rect.width),
+		y: Math.min(Math.max(point.y, rect.y), rect.y + rect.height),
+	};
+}
+
+/**
+ * @param recipient the card the message went to
+ * @param cards every card on the stage, recipient included
+ */
+export function placeSpeaker(
+	recipient: SpeakerRect,
+	cards: SpeakerRect[],
+	size: { width: number; height: number } = { width: SPEAKER_WIDTH, height: SPEAKER_HEIGHT },
+): SpeakerPlacement {
+	const { width, height } = size;
+	const midX = recipient.x + recipient.width / 2 - width / 2;
+	const above = recipient.y - SPEAKER_GAP - height;
+	const below = recipient.y + recipient.height + SPEAKER_GAP;
+	const left = recipient.x - SPEAKER_GAP - width;
+	const right = recipient.x + recipient.width + SPEAKER_GAP;
+	// Ordered by how little the reader has to move their eyes from the card.
+	const candidates: SpeakerRect[] = [
+		{ x: midX, y: above, width, height },
+		{ x: left, y: recipient.y + recipient.height - height, width, height },
+		{ x: right, y: recipient.y + recipient.height - height, width, height },
+		{ x: left, y: above, width, height },
+		{ x: right, y: above, width, height },
+		{ x: midX, y: below, width, height },
+	];
+	const blockers = cards.map((card) => ({
+		x: card.x - CLEARANCE,
+		y: card.y - CLEARANCE,
+		width: card.width + CLEARANCE * 2,
+		height: card.height + CLEARANCE * 2,
+	}));
+	let best = candidates[0];
+	let bestCost = Infinity;
+	for (const [index, candidate] of candidates.entries()) {
+		const cost = blockers.reduce((sum, card) => sum + overlap(candidate, card), 0);
+		if (cost === 0) return index === 0 ? { ...candidate, natural: true } : tethered(candidate, recipient);
+		if (cost < bestCost) {
+			bestCost = cost;
+			best = candidate;
+		}
+	}
+	// Every spot is taken — the least covered one still reads better than a pair
+	// sitting squarely on a card, and the tether keeps the recipient unambiguous.
+	return best === candidates[0] ? { ...best, natural: true } : tethered(best, recipient);
+}
+
+function tethered(pair: SpeakerRect, recipient: SpeakerRect): SpeakerPlacement {
+	// From the person, not from the corner of their reserved box: a short line
+	// leaving thin air reads as a stray mark, one leaving their feet reads as
+	// theirs. The box is wider than they are whenever the bubble is narrow.
+	const feet = { x: pair.x + pair.width / 2, y: pair.y + pair.height - LABEL_TO_HEAD };
+	return {
+		...pair,
+		natural: false,
+		tether: { from: feet, to: nearest(recipient, feet) },
+	};
+}

--- a/src/mainview/components/agent-traffic/traffic-camera.ts
+++ b/src/mainview/components/agent-traffic/traffic-camera.ts
@@ -123,7 +123,9 @@ export function clampToBounds(
 
 export function frameExchange(
 	viewport: Viewport,
-	nodes: PlacedNode[],
+	// Rectangles, not cards: the transient speaker is framed the same way and has
+	// no node behind it.
+	nodes: Pick<PlacedNode, "x" | "y" | "width" | "height">[],
 	route: Point[],
 	bounds?: SceneBounds,
 ): CameraView {

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -237,12 +237,11 @@
 	pointer-events: none;
 	text-align: center;
 	color: rgb(var(--text-primary));
-	transform: translateY(-100%);
 	animation: traffic-speaker-in 0.22s cubic-bezier(0.2, 0, 0, 1);
 }
 @keyframes traffic-speaker-in {
-	from { opacity: 0; transform: translateY(calc(-100% + 6px)); }
-	to { opacity: 1; transform: translateY(-100%); }
+	from { opacity: 0; transform: translateY(6px); }
+	to { opacity: 1; transform: translateY(0); }
 }
 @media (prefers-reduced-motion: reduce) {
 	.traffic-user-speaker {
@@ -274,17 +273,13 @@
 }
 /* What the person is saying, over their own head. Same bubble language as the
    wire subject, but glued to the person in scene space instead of chasing a
-   point on the wire — a speaker's words do not float away from the speaker. */
+   point on the wire — a speaker's words do not float away from the speaker.
+   In the flow of the pair, not absolute over it: the box the collision search
+   reserved is only honest if the bubble takes its share of it. */
 .traffic-user-speech {
 	--message-tone: var(--agent);
-	position: absolute;
-	bottom: calc(100% + 14px);
-	left: 50%;
-	transform: translateX(-50%);
-	display: -webkit-box;
-	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;
-	overflow: hidden;
+	position: relative;
+	margin-bottom: 6px;
 	width: max-content;
 	max-width: 264px;
 	padding: 9px 13px;
@@ -296,8 +291,27 @@
 	line-height: 1.35;
 	text-align: left;
 }
+/* Four lines, and the fourth is whole. The clamp sits here rather than on the
+   padded bubble because WebKit clips a -webkit-box at its content edge, so on a
+   padded box the line after the clamp shows through the padding, cut in half. */
+.traffic-user-speech-text {
+	display: -webkit-box;
+	-webkit-line-clamp: 4;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	/* The clamp already hides the fifth line; the 2px is slack against sub-pixel
+	   rounding, which would otherwise shave the bottom of the fourth. */
+	max-height: calc(4 * 1.35em + 2px);
+}
 .traffic-user-speech.is-failed {
 	--message-tone: var(--danger);
+}
+/* The run from a displaced pair to the card they wrote to. Accent, dashed and
+   short: it names a recipient, it is not a wire carrying traffic. */
+.traffic-speaker-tether {
+	stroke: rgb(var(--accent) / 0.75);
+	stroke-linecap: round;
+	fill: none;
 }
 .traffic-user-speech::after {
 	content: "";


### PR DESCRIPTION
In Agent traffic (Experiment 2) the transient person and their speech bubble had two problems, both visible in replay.

**The bubble sliced a line in half.** `-webkit-line-clamp` sat on the padded bubble itself, and WebKit clips a `-webkit-box` at its content edge — so the line after the clamp showed through the bottom padding, cut across the middle. The clamp now lives on an inner unpadded span, and the limit goes from 2 lines to 4.

**The pair landed on top of a card.** The person was anchored directly above the recipient. Above the top row that space belongs to the coordinator, and replay reorders the grid between steps, so the same recipient is under open air in one step and under a card in the next. A new `speaker-placement.ts` treats the pair as a real 292×212 box (bubble, air, head, label) and tests it against every placed card: six candidates ordered by how little the reader's eye has to travel — above, left, right, above-left, above-right, below — first free one wins, least-covered one as a fallback. Placement is recomputed from the current layout each render, so a reorder carries the pair along with its recipient. When the pair is displaced, a short dashed accent line runs from the head to the nearest edge of the recipient card, so "to whom" is never ambiguous.

Two camera fixes fall out of that: `sceneBounds` now leaves room on all four sides rather than only above (the camera clamps an exchange to that box, so a pair standing below or beside the outermost card was pushed off-screen), and a board-move step — which keeps the speaker on stage, exactly as it keeps the lit wire — frames the speaker together with the card instead of letting the bubble slide under the toolbar.

Unchanged: no permanent "You" node, same lifetime, history, live/replay behaviour and card ordering; no new controls.

**Verification.** `bun run lint` clean. Seven new unit tests in `speaker-placement.test.ts` (natural spot, dodging a coordinator, the tether, a dense grid, a replay reorder, the honest footprint, everything-occupied). Whole renderer suite across 4 shards: 5 599 tests green. Live headless-Chromium pass on the real board, Experiment 2 → Replay, over all 22 user-origin steps out of 121: zero overlaps with cards, the pair fully inside the stage on every step, the tether appearing exactly where the space was taken, clean console. On a message that runs past four lines the inner box measures exactly four lines and the fifth is hidden whole (`scrollHeight` 88 vs `clientHeight` 70).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=d55d9056-8259-47a6-bd4b-83c92787a558) · `dev3://task/d55d9056-8259-47a6-bd4b-83c92787a558` _(dev3 added this footer — turn it off in Settings → Tasks.)_