### PR TITLE
Turn off Codex's decorative composer stars by default

### DIFF
--- a/change-logs/2026/09/11/fix-codex-composer-stars-off-by-default.md
+++ b/change-logs/2026/09/11/fix-codex-composer-stars-off-by-default.md
@@ -1,0 +1,3 @@
+Short: Codex composer stars off by default
+
+Codex draws decorative "Astra composer stars" behind the input and repaints them every 150ms for as long as the composer is visible, so an idle pane streams around 187 KB every 20 seconds for nothing. dev3 now seeds `tui.whimsy = false` into `~/.codex/config.toml` — written once when the key is absent, so anyone who sets it back to `true` keeps the stars.

--- a/decisions/2026/09/11/seed-codex-whimsy-false-once.md
+++ b/decisions/2026/09/11/seed-codex-whimsy-false-once.md
@@ -1,0 +1,54 @@
+# Seed Codex's `tui.whimsy = false` once, never force it
+
+## Context
+
+Codex draws "Astra composer stars" — sparse braille dots — over the area behind the
+input, and repaints them every 150 ms for as long as the composer is on screen
+(`codex-rs/tui/src/bottom_pane/chat_composer/sparkle.rs`, `FRAME_TICK`). Measured on
+codex-cli 0.154.0 inside a dev3 pane: an **idle** pane emits 187 581 bytes in 20 s,
+and 3 677 of those braille glyphs appeared in one 20 s capture. In dev3 that traffic
+crosses a PTY, a WebSocket and a canvas renderer for decoration nobody asked for.
+
+The effect exists only because the model happens to be named `*astra*` — that is one
+of its four gates, alongside `tui.whimsy`, `tui.animations`, and a TrueColor stdout.
+
+## Investigation
+
+`tui.whimsy` is the precise switch: *"Enable decorative effects such as Astra
+composer stars"* (`codex-rs/config/src/types.rs`), default `true`.
+`tui.animations = false` would also kill it but takes the welcome screen, shimmer and
+spinners with it. The `terminal_resize_reflow` feature flag next to it is stage
+`removed`, so feature flags are not a route here at all.
+
+## Decision
+
+`ensureCodexConfig` (`src/bun/codex-config.ts`, step 6) writes
+`[tui] whimsy = false` — but **only when the key is absent**, checked against the
+parsed config, not the raw text. Both existing callers reach it: app startup
+(`ensureCodexConfigFile`, `src/bun/index.ts`) and worktree creation
+(`ensureCodexTrust`, `src/bun/agents.ts`). Managed Codex accounts symlink
+`config.toml` from `~/.codex`, so they inherit it.
+
+Seed-once rather than force, because forcing would silently undo the choice of a user
+who puts the stars back, on every single app start. Codex's own default is `true` and
+nobody writes it out explicitly, so in practice every install still gets the quiet
+default.
+
+## Risks
+
+- A user who liked the stars and never wrote the key loses them once, with no
+  announcement. Re-enabling is one line in their own config and dev3 then leaves it
+  alone — pinned by `codex-config.test.ts`.
+- A managed account whose `config.toml` is a real file instead of a symlink (it
+  happens when `~/.codex/config.toml` did not exist at account-creation time, see
+  `ensureCodexAccountHome`) never receives this, or any other, patch. That is a
+  pre-existing gap in account setup, deliberately not fixed here.
+
+## Alternatives considered
+
+- **Force it on every start.** Simple, and the reason it was rejected is above.
+- **`tui.animations = false`.** Wider blast radius for the same symptom.
+- **A dev3 setting with a UI toggle.** A whole surface for one decorative loop; the
+  user's own `config.toml` already is the toggle.
+- **Leave it and document it.** The cost is per-frame and permanent, and a user who
+  has never read `sparkle.rs` cannot connect an idle pane's traffic to it.

--- a/src/bun/__tests__/codex-config.test.ts
+++ b/src/bun/__tests__/codex-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { load } from "js-toml";
 import {
 	ensureCodexConfig,
 	codexServersWithTransport,
@@ -978,5 +979,74 @@ describe.each([
 			expect((healed.match(/^command = /gm) ?? []).length).toBe(6);
 			expect(count(healed, ourCommandLine)).toBe(6);
 		}
+	});
+});
+
+// ── [tui] whimsy — Codex's Astra composer stars ──────────────────────────────
+//
+// The stars repaint behind the input every 150ms for as long as the composer is
+// visible, so an idle pane streams ~187 KB every 20 seconds for decoration. dev3
+// seeds the quiet default, and must never overrule a user who wants them back.
+
+describe("ensureCodexConfig — [tui] whimsy", () => {
+	const WORKTREES_PATH = "/Users/testuser/.dev3.0/worktrees";
+	const SOCKETS_PATH = "/Users/testuser/.dev3.0/sockets";
+	const ensure = (content: string | null) =>
+		ensureCodexConfig(content, WORKTREES_PATH, SOCKETS_PATH);
+
+	it("seeds whimsy = false into a fresh config", () => {
+		const config = ensure(null);
+		expect(config).toContain("[tui]");
+		expect(config).toContain("whimsy = false");
+	});
+
+	it("adds whimsy to a [tui] section the user already has, keeping their other keys", () => {
+		const existing = `model = "gpt-6-astra"
+
+[tui]
+theme = "github"
+status_line = ["git-branch"]
+`;
+		const config = ensure(existing);
+		expect(config).toContain("whimsy = false");
+		expect(config).toContain('theme = "github"');
+		expect(config).toContain('status_line = ["git-branch"]');
+		// One [tui] section, not a second one appended below.
+		expect((config.match(/^\[tui\]$/gm) ?? []).length).toBe(1);
+	});
+
+	it("leaves an explicit whimsy = true alone — the user asked for the stars", () => {
+		const existing = `[tui]
+whimsy = true
+`;
+		const config = ensure(existing);
+		expect(config).toContain("whimsy = true");
+		expect(config).not.toContain("whimsy = false");
+	});
+
+	it("leaves an explicit whimsy = false alone rather than rewriting it", () => {
+		const existing = `[tui]
+whimsy = false
+`;
+		const config = ensure(existing);
+		expect((config.match(/^whimsy = /gm) ?? []).length).toBe(1);
+	});
+
+	it("is idempotent — a second pass adds nothing", () => {
+		const once = ensure(null);
+		const twice = ensure(once);
+		expect((twice.match(/^whimsy = /gm) ?? []).length).toBe(1);
+		expect((twice.match(/^\[tui\]$/gm) ?? []).length).toBe(1);
+	});
+
+	it("writes a config Codex can still parse", () => {
+		const config = ensure(`model = "gpt-6-astra"
+
+[tui]
+theme = "github"
+`);
+		const parsed = load(config) as { tui?: Record<string, unknown> };
+		expect(parsed.tui?.whimsy).toBe(false);
+		expect(parsed.tui?.theme).toBe("github");
 	});
 });

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -42,6 +42,7 @@ interface CodexConfig {
 	projects?: Record<string, { trust_level?: string; sandbox_mode?: string }>;
 	profiles?: Record<string, Record<string, unknown>>;
 	permissions?: Record<string, CodexPermissionsProfile | undefined>;
+	tui?: Record<string, unknown>;
 }
 
 interface CodexConfigOptions {
@@ -899,7 +900,23 @@ export function ensureCodexConfig(
 		}
 	}
 
-	// --- 6. Ensure dev3's status hooks are declared in the file ---
+	// --- 6. Seed [tui] whimsy = false once ---
+	// Codex's "Astra composer stars" repaint the area behind the input every
+	// 150ms for as long as the composer is on screen (its own
+	// tui/src/bottom_pane/chat_composer/sparkle.rs). Measured on codex-cli
+	// 0.154.0: an idle pane emits ~187 KB in 20 seconds and nothing else. In a
+	// dev3 pane that is pure cost — the animation is decorative, it inflates
+	// every terminal it runs in, and the effect only exists at all because the
+	// model happens to be named `*astra*`.
+	//
+	// Written ONLY when the key is absent, never forced: a user who sets it back
+	// to `true` keeps it across restarts. Codex's own default is `true`, so
+	// nobody spells it out and in practice every install gets the quiet default.
+	if (parsed.tui?.whimsy === undefined) {
+		config = upsertSectionLine(config, "[tui]", "whimsy", "false");
+	}
+
+	// --- 7. Ensure dev3's status hooks are declared in the file ---
 	config = ensureDev3HooksBlock(config, options.dialect);
 
 	return config;


### PR DESCRIPTION
Codex draws decorative "Astra composer stars" — sparse braille dots — behind the input, and repaints them every 150 ms for as long as the composer is on screen (`codex-rs/tui/src/bottom_pane/chat_composer/sparkle.rs`, `FRAME_TICK`). Measured on codex-cli 0.154.0 in a dev3 pane: an **idle** pane emitted 187 581 bytes in 20 seconds, with 3 677 of those glyphs in a single capture. In dev3 that traffic crosses a PTY, a WebSocket and a canvas renderer, continuously, for decoration.

The effect only exists because the model happens to be named `*astra*` — one of its four gates, alongside `tui.whimsy`, `tui.animations`, and a TrueColor stdout.

## The change

`ensureCodexConfig` (`src/bun/codex-config.ts`, step 6) writes `[tui] whimsy = false` into `~/.codex/config.toml`, **only when the key is absent**, checked against the parsed config rather than the raw text. Both existing callers reach it: app startup (`ensureCodexConfigFile`) and worktree creation (`ensureCodexTrust`). Managed Codex accounts symlink `config.toml` from `~/.codex`, so they inherit it.

`tui.whimsy` is the precise switch — *"Enable decorative effects such as Astra composer stars"*, default `true`. `tui.animations = false` would also kill it but takes the welcome screen, shimmer and spinners with it.

Seed-once rather than forced: forcing would silently undo the choice of anyone who puts the stars back, on every app start. Codex's own default is `true` and nobody writes it out explicitly, so in practice every install gets the quiet default.

## Scope — deliberately four files

This is **only** the decorative half of the earlier work. The transcript/resize/`refresh-client` changes from #1731 were reverted in #1733 and **none of them are reintroduced here**; this branch starts from `main` containing that revert and touches `codex-config.ts`, its test, one decision record and one changelog entry.

## Verification

- `bun run lint` clean; 281 tests across the codex-config, hooks, trust-prune, hook-guard, agents and decision-record suites.
- Six new tests pin the behaviour: seed into a fresh config, insert into a `[tui]` section the user already has without losing their keys, leave an explicit `whimsy = true` alone, leave an explicit `false` alone, idempotence, and that the result still parses as TOML.
- Both guard directions proved by mutation: forcing instead of seeding fails "leaves an explicit whimsy = true alone"; deleting the block fails four tests.
- Dry-run against a copy of a real, heavily-populated `~/.codex/config.toml`: the key lands inside the existing `[tui]` section, `status_line` and `theme` survive, one section rather than a duplicate, and `codex features list` still parses the result.

## Not verified

The stars actually going dark on a live run. In an isolated `CODEX_HOME` the effect never lit up even with `whimsy = true`, because codex did not treat that tmux as TrueColor — so there was nothing to switch off. That half rests on the gate in the 0.154.0 source: `if !self.whimsy … { return None; }`.

## If this needs reverting

Reverting this commit stops dev3 writing the key, but **does not remove a `whimsy = false` already on disk** — that is exactly how the previous round left an orphaned line behind. To undo it fully, also delete the `whimsy = false` line from `~/.codex/config.toml` (a single line; do not restore the whole file from a backup, since trust entries are appended to it constantly).

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=4f0e6396-4868-489e-bb00-ca00f5f4b37f) · `dev3://task/4f0e6396-4868-489e-bb00-ca00f5f4b37f` _(dev3 added this footer — turn it off in Settings → Tasks.)_