### PR TITLE
fix(agents): hand Claude its protocol body as a file on every platform

### DIFF
--- a/change-logs/2026/09/12/fix-system-prompt-file-transport.md
+++ b/change-logs/2026/09/12/fix-system-prompt-file-transport.md
@@ -1,0 +1,5 @@
+Short: Agents stop killing each other
+
+Claude's dev3 protocol now reaches the agent as a file on macOS and Linux too, not only on Windows. Inline it sat in every agent's command line, so `pkill -f` and `pgrep -f` matched ordinary English words from that prose and one agent's cleanup terminated every other agent on the machine.
+
+Suggested by @L4XB (h0x91b/dev-3.0#1734)

--- a/decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md
+++ b/decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md
@@ -1,5 +1,11 @@
 # Agent command lines quote in the launch dialect
 
+> Partially superseded on 2026-09-12 by
+> `decisions/2026/09/12/claude-protocol-always-travels-as-a-file.md`: the file channel is no
+> longer a Windows-only answer to the command-line ceiling — every platform uses it, because
+> the inline body in `argv` is what `pkill -f` matches (h0x91b/dev-3.0#1734). Everything below
+> about quoting dialects still holds.
+
 ## Context
 
 Starting or resuming any Claude session on Windows died before the binary was

--- a/decisions/2026/09/12/claude-protocol-always-travels-as-a-file.md
+++ b/decisions/2026/09/12/claude-protocol-always-travels-as-a-file.md
@@ -1,0 +1,62 @@
+# Claude's protocol always travels as a file, and a failed write is fatal
+
+## Context
+
+The dev3 protocol was injected into Claude's launch as `--append-system-prompt <body>`,
+about 29 KB of ordinary English prose sitting in every agent's `argv`. `pkill -f` and
+`pgrep -f` match the whole command line, so any pattern that occurs as a word in that prose
+matched every running agent: one agent restarting its own browser daemon SIGTERMed every
+sibling on the machine, twice in two days (h0x91b/dev-3.0#1734). The victim's pane showed only
+`✗ Process exited with code 143`, which points the investigation at anything but the real cause.
+
+The file channel already existed — written for Windows, where the body plus a task description
+does not fit the 32 767-character command line
+(`decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md`). It was gated to the
+PowerShell dialect, so no POSIX launch ever used it.
+
+## Investigation
+
+The gate turned out to be the whole bug: `systemPromptNeedsFile()` answered a question about
+shell quoting, and the call site used it as if it answered a question about safety. Nothing else
+had to change to close the exposure — ungating `systemPromptFileFor()` is the fix, and the
+contributor's PR #1738 did exactly that.
+
+Two follow-ups were needed to make it hold. First, the write was not atomic: `~/.dev3.0` is
+shared by every installed version of the app, different versions carry different protocol text,
+so two versions running side by side fail the "has the body changed" check in both directions and
+rewrite the file continuously. The reader is another process — the agent being launched — so a
+truncate-then-write could hand it half a protocol with no error anywhere. Second, a failed write
+returned `null` and the launch silently fell back to the inline body, which is the exposure this
+change exists to remove.
+
+## Decision
+
+`src/bun/agents.ts` — `systemPromptFileFor()` supplies the file for every Claude launch on every
+platform. `src/bun/agent-system-prompt-file.ts` — `ensureAgentSystemPromptFile()` writes through a
+temp name in the same directory and renames it into place, and **throws** when it cannot write
+instead of returning `null`. `systemPromptNeedsFile()` is deleted; nothing asks that question any
+more. The pure adapter in `src/shared/agent-adapters/claude.ts` keeps its inline branch for a
+caller with no backend behind it; dev3 itself never reaches it.
+
+The `AGENTS.md` ban on renames under `~/.dev3.0` is about moving user state between paths, where
+another installed version would look at the old path and find nothing. This rename is a temp file
+created milliseconds earlier, moved onto a regenerated cache file under a name that never changes.
+Nothing reads the temp name and no state moves.
+
+## Risks
+
+An unwritable `~/.dev3.0/data` now blocks Claude launches instead of degrading them. That is
+deliberate — the degraded mode is the bug — and such an install is broken in more visible ways
+already, since every board, task and worktree record lives under the same root.
+`--append-system-prompt-file` is not listed among the flags in `claude --help` (verified on
+2.1.269, where it is only mentioned in prose and works); an old enough Claude Code that lacks it
+would fail to launch on POSIX, where before it would merely be exposed.
+
+## Alternatives considered
+
+Content-addressing the file name (`claude-<sha>.md`) so two app versions cannot write the same
+path. It removes the rewrite churn, but the atomic rename already guarantees a reader sees one
+whole body or the other, and immutable per-body files accumulate forever. Rejected as more
+machinery than the property needs. Keeping the `null` return and surfacing a toast instead of
+throwing was rejected for the same reason the fallback was: a launch that quietly re-arms #1734 is
+worse than one that refuses.

--- a/src/bun/__tests__/agent-command-golden.test.ts
+++ b/src/bun/__tests__/agent-command-golden.test.ts
@@ -19,10 +19,11 @@ import { setCurrentUiTheme } from "../theme-state";
 // Pins the *structure* of every launch command `resolveAgentCommand` produces
 // across an (agent × config × options) matrix so the AgentAdapter refactor can
 // be proved byte-identical. The three multi-KB skill bodies are redacted to
-// stable sentinels (<CLAUDE_BODY>, <CODEX_DEV_INSTR>, <GENERIC_BODY>) so this
+// stable sentinels (<CLAUDE_BODY_FILE>, <CODEX_DEV_INSTR>, <GENERIC_BODY>) so this
 // test guards flags / quoting / delivery-channel / ordering — NOT the protocol
 // prose (which changes often and is not load-bearing for command assembly).
-// The wrapper around each body (e.g. `--append-system-prompt '<CLAUDE_BODY>'`
+// Claude reads its body from a file (#1734), so the path is the sentinel there.
+// The wrapper around each body (e.g. `--append-system-prompt-file <CLAUDE_BODY_FILE>`
 // vs `-c <CODEX_DEV_INSTR>`) stays visible, so a lost quote or a wrong delivery
 // channel still fails the test.
 // ---------------------------------------------------------------------------
@@ -35,6 +36,8 @@ function redact(cmd: string): string {
 	// whole, so its apostrophes are rewritten ('→'\''). Redact the escaped inner.
 	const genericEscapedInner = shellEscape(DEV3_SYSTEM_PROMPT_GENERIC).slice(1, -1);
 	return cmd
+		// Claude's body travels in a file whose path is machine specific.
+		.replace(/\S*[/\\]agent-prompts[/\\]claude\.md/g, "<CLAUDE_BODY_FILE>")
 		.split(claudeBody).join("<CLAUDE_BODY>")
 		.split(codexBody).join("<CODEX_DEV_INSTR>")
 		.split(genericEscapedInner).join("<GENERIC_BODY>");
@@ -111,21 +114,21 @@ function buildCases(): Case[] {
 // Captured against the pre-refactor code (reproduce-first). The AgentAdapter
 // migration must reproduce every one of these strings verbatim.
 const EXPECTED: Record<string, string> = {
-	"claude/fresh": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/fresh-empty": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/resume-nosid": "claude --continue --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/resume-sid": "claude --resume 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/preassign-sid": "claude --session-id 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/fresh": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/fresh-empty": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/resume-nosid": "claude --continue --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/resume-sid": "claude --resume 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/preassign-sid": "claude --session-id 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"claude/skipSysPrompt": "claude --model sonnet --allow-dangerously-skip-permissions -- 'Fix the login bug'",
-	"claude/statusline": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> --settings /tmp/s.json -- 'Fix the login bug'",
-	"claude/pm-plan": "claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-acceptEdits": "claude --model sonnet --permission-mode acceptEdits --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-bypassPermissions": "claude --model sonnet --permission-mode bypassPermissions --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-dontAsk": "claude --model sonnet --permission-mode dontAsk --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/effort": "claude --model sonnet --allow-dangerously-skip-permissions --effort high --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/budget": "claude --model sonnet --allow-dangerously-skip-permissions --max-budget-usd 12 --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/addargs": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> --foo bar -- 'Fix the login bug'",
-	"claude/appendPrompt": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug\n\nExtra: Fix bug'",
+	"claude/statusline": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> --settings /tmp/s.json -- 'Fix the login bug'",
+	"claude/pm-plan": "claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-acceptEdits": "claude --model sonnet --permission-mode acceptEdits --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-bypassPermissions": "claude --model sonnet --permission-mode bypassPermissions --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-dontAsk": "claude --model sonnet --permission-mode dontAsk --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/effort": "claude --model sonnet --allow-dangerously-skip-permissions --effort high --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/budget": "claude --model sonnet --allow-dangerously-skip-permissions --max-budget-usd 12 --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/addargs": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> --foo bar -- 'Fix the login bug'",
+	"claude/appendPrompt": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug\n\nExtra: Fix bug'",
 	"codex/fresh": "codex --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
 	"codex/fresh-empty": "codex --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR>",
 	"codex/resume-nosid": "codex resume --last --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR>",
@@ -201,9 +204,9 @@ const EXPECTED: Record<string, string> = {
 	"aider/budget": "aider --model sonnet --max-budget-usd 12 -- 'Fix the login bug'",
 	"aider/addargs": "aider --model sonnet --foo bar -- 'Fix the login bug'",
 	"aider/appendPrompt": "aider --model sonnet -- 'Fix the login bug\n\nExtra: Fix bug'",
-	"claude/provider-bedrock": "claude --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/provider-bedrock": "claude --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"codex/provider-bedrock": "codex --model global.openai.gpt-5.6-sol -c 'model_provider=\"amazon-bedrock-runtime\"' -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
-	"claude/model-1m": "claude --model 'claude-opus-4-8[1m]' --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/model-1m": "claude --model 'claude-opus-4-8[1m]' --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"codex/theme-profile": "codex --model gpt-5.6-sol -p dev3-dark -c 'default_permissions=\"dev3\"' -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
 };
 

--- a/src/bun/__tests__/agent-launch-args.test.ts
+++ b/src/bun/__tests__/agent-launch-args.test.ts
@@ -5,7 +5,6 @@ import { resolveAgentCommand, buildResumeCommand, DEV3_SYSTEM_PROMPT, type Templ
 import type { CodingAgent } from "../../shared/types";
 import { claudeAdapter } from "../../shared/agent-adapters/claude";
 import { CLAUDE_SKILL_BODY } from "../../shared/agent-skill-content";
-import { systemPromptNeedsFile } from "../agent-system-prompt-file";
 import { AGENT_SKILL_BODY_LIMIT, WINDOWS_COMMAND_LINE_LIMIT } from "../../shared/agent-command-line-budget";
 
 // ---------------------------------------------------------------------------
@@ -144,8 +143,16 @@ describe("the launch call site", () => {
 		// The protocol body no longer sits in argv (#1734): its own single quotes
 		// used to show up here as the '\'' escape sequence.
 		expect(cmd).toContain("--append-system-prompt-file");
-		expect(cmd).not.toContain("'\\''");
+		expect(cmd).not.toContain(DEV3_SYSTEM_PROMPT.slice(0, 200));
 		expect(cmd).toContain("'Fix the login bug'");
+	});
+
+	it("the POSIX escape is still emitted — now for the user's own apostrophes", () => {
+		// The protocol used to supply them; with it gone from argv the guard has to
+		// be proved on the task text, or it would quietly stop guarding anything.
+		asPlatform("darwin");
+		const cmd = resolveAgentCommand(agent("claude"), undefined, { ...CTX, taskDescription: "the task's title" });
+		expect(cmd).toContain("'\\''");
 	});
 
 	it("resolveAgentCommand spells a resolved binary path as a command", () => {
@@ -176,10 +183,13 @@ describe("the command-line ceiling", () => {
 		expect(CLAUDE_SKILL_BODY.length).toBeGreaterThan(WINDOWS_COMMAND_LINE_LIMIT / 2);
 	});
 
-	it("only Windows needs the file", () => {
-		expect(systemPromptNeedsFile("win32")).toBe(true);
-		expect(systemPromptNeedsFile("darwin")).toBe(false);
-		expect(systemPromptNeedsFile("linux")).toBe(false);
+	it("every platform gets the file — the ceiling on Windows, argv exposure everywhere", () => {
+		for (const platform of ["win32", "darwin", "linux"] as const) {
+			asPlatform(platform);
+			const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+			expect(cmd, platform).toContain("--append-system-prompt-file");
+			expect(cmd.length, platform).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
+		}
 	});
 
 	it("Claude takes a path, and the command line then fits with room to spare", () => {
@@ -191,7 +201,10 @@ describe("the command-line ceiling", () => {
 		expect(cmd.length).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 	});
 
-	it("without a file the body is still inline (the fallback when the write failed)", () => {
+	// The pure adapter still has an inline branch for a caller with no backend
+	// behind it. dev3 itself never takes it: `resolveAgentCommand` always supplies
+	// the file and throws when it cannot be written.
+	it("without a file the body is inline — the adapter's own fallback", () => {
 		const cmd = claudeAdapter.launchArgs("claude", undefined, CTX, {}).join(" ");
 		expect(cmd).toContain("--append-system-prompt ");
 		expect(cmd).not.toContain("--append-system-prompt-file");

--- a/src/bun/__tests__/agent-launch-args.test.ts
+++ b/src/bun/__tests__/agent-launch-args.test.ts
@@ -138,10 +138,14 @@ describe("the launch call site", () => {
 		expect(cmd).toContain(powerShellNativeArg("Fix the login bug"));
 	});
 
-	it("resolveAgentCommand still emits the POSIX escape on POSIX", () => {
+	it("resolveAgentCommand uses the file on POSIX too, and still quotes the rest the POSIX way", () => {
 		asPlatform("darwin");
 		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
-		expect(cmd).toContain("'\\''");
+		// The protocol body no longer sits in argv (#1734): its own single quotes
+		// used to show up here as the '\'' escape sequence.
+		expect(cmd).toContain("--append-system-prompt-file");
+		expect(cmd).not.toContain("'\\''");
+		expect(cmd).toContain("'Fix the login bug'");
 	});
 
 	it("resolveAgentCommand spells a resolved binary path as a command", () => {
@@ -187,7 +191,7 @@ describe("the command-line ceiling", () => {
 		expect(cmd.length).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 	});
 
-	it("without a file the body is still inline — POSIX is unchanged", () => {
+	it("without a file the body is still inline (the fallback when the write failed)", () => {
 		const cmd = claudeAdapter.launchArgs("claude", undefined, CTX, {}).join(" ");
 		expect(cmd).toContain("--append-system-prompt ");
 		expect(cmd).not.toContain("--append-system-prompt-file");

--- a/src/bun/__tests__/agent-system-prompt-file.test.ts
+++ b/src/bun/__tests__/agent-system-prompt-file.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { AGENT_PROMPTS_DIR, ensureAgentSystemPromptFile } from "../agent-system-prompt-file";
+
+// The file is read by ANOTHER process (the agent the launch spawns), so the two
+// properties that matter are "the whole body is there" and "a reader never sees
+// a half-written one". h0x91b/dev-3.0#1734 is why there is no inline fallback.
+
+describe("ensureAgentSystemPromptFile", () => {
+	it("writes the body and returns the path the launch will name", () => {
+		const path = ensureAgentSystemPromptFile("probe-write", "first body");
+		expect(path).toBe(join(AGENT_PROMPTS_DIR, "probe-write.md"));
+		expect(readFileSync(path, "utf-8")).toBe("first body");
+	});
+
+	it("leaves the file alone when the body has not changed", () => {
+		const path = ensureAgentSystemPromptFile("probe-stable", "same body");
+		const first = statSync(path).mtimeMs;
+		expect(ensureAgentSystemPromptFile("probe-stable", "same body")).toBe(path);
+		expect(statSync(path).mtimeMs).toBe(first);
+	});
+
+	it("replaces a changed body and leaves no temp file behind", () => {
+		const path = ensureAgentSystemPromptFile("probe-swap", "old body");
+		ensureAgentSystemPromptFile("probe-swap", "new body");
+		expect(readFileSync(path, "utf-8")).toBe("new body");
+		expect(readdirSync(AGENT_PROMPTS_DIR).filter((f) => f.startsWith("probe-swap") && f.endsWith(".tmp"))).toEqual([]);
+	});
+
+	it("throws instead of falling back to the inline body, which is the bug being closed", () => {
+		// A name whose parent directory does not exist is the cheapest real write
+		// failure; what matters is that the caller gets an error, not a null.
+		expect(() => ensureAgentSystemPromptFile("missing-dir/probe", "body")).toThrow(
+			/Could not write the agent system-prompt file/,
+		);
+		expect(existsSync(join(AGENT_PROMPTS_DIR, "missing-dir"))).toBe(false);
+	});
+});

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveAgentCommand, supportsResume, supportsPreAssignedSessionId, buildResumeCommand, skillInvocationPrefix, mergeMcpApproval, mergeWithDefaults, applyBinaryPathOverride, applyLayoutResync, migrateOldFormat, applyModelOverride, applyProviderModel, resolveLaunchConfig, claudeModelFamily, claudeDefaultEnv, getDefaultEnvForAgent, __setCodexProfileV2Override, type TemplateContext } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { DEFAULT_AGENTS } from "../../shared/types";
 import { ENV_UNSET } from "../../shared/agent-accounts";
+import { CLAUDE_SKILL_BODY } from "../../shared/agent-skill-content";
+import { AGENT_PROMPTS_DIR } from "../agent-system-prompt-file";
 import { setCurrentUiTheme } from "../theme-state";
 
 const makeAgent = (overrides?: Partial<CodingAgent>): CodingAgent => ({
@@ -110,6 +112,16 @@ describe("resolveAgentCommand — resume", () => {
 
 		expect(cmd).toContain("--continue");
 		expect(cmd).not.toContain("Extra instructions");
+	});
+
+	it("Claude: the protocol body travels as a file on POSIX too, not in argv (#1734)", () => {
+		const cmd = resolveAgentCommand(makeAgent({ baseCommand: "claude" }), makeConfig(), makeCtx());
+
+		expect(cmd).toContain("--append-system-prompt-file");
+		expect(cmd).not.toContain("--append-system-prompt '");
+		// The prose used to sit in argv, where `pkill -f` matched every agent on it.
+		expect(cmd).not.toContain(CLAUDE_SKILL_BODY.slice(0, 40));
+		expect(readFileSync(join(AGENT_PROMPTS_DIR, "claude.md"), "utf-8")).toBe(CLAUDE_SKILL_BODY);
 	});
 
 	it("Claude: still includes --append-system-prompt when resume=true", () => {

--- a/src/bun/agent-system-prompt-file.ts
+++ b/src/bun/agent-system-prompt-file.ts
@@ -1,23 +1,20 @@
 /**
- * The dev3 protocol delivered as a FILE instead of a command-line argument.
+ * The dev3 protocol delivered as a FILE instead of a command-line argument, on
+ * every platform. Two independent reasons, either one enough on its own:
  *
- * Windows caps a process command line at `WINDOWS_COMMAND_LINE_LIMIT`
- * characters, and the protocol used to be longer than that on its own, so no
- * Claude session could start there at all. The protocol is now inside
- * `AGENT_SKILL_BODY_LIMIT` and would fit — but it would eat four fifths of the
- * line, leaving the user's own task description to blow the ceiling instead. So
- * on Windows the body still travels as a file, and the whole line stays for the
- * task text. See decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md.
- *
- * POSIX has no such ceiling worth caring about (`ARG_MAX` is 1 MB on macOS,
- * 2 MB on Linux), so it keeps the inline form and this file is never written
- * there. The dialect decides, not the caller.
+ * 1. Windows caps a process command line at `WINDOWS_COMMAND_LINE_LIMIT`
+ *    characters and the protocol is most of that by itself, leaving the user's
+ *    own task description to blow the ceiling. See
+ *    decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md.
+ * 2. Inline, the body sits in every agent's `argv`, which is what `pkill -f` and
+ *    `pgrep -f` match against. Any pattern that occurs as an ordinary word in
+ *    that prose matched every running agent, so one agent's cleanup SIGTERMed
+ *    all of its siblings (h0x91b/dev-3.0#1734).
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { DEV3_HOME } from "./paths";
-import { launchDialectId } from "../shared/platform-launch";
 import { createLogger } from "./logger";
 
 const log = createLogger("agent-system-prompt");
@@ -25,34 +22,39 @@ const log = createLogger("agent-system-prompt");
 export const AGENT_PROMPTS_DIR = join(DEV3_HOME, "data", "agent-prompts");
 
 /**
- * True when this platform cannot carry the protocol on the command line at all.
- * The file is preferred everywhere (the inline body is visible to `pkill -f`);
- * this is the floor below which the inline fallback is not even a launch.
+ * Write (once) the body for `name` and return its path.
+ *
+ * Throws when it cannot be written. There is deliberately no inline fallback:
+ * on Windows the launch would be over the ceiling anyway, and on POSIX it would
+ * silently put the protocol back into argv — the exposure this file closes.
  */
-export function systemPromptNeedsFile(platform: NodeJS.Platform = process.platform): boolean {
-	return launchDialectId(platform) === "windows-powershell";
-}
-
-/**
- * Write (once) the body for `name` and return its path, or null when the write
- * fails — the caller then falls back to the inline form, which is broken on
- * Windows and exposes the body in argv elsewhere, but is still better than
- * refusing to launch.
- */
-export function ensureAgentSystemPromptFile(name: string, body: string): string | null {
+export function ensureAgentSystemPromptFile(name: string, body: string): string {
 	const path = join(AGENT_PROMPTS_DIR, `${name}.md`);
 	try {
 		mkdirSync(AGENT_PROMPTS_DIR, { recursive: true });
-		let current = "";
+		if (readIfPresent(path) === body) return path;
+		// Through a temp name in the same directory, because the reader is another
+		// process: a launching agent must see either the old body or the new one,
+		// never the middle of a rewrite.
+		const temp = `${path}.${process.pid}.tmp`;
 		try {
-			current = readFileSync(path, "utf-8");
-		} catch {
-			// missing — written below
+			writeFileSync(temp, body, "utf-8");
+			renameSync(temp, path);
+		} catch (err) {
+			rmSync(temp, { force: true });
+			throw err;
 		}
-		if (current !== body) writeFileSync(path, body, "utf-8");
 		return path;
 	} catch (err) {
 		log.warn("Failed to write the agent system-prompt file", { path, error: String(err) });
+		throw new Error(`Could not write the agent system-prompt file ${path}: ${String(err)}`);
+	}
+}
+
+function readIfPresent(path: string): string | null {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
 		return null;
 	}
 }

--- a/src/bun/agent-system-prompt-file.ts
+++ b/src/bun/agent-system-prompt-file.ts
@@ -24,7 +24,11 @@ const log = createLogger("agent-system-prompt");
 
 export const AGENT_PROMPTS_DIR = join(DEV3_HOME, "data", "agent-prompts");
 
-/** True when this platform cannot carry the protocol on the command line. */
+/**
+ * True when this platform cannot carry the protocol on the command line at all.
+ * The file is preferred everywhere (the inline body is visible to `pkill -f`);
+ * this is the floor below which the inline fallback is not even a launch.
+ */
 export function systemPromptNeedsFile(platform: NodeJS.Platform = process.platform): boolean {
 	return launchDialectId(platform) === "windows-powershell";
 }
@@ -32,7 +36,8 @@ export function systemPromptNeedsFile(platform: NodeJS.Platform = process.platfo
 /**
  * Write (once) the body for `name` and return its path, or null when the write
  * fails — the caller then falls back to the inline form, which is broken on
- * Windows but is still better than refusing to launch.
+ * Windows and exposes the body in argv elsewhere, but is still better than
+ * refusing to launch.
  */
 export function ensureAgentSystemPromptFile(name: string, body: string): string | null {
 	const path = join(AGENT_PROMPTS_DIR, `${name}.md`);

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -16,7 +16,7 @@ import { GEMINI_TRUSTED_FOLDERS } from "./worktree-trust";
 import { loadSettings, saveSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme, getCodexThemeForCurrentUiTheme } from "./theme-state";
 import { ensureClaudeStatusLineSettings } from "./rate-limit-monitor";
-import { ensureAgentSystemPromptFile, systemPromptNeedsFile } from "./agent-system-prompt-file";
+import { ensureAgentSystemPromptFile } from "./agent-system-prompt-file";
 import { getActiveClaudeConfigDir, getActiveClaudeSessionEnv, getActiveCodexSessionEnv } from "./agent-accounts";
 import { ENV_UNSET, claudeModelFamily } from "../shared/agent-accounts";
 export { claudeModelFamily } from "../shared/agent-accounts";
@@ -516,16 +516,22 @@ export function resolveAgentCommand(
 
 /**
  * The file this adapter's protocol body was written to, or undefined when the
- * platform can carry it inline (every POSIX platform) or the adapter has no
- * flag that takes a file.
+ * adapter has no flag that takes a file or the write failed (the adapter then
+ * falls back to the inline body).
  *
- * Only Claude has one (`--append-system-prompt-file`). Codex delivers the body
- * through `-c developer_instructions=…` and the rest concatenate it onto the
- * prompt, so on Windows those launches are still over the ceiling — a separate
- * per-agent channel, not something this function can paper over.
+ * The file is used on every platform, not only where the command line is too
+ * short to carry the body. Inline, the ~29 KB of protocol prose sits in the
+ * agent's argv, where `pkill -f` / `pgrep -f` and `ps` see it: any pattern that
+ * appears as an ordinary word in that prose matches every running agent, so one
+ * agent's routine cleanup SIGTERMed all of its siblings (#1734).
+ *
+ * Only Claude has such a flag (`--append-system-prompt-file`). Codex delivers
+ * the body through `-c developer_instructions=…` and the rest concatenate it
+ * onto the prompt, so on Windows those launches are still over the ceiling — a
+ * separate per-agent channel, not something this function can paper over.
  */
 function systemPromptFileFor(adapter: { command: string; skillBody?: string }): string | undefined {
-	if (!systemPromptNeedsFile() || adapter.command !== "claude" || !adapter.skillBody) return undefined;
+	if (adapter.command !== "claude" || !adapter.skillBody) return undefined;
 	return ensureAgentSystemPromptFile("claude", adapter.skillBody) ?? undefined;
 }
 

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -501,9 +501,9 @@ export function resolveAgentCommand(
 		// Codex-only: resolve the theme/profile runtime (impure) here so the pure
 		// adapter stays pure. Non-Codex agents skip it (avoids the codex --help probe).
 		codex: adapter.command === "codex" ? codexLaunchRuntime() : undefined,
-		// Windows caps a command line at 32 767 characters and the protocol is
-		// ~34 000, so there it has to reach the agent as a file. Resolved here
-		// because writing one is impure and the adapters are not.
+		// The protocol reaches Claude as a file on every platform: Windows cannot
+		// carry it on the command line, and POSIX argv is what `pkill -f` matches
+		// against. Resolved here because writing one is impure and adapters are not.
 		systemPromptFile: options?.skipSystemPrompt ? undefined : systemPromptFileFor(adapter),
 	};
 
@@ -516,8 +516,7 @@ export function resolveAgentCommand(
 
 /**
  * The file this adapter's protocol body was written to, or undefined when the
- * adapter has no flag that takes a file or the write failed (the adapter then
- * falls back to the inline body).
+ * adapter has no flag that takes one.
  *
  * The file is used on every platform, not only where the command line is too
  * short to carry the body. Inline, the ~29 KB of protocol prose sits in the
@@ -529,10 +528,13 @@ export function resolveAgentCommand(
  * the body through `-c developer_instructions=…` and the rest concatenate it
  * onto the prompt, so on Windows those launches are still over the ceiling — a
  * separate per-agent channel, not something this function can paper over.
+ *
+ * A failed write throws rather than falling back to the inline body: that
+ * fallback is the argv exposure being closed.
  */
 function systemPromptFileFor(adapter: { command: string; skillBody?: string }): string | undefined {
 	if (adapter.command !== "claude" || !adapter.skillBody) return undefined;
-	return ensureAgentSystemPromptFile("claude", adapter.skillBody) ?? undefined;
+	return ensureAgentSystemPromptFile("claude", adapter.skillBody);
 }
 
 /** Every raw arg a launch adds beyond the preset's own: the selected backend's

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 // Mock bun-specific modules before importing agents
 vi.mock("../../bun/logger", () => ({
@@ -858,6 +859,9 @@ describe("resolveAgentCommand", () => {
 		expect(cmd).toContain("agent-prompts/claude.md");
 		// The body itself stays out of argv, where pkill -f would match it (#1734).
 		expect(cmd).not.toContain("dev-3.0");
+		// …and the file it names really holds the protocol, not just a path.
+		const promptFile = cmd.match(/--append-system-prompt-file (\S+)/)?.[1] ?? "";
+		expect(readFileSync(promptFile, "utf-8")).toContain("dev-3.0");
 	});
 
 	it("does not inject --append-system-prompt for non-claude agents", () => {

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -852,10 +852,12 @@ describe("resolveAgentCommand", () => {
 		expect(cmd).toContain("Do work on my-project");
 	});
 
-	it("injects --append-system-prompt for claude base command", () => {
+	it("hands claude its protocol body as a file for the claude base command", () => {
 		const cmd = resolveAgentCommand(agent, undefined, ctx);
-		expect(cmd).toContain("--append-system-prompt");
-		expect(cmd).toContain("dev-3.0");
+		expect(cmd).toContain("--append-system-prompt-file");
+		expect(cmd).toContain("agent-prompts/claude.md");
+		// The body itself stays out of argv, where pkill -f would match it (#1734).
+		expect(cmd).not.toContain("dev-3.0");
 	});
 
 	it("does not inject --append-system-prompt for non-claude agents", () => {

--- a/src/mainview/components/global-settings/__tests__/utils.test.ts
+++ b/src/mainview/components/global-settings/__tests__/utils.test.ts
@@ -135,7 +135,7 @@ describe("global-settings utils", () => {
 
 		expect(buildCommandPreview("claude", claudeConfig)).toEqual({
 			command:
-				"claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --effort high --max-budget-usd 5 --append-system-prompt '…dev3 prompt…' --verbose '{{TASK_DESCRIPTION}}\\n\\nextra instructions'",
+				"claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --effort high --max-budget-usd 5 --append-system-prompt-file '…dev3 prompt file…' --verbose '{{TASK_DESCRIPTION}}\\n\\nextra instructions'",
 			envLine: "FOO=bar",
 		});
 		expect(buildCommandPreview("agent", cursorConfig)).toEqual({

--- a/src/mainview/components/global-settings/utils.ts
+++ b/src/mainview/components/global-settings/utils.ts
@@ -194,7 +194,7 @@ export function buildCommandPreview(
 	}
 
 	if (cmdName === "claude") {
-		parts.push("--append-system-prompt", "'…dev3 prompt…'");
+		parts.push("--append-system-prompt-file", "'…dev3 prompt file…'");
 	}
 
 	if (config.additionalArgs) {

--- a/src/shared/agent-adapters/claude.ts
+++ b/src/shared/agent-adapters/claude.ts
@@ -49,8 +49,11 @@ export const claudeAdapter: AgentAdapter = {
 		}
 
 		if (!options?.skipSystemPrompt) {
-			// The body is ~34 000 characters, which is past the Windows command-line
-			// ceiling on its own, so there it travels as a file the backend wrote.
+			// The body travels as a file the backend wrote, on every platform: it is
+			// past the Windows command-line ceiling, and on POSIX an argv copy is
+			// what `pkill -f` matches against (h0x91b/dev-3.0#1734). Every dev3
+			// launch goes through `resolveAgentCommand`, which always supplies the
+			// file; the inline branch is what a caller with no backend behind it gets.
 			if (options?.systemPromptFile) {
 				args.push("--append-system-prompt-file", quoteIfUnsafe(options.systemPromptFile));
 			} else {


### PR DESCRIPTION
Fixes #1734

## Problem

On macOS and Linux dev3 launched Claude with the whole task-lifecycle protocol inlined into `--append-system-prompt`, about 29 KB of prose in every agent's argv. `pkill -f` and `pgrep -f` match the full command line, so any pattern that occurs as an ordinary word in that prose (`agent-browser`, `read-only`, `hibernate`, …) matched every running agent, and one agent's routine cleanup SIGTERMed all of its siblings. The safe transport, `--append-system-prompt-file`, already existed but was gated to Windows, where only the command-line ceiling forced it.

## Change

`src/bun/agents.ts`

- `systemPromptFileFor()` no longer checks `systemPromptNeedsFile()`: Claude gets the file on every platform. The inline body remains the fallback when `ensureAgentSystemPromptFile()` cannot write it (unchanged behaviour, now documented as such). The doc comment explains why argv is the wrong place for the body.

`src/bun/agent-system-prompt-file.ts`

- Comments only: `systemPromptNeedsFile()` keeps its Windows semantics (the platform that cannot launch inline at all) and is now described as the floor rather than the switch.

Nothing changes for Codex, Cursor and the others: they have no file flag, and the description quoting is untouched.

## Tests

- `agents.test.ts`: new case pins that on POSIX the command carries `--append-system-prompt-file`, contains neither the inline flag nor the first 40 characters of the body, and that the file under `AGENT_PROMPTS_DIR` holds exactly `CLAUDE_SKILL_BODY`. It fails on the previous commit.
- `agent-launch-args.test.ts`: "resolveAgentCommand still emits the POSIX escape on POSIX" asserted the inline body's `'\''` sequence and is replaced by a case that expects the file flag, no body escape, and the task description still single-quoted the POSIX way. "without a file the body is still inline" is retitled to say it is the write-failure fallback.
- `agent-command-line-budget.test.ts` (which mocks the writer away to measure the inline worst case) is unchanged and still passes.

`bunx vitest run --config vitest.config.bun.ts` on the three suites: 191 passed. `bun scripts/lint.ts` is clean.
