### PR TITLE
Stretch the completion celebration to three seconds with confetti waves and fireworks

### DIFF
--- a/change-logs/2026/09/11/feature-20-longer-completion-celebration.md
+++ b/change-logs/2026/09/11/feature-20-longer-completion-celebration.md
@@ -1,0 +1,3 @@
+Short: Longer completion celebration
+
+The completion celebration in the Agents View now runs a full three seconds instead of a little over two: two waves of confetti over the finished card, three small fireworks going off around it, and a soft fade out instead of a hard cut. The completion badge, the duration it prints, the camera follow and the reduced-motion treatment are unchanged.

--- a/src/mainview/__tests__/completion-celebration.test.ts
+++ b/src/mainview/__tests__/completion-celebration.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from "vitest";
 import type { Task, TaskMovement, TaskStatus } from "../../shared/types";
 import {
 	burstPieces,
+	CELEBRATION_FADE_MS,
+	CELEBRATION_MS,
 	completionDuration,
+	FIREWORK_FLIGHT_MS,
+	fireworkBursts,
 	liveCompletions,
 	LIVE_WINDOW_MS,
+	PIECE_FLIGHT_MS,
+	PIECE_WAVE_GAP_MS,
 	replayCompletion,
 } from "../components/agent-traffic/completion-celebration";
 import type { TrafficNode } from "../components/agent-traffic/traffic-model";
@@ -271,12 +277,60 @@ describe("burstPieces", () => {
 
 	it("stays inside a bounded spread", () => {
 		for (const piece of burstPieces("m2", 20)) {
-			expect(piece.distance).toBeGreaterThanOrEqual(42);
-			expect(piece.distance).toBeLessThanOrEqual(88);
+			expect(piece.distance).toBeGreaterThanOrEqual(46);
+			expect(piece.distance).toBeLessThanOrEqual(108);
 			expect(piece.angle).toBeGreaterThanOrEqual(-160);
 			expect(piece.angle).toBeLessThanOrEqual(0);
 			expect(piece.delay).toBeGreaterThanOrEqual(0);
-			expect(piece.delay).toBeLessThanOrEqual(100);
+		}
+	});
+
+	it("fires in two waves, both of them a full fan", () => {
+		const pieces = burstPieces("m2", 18);
+		const early = pieces.filter((piece) => piece.delay < PIECE_WAVE_GAP_MS);
+		const late = pieces.filter((piece) => piece.delay >= PIECE_WAVE_GAP_MS);
+		expect(early).toHaveLength(9);
+		expect(late).toHaveLength(9);
+		// Each wave spans the fan rather than half of it.
+		for (const wave of [early, late]) {
+			expect(Math.min(...wave.map((piece) => piece.angle))).toBeLessThan(-140);
+			expect(Math.max(...wave.map((piece) => piece.angle))).toBeGreaterThan(-40);
+		}
+	});
+
+	it("lands every piece before the celebration fades", () => {
+		for (const piece of burstPieces("m2", 18)) {
+			expect(piece.delay + PIECE_FLIGHT_MS).toBeLessThanOrEqual(
+				CELEBRATION_MS - CELEBRATION_FADE_MS,
+			);
+		}
+	});
+});
+
+describe("fireworkBursts", () => {
+	it("is deterministic, so a replayed completion draws the same show", () => {
+		expect(fireworkBursts("m2")).toEqual(fireworkBursts("m2"));
+		expect(fireworkBursts("m2")).not.toEqual(fireworkBursts("m9"));
+	});
+
+	it("draws a finite number of sparks and no more", () => {
+		const bursts = fireworkBursts("m2");
+		expect(bursts).toHaveLength(4);
+		expect(bursts.flatMap((burst) => burst.sparks)).toHaveLength(36);
+	});
+
+	it("keeps every burst clear of the badge above the card's top centre", () => {
+		for (const burst of fireworkBursts("m2")) {
+			// Either off to a shoulder, or high enough to clear the badge entirely.
+			expect(Math.abs(burst.x - 0.5) > 0.25 || burst.y < -0.15).toBe(true);
+		}
+	});
+
+	it("burns out before the celebration fades", () => {
+		for (const burst of fireworkBursts("m2")) {
+			expect(burst.delay + FIREWORK_FLIGHT_MS).toBeLessThanOrEqual(
+				CELEBRATION_MS - CELEBRATION_FADE_MS,
+			);
 		}
 	});
 });

--- a/src/mainview/__tests__/traffic-celebration.test.tsx
+++ b/src/mainview/__tests__/traffic-celebration.test.tsx
@@ -182,6 +182,40 @@ describe("completion celebration on the traffic stage", () => {
 		expect(screen.queryByTestId("traffic-celebration")).toBeNull();
 	});
 
+	it("draws a bounded number of particles and clears all of them on expiry", () => {
+		// The shared setup forces reduced motion on; this is the full-motion case.
+		vi.stubGlobal("matchMedia", (query: string) => ({
+			matches: false,
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		}));
+		const { rerender } = render(
+			draw([node(task("task-a", 1, WORKING)), node(other)]),
+		);
+		rerender(draw([node(task("task-a", 1, DONE)), node(other)]));
+		const celebration = screen.getByTestId("traffic-celebration");
+		// Finite by construction: 18 confetti pieces, 4 fireworks of 9 sparks.
+		expect(
+			celebration.querySelectorAll(".traffic-celebration-piece"),
+		).toHaveLength(18);
+		expect(
+			celebration.querySelectorAll(".traffic-celebration-firework"),
+		).toHaveLength(4);
+		expect(
+			celebration.querySelectorAll(".traffic-celebration-spark"),
+		).toHaveLength(36);
+
+		act(() => {
+			vi.advanceTimersByTime(CELEBRATION_MS + 50);
+		});
+		// Nothing survives the single expiry timer — no orphan particle, no card ring.
+		expect(screen.queryByTestId("traffic-celebration")).toBeNull();
+		expect(document.querySelectorAll(".traffic-celebration-spark")).toHaveLength(0);
+		expect(document.querySelectorAll(".is-celebrating")).toHaveLength(0);
+		vi.unstubAllGlobals();
+	});
+
 	it("names the anchor as the task's creation when no work start is recorded", () => {
 		const born = [movement("a0", -90, "todo", "created")];
 		const { rerender } = render(draw([node(task("task-a", 1, born)), node(other)]));
@@ -226,6 +260,12 @@ describe("completion celebration on the traffic stage", () => {
 			expect(celebration.dataset.reduced).toBe("true");
 			expect(
 				celebration.querySelectorAll(".traffic-celebration-piece"),
+			).toHaveLength(0);
+			expect(
+				celebration.querySelectorAll(".traffic-celebration-firework"),
+			).toHaveLength(0);
+			expect(
+				celebration.querySelectorAll(".traffic-celebration-spark"),
 			).toHaveLength(0);
 			// Motion is never the only channel: the badge still says what happened.
 			expect(celebration.textContent).toContain("since work started");

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -37,6 +37,7 @@ import {
 } from "./task-history";
 import {
 	burstPieces,
+	fireworkBursts,
 	CAMERA_COOLDOWN_MS,
 	CELEBRATION_MS,
 	liveCompletions,
@@ -1101,8 +1102,14 @@ export default function TrafficNodes({
 }
 
 /**
- * The celebration itself: a bounded burst plus a badge naming what happened and,
- * when the movement log can prove one, how long it took.
+ * The celebration itself: two confetti waves and three small fireworks over the
+ * card, plus a badge naming what happened and, when the movement log can prove
+ * one, how long it took.
+ *
+ * Every particle is generated once per completion key and rendered as a fixed
+ * array of elements running CSS keyframes — no animation loop, no timer per
+ * piece. The whole overlay is removed by the single `CELEBRATION_MS` timer in
+ * the stage, so ten completions in a row still leave nothing running.
  *
  * Reduced motion drops every particle and keeps the badge. Motion is never the
  * only channel here — the badge carries the icon, the word and the number on its
@@ -1120,6 +1127,10 @@ function CompletionBurst({
 	const t = useT();
 	const pieces = useMemo(
 		() => (reduced ? [] : burstPieces(celebration.key)),
+		[celebration.key, reduced],
+	);
+	const fireworks = useMemo(
+		() => (reduced ? [] : fireworkBursts(celebration.key)),
 		[celebration.key, reduced],
 	);
 	const duration = celebration.duration;
@@ -1146,6 +1157,29 @@ function CompletionBurst({
 				height: placed.height,
 			}}
 		>
+			{fireworks.map((burst, index) => (
+				<i
+					key={`fw${index}`}
+					aria-hidden="true"
+					className="traffic-celebration-firework"
+					style={{
+						left: `${burst.x * 100}%`,
+						top: `${burst.y * 100}%`,
+					}}
+				>
+					{burst.sparks.map((spark, spark_index) => (
+						<i
+							key={spark_index}
+							className="traffic-celebration-spark"
+							style={{
+								["--spark-angle" as string]: `${spark.angle}deg`,
+								["--spark-distance" as string]: `${spark.distance}px`,
+								["--spark-delay" as string]: `${burst.delay}ms`,
+							}}
+						/>
+					))}
+				</i>
+			))}
 			{pieces.map((piece, index) => (
 				<i
 					key={index}

--- a/src/mainview/components/agent-traffic/completion-celebration.ts
+++ b/src/mainview/components/agent-traffic/completion-celebration.ts
@@ -16,8 +16,18 @@ import type { Task, TaskMovement } from "../../../shared/types";
 import { positionSeed, type TrafficNode } from "./traffic-model";
 import type { TrafficTimelineEvent } from "./traffic-timeline";
 
-/** How long one celebration stays on the card, particles or not. */
-export const CELEBRATION_MS = 2400;
+/**
+ * How long one celebration stays on the card, particles or not.
+ *
+ * Three seconds is the whole show: two confetti waves, three small fireworks
+ * staggered behind them, then a short fade so the overlay leaves instead of
+ * being cut. Every generator below is sized against this number — the last
+ * particle must finish before the fade starts, or it disappears mid-flight.
+ */
+export const CELEBRATION_MS = 3000;
+
+/** When the overlay starts fading out, leaving {@link CELEBRATION_MS} clean. */
+export const CELEBRATION_FADE_MS = 320;
 
 /**
  * How fresh a live completion must be to be celebrated. A board reload hands us
@@ -186,26 +196,97 @@ export function replayCompletion(
 	);
 }
 
+/** One confetti flight, so a piece never outlives the fade. */
+export const PIECE_FLIGHT_MS = 1200;
+
+/** Gap between the two confetti waves. The second re-lights a dying burst. */
+export const PIECE_WAVE_GAP_MS = 760;
+
+/** One firework: the sparks all fly within this. */
+export const FIREWORK_FLIGHT_MS = 760;
+
+/**
+ * When each firework goes off, measured from the start of the celebration.
+ *
+ * The last one is timed to land right before the fade: with nothing after ~2.4s
+ * the final half-second read as the show being over early, badge and ring alone.
+ */
+export const FIREWORK_DELAYS_MS = [380, 1040, 1580, 1900] as const;
+
+function seededRandom(key: string): () => number {
+	let hash = positionSeed(key);
+	return () => {
+		hash = (hash * 1664525 + 1013904223) >>> 0;
+		return hash / 0x1_0000_0000;
+	};
+}
+
 /**
  * A stable spread for the burst, so the same completion draws the same shape on
  * every render. `Math.random()` here would reshuffle every piece on each React
  * pass and turn a bounded burst into a jitter.
+ *
+ * Two waves, not one long one: a single burst stretched over three seconds
+ * reads as slow motion, while a second wave landing while the first is still
+ * falling reads as a celebration that keeps going. Even indices fly in wave
+ * one, odd in wave two, so each wave is a full fan rather than half a fan.
  */
 export function burstPieces(
 	key: string,
-	count = 12,
+	count = 18,
 ): { angle: number; distance: number; spin: number; delay: number }[] {
-	let hash = positionSeed(key);
-	const next = () => {
-		hash = (hash * 1664525 + 1013904223) >>> 0;
-		return hash / 0x1_0000_0000;
-	};
-	return Array.from({ length: count }, (_, index) => ({
-		// Fan upwards and outwards, one piece per slice so nothing clumps.
-		angle: -160 + (index + next() * 0.8) * (140 / count),
-		distance: 42 + next() * 46,
-		spin: -220 + next() * 440,
-		// better-ui's stagger, scaled to the piece count.
-		delay: Math.round(index * (100 / count) * 10) / 10,
+	const next = seededRandom(key);
+	return Array.from({ length: count }, (_, index) => {
+		const wave = index % 2;
+		const slot = Math.floor(index / 2);
+		const perWave = Math.ceil(count / 2);
+		return {
+			// Fan upwards and outwards, one piece per slice so nothing clumps.
+			angle: -160 + (slot + next() * 0.8) * (140 / perWave),
+			distance: 46 + next() * 62,
+			spin: -260 + next() * 520,
+			// better-ui's stagger inside a wave, plus the wave's own offset.
+			delay:
+				wave * PIECE_WAVE_GAP_MS +
+				Math.round(slot * (110 / perWave) * 10) / 10,
+		};
+	});
+}
+
+export interface FireworkBurst {
+	/** Fraction of the card box, so a burst follows the card it belongs to. */
+	x: number;
+	y: number;
+	delay: number;
+	sparks: { angle: number; distance: number }[];
+}
+
+/**
+ * Small radial bursts around the card, staggered behind the confetti.
+ *
+ * Deliberately small and off to the sides: the badge owns the top centre and
+ * the card owns its own title, so a burst is placed in the margin around them
+ * and never over readable text. Seeded from the same key as the confetti, so a
+ * replayed completion draws the identical show.
+ */
+export function fireworkBursts(key: string, sparks = 9): FireworkBurst[] {
+	const next = seededRandom(`${key}:fireworks`);
+	// Left and right shoulders, then one high above — never the top centre,
+	// where the badge sits.
+	const spots = [
+		{ x: 0.1, y: 0.16 },
+		{ x: 0.9, y: 0.08 },
+		{ x: 0.46, y: -0.26 },
+		{ x: 0.82, y: -0.2 },
+	];
+	return spots.map((spot, index) => ({
+		x: spot.x + (next() - 0.5) * 0.08,
+		y: spot.y + (next() - 0.5) * 0.08,
+		delay: FIREWORK_DELAYS_MS[index],
+		sparks: Array.from({ length: sparks }, (_, spark) => ({
+			// A full ring, jittered so it reads as a burst and not as a gear.
+			angle: (spark + next() * 0.6) * (360 / sparks),
+			distance: 22 + next() * 26,
+		})),
 	}));
 }

--- a/src/mainview/components/agent-traffic/traffic-nodes.css
+++ b/src/mainview/components/agent-traffic/traffic-nodes.css
@@ -1359,11 +1359,15 @@
 }
 
 /* ── Completion celebration ──────────────────────────────────────────────────
-   A bounded, run-once burst over the card that just reached `completed`, plus a
-   badge naming the verdict and — only when the movement log proves one — how
-   long it took. Keyframes rather than transitions because this is a staged
-   sequence that plays once (better-ui #4); the badge is a static cue that
-   survives `prefers-reduced-motion`, so motion is never the only channel. */
+   A bounded, run-once show over the card that just reached `completed`: two
+   confetti waves, three small fireworks staggered behind them, and a badge
+   naming the verdict and — only when the movement log proves one — how long it
+   took. The whole thing is three seconds, and the last particle lands before
+   the closing fade so nothing is cut mid-flight. Keyframes rather than
+   transitions because this is a staged sequence that plays once (better-ui #4);
+   the badge is a static cue that survives `prefers-reduced-motion`, so motion
+   is never the only channel. Timings live in `completion-celebration.ts`; the
+   numbers here mirror them. */
 .traffic-celebration {
 	position: absolute;
 	pointer-events: none;
@@ -1371,12 +1375,25 @@
 	display: flex;
 	align-items: flex-start;
 	justify-content: center;
+	/* The overlay leaves rather than being cut: 2680ms still, then 320ms out. */
+	animation: traffic-celebration-out 320ms cubic-bezier(0.2, 0, 0, 1) 2680ms both;
+}
+@keyframes traffic-celebration-out {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
 }
 .traffic-node-card.is-celebrating {
 	box-shadow:
 		0 0 0 2px rgb(var(--success) / 0.9),
 		0 10px 30px rgb(var(--success) / 0.22),
 		0 8px 22px rgb(0 0 0 / 0.13);
+	/* The ring is a colour change, not motion: it fades in and out with the
+	   overlay instead of snapping, and survives reduced motion untouched. */
+	transition: box-shadow 320ms cubic-bezier(0.2, 0, 0, 1);
 }
 .traffic-celebration-badge {
 	position: relative;
@@ -1426,7 +1443,7 @@
 	border-radius: 1.5px;
 	background: rgb(var(--success));
 	opacity: 0;
-	animation: traffic-celebration-piece 1100ms cubic-bezier(0.2, 0, 0, 1)
+	animation: traffic-celebration-piece 1200ms cubic-bezier(0.2, 0, 0, 1)
 		var(--piece-delay) both;
 }
 .traffic-celebration-piece:nth-child(3n) {
@@ -1444,8 +1461,8 @@
 	18% {
 		opacity: 1;
 	}
-	100% {
-		opacity: 0;
+	70% {
+		opacity: 1;
 		/* Translate first, then spin the piece: rotating before the offset would
 		   rotate the direction too and collapse the fan. */
 		transform: translate(-50%, 0)
@@ -1456,6 +1473,69 @@
 			rotate(var(--piece-spin))
 			scale(1);
 	}
+	100% {
+		opacity: 0;
+		/* The piece falls out of its arc instead of vanishing at the top of it —
+		   what makes a burst read as confetti rather than as a starburst. */
+		transform: translate(-50%, 0)
+			translate(
+				calc(cos(var(--piece-angle)) * var(--piece-distance)),
+				calc(sin(var(--piece-angle)) * var(--piece-distance) + 22px)
+			)
+			rotate(calc(var(--piece-spin) * 1.35))
+			scale(0.9);
+	}
+}
+/* Fireworks: a small ring of sparks going off beside the card, staggered behind
+   the confetti so the three seconds keep re-lighting instead of decaying once.
+   Positioned in the margin around the card — never over the title or the badge. */
+.traffic-celebration-firework {
+	position: absolute;
+	width: 0;
+	height: 0;
+}
+.traffic-celebration-spark {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 4px;
+	height: 4px;
+	margin: -2px 0 0 -2px;
+	border-radius: 50%;
+	background: rgb(var(--success));
+	opacity: 0;
+	box-shadow: 0 0 6px rgb(var(--success) / 0.7);
+	animation: traffic-celebration-spark 760ms cubic-bezier(0.2, 0, 0, 1)
+		var(--spark-delay) both;
+}
+.traffic-celebration-firework:nth-child(2) .traffic-celebration-spark {
+	background: rgb(var(--accent));
+	box-shadow: 0 0 6px rgb(var(--accent) / 0.7);
+}
+.traffic-celebration-firework:nth-child(3) .traffic-celebration-spark {
+	background: rgb(var(--agent));
+	box-shadow: 0 0 6px rgb(var(--agent) / 0.7);
+}
+.traffic-celebration-firework:nth-child(4) .traffic-celebration-spark {
+	background: rgb(var(--success));
+	box-shadow: 0 0 7px rgb(var(--success) / 0.8);
+}
+@keyframes traffic-celebration-spark {
+	0% {
+		opacity: 0;
+		transform: translate(0, 0) scale(0.4);
+	}
+	12% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translate(
+				calc(cos(var(--spark-angle)) * var(--spark-distance)),
+				calc(sin(var(--spark-angle)) * var(--spark-distance) + 6px)
+			)
+			scale(0.5);
+	}
 }
 /* Static success treatment: the badge stays, every particle goes. The card ring
    is a colour change, not motion, so it stays too. */
@@ -1463,11 +1543,18 @@
 	animation: none;
 }
 @media (prefers-reduced-motion: reduce) {
-	.traffic-celebration-piece {
+	.traffic-celebration-piece,
+	.traffic-celebration-firework {
 		display: none;
 	}
 	.traffic-celebration-badge {
 		animation: none;
+	}
+	/* The overlay still leaves on its own, by an opacity fade only — the one
+	   substitution reduced-motion asks for, rather than a hard cut. */
+	.traffic-celebration {
+		animation-duration: 200ms;
+		animation-delay: 2800ms;
 	}
 }
 


### PR DESCRIPTION
The completion celebration in the Agents View now runs a full three seconds instead of 2.4: two waves of confetti over the finished card, four small fireworks going off around it, and a 320ms fade-out instead of a hard cut. Every particle lands before the fade starts, so nothing is cut mid-flight.

The trigger, the camera/follow behaviour, the printed duration, the replay semantics and the reduced-motion treatment are unchanged — reduced motion still renders zero particles and keeps the badge and the card ring.

Measured in the running app with a MutationObserver, from the overlay entering the DOM to it leaving: 3001-3002 ms at 1600x1000, 1280x800, 1024x768 and 390x844 phone portrait (2402 ms before), with 18 confetti pieces plus 36 sparks and nothing left in the DOM afterwards.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=8c83797f-833e-4ff5-8d01-899e9b51b9c9) · `dev3://task/8c83797f-833e-4ff5-8d01-899e9b51b9c9` _(dev3 added this footer — turn it off in Settings → Tasks.)_