### PR TITLE
Keep the artifact toolbar's Close reachable in a narrow panel

### DIFF
--- a/change-logs/2026/09/11/fix-artifact-toolbar-narrow-close-clipped.md
+++ b/change-logs/2026/09/11/fix-artifact-toolbar-narrow-close-clipped.md
@@ -1,0 +1,3 @@
+Short: Artifact toolbar scrolls when narrow
+
+A narrow artifact panel no longer clips its toolbar: every control except Close now sits in a horizontally scrollable row, Close stays pinned at the trailing edge, and the artifact counter no longer wraps onto three lines.

--- a/src/mainview/components/TaskArtifactViewer.tsx
+++ b/src/mainview/components/TaskArtifactViewer.tsx
@@ -496,6 +496,14 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, offscreen 
 						<div className="truncate text-sm font-medium text-fg">{current.title}</div>
 						<div className="truncate text-micro text-fg-muted">{current.name}</div>
 					</div>
+					{/* Everything but Close scrolls sideways once the panel is too narrow
+					    for the full row; Close stays pinned outside it, because a docked
+					    panel can be dragged narrower than its own toolbar and the way out
+					    must never be the button that gets clipped. */}
+					<div
+						data-testid="artifact-viewer-actions"
+						className="artifact-toolbar-scroll flex min-w-0 items-center gap-2 overflow-x-auto overscroll-x-contain"
+					>
 					<HelpSpot topicId="viewer.artifact" />
 					{group && (
 						<ArtifactVersionPicker
@@ -507,7 +515,7 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, offscreen 
 					{artifacts.length > 1 && (
 						<>
 							<button type="button" className={iconButton} disabled={index === 0} onClick={() => go(-1)} aria-label={t("artifactViewer.previous")}><span style={{ fontFamily: ICON }}></span></button>
-							<span className="font-mono text-xs text-fg-3 tabular-nums">{index + 1} / {artifacts.length}</span>
+							<span className="flex-shrink-0 whitespace-nowrap font-mono text-xs text-fg-3 tabular-nums">{index + 1} / {artifacts.length}</span>
 							<button type="button" className={iconButton} disabled={index === artifacts.length - 1} onClick={() => go(1)} aria-label={t("artifactViewer.next")}><span style={{ fontFamily: ICON }}></span></button>
 						</>
 					)}
@@ -540,6 +548,7 @@ export default function TaskArtifactViewer({ artifacts, initialIndex, offscreen 
 						title={t("artifactViewer.openInBrowser")}
 					><span style={{ fontFamily: ICON }}>{""}</span></button>
 					<button type="button" data-testid="artifact-viewer-fullscreen" className={iconButton} onClick={() => setFullscreen((value) => !value)} aria-label={fullscreen ? t("artifactViewer.exitFullscreen") : t("artifactViewer.fullscreen")}><span style={{ fontFamily: ICON }}>{fullscreen ? "" : ""}</span></button>
+					</div>
 					<button type="button" data-testid="artifact-viewer-close" className={iconButton} onClick={onClose} aria-label={t("artifactViewer.close")}><span style={{ fontFamily: ICON }}></span></button>
 				</header>
 				{pendingDraft && !draftIsHere && !draftDismissed && (

--- a/src/mainview/components/__tests__/TaskArtifactViewerPresentation.test.tsx
+++ b/src/mainview/components/__tests__/TaskArtifactViewerPresentation.test.tsx
@@ -175,4 +175,18 @@ describe("TaskArtifactViewer presentation", () => {
 		expect(viewer).toHaveAttribute("data-presentation", "docked");
 		expect(document.documentElement).toHaveAttribute("data-artifact-viewer", "open");
 	});
+
+	// A docked panel can be dragged narrower than its own toolbar. Everything else
+	// may scroll out of sight there; Close may not, or the panel has no way out.
+	it("keeps Close out of the row that scrolls when the panel is narrow", async () => {
+		mountDock();
+		render(<I18nProvider><TaskArtifactViewer taskId="t1" artifacts={[artifact(), { ...artifact(), id: "a2", title: "Second" }]} initialIndex={0} onClose={vi.fn()} /></I18nProvider>);
+		const actions = await screen.findByTestId("artifact-viewer-actions");
+
+		expect(actions.contains(screen.getByTestId("artifact-viewer-close"))).toBe(false);
+		expect(actions.className).toContain("overflow-x-auto");
+		for (const id of ["artifact-viewer-search", "artifact-viewer-theme", "artifact-viewer-open-browser", "artifact-viewer-fullscreen"]) {
+			expect(actions.contains(screen.getByTestId(id))).toBe(true);
+		}
+	});
 });

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -609,6 +609,19 @@ body, #root {
 	display: none;
 }
 
+/* ---- Artifact viewer toolbar: scrolls sideways, no visible bar ----
+   A 7px always-on bar inside a 40px toolbar would eat the row's height and
+   clip the icons it is supposed to give access to. */
+
+.artifact-toolbar-scroll {
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+
+.artifact-toolbar-scroll::-webkit-scrollbar {
+	display: none;
+}
+
 /* ---- Collapsed kanban column vertical label ---- */
 
 .kanban-col-vertical-label {


### PR DESCRIPTION
The artifact viewer's header was a single flex row where every control is `flex-shrink-0` and nothing handles overflow. A docked panel can be dragged down to 360px (the pane's minimum), and at that width the header's content is wider than the header itself — the trailing controls simply run past the edge and get clipped by the card's `overflow-hidden`. Measured live at a 360px panel: `header.scrollWidth` 421px against `clientWidth` 359px, with the Close button's right edge at 1341.8px and the header ending at 1280px. Close and Fullscreen were off-screen: not visible, not clickable, not reachable by pointer at all. The artifact counter also collapsed and wrapped onto three lines, since it had neither `whitespace-nowrap` nor a shrink guard.

Every control except Close now lives in a horizontally scrollable row (`overflow-x-auto overscroll-x-contain`), so a narrow panel scrolls its toolbar sideways instead of clipping it. Close moves outside that row and stays pinned to the trailing edge at any width — the way out of the panel must never depend on scrolling. The counter gets `flex-shrink-0 whitespace-nowrap`. The scrollbar is hidden via `.artifact-toolbar-scroll`: an always-visible 7px bar inside a 40px toolbar would eat the row's height and clip the very icons it gives access to; the affordance for hidden content is the half-visible neighbouring button at the edge. No new controls, no overflow menu, and the order and behaviour of the existing buttons are unchanged.

Verified by driving the running app in headless Chromium at panel widths 360 / 560 / 900: header overflow is 0 everywhere, the action row scrolls by 103px at 360, and Close sits inside the header in all three. A real mouse click on Close at 360px closes the panel; Tab from Fullscreen lands on Close and Enter closes it; focusing a control that scrolled out of view pulls it back in (`scrollLeft` from max to 0); wheel/trackpad horizontal scrolling reaches both ends; the counter renders on one line; no console errors. One regression test pins the structural invariant (Close outside the scrolling row, everything else inside) and was mutation-checked — moving Close back inside fails it.

Not covered: the popup presentation (archived-task modal) was not driven manually, though it renders the same header and gets the same fix.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=465eab42-3175-4a17-af62-f71da4887ac8) · `dev3://task/465eab42-3175-4a17-af62-f71da4887ac8` _(dev3 added this footer — turn it off in Settings → Tasks.)_