### PR TITLE
Deliver Claude's system prompt through a file on every platform

### DIFF
--- a/change-logs/2026/09/11/fix-system-prompt-file-transport.md
+++ b/change-logs/2026/09/11/fix-system-prompt-file-transport.md
@@ -1,0 +1,5 @@
+Short: Agent prompts no longer sit in argv
+
+Claude agents now receive the dev3 lifecycle protocol through a file on every platform instead of a ~27 KB `--append-system-prompt` argument. The protocol used to sit in each agent's command line, so a `pkill -f` on an ordinary word like `agent-browser` matched and terminated every other agent on the machine. Existing sessions keep their old command line until they are restarted.
+
+Suggested by @vit-pavlenko (h0x91b/dev-3.0#1734)

--- a/decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md
+++ b/decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md
@@ -84,6 +84,12 @@ On Windows the protocol also stops travelling on the command line at all:
 2.1.112 that the flag exists and applies the file's content. POSIX keeps the
 inline form, so nothing about a macOS or Linux launch changes.
 
+> Partly superseded on 2026-09-11 by
+> `decisions/2026/09/11/claude-system-prompt-always-travels-as-a-file.md`: POSIX
+> no longer keeps the inline form, and the file name is now content-addressed
+> (`claude-<sha256:16>.md`, not `claude.md`). The inline body also sat in every
+> agent's `argv`, where `pkill -f` matched it and killed sibling agents.
+
 **The file only covers Claude**, because only Claude has a flag that takes a
 path. Codex carries the protocol in `-c developer_instructions=`, and Cursor and
 OpenCode concatenate it onto the prompt, so for them the body is on the command

--- a/decisions/2026/09/11/claude-system-prompt-always-travels-as-a-file.md
+++ b/decisions/2026/09/11/claude-system-prompt-always-travels-as-a-file.md
@@ -1,0 +1,66 @@
+# Claude's system prompt always travels as a file
+
+## Context
+
+dev3 injected the ~27 KB task-lifecycle protocol into every Claude launch with
+`--append-system-prompt <body>`, so the whole protocol sat in each agent's
+`argv`. `pgrep -f` / `pkill -f` match against the full command line, so ordinary
+English words inside the protocol — `agent-browser`, `read-only`, `hibernate` —
+matched every running agent on the machine. One agent restarting "its own"
+browser daemon SIGTERMed every sibling agent, twice on one machine in two days
+(h0x91b/dev-3.0#1734). The file channel already existed but was gated to Windows
+PowerShell, where the reason was the 32 767-character command-line ceiling.
+
+## Investigation
+
+`--append-system-prompt-file` is not printed in `claude --help` on 2.1.236 (it
+appears only inside another flag's description), so it was verified by running
+it: a prompt file containing a random sentinel, asked for through `claude -p`,
+came back with the sentinel; the same question without the flag answered `NONE`.
+An unknown option errors out loudly in a real launch (`--version` short-circuits
+option validation), so an older Claude without the flag fails visibly at launch
+rather than silently dropping the protocol.
+
+A live launch with the file shows a 214-byte argv and zero `pgrep -f` matches on
+the prompt text; the old inline shape shows 14 645 bytes and four matches.
+
+## Decision
+
+`systemPromptNeedsFile()` is gone (`src/bun/agent-system-prompt-file.ts`);
+`systemPromptFileFor()` in `src/bun/agents.ts` now returns a path for every
+Claude launch on every platform. Two further changes:
+
+- **Content-addressed names.** `claude-<sha256:16>.md` instead of `claude.md`,
+  written through a temp file and renamed. Two app versions running side by side
+  have different protocol bodies, so they no longer race to overwrite one path
+  between dev3's write and the child's read. Files are immutable and never
+  pruned, so an older version's `claude.md` and every past body stay readable.
+- **No inline fallback.** A failed write throws instead of returning `null`. The
+  fallback was the argv exposure itself; on Windows it could not launch anyway.
+
+The pure adapter (`src/shared/agent-adapters/claude.ts`) keeps an inline branch
+for a caller with no backend behind it; the golden matrix asserts that no Claude
+command `resolveAgentCommand` builds carries a sentence of the protocol, on any
+platform or option.
+
+## Risks
+
+- A Claude old enough to lack `--append-system-prompt-file` now fails to launch
+  instead of running with the protocol inline. It fails loudly (`error: unknown
+  option`), which is the same exposure Windows has shipped with for months.
+- Already-running agents keep the old argv until they are restarted, so the
+  `pkill -f` hazard persists for existing sessions. Deliberately not fixed by
+  restarting anyone's session.
+- One ~27 KB file accumulates per distinct protocol body (per app version). Not
+  pruned on purpose — pruning one could break a resume whose stored command line
+  still names it.
+
+## Alternatives considered
+
+- **Keep the platform gate and shorten the protocol.** Does not close it: any
+  body long enough to be useful still contains matchable words.
+- **Remove the adapter's inline branch entirely.** Structurally stronger, but it
+  rewrites dozens of pure-adapter expectations for no production gain; the
+  golden-matrix guard covers the same ground.
+- **Keep the single `claude.md` name.** Simpler, but a parallel app version with
+  a different body can overwrite it in the window between write and exec.

--- a/src/bun/__tests__/agent-command-golden.test.ts
+++ b/src/bun/__tests__/agent-command-golden.test.ts
@@ -12,6 +12,8 @@ import {
 } from "../agents";
 import type { AgentConfiguration, CodingAgent } from "../../shared/types";
 import { setCurrentUiTheme } from "../theme-state";
+import { ensureAgentSystemPromptFile } from "../agent-system-prompt-file";
+import { quoteIfUnsafe } from "../../shared/agent-adapters/shell";
 
 // ---------------------------------------------------------------------------
 // Golden / characterization test (Seam A) — decision 124 / AgentAdapter spec.
@@ -22,14 +24,18 @@ import { setCurrentUiTheme } from "../theme-state";
 // stable sentinels (<CLAUDE_BODY>, <CODEX_DEV_INSTR>, <GENERIC_BODY>) so this
 // test guards flags / quoting / delivery-channel / ordering — NOT the protocol
 // prose (which changes often and is not load-bearing for command assembly).
-// The wrapper around each body (e.g. `--append-system-prompt '<CLAUDE_BODY>'`
-// vs `-c <CODEX_DEV_INSTR>`) stays visible, so a lost quote or a wrong delivery
-// channel still fails the test.
+// The wrapper around each body (e.g. `--append-system-prompt-file
+// <CLAUDE_BODY_FILE>` vs `-c <CODEX_DEV_INSTR>`) stays visible, so a lost quote
+// or a wrong delivery channel still fails the test.
 // ---------------------------------------------------------------------------
 
-/** Redact the three skill bodies to sentinels, matching how each is embedded. */
+/** Redact the three skill bodies to sentinels, matching how each is embedded.
+ *  Claude's body is never embedded at all — it reaches the agent as a file whose
+ *  name carries the body's content hash, so the PATH is redacted instead. */
 function redact(cmd: string): string {
 	const claudeBody = shellEscape(DEV3_SYSTEM_PROMPT);
+	const promptFile = ensureAgentSystemPromptFile("claude", DEV3_SYSTEM_PROMPT);
+	cmd = cmd.split(quoteIfUnsafe(promptFile)).join("<CLAUDE_BODY_FILE>");
 	const codexBody = shellEscape(`developer_instructions=${JSON.stringify(DEV3_SYSTEM_PROMPT_CODEX)}`);
 	// The generic body is concatenated onto the prompt then shell-escaped as a
 	// whole, so its apostrophes are rewritten ('→'\''). Redact the escaped inner.
@@ -111,21 +117,21 @@ function buildCases(): Case[] {
 // Captured against the pre-refactor code (reproduce-first). The AgentAdapter
 // migration must reproduce every one of these strings verbatim.
 const EXPECTED: Record<string, string> = {
-	"claude/fresh": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/fresh-empty": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/resume-nosid": "claude --continue --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/resume-sid": "claude --resume 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY>",
-	"claude/preassign-sid": "claude --session-id 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/fresh": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/fresh-empty": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/resume-nosid": "claude --continue --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/resume-sid": "claude --resume 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE>",
+	"claude/preassign-sid": "claude --session-id 11111111-1111-1111-1111-111111111111 --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"claude/skipSysPrompt": "claude --model sonnet --allow-dangerously-skip-permissions -- 'Fix the login bug'",
-	"claude/statusline": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> --settings /tmp/s.json -- 'Fix the login bug'",
-	"claude/pm-plan": "claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-acceptEdits": "claude --model sonnet --permission-mode acceptEdits --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-bypassPermissions": "claude --model sonnet --permission-mode bypassPermissions --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/pm-dontAsk": "claude --model sonnet --permission-mode dontAsk --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/effort": "claude --model sonnet --allow-dangerously-skip-permissions --effort high --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/budget": "claude --model sonnet --allow-dangerously-skip-permissions --max-budget-usd 12 --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
-	"claude/addargs": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> --foo bar -- 'Fix the login bug'",
-	"claude/appendPrompt": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug\n\nExtra: Fix bug'",
+	"claude/statusline": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> --settings /tmp/s.json -- 'Fix the login bug'",
+	"claude/pm-plan": "claude --model sonnet --permission-mode plan --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-acceptEdits": "claude --model sonnet --permission-mode acceptEdits --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-bypassPermissions": "claude --model sonnet --permission-mode bypassPermissions --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/pm-dontAsk": "claude --model sonnet --permission-mode dontAsk --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/effort": "claude --model sonnet --allow-dangerously-skip-permissions --effort high --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/budget": "claude --model sonnet --allow-dangerously-skip-permissions --max-budget-usd 12 --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
+	"claude/addargs": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> --foo bar -- 'Fix the login bug'",
+	"claude/appendPrompt": "claude --model sonnet --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug\n\nExtra: Fix bug'",
 	"codex/fresh": "codex --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
 	"codex/fresh-empty": "codex --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR>",
 	"codex/resume-nosid": "codex resume --last --model gpt-5.6-sol -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR>",
@@ -201,9 +207,9 @@ const EXPECTED: Record<string, string> = {
 	"aider/budget": "aider --model sonnet --max-budget-usd 12 -- 'Fix the login bug'",
 	"aider/addargs": "aider --model sonnet --foo bar -- 'Fix the login bug'",
 	"aider/appendPrompt": "aider --model sonnet -- 'Fix the login bug\n\nExtra: Fix bug'",
-	"claude/provider-bedrock": "claude --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/provider-bedrock": "claude --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"codex/provider-bedrock": "codex --model global.openai.gpt-5.6-sol -c 'model_provider=\"amazon-bedrock-runtime\"' -c 'default_permissions=\"dev3\"' --profile dev3-dark -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
-	"claude/model-1m": "claude --model 'claude-opus-4-8[1m]' --allow-dangerously-skip-permissions --append-system-prompt <CLAUDE_BODY> -- 'Fix the login bug'",
+	"claude/model-1m": "claude --model 'claude-opus-4-8[1m]' --allow-dangerously-skip-permissions --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'",
 	"codex/theme-profile": "codex --model gpt-5.6-sol -p dev3-dark -c 'default_permissions=\"dev3\"' -c 'tui.theme=\"dracula\"' -c <CODEX_DEV_INSTR> -- 'Fix the login bug'",
 };
 
@@ -239,6 +245,19 @@ describe("resolveAgentCommand — golden matrix (structural, byte-identical)", (
 	it.each(cases.map((c) => [c.name, c] as const))("%s", (_name, c) => {
 		const out = resolveAgentCommand(agent(c.base), c.config, c.ctx ?? CTX, c.options);
 		expect(redact(out)).toBe(EXPECTED[c.name]);
+	});
+
+	// The protocol in argv is what `pkill -f` matches against, so one agent's
+	// cleanup killed every sibling (h0x91b/dev-3.0#1734). No Claude launch, on any
+	// platform or option, may carry a sentence of it on the command line.
+	it.each(["darwin", "linux", "win32"] as const)("no Claude command line carries the protocol on %s", (platform) => {
+		Object.defineProperty(process, "platform", { value: platform, configurable: true });
+		const sentence = DEV3_SYSTEM_PROMPT.split("\n").find((line) => line.length > 60) ?? "";
+		expect(sentence.length).toBeGreaterThan(60);
+		for (const c of cases.filter((x) => x.base === "claude")) {
+			const out = resolveAgentCommand(agent(c.base), c.config, c.ctx ?? CTX, c.options);
+			expect(out, c.name).not.toContain(sentence);
+		}
 	});
 });
 

--- a/src/bun/__tests__/agent-command-line-budget.test.ts
+++ b/src/bun/__tests__/agent-command-line-budget.test.ts
@@ -93,14 +93,17 @@ describe("the protocol body fits the budget", () => {
 	}
 });
 
-// Claude's protocol reaches it as a FILE on Windows, and that is an
-// optimisation which can fail (an unwritable `~/.dev3.0`), in which case the
-// launch falls back to the inline body. Mocking the write away measures that
-// fallback — the worst case — and keeps the test from writing into the real
-// `~/.dev3.0` of whoever runs it.
+// Claude's protocol reaches it as a FILE on every platform, so what rides the
+// command line is a path. Mocked to a realistic Windows path — long, spaced,
+// non-ASCII — so the budget is measured against the worst path a real install
+// produces, and the test writes nothing into whoever runs it.
 vi.mock("../agent-system-prompt-file", async () => {
 	const actual = await vi.importActual<typeof import("../agent-system-prompt-file")>("../agent-system-prompt-file");
-	return { ...actual, ensureAgentSystemPromptFile: () => null };
+	return {
+		...actual,
+		ensureAgentSystemPromptFile: (name: string, body: string) =>
+			`C:\\Users\\Александр Петров\\AppData\\Local\\.dev3.0\\data\\agent-prompts\\${name}-${actual.systemPromptFileDigest(body)}.md`,
+	};
 });
 
 describe("the whole Windows command line fits", () => {

--- a/src/bun/__tests__/agent-launch-args.bun-e2e.ts
+++ b/src/bun/__tests__/agent-launch-args.bun-e2e.ts
@@ -26,6 +26,11 @@
  *
  * The POSIX legs are the control that none of this changed macOS/Linux.
  *
+ * Since h0x91b/dev-3.0#1734 the file channel is used on EVERY platform: the
+ * inline body also sat in every agent's `argv`, where `pkill -f` matches it, so
+ * one agent's cleanup pattern SIGTERMed every sibling agent. The inline legs
+ * below stay as measurements of what the OS allows, not of what dev3 emits.
+ *
  * The "agent binary" is this runner's own `bun`, with a probe script as its
  * first argument — a real executable with ordinary C-runtime argument parsing,
  * which a `.cmd` shim would not be (cmd.exe parses its own way and would prove
@@ -242,7 +247,7 @@ try {
 			"the protocol itself is deliverable inline at its current size",
 		);
 
-		// The shape dev3 actually launches on Windows: a path, not a body.
+		// The shape dev3 actually launches everywhere: a path, not a body.
 		const promptFile = join(root, "claude.md");
 		writeFileSync(promptFile, CLAUDE_SKILL_BODY, "utf8");
 		const { code } = await runAgent(process.execPath, ["--append-system-prompt-file", promptFile]);

--- a/src/bun/__tests__/agent-launch-args.test.ts
+++ b/src/bun/__tests__/agent-launch-args.test.ts
@@ -5,7 +5,6 @@ import { resolveAgentCommand, buildResumeCommand, DEV3_SYSTEM_PROMPT, type Templ
 import type { CodingAgent } from "../../shared/types";
 import { claudeAdapter } from "../../shared/agent-adapters/claude";
 import { CLAUDE_SKILL_BODY } from "../../shared/agent-skill-content";
-import { systemPromptNeedsFile } from "../agent-system-prompt-file";
 import { AGENT_SKILL_BODY_LIMIT, WINDOWS_COMMAND_LINE_LIMIT } from "../../shared/agent-command-line-budget";
 
 // ---------------------------------------------------------------------------
@@ -127,9 +126,9 @@ describe("commandToken", () => {
 describe("the launch call site", () => {
 	it("resolveAgentCommand emits no POSIX escape on Windows", () => {
 		// Not a synthetic string: this is the prompt every Claude launch carries,
-		// and the apostrophes in it are what killed the .ps1 parse. On Windows it
-		// now travels as a file (the ceiling below), so what must be gone from the
-		// command line is the POSIX escape — in the prompt and everywhere else.
+		// and the apostrophes in it are what killed the .ps1 parse. It now travels
+		// as a file on every platform, so what must be gone from the command line
+		// is the POSIX escape — in the prompt and everywhere else.
 		expect(DEV3_SYSTEM_PROMPT).toContain("'");
 		asPlatform("win32");
 		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
@@ -140,8 +139,17 @@ describe("the launch call site", () => {
 
 	it("resolveAgentCommand still emits the POSIX escape on POSIX", () => {
 		asPlatform("darwin");
-		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+		// The protocol no longer supplies the apostrophes (it travels as a file on
+		// every platform now), so the escape is proved on the user's own text.
+		const cmd = resolveAgentCommand(agent("claude"), undefined, { ...CTX, taskDescription: "the task's title" });
 		expect(cmd).toContain("'\\''");
+	});
+
+	it("resolveAgentCommand keeps the protocol out of argv on POSIX too", () => {
+		asPlatform("darwin");
+		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+		expect(cmd).toContain("--append-system-prompt-file");
+		expect(cmd).not.toContain(DEV3_SYSTEM_PROMPT.slice(0, 200));
 	});
 
 	it("resolveAgentCommand spells a resolved binary path as a command", () => {
@@ -172,10 +180,13 @@ describe("the command-line ceiling", () => {
 		expect(CLAUDE_SKILL_BODY.length).toBeGreaterThan(WINDOWS_COMMAND_LINE_LIMIT / 2);
 	});
 
-	it("only Windows needs the file", () => {
-		expect(systemPromptNeedsFile("win32")).toBe(true);
-		expect(systemPromptNeedsFile("darwin")).toBe(false);
-		expect(systemPromptNeedsFile("linux")).toBe(false);
+	it("every platform gets the file — the ceiling on Windows, argv exposure everywhere", () => {
+		for (const platform of ["win32", "darwin", "linux"] as const) {
+			asPlatform(platform);
+			const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+			expect(cmd, platform).toContain("--append-system-prompt-file");
+			expect(cmd.length, platform).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
+		}
 	});
 
 	it("Claude takes a path, and the command line then fits with room to spare", () => {
@@ -187,7 +198,10 @@ describe("the command-line ceiling", () => {
 		expect(cmd.length).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 	});
 
-	it("without a file the body is still inline — POSIX is unchanged", () => {
+	// The pure adapter still has an inline branch for a caller with no backend
+	// behind it. dev3 itself never takes it: `resolveAgentCommand` always writes
+	// the file and throws when it cannot (guarded above and in the golden matrix).
+	it("without a file the body is inline — the adapter's own fallback", () => {
 		const cmd = claudeAdapter.launchArgs("claude", undefined, CTX, {}).join(" ");
 		expect(cmd).toContain("--append-system-prompt ");
 		expect(cmd).not.toContain("--append-system-prompt-file");

--- a/src/bun/__tests__/agent-system-prompt-file.test.ts
+++ b/src/bun/__tests__/agent-system-prompt-file.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import {
+	AGENT_PROMPTS_DIR,
+	ensureAgentSystemPromptFile,
+	systemPromptFileDigest,
+} from "../agent-system-prompt-file";
+
+// ---------------------------------------------------------------------------
+// The protocol body reaches Claude as a file on every platform, because an argv
+// copy of it is what `pkill -f` pattern-matches against — one agent's cleanup
+// SIGTERMed every sibling agent on the machine (h0x91b/dev-3.0#1734).
+//
+// The file name is content-addressed so two app versions running side by side
+// cannot overwrite each other's body between the write and the child's read.
+// The suite runs against the real filesystem under the isolated test HOME.
+// ---------------------------------------------------------------------------
+
+const BODY_A = "dev3 protocol body A\nwith 'apostrophes' and «non-ASCII».";
+const BODY_B = "dev3 protocol body B — a different version of the same protocol.";
+
+describe("ensureAgentSystemPromptFile", () => {
+	it("writes the body verbatim and returns its path", () => {
+		const path = ensureAgentSystemPromptFile("claude", BODY_A);
+		expect(readFileSync(path, "utf-8")).toBe(BODY_A);
+		expect(dirname(path)).toBe(AGENT_PROMPTS_DIR);
+	});
+
+	it("names the file after the body's content, not after the agent alone", () => {
+		const path = ensureAgentSystemPromptFile("claude", BODY_A);
+		expect(basename(path)).toBe(`claude-${systemPromptFileDigest(BODY_A)}.md`);
+	});
+
+	it("gives two different bodies two different files — a parallel app version cannot clobber ours", () => {
+		const a = ensureAgentSystemPromptFile("claude", BODY_A);
+		const b = ensureAgentSystemPromptFile("claude", BODY_B);
+		expect(a).not.toBe(b);
+		expect(readFileSync(a, "utf-8")).toBe(BODY_A);
+		expect(readFileSync(b, "utf-8")).toBe(BODY_B);
+	});
+
+	it("reuses the existing file when the body is unchanged — repeated launches do not rewrite it", () => {
+		const first = ensureAgentSystemPromptFile("claude", BODY_A);
+		const stamp = statSync(first).mtimeMs;
+		const second = ensureAgentSystemPromptFile("claude", BODY_A);
+		expect(second).toBe(first);
+		expect(statSync(second).mtimeMs).toBe(stamp);
+	});
+
+	it("repairs a truncated file instead of launching against half a protocol", () => {
+		const path = ensureAgentSystemPromptFile("claude", BODY_A);
+		writeFileSync(path, BODY_A.slice(0, 5), "utf-8");
+		expect(ensureAgentSystemPromptFile("claude", BODY_A)).toBe(path);
+		expect(readFileSync(path, "utf-8")).toBe(BODY_A);
+	});
+
+	it("leaves no temp file behind", () => {
+		ensureAgentSystemPromptFile("claude", BODY_A);
+		ensureAgentSystemPromptFile("claude", BODY_B);
+		expect(readdirSync(AGENT_PROMPTS_DIR).filter((f) => f.includes(".tmp"))).toEqual([]);
+	});
+
+	// No inline fallback: on Windows the inline body cannot be launched at all,
+	// and on POSIX it would put the protocol straight back into argv.
+	it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+		"throws when the file cannot be written",
+		() => {
+			const dir = join(AGENT_PROMPTS_DIR, "..", "unwritable-probe");
+			rmSync(dir, { recursive: true, force: true });
+			mkdirSync(dir, { recursive: true });
+			chmodSync(dir, 0o500);
+			try {
+				expect(() => writeFileSync(join(dir, "probe"), "x")).toThrow();
+			} finally {
+				chmodSync(dir, 0o700);
+				rmSync(dir, { recursive: true, force: true });
+			}
+			// Same failure through the real helper: an unwritable prompts dir.
+			const saved = statSync(AGENT_PROMPTS_DIR).mode;
+			chmodSync(AGENT_PROMPTS_DIR, 0o500);
+			try {
+				expect(() => ensureAgentSystemPromptFile("claude", `${BODY_A}-unwritable`)).toThrow(
+					/Could not write the agent system-prompt file/,
+				);
+			} finally {
+				chmodSync(AGENT_PROMPTS_DIR, saved);
+			}
+		},
+	);
+});

--- a/src/bun/agent-system-prompt-file.ts
+++ b/src/bun/agent-system-prompt-file.ts
@@ -1,53 +1,75 @@
 /**
  * The dev3 protocol delivered as a FILE instead of a command-line argument.
  *
- * Windows caps a process command line at `WINDOWS_COMMAND_LINE_LIMIT`
- * characters, and the protocol used to be longer than that on its own, so no
- * Claude session could start there at all. The protocol is now inside
- * `AGENT_SKILL_BODY_LIMIT` and would fit — but it would eat four fifths of the
- * line, leaving the user's own task description to blow the ceiling instead. So
- * on Windows the body still travels as a file, and the whole line stays for the
- * task text. See decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md.
+ * Two independent reasons, and either one alone is enough:
  *
- * POSIX has no such ceiling worth caring about (`ARG_MAX` is 1 MB on macOS,
- * 2 MB on Linux), so it keeps the inline form and this file is never written
- * there. The dialect decides, not the caller.
+ * 1. Windows caps a process command line at `WINDOWS_COMMAND_LINE_LIMIT`
+ *    characters and the protocol is most of that on its own, leaving the user's
+ *    own task description to blow the ceiling.
+ *    See decisions/2026/08/28/agent-command-lines-quote-in-the-launch-dialect.md.
+ * 2. On POSIX the whole protocol used to sit in every agent's `argv`, so ~29 KB
+ *    of ordinary English words was matchable by `pgrep -f` / `pkill -f`. One
+ *    agent killing "its own" process by pattern SIGTERMed every sibling agent on
+ *    the machine (h0x91b/dev-3.0#1734).
+ *
+ * So every platform now gets the file, and no platform carries the body in argv.
+ *
+ * The file name is content-addressed: two app versions running side by side
+ * write different bodies to different paths, so neither can overwrite the file
+ * the other's child process is about to read. Files are immutable once written
+ * and are never pruned — an older version's `claude.md` and every past body stay
+ * readable, which is what the on-disk layout invariants require.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { DEV3_HOME } from "./paths";
-import { launchDialectId } from "../shared/platform-launch";
 import { createLogger } from "./logger";
 
 const log = createLogger("agent-system-prompt");
 
 export const AGENT_PROMPTS_DIR = join(DEV3_HOME, "data", "agent-prompts");
 
-/** True when this platform cannot carry the protocol on the command line. */
-export function systemPromptNeedsFile(platform: NodeJS.Platform = process.platform): boolean {
-	return launchDialectId(platform) === "windows-powershell";
+/** Content address of a protocol body — the file name's stable half. */
+export function systemPromptFileDigest(body: string): string {
+	return createHash("sha256").update(body, "utf-8").digest("hex").slice(0, 16);
 }
 
 /**
- * Write (once) the body for `name` and return its path, or null when the write
- * fails — the caller then falls back to the inline form, which is broken on
- * Windows but is still better than refusing to launch.
+ * Write (once) the body for `name` and return its path.
+ *
+ * Throws when the file cannot be written. There is deliberately no inline
+ * fallback: on Windows it cannot be launched at all, and on POSIX it would
+ * silently put the protocol back into every agent's argv — the bug this file
+ * exists to close.
  */
-export function ensureAgentSystemPromptFile(name: string, body: string): string | null {
-	const path = join(AGENT_PROMPTS_DIR, `${name}.md`);
+export function ensureAgentSystemPromptFile(name: string, body: string): string {
+	const path = join(AGENT_PROMPTS_DIR, `${name}-${systemPromptFileDigest(body)}.md`);
 	try {
 		mkdirSync(AGENT_PROMPTS_DIR, { recursive: true });
-		let current = "";
+		if (readAsUtf8(path) === body) return path;
+		// Write through a temp name in the same directory: a concurrent launch
+		// must see either no file or the whole body, never a half-written one.
+		const temp = `${path}.${process.pid}.tmp`;
 		try {
-			current = readFileSync(path, "utf-8");
-		} catch {
-			// missing — written below
+			writeFileSync(temp, body, "utf-8");
+			renameSync(temp, path);
+		} catch (err) {
+			rmSync(temp, { force: true });
+			throw err;
 		}
-		if (current !== body) writeFileSync(path, body, "utf-8");
 		return path;
 	} catch (err) {
 		log.warn("Failed to write the agent system-prompt file", { path, error: String(err) });
+		throw new Error(`Could not write the agent system-prompt file ${path}: ${String(err)}`);
+	}
+}
+
+function readAsUtf8(path: string): string | null {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
 		return null;
 	}
 }

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -16,7 +16,7 @@ import { GEMINI_TRUSTED_FOLDERS } from "./worktree-trust";
 import { loadSettings, saveSettings } from "./settings";
 import { getCodexProfileForCurrentUiTheme, getCodexThemeForCurrentUiTheme } from "./theme-state";
 import { ensureClaudeStatusLineSettings } from "./rate-limit-monitor";
-import { ensureAgentSystemPromptFile, systemPromptNeedsFile } from "./agent-system-prompt-file";
+import { ensureAgentSystemPromptFile } from "./agent-system-prompt-file";
 import { getActiveClaudeConfigDir, getActiveClaudeSessionEnv, getActiveCodexSessionEnv } from "./agent-accounts";
 import { ENV_UNSET, claudeModelFamily } from "../shared/agent-accounts";
 export { claudeModelFamily } from "../shared/agent-accounts";
@@ -501,9 +501,9 @@ export function resolveAgentCommand(
 		// Codex-only: resolve the theme/profile runtime (impure) here so the pure
 		// adapter stays pure. Non-Codex agents skip it (avoids the codex --help probe).
 		codex: adapter.command === "codex" ? codexLaunchRuntime() : undefined,
-		// Windows caps a command line at 32 767 characters and the protocol is
-		// ~34 000, so there it has to reach the agent as a file. Resolved here
-		// because writing one is impure and the adapters are not.
+		// The protocol reaches Claude as a file on every platform: Windows cannot
+		// carry it on the command line, and POSIX argv is what `pkill -f` matches
+		// against. Resolved here because writing one is impure and adapters are not.
 		systemPromptFile: options?.skipSystemPrompt ? undefined : systemPromptFileFor(adapter),
 	};
 
@@ -516,17 +516,20 @@ export function resolveAgentCommand(
 
 /**
  * The file this adapter's protocol body was written to, or undefined when the
- * platform can carry it inline (every POSIX platform) or the adapter has no
- * flag that takes a file.
+ * adapter has no flag that takes one.
  *
- * Only Claude has one (`--append-system-prompt-file`). Codex delivers the body
- * through `-c developer_instructions=…` and the rest concatenate it onto the
- * prompt, so on Windows those launches are still over the ceiling — a separate
- * per-agent channel, not something this function can paper over.
+ * Only Claude has one (`--append-system-prompt-file`), and it is used on every
+ * platform — the body must stay out of argv, where `pkill -f` matches it
+ * (h0x91b/dev-3.0#1734). Codex delivers the body through
+ * `-c developer_instructions=…` and the rest concatenate it onto the prompt: a
+ * separate per-agent channel, not something this function can paper over.
+ *
+ * A failed write throws rather than falling back to the inline body — the
+ * fallback is exactly the argv exposure being closed.
  */
 function systemPromptFileFor(adapter: { command: string; skillBody?: string }): string | undefined {
-	if (!systemPromptNeedsFile() || adapter.command !== "claude" || !adapter.skillBody) return undefined;
-	return ensureAgentSystemPromptFile("claude", adapter.skillBody) ?? undefined;
+	if (adapter.command !== "claude" || !adapter.skillBody) return undefined;
+	return ensureAgentSystemPromptFile("claude", adapter.skillBody);
 }
 
 /** Every raw arg a launch adds beyond the preset's own: the selected backend's

--- a/src/shared/agent-adapters/claude.ts
+++ b/src/shared/agent-adapters/claude.ts
@@ -49,8 +49,11 @@ export const claudeAdapter: AgentAdapter = {
 		}
 
 		if (!options?.skipSystemPrompt) {
-			// The body is ~34 000 characters, which is past the Windows command-line
-			// ceiling on its own, so there it travels as a file the backend wrote.
+			// The body travels as a file the backend wrote: it is past the Windows
+			// command-line ceiling, and on POSIX an argv copy is what `pkill -f`
+			// pattern-matches against (h0x91b/dev-3.0#1734). Every dev3 launch goes
+			// through `resolveAgentCommand`, which always supplies the file; the
+			// inline branch is what a caller with no backend behind it gets.
 			if (options?.systemPromptFile) {
 				args.push("--append-system-prompt-file", quoteIfUnsafe(options.systemPromptFile));
 			} else {


### PR DESCRIPTION
Fixes #1734.

dev3 launched every Claude agent with `--append-system-prompt <~27 KB of protocol>`, so the whole lifecycle protocol sat in the agent's argv. `pgrep -f` / `pkill -f` match the full command line, so an ordinary word inside the protocol (`agent-browser`, `read-only`, `hibernate`) matched every running agent on the machine — one agent restarting its own browser daemon SIGTERMed every sibling. The safe channel already existed but was gated to Windows PowerShell, where the reason was the command-line ceiling rather than safety.

Claude now always gets `--append-system-prompt-file`. Prompt files are content-addressed (`claude-<sha256:16>.md`) and written through a temp file + rename, so two app versions running side by side cannot overwrite each other's body between dev3's write and the child's read. A failed write throws instead of silently restoring the inline form — that fallback was the exposure itself.

Verified by running it, because the flag is not printed in `claude --help` on 2.1.236: a prompt file with a random sentinel comes back from `claude -p` (control without the flag answers NONE), a live launch shows 214 bytes of argv and zero `pgrep -f` matches on the prompt text, while the old inline shape shows 14 645 bytes and four matches. Read-only evidence only: `ps`/`pgrep`, never `pkill`, no sibling process touched.

Note: already-running agents keep their old argv until they are restarted. A real Windows run was not done; the file channel there is unchanged in shape, only the file name became content-addressed.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=b99fb169-2b28-48fb-9cfc-12e99b5e0843) · `dev3://task/b99fb169-2b28-48fb-9cfc-12e99b5e0843` _(dev3 added this footer — turn it off in Settings → Tasks.)_