### PR TITLE
Stop offering task completion on a branch that never committed

### DIFF
--- a/change-logs/2026/09/11/fix-premature-merge-prompt.md
+++ b/change-logs/2026/09/11/fix-premature-merge-prompt.md
@@ -1,0 +1,3 @@
+Short: No merge prompt on brand-new tasks
+
+A task whose branch had not written a single commit could be told its branch was merged and be offered completion, because the merge check read the empty diff against the base as a delivered merge — most visibly in projects with no remote. The check now asks for positive proof that work landed (a merge commit carrying the branch head, or a commit the branch made that the base now contains), and that same proof also detects a purely local merge, which previously only a merged GitHub PR could.

--- a/decisions/2026/09/11/merge-detection-needs-proof-of-own-work.md
+++ b/decisions/2026/09/11/merge-detection-needs-proof-of-own-work.md
@@ -1,0 +1,56 @@
+# Merge detection asks for proof of own work, not an empty diff
+
+## Context
+
+A brand-new task — agent still asking its first clarifying question, not a line
+written — was offered "The branch is in the base branch / The merge is complete.
+Is the task complete too?" with a **Complete task** button. Reported with a
+screenshot of task #71 in a local-only project whose branch had only been renamed
+(`dev3/task-b498e2da` → `feat/dev3-colony-grass-test-map`).
+
+## Investigation
+
+`isContentMergedInto` (`src/bun/git.ts`) answered *true* for a branch with no
+commits of its own: `git merge-tree ref HEAD` equals `ref^{tree}`, and the
+patch-id path had an explicit `return true; // no task changes`. The old suite
+even pinned it — *"returns true when the branch carries no changes at all (empty
+diff)"*.
+
+Two callers guarded around it, one did not. `getBranchStatus`
+(`src/bun/rpc-handlers/git-operations.ts`) already skipped the content check when
+`ahead === 0`. The merge poller (`checkMergedBranches` in
+`src/bun/lifecycle/activities.ts`) only skipped it when `origin/<branch>` was
+missing — and a project with **no origin at all** forces `unpushed = 0` and goes
+straight into the content check. That is the reported repo.
+
+## Decision
+
+`isContentMergedInto` now resolves the `ahead === 0` case itself, in
+`isMergedWithoutOwnCommits`: the graph cannot separate "never committed" from
+"work merged", so it demands positive proof — a merge commit in `ref` whose
+parent is HEAD, or a tip this branch once committed (its own reflog, work-producing
+entries only) that `ref` now contains. No `gh` call on that path; callers keep
+their own PR proof. Both callers now go through it, so a purely local merge
+(including a fast-forward) is detected where previously only a merged GitHub PR
+counted.
+
+## Risks
+
+- **Reflog is the only witness of a fast-forward merge.** A pruned reflog (90-day
+  expiry) or a branch this machine never committed on degrades to "not merged" —
+  quiet, never a false prompt.
+- **Squash merge followed by a rebase is no longer detected locally**: the branch
+  tip becomes the base tip, byte-identical to an untouched branch that rebased
+  onto the base. Only the task's own merged PR separates them, and that proof
+  lives in both callers. `rebase` is deliberately excluded from the reflog
+  prefixes for exactly this reason.
+
+## Alternatives considered
+
+- **Guard the poller only** — leaves the landmine in `isContentMergedInto` for
+  the next caller, and keeps two different answers on two surfaces.
+- **Require a merged PR whenever `ahead === 0`** — simple, but blind to local
+  merges in repos with no GitHub remote, which is the very project that hit this.
+- **Store the branch's creation commit in the task** — the exact answer, but it
+  is new on-disk state that old app versions would not write, so tasks created
+  before it would stay undecidable.

--- a/src/bun/__tests__/git-merge-detection.test.ts
+++ b/src/bun/__tests__/git-merge-detection.test.ts
@@ -343,11 +343,11 @@ describe("isContentMergedInto", () => {
 		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
 	});
 
-	it("returns true when the branch carries no changes at all (empty diff)", async () => {
+	it("returns false when the branch carries no changes at all (a brand-new task branch)", async () => {
 		g("git checkout -b task-branch", repo.local);
 		g("git push -u origin task-branch", repo.local);
 
-		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
 	});
 
 	it("returns true after cherry-picking every task commit onto main", async () => {
@@ -380,6 +380,115 @@ describe("isContentMergedInto", () => {
 		g('git commit -m "other PR"', repo.local);
 		g("git push origin main", repo.local);
 		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
+	});
+});
+
+// A task branch that has written nothing is the same graph as one whose work was
+// merged: HEAD sits inside the base either way. These pin which side of that line
+// each real-world shape falls on — the false "Branch merged" prompt came from
+// reading the first shape as the second.
+describe("isContentMergedInto with a branch that has no commits of its own", () => {
+	let repo: TestRepo;
+
+	beforeEach(() => {
+		repo = createTestRepo();
+		ghPrListResponse = "[]";
+	});
+
+	afterEach(() => {
+		cleanup(repo);
+	});
+
+	it("returns false for a fresh branch in a repo with no remote at all", async () => {
+		g("git remote remove origin", repo.local);
+		g("git checkout -b task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "main")).toBe(false);
+	});
+
+	it("returns false for a fresh branch renamed before its first commit", async () => {
+		g("git checkout -b dev3/task-b498e2da", repo.local);
+		g("git branch -m feat/dev3-colony-grass-test-map", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "main")).toBe(false);
+	});
+
+	it("stays false for a fresh branch after the base advances", async () => {
+		g("git checkout -b task-branch", repo.local);
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "other.ts"), "export const x = 1;\n");
+		g("git add other.ts", repo.local);
+		g('git commit -m "someone else"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
+		// Re-running the detector must not drift — the poller asks every tick.
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
+	});
+
+	it("returns false when the branch's own commits were discarded, never merged", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git reset --hard main", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "main")).toBe(false);
+	});
+
+	it("returns true after a plain merge commit lands the branch in the base", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "other.ts"), "export const x = 1;\n");
+		g("git add other.ts", repo.local);
+		g('git commit -m "base moved on"', repo.local);
+		g("git merge --no-ff -m 'merge task-branch' task-branch", repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(true);
+	});
+
+	it("returns true after a local fast-forward merge, which leaves no merge commit", async () => {
+		g("git checkout -b task-branch", repo.local);
+		makeTaskCommits(repo.local);
+		g("git checkout main", repo.local);
+		g("git merge --ff-only task-branch", repo.local);
+		g("git checkout task-branch", repo.local);
+
+		expect(await isContentMergedInto(repo.local, "main")).toBe(true);
+	});
+
+	// Squash + rebase erases every local trace: the branch tip IS the base tip, byte
+	// for byte the same state an untouched branch that rebased onto the base is in.
+	// Only this task's own merged PR separates them, and that proof lives in the
+	// callers (getBranchStatus / the merge poller), not here.
+	it("returns false after a squash merge followed by a rebase onto the base", async () => {
+		g("git checkout -b task-branch", repo.local);
+		writeFileSync(join(repo.local, "feature.ts"), "export const add = (a: number, b: number) => a + b;\n");
+		g("git add feature.ts", repo.local);
+		g('git commit -m "feat: add function"', repo.local);
+		g("git checkout main", repo.local);
+		g("git merge --squash task-branch", repo.local);
+		g('git commit -m "squash: task (#1)"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+		g("git rebase origin/main", repo.local); // the branch's own commit is dropped as already applied
+
+		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
+	});
+
+	it("returns false for an untouched branch that merely rebased onto the base", async () => {
+		g("git checkout -b task-branch", repo.local);
+		g("git checkout main", repo.local);
+		writeFileSync(join(repo.local, "other.ts"), "export const x = 1;\n");
+		g("git add other.ts", repo.local);
+		g('git commit -m "base moved on"', repo.local);
+		g("git push origin main", repo.local);
+		g("git checkout task-branch", repo.local);
+		g("git rebase origin/main", repo.local);
 
 		expect(await isContentMergedInto(repo.local, "origin/main")).toBe(false);
 	});

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -5504,6 +5504,7 @@ describe("handlers.getBranchStatus", () => {
 			vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
 			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 			vi.mocked(git.canRebaseCleanly).mockResolvedValue(true);
+			vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 		}
 
 		it("reports merged when the task's own PR is merged (squash-merged, then rebased)", async () => {
@@ -5518,8 +5519,9 @@ describe("handlers.getBranchStatus", () => {
 
 			expect(result.mergedByContent).toBe(true);
 			expect(github.isPullRequestMerged).toHaveBeenCalledWith(project, "/tmp/wt", 1077, "dev3/t");
-			// Content strategies are pointless here — nothing of the branch is left.
-			expect(git.isContentMergedInto).not.toHaveBeenCalled();
+			// The local check runs first and finds nothing — squash + rebase leaves no
+			// local trace at all — so only the merged PR carries this verdict.
+			expect(git.isContentMergedInto).toHaveBeenCalled();
 		});
 
 		it("reports NOT merged for a brand-new branch sitting on the base tip", async () => {
@@ -5560,6 +5562,20 @@ describe("handlers.getBranchStatus", () => {
 			expect(result.mergedByContent).toBe(false);
 		});
 
+		it("reports merged with no PR at all when the local check proves the work landed", async () => {
+			const project = makeProject();
+			const task = makeTask({ worktreePath: "/tmp/wt", branchName: "dev3/t" });
+			vi.mocked(data.getProject).mockResolvedValue(project);
+			vi.mocked(data.getTask).mockResolvedValue(task);
+			mockAheadZero(0);
+			vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+
+			const result = await handlers.getBranchStatus({ taskId: "task-1", projectId: "proj-1" });
+
+			expect(result.mergedByContent).toBe(true);
+			expect(github.isPullRequestMerged).not.toHaveBeenCalled();
+		});
+
 		it("still uses the content strategies when the branch has commits of its own", async () => {
 			const project = makeProject();
 			const task = makeTask({ worktreePath: "/tmp/wt", branchName: "dev3/t", prNumber: 42, prUrl: "https://gh/pr/42" });
@@ -5588,6 +5604,7 @@ describe("handlers.getBranchStatus", () => {
 			vi.mocked(git.getUnpreservedCount).mockResolvedValue(-1);
 			vi.mocked(git.getBranchDiffStats).mockResolvedValue({ files: 0, insertions: 0, deletions: 0, fileStats: [] });
 			vi.mocked(github.runGitHub).mockResolvedValue({ ok: true, stdout: "[]", stderr: "", exitCode: 0 } as any);
+			vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 		}
 
 		it("hides the badge and refuses the merge proof when the PR's head is a foreign branch", async () => {
@@ -12149,6 +12166,7 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 		vi.mocked(git.isBranchMergedViaGitHubPR).mockResolvedValue(true);
 		setPushMessage(push);
 
@@ -12156,7 +12174,6 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		await vi.advanceTimersByTimeAsync(60_000);
 
 		expect(git.isBranchMergedViaGitHubPR).toHaveBeenCalledWith("/tmp/test-worktree", project);
-		expect(git.isContentMergedInto).not.toHaveBeenCalled();
 		expect(push).toHaveBeenCalledWith("branchMerged", expect.objectContaining({
 			taskId: task.id,
 			fingerprint: "v1:dev3/task-test:abc123",
@@ -12177,6 +12194,7 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 		vi.mocked(git.isBranchMergedViaGitHubPR).mockResolvedValue(false);
 		setPushMessage(push);
 
@@ -12184,6 +12202,34 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		await vi.advanceTimersByTimeAsync(60_000);
 
 		expect(push).not.toHaveBeenCalledWith("branchMerged", expect.anything());
+	});
+
+	// A local-only project never pushes, so origin/<branch> is absent for every
+	// task — the PR proof can never fire there. The local merge check is the only
+	// thing that can, and it is safe now that a branch with no commits of its own
+	// no longer reads as merged.
+	it("prompts when the remote branch is gone but the branch was merged locally", async () => {
+		const project = makeProject();
+		const task = makeTask({
+			status: "review-by-user",
+			worktreePath: "/tmp/test-worktree",
+			branchName: "dev3/task-test",
+		});
+		const push = vi.fn();
+
+		vi.mocked(data.loadProjects).mockResolvedValue([project]);
+		vi.mocked(data.loadTasks).mockResolvedValue([task]);
+		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
+		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
+		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(true);
+		vi.mocked(git.isBranchMergedViaGitHubPR).mockResolvedValue(false);
+		setPushMessage(push);
+
+		startMergeDetectionPoller();
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(push).toHaveBeenCalledWith("branchMerged", expect.objectContaining({ taskId: task.id }));
 	});
 
 	it("prompts when the remote branch is gone and the task's own PR merged, even though HEAD moved off the PR head (squash + rebase)", async () => {
@@ -12229,6 +12275,7 @@ describe("startMergeDetectionPoller / stopMergeDetectionPoller", () => {
 		vi.mocked(git.fetchOrigin).mockResolvedValue(true);
 		vi.mocked(git.getCurrentBranch).mockResolvedValue("dev3/task-test");
 		vi.mocked(git.getUnpushedCount).mockResolvedValue(-1);
+		vi.mocked(git.isContentMergedInto).mockResolvedValue(false);
 		vi.mocked(git.isBranchMergedViaGitHubPR).mockResolvedValue(false);
 		vi.mocked(git.getBranchStatus).mockResolvedValue({ ahead: 2, behind: 4, baseUnreachable: false });
 		vi.mocked(github.isPullRequestMerged).mockResolvedValue(true);

--- a/src/bun/git.ts
+++ b/src/bun/git.ts
@@ -1903,11 +1903,101 @@ const PATCH_ID_CMD = ["git", "patch-id", "--stable"];
 // has none, so we synthesise a zero SHA header.
 const FAKE_COMMIT_HEADER = new TextEncoder().encode(`commit ${"0".repeat(40)}\n\n`);
 
+/**
+ * Reflog messages that mean "this branch produced a commit of its own". A branch
+ * that only ever moved by `branch:`/`checkout:`/`reset:` entries never did.
+ *
+ * `rebase` is deliberately absent: its finish entry records the tip the branch
+ * was replayed onto, which for an empty branch is the base itself — proof of
+ * nothing. A rebase that kept real commits still leaves its `commit:` entries.
+ */
+const WORK_PRODUCING_REFLOG_RE = /^(commit|merge|cherry-pick|am|revert|pull|applypatch)\b/;
+/** How many distinct reflog tips to ancestry-test before giving up. */
+const REFLOG_PROOF_LIMIT = 10;
+
+/**
+ * Positive proof that a branch with **no commits of its own** against `ref` got
+ * there by having its work merged, rather than by never having written any.
+ *
+ * Both states are the same graph — HEAD is an ancestor of `ref` either way — so
+ * only history outside the graph can tell them apart. The branch's own reflog
+ * is that history: a tip it once committed (or rebased/cherry-picked) that is
+ * now contained in `ref` is work that landed. A brand-new branch has only its
+ * `branch: Created from ...` entry and yields nothing. A pruned or foreign
+ * reflog yields nothing either, which errs toward "not merged" on purpose.
+ *
+ * The graph still answers one case on its own: a plain (non-fast-forward) merge
+ * leaves a merge commit in `ref` whose parent is our HEAD, and that holds even
+ * for a branch this machine never committed on (a PR-review checkout).
+ *
+ * No `gh` call here — callers own their own PR proof, and this runs on every
+ * poll of every fresh task.
+ */
+async function isMergedWithoutOwnCommits(worktreePath: string, ref: string): Promise<boolean> {
+	const [headShaResult, branchResult] = await Promise.all([
+		run(["git", "rev-parse", "HEAD"], worktreePath),
+		run(["git", "rev-parse", "--abbrev-ref", "HEAD"], worktreePath),
+	]);
+	if (!headShaResult.ok || !headShaResult.stdout) return false;
+	const headSha = headShaResult.stdout;
+	assertSafeRef(headSha, "headSha");
+	assertSafeRef(ref, "ref");
+
+	// A merge commit in `ref` that has HEAD as one of its parents.
+	const mergesResult = await run(
+		["git", "rev-list", "--merges", "--parents", "--max-count=500", `${headSha}..${ref}`],
+		worktreePath,
+	);
+	if (mergesResult.ok && mergesResult.stdout) {
+		for (const line of mergesResult.stdout.split("\n")) {
+			if (line.split(" ").slice(1).includes(headSha)) {
+				log.info("isContentMergedInto", { ref, method: "merge-commit-parent", merged: true });
+				return true;
+			}
+		}
+	}
+
+	const branch = branchResult.ok ? branchResult.stdout : "";
+	if (!branch || branch === "HEAD") return false;
+	assertSafeRef(branch, "branch");
+	const reflogResult = await run(
+		["git", "log", "-g", "--format=%H%x09%gs", "--max-count=200", `refs/heads/${branch}`],
+		worktreePath,
+	);
+	if (!reflogResult.ok || !reflogResult.stdout) return false;
+
+	const tips: string[] = [];
+	for (const line of reflogResult.stdout.split("\n")) {
+		const [sha, message = ""] = line.split("\t");
+		if (!sha || !WORK_PRODUCING_REFLOG_RE.test(message)) continue;
+		if (!tips.includes(sha)) tips.push(sha);
+		if (tips.length >= REFLOG_PROOF_LIMIT) break;
+	}
+	for (const tip of tips) {
+		assertSafeRef(tip, "reflogTip");
+		if ((await run(["git", "merge-base", "--is-ancestor", tip, ref], worktreePath)).ok) {
+			log.info("isContentMergedInto", { ref, method: "reflog-tip", tip, merged: true });
+			return true;
+		}
+	}
+	log.info("isContentMergedInto", { ref, method: "no-own-commits", merged: false });
+	return false;
+}
+
 export async function isContentMergedInto(
 	worktreePath: string,
 	ref: string,
 	project?: Pick<Project, "githubAuthHost" | "githubAuthLogin">,
 ): Promise<boolean> {
+	// A branch with nothing of its own against `ref` makes every content strategy
+	// below trivially say "merged" — which is how a brand-new task branch that had
+	// not written a line got a "Branch merged → complete the task?" prompt. Ask
+	// for positive proof instead of reading the empty diff as a delivered merge.
+	const aheadResult = await run(["git", "rev-list", "--count", `${ref}..HEAD`], worktreePath);
+	if (aheadResult.ok && aheadResult.stdout === "0") {
+		return await isMergedWithoutOwnCommits(worktreePath, ref);
+	}
+
 	// Strategy 1: merge-tree comparison.
 	// Compute a hypothetical merge of ref and HEAD. If the resulting tree
 	// matches ref's tree, all of HEAD's changes are already incorporated —

--- a/src/bun/lifecycle/activities.ts
+++ b/src/bun/lifecycle/activities.ts
@@ -255,14 +255,16 @@ async function checkMergedBranches(): Promise<void> {
 				let merged: boolean;
 				if (unpushed === -1) {
 					// origin/<branch> is gone: either never pushed, or pruned after
-					// the PR merged (delete_branch_on_merge). Content strategies are
-					// unsafe here (a never-pushed branch with zero commits would
-					// false-positive), but a merged PR whose head equals local HEAD
-					// is definitive. A squash merge followed by a rebase moves HEAD off
+					// the PR merged (delete_branch_on_merge). The content check no
+					// longer reads a branch with zero commits of its own as merged,
+					// so it is safe here too and catches a purely local merge; a
+					// merged PR whose head equals local HEAD stays definitive.
+					// A squash merge followed by a rebase moves HEAD off
 					// that oid, so also accept this task's own merged PR — but only
 					// once the branch has no commits of its own left (ahead === 0),
 					// otherwise post-merge work would read as merged.
-					merged = await git.isBranchMergedViaGitHubPR(task.worktreePath!, project)
+					merged = await git.isContentMergedInto(task.worktreePath!, ref, project)
+						|| await git.isBranchMergedViaGitHubPR(task.worktreePath!, project)
 						|| (task.prNumber != null
 							&& (await git.getBranchStatus(task.worktreePath!, ref)).ahead === 0
 							&& await github.isPullRequestMerged(project, task.worktreePath!, task.prNumber, branchName));

--- a/src/bun/rpc-handlers/git-operations.ts
+++ b/src/bun/rpc-handlers/git-operations.ts
@@ -299,15 +299,16 @@ async function getBranchStatusImpl(params: { taskId: string; projectId: string; 
 	log.debug("getBranchStatus: raw results", { status, uncommitted, unpushed, branchDiff, prNumber, prUrl, ref });
 	const canRebase = status.behind > 0 ? await git.canRebaseCleanly(task.worktreePath, ref) : false;
 	// ahead === 0 means HEAD is an ancestor of `ref`: every commit of this branch
-	// is already in the base, so content strategies would trivially say "merged".
-	// Git alone cannot tell "merged, then rebased away" from "brand-new branch,
-	// nothing committed yet" — only this task's own merged PR proves work landed.
-	// No PR (or no GitHub / offline) ⇒ not merged, never a false positive.
+	// is already in the base. `isContentMergedInto` owns that case now — it demands
+	// positive proof that work landed (a merge commit carrying HEAD, or a reflog tip
+	// this branch committed and `ref` now contains) instead of reading the empty
+	// diff of a brand-new branch as a merge. This task's own merged PR still proves
+	// the "squash-merged, then rebased away" shape that leaves no local trace.
 	const prNumberForMergeProof = prInfo?.number ?? null;
-	const mergedByContent = status.ahead > 0
-		? await git.isContentMergedInto(task.worktreePath, ref, project) === true
-		: prNumberForMergeProof != null
-			&& await github.isPullRequestMerged(project, task.worktreePath, prNumberForMergeProof, branchForPush || null) === true;
+	const mergedByContent = await git.isContentMergedInto(task.worktreePath, ref, project) === true
+		|| (status.ahead === 0
+			&& prNumberForMergeProof != null
+			&& await github.isPullRequestMerged(project, task.worktreePath, prNumberForMergeProof, branchForPush || null) === true);
 	const mergeCompletionFingerprint = mergedByContent
 		? (await getMergeCompletionFingerprint(task, branchForPush)).fingerprint
 		: null;


### PR DESCRIPTION
A brand-new task — agent still asking its first clarifying question, not a line written — was offered "The branch is in the base branch / The merge is complete. Is the task complete too?" with a **Complete task** button.

## Cause

`isContentMergedInto` (`src/bun/git.ts`) answered *true* for a branch with no commits of its own: `git merge-tree <base> HEAD` equals `<base>^{tree}` when there is nothing to merge, and the patch-id path had an explicit `return true; // no task changes`. The old suite pinned it — *"returns true when the branch carries no changes at all (empty diff)"*.

Two callers guarded around that, one did not. `getBranchStatus` skipped the content check when the branch was not ahead of the base, and the merge poller skipped it when `origin/<branch>` was missing — but a project with **no origin at all** forces `unpushed = 0` and walks straight into the content check. That is the reported repo (its Push and PR buttons are greyed out in the screenshot).

## Fix

`isContentMergedInto` now resolves the "no commits of its own" case itself. The graph cannot separate "never committed" from "work landed in the base" — HEAD sits inside the base either way — so it demands positive proof:

1. a merge commit in the base whose parent is our HEAD, or
2. a reflog tip this branch itself committed that the base now contains (this is what catches a fast-forward merge, which leaves no merge commit).

No `gh` call on that path; both callers keep their own merged-PR proof. Side effect: a **purely local merge** is now detected, where previously only a merged GitHub PR counted.

## Known limitations, deliberately accepted

- **Squash merge followed by a rebase onto the base is no longer detected locally.** The branch tip becomes byte-for-byte the base tip — indistinguishable from an untouched branch that merely rebased. Only the task's own merged PR separates them, and that proof lives in both callers. `rebase` is excluded from the work-producing reflog prefixes for exactly this reason: its finish entry records the tip the branch was replayed onto, which for an empty branch is the base itself.
- **The reflog is the only witness of a fast-forward merge.** A pruned reflog (90-day expiry) or a branch this machine never committed on degrades to "not merged" — quiet, never a false prompt.

Rationale, risks and rejected alternatives: `decisions/2026/09/11/merge-detection-needs-proof-of-own-work.md`.

## Coverage

Seven new real-git fixtures: a fresh branch in a repo with no remote, a fresh branch renamed before its first commit, a fresh branch after the base advances (asked twice, as the poller does), own commits discarded by a reset, a plain merge commit, a local fast-forward merge, and an untouched branch that only rebased. The existing squash / rebase / cherry-pick / diverged-base cases keep their answers. Backend handler and poller tests cover both callers.

Verified end-to-end against the running app on a throwaway board backed by a local-only repo: the prompt appeared only for the task whose work was really merged, and stayed away from the commitless one.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=ec845f4d-8b43-44db-8a2a-9961f55d271a) · `dev3://task/ec845f4d-8b43-44db-8a2a-9961f55d271a` _(dev3 added this footer — turn it off in Settings → Tasks.)_