### PR TITLE
Keep the selected task visible when a status change reorders the sidebar

### DIFF
--- a/change-logs/2026/09/11/fix-sidebar-reveal-selected-task.md
+++ b/change-logs/2026/09/11/fix-sidebar-reveal-selected-task.md
@@ -1,0 +1,3 @@
+Short: Sidebar follows the selected task
+
+The left task list now scrolls just enough to keep the selected task visible when a status change reorders it — sending a message to an idle task no longer makes it vanish below the fold. The list stays put for background updates and never undoes a manual scroll.

--- a/decisions/2026/09/11/sidebar-reveal-selected-row.md
+++ b/decisions/2026/09/11/sidebar-reveal-selected-row.md
@@ -1,0 +1,49 @@
+# Revealing the selected sidebar row after a status-driven reorder
+
+## Context
+
+The left task list groups tasks into readiness tiers (`groupTasksIntoTiers`), so a task that
+starts working leaves NEEDS YOU and lands at the bottom of WAITING. The scroll position never
+moved with it: the user typed into an idle task, the agent started, and the still-selected row
+silently left the viewport.
+
+## Investigation
+
+Driving the running app showed two things a naive `scrollIntoView` would have got wrong. The
+tier headers are `sticky top-0`, so `block: "nearest"` tucks the row under a header; and
+`scrollIntoView` walks up the ancestors, which here means the page and the terminal pane.
+
+Measured in the browser, a single scroll assignment is also not enough: right after a task
+opens, the rest of the list has not laid out yet, so the browser clamps `scrollTop` and the
+row ends up 22 px short, then drifts further as rows arrive.
+
+## Decision
+
+`src/mainview/hooks/useRevealSelectedRow.ts`, wired into `ActiveTasksSidebar` with
+`data-task-id` on each row wrapper and `data-sidebar-tier` / `data-sidebar-tier-header` on the
+tier block. It writes the container's own `scrollTop` (never `scrollIntoView`), never touches
+focus, and fires only when the selected row's position key — task id, tier, index — changes.
+
+Three rules keep it out of the way:
+
+- A row the user had already scrolled away from stays where it is. A `scroll` listener records
+  whether the selected row was on screen; selecting another task overrides that, because
+  picking a task is an explicit request to see it.
+- After the first scroll the reveal keeps following the row frame by frame for up to a second,
+  which is what defeats the clamp described above. It stops as soon as the row is fully visible.
+- `wheel` / `touchstart` / `pointerdown` / `keydown` on the list cancel the whole thing. A
+  programmatic scroll must not count as the user taking over, which is why the follow loop
+  ignores `scrollTop` moving under it and watches for input events instead.
+
+## Risks
+
+The follow loop can scroll for up to a second after a reorder; if the list keeps reflowing for
+longer, the reveal gives up rather than chasing it forever. The `scroll` listener measures the
+selected row on every scroll event — three `getBoundingClientRect` calls, passive.
+
+## Alternatives considered
+
+`scrollIntoView({ block: "nearest" })`, as used by `TaskSwitcherOverlay` and `GlobalHeader`:
+rejected because it scrolls ancestors (page, terminal) and knows nothing about the sticky tier
+header. A `ResizeObserver` on the list instead of the frame loop: nothing in the sidebar is a
+single content wrapper to observe, and it would fire long after the reveal is over.

--- a/src/mainview/components/ActiveTasksSidebar.tsx
+++ b/src/mainview/components/ActiveTasksSidebar.tsx
@@ -22,6 +22,7 @@ import { getTaskAgentMeta } from "../utils/taskAgentMeta";
 import Tooltip from "./Tooltip";
 import { EyeIcon, PanelLeftIcon } from "./TaskIcons";
 import ActiveTaskRow from "./ActiveTaskRow";
+import { useRevealSelectedRow } from "../hooks/useRevealSelectedRow";
 import { useSpaces } from "../useSpaces";
 import SpaceIcon from "./SpaceIcon";
 import { spaceScopeProjectIds } from "../utils/spaceScope";
@@ -484,6 +485,24 @@ function ActiveTasksSidebar({
 		};
 	});
 
+	// Where the selected row sits in the rendered order. The reveal below fires on
+	// this key alone, so a status change that reorders the list scrolls it back
+	// into view while unrelated task updates leave the scroll position alone.
+	const listRef = useRef<HTMLDivElement>(null);
+	let selectedPositionKey: string | null = null;
+	if (activeTaskId) {
+		let index = 0;
+		for (const group of grouped) {
+			for (const task of group.tasks) {
+				if (task.id === activeTaskId && task.projectId === project?.id) {
+					selectedPositionKey = `${activeTaskId}:${group.key}:${index}`;
+				}
+				index++;
+			}
+		}
+	}
+	useRevealSelectedRow(listRef, activeTaskId ?? null, selectedPositionKey);
+
 	const handleSetPriority = useCallback(
 		async (task: Task, priority: TaskPriority) => {
 			try {
@@ -753,7 +772,7 @@ function ActiveTasksSidebar({
 			)}
 
 			{/* Task list */}
-			<div className="flex-1 overflow-y-auto overflow-x-hidden" data-help-id="sidebar.active-tasks">
+			<div ref={listRef} className="flex-1 overflow-y-auto overflow-x-hidden" data-help-id="sidebar.active-tasks">
 				{effectiveScope !== "project" && globalLoading && grouped.length === 0 ? (
 					<div className="px-3 py-6 text-center text-xs text-fg-muted">
 						{t("sidebar.globalLoading")}
@@ -771,7 +790,7 @@ function ActiveTasksSidebar({
 					</div>
 				) : (
 					grouped.map(({ key: groupKey, label: groupLabel, color: groupColor, tasks: groupTasks }, groupIdx) => (
-						<div key={groupKey}>
+						<div key={groupKey} data-sidebar-tier>
 							{/* Solid separator between readiness-tier blocks */}
 							{groupIdx > 0 && (
 								<div className="mx-3 border-t border-edge" />
@@ -780,7 +799,7 @@ function ActiveTasksSidebar({
 							{/* Tier header with count. No spinner: the WAITING tier merges
 							    working + AI-review + PRs, so a tier-wide spinner would mislead;
 							    the per-card rail busy-flow animation remains the cue. */}
-							<div className="relative px-3 py-1.5 flex items-center gap-2 sticky top-0 bg-base/95 backdrop-blur-sm z-10">
+							<div data-sidebar-tier-header className="relative px-3 py-1.5 flex items-center gap-2 sticky top-0 bg-base/95 backdrop-blur-sm z-10">
 								{/* Faint zone wash + left bar so the tier reads as one color zone */}
 								<span
 									className="absolute inset-0 pointer-events-none"
@@ -820,7 +839,7 @@ function ActiveTasksSidebar({
 								const showProjectBadge = effectiveScope !== "project" && task.projectId !== project?.id;
 
 								return (
-									<div key={task.id}>
+									<div key={task.id} data-task-id={task.id}>
 										{/* Dashed separator between tasks within the same group */}
 										{idx > 0 && (
 											<div className="mx-3 border-t border-dashed border-edge" />

--- a/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
+++ b/src/mainview/components/__tests__/ActiveTasksSidebar.test.tsx
@@ -1744,3 +1744,76 @@ describe("pull-request badges", () => {
 		expect(screen.getByLabelText("PR is mergeable — click to open the PR — Mergeable")).toHaveAttribute("title", "Mergeable");
 	});
 });
+
+describe("ActiveTasksSidebar — revealing the selected task", () => {
+	const VIEWPORT = 100;
+	const ROW_HEIGHT = 60;
+	const HEADER_HEIGHT = 20;
+
+	/** happy-dom has no layout: rows stack by document order under a sticky header. */
+	function stubLayout() {
+		vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+			const rect = (top: number, bottom: number) =>
+				({ top, bottom, height: bottom - top, left: 0, right: 0, width: 0, x: 0, y: top, toJSON() {} }) as DOMRect;
+			const container = document.querySelector('[data-help-id="sidebar.active-tasks"]');
+			if (this === container) return rect(0, VIEWPORT);
+			if (this.hasAttribute("data-sidebar-tier-header")) return rect(0, HEADER_HEIGHT);
+			if (this.hasAttribute("data-task-id")) {
+				const index = Array.from(document.querySelectorAll("[data-task-id]")).indexOf(this);
+				const top = HEADER_HEIGHT + index * ROW_HEIGHT - (container?.scrollTop ?? 0);
+				return rect(top, top + ROW_HEIGHT);
+			}
+			return rect(0, 0);
+		});
+	}
+
+	function sidebar(tasks: Task[]) {
+		return (
+			<I18nProvider>
+				<ActiveTasksSidebar project={project} tasks={tasks} activeTaskId="t1" dispatch={vi.fn()}
+					navigate={vi.fn()} agents={[claudeAgent]} bellCounts={new Map()} taskPorts={new Map()} />
+			</I18nProvider>
+		);
+	}
+
+	// Waiting tier, so a selected task that starts working sinks below them.
+	const others = [
+		makeTask({ id: "t2", seq: 2, status: "in-progress" }),
+		makeTask({ id: "t3", seq: 3, status: "in-progress" }),
+	];
+	// Highest seq, so once it starts working it sorts last inside the waiting tier.
+	const selectedIdle = makeTask({ id: "t1", seq: 9, status: "user-questions" });
+	const selectedWorking = makeTask({ id: "t1", seq: 9, status: "in-progress" });
+
+	beforeEach(stubLayout);
+	afterEach(() => vi.restoreAllMocks());
+
+	function list() {
+		return document.querySelector('[data-help-id="sidebar.active-tasks"]') as HTMLElement;
+	}
+
+	it("scrolls the selected task back into view when its status reorders the list", () => {
+		const { rerender } = render(sidebar([selectedIdle, ...others]));
+		expect(list().scrollTop).toBe(0);
+
+		rerender(sidebar([selectedWorking, ...others]));
+
+		expect(list().scrollTop).toBeGreaterThan(0);
+	});
+
+	it("stays put when a background task updates and the selection has not moved", () => {
+		const { rerender } = render(sidebar([selectedIdle, ...others]));
+		list().scrollTop = 40;
+
+		rerender(sidebar([selectedIdle, ...others.map((t) => ({ ...t, overview: "fresh" }))]));
+
+		expect(list().scrollTop).toBe(40);
+	});
+
+	it("keeps the selected row addressable and the tier header measurable", () => {
+		render(sidebar([selectedIdle, ...others]));
+
+		expect(list().querySelector('[data-task-id="t1"]')).not.toBeNull();
+		expect(list().querySelector("[data-sidebar-tier] [data-sidebar-tier-header]")).not.toBeNull();
+	});
+});

--- a/src/mainview/hooks/__tests__/useRevealSelectedRow.test.tsx
+++ b/src/mainview/hooks/__tests__/useRevealSelectedRow.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { computeRevealScrollTop, useRevealSelectedRow } from "../useRevealSelectedRow";
+
+/** Container viewport: 0..200 in client coords, with a 20px sticky tier header. */
+const CONTAINER_TOP = 0;
+const CONTAINER_BOTTOM = 200;
+const HEADER_HEIGHT = 20;
+const ROW_HEIGHT = 40;
+
+/** Rects come from `data-rect`, since happy-dom has no layout. */
+function stubRects() {
+	vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+		const raw = (this as HTMLElement).dataset.rect;
+		const { top = 0, bottom = 0 } = raw ? JSON.parse(raw) : {};
+		return { top, bottom, height: bottom - top, left: 0, right: 0, width: 0, x: 0, y: top, toJSON() {} } as DOMRect;
+	});
+}
+
+interface HarnessProps {
+	order: string[];
+	selectedId: string | null;
+	/** Scroll offset the rects are drawn at — the test keeps it in sync with the element. */
+	scrollTop: number;
+	/** Stands in for an unrelated task update: re-renders without moving anything. */
+	tick?: number;
+}
+
+function Harness({ order, selectedId, scrollTop }: HarnessProps) {
+	const listRef = useRef<HTMLDivElement>(null);
+	const index = selectedId ? order.indexOf(selectedId) : -1;
+	useRevealSelectedRow(listRef, selectedId, index >= 0 ? `${selectedId}:${index}` : null);
+	return (
+		<div
+			ref={listRef}
+			data-testid="list"
+			data-rect={JSON.stringify({ top: CONTAINER_TOP, bottom: CONTAINER_BOTTOM })}
+		>
+			<div data-sidebar-tier>
+				<div data-sidebar-tier-header data-rect={JSON.stringify({ top: CONTAINER_TOP, bottom: CONTAINER_TOP + HEADER_HEIGHT })} />
+				{order.map((id, i) => {
+					const top = CONTAINER_TOP - scrollTop + HEADER_HEIGHT + i * ROW_HEIGHT;
+					return <div key={id} data-task-id={id} data-rect={JSON.stringify({ top, bottom: top + ROW_HEIGHT })} />;
+				})}
+			</div>
+		</div>
+	);
+}
+
+describe("computeRevealScrollTop", () => {
+	const base = { containerTop: 0, containerBottom: 200, headerHeight: 20, scrollTop: 100 };
+
+	it("returns null while the row sits fully inside the viewport", () => {
+		expect(computeRevealScrollTop({ ...base, rowTop: 60, rowBottom: 100 })).toBeNull();
+	});
+
+	it("scrolls up by exactly what the sticky header hides", () => {
+		expect(computeRevealScrollTop({ ...base, rowTop: 5, rowBottom: 45 })).toBe(85);
+	});
+
+	it("scrolls down by exactly the overflow below the fold", () => {
+		expect(computeRevealScrollTop({ ...base, rowTop: 190, rowBottom: 230 })).toBe(130);
+	});
+
+	it("leaves a row taller than the viewport aligned to its top", () => {
+		expect(computeRevealScrollTop({ ...base, rowTop: 20, rowBottom: 400 })).toBeNull();
+		expect(computeRevealScrollTop({ ...base, rowTop: 10, rowBottom: 400 })).toBe(90);
+	});
+});
+
+describe("useRevealSelectedRow", () => {
+	beforeEach(stubRects);
+	afterEach(() => vi.restoreAllMocks());
+
+	function setup(props: HarnessProps) {
+		const view = render(<Harness {...props} />);
+		const list = screen.getByTestId("list") as HTMLDivElement;
+		list.scrollTop = props.scrollTop;
+		return { view, list };
+	}
+
+	it("reveals the selected row after a reorder pushes it below the fold", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+		expect(list.scrollTop).toBe(0);
+
+		// "a" starts working and sinks to the bottom of the list, below the fold.
+		view.rerender(<Harness order={["b", "c", "d", "e", "f", "a"]} selectedId="a" scrollTop={0} />);
+		expect(list.scrollTop).toBe(60);
+	});
+
+	it("does not scroll when the reordered row is still visible", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d"], selectedId: "a", scrollTop: 0 });
+
+		view.rerender(<Harness order={["b", "c", "a", "d"]} selectedId="a" scrollTop={0} />);
+		expect(list.scrollTop).toBe(0);
+	});
+
+	it("ignores background task updates that leave the selected row where it was", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f", "g"], selectedId: "g", scrollTop: 0 });
+		expect(list.scrollTop).toBe(0);
+
+		// Row "g" is out of view the whole time; nothing about the selection moved.
+		view.rerender(<Harness order={["a", "b", "c", "d", "e", "f", "g"]} selectedId="g" scrollTop={0} tick={1} />);
+		expect(list.scrollTop).toBe(0);
+	});
+
+	it("reveals a row selected from the keyboard without reordering the list", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+
+		view.rerender(<Harness order={["a", "b", "c", "d", "e", "f"]} selectedId="f" scrollTop={0} />);
+		expect(list.scrollTop).toBe(60);
+	});
+
+	it("leaves a manual scroll alone when nothing about the selection changed", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+
+		// The user scrolls down past the selected row.
+		list.scrollTop = 120;
+		fireEvent.scroll(list);
+		view.rerender(<Harness order={["a", "b", "c", "d", "e", "f"]} selectedId="a" scrollTop={120} tick={1} />);
+		expect(list.scrollTop).toBe(120);
+	});
+
+	it("scrolls back up when the selected row lands above the sticky header", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "f", scrollTop: 120 });
+
+		// "f" moves to the top tier while the view stays scrolled down.
+		view.rerender(<Harness order={["f", "a", "b", "c", "d", "e"]} selectedId="f" scrollTop={120} />);
+		expect(list.scrollTop).toBe(0);
+	});
+
+	it("leaves a row the user scrolled away from where it is", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+
+		// The user scrolls "a" off the top and keeps browsing further down the list.
+		list.scrollTop = 200;
+		view.rerender(<Harness order={["a", "b", "c", "d", "e", "f"]} selectedId="a" scrollTop={200} />);
+		fireEvent.scroll(list);
+
+		view.rerender(<Harness order={["b", "a", "c", "d", "e", "f"]} selectedId="a" scrollTop={200} />);
+
+		expect(list.scrollTop).toBe(200);
+	});
+
+	it("reveals a newly selected task even when the list was scrolled away", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+
+		list.scrollTop = 200;
+		fireEvent.scroll(list);
+		expect(list.scrollTop).toBe(200);
+
+		// Picking another task is an explicit request to see it.
+		view.rerender(<Harness order={["a", "b", "c", "d", "e", "f"]} selectedId="b" scrollTop={200} />);
+		expect(list.scrollTop).toBe(40);
+	});
+
+	it("finishes a reveal the browser clamped while the rows below were still laying out", () => {
+		const frames: FrameRequestCallback[] = [];
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => frames.push(cb));
+		vi.stubGlobal("cancelAnimationFrame", () => {});
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: "a", scrollTop: 0 });
+
+		// Only part of the list exists yet, so the browser clamps the scroll short.
+		let maxScroll = 20;
+		let value = 0;
+		Object.defineProperty(list, "scrollTop", {
+			get: () => value,
+			set: (v: number) => { value = Math.min(v, maxScroll); },
+			configurable: true,
+		});
+
+		view.rerender(<Harness order={["b", "c", "d", "e", "f", "a"]} selectedId="a" scrollTop={0} />);
+		expect(list.scrollTop).toBe(20);
+		expect(frames).toHaveLength(1);
+
+		// The rest of the rows land and the pending reveal completes on the next
+		// frame. The harness draws rows at a fixed offset, so the retry still
+		// measures the row below the fold and scrolls the rest of the way.
+		maxScroll = 1000;
+		frames.pop()!(0);
+		expect(list.scrollTop).toBe(80);
+
+		vi.unstubAllGlobals();
+	});
+
+	it("does nothing without a selected task", () => {
+		const { view, list } = setup({ order: ["a", "b", "c", "d", "e", "f"], selectedId: null, scrollTop: 90 });
+
+		view.rerender(<Harness order={["b", "a", "c", "d", "e", "f"]} selectedId={null} scrollTop={90} />);
+		expect(list.scrollTop).toBe(90);
+	});
+});

--- a/src/mainview/hooks/useRevealSelectedRow.ts
+++ b/src/mainview/hooks/useRevealSelectedRow.ts
@@ -1,0 +1,135 @@
+import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+
+export interface RevealGeometry {
+	/** Scroll container's viewport edges, in client coordinates. */
+	containerTop: number;
+	containerBottom: number;
+	/** Selected row's edges, in client coordinates. */
+	rowTop: number;
+	rowBottom: number;
+	/** Sticky tier header covering the container's top edge. */
+	headerHeight: number;
+	scrollTop: number;
+}
+
+/**
+ * Smallest scrollTop that brings the row fully into view, or null when it
+ * already is. Above the fold the row clears the sticky tier header; below it
+ * the row's bottom meets the container's. A row taller than the viewport is
+ * aligned to its top — the title lives there.
+ */
+export function computeRevealScrollTop(g: RevealGeometry): number | null {
+	const visibleTop = g.containerTop + g.headerHeight;
+	if (g.rowTop < visibleTop) return g.scrollTop - (visibleTop - g.rowTop);
+	if (g.rowBottom > g.containerBottom) {
+		const delta = Math.min(g.rowBottom - g.containerBottom, g.rowTop - visibleTop);
+		return delta > 0 ? g.scrollTop + delta : null;
+	}
+	return null;
+}
+
+/** An unfinished reveal keeps trying for ~60 frames (1s), then gives up. */
+const RETRY_FRAMES = 60;
+
+/** The user's own hands on the list — these call the whole reveal off. */
+const TAKEOVER_EVENTS = ["wheel", "touchstart", "pointerdown", "keydown"] as const;
+
+function measure(container: HTMLElement, selectedTaskId: string): RevealGeometry | null {
+	const row = container.querySelector(`[data-task-id="${selectedTaskId}"]`);
+	if (!row) return null;
+	const containerRect = container.getBoundingClientRect();
+	const rowRect = row.getBoundingClientRect();
+	const header = row.closest("[data-sidebar-tier]")?.querySelector("[data-sidebar-tier-header]");
+	return {
+		containerTop: containerRect.top,
+		containerBottom: containerRect.bottom,
+		rowTop: rowRect.top,
+		rowBottom: rowRect.bottom,
+		headerHeight: header ? header.getBoundingClientRect().height : 0,
+		scrollTop: container.scrollTop,
+	};
+}
+
+/**
+ * Scrolls the sidebar just enough to reveal the selected row again after a
+ * status change reorders the list. It moves the container's own scrollTop —
+ * never `scrollIntoView`, which would also scroll the page and the terminal —
+ * and never touches focus.
+ *
+ * Two gates keep it out of the user's way: it runs only when `positionKey`
+ * changes, so background task updates leave the scroll alone, and a row the
+ * user had already scrolled away from stays where it is. Picking another task
+ * always reveals it, wherever the list happens to sit.
+ */
+export function useRevealSelectedRow(
+	containerRef: RefObject<HTMLElement | null>,
+	selectedTaskId: string | null,
+	positionKey: string | null,
+) {
+	// Whether the selected row was on screen before this update — the difference
+	// between "it flew out from under the user" and "the user scrolled away".
+	const wasVisibleRef = useRef(true);
+	const lastSelectedRef = useRef<string | null>(null);
+	const retryRef = useRef<number | null>(null);
+
+	useLayoutEffect(() => {
+		const container = containerRef.current;
+		if (!positionKey || !selectedTaskId || !container) return;
+		const geometry = measure(container, selectedTaskId);
+		if (!geometry) return;
+		const reselected = lastSelectedRef.current !== selectedTaskId;
+		lastSelectedRef.current = selectedTaskId;
+		const needed = computeRevealScrollTop(geometry);
+		const allowed = reselected || wasVisibleRef.current;
+		let stop = (_byUser = false) => {};
+		if (needed !== null && allowed) {
+			// One pass is not enough: the rest of the list is often still laying
+			// out, so the browser clamps the scroll short and then shifts the row
+			// again. Follow it frame by frame until it is fully in view — and drop
+			// everything the moment the user touches the list themselves.
+			let framesLeft = RETRY_FRAMES;
+			const onTakeover = () => stop(true);
+			stop = (byUser = false) => {
+				if (retryRef.current !== null) cancelAnimationFrame(retryRef.current);
+				retryRef.current = null;
+				for (const event of TAKEOVER_EVENTS) container.removeEventListener(event, onTakeover);
+				// Our own scrolling fires scroll events mid-flight, so the tracker
+				// below may have recorded a half-scrolled frame. Only the user's own
+				// takeover decides that the row was left behind on purpose.
+				const g = byUser ? measure(container, selectedTaskId) : null;
+				wasVisibleRef.current = g ? computeRevealScrollTop(g) === null : true;
+			};
+			const step = () => {
+				const g = measure(container, selectedTaskId);
+				const target = g ? computeRevealScrollTop(g) : null;
+				if (target === null || --framesLeft <= 0) {
+					stop();
+					return;
+				}
+				container.scrollTop = target;
+				retryRef.current = requestAnimationFrame(step);
+			};
+			for (const event of TAKEOVER_EVENTS) container.addEventListener(event, onTakeover, { passive: true });
+			wasVisibleRef.current = true;
+			step();
+		} else {
+			wasVisibleRef.current = needed === null;
+		}
+		return () => stop();
+		// containerRef is a stable ref; the position key is the only trigger.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [positionKey]);
+
+	// Manual scrolling is what tells us the user left the selected row behind.
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+		function onScroll() {
+			if (!container || !selectedTaskId) return;
+			const geometry = measure(container, selectedTaskId);
+			if (geometry) wasVisibleRef.current = computeRevealScrollTop(geometry) === null;
+		}
+		container.addEventListener("scroll", onScroll, { passive: true });
+		return () => container.removeEventListener("scroll", onScroll);
+	}, [containerRef, selectedTaskId]);
+}


### PR DESCRIPTION
Selecting an idle task in the left task list and typing to it starts the agent, which moves the task from the NEEDS YOU tier to the bottom of WAITING. The list never followed: the still-selected row silently left the viewport while the scroll position stayed where it was.

The new `useRevealSelectedRow` hook scrolls the sidebar's own container just far enough to bring the selected row back into view, and `ActiveTasksSidebar` marks the pieces it measures (`data-task-id` on each row, `data-sidebar-tier` / `data-sidebar-tier-header` on the tier block). Sorting and selection are untouched.

Behaviour:

- The selected row was visible and got reordered out of view → the list scrolls exactly as far as needed, no further.
- The row is still visible after the reorder, or an unrelated task updated → nothing moves.
- Another task gets selected (click, switcher, shortcut) → it is revealed wherever the list happens to sit.
- The user had scrolled away from the selected row themselves → no snap-back.
- `wheel` / `touchstart` / `pointerdown` / `keydown` on the list cancel an in-flight reveal.

Two details worth knowing, both found by driving the running app:

- One `scrollTop` assignment is not enough right after a task opens — the rest of the list is still laying out, the browser clamps the scroll, and the row ends up ~22px short. The reveal therefore follows the row frame by frame for up to a second, stopping as soon as it is fully in view.
- "The user scrolled away" cannot be told from "the list reflowed under us" by watching `scrollTop`, since a programmatic scroll looks identical. Cancellation hangs off real input gestures instead.

It writes the container's own `scrollTop` rather than calling `scrollIntoView`, which would also scroll the page and the terminal pane, and it never touches focus. The row is aligned below the sticky tier header instead of under it.

Rationale and the rejected alternatives are in `decisions/2026/09/11/sidebar-reveal-selected-row.md`. Covered by 14 unit tests for the hook plus 3 in the sidebar suite, and verified in a browser at 1100x800, 1440x900 and 2560x1440.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=9084b394-98e1-430f-8927-34a119f026df) · `dev3://task/9084b394-98e1-430f-8927-34a119f026df` _(dev3 added this footer — turn it off in Settings → Tasks.)_