### PR TITLE
Report clone-path copy failures instead of logging them as success

### DIFF
--- a/change-logs/2026/09/12/fix-clone-path-copy-failure-reported.md
+++ b/change-logs/2026/09/12/fix-clone-path-copy-failure-reported.md
@@ -1,0 +1,5 @@
+Short: Clone paths report failed copies
+
+A clone path that failed to copy into a new worktree used to be logged as copied and silently missing; the copy's exit code and stderr are now checked, logged as an error, and shown on the task as a dismissible notice in the terminal. A source that simply does not exist in the project root is still skipped quietly, and a failed path no longer blocks the launch.
+
+Suggested by @diverru (h0x91b/dev-3.0#1728)

--- a/decisions/2026/09/11/clone-path-failures-are-reported-not-fatal.md
+++ b/decisions/2026/09/11/clone-path-failures-are-reported-not-fatal.md
@@ -1,0 +1,47 @@
+# Clone-path copy failures are reported on the task, not fatal to the launch
+
+## Context
+
+`cloneSingle` ran a plain `cp -R` as the last step of the CoW cascade and never read
+its exit code. A failed copy logged `Copied via cp -R`, the summary counted the path
+as `copy`, and the worktree simply lacked it (issue #1728, reported by @diverru).
+This matters more than a slow install: `clonePaths` is the only preparation hook that
+finishes **before** the agent launches, while `setupScript` in the default `parallel`
+mode starts alongside an already-running agent pane. A git-ignored file the agent
+reads once at startup can arrive only through `clonePaths`.
+
+## Investigation
+
+`runCowClones` (`src/bun/lifecycle/executor.ts`) discarded the `CloneResult[]`
+entirely, and `CloneResult.error` existed but was never written by anything. The
+Windows branch had the opposite failure mode: a rejected `node:fs` `cp` propagated
+out of `Promise.all` and aborted the whole preparation.
+
+## Decision
+
+`run()` in `src/bun/cow-clone.ts` now returns `{ code, stderr }` with stderr piped;
+the final `cp -R` and the Windows `cp` turn a non-zero exit or a throw into a
+`CloneResult` carrying `error` (last stderr line + exit code), logged at error level.
+Intermediate cascade steps stay at debug — a filesystem without reflink fails every
+time. `runCowClones` writes the failures to `Task.cloneFailures` and pushes
+`taskUpdated`; `TaskTerminal` renders them as a dismissible strip stacked with the
+setup-failure strip, cleared by `dismissCloneFailures` or by the next launch.
+
+**A failed clone path does not abort the launch.** The worktree is usable and one
+missing cache should not cost the user the task; a visible notice beats a dead
+launch. A *missing source* stays a silent skip (`skipped: true`) — a clone list is
+shared across machines, so an absent path is expected, not a fault.
+
+## Risks
+
+`Task.cloneFailures` is additive on disk; an older app version ignores it, so the
+notice is invisible there but nothing breaks. Piping stderr means the child's stderr
+is drained by us rather than inherited — `cp` writes little, and the reader runs
+before `await proc.exited` so a full pipe cannot deadlock it.
+
+## Alternatives considered
+
+- **Throw and fail preparation** — surfaces through the existing `preparationError`
+  UI with no new field, but one unreadable path would block the whole task.
+- **A transient toast / attention badge** — no persistence: a user who was not
+  looking at the app during preparation would never learn about it.

--- a/src/bun/__tests__/cow-clone.test.ts
+++ b/src/bun/__tests__/cow-clone.test.ts
@@ -28,8 +28,11 @@ vi.mock("../logger", () => ({
 
 import { clonePaths, detectClonePaths, WELL_KNOWN_CLONE_PATHS } from "../cow-clone";
 
-function makeProc(exitCode: number) {
-	return { exited: Promise.resolve(exitCode) };
+function makeProc(exitCode: number, stderr = "") {
+	return {
+		exited: Promise.resolve(exitCode),
+		stderr: stderr ? new Response(stderr).body : undefined,
+	};
 }
 
 describe("cow-clone", () => {
@@ -184,6 +187,78 @@ describe("cow-clone", () => {
 		expect((mkdirCall![0] as string[]).join(" ")).toContain("/dst/frontend");
 	});
 
+	// The cascade's last step has nothing behind it: whatever it reports is the
+	// truth about whether the path is in the worktree (issue #1728).
+	describe("final cp -R fallback", () => {
+		const origPlatform = process.platform;
+		beforeEach(() => {
+			Object.defineProperty(process, "platform", { value: "linux", writable: true });
+		});
+		afterEach(() => {
+			Object.defineProperty(process, "platform", { value: origPlatform, writable: true });
+		});
+
+		function cascade(finalCopyExit: number, stderr = "") {
+			mockSpawn.mockImplementation((cmd: string[]) => {
+				if (cmd[0] !== "cp") return makeProc(0);
+				if (cmd.includes("--reflink=always")) return makeProc(1, "cp: --reflink unsupported");
+				return makeProc(finalCopyExit, stderr);
+			});
+		}
+
+		it("reports success with no error when the plain copy succeeds", async () => {
+			cascade(0);
+			const results = await clonePaths("/src", "/dst", ["node_modules"]);
+			expect(results[0]).toMatchObject({ path: "node_modules", method: "copy" });
+			expect(results[0].error).toBeUndefined();
+			expect(results[0].skipped).toBeUndefined();
+		});
+
+		it("reports a failure with the exit code and stderr when the plain copy fails", async () => {
+			cascade(1, "cp: /src/.env: Permission denied");
+			const results = await clonePaths("/src", "/dst", [".env"]);
+			expect(results).toHaveLength(1);
+			expect(results[0].error).toContain("Permission denied");
+			expect(results[0].error).toContain("exited 1");
+			expect(results[0].skipped).toBeUndefined();
+		});
+
+		it("still reports the exit code when the command wrote nothing to stderr", async () => {
+			cascade(2);
+			const results = await clonePaths("/src", "/dst", [".env"]);
+			expect(results[0].error).toBe("cp -R exited 2");
+		});
+
+		it("never marks a failed path as copied, even alongside a successful one", async () => {
+			mockSpawn.mockImplementation((cmd: string[]) => {
+				if (cmd[0] !== "cp") return makeProc(0);
+				if (cmd.includes("--reflink=always")) return makeProc(1);
+				return cmd.includes("/src/.env")
+					? makeProc(1, "cp: /src/.env: Permission denied")
+					: makeProc(0);
+			});
+
+			const results = await clonePaths("/src", "/dst", ["node_modules", ".env"]);
+			const ok = results.find((r) => r.path === "node_modules")!;
+			const bad = results.find((r) => r.path === ".env")!;
+			expect(ok.error).toBeUndefined();
+			expect(bad.error).toBeDefined();
+			// A summary that counted this as a copy is exactly the reported bug.
+			expect(results.filter((r) => !r.error && !r.skipped)).toHaveLength(1);
+		});
+
+		it("keeps a missing source a skip, not a failure", async () => {
+			mockSpawn.mockImplementation((cmd: string[]) => (
+				cmd[0] === "test" ? makeProc(1) : makeProc(0)
+			));
+			const results = await clonePaths("/src", "/dst", ["node_modules"]);
+			expect(results[0].skipped).toBe(true);
+			expect(results[0].error).toBeUndefined();
+			// Nothing was copied, so no cp ran at all.
+			expect(mockSpawn.mock.calls.some((c: unknown[]) => (c[0] as string[])[0] === "cp")).toBe(false);
+		});
+	});
+
 	describe("on Windows", () => {
 		const origPlatform = process.platform;
 		beforeEach(() => {
@@ -191,6 +266,8 @@ describe("cow-clone", () => {
 		});
 		afterEach(() => {
 			Object.defineProperty(process, "platform", { value: origPlatform, writable: true });
+			// clearAllMocks keeps implementations, so a rigged cp would outlive this block.
+			mockCp.mockImplementation((async () => undefined) as never);
 		});
 
 		it("copies through node:fs without spawning a POSIX binary", async () => {
@@ -209,6 +286,15 @@ describe("cow-clone", () => {
 		it("creates the destination parent for a nested path", async () => {
 			await clonePaths("D:\\src\\repo", "C:/wt/worktree", ["frontend/node_modules"]);
 			expect(mockMkdir).toHaveBeenCalledWith("C:/wt/worktree/frontend", { recursive: true });
+		});
+
+		it("turns a copy error into a failed result instead of rejecting the whole clone", async () => {
+			mockCp.mockImplementation((async (src: string) => {
+				if (src.endsWith("node_modules")) throw new Error("EPERM: operation not permitted");
+			}) as never);
+			const results = await clonePaths("D:\\src\\repo", "C:/wt/worktree", ["node_modules", ".env"]);
+			expect(results.find((r) => r.path === "node_modules")!.error).toContain("EPERM");
+			expect(results.find((r) => r.path === ".env")!.error).toBeUndefined();
 		});
 	});
 });

--- a/src/bun/__tests__/rpc-handlers.test.ts
+++ b/src/bun/__tests__/rpc-handlers.test.ts
@@ -284,7 +284,7 @@ vi.mock("../artifact-template", () => ({
 }));
 
 vi.mock("../cow-clone", () => ({
-	clonePaths: vi.fn(),
+	clonePaths: vi.fn(async () => []),
 }));
 
 vi.mock("../logger", () => ({

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -159,7 +159,7 @@ is genuinely ambiguous (e.g., multiple possible dev servers, unclear base branch
    | \`setupScript\` | Package manager install command. Detect from lockfile: \`bun.lockb\` → \`bun install\`, \`pnpm-lock.yaml\` → \`pnpm install\`, \`yarn.lock\` → \`yarn\`, \`package-lock.json\` → \`npm install\`. For Python: \`pip install -e .\` or \`poetry install\`. For Rust: \`cargo build\`. Chain multiple steps with \`&&\` if needed. |
    | \`devScript\` | The dev server command. Check \`package.json\` scripts for \`dev\`, \`start\`, \`serve\`. Use the full command: \`bun run dev\`, \`npm run dev\`, etc. If no dev server exists, leave empty. |
    | \`cleanupScript\` | Teardown hook that runs before the task worktree is removed — on \`completed\` / \`cancelled\`, when an active task is deleted (\`$DEV3_TASK_STATUS\` = \`deleted\`), or when task preparation is cancelled (\`$DEV3_TASK_STATUS\` = \`todo\`). Useful for copy-back, exports, cache cleanup, and tearing down per-worktree containers. Inside the script you can branch on \`$DEV3_TASK_STATUS\`, \`$DEV3_TASK_FROM_STATUS\`, and \`$DEV3_TASK_TO_STATUS\`, plus the workspace env vars from step 3b. |
-   | \`clonePaths\` | Heavy directories that should be CoW-cloned into new worktrees instead of re-downloaded. Common: \`node_modules\`, \`.venv\`, \`target\`, \`.next\`, \`build\`. Only include dirs that actually exist in the project. |
+   | \`clonePaths\` | Directories **and individual files** CoW-cloned from the project root into every new worktree instead of being re-downloaded or lost. Heavy dirs: \`node_modules\`, \`.venv\`, \`target\`, \`.next\`, \`build\`. Single files matter just as much: a git-ignored \`.npmrc\`, \`.env\`, or a personal instruction file reaches the worktree only through here. Glob patterns are expanded. A path missing from the project root is skipped silently; a path that exists but fails to copy is logged as an error and shown on the task. |
    | \`defaultBaseBranch\` | Check \`git symbolic-ref refs/remotes/origin/HEAD\` or look at common branches. Usually \`main\` or \`master\`. |
    | \`defaultCompareRefMode\` | Default diff comparison target. Use \`"remote"\` for \`origin/<baseBranch>\` (recommended default) or \`"local"\` for the local base branch. |
    | \`peerReviewEnabled\` | Default \`true\`. Only set \`false\` for personal/solo projects. |
@@ -236,7 +236,7 @@ EOF
 | \`setupScript\` | string | Runs after a new worktree is created (install deps, generate code, etc.). Gets the workspace env vars from step 3b |
 | \`devScript\` | string | Dev server command (powers the "Dev Server" button in the UI) |
 | \`cleanupScript\` | string | Runs before the task worktree is removed (\`completed\` / \`cancelled\` / task deleted / preparation cancelled) |
-| \`clonePaths\` | string[] | Dirs to CoW-clone into worktrees (faster than re-downloading) |
+| \`clonePaths\` | string[] | Files and dirs (globs allowed) CoW-cloned into every worktree. Runs BEFORE the agent launches — unlike \`setupScript\`, which in the default \`parallel\` mode starts alongside the already-running agent — so this is the only hook that can put a git-ignored file in place before the agent reads it. Missing sources are skipped |
 | \`defaultBaseBranch\` | string | Base branch for new task branches (default: \`main\`) |
 | \`defaultCompareRefMode\` | \`"remote" \| "local"\` | Default diff comparison target (\`origin/<baseBranch>\` vs local base branch) |
 | \`peerReviewEnabled\` | boolean | Whether peer review is required (default: \`true\`) |

--- a/src/bun/cow-clone.ts
+++ b/src/bun/cow-clone.ts
@@ -21,6 +21,12 @@ export interface CloneResult {
 	path: string;
 	method: CloneMethod;
 	durationMs: number;
+	/**
+	 * The source does not exist in the project root. Deliberate and not an error:
+	 * a clone list is shared across machines and auto-detection is a snapshot, so
+	 * a path that is simply absent is skipped. `error` is the opposite case — the
+	 * source WAS there and the copy failed.
+	 */
 	skipped?: boolean;
 	error?: string;
 }
@@ -130,10 +136,33 @@ async function pathExists(fullPath: string): Promise<boolean> {
 	}
 }
 
-/** Run a command and return exit code. */
-async function run(cmd: string[]): Promise<number> {
-	const proc = spawn(cmd);
-	return await proc.exited;
+interface RunOutcome {
+	code: number;
+	stderr: string;
+}
+
+/** Drain a piped stderr before awaiting exit — a full pipe would deadlock the child. */
+async function readStderr(proc: { stderr?: unknown }): Promise<string> {
+	const stream = proc.stderr;
+	if (!stream || typeof stream === "number") return "";
+	try {
+		return (await new Response(stream as ReadableStream).text()).trim();
+	} catch {
+		return "";
+	}
+}
+
+/** Run a command and return its exit code plus whatever it wrote to stderr. */
+async function run(cmd: string[]): Promise<RunOutcome> {
+	const proc = spawn(cmd, { stderr: "pipe" });
+	const stderr = await readStderr(proc);
+	return { code: await proc.exited, stderr };
+}
+
+/** One line for a log field and for the task banner — never an empty string. */
+function describeFailure(cmd: string, outcome: RunOutcome): string {
+	const detail = outcome.stderr.split("\n").filter(Boolean).slice(-1)[0];
+	return detail ? `${detail} (${cmd} exited ${outcome.code})` : `${cmd} exited ${outcome.code}`;
 }
 
 /**
@@ -186,7 +215,11 @@ async function cloneSingle(
 	await removePath(dst);
 
 	if (isWindows()) {
-		await cp(src, dst, { recursive: true, force: true });
+		try {
+			await cp(src, dst, { recursive: true, force: true });
+		} catch (err) {
+			return failed(relativePath, start, String(err), { src, dst });
+		}
 		const ms = Math.round(performance.now() - start);
 		log.info("Copied via node:fs cp", { path: relativePath, ms });
 		return { path: relativePath, method: "copy", durationMs: ms };
@@ -201,27 +234,56 @@ async function cloneSingle(
 		}
 
 		// 2. Try cp -cR (per-file APFS clone)
-		if ((await run(["cp", "-cR", src, dst])) === 0) {
+		const apfs = await run(["cp", "-cR", src, dst]);
+		if (apfs.code === 0) {
 			const ms = Math.round(performance.now() - start);
 			log.info("Cloned via cp -cR", { path: relativePath, ms });
 			return { path: relativePath, method: "apfs-clone", durationMs: ms };
 		}
+		log.debug("cp -cR failed, falling back", { path: relativePath, reason: describeFailure("cp -cR", apfs) });
 		await removePath(dst);
 	} else {
-		// Linux: try reflink
-		if ((await run(["cp", "-R", "--reflink=always", src, dst])) === 0) {
+		// Linux: try reflink. A filesystem without reflink support fails every
+		// time, so this stays at debug — only the last fallback is an error.
+		const reflink = await run(["cp", "-R", "--reflink=always", src, dst]);
+		if (reflink.code === 0) {
 			const ms = Math.round(performance.now() - start);
 			log.info("Cloned via reflink", { path: relativePath, ms });
 			return { path: relativePath, method: "reflink", durationMs: ms };
 		}
+		log.debug("reflink failed, falling back", { path: relativePath, reason: describeFailure("cp -R --reflink=always", reflink) });
 		await removePath(dst);
 	}
 
-	// Fallback: regular copy
-	await run(["cp", "-R", src, dst]);
+	// Last fallback. Nothing catches a failure after this, so its exit code is the
+	// only thing standing between a missing path and a worktree that claims to have it.
+	const copy = await run(["cp", "-R", src, dst]);
+	if (copy.code !== 0) {
+		return failed(relativePath, start, describeFailure("cp -R", copy), { src, dst });
+	}
 	const ms = Math.round(performance.now() - start);
 	log.info("Copied via cp -R", { path: relativePath, ms });
 	return { path: relativePath, method: "copy", durationMs: ms };
+}
+
+/** A copy that did not happen: logged loudly, and carried back to the caller. */
+function failed(
+	relativePath: string,
+	start: number,
+	error: string,
+	where: { src: string; dst: string },
+): CloneResult {
+	log.error("Clone path copy failed — it is missing from the worktree", {
+		path: relativePath,
+		...where,
+		error,
+	});
+	return {
+		path: relativePath,
+		method: "copy",
+		durationMs: Math.round(performance.now() - start),
+		error,
+	};
 }
 
 /**
@@ -372,10 +434,21 @@ export async function clonePaths(
 	);
 
 	const totalMs = results.reduce((sum, r) => Math.max(sum, r.durationMs), 0);
+	const failures = results.filter((r) => r.error);
 	log.info("CoW clone complete", {
 		totalMs,
-		results: results.map((r) => `${r.path}: ${r.method} (${r.durationMs}ms${r.skipped ? ", skipped" : ""})`),
+		failed: failures.length,
+		results: results.map((r) => {
+			if (r.error) return `${r.path}: FAILED (${r.error})`;
+			return `${r.path}: ${r.method} (${r.durationMs}ms${r.skipped ? ", skipped" : ""})`;
+		}),
 	});
+	if (failures.length > 0) {
+		log.error("CoW clone finished with missing paths", {
+			destRoot,
+			failed: failures.map((r) => `${r.path}: ${r.error}`),
+		});
+	}
 
 	return results;
 }

--- a/src/bun/lifecycle/__tests__/clone-failure-propagation.test.ts
+++ b/src/bun/lifecycle/__tests__/clone-failure-propagation.test.ts
@@ -1,0 +1,197 @@
+/**
+ * A clone path that fails to copy must reach the task, not just the log (issue #1728).
+ *
+ * Cloning is the only preparation hook that finishes BEFORE the agent launches, so
+ * a silent miss changes what the agent reads with nothing on screen to say so. The
+ * suite drives the REAL `prepareTask` effect through the REAL executor with a faked
+ * `clonePaths`, and asserts on what is written to the task record.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Task } from "../../../shared/types";
+import type { LifecycleEffect } from "../effects";
+import type { LifecycleExecutionContext } from "../executor";
+
+vi.mock("../../logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+vi.mock("node:fs/promises", () => ({ mkdir: vi.fn(async () => undefined), rm: vi.fn(async () => undefined) }));
+
+const clonePaths = vi.fn(async () => [] as unknown[]);
+vi.mock("../../cow-clone", () => ({ clonePaths: (...args: unknown[]) => clonePaths(...(args as [])) }));
+
+vi.mock("../../data", () => ({
+	updateTask: vi.fn(async (_project: Project, id: string, updates: Partial<Task>) => ({ id, ...updates })),
+	deleteTask: vi.fn(async () => undefined),
+}));
+vi.mock("../../git", () => ({
+	createWorktree: vi.fn(async () => ({ worktreePath: "/tmp/wt", branchName: "feat/x" })),
+	applySparseCheckout: vi.fn(async () => undefined),
+	taskDir: vi.fn(() => "/managed/task"),
+	virtualWorkDir: vi.fn(() => "/managed/ops"),
+}));
+vi.mock("../../paths", () => ({ DEV3_HOME: "/home/.dev3.0", OPS_DIR: "/home/.dev3.0/ops" }));
+vi.mock("../../port-pool", () => ({ releasePorts: vi.fn(), getPortAssignments: vi.fn(() => []) }));
+vi.mock("../../preparation-runtime", () => ({
+	assertTaskPreparationActive: vi.fn(),
+	markTaskPreparationCancelled: vi.fn(),
+	reportCurrentPreparationStage: vi.fn(async () => undefined),
+	withTaskPreparationRunId: vi.fn(async (
+		_taskId: string,
+		_label: string,
+		_runId: string,
+		fn: () => Promise<unknown>,
+	) => fn()),
+}));
+vi.mock("../../pty-server", () => ({ destroySession: vi.fn(), destroyNativeTaskSession: vi.fn() }));
+vi.mock("../../repo-config", () => ({ resolveProjectConfig: vi.fn(async (p: Project) => p) }));
+vi.mock("../../settings", () => ({ loadSettingsSync: vi.fn(() => ({})) }));
+vi.mock("../../shell-env", () => ({ getUserShell: vi.fn(() => "/bin/zsh") }));
+vi.mock("../../spawn", () => ({ spawn: vi.fn(() => ({ exited: Promise.resolve(0) })) }));
+vi.mock("../../temp-paths", () => ({ dev3TaskTempPath: vi.fn(() => "/tmp/dev3/task") }));
+vi.mock("../../tmux", () => ({
+	DEFAULT_TMUX_SOCKET: "dev3",
+	activeTmuxConfigPath: vi.fn(() => "/tmp/dev3.tmux.conf"),
+	cleanupSessionName: vi.fn(() => "dev3-cleanup"),
+	tmux: { killSession: vi.fn(), spawnAttachedSession: vi.fn() },
+}));
+vi.mock("../../rpc-handlers/tmux-pty", () => ({
+	cleanupTaskTmuxState: vi.fn(),
+	killDevServerSession: vi.fn(),
+	launchColumnAgent: vi.fn(),
+	launchTaskPty: vi.fn(async () => undefined),
+}));
+vi.mock("../../rpc-handlers/settings-config", () => ({
+	resolveOperationalProjectConfig: vi.fn(async (p: Project) => ({ ...p, devScript: "", portCount: 0 })),
+}));
+
+const pushMessage = vi.fn();
+vi.mock("../../rpc-handlers/shared", () => ({
+	buildScriptRunnerCommand: vi.fn(() => "/bin/zsh /tmp/run"),
+	buildTaskLifecycleEnv: vi.fn(() => ({})),
+	getPushMessage: () => pushMessage,
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+	notifyWatchedTaskEvent: vi.fn(),
+	notifyWatchedTaskStatusChange: vi.fn(),
+	pushCliAttention: vi.fn(),
+}));
+
+import * as data from "../../data";
+import { launchTaskPty } from "../../rpc-handlers/tmux-pty";
+import { executeLifecycleEffect } from "../executor";
+
+const TASK_ID = "aabbccdd-1111-2222-3333-444444444444";
+
+function project(clonePathList: string[]): Project {
+	return {
+		id: "proj-1",
+		name: "Project",
+		path: "/repo",
+		setupScript: "",
+		devScript: "",
+		cleanupScript: "",
+		defaultBaseBranch: "main",
+		clonePaths: clonePathList,
+		createdAt: "2026-07-01T00:00:00.000Z",
+	} as unknown as Project;
+}
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: TASK_ID,
+		seq: 1,
+		projectId: "proj-1",
+		title: "Task",
+		description: "Task",
+		status: "in-progress",
+		baseBranch: "main",
+		...overrides,
+	} as unknown as Task;
+}
+
+function context(proj: Project, sourceTask: Task): LifecycleExecutionContext {
+	return {
+		project: proj,
+		sourceTask,
+		task: sourceTask,
+		stateTask: sourceTask,
+		hooks: {
+			processInline: vi.fn(async () => sourceTask),
+			dispatchFollowUp: vi.fn(async () => sourceTask),
+			runDetached: vi.fn(),
+		},
+	} as unknown as LifecycleExecutionContext;
+}
+
+const prepareEffect: LifecycleEffect = {
+	type: "prepareTask",
+	runId: "run-1",
+	awaitCompletion: true,
+	columnReserved: false,
+	isReopen: false,
+	successPatch: "activation",
+	origin: { status: "todo", customColumnId: null },
+	target: { status: "in-progress", customColumnId: null },
+	onError: "abort",
+} as unknown as LifecycleEffect;
+
+function cloneWrites(): Partial<Task>[] {
+	return vi.mocked(data.updateTask).mock.calls
+		.map((c) => c[2] as Partial<Task>)
+		.filter((updates) => "cloneFailures" in updates);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(data.updateTask).mockImplementation(
+		async (_project, id, updates) => ({ id, ...updates }) as unknown as Task,
+	);
+});
+
+describe("clone failures during task preparation", () => {
+	it("records the failed paths on the task and pushes the update", async () => {
+		clonePaths.mockResolvedValue([
+			{ path: "node_modules", method: "clonefile", durationMs: 3 },
+			{ path: ".env", method: "copy", durationMs: 2, error: "Permission denied (cp -R exited 1)" },
+		]);
+
+		await executeLifecycleEffect(prepareEffect, context(project(["node_modules", ".env"]), task()));
+
+		expect(cloneWrites()).toEqual([
+			{ cloneFailures: [{ path: ".env", error: "Permission denied (cp -R exited 1)" }] },
+		]);
+		expect(pushMessage).toHaveBeenCalledWith("taskUpdated", expect.objectContaining({ projectId: "proj-1" }));
+	});
+
+	it("still launches the agent — a missing cache must not cost the whole task", async () => {
+		clonePaths.mockResolvedValue([
+			{ path: ".env", method: "copy", durationMs: 2, error: "cp -R exited 1" },
+		]);
+
+		await executeLifecycleEffect(prepareEffect, context(project([".env"]), task()));
+
+		expect(launchTaskPty).toHaveBeenCalled();
+	});
+
+	it("writes nothing when every path copied or was skipped", async () => {
+		clonePaths.mockResolvedValue([
+			{ path: "node_modules", method: "copy", durationMs: 2 },
+			{ path: ".venv", method: "copy", durationMs: 1, skipped: true },
+		]);
+
+		await executeLifecycleEffect(prepareEffect, context(project(["node_modules", ".venv"]), task()));
+
+		expect(cloneWrites()).toEqual([]);
+	});
+
+	it("clears a previous launch's failures when the retry copies everything", async () => {
+		clonePaths.mockResolvedValue([{ path: ".env", method: "copy", durationMs: 1 }]);
+
+		await executeLifecycleEffect(
+			prepareEffect,
+			context(project([".env"]), task({ cloneFailures: [{ path: ".env", error: "cp -R exited 1" }] })),
+		);
+
+		expect(cloneWrites()).toEqual([{ cloneFailures: null }]);
+	});
+});

--- a/src/bun/lifecycle/executor.ts
+++ b/src/bun/lifecycle/executor.ts
@@ -4,6 +4,7 @@ import type {
 	ColumnAgentConfig,
 	ColumnAgentFailureReason,
 	ColumnAgentIdentity,
+	CloneFailure,
 	CompletedDiffStats,
 	CustomColumn,
 	AppRPCSchema,
@@ -187,9 +188,28 @@ function derivedPreparationPath(project: Project, task: Task): string {
 	return `${git.taskDir(project, task)}/worktree`;
 }
 
-async function runCowClones(project: Project, worktreePath: string): Promise<void> {
-	if (!project.clonePaths?.length) return;
-	await clonePaths(project.path, worktreePath, project.clonePaths);
+/**
+ * A failed clone path does not abort the launch: the worktree is usable, and one
+ * missing cache would otherwise cost the user the whole task. It is recorded on
+ * the task instead, because cloning is the only hook that finishes BEFORE the
+ * agent starts — by the time anyone reads the log, the agent has already run
+ * without the file (issue #1728).
+ */
+async function runCowClones(project: Project, task: Task, worktreePath: string): Promise<void> {
+	const results = project.clonePaths?.length
+		? await clonePaths(project.path, worktreePath, project.clonePaths)
+		: [];
+	const failures: CloneFailure[] = results
+		.filter((r) => r.error)
+		.map((r) => ({ path: r.path, error: r.error! }));
+	// This step is the only writer of the field, so it also clears a previous
+	// launch's verdict — nothing downstream may reset it, the notice has to
+	// outlive the launch that produced it.
+	if (failures.length === 0 && !task.cloneFailures?.length) return;
+	const updated = await data.updateTask(project, task.id, {
+		cloneFailures: failures.length > 0 ? failures : null,
+	});
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
 }
 
 async function preparationStep<T>(
@@ -302,7 +322,7 @@ async function prepareTask(
 			effect.runId,
 			"cloning-shared-paths",
 			"runCowClones",
-			() => runCowClones(resolved, worktree.worktreePath),
+			() => runCowClones(resolved, task, worktree.worktreePath),
 		);
 		await preparationStep(
 			task,

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -1920,6 +1920,14 @@ async function dismissSetupFailure(params: { taskId: string }): Promise<void> {
 	await clearSetupFailure(project, task);
 }
 
+async function dismissCloneFailures(params: { taskId: string }): Promise<void> {
+	log.info("→ dismissCloneFailures", { taskId: params.taskId.slice(0, 8) });
+	const { task, project } = await findTaskAcrossProjects(params.taskId);
+	if (!task || !project) throw new Error(`Cannot dismiss: task ${params.taskId} not found`);
+	const updated = await data.updateTask(project, task.id, { cloneFailures: null });
+	getPushMessage()?.("taskUpdated", { projectId: project.id, task: updated });
+}
+
 async function rerunSetupScript(params: { taskId: string }): Promise<void> {
 	log.info("→ rerunSetupScript", { taskId: params.taskId.slice(0, 8) });
 	const { task, project } = await findTaskAcrossProjects(params.taskId);
@@ -3497,4 +3505,5 @@ export const tmuxPtyHandlers = {
 	restartTask,
 	rerunSetupScript,
 	dismissSetupFailure,
+	dismissCloneFailures,
 };

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -132,6 +132,21 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		if (setupFailedExitCode == null) setSetupFailureDismissed(false);
 	}, [setupFailedExitCode]);
 
+	// Cloning finishes BEFORE the agent starts, so a path that never arrived has
+	// already changed what the agent read. Nothing in the pane shows it otherwise.
+	const cloneFailures = task?.cloneFailures ?? [];
+	const [cloneFailuresDismissed, setCloneFailuresDismissed] = useState(false);
+	useEffect(() => {
+		if (cloneFailures.length === 0) setCloneFailuresDismissed(false);
+	}, [cloneFailures.length]);
+
+	const dismissCloneFailures = useCallback(() => {
+		setCloneFailuresDismissed(true);
+		api.request.dismissCloneFailures({ taskId }).catch((err) => {
+			console.error("[TaskTerminal] dismissCloneFailures failed:", err);
+		});
+	}, [taskId]);
+
 	const dismissSetupFailure = useCallback(() => {
 		setSetupFailureDismissed(true);
 		api.request.dismissSetupFailure({ taskId }).catch((err) => {
@@ -495,6 +510,8 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		}
 	}
 
+	const showCloneFailures = cloneFailures.length > 0 && !cloneFailuresDismissed;
+	const cloneFailureDetail = cloneFailures.map((f) => `${f.path} — ${f.error}`).join("; ");
 	const showSetupFailure = setupFailedExitCode != null && !setupFailureDismissed;
 	const setupFailedTitle = t("terminal.setupFailedTitle", { code: String(setupFailedExitCode) });
 	const rerunSetupLabel = rerunningSetup ? t("terminal.setupRerunning") : t("terminal.setupFailedRerun");
@@ -507,7 +524,7 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		<div
 			data-testid="terminal-setup-failed-strip"
 			role="status"
-			className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 px-3 py-2 rounded-lg bg-raised border border-danger/40 shadow-lg max-w-[calc(100%-1rem)]"
+			className="flex items-center gap-3 px-3 py-2 rounded-lg bg-raised border border-danger/40 shadow-lg max-w-full"
 		>
 			<span className="text-danger shrink-0">⚠</span>
 			<div className="min-w-0">
@@ -582,9 +599,40 @@ function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, 
 		</div>
 	);
 
+	// A clone path that never arrived is the same kind of news as a failed setup
+	// script — read-only, non-blocking, and about the worktree rather than the
+	// session. It reuses the strip grammar and stacks under it when both fired.
+	const cloneFailedStrip = showCloneFailures && (
+		<div
+			data-testid="terminal-clone-failed-strip"
+			role="status"
+			className="flex items-center gap-3 px-3 py-2 rounded-lg bg-raised border border-danger/40 shadow-lg max-w-full"
+		>
+			<span className="text-danger shrink-0">⚠</span>
+			<div className="min-w-0">
+				<div className="text-fg text-sm font-medium truncate">
+					{t.plural("terminal.cloneFailedTitle", cloneFailures.length)}
+				</div>
+				<div className="text-fg-3 text-xs truncate" title={cloneFailureDetail}>{cloneFailureDetail}</div>
+			</div>
+			<button
+				onClick={dismissCloneFailures}
+				aria-label={t("terminal.cloneFailedDismiss")}
+				className="shrink-0 px-2 py-1 text-fg-3 rounded hover:bg-elevated-hover hover:text-fg transition-colors"
+			>
+				✕
+			</button>
+		</div>
+	);
+
 	const setupFailedNotice = (
 		<>
-			{setupFailedStrip}
+			{(setupFailedStrip || cloneFailedStrip) && (
+				<div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex flex-col items-stretch gap-2 max-w-[calc(100%-1rem)]">
+					{setupFailedStrip}
+					{cloneFailedStrip}
+				</div>
+			)}
 			{setupFailedCard}
 		</>
 	);

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../rpc", () => ({
 			restartTask: vi.fn(),
 			rerunSetupScript: vi.fn(),
 			dismissSetupFailure: vi.fn(),
+			dismissCloneFailures: vi.fn(),
 			moveTask: vi.fn(),
 			cancelTaskPreparation: vi.fn(),
 			checkWorktreeExists: vi.fn(),
@@ -850,6 +851,73 @@ describe("TaskTerminal", () => {
 			expect(mockedApi.request.dismissSetupFailure).toHaveBeenCalledWith({ taskId: "t1" });
 			expect(mockedApi.request.restartTask).not.toHaveBeenCalled();
 			expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+		});
+	});
+
+	// Cloning finishes before the agent starts, so by the time anyone looks the
+	// agent has already run without the file. Nothing else in the pane says so.
+	describe("clone-failure notice", () => {
+		beforeEach(() => {
+			mockedApi.request.getPtyUrl.mockResolvedValue({ url: "ws://localhost:1234" });
+			mockedApi.request.dismissCloneFailures.mockResolvedValue(undefined);
+		});
+
+		it("stays hidden when every clone path arrived", async () => {
+			await act(async () => {
+				renderTerminal();
+			});
+
+			await waitFor(() => expect(screen.getByTestId("terminal-view")).toBeInTheDocument());
+			expect(screen.queryByTestId("terminal-clone-failed-strip")).not.toBeInTheDocument();
+		});
+
+		it("names the failed path and why it failed", async () => {
+			await act(async () => {
+				renderTerminal({
+					tasks: [makeTask({
+						cloneFailures: [{ path: ".env", error: "Permission denied (cp -R exited 1)" }],
+					})],
+				});
+			});
+
+			const strip = await screen.findByTestId("terminal-clone-failed-strip");
+			expect(strip).toHaveTextContent(".env");
+			expect(strip).toHaveTextContent("Permission denied");
+			// Read-only news: the pane underneath keeps running.
+			expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+		});
+
+		it("stacks under the setup strip when both fired", async () => {
+			await act(async () => {
+				renderTerminal({
+					tasks: [makeTask({
+						setupFailedExitCode: 1,
+						setupFailedAgentRunning: true,
+						cloneFailures: [{ path: ".env", error: "cp -R exited 1" }],
+					})],
+				});
+			});
+
+			await screen.findByTestId("terminal-setup-failed-strip");
+			expect(screen.getByTestId("terminal-clone-failed-strip")).toBeInTheDocument();
+		});
+
+		it("clears the list in the task when dismissed", async () => {
+			const user = userEvent.setup();
+
+			await act(async () => {
+				renderTerminal({
+					tasks: [makeTask({ cloneFailures: [{ path: ".env", error: "cp -R exited 1" }] })],
+				});
+			});
+
+			await screen.findByTestId("terminal-clone-failed-strip");
+			await act(async () => {
+				await user.click(screen.getByRole("button", { name: /dismiss/i }));
+			});
+
+			expect(screen.queryByTestId("terminal-clone-failed-strip")).not.toBeInTheDocument();
+			expect(mockedApi.request.dismissCloneFailures).toHaveBeenCalledWith({ taskId: "t1" });
 		});
 	});
 });

--- a/src/mainview/i18n/translations/en/terminal.ts
+++ b/src/mainview/i18n/translations/en/terminal.ts
@@ -40,6 +40,9 @@ const terminal = {
 	"terminal.setupFailedDismiss": "Dismiss",
 	"terminal.setupFailedAgentRunningDesc": "The agent is running — dependencies may be missing.",
 	"terminal.setupFailedHint": "Dependencies may be missing. Re-running setup leaves the agent alone; starting it fresh does not.",
+	"terminal.cloneFailedTitle_one": "{count} clone path did not reach this worktree",
+	"terminal.cloneFailedTitle_other": "{count} clone paths did not reach this worktree",
+	"terminal.cloneFailedDismiss": "Dismiss",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Terminal panes",

--- a/src/mainview/i18n/translations/es/terminal.ts
+++ b/src/mainview/i18n/translations/es/terminal.ts
@@ -40,6 +40,9 @@ const terminal = {
 	"terminal.setupFailedDismiss": "Cerrar",
 	"terminal.setupFailedAgentRunningDesc": "El agente está en marcha — puede que falten dependencias.",
 	"terminal.setupFailedHint": "Puede que falten dependencias. Volver a ejecutar el setup no toca al agente; iniciarlo de cero sí.",
+	"terminal.cloneFailedTitle_one": "{count} ruta de clonado no llegó a este worktree",
+	"terminal.cloneFailedTitle_other": "{count} rutas de clonado no llegaron a este worktree",
+	"terminal.cloneFailedDismiss": "Cerrar",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Paneles del terminal",

--- a/src/mainview/i18n/translations/ru/terminal.ts
+++ b/src/mainview/i18n/translations/ru/terminal.ts
@@ -40,6 +40,11 @@ const terminal = {
 	"terminal.setupFailedDismiss": "Закрыть",
 	"terminal.setupFailedAgentRunningDesc": "Агент работает — зависимостей может не быть.",
 	"terminal.setupFailedHint": "Зависимостей может не быть. Перезапуск setup агента не трогает, запуск с нуля — трогает.",
+	"terminal.cloneFailedTitle_one": "{count} clone path не доехал до воркtree",
+	"terminal.cloneFailedTitle_few": "{count} clone path не доехали до воркtree",
+	"terminal.cloneFailedTitle_many": "{count} clone path не доехали до воркtree",
+	"terminal.cloneFailedTitle_other": "{count} clone path не доехали до воркtree",
+	"terminal.cloneFailedDismiss": "Закрыть",
 
 	// Mobile pane pager (narrow viewport: one zoomed pane at a time)
 	"panePager.role": "Панели терминала",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2246,6 +2246,14 @@ export interface TaskRuntimeState {
 	updatedAt: number;
 }
 
+/** One configured clone path that failed to copy into the worktree. */
+export interface CloneFailure {
+	/** The path as configured, relative to the project root. */
+	path: string;
+	/** Last stderr line plus the failing command's exit code. */
+	error: string;
+}
+
 export interface Task {
 	id: string;
 	seq: number;
@@ -2389,6 +2397,14 @@ export interface Task {
 	 * recovery in one case and destruction of a working agent in the other.
 	 */
 	setupFailedAgentRunning?: boolean | null;
+	/**
+	 * Clone paths whose source existed but did not reach the worktree. Cloning runs
+	 * before the agent launches, so the agent already read (or failed to read) these
+	 * files by the time anyone looks — the list is persisted rather than pushed so
+	 * the notice survives a closed window. Missing sources are skipped silently and
+	 * never land here. Cleared by the next launch and by dismissing the notice.
+	 */
+	cloneFailures?: CloneFailure[] | null;
 	/** Additive lifecycle runtime hint; older app versions ignore this field. */
 	runtimeState?: TaskRuntimeState;
 	/**
@@ -5029,6 +5045,11 @@ export type AppRPCSchema = {
 			};
 			/** Drop a setup-failure verdict the user has acknowledged. */
 			dismissSetupFailure: {
+				params: { taskId: string };
+				response: void;
+			};
+			/** Drop the clone-path failure list the user has acknowledged. */
+			dismissCloneFailures: {
 				params: { taskId: string };
 				response: void;
 			};


### PR DESCRIPTION
Fixes #1728.

The last step of the copy-on-write clone cascade in `cloneSingle` ran a plain `cp -R` and never read its exit code. A failed copy logged `Copied via cp -R`, the `CoW clone complete` summary counted the path as `copy`, and `runCowClones` discarded the results entirely — so the path was simply missing from the new worktree with nothing but a misleading log line to show for it.

That matters more than a slow install. `clonePaths` is the only preparation hook that finishes **before** the agent launches: the lifecycle executor runs `cloning-shared-paths` and only then `launchTaskPty`, while `setupScript` in the default `parallel` launch mode splits the agent pane before the script runs. A git-ignored file an agent reads once at startup — `.npmrc`, `.env`, a personal instruction file — can only be delivered through `clonePaths`, so a silent miss changes the agent's behaviour with no trace outside the log.

## What changed

- `src/bun/cow-clone.ts` — `run()` returns `{ code, stderr }` with stderr piped and drained before `await proc.exited`. The final `cp -R`, and the Windows `node:fs` `cp`, turn a non-zero exit or a throw into a `CloneResult` carrying `error` (last stderr line + exit code), logged at error level. Intermediate cascade steps stay at debug — a filesystem without reflink support fails every time. `clonePaths` counts failures in its summary and emits a second error log naming every missing path.
- On Windows a rejected `cp` previously escaped `Promise.all` and aborted the whole task preparation; it is now a failed result like any other.
- `src/shared/types.ts` — new `CloneFailure` type and `Task.cloneFailures`. Additive on disk; older app versions ignore it.
- `src/bun/lifecycle/executor.ts` — `runCowClones` writes the failures onto the task and pushes `taskUpdated`. It is the only writer of that field, so it also clears a previous launch's verdict.
- `src/mainview/components/TaskTerminal.tsx` — a dismissible strip naming each path and why it failed, stacked with the existing setup-failure strip; `dismissCloneFailures` RPC mirrors `dismissSetupFailure`. Keys added in all three locales with complete plural forms.

## Two deliberate semantics

| Case | Behaviour |
|---|---|
| Source missing from the project root | `skipped: true`, no error, silent — a clone list is shared across machines, so an absent path is expected |
| Source exists, copy fails | `error` set, logged as an error, shown on the task |

A failed clone path does **not** abort the launch: the worktree is usable and one missing cache should not cost the whole task. Rationale and the rejected alternatives are in `decisions/2026/09/11/clone-path-failures-are-reported-not-fatal.md`.

## Documentation

`clonePaths` was documented in the shipped `dev3-project-config` skill (`src/bun/agent-skills.ts`) only as "heavy directories". It now says: directories **and individual files**, globs expanded, missing sources skipped silently, failed copies logged and surfaced — and that it finishes before the agent launches, unlike `setupScript` in `parallel` mode. Each claim was verified against the code first.

## Verification

New tests cover fallback success, the final failure with exit code and stderr, no false success in a mixed run, the missing-source skip, the Windows copy error, propagation to the task, clearing on a clean retry, and the renderer notice. The exit-code check and the propagation write were both mutation-tested — reverting either fails the new tests, so they catch exactly the reported bug. `bun run lint` and `bun run test` are green locally.

Not exercised here: Windows and Linux at runtime (no machine available) — both branches are unit-tested, not proven on the real OS.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=450568fb-deb9-4cd1-a57c-5549fa27b4b6) · `dev3://task/450568fb-deb9-4cd1-a57c-5549fa27b4b6` _(dev3 added this footer — turn it off in Settings → Tasks.)_