### PR TITLE
Open agent-message notifications at all projects in the traffic screen

### DIFF
--- a/change-logs/2026/09/12/fix-agent-notification-opens-all-projects.md
+++ b/change-logs/2026/09/12/fix-agent-notification-opens-all-projects.md
@@ -1,0 +1,3 @@
+Short: Agent toasts open all traffic
+
+Clicking a notification about a message between agents now opens the agent traffic screen across all active projects instead of filtering it to the board you happened to be looking at, so traffic from another board is no longer hidden on arrival. Opening the screen deliberately — the header readout, ⇧⌘M, the View menu or the command palette — still starts on the project in view.

--- a/decisions/2026/09/12/notification-entry-to-traffic-opens-all-projects.md
+++ b/decisions/2026/09/12/notification-entry-to-traffic-opens-all-projects.md
@@ -1,0 +1,45 @@
+# A notification click opens agent traffic at all projects, never the board in view
+
+## Context
+
+Every entry point to the `agent-traffic` destination seeded the screen's project
+filter from the route it was opened from (`projectIdForRoute(state.route)`), and the
+screen turns that seed into its scope: `useState(projectId ?? ACTIVE_PROJECTS)` in
+`AgentTrafficScreen.tsx`. Standing on one board and clicking an agent-message toast
+about traffic on **another** board therefore opened the screen filtered to the board
+in view — so the message that raised the toast was filtered out of its own
+destination, and the screen looked empty.
+
+## Investigation
+
+The toast's click handler (`App.tsx`, the `rpc:agentMessage` effect) calls
+`openAgentTrafficLog()`, which fires one window event; the single `onOpen` handler
+did the route-to-scope translation for every opener alike. The payload already
+carries `projectId` (receiver) and `fromProjectId` (sender), so scoping to either
+end was available — and rejected: a toast is an arrival the user did not choose, and
+the thing they want to see is the traffic, not one board's slice of it.
+
+## Decision
+
+`openAgentTrafficLog()` takes a scope: `"current-project"` (the default, unchanged
+for the header readout, ⇧⌘M, the View menu and the command palette) or
+`"all-projects"`, which navigates with no `scopeProjectId` at all. Only the agent-
+message toast passes `"all-projects"`. No project id means the screen's own default
+scope, "All active projects" — so this reuses existing scope state rather than adding
+a filter or a control. Bible §5.7's traffic exception now reads "opens traffic at all
+active projects, else the **receiver**"; the receiver remains the destination with the
+beta off, because its terminal is where the text landed and the reply gets typed.
+
+## Risks
+
+A user who keeps one board in view and reads only its traffic now gets a wider stage
+from a toast click than from ⇧⌘M. That asymmetry is deliberate — the scope dropdown is
+one click away — and the alternative hides messages the notification just announced.
+
+## Alternatives considered
+
+Scope to the sender's or the receiver's project: still a filter the user did not ask
+for, and a cross-project pair has two right answers. Make every entry point global:
+loses the useful "this board's traffic" reading of a deliberate entry from a board.
+Update the scope of an already-open screen: nothing to fix — a toast is suppressed
+while this window sits on the traffic screen.

--- a/docs/ux/PRODUCT_UX_BIBLE.md
+++ b/docs/ux/PRODUCT_UX_BIBLE.md
@@ -386,7 +386,7 @@ Rules:
 - **`contextDetail`** appends one more segment after the resolved origin (`dev-3.0 · Nightly digest`) when the toast is about a named thing inside that scope.
 - **The clickable overlay's accessible name is `context — message`**, not the message alone: a screen reader must hear which task it is being sent to.
 
-- **One documented exception to "one origin": agent-to-agent traffic.** A `dev3 message` between two agents has a sender AND a receiver, so its source line is the pair — `#7 Coordinator → #42 Receiver` — and the click goes to the **receiver**, whose terminal now holds the text. It also carries the only non-severity variant, `agent` (violet `--agent`): identity, not severity, so it can never be misread as a status, a warning, or a failure. Silent for anything the human sent and for a send that landed nowhere.
+- **One documented exception to "one origin": agent-to-agent traffic.** A `dev3 message` between two agents has a sender AND a receiver, so its source line is the pair — `#7 Coordinator → #42 Receiver` — and the click opens traffic at all active projects, else the **receiver**. It also carries the only non-severity variant, `agent` (violet `--agent`): identity, not severity, so it can never be misread as a status, a warning, or a failure. Silent for anything the human sent and for a send that landed nowhere.
 
 Evidence: `toast.tsx`, `App.tsx` (`ToastHost` mount, `openTaskFromNotification`).
 

--- a/docs/ux/UX_DECISIONS.md
+++ b/docs/ux/UX_DECISIONS.md
@@ -11,6 +11,10 @@ record wins and this file stays an index. Write the entry in full only while no 
 exists; that is the case for 84 of the entries below, and their reasoning lives nowhere
 else, so do not compact them by deleting it.
 
+## 2026-09-12 — A notification into agent traffic opens all projects
+
+An agent-message toast opens the traffic screen unscoped ("All active projects"); deliberate entries still seed the board in view — bible §5.7. Why: `decisions/2026/09/12/notification-entry-to-traffic-opens-all-projects.md`.
+
 ## 2026-09-08 — Agent traffic becomes the ninth destination, not an overlay
 
 Routed screen under the standard header with Back/Forward and a fixed anonymous screen path; entry autoplays the trailing hour once. Reverses the 2026-08-25 "still an overlay" ruling — bible §5.9, yaml `agent_traffic_screen`. Why: `decisions/2026/09/08/agent-traffic-becomes-a-destination.md`.

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -48,7 +48,11 @@ import { setToastSuppressed, taskToastContext, ToastHost, toast, type ToastEntry
 import { useSpaces } from "./useSpaces";
 import AgentTrafficScreen from "./components/agent-traffic/AgentTrafficScreen";
 import { noteTrafficArrival } from "./agent-traffic";
-import { OPEN_AGENT_TRAFFIC_LOG_EVENT, openAgentTrafficLog } from "./agent-traffic-events";
+import {
+	OPEN_AGENT_TRAFFIC_LOG_EVENT,
+	openAgentTrafficLog,
+	type OpenAgentTrafficLogDetail,
+} from "./agent-traffic-events";
 import { getAgentTrafficEnabled, syncAgentTrafficFromGlobalSettings } from "./agent-traffic-flag";
 import { useAgentTrafficEnabled } from "./hooks/useAgentTrafficEnabled";
 import StuckPreparationPopover from "./components/StuckPreparationPopover";
@@ -1735,7 +1739,10 @@ function App() {
 					// toggle back to, and navigating again would stack a second identical
 					// history entry and make Back a dead key.
 					if (routeRef.current.screen === "agent-traffic") return;
-					openAgentTrafficLog();
+					// All projects, never the board in view: the message the toast is
+					// about may belong to any board, and seeding the current one hides
+					// exactly the traffic the click was asking to see.
+					openAgentTrafficLog("all-projects");
 				},
 			});
 		}
@@ -1756,11 +1763,15 @@ function App() {
 	// Everything that opens agent traffic goes through one event: the header
 	// readout, the native View menu and the command palette all fire it, and it
 	// lands as an ordinary navigation — so Back returns to wherever they were.
-	// The project in view rides along as the screen's initial scope.
+	// The project in view rides along as the screen's initial scope, unless the
+	// opener asked for all projects (a notification click — see the toast above).
 	useEffect(() => {
-		function onOpen() {
+		function onOpen(event: Event) {
 			if (!getAgentTrafficEnabled()) return;
-			navigate({ screen: "agent-traffic", scopeProjectId: projectIdForRoute(state.route) ?? undefined });
+			const scope = (event as CustomEvent<OpenAgentTrafficLogDetail>).detail?.scope ?? "current-project";
+			const scopeProjectId =
+				scope === "all-projects" ? undefined : projectIdForRoute(state.route) ?? undefined;
+			navigate({ screen: "agent-traffic", scopeProjectId });
 		}
 		window.addEventListener(OPEN_AGENT_TRAFFIC_LOG_EVENT, onOpen);
 		return () => window.removeEventListener(OPEN_AGENT_TRAFFIC_LOG_EVENT, onOpen);

--- a/src/mainview/__tests__/App.test.tsx
+++ b/src/mainview/__tests__/App.test.tsx
@@ -179,9 +179,12 @@ vi.mock("../components/ProjectTerminal", () => ({
 	default: () => <div data-testid="project-terminal-screen" />,
 }));
 // The screen's own data loading lives in agent-traffic-ui.test.tsx; here only
-// its routing matters.
+// its routing matters — including the scope it is handed, since the real screen
+// seeds its project filter from this prop and `null` means "all active projects".
 vi.mock("../components/agent-traffic/AgentTrafficScreen", () => ({
-	default: () => <div data-testid="agent-traffic-screen" />,
+	default: ({ projectId }: { projectId: string | null }) => (
+		<div data-testid="agent-traffic-screen" data-scope-project-id={projectId ?? ""} />
+	),
 }));
 vi.mock("../components/TaskImageViewer", () => ({
 	default: ({ initialIndex, newIds }: { initialIndex: number; newIds?: string[] }) => (
@@ -203,7 +206,7 @@ import { initTaskSoundPlayback, playTaskSoundFromPush, setTaskCompletionSoundEna
 import { adjustZoom, applyZoom, ZOOM_STEP, DEFAULT_ZOOM } from "../zoom";
 import { setStreamerMode } from "../streamer-mode";
 import { setAgentTrafficEnabledForTests, syncAgentTrafficFromGlobalSettings } from "../agent-traffic-flag";
-import { OPEN_AGENT_TRAFFIC_LOG_EVENT } from "../agent-traffic-events";
+import { OPEN_AGENT_TRAFFIC_LOG_EVENT, openAgentTrafficLog } from "../agent-traffic-events";
 
 const mockedAdjustZoom = vi.mocked(adjustZoom);
 
@@ -1087,6 +1090,25 @@ describe("App keyboard shortcuts", () => {
 				expect(await screen.findByTestId("agent-traffic-screen")).toBeInTheDocument();
 			});
 		});
+
+		// A deliberate entry keeps seeding the board in view — only a notification
+		// click overrides that, and it does so by asking for all projects.
+		it("seeds the board in view for a deliberate entry, and all projects when asked", async () => {
+			await withTrafficBeta(async () => {
+				await renderApp();
+				await userEvent.keyboard("{Shift>}{Meta>}m{/Meta}{/Shift}");
+				expect(await screen.findByTestId("agent-traffic-screen")).toHaveAttribute(
+					"data-scope-project-id",
+					"p1",
+				);
+
+				await userEvent.keyboard("{Escape}");
+				await act(async () => {
+					openAgentTrafficLog("all-projects");
+				});
+				expect(await screen.findByTestId("agent-traffic-screen")).toHaveAttribute("data-scope-project-id", "");
+			});
+		});
 	});
 
 	// Quick shell (⇧⌘`) spawns a scratch op in the built-in Operations board and
@@ -1601,6 +1623,32 @@ describe("App keyboard shortcuts", () => {
 			await userEvent.click(screen.getByRole("button", { name: /^Back/ }));
 			expect(screen.getByTestId("project-screen")).toHaveAttribute("data-project-id", "p1");
 			expect(screen.queryByTestId("agent-traffic-screen")).toBeNull();
+		});
+
+		// The reported bug: standing on one board, a toast about traffic on ANOTHER
+		// board opened the screen scoped to the board in view, so the message that
+		// raised the toast was filtered out of its own destination. A notification
+		// click always lands on all active projects (no seeded project id).
+		it("opens at all active projects when the traffic belongs to another board", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			dispatchAgentMessage({ projectId: "p2", fromProjectId: "p2" });
+
+			await userEvent.click(await toastButton());
+
+			expect(await screen.findByTestId("agent-traffic-screen")).toHaveAttribute("data-scope-project-id", "");
+		});
+
+		// Same rule when both ends sit on the board in view: the destination does not
+		// depend on where the message came from, only on how the screen was opened.
+		it("opens at all active projects for same-board traffic too", async () => {
+			await renderWithBoard();
+			enableTrafficBeta();
+			dispatchAgentMessage();
+
+			await userEvent.click(await toastButton());
+
+			expect(await screen.findByTestId("agent-traffic-screen")).toHaveAttribute("data-scope-project-id", "");
 		});
 
 		// The toast outlives the toggle, so the destination cannot be captured when

--- a/src/mainview/agent-traffic-events.ts
+++ b/src/mainview/agent-traffic-events.ts
@@ -8,6 +8,23 @@
  */
 export const OPEN_AGENT_TRAFFIC_LOG_EVENT = "open-agent-traffic-log";
 
-export function openAgentTrafficLog(): void {
-	window.dispatchEvent(new CustomEvent(OPEN_AGENT_TRAFFIC_LOG_EVENT));
+/**
+ * Which scope the screen opens on.
+ *
+ * `"current-project"` seeds the board in view — right for a deliberate entry, where
+ * the user is looking at one project and asks about its traffic. `"all-projects"`
+ * seeds no project at all, which is the screen's own "all active projects" default:
+ * an arrival the user did not choose (a toast about a message that may belong to
+ * any board) must not be filtered down to whichever board happened to be on screen.
+ */
+export type AgentTrafficOpenScope = "current-project" | "all-projects";
+
+export interface OpenAgentTrafficLogDetail {
+	scope: AgentTrafficOpenScope;
+}
+
+export function openAgentTrafficLog(scope: AgentTrafficOpenScope = "current-project"): void {
+	window.dispatchEvent(
+		new CustomEvent<OpenAgentTrafficLogDetail>(OPEN_AGENT_TRAFFIC_LOG_EVENT, { detail: { scope } }),
+	);
 }


### PR DESCRIPTION
Every entry point to the `agent-traffic` destination seeded the screen's project filter from the route it was opened from, and `AgentTrafficScreen` turns that seed into its scope (`useState(projectId ?? ACTIVE_PROJECTS)`). Standing on one board and clicking a toast about a message between agents on **another** board therefore opened the screen filtered to the board in view — the message that raised the toast was filtered out of its own destination and the stage looked empty.

`openAgentTrafficLog()` now takes a scope. `"current-project"` stays the default and keeps the existing behaviour for every deliberate entry — the header readout, ⇧⌘M, the View menu and the command palette. The agent-message toast passes `"all-projects"`, which navigates with no `scopeProjectId` at all; that is the screen's own default scope, "All active projects", so this reuses existing scope state rather than adding a filter, a control or a destination.

Everything else is untouched: with the traffic beta off the toast still opens the receiving task, an ordinary `dev3 notify` toast still points at its own task, and a toast is still suppressed while this window already sits on the traffic screen.

Verified in a browser on an isolated QA board with two projects and traffic recorded on only one of them: before, the click opened scoped to the board in view with 0 of 0 messages on stage; after, it opens at "All active projects" with both boards and 2 of 2 messages. Renderer regression tests cover the cross-board click, the same-board click and the deliberate entry that still seeds the board in view; both new assertions fail when the fix is reverted.

Why: `decisions/2026/09/12/notification-entry-to-traffic-opens-all-projects.md`. Bible §5.7's traffic exception updated to match.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=f4dff167-cd97-4739-ba44-6e732125de52) · `dev3://task/f4dff167-cd97-4739-ba44-6e732125de52` _(dev3 added this footer — turn it off in Settings → Tasks.)_