### PR TITLE
Send the completion chime to one window instead of every window

### DIFF
--- a/change-logs/2026/09/12/fix-completion-chime-once-per-window.md
+++ b/change-logs/2026/09/12/fix-completion-chime-once-per-window.md
@@ -1,0 +1,3 @@
+Short: One completion chime, not one per window
+
+A task completed from the CLI, an approval dialog or a branch merge now chimes once even with several app windows open — the completion sound is delivered to the focused window instead of every window. Attached remote browsers still receive it, since a phone on the LAN is a separate device.

--- a/decisions/2026/09/12/completion-chime-goes-to-one-window.md
+++ b/decisions/2026/09/12/completion-chime-goes-to-one-window.md
@@ -1,0 +1,37 @@
+# Completion chime goes to one window, browsers keep the fan-out
+
+## Context
+
+Completions no renderer played locally (CLI `dev3 task move`, the approval
+dialog, branch-merge auto-complete) are announced with the `taskSound` push.
+That push went through `pushEverywhere`, which broadcasts to every Electrobun
+window, so a user with two windows open heard one finished task chime twice.
+
+## Investigation
+
+The renderer cannot fix this: `src/mainview/task-sounds.ts` keeps its pending
+queue and autoplay flag in module state, and each window runs its own copy, so a
+local Set never sees another window's chime. The only choke point is delivery,
+in `src/bun/push-targets.ts`.
+
+## Decision
+
+`pushEverywhere` keeps a small `SINGLE_WINDOW_PUSHES` set; `taskSound` is in it
+and routes through `sendToFocusedWindow` instead of `broadcastToAllWindows`.
+Windows share one pair of speakers, so a sound is not state. Browser clients keep
+the full fan-out on purpose: a phone on the LAN is a different device in a
+different room, and a remote-only setup has no window to chime at all.
+
+## Risks
+
+A desktop window and a remote browser on the same machine still chime twice —
+unchanged from before, and not distinguishable from the legitimate second-device
+case without an identity the push does not carry. If no window has ever been
+focused, `getFocusedWindow` falls back to the first tracked window.
+
+## Alternatives considered
+
+Cross-window dedup in the renderer (BroadcastChannel or a shared store): needs a
+leader election and a race window, and still cannot reach a remote browser.
+Pushing to no window and letting the initiating surface own every sound: breaks
+CLI and agent-approval completions, which have no initiating surface.

--- a/src/bun/__tests__/push-targets.test.ts
+++ b/src/bun/__tests__/push-targets.test.ts
@@ -12,9 +12,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const broadcastToAllWindows = vi.fn();
+const sendToFocusedWindow = vi.fn();
 const pushToBrowserClients = vi.fn();
 
-vi.mock("../window-manager", () => ({ broadcastToAllWindows }));
+vi.mock("../window-manager", () => ({ broadcastToAllWindows, sendToFocusedWindow }));
 vi.mock("../remote-access-server", () => ({ pushToBrowserClients }));
 
 const { pushEverywhere } = await import("../push-targets");
@@ -22,6 +23,7 @@ const { pushEverywhere } = await import("../push-targets");
 describe("pushEverywhere", () => {
 	beforeEach(() => {
 		broadcastToAllWindows.mockClear();
+		sendToFocusedWindow.mockClear();
 		pushToBrowserClients.mockClear();
 	});
 
@@ -48,5 +50,24 @@ describe("pushEverywhere", () => {
 
 		expect(broadcastToAllWindows).toHaveBeenCalledTimes(1);
 		expect(pushToBrowserClients).toHaveBeenCalledTimes(1);
+	});
+
+	// A sound is not state: every window renders its own state, but they all share
+	// one pair of speakers, so a broadcast chime plays once per open window.
+	it("sends a completion chime to the focused window only", () => {
+		const payload = { status: "completed", taskId: "task-3" };
+		pushEverywhere("taskSound", payload);
+
+		expect(sendToFocusedWindow).toHaveBeenCalledWith("taskSound", payload);
+		expect(broadcastToAllWindows).not.toHaveBeenCalled();
+	});
+
+	// Remote-only setups exist: a phone on the LAN with no desktop window in view
+	// is the whole point of the push, so browsers keep the full fan-out.
+	it("still delivers the chime to remote browsers", () => {
+		const payload = { status: "cancelled", taskId: "task-4" };
+		pushEverywhere("taskSound", payload);
+
+		expect(pushToBrowserClients).toHaveBeenCalledWith("taskSound", payload);
 	});
 });

--- a/src/bun/__tests__/task-sound-single-window.test.ts
+++ b/src/bun/__tests__/task-sound-single-window.test.ts
@@ -1,0 +1,149 @@
+/**
+ * One finished task must make one sound, however many windows are open.
+ *
+ * A completion that no renderer played locally (CLI, approval dialog, merge
+ * auto-complete) is announced with the `taskSound` push. That push used to take
+ * the same route as state events — every window — so a user with two windows on
+ * one machine heard the chime twice for a single completion.
+ *
+ * This goes through the REAL window-manager with two real tracked windows,
+ * because the bug lived in the fan-out, not in anything a mocked helper would
+ * show. `push-targets.test.ts` covers the routing decision itself.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type FakeWindow = { webview: { rpc: { send: Record<string, ReturnType<typeof vi.fn>> } } };
+
+const globalBag = globalThis as typeof globalThis & { __soundWindows: FakeWindow[] };
+globalBag.__soundWindows = [];
+const createdWindows = globalBag.__soundWindows;
+
+vi.mock("electrobun/bun", () => {
+	const bag = globalThis as typeof globalThis & { __soundWindows: FakeWindow[] };
+	class FakeBrowserWindow {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		webview: any;
+		getSize = vi.fn(() => ({ width: 800, height: 600 }));
+		setSize = vi.fn();
+		getFrame = vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 }));
+		setFrame = vi.fn();
+		isFullScreen = vi.fn(() => false);
+		setFullScreen = vi.fn();
+		setTitle = vi.fn();
+		focus = vi.fn();
+		handlers: Record<string, () => void> = {};
+		on = vi.fn((name: string, handler: () => void) => {
+			this.handlers[name] = handler;
+		});
+		constructor() {
+			const send: Record<string, ReturnType<typeof vi.fn>> = {};
+			this.webview = {
+				rpc: {
+					send: new Proxy(send, {
+						get(target, prop: string) {
+							if (!(prop in target)) target[prop] = vi.fn();
+							return target[prop];
+						},
+					}),
+				},
+				openDevTools: vi.fn(),
+				on: vi.fn(),
+			};
+			bag.__soundWindows.push(this as unknown as FakeWindow);
+		}
+	}
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		BrowserView: { defineRPC: vi.fn((opts: any) => ({ setTransport: vi.fn(), __requests: opts?.handlers?.requests ?? {} })) },
+		BrowserWindow: FakeBrowserWindow,
+		Screen: {
+			getPrimaryDisplay: () => ({ id: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 }, workArea: { x: 0, y: 0, width: 1920, height: 1080 } }),
+			getAllDisplays: () => [{ id: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 }, workArea: { x: 0, y: 0, width: 1920, height: 1080 } }],
+		},
+	};
+});
+
+// Keep createAppWindow on its default placement path, away from the real
+// ~/.dev3.0/window-state.json.
+vi.mock("node:fs", () => ({
+	existsSync: () => false,
+	readFileSync: vi.fn(),
+	writeFileSync: vi.fn(),
+	mkdirSync: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const pushToBrowserClients = vi.fn();
+vi.mock("../remote-access-server", () => ({ pushToBrowserClients }));
+
+const { createAppWindow, __resetForTests } = await import("../window-manager");
+const { pushEverywhere } = await import("../push-targets");
+
+function spawn() {
+	return createAppWindow({ title: "dev-3.0", url: "views://mainview/index.html", handlers: {} });
+}
+
+function soundCallCounts(): number[] {
+	return createdWindows.map((win) => win.webview.rpc.send.taskSound.mock.calls.length);
+}
+
+beforeEach(() => {
+	createdWindows.length = 0;
+	pushToBrowserClients.mockClear();
+	__resetForTests();
+	vi.useFakeTimers();
+});
+
+describe("taskSound across multiple windows", () => {
+	it("chimes once for one completion with two windows open", () => {
+		spawn();
+		spawn();
+
+		pushEverywhere("taskSound", { status: "completed", taskId: "task-1" });
+
+		const counts = soundCallCounts();
+		expect(
+			counts.reduce((sum, n) => sum + n, 0),
+			`Cause: the taskSound push reached ${counts.length} windows (${counts.join(", ")} chimes) — ` +
+				"two windows on one machine share one pair of speakers, so the user hears the chime twice.\n" +
+				"Fix: keep `taskSound` in SINGLE_WINDOW_PUSHES in src/bun/push-targets.ts.",
+		).toBe(1);
+	});
+
+	it("plays in the window the user last focused", () => {
+		spawn();
+		const second = spawn();
+		// createAppWindow marks the newest window focused; move focus back to the
+		// first one the way a real click does.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(createdWindows[0] as any).handlers.focus?.();
+
+		pushEverywhere("taskSound", { status: "completed", taskId: "task-1" });
+
+		expect(soundCallCounts()).toEqual([1, 0]);
+		expect(second).toBeTruthy();
+	});
+
+	it("still carries the payload to remote browsers", () => {
+		spawn();
+		spawn();
+		const payload = { status: "cancelled", taskId: "task-2" };
+
+		pushEverywhere("taskSound", payload);
+
+		expect(pushToBrowserClients).toHaveBeenCalledWith("taskSound", payload);
+	});
+
+	it("leaves state events broadcasting to every window", () => {
+		spawn();
+		spawn();
+
+		pushEverywhere("ptyDied", { taskId: "task-3" });
+
+		expect(createdWindows.map((win) => win.webview.rpc.send.ptyDied.mock.calls.length)).toEqual([1, 1]);
+	});
+});

--- a/src/bun/push-targets.ts
+++ b/src/bun/push-targets.ts
@@ -13,11 +13,24 @@
  * call reappears there.
  */
 
-import { broadcastToAllWindows } from "./window-manager";
+import { broadcastToAllWindows, sendToFocusedWindow } from "./window-manager";
 import { pushToBrowserClients } from "./remote-access-server";
+
+/**
+ * Events that are a SOUND, not state. Every window renders its own state, so
+ * state goes to all of them — but two windows on one machine share one pair of
+ * speakers, and a CLI/approval/merge completion broadcast that way chimes once
+ * per window for a single finished task. These go to the focused window alone.
+ *
+ * Browser clients keep the full fan-out on purpose: a phone on the LAN is a
+ * different device in a different room, and silencing it would break the
+ * remote-only setup this push exists for.
+ */
+const SINGLE_WINDOW_PUSHES = new Set(["taskSound"]);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function pushEverywhere(name: string, payload: any): void {
-	broadcastToAllWindows(name, payload);
+	if (SINGLE_WINDOW_PUSHES.has(name)) sendToFocusedWindow(name, payload);
+	else broadcastToAllWindows(name, payload);
 	pushToBrowserClients(name, payload);
 }

--- a/src/mainview/__tests__/task-sound-one-play-per-completion.test.ts
+++ b/src/mainview/__tests__/task-sound-one-play-per-completion.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Counts actual playback, not push routing: how many times a real
+ * `HTMLMediaElement.play()` fires for ONE finished task with TWO renderers alive.
+ *
+ * Each window runs its own copy of `task-sounds`, with its own module state, so
+ * a renderer-local Set can never deduplicate against another window — the only
+ * place the duplicate can be stopped is the delivery, which is what
+ * `src/bun/push-targets.ts` now does. The second case here is the pre-fix
+ * behaviour, kept so the count that used to reach the user stays visible.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SoundsModule = typeof import("../task-sounds");
+
+const installedListeners: Array<[string, EventListenerOrEventListenerObject]> = [];
+const realAddEventListener = window.addEventListener.bind(window);
+
+/** A second, independent module instance stands in for a second window. */
+async function loadRenderer(): Promise<SoundsModule> {
+	vi.resetModules();
+	return await import("../task-sounds");
+}
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+let play: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	installedListeners.length = 0;
+	window.addEventListener = ((type: string, listener: EventListenerOrEventListenerObject, opts?: unknown) => {
+		installedListeners.push([type, listener]);
+		realAddEventListener(type as keyof WindowEventMap, listener as EventListener, opts as AddEventListenerOptions);
+	}) as typeof window.addEventListener;
+	play = vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(undefined as unknown as void);
+});
+
+afterEach(() => {
+	window.addEventListener = realAddEventListener;
+	for (const [type, listener] of installedListeners) window.removeEventListener(type, listener);
+	installedListeners.length = 0;
+	play.mockRestore();
+});
+
+describe("one completion, two renderers", () => {
+	it("plays once when the push reaches a single window", async () => {
+		const windowA = await loadRenderer();
+		const windowB = await loadRenderer();
+		expect(windowA).not.toBe(windowB);
+
+		// The backend now delivers `taskSound` to the focused window alone.
+		windowA.playTaskSoundFromPush("completed");
+		await settle();
+
+		expect(play).toHaveBeenCalledTimes(1);
+	});
+
+	it("played twice when the push reached both windows (the reported bug)", async () => {
+		const windowA = await loadRenderer();
+		const windowB = await loadRenderer();
+
+		windowA.playTaskSoundFromPush("completed");
+		windowB.playTaskSoundFromPush("completed");
+		await settle();
+
+		expect(
+			play.mock.calls.length,
+			"Two windows, one completion: this is the duplicate chime the delivery fix removes. " +
+				"A renderer-local guard cannot see the other window's module state.",
+		).toBe(2);
+	});
+});

--- a/src/mainview/task-sounds.ts
+++ b/src/mainview/task-sounds.ts
@@ -41,8 +41,8 @@ let unlockHandlersInstalled = false;
 //  - UI-initiated moves (drag, card menu, info panel, terminal toolbar) play it
 //    locally and instantly via `playTaskCompletionSound`, then tell the backend
 //    (`clientPlayedSound` on the moveTask RPC) to skip its `taskSound` push.
-//    The push would otherwise fan out to EVERY connected renderer — a desktop
-//    window AND a remote browser on the same machine — and play a second time.
+//    The push would otherwise come back to a window and a remote browser on the
+//    same machine and play a second time.
 //  - Non-UI completions (CLI, branch-merge auto-complete, agent approval) have no
 //    renderer that played locally, so the backend pushes `taskSound` and
 //    `playTaskSoundFromPush` plays it.
@@ -83,7 +83,8 @@ export function playTaskCompletionSound(status: TaskSoundStatus): boolean {
 /**
  * Handle a bun `taskSound` push. Fired for completions no renderer played
  * locally (CLI, branch-merge, agent approval), and for the ones a renderer
- * could not play.
+ * could not play. Only one window is sent this push (src/bun/push-targets.ts) —
+ * module state here is per-renderer and cannot see another window's chime.
  */
 export function playTaskSoundFromPush(status: TaskSoundStatus): void {
 	void playTaskSound(status);

--- a/src/mainview/utils/moveTaskToStatus.ts
+++ b/src/mainview/utils/moveTaskToStatus.ts
@@ -113,8 +113,8 @@ export async function moveTaskToStatus({
 		: { ...task, status: newStatus, customColumnId: null, movedAt: movedNow, statusEnteredAt: movedNow };
 	dispatch({ type: "updateTask", task: optimisticTask });
 	// When the UI plays the completion sound here, tell the backend to skip its
-	// own `taskSound` push — otherwise it fans out to every other connected
-	// renderer (e.g. a remote browser on the same machine) and plays twice.
+	// own `taskSound` push — otherwise it comes back to a window and to every
+	// attached remote browser, and the chime plays twice.
 	let clientPlayedSound = false;
 	if (terminal) {
 		dispatch({ type: "clearBell", taskId: task.id });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4927,9 +4927,9 @@ export type AppRPCSchema = {
 			moveTask: {
 				// `clientPlayedSound`: the UI already played the completion/cancel sound
 				// optimistically in the initiating renderer, so the backend must NOT
-				// also push `taskSound` (that push fans out to every connected renderer
-				// — a desktop window AND a remote browser on the same machine — and
-				// would play a second time). Unset for CLI / branch-merge / agent
+				// also push `taskSound` (that push still reaches a window and every
+				// attached remote browser, so the chime would play a second time on
+				// the same machine). Unset for CLI / branch-merge / agent
 				// approval, where no renderer played locally and the push is the sound.
 				params: { taskId: string; projectId: string; newStatus: TaskStatus; force?: boolean; clientPlayedSound?: boolean };
 				response: Task;


### PR DESCRIPTION
## Summary

A completion no renderer played locally (CLI `dev3 task move`, the approval dialog, branch-merge auto-complete) is announced with the `taskSound` push. That push went through `pushEverywhere` → `broadcastToAllWindows`, so every open Electrobun window played it: one finished task, one chime per window.

The renderer cannot deduplicate this. `src/mainview/task-sounds.ts` keeps its pending queue and autoplay flag in module state, and each window runs its own copy, so a local guard never sees another window's chime. The only choke point is delivery.

`pushEverywhere` now keeps a small `SINGLE_WINDOW_PUSHES` set — `taskSound` is in it and routes through the existing `sendToFocusedWindow` instead of the broadcast. Every other event still reaches every window: a sound is not state, and two windows on one machine share one pair of speakers.

Browser clients keep the full fan-out on purpose. A phone on the LAN is a different device in a different room, and a remote-only setup has no window to chime at all.

Comments in `types.ts`, `moveTaskToStatus.ts` and `task-sounds.ts` that claimed the push "fans out to EVERY connected renderer" were updated so they no longer describe behaviour the code dropped.

## Tests

- `src/bun/__tests__/task-sound-single-window.test.ts` — the real window-manager with two registered windows; counts `send.taskSound` per window. Mutation-checked: restoring `broadcastToAllWindows` makes it fail with `[1, 1]` instead of `[1, 0]`.
- `src/mainview/__tests__/task-sound-one-play-per-completion.test.ts` — spies on `HTMLMediaElement.play()` across two independent module instances (two windows): one `play()` when delivery hits a single window, two when it hits both.
- `src/bun/__tests__/push-targets.test.ts` — the routing decision itself, plus proof that remote browsers still receive the payload.

## Known limits

- A desktop window and a remote browser on the same machine still chime twice. Unchanged from before this PR, and not distinguishable from a legitimate second device with the data the push carries.
- Several attached browsers still chime once each, also deliberate.
- If no window has ever been focused, `getFocusedWindow` falls back to the first tracked window.

Decision record: `decisions/2026/09/12/completion-chime-goes-to-one-window.md`.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a0471516-c7fc-4c8a-97df-0d1225f9d422) · `dev3://task/a0471516-c7fc-4c8a-97df-0d1225f9d422` _(dev3 added this footer — turn it off in Settings → Tasks.)_