### PR TITLE
Gate the mobile terminal input stack on a coarse primary pointer

### DIFF
--- a/change-logs/2026/09/12/fix-touch-ui-coarse-pointer-gate.md
+++ b/change-logs/2026/09/12/fix-touch-ui-coarse-pointer-gate.md
@@ -1,0 +1,3 @@
+Short: No phone keyboard on touch laptops
+
+Fixed the browser remote mode showing the phone terminal composer and extra-key bar on touchscreen laptops and desktops: the mobile input stack now requires touch to be the device's primary pointer (a coarse-pointer media query), not merely a touchscreen being present.

--- a/decisions/2026/09/12/touch-primary-gates-mobile-terminal-input.md
+++ b/decisions/2026/09/12/touch-primary-gates-mobile-terminal-input.md
@@ -1,0 +1,17 @@
+# Touch-primary detection gates the mobile terminal input stack
+
+## Context
+
+`TaskTerminal` and `ProjectTerminal` switched into the mobile input stack (TerminalComposer, ExtraKeyBar, touch compose mode, the copy-mode scroll poll) whenever `navigator.maxTouchPoints > 0` in browser remote mode. A Windows laptop with a touchscreen reports touch points even when driven entirely by a mouse, so a 1900px desktop session over `dev3 remote` got the phone composer and a vw-sized key bar.
+
+## Decision
+
+`isTouchPrimary()` in `src/mainview/utils/platform.ts` is the single gate: `maxTouchPoints > 0` stays as the cheap precondition, and `matchMedia("(pointer: coarse)")` — the device's *primary* pointer per CSS Media Queries 4 — discriminates a phone/tablet from a touchscreen laptop. Where `matchMedia` is unavailable it falls back to the old touch-points-only behaviour. Both call sites (`TaskTerminal.tsx`, `ProjectTerminal.tsx`) use it; the value is read once per render, not subscribed — plugging in a mouse mid-session does not retract the composer until the next mount, which matches the old non-reactive behaviour.
+
+## Risks
+
+A convertible flipped into tablet mode after load keeps its laptop verdict until remount. Some browsers evaluate `pointer: coarse` per current primary pointer, so a phone with a paired Bluetooth mouse loses the composer — acceptable, since a hardware keyboard/mouse setup is exactly the desktop experience.
+
+## Alternatives considered
+
+Viewport width: wrong axis — an iPad is wide, a narrow desktop window is not a phone. `(hover: none)`: overlaps coarse but misclassifies hover-capable styluses. UA sniffing: rejected as unmaintainable.

--- a/src/mainview/components/ProjectTerminal.tsx
+++ b/src/mainview/components/ProjectTerminal.tsx
@@ -7,6 +7,7 @@ import type { TerminalHandle } from "../TerminalView";
 import ExtraKeyBar from "./ExtraKeyBar";
 import ScrollToLatestButton from "./ScrollToLatestButton";
 import TerminalComposer, { type TerminalComposerApi } from "./TerminalComposer";
+import { isTouchPrimary } from "../utils/platform";
 
 interface ProjectTerminalProps {
 	projectId: string;
@@ -20,7 +21,7 @@ function ProjectTerminal({ projectId, projectPath, onBack }: ProjectTerminalProp
 	const [error, setError] = useState(false);
 	const [restarting, setRestarting] = useState(false);
 	// Same touch input model as TaskTerminal: compose mode by default, ⌨ raw toggle.
-	const touchInput = !isElectrobun && navigator.maxTouchPoints > 0;
+	const touchInput = !isElectrobun && isTouchPrimary();
 	const [scrolledUp, setScrolledUp] = useState(false);
 	// Undefined off touch: its absence keeps the copy-mode poll from arming on a pointer.
 	const scrollSignal = touchInput ? setScrolledUp : undefined;

--- a/src/mainview/components/TaskTerminal.tsx
+++ b/src/mainview/components/TaskTerminal.tsx
@@ -32,6 +32,7 @@ import {
 import { useNarrowViewport } from "../hooks/useNarrowViewport";
 import { CAROUSEL_MAX_WIDTH } from "./MobileBoardCarousel";
 import { isElectrobun } from "../rpc";
+import { isTouchPrimary } from "../utils/platform";
 import type { TaskPaneState } from "../../shared/task-panes";
 import { getPaneRects, restoreSplitTree, serializeSplitTree, setSplitRatio } from "../../shared/split-tree";
 import NativePaneDividers from "./NativePaneDividers";
@@ -60,8 +61,7 @@ type ErrorKind = "worktree-gone" | "session-ended";
 
 function TaskTerminal({ projectId, taskId, tasks, projects, navigate, dispatch, hideInfoPanel }: TaskTerminalProps) {
 	const t = useT();
-	const isTouchDevice = navigator.maxTouchPoints > 0;
-	const touchInput = !isElectrobun && isTouchDevice;
+	const touchInput = !isElectrobun && isTouchPrimary();
 	// Which pane is scrolled into history, by pane id (the single tmux view uses
 	// TMUX_VIEW). Keyed rather than a boolean: focus can move in the tiled layout
 	// while another pane is still scrolled up, and the button must never offer to

--- a/src/mainview/components/__tests__/ProjectTerminal.test.tsx
+++ b/src/mainview/components/__tests__/ProjectTerminal.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProjectTerminal from "../ProjectTerminal";
@@ -13,9 +14,41 @@ vi.mock("../../rpc", () => ({
 	},
 }));
 
+// onReady hands the host a TerminalHandle; without it termHandle stays null and
+// the touch input stack can never mount, whatever the gate says.
 vi.mock("../../TerminalView", () => ({
-	default: () => <div data-testid="terminal-view" />,
+	default: ({ onReady }: { onReady?: (handle: unknown) => void }) => {
+		// In an effect, not during render — the host setState would land outside act().
+		useEffect(() => {
+			onReady?.({ focus: vi.fn(), blur: vi.fn(), paste: vi.fn(), scrollToBottom: vi.fn(), write: vi.fn() });
+		}, [onReady]);
+		return <div data-testid="terminal-view" />;
+	},
 }));
+
+vi.mock("../ExtraKeyBar", () => ({
+	default: () => <div data-testid="extra-key-bar" />,
+}));
+
+const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(Navigator.prototype, "maxTouchPoints");
+const originalMatchMedia = window.matchMedia;
+
+function setTouchPoints(maxTouchPoints: number) {
+	Object.defineProperty(navigator, "maxTouchPoints", { value: maxTouchPoints, configurable: true });
+}
+
+function setCoarsePointer(coarse: boolean) {
+	window.matchMedia = ((query: string) => ({
+		matches: query.includes("pointer: coarse") ? coarse : query.includes("prefers-reduced-motion"),
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	})) as typeof window.matchMedia;
+}
 
 function renderTerminal(onBack = vi.fn()) {
 	return {
@@ -53,5 +86,32 @@ describe("ProjectTerminal — back-to-board toolbar", () => {
 		const { onBack } = renderTerminal();
 		await user.click(screen.getByText("Back to Board"));
 		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});
+
+// Mirrors the TaskTerminal gate: both call sites share isTouchPrimary().
+describe("ProjectTerminal — touch input gate", () => {
+	afterEach(() => {
+		if (originalMaxTouchPoints) {
+			Object.defineProperty(Navigator.prototype, "maxTouchPoints", originalMaxTouchPoints);
+		} else {
+			setTouchPoints(0);
+		}
+		window.matchMedia = originalMatchMedia;
+	});
+
+	it("mounts the key bar on a phone", async () => {
+		setTouchPoints(5);
+		setCoarsePointer(true);
+		renderTerminal();
+		expect(await screen.findByTestId("extra-key-bar")).toBeInTheDocument();
+	});
+
+	it("stays hidden on a touchscreen laptop, whose primary pointer is the mouse", async () => {
+		setTouchPoints(10);
+		setCoarsePointer(false);
+		renderTerminal();
+		await screen.findByTestId("terminal-view");
+		expect(screen.queryByTestId("extra-key-bar")).not.toBeInTheDocument();
 	});
 });

--- a/src/mainview/components/__tests__/TaskTerminal.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminal.test.tsx
@@ -54,8 +54,28 @@ vi.mock("../ExtraKeyBar", () => ({
 
 // Mock navigator.maxTouchPoints for ExtraKeyBar visibility tests
 const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(Navigator.prototype, "maxTouchPoints");
+const originalMatchMedia = window.matchMedia;
+
+/** A phone: touch points AND a coarse primary pointer. */
 function setTouchDevice(isTouch: boolean) {
 	Object.defineProperty(navigator, "maxTouchPoints", { value: isTouch ? 5 : 0, configurable: true });
+	setCoarsePointer(isTouch);
+}
+
+// Set independently of the touch points to model a touchscreen laptop, whose
+// primary pointer is the mouse. The global test-setup stub answers every query
+// false, which would read as "fine" and hide the bar on a real phone too.
+function setCoarsePointer(coarse: boolean) {
+	window.matchMedia = ((query: string) => ({
+		matches: query.includes("pointer: coarse") ? coarse : query.includes("prefers-reduced-motion"),
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	})) as typeof window.matchMedia;
 }
 
 import { api } from "../../rpc";
@@ -140,6 +160,7 @@ describe("TaskTerminal", () => {
 		} else {
 			Object.defineProperty(navigator, "maxTouchPoints", { value: 0, configurable: true });
 		}
+		window.matchMedia = originalMatchMedia;
 	});
 
 	describe("Closed task", () => {
@@ -707,6 +728,26 @@ describe("TaskTerminal", () => {
 			await waitFor(() => {
 				expect(screen.getByTestId("extra-key-bar")).toBeInTheDocument();
 			});
+		});
+
+		it("stays hidden on a touchscreen laptop, whose primary pointer is the mouse", async () => {
+			setTouchDevice(true);
+			setCoarsePointer(false);
+			mockedApi.request.getPtyUrl.mockResolvedValue({ url: "ws://localhost:1234" });
+
+			await act(async () => {
+				renderTerminal();
+			});
+
+			await waitFor(() => {
+				expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+			});
+
+			await act(async () => {
+				await new Promise((r) => setTimeout(r, 10));
+			});
+
+			expect(screen.queryByTestId("extra-key-bar")).not.toBeInTheDocument();
 		});
 	});
 	describe("scroll-to-latest button (touch)", () => {

--- a/src/mainview/components/__tests__/TaskTerminalNative.test.tsx
+++ b/src/mainview/components/__tests__/TaskTerminalNative.test.tsx
@@ -214,7 +214,20 @@ describe("TaskTerminal (native multi-pane)", () => {
 	// put the button on the FOCUSED pane, so a tap scrolled a pane already live.
 	it("shows scroll-to-latest only for the focused pane that is scrolled up", async () => {
 		const originalTouch = Object.getOwnPropertyDescriptor(Navigator.prototype, "maxTouchPoints");
+		const originalMatchMedia = window.matchMedia;
 		Object.defineProperty(navigator, "maxTouchPoints", { value: 5, configurable: true });
+		// A phone: touch points plus a coarse primary pointer. The global stub
+		// answers every query false, which reads as a touchscreen laptop.
+		window.matchMedia = ((query: string) => ({
+			matches: query.includes("pointer: coarse"),
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		})) as typeof window.matchMedia;
 		try {
 			vi.mocked(api.request.taskPaneState).mockResolvedValue(makeNativePaneState(["pane-1", "pane-2"]));
 			renderTaskTerminal(NATIVE_TASK);
@@ -240,6 +253,7 @@ describe("TaskTerminal (native multi-pane)", () => {
 		} finally {
 			if (originalTouch) Object.defineProperty(Navigator.prototype, "maxTouchPoints", originalTouch);
 			else Object.defineProperty(navigator, "maxTouchPoints", { value: 0, configurable: true });
+			window.matchMedia = originalMatchMedia;
 		}
 	});
 

--- a/src/mainview/utils/__tests__/platform.test.ts
+++ b/src/mainview/utils/__tests__/platform.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { hasAppModifier } from "../platform";
+import { hasAppModifier, isTouchPrimary } from "../platform";
 
 const originalNavigator = globalThis.navigator;
 
@@ -41,5 +41,58 @@ describe("hasAppModifier", () => {
 		expect(hasAppModifier(keyEvent("o", {}))).toBe(false);
 		setPlatform("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)");
 		expect(hasAppModifier(keyEvent("o", {}))).toBe(false);
+	});
+});
+
+describe("isTouchPrimary", () => {
+	const originalMatchMedia = globalThis.window?.matchMedia;
+
+	function setTouchPoints(maxTouchPoints: number) {
+		Object.defineProperty(globalThis, "navigator", {
+			value: { ...originalNavigator, maxTouchPoints },
+			writable: true,
+			configurable: true,
+		});
+	}
+
+	function setCoarsePointer(coarse: boolean) {
+		window.matchMedia = ((query: string) => ({
+			matches: query.includes("pointer: coarse") ? coarse : false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		})) as typeof window.matchMedia;
+	}
+
+	afterEach(() => {
+		if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+	});
+
+	it("is true on a phone — touch points and a coarse primary pointer", () => {
+		setTouchPoints(5);
+		setCoarsePointer(true);
+		expect(isTouchPrimary()).toBe(true);
+	});
+
+	it("is false on a touchscreen laptop, where the mouse is the primary pointer", () => {
+		setTouchPoints(10);
+		setCoarsePointer(false);
+		expect(isTouchPrimary()).toBe(false);
+	});
+
+	it("is false with no touch points, without consulting the media query", () => {
+		setTouchPoints(0);
+		setCoarsePointer(true);
+		expect(isTouchPrimary()).toBe(false);
+	});
+
+	it("falls back to the touch points where pointer media queries are unavailable", () => {
+		setTouchPoints(5);
+		(window as { matchMedia?: unknown }).matchMedia = undefined;
+		expect(isTouchPrimary()).toBe(true);
 	});
 });

--- a/src/mainview/utils/platform.ts
+++ b/src/mainview/utils/platform.ts
@@ -34,3 +34,15 @@ export function isRemote(): boolean {
 	if (typeof window === "undefined") return false;
 	return typeof (window as Window & { __electrobunWebviewId?: number }).__electrobunWebviewId === "undefined";
 }
+
+/**
+ * Whether touch is the device's *primary* pointer — a phone or tablet, not a
+ * touchscreen laptop driven by a mouse, which `maxTouchPoints` alone also
+ * reports. Gates the mobile terminal input stack; see the
+ * `touch-primary-gates-mobile-terminal-input` decision record.
+ */
+export function isTouchPrimary(): boolean {
+	if (typeof navigator === "undefined" || navigator.maxTouchPoints === 0) return false;
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") return true;
+	return window.matchMedia("(pointer: coarse)").matches;
+}


### PR DESCRIPTION
## Problem

`TerminalComposer`, `ExtraKeyBar`, touch compose mode and the copy-mode scroll poll armed whenever `navigator.maxTouchPoints > 0` in browser remote mode. A Windows laptop with a touchscreen reports touch points even when driven entirely by a mouse, so a 1900px desktop session over `dev3 remote` got the phone composer and a vw-sized key bar — and, since compose mode blocks `mousedown`/`mouseup`/`click` on the terminal (by design, to keep taps from summoning the OSK), it also killed mouse text-selection and click-to-switch-pane.

## Fix

New `isTouchPrimary()` in `src/mainview/utils/platform.ts`: `maxTouchPoints > 0` stays as the cheap precondition, `matchMedia("(pointer: coarse)")` discriminates a phone/tablet from a touchscreen laptop, falling back to the old touch-points-only behaviour where `matchMedia` is absent. Both call sites (`TaskTerminal.tsx`, `ProjectTerminal.tsx`) use it.

Rationale and alternatives in `decisions/2026/09/12/touch-primary-gates-mobile-terminal-input.md`.

## Tests

- `platform.test.ts` — direct `isTouchPrimary()` coverage (phone, touchscreen laptop, no touch, no matchMedia fallback)
- `TaskTerminal.test.tsx` — `setTouchDevice` now stubs the pointer query too; new touchscreen-laptop (touch + `pointer: fine`) case
- `ProjectTerminal.test.tsx` — mirrored touch visibility cases
- `TaskTerminalNative.test.tsx` — the scroll-to-latest test now stubs a coarse pointer alongside `maxTouchPoints`

## Validation

`bun run lint` and the full local `bun run test` green; CI green. Verified on the affected hardware (Windows touchscreen laptop, browser remote mode): the device probes `[navigator.maxTouchPoints, matchMedia('(pointer: coarse)').matches]` → `[5, false]`, and a headless run of this branch's build confirmed the composer/key bar are gone while mouse selection and pane-click focus work again. A coarse-pointer device keeps the mobile input stack (unit-tested; no phone hardware check).

Origin: dev3 task 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvDm5ywmh8nwZPchFaepew